### PR TITLE
feat(fs): add portable snapshot store

### DIFF
--- a/crates/mvm-fs/src/clone.rs
+++ b/crates/mvm-fs/src/clone.rs
@@ -1,0 +1,359 @@
+//! Reflink (copy-on-write) file cloning primitives.
+//!
+//! APFS Copy-on-Write for Apple Container templates. Cloning a 1 GiB
+//! ext4 rootfs via `clonefile(2)` on macOS takes ~constant time regardless
+//! of file size, since APFS only writes new metadata and shares the
+//! underlying blocks until either side writes. The same shape works on
+//! Linux via the `FICLONE` ioctl on btrfs/xfs/overlayfs — those
+//! filesystems also have block-level CoW. ext4 returns `EOPNOTSUPP` (the
+//! default on the Linux host / builder VM), so the caller falls back to a
+//! regular byte copy.
+//!
+//! The cloned ext4 is the L3 rootfs; per-instance writes diverge into the
+//! clone's blocks and never touch the template.
+
+#![allow(unsafe_code)]
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// What strategy [`reflink_or_copy`] used to materialize the destination.
+///
+/// `Reflink` is the fast path (O(1) metadata operation, blocks shared
+/// until written). `Copied` is the byte-copy fallback that fires when the
+/// filesystem doesn't support reflinks (ext4 without explicit support,
+/// NTFS on Windows, network mounts, cross-volume copies on APFS, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloneStrategy {
+    /// Filesystem-level CoW clone (`clonefile(2)` on macOS,
+    /// `FICLONE` ioctl on Linux btrfs/xfs).
+    Reflink,
+    /// Byte-by-byte copy (slow path, no CoW).
+    Copied,
+}
+
+/// Reflink-clone `src` to `dst`. Errors with `EOPNOTSUPP` if the
+/// underlying filesystem does not support reflinks.
+///
+/// Use [`reflink_or_copy`] if you want to fall back to a regular copy
+/// instead of erroring.
+///
+/// On macOS: `libc::clonefile(src, dst, 0)`.
+/// On Linux: `ioctl(dst_fd, FICLONE, src_fd)` after creating `dst`.
+/// On other platforms: always returns `EOPNOTSUPP`.
+pub fn reflink_or_err(src: &Path, dst: &Path) -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::clonefile_path(src, dst)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        linux::ficlone(src, dst)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = (src, dst);
+        Err(io::Error::from_raw_os_error(libc_eopnotsupp()))
+    }
+}
+
+/// Reflink-clone `src` to `dst`, falling back to a byte copy if the
+/// filesystem doesn't support reflinks. Returns the strategy used so
+/// callers can log the fast/slow path for performance analysis.
+///
+/// Always succeeds modulo I/O errors (missing source, permission denied,
+/// disk full, etc.).
+pub fn reflink_or_copy(src: &Path, dst: &Path) -> io::Result<CloneStrategy> {
+    match reflink_or_err(src, dst) {
+        Ok(()) => Ok(CloneStrategy::Reflink),
+        Err(e) if is_unsupported(&e) => {
+            std::fs::copy(src, dst)?;
+            Ok(CloneStrategy::Copied)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn is_unsupported(e: &io::Error) -> bool {
+    // ENOTSUP and EOPNOTSUPP are the same value on macOS/Linux but
+    // we check both names defensively. EXDEV indicates cross-device
+    // (cross-volume) — APFS CoW requires same volume, btrfs/xfs FICLONE
+    // requires same filesystem instance. ENOTTY is what the kernel
+    // returns when the underlying filesystem doesn't implement the
+    // FICLONE ioctl at all — ext4 without reflink support (the
+    // default on stock Ubuntu, including the GitHub Actions Linux
+    // runner image) returns this rather than EOPNOTSUPP.
+    matches!(
+        e.raw_os_error(),
+        Some(libc::ENOTSUP) | Some(libc::EXDEV) | Some(libc::EINVAL) | Some(libc::ENOTTY)
+    )
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::ffi::CString;
+    use std::io;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::Path;
+
+    // `clonefile(const char *src, const char *dst, uint32_t flags)` from
+    // `<sys/clonefile.h>`. Available since macOS 10.12.
+    unsafe extern "C" {
+        fn clonefile(src: *const libc::c_char, dst: *const libc::c_char, flags: u32)
+        -> libc::c_int;
+    }
+
+    pub(super) fn clonefile_path(src: &Path, dst: &Path) -> io::Result<()> {
+        let src_c = CString::new(src.as_os_str().as_bytes())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        let dst_c = CString::new(dst.as_os_str().as_bytes())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        // SAFETY: both pointers come from CStrings that outlive the call.
+        // Flags = 0 means default (clone metadata + data links, no
+        // symlink follow).
+        let rc = unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::fs::OpenOptions;
+    use std::io;
+    use std::os::fd::AsRawFd;
+    use std::path::Path;
+
+    // ioctl(dst, FICLONE, src) — see <linux/fs.h>. Encoded the same way
+    // across architectures: _IOW('f', 9, int).
+    const FICLONE: libc::c_ulong = 0x4020_9409;
+
+    pub(super) fn ficlone(src: &Path, dst: &Path) -> io::Result<()> {
+        let src_fd = OpenOptions::new().read(true).open(src)?;
+        let dst_fd = OpenOptions::new().write(true).create_new(true).open(dst)?;
+        // SAFETY: both file descriptors are owned and valid for the
+        // duration of the ioctl. FICLONE atomically clones extents from
+        // src into dst (which must be empty / freshly created).
+        let rc = unsafe { libc::ioctl(dst_fd.as_raw_fd(), FICLONE as _, src_fd.as_raw_fd()) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            // Clean up the empty destination so the caller's copy
+            // fallback can recreate it without EEXIST.
+            let err = io::Error::last_os_error();
+            drop(dst_fd);
+            let _ = std::fs::remove_file(dst);
+            Err(err)
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn libc_eopnotsupp() -> i32 {
+    libc::ENOTSUP
+}
+
+/// Recursively clone a directory tree from `src` to `dst` using reflink
+/// where possible, falling back to byte copies otherwise.
+///
+/// Directories are created, regular files are cloned with
+/// [`reflink_or_copy`], and symlinks are recreated with the same target.
+/// Other file types (devices, FIFOs, sockets) are skipped because they
+/// cannot be meaningfully snapshotted as regular files.
+///
+/// `dst` must not already exist; its parent is created if necessary.
+/// Returns the aggregate strategy: `Reflink` only if every regular file
+/// was reflinked; `Copied` if any file fell back.
+pub fn reflink_or_copy_dir(src: &Path, dst: &Path) -> io::Result<CloneStrategy> {
+    if !src.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("source is not a directory: {}", src.display()),
+        ));
+    }
+
+    std::fs::create_dir_all(dst.parent().unwrap_or(dst))?;
+
+    fn walk(current_src: &Path, current_dst: &Path, saw_copy: &mut bool) -> io::Result<()> {
+        let meta = current_src.symlink_metadata()?;
+        let file_type = meta.file_type();
+
+        if file_type.is_dir() {
+            std::fs::create_dir_all(current_dst)?;
+            for entry in std::fs::read_dir(current_src)? {
+                let entry = entry?;
+                walk(
+                    &entry.path(),
+                    &current_dst.join(entry.file_name()),
+                    saw_copy,
+                )?;
+            }
+        } else if file_type.is_file() {
+            let strategy = reflink_or_copy(current_src, current_dst)?;
+            if strategy == CloneStrategy::Copied {
+                *saw_copy = true;
+            }
+        } else if file_type.is_symlink() {
+            let target = std::fs::read_link(current_src)?;
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(&target, current_dst)?;
+            #[cfg(not(unix))]
+            {
+                let _ = (target, current_dst);
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "symlink cloning is only supported on unix",
+                ));
+            }
+        }
+        // Non-regular files (devices, FIFOs, sockets) are silently skipped
+        // because they have no stable on-disk identity.
+
+        Ok(())
+    }
+
+    let mut saw_copy = false;
+    walk(src, dst, &mut saw_copy)?;
+
+    if saw_copy {
+        Ok(CloneStrategy::Copied)
+    } else {
+        Ok(CloneStrategy::Reflink)
+    }
+}
+
+/// Compute a content-addressed path for a snapshot file within a store
+/// rooted at `store_root`.
+///
+/// The id is opaque to this helper; callers produce it from a manifest
+/// hash or another stable identifier.
+pub fn snapshot_path(store_root: &Path, id: &str) -> PathBuf {
+    store_root.join(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_errors_classify_correctly() {
+        let enotsup = io::Error::from_raw_os_error(libc::ENOTSUP);
+        let exdev = io::Error::from_raw_os_error(libc::EXDEV);
+        let einval = io::Error::from_raw_os_error(libc::EINVAL);
+        let enotty = io::Error::from_raw_os_error(libc::ENOTTY);
+        let other = io::Error::from_raw_os_error(libc::EACCES);
+        assert!(is_unsupported(&enotsup));
+        assert!(is_unsupported(&exdev));
+        assert!(is_unsupported(&einval));
+        assert!(is_unsupported(&enotty));
+        assert!(!is_unsupported(&other));
+    }
+
+    #[test]
+    fn reflink_or_copy_produces_byte_equal_destination() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("src.bin");
+        let dst = dir.path().join("dst.bin");
+        std::fs::write(&src, b"hello snapshot").unwrap();
+
+        let strategy = reflink_or_copy(&src, &dst).expect("clone or copy");
+        assert!(matches!(
+            strategy,
+            CloneStrategy::Reflink | CloneStrategy::Copied
+        ));
+        assert_eq!(std::fs::read(&dst).unwrap(), b"hello snapshot");
+    }
+
+    #[test]
+    fn reflink_or_copy_refuses_existing_destination() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("src.bin");
+        let dst = dir.path().join("dst.bin");
+        std::fs::write(&src, b"src content").unwrap();
+        std::fs::write(&dst, b"existing").unwrap();
+
+        let result = reflink_or_copy(&src, &dst);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn reflink_or_copy_dir_clones_tree() {
+        let src_dir = tempfile::tempdir().expect("src tempdir");
+        let dst_dir = tempfile::tempdir().expect("dst tempdir");
+
+        std::fs::create_dir(src_dir.path().join("subdir")).unwrap();
+        std::fs::write(src_dir.path().join("top.txt"), b"top").unwrap();
+        std::fs::write(src_dir.path().join("subdir").join("nested.txt"), b"nested").unwrap();
+
+        let dst = dst_dir.path().join("clone");
+        let strategy = reflink_or_copy_dir(src_dir.path(), &dst).expect("clone dir");
+        assert!(matches!(
+            strategy,
+            CloneStrategy::Reflink | CloneStrategy::Copied
+        ));
+
+        assert_eq!(std::fs::read(dst.join("top.txt")).unwrap(), b"top");
+        assert_eq!(
+            std::fs::read(dst.join("subdir").join("nested.txt")).unwrap(),
+            b"nested"
+        );
+
+        // Mutating the clone must not affect the source.
+        std::fs::write(dst.join("top.txt"), b"mutated").unwrap();
+        assert_eq!(
+            std::fs::read(src_dir.path().join("top.txt")).unwrap(),
+            b"top"
+        );
+    }
+
+    /// On macOS with an APFS-backed `TMPDIR` (the default), `clonefile`
+    /// always works. The test asserts the fast path was taken and that
+    /// writes to the clone don't tamper the source.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_clonefile_creates_independent_copy() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let src_path = dir.path().join("src.bin");
+        let dst_path = dir.path().join("dst.bin");
+        let payload: Vec<u8> = (0..1_048_576).map(|i| (i % 251) as u8).collect();
+        std::fs::write(&src_path, &payload).expect("write src");
+
+        let strategy =
+            reflink_or_copy(&src_path, &dst_path).expect("reflink_or_copy on macOS APFS tempdir");
+        assert_eq!(strategy, CloneStrategy::Reflink);
+
+        let cloned = std::fs::read(&dst_path).expect("read clone");
+        assert_eq!(cloned, payload, "clone must byte-equal source");
+
+        std::fs::write(&dst_path, b"clone-only payload").expect("write clone");
+        let src_after = std::fs::read(&src_path).expect("re-read src");
+        assert_eq!(
+            src_after, payload,
+            "writing to clone must not affect source"
+        );
+    }
+
+    /// `reflink_or_copy` falls back to a byte copy when the source path
+    /// can be read but the FS doesn't support reflinks. We can't easily
+    /// force EOPNOTSUPP on macOS APFS (it always works), so this test
+    /// exercises the *Copied* path on Linux ext4 (where `FICLONE`
+    /// returns EOPNOTSUPP) and is skipped elsewhere.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_falls_back_to_copy_on_ext4() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let src_path = dir.path().join("src.bin");
+        let dst_path = dir.path().join("dst.bin");
+        std::fs::write(&src_path, b"hello").expect("write src");
+        let strategy = reflink_or_copy(&src_path, &dst_path).expect("clone or copy");
+        assert!(matches!(
+            strategy,
+            CloneStrategy::Reflink | CloneStrategy::Copied
+        ));
+        let read = std::fs::read(&dst_path).expect("read dst");
+        assert_eq!(read, b"hello");
+    }
+}

