### PR TITLE
feat(bdd): live transient sandbox boot, ping egress, and cleanup

### DIFF
--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1424,9 +1424,7 @@ fn boot_transient_vm(
     if !booted {
         ui::info(&format!("Booting transient VM '{vm_name}'..."));
         if let Err(e) = attempt.backend.start(attempt.start_config) {
-            remove_transient_state_dir(
-                &mvm_core::config::vm_state_dir(&vm_name).to_string_lossy(),
-            );
+            remove_transient_state_dir(&mvm_core::config::vm_state_dir(&vm_name).to_string_lossy());
             return Err(e).context("starting transient microVM");
         }
     }

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1017,7 +1017,6 @@ fn run_inner(
         backend: &backend,
         start_config: &start_config,
         resolved: &resolved,
-        staging_dir: &staging_dir,
     };
     let vm_name = boot_transient_vm(vm_name, use_snapshot, &boot_attempt)?;
     let t_backend_started = timing.then(std::time::Instant::now);
@@ -1337,7 +1336,6 @@ struct BootAttempt<'a> {
     backend: &'a AnyBackend,
     start_config: &'a VmStartConfig,
     resolved: &'a ResolvedImage,
-    staging_dir: &'a str,
 }
 
 /// Boot the transient VM: try to claim a warm standby first, then a
@@ -1426,7 +1424,9 @@ fn boot_transient_vm(
     if !booted {
         ui::info(&format!("Booting transient VM '{vm_name}'..."));
         if let Err(e) = attempt.backend.start(attempt.start_config) {
-            remove_transient_state_dir(attempt.staging_dir);
+            remove_transient_state_dir(
+                &mvm_core::config::vm_state_dir(&vm_name).to_string_lossy(),
+            );
             return Err(e).context("starting transient microVM");
         }
     }
@@ -1456,7 +1456,9 @@ fn install_ctrlc_teardown(
 
 /// Tear down the transient VM after the guest command finishes (or fails to
 /// dispatch): stop the backend VM, top up the warm pool toward its target,
-/// sync back any writable `--add-dir` mounts, and remove the staging dir.
+/// sync back any writable `--add-dir` mounts, and remove the host VM state
+/// directory (`~/.mvm/vms/<name>`), which includes the `extras` staging
+/// subdirectory and any backend files such as `hvf.pid` / `console.log`.
 ///
 /// The caller invokes this unconditionally after capturing the guest
 /// command's `Result` in a local — there is no `?` between the backend
@@ -1497,7 +1499,7 @@ fn teardown_transient_vm(
         }
     }
 
-    remove_transient_state_dir(staging_dir);
+    remove_transient_state_dir(&mvm_core::config::vm_state_dir(vm_name).to_string_lossy());
 }
 
 /// Restore a transient microVM from a template snapshot instead of cold-booting.

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -2,12 +2,50 @@
 //! its exit code / stdout. Covers the CLI-surface suite; scenarios that need
 //! a running microVM call through `mvm-client` instead as those suites land.
 
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use assert_cmd::cargo::CommandCargoExt;
-use cucumber::{then, when};
+use cucumber::{given, then, when};
 
 use crate::world::CliWorld;
