### PR TITLE
feat(mvm-core): image-lineage node model, store, and verification (B1 of #1808)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -2303,4 +2303,96 @@ mod tests {
             "the signed chain must catch a consistent local re-forge, got: {err}"
         );
     }
+
+    // ── image lineage: real signed-chain linkage ─────────────────────────────
+
+    use mvm_core::image_lineage::{
+        ImageBuildIdentity, ImageCanonicalId, ImageIdentity, ImageNode, ImageProvenance,
+    };
+    use mvm_runtime::image_lineage::{ImageStore, verify_image_lineage};
+
+    fn image_node(slot: &str, revision: &str, parent: Option<CheckpointDigest>) -> ImageNode {
+        ImageNode::builder(
+            ImageBuildIdentity::Flake {
+                slot_hash: slot.into(),
+            },
+            ImageIdentity {
+                canonical: ImageCanonicalId::Flake {
+                    revision_hash: revision.into(),
+                },
+                artifacts: vec![ContentBlob {
+                    name: "rootfs.ext4".into(),
+                    sha256: revision.into(),
+                }],
+            },
+            ImageProvenance::Build {
+                input_ref: ".#app".into(),
+                lock_digest: None,
+            },
+        )
+        .parent(parent)
+        .created_unix(1)
+        .build()
+    }
+
+    /// Save a node and emit its `image.created` entry into the host-signed chain
+    /// under the active `MVM_HOME`, exactly as the build path (a later slice)
+    /// will. Returns nothing; the store + chain are the observable state.
+    fn seed_audited_image_node(store: &ImageStore, node: &ImageNode) {
+        store.save(node).unwrap();
+        let signer = super::super::host_signer::load_or_init().unwrap();
+        let emitter = super::super::audit_chain::AuditEmitter::new(signer.signing).unwrap();
+        let plan = mvm_core::plan::test_support::PlanFixture::new()
+            .tenant("local")
+            .plan_id("plan-image-verify")
+            .build();
+        emitter.emit_image_created(&plan, node).unwrap();
+    }
+
+    #[test]
+    fn image_lineage_verifies_against_a_real_signed_chain() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        let store = ImageStore::open();
+        let g0 = image_node("slot-a", "rev-1", None);
+        let g1 = image_node("slot-a", "rev-2", Some(g0.node_digest.clone()));
+        let g2 = image_node("slot-a", "rev-3", Some(g1.node_digest.clone()));
+        seed_audited_image_node(&store, &g0);
+        seed_audited_image_node(&store, &g1);
+        seed_audited_image_node(&store, &g2);
+
+        let anchor = SignedChainAnchor::load().unwrap();
+        // The anchor recovers each node's content-address from the signed chain,
+        // and the full three-node version lineage verifies against it.
+        verify_image_lineage(&store, &g2.node_digest, &anchor).unwrap();
+        // The store's head_for reports g2 as the chain's tip.
+        assert_eq!(
+            store
+                .head_for(&ImageBuildIdentity::Flake {
+                    slot_hash: "slot-a".into()
+                })
+                .unwrap()
+                .unwrap()
+                .node_digest,
+            g2.node_digest
+        );
+    }
+
+    #[test]
+    fn image_lineage_refuses_a_node_absent_from_the_signed_chain() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        let store = ImageStore::open();
+        let g0 = image_node("slot-a", "rev-1", None);
+        // Saved but NEVER audited: no image.created entry anchors it.
+        store.save(&g0).unwrap();
+
+        let anchor = SignedChainAnchor::load().unwrap();
+        let err = verify_image_lineage(&store, &g0.node_digest, &anchor).unwrap_err();
+        assert!(err.to_string().contains("no signed audit entry"), "{err}");
+    }
 }

