### PR TITLE
feat(runtime): route libkrun workloads through WorkloadRunner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,10 @@ version = "0.18.0"
 dependencies = [
  "assert_cmd",
  "cucumber",
+ "mvm-core",
+ "mvm-runtime",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/crates/mvm-cli/src/doctor/security.rs
+++ b/crates/mvm-cli/src/doctor/security.rs
@@ -187,7 +187,6 @@ mod tests {
             ordered,
             vec![
                 ("firecracker".to_string(), true),
-                ("libkrun".to_string(), false),
                 ("qemu".to_string(), false),
             ]
         );

--- a/crates/mvm-cli/src/doctor/warm_start.rs
+++ b/crates/mvm-cli/src/doctor/warm_start.rs
@@ -20,7 +20,8 @@ pub(super) struct WarmStartReport {
     substrate: Option<WarmStartSubstrate>,
     /// Backend name → `supports_standby_pool()`. The standby pool
     /// (pre-pay spawn/codesign latency) is a *different* axis from the snapshot tier above;
-    /// only libkrun implements it today.
+    /// Firecracker implements it today; backends without warm-start support
+    /// are omitted with the rest of their warm-start row.
     standby_pool: BTreeMap<String, bool>,
     /// Live count of idle standbys recorded under `~/.mvm/pool/` (best-effort; `None` if
     /// the pool dir can't be read).
@@ -112,9 +113,9 @@ pub(super) fn render_capability_table(rows: &[BackendCapabilityRow]) {
 }
 
 /// Enumerate every backend's `snapshot_capability()` tier and, on Linux,
-/// probe the fast-resume substrate. Surfaced so a user knows which backend
-/// resumes from RAM (Firecracker live-memory, HVF save/restore) vs. reboots
-/// from a disk snapshot (libkrun) before relying on a warm start.
+/// probe the fast-resume substrate. Surfaced so a user knows which admitted
+/// backend resumes from RAM vs. reboots from a disk snapshot before relying
+/// on a warm start.
 pub(super) fn collect_warm_start_support() -> WarmStartReport {
     let mut backends = BTreeMap::new();
     let mut standby_pool = BTreeMap::new();
@@ -205,7 +206,7 @@ pub(super) fn render_warm_start_support(r: &WarmStartReport) {
     }
 
     // The standby pool (pre-pay spawn latency), a separate axis from
-    // the snapshot tiers above. Only libkrun implements it today.
+    // the snapshot tiers above.
     let pool_title = "Standby pool (per backend)";
     println!("\n{}", pool_title);
     println!("{}", "-".repeat(pool_title.len()));
@@ -233,7 +234,7 @@ mod tests {
         let r = collect_warm_start_support();
         // The honest per-backend warm-start matrix.
         assert_eq!(r.backends.get("firecracker"), Some(&"live-memory"));
-        assert_eq!(r.backends.get("libkrun"), Some(&"disk-only"));
+        assert_eq!(r.backends.get("libkrun"), None);
         assert_eq!(r.backends.get("qemu"), Some(&"disk-only"));
     }
 
@@ -247,7 +248,6 @@ mod tests {
             ordered_backends,
             vec![
                 ("firecracker".to_string(), "live-memory"),
-                ("libkrun".to_string(), "disk-only"),
                 ("qemu".to_string(), "disk-only"),
             ]
         );
@@ -255,7 +255,6 @@ mod tests {
             ordered_standby_pool,
             vec![
                 ("firecracker".to_string(), true),
-                ("libkrun".to_string(), true),
                 ("qemu".to_string(), false),
             ]
         );
@@ -264,10 +263,10 @@ mod tests {
     #[test]
     fn collect_warm_start_support_reports_standby_pool_per_backend() {
         let r = collect_warm_start_support();
-        // Firecracker and libkrun implement the standby pool; QEMU does not.
-        // Report honest values for every backend; none may be silently dropped.
+        // Firecracker implements the standby pool; QEMU does not. The runner
+        // seam does not expose libkrun's legacy standby implementation.
         assert_eq!(r.standby_pool.get("firecracker"), Some(&true));
-        assert_eq!(r.standby_pool.get("libkrun"), Some(&true));
+        assert_eq!(r.standby_pool.get("libkrun"), None);
         assert_eq!(r.standby_pool.get("qemu"), Some(&false));
     }
 
@@ -276,10 +275,10 @@ mod tests {
         let rows = collect_capability_table();
         let by = |name: &str| rows.iter().find(|r| r.backend == name).cloned();
 
-        // The Tier 3 `mock` test double is excluded; the three real
-        // backends are present, in stable name order.
+        // The Tier 3 `mock` test double and backends without warm-start
+        // support are excluded; the remaining rows use stable name order.
         let names: Vec<_> = rows.iter().map(|r| r.backend.as_str()).collect();
-        assert_eq!(names, vec!["firecracker", "libkrun", "qemu"]);
+        assert_eq!(names, vec!["firecracker", "qemu"]);
 
         let fc = by("firecracker").unwrap();
         assert_eq!(fc.snapshot_tier, "live-memory");
@@ -291,17 +290,7 @@ mod tests {
             "Firecracker implements live standby warm-spawn"
         );
 
-        let krun = by("libkrun").unwrap();
-        assert_eq!(krun.snapshot_tier, "disk-only");
-        assert!(
-            !krun.tap_networking,
-            "libkrun uses a userspace gateway, not a host TAP"
-        );
-        assert!(krun.vsock);
-        assert!(
-            krun.standby_pool,
-            "libkrun still pre-pays spawn latency through the supervisor pool"
-        );
+        assert!(by("libkrun").is_none());
 
         let qemu = by("qemu").unwrap();
         assert_eq!(qemu.snapshot_tier, "disk-only");

--- a/crates/mvm-conformance/Cargo.toml
+++ b/crates/mvm-conformance/Cargo.toml
@@ -37,6 +37,12 @@ assert_cmd.workspace = true
 # Parses the `build address --json` report in the workload-identity steps.
 # Dev-only: `cargo tree -p mvm-conformance -e no-dev` must not gain it.
 serde_json.workspace = true
+# Drives the real VMM-driver bootargs and libkrun kernel-mapping seams without
+# starting a VM. `test-support` keeps the conformance-only inspection helpers
+# out of production builds.
+mvm-runtime = { workspace = true, features = ["test-support"] }
+mvm-core = { workspace = true, features = ["test-support"] }
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/mvm-conformance/tests/steps/mod.rs
+++ b/crates/mvm-conformance/tests/steps/mod.rs
@@ -2,4 +2,5 @@
 
 mod cli;
 mod readme_contract;
+mod verified_boot;
 mod workload_identity;

--- a/crates/mvm-conformance/tests/steps/verified_boot.rs
+++ b/crates/mvm-conformance/tests/steps/verified_boot.rs
@@ -1,0 +1,109 @@
+//! Steps for verified-boot contracts shared by the workload runner and its
+//! concrete VMM drivers. These exercise pure assembly/mapping seams and never
+//! start a VM, so they run in the normal hermetic BDD gate.
+
+use cucumber::{then, when};
+use mvm_core::kernel_format::KernelFormat;
+use mvm_core::vm_backend::{RuntimeSourcePolicy, VmStartConfig};
+use mvm_runtime::driver::{
+    ConsoleCapture, HvfDriver, KernelImage, LibkrunDriver, VmmDriver, VmmSpec,
+};
+
+use crate::world::CliWorld;
+
+#[when(expr = "I assemble a sealed workload cmdline for {string}")]
+fn assemble_sealed_cmdline(world: &mut CliWorld, backend: String) {
+    let state = tempfile::tempdir().expect("create cmdline state dir");
+    let config = VmStartConfig {
+        name: format!("bdd-{backend}-sealed-boot"),
+        rootfs_path: "/image/rootfs.ext4".to_string(),
+        verity_path: Some("/image/rootfs.verity".to_string()),
+        roothash: Some("a".repeat(64)),
+        initrd_path: Some("/image/rootfs.initrd".to_string()),
+        runtime_overlay_path: Some("/image/runtime.ext4".to_string()),
+        runtime_overlay_verity_path: Some("/image/runtime.verity".to_string()),
+        runtime_overlay_roothash: Some("b".repeat(64)),
+        runtime_source_policy: RuntimeSourcePolicy::RequiredOverlay,
+        ..Default::default()
+    };
+    let driver: Box<dyn VmmDriver> = match backend.as_str() {
+        "libkrun" => Box::new(LibkrunDriver::new()),
+        "hvf" => Box::new(HvfDriver::new()),
+        _ => panic!("unsupported verified-boot BDD backend {backend:?}"),
+    };
+    world.workload_cmdline = Some(
+        mvm_runtime::workload_runner::assemble_workload_cmdline_for_test(
+            driver.as_ref(),
+            &config,
+            state.path(),
+        ),
+    );
+}
+
+#[then(expr = "the sealed workload cmdline contains {string}")]
+fn sealed_cmdline_contains(world: &mut CliWorld, expected: String) {
+    let cmdline = world
+        .workload_cmdline
+        .as_deref()
+        .expect("a prior step must assemble the workload cmdline");
+    assert!(
+        cmdline.contains(&expected),
+        "expected sealed workload cmdline to contain {expected:?}: {cmdline}"
+    );
+}
+
+#[then(expr = "the sealed workload cmdline omits {string}")]
+fn sealed_cmdline_omits(world: &mut CliWorld, unexpected: String) {
+    let cmdline = world
+        .workload_cmdline
+        .as_deref()
+        .expect("a prior step must assemble the workload cmdline");
+    assert!(
+        !cmdline.contains(&unexpected),
+        "expected sealed workload cmdline to omit {unexpected:?}: {cmdline}"
+    );
+}
+
+#[when("I map an existing ELF workload kernel through the libkrun driver")]
+fn map_elf_kernel(world: &mut CliWorld) {
+    let state = tempfile::tempdir().expect("create libkrun mapping state dir");
+    let kernel = state.path().join("vmlinux");
+    std::fs::write(&kernel, b"\x7fELFconformance-kernel").expect("write ELF kernel fixture");
+    let spec = VmmSpec {
+        name: "bdd-libkrun-kernel-format".to_string(),
+        kernel: KernelImage::Path(kernel.clone()),
+        initramfs: None,
+        cmdline: String::new(),
+        vcpus: 1,
+        memory_mib: 128,
+        mem_initial_mib: None,
+        blocks: vec![],
+        vsock: vec![],
+        console: ConsoleCapture {
+            log_path: state.path().join("console.log"),
+        },
+        trusted_builder: false,
+    };
+    let (mapped_path, format) =
+        mvm_runtime::driver::libkrun::map_kernel_for_test(&spec, state.path())
+            .expect("map libkrun kernel through supervisor config");
+    assert_eq!(
+        mapped_path.as_deref(),
+        kernel.to_str(),
+        "libkrun must preserve the mapped workload kernel path"
+    );
+    world.libkrun_kernel_format = Some(format);
+}
+
+#[then("the libkrun kernel format matches the current host architecture")]
+fn kernel_format_matches_host(world: &mut CliWorld) {
+    let format = world
+        .libkrun_kernel_format
+        .expect("a prior step must map the libkrun kernel");
+    let expected = if cfg!(target_arch = "x86_64") {
+        KernelFormat::Elf
+    } else {
+        KernelFormat::Raw
+    };
+    assert_eq!(format, expected);
+}

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -3,6 +3,8 @@
 use std::collections::HashMap;
 use std::process::Output;
 
+use mvm_core::kernel_format::KernelFormat;
+
 /// Constructed fresh for every scenario. Holds the result of the most
 /// recent CLI invocation so later `Then` steps can assert on it, plus the
 /// workload identities parsed from successful `build address` runs, keyed by
@@ -15,6 +17,10 @@ pub struct CliWorld {
     pub addresses: HashMap<String, String>,
     /// `ir_hash` per fixture name, from the same run as `addresses`.
     pub ir_hashes: HashMap<String, String>,
+    /// Full sealed-workload cmdline assembled through a real VMM driver.
+    pub workload_cmdline: Option<String>,
+    /// Kernel format mapped by the libkrun supervisor-config seam.
+    pub libkrun_kernel_format: Option<KernelFormat>,
 }
 
 impl CliWorld {

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -11,10 +11,9 @@ use mvm_core::vm_backend::{
 // (`config`, `shell`, `runtime_meta`) lives in `crate::base`.
 use crate::base::config::{PortMapping, VmSlot};
 use crate::base::shell::run_in_vm_stdout;
-use crate::driver::HvfDriver;
+use crate::driver::{HvfDriver, LibkrunDriver};
 use crate::hvf_backend::HvfBackend;
 use crate::image::RuntimeVolume;
-use crate::libkrun::LibkrunBackend;
 use crate::microvm::{DriveFile, FlakeRunConfig};
 #[cfg(feature = "test-support")]
 use crate::mock::MockBackend;
@@ -27,6 +26,25 @@ use crate::{firecracker, microvm};
 /// driver seam. One alias keeps the long generic instantiation readable at the
 /// enum variant and its construction site.
 type HvfRunner = WorkloadRunner<HvfDriver, RealEndpointSpawner, RealBrokerRegistrar>;
+
+/// libkrun driven through the same unified workload-runner role — libkrun's
+/// sole production launch path (both `--hypervisor libkrun` and `auto_select`).
+/// Egress routes to the per-VM gating endpoint over vsock only; the raw
+/// [`LibkrunBackend`](crate::libkrun::LibkrunBackend) shim stays behind the
+/// driver as its identity delegate and for the live benchmark, unreached via
+/// this enum.
+type LibkrunRunner = WorkloadRunner<LibkrunDriver, RealEndpointSpawner, RealBrokerRegistrar>;
+
+/// Construct libkrun's workload runner. The runner is not const-constructible,
+/// so this helper is the one construction site the enum variant, `auto_select`,
+/// the descriptor catalog, and the capability selector all call.
+pub(crate) fn libkrun_runner() -> LibkrunRunner {
+    WorkloadRunner::new(
+        LibkrunDriver::new(),
+        RealEndpointSpawner,
+        RealBrokerRegistrar,
+    )
+}
 
 /// Firecracker VM configuration for the [`VmBackend`] trait.
 ///
@@ -478,8 +496,12 @@ impl BackendTier {
 /// backend is active. Each variant delegates to its inner implementation.
 pub enum AnyBackend {
     Firecracker(FirecrackerBackend),
-    /// libkrun — Linux KVM / macOS Apple Silicon HVF.
-    Libkrun(LibkrunBackend),
+    /// libkrun (Linux KVM / macOS Apple Silicon HVF), driven through the unified
+    /// `WorkloadRunner` over the driver seam — libkrun's sole production path,
+    /// selected by `--hypervisor libkrun` and `auto_select`. Egress routes to
+    /// the per-VM gating endpoint over vsock only (claim-10 + claims 12/13 at
+    /// the endpoint); no transparent `:80/:443` terminator.
+    Libkrun(LibkrunRunner),
     /// QEMU workload runtime — Linux dev/test substrate (KVM where
     /// present, TCG fallback). Opt-in via `--hypervisor qemu` /
     /// `MVM_BACKEND=qemu`; `auto_select` never picks it (Firecracker
@@ -613,9 +635,9 @@ impl AnyBackend {
             return Self::Hvf(HvfBackend);
         }
 
-        // 3. libkrun installed → use the raw libkrun shim.
+        // 3. libkrun installed → the libkrun workload runner (vsock-only egress).
         if plat.has_libkrun() {
-            return Self::Libkrun(LibkrunBackend);
+            return Self::Libkrun(libkrun_runner());
         }
 
         // Final default. Reachable when no tier is available; start()
@@ -1290,8 +1312,8 @@ mod tests {
                     Some("libkrun.pid"),
                     Some(2),
                     true,
-                    true,
-                    true,
+                    false,
+                    false,
                 ),
                 (
                     "qemu",
@@ -1424,7 +1446,8 @@ mod tests {
         // A live-memory warm-start asked of libkrun's disk-only tier must
         // fail closed (no cold-boot fallback) and name a recovery action.
         // The Unsupported branch returns before any boot, so this needs
-        // no VM/KVM.
+        // no VM/KVM. Post-runner-flip libkrun takes the trait-default warm_start,
+        // whose hint points at a cold boot rather than naming a sibling backend.
         use mvm_core::vm_backend::WarmStartError;
         let cfg = VmStartConfig {
             name: "warm-gate-test".into(),
@@ -1441,7 +1464,7 @@ mod tests {
             }) => {
                 assert_eq!(requested, SnapshotCapability::LiveMemory);
                 assert_eq!(available, SnapshotCapability::DiskOnly);
-                assert!(hint.contains("Firecracker"), "{hint}");
+                assert!(hint.contains("cold boot"), "{hint}");
             }
             other => panic!("expected Unsupported, got {other:?}"),
         }
@@ -1631,7 +1654,7 @@ mod tests {
         // (the raw backend and the WorkloadRunner-driven role-runner path).
         let mut backends: Vec<(&str, AnyBackend)> = vec![
             ("firecracker", AnyBackend::Firecracker(FirecrackerBackend)),
-            ("libkrun", AnyBackend::Libkrun(LibkrunBackend)),
+            ("libkrun", AnyBackend::Libkrun(libkrun_runner())),
             ("qemu", AnyBackend::Qemu(QemuBackend)),
             ("hvf", AnyBackend::Hvf(HvfBackend)),
             (

--- a/crates/mvm-runtime/src/catalog.rs
+++ b/crates/mvm-runtime/src/catalog.rs
@@ -13,7 +13,6 @@
 //! the closed enum for the few intentionally backend-specific operations.
 
 use crate::backend::{AnyBackend, BackendTier, FirecrackerBackend};
-use crate::libkrun::LibkrunBackend;
 #[cfg(feature = "test-support")]
 use crate::mock::MockBackend;
 use crate::qemu::QemuBackend;
@@ -162,13 +161,16 @@ backend_catalog![
         kind: Libkrun,
         selector: "libkrun",
         aliases: ["krun"],
-        constructor: AnyBackend::Libkrun(LibkrunBackend),
+        constructor: AnyBackend::Libkrun(crate::backend::libkrun_runner()),
         tier: Tier2,
         marker_file: Some("libkrun.pid"),
         started_vm_probe_order: Some(2),
         list_all: true,
-        balloon_support: true,
-        warm_start_support: true,
+        // The runner takes the trait-default warm-start/standby (no live-memory
+        // snapshot, no standby pool) and reports no balloon elasticity, so
+        // libkrun drops off the balloon + warm-start doctor surfaces.
+        balloon_support: false,
+        warm_start_support: false,
         bundled_kernel: true,
         needs_plan_json: false,
         is_workload: true
@@ -349,11 +351,11 @@ mod tests {
     fn descriptor_surface_ordering_is_frozen() {
         assert_eq!(
             selectors(balloon_support_descriptors()),
-            ["firecracker", "libkrun", "qemu"]
+            ["firecracker", "qemu"]
         );
         assert_eq!(
             selectors(warm_start_support_descriptors()),
-            ["firecracker", "libkrun", "qemu"]
+            ["firecracker", "qemu"]
         );
         assert_eq!(
             selectors(list_all_descriptors()),

--- a/crates/mvm-runtime/src/driver/hvf.rs
+++ b/crates/mvm-runtime/src/driver/hvf.rs
@@ -79,14 +79,6 @@ impl SupervisorPaths {
     }
 }
 
-/// Find the host socket for a standing vsock port by its guest-port number.
-fn vsock_socket(spec: &VmmSpec, guest_port: u32) -> Option<PathBuf> {
-    spec.vsock
-        .iter()
-        .find(|p| p.guest_port == guest_port)
-        .map(|p| p.host_uds.clone())
-}
-
 /// Map a policy-free `VmmSpec` to a relay `HvfSupervisorConfig`: the supervisor
 /// wires the guest's `EGRESS_PORT` straight to the host-side endpoint bound at
 /// `egress_relay_socket`, which owns the claim-10 gate and substitution. The
@@ -119,7 +111,7 @@ fn relay_supervisor_config(spec: &VmmSpec, paths: &SupervisorPaths) -> Result<Hv
     // Guests that need host egress carry an explicit EGRESS_PORT relay socket in
     // the spec. Workloads must provide one; trusted builders now provide the same
     // vsock relay so every backend uses one egress path.
-    let egress_relay_socket = match vsock_socket(spec, EGRESS_PORT) {
+    let egress_relay_socket = match spec.host_socket_for_port(EGRESS_PORT) {
         Some(socket) => Some(socket),
         None if spec.trusted_builder => None,
         None => {
@@ -162,14 +154,14 @@ fn relay_supervisor_config(spec: &VmmSpec, paths: &SupervisorPaths) -> Result<Hv
         pid_file: paths.pid_file.clone(),
         workload_exit: paths.workload_exit.clone(),
         timeout_secs: paths.timeout_secs,
-        agent_socket: vsock_socket(spec, GUEST_AGENT_PORT),
+        agent_socket: spec.host_socket_for_port(GUEST_AGENT_PORT),
         substitution_socket: None,
         egress_relay_socket,
         // An admitted workload carries a BROKER_PORT relay socket; the supervisor
         // splices the guest's BROKER_PORT dial to it so host.audit.v1 /
         // host.secrets.v1 reach the per-VM broker (or the per-tenant host-agent
         // daemon). Absent for a builder/dev VM, which runs no admitted workload.
-        broker_socket: vsock_socket(spec, BROKER_PORT),
+        broker_socket: spec.host_socket_for_port(BROKER_PORT),
         // Builder/dev VMs carry no admitted egress tunnel.
         network_tunnel_socket: None,
         console_data_sockets,
@@ -269,7 +261,8 @@ impl VmmDriver for HvfDriver {
         // The agent RPC socket the supervisor binds for this VM (host→guest agent
         // bridge on GUEST_AGENT_PORT). Prefer the spec's own port; fall back to the
         // standing convention so a later `attach` re-derives the same path.
-        let agent_socket = vsock_socket(spec, GUEST_AGENT_PORT)
+        let agent_socket = spec
+            .host_socket_for_port(GUEST_AGENT_PORT)
             .unwrap_or_else(|| hvf_agent_socket(&paths.state_dir));
         Ok(Box::new(HvfRunningVm {
             id: VmId(spec.name.clone()),

--- a/crates/mvm-runtime/src/driver/libkrun.rs
+++ b/crates/mvm-runtime/src/driver/libkrun.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
 use libkrun_sys::{BridgeRestartPolicy, KrunContext, SupervisorConfig};
-use mvm_agentd::vsock::{CONSOLE_PORT_BASE, GUEST_AGENT_PORT, dev_console_data_ports};
+use mvm_agentd::vsock::{CONSOLE_PORT_BASE, EGRESS_PORT, GUEST_AGENT_PORT, dev_console_data_ports};
 use mvm_core::config::{vm_libkrun_pid, vm_state_dir, vm_vsock_port_socket_at};
 use mvm_core::vm_backend::{
     BackendKind, BackendSecurityProfile, GuestChannelInfo, SnapshotCapability, VmBackend,
@@ -170,11 +170,15 @@ fn relay_libkrun_supervisor_config(spec: &VmmSpec, state_dir: &Path) -> Result<S
         bundle: None,
         network_policy: None,
         bridge_restart_policy: BridgeRestartPolicy::HardFail,
-        // Pointing libkrun's egress proxy at the spawner's endpoint socket is a
-        // follow-up before this dormant driver is wired; egress is not exercised
-        // yet, so both the transparent terminator and the egress relay stay unset.
+        // No transparent :80/:443 terminator: the runner routes egress through
+        // the per-VM gating endpoint over vsock only. The runner puts that
+        // endpoint's host UDS on the spec's EGRESS_PORT channel, so pinning the
+        // guest egress port's host-listen socket to it makes the endpoint the
+        // sole path off the box — the claim-10 gate and secret substitution live
+        // there. A spec without an EGRESS_PORT channel (none of the workload
+        // paths) leaves this unset and the derived socket unchanged.
         transparent_terminator_port: None,
-        egress_relay_socket: None,
+        egress_relay_socket: spec.host_socket_for_port(EGRESS_PORT),
     })
 }
 
@@ -380,11 +384,15 @@ impl RunningVm for LibkrunRunningVm {
     }
 
     fn pause(&self) -> Result<()> {
-        bail!("libkrun does not support pause/resume")
+        bail!(
+            "pause is not supported by the libkrun backend (upstream C API does not expose vCPU pause)"
+        )
     }
 
     fn resume(&self) -> Result<()> {
-        bail!("libkrun does not support pause/resume")
+        bail!(
+            "resume is not supported by the libkrun backend (upstream C API does not expose vCPU pause)"
+        )
     }
 
     fn status(&self) -> Result<VmStatus> {
@@ -395,6 +403,13 @@ impl RunningVm for LibkrunRunningVm {
     }
 
     fn vsock_connect(&self, guest_port: u32) -> Result<Box<dyn DuplexStream>> {
+        // Console-port asymmetry, intentional: the runner's spec_map computes
+        // console data-socket paths under HVF's nested `vsock/` convention, but
+        // libkrun binds every per-port UDS FLAT (`<state_dir>/vsock-<port>.sock`)
+        // and its host-side resolver probes flat-first, so the driver ignores the
+        // spec's console `host_uds` and re-derives the flat path here. The nested
+        // spec path is therefore inert for libkrun by design — a future refactor
+        // must not "fix" it into the flat driver.
         // libkrun's per-port UDS convention: `<state_dir>/vsock-<port>.sock`
         // (flat), resolved through the single source of truth shared with the
         // host-side resolver — NOT HVF's nested `vsock/` convention. Restricted
@@ -420,7 +435,7 @@ impl RunningVm for LibkrunRunningVm {
 mod tests {
     use super::*;
     use crate::driver::{ConsoleCapture, VsockPort};
-    use mvm_agentd::vsock::{BROKER_PORT, EGRESS_PORT, WORKLOAD_EXIT_PORT};
+    use mvm_agentd::vsock::{BROKER_PORT, WORKLOAD_EXIT_PORT};
 
     fn host_dials(guest_port: u32, uds: &str) -> VsockPort {
         VsockPort {
@@ -530,6 +545,13 @@ mod tests {
         assert_eq!(cfg.gateway_events_socket, None);
         assert_eq!(cfg.signing_key_path, None);
         assert_eq!(cfg.transparent_terminator_port, None);
+        // Egress is not a role field: the spec's EGRESS_PORT channel names the
+        // per-VM gating endpoint UDS, and the relay pins the guest egress port's
+        // host-listen socket to it so the endpoint is the sole path off the box.
+        assert_eq!(
+            cfg.egress_relay_socket,
+            Some(std::path::PathBuf::from("/run/egress.sock"))
+        );
         // Physical recipe carried through.
         assert_eq!(cfg.krun.vcpus, 2);
         assert_eq!(cfg.krun.ram_mib, 512);

--- a/crates/mvm-runtime/src/driver/libkrun.rs
+++ b/crates/mvm-runtime/src/driver/libkrun.rs
@@ -82,12 +82,17 @@ fn attach_block(krun: KrunContext, block: &BlockDev) -> KrunContext {
 /// runner above this driver, so `relay` never sets an admission field — the
 /// supervisor takes its legacy run path and enforces nothing here.
 fn relay_libkrun_supervisor_config(spec: &VmmSpec, state_dir: &Path) -> Result<SupervisorConfig> {
-    let kernel = match &spec.kernel {
+    let kernel_path = match &spec.kernel {
         KernelImage::Path(p) => p.to_string_lossy().into_owned(),
         KernelImage::Bundled => {
             bail!("the libkrun driver requires an explicit kernel Image; VmmSpec.kernel is Bundled")
         }
     };
+    // Prepare the kernel exactly as the raw libkrun path does, reusing the same
+    // shared helper rather than forking it: on x86_64 this converts the workload
+    // kernel to a libkrun-loadable ELF and reports the format; on aarch64 it is a
+    // passthrough at Raw. The driver must not diverge from the host kernel-prep.
+    let (kernel, kernel_format) = crate::libkrun::libkrun_kernel_for_host(&kernel_path)?;
 
     let vcpus = u8::try_from(spec.vcpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX);
     let state_dir_str = state_dir.to_string_lossy().into_owned();
@@ -97,6 +102,7 @@ fn relay_libkrun_supervisor_config(spec: &VmmSpec, state_dir: &Path) -> Result<S
     // below owns the rootfs/extra-disk decision from spec.blocks.
     let mut krun = KrunContext::new(&spec.name, kernel, "")
         .with_resources(vcpus, spec.memory_mib)
+        .with_kernel_format(kernel_format)
         .with_vsock_socket_dir(state_dir_str.clone())
         .with_console_output(console_log.to_string_lossy().into_owned())
         // A libkrun workload has no guest NIC: an explicit virtio-vsock device

--- a/crates/mvm-runtime/src/driver/libkrun.rs
+++ b/crates/mvm-runtime/src/driver/libkrun.rs
@@ -188,6 +188,18 @@ fn relay_libkrun_supervisor_config(spec: &VmmSpec, state_dir: &Path) -> Result<S
     })
 }
 
+/// Return the kernel path and format produced by the real libkrun relay
+/// mapping, without spawning a supervisor. Available only to the conformance
+/// harness so it can verify the host-specific kernel preparation contract.
+#[cfg(feature = "test-support")]
+pub fn map_kernel_for_test(
+    spec: &VmmSpec,
+    state_dir: &Path,
+) -> Result<(Option<String>, mvm_core::kernel_format::KernelFormat)> {
+    let config = relay_libkrun_supervisor_config(spec, state_dir)?;
+    Ok((config.krun.kernel_path, config.krun.kernel_format))
+}
+
 impl VmmDriver for LibkrunDriver {
     fn name(&self) -> &str {
         self.backend.name()
@@ -228,16 +240,7 @@ impl VmmDriver for LibkrunDriver {
         let _ = std::fs::remove_file(mvm_core::exit_capture::exit_file_path(&state_dir));
         let _ = crate::libkrun::open_console_capture(&console_log);
 
-        let mut cfg = relay_libkrun_supervisor_config(spec, &state_dir)?;
-
-        // Host-side kernel prep: on x86_64 libkrun needs an ELF vmlinux, so
-        // extract it and mark the format. A no-op on aarch64 (raw Image
-        // passthrough). Reuses the raw backend's single kernel resolver.
-        if let Some(kpath) = cfg.krun.kernel_path.clone() {
-            let (resolved, format) = crate::libkrun::libkrun_kernel_for_host(&kpath)?;
-            cfg.krun.kernel_path = Some(resolved);
-            cfg.krun.kernel_format = format;
-        }
+        let cfg = relay_libkrun_supervisor_config(spec, &state_dir)?;
 
         let pid_file = vm_libkrun_pid(&spec.name);
         // Remove any stale PID file so the poll below detects this launch's.
@@ -564,6 +567,28 @@ mod tests {
         assert_eq!(cfg.krun.kernel_path.as_deref(), Some("/img/Image"));
         assert_eq!(cfg.vm_state_dir, "/state/w");
         assert_eq!(cfg.pid_file_name, None);
+    }
+
+    #[test]
+    fn relay_config_prepares_the_kernel_for_the_host_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("vmlinux");
+        std::fs::write(&kernel, b"\x7fELFconformance-kernel").unwrap();
+        let spec = spec_with(KernelImage::Path(kernel.clone()), vec![], vec![]);
+
+        let cfg = relay_libkrun_supervisor_config(&spec, dir.path()).unwrap();
+        if cfg!(target_arch = "x86_64") {
+            assert_eq!(
+                cfg.krun.kernel_format,
+                mvm_core::kernel_format::KernelFormat::Elf
+            );
+        } else {
+            assert_eq!(
+                cfg.krun.kernel_format,
+                mvm_core::kernel_format::KernelFormat::Raw
+            );
+        }
+        assert_eq!(cfg.krun.kernel_path.as_deref(), kernel.to_str());
     }
 
     #[test]

--- a/crates/mvm-runtime/src/driver/spec.rs
+++ b/crates/mvm-runtime/src/driver/spec.rs
@@ -91,6 +91,19 @@ pub struct VmmSpec {
     pub trusted_builder: bool,
 }
 
+impl VmmSpec {
+    /// The host unix socket a standing vsock port binds to, found by its
+    /// guest-port number. `None` when the spec carries no channel for that
+    /// port. Both drivers resolve the egress/agent/broker sockets through this
+    /// one lookup instead of each re-scanning `vsock`.
+    pub fn host_socket_for_port(&self, guest_port: u32) -> Option<PathBuf> {
+        self.vsock
+            .iter()
+            .find(|p| p.guest_port == guest_port)
+            .map(|p| p.host_uds.clone())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mvm-runtime/src/hvf_bootargs.rs
+++ b/crates/mvm-runtime/src/hvf_bootargs.rs
@@ -26,13 +26,6 @@ pub(crate) fn default_virtiofs_bootargs() -> String {
     )
 }
 
-/// Cmdline used for verity+initramfs workload boots. The initramfs PID 1 owns
-/// the root-device selection and switch-root flow, so no `root=` or `init=`
-/// token is emitted here.
-pub(crate) fn default_verity_bootargs() -> String {
-    default_bootargs(false)
-}
-
 /// Default workload kernel cmdline for the chosen root strategy.
 pub fn workload_bootargs(virtiofs_root: bool, has_disk: bool) -> String {
     if virtiofs_root {

--- a/crates/mvm-runtime/src/selection.rs
+++ b/crates/mvm-runtime/src/selection.rs
@@ -7,9 +7,8 @@
 
 use mvm_core::vm_backend::{RequiredCapabilities, VmCapabilities};
 
-use crate::backend::{AnyBackend, FirecrackerBackend};
+use crate::backend::{AnyBackend, FirecrackerBackend, libkrun_runner};
 use crate::hvf_backend::HvfBackend;
-use crate::libkrun::LibkrunBackend;
 use crate::qemu::QemuBackend;
 
 /// No backend could be selected: every candidate lacked a required capability.
@@ -66,7 +65,7 @@ impl AnyBackend {
         [
             AnyBackend::Firecracker(FirecrackerBackend),
             AnyBackend::Hvf(HvfBackend),
-            AnyBackend::Libkrun(LibkrunBackend),
+            AnyBackend::Libkrun(libkrun_runner()),
             AnyBackend::Qemu(QemuBackend),
         ]
     }

--- a/crates/mvm-runtime/src/workload_backend.rs
+++ b/crates/mvm-runtime/src/workload_backend.rs
@@ -4,7 +4,6 @@
 //! only, so a non-workload backend cannot reach it.
 use crate::backend::{AnyBackend, FirecrackerBackend};
 use crate::hvf_backend::HvfBackend;
-use crate::libkrun::LibkrunBackend;
 #[cfg(feature = "test-support")]
 use crate::mock::MockBackend;
 use anyhow::{Result, anyhow};
@@ -56,11 +55,6 @@ pub trait WorkloadBackend: VmBackend {
 impl WorkloadBackend for FirecrackerBackend {
     fn egress_substitution_transport(&self) -> EgressSubstitutionTransport {
         EgressSubstitutionTransport::NftTerminator
-    }
-}
-impl WorkloadBackend for LibkrunBackend {
-    fn egress_substitution_transport(&self) -> EgressSubstitutionTransport {
-        EgressSubstitutionTransport::RvproxyTransparentTerminator
     }
 }
 impl WorkloadBackend for HvfBackend {
@@ -125,10 +119,12 @@ mod tests {
     #[test]
     fn workload_backends_implement_marker() {
         assert_is_workload_backend::<FirecrackerBackend>();
-        assert_is_workload_backend::<LibkrunBackend>();
         assert_is_workload_backend::<HvfBackend>();
         #[cfg(feature = "test-support")]
         assert_is_workload_backend::<MockBackend>();
+        // libkrun is now a workload backend via the runner's blanket impl, not a
+        // standalone one; the refuses-bucket test below coerces a live
+        // `libkrun_runner()` to `&dyn WorkloadBackend`, which is that proof.
     }
 
     #[test]
@@ -148,14 +144,14 @@ mod tests {
     }
 
     #[test]
-    fn libkrun_declares_rvproxy_transparent_terminator() {
-        let transport = LibkrunBackend.egress_substitution_transport();
-        assert_eq!(
-            transport,
-            EgressSubstitutionTransport::RvproxyTransparentTerminator
-        );
+    fn libkrun_runner_declares_vsock_uds_channel() {
+        // Post-flip libkrun carries egress over the runner's vsock UDS channel
+        // (proxy-aware substitution, no transparent :80/:443 terminator) — the
+        // same posture as HVF, reached through the blanket runner impl.
+        let transport = crate::backend::libkrun_runner().egress_substitution_transport();
+        assert_eq!(transport, EgressSubstitutionTransport::VsockUdsChannel);
         assert!(transport.supports_proxy_aware_substitution());
-        assert!(transport.supports_transparent_terminator());
+        assert!(!transport.supports_transparent_terminator());
     }
 
     #[test]
@@ -198,22 +194,24 @@ mod tests {
     }
 
     #[test]
-    fn transparent_egress_terminator_requirement_accepts_libkrun() {
-        require_transparent_egress_terminator(&LibkrunBackend)
-            .expect("libkrun declares the rvproxy terminator leg");
-    }
-
-    #[test]
     fn transparent_egress_terminator_requirement_refuses_proxy_only_backends() {
+        // libkrun is now proxy-only (vsock UDS channel) like HVF, so it joins the
+        // refuses bucket. Coercing `libkrun_runner()` here also proves the runner
+        // implements `WorkloadBackend`.
+        let libkrun = crate::backend::libkrun_runner();
         #[cfg(feature = "test-support")]
         let mock = MockBackend::new();
         #[cfg(feature = "test-support")]
         let backends: Vec<&dyn WorkloadBackend> = vec![
             &HvfBackend as &dyn WorkloadBackend,
+            &libkrun as &dyn WorkloadBackend,
             &mock as &dyn WorkloadBackend,
         ];
         #[cfg(not(feature = "test-support"))]
-        let backends: Vec<&dyn WorkloadBackend> = vec![&HvfBackend as &dyn WorkloadBackend];
+        let backends: Vec<&dyn WorkloadBackend> = vec![
+            &HvfBackend as &dyn WorkloadBackend,
+            &libkrun as &dyn WorkloadBackend,
+        ];
         for backend in backends {
             let err = match require_transparent_egress_terminator(backend) {
                 Ok(()) => panic!("{} should not satisfy the terminator gate", backend.name()),

--- a/crates/mvm-runtime/src/workload_runner/cmdline.rs
+++ b/crates/mvm-runtime/src/workload_runner/cmdline.rs
@@ -103,7 +103,11 @@ pub(crate) fn workload_cmdline(
         return None;
     }
     let mut cmdline = if verity_is_enabled {
-        crate::hvf_bootargs::default_verity_bootargs()
+        // A verity/initramfs boot: the initramfs PID 1 owns root/init selection,
+        // so the base carries only the VMM-specific console (has_disk=false).
+        // Route through the driver seam — libkrun needs `console=hvc0`, HVF the
+        // pl011 UART — instead of hardcoding one VMM's console onto every guest.
+        base_bootargs(virtiofs_root, false)
     } else {
         base_bootargs(virtiofs_root, has_disk)
     };
@@ -283,6 +287,42 @@ mod tests {
         assert!(cmdline.contains("mvm.runtime_data=/dev/vdc"));
         assert!(cmdline.contains("mvm.runtime_hash=/dev/vdd"));
         assert!(cmdline.contains("mvm.runtime_source_policy=required_overlay"));
+    }
+
+    /// A verity boot must take its console base from the driver seam, not a
+    /// hardcoded HVF UART. A libkrun-style base yields `console=hvc0`; the
+    /// cmdline must never carry the pl011 `ttyAMA0`/`earlycon` that a libkrun
+    /// guest has no device for (the regression that emitted a 0-byte console).
+    #[test]
+    fn verity_cmdline_takes_the_console_from_the_driver_seam_not_a_hardcoded_uart() {
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"rootfs").unwrap();
+        let config = VmStartConfig {
+            rootfs_path: rootfs.display().to_string(),
+            verity_path: Some("/tmp/rootfs.verity".into()),
+            roothash: Some("a".repeat(64)),
+            runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
+            ..Default::default()
+        };
+        // libkrun's base: a verity boot (has_disk=false) carries only the
+        // console; a disk boot adds root/init.
+        let libkrun_base = |_virtiofs: bool, has_disk: bool| {
+            if has_disk {
+                "console=hvc0 root=/dev/vda rw init=/init".to_string()
+            } else {
+                "console=hvc0".to_string()
+            }
+        };
+        let cmdline = workload_cmdline(&config, dir.path(), libkrun_base).expect("cmdline");
+        assert!(
+            cmdline.contains("console=hvc0"),
+            "verity cmdline must use the driver console base: {cmdline}"
+        );
+        assert!(
+            !cmdline.contains("ttyAMA0") && !cmdline.contains("earlycon=pl011"),
+            "verity cmdline must not hardcode the HVF UART: {cmdline}"
+        );
     }
 
     fn disk_volume(host: &str, guest: &str) -> mvm_core::vm_backend::VmVolume {

--- a/crates/mvm-runtime/src/workload_runner/mod.rs
+++ b/crates/mvm-runtime/src/workload_runner/mod.rs
@@ -16,3 +16,18 @@ pub use spec_map::{
     WorkloadSockets, WorkloadSpecInputs, ensure_no_dir_share_volumes, workload_blocks,
     workload_spec, workload_vsock_ports,
 };
+
+/// Assemble the exact runner cmdline for conformance tests without booting a
+/// VM. This is feature-gated with the rest of the test-support surface so the
+/// BDD suite can exercise the real driver seam and shared assembler while the
+/// production library keeps that implementation detail private.
+#[cfg(feature = "test-support")]
+pub fn assemble_workload_cmdline_for_test(
+    driver: &dyn crate::driver::VmmDriver,
+    config: &mvm_core::vm_backend::VmStartConfig,
+    state_dir: &std::path::Path,
+) -> String {
+    cmdline::runner_cmdline(config, state_dir, |virtiofs_root, has_disk| {
+        driver.workload_base_bootargs(virtiofs_root, has_disk)
+    })
+}

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -15,8 +15,8 @@ use mvm_core::plan::SecretBinding;
 use mvm_core::policy::RedactionPolicy;
 use mvm_core::policy::network_policy::NetworkPolicy;
 use mvm_core::vm_backend::{
-    BackendKind, BackendSecurityProfile, GuestChannelInfo, SnapshotCapability, VmBackend,
-    VmCapabilities, VmExitStatus, VmId, VmInfo, VmStartConfig, VmStatus,
+    BackendKind, BackendSecurityProfile, GuestChannelInfo, SnapshotCapability, StartMode,
+    VmBackend, VmCapabilities, VmExitStatus, VmId, VmInfo, VmStartConfig, VmStatus,
 };
 
 use crate::driver::{RunningVm, VmmDriver};
@@ -355,6 +355,26 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 
         std::fs::create_dir_all(&state_dir)
             .with_context(|| format!("create state dir {}", state_dir.display()))?;
 
+        // Admission gate — refuse a rootfs whose parent dir carries no
+        // overlay-aware sidecar (no `/mvm/runtime` mount point). Runs before any
+        // endpoint/broker spawn or boot, so a refusal leaves no live process
+        // behind. The raw per-backend `start` paths run this; the runner is the
+        // sole path for the drivers behind it, so the gate lives here once.
+        let rootfs = Path::new(&config.rootfs_path);
+        let rootfs_dir = rootfs.parent().unwrap_or_else(|| Path::new("."));
+        mvm_build::builder_vm::admit_runtime_overlay_contract(
+            rootfs_dir,
+            config.runtime_source_policy,
+        )?;
+        // Record per-VM runtime metadata (the sidecar accessibility bit + the
+        // boot contract) so the `mvmctl console` accessible/sealed gate holds on
+        // every runner-launched VM, matching the raw backend start paths.
+        crate::base::runtime_meta::record_from_start_config(
+            &config.name,
+            StartMode::Detached,
+            config,
+        )?;
+
         // Owned decode + defaults must outlive the `WorkloadLaunchInputs` borrows
         // below, so bind them here rather than inline.
         let default_redaction = RedactionPolicy::default();
@@ -568,6 +588,23 @@ mod tests {
             rootfs_path: "/img/rootfs.ext4".into(),
             ..Default::default()
         }
+    }
+
+    /// Seed an overlay-aware `mvm-meta.json` sidecar next to a rootfs file in a
+    /// fresh tempdir and return `(dir, rootfs_path)`. `VmBackend::start`'s
+    /// admission gate refuses a rootfs whose parent dir carries no overlay-aware
+    /// sidecar, so every test that drives the full trait method provides one.
+    /// The returned `TempDir` must stay in scope for the rootfs to exist.
+    fn overlay_aware_rootfs(name: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"rootfs").unwrap();
+        // sealed=false (accessible dev image), runtime_lean=true so the sidecar
+        // clears the gate under every runtime-source policy, not just the default.
+        mvm_build::builder_vm::GuestSidecar::for_oci_run(name, false, true)
+            .write_to_dir(dir.path())
+            .unwrap();
+        (dir, rootfs.display().to_string())
     }
 
     fn keystore_secret() -> SecretBinding {
@@ -833,6 +870,13 @@ mod tests {
 
     #[test]
     fn vmbackend_start_then_status_wait_stop_via_the_driver() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
         let exit = VmExitStatus {
             code: Some(0),
             success: true,
@@ -843,7 +887,13 @@ mod tests {
             RecordingBrokerRegistrar::new(),
         );
 
-        let id = runner.start(&config("w")).expect("start succeeds");
+        let (_rootfs_dir, rootfs) = overlay_aware_rootfs("w");
+        let cfg = VmStartConfig {
+            name: "w".into(),
+            rootfs_path: rootfs,
+            ..Default::default()
+        };
+        let id = runner.start(&cfg).expect("start succeeds");
         assert_eq!(id.0, "w");
 
         // attach hands back a MockRunningVm, so the lifecycle works with no real VM.
@@ -905,6 +955,15 @@ mod tests {
         std::fs::write(&rootfs, b"rootfs").unwrap();
         std::fs::write(&verity, b"verity").unwrap();
         std::fs::write(&initrd, b"initrd").unwrap();
+        // Overlay-aware sidecar next to the rootfs so `start`'s admission gate
+        // (refuses a rootfs with no `/mvm/runtime` mount point) admits this boot.
+        mvm_build::builder_vm::GuestSidecar::for_oci_run(
+            "runner-security-cmdline-tokens",
+            false,
+            true,
+        )
+        .write_to_dir(rootfs_dir.path())
+        .unwrap();
 
         let vm_name = "runner-security-cmdline-tokens";
         seed_grant_sidecar_and_key(vm_name);
@@ -962,9 +1021,10 @@ mod tests {
         env.set("MVM_HOME", home.path());
 
         let driver = MockDriver::default();
+        let (_rootfs_dir, rootfs) = overlay_aware_rootfs("runner-driver-base-bootargs");
         let cfg = VmStartConfig {
             name: "runner-driver-base-bootargs".into(),
-            rootfs_path: "/img/rootfs.ext4".into(),
+            rootfs_path: rootfs,
             network_policy: NetworkPolicy::preset(mvm_core::network_policy::NetworkPreset::Dev),
             ..Default::default()
         };
@@ -1020,15 +1080,25 @@ mod tests {
     /// what they are for.
     #[test]
     fn start_carries_a_disk_volume_into_both_blocks_and_the_uvols_token() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
         let runner = WorkloadRunner::new(
             MockDriver::default(),
             RecordingSpawner::new("/run/ep.sock"),
             RecordingBrokerRegistrar::new(),
         );
 
+        let (_rootfs_dir, rootfs) = overlay_aware_rootfs("w-uvol");
         let cfg = VmStartConfig {
+            name: "w-uvol".into(),
+            rootfs_path: rootfs,
             volumes: vec![disk_volume("/vol/data.img", "/data", true)],
-            ..config("w-uvol")
+            ..Default::default()
         };
         runner.start(&cfg).expect("start succeeds");
 
@@ -1056,19 +1126,93 @@ mod tests {
 
     #[test]
     fn start_emits_no_uvols_token_when_there_are_no_volumes() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
         let runner = WorkloadRunner::new(
             MockDriver::default(),
             RecordingSpawner::new("/run/ep.sock"),
             RecordingBrokerRegistrar::new(),
         );
 
-        runner.start(&config("w-no-uvol")).expect("start succeeds");
+        let (_rootfs_dir, rootfs) = overlay_aware_rootfs("w-no-uvol");
+        let cfg = VmStartConfig {
+            name: "w-no-uvol".into(),
+            rootfs_path: rootfs,
+            ..Default::default()
+        };
+        runner.start(&cfg).expect("start succeeds");
 
         let specs = runner.driver.booted_specs();
         assert!(
             !specs[0].cmdline.contains("mvm.uvols="),
             "cmdline must carry no uvols token with no volumes: {}",
             specs[0].cmdline
+        );
+    }
+
+    /// The lifted admission gate: `VmBackend::start` refuses a rootfs whose
+    /// parent dir carries no overlay-aware sidecar (no `/mvm/runtime` mount
+    /// point) before any endpoint spawn or boot, and on an admitted boot it
+    /// records the per-VM runtime metadata the console accessible/sealed gate
+    /// reads. Drives the whole trait method through a `MockDriver`.
+    #[test]
+    fn start_refuses_a_rootfs_without_the_overlay_sidecar_and_records_runtime_meta() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
+        let runner = WorkloadRunner::new(
+            MockDriver::default(),
+            RecordingSpawner::new("/run/ep.sock"),
+            RecordingBrokerRegistrar::new(),
+        );
+
+        // A rootfs whose parent dir carries no sidecar is refused before boot.
+        let bare = tempfile::tempdir().unwrap();
+        let bare_rootfs = bare.path().join("rootfs.ext4");
+        std::fs::write(&bare_rootfs, b"rootfs").unwrap();
+        let refused = VmStartConfig {
+            name: "runner-gate-refused".into(),
+            rootfs_path: bare_rootfs.display().to_string(),
+            ..Default::default()
+        };
+        let err = runner
+            .start(&refused)
+            .expect_err("a rootfs with no overlay-aware sidecar must be refused");
+        assert!(
+            err.to_string().contains("mvm-meta.json"),
+            "refusal must name the missing sidecar: {err}"
+        );
+        assert!(
+            runner.driver.booted_specs().is_empty(),
+            "the gate must fire before any boot"
+        );
+
+        // An overlay-aware rootfs is admitted, and start records runtime_meta so
+        // the console accessible/sealed gate has a per-VM record to read.
+        let (_rootfs_dir, rootfs) = overlay_aware_rootfs("runner-gate-admitted");
+        let admitted = VmStartConfig {
+            name: "runner-gate-admitted".into(),
+            rootfs_path: rootfs,
+            ..Default::default()
+        };
+        runner
+            .start(&admitted)
+            .expect("an overlay-aware rootfs is admitted");
+        let meta = crate::base::runtime_meta::read("runner-gate-admitted")
+            .expect("runtime_meta read")
+            .expect("start records runtime_meta");
+        assert_eq!(
+            meta.rootfs_path.as_deref(),
+            Some(admitted.rootfs_path.as_str())
         );
     }
 

--- a/features/suites/s4_verified_boot/tampered_rootfs_fails_boot.feature
+++ b/features/suites/s4_verified_boot/tampered_rootfs_fails_boot.feature
@@ -2,7 +2,32 @@ Feature: Verified boot rejects a tampered rootfs
 
   A tampered rootfs image fails to boot: the dm-verity roothash check
   panics the kernel before userspace runs, so a compromised image can
-  never reach a running workload.
+  never reach a running workload. Each VMM must also receive the console and
+  kernel format it can actually boot, without changing the shared verity
+  device contract.
+
+  Scenario: A sealed libkrun workload uses its virtio console
+    When I assemble a sealed workload cmdline for "libkrun"
+    Then the sealed workload cmdline contains "console=hvc0"
+    And the sealed workload cmdline contains "mvm.roothash="
+    And the sealed workload cmdline contains "mvm.data=/dev/vda"
+    And the sealed workload cmdline contains "mvm.hash=/dev/vdb"
+    And the sealed workload cmdline contains "mvm.runtime_roothash="
+    And the sealed workload cmdline contains "mvm.runtime_data=/dev/vdc"
+    And the sealed workload cmdline contains "mvm.runtime_hash=/dev/vdd"
+    But the sealed workload cmdline omits "console=ttyAMA0"
+    And the sealed workload cmdline omits "earlycon=pl011"
+
+  Scenario: A sealed HVF workload keeps its pl011 console
+    When I assemble a sealed workload cmdline for "hvf"
+    Then the sealed workload cmdline contains "console=ttyAMA0"
+    And the sealed workload cmdline contains "earlycon=pl011"
+    And the sealed workload cmdline contains "mvm.roothash="
+    But the sealed workload cmdline omits "console=hvc0"
+
+  Scenario: Libkrun maps the workload kernel to its host-loadable format
+    When I map an existing ELF workload kernel through the libkrun driver
+    Then the libkrun kernel format matches the current host architecture
 
   @wip
   Scenario: A single flipped data block on a sealed rootfs refuses to boot


### PR DESCRIPTION
## What

Routes libkrun through the unified `WorkloadRunner` seam, making the driver-based vsock-only path libkrun's sole production launch path for both explicit selection and auto-selection. `AnyBackend::Libkrun` now carries `WorkloadRunner<LibkrunDriver, RealEndpointSpawner, RealBrokerRegistrar>`, matching the role already used by the HVF runner.

This keeps the security properties on one structural path:

- claim-10 default-deny egress is enforced at the runner's gating endpoint;
- claims 12/13 broker binding and secret substitution go through `RealBrokerRegistrar`;
- ingress and egress use vsock/UDS, with no routable guest NIC;
- overlay admission and runtime metadata gates execute before any endpoint, broker, or VMM process starts.

Warm-start, standby-pool, and balloon capabilities intentionally fall back to the runner trait defaults, and the doctor output/tests now reflect that capability surface.

## Verified-boot fix

The shared sealed-boot command line had hard-coded HVF's PL011 console (`console=ttyAMA0`), while libkrun exposes `hvc0`. The guest was booting into a dead console, hiding all later status. The verified-boot base command line now flows through the driver seam:

- libkrun selects `console=hvc0`;
- HVF retains its existing PL011 command line byte-for-byte;
- libkrun launch uses the shared host-kernel preparation path, yielding an ELF-loadable kernel on x86_64 and the raw aarch64 image where appropriate.

Root and runtime dm-verity remain enabled. The libkrun sealed layout is root data/hash on `vda`/`vdb` and runtime-overlay data/hash on `vdc`/`vdd`.

## Tests

- Host nextest: **7,577 passed / 7,577 run**.
- Host workspace clippy, all targets with warnings denied: clean.
- Rebasing onto current `main` adds its README contract scenarios; the combined BDD suite is **5 features, 26 scenarios, 130 steps passed**.
- New BDD coverage locks:
  - libkrun uses `hvc0` and never inherits PL011;
  - HVF retains its existing PL011 command line;
  - verified root/runtime disks keep the `vda`/`vdb`/`vdc`/`vdd` contract;
  - libkrun uses the shared host-kernel mapping.
- Fresh GitHub CI: Linux fmt/clippy/policy, full Test, Nix eval, protocol, MCP, ext4, and SDK dry-run checks all pass.

## Live witnesses

### macOS libkrun (`lkrw1`)

- guest console enumerated `vda` through `vdd`;
- root and runtime dm-verity mappings activated;
- guest agent reached ready and accepted `/bin/busybox sleep`;
- the signed plan launched with `backend=libkrun`;
- deny-all egress was recorded as `flow-drop`;
- workload processes were stopped after proof collection.

### Linux/KVM libkrun (`lkrkvm1`)

Run on an aarch64 Linux KVM test provider with libkrun 1.18.0 and libkrunfw 5.3.0:

- console enumerated `vda`, `vdb`, `vdc`, and `vdd`;
- `dm-verity root active` and `dm-verity runtime active` were observed;
- guest agent reported `control plane ready` and accepted `/bin/busybox sleep 180`;
- the signed plan reached `plan.launched` with `backend=libkrun`;
- runtime audit recorded `network=deny-all enforced=flow-drop`;
- the VM and all per-workload helper processes were stopped after proof collection.

The live-KVM merge gate is satisfied.
