### PR TITLE
feat(lineage): read-only machine timeline over checkpoint and image DAGs (C1 of #1809)

### DIFF
--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -147,6 +147,8 @@ impl Commands {
                 // `machine run --up-json` emits the SDK boot envelope;
                 // reserve stdout so reconcile chrome can't interleave.
                 machine::MachineAction::Run(r) => r.json || r.up_json,
+                // `machine timeline --json` prints a structured lineage.
+                machine::MachineAction::Timeline(t) => t.json,
                 _ => false,
             },
             _ => false,

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -123,6 +123,11 @@ pub(in crate::commands) enum MachineAction {
     /// extraction, no boot.
     #[command(name = "check-artifact", display_order = 13)]
     CheckArtifact(portable::CheckArtifactArgs),
+    /// Render a checkpoint or image's lineage (ancestors to genesis + immediate
+    /// children), verifying each hop against the signed audit chain. Read-only:
+    /// no restore, no admission, no boot.
+    #[command(display_order = 14)]
+    Timeline(super::vm::checkpoint::TimelineArgs),
     /// Advanced single-VM operations (pause, snapshot, cp, fs, …). Hidden; use `machine <verb>` directly.
     #[command(flatten)]
     Vm(VmCmd),
@@ -152,6 +157,7 @@ impl MachineAction {
             | MachineAction::Logs(_)
             | MachineAction::Console(_)
             | MachineAction::CheckArtifact(_) => "machine",
+            MachineAction::Timeline(_) => "timeline",
         }
     }
 }
@@ -1284,6 +1290,7 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
         MachineAction::Logs(log_args) => super::vm::logs::run(cli, log_args, cfg),
         MachineAction::Console(console_args) => super::vm::console::run(cli, console_args, cfg),
         MachineAction::CheckArtifact(a) => portable::run_check_artifact(a),
+        MachineAction::Timeline(a) => super::vm::checkpoint::run_timeline(a),
         MachineAction::Vm(cmd) => {
             super::vm::group::run(cli, super::vm::group::Args { action: cmd }, cfg)
         }

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -91,6 +91,7 @@ fn machine_subcommand(action: &MachineAction) -> &'static str {
         MachineAction::Logs(_) => "logs",
         MachineAction::Console(_) => "console",
         MachineAction::CheckArtifact(_) => "check-artifact",
+        MachineAction::Timeline(_) => "timeline",
         MachineAction::Vm(_) => "vm",
     }
 }

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -28,7 +28,9 @@ use super::shared::clap_vm_name;
 use crate::ui;
 
 mod lineage;
+mod timeline;
 pub(super) use lineage::SignedChainAnchor;