--- a/crates/mvm-cli/src/commands/vm/checkpoint/lineage.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/lineage.rs
@@ -29,8 +29,23 @@ struct CheckpointVerifyJson<'a> {
 /// chains that verify clean are indexed: an entry stranded behind a tampered
 /// line is not trusted, so the checkpoint it names fails closed as un-anchored.
 pub struct SignedChainAnchor {
-    /// checkpoint id -> content-address the signed chain recorded at creation.
+    /// `<namespace>:<id>` -> content-address the signed chain recorded at
+    /// creation. The namespace tag (`checkpoint` / `image`) keeps the checkpoint
+    /// and image key spaces structurally disjoint in one map, rather than
+    /// relying on their raw id/digest strings happening not to collide.
     recorded: std::collections::HashMap<String, CheckpointDigest>,
+}
+
+/// Namespace tag for a checkpoint-id key in [`SignedChainAnchor::recorded`].
+const CHECKPOINT_NS: &str = "checkpoint";
+/// Namespace tag for an image-node-digest key in [`SignedChainAnchor::recorded`].
+const IMAGE_NS: &str = "image";
+
+/// Compose a namespaced anchor-map key so the checkpoint and image key spaces
+/// cannot collide. The same composition is used by the indexer (writer) and
+/// both `recorded_creation_digest` lookups (readers), so the key cannot drift.
+fn anchor_key(namespace: &str, id: &str) -> String {
+    format!("{namespace}:{id}")
 }
 
 impl SignedChainAnchor {
@@ -104,39 +119,48 @@ fn index_creation_digest(
     use mvm_hostd::audit::emitter::checkpoint_audit as k;
     use mvm_hostd::audit::emitter::image_audit as ik;
     let event = envelope.entry.event.as_str();
-    // The (id, digest) label pair a creation event keys on; non-creation events
-    // carry neither.
-    let key_pair = if event == k::CREATED_EVENT {
-        Some((k::LABEL_CHECKPOINT_ID, k::LABEL_META_DIGEST))
+    // The (id-label, digest-label, namespace) a creation event keys on;
+    // non-creation events carry none.
+    let keys = if event == k::CREATED_EVENT {
+        Some((k::LABEL_CHECKPOINT_ID, k::LABEL_META_DIGEST, CHECKPOINT_NS))
     } else if event == k::FORKED_EVENT {
-        Some((k::LABEL_CHILD_ID, k::LABEL_CHILD_DIGEST))
+        Some((k::LABEL_CHILD_ID, k::LABEL_CHILD_DIGEST, CHECKPOINT_NS))
     } else if event == ik::CREATED_EVENT {
-        Some((ik::LABEL_NODE_DIGEST, ik::LABEL_NODE_DIGEST))
+        Some((ik::LABEL_NODE_DIGEST, ik::LABEL_NODE_DIGEST, IMAGE_NS))
     } else {
         None
     };
-    let Some((id_key, digest_key)) = key_pair else {
+    let Some((id_key, digest_key, namespace)) = keys else {
         return Ok(());
     };
     let labels = &envelope.entry.labels;
     if let (Some(id), Some(digest)) = (labels.get(id_key), labels.get(digest_key)) {
-        recorded.insert(id.clone(), CheckpointDigest::parse(digest.clone())?);
+        recorded.insert(
+            anchor_key(namespace, id),
+            CheckpointDigest::parse(digest.clone())?,
+        );
     }
     Ok(())
 }
 
 impl CheckpointChainAnchor for SignedChainAnchor {
     fn recorded_creation_digest(&self, meta: &CheckpointMeta) -> Result<Option<CheckpointDigest>> {
-        Ok(self.recorded.get(meta.id.as_str()).cloned())
+        Ok(self
+            .recorded
+            .get(&anchor_key(CHECKPOINT_NS, meta.id.as_str()))
+            .cloned())
     }
 }
 
 /// The same signed host-lifecycle chains anchor image-lineage nodes. An image
 /// node's identity is its own content-address, so the lookup key is the node
-/// digest the `image.created` entry recorded.
+/// digest the `image.created` entry recorded, under the image namespace.
 impl ImageChainAnchor for SignedChainAnchor {
     fn recorded_creation_digest(&self, node: &ImageNode) -> Result<Option<CheckpointDigest>> {
-        Ok(self.recorded.get(node.node_digest.as_str()).cloned())
+        Ok(self
+            .recorded
+            .get(&anchor_key(IMAGE_NS, node.node_digest.as_str()))
+            .cloned())
     }
 }
 

--- a/crates/mvm-cli/src/commands/vm/checkpoint/lineage.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/lineage.rs
@@ -4,7 +4,9 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 
 use mvm_core::checkpoint::{CheckpointDigest, CheckpointMeta};
+use mvm_core::image_lineage::ImageNode;
 use mvm_runtime::checkpoint::{CheckpointChainAnchor, CheckpointStore, verify_lineage};
+use mvm_runtime::image_lineage::ImageChainAnchor;
 
 use super::validated_checkpoint_id;
 use crate::ui;
@@ -90,14 +92,17 @@ fn is_host_lifecycle_chain(path: &Path) -> bool {
 }
 
 /// Index one signed audit entry's creation content-address, when it is a
-/// checkpoint creation event. `checkpoint.created` keys on
+/// checkpoint or image-node creation event. `checkpoint.created` keys on
 /// `checkpoint_id`/`meta_digest`; `checkpoint.forked` is a child's creation, so
-/// it keys on `child_id`/`child_digest`.
+/// it keys on `child_id`/`child_digest`. `image.created` has no separate id —
+/// the node's identity *is* its content-address — so it keys the digest under
+/// itself.
 fn index_creation_digest(
     recorded: &mut std::collections::HashMap<String, CheckpointDigest>,
     envelope: &mvm_hostd::supervisor::SignedEnvelope,
 ) -> Result<()> {
     use mvm_hostd::audit::emitter::checkpoint_audit as k;
+    use mvm_hostd::audit::emitter::image_audit as ik;
     let event = envelope.entry.event.as_str();
     // The (id, digest) label pair a creation event keys on; non-creation events
     // carry neither.
@@ -105,6 +110,8 @@ fn index_creation_digest(
         Some((k::LABEL_CHECKPOINT_ID, k::LABEL_META_DIGEST))
     } else if event == k::FORKED_EVENT {
         Some((k::LABEL_CHILD_ID, k::LABEL_CHILD_DIGEST))
+    } else if event == ik::CREATED_EVENT {
+        Some((ik::LABEL_NODE_DIGEST, ik::LABEL_NODE_DIGEST))
     } else {
         None
     };
@@ -121,6 +128,15 @@ fn index_creation_digest(
 impl CheckpointChainAnchor for SignedChainAnchor {
     fn recorded_creation_digest(&self, meta: &CheckpointMeta) -> Result<Option<CheckpointDigest>> {
         Ok(self.recorded.get(meta.id.as_str()).cloned())
+    }
+}
+
+/// The same signed host-lifecycle chains anchor image-lineage nodes. An image
+/// node's identity is its own content-address, so the lookup key is the node
+/// digest the `image.created` entry recorded.
+impl ImageChainAnchor for SignedChainAnchor {
+    fn recorded_creation_digest(&self, node: &ImageNode) -> Result<Option<CheckpointDigest>> {
+        Ok(self.recorded.get(node.node_digest.as_str()).cloned())
     }
 }
 

--- a/crates/mvm-core/src/checkpoint.rs
+++ b/crates/mvm-core/src/checkpoint.rs
@@ -245,8 +245,10 @@ impl CheckpointDigestInput<'_> {
 }
 
 /// Content blobs borrowed and sorted by `name`, so a checkpoint's digest does
-/// not depend on the order capture happened to append them.
-fn sorted_content(content: &[ContentBlob]) -> Vec<&ContentBlob> {
+/// not depend on the order capture happened to append them. Shared with the
+/// image-lineage node digest so both content-address a blob manifest the same
+/// order-invariant way.
+pub(crate) fn sorted_content(content: &[ContentBlob]) -> Vec<&ContentBlob> {
     let mut refs: Vec<&ContentBlob> = content.iter().collect();
     refs.sort_by(|a, b| a.name.cmp(&b.name));
     // Blob names index the manifest (fork/restore/diff look up by name); a
@@ -254,7 +256,7 @@ fn sorted_content(content: &[ContentBlob]) -> Vec<&ContentBlob> {
     // ambiguate the lookup. Capture never emits one — assert it in debug.
     debug_assert!(
         refs.windows(2).all(|w| w[0].name != w[1].name),
-        "checkpoint content manifest has duplicate blob names"
+        "content manifest has duplicate blob names"
     );
     refs
 }

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -642,6 +642,12 @@ pub fn checkpoints_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(mvm_home()).join("checkpoints")
 }
 
+/// Immutable image version-lineage store: `<mvm_home>/images/`. Each node is a
+/// subdirectory `<node-digest>/` holding `node.json`.
+pub fn images_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(mvm_home()).join("images")
+}
+
 /// Chain-signed audit logs: `<mvm_home>/audit/`.
 pub fn mvm_audit_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(mvm_home()).join("audit")

--- a/crates/mvm-core/src/image_lineage.rs
+++ b/crates/mvm-core/src/image_lineage.rs
@@ -32,7 +32,7 @@ use crate::checkpoint::{CheckpointDigest, ContentBlob};
 /// legitimately moves build to build (a resolved digest, a lockfile hash) so
 /// successive builds of one source line up on one chain.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum ImageBuildIdentity {
     /// A Nix flake output, keyed on the resolved slot hash of the flake ref.
     Flake { slot_hash: String },
@@ -49,7 +49,7 @@ pub enum ImageBuildIdentity {
 /// [`ImageBuildIdentity`] (the chain key): this pins the exact image this node
 /// records, not the line of builds it belongs to.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum ImageCanonicalId {
     /// A Nix flake build, identified by its revision hash.
     Flake { revision_hash: String },
@@ -76,7 +76,7 @@ pub struct ImageIdentity {
 /// this records the upstream input the build consumed. The verifier records it
 /// and never walks it, and it confers no trust.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum ImageProvenance {
     /// A Nix flake / template / local-project build input.
     Build {
@@ -336,6 +336,41 @@ mod tests {
             .unwrap()
             .insert("bogus".into(), serde_json::json!(true));
         assert!(serde_json::from_value::<ImageNode>(value).is_err());
+    }
+
+    #[test]
+    fn tagged_enum_variants_reject_unknown_fields() {
+        // deny_unknown_fields applies per-variant on the internally-tagged
+        // enums: an extra key inside a variant's object fails closed.
+        assert!(
+            serde_json::from_str::<ImageBuildIdentity>(
+                r#"{"kind":"flake","slot_hash":"s","bogus":1}"#
+            )
+            .is_err()
+        );
+        assert!(
+            serde_json::from_str::<ImageCanonicalId>(
+                r#"{"kind":"oci","resolved_digest":"d","bogus":1}"#
+            )
+            .is_err()
+        );
+        assert!(
+            serde_json::from_str::<ImageProvenance>(
+                r#"{"kind":"build","input_ref":"r","bogus":1}"#
+            )
+            .is_err()
+        );
+        // The well-formed variant forms still parse.
+        assert!(
+            serde_json::from_str::<ImageBuildIdentity>(r#"{"kind":"flake","slot_hash":"s"}"#)
+                .is_ok()
+        );
+        assert!(
+            serde_json::from_str::<ImageProvenance>(
+                r#"{"kind":"oci","resolved_digest":"d","layer_digests":[]}"#
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/mvm-core/src/image_lineage.rs
+++ b/crates/mvm-core/src/image_lineage.rs
@@ -1,0 +1,473 @@
+//! Immutable, audit-bound records of a compiled microVM image's version
+//! lineage. An [`ImageNode`] is the image analog of [`crate::checkpoint`]'s
+//! `CheckpointMeta`: a content-addressed record that hash-links to the prior
+//! build of the *same* build identity, so a version chain (build N ← build N-1
+//! ← … ← genesis) is a tamper-evident sequence anchored in the signed audit
+//! chain.
+//!
+//! # Lineage is PROVENANCE, not AUTHORIZATION
+//!
+//! A node's `parent` edge, and any ancestor reachable through it, is a record
+//! of *where this build came from* — never a grant of trust. Nothing here lets
+//! a present or trusted ancestor confer admission or boot rights on a child.
+//! Boot integrity stays gated by dm-verity (the tampered-rootfs claim);
+//! admission stays gated by the signed, content-addressed bundle and its
+//! pinned key id. A verified lineage proves only that the chain of records was
+//! not edited after it was signed — it says nothing about whether the image
+//! *may run*. Treat the lineage strictly as provenance metadata.
+//!
+//! The node reuses [`CheckpointDigest`] for its own content-address and its
+//! `parent` hash-link, and [`ContentBlob`] for its artifact commitments, so the
+//! image and checkpoint lineages share one digest shape and one verify walk
+//! rather than forking a second copy.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::checkpoint::{CheckpointDigest, ContentBlob};
+
+/// The stable identity a version chain is keyed on. Two builds belong to the
+/// same chain iff they share this identity; a new build's `parent` is the prior
+/// head for the *same* identity. Deliberately coarse: it excludes anything that
+/// legitimately moves build to build (a resolved digest, a lockfile hash) so
+/// successive builds of one source line up on one chain.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ImageBuildIdentity {
+    /// A Nix flake output, keyed on the resolved slot hash of the flake ref.
+    Flake { slot_hash: String },
+    /// An OCI repository, keyed on registry + repository. A specific tag or
+    /// digest is *not* part of the key — those advance within one repo's chain.
+    Oci {
+        registry: String,
+        repository: String,
+    },
+}
+
+/// The compiled image's own canonical source identity: the flake's Nix
+/// revision hash or the OCI resolved manifest digest. Distinct from
+/// [`ImageBuildIdentity`] (the chain key): this pins the exact image this node
+/// records, not the line of builds it belongs to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ImageCanonicalId {
+    /// A Nix flake build, identified by its revision hash.
+    Flake { revision_hash: String },
+    /// An OCI image, identified by its resolved manifest digest.
+    Oci { resolved_digest: String },
+}
+
+/// The compiled image's canonical identity plus content commitments to the
+/// bytes it produced (rootfs / kernel). Committing to the artifact hashes means
+/// the node content-addresses the *actual* image, not just a name for it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ImageIdentity {
+    /// Canonical source identity (flake revision hash / OCI resolved digest).
+    pub canonical: ImageCanonicalId,
+    /// Content-addressed commitments to the produced artifact bytes
+    /// (`rootfs.ext4`, `kernel`, …). Order-invariant in the digest.
+    pub artifacts: Vec<ContentBlob>,
+}
+
+/// Where this build's *external* base came from, recorded as a provenance
+/// attribute. This is emphatically NOT the [`ImageNode::parent`] edge: the
+/// parent is the predecessor build of the same identity (the walk edge), while
+/// this records the upstream input the build consumed. The verifier records it
+/// and never walks it, and it confers no trust.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ImageProvenance {
+    /// A Nix flake / template / local-project build input.
+    Build {
+        /// The supplied reference (flake ref, template name, project path).
+        input_ref: String,
+        /// Pin of the input (e.g. `flake.lock` hash), when recorded.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        lock_digest: Option<String>,
+    },
+    /// An OCI image pull input.
+    Oci {
+        /// The resolved manifest digest the reference pinned to.
+        resolved_digest: String,
+        /// The ordered layer digest set the manifest enumerated.
+        #[serde(default)]
+        layer_digests: Vec<String>,
+    },
+}
+
+/// On-disk record for one image build in a version chain
+/// (`<images_dir>/<node_digest>/node.json`).
+///
+/// `parent` hash-links to the predecessor node's `node_digest` (its
+/// content-address) for the same `build_identity`, so a descendant detects any
+/// post-seal edit of an ancestor — the recomputed ancestor digest no longer
+/// matches the child's link. `node_digest` is the content-address of the
+/// load-bearing fields, derived in [`ImageNodeBuilder::build`] and never set by
+/// callers. `audit_ref` is a non-load-bearing back-pointer backfilled after the
+/// chain-signed entry is emitted; it and `node_digest` are excluded from the
+/// digest so the backfill does not perturb the content-address.
+///
+/// See the module docs: a node is PROVENANCE, never AUTHORIZATION.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ImageNode {
+    /// Content-address of the load-bearing fields below. Required with no serde
+    /// default: a record that carries no content-address cannot be
+    /// lineage-verified, so a malformed node must fail closed rather than load
+    /// as an unverifiable record.
+    pub node_digest: CheckpointDigest,
+    /// The version-chain key. `ImageStore::head_for` looks up by this.
+    pub build_identity: ImageBuildIdentity,
+    /// The predecessor node for the same `build_identity`, hash-linked by
+    /// content-address. `None` = genesis. This is the walk edge.
+    pub parent: Option<CheckpointDigest>,
+    pub created_unix: u64,
+    /// The compiled image's own canonical identity + artifact commitments.
+    pub image_identity: ImageIdentity,
+    /// The external base, recorded as a provenance attribute (not a walk edge).
+    pub provenance: ImageProvenance,
+    /// Non-load-bearing back-pointer to the signed audit entry. Excluded from
+    /// the digest.
+    pub audit_ref: Option<String>,
+}
+
+impl ImageNode {
+    /// Start building a node. `node_digest` is derived in [`ImageNodeBuilder::build`].
+    pub fn builder(
+        build_identity: ImageBuildIdentity,
+        image_identity: ImageIdentity,
+        provenance: ImageProvenance,
+    ) -> ImageNodeBuilder {
+        ImageNodeBuilder {
+            build_identity,
+            parent: None,
+            created_unix: 0,
+            image_identity,
+            provenance,
+            audit_ref: None,
+        }
+    }
+
+    /// Recompute this record's content-address from its load-bearing fields. A
+    /// stored `node_digest` that no longer equals this value is proof the record
+    /// was edited after it was sealed — the check `verify_image_lineage` walks
+    /// with. Mirrors [`ImageNodeBuilder::build`]; the `node_digest_recomputes_*`
+    /// tests pin that the two agree.
+    pub fn compute_node_digest(&self) -> CheckpointDigest {
+        ImageNodeDigestInput {
+            build_identity: &self.build_identity,
+            parent: &self.parent,
+            created_unix: self.created_unix,
+            image_canonical: &self.image_identity.canonical,
+            image_artifacts: crate::checkpoint::sorted_content(&self.image_identity.artifacts),
+            provenance: &self.provenance,
+        }
+        .digest()
+    }
+}
+
+/// The load-bearing fields of an [`ImageNode`], borrowed in fixed declaration
+/// order, that `node_digest` content-addresses. `node_digest` itself and
+/// `audit_ref` are excluded: the former is what we are deriving (excluding it
+/// avoids circularity), the latter is backfilled after the audit entry is
+/// emitted and must not perturb the digest.
+#[derive(Serialize)]
+struct ImageNodeDigestInput<'a> {
+    build_identity: &'a ImageBuildIdentity,
+    parent: &'a Option<CheckpointDigest>,
+    created_unix: u64,
+    image_canonical: &'a ImageCanonicalId,
+    /// Sorted by `name` so the digest is invariant to artifact ordering.
+    image_artifacts: Vec<&'a ContentBlob>,
+    provenance: &'a ImageProvenance,
+}
+
+impl ImageNodeDigestInput<'_> {
+    fn digest(&self) -> CheckpointDigest {
+        // Plain serde_json (not JCS): host-only, single-implementation, no
+        // cross-language conformance need — the same posture the checkpoint
+        // digest and the audit envelope take.
+        let bytes =
+            serde_json::to_vec(self).expect("image node digest input is always JSON-serializable");
+        let hex = hex::encode(Sha256::digest(&bytes));
+        // Reuse the checkpoint digest's shape validation rather than poke its
+        // private field: the hex we produce is always a valid `sha256:<64 hex>`.
+        CheckpointDigest::parse(format!("{}{hex}", CheckpointDigest::PREFIX))
+            .expect("sha256 hex is always a valid checkpoint-digest shape")
+    }
+}
+
+/// Fluent builder for [`ImageNode`]; obtain via [`ImageNode::builder`]. Derives
+/// `node_digest` once in [`Self::build`], so a caller can never hand-set a
+/// content-address that disagrees with the fields.
+pub struct ImageNodeBuilder {
+    build_identity: ImageBuildIdentity,
+    parent: Option<CheckpointDigest>,
+    created_unix: u64,
+    image_identity: ImageIdentity,
+    provenance: ImageProvenance,
+    audit_ref: Option<String>,
+}
+
+impl ImageNodeBuilder {
+    /// Hash-link this node to its predecessor's content-address
+    /// ([`ImageNode::node_digest`]).
+    pub fn parent(mut self, parent: Option<CheckpointDigest>) -> Self {
+        self.parent = parent;
+        self
+    }
+    pub fn created_unix(mut self, secs: u64) -> Self {
+        self.created_unix = secs;
+        self
+    }
+    pub fn audit_ref(mut self, r: Option<String>) -> Self {
+        self.audit_ref = r;
+        self
+    }
+    pub fn build(self) -> ImageNode {
+        // Derive the content-address before moving the fields out. Mirrors
+        // `ImageNode::compute_node_digest` — the `node_digest_recomputes_*`
+        // tests pin that the two agree.
+        let node_digest = ImageNodeDigestInput {
+            build_identity: &self.build_identity,
+            parent: &self.parent,
+            created_unix: self.created_unix,
+            image_canonical: &self.image_identity.canonical,
+            image_artifacts: crate::checkpoint::sorted_content(&self.image_identity.artifacts),
+            provenance: &self.provenance,
+        }
+        .digest();
+        ImageNode {
+            node_digest,
+            build_identity: self.build_identity,
+            parent: self.parent,
+            created_unix: self.created_unix,
+            image_identity: self.image_identity,
+            provenance: self.provenance,
+            audit_ref: self.audit_ref,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn blob(name: &str, sha: &str) -> ContentBlob {
+        ContentBlob {
+            name: name.into(),
+            sha256: sha.into(),
+        }
+    }
+
+    fn flake_identity() -> ImageBuildIdentity {
+        ImageBuildIdentity::Flake {
+            slot_hash: "slot-abc".into(),
+        }
+    }
+
+    fn flake_image(revision: &str, artifacts: Vec<ContentBlob>) -> ImageIdentity {
+        ImageIdentity {
+            canonical: ImageCanonicalId::Flake {
+                revision_hash: revision.into(),
+            },
+            artifacts,
+        }
+    }
+
+    fn flake_provenance() -> ImageProvenance {
+        ImageProvenance::Build {
+            input_ref: ".#app".into(),
+            lock_digest: Some("sha256:lock".into()),
+        }
+    }
+
+    fn fixture_node(artifacts: Vec<ContentBlob>) -> ImageNode {
+        ImageNode::builder(
+            flake_identity(),
+            flake_image("rev-1", artifacts),
+            flake_provenance(),
+        )
+        .created_unix(100)
+        .build()
+    }
+
+    fn parent_digest() -> CheckpointDigest {
+        CheckpointDigest::parse(format!("sha256:{}", "a".repeat(64))).unwrap()
+    }
+
+    #[test]
+    fn node_roundtrips_through_json() {
+        let node = ImageNode::builder(
+            ImageBuildIdentity::Oci {
+                registry: "docker.io".into(),
+                repository: "library/alpine".into(),
+            },
+            ImageIdentity {
+                canonical: ImageCanonicalId::Oci {
+                    resolved_digest: format!("sha256:{}", "d".repeat(64)),
+                },
+                artifacts: vec![blob("rootfs.ext4", "aa")],
+            },
+            ImageProvenance::Oci {
+                resolved_digest: format!("sha256:{}", "d".repeat(64)),
+                layer_digests: vec![format!("sha256:{}", "e".repeat(64))],
+            },
+        )
+        .parent(Some(parent_digest()))
+        .created_unix(1_700_000_000)
+        .audit_ref(Some("local.jsonl#5".into()))
+        .build();
+
+        let json = serde_json::to_string(&node).unwrap();
+        let back: ImageNode = serde_json::from_str(&json).unwrap();
+        assert_eq!(node, back);
+        assert_eq!(back.node_digest, node.node_digest);
+        assert_eq!(back.parent.unwrap(), parent_digest());
+    }
+
+    #[test]
+    fn node_rejects_unknown_fields() {
+        let node = fixture_node(vec![blob("rootfs.ext4", "aa")]);
+        let mut value: serde_json::Value = serde_json::to_value(&node).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("bogus".into(), serde_json::json!(true));
+        assert!(serde_json::from_value::<ImageNode>(value).is_err());
+    }
+
+    #[test]
+    fn node_digest_wire_shape_is_sha256_prefixed_hex() {
+        let n = fixture_node(vec![blob("rootfs.ext4", "aa")]);
+        let s = n.node_digest.as_str();
+        assert!(s.starts_with("sha256:"));
+        assert_eq!(s.len(), "sha256:".len() + 64);
+    }
+
+    #[test]
+    fn node_digest_is_deterministic_across_builds() {
+        let a = fixture_node(vec![blob("rootfs.ext4", "aa")]);
+        let b = fixture_node(vec![blob("rootfs.ext4", "aa")]);
+        assert_eq!(a.node_digest, b.node_digest);
+    }
+
+    #[test]
+    fn identical_content_produces_identical_digest() {
+        // Full-field equality (not just the fixture) → identical digest.
+        let build = || {
+            ImageNode::builder(
+                flake_identity(),
+                flake_image(
+                    "rev-9",
+                    vec![blob("kernel", "k1"), blob("rootfs.ext4", "r1")],
+                ),
+                flake_provenance(),
+            )
+            .parent(Some(parent_digest()))
+            .created_unix(42)
+            .build()
+            .node_digest
+        };
+        assert_eq!(build(), build());
+    }
+
+    #[test]
+    fn node_digest_recomputes_equal_to_stored() {
+        let n = fixture_node(vec![blob("rootfs.ext4", "aa"), blob("kernel", "bb")]);
+        assert_eq!(n.node_digest, n.compute_node_digest());
+    }
+
+    #[test]
+    fn node_digest_invariant_under_artifact_insertion_order() {
+        let ordered = fixture_node(vec![blob("a", "1"), blob("b", "2"), blob("c", "3")]);
+        let permuted = fixture_node(vec![blob("c", "3"), blob("a", "1"), blob("b", "2")]);
+        assert_eq!(ordered.node_digest, permuted.node_digest);
+    }
+
+    #[test]
+    fn node_digest_excludes_node_digest_and_audit_ref() {
+        // audit_ref is backfilled after the chain entry is emitted; it must not
+        // move the content-address. (node_digest is derived, so it cannot be an
+        // input to itself — no circularity — which the recompute test also pins.)
+        let without = fixture_node(vec![blob("rootfs.ext4", "aa")]);
+        let with = ImageNode::builder(
+            flake_identity(),
+            flake_image("rev-1", vec![blob("rootfs.ext4", "aa")]),
+            flake_provenance(),
+        )
+        .created_unix(100)
+        .audit_ref(Some("local.jsonl#3".into()))
+        .build();
+        assert_eq!(without.node_digest, with.node_digest);
+    }
+
+    #[test]
+    fn node_digest_covers_every_load_bearing_field() {
+        // Flip exactly one load-bearing field per case; the content-address must
+        // move. Guards a future field silently falling outside the digest input.
+        let base = fixture_node(vec![blob("rootfs.ext4", "aa")]);
+        let baseline = base.node_digest.clone();
+
+        // build_identity
+        let n = ImageNode::builder(
+            ImageBuildIdentity::Flake {
+                slot_hash: "slot-OTHER".into(),
+            },
+            flake_image("rev-1", vec![blob("rootfs.ext4", "aa")]),
+            flake_provenance(),
+        )
+        .created_unix(100)
+        .build();
+        assert_ne!(baseline, n.node_digest, "build_identity");
+
+        // parent
+        let n = ImageNode::builder(
+            flake_identity(),
+            flake_image("rev-1", vec![blob("rootfs.ext4", "aa")]),
+            flake_provenance(),
+        )
+        .parent(Some(parent_digest()))
+        .created_unix(100)
+        .build();
+        assert_ne!(baseline, n.node_digest, "parent");
+
+        // created_unix
+        let n = ImageNode::builder(
+            flake_identity(),
+            flake_image("rev-1", vec![blob("rootfs.ext4", "aa")]),
+            flake_provenance(),
+        )
+        .created_unix(200)
+        .build();
+        assert_ne!(baseline, n.node_digest, "created_unix");
+
+        // image_identity.canonical
+        let n = ImageNode::builder(
+            flake_identity(),
+            flake_image("rev-OTHER", vec![blob("rootfs.ext4", "aa")]),
+            flake_provenance(),
+        )
+        .created_unix(100)
+        .build();
+        assert_ne!(baseline, n.node_digest, "image_canonical");
+
+        // image_identity.artifacts
+        let n = fixture_node(vec![blob("rootfs.ext4", "zz")]);
+        assert_ne!(baseline, n.node_digest, "image_artifacts");
+
+        // provenance
+        let n = ImageNode::builder(
+            flake_identity(),
+            flake_image("rev-1", vec![blob("rootfs.ext4", "aa")]),
+            ImageProvenance::Build {
+                input_ref: ".#other".into(),
+                lock_digest: Some("sha256:lock".into()),
+            },
+        )
+        .created_unix(100)
+        .build();
+        assert_ne!(baseline, n.node_digest, "provenance");
+    }
+}

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -31,6 +31,9 @@ pub mod guest_netd;
 /// decide restart/give-up actions. No I/O.
 pub mod health;
 /// Host ingress-broker decision logic (host listener only by explicit policy).
+/// Content-addressed image version-lineage nodes (the image analog of
+/// [`checkpoint`]). Provenance metadata, never authorization.
+pub mod image_lineage;
 pub mod ingress_broker;
 /// Ingress-broker handler: compose decision + trace into an audit record.
 pub mod ingress_handler;

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -30,10 +30,10 @@ pub mod guest_netd;
 /// Pure health-state reducer: fold probe results into a health state and
 /// decide restart/give-up actions. No I/O.
 pub mod health;
-/// Host ingress-broker decision logic (host listener only by explicit policy).
 /// Content-addressed image version-lineage nodes (the image analog of
 /// [`checkpoint`]). Provenance metadata, never authorization.
 pub mod image_lineage;
+/// Host ingress-broker decision logic (host listener only by explicit policy).
 pub mod ingress_broker;
 /// Ingress-broker handler: compose decision + trace into an audit record.
 pub mod ingress_handler;

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -75,6 +75,105 @@ pub mod checkpoint_audit {
     pub const LABEL_CHILD_DIGEST: &str = "child_digest";
 }
 
+/// Wire-stable event name and label keys for the image version-lineage audit
+/// entry. Shared so the emitter (writer) and the lineage chain-anchor (reader)
+/// cannot drift on a string — a drift there would silently defeat chain-anchored
+/// image-lineage verification.
+pub mod image_audit {
+    /// Emitted when a compiled image's version-lineage node is created.
+    pub const CREATED_EVENT: &str = "image.created";
+    /// Label: the node's own content-address. The chain-anchor keys on this.
+    pub const LABEL_NODE_DIGEST: &str = "image_node_digest";
+    /// Label: the predecessor node's content-address (the parent hash-link), or
+    /// [`GENESIS_PARENT`] when the node has none.
+    pub const LABEL_PARENT_DIGEST: &str = "image_parent_digest";
+    /// Label: the build-identity discriminant (`"flake"` / `"oci"`).
+    pub const LABEL_BUILD_IDENTITY_KIND: &str = "image_build_identity_kind";
+    /// Label: the build-identity value (flake slot hash, or
+    /// `"<registry>/<repository>"`).
+    pub const LABEL_BUILD_IDENTITY: &str = "image_build_identity";
+    /// Label: the provenance discriminant (`"build"` / `"oci"`).
+    pub const LABEL_PROVENANCE_KIND: &str = "image_provenance_kind";
+    /// Label: the build-provenance input reference.
+    pub const LABEL_PROVENANCE_INPUT_REF: &str = "image_provenance_input_ref";
+    /// Label: the build-provenance lock digest, when recorded.
+    pub const LABEL_PROVENANCE_LOCK_DIGEST: &str = "image_provenance_lock_digest";
+    /// Label: the OCI-provenance resolved manifest digest.
+    pub const LABEL_PROVENANCE_RESOLVED_DIGEST: &str = "image_provenance_resolved_digest";
+    /// Label: the OCI-provenance layer digest set (comma-joined).
+    pub const LABEL_PROVENANCE_LAYER_DIGESTS: &str = "image_provenance_layer_digests";
+    /// [`LABEL_PARENT_DIGEST`] sentinel for a genesis (parentless) node.
+    pub const GENESIS_PARENT: &str = "genesis";
+}
+
+/// Extract the `image.created` label set from a node's provenance attributes.
+/// The parent hash-link is recorded as provenance; nothing here is a trust
+/// grant (lineage is provenance, never authorization).
+fn image_created_labels(node: &mvm_core::image_lineage::ImageNode) -> Vec<(String, String)> {
+    use image_audit as k;
+    use mvm_core::image_lineage::{ImageBuildIdentity, ImageProvenance};
+
+    let mut labels = vec![
+        (
+            k::LABEL_NODE_DIGEST.to_string(),
+            node.node_digest.as_str().to_string(),
+        ),
+        (
+            k::LABEL_PARENT_DIGEST.to_string(),
+            node.parent
+                .as_ref()
+                .map(|p| p.as_str().to_string())
+                .unwrap_or_else(|| k::GENESIS_PARENT.to_string()),
+        ),
+    ];
+    match &node.build_identity {
+        ImageBuildIdentity::Flake { slot_hash } => {
+            labels.push((
+                k::LABEL_BUILD_IDENTITY_KIND.to_string(),
+                "flake".to_string(),
+            ));
+            labels.push((k::LABEL_BUILD_IDENTITY.to_string(), slot_hash.clone()));
+        }
+        ImageBuildIdentity::Oci {
+            registry,
+            repository,
+        } => {
+            labels.push((k::LABEL_BUILD_IDENTITY_KIND.to_string(), "oci".to_string()));
+            labels.push((
+                k::LABEL_BUILD_IDENTITY.to_string(),
+                format!("{registry}/{repository}"),
+            ));
+        }
+    }
+    match &node.provenance {
+        ImageProvenance::Build {
+            input_ref,
+            lock_digest,
+        } => {
+            labels.push((k::LABEL_PROVENANCE_KIND.to_string(), "build".to_string()));
+            labels.push((k::LABEL_PROVENANCE_INPUT_REF.to_string(), input_ref.clone()));
+            if let Some(lock) = lock_digest {
+                labels.push((k::LABEL_PROVENANCE_LOCK_DIGEST.to_string(), lock.clone()));
+            }
+        }
+        ImageProvenance::Oci {
+            resolved_digest,
+            layer_digests,
+        } => {
+            labels.push((k::LABEL_PROVENANCE_KIND.to_string(), "oci".to_string()));
+            labels.push((
+                k::LABEL_PROVENANCE_RESOLVED_DIGEST.to_string(),
+                resolved_digest.clone(),
+            ));
+            labels.push((
+                k::LABEL_PROVENANCE_LAYER_DIGESTS.to_string(),
+                layer_digests.join(","),
+            ));
+        }
+    }
+    labels
+}
+
 /// Resolve the default audit-chain directory: `~/.mvm/audit/`.
 pub fn default_audit_dir() -> Result<PathBuf> {
     Ok(mvm_core::config::mvm_home_strict()?.join("audit"))
@@ -360,6 +459,19 @@ impl AuditEmitter {
                 (k::LABEL_CHILD_DIGEST.to_string(), child_digest.to_string()),
             ],
         )
+    }
+
+    /// Record that a compiled image's version-lineage node was created. The
+    /// label set carries the node's content-address (the chain-anchor keys on
+    /// it), its parent hash-link, the build identity, and the provenance
+    /// attributes. Chain-signed so `verify_image_lineage` can anchor the node's
+    /// content-address to a signature it cannot forge.
+    pub fn emit_image_created(
+        &self,
+        plan: &ExecutionPlan,
+        node: &mvm_core::image_lineage::ImageNode,
+    ) -> Result<()> {
+        self.emit(plan, image_audit::CREATED_EVENT, image_created_labels(node))
     }
 
     /// Emit `plan.exited` — fires after a waited-for workload powers off,
@@ -918,6 +1030,79 @@ mod tests {
         assert!(content.contains(&parent_digest));
         assert!(content.contains(&child_digest));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
+    }
+
+    #[test]
+    fn image_created_is_chain_signed_with_required_labels() {
+        use mvm_core::image_lineage::{
+            ImageBuildIdentity, ImageCanonicalId, ImageIdentity, ImageNode, ImageProvenance,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-IMG");
+
+        let parent = ImageNode::builder(
+            ImageBuildIdentity::Flake {
+                slot_hash: "slot-a".into(),
+            },
+            ImageIdentity {
+                canonical: ImageCanonicalId::Flake {
+                    revision_hash: "rev-1".into(),
+                },
+                artifacts: vec![mvm_core::checkpoint::ContentBlob {
+                    name: "rootfs.ext4".into(),
+                    sha256: "aa".into(),
+                }],
+            },
+            ImageProvenance::Build {
+                input_ref: ".#app".into(),
+                lock_digest: Some("sha256:lock".into()),
+            },
+        )
+        .created_unix(1)
+        .build();
+        let child = ImageNode::builder(
+            ImageBuildIdentity::Flake {
+                slot_hash: "slot-a".into(),
+            },
+            ImageIdentity {
+                canonical: ImageCanonicalId::Flake {
+                    revision_hash: "rev-2".into(),
+                },
+                artifacts: vec![mvm_core::checkpoint::ContentBlob {
+                    name: "rootfs.ext4".into(),
+                    sha256: "bb".into(),
+                }],
+            },
+            ImageProvenance::Build {
+                input_ref: ".#app".into(),
+                lock_digest: None,
+            },
+        )
+        .parent(Some(parent.node_digest.clone()))
+        .created_unix(2)
+        .build();
+
+        emitter.emit_image_created(&plan, &parent).unwrap();
+        emitter.emit_image_created(&plan, &child).unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("image.created"));
+        assert!(content.contains("image_node_digest"));
+        assert!(content.contains(parent.node_digest.as_str()));
+        assert!(content.contains(child.node_digest.as_str()));
+        // The genesis node records the sentinel; the child records its hash-link.
+        assert!(content.contains("genesis"));
+        assert!(content.contains("image_build_identity"));
+        assert!(content.contains("slot-a"));
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 2);
     }
 
     #[test]

--- a/crates/mvm-runtime/src/checkpoint/mod.rs
+++ b/crates/mvm-runtime/src/checkpoint/mod.rs
@@ -7,6 +7,8 @@ use mvm_core::checkpoint::{
     CheckpointClass, CheckpointDigest, CheckpointId, CheckpointMeta, ContentBlob,
 };
 
+use crate::lineage::{LineageAnchor, LineageGraph, LineageRecord};
+
 /// Filename of the persisted supervisor launch config inside a vm_full
 /// checkpoint's content dir. Present only on checkpoints captured from a
 /// backend that writes a supervisor config (legacy captures); Firecracker
@@ -192,6 +194,54 @@ pub trait CheckpointChainAnchor {
     fn recorded_creation_digest(&self, meta: &CheckpointMeta) -> Result<Option<CheckpointDigest>>;
 }
 
+/// A checkpoint record participates in the shared, namespace-agnostic lineage
+/// walk ([`crate::lineage`]) as a content-addressed record: its stored digest is
+/// `meta_digest`, it recomputes via [`CheckpointMeta::compute_meta_digest`], and
+/// its parent hash-link is `parent`.
+impl LineageRecord for CheckpointMeta {
+    fn stored_digest(&self) -> &CheckpointDigest {
+        &self.meta_digest
+    }
+    fn recompute_digest(&self) -> CheckpointDigest {
+        self.compute_meta_digest()
+    }
+    fn parent_link(&self) -> Option<&CheckpointDigest> {
+        self.parent.as_ref()
+    }
+    fn kind(&self) -> &'static str {
+        "checkpoint"
+    }
+    fn id_label(&self) -> String {
+        self.id.to_string()
+    }
+    fn digest_field(&self) -> &'static str {
+        "meta_digest"
+    }
+}
+
+/// Bridge the checkpoint-specific anchor trait onto the generic one, so the
+/// shared walk accepts a `&dyn CheckpointChainAnchor` unchanged.
+impl LineageAnchor<CheckpointMeta> for dyn CheckpointChainAnchor + '_ {
+    fn recorded_creation_digest(&self, meta: &CheckpointMeta) -> Result<Option<CheckpointDigest>> {
+        CheckpointChainAnchor::recorded_creation_digest(self, meta)
+    }
+}
+
+/// Adapts a [`CheckpointStore`] to the generic [`LineageGraph`] the shared walk
+/// reads records from.
+struct CheckpointGraph<'a>(&'a CheckpointStore);
+
+impl LineageGraph for CheckpointGraph<'_> {
+    type Record = CheckpointMeta;
+    type Id = CheckpointId;
+    fn read(&self, id: &CheckpointId) -> Result<CheckpointMeta> {
+        self.0.read_meta(id)
+    }
+    fn by_digest(&self, digest: &CheckpointDigest) -> Result<Option<CheckpointMeta>> {
+        self.0.by_digest(digest)
+    }
+}
+
 /// Verify one checkpoint record against the signed audit chain: its stored
 /// `meta_digest` must equal a recomputation of its own fields (catches a
 /// post-seal edit that left the digest stale) AND must equal the