--- a/crates/mvm-fs/src/lib.rs
+++ b/crates/mvm-fs/src/lib.rs
@@ -1,4 +1,4 @@
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 //! Filesystem + image materialization for mvm.
 //!
 //! - [`oci`]: OCI distribution client — registry resolution, manifest/layer
@@ -11,7 +11,17 @@
 //!   verity-sealed ext4 rootfs image.
 //! - [`overlay`]: runtime-overlay cache resolution — pick and validate the
 //!   verity-sealed overlay artifact set for one `(version, arch)`.
+//! - [`clone`]: reflink (copy-on-write) file/directory cloning primitives
+//!   used by the runtime to materialize per-instance rootfs copies.
+//! - [`snapshot_store`]: content-addressed snapshot persistence used by the
+//!   warm-parent pool.
+//!
+//! The crate-level lint is `deny(unsafe_code)` rather than `forbid` so that
+//! the [`clone`] module can use the small, platform-specific unsafe blocks
+//! required to invoke `clonefile(2)` and `FICLONE`. Everywhere else in this
+//! crate remains unsafe-free.
 
+pub mod clone;
 pub mod ext4;
 pub mod oci;
 /// OCI layer unpack to a staging rootfs directory. Handles whiteouts,
@@ -22,3 +32,4 @@ pub mod oci;
 pub mod oci_to_rootfs;
 pub mod overlay;
 pub mod rootfs;