+pub(in crate::commands) use timeline::{TimelineArgs, run_timeline};
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct CheckpointArgs {

--- a/crates/mvm-cli/src/commands/vm/checkpoint/timeline.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/timeline.rs
@@ -1,0 +1,795 @@
+//! `mvmctl machine timeline <id|digest>` — a read-only navigator over the
+//! checkpoint and image lineage DAGs.
+//!
+//! It resolves a target in EITHER store, then renders its ancestry (backward to
+//! genesis) plus its immediate children (the forward fork tree), verifying every
+//! hop against the signed audit chain via [`SignedChainAnchor`]. It is strictly
+//! read-only: no restore, no admission, no VM launch, no store writes.
+//!
+//! Verification is surfaced, never enforced. Each hop is marked verified or not,
+//! and the whole timeline carries an overall verdict, but no trust decision is
+//! made from it — the pass/fail gate is `machine checkpoint verify`. A tampered
+//! or un-audited hop is marked, so the chain is never presented as if valid; the
+//! command still renders (exit 0) so it stays usable for navigation.
+
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+
+use mvm_core::checkpoint::{CheckpointClass, CheckpointDigest, CheckpointMeta};
+use mvm_core::image_lineage::{ImageBuildIdentity, ImageNode};
+use mvm_runtime::checkpoint::{CheckpointStore, checkpoint_ancestry, checkpoint_children};
+use mvm_runtime::image_lineage::{ImageStore, image_ancestry, image_children};
+use mvm_runtime::lineage::{Ancestry, VerifiedNode};
+
+use super::SignedChainAnchor;
+use super::validated_checkpoint_id;
+
+#[derive(clap::Args, Debug, Clone)]
+pub(in crate::commands) struct TimelineArgs {
+    /// Checkpoint id, or a `sha256:<hex>` content-address that names a
+    /// checkpoint or an image lineage node.
+    pub target: String,
+    /// Disambiguate a `sha256:<hex>` digest that exists in BOTH the checkpoint
+    /// and image stores. Not needed for a checkpoint id.
+    #[arg(long, value_enum)]
+    pub kind: Option<LineageKind>,
+    /// Output the timeline as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Which lineage DAG a `sha256:<hex>` digest refers to. Only used to resolve the
+/// rare cross-store collision where one digest names both a checkpoint and an
+/// image node.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::commands) enum LineageKind {
+    Checkpoint,
+    Image,
+}
+
+impl LineageKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            LineageKind::Checkpoint => "checkpoint",
+            LineageKind::Image => "image",
+        }
+    }
+}
+
+/// The record a target string resolved to, in one of the two stores.
+#[derive(Debug)]
+enum ResolvedTarget {
+    Checkpoint(CheckpointMeta),
+    Image(ImageNode),
+}
+
+pub(in crate::commands) fn run_timeline(args: TimelineArgs) -> Result<()> {
+    let checkpoint_store = CheckpointStore::open();
+    let image_store = ImageStore::open();
+    let anchor = SignedChainAnchor::load()
+        .context("loading the signed audit chain to anchor lineage verification")?;
+
+    let resolved = resolve_target(&checkpoint_store, &image_store, &args.target, args.kind)?;
+    let timeline = match resolved {
+        ResolvedTarget::Checkpoint(meta) => {
+            build_checkpoint_timeline(&checkpoint_store, &anchor, meta)?
+        }
+        ResolvedTarget::Image(node) => build_image_timeline(&image_store, &anchor, node)?,
+    };
+
+    if args.json {
+        crate::json_out::emit_json(&timeline)?;
+    } else {
+        println!("{}", render_human(&timeline));
+    }
+    Ok(())
+}
+
+/// Resolve `target` to a record in one of the two stores. A `sha256:<hex>`
+/// addresses either store (disambiguated by `kind` on a collision); anything
+/// else is a checkpoint id (image nodes have no id — their identity is their
+/// digest).
+fn resolve_target(
+    checkpoint_store: &CheckpointStore,
+    image_store: &ImageStore,
+    target: &str,
+    kind: Option<LineageKind>,
+) -> Result<ResolvedTarget> {
+    match CheckpointDigest::parse(target) {
+        Ok(digest) => resolve_digest(checkpoint_store, image_store, &digest, kind),
+        Err(_) => resolve_checkpoint_id(checkpoint_store, target, kind),
+    }
+}
+
+/// A `sha256:<hex>` digest may name a checkpoint, an image node, or (structurally
+/// possible) both. `kind` restricts the lookup to one store; without it, a
+/// both-stores hit is refused as ambiguous rather than silently picking one.
+fn resolve_digest(
+    checkpoint_store: &CheckpointStore,
+    image_store: &ImageStore,
+    digest: &CheckpointDigest,
+    kind: Option<LineageKind>,
+) -> Result<ResolvedTarget> {
+    let checkpoint_hit = match kind {
+        Some(LineageKind::Image) => None,
+        _ => checkpoint_store.by_digest(digest)?,
+    };
+    let image_hit = match kind {
+        Some(LineageKind::Checkpoint) => None,
+        _ => image_store.by_digest(digest)?,
+    };
+    match (checkpoint_hit, image_hit) {
+        // Only reachable with `kind == None` (a set `kind` forces one side off),
+        // so pointing at `--kind` is always the right remedy here.
+        (Some(_), Some(_)) => bail!(
+            "digest {digest} names BOTH a checkpoint and an image node; \
+             disambiguate with `--kind checkpoint` or `--kind image`"
+        ),
+        (Some(meta), None) => Ok(ResolvedTarget::Checkpoint(meta)),
+        (None, Some(node)) => Ok(ResolvedTarget::Image(node)),
+        (None, None) => match kind {
+            Some(k) => bail!("no {} lineage record found for digest {digest}", k.as_str()),
+            None => bail!("no checkpoint or image lineage record found for digest {digest}"),
+        },
+    }
+}
+
+/// A non-digest target is a checkpoint id. `--kind image` is incompatible: image
+/// nodes are addressed only by their `sha256:<hex>` content-address.
+fn resolve_checkpoint_id(
+    store: &CheckpointStore,
+    raw: &str,
+    kind: Option<LineageKind>,
+) -> Result<ResolvedTarget> {
+    if kind == Some(LineageKind::Image) {
+        bail!(
+            "`--kind image` needs a sha256:<hex> node digest; \
+             an image node has no id and {raw:?} is not a digest"
+        );
+    }
+    let id = validated_checkpoint_id(raw)?;
+    let meta = store
+        .read_meta(&id)
+        .with_context(|| format!("no checkpoint {raw:?} found"))?;
+    Ok(ResolvedTarget::Checkpoint(meta))
+}
+
+// ── timeline model (shared by both DAGs) ─────────────────────────────────────
+
+/// A rendered lineage: ancestors (genesis → the target's parent), the target,
+/// and its immediate children. Common shape for both the checkpoint and image
+/// DAGs; per-store presentation feeds this one struct.
+#[derive(Serialize, Debug)]
+struct Timeline {
+    schema_version: u8,
+    action: &'static str,
+    /// `"checkpoint"` or `"image"`.
+    kind: &'static str,
+    /// What identifies the target: a checkpoint id, or an image node digest.
+    target: String,
+    /// Ancestors ordered genesis → the target's immediate parent (excludes the
+    /// target itself).
+    ancestors: Vec<TimelineNode>,
+    /// The target node.
+    node: TimelineNode,
+    /// The target's immediate children — forward is a tree, so this may fork.
+    children: Vec<TimelineNode>,
+    /// A structural break that stopped the ancestry walk before genesis (a
+    /// dangling parent hash-link or a would-be cycle), if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lineage_broken: Option<String>,
+    /// Overall verdict: every rendered hop verified AND the ancestry reached
+    /// genesis with no structural break. Surfaced, never enforced.
+    verified: bool,
+}
+
+/// One node in a rendered timeline plus its per-hop verification verdict.
+#[derive(Serialize, Debug)]
+struct TimelineNode {
+    /// The node's content-address (checkpoint `meta_digest` / image
+    /// `node_digest`).
+    digest: String,
+    /// Checkpoint id; absent for image nodes (identity is the digest).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+    /// Parent hash-link (content-address); absent at genesis.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent: Option<String>,
+    created_unix: u64,
+    /// A short human descriptor (checkpoint: class + vm + tag; image: build
+    /// identity).
+    label: String,
+    /// Per-hop verdict against the signed audit chain.
+    verified: bool,
+    /// The fail-closed reason when `verified` is false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+fn build_checkpoint_timeline(
+    store: &CheckpointStore,
+    anchor: &SignedChainAnchor,
+    meta: CheckpointMeta,
+) -> Result<Timeline> {
+    let target_id = meta.id.to_string();
+    let target_digest = meta.meta_digest.clone();
+    let ancestry: Ancestry<CheckpointMeta> = checkpoint_ancestry(store, &meta.id, anchor)?;
+    let children = checkpoint_children(store, &target_digest, anchor)?;
+    Ok(assemble(
+        "checkpoint",
+        target_id,
+        ancestry,
+        children,
+        checkpoint_node,
+    ))
+}
+
+fn build_image_timeline(
+    store: &ImageStore,
+    anchor: &SignedChainAnchor,
+    node: ImageNode,
+) -> Result<Timeline> {
+    let target_digest = node.node_digest.clone();
+    let ancestry: Ancestry<ImageNode> = image_ancestry(store, &target_digest, anchor)?;
+    let children = image_children(store, &target_digest, anchor)?;
+    Ok(assemble(
+        "image",
+        target_digest.to_string(),
+        ancestry,
+        children,
+        image_node,
+    ))
+}
+
+/// Fold an enumerated ancestry + children into the presentation [`Timeline`].
+/// The ancestry's first node is the target; the rest are its ancestors in
+/// start→genesis order, which we reverse so the render reads genesis → target.
+fn assemble<R>(
+    kind: &'static str,
+    target: String,
+    ancestry: Ancestry<R>,
+    children: Vec<VerifiedNode<R>>,
+    to_node: fn(&VerifiedNode<R>) -> TimelineNode,
+) -> Timeline {
+    let children_verified = children.iter().all(|c| c.status.is_verified());
+    let verified = ancestry.fully_verified() && children_verified;
+
+    let mut nodes = ancestry.nodes;
+    // The target is the walk's first node; ancestors are the tail.
+    let target_node = to_node(&nodes.remove(0));
+    let mut ancestors: Vec<TimelineNode> = nodes.iter().map(to_node).collect();
+    ancestors.reverse(); // start→genesis becomes genesis→parent
+
+    Timeline {
+        schema_version: 1,
+        action: "timeline",
+        kind,
+        target,
+        ancestors,
+        node: target_node,
+        children: children.iter().map(to_node).collect(),
+        lineage_broken: ancestry.broken,
+        verified,
+    }
+}
+
+fn checkpoint_node(vn: &VerifiedNode<CheckpointMeta>) -> TimelineNode {
+    let m = &vn.record;
+    TimelineNode {
+        digest: m.meta_digest.to_string(),
+        id: Some(m.id.to_string()),
+        parent: m.parent.as_ref().map(ToString::to_string),
+        created_unix: m.created_unix,
+        label: checkpoint_label(m),
+        verified: vn.status.is_verified(),
+        error: vn.status.error().map(str::to_string),
+    }
+}
+
+fn checkpoint_label(m: &CheckpointMeta) -> String {
+    let class = match m.class {
+        CheckpointClass::FsQuick => "fs_quick",
+        CheckpointClass::VmFull => "vm_full",
+    };
+    match &m.tag {
+        Some(tag) => format!("{class} {} [{tag}]", m.vm_name),
+        None => format!("{class} {}", m.vm_name),
+    }
+}
+
+fn image_node(vn: &VerifiedNode<ImageNode>) -> TimelineNode {
+    let n = &vn.record;
+    TimelineNode {
+        digest: n.node_digest.to_string(),
+        id: None,
+        parent: n.parent.as_ref().map(ToString::to_string),
+        created_unix: n.created_unix,
+        label: image_label(n),
+        verified: vn.status.is_verified(),
+        error: vn.status.error().map(str::to_string),
+    }
+}
+
+fn image_label(n: &ImageNode) -> String {
+    match &n.build_identity {
+        ImageBuildIdentity::Flake { slot_hash } => format!("flake {slot_hash}"),
+        ImageBuildIdentity::Oci {
+            registry,
+            repository,
+        } => format!("oci {registry}/{repository}"),
+    }
+}
+
+// ── human rendering ──────────────────────────────────────────────────────────
+
+/// `sha256:<64hex>` abbreviated to `sha256:<first 12 hex>…` for the table; the
+/// full digest stays in `--json` for scripting.
+fn short_digest(digest: &str) -> String {
+    match digest.strip_prefix(CheckpointDigest::PREFIX) {
+        Some(hex) if hex.len() > 12 => format!("{}{}…", CheckpointDigest::PREFIX, &hex[..12]),
+        _ => digest.to_string(),
+    }
+}
+
+/// One rendered node line. `marker` prefixes the row (`▶` for the target, blank
+/// otherwise); the verdict trails so an UNVERIFIED hop reads loudly.
+fn node_line(marker: &str, node: &TimelineNode) -> String {
+    let verdict = match &node.error {
+        None => "verified".to_string(),
+        Some(reason) => format!("UNVERIFIED: {reason}"),
+    };
+    let id = node.id.as_deref().unwrap_or("-");
+    format!(
+        "  {marker:<2} {}  {:<10}  {}  {verdict}",
+        short_digest(&node.digest),
+        id,
+        node.label
+    )
+}
+
+/// Pure, testable human render of the whole timeline.
+fn render_human(timeline: &Timeline) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "timeline for {} {}",
+        timeline.kind, timeline.target
+    ));
+    lines.push(String::new());
+
+    lines.push("ancestors (genesis → target):".to_string());
+    if timeline.ancestors.is_empty() {
+        lines.push("  (target is a genesis root)".to_string());
+    } else {
+        for a in &timeline.ancestors {
+            lines.push(node_line("", a));
+        }
+    }
+    if let Some(reason) = &timeline.lineage_broken {
+        lines.push(format!("  ! lineage incomplete: {reason}"));
+    }
+
+    lines.push(String::new());
+    lines.push("target:".to_string());
+    lines.push(node_line("▶", &timeline.node));
+
+    lines.push(String::new());
+    lines.push("children (forks):".to_string());
+    if timeline.children.is_empty() {
+        lines.push("  (no children)".to_string());
+    } else {
+        for c in &timeline.children {
+            lines.push(node_line("", c));
+        }
+    }
+
+    lines.push(String::new());
+    lines.push(if timeline.verified {
+        "lineage verified against the signed audit chain".to_string()
+    } else {
+        "lineage has unverified hop(s) — see the UNVERIFIED marks above".to_string()
+    });
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::checkpoint::{CheckpointClass, CheckpointId, ContentBlob};
+    use mvm_core::image_lineage::{ImageCanonicalId, ImageIdentity, ImageNode, ImageProvenance};
+    use mvm_core::plan::test_support::PlanFixture;
+    use mvm_hostd::audit::bind::bind_checkpoint_created;
+    use mvm_hostd::audit::emitter::AuditEmitter;
+
+    // ── seed helpers: a store record + its host-signed creation entry ─────────
+
+    fn emitter() -> (AuditEmitter, mvm_core::plan::ExecutionPlan) {
+        let signer = crate::commands::vm::host_signer::load_or_init().unwrap();
+        let em = AuditEmitter::new(signer.signing).unwrap();
+        let plan = PlanFixture::new()
+            .tenant("local")
+            .plan_id("plan-timeline")
+            .build();
+        (em, plan)
+    }
+
+    fn seed_ckpt(
+        store: &CheckpointStore,
+        em: &AuditEmitter,
+        plan: &mvm_core::plan::ExecutionPlan,
+        id: &str,
+        parent: Option<CheckpointDigest>,
+    ) -> CheckpointMeta {
+        let meta = CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::FsQuick, "vm")
+            .parent(parent)
+            .content(vec![ContentBlob {
+                name: "rootfs.ext4".into(),
+                sha256: "h".into(),
+            }])
+            .supervisor_config_digest("d")
+            .created_unix(1)
+            .build();
+        store.write_meta(&meta).unwrap();
+        bind_checkpoint_created(em, plan, &meta).unwrap();
+        meta
+    }
+
+    fn image_of(slot: &str, revision: &str, parent: Option<CheckpointDigest>) -> ImageNode {
+        ImageNode::builder(
+            ImageBuildIdentity::Flake {
+                slot_hash: slot.into(),
+            },
+            ImageIdentity {
+                canonical: ImageCanonicalId::Flake {
+                    revision_hash: revision.into(),
+                },
+                artifacts: vec![ContentBlob {
+                    name: "rootfs.ext4".into(),
+                    sha256: revision.into(),
+                }],
+            },
+            ImageProvenance::Build {
+                input_ref: ".#app".into(),
+                lock_digest: None,
+            },
+        )
+        .parent(parent)
+        .created_unix(1)
+        .build()
+    }
+
+    fn seed_image(
+        store: &ImageStore,
+        em: &AuditEmitter,
+        plan: &mvm_core::plan::ExecutionPlan,
+        node: &ImageNode,
+    ) {
+        store.save(node).unwrap();
+        em.emit_image_created(plan, node).unwrap();
+    }
+
+    fn digest_of(hex_char: char) -> CheckpointDigest {
+        CheckpointDigest::parse(format!("sha256:{}", hex_char.to_string().repeat(64))).unwrap()
+    }
+
+    // ── pure helpers ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn short_digest_abbreviates_long_hex() {
+        let full = format!("sha256:{}", "a".repeat(64));
+        assert_eq!(short_digest(&full), "sha256:aaaaaaaaaaaa…");
+        // A non-digest string is left untouched.
+        assert_eq!(short_digest("not-a-digest"), "not-a-digest");
+    }
+
+    #[test]
+    fn render_human_marks_an_unverified_hop_loudly() {
+        let timeline = Timeline {
+            schema_version: 1,
+            action: "timeline",
+            kind: "checkpoint",
+            target: "c-target".into(),
+            ancestors: vec![TimelineNode {
+                digest: format!("sha256:{}", "a".repeat(64)),
+                id: Some("c-genesis".into()),
+                parent: None,
+                created_unix: 1,
+                label: "fs_quick vm".into(),
+                verified: false,
+                error: Some("meta_digest drift".into()),
+            }],
+            node: TimelineNode {
+                digest: format!("sha256:{}", "b".repeat(64)),
+                id: Some("c-target".into()),
+                parent: Some(format!("sha256:{}", "a".repeat(64))),
+                created_unix: 2,
+                label: "fs_quick vm".into(),
+                verified: true,
+                error: None,
+            },
+            children: vec![],
+            lineage_broken: None,
+            verified: false,
+        };
+        let out = render_human(&timeline);
+        assert!(out.contains("UNVERIFIED: meta_digest drift"), "{out}");
+        assert!(out.contains("unverified hop(s)"), "{out}");
+        assert!(out.contains("(no children)"), "{out}");
+    }
+
+    // ── resolution ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn resolves_a_checkpoint_by_id() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let cstore = CheckpointStore::open();
+        let istore = ImageStore::open();
+        let (em, plan) = emitter();
+        let meta = seed_ckpt(&cstore, &em, &plan, "ckpt-by-id", None);
+
+        match resolve_target(&cstore, &istore, "ckpt-by-id", None).unwrap() {
+            ResolvedTarget::Checkpoint(m) => assert_eq!(m.id, meta.id),
+            ResolvedTarget::Image(_) => panic!("id must resolve to a checkpoint"),
+        }
+    }
+
+    #[test]
+    fn unknown_checkpoint_id_is_an_error() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let cstore = CheckpointStore::open();
+        let istore = ImageStore::open();
+        let err = resolve_target(&cstore, &istore, "no-such-ckpt", None).unwrap_err();
+        assert!(err.to_string().contains("no checkpoint"), "{err}");
+    }
+
+    #[test]
+    fn digest_only_in_checkpoint_store_resolves_to_checkpoint() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let cstore = CheckpointStore::open();
+        let istore = ImageStore::open();
+        let (em, plan) = emitter();
+        let meta = seed_ckpt(&cstore, &em, &plan, "ckpt-dig", None);
+
+        match resolve_target(&cstore, &istore, meta.meta_digest.as_str(), None).unwrap() {
+            ResolvedTarget::Checkpoint(m) => assert_eq!(m.meta_digest, meta.meta_digest),
+            ResolvedTarget::Image(_) => panic!("digest is only in the checkpoint store"),
+        }
+    }
+
+    #[test]
+    fn digest_only_in_image_store_resolves_to_image() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let cstore = CheckpointStore::open();
+        let istore = ImageStore::open();
+        let (em, plan) = emitter();
+        let node = image_of("slot-a", "rev-1", None);
+        seed_image(&istore, &em, &plan, &node);
+
+        match resolve_target(&cstore, &istore, node.node_digest.as_str(), None).unwrap() {
+            ResolvedTarget::Image(n) => assert_eq!(n.node_digest, node.node_digest),
+            ResolvedTarget::Checkpoint(_) => panic!("digest is only in the image store"),
+        }
+    }
+
+    /// Plant the SAME digest string in both stores (content-addresses can't
+    /// collide naturally, so the records are hand-filed under one digest) to
+    /// exercise the cross-store ambiguity refusal + `--kind` disambiguation.
+    fn plant_collision(cstore: &CheckpointStore, istore: &ImageStore) -> CheckpointDigest {
+        let d = digest_of('c');
+        let mut meta =
+            CheckpointMeta::builder(CheckpointId::new("collide"), CheckpointClass::FsQuick, "vm")
+                .content(vec![])
+                .supervisor_config_digest("d")
+                .created_unix(1)
+                .build();
+        meta.meta_digest = d.clone();
+        cstore.write_meta(&meta).unwrap();
+
+        let mut node = image_of("slot-a", "rev-1", None);
+        node.node_digest = d.clone();
+        istore.save(&node).unwrap();
+        d
+    }
+
+    #[test]
+    fn a_digest_in_both_stores_is_refused_as_ambiguous() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let cstore = CheckpointStore::open();
+        let istore = ImageStore::open();
+        let d = plant_collision(&cstore, &istore);
+
+        let err = resolve_target(&cstore, &istore, d.as_str(), None).unwrap_err();
+        assert!(err.to_string().contains("BOTH"), "{err}");
+        assert!(err.to_string().contains("--kind"), "{err}");
+    }
+
+    #[test]
+    fn kind_disambiguates_a_cross_store_collision() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let cstore = CheckpointStore::open();
+        let istore = ImageStore::open();
+        let d = plant_collision(&cstore, &istore);
+
+        assert!(matches!(
+            resolve_target(&cstore, &istore, d.as_str(), Some(LineageKind::Checkpoint)).unwrap(),
+            ResolvedTarget::Checkpoint(_)
+        ));
+        assert!(matches!(
+            resolve_target(&cstore, &istore, d.as_str(), Some(LineageKind::Image)).unwrap(),
+            ResolvedTarget::Image(_)
+        ));
+    }
+
+    #[test]
+    fn kind_image_with_a_non_digest_is_an_error() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let cstore = CheckpointStore::open();
+        let istore = ImageStore::open();
+        let err =
+            resolve_target(&cstore, &istore, "some-id", Some(LineageKind::Image)).unwrap_err();
+        assert!(err.to_string().contains("node digest"), "{err}");
+    }
+
+    // ── checkpoint timeline build (real signed chain) ─────────────────────────
+
+    #[test]
+    fn checkpoint_timeline_orders_ancestors_and_lists_children_verified() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let store = CheckpointStore::open();
+        let (em, plan) = emitter();
+
+        let g0 = seed_ckpt(&store, &em, &plan, "g0", None);
+        let g1 = seed_ckpt(&store, &em, &plan, "g1", Some(g0.meta_digest.clone()));
+        let g2 = seed_ckpt(&store, &em, &plan, "g2", Some(g1.meta_digest.clone()));
+        // g2 forks into two children.
+        let c1 = seed_ckpt(&store, &em, &plan, "c1", Some(g2.meta_digest.clone()));
+        let c2 = seed_ckpt(&store, &em, &plan, "c2", Some(g2.meta_digest.clone()));
+
+        let anchor = SignedChainAnchor::load().unwrap();
+        let timeline = build_checkpoint_timeline(&store, &anchor, g2.clone()).unwrap();
+
+        assert_eq!(timeline.kind, "checkpoint");
+        assert_eq!(timeline.node.id.as_deref(), Some("g2"));
+        // Ancestors are genesis → parent: [g0, g1].
+        let anc: Vec<&str> = timeline
+            .ancestors
+            .iter()
+            .map(|a| a.id.as_deref().unwrap())
+            .collect();
+        assert_eq!(anc, vec!["g0", "g1"]);
+        assert!(timeline.ancestors.iter().all(|a| a.verified));
+        // Children are both forks (order is store-scan order; assert as a set).
+        let kids: std::collections::BTreeSet<&str> = timeline
+            .children
+            .iter()
+            .map(|c| c.id.as_deref().unwrap())
+            .collect();
+        assert_eq!(
+            kids,
+            ["c1", "c2"].into_iter().collect(),
+            "both forks are enumerated"
+        );
+        let _ = (c1, c2);
+        assert!(timeline.children.iter().all(|c| c.verified));
+        assert!(timeline.node.verified);
+        assert!(timeline.verified, "a fully-audited chain verifies");
+        assert!(timeline.lineage_broken.is_none());
+    }
+
+    #[test]
+    fn tampered_ancestor_is_marked_unverified_but_timeline_still_builds() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let store = CheckpointStore::open();
+        let (em, plan) = emitter();
+
+        let g0 = seed_ckpt(&store, &em, &plan, "g0", None);
+        let g1 = seed_ckpt(&store, &em, &plan, "g1", Some(g0.meta_digest.clone()));
+        let g2 = seed_ckpt(&store, &em, &plan, "g2", Some(g1.meta_digest.clone()));
+
+        let anchor = SignedChainAnchor::load().unwrap();
+
+        // Tamper genesis g0's meta.json: change a load-bearing field but keep the
+        // stored meta_digest, so its recompute now drifts.
+        let path = store.dir_for(&g0.id).join("meta.json");
+        let mut tampered: CheckpointMeta =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        tampered.created_unix = 999;
+        std::fs::write(&path, serde_json::to_vec_pretty(&tampered).unwrap()).unwrap();
+
+        // The timeline STILL builds (read-only navigation never bails)...
+        let timeline = build_checkpoint_timeline(&store, &anchor, g2).unwrap();
+        // ...listing all three nodes, with the tampered genesis marked unverified.
+        let g0_node = timeline
+            .ancestors
+            .iter()
+            .find(|a| a.id.as_deref() == Some("g0"))
+            .expect("tampered genesis is NOT dropped");
+        assert!(!g0_node.verified);
+        assert!(g0_node.error.as_ref().unwrap().contains("drift"));
+        // g1 (untouched) still verifies.
+        let g1_node = timeline
+            .ancestors
+            .iter()
+            .find(|a| a.id.as_deref() == Some("g1"))
+            .unwrap();
+        assert!(g1_node.verified);
+        // Overall verdict is failed, and the walk still reached genesis.
+        assert!(!timeline.verified);
+        assert!(timeline.lineage_broken.is_none());
+    }
+
+    #[test]
+    fn timeline_json_shape_is_stable() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let store = CheckpointStore::open();
+        let (em, plan) = emitter();
+        let g0 = seed_ckpt(&store, &em, &plan, "g0", None);
+
+        let anchor = SignedChainAnchor::load().unwrap();
+        let timeline = build_checkpoint_timeline(&store, &anchor, g0).unwrap();
+        let v: serde_json::Value = serde_json::to_value(&timeline).unwrap();
+        assert_eq!(v["schema_version"], 1);
+        assert_eq!(v["action"], "timeline");
+        assert_eq!(v["kind"], "checkpoint");
+        assert_eq!(v["target"], "g0");
+        assert_eq!(v["verified"], true);
+        assert!(v["ancestors"].as_array().unwrap().is_empty());
+        assert!(v["children"].as_array().unwrap().is_empty());
+        assert_eq!(v["node"]["id"], "g0");
+        assert_eq!(v["node"]["verified"], true);
+        // genesis node carries no parent key
+        assert!(v["node"].get("parent").is_none());
+    }
+
+    // ── image timeline build (real signed chain) ──────────────────────────────
+
+    #[test]
+    fn image_timeline_resolves_by_digest_and_verifies() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let cstore = CheckpointStore::open();
+        let istore = ImageStore::open();
+        let (em, plan) = emitter();
+
+        let g0 = image_of("slot-a", "rev-1", None);
+        seed_image(&istore, &em, &plan, &g0);
+        let g1 = image_of("slot-a", "rev-2", Some(g0.node_digest.clone()));
+        seed_image(&istore, &em, &plan, &g1);
+
+        // Resolve the tip by its node digest, then build its timeline.
+        let resolved = resolve_target(&cstore, &istore, g1.node_digest.as_str(), None).unwrap();
+        let ResolvedTarget::Image(node) = resolved else {
+            panic!("digest must resolve to an image node");
+        };
+        let anchor = SignedChainAnchor::load().unwrap();
+        let timeline = build_image_timeline(&istore, &anchor, node).unwrap();
+
+        assert_eq!(timeline.kind, "image");
+        assert_eq!(timeline.node.digest, g1.node_digest.to_string());
+        assert!(timeline.node.id.is_none(), "image nodes have no id");
+        // One ancestor (genesis g0), verified.
+        assert_eq!(timeline.ancestors.len(), 1);
+        assert_eq!(timeline.ancestors[0].digest, g0.node_digest.to_string());
+        assert!(timeline.verified);
+    }
+}

