### PR TITLE
fix(hvf,egress): ring crypto provider, /tmp endpoint log, 3 s DNS timeout on macOS

### DIFF
--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -4,9 +4,12 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use assert_cmd::cargo::CommandCargoExt;
 use cucumber::{given, then, when};
+use tokio::task::spawn_blocking;
+use tokio::time::timeout;
 
 use crate::world::CliWorld;
 
@@ -55,6 +58,25 @@ fn run_mvmctl(world: &mut CliWorld, args: String) {
         .args(args.split_whitespace())
         .output()
         .expect("failed to spawn mvmctl");
+    world.last_run = Some(output);
+}
+
+#[when(expr = "I run mvmctl with {string} with a {int} second timeout")]
+async fn run_mvmctl_with_timeout(world: &mut CliWorld, args: String, seconds: i64) {
+    let duration =
+        Duration::from_secs(u64::try_from(seconds).expect("timeout must be non-negative"));
+
+    let handle = spawn_blocking(move || {
+        mvmctl_command()
+            .args(args.split_whitespace())
+            .output()
+            .expect("failed to spawn mvmctl")
+    });
+
+    let output = timeout(duration, handle)
+        .await
+        .unwrap_or_else(|_| panic!("mvmctl did not exit within {seconds}s"))
+        .expect("spawn_blocking task panicked");
     world.last_run = Some(output);
 }
 
@@ -151,6 +173,22 @@ fn output_contains(world: &mut CliWorld, needle: String) {
         stdout.contains(needle.as_str()),
         "expected stdout to contain {needle:?}; stdout:\n{stdout}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[then(expr = "the file {string} exists")]
+fn file_exists(world: &mut CliWorld, path: String) {
+    let _ = world.last_output();
+    assert!(Path::new(&path).exists(), "expected file {path:?} to exist");
+}
+
+#[then(expr = "the file {string} contains {string}")]
+fn file_contains(world: &mut CliWorld, path: String, needle: String) {
+    let _ = world.last_output();
+    let contents = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+    assert!(
+        contents.contains(needle.as_str()),
+        "expected {path:?} to contain {needle:?}; contents:\n{contents}"
     );
 }
 

--- a/crates/mvm-hostd/src/bin/mvm-substitution-endpoint.rs
+++ b/crates/mvm-hostd/src/bin/mvm-substitution-endpoint.rs
@@ -50,6 +50,12 @@ fn main() -> Result<()> {
     // is gone (macOS / SIGKILL gap the spawn-side attach misses).
     mvm_hostd::parent_death::exit_when_orphaned();
 
+    // reqwest is built with rustls-no-provider; install the ring crypto provider
+    // before any tokio task creates a reqwest Client (e.g. HTTP forward/DNS-over-HTTPS).
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("ring rustls crypto provider should install once");
+
     tracing_subscriber::fmt()
         .with_target(true)
         .with_level(true)

--- a/crates/mvm-hostd/src/supervisor/raw_egress.rs
+++ b/crates/mvm-hostd/src/supervisor/raw_egress.rs
@@ -582,14 +582,32 @@ pub(super) fn resolve_hostname_ips_pure(
 #[cfg(not(target_os = "linux"))]
 pub(super) fn resolve_hostname_ips_pure(
     host: &str,
-    _timeout: Duration,
+    timeout: Duration,
 ) -> std::io::Result<Vec<IpAddr>> {
     use std::net::ToSocketAddrs;
+    use std::sync::mpsc;
+    use std::thread;
 
-    Ok((host, 0u16)
-        .to_socket_addrs()?
-        .map(|addr| addr.ip())
-        .collect())
+    let host = host.to_string();
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let result = (host.as_str(), 0u16)
+            .to_socket_addrs()
+            .map(|iter| iter.map(|addr| addr.ip()).collect());
+        let _ = tx.send(result);
+    });
+
+    let dns_timeout = timeout.min(Duration::from_secs(3));
+    match rx.recv_timeout(dns_timeout) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "DNS resolution timed out",
+        )),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Err(std::io::Error::other("DNS resolution thread disconnected"))
+        }
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/mvm-runtime/src/substitution_spawn.rs
+++ b/crates/mvm-runtime/src/substitution_spawn.rs
@@ -231,10 +231,26 @@ pub fn spawn_substitution_endpoint(params: SubstitutionSpawnParams<'_>) -> Resul
 
     let bin = resolve_substitution_endpoint_path()?;
 
+    // Capture endpoint diagnostics to /tmp so hangs/refusals are observable.
+    // The file is per-VM and truncated each run; stderr was previously /dev/null.
+    let stderr_log =
+        std::path::PathBuf::from("/tmp").join(format!("mvm-substitution-endpoint-{vm_name}.log"));
+    let log_file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&stderr_log)
+        .map_err(|e| {
+            anyhow!(
+                "open substitution endpoint stderr log {}: {e}",
+                stderr_log.display()
+            )
+        })?;
+
     let mut cmd = Command::new(&bin);
     cmd.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null());
