### PR TITLE
docs(research): scratch-backlog analysis notes

### DIFF
--- a/specs/research/complexity-simplification-analysis.md
+++ b/specs/research/complexity-simplification-analysis.md
@@ -1,0 +1,133 @@
+# Complexity & Simplification Analysis (fresh hotspot hunt)
+
+Grounded pass over `main` (worktree read from `/Users/auser/work/tinylabs/mvmco/mvm`).
+Complements the in-flight `specs/refactor/` plan of record — it does **not** restate it.
+Every hotspot is tagged **NEW** (not yet a workstream deliverable) or **TRACKED**
+(already owned by a `specs/refactor/` WS; listed only to point at the concrete files).
+
+## What the existing plan already owns (do not re-plan these)
+
+Read `specs/refactor/{01-goals,02-architecture,06-execution-plan,07-progress-and-decisions,09-closeout}.md` first. The relevant already-tracked items:
+
+- **File size >1500 production lines — DONE.** `xtask check-file-size` (`MAX_PROD_LINES = 1500`) is green and CI-wired. The 39 → 0 target is met; the 7149-line `libkrun_builder.rs` and 4287-line `mvm-host-vm-init.rs` pass because their *production* bodies are small and the rest is trailing `#[cfg(test)]`. WS8.
+- **String backend dispatch — DONE.** `VmBackend::kind() -> BackendKind`; `check-no-string-backend-dispatch` guards it. WS6.
+- **CLI top-level dispatch** is already a thin `TopLevelCommand` trait + 33-arm match (`crates/mvm-cli/src/commands/dispatch.rs`), one arm per verb delegating to a module `run`. The full per-command `Command`-trait redesign + verb consolidation is WS7 (not started).
+- **Networking sprawl is TRACKED (WS1d + WS-NET).** `mvm-net` is a near-empty seam (`enforcement.rs` 108, `provider.rs` 103, `registry.rs` 132, `lib.rs` 27) while the implementation still lives in `mvm-hostd`: `supervisor/substitution_proxy.rs` (2972), `supervisor/aggregate.rs` (2695), `smoltcp_egress.rs` (2250), `network_tunnel.rs` (1648). The two-egress-model collision is also WS-NET. Not re-listed below.
+- **Feature `#[cfg]` sprawl — partly TRACKED (WS5 surface done; WS10 dep cut).** 460 `#[cfg(feature …)]` sites remain (goal doc measured 396); worst files `mvm-build/src/rootfs.rs` (32), `qemu_builder.rs` (27), `pipeline/dev_build.rs` (24). Surface collapsed to `host`/`user`; the in-file `builder-vm` gating remains.
+- **Single host+guest binary / no fork-exec — TRACKED (WS2).** Hotspot H2 below is the one independently-landable slice of it.
+
+Everything under the numbered hotspots and Quick Wins below is **NEW** or a
+concrete, not-yet-scoped filling of an existing WS.
+
+---
+
+## Prioritized hotspots (highest impact first)
+
+### H1 — Builder-backend duplication + triple parallel abstraction  **NEW** (home: WS1f "slim the builder pipeline")
+
+The largest single duplication surface in the tree, and it has **already drifted**
+(the canonical failure mode this repo warns about). Three concrete symptoms:
+
+1. **`validate_shell_job` copy-pasted and drifted.** `crates/mvm-build/src/qemu_builder.rs:792` (free fn) and `crates/mvm-build/src/libkrun_builder.rs:1325` (method) validate the identical `BuilderShellJob` contract with near-identical bodies — except libkrun added `ensure_utf8_path(&job.work_dir…)` / `ensure_utf8_path(&disk.path…)` guards and qemu did not. The qemu path silently accepts non-UTF-8 paths the libkrun path rejects. `mvm-runtime/src/builder_runner/hvf_builder.rs:83` calls a *third* `validate_shell_job`.
+
+2. **`run_shell_script` re-implemented three ways** for one shell-job contract (`/work` in, `/out` out, `/job/cmd.sh` run by `mvm-host-vm-init`): `libkrun_builder.rs:997` (240 lines), `qemu_builder.rs:605` `run_shell_script_qemu` (185), `hvf_builder.rs:83`. Each independently: validates the job, acquires the nix-store image lock, stages the job dir, launches its VMM, reads the job result, maps exit codes. Only the VMM-launch middle differs.
+
+3. **Small helpers duplicated + drifted.** `fn unique_job_id()` exists in both `hvf_builder.rs:157` (`format!("{pid}-{nanos}")`, nanoseconds) and `libkrun_builder.rs:2775` (`format!("{now:013}-{pid}")`, milliseconds) — **different field order and time unit** for the "same" id. `fn tail(s,n)` is byte-duplicated at `qemu_builder.rs:551` and `mvm-runtime/src/qemu.rs:930`. `pack_ext4`/`extract_out_artifacts`/`dir_stats`/`io_err` in `qemu_builder.rs` have libkrun analogues.
+
+On top of the duplication there are **three parallel builder abstractions**: the `BuilderVm` trait (`mvm-build/src/builder_vm.rs:341`, impls: Libkrun/Qemu/Persistent/Stub/Hvf, the last one in a *different crate*), `MicrovmArtifactBuilder` (`mvm-runtime/src/artifacts/traits.rs:71`), and the `BuilderRunner`/`VmmDriver` seam (`HvfDriver`). Three trait vocabularies for "run a build in a VM."
+
+Proposal:
+- Lift the shell-job orchestration (validate → lock → stage → run → read-result → map-exit) into a single `builder_vm` module function parameterised by a `fn(&BuilderShellJob) -> VmLaunch` seam, or make it a **default method** on `BuilderVm` with backends supplying only `launch_vmm`. Delete the three `run_shell_script` bodies.
+- Make `validate_shell_job`, `unique_job_id`, `tail`, `io_err`, `pack_ext4`, `extract_out_artifacts` **single shared fns** in `mvm-build` (drop the copies; the `hvf_builder` copies in `mvm-runtime` import them — the types already cross the crate boundary, e.g. `hvf_builder` already uses `mvm_build::libkrun_builder::BuilderShellJob`).
+- Collapse `BuilderVm` + `MicrovmArtifactBuilder` into one trait (they both mean "produce `BuilderArtifacts` from a `BuilderJob`").
+
+Impact: removes the highest-drift-risk duplication in the codebase and gives WS1f (currently a one-line "slim the builder pipeline" with no content) a concrete deliverable.
+
+### H2 — Aux-binary path resolution hand-rolled at every spawn site despite a central resolver  **NEW** (independently landable slice of WS2)
+
+`crates/mvm-runtime/src/aux_bin.rs` already centralises helper-binary resolution:
+`resolve(&AuxBin{ bin, env_var })` does override-env → `MVM_AUX_BIN_DIR` → exe-dir →
+`target/{release,debug}`, with a proper missing-binary error. But it is `pub(crate)`
+in `mvm-runtime`, so **every other spawn site re-implements the override leg inline**:
+
+- `crates/mvm-runtime/src/hvf_backend.rs:299` — `env::var_os("MVM_HVF_SUPERVISOR_PATH")…`
+- `crates/mvm-runtime/src/microvm/egress_bridge.rs:82` (`MVM_PASST_PATH`) and `:138` (`MVM_BRIDGE_PATH`)
+- `crates/mvm-build/src/libkrun_builder.rs:418` (`MVM_SUBSTITUTION_ENDPOINT_PATH`) and `:3237` (`MVM_LIBKRUN_SUPERVISOR_PATH`)
+- `crates/mvm-runtime/src/substitution_spawn.rs:425`, `crates/mvm-runtime/src/broker_services_spawn.rs` (`MVM_AUDIT_SIGNER_PATH`/`MVM_BROKER_PATH`)
+
+29 `env::var*("MVM_*_(PATH|BIN)")` sites total. The set of aux binaries is a fixed,
+knowable list (`mvm-hvf-supervisor`, `mvm-libkrun-supervisor`, `mvm-substitution-endpoint`,
+`mvm-broker`, `mvm-audit-signer`, `mvm-host-signer`, passt, bridge, gateway).
+
+Proposal: promote `AuxBin` + `resolve` to a shared location (`mvm-core` or its own leaf),
+make the aux-bin set a single `enum AuxBinary { … }` with `bin()`/`env_var()`, and route
+every spawn site through `aux_bin::resolve(AuxBinary::X)`. Each `MVM_*_PATH` string then
+appears exactly once. Lands ahead of, and shrinks, WS2.
+
+### H3 — `cache prune` is a 492-line mega-sweep of copy-pasted step handlers  **NEW** (complements WS7)
+
+`crates/mvm-cli/src/commands/ops/cache.rs:182 fn run` is the largest non-test function
+in the tree (492 lines). The `CacheAction::Prune` arm is a flat sequence of ~8 independent
+sweep steps — orphaned VM helpers, template slots, Stage-0 staging dirs, flow-byte-log,
+standby pool, checkpoints, expired packs, pack versions — each an inline
+`match sweep(…) { Ok(n) => removed += n, Err(e) => ui::warn(…) }` block (lines 178, 214,
+250, 280, 305, 331, 341, 370, …). The Ok/Err/warn boilerplate is copy-pasted per step and
+each step reaches into a different subsystem, so none is independently testable.
+
+Proposal: a `trait PruneStep { fn name(&self) -> &str; fn run(&self, dry_run: bool) -> Result<Reclaimed>; }`,
+one impl per subsystem, iterated by a single loop that owns the `warn`-on-error + totals
+accounting. Collapses the 492-line fn to a table + a ~15-line driver and makes each sweeper
+unit-testable. WS7 folds `cache prune`/`pack prune`/`storage gc` into `env cleanup`/`env reset`;
+this is the refactor that makes that fold trivial.
+
+### H4 — Repeated `io::Error` → domain-error wrapping: 132 verbatim closures  **NEW**
+
+`BuilderVmError::ExtractionFailed(format!("<op> {}: {e}", path.display()))` (and its
+`NixBuildFailed` sibling) appears **132 times** across `mvm-build`, 80 of them in
+`libkrun_builder.rs` alone (`builder_vm_runtime.rs` 27, `qemu_builder.rs` 11). One backend
+already factored it — `qemu_builder.rs:556 fn io_err(ctx, path, e) -> BuilderVmError` — but
+the helper is local and unused by the other 120 sites.
+
+Proposal: promote `io_err` to the crate root (or an `IoCtx` extension trait
+`io::Result<T>::ctx(op, path)`), convert the 132 sites. Pure mechanical line-count reduction
+(~2–4 lines → 1 per site) that also erases the incidental drift between which sites map to
+`ExtractionFailed` vs an ad-hoc `format!`.
+
+### H5 — Two parallel backend enums with duplicated string round-trips  **NEW (minor)**
+
+WS6 removed `backend.name() == "…"` dispatch, but two independent enums each keep their own
+name↔string codec: runtime `BackendKind` and `BuilderBackendChoice`
+(`mvm-build/src/builder_backend_select.rs:93` name arm, `:144` parse arm — `"libkrun"`/`"qemu"`/`"hvf"`).
+`"libkrun"|"hvf"|"firecracker"|"qemu"` literals recur across 20 files. This is not the
+banned dispatch pattern (each enum has one parse fn), but it is a parallel-enum smell: the
+builder backend set is a subset of the workload backend set expressed as a separate type.
+Fold into the `H1` builder consolidation — one `BackendKind` with a `builder_capable()`
+predicate rather than a second enum.
+
+---
+
+## High-value quick wins (each an independent small PR)
+
+1. **Dedupe `tail(s,n)`.** `crates/mvm-build/src/qemu_builder.rs:551` is byte-identical to `crates/mvm-runtime/src/qemu.rs:930` (the latter adds an `n==0` guard). Move one copy to a shared util (or `mvm-core`), delete the other.
+
+2. **Unify `unique_job_id()` and kill the format drift.** `hvf_builder.rs:157` emits `"{pid}-{nanos}"` (ns); `libkrun_builder.rs:2775` emits `"{now:013}-{pid}"` (ms) — different unit *and* field order for the same-named id. Pick one, export it, delete the other. This is a latent bug, not just tidiness (any code that parses a job id by position breaks across backends).
+
+3. **Reconcile `validate_shell_job`.** Make `qemu_builder.rs:792` and `hvf_builder.rs`'s copy call the same fn as `libkrun_builder.rs:1325`, closing the missing-`ensure_utf8_path` gap on the qemu path (a real validation divergence today).
+
+4. **Route the three easiest aux-bin lookups through `aux_bin::resolve`.** Bump `aux_bin::{AuxBin,resolve}` visibility and convert `hvf_backend.rs:299`, `egress_bridge.rs:82`, `egress_bridge.rs:138`. Removes three hand-rolled `env::var_os` override blocks; a down-payment on H2.
+
+5. **Introduce `io_err`/`.ctx()` and convert `libkrun_builder.rs`'s 80 wrappers.** Single file, mechanical, ~150-line reduction; promotes the existing `qemu_builder.rs:556` helper.
+
+6. **Fix stale plan-of-record facts.** `specs/refactor/07-progress-and-decisions.md:31` lists `mvm-verify` in "Current crate set (14)", but it was absorbed into `mvm_protocol::verify` and is **not** a workspace member (`Cargo.toml`). The same doc's `egress_server.rs` "parked/dead" bullet (`:39`) is also stale — the module no longer exists in the tree. Two one-line corrections keep the SoT honest.
+
+7. **Make `OutputFormat::from_str_arg` fail loudly.** `crates/mvm-cli/src/output.rs:19` maps any unrecognised `--output` value to `Self::Table` via `_ => Self::Table`, so `--output jsonn` silently prints a table instead of erroring. Convert to `FromStr` with an explicit error (and let clap validate). Small correctness win, removes a silent stringly fallthrough.
+
+8. **Resolve the `DmsetupBackend` stub cluster.** `crates/mvm-runtime/src/storage/backend.rs:116–179` has 8 methods returning `"…phase-2 work…"`. The read path (`storage info`/`gc`) is live (per WS8 notes) but the create/mutate path is an unimplemented stub. Either wire it or delete `DmsetupBackend` and keep only the live read surface — before WS8's "0 dead modules" gate reaches it.
+
+---
+
+## Method / evidence notes
+
+- Function sizes measured by brace-matched span over `crates/ xtask/ src/` (excluding the vendored `.mvm-test/cargo` registry). Only one non-test fn exceeds 400 lines (`cache.rs:182`, 492); the rest of the top of the distribution is data tables (`threat_classifier.rs:426 literal_patterns`, 396) or already-decomposed backend `start`/`run_build` bodies (~200–330). WS8's decomposition largely holds.
+- Duplication was confirmed by reading both bodies, not by name-match alone (H1.1, QW1, QW2 all verified drifted or byte-identical in-place).
+- Crate count grounded against `Cargo.toml` workspace members: 14 non-fuzz library/bin crates + root + `xtask` (mvm-verify absent).