+pub mod snapshot_store;

--- a/crates/mvm-fs/src/snapshot_store.rs
+++ b/crates/mvm-fs/src/snapshot_store.rs
@@ -1,0 +1,421 @@
+//! Content-addressed snapshot store.
+//!
+//! A snapshot is an immutable, content-addressed on-disk artifact that
+//! can be cheaply materialized elsewhere via reflink CoW clones. The
+//! store is intentionally simple — a directory on a reflink-capable
+//! filesystem where each snapshot lives under its opaque id.
+//!
+//! Two layouts are supported:
+//!
+//! * **Directory snapshot** — the source path was a directory; the store
+//!   keeps it as `<root>/<id>/...` and materializes it with a recursive
+//!   directory clone.
+//! * **File snapshot** — the source path was a regular file; the store
+//!   keeps it as `<root>/<id>/data` with a `.mvm-snapshot-is-file`
+//!   marker, and materializes it as a single file.
+//!
+//! This is the persistence layer behind the warm-parent pool: a paused
+//! microVM's rootfs (and, later, memory snapshot) is stored once and then
+//! reflink-cloned into each child's per-instance path.
+
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::clone::{CloneStrategy, reflink_or_copy, reflink_or_copy_dir};
+
+const FILE_MARKER: &str = ".mvm-snapshot-is-file";
+const META_FILE: &str = ".mvm-snapshot-meta";
+
+/// Opaque identifier for a snapshot stored in a [`SnapshotStore`].
+///
+/// The `id` is the filesystem directory name under the store root. An
+/// optional `digest` can carry a content hash (e.g., SHA-256 of the
+/// serialized snapshot) used by callers for attestation or cache keys.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotId {
+    id: String,
+    digest: Option<String>,
+}
+
+impl SnapshotId {
+    /// Create a snapshot id with no digest.
+    ///
+    /// The id must not contain path separators.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            digest: None,
+        }
+    }
+
+    /// Create a snapshot id with an associated content digest.
+    pub fn with_digest(id: impl Into<String>, digest: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            digest: Some(digest.into()),
+        }
+    }
+
+    /// The opaque store id.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// The optional content digest supplied at creation time.
+    pub fn digest(&self) -> Option<&str> {
+        self.digest.as_deref()
+    }
+}
+
+impl fmt::Display for SnapshotId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.id)
+    }
+}
+
+impl From<String> for SnapshotId {
+    fn from(id: String) -> Self {
+        Self::new(id)
+    }
+}
+
+impl From<&str> for SnapshotId {
+    fn from(id: &str) -> Self {
+        Self::new(id)
+    }
+}
+
+/// A content-addressed store of immutable snapshots.
+///
+/// Implementations must be thread-safe; callers will use the store from
+/// async worker threads.
+pub trait SnapshotStore {
+    /// Persist `source` as snapshot `id`.
+    ///
+    /// `source` may be a regular file or a directory. The implementation
+    /// must preserve the distinction so that [`SnapshotStore::materialize`]
+    /// materializes the same shape.
+    ///
+    /// Returns `AlreadyExists` if a snapshot with this id already exists.
+    fn create(&self, id: &SnapshotId, source: &Path) -> io::Result<()>;
+
+    /// Materialize snapshot `id` at `dst` using reflink CoW when possible,
+    /// falling back to byte copies otherwise.
+    ///
+    /// `dst` must not already exist. Its parent is created if necessary.
+    fn materialize(&self, id: &SnapshotId, dst: &Path) -> io::Result<CloneStrategy>;
+
+    /// Remove snapshot `id` and reclaim its storage.
+    ///
+    /// Returns `NotFound` if the snapshot does not exist.
+    fn remove(&self, id: &SnapshotId) -> io::Result<()>;
+
+    /// List the ids of all snapshots currently in the store.
+    fn list(&self) -> io::Result<Vec<SnapshotId>>;
+}
+
+/// Filesystem-backed [`SnapshotStore`] rooted at a directory.
+///
+/// The store creates the root directory lazily on first access. It is
+/// safe to share the same root between processes as long as the
+/// filesystem provides atomic create-unlink semantics for the id
+/// directories.
+#[derive(Debug, Clone)]
+pub struct FsSnapshotStore {
+    root: PathBuf,
+}
+
+impl FsSnapshotStore {
+    /// Open or create a snapshot store at `root`.
+    pub fn new(root: impl AsRef<Path>) -> io::Result<Self> {
+        let root = root.as_ref().to_path_buf();
+        fs::create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+
+    /// The store root path.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn snapshot_dir(&self, id: &SnapshotId) -> PathBuf {
+        self.root.join(&id.id)
+    }
+
+    fn ensure_id_is_safe(id: &str) -> io::Result<()> {
+        if id.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "snapshot id must not be empty",
+            ));
+        }
+        if id.contains('/') || id.contains('\\') || id.contains('\0') {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("snapshot id contains path separator: {id}"),
+            ));
+        }
+        Ok(())
+    }
+
+    fn write_meta(&self, dir: &Path, id: &SnapshotId) -> io::Result<()> {
+        if let Some(digest) = &id.digest {
+            let meta = format!("digest={digest}\n");
+            fs::write(dir.join(META_FILE), meta)?;
+        }
+        Ok(())
+    }
+
+    fn read_meta(&self, dir: &Path, id: &str) -> SnapshotId {
+        let meta_path = dir.join(META_FILE);
+        let digest = fs::read_to_string(&meta_path)
+            .ok()
+            .and_then(|contents| {
+                contents
+                    .lines()
+                    .find(|line| line.starts_with("digest="))
+                    .map(|line| line.strip_prefix("digest=").unwrap_or("").to_string())
+            })
+            .filter(|d| !d.is_empty());
+        if let Some(digest) = digest {
+            SnapshotId::with_digest(id, digest)
+        } else {
+            SnapshotId::new(id)
+        }
+    }
+}
+
+impl SnapshotStore for FsSnapshotStore {
+    fn create(&self, id: &SnapshotId, source: &Path) -> io::Result<()> {
+        Self::ensure_id_is_safe(&id.id)?;
+        let dir = self.snapshot_dir(id);
+        if dir.exists() {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("snapshot {} already exists", id.id),
+            ));
+        }
+
+        fs::create_dir_all(&dir)?;
+
+        let meta = fs::symlink_metadata(source)?;
+        if meta.is_dir() {
+            // Directory snapshot: store contents directly under dir/.
+            for entry in fs::read_dir(source)? {
+                let entry = entry?;
+                let src = entry.path();
+                let dst = dir.join(entry.file_name());
+                if entry.file_type()?.is_dir() {
+                    reflink_or_copy_dir(&src, &dst)?;
+                } else if entry.file_type()?.is_file() {
+                    reflink_or_copy(&src, &dst)?;
+                } else if entry.file_type()?.is_symlink() {
+                    let target = fs::read_link(&src)?;
+                    #[cfg(unix)]
+                    std::os::unix::fs::symlink(&target, &dst)?;
+                    #[cfg(not(unix))]
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        "symlink snapshot is only supported on unix",
+                    ));
+                }
+            }
+        } else if meta.is_file() {
+            // File snapshot: store under dir/data with a marker.
+            let data_path = dir.join("data");
+            reflink_or_copy(source, &data_path)?;
+            fs::write(dir.join(FILE_MARKER), b"")?;
+        } else {
+            let _ = fs::remove_dir_all(&dir);
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "snapshot source must be a regular file or directory: {}",
+                    source.display()
+                ),
+            ));
+        }
+
+        self.write_meta(&dir, id)?;
+        Ok(())
+    }
+
+    fn materialize(&self, id: &SnapshotId, dst: &Path) -> io::Result<CloneStrategy> {
+        Self::ensure_id_is_safe(&id.id)?;
+        let dir = self.snapshot_dir(id);
+        if !dir.exists() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("snapshot {} not found", id.id),
+            ));
+        }
+
+        if dir.join(FILE_MARKER).exists() {
+            let data_path = dir.join("data");
+            reflink_or_copy(&data_path, dst)
+        } else {
+            reflink_or_copy_dir(&dir, dst)
+        }
+    }
+
+    fn remove(&self, id: &SnapshotId) -> io::Result<()> {
+        Self::ensure_id_is_safe(&id.id)?;
+        let dir = self.snapshot_dir(id);
+        if !dir.exists() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("snapshot {} not found", id.id),
+            ));
+        }
+        fs::remove_dir_all(&dir)
+    }
+
+    fn list(&self) -> io::Result<Vec<SnapshotId>> {
+        if !self.root.exists() {
+            return Ok(Vec::new());
+        }
+        let mut ids = Vec::new();
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                let id = entry.file_name().to_string_lossy().to_string();
+                if id.starts_with('.') {
+                    continue;
+                }
+                ids.push(self.read_meta(&entry.path(), &id));
+            }
+        }
+        Ok(ids)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_snapshot_roundtrip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+        let source = tmp.path().join("golden.ext4");
+        fs::write(&source, b"golden rootfs").unwrap();
+
+        let id = SnapshotId::with_digest("snap-1", "sha256:abc123");
+        store.create(&id, &source).expect("create");
+
+        let dst = tmp.path().join("instance.ext4");
+        let strategy = store.materialize(&id, &dst).expect("materialize");
+        assert!(matches!(
+            strategy,
+            CloneStrategy::Reflink | CloneStrategy::Copied
+        ));
+        assert_eq!(fs::read(&dst).unwrap(), b"golden rootfs");
+
+        let listed = store.list().expect("list");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id(), "snap-1");
+        assert_eq!(listed[0].digest(), Some("sha256:abc123"));
+    }
+
+    #[test]
+    fn directory_snapshot_roundtrip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+        let source = tmp.path().join("rootfs-dir");
+        fs::create_dir(&source).unwrap();
+        fs::write(source.join("vmlinuz"), b"kernel").unwrap();
+
+        let id = SnapshotId::new("dir-snap");
+        store.create(&id, &source).expect("create");
+
+        let dst = tmp.path().join("instance-dir");
+        let strategy = store.materialize(&id, &dst).expect("materialize");
+        assert!(matches!(
+            strategy,
+            CloneStrategy::Reflink | CloneStrategy::Copied
+        ));
+        assert_eq!(fs::read(dst.join("vmlinuz")).unwrap(), b"kernel");
+    }
+
+    #[test]
+    fn create_is_idempotent_only_on_distinct_ids() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+        let source = tmp.path().join("file.bin");
+        fs::write(&source, b"v1").unwrap();
+
+        let id = SnapshotId::new("same");
+        store.create(&id, &source).expect("first create");
+        let result = store.create(&id, &source);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn remove_deletes_snapshot_and_fails_when_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+        let source = tmp.path().join("file.bin");
+        fs::write(&source, b"data").unwrap();
+
+        let id = SnapshotId::new("gone");
+        store.create(&id, &source).expect("create");
+        assert!(store.snapshot_dir(&id).exists());
+
+        store.remove(&id).expect("remove");
+        assert!(!store.snapshot_dir(&id).exists());
+
+        assert!(store.remove(&id).is_err());
+    }
+
+    #[test]
+    fn materialize_missing_snapshot_fails() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+        let id = SnapshotId::new("missing");
+        let dst = tmp.path().join("dst");
+        assert!(store.materialize(&id, &dst).is_err());
+    }
+
+    #[test]
+    fn list_is_empty_for_fresh_store() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+        assert!(store.list().expect("list").is_empty());
+    }
+
+    #[test]
+    fn file_snapshot_independence() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+        let source = tmp.path().join("file.bin");
+        fs::write(&source, b"original").unwrap();
+
+        let id = SnapshotId::new("isolated");
+        store.create(&id, &source).expect("create");
+
+        let dst = tmp.path().join("instance.bin");
+        store.materialize(&id, &dst).expect("materialize");
+
+        fs::write(&dst, b"mutated").unwrap();
+        store
+            .materialize(&id, &tmp.path().join("instance2.bin"))
+            .expect("materialize again");
+        let data = fs::read(store.snapshot_dir(&id).join("data")).unwrap();
+        assert_eq!(data, b"original");
+    }
+
+    #[test]
+    fn rejects_path_separator_in_id() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+        let source = tmp.path().join("file.bin");
+        fs::write(&source, b"x").unwrap();
+
+        let id = SnapshotId::new("../../etc/passwd");
+        assert!(store.create(&id, &source).is_err());
+        assert!(store.materialize(&id, &tmp.path().join("dst")).is_err());
+        assert!(store.remove(&id).is_err());
+    }
+}

