### PR TITLE
Document broad BDD coverage expectation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ No task is complete without tests. Every feature, bug fix, or refactor must incl
 
 ## Test Expectations
 
+- Broad product coverage: cover as much of the product as practical with behavior-driven development (BDD) tests that exercise user-visible workflows end to end. Add or update BDD scenarios whenever behavior changes, while retaining focused unit and integration tests for lower-level logic and failure paths.
 - New types: serde roundtrip tests, default value tests where applicable.
 - New protocol/wire code: roundtrip through mock I/O (e.g. `UnixStream::pair()`), error path tests (invalid input, wrong keys, malformed data).
 - New CLI flags/commands: integration tests in `tests/cli.rs` verifying help text and argument parsing.


### PR DESCRIPTION
## What changed

- Add a test expectation that behavior-driven development scenarios should cover as much of the product as practical.
- Clarify that BDD scenarios should exercise user-visible workflows end to end while focused unit and integration tests continue to cover lower-level logic and failure paths.

## Why

Make broad product-level behavioral coverage an explicit part of the project working agreement.

## Impact

Future behavior changes should add or update end-to-end BDD scenarios where practical.

## Validation

- `git diff --check -- AGENTS.md`
- Documentation-only change; no runtime tests required.