@@ -204,30 +254,7 @@ fn verify_checkpoint_against_chain(
     anchor: &dyn CheckpointChainAnchor,
     meta: &CheckpointMeta,
 ) -> Result<()> {
-    let recomputed = meta.compute_meta_digest();
-    if recomputed != meta.meta_digest {
-        anyhow::bail!(
-            "checkpoint '{}' meta_digest drift: stored {}, recomputed {} \
-             (its meta.json was edited after sealing)",
-            meta.id,
-            meta.meta_digest,
-            recomputed
-        );
-    }
-    match anchor.recorded_creation_digest(meta)? {
-        Some(recorded) if recorded == recomputed => Ok(()),
-        Some(recorded) => anyhow::bail!(
-            "checkpoint '{}' content-address {recomputed} does not match the \
-             signed audit chain, which recorded {recorded} at creation \
-             (the on-disk record was edited after it was audited)",
-            meta.id
-        ),
-        None => anyhow::bail!(
-            "checkpoint '{}' has no signed audit entry to anchor its \
-             content-address; refusing to treat an un-audited record as verified",
-            meta.id
-        ),
-    }
+    crate::lineage::verify_record_against_chain(anchor, meta)
 }
 
 /// Walk a checkpoint's lineage from `id` up to its genesis root, verifying each
