### PR TITLE
fix(runtime): de-flake substitution endpoint rollback test

### DIFF
--- a/crates/mvm-runtime/src/substitution_spawn.rs
+++ b/crates/mvm-runtime/src/substitution_spawn.rs
@@ -537,10 +537,16 @@ mod tests {
         let stub = dir.join("stub-endpoint.sh");
         let stopped = dir.join("stopped");
         let pid_capture = dir.join("endpoint.pid");
+        // Arm the TERM trap BEFORE announcing readiness. The spawner only
+        // proceeds to the rollback SIGTERM once it reads this handshake line, so
+        // if the stub announced "ready" first, the SIGTERM could land in the gap
+        // before `trap` runs — default-terminating the stub with no `stopped`
+        // sentinel. Arming first makes the sentinel write deterministic instead
+        // of racing the trap install under load. Do not reorder these two lines.
         std::fs::write(
             &stub,
             format!(
-                "#!/bin/sh\ncat >/dev/null\necho $$ > {}\necho 'ready handshake'\ntrap 'echo stopped > {}; exit 0' TERM\nwhile :; do sleep 1; done\n",
+                "#!/bin/sh\ncat >/dev/null\necho $$ > {}\ntrap 'echo stopped > {}; exit 0' TERM\necho 'ready handshake'\nwhile :; do sleep 1; done\n",
                 pid_capture.display(),
                 stopped.display()
             ),


### PR DESCRIPTION
## Summary

De-flakes `substitution_spawn::tests::spawn_failure_after_pid_write_rolls_back_the_endpoint_sidecar` (`mvm-runtime`), which intermittently fails the `test-support` Lint lane under CI load.

## Root cause

The test's stub endpoint (a shell script) announced readiness **before** arming its `TERM` trap:

```
echo 'ready handshake'                          # spawner unblocks here → may SIGTERM
trap 'echo stopped > $stopped; exit 0' TERM     # trap armed only after
```

The production spawner (`spawn_substitution_endpoint`) only proceeds to the rollback `SIGTERM` (`SpawnedEndpointGuard::Drop`) **after** reading that handshake line. Under CI scheduling load, the `SIGTERM` can land in the gap after "ready" but before `trap` runs — the shell takes the default disposition (terminate) and never writes the `stopped` sentinel, so the assertion *"rollback must terminate the endpoint process"* trips. The SIGKILL fallback can't produce the sentinel either (SIGKILL is uncatchable).

The production spawn/rollback path is correct; only the test's stub declared itself ready prematurely.

## Fix

Arm the `TERM` trap **before** announcing readiness, so once the spawner can send the rollback `SIGTERM` the handler is guaranteed installed. One-line reorder in the stub script (test-only).

## Verification

Modeling the CI scheduling delay with an injected gap between handshake and trap, run 200× per ordering on **both macOS `sh` and Linux `dash`** (the CI shell):

| Ordering | FAILS / 200 |
|----------|-------------|
| handshake → trap (old) | **200** |
| trap → handshake (new) | **0** |

`cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean (pre-commit hook).

## Context

This flake blocked the merge queue for #1812 (an unrelated kernel-pin bump). This is the root-cause fix so it stops ambushing PRs.
