### PR TITLE
feat(cli): mvmctl build address + workload semantic-identity conformance lock + BDD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,7 @@ version = "0.18.0"
 dependencies = [
  "assert_cmd",
  "cucumber",
+ "serde_json",
  "tokio",
 ]
 

--- a/crates/mvm-cli/src/commands/build/address.rs
+++ b/crates/mvm-cli/src/commands/build/address.rs
@@ -8,7 +8,6 @@
 //! asserting they line up makes this verb a conformance check on the two
 //! canonical-form realizations, not just a printer.
 
-use std::io::Read;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
@@ -20,6 +19,7 @@ use mvm_core::user_config::MvmConfig;
 use mvm_protocol::ir::{Workload, ir_hash};
 
 use super::Cli;
+use super::ir_input::load_ir_json_workload;
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
@@ -37,12 +37,6 @@ pub(in crate::commands) struct Args {
     pub json: bool,
 }
 
-/// Where the IR JSON is read from.
-enum Source {
-    Path(PathBuf),
-    Stdin,
-}
-
 /// The two content identities of a workload, already self-checked to agree.
 #[derive(Debug)]
 struct Identities {
@@ -57,52 +51,10 @@ struct AddressReport {
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
-    let workload = load_workload(&args)?;
+    let workload = load_ir_json_workload(args.from_ir.as_deref(), args.entry.as_deref())?;
     let identities = compute_identities(&workload)?;
-    print!("{}", render(&identities, args.json));
+    print!("{}", render(&identities, args.json)?);
     Ok(())
-}
-
-fn load_workload(args: &Args) -> Result<Workload> {
-    let (bytes, label) = read_source(resolve_source(args)?)?;
-    parse_workload(&bytes, &label)
-}
-
-fn resolve_source(args: &Args) -> Result<Source> {
-    if let Some(path) = &args.from_ir {
-        if args.entry.as_deref().is_some_and(|s| !s.is_empty()) {
-            bail!(
-                "--from-ir and the positional entry are mutually exclusive — pass one or the other."
-            );
-        }
-        return Ok(Source::Path(path.clone()));
-    }
-    match args.entry.as_deref() {
-        None => bail!("missing entry: pass an IR JSON path, `-` for stdin, or `--from-ir <path>`."),
-        Some("-") => Ok(Source::Stdin),
-        Some(s) => Ok(Source::Path(PathBuf::from(s))),
-    }
-}
-
-fn read_source(source: Source) -> Result<(Vec<u8>, String)> {
-    match source {
-        Source::Path(path) => {
-            let bytes = std::fs::read(&path)
-                .with_context(|| format!("reading IR JSON from {}", path.display()))?;
-            Ok((bytes, path.display().to_string()))
-        }
-        Source::Stdin => {
-            let mut buf = Vec::new();
-            std::io::stdin()
-                .read_to_end(&mut buf)
-                .context("reading IR JSON from stdin")?;
-            Ok((buf, "stdin".to_string()))
-        }
-    }
-}
-
-fn parse_workload(bytes: &[u8], label: &str) -> Result<Workload> {
-    serde_json::from_slice(bytes).with_context(|| format!("parsing IR JSON from {label}"))
 }
 
 /// Compute both identities and prove they agree. The agreement is what makes
@@ -122,20 +74,20 @@ fn compute_identities(workload: &Workload) -> Result<Identities> {
     })
 }
 