@@ -253,34 +280,7 @@ pub fn verify_lineage(
     id: &CheckpointId,
     anchor: &dyn CheckpointChainAnchor,
 ) -> Result<()> {
-    let mut current = store.read_meta(id)?;
-    let mut seen: Vec<CheckpointDigest> = Vec::new();
-    loop {
-        verify_checkpoint_against_chain(anchor, &current)?;
-        if seen.contains(&current.meta_digest) {
-            anyhow::bail!(
-                "checkpoint '{}' lineage revisits digest {}: refusing a cyclic chain",
-                current.id,
-                current.meta_digest
-            );
-        }
-        seen.push(current.meta_digest.clone());
-
-        let parent_digest = match current.parent.clone() {
-            // Genesis root: no parent to chain to, the walk terminates clean.
-            None => return Ok(()),
-            Some(d) => d,
-        };
-        // Resolving the parent by its content-address *is* the hash-link check:
-        // by_digest only returns a record whose meta_digest equals the link, and
-        // that record's own digest is re-verified (against disk + chain) on the
-        // next iteration.
-        current = store.by_digest(&parent_digest)?.ok_or_else(|| {
-            anyhow::anyhow!(
-                "checkpoint lineage is broken: no checkpoint has parent-linked digest {parent_digest}"
-            )
-        })?;
-    }
+    crate::lineage::verify_lineage_chain(&CheckpointGraph(store), id, anchor)
 }
 
 /// The fork's source is the sealed checkpoint content (cloned at capture

