### PR TITLE
Implement user-space microVM outbound networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ attestation.
 - [Writing Nix flakes for guests (mkGuest)](public/src/content/docs/guides/nix-flakes.md)
 - [Secrets and credentials](public/src/content/docs/guides/secrets-and-credentials.mdx) ·
   [Network egress policy](public/src/content/docs/guides/network-egress-policy.mdx) ·
+  [Rootless networking](public/src/content/docs/guides/networking.md) ·
   [AI agent integration](public/src/content/docs/guides/ai-agent-integration.md)
 - [Security](public/src/content/docs/security/) ·
   [Troubleshooting](public/src/content/docs/guides/troubleshooting.md)

--- a/crates/mvm-agentd/src/egress_client.rs
+++ b/crates/mvm-agentd/src/egress_client.rs
@@ -18,6 +18,7 @@ use tokio::sync::watch;
 
 use crate::guest_vsock_session::HostVsockSession;
 use mvm_core::guest_netd::ConnectAck;
+use mvm_core::socks5_udp::{self, Datagram};
 
 const EGRESS_VSOCK_PORT_ENV: &str = "MVM_EGRESS_VSOCK_PORT";
 
@@ -50,6 +51,7 @@ const METHOD_NO_AUTH: u8 = 0x00;
 const METHOD_NONE: u8 = 0xFF;
 /// SOCKS5 CONNECT command.
 const CMD_CONNECT: u8 = 0x01;
+const CMD_UDP_ASSOCIATE: u8 = 0x03;
 /// Address types.
 const ATYP_IPV4: u8 = 0x01;
 const ATYP_DOMAIN: u8 = 0x03;
@@ -65,6 +67,7 @@ const HTTP_FORWARD_FRAME: &[u8] = b"MVM_HTTP_FORWARD/1\n";
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ProxyRoute {
     Socks { target: String },
+    SocksUdpAssociate,
     HttpConnect { target: String },
     HttpForward { head: Vec<u8>, content_length: u64 },
 }
@@ -111,10 +114,25 @@ where
 {
     let mut version = [0u8; 1];
     stream.read_exact(&mut version).await?;
-    negotiate_with_prefetched(stream, version[0]).await
+    match negotiate_request_with_prefetched(stream, version[0]).await? {
+        SocksRequest::Connect(target) => Ok(target),
+        SocksRequest::UdpAssociate => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "socks: UDP ASSOCIATE is not a CONNECT request",
+        )),
+    }
 }
 
-async fn negotiate_with_prefetched<S>(stream: &mut S, version: u8) -> std::io::Result<String>
+#[derive(Debug, PartialEq, Eq)]
+enum SocksRequest {
+    Connect(String),
+    UdpAssociate,
+}
+
+async fn negotiate_request_with_prefetched<S>(
+    stream: &mut S,
+    version: u8,
+) -> std::io::Result<SocksRequest>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
@@ -141,10 +159,10 @@ where
     if req[0] != SOCKS5 {
         return Err(invalid("socks: request not version 5"));
     }
-    if req[1] != CMD_CONNECT {
+    if req[1] != CMD_CONNECT && req[1] != CMD_UDP_ASSOCIATE {
         // Reply "command not supported" before closing.
         let _ = reply(stream, REP_CMD_NOT_SUPPORTED).await;
-        return Err(invalid("socks: only CONNECT is supported"));
+        return Err(invalid("socks: unsupported command"));
     }
     let atyp = req[3];
     let addr = match atyp {
@@ -169,7 +187,12 @@ where
     };
     let mut port = [0u8; 2];
     stream.read_exact(&mut port).await?;
-    format_target(atyp, &addr, u16::from_be_bytes(port))
+    let target = format_target(atyp, &addr, u16::from_be_bytes(port))?;
+    if req[1] == CMD_UDP_ASSOCIATE {
+        Ok(SocksRequest::UdpAssociate)
+    } else {
+        Ok(SocksRequest::Connect(target))
+    }
 }
 
 /// Send a SOCKS5 reply with code `rep` and a zero bind address (RFC 1928 §6).
@@ -191,9 +214,10 @@ where
     let mut first = [0u8; 1];
     stream.read_exact(&mut first).await?;
     if first[0] == SOCKS5 {
-        return Ok(ProxyRoute::Socks {
-            target: negotiate_with_prefetched(stream, first[0]).await?,
-        });
+        return match negotiate_request_with_prefetched(stream, first[0]).await? {
+            SocksRequest::Connect(target) => Ok(ProxyRoute::Socks { target }),
+            SocksRequest::UdpAssociate => Ok(ProxyRoute::SocksUdpAssociate),
+        };
     }
     read_http_proxy_route(stream, first[0]).await
 }
@@ -310,12 +334,105 @@ async fn serve(mut client: TcpStream) -> std::io::Result<()> {
     };
     match route {
         ProxyRoute::Socks { target } => serve_socks(client, &target).await,
+        ProxyRoute::SocksUdpAssociate => serve_socks_udp(client).await,
         ProxyRoute::HttpConnect { target } => serve_http_connect(client, &target).await,
         ProxyRoute::HttpForward {
             head,
             content_length,
         } => serve_http_forward(client, &head, content_length).await,
     }
+}
+
+async fn serve_socks_udp(control: TcpStream) -> std::io::Result<()> {
+    let upstream = HostVsockSession::connect(configured_egress_vsock_port())
+        .await?
+        .write_initial_bytes(format!("{}\n", socks5_udp::FRAME_LINE).as_bytes())
+        .await?
+        .into_inner();
+    serve_socks_udp_with_upstream(control, upstream).await
+}
+
+async fn serve_socks_udp_with_upstream<C, U>(mut control: C, mut upstream: U) -> std::io::Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+    U: AsyncRead + AsyncWrite + Unpin,
+{
+    let udp = tokio::net::UdpSocket::bind("127.0.0.1:0").await?;
+    let port = udp.local_addr()?.port();
+    control
+        .write_all(&[SOCKS5, REP_SUCCESS, 0, ATYP_IPV4, 127, 0, 0, 1])
+        .await?;
+    control.write_all(&port.to_be_bytes()).await?;
+    control.flush().await?;
+
+    let mut udp_buffer = vec![0_u8; socks5_udp::MAX_DATAGRAM_BYTES];
+    let mut control_buffer = [0_u8; 1];
+    let mut last_peer = None;
+
+    loop {
+        tokio::select! {
+            result = udp.recv_from(&mut udp_buffer) => {
+                let (length, peer) = result?;
+                let packet = match Datagram::decode(&udp_buffer[..length]) {
+                    Ok(packet) => packet,
+                    Err(_) => continue,
+                };
+                let frame = packet
+                    .encode()
+                    .map_err(|_| invalid_udp("UDP datagram is too large"))?;
+                write_udp_frame(&mut upstream, &frame).await?;
+                last_peer = Some(peer);
+            }
+            result = read_udp_frame(&mut upstream) => {
+                let Some(frame) = result? else { return Ok(()); };
+                let packet = match Datagram::decode(&frame) {
+                    Ok(packet) => packet,
+                    Err(_) => continue,
+                };
+                if let Some(peer) = last_peer {
+                    udp.send_to(&packet.payload, peer).await?;
+                }
+            }
+            result = control.read(&mut control_buffer) => {
+                if result? == 0 {
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+
+async fn read_udp_frame<S>(stream: &mut S) -> std::io::Result<Option<Vec<u8>>>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut length = [0_u8; 2];
+    match stream.read_exact(&mut length).await {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(error) => return Err(error),
+    }
+    let length = usize::from(u16::from_be_bytes(length));
+    if length == 0 || length > socks5_udp::MAX_DATAGRAM_BYTES {
+        return Err(invalid_udp("invalid UDP frame length"));
+    }
+    let mut frame = vec![0_u8; length];
+    stream.read_exact(&mut frame).await?;
+    Ok(Some(frame))
+}
+
+async fn write_udp_frame<S>(stream: &mut S, frame: &[u8]) -> std::io::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let length = u16::try_from(frame.len()).map_err(|_| invalid_udp("UDP frame is too large"))?;
+    stream.write_all(&length.to_be_bytes()).await?;
+    stream.write_all(frame).await?;
+    stream.flush().await
+}
+
+fn invalid_udp(message: &str) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, message.to_string())
 }
 
 /// Which client-facing proxy reply flavour a completed CONNECT-style session
@@ -884,6 +1001,115 @@ mod tests {
         let mut buf = [0u8; 10];
         client.read_exact(&mut buf).await.unwrap();
         assert_eq!(buf[1], REP_CMD_NOT_SUPPORTED);
+    }
+
+    #[tokio::test]
+    async fn udp_associate_frames_datagrams_over_the_upstream() {
+        let (mut client, control) = tokio::io::duplex(4096);
+        let (upstream, mut upstream_side) = tokio::io::duplex(4096);
+        let task = tokio::spawn(async move {
+            let mut control = control;
+            assert_eq!(
+                read_route(&mut control).await.expect("read UDP route"),
+                ProxyRoute::SocksUdpAssociate
+            );
+            serve_socks_udp_with_upstream(control, upstream)
+                .await
+                .expect("UDP relay succeeds");
+        });
+
+        client
+            .write_all(&[
+                SOCKS5,
+                1,
+                METHOD_NO_AUTH,
+                SOCKS5,
+                CMD_UDP_ASSOCIATE,
+                0,
+                ATYP_IPV4,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ])
+            .await
+            .expect("write associate request");
+
+        let mut selection = [0_u8; 2];
+        client
+            .read_exact(&mut selection)
+            .await
+            .expect("method reply");
+        assert_eq!(selection, [SOCKS5, METHOD_NO_AUTH]);
+        let mut association = [0_u8; 10];
+        client
+            .read_exact(&mut association)
+            .await
+            .expect("associate reply");
+        assert_eq!(association[..4], [SOCKS5, REP_SUCCESS, 0, ATYP_IPV4]);
+        let relay_port = u16::from_be_bytes([association[8], association[9]]);
+
+        let socket = tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("bind UDP client");
+        let packet = Datagram {
+            address: mvm_core::socks5_udp::Address::Ip("192.0.2.1".parse().expect("valid address")),
+            port: 5353,
+            payload: b"query".to_vec(),
+        };
+        let encoded = packet.encode().expect("encode packet");
+        socket
+            .send_to(&encoded, ("127.0.0.1", relay_port))
+            .await
+            .expect("send UDP packet");
+
+        let mut length = [0_u8; 2];
+        upstream_side
+            .read_exact(&mut length)
+            .await
+            .expect("upstream frame length");
+        let mut frame = vec![0_u8; usize::from(u16::from_be_bytes(length))];
+        upstream_side
+            .read_exact(&mut frame)
+            .await
+            .expect("upstream frame");
+        assert_eq!(Datagram::decode(&frame).expect("decode frame"), packet);
+
+        let response = Datagram {
+            address: mvm_core::socks5_udp::Address::Ip("192.0.2.1".parse().expect("valid address")),
+            port: 5353,
+            payload: b"answer".to_vec(),
+        }
+        .encode()
+        .expect("encode response");
+        upstream_side
+            .write_all(
+                &u16::try_from(response.len())
+                    .expect("response fits")
+                    .to_be_bytes(),
+            )
+            .await
+            .expect("response length");
+        upstream_side
+            .write_all(&response)
+            .await
+            .expect("response frame");
+
+        let mut received = [0_u8; 32];
+        let (length, _) = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            socket.recv_from(&mut received),
+        )
+        .await
+        .expect("UDP response timeout")
+        .expect("UDP response");
+        assert_eq!(&received[..length], b"answer");
+
+        drop(client);
+        drop(upstream_side);
+        task.await.expect("relay joins");
     }
 
     #[tokio::test]

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -97,6 +97,8 @@ pub mod residency;
 /// Hardened snapshot frame v0: cap-bounded, fail-closed parsing of the
 /// snapshot container mvm controls (eager-CoW / raw-hypervisor path).
 pub mod snapshot_frame;
