### PR TITLE
docs(mvm-hostd): document the two audit-chain canonicalizations + spine test (#1810)

### DIFF
--- a/crates/mvm-hostd/tests/audit_chain_spine.rs
+++ b/crates/mvm-hostd/tests/audit_chain_spine.rs
@@ -1,0 +1,175 @@
+//! One provable audit spine across both chain-signed logs.
+//!
+//! mvm keeps two audit chains that canonicalize differently on purpose (see
+//! specs/notes/2026-07-24-audit-chain-two-canonicalizations.md):
+//!
+//! - the host-lifecycle chain (`FileAuditSigner` / `verify_audit_chain`) signs a
+//!   fixed-shape struct in `serde_json` declaration order and has a `no_std`
+//!   browser mirror; and
+//! - the per-VM workload chain (`Chain` / `verify_workload_chain`) signs a
+//!   dynamic field bag through JCS (`serde_jcs`) and is host-only.
+//!
+//! This test anchors BOTH to the same Ed25519 host key and proves they compose
+//! into one coherent, tamper-evident spine: each verifier accepts its valid
+//! chain and each rejects a tampered variant.
+
+use std::collections::BTreeMap;
+
+use chrono::Utc;
+use ed25519_dalek::SigningKey;
+use tempfile::tempdir;
+
+use mvm_core::plan::{PlanId, TenantId};
+
+use mvm_hostd::audit_signer::canonical::CanonicalEntry;
+use mvm_hostd::audit_signer::chain::{Chain, OnDiskEntry};
+use mvm_hostd::audit_signer::verify::{WorkloadVerifyError, verify_workload_chain};
+use mvm_hostd::supervisor::audit::{AuditEntry, AuditSigner};
+use mvm_hostd::supervisor::audit_file::{FileAuditSigner, VerifyError, verify_audit_chain};
+
+/// Fresh host key, following the workspace's explicit seed-fill idiom.
+fn host_key() -> SigningKey {
+    let mut seed = [0u8; 32];
+    rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut seed);
+    SigningKey::from_bytes(&seed)
+}
+
+fn lifecycle_entry(tenant: &str, event: &str) -> AuditEntry {
+    AuditEntry {
+        timestamp: Utc::now(),
+        tenant: TenantId(tenant.to_string()),
+        plan_id: PlanId("plan-1".to_string()),
+        plan_version: 1,
+        bundle_id: None,
+        bundle_version: None,
+        image_name: "worker".to_string(),
+        image_sha256: "abc123".to_string(),
+        event: event.to_string(),
+        labels: BTreeMap::new(),
+    }
+}
+
+fn workload_entry(prev_hash: &str, fields: serde_json::Value) -> CanonicalEntry {
+    CanonicalEntry {
+        category: "workload_audit".into(),
+        correlation_id: "01HCORR0000000000000000".into(),
+        fields,
+        prev_hash: prev_hash.into(),
+        session_id: "sess-001".into(),
+        tenant_id: "spine-tenant".into(),
+        ts: "2026-07-24T00:00:00Z".into(),
+        workload_id: "wl-001".into(),
+    }
+}
+
+/// The spine: both chains, one host key, valid-accept + tamper-reject on each.
+#[tokio::test]
+async fn both_audit_chains_verify_and_reject_tamper_under_one_host_key() {
+    let dir = tempdir().unwrap();
+    let key = host_key();
+    let verifying_key = key.verifying_key();
+
+    // ---- Chain A: host lifecycle (declaration-order serde_json) ---------------
+    let lifecycle_dir = dir.path().join("lifecycle");
+    let signer = FileAuditSigner::open(key.clone(), &lifecycle_dir).unwrap();
+    for event in ["plan.admitted", "plan.launched", "plan.failed"] {
+        signer
+            .sign_and_emit(&lifecycle_entry("spine-tenant", event))
+            .await
+            .unwrap();
+    }
+    let lifecycle_path = signer.tenant_path("spine-tenant");
+    assert_eq!(
+        verify_audit_chain(&lifecycle_path, &verifying_key).unwrap(),
+        3,
+        "valid lifecycle chain must verify all three entries"
+    );
+
+    // ---- Chain B: per-VM workload (JCS via serde_jcs), SAME host key ----------
+    let workload_path = dir.path().join("spine-tenant.workload.jsonl");
+    let head_path = dir.path().join("HEAD");
+    let key_path = dir.path().join("chain.key");
+    std::fs::write(&key_path, key.to_bytes()).unwrap();
+    let mut chain = Chain::open(&workload_path, &head_path, Some(&key_path)).unwrap();
+    assert_eq!(
+        chain.pub_key(),
+        verifying_key.to_bytes().to_vec(),
+        "both chains are anchored to the one host key"
+    );
+    for _ in 0..3 {
+        let entry = workload_entry(chain.head(), serde_json::json!({"verb": "now"}));
+        chain.append(entry).expect("workload append must succeed");
+    }
+    assert_eq!(
+        verify_workload_chain(&workload_path, &verifying_key).unwrap(),
+        3,
+        "valid workload chain must verify all three entries"
+    );
+
+    // ---- Tamper Chain A: flip the first event; signature must break -----------
+    let content = std::fs::read_to_string(&lifecycle_path).unwrap();
+    // Same-length swap keeps the JSON well-formed but off the signed bytes.
+    let tampered = content.replacen("plan.admitted", "plan.smuggled", 1);
+    std::fs::write(&lifecycle_path, tampered).unwrap();
+    let err = verify_audit_chain(&lifecycle_path, &verifying_key)
+        .expect_err("tampered lifecycle chain must fail closed");
+    assert!(
+        matches!(err, VerifyError::SignatureInvalid { line: 0 }),
+        "got {err:?}"
+    );
+
+    // ---- Tamper Chain B: rewrite the first entry_hash; chain link must break --
+    let mut lines: Vec<String> = std::fs::read_to_string(&workload_path)
+        .unwrap()
+        .lines()
+        .map(str::to_string)
+        .collect();
+    let mut first: OnDiskEntry = serde_json::from_str(&lines[0]).unwrap();
+    first.entry_hash = "0".repeat(64);
+    lines[0] = serde_json::to_string(&first).unwrap();
+    std::fs::write(&workload_path, format!("{}\n", lines.join("\n"))).unwrap();
+    let err = verify_workload_chain(&workload_path, &verifying_key)
+        .expect_err("tampered workload chain must fail closed");
+    assert!(
+        matches!(err, WorkloadVerifyError::EntryHashMismatch { line: 0 }),
+        "got {err:?}"
+    );
+}
+
+/// Workload-chain self-consistency across Unicode key planes.
+///
+/// The workload chain's dynamic `fields` can carry non-ASCII object keys. Its
+/// verifier re-canonicalizes with the same `serde_jcs`, so it stays internally
+/// self-consistent regardless of key plane — including astral-plane (> U+FFFF)
+/// keys where `serde_jcs`'s UTF-8 sort would diverge from a strict RFC 8785
+/// UTF-16 verifier. This pins the "document, don't guard" decision: no mismatch
+/// exists inside mvm; the caveat is only for a hypothetical external verifier.
+#[test]
+fn workload_chain_is_self_consistent_across_unicode_key_planes() {
+    let dir = tempdir().unwrap();
+    let key = host_key();
+    let key_path = dir.path().join("chain.key");
+    std::fs::write(&key_path, key.to_bytes()).unwrap();
+    let workload_path = dir.path().join("spine-tenant.workload.jsonl");
+    let head_path = dir.path().join("HEAD");
+    let mut chain = Chain::open(&workload_path, &head_path, Some(&key_path)).unwrap();
+
+    // BMP non-ASCII ("café", "你好") plus an astral-plane key (U+1F600) in one bag.
+    let fields = serde_json::json!({
+        "café": 1,
+        "你好": 2,
+        "\u{1F600}": 3,
+        "\u{FFFF}": 4,
+        "a": 5,
+    });
+    let entry = workload_entry(chain.head(), fields);
+    chain
+        .append(entry)
+        .expect("append with unicode keys must succeed");
+
+    assert_eq!(
+        verify_workload_chain(&workload_path, &key.verifying_key()).unwrap(),
+        1,
+        "the same serde_jcs writes and re-canonicalizes, so any key plane verifies"
+    );
+}