--- a/crates/mvm-runtime/src/image_lineage.rs
+++ b/crates/mvm-runtime/src/image_lineage.rs
@@ -56,11 +56,27 @@ impl ImageStore {
         Ok(())
     }
 
-    /// Read the node stored under `node_digest` (its directory name).
+    /// Read the node stored under `node_digest` (its directory name). Fails
+    /// closed on a mis-filed record: the deserialized `node_digest` field must
+    /// equal the requested digest (the directory name), so a node planted under
+    /// another node's directory cannot slip through as that other node. This
+    /// self-consistency is what the lineage walk's first hop
+    /// (`graph.read(start)`) relies on; the walk then recomputes the digest to
+    /// prove the field is genuine.
     pub fn read(&self, node_digest: &CheckpointDigest) -> Result<ImageNode> {
         let path = self.node_path(node_digest);
         let bytes = std::fs::read(&path).with_context(|| format!("reading {}", path.display()))?;
-        serde_json::from_slice(&bytes).with_context(|| format!("parsing {}", path.display()))
+        let node: ImageNode = serde_json::from_slice(&bytes)
+            .with_context(|| format!("parsing {}", path.display()))?;
+        if &node.node_digest != node_digest {
+            anyhow::bail!(
+                "image node at {} is mis-filed: its directory names {node_digest} but the \
+                 record's node_digest is {}",
+                path.display(),
+                node.node_digest
+            );
+        }
+        Ok(node)
     }
 
     /// Every node with a well-formed `node.json`. `O(n)` directory scan (matches
@@ -109,21 +125,44 @@ impl ImageStore {
     }
 
     /// The current tip of `build_identity`'s version chain: the node with that
-    /// identity that is nobody's parent. `None` when no node carries the
+    /// identity that is nobody's parent. `Ok(None)` when no node carries the
     /// identity. A clean linear chain has exactly one such node; this is what a
     /// new build of the same identity hash-links its `parent` to.
+    ///
+    /// Fails closed on an ambiguous tip: if two or more nodes share the identity
+    /// and none descends from the others (a fork), there is no single tip to
+    /// build on, so this errors rather than silently pick a filesystem-order
+    /// arbitrary one — a caller (the build path) must not set a new node's
+    /// parent to a guessed head. It likewise errors if every matching node is
+    /// referenced as a parent (a cyclic/broken set with no tip).
     pub fn head_for(&self, build_identity: &ImageBuildIdentity) -> Result<Option<ImageNode>> {
         let matching: Vec<ImageNode> = self
             .list()?
             .into_iter()
             .filter(|n| &n.build_identity == build_identity)
             .collect();
+        if matching.is_empty() {
+            return Ok(None);
+        }
         let referenced_parents: std::collections::HashSet<&CheckpointDigest> =
             matching.iter().filter_map(|n| n.parent.as_ref()).collect();
-        Ok(matching
+        let tips: Vec<&ImageNode> = matching
             .iter()
-            .find(|n| !referenced_parents.contains(&n.node_digest))
-            .cloned())
+            .filter(|n| !referenced_parents.contains(&n.node_digest))
+            .collect();
+        match tips.as_slice() {
+            [tip] => Ok(Some((*tip).clone())),
+            [] => anyhow::bail!(
+                "image build identity {build_identity:?} has no version-chain tip: every \
+                 matching node is referenced as a parent (a cyclic or broken chain)"
+            ),
+            _ => anyhow::bail!(
+                "image build identity {build_identity:?} has an ambiguous version-chain tip: \
+                 {} nodes share it and none descends from the others (a fork); refusing to \
+                 pick one",
+                tips.len()
+            ),
+        }
     }
 }
 
@@ -349,6 +388,45 @@ mod tests {
             store.dir_for(&n.node_digest),
             tmp.path().join(n.node_digest.as_str())
         );
+    }
+
+    #[test]
+    fn read_rejects_a_misfiled_node() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        let real = node("slot-a", "rev-1", None);
+        let other = node("slot-a", "rev-2", None); // a different node_digest
+
+        // Plant `real`'s record under `other`'s directory name.
+        let dir = store.dir_for(&other.node_digest);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("node.json"),
+            serde_json::to_vec_pretty(&real).unwrap(),
+        )
+        .unwrap();
+
+        // Reading by the directory name must reject the mis-filed record...
+        let err = store.read(&other.node_digest).unwrap_err();
+        assert!(err.to_string().contains("mis-filed"), "{err}");
+        // ...and so must the walk's first hop.
+        let err = verify_image_lineage(&store, &other.node_digest, &AgreeingAnchor).unwrap_err();
+        assert!(err.to_string().contains("mis-filed"), "{err}");
+    }
+
+    #[test]
+    fn head_for_errors_on_an_ambiguous_forked_tip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        // g0 branches into two children — a genuine fork with two tips.
+        let g0 = node("slot-a", "rev-1", None);
+        let a = node("slot-a", "rev-2a", Some(g0.node_digest.clone()));
+        let b = node("slot-a", "rev-2b", Some(g0.node_digest.clone()));
+        for n in [&g0, &a, &b] {
+            store.save(n).unwrap();
+        }
+        let err = store.head_for(&flake_identity("slot-a")).unwrap_err();
+        assert!(err.to_string().contains("ambiguous"), "{err}");
     }
 
     // ── lineage tests (mock anchors) ─────────────────────────────────────────

