### PR TITLE
Gate release publishing on BDD tests

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -1,0 +1,48 @@
+name: BDD conformance gate
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  bdd:
+    name: BDD conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install system build dependencies
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
+          sudo apt-get update
+          sudo apt-get install -y libcap-ng-dev lld
+
+      - uses: ./.github/actions/install-zigbuild
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-bdd-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-bdd-
+
+      - name: Run BDD conformance suite
+        run: just bdd

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -29,8 +29,14 @@ permissions:
   contents: write # release asset upload on tags
 
 jobs:
+  bdd:
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/bdd.yml
+
   kernel:
     name: Build kernels (${{ matrix.arch }})
+    needs: [bdd]
+    if: ${{ always() && (needs.bdd.result == 'success' || needs.bdd.result == 'skipped') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -26,7 +26,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  bdd:
+    uses: ./.github/workflows/bdd.yml
+
   publish:
+    needs: [bdd]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -27,6 +27,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  bdd:
+    if: ${{ github.event_name == 'release' }}
+    uses: ./.github/workflows/bdd.yml
+
   preflight:
     if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'sdk-v') }}
     runs-on: ubuntu-latest
@@ -107,7 +111,7 @@ jobs:
 
   publish_pypi_release:
     if: ${{ github.event_name == 'release' }}
-    needs: preflight
+    needs: [preflight, bdd]
     uses: ./.github/workflows/publish-pypi.yml
     with:
       dry_run: false
@@ -121,7 +125,7 @@ jobs:
 
   publish_npm_release:
     if: ${{ github.event_name == 'release' }}
-    needs: preflight
+    needs: [preflight, bdd]
     uses: ./.github/workflows/publish-npm.yml
     with:
       dry_run: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ env:
   MVMCTL_RELEASE_FEATURES: host,user,template-registry-s3,release-artifact-bootstrap
 
 jobs:
+  bdd:
+    uses: ./.github/workflows/bdd.yml
+
   build:
     strategy:
       # Each target publishes independently — one target's failure must not
@@ -618,7 +621,7 @@ jobs:
             staging/default-microvm-${{ matrix.arch }}-checksums-sha256.txt
 
   release:
-    needs: [build, builder-vm-image, runtime-overlay-image, default-microvm]
+    needs: [bdd, build, builder-vm-image, runtime-overlay-image, default-microvm]
     # Gate the published release on the mvmctl binary build ONLY. The Nix
     # image jobs still run and their artifacts are attached when present,
     # but an image-build failure must not block the binary download
@@ -628,7 +631,7 @@ jobs:
     # Dry-run guard: a `workflow_dispatch` with dry_run=true builds + packages
     # (the `build` job) but never reaches this publish job — only a tag push or
     # an explicit dry_run=false dispatch publishes.