--- a/specs/research/control-data-plane-and-provable-chains.md
+++ b/specs/research/control-data-plane-and-provable-chains.md
@@ -1,0 +1,253 @@
+# Control/data-plane separation and provable chains of content & execution
+
+Grounded research note. Answers two questions from `specs/scratch.md:15` and
+`specs/scratch.md:19`:
+
+1. Does mvm have a cleanly separated control plane and data plane?
+2. Are merkle / mathematically-provable chains of content and execution already
+   covered, and where would an explicit merkle structure add value the current
+   mechanisms don't?
+
+All claims cite real code (`file:line`). Reading was done against the main
+checkout; nothing here proposes a specific patch, only maps what exists and
+where a bounded, dependency-light gap remains.
+
+---
+
+## Q1 — Control plane vs data plane
+
+### Verdict up front
+
+mvm has a **clean conceptual separation that is enforced by verb class and a
+disjoint vsock port map, not by physically distinct transports.** Both planes
+funnel through host-mediated vsock chokepoints — that funnel, not wire
+separation, is the actual security property (the "vsock-only auditable data
+plane" invariant). There are exactly two places where control and data ride the
+same channel; both are known, documented, and backstopped.
+
+### The unifying fact: there is no guest-native NIC
+
+Every guest I/O path — control RPC, workload egress, port-forward, console — is
+a host-mediated vsock service. HVF is vsock-only; libkrun/Firecracker route
+their virtio-net through a host gateway rather than giving the guest an
+unmediated route. Consequently **every byte of both planes crosses a host
+enforcement/substitution/audit seam.** The planes are separated by *port and
+verb*, and made auditable by *transport*.
+
+### Plane-boundary map
+
+Fixed vsock port map (`crates/mvm-agentd/src/vsock/mod.rs:90-135`):
+
+| Port / range | Channel | Plane | Enforcement seam | Cite |
+|---|---|---|---|---|
+| 5251 | workload exit-code report (`/init` → host) | control | one-shot i32, host binds listener | `vsock/mod.rs:96` |
+| 5252 | guest-agent control RPC (`GuestRequest`/`GuestResponse`) | **control + data (mixed)** | verb-grant + profile gate | `vsock/mod.rs:90` |
+| 5253 | host egress gateway (single egress chokepoint) | data | claim-10 allow/deny + claims-12/13 credential substitution | `vsock/mod.rs:98-106` |
+| 5300 | host-services broker (`ServiceCall`/`ServiceResponse`) | control | binding-gated dispatch, server-minted correlation id | `vsock/mod.rs:108-122` |
+| `NETWORK_TUNNEL_PORT` | guest-TUN ↔ host-worker packet tunnel | data | smoltcp L3 forward on host | `vsock/mod.rs:124-128` |
+| 10000+ | TCP port-forward | data | host proxy allowlist | `vsock/mod.rs:130-132` |
+| 20000+ | interactive console PTY | data (dev-only) | `interactive` feature + sealed-VM gate (claim 15) | `vsock/mod.rs:134-142` |
+
+The port ranges are asserted disjoint so the host-side proxy allowlist keeps a
+"disjoint-union" shape (`vsock/mod.rs:151-153`, test at `:217-229`).
+
+### Control-plane inventory
+
+- **ExecutionPlan admission.** `synthesize_plan` → `sign_plan` (Ed25519 over
+  canonical-JSON plan, `crates/mvm-core/src/plan/signing.rs:58-66`) → verify →
+  validity window + per-signer nonce replay store
+  (`crates/mvm-core/src/plan/validity.rs:125-167`) → dispatch. This is the
+  admission control plane (claim 8).
+- **Chain-signed audit log.** `AuditEmitter`
+  (`crates/mvm-hostd/src/audit/emitter.rs:61`) emits
+  `plan.admitted`/`plan.launched`/`plan.failed`/`plan.oci_provenance`/
+  `checkpoint.*`/`verb_denied`/`plan.grant_required` into per-tenant
+  `~/.mvm/audit/<tenant>.jsonl` via `FileAuditSigner`
+  (`crates/mvm-hostd/src/supervisor/audit_file.rs`). This is the tamper-evident
+  spine of the control plane (detail in Q2).
+- **Host-services broker.** UDS + vsock 5300; length-prefixed JSON
+  `ServiceCall`, **cap-checked before parse**, correlation id **reassigned
+  server-side at ingress** so a guest can't collide with the audit chain
+  (`crates/mvm-hostd/src/broker/server.rs:78-141`). Binding-gated dispatch
+  (claims 12/13); the guest-supplied id is never trusted.
+- **Guest-agent RPC (5252).** `GuestRequest`/`GuestResponse` over
+  authenticated frames, with a verb-grant layer and a
+  `RequestClass::{ProdSafe,DevOnly,BuilderOnly}` profile gate
+  (`crates/mvm-agentd/src/vsock/request_policy.rs:16-171`). `SealedProd` admits
+  only `ProdSafe` verbs; the dev-only data verbs are refused before the handler
+  runs, and additionally excluded at compile time (`do_exec`/`RunCode`/console
+  gated by the `interactive` feature — claims 4/15).
+
+### Data-plane inventory
+
+- **Egress (5253).** The single host-mediated chokepoint. Default-deny is the
+  type default: `NetworkPolicy::default() == deny_all()`
+  (`crates/mvm-net/src/lib.rs:11-14`, `crates/mvm-net/src/enforcement.rs:8-9`),
+  and an unwired enforcer **fails closed** — `EnforcementError::NotWired` rather
+  than silent open egress (`crates/mvm-net/src/enforcement.rs:31-40`, `:60-74`).
+  Firecracker self-enforces via nftables; libkrun goes through the
+  gateway-bridge `PlanFlowPolicy` (ADR-001 tier matrix,
+  `specs/adrs/001-microvm-security-posture.md:218-222`).
+- **Packet tunnel / port-forward / console** carry user payload bytes and are
+  data-plane by construction.
+- **`TrafficPlane` verb classification.** The agent wire enum tags every verb
+  `Control` or `Data`
+  (`crates/mvm-agentd/src/vsock/response.rs:375-437`): `Exec`, `ExecBatch`,
+  `RunEntrypoint`, `Fs{Read,Write,List}`, `FsDiff`, `ProcSendInput`,
+  `ProcWait`, `RunCode` are `Data`; lifecycle/status/mount/console-setup are
+  `Control`. The doc is explicit that this "drives dispatch capacity and audit
+  handling; it is independent of the prod/dev profile gate"
+  (`response.rs:372-379`).
+
+### Where control and data mix (the two honest exceptions)
+
+1. **The agent RPC channel (5252) is dual-plane on one socket.**
+   `RunEntrypoint` (Data) and `Ping`/lifecycle (Control) share the same
+   authenticated frame stream; `Exec`/`Fs*`/`Proc*`/`RunCode` (Data) also ride
+   it in dev. The `TrafficPlane` enum exists precisely because these are not
+   physically separated — it re-derives the plane from the verb. Mitigation:
+   under `SealedProd` every Data verb except `RunEntrypoint` is profile-gated
+   off (`request_policy.rs:96-152`, `:162-171`) and symbol-excluded from the
+   sealed build, so a sealed workload's agent channel is control-plus-entrypoint
+   only. **Separation here is enforced by profile + compile-time symbol
+   absence, not by transport.**
+
+2. **Broker / egress / DNS as covert-egress surface (the Cardoso / claim-10
+   concern).** The broker channel (5300), the egress gateway (5253), and the
+   deny-all control-plane carve-outs (DHCP/ARP/ND) are all host-mediated paths a
+   hostile guest could try to abuse as a low-bandwidth exfil side channel.
+   This is documented, not unmanaged:
+   - ADR-020 states the broker channel "carries no per-frame cryptographic
+     authentication; ... the identity guarantee ... rests entirely on
+     process/socket topology, not on a signature"
+     (`specs/adrs/020-host-services-broker.md:192`).
+   - Claim 13 guarantees no raw secret value ever crosses the broker channel
+     (`specs/adrs/001-microvm-security-posture.md:136`).
+   - The default-deny proxy plus leak-scan is the named backstop against the
+     "non-cooperative side channel"
+     (`specs/adrs/023-secrets-subsystem-egress-substitution.md:134`).
+   - Deny-all means deny-all even for control-plane link-bringup: DHCP is
+     dropped with no carve-out; the guest self-assigns a static fallback
+     (`specs/adrs/001-microvm-security-posture.md:224-236`).
+
+### Q1 conclusion
+
+The planes are cleanly *modeled* (explicit `TrafficPlane`, disjoint port map,
+fail-closed egress seam) and cleanly *separated in the sealed-prod profile*. They
+are **not** separated onto distinct transports — the agent socket is dual-plane,
+and several host-mediated control/egress paths converge as a covert-egress
+surface. That surface is a known, documented, leak-scanned concern rather than a
+defect. **No restructuring is warranted;** the honest posture statement is
+"one vsock transport family, plane-separated by verb class and port, made safe
+by the host-mediated-only invariant + default-deny + leak-scan," not "two
+physically isolated planes."
+
+---
+
+## Q2 — Provable chains of content and execution
+
+### What provability already exists
+
+Four independent cryptographic mechanisms already ship, each a real
+merkle-or-hash-chain construction:
+
+| Mechanism | Structure | Proves | Cite |
+|---|---|---|---|
+| dm-verity roothash | **Merkle tree** over rootfs data blocks, SHA-256, salted | any block tamper panics the kernel before userspace (claim 3); also the content-addressed image id | `crates/mvm-fs/src/ext4/verity.rs:26-58` (`root_hash`), `:73-131` (`format` emits full tree) |
+| Chain-signed audit log | **hash-linked list** — each line commits `sha256(prev line)` + Ed25519 over `json(entry)‖prev_hash` | append-only tamper-evidence of the execution event history; reorder/edit/delete all break it | `crates/mvm-hostd/src/supervisor/audit_file.rs:31-44`, `verify_audit_chain:213-266` |
+| Content-addressed signed bundle | manifest lists every artifact + SHA-256; detached Ed25519 sig; `key_id = sha256(pubkey)` looked up out-of-band | published workload artifacts are content-addressed, key-pinned, re-verified at fetch and admit (claim 9) | `crates/mvm-core/src/plan/bundle.rs:13-55`, `key_id_from_pubkey:83-87` |
+| Signed ExecutionPlan | Ed25519 over canonical-JSON plan + validity window + per-signer nonce replay store | plan authenticity + freshness/replay resistance (claim 8) | `crates/mvm-core/src/plan/signing.rs:58-66`, `validity.rs:125-167` |
+
+The audit verifier is even re-implemented byte-for-byte as `#![no_std]`/wasm so
+anyone can verify a downloaded log in a browser with no host and no server trust
+(`crates/mvm-protocol/src/verify.rs:169-236`); a supervisor-side test pins the
+two implementations equivalent (`audit_file.rs:366-400`).
+
+So the primitives the scratch note asks about — merkle trees, hash chains,
+content addressing — **are already in the codebase and already load-bearing.**
+There is no need for a new merkle library, and no need for UOR / veilid
+dependencies to obtain them (limit-dependencies, no-lock-in).
+
+### The one real gap: the checkpoint lineage is not hash-linked
+
+The scratch note's specific ask is narrower than "do we have merkle trees": it
+wants **"checkpoints where we can rewind to previous sessions, microvms, and
+revert with a single lookup"** — i.e. a content-addressed, provable *DAG of
+checkpoints spanning multiple runs*. That is the one thing the four mechanisms
+above do **not** provide.
+
+`CheckpointMeta` (`crates/mvm-core/src/checkpoint.rs:52-68`) already carries the
+skeleton of a DAG:
+
+- `parent: Option<CheckpointId>` — a single-parent lineage pointer, so a tree
+  already exists structurally (fork emits parent/child ids into the audit chain:
+  `crates/mvm-hostd/src/audit/emitter.rs:290-306`).
+- `content: Vec<ContentBlob>` where each blob is `{ name, sha256 }` — a
+  per-artifact content manifest (`checkpoint.rs:40-46`).
+- `supervisor_config_digest` and `audit_ref` — a config hash and a back-pointer
+  into the chain-signed log.
+
+But three properties are missing that keep it from being *mathematically
+provable* the way the audit chain and dm-verity are:
+
+1. **`parent` is an opaque id (a name), not a digest of the parent's meta.**
+   The audit chain commits each entry to `sha256(prev line)`; the checkpoint
+   lineage does not commit a child to its parent's content. Editing an
+   ancestor's `content` manifest is invisible to descendants.
+2. **`CheckpointMeta` itself is neither hashed nor signed.** `audit_ref` is
+   explicitly "non-load-bearing" and integrity "relies on `content`, not on
+   `audit_ref`" (`checkpoint.rs:48-51`) — but nothing rolls `content` up into a
+   single commitment. There is no `meta_digest`, so no "single lookup" root to
+   revert to.
+3. **`plan_id` is a random UUID, not content-addressed** — `PlanId(uuid::new_v4)`
+   (`crates/mvm-core/src/plan/synthesis.rs:180`). The plan is *signed* (which
+   gives authenticity) but not *content-addressed*, so a plan cannot be
+   referenced by, or chained to, a prior plan by hash.
+
+Net: mvm has a merkle tree *inside* one image (dm-verity), a hash chain *of
+events* (audit log), and content-addressing *of one artifact set* (bundle). It
+does **not** have a content-addressed, hash-linked DAG *across* checkpoints/runs.
+That DAG is exactly what "rewind and revert with a single lookup" needs.
+
+### Recommendation
+
+**Q1: no action beyond documentation.** Keep the current model. The one
+improvement worth considering is surfacing `TrafficPlane` into the audit labels
+on data-verb calls so an operator can attest which agent-channel calls carried
+payload bytes vs control — the enum already exists (`response.rs:375-437`), so
+this is a labeling change, not new machinery. The broker covert-egress surface
+is already documented and leak-scanned; no code change is warranted there.
+
+**Q2: mostly already covered; one bounded, dependency-free enhancement is
+genuinely additive.** Content-address the checkpoint DAG by *reusing primitives
+that already exist*:
+
+- Compute a `meta_digest` = a merkle/hash root over the sorted `content` blobs
+  (each `ContentBlob.sha256` is already a leaf; a rootfs blob's leaf can be its
+  dm-verity `root_hash`, which `crates/mvm-fs/src/ext4/verity.rs:26` already
+  produces — no new hashing of the rootfs).
+- Make `parent` a `meta_digest` (or add `parent_digest` alongside the id) so the
+  lineage becomes hash-linked, like the audit chain.
+- Let the checkpoint id **be** its `meta_digest`, giving "revert with a single
+  lookup" (address by content) and a provable ancestry (walk parent digests,
+  compare one root).
+- Bind each `meta_digest` into the existing chain-signed audit log via
+  `emit_checkpoint_created`/`_forked` (already carry `content_sha256` — promote
+  it to the full meta digest), so the DAG inherits the audit chain's Ed25519
+  tamper-evidence for free.
+
+This needs **no new crate, no merkle library, and no UOR/veilid dependency** —
+SHA-256 (`sha2`), Ed25519 (`ed25519-dalek`), the dm-verity merkle root, and the
+audit chain are all already in-tree and already the sanctioned primitives. It
+honors limit-dependencies and no-lock-in, and it keeps the vsock-only /
+host-mediated invariants untouched (this is host-side metadata, not a guest
+channel).
+
+**Honest bottom line:** for *content and execution integrity in a single run*,
+already covered — no action. For the scratch note's *cross-run rewindable
+checkpoint DAG*, there is a real, narrow gap, and closing it is a small
+reuse-first change to `CheckpointMeta` + the checkpoint audit events, not a new
+subsystem. If the UOR content-addressing exploration
+(`specs/research/uor-addr-integration-assessment.md`) proceeds, the natural seam
+is this `meta_digest`/content-address field — adopt the *addressing scheme*
+there without pulling the *library* as a runtime dependency.