--- a/crates/mvm-runtime/src/image_lineage.rs
+++ b/crates/mvm-runtime/src/image_lineage.rs
@@ -1,0 +1,438 @@
+//! Host-side image version-lineage store + chain-anchored verification. The
+//! image analog of [`crate::checkpoint`]'s store/verify: a filesystem registry
+//! of [`ImageNode`] records plus the fail-closed walk that proves a node's
+//! version chain against the signed audit log.
+//!
+//! Lineage is PROVENANCE, never AUTHORIZATION — see [`mvm_core::image_lineage`].
+//! Nothing here grants a child trust because an ancestor is present or verified;
+//! boot integrity stays with dm-verity and admission with the signed bundle.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use mvm_core::checkpoint::CheckpointDigest;
+use mvm_core::image_lineage::{ImageBuildIdentity, ImageNode};
+
+use crate::lineage::{LineageAnchor, LineageGraph, LineageRecord};
+
+/// Filesystem-backed registry over `config::images_dir()` (or any root, for
+/// tests). Layout: `<root>/<node-digest>/node.json`. A node's directory name is
+/// its own content-address, so a node is addressable by digest without an index.
+pub struct ImageStore {
+    root: PathBuf,
+}
+
+impl ImageStore {
+    /// Production constructor — uses the canonical `~/.mvm/images` path.
+    pub fn open() -> Self {
+        Self::at(mvm_core::config::images_dir())
+    }
+
+    /// Test/explicit-root constructor.
+    pub fn at(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn dir_for(&self, node_digest: &CheckpointDigest) -> PathBuf {
+        self.root.join(node_digest.as_str())
+    }
+
+    fn node_path(&self, node_digest: &CheckpointDigest) -> PathBuf {
+        self.dir_for(node_digest).join("node.json")
+    }
+
+    /// Persist a node under its own content-address.
+    pub fn save(&self, node: &ImageNode) -> Result<()> {
+        let dir = self.dir_for(&node.node_digest);
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("creating image node dir {}", dir.display()))?;
+        let json = serde_json::to_vec_pretty(node).context("serializing image node")?;
+        let path = self.node_path(&node.node_digest);
+        std::fs::write(&path, json).with_context(|| format!("writing {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Read the node stored under `node_digest` (its directory name).
+    pub fn read(&self, node_digest: &CheckpointDigest) -> Result<ImageNode> {
+        let path = self.node_path(node_digest);
+        let bytes = std::fs::read(&path).with_context(|| format!("reading {}", path.display()))?;
+        serde_json::from_slice(&bytes).with_context(|| format!("parsing {}", path.display()))
+    }
+
+    /// Every node with a well-formed `node.json`. `O(n)` directory scan (matches
+    /// [`crate::checkpoint::CheckpointStore::list`]).
+    pub fn list(&self) -> Result<Vec<ImageNode>> {
+        let mut out = Vec::new();
+        let entries = match std::fs::read_dir(&self.root) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(e) => return Err(e).context("reading images dir"),
+        };
+        for entry in entries {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let node_json = entry.path().join("node.json");
+            if node_json.exists() {
+                let bytes = std::fs::read(&node_json)
+                    .with_context(|| format!("reading {}", node_json.display()))?;
+                out.push(
+                    serde_json::from_slice(&bytes)
+                        .with_context(|| format!("parsing {}", node_json.display()))?,
+                );
+            }
+        }
+        Ok(out)
+    }
+
+    /// Look up a node by its content-address ([`ImageNode::node_digest`]). Scans
+    /// `list()` and matches the stored field, so a returned node's own digest
+    /// genuinely equals `digest` — the invariant the lineage walk relies on when
+    /// it resolves a parent hash-link.
+    pub fn by_digest(&self, digest: &CheckpointDigest) -> Result<Option<ImageNode>> {
+        Ok(self.list()?.into_iter().find(|n| &n.node_digest == digest))
+    }
+
+    /// Nodes whose parent hash-link is `parent_digest`. Lineage is derived by
+    /// content-address, not by a mutable name.
+    pub fn children_of(&self, parent_digest: &CheckpointDigest) -> Result<Vec<ImageNode>> {
+        Ok(self
+            .list()?
+            .into_iter()
+            .filter(|n| n.parent.as_ref() == Some(parent_digest))
+            .collect())
+    }
+
+    /// The current tip of `build_identity`'s version chain: the node with that
+    /// identity that is nobody's parent. `None` when no node carries the
+    /// identity. A clean linear chain has exactly one such node; this is what a
+    /// new build of the same identity hash-links its `parent` to.
+    pub fn head_for(&self, build_identity: &ImageBuildIdentity) -> Result<Option<ImageNode>> {
+        let matching: Vec<ImageNode> = self
+            .list()?
+            .into_iter()
+            .filter(|n| &n.build_identity == build_identity)
+            .collect();
+        let referenced_parents: std::collections::HashSet<&CheckpointDigest> =
+            matching.iter().filter_map(|n| n.parent.as_ref()).collect();
+        Ok(matching
+            .iter()
+            .find(|n| !referenced_parents.contains(&n.node_digest))
+            .cloned())
+    }
+}
+
+/// Resolves the signature-authenticated content-address an image node's creation
+/// was recorded under in the chain-signed audit log. The image analog of
+/// [`crate::checkpoint::CheckpointChainAnchor`]: injected so this crate's walk
+/// stays free of host-key loading and audit-file layout, which live in the CLI.
+/// An implementation MUST verify the audit chain's signatures before trusting
+/// any digest it returns.
+pub trait ImageChainAnchor {
+    /// The content-address recorded for `node`'s creation in the signature-
+    /// verified audit chain (`image.created`'s `image_node_digest`), or `None`
+    /// if the chain carries no creation entry for it.
+    fn recorded_creation_digest(&self, node: &ImageNode) -> Result<Option<CheckpointDigest>>;
+}
+
+/// An [`ImageNode`] participates in the shared lineage walk: its stored digest
+/// is `node_digest`, it recomputes via [`ImageNode::compute_node_digest`], and
+/// its parent hash-link is `parent`.
+impl LineageRecord for ImageNode {
+    fn stored_digest(&self) -> &CheckpointDigest {
+        &self.node_digest
+    }
+    fn recompute_digest(&self) -> CheckpointDigest {
+        self.compute_node_digest()
+    }
+    fn parent_link(&self) -> Option<&CheckpointDigest> {
+        self.parent.as_ref()
+    }
+    fn kind(&self) -> &'static str {
+        "image node"
+    }
+    fn id_label(&self) -> String {
+        self.node_digest.to_string()
+    }
+    fn digest_field(&self) -> &'static str {
+        "node_digest"
+    }
+}
+
+/// Bridge the image-specific anchor trait onto the generic one.
+impl LineageAnchor<ImageNode> for dyn ImageChainAnchor + '_ {
+    fn recorded_creation_digest(&self, node: &ImageNode) -> Result<Option<CheckpointDigest>> {
+        ImageChainAnchor::recorded_creation_digest(self, node)
+    }
+}
+
+/// Adapts an [`ImageStore`] to the generic [`LineageGraph`].
+struct ImageGraph<'a>(&'a ImageStore);
+
+impl LineageGraph for ImageGraph<'_> {
+    type Record = ImageNode;
+    type Id = CheckpointDigest;
+    fn read(&self, id: &CheckpointDigest) -> Result<ImageNode> {
+        self.0.read(id)
+    }
+    fn by_digest(&self, digest: &CheckpointDigest) -> Result<Option<ImageNode>> {
+        self.0.by_digest(digest)
+    }
+}
+
+/// Walk an image node's version lineage from `node_digest` to its genesis root,
+/// verifying each record against the **signed** audit chain via `anchor`: at
+/// every hop the record's recomputed content-address must equal both its stored
+/// `node_digest` and the digest the host signed into the audit chain at
+/// creation. Fails closed on a recompute drift, a chain mismatch, a node with no
+/// signed creation entry, a dangling parent hash-link, or a cycle — the same
+/// guarantees as the checkpoint verifier, over the same shared walk.
+///
+/// This proves integrity of the provenance chain; it grants nothing. A verified
+/// lineage does not admit or boot an image (dm-verity + signed bundle do).
+pub fn verify_image_lineage(
+    store: &ImageStore,
+    node_digest: &CheckpointDigest,
+    anchor: &dyn ImageChainAnchor,
+) -> Result<()> {
+    crate::lineage::verify_lineage_chain(&ImageGraph(store), node_digest, anchor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::image_lineage::{ImageCanonicalId, ImageIdentity, ImageProvenance};
+    use std::collections::HashMap;
+
+    fn flake_identity(slot: &str) -> ImageBuildIdentity {
+        ImageBuildIdentity::Flake {
+            slot_hash: slot.into(),
+        }
+    }
+
+    fn node(slot: &str, revision: &str, parent: Option<CheckpointDigest>) -> ImageNode {
+        ImageNode::builder(
+            flake_identity(slot),
+            ImageIdentity {
+                canonical: ImageCanonicalId::Flake {
+                    revision_hash: revision.into(),
+                },
+                artifacts: vec![mvm_core::checkpoint::ContentBlob {
+                    name: "rootfs.ext4".into(),
+                    sha256: revision.into(),
+                }],
+            },
+            ImageProvenance::Build {
+                input_ref: ".#app".into(),
+                lock_digest: None,
+            },
+        )
+        .parent(parent)
+        .created_unix(1)
+        .build()
+    }
+
+    // ── mock anchors (mirror the checkpoint mod's Agreeing/Disagreeing/Unaudited)
+
+    struct AgreeingAnchor;
+    impl ImageChainAnchor for AgreeingAnchor {
+        fn recorded_creation_digest(&self, n: &ImageNode) -> Result<Option<CheckpointDigest>> {
+            Ok(Some(n.compute_node_digest()))
+        }
+    }
+
+    /// Indexes only the node digests it was told about — models a signed chain
+    /// that recorded some nodes' creation but not others'.
+    struct IndexedAnchor(HashMap<String, CheckpointDigest>);
+    impl IndexedAnchor {
+        fn of(nodes: &[&ImageNode]) -> Self {
+            Self(
+                nodes
+                    .iter()
+                    .map(|n| (n.node_digest.to_string(), n.node_digest.clone()))
+                    .collect(),
+            )
+        }
+    }
+    impl ImageChainAnchor for IndexedAnchor {
+        fn recorded_creation_digest(&self, n: &ImageNode) -> Result<Option<CheckpointDigest>> {
+            Ok(self.0.get(n.node_digest.as_str()).cloned())
+        }
+    }
+
+    struct DisagreeingAnchor(CheckpointDigest);
+    impl ImageChainAnchor for DisagreeingAnchor {
+        fn recorded_creation_digest(&self, _n: &ImageNode) -> Result<Option<CheckpointDigest>> {
+            Ok(Some(self.0.clone()))
+        }
+    }
+
+    fn unrelated_digest() -> CheckpointDigest {
+        CheckpointDigest::parse(format!("sha256:{}", "f".repeat(64))).unwrap()
+    }
+
+    // ── store tests ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn save_then_read_roundtrips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        let n = node("slot-a", "rev-1", None);
+        store.save(&n).unwrap();
+        assert_eq!(store.read(&n.node_digest).unwrap(), n);
+    }
+
+    #[test]
+    fn by_digest_finds_the_node() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        let n = node("slot-a", "rev-1", None);
+        store.save(&n).unwrap();
+        assert_eq!(store.by_digest(&n.node_digest).unwrap().as_ref(), Some(&n));
+        assert!(store.by_digest(&unrelated_digest()).unwrap().is_none());
+    }
+
+    #[test]
+    fn children_of_finds_lineage_by_hashlink() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        let parent = node("slot-a", "rev-1", None);
+        store.save(&parent).unwrap();
+        let child = node("slot-a", "rev-2", Some(parent.node_digest.clone()));
+        store.save(&child).unwrap();
+        let kids = store.children_of(&parent.node_digest).unwrap();
+        assert_eq!(kids.len(), 1);
+        assert_eq!(kids[0].node_digest, child.node_digest);
+    }
+
+    #[test]
+    fn head_for_returns_the_tip_and_none_for_unknown_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        let g0 = node("slot-a", "rev-1", None);
+        let g1 = node("slot-a", "rev-2", Some(g0.node_digest.clone()));
+        let g2 = node("slot-a", "rev-3", Some(g1.node_digest.clone()));
+        // A node on a DIFFERENT identity must not affect slot-a's head.
+        let other = node("slot-b", "rev-1", None);
+        for n in [&g0, &g1, &g2, &other] {
+            store.save(n).unwrap();
+        }
+        // The tip is g2 (nobody's parent within slot-a).
+        assert_eq!(
+            store
+                .head_for(&flake_identity("slot-a"))
+                .unwrap()
+                .unwrap()
+                .node_digest,
+            g2.node_digest
+        );
+        // Unknown identity → None.
+        assert!(
+            store
+                .head_for(&flake_identity("slot-unknown"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn dir_name_is_the_node_digest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        let n = node("slot-a", "rev-1", None);
+        assert_eq!(
+            store.dir_for(&n.node_digest),
+            tmp.path().join(n.node_digest.as_str())
+        );
+    }
+
+    // ── lineage tests (mock anchors) ─────────────────────────────────────────
+
+    fn seed_three_node_chain(store: &ImageStore) -> (ImageNode, ImageNode, ImageNode) {
+        let g0 = node("slot-a", "rev-1", None);
+        let g1 = node("slot-a", "rev-2", Some(g0.node_digest.clone()));
+        let g2 = node("slot-a", "rev-3", Some(g1.node_digest.clone()));
+        for n in [&g0, &g1, &g2] {
+            store.save(n).unwrap();
+        }
+        (g0, g1, g2)
+    }
+
+    #[test]
+    fn three_node_chain_verifies_end_to_end() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        let (g0, g1, g2) = seed_three_node_chain(&store);
+        // Each hop is a hash-link to the predecessor's content-address.
+        assert_eq!(g2.parent.as_ref().unwrap(), &g1.node_digest);
+        assert_eq!(g1.parent.as_ref().unwrap(), &g0.node_digest);
+        let anchor = IndexedAnchor::of(&[&g0, &g1, &g2]);
+        verify_image_lineage(&store, &g2.node_digest, &anchor).unwrap();
+    }
+
+    #[test]
+    fn tampered_node_is_rejected_as_drift() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        let (g0, _g1, g2) = seed_three_node_chain(&store);
+        verify_image_lineage(&store, &g2.node_digest, &AgreeingAnchor).unwrap();
+
+        // Edit an ANCESTOR's node.json: change a load-bearing field but leave the
+        // stored node_digest, so recompute no longer matches.
+        let path = store.dir_for(&g0.node_digest).join("node.json");
+        let mut tampered: ImageNode =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        tampered.created_unix = 999;
+        std::fs::write(&path, serde_json::to_vec_pretty(&tampered).unwrap()).unwrap();
+
+        let err = verify_image_lineage(&store, &g2.node_digest, &AgreeingAnchor).unwrap_err();
+        assert!(err.to_string().contains("node_digest drift"), "{err}");
+    }
+
+    #[test]
+    fn node_absent_from_signed_chain_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        let (g0, g1, g2) = seed_three_node_chain(&store);
+        // The chain recorded g0 and g1 but NOT g2's creation.
+        let anchor = IndexedAnchor::of(&[&g0, &g1]);
+        let err = verify_image_lineage(&store, &g2.node_digest, &anchor).unwrap_err();
+        assert!(err.to_string().contains("no signed audit entry"), "{err}");
+    }
+
+    #[test]
+    fn chain_recorded_digest_disagreeing_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        let g0 = node("slot-a", "rev-1", None);
+        store.save(&g0).unwrap();
+        let err = verify_image_lineage(
+            &store,
+            &g0.node_digest,
+            &DisagreeingAnchor(unrelated_digest()),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not match the signed audit chain"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn dangling_parent_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        // A child hash-linked to a digest no stored node carries.
+        let orphan = CheckpointDigest::parse(format!("sha256:{}", "e".repeat(64))).unwrap();
+        let child = node("slot-a", "rev-1", Some(orphan));
+        store.save(&child).unwrap();
+        let err = verify_image_lineage(&store, &child.node_digest, &AgreeingAnchor).unwrap_err();
+        assert!(err.to_string().contains("lineage is broken"), "{err}");
+    }
+}

