### PR TITLE
feat(runtime): add LibkrunDriver (VmmDriver mechanics, dormant)

### DIFF
--- a/crates/mvm-runtime/src/driver/libkrun.rs
+++ b/crates/mvm-runtime/src/driver/libkrun.rs
@@ -1,0 +1,773 @@
+//! `LibkrunDriver` — the `VmmDriver` for the libkrun VMM (Linux KVM, macOS
+//! Apple Silicon). Identity and capabilities delegate to the proven
+//! `LibkrunBackend`. `boot` maps a policy-free `VmmSpec` to a relay
+//! `SupervisorConfig`, spawns `mvm-libkrun-supervisor`, and returns a live
+//! handle. Egress policy, the claim-10 gate, and secret substitution live in
+//! the host-side endpoint the role runner binds to the spec's `EGRESS_PORT`
+//! socket; the driver only wires that port through as a guest-dialed relay — it
+//! carries no policy and never sees a `NetworkPolicy`.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow, bail};
+use libkrun_sys::{BridgeRestartPolicy, KrunContext, SupervisorConfig};
+use mvm_agentd::vsock::{CONSOLE_PORT_BASE, GUEST_AGENT_PORT, dev_console_data_ports};
+use mvm_core::config::{vm_libkrun_pid, vm_state_dir, vm_vsock_port_socket_at};
+use mvm_core::vm_backend::{
+    BackendKind, BackendSecurityProfile, GuestChannelInfo, SnapshotCapability, VmBackend,
+    VmCapabilities, VmExitStatus, VmId, VmStatus,
+};
+
+use crate::driver::spec::KernelImage;
+use crate::driver::{BlockDev, DuplexStream, RunningVm, VmmDriver, VmmSpec, VsockDirection};
+use crate::libkrun::LibkrunBackend;
+
+/// The libkrun VMM driver: pure VMM mechanics, no policy and no admission. It
+/// boots what a `VmmSpec` describes and relays the guest's egress port to the
+/// host-side bridge; the claim-10 gate and substitution live in that bridge,
+/// not here.
+pub struct LibkrunDriver {
+    backend: LibkrunBackend,
+}
+
+impl LibkrunDriver {
+    pub fn new() -> Self {
+        Self {
+            backend: LibkrunBackend,
+        }
+    }
+}
+
+impl Default for LibkrunDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The default base kernel cmdline for a libkrun workload boot. libkrun guests
+/// use the virtio-console `console=hvc0` (there is no pl011 UART), and the
+/// root/init selection follows the boot shape. The shared cmdline assembler
+/// layers verity/grants/egress/uvols tokens on top of this.
+fn libkrun_base_bootargs(virtiofs_root: bool, has_disk: bool) -> String {
+    if virtiofs_root {
+        // Dev virtiofs-root boot: hvc0 console + the virtiofs guest root.
+        "console=hvc0 rootfstype=virtiofs root=mvmroot rw init=/init".to_string()
+    } else if has_disk {
+        crate::libkrun::DEFAULT_CMDLINE.to_string()
+    } else {
+        // Verity / initramfs boot: the initramfs PID 1 owns root/init selection,
+        // so only the console base is emitted here.
+        crate::libkrun::VERITY_CMDLINE.to_string()
+    }
+}
+
+/// Attach one slot-ordered block as a libkrun extra virtio-blk device. libkrun
+/// serves every disk from its host file — there is no RAM-backed ephemeral
+/// mode, so `BlockDev::ephemeral` is not representable here. Workload blocks are
+/// sealed read-only + non-ephemeral, so nothing is dropped.
+fn attach_block(krun: KrunContext, block: &BlockDev) -> KrunContext {
+    krun.add_disk(
+        format!("disk{}", block.slot),
+        block.source.to_string_lossy().into_owned(),
+        block.read_only,
+    )
+}
+
+/// Map a policy-free `VmmSpec` to a relay `SupervisorConfig`: the physical
+/// recipe (kernel, resources, slot-ordered disks, vsock wiring, console) with
+/// every role field inert. Role policy (tenant/plan/egress/audit) lives in the
+/// runner above this driver, so `relay` never sets an admission field — the
+/// supervisor takes its legacy run path and enforces nothing here.
+fn relay_libkrun_supervisor_config(spec: &VmmSpec, state_dir: &Path) -> Result<SupervisorConfig> {
+    let kernel = match &spec.kernel {
+        KernelImage::Path(p) => p.to_string_lossy().into_owned(),
+        KernelImage::Bundled => {
+            bail!("the libkrun driver requires an explicit kernel Image; VmmSpec.kernel is Bundled")
+        }
+    };
+
+    let vcpus = u8::try_from(spec.vcpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX);
+    let state_dir_str = state_dir.to_string_lossy().into_owned();
+    let console_log = state_dir.join("console.log");
+
+    // KrunContext::new seeds a rootfs arg we immediately null; the disk layout
+    // below owns the rootfs/extra-disk decision from spec.blocks.
+    let mut krun = KrunContext::new(&spec.name, kernel, "")
+        .with_resources(vcpus, spec.memory_mib)
+        .with_vsock_socket_dir(state_dir_str.clone())
+        .with_console_output(console_log.to_string_lossy().into_owned())
+        // A libkrun workload has no guest NIC: an explicit virtio-vsock device
+        // with libkrun's implicit TSI transport disabled. vsock is the only
+        // channel off the guest besides storage.
+        .with_vsock_direct();
+    krun.rootfs_path = None;
+
+    // An empty spec cmdline means "the driver supplies its own default base"
+    // (the shared assembler returns None when no extra tokens are needed); a
+    // non-empty one already carries the console + root/init base plus every
+    // layered token, so it is threaded verbatim.
+    let has_disk = spec.initramfs.is_none() && !spec.blocks.is_empty();
+    let trimmed = spec.cmdline.trim();
+    let cmdline = if trimmed.is_empty() {
+        libkrun_base_bootargs(false, has_disk)
+    } else {
+        trimmed.to_string()
+    };
+    krun = krun.with_cmdline(cmdline);
+
+    // Slot-ordered virtio-blk layout. libkrun serves /dev/vda from either the
+    // rootfs disk (plain-rootfs boot) or the first extra disk (initramfs boot,
+    // where the initramfs PID 1 owns root selection), so an initramfs spec puts
+    // every block in extra_disks and a plain spec pins slot 0 as the rootfs.
+    let mut ordered: Vec<&BlockDev> = spec.blocks.iter().collect();
+    ordered.sort_by_key(|b| b.slot);
+    match &spec.initramfs {
+        Some(initramfs) => {
+            krun.initramfs_path = Some(initramfs.to_string_lossy().into_owned());
+            for block in &ordered {
+                krun = attach_block(krun, block);
+            }
+        }
+        None => {
+            let mut disks = ordered.iter();
+            if let Some(root) = disks.next() {
+                krun.rootfs_path = Some(root.source.to_string_lossy().into_owned());
+            }
+            for block in disks {
+                krun = attach_block(krun, block);
+            }
+        }
+    }
+
+    // Wire every standing vsock port by direction: the host dials the guest's
+    // listeners (agent + dev-console data ports), and the guest dials the
+    // host-bound listeners (egress + exit + broker + tunnel). libkrun derives
+    // each unix socket from vsock_socket_dir, so the spec's host_uds is not
+    // re-bound here.
+    for port in &spec.vsock {
+        krun = match port.direction {
+            VsockDirection::HostDials => krun.add_vsock_port(port.guest_port),
+            VsockDirection::GuestDials => krun.add_host_listen_port(port.guest_port),
+        };
+    }
+
+    Ok(SupervisorConfig {
+        krun,
+        vm_state_dir: state_dir_str,
+        pid_file_name: None,
+        // Role fields — tenant/plan/policy/audit substrate live in the runner
+        // above this driver now, never in the pure VMM mechanics. All inert so
+        // the supervisor takes its legacy run path and enforces no admission.
+        tenant_id: None,
+        audit_dir: None,
+        gateway_audit_socket: None,
+        gateway_events_socket: None,
+        signing_key_path: None,
+        plan: None,
+        bundle: None,
+        network_policy: None,
+        bridge_restart_policy: BridgeRestartPolicy::HardFail,
+        // Pointing libkrun's egress proxy at the spawner's endpoint socket is a
+        // follow-up before this dormant driver is wired; egress is not exercised
+        // yet, so the transparent terminator stays unset.
+        transparent_terminator_port: None,
+    })
+}
+
+impl VmmDriver for LibkrunDriver {
+    fn name(&self) -> &str {
+        self.backend.name()
+    }
+
+    fn kind(&self) -> BackendKind {
+        self.backend.kind()
+    }
+
+    fn is_available(&self) -> Result<bool> {
+        self.backend.is_available()
+    }
+
+    fn capabilities(&self) -> VmCapabilities {
+        self.backend.capabilities()
+    }
+
+    fn snapshot_capability(&self) -> SnapshotCapability {
+        self.backend.snapshot_capability()
+    }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        self.backend.security_profile()
+    }
+
+    fn workload_base_bootargs(&self, virtiofs_root: bool, has_disk: bool) -> String {
+        libkrun_base_bootargs(virtiofs_root, has_disk)
+    }
+
+    fn boot(&self, spec: &VmmSpec) -> Result<Box<dyn RunningVm>> {
+        let state_dir = vm_state_dir(&spec.name);
+        std::fs::create_dir_all(&state_dir)
+            .map_err(|e| anyhow!("create state dir {}: {e}", state_dir.display()))?;
+        let console_log = state_dir.join("console.log");
+        // Clear any prior run's captured exit code so `wait` reads only this
+        // launch's, and the console capture so a stale panic isn't mistaken for
+        // this boot's.
+        let _ = std::fs::remove_file(mvm_core::exit_capture::exit_file_path(&state_dir));
+        let _ = crate::libkrun::open_console_capture(&console_log);
+
+        let mut cfg = relay_libkrun_supervisor_config(spec, &state_dir)?;
+
+        // Host-side kernel prep: on x86_64 libkrun needs an ELF vmlinux, so
+        // extract it and mark the format. A no-op on aarch64 (raw Image
+        // passthrough). Reuses the raw backend's single kernel resolver.
+        if let Some(kpath) = cfg.krun.kernel_path.clone() {
+            let (resolved, format) = crate::libkrun::libkrun_kernel_for_host(&kpath)?;
+            cfg.krun.kernel_path = Some(resolved);
+            cfg.krun.kernel_format = format;
+        }
+
+        let pid_file = vm_libkrun_pid(&spec.name);
+        // Remove any stale PID file so the poll below detects this launch's.
+        let _ = std::fs::remove_file(&pid_file);
+
+        let json = serde_json::to_string(&cfg)
+            .map_err(|e| anyhow!("serialize libkrun SupervisorConfig: {e}"))?;
+
+        let supervisor = crate::libkrun::resolve_supervisor_path()?;
+        let stdout = crate::libkrun::open_console_capture(&console_log)
+            .map(Stdio::from)
+            .unwrap_or_else(|_| Stdio::null());
+        let stderr = crate::libkrun::open_console_capture(&state_dir.join("supervisor.stderr.log"))
+            .map(Stdio::from)
+            .unwrap_or_else(|_| Stdio::inherit());
+        let mut child = Command::new(&supervisor)
+            .stdin(Stdio::piped())
+            .stdout(stdout)
+            .stderr(stderr)
+            .spawn()
+            .map_err(|e| anyhow!("spawn {}: {e}", supervisor.display()))?;
+        child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("supervisor stdin was not piped"))?
+            .write_all(json.as_bytes())
+            .map_err(|e| anyhow!("pipe libkrun SupervisorConfig to supervisor stdin: {e}"))?;
+
+        // Poll for the PID file (boot confirmed). If the supervisor exits first,
+        // surface that — its console capture carries the actionable detail.
+        let deadline = Instant::now() + crate::libkrun::PID_FILE_TIMEOUT;
+        loop {
+            if pid_file.exists() {
+                break;
+            }
+            if let Some(status) = child
+                .try_wait()
+                .map_err(|e| anyhow!("poll supervisor: {e}"))?
+            {
+                bail!(
+                    "libkrun supervisor exited before writing its PID file (status: {status}); see {}",
+                    console_log.display()
+                );
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                bail!(
+                    "libkrun supervisor did not confirm boot within {:?}; see {}",
+                    crate::libkrun::PID_FILE_TIMEOUT,
+                    console_log.display()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        // The PID file means the supervisor is up, but it binds the per-port
+        // vsock listener a beat later. Wait for the agent socket so a console
+        // attach / shell_exec that immediately follows doesn't race a
+        // not-yet-bound socket and report the VM "not running".
+        let agent_socket = vm_vsock_port_socket_at(&state_dir, GUEST_AGENT_PORT);
+        let sock_deadline = Instant::now() + crate::libkrun::VSOCK_SOCKET_TIMEOUT;
+        while !agent_socket.exists() {
+            if let Some(status) = child
+                .try_wait()
+                .map_err(|e| anyhow!("poll supervisor: {e}"))?
+            {
+                bail!(
+                    "libkrun supervisor exited before binding vsock socket {} (status: {status}); see {}",
+                    agent_socket.display(),
+                    console_log.display()
+                );
+            }
+            if Instant::now() >= sock_deadline {
+                let _ = child.kill();
+                bail!(
+                    "libkrun supervisor did not bind vsock socket {} within {:?}; killed; see {}",
+                    agent_socket.display(),
+                    crate::libkrun::VSOCK_SOCKET_TIMEOUT,
+                    console_log.display()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        // Detach: dropping the `Child` does not kill it, so the supervisor
+        // outlives this call (reaped via its PID file by `kill`).
+        drop(child);
+
+        Ok(Box::new(LibkrunRunningVm {
+            id: VmId(spec.name.clone()),
+            state_dir,
+            pid_file,
+        }))
+    }
+
+    fn attach(&self, id: &VmId) -> Result<Box<dyn RunningVm>> {
+        // The handle is entirely disk-backed (the supervisor's pid file + the
+        // persisted workload-exit code under the VM's state dir), so reattaching
+        // is just re-deriving those paths — no live boot state to recover.
+        let state_dir = vm_state_dir(&id.0);
+        Ok(Box::new(LibkrunRunningVm {
+            pid_file: vm_libkrun_pid(&id.0),
+            state_dir,
+            id: id.clone(),
+        }))
+    }
+
+    fn guest_channel_info(&self, id: &VmId) -> Result<GuestChannelInfo> {
+        self.backend.guest_channel_info(id)
+    }
+}
+
+/// A live libkrun VM: the detached `mvm-libkrun-supervisor` tracked by its PID
+/// file, with the workload's exit code persisted under its state dir.
+struct LibkrunRunningVm {
+    id: VmId,
+    state_dir: PathBuf,
+    pid_file: PathBuf,
+}
+
+impl RunningVm for LibkrunRunningVm {
+    fn id(&self) -> &VmId {
+        &self.id
+    }
+
+    fn wait(&self) -> Result<VmExitStatus> {
+        Ok(crate::workload_wait::wait_for_workload_exit(
+            &self.state_dir,
+        ))
+    }
+
+    fn kill(&self) -> Result<()> {
+        // SIGTERM → grace → SIGKILL, the escalation LibkrunBackend::stop uses:
+        // SIGTERM gives libkrun a chance to close its virtio-blk fds, then
+        // SIGKILL if it ignores us within the grace window.
+        if let Some(pid) = crate::libkrun::read_pid(&self.pid_file)
+            && crate::libkrun::pid_alive(pid)
+        {
+            crate::libkrun::send_signal(pid, libc::SIGTERM);
+            let deadline = Instant::now() + crate::libkrun::STOP_TIMEOUT;
+            while Instant::now() < deadline && crate::libkrun::pid_alive(pid) {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            if crate::libkrun::pid_alive(pid) {
+                crate::libkrun::send_signal(pid, libc::SIGKILL);
+            }
+        }
+        let _ = std::fs::remove_file(&self.pid_file);
+        Ok(())
+    }
+
+    fn pause(&self) -> Result<()> {
+        bail!("libkrun does not support pause/resume")
+    }
+
+    fn resume(&self) -> Result<()> {
+        bail!("libkrun does not support pause/resume")
+    }
+
+    fn status(&self) -> Result<VmStatus> {
+        Ok(match crate::libkrun::read_pid(&self.pid_file) {
+            Some(pid) if crate::libkrun::pid_alive(pid) => VmStatus::Running,
+            _ => VmStatus::Stopped,
+        })
+    }
+
+    fn vsock_connect(&self, guest_port: u32) -> Result<Box<dyn DuplexStream>> {
+        // libkrun's per-port UDS convention: `<state_dir>/vsock-<port>.sock`
+        // (flat), resolved through the single source of truth shared with the
+        // host-side resolver — NOT HVF's nested `vsock/` convention. Restricted
+        // to the agent port and the dev-only console data ports (claim 15: a
+        // sealed prod boot registers no console listeners).
+        if guest_port != GUEST_AGENT_PORT && !dev_console_data_ports().any(|p| p == guest_port) {
+            bail!(
+                "libkrun driver vsock_connect supports only the agent port \
+                 ({GUEST_AGENT_PORT}) and dev console data ports ({}..={}); got {guest_port}",
+                CONSOLE_PORT_BASE + 1,
+                CONSOLE_PORT_BASE + 128,
+            );
+        }
+        let socket_path = vm_vsock_port_socket_at(&self.state_dir, guest_port);
+        let stream = std::os::unix::net::UnixStream::connect(&socket_path).with_context(|| {
+            format!("connect to libkrun vsock socket {}", socket_path.display())
+        })?;
+        Ok(Box::new(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::{ConsoleCapture, VsockPort};
+    use mvm_agentd::vsock::{BROKER_PORT, EGRESS_PORT, WORKLOAD_EXIT_PORT};
+
+    fn host_dials(guest_port: u32, uds: &str) -> VsockPort {
+        VsockPort {
+            guest_port,
+            host_uds: uds.into(),
+            direction: VsockDirection::HostDials,
+        }
+    }
+
+    fn guest_dials(guest_port: u32, uds: &str) -> VsockPort {
+        VsockPort {
+            guest_port,
+            host_uds: uds.into(),
+            direction: VsockDirection::GuestDials,
+        }
+    }
+
+    fn spec_with(kernel: KernelImage, vsock: Vec<VsockPort>, blocks: Vec<BlockDev>) -> VmmSpec {
+        VmmSpec {
+            name: "w".into(),
+            kernel,
+            initramfs: None,
+            cmdline: String::new(),
+            vcpus: 2,
+            memory_mib: 512,
+            mem_initial_mib: None,
+            blocks,
+            vsock,
+            console: ConsoleCapture {
+                log_path: "/tmp/console.log".into(),
+            },
+            trusted_builder: false,
+        }
+    }
+
+    fn relay(spec: &VmmSpec) -> SupervisorConfig {
+        relay_libkrun_supervisor_config(spec, Path::new("/state/w")).unwrap()
+    }
+
+    #[test]
+    fn identity_and_capabilities_delegate_to_the_libkrun_backend() {
+        let d = LibkrunDriver::new();
+        assert_eq!(d.name(), "libkrun");
+        assert_eq!(d.kind(), BackendKind::Libkrun);
+        let caps = d.capabilities();
+        assert!(caps.vsock);
+        assert!(caps.no_routable_guest_nic);
+        assert!(caps.host_vsock_proxy);
+        assert_eq!(d.snapshot_capability(), SnapshotCapability::DiskOnly);
+        assert_eq!(
+            d.security_profile().tier,
+            LibkrunBackend.security_profile().tier
+        );
+    }
+
+    #[test]
+    fn workload_base_bootargs_uses_the_hvc0_console_not_ttyama0() {
+        let d = LibkrunDriver::new();
+        let disk = d.workload_base_bootargs(false, true);
+        assert!(disk.contains("console=hvc0"), "got: {disk}");
+        assert!(!disk.contains("ttyAMA0"), "got: {disk}");
+        assert!(disk.contains("root=/dev/vda"), "got: {disk}");
+
+        // Verity / initramfs base: hvc0 console only, no root/init token.
+        let verity = d.workload_base_bootargs(false, false);
+        assert_eq!(verity, "console=hvc0");
+
+        // The virtiofs-root variant still uses hvc0, not the pl011 UART.
+        let virtiofs = d.workload_base_bootargs(true, false);
+        assert!(virtiofs.contains("console=hvc0"), "got: {virtiofs}");
+        assert!(!virtiofs.contains("ttyAMA0"), "got: {virtiofs}");
+        assert!(virtiofs.contains("rootfstype=virtiofs"), "got: {virtiofs}");
+    }
+
+    #[test]
+    fn guest_channel_info_delegates_to_the_libkrun_backend() {
+        // LibkrunBackend reports a fixed vsock agent channel; the driver must
+        // relay that same answer rather than inventing one.
+        let d = LibkrunDriver::new();
+        let id = VmId("libkrun-guest-channel-info-test-vm".into());
+        // GuestChannelInfo has no PartialEq; compare the Debug rendering to
+        // assert the driver relays the backend's channel verbatim.
+        assert_eq!(
+            format!("{:?}", d.guest_channel_info(&id).unwrap()),
+            format!("{:?}", LibkrunBackend.guest_channel_info(&id).unwrap())
+        );
+    }
+
+    #[test]
+    fn relay_config_leaves_every_role_field_inert() {
+        let spec = spec_with(
+            KernelImage::Path("/img/Image".into()),
+            vec![
+                host_dials(GUEST_AGENT_PORT, "/run/agent.sock"),
+                guest_dials(EGRESS_PORT, "/run/egress.sock"),
+            ],
+            vec![],
+        );
+        let cfg = relay(&spec);
+        // Role fields all inert — no admission, no policy, no audit substrate.
+        assert_eq!(cfg.tenant_id, None);
+        assert_eq!(cfg.plan, None);
+        assert_eq!(cfg.bundle, None);
+        assert_eq!(cfg.network_policy, None);
+        assert_eq!(cfg.audit_dir, None);
+        assert_eq!(cfg.gateway_audit_socket, None);
+        assert_eq!(cfg.gateway_events_socket, None);
+        assert_eq!(cfg.signing_key_path, None);
+        assert_eq!(cfg.transparent_terminator_port, None);
+        // Physical recipe carried through.
+        assert_eq!(cfg.krun.vcpus, 2);
+        assert_eq!(cfg.krun.ram_mib, 512);
+        assert_eq!(cfg.krun.kernel_path.as_deref(), Some("/img/Image"));
+        assert_eq!(cfg.vm_state_dir, "/state/w");
+        assert_eq!(cfg.pid_file_name, None);
+    }
+
+    #[test]
+    fn relay_config_maps_a_plain_rootfs_to_vda_and_extras_to_vdb() {
+        let spec = spec_with(
+            KernelImage::Path("/img/Image".into()),
+            vec![],
+            vec![
+                // Out of slot order to prove sorting.
+                BlockDev {
+                    source: "/img/data.img".into(),
+                    read_only: false,
+                    ephemeral: false,
+                    slot: 1,
+                },
+                BlockDev {
+                    source: "/img/rootfs.ext4".into(),
+                    read_only: true,
+                    ephemeral: false,
+                    slot: 0,
+                },
+            ],
+        );
+        let cfg = relay(&spec);
+        // No initramfs ⇒ slot 0 is the rootfs (/dev/vda), rest are extra disks.
+        assert_eq!(cfg.krun.rootfs_path.as_deref(), Some("/img/rootfs.ext4"));
+        assert_eq!(cfg.krun.initramfs_path, None);
+        assert_eq!(cfg.krun.extra_disks.len(), 1);
+        assert_eq!(cfg.krun.extra_disks[0].path, "/img/data.img");
+        assert!(!cfg.krun.extra_disks[0].read_only);
+    }
+
+    #[test]
+    fn relay_config_puts_every_block_in_extra_disks_for_an_initramfs_boot() {
+        let mut spec = spec_with(
+            KernelImage::Path("/img/Image".into()),
+            vec![],
+            vec![
+                BlockDev {
+                    source: "/img/rootfs.ext4".into(),
+                    read_only: true,
+                    ephemeral: false,
+                    slot: 0,
+                },
+                BlockDev {
+                    source: "/img/rootfs.verity".into(),
+                    read_only: true,
+                    ephemeral: false,
+                    slot: 1,
+                },
+            ],
+        );
+        spec.initramfs = Some("/img/initrd.cpio".into());
+        let cfg = relay(&spec);
+        // initramfs boot ⇒ no rootfs_path; slot 0 is the first extra disk (vda).
+        assert_eq!(cfg.krun.rootfs_path, None);
+        assert_eq!(cfg.krun.initramfs_path.as_deref(), Some("/img/initrd.cpio"));
+        let paths: Vec<&str> = cfg
+            .krun
+            .extra_disks
+            .iter()
+            .map(|d| d.path.as_str())
+            .collect();
+        assert_eq!(paths, vec!["/img/rootfs.ext4", "/img/rootfs.verity"]);
+    }
+
+    #[test]
+    fn relay_config_splits_vsock_ports_by_direction() {
+        let spec = spec_with(
+            KernelImage::Path("/img/Image".into()),
+            vec![
+                host_dials(GUEST_AGENT_PORT, "/run/agent.sock"),
+                guest_dials(EGRESS_PORT, "/run/egress.sock"),
+                guest_dials(WORKLOAD_EXIT_PORT, "/run/exit.sock"),
+                guest_dials(BROKER_PORT, "/run/broker.sock"),
+                host_dials(CONSOLE_PORT_BASE + 1, "/run/console.sock"),
+            ],
+            vec![],
+        );
+        let cfg = relay(&spec);
+        // HostDials → the host dials the guest's listeners (add_vsock_port).
+        assert!(cfg.krun.vsock_ports.contains(&GUEST_AGENT_PORT));
+        assert!(cfg.krun.vsock_ports.contains(&(CONSOLE_PORT_BASE + 1)));
+        // GuestDials → the host binds the listener the guest dials.
+        assert!(cfg.krun.host_listen_ports.contains(&EGRESS_PORT));
+        assert!(cfg.krun.host_listen_ports.contains(&WORKLOAD_EXIT_PORT));
+        assert!(cfg.krun.host_listen_ports.contains(&BROKER_PORT));
+        // Disjoint: neither set carries a port from the other direction.
+        assert!(!cfg.krun.vsock_ports.contains(&EGRESS_PORT));
+        assert!(!cfg.krun.host_listen_ports.contains(&GUEST_AGENT_PORT));
+    }
+
+    #[test]
+    fn relay_config_threads_a_non_empty_cmdline_and_defaults_an_empty_one() {
+        let mut spec = spec_with(
+            KernelImage::Path("/img/Image".into()),
+            vec![],
+            vec![BlockDev {
+                source: "/img/rootfs.ext4".into(),
+                read_only: true,
+                ephemeral: false,
+                slot: 0,
+            }],
+        );
+        // Non-empty (already carries the assembled base + tokens) ⇒ verbatim.
+        spec.cmdline = "  console=hvc0 root=/dev/vda rw init=/init mvm.vsock_egress=1  ".into();
+        let cfg = relay(&spec);
+        assert_eq!(
+            cfg.krun.kernel_cmdline.as_deref(),
+            Some("console=hvc0 root=/dev/vda rw init=/init mvm.vsock_egress=1")
+        );
+
+        // Empty + a disk ⇒ the driver's default disk base.
+        spec.cmdline = "   ".into();
+        let cfg = relay(&spec);
+        assert_eq!(
+            cfg.krun.kernel_cmdline.as_deref(),
+            Some(crate::libkrun::DEFAULT_CMDLINE)
+        );
+
+        // Empty + an initramfs (no disk root) ⇒ the console-only verity base.
+        spec.initramfs = Some("/img/initrd.cpio".into());
+        spec.blocks.clear();
+        spec.cmdline = String::new();
+        let cfg = relay(&spec);
+        assert_eq!(
+            cfg.krun.kernel_cmdline.as_deref(),
+            Some(crate::libkrun::VERITY_CMDLINE)
+        );
+    }
+
+    #[test]
+    fn relay_config_rejects_a_bundled_kernel() {
+        // libkrun's workload disk-boot path requires an explicit kernel; a
+        // bundled-kernel spec must not reach the supervisor.
+        let spec = spec_with(KernelImage::Bundled, vec![], vec![]);
+        assert!(relay_libkrun_supervisor_config(&spec, Path::new("/state/w")).is_err());
+    }
+
+    #[test]
+    fn relay_config_disables_the_guest_nic() {
+        let spec = spec_with(KernelImage::Path("/img/Image".into()), vec![], vec![]);
+        let cfg = relay(&spec);
+        assert!(matches!(
+            cfg.krun.networking,
+            libkrun_sys::NetworkingMode::VsockDirect
+        ));
+    }
+
+    #[test]
+    fn attach_builds_a_disk_backed_handle_that_reports_stopped_for_a_missing_vm() {
+        // Reattaching needs no boot state — it re-derives the state dir. A VM
+        // that never ran (or has exited) reports Stopped rather than erroring.
+        let vm = LibkrunDriver::new()
+            .attach(&VmId("libkrun-nonexistent-attach-test-vm".into()))
+            .unwrap();
+        assert_eq!(vm.id().0, "libkrun-nonexistent-attach-test-vm");
+        assert_eq!(vm.status().unwrap(), VmStatus::Stopped);
+    }
+
+    #[test]
+    fn vsock_connect_reaches_the_agent_socket_and_rejects_other_ports() {
+        use crate::test_support::bind_unix_listener;
+        use std::io::{Read, Write};
+
+        let dir = tempfile::tempdir().unwrap();
+        // The libkrun flat convention: <state_dir>/vsock-<port>.sock.
+        let sock = vm_vsock_port_socket_at(dir.path(), GUEST_AGENT_PORT);
+        let Some(listener) = bind_unix_listener(&sock) else {
+            return;
+        };
+        let server = std::thread::spawn(move || {
+            if let Ok((mut c, _)) = listener.accept() {
+                let mut b = [0u8; 1];
+                if c.read_exact(&mut b).is_ok() {
+                    let _ = c.write_all(&b);
+                }
+            }
+        });
+
+        let vm = LibkrunRunningVm {
+            id: VmId("agent-vm".into()),
+            state_dir: dir.path().to_path_buf(),
+            pid_file: dir.path().join("libkrun.pid"),
+        };
+
+        // The agent port connects + round-trips through the socket.
+        let mut s = vm.vsock_connect(GUEST_AGENT_PORT).unwrap();
+        s.write_all(b"x").unwrap();
+        let mut got = [0u8; 1];
+        s.read_exact(&mut got).unwrap();
+        assert_eq!(&got, b"x");
+        server.join().unwrap();
+
+        // A port outside the agent + console data range is not host-dialable.
+        assert!(vm.vsock_connect(GUEST_AGENT_PORT + 1).is_err());
+        assert!(vm.vsock_connect(9999).is_err());
+    }
+
+    #[test]
+    fn vsock_connect_reaches_a_dev_console_data_port() {
+        use crate::test_support::bind_unix_listener;
+        use std::io::{Read, Write};
+
+        let dir = tempfile::tempdir().unwrap();
+        let port = CONSOLE_PORT_BASE + 1;
+        let sock = vm_vsock_port_socket_at(dir.path(), port);
+        let Some(listener) = bind_unix_listener(&sock) else {
+            return;
+        };
+        let server = std::thread::spawn(move || {
+            if let Ok((mut c, _)) = listener.accept() {
+                let mut b = [0u8; 1];
+                if c.read_exact(&mut b).is_ok() {
+                    let _ = c.write_all(&b);
+                }
+            }
+        });
+
+        let vm = LibkrunRunningVm {
+            id: VmId("console-vm".into()),
+            state_dir: dir.path().to_path_buf(),
+            pid_file: dir.path().join("libkrun.pid"),
+        };
+
+        let mut s = vm.vsock_connect(port).unwrap();
+        s.write_all(b"y").unwrap();
+        let mut got = [0u8; 1];
+        s.read_exact(&mut got).unwrap();
+        assert_eq!(&got, b"y");
+        server.join().unwrap();
+
+        // The last console data port is in range; one past it is not.
+        assert!(vm.vsock_connect(CONSOLE_PORT_BASE + 129).is_err());
+    }
+}

--- a/crates/mvm-runtime/src/driver/mod.rs
+++ b/crates/mvm-runtime/src/driver/mod.rs
@@ -3,11 +3,13 @@
 //! runners above it.
 
 pub mod hvf;
+pub mod libkrun;
 pub mod mock;
 pub mod spec;
 pub mod traits;
 
 pub use hvf::HvfDriver;
+pub use libkrun::LibkrunDriver;
 pub use mock::{MockDriver, MockRunningVm};
 pub use spec::{BlockDev, ConsoleCapture, KernelImage, VmmSpec, VsockDirection, VsockPort};
 pub use traits::{DuplexStream, RunningVm, VmmDriver};

--- a/crates/mvm-runtime/src/libkrun.rs
+++ b/crates/mvm-runtime/src/libkrun.rs
@@ -130,14 +130,16 @@ fn validate_libkrun_network_policy(
 }
 
 /// How long [`LibkrunBackend::start`] waits for the supervisor to
-/// write its PID file before giving up and killing the child.
-const PID_FILE_TIMEOUT: Duration = Duration::from_secs(5);
+/// write its PID file before giving up and killing the child. Shared with
+/// the libkrun driver, which spawns the same supervisor binary.
+pub(crate) const PID_FILE_TIMEOUT: Duration = Duration::from_secs(5);
 /// After the PID file appears the supervisor still has to bind the
 /// per-port vsock listener socket; callers (the console attach,
 /// `shell_exec` via `connect_with_auto_start`) race that window and
 /// wrongly see the VM as "not running". `start` waits for the
-/// agent socket before returning so "ready" actually means reachable.
-const VSOCK_SOCKET_TIMEOUT: Duration = Duration::from_secs(10);
+/// agent socket before returning so "ready" actually means reachable. Shared
+/// with the libkrun driver's boot path.
+pub(crate) const VSOCK_SOCKET_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// How long [`LibkrunBackend::stop`] waits after `SIGTERM` before
 /// escalating to `SIGKILL`. Tight because libkrun's signal handling
@@ -148,8 +150,9 @@ const VSOCK_SOCKET_TIMEOUT: Duration = Duration::from_secs(10);
 /// (see `libkrun_sys::install_shutdown_handler`) still helps the
 /// shell-stop case where SIGTERM is delivered cleanly (~200 ms); in
 /// the always-escalate cargo-spawn / launchd path a shorter timeout
-/// means `mvmctl stop` returns in 2 s instead of 5 s.
-const STOP_TIMEOUT: Duration = Duration::from_secs(2);
+/// means `mvmctl stop` returns in 2 s instead of 5 s. Shared with the libkrun
+/// driver's `kill` escalation.
+pub(crate) const STOP_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Open the per-VM guest-console capture sink. OUTPUT-ONLY by
 /// construction (write-only, create+truncate): the guest console
@@ -170,8 +173,8 @@ pub(crate) fn open_console_capture(path: &std::path::Path) -> std::io::Result<st
 /// `console=hvc0` matches libkrun's virtio-console wiring;
 /// `root=/dev/vda rw init=/init` matches Apple Container's
 /// boot for the same Nix-built rootfs layout.
-const DEFAULT_CMDLINE: &str = "console=hvc0 root=/dev/vda rw init=/init";
-const VERITY_CMDLINE: &str = "console=hvc0";
+pub(crate) const DEFAULT_CMDLINE: &str = "console=hvc0 root=/dev/vda rw init=/init";
+pub(crate) const VERITY_CMDLINE: &str = "console=hvc0";
 
 /// Build the supervisor config for one VM, lifting
 /// the audit-substrate resolution into the shared `audit_substrate`
@@ -290,7 +293,7 @@ fn now_unix_secs() -> u64 {
         .unwrap_or(0)
 }
 
-fn libkrun_kernel_for_host(kernel: &str) -> Result<(String, KernelFormat)> {
+pub(crate) fn libkrun_kernel_for_host(kernel: &str) -> Result<(String, KernelFormat)> {
     let path = Path::new(kernel);
     if cfg!(target_arch = "x86_64") && path.exists() {
         let loadable = mvm_build::fc_kernel::ensure_fc_loadable_kernel(path)
@@ -1458,18 +1461,18 @@ pub(crate) fn resolve_supervisor_path() -> Result<PathBuf> {
     })
 }
 
-fn read_pid(path: &Path) -> Option<libc::pid_t> {
+pub(crate) fn read_pid(path: &Path) -> Option<libc::pid_t> {
     let s = std::fs::read_to_string(path).ok()?;
     s.trim().parse::<libc::pid_t>().ok()
 }
 
-fn pid_alive(pid: libc::pid_t) -> bool {
+pub(crate) fn pid_alive(pid: libc::pid_t) -> bool {
     // `kill(pid, 0)` returns 0 if the process exists (and the caller
     // has permission to signal it), -1 with errno=ESRCH if not.
     unsafe { libc::kill(pid, 0) == 0 }
 }
 
-fn send_signal(pid: libc::pid_t, sig: libc::c_int) {
+pub(crate) fn send_signal(pid: libc::pid_t, sig: libc::c_int) {
     unsafe { libc::kill(pid, sig) };
 }
 


### PR DESCRIPTION
Adds `LibkrunDriver: VmmDriver` (+ `LibkrunRunningVm`) mirroring `HvfDriver`, so libkrun can later route through `WorkloadRunner<LibkrunDriver, RealEndpointSpawner, RealBrokerRegistrar>`. **Dormant** — not wired into `AnyBackend`/catalog/`auto_select`, nothing deleted from `libkrun.rs`. The production flip, the egress-socket-path fix (f-1), and the console-data-port path reconciliation are separate follow-ups.

- Wraps `LibkrunBackend` for identity delegation (name/caps/kind/security_profile/guest_channel_info), like `HvfDriver` wraps `HvfBackend`.
- `workload_base_bootargs` returns libkrun's `console=hvc0` base (no pl011/`ttyAMA0`).
- `relay_libkrun_supervisor_config(spec)` reads only the NIC-less `VmmSpec` and sets **all role fields `None`** (`tenant_id`/`plan`/`bundle`/`network_policy`/audit+gateway sockets/`transparent_terminator_port`; `bridge_restart_policy: HardFail`) — role policy lives in the runner now. Slot-ordered disks, vsock split by direction (exhaustive), `Bundled` kernel rejected.
- `vsock_connect` uses libkrun's flat `<state_dir>/vsock-<port>.sock` convention (not HVF's nested one), restricted to the agent + dev-console ports.
- `LibkrunRunningVm` reuses libkrun's existing lifecycle primitives (`read_pid`/`pid_alive`/`send_signal`/`wait_for_workload_exit`) — the only `libkrun.rs` change is bumping those to `pub(crate)` (no bodies copied, no logic touched), mirroring HVF's already-shared equivalents.

Verified: `nextest -p mvm-runtime` 934 passed (13 new driver tests), clippy `-D warnings`, `x86_64-unknown-linux-gnu` cross-build, `check-vsock-only-egress` / `check-no-spec-refs-in-comments`.