--- a/specs/research/external-sandbox-refactor-lessons.md
+++ b/specs/research/external-sandbox-refactor-lessons.md
@@ -1,0 +1,105 @@
+# Research — lessons from a comparable AI-sandbox offering for the mvm refactor
+
+**Status:** Research note; no implementation commitment
+**Date:** 2026-07-22
+**Owner:** mvm
+**Source:** A hosted AI-agent sandbox offering from a major cloud vendor, open-sourced under Apache-2.0 in April 2026. Reviewed from its public architecture docs, quickstart, and launch write-up. Named obliquely throughout, per the house convention in `specs/adrs/001-microvm-security-posture.md` §"Appendix: Cardoso minimum-viable-policy checklist"; competitor and product proper names are deliberately omitted, including the incumbent hosted-sandbox SDK it is wire-compatible with.
+
+## TL;DR
+
+The referenced external offering is a KVM microVM sandbox for AI agents, built on the `rust-vmm` building blocks plus a self-developed VMM, and wire-compatible with the incumbent proprietary code-interpreter SDK. Architecturally it converges on the *same thesis mvm already holds*: hardware-isolated microVMs with a per-guest kernel, a minimal virtio device set, default-deny/allowlist egress, and host-side credential injection so secrets never enter the guest.
+
+That convergence is the most useful finding: it independently validates several bets the mvm refactor has already placed (in-house minimal-device VMM, warm-snapshot restore, host-side secret substitution). The offering is not a security-posture peer — as documented it has no signed-and-audited admission, no verified boot, no supply-chain claim ladder, and no interactive-surface exclusion. Most of its surface (a cluster orchestrator, node scheduler, multi-node scaling) maps to mvm's *sibling fleet product*, not to mvm's single-VM CLI scope.
+
+Worth borrowing (details below): (1) copy-on-write / dirty-page **snapshot-and-fork** as an agent-facing DX primitive; (2) a **wire-compatible client adapter** for the incumbent SDK as an adoption on-ramp; (3) a **named, first-class egress-proxy component** with a domain-allowlist UX; (4) **published density/latency SLOs**. Do not borrow: a guest-NIC eBPF network data plane, or a mutable shared store as control-plane authority — both regress mvm claims or invariants.
+
+## What was reviewed
+
+The offering describes itself as production infrastructure for AI agents that hosts long-running agent processes, stateful service stacks, and one-shot code execution behind one lifecycle. Documented shape:
+
+- **Isolation:** each sandbox runs its own Linux kernel inside a KVM microVM; "no shared-kernel escape surface." The stated motivation is precisely the container multi-tenant-escape problem, traded against VM cold-start/memory cost.
+- **VMM:** self-developed rather than an off-the-shelf VMM, built on `rust-vmm` + KVM, retaining only `virtio-net`/`virtio-blk`/`serial` and a trimmed guest kernel "with only the minimal feature set required for agent execution." Hypervisor is seccomp-hardened.
+- **Boot/perf:** sub-60–100ms cold start via a pre-warmed pool plus CoW clone from a template sandbox (not raw VM boot speed); <5 MB overhead per instance; a claimed 2000+ concurrent sandboxes on a 96-vCPU host; P95 ~90ms under 50 concurrent creations. Vendor-published, not independently benchmarked.
+- **Storage/snapshots:** a CoW engine using the kernel `FICLONE` ioctl for O(1) clones, metadata-only snapshots (shared extents, no byte copy), and incremental dirty-page memory tracking to "fork multiple exploration branches" or roll back. One secondary source describes snapshot/fork as still-maturing, which conflicts with the architecture page presenting it as shipped — treat it as early.
+- **Networking:** per-sandbox TAP device; an eBPF kernel-space data plane doing SNAT/DNAT and policy without iptables; a transparent L7 egress proxy (OpenResty + Lua) enforcing a zero-trust domain allowlist on all outbound traffic.
+- **Secrets:** "credential injection" — the egress layer appends `Authorization` headers on the way out so keys "never enter the sandbox, model context, or logs."
+- **Control plane:** a REST gateway wire-compatible with the incumbent SDK, a cluster orchestrator, a node scheduler, a `containerd` shim-v2 bridge, a reverse proxy, and a shared in-memory store as "single source of truth" for sandbox metadata/events. Control-plane components are partly Go; the data-plane VMM/shim/egress are Rust.
+- **DX:** drop-in migration by repointing the SDK's base-URL env var; a `run_code(...)`-style one-shot exec API; templates built from an OCI image via a CLI; a browser console for administration.
+
+## Architecture at a glance
+
+| Concern | External offering | Nearest mvm equivalent |
+|---|---|---|
+| Isolation boundary | KVM microVM, per-guest kernel, minimal virtio set | ADR-001 L1/L2; Firecracker (Tier 1), HVF/libkrun (Tier 2) |
+| VMM provenance | Self-developed on `rust-vmm` + KVM | In-house HVF VMM (ADR-098 / Plan 214); Firecracker on Linux |
+| Warm start | Pre-warmed pool + CoW clone from template | Warm-snapshot direction (ADR-025); `vm/` checkpoints |
+| Snapshot/fork | `FICLONE` O(1) clone + dirty-page memory delta | `vm/` templates + checkpoints; not yet an agent-fork DX |
+| Egress control | eBPF SNAT/DNAT + L7 MITM proxy, domain allowlist | Claim 10 default-deny; nftables (FC) / gateway-bridge `PlanFlowPolicy` (libkrun) / vsock gate (HVF) |
+| Secret handling | Egress appends `Authorization`, secret never in guest | Claim 13 + preview claim 16 egress substitution |
+| Admission/authority | Mutable shared store as source of truth | Claim 8 signed, validity-windowed `ExecutionPlan` + chain-signed audit |
+| SDK model | `run_code(str)` + incumbent-SDK wire compat | Build-time decorator → Workload IR → Nix; transient `run` / exec runner |
+| Platform reach | KVM x86_64 Linux only | Linux KVM **and** macOS (HVF / libkrun) |
+| Scope | Cluster orchestrator + multi-node (fleet) | Single-VM CLI; fleet is the sibling product |
+
+## (a) Ideas genuinely worth borrowing
+
+1. **Snapshot-and-fork as an agent-facing DX primitive (highest value).** The offering packages CoW clone + dirty-page memory delta as a product capability: "roll back to any saved state or fork multiple exploration branches." mvm already has the substrate — `vm/` checkpoints and the warm-snapshot prior-art boundary in ADR-025 — but not the agent-centric *fork N branches from a warm state* story. This is squarely refactor-aligned (the overlay-only runtime and in-house-VMM work already touch the pieces). Mapping: expose fork/restore over the `VmBackend` seam, keyed on a checkpoint identity. **Hard constraint:** a forked or restored VM must not bypass admission — it must inherit or re-admit a signed `ExecutionPlan` (claim 8) and, on block+ext4 backends, keep its dm-verity binding (claim 3). A fork that silently reuses authority would be a claim-8 hole. Captured as a design guardrail, not a shortcut.
+
+2. **A wire-compatible client adapter for the incumbent SDK.** Their entire adoption pitch is "change one URL env var, zero code changes." mvm's `mvm-client` facade already has a `GatewayBackend` seam; a thin, host-side, audited translation from the incumbent SDK's `run_code`-style ephemeral-exec calls onto mvm's transient-run path would give the same on-ramp without adopting their execution model or abandoning mvm's decorator→IR philosophy. Keep it a pure translation layer: every admitted exec still synthesizes and signs an `ExecutionPlan` and emits audit entries. This is a DX/distribution win, not an architecture change.
+
+3. **Name the egress proxy as a first-class, observable component.** mvm *enforces* claim 10 (default-deny) and secret substitution today, but they are described as backend-internal mechanisms (nftables ruleset, gateway-bridge policy, per-VM vsock gate). The offering's "named L7 egress component + explicit domain-allowlist UX" is a packaging and observability idea: give the operator one place to read "what this workload is allowed to reach," surfaced in `mvmctl doctor` / receipts. Capability already exists; the borrow is presentation, discoverability, and a stated allowlist UX.
+
+4. **Publish warm-start and density SLOs.** They lead with measured numbers (cold start, per-instance overhead, concurrent density, P95/P99). mvm already measures boot/perf internally; as the snapshot path matures, turning those into stated, doc-level SLOs makes performance a claimed, regression-gated property rather than folklore — consistent with how mvm already treats security properties as CI-gated claims.
+
+5. **Convergent validation of the in-house-VMM bet (reassurance, not an action).** An independent team, optimizing for the same agent workload, also chose a self-developed minimal-device VMM on `rust-vmm`, a trimmed guest kernel, and pre-snapshot restore over an off-the-shelf VMM. That is exactly the mvm refactor's HVF direction (ADR-098 / Plan 214) and the minimal L2 device set. Worth citing when the in-house-VMM cost is questioned. The shared `rust-vmm` crate base (a community crate set, not a competitor product) is also a candidate to share rather than reimplement, subject to ADR-002 dependency review.
+
+## (b) Where mvm already does something equivalent or stronger
+
+Do not read the offering as exposing gaps in mvm; on the security axis mvm is broader. As documented, the offering asserts *isolation + egress* and little else. mvm's fifteen CI-gated claims cover strictly more:
+
+| mvm property | Claim | External offering as documented |
+|---|---|---|
+| Signed, validity-windowed, replay-gated admission | 8 | None; authority is a mutable shared store |
+| Chain-signed audit log with drift detection | 8, 12 | None stated |
+| Verified boot (dm-verity rootfs, panic-on-tamper) | 3 | None; "trimmed kernel" is not rootfs integrity |
+| Content-addressed, key-id-pinned signed bundles | 9 | None stated |
+| Sealed dep volumes: SBOM + CVE + attestation | 11 | None stated |
+| OCI image provenance in the audit chain | 14 | None stated |
+| Dep audit + reproducible double-build | 6, 7 | None stated |
+| No `do_exec` in prod agent; no interactive console | 4, 15 | Opposite by design — arbitrary agent code, long-running processes, admin console |
+| Secret is destination-bound, time-bound, zeroized, never in audit | 13, 16 | "Credential injection" is directionally identical but thinner as described (header append; no stated destination/time binding, zeroization, or audit-no-value guarantee) |
+| Cross-platform (macOS HVF/libkrun + Linux) | — | KVM x86_64 Linux only |
+| Rust boundary discipline + wasm-clean audit verifier | — | Control plane partly Go; no equivalent verifier surface |
+
+Two structural points:
+
+- **Scope mismatch.** The offering is a multi-tenant fleet system (cluster orchestrator, node scheduler, multi-node). mvm scopes multi-tenant guests *out* at the mvm layer; that trust boundary lives in the sibling fleet product. So most of the offering's control plane compares to the sibling, and any cross-tenant lessons belong to that product's own claim catalog, not to mvm's.
+- **Auditability model.** The offering runs *real guest networking* — a per-sandbox TAP with an eBPF SNAT/DNAT data plane and an L7 MITM egress proxy. mvm's HVF path is deliberately vsock-only with no guest NIC, precisely so the vsock seam remains the single auditable egress-and-substitution chokepoint. Their model is legitimate but is the thing mvm's vsock-only invariant intentionally rejects.
+
+## What mvm should NOT adopt
+
+- **A guest-NIC eBPF network data plane.** It conflicts with the vsock-only auditable-data-plane invariant. Matching their model would reintroduce a guest network interface and move enforcement off the vsock seam, regressing the audit/substitution story that claims 10/13/16 rest on. Considered and rejected, same spirit as ADR-001's serial-console rejection.
+- **A mutable shared store as control-plane authority.** mvm's trust root is the signed `ExecutionPlan` plus the chain-signed audit log. Introducing a mutable store as "single source of truth" for lifecycle/authority would undercut claim 8. A cache is fine; an authority is not.
+- **`containerd` shim / OCI-runtime integration on the runtime path.** mvm's posture is explicitly no container runtime on the runtime path (ADR-001 tier matrix: there is no Tier 3). The offering's shim-v2 bridge buys ecosystem reach at a cost mvm has already declined. mvm consumes OCI *images* (claim 14) without adopting an OCI *runtime*; keep that line.
+
+## (c) Prioritized recommendation
+
+**Adopt the DX/performance ideas that are already refactor-aligned; hold every security claim fixed.** The offering is a useful mirror of where the industry is converging on agent-sandbox *ergonomics*, and a poor mirror of mvm's *assurance* posture. Borrow from the first, not the second.
+
+- **P0 — Snapshot-and-fork DX, admission-safe.** Elevate warm checkpoints to a first-class fork/restore capability over the `VmBackend` seam, with the invariant that a forked/restored VM re-admits or inherits a bound signed plan and keeps its verified-boot binding. Highest leverage, already in the refactor's path, and the guardrail is the whole point. Sequence as a small design spike against ADR-025 + the checkpoint code before committing.
+- **P1 — Incumbent-SDK wire-compat adapter behind `mvm-client`.** A thin, audited translation of `run_code`-style calls onto the transient-run path. Adoption on-ramp with no change to the IR model; every call still signs a plan and audits.
+- **P1 — Publish warm-start + density SLOs** as the snapshot path lands, turning measured perf into stated, gated properties.
+- **P2 — First-class, observable egress-allowlist surface** in `doctor`/receipts. Presentation over an existing capability.
+- **Reject** the guest-NIC eBPF data plane, the mutable-store authority, and the container-runtime shim, for the reasons above.
+
+No dependency, wire contract, or claim changes are implied by this note. Any adoption starts as an additive, reversible spike, mirroring the pilot discipline in `specs/research/uor-addr-integration-assessment.md`.
+
+## Sources
+
+Public materials from the vendor's open-source project, cited obliquely to honor the naming rule (URLs and repository identifiers embed the product/vendor name and are therefore omitted):
+
+- Vendor architecture overview (public documentation) — component roster, VMM/storage/networking design, security-layer summary.
+- Vendor product introduction and quickstart (public documentation) — performance figures, execution model, SDK env-var setup, template CLI, admin console.
+- Vendor launch write-up (public blog) — motivation, container-vs-VM trade-off framing, self-developed-VMM rationale, SDK example.
+- Third-party technical explainer (independent blog) — isolation summary, unshipped/early-feature caveats, and the note that vendor metrics lack independent benchmarking.
+- `specs/adrs/001-microvm-security-posture.md` — mvm's threat model, tier matrix, and the fifteen-claim ledger used for the contrast above.

