### PR TITLE
feat(runtime): make the workload base bootargs driver-provided

### DIFF
--- a/crates/mvm-runtime/src/driver/hvf.rs
+++ b/crates/mvm-runtime/src/driver/hvf.rs
@@ -295,6 +295,10 @@ impl VmmDriver for HvfDriver {
     fn guest_channel_info(&self, id: &VmId) -> Result<GuestChannelInfo> {
         self.backend.guest_channel_info(id)
     }
+
+    fn workload_base_bootargs(&self, virtiofs_root: bool, has_disk: bool) -> String {
+        crate::hvf_bootargs::workload_bootargs(virtiofs_root, has_disk)
+    }
 }
 
 /// The per-VM agent RPC socket path (host→guest agent bridge). Matches the
@@ -441,6 +445,19 @@ mod tests {
         assert_eq!(
             d.security_profile().tier,
             HvfBackend.security_profile().tier
+        );
+    }
+
+    #[test]
+    fn workload_base_bootargs_delegates_to_hvf_bootargs() {
+        let d = HvfDriver::new();
+        assert_eq!(
+            d.workload_base_bootargs(false, true),
+            crate::hvf_bootargs::workload_bootargs(false, true)
+        );
+        assert_eq!(
+            d.workload_base_bootargs(true, false),
+            crate::hvf_bootargs::workload_bootargs(true, false)
         );
     }
 

--- a/crates/mvm-runtime/src/driver/mock.rs
+++ b/crates/mvm-runtime/src/driver/mock.rs
@@ -120,6 +120,19 @@ impl VmmDriver for MockDriver {
     fn guest_channel_info(&self, _id: &VmId) -> Result<GuestChannelInfo> {
         bail!("mock driver does not provide guest channel info")
     }
+
+    fn workload_base_bootargs(&self, virtiofs_root: bool, has_disk: bool) -> String {
+        // A deterministic stand-in for a non-HVF console base — `hvc0` rather
+        // than HVF's `ttyAMA0` — so runner-level tests can prove the base
+        // comes from the driver rather than a hardcoded HVF default.
+        let mut args = "console=hvc0 panic=-1 nokaslr loglevel=8".to_string();
+        if virtiofs_root {
+            args.push_str(" rootfstype=virtiofs root=mvmroot rw init=/init");
+        } else if has_disk {
+            args.push_str(" root=/dev/vda rw init=/init");
+        }
+        args
+    }
 }
 
 /// A `MockDriver`'s live VM: a scripted exit + a per-port loopback vsock whose
@@ -215,6 +228,21 @@ mod tests {
                 .iter()
                 .all(|c| *c == ClaimStatus::DoesNotHold)
         );
+    }
+
+    #[test]
+    fn mock_driver_workload_base_bootargs_uses_hvc0_console_by_root_shape() {
+        let driver = MockDriver::default();
+        let disk_base = driver.workload_base_bootargs(false, true);
+        assert!(disk_base.contains("console=hvc0"));
+        assert!(disk_base.contains("root=/dev/vda"));
+        assert!(!disk_base.contains("ttyAMA0"));
+
+        let virtiofs_base = driver.workload_base_bootargs(true, false);
+        assert!(virtiofs_base.contains("rootfstype=virtiofs"));
+
+        let bare_base = driver.workload_base_bootargs(false, false);
+        assert!(!bare_base.contains("root="));
     }
 
     #[test]

