### PR TITLE
feat(runtime): carry user-volume disks + mvm.uvols token through WorkloadRunner

### DIFF
--- a/crates/mvm-runtime/src/workload_runner/cmdline.rs
+++ b/crates/mvm-runtime/src/workload_runner/cmdline.rs
@@ -6,6 +6,14 @@
 //! policy / overlay knobs — is strung together here, once, so the raw HVF
 //! backend and `WorkloadRunner::start` boot with the identical cmdline. Pure
 //! string assembly (cfg-free) so it stays unit-testable with no hypervisor.
+//!
+//! One token is deliberately NOT in that shared list: `mvm.uvols=`, the
+//! user-volume mount manifest. The raw HVF backend calls `workload_cmdline`
+//! too, but its `hvf_workload_disks` never attaches `config.volumes` as block
+//! devices — so a `mvm.uvols=` token emitted from inside `workload_cmdline`
+//! would reach the guest describing disks that were never attached. Only the
+//! runner attaches volume disks (`spec_map::workload_blocks`), so only the
+//! runner appends the token, via `runner_cmdline` below.
 
 use std::path::{Path, PathBuf};
 
@@ -129,6 +137,35 @@ pub(crate) fn workload_cmdline(config: &VmStartConfig, state_dir: &Path) -> Opti
     Some(cmdline)
 }
 
+/// The runner's full cmdline: the shared `workload_cmdline` base plus, only
+/// on this path, the `mvm.uvols=` user-volume token (see the module doc for
+/// why it can't live inside `workload_cmdline` itself).
+///
+/// `workload_cmdline` returns `None` as a shortcut meaning "no extra tokens
+/// needed — let the driver apply its own built-in default base cmdline". A
+/// volume token can't ride on that shortcut (an empty `VmmSpec.cmdline` means
+/// "ignore this string entirely"), so when a volume is present and the
+/// shortcut would otherwise apply, this synthesizes the same base bootargs
+/// `workload_cmdline`'s non-shortcut branch would have produced and appends
+/// the token to that instead of to nothing.
+pub(crate) fn runner_cmdline(config: &VmStartConfig, state_dir: &Path) -> String {
+    let base = workload_cmdline(config, state_dir);
+    let Some(uvols) = mvm_core::vm_backend::encode_user_volumes_cmdline(&config.volumes) else {
+        return base.unwrap_or_default();
+    };
+    match base {
+        Some(base) => format!("{base} {uvols}"),
+        None => {
+            let virtiofs_root = config.virtiofs_root.is_some();
+            let has_disk = !virtiofs_root && !config.rootfs_path.is_empty();
+            format!(
+                "{} {uvols}",
+                crate::hvf_bootargs::workload_bootargs(virtiofs_root, has_disk)
+            )
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -235,5 +272,76 @@ mod tests {
         assert!(cmdline.contains("mvm.runtime_data=/dev/vdc"));
         assert!(cmdline.contains("mvm.runtime_hash=/dev/vdd"));
         assert!(cmdline.contains("mvm.runtime_source_policy=required_overlay"));
+    }
+
+    fn disk_volume(host: &str, guest: &str) -> mvm_core::vm_backend::VmVolume {
+        mvm_core::vm_backend::VmVolume {
+            host: host.into(),
+            guest: guest.into(),
+            size: String::new(),
+            read_only: true,
+            kind: mvm_core::vm_backend::VmVolumeKind::Disk,
+            encrypted: false,
+        }
+    }
+
+    #[test]
+    fn runner_cmdline_matches_workload_cmdline_when_no_volumes_are_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = VmStartConfig::default();
+        assert_eq!(
+            runner_cmdline(&config, dir.path()),
+            workload_cmdline(&config, dir.path()).unwrap_or_default()
+        );
+    }
+
+    #[test]
+    fn runner_cmdline_appends_uvols_to_a_non_trivial_base() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = VmStartConfig {
+            network_policy: mvm_core::network_policy::NetworkPolicy::preset(
+                mvm_core::network_policy::NetworkPreset::Dev,
+            ),
+            volumes: vec![disk_volume("/vol/data.img", "/data")],
+            ..Default::default()
+        };
+        // The egress token forces workload_cmdline's non-shortcut branch, so
+        // this exercises the `Some(base)` arm of runner_cmdline's match.
+        let base = workload_cmdline(&config, dir.path()).expect("non-trivial base");
+        let cmdline = runner_cmdline(&config, dir.path());
+        assert!(cmdline.starts_with(&base));
+        assert!(
+            cmdline.contains("mvm.uvols=uvol0:"),
+            "cmdline missing uvols token: {cmdline}"
+        );
+    }
+
+    #[test]
+    fn runner_cmdline_synthesizes_a_base_when_workload_cmdline_takes_the_shortcut() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = VmStartConfig {
+            rootfs_path: "/img/rootfs.ext4".into(),
+            volumes: vec![disk_volume("/vol/data.img", "/data")],
+            ..Default::default()
+        };
+        // Deny-all + RootfsOnly + no verity/tunnel/grants: workload_cmdline
+        // alone would return None here (the "let the driver default apply"
+        // shortcut), so runner_cmdline must not silently drop the base
+        // bootargs the volume token needs to ride on.
+        assert_eq!(workload_cmdline(&config, dir.path()), None);
+        let cmdline = runner_cmdline(&config, dir.path());
+        assert!(cmdline.contains("root=/dev/vda"), "cmdline: {cmdline}");
+        assert!(cmdline.contains("init=/init"), "cmdline: {cmdline}");
+        assert!(
+            cmdline.contains("mvm.uvols=uvol0:"),
+            "cmdline missing uvols token: {cmdline}"
+        );
+    }
+
+    #[test]
+    fn runner_cmdline_is_empty_when_neither_base_nor_volumes_are_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = VmStartConfig::default();
+        assert_eq!(runner_cmdline(&config, dir.path()), String::new());
     }
 }

