### PR TITLE
fix(net): IPv4 happy-eyeballs fallover for numeric-IPv6 egress dials (#1783)

### DIFF
--- a/crates/mvm-core/src/policy/dns_pin.rs
+++ b/crates/mvm-core/src/policy/dns_pin.rs
@@ -53,7 +53,7 @@ pub fn resolve_network_policy_pins(
         return reg; // unrestricted: no host rules to pin
     };
     for hp in rules {
-        let ips: Vec<IpAddr> = if let Ok(ip) = hp.host.parse::<IpAddr>() {
+        let mut ips: Vec<IpAddr> = if let Ok(ip) = hp.host.parse::<IpAddr>() {
             vec![ip]
         } else {
             (hp.host.as_str(), 0u16)
@@ -61,9 +61,18 @@ pub fn resolve_network_policy_pins(
                 .map(|addrs| addrs.map(|sa| sa.ip()).collect())
                 .unwrap_or_default()
         };
+        sort_ipv4_first(&mut ips);
         reg.add(new_pin(hp.host, ips, Duration::hours(24)));
     }
     reg
+}
+
+/// Order an address set IPv4-first, stable within each family. Host resolvers
+/// commonly return IPv6 first (macOS `getaddrinfo` does), which strands an
+/// admitted connect when the host has no IPv6 egress. Pinning IPv4-first makes
+/// the downstream happy-eyeballs connect prefer the routable IPv4 address.
+pub fn sort_ipv4_first(ips: &mut [IpAddr]) {
+    ips.sort_by_key(|ip| ip.is_ipv6());
 }
 
 #[cfg(test)]
@@ -107,6 +116,29 @@ mod tests {
         assert_eq!(
             reg.lookup("1.1.1.1").unwrap().ips,
             vec!["1.1.1.1".parse::<IpAddr>().unwrap()]
+        );
+    }
+
+    #[test]
+    fn sort_ipv4_first_orders_v4_before_v6_stably() {
+        // Mirrors the macOS getaddrinfo order for a dual-stack host: IPv6 first.
+        // After sorting, both IPv4 addresses lead and within-family order is
+        // preserved so the connect prefers the routable IPv4 pin.
+        let mut ips = vec![
+            ip("2606:4700:10::6814:179a"),
+            ip("2606:4700:10::ac42:93f3"),
+            ip("172.66.147.243"),
+            ip("104.20.23.154"),
+        ];
+        sort_ipv4_first(&mut ips);
+        assert_eq!(
+            ips,
+            vec![
+                ip("172.66.147.243"),
+                ip("104.20.23.154"),
+                ip("2606:4700:10::6814:179a"),
+                ip("2606:4700:10::ac42:93f3"),
+            ]
         );
     }
 

--- a/crates/mvm-hostd/src/supervisor/raw_egress.rs
+++ b/crates/mvm-hostd/src/supervisor/raw_egress.rs
@@ -981,6 +981,33 @@ mod tests {
         accept.await.unwrap();
     }
 
+    /// The issue's shape exactly: the first admitted address is an unreachable
+    /// IPv6 (the guest resolved a dual-stack host to its AAAA and the host has
+    /// no IPv6 egress) and the connect must fall over to the pinned IPv4.
+    #[tokio::test]
+    async fn connect_first_admitted_falls_over_from_unreachable_ipv6_to_ipv4() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accept = tokio::spawn(async move {
+            let _ = listener.accept().await;
+        });
+
+        // 2001:db8::/32 (RFC 3849) is the documentation range — never routed,
+        // so the connect consumes its per-IP budget (or errors immediately)
+        // before the IPv4 fallover, mirroring an admitted-but-unreachable AAAA.
+        let unreachable_v6: IpAddr = "2001:db8::1".parse().unwrap();
+        let loopback_v4: IpAddr = "127.0.0.1".parse().unwrap();
+
+        let stream =
+            connect_first_admitted(&[unreachable_v6, loopback_v4], port, Duration::from_secs(5))
+                .await;
+        assert!(
+            stream.is_some(),
+            "must fall over from the unreachable IPv6 to the IPv4 pin"
+        );
+        accept.await.unwrap();
+    }
+
     /// When every admitted address is unreachable, `splice` nacks the guest and
     /// closes without ever tunneling bytes.
     #[tokio::test]

--- a/crates/mvm-protocol/src/policy/dns_pin.rs
+++ b/crates/mvm-protocol/src/policy/dns_pin.rs
@@ -173,6 +173,15 @@ impl DnsPinRegistry {
         self.pins.get(dest)
     }
 
+    /// The first pin whose address set contains `ip`. Lets a numeric-IP
+    /// egress decision recover the destination the guest resolved so the
+    /// connect can fall over across the destination's full admitted address
+    /// set (e.g. an unreachable IPv6 to the pinned IPv4 sibling) instead of
+    /// stranding on the single address the guest happened to pick.
+    pub fn pin_containing(&self, ip: &IpAddr) -> Option<&DnsPin> {
+        self.pins.values().find(|pin| pin.matches(ip))
+    }
+
     /// Number of pins currently in the registry.
     pub fn len(&self) -> usize {
         self.pins.len()
@@ -292,6 +301,34 @@ mod tests {
         let pin = fixed_pin("example.com", &["93.184.216.34"]);
         // 12:00:00 → 13:00:00 = 3600s.
         assert_eq!(pin.ttl_secs(), 3600);
+    }
+
+    #[test]
+    fn registry_pin_containing_finds_pin_by_member_ip() {
+        // A dual-stack pin (IPv6 + IPv4) is recovered by either member address,
+        // and an address in no pin returns None — this is what widens a
+        // numeric-IP egress decision to the destination's full admitted set.
+        let mut reg = DnsPinRegistry::new();
+        reg.add(fixed_pin(
+            "example.com",
+            &["2606:4700:10::6814:179a", "104.20.23.154"],
+        ));
+        reg.add(fixed_pin("other.test", &["203.0.113.5"]));
+        assert_eq!(
+            reg.pin_containing(&ip("2606:4700:10::6814:179a"))
+                .unwrap()
+                .dest,
+            "example.com"
+        );
+        assert_eq!(
+            reg.pin_containing(&ip("104.20.23.154")).unwrap().dest,
+            "example.com"
+        );
+        assert_eq!(
+            reg.pin_containing(&ip("203.0.113.5")).unwrap().dest,
+            "other.test"
+        );
+        assert!(reg.pin_containing(&ip("198.51.100.9")).is_none());
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
+++ b/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
@@ -93,15 +93,27 @@ impl EgressGate {
     }
 
     /// Decide a TCP connect to an already-resolved address.
+    ///
+    /// When the address belongs to a pinned host, the verdict carries that
+    /// host's whole admitted address set (IPv4 first), not just the single
+    /// address requested. A guest that resolved a dual-stack host locally and
+    /// dialed the numeric IPv6 (macOS `getaddrinfo` returns IPv6 first) then
+    /// falls over to the pinned IPv4 sibling when the IPv6 route is unreachable
+    /// instead of stranding the connect — the same happy-eyeballs behaviour the
+    /// hostname path already gets. Every offered address is independently
+    /// policy-checked, so widening the set never admits an unpinned target.
     pub fn decide_addr(&self, ip: IpAddr, port: u16) -> EgressVerdict {
-        if self.egress.permits(&Proto::Tcp, ip, port) {
-            EgressVerdict::Allow {
-                ips: vec![ip],
-                port,
-            }
-        } else {
-            EgressVerdict::Deny
+        if !self.egress.permits(&Proto::Tcp, ip, port) {
+            return EgressVerdict::Deny;
         }
+        let ips = match self.pins.pin_containing(&ip) {
+            Some(pin) => admitted_ips(&self.egress, &pin.ips, port),
+            None => Vec::new(),
+        };
+        // No pin (or a pin that admitted nothing for this port) ⇒ keep just the
+        // requested address, which the guard above already confirmed admitted.
+        let ips = if ips.is_empty() { vec![ip] } else { ips };
+        EgressVerdict::Allow { ips, port }
     }
 
     /// Decide a guest connect request — either a numeric `"<ip>:<port>"` or a
@@ -498,6 +510,47 @@ mod tests {
             EgressVerdict::Deny | EgressVerdict::Malformed => panic!("expected allow"),
         }
         assert_eq!(gate.decide_request("example.com:80"), EgressVerdict::Deny);
+    }
+
+    /// A guest that resolved a dual-stack pinned host locally (macOS getaddrinfo
+    /// returns IPv6 first, so the guest picks it) and connects to the *numeric*
+    /// IPv6 target must still be handed the pinned IPv4 sibling — IPv4 first — so
+    /// the host connect falls over to IPv4 when the IPv6 route is unreachable
+    /// instead of stranding on the lone IPv6.
+    #[test]
+    fn numeric_pinned_ipv6_target_offers_ipv4_sibling_for_fallover() {
+        use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
+        use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+
+        let v6: IpAddr = "2606:4700:10::6814:179a".parse().unwrap();
+        let v4: IpAddr = "104.20.23.154".parse().unwrap();
+        let mut pins = DnsPinRegistry::new();
+        pins.add(DnsPin::at(
+            "example.com",
+            vec![v6, v4],
+            "2025-01-01T00:00:00Z",
+            "2030-01-01T00:00:00Z",
+        ));
+        let gate = EgressGate::from_network_policy(
+            &NetworkPolicy::allow_list(vec![HostPort::new("example.com", 443)]),
+            &pins,
+            "2026-01-01T00:00:00Z",
+        );
+
+        // The guest connects to the numeric IPv6 address it resolved.
+        match gate.decide_request("[2606:4700:10::6814:179a]:443") {
+            EgressVerdict::Allow { ips, port } => {
+                assert_eq!(port, 443);
+                assert_eq!(
+                    ips,
+                    vec![v4, v6],
+                    "numeric IPv6 connect must offer the pinned IPv4 sibling first"
+                );
+            }
+            EgressVerdict::Deny | EgressVerdict::Malformed => {
+                panic!("expected Allow with fallover candidates")
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1783.

## Symptom
`mvmctl machine run --image alpine --allow-host example.com -- wget -qO- https://example.com` hung to exit 124 on HVF (macOS 26). The guest's in-guest resolver returned an IPv6 answer for the dual-stack host and the host's admitted connect stalled — IPv4 happy-eyeballs fallover never completed, even with ADR-032 Part-1's `ConnectAck` fix present.

## Root cause
On macOS, `getaddrinfo("example.com")` returns **IPv6 addresses first**, then IPv4 (verified on macOS 26: `2606:4700:10::…` before `104.20.23.154`). The guest resolves the allow-listed host locally, its resolver prefers the IPv6, and it dials the **numeric IPv6** target. That numeric target reaches the host egress gate via `EgressGate::decide_addr`, which returned **only that single IPv6 address**:

```
EgressVerdict::Allow { ips: vec![ip], port }
```

So `connect_first_admitted` had a single unreachable IPv6 candidate and nothing to fall over to — even though the same host's IPv4 was equally pinned and admitted. The **hostname** path already handled this (it offers every admitted address IPv4-first via `admitted_ips`, and the connect loop iterates with a per-address budget). The gap was solely the **numeric-IP** path.

## Fix
- `EgressGate::decide_addr` now recovers the destination from the pin registry (`DnsPinRegistry::pin_containing`) and returns the host's **whole admitted address set, IPv4-first**, so happy-eyeballs falls over to the pinned IPv4 sibling when the IPv6 route is unreachable. Every offered address is independently policy-checked (`admitted_ips` filters through `CanonicalEgress::permits`), so widening the set never admits an unpinned target.
- `resolve_network_policy_pins` now orders admission-time pins IPv4-first (`sort_ipv4_first`) so the recorded pin set prefers the routable IPv4 address (candidate #1 in the issue).

This is ADR-032 Part-1 / egress-connect territory — not the DNS resolver.

## Tests
Deterministic, at the seam:
- `numeric_pinned_ipv6_target_offers_ipv4_sibling_for_fallover` (egress_gate) — RED before the fix (returned `[2606:…]`), GREEN after (returns `[104.20.23.154, 2606:…]`).
- `connect_first_admitted_falls_over_from_unreachable_ipv6_to_ipv4` (raw_egress) — unreachable IPv6 (`2001:db8::1`) → reachable IPv4 loopback.
- `sort_ipv4_first_orders_v4_before_v6_stably` (mvm-core dns_pin).
- `registry_pin_containing_finds_pin_by_member_ip` (mvm-protocol dns_pin).

`cargo nextest run -p mvm-core -p mvm-runtime -p mvm-hostd -p mvm-protocol -E 'test(/egress/) or test(/pin/) or test(/connect/) or test(/admitted/) or test(/fallover/) or test(/sort_ipv4/)'` — all pass, no regressions. `cargo clippy -D warnings` clean on the four touched crates; nightly `cargo fmt --all` clean.

## Remaining live check
A full HVF re-boot to confirm end-to-end needs the OCI-rootfs cache cleared first; not claimed live-verified here. The unit tests reproduce the defect deterministically at the gate + connect seam.