### PR TITLE
kernel: trim workload boot-probes (#1283); libkrunfw pin status (#1264)

### DIFF
--- a/nix/images/kernel/workload.nix
+++ b/nix/images/kernel/workload.nix
@@ -62,6 +62,25 @@ base.mkKernel {
   #                 symbol in Linux 6.12, so the syscall-facing interface goes
   #                 away here but the interpreter stays built-in until the
   #                 workload networking contract changes.
+  #
+  # The next four are boot-probe eliminations: each is compiled in by the
+  # defconfig base and *initialises at boot* on a single-workload OCI microVM
+  # that can never use it. They barely move the built-in symbol count, so the
+  # size budget alone never surfaced them — the win is deleted init work and
+  # registration threads on the cold-boot path, not bytes.
+  #   NET_9P      — the 9P2000 (9pnet) resource-sharing transport. A sealed
+  #                 workload shares host directories over virtio-fs, never 9p,
+  #                 so the "9pnet: Installing 9P2000 support" init is pure
+  #                 boot-probe cost with no reachable transport behind it.
+  #   BTRFS_FS    — the workload rootfs is ext4-on-virtio-blk, dm-verity sealed
+  #                 (Claim 3); no guest mounts btrfs. Dropping it deletes the
+  #                 "Btrfs loaded" registration and its background workers.
+  #   GNSS        — GPS/GNSS receiver core. No microVM exposes a GNSS device;
+  #                 "gnss: GNSS driver registered" registers a major number for
+  #                 hardware that can never appear behind virtio.
+  #   VLAN_8021Q  — 802.1Q VLAN tagging. Guest egress is host-mediated (egress
+  #                 proxy over vsock), never in-guest VLAN interfaces, so the
+  #                 "8021q: 802.1Q VLAN Support" init is dead weight.
   #   CC_OPTIMIZE_FOR_PERFORMANCE — flipped off only for the size experiment
   #                 output; the default workload kernel keeps the current mode
   #                 until measured results prove the size-oriented mode is worth
@@ -77,6 +96,10 @@ base.mkKernel {
       "IKCONFIG"
       "IKCONFIG_PROC"
       "CHECKPOINT_RESTORE"
+      "NET_9P"
+      "BTRFS_FS"
+      "GNSS"
+      "VLAN_8021Q"
     ]
     ++ pkgs.lib.optionals optimizeForSize [ "CC_OPTIMIZE_FOR_PERFORMANCE" ];
 }


### PR DESCRIPTION
## Summary

Two related kernel-pin/config issues.

### #1283 — workload kernel boot-probe trim (done)

The slim workload kernel derives from the arm64/x86 `defconfig` base, which compiles in several subsystems that **initialise at boot** on a single-workload OCI microVM that can never use them. Live guest `console.log` still showed:

```
9pnet: Installing 9P2000 support
Btrfs loaded, zoned=no, fsverity=no
gnss: GNSS driver registered with major 234
8021q: 802.1Q VLAN Support
```

None are reachable on the sealed workload path:
- **NET_9P** — host directory shares are virtio-fs, never 9p.
- **BTRFS_FS** — the rootfs is dm-verity-sealed ext4 (Claim 3); nothing mounts btrfs.
- **GNSS** — no GNSS device can appear behind virtio.
- **VLAN_8021Q** — guest egress is host-mediated over vsock; no in-guest VLAN interfaces.

They barely move the built-in symbol count, so the size-budget ratchet never surfaced them — the win is deleted init work + registration threads on the cold-boot path (the boot-time cost the symbol budget doesn't capture).

**Change:** add `NET_9P`, `BTRFS_FS`, `GNSS`, `VLAN_8021Q` to `nix/images/kernel/workload.nix` `extraDisables`. IPVS / RAID-autodetect / bridge-firewalling from the original report were already handled by the existing `NETFILTER` + `BLK_DEV_MD` disables. Scoped to `workload.nix` (not shared `base.nix`), so the **builder kernel is untouched**.

### #1264 — kernel pin freshness (status only; no code change)

`xtask check-kernel-pin-freshness` on this branch reports:

| Pin | Pinned | Latest 6.12.x | Gap | Status |
|-----|--------|---------------|-----|--------|
| `libkrunfw` (`nix/packages/libkrunfw.nix`) | 6.12.91 | 6.12.96 | 5 | behind |
| `nixpkgs-linux_6_12` (`nix/images/kernel/` flake) | 6.12.93 | 6.12.96 | 3 | behind |

**libkrunfw was not bumped.** `v5.5.0` is the **latest** libkrunfw release (no newer tag or pre-release), and its Makefile **hardcodes `KERNEL_VERSION = linux-6.12.91`**. Our nix only symlinks `kernelSrc` in as the tarball; advancing `kernelSrc` alone extracts to `linux-6.12.9x/` while the make target stays `linux-6.12.91`, so the build breaks. The pin therefore cannot be advanced on its own — the clean bump is blocked on upstream libkrunfw shipping a release that bundles a newer kernel.

The divergent alternative (patch `KERNEL_VERSION` in the Makefile ourselves + bump `kernelSrc`) diverges from upstream's tested kernel/config pairing and still needs a real libkrunfw build to confirm 6.12.96 config-compatibility, so it is deliberately not taken here. The `nixpkgs-linux_6_12` bump is a `flake.lock` update with a wide (every-package) blast radius requiring a full `nix flake check` + kernel build across the sibling flakes; out of scope for this change.

The daily `kernel-cve-watch` cron keeps tracking this; the PR-time lane is informational (a `::warning::`, never a hard fail), so this PR is not blocked by the still-trailing pins.

## Verification

- `nix-instantiate --parse nix/images/kernel/workload.nix` — parses.
- `nix flake check --no-build --all-systems` on `nix/images/kernel` — **all checks passed**; the `workload-configfile` derivation evaluates cleanly for both `aarch64-linux` and `x86_64-linux` with the new disables (valid `.drv` produced).
- No Rust code or test references these config symbols or `workload.nix`, so no `cargo`/Rust impact.
- Comments kept concept-focused (no plan/PR/ADR tokens) to satisfy `check-no-spec-refs-in-comments`.

## Boot-verification still required (not done here)

Kernels build **inside the builder VM**, so a host kernel compile/boot was not performed. The `make olddefconfig` pass + the `base.nix` enable-survival guard + the symbol-budget count run only at derivation **build** time (the `kernel-build.yml` CI lane on both arches, and the builder VM), not at eval. Before shipping, confirm on a boot-capable host:

```
mvmctl machine run --image alpine -it
```

and check the guest `console.log` no longer prints the `9pnet` / `Btrfs loaded` / `gnss` / `8021q` init lines, and that virtio-blk root + dm-verity + virtio-fs volumes still mount (the kept-enable guard should catch a dropped dependency at build time, but a live boot is the ground truth).

Closes #1283.
Refs #1264.