### PR TITLE
feat(lineage): restore exact flake image revisions

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -43,7 +43,7 @@ use mvm_runtime::machine::persist::{
 
 use super::Cli;
 use super::build::build;
-use super::vm::exec::{RunArgs, RunProfile, run_secure};
+use super::vm::exec::{RunArgs, RunProfile, run_secure, run_secure_with_source};
 use super::vm::group::VmCmd;
 #[cfg(test)]
 use super::vm::host_signer::PUBLIC_FILENAME;
@@ -1332,59 +1332,79 @@ fn complete_revert(
     match outcome {
         super::vm::checkpoint::RevertOutcome::Done => Ok(()),
         super::vm::checkpoint::RevertOutcome::RunImage(run) => {
-            run_dispatch(cli, run_args_for_image_revert(run), cfg)
+            let (args, source) = run_args_for_image_revert(run);
+            run_secure_with_source(cli, args.into_run_args(), cfg, source)
         }
     }
 }
 
-/// Build the `machine run --image` args for an image-node restore. The restore
+/// Build the transient-run args and exact image source for an image-node restore. The restore
 /// re-derives the current network policy at launch and never bakes the
 /// snapshot-era posture: outbound networking stays off (`net = false`). On the
 /// default `firecracker` backend that resolves to enforced default-deny; note
 /// the pre-existing caveat that a libkrun transient run does not enforce
 /// per-run egress, so "off" is a request the FC path enforces, not a blanket
 /// guarantee on every backend.
-fn run_args_for_image_revert(run: super::vm::checkpoint::RevertRunImage) -> MachineRunArgs {
-    MachineRunArgs {
-        image: run.image,
-        flake: None,
-        hypervisor: run.hypervisor,
-        json: run.json,
-        name: None,
-        manifest: None,
-        runtime_pack: false,
-        flake_profile: None,
-        net: false,
-        allow_host: Vec::new(),
-        cpus: 2,
-        memory: "512M".to_string(),
-        profile: RunProfile::Standard,
-        agent_verb: Vec::new(),
-        volume: Vec::new(),
-        env: Vec::new(),
-        timeout: None,
-        receipt: None,
-        dry_run: false,
-        tty: false,
-        interactive: false,
-        force: false,
-        no_supervisor: false,
-        up_json: false,
-        ttl: None,
-        healthcheck: None,
-        health_interval: 30,
-        health_timeout: 5,
-        health_retries: 3,
-        health_start_period: 0,
-        entrypoint: false,
-        fresh: false,
-        reset: false,
-        from_workload_ir: None,
-        attach: false,
-        detach: false,
-        kernel_pin: None,
-        argv: Vec::new(),
-    }
+fn run_args_for_image_revert(
+    run: super::vm::checkpoint::RevertRunImage,
+) -> (MachineRunArgs, Option<crate::exec::ImageSource>) {
+    let (image, manifest, source) = match run.source {
+        super::vm::checkpoint::RevertImageSource::Oci(reference) => (Some(reference), None, None),
+        super::vm::checkpoint::RevertImageSource::Flake {
+            slot_hash,
+            revision_hash,
+        } => (
+            None,
+            Some(format!("slot:{slot_hash}@{revision_hash}")),
+            Some(crate::exec::ImageSource::PinnedTemplate {
+                slot_hash,
+                revision_hash,
+            }),
+        ),
+    };
+    (
+        MachineRunArgs {
+            image,
+            flake: None,
+            hypervisor: run.hypervisor,
+            json: run.json,
+            name: None,
+            manifest,
+            runtime_pack: false,
+            flake_profile: None,
+            net: false,
+            allow_host: Vec::new(),
+            cpus: 2,
+            memory: "512M".to_string(),
+            profile: RunProfile::Standard,
+            agent_verb: Vec::new(),
+            volume: Vec::new(),
+            env: Vec::new(),
+            timeout: None,
+            receipt: None,
+            dry_run: false,
+            tty: false,
+            interactive: false,
+            force: false,
+            no_supervisor: false,
+            up_json: false,
+            ttl: None,
+            healthcheck: None,
+            health_interval: 30,
+            health_timeout: 5,
+            health_retries: 3,
+            health_start_period: 0,
+            entrypoint: false,
+            fresh: false,
+            reset: false,
+            from_workload_ir: None,
+            attach: false,
+            detach: false,
+            kernel_pin: None,
+            argv: Vec::new(),
+        },
+        source,
+    )
 }
 
 fn set_machine_timeout(args: MachineSetTimeoutArgs) -> Result<()> {

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -32,7 +32,8 @@ mod revert;
 mod timeline;
 pub(super) use lineage::SignedChainAnchor;
 pub(in crate::commands) use revert::{
-    AdvanceArgs, RevertArgs, RevertOutcome, RevertRunImage, run_advance, run_revert, run_rewind,
+    AdvanceArgs, RevertArgs, RevertImageSource, RevertOutcome, RevertRunImage, run_advance,
+    run_revert, run_rewind,
 };
 pub(in crate::commands) use timeline::{TimelineArgs, run_timeline};
 

--- a/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
@@ -14,12 +14,11 @@
 //!   (`<registry>/<repository>@<resolved_digest>`) through the normal admitted
 //!   `machine run` path, which re-fetches the exact bytes and re-admits
 //!   identically.
-//! - **Flake image-node targets are refused.** Restoring a flake-built image to
-//!   its exact prior revision would re-run `machine run --flake`, which rebuilds
-//!   from whatever the flake resolves to *now* — not the revision being
-//!   restored. Booting a specific stored revision instead of the slot's current
-//!   one is not yet wired, so the restore fails closed rather than silently
-//!   relaunch drifted (or, mid-incident, modified) source.
+//! - **Flake image-node targets pin the stored revision.** Restoring a
+//!   flake-built image resolves the recorded slot/revision directory directly,
+//!   reconciles every committed artifact hash before boot, and then runs that
+//!   exact source through the normal admitted path. It never rebuilds the flake
+//!   or follows the slot's mutable `current` symlink.
 //!
 //! Every restore verifies its target against the signed audit chain up front and
 //! fails closed on an un-audited, tampered, or dangling record — the same
@@ -28,6 +27,8 @@
 //! `checkpoint.restored` entry, and an image restore an `image.reverted` entry;
 //! both carry the initiating verb (`revert` / `rewind` / `advance`) as their
 //! `via` label.
+
+use std::path::{Component, Path};
 
 use anyhow::{Context, Result, bail};
 
@@ -125,11 +126,34 @@ pub(in crate::commands) enum RevertOutcome {
     RunImage(RevertRunImage),
 }
 
-/// The reconstructed `machine run --image` reference for an image-node restore.
-/// Always a digest-pinned OCI reference (flake nodes are refused upstream).
+/// The exact source selected for an image-node restore.
+#[derive(Debug)]
+pub(in crate::commands) enum RevertImageSource {
+    /// A digest-pinned OCI reference.
+    Oci(String),
+    /// A content-addressed stored flake revision.
+    Flake {
+        slot_hash: String,
+        revision_hash: String,
+    },
+}
+
+impl RevertImageSource {
+    fn audit_reference(&self) -> String {
+        match self {
+            Self::Oci(reference) => reference.clone(),
+            Self::Flake {
+                slot_hash,
+                revision_hash,
+            } => format!("flake:{slot_hash}@{revision_hash}"),
+        }
+    }
+}
+
+/// The source and run options for an image-node restore.
 #[derive(Debug)]
 pub(in crate::commands) struct RevertRunImage {
-    pub image: Option<String>,
+    pub source: RevertImageSource,
     pub hypervisor: Option<String>,
     pub json: bool,
 }
@@ -308,29 +332,26 @@ fn revert_image(
         )
     })?;
 
-    let image = reconstruct_image_run_reference(&node)?;
+    let source = reconstruct_image_source(&node)?;
+    let reference = source.audit_reference();
 
     // Distinctly audit the restore BEFORE handing off, so the chain records
     // "reverted to node X via Y" — not just an ordinary image run.
-    emit_image_revert_audit(&node, via, &image)?;
+    emit_image_revert_audit(&node, via, &reference)?;
 
     Ok(RevertOutcome::RunImage(RevertRunImage {
-        image: Some(image),
+        source,
         hypervisor: Some(opts.hypervisor.to_string()),
         json: opts.json,
     }))
 }
 
