### PR TITLE
feat(lineage): time-travel revert/rewind/advance restore verbs (C2, closes #1809)

### DIFF
--- a/crates/mvm-cli/src/commands/build/image_lineage.rs
+++ b/crates/mvm-cli/src/commands/build/image_lineage.rs
@@ -180,19 +180,28 @@ fn flake_node_inputs(
     }
 }
 
-/// Synthesize the audit-envelope plan an `image.created` entry binds to. A build
-/// is not a workload admission, so this plan is only the tenant / plan-id /
-/// image binding the chain entry carries — it is never signed, admitted, or
-/// booted. Tenant is the local host tenant (`DEFAULT_TENANT`).
-fn build_event_plan(image_name: &str, image_sha256: &str) -> Result<ExecutionPlan> {
+/// Synthesize the audit-envelope plan a host-side image-lineage chain entry
+/// (`image.created` / `image.reverted`) binds to. Such an event is not a
+/// workload admission, so this plan is only the tenant / plan-id / image binding
+/// the chain entry carries — it is never signed, admitted, or booted. Tenant is
+/// the local host tenant (`DEFAULT_TENANT`); `workload` / `intent` label the
+/// operation (build vs restore). `image_sha256` must be a 64-char lowercase hex
+/// digest. Shared with the revert engine so both host-side markers use one
+/// synthesis path.
+pub(in crate::commands) fn build_event_plan(
+    workload: &str,
+    intent: &str,
+    image_name: &str,
+    image_sha256: &str,
+) -> Result<ExecutionPlan> {
     let input = SynthesisInput {
-        vm_name: IMAGE_BUILD_WORKLOAD,
+        vm_name: workload,
         tenant: None,
-        backend_name: IMAGE_BUILD_WORKLOAD,
+        backend_name: workload,
         image_name,
         image_sha256,
         image_cosign_bundle: None,
-        intent: Some(IMAGE_BUILD_INTENT),
+        intent: Some(intent),
         seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
         network_policy_ref: None,
         fs_policy_ref: None,
@@ -215,7 +224,7 @@ fn build_event_plan(image_name: &str, image_sha256: &str) -> Result<ExecutionPla
         audit_labels: Default::default(),
         agent_verbs: None,
     };
-    synthesize_plan(&input).context("synthesizing the image.created audit-envelope plan")
+    synthesize_plan(&input).context("synthesizing the image-lineage audit-envelope plan")
 }
 
 /// Record an audited image-lineage node for a completed flake build.
@@ -304,7 +313,12 @@ fn record_over_signed_chain(
     let emitter = AuditEmitter::new(signer.signing)
         .context("opening the signed audit chain for the image-lineage node")?;
     // The plan binds the audit entry to the local tenant + the rootfs digest.
-    let plan = build_event_plan(image_name, image_sha256)?;
+    let plan = build_event_plan(
+        IMAGE_BUILD_WORKLOAD,
+        IMAGE_BUILD_INTENT,
+        image_name,
+        image_sha256,
+    )?;
 
     let outcome = with_identity_lock(store, &inputs.build_identity, || {
         record_image_node(store, &emitter, &plan, inputs, now_unix())
@@ -819,7 +833,8 @@ mod tests {
     #[test]
     fn build_event_plan_binds_local_tenant_and_rootfs_digest() {
         let sha = "a".repeat(64);
-        let plan = build_event_plan(".#app", &sha).unwrap();
+        let plan =
+            build_event_plan(IMAGE_BUILD_WORKLOAD, IMAGE_BUILD_INTENT, ".#app", &sha).unwrap();
         assert_eq!(plan.tenant.0, "local");
         assert_eq!(plan.image.name, ".#app");
         assert_eq!(plan.image.sha256, sha);

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -149,6 +149,9 @@ impl Commands {
                 machine::MachineAction::Run(r) => r.json || r.up_json,
                 // `machine timeline --json` prints a structured lineage.
                 machine::MachineAction::Timeline(t) => t.json,
+                // A `--json` restore reuses the fork path's structured output.
+                machine::MachineAction::Revert(a) | machine::MachineAction::Rewind(a) => a.json,
+                machine::MachineAction::Advance(a) => a.json,
                 _ => false,
             },
             _ => false,

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -1337,13 +1337,17 @@ fn complete_revert(
     }
 }
 
-/// Build the `machine run` args for an image-node restore. Egress defaults to
-/// deny-all — a restore re-derives the current policy at launch and never bakes
-/// the snapshot-era network posture.
+/// Build the `machine run --image` args for an image-node restore. The restore
+/// re-derives the current network policy at launch and never bakes the
+/// snapshot-era posture: outbound networking stays off (`net = false`). On the
+/// default `firecracker` backend that resolves to enforced default-deny; note
+/// the pre-existing caveat that a libkrun transient run does not enforce
+/// per-run egress, so "off" is a request the FC path enforces, not a blanket
+/// guarantee on every backend.
 fn run_args_for_image_revert(run: super::vm::checkpoint::RevertRunImage) -> MachineRunArgs {
     MachineRunArgs {
         image: run.image,
-        flake: run.flake,
+        flake: None,
         hypervisor: run.hypervisor,
         json: run.json,
         name: None,

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -128,6 +128,18 @@ pub(in crate::commands) enum MachineAction {
     /// no restore, no admission, no boot.
     #[command(display_order = 14)]
     Timeline(super::vm::checkpoint::TimelineArgs),
+    /// Restore a prior state: launch a fresh, re-admitted VM at the checkpoint or
+    /// image node the target names. Verifies the target against the signed audit
+    /// chain first and fails closed on an un-audited, tampered, or dangling
+    /// record.
+    #[command(display_order = 15)]
+    Revert(super::vm::checkpoint::RevertArgs),
+    /// Rewind one step: restore the target's parent in the lineage.
+    #[command(display_order = 16)]
+    Rewind(super::vm::checkpoint::RevertArgs),
+    /// Advance one step: restore a child of the target (a fork needs `--to`).
+    #[command(display_order = 17)]
+    Advance(super::vm::checkpoint::AdvanceArgs),
     /// Advanced single-VM operations (pause, snapshot, cp, fs, …). Hidden; use `machine <verb>` directly.
     #[command(flatten)]
     Vm(VmCmd),
@@ -158,6 +170,9 @@ impl MachineAction {
             | MachineAction::Console(_)
             | MachineAction::CheckArtifact(_) => "machine",
             MachineAction::Timeline(_) => "timeline",
+            MachineAction::Revert(_) => "revert",
+            MachineAction::Rewind(_) => "rewind",
+            MachineAction::Advance(_) => "advance",
         }
     }
 }
@@ -1291,9 +1306,80 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
         MachineAction::Console(console_args) => super::vm::console::run(cli, console_args, cfg),
         MachineAction::CheckArtifact(a) => portable::run_check_artifact(a),
         MachineAction::Timeline(a) => super::vm::checkpoint::run_timeline(a),
+        MachineAction::Revert(a) => {
+            complete_revert(cli, cfg, super::vm::checkpoint::run_revert(a)?)
+        }
+        MachineAction::Rewind(a) => {
+            complete_revert(cli, cfg, super::vm::checkpoint::run_rewind(a)?)
+        }
+        MachineAction::Advance(a) => {
+            complete_revert(cli, cfg, super::vm::checkpoint::run_advance(a)?)
+        }
         MachineAction::Vm(cmd) => {
             super::vm::group::run(cli, super::vm::group::Args { action: cmd }, cfg)
         }
+    }
+}
+
+/// Finish a restore. A checkpoint restore completes inside the engine (the fork
+/// re-admits + boots). An image-node restore re-runs the reconstructed reference
+/// through the normal admitted `machine run` path so it re-admits identically.
+fn complete_revert(
+    cli: &Cli,
+    cfg: &MvmConfig,
+    outcome: super::vm::checkpoint::RevertOutcome,
+) -> Result<()> {
+    match outcome {
+        super::vm::checkpoint::RevertOutcome::Done => Ok(()),
+        super::vm::checkpoint::RevertOutcome::RunImage(run) => {
+            run_dispatch(cli, run_args_for_image_revert(run), cfg)
+        }
+    }
+}
+
+/// Build the `machine run` args for an image-node restore. Egress defaults to
+/// deny-all — a restore re-derives the current policy at launch and never bakes
+/// the snapshot-era network posture.
+fn run_args_for_image_revert(run: super::vm::checkpoint::RevertRunImage) -> MachineRunArgs {
+    MachineRunArgs {
+        image: run.image,
+        flake: run.flake,
+        hypervisor: run.hypervisor,
+        json: run.json,
+        name: None,
+        manifest: None,
+        runtime_pack: false,
+        flake_profile: None,
+        net: false,
+        allow_host: Vec::new(),
+        cpus: 2,
+        memory: "512M".to_string(),
+        profile: RunProfile::Standard,
+        agent_verb: Vec::new(),
+        volume: Vec::new(),
+        env: Vec::new(),
+        timeout: None,
+        receipt: None,
+        dry_run: false,
+        tty: false,
+        interactive: false,
+        force: false,
+        no_supervisor: false,
+        up_json: false,
+        ttl: None,
+        healthcheck: None,
+        health_interval: 30,
+        health_timeout: 5,
+        health_retries: 3,
+        health_start_period: 0,
+        entrypoint: false,
+        fresh: false,
+        reset: false,
+        from_workload_ir: None,
+        attach: false,
+        detach: false,
+        kernel_pin: None,
+        argv: Vec::new(),
     }
 }
 

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -92,6 +92,9 @@ fn machine_subcommand(action: &MachineAction) -> &'static str {
         MachineAction::Console(_) => "console",
         MachineAction::CheckArtifact(_) => "check-artifact",
         MachineAction::Timeline(_) => "timeline",
+        MachineAction::Revert(_) => "revert",
+        MachineAction::Rewind(_) => "rewind",
+        MachineAction::Advance(_) => "advance",
         MachineAction::Vm(_) => "vm",
     }
 }
@@ -2347,4 +2350,47 @@ fn reconfigure_mem_initial_inconsistency_rejected() {
             || msg.contains("must be strictly less than"),
         "unexpected error: {err}"
     );
+}
+
+// ── revert / rewind / advance verb surface ────────────────────────────────
+
+#[test]
+fn revert_parses_target_and_kind() {
+    let action = parse(&["revert", "sha256:abc", "--kind", "image"]).expect("parse revert");
+    match action {
+        MachineAction::Revert(a) => {
+            assert_eq!(a.target, "sha256:abc");
+            // `--kind image` is accepted and captured (the variant internals stay
+            // private to the checkpoint module; parse acceptance is the contract).
+            assert!(a.kind.is_some());
+        }
+        other => panic!("expected revert, got {other:?}"),
+    }
+    // An unknown --kind is rejected by clap's value-enum.
+    assert!(parse(&["revert", "sha256:abc", "--kind", "bogus"]).is_err());
+}
+
+#[test]
+fn rewind_parses_as_its_own_verb() {
+    let action = parse(&["rewind", "ckpt-x"]).expect("parse rewind");
+    assert!(matches!(action, MachineAction::Rewind(_)));
+    assert_eq!(machine_subcommand(&action), "rewind");
+}
+
+/// The lineage forward-step is `advance`, deliberately NOT `forward` — `machine
+/// forward` is the port-forwarding op folded from `vm forward`. Both must parse
+/// to distinct, non-colliding actions.
+#[test]
+fn advance_does_not_collide_with_the_port_forward_verb() {
+    let advance = parse(&["advance", "ckpt-x", "--to", "sha256:child"]).expect("parse advance");
+    match advance {
+        MachineAction::Advance(a) => {
+            assert_eq!(a.target, "ckpt-x");
+            assert_eq!(a.to.as_deref(), Some("sha256:child"));
+        }
+        other => panic!("expected advance, got {other:?}"),
+    }
+    // `forward` still routes to the folded port-forwarding op, untouched.
+    let forward = parse(&["forward", "myvm", "8080:80"]).expect("parse forward");
+    assert!(matches!(forward, MachineAction::Vm(VmCmd::Forward(_))));
 }

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -28,8 +28,12 @@ use super::shared::clap_vm_name;
 use crate::ui;
 
 mod lineage;
+mod revert;
 mod timeline;
 pub(super) use lineage::SignedChainAnchor;
+pub(in crate::commands) use revert::{
+    AdvanceArgs, RevertArgs, RevertOutcome, RevertRunImage, run_advance, run_revert, run_rewind,
+};
 pub(in crate::commands) use timeline::{TimelineArgs, run_timeline};
 
 #[derive(ClapArgs, Debug, Clone)]

--- a/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
@@ -10,26 +10,36 @@
 //!   into a new identity, and admits a fresh plan through
 //!   `admit_plan_for_boot` before booting. A restore therefore never touches
 //!   `restore_checkpoint` (which bypasses admission).
-//! - **Image-node targets** re-run the node's recorded reference through the
-//!   normal admitted `machine run` path, which re-admits identically.
+//! - **OCI image-node targets** re-run the node's digest-pinned reference
+//!   (`<registry>/<repository>@<resolved_digest>`) through the normal admitted
+//!   `machine run` path, which re-fetches the exact bytes and re-admits
+//!   identically.
+//! - **Flake image-node targets are refused.** Restoring a flake-built image to
+//!   its exact prior revision would re-run `machine run --flake`, which rebuilds
+//!   from whatever the flake resolves to *now* — not the revision being
+//!   restored. Booting a specific stored revision instead of the slot's current
+//!   one is not yet wired, so the restore fails closed rather than silently
+//!   relaunch drifted (or, mid-incident, modified) source.
 //!
 //! Every restore verifies its target against the signed audit chain up front and
 //! fails closed on an un-audited, tampered, or dangling record — the same
 //! `verify_lineage` / `verify_image_lineage` gate `machine checkpoint verify`
-//! and `fork` use. A completed checkpoint restore additionally emits a
-//! chain-signed `checkpoint.restored` entry carrying the initiating verb
-//! (`revert` / `rewind` / `advance`) as its `via` label.
+//! and `fork` use. A completed checkpoint restore emits a chain-signed
+//! `checkpoint.restored` entry, and an image restore an `image.reverted` entry;
+//! both carry the initiating verb (`revert` / `rewind` / `advance`) as their
+//! `via` label.
 
 use anyhow::{Context, Result, bail};
 
 use mvm_core::checkpoint::CheckpointMeta;
-use mvm_core::image_lineage::{ImageBuildIdentity, ImageCanonicalId, ImageNode, ImageProvenance};
+use mvm_core::image_lineage::{ImageBuildIdentity, ImageCanonicalId, ImageNode};
 use mvm_runtime::checkpoint::{
     CheckpointStore, checkpoint_ancestry, checkpoint_children, verify_lineage,
 };
 use mvm_runtime::image_lineage::{
     ImageStore, image_ancestry, image_children, verify_image_lineage,
 };
+use mvm_runtime::lineage::VerifiedNode;
 
 use super::SignedChainAnchor;
 use super::timeline::{LineageKind, ResolvedTarget, resolve_target};
@@ -115,12 +125,11 @@ pub(in crate::commands) enum RevertOutcome {
     RunImage(RevertRunImage),
 }
 
-/// The reconstructed `machine run` reference for an image-node restore. Exactly
-/// one of `image` / `flake` is set.
+/// The reconstructed `machine run --image` reference for an image-node restore.
+/// Always a digest-pinned OCI reference (flake nodes are refused upstream).
 #[derive(Debug)]
 pub(in crate::commands) struct RevertRunImage {
     pub image: Option<String>,
-    pub flake: Option<String>,
     pub hypervisor: Option<String>,
     pub json: bool,
 }
@@ -237,7 +246,7 @@ fn revert_checkpoint(
     let restored_vm_name = opts
         .new_id
         .map(ToString::to_string)
-        .unwrap_or_else(|| format!("revert-{}-{}", target.id.as_str(), now_unix()));
+        .unwrap_or_else(|| format!("revert-{}-{}", target.id.as_str(), super::now_unix()));
 
     // Reuse the fork path verbatim: it re-admits through `admit_plan_for_boot`,
     // re-derives the sealed attenuation, and boots. This is the anti-bypass
@@ -269,16 +278,26 @@ fn revert_checkpoint(
     Ok(())
 }
 
-/// Restore an image-node target: verify it against the signed audit chain, then
-/// reconstruct its recorded `machine run` reference. The caller re-runs that
-/// reference through the normal admitted run path, which re-admits identically
-/// and chain-signs its own admission trail.
+/// Restore an image-node target: verify it against the signed audit chain,
+/// reconstruct its digest-pinned reference, emit a chain-signed `image.reverted`
+/// marker, then hand the reference to the caller. The caller re-runs it through
+/// the normal admitted `machine run` path, which re-fetches the exact bytes and
+/// re-admits identically.
 fn revert_image(
     store: &ImageStore,
     node: ImageNode,
     via: RevertVia,
     opts: &RestoreOpts<'_>,
 ) -> Result<RevertOutcome> {
+    // `--new-id` names the restored VM, but an image restore auto-names its VM
+    // through the run path — reject rather than silently drop it.
+    if let Some(new_id) = opts.new_id {
+        bail!(
+            "--new-id {new_id:?} applies only to checkpoint restores; an image restore \
+             auto-names its VM through the run path"
+        );
+    }
+
     let anchor = SignedChainAnchor::load()
         .context("loading the signed audit chain to verify the restore target")?;
     verify_image_lineage(store, &node.node_digest, &anchor).with_context(|| {
@@ -289,24 +308,29 @@ fn revert_image(
         )
     })?;
 
-    let reference = reconstruct_image_run_reference(&node)?;
-    tracing::info!(
-        node = %node.node_digest,
-        via = via.as_str(),
-        "image restore re-runs the recorded reference through the admitted run path"
-    );
+    let image = reconstruct_image_run_reference(&node)?;
+
+    // Distinctly audit the restore BEFORE handing off, so the chain records
+    // "reverted to node X via Y" — not just an ordinary image run.
+    emit_image_revert_audit(&node, via, &image)?;
+
     Ok(RevertOutcome::RunImage(RevertRunImage {
-        image: reference.image,
-        flake: reference.flake,
+        image: Some(image),
         hypervisor: Some(opts.hypervisor.to_string()),
         json: opts.json,
     }))
 }
 
-/// Reconstruct the `machine run` reference an image node recorded, so a restore
-/// re-materializes the exact prior image. OCI nodes yield a digest-pinned
-/// `<registry>/<repository>@<digest>`; flake nodes yield the recorded input ref.
-fn reconstruct_image_run_reference(node: &ImageNode) -> Result<RevertRunImage> {
+/// Reconstruct the digest-pinned `machine run --image` reference an OCI node
+/// recorded, so a restore re-fetches the exact prior image
+/// (`<registry>/<repository>@<resolved_digest>`).
+///
+/// Flake nodes are refused: relaunching a flake image to its exact prior
+/// revision would re-run `machine run --flake`, which rebuilds from whatever the
+/// flake resolves to now — not the revision being restored. Booting a specific
+/// stored revision instead of the slot's current one is not yet wired, so this
+/// fails closed rather than silently relaunch drifted source.
+fn reconstruct_image_run_reference(node: &ImageNode) -> Result<String> {
     match &node.build_identity {
         ImageBuildIdentity::Oci {
             registry,
@@ -319,34 +343,63 @@ fn reconstruct_image_run_reference(node: &ImageNode) -> Result<RevertRunImage> {
                     node.node_digest
                 );
             };
-            Ok(RevertRunImage {
-                image: Some(format!("{registry}/{repository}@{resolved_digest}")),
-                flake: None,
-                hypervisor: None,
-                json: false,
-            })
+            Ok(format!("{registry}/{repository}@{resolved_digest}"))
         }
-        ImageBuildIdentity::Flake { .. } => {
-            let ImageProvenance::Build { input_ref, .. } = &node.provenance else {
-                bail!(
-                    "image node {} names a flake build identity but non-build provenance; \
-                     refusing to reconstruct an ambiguous reference",
-                    node.node_digest
-                );
-            };
-            Ok(RevertRunImage {
-                image: None,
-                flake: Some(input_ref.clone()),
-                hypervisor: None,
-                json: false,
-            })
-        }
+        ImageBuildIdentity::Flake { .. } => bail!(
+            "reverting a flake-built image to its exact prior revision isn't wired yet: the run \
+             path rebuilds the flake's CURRENT revision, not the stored one, so a flake restore \
+             would silently relaunch drifted source. OCI images and checkpoints support exact \
+             restore."
+        ),
     }
+}
+
+/// Workload/intent labels for the host-side `image.reverted` audit-envelope plan.
+const IMAGE_REVERT_WORKLOAD: &str = "image-revert";
+const IMAGE_REVERT_INTENT: &str = "image:revert";
+
+/// Emit the chain-signed `image.reverted` marker recording the restored node's
+/// content-address, the initiating verb, and the reconstructed reference. Bound
+/// to a lightweight host-side event plan (never admitted or booted) on the local
+/// tenant, keyed to the node's content-address — mirroring how the build path
+/// audits `image.created`. A missing signer degrades to a warning (best-effort,
+/// as capture does); a present signer whose emit fails is fatal, so an
+/// un-auditable restore refuses before it re-runs.
+fn emit_image_revert_audit(node: &ImageNode, via: RevertVia, reference: &str) -> Result<()> {
+    let signer = match crate::commands::vm::host_signer::load_or_init() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "host signer unavailable; image.reverted chain entry skipped");
+            return Ok(());
+        }
+    };
+    let emitter = crate::commands::vm::audit_chain::AuditEmitter::new(signer.signing)
+        .context("refusing an unaudited image restore: audit emitter unavailable")?;
+    // The node's content-address is always a valid 64-hex digest — bind the
+    // event plan's image to it so synthesis can never reject a genuine node.
+    let node_hex = node
+        .node_digest
+        .as_str()
+        .strip_prefix(mvm_core::checkpoint::CheckpointDigest::PREFIX)
+        .unwrap_or_else(|| node.node_digest.as_str());
+    let plan = crate::commands::build::image_lineage::build_event_plan(
+        IMAGE_REVERT_WORKLOAD,
+        IMAGE_REVERT_INTENT,
+        reference,
+        node_hex,
+    )
+    .context("building the image.reverted audit-envelope plan")?;
+    emitter
+        .emit_image_reverted(&plan, node.node_digest.as_str(), via.as_str(), reference)
+        .context("refusing an unaudited image restore")?;
+    Ok(())
 }
 
 /// Resolve the parent of a restore target (the `rewind` step) via the C1
 /// ancestry enumeration, so the parent hop is chain-verified. Fails closed when