--- a/crates/mvm-runtime/src/checkpoint/mod.rs
+++ b/crates/mvm-runtime/src/checkpoint/mod.rs
@@ -240,6 +240,9 @@ impl LineageGraph for CheckpointGraph<'_> {
     fn by_digest(&self, digest: &CheckpointDigest) -> Result<Option<CheckpointMeta>> {
         self.0.by_digest(digest)
     }
+    fn children_of(&self, parent_digest: &CheckpointDigest) -> Result<Vec<CheckpointMeta>> {
+        self.0.children_of(parent_digest)
+    }
 }
 
 /// Verify one checkpoint record against the signed audit chain: its stored
@@ -281,6 +284,31 @@ pub fn verify_lineage(
     anchor: &dyn CheckpointChainAnchor,
 ) -> Result<()> {
     crate::lineage::verify_lineage_chain(&CheckpointGraph(store), id, anchor)
+}
+
+/// Enumerate a checkpoint's ancestry (itself + every ancestor up to genesis),
+/// verifying each hop against the signed audit chain. Read-only navigation: it
+/// records each node's [`crate::lineage::HopStatus`] and keeps walking rather
+/// than bailing, so a caller can render the whole chain with a failed hop marked;
+/// it still fails closed on a dangling parent or a cycle via
+/// [`crate::lineage::Ancestry::broken`]. The backward analog of the forward
+/// [`checkpoint_children`].
+pub fn checkpoint_ancestry(
+    store: &CheckpointStore,
+    id: &CheckpointId,
+    anchor: &dyn CheckpointChainAnchor,
+) -> Result<crate::lineage::Ancestry<CheckpointMeta>> {
+    crate::lineage::collect_ancestry(&CheckpointGraph(store), id, anchor)
+}
+
+/// Enumerate a checkpoint's immediate children (forward is a tree — a checkpoint
+/// may be forked many times), each verified against the signed audit chain.
+pub fn checkpoint_children(
+    store: &CheckpointStore,
+    parent_digest: &CheckpointDigest,
+    anchor: &dyn CheckpointChainAnchor,
+) -> Result<Vec<crate::lineage::VerifiedNode<CheckpointMeta>>> {
+    crate::lineage::verified_children(&CheckpointGraph(store), parent_digest, anchor)
 }
 
 /// The fork's source is the sealed checkpoint content (cloned at capture