-/// Reconstruct the digest-pinned `machine run --image` reference an OCI node
-/// recorded, so a restore re-fetches the exact prior image
-/// (`<registry>/<repository>@<resolved_digest>`).
+/// Resolve the exact boot source recorded by an image node.
 ///
-/// Flake nodes are refused: relaunching a flake image to its exact prior
-/// revision would re-run `machine run --flake`, which rebuilds from whatever the
-/// flake resolves to now — not the revision being restored. Booting a specific
-/// stored revision instead of the slot's current one is not yet wired, so this
-/// fails closed rather than silently relaunch drifted source.
-fn reconstruct_image_run_reference(node: &ImageNode) -> Result<String> {
+/// OCI nodes become digest-pinned references. Flake nodes resolve the stored
+/// slot revision, reconcile every committed artifact hash, and become a
+/// pinned template source. Neither branch follows a mutable tag or `current`.
+fn reconstruct_image_source(node: &ImageNode) -> Result<RevertImageSource> {
     match &node.build_identity {
         ImageBuildIdentity::Oci {
             registry,
@@ -343,14 +364,80 @@ fn reconstruct_image_run_reference(node: &ImageNode) -> Result<String> {
                     node.node_digest
                 );
             };
-            Ok(format!("{registry}/{repository}@{resolved_digest}"))
+            Ok(RevertImageSource::Oci(format!(
+                "{registry}/{repository}@{resolved_digest}"
+            )))
         }
-        ImageBuildIdentity::Flake { .. } => bail!(
-            "reverting a flake-built image to its exact prior revision isn't wired yet: the run \
-             path rebuilds the flake's CURRENT revision, not the stored one, so a flake restore \
-             would silently relaunch drifted source. OCI images and checkpoints support exact \
-             restore."
-        ),
+        ImageBuildIdentity::Flake { slot_hash } => {
+            let ImageCanonicalId::Flake { revision_hash } = &node.image_identity.canonical else {
+                bail!(
+                    "image node {} names a flake build identity but a non-flake canonical id; \
+                     refusing to reconstruct an ambiguous source",
+                    node.node_digest
+                );
+            };
+            let (_, _, _, rootfs, _) =
+                mvm_runtime::vm::template::lifecycle::template_artifacts_for_slot_revision(
+                    slot_hash,
+                    revision_hash,
+                )
+                .with_context(|| {
+                    format!("resolving stored flake revision {slot_hash}@{revision_hash}")
+                })?;
+            reconcile_flake_artifacts(
+                node,
+                Path::new(&rootfs).parent().ok_or_else(|| {
+                    anyhow::anyhow!("stored flake rootfs has no revision directory")
+                })?,
+            )?;
+            Ok(RevertImageSource::Flake {
+                slot_hash: slot_hash.clone(),
+                revision_hash: revision_hash.clone(),
+            })
+        }
+    }
+}
+
+/// Reconcile the stored revision's bytes against the image node before the
+/// admitted boot path sees them. The node must commit both boot artifacts and
+/// may not name paths outside its revision directory.
+fn reconcile_flake_artifacts(node: &ImageNode, revision_dir: &Path) -> Result<()> {
+    let required = ["vmlinux", "rootfs.ext4"];
+    for name in required {
+        if !node
+            .image_identity
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.name == name)
+        {
+            bail!(
+                "image node {} does not commit required flake artifact {name:?}",
+                node.node_digest
+            );
+        }
+    }
+
+    for artifact in &node.image_identity.artifacts {
+        let path = revision_dir.join(safe_artifact_name(&artifact.name)?);
+        let actual = mvm_core::crypto::image_verify::sha256_file(&path)
+            .with_context(|| format!("hashing stored flake artifact {}", path.display()))?;
+        if actual != artifact.sha256 {
+            bail!(
+                "stored flake artifact {:?} failed image-lineage reconciliation: expected {}, got {}",
+                artifact.name,
+                artifact.sha256,
+                actual
+            );
+        }
+    }
+    Ok(())
+}
+
+fn safe_artifact_name(name: &str) -> Result<&str> {
+    let mut components = Path::new(name).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(name),
+        _ => bail!("image-lineage artifact name {name:?} is not a plain file name"),
     }
 }
 