+/// Shared SOCKS5 UDP datagram wire codec for the guest proxy and host relay.
+pub mod socks5_udp;
 /// The guest↔host substitution-endpoint wire contract, shared so the
 /// in-guest client and the host server serialize identical bytes.
 pub mod substitution_wire;

--- a/crates/mvm-core/src/socks5_udp.rs
+++ b/crates/mvm-core/src/socks5_udp.rs
@@ -1,0 +1,235 @@
+//! SOCKS5 UDP datagrams shared by the guest proxy and host relay.
+
+use std::net::IpAddr;
+
+/// First-line marker selecting the SOCKS5 UDP relay on the shared egress stream.
+pub const FRAME_LINE: &str = "MVM_SOCKS5_UDP/1";
+/// Maximum SOCKS5 UDP datagram payload accepted by the relay.
+pub const MAX_DATAGRAM_BYTES: usize = 65_535;
+
+/// An address carried by a SOCKS5 UDP datagram.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Address {
+    /// A numeric IPv4 or IPv6 destination.
+    Ip(IpAddr),
+    /// A hostname that the host resolves and admits.
+    Domain(String),
+}
+
+impl Address {
+    /// Render the address and port in the host egress gate's target format.
+    pub fn target(&self, port: u16) -> String {
+        match self {
+            Self::Ip(ip) => match ip {
+                IpAddr::V4(_) => format!("{ip}:{port}"),
+                IpAddr::V6(_) => format!("[{ip}]:{port}"),
+            },
+            Self::Domain(host) => format!("{host}:{port}"),
+        }
+    }
+}
+
+/// One RFC 1928 §7 SOCKS5 UDP datagram.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Datagram {
+    /// The destination or source address in the SOCKS5 envelope.
+    pub address: Address,
+    /// The destination or source UDP port.
+    pub port: u16,
+    /// The application payload.
+    pub payload: Vec<u8>,
+}
+
+impl Datagram {
+    /// Decode a SOCKS5 UDP datagram. Fragmented datagrams are rejected because
+    /// the relay does not retain unbounded reassembly state.
+    pub fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+        if bytes.len() < 4 {
+            return Err(DecodeError::TooShort);
+        }
+        if bytes[0] != 0 || bytes[1] != 0 {
+            return Err(DecodeError::InvalidReserved);
+        }
+        if bytes[2] != 0 {
+            return Err(DecodeError::Fragmented);
+        }
+
+        let mut cursor: usize = 4;
+        let address = match bytes[3] {
+            0x01 => {
+                let end = cursor.checked_add(4).ok_or(DecodeError::TooShort)?;
+                let octets: [u8; 4] = bytes
+                    .get(cursor..end)
+                    .ok_or(DecodeError::TooShort)?
+                    .try_into()
+                    .map_err(|_| DecodeError::TooShort)?;
+                cursor = end;
+                Address::Ip(IpAddr::from(octets))
+            }
+            0x03 => {
+                let length = usize::from(*bytes.get(cursor).ok_or(DecodeError::TooShort)?);
+                cursor += 1;
+                if length == 0 {
+                    return Err(DecodeError::EmptyDomain);
+                }
+                let end = cursor.checked_add(length).ok_or(DecodeError::TooShort)?;
+                let host =
+                    std::str::from_utf8(bytes.get(cursor..end).ok_or(DecodeError::TooShort)?)
+                        .map_err(|_| DecodeError::InvalidDomain)?
+                        .to_string();
+                cursor = end;
+                Address::Domain(host)
+            }
+            0x04 => {
+                let end = cursor.checked_add(16).ok_or(DecodeError::TooShort)?;
+                let octets: [u8; 16] = bytes
+                    .get(cursor..end)
+                    .ok_or(DecodeError::TooShort)?
+                    .try_into()
+                    .map_err(|_| DecodeError::TooShort)?;
+                cursor = end;
+                Address::Ip(IpAddr::from(octets))
+            }
+            _ => return Err(DecodeError::UnknownAddressType),
+        };
+
+        let port_end = cursor.checked_add(2).ok_or(DecodeError::TooShort)?;
+        let port_bytes = bytes.get(cursor..port_end).ok_or(DecodeError::TooShort)?;
+        let port = u16::from_be_bytes(port_bytes.try_into().map_err(|_| DecodeError::TooShort)?);
+        let payload = bytes.get(port_end..).ok_or(DecodeError::TooShort)?.to_vec();
+        Ok(Self {
+            address,
+            port,
+            payload,
+        })
+    }
+
+    /// Encode this datagram in RFC 1928 §7 wire form.
+    pub fn encode(&self) -> Result<Vec<u8>, EncodeError> {
+        let (atyp, address_bytes) = match &self.address {
+            Address::Ip(IpAddr::V4(ip)) => (0x01, ip.octets().to_vec()),
+            Address::Ip(IpAddr::V6(ip)) => (0x04, ip.octets().to_vec()),
+            Address::Domain(host) => {
+                let length = u8::try_from(host.len()).map_err(|_| EncodeError::DomainTooLong)?;
+                if length == 0 {
+                    return Err(EncodeError::EmptyDomain);
+                }
+                if !host.is_ascii() {
+                    return Err(EncodeError::DomainNotAscii);
+                }
+                let mut bytes = Vec::with_capacity(1 + host.len());
+                bytes.push(length);
+                bytes.extend_from_slice(host.as_bytes());
+                (0x03, bytes)
+            }
+        };
+        let overhead = 4 + address_bytes.len() + 2;
+        let length = overhead
+            .checked_add(self.payload.len())
+            .ok_or(EncodeError::DatagramTooLarge)?;
+        if length > MAX_DATAGRAM_BYTES {
+            return Err(EncodeError::DatagramTooLarge);
+        }
+        let mut bytes = Vec::with_capacity(length);
+        bytes.extend_from_slice(&[0, 0, 0, atyp]);
+        bytes.extend_from_slice(&address_bytes);
+        bytes.extend_from_slice(&self.port.to_be_bytes());
+        bytes.extend_from_slice(&self.payload);
+        Ok(bytes)
+    }
+}
+
+/// A malformed SOCKS5 UDP datagram.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecodeError {
+    /// The datagram does not contain the required header and address fields.
+    TooShort,
+    /// The reserved bytes were not zero.
+    InvalidReserved,
+    /// Fragmentation is not supported.
+    Fragmented,
+    /// The address type is not IPv4, domain, or IPv6.
+    UnknownAddressType,
+    /// The domain field was empty.
+    EmptyDomain,
+    /// The domain field was not UTF-8.
+    InvalidDomain,
+}
+
+/// An unrepresentable SOCKS5 UDP datagram.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncodeError {
+    /// The domain field is empty.
+    EmptyDomain,
+    /// The domain field is not ASCII, as required by the SOCKS5 wire format.
+    DomainNotAscii,
+    /// The domain field exceeds its one-byte length prefix.
+    DomainTooLong,
+    /// The encoded datagram exceeds the relay's cap.
+    DatagramTooLarge,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ipv4_datagram_roundtrips() {
+        let datagram = Datagram {
+            address: Address::Ip("192.0.2.10".parse().expect("valid test address")),
+            port: 5353,
+            payload: b"hello".to_vec(),
+        };
+        assert_eq!(
+            Datagram::decode(&datagram.encode().expect("encodes")),
+            Ok(datagram)
+        );
+    }
+
+    #[test]
+    fn domain_datagram_roundtrips_and_formats_target() {
+        let datagram = Datagram {
+            address: Address::Domain("example.test".to_string()),
+            port: 443,
+            payload: vec![1, 2, 3],
+        };
+        assert_eq!(datagram.address.target(443), "example.test:443");
+        assert_eq!(
+            Datagram::decode(&datagram.encode().expect("encodes")),
+            Ok(datagram)
+        );
+    }
+
+    #[test]
+    fn rejects_reserved_fragment_and_unknown_address() {
+        assert_eq!(
+            Datagram::decode(&[1, 0, 0, 1]),
+            Err(DecodeError::InvalidReserved)
+        );
+        assert_eq!(
+            Datagram::decode(&[0, 0, 1, 1]),
+            Err(DecodeError::Fragmented)
+        );
+        assert_eq!(
+            Datagram::decode(&[0, 0, 0, 9]),
+            Err(DecodeError::UnknownAddressType)
+        );
+    }
+
+    #[test]
+    fn rejects_oversized_payload_and_non_ascii_domain() {
+        let oversized = Datagram {
+            address: Address::Ip("192.0.2.1".parse().expect("valid test address")),
+            port: 7,
+            payload: vec![0; MAX_DATAGRAM_BYTES],
+        };
+        assert_eq!(oversized.encode(), Err(EncodeError::DatagramTooLarge));
+
+        let non_ascii = Datagram {
+            address: Address::Domain("exämple.test".to_string()),
+            port: 7,
+            payload: Vec::new(),
+        };
+        assert_eq!(non_ascii.encode(), Err(EncodeError::DomainNotAscii));
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/mod.rs
@@ -87,6 +87,8 @@ pub mod reversible_replacement_resolve;
 /// audit events (claim 13: metadata only, never the secret value).
 pub mod secret_audit;
 pub mod secrets_scanner;
+/// Policy-gated SOCKS5 UDP Associate relay over the egress vsock stream.
+pub mod socks5_udp;
 /// The per-VM substitution endpoint subprocess library half: the
 /// stdin config contract + store-opening/service assembly. The
 /// `mvm-substitution-endpoint` bin is the process wrapper.

--- a/crates/mvm-hostd/src/supervisor/raw_egress.rs
+++ b/crates/mvm-hostd/src/supervisor/raw_egress.rs
@@ -30,7 +30,7 @@ use hickory_proto::serialize::binary::{BinDecodable, BinEncodable, BinEncoder};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::supervisor::audit_recorder::Recorder;
-use crate::supervisor::{dns_handler, http_forward};
+use crate::supervisor::{dns_handler, http_forward, socks5_udp};
 use mvm_core::guest_netd::ConnectAck;
 use mvm_runtime::vmm::egress_gate::{EgressGate, EgressVerdict};
 
@@ -100,6 +100,9 @@ where
     if target == dns_handler::FRAME_LINE {
         return dns_handler::serve_dns(guest, gate, recorder.as_deref(), &rate_guard, timeout)
             .await;
+    }
+    if target == socks5_udp::FRAME_LINE {
+        return socks5_udp::serve(guest, gate, timeout).await;
     }
     match gate.decide_request_with(&target, |host| resolve_hostname_ips_pure(host, timeout)) {
         EgressVerdict::Allow { ips, port } => {
@@ -285,6 +288,9 @@ fn handle_raw_conn_blocking(
             &rate_guard,
             timeout,
         );
+    }
+    if target == socks5_udp::FRAME_LINE {
+        return socks5_udp::serve_blocking(guest, gate, timeout);
     }
     let (ips, port) =
         match gate.decide_request_with(&target, |host| resolve_hostname_ips_pure(host, timeout)) {
@@ -550,7 +556,7 @@ fn shutdown_write(fd: libc::c_int) -> std::io::Result<()> {
 }
 
 #[cfg(target_os = "linux")]
-pub(super) fn resolve_hostname_ips_pure(
+pub(crate) fn resolve_hostname_ips_pure(
     host: &str,
     timeout: Duration,
 ) -> std::io::Result<Vec<IpAddr>> {
@@ -580,7 +586,7 @@ pub(super) fn resolve_hostname_ips_pure(
 }
 
 #[cfg(not(target_os = "linux"))]
-pub(super) fn resolve_hostname_ips_pure(
+pub(crate) fn resolve_hostname_ips_pure(
     host: &str,
     timeout: Duration,
 ) -> std::io::Result<Vec<IpAddr>> {

--- a/crates/mvm-hostd/src/supervisor/socks5_udp.rs
+++ b/crates/mvm-hostd/src/supervisor/socks5_udp.rs
@@ -1,0 +1,350 @@
+//! Policy-gated SOCKS5 UDP Associate relay over the egress vsock stream.
+
+use std::future::Future;
+use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
+
+#[cfg(target_os = "linux")]
+use std::io::{Read, Write};
+
+use mvm_core::socks5_udp::{self, Address, Datagram};
+use mvm_runtime::vmm::egress_gate::{EgressGate, EgressVerdict};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use crate::supervisor::raw_egress;
+
+/// First-line marker selecting the SOCKS5 UDP relay on the shared egress stream.
+pub const FRAME_LINE: &str = mvm_core::socks5_udp::FRAME_LINE;
+
+/// Serve one SOCKS5 UDP association over an asynchronous egress stream.
+pub async fn serve<S>(mut guest: S, gate: &EgressGate, timeout: Duration) -> std::io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let ipv4 = tokio::net::UdpSocket::bind("0.0.0.0:0").await?;
+    let ipv6 = tokio::net::UdpSocket::bind("[::]:0").await.ok();
+    while let Some(frame) = read_frame_async(&mut guest, timeout).await? {
+        let packet = Datagram::decode(&frame).map_err(invalid_datagram)?;
+        let Some(response) = relay_async(&packet, gate, &ipv4, ipv6.as_ref(), timeout).await?
+        else {
+            continue;
+        };
+        write_frame_async(&mut guest, &response, timeout).await?;
+    }
+    Ok(())
+}
+
+async fn relay_async(
+    packet: &Datagram,
+    gate: &EgressGate,
+    ipv4: &tokio::net::UdpSocket,
+    ipv6: Option<&tokio::net::UdpSocket>,
+    timeout: Duration,
+) -> std::io::Result<Option<Vec<u8>>> {
+    let target = packet.address.target(packet.port);
+    let (ips, port) = match gate.decide_udp_request_with(&target, |host| {
+        raw_egress::resolve_hostname_ips_pure(host, timeout)
+    }) {
+        EgressVerdict::Allow { ips, port } => (ips, port),
+        EgressVerdict::Deny | EgressVerdict::Malformed => return Ok(None),
+    };
+
+    let mut sent = false;
+    for ip in &ips {
+        let destination = SocketAddr::new(*ip, port);
+        let socket = match ip {
+            IpAddr::V4(_) => ipv4,
+            IpAddr::V6(_) => match ipv6 {
+                Some(socket) => socket,
+                None => continue,
+            },
+        };
+        socket.send_to(&packet.payload, destination).await?;
+        sent = true;
+    }
+    if !sent {
+        return Ok(None);
+    }
+
+    let response =
+        match tokio::time::timeout(timeout, receive_matching_async(ipv4, ipv6, &ips, port)).await {
+            Ok(response) => response?,
+            Err(_) => return Ok(None),
+        };
+    Ok(response.map(|(payload, source)| {
+        Datagram {
+            address: Address::Ip(source.ip()),
+            port: source.port(),
+            payload,
+        }
+        .encode()
+        .expect("socket addresses always encode")
+    }))
+}
+
+async fn receive_matching_async(
+    ipv4: &tokio::net::UdpSocket,
+    ipv6: Option<&tokio::net::UdpSocket>,
+    ips: &[IpAddr],
+    port: u16,
+) -> std::io::Result<Option<(Vec<u8>, SocketAddr)>> {
+    let mut ipv4_buffer = vec![0_u8; socks5_udp::MAX_DATAGRAM_BYTES];
+    let mut ipv6_buffer = vec![0_u8; socks5_udp::MAX_DATAGRAM_BYTES];
+    loop {
+        let received = match ipv6 {
+            Some(ipv6) => {
+                tokio::select! {
+                    result = ipv4.recv_from(&mut ipv4_buffer) => {
+                        let (length, source) = result?;
+                        (length, source, &ipv4_buffer)
+                    },
+                    result = ipv6.recv_from(&mut ipv6_buffer) => {
+                        let (length, source) = result?;
+                        (length, source, &ipv6_buffer)
+                    },
+                }
+            }
+            None => {
+                let (length, source) = ipv4.recv_from(&mut ipv4_buffer).await?;
+                (length, source, &ipv4_buffer)
+            }
+        };
+        let (length, source, buffer) = received;
+        if source.port() == port && ips.iter().any(|ip| *ip == source.ip()) {
+            return Ok(Some((buffer[..length].to_vec(), source)));
+        }
+    }
+}
+
+/// Serve one SOCKS5 UDP association over a blocking AF_VSOCK stream.
+#[cfg(target_os = "linux")]
+pub fn serve_blocking(
+    mut guest: std::fs::File,
+    gate: &EgressGate,
+    timeout: Duration,
+) -> std::io::Result<()> {
+    let ipv4 = std::net::UdpSocket::bind("0.0.0.0:0")?;
+    ipv4.set_read_timeout(Some(timeout))?;
+    ipv4.set_write_timeout(Some(timeout))?;
+    let ipv6 = std::net::UdpSocket::bind("[::]:0").ok();
+    if let Some(socket) = &ipv6 {
+        socket.set_read_timeout(Some(timeout))?;
+        socket.set_write_timeout(Some(timeout))?;
+    }
+    while let Some(frame) = read_frame_blocking(&mut guest)? {
+        let packet = Datagram::decode(&frame).map_err(invalid_datagram)?;
+        let Some(response) = relay_blocking(&packet, gate, &ipv4, ipv6.as_ref(), timeout)? else {
+            continue;
+        };
+        write_frame_blocking(&mut guest, &response)?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn relay_blocking(
+    packet: &Datagram,
+    gate: &EgressGate,
+    ipv4: &std::net::UdpSocket,
+    ipv6: Option<&std::net::UdpSocket>,
+    timeout: Duration,
+) -> std::io::Result<Option<Vec<u8>>> {
+    let target = packet.address.target(packet.port);
+    let (ips, port) = match gate.decide_udp_request_with(&target, |host| {
+        raw_egress::resolve_hostname_ips_pure(host, timeout)
+    }) {
+        EgressVerdict::Allow { ips, port } => (ips, port),
+        EgressVerdict::Deny | EgressVerdict::Malformed => return Ok(None),
+    };
+    let mut selected = None;
+    for ip in &ips {
+        let socket = match ip {
+            IpAddr::V4(_) => ipv4,
+            IpAddr::V6(_) => match ipv6 {
+                Some(socket) => socket,
+                None => continue,
+            },
+        };
+        socket.send_to(&packet.payload, SocketAddr::new(*ip, port))?;
+        selected = Some((socket, *ip));
+    }
+    let Some((socket, expected_ip)) = selected else {
+        return Ok(None);
+    };
+    let mut buffer = vec![0_u8; socks5_udp::MAX_DATAGRAM_BYTES];
+    loop {
+        let (length, source) = match socket.recv_from(&mut buffer) {
+            Ok(received) => received,
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+                ) =>
+            {
+                return Ok(None);
+            }
+            Err(error) => return Err(error),
+        };
+        if source.ip() == expected_ip && source.port() == port {
+            let response = Datagram {
+                address: Address::Ip(source.ip()),
+                port: source.port(),
+                payload: buffer[..length].to_vec(),
+            }
+            .encode()
+            .expect("socket addresses always encode");
+            return Ok(Some(response));
+        }
+    }
+}
+
+async fn read_frame_async<S>(stream: &mut S, timeout: Duration) -> std::io::Result<Option<Vec<u8>>>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut length = [0_u8; 2];
+    match stream.read_exact(&mut length).await {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(error) => return Err(error),
+    }
+    let length = usize::from(u16::from_be_bytes(length));
+    if length == 0 || length > socks5_udp::MAX_DATAGRAM_BYTES {
+        return Err(invalid_frame());
+    }
+    let mut frame = vec![0_u8; length];
+    with_timeout(timeout, stream.read_exact(&mut frame)).await?;
+    Ok(Some(frame))
+}
+
+async fn write_frame_async<S>(
+    stream: &mut S,
+    frame: &[u8],
+    timeout: Duration,
+) -> std::io::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let length = u16::try_from(frame.len()).map_err(|_| invalid_frame())?;
+    with_timeout(timeout, stream.write_all(&length.to_be_bytes())).await?;
+    with_timeout(timeout, stream.write_all(frame)).await?;
+    with_timeout(timeout, stream.flush()).await
+}
+
+#[cfg(target_os = "linux")]
+fn read_frame_blocking(stream: &mut std::fs::File) -> std::io::Result<Option<Vec<u8>>> {
+    let mut length = [0_u8; 2];
+    match stream.read_exact(&mut length) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(error) => return Err(error),
+    }
+    let length = usize::from(u16::from_be_bytes(length));
+    if length == 0 || length > socks5_udp::MAX_DATAGRAM_BYTES {
+        return Err(invalid_frame());
+    }
+    let mut frame = vec![0_u8; length];
+    stream.read_exact(&mut frame)?;
+    Ok(Some(frame))
+}
+
+#[cfg(target_os = "linux")]
+fn write_frame_blocking(stream: &mut std::fs::File, frame: &[u8]) -> std::io::Result<()> {
+    let length = u16::try_from(frame.len()).map_err(|_| invalid_frame())?;
+    stream.write_all(&length.to_be_bytes())?;
+    stream.write_all(frame)?;
+    stream.flush()
+}
+
+async fn with_timeout<T>(
+    timeout: Duration,
+    operation: impl Future<Output = std::io::Result<T>>,
+) -> std::io::Result<T> {
+    tokio::time::timeout(timeout, operation)
+        .await
+        .map_err(|_| timed_out())?
+}
+
+fn invalid_datagram(_error: socks5_udp::DecodeError) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "malformed SOCKS5 UDP datagram",
+    )
+}
+
+fn invalid_frame() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "invalid SOCKS5 UDP frame length",
+    )
+}
+
+fn timed_out() -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::TimedOut, "SOCKS5 UDP relay timed out")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::policy::projection::CanonicalEgress;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn exchange(client: &mut tokio::io::DuplexStream, packet: &Datagram) -> Option<Datagram> {
+        let frame = packet.encode().expect("test packet encodes");
+        client
+            .write_all(
+                &u16::try_from(frame.len())
+                    .expect("test frame fits")
+                    .to_be_bytes(),
+            )
+            .await
+            .expect("write length");
+        client.write_all(&frame).await.expect("write frame");
+        let mut length = [0_u8; 2];
+        match tokio::time::timeout(Duration::from_millis(200), client.read_exact(&mut length)).await
+        {
+            Ok(Ok(_)) => {}
+            Ok(Err(_)) | Err(_) => return None,
+        }
+        let mut response = vec![0_u8; usize::from(u16::from_be_bytes(length))];
+        client
+            .read_exact(&mut response)
+            .await
+            .expect("read response");
+        Some(Datagram::decode(&response).expect("response decodes"))
+    }
+
+    #[tokio::test]
+    async fn default_deny_drops_udp_without_host_send() {
+        let gate = EgressGate::default_deny();
+        let (mut client, server) = tokio::io::duplex(4096);
+        let task =
+            tokio::spawn(async move { serve(server, &gate, Duration::from_millis(100)).await });
+        let packet = Datagram {
+            address: Address::Ip("192.0.2.1".parse().expect("valid address")),
+            port: 5353,
+            payload: b"query".to_vec(),
+        };
+        assert!(exchange(&mut client, &packet).await.is_none());
+        drop(client);
+        task.await
+            .expect("handler joins")
+            .expect("handler succeeds");
+    }
+
+    #[tokio::test]
+    async fn malformed_frame_fails_closed() {
+        let gate = EgressGate::new(CanonicalEgress::Unrestricted);
+        let (mut client, server) = tokio::io::duplex(32);
+        let task = tokio::spawn(async move { serve(server, &gate, Duration::from_secs(1)).await });
+        client
+            .write_all(&[0, 3, 0, 0, 0])
+            .await
+            .expect("write malformed");
+        let error = task
+            .await
+            .expect("handler joins")
+            .expect_err("rejects malformed");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    }
+}

