### PR TITLE
fix(kernel): pin guest kernels to 6.12.97 and decouple from the nixpkgs channel (#1805)

### DIFF
--- a/.github/workflows/kernel-cve-watch.yml
+++ b/.github/workflows/kernel-cve-watch.yml
@@ -6,8 +6,11 @@ name: Kernel pin CVE watch
 #
 # - schedule  → daily monitor; opens/updates a tracking issue on staleness,
 #               does NOT fail (the repo wasn't touched).
-# - pull_request on the kernel-pin files → fails hard, so a pin bump can't land
-#               still behind upstream.
+# - pull_request on the kernel-pin files → posts an informational warning if a
+#               pin still trails upstream, but never fails the PR: staleness is
+#               almost always pre-existing (upstream cut a new point release),
+#               not introduced by the PR, so the daily cron + tracking issue is
+#               the enforcement surface, not a merge block.
 # - workflow_dispatch → manual.
 
 on:

--- a/crates/mvm-conformance/tests/steps/kernel_pin.rs
+++ b/crates/mvm-conformance/tests/steps/kernel_pin.rs
@@ -1,0 +1,83 @@
+//! Steps for the kernel-pin freshness watcher contract. These drive the pure
+//! `mvm_core::kernel_advisory::assess` decision — no I/O, no network, no VM —
+//! so they run in the normal hermetic BDD gate. The xtask shell that fetches
+//! upstream releases and reads the local pins is exercised separately; here we
+//! pin down the security-relevant verdict: a trailing pin recommends a bump,
+//! matched pins do not, and missing knowledge never recommends action.
+
+use cucumber::{given, then, when};
+use mvm_core::kernel_advisory::{KernelPin, Staleness, UpstreamReleases, assess};
+
+use crate::world::CliWorld;
+
+#[given(expr = "a local kernel pin {string} at version {string}")]
+fn local_pin(world: &mut CliWorld, name: String, version: String) {
+    world.kernel_pins.push(KernelPin { name, version });
+}
+
+#[given(expr = "the latest upstream point release for series {string} is {string}")]
+fn upstream_release(world: &mut CliWorld, series: String, latest: String) {
+    world.kernel_upstream.insert(series, latest);
+}
+
+#[given("no upstream release data")]
+fn no_upstream(world: &mut CliWorld) {
+    world.kernel_upstream.clear();
+}
+
+#[when("the kernel pin freshness is assessed")]
+fn assess_freshness(world: &mut CliWorld) {
+    let upstream = UpstreamReleases {
+        latest_by_series: world.kernel_upstream.clone(),
+    };
+    world.kernel_advisory = Some(assess(&world.kernel_pins, &upstream));
+}
+
+#[then("the advisory recommends action")]
+fn recommends_action(world: &mut CliWorld) {
+    assert!(
+        world.advisory().action_recommended,
+        "expected a bump to be recommended: {:?}",
+        world.advisory()
+    );
+}
+
+#[then("the advisory does not recommend action")]
+fn no_action(world: &mut CliWorld) {
+    assert!(
+        !world.advisory().action_recommended,
+        "expected no bump to be recommended: {:?}",
+        world.advisory()
+    );
+}
+
+#[then("every assessed pin is reported up to date")]
+fn all_up_to_date(world: &mut CliWorld) {
+    for (pin, staleness) in &world.advisory().pins {
+        assert!(
+            matches!(staleness, Staleness::UpToDate),
+            "expected pin {:?} up to date, got {staleness:?}",
+            pin.name
+        );
+    }
+}
+
+#[then(expr = "the worst pin is reported behind by {int} patch releases")]
+fn worst_behind_by(world: &mut CliWorld, gap: u32) {
+    match &world.advisory().worst {
+        Staleness::Behind { patch_gap, .. } => assert_eq!(
+            *patch_gap, gap,
+            "expected worst pin behind by {gap}, got {patch_gap}"
+        ),
+        other => panic!("expected worst pin behind by {gap}, got {other:?}"),
+    }
+}
+
+#[then("the worst pin status is unknown")]
+fn worst_unknown(world: &mut CliWorld) {
+    assert!(
+        matches!(world.advisory().worst, Staleness::Unknown { .. }),
+        "expected worst pin status unknown, got {:?}",
+        world.advisory().worst
+    );
+}

--- a/crates/mvm-conformance/tests/steps/mod.rs
+++ b/crates/mvm-conformance/tests/steps/mod.rs
@@ -1,6 +1,7 @@
 //! Step definitions, one module per scenario surface.
 
 mod cli;
+mod kernel_pin;
 mod readme_contract;
 mod verified_boot;
 mod workload_identity;

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -1,9 +1,10 @@
 //! Shared state cucumber threads through the steps of one scenario.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::process::Output;
 
+use mvm_core::kernel_advisory::{KernelAdvisory, KernelPin};
 use mvm_core::kernel_format::KernelFormat;
 
 /// Constructed fresh for every scenario. Holds the result of the most
@@ -27,6 +28,13 @@ pub struct CliWorld {
     pub isolated_home: Option<tempfile::TempDir>,
     /// Whether live CLI steps should keep one warm standby for the next run.
     pub warm_residency: bool,
+    /// Local kernel pins accumulated by the freshness-watcher scenarios.
+    pub kernel_pins: Vec<KernelPin>,
+    /// Latest upstream point release per `MAJOR.MINOR` series, as those same
+    /// scenarios stage it before assessing.
+    pub kernel_upstream: BTreeMap<String, String>,
+    /// The verdict from the most recent freshness assessment.
+    pub kernel_advisory: Option<KernelAdvisory>,
 }
 
 impl fmt::Debug for CliWorld {
@@ -42,6 +50,9 @@ impl fmt::Debug for CliWorld {
                 &self.isolated_home.as_ref().map(|t| t.path().to_path_buf()),
             )
             .field("warm_residency", &self.warm_residency)
+            .field("kernel_pins", &self.kernel_pins)
+            .field("kernel_upstream", &self.kernel_upstream)
+            .field("kernel_advisory", &self.kernel_advisory)
             .finish()
     }
 }
