### PR TITLE
fix(net): complete admitted egress — honest CONNECT ack + happy-eyeballs connect

### DIFF
--- a/crates/mvm-agentd/src/egress_client.rs
+++ b/crates/mvm-agentd/src/egress_client.rs
@@ -17,6 +17,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
 
 use crate::guest_vsock_session::HostVsockSession;
+use mvm_core::guest_netd::ConnectAck;
 
 const EGRESS_VSOCK_PORT_ENV: &str = "MVM_EGRESS_VSOCK_PORT";
 
@@ -317,28 +318,77 @@ async fn serve(mut client: TcpStream) -> std::io::Result<()> {
     }
 }
 
-async fn serve_socks(mut client: TcpStream, target: &str) -> std::io::Result<()> {
-    let session = match connect_to_host_egress(target).await {
-        Ok(session) => session,
-        Err(err) => {
-            let _ = reply(&mut client, REP_GENERAL_FAILURE).await;
-            return Err(err);
-        }
-    };
-    reply(&mut client, REP_SUCCESS).await?;
-    session.splice(client).await
+/// Which client-facing proxy reply flavour a completed CONNECT-style session
+/// answers with, so the ack->reply mapping is one exhaustive match rather than
+/// duplicated per call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProxyReplyStyle {
+    Socks,
+    HttpConnect,
 }
 