--- a/crates/mvm-runtime/src/compat.rs
+++ b/crates/mvm-runtime/src/compat.rs
@@ -10,9 +10,10 @@
 //! - **Libkrun**: `crates/mvm-libkrun/src/sys.rs` FFI mapping;
 //!   `crates/mvm-runtime/src/libkrun.rs` `DEFAULT_CMDLINE`; macOS-only so
 //!   `console=hvc0`; no jailer or snapshots (host process == supervisor).
-//! - **Qemu**: no implementation yet; capabilities are conventional QEMU
-//!   defaults for the mvm workload shape (ELF/Image per arch, ext4 rootfs,
-//!   TAP networking, snapshots, no jailer). Flagged with `// assumption`.
+//! - **Qemu**: the dev/test backend in `crates/mvm-runtime/src/qemu.rs` uses
+//!   QEMU's unprivileged user-mode virtio network (`-netdev user`), not a host
+//!   TAP device. It provides transparent guest TCP/UDP for the dev tier; it
+//!   is not part of the production claim boundary.
 //!
 //! `MicrovmBackend` has no `Hvf` variant yet (the removed Vz backend's row
 //! was deleted rather than repurposed); the raw HVF backend
@@ -133,23 +134,18 @@ static LIBKRUN: BackendCompat = BackendCompat {
     networking: NetworkingModel::None,
 };
 
