### PR TITLE
fix(cli): honor --hypervisor on a transient machine run

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -331,6 +331,7 @@ impl MachineRunArgs {
                 self.health_retries,
                 self.health_start_period,
             ),
+            hypervisor: self.hypervisor,
         }
     }
 

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -246,6 +246,34 @@ fn run_parses_image_and_trailing_argv() {
 }
 
 #[test]
+fn run_parses_hypervisor_flag_and_forwards_to_run_args() {
+    let args = parse_run(&[
+        "run",
+        "--image",
+        "alpine",
+        "--hypervisor",
+        "libkrun",
+        "--",
+        "echo",
+        "hello",
+    ])
+    .expect("parse");
+    assert_eq!(args.hypervisor.as_deref(), Some("libkrun"));
+
+    let run = args.into_run_args();
+    assert_eq!(run.hypervisor.as_deref(), Some("libkrun"));
+}
+
+#[test]
+fn run_without_hypervisor_flag_forwards_none() {
+    let args = parse_run(&["run", "--image", "alpine", "--", "echo", "hello"]).expect("parse");
+    assert!(args.hypervisor.is_none());
+
+    let run = args.into_run_args();
+    assert!(run.hypervisor.is_none());
+}
+
+#[test]
 fn run_parses_runtime_pack_flag_and_forwards_to_run_args() {
     let args = parse_run(&["run", "--runtime-pack", "--", "true"]).expect("parse");
     assert!(args.runtime_pack);

--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -432,6 +432,9 @@ impl ExecDispatcher {
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
             stdin: Vec::new(),
             healthcheck: None,
+            // MCP has no `--hypervisor` CLI flag; auto-detect (or the
+            // MVM_HYPERVISOR/MVM_BACKEND env override) applies as before.
+            hypervisor: None,
         };
         // Admit the run (see `mcp_untrusted_admit`): without it no bridge spawns
         // and the deny-all above is inert on the libkrun/HVF backends.

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -87,6 +87,10 @@ pub(in crate::commands) struct Args {
     /// forwarded from `machine run`'s `--healthcheck` + tuning flags.
     #[arg(skip)]
     pub healthcheck: Option<mvm_protocol::ir::HealthCheck>,
+    /// Internal (not a CLI flag): requested workload hypervisor, forwarded from
+    /// `RunArgs::hypervisor` via `into_exec_args`.
+    #[arg(skip)]
+    pub hypervisor: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -231,6 +235,11 @@ pub(in crate::commands) struct RunArgs {
     /// forwarded from `machine run`'s `--healthcheck` + tuning flags.
     #[arg(skip)]
     pub healthcheck: Option<mvm_protocol::ir::HealthCheck>,
+    /// Requested workload hypervisor from `machine run --hypervisor <x>`. Set
+    /// programmatically by `MachineRunArgs::into_run_args`; the transient backend
+    /// selection reads it (taking precedence over the `MVM_HYPERVISOR` env var).
+    #[arg(skip)]
+    pub hypervisor: Option<String>,
 }
 
 /// SDK transport modes for `mvmctl run`. Mirrors the `Mode` enum on
@@ -287,6 +296,7 @@ impl RunArgs {
             argv: self.argv,
             stdin: self.stdin,
             healthcheck: self.healthcheck,
+            hypervisor: self.hypervisor,
         }
     }
 }
@@ -344,9 +354,13 @@ pub(in crate::commands) fn run_secure(cli: &Cli, args: RunArgs, cfg: &MvmConfig)
     // unfiltered path. The closure runs inside the boot path with the resolved
     // rootfs + generated vm_name. cpus/mem are captured here because `args` is
     // consumed by `into_exec_args()` below.
-    let admit_backend = crate::exec::select_exec_backend(args.image.is_some(), &network_policy)?
-        .name()
-        .to_string();
+    let admit_backend = crate::exec::select_exec_backend(
+        args.image.is_some(),
+        &network_policy,
+        args.hypervisor.as_deref(),
+    )?
+    .name()
+    .to_string();
     // The closure below moves `admit_backend`; keep a copy for the receipt's
     // honest per-backend enforcement tier.
     let receipt_backend = admit_backend.clone();