--- a/crates/mvm-runtime/src/driver/traits.rs
+++ b/crates/mvm-runtime/src/driver/traits.rs
@@ -33,6 +33,12 @@ pub trait VmmDriver: Send + Sync {
     /// Boot the VM described by `spec`, returning a live handle.
     fn boot(&self, spec: &VmmSpec) -> Result<Box<dyn RunningVm>>;
 
+    /// The VMM-specific base kernel bootargs (console, earlycon, root/init
+    /// selection) for a workload boot with the given root/disk shape. The
+    /// shared cmdline assembler (`workload_runner::cmdline`) layers every
+    /// other token — verity, grants, egress, uvols — on top of this.
+    fn workload_base_bootargs(&self, virtiofs_root: bool, has_disk: bool) -> String;
+
     /// Reconstruct a live handle for an already-running VM by id — the stateless
     /// lifecycle entry (stop/status/wait from a process that didn't boot it). The
     /// handle is disk-backed (pid file + exit record), so no in-memory boot state

--- a/crates/mvm-runtime/src/hvf_backend.rs
+++ b/crates/mvm-runtime/src/hvf_backend.rs
@@ -490,7 +490,11 @@ impl VmBackend for HvfBackend {
             kernel: PathBuf::from(kernel),
             // Thread a full cmdline only when we need extra workload tokens;
             // otherwise keep the supervisor default (`init=/init`).
-            cmdline: cmdline::workload_cmdline(config, &state_dir),
+            cmdline: cmdline::workload_cmdline(
+                config,
+                &state_dir,
+                crate::hvf_bootargs::workload_bootargs,
+            ),
             memory_mib: config.memory_mib,
             initramfs: cmdline::effective_initrd(config),
             disks,
@@ -996,7 +1000,9 @@ mod tests {
         assert!(!disks[1].ephemeral);
 
         let dir = tempfile::tempdir().unwrap();
-        let assembled = cmdline::workload_cmdline(&config, dir.path()).expect("cmdline");
+        let assembled =
+            cmdline::workload_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs)
+                .expect("cmdline");
         assert!(
             assembled.contains("mvm.runtime_data=/dev/vdb"),
             "got: {assembled}"

--- a/crates/mvm-runtime/src/workload_runner/cmdline.rs
+++ b/crates/mvm-runtime/src/workload_runner/cmdline.rs
@@ -72,10 +72,16 @@ pub(crate) fn runtime_overlay(config: &VmStartConfig) -> Option<(&str, &str, &st
 /// tokens are needed (the driver then falls back to its own default base
 /// cmdline).
 ///
-/// The `ttyAMA0` console base lives in `crate::hvf_bootargs` — today's only
-/// runner driver. It moves behind a `VmmDriver` base-cmdline hook once a
-/// second driver with a different console needs to join the runner.
-pub(crate) fn workload_cmdline(config: &VmStartConfig, state_dir: &Path) -> Option<String> {
+/// `base_bootargs` supplies the VMM-specific console/earlycon/root base
+/// (`VmmDriver::workload_base_bootargs` for a runner driver, or
+/// `crate::hvf_bootargs::workload_bootargs` directly for the raw HVF
+/// backend, which has no driver to call through) — every other token here is
+/// shared across VMMs.
+pub(crate) fn workload_cmdline(
+    config: &VmStartConfig,
+    state_dir: &Path,
+    base_bootargs: impl Fn(bool, bool) -> String,
+) -> Option<String> {
     let egress = vsock_egress_cmdline_token(config, state_dir);
     // The userspace L3 egress tunnel: tell the guest (via mvm-guest-netinit →
     // mvm-guest-netd) to stand up its TUN and pump packets to the host worker over
@@ -99,7 +105,7 @@ pub(crate) fn workload_cmdline(config: &VmStartConfig, state_dir: &Path) -> Opti
     let mut cmdline = if verity_is_enabled {
         crate::hvf_bootargs::default_verity_bootargs()
     } else {
-        crate::hvf_bootargs::workload_bootargs(virtiofs_root, has_disk)
+        base_bootargs(virtiofs_root, has_disk)
     };
     if let Some(verity_args) = crate::microvm::build_verity_cmdline_args(
         config.roothash.as_deref(),
@@ -146,10 +152,15 @@ pub(crate) fn workload_cmdline(config: &VmStartConfig, state_dir: &Path) -> Opti
 /// volume token can't ride on that shortcut (an empty `VmmSpec.cmdline` means
 /// "ignore this string entirely"), so when a volume is present and the
 /// shortcut would otherwise apply, this synthesizes the same base bootargs
-/// `workload_cmdline`'s non-shortcut branch would have produced and appends
-/// the token to that instead of to nothing.
-pub(crate) fn runner_cmdline(config: &VmStartConfig, state_dir: &Path) -> String {
-    let base = workload_cmdline(config, state_dir);
+/// `workload_cmdline`'s non-shortcut branch would have produced (via the same
+/// `base_bootargs` closure) and appends the token to that instead of to
+/// nothing.
+pub(crate) fn runner_cmdline(
+    config: &VmStartConfig,
+    state_dir: &Path,
+    base_bootargs: impl Fn(bool, bool) -> String,
+) -> String {
+    let base = workload_cmdline(config, state_dir, &base_bootargs);
     let Some(uvols) = mvm_core::vm_backend::encode_user_volumes_cmdline(&config.volumes) else {
         return base.unwrap_or_default();
     };
@@ -158,10 +169,7 @@ pub(crate) fn runner_cmdline(config: &VmStartConfig, state_dir: &Path) -> String
         None => {
             let virtiofs_root = config.virtiofs_root.is_some();
             let has_disk = !virtiofs_root && !config.rootfs_path.is_empty();
-            format!(
-                "{} {uvols}",
-                crate::hvf_bootargs::workload_bootargs(virtiofs_root, has_disk)
-            )
+            format!("{} {uvols}", base_bootargs(virtiofs_root, has_disk))
         }
     }
 }
@@ -199,7 +207,8 @@ mod tests {
             ]),
             ..Default::default()
         };
-        let cmdline = workload_cmdline(&config, dir.path()).expect("cmdline");
+        let cmdline = workload_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs)
+            .expect("cmdline");
         assert!(cmdline.contains("rootfstype=virtiofs root=mvmroot"));
         assert!(cmdline.contains("init=/init"));
         assert!(cmdline.contains("mvm.runtime_source_policy=rootfs_only"));
@@ -231,7 +240,8 @@ mod tests {
             network_tunnel: Some(tunnel),
             ..Default::default()
         };
-        let cmdline = workload_cmdline(&config, dir.path()).expect("cmdline");
+        let cmdline = workload_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs)
+            .expect("cmdline");
         assert!(
             cmdline.contains(&expected),
             "cmdline missing the tunnel token: {cmdline}"
@@ -262,7 +272,8 @@ mod tests {
             runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
             ..Default::default()
         };
-        let cmdline = workload_cmdline(&config, dir.path()).expect("cmdline");
+        let cmdline = workload_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs)
+            .expect("cmdline");
         assert!(!cmdline.contains("root=/dev/vda"));
         assert!(!cmdline.contains("init=/init"));
         assert!(cmdline.contains("mvm.roothash="));
@@ -290,8 +301,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = VmStartConfig::default();
         assert_eq!(
-            runner_cmdline(&config, dir.path()),
-            workload_cmdline(&config, dir.path()).unwrap_or_default()
+            runner_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs),
+            workload_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs)
+                .unwrap_or_default()
         );
     }
 