-// Qemu: no implementation yet. Capabilities are conventional QEMU defaults
-// for the mvm workload shape. All fields are marked // assumption below.
-// x86_64: ELF vmlinux or bzImage (Raw accepted as generic blob);  // assumption
-// aarch64: uncompressed arm64 Image or ELF vmlinux;               // assumption
-// ext4 rootfs; TAP networking; snapshots; no jailer (FC-specific). // assumption
+// QEMU is the Linux dev/test substrate. Its user-mode virtio network gives the
+// guest an ordinary NIC without requiring a host TAP, bridge, or firewall
+// setup. It remains outside the production egress claim boundary.
 static QEMU: BackendCompat = BackendCompat {
     backend: MicrovmBackend::Qemu,
-    guest_arches: &[X86_64, Aarch64], // assumption: QEMU supports both
-    kernel_formats: &[
-        (X86_64, &[K::Elf, K::Raw]), // assumption: vmlinux ELF or bzImage (Raw)
-        (Aarch64, &[K::Image, K::Elf]), // assumption: arm64 Image or vmlinux
-    ],
-    rootfs_formats: &[R::Ext4, R::Raw],     // assumption
-    required_boot_args: &["console=ttyS0"], // assumption: ttyS0 for QEMU serial
-    supports_snapshots: true,               // assumption: QEMU supports savevm/loadvm
-    supports_jailer: false,                 // assumption: no FC jailer; QEMU has own isolation
-    networking: NetworkingModel::Tap,       // assumption: QEMU standard TAP
+    guest_arches: &[X86_64, Aarch64],
+    kernel_formats: &[(X86_64, &[K::Elf, K::Raw]), (Aarch64, &[K::Image, K::Elf])],
+    rootfs_formats: &[R::Ext4, R::Raw],
+    required_boot_args: &["console=ttyS0"],
+    supports_snapshots: false,
+    supports_jailer: false,
+    networking: NetworkingModel::UserModeVirtio,
 };
 
 // ── lookup ────────────────────────────────────────────────────────────────────
