### PR TITLE
feat(mvm-core): content-address plan_id (#1807)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,9 @@ jobs:
       - name: mvm-core default build is runtime-free
         run: cargo run -p xtask -- check-core-runtime-free
 
+      - name: content-address digests stay deterministic
+        run: cargo run -p xtask -- check-content-address-determinism
+
       - name: mvmctl default closure within budget
         run: cargo run -p xtask -- check-closure-budget
 

--- a/crates/mvm-cli/src/commands/ops/audit.rs
+++ b/crates/mvm-cli/src/commands/ops/audit.rs
@@ -49,7 +49,7 @@ pub(in crate::commands) enum AuditAction {
     },
     /// Show every audit chain entry bound to a specific plan_id.
     Show {
-        /// The plan_id (UUIDv4) to filter by.
+        /// The plan_id (`sha256:<hex>` content-address) to filter by.
         plan_id: String,
         /// Tenant whose chain to search. Defaults to `"local"`.
         #[arg(long, default_value = "local")]

--- a/crates/mvm-core/src/plan/content_id.rs
+++ b/crates/mvm-core/src/plan/content_id.rs
@@ -1,0 +1,195 @@
+//! Content-addressing for [`ExecutionPlan`]: a plan's `plan_id` is the SHA-256
+//! of its load-bearing content, rendered `sha256:<64 lowercase hex>`.
+//!
+//! The id commits to every load-bearing field of the plan *except* the id
+//! itself — so a run is addressable and hash-linkable by digest, and two plans
+//! with identical content share an id. The per-synthesis nonce is part of that
+//! content, so each synthesis still yields a distinct id even for the same
+//! workload shape.
+//!
+//! Two things are outside the digest input by construction:
+//! - `plan_id` — the value being derived; including it would be circular.
+//! - the Ed25519 signature — it lives in the signed envelope, not in the plan
+//!   body, so it is already outside the digested bytes. The signature covers
+//!   the whole plan (including the derived id), so the ordering is: derive id,
+//!   set it, then sign.
+//!
+//! The derivation serializes the plan, drops the `plan_id` key, and hashes the
+//! remainder. Serializing through [`serde_json::Value`] (whose object keys sort
+//! deterministically) means every current and future load-bearing field is
+//! covered automatically — a field cannot silently fall outside the address the
+//! way a hand-maintained field list could drift. This is host-only,
+//! single-implementation hashing with no cross-language conformance need — the
+//! same posture the checkpoint content-address and the audit envelope take.
+
+use sha2::{Digest, Sha256};
+
+use crate::digest_shape::SHA256_PREFIX;
+use crate::plan::{ExecutionPlan, PlanId};
+
+/// The JSON key `plan_id` serializes under; dropped from the digest input so
+/// the address commits to content only, never to its own output.
+const PLAN_ID_FIELD: &str = "plan_id";
+
+/// Derive `plan`'s content-address: `sha256:<hex>` over every load-bearing
+/// field except `plan_id`. Pure and deterministic — the id a synthesized plan
+/// carries is exactly this value, and a verifier recomputes it the same way.
+pub fn compute_plan_id(plan: &ExecutionPlan) -> PlanId {
+    let mut value = serde_json::to_value(plan).expect("ExecutionPlan is always JSON-serializable");
+    value
+        .as_object_mut()
+        .expect("ExecutionPlan serializes as a JSON object")
+        .remove(PLAN_ID_FIELD);
+    let bytes = serde_json::to_vec(&value).expect("a serde_json::Value re-serializes");
+    PlanId(format!(
+        "{SHA256_PREFIX}{}",
+        hex::encode(Sha256::digest(&bytes))
+    ))
+}
+
+/// Fail-closed content-address check: the plan's stored `plan_id` must equal
+/// the address recomputed from its load-bearing content. A mismatch means the
+/// id is not a genuine content-address of this body — reject rather than trust
+/// an unverifiable id.
+pub fn verify_plan_id(plan: &ExecutionPlan) -> Result<(), PlanIdMismatch> {
+    let recomputed = compute_plan_id(plan);
+    if recomputed == plan.plan_id {
+        Ok(())
+    } else {
+        Err(PlanIdMismatch {
+            stored: plan.plan_id.0.clone(),
+            recomputed: recomputed.0,
+        })
+    }
+}
+
+/// [`verify_plan_id`] failure: the stored id is not the content-address of the
+/// plan body.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "plan_id is not a content-address of the plan body: stored {stored}, recomputed {recomputed}"
+)]
+pub struct PlanIdMismatch {
+    pub stored: String,
+    pub recomputed: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::digest_shape::{Sha256PrefixedShape, validate_sha256_prefixed};
+    use crate::plan::test_support::PlanFixture;
+
+    fn plan() -> ExecutionPlan {
+        PlanFixture::new().build()
+    }
+
+    #[test]
+    fn compute_is_deterministic() {
+        let p = plan();
+        assert_eq!(compute_plan_id(&p), compute_plan_id(&p));
+    }
+
+    #[test]
+    fn id_has_sha256_prefixed_shape() {
+        // Reuse the one shared shape validator so this id can never drift from
+        // the checkpoint/OCI/semantic-address content-address wire shape.
+        let id = compute_plan_id(&plan());
+        assert!(matches!(
+            validate_sha256_prefixed(&id.0),
+            Sha256PrefixedShape::Ok
+        ));
+        assert_eq!(id.0.len(), SHA256_PREFIX.len() + 64);
+    }
+
+    #[test]
+    fn identical_content_yields_identical_id() {
+        // Two independently-built plans with identical load-bearing content
+        // (same nonce, same window) address to the same id.
+        let from = chrono::Utc::now();
+        let until = from + chrono::Duration::minutes(10);
+        let a = PlanFixture::new()
+            .nonce([4u8; 16])
+            .validity(from, until)
+            .build();
+        let b = PlanFixture::new()
+            .nonce([4u8; 16])
+            .validity(from, until)
+            .build();
+        assert_eq!(compute_plan_id(&a), compute_plan_id(&b));
+    }
+
+    #[test]
+    fn excludes_plan_id_field_no_circularity() {
+        // Altering the id the derivation is over must not move the address —
+        // otherwise the id would depend on its own value.
+        let mut p = plan();
+        let base = compute_plan_id(&p);
+        p.plan_id = PlanId("something-entirely-different".to_string());
+        assert_eq!(base, compute_plan_id(&p));
+        p.plan_id = PlanId(base.0.clone());
+        assert_eq!(base, compute_plan_id(&p));
+    }
+
+    #[test]
+    fn changing_any_load_bearing_field_changes_id() {
+        let base_plan = plan();
+        let base = compute_plan_id(&base_plan);
+
+        let mut p = base_plan.clone();
+        p.tenant.0 = "other-tenant".to_string();
+        assert_ne!(base, compute_plan_id(&p), "tenant");
+
+        let mut p = base_plan.clone();
+        p.workload.0 = "other-workload".to_string();
+        assert_ne!(base, compute_plan_id(&p), "workload");
+
+        let mut p = base_plan.clone();
+        p.resources.cpus += 1;
+        assert_ne!(base, compute_plan_id(&p), "resources.cpus");
+
+        let mut p = base_plan.clone();
+        p.image.sha256 = "b".repeat(64);
+        assert_ne!(base, compute_plan_id(&p), "image.sha256");
+
+        let mut p = base_plan.clone();
+        p.nonce = crate::plan::Nonce::from_bytes([0xcd; 16]);
+        assert_ne!(base, compute_plan_id(&p), "nonce");
+
+        let mut p = base_plan.clone();
+        p.valid_until += chrono::Duration::seconds(1);
+        assert_ne!(base, compute_plan_id(&p), "valid_until");
+
+        let mut p = base_plan;
+        p.plan_version += 1;
+        assert_ne!(base, compute_plan_id(&p), "plan_version");
+    }
+
+    #[test]
+    fn verify_accepts_a_content_addressed_plan() {
+        let mut p = plan();
+        p.plan_id = compute_plan_id(&p);
+        assert_eq!(verify_plan_id(&p), Ok(()));
+    }
+
+    #[test]
+    fn verify_rejects_an_id_that_is_not_the_content_address() {
+        let mut p = plan();
+        p.plan_id = compute_plan_id(&p);
+        let good = p.plan_id.0.clone();
+        p.plan_id = PlanId("sha256:not-the-real-address".to_string());
+        let err = verify_plan_id(&p).unwrap_err();
+        assert_eq!(err.stored, "sha256:not-the-real-address");
+        assert_eq!(err.recomputed, good);
+    }
+
+    #[test]
+    fn verify_rejects_after_a_load_bearing_field_is_mutated() {
+        // A tamper that keeps the old id but edits content: the recomputed
+        // address no longer matches, so the check fails closed.
+        let mut p = plan();
+        p.plan_id = compute_plan_id(&p);
+        p.resources.mem_mib += 1;
+        assert!(verify_plan_id(&p).is_err());
+    }
+}