@@ -63,5 +74,13 @@ impl CliWorld {
                 "no address recorded for {fixture:?} — its `When` step must run and succeed first"
             )
         })
+    }
+
+    /// The advisory from the most recent freshness assessment, or a failed
+    /// assertion naming the missing `When` step.
+    pub fn advisory(&self) -> &KernelAdvisory {
+        self.kernel_advisory
+            .as_ref()
+            .expect("no advisory recorded yet — a prior `When` step must assess freshness")
     }
 }

--- a/features/suites/s9_kernel_pin/kernel_pin_freshness.feature
+++ b/features/suites/s9_kernel_pin/kernel_pin_freshness.feature
@@ -1,0 +1,29 @@
+Feature: Kernel pin freshness watcher
+  mvm pins the guest kernel in two places — the libkrunfw bundled tarball and
+  the nix-built workload/builder kernel. Both are pinned to an exact upstream
+  LTS point release, so a pin can trail the latest release of its series, where
+  the maintainer backports security fixes. The watcher flags such a pin and
+  recommends a bump; it must never recommend action on missing knowledge.
+
+  Scenario: Both kernel pins at the latest point release recommend no action
+    Given a local kernel pin "libkrunfw" at version "6.12.97"
+    And a local kernel pin "nix-kernel" at version "6.12.97"
+    And the latest upstream point release for series "6.12" is "6.12.97"
+    When the kernel pin freshness is assessed
+    Then the advisory does not recommend action
+    And every assessed pin is reported up to date
+
+  Scenario: A pin trailing the latest point release recommends a bump
+    Given a local kernel pin "libkrunfw" at version "6.12.91"
+    And a local kernel pin "nix-kernel" at version "6.12.97"
+    And the latest upstream point release for series "6.12" is "6.12.97"
+    When the kernel pin freshness is assessed
+    Then the advisory recommends action
+    And the worst pin is reported behind by 6 patch releases
+
+  Scenario: Missing upstream data never recommends action
+    Given a local kernel pin "libkrunfw" at version "6.12.91"
+    And no upstream release data
+    When the kernel pin freshness is assessed
+    Then the advisory does not recommend action
+    And the worst pin status is unknown

--- a/nix/images/kernel/README.md
+++ b/nix/images/kernel/README.md
@@ -111,7 +111,11 @@ When the kernel needs a change:
    `enables`. `make olddefconfig` handles transitive deps.
 2. **Remove a feature.** Append to `disables`. If `olddefconfig`
    pulls it back in, the parent also needs to come off.
