### PR TITLE
fix(lineage): atomically publish image.created nodes

### DIFF
--- a/crates/mvm-cli/src/commands/build/image_lineage.rs
+++ b/crates/mvm-cli/src/commands/build/image_lineage.rs
@@ -3,8 +3,8 @@
 //! A build produces a compiled microVM image; this module content-addresses
 //! that image into an [`ImageNode`], hash-links it onto the prior build of the
 //! same slot identity, and binds its creation into the host-signed audit chain
-//! *before* the build reports success. The store never holds a node the audit
-//! chain cannot anchor.
+//! after staging the node, then atomically publishes it before the build reports
+//! success. The store never holds a node the audit chain cannot anchor.
 //!
 //! # Lineage is PROVENANCE, not AUTHORIZATION
 //!
@@ -77,9 +77,10 @@ pub(in crate::commands) enum ImageNodeOutcome {
 /// surfaces as an error rather than a silent guess — the store's `head_for`
 /// fails closed on a fork and that error is propagated.
 ///
-/// Creation is chain-signed into the audit log *before* the node is persisted:
-/// an audit failure aborts with no unaudited node left behind, so a node in the
-/// store is always backed by a signature the verifier can anchor.
+/// The node is staged before its creation is chain-signed, then atomically
+/// published after the audit succeeds. An audit or staging failure therefore
+/// leaves no visible node, while a node in the store is always backed by a
+/// signature the verifier can anchor.
 pub(in crate::commands) fn record_image_node(
     store: &ImageStore,
     emitter: &AuditEmitter,
@@ -103,7 +104,30 @@ pub(in crate::commands) fn record_image_node(
         None => None,
     };
 
-    let node = ImageNode::builder(
+    let node = build_image_node(inputs, parent, created_unix);
+
+    // Prepare all filesystem writes before signing. If staging fails, no audit
+    // entry is emitted and no visible node can be left behind.
+    let staged = store
+        .stage(&node)
+        .context("staging the image-lineage node before audit")?;
+
+    emitter
+        .emit_image_created(plan, &node)
+        .context("recording image.created in the signed audit chain")?;
+    staged
+        .commit()
+        .context("publishing the image-lineage node after audit")?;
+
+    Ok(ImageNodeOutcome::Created(node.node_digest))
+}
+
+fn build_image_node(
+    inputs: &ImageNodeInputs,
+    parent: Option<CheckpointDigest>,
+    created_unix: u64,
+) -> ImageNode {
+    ImageNode::builder(
         inputs.build_identity.clone(),
         ImageIdentity {
             canonical: inputs.canonical.clone(),
@@ -113,18 +137,7 @@ pub(in crate::commands) fn record_image_node(
     )
     .parent(parent)
     .created_unix(created_unix)
-    .build();
-
-    // Chain-sign the creation before persisting: the store must never hold a
-    // node the signed chain cannot anchor.
-    emitter
-        .emit_image_created(plan, &node)
-        .context("recording image.created in the signed audit chain")?;
-    store
-        .save(&node)
-        .context("persisting the image-lineage node")?;
-
-    Ok(ImageNodeOutcome::Created(node.node_digest))
+    .build()
 }
 
 fn flake_build_identity(slot_hash: &str) -> ImageBuildIdentity {
@@ -566,6 +579,23 @@ mod tests {
         // Its creation is a single chain-signed audit entry that verifies clean.
         let count = verify_audit_chain(&audit_dir.path().join("local.jsonl"), &vk).unwrap();
         assert_eq!(count, 1, "one image.created entry, chain-signed");
+    }
+
+    #[test]
+    fn staging_failure_does_not_emit_a_phantom_creation_entry() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let (store, emitter, _vk) = harness(store_dir.path(), audit_dir.path());
+        let plan = fixture_plan();
+        let inputs = flake_inputs("rev-1", ".#app");
+        let node = build_image_node(&inputs, None, 100);
+
+        // A regular file at the content-addressed directory makes staging fail
+        // before the emitter can append image.created.
+        std::fs::write(store.dir_for(&node.node_digest), b"not a directory").unwrap();
+        let err = record_image_node(&store, &emitter, &plan, &inputs, 100).unwrap_err();
+        assert!(format!("{err:#}").contains("staging the image-lineage node"));
+        assert!(!audit_dir.path().join("local.jsonl").exists());
     }
 
     #[test]

--- a/crates/mvm-runtime/src/image_lineage.rs
+++ b/crates/mvm-runtime/src/image_lineage.rs
@@ -7,6 +7,7 @@
 //! Nothing here grants a child trust because an ancestor is present or verified;
 //! boot integrity stays with dm-verity and admission with the signed bundle.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -20,6 +21,34 @@ use crate::lineage::{LineageAnchor, LineageGraph, LineageRecord};
 /// its own content-address, so a node is addressable by digest without an index.
 pub struct ImageStore {
     root: PathBuf,
+}
+
+/// A serialized image node prepared for publication after its audit entry is
+/// durable. Dropping an uncommitted stage removes its temporary file, so an
+/// audit failure cannot leave a visible node behind.
+#[must_use = "a staged image node must be committed after its audit entry succeeds"]
+pub struct StagedImageNode {
+    temp: Option<tempfile::NamedTempFile>,
+    destination: PathBuf,
+}
+
+impl StagedImageNode {
+    /// Atomically publish the staged node at its content-addressed destination.
+    pub fn commit(mut self) -> Result<()> {
+        let Some(temp) = self.temp.take() else {
+            anyhow::bail!("staged image node was already committed");
+        };
+        let destination = self.destination.clone();
+        match temp.persist(&destination) {
+            Ok(_) => Ok(()),
+            Err(error) => {
+                let _ = error.file.close();
+                Err(error.error).with_context(|| {
+                    format!("publishing staged image node {}", destination.display())
+                })
+            }
+        }
+    }
 }
 
 impl ImageStore {
@@ -45,15 +74,29 @@ impl ImageStore {
         self.dir_for(node_digest).join("node.json")
     }
 
-    /// Persist a node under its own content-address.
-    pub fn save(&self, node: &ImageNode) -> Result<()> {
+    /// Prepare a node under its own content-address without publishing it.
+    pub fn stage(&self, node: &ImageNode) -> Result<StagedImageNode> {
         let dir = self.dir_for(&node.node_digest);
         std::fs::create_dir_all(&dir)
             .with_context(|| format!("creating image node dir {}", dir.display()))?;
         let json = serde_json::to_vec_pretty(node).context("serializing image node")?;
-        let path = self.node_path(&node.node_digest);
-        std::fs::write(&path, json).with_context(|| format!("writing {}", path.display()))?;
-        Ok(())
+        let mut temp = tempfile::NamedTempFile::new_in(&dir)
+            .with_context(|| format!("creating staged image node in {}", dir.display()))?;
+        temp.write_all(&json)
+            .with_context(|| format!("writing staged image node in {}", dir.display()))?;
+        temp.flush().context("flushing staged image node")?;
+        temp.as_file()
+            .sync_all()
+            .context("syncing staged image node")?;
+        Ok(StagedImageNode {
+            temp: Some(temp),
+            destination: self.node_path(&node.node_digest),
+        })
+    }
+
+    /// Persist a node under its own content-address atomically.
+    pub fn save(&self, node: &ImageNode) -> Result<()> {
+        self.stage(node)?.commit()
     }
 
     /// Read the node stored under `node_digest` (its directory name). Fails
@@ -351,6 +394,22 @@ mod tests {
         let n = node("slot-a", "rev-1", None);
         store.save(&n).unwrap();
         assert_eq!(store.read(&n.node_digest).unwrap(), n);
+    }
+
+    #[test]
+    fn dropping_an_uncommitted_stage_does_not_publish_a_node() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ImageStore::at(tmp.path());
+        let n = node("slot-a", "rev-1", None);
+
+        {
+            let _staged = store.stage(&n).unwrap();
+            assert!(store.by_digest(&n.node_digest).unwrap().is_none());
+        }
+
+        assert!(store.by_digest(&n.node_digest).unwrap().is_none());
+        let node_dir = store.dir_for(&n.node_digest);
+        assert!(std::fs::read_dir(node_dir).unwrap().next().is_none());
     }
 
     #[test]

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -15,6 +15,11 @@
       Implementation, focused tests, workspace tests, check, and clippy pass;
       branch is ready for pull request review.
 
+- [x] #1833 image.created atomicity: stage image-lineage nodes before audit
+      emission and atomically publish them only after the signed entry succeeds.
+      Focused tests, workspace check, full tests, clippy, and formatting pass;
+      PR publication is pending.
+
 ---
 
 ## 1. Why

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -18,7 +18,7 @@
 - [x] #1833 image.created atomicity: stage image-lineage nodes before audit
       emission and atomically publish them only after the signed entry succeeds.
       Focused tests, workspace check, full tests, clippy, and formatting pass;
-      PR publication is pending.
+      published as PR #1846 for review.
 
 ---
 

--- a/specs/plans/263-image-created-atomicity.md
+++ b/specs/plans/263-image-created-atomicity.md
@@ -18,6 +18,6 @@ An audit or staging failure must leave no visible node or phantom creation entry
 - [x] Add store and recorder tests for uncommitted-stage cleanup and staging
       failure before audit emission.
 - [x] Run formatting, workspace check, tests, and clippy gates.
-- [ ] Publish the verified branch as a pull request.
+- [x] Publish the verified branch as pull request #1846.
 
-The verified branch is ready for publication as a pull request.
+Pull request #1846 is open for review.

--- a/specs/plans/263-image-created-atomicity.md
+++ b/specs/plans/263-image-created-atomicity.md
@@ -1,0 +1,23 @@
+# Atomic image-lineage publication
+
+Issue: #1833
+
+Status: COMPLETE
+
+## Scope
+
+Prepare the serialized image-lineage node before emitting `image.created`, then
+publish the prepared file atomically only after the signed audit entry succeeds.
+An audit or staging failure must leave no visible node or phantom creation entry.
+
+## Delivery checklist
+
+- [x] Add a staged image-node publication API with RAII cleanup for abandoned
+      temporary files.
+- [x] Move the build recorder to stage, audit, then atomically publish.
+- [x] Add store and recorder tests for uncommitted-stage cleanup and staging
+      failure before audit emission.
+- [x] Run formatting, workspace check, tests, and clippy gates.
+- [ ] Publish the verified branch as a pull request.
+
+The verified branch is ready for publication as a pull request.


### PR DESCRIPTION
Closes #1833

## Summary

- stage serialized image-lineage nodes before emitting `image.created`
- atomically publish the staged node only after audit succeeds
- clean up abandoned stages and cover staging failures with tests

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`