@@ -307,8 +319,9 @@ mod tests {
         };
         // The egress token forces workload_cmdline's non-shortcut branch, so
         // this exercises the `Some(base)` arm of runner_cmdline's match.
-        let base = workload_cmdline(&config, dir.path()).expect("non-trivial base");
-        let cmdline = runner_cmdline(&config, dir.path());
+        let base = workload_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs)
+            .expect("non-trivial base");
+        let cmdline = runner_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs);
         assert!(cmdline.starts_with(&base));
         assert!(
             cmdline.contains("mvm.uvols=uvol0:"),
@@ -328,8 +341,11 @@ mod tests {
         // alone would return None here (the "let the driver default apply"
         // shortcut), so runner_cmdline must not silently drop the base
         // bootargs the volume token needs to ride on.
-        assert_eq!(workload_cmdline(&config, dir.path()), None);
-        let cmdline = runner_cmdline(&config, dir.path());
+        assert_eq!(
+            workload_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs),
+            None
+        );
+        let cmdline = runner_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs);
         assert!(cmdline.contains("root=/dev/vda"), "cmdline: {cmdline}");
         assert!(cmdline.contains("init=/init"), "cmdline: {cmdline}");
         assert!(
@@ -342,6 +358,9 @@ mod tests {
     fn runner_cmdline_is_empty_when_neither_base_nor_volumes_are_present() {
         let dir = tempfile::tempdir().unwrap();
         let config = VmStartConfig::default();
-        assert_eq!(runner_cmdline(&config, dir.path()), String::new());
+        assert_eq!(
+            runner_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs),
+            String::new()
+        );
     }
 }

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -375,7 +375,9 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 
             secrets,
             redaction,
             network_policy: &config.network_policy,