--- a/crates/mvm-runtime/src/lib.rs
+++ b/crates/mvm-runtime/src/lib.rs
@@ -66,11 +66,17 @@ pub mod hvf;
 pub mod hvf_backend;
 pub(crate) mod hvf_bootargs;
 pub mod image;
+/// Content-addressed image version-lineage store + chain-anchored verification
+/// (the image analog of [`checkpoint`]). Reuses the shared `lineage` walk.
+pub mod image_lineage;
 /// KVM (Linux) backend — drives [`vmm`] on Linux via `kvm-ioctls`, implementing
 /// the [`vmm::hv`] seam. `kvm::x86_boot` is pure logic
 /// (compiles + tests everywhere); the ioctl glue is Linux-only.
 pub mod kvm;
 pub mod libkrun;
+/// Namespace-agnostic hash-linked lineage walk shared by [`checkpoint`] and
+/// [`image_lineage`].
+pub(crate) mod lineage;
 pub mod microvm;
 /// The hermetic in-memory `MockBackend` — see its module docs for the
 /// security posture. Gated behind `test-support` so it never compiles into

--- a/crates/mvm-runtime/src/lineage.rs
+++ b/crates/mvm-runtime/src/lineage.rs
@@ -1,0 +1,309 @@
+//! Generic, namespace-agnostic hash-linked lineage verification shared by the
+//! checkpoint store and the image-lineage store. The walk is written once here
+//! over three small traits; [`crate::checkpoint`] and [`crate::image_lineage`]
+//! supply the record/store/anchor impls and delegate to it rather than forking
+//! a second copy.
+//!
+//! Both lineages share the same guarantee and the same fail-closed posture:
+//! each record's recomputed content-address must equal both its stored digest
+//! (catching a post-seal edit) AND the digest the host signed into the audit
+//! chain at creation (catching a fully self-consistent local re-forge, which
+//! survives recompute alone but not the signed chain it cannot re-sign). The
+//! parent hash-link is followed by content-address, so editing any ancestor's
+//! sealed record is caught from any descendant.
+
+use anyhow::Result;
+use mvm_core::checkpoint::CheckpointDigest;
+
+/// One record in a content-addressed lineage: it carries its own stored
+/// content-address, can recompute that address from its load-bearing fields,
+/// and hash-links to its predecessor by content-address.
+pub(crate) trait LineageRecord {
+    /// The content-address stored on disk for this record.
+    fn stored_digest(&self) -> &CheckpointDigest;
+    /// Recompute the content-address from the record's current fields. Equal to
+    /// [`Self::stored_digest`] iff the record was not edited after sealing.
+    fn recompute_digest(&self) -> CheckpointDigest;
+    /// The predecessor's content-address, or `None` at genesis.
+    fn parent_link(&self) -> Option<&CheckpointDigest>;
+    /// Human noun for error messages, e.g. `"checkpoint"` / `"image node"`.
+    fn kind(&self) -> &'static str;
+    /// The record's own identifier for error messages (checkpoint id / node
+    /// digest).
+    fn id_label(&self) -> String;
+    /// The on-disk digest field's name, for drift messages (`"meta_digest"` /
+    /// `"node_digest"`).
+    fn digest_field(&self) -> &'static str;
+}
+
+/// A store the walk reads records from: by a start id, or by content-address to
+/// resolve a parent hash-link.
+pub(crate) trait LineageGraph {
+    type Record: LineageRecord;
+    type Id;
+    /// Read the record the walk starts at.
+    fn read(&self, id: &Self::Id) -> Result<Self::Record>;
+    /// The record whose stored content-address is `digest`, or `None` if no
+    /// stored record carries it. Returning only a record whose own digest equals
+    /// the link is what makes resolving a parent by content-address *be* the
+    /// hash-link check.
+    fn by_digest(&self, digest: &CheckpointDigest) -> Result<Option<Self::Record>>;
+}
+
+/// Resolves the signature-authenticated content-address a record's creation was
+/// recorded under in the chain-signed audit log. An implementation MUST verify
+/// the audit chain's signatures before trusting any digest it returns.
+pub(crate) trait LineageAnchor<R> {
+    fn recorded_creation_digest(&self, record: &R) -> Result<Option<CheckpointDigest>>;
+}
+
+/// Verify one record against the signed chain: its stored digest must equal a
+/// recomputation of its own fields (catches a post-seal edit that left the
+/// digest stale) AND must equal the signature-verified digest the audit chain
+/// recorded at creation (catches a full local re-forge). Fails closed on a
+/// drift, a mismatch against the chain, or the absence of any signed creation
+/// entry.
+pub(crate) fn verify_record_against_chain<R, A>(anchor: &A, record: &R) -> Result<()>
+where
+    R: LineageRecord,
+    A: LineageAnchor<R> + ?Sized,
+{
+    let recomputed = record.recompute_digest();
+    if &recomputed != record.stored_digest() {
+        anyhow::bail!(
+            "{} '{}' {} drift: stored {}, recomputed {} \
+             (its on-disk record was edited after sealing)",
+            record.kind(),
+            record.id_label(),
+            record.digest_field(),
+            record.stored_digest(),
+            recomputed
+        );
+    }
+    match anchor.recorded_creation_digest(record)? {
+        Some(recorded) if recorded == recomputed => Ok(()),
+        Some(recorded) => anyhow::bail!(
+            "{} '{}' content-address {recomputed} does not match the signed audit \
+             chain, which recorded {recorded} at creation \
+             (the on-disk record was edited after it was audited)",
+            record.kind(),
+            record.id_label()
+        ),
+        None => anyhow::bail!(
+            "{} '{}' has no signed audit entry to anchor its content-address; \
+             refusing to treat an un-audited record as verified",
+            record.kind(),
+            record.id_label()
+        ),
+    }
+}
+
+/// Walk a record's lineage from `start` up to its genesis root, verifying each
+/// record against the signed audit chain via `anchor`. Fails closed on: a drift
+/// or chain mismatch (via [`verify_record_against_chain`]), a parent hash-link
+/// that resolves to no stored record (dangling lineage), or a revisited digest
+/// (a would-be cycle — cryptographically infeasible for genuine
+/// content-addresses, refused rather than looped on).
+pub(crate) fn verify_lineage_chain<G, A>(graph: &G, start: &G::Id, anchor: &A) -> Result<()>
+where
+    G: LineageGraph,
+    A: LineageAnchor<G::Record> + ?Sized,
+{
+    let mut current = graph.read(start)?;
+    let mut seen: Vec<CheckpointDigest> = Vec::new();
+    loop {
+        verify_record_against_chain(anchor, &current)?;
+        if seen.contains(current.stored_digest()) {
+            anyhow::bail!(
+                "{} '{}' lineage revisits digest {}: refusing a cyclic chain",
+                current.kind(),
+                current.id_label(),
+                current.stored_digest()
+            );
+        }
+        seen.push(current.stored_digest().clone());
+
+        let kind = current.kind();
+        let parent_digest = match current.parent_link() {
+            // Genesis root: no parent to chain to, the walk terminates clean.
+            None => return Ok(()),
+            Some(d) => d.clone(),
+        };
+        // Resolving the parent by its content-address *is* the hash-link check:
+        // by_digest only returns a record whose stored digest equals the link,
+        // and that record's own digest is re-verified on the next iteration.
+        current = graph.by_digest(&parent_digest)?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "{kind} lineage is broken: no {kind} has parent-linked digest {parent_digest}"
+            )
+        })?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn digest(seed: char) -> CheckpointDigest {
+        CheckpointDigest::parse(format!("sha256:{}", seed.to_string().repeat(64))).unwrap()
+    }
+
+    /// A fully controllable record: its stored digest, recompute result, and
+    /// parent link are all set by the test, so cases impossible to construct
+    /// with a real content-address (a genuine cycle) are reachable here.
+    #[derive(Clone)]
+    struct MockRecord {
+        stored: CheckpointDigest,
+        recompute: CheckpointDigest,
+        parent: Option<CheckpointDigest>,
+    }
+
+    impl LineageRecord for MockRecord {
+        fn stored_digest(&self) -> &CheckpointDigest {
+            &self.stored
+        }
+        fn recompute_digest(&self) -> CheckpointDigest {
+            self.recompute.clone()
+        }
+        fn parent_link(&self) -> Option<&CheckpointDigest> {
+            self.parent.as_ref()
+        }
+        fn kind(&self) -> &'static str {
+            "mock"
+        }
+        fn id_label(&self) -> String {
+            self.stored.to_string()
+        }
+        fn digest_field(&self) -> &'static str {
+            "mock_digest"
+        }
+    }
+
+    struct MockGraph {
+        by_stored: HashMap<String, MockRecord>,
+    }
+
+    impl MockGraph {
+        fn new(records: Vec<MockRecord>) -> Self {
+            let by_stored = records
+                .into_iter()
+                .map(|r| (r.stored.to_string(), r))
+                .collect();
+            Self { by_stored }
+        }
+    }
+
+    impl LineageGraph for MockGraph {
+        type Record = MockRecord;
+        type Id = CheckpointDigest;
+        fn read(&self, id: &CheckpointDigest) -> Result<MockRecord> {
+            self.by_stored
+                .get(id.as_str())
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("no record {id}"))
+        }
+        fn by_digest(&self, d: &CheckpointDigest) -> Result<Option<MockRecord>> {
+            Ok(self.by_stored.get(d.as_str()).cloned())
+        }
+    }
+
+    /// Anchor that echoes each record's own recompute — the honest case.
+    struct AgreeingAnchor;
+    impl LineageAnchor<MockRecord> for AgreeingAnchor {
+        fn recorded_creation_digest(&self, r: &MockRecord) -> Result<Option<CheckpointDigest>> {
+            Ok(Some(r.recompute_digest()))
+        }
+    }
+
+    struct UnauditedAnchor;
+    impl LineageAnchor<MockRecord> for UnauditedAnchor {
+        fn recorded_creation_digest(&self, _r: &MockRecord) -> Result<Option<CheckpointDigest>> {
+            Ok(None)
+        }
+    }
+
+    struct DisagreeingAnchor(CheckpointDigest);
+    impl LineageAnchor<MockRecord> for DisagreeingAnchor {
+        fn recorded_creation_digest(&self, _r: &MockRecord) -> Result<Option<CheckpointDigest>> {
+            Ok(Some(self.0.clone()))
+        }
+    }
+
+    fn record(stored: char, parent: Option<char>) -> MockRecord {
+        MockRecord {
+            stored: digest(stored),
+            recompute: digest(stored),
+            parent: parent.map(digest),
+        }
+    }
+
+    #[test]
+    fn genesis_and_multi_generation_chains_verify() {
+        let g0 = record('a', None);
+        let g1 = record('b', Some('a'));
+        let g2 = record('c', Some('b'));
+        let graph = MockGraph::new(vec![g0, g1, g2]);
+        verify_lineage_chain(&graph, &digest('c'), &AgreeingAnchor).unwrap();
+        verify_lineage_chain(&graph, &digest('a'), &AgreeingAnchor).unwrap();
+    }
+
+    #[test]
+    fn drift_between_stored_and_recompute_is_rejected() {
+        let mut r = record('a', None);
+        r.recompute = digest('e'); // stored != recompute (valid but different hex)
+        let graph = MockGraph::new(vec![r]);
+        let err = verify_lineage_chain(&graph, &digest('a'), &AgreeingAnchor).unwrap_err();
+        assert!(err.to_string().contains("mock_digest drift"), "{err}");
+    }
+
+    #[test]
+    fn chain_recorded_digest_mismatch_is_rejected() {
+        let graph = MockGraph::new(vec![record('a', None)]);
+        let err = verify_lineage_chain(&graph, &digest('a'), &DisagreeingAnchor(digest('f')))
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not match the signed audit chain"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn node_with_no_signed_entry_is_rejected() {
+        let graph = MockGraph::new(vec![record('a', None)]);
+        let err = verify_lineage_chain(&graph, &digest('a'), &UnauditedAnchor).unwrap_err();
+        assert!(err.to_string().contains("no signed audit entry"), "{err}");
+    }
+
+    #[test]
+    fn dangling_parent_is_rejected() {
+        // Child links to a parent digest no stored record carries.
+        let graph = MockGraph::new(vec![record('a', Some('e'))]);
+        let err = verify_lineage_chain(&graph, &digest('a'), &AgreeingAnchor).unwrap_err();
+        assert!(err.to_string().contains("lineage is broken"), "{err}");
+    }
+
+    #[test]
+    fn a_genuine_cycle_is_refused_not_looped_on() {
+        // Only reachable with hand-set digests: a real content-address cannot
+        // encode a cycle. a→b→a; the anchor agrees so drift/mismatch don't fire
+        // first, isolating the cycle guard.
+        let a = MockRecord {
+            stored: digest('a'),
+            recompute: digest('a'),
+            parent: Some(digest('b')),
+        };
+        let b = MockRecord {
+            stored: digest('b'),
+            recompute: digest('b'),
+            parent: Some(digest('a')),
+        };
+        let graph = MockGraph::new(vec![a, b]);
+
+        // The cycle guard must terminate the walk (a hang here would time the
+        // test out) and refuse rather than loop.
+        let err = verify_lineage_chain(&graph, &digest('a'), &AgreeingAnchor).unwrap_err();
+        assert!(err.to_string().contains("cyclic chain"), "{err}");
+    }
+}


