### PR TITLE
feat: hash-linked, chain-anchored checkpoint lineage

### DIFF
--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2285,6 +2285,29 @@ fn test_checkpoint_rm_json_parses() {
 }
 
 #[test]
+fn test_checkpoint_verify_parses() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "machine",
+        "checkpoint",
+        "verify",
+        "ckpt-abc",
+        "--json",
+    ])
+    .unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Machine(machine::Args {
+            action: machine::MachineAction::Vm(group::VmCmd::Checkpoint(
+                checkpoint::CheckpointArgs {
+                    command: checkpoint::CheckpointCmd::Verify { json: true, .. }
+                }
+            ))
+        })
+    ));
+}
+
+#[test]
 fn test_checkpoint_create_defaults_fs_quick() {
     let cli = Cli::try_parse_from(["mvmctl", "machine", "checkpoint", "create", "myvm"]).unwrap();
     assert!(matches!(

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -19,14 +19,16 @@ use mvm_core::config::vm_state_dir;
 use mvm_core::vm_backend::SnapshotCapability;
 use mvm_hostd::audit::bind::class_str;
 use mvm_runtime::checkpoint::{
-    CaptureFsQuickParams, CaptureVmFullParams, CheckpointChainAnchor, CheckpointStore, ForkParams,
-    capture_fs_quick, capture_vm_full, checkpoint_is_vz, fork_checkpoint, fork_vm_full_fc,
-    verify_lineage,
+    CaptureFsQuickParams, CaptureVmFullParams, CheckpointStore, ForkParams, capture_fs_quick,
+    capture_vm_full, checkpoint_is_vz, fork_checkpoint, fork_vm_full_fc,
 };
 
 use super::Cli;
 use super::shared::clap_vm_name;
 use crate::ui;
+
+mod lineage;
+pub(super) use lineage::SignedChainAnchor;
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct CheckpointArgs {
@@ -195,7 +197,7 @@ pub(in crate::commands) fn run_checkpoint(_cli: &Cli, args: CheckpointArgs) -> R
             json,
         ),
         CheckpointCmd::Diff { a, b, json } => diff(&a, &b, json),
-        CheckpointCmd::Verify { id, json } => verify(&id, json),
+        CheckpointCmd::Verify { id, json } => lineage::verify(&id, json),
     }
 }
 
@@ -640,165 +642,6 @@ fn diff(a: &str, b: &str, json: bool) -> Result<()> {
         println!("{:<20} {}", blob.name, status);
     }
     Ok(())
-}
-
-#[derive(Serialize)]
-struct CheckpointVerifyJson<'a> {
-    schema_version: u8,
-    action: &'static str,
-    id: &'a str,
-    verified: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
-}
-
-/// A [`CheckpointChainAnchor`] backed by the host-signed audit chains on disk.
-///
-/// Verifies every host-lifecycle chain's signatures up front (skipping the
-/// per-VM workload chains, which use a different format) and indexes the
-/// content-address each checkpoint's creation entry recorded. Only entries from
-/// chains that verify clean are indexed: an entry stranded behind a tampered
-/// line is not trusted, so the checkpoint it names fails closed as un-anchored.
-struct SignedChainAnchor {
-    /// checkpoint id -> content-address the signed chain recorded at creation.
-    recorded: std::collections::HashMap<String, CheckpointDigest>,
-}
-
-impl SignedChainAnchor {
-    fn load() -> Result<Self> {
-        use mvm_hostd::audit::emitter::default_audit_dir;
-
-        let dir = default_audit_dir()?;
-        let mut recorded = std::collections::HashMap::new();
-        let read_dir = match std::fs::read_dir(&dir) {
-            Ok(rd) => rd,
-            // No audit dir yet → nothing to anchor; every lookup is None (fail closed).
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(Self { recorded });
-            }
-            Err(e) => return Err(e).with_context(|| format!("reading {}", dir.display())),
-        };
-
-        // All lifecycle chains are signed under the one host key.
-        let signer = super::host_signer::load_or_init()
-            .context("loading host signer to anchor checkpoint lineage")?;
-
-        for entry in read_dir {
-            let path = entry?.path();
-            if !is_host_lifecycle_chain(&path) {
-                continue;
-            }
-            // A chain we cannot verify cannot anchor anything: skip it whole so a
-            // tampered line strands (rather than silently trusts) its entries.
-            if mvm_hostd::supervisor::verify_audit_chain(&path, &signer.verifying).is_err() {
-                tracing::warn!(
-                    path = %path.display(),
-                    "audit chain failed verification; its entries will not anchor any checkpoint"
-                );
-                continue;
-            }
-            let content = std::fs::read_to_string(&path)
-                .with_context(|| format!("reading {}", path.display()))?;
-            for line in content.lines() {
-                if line.is_empty() {
-                    continue;
-                }
-                let envelope: mvm_hostd::supervisor::SignedEnvelope = serde_json::from_str(line)
-                    .with_context(|| format!("parsing audit line in {}", path.display()))?;
-                index_creation_digest(&mut recorded, &envelope)?;
-            }
-        }
-        Ok(Self { recorded })
-    }
-}
-
-/// A host-lifecycle audit chain is `<tenant>.jsonl` — NOT a per-VM workload
-/// chain (`<tenant>.<vm>.workload.jsonl`), which carries a different envelope
-/// format that `verify_audit_chain` does not parse.
-fn is_host_lifecycle_chain(path: &std::path::Path) -> bool {
-    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-        return false;
-    };
-    name.ends_with(".jsonl") && !name.ends_with(mvm_core::config::WORKLOAD_AUDIT_SUFFIX)
-}
-
-/// Index one signed audit entry's creation content-address, when it is a
-/// checkpoint creation event. `checkpoint.created` keys on
-/// `checkpoint_id`/`meta_digest`; `checkpoint.forked` is a child's creation, so
-/// it keys on `child_id`/`child_digest`.
-fn index_creation_digest(
-    recorded: &mut std::collections::HashMap<String, CheckpointDigest>,
-    envelope: &mvm_hostd::supervisor::SignedEnvelope,
-) -> Result<()> {
-    use mvm_hostd::audit::emitter::checkpoint_audit as k;
-    let event = envelope.entry.event.as_str();
-    // The (id, digest) label pair a creation event keys on; non-creation events
-    // carry neither.
-    let key_pair = if event == k::CREATED_EVENT {
-        Some((k::LABEL_CHECKPOINT_ID, k::LABEL_META_DIGEST))
-    } else if event == k::FORKED_EVENT {
-        Some((k::LABEL_CHILD_ID, k::LABEL_CHILD_DIGEST))
-    } else {
-        None
-    };
-    let Some((id_key, digest_key)) = key_pair else {
-        return Ok(());
-    };
-    let labels = &envelope.entry.labels;
-    if let (Some(id), Some(digest)) = (labels.get(id_key), labels.get(digest_key)) {
-        recorded.insert(id.clone(), CheckpointDigest::parse(digest.clone())?);
-    }
-    Ok(())
-}
-
-impl CheckpointChainAnchor for SignedChainAnchor {
-    fn recorded_creation_digest(&self, meta: &CheckpointMeta) -> Result<Option<CheckpointDigest>> {
-        Ok(self.recorded.get(meta.id.as_str()).cloned())
-    }
-}
-
-/// `mvmctl vm checkpoint verify <id>`: chain-anchored lineage verification.
-/// Exits nonzero on any failure so it is scriptable.
-fn verify(id: &str, json: bool) -> Result<()> {
-    let checkpoint = validated_checkpoint_id(id)?;
-    let store = CheckpointStore::open();
-    let anchor = SignedChainAnchor::load()
-        .context("loading the signed audit chain to anchor lineage verification")?;
-
-    match verify_lineage(&store, &checkpoint, &anchor) {
-        Ok(()) => {
-            if json {
-                crate::json_out::emit_json(&CheckpointVerifyJson {
-                    schema_version: 1,
-                    action: "verify",
-                    id: checkpoint.as_str(),
-                    verified: true,
-                    error: None,
-                })?;
-            } else {
-                ui::success(&format!(
-                    "checkpoint {} lineage verifies against the signed audit chain",
-                    checkpoint.as_str()
-                ));
-            }
-            Ok(())
-        }
-        Err(e) => {
-            if json {
-                crate::json_out::emit_json(&CheckpointVerifyJson {
-                    schema_version: 1,
-                    action: "verify",
-                    id: checkpoint.as_str(),
-                    verified: false,
-                    error: Some(format!("{e:#}")),
-                })?;
-            }
-            Err(e.context(format!(
-                "checkpoint {} lineage verification failed",
-                checkpoint.as_str()
-            )))
-        }
-    }
 }
 
 fn rm(id: &str, json: bool) -> Result<()> {
@@ -1519,6 +1362,7 @@ pub(crate) fn bind_checkpoint_forked(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_runtime::checkpoint::{CheckpointChainAnchor, verify_lineage};
 
     #[test]
     fn validated_checkpoint_id_accepts_normal() {

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -14,7 +14,7 @@ use anyhow::{Context, Result, bail};
 use clap::Args as ClapArgs;
 use serde::Serialize;
 
-use mvm_core::checkpoint::{CheckpointClass, CheckpointId, CheckpointMeta};
+use mvm_core::checkpoint::{CheckpointClass, CheckpointDigest, CheckpointId, CheckpointMeta};
 use mvm_core::config::vm_state_dir;
 use mvm_core::vm_backend::SnapshotCapability;
 use mvm_hostd::audit::bind::class_str;
@@ -531,22 +531,48 @@ fn ls(json: bool) -> Result<()> {
         ui::info("(no checkpoints)");
         return Ok(());
     }
+    // The parent hash-link is a content-address on disk; resolve it back to the
+    // human checkpoint id the operator recognizes. Build the digest->id lookup
+    // once from the metas already listed rather than re-scanning per row.
+    let id_by_digest: std::collections::HashMap<&CheckpointDigest, &str> = metas
+        .iter()
+        .map(|m| (&m.meta_digest, m.id.as_str()))
+        .collect();
     println!(
         "{:<32} {:<10} {:<20} {:<8} PARENT",
         "ID", "CLASS", "VM", "TAG"
     );
     for m in &metas {
-        let class = class_str(m.class);
+        let parent_display = match &m.parent {
+            None => "-".to_string(),
+            // Unknown parent (pruned/dangling): fall back to the short digest so
+            // the link stays visible instead of silently blank.
+            Some(digest) => id_by_digest
+                .get(digest)
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| short_digest(digest)),
+        };
         println!(
             "{:<32} {:<10} {:<20} {:<8} {}",
             m.id.as_str(),
-            class,
+            class_str(m.class),
             m.vm_name,
             m.tag.as_deref().unwrap_or("-"),
-            m.parent.as_ref().map(|p| p.as_str()).unwrap_or("-"),
+            parent_display,
         );
     }
     Ok(())
+}
+
+/// Compact display form of a checkpoint content-address (`sha256:` + first 12
+/// hex), for the `ls` PARENT column when the human id behind a link isn't in
+/// view.
+fn short_digest(digest: &CheckpointDigest) -> String {
+    let hex = digest
+        .as_str()
+        .strip_prefix(CheckpointDigest::PREFIX)
+        .unwrap_or_else(|| digest.as_str());
+    format!("{}{}", CheckpointDigest::PREFIX, &hex[..hex.len().min(12)])
 }
 
 fn diff(a: &str, b: &str, json: bool) -> Result<()> {

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -19,8 +19,9 @@ use mvm_core::config::vm_state_dir;
 use mvm_core::vm_backend::SnapshotCapability;
 use mvm_hostd::audit::bind::class_str;
 use mvm_runtime::checkpoint::{
-    CaptureFsQuickParams, CaptureVmFullParams, CheckpointStore, ForkParams, capture_fs_quick,
-    capture_vm_full, checkpoint_is_vz, fork_checkpoint, fork_vm_full_fc,
+    CaptureFsQuickParams, CaptureVmFullParams, CheckpointChainAnchor, CheckpointStore, ForkParams,
+    capture_fs_quick, capture_vm_full, checkpoint_is_vz, fork_checkpoint, fork_vm_full_fc,
+    verify_lineage,
 };
 
 use super::Cli;
@@ -147,6 +148,19 @@ pub(in crate::commands) enum CheckpointCmd {
         #[arg(long)]
         json: bool,
     },
+    /// Verify a checkpoint's full lineage against the signed audit chain.
+    ///
+    /// Walks from the checkpoint up to its genesis root; at every hop the
+    /// record's content-address must match both its stored `meta_digest` and the
+    /// digest the host signed into the audit chain at creation. Exits nonzero on
+    /// any drift, chain mismatch, missing signed entry, or broken lineage.
+    Verify {
+        /// Checkpoint id to verify.
+        id: String,
+        /// Output the verification result as JSON.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 pub(in crate::commands) fn run_checkpoint(_cli: &Cli, args: CheckpointArgs) -> Result<()> {
@@ -181,6 +195,7 @@ pub(in crate::commands) fn run_checkpoint(_cli: &Cli, args: CheckpointArgs) -> R
             json,
         ),
         CheckpointCmd::Diff { a, b, json } => diff(&a, &b, json),
+        CheckpointCmd::Verify { id, json } => verify(&id, json),
     }
 }
 
@@ -627,6 +642,165 @@ fn diff(a: &str, b: &str, json: bool) -> Result<()> {
     Ok(())
 }
 