--- a/specs/notes/2026-07-24-audit-chain-two-canonicalizations.md
+++ b/specs/notes/2026-07-24-audit-chain-two-canonicalizations.md
@@ -1,0 +1,138 @@
+# Two audit chains, two canonicalizations — the deliberate design
+
+_2026-07-24 — resolves the re-scoped workstream D of #1810._
+
+## Context
+
+#1810 originally proposed converging mvm's two chain-signed audit logs onto a
+single canonicalization (JCS / RFC 8785). Investigation rejected that: the two
+chains sign payloads of different *shapes*, each canonicalization is the correct
+one for its shape, and the constraint that blocks convergence
+(`serde_jcs` is std-only, so it cannot enter the `no_std` browser mirror) is
+structural, not incidental. This note records the design so a future reader does
+not re-file the same "inconsistency".
+
+There are two chains. They are not redundant — they attest different things and
+are read by different verifiers — and they are, together, one provable spine:
+both are Ed25519-signed under the **same** host key, both fail closed on tamper,
+and the integration test `audit_chain_spine` (in `mvm-hostd/tests/`) proves each
+verifier accepts its valid chain and rejects a tampered one.
+
+## Chain A — host lifecycle chain
+
+- **Writer / verifier:** `mvm-hostd/src/supervisor/audit_file.rs`
+  (`FileAuditSigner`, `verify_audit_chain`).
+- **Stream:** `~/.mvm/audit/<tenant>.jsonl`, one `SignedEnvelope` per line.
+- **Signed bytes:** `serde_json::to_vec(entry) || prev_hash`, where `entry` is a
+  **fixed-shape** `AuditEntry` struct (timestamp, tenant, plan id/version,
+  optional bundle id/version, image name/digest, event, `BTreeMap` labels).
+- **Canonicalization:** *none needed.* The struct's field order is fixed at
+  compile time and `serde_json` emits in declaration order (this workspace does
+  not enable `serde_json/preserve_order`). The one map, `labels`, is a
+  `BTreeMap`, so its key order is already canonical. The byte stream is therefore
+  deterministic and — critically — **reproducible from the struct definition
+  alone**, with no sorting pass.
+- **Browser mirror:** `mvm-protocol/src/verify.rs`
+  (`verify_audit_chain_bytes`, `MirrorEntry`) re-implements the exact same
+  verification in `#![no_std]` + `alloc`, so anyone can audit a downloaded log in
+  a browser tab (`web/audit-verify/`) with no host and no trusted server. The
+  mirror reproduces `AuditEntry`'s serde shape field-for-field. The
+  equivalence is pinned by `mvm_verify_matches_supervisor_chain` in
+  `audit_file.rs`: if the upstream struct drifts, a genuine line stops
+  verifying and CI fails loudly rather than only the browser tool breaking.
+
+## Chain B — per-VM workload chain
+
+- **Writer / verifier:** `mvm-hostd/src/audit_signer/` (`Chain::append` in
+  `chain.rs`, `verify_workload_chain` in `verify.rs`, `CanonicalEntry` in
+  `canonical.rs`).
+- **Stream:** `~/.mvm/audit/<tenant>.workload.jsonl`, one `OnDiskEntry` per
+  line (base64 canonical bytes + signature + `sig_alg` + `entry_hash`).
+- **Signed bytes:** the JCS-canonical form of a `CanonicalEntry`, which carries
+  a **dynamic** `fields: serde_json::Value`. `fields` is populated per-category
+  and, for `workload_audit` entries, reflects data the workload itself supplied
+  through `host.audit.v1`. Its object-key order is *not* struct-controlled.
+- **Canonicalization:** JCS (RFC 8785) via `serde_jcs::to_vec`
+  (`CanonicalEntry::jcs_bytes`). A dynamic value bag has no compile-time key
+  order, so a canonicalization pass that sorts object keys is genuinely
+  required to make the signed bytes deterministic and standalone-verifiable.
+  The verifier re-canonicalizes the parsed entry and rejects any line whose
+  stored bytes are not exactly the JCS re-serialization (`NonCanonical`), so a
+  non-canonical blob cannot enter through the writer or survive replay.
+- **Browser mirror:** none today. Host-only. `verify_workload_chain` is the sole
+  verifier and runs behind `mvmctl trust audit verify`.
+
+## Why the two canonicalizations don't converge
+
+The shapes force the choice:
+
+- Chain A signs a fixed struct → declaration-order `serde_json` is already
+  canonical and is trivially reproducible in a `no_std` mirror that mirrors the
+  struct field-for-field. Adding a sorting pass would buy nothing and would only
+  create a second thing that could drift from the mirror.
+- Chain B signs a dynamic `Value` → there is no struct order to lean on, so JCS
+  key-sorting is load-bearing.
+
+And the mirror constraint blocks moving A onto JCS even if we wanted uniformity:
+`serde_jcs` 0.1 is **std-only** — it writes through `std::io::Write`, uses
+`std::collections`, forces `serde_json/std`, and contains `unsafe`. It cannot
+compile to `wasm32-unknown-unknown` and therefore cannot enter `mvm-protocol`
+(which is `#![no_std]` + `forbid(unsafe_code)`, the wasm/browser foundation).
+So:
+
+- Chain A's browser mirror could not adopt JCS; Chain A keeps declaration-order.
+- Chain B, being host-only, can and does use `serde_jcs`; it has no wasm mirror
+  to keep in lockstep.
+
+Each scheme is correct for its payload. This is a deliberate split, not an
+inconsistency, and `mvm-protocol` must **not** take a `serde_jcs` dependency.
+
+## Astral-plane object-key ordering (Chain B caveat)
+
+`serde_jcs` 0.1 orders object keys by their serialized **UTF-8** bytes. RFC 8785
+mandates ordering by **UTF-16** code units. The two orders coincide for every
+code point up to U+FFFF and diverge only for astral-plane keys (> U+FFFF, e.g.
+emoji), where the UTF-16 leading surrogate `0xD800` sorts *below* U+FFFF —
+opposite to the UTF-8/scalar-value order. Chain B's dynamic `fields` could carry
+such a key.
+
+We **document** this rather than add a runtime guard, deliberately:
+
+1. The divergence is astral-plane-only, not "non-ASCII". An ASCII-only key guard
+   would wrongly reject benign BMP keys (`"café"`, `"你好"`); a precise
+   "> U+FFFF" guard is an oddly narrow special case.
+2. `verify_workload_chain` re-canonicalizes with the **same** `serde_jcs`, so
+   Chain B is internally self-consistent for any key plane — there is no actual
+   mismatch inside mvm. The `audit_chain_spine` integration test pins this with
+   an astral-plane `fields` key that still verifies.
+3. No external, spec-strict RFC 8785 verifier consumes Chain B today. The only
+   cross-implementation verifier in the tree is Chain A's browser mirror, which
+   uses declaration-order and is unaffected.
+4. The same scalar-value key ordering is used workspace-wide — `semantic_address`,
+   `ir_hash`, `broker_control`, and the IR `env`/`extensions` maps — un-guarded,
+   and is already pinned in `mvm-core::canonicalizer_equivalence`. Guarding only
+   this one chain would be inconsistent.
+
+The caveat only bites a hypothetical *third-party* verifier that reimplements
+strict RFC 8785 UTF-16 ordering and is fed an astral-plane workload key. If that
+ever becomes a real interop requirement, the fix is a canonicalizer change (or an
+input restriction) applied uniformly across the workspace, tracked with the
+`canonicalizer_equivalence` drift-lock — not a Chain-B-local patch.
+
+## Optional future migration (Chain B → browser-verifiable)
+
+If Chain B ever needs a browser verifier like Chain A's, migrate its
+canonicalization onto the existing `no_std` writer
+`mvm-protocol::ir::canonicalize` instead of adding `serde_jcs` to `mvm-protocol`.
+`mvm-core::canonicalizer_equivalence` already proves that
+`ir::canonicalize` and `serde_jcs` emit **byte-identical** output over a
+divergence-prone corpus (astral-plane keys, escaped values, large integers,
+nested/empty containers). So the migration would:
+
+- be **byte-preserving** — existing chains keep verifying, no re-signing, nothing
+  changes on the wire; and
+- carry the **same** astral-plane-key ordering (`ir::canonicalize` also sorts by
+  scalar value), so the caveat above is unchanged.
+
+Until such a requirement exists, Chain B stays host-only on `serde_jcs`. There is
+no migration code to write now, and this note is not a commitment to write it.