-3. **Bump the kernel version.** Edit the `pkgs.linux_6_12`
-   reference (or follow nixpkgs' rename if the LTS pin moves).
-   `make olddefconfig` reconciles dropped / renamed / added
-   symbols automatically.
+3. **Bump the kernel version.** Edit `kernelVersion` in `base.nix` and
+   the matching tarball `hash` (its own sha256 — `nix store
+   prefetch-file mirror://kernel/linux/kernel/v6.x/linux-<ver>.tar.xz`),
+   then bump the libkrunfw pin in `nix/packages/libkrunfw.nix` to the
+   same point release. The pin is deliberately decoupled from nixpkgs'
+   `linux_6_12` (which lags kernel.org's LTS point releases where CVE
+   backports land). `make olddefconfig` reconciles dropped / renamed /
+   added symbols automatically.

--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -41,6 +41,20 @@ let
   kernelArch =
     if pkgs.stdenv.hostPlatform.isAarch64 then "arm64" else "x86_64";
 
+  # Pin the exact upstream point release rather than inheriting nixpkgs'
+  # `linux_6_12`, which is gated by the release channel's cadence and lags
+  # kernel.org's LTS point releases (where the CVE backports land). We already
+  # build from the vanilla tarball and apply no distro kernel patches, so
+  # fetching the source directly — the same way libkrunfw pins its bundled
+  # kernel — lets both of mvm's kernels track the latest point release exactly
+  # and keeps the two pins from drifting apart. Bump `kernelVersion` + `hash`
+  # together (the tarball's own sha256, e.g. via `nix store prefetch-file`).
+  kernelVersion = "6.12.97";
+  kernelSrc = pkgs.fetchurl {
+    url = "mirror://kernel/linux/kernel/v6.x/linux-${kernelVersion}.tar.xz";
+    hash = "sha256-bL3fo7vSIpAm98xeSPa31rRtOXQt45qSV6L0kKD0XG8=";
+  };
+
   # ── Base: minimal feature set common to every mvm microVM kernel ──
   #
   # Each entry becomes a `scripts/config --enable CONFIG_<name>`.
@@ -280,7 +294,7 @@ let
       set -euo pipefail
 
       mkdir -p linux
-      tar -xf ${pkgs.linux_6_12.src} -C linux --strip-components=1
+      tar -xf ${kernelSrc} -C linux --strip-components=1
       cd linux
       chmod -R u+w .
 
@@ -349,17 +363,20 @@ let
   # false` keeps `nix flake check --no-build` (CI "Nix flake check"
   # lane) working: --no-build won't realize the configfile derivation,
   # and IFD from linuxManualConfig would then fail with
-  # `path '…-kernel-config.drv' is not valid`. We pass
-  # version/modDirVersion/src explicitly from pkgs.linux_6_12, so the
-  # configfile content is needed only at build time, not eval time.
+  # `path '…-kernel-config.drv' is not valid`. We pass the pinned
+  # version/modDirVersion/src explicitly, so the configfile content is
+  # needed only at build time, not eval time. `modDirVersion` matches the
+  # pinned version even though CONFIG_MODULES=n leaves the module tree empty.
   mkKernel = { extraEnables ? [ ], extraDisables ? [ ] }:
     pkgs.linuxManualConfig {
-      inherit (pkgs.linux_6_12) src version modDirVersion;
+      src = kernelSrc;
+      version = kernelVersion;
+      modDirVersion = kernelVersion;
       configfile = mkConfigfile { inherit extraEnables extraDisables; };
       allowImportFromDerivation = false;
     };
 
 in
 {
-  inherit kernelArch baseEnables baseDisables mkConfigfile mkKernel;
+  inherit kernelArch kernelVersion baseEnables baseDisables mkConfigfile mkKernel;
 }

--- a/nix/images/kernel/flake.nix
+++ b/nix/images/kernel/flake.nix
@@ -35,7 +35,7 @@
           # "aarch64" / "x86_64" for the published filenames (matches the
           # per-arch checksum-manifest naming the downloader verifies).
           arch = nixpkgs.lib.head (nixpkgs.lib.splitString "-" system);
-          kver = pkgs.linux_6_12.version;
+          kver = base.kernelVersion;
 
           # vmlinux size + built-in symbol count. Pure measurement; the
           # number is what the "tiny kernel" claim is anchored to.

--- a/nix/packages/libkrunfw.nix
+++ b/nix/packages/libkrunfw.nix
@@ -20,8 +20,8 @@ assert lib.elem variant [
 
 let
   kernelSrc = fetchurl {
-    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.91.tar.xz";
-    hash = "sha256-D/KrnhafnxlIVXRx+7RQ0wGPjFt3yvKI4aOYJYJZeWk=";
+    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.97.tar.xz";
+    hash = "sha256-bL3fo7vSIpAm98xeSPa31rRtOXQt45qSV6L0kKD0XG8=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -239,7 +239,7 @@ fn native_vmm_recipes_are_source_built_and_pinned() {
     }
 
     assert!(
-        libkrunfw.contains("linux-6.12.91.tar.xz")
+        libkrunfw.contains("linux-6.12.97.tar.xz")
             && libkrunfw.contains("KERNEL_REMOTE")
             && libkrunfw.contains("ln -s ${kernelSrc} $(KERNEL_TARBALL)"),
         "libkrunfw must pin and substitute the kernel source instead of downloading it during build"

--- a/xtask/src/check_kernel_pin_freshness.rs
+++ b/xtask/src/check_kernel_pin_freshness.rs
@@ -44,7 +44,7 @@ pub fn run(workspace: &Path, args: &[String]) -> Result<()> {
 }
 
 /// Read every kernel pin mvm carries. The libkrunfw pin is a deterministic
-/// file read; the nixpkgs `linux_6_12` version needs a Nix eval and is
+/// file read; the nix-built kernel's pinned version needs a Nix eval and is
 /// best-effort (skipped, not failed, when Nix is unavailable).
 fn read_local_pins(workspace: &Path) -> Vec<KernelPin> {
     let mut pins = Vec::new();
@@ -57,9 +57,9 @@ fn read_local_pins(workspace: &Path) -> Vec<KernelPin> {
             version,
         });
     }
-    if let Some(version) = eval_nixpkgs_linux_version(workspace) {
+    if let Some(version) = eval_nix_kernel_version(workspace) {
         pins.push(KernelPin {
-            name: "nixpkgs-linux_6_12".into(),
+            name: "nix-kernel".into(),
             version,
         });
     }
@@ -73,10 +73,11 @@ fn parse_libkrunfw_pin(content: &str) -> Option<String> {
     re.captures(content).map(|c| c[1].to_string())
 }
 
-/// Best-effort: the kernel package inherits `version` from `pkgs.linux_6_12`,
-/// so eval it from the standalone kernel flake. Returns `None` (skip the pin)
-/// on any Nix/eval failure rather than erroring.
-fn eval_nixpkgs_linux_version(workspace: &Path) -> Option<String> {
+/// Best-effort: the nix-built kernel pins an exact point release (decoupled
+/// from nixpkgs' channel-gated `linux_6_12`), exposed as the kernel flake's
+/// `workload-vmlinux.version`. Eval it from the standalone kernel flake.
+/// Returns `None` (skip the pin) on any Nix/eval failure rather than erroring.
+fn eval_nix_kernel_version(workspace: &Path) -> Option<String> {
     let arch = if cfg!(target_arch = "aarch64") {
         "aarch64"
     } else {


### PR DESCRIPTION
## Summary

Resolves the recurring "Kernel pin trails upstream" watcher issue and closes the structural gap that made it un-closeable.

mvm pins the guest kernel in two places. The **libkrunfw** bundled tarball is a direct kernel.org fetch and bumps cleanly. The **nix-built** workload/builder kernel inherited `pkgs.linux_6_12`, which is gated by the nixpkgs release channel — `nixos-25.11`'s current HEAD still ships only 6.12.93, so that pin was *structurally unable* to reach kernel.org's latest LTS point release and the watcher re-flagged it indefinitely.

Since the nix kernel is already a `linuxManualConfig` build from the vanilla tarball, this decouples it and pins the exact point release directly (the same pattern libkrunfw uses). Both kernels now track kernel.org's latest, so the advisory can reach `action_recommended: false`. Both pins bumped to the current latest LTS point release, **6.12.97** (the issue's 6.12.96 was already stale).

## Changes

- `nix/packages/libkrunfw.nix` — libkrunfw bundled kernel 6.12.91 → 6.12.97 (prefetch-verified hash).
- `nix/images/kernel/base.nix` — decouple the nix kernel from `pkgs.linux_6_12`; pin 6.12.97 tarball directly.
- `nix/images/kernel/flake.nix` — artifact-manifest `kver` now reads `base.kernelVersion`.
- `xtask/src/check_kernel_pin_freshness.rs` — rename the now-accurate pin `nixpkgs-linux_6_12` → `nix-kernel`; truthful comments.
- `.github/workflows/kernel-cve-watch.yml` — correct the stale header comment (the `pull_request` trigger warns, it does not fail the build).
- `nix/images/kernel/README.md` — updated maintenance-contract bump instructions.
- `tests/nix_flake_structure.rs` — doc-guard tarball literal.
- `features/suites/s9_kernel_pin/` + `crates/mvm-conformance/tests/steps/kernel_pin.rs` — hermetic BDD coverage of the watcher verdict (trailing → bump; matched → no action; missing data → never acts).

## Verification

- Real 6.12.97 kernel **compiled from source** on x86_64/KVM — config survives `olddefconfig`, real `bzImage`/`vmlinux` produced.
- `nix eval` — both workload and builder kernels report 6.12.97.
- End-to-end watcher against live kernel.org — `action_recommended: false`.
- BDD conformance — 31/31 scenarios (3 new), 155 steps.
- `nix_flake_structure` doc-guard — 27/27; `xtask` unit — 238/238.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (via pre-commit hook).

Closes #1805.