+#[derive(Serialize)]
+struct CheckpointVerifyJson<'a> {
+    schema_version: u8,
+    action: &'static str,
+    id: &'a str,
+    verified: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+/// A [`CheckpointChainAnchor`] backed by the host-signed audit chains on disk.
+///
+/// Verifies every host-lifecycle chain's signatures up front (skipping the
+/// per-VM workload chains, which use a different format) and indexes the
+/// content-address each checkpoint's creation entry recorded. Only entries from
+/// chains that verify clean are indexed: an entry stranded behind a tampered
+/// line is not trusted, so the checkpoint it names fails closed as un-anchored.
+struct SignedChainAnchor {
+    /// checkpoint id -> content-address the signed chain recorded at creation.
+    recorded: std::collections::HashMap<String, CheckpointDigest>,
+}
+
+impl SignedChainAnchor {
+    fn load() -> Result<Self> {
+        use mvm_hostd::audit::emitter::default_audit_dir;
+
+        let dir = default_audit_dir()?;
+        let mut recorded = std::collections::HashMap::new();
+        let read_dir = match std::fs::read_dir(&dir) {
+            Ok(rd) => rd,
+            // No audit dir yet → nothing to anchor; every lookup is None (fail closed).
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Self { recorded });
+            }
+            Err(e) => return Err(e).with_context(|| format!("reading {}", dir.display())),
+        };
+
+        // All lifecycle chains are signed under the one host key.
+        let signer = super::host_signer::load_or_init()
+            .context("loading host signer to anchor checkpoint lineage")?;
+
+        for entry in read_dir {
+            let path = entry?.path();
+            if !is_host_lifecycle_chain(&path) {
+                continue;
+            }
+            // A chain we cannot verify cannot anchor anything: skip it whole so a
+            // tampered line strands (rather than silently trusts) its entries.
+            if mvm_hostd::supervisor::verify_audit_chain(&path, &signer.verifying).is_err() {
+                tracing::warn!(
+                    path = %path.display(),
+                    "audit chain failed verification; its entries will not anchor any checkpoint"
+                );
+                continue;
+            }
+            let content = std::fs::read_to_string(&path)
+                .with_context(|| format!("reading {}", path.display()))?;
+            for line in content.lines() {
+                if line.is_empty() {
+                    continue;
+                }
+                let envelope: mvm_hostd::supervisor::SignedEnvelope = serde_json::from_str(line)
+                    .with_context(|| format!("parsing audit line in {}", path.display()))?;
+                index_creation_digest(&mut recorded, &envelope)?;
+            }
+        }
+        Ok(Self { recorded })
+    }
+}
+
+/// A host-lifecycle audit chain is `<tenant>.jsonl` — NOT a per-VM workload
+/// chain (`<tenant>.<vm>.workload.jsonl`), which carries a different envelope
+/// format that `verify_audit_chain` does not parse.
+fn is_host_lifecycle_chain(path: &std::path::Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    name.ends_with(".jsonl") && !name.ends_with(mvm_core::config::WORKLOAD_AUDIT_SUFFIX)
+}
+
+/// Index one signed audit entry's creation content-address, when it is a
+/// checkpoint creation event. `checkpoint.created` keys on
+/// `checkpoint_id`/`meta_digest`; `checkpoint.forked` is a child's creation, so
+/// it keys on `child_id`/`child_digest`.
+fn index_creation_digest(
+    recorded: &mut std::collections::HashMap<String, CheckpointDigest>,
+    envelope: &mvm_hostd::supervisor::SignedEnvelope,
+) -> Result<()> {
+    use mvm_hostd::audit::emitter::checkpoint_audit as k;
+    let event = envelope.entry.event.as_str();
+    // The (id, digest) label pair a creation event keys on; non-creation events
+    // carry neither.
+    let key_pair = if event == k::CREATED_EVENT {
+        Some((k::LABEL_CHECKPOINT_ID, k::LABEL_META_DIGEST))
+    } else if event == k::FORKED_EVENT {
+        Some((k::LABEL_CHILD_ID, k::LABEL_CHILD_DIGEST))
+    } else {
+        None
+    };
+    let Some((id_key, digest_key)) = key_pair else {
+        return Ok(());
+    };
+    let labels = &envelope.entry.labels;
+    if let (Some(id), Some(digest)) = (labels.get(id_key), labels.get(digest_key)) {
+        recorded.insert(id.clone(), CheckpointDigest::parse(digest.clone())?);
+    }
+    Ok(())
+}
+
+impl CheckpointChainAnchor for SignedChainAnchor {
+    fn recorded_creation_digest(&self, meta: &CheckpointMeta) -> Result<Option<CheckpointDigest>> {
+        Ok(self.recorded.get(meta.id.as_str()).cloned())
+    }
+}
+
+/// `mvmctl vm checkpoint verify <id>`: chain-anchored lineage verification.
+/// Exits nonzero on any failure so it is scriptable.
+fn verify(id: &str, json: bool) -> Result<()> {
+    let checkpoint = validated_checkpoint_id(id)?;
+    let store = CheckpointStore::open();
+    let anchor = SignedChainAnchor::load()
+        .context("loading the signed audit chain to anchor lineage verification")?;
+
+    match verify_lineage(&store, &checkpoint, &anchor) {
+        Ok(()) => {
+            if json {
+                crate::json_out::emit_json(&CheckpointVerifyJson {
+                    schema_version: 1,
+                    action: "verify",
+                    id: checkpoint.as_str(),
+                    verified: true,
+                    error: None,
+                })?;
+            } else {
+                ui::success(&format!(
+                    "checkpoint {} lineage verifies against the signed audit chain",
+                    checkpoint.as_str()
+                ));
+            }
+            Ok(())
+        }
+        Err(e) => {
+            if json {
+                crate::json_out::emit_json(&CheckpointVerifyJson {
+                    schema_version: 1,
+                    action: "verify",
+                    id: checkpoint.as_str(),
+                    verified: false,
+                    error: Some(format!("{e:#}")),
+                })?;
+            }
+            Err(e.context(format!(
+                "checkpoint {} lineage verification failed",
+                checkpoint.as_str()
+            )))
+        }
+    }
+}
+
 fn rm(id: &str, json: bool) -> Result<()> {
     let id = validated_checkpoint_id(id)?;
     CheckpointStore::open().remove(&id)?;
@@ -713,6 +887,11 @@ fn fork_fs_quick_arm(p: ForkFsQuickArmParams<'_>) -> Result<()> {
     let dest_dir = vm_state_dir(&child_vm_name);
     let child_id = CheckpointId::new(format!("fork-{child_vm_name}-{now}"));
 
+    // Verify the parent against the signed audit chain before any bytes are
+    // cloned — a fork must never build on a checkpoint edited after it was
+    // audited.
+    let anchor = SignedChainAnchor::load()
+        .context("loading the signed audit chain to verify the fork parent")?;
     let meta = fork_checkpoint(
         p.store,
         ForkParams {
@@ -724,6 +903,7 @@ fn fork_fs_quick_arm(p: ForkFsQuickArmParams<'_>) -> Result<()> {
             child_plan_json: None,
             child_tenant_id: None,
         },
+        &anchor,
     )
     .with_context(|| format!("forking checkpoint {:?}", p.checkpoint.as_str()))?;
 
@@ -974,6 +1154,9 @@ fn fork_vm_full_arm_fc(p: ForkVmFullArmFcParams<'_>) -> Result<()> {
         mvm_hostd::plan_admission::stash_plan_for_bridge(&mint_cfg)?;
     }
 
+    // Verify the parent against the signed audit chain before cloning/restoring.
+    let anchor = SignedChainAnchor::load()
+        .context("loading the signed audit chain to verify the fork parent")?;
     let restorer = mvm_runtime::firecracker::FcForkRestorer;
     let fork_result = fork_vm_full_fc(
         p.store,
@@ -987,6 +1170,7 @@ fn fork_vm_full_arm_fc(p: ForkVmFullArmFcParams<'_>) -> Result<()> {
             child_tenant_id,
         },
         &restorer,
+        &anchor,
     );
     if let Err(ref e) = fork_result {
         super::up::emit_failed_if(&admission, "fork-vm-full-fc", e);
@@ -2055,6 +2239,98 @@ mod tests {
         assert!(
             !SnapshotCapability::Unsupported.satisfies(SnapshotCapability::SaveRestore),
             "Unsupported must not satisfy SaveRestore"
+        );
+    }
+
+    // ── SignedChainAnchor: real signed-chain linkage ─────────────────────────
+
+    use mvm_core::checkpoint::{CheckpointClass, ContentBlob};
+
+    /// Capture a checkpoint record and emit its `checkpoint.created` entry into
+    /// the host-signed audit chain under the active `MVM_HOME`, exactly as the
+    /// capture path does. Returns the persisted meta.
+    fn seed_audited_checkpoint(
+        store: &CheckpointStore,
+        id: &str,
+        rootfs_sha: &str,
+    ) -> CheckpointMeta {
+        let meta = CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::FsQuick, "vm")
+            .content(vec![ContentBlob {
+                name: "rootfs.ext4".into(),
+                sha256: rootfs_sha.into(),
+            }])
+            .supervisor_config_digest("d")
+            .created_unix(1)
+            .build();
+        store.write_meta(&meta).unwrap();
+
+        let signer = super::super::host_signer::load_or_init().unwrap();
+        let emitter = super::super::audit_chain::AuditEmitter::new(signer.signing).unwrap();
+        let plan = mvm_core::plan::test_support::PlanFixture::new()
+            .tenant("local")
+            .plan_id("plan-verify")
+            .build();
+        mvm_hostd::audit::bind::bind_checkpoint_created(&emitter, &plan, &meta).unwrap();
+        meta
+    }
+
+    #[test]
+    fn signed_chain_anchor_indexes_a_real_created_entry_and_verify_passes() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        let store = CheckpointStore::open();
+        let meta = seed_audited_checkpoint(&store, "ckpt-anchor-1", "aa");
+
+        let anchor = SignedChainAnchor::load().unwrap();
+        // The anchor recovers the checkpoint's content-address from the signed
+        // chain, and the full lineage verifies against it.
+        assert_eq!(
+            anchor.recorded_creation_digest(&meta).unwrap(),
+            Some(meta.meta_digest.clone())
+        );
+        verify_lineage(&store, &meta.id, &anchor).unwrap();
+    }
+
+    /// The point of chain-anchoring: a fully self-consistent local re-forge — an
+    /// attacker rewrites the record's content AND recomputes its `meta_digest` so
+    /// the two agree on disk — passes local recompute but is caught by the signed
+    /// chain, which recorded the original content-address and cannot be re-signed.
+    #[test]
+    fn chain_anchor_catches_a_fully_consistent_local_reforge() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        let store = CheckpointStore::open();
+        // The audited original: the chain records ITS content-address.
+        seed_audited_checkpoint(&store, "ckpt-anchor-2", "aa");
+
+        // Attacker overwrites meta.json with a different-content record whose own
+        // meta_digest is recomputed to match (locally consistent).
+        let reforged = CheckpointMeta::builder(
+            CheckpointId::new("ckpt-anchor-2"),
+            CheckpointClass::FsQuick,
+            "vm",
+        )
+        .content(vec![ContentBlob {
+            name: "rootfs.ext4".into(),
+            sha256: "zz".into(),
+        }])
+        .supervisor_config_digest("d")
+        .created_unix(1)
+        .build();
+        store.write_meta(&reforged).unwrap();
+        // Local recompute alone would accept this — it is self-consistent.
+        assert_eq!(reforged.meta_digest, reforged.compute_meta_digest());
+
+        let anchor = SignedChainAnchor::load().unwrap();
+        let err = verify_lineage(&store, &reforged.id, &anchor).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not match the signed audit chain"),
+            "the signed chain must catch a consistent local re-forge, got: {err}"
         );
     }
 }

--- a/crates/mvm-cli/src/commands/vm/checkpoint/lineage.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/lineage.rs
@@ -1,0 +1,169 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use mvm_core::checkpoint::{CheckpointDigest, CheckpointMeta};
+use mvm_runtime::checkpoint::{CheckpointChainAnchor, CheckpointStore, verify_lineage};
+
+use super::validated_checkpoint_id;
+use crate::ui;
+
+#[derive(Serialize)]
+struct CheckpointVerifyJson<'a> {
+    schema_version: u8,
+    action: &'static str,
+    id: &'a str,
+    verified: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+/// A [`CheckpointChainAnchor`] backed by the host-signed audit chains on disk.
+///
+/// Verifies every host-lifecycle chain's signatures up front (skipping the
+/// per-VM workload chains, which use a different format) and indexes the
+/// content-address each checkpoint's creation entry recorded. Only entries from
+/// chains that verify clean are indexed: an entry stranded behind a tampered
+/// line is not trusted, so the checkpoint it names fails closed as un-anchored.
+pub struct SignedChainAnchor {
+    /// checkpoint id -> content-address the signed chain recorded at creation.
+    recorded: std::collections::HashMap<String, CheckpointDigest>,
+}
+
+impl SignedChainAnchor {
+    pub fn load() -> Result<Self> {
+        use mvm_hostd::audit::emitter::default_audit_dir;
+
+        let dir = default_audit_dir()?;
+        let mut recorded = std::collections::HashMap::new();
+        let read_dir = match std::fs::read_dir(&dir) {
+            Ok(rd) => rd,
+            // No audit dir yet → nothing to anchor; every lookup is None (fail closed).
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Self { recorded });
+            }
+            Err(e) => return Err(e).with_context(|| format!("reading {}", dir.display())),
+        };
+
+        // All lifecycle chains are signed under the one host key.
+        let signer = super::super::host_signer::load_or_init()
+            .context("loading host signer to anchor checkpoint lineage")?;
+
+        for entry in read_dir {
+            let path = entry?.path();
+            if !is_host_lifecycle_chain(&path) {
+                continue;
+            }
+            // A chain we cannot verify cannot anchor anything: skip it whole so a
+            // tampered line strands (rather than silently trusts) its entries.
+            if mvm_hostd::supervisor::verify_audit_chain(&path, &signer.verifying).is_err() {
+                tracing::warn!(
+                    path = %path.display(),
+                    "audit chain failed verification; its entries will not anchor any checkpoint"
+                );
+                continue;
+            }
+            let content = std::fs::read_to_string(&path)
+                .with_context(|| format!("reading {}", path.display()))?;
+            for line in content.lines() {
+                if line.is_empty() {
+                    continue;
+                }
+                let envelope: mvm_hostd::supervisor::SignedEnvelope = serde_json::from_str(line)
+                    .with_context(|| format!("parsing audit line in {}", path.display()))?;
+                index_creation_digest(&mut recorded, &envelope)?;
+            }
+        }
+        Ok(Self { recorded })
+    }
+}
+
+/// A host-lifecycle audit chain is `<tenant>.jsonl` — NOT a per-VM workload
+/// chain (`<tenant>.<vm>.workload.jsonl`), which carries a different envelope
+/// format that `verify_audit_chain` does not parse.
+fn is_host_lifecycle_chain(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    name.ends_with(".jsonl") && !name.ends_with(mvm_core::config::WORKLOAD_AUDIT_SUFFIX)
+}
+
+/// Index one signed audit entry's creation content-address, when it is a
+/// checkpoint creation event. `checkpoint.created` keys on
+/// `checkpoint_id`/`meta_digest`; `checkpoint.forked` is a child's creation, so
+/// it keys on `child_id`/`child_digest`.
+fn index_creation_digest(
+    recorded: &mut std::collections::HashMap<String, CheckpointDigest>,
+    envelope: &mvm_hostd::supervisor::SignedEnvelope,
+) -> Result<()> {
+    use mvm_hostd::audit::emitter::checkpoint_audit as k;
+    let event = envelope.entry.event.as_str();
+    // The (id, digest) label pair a creation event keys on; non-creation events
+    // carry neither.
+    let key_pair = if event == k::CREATED_EVENT {
+        Some((k::LABEL_CHECKPOINT_ID, k::LABEL_META_DIGEST))
+    } else if event == k::FORKED_EVENT {
+        Some((k::LABEL_CHILD_ID, k::LABEL_CHILD_DIGEST))
+    } else {
+        None
+    };
+    let Some((id_key, digest_key)) = key_pair else {
+        return Ok(());
+    };
+    let labels = &envelope.entry.labels;
+    if let (Some(id), Some(digest)) = (labels.get(id_key), labels.get(digest_key)) {
+        recorded.insert(id.clone(), CheckpointDigest::parse(digest.clone())?);
+    }
+    Ok(())
+}
+
+impl CheckpointChainAnchor for SignedChainAnchor {
+    fn recorded_creation_digest(&self, meta: &CheckpointMeta) -> Result<Option<CheckpointDigest>> {
+        Ok(self.recorded.get(meta.id.as_str()).cloned())
+    }
+}
+
+/// `mvmctl vm checkpoint verify <id>`: chain-anchored lineage verification.
+/// Exits nonzero on any failure so it is scriptable.
+pub(super) fn verify(id: &str, json: bool) -> Result<()> {
+    let checkpoint = validated_checkpoint_id(id)?;
+    let store = CheckpointStore::open();
+    let anchor = SignedChainAnchor::load()
+        .context("loading the signed audit chain to anchor lineage verification")?;
+
+    match verify_lineage(&store, &checkpoint, &anchor) {
+        Ok(()) => {
+            if json {
+                crate::json_out::emit_json(&CheckpointVerifyJson {
+                    schema_version: 1,
+                    action: "verify",
+                    id: checkpoint.as_str(),
+                    verified: true,
+                    error: None,
+                })?;
+            } else {
+                ui::success(&format!(
+                    "checkpoint {} lineage verifies against the signed audit chain",
+                    checkpoint.as_str()
+                ));
+            }
+            Ok(())
+        }
+        Err(e) => {
+            if json {
+                crate::json_out::emit_json(&CheckpointVerifyJson {
+                    schema_version: 1,
+                    action: "verify",
+                    id: checkpoint.as_str(),
+                    verified: false,
+                    error: Some(format!("{e:#}")),
+                })?;
+            }
+            Err(e.context(format!(
+                "checkpoint {} lineage verification failed",
+                checkpoint.as_str()
+            )))
+        }
+    }
+}

