### PR TITLE
fix(kernel): bump guest pins to 6.12.98

### DIFF
--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -49,10 +49,10 @@ let
   # kernel — lets both of mvm's kernels track the latest point release exactly
   # and keeps the two pins from drifting apart. Bump `kernelVersion` + `hash`
   # together (the tarball's own sha256, e.g. via `nix store prefetch-file`).
-  kernelVersion = "6.12.97";
+  kernelVersion = "6.12.98";
   kernelSrc = pkgs.fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${kernelVersion}.tar.xz";
-    hash = "sha256-bL3fo7vSIpAm98xeSPa31rRtOXQt45qSV6L0kKD0XG8=";
+    hash = "sha256-pitqLSB/9yUQ5fRxVrcHjh5xeXNXQSQRuOT/+X/I9Mc=";
   };
 
   # ── Base: minimal feature set common to every mvm microVM kernel ──

--- a/nix/packages/libkrunfw.nix
+++ b/nix/packages/libkrunfw.nix
@@ -20,8 +20,8 @@ assert lib.elem variant [
 
 let
   kernelSrc = fetchurl {
-    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.97.tar.xz";
-    hash = "sha256-bL3fo7vSIpAm98xeSPa31rRtOXQt45qSV6L0kKD0XG8=";
+    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.98.tar.xz";
+    hash = "sha256-pitqLSB/9yUQ5fRxVrcHjh5xeXNXQSQRuOT/+X/I9Mc=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -15,6 +15,12 @@
       Implementation, focused tests, workspace tests, check, and clippy pass;
       branch is ready for pull request review.
 
+- [x] #1839 kernel pin freshness remediation: update the synchronized
+      libkrunfw and custom guest kernel pins to Linux 6.12.98. Both pins now
+      use the verified upstream hash; focused coverage, freshness checking,
+      workspace tests, check, clippy, and formatting pass. Published as PR
+      #1845 for review.
+
 ---
 
 ## 1. Why

--- a/specs/plans/262-kernel-pin-bump.md
+++ b/specs/plans/262-kernel-pin-bump.md
@@ -1,0 +1,28 @@
+# Kernel pin freshness remediation
+
+Issue: #1839
+
+Status: COMPLETE
+
+## Scope
+
+Update the two deliberately synchronized Linux 6.12 kernel pins from 6.12.97
+to the published 6.12.98 point release. Both pins use the same upstream
+tarball and must carry the same verified Nix SRI hash.
+
+## Delivery checklist
+
+- [x] Update the `libkrunfw` tarball URL and hash.
+- [x] Update the custom workload/builder kernel version and hash.
+- [x] Add or update focused coverage for synchronized kernel pins.
+- [x] Run formatting, workspace check, tests, and clippy gates.
+- [ ] Publish the verified branch as a pull request.
+
+The verified branch is ready for publication as a pull request.
+
+## Source verification
+
+The upstream `linux-6.12.98.tar.xz` SHA-256 is
+`a62b6a2d207ff72510e5f47156b7078e1e71797357412411b8e4fff97fc8f4c7`, which
+converts to the Nix SRI hash
+`sha256-pitqLSB/9yUQ5fRxVrcHjh5xeXNXQSQRuOT/+X/I9Mc=`.

--- a/specs/plans/262-kernel-pin-bump.md
+++ b/specs/plans/262-kernel-pin-bump.md
@@ -16,9 +16,9 @@ tarball and must carry the same verified Nix SRI hash.
 - [x] Update the custom workload/builder kernel version and hash.
 - [x] Add or update focused coverage for synchronized kernel pins.
 - [x] Run formatting, workspace check, tests, and clippy gates.
-- [ ] Publish the verified branch as a pull request.
+- [x] Publish the verified branch as pull request #1845.
 
-The verified branch is ready for publication as a pull request.
+Pull request #1845 is open for review.
 
 ## Source verification
 

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -216,6 +216,8 @@ fn native_vmm_recipes_are_source_built_and_pinned() {
         .unwrap_or_else(|e| panic!("nix/packages/libkrunfw.nix must be present: {e}"));
     let libkrun = fs::read_to_string(packages_dir.join("libkrun.nix"))
         .unwrap_or_else(|e| panic!("nix/packages/libkrun.nix must be present: {e}"));
+    let kernel_base = fs::read_to_string(nix_dir().join("images/kernel/base.nix"))
+        .unwrap_or_else(|e| panic!("nix/images/kernel/base.nix must be present: {e}"));
 
     for (name, content) in [
         ("libkrunfw.nix", libkrunfw.as_str()),
@@ -238,11 +240,19 @@ fn native_vmm_recipes_are_source_built_and_pinned() {
         );
     }
 
+    const KERNEL_VERSION: &str = "6.12.98";
+    const KERNEL_HASH: &str = "sha256-pitqLSB/9yUQ5fRxVrcHjh5xeXNXQSQRuOT/+X/I9Mc=";
     assert!(
-        libkrunfw.contains("linux-6.12.97.tar.xz")
+        libkrunfw.contains(&format!("linux-{KERNEL_VERSION}.tar.xz"))
+            && libkrunfw.contains(&format!("hash = \"{KERNEL_HASH}\""))
             && libkrunfw.contains("KERNEL_REMOTE")
             && libkrunfw.contains("ln -s ${kernelSrc} $(KERNEL_TARBALL)"),
         "libkrunfw must pin and substitute the kernel source instead of downloading it during build"
+    );
+    assert!(
+        kernel_base.contains(&format!("kernelVersion = \"{KERNEL_VERSION}\""))
+            && kernel_base.contains(&format!("hash = \"{KERNEL_HASH}\"")),
+        "the custom kernel must use the same verified point-release pin as libkrunfw"
     );
     assert!(
         libkrun.contains("rustPlatform.fetchCargoVendor")


### PR DESCRIPTION
Closes #1839

## Summary

- bump the libkrunfw bundled kernel source to Linux 6.12.98
- bump the custom workload/builder kernel source to the same verified point release
- enforce synchronized version and hash coverage in the Nix structure test

## Verification

- `cargo run -q -p xtask -- check-kernel-pin-freshness --quiet`
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`