### PR TITLE
docs+test(bdd): README accuracy pass + s8 README-contract suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,8 @@ The guest agent runs as an unprivileged uid under `setpriv`; `~/.mvm` and
 multi-tenant guests (one guest = one workload), and hardware-backed key
 attestation.
 
-- The claim ledger (claim → witness, machine-checked): [`specs/claims/catalog.md`](specs/claims/catalog.md)
+- The claim ledger (claim → witness, machine-checked): the conformance claim
+  catalog embedded in [ADR-001](specs/adrs/001-microvm-security-posture.md)
 - The source of truth (threat model, tier matrix): [ADR-001](specs/adrs/001-microvm-security-posture.md)
 - Live posture on your host: `mvmctl doctor`
 - Audit chain verification: `mvmctl trust audit verify` (exits nonzero on drift)
@@ -559,9 +560,10 @@ Ground rules (enforced by CI — see [AGENTS.md](AGENTS.md) for the full set):
   through `mvm-core::config` helpers, never inline `$HOME` joins.
 - **Specs discipline.** Design docs live in `specs/` (ADRs in `specs/adrs/`,
   plans in `specs/plans/`). If your change lands a plan workstream, tick the
-  matching boxes in the plan and `specs/REFACTOR-STATUS.md` in the same PR. If it
-  touches a security claim, keep
-  [`specs/claims/catalog.md`](specs/claims/catalog.md) in sync — the
+  matching boxes in the plan and refresh the
+  [refactor status dashboard](specs/refactor/README.md) in the same PR. If it
+  touches a security claim, keep the conformance claim catalog in
+  [ADR-001](specs/adrs/001-microvm-security-posture.md) in sync — the
   claim→witness mapping is machine-checked.
 
 Keep PRs focused (one concern each) and write commit messages that explain

--- a/crates/mvm-conformance/tests/steps/mod.rs
+++ b/crates/mvm-conformance/tests/steps/mod.rs
@@ -1,4 +1,5 @@
 //! Step definitions, one module per scenario surface.
 
 mod cli;
+mod readme_contract;
 mod workload_identity;

