### PR TITLE
fix(cli): legible first-run OCI launches + transient VM state cleanup

### DIFF
--- a/crates/mvm-build/src/guest_agent_build.rs
+++ b/crates/mvm-build/src/guest_agent_build.rs
@@ -474,6 +474,26 @@ pub fn cached_guest_binaries(
     layout.is_complete().then(|| layout.binaries())
 }
 
+/// Whether resolving the guest runtime for `(cache_root, arch)` would trigger a
+/// source-checkout cross-compile: a source workspace is detected and its
+/// content-keyed cache is cold. Mirrors [`resolve_or_build_guest_binaries`]'s
+/// build/no-build decision so a caller can announce the slow, output-silent
+/// `cargo zigbuild` before it runs. A caller holding embedded guest binaries
+/// installs those instead and must not consult this.
+pub fn source_build_pending(cache_root: &Path, arch: GuestArch) -> bool {
+    match detect_source_workspace() {
+        Some(ws) => source_build_pending_for(cache_root, arch, &ws),
+        None => false,
+    }
+}
+
+fn source_build_pending_for(cache_root: &Path, arch: GuestArch, workspace_root: &Path) -> bool {
+    match source_cache_key(workspace_root) {
+        Ok(cache_key) => cached_guest_binaries(cache_root, &cache_key, arch).is_none(),
+        Err(_) => false,
+    }
+}
+
 /// Resolve the full runtime-overlay guest-binary set for `(version, arch)`,
 /// building + caching it from `workspace_root` on a cache miss.
 pub fn resolve_or_build_runtime_overlay_guest_binaries(
@@ -629,23 +649,28 @@ fn run_zigbuild(
     args: &[String],
 ) -> Result<(), GuestAgentBuildError> {
     let _zigbuild_lock = acquire_guest_zigbuild_lock(&spec.target_dir)?;
+    tracing::info!(
+        ?args,
+        workspace = %spec.workspace_root.display(),
+        "cross-compiling guest runtime via cargo zigbuild (first build for this source checkout)"
+    );
     let mut cmd = std::process::Command::new(cargo);
     cmd.args(args).current_dir(&spec.workspace_root);
     apply_zigbuild_env(&mut cmd, spec)?;
-    let out = cmd
-        .output()
+    // Inherit stdio so cargo's own "Compiling …" progress streams to the user: a
+    // multi-minute guest cross-compile must look alive, not like a silent hang.
+    let status = cmd
+        .status()
         .map_err(|e| GuestAgentBuildError::BuildFailed {
             reason: format!("spawn `{}`: {e}", PathBuf::from(cargo).display()),
         })?;
-    if out.status.success() {
+    if status.success() {
         return Ok(());
     }
     Err(GuestAgentBuildError::BuildFailed {
         reason: format!(
-            "args {:?} exited {:?}; stderr={}",
-            args,
-            out.status.code(),
-            String::from_utf8_lossy(&out.stderr)
+            "`cargo zigbuild` args {args:?} exited {:?} (see the streamed build output above)",
+            status.code()
         ),
     })
 }
@@ -684,20 +709,26 @@ pub fn build_guest_binaries(
 ) -> Result<BuiltGuestBinaries, GuestAgentBuildError> {
     let _zigbuild_lock = acquire_guest_zigbuild_lock(&spec.target_dir)?;
     let argv = spec.argv();
+    tracing::info!(
+        bins = ?&argv[1..],
+        workspace = %spec.workspace_root.display(),
+        "cross-compiling guest runtime via cargo zigbuild (first build for this source checkout)"
+    );
     let mut cmd = std::process::Command::new(&argv[0]);
     cmd.args(&argv[1..]).current_dir(&spec.workspace_root);
     apply_zigbuild_env(&mut cmd, spec)?;
-    let out = cmd
-        .output()
+    // Inherit stdio so cargo's own "Compiling …" progress streams to the user: a
+    // multi-minute guest cross-compile must look alive, not like a silent hang.
+    let status = cmd
+        .status()
         .map_err(|e| GuestAgentBuildError::BuildFailed {
             reason: format!("spawn `{}`: {e}", argv[0]),
         })?;
-    if !out.status.success() {
+    if !status.success() {
         return Err(GuestAgentBuildError::BuildFailed {
             reason: format!(
-                "exit {:?}; stderr={}",
-                out.status.code(),
-                String::from_utf8_lossy(&out.stderr)
+                "`cargo zigbuild` exited {:?} (see the streamed build output above)",
+                status.code()
             ),
         });
     }
@@ -853,6 +884,40 @@ fn set_exec(_path: &Path) -> Result<(), GuestAgentBuildError> {
 mod tests {
     use super::*;
     use mvm_core::util::test_env::TestEnv;
+
+    #[test]
+    fn source_build_pending_flips_when_the_source_keyed_cache_is_seeded() {
+        // A deterministic workspace root: this crate's manifest dir has the
+        // workspace root as an ancestor, independent of the test's CWD.
+        let ws = source_workspace_from(Path::new(env!("CARGO_MANIFEST_DIR")))
+            .expect("workspace root resolves from the crate manifest dir");
+        let cache = tempfile::tempdir().expect("tempdir");
+        let arch = GuestArch::Aarch64;
+
+        // Cold cache: resolving the guest runtime would cross-compile.
+        assert!(source_build_pending_for(cache.path(), arch, &ws));
+
+        // Seed the exact content-keyed slot the resolver would fill.
+        let key = source_cache_key(&ws).expect("source cache key");
+        install_prebuilt_guest_binaries(
+            GuestRuntimeBinaryBytes {
+                oci_init: b"x",
+                agent: b"x",
+                netinit: b"x",
+                netd: b"x",
+                egress_client: b"x",
+                entrypoint_runner: b"x",
+                verity_init: b"x",
+            },
+            cache.path(),
+            &key,
+            arch,
+        )
+        .expect("seed the source-keyed guest cache");
+
+        // Warm cache: no cross-compile pending.
+        assert!(!source_build_pending_for(cache.path(), arch, &ws));
+    }
 
     #[test]
     fn install_prebuilt_then_cached_round_trips() {

--- a/crates/mvm-cli/src/commands/image/materialize.rs
+++ b/crates/mvm-cli/src/commands/image/materialize.rs
@@ -344,6 +344,18 @@ pub(super) fn copy_tree(src: &Path, dst: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Whether booting an `--image` OCI run will cross-compile the mvm guest
+/// runtime from source first: this build carries no embedded guest binaries
+/// and the source-checkout guest cache is cold. Announcing this before the
+/// pull keeps the slow, output-silent `cargo zigbuild` from looking like a hang.
+pub(in crate::commands) fn oci_guest_runtime_compile_pending(cache_root: &Path) -> bool {
+    embedded_guest_binaries().is_none()
+        && mvm_build::guest_agent_build::source_build_pending(
+            cache_root,
+            mvm_core::arch::GuestArch::host(),
+        )
+}
+
 /// The guest-agent binaries embedded in this mvmctl at build time (build.rs).
 /// `None` only if a required embedded binary is unexpectedly missing.
 pub(super) fn embedded_guest_binaries()

--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -31,8 +31,10 @@ mod trust_policy;
 // sibling verb modules' `super::<name>` calls, and
 // `crate::commands::vm::exec`'s `super::super::image::<name>` reach-in.
 use cache::{inspect_image, list_rows, remove_image, render_inspect, render_list};
+pub(in crate::commands) use materialize::oci_guest_runtime_compile_pending;
 use oci_types::CosignIdentity;
 pub(in crate::commands) use oci_types::ResolvedOciRunImage;
+pub(in crate::commands) use pull_core::ensure_prod_digest_pin;
 use pull_core::pull_image_with_trust;
 pub(in crate::commands) use pull_core::resolve_or_pull_run_image;
 

--- a/crates/mvm-cli/src/commands/image/pull_core.rs
+++ b/crates/mvm-cli/src/commands/image/pull_core.rs
@@ -30,6 +30,24 @@ use super::trust_policy::trust_decision_for_cached_image;
 use super::trust_policy::{enforce_oci_trust_policy_with, enforce_registry_allowlist};
 use super::trust_policy::{ensure_signature_policy_is_configured, load_oci_registry_policy};
 
+/// Refuse a mutable (non-digest-pinned) registry reference under `--prod`
+/// before any network fetch or local resource resolution. Local sources
+/// (OCI archive / stdin / rootfs dir) carry their own provenance and are
+/// exempt. A pure reference-string check with no I/O, so it also gates the
+/// run path ahead of workload-kernel resolution — not only the pull itself.
+pub(in crate::commands) fn ensure_prod_digest_pin(reference: &str, prod: bool) -> Result<()> {
+    if !prod {
+        return Ok(());
+    }
+    if let source::ImageSource::Registry(_) = source::ImageSource::classify(reference)? {
+        let image_ref: ImageReference = reference.parse()?;
+        if !image_ref.is_digest_pinned() {
+            bail!("mvmctl run --image --prod requires a digest-pinned reference");
+        }
+    }
+    Ok(())
+}
+
 pub(in crate::commands) fn resolve_or_pull_run_image(
     cache_root: &Path,
     reference: &str,
@@ -69,10 +87,8 @@ pub(super) fn resolve_or_pull_run_image_with(
         }
         source::ImageSource::Registry(_) => {}
     }
+    ensure_prod_digest_pin(reference, prod)?;
     let image_ref: ImageReference = reference.parse()?;
-    if prod && !image_ref.is_digest_pinned() {
-        bail!("mvmctl run --image --prod requires a digest-pinned reference");
-    }
     let canonical = image_ref.canonical();
     let runtime_tag = oci_runtime_tag();
     let (image, pulled, trust_from_pull, auth_source_from_pull) = match load_index(cache_root)

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -728,8 +728,40 @@ fn build_exec_request(
                 crate::exec::ImageSource::Template(resolved)
             }
             (None, Some(reference)) => {
+                let oci_cache_root = super::super::image::oci_cache_root();
+                // A prod run refuses a mutable OCI tag before ANY work — the
+                // digest-pin policy refusal must be what the user sees, not an
+                // incidental missing-kernel error from the local resolution
+                // below. The pull path re-checks it, so this only reorders the
+                // refusal ahead of the workload-kernel resolution.
+                super::super::image::ensure_prod_digest_pin(&reference, prod)?;
+                // Resolve the workload kernel BEFORE the pull. An `--image` run
+                // boots the materialized OCI rootfs (with its injected agent), so
+                // it needs only a workload kernel — a cached workload/default-image
+                // kernel, a local build (source checkout), or the published
+                // download — rather than building/downloading a whole default image
+                // whose rootfs we'd discard. Resolving it first makes a missing or
+                // cold-cache kernel fail fast with an actionable error instead of
+                // surfacing only after a full pull + rootfs materialization. The
+                // rootfs boots verity-sealed, so the kernel must carry dm-verity;
+                // the builder kernel (which drops it) is never a stand-in.
+                let kernel_path = ensure_workload_kernel(prod)?;
+                // Enforce that invariant host-side: a kernel with no dm-verity
+                // support would panic the guest in early init opening
+                // /dev/mapper/control, with no host signal. Fail fast instead.
+                assert_workload_kernel_supports_verity(&kernel_path)?;
+                // A source-checkout run with no embedded guest runtime cross-compiles
+                // the mvm guest binaries inside materialization — a slow,
+                // output-silent host `cargo zigbuild`. Announce it so the run does
+                // not look wedged after the OCI pull logs.
+                if super::super::image::oci_guest_runtime_compile_pending(&oci_cache_root) {
+                    ui::info(
+                        "Compiling the mvm guest runtime from your source checkout \
+                         (first build for these sources; cached afterward)…",
+                    );
+                }
                 let cached = super::super::image::resolve_or_pull_run_image(
-                    &super::super::image::oci_cache_root(),
+                    &oci_cache_root,
                     &reference,
                     prod,
                 )?;
@@ -758,18 +790,6 @@ fn build_exec_request(
                         auth_source
                     );
                 }
-                // An `--image` run boots the materialized OCI rootfs (with its
-                // injected agent), so we need only a workload kernel — a cached
-                // workload/default-image kernel, a local build (source checkout),
-                // or the published download — rather than building/downloading a
-                // whole default image whose rootfs we'd discard. The rootfs boots
-                // verity-sealed, so the kernel must carry dm-verity; the builder
-                // kernel (which drops it) is never a stand-in.
-                let kernel_path = ensure_workload_kernel(prod)?;
-                // Enforce that invariant host-side: a kernel with no dm-verity
-                // support would panic the guest in early init opening
-                // /dev/mapper/control, with no host signal. Fail fast instead.
-                assert_workload_kernel_supports_verity(&kernel_path)?;
                 crate::exec::ImageSource::Prebuilt {
                     kernel_path,
                     rootfs_path: cached.rootfs_path.display().to_string(),

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -772,17 +772,22 @@ pub fn transient_run_dev_console(pty: bool, image_sealed: bool) -> bool {
     pty && !image_sealed
 }
 
-/// Remove the transient `--add-dir` staging dir, but only when extras were
-/// actually staged. `build_dir_image_ro` builds those ext4 images inside the
-/// builder Linux env (it needs `mkfs`/`mount`), so cleanup routes back through
-/// that env — and a run with no `--add-dir` never created the dir. Skipping the
-/// call there keeps a plain OCI/workload run from waking a builder VM just to
-/// `rm -rf` a path that does not exist.
-fn clean_add_dir_staging(add_dirs: &[AddDir], staging_dir: &str) {
-    if add_dirs.is_empty() {
-        return;
+/// Remove the transient VM's host state dir (`~/.mvm/vms/<name>`, which also
+/// holds any `--add-dir` extra images) once the VM is stopped. Host-side
+/// `std::fs` — never `run_in_vm`, which targets a path *inside* the guest and
+/// (on macOS) would wake a builder VM to `rm` a path that isn't there, leaking
+/// the real host dir. Runs for every transient run, `--add-dir` or not: the
+/// backend writes `hvf.pid` / `console.log` here regardless, so a plain OCI
+/// launch created the dir and must clean it up too. Best-effort — teardown must
+/// never fail on a cleanup error.
+fn remove_transient_state_dir(staging_dir: &str) {
+    match std::fs::remove_dir_all(staging_dir) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            tracing::debug!(error = %e, dir = staging_dir, "transient state dir cleanup failed");
+        }
     }
-    let _ = mvm_runtime::shell::run_in_vm(&format!("rm -rf {staging_dir}"));
 }
 
 /// Decide whether snapshot restore is safe for this request.
@@ -1012,7 +1017,6 @@ fn run_inner(
         backend: &backend,
         start_config: &start_config,
         resolved: &resolved,
-        add_dirs: &req.add_dirs,
         staging_dir: &staging_dir,
     };
     let vm_name = boot_transient_vm(vm_name, use_snapshot, &boot_attempt)?;
@@ -1333,7 +1337,6 @@ struct BootAttempt<'a> {
     backend: &'a AnyBackend,
     start_config: &'a VmStartConfig,
     resolved: &'a ResolvedImage,
-    add_dirs: &'a [AddDir],
     staging_dir: &'a str,
 }
 
@@ -1356,6 +1359,13 @@ fn boot_transient_vm(
     // without it a one-off run (or runs against different images) leaves warm
     // spares resident until a manual `cache prune`. Best-effort; never blocks.
     crate::commands::pool::reap_stale_standbys_best_effort();
+
+    // Reap state dirs a killed or crashed prior transient run left behind: a
+    // SIGKILL or a closed terminal skips teardown, so `~/.mvm/vms/<name>` leaks.
+    // Narrow orphan-only reap — no registry convergence or resume — so a
+    // throwaway launch stays side-effect free; shields this run's own name,
+    // whose dir may exist before its supervisor comes up.
+    let _ = mvm_runtime::vm::reconcile::reap_orphan_state_dirs(Some(vm_name.as_str()));
 
     // Try a warm-pool claim before snapshot/cold-boot. A claimed standby is
     // pre-booted to agent-ready and runs under its own standby-id, so the
@@ -1416,7 +1426,7 @@ fn boot_transient_vm(
     if !booted {
         ui::info(&format!("Booting transient VM '{vm_name}'..."));
         if let Err(e) = attempt.backend.start(attempt.start_config) {
-            clean_add_dir_staging(attempt.add_dirs, attempt.staging_dir);
+            remove_transient_state_dir(attempt.staging_dir);
             return Err(e).context("starting transient microVM");
         }
     }
@@ -1487,7 +1497,7 @@ fn teardown_transient_vm(
         }
     }
 
-    clean_add_dir_staging(add_dirs, staging_dir);
+    remove_transient_state_dir(staging_dir);
 }
 
 /// Restore a transient microVM from a template snapshot instead of cold-booting.
@@ -3044,55 +3054,26 @@ mod tests {
     }
 
     #[test]
-    fn staging_cleanup_skipped_without_add_dirs() {
-        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let calls_for_handler = calls.clone();
-        let _handler = mvm_runtime::shell_mock::install_handler(move |_script: &str| {
-            calls_for_handler.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            mvm_runtime::shell_mock::MockResponse {
-                exit_code: 0,
-                stdout: String::new(),
-            }
-        });
+    fn remove_transient_state_dir_removes_the_host_dir() {
+        // Every transient run (with or without --add-dir) creates its state dir
+        // when the backend writes hvf.pid / console.log there, so teardown must
+        // remove it host-side — not via run_in_vm, which targets the guest.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("vms").join("throwaway-vm");
+        std::fs::create_dir_all(&dir).expect("create state dir");
+        std::fs::write(dir.join("hvf.pid"), b"1234").expect("write pid file");
+        assert!(dir.exists());
 
-        clean_add_dir_staging(&[], "/tmp/mvm-staging");
+        remove_transient_state_dir(&dir.to_string_lossy());
 
-        assert_eq!(
-            calls.load(std::sync::atomic::Ordering::SeqCst),
-            0,
-            "no --add-dir means no builder cleanup command"
-        );
+        assert!(!dir.exists(), "the host state dir must be removed");
     }
 
     #[test]
-    fn staging_cleanup_enabled_with_add_dirs() {
-        let scripts = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
-        let scripts_for_handler = scripts.clone();
-        let _handler = mvm_runtime::shell_mock::install_handler(move |script: &str| {
-            scripts_for_handler
-                .lock()
-                .expect("mutex must not be poisoned")
-                .push(script.to_string());
-            mvm_runtime::shell_mock::MockResponse {
-                exit_code: 0,
-                stdout: String::new(),
-            }
-        });
-        let add_dir = AddDir {
-            host_path: "/tmp/host".to_string(),
-            guest_path: "/mnt/host".to_string(),
-            read_only: true,
-        };
-
-        clean_add_dir_staging(&[add_dir], "/tmp/mvm-staging");
-
-        let scripts = scripts.lock().expect("mutex must not be poisoned");
-        assert_eq!(scripts.len(), 1, "one cleanup command must be issued");
-        assert!(
-            scripts[0].contains("rm -rf /tmp/mvm-staging"),
-            "cleanup command must remove the staging directory: {}",
-            scripts[0]
-        );
+    fn remove_transient_state_dir_is_a_noop_on_a_missing_dir() {
+        // Best-effort: an already-gone dir (or a boot that never created one) is
+        // a clean no-op, never a panic.
+        remove_transient_state_dir("/nonexistent/mvm/vms/never-created");
     }
 
     #[test]

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -22,6 +22,26 @@ fn run_mvmctl(world: &mut CliWorld, args: String) {
     world.last_run = Some(output);
 }
 
+#[when(expr = "I run mvmctl with {string} and an isolated mvm home")]
+fn run_mvmctl_isolated_home(world: &mut CliWorld, args: String) {
+    // A fresh, empty MVM_HOME makes cache-precondition scenarios hermetic: every
+    // cache (workload kernel, OCI, guest runtime) is cold, so the run exercises
+    // the missing-prerequisite path without depending on — or mutating — the
+    // dev's real `~/.mvm`. The run is synchronous (`output()` blocks to exit)
+    // and the fail-fast path spawns no VM, so the temp dir can drop right after.
+    let home = tempfile::tempdir().expect("create isolated MVM_HOME");
+    #[allow(deprecated)] // matches crates/mvm-cli/tests/cli.rs's use of this API
+    let mut cmd = Command::cargo_bin("mvmctl").unwrap_or_else(|e| {
+        panic!("mvmctl binary not found ({e}) — run `cargo build --bin mvmctl` before `just bdd`")
+    });
+    let output = cmd
+        .args(args.split_whitespace())
+        .env("MVM_HOME", home.path())
+        .output()
+        .expect("failed to spawn mvmctl");
+    world.last_run = Some(output);
+}
+
 #[then(expr = "the command exits with code {int}")]
 fn exits_with_code(world: &mut CliWorld, code: i64) {
     let output = world.last_output();

--- a/crates/mvm-runtime/src/vm/reconcile.rs
+++ b/crates/mvm-runtime/src/vm/reconcile.rs
@@ -378,6 +378,53 @@ pub fn converge(opts: &ConvergeOpts) -> ConvergeReport {
     report
 }
 
+/// Reap only *orphan* state dirs under the default `vms` root: dirs with no
+/// live owning process and no registry record. Unlike [`converge`] it never
+/// drops records, tears down dead-process records, or drives any resume/boot,
+/// so the throwaway transient-run path — which opts out of full convergence to
+/// avoid auto-resuming unrelated machines — can still clean up a state dir a
+/// killed or crashed prior run left behind (a SIGKILL or a closed terminal
+/// skips teardown). `protect` shields the caller's in-flight VM name, whose dir
+/// may exist before its supervisor comes up. Fail-open: returns the reaped
+/// basenames, empty on any error, and audits each reap for observability.
+pub fn reap_orphan_state_dirs(protect: Option<&str>) -> Vec<String> {
+    let registry_path = crate::vm::name_registry::registry_path();
+    let vms_root = mvm_core::config::vms_dir();
+    let reaped = reap_orphan_state_dirs_at(&registry_path, &vms_root, protect);
+    for dir in &reaped {
+        mvm_core::audit_emit!(RegistryReconcile, vm: dir.as_str(), "action=orphan_state_no_record");
+    }
+    reaped
+}
+
+/// Path-explicit, audit-free seam for [`reap_orphan_state_dirs`] — the
+/// hermetically testable core. Reads the registry only to shield registered
+/// names; a registry that fails to load reaps nothing (fail-safe: never reap a
+/// registered VM's dir on a transient read error).
+pub fn reap_orphan_state_dirs_at(
+    registry_path: &Path,
+    vms_root: &Path,
+    protect: Option<&str>,
+) -> Vec<String> {
+    let mut known: BTreeSet<String> = match VmNameRegistry::load(registry_path) {
+        Ok(registry) => registry.vms.keys().cloned().collect(),
+        Err(_) => return Vec::new(),
+    };
+    if let Some(name) = protect {
+        known.insert(name.to_string());
+    }
+    let view = FsRuntimeView::new(vms_root);
+    let actions = FsReconcileActions::new(vms_root);
+    let mut reaped = Vec::new();
+    for dir in view.orphan_dirs(&known) {
+        if actions.reap_orphan(&dir).is_ok() {
+            reaped.push(dir);
+        }
+    }
+    reaped.sort();
+    reaped
+}
+
 /// Emit one `RegistryReconcile` audit line per healed item. Best-effort
 /// (the audit layer swallows write failures); consistent with the Stage 0
 /// audit-emit contract.
@@ -785,6 +832,69 @@ mod tests {
         let actions = FsReconcileActions::new(root);
         actions.reap_orphan("orphan").unwrap();
         assert!(!root.join("orphan").exists());
+    }
+
+    #[test]
+    fn reap_orphan_state_dirs_reaps_only_dead_unprotected_orphans() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vms_root = tmp.path().join("vms");
+        std::fs::create_dir_all(&vms_root).unwrap();
+
+        // A registered VM with a dead process is a *record*, not an orphan: the
+        // narrow reap leaves registry records untouched (tearing them down is
+        // converge's job, not this side-effect-free sweep).
+        let registered_dir = make_state_dir(&vms_root, "registered-dead", None);
+        let registry_path = tmp.path().join("registry.json");
+        let mut registry = VmNameRegistry::default();
+        registry
+            .register_with_metadata(RegisterParams::minimal(
+                "registered-dead",
+                &registered_dir,
+                "default",
+            ))
+            .unwrap();
+        registry.save(&registry_path).unwrap();
+
+        // A live orphan (no record, live supervisor) — shielded by liveness.
+        make_state_dir(&vms_root, "live-orphan", Some(std::process::id() as i32));
+        // The in-flight run's own dir (dead, no record) — shielded by `protect`.
+        make_state_dir(&vms_root, "current-run", None);
+        // A dead orphan (no record, no live process, unprotected) — reaped.
+        make_state_dir(&vms_root, "dead-orphan", Some(i32::MAX));
+
+        let reaped = reap_orphan_state_dirs_at(&registry_path, &vms_root, Some("current-run"));
+
+        assert_eq!(reaped, vec!["dead-orphan".to_string()]);
+        assert!(!vms_root.join("dead-orphan").exists(), "dead orphan reaped");
+        assert!(
+            vms_root.join("registered-dead").exists(),
+            "a registry record is not an orphan"
+        );
+        assert!(
+            vms_root.join("live-orphan").exists(),
+            "live orphan shielded"
+        );
+        assert!(
+            vms_root.join("current-run").exists(),
+            "the protected in-flight run is shielded"
+        );
+    }
+
+    #[test]
+    fn reap_orphan_state_dirs_reaps_nothing_when_the_registry_is_unreadable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vms_root = tmp.path().join("vms");
+        std::fs::create_dir_all(&vms_root).unwrap();
+        make_state_dir(&vms_root, "would-be-orphan", None);
+        // A corrupt registry fails safe: reap nothing rather than risk a
+        // registered VM's dir on a transient read error.
+        let registry_path = tmp.path().join("registry.json");
+        std::fs::write(&registry_path, b"not valid json {").unwrap();
+
+        let reaped = reap_orphan_state_dirs_at(&registry_path, &vms_root, None);
+
+        assert!(reaped.is_empty());
+        assert!(vms_root.join("would-be-orphan").exists());
     }
 
     #[test]

--- a/features/suites/s0_cli/machine_run_image_workload_kernel.feature
+++ b/features/suites/s0_cli/machine_run_image_workload_kernel.feature
@@ -1,0 +1,14 @@
+Feature: machine run --image workload-kernel precondition
+
+  Booting an OCI image needs a dm-verity-capable workload kernel. On a source
+  checkout that kernel is built locally and never downloaded, so when it is
+  missing `machine run --image` must fail fast with an actionable message
+  *before* pulling the image — never a silent hang after the pull. This guards
+  the regression where the run resolved the kernel only after the OCI pull, so a
+  cold-cache checkout looked wedged instead of telling the user what to do next.
+
+  Scenario: machine run --image fails fast when the workload kernel is missing
+    When I run mvmctl with "machine run --image alpine -- /bin/true" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "workload kernel"
+    And the error output contains "kernel build --which workload"


### PR DESCRIPTION
## What

Two CLI DX fixes, extracted cleanly onto current `main`. They were the only genuinely-unique work left in the stale draft #1774 — its egress-connect code and snapshot store already landed on `main` separately (the snapshot store is #1776, merge `957e2760`).

### `fix(cli): make first-run OCI launches legible`
A fresh source-checkout `machine run --image` could look wedged for minutes:
- Stream guest `cargo zigbuild` output at both cross-compile sites, so a source-checkout guest build shows live progress instead of silence.
- Resolve the workload kernel **before** the OCI pull, so a cold/missing kernel fails fast with an actionable message instead of hanging after a full pull. Announce a pending guest-runtime cross-compile before the pull.
- Order the `--prod` digest-pin refusal **ahead** of the workload-kernel resolution, via a small reused `ensure_prod_digest_pin` guard (a pure reference-string check, no I/O). A prod mutable-tag run still refuses with "requires a digest-pinned reference" before any local resource work — not an incidental missing-kernel error. The pull path reuses the same guard, so the refuse-before-network guarantee is a single source of truth.
- BDD: a workload-kernel fail-fast scenario with an isolated-`MVM_HOME` step (the only new conformance step; the digest-pin, `@live`-gating, and `error_output_contains` helpers already exist on `main`).

### `fix(cli): clean up transient VM state dirs on teardown and after a kill`
Reap transient VM state directories on teardown and after a kill.

## Verification (rustup toolchain)
- `cargo build --bin mvmctl` — green (drives the aarch64-musl embed cross-compile)
- `cargo fmt --all -- --check` — clean on stable and nightly
- `cargo clippy --workspace -- -D warnings` — zero warnings
- `cargo nextest run -p mvm-cli` — 1331 passed; the prod digest-pin gate tests `prod_run_image_requires_digest_pin_before_network` and `prod_pull_requires_digest_pin_before_network` both pass
- `just bdd` — 27 scenarios / 134 steps, all pass (the prod digest-pin refusal scenario and the new fail-fast-on-missing-kernel scenario both green)