--- a/specs/research/serde-jcs-rfc8785-keyorder-nonconformance.md
+++ b/specs/research/serde-jcs-rfc8785-keyorder-nonconformance.md
@@ -1,0 +1,77 @@
+# serde_jcs 0.1.0 — RFC 8785 object-key-ordering non-conformance
+
+**Status:** Upstream-facing finding; reproducing evidence in-tree
+**Scope:** `serde_jcs` 0.1.0 (the JCS canonicalizer `mvm-core` hashes for `SemanticAddress`)
+**Owner:** mvm (finding); resolution belongs to the `serde_jcs` / UOR-Foundation upstream
+
+## Summary
+
+`serde_jcs` 0.1.0 does not order object keys per RFC 8785 §3.2.3, which mandates
+sorting by **UTF-16 code units**. It instead serializes each key to its UTF-8
+bytes and emits keys in **UTF-8 byte** order (lexicographic on the encoded
+bytes), which equals Unicode **scalar-value** order. The two orderings coincide
+for every code point up to U+FFFF and diverge for astral-plane code points
+(> U+FFFF), because a UTF-16 surrogate pair's leading unit (0xD800–0xDBFF)
+sorts *before* U+FFFF, whereas the scalar value U+10000 sorts *after* U+FFFF.
+
+## Reproduction
+
+An object with the two keys `"\u{FFFF}"` and `"\u{10000}"`:
+
+- RFC 8785 (UTF-16 code-unit order): `"\u{10000}"` sorts first (0xD800 < 0xFFFF).
+- serde_jcs 0.1.0 (UTF-8 byte / scalar order): `"\u{FFFF}"` sorts first
+  (U+FFFF < U+10000).
+
+Mechanism: `serde_jcs`'s object serializer buffers entries as
+`BTreeMap<Vec<u8>, Vec<u8>>` keyed on the serialized key bytes and emits in that
+map's byte order. UTF-8 lexicographic order is identical to scalar-value order,
+not to UTF-16 code-unit order.
+
+mvm's own hand-rolled `no_std` canonicalizer (`mvm_protocol::ir::canonicalize`)
+sorts keys by `str` `Ord` (also scalar-value order), so the two agree with each
+other — which is why mvm's internal `semantic-address ↔ ir-hash` equivalence
+holds byte-for-byte. This is pinned as a drift-lock in
+`crates/mvm-core/src/canonicalizer_equivalence.rs`, with a caveat now on the
+`semantic_address` and `ir::canonicalize` module docs.
+
+## Impact
+
+- Any address computed via `serde_jcs` (or mvm's matching canonicalizer)
+  differs from one a strictly-conformant JCS implementation would produce **for
+  documents carrying astral-plane object keys** (e.g. an emoji key in a workload
+  `env` or `extensions` map). ASCII/BMP keys — i.e. all realistic workloads —
+  are unaffected.
+- For mvm this is a cross-implementation interop caveat, not an internal
+  correctness bug: mvm never claims two *different* documents share an address,
+  and both its canonicalizers agree. It matters only if a second toolchain
+  computes the "same" semantic address with a spec-correct JCS and expects
+  byte-identical results.
+
+## Proposed upstream fix
+
+Order object keys by UTF-16 code units before emission. In Rust this is a
+one-line comparator over the key strings:
+
+```rust
+keys.sort_by(|a, b| a.encode_utf16().cmp(b.encode_utf16()));
+```
+
+`str::encode_utf16` is `core`-available, so this is compatible with a `no_std`
+realization. A conformance vector for the U+FFFF / U+10000 pair should accompany
+the fix.
+
+## mvm follow-through
+
+- Keep the drift-lock test; it will catch the day `serde_jcs` changes ordering
+  (mvm's two canonicalizers would then disagree and the lock fails, signalling
+  that `ir::canonicalize` must adopt the same UTF-16 order in lockstep).
+- If mvm ever needs true cross-language address parity with a spec-correct JCS
+  SDK, adopt the UTF-16 ordering in **both** `serde_jcs` (or its replacement)
+  and `mvm_protocol::ir::canonicalize` together, and add cross-language
+  conformance vectors.
+
+## Sources
+
+- RFC 8785 §3.2.3 (Sorting of Object Properties).
+- `serde_jcs` 0.1.0 object serialization (`BTreeMap<Vec<u8>, Vec<u8>>` emit order).
+- In-tree reproducing test: `crates/mvm-core/src/canonicalizer_equivalence.rs`.

--- a/specs/research/unsafe-inventory-and-nostd-wasm.md
+++ b/specs/research/unsafe-inventory-and-nostd-wasm.md
@@ -1,0 +1,175 @@
+# Unsafe inventory + no_std/wasm reach — audit note
+
+Grounded in the tree at `/Users/auser/work/tinylabs/mvmco/mvm` (branch `main`).
+Method: `rg -n "\bunsafe\s+(fn|impl|extern|\{|trait)" --type rust` across the
+workspace, excluding `unsafe_code` attribute/comment lines and `target/`.
+
+Headline: **642 real unsafe sites**, **346 `// SAFETY:` comments**. The unsafe
+is overwhelmingly irreducible — FFI, OS syscall wrappers, and guest-memory/virtio
+pointer work inherent to being a from-scratch VMM plus a headless-guest init plus
+a process-moat supervisor. There is a small, targeted hygiene slice worth doing;
+a blanket minimization pass is not.
+
+Crate-level `#![forbid(unsafe_code)]`: **`mvm-protocol`**, **`mvm-fs`**.
+Zero-unsafe crates (not yet forbidding): **`mvm-net`**, **`mvm-client`**,
+**`mvm-conformance`**, **`mvm-vz-supervisor`** (stale post-Vz-removal stub).
+
+---
+
+## Part A — unsafe inventory
+
+### Per-crate table
+
+| Crate | Real unsafe | Hot spots (file:count) | What it does | Category |
+|---|---|---|---|---|
+| `mvm-runtime` | 188 | `hvf/` 55, `vmm/` 28, `base/` 11, `microvm/` 10, `vm/` 9, `kvm/` 8 | Apple Hypervisor.framework FFI (`hv_vm_*`/`hv_vcpu_*`), guest-RAM mapping + virtqueue walks (`GuestMem`, `hvf/guest_ram.rs`, `vmm/virtio.rs`), KVM ioctls, snapshot mmap, `libc::{kill,flock,waitpid,setsid}` liveness/spawn | FFI + syscall + VMM-memory (irreducible in kind) |
+| `mvm-agentd` | 140 | `console.rs` 30, `guest_net.rs` 15, `entrypoint.rs` 14, `mvm-verity-init.rs` 11, `mvm-guest-agent.rs` 10, `signals.rs` 8, `netinit.rs` 7, `port_forward.rs` 7 | In-guest init: PTY `openpty`/`ioctl` (`extern "C"`), network `SIOC*` ioctls, `extern "C"` signal handlers, mount/pivot/exec in the entrypoint runner | OS syscall wrappers (irreducible) |
+| `deps/libkrun-sys` | 105 | `libkrun_bindings.rs` 63, `sys.rs` 23, `passt.rs` 7, `native_gateway.rs` 6 | `libkrun_bindings.rs` = rust-bindgen output (`extern "C"` decls). `sys.rs` = hand-written thin safe wrappers, each one FFI call deep, errno→`Result` | Legitimate FFI (irreducible; bindgen is generated) |
+| `mvm-hostd` | 63 | `smoltcp_egress.rs` 9, `supervisor/substitution_proxy.rs` 7, `supervisor/raw_egress.rs` 7, `parent_death.rs` 6, `mvm-hvf-supervisor.rs` handlers | Egress socket plumbing, `prctl(PR_SET_PDEATHSIG)`, `extern "C"` stop/pause/resume signal handlers, fork/`setsid` for the process moat | syscall wrappers (irreducible) |
+| `mvm-cli` | 62 | `doctor/builder.rs` 14, `commands/vm/console.rs` 8, `commands/vm/checkpoint.rs` 7, `signal.rs` 6 | `libc::kill(pid,0)` liveness probes, terminal raw-mode termios, self-pipe SIGINT handler, `getpid`, and ~10 `std::env::set_var` (Rust-2024 unsafe) | syscall wrappers + env-var (mostly irreducible; env-var slice reducible) |
+| `mvm-build` | 57 | `mvm-host-vm-init.rs` 24, `stage0-init.rs` 9, `mvm-builderd.rs` 8, `mvm-egress-proxy.rs` 5 | Builder-VM guest-init: `extern "C"` decls, mount/pivot_root/exec, signal handlers — the same syscall class as `mvm-agentd` but for the builder guest | OS syscall wrappers (irreducible) |
+| `mvm-host-services-ffi` | 19 | `lib.rs` 19 | The C-ABI cdylib every language SDK dlopens: `pub unsafe extern "C" fn mvm_hsvc_call/_free`, `CString`/slice marshalling across the FFI boundary | Legitimate FFI — this IS the contract (irreducible) |
+| `mvm-core` | 6 | `util/test_env.rs` 6 | All six are `std::env::{set_var,remove_var}` inside the test-env helper (Rust-2024 made these `unsafe`) | Rust-2024 env-var (test-only; not reducible, but already centralized) |
+| `mvm-sdk` | 1 | `compile/flake.rs` 1 | One `std::env::remove_var` in a test | Rust-2024 env-var (test-only) |
+
+### Categories, honestly
+
+1. **Legitimate FFI — irreducible.** `libkrun_bindings.rs` (bindgen, 63),
+   `sys.rs` hand-written wrappers (23), passt/native_gateway (13), the HVF
+   `hv_*` calls in `mvm-runtime/src/hvf/` (~55, wrapped behind the portable
+   `HypervisorVm`/`HypervisorVcpu` seam in `vmm/hv.rs`), and the
+   `mvm-host-services-ffi` C-ABI exports (19). None of this can be safe Rust:
+   it is the boundary to libkrun's C, Apple's Hypervisor.framework, and the
+   language-SDK dlopen contract. **Do not touch.**
+
+2. **OS syscall wrappers via `libc` — irreducible.** `kill`/`waitpid`/`flock`/
+   `setsid`/`fork`/`prctl`/`ioctl(SIOC*/TIOC*)`/`openpty`/`mmap` and `extern "C"`
+   signal handlers, spread across `mvm-agentd` (guest init), `mvm-build`
+   (builder-guest init), `mvm-hostd` (supervisor/process-moat), and `mvm-cli`
+   (liveness + terminal). This is what a headless-guest init and a fork/exec
+   process-moat supervisor *are*. The `libc` crate is already the thin safe-ish
+   layer; the residual `unsafe` is the syscall invocation itself.
+
+3. **Guest-memory / virtio raw-pointer ops — irreducible in kind, improvable in
+   quality.** `vmm/guest_mem.rs` (`unsafe impl Send`, `ptr.add`,
+   `copy_nonoverlapping`), `hvf/guest_ram.rs` (mmap + `slice::from_raw_parts`),
+   `vmm/virtio.rs` (`unsafe fn new`, descriptor-ring pointer copies). Mapping
+   guest RAM and walking virtqueues over raw host pointers is intrinsic to an
+   in-house VMM. `GuestMem` already exposes bounds-checked `read`/`write`
+   helpers; a slice of `virtio.rs` still does ad-hoc `ptr.add` + `copy`.
+
+4. **Rust-2024 env-var unsafe — cosmetic.** `std::env::set_var`/`remove_var`
+   became `unsafe` in edition 2024 (thread-safety, not memory-safety). ~30 sites,
+   almost all test-only. `mvm-core::util::test_env` already wraps this; the
+   reducible slice is the handful of *open-coded* call sites in
+   `mvm-cli/src/commands/mod.rs`, `commands/build/build.rs`, and
+   `mvm-runtime/src/substitution_spawn.rs` that bypass the helper.
+
+### Reducibility verdict
+
+- **~95%+ is irreducible** (categories 1–2 and the *kind* of 3). It exists
+  because mvm is a from-scratch VMM + guest-init + process-moat. Eliminating it
+  means not being those things. Do not propose removing FFI or syscall wrappers.
+- **SAFETY-comment coverage is ~54%** (346 / 642). The gap is concentrated in
+  formulaic sites (`kill(pid,0)`, `set_var`) that don't need one, but also in the
+  category-3 raw-pointer blocks that genuinely should document their bounds /
+  aliasing / initialization invariants.
+
+### Recommendation — Part A
+
+**Do not run a blanket minimization pass.** Do one small, targeted hygiene pass:
+
+1. **SAFETY invariants on the VMM-memory blocks.** Add/complete `// SAFETY:`
+   on the raw-pointer sites in `vmm/guest_mem.rs`, `vmm/virtio.rs`,
+   `hvf/guest_ram.rs`, stating the offset-in-bounds, non-aliasing, and
+   initialization preconditions. Where `virtio.rs` still does direct
+   `ptr.add` + `copy_nonoverlapping`, route it through `GuestMem`'s existing
+   checked accessors so the unsafe lives in one audited place. This is the only
+   block where a real memory-safety bug could hide.
+2. **Funnel env-var unsafe through `mvm_core::util::test_env`.** Replace the
+   ~5 open-coded `std::env::set_var`/`remove_var` sites with the existing helper.
+   Zero behavior change; shrinks the raw-unsafe count and localizes it.
+3. **Lock in the zero-unsafe crates.** Add `#![forbid(unsafe_code)]` to
+   `mvm-net` and `mvm-client` (both already unsafe-free). Cheap, prevents
+   regression, extends the property that `mvm-protocol`/`mvm-fs` already hold.
+
+**Leave as-is:** all FFI (`libkrun-sys`, `mvm-host-services-ffi`, HVF), all
+`libc` liveness/signal/ioctl/spawn wrappers, the bindgen file, `mvm-vz-supervisor`
+(dead — delete under separate Vz-cleanup, out of scope here).
+
+---
+
+## Part B — no_std / wasm reach
+
+### Where the boundary is today
+
+`mvm-protocol` is `#![no_std]` + `alloc` + `#![forbid(unsafe_code)]`
+(`crates/mvm-protocol/src/lib.rs:13-14`), and it is **CI-gated for real**: the
+`wasm-no-std-boundary` job in `.github/workflows/ci.yml` builds it on
+`wasm32-unknown-unknown` and *runs its tests* on `wasm32-wasip1` via wasmtime.
+The `schema` feature (schemars codegen) and `--test` builds drop `no_std`
+deliberately; the shipped wasm library surface stays no_std.
+
+The heavy lifting is **already done**. Increment 3 of the protocol/core split
+(`specs/refactor/07-progress-and-decisions.md`, `10-increment3-...`) is COMPLETE:
+the entire claim-8 signed `ExecutionPlan` (46/46 fields byte-identical), the
+wire/policy/audit DTOs, and the `Workload` IR now live in `mvm-protocol` and
+compile on wasm32. This is the documented WS11 "wasm-container capable" core goal
+(`specs/refactor/01-goals.md`).
+
+### Candidate crates and their blockers
+
+- **`mvm-net` — plausible but low-value.** Pure trait/registry/policy seam, zero
+  unsafe, no async, no I/O in the seam itself; depends only on `mvm-core` +
+  `mvm-protocol`. It is std *only transitively*, through `mvm-core`. To go
+  no_std it would need to drop its `mvm-core` dep to `mvm-protocol`-only. Feasible
+  — but the trait's implementors (TAP/bridge/gateway/passt in `mvm-runtime`,
+  mesh in mvmd) are all host-side std, so a wasm consumer gains almost nothing
+  from a no_std `NetworkProvider` trait. Not worth it absent a concrete wasm
+  caller.
+
+- **`mvm-core` — no.** std-bound *by design*: 30+ files touch
+  `std::fs`/`env`/`process`/`os::unix` — `config.rs` (MVM_HOME paths),
+  `crypto/{keystore,secret_store,snapshot_*,egress_ca,volume}` (file-backed key
+  and secret stores), `util/atomic_io.rs`, `platform/linux_env.rs`,
+  `plan/bundle.rs` (tar/fs). It is deliberately the std layer *on top of*
+  `mvm-protocol`; the wasm-relevant pure DTOs were already extracted downward.
+  Leave it.
+
+- **Everything above `mvm-core` — no.** `mvm-runtime`/`-hostd`/`-agentd`/`-cli`/
+  `-build`/`-client` carry a hard std + tokio + OS floor. tokio enters the
+  shipped `mvmctl` through `mvm-hostd` (async server) and `mvm-agentd` (async
+  guest); this is architectural, not incidental (dependency-floor note in
+  memory). The only lever ever identified is splitting `mvm-hostd`'s sync-admit
+  path from its async-server path — and that is about keeping tokio out of a
+  *default* build, not about no_std/wasm.
+
+- **`mvm-sdk` — no.** Its build-time `compile/`/IR-emission path is std
+  (file I/O, Nix template emission). Its IR types already delegate to
+  `mvm-protocol`.
+
+### Is it worth it? Against concrete goals
+
+- **Browser SDK surface — already satisfied.** The realistic browser/wasm target
+  is exactly what `mvm-protocol` delivers today: audit-log *verification*,
+  plan/bundle DTO parsing, IR validation, all runnable with no host. A browser
+  SDK depends on `mvm-protocol` alone. **No further no_std migration is a
+  prerequisite** — the CI gate proves it builds and its tests pass under wasm.
+
+- **`WasmBackend` (WS11) — a runtime seam, not a no_std task.** Running a workload
+  through the shared `VmBackend` + egress/audit/secret-substitution seam needs a
+  wasm *runtime* on the host (e.g. wasmtime — itself std). It does not require
+  making any additional crate no_std; the no_std *core* it consumes already
+  landed with `mvm-protocol`.
+
+### Recommendation — Part B
+
+**Leave the no_std boundary exactly where it is — at `mvm-protocol`.** The split
+was done deliberately, is complete for the signed-plan/IR/DTO surface, and is
+CI-gated on `wasm32-unknown-unknown` + `wasm32-wasip1`. Do **not** chase no_std
+for `mvm-core` (std by design) or anything above it (tokio/OS floor is
+architectural and load-bearing). The one incrementally-feasible move —
+`mvm-net` to no_std — is low-value because its implementors are host-side; skip
+it until a real wasm consumer needs the trait. For a browser SDK, build on
+`mvm-protocol` as-is. The next wasm milestone (`WasmBackend`) is a host-side
+runtime feature, not a crate-flattening exercise.