### PR DESCRIPTION
Slice **B1** of #1808 (part of epic #1806) — the image-lineage node **model + store + verification + audit-anchor plumbing**. Build-path wiring is a separate slice (B2); walk/rewind verbs are workstream C.

Decision C (version-chain): a compiled image's parent is the **predecessor image node for the same build identity** (flake slot / OCI repo), so the lineage walk is a workload's compiled-image history. The external base is recorded as a **provenance attribute**, not the walk edge.

## What's here
- `ImageNode` (`mvm-core`) reusing `CheckpointDigest` + `ContentBlob` and the `CheckpointMeta` digest pattern (no forked digest newtype); global digest-keyed `ImageStore` at `~/.mvm/images/<node-digest>/node.json`; `head_for(build_identity)` for the version-chain tip.
- **Generalized the checkpoint `verify_lineage`** into a shared `lineage.rs` walk (traits `LineageRecord`/`LineageGraph`/`LineageAnchor`); the checkpoint verifier now delegates to it — reviewed and **proven behavior-identical** (every fail-closed check, ordering, and error preserved).
- `image.created` audit event + `emit_image_created`; `SignedChainAnchor` indexes it (namespaced keys so checkpoint/image can't collide) and anchors image lineage against the same signed host-lifecycle chain.

## Review
Two-stage adversarial (correctness + security): checkpoint refactor behavior-identical; node is inert w.r.t. trust (provenance-not-authorization); verifier fail-closed on drift / un-audited / dangling / cycle; anchor trusts only signature-verified entries. Five review fixes applied — self-verifying `ImageStore::read` (walk's first hop can't be fooled by a mis-filed node), `head_for` fails closed on an ambiguous fork tip, `deny_unknown_fields` on the new enums, namespaced anchor map, doc fix.

## Gate
`nextest --workspace` 7645 passed / 0 failed; doctests, `clippy --all-targets -D warnings`, nightly fmt, and `xtask check-content-address-determinism` (now covering `ImageNode`'s digest) all clean.
