### PR TITLE
fix(mvm-cli): image-lineage node creation save-then-emit + ancestor self-heal (closes #1833)

### DIFF
--- a/crates/mvm-cli/src/commands/build/image_lineage.rs
+++ b/crates/mvm-cli/src/commands/build/image_lineage.rs
@@ -40,6 +40,7 @@
 //! recorded provenance is never an input to it.
 
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 
@@ -220,13 +221,26 @@ fn create_image_node(
 /// orphan (which would make `verify_image_lineage` fail closed forever). Returns
 /// whether any node was healed.
 ///
-/// Marker-first: a node carrying an `audit_ref` is anchored, and by the
-/// create-time invariant so is its whole ancestry, so the walk stops there
-/// without touching the signed chain. Only an unmarked node consults the
-/// authoritative `anchor`: an already-audited-but-unmarked node (e.g. a
-/// pre-marker record) is confirmed and its marker backfilled with no re-emit; a
-/// genuine orphan has `image.created` re-emitted, then is marked. A single crash
-/// orphans one node, but the walk heals a run of them from successive crashes.
+/// The walk terminates on exactly two things: an `audit_ref` marker we stamped,
+/// or genesis. A marker is only ever set *after* healing a node's ancestry
+/// (`create_image_node` heals the tip before emitting+marking a new node; this
+/// walk marks each node it processes), so a marker means the whole chain below is
+/// already anchored — the walk stops there without touching the signed chain.
+///
+/// An *unmarked* node is never trusted to end the walk: it was written by a flow
+/// that did not heal its ancestry (a pre-marker record, or a crash between emit
+/// and mark), so an orphan may still lurk beneath it. Its state is resolved
+/// against the authoritative `anchor` and then the walk **continues** to the
+/// parent: an already-audited node has its marker backfilled with no re-emit; a
+/// genuine orphan has `image.created` re-emitted, then is marked. So the first
+/// post-upgrade build walks to genesis once (one lazy anchor load, reused),
+/// backfilling markers and healing any real orphans; later builds stop at the
+/// first marked node.
+///
+/// A `seen` set refuses to revisit a digest, so a fabricated cross-identity cycle
+/// fails closed rather than looping or re-emitting duplicates — even if a
+/// persistently-failing `mark_audited` never sets the markers that would
+/// otherwise end the walk (mirrors the lineage walkers' cycle guard).
 fn heal_unaudited_ancestry(
     store: &ImageStore,
     emitter: &dyn ImageCreatedEmitter,
@@ -235,24 +249,35 @@ fn heal_unaudited_ancestry(
     tip: &ImageNode,
 ) -> Result<bool> {
     let mut healed = false;
+    let mut seen: HashSet<CheckpointDigest> = HashSet::new();
     let mut current = tip.clone();
     loop {
+        // A revisit can only mean a cycle — a valid ancestry is a simple path.
+        if !seen.insert(current.node_digest.clone()) {
+            anyhow::bail!(
+                "image-lineage ancestry of {} revisits {}: a cycle; refusing to heal",
+                tip.node_digest,
+                current.node_digest
+            );
+        }
+        // A marker we stamped means this node's ancestry is already healed — stop.
         if current.audit_ref.is_some() {
             break;
         }
         if anchor.recorded_creation_digest(&current)?.is_some() {
-            // Anchored already; the missing marker is just a stale record. Backfill
-            // it and stop — its ancestry is anchored too.
+            // Anchored but unmarked (a pre-marker record, or a crash between emit
+            // and mark). Backfill the marker without re-emitting — but keep
+            // walking: this node's writer did not heal its ancestry.
             mark_audited(store, &current, plan);
-            break;
+        } else {
+            // A genuine orphan (saved, never emitted). The envelope binds to this
+            // build's plan; the entry's identity labels come from the node itself.
+            emitter
+                .emit_image_created(plan, &current)
+                .context("completing the audit of a crash-orphaned image-lineage ancestor")?;
+            mark_audited(store, &current, plan);
+            healed = true;
         }
-        // A genuine orphan (saved, never emitted). The envelope binds to this
-        // build's plan; the entry's identity labels come from the node itself.
-        emitter
-            .emit_image_created(plan, &current)
-            .context("completing the audit of a crash-orphaned image-lineage ancestor")?;
-        mark_audited(store, &current, plan);
-        healed = true;
 
         match &current.parent {
             Some(parent_digest) => {
@@ -1354,6 +1379,61 @@ mod tests {
         );
     }
 
+    /// A fabricated ancestry cycle (only reachable by tampering — a real
+    /// content-address cannot point at its own descendant) must fail closed
+    /// rather than loop the heal or re-emit duplicates.
+    #[test]
+    fn heal_refuses_a_fabricated_ancestry_cycle() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let (store, emitter, vk) = harness(store_dir.path(), audit_dir.path());
+        let plan = fixture_plan();
+
+        // A (genesis) and B (child of A), both unmarked.
+        let a = node_for(&flake_inputs("rev-a", ".#app"), 1);
+        store.save(&a).unwrap();
+        let b = ImageNode::builder(
+            a.build_identity.clone(),
+            ImageIdentity {
+                canonical: ImageCanonicalId::Flake {
+                    revision_hash: "rev-b".into(),
+                },
+                artifacts: vec![blob("rootfs.ext4", "rev-b")],
+            },
+            a.provenance.clone(),
+        )
+        .parent(Some(a.node_digest.clone()))
+        .created_unix(2)
+        .build();
+        store.save(&b).unwrap();
+
+        // Rewrite A to point back at B, keeping A's digest (its directory name) so
+        // the store's self-consistency check still admits it — an A↔B cycle.
+        let cyclic_a = ImageNode {
+            parent: Some(b.node_digest.clone()),
+            ..a.clone()
+        };
+        std::fs::write(
+            store.dir_for(&a.node_digest).join("node.json"),
+            serde_json::to_vec_pretty(&cyclic_a).unwrap(),
+        )
+        .unwrap();
+
+        // Healing from B walks B → A → B and must refuse the revisit.
+        let err =
+            heal_unaudited_ancestry(&store, &emitter, &plan, &UnauditedAnchor, &b).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("cycle"),
+            "a cycle must surface, got: {err:#}"
+        );
+        // Each node was emitted at most once before the bail — no duplicates.
+        let count = verify_audit_chain(&audit_dir.path().join("local.jsonl"), &vk).unwrap();
+        assert_eq!(
+            count, 2,
+            "B and A emitted once each, then the revisit bailed"
+        );
+    }
+
     #[test]
     fn flake_node_inputs_maps_slot_revision_and_artifacts() {
         let revision = TemplateRevision {
@@ -1684,6 +1764,99 @@ mod tests {
         assert_eq!(store.list().unwrap().len(), 2);
         let anchor = SignedChainAnchor::load().unwrap();
         verify_image_lineage(&store, &tip.node_digest, &anchor).unwrap();
+    }
+
+    /// The re-review's regression: a genuine orphan hidden *beneath* an
+    /// emitted-but-unmarked ancestor. The heal must not stop at the unmarked
+    /// ancestor (it was written by a flow that did not heal its own ancestry) —
+    /// it must walk through to the deeper orphan. Exercised against the real
+    /// signed chain: back it out and `verify_image_lineage(rev-3)` fails forever.
+    #[test]
+    fn record_image_node_heals_a_deep_orphan_beneath_an_unmarked_ancestor() {
+        let mut env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        let slot_hash = "slot-deep";
+        let store = ImageStore::open();
+        let emitter = AuditEmitter::new(load_or_init().unwrap().signing).unwrap();
+        let plan = fixture_plan();
+
+        let node = |rev: &str, sha_seed: &str, parent: Option<CheckpointDigest>, ts: u64| {
+            ImageNode::builder(
+                flake_build_identity(slot_hash),
+                ImageIdentity {
+                    canonical: flake_canonical(rev),
+                    artifacts: vec![blob("rootfs.ext4", &sha_seed.repeat(64))],
+                },
+                ImageProvenance::Build {
+                    input_ref: ".#app".into(),
+                    lock_digest: None,
+                },
+            )
+            .parent(parent)
+            .created_unix(ts)
+            .build()
+        };
+
+        // rev-1: a genuine orphan (saved, never emitted, unmarked) — genesis.
+        let rev1 = node("rev-1", "a", None, 1);
+        store.save(&rev1).unwrap();
+        // rev-2: emitted (raw) but never marked — the pre-marker / crash-after-emit
+        // flow — child of rev-1.
+        let rev2 = node("rev-2", "b", Some(rev1.node_digest.clone()), 2);
+        store.save(&rev2).unwrap();
+        emitter.emit_image_created(&plan, &rev2).unwrap();
+        assert_eq!(
+            local_audit_chain_len(tmp.path()),
+            1,
+            "only rev-2 is emitted pre-build"
+        );
+
+        // Build rev-3. The walk must backfill rev-2 (no re-emit) AND heal rev-1
+        // beneath it, or the new tip fails lineage verification forever.
+        let rev3 = ImageNodeInputs {
+            build_identity: flake_build_identity(slot_hash),
+            canonical: flake_canonical("rev-3"),
+            artifacts: vec![blob("rootfs.ext4", &"c".repeat(64))],
+            provenance: ImageProvenance::Build {
+                input_ref: ".#app".into(),
+                lock_digest: None,
+            },
+        };
+        let outcome = record_image_node(
+            &store,
+            &emitter,
+            &plan,
+            &rev3,
+            3,
+            &SignedChainAnchor::load().unwrap(),
+        )
+        .unwrap();
+        let rev3_digest = match outcome {
+            ImageNodeOutcome::Created(d) => d,
+            other => panic!("expected Created, got {other:?}"),
+        };
+
+        // rev-1 healed + rev-3 created; rev-2 backfilled, NOT re-emitted → exactly
+        // three entries, three nodes, and the whole lineage verifies.
+        assert_eq!(
+            local_audit_chain_len(tmp.path()),
+            3,
+            "rev-1 healed + rev-3 created; rev-2 not re-emitted"
+        );
+        assert_eq!(store.list().unwrap().len(), 3);
+        assert_eq!(
+            store
+                .by_digest(&rev3_digest)
+                .unwrap()
+                .unwrap()
+                .parent
+                .as_ref(),
+            Some(&rev2.node_digest)
+        );
+        let anchor = SignedChainAnchor::load().unwrap();
+        verify_image_lineage(&store, &rev3_digest, &anchor).unwrap();
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/build/image_lineage.rs
+++ b/crates/mvm-cli/src/commands/build/image_lineage.rs
@@ -3,8 +3,20 @@
 //! A build produces a compiled microVM image; this module content-addresses
 //! that image into an [`ImageNode`], hash-links it onto the prior build of the
 //! same slot identity, and binds its creation into the host-signed audit chain
-//! *before* the build reports success. The store never holds a node the audit
-//! chain cannot anchor.
+//! before the build reports success.
+//!
+//! # Ordering and the trust invariant
+//!
+//! A node is committed to the store with an atomic write, then its creation is
+//! chain-signed. If the emit fails, the just-saved node is rolled back, so the
+//! signed chain never carries an entry for a node the store dropped (no phantom
+//! entry). The invariant that actually protects trust is not "the store only
+//! holds anchored nodes" but "a stored node is never *trusted* without its
+//! signed chain entry": `verify_image_lineage` fails closed on any un-audited
+//! node. A process crash between the save and the emit can leave a stored node
+//! transiently un-audited; it is rejected by verification and self-healed on the
+//! next same-revision build, which detects the orphaned tip and completes its
+//! audit by re-emitting `image.created`.
 //!
 //! # Lineage is PROVENANCE, not AUTHORIZATION
 //!
@@ -31,9 +43,23 @@ use mvm_core::plan::{ExecutionPlan, SynthesisInput, synthesize_plan};
 use mvm_core::template::TemplateRevision;
 use mvm_hostd::audit::emitter::AuditEmitter;
 use mvm_hostd::audit::host_keypair::load_or_init;
-use mvm_runtime::image_lineage::ImageStore;
+use mvm_runtime::image_lineage::{ImageChainAnchor, ImageStore};
 
+use crate::commands::vm::checkpoint::SignedChainAnchor;
 use crate::ui;
+
+/// The audit-emit capability [`record_image_node`] depends on, narrowed to the
+/// single `image.created` emit so a test can inject a failing emitter and
+/// exercise the save-then-emit rollback. [`AuditEmitter`] is the production impl.
+pub(in crate::commands) trait ImageCreatedEmitter {
+    fn emit_image_created(&self, plan: &ExecutionPlan, node: &ImageNode) -> Result<()>;
+}
+
+impl ImageCreatedEmitter for AuditEmitter {
+    fn emit_image_created(&self, plan: &ExecutionPlan, node: &ImageNode) -> Result<()> {
+        AuditEmitter::emit_image_created(self, plan, node)
+    }
+}
 
 /// Workload name stamped on the synthesized audit-envelope plan. A build is not
 /// a workload run, so this is only the plan's identity label — never admitted.
@@ -62,47 +88,71 @@ pub(in crate::commands) struct ImageNodeInputs {
 /// Outcome of a node-record attempt.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::commands) enum ImageNodeOutcome {
-    /// A new node was created, audited, and persisted; carries its digest.
+    /// A new node was created, persisted, and audited; carries its digest.
     Created(CheckpointDigest),
-    /// The slot's current tip already records this exact revision, so no new
-    /// node was created — an identical-revision rebuild is a no-op.
+    /// The slot's current tip already records this exact revision and is already
+    /// anchored in the signed chain, so no new node and no new entry — an
+    /// identical-revision rebuild is a no-op.
     AlreadyCurrent(CheckpointDigest),
+    /// The tip already records this revision but carried no signed creation entry
+    /// (a crash orphaned it between save and emit); its audit was completed by
+    /// re-emitting `image.created`. Carries the healed node's digest.
+    Healed(CheckpointDigest),
 }
 
-/// Create, audit, and persist an image-lineage node for a freshly built image.
+/// Create, persist, and audit an image-lineage node for a freshly built image.
 ///
 /// Resolves the slot's current chain tip and either chains the new build as its
-/// child, opens a genesis node when the slot has no prior build, or treats an
-/// identical-revision rebuild as a no-op. A genuinely ambiguous (forked) tip
-/// surfaces as an error rather than a silent guess — the store's `head_for`
-/// fails closed on a fork and that error is propagated.
+/// child, opens a genesis node when the slot has no prior build, or reconciles
+/// an identical-revision rebuild. A genuinely ambiguous (forked) tip surfaces as
+/// an error rather than a silent guess — the store's `head_for` fails closed on
+/// a fork and that error is propagated.
 ///
-/// Creation is chain-signed into the audit log *before* the node is persisted:
-/// an audit failure aborts with no unaudited node left behind, so a node in the
-/// store is always backed by a signature the verifier can anchor.
+/// A new node is committed to the store (atomically) and *then* chain-signed; an
+/// emit failure rolls the node back, so the chain never references a node the
+/// store dropped. When the tip already records this revision the outcome is a
+/// no-op ([`ImageNodeOutcome::AlreadyCurrent`]) if it is anchored in the signed
+/// chain, or a self-heal ([`ImageNodeOutcome::Healed`]) if a crash orphaned it
+/// before its `image.created` — checked via the same `anchor` the verifier uses.
 pub(in crate::commands) fn record_image_node(
     store: &ImageStore,
-    emitter: &AuditEmitter,
+    emitter: &dyn ImageCreatedEmitter,
     plan: &ExecutionPlan,
     inputs: &ImageNodeInputs,
     created_unix: u64,
+    anchor: &dyn ImageChainAnchor,
 ) -> Result<ImageNodeOutcome> {
     let head = store
         .head_for(&inputs.build_identity)
         .context("resolving the current image-lineage tip for this build identity")?;
 
-    let parent = match &head {
-        // The current tip already records this exact revision. Rebuilding it is
-        // a no-op: we do not fork a second tip for one identity, and we do not
-        // re-emit. Provenance is deliberately not compared — it is recorded,
-        // never a chain-shaping input.
-        Some(tip) if tip.image_identity.canonical == inputs.canonical => {
-            return Ok(ImageNodeOutcome::AlreadyCurrent(tip.node_digest.clone()));
-        }
-        Some(tip) => Some(tip.node_digest.clone()),
-        None => None,
-    };
+    // The current tip already records this exact revision. We do not fork a
+    // second tip for one identity; instead reconcile its audit state. Provenance
+    // is deliberately not compared — it is recorded, never a chain-shaping input.
+    if let Some(tip) = head
+        .as_ref()
+        .filter(|tip| tip.image_identity.canonical == inputs.canonical)
+    {
+        return reconcile_recorded_tip(emitter, plan, anchor, tip);
+    }
 
+    let parent = head.map(|tip| tip.node_digest);
+    create_image_node(store, emitter, plan, inputs, created_unix, parent)
+}
+
+/// Build, commit, then chain-sign a genuinely new node (genesis or child).
+///
+/// Save precedes emit so the store never holds a node the chain references but
+/// cannot resolve; the save is atomic ([`ImageStore::save`]). If the emit fails
+/// the just-saved node is rolled back, leaving nothing behind for a clean retry.
+fn create_image_node(
+    store: &ImageStore,
+    emitter: &dyn ImageCreatedEmitter,
+    plan: &ExecutionPlan,
+    inputs: &ImageNodeInputs,
+    created_unix: u64,
+    parent: Option<CheckpointDigest>,
+) -> Result<ImageNodeOutcome> {
     let node = ImageNode::builder(
         inputs.build_identity.clone(),
         ImageIdentity {
@@ -115,16 +165,36 @@ pub(in crate::commands) fn record_image_node(
     .created_unix(created_unix)
     .build();
 
-    // Chain-sign the creation before persisting: the store must never hold a
-    // node the signed chain cannot anchor.
-    emitter
-        .emit_image_created(plan, &node)
-        .context("recording image.created in the signed audit chain")?;
     store
         .save(&node)
         .context("persisting the image-lineage node")?;
-
+    if let Err(e) = emitter.emit_image_created(plan, &node) {
+        // Roll the node back so the chain never references a node the store
+        // dropped, and a retry re-creates it cleanly.
+        let _ = store.remove(&node.node_digest);
+        return Err(e).context("recording image.created in the signed audit chain");
+    }
     Ok(ImageNodeOutcome::Created(node.node_digest))
+}
+
+/// The tip already records this revision. A no-op if it is anchored in the
+/// signed chain; otherwise (a crash orphaned it between save and emit) complete
+/// its audit by re-emitting `image.created` for the *stored* node — no re-hash,
+/// no new node. The anchor is the same signed-chain reader the verifier uses, so
+/// "un-anchored" here means exactly what `verify_image_lineage` fails closed on.
+fn reconcile_recorded_tip(
+    emitter: &dyn ImageCreatedEmitter,
+    plan: &ExecutionPlan,
+    anchor: &dyn ImageChainAnchor,
+    tip: &ImageNode,
+) -> Result<ImageNodeOutcome> {
+    if anchor.recorded_creation_digest(tip)?.is_some() {
+        return Ok(ImageNodeOutcome::AlreadyCurrent(tip.node_digest.clone()));
+    }
+    emitter
+        .emit_image_created(plan, tip)
+        .context("completing the audit of a crash-orphaned image-lineage node")?;
+    Ok(ImageNodeOutcome::Healed(tip.node_digest.clone()))
 }
 
 fn flake_build_identity(slot_hash: &str) -> ImageBuildIdentity {
@@ -247,9 +317,16 @@ pub(in crate::commands) fn record_flake_build_node(
     let canonical = flake_canonical(&revision.revision_hash);
     let store = ImageStore::open();
 
-    if let Some(digest) = tip_already_records(&store, &build_identity, &canonical)? {
-        report_already_current(&digest);
-        return Ok(());
+    if tip_already_records(&store, &build_identity, &canonical)? {
+        // Tip already records this revision: reconcile its audit state without
+        // re-hashing the rootfs — a no-op if it is anchored, a self-heal if a
+        // crash orphaned it before its `image.created`.
+        return reconcile_over_signed_chain(
+            &store,
+            &build_identity,
+            &canonical,
+            &revision.flake_ref,
+        );
     }
 
     // Genuinely new (or genesis): hash the installed artifacts now, using the
@@ -274,44 +351,41 @@ pub(in crate::commands) fn record_flake_build_node(
     record_over_signed_chain(&store, &inputs, &revision.flake_ref, &rootfs_sha256)
 }
 
-/// The current tip's digest if it already records `canonical` for
-/// `build_identity` (an identical-revision rebuild), else `None`. Cheap: reads
-/// only the stored node records, never hashing an artifact — this is the guard
-/// the hot path relies on to skip re-hashing an unchanged image. Propagates
-/// `head_for`'s fork error, so an ambiguous tip surfaces before any work.
+/// Whether the current tip already records `canonical` for `build_identity` (an
+/// identical-revision rebuild). Cheap: reads only the stored node records, never
+/// hashing an artifact — this is the guard the hot path relies on to skip
+/// re-hashing an unchanged image. Propagates `head_for`'s fork error, so an
+/// ambiguous tip surfaces before any work.
 fn tip_already_records(
     store: &ImageStore,
     build_identity: &ImageBuildIdentity,
     canonical: &ImageCanonicalId,
-) -> Result<Option<CheckpointDigest>> {
+) -> Result<bool> {
     let head = store
         .head_for(build_identity)
         .context("resolving the current image-lineage tip for this build identity")?;
-    Ok(head
-        .filter(|tip| &tip.image_identity.canonical == canonical)
-        .map(|tip| tip.node_digest.clone()))
+    Ok(head.is_some_and(|tip| &tip.image_identity.canonical == canonical))
 }
 
-/// Shared tail of the flake and OCI recorders: load the host signer, synthesize
-/// the audit-envelope plan, and record the node under a per-identity advisory
-/// lock. `image_name` / `image_sha256` bind the audit entry; `image_sha256` is
-/// the rootfs digest for both callers.
+/// Shared tail for a genuinely-new node: load the host signer, synthesize the
+/// audit-envelope plan, and record the node under a per-identity advisory lock.
+/// `image_name` / `image_sha256` bind the audit entry; `image_sha256` is the
+/// rootfs digest for both callers.
 ///
-/// The lock serializes the `head_for` → emit → save critical section per build
+/// The lock serializes the `head_for` → save → emit critical section per build
 /// identity, so two concurrent recorders of one identity (e.g. two concurrent
 /// `machine run --flake` of one slot) cannot both read the same tip and fork the
-/// chain. `record_image_node`'s own `AlreadyCurrent` guard is the backstop: the
-/// second writer sees the first's node as the tip and no-ops rather than forks.
+/// chain. The signed-chain anchor is loaded *inside* the lock so it reflects the
+/// chain as of the write, and `record_image_node`'s own reconcile guard is the
+/// backstop: a second writer that finds the first's node as the tip reconciles
+/// (no-op or self-heal) rather than forking.
 fn record_over_signed_chain(
     store: &ImageStore,
     inputs: &ImageNodeInputs,
     image_name: &str,
     image_sha256: &str,
 ) -> Result<()> {
-    let signer =
-        load_or_init().context("loading the host signer to audit the image-lineage node")?;
-    let emitter = AuditEmitter::new(signer.signing)
-        .context("opening the signed audit chain for the image-lineage node")?;
+    let emitter = open_audit_emitter()?;
     // The plan binds the audit entry to the local tenant + the rootfs digest.
     let plan = build_event_plan(
         IMAGE_BUILD_WORKLOAD,
@@ -321,9 +395,77 @@ fn record_over_signed_chain(
     )?;
 
     let outcome = with_identity_lock(store, &inputs.build_identity, || {
-        record_image_node(store, &emitter, &plan, inputs, now_unix())
+        let anchor = load_signed_chain_anchor()?;
+        record_image_node(store, &emitter, &plan, inputs, now_unix(), &anchor)
+    })?;
+    report_outcome(&outcome);
+    Ok(())
+}
+
+/// Shared tail for an already-recorded tip: reconcile its audit state under the
+/// per-identity lock without re-hashing the rootfs. The tip is re-read under the
+/// lock (it may have advanced since the caller's cheap pre-lock check); if it
+/// still records `canonical` its audit is completed when orphaned, else there is
+/// nothing to do here (a concurrent build advanced the chain past this revision).
+fn reconcile_over_signed_chain(
+    store: &ImageStore,
+    build_identity: &ImageBuildIdentity,
+    canonical: &ImageCanonicalId,
+    image_name: &str,
+) -> Result<()> {
+    let emitter = open_audit_emitter()?;
+
+    let outcome = with_identity_lock(store, build_identity, || {
+        let anchor = load_signed_chain_anchor()?;
+        let Some(tip) = store
+            .head_for(build_identity)
+            .context("resolving the current image-lineage tip for this build identity")?
+            .filter(|tip| &tip.image_identity.canonical == canonical)
+        else {
+            return Ok(None);
+        };
+        // The plan is just the audit envelope; bind it to the stored rootfs digest.
+        let image_sha256 = rootfs_digest(&tip.image_identity.artifacts)?.to_string();
+        let plan = build_event_plan(
+            IMAGE_BUILD_WORKLOAD,
+            IMAGE_BUILD_INTENT,
+            image_name,
+            &image_sha256,
+        )?;
+        reconcile_recorded_tip(&emitter, &plan, &anchor, &tip).map(Some)
     })?;
 
+    if let Some(outcome) = outcome {
+        report_outcome(&outcome);
+    }
+    Ok(())
+}
+
+/// Open the host-signed audit emitter over the default audit dir.
+fn open_audit_emitter() -> Result<AuditEmitter> {
+    let signer =
+        load_or_init().context("loading the host signer to audit the image-lineage node")?;
+    AuditEmitter::new(signer.signing)
+        .context("opening the signed audit chain for the image-lineage node")
+}
+
+/// Load the signed-chain anchor the verifier uses, to detect an orphaned tip.
+fn load_signed_chain_anchor() -> Result<SignedChainAnchor> {
+    SignedChainAnchor::load()
+        .context("loading the signed audit chain to detect an orphaned image-lineage tip")
+}
+
+/// The rootfs digest an audit-envelope plan binds to: the first artifact's
+/// sha256. Both node constructions put the rootfs first (flake: rootfs, kernel;
+/// OCI: rootfs). Errors on an artifact-less node rather than fabricate a digest.
+fn rootfs_digest(artifacts: &[ContentBlob]) -> Result<&str> {
+    artifacts
+        .first()
+        .map(|blob| blob.sha256.as_str())
+        .context("image-lineage node has no rootfs artifact to bind its audit envelope to")
+}
+
+fn report_outcome(outcome: &ImageNodeOutcome) {
     match outcome {
         ImageNodeOutcome::Created(digest) => {
             ui::info(&format!(
@@ -331,9 +473,14 @@ fn record_over_signed_chain(
                 digest.as_str()
             ));
         }
-        ImageNodeOutcome::AlreadyCurrent(digest) => report_already_current(&digest),
+        ImageNodeOutcome::Healed(digest) => {
+            ui::info(&format!(
+                "  Image lineage: completed audit for node {}",
+                digest.as_str()
+            ));
+        }
+        ImageNodeOutcome::AlreadyCurrent(digest) => report_already_current(digest),
     }
-    Ok(())
 }
 
 fn report_already_current(digest: &CheckpointDigest) {
@@ -447,9 +594,16 @@ pub(in crate::commands) fn record_oci_pull_node(node: &OciPullNode<'_>) -> Resul
     let canonical = oci_canonical(node.resolved_digest);
     let store = ImageStore::open();
 
-    if let Some(digest) = tip_already_records(&store, &build_identity, &canonical)? {
-        report_already_current(&digest);
-        return Ok(());
+    if tip_already_records(&store, &build_identity, &canonical)? {
+        // Tip already records this digest: reconcile its audit state without
+        // re-hashing the materialized rootfs (no-op if anchored, self-heal if a
+        // crash orphaned it).
+        return reconcile_over_signed_chain(
+            &store,
+            &build_identity,
+            &canonical,
+            node.canonical_reference,
+        );
     }
 
     let rootfs_sha256 = sha256_file_cached(node.rootfs_path).with_context(|| {
@@ -483,15 +637,35 @@ mod tests {
     use mvm_core::pool::ArtifactPaths;
     use mvm_core::util::test_env::TestEnv;
     use mvm_hostd::supervisor::verify_audit_chain;
-    use mvm_runtime::image_lineage::ImageChainAnchor;
+    use mvm_runtime::image_lineage::verify_image_lineage;
 
-    /// A test anchor that agrees with every node's recomputed digest — isolates
-    /// the store-side lineage walk (parent links + digest recompute) from the
-    /// signed-chain reader, which the MVM_HOME integration test exercises.
+    /// A test anchor that agrees with every node's recomputed digest — models a
+    /// signed chain that recorded every node's creation, isolating the store-side
+    /// lineage walk from the real signed-chain reader (the MVM_HOME integration
+    /// tests exercise that).
     struct AgreeingAnchor;
     impl ImageChainAnchor for AgreeingAnchor {
         fn recorded_creation_digest(&self, n: &ImageNode) -> Result<Option<CheckpointDigest>> {
             Ok(Some(n.compute_node_digest()))
+        }
+    }
+
+    /// A test anchor that recorded *no* node — models a signed chain missing an
+    /// `image.created` entry (a crash-orphaned node), so the reconcile path
+    /// self-heals.
+    struct UnauditedAnchor;
+    impl ImageChainAnchor for UnauditedAnchor {
+        fn recorded_creation_digest(&self, _n: &ImageNode) -> Result<Option<CheckpointDigest>> {
+            Ok(None)
+        }
+    }
+
+    /// An emitter whose `image.created` always fails — exercises the
+    /// save-then-emit rollback without a real audit chain.
+    struct FailingEmitter;
+    impl ImageCreatedEmitter for FailingEmitter {
+        fn emit_image_created(&self, _plan: &ExecutionPlan, _node: &ImageNode) -> Result<()> {
+            anyhow::bail!("injected audit-emit failure")
         }
     }
 
@@ -550,7 +724,8 @@ mod tests {
         let plan = fixture_plan();
         let inputs = flake_inputs("rev-1", ".#app");
 
-        let outcome = record_image_node(&store, &emitter, &plan, &inputs, 100).unwrap();
+        let outcome =
+            record_image_node(&store, &emitter, &plan, &inputs, 100, &AgreeingAnchor).unwrap();
         let digest = match outcome {
             ImageNodeOutcome::Created(d) => d,
             other => panic!("expected Created, got {other:?}"),
@@ -575,10 +750,24 @@ mod tests {
         let (store, emitter, vk) = harness(store_dir.path(), audit_dir.path());
         let plan = fixture_plan();
 
-        let genesis =
-            record_image_node(&store, &emitter, &plan, &flake_inputs("rev-1", ".#app"), 1).unwrap();
-        let child =
-            record_image_node(&store, &emitter, &plan, &flake_inputs("rev-2", ".#app"), 2).unwrap();
+        let genesis = record_image_node(
+            &store,
+            &emitter,
+            &plan,
+            &flake_inputs("rev-1", ".#app"),
+            1,
+            &AgreeingAnchor,
+        )
+        .unwrap();
+        let child = record_image_node(
+            &store,
+            &emitter,
+            &plan,
+            &flake_inputs("rev-2", ".#app"),
+            2,
+            &AgreeingAnchor,
+        )
+        .unwrap();
 
         let (genesis_d, child_d) = match (&genesis, &child) {
             (ImageNodeOutcome::Created(g), ImageNodeOutcome::Created(c)) => (g.clone(), c.clone()),
@@ -598,8 +787,7 @@ mod tests {
 
         // The full two-node version lineage verifies, and both creations are
         // chain-signed.
-        mvm_runtime::image_lineage::verify_image_lineage(&store, &child_d, &AgreeingAnchor)
-            .unwrap();
+        verify_image_lineage(&store, &child_d, &AgreeingAnchor).unwrap();
         let count = verify_audit_chain(&audit_dir.path().join("local.jsonl"), &vk).unwrap();
         assert_eq!(count, 2, "genesis + child, chain-signed");
     }
@@ -612,15 +800,18 @@ mod tests {
         let plan = fixture_plan();
         let inputs = flake_inputs("rev-1", ".#app");
 
-        let first = record_image_node(&store, &emitter, &plan, &inputs, 1).unwrap();
+        let first =
+            record_image_node(&store, &emitter, &plan, &inputs, 1, &AgreeingAnchor).unwrap();
         let first_d = match first {
             ImageNodeOutcome::Created(d) => d,
             other => panic!("expected Created, got {other:?}"),
         };
 
-        // Rebuilding the identical revision is a no-op: same digest, no fork, no
-        // new audit entry — even with a different `created_unix`.
-        let second = record_image_node(&store, &emitter, &plan, &inputs, 999).unwrap();
+        // Rebuilding the identical revision (already anchored, per AgreeingAnchor)
+        // is a no-op: same digest, no fork, no new audit entry — even with a
+        // different `created_unix`.
+        let second =
+            record_image_node(&store, &emitter, &plan, &inputs, 999, &AgreeingAnchor).unwrap();
         assert_eq!(
             second,
             ImageNodeOutcome::AlreadyCurrent(first_d.clone()),
@@ -649,13 +840,19 @@ mod tests {
         let plan = fixture_plan();
 
         // Genesis records provenance ".#app".
-        let genesis_d =
-            match record_image_node(&store, &emitter, &plan, &flake_inputs("rev-1", ".#app"), 1)
-                .unwrap()
-            {
-                ImageNodeOutcome::Created(d) => d,
-                other => panic!("expected Created, got {other:?}"),
-            };
+        let genesis_d = match record_image_node(
+            &store,
+            &emitter,
+            &plan,
+            &flake_inputs("rev-1", ".#app"),
+            1,
+            &AgreeingAnchor,
+        )
+        .unwrap()
+        {
+            ImageNodeOutcome::Created(d) => d,
+            other => panic!("expected Created, got {other:?}"),
+        };
 
         // A rebuild of the SAME canonical revision but a DIFFERENT provenance
         // must still be idempotent — the create/idempotency decision keys on the
@@ -666,6 +863,7 @@ mod tests {
             &plan,
             &flake_inputs("rev-1", ".#other"),
             2,
+            &AgreeingAnchor,
         )
         .unwrap();
         assert_eq!(
@@ -734,12 +932,93 @@ mod tests {
         }
 
         // Recording a new build must refuse to guess a tip on the fork.
-        let err = record_image_node(&store, &emitter, &plan, &flake_inputs("rev-3", ".#app"), 3)
-            .unwrap_err();
+        let err = record_image_node(
+            &store,
+            &emitter,
+            &plan,
+            &flake_inputs("rev-3", ".#app"),
+            3,
+            &AgreeingAnchor,
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("tip") || format!("{err:#}").contains("ambiguous"),
             "fork must surface, got: {err:#}"
         );
+    }
+
+    #[test]
+    fn emit_failure_rolls_back_the_saved_node() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(store_dir.path());
+        let plan = fixture_plan();
+        let inputs = flake_inputs("rev-1", ".#app");
+
+        // The node saves, then the emit fails. The error surfaces...
+        let err = record_image_node(&store, &FailingEmitter, &plan, &inputs, 1, &AgreeingAnchor)
+            .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("image.created"),
+            "the emit failure surfaces: {err:#}"
+        );
+
+        // ...and the just-saved node is rolled back, so the store keeps no
+        // un-audited phantom and a retry starts from a clean genesis.
+        assert!(
+            store.list().unwrap().is_empty(),
+            "the saved node must be rolled back when its audit emit fails"
+        );
+    }
+
+    #[test]
+    fn crash_orphaned_tip_self_heals_on_next_record() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let (store, emitter, vk) = harness(store_dir.path(), audit_dir.path());
+        let plan = fixture_plan();
+        let inputs = flake_inputs("rev-1", ".#app");
+
+        // Simulate a crash between save and emit: the node is in the store, but
+        // no `image.created` anchors it in the chain.
+        let orphan = ImageNode::builder(
+            inputs.build_identity.clone(),
+            ImageIdentity {
+                canonical: inputs.canonical.clone(),
+                artifacts: inputs.artifacts.clone(),
+            },
+            inputs.provenance.clone(),
+        )
+        .created_unix(7)
+        .build();
+        store.save(&orphan).unwrap();
+        assert!(
+            !audit_dir.path().join("local.jsonl").exists(),
+            "the orphan starts un-audited"
+        );
+
+        // Recording the same revision detects the un-audited tip and re-emits,
+        // rather than silently no-oping.
+        let outcome =
+            record_image_node(&store, &emitter, &plan, &inputs, 999, &UnauditedAnchor).unwrap();
+        assert_eq!(
+            outcome,
+            ImageNodeOutcome::Healed(orphan.node_digest.clone()),
+            "an orphaned tip must self-heal, not no-op"
+        );
+
+        // Exactly one node (no duplicate/fork) and now exactly one signed entry,
+        // and the healed node verifies against a chain that records it.
+        assert_eq!(store.list().unwrap().len(), 1, "no duplicate node");
+        let count = verify_audit_chain(&audit_dir.path().join("local.jsonl"), &vk).unwrap();
+        assert_eq!(count, 1, "the orphan's audit was completed with one entry");
+        verify_image_lineage(&store, &orphan.node_digest, &AgreeingAnchor).unwrap();
+
+        // A further rebuild, now that the chain records it, is a plain no-op.
+        let again =
+            record_image_node(&store, &emitter, &plan, &inputs, 1000, &AgreeingAnchor).unwrap();
+        assert_eq!(again, ImageNodeOutcome::AlreadyCurrent(orphan.node_digest));
+        let count = verify_audit_chain(&audit_dir.path().join("local.jsonl"), &vk).unwrap();
+        assert_eq!(count, 1, "a healed tip is not re-emitted again");
     }
 
     #[test]
@@ -961,6 +1240,61 @@ mod tests {
         // Still exactly one node and one audit entry — no duplicate, no re-emit.
         assert_eq!(ImageStore::open().list().unwrap().len(), 1);
         assert_eq!(local_audit_chain_len(tmp.path()), 1);
+    }
+
+    #[test]
+    fn record_flake_build_node_self_heals_a_crash_orphaned_tip() {
+        let mut env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        let slot_hash = "slot-orphan";
+        let revision_hash = "rev-orphan-1";
+        seed_slot_artifacts(slot_hash, revision_hash);
+        let persisted = persisted_manifest(slot_hash);
+        let revision = template_revision(revision_hash);
+
+        // Simulate a crash between save and emit: persist the node in the store
+        // WITHOUT recording its `image.created`. The store holds an un-audited
+        // orphan; no audit chain exists yet.
+        let store = ImageStore::open();
+        let rev_dir = slot_revision_dir(slot_hash, revision_hash);
+        let rootfs_sha = sha256_file_cached(&Path::new(&rev_dir).join("rootfs.ext4")).unwrap();
+        let vmlinux_sha = sha256_file_cached(&Path::new(&rev_dir).join("vmlinux")).unwrap();
+        let inputs = flake_node_inputs(slot_hash, &revision, rootfs_sha, vmlinux_sha);
+        let orphan = ImageNode::builder(
+            inputs.build_identity.clone(),
+            ImageIdentity {
+                canonical: inputs.canonical.clone(),
+                artifacts: inputs.artifacts.clone(),
+            },
+            inputs.provenance.clone(),
+        )
+        .created_unix(42)
+        .build();
+        store.save(&orphan).unwrap();
+        assert!(
+            !tmp.path().join("audit").join("local.jsonl").exists(),
+            "the orphan starts un-audited"
+        );
+
+        // A rebuild of the SAME revision detects the un-audited tip and completes
+        // its audit — without re-hashing (delete the artifacts to prove it).
+        std::fs::remove_file(Path::new(&rev_dir).join("rootfs.ext4")).unwrap();
+        std::fs::remove_file(Path::new(&rev_dir).join("vmlinux")).unwrap();
+        record_flake_build_node(&persisted, &revision)
+            .expect("self-heal must not re-hash the now-absent artifacts");
+
+        // The orphan is now audited: one signed entry, still exactly one node, and
+        // the node verifies against the real signed chain.
+        assert_eq!(
+            ImageStore::open().list().unwrap().len(),
+            1,
+            "no duplicate node"
+        );
+        assert_eq!(local_audit_chain_len(tmp.path()), 1, "orphan self-healed");
+        let anchor = SignedChainAnchor::load().unwrap();
+        verify_image_lineage(&store, &orphan.node_digest, &anchor).unwrap();
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/build/image_lineage.rs
+++ b/crates/mvm-cli/src/commands/build/image_lineage.rs
@@ -13,10 +13,22 @@
 //! entry). The invariant that actually protects trust is not "the store only
 //! holds anchored nodes" but "a stored node is never *trusted* without its
 //! signed chain entry": `verify_image_lineage` fails closed on any un-audited
-//! node. A process crash between the save and the emit can leave a stored node
-//! transiently un-audited; it is rejected by verification and self-healed on the
-//! next same-revision build, which detects the orphaned tip and completes its
-//! audit by re-emitting `image.created`.
+//! node.
+//!
+//! A process crash between the save and the emit can leave a stored node
+//! transiently un-audited. Verification rejects it; the next build self-heals
+//! it. Because a *later* revision can chain onto a crash-orphaned predecessor,
+//! the self-heal walks the tip's ancestry and completes the audit of every
+//! un-audited ancestor before either no-oping (same revision) or chaining a new
+//! child onto it — so a newly created node's full ancestry is always anchored
+//! and lineage verification cannot fail closed on a stranded orphan.
+//!
+//! A node carries a non-load-bearing `audit_ref` back-pointer, stamped once its
+//! creation is anchored, so the common path tells "already audited" from a cheap
+//! field read; the full signed chain is loaded (lazily, once) only when a node
+//! lacks the marker. The signed chain stays authoritative: a missing marker on
+//! an actually-audited node is confirmed against it and backfilled, never
+//! double-emitted.
 //!
 //! # Lineage is PROVENANCE, not AUTHORIZATION
 //!
@@ -27,6 +39,7 @@
 //! strictly on the build identity and the image's canonical revision — the
 //! recorded provenance is never an input to it.
 
+use std::cell::RefCell;
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 
@@ -108,12 +121,15 @@ pub(in crate::commands) enum ImageNodeOutcome {
 /// an error rather than a silent guess — the store's `head_for` fails closed on
 /// a fork and that error is propagated.
 ///
-/// A new node is committed to the store (atomically) and *then* chain-signed; an
-/// emit failure rolls the node back, so the chain never references a node the
-/// store dropped. When the tip already records this revision the outcome is a
-/// no-op ([`ImageNodeOutcome::AlreadyCurrent`]) if it is anchored in the signed
-/// chain, or a self-heal ([`ImageNodeOutcome::Healed`]) if a crash orphaned it
-/// before its `image.created` — checked via the same `anchor` the verifier uses.
+/// Before either no-oping or chaining a child, the tip's ancestry is healed: any
+/// un-audited ancestor (a crash orphan) has its `image.created` re-emitted, so a
+/// newly created node's full ancestry is always anchored and lineage
+/// verification cannot fail closed on a stranded orphan. A new node is committed
+/// atomically and *then* chain-signed; an emit failure rolls it back so the
+/// chain never references a node the store dropped. The healing check is
+/// marker-first — a node's `audit_ref` back-pointer proves it is anchored
+/// cheaply — and consults `anchor` (the same reader the verifier uses) only when
+/// a marker is absent.
 pub(in crate::commands) fn record_image_node(
     store: &ImageStore,
     emitter: &dyn ImageCreatedEmitter,
@@ -126,14 +142,26 @@ pub(in crate::commands) fn record_image_node(
         .head_for(&inputs.build_identity)
         .context("resolving the current image-lineage tip for this build identity")?;
 
+    // Heal any un-audited ancestor before we no-op on the tip or chain a child
+    // onto it, so the resulting tip's whole ancestry is anchored.
+    let healed = match &head {
+        Some(tip) => heal_unaudited_ancestry(store, emitter, plan, anchor, tip)?,
+        None => false,
+    };
+
     // The current tip already records this exact revision. We do not fork a
-    // second tip for one identity; instead reconcile its audit state. Provenance
-    // is deliberately not compared — it is recorded, never a chain-shaping input.
+    // second tip for one identity; the ancestry heal above already completed any
+    // orphaned audit. Provenance is deliberately not compared — it is recorded,
+    // never a chain-shaping input.
     if let Some(tip) = head
         .as_ref()
         .filter(|tip| tip.image_identity.canonical == inputs.canonical)
     {
-        return reconcile_recorded_tip(emitter, plan, anchor, tip);
+        return Ok(if healed {
+            ImageNodeOutcome::Healed(tip.node_digest.clone())
+        } else {
+            ImageNodeOutcome::AlreadyCurrent(tip.node_digest.clone())
+        });
     }
 
     let parent = head.map(|tip| tip.node_digest);
@@ -145,6 +173,8 @@ pub(in crate::commands) fn record_image_node(
 /// Save precedes emit so the store never holds a node the chain references but
 /// cannot resolve; the save is atomic ([`ImageStore::save`]). If the emit fails
 /// the just-saved node is rolled back, leaving nothing behind for a clean retry.
+/// On success the node is stamped with its audit back-pointer so a later build
+/// recognizes it as anchored without scanning the chain.
 fn create_image_node(
     store: &ImageStore,
     emitter: &dyn ImageCreatedEmitter,
@@ -171,30 +201,130 @@ fn create_image_node(
     if let Err(e) = emitter.emit_image_created(plan, &node) {
         // Roll the node back so the chain never references a node the store
         // dropped, and a retry re-creates it cleanly.
-        let _ = store.remove(&node.node_digest);
+        if let Err(rollback_err) = store.remove(&node.node_digest) {
+            tracing::warn!(
+                node_digest = %node.node_digest,
+                error = %rollback_err,
+                "failed to roll back an un-audited image-lineage node after its audit emit \
+                 failed; it will be rejected by lineage verification and healed on the next build"
+            );
+        }
         return Err(e).context("recording image.created in the signed audit chain");
     }
+    mark_audited(store, &node, plan);
     Ok(ImageNodeOutcome::Created(node.node_digest))
 }
 
-/// The tip already records this revision. A no-op if it is anchored in the
-/// signed chain; otherwise (a crash orphaned it between save and emit) complete
-/// its audit by re-emitting `image.created` for the *stored* node — no re-hash,
-/// no new node. The anchor is the same signed-chain reader the verifier uses, so
-/// "un-anchored" here means exactly what `verify_image_lineage` fails closed on.
-fn reconcile_recorded_tip(
+/// Walk `tip`'s ancestry to genesis, completing the audit of every un-audited
+/// node so a build never chains onto — or no-ops on — a chain with a stranded
+/// orphan (which would make `verify_image_lineage` fail closed forever). Returns
+/// whether any node was healed.
+///
+/// Marker-first: a node carrying an `audit_ref` is anchored, and by the
+/// create-time invariant so is its whole ancestry, so the walk stops there
+/// without touching the signed chain. Only an unmarked node consults the
+/// authoritative `anchor`: an already-audited-but-unmarked node (e.g. a
+/// pre-marker record) is confirmed and its marker backfilled with no re-emit; a
+/// genuine orphan has `image.created` re-emitted, then is marked. A single crash
+/// orphans one node, but the walk heals a run of them from successive crashes.
+fn heal_unaudited_ancestry(
+    store: &ImageStore,
     emitter: &dyn ImageCreatedEmitter,
     plan: &ExecutionPlan,
     anchor: &dyn ImageChainAnchor,
     tip: &ImageNode,
-) -> Result<ImageNodeOutcome> {
-    if anchor.recorded_creation_digest(tip)?.is_some() {
-        return Ok(ImageNodeOutcome::AlreadyCurrent(tip.node_digest.clone()));
+) -> Result<bool> {
+    let mut healed = false;
+    let mut current = tip.clone();
+    loop {
+        if current.audit_ref.is_some() {
+            break;
+        }
+        if anchor.recorded_creation_digest(&current)?.is_some() {
+            // Anchored already; the missing marker is just a stale record. Backfill
+            // it and stop — its ancestry is anchored too.
+            mark_audited(store, &current, plan);
+            break;
+        }
+        // A genuine orphan (saved, never emitted). The envelope binds to this
+        // build's plan; the entry's identity labels come from the node itself.
+        emitter
+            .emit_image_created(plan, &current)
+            .context("completing the audit of a crash-orphaned image-lineage ancestor")?;
+        mark_audited(store, &current, plan);
+        healed = true;
+
+        match &current.parent {
+            Some(parent_digest) => {
+                current = store
+                    .read(parent_digest)
+                    .context("reading an image-lineage ancestor to heal its audit")?;
+            }
+            None => break,
+        }
     }
-    emitter
-        .emit_image_created(plan, tip)
-        .context("completing the audit of a crash-orphaned image-lineage node")?;
-    Ok(ImageNodeOutcome::Healed(tip.node_digest.clone()))
+    Ok(healed)
+}
+
+/// Stamp a node's `audit_ref` back-pointer once its creation is anchored, so a
+/// later build recognizes it as audited from a field read rather than a chain
+/// scan. `audit_ref` is excluded from the content-address, so the re-save keeps
+/// the same `node_digest` (and directory) — the record is unchanged for
+/// verification. Best-effort: the marker is an optimization, and the signed
+/// chain stays authoritative, so a re-save failure is logged, not fatal.
+fn mark_audited(store: &ImageStore, node: &ImageNode, plan: &ExecutionPlan) {
+    if node.audit_ref.is_some() {
+        return;
+    }
+    let marked = ImageNode {
+        audit_ref: Some(audit_ref_marker(plan)),
+        ..node.clone()
+    };
+    if let Err(e) = store.save(&marked) {
+        tracing::warn!(
+            node_digest = %node.node_digest,
+            error = %e,
+            "failed to stamp an image-lineage node's audit marker; the next build will \
+             re-confirm it against the signed chain"
+        );
+    }
+}
+
+/// The value stamped in `audit_ref`: the per-tenant chain file the node's
+/// `image.created` entry lives in. Only its presence is load-bearing (the cheap
+/// "audited" marker); the value is informational, so the chain filename suffices.
+fn audit_ref_marker(plan: &ExecutionPlan) -> String {
+    format!("{}.jsonl", plan.tenant.0)
+}
+
+/// A [`SignedChainAnchor`] loaded on first use and cached, so the hot build path
+/// pays the full `~/.mvm/audit/` scan + verify only when a node lacks its cheap
+/// `audit_ref` marker (the rare orphan / pre-marker case), never on a build whose
+/// ancestry is fully marked.
+struct LazySignedChainAnchor {
+    inner: RefCell<Option<SignedChainAnchor>>,
+}
+
+impl LazySignedChainAnchor {
+    fn new() -> Self {
+        Self {
+            inner: RefCell::new(None),
+        }
+    }
+}
+
+impl ImageChainAnchor for LazySignedChainAnchor {
+    fn recorded_creation_digest(&self, node: &ImageNode) -> Result<Option<CheckpointDigest>> {
+        if self.inner.borrow().is_none() {
+            let loaded = load_signed_chain_anchor()?;
+            *self.inner.borrow_mut() = Some(loaded);
+        }
+        self.inner
+            .borrow()
+            .as_ref()
+            .expect("anchor was just loaded")
+            .recorded_creation_digest(node)
+    }
 }
 
 fn flake_build_identity(slot_hash: &str) -> ImageBuildIdentity {
@@ -317,16 +447,25 @@ pub(in crate::commands) fn record_flake_build_node(
     let canonical = flake_canonical(&revision.revision_hash);
     let store = ImageStore::open();
 
-    if tip_already_records(&store, &build_identity, &canonical)? {
-        // Tip already records this revision: reconcile its audit state without
-        // re-hashing the rootfs — a no-op if it is anchored, a self-heal if a
-        // crash orphaned it before its `image.created`.
-        return reconcile_over_signed_chain(
-            &store,
-            &build_identity,
-            &canonical,
-            &revision.flake_ref,
-        );
+    match classify_tip(&store, &build_identity, &canonical)? {
+        // Tip records this revision and is marked audited — the whole ancestry is
+        // anchored, so this is a genuine no-op: no lock, no hash, no chain scan.
+        TipDisposition::CurrentAndAudited(digest) => {
+            report_already_current(&digest);
+            return Ok(());
+        }
+        // Tip records this revision but is unmarked: reconcile (heal) without
+        // re-hashing the rootfs.
+        TipDisposition::CurrentButUnmarked => {
+            return reconcile_over_signed_chain(
+                &store,
+                &build_identity,
+                &canonical,
+                &revision.flake_ref,
+            );
+        }
+        // A genuinely new revision falls through to hash + record.
+        TipDisposition::NewRevision => {}
     }
 
     // Genuinely new (or genesis): hash the installed artifacts now, using the
@@ -351,20 +490,40 @@ pub(in crate::commands) fn record_flake_build_node(
     record_over_signed_chain(&store, &inputs, &revision.flake_ref, &rootfs_sha256)
 }
 
-/// Whether the current tip already records `canonical` for `build_identity` (an
-/// identical-revision rebuild). Cheap: reads only the stored node records, never
-/// hashing an artifact — this is the guard the hot path relies on to skip
-/// re-hashing an unchanged image. Propagates `head_for`'s fork error, so an
-/// ambiguous tip surfaces before any work.
-fn tip_already_records(
+/// How the current tip relates to the revision being recorded. Cheap: reads only
+/// the stored node records (and their `audit_ref` markers), never hashing an
+/// artifact and never scanning the signed chain — this is the guard the hot path
+/// relies on to skip re-hashing an unchanged image. Propagates `head_for`'s fork
+/// error, so an ambiguous tip surfaces before any work.
+enum TipDisposition {
+    /// The tip records this revision and carries its audit marker (so its whole
+    /// ancestry is anchored). Carries the tip digest.
+    CurrentAndAudited(CheckpointDigest),
+    /// The tip records this revision but has no audit marker — reconcile it (heal
+    /// an orphan, or backfill a pre-marker record) without re-hashing.
+    CurrentButUnmarked,
+    /// This revision is not the current tip — a new node must be created.
+    NewRevision,
+}
+
+fn classify_tip(
     store: &ImageStore,
     build_identity: &ImageBuildIdentity,
     canonical: &ImageCanonicalId,
-) -> Result<bool> {
+) -> Result<TipDisposition> {
     let head = store
         .head_for(build_identity)
         .context("resolving the current image-lineage tip for this build identity")?;
-    Ok(head.is_some_and(|tip| &tip.image_identity.canonical == canonical))
+    Ok(match head {
+        Some(tip) if &tip.image_identity.canonical == canonical => {
+            if tip.audit_ref.is_some() {
+                TipDisposition::CurrentAndAudited(tip.node_digest)
+            } else {
+                TipDisposition::CurrentButUnmarked
+            }
+        }
+        _ => TipDisposition::NewRevision,
+    })
 }
 
 /// Shared tail for a genuinely-new node: load the host signer, synthesize the
@@ -372,13 +531,14 @@ fn tip_already_records(
 /// `image_name` / `image_sha256` bind the audit entry; `image_sha256` is the
 /// rootfs digest for both callers.
 ///
-/// The lock serializes the `head_for` → save → emit critical section per build
-/// identity, so two concurrent recorders of one identity (e.g. two concurrent
-/// `machine run --flake` of one slot) cannot both read the same tip and fork the
-/// chain. The signed-chain anchor is loaded *inside* the lock so it reflects the
-/// chain as of the write, and `record_image_node`'s own reconcile guard is the
-/// backstop: a second writer that finds the first's node as the tip reconciles
-/// (no-op or self-heal) rather than forking.
+/// The lock serializes the `head_for` → heal → save → emit critical section per
+/// build identity, so two concurrent recorders of one identity (e.g. two
+/// concurrent `machine run --flake` of one slot) cannot both read the same tip
+/// and fork the chain. The signed-chain anchor is loaded lazily (and only inside
+/// the lock), so a build whose ancestry is fully marked never pays the scan, and
+/// `record_image_node`'s own reconcile guard is the backstop: a second writer
+/// that finds the first's node as the tip reconciles (no-op or self-heal) rather
+/// than forking.
 fn record_over_signed_chain(
     store: &ImageStore,
     inputs: &ImageNodeInputs,
@@ -395,7 +555,7 @@ fn record_over_signed_chain(
     )?;
 
     let outcome = with_identity_lock(store, &inputs.build_identity, || {
-        let anchor = load_signed_chain_anchor()?;
+        let anchor = LazySignedChainAnchor::new();
         record_image_node(store, &emitter, &plan, inputs, now_unix(), &anchor)
     })?;
     report_outcome(&outcome);
@@ -405,8 +565,9 @@ fn record_over_signed_chain(
 /// Shared tail for an already-recorded tip: reconcile its audit state under the
 /// per-identity lock without re-hashing the rootfs. The tip is re-read under the
 /// lock (it may have advanced since the caller's cheap pre-lock check); if it
-/// still records `canonical` its audit is completed when orphaned, else there is
-/// nothing to do here (a concurrent build advanced the chain past this revision).
+/// still records `canonical` its ancestry is healed (any orphan's audit
+/// completed, any pre-marker record backfilled), else there is nothing to do
+/// here (a concurrent build advanced the chain past this revision).
 fn reconcile_over_signed_chain(
     store: &ImageStore,
     build_identity: &ImageBuildIdentity,
@@ -416,7 +577,7 @@ fn reconcile_over_signed_chain(
     let emitter = open_audit_emitter()?;
 
     let outcome = with_identity_lock(store, build_identity, || {
-        let anchor = load_signed_chain_anchor()?;
+        let anchor = LazySignedChainAnchor::new();
         let Some(tip) = store
             .head_for(build_identity)
             .context("resolving the current image-lineage tip for this build identity")?
@@ -432,7 +593,12 @@ fn reconcile_over_signed_chain(
             image_name,
             &image_sha256,
         )?;
-        reconcile_recorded_tip(&emitter, &plan, &anchor, &tip).map(Some)
+        let healed = heal_unaudited_ancestry(store, &emitter, &plan, &anchor, &tip)?;
+        Ok(Some(if healed {
+            ImageNodeOutcome::Healed(tip.node_digest.clone())
+        } else {
+            ImageNodeOutcome::AlreadyCurrent(tip.node_digest.clone())
+        }))
     })?;
 
     if let Some(outcome) = outcome {
@@ -594,16 +760,23 @@ pub(in crate::commands) fn record_oci_pull_node(node: &OciPullNode<'_>) -> Resul
     let canonical = oci_canonical(node.resolved_digest);
     let store = ImageStore::open();
 
-    if tip_already_records(&store, &build_identity, &canonical)? {
-        // Tip already records this digest: reconcile its audit state without
-        // re-hashing the materialized rootfs (no-op if anchored, self-heal if a
-        // crash orphaned it).
-        return reconcile_over_signed_chain(
-            &store,
-            &build_identity,
-            &canonical,
-            node.canonical_reference,
-        );
+    match classify_tip(&store, &build_identity, &canonical)? {
+        // Tip records this digest and is marked audited — a genuine no-op.
+        TipDisposition::CurrentAndAudited(digest) => {
+            report_already_current(&digest);
+            return Ok(());
+        }
+        // Tip records this digest but is unmarked: reconcile (heal) without
+        // re-hashing the materialized rootfs.
+        TipDisposition::CurrentButUnmarked => {
+            return reconcile_over_signed_chain(
+                &store,
+                &build_identity,
+                &canonical,
+                node.canonical_reference,
+            );
+        }
+        TipDisposition::NewRevision => {}
     }
 
     let rootfs_sha256 = sha256_file_cached(node.rootfs_path).with_context(|| {
@@ -660,6 +833,24 @@ mod tests {
         }
     }
 
+    /// A test anchor that recognizes exactly the node digests it was given —
+    /// models a signed chain that recorded precisely those creations, so lineage
+    /// verification fails closed on any node whose heal was missed.
+    struct RecognizingAnchor(std::collections::HashSet<CheckpointDigest>);
+    impl RecognizingAnchor {
+        fn of(digests: &[&CheckpointDigest]) -> Self {
+            Self(digests.iter().map(|d| (*d).clone()).collect())
+        }
+    }
+    impl ImageChainAnchor for RecognizingAnchor {
+        fn recorded_creation_digest(&self, n: &ImageNode) -> Result<Option<CheckpointDigest>> {
+            Ok(self
+                .0
+                .contains(&n.node_digest)
+                .then(|| n.node_digest.clone()))
+        }
+    }
+
     /// An emitter whose `image.created` always fails — exercises the
     /// save-then-emit rollback without a real audit chain.
     struct FailingEmitter;
@@ -667,6 +858,21 @@ mod tests {
         fn emit_image_created(&self, _plan: &ExecutionPlan, _node: &ImageNode) -> Result<()> {
             anyhow::bail!("injected audit-emit failure")
         }
+    }
+
+    /// Build an [`ImageNode`] from node inputs at a fixed timestamp, as the
+    /// recorder would — for seeding crash-orphan fixtures directly into the store.
+    fn node_for(inputs: &ImageNodeInputs, created_unix: u64) -> ImageNode {
+        ImageNode::builder(
+            inputs.build_identity.clone(),
+            ImageIdentity {
+                canonical: inputs.canonical.clone(),
+                artifacts: inputs.artifacts.clone(),
+            },
+            inputs.provenance.clone(),
+        )
+        .created_unix(created_unix)
+        .build()
     }
 
     fn keypair() -> (SigningKey, VerifyingKey) {
@@ -1021,6 +1227,133 @@ mod tests {
         assert_eq!(count, 1, "a healed tip is not re-emitted again");
     }
 
+    /// The reviewer's regression: a DIFFERENT revision must heal a crash-orphaned
+    /// ancestor before chaining onto it. Without the ancestry walk, `rev-2` would
+    /// chain onto an un-audited `rev-1` and `verify_image_lineage(rev-2)` would
+    /// fail closed forever.
+    #[test]
+    fn a_new_revision_heals_the_orphaned_ancestor_it_chains_onto() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let (store, emitter, vk) = harness(store_dir.path(), audit_dir.path());
+        let plan = fixture_plan();
+
+        // Crash-orphan a genesis node for rev-1: saved, never emitted, unmarked.
+        let orphan = node_for(&flake_inputs("rev-1", ".#app"), 1);
+        store.save(&orphan).unwrap();
+
+        // A different revision rev-2 records. The anchor recognizes only what was
+        // emitted (nothing yet), so the orphaned ancestor must be healed first.
+        let rev2 = flake_inputs("rev-2", ".#app");
+        let outcome =
+            record_image_node(&store, &emitter, &plan, &rev2, 2, &UnauditedAnchor).unwrap();
+        let rev2_digest = match outcome {
+            ImageNodeOutcome::Created(d) => d,
+            other => panic!("expected Created, got {other:?}"),
+        };
+
+        // rev-2 hash-links to the (now healed) rev-1.
+        assert_eq!(
+            store
+                .by_digest(&rev2_digest)
+                .unwrap()
+                .unwrap()
+                .parent
+                .as_ref(),
+            Some(&orphan.node_digest)
+        );
+        // The chain grew by exactly two — the healed ancestor + the new node —
+        // with no duplicate emits, and the store holds exactly those two nodes.
+        let count = verify_audit_chain(&audit_dir.path().join("local.jsonl"), &vk).unwrap();
+        assert_eq!(count, 2, "one ancestor heal + one create, no duplicates");
+        assert_eq!(store.list().unwrap().len(), 2);
+        // The full lineage now verifies against a chain that records every node.
+        let recognized = RecognizingAnchor::of(&[&orphan.node_digest, &rev2_digest]);
+        verify_image_lineage(&store, &rev2_digest, &recognized).unwrap();
+    }
+
+    /// The walk heals a *run* of orphaned ancestors from successive crashes, not
+    /// just the immediate parent, and emits each exactly once.
+    #[test]
+    fn the_heal_walks_a_run_of_orphaned_ancestors() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let (store, emitter, vk) = harness(store_dir.path(), audit_dir.path());
+        let plan = fixture_plan();
+
+        // Two stacked orphans: rev-1 (genesis) ← rev-2, both saved, none emitted.
+        let g0 = node_for(&flake_inputs("rev-1", ".#app"), 1);
+        let g1 = ImageNode::builder(
+            g0.build_identity.clone(),
+            ImageIdentity {
+                canonical: ImageCanonicalId::Flake {
+                    revision_hash: "rev-2".into(),
+                },
+                artifacts: vec![blob("rootfs.ext4", "rev-2")],
+            },
+            g0.provenance.clone(),
+        )
+        .parent(Some(g0.node_digest.clone()))
+        .created_unix(2)
+        .build();
+        store.save(&g0).unwrap();
+        store.save(&g1).unwrap();
+
+        // A third revision chains on. Both orphaned ancestors must be healed.
+        let rev3 = flake_inputs("rev-3", ".#app");
+        let outcome =
+            record_image_node(&store, &emitter, &plan, &rev3, 3, &UnauditedAnchor).unwrap();
+        let rev3_digest = match outcome {
+            ImageNodeOutcome::Created(d) => d,
+            other => panic!("expected Created, got {other:?}"),
+        };
+
+        // Three emits total (two heals + one create), no double-heal, three nodes.
+        let count = verify_audit_chain(&audit_dir.path().join("local.jsonl"), &vk).unwrap();
+        assert_eq!(count, 3, "two ancestor heals + one create, each once");
+        assert_eq!(store.list().unwrap().len(), 3);
+        let recognized = RecognizingAnchor::of(&[&g0.node_digest, &g1.node_digest, &rev3_digest]);
+        verify_image_lineage(&store, &rev3_digest, &recognized).unwrap();
+    }
+
+    /// An audited-but-unmarked node (as a pre-marker record would be) is confirmed
+    /// against the signed chain and its marker backfilled — never re-emitted.
+    #[test]
+    fn an_audited_but_unmarked_tip_is_backfilled_not_re_emitted() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let (store, emitter, vk) = harness(store_dir.path(), audit_dir.path());
+        let plan = fixture_plan();
+        let inputs = flake_inputs("rev-1", ".#app");
+
+        // A node that was emitted but carries no audit marker on disk.
+        let node = node_for(&inputs, 5);
+        store.save(&node).unwrap();
+        emitter.emit_image_created(&plan, &node).unwrap();
+        assert!(node.audit_ref.is_none(), "seeded record has no marker");
+
+        // Recording the same revision: the anchor confirms it is audited, so the
+        // marker is backfilled with no second emit — a no-op, not a heal.
+        let outcome =
+            record_image_node(&store, &emitter, &plan, &inputs, 99, &AgreeingAnchor).unwrap();
+        assert_eq!(
+            outcome,
+            ImageNodeOutcome::AlreadyCurrent(node.node_digest.clone()),
+            "an already-audited tip is a no-op, not a heal"
+        );
+        let count = verify_audit_chain(&audit_dir.path().join("local.jsonl"), &vk).unwrap();
+        assert_eq!(count, 1, "confirmed-audited node must not be re-emitted");
+        assert!(
+            store
+                .by_digest(&node.node_digest)
+                .unwrap()
+                .unwrap()
+                .audit_ref
+                .is_some(),
+            "the marker was backfilled"
+        );
+    }
+
     #[test]
     fn flake_node_inputs_maps_slot_revision_and_artifacts() {
         let revision = TemplateRevision {
@@ -1295,6 +1628,62 @@ mod tests {
         assert_eq!(local_audit_chain_len(tmp.path()), 1, "orphan self-healed");
         let anchor = SignedChainAnchor::load().unwrap();
         verify_image_lineage(&store, &orphan.node_digest, &anchor).unwrap();
+    }
+
+    /// End-to-end regression against the real signed chain: a build of a DIFFERENT
+    /// revision must heal a crash-orphaned ancestor before chaining onto it, so
+    /// the new tip verifies. This is the reviewer's exact case, through the real
+    /// flake entry point and the production `SignedChainAnchor`.
+    #[test]
+    fn record_flake_build_node_heals_an_orphaned_ancestor_across_revisions() {
+        let mut env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        let slot_hash = "slot-cross";
+        let store = ImageStore::open();
+
+        // Crash-orphan a genesis node for rev-1: saved, never emitted, unmarked.
+        let orphan = ImageNode::builder(
+            flake_build_identity(slot_hash),
+            ImageIdentity {
+                canonical: flake_canonical("rev-1"),
+                artifacts: vec![blob("rootfs.ext4", &"a".repeat(64))],
+            },
+            ImageProvenance::Build {
+                input_ref: ".#app".into(),
+                lock_digest: None,
+            },
+        )
+        .created_unix(1)
+        .build();
+        store.save(&orphan).unwrap();
+        assert!(!tmp.path().join("audit").join("local.jsonl").exists());
+
+        // A different revision rev-2 builds and records. It must heal rev-1 first.
+        let revision_hash = "rev-2";
+        seed_slot_artifacts(slot_hash, revision_hash);
+        record_flake_build_node(
+            &persisted_manifest(slot_hash),
+            &template_revision(revision_hash),
+        )
+        .unwrap();
+
+        // rev-2 chained onto the (now healed) rev-1; the chain grew by exactly two
+        // (heal + create); the whole lineage verifies against the real chain.
+        let tip = store
+            .head_for(&flake_build_identity(slot_hash))
+            .unwrap()
+            .expect("rev-2 recorded");
+        assert_eq!(tip.parent.as_ref(), Some(&orphan.node_digest));
+        assert_eq!(
+            local_audit_chain_len(tmp.path()),
+            2,
+            "heal + create, no dupes"
+        );
+        assert_eq!(store.list().unwrap().len(), 2);
+        let anchor = SignedChainAnchor::load().unwrap();
+        verify_image_lineage(&store, &tip.node_digest, &anchor).unwrap();
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -30,7 +30,7 @@ use crate::ui;
 mod lineage;
 mod revert;
 mod timeline;
-pub(super) use lineage::SignedChainAnchor;
+pub(in crate::commands) use lineage::SignedChainAnchor;
 pub(in crate::commands) use revert::{
     AdvanceArgs, RevertArgs, RevertOutcome, RevertRunImage, run_advance, run_revert, run_rewind,
 };
@@ -2442,19 +2442,46 @@ mod tests {
             },
         };
 
-        // Genesis build.
-        let genesis = match record_image_node(&store, &emitter, &plan, &inputs("rev-1"), 1).unwrap()
+        // Genesis build. The anchor is the real signed-chain reader, reloaded per
+        // call so it reflects the chain as of that record.
+        let genesis = match record_image_node(
+            &store,
+            &emitter,
+            &plan,
+            &inputs("rev-1"),
+            1,
+            &SignedChainAnchor::load().unwrap(),
+        )
+        .unwrap()
         {
             ImageNodeOutcome::Created(d) => d,
             other => panic!("expected Created, got {other:?}"),
         };
-        // Idempotent rebuild of the identical revision → no new node.
+        // Idempotent rebuild of the identical revision → no new node (the genesis
+        // is now anchored in the reloaded chain).
         assert!(matches!(
-            record_image_node(&store, &emitter, &plan, &inputs("rev-1"), 2).unwrap(),
+            record_image_node(
+                &store,
+                &emitter,
+                &plan,
+                &inputs("rev-1"),
+                2,
+                &SignedChainAnchor::load().unwrap(),
+            )
+            .unwrap(),
             ImageNodeOutcome::AlreadyCurrent(_)
         ));
         // New revision chains as a child of genesis.
-        let child = match record_image_node(&store, &emitter, &plan, &inputs("rev-2"), 3).unwrap() {
+        let child = match record_image_node(
+            &store,
+            &emitter,
+            &plan,
+            &inputs("rev-2"),
+            3,
+            &SignedChainAnchor::load().unwrap(),
+        )
+        .unwrap()
+        {
             ImageNodeOutcome::Created(d) => d,
             other => panic!("expected Created, got {other:?}"),
         };
@@ -2518,17 +2545,43 @@ mod tests {
             },
         };
 
-        let genesis = match record_image_node(&store, &emitter, &plan, &inputs("a"), 1).unwrap() {
+        let genesis = match record_image_node(
+            &store,
+            &emitter,
+            &plan,
+            &inputs("a"),
+            1,
+            &SignedChainAnchor::load().unwrap(),
+        )
+        .unwrap()
+        {
             ImageNodeOutcome::Created(d) => d,
             other => panic!("expected Created, got {other:?}"),
         };
-        // Re-pulling the same digest is idempotent.
+        // Re-pulling the same digest is idempotent (the genesis is now anchored).
         assert!(matches!(
-            record_image_node(&store, &emitter, &plan, &inputs("a"), 2).unwrap(),
+            record_image_node(
+                &store,
+                &emitter,
+                &plan,
+                &inputs("a"),
+                2,
+                &SignedChainAnchor::load().unwrap(),
+            )
+            .unwrap(),
             ImageNodeOutcome::AlreadyCurrent(_)
         ));
         // A newly-resolved digest for the same repo chains as a child.
-        let child = match record_image_node(&store, &emitter, &plan, &inputs("b"), 3).unwrap() {
+        let child = match record_image_node(
+            &store,
+            &emitter,
+            &plan,
+            &inputs("b"),
+            3,
+            &SignedChainAnchor::load().unwrap(),
+        )
+        .unwrap()
+        {
             ImageNodeOutcome::Created(d) => d,
             other => panic!("expected Created, got {other:?}"),
         };

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -3,7 +3,7 @@
 pub(super) mod agent_verbs;
 pub(super) mod artifact;
 pub(super) mod audit_chain;
-pub(super) mod checkpoint;
+pub(in crate::commands) mod checkpoint;
 pub(crate) mod console;
 pub(super) mod cp;
 pub(super) mod diff;

--- a/crates/mvm-runtime/src/image_lineage.rs
+++ b/crates/mvm-runtime/src/image_lineage.rs
@@ -7,13 +7,31 @@
 //! Nothing here grants a child trust because an ancestor is present or verified;
 //! boot integrity stays with dm-verity and admission with the signed bundle.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result};
 use mvm_core::checkpoint::CheckpointDigest;
 use mvm_core::image_lineage::{ImageBuildIdentity, ImageNode};
 
 use crate::lineage::{LineageAnchor, LineageGraph, LineageRecord};
+
+/// Distinguishes concurrent temp files a single process writes into one node
+/// directory, so two threads saving the same content-address never collide on
+/// the scratch name before the atomic `rename`.
+static NEXT_TMP_NONCE: AtomicU64 = AtomicU64::new(0);
+
+/// Write `bytes` to `tmp_path`, fsync it, then `rename` it onto `final_path`.
+/// The rename is the atomic commit point; the fsync makes the committed bytes
+/// durable across a power loss.
+fn write_fsync_rename(tmp_path: &Path, final_path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let mut f = std::fs::File::create(tmp_path)?;
+    f.write_all(bytes)?;
+    f.sync_all()?;
+    drop(f);
+    std::fs::rename(tmp_path, final_path)
+}
 
 /// Filesystem-backed registry over `config::images_dir()` (or any root, for
 /// tests). Layout: `<root>/<node-digest>/node.json`. A node's directory name is
@@ -45,15 +63,42 @@ impl ImageStore {
         self.dir_for(node_digest).join("node.json")
     }
 
-    /// Persist a node under its own content-address.
+    /// Persist a node under its own content-address, atomically. The record is
+    /// written to a temp sibling, fsynced, and `rename`d into place, so a reader
+    /// (or a crash) never observes a half-written `node.json` — a save is
+    /// all-or-nothing. The recorder relies on this: it commits the node before
+    /// chain-signing its creation, and a partially-written record would break the
+    /// digest self-consistency [`read`] enforces.
     pub fn save(&self, node: &ImageNode) -> Result<()> {
         let dir = self.dir_for(&node.node_digest);
         std::fs::create_dir_all(&dir)
             .with_context(|| format!("creating image node dir {}", dir.display()))?;
         let json = serde_json::to_vec_pretty(node).context("serializing image node")?;
-        let path = self.node_path(&node.node_digest);
-        std::fs::write(&path, json).with_context(|| format!("writing {}", path.display()))?;
+        let final_path = self.node_path(&node.node_digest);
+        let tmp_path = dir.join(format!(
+            "node.json.{}.{}.tmp",
+            std::process::id(),
+            NEXT_TMP_NONCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        if let Err(e) = write_fsync_rename(&tmp_path, &final_path, &json) {
+            // Never leave a stray temp behind on a failed write.
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(e).with_context(|| format!("writing {}", final_path.display()));
+        }
         Ok(())
+    }
+
+    /// Delete a node's on-disk record and its directory. Tolerates an
+    /// already-absent node (idempotent). Used to roll back a just-saved node when
+    /// chain-signing its creation fails, so the store never keeps a node whose
+    /// creation the recorder abandoned.
+    pub fn remove(&self, node_digest: &CheckpointDigest) -> Result<()> {
+        let dir = self.dir_for(node_digest);
+        match std::fs::remove_dir_all(&dir) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("removing image node dir {}", dir.display())),
+        }
     }
 
     /// Read the node stored under `node_digest` (its directory name). Fails
@@ -351,6 +396,52 @@ mod tests {
         let n = node("slot-a", "rev-1", None);
         store.save(&n).unwrap();
         assert_eq!(store.read(&n.node_digest).unwrap(), n);
+    }
+
+    #[test]
+    fn save_is_atomic_and_leaves_no_temp_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        let n = node("slot-a", "rev-1", None);
+        store.save(&n).unwrap();
+
+        // The committed record is complete and parses back to the same node.
+        assert_eq!(store.read(&n.node_digest).unwrap(), n);
+
+        // The node directory holds exactly node.json — the temp sibling was
+        // renamed away, never left behind.
+        let dir = store.dir_for(&n.node_digest);
+        let names: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["node.json".to_string()],
+            "only node.json, no .tmp"
+        );
+
+        // Re-saving overwrites in place (rename-replace), still leaving one file.
+        store.save(&n).unwrap();
+        assert_eq!(store.read(&n.node_digest).unwrap(), n);
+        let after: Vec<_> = std::fs::read_dir(&dir).unwrap().collect();
+        assert_eq!(after.len(), 1, "overwrite leaves a single node.json");
+    }
+
+    #[test]
+    fn remove_deletes_the_node_and_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        let n = node("slot-a", "rev-1", None);
+        store.save(&n).unwrap();
+        assert!(store.dir_for(&n.node_digest).exists());
+
+        store.remove(&n.node_digest).unwrap();
+        assert!(!store.dir_for(&n.node_digest).exists(), "node dir removed");
+        assert!(store.by_digest(&n.node_digest).unwrap().is_none());
+
+        // Removing an already-absent node is a no-op, not an error.
+        store.remove(&n.node_digest).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Closes #1833.

Fixes the `image.created` emit-then-save non-atomicity in image-lineage node
creation, so a failure between the audit emit and the store save can't leave a
phantom audit entry — while keeping the security invariant intact: a node is
never *trusted* without its signed chain entry (`verify_image_lineage` stays
fail-closed).

## What's here
- **Save-then-emit with rollback.** `record_image_node` saves the node
  (atomically — temp + fsync + rename), then emits `image.created`; if the emit
  fails it rolls the node back (logging a warn) — so the chain never references a
  node the store dropped, and a failed emit leaves nothing behind.
- **Heal every un-audited ancestor before chaining.** Before a new node chains
  onto the current tip, the tip's ancestry is walked and any un-audited node is
  re-emitted (a crash-orphan self-heal), stopping only at a node WE marked
  (whose ancestry is therefore already healed) or genesis — never on a bare
  anchor confirmation. So `verify_image_lineage` can never be permanently broken
  by an orphaned ancestor. A `seen` cycle guard bounds the walk.
- **Cheap hot path.** A per-node `audit_ref` marker (set after a successful
  emit; excluded from the content-address) + a lazily-loaded, at-most-once
  signed-chain anchor mean a normal `machine run --flake` of an already-marked
  tip does no lock, no hash, and no audit-chain scan; the full anchor loads only
  on a marker miss (the rare orphan / pre-marker case), and stays authoritative.

## Verification
Two-stage adversarial review caught two subtle regressions in the heal logic (an
incomplete self-heal that could permanently break `verify_image_lineage` for a
different-revision next build, then the same one hop deeper past an
anchored-but-unmarked node) — both fixed, each with a test for the exact
reproduced case, plus a fabricated-cycle test. `verify_image_lineage` proven to
stay anchor-authoritative (the marker never bypasses verification).

`nextest --workspace` 7713 passed / 0 failed; doctests, `clippy --all-targets
-D warnings`, nightly fmt, `check-content-address-determinism`, and
`check-no-spec-refs-in-comments` all clean.
