### PR TITLE
feat(libkrun-sys): allow an explicit host UDS for a host-listen egress port

### DIFF
--- a/crates/deps/libkrun-sys/src/context.rs
+++ b/crates/deps/libkrun-sys/src/context.rs
@@ -56,6 +56,21 @@ pub struct KrunVirtioFs {
     pub host_path: String,
 }
 
+/// A per-port override for the host-side unix socket a host-listen
+/// vsock port pairs with, replacing the dir-derived
+/// `vsock-<port>.sock` path for that one port. See
+/// [`KrunContext::host_listen_socket_path`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct HostListenOverride {
+    /// The host-listen port this override applies to. Must also
+    /// appear in [`KrunContext::host_listen_ports`] for libkrun to
+    /// register it.
+    pub port: u32,
+    /// Host unix socket path libkrun should proxy guest connects on
+    /// `port` to, instead of the derived `vsock_socket_path(port)`.
+    pub socket_path: String,
+}
+
 /// Configuration for a libkrun guest VM.
 ///
 /// Pure data — no I/O until [`start`](crate::start) /
@@ -106,6 +121,13 @@ pub struct KrunContext {
     /// Disjoint from [`Self::vsock_ports`].
     #[serde(default)]
     pub host_listen_ports: Vec<u32>,
+    /// Per-port overrides of the host-listen socket path, for ports
+    /// that should proxy to an explicit UDS instead of the
+    /// dir-derived `vsock-<port>.sock` path. Empty by default — no
+    /// current construction site populates this; see
+    /// [`Self::host_listen_socket_path`].
+    #[serde(default)]
+    pub host_listen_port_overrides: Vec<HostListenOverride>,
     /// Additional virtio-blk devices, appearing as `/dev/vdb`,
     /// `/dev/vdc`, … in the order listed. Empty by default; the
     /// dev-VM builder VM uses one entry for the Nix-store overlay
@@ -258,6 +280,7 @@ impl KrunContext {
             kernel_cmdline: None,
             vsock_ports: Vec::new(),
             host_listen_ports: Vec::new(),
+            host_listen_port_overrides: Vec::new(),
             extra_disks: Vec::new(),
             virtio_fs_mounts: Vec::new(),
             console_output_path: None,
@@ -287,6 +310,7 @@ impl KrunContext {
             kernel_cmdline: None,
             vsock_ports: Vec::new(),
             host_listen_ports: Vec::new(),
+            host_listen_port_overrides: Vec::new(),
             extra_disks: Vec::new(),
             virtio_fs_mounts: Vec::new(),
             console_output_path: None,
@@ -325,6 +349,7 @@ impl KrunContext {
             kernel_cmdline: None,
             vsock_ports: Vec::new(),
             host_listen_ports: Vec::new(),
+            host_listen_port_overrides: Vec::new(),
             extra_disks: Vec::new(),
             virtio_fs_mounts: Vec::new(),
             console_output_path: None,
@@ -452,6 +477,46 @@ impl KrunContext {
     pub fn add_host_listen_port(mut self, port: u32) -> Self {
         self.host_listen_ports.push(port);
         self
+    }
+
+    /// Append a control vsock port the HOST listens on, AND pin its
+    /// host-side socket to an explicit `uds` path instead of the
+    /// dir-derived one. Equivalent to calling
+    /// [`Self::add_host_listen_port`] followed by
+    /// [`Self::set_host_listen_socket_override`].
+    pub fn add_host_listen_port_at(mut self, port: u32, uds: impl Into<String>) -> Self {
+        self.host_listen_ports.push(port);
+        self.set_host_listen_socket_override(port, uds);
+        self
+    }
+
+    /// Pin the host-side socket for an already-registered (or
+    /// about-to-be-registered) host-listen `port` to an explicit
+    /// `uds` path, overriding the dir-derived default. See
+    /// [`Self::host_listen_socket_path`] for the resolution order.
+    pub fn set_host_listen_socket_override(&mut self, port: u32, uds: impl Into<String>) {
+        self.host_listen_port_overrides.push(HostListenOverride {
+            port,
+            socket_path: uds.into(),
+        });
+    }
+
+    /// Resolve the host-side unix socket path for a host-listen
+    /// `port`: the last-registered [`HostListenOverride`] entry for
+    /// `port` if one exists, else the dir-derived
+    /// [`Self::vsock_socket_path`]. `None` overrides (the common
+    /// case today) make this byte-identical to calling
+    /// `vsock_socket_path` directly.
+    pub fn host_listen_socket_path(&self, port: u32) -> std::path::PathBuf {
+        match self
+            .host_listen_port_overrides
+            .iter()
+            .rev()
+            .find(|o| o.port == port)
+        {
+            Some(o) => std::path::PathBuf::from(&o.socket_path),
+            None => self.vsock_socket_path(port),
+        }
     }
 
     /// Attach an additional virtio-blk device. The first call appears
@@ -636,6 +701,7 @@ mod tests {
         let ctx: KrunContext = serde_json::from_str(json).unwrap();
         assert!(ctx.virtio_fs_mounts.is_empty());
         assert_eq!(ctx.kernel_format, KernelFormat::Raw);
+        assert!(ctx.host_listen_port_overrides.is_empty());
     }
 
     /// Roundtrip with virtio-fs entries populated — the JSON shape
@@ -669,5 +735,73 @@ mod tests {
     fn with_vsock_direct_switches_networking_mode() {
         let ctx = KrunContext::new("vm", "/k", "/r").with_vsock_direct();
         assert!(matches!(ctx.networking, NetworkingMode::VsockDirect));
+    }
+
+    /// Non-regression: a context with no overrides resolves
+    /// `host_listen_socket_path` to exactly the same path
+    /// `vsock_socket_path` returns today — byte-identical, not just
+    /// equal in shape.
+    #[test]
+    fn host_listen_socket_path_matches_derived_path_when_no_override() {
+        let ctx = KrunContext::new("vm-1", "/k", "/r")
+            .with_vsock_socket_dir("/home/user/mvm-home/vms/vm-1")
+            .add_host_listen_port(5253);
+        assert!(ctx.host_listen_port_overrides.is_empty());
+        assert_eq!(
+            ctx.host_listen_socket_path(5253),
+            ctx.vsock_socket_path(5253)
+        );
+    }
+
+    /// `add_host_listen_port_at` registers the port AND pins its
+    /// socket path; a different, non-overridden port keeps resolving
+    /// to the derived path.
+    #[test]
+    fn add_host_listen_port_at_registers_port_and_override() {
+        let ctx = KrunContext::new("vm-1", "/k", "/r")
+            .with_vsock_socket_dir("/d")
+            .add_host_listen_port_at(5253, "/run/mvm/egress-endpoint.sock")
+            .add_host_listen_port(5251);
+        assert!(ctx.host_listen_ports.contains(&5253));
+        assert_eq!(
+            ctx.host_listen_socket_path(5253),
+            std::path::PathBuf::from("/run/mvm/egress-endpoint.sock")
+        );
+        // The non-overridden port still resolves to the dir-derived path.
+        assert_eq!(
+            ctx.host_listen_socket_path(5251),
+            ctx.vsock_socket_path(5251)
+        );
+    }
+
+    /// `set_host_listen_socket_override` can be applied to a port
+    /// already registered via `add_host_listen_port` — the resolver
+    /// picks it up regardless of registration order.
+    #[test]
+    fn set_host_listen_socket_override_applies_to_registered_port() {
+        let mut ctx = KrunContext::new("vm-1", "/k", "/r")
+            .with_vsock_socket_dir("/d")
+            .add_host_listen_port(5253);
+        ctx.set_host_listen_socket_override(5253, "/run/mvm/egress-endpoint.sock");
+        assert_eq!(
+            ctx.host_listen_socket_path(5253),
+            std::path::PathBuf::from("/run/mvm/egress-endpoint.sock")
+        );
+    }
+
+    /// `KrunContext` serde roundtrip with `host_listen_port_overrides`
+    /// populated.
+    #[test]
+    fn host_listen_port_overrides_roundtrip_through_json() {
+        let ctx = KrunContext::new("vm-1", "/k", "/r")
+            .add_host_listen_port_at(5253, "/run/mvm/egress-endpoint.sock");
+        let json = serde_json::to_string(&ctx).unwrap();
+        assert!(json.contains("\"host_listen_port_overrides\""));
+        let back: KrunContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.host_listen_port_overrides.len(), 1);
+        assert_eq!(
+            back.host_listen_socket_path(5253),
+            std::path::PathBuf::from("/run/mvm/egress-endpoint.sock")
+        );
     }
 }

--- a/crates/deps/libkrun-sys/src/start.rs
+++ b/crates/deps/libkrun-sys/src/start.rs
@@ -225,7 +225,7 @@ pub(super) fn configure_pre_net(ctx: &KrunContext) -> Result<sys::Context, Error
         krun.add_vsock_port2(port, &socket, /* listen = */ true)?;
     }
     for &port in &ctx.host_listen_ports {
-        let socket = ctx.vsock_socket_path(port);
+        let socket = ctx.host_listen_socket_path(port);
         // listen=false: the host (supervisor) binds the listener; do NOT
         // pre-unlink — the supervisor created it. libkrun proxies guest
         // connects on `port` to that socket.

--- a/crates/deps/libkrun-sys/src/supervisor.rs
+++ b/crates/deps/libkrun-sys/src/supervisor.rs
@@ -151,6 +151,14 @@ pub struct SupervisorConfig {
     /// `:443` flows and forward them here.
     #[serde(default)]
     pub transparent_terminator_port: Option<u16>,
+    /// When set, the supervisor pins the guest egress port's host-side
+    /// socket to this explicit UDS instead of the dir-derived
+    /// `vsock-<port>.sock` path — see
+    /// `libkrun_sys::KrunContext::set_host_listen_socket_override`.
+    /// `None` (the default at every construction site today) leaves
+    /// the derived path unchanged; no current caller populates this.
+    #[serde(default)]
+    pub egress_relay_socket: Option<std::path::PathBuf>,
 }
 
 impl SupervisorConfig {
@@ -378,6 +386,7 @@ impl SupervisorConfig {
             network_policy: attach.network_policy,
             bridge_restart_policy: base.bridge_restart_policy,
             transparent_terminator_port: attach.transparent_terminator_port,
+            egress_relay_socket: None,
         })
     }
 }
@@ -633,6 +642,7 @@ mod tests {
             network_policy: None,
             bridge_restart_policy: BridgeRestartPolicy::HardFail,
             transparent_terminator_port: None,
+            egress_relay_socket: None,
         }
     }
 
@@ -756,6 +766,7 @@ mod tests {
             network_policy: None,
             bridge_restart_policy: BridgeRestartPolicy::HardFail,
             transparent_terminator_port: None,
+            egress_relay_socket: None,
         };
         let json = serde_json::to_string(&cfg_pre_w6a).unwrap();
         let parsed: SupervisorConfig =
@@ -766,6 +777,7 @@ mod tests {
         assert!(parsed.signing_key_path.is_none());
         assert!(parsed.plan.is_none());
         assert!(parsed.bundle.is_none());
+        assert!(parsed.egress_relay_socket.is_none());
         // But validate_audit_substrate must refuse it.
         assert!(parsed.validate_audit_substrate().is_err());
     }
@@ -799,6 +811,22 @@ mod tests {
             serde_json::from_str(json).expect("pre-W6.A.5 JSON must still parse");
         assert!(parsed.plan.is_none());
         assert!(parsed.bundle.is_none());
+        assert!(parsed.egress_relay_socket.is_none());
+    }
+
+    /// `SupervisorConfig` serde roundtrip with `egress_relay_socket`
+    /// populated — the JSON shape a future `LibkrunDriver` producer
+    /// will emit.
+    #[test]
+    fn supervisor_config_roundtrips_with_egress_relay_socket_populated() {
+        let mut cfg = well_formed_supervisor_config();
+        cfg.egress_relay_socket = Some(std::path::PathBuf::from(
+            "/run/mvm/vm-a/substitution-endpoint.sock",
+        ));
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        assert!(json.contains("\"egress_relay_socket\""));
+        let parsed: SupervisorConfig = serde_json::from_str(&json).expect("roundtrip");
+        assert_eq!(parsed.egress_relay_socket, cfg.egress_relay_socket);
     }
 
     #[test]

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -957,6 +957,7 @@ impl LibkrunBuilderVm {
             // they move onto the bridge.
             network_policy: None,
             transparent_terminator_port: None,
+            egress_relay_socket: None,
             // Builder VMs are always hard-fail; they don't model
             // long-running user workloads where a restart policy would
             // apply.
@@ -1138,6 +1139,7 @@ impl LibkrunBuilderVm {
             // they move onto the bridge.
             network_policy: None,
             transparent_terminator_port: None,
+            egress_relay_socket: None,
             // Builder VMs are always hard-fail; they don't model
             // long-running user workloads where a restart policy would
             // apply.
@@ -1649,6 +1651,7 @@ impl BuilderVm for LibkrunBuilderVm {
             // they move onto the bridge.
             network_policy: None,
             transparent_terminator_port: None,
+            egress_relay_socket: None,
             // Builder VMs are always hard-fail; they don't model
             // long-running user workloads where a restart policy would
             // apply.
@@ -1885,6 +1888,7 @@ impl VmBackendForBuilder for LibkrunBuilderBackend {
             // they move onto the bridge.
             network_policy: None,
             transparent_terminator_port: None,
+            egress_relay_socket: None,
             // Builder VMs are always hard-fail; they don't model
             // long-running user workloads where a restart policy would
             // apply.
@@ -4329,6 +4333,7 @@ impl LibkrunPersistentHostVm {
             // they move onto the bridge.
             network_policy: None,
             transparent_terminator_port: None,
+            egress_relay_socket: None,
             // Builder VMs are always hard-fail; they don't model
             // long-running user workloads where a restart policy would
             // apply.

--- a/crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs
@@ -155,11 +155,26 @@ fn main() -> ExitCode {
     dispatch_config(cfg)
 }
 
+/// When `cfg.egress_relay_socket` is set, pin the guest egress port's
+/// host-side socket to that explicit UDS instead of the dir-derived
+/// `vsock-<port>.sock` path. No-op when `None` (every construction
+/// site today) — the derived path is unchanged.
+fn apply_egress_relay_override(cfg: &mut SupervisorConfig) {
+    if let Some(sock) = cfg.egress_relay_socket.clone() {
+        cfg.krun.set_host_listen_socket_override(
+            mvm_agentd::vsock::EGRESS_PORT,
+            sock.to_string_lossy().into_owned(),
+        );
+    }
+}
+
 /// Shared tail: given a finalized `SupervisorConfig` (from the legacy stdin
 /// decode OR a verified prelaunch attach), bind the workload-exit control
 /// listener and route to the bridge/legacy boot path. Extracted so both
 /// entrypoints run identical post-config logic.
-fn dispatch_config(cfg: SupervisorConfig) -> ExitCode {
+fn dispatch_config(mut cfg: SupervisorConfig) -> ExitCode {
+    apply_egress_relay_override(&mut cfg);
+
     append_supervisor_breadcrumb(
         std::path::Path::new(&cfg.vm_state_dir),
         "dispatch_config",
@@ -655,7 +670,9 @@ fn append_supervisor_breadcrumb(vm_state_dir: &std::path::Path, stage: &str, det
 
 #[cfg(test)]
 mod tests {
-    use super::{append_supervisor_breadcrumb, should_use_bridge_route};
+    use super::{
+        append_supervisor_breadcrumb, apply_egress_relay_override, should_use_bridge_route,
+    };
     use libkrun_sys::{BridgeRestartPolicy, KrunContext, NetworkingMode, SupervisorConfig};
 
     fn sample_cfg(networking: NetworkingMode, tenant_id: Option<&str>) -> SupervisorConfig {
@@ -675,6 +692,7 @@ mod tests {
             network_policy: None,
             bridge_restart_policy: BridgeRestartPolicy::HardFail,
             transparent_terminator_port: None,
+            egress_relay_socket: None,
         }
     }
 
@@ -708,6 +726,40 @@ mod tests {
         assert!(
             should_use_bridge_route(&cfg),
             "gateway-backed admitted workloads must keep the bridge route"
+        );
+    }
+
+    #[test]
+    fn apply_egress_relay_override_pins_egress_port_when_set() {
+        let mut cfg = sample_cfg(NetworkingMode::Tsi, None);
+        cfg.krun = cfg
+            .krun
+            .add_host_listen_port(mvm_agentd::vsock::EGRESS_PORT);
+        cfg.egress_relay_socket = Some(std::path::PathBuf::from(
+            "/run/mvm/vm-1/substitution-endpoint.sock",
+        ));
+        apply_egress_relay_override(&mut cfg);
+        assert_eq!(
+            cfg.krun
+                .host_listen_socket_path(mvm_agentd::vsock::EGRESS_PORT),
+            std::path::PathBuf::from("/run/mvm/vm-1/substitution-endpoint.sock")
+        );
+    }
+
+    #[test]
+    fn apply_egress_relay_override_is_noop_when_unset() {
+        let mut cfg = sample_cfg(NetworkingMode::Tsi, None);
+        cfg.krun = cfg
+            .krun
+            .add_host_listen_port(mvm_agentd::vsock::EGRESS_PORT);
+        let derived = cfg
+            .krun
+            .host_listen_socket_path(mvm_agentd::vsock::EGRESS_PORT);
+        apply_egress_relay_override(&mut cfg);
+        assert_eq!(
+            cfg.krun
+                .host_listen_socket_path(mvm_agentd::vsock::EGRESS_PORT),
+            derived
         );
     }
 }

--- a/crates/mvm-runtime/src/driver/libkrun.rs
+++ b/crates/mvm-runtime/src/driver/libkrun.rs
@@ -172,8 +172,9 @@ fn relay_libkrun_supervisor_config(spec: &VmmSpec, state_dir: &Path) -> Result<S
         bridge_restart_policy: BridgeRestartPolicy::HardFail,
         // Pointing libkrun's egress proxy at the spawner's endpoint socket is a
         // follow-up before this dormant driver is wired; egress is not exercised
-        // yet, so the transparent terminator stays unset.
+        // yet, so both the transparent terminator and the egress relay stay unset.
         transparent_terminator_port: None,
+        egress_relay_socket: None,
     })
 }
 

--- a/crates/mvm-runtime/src/libkrun.rs
+++ b/crates/mvm-runtime/src/libkrun.rs
@@ -666,6 +666,7 @@ fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<S
         transparent_terminator_port: Some(crate::egress_redirect::terminator_port_for_vm_name(
             &config.name,
         )),
+        egress_relay_socket: None,
     })
 }
 
@@ -2184,6 +2185,7 @@ mod tests {
             network_policy: None,
             bridge_restart_policy: libkrun_sys::BridgeRestartPolicy::HardFail,
             transparent_terminator_port: None,
+            egress_relay_socket: None,
         };
         let json = serde_json::to_string(&cfg).expect("serialize");
         persist_supervisor_config_dump(dir.path(), &json).expect("persist supervisor config");

--- a/crates/mvm-runtime/tests/phase3c_supervisor_dispatch.rs
+++ b/crates/mvm-runtime/tests/phase3c_supervisor_dispatch.rs
@@ -92,6 +92,7 @@ fn supervisor_takes_bridge_path_when_tenant_id_some() {
         network_policy: None,
         bridge_restart_policy: libkrun_sys::BridgeRestartPolicy::HardFail,
         transparent_terminator_port: None,
+        egress_relay_socket: None,
     };
 
     let json = serde_json::to_string_pretty(&cfg).unwrap();
@@ -168,6 +169,7 @@ fn supervisor_takes_legacy_path_when_tenant_id_none() {
         network_policy: None,
         bridge_restart_policy: libkrun_sys::BridgeRestartPolicy::HardFail,
         transparent_terminator_port: None,
+        egress_relay_socket: None,
     };
 
     let json = serde_json::to_string_pretty(&cfg).unwrap();


### PR DESCRIPTION
Prerequisite for flipping libkrun onto the uniform `WorkloadRunner` seam (f-1). libkrun proxies a guest `connect(EGRESS_PORT)` to a host UDS whose path mvm derives (`<vsock_socket_dir>/vsock-<port>.sock`). The runner's `RealEndpointSpawner` binds the endpoint at a different path (`substitution-endpoint.sock`), so a runner-driven libkrun would proxy egress to the wrong socket. The `krun_add_vsock_port2` FFI already takes an explicit path, so this adds a clean, **non-regressive** override:

- `KrunContext` gains `host_listen_port_overrides` + `add_host_listen_port_at` / `set_host_listen_socket_override` / `host_listen_socket_path`. `libkrun-sys` stays port-agnostic (no `EGRESS_PORT` reference). `start.rs` resolves the host-listen loop via `host_listen_socket_path` (derived path when no override — byte-identical to today).
- `SupervisorConfig.egress_relay_socket: Option<PathBuf>`; the supervisor bin applies it for `EGRESS_PORT` in `dispatch_config` (covers cold + warm/prelaunch).
- Every `SupervisorConfig` literal defaults the field to `None` → **derived path, unchanged**. Nothing sets the override yet; the `LibkrunDriver` flip populates it (out of scope here).

Verified: `nextest -p libkrun-sys -p mvm-runtime` 998 passed (incl. a byte-identical non-regression test + serde back-compat), clippy `-D warnings` (with an extra `--features libkrun-sys` pass for the feature-gated bin), `mvm-build` build, `x86_64-unknown-linux-gnu` cross-build, `check-no-spec-refs-in-comments`.