### PR TITLE
feat(sdk): Sandbox.connect() inherits the dev-only exec guard (fail-closed build_mode)

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -1062,6 +1062,10 @@ struct MachineListEntry<'a> {
     #[serde(flatten)]
     spec: &'a MachineSpec,
     status: &'static str,
+    /// `"dev"` / `"prod"`, resolved the same way as the boot-time SDK
+    /// envelope. Read by `Sandbox.connect(id)` to inherit the dev-only exec
+    /// guard when attaching to a running machine from a fresh process.
+    build_mode: &'static str,
 }
 
 /// Live status label for a persisted machine, resolved through the backend.

--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -181,7 +181,17 @@ fn apply_machine_ttl(name: &str, dur_str: &str) -> Result<()> {
 }
 
 fn resolve_build_mode_for_envelope(args: &MachineRunArgs, name: &str) -> &'static str {
-    if let Some(manifest) = args.manifest.as_deref() {
+    resolve_machine_build_mode(args.manifest.as_deref(), name)
+}
+
+/// Resolve a machine's `build_mode` (`"dev"` / `"prod"`) from its manifest
+/// slot's template revision, falling back to the runtime accessibility flag.
+/// Shared by the boot-time SDK envelope and the `machine ls --json` listing so
+/// an attach-from-a-fresh-process client reads the same value the boot path
+/// stamps. Fails closed on `"prod"` — only an explicitly dev-built template or
+/// an accessible (dev) runtime resolves to `"dev"`.
+pub(super) fn resolve_machine_build_mode(manifest: Option<&str>, name: &str) -> &'static str {
+    if let Some(manifest) = manifest {
         let slot_name = manifest
             .trim_end_matches('/')
             .split('/')

--- a/crates/mvm-cli/src/commands/machine/spec_ops.rs
+++ b/crates/mvm-cli/src/commands/machine/spec_ops.rs
@@ -26,6 +26,10 @@ pub(super) fn list_machines(args: MachineListArgs) -> Result<()> {
             .map(|spec| MachineListEntry {
                 spec,
                 status: machine_status_label(&spec.name),
+                build_mode: runtime::resolve_machine_build_mode(
+                    spec.manifest.as_deref(),
+                    &spec.name,
+                ),
             })
             .collect();
         println!("{}", serde_json::to_string_pretty(&entries)?);

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -791,6 +791,49 @@ fn interactive_refuses_a_sealed_machine_via_the_claim15_gate() {
 }
 
 #[test]
+fn resolve_machine_build_mode_is_fail_closed_and_reads_accessible() {
+    let _guard = mvm_runtime::vm::runtime_meta::HOME_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let mut env = TestEnv::new();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    env.set("HOME", tmp.path());
+    env.set("MVM_HOME", tmp.path());
+
+    // No manifest, no runtime meta → fail-closed to prod. This is the value
+    // `Sandbox.connect(id)` inherits its dev-only exec guard from, so a machine
+    // the CLI cannot positively classify must never resolve to dev.
+    assert_eq!(
+        super::runtime::resolve_machine_build_mode(None, "ghost"),
+        "prod"
+    );
+
+    let write_meta = |name: &str, accessible: bool| {
+        mvm_runtime::vm::runtime_meta::write(
+            name,
+            &mvm_runtime::vm::runtime_meta::VmRuntimeMeta {
+                mode: mvm_runtime::vm::runtime_meta::StartModeKind::Detached,
+                accessible,
+                rootfs_path: None,
+                runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy::RootfsOnly,
+                runtime_overlay_version: None,
+            },
+        )
+        .expect("write runtime meta");
+    };
+    write_meta("dev-machine", true);
+    write_meta("sealed-machine", false);
+    assert_eq!(
+        super::runtime::resolve_machine_build_mode(None, "dev-machine"),
+        "dev"
+    );
+    assert_eq!(
+        super::runtime::resolve_machine_build_mode(None, "sealed-machine"),
+        "prod"
+    );
+}
+
+#[test]
 fn translation_is_an_image_backed_transient_run() {
     let args = parse_run(&[
         "run",
@@ -1717,12 +1760,16 @@ fn machine_list_entry_flattens_spec_and_adds_status() {
     let entry = MachineListEntry {
         spec: &spec,
         status: "running",
+        build_mode: "prod",
     };
     let v: serde_json::Value = serde_json::to_value(&entry).expect("serialize");
     // Spec fields are flattened to the top level (not nested under `spec`),
-    // and the live `status` label rides alongside — the shape SDK facades read.
+    // and the live `status` label + `build_mode` ride alongside — the shape SDK
+    // facades read. `build_mode` is what `Sandbox.connect(id)` inherits the
+    // dev-only exec guard from.
     assert_eq!(v["name"], "web");
     assert_eq!(v["status"], "running");
+    assert_eq!(v["build_mode"], "prod");
     assert!(v.get("spec").is_none());
 }
 

--- a/crates/mvm-sdk/sdks/python/mvm/_sandbox.py
+++ b/crates/mvm-sdk/sdks/python/mvm/_sandbox.py
@@ -605,6 +605,49 @@ class _LiveTransport:
             build_mode=envelope["build_mode"],
         )
 
+    @classmethod
+    def for_existing(cls, *, vm_id: str) -> "_LiveTransport":
+        """Attach to an already-running machine by name.
+
+        Shells ``mvmctl machine ls --json`` and re-derives the
+        machine's ``build_mode`` from its listing entry — the attach
+        path never boots, so there is no ``--up-json`` envelope to
+        read it from. Fails closed: only an explicit
+        ``build_mode == "dev"`` unlocks the dev-only exec path; a
+        prod / missing / unknown value resolves to ``"prod"`` so the
+        same guard that protects :meth:`for_template` also protects
+        the attach path (security claim 4). Raises
+        :class:`SandboxLiveError` when no machine of that name is
+        listed (there is nothing to attach to)."""
+        try:
+            mvm_cli_bin = resolve_cli_bin(purpose="Sandbox.connect")
+        except RuntimeError as exc:
+            raise SandboxModeError(str(exc)) from exc
+        argv = [mvm_cli_bin, "machine", "ls", "--json"]
+        try:
+            result = subprocess.run(
+                argv,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError as exc:
+            raise SandboxLiveError(
+                f"`{mvm_cli_bin}` not found on disk; {cli_resolution_hint()}",
+                argv=argv,
+            ) from exc
+        if result.returncode != 0:
+            raise SandboxLiveError(
+                f"`mvmctl machine ls --json` failed with exit code {result.returncode}",
+                argv=argv,
+                exit_code=result.returncode,
+                stderr=result.stderr,
+            )
+        build_mode = _derive_attached_build_mode(
+            result.stdout, vm_id=vm_id, argv=argv
+        )
+        return cls(mvm_cli_bin=mvm_cli_bin, vm_id=vm_id, build_mode=build_mode)
+
     def commands_start(
         self, argv: list[str], env: dict[str, Any] | None
     ) -> None:
@@ -932,6 +975,48 @@ def _parse_up_envelope(stdout: str, *, argv: list[str]) -> dict[str, str]:
     return {"vm_id": vm_id, "build_mode": build_mode}
 
 
+def _derive_attached_build_mode(
+    stdout: str, *, vm_id: str, argv: list[str]
+) -> str:
+    """Re-derive ``build_mode`` for an attached machine from
+    ``mvmctl machine ls --json`` output.
+
+    The listing is a JSON array of machine entries; we match on the
+    ``name`` field. Fail-closed by construction: only an explicit
+    ``"dev"`` returns ``"dev"``; a ``"prod"`` / missing / unknown
+    value returns ``"prod"``, so a stale or hostile listing can never
+    *open* the dev-only exec path — it can only keep it shut. Raises
+    :class:`SandboxLiveError` when ``vm_id`` is absent from the
+    listing (there is nothing to attach to)."""
+    line = stdout.strip()
+    if not line:
+        raise SandboxLiveError(
+            f"`mvmctl machine ls --json` produced no output; cannot attach to {vm_id!r}.",
+            argv=argv,
+        )
+    try:
+        parsed = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise SandboxLiveError(
+            f"`mvmctl machine ls --json` stdout is not valid JSON: {exc.msg}",
+            argv=argv,
+            stderr=line,
+        ) from exc
+    if not isinstance(parsed, list):
+        raise SandboxLiveError(
+            f"`mvmctl machine ls --json` must be a JSON array; got "
+            f"{type(parsed).__name__}",
+            argv=argv,
+        )
+    for entry in parsed:
+        if isinstance(entry, dict) and entry.get("name") == vm_id:
+            return "dev" if entry.get("build_mode") == "dev" else "prod"
+    raise SandboxLiveError(
+        f"no machine named {vm_id!r} in `mvmctl machine ls`; is it running?",
+        argv=argv,
+    )
+
+
 class Sandbox:
     """A recordable / live handle for an imperative ``Sandbox``
     script.
@@ -1046,6 +1131,42 @@ class Sandbox:
             "ops": [],
         }
         return cls(wid)
+
+    @classmethod
+    def connect(cls, id: str) -> "Sandbox":
+        """Attach to an already-running machine by name, from a fresh
+        process.
+
+        Unlike :meth:`create`, ``connect`` never boots a VM — it binds
+        to a machine that is already up. Because it does not boot, it
+        has no ``--up-json`` envelope to read the machine's
+        ``build_mode`` from, so it re-derives it from
+        ``mvmctl machine ls --json`` (see
+        :meth:`_LiveTransport.for_existing`).
+
+        The dev-only exec guard is inherited unchanged: the derived
+        ``build_mode`` is never defaulted to ``"dev"`` — a prod /
+        missing / unknown value resolves to ``"prod"``, so
+        ``connect(...).exec(...)`` / ``.commands.start(...)`` on a
+        sealed prod machine raises :class:`SandboxDevOnly` exactly like
+        the ``create`` path (security claim 4).
+
+        Always a live operation: it resolves the mvm CLI regardless of
+        ``MVM_SDK_MODE`` (attaching to a running VM has no record-mode
+        meaning). Raises :class:`SandboxLiveError` when no machine of
+        that name is listed."""
+        if not isinstance(id, str) or not id:
+            raise ValueError("Sandbox.connect requires a non-empty machine id")
+        if _recording is not None or _live_sandbox_active():
+            raise RuntimeError(
+                "a Sandbox session is already active — call "
+                "Sandbox.kill() or exit the `with` block before "
+                "attaching to another machine."
+            )
+        live = _LiveTransport.for_existing(vm_id=id)
+        sb = cls(id, live=live)
+        _register_live(sb)
+        return sb
 
     @property
     def workload_id(self) -> str:

--- a/crates/mvm-sdk/sdks/python/tests/test_sandbox_live.py
+++ b/crates/mvm-sdk/sdks/python/tests/test_sandbox_live.py
@@ -30,7 +30,7 @@ from pathlib import Path
 import pytest
 
 import mvm
-from mvm._sandbox import _parse_up_envelope
+from mvm._sandbox import _derive_attached_build_mode, _parse_up_envelope
 
 
 @pytest.fixture(autouse=True)
@@ -57,6 +57,8 @@ def _write_fixture_mvmctl(
     cp_exit: int = 0,
     forward_sleep: int = 0,
     down_exit: int = 0,
+    ls_out: str = "[]",
+    ls_exit: int = 0,
 ) -> Path:
     """Write a shell script that pretends to be `mvmctl`. It
     records each invocation's argv + stdin to sidecar files so
@@ -107,6 +109,12 @@ case "$verb" in
       cat > {stdin_dir!s}/fs-write-stdin.bin
     fi
     exit {fs_exit}
+    ;;
+  ls)
+    # `mvmctl machine ls --json` — Sandbox.connect() reads this to
+    # re-derive an attached machine's build_mode.
+    echo '{ls_out}'
+    exit {ls_exit}
     ;;
   cp)
     exit {cp_exit}
@@ -726,3 +734,128 @@ def test_browser_sandbox_custom_host_port(tmp_path: Path) -> None:
 def test_browser_sandbox_unknown_browser_raises() -> None:
     with pytest.raises(ValueError, match="browser"):
         mvm.BrowserSandbox("safari")
+
+
+# ── connect (attach to a running machine; inherits dev-only guard) ────
+
+
+def _connect_fixture(tmp_path: Path, ls_out: str, **kw: object) -> Path:
+    """A fixture mvmctl that boots nothing — only serves `machine ls
+    --json`. `connect()` never boots, so `up_envelope` is None."""
+    return _write_fixture_mvmctl(tmp_path, up_envelope=None, ls_out=ls_out, **kw)
+
+
+def test_derive_attached_build_mode_matches_by_name() -> None:
+    stdout = json.dumps(
+        [
+            {"name": "a", "build_mode": "prod", "status": "running"},
+            {"name": "b", "build_mode": "dev", "status": "running"},
+        ]
+    )
+    assert _derive_attached_build_mode(stdout, vm_id="b", argv=["mvmctl"]) == "dev"
+    assert _derive_attached_build_mode(stdout, vm_id="a", argv=["mvmctl"]) == "prod"
+
+
+def test_derive_attached_build_mode_fail_closed_on_missing_field() -> None:
+    stdout = json.dumps([{"name": "a", "status": "running"}])
+    assert _derive_attached_build_mode(stdout, vm_id="a", argv=["mvmctl"]) == "prod"
+
+
+def test_derive_attached_build_mode_fail_closed_on_unknown_value() -> None:
+    stdout = json.dumps([{"name": "a", "build_mode": "staging"}])
+    assert _derive_attached_build_mode(stdout, vm_id="a", argv=["mvmctl"]) == "prod"
+
+
+def test_derive_attached_build_mode_raises_when_absent() -> None:
+    stdout = json.dumps([{"name": "other", "build_mode": "dev"}])
+    with pytest.raises(mvm.SandboxLiveError, match="no machine named"):
+        _derive_attached_build_mode(stdout, vm_id="ghost", argv=["mvmctl"])
+
+
+def test_connect_dev_machine_allows_exec(tmp_path: Path) -> None:
+    ls_out = json.dumps(
+        [
+            {"name": "web-1", "build_mode": "dev", "status": "running"},
+            {"name": "other", "build_mode": "prod", "status": "running"},
+        ]
+    )
+    script = _connect_fixture(tmp_path, ls_out, proc_wait_stdout="4")
+    os.environ["MVM_CLI_BIN"] = str(script)
+
+    sb = mvm.Sandbox.connect("web-1")
+    assert sb._live is not None
+    assert sb._live.vm_id == "web-1"
+    assert sb._live.build_mode == "dev"
+
+    result = sb.exec("python", "-c", "print(2 + 2)")
+    assert result.exit_code == 0
+    assert result.stdout == "4"
+
+    calls = _read_fixture_log(tmp_path)
+    assert calls[0].startswith("machine ls --json")
+    assert any(c.startswith("machine proc start web-1") for c in calls)
+
+
+def test_connect_prod_machine_refuses_exec_fail_closed(tmp_path: Path) -> None:
+    """Mirror of the create-path prod refusal: connect() to a sealed
+    prod machine must refuse exec/commands.start client-side before any
+    vsock traffic (security claim 4)."""
+    ls_out = json.dumps([{"name": "sealed", "build_mode": "prod", "status": "running"}])
+    script = _connect_fixture(tmp_path, ls_out)
+    os.environ["MVM_CLI_BIN"] = str(script)
+
+    sb = mvm.Sandbox.connect("sealed")
+    assert sb._live.build_mode == "prod"
+
+    with pytest.raises(mvm.SandboxDevOnly, match="dev-mode template"):
+        sb.exec("python", "-c", "x")
+    with pytest.raises(mvm.SandboxDevOnly):
+        sb.commands.start(["python", "run.py"])
+
+    # The SDK must NOT have shelled to `mvmctl machine proc *`.
+    calls = _read_fixture_log(tmp_path)
+    assert not any(c.startswith("machine proc") for c in calls), calls
+
+
+def test_connect_missing_build_mode_refuses_exec(tmp_path: Path) -> None:
+    """A listing entry that omits build_mode must be treated as
+    non-dev — never defaulted to dev."""
+    ls_out = json.dumps([{"name": "m", "status": "running"}])
+    script = _connect_fixture(tmp_path, ls_out)
+    os.environ["MVM_CLI_BIN"] = str(script)
+
+    sb = mvm.Sandbox.connect("m")
+    assert sb._live.build_mode == "prod"
+    with pytest.raises(mvm.SandboxDevOnly):
+        sb.exec("echo", "hi")
+
+
+def test_connect_machine_not_listed_raises(tmp_path: Path) -> None:
+    ls_out = json.dumps([{"name": "other", "build_mode": "dev", "status": "running"}])
+    script = _connect_fixture(tmp_path, ls_out)
+    os.environ["MVM_CLI_BIN"] = str(script)
+
+    with pytest.raises(mvm.SandboxLiveError, match="no machine named"):
+        mvm.Sandbox.connect("ghost")
+
+
+def test_connect_propagates_ls_failure(tmp_path: Path) -> None:
+    script = _connect_fixture(tmp_path, "[]", ls_exit=5)
+    os.environ["MVM_CLI_BIN"] = str(script)
+    with pytest.raises(mvm.SandboxLiveError, match="exit code 5"):
+        mvm.Sandbox.connect("web-1")
+
+
+def test_connect_refuses_second_session(tmp_path: Path) -> None:
+    ls_out = json.dumps([{"name": "a", "build_mode": "dev", "status": "running"}])
+    script = _connect_fixture(tmp_path, ls_out)
+    os.environ["MVM_CLI_BIN"] = str(script)
+
+    mvm.Sandbox.connect("a")
+    with pytest.raises(RuntimeError, match="already active"):
+        mvm.Sandbox.connect("a")
+
+
+def test_connect_rejects_empty_id() -> None:
+    with pytest.raises(ValueError, match="non-empty machine id"):
+        mvm.Sandbox.connect("")

--- a/crates/mvm-sdk/sdks/typescript/src/_sandbox.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/_sandbox.ts
@@ -457,6 +457,54 @@ export class LiveTransport {
     });
   }
 
+  /** Attach to an already-running machine by name. Shells
+   *  `mvmctl machine ls --json` and re-derives `build_mode` from the
+   *  listing entry (the attach path never boots, so there is no
+   *  `--up-json` envelope). Fails closed: only an explicit
+   *  `build_mode === "dev"` unlocks the dev-only exec path — a prod /
+   *  missing / unknown value resolves to `"prod"`. */
+  static forExisting(vmId: string): LiveTransport {
+    let mvmCliBin: string;
+    try {
+      mvmCliBin = resolveCliBin("Sandbox.connect");
+    } catch (err) {
+      throw new SandboxModeError(String(err instanceof Error ? err.message : err));
+    }
+    const argv = ["machine", "ls", "--json"];
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const child = require("node:child_process") as typeof import("node:child_process");
+    let result;
+    try {
+      result = child.spawnSync(mvmCliBin, argv, { encoding: "utf-8" });
+    } catch (err) {
+      throw new SandboxLiveError(
+        `\`${mvmCliBin}\` not found on disk; ${cliResolutionHint()}: ${String(err)}`,
+        { argv: [mvmCliBin, ...argv] },
+      );
+    }
+    if (result.error) {
+      throw new SandboxLiveError(
+        `failed to spawn \`${mvmCliBin}\`: ${result.error.message}`,
+        { argv: [mvmCliBin, ...argv] },
+      );
+    }
+    if (result.status !== 0) {
+      throw new SandboxLiveError(
+        `\`mvmctl machine ls --json\` failed with exit code ${result.status}`,
+        {
+          argv: [mvmCliBin, ...argv],
+          exitCode: result.status,
+          stderr: result.stderr ?? "",
+        },
+      );
+    }
+    const buildMode = deriveAttachedBuildMode(result.stdout ?? "", vmId, [
+      mvmCliBin,
+      ...argv,
+    ]);
+    return new LiveTransport({ mvmCliBin, vmId, buildMode });
+  }
+
   commandsStart(argv: string[], env: Record<string, EnvValue | string> | undefined): void {
     if (this.buildMode !== "dev") {
       throw new SandboxDevOnly(
@@ -796,6 +844,54 @@ export function parseUpEnvelope(
   return { vm_id: obj.vm_id, build_mode: obj.build_mode };
 }
 
+/** Re-derive `build_mode` for an attached machine from
+ *  `mvmctl machine ls --json` output. The listing is a JSON array of
+ *  machine entries matched on `name`. Fails closed: only an explicit
+ *  `"dev"` returns `"dev"`; a `"prod"` / missing / unknown value
+ *  returns `"prod"`, so a stale or hostile listing can never *open*
+ *  the dev-only exec path. Throws `SandboxLiveError` when `vmId` is
+ *  absent from the listing. Exported for tests. */
+export function deriveAttachedBuildMode(
+  stdout: string,
+  vmId: string,
+  argv: string[],
+): "dev" | "prod" {
+  const line = stdout.trim();
+  if (!line) {
+    throw new SandboxLiveError(
+      `\`mvmctl machine ls --json\` produced no output; cannot attach to ${JSON.stringify(vmId)}.`,
+      { argv },
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch (err) {
+    throw new SandboxLiveError(
+      `\`mvmctl machine ls --json\` stdout is not valid JSON: ${String(err)}`,
+      { argv, stderr: line },
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new SandboxLiveError("`mvmctl machine ls --json` must be a JSON array.", {
+      argv,
+    });
+  }
+  for (const entry of parsed) {
+    if (
+      typeof entry === "object" &&
+      entry !== null &&
+      (entry as { name?: unknown }).name === vmId
+    ) {
+      return (entry as { build_mode?: unknown }).build_mode === "dev" ? "dev" : "prod";
+    }
+  }
+  throw new SandboxLiveError(
+    `no machine named ${JSON.stringify(vmId)} in \`mvmctl machine ls\`; is it running?`,
+    { argv },
+  );
+}
+
 function randomHex(byteCount: number): string {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const crypto = require("node:crypto") as typeof import("node:crypto");
@@ -892,6 +988,37 @@ export class Sandbox {
       ops: [],
     };
     return new Sandbox(wid, null);
+  }
+
+  /** Attach to an already-running machine by name, from a fresh
+   *  process. Unlike {@link Sandbox.create}, `connect` never boots a
+   *  VM — so it re-derives the machine's `build_mode` from
+   *  `mvmctl machine ls --json` (see {@link LiveTransport.forExisting})
+   *  rather than an `--up-json` envelope.
+   *
+   *  The dev-only exec guard is inherited unchanged: the derived
+   *  `build_mode` is never defaulted to `"dev"` — a prod / missing /
+   *  unknown value resolves to `"prod"`, so `connect(...).exec(...)` /
+   *  `.commands.start(...)` on a sealed prod machine throws
+   *  {@link SandboxDevOnly} exactly like the create path (security
+   *  claim 4).
+   *
+   *  Always a live operation: resolves the mvm CLI regardless of
+   *  `MVM_SDK_MODE`. Throws {@link SandboxLiveError} when no machine of
+   *  that name is listed. */
+  static connect(id: string): Sandbox {
+    if (typeof id !== "string" || id.length === 0) {
+      throw new TypeError("Sandbox.connect requires a non-empty machine id");
+    }
+    if (recording !== null || isLiveActive()) {
+      throw new Error(
+        "a Sandbox session is already active — call Sandbox.kill() before attaching to another machine.",
+      );
+    }
+    const live = LiveTransport.forExisting(id);
+    const sb = new Sandbox(id, live);
+    liveSandbox = sb;
+    return sb;
   }
 
   /** One-shot: run `argv` inside the sandbox, capturing stdout / stderr /

--- a/crates/mvm-sdk/sdks/typescript/src/index.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/index.ts
@@ -69,6 +69,7 @@ export {
   SandboxLiveError,
   SandboxModeError,
   currentRecording,
+  deriveAttachedBuildMode,
   emitRecordingJson,
   flushRecordingToOutPath,
   parseUpEnvelope,

--- a/crates/mvm-sdk/sdks/typescript/tests/sandbox_live.test.ts
+++ b/crates/mvm-sdk/sdks/typescript/tests/sandbox_live.test.ts
@@ -25,6 +25,8 @@ interface FixtureOptions {
   cpExit?: number;
   forwardSleep?: number;
   downExit?: number;
+  lsOut?: string;
+  lsExit?: number;
 }
 
 function writeFixtureMvmctl(opts: FixtureOptions): string {
@@ -41,6 +43,8 @@ function writeFixtureMvmctl(opts: FixtureOptions): string {
   const cpExit = opts.cpExit ?? 0;
   const forwardSleep = opts.forwardSleep ?? 0;
   const downExit = opts.downExit ?? 0;
+  const lsOut = opts.lsOut ?? "[]";
+  const lsExit = opts.lsExit ?? 0;
 
   const script = path.join(tmpDir, "fake-mvmctl");
   fs.writeFileSync(
@@ -80,6 +84,10 @@ case "$verb" in
       cat > ${JSON.stringify(path.join(stdinDir, "fs-write-stdin.bin"))}
     fi
     exit ${fsExit}
+    ;;
+  ls)
+    echo '${lsOut}'
+    exit ${lsExit}
     ;;
   cp)
     exit ${cpExit}
@@ -165,6 +173,109 @@ describe("parseUpEnvelope", () => {
     expect(() => mvm.parseUpEnvelope("not json", ["mvmctl", "up"])).toThrow(
       /not valid JSON/,
     );
+  });
+});
+
+// ── deriveAttachedBuildMode + connect ────────────────────────────────
+
+describe("deriveAttachedBuildMode", () => {
+  const argv = ["mvmctl", "machine", "ls", "--json"];
+
+  it("matches on name and returns the entry build_mode", () => {
+    const stdout = JSON.stringify([
+      { name: "a", build_mode: "prod", status: "running" },
+      { name: "b", build_mode: "dev", status: "running" },
+    ]);
+    expect(mvm.deriveAttachedBuildMode(stdout, "b", argv)).toBe("dev");
+    expect(mvm.deriveAttachedBuildMode(stdout, "a", argv)).toBe("prod");
+  });
+
+  it("fails closed on a missing build_mode", () => {
+    const stdout = JSON.stringify([{ name: "a", status: "running" }]);
+    expect(mvm.deriveAttachedBuildMode(stdout, "a", argv)).toBe("prod");
+  });
+
+  it("fails closed on an unknown build_mode", () => {
+    const stdout = JSON.stringify([{ name: "a", build_mode: "staging" }]);
+    expect(mvm.deriveAttachedBuildMode(stdout, "a", argv)).toBe("prod");
+  });
+
+  it("throws when the machine is absent", () => {
+    const stdout = JSON.stringify([{ name: "other", build_mode: "dev" }]);
+    expect(() => mvm.deriveAttachedBuildMode(stdout, "ghost", argv)).toThrow(
+      /no machine named/,
+    );
+  });
+});
+
+describe("Sandbox.connect (attach; inherits dev-only guard)", () => {
+  it("attaches to a dev machine and allows exec", () => {
+    const lsOut = JSON.stringify([
+      { name: "web-1", build_mode: "dev", status: "running" },
+      { name: "other", build_mode: "prod", status: "running" },
+    ]);
+    const script = writeFixtureMvmctl({ upEnvelope: null, lsOut, procWaitStdout: "4" });
+    process.env.MVM_CLI_BIN = script;
+
+    const sb = mvm.Sandbox.connect("web-1");
+    expect(sb._live).not.toBeNull();
+    expect(sb._live!.vmId).toBe("web-1");
+    expect(sb._live!.buildMode).toBe("dev");
+
+    const r = sb.exec(["python", "-c", "print(2 + 2)"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("4");
+
+    const calls = readFixtureLog();
+    expect(calls[0]).toMatch(/^machine ls --json/);
+    expect(calls.some((c) => c.startsWith("machine proc start web-1"))).toBe(true);
+  });
+
+  it("refuses exec on a prod machine (fail-closed, no proc traffic)", () => {
+    const lsOut = JSON.stringify([{ name: "sealed", build_mode: "prod", status: "running" }]);
+    const script = writeFixtureMvmctl({ upEnvelope: null, lsOut });
+    process.env.MVM_CLI_BIN = script;
+
+    const sb = mvm.Sandbox.connect("sealed");
+    expect(sb._live!.buildMode).toBe("prod");
+    expect(() => sb.exec(["python", "-c", "x"])).toThrow(mvm.SandboxDevOnly);
+    expect(() => sb.commands.start(["python", "run.py"])).toThrow(mvm.SandboxDevOnly);
+    expect(readFixtureLog().some((c) => c.startsWith("machine proc"))).toBe(false);
+  });
+
+  it("treats a missing build_mode as non-dev (fail-closed)", () => {
+    const lsOut = JSON.stringify([{ name: "m", status: "running" }]);
+    const script = writeFixtureMvmctl({ upEnvelope: null, lsOut });
+    process.env.MVM_CLI_BIN = script;
+
+    const sb = mvm.Sandbox.connect("m");
+    expect(sb._live!.buildMode).toBe("prod");
+    expect(() => sb.exec(["echo", "hi"])).toThrow(mvm.SandboxDevOnly);
+  });
+
+  it("throws when the machine is not listed", () => {
+    const lsOut = JSON.stringify([{ name: "other", build_mode: "dev", status: "running" }]);
+    const script = writeFixtureMvmctl({ upEnvelope: null, lsOut });
+    process.env.MVM_CLI_BIN = script;
+    expect(() => mvm.Sandbox.connect("ghost")).toThrow(/no machine named/);
+  });
+
+  it("propagates a machine ls failure", () => {
+    const script = writeFixtureMvmctl({ upEnvelope: null, lsExit: 5 });
+    process.env.MVM_CLI_BIN = script;
+    expect(() => mvm.Sandbox.connect("web-1")).toThrow(/exit code 5/);
+  });
+
+  it("refuses a second concurrent session", () => {
+    const lsOut = JSON.stringify([{ name: "a", build_mode: "dev", status: "running" }]);
+    const script = writeFixtureMvmctl({ upEnvelope: null, lsOut });
+    process.env.MVM_CLI_BIN = script;
+    mvm.Sandbox.connect("a");
+    expect(() => mvm.Sandbox.connect("a")).toThrow(/already active/);
+  });
+
+  it("rejects an empty id", () => {
+    expect(() => mvm.Sandbox.connect("")).toThrow(/non-empty machine id/);
   });
 });
 


### PR DESCRIPTION
Closes #1366.

## What

`Sandbox.connect(id)` — attach to an already-running machine from a fresh process — now inherits the existing fail-closed dev-only exec guard, so `connect().exec()` / `connect().commands.start()` cannot run on a sealed **prod** machine. Landed in both the Python (`sdks/python/mvm/_sandbox.py`) and TypeScript (`sdks/typescript/src/_sandbox.ts`) runtime SDKs.

## How the guard is inherited

The dev-only guard is keyed on `build_mode` (`commands_start` / `commands_exec` each do `if build_mode != "dev": raise SandboxDevOnly(...)`), which fails closed on anything that isn't exactly `"dev"`.

`create()` gets `build_mode` from the `mvmctl machine run --up-json` envelope. `connect()` never boots, so it has **no** envelope — it re-derives `build_mode` from `mvmctl machine ls --json`, matching the target by `name`:

- Only an explicit `build_mode == "dev"` resolves to `dev` (exec allowed).
- A `prod` / **missing** / **unknown** value resolves to `prod` (exec refused). `build_mode` is **never** defaulted to `"dev"` — the one way to open a hole per the issue.
- A machine absent from the listing raises `SandboxLiveError` (nothing to attach to), distinct from the guard.
- `connect()` is always a live operation (resolves the CLI regardless of `MVM_SDK_MODE`) and honours the one-session-per-process gate.

## CLI enabler

For a real dev-attach to actually reach exec (not just fail-closed forever), `mvmctl machine ls --json` now emits a per-entry `build_mode`, resolved the same way as the boot-time SDK envelope. The resolver was factored into a shared `resolve_machine_build_mode(manifest, name)` used by both the `--up-json` envelope path and the listing, so an attached client reads exactly what the boot path stamps. It fails closed to `prod` for any machine the CLI cannot positively classify as dev.

## Acceptance criteria

- [x] `connect()` sources `build_mode` from `machine ls --json`; never defaults to `dev`; unknown/missing → non-dev (refuse).
- [x] Mirror test: `connect()` to a prod machine → `.exec()` / `.commands.start()` raises `SandboxDevOnly`, matching the create-path coverage.
- [x] Same applied in the TypeScript SDK.

## Tests

- Python `test_sandbox_live.py` and TypeScript `sandbox_live.test.ts` (parity): dev-attach allows exec; prod / missing / unknown refuse fail-closed and emit **no** proc traffic; absent machine raises; ls-failure propagation; one-session gate; empty-id rejection; plus `build_mode` derivation unit tests.
- Rust `commands::machine::tests`: `resolve_machine_build_mode` fail-closed default + accessible-flag (dev) / sealed (prod) paths; ls entry serialization carries `build_mode`.

Verified locally: Python `pytest test_sandbox_live.py` (48 passed), TS `vitest sandbox_live.test.ts` (49 passed) + `tsc --noEmit`, Rust `nextest -p mvm-cli` machine module (110 passed) + `clippy -p mvm-cli -- -D warnings` clean + `fmt --all --check` clean + `xtask check-no-spec-refs-in-comments` clean. (Pre-existing, unrelated `test_machine.py` / `machine.test.ts` argv-fixture failures reproduce on untouched `main` — a cwd-relative fixture-path issue, not touched here.)

## Deferred / out of scope

- `machine inspect --json` is left unchanged (connect reads `ls`, not `inspect`); adding `build_mode` there for symmetry is a small follow-up.
- `Sandbox.list()` (named alongside `connect()` in the fixture comment) is not implemented — not part of this issue's acceptance criteria.

## Risk

Low, and fail-closed by construction: the guest-side backstops are independent of the SDK (a sealed prod agent strips `do_exec`, and the console is dev-gated), so even a bypassed SDK guard cannot reach exec on a sealed prod guest.