-fn render(identities: &Identities, json: bool) -> String {
+fn render(identities: &Identities, json: bool) -> Result<String> {
     if json {
         let report = AddressReport {
             semantic_address: identities.semantic_address.clone(),
             ir_hash: identities.ir_hash.clone(),
         };
-        let mut out = serde_json::to_string(&report).expect("AddressReport serializes");
+        let mut out = serde_json::to_string(&report).context("serializing address report")?;
         out.push('\n');
-        out
+        Ok(out)
     } else {
-        format!(
+        Ok(format!(
             "semantic-address: {}\nir-hash: {}\n",
             identities.semantic_address, identities.ir_hash
-        )
+        ))
     }
 }
 
@@ -193,8 +145,10 @@ mod tests {
         let pretty = serde_json::to_vec_pretty(&value).unwrap();
         assert_ne!(compact, pretty, "the two encodings must differ in bytes");
 
-        let a = compute_identities(&parse_workload(&compact, "compact").unwrap()).unwrap();
-        let b = compute_identities(&parse_workload(&pretty, "pretty").unwrap()).unwrap();
+        let from_compact: Workload = serde_json::from_slice(&compact).unwrap();
+        let from_pretty: Workload = serde_json::from_slice(&pretty).unwrap();
+        let a = compute_identities(&from_compact).unwrap();
+        let b = compute_identities(&from_pretty).unwrap();
         assert_eq!(a.semantic_address, b.semantic_address);
     }
 
@@ -229,15 +183,9 @@ mod tests {
     }
 
     #[test]
-    fn malformed_json_is_rejected() {
-        let err = parse_workload(b"{ not json", "fixture").unwrap_err();
-        assert!(err.to_string().contains("parsing IR JSON"));
-    }
-
-    #[test]
     fn human_render_is_two_stable_lines() {
         let ids = compute_identities(&sample_workload()).unwrap();
-        let out = render(&ids, false);
+        let out = render(&ids, false).unwrap();
         let lines: Vec<&str> = out.lines().collect();
         assert_eq!(lines.len(), 2);
         assert_eq!(
@@ -250,29 +198,9 @@ mod tests {
     #[test]
     fn json_render_carries_both_identities() {
         let ids = compute_identities(&sample_workload()).unwrap();
-        let out = render(&ids, true);
+        let out = render(&ids, true).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
         assert_eq!(parsed["semantic_address"], ids.semantic_address);
         assert_eq!(parsed["ir_hash"], ids.ir_hash);
-    }
-
-    #[test]
-    fn resolve_source_rejects_conflicting_inputs() {
-        let args = Args {
-            entry: Some("a.json".to_string()),
-            from_ir: Some(PathBuf::from("b.json")),
-            json: false,
-        };
-        assert!(resolve_source(&args).is_err());
-    }
-
-    #[test]
-    fn resolve_source_requires_an_input() {
-        let args = Args {
-            entry: None,
-            from_ir: None,
-            json: false,
-        };
-        assert!(resolve_source(&args).is_err());
     }
 }

--- a/crates/mvm-cli/src/commands/build/address.rs
+++ b/crates/mvm-cli/src/commands/build/address.rs
@@ -1,0 +1,278 @@
+//! `mvmctl build address` — print a Workload IR's semantic identities.
+//!
+//! Reads a Workload IR JSON (the cross-language interop shape the SDKs emit)
+//! and prints its content identity: the `sha256(JCS(ir))` semantic address and
+//! the matching `ir_hash`. Two IR documents that mean the same thing hash the
+//! same regardless of key order or whitespace, so this is the boundary where a
+//! host and an SDK can agree on a workload's identity. Computing both and
+//! asserting they line up makes this verb a conformance check on the two
+//! canonical-form realizations, not just a printer.
+
+use std::io::Read;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use clap::Args as ClapArgs;
+use serde::Serialize;
+
+use mvm_core::semantic_address::semantic_address;
+use mvm_core::user_config::MvmConfig;
+use mvm_protocol::ir::{Workload, ir_hash};
+
+use super::Cli;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// IR JSON path, or `-` for stdin. Omit to use `--from-ir`.
+    #[arg(value_name = "ENTRY")]
+    pub entry: Option<String>,
+
+    /// Read the Workload IR from this JSON file (alternative to the
+    /// positional entry).
+    #[arg(long = "from-ir", value_name = "PATH")]
+    pub from_ir: Option<PathBuf>,
+
+    /// Emit JSON instead of the human-readable lines.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Where the IR JSON is read from.
+enum Source {
+    Path(PathBuf),
+    Stdin,
+}
+
+/// The two content identities of a workload, already self-checked to agree.
+#[derive(Debug)]
+struct Identities {
+    semantic_address: String,
+    ir_hash: String,
+}
+
+#[derive(Serialize)]
+struct AddressReport {
+    semantic_address: String,
+    ir_hash: String,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    let workload = load_workload(&args)?;
+    let identities = compute_identities(&workload)?;
+    print!("{}", render(&identities, args.json));
+    Ok(())
+}
+
+fn load_workload(args: &Args) -> Result<Workload> {
+    let (bytes, label) = read_source(resolve_source(args)?)?;
+    parse_workload(&bytes, &label)
+}
+
+fn resolve_source(args: &Args) -> Result<Source> {
+    if let Some(path) = &args.from_ir {
+        if args.entry.as_deref().is_some_and(|s| !s.is_empty()) {
+            bail!(
+                "--from-ir and the positional entry are mutually exclusive — pass one or the other."
+            );
+        }
+        return Ok(Source::Path(path.clone()));
+    }
+    match args.entry.as_deref() {
+        None => bail!("missing entry: pass an IR JSON path, `-` for stdin, or `--from-ir <path>`."),
+        Some("-") => Ok(Source::Stdin),
+        Some(s) => Ok(Source::Path(PathBuf::from(s))),
+    }
+}
+
+fn read_source(source: Source) -> Result<(Vec<u8>, String)> {
+    match source {
+        Source::Path(path) => {
+            let bytes = std::fs::read(&path)
+                .with_context(|| format!("reading IR JSON from {}", path.display()))?;
+            Ok((bytes, path.display().to_string()))
+        }
+        Source::Stdin => {
+            let mut buf = Vec::new();
+            std::io::stdin()
+                .read_to_end(&mut buf)
+                .context("reading IR JSON from stdin")?;
+            Ok((buf, "stdin".to_string()))
+        }
+    }
+}
+
+fn parse_workload(bytes: &[u8], label: &str) -> Result<Workload> {
+    serde_json::from_slice(bytes).with_context(|| format!("parsing IR JSON from {label}"))
+}
+
+/// Compute both identities and prove they agree. The agreement is what makes
+/// the semantic address and the `ir_hash` interchangeable identifiers for the
+/// same workload; a mismatch means the two canonical-form realizations drifted,
+/// so fail loud rather than print two identities that disagree.
+fn compute_identities(workload: &Workload) -> Result<Identities> {
+    let addr = semantic_address(workload).context("computing semantic address")?;
+    let ih = ir_hash(workload).context("computing ir_hash")?;
+    let addr = addr.as_str().to_string();
+    if addr.strip_prefix("sha256:") != Some(ih.as_str()) {
+        bail!("semantic address {addr} does not match ir_hash {ih} — canonicalizer drift");
+    }
+    Ok(Identities {
+        semantic_address: addr,
+        ir_hash: ih,
+    })
+}
+
+fn render(identities: &Identities, json: bool) -> String {
+    if json {
+        let report = AddressReport {
+            semantic_address: identities.semantic_address.clone(),
+            ir_hash: identities.ir_hash.clone(),
+        };
+        let mut out = serde_json::to_string(&report).expect("AddressReport serializes");
+        out.push('\n');
+        out
+    } else {
+        format!(
+            "semantic-address: {}\nir-hash: {}\n",
+            identities.semantic_address, identities.ir_hash
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_protocol::ir::{App, Entrypoint, Image, Resources, Source as IrSource};
+
+    fn sample_workload() -> Workload {
+        Workload {
+            schema_version: "0.1".to_string(),
+            id: "hello".to_string(),
+            apps: vec![App {
+                name: "hello".to_string(),
+                source: IrSource::LocalPath {
+                    path: ".".to_string(),
+                    include: vec!["**".to_string()],
+                    exclude: vec![],
+                },
+                image: Image::NixPackages {
+                    packages: vec!["python312".to_string()],
+                },
+                entrypoints: vec![Entrypoint::Command {
+                    command: vec!["python".to_string(), "-m".to_string(), "hello".to_string()],
+                    working_dir: "/app".to_string(),
+                    env: Default::default(),
+                }],
+                env: Default::default(),
+                mounts: vec![],
+                network: None,
+                resources: Resources {
+                    cpu_cores: 1,
+                    memory_mb: 256,
+                    rootfs_size_mb: 512,
+                },
+                dependencies: None,
+                threat_tier: Default::default(),
+                addons: vec![],
+                hooks: Default::default(),
+                files: vec![],
+                health_check: None,
+            }],
+            volumes: vec![],
+            extensions: Default::default(),
+        }
+    }
+
+    #[test]
+    fn reordered_keys_produce_equal_address() {
+        let w = sample_workload();
+        let compact = serde_json::to_vec(&w).unwrap();
+        // Round-trip through a Value and pretty-print to force a different byte
+        // encoding (whitespace + serde_json::Map re-ordering) of the same IR.
+        let value: serde_json::Value = serde_json::from_slice(&compact).unwrap();
+        let pretty = serde_json::to_vec_pretty(&value).unwrap();
+        assert_ne!(compact, pretty, "the two encodings must differ in bytes");
+
+        let a = compute_identities(&parse_workload(&compact, "compact").unwrap()).unwrap();
+        let b = compute_identities(&parse_workload(&pretty, "pretty").unwrap()).unwrap();
+        assert_eq!(a.semantic_address, b.semantic_address);
+    }
+
+    #[test]
+    fn different_meaning_produces_different_address() {
+        let a = sample_workload();
+        let mut b = sample_workload();
+        b.id = "goodbye".to_string();
+        let ia = compute_identities(&a).unwrap();
+        let ib = compute_identities(&b).unwrap();
+        assert_ne!(ia.semantic_address, ib.semantic_address);
+    }
+
+    #[test]
+    fn identities_self_check_agrees() {
+        let ids = compute_identities(&sample_workload()).unwrap();
+        assert_eq!(
+            ids.semantic_address.strip_prefix("sha256:"),
+            Some(ids.ir_hash.as_str())
+        );
+    }
+
+    #[test]
+    fn unknown_schema_fails_closed() {
+        let mut w = sample_workload();
+        w.schema_version = "1.0".to_string();
+        let err = compute_identities(&w).unwrap_err();
+        assert!(
+            err.chain().any(|e| e.to_string().contains("schema")),
+            "error chain should mention the schema: {err:#}"
+        );
+    }
+
+    #[test]
+    fn malformed_json_is_rejected() {
+        let err = parse_workload(b"{ not json", "fixture").unwrap_err();
+        assert!(err.to_string().contains("parsing IR JSON"));
+    }
+
+    #[test]
+    fn human_render_is_two_stable_lines() {
+        let ids = compute_identities(&sample_workload()).unwrap();
+        let out = render(&ids, false);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(
+            lines[0],
+            format!("semantic-address: {}", ids.semantic_address)
+        );
+        assert_eq!(lines[1], format!("ir-hash: {}", ids.ir_hash));
+    }
+
+    #[test]
+    fn json_render_carries_both_identities() {
+        let ids = compute_identities(&sample_workload()).unwrap();
+        let out = render(&ids, true);
+        let parsed: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+        assert_eq!(parsed["semantic_address"], ids.semantic_address);
+        assert_eq!(parsed["ir_hash"], ids.ir_hash);
+    }
+
+    #[test]
+    fn resolve_source_rejects_conflicting_inputs() {
+        let args = Args {
+            entry: Some("a.json".to_string()),
+            from_ir: Some(PathBuf::from("b.json")),
+            json: false,
+        };
+        assert!(resolve_source(&args).is_err());
+    }
+
+    #[test]
+    fn resolve_source_requires_an_input() {
+        let args = Args {
+            entry: None,
+            from_ir: None,
+            json: false,
+        };
+        assert!(resolve_source(&args).is_err());
+    }
+}

--- a/crates/mvm-cli/src/commands/build/compile.rs
+++ b/crates/mvm-cli/src/commands/build/compile.rs
@@ -27,7 +27,6 @@
 //!   (use `mvmctl run` for the live transport).
 //! - `MVM_SDK_MODE` — env-var override that supersedes flags.
 
-use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -39,6 +38,7 @@ use mvm_sdk::compile::{compile, compile_archive, is_archive_output};
 use mvm_sdk::decorator::{ParseError, parse_python, parse_typescript};
 
 use super::Cli;
+use super::ir_input::{IrJsonSource, read_ir_json_workload};
 use super::sandbox_record::{
     LoadedRecording, ScriptLanguage, auto_exec_record_script, load_recording,
     script_language_from_path,
@@ -220,10 +220,7 @@ fn load_workload(args: &Args) -> Result<LoadedRecording> {
     let source = workload_source(args)?;
     match source {
         WorkloadSource::IrJsonPath(path) => {
-            let bytes = std::fs::read(&path)
-                .with_context(|| format!("reading IR JSON from {}", path.display()))?;
-            let workload: Workload = serde_json::from_slice(&bytes)
-                .with_context(|| format!("parsing IR JSON from {}", path.display()))?;
+            let workload = read_ir_json_workload(&IrJsonSource::Path(path))?;
             Ok(LoadedRecording {
                 workload,
                 findings: Vec::new(),
@@ -232,12 +229,7 @@ fn load_workload(args: &Args) -> Result<LoadedRecording> {
             })
         }
         WorkloadSource::IrJsonStdin => {
-            let mut buf = Vec::new();
-            std::io::stdin()
-                .read_to_end(&mut buf)
-                .context("reading IR JSON from stdin")?;
-            let workload: Workload =
-                serde_json::from_slice(&buf).context("parsing IR JSON from stdin")?;
+            let workload = read_ir_json_workload(&IrJsonSource::Stdin)?;
             Ok(LoadedRecording {
                 workload,
                 findings: Vec::new(),

--- a/crates/mvm-cli/src/commands/build/group.rs
+++ b/crates/mvm-cli/src/commands/build/group.rs
@@ -1,7 +1,7 @@
 //! `mvmctl build <sub>` — build-time commands.
 //!
-//! `compile`/`validate`/`kernel` are the remaining build-time verbs.
-//! Image builds moved to `machine build`. Leaf modules are unchanged.
+//! `address`/`compile`/`validate`/`kernel`/`runtime-overlay` are the
+//! build-time verbs. Image builds moved to `machine build`.
 
 use anyhow::Result;
 use clap::{Args as ClapArgs, Subcommand};

--- a/crates/mvm-cli/src/commands/build/group.rs
+++ b/crates/mvm-cli/src/commands/build/group.rs
@@ -9,7 +9,7 @@ use clap::{Args as ClapArgs, Subcommand};
 use mvm_core::user_config::MvmConfig;
 
 use super::Cli;
-use super::{compile, kernel, runtime_overlay, validate};
+use super::{address, compile, kernel, runtime_overlay, validate};
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
@@ -28,6 +28,8 @@ pub(in crate::commands) enum BuildCmd {
     /// Prebuild or refresh the read-only runtime overlay cache
     #[command(name = "runtime-overlay")]
     RuntimeOverlay(runtime_overlay::Args),
+    /// Print a Workload IR's semantic address and ir-hash
+    Address(address::Args),
 }
 
 impl BuildCmd {
@@ -38,6 +40,7 @@ impl BuildCmd {
             BuildCmd::Validate(_) => "validate",
             BuildCmd::Kernel(_) => "kernel",
             BuildCmd::RuntimeOverlay(_) => "runtime-overlay",
+            BuildCmd::Address(_) => "address",
         }
     }
 }
@@ -48,5 +51,6 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
         BuildCmd::Validate(a) => validate::run(cli, a, cfg),
         BuildCmd::Kernel(a) => kernel::run(cli, a, cfg),
         BuildCmd::RuntimeOverlay(a) => runtime_overlay::run(cli, a, cfg),
+        BuildCmd::Address(a) => address::run(cli, a, cfg),
     }
 }

--- a/crates/mvm-cli/src/commands/build/ir_input.rs
+++ b/crates/mvm-cli/src/commands/build/ir_input.rs
@@ -1,0 +1,141 @@
+//! Shared IR-JSON input loading for the build-time verbs.
+//!
+//! Both `build address` and `build compile` accept a Workload IR document from
+//! a `--from-ir <path>`, a positional path, or `-` (stdin). This module owns
+//! the one copy of that resolution + read + parse so the two verbs can't drift.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+use mvm_protocol::ir::Workload;
+
+/// A resolved place to read IR-JSON bytes from.
+#[derive(Debug)]
+pub(in crate::commands) enum IrJsonSource {
+    Path(PathBuf),
+    Stdin,
+}
+
+/// Resolve the IR-JSON source from a `--from-ir` path and an optional
+/// positional entry. An empty (or whitespace-only) positional counts as no
+/// positional, so a stray `""` argument never silently competes with
+/// `--from-ir`. Errors when both are given (ambiguous) or neither is.
+pub(in crate::commands) fn resolve_ir_json_source(
+    from_ir: Option<&Path>,
+    entry: Option<&str>,
+) -> Result<IrJsonSource> {
+    let entry = entry.map(str::trim).filter(|s| !s.is_empty());
+    match (from_ir, entry) {
+        (Some(_), Some(_)) => {
+            bail!(
+                "--from-ir and the positional entry are mutually exclusive — pass one or the other."
+            )
+        }
+        (Some(path), None) => Ok(IrJsonSource::Path(path.to_path_buf())),
+        (None, Some("-")) => Ok(IrJsonSource::Stdin),
+        (None, Some(s)) => Ok(IrJsonSource::Path(PathBuf::from(s))),
+        (None, None) => {
+            bail!("missing entry: pass an IR JSON path, `-` for stdin, or `--from-ir <path>`.")
+        }
+    }
+}
+
+/// Read and parse a `Workload` from a resolved IR-JSON source.
+pub(in crate::commands) fn read_ir_json_workload(source: &IrJsonSource) -> Result<Workload> {
+    let (bytes, label) = read_bytes(source)?;
+    parse_ir_json(&bytes, &label)
+}
+
+fn parse_ir_json(bytes: &[u8], label: &str) -> Result<Workload> {
+    serde_json::from_slice(bytes).with_context(|| format!("parsing IR JSON from {label}"))
+}
+
+/// Resolve, read, and parse in one step — the shape the single-source verbs use.
+pub(in crate::commands) fn load_ir_json_workload(
+    from_ir: Option<&Path>,
+    entry: Option<&str>,
+) -> Result<Workload> {
+    read_ir_json_workload(&resolve_ir_json_source(from_ir, entry)?)
+}
+
+fn read_bytes(source: &IrJsonSource) -> Result<(Vec<u8>, String)> {
+    match source {
+        IrJsonSource::Path(path) => {
+            let bytes = std::fs::read(path)
+                .with_context(|| format!("reading IR JSON from {}", path.display()))?;
+            Ok((bytes, path.display().to_string()))
+        }
+        IrJsonSource::Stdin => {
+            let mut buf = Vec::new();
+            std::io::stdin()
+                .read_to_end(&mut buf)
+                .context("reading IR JSON from stdin")?;
+            Ok((buf, "stdin".to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_ir_resolves_to_its_path() {
+        let source = resolve_ir_json_source(Some(Path::new("ir.json")), None).unwrap();
+        assert!(matches!(source, IrJsonSource::Path(p) if p == Path::new("ir.json")));
+    }
+
+    #[test]
+    fn dash_positional_resolves_to_stdin() {
+        let source = resolve_ir_json_source(None, Some("-")).unwrap();
+        assert!(matches!(source, IrJsonSource::Stdin));
+    }
+
+    #[test]
+    fn positional_path_resolves_to_path() {
+        let source = resolve_ir_json_source(None, Some("workload.json")).unwrap();
+        assert!(matches!(source, IrJsonSource::Path(p) if p == Path::new("workload.json")));
+    }
+
+    #[test]
+    fn empty_positional_is_ignored_so_from_ir_wins() {
+        // A stray empty arg alongside --from-ir is not an ambiguity; the flag
+        // is the sole real input.
+        let source = resolve_ir_json_source(Some(Path::new("ir.json")), Some("")).unwrap();
+        assert!(matches!(source, IrJsonSource::Path(p) if p == Path::new("ir.json")));
+        let whitespace = resolve_ir_json_source(Some(Path::new("ir.json")), Some("   ")).unwrap();
+        assert!(matches!(whitespace, IrJsonSource::Path(p) if p == Path::new("ir.json")));
+    }
+
+    #[test]
+    fn conflicting_inputs_are_rejected() {
+        let err = resolve_ir_json_source(Some(Path::new("a.json")), Some("b.json")).unwrap_err();
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn missing_input_is_rejected() {
+        let err = resolve_ir_json_source(None, None).unwrap_err();
+        assert!(err.to_string().contains("missing entry"));
+        // An empty positional with no flag is still "no input".
+        let empty = resolve_ir_json_source(None, Some("")).unwrap_err();
+        assert!(empty.to_string().contains("missing entry"));
+    }
+
+    #[test]
+    fn missing_file_is_reported() {
+        let err = read_ir_json_workload(&IrJsonSource::Path(PathBuf::from(
+            "/nonexistent/does-not-exist.json",
+        )))
+        .unwrap_err();
+        assert!(err.to_string().contains("reading IR JSON"));
+    }
+
+    #[test]
+    fn malformed_json_is_rejected() {
+        let err = parse_ir_json(b"{ not json", "fixture").unwrap_err();
+        assert!(err.to_string().contains("parsing IR JSON"));
+    }
+}

--- a/crates/mvm-cli/src/commands/build/mod.rs
+++ b/crates/mvm-cli/src/commands/build/mod.rs
@@ -10,6 +10,9 @@ pub(super) mod compile;
 pub(super) mod group;
 #[cfg(feature = "builder-vm")]
 pub mod hvf_builder_image;
+/// Shared IR-JSON input loading (`--from-ir` / positional / `-` stdin) for the
+/// build-time verbs that read a Workload document.
+pub(super) mod ir_input;
 pub(super) mod kernel;
 /// `mvmctl persistent-builder` user-facing verb. Wires the
 /// host-side `LibkrunPersistentHostVm` and

--- a/crates/mvm-cli/src/commands/build/mod.rs
+++ b/crates/mvm-cli/src/commands/build/mod.rs
@@ -3,6 +3,7 @@
 //! The `image` catalog lives in the top-level `catalog` module; `flake`
 //! validation is the `validate` subcommand.
 
+pub(super) mod address;
 #[allow(clippy::module_inception)]
 pub(in crate::commands) mod build;
 pub(super) mod compile;

--- a/crates/mvm-conformance/Cargo.toml
+++ b/crates/mvm-conformance/Cargo.toml
@@ -34,6 +34,9 @@ tokio.workspace = true
 # through a crate rename as long as the produced binary is still named
 # `mvmctl`.
 assert_cmd.workspace = true
+# Parses the `build address --json` report in the workload-identity steps.
+# Dev-only: `cargo tree -p mvm-conformance -e no-dev` must not gain it.
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -57,6 +57,17 @@ fn output_contains(world: &mut CliWorld, needle: String) {
     );
 }
 
+#[then(expr = "the error output contains {string}")]
+fn error_output_contains(world: &mut CliWorld, needle: String) {
+    let output = world.last_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(needle.as_str()),
+        "expected stderr to contain {needle:?}; stderr:\n{stderr}\nstdout:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+}
+
 #[then(expr = "the help output contains {string}")]
 fn help_contains(world: &mut CliWorld, expected: String) {
     let output = world.last_output();

--- a/crates/mvm-conformance/tests/steps/mod.rs
+++ b/crates/mvm-conformance/tests/steps/mod.rs
@@ -1,3 +1,4 @@
 //! Step definitions, one module per scenario surface.
 
 mod cli;
+mod workload_identity;

--- a/crates/mvm-conformance/tests/steps/workload_identity.rs
+++ b/crates/mvm-conformance/tests/steps/workload_identity.rs
@@ -1,0 +1,93 @@
+//! Steps driving `mvmctl build address` over the workload-identity fixtures.
+//!
+//! Each `When` runs the real binary against a fixture and records the raw
+//! `Output` (so failing-exit scenarios can still assert). On a zero exit it
+//! parses the `--json` report and stashes the semantic address + ir-hash by
+//! fixture name, which the `Then` steps compare.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use assert_cmd::cargo::CommandCargoExt;
+use cucumber::{then, when};
+
+use crate::world::CliWorld;
+
+/// Absolute path to a fixture under this suite, resolved from the crate
+/// manifest dir (two levels below the repo-root `features/` tree) so the run
+/// is independent of the process working directory.
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("features")
+        .join("suites")
+        .join("s7_workload_identity")
+        .join("fixtures")
+        .join(name)
+}
+
+#[when(expr = "I compute the workload address of fixture {string}")]
+fn compute_address(world: &mut CliWorld, fixture: String) {
+    let path = fixture_path(&fixture);
+    #[allow(deprecated)] // matches the sibling cli.rs use of this API
+    let mut cmd = Command::cargo_bin("mvmctl").unwrap_or_else(|e| {
+        panic!("mvmctl binary not found ({e}) — run `cargo build --bin mvmctl` before `just bdd`")
+    });
+    let output = cmd
+        .args(["build", "address", "--from-ir"])
+        .arg(&path)
+        .arg("--json")
+        .output()
+        .expect("failed to spawn mvmctl");
+
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let report: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+            panic!("build address --json did not emit valid JSON ({e}); stdout:\n{stdout}")
+        });
+        let addr = report["semantic_address"]
+            .as_str()
+            .expect("report carries a string semantic_address")
+            .to_string();
+        let ih = report["ir_hash"]
+            .as_str()
+            .expect("report carries a string ir_hash")
+            .to_string();
+        world.addresses.insert(fixture.clone(), addr);
+        world.ir_hashes.insert(fixture.clone(), ih);
+    }
+    world.last_run = Some(output);
+}
+
+#[then(expr = "the workload address of {string} equals {string}")]
+fn address_equals(world: &mut CliWorld, a: String, b: String) {
+    assert_eq!(
+        world.address_of(&a),
+        world.address_of(&b),
+        "expected {a:?} and {b:?} to share a semantic address"
+    );
+}
+
+#[then(expr = "the workload address of {string} differs from {string}")]
+fn address_differs(world: &mut CliWorld, a: String, b: String) {
+    assert_ne!(
+        world.address_of(&a),
+        world.address_of(&b),
+        "expected {a:?} and {b:?} to have different semantic addresses"
+    );
+}
+
+#[then(expr = "the semantic address of {string} matches its ir-hash")]
+fn semantic_matches_ir_hash(world: &mut CliWorld, fixture: String) {
+    let addr = world.address_of(&fixture);
+    let ih = world
+        .ir_hashes
+        .get(&fixture)
+        .unwrap_or_else(|| panic!("no ir-hash recorded for {fixture:?}"));
+    assert_eq!(
+        addr.strip_prefix("sha256:"),
+        Some(ih.as_str()),
+        "semantic address {addr:?} must be sha256: + ir-hash {ih:?}"
+    );
+}

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -1,12 +1,20 @@
 //! Shared state cucumber threads through the steps of one scenario.
 
+use std::collections::HashMap;
 use std::process::Output;
 
 /// Constructed fresh for every scenario. Holds the result of the most
-/// recent CLI invocation so later `Then` steps can assert on it.
+/// recent CLI invocation so later `Then` steps can assert on it, plus the
+/// workload identities parsed from successful `build address` runs, keyed by
+/// fixture name.
 #[derive(Debug, Default, cucumber::World)]
 pub struct CliWorld {
     pub last_run: Option<Output>,
+    /// `semantic_address` per fixture name, populated on a zero-exit
+    /// `build address` run.
+    pub addresses: HashMap<String, String>,
+    /// `ir_hash` per fixture name, from the same run as `addresses`.
+    pub ir_hashes: HashMap<String, String>,
 }
 
 impl CliWorld {
@@ -16,5 +24,15 @@ impl CliWorld {
         self.last_run
             .as_ref()
             .expect("no CLI invocation recorded yet — a prior `When` step must run one")
+    }
+
+    /// The stored semantic address for `fixture`, or a failed assertion
+    /// naming the fixture whose `When` step didn't run (or didn't succeed).
+    pub fn address_of(&self, fixture: &str) -> &str {
+        self.addresses.get(fixture).unwrap_or_else(|| {
+            panic!(
+                "no address recorded for {fixture:?} — its `When` step must run and succeed first"
+            )
+        })
     }
 }

--- a/crates/mvm-core/src/canonicalizer_equivalence.rs
+++ b/crates/mvm-core/src/canonicalizer_equivalence.rs
@@ -84,10 +84,13 @@ mod tests {
 
         cases.push(("base", base_workload()));
 
-        // The key probe: JCS orders object keys by UTF-16 code units, while a
-        // naive `str` sort orders by Unicode scalar value. For U+FFFF vs
-        // U+10000 those orders are opposite, so an astral-plane key exercises
-        // exactly the case where a UTF-16-vs-scalar mismatch would surface.
+        // The key probe. RFC 8785 mandates ordering object keys by UTF-16 code
+        // units, under which U+10000 sorts before U+FFFF (its leading surrogate
+        // 0xD800 < 0xFFFF) — opposite to a scalar-value sort. serde_jcs 0.1.0
+        // does NOT implement that: it orders keys by their UTF-8 byte value,
+        // which coincides with the hand-rolled writer's scalar-value `str` sort.
+        // This entry pins that coincidence as a drift-lock; it is not evidence
+        // of RFC 8785 conformance (see this module's header).
         {
             let mut w = base_workload();
             w.extensions

--- a/crates/mvm-core/src/canonicalizer_equivalence.rs
+++ b/crates/mvm-core/src/canonicalizer_equivalence.rs
@@ -1,0 +1,210 @@
+//! Drift-lock between the two RFC 8785 realizations this workspace carries.
+//!
+//! `mvm_protocol::ir::canonicalize` (the load-bearing hand-rolled `no_std`
+//! JCS writer that feeds `ir_hash`) and `serde_jcs` (the crate
+//! [`crate::semantic_address::semantic_address`] hashes) are independent
+//! implementations of the same canonical form. Nothing else proves they emit
+//! byte-identical output, so a change to either one could silently make an
+//! `ir_hash` disagree with a `SemanticAddress` for the same workload — which
+//! would break the CLI self-check that ties the two together.
+//!
+//! These tests assert byte-for-byte agreement over a corpus of divergence-prone
+//! `Workload` shapes (astral-plane map keys, escaped string values, large
+//! integers, nested/empty containers), plus the full digest chain
+//! `ir_hash == hex(sha256(serde_jcs)) == semantic_address` minus the prefix.
+//!
+//! The two realizations already agree on every shape, including astral-plane
+//! keys: both order object keys by Unicode scalar value. The hand-rolled writer
+//! sorts `str` keys directly; `serde_jcs` sorts on each key's serialized UTF-8
+//! bytes, whose lexicographic order is identical to scalar-value order. So this
+//! is a lock against future drift, not a witness of an existing gap.
+//! Test-only; it introduces no runtime code.
+
+#[cfg(test)]
+mod tests {
+    use crate::semantic_address::semantic_address;
+    use mvm_protocol::ir::{
+        App, Entrypoint, EnvValue, Image, Resources, Source, Workload, canonicalize, ir_hash,
+    };
+    use sha2::{Digest, Sha256};
+    use std::collections::BTreeMap;
+
+    fn base_workload() -> Workload {
+        Workload {
+            schema_version: "0.1".to_string(),
+            id: "hello".to_string(),
+            apps: vec![base_app()],
+            volumes: vec![],
+            extensions: BTreeMap::new(),
+        }
+    }
+
+    fn base_app() -> App {
+        App {
+            name: "hello".to_string(),
+            source: Source::LocalPath {
+                path: ".".to_string(),
+                include: vec!["**".to_string()],
+                exclude: vec![],
+            },
+            image: Image::NixPackages {
+                packages: vec!["python312".to_string()],
+            },
+            entrypoints: vec![Entrypoint::Command {
+                command: vec!["python".to_string(), "-m".to_string(), "hello".to_string()],
+                working_dir: "/app".to_string(),
+                env: BTreeMap::new(),
+            }],
+            env: BTreeMap::new(),
+            mounts: vec![],
+            network: None,
+            resources: Resources {
+                cpu_cores: 1,
+                memory_mb: 256,
+                rootfs_size_mb: 512,
+            },
+            dependencies: None,
+            threat_tier: Default::default(),
+            addons: vec![],
+            hooks: Default::default(),
+            files: vec![],
+            health_check: None,
+        }
+    }
+
+    fn literal(value: &str) -> EnvValue {
+        EnvValue::Literal {
+            value: value.to_string(),
+        }
+    }
+
+    /// Divergence-prone corpus, each entry `(label, workload)`.
+    fn corpus() -> Vec<(&'static str, Workload)> {
+        let mut cases: Vec<(&'static str, Workload)> = Vec::new();
+
+        cases.push(("base", base_workload()));
+
+        // The key probe: JCS orders object keys by UTF-16 code units, while a
+        // naive `str` sort orders by Unicode scalar value. For U+FFFF vs
+        // U+10000 those orders are opposite, so an astral-plane key exercises
+        // exactly the case where a UTF-16-vs-scalar mismatch would surface.
+        {
+            let mut w = base_workload();
+            w.extensions
+                .insert("\u{FFFF}".to_string(), serde_json::json!(1));
+            w.extensions
+                .insert("\u{10000}".to_string(), serde_json::json!(2));
+            w.extensions
+                .insert("\u{1F600}".to_string(), serde_json::json!(3));
+            w.extensions.insert("a".to_string(), serde_json::json!(4));
+            cases.push(("astral-plane-extension-keys", w));
+        }
+
+        // Same probe, second string-keyed map: an app's env.
+        {
+            let mut w = base_workload();
+            let mut env = BTreeMap::new();
+            env.insert("\u{10000}".to_string(), literal("astral"));
+            env.insert("\u{FFFF}".to_string(), literal("bmp-max"));
+            env.insert("\u{1F600}".to_string(), literal("emoji"));
+            w.apps[0].env = env;
+            cases.push(("astral-plane-env-keys", w));
+        }
+
+        // Escaping parity: control chars, quote, backslash, newline in a value.
+        {
+            let mut w = base_workload();
+            let mut env = BTreeMap::new();
+            env.insert(
+                "escapes".to_string(),
+                literal("a\"b\\c\nd\te\rf\u{08}g\u{0c}h\u{01}i\u{1f}j"),
+            );
+            w.apps[0].env = env;
+            cases.push(("escaped-string-values", w));
+        }
+
+        // Multi-byte BMP characters in values should already agree.
+        {
+            let mut w = base_workload();
+            let mut env = BTreeMap::new();
+            env.insert("bmp".to_string(), literal("café 你好 Ω"));
+            w.apps[0].env = env;
+            cases.push(("multibyte-bmp-values", w));
+        }
+
+        // Large integer fields near the u32 ceiling.
+        {
+            let mut w = base_workload();
+            w.apps[0].resources = Resources {
+                cpu_cores: u16::MAX,
+                memory_mb: u32::MAX,
+                rootfs_size_mb: u32::MAX - 1,
+            };
+            cases.push(("large-integers", w));
+        }
+
+        // Nested arrays/objects and empty containers in the extension bag.
+        {
+            let mut w = base_workload();
+            w.extensions.insert(
+                "nested".to_string(),
+                serde_json::json!({
+                    "z": [3, 2, 1],
+                    "a": {"b": {"c": [true, false, null]}},
+                    "empty_obj": {},
+                    "empty_arr": [],
+                }),
+            );
+            cases.push(("nested-and-empty-containers", w));
+        }
+
+        cases
+    }
+
+    fn hex_sha256(bytes: &[u8]) -> String {
+        hex::encode(Sha256::digest(bytes))
+    }
+
+    /// Report the first differing byte so a regression points at *where* the
+    /// two realizations drift, not merely *that* they do.
+    fn assert_same_bytes(label: &str, hand_rolled: &[u8], jcs: &[u8]) {
+        if hand_rolled == jcs {
+            return;
+        }
+        let at = hand_rolled
+            .iter()
+            .zip(jcs.iter())
+            .position(|(a, b)| a != b)
+            .unwrap_or_else(|| hand_rolled.len().min(jcs.len()));
+        panic!(
+            "canonical byte divergence for {label:?} at offset {at}\n  ir::canonicalize: {}\n  serde_jcs:        {}",
+            String::from_utf8_lossy(hand_rolled),
+            String::from_utf8_lossy(jcs),
+        );
+    }
+
+    #[test]
+    fn ir_canonicalize_matches_serde_jcs_byte_for_byte() {
+        for (label, w) in corpus() {
+            let hand_rolled = canonicalize(&w).expect("canonicalize").into_bytes();
+            let jcs = serde_jcs::to_vec(&w).expect("serde_jcs");
+            assert_same_bytes(label, &hand_rolled, &jcs);
+        }
+    }
+
+    #[test]
+    fn digest_chain_agrees_end_to_end() {
+        for (label, w) in corpus() {
+            let jcs = serde_jcs::to_vec(&w).expect("serde_jcs");
+            let ih = ir_hash(&w).expect("ir_hash");
+            assert_eq!(ih, hex_sha256(&jcs), "ir_hash vs sha256(jcs) for {label:?}");
+
+            let addr = semantic_address(&w).expect("semantic_address");
+            assert_eq!(
+                addr.as_str().strip_prefix("sha256:"),
+                Some(ih.as_str()),
+                "semantic_address vs ir_hash for {label:?}",
+            );
+        }
+    }
+}

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -64,6 +64,11 @@ pub mod release_trust;
 pub mod semantic_address;
 pub mod user_config;
 
+/// Test-only drift-lock proving `mvm_protocol::ir::canonicalize` and
+/// `serde_jcs` emit byte-identical canonical form for the same workload.
+#[cfg(test)]
+mod canonicalizer_equivalence;
+
 /// Cryptographic primitives — attestation, key rotation, keystore,
 /// secret store, snapshot encryption/HMAC, image (cosign) verification,
 /// seccomp, fs/mount/path/ttl policy. Folded in from the former

--- a/crates/mvm-core/src/semantic_address.rs
+++ b/crates/mvm-core/src/semantic_address.rs
@@ -15,6 +15,15 @@
 //! `SemanticAddress` exists specifically to match the external UOR-ADDR
 //! realization byte-for-byte, so it goes through the dedicated JCS crate.
 //!
+//! Caveat on the canonical form: `serde_jcs` 0.1.0 orders object keys by their
+//! UTF-8 byte value, not the UTF-16 code-unit order true RFC 8785 mandates. The
+//! two coincide for every code point up to U+FFFF but diverge for astral-plane
+//! (>U+FFFF) keys, so an address computed here can differ from one a strictly
+//! conformant implementation would produce for a workload carrying such keys.
+//! The `canonicalizer_equivalence` test module documents and pins this
+//! divergence class; cross-implementation conformance vectors are a tracked
+//! follow-up.
+//!
 //! # What this is not
 //!
 //! A semantic address authenticates nothing, proves no provenance, is not

--- a/crates/mvm-protocol/src/ir/canonicalize.rs
+++ b/crates/mvm-protocol/src/ir/canonicalize.rs
@@ -1,9 +1,16 @@
 //! Canonicalization of IR documents.
 //!
-//! Output conforms to RFC 8785 (JSON Canonicalization Scheme). v0 IR uses
-//! only integer numeric types, which sidesteps the main JCS complexity
-//! (ECMA-262 number serialization). If floats are ever admitted to the IR,
-//! this module must be extended to perform JCS number canonicalization.
+//! Output tracks RFC 8785 (JSON Canonicalization Scheme). v0 IR uses only
+//! integer numeric types, which sidesteps the main JCS complexity (ECMA-262
+//! number serialization). If floats are ever admitted to the IR, this module
+//! must be extended to perform JCS number canonicalization.
+//!
+//! Object keys are ordered by Unicode scalar value (a `str` sort). This matches
+//! the `serde_jcs` realization mvm-core hashes for its semantic address — which
+//! also orders by byte/scalar value — but diverges from the UTF-16 code-unit
+//! order true RFC 8785 mandates for astral-plane (>U+FFFF) keys. The two agree
+//! for every code point up to U+FFFF; the divergence class is documented and
+//! pinned by mvm-core's `canonicalizer_equivalence` test module.
 
 use alloc::format;
 use alloc::string::{String, ToString};

--- a/features/suites/s7_workload_identity/fixtures/bad-schema.json
+++ b/features/suites/s7_workload_identity/fixtures/bad-schema.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0",
+  "id": "hello",
+  "apps": [
+    {
+      "name": "hello",
+      "source": { "kind": "local_path", "path": "." },
+      "image": { "kind": "nix_packages", "packages": ["python312"] },
+      "entrypoints": [
+        { "kind": "command", "command": ["python", "-m", "hello"] }
+      ],
+      "resources": { "cpu_cores": 1, "memory_mb": 256, "rootfs_size_mb": 512 }
+    }
+  ]
+}

--- a/features/suites/s7_workload_identity/fixtures/goodbye.json
+++ b/features/suites/s7_workload_identity/fixtures/goodbye.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "0.1",
+  "id": "goodbye",
+  "apps": [
+    {
+      "name": "goodbye",
+      "source": { "kind": "local_path", "path": "." },
+      "image": { "kind": "nix_packages", "packages": ["python312"] },
+      "entrypoints": [
+        { "kind": "command", "command": ["python", "-m", "goodbye"] }
+      ],
+      "resources": { "cpu_cores": 1, "memory_mb": 256, "rootfs_size_mb": 512 }
+    }
+  ]
+}

--- a/features/suites/s7_workload_identity/fixtures/hello.min.json
+++ b/features/suites/s7_workload_identity/fixtures/hello.min.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "0.1",
+  "id": "hello",
+  "apps": [
+    {
+      "name": "hello",
+      "source": { "kind": "local_path", "path": "." },
+      "image": { "kind": "nix_packages", "packages": ["python312"] },
+      "entrypoints": [
+        { "kind": "command", "command": ["python", "-m", "hello"] }
+      ],
+      "resources": { "cpu_cores": 1, "memory_mb": 256, "rootfs_size_mb": 512 }
+    }
+  ]
+}

--- a/features/suites/s7_workload_identity/fixtures/hello.reordered.json
+++ b/features/suites/s7_workload_identity/fixtures/hello.reordered.json
@@ -1,0 +1,32 @@
+{
+  "apps": [
+    {
+      "resources": {
+        "rootfs_size_mb": 512,
+        "memory_mb": 256,
+        "cpu_cores": 1
+      },
+      "entrypoints": [
+        {
+          "env": {},
+          "working_dir": "/app",
+          "command": ["python", "-m", "hello"],
+          "kind": "command"
+        }
+      ],
+      "image": {
+        "packages": ["python312"],
+        "kind": "nix_packages"
+      },
+      "source": {
+        "exclude": [],
+        "include": ["**"],
+        "path": ".",
+        "kind": "local_path"
+      },
+      "name": "hello"
+    }
+  ],
+  "id": "hello",
+  "schema_version": "0.1"
+}

--- a/features/suites/s7_workload_identity/workload_address.feature
+++ b/features/suites/s7_workload_identity/workload_address.feature
@@ -1,0 +1,31 @@
+Feature: Workload semantic identity
+
+  `mvmctl build address` prints a Workload IR's content identity: the
+  `sha256(JCS(ir))` semantic address and the matching ir-hash. The identity is
+  a property of what the workload means, not how its JSON was written, so two
+  encodings of the same workload must address alike, two different workloads
+  must not, and an unrecognized schema must fail closed.
+
+  Scenario: Reordered keys and whitespace do not change the address
+    When I compute the workload address of fixture "hello.min.json"
+    Then the command exits with code 0
+    When I compute the workload address of fixture "hello.reordered.json"
+    Then the command exits with code 0
+    And the workload address of "hello.reordered.json" equals "hello.min.json"
+
+  Scenario: A meaningfully different workload has a different address
+    When I compute the workload address of fixture "hello.min.json"
+    Then the command exits with code 0
+    When I compute the workload address of fixture "goodbye.json"
+    Then the command exits with code 0
+    And the workload address of "goodbye.json" differs from "hello.min.json"
+
+  Scenario: The semantic address matches the ir-hash
+    When I compute the workload address of fixture "hello.min.json"
+    Then the command exits with code 0
+    And the semantic address of "hello.min.json" matches its ir-hash
+
+  Scenario: An unsupported schema version fails closed
+    When I compute the workload address of fixture "bad-schema.json"
+    Then the command exits with code 1
+    And the error output contains "schema"

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -119,6 +119,8 @@ const RUNTIME_OVERLAY_SUB: &[(&str, AuditPosture)] = &[("build", AuditPosture::R
 
 // Plan 178 (D1) — build-time verbs grouped under `build <sub>`.
 const BUILD_SUB: &[(&str, AuditPosture)] = &[
+    // Reads an IR document and prints its content identity; no state change.
+    ("address", AuditPosture::ReadOnly),
     ("compile", AuditPosture::ReadOnly),
     ("validate", AuditPosture::ReadOnly),
     ("kernel", AuditPosture::DelegatesToSub(KERNEL_SUB)),


### PR DESCRIPTION
## Summary

Adds `mvmctl build address` — a build-time verb that reads a Workload IR JSON and prints its semantic content identity (`sha256(JCS(ir))`, rendered `sha256:<hex>`) alongside the load-bearing `ir_hash`, self-checking that the two agree. This gives the previously-orphaned `mvm_core::semantic_address::SemanticAddress` a real consumer and a cross-language interop tool: diff its output against an SDK's emitted IR to confirm two workload declarations mean the same thing regardless of JSON formatting or key order.

Along the way it locks down a latent canonicalization risk and corrects an over-broad conformance claim.

## What's in here

- **`mvmctl build address`** (`crates/mvm-cli/src/commands/build/address.rs`) — IR JSON in (positional / `-` stdin / `--from-ir`), `semantic-address` + `ir-hash` out; `--json` for machine use. Fails closed on an unknown schema version and on a self-check mismatch. Routes through one shared IR-JSON loader (`build/ir_input.rs`) alongside `build compile` rather than duplicating the loader.
- **Canonicalizer equivalence lock** (`crates/mvm-core/src/canonicalizer_equivalence.rs`) — proves byte-for-byte that mvm's two RFC-8785 realizations agree: the hand-rolled `no_std` `mvm_protocol::ir::canonicalize` (load-bearing — it feeds SDK `emit_json`, launch plans, and the audit `ir_hash`) and the `serde_jcs`-backed `SemanticAddress`. Asserts the full chain `ir_hash == sha256(serde_jcs) == semantic_address` (minus prefix) over an adversarial corpus including astral-plane map keys, control chars, and nested maps.
- **BDD** (`features/suites/s7_workload_identity/`) — CLI-driven Gherkin driving the real `mvmctl`: same-meaning/different-encoding → one address, different-meaning → differ, semantic-address == ir-hash, unsupported schema → fails closed.

## Conformance finding (worth a maintainer's eye)

The equivalence test was written expecting a UTF-16 key-ordering bug in the hand-rolled canonicalizer. It didn't fire — because `serde_jcs` 0.1.0, the realization `SemanticAddress` treats as the reference, **also** isn't RFC-8785-compliant on key ordering: it sorts object keys by UTF-8 byte value (= Unicode scalar order), not the UTF-16 code-unit order the spec mandates. mvm's two canonicalizers therefore agree with each other, but neither matches a strictly-conformant JCS for astral-plane (>U+FFFF) keys. ASCII/BMP keys — i.e. every realistic workload — are unaffected.

`semantic_address.rs` and `canonicalize.rs` previously claimed flat RFC-8785 conformance; this PR adds the astral-key caveat so the claim is honest, and the equivalence module pins the coincidence as a drift-lock. Making the addresses agree with a *spec-correct* JCS is an upstream `serde_jcs` matter and out of scope here; the test in this branch reproduces the divergence class.

## Deliberately not done

No `uor-addr` crate dependency. mvm keeps its small in-house JSON realization rather than inheriting the upstream transitive closure for realizations it doesn't use.

## Testing

nightly `fmt --all --check` · `clippy --workspace --all-targets -D warnings` · `build --all-targets` (`-D warnings`) · `nextest --workspace` (7528 passed, 0 failed) · workspace doctests · `just bdd` (13 scenarios / 62 steps) · `check-no-spec-refs`.