--- a/crates/mvm-runtime/src/workload_runner/mod.rs
+++ b/crates/mvm-runtime/src/workload_runner/mod.rs
@@ -13,5 +13,6 @@ pub use runner::{
     RealBrokerRegistrar, RealEndpointSpawner, WorkloadLaunchInputs, WorkloadRunner,
 };
 pub use spec_map::{
-    WorkloadSockets, WorkloadSpecInputs, workload_blocks, workload_spec, workload_vsock_ports,
+    WorkloadSockets, WorkloadSpecInputs, ensure_no_dir_share_volumes, workload_blocks,
+    workload_spec, workload_vsock_ports,
 };

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -32,7 +32,8 @@ use crate::substitution_spawn::{
 use crate::workload_backend::{EgressSubstitutionTransport, WorkloadBackend};
 use crate::workload_runner::cmdline;
 use crate::workload_runner::spec_map::{
-    WorkloadSockets, WorkloadSpecInputs, console_data_sockets, network_tunnel_socket, workload_spec,
+    WorkloadSockets, WorkloadSpecInputs, console_data_sockets, ensure_no_dir_share_volumes,
+    network_tunnel_socket, workload_spec,
 };
 
 /// What the workload runner needs to stand up the per-VM gating endpoint.
@@ -243,6 +244,12 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
     /// ALWAYS spawned — it is the sole egress gate now, even for the no-secret
     /// raw path.
     pub fn start_workload(&self, inputs: &WorkloadLaunchInputs<'_>) -> Result<Box<dyn RunningVm>> {
+        // Fail closed before any side effect (endpoint/tunnel spawn) runs: a
+        // `DirShare` volume has no `VmmSpec` representation on this driver
+        // seam, so refuse it here rather than silently dropping it later in
+        // `workload_blocks`.
+        ensure_no_dir_share_volumes(inputs.config)?;
+
         let state_dir = vm_state_dir(&inputs.config.name);
         std::fs::create_dir_all(&state_dir)
             .with_context(|| format!("create state dir {}", state_dir.display()))?;
@@ -368,7 +375,7 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 
             secrets,
             redaction,
             network_policy: &config.network_policy,
-            cmdline: cmdline::workload_cmdline(config, &state_dir).unwrap_or_default(),
+            cmdline: cmdline::runner_cmdline(config, &state_dir),
         };
         // The supervisor + endpoint are detached/disk-backed; the live handle is
         // reconstructed by id via `attach`, so the boot handle is dropped here.
@@ -936,6 +943,134 @@ mod tests {
                 "booted cmdline missing {needle:?}: {cmdline}"
             );
         }