--- a/crates/mvm-conformance/tests/steps/readme_contract.rs
+++ b/crates/mvm-conformance/tests/steps/readme_contract.rs
@@ -1,0 +1,147 @@
+//! Steps locking the README's user-facing contract to the real `mvmctl`
+//! surface — the slice checkable without booting a builder VM or a microVM.
+//! Live-boot behaviours (a guest booted to completion, the verified-boot tamper
+//! panic, egress enforcement, vsock secret substitution) are proven by the
+//! live-KVM smokes, not here.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use assert_cmd::cargo::CommandCargoExt;
+use cucumber::{then, when};
+
+use crate::world::CliWorld;
+
+/// Repo root — two levels above this crate's manifest dir, resolved at compile
+/// time so the run is independent of the process working directory.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+/// A private, empty `MVM_HOME` for one invocation so a refusal scenario never
+/// reads or writes the developer's real `~/.mvm`. Uniqueness comes from the pid
+/// plus a monotonic counter, avoiding a temp-dir crate dependency.
+fn isolated_mvm_home() -> PathBuf {
+    static SEQ: AtomicU32 = AtomicU32::new(0);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("mvm-readme-contract-{}-{n}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create isolated MVM_HOME");
+    dir
+}
+
+/// Spawn the built `mvmctl` binary with the given whitespace-split argv,
+/// capturing its `Output`. Panics with an actionable hint if the binary is
+/// missing, mirroring the sibling `cli` steps.
+fn spawn_mvmctl(args: &str, home: Option<PathBuf>) -> std::process::Output {
+    #[allow(deprecated)] // matches the sibling cli.rs use of this API
+    let mut cmd = Command::cargo_bin("mvmctl").unwrap_or_else(|e| {
+        panic!("mvmctl binary not found ({e}) — run `cargo build --bin mvmctl` before `just bdd`")
+    });
+    if let Some(home) = home {
+        // Reconcile-on-entry converges live-VM state; disable it so a refusal
+        // guard runs against a clean slate with no host side effects.
+        cmd.env("MVM_HOME", home).env("MVM_SKIP_RECONCILE", "1");
+    }
+    cmd.args(args.split_whitespace())
+        .output()
+        .expect("failed to spawn mvmctl")
+}
+
+/// Run the real `mvmctl` against a private, empty `MVM_HOME` so the README's
+/// documented refusal/exit-code contracts are exercised hermetically.
+#[when(expr = "I run mvmctl in a clean home with {string}")]
+fn run_mvmctl_clean_home(world: &mut CliWorld, args: String) {
+    world.last_run = Some(spawn_mvmctl(&args, Some(isolated_mvm_home())));
+}
+
+/// Count the README's enumerated security claims: `N. **…` items inside the
+/// `## Security model` section only, so an unrelated numbered list elsewhere
+/// cannot inflate the count.
+fn readme_enumerated_claims() -> usize {
+    let readme = std::fs::read_to_string(repo_root().join("README.md")).expect("read README.md");
+    let mut in_section = false;
+    let mut count = 0;
+    for line in readme.lines() {
+        if line.starts_with("## Security model") {
+            in_section = true;
+            continue;
+        }
+        if in_section && line.starts_with("## ") {
+            break;
+        }
+        if in_section && is_numbered_bold_item(line) {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// A README claim item opens with `<int>. **`.
+fn is_numbered_bold_item(line: &str) -> bool {
+    match line.split_once(". ") {
+        Some((lead, rest)) => {
+            !lead.is_empty() && lead.chars().all(|c| c.is_ascii_digit()) && rest.starts_with("**")
+        }
+        None => false,
+    }
+}
+
+/// Count the `Shipped` numbered rows in the conformance claim catalog embedded
+/// in the security-posture ADR (the machine-checked claim -> witness table
+/// between its begin/end markers).
+fn catalog_shipped_claims() -> usize {
+    const BEGIN: &str = "<!-- claims-catalog:begin -->";
+    const END: &str = "<!-- claims-catalog:end -->";
+    let adr =
+        std::fs::read_to_string(repo_root().join("specs/adrs/001-microvm-security-posture.md"))
+            .expect("read the security-posture ADR");
+    let mut in_catalog = false;
+    let mut count = 0;
+    for line in adr.lines() {
+        if line.contains(BEGIN) {
+            in_catalog = true;
+            continue;
+        }
+        if line.contains(END) {
+            break;
+        }
+        if in_catalog && is_shipped_claim_row(line) {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// A catalog table row for a numbered, `Shipped` claim: `| <int> | … | Shipped |`.
+fn is_shipped_claim_row(line: &str) -> bool {
+    let cells: Vec<&str> = line.split('|').map(str::trim).collect();
+    let numbered = cells
+        .get(1)
+        .is_some_and(|c| !c.is_empty() && c.chars().all(|ch| ch.is_ascii_digit()));
+    let shipped = cells
+        .iter()
+        .rev()
+        .find(|c| !c.is_empty())
+        .is_some_and(|c| *c == "Shipped");
+    numbered && shipped
+}
+
+/// Cross-check: the README's enumerated claim count and the catalog's `Shipped`
+/// claim count both equal the documented number. Locks the README summary to the
+/// machine-checked ledger — either one drifting fails this step.
+#[then(expr = "the README and the claim catalog agree on {int} numbered claims")]
+fn readme_and_catalog_agree(_world: &mut CliWorld, expected: usize) {
+    let readme = readme_enumerated_claims();
+    let catalog = catalog_shipped_claims();
+    assert_eq!(
+        readme, expected,
+        "README enumerates {readme} security claims, expected {expected}"
+    );
+    assert_eq!(
+        catalog, expected,
+        "conformance catalog lists {catalog} Shipped claims, expected {expected}"
+    );
+}

--- a/features/suites/s8_readme_contract/readme_contract.feature
+++ b/features/suites/s8_readme_contract/readme_contract.feature
@@ -1,0 +1,93 @@
+Feature: README CLI contract
+
+  The README's user-facing surface — the verbs, subcommands, and flags it shows,
+  the refusals it promises, and the security-claim count it advertises — must
+  match the real `mvmctl` binary. Every scenario here is checkable in PR CI
+  without `/dev/kvm`: it drives `mvmctl --help` / `<verb> --help`, exercises a
+  refusal path that fails before any VM boot or network fetch, or cross-reads two
+  in-tree docs.
+
+  Behaviours the README can only prove live are deliberately out of this suite's
+  scope and are covered by the live-KVM smokes instead: an actual `machine run`
+  booting a guest to completion, the dm-verity tamper panic before userspace,
+  default-deny egress enforcement on a running guest, and secret substitution
+  over vsock. None of those can run where there is no `/dev/kvm`.
+
+  Scenario: the README's documented top-level verbs are discoverable
+    When I run mvmctl with "--help"
+    Then the command exits with code 0
+    And the help output lists the "machine" verb
+    And the help output lists the "build" verb
+    And the help output lists the "kernel" verb
+    And the help output lists the "doctor" verb
+    And the help output lists the "bootstrap" verb
+
+  Scenario: the SDK-transport `run` verb resolves even though it is hidden
+    # `run --mode live/plan` is documented in the SDK section but hidden from the
+    # top-level verb list, so it is checked by resolving its own help.
+    When I run mvmctl with "run --help"
+    Then the command exits with code 0
+    And the help output contains "--mode"
+    And the help output contains "Plan transport"
+    And the help output contains "Live transport"
+
+  Scenario: `trust audit verify` is a real command
+    When I run mvmctl with "trust audit --help"
+    Then the command exits with code 0
+    And the help output lists the "verify" verb
+
+  Scenario: the persistent-machine subcommands the README documents exist
+    When I run mvmctl with "machine --help"
+    Then the command exits with code 0
+    And the help output lists the "create" verb
+    And the help output lists the "start" verb
+    And the help output lists the "exec" verb
+    And the help output lists the "logs" verb
+    And the help output lists the "reconfigure" verb
+    And the help output lists the "stop" verb
+    And the help output lists the "rm" verb
+    And the help output lists the "ls" verb
+    And the help output lists the "inspect" verb
+
+  Scenario: the `machine run` flags the README's examples use exist
+    When I run mvmctl with "machine run --help"
+    Then the command exits with code 0
+    And the help output contains "--image"
+    And the help output contains "--flake"
+    And the help output contains "--allow-host"
+    And the help output contains "--cpus"
+    And the help output contains "--memory"
+    And the help output contains "--mount"
+    And the help output contains "--entrypoint"
+    And the help output contains "-i, --interactive"
+
+  Scenario: `build compile` exposes the documented IR flags
+    When I run mvmctl with "build compile --help"
+    Then the command exits with code 0
+    And the help output contains "--from-ir"
+    And the help output contains "--out"
+
+  Scenario: `kernel build --which workload` is a documented option
+    When I run mvmctl with "kernel build --help"
+    Then the command exits with code 0
+    And the help output contains "--which"
+    And the help output contains "workload"
+
+  Scenario: `run --image --prod` refuses a mutable OCI tag before any network fetch
+    # Backs the README OCI section: `--prod` refuses mutable tags before fetch.
+    # The guard is a pure reference-string check, so it never boots a VM or
+    # touches the network — exactly the CI-checkable slice of claim 14.
+    When I run mvmctl in a clean home with "run --image alpine:latest --prod -- echo hi"
+    Then the command exits with code 1
+    And the error output contains "requires a digest-pinned reference"
+
+  Scenario: `image pull --prod` refuses a mutable tag before any network fetch
+    When I run mvmctl in a clean home with "image pull --prod alpine:latest"
+    Then the command exits with code 1
+    And the error output contains "requires a digest-pinned reference"
+
+  Scenario: the README's claim count matches the machine-checked ledger
+    # The README summarizes fifteen numbered claims; the in-tree conformance
+    # catalog is the machine-checked claim -> witness ledger. Locking them
+    # together fails this scenario the moment either drifts.
+    Then the README and the claim catalog agree on 15 numbered claims


### PR DESCRIPTION
## Summary

README accuracy pass + a CI-checkable README-contract BDD suite. **No product-code change** — docs + test-only.

## Deliverable 1 — README accuracy

Fixed 3 stale doc-links left over from the v1 restructure (both original targets are gone from `main` — verified with `git cat-file`):
- `specs/claims/catalog.md` → the conformance claim catalog embedded in [ADR-001](specs/adrs/001-microvm-security-posture.md) (what the claim gate actually parses).
- `specs/REFACTOR-STATUS.md` → [`specs/refactor/README.md`](specs/refactor/README.md) (the refactor status dashboard).

Everything else verified accurate and left unchanged: every documented `mvmctl` command/subcommand/flag exists in the clap tree and `--help`; "14-crate workspace", "fifteen numbered claims (+ preview)", backend selection (HVF/libkrun/Firecracker), vsock `:5252`, TCP/22-always-refused, `SandboxDevOnly`, the `MachineSpec::builder(...)` API.

> Note: `CLAUDE.md` and `AGENTS.md` still reference the same two removed paths — out of scope for this PR, flagged for a follow-up.

## Deliverable 2 — `s8_readme_contract` BDD

10 scenarios driving the real `mvmctl`, all checkable without `/dev/kvm`:
- top-level + subcommand help lists the documented verbs/flags (machine run/create/…, build compile `--from-ir`/`--out`, kernel build `--which workload`, hidden `run`/`trust audit verify`);
- the `run --image --prod` and `image pull --prod` mutable-tag refusals (exit 1, verified to fire before any network/VM);
- a cross-check that the README's numbered-claim count equals the machine-checked catalog.

New hermetic step runs `mvmctl` under a private empty `MVM_HOME` so refusal contracts never touch real `~/.mvm`. Live-VM behaviors (actual boot, dm-verity panic, egress enforcement, secret substitution) are explicitly left to live-KVM smokes, noted in the feature header.

## Behavior note surfaced

`mvmctl machine run` does **not** honor `--prod` as a pin gate (the flag is swallowed into argv; the path hardcodes `prod: false`). The real prod mutable-tag refusal lives on `run --image --prod` and `image pull --prod`, which is what these scenarios assert. Flagged as a possible UX gap — not changed here.

## Testing

nextest 7570 passed / 12 skipped · `just bdd` 4 features / 23 scenarios / 113 steps · clippy `--all-targets -D warnings` · nightly fmt · doctests · check-no-spec-refs · check-doc-claims.