+
+/// Build an `mvmctl` subprocess with the same binary discovery the rest of
+/// the conformance suite uses, plus the target directory on `PATH` so helper
+/// binaries built alongside `mvmctl` are visible during live boots.
+fn mvmctl_command() -> Command {
+    #[allow(deprecated)] // matches crates/mvm-cli/tests/cli.rs's use of this API
+    let mut cmd = Command::cargo_bin("mvmctl").unwrap_or_else(|e| {
+        panic!(
+            "mvmctl binary not found ({e}) — run `cargo build --bin mvmctl` before `just bdd`"
+        )
+    });
+
+    let bin_path = PathBuf::from(cmd.get_program());
+    if let Some(bin_dir) = bin_path.parent() {
+        let mut path = bin_dir.as_os_str().to_os_string();
+        path.push(":");
+        if let Some(existing) = std::env::var_os("PATH") {
+            path.push(existing);
+        }
+        cmd.env("PATH", path);
+    }
+
+    cmd
+}
+
+/// The repository root, resolved from this crate's manifest directory.
+///
+/// Steps that reference workspace files (e.g. `examples/exit_code`) run `mvmctl`
+/// with this as the working directory so relative flake paths resolve the same
+/// way they do from a manual invocation at the project root.
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("workspace root must exist")
+}
 
 #[when(expr = "I run mvmctl with {string}")]
 fn run_mvmctl(world: &mut CliWorld, args: String) {
@@ -40,6 +78,47 @@ fn run_mvmctl_isolated_home(world: &mut CliWorld, args: String) {
         .output()
         .expect("failed to spawn mvmctl");
     world.last_run = Some(output);
+}
+
+#[given(expr = "an isolated mvm home")]
+fn isolated_mvm_home(world: &mut CliWorld) {
+    world.isolated_home = Some(tempfile::tempdir().expect("create isolated MVM_HOME"));
+}
+
+#[when(expr = "I run mvmctl in an isolated live home with {string}")]
+fn run_mvmctl_isolated_live_home(world: &mut CliWorld, args: String) {
+    // Like `run_mvmctl_isolated_home`, but for scenarios that boot a real
+    // microVM. The working directory is the workspace root so relative flake
+    // paths (e.g. `examples/exit_code`) resolve the same way as a manual run
+    // from the repo root, and the target directory is prepended to `PATH` so
+    // helper binaries built alongside `mvmctl` are found.
+    if world.isolated_home.is_none() {
+        world.isolated_home = Some(tempfile::tempdir().expect("create isolated MVM_HOME"));
+    }
+    let home = world
+        .isolated_home
+        .as_ref()
+        .expect("isolated home is set above");
+    let output = mvmctl_command()
+        .current_dir(workspace_root())
+        .args(args.split_whitespace())
+        .env("MVM_HOME", home.path())
+        .output()
+        .expect("failed to spawn mvmctl");
+    world.last_run = Some(output);
+}
+
+#[then(expr = "the isolated mvm home does not contain directory {string}")]
+fn isolated_home_no_dir(world: &mut CliWorld, rel: String) {
+    let home = world
+        .isolated_home
+        .as_ref()
+        .expect("isolated home must be created before checking it");
+    let path = home.path().join(rel.as_str());
+    assert!(
+        !path.exists(),
+        "expected {path:?} to be removed after teardown, but it still exists"
+    );
 }
 
 #[then(expr = "the command exits with code {int}")]

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -16,9 +16,7 @@ use crate::world::CliWorld;
 fn mvmctl_command() -> Command {
     #[allow(deprecated)] // matches crates/mvm-cli/tests/cli.rs's use of this API
     let mut cmd = Command::cargo_bin("mvmctl").unwrap_or_else(|e| {
-        panic!(
-            "mvmctl binary not found ({e}) — run `cargo build --bin mvmctl` before `just bdd`"
-        )
+        panic!("mvmctl binary not found ({e}) — run `cargo build --bin mvmctl` before `just bdd`")
     });
 
     let bin_path = PathBuf::from(cmd.get_program());

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -1,6 +1,7 @@
 //! Shared state cucumber threads through the steps of one scenario.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::process::Output;
 
 use mvm_core::kernel_format::KernelFormat;
@@ -9,7 +10,7 @@ use mvm_core::kernel_format::KernelFormat;
 /// recent CLI invocation so later `Then` steps can assert on it, plus the
 /// workload identities parsed from successful `build address` runs, keyed by
 /// fixture name.
-#[derive(Debug, Default, cucumber::World)]
+#[derive(cucumber::World)]
 pub struct CliWorld {
     pub last_run: Option<Output>,
     /// `semantic_address` per fixture name, populated on a zero-exit
@@ -21,6 +22,38 @@ pub struct CliWorld {
     pub workload_cmdline: Option<String>,
     /// Kernel format mapped by the libkrun supervisor-config seam.
     pub libkrun_kernel_format: Option<KernelFormat>,
+    /// An isolated `MVM_HOME` created by a `Given` step and reused by later
+    /// steps that need to inspect the filesystem after a run.
+    pub isolated_home: Option<tempfile::TempDir>,
+}
+
+impl Default for CliWorld {
+    fn default() -> Self {
+        Self {
+            last_run: None,
+            addresses: HashMap::new(),
+            ir_hashes: HashMap::new(),
+            workload_cmdline: None,
+            libkrun_kernel_format: None,
+            isolated_home: None,
+        }
+    }
+}
+
+impl fmt::Debug for CliWorld {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CliWorld")
+            .field("last_run", &self.last_run)
+            .field("addresses", &self.addresses)
+            .field("ir_hashes", &self.ir_hashes)
+            .field("workload_cmdline", &self.workload_cmdline)
+            .field("libkrun_kernel_format", &self.libkrun_kernel_format)
+            .field(
+                "isolated_home",
+                &self.isolated_home.as_ref().map(|t| t.path().to_path_buf()),
+            )
+            .finish()
+    }
 }
 
 impl CliWorld {

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -10,7 +10,7 @@ use mvm_core::kernel_format::KernelFormat;
 /// recent CLI invocation so later `Then` steps can assert on it, plus the
 /// workload identities parsed from successful `build address` runs, keyed by
 /// fixture name.
-#[derive(cucumber::World)]
+#[derive(cucumber::World, Default)]
 pub struct CliWorld {
     pub last_run: Option<Output>,
     /// `semantic_address` per fixture name, populated on a zero-exit
@@ -25,19 +25,6 @@ pub struct CliWorld {
     /// An isolated `MVM_HOME` created by a `Given` step and reused by later
     /// steps that need to inspect the filesystem after a run.
     pub isolated_home: Option<tempfile::TempDir>,
-}
-
-impl Default for CliWorld {
-    fn default() -> Self {
-        Self {
-            last_run: None,
-            addresses: HashMap::new(),
-            ir_hashes: HashMap::new(),
-            workload_cmdline: None,
-            libkrun_kernel_format: None,
-            isolated_home: None,
-        }
-    }
 }
 
 impl fmt::Debug for CliWorld {

--- a/features/suites/s5_lifecycle/transient_sandbox_boot.feature
+++ b/features/suites/s5_lifecycle/transient_sandbox_boot.feature
@@ -1,0 +1,31 @@
+Feature: Transient sandbox boot
+
+  A transient microVM can be launched successfully from both OCI and Nix
+  sources, can reach an admitted host, and cleans up its host state directory
+  after the guest exits. These scenarios boot a real VM, so they are opt-in via
+  `MVM_BDD_LIVE`.
+
+  @live
+  Scenario: machine run boots a transient sandbox from an OCI image
+    When I run mvmctl in an isolated live home with "machine run --name bdd-oci-boot --image alpine --timeout 120 -- /bin/echo mvm-bdd-oci-hello"
+    Then the command exits with code 0
+    And the output contains "mvm-bdd-oci-hello"
+
+  @live
+  Scenario: machine run boots a transient sandbox from a Nix flake
+    When I run mvmctl in an isolated live home with "machine run --name bdd-nix-boot --flake examples/exit_code --timeout 120"
+    Then the command exits with code 7
+
+  @live
+  Scenario: machine run reaches an admitted host with ping
+    When I run mvmctl in an isolated live home with "machine run --name bdd-egress-ping --image alpine --allow-host google.com --timeout 120 -- /bin/ping -c 1 google.com"
+    Then the command exits with code 0
+    And the output contains "1 received"
+
+  @live
+  Scenario: machine run removes the transient VM state directory on guest exit
+    Given an isolated mvm home
+    When I run mvmctl in an isolated live home with "machine run --name bdd-transient-cleanup --image alpine --timeout 120 -- /bin/echo mvm-bdd-cleanup-marker"
+    Then the command exits with code 0
+    And the output contains "mvm-bdd-cleanup-marker"
+    And the isolated mvm home does not contain directory "vms/bdd-transient-cleanup"


### PR DESCRIPTION
Adds live BDD coverage for transient OCI/Nix boots, admitted-host ping, and post-shutdown VM directory cleanup. Also fixes teardown to remove the full ~/.mvm/vms/<name> directory.