-async fn serve_http_connect(mut client: TcpStream, target: &str) -> std::io::Result<()> {
-    let session = match connect_to_host_egress(target).await {
-        Ok(session) => session,
-        Err(err) => {
-            let _ = write_http_response(&mut client, "502 Bad Gateway").await;
-            return Err(err);
+/// Emit the client-facing reply for a connect outcome. Exhaustive over the
+/// (style, ack) matrix: SOCKS success/failure replies and HTTP `200`/`502`.
+async fn write_connect_reply<C>(
+    client: &mut C,
+    style: ProxyReplyStyle,
+    ack: ConnectAck,
+) -> std::io::Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+{
+    match (style, ack) {
+        (ProxyReplyStyle::Socks, ConnectAck::Ok) => reply(client, REP_SUCCESS).await,
+        (ProxyReplyStyle::Socks, ConnectAck::Fail) => reply(client, REP_GENERAL_FAILURE).await,
+        (ProxyReplyStyle::HttpConnect, ConnectAck::Ok) => reply_http_connect_ok(client).await,
+        (ProxyReplyStyle::HttpConnect, ConnectAck::Fail) => {
+            write_http_response(client, "502 Bad Gateway").await
         }
-    };
-    reply_http_connect_ok(&mut client).await?;
-    session.splice(client).await
+    }
+}
+
+/// Finish a CONNECT-style request once the host session is open: read the host
+/// connect ack, answer the client truthfully, and splice only on `Ok`. Generic
+/// over both streams so it unit-tests over in-memory duplex pipes.
+async fn complete_connect_session<C, U>(
+    mut client: C,
+    mut session: HostVsockSession<U>,
+    style: ProxyReplyStyle,
+) -> std::io::Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+    U: AsyncRead + AsyncWrite + Unpin,
+{
+    let ack = session.read_connect_ack().await;
+    write_connect_reply(&mut client, style, ack).await?;
+    match ack {
+        ConnectAck::Ok => session.splice(client).await,
+        ConnectAck::Fail => Ok(()),
+    }
+}
+
+async fn serve_socks(client: TcpStream, target: &str) -> std::io::Result<()> {
+    match connect_to_host_egress(target).await {
+        Ok(session) => complete_connect_session(client, session, ProxyReplyStyle::Socks).await,
+        Err(err) => {
+            let mut client = client;
+            let _ = reply(&mut client, REP_GENERAL_FAILURE).await;
+            Err(err)
+        }
+    }
+}
+
+async fn serve_http_connect(client: TcpStream, target: &str) -> std::io::Result<()> {
+    match connect_to_host_egress(target).await {
+        Ok(session) => {
+            complete_connect_session(client, session, ProxyReplyStyle::HttpConnect).await
+        }
+        Err(err) => {
+            let mut client = client;
+            let _ = write_http_response(&mut client, "502 Bad Gateway").await;
+            Err(err)
+        }
+    }
 }
 
 async fn serve_http_forward(
@@ -949,6 +999,95 @@ mod tests {
             head: head.to_vec(),
             content_length: parse_http_content_length(head)?,
         })
+    }
+
+    #[tokio::test]
+    async fn http_connect_replies_502_when_host_nacks() {
+        let (mut client, client_bridge) = tokio::io::duplex(256);
+        let (upstream_bridge, mut host) = tokio::io::duplex(256);
+        let session = HostVsockSession::new(upstream_bridge)
+            .write_initial_bytes(b"example.com:443\n")
+            .await
+            .unwrap();
+        let task = tokio::spawn(complete_connect_session(
+            client_bridge,
+            session,
+            ProxyReplyStyle::HttpConnect,
+        ));
+
+        let mut line = vec![0u8; b"example.com:443\n".len()];
+        host.read_exact(&mut line).await.unwrap();
+        host.write_all(&[ConnectAck::Fail.as_byte()]).await.unwrap();
+        host.shutdown().await.unwrap();
+
+        let mut resp = Vec::new();
+        client.read_to_end(&mut resp).await.unwrap();
+        let text = std::str::from_utf8(&resp).unwrap();
+        assert!(text.starts_with("HTTP/1.1 502"), "{text:?}");
+        task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn http_connect_replies_200_then_splices_when_host_acks_ok() {
+        let (mut client, client_bridge) = tokio::io::duplex(256);
+        let (upstream_bridge, mut host) = tokio::io::duplex(256);
+        let session = HostVsockSession::new(upstream_bridge)
+            .write_initial_bytes(b"example.com:443\n")
+            .await
+            .unwrap();
+        let task = tokio::spawn(complete_connect_session(
+            client_bridge,
+            session,
+            ProxyReplyStyle::HttpConnect,
+        ));
+
+        let mut line = vec![0u8; b"example.com:443\n".len()];
+        host.read_exact(&mut line).await.unwrap();
+        host.write_all(&[ConnectAck::Ok.as_byte()]).await.unwrap();
+
+        let expected = b"HTTP/1.1 200 Connection established\r\n\r\n";
+        let mut ok = vec![0u8; expected.len()];
+        client.read_exact(&mut ok).await.unwrap();
+        assert_eq!(&ok, expected);
+
+        client.write_all(b"ping").await.unwrap();
+        let mut got = [0u8; 4];
+        host.read_exact(&mut got).await.unwrap();
+        assert_eq!(&got, b"ping");
+        host.write_all(b"pong").await.unwrap();
+        let mut back = [0u8; 4];
+        client.read_exact(&mut back).await.unwrap();
+        assert_eq!(&back, b"pong");
+
+        drop(client);
+        drop(host);
+        task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn socks_replies_general_failure_when_host_nacks() {
+        let (mut client, client_bridge) = tokio::io::duplex(256);
+        let (upstream_bridge, mut host) = tokio::io::duplex(256);
+        let session = HostVsockSession::new(upstream_bridge)
+            .write_initial_bytes(b"1.2.3.4:443\n")
+            .await
+            .unwrap();
+        let task = tokio::spawn(complete_connect_session(
+            client_bridge,
+            session,
+            ProxyReplyStyle::Socks,
+        ));
+
+        let mut line = vec![0u8; b"1.2.3.4:443\n".len()];
+        host.read_exact(&mut line).await.unwrap();
+        host.write_all(&[ConnectAck::Fail.as_byte()]).await.unwrap();
+        host.shutdown().await.unwrap();
+
+        let mut reply = [0u8; 10];
+        client.read_exact(&mut reply).await.unwrap();
+        assert_eq!(reply[0], SOCKS5);
+        assert_eq!(reply[1], REP_GENERAL_FAILURE);
+        task.await.unwrap().unwrap();
     }
 
     async fn proxy_single_http_forward(

--- a/crates/mvm-agentd/src/guest_vsock_session.rs
+++ b/crates/mvm-agentd/src/guest_vsock_session.rs
@@ -6,11 +6,13 @@
 //! The guest stays responsible for the exact prelude bytes, and the
 //! host stays responsible for all admission/policy decisions.
 
-use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 
 #[cfg(target_os = "linux")]
 use std::os::fd::FromRawFd;
+
+use mvm_core::guest_netd::ConnectAck;
 
 /// One guest-initiated session to a host AF_VSOCK port.
 pub struct HostVsockSession<U> {
@@ -55,6 +57,17 @@ where
     /// Recover the wrapped upstream stream for flows that need a custom relay.
     pub fn into_inner(self) -> U {
         self.upstream
+    }
+
+    /// Read the host's one-byte connect-result ack that follows the target-line
+    /// frame on the raw-egress protocol. Fail-closed: EOF or an unrecognised byte
+    /// is treated as a connect failure so the caller answers its client honestly.
+    pub async fn read_connect_ack(&mut self) -> ConnectAck {
+        let mut byte = [0u8; 1];
+        match self.upstream.read_exact(&mut byte).await {
+            Ok(_) => ConnectAck::from_byte(byte[0]).unwrap_or(ConnectAck::Fail),
+            Err(_) => ConnectAck::Fail,
+        }
     }
 }
 

--- a/crates/mvm-conformance/tests/conformance.rs
+++ b/crates/mvm-conformance/tests/conformance.rs
@@ -31,14 +31,28 @@ use world::CliWorld;
 
 const PENDING_TAG: &str = "wip";
 
+/// Scenarios that boot a real microVM and reach the network; opt in with
+/// `MVM_BDD_LIVE=1` (skipped in the default hermetic lane).
+const LIVE_TAG: &str = "live";
+
 #[tokio::main]
 async fn main() {
-    CliWorld::filter_run(features_dir(), not_pending).await;
+    CliWorld::filter_run(features_dir(), should_run).await;
 }
 
-/// Keep a scenario only if it isn't tagged as pending-implementation.
-fn not_pending(_feature: &Feature, _rule: Option<&Rule>, scenario: &Scenario) -> bool {
-    !scenario.tags.iter().any(|tag| tag == PENDING_TAG)
+/// Keep a scenario unless it is pending-implementation (`@wip`) or a live
+/// scenario (`@live`) that must be opted into. A `@live` scenario boots a real
+/// microVM and reaches the network, so it can't run in the default hermetic
+/// lane — set `MVM_BDD_LIVE=1` on a host with a working backend to include it.
+fn should_run(_feature: &Feature, _rule: Option<&Rule>, scenario: &Scenario) -> bool {
+    let tags = &scenario.tags;
+    if tags.iter().any(|tag| tag == PENDING_TAG) {
+        return false;
+    }
+    if tags.iter().any(|tag| tag == LIVE_TAG) && std::env::var_os("MVM_BDD_LIVE").is_none() {
+        return false;
+    }
+    true
 }
 
 /// `features/suites/` lives at the repo root, two levels above this crate's

--- a/crates/mvm-core/src/guest_netd.rs
+++ b/crates/mvm-core/src/guest_netd.rs
@@ -19,6 +19,45 @@ pub const DEFAULT_EGRESS_PROXY_LISTEN: &str = "127.0.0.1:1080";
 /// `ALL_PROXY` / `HTTP_PROXY` must carry a scheme.
 pub const DEFAULT_EGRESS_PROXY_URL: &str = "socks5h://127.0.0.1:1080";
 
+/// The host's connect-result acknowledgement on the raw-egress stream.
+///
+/// The in-guest proxy dials the host, writes the `"host:port\n"` target line,
+/// then waits for this one byte before answering its own client. The host emits
+/// it only after the outbound `connect` resolves — `Ok` once the tunnel is live,
+/// `Fail` when the target was refused or unreachable — so the guest reply
+/// (`200` / SOCKS success on `Ok`, `502` / SOCKS failure on `Fail`) is truthful
+/// instead of assuming success the moment the stream opened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectAck {
+    /// The host connected to the admitted destination; tunnel bytes follow.
+    Ok,
+    /// The host refused or could not reach the destination; nothing follows.
+    Fail,
+}
+
+impl ConnectAck {
+    /// The single byte written on the wire.
+    pub fn as_byte(self) -> u8 {
+        match self {
+            ConnectAck::Ok => 0x01,
+            ConnectAck::Fail => 0x00,
+        }
+    }
+
+    /// Parse a wire byte back into an ack. Any byte outside the two defined
+    /// codes is rejected so a desynchronised stream never reads a tunnel data
+    /// byte as a spurious `Ok`.
+    pub fn from_byte(byte: u8) -> Option<ConnectAck> {
+        if byte == ConnectAck::Ok.as_byte() {
+            Some(ConnectAck::Ok)
+        } else if byte == ConnectAck::Fail.as_byte() {
+            Some(ConnectAck::Fail)
+        } else {
+            None
+        }
+    }
+}
+
 /// Build the standard proxy environment for a cooperative app, pointing it at
 /// the in-guest `mvm-netd` proxy at `proxy_addr` (e.g. `127.0.0.1:3128`). Both
 /// upper- and lower-case variants are emitted because tooling is inconsistent
@@ -79,5 +118,28 @@ mod tests {
         for key in ["http_proxy", "https_proxy", "all_proxy", "no_proxy"] {
             assert!(env.contains_key(key), "missing {key}");
         }
+    }
+
+    #[test]
+    fn connect_ack_roundtrips_through_its_wire_byte() {
+        assert_eq!(
+            ConnectAck::from_byte(ConnectAck::Ok.as_byte()),
+            Some(ConnectAck::Ok)
+        );
+        assert_eq!(
+            ConnectAck::from_byte(ConnectAck::Fail.as_byte()),
+            Some(ConnectAck::Fail)
+        );
+    }
+
+    #[test]
+    fn connect_ack_ok_and_fail_are_distinct_bytes() {
+        assert_ne!(ConnectAck::Ok.as_byte(), ConnectAck::Fail.as_byte());
+    }
+
+    #[test]
+    fn connect_ack_rejects_unknown_bytes_fail_closed() {
+        assert_eq!(ConnectAck::from_byte(0x02), None);
+        assert_eq!(ConnectAck::from_byte(0xff), None);
     }
 }

--- a/crates/mvm-hostd/src/supervisor/http_forward.rs
+++ b/crates/mvm-hostd/src/supervisor/http_forward.rs
@@ -76,8 +76,8 @@ where
             return Ok(());
         }
     };
-    let (ip, port) = match gate.decide_request(&request.target) {
-        EgressVerdict::Allow { ip, port } => (ip, port),
+    let (ips, port) = match gate.decide_request(&request.target) {
+        EgressVerdict::Allow { ips, port } => (ips, port),
         EgressVerdict::Deny => {
             write_proxy_error_async(&mut guest, ProxyStatus::Forbidden).await?;
             return Ok(());
@@ -94,7 +94,7 @@ where
             return Err(error);
         }
     };
-    let response = match send_host_request(&request, body, ip, port, timeout).await {
+    let response = match send_host_request(&request, body, &ips, port, timeout).await {
         Ok(response) => response,
         Err(error) => {
             tracing::warn!(error = %error, target = %request.target, "host HTTP forward request failed");
@@ -129,8 +129,8 @@ where
             return Ok(());
         }
     };
-    let (ip, port) = match gate.decide_request(&request.target) {
-        EgressVerdict::Allow { ip, port } => (ip, port),
+    let (ips, port) = match gate.decide_request(&request.target) {
+        EgressVerdict::Allow { ips, port } => (ips, port),
         EgressVerdict::Deny => {
             write_proxy_error_blocking(&mut guest, ProxyStatus::Forbidden)?;
             return Ok(());
@@ -147,7 +147,7 @@ where
             return Err(error);
         }
     };
-    let response = match send_host_request_blocking(&request, body, ip, port, timeout) {
+    let response = match send_host_request_blocking(&request, body, &ips, port, timeout) {
         Ok(response) => response,
         Err(error) => {
             tracing::warn!(error = %error, target = %request.target, "host HTTP forward request failed");
@@ -336,7 +336,7 @@ where
 async fn send_host_request(
     request: &ForwardRequest,
     body: Vec<u8>,
-    admitted_ip: IpAddr,
+    admitted_ips: &[IpAddr],
     admitted_port: u16,
     timeout: Duration,
 ) -> std::io::Result<reqwest::Response> {
@@ -349,10 +349,11 @@ async fn send_host_request(
         .connect_timeout(timeout)
         .redirect(reqwest::redirect::Policy::none());
     if request.host.parse::<IpAddr>().is_err() {
-        builder = builder.resolve_to_addrs(
-            &request.host,
-            &[SocketAddr::new(admitted_ip, admitted_port)],
-        );
+        let socket_addrs: Vec<SocketAddr> = admitted_ips
+            .iter()
+            .map(|ip| SocketAddr::new(*ip, admitted_port))
+            .collect();
+        builder = builder.resolve_to_addrs(&request.host, &socket_addrs);
     }
     let client = builder.build().map_err(other)?;
     let method = reqwest::Method::from_bytes(request.method.as_bytes()).map_err(invalid_input)?;
@@ -370,7 +371,7 @@ async fn send_host_request(
 fn send_host_request_blocking(
     request: &ForwardRequest,
     body: Vec<u8>,
-    admitted_ip: IpAddr,
+    admitted_ips: &[IpAddr],
     admitted_port: u16,
     timeout: Duration,
 ) -> std::io::Result<reqwest::blocking::Response> {
@@ -383,10 +384,11 @@ fn send_host_request_blocking(
         .connect_timeout(timeout)
         .redirect(reqwest::redirect::Policy::none());
     if request.host.parse::<IpAddr>().is_err() {
-        builder = builder.resolve_to_addrs(
-            &request.host,
-            &[SocketAddr::new(admitted_ip, admitted_port)],
-        );
+        let socket_addrs: Vec<SocketAddr> = admitted_ips
+            .iter()
+            .map(|ip| SocketAddr::new(*ip, admitted_port))
+            .collect();
+        builder = builder.resolve_to_addrs(&request.host, &socket_addrs);
     }
     let client = builder.build().map_err(other)?;
     let method = reqwest::Method::from_bytes(request.method.as_bytes()).map_err(invalid_input)?;

--- a/crates/mvm-hostd/src/supervisor/raw_egress.rs
+++ b/crates/mvm-hostd/src/supervisor/raw_egress.rs
@@ -30,6 +30,7 @@ use hickory_proto::serialize::binary::{BinDecodable, BinEncodable, BinEncoder};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::supervisor::http_forward;
+use mvm_core::guest_netd::ConnectAck;
 use mvm_runtime::vmm::egress_gate::{EgressGate, EgressVerdict};
 
 /// Cap on the first `host:port` line. A guest that never sends a `\n` inside this
@@ -89,7 +90,8 @@ where
         }
         EgressVerdict::Deny | EgressVerdict::Malformed => {
             eprintln!("raw-egress: refusing target {target}");
-            // Refused: close without ever opening a host socket.
+            // Refused: nack the guest and close without ever opening a host socket.
+            write_connect_ack_async(&mut guest, ConnectAck::Fail).await?;
             Ok(())
         }
     }
@@ -143,16 +145,19 @@ where
     let connect = tokio::net::TcpStream::connect((ip, port));
     let mut upstream = match tokio::time::timeout(timeout, connect).await {
         Ok(Ok(s)) => s,
-        // Connect error or timeout → close the guest side, no splice.
+        // Connect error or timeout → nack the guest, close, no splice.
         Ok(Err(e)) => {
             eprintln!("raw-egress: connect to {ip}:{port} failed: {e}");
+            write_connect_ack_async(&mut guest, ConnectAck::Fail).await?;
             return Ok(());
         }
         Err(_) => {
             eprintln!("raw-egress: connect to {ip}:{port} timed out after {timeout:?}");
+            write_connect_ack_async(&mut guest, ConnectAck::Fail).await?;
             return Ok(());
         }
     };
+    write_connect_ack_async(&mut guest, ConnectAck::Ok).await?;
     if !leftover.is_empty() {
         upstream.write_all(&leftover).await?;
     }
@@ -167,6 +172,15 @@ where
         );
     }
     Ok(())
+}
+
+/// Write the host's one-byte connect-result ack on the async raw-egress path.
+async fn write_connect_ack_async<S>(guest: &mut S, ack: ConnectAck) -> std::io::Result<()>
+where
+    S: tokio::io::AsyncWrite + Unpin,
+{
+    guest.write_all(&[ack.as_byte()]).await?;
+    guest.flush().await
 }
 
 /// Serve raw-TCP egress over a host **AF_VSOCK** listener — the QEMU path,
@@ -222,6 +236,7 @@ fn handle_raw_conn_blocking(
             EgressVerdict::Allow { ip, port } => (ip, port),
             EgressVerdict::Deny | EgressVerdict::Malformed => {
                 eprintln!("raw-egress: refusing target {target}");
+                write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
                 return Ok(());
             }
         };
@@ -231,9 +246,11 @@ fn handle_raw_conn_blocking(
             Ok(stream) => stream,
             Err(e) => {
                 eprintln!("raw-egress: connect to {ip}:{port} failed: {e}");
+                write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
                 return Ok(());
             }
         };
+    write_connect_ack_blocking(&mut guest, ConnectAck::Ok)?;
     eprintln!("raw-egress: connected target {target} -> {ip}:{port}");
     let guest_fd = guest.as_raw_fd();
     set_nonblocking(guest_fd)?;
@@ -247,6 +264,14 @@ fn handle_raw_conn_blocking(
         stats.upstream_eof,
     );
     Ok(())
+}
+
+/// Write the host's one-byte connect-result ack on the blocking raw-egress path.
+#[cfg(target_os = "linux")]
+fn write_connect_ack_blocking(guest: &mut std::fs::File, ack: ConnectAck) -> std::io::Result<()> {
+    use std::io::Write;
+    guest.write_all(&[ack.as_byte()])?;
+    guest.flush()
 }
 
 #[cfg(target_os = "linux")]
@@ -621,12 +646,10 @@ mod tests {
     use tempfile::tempdir;
     use tokio::io::AsyncWriteExt;
 
-    /// A default-deny gate + a well-formed target ⇒ the connection is closed and
-    /// NO upstream connect happens (fail closed). We prove no connect by pointing
-    /// the target at a port nothing listens on and asserting the guest side simply
-    /// sees EOF quickly rather than a splice.
+    /// A default-deny gate + a well-formed target ⇒ the host nacks the connect and
+    /// closes without ever opening an upstream socket (fail closed).
     #[tokio::test]
-    async fn denied_target_closes_without_connecting() {
+    async fn denied_target_sends_fail_ack_then_closes() {
         let gate = EgressGate::default_deny();
         let (mut client, server) = tokio::io::duplex(1024);
         let h =
@@ -634,11 +657,14 @@ mod tests {
                 async move { handle_raw_conn(server, &gate, Duration::from_secs(1)).await },
             );
         client.write_all(b"93.184.216.34:80\n").await.unwrap();
-        // Denied ⇒ handler returns without connecting; the server half is dropped,
-        // so the client read hits EOF.
-        let mut sink = Vec::new();
-        let n = client.read_to_end(&mut sink).await.unwrap();
-        assert_eq!(n, 0, "denied target must not splice any bytes back");
+
+        let mut ack = [0u8; 1];
+        client.read_exact(&mut ack).await.unwrap();
+        assert_eq!(ack[0], ConnectAck::Fail.as_byte());
+
+        let mut rest = Vec::new();
+        client.read_to_end(&mut rest).await.unwrap();
+        assert!(rest.is_empty(), "no tunnel bytes after a Fail ack");
         h.await.unwrap().unwrap();
     }
 
@@ -679,6 +705,9 @@ mod tests {
                 async move { handle_raw_conn(server2, &gate2, Duration::from_secs(1)).await },
             );
         client2.write_all(b"not-an-address\n").await.unwrap();
+        let mut ack2 = [0u8; 1];
+        client2.read_exact(&mut ack2).await.unwrap();
+        assert_eq!(ack2[0], ConnectAck::Fail.as_byte());
         let mut sink2 = Vec::new();
         let n2 = client2.read_to_end(&mut sink2).await.unwrap();
         assert_eq!(n2, 0, "malformed target must not splice");
@@ -720,6 +749,10 @@ mod tests {
             .await
         });
 
+        let mut ack = [0u8; 1];
+        client.read_exact(&mut ack).await.unwrap();
+        assert_eq!(ack[0], ConnectAck::Ok.as_byte());
+
         // The leftover "lead" is echoed back first, then our live "ping".
         client.write_all(b"ping").await.unwrap();
         let mut got = Vec::new();
@@ -733,6 +766,47 @@ mod tests {
         assert_eq!(&got, b"leadping");
 
         // Half-close the guest so the echo server + splice wind down.
+        client.shutdown().await.ok();
+        drop(client);
+        splicer.await.unwrap().unwrap();
+        server.await.unwrap();
+    }
+
+    /// The ack precedes any tunnel bytes: `splice` writes `ConnectAck::Ok` right
+    /// after the upstream connect succeeds and before relaying anything.
+    #[tokio::test]
+    async fn splice_sends_ok_ack_before_tunneling() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut b = [0u8; 4];
+            sock.read_exact(&mut b).await.unwrap();
+            sock.write_all(&b).await.unwrap();
+        });
+
+        let (mut client, guest) = tokio::io::duplex(1024);
+        let splicer = tokio::spawn(async move {
+            splice(
+                guest,
+                "echo",
+                addr.ip(),
+                addr.port(),
+                Vec::new(),
+                Duration::from_secs(2),
+            )
+            .await
+        });
+
+        let mut ack = [0u8; 1];
+        client.read_exact(&mut ack).await.unwrap();
+        assert_eq!(ack[0], ConnectAck::Ok.as_byte());
+
+        client.write_all(b"ping").await.unwrap();
+        let mut echoed = [0u8; 4];
+        client.read_exact(&mut echoed).await.unwrap();
+        assert_eq!(&echoed, b"ping");
+
         client.shutdown().await.ok();
         drop(client);
         splicer.await.unwrap().unwrap();

--- a/crates/mvm-hostd/src/supervisor/raw_egress.rs
+++ b/crates/mvm-hostd/src/supervisor/raw_egress.rs
@@ -36,6 +36,10 @@ use mvm_runtime::vmm::egress_gate::{EgressGate, EgressVerdict};
 /// Cap on the first `host:port` line. A guest that never sends a `\n` inside this
 /// many bytes is refused (fail closed) rather than read unbounded.
 const MAX_TARGET_LINE: usize = 256;
+/// Per-address connect budget when trying an admitted set: small so an
+/// unreachable address (e.g. an AAAA with no host IPv6 egress) fails over to the
+/// next candidate quickly instead of stalling the request on the first.
+const PER_IP_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 #[cfg(target_os = "linux")]
 const DNS_QUERY_TIMEOUT: Duration = Duration::from_secs(2);
 #[cfg(target_os = "linux")]
@@ -85,8 +89,8 @@ where
         return http_forward::serve_http_forward(guest, gate, timeout).await;
     }
     match gate.decide_request_with(&target, |host| resolve_hostname_ips_pure(host, timeout)) {
-        EgressVerdict::Allow { ip, port } => {
-            splice(guest, &target, ip, port, leftover, timeout).await
+        EgressVerdict::Allow { ips, port } => {
+            splice(guest, &target, &ips, port, leftover, timeout).await
         }
         EgressVerdict::Deny | EgressVerdict::Malformed => {
             eprintln!("raw-egress: refusing target {target}");
@@ -125,16 +129,16 @@ where
     }
 }
 
-/// Connect to an admitted `(ip, port)` and splice bytes both ways until either
-/// side EOFs. `leftover` bytes (pipelined after the target line's `\n`) are
-/// forwarded upstream before the bidirectional copy so nothing is dropped.
+/// Connect to the first reachable of `ips` and splice bytes both ways until
+/// either side EOFs. `leftover` bytes (pipelined after the target line's `\n`)
+/// are forwarded upstream before the bidirectional copy so nothing is dropped.
 ///
 /// Split out from the gate decision so it's unit-testable against a loopback echo
 /// server without routing through the real gate (which mandatory-denies loopback).
 async fn splice<S>(
     mut guest: S,
     target: &str,
-    ip: IpAddr,
+    ips: &[IpAddr],
     port: u16,
     leftover: Vec<u8>,
     timeout: Duration,
@@ -142,17 +146,10 @@ async fn splice<S>(
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
-    let connect = tokio::net::TcpStream::connect((ip, port));
-    let mut upstream = match tokio::time::timeout(timeout, connect).await {
-        Ok(Ok(s)) => s,
-        // Connect error or timeout → nack the guest, close, no splice.
-        Ok(Err(e)) => {
-            eprintln!("raw-egress: connect to {ip}:{port} failed: {e}");
-            write_connect_ack_async(&mut guest, ConnectAck::Fail).await?;
-            return Ok(());
-        }
-        Err(_) => {
-            eprintln!("raw-egress: connect to {ip}:{port} timed out after {timeout:?}");
+    let mut upstream = match connect_first_admitted(ips, port, timeout).await {
+        Some(stream) => stream,
+        None => {
+            eprintln!("raw-egress: no admitted address reachable for {target}");
             write_connect_ack_async(&mut guest, ConnectAck::Fail).await?;
             return Ok(());
         }
@@ -161,7 +158,7 @@ where
     if !leftover.is_empty() {
         upstream.write_all(&leftover).await?;
     }
-    eprintln!("raw-egress: connected target {target} -> {ip}:{port}");
+    eprintln!("raw-egress: connected target {target}");
     // EOF on either side ends the copy; a reset surfaces as an error we swallow so
     // one torn-down connection never crashes the accept loop.
     if let Ok((guest_to_upstream, upstream_to_guest)) =
@@ -172,6 +169,32 @@ where
         );
     }
     Ok(())
+}
+
+/// Try each admitted address in order, first success wins, bounded overall by
+/// `overall_timeout` and per-address by [`PER_IP_CONNECT_TIMEOUT`]. This is the
+/// happy-eyeballs fallover: a pinned host can carry both an A and an AAAA
+/// record, and an unreachable IPv6 address (no host IPv6 egress) must not
+/// strand an otherwise-admitted request.
+async fn connect_first_admitted(
+    ips: &[IpAddr],
+    port: u16,
+    overall_timeout: Duration,
+) -> Option<tokio::net::TcpStream> {
+    let deadline = tokio::time::Instant::now() + overall_timeout;
+    for ip in ips {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let budget = remaining.min(PER_IP_CONNECT_TIMEOUT);
+        match tokio::time::timeout(budget, tokio::net::TcpStream::connect((*ip, port))).await {
+            Ok(Ok(stream)) => return Some(stream),
+            Ok(Err(e)) => eprintln!("raw-egress: connect to {ip}:{port} failed: {e}"),
+            Err(_) => eprintln!("raw-egress: connect to {ip}:{port} timed out after {budget:?}"),
+        }
+    }
+    None
 }
 
 /// Write the host's one-byte connect-result ack on the async raw-egress path.
@@ -231,9 +254,9 @@ fn handle_raw_conn_blocking(
     if target == http_forward::FRAME_LINE {
         return http_forward::serve_http_forward_blocking(guest, gate, timeout);
     }
-    let (ip, port) =
+    let (ips, port) =
         match gate.decide_request_with(&target, |host| resolve_hostname_ips_pure(host, timeout)) {
-            EgressVerdict::Allow { ip, port } => (ip, port),
+            EgressVerdict::Allow { ips, port } => (ips, port),
             EgressVerdict::Deny | EgressVerdict::Malformed => {
                 eprintln!("raw-egress: refusing target {target}");
                 write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
@@ -241,17 +264,16 @@ fn handle_raw_conn_blocking(
             }
         };
 
-    let upstream =
-        match std::net::TcpStream::connect_timeout(&std::net::SocketAddr::new(ip, port), timeout) {
-            Ok(stream) => stream,
-            Err(e) => {
-                eprintln!("raw-egress: connect to {ip}:{port} failed: {e}");
-                write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
-                return Ok(());
-            }
-        };
+    let upstream = match connect_first_admitted_blocking(&ips, port, timeout) {
+        Some(stream) => stream,
+        None => {
+            eprintln!("raw-egress: no admitted address reachable for {target}");
+            write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
+            return Ok(());
+        }
+    };
     write_connect_ack_blocking(&mut guest, ConnectAck::Ok)?;
-    eprintln!("raw-egress: connected target {target} -> {ip}:{port}");
+    eprintln!("raw-egress: connected target {target}");
     let guest_fd = guest.as_raw_fd();
     set_nonblocking(guest_fd)?;
     upstream.set_nonblocking(true)?;
@@ -272,6 +294,28 @@ fn write_connect_ack_blocking(guest: &mut std::fs::File, ack: ConnectAck) -> std
     use std::io::Write;
     guest.write_all(&[ack.as_byte()])?;
     guest.flush()
+}
+
+/// Blocking sibling of [`connect_first_admitted`] for the AF_VSOCK accept path.
+#[cfg(target_os = "linux")]
+fn connect_first_admitted_blocking(
+    ips: &[IpAddr],
+    port: u16,
+    overall_timeout: Duration,
+) -> Option<std::net::TcpStream> {
+    let deadline = std::time::Instant::now() + overall_timeout;
+    for ip in ips {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let budget = remaining.min(PER_IP_CONNECT_TIMEOUT);
+        match std::net::TcpStream::connect_timeout(&std::net::SocketAddr::new(*ip, port), budget) {
+            Ok(stream) => return Some(stream),
+            Err(e) => eprintln!("raw-egress: connect to {ip}:{port} failed: {e}"),
+        }
+    }
+    None
 }
 
 #[cfg(target_os = "linux")]
@@ -738,10 +782,11 @@ mod tests {
         // `leftover` = bytes pipelined after the `\n`; they must reach upstream first.
         let splicer = tokio::spawn(async move {
             let target = format!("{}:{}", addr.ip(), addr.port());
+            let ips = vec![addr.ip()];
             splice(
                 guest,
                 &target,
-                addr.ip(),
+                &ips,
                 addr.port(),
                 b"lead".to_vec(),
                 Duration::from_secs(2),
@@ -787,10 +832,11 @@ mod tests {
 
         let (mut client, guest) = tokio::io::duplex(1024);
         let splicer = tokio::spawn(async move {
+            let ips = vec![addr.ip()];
             splice(
                 guest,
                 "echo",
-                addr.ip(),
+                &ips,
                 addr.port(),
                 Vec::new(),
                 Duration::from_secs(2),
@@ -811,6 +857,59 @@ mod tests {
         drop(client);
         splicer.await.unwrap().unwrap();
         server.await.unwrap();
+    }
+
+    /// Happy-eyeballs fallover: an unreachable admitted address (e.g. an AAAA
+    /// with no host IPv6 route) must not strand the connect — it falls over to
+    /// the next admitted address instead.
+    #[tokio::test]
+    async fn connect_first_admitted_skips_unreachable_then_uses_reachable() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accept = tokio::spawn(async move {
+            let _ = listener.accept().await;
+        });
+
+        // TEST-NET-1 (RFC 5737) is not routable — packets sent to it are
+        // silently dropped rather than rejected, so the connect consumes its
+        // full `PER_IP_CONNECT_TIMEOUT` budget before falling over. The overall
+        // timeout here must exceed that per-IP budget, leaving room for the
+        // fallover attempt against the reachable loopback address.
+        let unreachable: IpAddr = "192.0.2.1".parse().unwrap();
+        let loopback: IpAddr = "127.0.0.1".parse().unwrap();
+
+        let stream =
+            connect_first_admitted(&[unreachable, loopback], port, Duration::from_secs(5)).await;
+        assert!(stream.is_some(), "must fall over to the reachable address");
+        accept.await.unwrap();
+    }
+
+    /// When every admitted address is unreachable, `splice` nacks the guest and
+    /// closes without ever tunneling bytes.
+    #[tokio::test]
+    async fn splice_sends_fail_ack_when_no_admitted_ip_is_reachable() {
+        let (mut client, guest) = tokio::io::duplex(1024);
+        let ips = vec!["192.0.2.1".parse::<IpAddr>().unwrap()];
+        let splicer = tokio::spawn(async move {
+            splice(
+                guest,
+                "unreachable",
+                &ips,
+                443,
+                Vec::new(),
+                Duration::from_secs(1),
+            )
+            .await
+        });
+
+        let mut ack = [0u8; 1];
+        client.read_exact(&mut ack).await.unwrap();
+        assert_eq!(ack[0], ConnectAck::Fail.as_byte());
+
+        let mut rest = Vec::new();
+        client.read_to_end(&mut rest).await.unwrap();
+        assert!(rest.is_empty());
+        splicer.await.unwrap().unwrap();
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
+++ b/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
@@ -19,8 +19,10 @@ use mvm_core::policy::projection::{CanonicalEgress, Proto};
 /// Outcome of an egress request.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EgressVerdict {
-    /// The plan permits a TCP connection to this destination.
-    Allow { ip: IpAddr, port: u16 },
+    /// The plan permits a TCP connection to this destination. `ips` are every
+    /// admitted address (a pinned host can carry both an A and an AAAA record),
+    /// IPv4 first; the caller connects to them in order, first success wins.
+    Allow { ips: Vec<IpAddr>, port: u16 },
     /// Refused — policy did not admit it (claim-10 default-deny / mandatory-deny).
     Deny,
     /// The guest's connect request was malformed (not `ip:port`).
@@ -81,7 +83,10 @@ impl EgressGate {
     /// Decide a TCP connect to an already-resolved address.
     pub fn decide_addr(&self, ip: IpAddr, port: u16) -> EgressVerdict {
         if self.egress.permits(&Proto::Tcp, ip, port) {
-            EgressVerdict::Allow { ip, port }
+            EgressVerdict::Allow {
+                ips: vec![ip],
+                port,
+            }
         } else {
             EgressVerdict::Deny
         }
@@ -123,32 +128,41 @@ impl EgressGate {
     where
         F: Fn(&str) -> std::io::Result<Vec<IpAddr>>,
     {
-        if let Some(pin) = self.pins.lookup(host) {
-            return pin
-                .ips
-                .iter()
-                .find_map(|ip| match self.decide_addr(*ip, port) {
-                    EgressVerdict::Allow { ip, port } => Some(EgressVerdict::Allow { ip, port }),
-                    _ => None,
-                })
-                .unwrap_or(EgressVerdict::Deny);
-        }
-
-        if !matches!(self.egress, CanonicalEgress::Unrestricted) {
+        let candidates = if let Some(pin) = self.pins.lookup(host) {
+            pin.ips.clone()
+        } else if matches!(self.egress, CanonicalEgress::Unrestricted) {
+            match resolve(host) {
+                Ok(ips) => ips,
+                Err(_) => return EgressVerdict::Deny,
+            }
+        } else {
             return EgressVerdict::Deny;
-        }
-
-        match resolve(host) {
-            Ok(ips) => ips
-                .into_iter()
-                .find_map(|ip| match self.decide_addr(ip, port) {
-                    EgressVerdict::Allow { ip, port } => Some(EgressVerdict::Allow { ip, port }),
-                    _ => None,
-                })
-                .unwrap_or(EgressVerdict::Deny),
-            Err(_) => EgressVerdict::Deny,
+        };
+        let ips = admitted_ips(&self.egress, &candidates, port);
+        if ips.is_empty() {
+            EgressVerdict::Deny
+        } else {
+            EgressVerdict::Allow { ips, port }
         }
     }
+}
+
+/// Filter `candidates` to the addresses the policy admits on `port`, ordered so
+/// IPv4 is tried before IPv6. Preferring IPv4 avoids stalling a connect on an
+/// AAAA address when the host has no working IPv6 egress; the caller still falls
+/// back to every admitted address, so a v4-only or v6-only destination is
+/// unaffected. Stable within each family, so resolver order is otherwise kept.
+fn admitted_ips(egress: &CanonicalEgress, candidates: &[IpAddr], port: u16) -> Vec<IpAddr> {
+    let mut admitted: Vec<IpAddr> = candidates
+        .iter()
+        .copied()
+        .filter(|ip| egress.permits(&Proto::Tcp, *ip, port))
+        .collect();
+    admitted.sort_by_key(|ip| match ip {
+        IpAddr::V4(_) => 0u8,
+        IpAddr::V6(_) => 1u8,
+    });
+    admitted
 }
 
 fn resolve_hostname_ips(host: &str) -> std::io::Result<Vec<IpAddr>> {
@@ -185,7 +199,7 @@ mod tests {
         assert_eq!(
             gate.decide_request("1.1.1.1:443"),
             EgressVerdict::Allow {
-                ip: "1.1.1.1".parse().unwrap(),
+                ips: vec!["1.1.1.1".parse().unwrap()],
                 port: 443
             }
         );
@@ -214,7 +228,7 @@ mod tests {
         assert_eq!(
             gate.decide_request("93.184.216.34:80"),
             EgressVerdict::Allow {
-                ip: "93.184.216.34".parse().unwrap(),
+                ips: vec!["93.184.216.34".parse().unwrap()],
                 port: 80
             }
         );
@@ -229,7 +243,7 @@ mod tests {
         assert_eq!(
             verdict,
             EgressVerdict::Allow {
-                ip: "151.101.1.91".parse().unwrap(),
+                ips: vec!["151.101.1.91".parse().unwrap()],
                 port: 443
             }
         );
@@ -268,7 +282,7 @@ mod tests {
         assert_eq!(
             EgressGate::new(open).decide_request("93.184.216.34:80"),
             EgressVerdict::Allow {
-                ip: "93.184.216.34".parse().unwrap(),
+                ips: vec!["93.184.216.34".parse().unwrap()],
                 port: 80
             }
         );
@@ -291,7 +305,7 @@ mod tests {
         assert_eq!(
             open.decide_request("93.184.216.34:80"),
             EgressVerdict::Allow {
-                ip: "93.184.216.34".parse().unwrap(),
+                ips: vec!["93.184.216.34".parse().unwrap()],
                 port: 80
             }
         );
@@ -333,7 +347,7 @@ mod tests {
         assert_eq!(
             gate.decide_request("192.168.4.23:19099"),
             EgressVerdict::Allow {
-                ip: "192.168.4.23".parse().unwrap(),
+                ips: vec!["192.168.4.23".parse().unwrap()],
                 port: 19099
             }
         );
@@ -369,7 +383,7 @@ mod tests {
         assert_eq!(
             gate.decide_request("api.example.test:443"),
             EgressVerdict::Allow {
-                ip: pinned,
+                ips: vec![pinned],
                 port: 443
             }
         );
@@ -392,9 +406,55 @@ mod tests {
         assert_eq!(
             gate.decide_request("93.184.216.34:443"),
             EgressVerdict::Allow {
-                ip: pinned,
+                ips: vec![pinned],
                 port: 443
             }
         );
+    }
+
+    #[test]
+    fn admitted_ips_keeps_only_permitted_and_orders_ipv4_first() {
+        let egress = CanonicalEgress::Rules(vec![
+            allow_rule("93.184.216.34/32", 443),
+            allow_rule("2606:2800:220:1:248:1893:25c8:1946/128", 443),
+        ]);
+        let v4: IpAddr = "93.184.216.34".parse().unwrap();
+        let v6: IpAddr = "2606:2800:220:1:248:1893:25c8:1946".parse().unwrap();
+        let unlisted: IpAddr = "8.8.8.8".parse().unwrap();
+
+        // Resolver order is v6-first (as a dual-stack host often returns); the
+        // unlisted address is dropped and the admitted set is reordered v4-first.
+        let got = admitted_ips(&egress, &[v6, unlisted, v4], 443);
+        assert_eq!(got, vec![v4, v6]);
+
+        // Wrong port admits nothing.
+        assert!(admitted_ips(&egress, &[v4, v6], 80).is_empty());
+    }
+
+    #[test]
+    fn hostname_request_returns_all_admitted_ips_ipv4_first() {
+        use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
+        use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+
+        let v6: IpAddr = "2606:2800:220:1:248:1893:25c8:1946".parse().unwrap();
+        let v4: IpAddr = "93.184.216.34".parse().unwrap();
+        let mut pins = DnsPinRegistry::new();
+        pins.add(DnsPin::at(
+            "example.com",
+            vec![v6, v4],
+            "2025-01-01T00:00:00Z",
+            "2030-01-01T00:00:00Z",
+        ));
+        let policy = NetworkPolicy::allow_list(vec![HostPort::new("example.com", 443)]);
+        let gate = EgressGate::from_network_policy(&policy, &pins, "2026-01-01T00:00:00Z");
+
+        match gate.decide_request("example.com:443") {
+            EgressVerdict::Allow { ips, port } => {
+                assert_eq!(ips, vec![v4, v6]);
+                assert_eq!(port, 443);
+            }
+            EgressVerdict::Deny | EgressVerdict::Malformed => panic!("expected allow"),
+        }
+        assert_eq!(gate.decide_request("example.com:80"), EgressVerdict::Deny);
     }
 }

--- a/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
+++ b/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
@@ -25,7 +25,7 @@ pub enum EgressVerdict {
     Allow { ips: Vec<IpAddr>, port: u16 },
     /// Refused — policy did not admit it (claim-10 default-deny / mandatory-deny).
     Deny,
-    /// The guest's connect request was malformed (not `ip:port`).
+    /// The guest's connect request was malformed (not `<ip>:<port>` or `<hostname>:<port>`).
     Malformed,
 }
 

--- a/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
+++ b/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
@@ -147,22 +147,20 @@ impl EgressGate {
     }
 }
 
-/// Filter `candidates` to the addresses the policy admits on `port`, ordered so
-/// IPv4 is tried before IPv6. Preferring IPv4 avoids stalling a connect on an
-/// AAAA address when the host has no working IPv6 egress; the caller still falls
-/// back to every admitted address, so a v4-only or v6-only destination is
-/// unaffected. Stable within each family, so resolver order is otherwise kept.
 fn admitted_ips(egress: &CanonicalEgress, candidates: &[IpAddr], port: u16) -> Vec<IpAddr> {
-    let mut admitted: Vec<IpAddr> = candidates
-        .iter()
-        .copied()
-        .filter(|ip| egress.permits(&Proto::Tcp, *ip, port))
-        .collect();
-    admitted.sort_by_key(|ip| match ip {
-        IpAddr::V4(_) => 0u8,
-        IpAddr::V6(_) => 1u8,
-    });
-    admitted
+    let mut v4 = Vec::new();
+    let mut v6 = Vec::new();
+    for ip in candidates.iter().copied() {
+        if !egress.permits(&Proto::Tcp, ip, port) {
+            continue;
+        }
+        match ip {
+            IpAddr::V4(_) => v4.push(ip),
+            IpAddr::V6(_) => v6.push(ip),
+        }
+    }
+    v4.extend(v6);
+    v4
 }
 
 fn resolve_hostname_ips(host: &str) -> std::io::Result<Vec<IpAddr>> {

--- a/features/suites/s2_egress_vsock/admitted_egress_live.feature
+++ b/features/suites/s2_egress_vsock/admitted_egress_live.feature
@@ -1,0 +1,12 @@
+Feature: Admitted egress completes end-to-end over the vsock seam
+
+  An allow-listed destination reached through the in-guest proxy connects and
+  returns real bytes: the host confirms the outbound connect before the guest
+  reports success, and it tries every admitted address so an unreachable IPv6
+  pin never strands the request.
+
+  @live
+  Scenario: An admitted https destination returns its page body
+    When I run mvmctl with "machine run --image alpine --allow-host example.com -- wget -q -O - https://example.com"
+    Then the command exits with code 0
+    And the output contains "Example Domain"

--- a/specs/adrs/032-egress-connect-completion-and-in-seam-dns.md
+++ b/specs/adrs/032-egress-connect-completion-and-in-seam-dns.md
@@ -1,0 +1,177 @@
+# ADR-032: Admitted egress must complete; DNS becomes a first-class part of the egress seam
+
+## Status
+
+Proposed
+
+## Context
+
+The vsock-only auditable data plane is an invariant (ADR-001; the
+`vsock-only-auditable-data-plane` posture): the guest has no routable NIC, every
+outbound flow crosses the host over vsock, the host mediates and audits it, and
+egress is admitted only by the workload's signed `NetworkPolicy` allow-list
+(claim 10 — no untrusted workload reaches the network unless explicitly
+admitted).
+
+Two live defects break that story for admitted workloads on the vsock-proxy
+backends (libkrun / HVF):
+
+1. **Admitted egress times out.** With `--allow-host example.com`, `wget
+   https://example.com` hangs and exits 124, even though the destination is
+   admitted. A *disallowed* destination is refused fast (a synthesized
+   `403`), so enforcement looks instant while an admitted connect never
+   completes.
+2. **The guest has no DNS resolver.** `/etc/resolv.conf` is empty. Any app that
+   resolves names itself (`ping`, and many TCP clients) fails with `bad
+   address`; only proxy-aware apps work, because the host resolves the name the
+   proxy is handed. DNS today is *implicit* — it only happens as a side effect
+   of an admitted CONNECT.
+
+Both defects live on the same host egress path, so this ADR addresses them
+together. Making the vsock proxy the sole egress plane (recent work that dropped
+the parallel L3 tunnel on host-vsock-proxy backends and fixed the guest
+egress-client spawn for OCI images) is what *exposed* defect 1 — the L3 tunnel
+had masked it.
+
+## Decision
+
+### Part 1 — Make admitted egress actually connect
+
+**Root cause** (two compounding defects):
+
+- **Optimistic CONNECT handshake.** The guest egress client
+  (`crates/mvm-agentd/src/egress_client.rs`, `serve_http_connect` ~332-342,
+  `serve_socks` ~320-330) writes `HTTP/1.1 200 Connection established` (or SOCKS
+  `REP_SUCCESS`) *before* the host confirms the outbound connect — it only opens
+  the vsock and writes the target line, then replies OK and splices. A failed
+  admitted connect therefore cannot surface as an error: the client has already
+  been told the tunnel is up, sends its TLS ClientHello into a tunnel that never
+  delivers a response, and blocks until timeout.
+- **Single-IP connect, no fallback.** Pins collect *all* resolved addresses
+  (A + AAAA) via `to_socket_addrs()`
+  (`crates/mvm-core/src/policy/dns_pin.rs`, `resolve_network_policy_pins`
+  ~47-67), but `EgressGate::decide_hostname_request`
+  (`crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs` ~122-151) returns
+  only the *first* admitted IP, and `raw_egress::splice`
+  (`crates/mvm-hostd/src/supervisor/raw_egress.rs` ~143-155) does a single
+  `TcpStream::connect` with no iteration. On a dual-stack host whose first
+  pinned IP (typically IPv6) has no working egress — the common dev-Mac case —
+  the connect stalls the full 30s timeout.
+- **Why enforcement stays fast:** a disallowed `http://` request is classified
+  `HttpForward` and answered inline by a *different* host component
+  (`crates/mvm-hostd/src/supervisor/http_forward.rs`), which synthesizes the
+  `403` with no outbound socket. The admitted-CONNECT path is the raw TCP splice
+  above. That asymmetry — plus the optimistic `200` — is exactly why enforcement
+  looks instant while an admitted connect hangs. Byte-pumping is correct in both
+  directions (the `403` round-trip proves it), and the host endpoint is spawned
+  and policy is threaded (the `403` proves the pin exists).
+
+**Decision 1a — honest CONNECT handshake.** Add a connect-result ack to the
+raw-egress protocol: after `TcpStream::connect` returns on the host, send a
+one-line `OK` / `FAIL` back to the guest before splicing; the guest relays `200
+Connection established` (or SOCKS `REP_SUCCESS`) only on `OK`, and otherwise
+returns `502` / `REP_GENERAL_FAILURE`. A failed admitted connect becomes a fast,
+correct client error instead of a hang.
+
+**Decision 1b — try every admitted pinned IP.**
+`EgressGate::decide_hostname_request` returns all admitted IPs (not just the
+first); `raw_egress::splice` iterates them happy-eyeballs style — prefer IPv4, a
+short per-IP connect budget, first success wins. An unreachable AAAA pin no
+longer stalls the request. 1b is what makes an admitted connection actually
+*succeed* on a dual-stack host; 1a makes any residual failure fail fast instead
+of hanging.
+
+### Part 2 — DNS as a first-class, policy-gated, audited part of the egress seam
+
+**Principle:** "can this workload reach destination D?" is *one* policy
+decision, applied to name resolution and to connection alike. A resolver bolted
+on beside the seam would be a second door with weaker policy — the classic way
+allow-listed egress is bypassed. So DNS is folded into the seam that already
+owns the gate, not added next to it.
+
+**Architecture.**
+
+- *Guest:* `mvm-netd` gains a DNS stub listener on `127.0.0.1:53` (UDP + TCP);
+  the guest's `/etc/resolv.conf` becomes `nameserver 127.0.0.1`. Queries are
+  forwarded over the *same* vsock plane already used for the proxy — no new
+  transport, no NIC.
+- *Host:* the egress endpoint gains a DNS handler that, per query: checks the
+  QNAME against the workload's admitted `NetworkPolicy` allow-list, resolves
+  upstream **only if admitted**, validates the answer IPs against IP-egress
+  policy, audits the query, and returns.
+
+**The five guards** (each closes one attack-surface item):
+
+1. **No covert exfil / DNS tunneling.** Resolve only allow-listed names;
+   everything else → `REFUSED`, no upstream lookup. Chain-audit every query
+   (qname, qtype, verdict, resolved IPs) so DNS is not a claim-10 blind spot.
+   (Wildcard / parent-domain allow-listing widens the channel to subdomains of
+   an admitted domain; it stays audited and rate-limited, and exact-name
+   allow-listing is preferred.)
+2. **No SSRF / DNS rebinding.** Reject A/AAAA answers in RFC1918, link-local,
+   loopback, ULA, and the metadata address `169.254.169.254` unless explicitly
+   allowed; re-check the IP at connect time (Part 1b already dials by admitted
+   IP), so a short-TTL rebind to a private IP is caught before dialing.
+3. **Parser safety across the vsock trust boundary.** A minimal, in-house
+   `forbid(unsafe)` DNS codec (question section + A/AAAA answers only — the wire
+   format we need is small), bounded message size, fail-closed on malformed,
+   plus a `cargo-fuzz` target sibling to the existing vsock-framing fuzzers
+   (claim 5). We do **not** pull `hickory-proto`: the surface we need is tiny
+   and a large parser dep works against the limit-dependencies norm (ADR-002).
+4. **Resource bounds.** Per-workload token-bucket on queries, a concurrency cap
+   on in-flight upstream lookups, and a response-size bound.
+5. **No confused deputy.** The handler is scoped to the *workload's* admitted
+   policy (threaded from the signed `ExecutionPlan`, exactly like TCP egress),
+   never a host-global resolver.
+
+The result: one `NetworkPolicy` drives both the DNS name gate and the TCP
+connect gate; one host component enforces both; one audit stream records both.
+
+### Test & fuzz matrix
+
+- **Unit (hermetic, no VM):** the name-gate + IP-policy filter; the
+  pinned-IP happy-eyeballs selection; the CONNECT ack state machine
+  (`OK` → `200`, `FAIL` → `502`).
+- **`@live` BDD** (`MVM_BDD_LIVE=1`, the lane added in this branch): an admitted
+  host is reachable (Part 1); an admitted *name* resolves and connects; a
+  non-admitted name is `REFUSED`; a name resolving to an internal/metadata IP is
+  blocked; the audit chain carries the query entries.
+- **Fuzz:** the DNS codec.
+
+### Sequencing
+
+1. **Part 1** (data-path fix) first — independently shippable, unblocks
+   everything, and makes the `@live` admitted-reachability scenario pass.
+2. **Part 2** (DNS resolver) rides the fixed path.
+
+## Consequences
+
+**Positive.** Admitted egress completes (fast failure when it can't); workloads
+that resolve names work without a NIC; DNS becomes auditable, so claim 10 stays
+honest with DNS in the picture; enforcement *and* reachability are both covered
+by `@live` tests.
+
+**Trade-offs / non-goals.** This does **not** make `ping` / ICMP work, and does
+**not** give non-proxy-aware raw TCP a transparent path — that is the L3-tunnel
+"full transparency" option, explicitly out of scope here. Wildcard / parent-domain
+allow-listing remains a wider (audited) DNS channel than exact-name matching. A
+workload that resolves a name it is not admitted to reach gets `REFUSED` by
+design.
+
+**Alternatives rejected.**
+- *A plain forwarding resolver* (forward all guest DNS to the host): reopens the
+  covert-egress hole — DNS would bypass the TCP allow-list. Rejected.
+- *Full L3 transparency* (guest TUN + L3 tunnel over vsock): makes arbitrary
+  TCP/UDP and `ping` work transparently, but is a much larger change and is the
+  currently-unstable area. Deferred; not this ADR.
+- *UX-only error* (replace `bad address` with a helpful message, no DNS
+  behavior change): doesn't fix the actual DNS need. Rejected.
+
+## References
+
+- ADR-001 — microVM security posture, threat model, claim 10.
+- ADR-023 — secrets subsystem / egress substitution (the other half of the
+  host-mediated egress boundary).
+- The admitted-egress-timeout root cause was confirmed by end-to-end static
+  analysis of the guest→vsock→host egress path on this branch; the file
+  references above are the anchor points a plan will change.

--- a/specs/plans/256-admitted-egress-connect-completion.md
+++ b/specs/plans/256-admitted-egress-connect-completion.md
@@ -1,0 +1,943 @@
+# Admitted-egress connect completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an admitted (`--allow-host`) egress connection actually complete over the vsock seam instead of hanging until timeout.
+
+**Architecture:** Two coupled fixes on the host↔guest raw-egress sub-protocol. (1a) The host sends a one-byte connect-result ack after `TcpStream::connect` returns; the in-guest proxy relays `200`/SOCKS-success only on OK, else `502`/failure — killing the current optimistic reply. (1b) The host gate returns *every* admitted pinned IP (IPv4 first) and the splice tries them in order with a short per-address budget, so an unreachable AAAA pin no longer strands the request. Implements ADR-032 Part 1 only; the DNS resolver (Part 2) is a separate plan.
+
+**Tech Stack:** Rust, tokio (async host + guest paths) and a Linux blocking path (`#[cfg(target_os = "linux")]`); `mvm-core` (shared wire type), `mvm-agentd` (guest proxy), `mvm-hostd` (host egress), `mvm-runtime` (egress gate), `mvm-conformance` (cucumber BDD).
+
+## Global Constraints
+
+- No `#[allow(clippy::...)]` anywhere — restructure instead (introduce a struct/enum/helper).
+- No spec/PR references in code comments (CI-gated): none of `Plan N`, `ADR-\d+`, `#\d+`, `W\d.` — reword to the concept.
+- Traits/enums over stringly-typed flags; exhaustive matches (no `_ =>` on our own enums).
+- No backwards-compat shims or aliases; hard-change the wire and the enum. Guest and host ship together from this one repo in the same `mvmctl`, so both sides change atomically — no protocol version bump, no capability flag.
+- `mvm-protocol` stays `#![no_std]` + `forbid(unsafe_code)` **if touched** — this plan does **not** touch it (the shared type lands in `mvm-core`, which is std).
+- Before every commit: `cargo nextest run` for the touched crates **and** `cargo clippy --workspace -- -D warnings` (or at minimum `-p <touched crate>`), plus `cargo fmt --all -- --check`.
+
+---
+
+## Overview
+
+Root cause: an admitted HTTPS `CONNECT` through the in-guest proxy hangs because (1) the guest emits `200 Connection established` / SOCKS `REP_SUCCESS` **optimistically**, before the host confirms anything, so any host-side non-completion becomes a client hang instead of an error; and (2) the host gate selects a **single** resolved pinned IP and `splice` does **one** `TcpStream::connect` with no fallback, so an unreachable first address (typically an AAAA/IPv6 pin on an IPv4-only-egress host) stalls the whole request. The disallowed-HTTP path fast-fails with `403` only because it is a different host component (`http_forward`) that answers inline.
+
+This plan implements the admitted-egress data-path fix:
+
+- **1a — honest CONNECT handshake.** Add a one-byte host→guest connect-result ack on the raw-egress sub-protocol. The host sends `ConnectAck::Ok` only after `TcpStream::connect` returns success, `ConnectAck::Fail` otherwise. The guest reads the ack and emits `200`/`REP_SUCCESS` on `Ok`, `502`/`REP_GENERAL_FAILURE` on `Fail`. Kills the optimistic replies in `egress_client.rs`.
+- **1b — happy-eyeballs over admitted IPs.** `EgressGate` returns **all** admitted pinned IPs (IPv4 first), and `raw_egress::splice` iterates them with a short per-address connect budget, first success wins.
+- **1c — one `@live` BDD scenario** asserting the end-to-end run now exits 0 and returns the page body.
+
+Part 2 (the DNS resolver) is explicitly **out of scope**.
+
+### Wire-protocol change (read before implementing)
+
+The raw-egress guest→host stream currently frames a first line — either `"host:port\n"` (raw CONNECT/SOCKS) or `"MVM_HTTP_FORWARD/1\n"` (host forward-proxy) — then splices. `raw_egress::read_target_line` (`crates/mvm-hostd/src/supervisor/raw_egress.rs:102`) reads that line byte-by-byte until `\n`.
+
+This change **adds exactly one host→guest byte** on the raw CONNECT/SOCKS sub-path only (not the `MVM_HTTP_FORWARD/1` forward path, which already returns a real HTTP response the guest relays). After the host reads the target line, decides, and attempts the connect, it writes one `ConnectAck` byte, then splices. The guest reads that one byte (`read_exact`) before emitting its own proxy reply; remaining bytes stay buffered in the socket for the splice. The `"host:port\n"` framing is unchanged.
+
+**No protocol version bump / no negotiation.** The guest (`mvm-agentd` bins, cross-compiled + embedded by `mvm-cli/build.rs`) and the host (`mvm-hostd` bins) build and ship from this one repo in the same `mvmctl`; there is no persisted or old-peer wire surface. Both sides change atomically.
+
+---
+
+## Task 1a — Honest CONNECT handshake (host ack + guest ack-gated reply)
+
+**Files**
+
+- Modify `crates/mvm-core/src/guest_netd.rs` (append `ConnectAck` after the consts; extend `#[cfg(test)] mod tests`).
+- Modify `crates/mvm-agentd/src/guest_vsock_session.rs` (imports; add `read_connect_ack` to the `impl<U> HostVsockSession<U>` block).
+- Modify `crates/mvm-agentd/src/egress_client.rs` (`serve_socks`, `serve_http_connect`; add `ProxyReplyStyle` + `write_connect_reply` + `complete_connect_session`; `connect_to_host_egress` unchanged; add tests).
+- Modify `crates/mvm-hostd/src/supervisor/raw_egress.rs` (import `ConnectAck`; `handle_raw_conn` Deny/Malformed arm; `splice` — send ack; `handle_raw_conn_blocking` + add blocking ack writer; extend tests).
+- Test paths: unit tests inline in each of the four files' `#[cfg(test)] mod tests`.
+
+**Interfaces**
+
+- Produces `mvm_core::guest_netd::ConnectAck`:
+  ```rust
+  pub enum ConnectAck { Ok, Fail }
+  impl ConnectAck { pub fn as_byte(self) -> u8; pub fn from_byte(byte: u8) -> Option<ConnectAck>; }
+  ```
+- Produces `HostVsockSession::read_connect_ack(&mut self) -> ConnectAck` (fail-closed to `Fail` on EOF/unknown byte).
+- Produces (guest, private): `enum ProxyReplyStyle { Socks, HttpConnect }`; `async fn write_connect_reply<C>(&mut C, ProxyReplyStyle, ConnectAck) -> io::Result<()>`; `async fn complete_connect_session<C, U>(C, HostVsockSession<U>, ProxyReplyStyle) -> io::Result<()>`.
+- Produces (host, private): `async fn write_connect_ack_async<S: AsyncWrite + Unpin>(&mut S, ConnectAck) -> io::Result<()>`; `#[cfg(target_os = "linux")] fn write_connect_ack_blocking(&mut std::fs::File, ConnectAck) -> io::Result<()>`.
+- Consumes existing: `reply`, `reply_http_connect_ok`, `write_http_response`, `HostVsockSession::{write_initial_bytes, splice}`; `raw_egress::splice` (still single-IP in 1a).
+
+- [ ] **Step 1a.1 — Failing test: `ConnectAck` byte roundtrip (pure)**
+
+In `crates/mvm-core/src/guest_netd.rs` `mod tests`, add:
+
+```rust
+#[test]
+fn connect_ack_roundtrips_through_its_wire_byte() {
+    assert_eq!(ConnectAck::from_byte(ConnectAck::Ok.as_byte()), Some(ConnectAck::Ok));
+    assert_eq!(ConnectAck::from_byte(ConnectAck::Fail.as_byte()), Some(ConnectAck::Fail));
+}
+
+#[test]
+fn connect_ack_ok_and_fail_are_distinct_bytes() {
+    assert_ne!(ConnectAck::Ok.as_byte(), ConnectAck::Fail.as_byte());
+}
+
+#[test]
+fn connect_ack_rejects_unknown_bytes_fail_closed() {
+    assert_eq!(ConnectAck::from_byte(0x02), None);
+    assert_eq!(ConnectAck::from_byte(0xff), None);
+}
+```
+
+Run (expect FAIL — type does not exist): `cargo nextest run -p mvm-core connect_ack`
+
+- [ ] **Step 1a.2 — Implement `ConnectAck`**
+
+Append to `crates/mvm-core/src/guest_netd.rs` (after `DEFAULT_EGRESS_PROXY_URL`):
+
+```rust
+/// The host's connect-result acknowledgement on the raw-egress stream.
+///
+/// The in-guest proxy dials the host, writes the `"host:port\n"` target line,
+/// then waits for this one byte before answering its own client. The host emits
+/// it only after the outbound `connect` resolves — `Ok` once the tunnel is live,
+/// `Fail` when the target was refused or unreachable — so the guest reply
+/// (`200` / SOCKS success on `Ok`, `502` / SOCKS failure on `Fail`) is truthful
+/// instead of assuming success the moment the stream opened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectAck {
+    /// The host connected to the admitted destination; tunnel bytes follow.
+    Ok,
+    /// The host refused or could not reach the destination; nothing follows.
+    Fail,
+}
+
+impl ConnectAck {
+    /// The single byte written on the wire.
+    pub fn as_byte(self) -> u8 {
+        match self {
+            ConnectAck::Ok => 0x01,
+            ConnectAck::Fail => 0x00,
+        }
+    }
+
+    /// Parse a wire byte back into an ack. Any byte outside the two defined
+    /// codes is rejected so a desynchronised stream never reads a tunnel data
+    /// byte as a spurious `Ok`.
+    pub fn from_byte(byte: u8) -> Option<ConnectAck> {
+        if byte == ConnectAck::Ok.as_byte() {
+            Some(ConnectAck::Ok)
+        } else if byte == ConnectAck::Fail.as_byte() {
+            Some(ConnectAck::Fail)
+        } else {
+            None
+        }
+    }
+}
+```
+
+Run (expect PASS): `cargo nextest run -p mvm-core connect_ack`; then `cargo clippy -p mvm-core -- -D warnings`.
+Commit: `feat(net): add ConnectAck wire type for the raw-egress connect handshake`
+
+- [ ] **Step 1a.3 — Failing test: guest reads the ack and answers accordingly**
+
+Add `use tokio::io::AsyncReadExt;` and `use mvm_core::guest_netd::ConnectAck;` where needed, then in `crates/mvm-agentd/src/egress_client.rs` `mod tests`:
+
+```rust
+#[tokio::test]
+async fn http_connect_replies_502_when_host_nacks() {
+    let (mut client, client_bridge) = tokio::io::duplex(256);
+    let (upstream_bridge, mut host) = tokio::io::duplex(256);
+    let session = HostVsockSession::new(upstream_bridge)
+        .write_initial_bytes(b"example.com:443\n")
+        .await
+        .unwrap();
+    let task = tokio::spawn(complete_connect_session(
+        client_bridge,
+        session,
+        ProxyReplyStyle::HttpConnect,
+    ));
+
+    let mut line = vec![0u8; b"example.com:443\n".len()];
+    host.read_exact(&mut line).await.unwrap();
+    host.write_all(&[ConnectAck::Fail.as_byte()]).await.unwrap();
+    host.shutdown().await.unwrap();
+
+    let mut resp = Vec::new();
+    client.read_to_end(&mut resp).await.unwrap();
+    let text = std::str::from_utf8(&resp).unwrap();
+    assert!(text.starts_with("HTTP/1.1 502"), "{text:?}");
+    task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn http_connect_replies_200_then_splices_when_host_acks_ok() {
+    let (mut client, client_bridge) = tokio::io::duplex(256);
+    let (upstream_bridge, mut host) = tokio::io::duplex(256);
+    let session = HostVsockSession::new(upstream_bridge)
+        .write_initial_bytes(b"example.com:443\n")
+        .await
+        .unwrap();
+    let task = tokio::spawn(complete_connect_session(
+        client_bridge,
+        session,
+        ProxyReplyStyle::HttpConnect,
+    ));
+
+    let mut line = vec![0u8; b"example.com:443\n".len()];
+    host.read_exact(&mut line).await.unwrap();
+    host.write_all(&[ConnectAck::Ok.as_byte()]).await.unwrap();
+
+    let expected = b"HTTP/1.1 200 Connection established\r\n\r\n";
+    let mut ok = vec![0u8; expected.len()];
+    client.read_exact(&mut ok).await.unwrap();
+    assert_eq!(&ok, expected);
+
+    client.write_all(b"ping").await.unwrap();
+    let mut got = [0u8; 4];
+    host.read_exact(&mut got).await.unwrap();
+    assert_eq!(&got, b"ping");
+    host.write_all(b"pong").await.unwrap();
+    let mut back = [0u8; 4];
+    client.read_exact(&mut back).await.unwrap();
+    assert_eq!(&back, b"pong");
+
+    drop(client);
+    drop(host);
+    task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn socks_replies_general_failure_when_host_nacks() {
+    let (mut client, client_bridge) = tokio::io::duplex(256);
+    let (upstream_bridge, mut host) = tokio::io::duplex(256);
+    let session = HostVsockSession::new(upstream_bridge)
+        .write_initial_bytes(b"1.2.3.4:443\n")
+        .await
+        .unwrap();
+    let task = tokio::spawn(complete_connect_session(
+        client_bridge,
+        session,
+        ProxyReplyStyle::Socks,
+    ));
+
+    let mut line = vec![0u8; b"1.2.3.4:443\n".len()];
+    host.read_exact(&mut line).await.unwrap();
+    host.write_all(&[ConnectAck::Fail.as_byte()]).await.unwrap();
+    host.shutdown().await.unwrap();
+
+    let mut reply = [0u8; 10];
+    client.read_exact(&mut reply).await.unwrap();
+    assert_eq!(reply[0], SOCKS5);
+    assert_eq!(reply[1], REP_GENERAL_FAILURE);
+    task.await.unwrap().unwrap();
+}
+```
+
+Run (expect FAIL — `complete_connect_session` / `ProxyReplyStyle` absent): `cargo nextest run -p mvm-agentd egress_client`
+
+- [ ] **Step 1a.4 — Implement guest ack read + reply-style state machine**
+
+In `crates/mvm-agentd/src/guest_vsock_session.rs`: ensure the import line is
+```rust
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+```
+and add `use mvm_core::guest_netd::ConnectAck;`. In the `impl<U> HostVsockSession<U> where U: AsyncRead + AsyncWrite + Unpin` block, add:
+
+```rust
+/// Read the host's one-byte connect-result ack that follows the target-line
+/// frame on the raw-egress protocol. Fail-closed: EOF or an unrecognised byte
+/// is treated as a connect failure so the caller answers its client honestly.
+pub async fn read_connect_ack(&mut self) -> ConnectAck {
+    let mut byte = [0u8; 1];
+    match self.upstream.read_exact(&mut byte).await {
+        Ok(_) => ConnectAck::from_byte(byte[0]).unwrap_or(ConnectAck::Fail),
+        Err(_) => ConnectAck::Fail,
+    }
+}
+```
+
+In `crates/mvm-agentd/src/egress_client.rs`, add near the top: `use mvm_core::guest_netd::ConnectAck;`, then add the state machine and rewrite the two `serve_*` fns. Replace the current `serve_socks` and `serve_http_connect` with:
+
+```rust
+/// Which client-facing proxy reply flavour a completed CONNECT-style session
+/// answers with, so the ack->reply mapping is one exhaustive match rather than
+/// duplicated per call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProxyReplyStyle {
+    Socks,
+    HttpConnect,
+}
+
+/// Emit the client-facing reply for a connect outcome. Exhaustive over the
+/// (style, ack) matrix: SOCKS success/failure replies and HTTP `200`/`502`.
+async fn write_connect_reply<C>(
+    client: &mut C,
+    style: ProxyReplyStyle,
+    ack: ConnectAck,
+) -> std::io::Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+{
+    match (style, ack) {
+        (ProxyReplyStyle::Socks, ConnectAck::Ok) => reply(client, REP_SUCCESS).await,
+        (ProxyReplyStyle::Socks, ConnectAck::Fail) => reply(client, REP_GENERAL_FAILURE).await,
+        (ProxyReplyStyle::HttpConnect, ConnectAck::Ok) => reply_http_connect_ok(client).await,
+        (ProxyReplyStyle::HttpConnect, ConnectAck::Fail) => {
+            write_http_response(client, "502 Bad Gateway").await
+        }
+    }
+}
+
+/// Finish a CONNECT-style request once the host session is open: read the host
+/// connect ack, answer the client truthfully, and splice only on `Ok`. Generic
+/// over both streams so it unit-tests over in-memory duplex pipes.
+async fn complete_connect_session<C, U>(
+    mut client: C,
+    mut session: HostVsockSession<U>,
+    style: ProxyReplyStyle,
+) -> std::io::Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+    U: AsyncRead + AsyncWrite + Unpin,
+{
+    let ack = session.read_connect_ack().await;
+    write_connect_reply(&mut client, style, ack).await?;
+    match ack {
+        ConnectAck::Ok => session.splice(client).await,
+        ConnectAck::Fail => Ok(()),
+    }
+}
+
+async fn serve_socks(client: TcpStream, target: &str) -> std::io::Result<()> {
+    match connect_to_host_egress(target).await {
+        Ok(session) => complete_connect_session(client, session, ProxyReplyStyle::Socks).await,
+        Err(err) => {
+            let mut client = client;
+            let _ = reply(&mut client, REP_GENERAL_FAILURE).await;
+            Err(err)
+        }
+    }
+}
+
+async fn serve_http_connect(client: TcpStream, target: &str) -> std::io::Result<()> {
+    match connect_to_host_egress(target).await {
+        Ok(session) => {
+            complete_connect_session(client, session, ProxyReplyStyle::HttpConnect).await
+        }
+        Err(err) => {
+            let mut client = client;
+            let _ = write_http_response(&mut client, "502 Bad Gateway").await;
+            Err(err)
+        }
+    }
+}
+```
+
+`connect_to_host_egress` is unchanged — it still opens the vsock and writes `"host:port\n"`; the optimistic reply is gone because `serve_*` no longer call `reply`/`reply_http_connect_ok` before the ack. `serve_http_forward` is untouched (no ack on the forward path).
+
+Run (expect PASS): `cargo nextest run -p mvm-agentd egress_client` and `cargo nextest run -p mvm-agentd guest_vsock_session`.
+
+- [ ] **Step 1a.5 — Failing test: host sends the ack (deny + failed connect)**
+
+In `crates/mvm-hostd/src/supervisor/raw_egress.rs` `mod tests` (import `mvm_core::guest_netd::ConnectAck`):
+
+```rust
+#[tokio::test]
+async fn denied_target_sends_fail_ack_then_closes() {
+    let gate = EgressGate::default_deny();
+    let (mut client, server) = tokio::io::duplex(1024);
+    let h = tokio::spawn(async move {
+        handle_raw_conn(server, &gate, Duration::from_secs(1)).await
+    });
+    client.write_all(b"93.184.216.34:80\n").await.unwrap();
+
+    let mut ack = [0u8; 1];
+    client.read_exact(&mut ack).await.unwrap();
+    assert_eq!(ack[0], ConnectAck::Fail.as_byte());
+
+    let mut rest = Vec::new();
+    client.read_to_end(&mut rest).await.unwrap();
+    assert!(rest.is_empty(), "no tunnel bytes after a Fail ack");
+    h.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn splice_sends_ok_ack_before_tunneling() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.unwrap();
+        let mut b = [0u8; 4];
+        sock.read_exact(&mut b).await.unwrap();
+        sock.write_all(&b).await.unwrap();
+    });
+
+    let (mut client, guest) = tokio::io::duplex(1024);
+    let splicer = tokio::spawn(async move {
+        // 1a: single-IP splice. (Signature widens to `&[IpAddr]` in Task 1b,
+        // and this call becomes `&[addr.ip()]`.)
+        splice(guest, "echo", addr.ip(), addr.port(), Vec::new(), Duration::from_secs(2)).await
+    });
+
+    let mut ack = [0u8; 1];
+    client.read_exact(&mut ack).await.unwrap();
+    assert_eq!(ack[0], ConnectAck::Ok.as_byte());
+
+    client.write_all(b"ping").await.unwrap();
+    let mut echoed = [0u8; 4];
+    client.read_exact(&mut echoed).await.unwrap();
+    assert_eq!(&echoed, b"ping");
+
+    client.shutdown().await.ok();
+    drop(client);
+    splicer.await.unwrap().unwrap();
+    server.await.unwrap();
+}
+```
+
+Also update the existing tests whose byte expectations change:
+- `denied_target_closes_without_connecting`: it now reads the `Fail` ack first — replace with the assertion above (or delete it in favour of `denied_target_sends_fail_ack_then_closes`).
+- `malformed_or_unterminated_first_line_fails_closed`: the **unterminated** half (no `\n` → `read_target_line` returns `None`) is unchanged (no ack). The **malformed-but-terminated** half (`"not-an-address\n"` → `Malformed`) now receives a `Fail` ack — read one ack byte == `ConnectAck::Fail.as_byte()`, then assert EOF.
+- `splice_proxies_both_directions`: prepend a one-byte ack read (`assert_eq!(ack[0], ConnectAck::Ok.as_byte())`) before the leftover/`ping` assertions.
+
+Run (expect FAIL): `cargo nextest run -p mvm-hostd raw_egress`
+
+- [ ] **Step 1a.6 — Implement host ack (async + blocking)**
+
+In `crates/mvm-hostd/src/supervisor/raw_egress.rs` add `use mvm_core::guest_netd::ConnectAck;`. Change `handle_raw_conn` Deny/Malformed arm:
+
+```rust
+EgressVerdict::Deny | EgressVerdict::Malformed => {
+    eprintln!("raw-egress: refusing target {target}");
+    write_connect_ack_async(&mut guest, ConnectAck::Fail).await?;
+    Ok(())
+}
+```
+
+Rewrite `splice` — 1a keeps the single `ip` param and adds the ack:
+
+```rust
+async fn splice<S>(
+    mut guest: S,
+    target: &str,
+    ip: IpAddr,
+    port: u16,
+    leftover: Vec<u8>,
+    timeout: Duration,
+) -> std::io::Result<()>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let connect = tokio::net::TcpStream::connect((ip, port));
+    let mut upstream = match tokio::time::timeout(timeout, connect).await {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => {
+            eprintln!("raw-egress: connect to {ip}:{port} failed: {e}");
+            write_connect_ack_async(&mut guest, ConnectAck::Fail).await?;
+            return Ok(());
+        }
+        Err(_) => {
+            eprintln!("raw-egress: connect to {ip}:{port} timed out after {timeout:?}");
+            write_connect_ack_async(&mut guest, ConnectAck::Fail).await?;
+            return Ok(());
+        }
+    };
+    write_connect_ack_async(&mut guest, ConnectAck::Ok).await?;
+    if !leftover.is_empty() {
+        upstream.write_all(&leftover).await?;
+    }
+    eprintln!("raw-egress: connected target {target} -> {ip}:{port}");
+    if let Ok((guest_to_upstream, upstream_to_guest)) =
+        tokio::io::copy_bidirectional(&mut guest, &mut upstream).await
+    {
+        eprintln!(
+            "raw-egress: completed target {target} guest_to_upstream_bytes={guest_to_upstream} upstream_to_guest_bytes={upstream_to_guest}"
+        );
+    }
+    Ok(())
+}
+
+async fn write_connect_ack_async<S>(guest: &mut S, ack: ConnectAck) -> std::io::Result<()>
+where
+    S: tokio::io::AsyncWrite + Unpin,
+{
+    guest.write_all(&[ack.as_byte()]).await?;
+    guest.flush().await
+}
+```
+
+In the blocking path, `handle_raw_conn_blocking`: change the Deny/Malformed arm and add the `Ok` ack after a successful connect:
+
+```rust
+let (ip, port) =
+    match gate.decide_request_with(&target, |host| resolve_hostname_ips_pure(host, timeout)) {
+        EgressVerdict::Allow { ip, port } => (ip, port),
+        EgressVerdict::Deny | EgressVerdict::Malformed => {
+            eprintln!("raw-egress: refusing target {target}");
+            write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
+            return Ok(());
+        }
+    };
+
+let upstream =
+    match std::net::TcpStream::connect_timeout(&std::net::SocketAddr::new(ip, port), timeout) {
+        Ok(stream) => stream,
+        Err(e) => {
+            eprintln!("raw-egress: connect to {ip}:{port} failed: {e}");
+            write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
+            return Ok(());
+        }
+    };
+write_connect_ack_blocking(&mut guest, ConnectAck::Ok)?;
+eprintln!("raw-egress: connected target {target} -> {ip}:{port}");
+// ... (unchanged: set_nonblocking / pump_bidirectional_poll)
+```
+
+Add the blocking ack writer (Linux-only):
+
+```rust
+#[cfg(target_os = "linux")]
+fn write_connect_ack_blocking(guest: &mut std::fs::File, ack: ConnectAck) -> std::io::Result<()> {
+    use std::io::Write;
+    guest.write_all(&[ack.as_byte()])?;
+    guest.flush()
+}
+```
+
+Run (expect PASS): `cargo nextest run -p mvm-hostd raw_egress`; then `cargo nextest run -p mvm-core -p mvm-agentd -p mvm-hostd`, `cargo clippy -p mvm-core -p mvm-agentd -p mvm-hostd -- -D warnings`, `cargo fmt --all -- --check`.
+Commit: `fix(net): gate the in-guest CONNECT reply on the host connect-result ack`
+
+---
+
+## Task 1b — Happy-eyeballs over all admitted pinned IPs
+
+**Files**
+
+- Modify `crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs` (`EgressVerdict`; `decide_addr`; `decide_hostname_request`; add `admitted_ips`; update tests).
+- Modify `crates/mvm-hostd/src/supervisor/raw_egress.rs` (`handle_raw_conn` Allow arm; `splice` signature `ip: IpAddr` → `ips: &[IpAddr]`; add `PER_IP_CONNECT_TIMEOUT` + `connect_first_admitted` (+ `_blocking`); `handle_raw_conn_blocking` Allow arm; update the 1a tests' `splice(...)` calls to `&[addr.ip()]`).
+- Modify `crates/mvm-hostd/src/supervisor/http_forward.rs` (async `serve_http_forward` + `send_host_request`; blocking siblings) — compile-fix for the widened `Allow` variant, passing all IPs to reqwest `resolve_to_addrs`.
+- No change at `crates/mvm-hostd/src/supervisor/substitution_proxy.rs` — its match is `EgressVerdict::Allow { .. }` (field-agnostic).
+- Test paths: inline in `egress_gate.rs` and `raw_egress.rs` tests modules.
+
+**Interfaces**
+
+- Modifies `EgressVerdict::Allow { ip: IpAddr, port: u16 }` → `Allow { ips: Vec<IpAddr>, port: u16 }`.
+- Produces (gate, private) `fn admitted_ips(egress: &CanonicalEgress, candidates: &[IpAddr], port: u16) -> Vec<IpAddr>` (pure; filters to policy-permitted, IPv4 before IPv6, stable within family).
+- Modifies `EgressGate::{decide_addr, decide_hostname_request}` to the Vec form.
+- Produces (host, private) `const PER_IP_CONNECT_TIMEOUT: Duration`; `async fn connect_first_admitted(&[IpAddr], u16, Duration) -> Option<tokio::net::TcpStream>`; `#[cfg(target_os = "linux")] fn connect_first_admitted_blocking(&[IpAddr], u16, Duration) -> Option<std::net::TcpStream>`.
+- Modifies `raw_egress::splice(guest, target, ips: &[IpAddr], port, leftover, timeout)` and `http_forward::send_host_request{,_blocking}(.., admitted_ips: &[IpAddr], admitted_port, ..)`.
+
+- [ ] **Step 1b.1 — Failing test: pure IP selection/ordering**
+
+In `crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs` `mod tests`:
+
+```rust
+#[test]
+fn admitted_ips_keeps_only_permitted_and_orders_ipv4_first() {
+    let egress = CanonicalEgress::Rules(vec![
+        allow_rule("93.184.216.34/32", 443),
+        allow_rule("2606:2800:220:1:248:1893:25c8:1946/128", 443),
+    ]);
+    let v4: IpAddr = "93.184.216.34".parse().unwrap();
+    let v6: IpAddr = "2606:2800:220:1:248:1893:25c8:1946".parse().unwrap();
+    let unlisted: IpAddr = "8.8.8.8".parse().unwrap();
+
+    // Resolver order is v6-first (as a dual-stack host often returns); the
+    // unlisted address is dropped and the admitted set is reordered v4-first.
+    let got = admitted_ips(&egress, &[v6, unlisted, v4], 443);
+    assert_eq!(got, vec![v4, v6]);
+
+    // Wrong port admits nothing.
+    assert!(admitted_ips(&egress, &[v4, v6], 80).is_empty());
+}
+
+#[test]
+fn hostname_request_returns_all_admitted_ips_ipv4_first() {
+    use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
+    use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+
+    let v6: IpAddr = "2606:2800:220:1:248:1893:25c8:1946".parse().unwrap();
+    let v4: IpAddr = "93.184.216.34".parse().unwrap();
+    let mut pins = DnsPinRegistry::new();
+    pins.add(DnsPin::at(
+        "example.com",
+        vec![v6, v4],
+        "2025-01-01T00:00:00Z",
+        "2030-01-01T00:00:00Z",
+    ));
+    let policy = NetworkPolicy::allow_list(vec![HostPort::new("example.com", 443)]);
+    let gate = EgressGate::from_network_policy(&policy, &pins, "2026-01-01T00:00:00Z");
+
+    match gate.decide_request("example.com:443") {
+        EgressVerdict::Allow { ips, port } => {
+            assert_eq!(ips, vec![v4, v6]);
+            assert_eq!(port, 443);
+        }
+        EgressVerdict::Deny | EgressVerdict::Malformed => panic!("expected allow"),
+    }
+    assert_eq!(gate.decide_request("example.com:80"), EgressVerdict::Deny);
+}
+```
+
+Every existing `egress_gate.rs` test asserting `Allow { ip: X, port }` must be updated to `Allow { ips: vec![X], port }` in the same step (they will fail to compile until then). NOTE: verify the exact constructor names (`CanonicalEgress::Rules`, `allow_rule`, `DnsPin::at`, `DnsPinRegistry::{new,add}`, `NetworkPolicy::allow_list`, `HostPort::new`) against the real code and adjust the test to the actual signatures before running. Run (expect FAIL — `admitted_ips` absent, variant shape mismatch): `cargo nextest run -p mvm-runtime egress_gate`
+
+- [ ] **Step 1b.2 — Implement the widened verdict + selection**
+
+In `egress_gate.rs`, change the enum:
+
+```rust
+pub enum EgressVerdict {
+    /// The plan permits a TCP connection to this destination. `ips` are every
+    /// admitted address (a pinned host can carry both an A and an AAAA record),
+    /// IPv4 first; the caller connects to them in order, first success wins.
+    Allow { ips: Vec<IpAddr>, port: u16 },
+    Deny,
+    Malformed,
+}
+```
+
+`decide_addr`:
+
+```rust
+pub fn decide_addr(&self, ip: IpAddr, port: u16) -> EgressVerdict {
+    if self.egress.permits(&Proto::Tcp, ip, port) {
+        EgressVerdict::Allow { ips: vec![ip], port }
+    } else {
+        EgressVerdict::Deny
+    }
+}
+```
+
+`decide_hostname_request` — collect candidates once, filter through the pure helper:
+
+```rust
+fn decide_hostname_request<F>(&self, host: &str, port: u16, resolve: F) -> EgressVerdict
+where
+    F: Fn(&str) -> std::io::Result<Vec<IpAddr>>,
+{
+    let candidates = if let Some(pin) = self.pins.lookup(host) {
+        pin.ips.clone()
+    } else if matches!(self.egress, CanonicalEgress::Unrestricted) {
+        match resolve(host) {
+            Ok(ips) => ips,
+            Err(_) => return EgressVerdict::Deny,
+        }
+    } else {
+        return EgressVerdict::Deny;
+    };
+    let ips = admitted_ips(&self.egress, &candidates, port);
+    if ips.is_empty() {
+        EgressVerdict::Deny
+    } else {
+        EgressVerdict::Allow { ips, port }
+    }
+}
+```
+
+Add the pure helper (free function, below the `impl`):
+
+```rust
+/// Filter `candidates` to the addresses the policy admits on `port`, ordered so
+/// IPv4 is tried before IPv6. Preferring IPv4 avoids stalling a connect on an
+/// AAAA address when the host has no working IPv6 egress; the caller still falls
+/// back to every admitted address, so a v4-only or v6-only destination is
+/// unaffected. Stable within each family, so resolver order is otherwise kept.
+fn admitted_ips(egress: &CanonicalEgress, candidates: &[IpAddr], port: u16) -> Vec<IpAddr> {
+    let mut admitted: Vec<IpAddr> = candidates
+        .iter()
+        .copied()
+        .filter(|ip| egress.permits(&Proto::Tcp, *ip, port))
+        .collect();
+    admitted.sort_by_key(|ip| match ip {
+        IpAddr::V4(_) => 0u8,
+        IpAddr::V6(_) => 1u8,
+    });
+    admitted
+}
+```
+
+Run (expect PASS): `cargo nextest run -p mvm-runtime egress_gate`. Hold the commit to the end of Task 1b (the enum change breaks the host call sites until 1b.4/1b.5 update them; keep the workspace green before any commit).
+
+- [ ] **Step 1b.3 — Failing test: connect fallover + splice over multiple IPs**
+
+In `raw_egress.rs` `mod tests`:
+
+```rust
+#[tokio::test]
+async fn connect_first_admitted_skips_unreachable_then_uses_reachable() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let accept = tokio::spawn(async move { let _ = listener.accept().await; });
+
+    // TEST-NET-1 (RFC 5737) is not routable — the connect fails or is bounded
+    // by the per-IP budget, then falls over to the reachable loopback address.
+    let unreachable: IpAddr = "192.0.2.1".parse().unwrap();
+    let loopback: IpAddr = "127.0.0.1".parse().unwrap();
+
+    let stream =
+        connect_first_admitted(&[unreachable, loopback], port, Duration::from_secs(2)).await;
+    assert!(stream.is_some(), "must fall over to the reachable address");
+    accept.await.unwrap();
+}
+
+#[tokio::test]
+async fn splice_sends_fail_ack_when_no_admitted_ip_is_reachable() {
+    let (mut client, guest) = tokio::io::duplex(1024);
+    let ips = vec!["192.0.2.1".parse::<IpAddr>().unwrap()];
+    let splicer = tokio::spawn(async move {
+        splice(guest, "unreachable", &ips, 443, Vec::new(), Duration::from_secs(1)).await
+    });
+
+    let mut ack = [0u8; 1];
+    client.read_exact(&mut ack).await.unwrap();
+    assert_eq!(ack[0], ConnectAck::Fail.as_byte());
+
+    let mut rest = Vec::new();
+    client.read_to_end(&mut rest).await.unwrap();
+    assert!(rest.is_empty());
+    splicer.await.unwrap().unwrap();
+}
+```
+
+Update the 1a `splice_sends_ok_ack_before_tunneling` and `splice_proxies_both_directions` calls from `addr.ip()` to `&[addr.ip()]` (move an owned `let ips = vec![addr.ip()];` into the spawned closure so the borrow is `'static`).
+
+Run (expect FAIL — `connect_first_admitted` absent, `splice` still single-IP): `cargo nextest run -p mvm-hostd raw_egress`
+
+- [ ] **Step 1b.4 — Implement the multi-IP connect loop + splice**
+
+In `raw_egress.rs`, add near the constants:
+
+```rust
+/// Per-address connect budget when trying an admitted set: small so an
+/// unreachable address (e.g. an AAAA with no host IPv6 egress) fails over to the
+/// next candidate quickly instead of stalling the request on the first.
+const PER_IP_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+```
+
+Change `handle_raw_conn` Allow arm:
+
+```rust
+EgressVerdict::Allow { ips, port } => {
+    splice(guest, &target, &ips, port, leftover, timeout).await
+}
+```
+
+Rewrite `splice` to iterate (replacing the 1a body):
+
+```rust
+async fn splice<S>(
+    mut guest: S,
+    target: &str,
+    ips: &[IpAddr],
+    port: u16,
+    leftover: Vec<u8>,
+    timeout: Duration,
+) -> std::io::Result<()>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let mut upstream = match connect_first_admitted(ips, port, timeout).await {
+        Some(stream) => stream,
+        None => {
+            eprintln!("raw-egress: no admitted address reachable for {target}");
+            write_connect_ack_async(&mut guest, ConnectAck::Fail).await?;
+            return Ok(());
+        }
+    };
+    write_connect_ack_async(&mut guest, ConnectAck::Ok).await?;
+    if !leftover.is_empty() {
+        upstream.write_all(&leftover).await?;
+    }
+    eprintln!("raw-egress: connected target {target}");
+    if let Ok((guest_to_upstream, upstream_to_guest)) =
+        tokio::io::copy_bidirectional(&mut guest, &mut upstream).await
+    {
+        eprintln!(
+            "raw-egress: completed target {target} guest_to_upstream_bytes={guest_to_upstream} upstream_to_guest_bytes={upstream_to_guest}"
+        );
+    }
+    Ok(())
+}
+
+/// Try each admitted address in order, first success wins, bounded overall by
+/// `overall_timeout` and per-address by [`PER_IP_CONNECT_TIMEOUT`].
+async fn connect_first_admitted(
+    ips: &[IpAddr],
+    port: u16,
+    overall_timeout: Duration,
+) -> Option<tokio::net::TcpStream> {
+    let deadline = tokio::time::Instant::now() + overall_timeout;
+    for ip in ips {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let budget = remaining.min(PER_IP_CONNECT_TIMEOUT);
+        match tokio::time::timeout(budget, tokio::net::TcpStream::connect((*ip, port))).await {
+            Ok(Ok(stream)) => return Some(stream),
+            Ok(Err(e)) => eprintln!("raw-egress: connect to {ip}:{port} failed: {e}"),
+            Err(_) => eprintln!("raw-egress: connect to {ip}:{port} timed out after {budget:?}"),
+        }
+    }
+    None
+}
+```
+
+Blocking path — `handle_raw_conn_blocking` Allow arm + connect loop:
+
+```rust
+let (ips, port) =
+    match gate.decide_request_with(&target, |host| resolve_hostname_ips_pure(host, timeout)) {
+        EgressVerdict::Allow { ips, port } => (ips, port),
+        EgressVerdict::Deny | EgressVerdict::Malformed => {
+            eprintln!("raw-egress: refusing target {target}");
+            write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
+            return Ok(());
+        }
+    };
+
+let upstream = match connect_first_admitted_blocking(&ips, port, timeout) {
+    Some(stream) => stream,
+    None => {
+        eprintln!("raw-egress: no admitted address reachable for {target}");
+        write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
+        return Ok(());
+    }
+};
+write_connect_ack_blocking(&mut guest, ConnectAck::Ok)?;
+// ... (unchanged: set_nonblocking / pump_bidirectional_poll)
+```
+
+```rust
+#[cfg(target_os = "linux")]
+fn connect_first_admitted_blocking(
+    ips: &[IpAddr],
+    port: u16,
+    overall_timeout: Duration,
+) -> Option<std::net::TcpStream> {
+    let deadline = std::time::Instant::now() + overall_timeout;
+    for ip in ips {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let budget = remaining.min(PER_IP_CONNECT_TIMEOUT);
+        match std::net::TcpStream::connect_timeout(&std::net::SocketAddr::new(*ip, port), budget) {
+            Ok(stream) => return Some(stream),
+            Err(e) => eprintln!("raw-egress: connect to {ip}:{port} failed: {e}"),
+        }
+    }
+    None
+}
+```
+
+Run (expect PASS): `cargo nextest run -p mvm-hostd raw_egress`
+
+- [ ] **Step 1b.5 — Compile-fix `http_forward` for the widened variant**
+
+In `crates/mvm-hostd/src/supervisor/http_forward.rs`, async arm:
+
+```rust
+let (ips, port) = match gate.decide_request(&request.target) {
+    EgressVerdict::Allow { ips, port } => (ips, port),
+    EgressVerdict::Deny => {
+        write_proxy_error_async(&mut guest, ProxyStatus::Forbidden).await?;
+        return Ok(());
+    }
+    EgressVerdict::Malformed => {
+        write_proxy_error_async(&mut guest, ProxyStatus::BadRequest).await?;
+        return Ok(());
+    }
+};
+// ...
+let response = match send_host_request(&request, body, &ips, port, timeout).await { /* unchanged */ };
+```
+
+`send_host_request` signature `admitted_ip: IpAddr` → `admitted_ips: &[IpAddr]`, and the resolve override passes all (reqwest tries them):
+
+```rust
+if request.host.parse::<IpAddr>().is_err() {
+    let socket_addrs: Vec<SocketAddr> = admitted_ips
+        .iter()
+        .map(|ip| SocketAddr::new(*ip, admitted_port))
+        .collect();
+    builder = builder.resolve_to_addrs(&request.host, &socket_addrs);
+}
+```
+
+Apply the identical change to the blocking `serve_http_forward_blocking` and `send_host_request_blocking`. The `http_forward` tests use `default_deny` (Deny→403) and `unrestricted`+malformed (Malformed→400) — none match `Allow { .. }`, so they are unaffected.
+
+Run (expect PASS): `cargo nextest run -p mvm-runtime -p mvm-hostd`; then `cargo clippy -p mvm-runtime -p mvm-hostd -- -D warnings`, `cargo fmt --all -- --check`, and `cargo build --workspace --all-targets` to catch any other `Allow` consumer.
+Commit: `fix(net): connect to every admitted pinned IP, IPv4-first, on the egress splice`
+
+---
+
+## Task 1c — `@live` BDD scenario for an admitted egress round-trip
+
+**Files**
+
+- Create `features/suites/s2_egress_vsock/admitted_egress_live.feature`.
+- No step code needed — reuses `When I run mvmctl with {string}`, `Then the command exits with code {int}`, `Then the output contains {string}` (`crates/mvm-conformance/tests/steps/cli.rs`). The `@live` tag is gated by `MVM_BDD_LIVE` in `crates/mvm-conformance/tests/conformance.rs` (`LIVE_TAG = "live"`).
+
+**Interfaces**
+
+- Consumes the existing `CliWorld` step facade and the `@live` lane. Produces no Rust.
+
+- [ ] **Step 1c.1 — Add the scenario**
+
+Create `features/suites/s2_egress_vsock/admitted_egress_live.feature`:
+
+```gherkin
+Feature: Admitted egress completes end-to-end over the vsock seam
+
+  An allow-listed destination reached through the in-guest proxy connects and
+  returns real bytes: the host confirms the outbound connect before the guest
+  reports success, and it tries every admitted address so an unreachable IPv6
+  pin never strands the request.
+
+  @live
+  Scenario: An admitted https destination returns its page body
+    When I run mvmctl with "machine run --image alpine --allow-host example.com -- wget -q -O - https://example.com"
+    Then the command exits with code 0
+    And the output contains "Example Domain"
+```
+
+- [ ] **Step 1c.2 — Verify hermetic-lane skip and live-lane shape**
+
+- Hermetic (default) lane — the scenario is skipped, suite still green:
+  `cargo nextest run -p mvm-conformance` (expect PASS; `@live` skipped because `MVM_BDD_LIVE` is unset)
+- Live lane (HVF host, after 1a+1b merged):
+  `MVM_BDD_LIVE=1 cargo nextest run -p mvm-conformance` (expect PASS — exits 0, body contains `Example Domain`)
+
+The live run is the regression that the prior symptom (`exit 124` hang) is fixed; it requires a working HVF backend host and is not part of the hermetic PR gate.
+
+Commit: `test(bdd): assert an admitted allow-host https run completes over vsock egress`
+
+---
+
+## Sequencing & final gate
+
+1a → 1b → 1c. Each task ends green independently; `splice` is edited by both 1a (add ack, single-IP) and 1b (generalise to `&[IpAddr]`), which is expected. Before the final push run the full named gate:
+
+```
+cargo fmt --all -- --check
+cargo nextest run -p mvm-core -p mvm-agentd -p mvm-runtime -p mvm-hostd -p mvm-conformance
+cargo test -p mvm-core -p mvm-agentd -p mvm-runtime -p mvm-hostd --doc
+cargo clippy --workspace -- -D warnings
+cargo build --workspace --all-targets
+```
+
+## Deferred follow-ups
+
+- **DNS resolver (ADR-032 Part 2)** — the policy-gated, audited in-seam resolver
+  (guest stub on `127.0.0.1:53` → vsock → host), pin TTL/refresh. A separate
+  plan. Not addressed here; 1b's IPv4-first happy-eyeballs is the data-path
+  mitigation, not a resolver change.
+- **Linux blocking-path test** — `connect_first_admitted_blocking` /
+  `write_connect_ack_blocking` and the blocking `Allow`/refuse arms (the
+  QEMU/Firecracker vsock path) are a hand-mirror of the async path with no
+  direct test; every new test is `#[tokio::test]` against the async path. Add a
+  Linux-gated test driving the blocking connect-fallover (loopback + a
+  non-routable address) and a blocking deny→`Fail`-ack assertion so the two
+  paths can't silently drift.
+- **Optional refusal symmetry** — the unterminated-first-line refusal returns
+  without an explicit `Fail` ack (unlike every other refusal); it is fail-closed
+  because the guest maps the prompt EOF to `Fail`, so this is polish, not a bug.


### PR DESCRIPTION
## Problem

An **admitted** egress connection hangs to timeout instead of connecting. With `mvmctl machine run --image alpine --allow-host example.com -- wget https://example.com`, the guest hangs (`exit 124`), while a *disallowed* port fast-fails with `403`. On the vsock-only egress data plane (the claim-10 enforcement seam), an allow-listed destination could not actually be reached.

## Root cause

Two compounding defects:

1. **Optimistic CONNECT handshake** — the in-guest proxy (`egress_client.rs`) sent `200 Connection established` / SOCKS success *before* the host confirmed the outbound connect. A failed admitted connect therefore couldn't surface as an error; the client sent its TLS hello into a tunnel that never delivers and blocked until timeout.
2. **Single-IP connect, no fallback** — the host (`raw_egress::splice`) connected to only the *first* pinned IP with no iteration. On a dual-stack host whose first pinned IP is an unreachable IPv6 address (common on a dev Mac with no IPv6 egress), the connect stalled the whole timeout.

The fast `403` came from a *different* host component (`http_forward`, which answers inline with no socket), which is why enforcement looked instant while an admitted connect hung.

## Fix

- **Honest CONNECT handshake** — the host sends a one-byte `ConnectAck` only after `TcpStream::connect` resolves; the guest relays `200`/`REP_SUCCESS` only on `Ok`, else `502`/`REP_GENERAL_FAILURE`, and splices only on `Ok`. Fail-closed by construction (`from_byte` rejects unknown bytes; EOF → `Fail`); exactly one byte is read so no tunnel bytes are stolen; the `HTTP_FORWARD` path is deliberately ack-free.
- **Happy-eyeballs** — the egress gate returns every *admitted* pinned IP (IPv4-first, still individually policy-filtered), and the host tries them in order with a per-IP connect budget, first success wins. An unreachable IPv6 pin no longer strands the request.

Both the async and the Linux blocking (`#[cfg(target_os = "linux")]`) paths are updated symmetrically. The wire and the `EgressVerdict` enum are hard-changed — guest and host ship together in one `mvmctl`, so no version negotiation is needed.

Design: ADR-032 Part 1 (`specs/adrs/032-*`), Plan 256 (`specs/plans/256-*`). Part 2 (a policy-gated, audited in-seam DNS resolver — the "guest DNS story") is deferred to its own plan.

## Testing

- 3984 hermetic tests across `mvm-core`/`mvm-agentd`/`mvm-runtime`/`mvm-hostd` (the ack state machine and pinned-IP selection are pure/duplex-pipe units — the full matrix: 502-on-nack, 200-then-splice-on-ack, deny→Fail, unreachable→reachable fallover, fail-closed byte rejection).
- A `@live` conformance scenario (`MVM_BDD_LIVE=1`) that boots alpine with `--allow-host` and asserts `wget https://example.com` returns the page body — the end-to-end regression for the original hang. Skipped in the hermetic lane.

## Follow-ups (tracked in Plan 256)

- The in-seam DNS resolver (ADR-032 Part 2).
- A Linux blocking-path unit test (the blocking connect-fallover mirrors the async path with no direct test yet).
- Optional refusal-symmetry polish on the unterminated-first-line path.