--- a/crates/mvm-core/src/plan/content_id.rs
+++ b/crates/mvm-core/src/plan/content_id.rs
@@ -1,6 +1,13 @@
 //! Content-addressing for [`ExecutionPlan`]: a plan's `plan_id` is the SHA-256
 //! of its load-bearing content, rendered `sha256:<64 lowercase hex>`.
 //!
+//! This is a **per-execution** identity, not a workload identity: because the
+//! id commits to the full content — including the per-synthesis nonce and the
+//! validity window — it changes on every synthesis and every revision. The
+//! *stable* identity of a workload across executions is `(tenant, workload)`
+//! (the [`ExecutionPlan::tenant`] + [`ExecutionPlan::workload`] fields);
+//! `plan_id` addresses one concrete run of it.
+//!
 //! The id commits to every load-bearing field of the plan *except* the id
 //! itself — so a run is addressable and hash-linkable by digest, and two plans
 //! with identical content share an id. The per-synthesis nonce is part of that

--- a/crates/mvm-core/src/plan/mod.rs
+++ b/crates/mvm-core/src/plan/mod.rs
@@ -25,6 +25,7 @@
 //!   valid plan now".
 
 pub mod bundle;
+pub mod content_id;
 pub mod signing;
 pub mod synthesis;
 #[cfg(any(test, feature = "test-support"))]
@@ -45,6 +46,7 @@ pub use bundle::{
     TrustStore, VerifiedBundle, VerityInfo, bundle_sha256, read_and_verify_bundle, sha256_hex,
     signature_from_base64, signature_to_base64, verify_plan_bundle, write_bundle,
 };