--- a/crates/mvm-core/src/checkpoint.rs
+++ b/crates/mvm-core/src/checkpoint.rs
@@ -47,23 +47,22 @@ impl CheckpointDigest {
     pub const PREFIX: &'static str = "sha256:";
 
     /// Validates and wraps a `sha256:<64 lowercase hex>` string. Rejects any
-    /// other prefix, wrong length, or non-lowercase-hex content.
+    /// other prefix, wrong length, or non-lowercase-hex content. Shares the
+    /// shape check with every other prefixed content-address newtype so none
+    /// can drift.
     pub fn parse(value: impl Into<String>) -> Result<Self, CheckpointDigestParseError> {
+        use crate::digest_shape::Sha256PrefixedShape;
         let value = value.into();
-        let hex_part = value
-            .strip_prefix(Self::PREFIX)
-            .ok_or_else(|| CheckpointDigestParseError::MissingPrefix(value.clone()))?;
-        if hex_part.len() != 64 {
-            return Err(CheckpointDigestParseError::WrongLength {
-                len: hex_part.len(),
-            });
-        }
-        for ch in hex_part.chars() {
-            if !matches!(ch, '0'..='9' | 'a'..='f') {
-                return Err(CheckpointDigestParseError::NonHex { ch });
+        match crate::digest_shape::validate_sha256_prefixed(&value) {
+            Sha256PrefixedShape::Ok => Ok(Self(value)),
+            Sha256PrefixedShape::MissingPrefix => {
+                Err(CheckpointDigestParseError::MissingPrefix(value))
             }
+            Sha256PrefixedShape::WrongLength { len } => {
+                Err(CheckpointDigestParseError::WrongLength { len })
+            }
+            Sha256PrefixedShape::NonHex { ch } => Err(CheckpointDigestParseError::NonHex { ch }),
         }
-        Ok(Self(value))
     }
 
     /// The `sha256:<64-hex>` string view.
@@ -250,6 +249,13 @@ impl CheckpointDigestInput<'_> {
 fn sorted_content(content: &[ContentBlob]) -> Vec<&ContentBlob> {
     let mut refs: Vec<&ContentBlob> = content.iter().collect();
     refs.sort_by(|a, b| a.name.cmp(&b.name));
+    // Blob names index the manifest (fork/restore/diff look up by name); a
+    // duplicate would make the content-address depend on tie-break order and
+    // ambiguate the lookup. Capture never emits one — assert it in debug.
+    debug_assert!(
+        refs.windows(2).all(|w| w[0].name != w[1].name),
+        "checkpoint content manifest has duplicate blob names"
+    );
     refs
 }
 
@@ -538,6 +544,83 @@ mod tests {
             .audit_ref(Some("local.jsonl#3".to_string()))
             .build();
         assert_eq!(without.meta_digest, with.meta_digest);
+    }
+
+    #[test]
+    fn meta_digest_covers_every_load_bearing_field() {
+        // Flip exactly one load-bearing field per case and assert the
+        // content-address moves. Guards a future field silently falling outside
+        // the digest input (the two excluded fields — meta_digest, audit_ref —
+        // are covered by their own tests above).
+        #[derive(Clone)]
+        struct Fields {
+            id: String,
+            class: CheckpointClass,
+            vm: String,
+            tag: Option<String>,
+            parent: Option<CheckpointDigest>,
+            created: u64,
+            content: Vec<ContentBlob>,
+            cfg: String,
+            policy: Option<RuntimeSourcePolicy>,
+            overlay: Option<String>,
+        }
+        let build = |f: &Fields| {
+            CheckpointMeta::builder(CheckpointId::new(f.id.clone()), f.class, f.vm.clone())
+                .tag(f.tag.clone())
+                .parent(f.parent.clone())
+                .created_unix(f.created)
+                .content(f.content.clone())
+                .supervisor_config_digest(f.cfg.clone())
+                .runtime_source_policy(f.policy)
+                .runtime_overlay_version(f.overlay.clone())
+                .build()
+                .meta_digest
+        };
+        let base = Fields {
+            id: "id0".into(),
+            class: CheckpointClass::FsQuick,
+            vm: "vm0".into(),
+            tag: Some("t0".into()),
+            parent: None,
+            created: 100,
+            content: vec![blob("rootfs.ext4", "aa")],
+            cfg: "cfg0".into(),
+            policy: Some(RuntimeSourcePolicy::PreferOverlay),
+            overlay: Some("0.1.0".into()),
+        };
+        let baseline = build(&base);
+
+        let mut f = base.clone();
+        f.id = "id1".into();
+        assert_ne!(baseline, build(&f), "id");
+        let mut f = base.clone();
+        f.class = CheckpointClass::VmFull;
+        assert_ne!(baseline, build(&f), "class");
+        let mut f = base.clone();
+        f.vm = "vm1".into();
+        assert_ne!(baseline, build(&f), "vm_name");
+        let mut f = base.clone();
+        f.tag = Some("t1".into());
+        assert_ne!(baseline, build(&f), "tag");
+        let mut f = base.clone();
+        f.created = 200;
+        assert_ne!(baseline, build(&f), "created_unix");
+        let mut f = base.clone();
+        f.content = vec![blob("rootfs.ext4", "bb")];
+        assert_ne!(baseline, build(&f), "content");
+        let mut f = base.clone();
+        f.cfg = "cfg1".into();
+        assert_ne!(baseline, build(&f), "supervisor_config_digest");
+        let mut f = base.clone();
+        f.policy = Some(RuntimeSourcePolicy::RequiredOverlay);
+        assert_ne!(baseline, build(&f), "runtime_source_policy");
+        let mut f = base.clone();
+        f.overlay = Some("0.2.0".into());
+        assert_ne!(baseline, build(&f), "runtime_overlay_version");
+        let mut f = base.clone();
+        f.parent = Some(parent_digest());
+        assert_ne!(baseline, build(&f), "parent");
     }
 
     #[test]

--- a/crates/mvm-core/src/checkpoint.rs
+++ b/crates/mvm-core/src/checkpoint.rs
@@ -2,6 +2,7 @@
 //! origin a `fork` clones a new sandbox instance from.
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::vm_backend::RuntimeSourcePolicy;
 
@@ -25,6 +26,92 @@ impl std::fmt::Display for CheckpointId {
     }
 }
 
+/// Content-address of a [`CheckpointMeta`]: `sha256(serde_json(load-bearing
+/// fields))` rendered `sha256:<64 lowercase hex>`. A child hash-links to its
+/// parent by this digest, so editing an ancestor's sealed record is detectable
+/// from any descendant — the recomputed ancestor digest no longer matches the
+/// child's link.
+///
+/// This is a content-address, not a signature and not an exact-byte blob
+/// digest. It shares the `sha256:<64-hex>` wire shape with several unrelated
+/// ids (OCI manifest/layer digests, blob shas, semantic addresses) precisely so
+/// the boundary between them is a type-system property, not a string check:
+/// there is no `From`/`Into`/`Deref` to or from any of them (nor to
+/// [`CheckpointId`]), so handing one where another is expected does not compile.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct CheckpointDigest(String);
+
+impl CheckpointDigest {
+    /// The fixed hash-axis prefix every checkpoint digest carries.
+    pub const PREFIX: &'static str = "sha256:";
+
+    /// Validates and wraps a `sha256:<64 lowercase hex>` string. Rejects any
+    /// other prefix, wrong length, or non-lowercase-hex content.
+    pub fn parse(value: impl Into<String>) -> Result<Self, CheckpointDigestParseError> {
+        let value = value.into();
+        let hex_part = value
+            .strip_prefix(Self::PREFIX)
+            .ok_or_else(|| CheckpointDigestParseError::MissingPrefix(value.clone()))?;
+        if hex_part.len() != 64 {
+            return Err(CheckpointDigestParseError::WrongLength {
+                len: hex_part.len(),
+            });
+        }
+        for ch in hex_part.chars() {
+            if !matches!(ch, '0'..='9' | 'a'..='f') {
+                return Err(CheckpointDigestParseError::NonHex { ch });
+            }
+        }
+        Ok(Self(value))
+    }
+
+    /// The `sha256:<64-hex>` string view.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for CheckpointDigest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::str::FromStr for CheckpointDigest {
+    type Err = CheckpointDigestParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl TryFrom<String> for CheckpointDigest {
+    type Error = CheckpointDigestParseError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl From<CheckpointDigest> for String {
+    fn from(digest: CheckpointDigest) -> Self {
+        digest.0
+    }
+}
+
+/// [`CheckpointDigest::parse`] / [`CheckpointDigest::from_str`] failure.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum CheckpointDigestParseError {
+    /// The value did not start with `sha256:`.
+    #[error("checkpoint digest must start with \"sha256:\", got {0:?}")]
+    MissingPrefix(String),
+    /// The hex portion (after the prefix) was not exactly 64 characters.
+    #[error("checkpoint digest hex must be exactly 64 chars, got {len}")]
+    WrongLength { len: usize },
+    /// The hex portion contained a non-lowercase-hex character.
+    #[error("checkpoint digest hex must be lowercase 0-9a-f, found {ch:?}")]
+    NonHex { ch: char },
+}
+
 /// The capture mechanism behind a checkpoint. Only `FsQuick` is currently
 /// implemented; `VmFull` is reserved so the memory-state path can slot into the
 /// same model without a new surface.
@@ -46,9 +133,16 @@ pub struct ContentBlob {
 }
 
 /// On-disk metadata for one checkpoint (`<checkpoints_dir>/<id>/meta.json`).
+///
+/// `parent` hash-links to the parent checkpoint's `meta_digest` (its
+/// content-address), not to a mutable name — so a descendant can detect any
+/// post-seal edit of an ancestor. `meta_digest` is the content-address of this
+/// record's load-bearing fields, derived in [`CheckpointMetaBuilder::build`]
+/// and never set by callers.
+///
 /// `audit_ref` is a non-load-bearing back-pointer backfilled after the
-/// chain-signed entry is emitted; integrity verification relies on
-/// `content`, not on `audit_ref`.
+/// chain-signed entry is emitted; it and `meta_digest` are excluded from the
+/// digest so the backfill does not perturb the content-address.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckpointMeta {
@@ -56,7 +150,7 @@ pub struct CheckpointMeta {
     pub class: CheckpointClass,
     pub vm_name: String,
     pub tag: Option<String>,
-    pub parent: Option<CheckpointId>,
+    pub parent: Option<CheckpointDigest>,
     pub created_unix: u64,
     pub content: Vec<ContentBlob>,
     pub supervisor_config_digest: String,
@@ -64,6 +158,11 @@ pub struct CheckpointMeta {
     pub runtime_source_policy: Option<RuntimeSourcePolicy>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_overlay_version: Option<String>,
+    /// Content-address of the load-bearing fields above. Required with no serde
+    /// default: a record that carries no content-address cannot be
+    /// lineage-verified, so a pre-lineage meta.json must fail closed rather than
+    /// load as an unverifiable record.
+    pub meta_digest: CheckpointDigest,
     pub audit_ref: Option<String>,
 }
 
@@ -87,6 +186,71 @@ impl CheckpointMeta {
             audit_ref: None,
         }
     }
+
+    /// Recompute this record's content-address from its load-bearing fields. A
+    /// stored `meta_digest` that no longer equals this value is proof the
+    /// record was edited after it was sealed — the check `verify_lineage` walks
+    /// with. Mirrors the derivation in [`CheckpointMetaBuilder::build`]; the
+    /// `capture_*` tests pin that the two agree.
+    pub fn compute_meta_digest(&self) -> CheckpointDigest {
+        CheckpointDigestInput {
+            id: &self.id,
+            class: self.class,
+            vm_name: &self.vm_name,
+            tag: &self.tag,
+            parent: &self.parent,
+            created_unix: self.created_unix,
+            content: sorted_content(&self.content),
+            supervisor_config_digest: &self.supervisor_config_digest,
+            runtime_source_policy: &self.runtime_source_policy,
+            runtime_overlay_version: &self.runtime_overlay_version,
+        }
+        .digest()
+    }
+}
+
+/// The load-bearing fields of a [`CheckpointMeta`], borrowed in fixed
+/// declaration order, that `meta_digest` content-addresses. `meta_digest`
+/// itself and `audit_ref` are excluded: the former is what we are deriving, the
+/// latter is backfilled after the audit entry is emitted and must not perturb
+/// the digest.
+#[derive(Serialize)]
+struct CheckpointDigestInput<'a> {
+    id: &'a CheckpointId,
+    class: CheckpointClass,
+    vm_name: &'a str,
+    tag: &'a Option<String>,
+    parent: &'a Option<CheckpointDigest>,
+    created_unix: u64,
+    /// Sorted by `name` (capture builds it in insertion order) so the digest is
+    /// invariant to blob ordering.
+    content: Vec<&'a ContentBlob>,
+    supervisor_config_digest: &'a str,
+    runtime_source_policy: &'a Option<RuntimeSourcePolicy>,
+    runtime_overlay_version: &'a Option<String>,
+}
+
+impl CheckpointDigestInput<'_> {
+    fn digest(&self) -> CheckpointDigest {
+        // Plain serde_json (not JCS): this is host-only, single-implementation,
+        // with no cross-language conformance need — the same posture the audit
+        // envelope and the app-dep volume-hash derivation take.
+        let bytes =
+            serde_json::to_vec(self).expect("checkpoint digest input is always JSON-serializable");
+        CheckpointDigest(format!(
+            "{}{}",
+            CheckpointDigest::PREFIX,
+            hex::encode(Sha256::digest(&bytes))
+        ))
+    }
+}
+
+/// Content blobs borrowed and sorted by `name`, so a checkpoint's digest does
+/// not depend on the order capture happened to append them.
+fn sorted_content(content: &[ContentBlob]) -> Vec<&ContentBlob> {
+    let mut refs: Vec<&ContentBlob> = content.iter().collect();
+    refs.sort_by(|a, b| a.name.cmp(&b.name));
+    refs
 }
 
 /// Fluent builder for [`CheckpointMeta`]; obtain via [`CheckpointMeta::builder`].