+        .stderr(log_file);
     // Detach into its own session so it survives this `mvmctl` process.
     unsafe {
         use std::os::unix::process::CommandExt;

--- a/features/suites/s2_egress_vsock/hvf_egress_observable.feature
+++ b/features/suites/s2_egress_vsock/hvf_egress_observable.feature
@@ -1,0 +1,20 @@
+Feature: HVF admitted egress is observable and does not hang
+
+  The per-VM substitution endpoint initializes a rustls crypto provider before
+  making outbound HTTPS requests. Without it the endpoint panics, the guest's
+  egress client writes to a dead UDS, and the workload hangs until an external
+  timeout kills it. Endpoint diagnostics must also be capturable on disk instead
+  of being discarded to /dev/null.
+
+  @live
+  Scenario: Admitted HTTPS egress completes instead of hanging
+    When I run mvmctl with "machine run --image alpine --allow-host httpbin.org -- wget -q -O - https://httpbin.org/get" with a 120 second timeout
+    Then the command exits with code 0
+    And the output contains "httpbin.org"
+
+  @live
+  Scenario: Substitution endpoint diagnostics are written to /tmp
+    When I run mvmctl with "machine run --name bdd-subst-log --image alpine --allow-host httpbin.org -- wget -q -O - https://httpbin.org/get" with a 120 second timeout
+    Then the command exits with code 0
+    And the file "/tmp/mvm-substitution-endpoint-bdd-subst-log.log" exists
+    And the file "/tmp/mvm-substitution-endpoint-bdd-subst-log.log" contains "substitution endpoint bound"


### PR DESCRIPTION
Three macOS HVF egress hardening fixes:

- Install the rustls `ring` crypto provider in `mvm-substitution-endpoint` before creating a reqwest Client. Without this the endpoint panicked with "No rustls crypto provider is configured" and the guest hung.
- Capture `mvm-substitution-endpoint` stderr to `/tmp/mvm-substitution-endpoint-{vm_name}.log` instead of `/dev/null` so panics and handshake diagnostics are observable.
- Cap `resolve_hostname_ips_pure` on non-Linux hosts at 3 s using a dedicated resolver thread + `recv_timeout`.

Also add a live BDD feature (`features/suites/s2_egress_vsock/hvf_egress_observable.feature`) and new conformance steps for a timeout-wrapped `mvmctl` run and `/tmp` log assertions.

Validation:
- `MVM_BDD_LIVE=1 cargo test -p mvm-conformance --test conformance --features bdd` passes the two new scenarios.
- Full hermetic BDD suite passes (27 scenarios).
- `cargo fmt --check` and targeted `cargo clippy -p mvm-hostd -p mvm-runtime -p mvm-conformance --all-targets --features bdd -- -D warnings` are clean.