--- a/crates/mvm-runtime/src/image_lineage.rs
+++ b/crates/mvm-runtime/src/image_lineage.rs
@@ -222,6 +222,9 @@ impl LineageGraph for ImageGraph<'_> {
     fn by_digest(&self, digest: &CheckpointDigest) -> Result<Option<ImageNode>> {
         self.0.by_digest(digest)
     }
+    fn children_of(&self, parent_digest: &CheckpointDigest) -> Result<Vec<ImageNode>> {
+        self.0.children_of(parent_digest)
+    }
 }
 
 /// Walk an image node's version lineage from `node_digest` to its genesis root,
@@ -240,6 +243,30 @@ pub fn verify_image_lineage(
     anchor: &dyn ImageChainAnchor,
 ) -> Result<()> {
     crate::lineage::verify_lineage_chain(&ImageGraph(store), node_digest, anchor)
+}
+
+/// Enumerate an image node's ancestry (itself + every ancestor up to genesis),
+/// verifying each hop against the signed audit chain. Read-only navigation: each
+/// node carries its [`crate::lineage::HopStatus`] and the walk fails closed on a
+/// dangling parent or a cycle via [`crate::lineage::Ancestry::broken`] rather
+/// than bailing on the first bad node. The image analog of
+/// [`crate::checkpoint::checkpoint_ancestry`].
+pub fn image_ancestry(
+    store: &ImageStore,
+    node_digest: &CheckpointDigest,
+    anchor: &dyn ImageChainAnchor,
+) -> Result<crate::lineage::Ancestry<ImageNode>> {
+    crate::lineage::collect_ancestry(&ImageGraph(store), node_digest, anchor)
+}
+
+/// Enumerate an image node's immediate children (forward is a tree — the same
+/// build identity can fork), each verified against the signed audit chain.
+pub fn image_children(
+    store: &ImageStore,
+    parent_digest: &CheckpointDigest,
+    anchor: &dyn ImageChainAnchor,
+) -> Result<Vec<crate::lineage::VerifiedNode<ImageNode>>> {
+    crate::lineage::verified_children(&ImageGraph(store), parent_digest, anchor)
 }
 
 #[cfg(test)]

