### PR TITLE
fix(mvm-fs): ext4 fast-symlink threshold off-by-one truncated 60-byte targets

### DIFF
--- a/crates/mvm-fs/src/ext4/mod.rs
+++ b/crates/mvm-fs/src/ext4/mod.rs
@@ -712,8 +712,12 @@ where
             }
             Kind::File => p.size.div_ceil(BLOCK_SIZE as u64) as u32,
             Kind::Symlink => {
-                // Fast symlink: target ≤ 60 bytes lives in i_block, no data block.
-                if p.size <= 60 {
+                // Fast symlink: a target that fits strictly inside the 60-byte
+                // i_block lives there with no data block. The boundary is `< 60`,
+                // not `<= 60`: a 60-byte target fills i_block exactly, and readers
+                // treat `i_size >= 60` as a slow symlink read from a data block —
+                // so an inline 60-byte target reads back truncated.
+                if p.size < 60 {
                     0
                 } else {
                     p.size.div_ceil(BLOCK_SIZE as u64) as u32

--- a/crates/mvm-fs/tests/oracle.rs
+++ b/crates/mvm-fs/tests/oracle.rs
@@ -68,6 +68,32 @@ fn read_file(fs: &Filesystem, ino: u32) -> Vec<u8> {
     file_io::read_all(fs, &inode).expect("read file data")
 }
 
+/// Read a symlink target back exactly as the independent reader's `readlink`
+/// does: a target strictly shorter than the 60-byte `i_block` is a *fast*
+/// symlink stored inline; a target of 60 bytes or more is a *slow* symlink read
+/// from a data block. The writer must pick the same boundary or the reader
+/// resolves the wrong bytes. Asserts the fast/slow flag matches the length so a
+/// misclassified symlink fails here rather than silently truncating.
+fn read_symlink_target(fs: &Filesystem, ino: u32) -> Vec<u8> {
+    let (inode, _) = fs.read_inode_verified(ino).expect("read symlink inode");
+    assert!(inode.is_symlink(), "inode {ino} must be a symlink");
+    if inode.size < 60 {
+        assert!(
+            !inode.has_extents(),
+            "fast symlink (size {}) must store its target inline, not in extents",
+            inode.size
+        );
+        inode.block[..inode.size as usize].to_vec()
+    } else {
+        assert!(
+            inode.has_extents(),
+            "slow symlink (size {}) must be extent-backed, not inline",
+            inode.size
+        );
+        file_io::read_all(fs, &inode).expect("read slow symlink target")
+    }
+}
+
 #[test]
 fn empty_tree_mounts_with_root_dir() {
     let fs = mount(build_image(&[]).unwrap());
@@ -127,6 +153,62 @@ fn tree_round_trips_through_real_reader() {
     let (link_inode, _) = fs.read_inode_verified(link_ino).unwrap();
     assert!(link_inode.is_symlink());
     assert_eq!(link_inode.size, "hosts".len() as u64);
+}
+
+/// Symlink targets must round-trip byte-for-byte across the fast/slow boundary.
+/// The inode's `i_block` area is exactly 60 bytes, so a fast (inline) symlink
+/// can hold a target of at most 59 bytes; a 60-byte target is a *slow* symlink
+/// backed by a data block. A 60-byte target previously stored inline lost its
+/// final byte on readback (an independent reader treats `i_size >= 60` as slow
+/// and reads the — absent — data block). Boundary-checked around the transition
+/// and out to a multi-block target.
+#[test]
+fn symlink_targets_round_trip_across_fast_slow_boundary() {
+    // A real 60-byte target: `/usr/local/bin/claude` after `npm i -g` points at
+    // `../lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe`.
+    let real_60 = "../lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe";
+    assert_eq!(real_60.len(), 60, "fixture must be exactly 60 bytes");
+
+    // Distinct generated targets straddling the boundary plus a multi-block
+    // long target. Each byte is a printable ASCII letter, so the target is
+    // valid UTF-8 and every position is individually distinguishable.
+    let make_target =
+        |len: usize| -> String { (0..len).map(|i| (b'a' + (i % 26) as u8) as char).collect() };
+    let mut cases: Vec<(String, String)> = [58usize, 59, 60, 61, 62, 200]
+        .into_iter()
+        .map(|len| (format!("/links/gen{len}"), make_target(len)))
+        .collect();
+    cases.push(("/links/real60".to_string(), real_60.to_string()));
+
+    let mut nodes = vec![Node::Dir {
+        path: "/links".into(),
+        mode: 0o755,
+        xattrs: Vec::new(),
+    }];
+    for (path, target) in &cases {
+        nodes.push(Node::Symlink {
+            path: path.clone(),
+            target: target.clone(),
+        });
+    }
+
+    let fs = mount(build_image(&nodes).unwrap());
+    let (links_ino, links_ft) = find(&list_dir(&fs, 2), "links").expect("/links present");
+    assert_eq!(links_ft, DirEntryType::Directory);
+    let entries = list_dir(&fs, links_ino);
+
+    for (path, target) in &cases {
+        let name = path.rsplit('/').next().unwrap();
+        let (ino, ft) = find(&entries, name).unwrap_or_else(|| panic!("{path} present"));
+        assert_eq!(ft, DirEntryType::Symlink, "{path} must be a symlink");
+        let got = read_symlink_target(&fs, ino);
+        assert_eq!(
+            got,
+            target.as_bytes(),
+            "symlink {path} (target {} bytes) must round-trip intact",
+            target.len()
+        );
+    }
 }
 
 /// The empty-growable `mkfs` path (a writable Stage 0 store, not a sealed


### PR DESCRIPTION
Fixes #1719.

## Problem

The pure-Rust ext4 writer (`crates/mvm-fs/src/ext4/mod.rs`) classified a
symlink as a *fast* (inline) symlink when its target was `<= 60` bytes,
storing the target in the inode's 60-byte `i_block` with no data block. But
the `i_block` is *exactly* 60 bytes, and readers (the Linux kernel and the
independent `am-fs-ext4` oracle) decide fast-vs-slow with `i_size < 60`: a
target of 60 bytes or more is a **slow** symlink read from a data block.

So a 60-byte target written inline read back corrupted — the reader looks
for a data block that was never allocated. Hit in practice by npm-installed
shims whose relative target is exactly 60 bytes (e.g.
`../lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe`), which
booted as a dangling link.

## Fix

Change the symlink block-count threshold from `p.size <= 60` to
`p.size < 60`. A 60-byte target now allocates a data block and sets the
extents flag. The write-side emit path already keys off the resulting
`p.extents`, so both the sizing decision and the byte-emit decision agree on
the `< 60` boundary automatically — no second edit needed.

## Test

Added `symlink_targets_round_trip_across_fast_slow_boundary` to the
`tests/oracle.rs` round-trip suite. It materializes symlinks with targets of
58/59/60/61/62/200 bytes (plus the exact 60-byte real-world repro), mounts
the image in the independent `am-fs-ext4` reader, and asserts each target
round-trips byte-for-byte. A helper mirrors the reader's `readlink`
decision and asserts the fast/slow classification (`has_extents()`) matches
the target length, so a misclassified symlink fails loudly rather than
silently truncating. The test fails on the pre-fix code at the 60-byte case
("slow symlink (size 60) must be extent-backed, not inline") and passes
after the fix.

## Verification

- `cargo nextest run -p mvm-fs` — 268 passed, 1 skipped
- `cargo clippy -p mvm-fs --all-targets -- -D warnings` — clean
- `rustup run nightly cargo fmt -p mvm-fs -- --check` — clean