### PR TITLE
test(egress): cover literal fallback edge cases

### DIFF
--- a/crates/mvm-protocol/src/policy/dns_pin.rs
+++ b/crates/mvm-protocol/src/policy/dns_pin.rs
@@ -332,6 +332,21 @@ mod tests {
     }
 
     #[test]
+    fn registry_pin_containing_picks_lowest_dest_on_a_shared_ip() {
+        // Shared anycast addresses must resolve deterministically to the
+        // lexicographically lowest destination.
+        let mut reg = DnsPinRegistry::new();
+        reg.add(fixed_pin("zebra.example", &["203.0.113.7"]));
+        reg.add(fixed_pin("alpha.example", &["203.0.113.7"]));
+
+        assert_eq!(
+            reg.pin_containing(&ip("203.0.113.7"))
+                .map(|pin| pin.dest.as_str()),
+            Some("alpha.example")
+        );
+    }
+
+    #[test]
     fn pin_ttl_secs_returns_zero_on_malformed_timestamps() {
         let pin = DnsPin::at(
             "example.com",

--- a/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
+++ b/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
@@ -554,6 +554,68 @@ mod tests {
     }
 
     #[test]
+    fn literal_ipv4_target_offers_pinned_ipv6_sibling() {
+        use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
+        use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+
+        let v6: IpAddr = "2606:4700:10::6814:179a".parse().unwrap();
+        let v4: IpAddr = "104.20.23.154".parse().unwrap();
+        let mut pins = DnsPinRegistry::new();
+        pins.add(DnsPin::at(
+            "example.com",
+            vec![v6, v4],
+            "2025-01-01T00:00:00Z",
+            "2030-01-01T00:00:00Z",
+        ));
+        let policy = NetworkPolicy::allow_list(vec![HostPort::new("example.com", 443)]);
+        let gate = EgressGate::from_network_policy(&policy, &pins, "2026-01-01T00:00:00Z");
+
+        assert_eq!(
+            gate.decide_request("104.20.23.154:443"),
+            EgressVerdict::Allow {
+                ips: vec![v4, v6],
+                port: 443,
+            }
+        );
+    }
+
+    #[test]
+    fn literal_shared_ip_uses_lowest_dest_pin_for_fallback() {
+        use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
+        use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+
+        let shared_v6: IpAddr = "2606:4700:10::6814:179a".parse().unwrap();
+        let alpha_v4: IpAddr = "104.20.0.1".parse().unwrap();
+        let zebra_v4: IpAddr = "104.20.0.2".parse().unwrap();
+        let mut pins = DnsPinRegistry::new();
+        pins.add(DnsPin::at(
+            "zebra.example",
+            vec![shared_v6, zebra_v4],
+            "2025-01-01T00:00:00Z",
+            "2030-01-01T00:00:00Z",
+        ));
+        pins.add(DnsPin::at(
+            "alpha.example",
+            vec![shared_v6, alpha_v4],
+            "2025-01-01T00:00:00Z",
+            "2030-01-01T00:00:00Z",
+        ));
+        let policy = NetworkPolicy::allow_list(vec![
+            HostPort::new("alpha.example", 443),
+            HostPort::new("zebra.example", 443),
+        ]);
+        let gate = EgressGate::from_network_policy(&policy, &pins, "2026-01-01T00:00:00Z");
+
+        assert_eq!(
+            gate.decide_request("[2606:4700:10::6814:179a]:443"),
+            EgressVerdict::Allow {
+                ips: vec![alpha_v4, shared_v6],
+                port: 443,
+            }
+        );
+    }
+
+    #[test]
     fn dns_verdict_uses_pin_without_upstream_lookup() {
         use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
         use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};

--- a/features/suites/s2_egress_vsock/admitted_egress_live.feature
+++ b/features/suites/s2_egress_vsock/admitted_egress_live.feature
@@ -12,6 +12,12 @@ Feature: Admitted egress completes end-to-end over the vsock seam
     And the output contains "Example Domain"
 
   @live
+  Scenario: An admitted IPv6 literal falls back to its pinned IPv4 sibling
+    When I run mvmctl with "machine run --image alpine --allow-host one.one.one.one -- wget -q --no-check-certificate --header=Host:one.one.one.one -O - https://[2606:4700:4700::1111]/cdn-cgi/trace" with a 120 second timeout
+    Then the command exits with code 0
+    And the output contains "fl="
+
+  @live
   Scenario: A non-admitted name is refused, not resolved
     When I run mvmctl with "machine run --image alpine --allow-host example.com -- wget -q -O - https://not-admitted.test"
     Then the command exits with code 1


### PR DESCRIPTION
Ports regression coverage from superseded #1790 onto current main using DnsPinRegistry::pin_containing. Adds deterministic shared-anycast selection, IPv4-literal to pinned-IPv6 fallback, and gate-level shared-IP coverage. Existing tests cover unpinned literals and wrong-port denial. Verified with cargo fmt --all -- --check, focused mvm-protocol/mvm-runtime tests, and clippy -p mvm-protocol -p mvm-runtime --all-targets -- -D warnings.