@@ -215,6 +211,14 @@ mod tests {
         for b in [MicrovmBackend::Libkrun, MicrovmBackend::Qemu] {
             assert!(!compat(b).supports_jailer, "{b:?} should not have jailer");
         }
+    }
+
+    #[test]
+    fn qemu_uses_rootless_user_mode_virtio_networking() {
+        let c = compat(MicrovmBackend::Qemu);
+        assert_eq!(c.networking, NetworkingModel::UserModeVirtio);
+        assert!(!c.supports_snapshots);
+        assert!(!c.supports_jailer);
     }
 
     #[test]

--- a/crates/mvm-runtime/src/qemu.rs
+++ b/crates/mvm-runtime/src/qemu.rs
@@ -61,6 +61,17 @@ const BRIDGE_SOCKET_TIMEOUT: Duration = Duration::from_secs(5);
 /// SIGTERM→SIGKILL grace on `stop`.
 const STOP_TIMEOUT: Duration = Duration::from_secs(3);
 
+/// QEMU's unprivileged user-mode network gives dev/test guests transparent
+/// TCP and UDP without requiring a host TAP device or elevated setup.
+fn qemu_user_network_args() -> [&'static str; 4] {
+    [
+        "-netdev",
+        "user,id=n0",
+        "-device",
+        "virtio-net-pci,netdev=n0",
+    ]
+}
+
 /// Per-VM file names under `vm_state_dir(name)`.
 const QEMU_PID_FILE: &str = "qemu.pid";
 const QEMU_LOG_FILE: &str = "qemu.log";
