### PR TITLE
feat(runtime): converge HVF onto the vsock runner + fail-closed egress

### DIFF
--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -2187,11 +2187,13 @@ mod tests {
         unsafe {
             std::env::remove_var("MVM_HVF_SUPERVISOR_PATH");
         }
+        // HVF always advertises the NIC-less host-vsock-proxy egress caps (they
+        // are unconditional — the fail-closed posture), so the capability
+        // shortfall is empty and the refusal comes from the availability probe:
+        // a host whose supervisor can't launch is unavailable, not egress-capable.
         let msg = err.to_string();
         assert!(msg.contains("NIC-less host-vsock-proxy backend"));
-        assert!(msg.contains("backend hvf lacks ["));
-        assert!(msg.contains("host_vsock_proxy"));
-        assert!(msg.contains("no_routable_guest_nic"));
+        assert!(msg.contains("backend hvf is unavailable on this host"));
     }
 
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -494,19 +494,14 @@ pub fn inhouse_agent_socket_filename() -> &'static str {
     "agent.sock"
 }
 
-/// The in-house (`WorkloadRunner` / HVF) runner's standing guest-agent RPC
-/// bridge under an explicit per-VM state dir. The supervisor / in-process VMM
-/// binds it at boot and forwards to the guest's `GUEST_AGENT_PORT` vsock.
-/// Single source of truth so **both** in-house execution models — the
-/// in-process `WorkloadRunner`/`InHouseDriver` (the `--hypervisor inhouse`
-/// auto-default) and the detached `HvfBackend` supervisor — and the host-side
-/// resolvers (`DevConsoleTransport`, the `for_vm` agent ladder) cannot drift.
-/// A mismatch here silently makes the guest agent unreachable and every RPC
-/// time out.
-///
-/// The `MVM_HVF_AGENT_SOCKET` dev hook overrides this for live drivers; it is
-/// honored on the backend side only, so the override path must set the same
-/// value both sides use.
+/// The `WorkloadRunner`'s generic standing guest-agent RPC hint under an
+/// explicit per-VM state dir: `<socket-dir>/agent.sock`. It is a backend-neutral
+/// placeholder the runner threads onto the spec's `GUEST_AGENT_PORT` channel; a
+/// concrete driver re-derives its own agent-bridge path and ignores this value,
+/// exactly as the FC and libkrun drivers ignore the spec's agent host_uds. The
+/// detached-supervisor HVF path binds and probes [`vm_hvf_agent_socket_at`]
+/// (`hvf-agent.sock`) instead — that is the socket that must not drift between
+/// binder and host resolver.
 pub fn vm_inhouse_agent_socket_at(state_dir: &std::path::Path) -> std::path::PathBuf {
     vm_socket_dir_at(state_dir).join(inhouse_agent_socket_filename())
 }
@@ -587,14 +582,31 @@ pub fn vm_substitution_endpoint_socket(name: &str) -> std::path::PathBuf {
     vm_socket_dir(name).join("substitution-endpoint.sock")
 }
 
-/// The hvf (HVF / `WorkloadRunner`) VMM's host→guest agent-RPC socket:
-/// `<socket-dir>/hvf-agent.sock`. The device's `AgentBridge` binds it and
-/// bridges every host connection to the guest agent on `GUEST_AGENT_PORT`.
-/// Single source of truth so the backend (which binds it) and the host-side
-/// agent-RPC transport (which connects to it) cannot drift — the drift that
-/// silently broke non-interactive `machine run` on the hvf VMM.
+/// Filename of the hvf VMM's host→guest agent-RPC bridge socket:
+/// `hvf-agent.sock`. Single source of truth for the name; callers that hold the
+/// per-VM state dir join it via [`vm_hvf_agent_socket_at`], callers that hold
+/// the VM name use [`vm_hvf_agent_socket`].
+pub fn hvf_agent_socket_filename() -> &'static str {
+    "hvf-agent.sock"
+}
+
+/// The hvf VMM's host→guest agent-RPC socket under an explicit per-VM state dir:
+/// `<socket-dir>/hvf-agent.sock`. The detached `mvm-hvf-supervisor`'s
+/// `AgentBridge` binds it and bridges every host connection to the guest agent
+/// on `GUEST_AGENT_PORT`. Single source of truth so all three sides that name it
+/// — the detached supervisor (which binds it), the `HvfDriver` / `HvfBackend`
+/// (which derive the value they hand the supervisor), and the host-side
+/// agent-RPC resolvers (`DevConsoleTransport`, the `for_vm` ladder, which
+/// connect to it) — cannot drift. A mismatch here silently makes the guest
+/// agent unreachable and every non-interactive `machine run` RPC time out.
+pub fn vm_hvf_agent_socket_at(state_dir: &std::path::Path) -> std::path::PathBuf {
+    vm_socket_dir_at(state_dir).join(hvf_agent_socket_filename())
+}
+
+/// The hvf VMM's host→guest agent-RPC socket for a VM by name:
+/// `<socket-dir>/hvf-agent.sock`. See [`vm_hvf_agent_socket_at`].
 pub fn vm_hvf_agent_socket(name: &str) -> std::path::PathBuf {
-    vm_socket_dir(name).join("hvf-agent.sock")
+    vm_hvf_agent_socket_at(&vm_state_dir(name))
 }
 
 /// The hvf VMM's per-VM `BROKER_PORT` listener socket the host-agent daemon
