### PR TITLE
fix(fc/fork): kernel path, inherited agent verbs, and verity sidecars for fork boot (#1792)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -947,6 +947,7 @@ fn fork_vm_full_arm_fc(p: ForkVmFullArmFcParams<'_>) -> Result<()> {
         .iter()
         .find(|b| b.name == "rootfs.ext4")
         .map(|b| b.sha256.clone());
+    let parent_agent_verbs = parent_agent_verb_override(p.checkpoint, p.store);
     let tenant = super::tenant_resolution::resolve_tenant(None);
     let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::new();
     let admission = super::up::admit_plan_for_boot(super::up::AdmitPlanForBootParams {
@@ -970,13 +971,14 @@ fn fork_vm_full_arm_fc(p: ForkVmFullArmFcParams<'_>) -> Result<()> {
         shares: Vec::new(),
         redaction: mvm_core::policy::RedactionPolicy::default(),
         network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
-        agent_verb_override: vec![],
-        restrict_agent_verbs: super::agent_verbs::grant_eligible(
-            false,
-            false,
-            false,
-            super::agent_verbs::image_is_sealed(&rootfs_blob),
-        ),
+        agent_verb_override: parent_agent_verbs.clone(),
+        restrict_agent_verbs: !parent_agent_verbs.is_empty()
+            || super::agent_verbs::grant_eligible(
+                false,
+                false,
+                false,
+                super::agent_verbs::image_is_sealed(&rootfs_blob),
+            ),
     })?;
 
     let child_plan_json = admission.as_ref().map(|ctx| {
@@ -1132,6 +1134,7 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
     use mvm_runtime::backend::AnyBackend;
 
     let effective_hypervisor = super::super::shared::resolve_effective_hypervisor(p.hypervisor);
+    let parent_agent_verbs = parent_agent_verb_override(p.parent_checkpoint, p.store);
     let parent_meta = p.store.read_meta(p.parent_checkpoint)?;
 
     // Resource shape: flag > parent plan > global defaults.
@@ -1182,15 +1185,16 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
         shares: Vec::new(),
         redaction: mvm_core::policy::RedactionPolicy::default(),
         network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
-        agent_verb_override: vec![],
+        agent_verb_override: parent_agent_verbs.clone(),
         // A sealed baked-entrypoint child qualifies for an attenuated grant.
         // Forks never carry trailing argv and are always prod-profile.
-        restrict_agent_verbs: super::agent_verbs::grant_eligible(
-            false,
-            false,
-            false,
-            super::agent_verbs::image_is_sealed(p.instance_rootfs),
-        ),
+        restrict_agent_verbs: !parent_agent_verbs.is_empty()
+            || super::agent_verbs::grant_eligible(
+                false,
+                false,
+                false,
+                super::agent_verbs::image_is_sealed(p.instance_rootfs),
+            ),
     })?;
 
     let mut start_config = mvm_core::vm_backend::VmStartConfig {
@@ -1304,6 +1308,27 @@ fn grant_predecessor_from_vm_name(vm_name: &str) -> Option<(String, mvm_core::pl
 /// Read the parent checkpoint's source VM plan and return (cpus, mem_mib).
 /// Returns (None, None) when the plan is absent — the caller falls back to
 /// global defaults. The parent checkpoint's `vm_name` field names the source VM.
+/// Read the parent checkpoint's source VM plan and return the agent-verb
+/// override it was admitted with. Forks inherit the parent's explicit
+/// `--agent-verb` list so that a child of an unsealed image can still be
+/// grant-bearing when the parent was.
+fn parent_agent_verb_override(
+    parent_checkpoint: &CheckpointId,
+    store: &CheckpointStore,
+) -> Vec<String> {
+    let Ok(parent_meta) = store.read_meta(parent_checkpoint) else {
+        return Vec::new();
+    };
+    let Ok(plan) = super::plan_persist::read_plan(&parent_meta.vm_name) else {
+        return Vec::new();
+    };
+    plan.agent_verbs
+        .unwrap_or_default()
+        .into_iter()
+        .map(|v| v.as_str().to_string())
+        .collect()
+}
+
 fn parent_plan_resources(
     parent_checkpoint: &CheckpointId,
     store: &CheckpointStore,
@@ -1378,6 +1403,65 @@ mod tests {
         assert!(validated_checkpoint_id("").is_err());
         assert!(validated_checkpoint_id("a\0b").is_err());
         assert!(validated_checkpoint_id("a\nb").is_err());
+    }
+
+    #[test]
+    fn parent_agent_verb_override_inherits_parent_verbs() {
+        use mvm_core::checkpoint::{CheckpointClass, CheckpointId};
+        use mvm_core::plan::test_support::PlanFixture;
+        use mvm_protocol::plan::VerbId;
+
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        let mut plan = PlanFixture::new()
+            .tenant("local")
+            .plan_id("parent-plan")
+            .build();
+        plan.agent_verbs = Some(vec![
+            VerbId::new("ping").unwrap(),
+            VerbId::new("run-entrypoint").unwrap(),
+        ]);
+        mvm_hostd::audit::plan_persist::write_plan("parent-vm", &plan).unwrap();
+
+        let store = mvm_runtime::checkpoint::CheckpointStore::open();
+        let meta = mvm_core::checkpoint::CheckpointMeta::builder(
+            CheckpointId::new("ckpt-parent"),
+            CheckpointClass::FsQuick,
+            "parent-vm",
+        )
+        .content(vec![])
+        .supervisor_config_digest("d")
+        .created_unix(1)
+        .build();
+        store.write_meta(&meta).unwrap();
+
+        let verbs = parent_agent_verb_override(&meta.id, &store);
+        assert_eq!(verbs, vec!["ping", "run-entrypoint"]);
+    }
+
+    #[test]
+    fn parent_agent_verb_override_returns_empty_when_plan_missing() {
+        use mvm_core::checkpoint::{CheckpointClass, CheckpointId};
+
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        let store = mvm_runtime::checkpoint::CheckpointStore::open();
+        let meta = mvm_core::checkpoint::CheckpointMeta::builder(
+            CheckpointId::new("ckpt-no-plan"),
+            CheckpointClass::FsQuick,
+            "orphan-vm",
+        )
+        .content(vec![])
+        .supervisor_config_digest("d")
+        .created_unix(1)
+        .build();
+        store.write_meta(&meta).unwrap();
+
+        assert!(parent_agent_verb_override(&meta.id, &store).is_empty());
     }
 
     // ── FC vm_full fork gate ─────────────────────────────────────────────

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -1218,6 +1218,8 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
         parent_meta.runtime_overlay_version.as_deref(),
     )?;
 
+    populate_fork_rootfs_verity(&mut start_config, p.instance_rootfs)?;
+
     if let Some(ctx) = admission.as_ref() {
         mvm_hostd::plan_admission::populate_audit_substrate(
             &mut start_config,
@@ -1308,6 +1310,34 @@ fn grant_predecessor_from_vm_name(vm_name: &str) -> Option<(String, mvm_core::pl
 /// Read the parent checkpoint's source VM plan and return (cpus, mem_mib).
 /// Returns (None, None) when the plan is absent — the caller falls back to
 /// global defaults. The parent checkpoint's `vm_name` field names the source VM.
+/// If the child rootfs directory carries dm-verity sidecars, populate the
+/// start config so the backend attaches the hash tree and emits the roothash
+/// on the kernel cmdline. Without this the child skips `mvm-verity-init` and
+/// cannot mount the runtime overlay, leading to a guest panic.
+fn populate_fork_rootfs_verity(
+    start_config: &mut mvm_core::vm_backend::VmStartConfig,
+    rootfs: &std::path::Path,
+) -> anyhow::Result<()> {
+    let rootfs_dir = rootfs.parent().unwrap_or(std::path::Path::new("."));
+    let verity = rootfs_dir.join("rootfs.verity");
+    let roothash = rootfs_dir.join("rootfs.roothash");
+    if verity.exists() && roothash.exists() {
+        start_config.verity_path = Some(
+            verity
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("rootfs.verity path is not UTF-8"))?
+                .to_string(),
+        );
+        start_config.roothash = Some(
+            std::fs::read_to_string(&roothash)
+                .with_context(|| format!("reading {}", roothash.display()))?
+                .trim()
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 /// Read the parent checkpoint's source VM plan and return the agent-verb
 /// override it was admitted with. Forks inherit the parent's explicit
 /// `--agent-verb` list so that a child of an unsealed image can still be

--- a/crates/mvm-cli/src/commands/vm/up/kernel.rs
+++ b/crates/mvm-cli/src/commands/vm/up/kernel.rs
@@ -29,7 +29,7 @@ pub(in crate::commands::vm) fn resolve_workload_kernel(
         "x86_64"
     };
     let fallback = format!(
-        "{}/builder-vm/{arch}/vmlinux",
+        "{}/builder-vm/{arch}/kernels/workload/vmlinux",
         mvm_core::config::mvm_cache_dir()
     );
     if std::path::Path::new(&fallback).exists() {
@@ -38,7 +38,7 @@ pub(in crate::commands::vm) fn resolve_workload_kernel(
     anyhow::bail!(
         "image has no kernel ({vmlinux_path} missing) and the {hypervisor} backend \
          needs one; the builder-VM kernel fallback at {fallback} is also absent — \
-         run `mvmctl bootstrap` once to populate it"
+         run `mvmctl kernel build --which workload` once to populate it"
     )
 }
 
@@ -171,7 +171,13 @@ mod resolve_workload_kernel_tests {
         } else {
             "x86_64"
         };
-        let fallback_dir = tmp.path().join("cache").join("builder-vm").join(arch);
+        let fallback_dir = tmp
+            .path()
+            .join("cache")
+            .join("builder-vm")
+            .join(arch)
+            .join("kernels")
+            .join("workload");
         std::fs::create_dir_all(&fallback_dir).unwrap();
         let fallback = fallback_dir.join("vmlinux");
         std::fs::write(&fallback, b"builder-kernel").unwrap();
@@ -193,7 +199,13 @@ mod resolve_workload_kernel_tests {
         } else {
             "x86_64"
         };
-        let fallback_dir = tmp.path().join("cache").join("builder-vm").join(arch);
+        let fallback_dir = tmp
+            .path()
+            .join("cache")
+            .join("builder-vm")
+            .join(arch)
+            .join("kernels")
+            .join("workload");
         std::fs::create_dir_all(&fallback_dir).unwrap();
         let fallback = fallback_dir.join("vmlinux");
         std::fs::write(&fallback, b"builder-kernel").unwrap();
@@ -210,8 +222,8 @@ mod resolve_workload_kernel_tests {
         let err = resolve_workload_kernel("/nonexistent/vmlinux", "hvf").unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("mvmctl bootstrap"),
-            "expected 'mvmctl bootstrap' in: {msg}"
+            msg.contains("mvmctl kernel build --which workload"),
+            "expected 'mvmctl kernel build --which workload' in: {msg}"
         );
         assert!(msg.contains("hvf"), "expected hypervisor name in: {msg}");
     }

--- a/crates/mvm-runtime/src/base/cow.rs
+++ b/crates/mvm-runtime/src/base/cow.rs
@@ -93,16 +93,25 @@ pub fn prepare_instance_rootfs_inner(instance_path: &Path, source_rootfs: &str) 
     // The runtime-meta gate reads mvm-meta.json from the rootfs's own directory,
     // so any rootfs clone that may later be checkpointed or forked must carry the
     // sidecar alongside it.
-    copy_sidecar_if_present(source_path, instance_path);
+    copy_sidecars_if_present(source_path, instance_path);
 
     Ok(instance_path.to_path_buf())
 }
 
-/// Copy `mvm-meta.json` from the source rootfs's directory to the destination
-/// rootfs's directory when the sidecar exists. Silently does nothing when the
-/// source has no sidecar (older build dirs) or when source and destination dirs
-/// are the same.
-fn copy_sidecar_if_present(source_rootfs: &Path, dest_rootfs: &Path) {
+/// Guest sidecar files that may sit next to `rootfs.ext4` and must travel
+/// with it when it is cloned into a per-instance path.
+const ROOTFS_SIDECAR_FILES: &[&str] = &[
+    mvm_build::builder_vm::SIDECAR_FILENAME,
+    "rootfs.verity",
+    "rootfs.roothash",
+    "rootfs.initrd",
+];
+
+/// Copy guest sidecars from the source rootfs's directory to the destination
+/// rootfs's directory when they exist. Silently does nothing when the source
+/// has no sidecars (older build dirs / unsealed images) or when source and
+/// destination dirs are the same.
+fn copy_sidecars_if_present(source_rootfs: &Path, dest_rootfs: &Path) {
     let src_dir = match source_rootfs.parent() {
         Some(d) => d,
         None => return,
@@ -114,18 +123,20 @@ fn copy_sidecar_if_present(source_rootfs: &Path, dest_rootfs: &Path) {
     if src_dir == dst_dir {
         return;
     }
-    let src_sidecar = src_dir.join(mvm_build::builder_vm::SIDECAR_FILENAME);
-    if !src_sidecar.exists() {
-        return;
-    }
-    let dst_sidecar = dst_dir.join(mvm_build::builder_vm::SIDECAR_FILENAME);
-    if let Err(e) = std::fs::copy(&src_sidecar, &dst_sidecar) {
-        tracing::warn!(
-            src = %src_sidecar.display(),
-            dst = %dst_sidecar.display(),
-            error = %e,
-            "could not copy mvm-meta.json sidecar alongside rootfs clone",
-        );
+    for name in ROOTFS_SIDECAR_FILES {
+        let src_sidecar = src_dir.join(name);
+        if !src_sidecar.exists() {
+            continue;
+        }
+        let dst_sidecar = dst_dir.join(name);
+        if let Err(e) = std::fs::copy(&src_sidecar, &dst_sidecar) {
+            tracing::warn!(
+                src = %src_sidecar.display(),
+                dst = %dst_sidecar.display(),
+                error = %e,
+                "could not copy {name} sidecar alongside rootfs clone",
+            );
+        }
     }
 }
 
@@ -176,6 +187,24 @@ mod tests {
         );
         let content = std::fs::read_to_string(&dst_sidecar).unwrap();
         assert!(content.contains("accessible"));
+    }
+
+    #[test]
+    fn clone_copies_verity_sidecars_when_present() {
+        let src_dir = tempfile::tempdir().expect("src tempdir");
+        let dst_dir = tempfile::tempdir().expect("dst tempdir");
+        let src = src_dir.path().join("rootfs.ext4");
+        std::fs::write(&src, b"data").unwrap();
+        std::fs::write(src_dir.path().join("rootfs.verity"), b"verity-tree").unwrap();
+        std::fs::write(src_dir.path().join("rootfs.roothash"), b"abc123").unwrap();
+        std::fs::write(src_dir.path().join("rootfs.initrd"), b"initrd-bytes").unwrap();
+        let instance = dst_dir.path().join("rootfs.ext4");
+        prepare_instance_rootfs_inner(&instance, src.to_str().unwrap()).expect("clone");
+        assert!(dst_dir.path().join("rootfs.verity").exists());
+        assert!(dst_dir.path().join("rootfs.roothash").exists());
+        assert!(dst_dir.path().join("rootfs.initrd").exists());
+        let hash = std::fs::read_to_string(dst_dir.path().join("rootfs.roothash")).unwrap();
+        assert_eq!(hash, "abc123");
     }
 
     #[test]

--- a/crates/mvm-runtime/src/checkpoint/mod.rs
+++ b/crates/mvm-runtime/src/checkpoint/mod.rs
@@ -571,16 +571,14 @@ pub fn capture_vm_full(
         });
     }
 
-    // Mirror the fs_quick path: when the source rootfs directory carries a
-    // mvm-meta.json sidecar, include it so that forks of this vm_full checkpoint
-    // can read the sidecar from their content dir and boot through the
-    // runtime-meta gate (image_is_sealed / fork grant reconciliation).
+    // Mirror the fs_quick path: copy guest sidecars (mvm-meta.json,
+    // rootfs.verity, rootfs.roothash, rootfs.initrd) so that forks of this
+    // vm_full checkpoint can read them from their content dir and boot through
+    // the runtime-meta gate plus verity reconstruction.
     // The sidecar read is from the static source dir — outside the pause window
     // is fine.
     let live_rootfs_for_sidecar = control.rootfs_path()?;
-    if let Some(sidecar_blob) =
-        copy_guest_sidecar_if_present(&live_rootfs_for_sidecar, &content_dir)?
-    {
+    for sidecar_blob in copy_guest_sidecars_if_present(&live_rootfs_for_sidecar, &content_dir)? {
         content.push(sidecar_blob);
     }
 
@@ -663,34 +661,47 @@ fn sha256_file_hex(path: &Path) -> Result<String> {
         .with_context(|| format!("hashing {}", path.display()))
 }
 
-/// Copy the `mvm-meta.json` guest sidecar from the directory that contains
-/// `src_rootfs` into `content_dir`, and return a `ContentBlob` for it.
+/// Guest sidecar files that may sit next to `rootfs.ext4` and must be
+/// carried into a checkpoint so that forks can reconstruct a verity boot.
+const GUEST_SIDECAR_FILES: &[&str] = &[
+    mvm_build::builder_vm::SIDECAR_FILENAME,
+    "rootfs.verity",
+    "rootfs.roothash",
+    "rootfs.initrd",
+];
+
+/// Copy guest sidecars from the directory that contains `src_rootfs` into
+/// `content_dir`, returning a `ContentBlob` for each one that exists.
 ///
-/// Returns `None` (no-op) when the sidecar is absent — unsealed/dev images
-/// have no sidecar and must not error. Call from both `capture_fs_quick` and
-/// `capture_vm_full` so that the sidecar propagation stays DRY.
-fn copy_guest_sidecar_if_present(
+/// Unsealed/dev images may have none of these; the function is a no-op for
+/// absent files. Call from both `capture_fs_quick` and `capture_vm_full` so
+/// that sidecar propagation stays DRY.
+fn copy_guest_sidecars_if_present(
     src_rootfs: &Path,
     content_dir: &Path,
-) -> Result<Option<ContentBlob>> {
+) -> Result<Vec<ContentBlob>> {
     let src_dir = src_rootfs
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."));
-    let src_sidecar = src_dir.join(mvm_build::builder_vm::SIDECAR_FILENAME);
-    if !src_sidecar.exists() {
-        return Ok(None);
+    let mut blobs = Vec::new();
+    for name in GUEST_SIDECAR_FILES {
+        let src_sidecar = src_dir.join(name);
+        if !src_sidecar.exists() {
+            continue;
+        }
+        let dst_sidecar = content_dir.join(name);
+        std::fs::copy(&src_sidecar, &dst_sidecar).with_context(|| {
+            format!(
+                "copying {name} sidecar into checkpoint content dir {}",
+                content_dir.display()
+            )
+        })?;
+        blobs.push(ContentBlob {
+            name: (*name).into(),
+            sha256: sha256_file_hex(&dst_sidecar)?,
+        });
     }
-    let dst_sidecar = content_dir.join(mvm_build::builder_vm::SIDECAR_FILENAME);
-    std::fs::copy(&src_sidecar, &dst_sidecar).with_context(|| {
-        format!(
-            "copying mvm-meta.json sidecar into checkpoint content dir {}",
-            content_dir.display()
-        )
-    })?;
-    Ok(Some(ContentBlob {
-        name: mvm_build::builder_vm::SIDECAR_FILENAME.into(),
-        sha256: sha256_file_hex(&dst_sidecar)?,
-    }))
+    Ok(blobs)
 }
 
 /// How blob `name` differs between two checkpoints (B relative to A).
@@ -838,10 +849,11 @@ pub fn capture_fs_quick(
         sha256: content_sha256,
     }];
 
-    // When the source rootfs directory carries a mvm-meta.json sidecar, include it
-    // as a second blob so that any fork materialised from this checkpoint can boot
-    // through the runtime-meta gate (which reads the sidecar from the rootfs dir).
-    if let Some(sidecar_blob) = copy_guest_sidecar_if_present(&params.rootfs, &content_dir)? {
+    // When the source rootfs directory carries guest sidecars (mvm-meta.json,
+    // rootfs.verity, rootfs.roothash, rootfs.initrd), include them so that any
+    // fork materialised from this checkpoint can boot through the runtime-meta
+    // gate and reconstruct a verity rootfs.
+    for sidecar_blob in copy_guest_sidecars_if_present(&params.rootfs, &content_dir)? {
         content.push(sidecar_blob);
     }
 
@@ -1145,6 +1157,42 @@ mod tests {
             .find(|b| b.name == mvm_build::builder_vm::SIDECAR_FILENAME)
             .unwrap();
         assert!(!sidecar_blob.sha256.is_empty());
+    }
+
+    #[test]
+    fn capture_includes_verity_sidecars_when_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let rootfs = write_fake_rootfs(tmp.path());
+        std::fs::write(tmp.path().join("rootfs.verity"), b"verity-tree").unwrap();
+        std::fs::write(tmp.path().join("rootfs.roothash"), b"abc123").unwrap();
+        std::fs::write(tmp.path().join("rootfs.initrd"), b"initrd-bytes").unwrap();
+        let meta = capture_fs_quick(
+            &store,
+            CaptureFsQuickParams {
+                id: CheckpointId::new("c-verity"),
+                vm_name: "parentvm".into(),
+                rootfs,
+                supervisor_config_digest: "d".into(),
+                runtime_source_policy: None,
+                runtime_overlay_version: None,
+                tag: None,
+                created_unix: 1,
+                quiesced: true,
+            },
+        )
+        .unwrap();
+        let names: Vec<&str> = meta.content.iter().map(|b| b.name.as_str()).collect();
+        assert!(names.contains(&"rootfs.ext4"));
+        assert!(names.contains(&"rootfs.verity"));
+        assert!(names.contains(&"rootfs.roothash"));
+        assert!(names.contains(&"rootfs.initrd"));
+        let roothash_blob = meta
+            .content
+            .iter()
+            .find(|b| b.name == "rootfs.roothash")
+            .unwrap();
+        assert!(!roothash_blob.sha256.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Partial fix for #1792 — addresses root causes #1, #2, and #3 of the Firecracker fork/restore verb-grant live-validation failure.

- **#1 — kernel path:** `resolve_workload_kernel` now falls back to the cached workload kernel at `builder-vm/<arch>/kernels/workload/vmlinux`, matching `machine run`. The previous builder-VM kernel path lacks dm-verity support.
- **#2 — inherited agent verbs:** forked children now read the parent VM plan and propagate its `agent_verbs` into child admission, so an unsealed clone can still mint a verb grant when the parent was started with `--agent-verb`.
- **#3 — verity sidecars:** `fs_quick` and `vm_full` checkpoint capture copy `rootfs.verity`, `rootfs.roothash`, and `rootfs.initrd` alongside the rootfs; `prepare_instance_rootfs_inner` copies them too. `boot_forked_child` populates `verity_path` and `roothash` in the child start config so `mvm-verity-init` runs and the runtime overlay is mounted.

Remaining out of scope in this PR:
- **#4 — vm_full FC device-path remapping** (parent TAP/MAC/drive paths baked into `vmstate.bin`).
- **#5 — pause/resume lifecycle** (`machine pause` seals a snapshot and FC exits, so `machine resume` cannot find the API socket).

Validation:
- `cargo test -p mvm-cli --lib commands::vm::up::kernel::resolve_workload_kernel_tests`
- `cargo test -p mvm-cli --lib commands::vm::checkpoint::tests::parent_agent_verb_override`
- `cargo test -p mvm-runtime --lib checkpoint`
- `cargo test -p mvm-runtime --lib base::cow`
- `cargo fmt --check` and targeted `cargo clippy -p mvm-runtime -p mvm-cli --lib --bins -- -D warnings` are clean.