-/// the target is a genesis root or the ancestry is structurally broken.
+/// the target is a genesis root, the ancestry is structurally broken, or the
+/// parent hop itself did not verify — the selected node's own verdict is
+/// enforced here, not left to a downstream re-verify.
 fn parent_of(
     cstore: &CheckpointStore,
     istore: &ImageStore,
@@ -369,7 +422,8 @@ fn parent_of(
                     meta.id.as_str()
                 )
             })?;
-            Ok(ResolvedTarget::Checkpoint(parent.record))
+            let record = verified_record(parent, "rewind")?;
+            Ok(ResolvedTarget::Checkpoint(record))
         }
         ResolvedTarget::Image(node) => {
             let ancestry = image_ancestry(istore, &node.node_digest, anchor)?;
@@ -385,8 +439,21 @@ fn parent_of(
                     node.node_digest
                 )
             })?;
-            Ok(ResolvedTarget::Image(parent.record))
+            let record = verified_record(parent, "rewind")?;
+            Ok(ResolvedTarget::Image(record))
         }
+    }
+}
+
+/// Extract a verified node's record, failing closed if its per-hop verdict is
+/// not `Verified`. `op` names the verb for the error (`rewind` / `advance`).
+/// Safety here does not depend on the downstream restore re-verifying.
+fn verified_record<R>(node: VerifiedNode<R>, op: &str) -> Result<R> {
+    match node.status.error() {
+        None => Ok(node.record),
+        Some(reason) => bail!(
+            "cannot {op}: the selected node did not verify against the signed audit chain: {reason}"
+        ),
     }
 }
 