--- a/crates/mvm-runtime/src/lib.rs
+++ b/crates/mvm-runtime/src/lib.rs
@@ -74,9 +74,12 @@ pub mod image_lineage;
 /// (compiles + tests everywhere); the ioctl glue is Linux-only.
 pub mod kvm;
 pub mod libkrun;
-/// Namespace-agnostic hash-linked lineage walk shared by [`checkpoint`] and
-/// [`image_lineage`].
-pub(crate) mod lineage;
+/// Namespace-agnostic hash-linked lineage walk + read-only enumeration shared by
+/// [`checkpoint`] and [`image_lineage`]. The walk traits stay crate-private (the
+/// stores provide concrete wrappers); the enumeration result types
+/// ([`lineage::Ancestry`], [`lineage::VerifiedNode`], [`lineage::HopStatus`]) are
+/// public so a navigator can name what the wrappers return.
+pub mod lineage;
 pub mod microvm;
 /// The hermetic in-memory `MockBackend` — see its module docs for the
 /// security posture. Gated behind `test-support` so it never compiles into

--- a/crates/mvm-runtime/src/lineage.rs
+++ b/crates/mvm-runtime/src/lineage.rs
@@ -36,8 +36,9 @@ pub(crate) trait LineageRecord {
     fn digest_field(&self) -> &'static str;
 }
 