@@ -683,7 +697,11 @@ fn build_exec_request(
     for kv in &args.env {
         env_pairs.push(parse_env_pair(kv)?);
     }
-    let selected_backend = crate::exec::select_exec_backend(image_ref.is_some(), &network_policy)?;
+    let selected_backend = crate::exec::select_exec_backend(
+        image_ref.is_some(),
+        &network_policy,
+        args.hypervisor.as_deref(),
+    )?;
     let mut effective_env =
         oci_vsock_proxy_env_for_backend(&selected_backend, image_ref.is_some(), &network_policy);
     effective_env.extend(env_pairs);
@@ -820,6 +838,7 @@ fn build_exec_request(
         warm_pool_size: args.warm_pool_size,
         stdin: args.stdin,
         healthcheck: args.healthcheck,
+        hypervisor: args.hypervisor,
     })
 }
 
@@ -1075,9 +1094,13 @@ impl RunPreflightSummary {
         let policy = super::shared::resolve_run_network_policy(args.net, &args.allow_host)?;
         let backend = match backend_override {
             Some(backend) => backend.to_string(),
-            None => crate::exec::select_exec_backend(args.image.is_some(), &policy)?
-                .name()
-                .to_string(),
+            None => crate::exec::select_exec_backend(
+                args.image.is_some(),
+                &policy,
+                args.hypervisor.as_deref(),
+            )?
+            .name()
+            .to_string(),
         };
         let receipt_input = ReceiptInput::from_run_args(args, &backend)?;
 
@@ -1530,6 +1553,21 @@ mod tests {
     }
 
     #[test]
+    fn dry_run_preflight_honors_requested_hypervisor() {
+        // A `RunArgs` carrying `--hypervisor libkrun` (as `machine run` threads
+        // it via `into_run_args`) must make the dry-run receipt's resolved
+        // backend agree — the same `select_exec_backend` call the admit/build/
+        // boot sites use. Deny-all policy reports a uniform "flow-drop" label
+        // regardless of backend, so use an allow-list posture (which is
+        // `<backend>:l4-host-port`) to make the resolved backend observable.
+        let mut args = run_args(RunProfile::Standard);
+        args.allow_host = vec!["a.com".into()];
+        args.hypervisor = Some("libkrun".to_string());
+        let s = RunPreflightSummary::from_args(&args).expect("preflight");
+        assert_eq!(s.invocation.egress_enforcement, "libkrun:l4-host-port");
+    }
+
+    #[test]
     fn receipt_records_resolved_posture() {
         let mut args = run_args(RunProfile::Standard);
         args.allow_host = vec!["api.example.com".into()];
@@ -1688,6 +1726,7 @@ mod tests {
             ack_divergence: Vec::new(),
             stdin: Vec::new(),
             healthcheck: None,
+            hypervisor: None,
         }
     }
 

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -554,6 +554,7 @@ mod tests {
             ack_divergence: Vec::new(),
             stdin: Vec::new(),
             healthcheck: None,
+            hypervisor: None,
         }
     }
 

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -373,13 +373,21 @@ pub struct ExecRequest {
     /// Recorded liveness declaration (phase A: presence only). Persisted with a
     /// persistent machine so it survives + is inspectable; not yet probed.
     pub healthcheck: Option<mvm_protocol::ir::HealthCheck>,
+    /// Requested workload hypervisor (from `--hypervisor`), or `None` to
+    /// auto-detect. Kept here so `run_inner`'s backend selection agrees with the
+    /// admit/build sites that read it off `RunArgs`.
+    pub hypervisor: Option<String>,
 }
 
 pub(crate) fn select_exec_backend(
     image_requested: bool,
     network_policy: &mvm_core::network_policy::NetworkPolicy,
+    requested: Option<&str>,
 ) -> Result<AnyBackend> {
-    let backend_override = explicit_hypervisor_override();
+    // CLI `--hypervisor` wins over the MVM_HYPERVISOR/MVM_BACKEND env override.
+    let backend_override = requested
+        .and_then(normalize_backend_override)
+        .or_else(explicit_hypervisor_override);
     let backend_name = select_backend_name_for_egress(
         backend_override.as_deref(),
         image_requested,
@@ -919,7 +927,11 @@ fn run_inner(
     posture: Option<&PostureSink>,
     runtime_source_policy_sink: Option<&RuntimeSourcePolicySink>,
 ) -> Result<Either<i32, ExecOutput>> {
-    let backend = select_exec_backend(request_uses_vsock_proxy_backend(&req), &req.network_policy)?;
+    let backend = select_exec_backend(
+        request_uses_vsock_proxy_backend(&req),
+        &req.network_policy,
+        req.hypervisor.as_deref(),
+    )?;
 
     // Phase timing (off unless `MVM_PHASE_TIMING` is set): capture a
     // host-monotonic mark at each run seam, then emit a one-line breakdown
@@ -1896,6 +1908,7 @@ pub fn dispatch_in_session(
         network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
         stdin: Vec::new(),
         healthcheck: None,
+        hypervisor: None,
     };
     let wrapper = build_guest_wrapper(&req, &[]);
     let transport = vsock_transport::for_vm(&vm.vm_name)?;
@@ -2006,6 +2019,77 @@ mod tests {
         );
         assert_eq!(hc.interval_secs, 10);
         assert_eq!(build_healthcheck(None, 30, 5, 3, 0), None);
+    }
+
+    #[test]
+    fn select_exec_backend_requested_flag_selects_backend() {
+        let deny_all = mvm_core::network_policy::NetworkPolicy::deny_all();
+        let backend = select_exec_backend(false, &deny_all, Some("libkrun"))
+            .expect("libkrun resolves without probing availability (image not requested)");
+        assert_eq!(backend.name(), "libkrun");
+
+        let backend = select_exec_backend(false, &deny_all, Some("hvf"))
+            .expect("hvf resolves without probing availability (image not requested)");
+        assert_eq!(backend.name(), "hvf");
+    }
+
+    #[test]
+    fn select_exec_backend_none_with_no_env_falls_to_auto_detect() {
+        let saved_hv = std::env::var_os("MVM_HYPERVISOR");
+        let saved_be = std::env::var_os("MVM_BACKEND");
+        // SAFETY: test-local env mutation, restored before returning.
+        unsafe {
+            std::env::remove_var("MVM_HYPERVISOR");
+            std::env::remove_var("MVM_BACKEND");
+        }
+        let deny_all = mvm_core::network_policy::NetworkPolicy::deny_all();
+        let backend =
+            select_exec_backend(false, &deny_all, None).expect("auto-detect always resolves");
+        assert_eq!(backend.name(), AnyBackend::auto_select().name());
+        // SAFETY: restore prior values.
+        unsafe {
+            match saved_hv {
+                Some(v) => std::env::set_var("MVM_HYPERVISOR", v),
+                None => std::env::remove_var("MVM_HYPERVISOR"),
+            }
+            match saved_be {
+                Some(v) => std::env::set_var("MVM_BACKEND", v),
+                None => std::env::remove_var("MVM_BACKEND"),
+            }
+        }
+    }
+
+    /// The CLI `--hypervisor` flag (the `requested` param) wins over a
+    /// conflicting `MVM_HYPERVISOR` env override — the admit/build/boot call
+    /// sites must all resolve to the same backend as what was requested.
+    #[test]
+    fn select_exec_backend_requested_flag_beats_conflicting_env() {
+        let saved_hv = std::env::var_os("MVM_HYPERVISOR");
+        let saved_be = std::env::var_os("MVM_BACKEND");
+        // SAFETY: test-local env mutation, restored before returning.
+        unsafe {
+            std::env::remove_var("MVM_BACKEND");
+            std::env::set_var("MVM_HYPERVISOR", "qemu");
+        }
+        let deny_all = mvm_core::network_policy::NetworkPolicy::deny_all();
+        let backend = select_exec_backend(false, &deny_all, Some("libkrun"))
+            .expect("libkrun resolves without probing availability (image not requested)");
+        assert_eq!(
+            backend.name(),
+            "libkrun",
+            "the requested flag must win over MVM_HYPERVISOR=qemu"
+        );
+        // SAFETY: restore prior values.
+        unsafe {
+            match saved_hv {
+                Some(v) => std::env::set_var("MVM_HYPERVISOR", v),
+                None => std::env::remove_var("MVM_HYPERVISOR"),
+            }
+            match saved_be {
+                Some(v) => std::env::set_var("MVM_BACKEND", v),
+                None => std::env::remove_var("MVM_BACKEND"),
+            }
+        }
     }
 
     fn fixture_network_tunnel() -> mvm_core::protocol::network_tunnel::TunnelRuntimeConfig {
@@ -2223,6 +2307,7 @@ mod tests {
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
             stdin: Vec::new(),
             healthcheck: None,
+            hypervisor: None,
         };
         assert_eq!(req.target_command(), "exec 'uname' '-a'");
     }
@@ -2246,6 +2331,7 @@ mod tests {
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
             stdin: Vec::new(),
             healthcheck: None,
+            hypervisor: None,
         };
         let script = build_guest_wrapper(&req, &[]);
         assert!(script.starts_with("set -e\n"));
@@ -2277,6 +2363,7 @@ mod tests {
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
             stdin: Vec::new(),
             healthcheck: None,
+            hypervisor: None,
         };
         let script = build_guest_wrapper(&req, &["mvm-extra-0".to_string()]);
         assert!(script.contains("mkdir -p '/g'"));
@@ -2308,6 +2395,7 @@ mod tests {
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
             stdin: Vec::new(),
             healthcheck: None,
+            hypervisor: None,
         };
         let script = build_guest_wrapper(&req, &["mvm-extra-0".to_string()]);
         // RW mount is unqualified — no `-o ro`.
@@ -2337,6 +2425,7 @@ mod tests {
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
             stdin: Vec::new(),
             healthcheck: None,
+            hypervisor: None,
         };
 
         let pty = pty_console_request(&req, &[], "set -e\nexec '/bin/sh'\n".to_string());
@@ -2368,6 +2457,7 @@ mod tests {
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
             stdin: Vec::new(),
             healthcheck: None,
+            hypervisor: None,
         };
         let wrapper = build_guest_wrapper(&req, &["mvm-extra-0".to_string()]);
 
@@ -2396,6 +2486,7 @@ mod tests {
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
             stdin: Vec::new(),
             healthcheck: None,
+            hypervisor: None,
         };
         let wrapper = build_guest_wrapper(&req, &[]);
 
@@ -2631,6 +2722,7 @@ mod tests {
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
             stdin: Vec::new(),
             healthcheck: None,
+            hypervisor: None,
         };
         assert_eq!(req.target_command(), "exec 'python' '-m' 'x'");
     }
@@ -2661,6 +2753,7 @@ mod tests {
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
             stdin: Vec::new(),
             healthcheck: None,
+            hypervisor: None,
         };
         let script = build_guest_wrapper(&req, &[]);
         // Env from entrypoint exported.
@@ -2702,6 +2795,7 @@ mod tests {
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
             stdin: Vec::new(),
             healthcheck: None,
+            hypervisor: None,
         };
         let script = build_guest_wrapper(&req, &[]);
         assert!(!script.contains("cd "));


### PR DESCRIPTION
## What

Transient `mvmctl machine run --hypervisor X <cmd>` silently ignored the flag and ran the default backend; only the persistent `-d`/`--name` form and the `MVM_HYPERVISOR`/`MVM_BACKEND` env vars honored it.

Two causes: `MachineRunArgs::into_run_args()` dropped the `hypervisor` field, and `select_exec_backend` resolved the transient backend only from the env override, never the CLI flag.

## Fix

Thread the flag `RunArgs.hypervisor → Args → ExecRequest.hypervisor → select_exec_backend(requested)`, with the CLI flag taking precedence over the env override (`requested.and_then(normalize).or_else(env)`). All four transient backend-selection sites (admit, build, dry-run, boot) read the same value, so the admitted plan's backend and the boot backend agree. Non-transient callers (MCP, run-plan) pass `None` and keep auto-detect/env behavior.

## Tests

Parse→`into_run_args` threading, no-flag→None, dry-run receipt honors the flag, and selector precedence (requested beats a conflicting `MVM_HYPERVISOR`). `cargo nextest -p mvm-cli` 1438 pass; fmt/clippy/check-no-spec-refs clean.

Followup F1 of the vsock-egress convergence (plan 258 / #1771).