### PR TITLE
fix(mvm-fs): OCI multi-layer unpack replaces prior-layer paths (#1674)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2760,8 +2760,10 @@ dependencies = [
  "assert_cmd",
  "cucumber",
  "mvm-core",
+ "mvm-fs",
  "mvm-runtime",
  "serde_json",
+ "tar",
  "tempfile",
  "tokio",
 ]

--- a/crates/mvm-cli/src/commands/image/ingest.rs
+++ b/crates/mvm-cli/src/commands/image/ingest.rs
@@ -97,9 +97,16 @@ pub(super) fn ingest_archive_from_reader<R: Read>(
     }
     fs::create_dir_all(&unpacked_root)
         .with_context(|| format!("create {}", unpacked_root.display()))?;
+    let mut prior_layer_paths = std::collections::HashSet::new();
     for layer in &image.layers {
-        unpack_layer_bytes(&layer.descriptor, &layer.bytes, &unpacked_root)
-            .with_context(|| format!("unpack layer {}", layer.descriptor.digest))?;
+        let report = unpack_layer_bytes(
+            &layer.descriptor,
+            &layer.bytes,
+            &unpacked_root,
+            &prior_layer_paths,
+        )
+        .with_context(|| format!("unpack layer {}", layer.descriptor.digest))?;
+        prior_layer_paths.extend(report.paths_written);
     }
 
     let rootfs_rel = format!("rootfs/{manifest_hex}-{}/rootfs.ext4", oci_runtime_tag());

--- a/crates/mvm-cli/src/commands/image/pull_core.rs
+++ b/crates/mvm-cli/src/commands/image/pull_core.rs
@@ -3,9 +3,10 @@
 //! registry pull. This is the run-path entry every OCI source funnels
 //! through once it's been classified as a registry reference.
 
+use std::collections::HashSet;
 use std::fs;
 use std::io::Cursor;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use flate2::read::GzDecoder;
@@ -13,7 +14,7 @@ use serde_json::Value;
 
 use mvm_fs::oci::{
     ImageReference, LayerDescriptor, LayerFetchOptions, LinuxPlatform, OciLayerFetcher,
-    OciManifestFetcher, UnpackOptions, unpack_layer,
+    OciManifestFetcher, UnpackOptions, UnpackReport, unpack_layer_with_prior_paths,
 };
 
 use super::cache::{find_image, layer_blob_path, load_index, read_verified_cache_file, save_index};