@@ -575,6 +662,7 @@ mod tests {
     use mvm_core::image_lineage::{
         ImageBuildIdentity, ImageCanonicalId, ImageIdentity, ImageNode, ImageProvenance,
     };
+    use mvm_core::manifest::{PersistedManifest, Provenance, slot_dir, slot_revision_dir};
     use mvm_core::plan::test_support::PlanFixture;
     use mvm_hostd::audit::bind::bind_checkpoint_created;
     use mvm_hostd::audit::emitter::AuditEmitter;
@@ -640,6 +728,71 @@ mod tests {
         .build()
     }
 
+    fn seed_flake_revision(slot_hash: &str, revision_hash: &str) -> ImageNode {
+        let slot = std::path::PathBuf::from(slot_dir(slot_hash));
+        std::fs::create_dir_all(&slot).unwrap();
+        PersistedManifest {
+            schema_version: 1,
+            manifest_path: "/tmp/mvm.toml".into(),
+            manifest_hash: slot_hash.into(),
+            flake_ref: ".#app".into(),
+            profile: "app".into(),
+            vcpus: 2,
+            mem_mib: 512,
+            mem_initial_mib: None,
+            data_disk_mib: 0,
+            name: None,
+            backend: "firecracker".into(),
+            provenance: Provenance {
+                toolchain_version: "test".into(),
+                builder_image_digest: None,
+                host_arch: "aarch64-darwin".into(),
+                built_at: "2026-01-01T00:00:00Z".into(),
+                ir_hash: None,
+            },
+            created_at: "2026-01-01T00:00:00Z".into(),
+            updated_at: "2026-01-01T00:00:00Z".into(),
+        }
+        .write_to_slot(&slot)
+        .unwrap();
+
+        let revision_dir = std::path::PathBuf::from(slot_revision_dir(slot_hash, revision_hash));
+        std::fs::create_dir_all(&revision_dir).unwrap();
+        let rootfs = revision_dir.join("rootfs.ext4");
+        let vmlinux = revision_dir.join("vmlinux");
+        std::fs::write(&rootfs, b"rootfs-revision-1").unwrap();
+        std::fs::write(&vmlinux, b"kernel-revision-1").unwrap();
+        let rootfs_sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
+        let vmlinux_sha = mvm_core::crypto::image_verify::sha256_file(&vmlinux).unwrap();
+
+        ImageNode::builder(
+            ImageBuildIdentity::Flake {
+                slot_hash: slot_hash.into(),
+            },
+            ImageIdentity {
+                canonical: ImageCanonicalId::Flake {
+                    revision_hash: revision_hash.into(),
+                },
+                artifacts: vec![
+                    ContentBlob {
+                        name: "rootfs.ext4".into(),
+                        sha256: rootfs_sha,
+                    },
+                    ContentBlob {
+                        name: "vmlinux".into(),
+                        sha256: vmlinux_sha,
+                    },
+                ],
+            },
+            ImageProvenance::Build {
+                input_ref: ".#app".into(),
+                lock_digest: Some("lock".into()),
+            },
+        )
+        .created_unix(1)
+        .build()
+    }
+
     fn seed_image(
         store: &ImageStore,
         em: &AuditEmitter,
@@ -680,27 +833,21 @@ mod tests {
     #[test]
     fn oci_node_reconstructs_a_digest_pinned_reference() {
         let node = oci_node("a");
-        let reference = reconstruct_image_run_reference(&node).unwrap();
-        assert_eq!(
-            reference,
-            format!("docker.io/library/alpine@sha256:{}", "a".repeat(64)),
-            "OCI restore must re-fetch the exact resolved digest"
-        );
+        let source = reconstruct_image_source(&node).unwrap();
+        assert!(matches!(
+            source,
+            RevertImageSource::Oci(reference)
+                if reference == format!("docker.io/library/alpine@sha256:{}", "a".repeat(64))
+        ));
     }
 
-    /// Restoring a flake image to its exact prior revision is not wired: the run
-    /// path rebuilds the flake's current revision, not the stored one, so it must
-    /// refuse rather than silently relaunch drifted source.
     #[test]
-    fn flake_node_reconstruction_is_refused_as_unwired() {
+    fn flake_node_reconstruction_requires_the_stored_revision() {
         let node = image_of("slot-a", "rev-1", None);
-        let err = reconstruct_image_run_reference(&node).unwrap_err();
+        let err = reconstruct_image_source(&node).unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("flake"), "{msg}");
-        assert!(
-            msg.contains("isn't wired") || msg.contains("not wired") || msg.contains("drifted"),
-            "the refusal must explain why: {msg}"
-        );
+        assert!(msg.contains("manifest") || msg.contains("stored"), "{msg}");
     }
 
     // ── invariant 5: verify the target before restoring (fail closed) ─────────
@@ -824,11 +971,15 @@ mod tests {
         .unwrap();
         match outcome {
             RevertOutcome::RunImage(run) => {
-                assert_eq!(
-                    run.image.as_deref(),
-                    Some(format!("docker.io/library/alpine@sha256:{}", "a".repeat(64)).as_str()),
-                    "an OCI image node restores through its digest-pinned reference"
-                );
+                assert!(matches!(
+                    run.source,
+                    RevertImageSource::Oci(reference)
+                        if reference
+                            == format!(
+                                "docker.io/library/alpine@sha256:{}",
+                                "a".repeat(64)
+                            )
+                ));
             }
             RevertOutcome::Done => {
                 panic!(
@@ -851,29 +1002,48 @@ mod tests {
         assert_eq!(verify_audit_chain(&path, &signer.verifying).unwrap(), 2);
     }
 
-    /// A flake image node is refused at the run_revert level even when audited:
-    /// exact-revision restore isn't wired, so it fails closed rather than rebuild
-    /// the flake's current (possibly drifted) source.
     #[test]
-    fn revert_of_an_audited_flake_node_is_refused() {
+    fn flake_node_reconstruction_rejects_tampered_artifacts() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let node = seed_flake_revision("slot-a", "rev-1");
+        let rootfs =
+            std::path::PathBuf::from(slot_revision_dir("slot-a", "rev-1")).join("rootfs.ext4");
+        std::fs::write(rootfs, b"tampered").unwrap();
+        let err = reconstruct_image_source(&node).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("reconciliation"), "{msg}");
+    }
+
+    #[test]
+    fn revert_of_an_audited_flake_node_selects_the_pinned_revision() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
         env.set("MVM_HOME", tmp.path());
         let istore = ImageStore::open();
         let (em, plan) = emitter();
-        let node = image_of("slot-a", "rev-1", None);
+        let node = seed_flake_revision("slot-a", "rev-1");
         seed_image(&istore, &em, &plan, &node);
 
-        let err = run_revert(RevertArgs {
+        let outcome = run_revert(RevertArgs {
             target: node.node_digest.as_str().to_string(),
             kind: None,
             hypervisor: "firecracker".into(),
             new_id: None,
             json: false,
         })
-        .unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(msg.contains("flake"), "{msg}");
+        .unwrap();
+        match outcome {
+            RevertOutcome::RunImage(run) => assert!(matches!(
+                run.source,
+                RevertImageSource::Flake {
+                    slot_hash,
+                    revision_hash,
+                } if slot_hash == "slot-a" && revision_hash == "rev-1"
+            )),
+            RevertOutcome::Done => panic!("flake image restore must use the admitted run path"),
+        }
     }
 
     /// `--new-id` names the restored VM for a checkpoint restore; an image restore

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -321,6 +321,19 @@ pub(in crate::commands) fn run_receipt(
 }
 
 pub(in crate::commands) fn run_secure(cli: &Cli, args: RunArgs, cfg: &MvmConfig) -> Result<()> {
+    run_secure_with_source(cli, args, cfg, None)
+}
+
+/// Run a transient workload through the normal admitted path, optionally
+/// overriding the user-facing image lookup with an already-verified source.
+/// The override is used only by content-addressed restore, where following a
+/// mutable template pointer would boot the wrong revision.
+pub(in crate::commands) fn run_secure_with_source(
+    cli: &Cli,
+    args: RunArgs,
+    cfg: &MvmConfig,
+    source_override: Option<crate::exec::ImageSource>,
+) -> Result<()> {
     // When an SDK transport mode is requested, peel off the
     // SDK-shaped surface before the sandbox-runner validation kicks
     // in. `--dev` (alias for live) is refused in v1; `--prod` (alias
@@ -461,6 +474,7 @@ pub(in crate::commands) fn run_secure(cli: &Cli, args: RunArgs, cfg: &MvmConfig)
             "`mvmctl run`",
             selection,
             network_policy,
+            source_override.clone(),
         )?;
         let posture = crate::exec::PostureSink::new(mvm_build::run_image::RootStrategy::BlockExt4);
         let runtime_source_policy = crate::exec::RuntimeSourcePolicySink::new(
@@ -516,6 +530,7 @@ pub(in crate::commands) fn run_secure(cli: &Cli, args: RunArgs, cfg: &MvmConfig)
         cfg,
         selection,
         network_policy,
+        source_override,
         RunAudit {
             admit: Some(&admit),
             ctx: &admit_ctx,
@@ -633,9 +648,16 @@ fn run_run_args(
     _cfg: &MvmConfig,
     selection: ImageSelection,
     network_policy: mvm_core::network_policy::NetworkPolicy,
+    source_override: Option<crate::exec::ImageSource>,
     audit: RunAudit<'_>,
 ) -> Result<()> {
-    let req = build_exec_request(args, "`mvmctl run`", selection, network_policy)?;
+    let req = build_exec_request(
+        args,
+        "`mvmctl run`",
+        selection,
+        network_policy,
+        source_override,
+    )?;
     let posture = crate::exec::PostureSink::new(mvm_build::run_image::RootStrategy::BlockExt4);
     let runtime_source_policy = crate::exec::RuntimeSourcePolicySink::new(
         mvm_core::vm_backend::RuntimeSourcePolicy::PreferOverlay,
@@ -667,6 +689,7 @@ fn build_exec_request(
     command_name: &str,
     selection: ImageSelection,
     network_policy: mvm_core::network_policy::NetworkPolicy,
+    source_override: Option<crate::exec::ImageSource>,
 ) -> Result<crate::exec::ExecRequest> {
     let ImageSelection {
         image_ref,
@@ -717,6 +740,8 @@ fn build_exec_request(
     let image = if runtime_pack {
         super::runtime_pack::resolve_runtime_pack_image_source(prod)
             .context("resolving --runtime-pack image source")?
+    } else if let Some(source) = source_override {
+        source
     } else {
         match (args.manifest, image_ref) {
             (Some(_), Some(_)) => unreachable!("clap conflicts_with prevents --manifest + --image"),
@@ -810,6 +835,10 @@ fn build_exec_request(
                     let label = match &src {
                         crate::exec::ImageSource::Prebuilt { label, .. } => label.clone(),
                         crate::exec::ImageSource::Template(name) => name.clone(),
+                        crate::exec::ImageSource::PinnedTemplate {
+                            slot_hash,
+                            revision_hash,
+                        } => format!("{slot_hash}@{revision_hash}"),
                     };
                     ui::info(&format!(
                         "Instant boot from verified runtime pack ({label}); \

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -143,6 +143,12 @@ fn expand_tilde(path: &str) -> String {
 pub enum ImageSource {
     /// A registered template (resolved via `template::lifecycle::template_artifacts`).
     Template(String),
+    /// A specific stored revision in a manifest-keyed slot. This is used by
+    /// content-addressed image restore so the boot cannot follow `current`.
+    PinnedTemplate {
+        slot_hash: String,
+        revision_hash: String,
+    },
     /// Pre-built kernel + rootfs paths (e.g., the cached dev image).
     Prebuilt {
         kernel_path: String,
@@ -187,7 +193,9 @@ pub fn runtime_source_policy_for(
         return mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay;
     }
     let launch_kind = match image {
-        ImageSource::Template(_) => mvm_core::vm_backend::RuntimeSourceLaunchKind::WorkloadImage,
+        ImageSource::Template(_) | ImageSource::PinnedTemplate { .. } => {
+            mvm_core::vm_backend::RuntimeSourceLaunchKind::WorkloadImage
+        }
         ImageSource::Prebuilt { .. } => {
             mvm_core::vm_backend::RuntimeSourceLaunchKind::InjectedRootfs
         }
@@ -1125,6 +1133,29 @@ fn resolve_image_artifacts(image: &ImageSource) -> Result<ResolvedImage> {
                 profile: Some(spec.profile.clone()),
                 snap_info,
                 template_id: Some(name.clone()),
+            })
+        }
+        ImageSource::PinnedTemplate {
+            slot_hash,
+            revision_hash,
+        } => {
+            let (spec, vmlinux, initrd, rootfs, rev) =
+                mvm_runtime::vm::template::lifecycle::template_artifacts_for_slot_revision(
+                    slot_hash,
+                    revision_hash,
+                )
+                .with_context(|| {
+                    format!("Loading stored template revision {slot_hash}@{revision_hash}")
+                })?;
+            Ok(ResolvedImage {
+                vmlinux,
+                initrd,
+                rootfs,
+                revision: rev,
+                flake_ref: spec.flake_ref,
+                profile: Some(spec.profile),
+                snap_info: None,
+                template_id: Some(slot_hash.clone()),
             })
         }
         ImageSource::Prebuilt {

--- a/crates/mvm-runtime/src/vm/template/lifecycle/artifacts.rs
+++ b/crates/mvm-runtime/src/vm/template/lifecycle/artifacts.rs
@@ -178,7 +178,38 @@ pub fn template_artifacts_for_slot(
 ) -> Result<(PersistedManifest, String, Option<String>, String, String)> {
     let persisted = template_load_slot(slot_hash)?;
     let rev = current_revision_id_for_slot(slot_hash)?;
-    let rev_dir = slot_revision_dir(slot_hash, &rev);
+    template_artifacts_for_slot_revision_with_manifest(slot_hash, &rev, persisted)
+}
+
+/// Resolve a specific stored revision in a manifest-keyed slot.
+///
+/// Unlike [`template_artifacts_for_slot`], this never follows the slot's
+/// `current` symlink. Callers use it for content-addressed restore, where
+/// selecting the current revision would silently boot newer artifacts than
+/// the recorded node names.
+#[instrument(skip_all, fields(slot_hash = slot_hash, revision = revision_hash))]
+pub fn template_artifacts_for_slot_revision(
+    slot_hash: &str,
+    revision_hash: &str,
+) -> Result<(PersistedManifest, String, Option<String>, String, String)> {
+    let persisted = template_load_slot(slot_hash)?;
+    template_artifacts_for_slot_revision_with_manifest(slot_hash, revision_hash, persisted)
+}
+
+fn template_artifacts_for_slot_revision_with_manifest(
+    slot_hash: &str,
+    revision_hash: &str,
+    persisted: PersistedManifest,
+) -> Result<(PersistedManifest, String, Option<String>, String, String)> {
+    if revision_hash.is_empty()
+        || revision_hash.contains('/')
+        || revision_hash.contains('\\')
+        || revision_hash == "."
+        || revision_hash == ".."
+    {
+        anyhow::bail!("invalid slot revision hash {revision_hash:?}");
+    }
+    let rev_dir = slot_revision_dir(slot_hash, revision_hash);
 
     let vmlinux = format!("{rev_dir}/vmlinux");
     let rootfs = format!("{rev_dir}/rootfs.ext4");
@@ -206,7 +237,13 @@ pub fn template_artifacts_for_slot(
         None
     };
 
-    Ok((persisted, vmlinux, initrd_path, rootfs, rev))
+    Ok((
+        persisted,
+        vmlinux,
+        initrd_path,
+        rootfs,
+        revision_hash.to_string(),
+    ))
 }
 
 /// Resolve a bundle-sha256 reference through

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -8,6 +8,13 @@
 > The current tree is treated as a **disposable v1**. This sprint restructures it completely.
 > **No legacy paths, no compatibility shims, no aliases.** Hard renames only.
 
+## Current issue delivery
+
+- [x] #1840 faithful flake-image revert: boot the recorded slot revision,
+      reconcile signed artifact hashes, and preserve the admitted restore path.
+      Implementation, focused tests, workspace tests, check, and clippy pass;
+      branch is ready for pull request review.
+
 ---
 
 ## 1. Why

--- a/specs/plans/261-faithful-flake-image-revert.md
+++ b/specs/plans/261-faithful-flake-image-revert.md
@@ -1,0 +1,42 @@
+# Faithful flake-image revert
+
+Issue: #1840
+
+Status: COMPLETE
+
+## Scope
+
+Flake image-lineage nodes currently identify the slot and revision but the
+restore path can only follow the slot's current revision. This work adds an
+exact stored-revision source that resolves the recorded artifact directory,
+reconciles its committed `vmlinux` and `rootfs.ext4` hashes, and then routes
+the source through the existing admitted transient runner.
+
+Rebuilding the flake is intentionally excluded: it could resolve different
+source inputs while claiming to restore the historical image.
+
+## Delivery checklist
+
+- [x] Add lifecycle resolution for a specific manifest slot revision without
+      following `current`.
+- [x] Add a pinned template image source to the transient runner.
+- [x] Reconcile every signed flake-node artifact before boot and reject path
+      traversal or missing required boot artifacts.
+- [x] Route a successful flake revert through the normal admission callback.
+- [x] Add success, missing-revision, and tampered-artifact tests.
+- [x] Run workspace format, tests, check, and clippy gates.
+- [ ] Publish the verified branch as a pull request.
+
+## Verification
+
+Verification passes:
+
+```text
+cargo test -p mvm-cli --lib commands::vm::checkpoint::revert -- --nocapture
+cargo fmt --all -- --check
+cargo check --workspace
+cargo test --workspace -- --test-threads=1
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+The branch is ready for pull request review.

--- a/specs/plans/261-faithful-flake-image-revert.md
+++ b/specs/plans/261-faithful-flake-image-revert.md
@@ -25,7 +25,7 @@ source inputs while claiming to restore the historical image.
 - [x] Route a successful flake revert through the normal admission callback.
 - [x] Add success, missing-revision, and tampered-artifact tests.
 - [x] Run workspace format, tests, check, and clippy gates.
-- [ ] Publish the verified branch as a pull request.
+- [x] Publish the verified branch as pull request #1843.
 
 ## Verification
 
@@ -39,4 +39,4 @@ cargo test --workspace -- --test-threads=1
 cargo clippy --workspace --all-targets -- -D warnings
 ```
 
-The branch is ready for pull request review.
+Pull request #1843 is open for review.


### PR DESCRIPTION
Closes #1840

## Summary

- resolve flake image nodes to their recorded slot/revision artifacts without following `current` or rebuilding
- reconcile committed `vmlinux` and `rootfs.ext4` hashes and reject missing, tampered, or unsafe artifacts
- route restores through the existing admitted transient runner

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`