### PR TITLE
Reduce and fence `unsafe` across the workspace

### DIFF
--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -1216,6 +1216,9 @@ fn nix_system() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // The local `TestEnv` below is a ShellEnvironment mock; import the
+    // process-env guard under a distinct name so the two don't collide.
+    use mvm_core::util::test_env::TestEnv as EnvGuard;
     use std::collections::HashMap;
     use std::sync::Mutex;
 
@@ -2076,17 +2079,9 @@ mod tests {
         // sentinel to check for in this mock), the env var escape
         // hatch can force one.
         let env = TestEnv::new();
-        // SAFETY: tests only; MVM_DEV_FLAKE_URL is process-global
-        // but the value is harmless and we restore it.
-        let prev = std::env::var("MVM_DEV_FLAKE_URL").ok();
-        unsafe { std::env::set_var("MVM_DEV_FLAKE_URL", "git+file:///tmp/fake?dir=nix/dev") };
+        let mut env_guard = EnvGuard::new();
+        env_guard.set("MVM_DEV_FLAKE_URL", "git+file:///tmp/fake?dir=nix/dev");
         let flags = dev_override_flags(&env, BuildMode::Dev);
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("MVM_DEV_FLAKE_URL", v),
-                None => std::env::remove_var("MVM_DEV_FLAKE_URL"),
-            }
-        }
         assert!(
             flags.contains("--override-input mvm"),
             "Dev with MVM_DEV_FLAKE_URL set must produce an override; got: {flags:?}"

--- a/crates/mvm-cli/src/commands/build/build.rs
+++ b/crates/mvm-cli/src/commands/build/build.rs
@@ -74,15 +74,13 @@ pub(in crate::commands) struct Args {
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
-    // `--no-persistent-builder` flips the
-    // env-var bridge that `mvm_build::pipeline::dev_build` reads.
-    // Set once at the top so every subsequent dispatch (flake /
-    // manifest / mvmfile) sees the same toggle. We deliberately
-    // leave the env var set for the process's lifetime — every
-    // codepath under `mvmctl build` should agree on the choice.
-    // SAFETY: called early, before any threads spawn.
+    // `--no-persistent-builder` flips the env-var bridge that
+    // `mvm_build::pipeline::dev_build` reads. Set once at the top so every
+    // subsequent dispatch (flake / manifest / mvmfile) sees the same toggle,
+    // and left set for the process's lifetime so every codepath under
+    // `mvmctl build` agrees on the choice.
     if args.no_persistent_builder {
-        unsafe { std::env::set_var("MVM_NO_PERSISTENT_BUILDER", "1") };
+        crate::commands::set_cli_env("MVM_NO_PERSISTENT_BUILDER", "1");
     }
     // `--deps` narrows the build to the deps
     // volume only. We invalidate the cache index entries pointing at

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -227,21 +227,37 @@ pub fn run() -> Result<()> {
     with_hints(result)
 }
 
+/// Set a process-global environment variable from the CLI.
+///
+/// mvmctl uses the environment as its config-propagation channel: these values
+/// are read both in-process (`fc_version()`, the backend/kernel resolvers) and,
+/// crucially, by re-exec'd child `mvmctl` helpers — e.g. the builder-VM
+/// bootstrap — which receive the resolved CLI choice only by inheriting this
+/// environment. That rules out a `OnceCell` or a threaded parameter.
+pub(in crate::commands) fn set_cli_env(key: &str, value: impl AsRef<std::ffi::OsStr>) {
+    // SAFETY: every caller runs on the main thread before mvmctl creates any
+    // worker threads or async runtime — at CLI startup and at the very top of a
+    // command handler. The only thread alive by then is the SIGINT servicer
+    // (`crate::signal`), which blocks on a pipe read and never touches the
+    // environment, so no `getenv` can race this `setenv`.
+    unsafe { std::env::set_var(key, value) };
+}
+
 fn apply_startup_env(cli: &Cli) {
     if let Some(ref version) = cli.fc_version {
-        unsafe { std::env::set_var("MVM_FC_VERSION", version) };
+        set_cli_env("MVM_FC_VERSION", version);
     }
     if let Some(ref backend) = cli.builder {
-        unsafe { std::env::set_var("MVM_BUILDER_BACKEND", backend) };
+        set_cli_env("MVM_BUILDER_BACKEND", backend);
     }
     if let Some(dir) = aux_bin_dir_to_apply(
         env!("MVM_AUX_BIN_DIR"),
         std::env::var_os("MVM_AUX_BIN_DIR").is_some(),
     ) {
-        unsafe { std::env::set_var("MVM_AUX_BIN_DIR", dir) };
+        set_cli_env("MVM_AUX_BIN_DIR", dir);
     }
     if let Some(ref source) = cli.kernel_source {
-        unsafe { std::env::set_var("MVM_KERNEL_SOURCE", source) };
+        set_cli_env("MVM_KERNEL_SOURCE", source);
     }
 }
 
@@ -278,9 +294,7 @@ fn configure_runtime_logging(cli: &Cli) {
     let verbose = cli.verbose > 0 || std::env::var_os("RUST_LOG").is_some();
     mvm_runtime::ui::set_verbose(verbose);
     if cli.verbose > 0 && std::env::var_os("RUST_LOG").is_none() {
-        unsafe {
-            std::env::set_var("RUST_LOG", logging::filter_for_verbosity(cli.verbose));
-        }
+        set_cli_env("RUST_LOG", logging::filter_for_verbosity(cli.verbose));
     }
     let log_format = match cli.log_format.as_deref() {
         Some("json") => LogFormat::Json,

--- a/crates/mvm-cli/src/commands/shared/resolve.rs
+++ b/crates/mvm-cli/src/commands/shared/resolve.rs
@@ -278,6 +278,7 @@ pub fn resolve_effective_hypervisor(requested: &str) -> String {
 mod tests {
     use super::*;
     use mvm_core::network_policy::{HostPort, NetworkPolicy, NetworkPreset};
+    use mvm_core::util::test_env::TestEnv;
 
     #[test]
     fn run_net_default_is_deny_all() {
@@ -390,33 +391,16 @@ mod tests {
     /// under nextest; restored here so a threaded runner doesn't leak it.
     #[test]
     fn env_overrides_auto_detect_with_alias() {
-        let saved_hv = std::env::var_os("MVM_HYPERVISOR");
-        let saved_be = std::env::var_os("MVM_BACKEND");
-        // SAFETY: test-local env mutation, restored before returning.
-        unsafe {
-            std::env::remove_var("MVM_BACKEND");
-            std::env::set_var("MVM_HYPERVISOR", "libkrun");
-        }
+        let mut env = TestEnv::new();
+        env.remove("MVM_BACKEND");
+        env.set("MVM_HYPERVISOR", "libkrun");
         assert_eq!(resolve_effective_hypervisor("firecracker"), "libkrun");
         // An explicit flag wins over the env override.
         assert_eq!(resolve_effective_hypervisor("qemu"), "qemu");
         // The older alias is still honored.
-        unsafe {
-            std::env::remove_var("MVM_HYPERVISOR");
-            std::env::set_var("MVM_BACKEND", "hvf");
-        }
+        env.remove("MVM_HYPERVISOR");
+        env.set("MVM_BACKEND", "hvf");
         assert_eq!(resolve_effective_hypervisor("firecracker"), "hvf");
-        // SAFETY: restore prior values.
-        unsafe {
-            match saved_hv {
-                Some(v) => std::env::set_var("MVM_HYPERVISOR", v),
-                None => std::env::remove_var("MVM_HYPERVISOR"),
-            }
-            match saved_be {
-                Some(v) => std::env::set_var("MVM_BACKEND", v),
-                None => std::env::remove_var("MVM_BACKEND"),
-            }
-        }
     }
 
     /// On the macOS-26 Apple Silicon tier the auto-detect default is the
@@ -428,24 +412,9 @@ mod tests {
         if !mvm_core::platform::current().is_hvf_default_tier() {
             return; // Not on the macOS-26 tier (e.g. macOS 13-25 CI runner).
         }
-        let saved_hv = std::env::var_os("MVM_HYPERVISOR");
-        let saved_be = std::env::var_os("MVM_BACKEND");
-        // SAFETY: test-local env mutation, restored before returning.
-        unsafe {
-            std::env::remove_var("MVM_HYPERVISOR");
-            std::env::remove_var("MVM_BACKEND");
-        }
+        let mut env = TestEnv::new();
+        env.remove("MVM_HYPERVISOR");
+        env.remove("MVM_BACKEND");
         assert_eq!(resolve_effective_hypervisor("firecracker"), "hvf");
-        // SAFETY: restore prior values.
-        unsafe {
-            match saved_hv {
-                Some(v) => std::env::set_var("MVM_HYPERVISOR", v),
-                None => std::env::remove_var("MVM_HYPERVISOR"),
-            }
-            match saved_be {
-                Some(v) => std::env::set_var("MVM_BACKEND", v),
-                None => std::env::remove_var("MVM_BACKEND"),
-            }
-        }
     }
 }

--- a/crates/mvm-cli/src/doctor/builder.rs
+++ b/crates/mvm-cli/src/doctor/builder.rs
@@ -646,13 +646,9 @@ mod tests {
     #[cfg(feature = "builder-vm")]
     #[test]
     fn builder_transport_check_reports_hvf_as_vsock_only() {
-        unsafe {
-            std::env::set_var("MVM_BUILDER_BACKEND", "hvf");
-        }
+        let mut env = TestEnv::new();
+        env.set("MVM_BUILDER_BACKEND", "hvf");
         let c = builder_transport_check(Platform::MacOS);
-        unsafe {
-            std::env::remove_var("MVM_BUILDER_BACKEND");
-        }
         assert_eq!(c.name, "builder transport");
         assert_eq!(c.category, "platform");
         assert!(c.ok);
@@ -663,13 +659,9 @@ mod tests {
     #[cfg(feature = "builder-vm")]
     #[test]
     fn builder_transport_check_reports_libkrun_as_legacy_guest_network() {
-        unsafe {
-            std::env::set_var("MVM_BUILDER_BACKEND", "libkrun");
-        }
+        let mut env = TestEnv::new();
+        env.set("MVM_BUILDER_BACKEND", "libkrun");
         let c = builder_transport_check(Platform::MacOS);
-        unsafe {
-            std::env::remove_var("MVM_BUILDER_BACKEND");
-        }
         assert_eq!(c.name, "builder transport");
         assert!(
             c.info.contains("legacy guest-network bootstrap"),
@@ -682,13 +674,9 @@ mod tests {
     #[cfg(feature = "builder-vm")]
     #[test]
     fn builder_transport_check_marks_qemu_as_unsupported_legacy() {
-        unsafe {
-            std::env::set_var("MVM_BUILDER_BACKEND", "qemu");
-        }
+        let mut env = TestEnv::new();
+        env.set("MVM_BUILDER_BACKEND", "qemu");
         let c = builder_transport_check(Platform::LinuxNoKvm);
-        unsafe {
-            std::env::remove_var("MVM_BUILDER_BACKEND");
-        }
         assert_eq!(c.name, "builder transport");
         assert!(c.info.contains("unsupported legacy"), "got {:?}", c.info);
         assert!(c.info.contains("qemu"), "got {:?}", c.info);
@@ -697,22 +685,10 @@ mod tests {
     #[cfg(all(target_os = "linux", feature = "builder-vm"))]
     #[test]
     fn builder_backend_check_linux_reports_qemu_auto_detected() {
-        // SAFETY: single-threaded test phase per crate; this env var
-        // isn't read elsewhere in this test binary.
-        let prev = std::env::var_os("MVM_BUILDER_BACKEND");
-        unsafe {
-            std::env::remove_var("MVM_BUILDER_BACKEND");
-        }
+        let mut env = TestEnv::new();
+        env.remove("MVM_BUILDER_BACKEND");
 
         let c = builder_backend_check(Platform::LinuxNative);
-
-        // Restore before any assertion so a panic doesn't strand the
-        // env var.
-        unsafe {
-            if let Some(v) = prev {
-                std::env::set_var("MVM_BUILDER_BACKEND", v);
-            }
-        }
 
         assert!(c.ok, "builder backend check must not fail informational");
         assert_eq!(c.name, "builder backend");
@@ -738,19 +714,10 @@ mod tests {
     #[cfg(all(target_os = "linux", feature = "builder-vm"))]
     #[test]
     fn builder_backend_check_linux_honors_env_override() {
-        let prev = std::env::var_os("MVM_BUILDER_BACKEND");
-        unsafe {
-            std::env::set_var("MVM_BUILDER_BACKEND", "qemu");
-        }
+        let mut env = TestEnv::new();
+        env.set("MVM_BUILDER_BACKEND", "qemu");
 
         let c = builder_backend_check(Platform::LinuxNative);
-
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("MVM_BUILDER_BACKEND", v),
-                None => std::env::remove_var("MVM_BUILDER_BACKEND"),
-            }
-        }
 
         assert!(c.ok);
         // Env override flips the resolved backend even when
@@ -775,19 +742,10 @@ mod tests {
     #[cfg(all(target_os = "linux", feature = "builder-vm"))]
     #[test]
     fn builder_backend_check_linux_libkrun_override_no_longer_reports_a_rootfs_gap() {
-        let prev = std::env::var_os("MVM_BUILDER_BACKEND");
-        unsafe {
-            std::env::set_var("MVM_BUILDER_BACKEND", "libkrun");
-        }
+        let mut env = TestEnv::new();
+        env.set("MVM_BUILDER_BACKEND", "libkrun");
 
         let c = builder_backend_check(Platform::LinuxNative);
-
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("MVM_BUILDER_BACKEND", v),
-                None => std::env::remove_var("MVM_BUILDER_BACKEND"),
-            }
-        }
 
         assert!(
             c.info.starts_with("libkrun — "),
@@ -815,25 +773,11 @@ mod tests {
         // When MVM_LINUX_BUILDER_VM=1 is set, the builder-backend line
         // adds the rollout-opt-in annotation alongside the resolved
         // backend + availability.
-        let prev_bb = std::env::var_os("MVM_BUILDER_BACKEND");
-        let prev_lbvm = std::env::var_os("MVM_LINUX_BUILDER_VM");
-        unsafe {
-            std::env::remove_var("MVM_BUILDER_BACKEND");
-            std::env::set_var("MVM_LINUX_BUILDER_VM", "1");
-        }
+        let mut env = TestEnv::new();
+        env.remove("MVM_BUILDER_BACKEND");
+        env.set("MVM_LINUX_BUILDER_VM", "1");
 
         let c = builder_backend_check(Platform::LinuxNative);
-
-        unsafe {
-            match prev_bb {
-                Some(v) => std::env::set_var("MVM_BUILDER_BACKEND", v),
-                None => std::env::remove_var("MVM_BUILDER_BACKEND"),
-            }
-            match prev_lbvm {
-                Some(v) => std::env::set_var("MVM_LINUX_BUILDER_VM", v),
-                None => std::env::remove_var("MVM_LINUX_BUILDER_VM"),
-            }
-        }
 
         assert!(c.ok);
         assert!(

--- a/crates/mvm-cli/src/doctor/platform_checks.rs
+++ b/crates/mvm-cli/src/doctor/platform_checks.rs
@@ -397,16 +397,9 @@ mod tests {
         // "platform", and the info text covers one of the four
         // documented branches (env-set + ready, env-set + missing,
         // env-unset + ready, env-unset + missing).
-        let prev = std::env::var_os("MVM_LINUX_BUILDER_VM");
-        unsafe {
-            std::env::remove_var("MVM_LINUX_BUILDER_VM");
-        }
+        let mut env = TestEnv::new();
+        env.remove("MVM_LINUX_BUILDER_VM");
         let c = nested_kvm_check(Platform::LinuxNative);
-        unsafe {
-            if let Some(v) = prev {
-                std::env::set_var("MVM_LINUX_BUILDER_VM", v);
-            }
-        }
         assert_eq!(c.name, "nested-kvm");
         assert_eq!(c.category, "platform");
         let info = &c.info;

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1974,6 +1974,7 @@ pub fn wait_for_agent(vm_name: &str, timeout_secs: u64) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_core::util::test_env::TestEnv;
 
     #[test]
     fn build_healthcheck_wraps_shell_command() {
@@ -2001,28 +2002,13 @@ mod tests {
 
     #[test]
     fn select_exec_backend_none_with_no_env_falls_to_auto_detect() {
-        let saved_hv = std::env::var_os("MVM_HYPERVISOR");
-        let saved_be = std::env::var_os("MVM_BACKEND");
-        // SAFETY: test-local env mutation, restored before returning.
-        unsafe {
-            std::env::remove_var("MVM_HYPERVISOR");
-            std::env::remove_var("MVM_BACKEND");
-        }
+        let mut env = TestEnv::new();
+        env.remove("MVM_HYPERVISOR");
+        env.remove("MVM_BACKEND");
         let deny_all = mvm_core::network_policy::NetworkPolicy::deny_all();
         let backend =
             select_exec_backend(false, &deny_all, None).expect("auto-detect always resolves");
         assert_eq!(backend.name(), AnyBackend::auto_select().name());
-        // SAFETY: restore prior values.
-        unsafe {
-            match saved_hv {
-                Some(v) => std::env::set_var("MVM_HYPERVISOR", v),
-                None => std::env::remove_var("MVM_HYPERVISOR"),
-            }
-            match saved_be {
-                Some(v) => std::env::set_var("MVM_BACKEND", v),
-                None => std::env::remove_var("MVM_BACKEND"),
-            }
-        }
     }
 
     /// The CLI `--hypervisor` flag (the `requested` param) wins over a
@@ -2030,13 +2016,9 @@ mod tests {
     /// sites must all resolve to the same backend as what was requested.
     #[test]
     fn select_exec_backend_requested_flag_beats_conflicting_env() {
-        let saved_hv = std::env::var_os("MVM_HYPERVISOR");
-        let saved_be = std::env::var_os("MVM_BACKEND");
-        // SAFETY: test-local env mutation, restored before returning.
-        unsafe {
-            std::env::remove_var("MVM_BACKEND");
-            std::env::set_var("MVM_HYPERVISOR", "qemu");
-        }
+        let mut env = TestEnv::new();
+        env.remove("MVM_BACKEND");
+        env.set("MVM_HYPERVISOR", "qemu");
         let deny_all = mvm_core::network_policy::NetworkPolicy::deny_all();
         let backend = select_exec_backend(false, &deny_all, Some("libkrun"))
             .expect("libkrun resolves without probing availability (image not requested)");
@@ -2045,17 +2027,6 @@ mod tests {
             "libkrun",
             "the requested flag must win over MVM_HYPERVISOR=qemu"
         );
-        // SAFETY: restore prior values.
-        unsafe {
-            match saved_hv {
-                Some(v) => std::env::set_var("MVM_HYPERVISOR", v),
-                None => std::env::remove_var("MVM_HYPERVISOR"),
-            }
-            match saved_be {
-                Some(v) => std::env::set_var("MVM_BACKEND", v),
-                None => std::env::remove_var("MVM_BACKEND"),
-            }
-        }
     }
 
     #[test]
@@ -2063,13 +2034,11 @@ mod tests {
         let _guard = mvm_runtime::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
         let policy = mvm_core::network_policy::NetworkPolicy::allow_list(vec![
             mvm_core::network_policy::HostPort::new("example.com", 443),
         ]);
-        // SAFETY: test-only env mutation.
-        unsafe {
-            std::env::set_var("MVM_HVF_SUPERVISOR_PATH", "/no/such/mvm-hvf-supervisor");
-        }
+        env.set("MVM_HVF_SUPERVISOR_PATH", "/no/such/mvm-hvf-supervisor");
         let err = validate_backend_for_egress(
             "hvf",
             true,
@@ -2077,10 +2046,6 @@ mod tests {
             "OCI --image runs with outbound egress enabled",
         )
         .expect_err("unavailable hvf must fail closed before OCI work");
-        // SAFETY: test-only env mutation.
-        unsafe {
-            std::env::remove_var("MVM_HVF_SUPERVISOR_PATH");
-        }
         // HVF always advertises the NIC-less host-vsock-proxy egress caps (they
         // are unconditional — the fail-closed posture), so the capability
         // shortfall is empty and the refusal comes from the availability probe:
@@ -2096,6 +2061,7 @@ mod tests {
         let _guard = mvm_runtime::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
         let dir = tempfile::tempdir().expect("tempdir");
         let supervisor = dir.path().join("mvm-hvf-supervisor");
         std::fs::write(&supervisor, b"stub").expect("stub supervisor");
@@ -2103,10 +2069,7 @@ mod tests {
             mvm_core::network_policy::HostPort::new("example.com", 443),
         ]);
 
-        // SAFETY: test-only env mutation.
-        unsafe {
-            std::env::set_var("MVM_HVF_SUPERVISOR_PATH", &supervisor);
-        }
+        env.set("MVM_HVF_SUPERVISOR_PATH", &supervisor);
         let selected = select_backend_name_for_egress(
             None,
             true,
@@ -2114,10 +2077,6 @@ mod tests {
             "OCI --image runs with outbound egress enabled",
         )
         .expect("hvf should satisfy the proxy backend requirement");
-        // SAFETY: test-only env mutation.
-        unsafe {
-            std::env::remove_var("MVM_HVF_SUPERVISOR_PATH");
-        }
 
         assert_eq!(selected, "hvf");
     }

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! The `MvmClient` facade users touch. One import surface fronts every piece:
 //! the trait + DTOs + `MockBackend` (re-exported from `mvm-core`'s `client`
 //! module), the in-process [`LocalBackend`], and the [`connect`] selector. A

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -1,5 +1,8 @@
+#![deny(unsafe_code)]
 // mvm-core: Pure types, IDs, config, utilities
 // No internal mvm dependencies — this is the foundation crate.
+// `deny` (not `forbid`) so `util::test_env` can carry the one narrow
+// unsafe carve-out for process-wide env mutation in tests.
 
 pub mod arch;
 pub mod build_env;

--- a/crates/mvm-core/src/util/test_env.rs
+++ b/crates/mvm-core/src/util/test_env.rs
@@ -1,3 +1,8 @@
+// The one `unsafe` carve-out under the crate's `deny(unsafe_code)`: this module
+// centralizes the process-wide env mutation Rust 2024 marks unsafe, serialized
+// behind `ENV_LOCK` and restored on drop.
+#![allow(unsafe_code)]
+
 use std::ffi::{OsStr, OsString};
 use std::sync::{Mutex, MutexGuard};
 

--- a/crates/mvm-hostd/src/supervisor/tools/web_fetch.rs
+++ b/crates/mvm-hostd/src/supervisor/tools/web_fetch.rs
@@ -549,6 +549,7 @@ impl HostMediatedTool for WebFetchTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_core::util::test_env::TestEnv;
 
     // Test fetcher — records its calls + returns canned responses.
     struct StubFetcher {
@@ -799,37 +800,27 @@ mod tests {
     fn allowlist_from_env_var_parses_comma_separated() {
         // Use a process-unique var name so parallel tests don't
         // race on the same key.
+        let mut env = TestEnv::new();
         let var = "MVM_TEST_WEB_FETCH_ALLOWLIST_PARSE";
-        // SAFETY: tests are single-threaded for this var; the name
-        // is unique to this test.
-        unsafe {
-            std::env::set_var(var, "api.openai.com,api.anthropic.com,api.brave.com");
-        }
+        env.set(var, "api.openai.com,api.anthropic.com,api.brave.com");
         let set = allowlist_from_env_var(var);
         assert!(set.contains("api.openai.com"));
         assert!(set.contains("api.anthropic.com"));
         assert!(set.contains("api.brave.com"));
         assert_eq!(set.len(), 3);
-        unsafe {
-            std::env::remove_var(var);
-        }
     }
 
     #[test]
     fn allowlist_from_env_var_drops_empty_entries_and_trims_whitespace() {
+        let mut env = TestEnv::new();
         let var = "MVM_TEST_WEB_FETCH_ALLOWLIST_TRIM";
-        unsafe {
-            std::env::set_var(var, "  api.openai.com  , ,, api.brave.com,");
-        }
+        env.set(var, "  api.openai.com  , ,, api.brave.com,");
         let set = allowlist_from_env_var(var);
         assert!(set.contains("api.openai.com"));
         assert!(set.contains("api.brave.com"));
         // Empty entries (`,,` / trailing comma) and whitespace-only
         // entries don't widen the allowlist.
         assert_eq!(set.len(), 2);
-        unsafe {
-            std::env::remove_var(var);
-        }
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/tools/web_search.rs
+++ b/crates/mvm-hostd/src/supervisor/tools/web_search.rs
@@ -812,6 +812,7 @@ pub const GOOGLE_CSE_ID_ENV_VAR: &str = "GOOGLE_CSE_ID";
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_core::util::test_env::TestEnv;
 
     /// Test helper: wrap a literal in `SecretBox<String>`. The
     /// production callers receive a `SecretBox` from the credential
@@ -1408,18 +1409,14 @@ mod tests {
 
     #[test]
     fn allowlist_env_var_parses_comma_separated() {
+        let mut env = TestEnv::new();
         let var = "MVM_TEST_WEB_SEARCH_ALLOWLIST_PARSE";
-        unsafe {
-            std::env::set_var(var, "brave,google,duckduckgo");
-        }
+        env.set(var, "brave,google,duckduckgo");
         let set = allowlist_from_env_var(var);
         assert!(set.contains("brave"));
         assert!(set.contains("google"));
         assert!(set.contains("duckduckgo"));
         assert_eq!(set.len(), 3);
-        unsafe {
-            std::env::remove_var(var);
-        }
     }
 
     #[test]

--- a/crates/mvm-net/src/lib.rs
+++ b/crates/mvm-net/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! `NetworkProvider` — the provisioning + policy + teardown seam for one
 //! VM's network.
 //!

--- a/crates/mvm-runtime/src/base/config.rs
+++ b/crates/mvm-runtime/src/base/config.rs
@@ -106,6 +106,7 @@ pub struct RunInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_core::util::test_env::TestEnv;
 
     #[test]
     fn test_constants_non_empty() {
@@ -289,7 +290,8 @@ mod tests {
     #[test]
     fn test_production_mode_disabled_by_default() {
         // Without env var set, should be false
-        unsafe { std::env::remove_var("MVM_PRODUCTION") };
+        let mut env = TestEnv::new();
+        env.remove("MVM_PRODUCTION");
         assert!(!mvm_core::config::is_production_mode());
     }
 }

--- a/crates/mvm-runtime/src/base/linux_env.rs
+++ b/crates/mvm-runtime/src/base/linux_env.rs
@@ -366,6 +366,7 @@ pub fn default_env() -> &'static dyn LinuxEnv {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_core::util::test_env::TestEnv;
 
     #[test]
     fn test_create_linux_env_returns_env() {
@@ -405,7 +406,7 @@ mod tests {
         let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let mut env = TestEnv::new();
         let tmp = tempfile::tempdir().expect("tempdir");
         env.set("HOME", tmp.path());
         env.remove("MVM_HOME");
@@ -432,66 +433,34 @@ mod tests {
     /// parallel tests can't see partial state.
     #[test]
     fn test_auto_start_allowed_env_precedence() {
-        use std::sync::Mutex;
-        static ENV_LOCK: Mutex<()> = Mutex::new(());
-        let _guard = ENV_LOCK.lock().expect("env lock poisoned");
-
-        // Snapshot then clear so the test isn't perturbed by the runner.
-        let saved: Vec<(&str, Option<String>)> =
-            ["MVM_NO_AUTO_DEV", "MVM_AUTO_DEV", "MVM_DEV_DAEMON"]
-                .iter()
-                .map(|k| (*k, std::env::var(k).ok()))
-                .collect();
-        let restore = || {
-            for (k, v) in &saved {
-                // SAFETY: serialised via ENV_LOCK above.
-                unsafe {
-                    match v {
-                        Some(val) => std::env::set_var(k, val),
-                        None => std::env::remove_var(k),
-                    }
-                }
-            }
-        };
-
-        let set = |k: &str, v: Option<&str>| {
-            // SAFETY: serialised via ENV_LOCK above.
-            unsafe {
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-        };
+        let mut env = TestEnv::new();
 
         // Clear all three so each branch is exercised in isolation.
-        set("MVM_NO_AUTO_DEV", None);
-        set("MVM_AUTO_DEV", None);
-        set("MVM_DEV_DAEMON", None);
+        env.remove("MVM_NO_AUTO_DEV");
+        env.remove("MVM_AUTO_DEV");
+        env.remove("MVM_DEV_DAEMON");
 
         // Opt-out always wins, even alongside the explicit opt-in.
-        set("MVM_NO_AUTO_DEV", Some("1"));
-        set("MVM_AUTO_DEV", Some("1"));
+        env.set("MVM_NO_AUTO_DEV", "1");
+        env.set("MVM_AUTO_DEV", "1");
         assert!(
             !auto_start_allowed(),
             "MVM_NO_AUTO_DEV must override opt-in"
         );
 
         // Daemon-self check prevents re-spawn recursion.
-        set("MVM_NO_AUTO_DEV", None);
-        set("MVM_AUTO_DEV", None);
-        set("MVM_DEV_DAEMON", Some("1"));
+        env.remove("MVM_NO_AUTO_DEV");
+        env.remove("MVM_AUTO_DEV");
+        env.set("MVM_DEV_DAEMON", "1");
         assert!(!auto_start_allowed(), "daemon must not auto-start itself");
 
         // Explicit opt-in overrides the TTY heuristic in headless runs.
-        set("MVM_DEV_DAEMON", None);
-        set("MVM_AUTO_DEV", Some("1"));
+        env.remove("MVM_DEV_DAEMON");
+        env.set("MVM_AUTO_DEV", "1");
         assert!(
             auto_start_allowed(),
             "MVM_AUTO_DEV=1 must enable auto-start"
         );
-
-        restore();
     }
 
     /// `SUDO_SHIM` must parse cleanly in POSIX `sh` (busybox ash on the

--- a/crates/mvm-runtime/src/base/runtime_meta.rs
+++ b/crates/mvm-runtime/src/base/runtime_meta.rs
@@ -242,29 +242,20 @@ pub fn record_from_start_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_core::util::test_env::TestEnv;
 
     fn with_home_temp<F>(f: F)
     where
         F: FnOnce(&std::path::Path),
     {
         let _guard = HOME_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
         let tmp = tempfile::tempdir().expect("tempdir");
         // `meta_path` resolves via `vm_state_dir`, which honors the MVM_HOME
         // override — point it at the tempdir so every path lands there, even
         // if a sibling test (under the same lock) leaked its own override.
-        let prev = std::env::var_os("MVM_HOME");
-        // SAFETY: tests only; MVM_HOME is process-global but the
-        // HOME_TEST_LOCK serializes us with everything else that reads it.
-        unsafe {
-            std::env::set_var("MVM_HOME", tmp.path());
-        }
+        env.set("MVM_HOME", tmp.path());
         f(tmp.path());
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("MVM_HOME", v),
-                None => std::env::remove_var("MVM_HOME"),
-            }
-        }
     }
 
     #[test]

--- a/crates/mvm-runtime/src/broker_services_spawn.rs
+++ b/crates/mvm-runtime/src/broker_services_spawn.rs
@@ -464,6 +464,7 @@ impl Drop for BrokerServicesGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_core::util::test_env::TestEnv;
     use std::os::unix::fs::PermissionsExt;
 
     #[test]
@@ -471,12 +472,11 @@ mod tests {
         let _g = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|p| p.into_inner());
+        let mut env = TestEnv::new();
         let dir = std::env::temp_dir().join(format!("mvm-as-spawn-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
-        let saved_mvm_home = std::env::var_os("MVM_HOME");
         // Route mvm_audit_dir() / mvm_keys_dir() under a disposable MVM_HOME.
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe { std::env::set_var("MVM_HOME", &dir) };
+        env.set("MVM_HOME", &dir);
 
         let state_dir = dir.join("state");
         std::fs::create_dir_all(&state_dir).unwrap();
@@ -497,9 +497,7 @@ mod tests {
         )
         .unwrap();
         std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let saved_bin = std::env::var_os("MVM_AUDIT_SIGNER_PATH");
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe { std::env::set_var("MVM_AUDIT_SIGNER_PATH", &stub) };
+        env.set("MVM_AUDIT_SIGNER_PATH", &stub);
 
         let res = spawn_audit_signer(AuditSignerSpawnParams {
             workload_id: "wl-001",
@@ -508,14 +506,6 @@ mod tests {
             state_dir: &state_dir,
         });
 
-        // Restore the bin override before asserting so a failure can't leak it.
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe {
-            match saved_bin {
-                Some(v) => std::env::set_var("MVM_AUDIT_SIGNER_PATH", v),
-                None => std::env::remove_var("MVM_AUDIT_SIGNER_PATH"),
-            }
-        }
         let handle = res.expect("spawn with stub audit-signer should succeed");
         assert_eq!(handle.uds_path, uds);
 
@@ -549,13 +539,6 @@ mod tests {
         );
 
         reap_audit_signer(&state_dir);
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe {
-            match saved_mvm_home {
-                Some(v) => std::env::set_var("MVM_HOME", v),
-                None => std::env::remove_var("MVM_HOME"),
-            }
-        }
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -564,11 +547,10 @@ mod tests {
         let _g = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|p| p.into_inner());
+        let mut env = TestEnv::new();
         let dir = std::env::temp_dir().join(format!("mvm-as-nobind-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
-        let saved_mvm_home = std::env::var_os("MVM_HOME");
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe { std::env::set_var("MVM_HOME", &dir) };
+        env.set("MVM_HOME", &dir);
         let state_dir = dir.join("state");
         std::fs::create_dir_all(&state_dir).unwrap();
 
@@ -577,9 +559,7 @@ mod tests {
         let stub = dir.join("stub-nobind.sh");
         std::fs::write(&stub, "#!/bin/sh\ncat > /dev/null\nsleep 5\n").unwrap();
         std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let saved_bin = std::env::var_os("MVM_AUDIT_SIGNER_PATH");
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe { std::env::set_var("MVM_AUDIT_SIGNER_PATH", &stub) };
+        env.set("MVM_AUDIT_SIGNER_PATH", &stub);
 
         let res = spawn_audit_signer_with_timeout(
             AuditSignerSpawnParams {
@@ -591,17 +571,6 @@ mod tests {
             Duration::from_millis(200),
         );
 
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe {
-            match saved_bin {
-                Some(v) => std::env::set_var("MVM_AUDIT_SIGNER_PATH", v),
-                None => std::env::remove_var("MVM_AUDIT_SIGNER_PATH"),
-            }
-            match saved_mvm_home {
-                Some(v) => std::env::set_var("MVM_HOME", v),
-                None => std::env::remove_var("MVM_HOME"),
-            }
-        }
         let err = res.expect_err("must fail closed when the UDS never binds");
         assert!(err.to_string().contains("did not bind"), "got {err}");
         // No PID file is left behind on a failed spawn.
@@ -614,11 +583,10 @@ mod tests {
         let _g = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|p| p.into_inner());
+        let mut env = TestEnv::new();
         let dir = std::env::temp_dir().join(format!("mvm-as-nobin-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
-        let saved_bin = std::env::var_os("MVM_AUDIT_SIGNER_PATH");
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe { std::env::set_var("MVM_AUDIT_SIGNER_PATH", dir.join("nope")) };
+        env.set("MVM_AUDIT_SIGNER_PATH", dir.join("nope"));
 
         let res = spawn_audit_signer(AuditSignerSpawnParams {
             workload_id: "wl",
@@ -627,13 +595,6 @@ mod tests {
             state_dir: &dir,
         });
 
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe {
-            match saved_bin {
-                Some(v) => std::env::set_var("MVM_AUDIT_SIGNER_PATH", v),
-                None => std::env::remove_var("MVM_AUDIT_SIGNER_PATH"),
-            }
-        }
         let err = res.expect_err("a missing bin override must error");
         assert!(err.to_string().contains("is not a file"), "got {err}");
         std::fs::remove_dir_all(&dir).ok();
@@ -644,11 +605,10 @@ mod tests {
         let _g = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|p| p.into_inner());
+        let mut env = TestEnv::new();
         let dir = std::env::temp_dir().join(format!("mvm-broker-spawn-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
-        let saved_mvm_home = std::env::var_os("MVM_HOME");
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe { std::env::set_var("MVM_HOME", &dir) };
+        env.set("MVM_HOME", &dir);
 
         let state_dir = dir.join("state");
         std::fs::create_dir_all(&state_dir).unwrap();
@@ -669,9 +629,7 @@ mod tests {
         )
         .unwrap();
         std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let saved_bin = std::env::var_os("MVM_BROKER_PATH");
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe { std::env::set_var("MVM_BROKER_PATH", &stub) };
+        env.set("MVM_BROKER_PATH", &stub);
 
         let audit_uds = state_dir.join(AUDIT_SIGNER_SOCK);
         let res = spawn_broker(BrokerSpawnParams {
@@ -682,13 +640,6 @@ mod tests {
             audit_signer_uds_path: &audit_uds,
         });
 
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe {
-            match saved_bin {
-                Some(v) => std::env::set_var("MVM_BROKER_PATH", v),
-                None => std::env::remove_var("MVM_BROKER_PATH"),
-            }
-        }
         let handle = res.expect("spawn with stub broker should succeed");
         assert_eq!(handle.uds_path, uds);
 
@@ -716,13 +667,6 @@ mod tests {
         assert!(state_dir.join(BROKER_PID_FILE).exists());
 
         reap_broker(&state_dir);
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe {
-            match saved_mvm_home {
-                Some(v) => std::env::set_var("MVM_HOME", v),
-                None => std::env::remove_var("MVM_HOME"),
-            }
-        }
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -753,11 +697,10 @@ mod tests {
         let _g = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|p| p.into_inner());
+        let mut env = TestEnv::new();
         let dir = std::env::temp_dir().join(format!("mvm-bs-admit-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
-        let saved_mvm_home = std::env::var_os("MVM_HOME");
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe { std::env::set_var("MVM_HOME", &dir) };
+        env.set("MVM_HOME", &dir);
 
         let state_dir = dir.join("state");
         std::fs::create_dir_all(&state_dir).unwrap();
@@ -789,13 +732,8 @@ mod tests {
         for s in [&as_stub, &br_stub] {
             std::fs::set_permissions(s, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
-        let saved_as = std::env::var_os("MVM_AUDIT_SIGNER_PATH");
-        let saved_br = std::env::var_os("MVM_BROKER_PATH");
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe {
-            std::env::set_var("MVM_AUDIT_SIGNER_PATH", &as_stub);
-            std::env::set_var("MVM_BROKER_PATH", &br_stub);
-        }
+        env.set("MVM_AUDIT_SIGNER_PATH", &as_stub);
+        env.set("MVM_BROKER_PATH", &br_stub);
 
         let res = spawn_broker_services_if_admitted(BrokerServicesSpawnParams {
             workload_id: "wl-001",
@@ -805,17 +743,6 @@ mod tests {
             broker_listen_socket: &broker_uds,
         });
 
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe {
-            match saved_as {
-                Some(v) => std::env::set_var("MVM_AUDIT_SIGNER_PATH", v),
-                None => std::env::remove_var("MVM_AUDIT_SIGNER_PATH"),
-            }
-            match saved_br {
-                Some(v) => std::env::set_var("MVM_BROKER_PATH", v),
-                None => std::env::remove_var("MVM_BROKER_PATH"),
-            }
-        }
         let mut guard = res.expect("admitted VM spawns both broker services");
         // Both subprocesses bound their UDS and wrote their PID files.
         assert!(
@@ -826,13 +753,6 @@ mod tests {
 
         guard.defuse();
         reap_broker_services(&state_dir);
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe {
-            match saved_mvm_home {
-                Some(v) => std::env::set_var("MVM_HOME", v),
-                None => std::env::remove_var("MVM_HOME"),
-            }
-        }
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/mvm-runtime/src/firecracker.rs
+++ b/crates/mvm-runtime/src/firecracker.rs
@@ -496,6 +496,7 @@ impl crate::checkpoint::ForkVmFullRestorer for FcForkRestorer {
 mod tests {
     use super::*;
     use crate::checkpoint::VmFullControl as _;
+    use mvm_core::util::test_env::TestEnv;
 
     /// `save_memory` requires an absolute path — a relative path would be
     /// misinterpreted by the Firecracker API.
@@ -544,10 +545,9 @@ mod tests {
         let _g = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        let saved = std::env::var_os("MVM_HOME");
-        // SAFETY: serialized by HOME_TEST_LOCK.
-        unsafe { std::env::set_var("MVM_HOME", tmp.path()) };
+        env.set("MVM_HOME", tmp.path());
 
         let vm_name = "anchor-test";
         let vm_dir = mvm_core::config::vm_state_dir(vm_name);
@@ -580,14 +580,6 @@ mod tests {
                 &vm_dir.to_string_lossy()
             ))
         );
-
-        // Restore before dropping the lock so concurrent tests see clean env.
-        unsafe {
-            match saved {
-                Some(v) => std::env::set_var("MVM_HOME", v),
-                None => std::env::remove_var("MVM_HOME"),
-            }
-        }
     }
 
     /// `device_anchors` fails with a clear message when the VM has no persisted
@@ -597,10 +589,9 @@ mod tests {
         let _g = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        let saved = std::env::var_os("MVM_HOME");
-        // SAFETY: serialized by HOME_TEST_LOCK.
-        unsafe { std::env::set_var("MVM_HOME", tmp.path()) };
+        env.set("MVM_HOME", tmp.path());
 
         let ctl = FcVmFullControl::new("no-mode-vm");
         let err = ctl.device_anchors().unwrap_err();
@@ -608,12 +599,5 @@ mod tests {
             err.to_string().contains("mode.json"),
             "error must mention missing mode.json: {err}"
         );
-
-        unsafe {
-            match saved {
-                Some(v) => std::env::set_var("MVM_HOME", v),
-                None => std::env::remove_var("MVM_HOME"),
-            }
-        }
     }
 }

--- a/crates/mvm-runtime/src/hvf_backend.rs
+++ b/crates/mvm-runtime/src/hvf_backend.rs
@@ -746,26 +746,16 @@ mod tests {
         let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
         let dir = tempfile::tempdir().expect("tempdir");
         let good = dir.path().join("mvm-hvf-supervisor");
         std::fs::write(&good, b"stub").expect("stub supervisor");
 
-        // SAFETY: test-only env mutation.
-        unsafe {
-            std::env::set_var("MVM_HVF_SUPERVISOR_PATH", &good);
-        }
+        env.set("MVM_HVF_SUPERVISOR_PATH", &good);
         assert!(hvf_supervisor_launch_support_available());
 
-        // SAFETY: test-only env mutation.
-        unsafe {
-            std::env::set_var("MVM_HVF_SUPERVISOR_PATH", dir.path().join("missing"));
-        }
+        env.set("MVM_HVF_SUPERVISOR_PATH", dir.path().join("missing"));
         assert!(!hvf_supervisor_launch_support_available());
-
-        // SAFETY: test-only env mutation.
-        unsafe {
-            std::env::remove_var("MVM_HVF_SUPERVISOR_PATH");
-        }
     }
 
     #[test]
@@ -773,15 +763,9 @@ mod tests {
         let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        // SAFETY: test-only env mutation.
-        unsafe {
-            std::env::set_var("MVM_HVF_SUPERVISOR_PATH", "/no/such/mvm-hvf-supervisor");
-        }
+        let mut env = TestEnv::new();
+        env.set("MVM_HVF_SUPERVISOR_PATH", "/no/such/mvm-hvf-supervisor");
         let caps = HvfBackend.capabilities();
-        // SAFETY: test-only env mutation.
-        unsafe {
-            std::env::remove_var("MVM_HVF_SUPERVISOR_PATH");
-        }
         // Fail-closed: even a degraded host (unlaunchable supervisor) advertises
         // no routable NIC and the host vsock proxy, so egress can only ride the
         // per-VM endpoint — it never falls back to a guest NIC. Only the dev-tier
@@ -797,20 +781,14 @@ mod tests {
         let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
         let dir = tempfile::tempdir().expect("tempdir");
         let good = dir.path().join("mvm-hvf-supervisor");
         std::fs::write(&good, b"stub").expect("stub supervisor");
 
-        // SAFETY: test-only env mutation.
-        unsafe {
-            std::env::set_var("MVM_HVF_SUPERVISOR_PATH", &good);
-        }
+        env.set("MVM_HVF_SUPERVISOR_PATH", &good);
         let caps = HvfBackend.capabilities();
         let available = HvfBackend.is_available().expect("availability probe");
-        // SAFETY: test-only env mutation.
-        unsafe {
-            std::env::remove_var("MVM_HVF_SUPERVISOR_PATH");
-        }
         assert!(available);
         // The egress caps are unconditional (fail-closed); a launchable
         // supervisor additionally enables the dev-tier virtiofs-root boot.

--- a/crates/mvm-runtime/src/substitution_spawn.rs
+++ b/crates/mvm-runtime/src/substitution_spawn.rs
@@ -426,6 +426,7 @@ fn kill(pid: libc::pid_t, sig: libc::c_int) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_core::util::test_env::TestEnv;
 
     // `stop_vm` reaps the moat BEFORE its not-running early return (so a crashed
     // VM's decrypted-secret endpoint can't outlive the guest). That ordering is
@@ -450,13 +451,12 @@ mod tests {
         let _g = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|p| p.into_inner());
+        let mut env = TestEnv::new();
         let dir = std::env::temp_dir().join(format!("mvm-subst-uds-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
-        let saved_mvm_home = std::env::var_os("MVM_HOME");
         // Route vm_substitution_env_path under a temp MVM_HOME so the write lands
         // somewhere disposable.
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe { std::env::set_var("MVM_HOME", &dir) };
+        env.set("MVM_HOME", &dir);
 
         // Stub endpoint: dump stdin (the config JSON) to a file, then emit one
         // handshake line so the spawn helper's read_handshake_line succeeds.
@@ -474,9 +474,7 @@ mod tests {
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
-        let saved_bin = std::env::var_os("MVM_SUBSTITUTION_ENDPOINT_PATH");
-        // SAFETY: serialised by HOME_TEST_LOCK.
-        unsafe { std::env::set_var("MVM_SUBSTITUTION_ENDPOINT_PATH", &stub) };
+        env.set("MVM_SUBSTITUTION_ENDPOINT_PATH", &stub);
 
         // The spawn helper writes the minted (var→placeholder) handshake to
         // `vm_substitution_env_path` — ensure its parent dir exists under the root.
@@ -499,17 +497,6 @@ mod tests {
             raw_egress: false,
         });
 
-        // Restore env before asserting so a failure can't leak it.
-        unsafe {
-            match saved_bin {
-                Some(v) => std::env::set_var("MVM_SUBSTITUTION_ENDPOINT_PATH", v),
-                None => std::env::remove_var("MVM_SUBSTITUTION_ENDPOINT_PATH"),
-            }
-            match saved_mvm_home {
-                Some(v) => std::env::set_var("MVM_HOME", v),
-                None => std::env::remove_var("MVM_HOME"),
-            }
-        }
         res.expect("spawn with stub endpoint should succeed");
 
         let captured = std::fs::read_to_string(&cfg_out).expect("stub wrote config");
@@ -525,13 +512,12 @@ mod tests {
         let _g = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|p| p.into_inner());
+        let mut env = TestEnv::new();
         let dir = std::env::temp_dir().join(format!("mvm-subst-rollback-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let state_dir = dir.join("state");
         std::fs::create_dir_all(&state_dir).unwrap();
 
-        let saved_mvm_home = std::env::var_os("MVM_HOME");
-        let saved_bin = std::env::var_os("MVM_SUBSTITUTION_ENDPOINT_PATH");
         let invalid_home = dir.join("mvm-home-file");
         std::fs::write(&invalid_home, b"not a directory").unwrap();
         let stub = dir.join("stub-endpoint.sh");
@@ -556,11 +542,8 @@ mod tests {
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
-        // SAFETY: serialised by HOME_TEST_LOCK; restored before the test exits.
-        unsafe {
-            std::env::set_var("MVM_HOME", &invalid_home);
-            std::env::set_var("MVM_SUBSTITUTION_ENDPOINT_PATH", &stub);
-        }
+        env.set("MVM_HOME", &invalid_home);
+        env.set("MVM_SUBSTITUTION_ENDPOINT_PATH", &stub);
 
         let redaction = mvm_core::policy::RedactionPolicy::default();
         let result = spawn_substitution_endpoint(SubstitutionSpawnParams {
@@ -577,17 +560,6 @@ mod tests {
             network_policy: None,
             raw_egress: false,
         });
-
-        unsafe {
-            match saved_bin {
-                Some(value) => std::env::set_var("MVM_SUBSTITUTION_ENDPOINT_PATH", value),
-                None => std::env::remove_var("MVM_SUBSTITUTION_ENDPOINT_PATH"),
-            }
-            match saved_mvm_home {
-                Some(value) => std::env::set_var("MVM_HOME", value),
-                None => std::env::remove_var("MVM_HOME"),
-            }
-        }
 
         assert!(result.is_err(), "invalid MVM_HOME must fail sidecar setup");
         assert!(!state_dir.join(SUBST_PID_FILE).exists());

--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -784,7 +784,7 @@ mod tests {
     /// `DATA_DIR_LOCK` since `set_var` is process-global.
     struct DataDirGuard {
         _guard: std::sync::MutexGuard<'static, ()>,
-        _env: TestEnv,
+        env: TestEnv,
         _tmp: tempfile::TempDir,
     }
 
@@ -798,7 +798,7 @@ mod tests {
             env.set("MVM_HOME", tmp.path());
             DataDirGuard {
                 _guard: lock,
-                _env: env,
+                env,
                 _tmp: tmp,
             }
         }
@@ -957,39 +957,10 @@ mod tests {
     /// provider via `MVM_TENANT_KEY_LOCAL`.
     const TEST_DEK_HEX: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
-    /// RAII guard that pins `MVM_TENANT_KEY_LOCAL` for the lifetime
-    /// of the test. Combine with `DataDirGuard` (which holds the
-    /// data-dir lock) — both pieces must be in scope so the
-    /// env-var mutation is serialised across the test binary.
-    struct TenantKeyGuard {
-        prev: Option<String>,
-    }
-
-    impl TenantKeyGuard {
-        fn set(hex: &str) -> Self {
-            let prev = std::env::var("MVM_TENANT_KEY_LOCAL").ok();
-            unsafe {
-                std::env::set_var("MVM_TENANT_KEY_LOCAL", hex);
-            }
-            Self { prev }
-        }
-    }
-
-    impl Drop for TenantKeyGuard {
-        fn drop(&mut self) {
-            unsafe {
-                match &self.prev {
-                    Some(v) => std::env::set_var("MVM_TENANT_KEY_LOCAL", v),
-                    None => std::env::remove_var("MVM_TENANT_KEY_LOCAL"),
-                }
-            }
-        }
-    }
-
     #[test]
     fn pause_and_seal_encrypts_vmstate_and_mem_when_key_is_configured() {
-        let _g = DataDirGuard::new();
-        let _k = TenantKeyGuard::set(TEST_DEK_HEX);
+        let mut g = DataDirGuard::new();
+        g.env.set("MVM_TENANT_KEY_LOCAL", TEST_DEK_HEX);
         let _s = pause_and_seal("vm-encrypt", &canned()).unwrap();
         let dir = snapshot_dir("vm-encrypt");
         // Both artifact files must now begin with the MVSE magic.
@@ -1014,11 +985,11 @@ mod tests {
 
     #[test]
     fn pause_and_seal_leaves_artifacts_unencrypted_when_no_key() {
-        let _g = DataDirGuard::new();
+        let mut g = DataDirGuard::new();
         // Defensive: clear the env var in case a parallel test left
         // it set. The DataDirGuard's lock means we're alone for the
         // duration of this test.
-        unsafe { std::env::remove_var("MVM_TENANT_KEY_LOCAL") };
+        g.env.remove("MVM_TENANT_KEY_LOCAL");
         let _s = pause_and_seal("vm-plain", &canned()).unwrap();
         let dir = snapshot_dir("vm-plain");
         // No MVSE magic — vmstate is raw bytes from CannedIO.
@@ -1033,8 +1004,8 @@ mod tests {
 
     #[test]
     fn verify_and_resume_round_trips_encrypted_snapshot() {
-        let _g = DataDirGuard::new();
-        let _k = TenantKeyGuard::set(TEST_DEK_HEX);
+        let mut g = DataDirGuard::new();
+        g.env.set("MVM_TENANT_KEY_LOCAL", TEST_DEK_HEX);
         let sealed = pause_and_seal("vm-rt", &canned()).unwrap();
         let verified = verify_and_resume("vm-rt", &canned()).unwrap();
         assert_eq!(verified, sealed);
@@ -1047,15 +1018,14 @@ mod tests {
 
     #[test]
     fn verify_and_resume_rejects_encrypted_snapshot_with_wrong_key() {
-        let _g = DataDirGuard::new();
-        let _k = TenantKeyGuard::set(TEST_DEK_HEX);
+        let mut g = DataDirGuard::new();
+        g.env.set("MVM_TENANT_KEY_LOCAL", TEST_DEK_HEX);
         pause_and_seal("vm-wk", &canned()).unwrap();
-        drop(_k);
         // Swap to a different DEK and try to resume. HMAC verify
         // passes (it's keyed on the host HMAC key, not the DEK), so
         // we fail at the AEAD step.
         let wrong = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
-        let _k2 = TenantKeyGuard::set(wrong);
+        g.env.set("MVM_TENANT_KEY_LOCAL", wrong);
         let err = verify_and_resume("vm-wk", &canned()).unwrap_err();
         let s = err.to_string();
         assert!(
@@ -1066,16 +1036,16 @@ mod tests {
 
     #[test]
     fn verify_and_resume_refuses_unencrypted_snapshot_when_key_configured() {
-        let _g = DataDirGuard::new();
+        let mut g = DataDirGuard::new();
         // First seal WITHOUT a key — unencrypted, v1-shape.
-        unsafe { std::env::remove_var("MVM_TENANT_KEY_LOCAL") };
+        g.env.remove("MVM_TENANT_KEY_LOCAL");
         pause_and_seal("vm-mix", &canned()).unwrap();
 
         // Now configure a key and try to resume. Refuse because the
         // snapshot was sealed before the DEK was
         // provisioned (downgrade vs v1 leftover indistinguishable
         // at this layer).
-        let _k = TenantKeyGuard::set(TEST_DEK_HEX);
+        g.env.set("MVM_TENANT_KEY_LOCAL", TEST_DEK_HEX);
         let err = verify_and_resume("vm-mix", &canned()).unwrap_err();
         let chained: String = err
             .chain()
@@ -1093,14 +1063,13 @@ mod tests {
         // The one-time v1 → v2 migration escape: operator opts in
         // via MVM_ALLOW_UNENCRYPTED_SNAPSHOT=1 to resume a legacy
         // unencrypted snapshot under a key-configured tenant.
-        let _g = DataDirGuard::new();
-        unsafe { std::env::remove_var("MVM_TENANT_KEY_LOCAL") };
+        let mut g = DataDirGuard::new();
+        g.env.remove("MVM_TENANT_KEY_LOCAL");
         pause_and_seal("vm-mig", &canned()).unwrap();
 
-        let _k = TenantKeyGuard::set(TEST_DEK_HEX);
-        unsafe { std::env::set_var(ALLOW_UNENCRYPTED_ENV, "1") };
+        g.env.set("MVM_TENANT_KEY_LOCAL", TEST_DEK_HEX);
+        g.env.set(ALLOW_UNENCRYPTED_ENV, "1");
         let result = verify_and_resume("vm-mig", &canned());
-        unsafe { std::env::remove_var(ALLOW_UNENCRYPTED_ENV) };
         assert!(
             result.is_ok(),
             "migration escape should let unencrypted v1 snapshot resume; got {:?}",
@@ -1110,13 +1079,12 @@ mod tests {
 
     #[test]
     fn verify_and_resume_refuses_encrypted_snapshot_when_key_missing() {
-        let _g = DataDirGuard::new();
-        let _k = TenantKeyGuard::set(TEST_DEK_HEX);
+        let mut g = DataDirGuard::new();
+        g.env.set("MVM_TENANT_KEY_LOCAL", TEST_DEK_HEX);
         pause_and_seal("vm-lost", &canned()).unwrap();
-        drop(_k);
         // Operator lost the key. Resume must refuse rather than
         // silently produce gibberish.
-        unsafe { std::env::remove_var("MVM_TENANT_KEY_LOCAL") };
+        g.env.remove("MVM_TENANT_KEY_LOCAL");
         let err = verify_and_resume("vm-lost", &canned()).unwrap_err();
         let chained: String = err
             .chain()

--- a/crates/mvm-runtime/src/vsock_transport.rs
+++ b/crates/mvm-runtime/src/vsock_transport.rs
@@ -414,7 +414,6 @@ mod tests {
         let sock =
             mvm_core::config::vm_hvf_vsock_port_socket(name, mvm_agentd::vsock::GUEST_AGENT_PORT);
         let Some(_listener) = bind_unix_listener(&sock) else {
-            unsafe { std::env::remove_var("MVM_HOME") };
             return;
         };
 
@@ -440,7 +439,6 @@ mod tests {
         let name = "hvf-picker-probe";
         let sock = mvm_core::config::vm_hvf_agent_socket(name);
         let Some(_listener) = bind_unix_listener(&sock) else {
-            unsafe { std::env::remove_var("MVM_HOME") };
             return;
         };
 
@@ -462,7 +460,6 @@ mod tests {
         let name = "hvf-picker-long-path";
         let sock = mvm_core::config::vm_hvf_agent_socket(name);
         let Some(_listener) = bind_unix_listener(&sock) else {
-            unsafe { std::env::remove_var("MVM_HOME") };
             return;
         };
 

--- a/crates/mvm-sdk/src/compile/flake.rs
+++ b/crates/mvm-sdk/src/compile/flake.rs
@@ -207,6 +207,7 @@ pub fn build_flake_nix(workload: &Workload) -> Result<String, serde_json::Error>
 mod tests {
     use super::*;
     use crate::ir::{App, Entrypoint, Image, Resources, Source};
+    use mvm_core::util::test_env::TestEnv;
 
     fn sample() -> Workload {
         Workload {
@@ -250,7 +251,8 @@ mod tests {
     #[test]
     fn flake_is_deterministic_under_default_pin() {
         // Defensive: clear any test-set override.
-        unsafe { std::env::remove_var("MVM_FLAKE_URL") };
+        let mut env = TestEnv::new();
+        env.remove("MVM_FLAKE_URL");
         let a = build_flake_nix(&sample()).unwrap();
         let b = build_flake_nix(&sample()).unwrap();
         assert_eq!(a, b);

--- a/crates/mvm-sdk/src/lib.rs
+++ b/crates/mvm-sdk/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! mvm-sdk — build-time Rust SDK for declaring mvm workloads.
 //!
 //! Builder-pattern surface (no globals), build-time DSL only in v1 (no


### PR DESCRIPTION
## What

Reduces `unsafe` and fences the pure crates against regression, in four self-contained commits:

1. **`forbid(unsafe_code)` on `mvm-net` + `mvm-client`** — both were already unsafe-free; `forbid` makes adding any a compile error.
2. **Route 137 test-side env mutations through `TestEnv`** — `std::env::set_var`/`remove_var` are `unsafe` under Rust 2024. These 137 test sites carried raw `unsafe` plus hand-rolled `Mutex` + manual save/restore duplicating `mvm_core::util::test_env::TestEnv`. Routing them through the one guard deletes the duplication (net −369 lines). `HOME_TEST_LOCK`/`DATA_DIR_LOCK` are kept where they also serialize out-of-scope tests against `MVM_HOME`; the lock is always taken before `TestEnv::new()`, so there is no ordering inversion.
3. **Centralize the CLI env writes behind one documented `set_cli_env` helper** — the startup writes (`MVM_FC_VERSION` / `MVM_BUILDER_BACKEND` / `MVM_AUX_BIN_DIR` / `MVM_KERNEL_SOURCE`, `RUST_LOG`, `MVM_NO_PERSISTENT_BUILDER`) are the CLI's config-propagation channel — read in-process **and inherited by re-exec'd child `mvmctl` helpers** (the builder-VM bootstrap spawns a child with no flag args and relies on env inheritance), so they must stay process-global. Six `unsafe` blocks collapse to one, behind a single verified `// SAFETY:` justification (every caller runs on the main thread before any worker thread exists; the lone SIGINT servicer never reads env). Behavior unchanged.
4. **`deny(unsafe_code)` on `mvm-core`, `forbid` on `mvm-sdk`** — `mvm-core`'s only real `unsafe` is the `test_env` helper; `deny` at the crate root with one documented `allow` on `util::test_env` (the `mvm-fs` model) walls off the rest of the foundation crate.

## Why not remove the CLI env writes entirely

An earlier idea was to replace them with a `OnceLock`. That would silently break `--builder` / `--kernel-source` / `-v` propagation to re-exec'd child processes (the `__builder-vm-bootstrap` child receives no flag args and relies on inherited env), and the in-process test suite would not catch it. The remaining ~500 workspace `unsafe` are irreducible FFI/hypervisor/syscall — the honest floor, now with the pure crates fenced so it can't creep back in.

## Verification

- nightly `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (enforced per-commit by the pre-commit hook)
- `cargo nextest run --workspace` (macOS) — 7612 passed, 12 skipped, 0 failed
- Firecracker/KVM host (Linux x86_64, `/dev/kvm`): `cargo build --workspace --all-targets` green (confirms `deny`/`forbid` and every `#[cfg(linux)]`-gated converted test compile on Linux); touched-crate tests pass (`mvm-cli`, `mvm-runtime`, `mvm-core`, `mvm-build`, `mvm-hostd`, `mvm-sdk`). The only failures were 2 pre-existing `nix build` integration tests (`mvm-build` `runtime_overlay_build`) — the box's nix produced an incomplete overlay artifact (missing `checksums-sha256.txt`) — which this diff does not touch and which early-return on hosts without nix.
- `mvm-protocol` builds `no_std` + `alloc` on `wasm32-unknown-unknown` — green