-            cmdline: cmdline::runner_cmdline(config, &state_dir),
+            cmdline: cmdline::runner_cmdline(config, &state_dir, |virtiofs_root, has_disk| {
+                self.driver.workload_base_bootargs(virtiofs_root, has_disk)
+            }),
         };
         // The supervisor + endpoint are detached/disk-backed; the live handle is
         // reconstructed by id via `attach`, so the boot handle is dropped here.
@@ -943,6 +945,50 @@ mod tests {
                 "booted cmdline missing {needle:?}: {cmdline}"
             );
         }
+    }
+
+    /// The base console/earlycon/root bootargs the runner boots with must come
+    /// from the driver (`VmmDriver::workload_base_bootargs`), not a hardcoded
+    /// HVF default — proven by driving `start` through a `MockDriver` whose
+    /// base uses `hvc0` rather than HVF's `ttyAMA0` and asserting the booted
+    /// spec's cmdline carries that base.
+    #[test]
+    fn start_uses_the_drivers_base_bootargs_not_a_hardcoded_hvf_default() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
+        let driver = MockDriver::default();
+        let cfg = VmStartConfig {
+            name: "runner-driver-base-bootargs".into(),
+            rootfs_path: "/img/rootfs.ext4".into(),
+            network_policy: NetworkPolicy::preset(mvm_core::network_policy::NetworkPreset::Dev),
+            ..Default::default()
+        };
+
+        let runner = WorkloadRunner::new(
+            driver.clone(),
+            RecordingSpawner::new("/run/ep.sock"),
+            RecordingBrokerRegistrar::new(),
+        );
+        runner.start(&cfg).expect("start succeeds");
+
+        let specs = runner.driver.booted_specs();
+        assert_eq!(specs.len(), 1);
+        let cmdline = &specs[0].cmdline;
+
+        let expected_base = driver.workload_base_bootargs(false, true);
+        assert!(
+            cmdline.starts_with(&expected_base),
+            "cmdline did not start with the driver's base bootargs {expected_base:?}: {cmdline}"
+        );
+        assert!(
+            !cmdline.contains("ttyAMA0"),
+            "cmdline carried the hardcoded HVF console rather than the driver's: {cmdline}"
+        );
     }
 
     fn disk_volume(host: &str, guest: &str, read_only: bool) -> mvm_core::vm_backend::VmVolume {


### PR DESCRIPTION
Driver-phase prerequisite for `LibkrunDriver`. The shared workload cmdline assembler hardcoded HVF's ARM base bootargs (`earlycon=pl011 console=ttyAMA0 nokaslr`); a libkrun driver needs `console=hvc0` and no pl011 earlycon. This makes the base **driver-provided** while the token suffix (verity/grant/egress/uvols) stays shared.

- New `VmmDriver::workload_base_bootargs(virtiofs_root, has_disk) -> String` (VMM-specific mechanics — fits the trait's contract).
- `HvfDriver` delegates to `hvf_bootargs::workload_bootargs` (byte-identical); `MockDriver` returns an `hvc0` base.
- `workload_cmdline`/`runner_cmdline` take a `base_bootargs: impl Fn(bool,bool)->String` closure; raw `HvfBackend::start` passes the HVF fn (unchanged behavior), the runner passes `self.driver.workload_base_bootargs`.

Behavior-preserving now (HVF is the only driver, returns the same base). A runner-level test drives `VmBackend::start` through `MockDriver` and asserts the booted spec's cmdline carries the driver's `hvc0` base with no `ttyAMA0` — proving the injection point is the driver.

Verified: `nextest -p mvm-runtime` 921 passed, clippy `-D warnings`, full `cargo build --workspace --all-targets -D warnings`, `x86_64-unknown-linux-gnu` cross-build, `check-vsock-only-egress` / `check-no-spec-refs-in-comments`. (`default_verity_bootargs()` is still HVF-shaped — a tracked follow-up folded into the LibkrunDriver work.)