--- a/specs/plans/255-vsock-first-snapshot-egress-adoption.md
+++ b/specs/plans/255-vsock-first-snapshot-egress-adoption.md
@@ -1,0 +1,281 @@
+# Plan 255 — Vsock-first snapshot, egress, and warm-start adoption
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Status:** Draft.
+
+## Goal
+
+Adopt the useful, externally-proven techniques identified in the prior
+competitor research while keeping the vsock seam the *only* guest↔host and
+egress boundary. The result is:
+
+- snapshot-first templates with O(1) CoW clone and fast restore;
+- a warm pool of clean paused parents that fork fresh, identity-scrubbed
+  children on demand;
+- richer, auditable egress policy on the existing typed-connector path;
+- a one-step OCI-image → template build path;
+- all of the above exposed through the `mvm-client` facade and CLI.
+
+Nothing here weakens the standing invariants: one guest is one workload,
+default-deny egress, guest sees no secrets, every egress byte crosses the
+auditable vsock seam, and the host/guest remain single binaries.
+
+## Why this plan exists
+
+The open-source competitor validates several design choices mvm is already
+moving toward: pre-baked memory snapshots, CoW storage for fast clone/restore,
+pause/resume for density, host-side L7 egress rules with credential injection,
+and an OCI-image template path. It also demonstrates some paths mvm should
+refuse: transparent TLS MITM inside the guest, reusing dirty guests across
+jobs, and a polyglot multi-process cluster stack for the local case.
+
+This plan turns that survey into a bounded execution plan. It builds on the
+simplification worktree's existing workstreams rather than replacing them:
+WS-NET supplies the consolidated vsock seam, WS-DX supplies warm-start and
+snapshot scaffolding, WS1g supplies the OCI-image build work, and WS10 supplies
+the density/kernel/memory work. This plan adds the prior-art-shaped details.
+
+## Invariants (non-negotiable)
+
+1. **Vsock is the sole boundary.** Every byte between guest and host, and every
+   egress byte to the outside world, crosses the vsock seam (or its wasm
+   equivalent host-call transport). No default NIC/TAP/bridge path, no
+   transparent TLS MITM, no host-level eBPF data plane as the default.
+2. **One guest = one workload.** A warm parent is never resumed to continue a
+   prior workload; it is forked into a fresh child with fresh identity.
+3. **Guest sees no secrets.** Credential injection happens host-side on the
+   typed-connector path only; secrets never enter guest memory, disk, or logs.
+4. **Single-binary discipline.** `mvm-hostd` and `mvm-agentd` stay one process
+   each; CLI stays a thin shell over `mvm-client`.
+
+## Product decisions
+
+1. **Adopt snapshot-first templates.** A template is a sealed base image *plus*
+   an optional ready-point memory snapshot. Running an instance means CoW-cloning
+   both and restoring from the memory snapshot when present.
+2. **Keep CoW in `mvm-fs`, lifecycle in `mvm-runtime`.** `mvm-fs` owns the
+   storage primitives (reflink clone, snapshot graph, memory-snapshot files);
+   `mvm-runtime` owns pool sizing, pause/resume, and fork identity hygiene.
+3. **Enrich egress policy, don't replace the seam.** The typed-connector path
+   gains scheme/host/method/path matching and audit levels, but the transport
+   stays vsock and the secret model stays destination-bound placeholders.
+4. **Add operational JSONL access logs alongside the chain-signed audit log.**
+   The audit log remains the tamper-evident source of truth; the JSONL log is
+   for operator observability and SIEM ingest. Secrets are redacted from both.
+5. **OCI image as a first-class template base.** `mvmctl template build --image
+   <ref>` must work without a Nix flake, while Nix flakes remain a supported
+   authoring surface.
+
+## Architecture
+
+### Storage model
+
+```text
+Template (sealed, signed, read-only)
+  ├─ rootfs volume        (verity-sealed)
+  ├─ warm overlay         (CoW, optional)
+  └─ memory snapshot      (frozen at ready point, optional)
+
+Instance = CoW clone of template rootfs + warm overlay + fresh per-instance
+           volume + memory snapshot restore (if warm) OR cold boot (if not warm)
+
+Snapshot graph (flat, content-addressed):
+  Template ──► Instance A
+         ├────► Instance B
+         └────► Snapshot S ──► Instance C
+```
+
+- Reflink/FICLONE is used when the underlying filesystem supports it; otherwise
+  a sparse copy fallback is used. The clone operation is hidden behind a
+  `SnapshotStore` trait so callers do not branch on filesystem.
+- Memory snapshots are captured at a template-defined ready point and restored
+  on instance start. Page-cache priming (ADR-025) is applied at freeze time,
+  confined to the read-only rootfs.
+
+### Warm-pool model
+
+- A pool holds **paused clean parents** per template. A parent is *not* a
+  workload; it is a factory.
+- On request, the runtime:
+  1. picks a paused parent;
+  2. CoW-clones its rootfs, overlay, and memory snapshot;
+  3. assigns a fresh `vm_id`, `boot_id`, `session_nonce`, generation id, and
+     per-instance secrets disk;
+  4. resumes the child;
+  5. reseeds entropy and resyncs the clock;
+  6. closes any stale vsock flows and re-handshakes.
+- The parent remains paused and available for the next fork.
+- Auto-pause of *running workloads* is a separate, opt-in lifecycle behavior and
+  does not conflate with warm-parent reuse.
+
+### Egress model
+
+- The generic L3 tunnel and typed connectors from WS-NET remain unchanged.
+- The typed-connector policy DTOs in `mvm-protocol` gain:
+  - `scheme`: `http` | `https`;
+  - `host` / `sni`: exact or `*.example.com` subdomain;
+  - `method`: list of HTTP methods;
+  - `path`: exact or trailing-`*` prefix;
+  - `audit_level`: `none` | `metadata` | `full`;
+  - `inject`: header + format + placeholder name (secret value stays in
+    `mvm-hostd`).
+- `mvm-hostd` enforces first-match-wins default-deny, emits structured allow /
+  deny / inject / security-event / TLS-handshake events, and writes a redacted
+  JSONL access log in addition to the chain-signed audit log.
+
+## Phases
+
+### Phase 0 — Boundary record and spec update
+
+- [ ] Update ADR-025 to add the open-source competitor as a second prior-art
+      data point: confirm the snapshot/CoW model, confirm refusal of dirty-
+      guest reuse, and note the richer egress-policy vocabulary as inspiration
+      only (no MITM adoption).
+- [ ] Add a short design note in this plan (above) or in `03-networking.md`
+      capturing the "vsock-first adoption boundary": what is adopted, what is
+      refused, and why.
+- [ ] File/update a tracking issue for Plan 255 and link it in
+      `specs/SPRINT.md` under the appropriate phase.
+
+**Acceptance gate:** ADR-025 updated and reviewed; no security claim changes;
+`check-claim-catalog` still green.
+
+### Phase 1 — Snapshot-first storage in `mvm-fs`
+
+- [ ] Introduce `SnapshotStore` trait in `mvm-fs` with operations `create`,
+      `clone`, `delete`, `list_parents`. Implementation uses reflink when
+      supported, sparse copy fallback otherwise.
+- [ ] Move memory-snapshot file handling from `mvm-runtime` into `mvm-fs` if it
+      is not already there; ensure content-addressed naming and reference
+      tracking.
+- [ ] Add unit tests for reflink/fallback roundtrips and for snapshot graph
+      integrity (deleting a child does not affect parent or siblings).
+- [ ] Add a BDD scenario: build a template with a warm snapshot, clone it into
+      an instance, and verify the instance boots faster than a cold-booted
+      equivalent.
+
+**Acceptance gate:** `cargo test -p mvm-fs` green; BDD scenario passes on Linux;
+no `mvm-fs` consumer sees filesystem-specific logic.
+
+### Phase 2 — Warm pool and fork hygiene in `mvm-runtime`
+
+- [ ] Implement paused-parent pool keyed by template id in `mvm-runtime`:
+      create, maintain, and evict parents based on TTL / memory budget.
+- [ ] Implement `fork_from_parent` that performs the CoW clone and assigns fresh
+      identity (CID, `boot_id`, `session_nonce`, generation id, per-instance
+      secrets disk).
+- [ ] Implement post-resume hygiene: entropy reseed, clock resync, vsock flow
+      teardown, and fresh handshake.
+- [ ] Add a hard guard that refuses to resume a warm parent as a workload
+      (different code path / enum variant).
+- [ ] Add unit tests for identity freshness and replay refusal; add BDD
+      scenarios for sub-second warm launch and for fork isolation.
+
+**Acceptance gate:** warm launch is sub-second on Linux and macOS; forked child
+has a new session nonce and cannot reuse an old one; clippy/test green.
+
+### Phase 3 — Egress policy enrichment (vsock seam only)
+
+- [ ] Extend typed-connector policy DTOs in `mvm-protocol` with scheme, host,
+      sni, method, path, audit_level, and inject fields. Keep the DTO
+      `#![no_std]`-clean.
+- [ ] Implement rule matching in `mvm-net`/`mvm-hostd`: first-match-wins,
+      default-deny, subdomain wildcard semantics, path-prefix semantics.
+- [ ] Implement audit-event variants: `allow`, `deny`, `security_event`,
+      `tls_handshake`, `inject_fired`. Secrets are redacted before logging.
+- [ ] Add per-host JSONL access log at `~/.mvm/logs/egress-access.jsonl`,
+      rotated, with the same redaction rules as the chain-signed audit log.
+- [ ] Add BDD scenarios for allow/deny/subdomain/path/audit-level/security-event
+      and for secret absence from both log sinks.
+
+**Acceptance gate:** all new egress-policy BDD scenarios pass; secrets are
+absent from logs and from guest memory; `mvm-protocol` stays `no_std` and
+wasm-clean; clippy/test green.
+
+### Phase 4 — OCI-image template build path
+
+- [ ] Add `mvmctl template build --image <oci-ref>` support in `mvm-cli`,
+      routed through `mvm-client` to `mvm-sdk`/`mvm-build`.
+- [ ] Reuse `mvm-fs::oci` fetch/unpack and the ext4 writer to materialize the
+      template rootfs.
+- [ ] Optionally take a ready-point snapshot to produce a warm template if
+      `--warm` is given.
+- [ ] Ensure the produced template emits the same signed `ExecutionPlan` /
+      bundle shape as the Nix path, so admission and audit are uniform.
+- [ ] Add BDD scenario: `template build --image alpine` followed by
+      `machine run --template <id>`.
+
+**Acceptance gate:** OCI-built template is signed, admits cleanly, and boots;
+Nix-built templates still work; clippy/test green.
+
+### Phase 5 — CLI / SDK surface through `mvm-client`
+
+- [ ] Add facade methods to `mvm-client`: `build_template`, `snapshot_machine`,
+      `fork_machine`, `restore_machine`, `list_warm_pool`.
+- [ ] Add CLI verbs/subcommands: `mvmctl template build --image`,
+      `mvmctl machine snapshot`, `mvmctl machine fork`,
+      `mvmctl machine restore`, `mvmctl pool ls`.
+- [ ] Ensure all new commands route through `mvm-client` and do not reach into
+      `mvm-runtime` directly (lint `check-cli-runtime-surface` must stay
+      green).
+- [ ] Update `tests/cli.rs` for help text and argument parsing of the new
+      verbs.
+
+**Acceptance gate:** `mvmctl --help` reflects new surface; `check-cli-runtime-surface` green; `tests/cli.rs` updated and passing.
+
+### Phase 6 — Docs, ADRs, and close-out
+
+- [ ] Update `03-networking.md` if egress policy details changed.
+- [ ] Update `04-security.md` if the JSONL access log or audit-level semantics
+      need documentation.
+- [ ] Update website docs (`public/src/content/docs/**`) for templates,
+      snapshots, warm start, and egress policy.
+- [ ] Tick checkboxes in this plan and in `specs/SPRINT.md`; close the tracking
+      issue.
+
+**Acceptance gate:** docs match shipped behavior; no stale `specs/` paths;
+SPRINT.md is consistent with this plan.
+
+## Verification gates
+
+No phase closes without:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace` (or `cargo nextest run --workspace`)
+- touched BDD scenarios green via `just bdd`
+- `check-claim-catalog` green (no security claim regressed)
+- `check-cli-runtime-surface` green (CLI does not bypass `mvm-client`)
+- `check-core-runtime-free` green (no async runtime leaks into the default
+  build)
+- `mvm-protocol` `wasm32-unknown-unknown` build green if policy DTOs changed
+
+## Risks
+
+- **Filesystem support for reflink.** XFS and Btrfs support it; APFS has
+  clonefile; ext4 generally does not. The fallback must be tested and fast
+  enough not to destroy the warm-start value proposition.
+- **Memory-snapshot size.** Restoring from a warm snapshot is fast only if the
+  snapshot is small or demand-faulted. Page-cache priming must be limited to
+  the read-only rootfs to avoid sharing mutable/sensitive state.
+- **Identity hygiene on fork.** If `boot_id`/`session_nonce`/generation id are
+  not correctly rotated, a restored child could replay a stale session or
+  inherit entropy state. This is a correctness *and* security issue.
+- **Policy grammar explosion.** Richer egress rules are useful but can become
+  hard to reason about. Keep the grammar small and first-match-wins; document
+  evaluation order explicitly.
+- **Log duplication.** Two log sinks (chain-signed audit + JSONL access) could
+  drift in redaction behavior. Share one redactor module and test both sinks
+  with the same secrets corpus.
+
+## Non-goals
+
+- Replacing vsock with a NIC/TAP/bridge path or with an eBPF-only data plane.
+- Transparent TLS MITM inside the guest (no baked root CA, no guest trust
+  model change).
+- Reusing dirty guests across workloads.
+- Introducing a multi-process, multi-language cluster control plane for the
+  local runtime.
+- Full compatibility with the competitor's SDK or API surface.
+- Changing the public package names on PyPI or npm.


### PR DESCRIPTION
## What

A portable snapshot store in `mvm-fs`: content-addressed create / list / materialize / remove of file and directory snapshots, backed by a portable copy-on-write clone helper.

- **`clone.rs`** — `reflink_or_copy` picks the cheapest faithful copy per platform and reports which mechanism it used:
  - macOS: APFS `clonefile` (copy-on-write)
  - Linux: `FICLONE` ioctl on btrfs/xfs/overlayfs (copy-on-write), with a byte-identical copy fallback on ext4-without-reflink
  - classifies the outcome as `Cloned` vs `Copied`
- **`snapshot_store.rs`** — a small content-addressed store over that helper: idempotent create, roundtrip materialize, independence of materialized copies, id validation (rejects path separators), and fail-closed behavior on a missing snapshot.

## Portability note

`libc::ioctl`'s request argument is the per-target `libc::Ioctl` alias — `c_ulong` on glibc but `c_int` on musl. The `FICLONE` request is cast at the call site so the target's type is inferred, keeping the `aarch64-unknown-linux-musl` cross-compile green (this is the target `crates/mvm-cli/build.rs` uses to embed `mvm-host-vm-init`). The constant stays `c_ulong`; `0x40209409` fits positively in `i32`, so there is no truncation.

## Scope

4 files, based directly on `main` — the minimal, standalone slice of the snapshot-store work.

The stacked draft #1774 carries this same commit on top of the in-flight restructure and the egress-connect completion work; it stays open for that. This PR is the clean, mergeable slice of just the snapshot store.

## Verification (rustup toolchain, against this branch's `main` base)

- `cargo build --bin mvmctl` — green (drives the `aarch64-unknown-linux-musl` embed cross-compile that the portability note fixes)
- `cargo fmt --all -- --check` — clean on stable and nightly
- `cargo clippy --workspace -- -D warnings` — zero warnings
- `cargo nextest run -p mvm-fs` — 267 passed (the `clone` Copied/Cloned suites + the `snapshot_store` suite)