@@ -97,7 +261,7 @@ pub struct CheckpointMetaBuilder {
     class: CheckpointClass,
     vm_name: String,
     tag: Option<String>,
-    parent: Option<CheckpointId>,
+    parent: Option<CheckpointDigest>,
     created_unix: u64,
     content: Vec<ContentBlob>,
     supervisor_config_digest: String,
@@ -111,7 +275,9 @@ impl CheckpointMetaBuilder {
         self.tag = tag;
         self
     }
-    pub fn parent(mut self, parent: Option<CheckpointId>) -> Self {
+    /// Hash-link this checkpoint to its parent's content-address
+    /// ([`CheckpointMeta::meta_digest`]).
+    pub fn parent(mut self, parent: Option<CheckpointDigest>) -> Self {
         self.parent = parent;
         self
     }
@@ -140,6 +306,23 @@ impl CheckpointMetaBuilder {
         self
     }
     pub fn build(self) -> CheckpointMeta {
+        // Derive the content-address before moving the fields out. Mirrors
+        // `CheckpointMeta::compute_meta_digest` — two borrows of the same field
+        // set with different owners (builder here, meta there); the
+        // `capture_*_recomputes_equal` tests pin that they agree.
+        let meta_digest = CheckpointDigestInput {
+            id: &self.id,
+            class: self.class,
+            vm_name: &self.vm_name,
+            tag: &self.tag,
+            parent: &self.parent,
+            created_unix: self.created_unix,
+            content: sorted_content(&self.content),
+            supervisor_config_digest: &self.supervisor_config_digest,
+            runtime_source_policy: &self.runtime_source_policy,
+            runtime_overlay_version: &self.runtime_overlay_version,
+        }
+        .digest();
         CheckpointMeta {
             id: self.id,
             class: self.class,
@@ -151,6 +334,7 @@ impl CheckpointMetaBuilder {
             supervisor_config_digest: self.supervisor_config_digest,
             runtime_source_policy: self.runtime_source_policy,
             runtime_overlay_version: self.runtime_overlay_version,
+            meta_digest,
             audit_ref: self.audit_ref,
         }
     }
@@ -159,6 +343,10 @@ impl CheckpointMetaBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn parent_digest() -> CheckpointDigest {
+        CheckpointDigest::parse(format!("sha256:{}", "a".repeat(64))).unwrap()
+    }
 
     #[test]
     fn meta_roundtrips_through_json() {
@@ -173,7 +361,7 @@ mod tests {
         }])
         .supervisor_config_digest("cfg99")
         .tag(Some("golden".to_string()))
-        .parent(Some(CheckpointId::new("ckpt-parent")))
+        .parent(Some(parent_digest()))
         .created_unix(1_700_000_000)
         .runtime_source_policy(Some(RuntimeSourcePolicy::RequiredOverlay))
         .runtime_overlay_version(Some("0.17.0".to_string()))
@@ -183,8 +371,9 @@ mod tests {
         let back: CheckpointMeta = serde_json::from_str(&json).unwrap();
         assert_eq!(meta, back);
         assert_eq!(back.class, CheckpointClass::FsQuick);
-        assert_eq!(back.parent.unwrap().as_str(), "ckpt-parent");
+        assert_eq!(back.parent.unwrap(), parent_digest());
         assert_eq!(back.content[0].sha256, "deadbeef");
+        assert_eq!(back.meta_digest, meta.meta_digest);
         assert_eq!(
             back.runtime_source_policy,
             Some(RuntimeSourcePolicy::RequiredOverlay)
@@ -260,12 +449,160 @@ mod tests {
     }
 
     #[test]
-    fn older_meta_without_runtime_overlay_fields_still_parses() {
+    fn old_shape_meta_without_meta_digest_fails_to_parse() {
+        // The pre-lineage meta.json carried a name-based `parent` and no
+        // `meta_digest`. That shape is intentionally unreadable now: a record
+        // with no content-address cannot be lineage-verified, so it fails
+        // closed (both the name-shaped parent and the missing digest are
+        // rejected) rather than loading as an unverifiable record.
         let json = r#"{"id":"x","class":"fs_quick","vm_name":"v","tag":null,
-            "parent":null,"created_unix":1,"content":[],
+            "parent":"ckpt-parent","created_unix":1,"content":[],
             "supervisor_config_digest":"d","audit_ref":null}"#;
-        let meta: CheckpointMeta = serde_json::from_str(json).unwrap();
-        assert!(meta.runtime_source_policy.is_none());
-        assert!(meta.runtime_overlay_version.is_none());
+        assert!(serde_json::from_str::<CheckpointMeta>(json).is_err());
+    }
+
+    fn digest_fixture_meta(content: Vec<ContentBlob>) -> CheckpointMeta {
+        CheckpointMeta::builder(CheckpointId::new("c1"), CheckpointClass::FsQuick, "vm")
+            .content(content)
+            .supervisor_config_digest("cfg")
+            .created_unix(7)
+            .build()
+    }
+
+    fn blob(name: &str, sha: &str) -> ContentBlob {
+        ContentBlob {
+            name: name.into(),
+            sha256: sha.into(),
+        }
+    }
+
+    #[test]
+    fn meta_digest_wire_shape_is_sha256_prefixed_hex() {
+        let m = digest_fixture_meta(vec![blob("rootfs.ext4", "aa")]);
+        let s = m.meta_digest.as_str();
+        assert!(s.starts_with("sha256:"));
+        assert_eq!(s.len(), "sha256:".len() + 64);
+    }
+
+    #[test]
+    fn meta_digest_is_deterministic_across_builds() {
+        let a = digest_fixture_meta(vec![blob("rootfs.ext4", "aa")]);
+        let b = digest_fixture_meta(vec![blob("rootfs.ext4", "aa")]);
+        assert_eq!(a.meta_digest, b.meta_digest);
+    }
+
+    #[test]
+    fn meta_digest_recomputes_equal_to_stored() {
+        let m = digest_fixture_meta(vec![blob("rootfs.ext4", "aa"), blob("memory.bin", "bb")]);
+        assert_eq!(m.meta_digest, m.compute_meta_digest());
+    }
+
+    #[test]
+    fn meta_digest_invariant_under_content_insertion_order() {
+        // The blob manifest is content-addressed by name, not by the order
+        // capture appended it — permuting the vec must not move the digest.
+        let ordered = digest_fixture_meta(vec![blob("a", "1"), blob("b", "2"), blob("c", "3")]);
+        let permuted = digest_fixture_meta(vec![blob("c", "3"), blob("a", "1"), blob("b", "2")]);
+        assert_eq!(ordered.meta_digest, permuted.meta_digest);
+    }
+
+    #[test]
+    fn meta_digest_changes_when_a_content_sha_changes() {
+        let base = digest_fixture_meta(vec![blob("rootfs.ext4", "aa")]);
+        let edited = digest_fixture_meta(vec![blob("rootfs.ext4", "zz")]);
+        assert_ne!(base.meta_digest, edited.meta_digest);
+    }
+
+    #[test]
+    fn meta_digest_changes_when_parent_link_changes() {
+        let genesis = digest_fixture_meta(vec![blob("rootfs.ext4", "aa")]);
+        let child =
+            CheckpointMeta::builder(CheckpointId::new("c1"), CheckpointClass::FsQuick, "vm")
+                .content(vec![blob("rootfs.ext4", "aa")])
+                .supervisor_config_digest("cfg")
+                .created_unix(7)
+                .parent(Some(parent_digest()))
+                .build();
+        assert_ne!(genesis.meta_digest, child.meta_digest);
+    }
+
+    #[test]
+    fn meta_digest_excludes_audit_ref() {
+        // audit_ref is backfilled after the chain entry is emitted; it must not
+        // move the content-address, or the backfill would invalidate it.
+        let without = digest_fixture_meta(vec![blob("rootfs.ext4", "aa")]);
+        let with = CheckpointMeta::builder(CheckpointId::new("c1"), CheckpointClass::FsQuick, "vm")
+            .content(vec![blob("rootfs.ext4", "aa")])
+            .supervisor_config_digest("cfg")
+            .created_unix(7)
+            .audit_ref(Some("local.jsonl#3".to_string()))
+            .build();
+        assert_eq!(without.meta_digest, with.meta_digest);
+    }
+
+    #[test]
+    fn checkpoint_digest_parse_accepts_and_round_trips_serde() {
+        let s = format!("sha256:{}", "b".repeat(64));
+        let d = CheckpointDigest::parse(s.clone()).unwrap();
+        assert_eq!(d.as_str(), s);
+        assert_eq!(d.to_string(), s);
+        let via_from_str: CheckpointDigest = s.parse().unwrap();
+        assert_eq!(via_from_str, d);
+        let json = serde_json::to_string(&d).unwrap();
+        assert_eq!(json, format!("{:?}", s));
+        let back: CheckpointDigest = serde_json::from_str(&json).unwrap();
+        assert_eq!(d, back);
+    }
+
+    #[test]
+    fn checkpoint_digest_parse_rejects_malformed() {
+        let wrong_prefix = format!("md5:{}", "a".repeat(64));
+        assert_eq!(
+            CheckpointDigest::parse(wrong_prefix.clone()).unwrap_err(),
+            CheckpointDigestParseError::MissingPrefix(wrong_prefix)
+        );
+        assert_eq!(
+            CheckpointDigest::parse(format!("sha256:{}", "a".repeat(63))).unwrap_err(),
+            CheckpointDigestParseError::WrongLength { len: 63 }
+        );
+        assert_eq!(
+            CheckpointDigest::parse(format!("sha256:{}", "A".repeat(64))).unwrap_err(),
+            CheckpointDigestParseError::NonHex { ch: 'A' }
+        );
+        assert_eq!(
+            CheckpointDigest::parse(format!("sha256:{}", "g".repeat(64))).unwrap_err(),
+            CheckpointDigestParseError::NonHex { ch: 'g' }
+        );
+        let bad = "\"not-a-checkpoint-digest\"";
+        assert!(serde_json::from_str::<CheckpointDigest>(bad).is_err());
+    }
+
+    /// `CheckpointDigest` shares the `sha256:<64-hex>` shape with [`OciDigest`]
+    /// and [`SemanticAddress`], which is exactly why the boundary is a
+    /// type-system property rather than a string check. A `sha256:...` string
+    /// re-validates as each type independently, but there is no
+    /// `From`/`TryFrom`/`Deref` from `CheckpointDigest` to any of them (or to
+    /// `Sha256Hex`, whose wire shape omits the prefix), so a value of one type
+    /// cannot be handed to code expecting another without an explicit,
+    /// separate re-parse that names both types at the call site.
+    ///
+    /// [`OciDigest`]: crate::packs::OciDigest
+    /// [`SemanticAddress`]: crate::semantic_address::SemanticAddress
+    #[test]
+    fn checkpoint_digest_shape_overlaps_oci_digest_but_types_never_convert() {
+        let m = digest_fixture_meta(vec![blob("rootfs.ext4", "aa")]);
+        let digest = m.meta_digest;
+
+        // Same shape, independently re-validated — not a type conversion.
+        assert!(crate::packs::OciDigest::new(digest.as_str().to_string()).is_ok());
+        assert!(
+            crate::semantic_address::SemanticAddress::parse(digest.as_str()).is_ok(),
+            "the semantic-address shape overlaps too"
+        );
+
+        // `Sha256Hex` carries no `sha256:` prefix, so the same string is
+        // rejected there — a second, independent illustration of unrelated
+        // types with coincidentally similar cousins.
+        assert!(crate::packs::Sha256Hex::new(digest.as_str().to_string()).is_err());
     }
 }

--- a/crates/mvm-core/src/digest_shape.rs
+++ b/crates/mvm-core/src/digest_shape.rs
@@ -1,0 +1,67 @@
+//! The one `sha256:<64 lowercase hex>` shape check shared by every
+//! prefixed content-address newtype in this crate (checkpoint digests,
+//! semantic addresses, OCI digests). The wrapper types stay distinct and
+//! non-convertible — only this validation routine is shared, so a bug fixed
+//! here is fixed for all three and none can silently drift.
+
+/// The fixed prefix every `sha256:`-tagged content-address carries.
+pub(crate) const SHA256_PREFIX: &str = "sha256:";
+
+/// Outcome of validating a `sha256:<64 lowercase hex>` string. Neutral so each
+/// newtype maps it onto its own distinct error type.
+pub(crate) enum Sha256PrefixedShape {
+    Ok,
+    MissingPrefix,
+    WrongLength { len: usize },
+    NonHex { ch: char },
+}
+
+/// Validate `value` as `sha256:` followed by exactly 64 lowercase hex digits.
+pub(crate) fn validate_sha256_prefixed(value: &str) -> Sha256PrefixedShape {
+    let Some(hex) = value.strip_prefix(SHA256_PREFIX) else {
+        return Sha256PrefixedShape::MissingPrefix;
+    };
+    if hex.len() != 64 {
+        return Sha256PrefixedShape::WrongLength { len: hex.len() };
+    }
+    for ch in hex.chars() {
+        if !matches!(ch, '0'..='9' | 'a'..='f') {
+            return Sha256PrefixedShape::NonHex { ch };
+        }
+    }
+    Sha256PrefixedShape::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_ok(value: &str) -> bool {
+        matches!(validate_sha256_prefixed(value), Sha256PrefixedShape::Ok)
+    }
+
+    #[test]
+    fn accepts_well_formed() {
+        assert!(is_ok(&format!("sha256:{}", "a".repeat(64))));
+    }
+
+    #[test]
+    fn rejects_missing_prefix_wrong_length_and_non_hex() {
+        assert!(matches!(
+            validate_sha256_prefixed(&format!("md5:{}", "a".repeat(64))),
+            Sha256PrefixedShape::MissingPrefix
+        ));
+        assert!(matches!(
+            validate_sha256_prefixed(&format!("sha256:{}", "a".repeat(63))),
+            Sha256PrefixedShape::WrongLength { len: 63 }
+        ));
+        assert!(matches!(
+            validate_sha256_prefixed(&format!("sha256:{}", "A".repeat(64))),
+            Sha256PrefixedShape::NonHex { ch: 'A' }
+        ));
+        assert!(matches!(
+            validate_sha256_prefixed(&format!("sha256:{}", "g".repeat(64))),
+            Sha256PrefixedShape::NonHex { ch: 'g' }
+        ));
+    }
+}

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -13,6 +13,9 @@ pub mod checkpoint;
 pub mod client;
 pub mod config;
 pub mod dev_network;
+/// The single `sha256:<64 lowercase hex>` shape check every prefixed
+/// content-address newtype in this crate shares (crate-private).
+pub(crate) mod digest_shape;
 /// Host egress-broker decision logic (closed-by-default allow/deny per request).
 pub mod egress_broker;
 /// Egress-broker handler: compose decision + trace into an audit record.

--- a/crates/mvm-core/src/packs.rs
+++ b/crates/mvm-core/src/packs.rs
@@ -103,13 +103,17 @@ pub struct OciDigest(String);
 
 impl OciDigest {
     pub fn new(value: impl Into<String>) -> Result<Self, PackManifestError> {
+        use crate::digest_shape::Sha256PrefixedShape;
         let value = value.into();
-        if let Some(hex) = value.strip_prefix("sha256:")
-            && is_sha256_hex(hex)
-        {
-            return Ok(Self(value));
+        // Shares the `sha256:<64 lowercase hex>` shape check with the other
+        // prefixed content-address newtypes; this type keeps its single flat
+        // error, so every non-Ok shape maps to `InvalidOciDigest`.
+        match crate::digest_shape::validate_sha256_prefixed(&value) {
+            Sha256PrefixedShape::Ok => Ok(Self(value)),
+            Sha256PrefixedShape::MissingPrefix
+            | Sha256PrefixedShape::WrongLength { .. }
+            | Sha256PrefixedShape::NonHex { .. } => Err(PackManifestError::InvalidOciDigest(value)),
         }
-        Err(PackManifestError::InvalidOciDigest(value))
     }
 
     pub fn as_str(&self) -> &str {

--- a/crates/mvm-core/src/semantic_address.rs
+++ b/crates/mvm-core/src/semantic_address.rs
@@ -60,23 +60,22 @@ impl SemanticAddress {
     pub const PREFIX: &'static str = "sha256:";
 
     /// Validates and wraps a `sha256:<64 lowercase hex>` string. Rejects any
-    /// other prefix, wrong length, or non-lowercase-hex content.
+    /// other prefix, wrong length, or non-lowercase-hex content. Shares the
+    /// shape check with every other prefixed content-address newtype so none
+    /// can drift.
     pub fn parse(value: impl Into<String>) -> Result<Self, SemanticAddressParseError> {
+        use crate::digest_shape::Sha256PrefixedShape;
         let value = value.into();
-        let hex_part = value
-            .strip_prefix(Self::PREFIX)
-            .ok_or_else(|| SemanticAddressParseError::MissingPrefix(value.clone()))?;
-        if hex_part.len() != 64 {
-            return Err(SemanticAddressParseError::WrongLength {
-                len: hex_part.len(),
-            });
-        }
-        for ch in hex_part.chars() {
-            if !matches!(ch, '0'..='9' | 'a'..='f') {
-                return Err(SemanticAddressParseError::NonHex { ch });
+        match crate::digest_shape::validate_sha256_prefixed(&value) {
+            Sha256PrefixedShape::Ok => Ok(Self(value)),
+            Sha256PrefixedShape::MissingPrefix => {
+                Err(SemanticAddressParseError::MissingPrefix(value))
             }
+            Sha256PrefixedShape::WrongLength { len } => {
+                Err(SemanticAddressParseError::WrongLength { len })
+            }
+            Sha256PrefixedShape::NonHex { ch } => Err(SemanticAddressParseError::NonHex { ch }),
         }
-        Ok(Self(value))
     }
 
     /// The `sha256:<64-hex>` string view.

--- a/crates/mvm-hostd/src/audit/bind.rs
+++ b/crates/mvm-hostd/src/audit/bind.rs
@@ -57,13 +57,19 @@ pub fn bind_checkpoint_forked(
     child: &CheckpointMeta,
     child_vm_name: &str,
 ) -> Result<()> {
-    let parent_digest = child.parent.as_ref().map(|d| d.as_str()).unwrap_or("");
+    // A forked child is built by the fork path, which always hash-links it to
+    // its parent's content-address. A genesis-shaped child (no parent) must not
+    // silently chain-sign an empty parent_digest — fail loud instead.
+    let parent_digest = child
+        .parent
+        .as_ref()
+        .expect("a forked child always carries a parent hash-link");
     emitter.emit_checkpoint_forked(
         plan,
         parent.as_str(),
         child.id.as_str(),
         child_vm_name,
-        parent_digest,
+        parent_digest.as_str(),
         child.meta_digest.as_str(),
     )
 }
@@ -121,5 +127,54 @@ mod tests {
     fn class_str_maps_both_variants() {
         assert_eq!(class_str(CheckpointClass::FsQuick), "fs_quick");
         assert_eq!(class_str(CheckpointClass::VmFull), "vm_full");
+    }
+
+    #[test]
+    fn bind_forked_emits_parent_and_child_content_addresses() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-F");
+
+        // A real parent + a child hash-linked to the parent's content-address.
+        let parent = CheckpointMeta::builder(
+            CheckpointId::new("ckpt-parent"),
+            CheckpointClass::FsQuick,
+            "parentvm",
+        )
+        .content(vec![ContentBlob {
+            name: "rootfs.ext4".into(),
+            sha256: "aa".into(),
+        }])
+        .supervisor_config_digest("d")
+        .created_unix(1)
+        .build();
+        let child = CheckpointMeta::builder(
+            CheckpointId::new("ckpt-child"),
+            CheckpointClass::FsQuick,
+            "childvm",
+        )
+        .parent(Some(parent.meta_digest.clone()))
+        .content(parent.content.clone())
+        .supervisor_config_digest("d")
+        .created_unix(2)
+        .build();
+
+        bind_checkpoint_forked(&emitter, &plan, &parent.id, &child, &child.vm_name).unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        // The emitted parent_digest is the child's own hash-link; child_digest
+        // is the child's content-address.
+        assert!(content.contains("parent_digest"));
+        assert!(content.contains("child_digest"));
+        assert!(content.contains(parent.meta_digest.as_str()));
+        assert!(content.contains(child.meta_digest.as_str()));
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
     }
 }

--- a/crates/mvm-hostd/src/audit/bind.rs
+++ b/crates/mvm-hostd/src/audit/bind.rs
@@ -16,22 +16,19 @@ pub fn class_str(class: CheckpointClass) -> &'static str {
     }
 }
 
-/// Emit `checkpoint.created` for a freshly captured checkpoint.
+/// Emit `checkpoint.created` for a freshly captured checkpoint. The bound
+/// content-address is the record's `meta_digest` — it covers the whole manifest
+/// and the parent hash-link, not just the first blob's sha.
 pub fn bind_checkpoint_created(
     emitter: &AuditEmitter,
     plan: &ExecutionPlan,
     meta: &CheckpointMeta,
 ) -> Result<()> {
-    let content_sha = meta
-        .content
-        .first()
-        .map(|b| b.sha256.as_str())
-        .unwrap_or("");
     emitter.emit_checkpoint_created(
         plan,
         meta.id.as_str(),
         class_str(meta.class),
-        content_sha,
+        meta.meta_digest.as_str(),
         &meta.vm_name,
     )
 }
@@ -42,10 +39,17 @@ pub fn bind_checkpoint_restored(
     plan: &ExecutionPlan,
     meta: &CheckpointMeta,
 ) -> Result<()> {
-    emitter.emit_checkpoint_restored(plan, meta.id.as_str(), &meta.vm_name)
+    emitter.emit_checkpoint_restored(
+        plan,
+        meta.id.as_str(),
+        meta.meta_digest.as_str(),
+        &meta.vm_name,
+    )
 }
 
-/// Emit `checkpoint.forked` recording the parent→child lineage.
+/// Emit `checkpoint.forked` recording the parent→child lineage. The bound
+/// `parent_digest` is the child's own hash-link (`child.parent`), so the
+/// audited lineage is the content-address chain the fork actually recorded.
 pub fn bind_checkpoint_forked(
     emitter: &AuditEmitter,
     plan: &ExecutionPlan,
@@ -53,7 +57,15 @@ pub fn bind_checkpoint_forked(
     child: &CheckpointMeta,
     child_vm_name: &str,
 ) -> Result<()> {
-    emitter.emit_checkpoint_forked(plan, parent.as_str(), child.id.as_str(), child_vm_name)
+    let parent_digest = child.parent.as_ref().map(|d| d.as_str()).unwrap_or("");
+    emitter.emit_checkpoint_forked(
+        plan,
+        parent.as_str(),
+        child.id.as_str(),
+        child_vm_name,
+        parent_digest,
+        child.meta_digest.as_str(),
+    )
 }
 
 #[cfg(test)]
@@ -99,7 +111,9 @@ mod tests {
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("checkpoint.created"));
         assert!(content.contains("vm_full")); // class derived from meta
-        assert!(content.contains("abcd")); // content hash from meta.content.first()
+        assert!(content.contains("meta_digest"));
+        // The record's content-address, sourced from meta.meta_digest.
+        assert!(content.contains(meta.meta_digest.as_str()));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
     }
 

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -251,7 +251,7 @@ impl AuditEmitter {
         plan: &ExecutionPlan,
         checkpoint_id: &str,
         class: &str,
-        content_sha256: &str,
+        meta_digest: &str,
         vm_name: &str,
     ) -> Result<()> {
         self.emit(
@@ -260,18 +260,22 @@ impl AuditEmitter {
             [
                 ("checkpoint_id".to_string(), checkpoint_id.to_string()),
                 ("class".to_string(), class.to_string()),
-                ("content_sha256".to_string(), content_sha256.to_string()),
+                // The record's content-address, not a single-blob sha: it covers
+                // the whole manifest plus the parent hash-link.
+                ("meta_digest".to_string(), meta_digest.to_string()),
                 ("vm_name".to_string(), vm_name.to_string()),
             ],
         )
     }
 
     /// Record that a VM was restored to the state captured in a vm_full
-    /// checkpoint. The label set carries the checkpoint id and the VM name.
+    /// checkpoint. The label set carries the checkpoint id, its content-address,
+    /// and the VM name.
     pub fn emit_checkpoint_restored(
         &self,
         plan: &ExecutionPlan,
         checkpoint_id: &str,
+        meta_digest: &str,
         vm_name: &str,
     ) -> Result<()> {
         self.emit(
@@ -279,20 +283,24 @@ impl AuditEmitter {
             "checkpoint.restored",
             [
                 ("checkpoint_id".to_string(), checkpoint_id.to_string()),
+                ("meta_digest".to_string(), meta_digest.to_string()),
                 ("vm_name".to_string(), vm_name.to_string()),
             ],
         )
     }
 
     /// Record that a new sandbox was branched from a checkpoint via
-    /// copy-on-write. The label set carries the parent and child
-    /// checkpoint ids and the child VM name.
+    /// copy-on-write. The label set carries the parent and child checkpoint ids
+    /// and VM name, plus the parent and child content-addresses — so the
+    /// audited lineage is the hash chain, not just the mutable names.
     pub fn emit_checkpoint_forked(
         &self,
         plan: &ExecutionPlan,
         parent_id: &str,
         child_id: &str,
         child_vm_name: &str,
+        parent_digest: &str,
+        child_digest: &str,
     ) -> Result<()> {
         self.emit(
             plan,
@@ -301,6 +309,8 @@ impl AuditEmitter {
                 ("parent_id".to_string(), parent_id.to_string()),
                 ("child_id".to_string(), child_id.to_string()),
                 ("child_vm_name".to_string(), child_vm_name.to_string()),
+                ("parent_digest".to_string(), parent_digest.to_string()),
+                ("child_digest".to_string(), child_digest.to_string()),
             ],
         )
     }
@@ -803,7 +813,7 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_created_records_id_and_hash() {
+    fn checkpoint_created_records_id_and_digest() {
         let dir = tempfile::tempdir().unwrap();
         let key = {
             let mut __ed_seed = [0u8; 32];
@@ -813,19 +823,22 @@ mod tests {
         let vk = key.verifying_key();
         let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
         let plan = fixture_plan("local", "plan-C");
+        let meta_digest = format!("sha256:{}", "a".repeat(64));
         emitter
-            .emit_checkpoint_created(&plan, "ckpt-abc", "fs_quick", "deadbeef", "myvm")
+            .emit_checkpoint_created(&plan, "ckpt-abc", "fs_quick", &meta_digest, "myvm")
             .unwrap();
         let path = dir.path().join("local.jsonl");
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("checkpoint.created"));
         assert!(content.contains("ckpt-abc"));
-        assert!(content.contains("deadbeef"));
+        // The content-address rides opaquely as a label; the chain still verifies.
+        assert!(content.contains("meta_digest"));
+        assert!(content.contains(&meta_digest));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
     }
 
     #[test]
-    fn checkpoint_forked_records_lineage() {
+    fn checkpoint_forked_records_lineage_digests() {
         let dir = tempfile::tempdir().unwrap();
         let key = {
             let mut __ed_seed = [0u8; 32];
@@ -835,19 +848,33 @@ mod tests {
         let vk = key.verifying_key();
         let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
         let plan = fixture_plan("local", "plan-F");
+        let parent_digest = format!("sha256:{}", "b".repeat(64));
+        let child_digest = format!("sha256:{}", "c".repeat(64));
         emitter
-            .emit_checkpoint_forked(&plan, "ckpt-parent", "ckpt-child", "childvm")
+            .emit_checkpoint_forked(
+                &plan,
+                "ckpt-parent",
+                "ckpt-child",
+                "childvm",
+                &parent_digest,
+                &child_digest,
+            )
             .unwrap();
         let path = dir.path().join("local.jsonl");
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("checkpoint.forked"));
         assert!(content.contains("ckpt-parent"));
         assert!(content.contains("ckpt-child"));
+        // The hash-linked lineage is bound, not just the mutable names.
+        assert!(content.contains("parent_digest"));
+        assert!(content.contains("child_digest"));
+        assert!(content.contains(&parent_digest));
+        assert!(content.contains(&child_digest));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
     }
 
     #[test]
-    fn checkpoint_restored_records_id_and_vm() {
+    fn checkpoint_restored_records_id_digest_and_vm() {
         let dir = tempfile::tempdir().unwrap();
         let key = {
             let mut __ed_seed = [0u8; 32];
@@ -857,14 +884,16 @@ mod tests {
         let vk = key.verifying_key();
         let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
         let plan = fixture_plan("local", "plan-R");
+        let meta_digest = format!("sha256:{}", "d".repeat(64));
         emitter
-            .emit_checkpoint_restored(&plan, "ckpt-abc", "myvm")
+            .emit_checkpoint_restored(&plan, "ckpt-abc", &meta_digest, "myvm")
             .unwrap();
         let path = dir.path().join("local.jsonl");
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("checkpoint.restored"));
         assert!(content.contains("ckpt-abc"));
         assert!(content.contains("myvm"));
+        assert!(content.contains(&meta_digest));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
     }
 }

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -43,6 +43,38 @@ use anyhow::{Context, Result};
 use ed25519_dalek::SigningKey;
 use mvm_core::plan::ExecutionPlan;
 
+/// Wire-stable event names and label keys for the checkpoint audit entries.
+/// Shared so the emitter (writer) and the lineage chain-anchor (reader) can't
+/// drift on a string — a drift there would silently defeat chain-anchored
+/// lineage verification.
+pub mod checkpoint_audit {
+    /// Emitted when a VM's state is frozen into a checkpoint.
+    pub const CREATED_EVENT: &str = "checkpoint.created";
+    /// Emitted when a VM is resumed from a vm_full checkpoint (same identity).
+    pub const RESTORED_EVENT: &str = "checkpoint.restored";
+    /// Emitted when a new sandbox is branched from a checkpoint.
+    pub const FORKED_EVENT: &str = "checkpoint.forked";
+
+    /// Label: the checkpoint's own id (created/restored).
+    pub const LABEL_CHECKPOINT_ID: &str = "checkpoint_id";
+    /// Label: the checkpoint's content-address (created/restored).
+    pub const LABEL_META_DIGEST: &str = "meta_digest";
+    /// Label: the checkpoint class (created).
+    pub const LABEL_CLASS: &str = "class";
+    /// Label: the owning VM name (created/restored).
+    pub const LABEL_VM_NAME: &str = "vm_name";
+    /// Label: the parent checkpoint id (forked).
+    pub const LABEL_PARENT_ID: &str = "parent_id";
+    /// Label: the child (new) checkpoint id (forked).
+    pub const LABEL_CHILD_ID: &str = "child_id";
+    /// Label: the child VM name (forked).
+    pub const LABEL_CHILD_VM_NAME: &str = "child_vm_name";
+    /// Label: the parent's content-address, i.e. the child's hash-link (forked).
+    pub const LABEL_PARENT_DIGEST: &str = "parent_digest";
+    /// Label: the child's content-address (forked).
+    pub const LABEL_CHILD_DIGEST: &str = "child_digest";
+}
+
 /// Resolve the default audit-chain directory: `~/.mvm/audit/`.
 pub fn default_audit_dir() -> Result<PathBuf> {
     Ok(mvm_core::config::mvm_home_strict()?.join("audit"))
@@ -254,16 +286,20 @@ impl AuditEmitter {
         meta_digest: &str,
         vm_name: &str,
     ) -> Result<()> {
+        use checkpoint_audit as k;
         self.emit(
             plan,
-            "checkpoint.created",
+            k::CREATED_EVENT,
             [
-                ("checkpoint_id".to_string(), checkpoint_id.to_string()),
-                ("class".to_string(), class.to_string()),
+                (
+                    k::LABEL_CHECKPOINT_ID.to_string(),
+                    checkpoint_id.to_string(),
+                ),
+                (k::LABEL_CLASS.to_string(), class.to_string()),
                 // The record's content-address, not a single-blob sha: it covers
                 // the whole manifest plus the parent hash-link.
-                ("meta_digest".to_string(), meta_digest.to_string()),
-                ("vm_name".to_string(), vm_name.to_string()),
+                (k::LABEL_META_DIGEST.to_string(), meta_digest.to_string()),
+                (k::LABEL_VM_NAME.to_string(), vm_name.to_string()),
             ],
         )
     }
@@ -278,13 +314,17 @@ impl AuditEmitter {
         meta_digest: &str,
         vm_name: &str,
     ) -> Result<()> {
+        use checkpoint_audit as k;
         self.emit(
             plan,
-            "checkpoint.restored",
+            k::RESTORED_EVENT,
             [
-                ("checkpoint_id".to_string(), checkpoint_id.to_string()),
-                ("meta_digest".to_string(), meta_digest.to_string()),
-                ("vm_name".to_string(), vm_name.to_string()),
+                (
+                    k::LABEL_CHECKPOINT_ID.to_string(),
+                    checkpoint_id.to_string(),
+                ),
+                (k::LABEL_META_DIGEST.to_string(), meta_digest.to_string()),
+                (k::LABEL_VM_NAME.to_string(), vm_name.to_string()),
             ],
         )
     }
@@ -302,15 +342,22 @@ impl AuditEmitter {
         parent_digest: &str,
         child_digest: &str,
     ) -> Result<()> {
+        use checkpoint_audit as k;
         self.emit(
             plan,
-            "checkpoint.forked",
+            k::FORKED_EVENT,
             [
-                ("parent_id".to_string(), parent_id.to_string()),
-                ("child_id".to_string(), child_id.to_string()),
-                ("child_vm_name".to_string(), child_vm_name.to_string()),
-                ("parent_digest".to_string(), parent_digest.to_string()),
-                ("child_digest".to_string(), child_digest.to_string()),
+                (k::LABEL_PARENT_ID.to_string(), parent_id.to_string()),
+                (k::LABEL_CHILD_ID.to_string(), child_id.to_string()),
+                (
+                    k::LABEL_CHILD_VM_NAME.to_string(),
+                    child_vm_name.to_string(),
+                ),
+                (
+                    k::LABEL_PARENT_DIGEST.to_string(),
+                    parent_digest.to_string(),
+                ),
+                (k::LABEL_CHILD_DIGEST.to_string(), child_digest.to_string()),
             ],
         )
     }

--- a/crates/mvm-hostd/src/supervisor/audit_file.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_file.rs
@@ -378,6 +378,19 @@ mod tests {
             .labels
             .insert("workflow".to_string(), "wf-1".to_string());
         signer.sign_and_emit(&entry).await.unwrap();
+        // A checkpoint.forked entry carrying content-address labels. These ride
+        // opaquely inside the signed bytes as ordinary BTreeMap labels, so the
+        // wasm mirror must accept them with no change to its MirrorEntry shape.
+        let mut forked = make_entry("tenant-a", "checkpoint.forked");
+        forked.labels.insert(
+            "parent_digest".to_string(),
+            format!("sha256:{}", "b".repeat(64)),
+        );
+        forked.labels.insert(
+            "child_digest".to_string(),
+            format!("sha256:{}", "c".repeat(64)),
+        );
+        signer.sign_and_emit(&forked).await.unwrap();
         signer
             .sign_and_emit(&make_entry("tenant-a", "plan.failed"))
             .await
@@ -386,9 +399,10 @@ mod tests {
         let content = std::fs::read_to_string(signer.tenant_path("tenant-a")).unwrap();
         let verified = mvm_protocol::verify::verify_audit_chain_bytes(&content, &vk)
             .expect("mvm-protocol's verifier must accept a chain mvm-supervisor wrote");
-        assert_eq!(verified.count, 2);
+        assert_eq!(verified.count, 3);
         assert_eq!(verified.entries[0].event, "plan.launched");
         assert_eq!(verified.entries[0].tenant, "tenant-a");
+        assert_eq!(verified.entries[1].event, "checkpoint.forked");
 
         // And it must reject a tampered stream just like the native path.
         let tampered = content.replacen("plan.launched", "plan.hijacked", 1);

--- a/crates/mvm-hostd/src/supervisor/audit_file.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_file.rs
@@ -404,6 +404,30 @@ mod tests {
         assert_eq!(verified.entries[0].tenant, "tenant-a");
         assert_eq!(verified.entries[1].event, "checkpoint.forked");
 
+        // The digest label VALUES must survive the wasm mirror intact (they are
+        // exactly what chain-anchored lineage verification reads back). Parse the
+        // forked line through the mirror's own SignedEnvelope and assert the
+        // labels round-trip.
+        let forked_line = content.lines().nth(1).expect("second entry present");
+        let mirrored: mvm_protocol::verify::SignedEnvelope =
+            serde_json::from_str(forked_line).expect("mirror parses the forked entry");
+        assert_eq!(
+            mirrored
+                .entry
+                .labels
+                .get("parent_digest")
+                .map(String::as_str),
+            Some(format!("sha256:{}", "b".repeat(64)).as_str())
+        );
+        assert_eq!(
+            mirrored
+                .entry
+                .labels
+                .get("child_digest")
+                .map(String::as_str),
+            Some(format!("sha256:{}", "c".repeat(64)).as_str())
+        );
+
         // And it must reject a tampered stream just like the native path.
         let tampered = content.replacen("plan.launched", "plan.hijacked", 1);
         let err = mvm_protocol::verify::verify_audit_chain_bytes(&tampered, &vk).unwrap_err();

--- a/crates/mvm-runtime/src/checkpoint/mod.rs
+++ b/crates/mvm-runtime/src/checkpoint/mod.rs
@@ -3,7 +3,9 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use mvm_core::checkpoint::{CheckpointClass, CheckpointId, CheckpointMeta, ContentBlob};
+use mvm_core::checkpoint::{
+    CheckpointClass, CheckpointDigest, CheckpointId, CheckpointMeta, ContentBlob,
+};
 
 /// Filename of the persisted supervisor launch config inside a vm_full
 /// checkpoint's content dir. Present only on checkpoints captured from a
@@ -84,12 +86,20 @@ impl CheckpointStore {
             .collect())
     }
 
-    pub fn children_of(&self, parent: &CheckpointId) -> Result<Vec<CheckpointMeta>> {
+    /// Checkpoints whose parent hash-link is `parent_digest` (its parent's
+    /// content-address). Lineage is derived by digest, not by mutable name.
+    pub fn children_of(&self, parent_digest: &CheckpointDigest) -> Result<Vec<CheckpointMeta>> {
         Ok(self
             .list()?
             .into_iter()
-            .filter(|m| m.parent.as_ref() == Some(parent))
+            .filter(|m| m.parent.as_ref() == Some(parent_digest))
             .collect())
+    }
+
+    /// Look up a checkpoint by its content-address ([`CheckpointMeta::meta_digest`]).
+    /// Scans `list()`; `Ok(None)` when no stored record carries that digest.
+    pub fn by_digest(&self, digest: &CheckpointDigest) -> Result<Option<CheckpointMeta>> {
+        Ok(self.list()?.into_iter().find(|m| &m.meta_digest == digest))
     }
 
     pub fn remove(&self, id: &CheckpointId) -> Result<()> {
@@ -165,6 +175,58 @@ pub fn verify_content(store: &CheckpointStore, meta: &CheckpointMeta) -> Result<
     Ok(())
 }
 
+/// Walk a checkpoint's lineage from `id` up to its genesis root, proving the
+/// hash chain at every hop. For each record it recomputes `meta_digest` from
+/// the record's own fields and refuses a drift from the stored value; the
+/// hash-link to the parent is enforced by looking the parent up *by its
+/// content-address*, so editing any ancestor's sealed record — its content
+/// manifest, its lineage, anything the digest covers — is caught here even
+/// though the edit is invisible to the plain parent-name back-pointer the old
+/// model used.
+///
+/// Fails closed on: a record whose stored digest no longer matches its fields
+/// (post-seal edit), a parent hash-link that resolves to no stored checkpoint
+/// (dangling lineage), or a revisited digest (a would-be cycle — infeasible for
+/// genuine content-addresses, refused rather than looped on).
+pub fn verify_lineage(store: &CheckpointStore, id: &CheckpointId) -> Result<()> {
+    let mut current = store.read_meta(id)?;
+    let mut seen: Vec<CheckpointDigest> = Vec::new();
+    loop {
+        let recomputed = current.compute_meta_digest();
+        if recomputed != current.meta_digest {
+            anyhow::bail!(
+                "checkpoint '{}' meta_digest drift: stored {}, recomputed {} \
+                 (its meta.json was edited after sealing)",
+                current.id,
+                current.meta_digest,
+                recomputed
+            );
+        }
+        if seen.contains(&current.meta_digest) {
+            anyhow::bail!(
+                "checkpoint '{}' lineage revisits digest {}: refusing a cyclic chain",
+                current.id,
+                current.meta_digest
+            );
+        }
+        seen.push(current.meta_digest.clone());
+
+        let parent_digest = match current.parent.clone() {
+            // Genesis root: no parent to chain to, the walk terminates clean.
+            None => return Ok(()),
+            Some(d) => d,
+        };
+        // Resolving the parent by its content-address *is* the hash-link check:
+        // by_digest only returns a record whose meta_digest equals the link, and
+        // that record's own digest is re-verified on the next iteration.
+        current = store.by_digest(&parent_digest)?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "checkpoint lineage is broken: no checkpoint has parent-linked digest {parent_digest}"
+            )
+        })?;
+    }
+}
+
 /// The fork's source is the sealed checkpoint content (cloned at capture
 /// time), never the parent's live disks, so a running parent races nothing.
 /// The child duplicates the parent's machine-id and MAC by construction —
@@ -225,7 +287,7 @@ pub fn fork_checkpoint(store: &CheckpointStore, params: ForkParams) -> Result<Ch
         CheckpointClass::FsQuick,
         params.child_vm_name,
     )
-    .parent(Some(parent.id))
+    .parent(Some(parent.meta_digest.clone()))
     .created_unix(params.created_unix)
     .content(parent.content.clone())
     .supervisor_config_digest(parent.supervisor_config_digest)
@@ -287,7 +349,7 @@ pub fn fork_vm_full_fc(
         CheckpointClass::VmFull,
         params.child_vm_name,
     )
-    .parent(Some(parent.id))
+    .parent(Some(parent.meta_digest.clone()))
     .created_unix(params.created_unix)
     .content(parent.content.clone())
     .supervisor_config_digest(parent.supervisor_config_digest)
@@ -609,11 +671,13 @@ pub struct CheckpointDiff {
 
 /// Compare two checkpoint metadata records. Pure — no store/disk access.
 pub fn diff_checkpoints(a: &CheckpointMeta, b: &CheckpointMeta) -> CheckpointDiff {
+    // Lineage is a hash-link: B is A's child iff B's parent digest is A's
+    // content-address, not iff it names A's (mutable) id.
     let lineage = if a.id == b.id {
         LineageRelation::Same
-    } else if b.parent.as_ref() == Some(&a.id) {
+    } else if b.parent.as_ref() == Some(&a.meta_digest) {
         LineageRelation::BChildOfA
-    } else if a.parent.as_ref() == Some(&b.id) {
+    } else if a.parent.as_ref() == Some(&b.meta_digest) {
         LineageRelation::AChildOfB
     } else {
         LineageRelation::Unrelated
@@ -724,12 +788,14 @@ pub fn capture_fs_quick(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mvm_core::checkpoint::{CheckpointClass, CheckpointId, CheckpointMeta, ContentBlob};
+    use mvm_core::checkpoint::{
+        CheckpointClass, CheckpointDigest, CheckpointId, CheckpointMeta, ContentBlob,
+    };
 
-    fn meta(id: &str, tag: Option<&str>, parent: Option<&str>) -> CheckpointMeta {
+    fn meta(id: &str, tag: Option<&str>, parent: Option<CheckpointDigest>) -> CheckpointMeta {
         CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::FsQuick, "vm")
             .tag(tag.map(String::from))
-            .parent(parent.map(CheckpointId::new))
+            .parent(parent)
             .content(vec![ContentBlob {
                 name: "rootfs.ext4".into(),
                 sha256: "h".into(),
@@ -774,11 +840,12 @@ mod tests {
     fn children_of_finds_lineage() {
         let tmp = tempfile::tempdir().unwrap();
         let store = CheckpointStore::at(tmp.path());
-        store.write_meta(&meta("parent", None, None)).unwrap();
+        let parent = meta("parent", None, None);
+        store.write_meta(&parent).unwrap();
         store
-            .write_meta(&meta("child", None, Some("parent")))
+            .write_meta(&meta("child", None, Some(parent.meta_digest.clone())))
             .unwrap();
-        let kids = store.children_of(&CheckpointId::new("parent")).unwrap();
+        let kids = store.children_of(&parent.meta_digest).unwrap();
         assert_eq!(kids.len(), 1);
         assert_eq!(kids[0].id.as_str(), "child");
     }
@@ -858,7 +925,7 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(child.parent.as_ref().unwrap(), &parent.id);
+        assert_eq!(child.parent.as_ref().unwrap(), &parent.meta_digest);
         assert_eq!(child.vm_name, "childvm");
         assert_eq!(
             std::fs::read(dst.join("rootfs.ext4")).unwrap(),
@@ -866,7 +933,7 @@ mod tests {
         );
         // byte-identical clone → manifest hashes are preserved
         assert_eq!(child.content, parent.content);
-        assert_eq!(store.children_of(&parent.id).unwrap().len(), 1);
+        assert_eq!(store.children_of(&parent.meta_digest).unwrap().len(), 1);
     }
 
     #[test]
@@ -1355,9 +1422,14 @@ mod tests {
         assert_eq!(store.read_meta(&meta.id).unwrap(), meta);
     }
 
-    fn fs_quick_meta(id: &str, vm: &str, parent: Option<&str>, rootfs_sha: &str) -> CheckpointMeta {
+    fn fs_quick_meta(
+        id: &str,
+        vm: &str,
+        parent: Option<CheckpointDigest>,
+        rootfs_sha: &str,
+    ) -> CheckpointMeta {
         CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::FsQuick, vm)
-            .parent(parent.map(CheckpointId::new))
+            .parent(parent)
             .content(vec![ContentBlob {
                 name: "rootfs.ext4".into(),
                 sha256: rootfs_sha.into(),
@@ -1442,7 +1514,7 @@ mod tests {
     #[test]
     fn diff_detects_child_lineage() {
         let a = fs_quick_meta("parent", "vm", None, "aaaa");
-        let b = fs_quick_meta("child", "vm", Some("parent"), "aaaa");
+        let b = fs_quick_meta("child", "vm", Some(a.meta_digest.clone()), "aaaa");
         assert_eq!(diff_checkpoints(&a, &b).lineage, LineageRelation::BChildOfA);
         assert_eq!(diff_checkpoints(&b, &a).lineage, LineageRelation::AChildOfB);
     }
@@ -1691,7 +1763,7 @@ mod tests {
         assert!(!dest.join("machine-id").exists());
 
         assert_eq!(child.class, CheckpointClass::VmFull);
-        assert_eq!(child.parent.as_ref().unwrap(), &parent.id);
+        assert_eq!(child.parent.as_ref().unwrap(), &parent.meta_digest);
         assert_eq!(child.vm_name, "fc-childvm");
         assert_eq!(child.content, parent.content);
 
@@ -1728,6 +1800,141 @@ mod tests {
             "unexpected error: {err}"
         );
         assert!(restorer.seen.borrow().is_none());
+    }
+
+    // ── hash-linked lineage: verify_lineage ─────────────────────────────────
+
+    /// Seed a bare fs_quick meta hash-linked to `parent`, written to the store.
+    /// Only metadata is written (no content blobs) — `verify_lineage` reads
+    /// meta.json and recomputes digests; it never touches blob bytes.
+    fn seed_linked_meta(
+        store: &CheckpointStore,
+        id: &str,
+        parent: Option<CheckpointDigest>,
+        rootfs_sha: &str,
+    ) -> CheckpointMeta {
+        let m = CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::FsQuick, "vm")
+            .parent(parent)
+            .content(vec![ContentBlob {
+                name: "rootfs.ext4".into(),
+                sha256: rootfs_sha.into(),
+            }])
+            .supervisor_config_digest("d")
+            .created_unix(1)
+            .build();
+        store.write_meta(&m).unwrap();
+        m
+    }
+
+    #[test]
+    fn capture_writes_a_meta_digest_that_recomputes_equal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let meta = seed_fs_quick_checkpoint(&store, tmp.path(), "p1");
+        assert_eq!(meta.meta_digest, meta.compute_meta_digest());
+        // A freshly captured genesis checkpoint is a valid one-node lineage.
+        verify_lineage(&store, &meta.id).unwrap();
+    }
+
+    #[test]
+    fn fork_records_parent_meta_digest_as_hashlink() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let parent = seed_fs_quick_checkpoint(&store, tmp.path(), "p1");
+        let child = fork_checkpoint(
+            &store,
+            ForkParams {
+                checkpoint: parent.id.clone(),
+                child_id: CheckpointId::new("c1"),
+                child_vm_name: "childvm".into(),
+                dest_dir: tmp.path().join("childvm-state"),
+                created_unix: 2,
+                child_plan_json: None,
+                child_tenant_id: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(child.parent.as_ref().unwrap(), &parent.meta_digest);
+    }
+
+    #[test]
+    fn verify_lineage_passes_for_genesis_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let root = seed_linked_meta(&store, "g0", None, "aa");
+        assert!(root.parent.is_none());
+        verify_lineage(&store, &root.id).unwrap();
+    }
+
+    #[test]
+    fn verify_lineage_walks_multiple_generations_to_genesis() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let g0 = seed_linked_meta(&store, "g0", None, "aa");
+        let g1 = seed_linked_meta(&store, "g1", Some(g0.meta_digest.clone()), "bb");
+        let g2 = seed_linked_meta(&store, "g2", Some(g1.meta_digest.clone()), "cc");
+        verify_lineage(&store, &g2.id).unwrap();
+        // Each hop is a hash-link to the parent's content-address.
+        assert_eq!(g2.parent.as_ref().unwrap(), &g1.meta_digest);
+        assert_eq!(g1.parent.as_ref().unwrap(), &g0.meta_digest);
+    }
+
+    /// HEADLINE: editing an ancestor's recorded content sha in its meta.json —
+    /// two hops up from the checkpoint under test — is invisible to the old
+    /// name-based parent pointer but is caught here: the ancestor's stored
+    /// meta_digest no longer matches a recomputation of its (now-edited) fields.
+    #[test]
+    fn verify_lineage_detects_an_edited_ancestor_content_sha() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let g0 = seed_linked_meta(&store, "g0", None, "aa");
+        let g1 = seed_linked_meta(&store, "g1", Some(g0.meta_digest.clone()), "bb");
+        let g2 = seed_linked_meta(&store, "g2", Some(g1.meta_digest.clone()), "cc");
+
+        // Baseline: the intact chain verifies.
+        verify_lineage(&store, &g2.id).unwrap();
+
+        // Tamper the ANCESTOR (g0): rewrite its recorded content sha, leaving
+        // its stored meta_digest (and g1's hash-link to it) stale.
+        let g0_meta_path = store.dir_for(&g0.id).join("meta.json");
+        let mut tampered: CheckpointMeta =
+            serde_json::from_slice(&std::fs::read(&g0_meta_path).unwrap()).unwrap();
+        tampered.content[0].sha256 = "0".repeat(64);
+        std::fs::write(&g0_meta_path, serde_json::to_vec_pretty(&tampered).unwrap()).unwrap();
+
+        let err = verify_lineage(&store, &g2.id).unwrap_err();
+        assert!(
+            err.to_string().contains("meta_digest drift"),
+            "expected a meta_digest drift error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn verify_lineage_fails_closed_on_a_dangling_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        // A child hash-linked to a digest no stored checkpoint carries.
+        let orphan_parent = CheckpointDigest::parse(format!("sha256:{}", "e".repeat(64))).unwrap();
+        let child = seed_linked_meta(&store, "child", Some(orphan_parent), "cc");
+        let err = verify_lineage(&store, &child.id).unwrap_err();
+        assert!(
+            err.to_string().contains("lineage is broken"),
+            "expected a dangling-parent error, got: {err}"
+        );
+    }
+
+    /// A flipped blob byte does not touch meta.json, so `meta_digest` still
+    /// recomputes equal — that tamper class is `verify_content`'s job (it
+    /// re-hashes the bytes), while `verify_lineage` guards the metadata chain.
+    #[test]
+    fn content_byte_flip_fails_verify_content_though_meta_digest_recomputes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let parent = seed_fs_quick_checkpoint(&store, tmp.path(), "p1");
+        let blob = store.content_dir(&parent.id).join("rootfs.ext4");
+        std::fs::write(&blob, b"flipped-bytes").unwrap();
+        assert!(verify_content(&store, &parent).is_err());
+        assert_eq!(parent.meta_digest, parent.compute_meta_digest());
     }
 
     // SAFETY: serialized by HOME_TEST_LOCK.

--- a/crates/mvm-runtime/src/checkpoint/mod.rs
+++ b/crates/mvm-runtime/src/checkpoint/mod.rs
@@ -175,33 +175,88 @@ pub fn verify_content(store: &CheckpointStore, meta: &CheckpointMeta) -> Result<
     Ok(())
 }
 
-/// Walk a checkpoint's lineage from `id` up to its genesis root, proving the
-/// hash chain at every hop. For each record it recomputes `meta_digest` from
-/// the record's own fields and refuses a drift from the stored value; the
-/// hash-link to the parent is enforced by looking the parent up *by its
-/// content-address*, so editing any ancestor's sealed record — its content
-/// manifest, its lineage, anything the digest covers — is caught here even
-/// though the edit is invisible to the plain parent-name back-pointer the old
-/// model used.
+/// Resolves the signature-authenticated content-address a checkpoint's creation
+/// was recorded under in the chain-signed audit log.
 ///
-/// Fails closed on: a record whose stored digest no longer matches its fields
-/// (post-seal edit), a parent hash-link that resolves to no stored checkpoint
-/// (dangling lineage), or a revisited digest (a would-be cycle — infeasible for
+/// Injected (rather than called directly) so this crate's lineage walk stays
+/// free of host-key loading, tenant resolution, and audit-file layout — those
+/// live in the layer above (the CLI), which owns the host signer. An
+/// implementation MUST verify the audit chain's signatures before trusting any
+/// label it returns, so the value it yields is one no party but the host could
+/// have produced.
+pub trait CheckpointChainAnchor {
+    /// The content-address recorded for `meta`'s creation in the tenant's
+    /// signature-verified audit chain (`checkpoint.created`'s `meta_digest`, or
+    /// `checkpoint.forked`'s `child_digest`), or `None` if the chain carries no
+    /// creation entry for it.
+    fn recorded_creation_digest(&self, meta: &CheckpointMeta) -> Result<Option<CheckpointDigest>>;
+}
+
+/// Verify one checkpoint record against the signed audit chain: its stored
+/// `meta_digest` must equal a recomputation of its own fields (catches a
+/// post-seal edit that left the digest stale) AND must equal the
+/// signature-verified digest the audit chain recorded at creation (catches a
+/// full local re-forge, where an attacker rewrites content, digest, and links
+/// all consistently — that survives recompute alone but not the signed chain,
+/// which it cannot re-sign without the host key). Fails closed on a drift, a
+/// mismatch against the chain, or the absence of any signed creation entry.
+fn verify_checkpoint_against_chain(
+    anchor: &dyn CheckpointChainAnchor,
+    meta: &CheckpointMeta,
+) -> Result<()> {
+    let recomputed = meta.compute_meta_digest();
+    if recomputed != meta.meta_digest {
+        anyhow::bail!(
+            "checkpoint '{}' meta_digest drift: stored {}, recomputed {} \
+             (its meta.json was edited after sealing)",
+            meta.id,
+            meta.meta_digest,
+            recomputed
+        );
+    }
+    match anchor.recorded_creation_digest(meta)? {
+        Some(recorded) if recorded == recomputed => Ok(()),
+        Some(recorded) => anyhow::bail!(
+            "checkpoint '{}' content-address {recomputed} does not match the \
+             signed audit chain, which recorded {recorded} at creation \
+             (the on-disk record was edited after it was audited)",
+            meta.id
+        ),
+        None => anyhow::bail!(
+            "checkpoint '{}' has no signed audit entry to anchor its \
+             content-address; refusing to treat an un-audited record as verified",
+            meta.id
+        ),
+    }
+}
+
+/// Walk a checkpoint's lineage from `id` up to its genesis root, verifying each
+/// record against the **signed** audit chain via `anchor`: at every hop the
+/// record's recomputed content-address must equal both its stored `meta_digest`
+/// and the digest the host signed into the audit chain at creation. The
+/// parent hash-link is followed by content-address, so editing any ancestor's
+/// sealed record — content manifest, lineage, anything the digest covers — is
+/// caught here even though it is invisible to a plain parent-name back-pointer.
+///
+/// Fails closed on: a drift between a record and its stored digest, a record
+/// whose digest disagrees with the signed chain (or has no signed entry), a
+/// parent hash-link that resolves to no stored checkpoint (dangling lineage),
+/// or a revisited digest (a would-be cycle — cryptographically infeasible for
 /// genuine content-addresses, refused rather than looped on).
-pub fn verify_lineage(store: &CheckpointStore, id: &CheckpointId) -> Result<()> {
+///
+/// Threat boundary: this proves integrity against edits made *after* the host
+/// signed each record. A malicious host that holds the signing key is out of
+/// scope (it is out of scope for the whole audit chain), as is a checkpoint
+/// that was never audited — for which there is nothing signed to anchor to.
+pub fn verify_lineage(
+    store: &CheckpointStore,
+    id: &CheckpointId,
+    anchor: &dyn CheckpointChainAnchor,
+) -> Result<()> {
     let mut current = store.read_meta(id)?;
     let mut seen: Vec<CheckpointDigest> = Vec::new();
     loop {
-        let recomputed = current.compute_meta_digest();
-        if recomputed != current.meta_digest {
-            anyhow::bail!(
-                "checkpoint '{}' meta_digest drift: stored {}, recomputed {} \
-                 (its meta.json was edited after sealing)",
-                current.id,
-                current.meta_digest,
-                recomputed
-            );
-        }
+        verify_checkpoint_against_chain(anchor, &current)?;
         if seen.contains(&current.meta_digest) {
             anyhow::bail!(
                 "checkpoint '{}' lineage revisits digest {}: refusing a cyclic chain",
@@ -218,7 +273,8 @@ pub fn verify_lineage(store: &CheckpointStore, id: &CheckpointId) -> Result<()> 
         };
         // Resolving the parent by its content-address *is* the hash-link check:
         // by_digest only returns a record whose meta_digest equals the link, and
-        // that record's own digest is re-verified on the next iteration.
+        // that record's own digest is re-verified (against disk + chain) on the
+        // next iteration.
         current = store.by_digest(&parent_digest)?.ok_or_else(|| {
             anyhow::anyhow!(
                 "checkpoint lineage is broken: no checkpoint has parent-linked digest {parent_digest}"
@@ -254,13 +310,22 @@ pub fn checkpoint_is_vz(meta: &mvm_core::checkpoint::CheckpointMeta) -> bool {
 }
 
 /// Branch a new sandbox lineage from a checkpoint: verify the source content's
-/// integrity, CoW-clone it into `dest_dir`, and record a child checkpoint whose
-/// `parent` points back to the source. Boot of the child is the caller's job.
+/// integrity AND its content-address against the signed audit chain, CoW-clone
+/// it into `dest_dir`, and record a child checkpoint whose `parent` hash-links
+/// to the source. Boot of the child is the caller's job.
+///
+/// The parent is verified against the signed chain (`anchor`) before any bytes
+/// are cloned, so a fork never builds on a checkpoint whose sealed record was
+/// edited after it was audited — fail-closed.
 ///
 /// fs_quick only — a vm_full checkpoint carries saved memory and must be forked
 /// through [`fork_vm_full_fc`], which restores the memory state into the new
 /// identity.
-pub fn fork_checkpoint(store: &CheckpointStore, params: ForkParams) -> Result<CheckpointMeta> {
+pub fn fork_checkpoint(
+    store: &CheckpointStore,
+    params: ForkParams,
+    anchor: &dyn CheckpointChainAnchor,
+) -> Result<CheckpointMeta> {
     let parent = store.read_meta(&params.checkpoint)?;
     if parent.class != CheckpointClass::FsQuick {
         anyhow::bail!(
@@ -270,6 +335,9 @@ pub fn fork_checkpoint(store: &CheckpointStore, params: ForkParams) -> Result<Ch
     }
 
     verify_content(store, &parent)?;
+    // The parent's sealed record must still match the digest the host signed at
+    // creation — refuse to branch from a checkpoint edited after it was audited.
+    verify_checkpoint_against_chain(anchor, &parent)?;
 
     std::fs::create_dir_all(&params.dest_dir)
         .with_context(|| format!("creating {}", params.dest_dir.display()))?;
@@ -311,6 +379,7 @@ pub fn fork_vm_full_fc(
     store: &CheckpointStore,
     params: ForkParams,
     restorer: &dyn ForkVmFullRestorer,
+    anchor: &dyn CheckpointChainAnchor,
 ) -> Result<CheckpointMeta> {
     let parent = store.read_meta(&params.checkpoint)?;
     if parent.class != CheckpointClass::VmFull {
@@ -320,6 +389,9 @@ pub fn fork_vm_full_fc(
         );
     }
     verify_content(store, &parent)?;
+    // Same fail-closed posture as fork_checkpoint: the parent's sealed record
+    // must still match the digest the host signed at creation before we clone.
+    verify_checkpoint_against_chain(anchor, &parent)?;
 
     if !FORK_ALLOW_PARENT_RUNNING && vm_is_running(&parent.vm_name) {
         anyhow::bail!(
@@ -805,6 +877,46 @@ mod tests {
             .build()
     }
 
+    /// Anchor that echoes each record's own recomputed digest: the signed audit
+    /// chain agrees with what's on disk — the honest case.
+    struct AgreeingAnchor;
+    impl CheckpointChainAnchor for AgreeingAnchor {
+        fn recorded_creation_digest(
+            &self,
+            meta: &CheckpointMeta,
+        ) -> Result<Option<CheckpointDigest>> {
+            Ok(Some(meta.compute_meta_digest()))
+        }
+    }
+
+    /// Anchor that reports a fixed, unrelated digest for every record: models a
+    /// signed chain that disagrees with the on-disk record (post-audit edit).
+    struct DisagreeingAnchor(CheckpointDigest);
+    impl CheckpointChainAnchor for DisagreeingAnchor {
+        fn recorded_creation_digest(
+            &self,
+            _meta: &CheckpointMeta,
+        ) -> Result<Option<CheckpointDigest>> {
+            Ok(Some(self.0.clone()))
+        }
+    }
+
+    /// Anchor with no signed creation entry for anything: models an un-audited
+    /// checkpoint, which chain-anchored verification must refuse.
+    struct UnauditedAnchor;
+    impl CheckpointChainAnchor for UnauditedAnchor {
+        fn recorded_creation_digest(
+            &self,
+            _meta: &CheckpointMeta,
+        ) -> Result<Option<CheckpointDigest>> {
+            Ok(None)
+        }
+    }
+
+    fn unrelated_digest() -> CheckpointDigest {
+        CheckpointDigest::parse(format!("sha256:{}", "f".repeat(64))).unwrap()
+    }
+
     #[test]
     fn write_then_read_roundtrips() {
         let tmp = tempfile::tempdir().unwrap();
@@ -923,6 +1035,7 @@ mod tests {
                 child_plan_json: None,
                 child_tenant_id: None,
             },
+            &AgreeingAnchor,
         )
         .unwrap();
         assert_eq!(child.parent.as_ref().unwrap(), &parent.meta_digest);
@@ -960,6 +1073,7 @@ mod tests {
                 child_plan_json: None,
                 child_tenant_id: None,
             },
+            &AgreeingAnchor,
         )
         .unwrap_err();
         assert!(err.to_string().contains("vm_full"));
@@ -983,6 +1097,7 @@ mod tests {
                 child_plan_json: None,
                 child_tenant_id: None,
             },
+            &AgreeingAnchor,
         )
         .unwrap_err();
         assert!(err.to_string().contains("integrity") || err.to_string().contains("sha256"));
@@ -1059,6 +1174,7 @@ mod tests {
                 child_plan_json: None,
                 child_tenant_id: None,
             },
+            &AgreeingAnchor,
         )
         .unwrap();
         assert_eq!(child.content.len(), 2);
@@ -1751,6 +1867,7 @@ mod tests {
                 child_tenant_id: None,
             },
             &restorer,
+            &AgreeingAnchor,
         )
         .unwrap();
 
@@ -1793,6 +1910,7 @@ mod tests {
                 child_tenant_id: None,
             },
             &restorer,
+            &AgreeingAnchor,
         )
         .unwrap_err();
         assert!(
@@ -1833,7 +1951,7 @@ mod tests {
         let meta = seed_fs_quick_checkpoint(&store, tmp.path(), "p1");
         assert_eq!(meta.meta_digest, meta.compute_meta_digest());
         // A freshly captured genesis checkpoint is a valid one-node lineage.
-        verify_lineage(&store, &meta.id).unwrap();
+        verify_lineage(&store, &meta.id, &AgreeingAnchor).unwrap();
     }
 
     #[test]
@@ -1852,6 +1970,7 @@ mod tests {
                 child_plan_json: None,
                 child_tenant_id: None,
             },
+            &AgreeingAnchor,
         )
         .unwrap();
         assert_eq!(child.parent.as_ref().unwrap(), &parent.meta_digest);
@@ -1863,7 +1982,7 @@ mod tests {
         let store = CheckpointStore::at(tmp.path().join("store"));
         let root = seed_linked_meta(&store, "g0", None, "aa");
         assert!(root.parent.is_none());
-        verify_lineage(&store, &root.id).unwrap();
+        verify_lineage(&store, &root.id, &AgreeingAnchor).unwrap();
     }
 
     #[test]
@@ -1873,7 +1992,7 @@ mod tests {
         let g0 = seed_linked_meta(&store, "g0", None, "aa");
         let g1 = seed_linked_meta(&store, "g1", Some(g0.meta_digest.clone()), "bb");
         let g2 = seed_linked_meta(&store, "g2", Some(g1.meta_digest.clone()), "cc");
-        verify_lineage(&store, &g2.id).unwrap();
+        verify_lineage(&store, &g2.id, &AgreeingAnchor).unwrap();
         // Each hop is a hash-link to the parent's content-address.
         assert_eq!(g2.parent.as_ref().unwrap(), &g1.meta_digest);
         assert_eq!(g1.parent.as_ref().unwrap(), &g0.meta_digest);
@@ -1892,7 +2011,7 @@ mod tests {
         let g2 = seed_linked_meta(&store, "g2", Some(g1.meta_digest.clone()), "cc");
 
         // Baseline: the intact chain verifies.
-        verify_lineage(&store, &g2.id).unwrap();
+        verify_lineage(&store, &g2.id, &AgreeingAnchor).unwrap();
 
         // Tamper the ANCESTOR (g0): rewrite its recorded content sha, leaving
         // its stored meta_digest (and g1's hash-link to it) stale.
@@ -1902,7 +2021,7 @@ mod tests {
         tampered.content[0].sha256 = "0".repeat(64);
         std::fs::write(&g0_meta_path, serde_json::to_vec_pretty(&tampered).unwrap()).unwrap();
 
-        let err = verify_lineage(&store, &g2.id).unwrap_err();
+        let err = verify_lineage(&store, &g2.id, &AgreeingAnchor).unwrap_err();
         assert!(
             err.to_string().contains("meta_digest drift"),
             "expected a meta_digest drift error, got: {err}"
@@ -1916,7 +2035,7 @@ mod tests {
         // A child hash-linked to a digest no stored checkpoint carries.
         let orphan_parent = CheckpointDigest::parse(format!("sha256:{}", "e".repeat(64))).unwrap();
         let child = seed_linked_meta(&store, "child", Some(orphan_parent), "cc");
-        let err = verify_lineage(&store, &child.id).unwrap_err();
+        let err = verify_lineage(&store, &child.id, &AgreeingAnchor).unwrap_err();
         assert!(
             err.to_string().contains("lineage is broken"),
             "expected a dangling-parent error, got: {err}"
@@ -1935,6 +2054,101 @@ mod tests {
         std::fs::write(&blob, b"flipped-bytes").unwrap();
         assert!(verify_content(&store, &parent).is_err());
         assert_eq!(parent.meta_digest, parent.compute_meta_digest());
+    }
+
+    // ── chain-anchored verification (the signed-chain leg) ───────────────────
+
+    #[test]
+    fn verify_lineage_fails_when_chain_recorded_digest_disagrees() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let root = seed_linked_meta(&store, "g0", None, "aa");
+        // The on-disk record is internally consistent (recompute == stored), but
+        // the signed chain recorded a different content-address at creation — a
+        // full local re-forge that only the signed chain can catch.
+        let err =
+            verify_lineage(&store, &root.id, &DisagreeingAnchor(unrelated_digest())).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not match the signed audit chain"),
+            "expected a chain-mismatch error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn verify_lineage_refuses_a_node_with_no_signed_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let root = seed_linked_meta(&store, "g0", None, "aa");
+        let err = verify_lineage(&store, &root.id, &UnauditedAnchor).unwrap_err();
+        assert!(
+            err.to_string().contains("no signed audit entry"),
+            "expected an un-audited-node error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn fork_fails_closed_when_parent_disagrees_with_chain() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let parent = seed_fs_quick_checkpoint(&store, tmp.path(), "p1");
+        let dest = tmp.path().join("childvm-state");
+        // Parent bytes and stored digest agree, but the signed chain recorded a
+        // different digest at creation → refuse to fork, before cloning a byte.
+        let err = fork_checkpoint(
+            &store,
+            ForkParams {
+                checkpoint: parent.id.clone(),
+                child_id: CheckpointId::new("c1"),
+                child_vm_name: "childvm".into(),
+                dest_dir: dest.clone(),
+                created_unix: 2,
+                child_plan_json: None,
+                child_tenant_id: None,
+            },
+            &DisagreeingAnchor(unrelated_digest()),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not match the signed audit chain"),
+            "expected a chain-mismatch error, got: {err}"
+        );
+        assert!(
+            !dest.join("rootfs.ext4").exists(),
+            "fork must fail closed before cloning a chain-inconsistent parent"
+        );
+        assert!(
+            store.read_meta(&CheckpointId::new("c1")).is_err(),
+            "no child checkpoint record must be written"
+        );
+    }
+
+    #[test]
+    fn fork_fails_closed_when_parent_has_no_signed_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let parent = seed_fs_quick_checkpoint(&store, tmp.path(), "p1");
+        let dest = tmp.path().join("childvm-state");
+        let err = fork_checkpoint(
+            &store,
+            ForkParams {
+                checkpoint: parent.id.clone(),
+                child_id: CheckpointId::new("c1"),
+                child_vm_name: "childvm".into(),
+                dest_dir: dest.clone(),
+                created_unix: 2,
+                child_plan_json: None,
+                child_tenant_id: None,
+            },
+            &UnauditedAnchor,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("no signed audit entry"),
+            "expected an un-audited-parent error, got: {err}"
+        );
+        assert!(!dest.join("rootfs.ext4").exists());
     }
 
     // SAFETY: serialized by HOME_TEST_LOCK.

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -610,6 +610,7 @@ host registry records.
 | `mvmctl machine checkpoint fork <checkpoint> [--new-id <name>] [--boot] [--json]` | Restore a checkpoint into a new VM identity (new name, separate audit lineage). `vm_full` forks auto-boot; `fs_quick` forks boot only with `--boot`. |
 | `mvmctl machine checkpoint ls [--json]` | List checkpoints. |
 | `mvmctl machine checkpoint diff <a> <b> [--json]` | Compare two checkpoint metadata/content manifests. |
+| `mvmctl machine checkpoint verify <checkpoint> [--json]` | Verify a checkpoint's full lineage against the signed audit chain (recomputed content-address must match both the stored `meta_digest` and the digest signed at creation, at every hop). Exits nonzero on any drift, chain mismatch, missing signed entry, or broken lineage. |
 | `mvmctl machine checkpoint rm <checkpoint> [--json]` | Delete a checkpoint and its blobs. |
 | `mvmctl machine snapshot ls [--json]` | List sealed Firecracker instance snapshots. |
 | `mvmctl machine snapshot rm <name> [--json]` | Delete a sealed Firecracker instance snapshot. |

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -176,6 +176,8 @@ const CHECKPOINT_SUB: &[(&str, AuditPosture)] = &[
     ("diff", AuditPosture::ReadOnly),
     ("ls", AuditPosture::ReadOnly),
     ("rm", AuditPosture::ReadOnly),
+    // Reads the signed audit chain to verify lineage; emits nothing itself.
+    ("verify", AuditPosture::ReadOnly),
 ];
 
 const IMAGE_SUB: &[(&str, AuditPosture)] = &[


### PR DESCRIPTION
## Summary

Makes checkpoint lineage **content-addressed and cryptographically anchored to the signed audit log**, closing a gap surfaced by backlog research (#1761): checkpoint lineage was a linked list of *opaque ids* — `CheckpointMeta.parent` was a name, the meta was unsigned/unhashed, and editing an ancestor's content manifest was invisible to its descendants.

This is **additive hardening of the existing claim-8 audit surface** — plan signing/admission is unchanged. (No claim-catalog row: that machinery's file is currently absent from the tree; rationale grounds on the security-posture ADR.)

## What it does

- **`CheckpointDigest`** — a `sha256:<hex>` content-address newtype (modeled on `SemanticAddress`, non-convertible to it / `OciDigest` / `Sha256Hex`). `CheckpointMeta` gains a required `meta_digest` and its `parent` becomes an `Option<CheckpointDigest>` (a **hash-link**, not a name). The digest is a plain-serde SHA-256 over every load-bearing field (content sorted by name; `meta_digest`/`audit_ref` excluded), reusing the `deps_audit` volume-hash pattern — no new byte hashing, no new dependency.
- **Chain-anchored verification** — `verify_lineage` walks a lineage by content-address and, at every hop, requires the record's recomputed digest to equal *both* its stored `meta_digest` (catches a post-seal edit) *and* the digest the host signed into the audit chain at creation (catches a fully-consistent local re-forge — an attacker cannot re-sign the chain without the host key). The anchor verifies each audit chain's Ed25519 signature *before* trusting any of its records, so a tampered chain strands its entries. Proven by `chain_anchor_catches_a_fully_consistent_local_reforge`.
- **Reachable** — new `mvmctl machine checkpoint verify <id> [--json]` (read-only, nonzero exit on any failure). And **`fork` now verifies the parent against the signed chain before cloning any bytes** — see behavior note.
- **Audit binding** — `checkpoint.created`/`restored` carry a `meta_digest` label; `checkpoint.forked` carries `parent_digest`+`child_digest`. These are `BTreeMap` label additions that ride inside the already-signed entry bytes, so **`verify_audit_chain` and its wasm mirror needed zero changes** (`mvm-protocol/src/verify.rs` is a 0-line diff; the mirror-equivalence test is extended to prove it).

## ⚠️ Behavior change

`fork` is now **fail-closed**: forking a checkpoint whose sealed record was edited after auditing, or that was **never audited** (best-effort capture skipped its entry), is refused. Normal flow is unaffected — `up`/`run` persists a plan, so `checkpoint create` emits the signed creation entry and the parent is anchorable.

## Hard break (no back-compat, per project policy)

Old-shape `meta.json` (name `parent`, no `meta_digest`) fails to parse — asserted. Existing `~/.mvm/checkpoints/*` from before this change won't load; clear the dir.

## Process

Design pass → implement (TDD; the headline tamper test was demonstrated to fail *without* the digest check and pass *with* it) → independent adversarial review → second implementation round addressing all findings (the review caught that verification wasn't wired into production and wasn't chain-anchored — both fixed here) → direct re-verification of the trust core. Reuse-first fix folded in: the triplicated `sha256:<hex>` validator is now one shared helper backing `CheckpointDigest`/`SemanticAddress`/`OciDigest`.

## Testing

nextest **7598 passed / 0 failed**; doctests; `just bdd` 62 steps; clippy `--all-targets -D warnings`; nightly fmt; `build --all-targets -D warnings`; check-no-spec-refs. New coverage includes the re-forge catch, fork-fails-closed (parent-disagrees + no-signed-entry, asserting no bytes cloned), per-field digest completeness (all 10 fields), genesis, dangling-parent, cycle, and the wasm-mirror label survival.

## Deferred

`plan_id` content-addressing (larger, claim-8-touching); tightening capture's best-effort audit binding to fail-closed; a digest→path index if checkpoint counts grow (`by_digest` is O(n), matching the existing store scans).
