### PR TITLE
Harden guest control and data planes

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent.rs
@@ -45,20 +45,62 @@ mod state;
 
 use std::mem::size_of;
 use std::os::fd::{FromRawFd, RawFd};
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use mvm_agentd::vsock::{
-    GuestRequest, GuestResponse, HOST_SIGNER_PUBKEY_PATH, TrustDecision, VERB_TRUST_POLICY_PATH,
-    enforce_verb_grant, is_verb_trust_baseline, launch_requires_grant,
+    GuestRequest, GuestResponse, HOST_SIGNER_PUBKEY_PATH, TrafficPlane, TrustDecision,
+    VERB_TRUST_POLICY_PATH, enforce_verb_grant, is_verb_trust_baseline, launch_requires_grant,
     load_host_signer_verifying_key, load_pinned_verb_grant, load_verb_trust_policy, trust_decision,
 };
+
+#[derive(Debug, Clone, Copy)]
+struct ConnectionLimits {
+    total: usize,
+    data: usize,
+}
+
+impl Default for ConnectionLimits {
+    fn default() -> Self {
+        Self {
+            total: 64,
+            data: 48,
+        }
+    }
+}
+
+static ACTIVE_CONNECTIONS: AtomicUsize = AtomicUsize::new(0);
+static ACTIVE_DATA_REQUESTS: AtomicUsize = AtomicUsize::new(0);
+
+struct CounterGuard {
+    counter: &'static AtomicUsize,
+}
+
+impl Drop for CounterGuard {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+fn try_acquire(counter: &'static AtomicUsize, limit: usize) -> Option<CounterGuard> {
+    let mut active = counter.load(Ordering::Acquire);
+    loop {
+        if active >= limit {
+            return None;
+        }
+        match counter.compare_exchange_weak(active, active + 1, Ordering::AcqRel, Ordering::Acquire)
+        {
+            Ok(_) => return Some(CounterGuard { counter }),
+            Err(observed) => active = observed,
+        }
+    }
+}
 
 use crate::boot::{init_entrypoint_validation, init_integrations, init_probes, init_warm_pool};
 use crate::config::parse_config;
 use crate::globals::{
     DEFAULT_SHUTDOWN_GRACE, HOT_BUSY_THRESHOLD_BITS, HOT_SAMPLE_INTERVAL_SECS, RELOAD_REQUESTED,
-    SHUTDOWN_REQUESTED, WARM_POOL,
+    SHUTDOWN_REQUESTED,
 };
 use crate::monitoring::monitoring_loop;
 use crate::signals::{apply_reload, install_signal_handlers, shutdown_subsystems};
@@ -196,6 +238,22 @@ fn handle_client(
         return;
     }
 
+    let limits = ConnectionLimits::default();
+    let _data_guard = if req.verb().traffic_plane() == TrafficPlane::Data {
+        let Some(guard) = try_acquire(&ACTIVE_DATA_REQUESTS, limits.data) else {
+            write_response(
+                &mut file,
+                &GuestResponse::Error {
+                    message: "guest data plane is at its concurrency limit".to_string(),
+                },
+            );
+            return;
+        };
+        Some(guard)
+    } else {
+        None
+    };
+
     let mut ctx = HandlerCtx {
         file: &mut file,
         state,
@@ -312,8 +370,17 @@ fn handle_client(
             content,
             mode,
             create_parents,
+            offset,
+            truncate,
             ..
-        } => handle_fs_write(path, content, mode, create_parents),
+        } => handle_fs_write(
+            path,
+            content,
+            mode,
+            create_parents,
+            offset.unwrap_or(0),
+            truncate,
+        ),
         GuestRequest::FsList { path, .. } => handle_fs_list(path),
         GuestRequest::FsStat {
             path,
@@ -581,26 +648,16 @@ fn main() {
         cfg.port
     );
 
-    // When warm-process is active, real concurrency from multiple
-    // host invokes lands in parallel — spawn a thread per
-    // accepted connection so they reach distinct workers. Cold-tier
-    // images keep the single-threaded accept loop unchanged for
-    // bit-identical behavior. `handle_client` already takes shared
-    // state through `Arc<Mutex<…>>`, so per-connection threading
-    // is a safe addition; the new pool itself does its own slot
-    // mutex / condvar bookkeeping.
+    // Every accepted connection gets its own bounded worker so a long-running
+    // data stream cannot prevent Ping, readiness, sleep, or shutdown requests
+    // from being accepted. Data dispatch has a lower cap than total dispatch,
+    // reserving capacity for control traffic.
     //
     // Poll `SHUTDOWN_REQUESTED` between accepts and after each
     // `accept()` return (signals deliver `EINTR` so accept
     // returns < 0, which already triggers the bottom-of-loop check).
     // Once the flag flips, break out and drain via
     // `shutdown_subsystems`.
-    // `warm_active` is now re-evaluated per
-    // iteration. The background init thread populates `WARM_POOL`
-    // some time after the accept loop starts, so a one-shot capture
-    // at loop entry would mis-classify all subsequent connections
-    // as cold-tier. `WARM_POOL.get()` is a relaxed atomic load —
-    // cheap enough to do per-accept.
     loop {
         if SHUTDOWN_REQUESTED.load(Ordering::Acquire) {
             break;
@@ -668,18 +725,22 @@ fn main() {
         // Stamp first-accept timing once. Idempotent inside
         // `AgentBootState` — subsequent calls are no-ops.
         boot_state.mark_first_accept();
-        let warm_active = matches!(WARM_POOL.get(), Some(Some(_)));
-        if warm_active {
-            let state = Arc::clone(&state);
-            let integration_state = Arc::clone(&integration_state);
-            let probe_state = Arc::clone(&probe_state);
-            let bs = Arc::clone(&boot_state);
-            std::thread::spawn(move || {
-                handle_client(cfd, &state, &integration_state, &probe_state, &bs);
-            });
-        } else {
-            handle_client(cfd, &state, &integration_state, &probe_state, &boot_state);
-        }
+        let limits = ConnectionLimits::default();
+        let Some(connection_guard) = try_acquire(&ACTIVE_CONNECTIONS, limits.total) else {
+            eprintln!("mvm-guest-agent: rejecting connection at concurrency limit");
+            unsafe {
+                close(cfd);
+            }
+            continue;
+        };
+        let state = Arc::clone(&state);
+        let integration_state = Arc::clone(&integration_state);
+        let probe_state = Arc::clone(&probe_state);
+        let bs = Arc::clone(&boot_state);
+        std::thread::spawn(move || {
+            let _connection_guard = connection_guard;
+            handle_client(cfd, &state, &integration_state, &probe_state, &bs);
+        });
     }
 
     // Close the listening socket so any in-flight accept on a
@@ -699,6 +760,29 @@ mod tests {
     use std::os::fd::IntoRawFd;
     use std::os::unix::net::UnixStream;
     use std::time::Duration;
+
+    #[test]
+    fn data_plane_limit_reserves_control_plane_capacity() {
+        let limits = ConnectionLimits::default();
+        assert_eq!(limits.total, 64);
+        assert_eq!(limits.data, 48);
+        assert!(limits.total - limits.data >= 16);
+    }
+
+    #[test]
+    fn counter_guard_enforces_and_releases_capacity() {
+        static TEST_COUNTER: AtomicUsize = AtomicUsize::new(0);
+        TEST_COUNTER.store(0, Ordering::Release);
+
+        let first = try_acquire(&TEST_COUNTER, 2).expect("first slot");
+        let second = try_acquire(&TEST_COUNTER, 2).expect("second slot");
+        assert!(try_acquire(&TEST_COUNTER, 2).is_none());
+        drop(first);
+        let replacement = try_acquire(&TEST_COUNTER, 2).expect("released slot");
+        drop(second);
+        drop(replacement);
+        assert_eq!(TEST_COUNTER.load(Ordering::Acquire), 0);
+    }
 
     #[test]
     fn handle_client_accepts_protocol_hello_before_request() {

--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/handlers.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/handlers.rs
@@ -90,6 +90,26 @@ fn evt(e: EntrypointEvent) -> GuestResponse {
     GuestResponse::EntrypointEvent(e)
 }
 
+fn emit_entrypoint_bytes(file: &mut std::fs::File, bytes: &[u8], stdout: bool) {
+    for chunk in bytes.chunks(mvm_agentd::vsock::MAX_DATA_CHUNK_SIZE) {
+        let event = if stdout {
+            EntrypointEvent::Stdout {
+                chunk: chunk.to_vec(),
+            }
+        } else {
+            EntrypointEvent::Stderr {
+                chunk: chunk.to_vec(),
+            }
+        };
+        write_response(file, &evt(event));
+    }
+}
+
+fn emit_entrypoint_output(file: &mut std::fs::File, stdout: &[u8], stderr: &[u8]) {
+    emit_entrypoint_bytes(file, stdout, true);
+    emit_entrypoint_bytes(file, stderr, false);
+}
+
 /// Handle a `RunEntrypoint` request. Writes streaming events directly via
 /// `write_response` and returns the terminal event for the dispatcher to
 /// send through the existing `match` arm pattern.
@@ -171,8 +191,7 @@ fn handle_run_entrypoint(
             stderr,
             controls,
         } => {
-            write_response(file, &evt(EntrypointEvent::Stdout { chunk: stdout }));
-            write_response(file, &evt(EntrypointEvent::Stderr { chunk: stderr }));
+            emit_entrypoint_output(file, &stdout, &stderr);
             emit_controls(file, controls);
             evt(EntrypointEvent::Exit { code })
         }
@@ -181,8 +200,7 @@ fn handle_run_entrypoint(
             stderr,
             controls,
         } => {
-            write_response(file, &evt(EntrypointEvent::Stdout { chunk: stdout }));
-            write_response(file, &evt(EntrypointEvent::Stderr { chunk: stderr }));
+            emit_entrypoint_output(file, &stdout, &stderr);
             emit_controls(file, controls);
             evt(EntrypointEvent::Error {
                 kind: RunEntrypointError::Timeout,
@@ -195,8 +213,7 @@ fn handle_run_entrypoint(
             stderr,
             controls,
         } => {
-            write_response(file, &evt(EntrypointEvent::Stdout { chunk: stdout }));
-            write_response(file, &evt(EntrypointEvent::Stderr { chunk: stderr }));
+            emit_entrypoint_output(file, &stdout, &stderr);
             emit_controls(file, controls);
             let stream_name = match stream {
                 PayloadCapStream::Stdin => "stdin",
@@ -218,8 +235,7 @@ fn handle_run_entrypoint(
             stderr,
             controls,
         } => {
-            write_response(file, &evt(EntrypointEvent::Stdout { chunk: stdout }));
-            write_response(file, &evt(EntrypointEvent::Stderr { chunk: stderr }));
+            emit_entrypoint_output(file, &stdout, &stderr);
             emit_controls(file, controls);
             evt(EntrypointEvent::Error {
                 kind: RunEntrypointError::WrapperCrashed,
@@ -275,8 +291,7 @@ fn dispatch_via_warm_pool(
             controls,
             outcome,
         }) => {
-            write_response(file, &evt(EntrypointEvent::Stdout { chunk: stdout }));
-            write_response(file, &evt(EntrypointEvent::Stderr { chunk: stderr }));
+            emit_entrypoint_output(file, &stdout, &stderr);
             emit_controls(file, controls);
             match outcome {
                 WorkerOutcome::Exit { code } => evt(EntrypointEvent::Exit { code }),
@@ -695,6 +710,8 @@ pub(crate) fn handle_fs_write(
     content: Vec<u8>,
     mode: u32,
     create_parents: bool,
+    offset: u64,
+    truncate: bool,
 ) -> GuestResponse {
     GuestResponse::FsResult(mvm_agentd::fs_rpc::handle_with_defaults(
         mvm_agentd::fs_rpc::FsRequest::Write {
@@ -702,6 +719,8 @@ pub(crate) fn handle_fs_write(
             content: &content,
             mode,
             create_parents,
+            offset,
+            truncate,
         },
     ))
 }

--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/socket.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/socket.rs
@@ -3,13 +3,11 @@
 
 use std::io::{Read, Write};
 
-use mvm_agentd::vsock::{GuestRequest, GuestResponse, HOST_CID};
+use mvm_agentd::vsock::{GuestRequest, GuestResponse, HOST_CID, MAX_FRAME_SIZE, write_frame};
 
 pub(crate) const AF_VSOCK: i32 = 40;
 pub(crate) const SOCK_STREAM: i32 = 1;
 pub(crate) const VMADDR_CID_ANY: u32 = 0xFFFF_FFFF;
-pub(crate) const MAX_FRAME_SIZE: usize = 256 * 1024;
-
 #[repr(C)]
 pub(crate) struct SockAddrVm {
     pub(crate) svm_family: u16,
@@ -43,7 +41,8 @@ pub(crate) fn read_request(file: &mut std::fs::File) -> Option<GuestRequest> {
     if file.read_exact(&mut len_buf).is_err() {
         return None;
     }
-    let frame_len = u32::from_be_bytes(len_buf) as usize;
+    let frame_len =
+        usize::try_from(u32::from_be_bytes(len_buf)).expect("u32 frame length fits usize");
     if frame_len > MAX_FRAME_SIZE {
         eprintln!("frame too large: {} bytes", frame_len);
         return None;
@@ -55,29 +54,30 @@ pub(crate) fn read_request(file: &mut std::fs::File) -> Option<GuestRequest> {
     serde_json::from_slice(&buf).ok()
 }
 
-pub(crate) fn write_response(file: &mut std::fs::File, resp: &GuestResponse) {
-    let data = match serde_json::to_vec(resp) {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("failed to serialize response: {}", e);
-            return;
+pub(crate) fn write_response(file: &mut impl Write, resp: &GuestResponse) {
+    let fallback = GuestResponse::Error {
+        message: "guest response exceeded the protocol frame cap".to_string(),
+    };
+    let selected = match serde_json::to_vec(resp) {
+        Ok(encoded) if encoded.len() <= MAX_FRAME_SIZE => resp,
+        Ok(_) => &fallback,
+        Err(error) => {
+            eprintln!("failed to serialize vsock response: {error}");
+            &fallback
         }
     };
-    let len = (data.len() as u32).to_be_bytes();
-    if let Err(e) = file.write_all(&len) {
-        eprintln!("failed to write vsock response: {e}");
-    }
-    if let Err(e) = file.write_all(&data) {
-        eprintln!("failed to write vsock response: {e}");
-    }
-    if let Err(e) = file.flush() {
-        eprintln!("failed to flush vsock response: {e}");
+    if let Err(error) = write_frame(file, selected) {
+        // Do not append a fallback after an I/O error: the original frame may
+        // already be partially written, so another prefix would corrupt it.
+        eprintln!("failed to write vsock response: {error}");
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_agentd::vsock::read_frame;
+    use std::io::Cursor;
 
     /// Only the host CID (2) may drive the control port.
     #[test]
@@ -101,5 +101,27 @@ mod tests {
         for cid in [4u32, 42, 5252, u32::MAX - 1] {
             assert!(!peer_cid_is_authorized(cid), "cid {cid} must be rejected");
         }
+    }
+
+    #[test]
+    fn oversized_response_is_replaced_by_one_bounded_error_frame() {
+        let oversized = GuestResponse::Error {
+            message: "x".repeat(MAX_FRAME_SIZE),
+        };
+        let mut wire = Cursor::new(Vec::new());
+        write_response(&mut wire, &oversized);
+
+        assert!(wire.get_ref().len() <= MAX_FRAME_SIZE + 4);
+        wire.set_position(0);
+        let response: GuestResponse = read_frame(&mut wire).expect("bounded response frame");
+        assert!(matches!(
+            response,
+            GuestResponse::Error { message }
+                if message == "guest response exceeded the protocol frame cap"
+        ));
+        assert_eq!(
+            usize::try_from(wire.position()).expect("cursor position fits usize"),
+            wire.get_ref().len()
+        );
     }
 }

--- a/crates/mvm-agentd/src/console.rs
+++ b/crates/mvm-agentd/src/console.rs
@@ -12,7 +12,7 @@ use std::io::{Read, Write};
 use std::os::fd::{FromRawFd, RawFd};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
-use crate::vsock::CONSOLE_PORT_BASE;
+use crate::vsock::{CONSOLE_PORT_BASE, HOST_CID};
 
 /// Tracks the active console session. Only one session at a time.
 static CONSOLE_ACTIVE: AtomicBool = AtomicBool::new(false);
@@ -83,6 +83,10 @@ const AF_VSOCK: i32 = 40;
 const SOCK_STREAM: i32 = 1;
 const VMADDR_CID_ANY: u32 = 0xFFFF_FFFF;
 const SIGTERM: i32 = 15;
+
+fn console_peer_is_authorized(cid: u32) -> bool {
+    cid == HOST_CID
+}
 
 /// ioctl request for setting window size (Linux).
 #[cfg(target_os = "linux")]
@@ -385,10 +389,28 @@ pub fn run_console_relay(session: &ConsoleSession) -> i32 {
         session.data_port
     );
 
-    // Accept one connection.
-    // SAFETY: `listen_fd` is the listening socket; NULL addr/len out-params
-    // are allowed when the peer address is not needed.
-    let conn_fd = unsafe { accept(listen_fd, std::ptr::null_mut(), std::ptr::null_mut()) };
+    // Accept one host connection and capture its CID. A guest-local process
+    // must not be able to win the race for this raw PTY channel after the
+    // authenticated control request allocates it.
+    let mut peer = SockAddrVm {
+        svm_family: 0,
+        svm_reserved1: 0,
+        svm_port: 0,
+        svm_cid: 0,
+        svm_zero: [0; 4],
+    };
+    let expected_peer_len =
+        u32::try_from(std::mem::size_of::<SockAddrVm>()).expect("vsock address size fits u32");
+    let mut peer_len = expected_peer_len;
+    // SAFETY: `peer` is correctly sized for AF_VSOCK and `peer_len` bounds the
+    // kernel write into it.
+    let conn_fd = unsafe {
+        accept(
+            listen_fd,
+            (&raw mut peer).cast::<core::ffi::c_void>(),
+            &raw mut peer_len,
+        )
+    };
     // SAFETY: `listen_fd` is the open listening socket; no owning wrapper
     // holds it. Closing it stops further connections.
     unsafe {
@@ -396,6 +418,18 @@ pub fn run_console_relay(session: &ConsoleSession) -> i32 {
     }
     if conn_fd < 0 {
         eprintln!("console: accept failed");
+        return close_session(session);
+    }
+    let peer_known = peer_len >= expected_peer_len && peer.svm_family == AF_VSOCK as u16;
+    if !peer_known || !console_peer_is_authorized(peer.svm_cid) {
+        eprintln!(
+            "console: rejected non-host data peer (cid={}, family={})",
+            peer.svm_cid, peer.svm_family
+        );
+        // SAFETY: `conn_fd` is the accepted socket and no owner wraps it yet.
+        unsafe {
+            close(conn_fd);
+        }
         return close_session(session);
     }
 
@@ -725,6 +759,17 @@ mod tests {
     fn test_data_port_calculation() {
         assert_eq!(CONSOLE_PORT_BASE + 1, 20001);
         assert_eq!(CONSOLE_PORT_BASE + 42, 20042);
+    }
+
+    #[test]
+    fn console_data_peer_authorizes_only_the_host_cid() {
+        assert!(console_peer_is_authorized(crate::vsock::HOST_CID));
+        for cid in [0, 1, crate::vsock::GUEST_CID, VMADDR_CID_ANY] {
+            assert!(
+                !console_peer_is_authorized(cid),
+                "CID {cid} must be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/mvm-agentd/src/exec_stream.rs
+++ b/crates/mvm-agentd/src/exec_stream.rs
@@ -57,16 +57,19 @@ fn drain_into<F: FnMut(ExecEvent)>(
     if room == 0 {
         return true;
     }
-    let new = &b[*sent..];
-    let take = new.len().min(room);
-    let chunk = new[..take].to_vec();
-    emit(if stdout {
-        ExecEvent::Stdout { chunk }
-    } else {
-        ExecEvent::Stderr { chunk }
-    });
-    *sent += take;
-    take < new.len()
+    let available = (b.len() - *sent).min(room);
+    let end = *sent + available;
+    while *sent < end {
+        let chunk_end = (*sent + crate::vsock::MAX_DATA_CHUNK_SIZE).min(end);
+        let chunk = b[*sent..chunk_end].to_vec();
+        emit(if stdout {
+            ExecEvent::Stdout { chunk }
+        } else {
+            ExecEvent::Stderr { chunk }
+        });
+        *sent = chunk_end;
+    }
+    end < b.len()
 }
 
 /// SIGKILL the child's entire process group. The child is spawned with

--- a/crates/mvm-agentd/src/fs_rpc.rs
+++ b/crates/mvm-agentd/src/fs_rpc.rs
@@ -35,7 +35,7 @@ use crate::vsock::{FsEntry, FsEntryKind, FsErrorKind, FsResult, FsStat};
 
 /// Per-call resource caps. Production agent wires `Caps::production()`
 /// at boot; tests construct tighter caps to exercise the
-/// `CapExceeded` branches without writing 16 MiB to disk.
+/// `CapExceeded` branches without allocating a full wire chunk.
 #[derive(Debug, Clone, Copy)]
 pub struct Caps {
     /// Max bytes returned by `FsRead` in a single call.
@@ -53,8 +53,8 @@ pub struct Caps {
 impl Caps {
     pub const fn production() -> Self {
         Self {
-            max_read_bytes: 16 * 1024 * 1024,
-            max_write_bytes: 1024 * 1024,
+            max_read_bytes: crate::vsock::MAX_DATA_CHUNK_SIZE as u64,
+            max_write_bytes: crate::vsock::MAX_DATA_CHUNK_SIZE as u64,
             max_list_entries: 4096,
             max_recursive_entries: 100_000,
         }
@@ -72,18 +72,81 @@ impl Default for Caps {
 /// `std::fs` semantics unless noted.
 pub trait FsOps {
     fn read_at(&self, path: &Path, offset: u64, length: u64) -> std::io::Result<(Vec<u8>, u64)>;
-    fn write(
+    fn write_at(
         &self,
         path: &Path,
         content: &[u8],
-        mode: u32,
-        create_parents: bool,
+        options: FsWriteOptions,
     ) -> std::io::Result<u64>;
     fn list(&self, path: &Path, max_entries: usize) -> std::io::Result<(Vec<FsEntry>, bool)>;
     fn stat(&self, path: &Path, follow_symlinks: bool) -> std::io::Result<FsStat>;
     fn mkdir(&self, path: &Path, mode: u32, parents: bool) -> std::io::Result<()>;
     fn remove(&self, path: &Path, recursive: bool, max_entries: u64) -> std::io::Result<u64>;
     fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()>;
+}
+
+/// Options for one offset-addressed filesystem write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FsWriteOptions {
+    offset: u64,
+    truncate: bool,
+    mode: u32,
+    create_parents: bool,
+}
+
+impl FsWriteOptions {
+    #[must_use]
+    pub fn builder() -> FsWriteOptionsBuilder {
+        FsWriteOptionsBuilder::default()
+    }
+}
+
+/// Builder for [`FsWriteOptions`].
+#[derive(Debug, Default)]
+pub struct FsWriteOptionsBuilder {
+    options: FsWriteOptions,
+}
+
+impl FsWriteOptionsBuilder {
+    #[must_use]
+    pub fn offset(mut self, offset: u64) -> Self {
+        self.options.offset = offset;
+        self
+    }
+
+    #[must_use]
+    pub fn truncate(mut self, truncate: bool) -> Self {
+        self.options.truncate = truncate;
+        self
+    }
+
+    #[must_use]
+    pub fn mode(mut self, mode: u32) -> Self {
+        self.options.mode = mode;
+        self
+    }
+
+    #[must_use]
+    pub fn create_parents(mut self, create_parents: bool) -> Self {
+        self.options.create_parents = create_parents;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> FsWriteOptions {
+        self.options
+    }
+}
+
+impl Default for FsWriteOptions {
+    fn default() -> Self {
+        Self {
+            offset: 0,
+            truncate: true,
+            mode: 0o644,
+            create_parents: false,
+        }
+    }
 }
 
 /// Production filesystem ops — delegates to `std::fs`.
@@ -132,28 +195,30 @@ impl FsOps for OsFs {
         Ok((buf, total))
     }
 
-    fn write(
+    fn write_at(
         &self,
         path: &Path,
         content: &[u8],
-        mode: u32,
-        create_parents: bool,
+        options: FsWriteOptions,
     ) -> std::io::Result<u64> {
-        use std::io::Write;
-        if create_parents && let Some(parent) = path.parent() {
+        use std::io::{Seek, SeekFrom, Write};
+        if options.create_parents
+            && let Some(parent) = path.parent()
+        {
             std::fs::create_dir_all(parent)?;
         }
         let mut opts = std::fs::OpenOptions::new();
-        opts.write(true).create(true).truncate(true);
+        opts.write(true).create(true).truncate(options.truncate);
         #[cfg(unix)]
         {
             use std::os::unix::fs::OpenOptionsExt;
-            opts.mode(mode);
+            opts.mode(options.mode);
         }
-        let _ = mode; // silence unused-var on non-unix
+        let _ = options.mode;
         let mut f = opts.open(path)?;
+        f.seek(SeekFrom::Start(options.offset))?;
         f.write_all(content)?;
-        Ok(content.len() as u64)
+        Ok(u64::try_from(content.len()).expect("content length fits u64"))
     }
 
     fn list(&self, path: &Path, max_entries: usize) -> std::io::Result<(Vec<FsEntry>, bool)> {
@@ -197,7 +262,7 @@ impl FsOps for OsFs {
 
     fn mkdir(&self, path: &Path, mode: u32, parents: bool) -> std::io::Result<()> {
         let _ = mode; // mode-on-create requires a custom dance on
-        // unix; v1 uses default umask + post-chmod when mode != 0.
+        // Unix uses the default umask plus post-chmod when mode != 0.
         if parents {
             std::fs::create_dir_all(path)?;
         } else {
@@ -342,6 +407,8 @@ pub fn handle_request<C: PathCanonicalizer, F: FsOps>(
             content,
             mode,
             create_parents,
+            offset,
+            truncate,
         } => {
             if (content.len() as u64) > caps.max_write_bytes {
                 return err_result(
@@ -370,7 +437,13 @@ pub fn handle_request<C: PathCanonicalizer, F: FsOps>(
                 }
                 Err(e) => return err_result(map_policy_error(&e), e.to_string()),
             };
-            match fs.write(canonical.as_path(), content, mode, create_parents) {
+            let options = FsWriteOptions::builder()
+                .offset(offset)
+                .truncate(truncate)
+                .mode(mode)
+                .create_parents(create_parents)
+                .build();
+            match fs.write_at(canonical.as_path(), content, options) {
                 Ok(bytes_written) => FsResult::Write { bytes_written },
                 Err(e) => err_result(map_io_error_kind(&e), e.to_string()),
             }
@@ -545,6 +618,8 @@ pub enum FsRequest<'a> {
         content: &'a [u8],
         mode: u32,
         create_parents: bool,
+        offset: u64,
+        truncate: bool,
     },
     List {
         path: &'a str,
@@ -582,6 +657,54 @@ mod tests {
         // freely under tempdirs whose canonical paths may live
         // anywhere (`/private/var/folders/...` on macOS).
         PathPolicy::with_extra_deny::<[std::path::PathBuf; 0], std::path::PathBuf>([])
+    }
+
+    #[test]
+    fn production_chunk_caps_fit_worst_case_json_frames() {
+        let caps = Caps::production();
+        let content = vec![u8::MAX; caps.max_write_bytes as usize];
+        let request = crate::vsock::GuestRequest::FsWrite {
+            path: "/work/chunk.bin".to_string(),
+            content: content.clone(),
+            mode: 0o600,
+            create_parents: false,
+            follow_symlinks: false,
+            offset: Some(0),
+            truncate: true,
+        };
+        let response = crate::vsock::GuestResponse::FsResult(FsResult::Read {
+            content,
+            total_size: caps.max_read_bytes,
+        });
+
+        assert!(serde_json::to_vec(&request).unwrap().len() <= crate::vsock::MAX_FRAME_SIZE);
+        assert!(serde_json::to_vec(&response).unwrap().len() <= crate::vsock::MAX_FRAME_SIZE);
+    }
+
+    #[test]
+    fn offset_writes_reconstruct_a_file_without_retruncating() {
+        let dir = tmp();
+        let path = dir.path().join("chunked.bin");
+        let fs = OsFs;
+
+        fs.write_at(
+            &path,
+            b"first-",
+            FsWriteOptions::builder().truncate(true).mode(0o600).build(),
+        )
+        .expect("first chunk");
+        fs.write_at(
+            &path,
+            b"second",
+            FsWriteOptions::builder()
+                .offset(6)
+                .truncate(false)
+                .mode(0o600)
+                .build(),
+        )
+        .expect("second chunk");
+
+        assert_eq!(std::fs::read(path).unwrap(), b"first-second");
     }
 
     #[test]
@@ -627,6 +750,8 @@ mod tests {
                 content: b"too long",
                 mode: 0o644,
                 create_parents: false,
+                offset: 0,
+                truncate: true,
             },
         );
         match result {
@@ -681,6 +806,8 @@ mod tests {
                 content: &payload,
                 mode: 0o600,
                 create_parents: false,
+                offset: 0,
+                truncate: true,
             },
         );
         assert!(matches!(w, FsResult::Write { bytes_written } if bytes_written == 11));

--- a/crates/mvm-agentd/src/guest_tun.rs
+++ b/crates/mvm-agentd/src/guest_tun.rs
@@ -1,13 +1,13 @@
 //! Guest-side TUN device helpers for the shared network tunnel.
 //!
-//! This module is the smallest real data-plane building block after the shared
+//! This module is the guest-side data-plane device after the shared
 //! `HELLO` / `HELLO_ACK` / `CONFIG` bootstrap:
 //! - open the guest's `/dev/net/tun`,
 //! - bind it to the host-authored interface name (`mvm-net0` by default),
 //! - exchange raw IP packets through ordinary blocking `Read` / `Write`.
 //!
-//! The live packet pump lands in a later slice; this module keeps the device
-//! side isolated and reusable.
+//! The device side stays isolated from the live packet pump so both remain
+//! independently testable.
 
 use std::fs::File;
 use std::io::{Read, Write};

--- a/crates/mvm-agentd/src/process_rpc.rs
+++ b/crates/mvm-agentd/src/process_rpc.rs
@@ -23,7 +23,9 @@ use std::os::unix::process::CommandExt;
 use mvm_core::crypto::policy::{OsCanonicalizer, PathOp, PathPolicy};
 use mvm_core::domain::instance::BackpressureReason;
 
-use crate::vsock::{ProcErrorKind, ProcInfo, ProcResult, ProcState, ProcWaitEvent};
+use crate::vsock::{
+    MAX_DATA_CHUNK_SIZE, ProcErrorKind, ProcInfo, ProcResult, ProcState, ProcWaitEvent,
+};
 
 // ============================================================================
 // Caps
@@ -49,7 +51,7 @@ impl Caps {
     pub const fn production() -> Self {
         Self {
             max_concurrent: 32,
-            max_stdin_per_call: 1024 * 1024,
+            max_stdin_per_call: MAX_DATA_CHUNK_SIZE,
             max_output_buffer: 16 * 1024 * 1024,
             reap_grace: Duration::from_secs(60),
             wait_poll_interval: Duration::from_millis(50),
@@ -459,16 +461,26 @@ fn drain_into_events(record: &ProcessRecord) -> Vec<ProcWaitEvent> {
     let mut events = Vec::new();
     let mut out = record.stdout_buf.lock().expect("stdout mutex");
     if !out.is_empty() {
-        events.push(ProcWaitEvent::Stdout {
-            chunk: std::mem::take(&mut *out),
-        });
+        let drained = std::mem::take(&mut *out);
+        events.extend(
+            drained
+                .chunks(crate::vsock::MAX_DATA_CHUNK_SIZE)
+                .map(|chunk| ProcWaitEvent::Stdout {
+                    chunk: chunk.to_vec(),
+                }),
+        );
     }
     drop(out);
     let mut err = record.stderr_buf.lock().expect("stderr mutex");
     if !err.is_empty() {
-        events.push(ProcWaitEvent::Stderr {
-            chunk: std::mem::take(&mut *err),
-        });
+        let drained = std::mem::take(&mut *err);
+        events.extend(
+            drained
+                .chunks(crate::vsock::MAX_DATA_CHUNK_SIZE)
+                .map(|chunk| ProcWaitEvent::Stderr {
+                    chunk: chunk.to_vec(),
+                }),
+        );
     }
     events
 }
@@ -657,6 +669,11 @@ mod tests {
             reap_grace: Duration::from_millis(100),
             wait_poll_interval: Duration::from_millis(10),
         }
+    }
+
+    #[test]
+    fn production_stdin_cap_fits_a_data_plane_chunk() {
+        assert_eq!(Caps::production().max_stdin_per_call, MAX_DATA_CHUNK_SIZE);
     }
 
     #[test]

--- a/crates/mvm-agentd/src/vsock/connection.rs
+++ b/crates/mvm-agentd/src/vsock/connection.rs
@@ -276,17 +276,7 @@ pub(super) fn connect(instance_dir: &str, timeout_secs: u64) -> Result<UnixStrea
 ///
 /// Uses 4-byte big-endian length prefix + JSON body (same pattern as hostd).
 pub fn send_request(stream: &mut UnixStream, req: &GuestRequest) -> Result<GuestResponse> {
-    let data = serde_json::to_vec(req).with_context(|| "Failed to serialize request")?;
-
-    // Write length-prefixed frame
-    let len = (data.len() as u32).to_be_bytes();
-    stream
-        .write_all(&len)
-        .with_context(|| "Failed to write frame length")?;
-    stream
-        .write_all(&data)
-        .with_context(|| "Failed to write frame body")?;
-    stream.flush()?;
+    write_frame(stream, req).with_context(|| "Failed to write request frame")?;
 
     // Read response length
     let mut len_buf = [0u8; 4];

--- a/crates/mvm-agentd/src/vsock/framing.rs
+++ b/crates/mvm-agentd/src/vsock/framing.rs
@@ -16,12 +16,13 @@ use serde::Serialize;
 
 /// Read a single length-prefixed JSON frame from a stream.
 /// Returns the deserialized value.
-pub fn read_frame<T: serde::de::DeserializeOwned>(stream: &mut UnixStream) -> Result<T> {
+pub fn read_frame<T: serde::de::DeserializeOwned>(stream: &mut impl Read) -> Result<T> {
     let mut len_buf = [0u8; 4];
     stream
         .read_exact(&mut len_buf)
         .with_context(|| "Failed to read frame length")?;
-    let frame_len = u32::from_be_bytes(len_buf) as usize;
+    let frame_len =
+        usize::try_from(u32::from_be_bytes(len_buf)).expect("u32 frame length fits usize");
 
     if frame_len > MAX_FRAME_SIZE {
         bail!(
@@ -40,9 +41,18 @@ pub fn read_frame<T: serde::de::DeserializeOwned>(stream: &mut UnixStream) -> Re
 }
 
 /// Write a single length-prefixed JSON frame to a stream.
-pub fn write_frame<T: Serialize>(stream: &mut UnixStream, value: &T) -> Result<()> {
+pub fn write_frame<T: Serialize>(stream: &mut impl Write, value: &T) -> Result<()> {
     let data = serde_json::to_vec(value).with_context(|| "Failed to serialize frame")?;
-    let len = (data.len() as u32).to_be_bytes();
+    if data.len() > MAX_FRAME_SIZE {
+        bail!(
+            "Frame too large: {} bytes (max {})",
+            data.len(),
+            MAX_FRAME_SIZE
+        );
+    }
+    let len = u32::try_from(data.len())
+        .expect("bounded frame length fits u32")
+        .to_be_bytes();
     stream
         .write_all(&len)
         .with_context(|| "Failed to write frame length")?;
@@ -300,6 +310,7 @@ pub fn handshake_as_guest(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
 
     // ========================================================================
     // Authenticated frame tests
@@ -529,6 +540,17 @@ mod tests {
         assert_eq!(host_vk.as_bytes(), host_vk_expected.as_bytes());
         // Session ID was echoed correctly
         assert_eq!(received_session_id, session_id);
+    }
+
+    #[test]
+    fn oversized_write_is_rejected_before_writing_any_bytes() {
+        let payload = vec![0_u8; MAX_FRAME_SIZE + 1];
+        let mut output = Cursor::new(Vec::new());
+
+        let err = write_frame(&mut output, &payload).expect_err("oversized frame must fail");
+
+        assert!(err.to_string().contains("Frame too large"));
+        assert!(output.into_inner().is_empty());
     }
 
     #[test]

--- a/crates/mvm-agentd/src/vsock/mod.rs
+++ b/crates/mvm-agentd/src/vsock/mod.rs
@@ -42,8 +42,8 @@ pub use request_policy::RequestClass;
 pub use response::{
     BootTimingReport, ComponentState, GuestCapability, GuestResponse, ProtocolNegotiation,
     ProtocolUpgradeAction, ReadinessReport, ResponseContract, ResponseKind, ResponseVariant,
-    RunEntrypointError, Verb, VolumeMountErrorKind, VolumeMountResult, protocol_hello_response,
-    supported_capabilities,
+    RunEntrypointError, TrafficPlane, Verb, VolumeMountErrorKind, VolumeMountResult,
+    protocol_hello_response, supported_capabilities,
 };
 pub use response_payloads::{
     EntrypointEvent, ExecEvent, ExecOutcomeWire, FsChange, FsChangeKind, FsEntry, FsEntryKind,
@@ -161,13 +161,20 @@ pub const DEFAULT_TIMEOUT_SECS: u64 = 10;
 /// versions the signed envelope used by authenticated frame wrappers.
 /// `PROTOCOL_VERSION` versions the `GuestRequest` / `GuestResponse`
 /// control surface served by `mvm-guest-agent`.
-pub const PROTOCOL_VERSION: u32 = 1;
+pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Oldest guest-agent control protocol this host can speak.
-pub const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 1;
+pub const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 2;
 
 /// Maximum response frame size (256 KiB).
-const MAX_FRAME_SIZE: usize = 256 * 1024;
+pub const MAX_FRAME_SIZE: usize = 256 * 1024;
+
+/// Maximum raw user-content bytes placed in one JSON data-plane frame.
+///
+/// `Vec<u8>` serializes as a JSON integer array, whose worst case is four
+/// bytes per input byte (`255,`). Forty-eight KiB leaves room for the request
+/// or response envelope while remaining below [`MAX_FRAME_SIZE`].
+pub const MAX_DATA_CHUNK_SIZE: usize = 48 * 1024;
 
 /// Number of transport reconnect attempts before giving up.
 const CONNECT_RETRIES: u32 = 4;

--- a/crates/mvm-agentd/src/vsock/request.rs
+++ b/crates/mvm-agentd/src/vsock/request.rs
@@ -78,9 +78,8 @@ pub enum GuestRequest {
     ///
     /// The response is a stream of `EntrypointEvent` frames
     /// terminated by `EntrypointEvent::Exit` or
-    /// `EntrypointEvent::Error`. v1 emits one `Stdout` chunk + one
-    /// `Stderr` chunk + a terminal event (buffered up to caps); v2
-    /// may chunk progressively without changing the wire shape.
+    /// `EntrypointEvent::Error`. Output events carry bounded chunks;
+    /// callers consume frames until the terminal event.
     ///
     /// Caps and timeouts are enforced agent-side. The wire
     /// frame size is bounded by `MAX_FRAME_SIZE`.
@@ -198,10 +197,8 @@ pub enum GuestRequest {
     // `prod-agent-runentry-contract` CI lane to assert handler
     // symbols PRESENT in prod builds is part of the per-verb landing.
     // ========================================================================
-    /// Read up to `length` bytes from `path`, optionally starting at
-    /// `offset`. The agent enforces `length` ≤ a hard cap (default
-    /// 16 MiB); callers wanting larger reads must use the streaming
-    /// surface (lands in W2).
+    /// Read one bounded chunk from `path`, optionally starting at `offset`.
+    /// Callers transfer larger files through repeated offset-addressed calls.
     FsRead {
         path: String,
         offset: Option<u64>,
@@ -212,8 +209,8 @@ pub enum GuestRequest {
         #[serde(default = "default_true")]
         follow_symlinks: bool,
     },
-    /// Write `content` to `path`. Small-content path; large writes
-    /// must use the streaming surface (W2).
+    /// Write one bounded chunk to `path`. Callers transfer larger files through
+    /// repeated offset-addressed calls; only the first chunk truncates.
     FsWrite {
         path: String,
         content: Vec<u8>,
@@ -227,6 +224,12 @@ pub enum GuestRequest {
         /// a malicious symlink could redirect the write.
         #[serde(default)]
         follow_symlinks: bool,
+        /// Byte offset at which this chunk is written. Defaults to the start.
+        #[serde(default)]
+        offset: Option<u64>,
+        /// Truncate before writing. Defaults to the original one-shot behavior.
+        #[serde(default = "default_true")]
+        truncate: bool,
     },
     /// List entries in `path`. Cap: 4096 entries; truncated flag set
     /// in the response when exceeded.
@@ -408,12 +411,9 @@ pub enum GuestRequest {
     /// Other values, or a missing/unparseable wrapper.json, refuse
     /// with a wire-stable error message.
     ///
-    /// **v1 is stateless** — each call spawns a fresh interpreter
+    /// This call is stateless: each request spawns a fresh interpreter
     /// process, so `from foo import bar` in call 1 isn't visible in
-    /// call 2. A future v2 routes
-    /// through the warm-process pool's wrapper for stateful eval
-    /// across calls; the wire shape stays identical, the dispatch
-    /// flips inside the agent.
+    /// call 2.
     RunCode {
         code: String,
         timeout_secs: Option<u64>,
@@ -556,6 +556,8 @@ mod tests {
                 mode: 0o644,
                 create_parents: true,
                 follow_symlinks: false,
+                offset: None,
+                truncate: true,
             },
             GuestRequest::FsList {
                 path: "/work".to_string(),
@@ -802,6 +804,8 @@ mod tests {
             GuestRequest::FsWrite {
                 follow_symlinks,
                 create_parents,
+                offset,
+                truncate,
                 ..
             } => {
                 assert!(
@@ -809,6 +813,8 @@ mod tests {
                     "FsWrite must NOT follow symlinks by default"
                 );
                 assert!(!create_parents, "create_parents defaults to false");
+                assert_eq!(offset, None, "offset defaults to the beginning of the file");
+                assert!(truncate, "legacy one-shot writes truncate by default");
             }
             _ => panic!("expected FsWrite"),
         }
@@ -1158,6 +1164,8 @@ mod tests {
                     mode: 0,
                     create_parents: false,
                     follow_symlinks: false,
+                    offset: None,
+                    truncate: true,
                 },
                 "fs-write",
             ),

--- a/crates/mvm-agentd/src/vsock/request_policy.rs
+++ b/crates/mvm-agentd/src/vsock/request_policy.rs
@@ -289,6 +289,8 @@ mod tests {
                 mode: 0,
                 create_parents: false,
                 follow_symlinks: false,
+                offset: None,
+                truncate: true,
             },
             GuestRequest::FsList {
                 path: "/x".into(),
@@ -480,6 +482,8 @@ mod tests {
                 mode: 0,
                 create_parents: false,
                 follow_symlinks: false,
+                offset: None,
+                truncate: true,
             },
             GuestRequest::FsRead {
                 path: "/x".into(),

--- a/crates/mvm-agentd/src/vsock/response.rs
+++ b/crates/mvm-agentd/src/vsock/response.rs
@@ -116,8 +116,8 @@ pub struct ReadinessReport {
     /// Drop-in probe scan + probe loop. `Disabled` if no
     /// `/etc/mvm/probes.d/*.json` files present.
     pub probes: ComponentState,
-    /// Volume-mount state — wire-stable placeholder. `Disabled` in
-    /// v1 (mount/unmount are on-demand verbs, not boot state).
+    /// Volume-mount state — wire-stable placeholder. `Disabled` because
+    /// mount/unmount are on-demand verbs, not boot state.
     pub volumes: ComponentState,
     /// Active agent profile. Same value the dispatcher uses for the
     /// `allowed_in` gate.
@@ -369,6 +369,15 @@ pub enum ResponseKind {
     Stream,
 }
 
+/// Whether a verb carries bounded orchestration metadata or user-controlled
+/// payload bytes. The distinction drives dispatch capacity and audit handling;
+/// it is independent of the prod/dev profile gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TrafficPlane {
+    Control,
+    Data,
+}
+
 /// The declared response contract for a request verb: which `GuestResponse`
 /// variant(s) answer it, and whether the answer is a single frame or a
 /// terminal-terminated stream. The universal responses (`Error`,
@@ -382,6 +391,52 @@ pub struct ResponseContract {
 }
 
 impl Verb {
+    /// Exhaustive control/data-plane classification for this wire verb.
+    pub fn traffic_plane(self) -> TrafficPlane {
+        use TrafficPlane::{Control, Data};
+        match self {
+            Self::Exec
+            | Self::ExecBatch
+            | Self::RunEntrypoint
+            | Self::FsDiff
+            | Self::FsRead
+            | Self::FsWrite
+            | Self::FsList
+            | Self::ProcSendInput
+            | Self::ProcWait
+            | Self::RunCode => Data,
+            Self::ProtocolHello
+            | Self::WorkerStatus
+            | Self::SleepPrep
+            | Self::Wake
+            | Self::Ping
+            | Self::IntegrationStatus
+            | Self::CheckpointIntegrations
+            | Self::ProbeStatus
+            | Self::PrimedStatus
+            | Self::RunDetached
+            | Self::PostRestore
+            | Self::StartPortForward
+            | Self::StartUnixSocketForward
+            | Self::ConsoleOpen
+            | Self::ConsoleClose
+            | Self::ConsoleResize
+            | Self::EntrypointStatus
+            | Self::ReadinessStatus
+            | Self::FsStat
+            | Self::FsMkdir
+            | Self::FsRemove
+            | Self::FsMove
+            | Self::ProcStart
+            | Self::ProcList
+            | Self::ProcSignal
+            | Self::ProcKill
+            | Self::MountVolume
+            | Self::UnmountVolume
+            | Self::UpdateIdleTimeout => Control,
+        }
+    }
+
     /// The declared host↔guest response contract for this verb — the
     /// machine-readable pairing previously implicit in the agent dispatch.
     pub fn response_contract(self) -> ResponseContract {
@@ -1404,6 +1459,24 @@ mod tests {
             streaming,
             BTreeSet::from(["Exec", "ProcWait", "RunCode", "RunEntrypoint"])
         );
+    }
+
+    #[test]
+    fn every_streaming_verb_is_data_plane() {
+        for verb in Verb::ALL {
+            if verb.response_contract().kind == ResponseKind::Stream {
+                assert_eq!(verb.traffic_plane(), TrafficPlane::Data, "{}", verb.name());
+            }
+        }
+    }
+
+    #[test]
+    fn representative_verbs_have_expected_traffic_planes() {
+        assert_eq!(Verb::Ping.traffic_plane(), TrafficPlane::Control);
+        assert_eq!(Verb::ReadinessStatus.traffic_plane(), TrafficPlane::Control);
+        assert_eq!(Verb::RunEntrypoint.traffic_plane(), TrafficPlane::Data);
+        assert_eq!(Verb::FsRead.traffic_plane(), TrafficPlane::Data);
+        assert_eq!(Verb::ConsoleOpen.traffic_plane(), TrafficPlane::Control);
     }
 
     // Drift guard: every GuestResponse variant must be answered by some

--- a/crates/mvm-agentd/src/vsock/response_payloads.rs
+++ b/crates/mvm-agentd/src/vsock/response_payloads.rs
@@ -285,10 +285,8 @@ pub enum FsChangeKind {
 /// stream for one call. The agent emits exactly one terminal event
 /// per call.
 ///
-/// v1 buffers each stream fully before sending one `Stdout` and one
-/// `Stderr` event (sizes bounded by agent caps). v2 may chunk
-/// progressively without changing the type or the protocol shape:
-/// the host already reads frames in a loop until terminal.
+/// Buffered output is split into bounded `Stdout` and `Stderr` events without
+/// changing the protocol shape: the host reads frames until terminal.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]

--- a/crates/mvm-agentd/src/vsock/rpc.rs
+++ b/crates/mvm-agentd/src/vsock/rpc.rs
@@ -177,9 +177,7 @@ pub fn require_capabilities(
 /// (`Exit` or `Error`) for the caller to inspect.
 ///
 /// The wire format is the same length-prefixed JSON envelope as every
-/// other vsock verb. v1 emits exactly three frames per call: one
-/// `Stdout`, one `Stderr`, and one terminal event. v2 may chunk
-/// progressively without changing this consumer — termination is
+/// other vsock verb. Output may span multiple bounded frames; termination is
 /// detected via [`EntrypointEvent::is_terminal`], not frame count.
 pub fn send_run_entrypoint<F>(
     stream: &mut UnixStream,

--- a/crates/mvm-cli/src/commands/vm/cp.rs
+++ b/crates/mvm-cli/src/commands/vm/cp.rs
@@ -122,34 +122,26 @@ fn copy_host_to_guest(host: &Path, vm: &str, guest_path: &str, args: &Args) -> R
     if !args.force && guest_exists(vm, guest_path)? {
         bail!("Guest destination {vm}:{guest_path} exists; pass --force to overwrite");
     }
-    let req = GuestRequest::FsWrite {
-        path: guest_path.to_string(),
-        content,
-        mode: DEFAULT_MODE,
-        create_parents: args.create_parents,
-        follow_symlinks: false,
-    };
-    // Inbound vsock RPC audit. Emit before dispatch so a failure
-    // on the wire still leaves an audit trail of "host tried to
-    // write to this guest path".
-    super::shared::emit_vsock_rpc_audit(vm, &req);
-    match unwrap_fs(super::fs::fs_request(vm, req)?)? {
-        FsResult::Write { bytes_written } => {
-            mvm_core::audit_emit!(
-                VmFileCopy,
-                vm: vm,
-                "direction=host_to_guest path={guest_path} bytes={bytes_written}"
-            );
-            Ok(CopySummary::new(
-                CopyDirection::HostToGuest,
-                vm,
-                guest_path,
-                bytes_written,
-                args,
-            ))
-        }
-        other => bail!("Unexpected FsResult variant for Write: {:?}", other),
-    }
+    let bytes_written = super::fs::write_guest_chunks(
+        vm,
+        guest_path,
+        &content,
+        DEFAULT_MODE,
+        args.create_parents,
+        false,
+    )?;
+    mvm_core::audit_emit!(
+        VmFileCopy,
+        vm: vm,
+        "direction=host_to_guest path={guest_path} bytes={bytes_written}"
+    );
+    Ok(CopySummary::new(
+        CopyDirection::HostToGuest,
+        vm,
+        guest_path,
+        bytes_written,
+        args,
+    ))
 }
 
 fn copy_guest_to_host(vm: &str, guest_path: &str, host: &Path, args: &Args) -> Result<CopySummary> {
@@ -181,51 +173,39 @@ fn copy_guest_to_host(vm: &str, guest_path: &str, host: &Path, args: &Args) -> R
             )
         })?;
     }
-    let req = GuestRequest::FsRead {
-        path: guest_path.to_string(),
-        offset: None,
-        length: stat.size,
-        follow_symlinks: true,
-    };
-    // Inbound vsock RPC audit.
-    super::shared::emit_vsock_rpc_audit(vm, &req);
-    match unwrap_fs(super::fs::fs_request(vm, req)?)? {
-        FsResult::Read { content, .. } => {
-            if content.len() as u64 != stat.size {
-                bail!(
-                    "Guest read returned {} bytes, expected {}",
-                    content.len(),
-                    stat.size
-                );
-            }
-            let mut options = std::fs::OpenOptions::new();
-            options.write(true).create(true);
-            if args.force {
-                options.truncate(true);
-            } else {
-                options.create_new(true);
-            }
-            let mut file = options
-                .open(host)
-                .with_context(|| format!("Failed to open host destination {}", host.display()))?;
-            file.write_all(&content)
-                .with_context(|| format!("Failed to write host destination {}", host.display()))?;
-            mvm_core::audit_emit!(
-                VmFileCopy,
-                vm: vm,
-                "direction=guest_to_host path={guest_path} bytes={}",
-                content.len()
-            );
-            Ok(CopySummary::new(
-                CopyDirection::GuestToHost,
-                vm,
-                guest_path,
-                content.len() as u64,
-                args,
-            ))
-        }
-        other => bail!("Unexpected FsResult variant for Read: {:?}", other),
+    let content = super::fs::read_guest_chunks(vm, guest_path, 0, stat.size)?;
+    let content_len = u64::try_from(content.len()).expect("content length fits u64");
+    if content_len != stat.size {
+        bail!(
+            "Guest read returned {} bytes, expected {}",
+            content.len(),
+            stat.size
+        );
     }
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true);
+    if args.force {
+        options.truncate(true);
+    } else {
+        options.create_new(true);
+    }
+    let mut file = options
+        .open(host)
+        .with_context(|| format!("Failed to open host destination {}", host.display()))?;
+    file.write_all(&content)
+        .with_context(|| format!("Failed to write host destination {}", host.display()))?;
+    mvm_core::audit_emit!(
+        VmFileCopy,
+        vm: vm,
+        "direction=guest_to_host path={guest_path} bytes={content_len}"
+    );
+    Ok(CopySummary::new(
+        CopyDirection::GuestToHost,
+        vm,
+        guest_path,
+        content_len,
+        args,
+    ))
 }
 
 impl CopySummary {

--- a/crates/mvm-cli/src/commands/vm/fs.rs
+++ b/crates/mvm-cli/src/commands/vm/fs.rs
@@ -193,22 +193,9 @@ fn unwrap_fs(result: FsResult) -> Result<FsResult> {
 }
 
 fn cmd_read(name: &str, path: &str, offset: u64, length: u64) -> Result<()> {
-    let req = GuestRequest::FsRead {
-        path: path.to_string(),
-        offset: if offset == 0 { None } else { Some(offset) },
-        length,
-        follow_symlinks: true,
-    };
-    // Inbound vsock RPC audit.
-    super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_fs(fs_request(name, req)?)?;
-    match result {
-        FsResult::Read { content, .. } => {
-            std::io::stdout().write_all(&content)?;
-            Ok(())
-        }
-        other => bail!("Unexpected FsResult variant for Read: {:?}", other),
-    }
+    let content = read_guest_chunks(name, path, offset, length)?;
+    std::io::stdout().write_all(&content)?;
+    Ok(())
 }
 
 fn cmd_write(
@@ -227,24 +214,96 @@ fn cmd_write(
             buf
         }
     };
-    let req = GuestRequest::FsWrite {
-        path: path.to_string(),
-        content: bytes,
-        mode,
-        create_parents,
-        follow_symlinks,
-    };
-    // Inbound vsock RPC audit.
-    super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_fs(fs_request(name, req)?)?;
-    match result {
-        FsResult::Write { bytes_written } => {
-            eprintln!("wrote {} bytes", bytes_written);
-            mvm_core::audit_emit!(VmFsMutate, vm: name, "op=write path={path} bytes={bytes_written}");
-            Ok(())
+    let bytes_written =
+        write_guest_chunks(name, path, &bytes, mode, create_parents, follow_symlinks)?;
+    eprintln!("wrote {} bytes", bytes_written);
+    mvm_core::audit_emit!(VmFsMutate, vm: name, "op=write path={path} bytes={bytes_written}");
+    Ok(())
+}
+
+pub(super) fn read_guest_chunks(
+    name: &str,
+    path: &str,
+    start_offset: u64,
+    length: u64,
+) -> Result<Vec<u8>> {
+    let chunk_cap =
+        u64::try_from(mvm_agentd::vsock::MAX_DATA_CHUNK_SIZE).expect("wire chunk size fits u64");
+    let capacity = usize::try_from(length).unwrap_or(usize::MAX);
+    let mut content = Vec::with_capacity(capacity.min(mvm_agentd::vsock::MAX_DATA_CHUNK_SIZE));
+    let mut offset = start_offset;
+    let mut remaining = length;
+    while remaining > 0 {
+        let requested = remaining.min(chunk_cap);
+        let req = GuestRequest::FsRead {
+            path: path.to_string(),
+            offset: Some(offset),
+            length: requested,
+            follow_symlinks: true,
+        };
+        super::shared::emit_vsock_rpc_audit(name, &req);
+        match unwrap_fs(fs_request(name, req)?)? {
+            FsResult::Read {
+                content: chunk,
+                total_size,
+            } => {
+                let chunk_len = u64::try_from(chunk.len()).expect("chunk length fits u64");
+                if chunk_len > requested {
+                    bail!("Guest read returned a chunk larger than requested");
+                }
+                content.extend_from_slice(&chunk);
+                offset = offset
+                    .checked_add(chunk_len)
+                    .ok_or_else(|| anyhow::anyhow!("Guest read offset overflow"))?;
+                remaining -= chunk_len;
+                if chunk_len < requested || offset >= total_size {
+                    break;
+                }
+            }
+            other => bail!("Unexpected FsResult variant for Read: {other:?}"),
         }
-        other => bail!("Unexpected FsResult variant for Write: {:?}", other),
     }
+    Ok(content)
+}
+
+pub(super) fn write_guest_chunks(
+    name: &str,
+    path: &str,
+    content: &[u8],
+    mode: u32,
+    create_parents: bool,
+    follow_symlinks: bool,
+) -> Result<u64> {
+    let mut offset = 0_u64;
+    for (index, chunk) in content
+        .chunks(mvm_agentd::vsock::MAX_DATA_CHUNK_SIZE)
+        .chain(content.is_empty().then_some(content))
+        .enumerate()
+    {
+        let req = GuestRequest::FsWrite {
+            path: path.to_string(),
+            content: chunk.to_vec(),
+            mode,
+            create_parents: create_parents && index == 0,
+            follow_symlinks,
+            offset: Some(offset),
+            truncate: index == 0,
+        };
+        super::shared::emit_vsock_rpc_audit(name, &req);
+        match unwrap_fs(fs_request(name, req)?)? {
+            FsResult::Write { bytes_written } => {
+                let expected = u64::try_from(chunk.len()).expect("chunk length fits u64");
+                if bytes_written != expected {
+                    bail!("Guest wrote {bytes_written} bytes, expected {expected}");
+                }
+                offset = offset
+                    .checked_add(bytes_written)
+                    .ok_or_else(|| anyhow::anyhow!("Guest write offset overflow"))?;
+            }
+            other => bail!("Unexpected FsResult variant for Write: {other:?}"),
+        }
+    }
+    Ok(offset)
 }
 
 fn cmd_ls(name: &str, path: &str, json: bool) -> Result<()> {

--- a/crates/mvm-cli/src/commands/vm/proc.rs
+++ b/crates/mvm-cli/src/commands/vm/proc.rs
@@ -292,21 +292,32 @@ fn cmd_stdin(name: &str, token: &str, content: Option<String>) -> Result<()> {
             buf
         }
     };
-    let req = GuestRequest::ProcSendInput {
-        pid_token: token.to_string(),
-        bytes,
-    };
-    // Inbound vsock RPC audit.
-    super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_proc(proc_request(name, req)?)?;
-    match result {
-        ProcResult::InputAccepted { bytes_accepted } => {
-            eprintln!("accepted {bytes_accepted} bytes");
-            mvm_core::audit_emit!(VmProcStdin, vm: name, "token={token} bytes={bytes_accepted}");
-            Ok(())
+    let mut total_accepted = 0_u64;
+    for chunk in bytes
+        .chunks(mvm_agentd::vsock::MAX_DATA_CHUNK_SIZE)
+        .chain(bytes.is_empty().then_some(bytes.as_slice()))
+    {
+        let req = GuestRequest::ProcSendInput {
+            pid_token: token.to_string(),
+            bytes: chunk.to_vec(),
+        };
+        super::shared::emit_vsock_rpc_audit(name, &req);
+        match unwrap_proc(proc_request(name, req)?)? {
+            ProcResult::InputAccepted { bytes_accepted } => {
+                let expected = u64::try_from(chunk.len()).expect("chunk length fits u64");
+                if bytes_accepted != expected {
+                    bail!("Guest accepted {bytes_accepted} stdin bytes, expected {expected}");
+                }
+                total_accepted = total_accepted
+                    .checked_add(bytes_accepted)
+                    .ok_or_else(|| anyhow::anyhow!("Accepted stdin byte count overflow"))?;
+            }
+            other => bail!("Unexpected ProcResult variant for SendInput: {other:?}"),
         }
-        other => bail!("Unexpected ProcResult variant for SendInput: {:?}", other),
     }
+    eprintln!("accepted {total_accepted} bytes");
+    mvm_core::audit_emit!(VmProcStdin, vm: name, "token={token} bytes={total_accepted}");
+    Ok(())
 }
 
 fn cmd_wait(name: &str, token: &str, timeout: Option<u64>) -> Result<()> {

--- a/crates/mvm-protocol/src/protocol/network_tunnel.rs
+++ b/crates/mvm-protocol/src/protocol/network_tunnel.rs
@@ -1,17 +1,16 @@
 //! Shared guest-TUN ↔ host-UDS network tunnel contract.
 //!
-//! This module defines the first stable wire/config seam for a production
+//! This module defines the stable wire/config seam for the production
 //! vsock-only data path:
 //!
 //! guest TUN -> framed packets -> AF_VSOCK -> host UDS -> host worker
 //!
-//! The implementation deliberately stops at the contract:
+//! The contract covers:
 //! - session-bound identity and feature negotiation,
 //! - guest network configuration,
 //! - frame typing and bounded decoding.
 //!
-//! The host/guest packet pumps land in later slices; pinning the contract here
-//! first lets both ends converge on one fail-closed shape.
+//! Host and guest packet pumps consume this shared fail-closed shape.
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;

--- a/crates/mvm-runtime/src/mock_guest_agent.rs
+++ b/crates/mvm-runtime/src/mock_guest_agent.rs
@@ -439,6 +439,8 @@ mod tests {
             mode: 0o644,
             create_parents: false,
             follow_symlinks: false,
+            offset: None,
+            truncate: true,
         };
         let result = send_fs_request(&dir.path().to_string_lossy(), req).expect("send_fs_request");
         match result {
@@ -586,6 +588,8 @@ mod tests {
                 mode: 0o644,
                 create_parents: false,
                 follow_symlinks: false,
+                offset: None,
+                truncate: true,
             },
         )
         .expect("write a");
@@ -597,6 +601,8 @@ mod tests {
                 mode: 0o644,
                 create_parents: false,
                 follow_symlinks: false,
+                offset: None,
+                truncate: true,
             },
         )
         .expect("write b");

--- a/crates/mvm-runtime/src/vm/exec_builder.rs
+++ b/crates/mvm-runtime/src/vm/exec_builder.rs
@@ -166,6 +166,8 @@ fn stage_files(stream: &mut UnixStream, stages: &[StagedFile]) -> Result<()> {
                 mode: s.mode,
                 create_parents: true,
                 follow_symlinks: false,
+                offset: None,
+                truncate: true,
             },
         )
         .with_context(|| format!("staging {}", s.path))?;

--- a/crates/mvm-sdk/sdks/python/mvm/_protocol/protocol.py
+++ b/crates/mvm-sdk/sdks/python/mvm/_protocol/protocol.py
@@ -506,6 +506,8 @@ class FsWrite:
     path: str
     create_parents: Optional[bool] = False
     follow_symlinks: Optional[bool] = False
+    offset: Optional[int] = None
+    truncate: Optional[bool] = True
 
 
 @dataclass

--- a/crates/mvm-sdk/sdks/typescript/src/protocol/protocol.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/protocol/protocol.ts
@@ -127,7 +127,15 @@ follow_symlinks?: boolean
  * File mode for newly-created files (e.g. `0o644`). Ignored when overwriting an existing file (existing perms kept).
  */
 mode: number
+/**
+ * Byte offset at which this chunk is written. Defaults to the start.
+ */
+offset?: (number | null)
 path: string
+/**
+ * Truncate before writing. Defaults to the original one-shot behavior.
+ */
+truncate?: boolean
 }
 } | {
 FsList: {
@@ -406,7 +414,7 @@ error: string
  * 
  * `Stdout` / `Stderr` carry bytes from the wrapper's respective streams. `Exit` and `Error` are terminal — they end the response stream for one call. The agent emits exactly one terminal event per call.
  * 
- * v1 buffers each stream fully before sending one `Stdout` and one `Stderr` event (sizes bounded by agent caps). v2 may chunk progressively without changing the type or the protocol shape: the host already reads frames in a loop until terminal.
+ * Buffered output is split into bounded `Stdout` and `Stderr` events without changing the protocol shape: the host reads frames until terminal.
  */
 export type EntrypointEvent = ({
 Stdout: {
@@ -779,7 +787,7 @@ probes: ComponentState
  */
 profile: AgentProfile
 /**
- * Volume-mount state — wire-stable placeholder. `Disabled` in v1 (mount/unmount are on-demand verbs, not boot state).
+ * Volume-mount state — wire-stable placeholder. `Disabled` because mount/unmount are on-demand verbs, not boot state.
  */
 volumes: ComponentState
 /**

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -64,34 +64,30 @@ Request types: `ping`, `status`, `sleep-prep`, `wake`, and more.
 
 ## Control plane and data plane
 
-Plan 74 / ADR-019 §4 splits the agent's wire surface into a
-**control plane** (small, single-frame, bounded requests/responses)
-and a **data plane** (streaming or chunked operations where the
-payload size is dominated by user content, not metadata). The
-distinction is load-bearing for the redaction invariant: data-plane
-payload bytes never appear in audit records, readiness messages,
-progress events, backpressure events, or receipts. The control
-plane is fully tracked in those surfaces; the data plane carries
-hashes and counts only.
+The agent has separate logical **control** and **data** planes. They share the
+authenticated guest-protocol listener, but classification is exhaustive and
+drives admission: at most 64 requests run concurrently, data-plane work is
+limited to 48, and the remaining 16 slots stay available for health,
+readiness, lifecycle, and cancellation requests. A saturated transfer cannot
+consume all control capacity.
 
-Every verb in the table below is also gated by an agent profile
-(see "Profile gate" below) — but the control-plane / data-plane
-split is **orthogonal**. `Exec` (dev-only) is a data-plane verb;
-`Ping` (always available) is control-plane.
+Every encoded request and response is capped symmetrically at 256 KiB before
+any bytes are written. User-content chunks are at most 48 KiB, leaving enough
+headroom for worst-case JSON encoding and the response envelope. The split is
+orthogonal to the agent profile gate: `Exec` is dev-only and data-plane;
+`Ping` is always available and control-plane.
 
 ### Control-plane verbs
 
-Small bounded JSON in / small bounded JSON out. Maximum response
-frame size is `MAX_FRAME_SIZE = 256 KiB` (`crates/mvm-agentd/src/vsock/mod.rs`).
-No streaming. No payload bytes from user processes.
+Small bounded JSON in and out, with no user process or file payload bytes.
 
 | Verb | Response shape | Notes |
 |---|---|---|
-| `ProtocolHello` | `ProtocolHelloAck` / `ProtocolMismatch` | Required first request in every session (ADR-019 §1, hard cutover). |
+| `ProtocolHello` | `ProtocolHelloAck` / `ProtocolMismatch` | Required first request in every session; protocol v2 is a hard cutover. |
 | `Ping` | `Pong` | Reachability probe. Requires `Ping` capability. |
 | `WorkerStatus` | `WorkerStatus { status, last_busy_at }` | Idle/busy sampled from `/proc/loadavg`. |
 | `ReadinessStatus` | `ReadinessStatusReport` | Component-level readiness (see "Readiness model" below). |
-| `IntegrationStatus` | `IntegrationStatusReport { integrations: Vec<…> }` | One per declared integration. Used by `mvmctl ls --json` readiness column (plan 74 W2). |
+| `IntegrationStatus` | `IntegrationStatusReport { integrations: Vec<…> }` | One per declared integration. |
 | `EntrypointStatus` | `EntrypointStatusReport` | Validation result + warm-pool state. |
 | `ProbeStatus` | `ProbeStatusReport { probes: Vec<ProbeResult> }` | One per declared probe. |
 | `SleepPrep` / `Wake` / `PostRestore` / `CheckpointIntegrations` | Ack | Snapshot lifecycle handshakes. |
@@ -99,26 +95,24 @@ No streaming. No payload bytes from user processes.
 | `MountVolume` / `UnmountVolume` | `MountVolumeResult` (closed enum) | Volume metadata only — no file contents. |
 | `StartPortForward` | `PortForwardStarted { vsock_port, … }` | Sets up a vsock→TCP forwarder. The data plane on that forwarder is byte-for-byte; the *control* plane that asks for it is one frame. |
 | `ProcStart` / `ProcSignal` / `ProcKill` / `ProcList` | `ProcResult` (closed enum) | Process control. `ProcStart` accepts an `argv` up to capped length but does not echo it back. |
-| `FsStat` / `FsList` / `FsMkdir` / `FsRemove` / `FsMove` | `FsResult` (closed enum) | Filesystem metadata. `FsList` truncates at `max_entries` and reports `truncated: true`. |
+| `FsStat` / `FsMkdir` / `FsRemove` / `FsMove` | `FsResult` (closed enum) | Bounded filesystem metadata and mutations. |
 | `ConsoleOpen` / `ConsoleClose` / `ConsoleResize` | Ack with vsock port | Allocates a PTY forwarder. The PTY itself runs on a different vsock port — that's the data plane. |
 
 ### Data-plane verbs
 
-Streaming, chunked, or potentially-large bounded transfers. Each
-data-plane verb names its frame cap, chunk size, terminal event,
-and backpressure behavior below.
+Streaming, chunked, or potentially large bounded transfers. These requests
+share the 48-request data admission budget.
 
 | Verb | Flow | Frame cap | Chunk size | Terminal | Backpressure | Payload in audit? |
 |---|---|---|---|---|---|---|
-| `RunEntrypoint` | Single request → stream of `EntrypointEvent`s | `MAX_FRAME_SIZE` per event | Stdout/stderr drained per agent tick | `Exit { code }` / `Killed { signal }` / `TimedOut` / `Error` | None today (W4 wires the next slice). | No. Hash of stdout/stderr appears in receipts (plan 74 W6); raw bytes do not. |
-| `ProcWait` | Single request → stream of `ProcWaitEvent`s | `MAX_FRAME_SIZE` per event | Stdout/stderr drained per ~50 ms agent tick | `Exit` / `Killed` / `TimedOut` / `Error` | **`Backpressure { reason: OutputConsumerSlow, detail }`** — rising-edge at 75 % of `Caps::max_output_buffer` (16 MiB prod, plan 74 W4). Non-terminal; wait continues. | No. Output streams to the host live; nothing about chunk content goes to audit. |
-| `ProcSendInput` | Bounded request → ack | Request body capped at `Caps::max_stdin_per_call` (1 MiB prod) | Single-frame | `ProcResult::InputAccepted { bytes_accepted }` | Caller-driven — request body fails closed if it exceeds the cap (no implicit truncation). | No. `bytes_accepted` count only; never stdin bytes. |
-| `FsRead` | Single request → `FsResult::Read { content, total_size }` | `MAX_FRAME_SIZE` per response | The agent caps reads at `max_read_bytes` and reports `total_size` so callers detect short reads. Bigger files require multiple requests with offset/length. | Response itself is the terminal | None — bounded by frame cap. | No. `total_size` and offset/length appear in audit; `content` bytes do not. |
-| `FsWrite` | Bounded request → `FsResult::Write { bytes_written }` | Request body capped at the agent's write cap | Single-frame | Response itself is the terminal | Caller-driven — too-large bodies fail closed. | No. Byte count only. |
-| `Exec` / `RunCode` (dev-only) | Single request → `ExecResult { exit_code, stdout, stderr }` | Each captured stream capped by the dev caps; total response bounded by `MAX_FRAME_SIZE` | One-shot capture; no streaming | Response itself is the terminal | None — dev-only, not exercised in prod. | No. Hash of stdout/stderr can be receipted; raw bytes are not audited. |
-| Console PTY traffic | Bidirectional bytes over a dedicated vsock port (`ConsoleOpen` allocates it) | Per-frame cap defined by the console transport, not `MAX_FRAME_SIZE` | TTY-shaped reads | Caller closes (`ConsoleClose`) or PTY exits | None — interactive, not buffered. | No. Console bytes never enter audit. |
+| `RunEntrypoint` | Request → `EntrypointEvent` stream | 256 KiB per event | 48 KiB stdout/stderr | `Exit` / `Killed` / `TimedOut` / `Error` | Bounded process buffers. | No. |
+| `ProcWait` | Request → `ProcWaitEvent` stream | 256 KiB per event | 48 KiB stdout/stderr | `Exit` / `Killed` / `TimedOut` / `Error` | Typed non-terminal backpressure events. | No. |
+| `ProcSendInput` | Bounded request → ack | 256 KiB | At most 48 KiB per protocol frame | `InputAccepted` | Caller retries subsequent chunks. | No; byte count only. |
+| `FsRead` / `FsWrite` | Repeated offset requests → bounded responses | 256 KiB | 48 KiB | Each chunk response | Caller advances the offset; the first write truncates and later chunks do not. | No; offsets, sizes, and counts only. |
+| `FsList` / `FsDiff` | Request → bounded metadata response | 256 KiB | Protocol-bounded result | Response itself | Result caps and frame cap fail closed. | No file contents. |
+| `Exec` / `ExecBatch` / `RunCode` (dev-only) | One-shot request and capture | 256 KiB | Protocol-bounded result | Response itself | Oversized encoded responses fail closed. | No. |
+| Console PTY traffic | Raw bytes on a dedicated vsock port | Raw transport | TTY-shaped reads | Close or PTY exit | Kernel/socket backpressure; only the host CID may connect. | No. |
 | Port-forward TCP traffic | Bidirectional bytes over the vsock port returned by `StartPortForward` | None — raw TCP | TCP-shaped reads | TCP teardown | None — kernel TCP. | No. Forwarded bytes never enter audit. |
-| Builder output (builder VM only) | Streamed during `mvm-host-vm-init` builds | Frame cap on the builder vsock channel | Lines / records | Builder's terminal status | None today; builder egress events (plan 74 W8) will surface backpressure. | No. Build logs are stored next to the receipt; raw bytes never get into audit detail strings. |
 
 ### Redaction invariant
 
@@ -135,30 +129,19 @@ payload bytes. The list is the authoritative one:
   declared integration `name` field). Health-check command output
   never appears.
 - `ProcWaitEvent::Backpressure { reason, detail }` — the `detail`
-  string is metadata only: byte counts, threshold, cap. Plan 74 W4
-  unit tests pin this.
+  string is metadata only: byte counts, threshold, and cap.
 - `BackpressureReason::ServiceHealthPending { pending }` — service
   names only.
 - Receipts written by `mvmctl run` / `mvmctl machine run` / `mvmctl build`
-  (plan 74 W6) store hashes and metadata. Raw stdout / stderr /
+  store hashes and metadata. Raw stdout / stderr /
   stdin / env / argv values are never written.
 - `mvmctl ls --json` rows — the `readiness` and
   `last_readiness_change_at` fields render directly from the
   registry; the registry only stores the closed enum + RFC 3339
   timestamps.
 
-### Exit checks
-
-Plan 74 W3 calls out two contract checks that this section
-underwrites:
-
-1. **No code path advertises an unbounded single-frame response.**
-   Every entry above either names a frame cap or routes through a
-   streaming surface (`ProcWaitEvent` / `EntrypointEvent` / PTY /
-   raw TCP).
-2. **Docs explicitly state that payload bytes are not included in
-   audit or readiness messages.** The "Redaction invariant"
-   subsection is that statement.
+The classification is encoded by `Verb::traffic_plane()`. Because its match is
+exhaustive, adding a verb requires choosing a plane at compile time.
 
 ## Profile gate
 

--- a/schema/protocol-v0.json
+++ b/schema/protocol-v0.json
@@ -227,7 +227,7 @@
       ]
     },
     "EntrypointEvent": {
-      "description": "One event in the streaming response of a `RunEntrypoint` call.\n\n`Stdout` / `Stderr` carry bytes from the wrapper's respective streams. `Exit` and `Error` are terminal — they end the response stream for one call. The agent emits exactly one terminal event per call.\n\nv1 buffers each stream fully before sending one `Stdout` and one `Stderr` event (sizes bounded by agent caps). v2 may chunk progressively without changing the type or the protocol shape: the host already reads frames in a loop until terminal.",
+      "description": "One event in the streaming response of a `RunEntrypoint` call.\n\n`Stdout` / `Stderr` carry bytes from the wrapper's respective streams. `Exit` and `Error` are terminal — they end the response stream for one call. The agent emits exactly one terminal event per call.\n\nBuffered output is split into bounded `Stdout` and `Stderr` events without changing the protocol shape: the host reads frames until terminal.",
       "oneOf": [
         {
           "description": "Bytes from the wrapper's stdout.",
@@ -1110,7 +1110,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Run the image's baked entrypoint program with the given stdin piped in and stdout/stderr captured.\n\nThis is the production-safe call surface. The agent reads the entrypoint path from `/etc/mvm/entrypoint` at boot, validates it (verity-partition, mode, ownership), and that resolved path is the only program `RunEntrypoint` will spawn. There is no argv override, no shell, no env injection beyond what the wrapper template defines at image build time.\n\nThe response is a stream of `EntrypointEvent` frames terminated by `EntrypointEvent::Exit` or `EntrypointEvent::Error`. v1 emits one `Stdout` chunk + one `Stderr` chunk + a terminal event (buffered up to caps); v2 may chunk progressively without changing the wire shape.\n\nCaps and timeouts are enforced agent-side. The wire frame size is bounded by `MAX_FRAME_SIZE`.",
+          "description": "Run the image's baked entrypoint program with the given stdin piped in and stdout/stderr captured.\n\nThis is the production-safe call surface. The agent reads the entrypoint path from `/etc/mvm/entrypoint` at boot, validates it (verity-partition, mode, ownership), and that resolved path is the only program `RunEntrypoint` will spawn. There is no argv override, no shell, no env injection beyond what the wrapper template defines at image build time.\n\nThe response is a stream of `EntrypointEvent` frames terminated by `EntrypointEvent::Exit` or `EntrypointEvent::Error`. Output events carry bounded chunks; callers consume frames until the terminal event.\n\nCaps and timeouts are enforced agent-side. The wire frame size is bounded by `MAX_FRAME_SIZE`.",
           "type": "object",
           "required": [
             "RunEntrypoint"
@@ -1455,7 +1455,7 @@
           ]
         },
         {
-          "description": "Read up to `length` bytes from `path`, optionally starting at `offset`. The agent enforces `length` ≤ a hard cap (default 16 MiB); callers wanting larger reads must use the streaming surface (lands in W2).",
+          "description": "Read one bounded chunk from `path`, optionally starting at `offset`. Callers transfer larger files through repeated offset-addressed calls.",
           "type": "object",
           "required": [
             "FsRead"
@@ -1496,7 +1496,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Write `content` to `path`. Small-content path; large writes must use the streaming surface (W2).",
+          "description": "Write one bounded chunk to `path`. Callers transfer larger files through repeated offset-addressed calls; only the first chunk truncates.",
           "type": "object",
           "required": [
             "FsWrite"
@@ -1534,8 +1534,23 @@
                   "format": "uint32",
                   "minimum": 0.0
                 },
+                "offset": {
+                  "description": "Byte offset at which this chunk is written. Defaults to the start.",
+                  "default": null,
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
                 "path": {
                   "type": "string"
+                },
+                "truncate": {
+                  "description": "Truncate before writing. Defaults to the original one-shot behavior.",
+                  "default": true,
+                  "type": "boolean"
                 }
               },
               "additionalProperties": false
@@ -1949,7 +1964,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Run user-supplied source code in the wrapper's native interpreter. Dev-only — gated behind the agent's `interactive` feature flag, same fence as `Exec`. The host (`mvmctl session run-code`) provides additional gating: the session must be `mode=Dev`.\n\nThe interpreter is selected by reading `/etc/mvm/wrapper.json` at dispatch time: - `language = \"python\"` → `python3 -c <code>` - `language = \"node\"`   → `node -e <code>`\n\nOther values, or a missing/unparseable wrapper.json, refuse with a wire-stable error message.\n\n**v1 is stateless** — each call spawns a fresh interpreter process, so `from foo import bar` in call 1 isn't visible in call 2. A future v2 routes through the warm-process pool's wrapper for stateful eval across calls; the wire shape stays identical, the dispatch flips inside the agent.",
+          "description": "Run user-supplied source code in the wrapper's native interpreter. Dev-only — gated behind the agent's `interactive` feature flag, same fence as `Exec`. The host (`mvmctl session run-code`) provides additional gating: the session must be `mode=Dev`.\n\nThe interpreter is selected by reading `/etc/mvm/wrapper.json` at dispatch time: - `language = \"python\"` → `python3 -c <code>` - `language = \"node\"`   → `node -e <code>`\n\nOther values, or a missing/unparseable wrapper.json, refuse with a wire-stable error message.\n\nThis call is stateless: each request spawns a fresh interpreter process, so `from foo import bar` in call 1 isn't visible in call 2.",
           "type": "object",
           "required": [
             "RunCode"
@@ -3374,7 +3389,7 @@
           ]
         },
         "volumes": {
-          "description": "Volume-mount state — wire-stable placeholder. `Disabled` in v1 (mount/unmount are on-demand verbs, not boot state).",
+          "description": "Volume-mount state — wire-stable placeholder. `Disabled` because mount/unmount are on-demand verbs, not boot state.",
           "allOf": [
             {
               "$ref": "#/definitions/ComponentState"

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -178,6 +178,15 @@ Checkbox legend: `- [ ]` todo. Each WS lists its acceptance gate. Execution is s
 
 ### Phase 1 — Foundations
 
+- [x] **Cross-cutting guest protocol hardening (Plan 254):** made the logical
+  control/data-plane split executable with exhaustive verb classification,
+  64 total / 48 data request admission, symmetric 256 KiB frame limits,
+  48 KiB filesystem/process chunks, offset-addressed `fs`/`cp` transfers, and
+  host-CID-only console data admission. Guest protocol v2 is a hard cutover;
+  schemas and Python/TypeScript bindings are regenerated. Host workspace tests
+  and checks plus affected-crate clippy are green; Linux workspace-wide clippy
+  remains the required merge-CI gate.
+
 **WS1 — crate restructure** (the spine; each sub-step keeps tests green)
 - [ ] 1a `mvm-protocol`: extract `mvm-sdk::ir` + wire + policy + `mvm-verify`; make it `#![no_std]` + `alloc`; add a `wasm32-unknown-unknown` CI build; `unsafe_code = "forbid"`.
 - [ ] 1b `mvm-core`: rebuild on `mvm-protocol`; own single-dir config, crypto, keystore, attestation, catalog, `log`.

--- a/specs/adrs/019-guest-protocol-versioning-and-readiness.md
+++ b/specs/adrs/019-guest-protocol-versioning-and-readiness.md
@@ -67,6 +67,15 @@ streaming or chunked paths with their own frame caps. Payload bytes are
 never copied into audit entries, readiness reports, or receipts; where a
 receipt needs to reference output, it stores a hash, not the bytes.
 
+This is a logical and scheduling separation within the authenticated guest
+protocol, not a claim that every verb has a dedicated socket. The agent
+classifies every verb exhaustively, caps every encoded request and response at
+256 KiB, admits at most 64 concurrent sessions, and reserves 16 of those slots
+for control-plane work by limiting data-plane requests to 48. Filesystem
+payloads and process output use 48 KiB chunks so JSON encoding cannot consume
+the frame headroom. Dedicated raw transports, such as console and port-forward
+sockets, remain separate and accept only the host vsock CID.
+
 ### Backpressure is typed, non-terminal product state
 
 A backpressured operation (today: `ProcWait`) reports one of a closed set

--- a/specs/plans/254-control-data-plane-hardening.md
+++ b/specs/plans/254-control-data-plane-hardening.md
@@ -1,0 +1,38 @@
+# Plan 254 — Control/data-plane hardening
+
+**Status:** Implementation complete — Linux merge gate pending
+
+## Goal
+
+Make the documented host↔guest control/data-plane boundary executable and
+preserve control-plane responsiveness while bounded data-plane work is active.
+
+## Tasks
+
+- [x] Enforce the 256 KiB guest-protocol frame cap symmetrically on readers and
+      writers, with tests proving oversized frames are rejected before bytes are
+      written.
+- [x] Bound user-content chunks below the JSON frame cap and make `mvmctl fs`
+      and `mvmctl cp` transfer larger files as multiple offset-addressed chunks.
+- [x] Add an exhaustive traffic-plane classification for every guest verb and
+      tests that all streaming response contracts are data-plane contracts.
+- [x] Serve guest-agent connections concurrently under explicit total and
+      data-plane limits so bounded control-plane capacity remains available.
+- [x] Reject console data-channel connections whose AF_VSOCK peer CID is not
+      the host CID.
+- [x] Refresh the guest-agent reference and stale packet-tunnel comments to
+      describe the implemented transport accurately.
+- [x] Run `cargo test --workspace`, `cargo check --workspace`, generated-stub
+      drift checks, and all-target/all-feature clippy for every affected crate.
+- [ ] Run workspace-wide all-target clippy in the Linux builder/CI environment
+      before merge; the headless builder has no local arbitrary-command surface.
+
+## Acceptance gates
+
+- A serialized worst-case filesystem chunk fits below the frame cap in both
+  directions.
+- Oversized frame writes return an error and write zero bytes.
+- At most 48 data-plane requests can occupy the 64-connection guest-agent
+  budget, leaving 16 slots for control traffic.
+- Every `Verb` has an exhaustive `TrafficPlane` mapping.
+- Console relay peer authorization accepts CID 2 and rejects guest-local CIDs.


### PR DESCRIPTION
## What changed

- classify every guest-agent verb exhaustively as control-plane or data-plane traffic
- cap guest protocol requests and responses symmetrically at 256 KiB
- use 48 KiB filesystem, process-input, and process-output chunks
- make `mvmctl fs` and `mvmctl cp` transfer large files through offset-addressed chunks
- bound guest-agent concurrency at 64 total requests and 48 data-plane requests, preserving 16 control-plane slots
- admit console data connections only from the host vsock CID
- bump the guest protocol to v2 and regenerate schema plus Python/TypeScript bindings
- refresh the ADR, reference documentation, sprint status, and implementation plan

## Why

The documentation described separate logical control and data planes, but dispatch did not reserve control capacity and outgoing frames were not uniformly bounded. Large JSON payloads could exceed the transport contract, filesystem transfers were one-shot, and a saturated data operation could delay lifecycle or readiness traffic.

This change makes the boundary executable and fail-closed while retaining the existing authenticated listener and dedicated raw console/forwarding channels.

## Impact

Health, readiness, lifecycle, and cancellation traffic retain capacity during data-plane load. Files larger than one protocol frame now transfer in bounded chunks. Guest protocol v2 is a deliberate hard cutover, so older host/guest combinations receive a typed mismatch and require a rebuilt guest.

## Validation

- `cargo test --workspace -- --test-threads=1`
- `cargo check --workspace`
- `cargo test -p mvm-agentd --all-features -- --test-threads=1` after rebasing onto current `main`
- all-target/all-feature clippy for `mvm-agentd`, `mvm-runtime`, and the `mvmctl` binary
- `cargo run -p xtask -- check-stubs`
- `cargo run -p xtask -- check-no-spec-refs-in-comments`
- `cargo fmt --all -- --check`

Linux workspace-wide all-target clippy remains the merge-CI gate.