-/// A store the walk reads records from: by a start id, or by content-address to
-/// resolve a parent hash-link.
+/// A store the walk reads records from: by a start id, by content-address to
+/// resolve a parent hash-link, or by parent digest to enumerate forward
+/// children.
 pub(crate) trait LineageGraph {
     type Record: LineageRecord;
     type Id;
@@ -48,6 +49,10 @@ pub(crate) trait LineageGraph {
     /// the link is what makes resolving a parent by content-address *be* the
     /// hash-link check.
     fn by_digest(&self, digest: &CheckpointDigest) -> Result<Option<Self::Record>>;
+    /// Every stored record whose parent hash-link is `parent_digest`. Forward
+    /// lineage is a tree: a node may have several children (forks), so this
+    /// returns a set rather than an `Option`.
+    fn children_of(&self, parent_digest: &CheckpointDigest) -> Result<Vec<Self::Record>>;
 }
 
 /// Resolves the signature-authenticated content-address a record's creation was
@@ -140,6 +145,159 @@ where
     }
 }
 
+/// The verification verdict for one enumerated lineage node, checked against the
+/// signed audit chain. Unlike [`verify_lineage_chain`] — which bails on the
+/// first failure — enumeration *records* a failure so a read-only navigator can
+/// render the whole lineage while marking the bad hop. Marking, never hiding:
+/// the caller must not present a `Failed` node as a valid one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HopStatus {
+    /// The node's content-address matched both its recompute and the signed
+    /// chain's recorded creation digest.
+    Verified,
+    /// Verification failed; the string is the fail-closed reason
+    /// ([`verify_record_against_chain`]'s error: drift, chain mismatch, or no
+    /// signed entry).
+    Failed(String),
+}
+
+impl HopStatus {
+    /// `true` only for [`HopStatus::Verified`].
+    pub fn is_verified(&self) -> bool {
+        matches!(self, HopStatus::Verified)
+    }
+
+    /// The failure reason, or `None` when verified.
+    pub fn error(&self) -> Option<&str> {
+        match self {
+            HopStatus::Verified => None,
+            HopStatus::Failed(reason) => Some(reason),
+        }
+    }
+}
+
+/// One enumerated lineage node paired with its chain-verification verdict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedNode<R> {
+    pub record: R,
+    pub status: HopStatus,
+}
+
+/// A record's ancestry: the record itself plus every ancestor up to genesis,
+/// each verified against the signed chain, ordered start → genesis. `broken`
+/// carries a fail-closed reason when the walk could not reach genesis (a
+/// dangling parent hash-link or a would-be cycle); `None` means it terminated
+/// cleanly at a genesis root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ancestry<R> {
+    pub nodes: Vec<VerifiedNode<R>>,
+    pub broken: Option<String>,
+}
+
+impl<R> Ancestry<R> {
+    /// `true` iff every node verified AND the walk reached genesis without a
+    /// structural break. A single failed hop or a break makes the whole
+    /// ancestry unverified — fail closed.
+    pub fn fully_verified(&self) -> bool {
+        self.broken.is_none() && self.nodes.iter().all(|n| n.status.is_verified())
+    }
+}
+
+/// Enumerate a record's ancestry from `start` up to its genesis root, verifying
+/// each node against the signed audit chain via `anchor`. The read-only
+/// enumeration analog of [`verify_lineage_chain`]: it reuses the same
+/// content-address hash-link walk and the same guards, but instead of bailing on
+/// the first bad node it records the node's [`HopStatus`] and keeps walking, so a
+/// navigator can render the full chain with the failing hop marked. It still
+/// fails closed on the *structural* breaks a verdict cannot express — a dangling
+/// parent hash-link or a would-be cycle — by terminating the walk and reporting
+/// the reason in [`Ancestry::broken`] rather than looping or fabricating a link.
+///
+/// The initial [`LineageGraph::read`] of `start` is the one hard error: a start
+/// that cannot even be read is returned as `Err` (there is no lineage to show).
+pub(crate) fn collect_ancestry<G, A>(
+    graph: &G,
+    start: &G::Id,
+    anchor: &A,
+) -> Result<Ancestry<G::Record>>
+where
+    G: LineageGraph,
+    A: LineageAnchor<G::Record> + ?Sized,
+{
+    let mut current = graph.read(start)?;
+    let mut nodes: Vec<VerifiedNode<G::Record>> = Vec::new();
+    let mut seen: Vec<CheckpointDigest> = Vec::new();
+    let broken = loop {
+        // Cycle guard first: a genuine content-address chain cannot revisit a
+        // digest, so a revisit is a forged/broken set — stop before re-adding it
+        // (which would also loop forever).
+        if seen.contains(current.stored_digest()) {
+            break Some(format!(
+                "{} '{}' lineage revisits digest {}: refusing a cyclic chain",
+                current.kind(),
+                current.id_label(),
+                current.stored_digest()
+            ));
+        }
+        let status = match verify_record_against_chain(anchor, &current) {
+            Ok(()) => HopStatus::Verified,
+            Err(e) => HopStatus::Failed(format!("{e:#}")),
+        };
+        seen.push(current.stored_digest().clone());
+
+        let kind = current.kind();
+        let parent_digest = current.parent_link().cloned();
+        nodes.push(VerifiedNode {
+            record: current,
+            status,
+        });
+
+        let Some(parent_digest) = parent_digest else {
+            // Genesis root: no parent to chain to, the walk terminates clean.
+            break None;
+        };
+        // Resolving the parent by its content-address *is* the hash-link check:
+        // by_digest only returns a record whose stored digest equals the link,
+        // and that record's own digest is re-verified on the next iteration.
+        match graph.by_digest(&parent_digest)? {
+            Some(parent) => current = parent,
+            None => {
+                break Some(format!(
+                    "{kind} lineage is broken: no {kind} has parent-linked digest {parent_digest}"
+                ));
+            }
+        }
+    };
+    Ok(Ancestry { nodes, broken })
+}
+
+/// Enumerate a record's immediate children (forward is a tree — a node may have
+/// several forks), each verified against the signed chain via `anchor`. Verifies
+/// but does not recurse: one generation of forward branches, each marked with its
+/// own [`HopStatus`] so a tampered / un-audited child is surfaced, never hidden.
+pub(crate) fn verified_children<G, A>(
+    graph: &G,
+    parent_digest: &CheckpointDigest,
+    anchor: &A,
+) -> Result<Vec<VerifiedNode<G::Record>>>
+where
+    G: LineageGraph,
+    A: LineageAnchor<G::Record> + ?Sized,
+{
+    let mut out = Vec::new();
+    for child in graph.children_of(parent_digest)? {
+        let status = match verify_record_against_chain(anchor, &child) {
+            Ok(()) => HopStatus::Verified,
+            Err(e) => HopStatus::Failed(format!("{e:#}")),
+        };
+        out.push(VerifiedNode {
+            record: child,
+            status,
+        });
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -205,6 +363,17 @@ mod tests {
         }
         fn by_digest(&self, d: &CheckpointDigest) -> Result<Option<MockRecord>> {
             Ok(self.by_stored.get(d.as_str()).cloned())
+        }
+        fn children_of(&self, parent: &CheckpointDigest) -> Result<Vec<MockRecord>> {
+            let mut kids: Vec<MockRecord> = self
+                .by_stored
+                .values()
+                .filter(|r| r.parent.as_ref() == Some(parent))
+                .cloned()
+                .collect();
+            // Deterministic order for assertions (HashMap iteration is not).
+            kids.sort_by(|a, b| a.stored.as_str().cmp(b.stored.as_str()));
+            Ok(kids)
         }
     }
 
@@ -305,5 +474,175 @@ mod tests {
         // test out) and refuse rather than loop.
         let err = verify_lineage_chain(&graph, &digest('a'), &AgreeingAnchor).unwrap_err();
         assert!(err.to_string().contains("cyclic chain"), "{err}");
+    }
+
+    // ── enumeration: collect_ancestry ────────────────────────────────────────
+
+    /// Digests carried by the ancestry, in walk order (start → genesis).
+    fn ancestry_order(a: &Ancestry<MockRecord>) -> Vec<String> {
+        a.nodes
+            .iter()
+            .map(|n| n.record.stored.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn ancestry_collects_start_to_genesis_in_order_each_verified() {
+        let graph = MockGraph::new(vec![
+            record('a', None),
+            record('b', Some('a')),
+            record('c', Some('b')),
+        ]);
+        let ancestry = collect_ancestry(&graph, &digest('c'), &AgreeingAnchor).unwrap();
+        assert_eq!(
+            ancestry_order(&ancestry),
+            vec![
+                digest('c').to_string(),
+                digest('b').to_string(),
+                digest('a').to_string()
+            ],
+            "nodes must be ordered start → genesis"
+        );
+        assert!(ancestry.broken.is_none(), "a clean chain reaches genesis");
+        assert!(ancestry.fully_verified());
+        assert!(ancestry.nodes.iter().all(|n| n.status.is_verified()));
+    }
+
+    #[test]
+    fn ancestry_of_a_genesis_node_is_just_itself() {
+        let graph = MockGraph::new(vec![record('a', None)]);
+        let ancestry = collect_ancestry(&graph, &digest('a'), &AgreeingAnchor).unwrap();
+        assert_eq!(ancestry.nodes.len(), 1);
+        assert!(ancestry.nodes[0].record.parent.is_none());
+        assert!(ancestry.broken.is_none());
+        assert!(ancestry.fully_verified());
+    }
+
+    #[test]
+    fn a_tampered_hop_is_surfaced_as_failed_not_dropped() {
+        // Middle node drifts (stored != recompute); the walk must still list all
+        // three nodes and mark exactly the drifted one Failed.
+        let mut mid = record('b', Some('a'));
+        mid.recompute = digest('e');
+        let graph = MockGraph::new(vec![record('a', None), mid, record('c', Some('b'))]);
+        let ancestry = collect_ancestry(&graph, &digest('c'), &AgreeingAnchor).unwrap();
+        assert_eq!(
+            ancestry.nodes.len(),
+            3,
+            "the failed hop must NOT be dropped"
+        );
+        assert!(
+            ancestry.nodes[0].status.is_verified(),
+            "target 'c' verifies"
+        );
+        let failed = &ancestry.nodes[1];
+        assert_eq!(failed.record.stored, digest('b'));
+        assert!(!failed.status.is_verified());
+        assert!(
+            failed.status.error().unwrap().contains("drift"),
+            "the failure reason is preserved: {:?}",
+            failed.status.error()
+        );
+        assert!(
+            !ancestry.fully_verified(),
+            "one failed hop fails the whole chain"
+        );
+        // The walk still reached genesis past the tampered node.
+        assert!(ancestry.broken.is_none());
+    }
+
+    #[test]
+    fn an_unaudited_hop_is_surfaced_as_failed() {
+        let graph = MockGraph::new(vec![record('a', None)]);
+        let ancestry = collect_ancestry(&graph, &digest('a'), &UnauditedAnchor).unwrap();
+        assert!(!ancestry.nodes[0].status.is_verified());
+        assert!(
+            ancestry.nodes[0]
+                .status
+                .error()
+                .unwrap()
+                .contains("no signed audit entry")
+        );
+        assert!(!ancestry.fully_verified());
+    }
+
+    #[test]
+    fn ancestry_reports_a_dangling_parent_as_broken() {
+        // Child links to a parent digest no stored record carries.
+        let graph = MockGraph::new(vec![record('a', Some('e'))]);
+        let ancestry = collect_ancestry(&graph, &digest('a'), &AgreeingAnchor).unwrap();
+        // The reachable node is still listed and verified...
+        assert_eq!(ancestry.nodes.len(), 1);
+        assert!(ancestry.nodes[0].status.is_verified());
+        // ...but the walk could not reach genesis, so it fails closed.
+        assert!(
+            ancestry
+                .broken
+                .as_ref()
+                .unwrap()
+                .contains("lineage is broken")
+        );
+        assert!(!ancestry.fully_verified());
+    }
+
+    #[test]
+    fn ancestry_refuses_a_cycle_without_looping() {
+        // a→b→a; a hang here (no cycle guard) would time the test out.
+        let a = MockRecord {
+            stored: digest('a'),
+            recompute: digest('a'),
+            parent: Some(digest('b')),
+        };
+        let b = MockRecord {
+            stored: digest('b'),
+            recompute: digest('b'),
+            parent: Some(digest('a')),
+        };
+        let graph = MockGraph::new(vec![a, b]);
+        let ancestry = collect_ancestry(&graph, &digest('a'), &AgreeingAnchor).unwrap();
+        assert!(ancestry.broken.as_ref().unwrap().contains("cyclic chain"));
+        // Each distinct node is listed exactly once, not re-added on revisit.
+        assert_eq!(ancestry.nodes.len(), 2);
+        assert!(!ancestry.fully_verified());
+    }
+
+    // ── enumeration: verified_children ───────────────────────────────────────
+
+    #[test]
+    fn children_are_enumerated_and_each_verified() {
+        // genesis 'a' forks into two children 'b' and 'c'.
+        let graph = MockGraph::new(vec![
+            record('a', None),
+            record('b', Some('a')),
+            record('c', Some('a')),
+        ]);
+        let kids = verified_children(&graph, &digest('a'), &AgreeingAnchor).unwrap();
+        let digests: Vec<String> = kids.iter().map(|k| k.record.stored.to_string()).collect();
+        assert_eq!(
+            digests,
+            vec![digest('b').to_string(), digest('c').to_string()]
+        );
+        assert!(kids.iter().all(|k| k.status.is_verified()));
+    }
+
+    #[test]
+    fn a_node_with_no_children_enumerates_empty() {
+        let graph = MockGraph::new(vec![record('a', None)]);
+        assert!(
+            verified_children(&graph, &digest('a'), &AgreeingAnchor)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn a_tampered_child_is_marked_failed_not_dropped() {
+        let mut child = record('b', Some('a'));
+        child.recompute = digest('e'); // drift
+        let graph = MockGraph::new(vec![record('a', None), child]);
+        let kids = verified_children(&graph, &digest('a'), &AgreeingAnchor).unwrap();
+        assert_eq!(kids.len(), 1, "the tampered child is listed, not hidden");
+        assert!(!kids[0].status.is_verified());
+        assert!(kids[0].status.error().unwrap().contains("drift"));
     }
 }

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -225,6 +225,10 @@ const MACHINE_SUB: &[(&str, AuditPosture)] = &[
     ("check-artifact", AuditPosture::ReadOnly),
     ("logs", AuditPosture::ReadOnly),
     ("console", AuditPosture::InteractiveOrControl),
+    // Read-only lineage navigator over the checkpoint + image DAGs. Verifies
+    // each hop against the signed chain but makes no trust decision and writes
+    // nothing — no audit-chain emission.
+    ("timeline", AuditPosture::ReadOnly),
     // Advanced single-VM verbs folded under `machine` (hidden from default help).
     // The audit postures are unchanged from when these lived under `vm <sub>`.
     ("pause", AuditPosture::Emits("VmStop")),


### PR DESCRIPTION
Slice **C1** of #1809 (part of epic #1806) — a **read-only** `machine timeline`
verb + the shared lineage enumeration layer C2's revert will reuse.

## What's here
- **Enumeration layer** (`crates/mvm-runtime/src/lineage.rs`, generic over the
  existing `LineageRecord`/`LineageGraph`/`LineageAnchor` traits): `collect_ancestry`
  walks `parent`→genesis verifying each hop with the same `verify_record_against_chain`
  the verifier uses, marking a tampered/un-audited hop `Failed` **without dropping
  it**, and failing closed on a dangling parent / cycle (reported in
  `Ancestry::broken`, bounded — no loop). `verified_children` enumerates forward.
  Both DAGs reuse it via thin wrappers — no per-store fork.
- **`machine timeline <id|digest>`** (read-only): resolves a checkpoint id or a
  `sha256:<hex>` digest in either store; a digest matching **both** stores is
  refused as ambiguous (`--kind` disambiguates). Renders ancestors→genesis + the
  target + immediate children with each hop's verified status; `--json`. Strictly
  read-only — no restore/admission/launch/writes (that's C2).

## Verification
Independently re-gated and adversarially reviewed (read-only confirmed;
fail-closed enumeration confirmed; the shared verifier is byte-identical, 70/70
lineage tests pass; cross-store ambiguity refused). `nextest --workspace` 7667
passed / 0 failed; doctests, `clippy --all-targets -D warnings`, nightly fmt,
`check-content-address-determinism`, and `check-no-spec-refs-in-comments` clean.

## Folds into C2
- A CLI-surface test driving a genuinely broken ancestry through the render path
  (the fail-closed logic is already covered at the enumeration layer; this is an
  additive surface-level assertion).
- Footer wording that distinguishes a structural break (dangling/cycle) from a
  per-hop verification failure.