@@ -406,35 +473,37 @@ fn child_of(
             let picked = pick_child(
                 children
                     .into_iter()
-                    .map(|c| (c.record.meta_digest.to_string(), c.record)),
+                    .map(|c| (c.record.meta_digest.to_string(), c)),
                 to,
                 &format!("checkpoint {:?}", meta.id.as_str()),
             )?;
-            Ok(ResolvedTarget::Checkpoint(picked))
+            Ok(ResolvedTarget::Checkpoint(verified_record(
+                picked, "advance",
+            )?))
         }
         ResolvedTarget::Image(node) => {
             let children = image_children(istore, &node.node_digest, anchor)?;
             let picked = pick_child(
                 children
                     .into_iter()
-                    .map(|c| (c.record.node_digest.to_string(), c.record)),
+                    .map(|c| (c.record.node_digest.to_string(), c)),
                 to,
                 &format!("image node {}", node.node_digest),
             )?;
-            Ok(ResolvedTarget::Image(picked))
+            Ok(ResolvedTarget::Image(verified_record(picked, "advance")?))
         }
     }
 }
 
-/// Pick the single child to advance to. No children → nothing to advance to; one
-/// child → that one (or the one `--to` names); many children → `--to` must
-/// disambiguate the fork.
+/// Pick the single child to advance to, carrying its per-hop verdict for the
+/// caller to enforce. No children → nothing to advance to; one child → that one
+/// (or the one `--to` names); many children → `--to` must disambiguate the fork.
 fn pick_child<R>(
-    children: impl Iterator<Item = (String, R)>,
+    children: impl Iterator<Item = (String, VerifiedNode<R>)>,
     to: Option<&str>,
     target_label: &str,
-) -> Result<R> {
-    let all: Vec<(String, R)> = children.collect();
+) -> Result<VerifiedNode<R>> {
+    let all: Vec<(String, VerifiedNode<R>)> = children.collect();
     if all.is_empty() {
         bail!("cannot advance: {target_label} has no children to advance to");
     }
@@ -442,7 +511,7 @@ fn pick_child<R>(
         Some(want) => all
             .into_iter()
             .find(|(digest, _)| digest == want)
-            .map(|(_, record)| record)
+            .map(|(_, node)| node)
             .ok_or_else(|| {
                 anyhow::anyhow!("cannot advance: {target_label} has no child with digest {want:?}")
             }),
@@ -497,13 +566,6 @@ fn emit_revert_audit(
     )
     .context("refusing an unaudited restore")?;
     Ok(())
-}
-
-fn now_unix() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -618,21 +680,27 @@ mod tests {
     #[test]
     fn oci_node_reconstructs_a_digest_pinned_reference() {
         let node = oci_node("a");
-        let out = reconstruct_image_run_reference(&node).unwrap();
+        let reference = reconstruct_image_run_reference(&node).unwrap();
         assert_eq!(
-            out.image.as_deref(),
-            Some(format!("docker.io/library/alpine@sha256:{}", "a".repeat(64)).as_str()),
+            reference,
+            format!("docker.io/library/alpine@sha256:{}", "a".repeat(64)),
             "OCI restore must re-fetch the exact resolved digest"
         );
-        assert!(out.flake.is_none());
     }
 
+    /// Restoring a flake image to its exact prior revision is not wired: the run
+    /// path rebuilds the flake's current revision, not the stored one, so it must
+    /// refuse rather than silently relaunch drifted source.
     #[test]
-    fn flake_node_reconstructs_the_recorded_input_ref() {
+    fn flake_node_reconstruction_is_refused_as_unwired() {
         let node = image_of("slot-a", "rev-1", None);
-        let out = reconstruct_image_run_reference(&node).unwrap();
-        assert_eq!(out.flake.as_deref(), Some(".#app"));
-        assert!(out.image.is_none());
+        let err = reconstruct_image_run_reference(&node).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("flake"), "{msg}");
+        assert!(
+            msg.contains("isn't wired") || msg.contains("not wired") || msg.contains("drifted"),
+            "the refusal must explain why: {msg}"
+        );
     }
 
     // ── invariant 5: verify the target before restoring (fail closed) ─────────
@@ -710,7 +778,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         env.set("MVM_HOME", tmp.path());
         let istore = ImageStore::open();
-        let node = image_of("slot-a", "rev-1", None);
+        let node = oci_node("a");
         // Saved but NEVER audited.
         istore.save(&node).unwrap();
 
@@ -729,18 +797,21 @@ mod tests {
         );
     }
 
-    /// An audited image node passes verification and reconstructs its recorded
-    /// reference, returning a `RunImage` that the dispatcher re-runs through the
-    /// normal admitted run path — the image analog of "re-admit, don't bypass".
-    /// `run_revert` never boots inline for an image target.
+    /// An audited OCI image node passes verification, reconstructs its
+    /// digest-pinned reference, emits a chain-signed `image.reverted` marker, and
+    /// returns a `RunImage` the dispatcher re-runs through the admitted run path —
+    /// the image analog of "re-admit, don't bypass". `run_revert` never boots
+    /// inline for an image target.
     #[test]
-    fn revert_of_an_audited_image_node_reconstructs_a_run_not_a_bypass() {
+    fn revert_of_an_audited_oci_node_reconstructs_a_run_and_audits_the_revert() {
+        use mvm_hostd::supervisor::verify_audit_chain;
+
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
         env.set("MVM_HOME", tmp.path());
         let istore = ImageStore::open();
         let (em, plan) = emitter();
-        let node = image_of("slot-a", "rev-1", None);
+        let node = oci_node("a");
         seed_image(&istore, &em, &plan, &node);
 
         let outcome = run_revert(RevertArgs {
@@ -754,11 +825,10 @@ mod tests {
         match outcome {
             RevertOutcome::RunImage(run) => {
                 assert_eq!(
-                    run.flake.as_deref(),
-                    Some(".#app"),
-                    "a flake image node restores through its recorded input ref"
+                    run.image.as_deref(),
+                    Some(format!("docker.io/library/alpine@sha256:{}", "a".repeat(64)).as_str()),
+                    "an OCI image node restores through its digest-pinned reference"
                 );
-                assert!(run.image.is_none());
             }
             RevertOutcome::Done => {
                 panic!(
@@ -766,6 +836,95 @@ mod tests {
                 )
             }
         }
+
+        // The revert is distinctly audited BEFORE handoff: image.created (seed) +
+        // image.reverted (revert), both chain-signed and verifiable.
+        let signer = crate::commands::vm::host_signer::load_or_init().unwrap();
+        let path = mvm_hostd::audit::emitter::default_audit_dir()
+            .unwrap()
+            .join("local.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("image.reverted"), "{content}");
+        assert!(content.contains(node.node_digest.as_str()));
+        assert!(content.contains("\"via\""));
+        assert!(content.contains("revert"));
+        assert_eq!(verify_audit_chain(&path, &signer.verifying).unwrap(), 2);
+    }
+
+    /// A flake image node is refused at the run_revert level even when audited:
+    /// exact-revision restore isn't wired, so it fails closed rather than rebuild
+    /// the flake's current (possibly drifted) source.
+    #[test]
+    fn revert_of_an_audited_flake_node_is_refused() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let istore = ImageStore::open();
+        let (em, plan) = emitter();
+        let node = image_of("slot-a", "rev-1", None);
+        seed_image(&istore, &em, &plan, &node);
+
+        let err = run_revert(RevertArgs {
+            target: node.node_digest.as_str().to_string(),
+            kind: None,
+            hypervisor: "firecracker".into(),
+            new_id: None,
+            json: false,
+        })
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("flake"), "{msg}");
+    }
+
+    /// `--new-id` names the restored VM for a checkpoint restore; an image restore
+    /// auto-names through the run path, so passing it is rejected, not dropped.
+    #[test]
+    fn image_revert_rejects_new_id() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let istore = ImageStore::open();
+        let (em, plan) = emitter();
+        let node = oci_node("a");
+        seed_image(&istore, &em, &plan, &node);
+
+        let err = run_revert(RevertArgs {
+            target: node.node_digest.as_str().to_string(),
+            kind: None,
+            hypervisor: "firecracker".into(),
+            new_id: Some("my-restored-vm".into()),
+            json: false,
+        })
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("--new-id"), "{msg}");
+    }
+
+    /// A rewind/advance target's own per-hop verdict is enforced here, not left
+    /// to the downstream restore re-verify: a `Failed` hop is refused, a
+    /// `Verified` hop yields its record.
+    #[test]
+    fn verified_record_gates_on_hop_status() {
+        use mvm_runtime::lineage::{HopStatus, VerifiedNode};
+        let meta = CheckpointMeta::builder(CheckpointId::new("n"), CheckpointClass::FsQuick, "vm")
+            .content(vec![])
+            .supervisor_config_digest("d")
+            .created_unix(1)
+            .build();
+        let verified = VerifiedNode {
+            record: meta.clone(),
+            status: HopStatus::Verified,
+        };
+        assert!(verified_record(verified, "rewind").is_ok());
+
+        let failed = VerifiedNode {
+            record: meta,
+            status: HopStatus::Failed("meta_digest drift".into()),
+        };
+        let err = verified_record(failed, "advance").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("advance"), "names the op: {msg}");
+        assert!(msg.contains("drift"), "preserves the reason: {msg}");
     }
 
     // ── cross-store ambiguity refused (shared resolver) ──────────────────────

--- a/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
@@ -1,0 +1,934 @@
+//! `mvmctl machine revert|rewind|advance` — time-travel restore verbs.
+//!
+//! A restore here is **not** an in-place same-identity mutation. It launches a
+//! *fresh, re-admitted* VM at a prior state, so the current security posture
+//! (signed `ExecutionPlan`, current egress policy, sealed attenuation) is
+//! re-derived at launch rather than inherited from the snapshot era:
+//!
+//! - **Checkpoint targets** reuse the fork path (`super::fork` with `--boot`):
+//!   fork re-verifies the source against the signed audit chain, CoW-clones it
+//!   into a new identity, and admits a fresh plan through
+//!   `admit_plan_for_boot` before booting. A restore therefore never touches
+//!   `restore_checkpoint` (which bypasses admission).
+//! - **Image-node targets** re-run the node's recorded reference through the
+//!   normal admitted `machine run` path, which re-admits identically.
+//!
+//! Every restore verifies its target against the signed audit chain up front and
+//! fails closed on an un-audited, tampered, or dangling record — the same
+//! `verify_lineage` / `verify_image_lineage` gate `machine checkpoint verify`
+//! and `fork` use. A completed checkpoint restore additionally emits a
+//! chain-signed `checkpoint.restored` entry carrying the initiating verb
+//! (`revert` / `rewind` / `advance`) as its `via` label.
+
+use anyhow::{Context, Result, bail};
+
+use mvm_core::checkpoint::CheckpointMeta;
+use mvm_core::image_lineage::{ImageBuildIdentity, ImageCanonicalId, ImageNode, ImageProvenance};
+use mvm_runtime::checkpoint::{
+    CheckpointStore, checkpoint_ancestry, checkpoint_children, verify_lineage,
+};
+use mvm_runtime::image_lineage::{
+    ImageStore, image_ancestry, image_children, verify_image_lineage,
+};
+
+use super::SignedChainAnchor;
+use super::timeline::{LineageKind, ResolvedTarget, resolve_target};
+use crate::ui;
+
+/// How a restore was initiated, recorded as the `via` label on the chain-signed
+/// `checkpoint.restored` entry so a time-travel restore reads distinctly in the
+/// audit log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RevertVia {
+    /// Restore to the resolved target itself.
+    Revert,
+    /// Restore to the target's parent (one step back).
+    Rewind,
+    /// Restore to a child of the target (one step forward).
+    Advance,
+}
+
+impl RevertVia {
+    fn as_str(self) -> &'static str {
+        match self {
+            RevertVia::Revert => "revert",
+            RevertVia::Rewind => "rewind",
+            RevertVia::Advance => "advance",
+        }
+    }
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub(in crate::commands) struct RevertArgs {
+    /// Checkpoint id, or a `sha256:<hex>` content-address naming a checkpoint or
+    /// an image lineage node to restore.
+    pub target: String,
+    /// Disambiguate a `sha256:<hex>` digest present in BOTH the checkpoint and
+    /// image stores. Not needed for a checkpoint id.
+    #[arg(long, value_enum)]
+    pub kind: Option<LineageKind>,
+    /// Hypervisor backend for the restored checkpoint VM. Defaults to the same
+    /// auto-detect order as `machine run`.
+    #[arg(long, default_value = "firecracker")]
+    pub hypervisor: String,
+    /// Name for the restored VM (checkpoint restores only; auto-generated if
+    /// omitted). Image restores auto-name through the run path.
+    #[arg(long, value_parser = super::super::shared::clap_vm_name)]
+    pub new_id: Option<String>,
+    /// Emit the restore result as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub(in crate::commands) struct AdvanceArgs {
+    /// Checkpoint id or `sha256:<hex>` digest whose child to restore.
+    pub target: String,
+    /// The specific child to advance to, by its `sha256:<hex>` content-address.
+    /// Required when the target has more than one child (a fork).
+    #[arg(long)]
+    pub to: Option<String>,
+    /// Disambiguate a `sha256:<hex>` target present in BOTH stores.
+    #[arg(long, value_enum)]
+    pub kind: Option<LineageKind>,
+    /// Hypervisor backend for the restored checkpoint VM.
+    #[arg(long, default_value = "firecracker")]
+    pub hypervisor: String,
+    /// Name for the restored VM (checkpoint restores only).
+    #[arg(long, value_parser = super::super::shared::clap_vm_name)]
+    pub new_id: Option<String>,
+    /// Emit the restore result as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// The result of a restore verb, so the `machine` dispatcher can complete the
+/// image path (which re-runs through `run_dispatch`) without this module
+/// depending on the run surface.
+#[derive(Debug)]
+pub(in crate::commands) enum RevertOutcome {
+    /// A checkpoint restore ran to completion here: fork re-admitted + booted the
+    /// restored VM and emitted the chain-signed `checkpoint.restored` entry.
+    Done,
+    /// An image-node restore: the caller must re-run the reconstructed reference
+    /// through the normal admitted `machine run` path.
+    RunImage(RevertRunImage),
+}
+
+/// The reconstructed `machine run` reference for an image-node restore. Exactly
+/// one of `image` / `flake` is set.
+#[derive(Debug)]
+pub(in crate::commands) struct RevertRunImage {
+    pub image: Option<String>,
+    pub flake: Option<String>,
+    pub hypervisor: Option<String>,
+    pub json: bool,
+}
+
+/// Common restore knobs threaded from the verb args into the engine.
+struct RestoreOpts<'a> {
+    hypervisor: &'a str,
+    new_id: Option<&'a str>,
+    json: bool,
+}
+
+/// `machine revert <target>` — restore the resolved target itself.
+pub(in crate::commands) fn run_revert(args: RevertArgs) -> Result<RevertOutcome> {
+    let cstore = CheckpointStore::open();
+    let istore = ImageStore::open();
+    let resolved = resolve_target(&cstore, &istore, &args.target, args.kind)?;
+    restore_resolved(
+        &cstore,
+        &istore,
+        resolved,
+        RevertVia::Revert,
+        RestoreOpts {
+            hypervisor: &args.hypervisor,
+            new_id: args.new_id.as_deref(),
+            json: args.json,
+        },
+    )
+}
+
+/// `machine rewind <target>` — restore the target's parent (one step back).
+pub(in crate::commands) fn run_rewind(args: RevertArgs) -> Result<RevertOutcome> {
+    let cstore = CheckpointStore::open();
+    let istore = ImageStore::open();
+    let anchor = SignedChainAnchor::load()
+        .context("loading the signed audit chain to resolve the rewind target")?;
+    let resolved = resolve_target(&cstore, &istore, &args.target, args.kind)?;
+    let parent = parent_of(&cstore, &istore, &anchor, resolved)?;
+    restore_resolved(
+        &cstore,
+        &istore,
+        parent,
+        RevertVia::Rewind,
+        RestoreOpts {
+            hypervisor: &args.hypervisor,
+            new_id: args.new_id.as_deref(),
+            json: args.json,
+        },
+    )
+}
+
+/// `machine advance <target> [--to <child>]` — restore a child of the target
+/// (one step forward). Forward is a tree, so a fork requires `--to`.
+pub(in crate::commands) fn run_advance(args: AdvanceArgs) -> Result<RevertOutcome> {
+    let cstore = CheckpointStore::open();
+    let istore = ImageStore::open();
+    let anchor = SignedChainAnchor::load()
+        .context("loading the signed audit chain to resolve the advance target")?;
+    let resolved = resolve_target(&cstore, &istore, &args.target, args.kind)?;
+    let child = child_of(&cstore, &istore, &anchor, resolved, args.to.as_deref())?;
+    restore_resolved(
+        &cstore,
+        &istore,
+        child,
+        RevertVia::Advance,
+        RestoreOpts {
+            hypervisor: &args.hypervisor,
+            new_id: args.new_id.as_deref(),
+            json: args.json,
+        },
+    )
+}
+
+fn restore_resolved(
+    cstore: &CheckpointStore,
+    istore: &ImageStore,
+    resolved: ResolvedTarget,
+    via: RevertVia,
+    opts: RestoreOpts<'_>,
+) -> Result<RevertOutcome> {
+    match resolved {
+        ResolvedTarget::Checkpoint(meta) => {
+            revert_checkpoint(cstore, meta, via, &opts)?;
+            Ok(RevertOutcome::Done)
+        }
+        ResolvedTarget::Image(node) => revert_image(istore, node, via, &opts),
+    }
+}
+
+/// Restore a checkpoint target by forking a fresh, re-admitted VM from it.
+///
+/// The full lineage is verified against the signed audit chain first (fail
+/// closed on an un-audited, tampered, or dangling record) — a restore must
+/// never build on a checkpoint edited after it was audited. The fork path then
+/// re-admits (`admit_plan_for_boot`), preserving the current egress policy and
+/// re-deriving the sealed attenuation, and boots the restored VM. Finally a
+/// chain-signed `checkpoint.restored` entry binds the restore to the launched
+/// plan, carrying the initiating verb as its `via` label.
+fn revert_checkpoint(
+    store: &CheckpointStore,
+    target: CheckpointMeta,
+    via: RevertVia,
+    opts: &RestoreOpts<'_>,
+) -> Result<()> {
+    let anchor = SignedChainAnchor::load()
+        .context("loading the signed audit chain to verify the restore target")?;
+    verify_lineage(store, &target.id, &anchor).with_context(|| {
+        format!(
+            "refusing to restore checkpoint {:?}: its lineage does not verify against the \
+             signed audit chain",
+            target.id.as_str()
+        )
+    })?;
+
+    let restored_vm_name = opts
+        .new_id
+        .map(ToString::to_string)
+        .unwrap_or_else(|| format!("revert-{}-{}", target.id.as_str(), now_unix()));
+
+    // Reuse the fork path verbatim: it re-admits through `admit_plan_for_boot`,
+    // re-derives the sealed attenuation, and boots. This is the anti-bypass
+    // guarantee — a restore never reaches `restore_checkpoint`.
+    super::fork(
+        target.id.as_str(),
+        Some(restored_vm_name.clone()),
+        /* boot */ true,
+        opts.hypervisor,
+        /* cpus */ None,
+        /* memory */ None,
+        opts.json,
+    )
+    .with_context(|| format!("restoring checkpoint {:?}", target.id.as_str()))?;
+
+    // Bind the restore to the launched plan (persisted by the fork boot) so the
+    // operation is tamper-evident in the chain, distinct from the fork's own
+    // `checkpoint.forked` lineage entry.
+    emit_revert_audit(&restored_vm_name, &target, via)?;
+
+    if !opts.json {
+        ui::success(&format!(
+            "{} {} -> restored vm '{}' (re-admitted from checkpoint)",
+            via.as_str(),
+            target.id.as_str(),
+            restored_vm_name
+        ));
+    }
+    Ok(())
+}
+
+/// Restore an image-node target: verify it against the signed audit chain, then
+/// reconstruct its recorded `machine run` reference. The caller re-runs that
+/// reference through the normal admitted run path, which re-admits identically
+/// and chain-signs its own admission trail.
+fn revert_image(
+    store: &ImageStore,
+    node: ImageNode,
+    via: RevertVia,
+    opts: &RestoreOpts<'_>,
+) -> Result<RevertOutcome> {
+    let anchor = SignedChainAnchor::load()
+        .context("loading the signed audit chain to verify the restore target")?;
+    verify_image_lineage(store, &node.node_digest, &anchor).with_context(|| {
+        format!(
+            "refusing to restore image node {}: its lineage does not verify against the \
+             signed audit chain",
+            node.node_digest
+        )
+    })?;
+
+    let reference = reconstruct_image_run_reference(&node)?;
+    tracing::info!(
+        node = %node.node_digest,
+        via = via.as_str(),
+        "image restore re-runs the recorded reference through the admitted run path"
+    );
+    Ok(RevertOutcome::RunImage(RevertRunImage {
+        image: reference.image,
+        flake: reference.flake,
+        hypervisor: Some(opts.hypervisor.to_string()),
+        json: opts.json,
+    }))
+}
+
+/// Reconstruct the `machine run` reference an image node recorded, so a restore
+/// re-materializes the exact prior image. OCI nodes yield a digest-pinned
+/// `<registry>/<repository>@<digest>`; flake nodes yield the recorded input ref.
+fn reconstruct_image_run_reference(node: &ImageNode) -> Result<RevertRunImage> {
+    match &node.build_identity {
+        ImageBuildIdentity::Oci {
+            registry,
+            repository,
+        } => {
+            let ImageCanonicalId::Oci { resolved_digest } = &node.image_identity.canonical else {
+                bail!(
+                    "image node {} names an OCI build identity but a non-OCI canonical id; \
+                     refusing to reconstruct an ambiguous reference",
+                    node.node_digest
+                );
+            };
+            Ok(RevertRunImage {
+                image: Some(format!("{registry}/{repository}@{resolved_digest}")),
+                flake: None,
+                hypervisor: None,
+                json: false,
+            })
+        }
+        ImageBuildIdentity::Flake { .. } => {
+            let ImageProvenance::Build { input_ref, .. } = &node.provenance else {
+                bail!(
+                    "image node {} names a flake build identity but non-build provenance; \
+                     refusing to reconstruct an ambiguous reference",
+                    node.node_digest
+                );
+            };
+            Ok(RevertRunImage {
+                image: None,
+                flake: Some(input_ref.clone()),
+                hypervisor: None,
+                json: false,
+            })
+        }
+    }
+}
+
+/// Resolve the parent of a restore target (the `rewind` step) via the C1
+/// ancestry enumeration, so the parent hop is chain-verified. Fails closed when
+/// the target is a genesis root or the ancestry is structurally broken.
+fn parent_of(
+    cstore: &CheckpointStore,
+    istore: &ImageStore,
+    anchor: &SignedChainAnchor,
+    resolved: ResolvedTarget,
+) -> Result<ResolvedTarget> {
+    match resolved {
+        ResolvedTarget::Checkpoint(meta) => {
+            let ancestry = checkpoint_ancestry(cstore, &meta.id, anchor)?;
+            if let Some(reason) = &ancestry.broken {
+                bail!(
+                    "cannot rewind: checkpoint {:?} lineage is broken: {reason}",
+                    meta.id.as_str()
+                );
+            }
+            // nodes[0] is the target; nodes[1] is its parent.
+            let parent = ancestry.nodes.into_iter().nth(1).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "cannot rewind: checkpoint {:?} is a genesis root with no parent",
+                    meta.id.as_str()
+                )
+            })?;
+            Ok(ResolvedTarget::Checkpoint(parent.record))
+        }
+        ResolvedTarget::Image(node) => {
+            let ancestry = image_ancestry(istore, &node.node_digest, anchor)?;
+            if let Some(reason) = &ancestry.broken {
+                bail!(
+                    "cannot rewind: image node {} lineage is broken: {reason}",
+                    node.node_digest
+                );
+            }
+            let parent = ancestry.nodes.into_iter().nth(1).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "cannot rewind: image node {} is a genesis root with no parent",
+                    node.node_digest
+                )
+            })?;
+            Ok(ResolvedTarget::Image(parent.record))
+        }
+    }
+}
+
+/// Resolve a child of a restore target (the `advance` step) via the C1 children
+/// enumeration. Forward is a tree, so a fork (more than one child) requires an
+/// explicit `--to <child-digest>`.
+fn child_of(
+    cstore: &CheckpointStore,
+    istore: &ImageStore,
+    anchor: &SignedChainAnchor,
+    resolved: ResolvedTarget,
+    to: Option<&str>,
+) -> Result<ResolvedTarget> {
+    match resolved {
+        ResolvedTarget::Checkpoint(meta) => {
+            let children = checkpoint_children(cstore, &meta.meta_digest, anchor)?;
+            let picked = pick_child(
+                children
+                    .into_iter()
+                    .map(|c| (c.record.meta_digest.to_string(), c.record)),
+                to,
+                &format!("checkpoint {:?}", meta.id.as_str()),
+            )?;
+            Ok(ResolvedTarget::Checkpoint(picked))
+        }
+        ResolvedTarget::Image(node) => {
+            let children = image_children(istore, &node.node_digest, anchor)?;
+            let picked = pick_child(
+                children
+                    .into_iter()
+                    .map(|c| (c.record.node_digest.to_string(), c.record)),
+                to,
+                &format!("image node {}", node.node_digest),
+            )?;
+            Ok(ResolvedTarget::Image(picked))
+        }
+    }
+}
+
+/// Pick the single child to advance to. No children → nothing to advance to; one
+/// child → that one (or the one `--to` names); many children → `--to` must
+/// disambiguate the fork.
+fn pick_child<R>(
+    children: impl Iterator<Item = (String, R)>,
+    to: Option<&str>,
+    target_label: &str,
+) -> Result<R> {
+    let all: Vec<(String, R)> = children.collect();
+    if all.is_empty() {
+        bail!("cannot advance: {target_label} has no children to advance to");
+    }
+    match to {
+        Some(want) => all
+            .into_iter()
+            .find(|(digest, _)| digest == want)
+            .map(|(_, record)| record)
+            .ok_or_else(|| {
+                anyhow::anyhow!("cannot advance: {target_label} has no child with digest {want:?}")
+            }),
+        None => {
+            if all.len() > 1 {
+                let digests: Vec<&str> = all.iter().map(|(d, _)| d.as_str()).collect();
+                bail!(
+                    "cannot advance: {target_label} has {} children (a fork); \
+                     disambiguate with `--to <child-digest>`. Children: {}",
+                    all.len(),
+                    digests.join(", ")
+                );
+            }
+            Ok(all.into_iter().next().expect("len == 1").1)
+        }
+    }
+}
+
+/// Emit the chain-signed `checkpoint.restored` entry for a completed restore,
+/// bound to the plan the restored VM launched under (persisted by the fork
+/// boot). Best-effort on a missing plan/signer (the VM already booted); a
+/// present signer whose emit fails is fatal — an unaudited restore breaks the
+/// chain.
+fn emit_revert_audit(
+    restored_vm_name: &str,
+    target: &CheckpointMeta,
+    via: RevertVia,
+) -> Result<()> {
+    let plan = match crate::commands::vm::plan_persist::read_plan(restored_vm_name) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error = %e, vm = restored_vm_name,
+                "no persisted plan for restored VM; checkpoint.restored emitted without chain binding");
+            return Ok(());
+        }
+    };
+    let signer = match crate::commands::vm::host_signer::load_or_init() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "host signer unavailable; restore chain entry skipped");
+            return Ok(());
+        }
+    };
+    let emitter = crate::commands::vm::audit_chain::AuditEmitter::new(signer.signing)
+        .context("refusing an unaudited restore: audit emitter unavailable")?;
+    mvm_hostd::audit::bind::bind_checkpoint_restored(
+        &emitter,
+        &plan,
+        target,
+        restored_vm_name,
+        via.as_str(),
+    )
+    .context("refusing an unaudited restore")?;
+    Ok(())
+}
+
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::checkpoint::{CheckpointClass, CheckpointId, CheckpointMeta, ContentBlob};
+    use mvm_core::image_lineage::{
+        ImageBuildIdentity, ImageCanonicalId, ImageIdentity, ImageNode, ImageProvenance,
+    };
+    use mvm_core::plan::test_support::PlanFixture;
+    use mvm_hostd::audit::bind::bind_checkpoint_created;
+    use mvm_hostd::audit::emitter::AuditEmitter;
+
+    // ── seed helpers: a store record + its host-signed creation entry ─────────
+
+    fn emitter() -> (AuditEmitter, mvm_core::plan::ExecutionPlan) {
+        let signer = crate::commands::vm::host_signer::load_or_init().unwrap();
+        let em = AuditEmitter::new(signer.signing).unwrap();
+        let plan = PlanFixture::new()
+            .tenant("local")
+            .plan_id("plan-revert")
+            .build();
+        (em, plan)
+    }
+
+    fn seed_ckpt(
+        store: &CheckpointStore,
+        em: &AuditEmitter,
+        plan: &mvm_core::plan::ExecutionPlan,
+        id: &str,
+        parent: Option<mvm_core::checkpoint::CheckpointDigest>,
+    ) -> CheckpointMeta {
+        let meta = CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::FsQuick, "vm")
+            .parent(parent)
+            .content(vec![ContentBlob {
+                name: "rootfs.ext4".into(),
+                sha256: "h".into(),
+            }])
+            .supervisor_config_digest("d")
+            .created_unix(1)
+            .build();
+        store.write_meta(&meta).unwrap();
+        bind_checkpoint_created(em, plan, &meta).unwrap();
+        meta
+    }
+
+    fn image_of(
+        slot: &str,
+        revision: &str,
+        parent: Option<mvm_core::checkpoint::CheckpointDigest>,
+    ) -> ImageNode {
+        ImageNode::builder(
+            ImageBuildIdentity::Flake {
+                slot_hash: slot.into(),
+            },
+            ImageIdentity {
+                canonical: ImageCanonicalId::Flake {
+                    revision_hash: revision.into(),
+                },
+                artifacts: vec![ContentBlob {
+                    name: "rootfs.ext4".into(),
+                    sha256: revision.into(),
+                }],
+            },
+            ImageProvenance::Build {
+                input_ref: ".#app".into(),
+                lock_digest: None,
+            },
+        )
+        .parent(parent)
+        .created_unix(1)
+        .build()
+    }
+
+    fn seed_image(
+        store: &ImageStore,
+        em: &AuditEmitter,
+        plan: &mvm_core::plan::ExecutionPlan,
+        node: &ImageNode,
+    ) {
+        store.save(node).unwrap();
+        em.emit_image_created(plan, node).unwrap();
+    }
+
+    fn oci_node(digest_hex: &str) -> ImageNode {
+        let resolved = format!("sha256:{}", digest_hex.repeat(64));
+        ImageNode::builder(
+            ImageBuildIdentity::Oci {
+                registry: "docker.io".into(),
+                repository: "library/alpine".into(),
+            },
+            ImageIdentity {
+                canonical: ImageCanonicalId::Oci {
+                    resolved_digest: resolved.clone(),
+                },
+                artifacts: vec![ContentBlob {
+                    name: "rootfs.ext4".into(),
+                    sha256: digest_hex.into(),
+                }],
+            },
+            ImageProvenance::Oci {
+                resolved_digest: resolved,
+                layer_digests: vec![],
+            },
+        )
+        .created_unix(1)
+        .build()
+    }
+
+    // ── reference reconstruction (pure) ──────────────────────────────────────
+
+    #[test]
+    fn oci_node_reconstructs_a_digest_pinned_reference() {
+        let node = oci_node("a");
+        let out = reconstruct_image_run_reference(&node).unwrap();
+        assert_eq!(
+            out.image.as_deref(),
+            Some(format!("docker.io/library/alpine@sha256:{}", "a".repeat(64)).as_str()),
+            "OCI restore must re-fetch the exact resolved digest"
+        );
+        assert!(out.flake.is_none());
+    }
+
+    #[test]
+    fn flake_node_reconstructs_the_recorded_input_ref() {
+        let node = image_of("slot-a", "rev-1", None);
+        let out = reconstruct_image_run_reference(&node).unwrap();
+        assert_eq!(out.flake.as_deref(), Some(".#app"));
+        assert!(out.image.is_none());
+    }
+
+    // ── invariant 5: verify the target before restoring (fail closed) ─────────
+
+    #[test]
+    fn revert_refuses_an_unaudited_checkpoint_before_booting() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let store = CheckpointStore::open();
+        // Written to the store but NEVER audited: no signed creation entry.
+        let meta = CheckpointMeta::builder(
+            CheckpointId::new("unaudited"),
+            CheckpointClass::FsQuick,
+            "vm",
+        )
+        .content(vec![ContentBlob {
+            name: "rootfs.ext4".into(),
+            sha256: "h".into(),
+        }])
+        .supervisor_config_digest("d")
+        .created_unix(1)
+        .build();
+        store.write_meta(&meta).unwrap();
+
+        let err = run_revert(RevertArgs {
+            target: "unaudited".into(),
+            kind: None,
+            hypervisor: "firecracker".into(),
+            new_id: None,
+            json: false,
+        })
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("no signed audit entry"),
+            "revert must fail closed on an un-audited target: {msg}"
+        );
+    }
+
+    #[test]
+    fn revert_refuses_a_tampered_checkpoint_before_booting() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let store = CheckpointStore::open();
+        let (em, plan) = emitter();
+        let meta = seed_ckpt(&store, &em, &plan, "audited", None);
+
+        // Tamper the sealed record after it was audited: recompute now drifts.
+        let path = store.dir_for(&meta.id).join("meta.json");
+        let mut tampered: CheckpointMeta =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        tampered.created_unix = 999;
+        std::fs::write(&path, serde_json::to_vec_pretty(&tampered).unwrap()).unwrap();
+
+        let err = run_revert(RevertArgs {
+            target: "audited".into(),
+            kind: None,
+            hypervisor: "firecracker".into(),
+            new_id: None,
+            json: false,
+        })
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("drift") || msg.contains("does not match the signed audit chain"),
+            "revert must fail closed on a tampered target: {msg}"
+        );
+    }
+
+    #[test]
+    fn revert_refuses_an_image_node_absent_from_the_signed_chain() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let istore = ImageStore::open();
+        let node = image_of("slot-a", "rev-1", None);
+        // Saved but NEVER audited.
+        istore.save(&node).unwrap();
+
+        let err = run_revert(RevertArgs {
+            target: node.node_digest.as_str().to_string(),
+            kind: None,
+            hypervisor: "firecracker".into(),
+            new_id: None,
+            json: false,
+        })
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("no signed audit entry"),
+            "image revert must fail closed on an un-audited node: {msg}"
+        );
+    }
+
+    /// An audited image node passes verification and reconstructs its recorded
+    /// reference, returning a `RunImage` that the dispatcher re-runs through the
+    /// normal admitted run path — the image analog of "re-admit, don't bypass".
+    /// `run_revert` never boots inline for an image target.
+    #[test]
+    fn revert_of_an_audited_image_node_reconstructs_a_run_not_a_bypass() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let istore = ImageStore::open();
+        let (em, plan) = emitter();
+        let node = image_of("slot-a", "rev-1", None);
+        seed_image(&istore, &em, &plan, &node);
+
+        let outcome = run_revert(RevertArgs {
+            target: node.node_digest.as_str().to_string(),
+            kind: None,
+            hypervisor: "firecracker".into(),
+            new_id: None,
+            json: false,
+        })
+        .unwrap();
+        match outcome {
+            RevertOutcome::RunImage(run) => {
+                assert_eq!(
+                    run.flake.as_deref(),
+                    Some(".#app"),
+                    "a flake image node restores through its recorded input ref"
+                );
+                assert!(run.image.is_none());
+            }
+            RevertOutcome::Done => {
+                panic!(
+                    "an image restore must route through the admitted run path, not complete inline"
+                )
+            }
+        }
+    }
+
+    // ── cross-store ambiguity refused (shared resolver) ──────────────────────
+
+    #[test]
+    fn revert_refuses_a_cross_store_ambiguous_digest() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let cstore = CheckpointStore::open();
+        let istore = ImageStore::open();
+
+        // Plant the same digest string in both stores.
+        let d = mvm_core::checkpoint::CheckpointDigest::parse(format!("sha256:{}", "c".repeat(64)))
+            .unwrap();
+        let mut meta =
+            CheckpointMeta::builder(CheckpointId::new("collide"), CheckpointClass::FsQuick, "vm")
+                .content(vec![])
+                .supervisor_config_digest("d")
+                .created_unix(1)
+                .build();
+        meta.meta_digest = d.clone();
+        cstore.write_meta(&meta).unwrap();
+        let mut node = image_of("slot-a", "rev-1", None);
+        node.node_digest = d.clone();
+        istore.save(&node).unwrap();
+
+        let err = run_revert(RevertArgs {
+            target: d.as_str().to_string(),
+            kind: None,
+            hypervisor: "firecracker".into(),
+            new_id: None,
+            json: false,
+        })
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("BOTH"),
+            "ambiguous digest must be refused: {msg}"
+        );
+        assert!(
+            msg.contains("--kind"),
+            "refusal must point at --kind: {msg}"
+        );
+    }
+
+    // ── invariant 4: a completed restore emits a verifiable chain entry ───────
+
+    #[test]
+    fn emit_revert_audit_writes_a_verifiable_restored_entry() {
+        use mvm_hostd::supervisor::verify_audit_chain;
+
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        // The restored VM's plan is persisted by the fork boot; seed it here so
+        // the audit binds to the launched identity.
+        let restored_vm = "revert-target-child";
+        let plan = PlanFixture::new()
+            .tenant("local")
+            .plan_id("plan-restored")
+            .build();
+        crate::commands::vm::plan_persist::write_plan(restored_vm, &plan).unwrap();
+
+        let target = CheckpointMeta::builder(
+            CheckpointId::new("target"),
+            CheckpointClass::FsQuick,
+            "origin",
+        )
+        .content(vec![ContentBlob {
+            name: "rootfs.ext4".into(),
+            sha256: "h".into(),
+        }])
+        .supervisor_config_digest("d")
+        .created_unix(1)
+        .build();
+
+        emit_revert_audit(restored_vm, &target, RevertVia::Rewind).unwrap();
+
+        let signer = crate::commands::vm::host_signer::load_or_init().unwrap();
+        let path = mvm_hostd::audit::emitter::default_audit_dir()
+            .unwrap()
+            .join("local.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("checkpoint.restored"));
+        assert!(content.contains("target"));
+        assert!(content.contains(restored_vm));
+        assert!(content.contains("rewind"), "the via label must be recorded");
+        // The chain-signed entry verifies under the host key.
+        assert_eq!(verify_audit_chain(&path, &signer.verifying).unwrap(), 1);
+    }
+
+    #[test]
+    fn emit_revert_audit_is_best_effort_when_no_plan_is_persisted() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let target =
+            CheckpointMeta::builder(CheckpointId::new("t"), CheckpointClass::FsQuick, "origin")
+                .content(vec![])
+                .supervisor_config_digest("d")
+                .created_unix(1)
+                .build();
+        // No persisted plan for the restored VM → best-effort skip, not an error.
+        emit_revert_audit("no-plan-vm", &target, RevertVia::Revert).unwrap();
+    }
+
+    // ── invariant 3: a sealed restore preserves the sealed posture ────────────
+
+    #[test]
+    fn sealed_restore_derives_the_attenuated_grant_and_refuses_console() {
+        // A restore of a sealed image reuses the fork boot, which derives the
+        // attenuated ProdSafe grant from `image_is_sealed` (no console/exec) and
+        // whose backend records accessible=false — exactly as fork does.
+        let tmp = tempfile::tempdir().unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"fake").unwrap();
+        let sidecar = mvm_build::builder_vm::GuestSidecar {
+            name: "sealed".to_string(),
+            accessible: false,
+            sealed: true,
+            entrypoint_kind: "command".to_string(),
+            init_system: "busybox".to_string(),
+            expected_boot_ms: 300,
+            agent_binary: "real".to_string(),
+            rootless_entrypoint: true,
+            hypervisor: "firecracker".to_string(),
+            overlay_aware: true,
+            runtime_lean: true,
+        };
+        sidecar.write_to_dir(tmp.path()).unwrap();
+
+        // The sealed rootfs qualifies for the attenuated grant the fork boot sets
+        // on the restored VM's admitted plan.
+        assert!(crate::commands::vm::agent_verbs::image_is_sealed(&rootfs));
+        assert!(
+            crate::commands::vm::agent_verbs::grant_eligible(
+                false,
+                false,
+                false,
+                crate::commands::vm::agent_verbs::image_is_sealed(&rootfs),
+            ),
+            "a sealed restore must receive the attenuated ProdSafe grant"
+        );
+
+        // And a restored VM whose recorded runtime meta is sealed refuses the
+        // interactive console gate (claim 15).
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let home = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", home.path());
+        let state_dir = mvm_core::config::vm_state_dir("restored-sealed");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::write(
+            state_dir.join("mode.json"),
+            "{\"mode\":\"detached\",\"accessible\":false}\n",
+        )
+        .unwrap();
+        let err = crate::commands::vm::console::enforce_accessible_gate("restored-sealed", false)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("sealed"),
+            "a restored sealed VM must refuse console: {err}"
+        );
+    }
+}

