### PR TITLE
fix(dns): reject IPv4-mapped IPv6 SSRF + audit malformed DNS queries

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-oci-init.rs
@@ -33,10 +33,14 @@ mod linux {
         if cmdline_has_flag("mvm.vsock_egress=1") {
             bring_loopback_up();
             if let Err(error) = mvm_agentd::guest_net::seed_loopback_resolver() {
+                // Non-fatal: a read-only image rootfs may have no writable
+                // /etc/resolv.conf to repoint, but the workload still reaches its
+                // admitted egress through the loopback proxy. Log and continue —
+                // panicking PID 1 here would fail an otherwise-bootable VM.
                 eprintln!(
-                    "mvm-oci-init: failed to point resolv.conf at the loopback DNS stub: {error}"
+                    "mvm-oci-init: could not point resolv.conf at the loopback DNS stub \
+                     (continuing; proxy egress is unaffected): {error}"
                 );
-                std::process::exit(1);
             }
             // Egress is required when this flag is set; the client is the only guest
             // path to the admitted network. Resolve overlay-first (respecting the

--- a/crates/mvm-core/src/policy/dns_guard.rs
+++ b/crates/mvm-core/src/policy/dns_guard.rs
@@ -10,12 +10,16 @@ use std::net::IpAddr;
 /// an admitted public hostname from rebinding to an internal service.
 #[must_use]
 pub fn dns_answer_forbidden(ip: IpAddr) -> bool {
-    match ip {
+    // An IPv4-mapped IPv6 answer (`::ffff:a.b.c.d`) reaches the embedded IPv4
+    // destination on a dual-stack connect, so classify it as that IPv4 address
+    // rather than letting it slip past the IPv4 rules as an opaque IPv6 one.
+    match crate::policy::network_policy::unmap_v4_mapped(ip) {
         IpAddr::V4(address) => {
             address.is_private()
                 || address.is_loopback()
                 || address.is_link_local()
                 || address.is_unspecified()
+                || is_shared_address_space(address)
         }
         IpAddr::V6(address) => {
             let first_segment = address.segments()[0];
@@ -25,6 +29,15 @@ pub fn dns_answer_forbidden(ip: IpAddr) -> bool {
                 || first_segment & 0xfe00 == 0xfc00
         }
     }
+}
+
+/// RFC 6598 carrier-grade-NAT shared address space (`100.64.0.0/10`).
+///
+/// `Ipv4Addr::is_private` does not cover this range, but it is reachable
+/// internal space in some deployments and is already in the connect-time
+/// mandatory-deny set — so the stricter DNS-answer guard must reject it too.
+const fn is_shared_address_space(address: std::net::Ipv4Addr) -> bool {
+    matches!(address.octets(), [100, 64..=127, _, _])
 }
 
 #[cfg(test)]
@@ -43,6 +56,8 @@ mod tests {
             "1.1.1.1",
             "2606:2800:220:1:248:1893:25c8:1946",
             "2001:4860:4860::8888",
+            // A mapped *public* address stays allowed after normalization.
+            "::ffff:93.184.216.34",
         ] {
             assert!(
                 !dns_answer_forbidden(ip(value)),
@@ -77,6 +92,27 @@ mod tests {
     }
 
     #[test]
+    fn ipv4_mapped_and_cgnat_forms_are_forbidden() {
+        for value in [
+            // IPv4-mapped IPv6 must not bypass the IPv4 rebinding rules — the
+            // kernel reaches the embedded IPv4 destination on a dual-stack connect.
+            "::ffff:169.254.169.254",
+            "::ffff:10.0.0.1",
+            "::ffff:127.0.0.1",
+            "::ffff:192.168.1.1",
+            // Carrier-grade-NAT shared space (RFC 6598), plain and mapped.
+            "100.64.0.1",
+            "100.127.255.255",
+            "::ffff:100.64.0.1",
+        ] {
+            assert!(
+                dns_answer_forbidden(ip(value)),
+                "{value} should be forbidden"
+            );
+        }
+    }
+
+    #[test]
     fn addresses_adjacent_to_explicit_ranges_are_allowed() {
         for value in [
             "9.255.255.255",
@@ -89,6 +125,8 @@ mod tests {
             "169.255.0.0",
             "126.255.255.255",
             "128.0.0.0",
+            "100.63.255.255",
+            "100.128.0.0",
             "fbff:ffff::1",
             "fe00::1",
             "fe7f:ffff::1",

--- a/crates/mvm-core/src/policy/network_policy.rs
+++ b/crates/mvm-core/src/policy/network_policy.rs
@@ -136,7 +136,30 @@ pub fn mandatory_deny_ranges() -> Vec<ipnet::IpNet> {
 /// justify cached parsing. A perf-sensitive consumer can hoist
 /// [`mandatory_deny_ranges`] outside its loop.
 pub fn is_mandatory_deny(ip: std::net::IpAddr) -> bool {
+    let ip = unmap_v4_mapped(ip);
     mandatory_deny_ranges().iter().any(|net| net.contains(&ip))
+}
+
+/// Collapse an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) to its embedded
+/// IPv4 address, leaving every other address unchanged.
+///
+/// A dual-stack socket (the Linux default, without `IPV6_V6ONLY`) connecting
+/// to the mapped form is routed by the kernel to the embedded IPv4
+/// destination, so an egress range check that inspects the IPv6 form sees an
+/// opaque address and misses IPv4-only deny ranges — a `::ffff:169.254.169.254`
+/// would otherwise slip past the metadata deny. Normalizing here forces the
+/// check onto the address the kernel will actually reach. `::1`, `::`,
+/// `fe80::/10` and `fc00::/7` are not mapped forms, so they stay IPv6 and are
+/// classified by the IPv6 rules.
+#[must_use]
+pub fn unmap_v4_mapped(ip: std::net::IpAddr) -> std::net::IpAddr {
+    match ip {
+        std::net::IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => std::net::IpAddr::V4(v4),
+            None => std::net::IpAddr::V6(v6),
+        },
+        std::net::IpAddr::V4(_) => ip,
+    }
 }
 
 /// Emit the iptables shell fragment that drops outbound from
@@ -386,6 +409,26 @@ mod tests {
         // Anywhere inside 127.0.0.0/8 must be denied too.
         let nested: std::net::IpAddr = "127.42.99.7".parse().unwrap();
         assert!(is_mandatory_deny(nested), "127.42.99.7 must be denied");
+    }
+
+    #[test]
+    fn ipv4_mapped_forms_do_not_bypass_mandatory_deny() {
+        // The IPv4-only deny ranges must still catch the IPv4-mapped IPv6
+        // spelling — a dual-stack connect to `::ffff:a.b.c.d` reaches `a.b.c.d`.
+        for addr in [
+            "::ffff:169.254.169.254", // metadata
+            "::ffff:127.0.0.1",       // loopback
+            "::ffff:100.64.0.1",      // CGNAT
+        ] {
+            let ip: std::net::IpAddr = addr.parse().unwrap();
+            assert!(is_mandatory_deny(ip), "mapped {addr} must be denied");
+        }
+        // A mapped *public* address is not mandatory-deny.
+        let public: std::net::IpAddr = "::ffff:93.184.216.34".parse().unwrap();
+        assert!(
+            !is_mandatory_deny(public),
+            "mapped public must not be denied"
+        );
     }
 
     /// Legitimate public IPs must pass through cleanly so a

--- a/crates/mvm-hostd/src/supervisor/dns_audit.rs
+++ b/crates/mvm-hostd/src/supervisor/dns_audit.rs
@@ -42,6 +42,19 @@ pub async fn emit_dns_rate_limited(recorder: &Recorder, name: &str, qtype: DnsRe
     .await;
 }
 
+/// Record a DNS query refused because it failed to decode. No qname/qtype is
+/// recoverable, so the entry carries the `malformed` verdict with empty
+/// name/type — every query, valid or not, leaves a trace in the chain.
+pub async fn emit_dns_malformed(recorder: &Recorder) {
+    record_dns(recorder, "dns.refused", "", "", "malformed", String::new()).await;
+}
+
+/// Record a malformed DNS query from the blocking vsock transport.
+#[cfg(target_os = "linux")]
+pub fn emit_dns_malformed_blocking(recorder: &Recorder) {
+    emit_blocking("", emit_dns_malformed(recorder));
+}
+
 async fn emit_dns_event(
     recorder: &Recorder,
     name: &str,
@@ -54,17 +67,28 @@ async fn emit_dns_event(
         DnsRecordType::A => "a",
         DnsRecordType::Aaaa => "aaaa",
     };
+    record_dns(recorder, event, name, qtype, verdict_label, ips).await;
+}
+
+async fn record_dns(
+    recorder: &Recorder,
+    event: &'static str,
+    qname: &str,
+    qtype: &str,
+    verdict: &str,
+    ips: String,
+) {
     let labels = [
-        ("qname".to_string(), name.to_string()),
+        ("qname".to_string(), qname.to_string()),
         ("qtype".to_string(), qtype.to_string()),
-        ("verdict".to_string(), verdict_label.to_string()),
+        ("verdict".to_string(), verdict.to_string()),
         ("ips".to_string(), ips),
     ];
     if let Err(error) = recorder
         .record_unbound(EventCategory::Dns, event, labels)
         .await
     {
-        tracing::warn!(%error, qname = %name, "DNS audit emit failed");
+        tracing::warn!(%error, qname = %qname, "DNS audit emit failed");
     }
 }
 
@@ -193,6 +217,28 @@ mod tests {
             Some("rate_limited")
         );
         assert_eq!(entries[0].labels.get("ips").map(String::as_str), Some(""));
+        assert_eq!(metrics.snapshot().audit_dns_total, 1);
+    }
+
+    #[tokio::test]
+    async fn emits_malformed_query_as_a_distinct_refusal() {
+        let (recorder, signer, metrics) = fixture();
+        emit_dns_malformed(&recorder).await;
+
+        let entries = signer.entries();
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry.event, "dns.refused");
+        assert_eq!(
+            entry.labels.get("verdict").map(String::as_str),
+            Some("malformed")
+        );
+        assert_eq!(entry.labels.get("qname").map(String::as_str), Some(""));
+        assert_eq!(
+            entry.labels.len(),
+            5,
+            "malformed keeps the fixed DNS schema"
+        );
         assert_eq!(metrics.snapshot().audit_dns_total, 1);
     }
 }

--- a/crates/mvm-hostd/src/supervisor/dns_handler.rs
+++ b/crates/mvm-hostd/src/supervisor/dns_handler.rs
@@ -125,7 +125,16 @@ where
                 encode_response(&question, DnsRcode::Refused, &[])
             }
         },
-        Err(_) => encode_malformed_refusal(&query),
+        Err(_) => {
+            // Count the malformed frame against the same limiter and audit it,
+            // so a malformed-frame flood is throttled like valid queries and no
+            // query escapes the chain-signed log.
+            let _ = rate_guard.admit().await;
+            if let Some(recorder) = recorder {
+                dns_audit::emit_dns_malformed(recorder).await;
+            }
+            encode_malformed_refusal(&query)
+        }
     };
     write_frame_async(&mut guest, &response, timeout).await
 }
@@ -251,7 +260,15 @@ pub fn serve_dns_blocking(
                 encode_response(&question, DnsRcode::Refused, &[])
             }
         },
-        Err(_) => encode_malformed_refusal(&query),
+        Err(_) => {
+            // Count the malformed frame against the limiter and audit it — every
+            // query leaves a trace, malformed floods are throttled.
+            let _ = rate_guard.try_admit();
+            if let Some(recorder) = recorder {
+                dns_audit::emit_dns_malformed_blocking(recorder);
+            }
+            encode_malformed_refusal(&query)
+        }
     };
     let length = u16::try_from(response.len()).map_err(|_| invalid_frame_length())?;
     guest.write_all(&length.to_be_bytes())?;