+    }
+
+    fn disk_volume(host: &str, guest: &str, read_only: bool) -> mvm_core::vm_backend::VmVolume {
+        mvm_core::vm_backend::VmVolume {
+            host: host.into(),
+            guest: guest.into(),
+            size: String::new(),
+            read_only,
+            kind: mvm_core::vm_backend::VmVolumeKind::Disk,
+            encrypted: false,
+        }
+    }
+
+    fn dir_share_volume(host: &str, guest: &str) -> mvm_core::vm_backend::VmVolume {
+        mvm_core::vm_backend::VmVolume {
+            host: host.into(),
+            guest: guest.into(),
+            size: String::new(),
+            read_only: false,
+            kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
+            encrypted: false,
+        }
+    }
+
+    /// A `--volume` disk (claim 11's sealed app-dep disk, or any other
+    /// `Disk`-kind volume) must reach a runner-booted guest both as an
+    /// attached `BlockDev` and as an `mvm.uvols=` cmdline entry naming it —
+    /// otherwise the guest has the bytes on `/dev/vdb` but no manifest saying
+    /// what they are for.
+    #[test]
+    fn start_carries_a_disk_volume_into_both_blocks_and_the_uvols_token() {
+        let runner = WorkloadRunner::new(
+            MockDriver::default(),
+            RecordingSpawner::new("/run/ep.sock"),
+            RecordingBrokerRegistrar::new(),
+        );
+
+        let cfg = VmStartConfig {
+            volumes: vec![disk_volume("/vol/data.img", "/data", true)],
+            ..config("w-uvol")
+        };
+        runner.start(&cfg).expect("start succeeds");
+
+        let specs = runner.driver.booted_specs();
+        assert_eq!(specs.len(), 1);
+        let spec = &specs[0];
+
+        // The rootfs takes /dev/vda; the volume disk lands right after it.
+        assert_eq!(
+            spec.blocks
+                .iter()
+                .map(|b| b.device_node())
+                .collect::<Vec<_>>(),
+            vec!["/dev/vda", "/dev/vdb"]
+        );
+        assert_eq!(spec.blocks[1].source, PathBuf::from("/vol/data.img"));
+        assert!(spec.blocks[1].read_only);
+
+        assert!(
+            spec.cmdline.contains("mvm.uvols=uvol0:"),
+            "booted cmdline missing the uvols token: {}",
+            spec.cmdline
+        );
+    }
+
+    #[test]
+    fn start_emits_no_uvols_token_when_there_are_no_volumes() {
+        let runner = WorkloadRunner::new(
+            MockDriver::default(),
+            RecordingSpawner::new("/run/ep.sock"),
+            RecordingBrokerRegistrar::new(),
+        );
+
+        runner.start(&config("w-no-uvol")).expect("start succeeds");
+
+        let specs = runner.driver.booted_specs();
+        assert!(
+            !specs[0].cmdline.contains("mvm.uvols="),
+            "cmdline must carry no uvols token with no volumes: {}",
+            specs[0].cmdline
+        );
+    }
+
+    /// A `DirShare` volume has no `VmmSpec` representation on this driver
+    /// seam. `start_workload` must refuse it before spawning the gating
+    /// endpoint or the broker — never boot a VM missing a share the caller
+    /// asked for.
+    #[test]
+    fn start_workload_refuses_a_dir_share_volume_before_any_side_effect() {
+        let policy = NetworkPolicy::deny_all();
+        let redaction = RedactionPolicy::default();
+        let runner = WorkloadRunner::new(
+            MockDriver::default(),
+            RecordingSpawner::new("/run/ep.sock"),
+            RecordingBrokerRegistrar::new(),
+        );
+
+        let cfg = VmStartConfig {
+            volumes: vec![dir_share_volume("/host/dir", "/mnt/share")],
+            ..config("w-dirshare-refused")
+        };
+        let result = runner.start_workload(&WorkloadLaunchInputs {
+            config: &cfg,
+            tenant: "tenant-x",
+            secrets: &[],
+            redaction: &redaction,
+            network_policy: &policy,
+            cmdline: String::new(),
+        });
+        let message = match result {
+            Ok(_) => panic!("a DirShare volume must be refused"),
+            Err(e) => e.to_string(),
+        };
+        assert!(message.contains("/host/dir"), "message: {message}");
+        assert!(message.contains("/mnt/share"), "message: {message}");
+
+        assert!(
+            runner.driver.booted_specs().is_empty(),
+            "refused start must never reach the driver"
+        );
+        assert!(
+            runner.spawner.seen.lock().unwrap().is_none(),
+            "refused start must never spawn the gating endpoint"
+        );
+        assert!(
+            runner.broker.seen.lock().unwrap().is_none(),
+            "refused start must never register the broker"
+        );
     }
 
     #[test]