+pub use content_id::{PlanIdMismatch, compute_plan_id, verify_plan_id};
 pub use execution_plan::{ExecutionPlan, SCHEMA_VERSION};
 pub use signing::{
     PlanVerifyError, SignedExecutionPlan, plan_from_admitted_json, redaction_from_signed_json,

--- a/crates/mvm-core/src/plan/signing.rs
+++ b/crates/mvm-core/src/plan/signing.rs
@@ -49,14 +49,21 @@ pub enum PlanVerifyError {
 
 /// Sign an `ExecutionPlan` with the given key.
 ///
-/// The plan is serialised to canonical JSON via `serde_json` (the
-/// same encoding `verify_plan` round-trips through), signed, and
-/// wrapped in a `SignedExecutionPlan` envelope. The `signer_id` is
-/// the human-readable name of the key inside the envelope — used
-/// by the verifier to look the corresponding `VerifyingKey` up in
-/// the trusted-keys set.
+/// The `plan_id` is (re-)derived as the content-address of the plan body
+/// immediately before signing, so a signed plan whose id does not address its
+/// content is unrepresentable through this API — the sole way to mint a valid
+/// envelope. A caller who already content-addressed the plan (e.g.
+/// [`crate::plan::synthesize_plan`]) gets the same id back; one who hands a
+/// stale or bogus id gets it corrected. The stamped plan is then serialised to
+/// canonical JSON via `serde_json` (the same encoding `verify_plan` round-trips
+/// through), signed, and wrapped in a `SignedExecutionPlan` envelope. The
+/// `signer_id` is the human-readable name of the key inside the envelope — used
+/// by the verifier to look the corresponding `VerifyingKey` up in the
+/// trusted-keys set.
 pub fn sign_plan(plan: &ExecutionPlan, key: &SigningKey, signer_id: &str) -> SignedExecutionPlan {
-    let payload = serde_json::to_vec(plan).expect("ExecutionPlan must serialise to JSON");
+    let mut plan = plan.clone();
+    plan.plan_id = crate::plan::compute_plan_id(&plan);
+    let payload = serde_json::to_vec(&plan).expect("ExecutionPlan must serialise to JSON");
     let signature: Signature = key.sign(&payload);
     SignedExecutionPlan(SignedPayload {
         payload,
@@ -299,11 +306,28 @@ mod tests {
 
     #[test]
     fn signed_plan_roundtrip() {
-        let plan = sample_plan();
+        // sign_plan stamps the content-address; give the fixture that id up
+        // front so the round-trip recovers a byte-identical plan.
+        let mut plan = sample_plan();
+        plan.plan_id = crate::plan::compute_plan_id(&plan);
         let (sk, vk) = fresh_key();
         let signed = sign_plan(&plan, &sk, "test-signer");
         let recovered = verify_plan(&signed, &[("test-signer", &vk)]).unwrap();
         assert_eq!(recovered, plan);
+    }
+
+    #[test]
+    fn sign_plan_stamps_content_address_over_a_bogus_id() {
+        // Handing sign_plan a plan carrying a wrong id yields an envelope whose
+        // inner plan is content-addressed — a mismatched signed plan cannot be
+        // produced through this API.
+        let mut plan = sample_plan();
+        plan.plan_id = PlanId("sha256:not-the-real-address".to_string());
+        let (sk, vk) = fresh_key();
+        let signed = sign_plan(&plan, &sk, "test-signer");
+        let recovered = verify_plan(&signed, &[("test-signer", &vk)]).unwrap();
+        assert_ne!(recovered.plan_id.0, "sha256:not-the-real-address");
+        assert!(crate::plan::verify_plan_id(&recovered).is_ok());
     }
 
     #[test]
@@ -350,6 +374,8 @@ mod tests {
                 address: "echo-key".into(),
             },
         }];
+        // Content-address after the last body edit so the decoded plan matches.
+        plan.plan_id = crate::plan::compute_plan_id(&plan);
         let (sk, _vk) = fresh_key();
         let signed = sign_plan(&plan, &sk, "test-signer");
         let json = serde_json::to_string(&signed).unwrap();
@@ -576,6 +602,7 @@ mod tests {
             crate::plan::DepsVolumeBinding::new("a".repeat(64), "b".repeat(64))
                 .expect("valid binding"),
         );
+        plan.plan_id = crate::plan::compute_plan_id(&plan);
         let (sk, vk) = fresh_key();
         let signed_a = sign_plan(&plan, &sk, "test-signer");
         let signed_b = sign_plan(&plan, &sk, "test-signer");

--- a/crates/mvm-core/src/plan/synthesis.rs
+++ b/crates/mvm-core/src/plan/synthesis.rs
@@ -30,7 +30,7 @@
 //! | Plan field | Where it comes from |
 //! |---|---|
 //! | `plan_id` | content-address of the finished plan (all load-bearing fields except the id itself) |
-//! | `plan_version` | always 1 for synthesized plans (mvmd revisions get higher numbers) |
+//! | `plan_version` | always 1 for synthesized plans; the revision counter under the stable `(tenant, workload)` identity (mvmd revisions get higher numbers) |
 //! | `tenant` | `--tenant` flag or default `"local"` |
 //! | `workload` | derived from `--name` or flake ref leaf |
 //! | `runtime_profile` | hypervisor flag mapped to a profile name |

--- a/crates/mvm-core/src/plan/synthesis.rs
+++ b/crates/mvm-core/src/plan/synthesis.rs
@@ -29,7 +29,7 @@
 //!
 //! | Plan field | Where it comes from |
 //! |---|---|
-//! | `plan_id` | fresh `Uuid::new_v4()` per invocation |
+//! | `plan_id` | content-address of the finished plan (all load-bearing fields except the id itself) |
 //! | `plan_version` | always 1 for synthesized plans (mvmd revisions get higher numbers) |
 //! | `tenant` | `--tenant` flag or default `"local"` |
 //! | `workload` | derived from `--name` or flake ref leaf |
@@ -171,13 +171,13 @@ pub struct SynthesisInput<'a> {
 
 /// Build an unsigned `ExecutionPlan` from CLI-shaped input.
 ///
-/// Generates a fresh `plan_id` (UUIDv4) and `nonce` (128 random bits)
-/// per invocation; the validity window starts at the call site's
-/// `now()` and lasts `VALIDITY_WINDOW_MINUTES`. The caller signs the
-/// returned plan via [`crate::plan::sign_plan`] before passing it to the
-/// supervisor.
+/// Generates a fresh `nonce` (128 random bits) per invocation and
+/// derives `plan_id` as the content-address of the finished plan (see
+/// [`crate::plan::compute_plan_id`]); the validity window starts at the
+/// call site's `now()` and lasts `VALIDITY_WINDOW_MINUTES`. The caller
+/// signs the returned plan via [`crate::plan::sign_plan`] before passing
+/// it to the supervisor — the signature covers the derived id.
 pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
-    let plan_id = PlanId(uuid::Uuid::new_v4().to_string());
     let nonce = fresh_nonce();
     let now = Utc::now();
 
@@ -238,12 +238,15 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
         entrypoint_present: true,
     };
 
-    Ok(ExecutionPlan {
+    let mut plan = ExecutionPlan {
         build_provenance: Default::default(),
         snapshot_at: Default::default(),
         network_mode: Default::default(),
         schema_version: SCHEMA_VERSION,
-        plan_id,
+        // Placeholder — overwritten below with the content-address once every
+        // load-bearing field is set. The derivation excludes `plan_id`, so this
+        // seed value never influences the result.
+        plan_id: PlanId(String::new()),
         plan_version: 1,
         tenant: TenantId(tenant_str.to_string()),
         workload: WorkloadId(input.vm_name.to_string()),
@@ -284,7 +287,12 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
         // deps-volume gate is skipped).
         deps_volume: input.deps_volume.clone(),
         shares: input.shares.clone(),
-    })
+    };
+
+    // Content-address the finished plan. The fresh nonce makes this unique per
+    // synthesis; the signature the caller applies next covers the derived id.
+    plan.plan_id = crate::plan::compute_plan_id(&plan);
+    Ok(plan)
 }
 
 /// Generate a fresh 128-bit nonce from `OsRng`. `crate::plan::Nonce`
@@ -436,9 +444,37 @@ mod tests {
 
     #[test]
     fn generates_unique_plan_id_per_call() {
+        // Fresh nonce per synthesis ⇒ distinct content ⇒ distinct
+        // content-address, even for byte-identical CLI input.
         let p1 = synthesize_plan(&input("myvm")).unwrap();
         let p2 = synthesize_plan(&input("myvm")).unwrap();
         assert_ne!(p1.plan_id, p2.plan_id);
+    }
+
+    #[test]
+    fn plan_id_is_the_content_address_of_the_plan() {
+        let plan = synthesize_plan(&input("myvm")).unwrap();
+        assert!(
+            plan.plan_id.0.starts_with("sha256:"),
+            "content-addressed, not a UUID: {}",
+            plan.plan_id.0
+        );
+        // The stored id equals the address recomputed from the plan body.
+        assert_eq!(crate::plan::verify_plan_id(&plan), Ok(()));
+        assert_eq!(plan.plan_id, crate::plan::compute_plan_id(&plan));
+    }
+
+    #[test]
+    fn signing_does_not_perturb_the_content_address() {
+        // The signature lives in the envelope, not the plan body, so the id a
+        // verified plan carries is exactly the address of its content.
+        let plan = synthesize_plan(&input("myvm")).unwrap();
+        let key = ed25519_dalek::SigningKey::from_bytes(&[5u8; 32]);
+        let signed = crate::plan::sign_plan(&plan, &key, "host:test");
+        let recovered =
+            crate::plan::verify_plan(&signed, &[("host:test", &key.verifying_key())]).unwrap();
+        assert_eq!(recovered.plan_id, plan.plan_id);
+        assert_eq!(crate::plan::verify_plan_id(&recovered), Ok(()));
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit/host_keypair.rs
+++ b/crates/mvm-hostd/src/audit/host_keypair.rs
@@ -382,7 +382,10 @@ mod tests {
     fn signs_plan_envelope_verifiable_via_pubkey() {
         let dir = fresh_keys_dir();
         let signer = load_or_init_at(dir.path()).expect("init");
-        let plan = fixture_plan();
+        // sign_plan stamps the content-address; give the fixture that id so the
+        // recovered plan matches.
+        let mut plan = fixture_plan();
+        plan.plan_id = mvm_core::plan::compute_plan_id(&plan);
 
         let signer_id = "host:test";
         let signed = sign_plan(&plan, &signer.signing, signer_id);

--- a/crates/mvm-hostd/src/firecracker_bridge/parse.rs
+++ b/crates/mvm-hostd/src/firecracker_bridge/parse.rs
@@ -227,7 +227,10 @@ mod tests {
         use mvm_core::plan::sign_plan;
         use mvm_core::plan::signing::test_support::sample_plan;
 
-        let plan = sample_plan();
+        // sign_plan stamps the content-address; give the fixture that id so the
+        // decoded inner plan matches.
+        let mut plan = sample_plan();
+        plan.plan_id = mvm_core::plan::compute_plan_id(&plan);
         let sk = SigningKey::from_bytes(&[7u8; 32]);
         let signed = sign_plan(&plan, &sk, "test-signer");
         // This is exactly what stash_plan_for_bridge persists.

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -49,7 +49,7 @@ use ed25519_dalek::VerifyingKey;
 use mvm_core::plan::bundle::{BundleResolver, TrustStore};
 use mvm_core::plan::{
     ExecutionPlan, NonceStore, PlanId, PlanValidityError, SignedExecutionPlan, check_window,
-    sign_plan, verify_plan, verify_plan_bundle,
+    sign_plan, verify_plan, verify_plan_bundle, verify_plan_id,
 };
 use mvm_core::policy::PolicyBundle;
 use std::sync::Mutex;
@@ -153,6 +153,11 @@ pub fn admit_for_run(
     let signed = sign_plan(&plan, &signer.signing, &signer_id);
     let trusted: [(&str, &VerifyingKey); 1] = [(&signer_id, &signer.verifying)];
     let verified = verify_plan(&signed, &trusted).context("verifying just-signed plan")?;
+
+    // The plan_id is the content-address of the plan body — recompute it and
+    // refuse a plan whose stored id doesn't match, so a run is only ever
+    // admitted under an id that genuinely addresses its content.
+    verify_plan_id(&verified).context("plan_id content-address check")?;
 
     // Validity window — refuses plans whose now() is outside
     // [valid_from, valid_until). For freshly-synthesized plans this
@@ -651,6 +656,27 @@ mod tests {
             [(&admitted.signer_id, &signer.verifying)];
         let recovered = mvm_core::plan::verify_plan(&admitted.signed, &trusted).unwrap();
         assert_eq!(recovered.plan_id, admitted.plan_id);
+    }
+
+    #[test]
+    fn admitted_plan_id_is_a_content_address() {
+        let dir = tempfile::tempdir().unwrap();
+        let admitted = admit_for_run(
+            &fixture_input("vm1"),
+            &SystemClock,
+            &InMemoryNonceLedger::new(),
+            Some(dir.path()),
+            None,
+        )
+        .expect("happy path");
+        assert!(
+            admitted.plan_id.0.starts_with("sha256:"),
+            "content-addressed, not a UUID: {}",
+            admitted.plan_id.0
+        );
+        // The admission path enforces the content-address; the admitted plan
+        // re-derives to exactly its stored id.
+        assert_eq!(mvm_core::plan::verify_plan_id(&admitted.plan), Ok(()));
     }
 
     #[test]

--- a/crates/mvm-hostd/src/prelaunch.rs
+++ b/crates/mvm-hostd/src/prelaunch.rs
@@ -10,7 +10,7 @@
 use chrono::{DateTime, Utc};
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use libkrun_sys::{SupervisorAttachConfig, SupervisorBaseConfig, SupervisorConfig};
-use mvm_core::plan::{NonceStore, SignedExecutionPlan, check_window, verify_plan};
+use mvm_core::plan::{NonceStore, SignedExecutionPlan, check_window, verify_plan, verify_plan_id};
 
 /// Why an attach was refused. Every variant means the caller must NOT
 /// `start_enter` — the standby exits non-zero.
@@ -72,6 +72,11 @@ pub fn verify_and_merge_attach(
         .map_err(|e| AttachVerifyError::Envelope(e.to_string()))?;
     let plan = verify_plan(&signed, &[(signer_id.as_str(), &vk)])
         .map_err(|e| AttachVerifyError::PlanVerify(e.to_string()))?;
+
+    // The plan_id must be the content-address of the plan body. A
+    // signature-valid plan whose id doesn't address its content is refused
+    // before the caller may `start_enter`.
+    verify_plan_id(&plan).map_err(|e| AttachVerifyError::PlanVerify(e.to_string()))?;
 
     // G4 validity window + per-signer nonce-replay.
     check_window(&plan, now).map_err(|e| AttachVerifyError::Validity(e.to_string()))?;
@@ -223,5 +228,35 @@ mod tests {
         let err =
             verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
         assert!(matches!(err, AttachVerifyError::Validity(_)));
+    }
+
+    #[test]
+    fn rejects_plan_id_not_content_address() {
+        use ed25519_dalek::Signer;
+        use mvm_core::plan::PlanId;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (kp, key) = write_key(dir.path());
+        let now = Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap();
+        let plan = plan_around(now);
+
+        // A signature-valid envelope whose inner plan_id is NOT the
+        // content-address: sign_plan stamps, so mint the mismatch by hand —
+        // sign wrong-id bytes into the envelope shell with the on-disk key.
+        let mut signed = sign_plan(&plan, &key, "host:test");
+        let mut tampered = plan.clone();
+        tampered.plan_id = PlanId("sha256:not-the-content-address".into());
+        let payload = serde_json::to_vec(&tampered).unwrap();
+        signed.0.signature = key.sign(&payload).to_bytes().to_vec();
+        signed.0.payload = payload;
+
+        let bytes = attach_bytes(NONCE, serde_json::to_value(&signed).unwrap());
+        let mut store = NonceStore::new();
+        let err =
+            verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
+        assert!(
+            matches!(err, AttachVerifyError::PlanVerify(_)),
+            "got {err:?}"
+        );
     }
 }

--- a/crates/mvm-hostd/src/supervisor/aggregate.rs
+++ b/crates/mvm-hostd/src/supervisor/aggregate.rs
@@ -315,11 +315,14 @@ impl Supervisor {
         // Step 1.1: the plan_id must be the content-address of the plan body.
         // A signature-valid plan whose id does not address its content is
         // refused before any resource-allocating work, so a run is only ever
-        // launched under an id that genuinely addresses what ran.
+        // launched under an id that genuinely addresses what ran. The plan is
+        // signature-verified here, so its plan_id is trusted enough to bind a
+        // chain-signed rejection entry to — unlike the Step 1 signature failure
+        // above, which has no trusted plan to audit.
         if let Err(e) = mvm_core::plan::verify_plan_id(&plan) {
-            let err = SupervisorError::PlanVerify(e.to_string());
-            self.transition_or_warn(PlanState::Failed);
-            return Err(err);
+            self.emit_audit_then_fail(&plan, "plan.rejected.plan_id_mismatch", &e.to_string())
+                .await?;
+            return Err(SupervisorError::PlanVerify(e.to_string()));
         }
 
         // Step 1.5: time-window + nonce-replay
@@ -1685,10 +1688,24 @@ mod tests {
         signed.0.payload = payload;
 
         let backend = Arc::new(MockBackend::new());
-        let mut s = make_supervisor_with_backend(backend.clone());
+        let (mut s, audit) = make_supervisor_with_audit(backend.clone());
         let err = s.launch(&signed, &[("test", &vk)]).await.unwrap_err();
         assert!(matches!(err, SupervisorError::PlanVerify(_)), "got {err:?}");
         assert_eq!(backend.launches().len(), 0, "mismatched plan must not boot");
+
+        // The rejection is a chain-signed audit entry, like every other
+        // admission decision — no unaudited control-plane refusal.
+        assert_eq!(audit_events(&audit), vec!["plan.rejected.plan_id_mismatch"]);
+        let entry = &audit.entries()[0];
+        assert_eq!(entry.plan_id, tampered.plan_id);
+        assert!(
+            entry
+                .labels
+                .get("reason")
+                .is_some_and(|r| r.contains("content-address")),
+            "reason label names the mismatch: {:?}",
+            entry.labels
+        );
     }
 
     // ----- admission audit -----

--- a/crates/mvm-hostd/src/supervisor/aggregate.rs
+++ b/crates/mvm-hostd/src/supervisor/aggregate.rs
@@ -312,6 +312,16 @@ impl Supervisor {
             }
         };
 
+        // Step 1.1: the plan_id must be the content-address of the plan body.
+        // A signature-valid plan whose id does not address its content is
+        // refused before any resource-allocating work, so a run is only ever
+        // launched under an id that genuinely addresses what ran.
+        if let Err(e) = mvm_core::plan::verify_plan_id(&plan) {
+            let err = SupervisorError::PlanVerify(e.to_string());
+            self.transition_or_warn(PlanState::Failed);
+            return Err(err);
+        }
+
         // Step 1.5: time-window + nonce-replay
         // check. Without this, a captured signed plan is replayable
         // indefinitely. Both checks must pass before the backend is
@@ -1147,12 +1157,15 @@ mod tests {
     }
 
     fn sample_plan() -> ExecutionPlan {
-        ExecutionPlan {
+        let mut plan = ExecutionPlan {
             build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),
             schema_version: SCHEMA_VERSION,
-            plan_id: PlanId("01HXTEST0000000000000000".to_string()),
+            // Overwritten below with the content-address, matching what
+            // sign_plan stamps — so a test's `plan.plan_id` equals the id that
+            // actually launches and is audited.
+            plan_id: PlanId(String::new()),
             plan_version: 1,
             tenant: TenantId("tenant-a".to_string()),
             workload: WorkloadId("workload-1".to_string()),
@@ -1209,7 +1222,9 @@ mod tests {
             deps_volume: None,
             shares: Vec::new(),
             agent_verbs: None,
-        }
+        };
+        plan.plan_id = mvm_core::plan::compute_plan_id(&plan);
+        plan
     }
 
     fn sign_sample(plan: &ExecutionPlan) -> (SignedExecutionPlan, SigningKey, VerifyingKey) {
@@ -1655,6 +1670,27 @@ mod tests {
         assert_eq!(backend.launches().len(), 2);
     }
 
+    #[tokio::test]
+    async fn launch_rejects_plan_id_not_content_address() {
+        use ed25519_dalek::Signer;
+
+        // A signature-valid envelope whose inner plan_id is NOT the
+        // content-address: sign_plan stamps, so mint the mismatch by hand.
+        let plan = sample_plan();
+        let (mut signed, sk, vk) = sign_sample(&plan);
+        let mut tampered = plan.clone();
+        tampered.plan_id = mvm_core::plan::PlanId("sha256:not-the-content-address".into());
+        let payload = serde_json::to_vec(&tampered).unwrap();
+        signed.0.signature = sk.sign(&payload).to_bytes().to_vec();
+        signed.0.payload = payload;
+
+        let backend = Arc::new(MockBackend::new());
+        let mut s = make_supervisor_with_backend(backend.clone());
+        let err = s.launch(&signed, &[("test", &vk)]).await.unwrap_err();
+        assert!(matches!(err, SupervisorError::PlanVerify(_)), "got {err:?}");
+        assert_eq!(backend.launches().len(), 0, "mismatched plan must not boot");
+    }
+
     // ----- admission audit -----
 
     /// Convenience: collect just the `event` strings from captured
@@ -1731,6 +1767,9 @@ mod tests {
     async fn admission_refuses_sealed_plan_with_absent_entrypoint() {
         let mut plan = sample_plan();
         plan.image.entrypoint_present = false;
+        // Re-address after the edit so the fixture's id matches what sign_plan
+        // stamps and what the audit chain records.
+        plan.plan_id = mvm_core::plan::compute_plan_id(&plan);
         let (signed, _sk, vk) = sign_sample(&plan);
         let backend = Arc::new(MockBackend::new());
         let (mut s, _audit) = make_supervisor_with_audit(backend.clone());
@@ -1748,6 +1787,9 @@ mod tests {
     async fn admission_emits_plan_failed_entrypoint_absent_audit_entry() {
         let mut plan = sample_plan();
         plan.image.entrypoint_present = false;
+        // Re-address after the edit so the fixture's id matches what sign_plan
+        // stamps and what the audit chain records.
+        plan.plan_id = mvm_core::plan::compute_plan_id(&plan);
         let (signed, _sk, vk) = sign_sample(&plan);
         let backend = Arc::new(MockBackend::new());
         let (mut s, audit) = make_supervisor_with_audit(backend.clone());
@@ -2431,6 +2473,7 @@ mod tests {
     ) -> Result<ExecutionPlan, mvm_core::plan::DepsVolumeBindingError> {
         let mut plan = sample_plan();
         plan.deps_volume = Some(DepsVolumeBinding::new(volume_hash, manifest_sha256)?);
+        plan.plan_id = mvm_core::plan::compute_plan_id(&plan);
         Ok(plan)
     }
 
@@ -2515,6 +2558,7 @@ mod tests {
         fs::write(final_vol_dir.join(FILE_CVE), b"{\"results\":[\"FORGED\"]}").unwrap();
         let mut tampered_plan = plan.clone();
         tampered_plan.nonce = Nonce::from_bytes([0xcd; 16]); // fresh nonce
+        tampered_plan.plan_id = mvm_core::plan::compute_plan_id(&tampered_plan);
         let (signed, _sk, vk) = sign_sample(&tampered_plan);
         let backend = Arc::new(MockBackend::new());
         let (mut s, audit) = make_supervisor_with_audit(backend.clone());

--- a/crates/mvm-protocol/src/plan/execution_plan.rs
+++ b/crates/mvm-protocol/src/plan/execution_plan.rs
@@ -41,11 +41,15 @@ pub struct ExecutionPlan {
     /// Stable plan identifier. Audit entries reference this verbatim.
     pub plan_id: PlanId,
 
-    /// Monotonic per-`plan_id` revision counter. Bumped each time
-    /// mvmd publishes a revised plan with the same id (eg. policy
-    /// changes). The supervisor logs both id+version on every
-    /// audit entry so "which version of the plan was running" is
-    /// answerable from audit alone.
+    /// Monotonic revision counter under the stable workload identity
+    /// `(tenant, workload)`. `plan_id` is a per-execution content-address
+    /// that changes on every synthesis/revision, so it does not stay
+    /// constant across revisions — `plan_version` is what increments as
+    /// mvmd publishes revised plans for the same workload (eg. policy
+    /// changes). The supervisor logs `plan_id` + `plan_version` +
+    /// `(tenant, workload)` on every audit entry, so both "which exact
+    /// run" (`plan_id`) and "which revision of the workload"
+    /// (`plan_version`) are answerable from audit alone.
     pub plan_version: u32,
 
     pub tenant: TenantId,

--- a/crates/mvm-protocol/src/plan/types.rs
+++ b/crates/mvm-protocol/src/plan/types.rs
@@ -87,10 +87,13 @@ pub struct BuildProvenance {
     pub artifacts: ArtifactDigests,
 }
 
-/// Stable identifier for an `ExecutionPlan` instance. Currently a
-/// ULID; we keep the type opaque so the constructor can switch
-/// generators (UUIDv7, snowflake, etc.) without touching the wire
-/// format. Audit entries reference this id verbatim.
+/// Stable identifier for an `ExecutionPlan` instance. Synthesis derives it
+/// as the content-address of the plan body — `sha256:<64 lowercase hex>` over
+/// every load-bearing field except the id itself — so a run is addressable and
+/// hash-linkable by digest. The type stays an opaque `String` newtype: the
+/// derivation lives in `mvm-core` (which owns the hashing crates), and this
+/// no_std DTO crate only carries the value across the wire. Audit entries
+/// reference this id verbatim.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct PlanId(pub String);

--- a/crates/mvm-protocol/src/policy/bundle.rs
+++ b/crates/mvm-protocol/src/policy/bundle.rs
@@ -17,9 +17,11 @@ use crate::policy::policies::{
 pub const SCHEMA_VERSION: u32 = 1;
 
 /// Stable identifier for a `PolicyBundle`. Audit entries reference
-/// `(bundle_id, bundle_version)` alongside the plan's
-/// `(plan_id, plan_version)` so a runbook can answer "which policy
-/// was in force when this audit entry was written?" in O(1).
+/// `(bundle_id, bundle_version)` alongside the plan's `plan_id` and its
+/// stable `(tenant, workload)` identity so a runbook can answer "which
+/// policy was in force when this audit entry was written?" in O(1).
+/// Correlate across a workload's revisions by `(tenant, workload)`; pin
+/// one concrete execution by the per-execution `plan_id` content-address.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct PolicyId(pub String);

--- a/xtask/src/check_content_address_determinism.rs
+++ b/xtask/src/check_content_address_determinism.rs
@@ -1,0 +1,152 @@
+//! `xtask check-content-address-determinism`
+//!
+//! The plan_id and checkpoint content-addresses are `sha256(serde_json(...))`
+//! over a value whose object keys must serialize in a stable order. `serde_json`
+//! sorts object keys only while its `preserve_order` feature is **off**; with it
+//! on, keys emit in insertion order and the same logical content can hash two
+//! ways across builds — silently breaking every content-address and its
+//! hash-linked lineage.
+//!
+//! Nothing in the normal dependency graph enables `preserve_order` today, and
+//! the feature resolver keeps build-dependency features (some transitive
+//! build-deps do pull it in) separate from the normal-dependency unit. This gate
+//! pins that invariant: the **non-build** `serde_json` unit reachable from
+//! `mvm-core` and `mvm-protocol` must not carry `preserve_order`. It reads the
+//! resolved feature set from `cargo tree` rather than the lockfile, because
+//! whether a feature is on is a resolution fact, not a lockfile-name fact — the
+//! same posture as `check-core-runtime-free`.
+
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+use std::process::Command;
+
+/// Crates whose runtime `serde_json` unit derives content-addresses.
+const CRATES: &[&str] = &["mvm-core", "mvm-protocol"];
+
+/// The feature whose presence on `serde_json` would break key-order determinism.
+const FORBIDDEN_FEATURE: &str = "preserve_order";
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let mut offenders: Vec<String> = Vec::new();
+    for crate_name in CRATES {
+        let tree = serde_json_normal_tree(&cargo, workspace, crate_name)?;
+        for line in serde_json_lines_with(&tree, FORBIDDEN_FEATURE) {
+            offenders.push(format!("{crate_name}: {line}"));
+        }
+    }
+
+    if !offenders.is_empty() {
+        bail!(
+            "check-content-address-determinism: a non-build serde_json unit reachable from \
+             mvm-core/mvm-protocol carries the `{FORBIDDEN_FEATURE}` feature. That makes \
+             serde_json emit object keys in insertion order instead of sorted order, so the \
+             plan_id and checkpoint content-addresses would hash non-deterministically across \
+             builds. A workspace member likely enabled it on a normal (non-build) serde_json \
+             dependency. Offending unit(s):\n  {}",
+            offenders.join("\n  ")
+        );
+    }
+
+    eprintln!(
+        "check-content-address-determinism: clean (serde_json reachable from \
+         mvm-core/mvm-protocol has no `{FORBIDDEN_FEATURE}`)"
+    );
+    Ok(())
+}
+
+/// `cargo tree` for `crate_name`'s **normal** dependency unit, with each node's
+/// resolved feature set. `-e no-dev,no-build` excludes dev- and build-deps so
+/// the serde_json shown is the one linked into the crate's runtime code — the
+/// unit whose key-order determinism the content-addresses depend on.
+fn serde_json_normal_tree(cargo: &str, workspace: &Path, crate_name: &str) -> Result<String> {
+    let output = Command::new(cargo)
+        .current_dir(workspace)
+        .args([
+            "tree",
+            "-p",
+            crate_name,
+            "-e",
+            "no-dev,no-build",
+            "--prefix",
+            "none",
+            "--format",
+            "{p} {f}",
+            "--locked",
+        ])
+        .output()
+        .with_context(|| format!("running `cargo tree -p {crate_name} -e no-dev,no-build`"))?;
+
+    if !output.status.success() {
+        bail!(
+            "cargo tree failed for {crate_name}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Lines of a `cargo tree --prefix none --format "{p} {f}"` dump that are the
+/// `serde_json` **package** and whose resolved feature set contains `feature`.
+///
+/// Keyed on the first column being exactly `serde_json`, so a feature named
+/// `serde_json` on some other crate's line (e.g. `tracing-subscriber`) is never
+/// mistaken for the crate itself.
+fn serde_json_lines_with(tree: &str, feature: &str) -> Vec<String> {
+    tree.lines()
+        .filter(|line| line.split_whitespace().next() == Some("serde_json"))
+        .filter(|line| line_lists_feature(line, feature))
+        .map(|line| line.trim().to_string())
+        .collect()
+}
+
+/// Whether `line` lists `feature` as one of its comma-joined features. The `{f}`
+/// column is comma-separated; splitting each whitespace token on `,` and testing
+/// whole-token equality avoids matching a version or a substring.
+fn line_lists_feature(line: &str, feature: &str) -> bool {
+    line.split_whitespace()
+        .flat_map(|tok| tok.split(','))
+        .any(|f| f == feature)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_tree_has_no_offenders() {
+        let tree = "mvm-core v0.18.0 \n\
+                    serde_json v1.0.150 alloc,default,float_roundtrip,std\n\
+                    serde v1.0.0 alloc,derive,std\n";
+        assert!(serde_json_lines_with(tree, "preserve_order").is_empty());
+    }
+
+    #[test]
+    fn preserve_order_on_serde_json_is_flagged() {
+        // Proof of teeth: the serde_json unit carrying preserve_order is caught.
+        let tree = "mvm-core v0.18.0 \n\
+                    serde_json v1.0.150 alloc,default,preserve_order,std (*)\n";
+        let hits = serde_json_lines_with(tree, "preserve_order");
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].contains("preserve_order"));
+    }
+
+    #[test]
+    fn preserve_order_on_another_crate_is_not_serde_json() {
+        // `serde_json` appears here only as a FEATURE of another crate, which
+        // also (synthetically) carries `preserve_order`. The gate keys on the
+        // package in column 1, so neither is mistaken for the serde_json crate.
+        let tree = "tracing-subscriber v0.3.23 alloc,serde_json,preserve_order,std\n\
+                    serde_json v1.0.150 alloc,std\n";
+        assert!(serde_json_lines_with(tree, "preserve_order").is_empty());
+    }
+
+    #[test]
+    fn real_shape_line_with_version_and_dedup_marker_parses() {
+        // The exact `{p} {f}` shape cargo tree emits, including the `(*)`
+        // dedup marker: no false positive on preserve_order, real features found.
+        let tree = "serde_json v1.0.150 alloc,default,float_roundtrip,std (*)\n";
+        assert!(serde_json_lines_with(tree, "preserve_order").is_empty());
+        assert_eq!(serde_json_lines_with(tree, "float_roundtrip").len(), 1);
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,6 +15,7 @@ mod check_builder_shell_job_sites;
 mod check_claim_catalog;
 mod check_cli_runtime_surface;
 mod check_closure_budget;
+mod check_content_address_determinism;
 mod check_core_runtime_free;
 mod check_doc_claims;
 mod check_duplicate_majors;
@@ -96,6 +97,10 @@ fn main() -> Result<()> {
         Some("check-core-runtime-free") => {
             let workspace = workspace_root();
             check_core_runtime_free::run(&workspace)
+        }
+        Some("check-content-address-determinism") => {
+            let workspace = workspace_root();
+            check_content_address_determinism::run(&workspace)
         }
         Some("check-builder-shell-job-sites") => {
             let workspace = workspace_root();
@@ -213,7 +218,7 @@ fn main() -> Result<()> {
             ir_parity::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-trust-gradient, check-vsock-only-egress, check-uniform-vsock-egress, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-trust-gradient, check-vsock-only-egress, check-uniform-vsock-egress, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {
@@ -242,6 +247,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-core-runtime-free                 Plan 126 B5: assert mvm-core's default build pulls no tokio"
+            );
+            eprintln!(
+                "  check-content-address-determinism       Assert serde_json in mvm-core/mvm-protocol has no preserve_order (stable key order → deterministic plan_id/checkpoint digests)"
             );
             eprintln!(
                 "  check-builder-shell-job-sites           Plan 204 WS-D: freeze the set of files that construct a legacy builder shell-job request"


### PR DESCRIPTION
Implements #1807 (part of the provable-state-DAG epic #1806).

`plan_id` becomes a **per-execution content-address** (`sha256:<hex>` over the
canonical `ExecutionPlan` minus the `plan_id` field), replacing the random
UUID, so a run is addressable and hash-linkable by digest.

## Identity model
- `plan_id` = per-execution identity — changes every synthesis/revision.
- Stable workload identity = the **existing** `(tenant, workload)` — no new
  identifier introduced (reuse-first).
- `plan_version` = monotonic revision counter under `(tenant, workload)`.

## What's here
- Content-address derivation reuses the checkpoint-digest pattern (`sha2` +
  the shared `sha256:<hex>` validator).
- **Determinism guard:** new `xtask check-content-address-determinism` asserts
  the normal `serde_json` unit for `mvm-core`/`mvm-protocol` lacks
  `preserve_order` (proven to fail if it's enabled). Also protects the existing
  checkpoint digest. Wired into the CI lint job.
- **Enforced at all three admission doors** (`admit_for_run`,
  `Supervisor::launch`, `verify_and_merge_attach`) and derived inside
  `sign_plan`, so a mismatched signed plan is unrepresentable.
- Docs updated for the identity split; stale `UUIDv4` CLI help fixed.

## Deferred (tracked, latent)
#1813 re-keys workload-lifetime firewall/`DekBinding` state onto
`(tenant, workload)` — only matters under mvmd's not-yet-live hot policy-revision
path; the current `mvmctl up` / `stop` flow is correct as-is.

## Verification
- Two-stage adversarial review (correctness + security) on the crypto core;
  focused delta review on the enforcement wiring.
- `cargo nextest run --workspace` → 7611 passed, 0 failed, 12 skipped.
- Doctests, `clippy -D warnings`, nightly `fmt --all --check`, and the new
  `xtask` guard all clean.