-    if: ${{ !cancelled() && needs.build.result == 'success' && (github.event_name == 'push' || github.event.inputs.dry_run == 'false') }}
+    if: ${{ !cancelled() && needs.bdd.result == 'success' && needs.build.result == 'success' && (github.event_name == 'push' || github.event.inputs.dry_run == 'false') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -173,6 +173,7 @@ Checkbox legend: `- [ ]` todo. Each WS lists its acceptance gate. Execution is s
 
 **WS0.6 — BDD conformance harness (cucumber-rs)** (see §2.7)
 - [ ] Add `features/suites/sN_<name>/` + the `crates/mvm-conformance` cucumber-rs runner + a `just bdd` recipe (folded into `just ci`); seed scenarios for the current security claims and the top-level CLI verbs, wired through `mvm-client`.
+  - [x] Gate every software-publication path on a reusable GitHub Actions workflow that runs `just bdd`: runtime releases, kernel release assets, SDK registry releases, and crates.io publication. Keep emergency revocation-list publication independent of the product suite.
 - [ ] Standing rule for every later WS: land its Gherkin scenarios in the same change (feature-first — the scenario is written and red before the implementation).
 - Gate: `just bdd` green in CI; each security claim has a scenario.
 

--- a/specs/refactor/06-execution-plan.md
+++ b/specs/refactor/06-execution-plan.md
@@ -26,6 +26,7 @@ Note: by the time of writing, this WS has run further than "~15" — the ADR set
 
 **WS0.6 — BDD conformance harness (cucumber-rs)** (see [05-sdk-and-testing.md](05-sdk-and-testing.md))
 - [ ] Add `features/suites/sN_<name>/` + the `crates/mvm-conformance` cucumber-rs runner + a `just bdd` recipe (folded into `just ci`); seed scenarios for the current security claims and the top-level CLI verbs, wired through `mvm-client`.
+  - [x] Gate every software-publication path on a reusable GitHub Actions workflow that runs `just bdd`: runtime releases, kernel release assets, SDK registry releases, and crates.io publication. Keep emergency revocation-list publication independent of the product suite.
 - [ ] Standing rule for every later WS: land its Gherkin scenarios in the same change (feature-first — the scenario is written and red before the implementation).
 - Gate: `just bdd` green in CI; each security claim has a scenario.
 

--- a/specs/refactor/07-progress-and-decisions.md
+++ b/specs/refactor/07-progress-and-decisions.md
@@ -9,6 +9,7 @@ The execution reality: what's landed, what's been deliberately deviated from pla
 - **92 → 30 ADRs, renumbered contiguous 001–030**, rewritten to absolute decision form (17,973 → 3,912 lines). All machine-checked gates green on the resulting set: claim-catalog (16 claims / 38 witnesses), trust-gradient, adr-coverage. Detail: [08-adr-consolidation.md](08-adr-consolidation.md).
 - **Dead workspace deps dropped** (`dfc70f6a7`).
 - **BDD cucumber harness** scaffolded.
+- **BDD publication gate** wired: runtime releases, kernel release assets, SDK registry releases, and crates.io publication all depend on one reusable workflow that runs `just bdd`; structural tests prevent those dependencies from being removed silently. Emergency revocation-list publication remains independent so urgent trust revocations cannot be delayed by the product suite.
 - **Worktrees swept** to the 2-tree working set.
 - **SDK python/typescript moved** to `crates/mvm-sdk/sdks/`.
 - **`bin/dev` → `scripts/dev`.**

--- a/tests/github_actions_bdd_gate.rs
+++ b/tests/github_actions_bdd_gate.rs
@@ -1,0 +1,100 @@
+use std::fs;
+use std::path::Path;
+
+const WORKFLOWS: &str = ".github/workflows";
+
+fn workflow(name: &str) -> String {
+    fs::read_to_string(Path::new(WORKFLOWS).join(name))
+        .unwrap_or_else(|error| panic!("failed to read {name}: {error}"))
+}
+
+fn job_block<'a>(workflow: &'a str, job: &str) -> &'a str {
+    let marker = format!("  {job}:\n");
+    let start = workflow
+        .find(&marker)
+        .unwrap_or_else(|| panic!("workflow is missing the {job} job"));
+    let rest_start = start + marker.len();
+    let rest = &workflow[rest_start..];
+    let end = rest
+        .match_indices("\n  ")
+        .find_map(|(offset, _)| {
+            let line = rest[offset + 1..].lines().next()?;
+            (!line.starts_with("    ") && line.ends_with(':')).then_some(rest_start + offset)
+        })
+        .unwrap_or(workflow.len());
+    &workflow[start..end]
+}
+
+fn assert_reuses_bdd_gate(workflow_name: &str) {
+    let contents = workflow(workflow_name);
+    let bdd = job_block(&contents, "bdd");
+    assert!(
+        bdd.contains("uses: ./.github/workflows/bdd.yml"),
+        "{workflow_name} must reuse the canonical BDD workflow"
+    );
+}
+
+fn assert_job_needs_bdd(workflow_name: &str, job: &str) {
+    let contents = workflow(workflow_name);
+    let block = job_block(&contents, job);
+    let needs_line = block
+        .lines()
+        .find(|line| line.trim_start().starts_with("needs:"))
+        .unwrap_or_else(|| panic!("{workflow_name}'s {job} job must declare needs"));
+    assert!(
+        needs_line.contains("bdd"),
+        "{workflow_name}'s {job} job must depend on the BDD gate"
+    );
+}
+
+fn assert_job_contains(workflow_name: &str, job: &str, expected: &str) {
+    let contents = workflow(workflow_name);
+    let block = job_block(&contents, job);
+    assert!(
+        block.contains(expected),
+        "{workflow_name}'s {job} job must contain {expected:?}"
+    );
+}
+
+#[test]
+fn canonical_bdd_workflow_runs_the_full_suite() {
+    let contents = workflow("bdd.yml");
+    assert!(contents.contains("  workflow_call:"));
+    assert!(contents.contains("run: just bdd"));
+}
+
+#[test]
+fn runtime_release_publication_needs_bdd() {
+    assert_reuses_bdd_gate("release.yml");
+    assert_job_needs_bdd("release.yml", "release");
+    assert_job_contains("release.yml", "release", "needs.bdd.result == 'success'");
+}
+
+#[test]
+fn kernel_release_asset_publication_needs_bdd() {
+    assert_reuses_bdd_gate("kernel-build.yml");
+    assert_job_contains(
+        "kernel-build.yml",
+        "bdd",
+        "startsWith(github.ref, 'refs/tags/v')",
+    );
+    assert_job_needs_bdd("kernel-build.yml", "kernel");
+    assert_job_contains(
+        "kernel-build.yml",
+        "kernel",
+        "needs.bdd.result == 'success' || needs.bdd.result == 'skipped'",
+    );
+}
+
+#[test]
+fn sdk_registry_publication_needs_bdd() {
+    assert_reuses_bdd_gate("publish-sdk.yml");
+    assert_job_needs_bdd("publish-sdk.yml", "publish_pypi_release");
+    assert_job_needs_bdd("publish-sdk.yml", "publish_npm_release");
+}
+
+#[test]
+fn crates_io_publication_needs_bdd() {
+    assert_reuses_bdd_gate("publish-crates.yml");
+    assert_job_needs_bdd("publish-crates.yml", "publish");
+}


### PR DESCRIPTION
## Summary

- add one reusable GitHub Actions workflow that runs the canonical `just bdd` suite
- require that gate before runtime releases, versioned kernel assets, SDK registry releases, and crates.io publication
- add structural regression tests that keep every publication job dependent on the BDD gate
- document the gate while keeping emergency revocation-list publication independent

## Why

Publication workflows previously relied on their own build or preflight jobs and could publish a new version without running the product-level BDD conformance suite. This makes BDD success a direct prerequisite of every normal software publication path.

## Validation

- `just bdd` — 13 scenarios and 62 steps passed
- `cargo test --test github_actions_bdd_gate` — 5 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `actionlint -shellcheck=` on all affected workflows
- `cargo test --workspace` reached an existing parallel shared-state race in two unrelated `mvm-runtime` tests; both tests pass when rerun individually