--- a/specs/research/veilid-networking-evaluation.md
+++ b/specs/research/veilid-networking-evaluation.md
@@ -1,0 +1,165 @@
+# Research — veilid for mvm networking
+
+**Status:** Research note; no implementation commitment
+**Date:** 2026-07-22
+**Owner:** mvm
+**Source:** [veilid-core](https://gitlab.com/veilid/veilid/-/tree/main/veilid-core), reviewed against `docs.rs/veilid-core`
+
+## TL;DR
+
+**Do not adopt.** `veilid` is a peer-to-peer, DHT-addressed, anonymity-routing
+overlay. Its entire purpose — reach arbitrary peers over an encrypted overlay
+that intermediaries (and the sender's own host) cannot associate with a
+destination — is the direct inverse of mvm's networking model, which is *one
+host-mediated egress chokepoint per guest, default-deny, fully audited*
+(ADR-003, claim 10). On the guest data path it is not merely a poor fit; it is
+a textbook covert-egress channel that would defeat the auditable-vsock-seam
+invariant, claim-10 default-deny, and claim-13 secret substitution
+simultaneously.
+
+The one seam where a P2P provider is even *mechanically* pluggable — the
+`NetworkProvider` fleet-mesh registry — lives in **mvmd, not this repo**, is
+already served by authenticated WireGuard/Tailscale mesh providers, and *wants*
+the non-anonymous, host-identified routing that veilid deliberately hides. Even
+there veilid is the wrong tool.
+
+## What veilid is
+
+A privacy-preserving P2P network framework. Each app instance is a node
+identified by a 256-bit public key; there are no special nodes and no central
+party. It composes a BitTorrent-style DHT, IPFS-style decentralized storage,
+and Tor-style onion/route-based traffic routing. `RoutingContext` is the API
+surface: by default "safety routing" gives sender privacy, and "private routes"
+give receiver privacy — you address a `RouteId` or `NodeId`, *not* an IP:port.
+Transport is authenticated, timestamped, end-to-end encrypted, and signed
+(VLD0 suite: blake3 / ed25519-dalek / chacha20poly1305).
+
+Practical profile relevant to adoption:
+
+- **Mandatory async runtime** (tokio, async-std, or wasm-bindgen-futures).
+- **Large closure**: pulls its own full crypto stack plus overlay/DHT
+  infrastructure (~2M SLoC transitively per lib.rs).
+- **Needs a peer network to be useful**: a node's value is reaching *other*
+  veilid nodes via DHT rendezvous/bootstrap — an external, non-hermetic
+  runtime dependency.
+- **License MPL-2.0** (file-level copyleft; distinct from the workspace's
+  permissive-leaning posture).
+
+## mvm's actual networking model (what it would have to fit)
+
+Grounded in `specs/adrs/003-hypervisor-egress-policy.md` and the code:
+
+- **Egress is a single host-mediated chokepoint, default-deny.** The
+  `NetworkProvider` trait (`crates/mvm-net/src/provider.rs`) provisions one
+  VM's network against a `NetworkSpec` whose `policy` defaults to
+  `NetworkPolicy::deny_all()` — opening egress is opt-in (claim 10). The
+  `EgressEnforcer` seam (`crates/mvm-net/src/enforcement.rs`) fails **closed**
+  (`EnforcementError::NotWired`) rather than boot a VM with silent host egress.
+
+- **Vsock-only on the workload backends.** HVF and libkrun guests attach *no*
+  virtio-net device: no guest kernel IP stack, no tap, no gateway process. The
+  guest's only channel out is `AF_VSOCK`. This is the standing
+  auditable-vsock-seam invariant — the vsock boundary is exactly where audit
+  and secret substitution happen.
+
+- **One shared host forwarder.** The guest hands the host raw IPv4 packets over
+  a dedicated vsock port; a decision gate (`L3ForwardPolicy::decide_packet`)
+  checks each packet's destination against the admitted policy projected
+  through a host-side DNS-pin registry (there is no guest-side DNS to trust);
+  admitted packets go to an in-process userspace `smoltcp` stack that
+  terminates the flow and splices it to an ordinary host socket
+  (`crates/mvm-hostd/src/smoltcp_egress.rs`). Unparseable packet, unpinned
+  host, or no IP pin all resolve to *drop*. Firecracker adds a TAP behind
+  nftables default-deny; when the tunnel is configured the TAP is pinned
+  deny-all so the audited tunnel is the sole path.
+
+- **Secrets never enter the guest.** A per-VM host-side substitution endpoint
+  swaps an opaque placeholder for a real credential only on the outbound leg,
+  after a destination allow-list check, with a per-VM name-constrained
+  intermediate CA (claim 13; ADR-003 §secret-bound destinations; the claim-16
+  egress-substitution leak-gate).
+
+Every one of these mechanisms depends on the host being able to see, name,
+authorize, and audit each destination the guest reaches.
+
+## Why veilid conflicts on the guest path
+
+The conflict is structural, not incidental:
+
+| mvm requires | veilid provides |
+| --- | --- |
+| Host names + authorizes every destination (IP-pinned, default-deny) | Guest addresses opaque `RouteId`/`NodeId`; destination is *hidden by design* |
+| No guest-side IP stack (vsock-only); host is the sole egress origin | A full in-guest overlay stack that originates its own encrypted flows |
+| Every outbound flow audited on the vsock seam | Onion-routed traffic the host cannot associate with a destination |
+| Secret substitution at a host chokepoint the guest can't bypass | End-to-end encrypted guest-originated channel — nothing to substitute into |
+| Sealed guest agent stays tokio-free, minimal fuzzed surface (claims 4/5/15) | Mandatory async runtime + megabytes of crypto/DHT in the guest binary |
+
+Putting veilid in the guest is precisely the covert-egress channel that Plan 111
+Workstream A audits *against* (DNS / control-plane / broker as covert egress).
+It would give a compromised workload an anonymizing, host-unobservable exfil
+path — nullifying claim 10, claim 13, and the audit log's egress record in one
+move. This is disqualifying regardless of dependency cost.
+
+## The only narrow niche — and why it still loses
+
+The `NetworkProvider` trait is deliberately backend-agnostic and registers
+mesh providers via `NetworkProviderRegistry` (`NetworkMode::Custom`), and
+ADR-003 notes the same trait is implemented *outside* single-host mvm for
+fleet-mesh networking. So a `kind() == "veilid"` provider is *mechanically*
+constructable. That is the shallow reading. It fails on substance:
+
+1. **Wrong repo.** Fleet-mesh between coordinators/hosts is an **mvmd**
+   concern; this repo (mvm) owns single-VM guest egress, which veilid must
+   never touch.
+2. **Impedance mismatch with the trait contract.** `NetworkSpec` is *a
+   deny-by-default policy over explicit admitted destinations plus a
+   `slot_index`*. veilid has no notion of an admitted IP allow-list to enforce
+   or a `policy()` to report; its model is "reach any peer anonymously." The
+   trait would host it in name only.
+3. **Anonymity is a liability for a control plane.** A fleet mesh *wants* to
+   know exactly which authenticated host it is talking to. WireGuard/Tailscale
+   (the incumbent providers) give authenticated, non-anonymous, low-dependency
+   transport. veilid's sender/receiver privacy is dead weight — or worse, an
+   auditability regression — for that role.
+4. **No genuine gap.** There is no current mvm requirement (NAT-traversing,
+   censorship-resistant, central-authority-free rendezvous) that the incumbents
+   don't already cover for the fleet case.
+
+## Weighed against the binding constraints
+
+- **Limit dependencies (ADR-002):** hard fail. ~2M SLoC transitive, a second
+  full crypto stack duplicating what `mvm-core::crypto` already carries, a
+  mandatory async runtime, and a runtime dependency on an external peer network
+  — the antithesis of "reuse workspace crypto crates; question every new dep."
+- **No lock-in / isolate transports behind traits:** the trait *seam* survives,
+  but veilid's model can't be isolated behind it cleanly because its transport
+  *is* the abstraction — you would be modeling an anonymity overlay through a
+  deny-by-default egress-policy interface. That is lock-in dressed as a plugin.
+- **No external services / hermetic + deterministic:** needs bootstrap peers /
+  DHT rendezvous to function — an external, non-deterministic runtime service,
+  against the same grain as the no-external-cache-provider posture.
+- **Auditable-vsock-seam invariant:** direct violation on the guest path (above).
+- **Claim 10 / claim 13 / claim 16:** each defeated by an anonymizing,
+  host-unobservable, guest-originated transport.
+
+## Decision
+
+**Do not adopt veilid for mvm networking.** It is architecturally opposed to
+the host-mediated, default-deny, vsock-only, fully-audited egress model on the
+guest path, and it is a heavy, external-network-dependent, license-divergent
+dependency that duplicates the workspace crypto stack. The only pluggable seam
+belongs to mvmd's fleet mesh, where authenticated WireGuard/Tailscale providers
+already win and veilid's anonymity is a liability. Revisit only if mvmd ever
+develops a concrete need for decentralized, central-authority-free coordinator
+rendezvous — and even then benchmark it against a plain authenticated mesh
+first, and keep it strictly out of any guest data path.
+
+## Sources
+
+- [veilid-core repository](https://gitlab.com/veilid/veilid/-/tree/main/veilid-core)
+- [veilid-core on docs.rs](https://docs.rs/veilid-core)
+- [veilid-core on lib.rs](https://lib.rs/crates/veilid-core)
+- [Veilid developer book — Why Veilid](https://veilid.gitlab.io/developer-book/why-veilid/index.html)
+- mvm `specs/adrs/003-hypervisor-egress-policy.md`
+- mvm `crates/mvm-net/src/{provider,enforcement,registry,lib}.rs`
+- mvm `crates/mvm-hostd/src/smoltcp_egress.rs`, `crates/mvm-runtime/src/network_provider.rs`


### PR DESCRIPTION
## Summary

Backlog research notes from working through `specs/scratch.md` — grounded analyses, **no code changes**. Each note leads with a clear recommendation. These seed follow-up PRs; nothing here commits mvm to any of them.

## Notes

- **`serde-jcs-rfc8785-keyorder-nonconformance.md`** — `serde_jcs` 0.1.0 sorts object keys by UTF-8 byte value, not RFC 8785's UTF-16 code-unit order; the two diverge only for astral-plane (>U+FFFF) keys. Upstream-facing, with reproduction + a one-line fix. Follow-on to the semantic-address work (the drift-lock test that surfaced it is already on main).
- **`control-data-plane-and-provable-chains.md`** (scratch L15/L19) — plane separation is real (verb-class + a disjoint vsock port map, all funneled through the vsock-only host chokepoint); merkle/provable-content already ships (dm-verity roothash, hash-linked + Ed25519 audit log, content-addressed signed bundles, signed plans). One genuine gap: **checkpoint lineage is opaque-id-linked, not hash-linked** — bounded, dependency-free fix proposed (content-address `CheckpointMeta`, hash-link the parent, bind it into the audit chain), reusing in-tree SHA-256/Ed25519.
- **`veilid-networking-evaluation.md`** (scratch L29) — **do not adopt.** An anonymizing P2P/DHT transport is the structural inverse of mvm's audited, default-deny, vsock-only chokepoint; on the guest path it is a covert-egress channel that nullifies claim 10 + claim 13 + the audit log. Also fails limit-dependencies, hermeticity, and license constraints.
- **`complexity-simplification-analysis.md`** (scratch L33–35) — complements (does not duplicate) the existing `specs/refactor/` plan; each hotspot tagged NEW vs TRACKED. Top hotspots: builder-backend copy-paste that has **already drifted** (missing UTF-8 guards, divergent id formats across the three `*_builder.rs`), 29 aux-bin path lookups bypassing the central `aux_bin::resolve`, a 492-line prune fn → a `PruneStep` trait, 132 verbatim io-error wrapping closures. Ships 8 independently-landable quick wins.
- **`unsafe-inventory-and-nostd-wasm.md`** (scratch L45–47) — 642 unsafe sites, ~95% irreducible FFI/syscall boundary; no blanket pass warranted, just a small targeted slice (SAFETY docs on the guest-memory/virtio files, funnel `set_var` through the existing test-env helper, `forbid(unsafe_code)` on the already-clean `mvm-net`/`mvm-client`). no_std/wasm boundary correctly stays at `mvm-protocol`.
- **`external-sandbox-refactor-lessons.md`** (scratch L51) — mostly convergence: an external offering independently validates mvm's self-VMM / trimmed-kernel / warm-snapshot / host-side-secrets bets. One borrow worth considering (admission-safe CoW snapshot-and-fork as an agent DX primitive); clear rejects (guest-NIC eBPF data plane, mutable-store-as-control-authority) that would break mvm invariants.