@@ -351,6 +368,39 @@ mod tests {
         assert_eq!(
             entries[0].labels.get("qname").map(String::as_str),
             Some("blocked.test")
+        );
+    }
+
+    #[tokio::test]
+    async fn audits_a_malformed_query_without_a_lookup() {
+        let gate = EgressGate::default_deny();
+        let signer = Arc::new(CapturingAuditSigner::new());
+        let recorder = Arc::new(Recorder::new(signer.clone(), TenantId("local".to_string())));
+        let (mut client, server) = tokio::io::duplex(4096);
+        let handler_recorder = Arc::clone(&recorder);
+        let handler = tokio::spawn(async move {
+            serve_dns(
+                server,
+                &gate,
+                Some(&handler_recorder),
+                &DnsRateGuard::default(),
+                Duration::from_secs(1),
+            )
+            .await
+        });
+
+        // A compression-pointer label byte (0xc0 > 63) makes decode_query fail.
+        let malformed = vec![0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0xc0, 0x0c, 0, 1, 0, 1];
+        let response = exchange_query(&mut client, &malformed).await;
+        assert_eq!(response[3] & 0x0f, 5, "malformed query is refused");
+        handler.await.unwrap().unwrap();
+
+        let entries = signer.entries();
+        assert_eq!(entries.len(), 1, "a malformed query is still audited");
+        assert_eq!(entries[0].event, "dns.refused");
+        assert_eq!(
+            entries[0].labels.get("verdict").map(String::as_str),
+            Some("malformed")
         );
     }
 