--- a/crates/mvm-runtime/src/workload_runner/spec_map.rs
+++ b/crates/mvm-runtime/src/workload_runner/spec_map.rs
@@ -4,11 +4,12 @@
 
 use std::path::{Path, PathBuf};
 
+use anyhow::{Result, bail};
 use mvm_agentd::vsock::{
     BROKER_PORT, EGRESS_PORT, GUEST_AGENT_PORT, WORKLOAD_EXIT_PORT, dev_console_data_ports,
 };
 use mvm_core::config::{vm_hvf_vsock_port_socket_at, vm_vsock_port_socket_at};
-use mvm_core::vm_backend::VmStartConfig;
+use mvm_core::vm_backend::{VmStartConfig, VmVolumeKind};
 
 use crate::driver::{BlockDev, ConsoleCapture, KernelImage, VmmSpec, VsockDirection, VsockPort};
 
@@ -16,16 +17,26 @@ use crate::driver::{BlockDev, ConsoleCapture, KernelImage, VmmSpec, VsockDirecti
 /// `/dev/vda` (slot 0), its dm-verity Merkle sidecar at `/dev/vdb` (slot 1) when
 /// the image was built with verified boot, and — only when the full runtime
 /// overlay triple (image + verity sidecar + roothash) is present — the overlay
-/// at `/dev/vdc` (slot 2) and its verity sidecar at `/dev/vdd` (slot 3).
+/// at `/dev/vdc` (slot 2) and its verity sidecar at `/dev/vdd` (slot 3). After
+/// those, every `Disk`-kind entry in `config.volumes` (a sealed app-dep volume
+/// or other `--volume` disk image) lands at the next free slot, in `volumes`
+/// order — the same order `encode_user_volumes_cmdline` walks to number its
+/// `uvol{idx}` tokens, so the Nth appended volume block matches the Nth
+/// `mvm.uvols=` entry. A `DirShare` volume has no block-device representation
+/// and is skipped here; callers must refuse it before reaching this function
+/// (see `ensure_no_dir_share_volumes`) rather than relying on this silent skip.
 ///
-/// Every device is read-only: a workload rootfs is sealed, and the verity
-/// sidecars are integrity data the guest only reads. The all-three-or-none
-/// overlay rule mirrors `VmStartConfig`'s own contract — a partial overlay set
-/// is treated as no overlay rather than a half-configured boot.
+/// The rootfs/verity/overlay devices are read-only: a workload rootfs is
+/// sealed, and the verity sidecars are integrity data the guest only reads.
+/// The all-three-or-none overlay rule mirrors `VmStartConfig`'s own contract —
+/// a partial overlay set is treated as no overlay rather than a
+/// half-configured boot. A volume's `read_only` flag is the caller's own
+/// choice, carried through verbatim.
 ///
 /// An empty `rootfs_path` yields no disks at all — an initramfs-only guest boots
-/// entirely from RAM (matching `HvfBackend`'s own empty-path skip). The verity
-/// and overlay disks presuppose a rootfs, so they are dropped with it.
+/// entirely from RAM (matching `HvfBackend`'s own empty-path skip). The verity,
+/// overlay, and user-volume disks all presuppose a rootfs, so they are dropped
+/// with it.
 pub fn workload_blocks(config: &VmStartConfig) -> Vec<BlockDev> {
     let ro = |source: &str, slot: u8| BlockDev {
         source: source.into(),
@@ -54,7 +65,49 @@ pub fn workload_blocks(config: &VmStartConfig) -> Vec<BlockDev> {
         blocks.push(ro(overlay_verity, 3));
     }
 
+    for volume in config
+        .volumes
+        .iter()
+        .filter(|v| matches!(v.kind, VmVolumeKind::Disk))
+    {
+        let slot = blocks.len() as u8;
+        blocks.push(BlockDev {
+            source: volume.host.clone().into(),
+            read_only: volume.read_only,
+            // A sealed app-dep / user-supplied disk persists to the host file
+            // like the rootfs — never RAM-backed, so a writable volume's
+            // mutations actually land on disk instead of vanishing on exit.
+            ephemeral: false,
+            slot,
+        });
+    }
+
     blocks
+}
+
+/// Refuse a `DirShare` volume before a `VmmSpec` is assembled: the runner's
+/// `VmmSpec` has no virtio-fs device, so a directory share can't be expressed
+/// on this path (unlike a `Disk` volume, which becomes a `BlockDev`). Fails
+/// closed with the offending volume named, rather than letting
+/// `workload_blocks` silently drop it. `VmmSpec.shares` (virtio-fs) is a
+/// deferred follow-up; the dev-tier `virtiofs_root` flat share is a separate,
+/// unrelated field and out of scope here.
+pub fn ensure_no_dir_share_volumes(config: &VmStartConfig) -> Result<()> {
+    if let Some(v) = config
+        .volumes
+        .iter()
+        .find(|v| matches!(v.kind, VmVolumeKind::DirShare))
+    {
+        bail!(
+            "directory-share volume '{}' -> '{}' cannot be attached: the WorkloadRunner has no \
+             virtio-fs device yet, so a live host-directory share can't be expressed. Use a \
+             disk-image volume instead (host:/guest:SIZE), or run this workload on a backend \
+             with virtio-fs support.",
+            v.host,
+            v.guest
+        );
+    }
+    Ok(())
 }
 
 /// The host-side unix sockets a workload's standing vsock channels bind to.
@@ -277,6 +330,124 @@ mod tests {
             ..base()
         };
         assert_eq!(nodes(&workload_blocks(&cfg)), vec!["/dev/vda"]);
+    }
+
+    fn disk_volume(host: &str, guest: &str, read_only: bool) -> mvm_core::vm_backend::VmVolume {
+        mvm_core::vm_backend::VmVolume {
+            host: host.into(),
+            guest: guest.into(),
+            size: String::new(),
+            read_only,
+            kind: VmVolumeKind::Disk,
+            encrypted: false,
+        }
+    }
+
+    fn dir_share_volume(host: &str, guest: &str) -> mvm_core::vm_backend::VmVolume {
+        mvm_core::vm_backend::VmVolume {
+            host: host.into(),
+            guest: guest.into(),
+            size: String::new(),
+            read_only: false,
+            kind: VmVolumeKind::DirShare,
+            encrypted: false,
+        }
+    }
+
+    #[test]
+    fn a_disk_volume_lands_at_slot_4_after_the_full_base_stack() {
+        let cfg = VmStartConfig {
+            verity_path: Some("/img/rootfs.verity".into()),
+            runtime_overlay_path: Some("/img/overlay.ext4".into()),
+            runtime_overlay_verity_path: Some("/img/overlay.verity".into()),
+            runtime_overlay_roothash: Some("ab".repeat(32)),
+            volumes: vec![disk_volume("/vol/data.img", "/data", true)],
+            ..base()
+        };
+        let blocks = workload_blocks(&cfg);
+        assert_eq!(
+            nodes(&blocks),
+            vec!["/dev/vda", "/dev/vdb", "/dev/vdc", "/dev/vdd", "/dev/vde"]
+        );
+        let vol_block = &blocks[4];
+        assert_eq!(vol_block.source, PathBuf::from("/vol/data.img"));
+        assert!(vol_block.read_only);
+        assert!(!vol_block.ephemeral);
+    }
+
+    #[test]
+    fn two_disk_volumes_preserve_order_at_slots_4_and_5() {
+        let cfg = VmStartConfig {
+            verity_path: Some("/img/rootfs.verity".into()),
+            runtime_overlay_path: Some("/img/overlay.ext4".into()),
+            runtime_overlay_verity_path: Some("/img/overlay.verity".into()),
+            runtime_overlay_roothash: Some("ab".repeat(32)),
+            volumes: vec![
+                disk_volume("/vol/first.img", "/first", true),
+                disk_volume("/vol/second.img", "/second", false),
+            ],
+            ..base()
+        };
+        let blocks = workload_blocks(&cfg);
+        assert_eq!(
+            nodes(&blocks),
+            vec![
+                "/dev/vda", "/dev/vdb", "/dev/vdc", "/dev/vdd", "/dev/vde", "/dev/vdf"
+            ]
+        );
+        assert_eq!(blocks[4].source, PathBuf::from("/vol/first.img"));
+        assert!(blocks[4].read_only);
+        assert_eq!(blocks[5].source, PathBuf::from("/vol/second.img"));
+        assert!(!blocks[5].read_only);
+    }
+
+    #[test]
+    fn a_disk_volume_with_no_verity_or_overlay_lands_right_after_the_rootfs() {
+        let cfg = VmStartConfig {
+            volumes: vec![disk_volume("/vol/data.img", "/data", false)],
+            ..base()
+        };
+        let blocks = workload_blocks(&cfg);
+        assert_eq!(nodes(&blocks), vec!["/dev/vda", "/dev/vdb"]);
+        assert_eq!(blocks[1].source, PathBuf::from("/vol/data.img"));
+    }
+
+    #[test]
+    fn a_dir_share_volume_is_skipped_by_workload_blocks() {
+        // workload_blocks itself has no Result to refuse through; the fail-closed
+        // guard lives in `ensure_no_dir_share_volumes`, which callers must run
+        // first. This only proves the low-level mapper never fabricates a bogus
+        // block device for a share it can't express.
+        let cfg = VmStartConfig {
+            volumes: vec![dir_share_volume("/host/dir", "/mnt")],
+            ..base()
+        };
+        assert_eq!(nodes(&workload_blocks(&cfg)), vec!["/dev/vda"]);
+    }
+
+    #[test]
+    fn ensure_no_dir_share_volumes_accepts_disk_only_configs() {
+        let cfg = VmStartConfig {
+            volumes: vec![disk_volume("/vol/data.img", "/data", true)],
+            ..base()
+        };
+        assert!(ensure_no_dir_share_volumes(&cfg).is_ok());
+    }
+
+    #[test]
+    fn ensure_no_dir_share_volumes_refuses_and_names_the_volume() {
+        let cfg = VmStartConfig {
+            volumes: vec![
+                disk_volume("/vol/data.img", "/data", true),
+                dir_share_volume("/host/dir", "/mnt/share"),
+            ],
+            ..base()
+        };
+        let err = ensure_no_dir_share_volumes(&cfg)
+            .expect_err("a DirShare volume must be refused, not silently dropped");
+        let message = err.to_string();
+        assert!(message.contains("/host/dir"), "message: {message}");
+        assert!(message.contains("/mnt/share"), "message: {message}");
     }
 
     #[test]


### PR DESCRIPTION
Final enrichment PR: `WorkloadRunner` now carries `--volume` disk images (claim 11's sealed app-dep disks) + the `mvm.uvols=` token to a runner-booted guest. Claim 11 is enforced at admission (`verify_sealed_volume`, host-side, pre-boot — unchanged); this brings the runner to **parity** with the raw backends on the guest-delivery side.

- `workload_blocks` appends each `Disk`-kind volume as a read-only `BlockDev` after the rootfs/verity/overlay slots, order-preserving.
- `mvm.uvols=` is emitted from a runner-only `runner_cmdline` (appended after the shared `workload_cmdline`), **not** the shared assembler — verified that raw `HvfBackend` calls the same assembler but never attaches `config.volumes`, so a shared-assembler token would dangle. `runner_cmdline` also handles the empty-cmdline-means-driver-default shortcut so appending the token never clobbers the driver's base boot args.
- `DirShare` volumes have no `VmmSpec` (virtio-fs) representation, so they're **refused fail-closed** (mirroring libkrun's RO-refusal), checked in `start_workload` before any endpoint/tunnel/broker spawn — never silently dropped. `VmmSpec.shares` is a tracked follow-up.

Also traced: neither guest init (`mvm-host-vm-init`, `mvm-oci-init`) auto-mounts `Disk` `mvm.uvols=` entries yet on any backend — so there's no order-vs-tag correlation to preserve today; `BlockDev` kept tag-free, flagged for when auto-mount lands.

Verified: `nextest -p mvm-runtime` 918 passed, clippy `-D warnings`, `x86_64-unknown-linux-gnu` cross-build, `check-vsock-only-egress` / `check-no-spec-refs-in-comments`. Completes the runner enrichment (cmdline + broker + volumes) — the drivers can now move backends onto the seam without dropping a claim.