@@ -1066,6 +1078,17 @@ mod tests {
         assert_eq!(
             vm_hvf_broker_socket("foo"),
             std::path::PathBuf::from("/custom/data/vms/foo/hvf-broker.sock")
+        );
+        // The hvf agent-RPC bridge: the detached supervisor binds it and the host
+        // resolver probes it, so the name-based and state-dir-based accessors must
+        // resolve to ONE socket or the guest agent goes unreachable.
+        assert_eq!(
+            vm_hvf_agent_socket("foo"),
+            std::path::PathBuf::from("/custom/data/vms/foo/hvf-agent.sock")
+        );
+        assert_eq!(
+            vm_hvf_agent_socket_at(&vm_state_dir("foo")),
+            vm_hvf_agent_socket("foo")
         );
 
         env.remove("MVM_HOME");

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -12,7 +12,6 @@ use mvm_core::vm_backend::{
 use crate::base::config::{PortMapping, VmSlot};
 use crate::base::shell::run_in_vm_stdout;
 use crate::driver::{FcDriver, HvfDriver, LibkrunDriver};
-use crate::hvf_backend::HvfBackend;
 use crate::image::RuntimeVolume;
 use crate::microvm::{DriveFile, FlakeRunConfig};
 #[cfg(feature = "test-support")]
@@ -22,10 +21,23 @@ use crate::wasm_backend::WasmBackend;
 use crate::workload_runner::{RealBrokerRegistrar, RealEndpointSpawner, WorkloadRunner};
 use crate::{firecracker, microvm};
 
-/// The hvf VMM driven through the unified workload-runner role over the
-/// driver seam. One alias keeps the long generic instantiation readable at the
-/// enum variant and its construction site.
+/// The hvf VMM driven through the unified workload-runner role over the driver
+/// seam — hvf's sole workload launch path (`--hypervisor hvf` and the macOS-26
+/// `auto_select` default). NIC-less: egress routes to the per-VM gating endpoint
+/// over vsock only; the raw [`HvfBackend`](crate::hvf_backend::HvfBackend) shim
+/// stays behind the driver as its identity delegate and for the
+/// `examples/hvf-backend-*.rs` witnesses, unreached via this enum. One alias
+/// keeps the long generic instantiation readable at the enum variant and its
+/// construction site.
 type HvfRunner = WorkloadRunner<HvfDriver, RealEndpointSpawner, RealBrokerRegistrar>;
+
+/// Construct the hvf VMM's workload runner. Like [`libkrun_runner`] and
+/// [`fc_runner`] the runner is not const-constructible, so this helper is the
+/// one construction site the enum variant, `auto_select`, the descriptor
+/// catalog, and the capability selector all call.
+pub(crate) fn hvf_runner() -> HvfRunner {
+    WorkloadRunner::new(HvfDriver::new(), RealEndpointSpawner, RealBrokerRegistrar)
+}
 
 /// libkrun driven through the same unified workload-runner role — libkrun's
 /// sole production launch path (both `--hypervisor libkrun` and `auto_select`).
@@ -543,20 +555,16 @@ pub enum AnyBackend {
     /// a production `mvmctl` binary.
     #[cfg(feature = "test-support")]
     Mock(MockBackend),
-    /// Raw HVF — Hypervisor.framework on macOS / Apple silicon,
-    /// driven by the unified `vmm::run` loop via the detached
-    /// `mvm-hvf-supervisor`. Selectable via `--hypervisor hvf` / `MVM_BACKEND=hvf`,
-    /// and the macOS-26 auto-detect default. Its `start()` spawns the per-VM
-    /// gating endpoint that is the sole claim-10 egress gate over vsock — no
-    /// legacy userspace gateway sidecar. The destination macOS backend.
-    Hvf(HvfBackend),
-    /// The hvf VMM driven through the unified `WorkloadRunner` over the
-    /// driver seam — the role-runner that will replace the per-backend
-    /// Hvf/Libkrun/FC `start()` copies. Opt-in via `--hypervisor hvf`.
-    /// Same hvf VMM, tier, and security profile as `Hvf` — just reached via
-    /// the runner role. `auto_select` picks the raw [`Self::Hvf`] variant on the
-    /// macOS-26 tier today, not this one.
-    HvfRunner(HvfRunner),
+    /// HVF (Hypervisor.framework on macOS / Apple silicon), driven through the
+    /// unified `WorkloadRunner` over the driver seam — hvf's sole workload path,
+    /// selected by `--hypervisor hvf` / `MVM_BACKEND=hvf` and the macOS-26
+    /// auto-detect default. NIC-less: egress routes to the per-VM gating endpoint
+    /// over vsock only (claim-10 + claims 12/13 at the endpoint); no routable
+    /// guest NIC. The raw [`HvfBackend`](crate::hvf_backend::HvfBackend) stays
+    /// behind the driver as its identity delegate and for the
+    /// `examples/hvf-backend-*.rs` witnesses, unreached via this enum. The
+    /// destination macOS backend.
+    Hvf(HvfRunner),
     /// Host-`wasmtime` claim-free portability tier — see
     /// [`crate::wasm_backend`]. Selectable only via explicit
     /// `--hypervisor wasm` / `MVM_BACKEND=wasm`; `auto_select` never falls
@@ -595,16 +603,6 @@ impl AnyBackend {
     /// [`Self::require_hypervisor_selectable`] first at a user-facing
     /// `--hypervisor` boundary to refuse it loudly instead.
     pub fn from_hypervisor(name: &str) -> Self {
-        // The runner isn't const-constructible, so it can't live in the catalog
-        // table; special-case its opt-in selector before the descriptor lookup.
-        // Every other selector — `hvf` included — stays byte-identical.
-        if matches!(name, "hvf-runner") {
-            return Self::HvfRunner(WorkloadRunner::new(
-                HvfDriver::new(),
-                RealEndpointSpawner,
-                RealBrokerRegistrar,
-            ));
-        }
         catalog::descriptor_for_selector(name)
             .map(|descriptor| descriptor.instantiate())
             .unwrap_or_else(Self::default_backend)
@@ -658,7 +656,7 @@ impl AnyBackend {
         //    claim-10 and claims 12/13 are enforced — no guest-NIC helper
         //    sidecar.
         if plat.is_hvf_default_tier() {
-            return Self::Hvf(HvfBackend);
+            return Self::Hvf(hvf_runner());
         }
 
         // 3. libkrun installed → the libkrun workload runner (vsock-only egress).
@@ -709,9 +707,9 @@ impl AnyBackend {
 
     /// The typed discriminant for this backend. Lets callers branch on
     /// `BackendKind::Hvf` etc. instead of string-matching `name()`. Delegates
-    /// to the wrapped backend's own `VmBackend::kind()` — the runner-role
-    /// variant reports the same hvf VMM kind as the raw `Hvf` variant because
-    /// `WorkloadRunner<HvfDriver, _>` reports `BackendKind::Hvf` too.
+    /// to the wrapped backend's own `VmBackend::kind()` — the HVF variant holds
+    /// the runner, and `WorkloadRunner<HvfDriver, _>` reports `BackendKind::Hvf`,
+    /// so the discriminant is unchanged by the runner convergence.
     pub fn kind(&self) -> catalog::BackendKind {
         self.inner().kind()
     }
@@ -724,7 +722,6 @@ impl AnyBackend {
             #[cfg(feature = "test-support")]
             Self::Mock(backend) => backend,
             Self::Hvf(backend) => backend,
-            Self::HvfRunner(backend) => backend,
             Self::Wasm(backend) => backend,
         }
     }
@@ -741,9 +738,6 @@ impl AnyBackend {
             #[cfg(feature = "test-support")]
             Self::Mock(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
             Self::Hvf(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
-            Self::HvfRunner(backend) => {
-                std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>
-            }
             Self::Wasm(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
         }
     }
@@ -794,13 +788,10 @@ impl AnyBackend {
             #[cfg(feature = "test-support")]
             AnyBackend::Mock(b) => Some(b),
             AnyBackend::Qemu(_) => None,
-            // HVF carries untrusted workloads: a real mkGuest workload boot, a
-            // host-reachable guest agent, and an egress relay to the per-VM
-            // endpoint that owns claim-10 and claims 12/13.
+            // HVF carries untrusted workloads through the runner role: a real
+            // mkGuest workload boot, a host-reachable guest agent, and an egress
+            // relay to the per-VM endpoint that owns claim-10 and claims 12/13.
             AnyBackend::Hvf(b) => Some(b),
-            // Same hvf VMM as Hvf, reached via the runner role: claim-10 at
-            // the endpoint, claims 12/13 at the per-VM substitution endpoint.
-            AnyBackend::HvfRunner(b) => Some(b),
             // Wasm has no egress substitution channel yet — it mediates no
             // networking at all (a later phase wires the governed WASI
             // egress seam). Barred from the admitted launch funnel until
@@ -1167,7 +1158,9 @@ mod tests {
 
     #[test]
     fn test_any_backend_from_hypervisor_hvf() {
-        // `--hypervisor hvf` (and the `hypervisor` alias) resolve to HvfBackend.
+        // `--hypervisor hvf` (and the `hypervisor` alias) resolve to the HVF
+        // workload runner (the sole `Hvf` variant), whose name delegates to the
+        // hvf driver ("hvf") and whose kind is `BackendKind::Hvf`.
         for sel in ["hvf", "hypervisor"] {
             let backend = AnyBackend::from_hypervisor(sel);
             assert!(matches!(backend, AnyBackend::Hvf(_)), "selector {sel}");
@@ -1181,26 +1174,27 @@ mod tests {
 
     #[test]
     fn from_hypervisor_hvf_selects_the_workload_runner() {
-        // The opt-in `hvf-runner` selector constructs the runner-role backend.
-        // Its VmBackend name delegates to the hvf driver ("hvf"), and it is a
-        // workload backend (carries untrusted workloads).
-        let backend = AnyBackend::from_hypervisor("hvf-runner");
-        assert!(matches!(backend, AnyBackend::HvfRunner(_)));
+        // The `Hvf` variant now IS the runner (no separate raw-HVF / runner
+        // selectors): `hvf` resolves through the catalog to the workload runner.
+        // It is a workload backend and advertises the fail-closed egress posture
+        // — no routable guest NIC, egress only via the per-VM vsock endpoint.
+        let backend = AnyBackend::from_hypervisor("hvf");
+        assert!(matches!(backend, AnyBackend::Hvf(_)));
         assert_eq!(backend.as_vm_backend().name(), "hvf");
+        assert_eq!(backend.kind(), catalog::BackendKind::Hvf);
         assert!(
             backend.as_workload_backend().is_some(),
             "runner must be a workload backend"
         );
-        assert_eq!(backend.kind(), catalog::BackendKind::Hvf);
-    }
-
-    #[test]
-    fn from_hypervisor_hvf_still_selects_hvf_backend() {
-        // The new selector is purely additive: `hvf` must still resolve to the
-        // raw HvfBackend, unchanged by the runner opt-in.
-        let backend = AnyBackend::from_hypervisor("hvf");
-        assert!(matches!(backend, AnyBackend::Hvf(_)));
-        assert_eq!(backend.name(), "hvf");
+        let caps = backend.capabilities();
+        assert!(
+            caps.no_routable_guest_nic,
+            "HVF must advertise no guest NIC"
+        );
+        assert!(
+            caps.host_vsock_proxy,
+            "HVF egress must ride the vsock proxy"
+        );
     }
 
     #[test]
@@ -1262,7 +1256,7 @@ mod tests {
         let name = backend.name();
         assert!(
             // The full set of legitimate auto_select returns is:
-            //   firecracker (KVM), hvf (macOS 26+ hvf VMM, via the HvfRunner
+            //   firecracker (KVM), hvf (macOS 26+ hvf VMM, via the HVF workload
             //   runner whose name() delegates to the hvf driver), libkrun
             //   (macOS 13-25 / Linux non-KVM fallback).
             matches!(name, "firecracker" | "hvf" | "libkrun"),
@@ -1666,21 +1660,12 @@ mod tests {
     fn no_backend_advertises_production_ssh() {
         // The capability layer encodes the SSH ban: no backend may advertise an
         // in-guest SSH server. A future backend that flips this trips here.
-        // Covers every `AnyBackend` variant, including both hvf entry points
-        // (the raw backend and the WorkloadRunner-driven role-runner path).
+        // Covers every `AnyBackend` variant, including the HVF workload-runner path.
         let mut backends: Vec<(&str, AnyBackend)> = vec![
             ("firecracker", AnyBackend::Firecracker(fc_runner())),
             ("libkrun", AnyBackend::Libkrun(libkrun_runner())),
             ("qemu", AnyBackend::Qemu(QemuBackend)),
-            ("hvf", AnyBackend::Hvf(HvfBackend)),
-            (
-                "hvf_runner",
-                AnyBackend::HvfRunner(WorkloadRunner::new(
-                    HvfDriver::new(),
-                    RealEndpointSpawner,
-                    RealBrokerRegistrar,
-                )),
-            ),
+            ("hvf", AnyBackend::Hvf(hvf_runner())),
         ];
         backends.extend(mock_variant_for_ssh_check());
         for (name, backend) in backends {

--- a/crates/mvm-runtime/src/catalog.rs
+++ b/crates/mvm-runtime/src/catalog.rs
@@ -214,7 +214,7 @@ backend_catalog![
         kind: Hvf,
         selector: "hvf",
         aliases: ["hypervisor"],
-        constructor: AnyBackend::Hvf(crate::hvf_backend::HvfBackend),
+        constructor: AnyBackend::Hvf(crate::backend::hvf_runner()),
         tier: Tier2,
         marker_file: Some("hvf.pid"),
         started_vm_probe_order: Some(5),

--- a/crates/mvm-runtime/src/driver/hvf.rs
+++ b/crates/mvm-runtime/src/driver/hvf.rs
@@ -154,7 +154,11 @@ fn relay_supervisor_config(spec: &VmmSpec, paths: &SupervisorPaths) -> Result<Hv
         pid_file: paths.pid_file.clone(),
         workload_exit: paths.workload_exit.clone(),
         timeout_secs: paths.timeout_secs,
-        agent_socket: spec.host_socket_for_port(GUEST_AGENT_PORT),
+        // Re-derive the agent bridge from the state dir rather than trusting the
+        // spec's backend-neutral agent hint (`agent.sock`): the detached
+        // supervisor binds this exact path, and the host resolver probes the same
+        // `hvf-agent.sock`, so binder and resolver can't drift.
+        agent_socket: Some(hvf_agent_socket(&paths.state_dir)),
         substitution_socket: None,
         egress_relay_socket,
         // An admitted workload carries a BROKER_PORT relay socket; the supervisor
@@ -259,11 +263,10 @@ impl VmmDriver for HvfDriver {
         drop(child);
 
         // The agent RPC socket the supervisor binds for this VM (host→guest agent
-        // bridge on GUEST_AGENT_PORT). Prefer the spec's own port; fall back to the
-        // standing convention so a later `attach` re-derives the same path.
-        let agent_socket = spec
-            .host_socket_for_port(GUEST_AGENT_PORT)
-            .unwrap_or_else(|| hvf_agent_socket(&paths.state_dir));
+        // bridge on GUEST_AGENT_PORT). Re-derived from the state dir so it matches
+        // the value handed to the supervisor above and the path a later `attach`
+        // and the host resolver both probe.
+        let agent_socket = hvf_agent_socket(&paths.state_dir);
         Ok(Box::new(HvfRunningVm {
             id: VmId(spec.name.clone()),
             state_dir: paths.state_dir,
@@ -294,11 +297,15 @@ impl VmmDriver for HvfDriver {
     }
 }
 
-/// The per-VM agent RPC socket path (host→guest agent bridge). Matches the
-/// standing socket a `WorkloadRunner` binds so `attach` re-derives it — via
-/// the single source of truth shared with the host-side resolver.
+/// The per-VM agent-RPC socket the detached `mvm-hvf-supervisor` binds
+/// (host→guest agent bridge). The driver re-derives this from the state dir
+/// rather than trusting the spec's generic agent hint — the same way the FC and
+/// libkrun drivers ignore the spec's agent host_uds — so the value it hands the
+/// supervisor is exactly the one the host resolver (`DevConsoleTransport` /
+/// `for_vm` → `vm_hvf_agent_socket`) probes. A drift here silently makes the
+/// guest agent unreachable and every RPC time out.
 fn hvf_agent_socket(state_dir: &std::path::Path) -> PathBuf {
-    mvm_core::config::vm_inhouse_agent_socket_at(state_dir)
+    mvm_core::config::vm_hvf_agent_socket_at(state_dir)
 }
 
 /// Resolve the host UDS for a console data port via the shared HVF-style socket
@@ -486,7 +493,8 @@ mod tests {
             ],
             vec![],
         );
-        let cfg = relay_supervisor_config(&spec, &sample_paths()).unwrap();
+        let paths = sample_paths();
+        let cfg = relay_supervisor_config(&spec, &paths).unwrap();
 
         assert_eq!(cfg.kernel, PathBuf::from("/img/Image"));
         assert_eq!(cfg.initramfs, Some(PathBuf::from("/img/initrd.cpio")));
@@ -494,7 +502,11 @@ mod tests {
             cfg.egress_relay_socket,
             Some(PathBuf::from("/run/egress.sock"))
         );
-        assert_eq!(cfg.agent_socket, Some(PathBuf::from("/run/agent.sock")));
+        // The driver re-derives the agent bridge from the state dir (hvf-agent.sock)
+        // and ignores the spec's backend-neutral agent hint (/run/agent.sock), so
+        // the supervisor binds the exact path the host resolver probes.
+        assert_eq!(cfg.agent_socket, Some(hvf_agent_socket(&paths.state_dir)));
+        assert_ne!(cfg.agent_socket, Some(PathBuf::from("/run/agent.sock")));
         assert_eq!(cfg.substitution_socket, None);
         // No BROKER_PORT in this spec ⇒ no broker relay (unadmitted / builder).
         assert_eq!(cfg.broker_socket, None);
@@ -503,6 +515,50 @@ mod tests {
         assert!(cfg.disks.is_empty());
         // Empty spec cmdline ⇒ None (supervisor uses its workload default).
         assert_eq!(cfg.cmdline, None);
+    }
+
+    #[test]
+    fn driver_agent_bind_path_equals_the_host_resolver_probe() {
+        // The live regression this pins closed: the detached mvm-hvf-supervisor
+        // binds the `agent_socket` the driver hands it, while the host reaches the
+        // guest agent through DevConsoleTransport::for_vm / vm_hvf_agent_socket. If
+        // those two ever name different sockets the guest agent is unreachable and
+        // every RPC times out (the witness that caught the agent.sock/hvf-agent.sock
+        // drift). Assert the exact bind path == the exact probe path for the same
+        // VM so neither side can drift independently again.
+        let name = "hvf-agent-socket-drift-guard-vm";
+        let paths = SupervisorPaths::resolve(vm_state_dir(name), 0);
+        let spec = spec_with(
+            KernelImage::Path("/img/Image".into()),
+            vec![
+                egress_port("/run/egress.sock"),
+                agent_port("/run/agent.sock"),
+            ],
+            vec![],
+        );
+
+        // What the supervisor binds: the agent socket the driver puts on the config.
+        let cfg = relay_supervisor_config(&spec, &paths).unwrap();
+        let binder = cfg
+            .agent_socket
+            .expect("hvf relay config must carry an agent socket");
+
+        // What the host reaches the guest agent through.
+        let resolver = mvm_core::config::vm_hvf_agent_socket(name);
+        let transport =
+            crate::vsock_transport::DevConsoleTransport::for_vm(name).socket_path(GUEST_AGENT_PORT);
+
+        assert_eq!(
+            binder, resolver,
+            "supervisor bind path must equal the resolver"
+        );
+        assert_eq!(
+            binder, transport,
+            "supervisor bind path must equal the transport probe"
+        );
+        // The running-vm / attach handle re-derives via the same driver helper, so
+        // vsock_connect(GUEST_AGENT_PORT) reaches the identical socket.
+        assert_eq!(hvf_agent_socket(&paths.state_dir), resolver);
     }
 
     #[test]
@@ -632,7 +688,7 @@ mod tests {
         use std::io::{Read, Write};
 
         let dir = tempfile::tempdir().unwrap();
-        let sock = dir.path().join("agent.sock");
+        let sock = dir.path().join("hvf-agent.sock");
         // Stand-in for the supervisor's agent bridge: echo one byte back.
         let Some(listener) = bind_unix_listener(&sock) else {
             return;
@@ -717,7 +773,7 @@ mod tests {
             id: VmId("console-vm".into()),
             state_dir: dir.path().to_path_buf(),
             pid_file: dir.path().join(PID_FILE_NAME),
-            agent_socket: dir.path().join("agent.sock"),
+            agent_socket: dir.path().join("hvf-agent.sock"),
         };
 
         // Port 20001 (first console data port) connects via the vsock subdir.

--- a/crates/mvm-runtime/src/hvf_backend.rs
+++ b/crates/mvm-runtime/src/hvf_backend.rs
@@ -345,15 +345,18 @@ impl VmBackend for HvfBackend {
         // pause/snapshot/networking are wired onto the primitive.
         VmCapabilities {
             vsock: true,
-            // The hvf VMM is vsock-only by design: no guest NIC, and egress
-            // rides the host vsock proxy (the gating endpoint), not a guest NIC.
-            // Advertise those workload-path capabilities only when the detached
-            // supervisor path is actually launchable on this host.
-            no_routable_guest_nic: proxy_path_ready,
-            host_vsock_proxy: proxy_path_ready,
+            // The hvf VMM is vsock-only by design: no guest NIC, and egress rides
+            // the host vsock proxy (the per-VM gating endpoint), not a guest NIC.
+            // Both are unconditional so the backend fails closed: a degraded host
+            // (the detached supervisor can't launch) loses egress entirely — it
+            // never falls back to a routable guest NIC. HVF never advertises a NIC
+            // and always routes egress through the per-VM endpoint over vsock.
+            no_routable_guest_nic: true,
+            host_vsock_proxy: true,
             // The hvf VMM can serve the unpacked OCI tree as a read-only
             // virtiofs root (dev tier); the run-path tier gate selects it only for
-            // non-prod, non-sealed workloads.
+            // non-prod, non-sealed workloads. This stays gated on the launchable
+            // supervisor path — it is a dev-tier boot capability, not egress.
             virtiofs_root: proxy_path_ready,
             // pause/snapshot/cow/remap land as they are wired onto the primitive.
             ..Default::default()
@@ -796,7 +799,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_supervisor_override_hides_proxy_capabilities() {
+    fn degraded_host_still_advertises_failclosed_egress_caps() {
         let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
@@ -809,14 +812,18 @@ mod tests {
         unsafe {
             std::env::remove_var("MVM_HVF_SUPERVISOR_PATH");
         }
-        assert!(!caps.no_routable_guest_nic);
-        assert!(!caps.host_vsock_proxy);
+        // Fail-closed: even a degraded host (unlaunchable supervisor) advertises
+        // no routable NIC and the host vsock proxy, so egress can only ride the
+        // per-VM endpoint — it never falls back to a guest NIC. Only the dev-tier
+        // virtiofs-root boot capability drops when the supervisor path is dead.
+        assert!(caps.no_routable_guest_nic);
+        assert!(caps.host_vsock_proxy);
         assert!(!caps.virtiofs_root);
     }
 
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     #[test]
-    fn valid_supervisor_override_advertises_proxy_capabilities() {
+    fn launchable_supervisor_enables_virtiofs_root_dev_boot() {
         let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
@@ -835,6 +842,8 @@ mod tests {
             std::env::remove_var("MVM_HVF_SUPERVISOR_PATH");
         }
         assert!(available);
+        // The egress caps are unconditional (fail-closed); a launchable
+        // supervisor additionally enables the dev-tier virtiofs-root boot.
         assert!(caps.no_routable_guest_nic);
         assert!(caps.host_vsock_proxy);
         assert!(caps.virtiofs_root);

--- a/crates/mvm-runtime/src/selection.rs
+++ b/crates/mvm-runtime/src/selection.rs
@@ -7,8 +7,7 @@
 
 use mvm_core::vm_backend::{RequiredCapabilities, VmCapabilities};
 
-use crate::backend::{AnyBackend, fc_runner, libkrun_runner};
-use crate::hvf_backend::HvfBackend;
+use crate::backend::{AnyBackend, fc_runner, hvf_runner, libkrun_runner};
 use crate::qemu::QemuBackend;
 
 /// No backend could be selected: every candidate lacked a required capability.
@@ -64,7 +63,7 @@ impl AnyBackend {
     fn capability_candidates() -> [AnyBackend; 4] {
         [
             AnyBackend::Firecracker(fc_runner()),
-            AnyBackend::Hvf(HvfBackend),
+            AnyBackend::Hvf(hvf_runner()),
             AnyBackend::Libkrun(libkrun_runner()),
             AnyBackend::Qemu(QemuBackend),
         ]

--- a/specs/notes/2026-07-23-f5-hvf-converge-delete-l3.md
+++ b/specs/notes/2026-07-23-f5-hvf-converge-delete-l3.md
@@ -1,0 +1,77 @@
+# F5 — WS-NET endgame: HVF converge + fail-closed, then delete smoltcp-L3
+
+**Context:** F3 (#1779) + F4 (#1781) merged. FC + libkrun run through the one
+`WorkloadRunner`/`RealEndpointSpawner` vsock seam (Model B) and are machine-checked by
+`check-uniform-vsock-egress`. F5 finishes the convergence: converge HVF (the last raw workload
+variant, still the macOS-26 default) and then delete the smoltcp-L3 (Model A) second egress model.
+
+Owner-approved: **HVF fail-closed** — a degraded HVF host (supervisor can't launch) loses egress
+rather than falling back to a routable NIC. That fallback is the exact vsock-only-invariant
+violation F5 removes.
+
+## Why the order is forced
+After F3, FC + libkrun advertise `host_vsock_proxy: true` unconditionally, so
+`drop_l3_tunnel_for_host_vsock_proxy` (exec.rs) always clears `config.network_tunnel` for them —
+they never touch Model A. **HVF is the only remaining Model-A consumer, and only in its fail-open
+fallback:** `hvf_backend.rs:343` gates the egress caps on `proxy_path_ready =
+hvf_workload_support_available()`, so when the supervisor can't launch, HVF stops advertising
+`host_vsock_proxy` (tunnel not dropped) and advertises a routable NIC (`no_routable_guest_nic:
+proxy_path_ready`, :352-353). So the L3 stack cannot be deleted until HVF stops using it.
+
+## F5.1 — HVF converge + fail-closed (needs a LIVE HVF witness on this Mac)
+This Mac is macOS 26 → HVF is the native `auto_select` default and boots real workloads here, so the
+witness is **local** (not the KVM box).
+
+1. **Ungate the egress caps** (`hvf_backend.rs:352-353`): `no_routable_guest_nic` and
+   `host_vsock_proxy` become **unconditional `true`**. Leave `virtiofs_root: proxy_path_ready`
+   (:357) alone — it's a separate dev-tier gate, not egress. Update the two cap tests (:812-813
+   unavailable, :838-839 available) to the new unconditional posture. This is the fail-closed
+   change: HVF never advertises a NIC, and `drop_l3_tunnel_for_host_vsock_proxy` always clears the
+   tunnel for HVF.
+2. **Retype `AnyBackend::Hvf` → `Hvf(HvfRunner)`** (mirror the F3 FC/libkrun retype; `HvfRunner =
+   WorkloadRunner<HvfDriver, RealEndpointSpawner, RealBrokerRegistrar>` already exists,
+   `HvfDriver` is a complete `VmmDriver`). Collapse to ONE HVF variant: retype the `Hvf` arm to
+   hold the runner and DELETE the redundant `HvfRunner(HvfRunner)` variant + the `"hvf-runner"`
+   `from_hypervisor` special-case (no backcompat — `hvf` now IS the runner). Add an `hvf_runner()`
+   constructor. Flip: `auto_select` (backend.rs:660-661), catalog Hvf row constructor
+   (catalog.rs:217), `selection.rs` capability_candidates (:67), `inner`/`into_dyn`/
+   `as_workload_backend` (delete the HvfRunner arm, Hvf arm now the runner). Update the raw-Hvf +
+   hvf-runner tests. HVF has no warm-start/standby (nothing to descope there); keep the catalog
+   flags accurate.
+3. **Flip the F4 gate's last exemption** (`xtask/src/check_uniform_vsock_egress.rs`): add
+   `"Hvf(HvfRunner)"` to `REQUIRED_ENUM_ARMS` (:65) and `"Hvf(HvfBackend)"` to
+   `FORBIDDEN_ENUM_ARMS` (:69); update the exemption module doc + pass/bail messages to drop raw
+   Hvf (Wasm stays exempt — still raw); update `current_tree_passes` + the revert test.
+   `REQUIRED_ALIASES` already lists `HvfRunner`.
+4. The raw HVF L3 wiring (`hvf_backend.rs:435-447,511`) becomes **dead** after (1) (network_tunnel
+   always None) — leave it for F5.2's stack deletion. Raw `HvfBackend::start` stays (the
+   `examples/hvf-backend-*.rs` pin it; they double as the local witnesses).
+
+**Live HVF witness (the F5.1 merge gate):** local, macOS 26. Default-deny, egress-attempting
+workload; observe boots + reachable agent + no routable NIC + egress port pinned to
+`substitution-endpoint.sock` + default-deny blocks the outbound. Build `mvmctl` +
+`mvm-hvf-supervisor` (the per-VM supervisor bin does not auto-rebuild). Watch for the macOS-26
+codesign SIGKILL gotcha on test bins.
+
+## F5.2 — delete the smoltcp-L3 (Model A) stack
+After F5.1 (nothing populates a live `network_tunnel`), remove the dead second egress model:
+- Wiring: the four spawn sites (`workload_runner/runner.rs:261`, `hvf_backend.rs:440`,
+  `libkrun.rs:929`, `microvm/flake_run.rs:312`) + reaps; the `mvm.network_tunnel=` emission
+  (`workload_runner/cmdline.rs:89-92`); the CLI populators (`exec.rs:1315,1796`) +
+  `drop_l3_tunnel_for_host_vsock_proxy` (now vacuous).
+- Modules: `mvm-runtime/src/network_tunnel_spawn.rs`; host
+  `smoltcp_egress.rs`/`network_tunnel.rs`/`net_l3.rs`/`bin/mvm-network-tunnel-worker.rs` +
+  `fuzz/fuzz_targets/fuzz_l3_gate.rs` + the `packet-forwarder` feature + the `smoltcp` dep; guest
+  `network_tunnel.rs`/`bin/mvm-guest-netd.rs` + the L3 parts of `guest_net.rs` +
+  `bin/mvm-guest-netinit.rs` consumers; protocol `network_tunnel.rs` +
+  `encode/decode_network_tunnel_cmdline` (`mvm-core/src/protocol/vm_backend.rs:243,255`).
+- **Do NOT delete `supervisor/proxy/l4.rs`** — it is the hostd supervisor's live L4 egress gate,
+  not Model A.
+- Confirm the two out-of-scope raw spawn sites (`libkrun.rs:929`, `microvm/flake_run.rs:312`) have
+  no live `network_tunnel` populator before deletion (a leftover reference is a safe compile break).
+- Host-testable (compile + `check-uniform-vsock-egress` + tests) + a light re-witness that FC +
+  libkrun + HVF still egress-gate after the deletion.
+
+## Slices
+- **F5.1** — HVF converge + fail-closed + gate flip → local HVF witness → merge.
+- **F5.2** — delete the smoltcp-L3 stack → host gates + light re-witness → merge.

--- a/xtask/src/check_uniform_vsock_egress.rs
+++ b/xtask/src/check_uniform_vsock_egress.rs
@@ -1,7 +1,7 @@
 //! `xtask check-uniform-vsock-egress`
 //!
-//! Uniform vsock egress: the Firecracker and libkrun CLI workload backends are
-//! converged onto **one** launch seam — `WorkloadRunner<Driver,
+//! Uniform vsock egress: the Firecracker, libkrun, and HVF CLI workload backends
+//! are converged onto **one** launch seam — `WorkloadRunner<Driver,
 //! RealEndpointSpawner, RealBrokerRegistrar>`. The per-VM substitution endpoint
 //! (the sole claim-10 egress gate) is spawned in exactly one place,
 //! `RealEndpointSpawner::spawn` (`workload_runner/runner.rs`), over vsock/uds; a
@@ -17,19 +17,20 @@
 //!   `WorkloadRunner<Driver, RealEndpointSpawner, RealBrokerRegistrar>` shape
 //!   (matching the `RealEndpointSpawner, RealBrokerRegistrar` tail, so a spawner
 //!   swap trips the gate), and `pub enum AnyBackend` binds the runner arms
-//!   `Firecracker(FcRunner)` + `Libkrun(LibkrunRunner)` — never a raw
-//!   `Firecracker(FirecrackerBackend)` / `Libkrun(LibkrunBackend)`.
+//!   `Firecracker(FcRunner)` + `Libkrun(LibkrunRunner)` + `Hvf(HvfRunner)` —
+//!   never a raw `Firecracker(FirecrackerBackend)` / `Libkrun(LibkrunBackend)` /
+//!   `Hvf(HvfBackend)`.
 //! - **B — no egress-endpoint wiring on the converged driver surface.** The
 //!   `driver/*.rs` files carry none of the raw egress-spawn tokens; the one legal
 //!   spawn site (`workload_runner/runner.rs`) is out of the guarded set.
 //!
-//! Scope — this gate is **incremental by design**. It cannot assert "every
-//! workload backend is a runner": raw `AnyBackend::Hvf` is still the macOS-26
-//! auto-select default (`HvfRunner` is opt-in), and `Wasm` is a workload but
-//! raw. Those two are **explicitly exempt** — the exemption list is the
-//! remaining-convergence ledger, and it shrinks to nothing once the HVF backend
-//! also converges onto the runner seam. Until then this gate locks Firecracker +
-//! libkrun and leaves raw Hvf + Wasm alone.
+//! Scope — this gate is **incremental by design**. It cannot yet assert "every
+//! workload backend is a runner": `Wasm` is a workload but still raw — it
+//! mediates no networking, so it carries no egress seam to converge. That one
+//! variant is the **sole remaining exemption** — the exemption list is the
+//! remaining-convergence ledger, and it shrinks to nothing once the wasm
+//! portability tier grows a governed WASI egress seam. Until then this gate locks
+//! Firecracker + libkrun + HVF and leaves raw Wasm alone.
 
 use anyhow::{Result, bail};
 use regex::Regex;
@@ -62,12 +63,19 @@ const REQUIRED_ALIASES: &[RunnerAlias] = &[
 ];
 
 /// Enum arms `pub enum AnyBackend` MUST bind — the converged runner variants.
-const REQUIRED_ENUM_ARMS: &[&str] = &["Firecracker(FcRunner)", "Libkrun(LibkrunRunner)"];
+const REQUIRED_ENUM_ARMS: &[&str] = &[
+    "Firecracker(FcRunner)",
+    "Libkrun(LibkrunRunner)",
+    "Hvf(HvfRunner)",
+];
 
 /// Enum arms a regression would introduce — a converged variant reverted to its
 /// raw backend. Their presence as a variant construction fails the gate.
-const FORBIDDEN_ENUM_ARMS: &[&str] =
-    &["Firecracker(FirecrackerBackend)", "Libkrun(LibkrunBackend)"];
+const FORBIDDEN_ENUM_ARMS: &[&str] = &[
+    "Firecracker(FirecrackerBackend)",
+    "Libkrun(LibkrunBackend)",
+    "Hvf(HvfBackend)",
+];
 
 /// The converged driver surface Assertion B guards: a `VmmDriver` only wires the
 /// guest port through, so no per-VM egress endpoint may be spawned here.
@@ -96,9 +104,9 @@ pub fn run(workspace: &Path) -> Result<()> {
     check_converged_runner_shape(workspace)?;
     let scanned = check_no_driver_egress_spawn(workspace)?;
     eprintln!(
-        "check-uniform-vsock-egress: clean (Firecracker + libkrun bind WorkloadRunner \
-         runners; {scanned} driver file(s) spawn no egress endpoint — raw Hvf + Wasm \
-         exempt until HVF converges)"
+        "check-uniform-vsock-egress: clean (Firecracker + libkrun + HVF bind WorkloadRunner \
+         runners; {scanned} driver file(s) spawn no egress endpoint — only raw Wasm \
+         remains exempt)"
     );
     Ok(())
 }
@@ -119,8 +127,8 @@ fn check_converged_runner_shape(workspace: &Path) -> Result<()> {
                 "check-uniform-vsock-egress: {alias} lost its converged runner shape. \
                  Expected `type {alias} = WorkloadRunner<{driver}, RealEndpointSpawner, \
                  RealBrokerRegistrar>`. Swapping the endpoint spawner or broker registrar \
-                 off this seam breaks the uniform vsock-egress convergence. (Raw Hvf + \
-                 Wasm remain exempt until HVF converges — see the module doc.)",
+                 off this seam breaks the uniform vsock-egress convergence. (Raw Wasm \
+                 remains exempt — see the module doc.)",
                 alias = alias.alias,
                 driver = alias.driver
             );
@@ -136,7 +144,7 @@ fn check_converged_runner_shape(workspace: &Path) -> Result<()> {
                 bail!(
                     "check-uniform-vsock-egress: {BACKEND_RS}:{n}: `{arm}` reverts a \
                      converged CLI workload variant to a raw backend. Firecracker + \
-                     libkrun must stay `WorkloadRunner` arms.\n    {}",
+                     libkrun + HVF must stay `WorkloadRunner` arms.\n    {}",
                     line.trim()
                 );
             }
@@ -146,7 +154,7 @@ fn check_converged_runner_shape(workspace: &Path) -> Result<()> {
         if !code.iter().any(|(_, line)| line.contains(arm)) {
             bail!(
                 "check-uniform-vsock-egress: `pub enum AnyBackend` no longer binds the \
-                 `{arm}` runner arm. Firecracker + libkrun must dispatch through \
+                 `{arm}` runner arm. Firecracker + libkrun + HVF must dispatch through \
                  `WorkloadRunner`, not a raw backend."
             );
         }
@@ -335,5 +343,28 @@ mod tests {
             err.to_string().contains("Firecracker(FirecrackerBackend)"),
             "got {err}"
         );
+    }
+
+    #[test]
+    fn reverting_hvf_to_a_raw_backend_fails() {
+        // HVF is now a converged runner arm, so a revert to the raw `HvfBackend`
+        // must fail the gate exactly like the Firecracker/libkrun reverts. The
+        // fixture keeps the aliases and the other two runner arms intact so the
+        // failure is unambiguously the HVF revert.
+        let root = tempfile::tempdir().expect("tempdir");
+        let backend = root.path().join(BACKEND_RS);
+        std::fs::create_dir_all(backend.parent().expect("parent")).expect("create dirs");
+        std::fs::write(
+            &backend,
+            "type FcRunner = WorkloadRunner<FcDriver, RealEndpointSpawner, RealBrokerRegistrar>;\n\
+             type LibkrunRunner = WorkloadRunner<LibkrunDriver, RealEndpointSpawner, RealBrokerRegistrar>;\n\
+             type HvfRunner = WorkloadRunner<HvfDriver, RealEndpointSpawner, RealBrokerRegistrar>;\n\
+             pub enum AnyBackend {\n    Firecracker(FcRunner),\n    Libkrun(LibkrunRunner),\n    Hvf(HvfBackend),\n}\n",
+        )
+        .expect("write backend fixture");
+
+        let err = check_converged_runner_shape(root.path())
+            .expect_err("a raw Hvf arm must fail the gate");
+        assert!(err.to_string().contains("Hvf(HvfBackend)"), "got {err}");
     }
 }


### PR DESCRIPTION
Converge HVF — the macOS-26 default workload backend — onto the shared vsock `WorkloadRunner` seam
and make its egress **fail-closed**, closing the machine-checked gate's last exemption. With this,
every CLI-selected workload backend (Firecracker, libkrun, HVF) runs through the one
`RealEndpointSpawner` seam; only the deliberately-non-workload Wasm tier remains exempt.

- **Fail-closed:** HVF's `no_routable_guest_nic` + `host_vsock_proxy` caps are now unconditional
  `true`. A degraded HVF host (supervisor can't launch) is refused before boot by the availability
  probe rather than falling back to a routable guest NIC — that fallback was the exact vsock-only
  invariant this convergence removes.
- **Retype:** `AnyBackend::Hvf` → `Hvf(HvfRunner)`, collapsing the redundant `HvfRunner` variant +
  `hvf-runner` selector (no backcompat). `HvfDriver` was already a complete `VmmDriver`.
- **Gate:** `check-uniform-vsock-egress` now REQUIRES `Hvf(HvfRunner)` and FORBIDS `Hvf(HvfBackend)`.
- **Fix (a live witness caught it):** the runner-launched HVF agent was unreachable because the
  HvfDriver bound the agent bridge at `agent.sock` (`vm_inhouse_agent_socket_at`, the in-process
  socket) while the host resolver probes `hvf-agent.sock` (`vm_hvf_agent_socket`, the detached
  supervisor socket). The driver now re-derives its own `hvf-agent.sock` bridge (matching the
  detached `mvm-hvf-supervisor` + host resolver + raw path), with a regression test pinning
  binder==resolver so this drift can't recur.

**Live HVF witness on macOS 26 = PASS** (converged runner, default-deny): boots, host reaches the
agent (`hvf-agent.sock`), no routable NIC (`eth0: No such device`), egress endpoint spawned, and
default-deny blocks a real `wget`; audit records `backend=hvf`.

Gates: `nextest --workspace` 7711/7711, workspace doctests, `check-uniform-vsock-egress`, nightly
fmt, no-spec-refs — all clean. Follow-ups (out of scope): the guest `127.0.0.1:18080` substitution
forward-proxy needs guest `lo` up on non-egress OCI boots (admitted-egress substitution, pre-existing,
backend-agnostic — deny gate unaffected); then F5's second half deletes the smoltcp-L3 stack.
