### PR TITLE
feat(runtime): converge Firecracker onto the WorkloadRunner (FcDriver)

### DIFF
--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -559,17 +559,22 @@ mod tests {
     }
 
     #[test]
-    fn warm_claim_plan_json_is_optional_for_firecracker_only() {
+    fn warm_claim_plan_json_passes_supplied_plan_and_none_when_absent() {
+        // Every CLI-selectable backend now routes through the workload runner,
+        // which takes the admitted plan in-process (no `needs_plan_json`), so a
+        // missing plan yields None for all of them and a supplied plan passes
+        // through verbatim.
         let mut cfg = eligible_cfg();
         cfg.plan_json = None;
         let fc = AnyBackend::from_hypervisor("firecracker");
         let libkrun = AnyBackend::from_hypervisor("libkrun");
-        assert_eq!(
-            warm_claim_plan_json(fc.as_vm_backend(), &cfg),
-            Some(String::new())
-        );
+        assert_eq!(warm_claim_plan_json(fc.as_vm_backend(), &cfg), None);
         assert_eq!(warm_claim_plan_json(libkrun.as_vm_backend(), &cfg), None);
         cfg.plan_json = Some("{\"signed\":\"plan\"}".into());
+        assert_eq!(
+            warm_claim_plan_json(fc.as_vm_backend(), &cfg),
+            Some("{\"signed\":\"plan\"}".into())
+        );
         assert_eq!(
             warm_claim_plan_json(libkrun.as_vm_backend(), &cfg),
             Some("{\"signed\":\"plan\"}".into())

--- a/crates/mvm-cli/src/doctor/security.rs
+++ b/crates/mvm-cli/src/doctor/security.rs
@@ -169,13 +169,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn collect_balloon_support_advertises_firecracker() {
+    fn collect_balloon_support_omits_runner_backends() {
         let support = collect_balloon_support();
-        // The backend catalog must include Firecracker in the balloon
-        // support matrix. If a future refactor drops it, this fails
-        // loudly.
-        assert_eq!(support.get("firecracker"), Some(&true));
-        // And honestly-`false` backends should not be silently dropped.
+        // Firecracker and libkrun route through the workload runner, which takes
+        // no balloon elasticity, so both drop off the balloon matrix. qemu is
+        // the one remaining descriptor and its honest `false` is not dropped.
+        assert!(!support.contains_key("firecracker"));
+        assert!(!support.contains_key("libkrun"));
         assert_eq!(support.get("qemu"), Some(&false));
     }
 
@@ -183,13 +183,7 @@ mod tests {
     fn collect_balloon_support_keeps_catalog_backends_in_stable_order() {
         let support = collect_balloon_support();
         let ordered: Vec<_> = support.into_iter().collect();
-        assert_eq!(
-            ordered,
-            vec![
-                ("firecracker".to_string(), true),
-                ("qemu".to_string(), false),
-            ]
-        );
+        assert_eq!(ordered, vec![("qemu".to_string(), false)]);
     }
 
     #[test]

--- a/crates/mvm-cli/src/doctor/tests.rs
+++ b/crates/mvm-cli/src/doctor/tests.rs
@@ -211,7 +211,9 @@ fn doctor_report_serializes_warm_start() {
     })
     .unwrap();
     assert!(json.contains("\"warm_start\""), "{json}");
-    assert!(json.contains("\"live-memory\""), "{json}");
+    // The CLI workload runners are disk-only, so the warm-start section serializes
+    // the disk-only tier (qemu is the one remaining warm-start row).
+    assert!(json.contains("\"disk-only\""), "{json}");
 }
 
 #[test]

--- a/crates/mvm-cli/src/doctor/warm_start.rs
+++ b/crates/mvm-cli/src/doctor/warm_start.rs
@@ -20,8 +20,8 @@ pub(super) struct WarmStartReport {
     substrate: Option<WarmStartSubstrate>,
     /// Backend name → `supports_standby_pool()`. The standby pool
     /// (pre-pay spawn/codesign latency) is a *different* axis from the snapshot tier above;
-    /// Firecracker implements it today; backends without warm-start support
-    /// are omitted with the rest of their warm-start row.
+    /// backends without warm-start support are omitted with the rest of their
+    /// warm-start row.
     standby_pool: BTreeMap<String, bool>,
     /// Live count of idle standbys recorded under `~/.mvm/pool/` (best-effort; `None` if
     /// the pool dir can't be read).
@@ -232,8 +232,10 @@ mod tests {
     #[test]
     fn collect_warm_start_support_reports_per_backend_tier() {
         let r = collect_warm_start_support();
-        // The honest per-backend warm-start matrix.
-        assert_eq!(r.backends.get("firecracker"), Some(&"live-memory"));
+        // The honest per-backend warm-start matrix. Firecracker and libkrun
+        // route through the workload runner (trait-default no-warm-start), so
+        // both are omitted; qemu is the one remaining disk-only row.
+        assert_eq!(r.backends.get("firecracker"), None);
         assert_eq!(r.backends.get("libkrun"), None);
         assert_eq!(r.backends.get("qemu"), Some(&"disk-only"));
     }
@@ -244,28 +246,17 @@ mod tests {
         let ordered_backends: Vec<_> = r.backends.into_iter().collect();
         let ordered_standby_pool: Vec<_> = r.standby_pool.into_iter().collect();
 
-        assert_eq!(
-            ordered_backends,
-            vec![
-                ("firecracker".to_string(), "live-memory"),
-                ("qemu".to_string(), "disk-only"),
-            ]
-        );
-        assert_eq!(
-            ordered_standby_pool,
-            vec![
-                ("firecracker".to_string(), true),
-                ("qemu".to_string(), false),
-            ]
-        );
+        assert_eq!(ordered_backends, vec![("qemu".to_string(), "disk-only")]);
+        assert_eq!(ordered_standby_pool, vec![("qemu".to_string(), false)]);
     }
 
     #[test]
     fn collect_warm_start_support_reports_standby_pool_per_backend() {
         let r = collect_warm_start_support();
-        // Firecracker implements the standby pool; QEMU does not. The runner
-        // seam does not expose libkrun's legacy standby implementation.
-        assert_eq!(r.standby_pool.get("firecracker"), Some(&true));
+        // The runner seam exposes neither Firecracker's nor libkrun's legacy
+        // standby implementation, so both are omitted; QEMU stays and reports
+        // no standby pool.
+        assert_eq!(r.standby_pool.get("firecracker"), None);
         assert_eq!(r.standby_pool.get("libkrun"), None);
         assert_eq!(r.standby_pool.get("qemu"), Some(&false));
     }
@@ -277,19 +268,12 @@ mod tests {
 
         // The Tier 3 `mock` test double and backends without warm-start
         // support are excluded; the remaining rows use stable name order.
+        // Firecracker and libkrun both route through the workload runner, so
+        // neither carries a warm-start row — only qemu's disk-only row remains.
         let names: Vec<_> = rows.iter().map(|r| r.backend.as_str()).collect();
-        assert_eq!(names, vec!["firecracker", "qemu"]);
+        assert_eq!(names, vec!["qemu"]);
 
-        let fc = by("firecracker").unwrap();
-        assert_eq!(fc.snapshot_tier, "live-memory");
-        assert!(fc.tap_networking, "firecracker uses a host TAP device");
-        assert!(fc.vsock);
-        assert!(fc.balloon);
-        assert!(
-            fc.standby_pool,
-            "Firecracker implements live standby warm-spawn"
-        );
-
+        assert!(by("firecracker").is_none());
         assert!(by("libkrun").is_none());
 
         let qemu = by("qemu").unwrap();

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -2037,16 +2037,36 @@ mod tests {
     }
 
     #[test]
-    fn drop_l3_tunnel_for_host_vsock_proxy_keeps_it_on_firecracker() {
+    fn drop_l3_tunnel_for_host_vsock_proxy_drops_it_on_firecracker() {
         let mut config = VmStartConfig {
             network_tunnel: Some(fixture_network_tunnel()),
             ..Default::default()
         };
+        // The converged Firecracker CLI path routes through the workload runner:
+        // NIC-less, egress over the per-VM vsock endpoint (a host-vsock proxy).
+        // The L3 tunnel is then a redundant second data plane and is dropped,
+        // exactly like libkrun.
         let backend = AnyBackend::from_hypervisor("firecracker");
         drop_l3_tunnel_for_host_vsock_proxy(&mut config, &backend);
         assert!(
+            config.network_tunnel.is_none(),
+            "the converged firecracker path carries egress over its host-vsock proxy; the L3 tunnel is a redundant second data plane"
+        );
+    }
+
+    #[test]
+    fn drop_l3_tunnel_for_host_vsock_proxy_keeps_it_on_qemu() {
+        let mut config = VmStartConfig {
+            network_tunnel: Some(fixture_network_tunnel()),
+            ..Default::default()
+        };
+        // qemu advertises no host-vsock proxy, so the capability gate leaves the
+        // L3 tunnel in place — covering the keep branch of the decision.
+        let backend = AnyBackend::from_hypervisor("qemu");
+        drop_l3_tunnel_for_host_vsock_proxy(&mut config, &backend);
+        assert!(
             config.network_tunnel.is_some(),
-            "firecracker has no host-vsock proxy; the L3 tunnel is its only vsock-only egress path"
+            "qemu has no host-vsock proxy; a workload given the L3 tunnel keeps it"
         );
     }
 

--- a/crates/mvm-core/src/exit_capture.rs
+++ b/crates/mvm-core/src/exit_capture.rs
@@ -1,13 +1,12 @@
-//! Workload exit-code file convention.
+//! Workload exit-code file convention + capture.
 //!
-//! The supervisor captures a finished one-shot workload's exit code
-//! (written by the guest `/init` over the control vsock port) and
-//! persists it to `<vm_state_dir>/workload.exit`. This module is the
-//! shared home for the file name + path + reader, so the backend
-//! (`mvm-backend`) can read it without depending on the supervisor crate
-//! (`mvm-vm-host`), which sits above it in the dep graph. The capture
-//! side (`capture_once`) lives in `mvm-vm-host` and uses `exit_file_path`
-//! from here.
+//! A finished one-shot workload's exit code (written by the guest `/init`
+//! over the control vsock port) is persisted to `<vm_state_dir>/workload.exit`.
+//! This module is the shared home for the file name + path + reader **and** the
+//! `capture_once` writer, so every host-side capture site — the libkrun
+//! supervisor subprocess and the in-process Firecracker driver alike — reads a
+//! guest exit report the same way, and the backends that only read the file
+//! (`mvm-runtime`) depend on nothing above them in the graph.
 
 use std::path::{Path, PathBuf};
 
@@ -25,6 +24,34 @@ pub fn read_captured(vm_state_dir: &Path) -> Option<i32> {
         .and_then(|s| s.trim().parse().ok())
 }
 
+/// Block on `listener` for one guest connection, read the 4-byte LE i32, and
+/// persist it to `<vm_state_dir>/workload.exit`. Returns the code.
+///
+/// The caller passes a bound `UnixListener` for the control vsock port; this
+/// function binds nothing itself. Best-effort by design: it runs on a
+/// background thread, and an `Err` simply leaves no file, which readers treat
+/// downstream as `UNKNOWN`.
+#[cfg(unix)]
+pub fn capture_once(
+    listener: &std::os::unix::net::UnixListener,
+    vm_state_dir: &Path,
+) -> std::io::Result<i32> {
+    use std::io::Read as _;
+    let (mut stream, _addr) = listener.accept()?;
+    let mut buf = [0u8; 4];
+    stream.read_exact(&mut buf)?;
+    let code = i32::from_le_bytes(buf);
+    std::fs::write(exit_file_path(vm_state_dir), code.to_string())?;
+    // Ack AFTER the file is durably written: the guest waits for this before
+    // powering off, so a supervisor's start_enter->exit() can't race the file
+    // write. Best-effort — a failed ack just means the guest times out and
+    // powers off (file already written).
+    use std::io::Write as _;
+    let _ = stream.write_all(&[1u8]);
+    let _ = stream.flush();
+    Ok(code)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -40,5 +67,32 @@ mod tests {
     fn read_captured_is_none_when_absent() {
         let dir = tempfile::tempdir().unwrap();
         assert_eq!(read_captured(dir.path()), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capture_persists_le_i32_and_reads_back() {
+        use std::io::Write;
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("vsock-5251.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let handle = std::thread::spawn({
+            let sock = sock.clone();
+            move || {
+                let mut c = std::os::unix::net::UnixStream::connect(&sock).unwrap();
+                c.write_all(&(-7i32).to_le_bytes()).unwrap();
+                let mut ack = [0u8; 1];
+                use std::io::Read as _;
+                let _ = c.read_exact(&mut ack);
+            }
+        });
+
+        let code = capture_once(&listener, dir.path()).unwrap();
+        handle.join().unwrap();
+        assert_eq!(code, -7);
+        assert_eq!(read_captured(dir.path()), Some(-7));
     }
 }

--- a/crates/mvm-hostd/src/exit_capture.rs
+++ b/crates/mvm-hostd/src/exit_capture.rs
@@ -1,62 +1,8 @@
 //! Supervisor-side workload exit-code capture.
 //!
-//! Binds nothing itself — the caller passes a bound `UnixListener` for
-//! the control vsock port. Reads the guest's 4-byte LE i32 and persists
-//! it via `mvm_core::exit_capture::exit_file_path`. The file convention +
-//! reader live in `mvm-core` so `mvm-backend` can read without depending
-//! on this (supervisor) crate.
+//! The whole convention — file name, path, reader, and the `capture_once`
+//! writer — lives in `mvm-core::exit_capture` so every host-side capture site
+//! shares one implementation. This module re-exports it under the historical
+//! `mvm_hostd::exit_capture` path the supervisor binary imports.
 
-use std::io::Read;
-use std::os::unix::net::UnixListener;
-use std::path::Path;
-
-pub use mvm_core::exit_capture::{WORKLOAD_EXIT_FILE, exit_file_path, read_captured};
-
-/// Block on `listener` for one guest connection, read the 4-byte LE i32,
-/// and persist it to `<vm_state_dir>/workload.exit`. Returns the code.
-/// Best-effort: called on a background thread; an `Err` simply leaves no
-/// file, which the backend reads downstream as `UNKNOWN`.
-pub fn capture_once(listener: &UnixListener, vm_state_dir: &Path) -> std::io::Result<i32> {
-    let (mut stream, _addr) = listener.accept()?;
-    let mut buf = [0u8; 4];
-    stream.read_exact(&mut buf)?;
-    let code = i32::from_le_bytes(buf);
-    std::fs::write(exit_file_path(vm_state_dir), code.to_string())?;
-    // Ack AFTER the file is durably written: the guest waits for this
-    // before powering off, so the supervisor's start_enter->exit() can't
-    // race the file write. Best-effort — a failed ack just means the
-    // guest times out and powers off (file already written).
-    use std::io::Write as _;
-    let _ = stream.write_all(&[1u8]);
-    let _ = stream.flush();
-    Ok(code)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::io::Write;
-
-    #[test]
-    fn capture_persists_le_i32_and_reads_back() {
-        let dir = tempfile::tempdir().unwrap();
-        let sock = dir.path().join("vsock-5251.sock");
-        let listener = UnixListener::bind(&sock).unwrap();
-
-        let handle = std::thread::spawn({
-            let sock = sock.clone();
-            move || {
-                let mut c = std::os::unix::net::UnixStream::connect(&sock).unwrap();
-                c.write_all(&(-7i32).to_le_bytes()).unwrap();
-                let mut ack = [0u8; 1];
-                use std::io::Read as _;
-                let _ = c.read_exact(&mut ack);
-            }
-        });
-
-        let code = capture_once(&listener, dir.path()).unwrap();
-        handle.join().unwrap();
-        assert_eq!(code, -7);
-        assert_eq!(read_captured(dir.path()), Some(-7));
-    }
-}
+pub use mvm_core::exit_capture::{WORKLOAD_EXIT_FILE, capture_once, exit_file_path, read_captured};

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -11,7 +11,7 @@ use mvm_core::vm_backend::{
 // (`config`, `shell`, `runtime_meta`) lives in `crate::base`.
 use crate::base::config::{PortMapping, VmSlot};
 use crate::base::shell::run_in_vm_stdout;
-use crate::driver::{HvfDriver, LibkrunDriver};
+use crate::driver::{FcDriver, HvfDriver, LibkrunDriver};
 use crate::hvf_backend::HvfBackend;
 use crate::image::RuntimeVolume;
 use crate::microvm::{DriveFile, FlakeRunConfig};
@@ -44,6 +44,23 @@ pub(crate) fn libkrun_runner() -> LibkrunRunner {
         RealEndpointSpawner,
         RealBrokerRegistrar,
     )
+}
+
+/// Firecracker (Linux KVM) driven through the same unified workload-runner role
+/// — Firecracker's sole mvmctl-CLI workload launch path (`--hypervisor
+/// firecracker`, `default_backend`, and `auto_select`). NIC-less: egress routes
+/// to the per-VM gating endpoint over vsock only; the raw
+/// [`FirecrackerBackend`] shim stays behind the driver as its identity delegate
+/// and for the out-of-scope hostd-supervisor / warm-start / standby callers,
+/// unreached via this enum.
+type FcRunner = WorkloadRunner<FcDriver, RealEndpointSpawner, RealBrokerRegistrar>;
+
+/// Construct Firecracker's workload runner. Like [`libkrun_runner`] the runner
+/// is not const-constructible, so this helper is the one construction site the
+/// enum variant, `auto_select`, the descriptor catalog, and the capability
+/// selector all call.
+pub(crate) fn fc_runner() -> FcRunner {
+    WorkloadRunner::new(FcDriver::new(), RealEndpointSpawner, RealBrokerRegistrar)
 }
 
 /// Firecracker VM configuration for the [`VmBackend`] trait.
@@ -495,7 +512,15 @@ impl BackendTier {
 /// Wraps concrete backends so CLI commands don't need to know which
 /// backend is active. Each variant delegates to its inner implementation.
 pub enum AnyBackend {
-    Firecracker(FirecrackerBackend),
+    /// Firecracker (Linux KVM), driven through the unified `WorkloadRunner` over
+    /// the driver seam — Firecracker's sole mvmctl-CLI workload path, selected
+    /// by `--hypervisor firecracker`, `default_backend`, and `auto_select`.
+    /// NIC-less: egress routes to the per-VM gating endpoint over vsock only
+    /// (claim-10 + claims 12/13 at the endpoint); no routable guest NIC and no
+    /// transparent `:80/:443` terminator. The raw [`FirecrackerBackend`] stays
+    /// behind the driver as its identity delegate and for the out-of-scope
+    /// hostd-supervisor / warm-start / standby callers, unreached via this enum.
+    Firecracker(FcRunner),
     /// libkrun (Linux KVM / macOS Apple Silicon HVF), driven through the unified
     /// `WorkloadRunner` over the driver seam — libkrun's sole production path,
     /// selected by `--hypervisor libkrun` and `auto_select`. Egress routes to
@@ -545,7 +570,7 @@ pub enum AnyBackend {
 impl AnyBackend {
     /// Create the default backend (Firecracker).
     pub fn default_backend() -> Self {
-        Self::Firecracker(FirecrackerBackend)
+        Self::Firecracker(fc_runner())
     }
 
     /// Select backend based on whether the build output is a non-KVM
@@ -555,7 +580,7 @@ impl AnyBackend {
         if has_runner {
             Self::Qemu(QemuBackend)
         } else {
-            Self::Firecracker(FirecrackerBackend)
+            Self::Firecracker(fc_runner())
         }
     }
 
@@ -621,10 +646,11 @@ impl AnyBackend {
     pub fn auto_select() -> Self {
         let plat = mvm_core::platform::current();
 
-        // 1. Native Linux KVM → Firecracker directly (fastest — dev & production).
-        //    WSL2 nested KVM is future/experimental and is not auto-selected today.
+        // 1. Native Linux KVM → the Firecracker workload runner (vsock-only
+        //    egress; fastest — dev & production). WSL2 nested KVM is
+        //    future/experimental and is not auto-selected today.
         if plat.supports_native_runner() {
-            return Self::Firecracker(FirecrackerBackend);
+            return Self::Firecracker(fc_runner());
         }
 
         // 2. macOS 26+ Apple Silicon → the HVF VMM (`hvf`); the hvf path
@@ -643,7 +669,7 @@ impl AnyBackend {
         // Final default. Reachable when no tier is available; start()
         // then fails with the production-path error message rather than
         // silently picking a backend the caller didn't ask for.
-        Self::Firecracker(FirecrackerBackend)
+        Self::Firecracker(fc_runner())
     }
 
     /// Resolve the backend that owns an already-started VM by its per-VM
@@ -1205,10 +1231,15 @@ mod tests {
 
     #[test]
     fn test_any_backend_capabilities() {
+        // The default backend is the converged Firecracker runner: NIC-less,
+        // vsock-only egress. It advertises the vsock control channel and no
+        // routable guest NIC, not the raw TAP the entangled Firecracker path
+        // used to carry.
         let backend = AnyBackend::default_backend();
         let caps = backend.capabilities();
         assert!(caps.vsock);
-        assert!(caps.tap_networking);
+        assert!(!caps.tap_networking);
+        assert!(caps.no_routable_guest_nic);
     }
 
     #[test]
@@ -1302,8 +1333,8 @@ mod tests {
                     Some("fc.pid"),
                     Some(3),
                     true,
-                    true,
-                    true,
+                    false,
+                    false,
                 ),
                 (
                     "libkrun",
@@ -1416,10 +1447,15 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_capability_live_memory_on_firecracker() {
+    fn snapshot_capability_disk_only_on_firecracker() {
+        // The CLI Firecracker path routes through the workload runner, which is
+        // honest about disk-only warm-start (no live-memory snapshot). The raw
+        // `FirecrackerBackend` still advertises the live-memory tier for the
+        // out-of-scope hostd path — see
+        // `warm_start_on_firecracker_admits_the_live_memory_tier`.
         assert_eq!(
             AnyBackend::from_hypervisor("firecracker").snapshot_capability(),
-            SnapshotCapability::LiveMemory
+            SnapshotCapability::DiskOnly
         );
     }
 
@@ -1653,7 +1689,7 @@ mod tests {
         // Covers every `AnyBackend` variant, including both hvf entry points
         // (the raw backend and the WorkloadRunner-driven role-runner path).
         let mut backends: Vec<(&str, AnyBackend)> = vec![
-            ("firecracker", AnyBackend::Firecracker(FirecrackerBackend)),
+            ("firecracker", AnyBackend::Firecracker(fc_runner())),
             ("libkrun", AnyBackend::Libkrun(libkrun_runner())),
             ("qemu", AnyBackend::Qemu(QemuBackend)),
             ("hvf", AnyBackend::Hvf(HvfBackend)),

--- a/crates/mvm-runtime/src/catalog.rs
+++ b/crates/mvm-runtime/src/catalog.rs
@@ -12,7 +12,7 @@
 //! constructor wiring; `VmBackend` owns runtime behavior; `AnyBackend` remains
 //! the closed enum for the few intentionally backend-specific operations.
 
-use crate::backend::{AnyBackend, BackendTier, FirecrackerBackend};
+use crate::backend::{AnyBackend, BackendTier};
 #[cfg(feature = "test-support")]
 use crate::mock::MockBackend;
 use crate::qemu::QemuBackend;
@@ -44,7 +44,8 @@ pub struct BackendDescriptor {
     pub bundled_kernel: bool,
     /// This backend needs the admitted plan JSON stashed to disk for its
     /// external-VMM bridge to read at spawn time, rather than taking it
-    /// in-process. True only for Firecracker today.
+    /// in-process. False for every runner-driven backend — the runner takes the
+    /// plan in-process — so no CLI-selectable backend sets it today.
     pub needs_plan_json: bool,
     /// This backend runs real (non-mock, non-dev-substrate) workloads —
     /// the admitted plan is stashed for its gateway/bridge audit path.
@@ -146,15 +147,19 @@ backend_catalog![
         kind: Firecracker,
         selector: "firecracker",
         aliases: [],
-        constructor: AnyBackend::Firecracker(FirecrackerBackend),
+        constructor: AnyBackend::Firecracker(crate::backend::fc_runner()),
         tier: Tier1,
         marker_file: Some("fc.pid"),
         started_vm_probe_order: Some(3),
         list_all: true,
-        balloon_support: true,
-        warm_start_support: true,
+        // The runner takes the trait-default warm-start/standby (no live-memory
+        // snapshot, no standby pool) and takes the admitted plan in-process, so
+        // Firecracker drops off the balloon + warm-start doctor surfaces and
+        // needs no disk-stashed plan for an external bridge.
+        balloon_support: false,
+        warm_start_support: false,
         bundled_kernel: false,
-        needs_plan_json: true,
+        needs_plan_json: false,
         is_workload: true
     },
     {
@@ -349,14 +354,8 @@ mod tests {
     /// reshuffle can't silently change what users see or the probe priority.
     #[test]
     fn descriptor_surface_ordering_is_frozen() {
-        assert_eq!(
-            selectors(balloon_support_descriptors()),
-            ["firecracker", "qemu"]
-        );
-        assert_eq!(
-            selectors(warm_start_support_descriptors()),
-            ["firecracker", "qemu"]
-        );
+        assert_eq!(selectors(balloon_support_descriptors()), ["qemu"]);
+        assert_eq!(selectors(warm_start_support_descriptors()), ["qemu"]);
         assert_eq!(
             selectors(list_all_descriptors()),
             ["firecracker", "libkrun", "qemu", "hvf", "wasm"]

--- a/crates/mvm-runtime/src/driver/fc.rs
+++ b/crates/mvm-runtime/src/driver/fc.rs
@@ -1,0 +1,942 @@
+//! `FcDriver` — the `VmmDriver` for Firecracker (Linux KVM). Identity delegates
+//! to the proven `FirecrackerBackend`, but capabilities are the flipped,
+//! NIC-less profile: the converged Firecracker path carries no routable guest
+//! NIC and routes egress solely over vsock, exactly like libkrun and hvf.
+//!
+//! `boot` assembles a NIC-less Firecracker launch from a policy-free `VmmSpec`
+//! using the shared `microvm` primitives — the FC-loadable kernel prep, the
+//! process spawn, and the raw API client — never the entangled production TAP
+//! path. It drives the guest's egress port to the host-side endpoint the runner
+//! bound to the spec's `EGRESS_PORT` socket; the claim-10 gate and secret
+//! substitution live in that endpoint, not here. The driver carries no policy
+//! and never sees a `NetworkPolicy`.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow, bail};
+use mvm_agentd::vsock::{
+    CONSOLE_PORT_BASE, GUEST_AGENT_PORT, GUEST_CID, WORKLOAD_EXIT_PORT, connect_to_port,
+    dev_console_data_ports,
+};
+use mvm_core::config::vm_state_dir;
+use mvm_core::vm_backend::{
+    BackendKind, BackendSecurityProfile, GuestChannelInfo, SnapshotCapability, VmBackend,
+    VmCapabilities, VmExitStatus, VmId, VmStatus,
+};
+
+use crate::backend::FirecrackerBackend;
+use crate::driver::spec::KernelImage;
+use crate::driver::{BlockDev, DuplexStream, RunningVm, VmmDriver, VmmSpec, VsockDirection};
+use crate::microvm::{api_put_socket, firecracker_vsock_uds_path, start_vm_firecracker};
+
+/// File name of Firecracker's PID marker under the VM state dir. Written by
+/// `start_vm_firecracker` and read back by the running-VM handle for kill/status.
+const FC_PID_FILE: &str = "fc.pid";
+
+/// Host→guest dial timeout (seconds) for `vsock_connect`. The underlying
+/// `connect_to_port` retries the CONNECT handshake internally within this bound.
+const VSOCK_CONNECT_TIMEOUT_SECS: u64 = 30;
+
+/// Overall deadline for the guest agent to answer its first CONNECT after
+/// `InstanceStart` — the boot-confirmation signal that the guest is up.
+const AGENT_READY_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The Firecracker VMM driver: pure VMM mechanics, no policy and no admission.
+/// It boots what a `VmmSpec` describes and relays the guest's egress port to the
+/// host-side bridge; the claim-10 gate and substitution live in that bridge,
+/// not here.
+pub struct FcDriver {
+    backend: FirecrackerBackend,
+}
+
+impl FcDriver {
+    pub fn new() -> Self {
+        Self {
+            backend: FirecrackerBackend,
+        }
+    }
+}
+
+impl Default for FcDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The default base kernel cmdline for a Firecracker workload boot. Firecracker
+/// guests use the `ttyS0` serial console (not virtio-console `hvc0` or the pl011
+/// UART), and carry NO `mvm.ip=` / `mvm.gw=` tokens — the converged path has no
+/// guest NIC. The root/init selection follows the boot shape; the shared cmdline
+/// assembler layers verity/grants/egress/uvols tokens on top of this.
+fn fc_base_bootargs(virtiofs_root: bool, has_disk: bool) -> String {
+    // Serial console + reboot/panic behavior + stable interface naming. The NIC
+    // fields the raw Firecracker TAP path appends here are deliberately absent.
+    let console = "console=ttyS0 reboot=k panic=1 net.ifnames=0";
+    if virtiofs_root {
+        format!("{console} rootfstype=virtiofs root=mvmroot rw init=/init")
+    } else if has_disk {
+        format!("{console} root=/dev/vda rw rootwait init=/init")
+    } else {
+        // Verity / initramfs boot: the initramfs PID 1 owns root/init selection,
+        // so only the serial-console base is emitted here.
+        console.to_string()
+    }
+}
+
+/// Resolve the explicit host kernel path from the spec, rejecting a bundled
+/// kernel. Firecracker has no bundled kernel (libkrun's libkrunfw is the only
+/// bundled-kernel backend), so a `Bundled` spec must not reach the API.
+fn resolve_fc_kernel_path(spec: &VmmSpec) -> Result<PathBuf> {
+    match &spec.kernel {
+        KernelImage::Path(p) => Ok(p.clone()),
+        KernelImage::Bundled => {
+            bail!(
+                "the Firecracker driver requires an explicit kernel Image; VmmSpec.kernel is Bundled"
+            )
+        }
+    }
+}
+
+/// One Firecracker API configuration call: an HTTP PUT of `body` to `path` on
+/// the per-VM API socket. Kept as data so the whole NIC-less config sequence is
+/// a pure, testable value the driver replays through `api_put_socket`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FcApiPut {
+    path: String,
+    body: String,
+}
+
+/// Map slot-ordered blocks to `/drives/*` PUTs in the order Firecracker assigns
+/// device letters (first PUT → `/dev/vda`, next → `/dev/vdb`, …), so the guest
+/// device nodes line up with the verity slot model the cmdline names
+/// (`mvm.data=/dev/vda mvm.hash=/dev/vdb …`). The lowest-slot block is the root
+/// device; every block carries its own read-only policy verbatim.
+fn fc_drive_puts(blocks: &[BlockDev]) -> Vec<FcApiPut> {
+    let mut ordered: Vec<&BlockDev> = blocks.iter().collect();
+    ordered.sort_by_key(|b| b.slot);
+    ordered
+        .iter()
+        .enumerate()
+        .map(|(index, block)| {
+            let drive_id = format!("blk{}", block.slot);
+            FcApiPut {
+                path: format!("/drives/{drive_id}"),
+                body: format!(
+                    r#"{{"drive_id": "{drive_id}", "path_on_host": "{path}", "is_root_device": {root}, "is_read_only": {ro}}}"#,
+                    path = block.source.to_string_lossy(),
+                    root = index == 0,
+                    ro = block.read_only,
+                ),
+            }
+        })
+        .collect()
+}
+
+/// Assemble the full NIC-less Firecracker API config sequence for a spec:
+/// logger, boot-source (kernel + initramfs + **`spec.cmdline` verbatim**),
+/// machine-config, slot-ordered drives, the vsock device, and — only when the
+/// spec opts into balloon elasticity — the virtio-balloon device. There is
+/// deliberately no `/network-interfaces` PUT: the converged Firecracker path
+/// attaches no guest NIC.
+fn fc_config_api_puts(
+    spec: &VmmSpec,
+    kernel_for_boot: &str,
+    vsock_uds: &str,
+    log_dir: &str,
+) -> Vec<FcApiPut> {
+    let mut puts = Vec::new();
+
+    puts.push(FcApiPut {
+        path: "/logger".to_string(),
+        body: format!(
+            r#"{{"log_path": "{log_dir}/firecracker.log", "level": "Debug", "show_level": true, "show_log_origin": true}}"#,
+        ),
+    });
+
+    // An empty spec cmdline means "the driver supplies its own default base";
+    // a non-empty one already carries the console + root/init base plus every
+    // layered token, so it is threaded verbatim.
+    let has_disk = spec.initramfs.is_none() && !spec.blocks.is_empty();
+    let trimmed = spec.cmdline.trim();
+    let cmdline = if trimmed.is_empty() {
+        fc_base_bootargs(false, has_disk)
+    } else {
+        trimmed.to_string()
+    };
+    let boot_source = match &spec.initramfs {
+        Some(initramfs) => format!(
+            r#"{{"kernel_image_path": "{kernel_for_boot}", "boot_args": "{cmdline}", "initrd_path": "{initrd}"}}"#,
+            initrd = initramfs.to_string_lossy(),
+        ),
+        None => {
+            format!(r#"{{"kernel_image_path": "{kernel_for_boot}", "boot_args": "{cmdline}"}}"#,)
+        }
+    };
+    puts.push(FcApiPut {
+        path: "/boot-source".to_string(),
+        body: boot_source,
+    });
+
+    puts.push(FcApiPut {
+        path: "/machine-config".to_string(),
+        body: format!(
+            r#"{{"vcpu_count": {cpus}, "mem_size_mib": {mem}}}"#,
+            cpus = spec.vcpus,
+            mem = spec.memory_mib,
+        ),
+    });
+
+    puts.extend(fc_drive_puts(&spec.blocks));
+
+    puts.push(FcApiPut {
+        path: "/vsock".to_string(),
+        body: format!(
+            r#"{{"vsock_id": "vsock0", "guest_cid": {cid}, "uds_path": "{vsock_uds}"}}"#,
+            cid = GUEST_CID,
+        ),
+    });
+
+    // Balloon only when the workload opted into elasticity: the device boots
+    // pre-inflated to `memory - mem_initial` MiB so the host commits only
+    // `mem_initial` MiB until the reclaim controller deflates it.
+    if let Some(initial) = spec.mem_initial_mib {
+        let amount_mib = spec.memory_mib.saturating_sub(initial);
+        puts.push(FcApiPut {
+            path: "/balloon".to_string(),
+            body: format!(
+                r#"{{"amount_mib": {amount_mib}, "deflate_on_oom": true, "stats_polling_interval_s": 1}}"#,
+            ),
+        });
+    }
+
+    puts
+}
+
+/// The host UDS Firecracker connects *out* to when the guest dials
+/// `CID_HOST:<port>`: the sibling `<runtime_dir>/v.sock_<port>` of the vsock mux
+/// socket. The host must own a listener there before the guest dials.
+fn fc_guest_dial_socket(runtime_dir: &Path, port: u32) -> PathBuf {
+    runtime_dir.join(format!("v.sock_{port}"))
+}
+
+/// Wire every guest-dialed vsock port (except the workload-exit port, which the
+/// driver binds and captures itself) to the runner-owned host socket it relays
+/// to. Firecracker connects out to `<runtime_dir>/v.sock_<port>`, so a symlink
+/// from that path to the entry's `host_uds` makes the guest's dial follow
+/// straight through to the endpoint the runner already bound — the egress
+/// gateway (the claim-critical one), the host-services broker, and any packet
+/// tunnel. `HostDials` ports (agent, dev-console) are not bridged here: the host
+/// dials those inbound through the CONNECT handshake on the mux socket.
+fn wire_guest_dial_bridges(spec: &VmmSpec, runtime_dir: &Path) -> Result<Vec<(PathBuf, PathBuf)>> {
+    let mut created = Vec::new();
+    for port in &spec.vsock {
+        if port.direction != VsockDirection::GuestDials {
+            continue;
+        }
+        // The workload-exit port has no runner-bound listener — its `host_uds`
+        // is the captured-code output file, not a socket. The driver binds and
+        // captures it directly (see `spawn_workload_exit_capture`).
+        if port.guest_port == WORKLOAD_EXIT_PORT {
+            continue;
+        }
+        let link = fc_guest_dial_socket(runtime_dir, port.guest_port);
+        // Clear any stale link/socket from a prior run so the symlink lands.
+        let _ = std::fs::remove_file(&link);
+        std::os::unix::fs::symlink(&port.host_uds, &link).with_context(|| {
+            format!(
+                "link guest-dial vsock bridge {} -> {}",
+                link.display(),
+                port.host_uds.display()
+            )
+        })?;
+        created.push((link, port.host_uds.clone()));
+    }
+    Ok(created)
+}
+
+/// Bind the workload-exit control socket and capture the guest's exit code on a
+/// background thread. Firecracker has no supervisor subprocess to write
+/// `workload.exit`, so the driver owns it: the guest dials `WORKLOAD_EXIT_PORT`,
+/// Firecracker connects out to `<runtime_dir>/v.sock_<port>`, and the bound
+/// listener there reads the 4-byte exit code and persists it under the state
+/// dir where `wait_for_workload_exit` reads it. Best-effort — a bind failure
+/// leaves `workload.exit` absent, which readers treat as UNKNOWN.
+fn spawn_workload_exit_capture(runtime_dir: &Path, state_dir: &Path) {
+    let sock = fc_guest_dial_socket(runtime_dir, WORKLOAD_EXIT_PORT);
+    let _ = std::fs::remove_file(&sock);
+    match std::os::unix::net::UnixListener::bind(&sock) {
+        Ok(listener) => {
+            let state_dir = state_dir.to_path_buf();
+            std::thread::spawn(move || {
+                if let Err(e) = mvm_core::exit_capture::capture_once(&listener, &state_dir) {
+                    tracing::warn!("Firecracker workload exit capture failed: {e}");
+                }
+            });
+        }
+        Err(e) => tracing::warn!(
+            "Firecracker driver could not bind the workload-exit socket {}: {e}",
+            sock.display()
+        ),
+    }
+}
+
+impl VmmDriver for FcDriver {
+    fn name(&self) -> &str {
+        self.backend.name()
+    }
+
+    fn kind(&self) -> BackendKind {
+        self.backend.kind()
+    }
+
+    fn is_available(&self) -> Result<bool> {
+        self.backend.is_available()
+    }
+
+    fn capabilities(&self) -> VmCapabilities {
+        // The flipped, NIC-less profile — NOT the raw FirecrackerBackend caps
+        // (which advertise a routable TAP). The converged Firecracker driver
+        // carries no guest NIC and routes egress solely over the vsock proxy,
+        // matching libkrun and hvf. Pause/resume and balloon stay true (both are
+        // wired through this driver's boot + running-VM handle); live-memory
+        // snapshots are dropped, since the runner path warm-starts disk-only.
+        VmCapabilities {
+            pause_resume: true,
+            snapshots: false,
+            vsock: true,
+            tap_networking: false,
+            no_routable_guest_nic: true,
+            host_vsock_proxy: true,
+            balloon: true,
+            fs_quick_checkpoint: false,
+            ..VmCapabilities::default()
+        }
+    }
+
+    fn snapshot_capability(&self) -> SnapshotCapability {
+        // The runner takes no live-memory warm-start on this path, so the driver
+        // is honest about disk-only — matching libkrun and hvf.
+        SnapshotCapability::DiskOnly
+    }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        self.backend.security_profile()
+    }
+
+    fn workload_base_bootargs(&self, virtiofs_root: bool, has_disk: bool) -> String {
+        fc_base_bootargs(virtiofs_root, has_disk)
+    }
+
+    fn boot(&self, spec: &VmmSpec) -> Result<Box<dyn RunningVm>> {
+        let kernel_path = resolve_fc_kernel_path(spec)?;
+
+        let state_dir = vm_state_dir(&spec.name);
+        std::fs::create_dir_all(&state_dir)
+            .map_err(|e| anyhow!("create state dir {}: {e}", state_dir.display()))?;
+        let runtime_dir = state_dir.join("runtime");
+        std::fs::create_dir_all(&runtime_dir)
+            .map_err(|e| anyhow!("create runtime dir {}: {e}", runtime_dir.display()))?;
+
+        let abs_dir = state_dir.to_string_lossy().into_owned();
+        let pid_file = state_dir.join(FC_PID_FILE);
+        // Clear any prior run's captured exit code and stale pid marker so `wait`
+        // and the readiness poll observe only this launch's.
+        let _ = std::fs::remove_file(mvm_core::exit_capture::exit_file_path(&state_dir));
+        let _ = std::fs::remove_file(&pid_file);
+
+        // Convert the workload kernel to an FC-loadable image (x86_64 bzImage →
+        // extracted ELF; aarch64 Image passthrough), reusing the same helper the
+        // raw path calls so the driver never diverges from host kernel-prep.
+        let kernel_for_boot = mvm_build::fc_kernel::ensure_fc_loadable_kernel(&kernel_path)
+            .with_context(|| {
+                format!(
+                    "preparing FC-loadable kernel from {}",
+                    kernel_path.display()
+                )
+            })?;
+
+        // Spawn the Firecracker daemon (writes fc.pid, waits for its API socket).
+        let socket = format!("{abs_dir}/fc.socket");
+        start_vm_firecracker(&abs_dir, &socket)?;
+
+        // Drive the NIC-less API config sequence.
+        let vsock_uds = firecracker_vsock_uds_path(&abs_dir);
+        let puts = fc_config_api_puts(
+            spec,
+            &kernel_for_boot.to_string_lossy(),
+            &vsock_uds,
+            &abs_dir,
+        );
+        for put in &puts {
+            api_put_socket(&socket, &put.path, &put.body)
+                .with_context(|| format!("Firecracker API PUT {}", put.path))?;
+        }
+
+        // Wire the guest-dial egress/broker/tunnel bridges, then bind the
+        // workload-exit capture — both must be in place before the guest boots
+        // and dials out.
+        wire_guest_dial_bridges(spec, &runtime_dir)?;
+        spawn_workload_exit_capture(&runtime_dir, &state_dir);
+
+        // Boot the configured instance.
+        api_put_socket(&socket, "/actions", r#"{"action_type": "InstanceStart"}"#)
+            .context("Firecracker API PUT /actions InstanceStart")?;
+
+        // Confirm the guest is up: a successful agent CONNECT over the vsock mux
+        // means userspace booted and the agent is listening. Bounded so a guest
+        // that never comes up fails closed rather than hanging forever.
+        let deadline = Instant::now() + AGENT_READY_TIMEOUT;
+        loop {
+            if connect_to_port(&vsock_uds, GUEST_AGENT_PORT, VSOCK_CONNECT_TIMEOUT_SECS).is_ok() {
+                break;
+            }
+            if Instant::now() >= deadline {
+                bail!(
+                    "Firecracker guest agent did not answer within {AGENT_READY_TIMEOUT:?}; see {}/console.log",
+                    abs_dir
+                );
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+
+        Ok(Box::new(FcRunningVm {
+            id: VmId(spec.name.clone()),
+            state_dir,
+            pid_file,
+            vsock_uds,
+        }))
+    }
+
+    fn attach(&self, id: &VmId) -> Result<Box<dyn RunningVm>> {
+        // The handle is entirely disk-backed (the fc.pid marker + the persisted
+        // workload-exit code under the VM's state dir), so reattaching is just
+        // re-deriving those paths — no live boot state to recover.
+        let state_dir = vm_state_dir(&id.0);
+        let vsock_uds = firecracker_vsock_uds_path(&state_dir.to_string_lossy());
+        Ok(Box::new(FcRunningVm {
+            pid_file: state_dir.join(FC_PID_FILE),
+            state_dir,
+            vsock_uds,
+            id: id.clone(),
+        }))
+    }
+
+    fn guest_channel_info(&self, id: &VmId) -> Result<GuestChannelInfo> {
+        self.backend.guest_channel_info(id)
+    }
+}
+
+/// A live Firecracker VM: the detached `firecracker` daemon tracked by its PID
+/// file, with the workload's exit code persisted under its state dir and the
+/// vsock mux UDS for host→guest dials.
+struct FcRunningVm {
+    id: VmId,
+    state_dir: PathBuf,
+    pid_file: PathBuf,
+    /// The single host-side vsock mux UDS (`<state_dir>/runtime/v.sock`); the
+    /// host dials guest ports through the CONNECT handshake on this socket.
+    vsock_uds: String,
+}
+
+impl RunningVm for FcRunningVm {
+    fn id(&self) -> &VmId {
+        &self.id
+    }
+
+    fn wait(&self) -> Result<VmExitStatus> {
+        Ok(crate::workload_wait::wait_for_workload_exit(
+            &self.state_dir,
+        ))
+    }
+
+    fn kill(&self) -> Result<()> {
+        // SIGTERM → grace → SIGKILL, the same escalation the libkrun running-VM
+        // uses: SIGTERM gives Firecracker a chance to close its virtio-blk fds,
+        // then SIGKILL if it ignores us within the grace window.
+        if let Some(pid) = crate::libkrun::read_pid(&self.pid_file)
+            && crate::libkrun::pid_alive(pid)
+        {
+            crate::libkrun::send_signal(pid, libc::SIGTERM);
+            let deadline = Instant::now() + crate::libkrun::STOP_TIMEOUT;
+            while Instant::now() < deadline && crate::libkrun::pid_alive(pid) {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            if crate::libkrun::pid_alive(pid) {
+                crate::libkrun::send_signal(pid, libc::SIGKILL);
+            }
+        }
+        let _ = std::fs::remove_file(&self.pid_file);
+        Ok(())
+    }
+
+    fn pause(&self) -> Result<()> {
+        // Firecracker exposes vCPU pause via the control API; reuse the existing
+        // FC control helper (PATCH /vm InstanceState) keyed by the VM name.
+        crate::microvm::pause_vm(&self.id.0)
+    }
+
+    fn resume(&self) -> Result<()> {
+        crate::microvm::resume_vm(&self.id.0)
+    }
+
+    fn status(&self) -> Result<VmStatus> {
+        Ok(match crate::libkrun::read_pid(&self.pid_file) {
+            Some(pid) if crate::libkrun::pid_alive(pid) => VmStatus::Running,
+            _ => VmStatus::Stopped,
+        })
+    }
+
+    fn vsock_connect(&self, guest_port: u32) -> Result<Box<dyn DuplexStream>> {
+        // Firecracker multiplexes every host→guest connection over the single
+        // vsock UDS, selecting the destination port via the `CONNECT <port>\n`
+        // handshake. Restricted to the agent port and the dev-only console data
+        // ports (a sealed prod boot registers no console listeners), mirroring
+        // the other drivers' allow-list.
+        if guest_port != GUEST_AGENT_PORT && !dev_console_data_ports().any(|p| p == guest_port) {
+            bail!(
+                "Firecracker driver vsock_connect supports only the agent port \
+                 ({GUEST_AGENT_PORT}) and dev console data ports ({}..={}); got {guest_port}",
+                CONSOLE_PORT_BASE + 1,
+                CONSOLE_PORT_BASE + 128,
+            );
+        }
+        let stream = connect_to_port(&self.vsock_uds, guest_port, VSOCK_CONNECT_TIMEOUT_SECS)
+            .with_context(|| {
+                format!(
+                    "connect to Firecracker vsock port {guest_port} via {}",
+                    self.vsock_uds
+                )
+            })?;
+        Ok(Box::new(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::{ConsoleCapture, VsockPort};
+    use mvm_agentd::vsock::{BROKER_PORT, EGRESS_PORT};
+
+    fn host_dials(guest_port: u32, uds: &str) -> VsockPort {
+        VsockPort {
+            guest_port,
+            host_uds: uds.into(),
+            direction: VsockDirection::HostDials,
+        }
+    }
+
+    fn guest_dials(guest_port: u32, uds: &str) -> VsockPort {
+        VsockPort {
+            guest_port,
+            host_uds: uds.into(),
+            direction: VsockDirection::GuestDials,
+        }
+    }
+
+    fn spec_with(kernel: KernelImage, vsock: Vec<VsockPort>, blocks: Vec<BlockDev>) -> VmmSpec {
+        VmmSpec {
+            name: "w".into(),
+            kernel,
+            initramfs: None,
+            cmdline: String::new(),
+            vcpus: 2,
+            memory_mib: 512,
+            mem_initial_mib: None,
+            blocks,
+            vsock,
+            console: ConsoleCapture {
+                log_path: "/tmp/console.log".into(),
+            },
+            trusted_builder: false,
+        }
+    }
+
+    fn ro_block(source: &str, slot: u8) -> BlockDev {
+        BlockDev {
+            source: source.into(),
+            read_only: true,
+            ephemeral: false,
+            slot,
+        }
+    }
+
+    fn config_puts(spec: &VmmSpec) -> Vec<FcApiPut> {
+        fc_config_api_puts(spec, "/img/vmlinux", "/state/w/runtime/v.sock", "/state/w")
+    }
+
+    fn body_for<'a>(puts: &'a [FcApiPut], path: &str) -> &'a str {
+        puts.iter()
+            .find(|p| p.path == path)
+            .map(|p| p.body.as_str())
+            .unwrap_or_else(|| panic!("no PUT for {path}"))
+    }
+
+    #[test]
+    fn identity_and_capabilities_report_the_flipped_nic_less_profile() {
+        let d = FcDriver::new();
+        assert_eq!(d.name(), "firecracker");
+        assert_eq!(d.kind(), BackendKind::Firecracker);
+        let caps = d.capabilities();
+        assert!(caps.vsock);
+        // Flipped: no routable NIC + host vsock proxy, TAP off — the raw
+        // FirecrackerBackend advertises the inverse (TAP on).
+        assert!(caps.no_routable_guest_nic);
+        assert!(caps.host_vsock_proxy);
+        assert!(!caps.tap_networking);
+        assert!(
+            FirecrackerBackend.capabilities().tap_networking,
+            "sanity: the raw backend still advertises TAP, so caps are not delegated"
+        );
+        assert_eq!(d.snapshot_capability(), SnapshotCapability::DiskOnly);
+        // Security tier still delegates to the raw backend (same claims).
+        assert_eq!(
+            d.security_profile().tier,
+            FirecrackerBackend.security_profile().tier
+        );
+    }
+
+    #[test]
+    fn workload_base_bootargs_uses_ttys0_and_carries_no_nic_or_other_console() {
+        let d = FcDriver::new();
+        let disk = d.workload_base_bootargs(false, true);
+        assert!(disk.contains("console=ttyS0"), "got: {disk}");
+        assert!(disk.contains("root=/dev/vda"), "got: {disk}");
+        // No NIC tokens, and not another VMM's console.
+        assert!(!disk.contains("mvm.ip="), "got: {disk}");
+        assert!(!disk.contains("mvm.gw="), "got: {disk}");
+        assert!(!disk.contains("hvc0"), "got: {disk}");
+        assert!(!disk.contains("ttyAMA0"), "got: {disk}");
+
+        // Verity / initramfs base: serial console only, no root/init token.
+        let verity = d.workload_base_bootargs(false, false);
+        assert_eq!(verity, "console=ttyS0 reboot=k panic=1 net.ifnames=0");
+        assert!(!verity.contains("root="), "got: {verity}");
+
+        // The virtiofs-root variant still uses ttyS0, not another VMM's console.
+        let virtiofs = d.workload_base_bootargs(true, false);
+        assert!(virtiofs.contains("console=ttyS0"), "got: {virtiofs}");
+        assert!(virtiofs.contains("rootfstype=virtiofs"), "got: {virtiofs}");
+        assert!(!virtiofs.contains("mvm.ip="), "got: {virtiofs}");
+    }
+
+    #[test]
+    fn guest_channel_info_delegates_to_the_firecracker_backend() {
+        let d = FcDriver::new();
+        let id = VmId("fc-guest-channel-info-test-vm".into());
+        assert_eq!(
+            format!("{:?}", d.guest_channel_info(&id).map_err(|e| e.to_string())),
+            format!(
+                "{:?}",
+                FirecrackerBackend
+                    .guest_channel_info(&id)
+                    .map_err(|e| e.to_string())
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_kernel_rejects_a_bundled_kernel() {
+        // Firecracker has no bundled kernel; a bundled-kernel spec must not reach
+        // the API.
+        let spec = spec_with(KernelImage::Bundled, vec![], vec![]);
+        assert!(resolve_fc_kernel_path(&spec).is_err());
+        assert!(
+            resolve_fc_kernel_path(&spec_with(
+                KernelImage::Path("/img/vmlinux".into()),
+                vec![],
+                vec![]
+            ))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn drives_map_slot_ordered_blocks_to_vda_vdb_vdc_in_order() {
+        // Out of slot order to prove sorting: the PUT order (== FC device-letter
+        // order) must follow slot order, so slot 0 → first PUT (/dev/vda).
+        let blocks = vec![
+            ro_block("/img/overlay.ext4", 2),
+            ro_block("/img/rootfs.verity", 1),
+            ro_block("/img/rootfs.ext4", 0),
+        ];
+        let puts = fc_drive_puts(&blocks);
+        let paths: Vec<&str> = puts.iter().map(|p| p.path.as_str()).collect();
+        assert_eq!(paths, vec!["/drives/blk0", "/drives/blk1", "/drives/blk2"]);
+        // The device-letter order the guest sees lines up with BlockDev::device_node.
+        assert_eq!(blocks[2].device_node(), "/dev/vda");
+        assert_eq!(blocks[1].device_node(), "/dev/vdb");
+        assert_eq!(blocks[0].device_node(), "/dev/vdc");
+        // Only the first PUT (slot 0) is the root device; all read-only.
+        assert!(puts[0].body.contains("\"is_root_device\": true"));
+        assert!(puts[1].body.contains("\"is_root_device\": false"));
+        assert!(puts[0].body.contains("/img/rootfs.ext4"));
+        assert!(puts[1].body.contains("/img/rootfs.verity"));
+        assert!(puts[2].body.contains("/img/overlay.ext4"));
+        assert!(
+            puts.iter()
+                .all(|p| p.body.contains("\"is_read_only\": true"))
+        );
+    }
+
+    #[test]
+    fn config_threads_cmdline_verbatim_and_configures_no_nic() {
+        let mut spec = spec_with(
+            KernelImage::Path("/img/vmlinux".into()),
+            vec![guest_dials(EGRESS_PORT, "/run/egress.sock")],
+            vec![ro_block("/img/rootfs.ext4", 0)],
+        );
+        spec.cmdline = "  console=ttyS0 root=/dev/vda mvm.roothash=abc mvm.vsock_egress=1  ".into();
+        let puts = config_puts(&spec);
+
+        // The already-assembled cmdline is threaded verbatim (trimmed) — no
+        // re-derivation of verity/egress tokens.
+        let boot = body_for(&puts, "/boot-source");
+        assert!(
+            boot.contains(
+                r#""boot_args": "console=ttyS0 root=/dev/vda mvm.roothash=abc mvm.vsock_egress=1""#
+            ),
+            "boot-source did not thread the cmdline verbatim: {boot}"
+        );
+        assert!(
+            boot.contains(r#""kernel_image_path": "/img/vmlinux""#),
+            "{boot}"
+        );
+
+        // Machine config carries the resources.
+        let machine = body_for(&puts, "/machine-config");
+        assert!(machine.contains("\"vcpu_count\": 2"), "{machine}");
+        assert!(machine.contains("\"mem_size_mib\": 512"), "{machine}");
+
+        // vsock device carries the guest CID + the mux uds.
+        let vsock = body_for(&puts, "/vsock");
+        assert!(
+            vsock.contains(&format!("\"guest_cid\": {GUEST_CID}")),
+            "{vsock}"
+        );
+        assert!(vsock.contains("/state/w/runtime/v.sock"), "{vsock}");
+
+        // No NIC anywhere: no /network-interfaces PUT and no NIC JSON fields.
+        assert!(
+            puts.iter()
+                .all(|p| !p.path.starts_with("/network-interfaces")),
+            "a NIC device was configured: {:?}",
+            puts.iter().map(|p| &p.path).collect::<Vec<_>>()
+        );
+        assert!(
+            puts.iter()
+                .all(|p| !p.body.contains("iface_id") && !p.body.contains("host_dev_name")),
+            "a NIC JSON field leaked into the config"
+        );
+    }
+
+    #[test]
+    fn config_defaults_an_empty_cmdline_and_threads_the_initramfs() {
+        let mut spec = spec_with(
+            KernelImage::Path("/img/vmlinux".into()),
+            vec![],
+            vec![ro_block("/img/rootfs.ext4", 0)],
+        );
+        // Empty + a disk ⇒ the driver's default disk base.
+        let puts = config_puts(&spec);
+        let boot = body_for(&puts, "/boot-source");
+        assert!(
+            boot.contains(&fc_base_bootargs(false, true)),
+            "empty cmdline should default to the disk base: {boot}"
+        );
+        assert!(
+            !boot.contains("initrd_path"),
+            "no initramfs ⇒ no initrd_path"
+        );
+
+        // An initramfs boot threads the initrd path and defaults to the
+        // console-only base (initramfs PID 1 owns root/init).
+        spec.initramfs = Some("/img/initrd.cpio".into());
+        spec.blocks.clear();
+        let puts = config_puts(&spec);
+        let boot = body_for(&puts, "/boot-source");
+        assert!(
+            boot.contains(r#""initrd_path": "/img/initrd.cpio""#),
+            "{boot}"
+        );
+        assert!(
+            boot.contains(r#""boot_args": "console=ttyS0 reboot=k panic=1 net.ifnames=0""#),
+            "{boot}"
+        );
+    }
+
+    #[test]
+    fn balloon_is_configured_only_when_mem_initial_is_set() {
+        let mut spec = spec_with(
+            KernelImage::Path("/img/vmlinux".into()),
+            vec![],
+            vec![ro_block("/img/rootfs.ext4", 0)],
+        );
+        assert!(
+            config_puts(&spec).iter().all(|p| p.path != "/balloon"),
+            "no balloon without mem_initial"
+        );
+        spec.mem_initial_mib = Some(128);
+        let puts = config_puts(&spec);
+        let balloon = body_for(&puts, "/balloon");
+        // memory 512 - initial 128 = 384 MiB pre-inflated.
+        assert!(balloon.contains("\"amount_mib\": 384"), "{balloon}");
+        assert!(balloon.contains("\"deflate_on_oom\": true"), "{balloon}");
+    }
+
+    #[test]
+    fn wire_guest_dial_bridges_links_egress_and_broker_but_not_exit_or_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = dir.path();
+        let spec = spec_with(
+            KernelImage::Path("/img/vmlinux".into()),
+            vec![
+                host_dials(GUEST_AGENT_PORT, "/run/agent.sock"),
+                guest_dials(EGRESS_PORT, "/run/egress.sock"),
+                guest_dials(BROKER_PORT, "/run/broker.sock"),
+                guest_dials(WORKLOAD_EXIT_PORT, "/state/w/workload.exit"),
+            ],
+            vec![],
+        );
+        let created = wire_guest_dial_bridges(&spec, runtime).unwrap();
+        assert_eq!(created.len(), 2, "only egress + broker are bridged");
+
+        // Egress: v.sock_5253 → the runner's endpoint socket.
+        let egress_link = fc_guest_dial_socket(runtime, EGRESS_PORT);
+        assert_eq!(
+            std::fs::read_link(&egress_link).unwrap(),
+            PathBuf::from("/run/egress.sock")
+        );
+        // Broker similarly.
+        let broker_link = fc_guest_dial_socket(runtime, BROKER_PORT);
+        assert_eq!(
+            std::fs::read_link(&broker_link).unwrap(),
+            PathBuf::from("/run/broker.sock")
+        );
+        // The exit port is driver-bound, not bridged — no symlink for it.
+        assert!(
+            !fc_guest_dial_socket(runtime, WORKLOAD_EXIT_PORT).exists(),
+            "the workload-exit port must not be symlinked; the driver binds it"
+        );
+        // The host-dialed agent port is never bridged here.
+        assert!(!fc_guest_dial_socket(runtime, GUEST_AGENT_PORT).exists());
+    }
+
+    #[test]
+    fn workload_exit_capture_binds_and_persists_the_guest_exit_code() {
+        use std::io::{Read, Write};
+
+        let state_dir = tempfile::tempdir().unwrap();
+        let runtime = state_dir.path().join("runtime");
+        std::fs::create_dir_all(&runtime).unwrap();
+
+        // The driver binds the exit socket synchronously before returning, so a
+        // guest dial (here: a plain UnixStream, as Firecracker forwards it) lands.
+        spawn_workload_exit_capture(&runtime, state_dir.path());
+
+        let sock = fc_guest_dial_socket(&runtime, WORKLOAD_EXIT_PORT);
+        let mut client = std::os::unix::net::UnixStream::connect(&sock).unwrap();
+        client.write_all(&3i32.to_le_bytes()).unwrap();
+        // capture acks after the file is durably written.
+        let mut ack = [0u8; 1];
+        let _ = client.read_exact(&mut ack);
+
+        // wait_for_workload_exit reads the persisted code from the state dir.
+        let status = crate::workload_wait::wait_for_workload_exit(state_dir.path());
+        assert_eq!(status.code, Some(3));
+        assert!(!status.success);
+    }
+
+    #[test]
+    fn attach_builds_a_disk_backed_handle_that_reports_stopped_for_a_missing_vm() {
+        let vm = FcDriver::new()
+            .attach(&VmId("fc-nonexistent-attach-test-vm".into()))
+            .unwrap();
+        assert_eq!(vm.id().0, "fc-nonexistent-attach-test-vm");
+        assert_eq!(vm.status().unwrap(), VmStatus::Stopped);
+    }
+
+    #[test]
+    fn vsock_connect_reaches_the_agent_over_the_connect_handshake_and_rejects_other_ports() {
+        use crate::test_support::bind_unix_listener;
+        use std::io::{BufRead, BufReader, Read, Write};
+
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = dir.path().join("runtime");
+        std::fs::create_dir_all(&runtime).unwrap();
+        let vsock = runtime.join("v.sock");
+        let Some(listener) = bind_unix_listener(&vsock) else {
+            return;
+        };
+        // Firecracker's mux: read `CONNECT <port>`, reply `OK <port>`, then echo.
+        let server = std::thread::spawn(move || {
+            if let Ok((stream, _)) = listener.accept() {
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                let mut line = String::new();
+                if reader.read_line(&mut line).is_ok() {
+                    let mut w = stream;
+                    let port = line.trim().trim_start_matches("CONNECT ").trim();
+                    let _ = writeln!(w, "OK {port}");
+                    let _ = w.flush();
+                    let mut b = [0u8; 1];
+                    if reader.read_exact(&mut b).is_ok() {
+                        let _ = w.write_all(&b);
+                    }
+                }
+            }
+        });
+
+        let vm = FcRunningVm {
+            id: VmId("agent-vm".into()),
+            state_dir: dir.path().to_path_buf(),
+            pid_file: dir.path().join(FC_PID_FILE),
+            vsock_uds: vsock.to_string_lossy().into_owned(),
+        };
+
+        // The agent port connects through the CONNECT handshake + round-trips.
+        let mut s = vm.vsock_connect(GUEST_AGENT_PORT).unwrap();
+        s.write_all(b"x").unwrap();
+        let mut got = [0u8; 1];
+        s.read_exact(&mut got).unwrap();
+        assert_eq!(&got, b"x");
+        server.join().unwrap();
+
+        // Ports outside the agent + console data range are not host-dialable
+        // (rejected before any connect attempt).
+        assert!(vm.vsock_connect(GUEST_AGENT_PORT + 1).is_err());
+        assert!(vm.vsock_connect(9999).is_err());
+    }
+
+    #[test]
+    fn vsock_connect_allows_a_dev_console_data_port() {
+        // The allow-list admits the dev console data range; one past the top is
+        // rejected. Proven at the boundary without a live socket, since the
+        // reject path returns before connecting.
+        let vm = FcRunningVm {
+            id: VmId("console-vm".into()),
+            state_dir: PathBuf::from("/state/console-vm"),
+            pid_file: PathBuf::from("/state/console-vm/fc.pid"),
+            vsock_uds: "/nonexistent/runtime/v.sock".into(),
+        };
+        // In range but no listener ⇒ a connect error (not an allow-list refusal).
+        let in_range = vm
+            .vsock_connect(CONSOLE_PORT_BASE + 1)
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(
+            in_range.contains("connect to Firecracker vsock port"),
+            "an in-range port must pass the allow-list and fail at connect: {in_range}"
+        );
+        // One past the top of the range is refused by the allow-list itself.
+        let refused = vm
+            .vsock_connect(CONSOLE_PORT_BASE + 129)
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(
+            refused.contains("supports only the agent port"),
+            "an out-of-range port must be refused by the allow-list: {refused}"
+        );
+    }
+}

--- a/crates/mvm-runtime/src/driver/fc.rs
+++ b/crates/mvm-runtime/src/driver/fc.rs
@@ -28,11 +28,10 @@ use mvm_core::vm_backend::{
 use crate::backend::FirecrackerBackend;
 use crate::driver::spec::KernelImage;
 use crate::driver::{BlockDev, DuplexStream, RunningVm, VmmDriver, VmmSpec, VsockDirection};
-use crate::microvm::{api_put_socket, firecracker_vsock_uds_path, start_vm_firecracker};
-
-/// File name of Firecracker's PID marker under the VM state dir. Written by
-/// `start_vm_firecracker` and read back by the running-VM handle for kill/status.
-const FC_PID_FILE: &str = "fc.pid";
+use crate::microvm::{
+    api_put_socket, balloon_body, boot_source_body, drive_body, fc_pid_path,
+    firecracker_vsock_uds_path, logger_body, machine_config_body, start_vm_firecracker, vsock_body,
+};
 
 /// Host→guest dial timeout (seconds) for `vsock_connect`. The underlying
 /// `connect_to_port` retries the CONNECT handshake internally within this bound.
@@ -120,14 +119,17 @@ fn fc_drive_puts(blocks: &[BlockDev]) -> Vec<FcApiPut> {
         .enumerate()
         .map(|(index, block)| {
             let drive_id = format!("blk{}", block.slot);
+            // The lowest-slot block (first PUT) is the root device; each block
+            // keeps its own read-only policy. Body shape shared with the raw path.
+            let body = drive_body(
+                &drive_id,
+                &block.source.to_string_lossy(),
+                index == 0,
+                block.read_only,
+            );
             FcApiPut {
                 path: format!("/drives/{drive_id}"),
-                body: format!(
-                    r#"{{"drive_id": "{drive_id}", "path_on_host": "{path}", "is_root_device": {root}, "is_read_only": {ro}}}"#,
-                    path = block.source.to_string_lossy(),
-                    root = index == 0,
-                    ro = block.read_only,
-                ),
+                body,
             }
         })
         .collect()
@@ -149,9 +151,7 @@ fn fc_config_api_puts(
 
     puts.push(FcApiPut {
         path: "/logger".to_string(),
-        body: format!(
-            r#"{{"log_path": "{log_dir}/firecracker.log", "level": "Debug", "show_level": true, "show_log_origin": true}}"#,
-        ),
+        body: logger_body(log_dir),
     });
 
     // An empty spec cmdline means "the driver supplies its own default base";
@@ -164,37 +164,25 @@ fn fc_config_api_puts(
     } else {
         trimmed.to_string()
     };
-    let boot_source = match &spec.initramfs {
-        Some(initramfs) => format!(
-            r#"{{"kernel_image_path": "{kernel_for_boot}", "boot_args": "{cmdline}", "initrd_path": "{initrd}"}}"#,
-            initrd = initramfs.to_string_lossy(),
-        ),
-        None => {
-            format!(r#"{{"kernel_image_path": "{kernel_for_boot}", "boot_args": "{cmdline}"}}"#,)
-        }
-    };
+    let initrd = spec
+        .initramfs
+        .as_ref()
+        .map(|p| p.to_string_lossy().into_owned());
     puts.push(FcApiPut {
         path: "/boot-source".to_string(),
-        body: boot_source,
+        body: boot_source_body(kernel_for_boot, &cmdline, initrd.as_deref()),
     });
 
     puts.push(FcApiPut {
         path: "/machine-config".to_string(),
-        body: format!(
-            r#"{{"vcpu_count": {cpus}, "mem_size_mib": {mem}}}"#,
-            cpus = spec.vcpus,
-            mem = spec.memory_mib,
-        ),
+        body: machine_config_body(spec.vcpus, spec.memory_mib),
     });
 
     puts.extend(fc_drive_puts(&spec.blocks));
 
     puts.push(FcApiPut {
         path: "/vsock".to_string(),
-        body: format!(
-            r#"{{"vsock_id": "vsock0", "guest_cid": {cid}, "uds_path": "{vsock_uds}"}}"#,
-            cid = GUEST_CID,
-        ),
+        body: vsock_body(GUEST_CID, vsock_uds),
     });
 
     // Balloon only when the workload opted into elasticity: the device boots
@@ -204,9 +192,7 @@ fn fc_config_api_puts(
         let amount_mib = spec.memory_mib.saturating_sub(initial);
         puts.push(FcApiPut {
             path: "/balloon".to_string(),
-            body: format!(
-                r#"{{"amount_mib": {amount_mib}, "deflate_on_oom": true, "stats_polling_interval_s": 1}}"#,
-            ),
+            body: balloon_body(amount_mib),
         });
     }
 
@@ -281,6 +267,86 @@ fn spawn_workload_exit_capture(runtime_dir: &Path, state_dir: &Path) {
     }
 }
 
+/// The stop signal to deliver to the Firecracker process during teardown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FcStopSignal {
+    /// Graceful termination — gives Firecracker a chance to close its
+    /// virtio-blk file descriptors.
+    Terminate,
+    /// Force kill after the grace window lapses.
+    ForceKill,
+}
+
+/// Where the kill escalation ended up, so the caller can fail closed rather
+/// than report a stop that never happened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KillOutcome {
+    /// The process was already gone before we signalled.
+    AlreadyStopped,
+    /// The process exited after SIGTERM or SIGKILL.
+    Stopped,
+    /// The process was still alive after both signals — the signal could not be
+    /// delivered.
+    StillRunning,
+}
+
+/// Deliver `signal` to the sudo-launched Firecracker process recorded in
+/// `pid_file`. Firecracker is started under `sudo` and runs as **root**, so a
+/// non-root `mvmctl` cannot signal it directly — a plain `libc::kill` returns
+/// `EPERM` and silently no-ops. The signal therefore goes through `sudo kill`,
+/// the same mechanism the raw stop path uses. Best-effort: a delivery failure
+/// is logged, and the caller's liveness probe is the authority on whether the
+/// process actually stopped (so a lost race with a self-exiting process is not
+/// mistaken for a failure).
+fn fc_sudo_signal(pid_file: &str, signal: FcStopSignal) {
+    let flag = match signal {
+        FcStopSignal::Terminate => "",
+        FcStopSignal::ForceKill => " -9",
+    };
+    let q_pid = crate::base::shell::shell_quote(pid_file);
+    let script = format!(r#"[ -f {q_pid} ] && sudo kill{flag} "$(cat {q_pid})""#);
+    match crate::base::shell::run_in_vm(&script) {
+        Ok(out) if out.status.success() => {}
+        Ok(_) | Err(_) => tracing::warn!(
+            "Firecracker stop signal {signal:?} to pid in {pid_file} did not report success \
+             (the process may have already exited)"
+        ),
+    }
+}
+
+/// SIGTERM → grace → SIGKILL escalation against a Firecracker process, mirroring
+/// the raw stop path's shutdown escalation. The liveness probe, signal
+/// delivery, clock, and sleep are injected so the decision — "did the process
+/// stop, and if not did the signal even land?" — is unit-testable without a live
+/// VM or wall-clock waits.
+fn escalate_kill(
+    grace: Duration,
+    poll: Duration,
+    mut is_running: impl FnMut() -> Result<bool>,
+    mut signal: impl FnMut(FcStopSignal),
+    mut now: impl FnMut() -> Instant,
+    mut sleep: impl FnMut(Duration),
+) -> Result<KillOutcome> {
+    if !is_running()? {
+        return Ok(KillOutcome::AlreadyStopped);
+    }
+    signal(FcStopSignal::Terminate);
+    let deadline = now() + grace;
+    while now() < deadline {
+        if !is_running()? {
+            return Ok(KillOutcome::Stopped);
+        }
+        sleep(poll);
+    }
+    // Grace lapsed; force-kill and re-probe to decide whether the signal landed.
+    signal(FcStopSignal::ForceKill);
+    if is_running()? {
+        Ok(KillOutcome::StillRunning)
+    } else {
+        Ok(KillOutcome::Stopped)
+    }
+}
+
 impl VmmDriver for FcDriver {
     fn name(&self) -> &str {
         self.backend.name()
@@ -339,7 +405,8 @@ impl VmmDriver for FcDriver {
             .map_err(|e| anyhow!("create runtime dir {}: {e}", runtime_dir.display()))?;
 
         let abs_dir = state_dir.to_string_lossy().into_owned();
-        let pid_file = state_dir.join(FC_PID_FILE);
+        let pid_file = fc_pid_path(&spec.name)
+            .ok_or_else(|| anyhow!("resolve Firecracker pid path for '{}'", spec.name))?;
         // Clear any prior run's captured exit code and stale pid marker so `wait`
         // and the readiness poll observe only this launch's.
         let _ = std::fs::remove_file(mvm_core::exit_capture::exit_file_path(&state_dir));
@@ -386,8 +453,20 @@ impl VmmDriver for FcDriver {
         // Confirm the guest is up: a successful agent CONNECT over the vsock mux
         // means userspace booted and the agent is listening. Bounded so a guest
         // that never comes up fails closed rather than hanging forever.
+        let pid_file_str = pid_file.to_string_lossy().into_owned();
         let deadline = Instant::now() + AGENT_READY_TIMEOUT;
         loop {
+            // Fail fast if Firecracker itself died on boot (kernel panic,
+            // rejected config) rather than waiting out the full agent deadline.
+            // The console log carries the actionable detail. Probed ownership-
+            // independently since a sudo-launched FC runs as root.
+            if !crate::firecracker::is_vm_running(&pid_file_str)? {
+                bail!(
+                    "Firecracker process for '{}' exited before its guest agent came up; see {}/console.log",
+                    spec.name,
+                    abs_dir
+                );
+            }
             if connect_to_port(&vsock_uds, GUEST_AGENT_PORT, VSOCK_CONNECT_TIMEOUT_SECS).is_ok() {
                 break;
             }
@@ -414,8 +493,10 @@ impl VmmDriver for FcDriver {
         // re-deriving those paths — no live boot state to recover.
         let state_dir = vm_state_dir(&id.0);
         let vsock_uds = firecracker_vsock_uds_path(&state_dir.to_string_lossy());
+        let pid_file = fc_pid_path(&id.0)
+            .ok_or_else(|| anyhow!("resolve Firecracker pid path for '{}'", id.0))?;
         Ok(Box::new(FcRunningVm {
-            pid_file: state_dir.join(FC_PID_FILE),
+            pid_file,
             state_dir,
             vsock_uds,
             id: id.clone(),
@@ -439,6 +520,36 @@ struct FcRunningVm {
     vsock_uds: String,
 }
 
+impl FcRunningVm {
+    /// The kill escalation with the grace timeout, liveness probe, signal
+    /// delivery, and clock injected, so the fail-closed pid-retention decision
+    /// is unit-testable without a live VM or a wall-clock grace wait. `kill`
+    /// wires the real FC `/proc` probe + sudo signal here.
+    fn kill_with(
+        &self,
+        grace: Duration,
+        poll: Duration,
+        is_running: impl FnMut() -> Result<bool>,
+        signal: impl FnMut(FcStopSignal),
+        now: impl FnMut() -> Instant,
+        sleep: impl FnMut(Duration),
+    ) -> Result<()> {
+        match escalate_kill(grace, poll, is_running, signal, now, sleep)? {
+            KillOutcome::AlreadyStopped | KillOutcome::Stopped => {
+                let _ = std::fs::remove_file(&self.pid_file);
+                Ok(())
+            }
+            // Fail closed: do NOT remove the pid file or report success when the
+            // signal never landed — that would orphan a live root VM silently.
+            KillOutcome::StillRunning => bail!(
+                "Firecracker VM '{}' is still running after SIGTERM and SIGKILL; \
+                 the stop signal could not be delivered",
+                self.id.0
+            ),
+        }
+    }
+}
+
 impl RunningVm for FcRunningVm {
     fn id(&self) -> &VmId {
         &self.id
@@ -451,23 +562,21 @@ impl RunningVm for FcRunningVm {
     }
 
     fn kill(&self) -> Result<()> {
-        // SIGTERM → grace → SIGKILL, the same escalation the libkrun running-VM
-        // uses: SIGTERM gives Firecracker a chance to close its virtio-blk fds,
-        // then SIGKILL if it ignores us within the grace window.
-        if let Some(pid) = crate::libkrun::read_pid(&self.pid_file)
-            && crate::libkrun::pid_alive(pid)
-        {
-            crate::libkrun::send_signal(pid, libc::SIGTERM);
-            let deadline = Instant::now() + crate::libkrun::STOP_TIMEOUT;
-            while Instant::now() < deadline && crate::libkrun::pid_alive(pid) {
-                std::thread::sleep(Duration::from_millis(100));
-            }
-            if crate::libkrun::pid_alive(pid) {
-                crate::libkrun::send_signal(pid, libc::SIGKILL);
-            }
-        }
-        let _ = std::fs::remove_file(&self.pid_file);
-        Ok(())
+        // Firecracker is sudo-launched and runs as root, so the libkrun
+        // running-VM's plain `libc::kill` would return EPERM from a non-root
+        // mvmctl — neither stopping the VM nor reporting the failure. Signal
+        // through sudo (reaching the root process) and probe liveness
+        // ownership-independently via /proc/<pid>/comm; the escalation is
+        // SIGTERM → grace → SIGKILL, mirroring the raw stop path.
+        let pid_file = self.pid_file.to_string_lossy().into_owned();
+        self.kill_with(
+            crate::libkrun::STOP_TIMEOUT,
+            Duration::from_millis(100),
+            || crate::firecracker::is_vm_running(&pid_file),
+            |signal| fc_sudo_signal(&pid_file, signal),
+            Instant::now,
+            std::thread::sleep,
+        )
     }
 
     fn pause(&self) -> Result<()> {
@@ -481,10 +590,15 @@ impl RunningVm for FcRunningVm {
     }
 
     fn status(&self) -> Result<VmStatus> {
-        Ok(match crate::libkrun::read_pid(&self.pid_file) {
-            Some(pid) if crate::libkrun::pid_alive(pid) => VmStatus::Running,
-            _ => VmStatus::Stopped,
-        })
+        // Firecracker is sudo-launched and runs as root, so the libkrun
+        // running-VM's `libc::kill(pid, 0)` probe returns EPERM from a non-root
+        // mvmctl and would misreport a live VM as Stopped. Probe ownership-
+        // independently via /proc/<pid>/comm, reusing FC's own liveness helper.
+        if crate::firecracker::is_vm_running(&self.pid_file.to_string_lossy())? {
+            Ok(VmStatus::Running)
+        } else {
+            Ok(VmStatus::Stopped)
+        }
     }
 
     fn vsock_connect(&self, guest_port: u32) -> Result<Box<dyn DuplexStream>> {
@@ -849,11 +963,209 @@ mod tests {
 
     #[test]
     fn attach_builds_a_disk_backed_handle_that_reports_stopped_for_a_missing_vm() {
+        // status probes /proc/<pid>/comm through the Linux shell env; mock it so
+        // the probe is deterministic on every host (a missing VM ⇒ "no").
+        let _guard = crate::base::shell_mock::install_handler(|_| {
+            crate::base::shell_mock::MockResponse::ok("no")
+        });
         let vm = FcDriver::new()
             .attach(&VmId("fc-nonexistent-attach-test-vm".into()))
             .unwrap();
         assert_eq!(vm.id().0, "fc-nonexistent-attach-test-vm");
         assert_eq!(vm.status().unwrap(), VmStatus::Stopped);
+    }
+
+    #[test]
+    fn status_uses_the_ownership_independent_probe_not_libc_kill() {
+        // A sudo-launched Firecracker runs as root, so libc::kill(pid, 0) from a
+        // non-root mvmctl returns EPERM and would misreport a live VM as Stopped.
+        // status must instead honour the /proc/<pid>/comm probe: "yes" ⇒ Running.
+        let vm = FcRunningVm {
+            id: VmId("root-vm".into()),
+            state_dir: PathBuf::from("/state/root-vm"),
+            pid_file: PathBuf::from("/state/root-vm/fc.pid"),
+            vsock_uds: "/state/root-vm/runtime/v.sock".into(),
+        };
+        let running = crate::base::shell_mock::install_handler(|_| {
+            crate::base::shell_mock::MockResponse::ok("yes")
+        });
+        assert_eq!(vm.status().unwrap(), VmStatus::Running);
+        drop(running);
+
+        let stopped = crate::base::shell_mock::install_handler(|_| {
+            crate::base::shell_mock::MockResponse::ok("no")
+        });
+        assert_eq!(vm.status().unwrap(), VmStatus::Stopped);
+        drop(stopped);
+    }
+
+    #[test]
+    fn kill_removes_the_pid_file_when_the_vm_is_already_gone() {
+        // A "no" liveness probe short-circuits the escalation: no signals sent,
+        // the pid marker cleaned up, Ok returned.
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("fc.pid");
+        std::fs::write(&pid_file, "4242").unwrap();
+        let vm = FcRunningVm {
+            id: VmId("gone-vm".into()),
+            state_dir: dir.path().to_path_buf(),
+            pid_file: pid_file.clone(),
+            vsock_uds: "/state/gone-vm/runtime/v.sock".into(),
+        };
+        let _guard = crate::base::shell_mock::install_handler(|_| {
+            crate::base::shell_mock::MockResponse::ok("no")
+        });
+        vm.kill().unwrap();
+        assert!(!pid_file.exists(), "pid marker must be removed on kill");
+    }
+
+    #[test]
+    fn escalate_kill_returns_already_stopped_without_signalling() {
+        let mut signals = Vec::new();
+        let outcome = escalate_kill(
+            Duration::from_secs(2),
+            Duration::from_millis(10),
+            || Ok(false),
+            |s| signals.push(s),
+            Instant::now,
+            |_| {},
+        )
+        .unwrap();
+        assert_eq!(outcome, KillOutcome::AlreadyStopped);
+        assert!(signals.is_empty(), "a dead process must not be signalled");
+    }
+
+    #[test]
+    fn escalate_kill_stops_after_sigterm_within_the_grace_window() {
+        use std::cell::Cell;
+        // Alive on the pre-check, gone on the first grace-loop probe.
+        let probes = Cell::new(0u32);
+        let is_running = || {
+            let n = probes.get();
+            probes.set(n + 1);
+            Ok(n < 1)
+        };
+        let mut signals = Vec::new();
+        // A large grace + fixed clock so the loop runs (and sees the exit) rather
+        // than the deadline being the reason it ends.
+        let base = Instant::now();
+        let outcome = escalate_kill(
+            Duration::from_secs(10),
+            Duration::from_millis(10),
+            is_running,
+            |s| signals.push(s),
+            || base,
+            |_| {},
+        )
+        .unwrap();
+        assert_eq!(outcome, KillOutcome::Stopped);
+        assert_eq!(
+            signals,
+            vec![FcStopSignal::Terminate],
+            "a graceful exit must not escalate to SIGKILL"
+        );
+    }
+
+    #[test]
+    fn escalate_kill_fails_closed_when_the_signal_never_lands() {
+        // The process ignores both signals (a non-root kill of a root process
+        // that never reaches it): SIGTERM, then SIGKILL, then StillRunning.
+        let mut signals = Vec::new();
+        let base = Instant::now();
+        let tick = std::cell::Cell::new(0u64);
+        let now = || {
+            let n = tick.get();
+            tick.set(n + 1);
+            base + Duration::from_millis(n)
+        };
+        let outcome = escalate_kill(
+            Duration::from_millis(1),
+            Duration::from_millis(10),
+            || Ok(true),
+            |s| signals.push(s),
+            now,
+            |_| {},
+        )
+        .unwrap();
+        assert_eq!(outcome, KillOutcome::StillRunning);
+        assert_eq!(
+            signals,
+            vec![FcStopSignal::Terminate, FcStopSignal::ForceKill],
+            "an unresponsive process must be escalated to SIGKILL"
+        );
+    }
+
+    #[test]
+    fn kill_fails_closed_and_keeps_the_pid_file_when_the_signal_cannot_land() {
+        // A liveness probe that always reports alive models a root VM a non-root
+        // mvmctl can't signal. kill_with (the injectable seam kill delegates to)
+        // must surface the failure and NOT remove the pid file — removing it
+        // would orphan a live root VM silently. Injected clock so no 2s wait.
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("fc.pid");
+        std::fs::write(&pid_file, "4242").unwrap();
+        let vm = FcRunningVm {
+            id: VmId("wedged-vm".into()),
+            state_dir: dir.path().to_path_buf(),
+            pid_file: pid_file.clone(),
+            vsock_uds: "/state/wedged-vm/runtime/v.sock".into(),
+        };
+        let base = Instant::now();
+        let tick = std::cell::Cell::new(0u64);
+        let now = || {
+            let n = tick.get();
+            tick.set(n + 1);
+            base + Duration::from_millis(n)
+        };
+        let err = vm
+            .kill_with(
+                Duration::from_millis(1),
+                Duration::from_millis(10),
+                || Ok(true),
+                |_| {},
+                now,
+                |_| {},
+            )
+            .expect_err("kill must fail closed when the signal can't land");
+        assert!(
+            err.to_string().contains("still running"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            pid_file.exists(),
+            "pid marker must survive a failed kill so the live VM isn't orphaned silently"
+        );
+    }
+
+    #[test]
+    fn fc_sudo_signal_routes_terminate_and_forcekill_through_sudo() {
+        use std::sync::{Arc, Mutex};
+        // Capture the emitted shell script to prove SIGTERM omits -9 and the
+        // force kill adds it — and that both go through sudo (root reach).
+        let scripts: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = scripts.clone();
+        let _guard = crate::base::shell_mock::install_handler(move |s: &str| {
+            sink.lock().unwrap().push(s.to_string());
+            crate::base::shell_mock::MockResponse::empty()
+        });
+        fc_sudo_signal("/state/vm/fc.pid", FcStopSignal::Terminate);
+        fc_sudo_signal("/state/vm/fc.pid", FcStopSignal::ForceKill);
+        let captured = scripts.lock().unwrap();
+        assert!(
+            captured[0].contains("sudo kill "),
+            "SIGTERM: {}",
+            captured[0]
+        );
+        assert!(
+            !captured[0].contains("kill -9"),
+            "SIGTERM must not force: {}",
+            captured[0]
+        );
+        assert!(
+            captured[1].contains("sudo kill -9"),
+            "ForceKill: {}",
+            captured[1]
+        );
     }
 
     #[test]
@@ -889,7 +1201,7 @@ mod tests {
         let vm = FcRunningVm {
             id: VmId("agent-vm".into()),
             state_dir: dir.path().to_path_buf(),
-            pid_file: dir.path().join(FC_PID_FILE),
+            pid_file: dir.path().join("fc.pid"),
             vsock_uds: vsock.to_string_lossy().into_owned(),
         };
 

--- a/crates/mvm-runtime/src/driver/mod.rs
+++ b/crates/mvm-runtime/src/driver/mod.rs
@@ -2,12 +2,14 @@
 //! (workload admission/egress/audit, builder orchestration) living in the role
 //! runners above it.
 
+pub mod fc;
 pub mod hvf;
 pub mod libkrun;
 pub mod mock;
 pub mod spec;
 pub mod traits;
 
+pub use fc::FcDriver;
 pub use hvf::HvfDriver;
 pub use libkrun::LibkrunDriver;
 pub use mock::{MockDriver, MockRunningVm};

--- a/crates/mvm-runtime/src/microvm/boot_config.rs
+++ b/crates/mvm-runtime/src/microvm/boot_config.rs
@@ -162,6 +162,74 @@ fn resolve_effective_initrd(config: &FlakeRunConfig) -> Result<Option<String>> {
     Ok(effective_initrd)
 }
 
+// ── Firecracker per-device API PUT body builders ─────────────────────────────
+//
+// One scalar-parameterized builder per device body, shared by the raw flake
+// path (the `configure_*` functions below) and the converged NIC-less driver.
+// A field change to any body now lands in exactly one place instead of drifting
+// between two copies. The `api_put_socket` call stays per-caller; only the
+// body-string construction is shared.
+
+/// Firecracker `/logger` PUT body. `log_dir` is the per-VM directory whose
+/// `firecracker.log` the VMM writes.
+pub fn logger_body(log_dir: &str) -> String {
+    format!(
+        r#"{{"log_path": "{log_dir}/firecracker.log", "level": "Debug", "show_level": true, "show_log_origin": true}}"#,
+    )
+}
+
+/// Firecracker `/machine-config` PUT body: vCPU count and memory size.
+pub fn machine_config_body(vcpus: u32, mem_mib: u32) -> String {
+    format!(r#"{{"vcpu_count": {vcpus}, "mem_size_mib": {mem_mib}}}"#)
+}
+
+/// Firecracker `/boot-source` PUT body. The `initrd_path` field is emitted only
+/// when an initramfs is present, matching the two shapes the API accepts (an
+/// initramfs boot owns root mounting; a plain boot lets the kernel mount vda).
+pub fn boot_source_body(
+    kernel_image_path: &str,
+    boot_args: &str,
+    initrd_path: Option<&str>,
+) -> String {
+    match initrd_path {
+        Some(initrd) => format!(
+            r#"{{"kernel_image_path": "{kernel_image_path}", "boot_args": "{boot_args}", "initrd_path": "{initrd}"}}"#,
+        ),
+        None => {
+            format!(r#"{{"kernel_image_path": "{kernel_image_path}", "boot_args": "{boot_args}"}}"#,)
+        }
+    }
+}
+
+/// Firecracker `/drives/<id>` PUT body. Firecracker assigns guest device letters
+/// in API-call order, so the caller owns the ordering; this only shapes one
+/// drive's JSON.
+pub fn drive_body(
+    drive_id: &str,
+    path_on_host: &str,
+    is_root_device: bool,
+    is_read_only: bool,
+) -> String {
+    format!(
+        r#"{{"drive_id": "{drive_id}", "path_on_host": "{path_on_host}", "is_root_device": {is_root_device}, "is_read_only": {is_read_only}}}"#,
+    )
+}
+
+/// Firecracker `/vsock` PUT body: the single vsock device (`vsock0`) with the
+/// guest CID and the host-side UDS the mux binds.
+pub fn vsock_body(guest_cid: u32, uds_path: &str) -> String {
+    format!(r#"{{"vsock_id": "vsock0", "guest_cid": {guest_cid}, "uds_path": "{uds_path}"}}"#)
+}
+
+/// Firecracker `/balloon` PUT body. `deflate_on_oom` is always on so the device
+/// yields pages back under guest memory pressure instead of letting the guest
+/// OOM-kill the workload while the host still has memory to give.
+pub fn balloon_body(amount_mib: u32) -> String {
+    format!(
+        r#"{{"amount_mib": {amount_mib}, "deflate_on_oom": true, "stats_polling_interval_s": 1}}"#
+    )
+}
+
 /// Configure a flake-built microVM via the Firecracker API (multi-VM).
 #[instrument(skip_all, fields(name = %config.name))]
 pub fn configure_flake_microvm(config: &FlakeRunConfig, abs_dir: &str, socket: &str) -> Result<()> {
@@ -198,14 +266,7 @@ pub fn configure_flake_microvm_with_drives_dir(
 /// Configure the Firecracker logger sink (`/logger`).
 fn configure_logger(socket: &str, abs_dir: &str) -> Result<()> {
     ui::info("Configuring logger...");
-    api_put_socket(
-        socket,
-        "/logger",
-        &format!(
-            r#"{{"log_path": "{dir}/firecracker.log", "level": "Debug", "show_level": true, "show_log_origin": true}}"#,
-            dir = abs_dir,
-        ),
-    )
+    api_put_socket(socket, "/logger", &logger_body(abs_dir))
 }
 
 /// Configure the Firecracker boot source (`/boot-source`): kernel image
@@ -310,27 +371,13 @@ fn configure_boot_source(
             .with_context(|| {
                 format!("preparing FC-loadable kernel from {}", config.vmlinux_path)
             })?;
-    let kernel_for_boot = kernel_for_boot.display();
+    let kernel_for_boot = kernel_for_boot.display().to_string();
 
     ui::info(&format!("Setting boot source: {kernel_for_boot}"));
-    let boot_source = match &effective_initrd {
-        Some(initrd) => {
-            ui::info(&format!("Using initrd: {}", initrd));
-            format!(
-                r#"{{"kernel_image_path": "{kernel}", "boot_args": "{args}", "initrd_path": "{initrd}"}}"#,
-                kernel = kernel_for_boot,
-                args = boot_args,
-                initrd = initrd,
-            )
-        }
-        None => {
-            format!(
-                r#"{{"kernel_image_path": "{kernel}", "boot_args": "{args}"}}"#,
-                kernel = kernel_for_boot,
-                args = boot_args,
-            )
-        }
-    };
+    if let Some(initrd) = &effective_initrd {
+        ui::info(&format!("Using initrd: {}", initrd));
+    }
+    let boot_source = boot_source_body(&kernel_for_boot, &boot_args, effective_initrd.as_deref());
     api_put_socket(socket, "/boot-source", &boot_source)
 }
 
@@ -344,11 +391,7 @@ fn configure_machine(socket: &str, config: &FlakeRunConfig) -> Result<()> {
     api_put_socket(
         socket,
         "/machine-config",
-        &format!(
-            r#"{{"vcpu_count": {cpus}, "mem_size_mib": {mem}}}"#,
-            cpus = config.cpus,
-            mem = config.memory,
-        ),
+        &machine_config_body(config.cpus, config.memory),
     )
 }
 
@@ -372,11 +415,7 @@ fn configure_drives(
     api_put_socket(
         socket,
         "/drives/rootfs",
-        &format!(
-            r#"{{"drive_id": "rootfs", "path_on_host": "{rootfs}", "is_root_device": true, "is_read_only": {ro}}}"#,
-            rootfs = config.rootfs_path,
-            ro = rootfs_read_only,
-        ),
+        &drive_body("rootfs", &config.rootfs_path, true, rootfs_read_only),
     )?;
 
     // dm-verity Merkle tree → /dev/vdb. Firecracker assigns drive
@@ -388,10 +427,7 @@ fn configure_drives(
         api_put_socket(
             socket,
             "/drives/verity",
-            &format!(
-                r#"{{"drive_id": "verity", "path_on_host": "{path}", "is_root_device": false, "is_read_only": true}}"#,
-                path = verity_path,
-            ),
+            &drive_body("verity", verity_path, false, true),
         )?;
     }
 
@@ -406,10 +442,7 @@ fn configure_drives(
         api_put_socket(
             socket,
             "/drives/runtime_overlay",
-            &format!(
-                r#"{{"drive_id": "runtime_overlay", "path_on_host": "{path}", "is_root_device": false, "is_read_only": true}}"#,
-                path = overlay_path,
-            ),
+            &drive_body("runtime_overlay", overlay_path, false, true),
         )?;
         if config.roothash.is_some() {
             ui::info(&format!(
@@ -419,10 +452,7 @@ fn configure_drives(
             api_put_socket(
                 socket,
                 "/drives/runtime_verity",
-                &format!(
-                    r#"{{"drive_id": "runtime_verity", "path_on_host": "{path}", "is_root_device": false, "is_read_only": true}}"#,
-                    path = overlay_verity_path,
-                ),
+                &drive_body("runtime_verity", overlay_verity_path, false, true),
             )?;
         }
     }
@@ -433,10 +463,7 @@ fn configure_drives(
     api_put_socket(
         socket,
         "/drives/config",
-        &format!(
-            r#"{{"drive_id": "config", "path_on_host": "{path}", "is_root_device": false, "is_read_only": true}}"#,
-            path = config_drive,
-        ),
+        &drive_body("config", &config_drive, false, true),
     )?;
 
     // Attach the mvm-secrets drive ONLY when there is something to put on it.
@@ -453,10 +480,7 @@ fn configure_drives(
         api_put_socket(
             socket,
             "/drives/secrets",
-            &format!(
-                r#"{{"drive_id": "secrets", "path_on_host": "{path}", "is_root_device": false, "is_read_only": true}}"#,
-                path = secrets_drive,
-            ),
+            &drive_body("secrets", &secrets_drive, false, true),
         )?;
     }
 
@@ -470,12 +494,7 @@ fn configure_drives(
         api_put_socket(
             socket,
             &format!("/drives/{}", drive_id),
-            &format!(
-                r#"{{"drive_id": "{id}", "path_on_host": "{host}", "is_root_device": false, "is_read_only": {ro}}}"#,
-                id = drive_id,
-                host = vol.host,
-                ro = vol.read_only,
-            ),
+            &drive_body(&drive_id, &vol.host, false, vol.read_only),
         )?;
     }
 
@@ -508,11 +527,7 @@ fn configure_vsock(socket: &str, drives_dir: &str) -> Result<()> {
     api_put_socket(
         socket,
         "/vsock",
-        &format!(
-            r#"{{"vsock_id": "vsock0", "guest_cid": {cid}, "uds_path": "{vsock}"}}"#,
-            cid = mvm_agentd::vsock::GUEST_CID,
-            vsock = vsock,
-        ),
+        &vsock_body(mvm_agentd::vsock::GUEST_CID, &vsock),
     )
 }
 
@@ -533,14 +548,7 @@ fn configure_balloon(socket: &str, config: &FlakeRunConfig) -> Result<()> {
             "Attaching virtio-balloon (cap {} MiB, initial commit {} MiB, balloon {} MiB)",
             config.memory, initial, amount_mib
         ));
-        api_put_socket(
-            socket,
-            "/balloon",
-            &format!(
-                r#"{{"amount_mib": {amount}, "deflate_on_oom": true, "stats_polling_interval_s": 1}}"#,
-                amount = amount_mib,
-            ),
-        )?;
+        api_put_socket(socket, "/balloon", &balloon_body(amount_mib))?;
     }
     Ok(())
 }
@@ -576,6 +584,130 @@ mod tests {
             network_policy: mvm_core::network_policy::NetworkPolicy::default(),
             network_tunnel: None,
         }
+    }
+
+    // ------------------------------------------------------------------
+    // Firecracker API body builders — byte-identical pins
+    //
+    // These lock each shared body builder to the exact JSON the raw flake path
+    // emitted inline before the extraction, so the driver and the raw path can
+    // never silently diverge and the raw (Linux production default) path stays
+    // byte-for-byte unchanged.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn logger_body_pins_the_exact_json() {
+        let legacy = format!(
+            r#"{{"log_path": "{dir}/firecracker.log", "level": "Debug", "show_level": true, "show_log_origin": true}}"#,
+            dir = "/vms/w",
+        );
+        assert_eq!(logger_body("/vms/w"), legacy);
+        assert_eq!(
+            logger_body("/vms/w"),
+            r#"{"log_path": "/vms/w/firecracker.log", "level": "Debug", "show_level": true, "show_log_origin": true}"#,
+        );
+    }
+
+    #[test]
+    fn machine_config_body_pins_the_exact_json() {
+        let legacy = format!(
+            r#"{{"vcpu_count": {cpus}, "mem_size_mib": {mem}}}"#,
+            cpus = 2,
+            mem = 1024,
+        );
+        assert_eq!(machine_config_body(2, 1024), legacy);
+        assert_eq!(
+            machine_config_body(2, 1024),
+            r#"{"vcpu_count": 2, "mem_size_mib": 1024}"#,
+        );
+    }
+
+    #[test]
+    fn boot_source_body_pins_both_shapes() {
+        // No initramfs: kernel + boot_args only.
+        let legacy_plain = format!(
+            r#"{{"kernel_image_path": "{kernel}", "boot_args": "{args}"}}"#,
+            kernel = "/img/vmlinux",
+            args = "console=ttyS0",
+        );
+        assert_eq!(
+            boot_source_body("/img/vmlinux", "console=ttyS0", None),
+            legacy_plain,
+        );
+        assert_eq!(
+            boot_source_body("/img/vmlinux", "console=ttyS0", None),
+            r#"{"kernel_image_path": "/img/vmlinux", "boot_args": "console=ttyS0"}"#,
+        );
+
+        // With initramfs: the initrd_path field is appended.
+        let legacy_initrd = format!(
+            r#"{{"kernel_image_path": "{kernel}", "boot_args": "{args}", "initrd_path": "{initrd}"}}"#,
+            kernel = "/img/vmlinux",
+            args = "console=ttyS0",
+            initrd = "/img/initrd.cpio",
+        );
+        assert_eq!(
+            boot_source_body("/img/vmlinux", "console=ttyS0", Some("/img/initrd.cpio")),
+            legacy_initrd,
+        );
+        assert_eq!(
+            boot_source_body("/img/vmlinux", "console=ttyS0", Some("/img/initrd.cpio")),
+            r#"{"kernel_image_path": "/img/vmlinux", "boot_args": "console=ttyS0", "initrd_path": "/img/initrd.cpio"}"#,
+        );
+    }
+
+    #[test]
+    fn drive_body_pins_root_and_non_root_shapes() {
+        // Root device, read-write (the plain-rootfs unverified boot).
+        let legacy_root = format!(
+            r#"{{"drive_id": "rootfs", "path_on_host": "{rootfs}", "is_root_device": true, "is_read_only": {ro}}}"#,
+            rootfs = "/k/rootfs.ext4",
+            ro = false,
+        );
+        assert_eq!(
+            drive_body("rootfs", "/k/rootfs.ext4", true, false),
+            legacy_root,
+        );
+        assert_eq!(
+            drive_body("rootfs", "/k/rootfs.ext4", true, false),
+            r#"{"drive_id": "rootfs", "path_on_host": "/k/rootfs.ext4", "is_root_device": true, "is_read_only": false}"#,
+        );
+
+        // Non-root read-only sidecar (verity/overlay/config/secrets shape).
+        let legacy_sidecar = format!(
+            r#"{{"drive_id": "verity", "path_on_host": "{path}", "is_root_device": false, "is_read_only": true}}"#,
+            path = "/k/rootfs.verity",
+        );
+        assert_eq!(
+            drive_body("verity", "/k/rootfs.verity", false, true),
+            legacy_sidecar,
+        );
+    }
+
+    #[test]
+    fn vsock_body_pins_the_exact_json() {
+        let legacy = format!(
+            r#"{{"vsock_id": "vsock0", "guest_cid": {cid}, "uds_path": "{vsock}"}}"#,
+            cid = mvm_agentd::vsock::GUEST_CID,
+            vsock = "/vms/w/runtime/v.sock",
+        );
+        assert_eq!(
+            vsock_body(mvm_agentd::vsock::GUEST_CID, "/vms/w/runtime/v.sock"),
+            legacy,
+        );
+    }
+
+    #[test]
+    fn balloon_body_pins_the_exact_json() {
+        let legacy = format!(
+            r#"{{"amount_mib": {amount}, "deflate_on_oom": true, "stats_polling_interval_s": 1}}"#,
+            amount = 384,
+        );
+        assert_eq!(balloon_body(384), legacy);
+        assert_eq!(
+            balloon_body(384),
+            r#"{"amount_mib": 384, "deflate_on_oom": true, "stats_polling_interval_s": 1}"#,
+        );
     }
 
     // ------------------------------------------------------------------

--- a/crates/mvm-runtime/src/selection.rs
+++ b/crates/mvm-runtime/src/selection.rs
@@ -7,7 +7,7 @@
 
 use mvm_core::vm_backend::{RequiredCapabilities, VmCapabilities};
 
-use crate::backend::{AnyBackend, FirecrackerBackend, libkrun_runner};
+use crate::backend::{AnyBackend, fc_runner, libkrun_runner};
 use crate::hvf_backend::HvfBackend;
 use crate::qemu::QemuBackend;
 
@@ -63,7 +63,7 @@ impl AnyBackend {
     /// must never be a capability-selection candidate.
     fn capability_candidates() -> [AnyBackend; 4] {
         [
-            AnyBackend::Firecracker(FirecrackerBackend),
+            AnyBackend::Firecracker(fc_runner()),
             AnyBackend::Hvf(HvfBackend),
             AnyBackend::Libkrun(libkrun_runner()),
             AnyBackend::Qemu(QemuBackend),

--- a/specs/notes/2026-07-22-fc-driver-convergence-design.md
+++ b/specs/notes/2026-07-22-fc-driver-convergence-design.md
@@ -1,0 +1,165 @@
+# F3 — FcDriver convergence: design & scoping note
+
+**Date:** 2026-07-22
+**Context:** Plan 258 (uniform vsock-egress convergence). libkrun converged + live-witnessed
+(#1766); HVF routes via `HvfDriver`. Firecracker is the last workload backend with its own
+`VmBackend` impl. This note scopes F3 — converging Firecracker onto
+`WorkloadRunner<FcDriver, RealEndpointSpawner, RealBrokerRegistrar>` — before any code.
+
+Firecracker is the **Linux default** workload backend and `auto_select`'s final fallback, so a
+regression here has higher blast radius than the libkrun flip. This note mirrors the libkrun
+flip exactly: a dormant driver PR, then a retype PR gated on an observed live-KVM egress witness.
+
+## What the seam already gives us (nothing to port from the backend)
+
+The runner does every role step backend-agnostically, above the driver:
+
+- **Egress endpoint** — `RealEndpointSpawner` spawns one per-VM `mvm-substitution-endpoint`
+  (`EndpointTransport::Uds` → `vm_substitution_endpoint_socket(vm)`), threads its UDS into the
+  spec as the `EGRESS_PORT` `GuestDials` channel (`runner.rs`, `spec_map.rs`). The claim-10 gate
+  + claims-12/13 substitution live there.
+- **`mvm.vsock_egress=1`, verity, grants, runtime-overlay, uvols** — assembled once in
+  `workload_runner/cmdline.rs` and handed to the driver as `spec.cmdline`. FC gets the egress
+  token for free on retype (it emits none today).
+- **Broker** — `RealBrokerRegistrar` (claims 12/13). **Admission gates** — overlay contract +
+  `record_from_start_config` (claim-15 console gate) in `WorkloadRunner::start`.
+- **No NIC** — `VmmSpec` has no network field by construction; a driver cannot add or bypass
+  egress policy. "No routable guest NIC" is a property of the type.
+
+So the scoped-but-superseded `wsnet/fc-model-b` branch (stale: 1 ahead / 24 behind, both its
+companion fixes — OCI overlay-first #1747, seccomp `lseek` #1749 — already on main) contributes
+almost nothing to port. Its only reusable nuggets: the FC vsock per-port UDS naming, the
+capability values, and the live confirmation that a guest vsock dial reaches the host endpoint
+over FC userspace virtio-vsock. **Build FcDriver on origin/main; do not rebase that branch.**
+
+## Current Firecracker state (from code, file:line)
+
+- `FirecrackerBackend` — `backend.rs:155` (struct), `impl VmBackend` `backend.rs:220`, `start`
+  `backend.rs:285`. `firecracker.rs` is only install/asset/checkpoint helpers.
+- Boot: `start` → `FirecrackerConfig::from_start_config` (slot + `FlakeRunConfig`) →
+  `microvm::run_from_build` (`flake_run.rs:163`) → `run_configured_firecracker` (`flake_run.rs:236`):
+  TAP provision + iptables policy → optional `mvm-bridge` → `start_vm_firecracker`
+  (`daemon.rs:86`, `firecracker --api-sock`, pid→`fc.pid`) → `spawn_egress_endpoint` →
+  tunnel worker → `configure_flake_microvm` (API sequence, `boot_config.rs:175`) → `InstanceStart`
+  → `install_egress_redirect` (post-boot nft REDIRECT).
+- API config sequence (`boot_config.rs:175`): logger, boot-source (kernel+initrd+cmdline),
+  machine-config, drives, **network-interfaces/net1**, vsock, balloon.
+- Reusable primitives (call, don't fork): kernel-prep `mvm_build::fc_kernel::ensure_fc_loadable_kernel`
+  (`boot_config.rs:309`; FC's `libkrun_kernel_for_host` analogue), `build_verity_cmdline_args`
+  (`boot_config.rs:59`), `build_runtime_overlay_cmdline_args` (`:79`), `configure_drives` (`:360`),
+  `configure_vsock` (`:504`), `configure_machine` (`:339`), `start_vm_firecracker`/`api_put_socket`
+  (`daemon.rs`).
+- vsock: `guest_cid=GUEST_CID(3)`, `uds_path=firecracker_vsock_uds_path(dir)` =
+  `<vm_dir>/runtime/v.sock` (`mod.rs:84`). Host→guest = connect `v.sock` + `CONNECT <port>\n`
+  (`vsock_transport.rs`). Guest→host = FC muxes to sibling **`v.sock_<port>`**.
+- Egress today: routable NIC (`configure_network` `boot_config.rs:486`, `mvm.ip=`/`mvm.gw=`
+  `:226`), TAP + **iptables** deny (`network.rs::apply_network_policy`; provider default
+  `deny_all`), substitution endpoint `EndpointTransport::Vsock{EGRESS_PORT}` **+ transparent
+  terminator** (`egress_bridge.rs:185`), nft `:80/:443` REDIRECT (`egress_redirect.rs`). FC emits
+  neither `mvm.vsock_egress=1` nor `mvm.network_tunnel=` (its token builder is `#[cfg(test)]`),
+  so its tunnel worker is spawned but never activated — FC egress today is purely NIC+iptables.
+- Caps (`backend.rs:229`): `tap_networking:true`, `no_routable_guest_nic:false` (default),
+  `host_vsock_proxy:false` (default). The converged driver flips to the libkrun profile.
+
+### Mission-brief corrections
+
+- FC's TAP deny is **iptables** (`network.rs`), not nftables `install_default_deny` — the latter
+  is the hostd-supervisor firewall (`supervisor/firewall/linux_nft.rs`), a *different* subsystem
+  not on the FC start path. nftables on FC is only the `:80/:443` REDIRECT.
+- **Raw FC start is not deletable in F4.** Besides `FirecrackerBackend::start`, the hostd
+  supervisor's admitted-plan launcher (`FirecrackerRunConfigLauncher::launch` →
+  `mvm_runtime::microvm::run_from_build`, `mvm-hostd/src/supervisor/backend.rs:144`) drives
+  `run_from_build` directly. That is the mvmd/fleet multi-tenant path; converging it is out of
+  F3/F4 scope (its egress is the supervisor nft firewall). The libkrun flip left its supervisor
+  path raw too. So the F4 gate scopes to the **`AnyBackend` (mvmctl CLI/local) workload path**.
+- `bench_probe` pins **libkrun**, not FC — there is no raw-FC bench caller to migrate.
+
+## FcDriver design (`crates/mvm-runtime/src/driver/fc.rs`)
+
+`FcDriver: VmmDriver`, wrapping a `FirecrackerBackend` for identity/`is_available`/kind, mirroring
+`LibkrunDriver`. Pure mechanics: it never sees a plan, tenant, or `NetworkPolicy`.
+
+- `workload_base_bootargs(virtiofs_root, has_disk)` — FC's serial-console base
+  (`console=ttyS0 reboot=k panic=1 net.ifnames=0` + root/init by shape), **no `mvm.ip=`/`mvm.gw=`**.
+  Routed through the seam (do not hardcode a console class — libkrun=hvc0, HVF=pl011, FC=ttyS0).
+- `capabilities()` — `tap_networking:false`, `no_routable_guest_nic:true`, `host_vsock_proxy:true`
+  (the libkrun profile).
+- `boot(&VmmSpec)` — a NIC-less, endpoint-free FC boot assembled from the spec, reusing the
+  boot_config/daemon primitives above (not `run_configured_firecracker`, which is entangled with
+  TAP/egress/FlakeRunConfig):
+  1. `ensure_fc_loadable_kernel(spec.kernel)`; `start_vm_firecracker(dir, socket)` → `fc.pid`.
+  2. API: logger; boot-source (kernel, `spec.initramfs`, **`spec.cmdline` verbatim** — the runner
+     already assembled every token); machine-config (`spec.vcpus`/`memory_mib`/`mem_initial_mib`);
+     drives from `spec.blocks` sorted by `slot` (vda/vdb/vdc/… — the shared verity slot model
+     the runner's `build_verity_cmdline_args` names); vsock (`v.sock`, `guest_cid`); balloon if
+     `mem_initial`.
+  3. **No** `configure_network`, TAP, iptables, `spawn_egress_endpoint`, or `install_egress_redirect`.
+  4. vsock egress bridge (the one FC-specific nugget): for each `GuestDials` port, make the FC
+     sibling socket `v.sock_<port>` resolve to the spec's `host_uds`. For `EGRESS_PORT` that is
+     the runner endpoint's `substitution-endpoint.sock`; for `WORKLOAD_EXIT_PORT`/`BROKER_PORT`
+     the runner's state-dir sockets. This is FC's analogue of libkrun's `egress_relay_socket` /
+     `add_host_listen_port_at`. Mechanism (symlink vs bind-relay) decided in F3.1; a symlink of
+     `v.sock_<port>` → `host_uds` is the zero-overhead candidate (FC *connects* to that path for a
+     guest-initiated dial), validated live.
+  5. `InstanceStart`; poll `fc.pid` + the agent socket; return `FcRunningVm { id, state_dir, pid_file }`.
+- `RunningVm` — `fc.pid` lifecycle (kill/status/wait via the existing FC helpers);
+  `vsock_connect(port)` = `connect_to_port(v.sock, port)` (agent + dev-console ports only, claim-15).
+- `attach(id)` — disk-backed (re-derive `fc.pid` + state dir), like `LibkrunDriver::attach`.
+
+**Reuse-first rule for F3.1:** where a boot_config primitive is entangled with FlakeRunConfig or
+the NIC, extract the shared inner helper both the raw path and the driver call — never a second
+copy. The 0-byte-console libkrun regression came from a forked cmdline branch; the driver must
+reuse `ensure_fc_loadable_kernel` + `build_verity_cmdline_args` + `configure_drives`/`configure_vsock`,
+not reimplement them.
+
+## Slices (each its own PR + task review; the retype gated on a live witness)
+
+- **F3.1 — FcDriver mechanics, dormant.** New `driver/fc.rs` + `driver/mod.rs` export. Full host
+  unit tests (relay-config-style: no NIC, egress/exit/broker `v.sock_<port>` bridged to the spec
+  `host_uds`, `spec.cmdline` threaded verbatim, drives slot-ordered vda/vdb/vdc, caps flipped,
+  bundled-kernel rejected, `attach` disk-backed). Extract shared FC boot primitives (no fork).
+  **Not** wired into `AnyBackend` — dormant, exactly as the libkrun driver landed before its flip.
+- **F3.2 — retype `AnyBackend::Firecracker`.** `type FcRunner` + `fc_runner()`; swap the enum
+  variant + `default_backend`/`from_build_output`/`auto_select`(×2)/`capability_candidates`
+  (selection.rs) + catalog + `from_hypervisor`. Flip catalog rows (warm_start/balloon → false,
+  needs_plan_json → false, marker stays `fc.pid`). Update the enum/kind/dispatch tests. Host gates
+  green. This makes the runner FC's sole mvmctl-CLI path.
+- **F3.3 — live FC egress witness (Hetzner KVM, run from the main loop via SSH).** Default-deny,
+  egress-attempting workload. Arm the merge only after it passes.
+
+## Decisions for the owner (batched, before F3.1)
+
+1. **Warm-start/standby + balloon descope on the Linux default.** Retyping FC onto the runner
+   drops FC's warm-start (snapshot restore), standby pool, and balloon from the mvmctl path (the
+   runner takes trait defaults, like libkrun). A plain transient `machine run` calls `start`, not
+   `warm_start`, so this only affects explicit warm-pool usage; FC warm-start also stays available
+   on the raw hostd-supervisor path. **Recommend descope** (flip catalog rows, mirror libkrun) +
+   track "port standby into the runner" as a deferred follow-up. Flagged because FC is the
+   production default, not a Tier-2 backend.
+2. **claim-10 enforcement-point shift for FC.** FC today pins admission-time IPs at iptables on
+   the TAP (Model A). The runner moves claim-10 to the host-side endpoint that re-resolves the
+   destination per connection (Model B, pin-consistency → host-resolution). libkrun/HVF already
+   made this shift and it is witnessed; FC makes the same shift. The live witness must re-confirm
+   default-deny holds on the FC vsock path. (Owner-awareness item, not a blocker.)
+3. **Convergence claim is scoped to the CLI path.** The F4 gate proves the `AnyBackend` workload
+   backends are runners with egress only in `RealEndpointSpawner`. The hostd-supervisor / mvmd
+   fleet FC launcher keeps raw `run_from_build` + its nft firewall — the same scope boundary
+   libkrun's flip left. If the intent is "every FC launch," converging the supervisor launcher is
+   a separate, larger effort to sequence after F3.
+
+## Live witness definition (F3.3 — the merge gate)
+
+`MVM_HYPERVISOR=firecracker` (or `--hypervisor` once F1/#1772 lands), `machine run --image alpine`,
+entrypoint that attempts egress (`wget -T 8 -O- http://example.com`), **no `--network-allow`**.
+Observe all of: boots (console fills), agent reachable (`listening on vsock port 5252`), **no
+routable NIC** (`eth0: No such device`), egress endpoint spawned with the guest EGRESS_PORT pinned
+to `substitution-endpoint.sock` (via the `v.sock_5253` bridge), and default-deny **blocks** the
+outbound attempt. Host tests do not boot a guest — this witness is mandatory, not CI alone.
+
+## Deferred follow-ups (track in plan 258)
+
+- Port FC warm-start/standby into the runner (if CLI warm-pool needs it).
+- Converge the hostd-supervisor FC launcher onto the runner (fleet path).
+- F4 gate + retire libkrun `spawn_libkrun_egress_endpoint` / FC `egress_bridge` raw wiring on the
+  CLI path; delete raw `LibkrunBackend::start` after migrating `bench_probe`.
+- F5: delete the smoltcp-L3 stack; HVF fail-closed on the endpoint.

--- a/specs/notes/2026-07-22-fc-driver-convergence-design.md
+++ b/specs/notes/2026-07-22-fc-driver-convergence-design.md
@@ -163,3 +163,18 @@ outbound attempt. Host tests do not boot a guest — this witness is mandatory, 
 - F4 gate + retire libkrun `spawn_libkrun_egress_endpoint` / FC `egress_bridge` raw wiring on the
   CLI path; delete raw `LibkrunBackend::start` after migrating `bench_probe`.
 - F5: delete the smoltcp-L3 stack; HVF fail-closed on the endpoint.
+
+### Post-F3 review follow-ups (from the final whole-branch review; non-blocking)
+
+- Delete or route `AnyBackend::start_firecracker` — it still drives the raw `microvm::run_from_build`
+  (NIC/TAP) path for the Firecracker arm. Zero callers today, but now that the variant is the
+  NIC-less runner it reads as a raw-boot bypass; fold into F4's raw-path retirement.
+- Detached-VM exit capture asymmetry: `FcDriver`'s workload-exit listener lives in the ephemeral
+  `mvmctl` process, so a `-d`/`--name` FC VM never gets `workload.exit` written (mvmctl exits after
+  boot). Transient (the default lifecycle) captures it and was live-witnessed; the persistent path
+  needs a supervisor-like owner (mirror libkrun's per-VM supervisor) if detached FC exit codes matter.
+- Investigate the tail `Failed to read frame length (EAGAIN)` on a transient run whose exec'd
+  command outlives the expected response (trailing `sleep`); no-sleep runs are clean, and the review
+  read it as a benign long-open-exec-stream artifact, but confirm it is not a transient-teardown race.
+- Correct the stale `doctor/warm_start.rs` prose that still says the substrate backs "Firecracker's
+  live-memory path" — true only for the raw hostd path now, not the CLI path.


### PR DESCRIPTION
Converge Firecracker — the Linux default workload backend — onto the single
`WorkloadRunner<VmmDriver, EndpointSpawner, BrokerRegistrar>` seam, so claim-10 (default-deny
egress) and claims 12/13 (secret substitution) are enforced structurally in one place every
backend traverses, not by per-backend convention. Follows the libkrun convergence (#1766).

**F3.1 — `FcDriver` (dormant).** New `driver/fc.rs`: a NIC-less Firecracker boot mapped from the
policy-free `VmmSpec`, reusing the existing `microvm` primitives (kernel-prep, verity cmdline,
the API body builders — now extracted and shared byte-identically with the raw path, not forked),
the guest→host vsock egress bridge (`v.sock_<port>` → the runner endpoint's
`substitution-endpoint.sock`, the FC analogue of libkrun's `egress_relay_socket`), and a
workload-exit capture (`capture_once` lifted into `mvm-core` so the driver can reuse it).
`kill`/`status` route through Firecracker's sudo teardown (it runs as root) and fail closed.
The raw `FirecrackerBackend` boot path is left byte-identical.

**F3.2 — retype `AnyBackend::Firecracker`** onto `WorkloadRunner<FcDriver, RealEndpointSpawner,
RealBrokerRegistrar>` — Firecracker's sole mvmctl-CLI workload path (`--hypervisor firecracker`
and `auto_select`). The raw `FirecrackerBackend` stays as the driver's identity delegate and for
the out-of-scope hostd/fleet launcher.

**Scope + decisions (owner-approved):**
- Warm-start/standby/balloon are descoped on the runner path (mirrors libkrun); they remain on the
  raw path for the fleet launcher. `mvmctl doctor`'s warm-start/balloon surfaces now list only qemu.
- claim-10 enforcement shifts from admission-time IP-pinning at iptables to the host-side endpoint
  re-resolving per connection (the same shift libkrun/HVF already made and witnessed).
- Convergence is scoped to the `AnyBackend` CLI path; the hostd-supervisor FC launcher stays raw
  (same boundary libkrun drew).

**Gates:** `cargo nextest run --workspace` 7649/7649, `clippy --workspace -D warnings` clean,
workspace doctests, nightly `fmt --all --check`, and the no-spec-refs lint all pass.

**Merge gate — live witness.** Host tests do not boot a guest (the libkrun flip's 0-byte-console
defect was invisible to all of them). This is **draft** until an observed live default-deny egress
witness on real KVM confirms: boots + reachable agent, no routable NIC, the guest egress port
pinned to `substitution-endpoint.sock`, and a real outbound attempt blocked by default-deny.

Design note: `specs/notes/2026-07-22-fc-driver-convergence-design.md`. Follow-ups (F4 machine-checked
`check-uniform-vsock-egress` gate; F5 delete the smoltcp-L3 stack + HVF fail-closed) tracked in plan 258.