--- a/crates/mvm-cli/src/commands/vm/checkpoint/timeline.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/timeline.rs
@@ -56,9 +56,10 @@ impl LineageKind {
     }
 }
 
-/// The record a target string resolved to, in one of the two stores.
+/// The record a target string resolved to, in one of the two stores. Shared
+/// with the revert engine, which resolves a target identically before restoring.
 #[derive(Debug)]
-enum ResolvedTarget {
+pub(in crate::commands::vm::checkpoint) enum ResolvedTarget {
     Checkpoint(CheckpointMeta),
     Image(ImageNode),
 }
@@ -88,8 +89,9 @@ pub(in crate::commands) fn run_timeline(args: TimelineArgs) -> Result<()> {
 /// Resolve `target` to a record in one of the two stores. A `sha256:<hex>`
 /// addresses either store (disambiguated by `kind` on a collision); anything
 /// else is a checkpoint id (image nodes have no id — their identity is their
-/// digest).
-fn resolve_target(
+/// digest). Shared with the revert engine so a target resolves identically
+/// whether it is being navigated (timeline) or restored (revert).
+pub(in crate::commands::vm::checkpoint) fn resolve_target(
     checkpoint_store: &CheckpointStore,
     image_store: &ImageStore,
     target: &str,
@@ -383,12 +385,34 @@ fn render_human(timeline: &Timeline) -> String {
     }
 
     lines.push(String::new());
-    lines.push(if timeline.verified {
-        "lineage verified against the signed audit chain".to_string()
-    } else {
-        "lineage has unverified hop(s) — see the UNVERIFIED marks above".to_string()
-    });
+    lines.push(timeline_footer(timeline));
     lines.join("\n")
+}
+
+/// The overall-verdict footer. A failed verdict has two independent causes that
+/// read very differently, so the footer names which one(s) apply rather than
+/// blaming every failure on a bad hop: a *structural* break (a dangling or
+/// cyclic parent hash-link that stopped the walk before genesis) versus a
+/// *per-hop* verification failure (a hop present in the chain that did not
+/// verify against the signed audit log). Both can hold at once.
+fn timeline_footer(timeline: &Timeline) -> String {
+    if timeline.verified {
+        return "lineage verified against the signed audit chain".to_string();
+    }
+    let structural_break = timeline.lineage_broken.is_some();
+    let has_failed_hop = !timeline.node.verified
+        || timeline.ancestors.iter().any(|n| !n.verified)
+        || timeline.children.iter().any(|n| !n.verified);
+    match (structural_break, has_failed_hop) {
+        (true, true) => "lineage is structurally broken (dangling or cyclic parent link) AND \
+             has unverified hop(s) — see the incompleteness note and the UNVERIFIED marks above"
+            .to_string(),
+        (true, false) => "lineage is structurally broken (dangling or cyclic parent link): the \
+             walk could not reach genesis — see the incompleteness note above"
+            .to_string(),
+        // structural_break is false here, so the only remaining cause is a failed hop.
+        (false, _) => "lineage has unverified hop(s) — see the UNVERIFIED marks above".to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -733,6 +757,42 @@ mod tests {
         // Overall verdict is failed, and the walk still reached genesis.
         assert!(!timeline.verified);
         assert!(timeline.lineage_broken.is_none());
+    }
+
+    #[test]
+    fn dangling_ancestry_sets_lineage_broken_and_renders_a_structural_break() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let store = CheckpointStore::open();
+        let (em, plan) = emitter();
+
+        // A checkpoint whose parent hash-link names a digest no stored record
+        // carries: the node itself is audited and verifies, but the walk cannot
+        // reach genesis — a genuine structural break, not a per-hop failure.
+        let missing_parent = digest_of('e');
+        let target = seed_ckpt(&store, &em, &plan, "orphan", Some(missing_parent));
+
+        let anchor = SignedChainAnchor::load().unwrap();
+        let timeline = build_checkpoint_timeline(&store, &anchor, target).unwrap();
+
+        // The reachable node is listed and verified...
+        assert!(timeline.node.verified);
+        // ...but the walk fails closed with a structural break, not a bad hop.
+        assert!(
+            timeline.lineage_broken.is_some(),
+            "a dangling parent must surface as a structural break"
+        );
+        assert!(!timeline.verified, "a broken lineage is not verified");
+
+        let out = render_human(&timeline);
+        assert!(out.contains("lineage incomplete"), "{out}");
+        // The footer names the STRUCTURAL cause, not a phantom unverified hop.
+        assert!(out.contains("structurally broken"), "{out}");
+        assert!(
+            !out.contains("unverified hop(s)"),
+            "a purely structural break must not be reported as an unverified hop: {out}"
+        );
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit/bind.rs
+++ b/crates/mvm-hostd/src/audit/bind.rs
@@ -33,17 +33,23 @@ pub fn bind_checkpoint_created(
     )
 }
 
-/// Emit `checkpoint.restored` for a same-identity resume.
+/// Emit `checkpoint.restored` binding a restore to the plan it launched under.
+/// `restored_vm_name` is the identity that came up carrying the checkpoint's
+/// state (the fresh re-admitted VM for a time-travel restore), and `via` records
+/// how the restore was initiated (`revert` / `rewind` / `advance`).
 pub fn bind_checkpoint_restored(
     emitter: &AuditEmitter,
     plan: &ExecutionPlan,
     meta: &CheckpointMeta,
+    restored_vm_name: &str,
+    via: &str,
 ) -> Result<()> {
     emitter.emit_checkpoint_restored(
         plan,
         meta.id.as_str(),
         meta.meta_digest.as_str(),
-        &meta.vm_name,
+        restored_vm_name,
+        via,
     )
 }
 
@@ -127,6 +133,34 @@ mod tests {
     fn class_str_maps_both_variants() {
         assert_eq!(class_str(CheckpointClass::FsQuick), "fs_quick");
         assert_eq!(class_str(CheckpointClass::VmFull), "vm_full");
+    }
+
+    #[test]
+    fn bind_restored_binds_the_restored_vm_and_via() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-RV");
+        // The target checkpoint is captured on `origin`; the restore comes up as
+        // a fresh identity `restored-child`, which the bound entry must name.
+        let target = vm_full_meta("ckpt-target", "origin");
+
+        bind_checkpoint_restored(&emitter, &plan, &target, "restored-child", "rewind").unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("checkpoint.restored"));
+        assert!(content.contains("ckpt-target"));
+        assert!(content.contains(target.meta_digest.as_str()));
+        // The restored VM name is the fresh identity, not the origin.
+        assert!(content.contains("restored-child"));
+        assert!(content.contains("rewind"));
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -86,6 +86,17 @@ pub mod checkpoint_audit {
 pub mod image_audit {
     /// Emitted when a compiled image's version-lineage node is created.
     pub const CREATED_EVENT: &str = "image.created";
+    /// Emitted when a fresh VM is launched from a prior image-lineage node (a
+    /// time-travel restore), so a revert is distinguishable in the chain from an
+    /// ordinary image run. Not a creation event — the chain-anchor never indexes
+    /// it, since a restore mints no new lineage node.
+    pub const REVERTED_EVENT: &str = "image.reverted";
+    /// Label: how a restore was initiated (`revert` / `rewind` / `advance`).
+    /// Carried on [`REVERTED_EVENT`].
+    pub const LABEL_VIA: &str = "via";
+    /// Label: the reconstructed `machine run` reference a restore re-runs.
+    /// Carried on [`REVERTED_EVENT`].
+    pub const LABEL_REVERTED_REFERENCE: &str = "image_reverted_reference";
     /// Label: the node's own content-address. The chain-anchor keys on this.
     pub const LABEL_NODE_DIGEST: &str = "image_node_digest";
     /// Label: the predecessor node's content-address (the parent hash-link), or
@@ -479,6 +490,33 @@ impl AuditEmitter {
         node: &mvm_core::image_lineage::ImageNode,
     ) -> Result<()> {
         self.emit(plan, image_audit::CREATED_EVENT, image_created_labels(node))
+    }
+
+    /// Record that a fresh VM was launched from a prior image-lineage node (a
+    /// time-travel restore). The label set carries the restored node's
+    /// content-address, the initiating verb (`via`), and the reconstructed
+    /// `machine run` reference the restore re-runs, so a revert is distinct in
+    /// the chain from an ordinary image run.
+    pub fn emit_image_reverted(
+        &self,
+        plan: &ExecutionPlan,
+        node_digest: &str,
+        via: &str,
+        reference: &str,
+    ) -> Result<()> {
+        use image_audit as k;
+        self.emit(
+            plan,
+            k::REVERTED_EVENT,
+            [
+                (k::LABEL_NODE_DIGEST.to_string(), node_digest.to_string()),
+                (k::LABEL_VIA.to_string(), via.to_string()),
+                (
+                    k::LABEL_REVERTED_REFERENCE.to_string(),
+                    reference.to_string(),
+                ),
+            ],
+        )
     }
 
     /// Emit `plan.exited` — fires after a waited-for workload powers off,
@@ -1110,6 +1148,36 @@ mod tests {
         assert!(content.contains("image_build_identity"));
         assert!(content.contains("slot-a"));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 2);
+    }
+
+    #[test]
+    fn image_reverted_records_node_digest_via_and_reference() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-IR");
+        let node_digest = format!("sha256:{}", "c".repeat(64));
+        emitter
+            .emit_image_reverted(
+                &plan,
+                &node_digest,
+                "revert",
+                "docker.io/library/alpine@sha256:aa",
+            )
+            .unwrap();
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("image.reverted"));
+        assert!(content.contains(&node_digest));
+        assert!(content.contains("\"via\""));
+        assert!(content.contains("revert"));
+        assert!(content.contains("docker.io/library/alpine@sha256:aa"));
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -63,6 +63,10 @@ pub mod checkpoint_audit {
     pub const LABEL_CLASS: &str = "class";
     /// Label: the owning VM name (created/restored).
     pub const LABEL_VM_NAME: &str = "vm_name";
+    /// Label: how a restore was initiated (`revert` / `rewind` / `advance`),
+    /// so a time-travel restore is distinguishable in the chain from a
+    /// same-identity resume. Carried on `checkpoint.restored`.
+    pub const LABEL_VIA: &str = "via";
     /// Label: the parent checkpoint id (forked).
     pub const LABEL_PARENT_ID: &str = "parent_id";
     /// Label: the child (new) checkpoint id (forked).
@@ -403,15 +407,17 @@ impl AuditEmitter {
         )
     }
 
-    /// Record that a VM was restored to the state captured in a vm_full
-    /// checkpoint. The label set carries the checkpoint id, its content-address,
-    /// and the VM name.
+    /// Record that a VM was restored to the state captured in a checkpoint. The
+    /// label set carries the checkpoint id, its content-address, the restored VM
+    /// name, and `via` — how the restore was initiated (`revert` / `rewind` /
+    /// `advance`), so a time-travel restore reads distinctly in the chain.
     pub fn emit_checkpoint_restored(
         &self,
         plan: &ExecutionPlan,
         checkpoint_id: &str,
         meta_digest: &str,
         vm_name: &str,
+        via: &str,
     ) -> Result<()> {
         use checkpoint_audit as k;
         self.emit(
@@ -424,6 +430,7 @@ impl AuditEmitter {
                 ),
                 (k::LABEL_META_DIGEST.to_string(), meta_digest.to_string()),
                 (k::LABEL_VM_NAME.to_string(), vm_name.to_string()),
+                (k::LABEL_VIA.to_string(), via.to_string()),
             ],
         )
     }
@@ -1118,7 +1125,7 @@ mod tests {
         let plan = fixture_plan("local", "plan-R");
         let meta_digest = format!("sha256:{}", "d".repeat(64));
         emitter
-            .emit_checkpoint_restored(&plan, "ckpt-abc", &meta_digest, "myvm")
+            .emit_checkpoint_restored(&plan, "ckpt-abc", &meta_digest, "myvm", "revert")
             .unwrap();
         let path = dir.path().join("local.jsonl");
         let content = std::fs::read_to_string(&path).unwrap();
@@ -1126,6 +1133,9 @@ mod tests {
         assert!(content.contains("ckpt-abc"));
         assert!(content.contains("myvm"));
         assert!(content.contains(&meta_digest));
+        // The initiating verb rides as the `via` label.
+        assert!(content.contains("\"via\""));
+        assert!(content.contains("revert"));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
     }
 }

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -230,11 +230,22 @@ const MACHINE_SUB: &[(&str, AuditPosture)] = &[
     // nothing — no audit-chain emission.
     ("timeline", AuditPosture::ReadOnly),
     // Time-travel restore verbs: launch a fresh, re-admitted VM at a prior
-    // checkpoint/image state. A completed checkpoint restore emits a chain-signed
-    // `checkpoint.restored` entry (plus the fork boot's own admission trail).
-    ("revert", AuditPosture::Emits("CheckpointRestored")),
-    ("rewind", AuditPosture::Emits("CheckpointRestored")),
-    ("advance", AuditPosture::Emits("CheckpointRestored")),
+    // checkpoint/image state. The two sub-paths emit different chain markers: a
+    // checkpoint restore emits `checkpoint.restored` (plus the fork boot's own
+    // admission trail); an OCI image restore emits `image.reverted` before it
+    // re-runs through the admitted run path.
+    (
+        "revert",
+        AuditPosture::Emits("CheckpointRestored+image.reverted"),
+    ),
+    (
+        "rewind",
+        AuditPosture::Emits("CheckpointRestored+image.reverted"),
+    ),
+    (
+        "advance",
+        AuditPosture::Emits("CheckpointRestored+image.reverted"),
+    ),
     // Advanced single-VM verbs folded under `machine` (hidden from default help).
     // The audit postures are unchanged from when these lived under `vm <sub>`.
     ("pause", AuditPosture::Emits("VmStop")),
@@ -677,6 +688,8 @@ fn audit_posture_emits_entries_reference_known_audit_kinds() {
         // Plan-64 audit-chain events.
         "plan.admitted",
         "plan.launched",
+        // Image time-travel restore marker.
+        "image.reverted",
     ];
 
     let mut failures: Vec<(String, &'static str)> = Vec::new();

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -229,6 +229,12 @@ const MACHINE_SUB: &[(&str, AuditPosture)] = &[
     // each hop against the signed chain but makes no trust decision and writes
     // nothing — no audit-chain emission.
     ("timeline", AuditPosture::ReadOnly),
+    // Time-travel restore verbs: launch a fresh, re-admitted VM at a prior
+    // checkpoint/image state. A completed checkpoint restore emits a chain-signed
+    // `checkpoint.restored` entry (plus the fork boot's own admission trail).
+    ("revert", AuditPosture::Emits("CheckpointRestored")),
+    ("rewind", AuditPosture::Emits("CheckpointRestored")),
+    ("advance", AuditPosture::Emits("CheckpointRestored")),
     // Advanced single-VM verbs folded under `machine` (hidden from default help).
     // The audit postures are unchanged from when these lived under `vm <sub>`.
     ("pause", AuditPosture::Emits("VmStop")),


### PR DESCRIPTION
Closes #1809 — completes workstream C of epic #1806. Time-travel restore verbs
on top of C1's read-only `timeline`.

## Verbs
- `machine revert <id|digest>` — restore the target (a fresh, **re-admitted** VM
  at the prior state).
- `machine rewind <id|digest>` — restore the target's parent.
- `machine advance <id|digest> [--to <child>]` — restore a child (`--to`
  disambiguates a fork). Named `advance`, not `forward`, to avoid the
  `machine forward` port-forward clash.

## Built on fork's admission, never the bypass seam
Restores route through the fork path's `admit_plan_for_boot` (checkpoints) / the
normal admitted `machine run` path (images) — **never** the admission-bypassing
`restore_checkpoint`. Independently confirmed by two adversarial reviews. So:
- **Re-admit** every restore (claim 8); **sealed stays sealed** (claims 3/15 —
  `accessible=false` + `restrict_agent_verbs` re-derived from the real rootfs, a
  reverted sealed VM refuses console); **anti-downgrade** via current-policy
  re-resolution + deny-all default; **fail-closed** on un-audited / tampered /
  dangling / cross-store-ambiguous targets *before any boot*; **every op emits a
  chain-signed marker** (`checkpoint.restored` for checkpoints, `image.reverted`
  for images) recording the target digest + `via`.

## Scope
- OCI-image and checkpoint reverts are exact-restore.
- **Flake-image reverts are refused** with a clear error, pending #1840 — a
  faithful flake revert needs boot-from-a-specific-stored-revision plumbing;
  rebuilding from current source would be silently wrong for a rollback tool.
- Folds in the C1 review follow-ups (a broken-ancestry CLI test + timeline
  footer wording).

## Verification
Two-stage adversarial review (correctness + security): boundary confirmed sound.
Six review fixes applied (flake refusal over silent rebuild; distinct
`image.reverted` audit marker; hardened hop-status gating on rewind/advance
selection; reuse-first `now_unix`; `--new-id` rejected for image targets;
egress doc caveat). `nextest --workspace` 7699 passed / 0 failed; doctests,
`clippy --all-targets -D warnings`, nightly fmt, `check-content-address-determinism`,
and `check-no-spec-refs-in-comments` all clean.