### PR DESCRIPTION
Implements #1810 (re-scoped) — part of epic #1806.

Reconciles mvm's two chain-signed audit logs by **documenting** that their two
canonicalizations are deliberate and correct, rather than converging them. The
original "converge on JCS" framing was rejected after investigation:
`serde_jcs` is std-only and cannot enter the `no_std` browser mirror, and the
host-lifecycle chain is already deterministic and byte-mirrored under a CI pin
test — so a JCS swap would be a wire break for zero gain.

## What's here (two new files, no wire changes)
- `specs/notes/2026-07-24-audit-chain-two-canonicalizations.md` — Chain A
  (host-lifecycle, `serde_json` declaration-order, `no_std` wasm mirror) vs
  Chain B (per-VM workload, `serde_jcs` JCS over a dynamic field bag); why each
  canonicalization fits its payload shape; the `no_std`/`serde_jcs` constraint;
  the astral-plane (>U+FFFF) UTF-8-vs-UTF-16 key-ordering caveat (document, not
  guard — with reasoning); and the optional byte-preserving future migration of
  Chain B onto `mvm-protocol::ir::canonicalize`.
- `crates/mvm-hostd/tests/audit_chain_spine.rs` — proves both chains verify and
  **fail closed** under one host key, plus workload-chain self-consistency
  across Unicode key planes (including an astral-plane key).

## Invariants
- No signed-byte changes; the pin test `mvm_verify_matches_supervisor_chain`
  is untouched and green. claim-8 witnesses unaffected.
- `mvm-protocol` takes no `serde_jcs` dependency (stays `no_std`).

## Gate
`cargo nextest run --workspace` → 7596 passed, 0 failed, 12 skipped; doctests
clean; `check-no-overclaim` / `check-doc-claims` / `check-no-spec-refs-in-comments`
/ `check-adr-coverage` all pass.