@@ -263,12 +264,14 @@ fn pull_image_ref(
         .with_context(|| format!("create {}", unpacked_root.display()))?;
 
     let mut cached_layers = Vec::with_capacity(layers.len());
+    let mut prior_layer_paths = std::collections::HashSet::new();
     for layer in &layers {
         let compressed =
             fetch_or_read_layer(cache_root, &runtime, &layer_fetcher, &image_ref, layer)
                 .with_context(|| format!("fetch layer {}", layer.digest))?;
-        unpack_layer_bytes(layer, &compressed, &unpacked_root)
+        let report = unpack_layer_bytes(layer, &compressed, &unpacked_root, &prior_layer_paths)
             .with_context(|| format!("unpack layer {}", layer.digest))?;
+        prior_layer_paths.extend(report.paths_written);
         cached_layers.push(CachedOciLayer {
             digest: layer.digest.clone(),
             size_bytes: layer.size,
@@ -402,20 +405,27 @@ pub(super) fn unpack_layer_bytes(
     layer: &LayerDescriptor,
     bytes: &[u8],
     unpacked_root: &Path,
-) -> Result<()> {
+    prior_layer_paths: &HashSet<PathBuf>,
+) -> Result<UnpackReport> {
     let report = if is_gzip_layer(&layer.media_type) {
-        unpack_layer(
+        unpack_layer_with_prior_paths(
             GzDecoder::new(Cursor::new(bytes)),
             unpacked_root,
             &UnpackOptions::default(),
+            prior_layer_paths,
         )
     } else {
-        unpack_layer(Cursor::new(bytes), unpacked_root, &UnpackOptions::default())
+        unpack_layer_with_prior_paths(
+            Cursor::new(bytes),
+            unpacked_root,
+            &UnpackOptions::default(),
+            prior_layer_paths,
+        )
     }?;
     if !report.refused.is_empty() {
         bail!("layer unpack refused entries: {:?}", report.refused);
     }
-    Ok(())
+    Ok(report)
 }
 
 fn is_gzip_layer(media_type: &str) -> bool {

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -14,6 +14,7 @@
 //! it to `mvm_hostd::run::admit_and_boot_local`. A workload never boots on a
 //! path that skipped admission.
 
+use std::collections::HashSet;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
@@ -22,7 +23,7 @@ use flate2::read::GzDecoder;
 use mvm_core::protocol::vm_backend::{BackendKind, VmId, VmInfo, VmStatus};
 use mvm_fs::oci::{
     ImageReference, LayerDescriptor, LayerFetchOptions, LinuxPlatform, OciLayerFetcher,
-    OciManifestFetcher, UnpackOptions, unpack_layer,
+    OciManifestFetcher, UnpackOptions, UnpackReport, unpack_layer_with_prior_paths,
 };
 use mvm_hostd::plan_admission::{InMemoryNonceLedger, SystemClock};
 use mvm_hostd::run::{LocalRunContext, LocalRunRequest, admit_and_boot_local};
@@ -448,28 +449,41 @@ async fn pull_image_to_dir(reference: &str, dest: &Path) -> Result<()> {
     }
     let layer_fetcher =
         OciLayerFetcher::from_manifest_fetcher(&manifest_fetcher, LayerFetchOptions::default());
+    let mut prior_layer_paths = std::collections::HashSet::new();
     for layer in &layers {
         let mut bytes = Vec::new();
         layer_fetcher
             .fetch_layer(&image_ref, layer, &mut bytes)
             .await
             .map_err(|e| backend_err(format!("fetch layer {}: {e}", layer.digest)))?;
-        unpack_one_layer(layer, &bytes, dest)?;
+        let report = unpack_one_layer(layer, &bytes, dest, &prior_layer_paths)?;
+        prior_layer_paths.extend(report.paths_written);
     }
     Ok(())
 }
 
 /// Unpack one layer's bytes into `dest`, decompressing gzip layers first.
-fn unpack_one_layer(layer: &LayerDescriptor, bytes: &[u8], dest: &Path) -> Result<()> {
+fn unpack_one_layer(
+    layer: &LayerDescriptor,
+    bytes: &[u8],
+    dest: &Path,
+    prior_layer_paths: &HashSet<PathBuf>,
+) -> Result<UnpackReport> {
     let mt = &layer.media_type;
     let report = if mt.ends_with("+gzip") || mt.ends_with(".gzip") || mt.contains("tar.gzip") {
-        unpack_layer(
+        unpack_layer_with_prior_paths(
             GzDecoder::new(Cursor::new(bytes)),
             dest,
             &UnpackOptions::default(),
+            prior_layer_paths,
         )
     } else {
-        unpack_layer(Cursor::new(bytes), dest, &UnpackOptions::default())
+        unpack_layer_with_prior_paths(
+            Cursor::new(bytes),
+            dest,
+            &UnpackOptions::default(),
+            prior_layer_paths,
+        )
     }
     .map_err(|e| backend_err(format!("unpack layer {}: {e}", layer.digest)))?;
     if !report.refused.is_empty() {
@@ -478,7 +492,7 @@ fn unpack_one_layer(layer: &LayerDescriptor, bytes: &[u8], dest: &Path) -> Resul
             layer.digest, report.refused
         )));
     }
-    Ok(())
+    Ok(report)
 }
 
 /// Probe the dm-verity sidecars the pure materializer writes beside the image

--- a/crates/mvm-conformance/Cargo.toml
+++ b/crates/mvm-conformance/Cargo.toml
@@ -42,6 +42,8 @@ serde_json.workspace = true
 # out of production builds.
 mvm-runtime = { workspace = true, features = ["test-support"] }
 mvm-core = { workspace = true, features = ["test-support"] }
+mvm-fs = { workspace = true }
+tar.workspace = true
 tempfile.workspace = true
 
 [lints]

--- a/crates/mvm-conformance/tests/steps/mod.rs
+++ b/crates/mvm-conformance/tests/steps/mod.rs
@@ -2,6 +2,7 @@
 
 mod cli;
 mod kernel_pin;
+mod oci_unpack;
 mod readme_contract;
 mod verified_boot;
 mod workload_identity;

--- a/crates/mvm-conformance/tests/steps/oci_unpack.rs
+++ b/crates/mvm-conformance/tests/steps/oci_unpack.rs
@@ -1,0 +1,176 @@
+//! Step definitions for OCI image layer materialization scenarios.
+//!
+//! These steps exercise `mvm_fs::oci::unpack_layer_with_prior_paths` directly
+//! so multi-layer semantics stay covered without requiring a live registry or
+//! a full microVM boot for every scenario.
+
+use std::io::Cursor;
+
+use cucumber::{given, then, when};
+
+use crate::world::CliWorld;
+
+/// Build an in-memory tar archive from a Gherkin data table.
+///
+/// Columns: `path`, `kind`, `content`. Supported kinds:
+/// - `file` — a regular file whose contents come from the `content` cell.
+/// - `directory` — a directory entry; `content` is ignored.
+/// - `whiteout` — a whiteout marker file; the path itself (e.g. `.wh.foo.txt`)
+///   triggers the unpacker's whiteout logic.
+fn build_layer_tar(table: &cucumber::gherkin::Table) -> Vec<u8> {
+    let mut buf = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut buf);
+        let rows = &table.rows;
+        assert!(
+            rows.len() > 1,
+            "layer table must have a header and at least one data row"
+        );
+        let header = &rows[0];
+        let col = |name: &str| {
+            header
+                .iter()
+                .position(|h| h.eq_ignore_ascii_case(name))
+                .unwrap_or_else(|| panic!("layer table missing {name:?} column"))
+        };
+        let path_idx = col("path");
+        let kind_idx = col("kind");
+
+        for row in rows.iter().skip(1) {
+            let path = &row[path_idx];
+            let kind = row[kind_idx].to_ascii_lowercase();
+            let content = row.get(col("content")).map(String::as_str).unwrap_or("");
+
+            match kind.as_str() {
+                "file" | "whiteout" => {
+                    let data = if kind == "whiteout" {
+                        &[][..]
+                    } else {
+                        content.as_bytes()
+                    };
+                    let mut header = tar::Header::new_gnu();
+                    header.set_size(data.len() as u64);
+                    header.set_mode(0o644);
+                    header.set_entry_type(tar::EntryType::Regular);
+                    builder
+                        .append_data(&mut header, path, data)
+                        .expect("append tar entry");
+                }
+                "directory" => {
+                    let mut header = tar::Header::new_gnu();
+                    header.set_size(0);
+                    header.set_mode(0o755);
+                    header.set_entry_type(tar::EntryType::Directory);
+                    builder
+                        .append_data(&mut header, path, std::io::empty())
+                        .expect("append tar directory");
+                }
+                other => panic!("unknown layer entry kind {other:?}"),
+            }
+        }
+        builder.finish().expect("finish tar archive");
+    }
+    buf
+}
+
+#[given(expr = "an empty OCI unpack root")]
+fn empty_unpack_root(world: &mut CliWorld) {
+    world.unpack_root = Some(tempfile::tempdir().expect("create unpack root"));
+    world.prior_layer_paths.clear();
+    world.last_unpack_report = None;
+}
+
+#[when(expr = "I unpack a layer containing:")]
+fn unpack_layer(world: &mut CliWorld, step: &cucumber::gherkin::Step) {
+    let root = world
+        .unpack_root
+        .as_ref()
+        .expect("unpack root must be created first")
+        .path();
+    let table = step
+        .table()
+        .expect("layer entries must be given as a data table");
+    let tar_bytes = build_layer_tar(table);
+
+    let report = mvm_fs::oci::unpack_layer_with_prior_paths(
+        Cursor::new(tar_bytes),
+        root,
+        &mvm_fs::oci::UnpackOptions::default(),
+        &world.prior_layer_paths,
+    )
+    .expect("layer unpack should succeed");
+
+    world.prior_layer_paths.extend(report.paths_written.clone());
+    world.last_unpack_report = Some(report);
+}
+
+#[then(expr = "the path {string} exists as a file")]
+fn path_exists_as_file(world: &mut CliWorld, rel: String) {
+    let root = world
+        .unpack_root
+        .as_ref()
+        .expect("unpack root must be created first")
+        .path();
+    let path = root.join(&rel);
+    assert!(
+        path.is_file(),
+        "expected {rel:?} to be a file under {root:?}"
+    );
+}
+
+#[then(expr = "the path {string} exists as a directory")]
+fn path_exists_as_directory(world: &mut CliWorld, rel: String) {
+    let root = world
+        .unpack_root
+        .as_ref()
+        .expect("unpack root must be created first")
+        .path();
+    let path = root.join(&rel);
+    assert!(
+        path.is_dir(),
+        "expected {rel:?} to be a directory under {root:?}"
+    );
+}
+
+#[then(expr = "the path {string} does not exist")]
+fn path_does_not_exist(world: &mut CliWorld, rel: String) {
+    let root = world
+        .unpack_root
+        .as_ref()
+        .expect("unpack root must be created first")
+        .path();
+    let path = root.join(&rel);
+    assert!(
+        !path.exists(),
+        "expected {rel:?} to not exist under {root:?}"
+    );
+}
+
+#[then(expr = "the path {string} contains {string}")]
+fn path_contains(world: &mut CliWorld, rel: String, expected: String) {
+    let root = world
+        .unpack_root
+        .as_ref()
+        .expect("unpack root must be created first")
+        .path();
+    let path = root.join(&rel);
+    let contents = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {rel:?}: {e}"));
+    assert!(
+        contents == expected,
+        "expected {rel:?} to contain {expected:?}, got {contents:?}"
+    );
+}
+
+#[then(expr = "the unpack report has {int} refused entries")]
+fn unpack_report_refused_count(world: &mut CliWorld, count: i64) {
+    let report = world
+        .last_unpack_report
+        .as_ref()
+        .expect("an unpack step must have run first");
+    assert_eq!(
+        report.refused.len(),
+        count as usize,
+        "unexpected refused entry count: {:?}",
+        report.refused
+    );
+}

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -1,7 +1,8 @@
 //! Shared state cucumber threads through the steps of one scenario.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
+use std::path::PathBuf;
 use std::process::Output;
 
 use mvm_core::kernel_advisory::{KernelAdvisory, KernelPin};
@@ -35,6 +36,12 @@ pub struct CliWorld {
     pub kernel_upstream: BTreeMap<String, String>,
     /// The verdict from the most recent freshness assessment.
     pub kernel_advisory: Option<KernelAdvisory>,
+    /// Root directory for the OCI unpack scenarios.
+    pub unpack_root: Option<tempfile::TempDir>,
+    /// Paths written by prior layers when unpacking multiple layers.
+    pub prior_layer_paths: HashSet<PathBuf>,
+    /// The most recent OCI unpack report.
+    pub last_unpack_report: Option<mvm_fs::oci::UnpackReport>,
 }
 
 impl fmt::Debug for CliWorld {

--- a/crates/mvm-fs/src/oci/mod.rs
+++ b/crates/mvm-fs/src/oci/mod.rs
@@ -68,4 +68,5 @@ pub use reference::ImageReference;
 pub use registry::{ClientConfig, ClientProtocol, RegistryAuthConfig};
 pub use unpack::{
     RefusalReason, RefusedEntry, UnpackError, UnpackOptions, UnpackReport, unpack_layer,
+    unpack_layer_with_prior_paths,
 };

--- a/crates/mvm-fs/src/oci/unpack/device_nodes.rs
+++ b/crates/mvm-fs/src/oci/unpack/device_nodes.rs
@@ -3,8 +3,9 @@
 //! major/minor pair against it, and the Linux (`mknodat`) /
 //! non-Linux (skip) materialization paths.
 
+use std::collections::HashSet;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::RefusalReason;
 
@@ -45,6 +46,7 @@ impl<'a> super::fs_ops::Rooted<'a> {
         entry: &tar::Entry<R>,
         rel: &Path,
         raw_path: &[u8],
+        prior_layer_paths: &HashSet<PathBuf>,
     ) -> Result<DeviceNodeAction, RefusalReason> {
         use rustix::fs::{FileType, Mode, makedev, mknodat};
         use std::os::fd::AsFd;
@@ -62,6 +64,9 @@ impl<'a> super::fs_ops::Rooted<'a> {
         let (parent, leaf) = self
             .open_parent(rel, true)
             .map_err(super::fs_ops::map_resolve_errno)?;
+        if prior_layer_paths.contains(rel) {
+            super::fs_ops::remove_prior_layer_path(self, rel)?;
+        }
         mknodat(
             parent.as_fd(),
             &leaf,
@@ -81,7 +86,11 @@ impl<'a> super::fs_ops::Rooted<'a> {
         entry: &tar::Entry<R>,
         rel: &Path,
         raw_path: &[u8],
+        prior_layer_paths: &HashSet<PathBuf>,
     ) -> Result<DeviceNodeAction, RefusalReason> {
+        if prior_layer_paths.contains(rel) {
+            super::fs_ops::remove_prior_layer_path(self.root, rel)?;
+        }
         materialize_device_node(entry, &self.root.join(rel), raw_path)
     }
 }

--- a/crates/mvm-fs/src/oci/unpack/entries.rs
+++ b/crates/mvm-fs/src/oci/unpack/entries.rs
@@ -26,6 +26,7 @@ pub(super) struct EntryCtx<'a> {
     pub(super) rel_path: &'a Path,
     pub(super) raw_path: &'a [u8],
     pub(super) target: &'a Path,
+    pub(super) prior_layer_paths: &'a HashSet<PathBuf>,
 }
 
 /// Materialize a `Regular`/`Continuous` tar entry: either write the
@@ -41,14 +42,19 @@ pub(super) fn unpack_regular_entry<R: Read>(
 ) {
     match classify_whiteout(ctx.raw_path) {
         WhiteoutKind::None => {
-            match ctx
-                .rooted
-                .write_regular_file(ctx.rel_path, entry, ctx.raw_path, options, report)
-            {
+            match ctx.rooted.write_regular_file(
+                ctx.rel_path,
+                entry,
+                ctx.raw_path,
+                options,
+                ctx.prior_layer_paths,
+                report,
+            ) {
                 Ok(()) => {
                     report.files_written += 1;
                     apply_collected_xattrs(ctx.target, ctx.raw_path, entry_xattrs, report);
                     current_layer_paths.insert(ctx.rel_path.to_path_buf());
+                    report.paths_written.insert(ctx.rel_path.to_path_buf());
                 }
                 Err(refuse) => report.refused.push(RefusedEntry {
                     raw_path: ctx.raw_path.to_vec(),
@@ -101,13 +107,17 @@ pub(super) fn unpack_directory_entry(
     current_layer_paths: &mut HashSet<PathBuf>,
     report: &mut UnpackReport,
 ) {
-    match ctx.rooted.create_directory(ctx.rel_path) {
+    match ctx
+        .rooted
+        .create_directory(ctx.rel_path, ctx.prior_layer_paths)
+    {
         Ok(created) => {
             if created {
                 report.dirs_created += 1;
             }
             apply_collected_xattrs(ctx.target, ctx.raw_path, entry_xattrs, report);
             current_layer_paths.insert(ctx.rel_path.to_path_buf());
+            report.paths_written.insert(ctx.rel_path.to_path_buf());
         }
         Err(refuse) => report.refused.push(RefusedEntry {
             raw_path: ctx.raw_path.to_vec(),
@@ -127,12 +137,13 @@ pub(super) fn unpack_symlink_entry<R: Read>(
     let link_target = entry.link_name_bytes().map(|b| b.into_owned());
     match ctx
         .rooted
-        .write_symlink(ctx.rel_path, link_target.as_deref())
+        .write_symlink(ctx.rel_path, link_target.as_deref(), ctx.prior_layer_paths)
     {
         Ok(()) => {
             report.symlinks_written += 1;
             apply_collected_xattrs(ctx.target, ctx.raw_path, entry_xattrs, report);
             current_layer_paths.insert(ctx.rel_path.to_path_buf());
+            report.paths_written.insert(ctx.rel_path.to_path_buf());
         }
         Err(refuse) => report.refused.push(RefusedEntry {
             raw_path: ctx.raw_path.to_vec(),
@@ -156,16 +167,19 @@ pub(super) fn unpack_hardlink_entry<R: Read>(
         ctx.rel_path,
         options,
         current_layer_paths,
+        ctx.prior_layer_paths,
     ) {
         Ok(HardlinkAction::Linked) => {
             report.hardlinks_written += 1;
             apply_collected_xattrs(ctx.target, ctx.raw_path, entry_xattrs, report);
             current_layer_paths.insert(ctx.rel_path.to_path_buf());
+            report.paths_written.insert(ctx.rel_path.to_path_buf());
         }
         Ok(HardlinkAction::Copied) => {
             report.hardlink_copies_written += 1;
             apply_collected_xattrs(ctx.target, ctx.raw_path, entry_xattrs, report);
             current_layer_paths.insert(ctx.rel_path.to_path_buf());
+            report.paths_written.insert(ctx.rel_path.to_path_buf());
         }
         Err(refuse) => report.refused.push(RefusedEntry {
             raw_path: ctx.raw_path.to_vec(),
@@ -185,14 +199,17 @@ pub(super) fn unpack_device_entry<R: Read>(
     current_layer_paths: &mut HashSet<PathBuf>,
     report: &mut UnpackReport,
 ) {
-    match ctx
-        .rooted
-        .materialize_device_node(entry, ctx.rel_path, ctx.raw_path)
-    {
+    match ctx.rooted.materialize_device_node(
+        entry,
+        ctx.rel_path,
+        ctx.raw_path,
+        ctx.prior_layer_paths,
+    ) {
         Ok(DeviceNodeAction::Materialized) => {
             report.device_nodes_written += 1;
             apply_collected_xattrs(ctx.target, ctx.raw_path, entry_xattrs, report);
             current_layer_paths.insert(ctx.rel_path.to_path_buf());
+            report.paths_written.insert(ctx.rel_path.to_path_buf());
         }
         Err(refuse) => report.refused.push(RefusedEntry {
             raw_path: ctx.raw_path.to_vec(),
@@ -214,10 +231,12 @@ pub(super) fn unpack_device_entry<R: Read>(
     _current_layer_paths: &mut HashSet<PathBuf>,
     report: &mut UnpackReport,
 ) {
-    match ctx
-        .rooted
-        .materialize_device_node(entry, ctx.rel_path, ctx.raw_path)
-    {
+    match ctx.rooted.materialize_device_node(
+        entry,
+        ctx.rel_path,
+        ctx.raw_path,
+        ctx.prior_layer_paths,
+    ) {
         Ok(DeviceNodeAction::Skipped) => {
             report.device_nodes_skipped += 1;
         }

--- a/crates/mvm-fs/src/oci/unpack/fs_ops.rs
+++ b/crates/mvm-fs/src/oci/unpack/fs_ops.rs
@@ -105,12 +105,27 @@ impl<'a> Rooted<'a> {
         Ok((parent, leaf))
     }
 
-    pub(super) fn create_directory(&self, rel: &Path) -> Result<bool, RefusalReason> {
-        use rustix::fs::{Mode, mkdirat};
+    pub(super) fn create_directory(
+        &self,
+        rel: &Path,
+        prior_layer_paths: &HashSet<PathBuf>,
+    ) -> Result<bool, RefusalReason> {
+        use rustix::fs::{AtFlags, Mode, mkdirat, unlinkat};
         use rustix::io::Errno;
         use std::os::fd::AsFd;
 
         let (parent, leaf) = self.open_parent(rel, true).map_err(map_resolve_errno)?;
+        if prior_layer_paths.contains(rel) {
+            // A prior-layer file or symlink occupying this directory
+            // path must be removed before we can create the directory.
+            // If the prior entry is itself a directory, `mkdirat` will
+            // return EEXIST and we coalesce below.
+            if let Err(e) = unlinkat(parent.as_fd(), &leaf, AtFlags::empty()) {
+                if e != Errno::NOENT && e != Errno::ISDIR {
+                    return Err(RefusalReason::MalformedHeader);
+                }
+            }
+        }
         match mkdirat(parent.as_fd(), &leaf, Mode::from_raw_mode(0o755)) {
             Ok(()) => Ok(true),
             Err(e) if e == Errno::EXIST => Ok(false),
@@ -122,6 +137,7 @@ impl<'a> Rooted<'a> {
         &self,
         rel: &Path,
         link_target_bytes: Option<&[u8]>,
+        prior_layer_paths: &HashSet<PathBuf>,
     ) -> Result<(), RefusalReason> {
         use rustix::fs::symlinkat;
         use std::os::fd::AsFd;
@@ -131,6 +147,9 @@ impl<'a> Rooted<'a> {
             _ => return Err(RefusalReason::MalformedHeader),
         };
         let (parent, leaf) = self.open_parent(rel, true).map_err(map_resolve_errno)?;
+        if prior_layer_paths.contains(rel) {
+            remove_prior_layer_path(self, rel)?;
+        }
         symlinkat(OsStr::from_bytes(link_target), parent.as_fd(), &leaf)
             .map_err(|_| RefusalReason::MalformedHeader)
     }
@@ -141,6 +160,7 @@ impl<'a> Rooted<'a> {
         target_rel: &Path,
         options: &UnpackOptions,
         current_layer_paths: &HashSet<PathBuf>,
+        prior_layer_paths: &HashSet<PathBuf>,
     ) -> Result<HardlinkAction, RefusalReason> {
         use rustix::fs::{AtFlags, FileType, Mode, OFlags, ResolveFlags, linkat, openat2, statat};
         use rustix::io::Errno;
@@ -177,6 +197,10 @@ impl<'a> Rooted<'a> {
         let (dst_parent, dst_leaf) = self
             .open_parent(target_rel, true)
             .map_err(map_resolve_errno)?;
+
+        if prior_layer_paths.contains(target_rel) {
+            remove_prior_layer_path(self, target_rel)?;
+        }
 
         if current_layer_paths.contains(&src_rel) {
             linkat(
@@ -242,6 +266,101 @@ impl<'a> Rooted<'a> {
     }
 }
 
+/// Remove a path known to originate from a prior layer so the current
+/// layer can recreate it with a different entry type. Directories are
+/// removed recursively; files and symlinks are unlinked without
+/// dereferencing. Operations resolve through `openat2(RESOLVE_NO_SYMLINKS)`
+/// so a swapped symlink parent cannot redirect the removal.
+#[cfg(target_os = "linux")]
+pub(super) fn remove_prior_layer_path(rooted: &Rooted, rel: &Path) -> Result<(), RefusalReason> {
+    use rustix::fs::{AtFlags, FileType, Mode, OFlags, ResolveFlags, openat2, statat, unlinkat};
+    use rustix::io::Errno;
+    use std::os::fd::AsFd;
+
+    let resolve = ResolveFlags::IN_ROOT | ResolveFlags::NO_SYMLINKS;
+    let (parent, leaf) = match rooted.open_parent(rel, false) {
+        Ok(v) => v,
+        Err(e) if e == Errno::NOENT => return Ok(()),
+        Err(e) => return Err(map_resolve_errno(e)),
+    };
+
+    let st = match statat(parent.as_fd(), &leaf, AtFlags::SYMLINK_NOFOLLOW) {
+        Ok(s) => s,
+        Err(e) if e == Errno::NOENT => return Ok(()),
+        Err(_) => return Err(RefusalReason::MalformedHeader),
+    };
+
+    if FileType::from_raw_mode(st.st_mode) == FileType::Directory {
+        let dir_fd = openat2(
+            parent.as_fd(),
+            &leaf,
+            OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+            resolve,
+        )
+        .map_err(map_resolve_errno)?;
+        remove_all_children_in_dir(&dir_fd)?;
+        unlinkat(parent.as_fd(), &leaf, AtFlags::REMOVEDIR)
+            .map_err(|_| RefusalReason::MalformedHeader)
+    } else {
+        unlinkat(parent.as_fd(), &leaf, AtFlags::empty())
+            .map_err(|_| RefusalReason::MalformedHeader)
+    }
+}
+
+/// Recursively remove every child of `dir_fd`, descending through
+/// directory handles so the walk cannot be redirected by a symlink swap.
+#[cfg(target_os = "linux")]
+fn remove_all_children_in_dir(dir_fd: &std::os::fd::OwnedFd) -> Result<(), RefusalReason> {
+    use rustix::fs::{
+        AtFlags, Dir, FileType, Mode, OFlags, ResolveFlags, openat2, statat, unlinkat,
+    };
+    use std::os::fd::AsFd;
+
+    let resolve = ResolveFlags::IN_ROOT | ResolveFlags::NO_SYMLINKS;
+    let child_dir_oflags = OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC;
+
+    let mut children: Vec<(std::ffi::OsString, bool)> = Vec::new();
+    let dir = Dir::read_from(dir_fd.as_fd()).map_err(|_| RefusalReason::MalformedHeader)?;
+    for entry in dir {
+        let entry = entry.map_err(|_| RefusalReason::MalformedHeader)?;
+        let name_bytes = entry.file_name().to_bytes();
+        if name_bytes == b"." || name_bytes == b".." {
+            continue;
+        }
+        let name = OsStr::from_bytes(name_bytes).to_os_string();
+        let is_dir = match entry.file_type() {
+            FileType::Directory => true,
+            FileType::Unknown => match statat(dir_fd.as_fd(), &name, AtFlags::SYMLINK_NOFOLLOW) {
+                Ok(st) => FileType::from_raw_mode(st.st_mode) == FileType::Directory,
+                Err(_) => false,
+            },
+            _ => false,
+        };
+        children.push((name, is_dir));
+    }
+
+    for (name, is_dir) in children {
+        if is_dir {
+            let child_fd = openat2(
+                dir_fd.as_fd(),
+                &name,
+                child_dir_oflags,
+                Mode::empty(),
+                resolve,
+            )
+            .map_err(map_resolve_errno)?;
+            remove_all_children_in_dir(&child_fd)?;
+            unlinkat(dir_fd.as_fd(), &name, AtFlags::REMOVEDIR)
+                .map_err(|_| RefusalReason::MalformedHeader)?;
+        } else {
+            unlinkat(dir_fd.as_fd(), &name, AtFlags::empty())
+                .map_err(|_| RefusalReason::MalformedHeader)?;
+        }
+    }
+    Ok(())
+}
+
 /// Map an `openat2`/`*at` failure to the unpacker's refusal taxonomy.
 /// `ELOOP` is a `RESOLVE_NO_SYMLINKS` hit on a symlinked component;
 /// `EXDEV` is a `RESOLVE_IN_ROOT` boundary escape. Everything else is
@@ -258,13 +377,38 @@ pub(super) fn map_resolve_errno(e: rustix::io::Errno) -> RefusalReason {
     }
 }
 
+/// Remove a path known to originate from a prior layer so the current
+/// layer can recreate it. Non-Linux fallback only.
+#[cfg(not(target_os = "linux"))]
+pub(super) fn remove_prior_layer_path(root: &Path, rel: &Path) -> Result<(), RefusalReason> {
+    let target = root.join(rel);
+    if !target.starts_with(root) {
+        return Err(RefusalReason::JoinedPathEscape);
+    }
+    match std::fs::symlink_metadata(&target) {
+        Ok(meta) if meta.file_type().is_dir() => {
+            std::fs::remove_dir_all(&target).map_err(|_| RefusalReason::MalformedHeader)
+        }
+        Ok(_) => std::fs::remove_file(&target).map_err(|_| RefusalReason::MalformedHeader),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(_) => Err(RefusalReason::MalformedHeader),
+    }
+}
+
 #[cfg(not(target_os = "linux"))]
 impl<'a> Rooted<'a> {
     pub(super) fn open(root: &'a Path) -> std::io::Result<Self> {
         Ok(Self { root })
     }
 
-    pub(super) fn create_directory(&self, rel: &Path) -> Result<bool, RefusalReason> {
+    pub(super) fn create_directory(
+        &self,
+        rel: &Path,
+        prior_layer_paths: &HashSet<PathBuf>,
+    ) -> Result<bool, RefusalReason> {
+        if prior_layer_paths.contains(rel) {
+            remove_prior_layer_path(self.root, rel)?;
+        }
         create_directory(&self.root.join(rel))
     }
 
@@ -272,7 +416,11 @@ impl<'a> Rooted<'a> {
         &self,
         rel: &Path,
         link_target_bytes: Option<&[u8]>,
+        prior_layer_paths: &HashSet<PathBuf>,
     ) -> Result<(), RefusalReason> {
+        if prior_layer_paths.contains(rel) {
+            remove_prior_layer_path(self.root, rel)?;
+        }
         write_symlink(link_target_bytes, &self.root.join(rel))
     }
 
@@ -282,6 +430,7 @@ impl<'a> Rooted<'a> {
         target_rel: &Path,
         options: &UnpackOptions,
         current_layer_paths: &HashSet<PathBuf>,
+        prior_layer_paths: &HashSet<PathBuf>,
     ) -> Result<HardlinkAction, RefusalReason> {
         materialize_hardlink(
             link_target_bytes,
@@ -289,6 +438,7 @@ impl<'a> Rooted<'a> {
             self.root,
             options,
             current_layer_paths,
+            prior_layer_paths,
         )
     }
 }
@@ -407,6 +557,7 @@ fn materialize_hardlink(
     output_root: &Path,
     options: &UnpackOptions,
     current_layer_paths: &HashSet<PathBuf>,
+    prior_layer_paths: &HashSet<PathBuf>,
 ) -> Result<HardlinkAction, RefusalReason> {
     let target_rel = validate_hardlink_target(link_target_bytes, output_root, options)?;
     let source = output_root.join(&target_rel);
@@ -433,6 +584,10 @@ fn materialize_hardlink(
         if std::fs::create_dir_all(parent).is_err() {
             return Err(RefusalReason::MalformedHeader);
         }
+    }
+
+    if prior_layer_paths.contains(&target_rel) {
+        remove_prior_layer_path(output_root, &target_rel)?;
     }
 
     if current_layer_paths.contains(&target_rel) {

--- a/crates/mvm-fs/src/oci/unpack/mod.rs
+++ b/crates/mvm-fs/src/oci/unpack/mod.rs
@@ -247,6 +247,12 @@ impl Default for UnpackOptions {
 pub struct UnpackReport {
     /// Regular files materialized.
     pub files_written: u64,
+    /// Paths written by this layer (regular files, directories,
+    /// symlinks, hardlinks, device nodes). Callers applying multiple
+    /// layers to the same root accumulate this set and pass it as
+    /// `prior_layer_paths` to the next layer so that later layers can
+    /// replace paths known to originate from earlier layers.
+    pub paths_written: HashSet<PathBuf>,
     /// Directories created (counts only newly-created dirs; entries
     /// for already-existing dirs are silently coalesced).
     pub dirs_created: u64,
@@ -443,6 +449,11 @@ pub enum UnpackError {
 /// Unpack a single layer tarball under `output_root`, applying the
 /// safety policies described at module level.
 ///
+/// This is the backward-compatible entry point for single-layer
+/// callers and tests. Multi-layer callers should use
+/// [`unpack_layer_with_prior_paths`] and accumulate the
+/// [`UnpackReport::paths_written`] set across layers.
+///
 /// Caller's responsibilities:
 ///
 /// - Pre-create `output_root` (we refuse to silently `mkdir` it).
@@ -456,9 +467,28 @@ pub enum UnpackError {
 /// refused entries. Refusals are **not** errors — callers that want
 /// "all-or-nothing" inspect `report.refused.is_empty()`.
 pub fn unpack_layer<R: Read>(
+    layer_tar: R,
+    output_root: &Path,
+    options: &UnpackOptions,
+) -> Result<UnpackReport, UnpackError> {
+    unpack_layer_with_prior_paths(layer_tar, output_root, options, &HashSet::new())
+}
+
+/// Unpack a single layer tarball under `output_root`, with knowledge
+/// of paths written by earlier layers.
+///
+/// When `prior_layer_paths` contains the relative path of an entry
+/// being unpacked, the unpacker removes the existing leaf first
+/// (file, symlink, or directory tree) and then re-creates it with
+/// the new entry's type. This lets later OCI layers replace files
+/// from earlier layers without giving up the `O_EXCL` / `O_NOFOLLOW`
+/// first-creation safety for paths that are genuinely new. Same-layer
+/// duplicates remain refused.
+pub fn unpack_layer_with_prior_paths<R: Read>(
     mut layer_tar: R,
     output_root: &Path,
     options: &UnpackOptions,
+    prior_layer_paths: &HashSet<PathBuf>,
 ) -> Result<UnpackReport, UnpackError> {
     if !output_root.is_absolute() {
         return Err(UnpackError::NonAbsoluteOutputRoot(
@@ -599,6 +629,7 @@ pub fn unpack_layer<R: Read>(
             rel_path: &rel_path,
             raw_path: &raw_path,
             target: &target,
+            prior_layer_paths,
         };
         match entry_type {
             tar::EntryType::Regular | tar::EntryType::Continuous => unpack_regular_entry(

--- a/crates/mvm-fs/src/oci/unpack/regular_file.rs
+++ b/crates/mvm-fs/src/oci/unpack/regular_file.rs
@@ -5,8 +5,9 @@
 //! that [`super::fs_ops`] uses when a hardlink's target lives in a
 //! lower/prior layer.
 
+use std::collections::HashSet;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::{RefusalReason, SetidEntry, SetidPolicy, UnpackOptions, UnpackReport};
 
@@ -22,6 +23,7 @@ impl<'a> super::fs_ops::Rooted<'a> {
         entry: &mut tar::Entry<R>,
         raw_path: &[u8],
         options: &UnpackOptions,
+        prior_layer_paths: &HashSet<PathBuf>,
         report: &mut UnpackReport,
     ) -> Result<(), RefusalReason> {
         use rustix::fs::{Mode, OFlags, ResolveFlags, openat2};
@@ -34,6 +36,9 @@ impl<'a> super::fs_ops::Rooted<'a> {
         let (parent, leaf) = self
             .open_parent(rel, true)
             .map_err(super::fs_ops::map_resolve_errno)?;
+        if prior_layer_paths.contains(rel) {
+            super::fs_ops::remove_prior_layer_path(self, rel)?;
+        }
         let resolve = ResolveFlags::IN_ROOT | ResolveFlags::NO_SYMLINKS;
         let flags =
             OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::NOFOLLOW | OFlags::CLOEXEC;
@@ -77,8 +82,12 @@ impl<'a> super::fs_ops::Rooted<'a> {
         entry: &mut tar::Entry<R>,
         raw_path: &[u8],
         options: &UnpackOptions,
+        prior_layer_paths: &HashSet<PathBuf>,
         report: &mut UnpackReport,
     ) -> Result<(), RefusalReason> {
+        if prior_layer_paths.contains(rel) {
+            super::fs_ops::remove_prior_layer_path(self.root, rel)?;
+        }
         write_regular_file(entry, &self.root.join(rel), raw_path, options, report)
     }
 }

--- a/features/suites/s9_image_materialization/oci_multi_layer_unpack.feature
+++ b/features/suites/s9_image_materialization/oci_multi_layer_unpack.feature
@@ -1,0 +1,50 @@
+Feature: OCI multi-layer unpack replaces prior-layer paths
+
+  Each OCI image layer is unpacked onto the same rootfs tree. A later layer
+  must be able to replace a path written by an earlier layer, including
+  changing its entry type (file to directory, directory to file, etc.), while
+  still refusing duplicate entries within the same layer.
+
+  Scenario: A later layer file overrides an earlier layer file
+    Given an empty OCI unpack root
+    When I unpack a layer containing:
+      | path    | kind | content |
+      | foo.txt | file | first   |
+    When I unpack a layer containing:
+      | path    | kind | content |
+      | foo.txt | file | second  |
+    Then the path "foo.txt" exists as a file
+    And the path "foo.txt" contains "second"
+
+  Scenario: A later layer directory replaces an earlier layer file
+    Given an empty OCI unpack root
+    When I unpack a layer containing:
+      | path    | kind | content |
+      | foo/bar | file | hello   |
+    When I unpack a layer containing:
+      | path    | kind      | content |
+      | foo/bar | directory |         |
+    Then the path "foo/bar" exists as a directory
+
+  Scenario: A whiteout removes a path and a later layer recreates it
+    Given an empty OCI unpack root
+    When I unpack a layer containing:
+      | path    | kind | content |
+      | foo.txt | file | first   |
+    When I unpack a layer containing:
+      | path        | kind     | content |
+      | .wh.foo.txt | whiteout |         |
+    Then the path "foo.txt" does not exist
+    When I unpack a layer containing:
+      | path    | kind | content |
+      | foo.txt | file | third   |
+    Then the path "foo.txt" exists as a file
+    And the path "foo.txt" contains "third"
+
+  Scenario: A duplicate entry in the same layer is refused
+    Given an empty OCI unpack root
+    When I unpack a layer containing:
+      | path    | kind | content |
+      | foo.txt | file | first   |
+      | foo.txt | file | second  |
+    Then the unpack report has 1 refused entries

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -449,7 +449,7 @@ WS4/WS5/WS6 can proceed in parallel with WS1 sub-steps. WS3 depends on `mvm-net`
 | 1701     | issue      | Fold → WS3 (finish vsock tunnel), then close                        |
 | 1717     | PR         | Fold → WS3 (FC transparent net over vsock), then close              |
 | 1601     | issue      | Fold → WS3 (HVF host-vsock-proxy), then close                       |
-| 1674     | issue      | Fold → WS1c / WS8 (OCI unpack O_EXCL), then close                   |
+| 1674     | issue      | **Fixed by #1804** — prior-layer path tracking                      |
 | 1654     | issue      | Fold → WS4 (runtime sockets under `~/.mvm/run`), then close         |
 | 1462     | issue      | Fold → WS2 (verb-grant delivery), then close                        |
 | 1366     | issue      | **Closed** — landed via #1791 (Sandbox.connect dev-only exec guard) |


### PR DESCRIPTION
Closes #1674.

Threads `prior_layer_paths` through `unpack_layer` so later OCI layers can remove paths written by earlier layers before recreating them. This preserves `O_CREAT | O_EXCL` / `O_NOFOLLOW` first-creation safety for genuinely new paths while allowing later layers to override a prior-layer file/directory/symlink/device. Same-layer duplicates remain refused.

- Adds `unpack_layer_with_prior_paths` and `UnpackReport::paths_written`.
- Removes prior-layer leafs before regular file, symlink, hardlink, device node, and directory materialization.
- Accumulates `paths_written` across layers in `mvm-cli image pull/ingest` and `mvm-client local`.
- Adds BDD scenarios in `features/suites/s9_image_materialization/` covering multi-layer override, type-changing replacement, whiteout + recreation, and same-layer duplicate refusal.