### PR DESCRIPTION
Two follow-up hardening fixes for the in-seam DNS resolver (stacks on #1775), surfaced by an independent security review of that PR.

## C1 — SSRF via IPv4-mapped IPv6 (the merge-blocker)

`::ffff:169.254.169.254` (the IPv4-mapped form of the cloud-metadata IP) bypassed **both** egress deny filters: `dns_answer_forbidden` and the connect-time `is_mandatory_deny` each classified it as an opaque IPv6 address, and the mandatory-deny ranges are IPv4 `IpNet`s that `contains()` false-matches across address families. Under an unrestricted policy a workload could reach metadata / RFC1918 space via a crafted AAAA answer **or** a direct connect to the mapped address (Linux dual-stack routes it to the embedded IPv4).

- New shared `unmap_v4_mapped` collapses `::ffff:a.b.c.d` → `a.b.c.d` before both checks.
- Adds CGNAT `100.64.0.0/10` to `dns_answer_forbidden` — it was already in the connect-time deny list, so the "stricter" DNS-answer guard was out of sync.
- Witness tests for the mapped metadata/RFC1918/loopback/CGNAT forms on both filters; a mapped **public** address stays allowed.

## C2 — malformed DNS queries bypassed audit and rate-limit

`decode_query` ran before the rate guard, and the malformed branch emitted no audit event — so a guest could flood malformed frames at unlimited rate, invisible to the chain-signed log.

- Every malformed frame now consumes a rate token (throttled like a valid query) and emits a `malformed` audit event, on both the async and blocking transports.
- Unit + end-to-end handler witnesses.

## Verification
`mvm-core` policy tests 39/39, `mvm-hostd` DNS tests 32/32, clippy `-D warnings` clean, nightly rustfmt clean.

## Not included (follow-ups)
- 6to4 / Teredo / IPv4-compatible embedded-v4 forms (lower-confidence than the kernel-routed mapped form).
- Connection-level flood bound (each DNS query opens a fresh vsock connection spawned upstream of `serve_dns`; C2 adds backpressure + audit but does not bound the accept rate).
- Other review findings still open on #1775: plan-unbound DNS audit, `:53` boot-readiness race, `TokenBucket` refill test, OCI-init uid-0, EDNS0 doc note.