@@ -334,12 +345,7 @@ impl VmBackend for QemuBackend {
         cmd.arg("-device")
             .arg(format!("vhost-vsock-pci,guest-cid={cid}"));
         // User-mode (slirp) networking — no root, no TAP.
-        cmd.args([
-            "-netdev",
-            "user,id=n0",
-            "-device",
-            "virtio-net-pci,netdev=n0",
-        ]);
+        cmd.args(qemu_user_network_args());
         cmd.args(["-display", "none", "-monitor", "none", "-no-reboot"]);
         cmd.arg("-serial")
             .arg(format!("file:{}", console_log.display()));
@@ -951,6 +957,19 @@ mod tests {
         assert!(!c.pause_resume);
         assert!(!c.snapshots);
         assert!(!c.tap_networking);
+    }
+
+    #[test]
+    fn qemu_user_network_is_rootless_and_transparent() {
+        assert_eq!(
+            qemu_user_network_args(),
+            [
+                "-netdev",
+                "user,id=n0",
+                "-device",
+                "virtio-net-pci,netdev=n0",
+            ]
+        );
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
+++ b/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
@@ -21,9 +21,10 @@ use mvm_core::protocol::dns::DnsRecordType;
 /// Outcome of an egress request.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EgressVerdict {
-    /// The plan permits a TCP connection to this destination. `ips` are every
-    /// admitted address (a pinned host can carry both an A and an AAAA record),
-    /// IPv4 first; the caller connects to them in order, first success wins.
+    /// The plan permits traffic to this destination. `ips` are every admitted
+    /// address (a pinned host can carry both an A and an AAAA record), IPv4
+    /// first; stream callers connect to them in order, while datagram callers
+    /// may send to each and accept the first valid response.
     Allow { ips: Vec<IpAddr>, port: u16 },
     /// Refused — policy did not admit it (claim-10 default-deny / mandatory-deny).
     Deny,
@@ -103,17 +104,12 @@ impl EgressGate {
     /// hostname path already gets. Every offered address is independently
     /// policy-checked, so widening the set never admits an unpinned target.
     pub fn decide_addr(&self, ip: IpAddr, port: u16) -> EgressVerdict {
-        if !self.egress.permits(&Proto::Tcp, ip, port) {
-            return EgressVerdict::Deny;
-        }
-        let ips = match self.pins.pin_containing(&ip) {
-            Some(pin) => admitted_ips(&self.egress, &pin.ips, port),
-            None => Vec::new(),
-        };
-        // No pin (or a pin that admitted nothing for this port) ⇒ keep just the
-        // requested address, which the guard above already confirmed admitted.
-        let ips = if ips.is_empty() { vec![ip] } else { ips };
-        EgressVerdict::Allow { ips, port }
+        self.decide_addr_for_proto(Proto::Tcp, ip, port)
+    }
+
+    /// Decide a UDP datagram to an already-resolved address.
+    pub fn decide_udp_addr(&self, ip: IpAddr, port: u16) -> EgressVerdict {
+        self.decide_addr_for_proto(Proto::Udp, ip, port)
     }
 
     /// Decide a guest connect request — either a numeric `"<ip>:<port>"` or a
@@ -132,23 +128,63 @@ impl EgressGate {
     where
         F: Fn(&str) -> std::io::Result<Vec<IpAddr>>,
     {
+        self.decide_request_with_proto(Proto::Tcp, target, resolve)
+    }
+
+    /// Decide a UDP datagram request, resolving hostnames on the host side.
+    pub fn decide_udp_request_with<F>(&self, target: &str, resolve: F) -> EgressVerdict
+    where
+        F: Fn(&str) -> std::io::Result<Vec<IpAddr>>,
+    {
+        self.decide_request_with_proto(Proto::Udp, target, resolve)
+    }
+
+    /// Decide a UDP datagram request using the host resolver.
+    pub fn decide_udp_request(&self, target: &str) -> EgressVerdict {
+        self.decide_udp_request_with(target, resolve_hostname_ips)
+    }
+
+    fn decide_addr_for_proto(&self, proto: Proto, ip: IpAddr, port: u16) -> EgressVerdict {
+        if !self.egress.permits(&proto, ip, port) {
+            return EgressVerdict::Deny;
+        }
+        let ips = match self.pins.pin_containing(&ip) {
+            Some(pin) => admitted_ips(&self.egress, &proto, &pin.ips, port),
+            None => Vec::new(),
+        };
+        // No pin (or a pin that admitted nothing for this port) ⇒ keep just the
+        // requested address, which the guard above already confirmed admitted.
+        let ips = if ips.is_empty() { vec![ip] } else { ips };
+        EgressVerdict::Allow { ips, port }
+    }
+
+    fn decide_request_with_proto<F>(&self, proto: Proto, target: &str, resolve: F) -> EgressVerdict
+    where
+        F: Fn(&str) -> std::io::Result<Vec<IpAddr>>,
+    {
         let target = target.trim();
         // Numeric ip:port — decide directly.
         if let Ok(addr) = target.parse::<SocketAddr>() {
-            return self.decide_addr(addr.ip(), addr.port());
+            return self.decide_addr_for_proto(proto, addr.ip(), addr.port());
         }
         // hostname:port — resolve host-side against the pinned set, then policy-check
         // each pinned IP. Admit iff some pinned IP is permitted.
         match target.rsplit_once(':') {
             Some((host, port_str)) => match port_str.parse::<u16>() {
-                Ok(port) => self.decide_hostname_request(host, port, resolve),
+                Ok(port) => self.decide_hostname_request(proto, host, port, resolve),
                 Err(_) => EgressVerdict::Malformed,
             },
             None => EgressVerdict::Malformed,
         }
     }
 
-    fn decide_hostname_request<F>(&self, host: &str, port: u16, resolve: F) -> EgressVerdict
+    fn decide_hostname_request<F>(
+        &self,
+        proto: Proto,
+        host: &str,
+        port: u16,
+        resolve: F,
+    ) -> EgressVerdict
     where
         F: Fn(&str) -> std::io::Result<Vec<IpAddr>>,
     {
@@ -162,7 +198,7 @@ impl EgressGate {
         } else {
             return EgressVerdict::Deny;
         };
-        let ips = admitted_ips(&self.egress, &candidates, port);
+        let ips = admitted_ips(&self.egress, &proto, &candidates, port);
         if ips.is_empty() {
             EgressVerdict::Deny
         } else {
@@ -203,11 +239,16 @@ impl EgressGate {
     }
 }
 
-fn admitted_ips(egress: &CanonicalEgress, candidates: &[IpAddr], port: u16) -> Vec<IpAddr> {
+fn admitted_ips(
+    egress: &CanonicalEgress,
+    proto: &Proto,
+    candidates: &[IpAddr],
+    port: u16,
+) -> Vec<IpAddr> {
     let mut v4 = Vec::new();
     let mut v6 = Vec::new();
     for ip in candidates.iter().copied() {
-        if !egress.permits(&Proto::Tcp, ip, port) {
+        if !egress.permits(proto, ip, port) {
             continue;
         }
         match ip {
@@ -289,9 +330,27 @@ mod tests {
     }
 
     #[test]
+    fn udp_decision_uses_udp_rules_without_widening_tcp() {
+        let gate = EgressGate::new(CanonicalEgress::Rules(vec![CanonicalRule {
+            proto: Proto::Udp,
+            net: "192.0.2.1/32".parse().unwrap(),
+            port_lo: 5353,
+            port_hi: 5353,
+        }]));
+        assert_eq!(
+            gate.decide_udp_request("192.0.2.1:5353"),
+            EgressVerdict::Allow {
+                ips: vec!["192.0.2.1".parse().unwrap()],
+                port: 5353,
+            }
+        );
+        assert_eq!(gate.decide_request("192.0.2.1:5353"), EgressVerdict::Deny);
+    }
+
+    #[test]
     fn unrestricted_hostname_without_pin_resolves_host_side() {
         let gate = EgressGate::new(CanonicalEgress::Unrestricted);
-        let verdict = gate.decide_hostname_request("cache.nixos.org", 443, |_host| {
+        let verdict = gate.decide_hostname_request(Proto::Tcp, "cache.nixos.org", 443, |_host| {
             Ok(vec!["151.101.1.91".parse().unwrap()])
         });
         assert_eq!(
@@ -309,7 +368,7 @@ mod tests {
             "151.101.1.91/32",
             443,
         )]));
-        let verdict = gate.decide_hostname_request("cache.nixos.org", 443, |_host| {
+        let verdict = gate.decide_hostname_request(Proto::Tcp, "cache.nixos.org", 443, |_host| {
             Ok(vec!["151.101.1.91".parse().unwrap()])
         });
         assert_eq!(verdict, EgressVerdict::Deny);
@@ -478,11 +537,11 @@ mod tests {
 
         // Resolver order is v6-first (as a dual-stack host often returns); the
         // unlisted address is dropped and the admitted set is reordered v4-first.
-        let got = admitted_ips(&egress, &[v6, unlisted, v4], 443);
+        let got = admitted_ips(&egress, &Proto::Tcp, &[v6, unlisted, v4], 443);
         assert_eq!(got, vec![v4, v6]);
 
         // Wrong port admits nothing.
-        assert!(admitted_ips(&egress, &[v4, v6], 80).is_empty());
+        assert!(admitted_ips(&egress, &Proto::Tcp, &[v4, v6], 80).is_empty());
     }
 
     #[test]

--- a/public/src/content/docs/guides/networking.md
+++ b/public/src/content/docs/guides/networking.md
@@ -9,20 +9,50 @@ Networking differs by backend:
 
 | Backend | Network Type | Guest IP | Host Access |
 |---------|-------------|----------|-------------|
-| Firecracker (Linux native) | TAP device | 172.16.0.2/30 | Direct via TAP |
-| HVF (macOS 26+, default) | vsock-only | — | Guest I/O over vsock; no guest NIC |
-| libkrun (macOS) | vsock-only | — | Control/data via vsock; egress via the host-side vsock proxy |
-| microvm.nix | TAP device | 172.16.0.2/30 | Direct via TAP |
+| Firecracker (Linux native) | NIC-less vsock egress | — | Host endpoint; default-deny policy gate |
+| HVF (macOS 26+, default) | NIC-less vsock egress | — | Host endpoint; default-deny policy gate |
+| libkrun (macOS) | NIC-less vsock egress | — | Host endpoint; default-deny policy gate |
+| QEMU (Linux dev/test) | Rootless user-mode virtio | 10.0.2.15/24 | QEMU user-mode network; outside production claims |
 
-## Firecracker Network Layout
+## Production Network Layout
 
 ```
-Firecracker microVM (172.16.0.2/30, eth0)
-    | TAP interface (tap0)
-Linux host (172.16.0.1/30, tap0)  --  iptables NAT  --  internet
+MicroVM workload (no guest NIC)
+    | loopback SOCKS5 TCP CONNECT / UDP ASSOCIATE
+    | authenticated vsock egress seam
+Host endpoint -- policy + host DNS -- internet
 ```
 
-On Linux with `/dev/kvm`, Firecracker boots directly on the host — no VM hop. The TAP device connects the microVM to the host network namespace and gets NAT'd to the internet. On macOS hosts, networking is backend-specific: the default HVF backend is vsock-only (guest I/O crosses vsock, no guest NIC); libkrun now follows the same workload shape, with guest traffic routed through the host-side vsock egress path instead of a guest-NIC helper.
+Firecracker, HVF, and libkrun production workloads do not expose a guest NIC.
+Proxy-aware TCP applications use the injected loopback SOCKS5 listener; UDP
+applications use SOCKS5 `UDP ASSOCIATE`. The host resolves names, applies the
+signed allow/deny policy separately for TCP and UDP, and opens the external
+socket only after admission. This keeps DNS and egress on the same auditable
+host seam.
+
+Raw ICMP and arbitrary non-proxy-aware sockets are intentionally not available
+on this path. `ping` is therefore not a valid egress smoke test; use an HTTP,
+TCP, or SOCKS5-aware UDP probe.
+
+## Rootless QEMU transparent networking
+
+Linux users who need ordinary guest TCP and UDP sockets without configuring a
+host TAP device can opt into QEMU's dev/test backend:
+
+```bash
+mvmctl machine run --hypervisor qemu --image alpine --net -- \
+  sh -c 'wget -qO- https://example.com'
+```
+
+QEMU attaches `virtio-net-pci` to its unprivileged `-netdev user` stack. The
+workload sees a normal guest interface, so TCP and UDP are transparent to the
+application and no host bridge, NAT rule, or elevated network setup is needed.
+QEMU is explicit dev/test infrastructure, is never selected automatically for
+production, and does not inherit the production NIC-less security claim.
+
+The QEMU user-mode stack follows the host's normal routing as seen by QEMU's
+user-mode network process, but its behavior differs from a host TAP bridge:
+incoming connections require explicit forwarding, and ICMP support is limited.
 
 ## Port Forwarding
 
@@ -104,7 +134,22 @@ That wrapper packages both the exact CLI path
 and a second admit/deny relay proof that demonstrates allowed traffic is
 reachable while a non-admitted destination is refused, all without a guest NIC.
 
-Network policies are enforced via iptables FORWARD rules on the bridge interface (Firecracker backend on Linux). DNS (port 53) is always allowed so domain resolution works. Rules are automatically cleaned up when the VM stops. On macOS backends, policies are enforced at the host-side layer rather than via iptables.
+For production NIC-less backends, policies are enforced by the host endpoint
+and the shared egress gate rather than guest firewall rules. QEMU's user-mode
+network is a dev/test convenience and is not a substitute for that production
+policy boundary.
+
+## Measuring the paths
+
+Run the opt-in local benchmark to compare direct kernel sockets with the
+SOCKS5-framed relay overhead for TCP and UDP:
+
+```bash
+MVM_EGRESS_BENCH=1 cargo test --test egress_path_bench -- --nocapture
+```
+
+The benchmark measures local transport overhead only; it does not represent a
+particular hypervisor, VPN, or Internet route.
 
 ## Security Profiles
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -299,6 +299,8 @@ First vertical slice (build in this order):
 - [ ] `VmDuplexTransport` trait + an in-memory / process-UDS test backend (so CI needs no VMM).
 - [x] Guest loopback/egress-client path and host `RealEndpointSpawner` enforce the admitted policy.
 - [x] Supervisor L4 gate owns raw host/port forwarding and structured allow/deny audit.
+- [x] SOCKS5 UDP Associate uses the same NIC-less vsock seam with shared UDP policy gating.
+- [x] User-space egress evaluation, transparent rootless QEMU prototype, local TCP/UDP path benchmark, and non-root networking documentation are complete.
 
 Then unify + retire the old paths:
 

--- a/specs/plans/259-userspace-socks5-udp-vsock.md
+++ b/specs/plans/259-userspace-socks5-udp-vsock.md
@@ -1,0 +1,62 @@
+# Plan 259 — User-space MicroVM outbound networking
+
+**Status: COMPLETE**
+
+This plan implements the actionable networking work from PR #1831 while
+preserving the repository's uniform-vsock production boundary. Production
+workloads remain NIC-less and use the authenticated host egress endpoint;
+transparent ordinary TCP/UDP sockets are available in the explicit QEMU
+dev/test backend through QEMU's rootless user-mode virtio network.
+
+## Completed work
+
+- [x] Evaluate slirp4netns/libslirp, gVisor netstack, gost, redsocks, QEMU
+  user-mode networking, and the custom vsock SOCKS5 relay. Record the choice
+  and its security boundary in
+  [`specs/research/259-userspace-egress-evaluation.md`](../research/259-userspace-egress-evaluation.md).
+- [x] Keep the production path on the existing NIC-less vsock seam rather than
+  adding a second packet-forwarding model.
+- [x] Add a shared, bounded SOCKS5 UDP datagram codec. IPv4, IPv6, and hostname
+  destinations are supported; fragmented datagrams, malformed headers, invalid
+  domains, and oversized datagrams fail closed.
+- [x] Extend the host egress gate with UDP decisions while preserving the
+  existing TCP decision path and mandatory-deny ranges.
+- [x] Add guest-side UDP Associate negotiation, loopback UDP relay, and framed
+  vsock transport handling.
+- [x] Add host-side async UDS and Linux blocking-vsock UDP relays. Hostname
+  resolution remains host-side and every destination is checked against the
+  shared UDP policy before a host socket is used.
+- [x] Bound frame and datagram allocations, reject malformed frames, drop
+  unanswered datagrams after the response budget, and keep the association
+  alive for later datagrams.
+- [x] Confirm and test transparent TCP/UDP for the rootless QEMU dev/test
+  backend. Its `-netdev user` + `virtio-net-pci` path gives workloads a normal
+  guest NIC without a host TAP or elevated setup; it is explicitly outside
+  production claims.
+- [x] Add an opt-in local latency/throughput comparison for direct kernel
+  sockets versus SOCKS5-framed/relayed TCP and UDP in
+  [`tests/egress_path_bench.rs`](../../tests/egress_path_bench.rs).
+- [x] Document rootless launch modes, backend boundaries, and proxy behavior in
+  [`public/src/content/docs/guides/networking.md`](../../public/src/content/docs/guides/networking.md).
+- [x] Cover codec round trips and rejection paths, UDP policy separation from
+  TCP, guest association framing, host default-deny/malformed handling, QEMU
+  networking selection, and the benchmark's opt-in path.
+
+## Validation
+
+Focused validation:
+
+```text
+cargo fmt --all -- --check
+cargo check -p mvm-core -p mvm-runtime -p mvm-agentd -p mvm-hostd
+cargo test -p mvm-core socks5_udp
+cargo test -p mvm-runtime egress_gate::tests::udp_decision_uses_udp_rules_without_widening_tcp
+cargo test -p mvm-agentd --features addons egress_client::tests::udp_associate_frames_datagrams_over_the_upstream
+cargo test -p mvm-hostd supervisor::socks5_udp::tests
+MVM_EGRESS_BENCH=1 cargo test --test egress_path_bench -- --nocapture
+```
+
+The benchmark compares transport overhead on the local host; it is not a
+claim about a particular hypervisor, network, VPN, or Internet route. A live
+QEMU run is the transparent rootless integration path; the production
+NIC-less backends intentionally require proxy-aware workloads.

--- a/specs/research/259-userspace-egress-evaluation.md
+++ b/specs/research/259-userspace-egress-evaluation.md
@@ -1,0 +1,59 @@
+# User-space egress evaluation
+
+**Date:** 2026-07-24
+**Decision:** keep the production workload path NIC-less and add SOCKS5 TCP
+CONNECT plus UDP ASSOCIATE over the authenticated vsock egress seam. Use the
+existing QEMU dev/test backend as the transparent rootless TCP/UDP prototype.
+
+## Requirements
+
+The candidate must support rootless operation, host-route/VPN awareness,
+default-deny policy enforcement, bounded untrusted input, and an auditable
+host-side decision point. A transparent path must also work for ordinary guest
+TCP and UDP sockets without requiring applications to understand SOCKS5.
+
+## Candidates
+
+| Candidate | Transparent TCP/UDP | Rootless | Fits NIC-less production path | Decision |
+| --- | --- | --- | --- | --- |
+| QEMU user-mode networking | Yes, through an ordinary guest virtio NIC | Yes | No; it is an L3 guest-network model | Keep as the dev/test prototype. |
+| slirp4netns/libslirp | Yes, through a namespace TAP file descriptor | Yes in its intended namespace/container model | No; it still needs a guest network endpoint and routing setup | Do not add as a production dependency. |
+| gVisor netstack | Yes, with a user-space network stack | Depends on the endpoint supplied to the stack | No; the stable integration boundary is a Go userspace-kernel stack, not a Rust library API | Do not embed; revisit only as a separately governed backend. |
+| gost | SOCKS5, TCP/UDP forwarding, and firewall-based transparent modes | The proxy process can be unprivileged, but transparent interception needs a redirect/TUN/TAP boundary | No; it adds an external proxy and a second policy/audit implementation | Do not vendor or shell out to it. |
+| redsocks | Transparent TCP and selected UDP-over-SOCKS modes | Requires firewall redirection or equivalent interception | No; same missing packet interception boundary | Do not use for production. |
+| Custom vsock SOCKS5 relay | Cooperative TCP and UDP | Yes | Yes; uses the existing authenticated host endpoint and policy gate | Implement and make it the production path. |
+
+The external projects document the same boundary: QEMU's `-net user` is a
+complete user-mode network stack with no host root requirement; slirp4netns
+connects a user-space stack to a TAP file descriptor; gVisor netstack is part
+of a Go userspace kernel and does not promise a stable standalone API; gost and
+redsocks obtain transparency through a network redirect or virtual interface.
+
+References:
+
+- QEMU user-mode networking: <https://qemu.readthedocs.io/en/latest/system/devices/net.html>
+- slirp4netns: <https://github.com/rootless-containers/slirp4netns>
+- gVisor networking: <https://gvisor.dev/docs/architecture_guide/networking/>
+- gost: <https://github.com/ginuerzh/gost>
+- redsocks: <https://github.com/darkk/redsocks>
+
+## Decision and boundary
+
+There is no transparent packet path from a NIC-less guest that only has a
+vsock device. Something must intercept the guest's socket or packet boundary;
+adding a hidden guest NIC, TUN, TAP, or firewall redirect would recreate the
+second production egress model that the uniform-vsock convergence removed.
+
+The implementation therefore has two explicit modes:
+
+1. Production HVF/libkrun/Firecracker workloads use the existing loopback
+   SOCKS5 client and the host's authenticated vsock endpoint. TCP CONNECT and
+   UDP ASSOCIATE share the host policy gate and host-side DNS resolution.
+2. Linux QEMU dev/test workloads use QEMU's rootless user-mode virtio network.
+   Ordinary guest TCP and UDP sockets are transparent to the workload. This
+   mode is intentionally outside the production security claims and is useful
+   for compatibility testing and comparison measurements.
+
+The distinction is surfaced in the backend capability matrix rather than
+hidden behind a fallback: QEMU reports `UserModeVirtio`; production workload
+backends report no guest NIC and `vsock` mediation.

--- a/tests/egress_path_bench.rs
+++ b/tests/egress_path_bench.rs
@@ -1,0 +1,284 @@
+//! Optional local benchmark for the two user-space egress shapes.
+//!
+//! This is intentionally opt-in because it opens local listeners and takes
+//! wall-clock measurements. It compares a direct kernel UDP/TCP socket path
+//! (the transport shape used by TAP/NAT) with the extra SOCKS5 framing and
+//! relay hop used by the NIC-less vsock path. It does not claim to measure a
+//! particular hypervisor or host VPN.
+//!
+//! ```text
+//! MVM_EGRESS_BENCH=1 MVM_EGRESS_BENCH_RUNS=1000 \
+//!   cargo test --test egress_path_bench -- --nocapture
+//! ```
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream, UdpSocket};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use mvm_core::socks5_udp::{Address, Datagram};
+
+const SOCKET_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_RUNS: usize = 250;
+const DEFAULT_PAYLOAD_BYTES: usize = 1024;
+
+#[test]
+fn compare_direct_and_socks5_egress_paths() {
+    if std::env::var("MVM_EGRESS_BENCH").as_deref() != Ok("1") {
+        eprintln!("[egress_path_bench] skipped; set MVM_EGRESS_BENCH=1 to run");
+        return;
+    }
+
+    let runs = env_usize("MVM_EGRESS_BENCH_RUNS", DEFAULT_RUNS);
+    let payload_bytes = env_usize("MVM_EGRESS_BENCH_PAYLOAD_BYTES", DEFAULT_PAYLOAD_BYTES);
+    assert!(runs > 0, "MVM_EGRESS_BENCH_RUNS must be positive");
+    assert!(
+        payload_bytes > 0,
+        "MVM_EGRESS_BENCH_PAYLOAD_BYTES must be positive"
+    );
+    let payload = vec![0x5a; payload_bytes];
+
+    let udp = benchmark_udp(runs, &payload);
+    let tcp = benchmark_tcp(runs, &payload);
+    print_summary("udp-direct-kernel", &udp.direct, payload_bytes);
+    print_summary("udp-socks5-framed", &udp.socks5, payload_bytes);
+    print_summary("tcp-direct-kernel", &tcp.direct, payload_bytes);
+    print_summary("tcp-socks5-relayed", &tcp.socks5, payload_bytes);
+}
+
+#[derive(Debug)]
+struct PathSamples {
+    direct: Vec<Duration>,
+    socks5: Vec<Duration>,
+}
+
+fn benchmark_udp(runs: usize, payload: &[u8]) -> PathSamples {
+    let echo = UdpSocket::bind("127.0.0.1:0").expect("bind UDP echo");
+    echo.set_read_timeout(Some(SOCKET_TIMEOUT))
+        .expect("set UDP echo timeout");
+    let echo_addr = echo.local_addr().expect("read UDP echo address");
+    let payload_len = payload.len();
+    let echo_thread = thread::spawn(move || {
+        let mut buf = vec![0u8; payload_len.max(65_535)];
+        for _ in 0..runs.saturating_mul(2) {
+            let (len, peer) = echo.recv_from(&mut buf).expect("receive UDP echo packet");
+            echo.send_to(&buf[..len], peer)
+                .expect("send UDP echo packet");
+        }
+    });
+
+    let direct_socket = UdpSocket::bind("127.0.0.1:0").expect("bind direct UDP client");
+    direct_socket
+        .set_read_timeout(Some(SOCKET_TIMEOUT))
+        .expect("set direct UDP timeout");
+    let mut direct = Vec::with_capacity(runs);
+    let mut buf = vec![0u8; 65_535];
+    for _ in 0..runs {
+        let started = Instant::now();
+        direct_socket
+            .send_to(payload, echo_addr)
+            .expect("send direct UDP payload");
+        let (len, _) = direct_socket
+            .recv_from(&mut buf)
+            .expect("receive direct UDP payload");
+        assert_eq!(&buf[..len], payload);
+        direct.push(started.elapsed());
+    }
+
+    let relay = UdpSocket::bind("127.0.0.1:0").expect("bind SOCKS5 UDP relay");
+    relay
+        .set_read_timeout(Some(SOCKET_TIMEOUT))
+        .expect("set SOCKS5 UDP relay timeout");
+    let relay_addr = relay.local_addr().expect("read SOCKS5 UDP relay address");
+    let relay_payload = payload.to_vec();
+    let relay_thread = thread::spawn(move || {
+        let mut buf = vec![0u8; 65_535];
+        for _ in 0..runs {
+            let (len, peer) = relay
+                .recv_from(&mut buf)
+                .expect("receive SOCKS5 UDP packet");
+            let request = Datagram::decode(&buf[..len]).expect("decode SOCKS5 UDP packet");
+            assert_eq!(request.payload, relay_payload);
+            relay
+                .send_to(&request.payload, echo_addr)
+                .expect("send relayed UDP payload");
+            let (response_len, source) = relay.recv_from(&mut buf).expect("receive relayed UDP");
+            assert_eq!(source, echo_addr);
+            let response = Datagram {
+                address: Address::Ip(echo_addr.ip()),
+                port: echo_addr.port(),
+                payload: buf[..response_len].to_vec(),
+            };
+            let encoded = response.encode().expect("encode SOCKS5 UDP response");
+            relay
+                .send_to(&encoded, peer)
+                .expect("send SOCKS5 UDP response");
+        }
+    });
+
+    let socks_socket = UdpSocket::bind("127.0.0.1:0").expect("bind SOCKS5 UDP client");
+    socks_socket
+        .set_read_timeout(Some(SOCKET_TIMEOUT))
+        .expect("set SOCKS5 UDP client timeout");
+    let mut socks5 = Vec::with_capacity(runs);
+    for _ in 0..runs {
+        let started = Instant::now();
+        let request = Datagram {
+            address: Address::Ip(echo_addr.ip()),
+            port: echo_addr.port(),
+            payload: payload.to_vec(),
+        };
+        let encoded = request.encode().expect("encode SOCKS5 UDP request");
+        socks_socket
+            .send_to(&encoded, relay_addr)
+            .expect("send SOCKS5 UDP request");
+        let (len, _) = socks_socket
+            .recv_from(&mut buf)
+            .expect("receive SOCKS5 UDP response");
+        let response = Datagram::decode(&buf[..len]).expect("decode SOCKS5 UDP response");
+        assert_eq!(response.payload, payload);
+        socks5.push(started.elapsed());
+    }
+
+    relay_thread.join().expect("join SOCKS5 UDP relay");
+    echo_thread.join().expect("join UDP echo");
+    PathSamples { direct, socks5 }
+}
+
+fn benchmark_tcp(runs: usize, payload: &[u8]) -> PathSamples {
+    let echo = TcpListener::bind("127.0.0.1:0").expect("bind TCP echo");
+    let echo_addr = echo.local_addr().expect("read TCP echo address");
+    let payload_len = payload.len();
+    let echo_thread = thread::spawn(move || {
+        for _ in 0..runs.saturating_mul(2) {
+            let (mut stream, _) = echo.accept().expect("accept TCP echo connection");
+            stream
+                .set_read_timeout(Some(SOCKET_TIMEOUT))
+                .expect("set TCP echo timeout");
+            let mut buf = vec![0u8; payload_len];
+            stream.read_exact(&mut buf).expect("read TCP echo payload");
+            stream.write_all(&buf).expect("write TCP echo payload");
+        }
+    });
+
+    let mut direct = Vec::with_capacity(runs);
+    for _ in 0..runs {
+        let started = Instant::now();
+        let mut stream = TcpStream::connect(echo_addr).expect("connect direct TCP");
+        stream
+            .set_read_timeout(Some(SOCKET_TIMEOUT))
+            .expect("set direct TCP timeout");
+        stream.write_all(payload).expect("write direct TCP payload");
+        let mut response = vec![0u8; payload.len()];
+        stream
+            .read_exact(&mut response)
+            .expect("read direct TCP payload");
+        assert_eq!(response, payload);
+        direct.push(started.elapsed());
+    }
+
+    let relay = TcpListener::bind("127.0.0.1:0").expect("bind SOCKS5 TCP relay");
+    let relay_addr = relay.local_addr().expect("read SOCKS5 TCP relay address");
+    let relay_payload_len = payload.len();
+    let relay_thread = thread::spawn(move || {
+        for _ in 0..runs {
+            let (mut client, _) = relay.accept().expect("accept SOCKS5 TCP client");
+            client
+                .set_read_timeout(Some(SOCKET_TIMEOUT))
+                .expect("set SOCKS5 TCP timeout");
+            let mut greeting = [0u8; 3];
+            client
+                .read_exact(&mut greeting)
+                .expect("read SOCKS5 greeting");
+            assert_eq!(greeting, [5, 1, 0]);
+            client
+                .write_all(&[5, 0])
+                .expect("write SOCKS5 method response");
+            let mut request = [0u8; 10];
+            client
+                .read_exact(&mut request)
+                .expect("read SOCKS5 request");
+            assert_eq!(request[0..4], [5, 1, 0, 1]);
+            client
+                .write_all(&[5, 0, 0, 1, 0, 0, 0, 0, 0, 0])
+                .expect("write SOCKS5 connect response");
+            let mut upstream = TcpStream::connect(echo_addr).expect("connect relayed TCP");
+            upstream
+                .set_read_timeout(Some(SOCKET_TIMEOUT))
+                .expect("set relayed TCP timeout");
+            let mut body = vec![0u8; relay_payload_len];
+            client
+                .read_exact(&mut body)
+                .expect("read relayed TCP payload");
+            upstream
+                .write_all(&body)
+                .expect("write relayed TCP payload");
+            upstream
+                .read_exact(&mut body)
+                .expect("read upstream TCP payload");
+            client.write_all(&body).expect("write relayed TCP response");
+        }
+    });
+
+    let mut socks5 = Vec::with_capacity(runs);
+    for _ in 0..runs {
+        let started = Instant::now();
+        let mut stream = TcpStream::connect(relay_addr).expect("connect SOCKS5 TCP relay");
+        stream
+            .set_read_timeout(Some(SOCKET_TIMEOUT))
+            .expect("set SOCKS5 TCP client timeout");
+        stream.write_all(&[5, 1, 0]).expect("write SOCKS5 greeting");
+        let mut method = [0u8; 2];
+        stream
+            .read_exact(&mut method)
+            .expect("read SOCKS5 method response");
+        assert_eq!(method, [5, 0]);
+        let ip = match echo_addr.ip() {
+            std::net::IpAddr::V4(ip) => ip.octets(),
+            std::net::IpAddr::V6(_) => unreachable!("benchmark uses IPv4 loopback"),
+        };
+        let mut request = vec![5, 1, 0, 1];
+        request.extend_from_slice(&ip);
+        request.extend_from_slice(&echo_addr.port().to_be_bytes());
+        stream.write_all(&request).expect("write SOCKS5 request");
+        let mut response = [0u8; 10];
+        stream
+            .read_exact(&mut response)
+            .expect("read SOCKS5 connect response");
+        assert_eq!(response[0..2], [5, 0]);
+        stream.write_all(payload).expect("write SOCKS5 TCP payload");
+        let mut body = vec![0u8; payload.len()];
+        stream
+            .read_exact(&mut body)
+            .expect("read SOCKS5 TCP response");
+        assert_eq!(body, payload);
+        socks5.push(started.elapsed());
+    }
+
+    relay_thread.join().expect("join SOCKS5 TCP relay");
+    echo_thread.join().expect("join TCP echo");
+    PathSamples { direct, socks5 }
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn print_summary(name: &str, samples: &[Duration], payload_bytes: usize) {
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let p50 = sorted[sorted.len() / 2];
+    let p95 = sorted[(sorted.len() * 95 / 100).min(sorted.len() - 1)];
+    let total = samples.iter().copied().sum::<Duration>();
+    let throughput = payload_bytes as f64 * samples.len() as f64 / total.as_secs_f64();
+    eprintln!(
+        "[egress_path_bench] {name} runs={} p50_us={} p95_us={} throughput_mib_s={:.2}",
+        samples.len(),
+        p50.as_micros(),
+        p95.as_micros(),
+        throughput / (1024.0 * 1024.0),
+    );
+}


### PR DESCRIPTION
## Summary

Implements the actionable networking scope from PR #1831:

- Adds bounded SOCKS5 UDP Associate support across the guest loopback client, authenticated vsock seam, and host relays.
- Applies host-side DNS resolution and separate TCP/UDP egress policy gates with fail-closed malformed-input handling.
- Evaluates QEMU user-mode networking, slirp4netns/libslirp, gVisor netstack, gost, redsocks, and the custom vsock relay.
- Adds transparent rootless TCP/UDP networking to the explicit QEMU dev/test backend.
- Adds an opt-in TCP/UDP local path benchmark and rootless networking documentation.

Production Firecracker, HVF, and libkrun workloads remain NIC-less and use the authenticated vsock egress path. QEMU user-mode networking is intentionally limited to the dev/test tier.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Focused mvm-core, mvm-runtime, mvm-agentd, and mvm-hostd tests
- QEMU networking tests
- `MVM_EGRESS_BENCH=1 cargo test --test egress_path_bench -- --nocapture`

The full workspace test run was not completed because the existing nested `mvm-cli` guest build did not finish in the host environment; the focused suites and required clippy gate passed.

Relates to #1831 and closes #1830.