### PR TITLE
feat(audit): host Merkle root builder + trust-audit verbs, tenant-bound (closes #1811)

### DIFF
--- a/crates/mvm-cli/src/commands/ops/audit.rs
+++ b/crates/mvm-cli/src/commands/ops/audit.rs
@@ -143,9 +143,10 @@ pub(in crate::commands) enum AuditAction {
     },
     /// Verify an inclusion proof against a host-signed root — the full
     /// membership check. Verifies the signed root under the trusted host
-    /// key, verifies the proof, and binds the two (root_hash + tree_size
-    /// must match). Nonzero exit naming the failed check on any failure; a
-    /// self-consistent proof over an unsigned root is rejected.
+    /// key, checks it is for `--tenant`, verifies the proof, and binds the
+    /// two (root_hash + tree_size must match). Nonzero exit naming the
+    /// failed check on any failure; a genuinely-signed root for a different
+    /// tenant, or a self-consistent proof over an unsigned root, is rejected.
     VerifyInclusion {
         /// Path to the inclusion-proof JSON, or `-` to read from stdin.
         #[arg(long)]
@@ -159,7 +160,8 @@ pub(in crate::commands) enum AuditAction {
         /// or base64.
         #[arg(long)]
         pubkey: Option<std::path::PathBuf>,
-        /// Tenant whose default root path to use when `--root` is omitted.
+        /// Tenant the signed root must be bound to (and whose default root
+        /// path is used when `--root` is omitted).
         #[arg(long, default_value = "local")]
         tenant: String,
     },
@@ -548,8 +550,8 @@ fn audit_verify_inclusion(
         }
     };
 
-    // 4-6: the composition. Fail closed naming the failed check.
-    let message = run_verify_inclusion(&proof, &signed_root, &vk)?;
+    // 4-7: the composition. Fail closed naming the failed check.
+    let message = run_verify_inclusion(&proof, &signed_root, &vk, tenant)?;
     ui::success(&message);
     Ok(())
 }
@@ -559,20 +561,31 @@ fn audit_verify_inclusion(
 ///
 /// Enforces, in order and fail-closed:
 ///   1. the signed root verifies under the trusted host key;
-///   2. the inclusion proof is internally consistent (folds to its own root);
-///   3. the proof binds to THIS signed root — `root_hash` and `tree_size`
+///   2. the signed root is for the tenant the caller intended
+///      (`signed_root.tenant == expected_tenant`) — a genuinely-signed root
+///      for a different tenant is not evidence for this one;
+///   3. the inclusion proof is internally consistent (folds to its own root);
+///   4. the proof binds to THIS signed root — `root_hash` and `tree_size`
 ///      must match.
 ///
-/// Only when all three hold does it return the success message. A proof that
+/// Only when all hold does it return the success message. A proof that
 /// self-verifies but whose embedded root differs from the host-signed root is
-/// rejected at step 3 — self-consistency is not membership.
+/// rejected at step 4 — self-consistency is not membership.
 fn run_verify_inclusion(
     proof: &InclusionProof,
     signed_root: &SignedAuditRoot,
     vk: &VerifyingKey,
+    expected_tenant: &str,
 ) -> Result<String> {
     verify_signed_root(signed_root, vk)
         .map_err(|e| anyhow::anyhow!("signed-root verification failed: {e}"))?;
+    if signed_root.tenant != expected_tenant {
+        anyhow::bail!(
+            "tenant binding failed: signed root is for tenant '{}', expected '{}'",
+            signed_root.tenant,
+            expected_tenant
+        );
+    }
     verify_inclusion(proof)
         .map_err(|e| anyhow::anyhow!("inclusion-proof verification failed: {e}"))?;
     if proof.root != signed_root.root_hash {
@@ -1384,7 +1397,7 @@ mod merkle_verb_tests {
         let leaves = lines(5);
         let signed = sign_root(&key, "local", &leaves);
         let proof = build_inclusion_proof(&leaves, 2).unwrap();
-        let msg = run_verify_inclusion(&proof, &signed, &vk).unwrap();
+        let msg = run_verify_inclusion(&proof, &signed, &vk, "local").unwrap();
         assert!(msg.contains("index 2 of 5"), "{msg}");
         assert!(msg.contains(&signed.root_hash), "{msg}");
     }
@@ -1405,7 +1418,7 @@ mod merkle_verb_tests {
         assert_eq!(proof.tree_size, signed.tree_size);
         assert_ne!(proof.root, signed.root_hash);
 
-        let err = run_verify_inclusion(&proof, &signed, &vk).unwrap_err();
+        let err = run_verify_inclusion(&proof, &signed, &vk, "local").unwrap_err();
         assert!(
             format!("{err:#}").contains("root binding failed"),
             "{err:#}"
@@ -1422,7 +1435,7 @@ mod merkle_verb_tests {
         let mut signed = sign_root(&key, "local", &leaves);
         let proof = build_inclusion_proof(&leaves, 0).unwrap();
         signed.root_hash = hex::encode([0xabu8; 32]);
-        let err = run_verify_inclusion(&proof, &signed, &vk).unwrap_err();
+        let err = run_verify_inclusion(&proof, &signed, &vk, "local").unwrap_err();
         assert!(
             format!("{err:#}").contains("signed-root verification failed"),
             "{err:#}"
@@ -1437,7 +1450,7 @@ mod merkle_verb_tests {
         let signed = sign_root(&key, "local", &leaves);
         let proof = build_inclusion_proof(&leaves, 1).unwrap();
         let wrong_vk = fresh_key().verifying_key();
-        let err = run_verify_inclusion(&proof, &signed, &wrong_vk).unwrap_err();
+        let err = run_verify_inclusion(&proof, &signed, &wrong_vk, "local").unwrap_err();
         assert!(
             format!("{err:#}").contains("signed-root verification failed"),
             "{err:#}"
@@ -1454,7 +1467,7 @@ mod merkle_verb_tests {
         let signed = sign_root(&key, "local", &leaves);
         let mut proof = build_inclusion_proof(&leaves, 3).unwrap();
         proof.leaf_index = 4;
-        let err = run_verify_inclusion(&proof, &signed, &vk).unwrap_err();
+        let err = run_verify_inclusion(&proof, &signed, &vk, "local").unwrap_err();
         assert!(
             format!("{err:#}").contains("inclusion-proof verification failed"),
             "{err:#}"
@@ -1472,11 +1485,33 @@ mod merkle_verb_tests {
         let leaves = lines(5);
         let proof = build_inclusion_proof(&leaves, 0).unwrap();
         let signed = sign_root_fields(&key, "local", 99, &proof.root);
-        let err = run_verify_inclusion(&proof, &signed, &vk).unwrap_err();
+        let err = run_verify_inclusion(&proof, &signed, &vk, "local").unwrap_err();
         assert!(
             format!("{err:#}").contains("tree-size binding failed"),
             "{err:#}"
         );
+    }
+
+    #[test]
+    fn composition_rejects_root_for_a_different_tenant() {
+        // A genuinely-signed root+proof for tenant `beta` must NOT count as
+        // evidence for tenant `acme` — the signed `tenant` field is checked
+        // against the caller's intent, fail closed. Same key, same valid
+        // signature: only the tenant binding catches the mix-up.
+        let key = fresh_key();
+        let vk = key.verifying_key();
+        let leaves = lines(5);
+        let signed = sign_root(&key, "beta", &leaves);
+        let proof = build_inclusion_proof(&leaves, 2).unwrap();
+
+        let err = run_verify_inclusion(&proof, &signed, &vk, "acme").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("tenant binding failed"), "{msg}");
+        assert!(msg.contains("beta") && msg.contains("acme"), "{msg}");
+
+        // The same root+proof verifies when the intended tenant matches.
+        let ok = run_verify_inclusion(&proof, &signed, &vk, "beta").unwrap();
+        assert!(ok.contains("index 2 of 5"), "{ok}");
     }
 
     // ---- resolve_selector ----
@@ -1580,7 +1615,7 @@ mod merkle_verb_tests {
         assert_eq!(idx, 2);
         let proof = build_inclusion_proof(&leaves, idx).unwrap();
         let signed = sign_root(&key, "local", &leaves);
-        let msg = run_verify_inclusion(&proof, &signed, &key.verifying_key()).unwrap();
+        let msg = run_verify_inclusion(&proof, &signed, &key.verifying_key(), "local").unwrap();
         assert!(msg.contains("index 2 of 4"), "{msg}");
     }
 

--- a/crates/mvm-cli/src/commands/ops/audit.rs
+++ b/crates/mvm-cli/src/commands/ops/audit.rs
@@ -5,11 +5,13 @@ use clap::{Args as ClapArgs, Subcommand};
 
 use crate::ui;
 
+use ed25519_dalek::VerifyingKey;
 use mvm_core::user_config::MvmConfig;
 use mvm_hostd::audit_signer::verify::verify_workload_chain;
 use mvm_hostd::supervisor::{SignedEnvelope, verify_audit_chain};
+use mvm_protocol::merkle::{InclusionProof, SignedAuditRoot, verify_inclusion, verify_signed_root};
 
-use super::super::vm::audit_chain::{audit_path_for_tenant, default_audit_dir};
+use super::super::vm::audit_chain::{AuditEmitter, audit_path_for_tenant, default_audit_dir};
 use super::super::vm::host_signer;
 use super::Cli;
 
@@ -113,6 +115,54 @@ pub(in crate::commands) enum AuditAction {
         #[arg(long)]
         json: bool,
     },
+    /// Build, sign, and publish a Merkle transparency-log root over the
+    /// tenant's chain-signed audit log (host-side). The signed root at
+    /// `~/.mvm/audit/<tenant>.root.json` lets an external auditor pin the
+    /// log's state without replaying the whole chain. The root is only
+    /// built over a chain that verifies clean.
+    PublishRoot {
+        /// Tenant whose chain to publish a root for. Defaults to `"local"`.
+        #[arg(long, default_value = "local")]
+        tenant: String,
+    },
+    /// Emit an inclusion proof that one audit line is a leaf of the log,
+    /// paired with the current signed root, as JSON. The selector picks the
+    /// line: a numeric 0-based index, a `plan_id`, or `sha256:<hex>` of the
+    /// exact line. A selector matching more than one line is refused as
+    /// ambiguous (fail closed).
+    Prove {
+        /// Line selector: numeric index, a plan_id, or `sha256:<hex>` of the
+        /// exact audit line.
+        selector: String,
+        /// Tenant whose chain to prove against. Defaults to `"local"`.
+        #[arg(long, default_value = "local")]
+        tenant: String,
+        /// Emit the proof + current signed root as a JSON object to stdout.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Verify an inclusion proof against a host-signed root — the full
+    /// membership check. Verifies the signed root under the trusted host
+    /// key, verifies the proof, and binds the two (root_hash + tree_size
+    /// must match). Nonzero exit naming the failed check on any failure; a
+    /// self-consistent proof over an unsigned root is rejected.
+    VerifyInclusion {
+        /// Path to the inclusion-proof JSON, or `-` to read from stdin.
+        #[arg(long)]
+        proof: String,
+        /// Path to the signed-root JSON. Defaults to
+        /// `~/.mvm/audit/<tenant>.root.json`.
+        #[arg(long)]
+        root: Option<std::path::PathBuf>,
+        /// Path to the trusted host public key. Defaults to
+        /// `~/.mvm/keys/host-signer.pub`. Accepts the raw 32-byte key, hex,
+        /// or base64.
+        #[arg(long)]
+        pubkey: Option<std::path::PathBuf>,
+        /// Tenant whose default root path to use when `--root` is omitted.
+        #[arg(long, default_value = "local")]
+        tenant: String,
+    },
     /// Opt-in forensic network transcript capture: arm / disarm / list /
     /// export. Off by default; separate from the metadata-only flow audit.
     Transcript {
@@ -149,6 +199,18 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             chain,
             json,
         } => verify_cert(&cert, pubkey.as_deref(), chain.as_deref(), json),
+        AuditAction::PublishRoot { tenant } => audit_publish_root(&tenant),
+        AuditAction::Prove {
+            selector,
+            tenant,
+            json,
+        } => audit_prove(&tenant, &selector, json),
+        AuditAction::VerifyInclusion {
+            proof,
+            root,
+            pubkey,
+            tenant,
+        } => audit_verify_inclusion(&proof, root.as_deref(), pubkey.as_deref(), &tenant),
     }
 }
 
@@ -315,6 +377,269 @@ fn verify_cert(
         );
     }
     Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Merkle transparency log: publish-root / prove / verify-inclusion
+// ─────────────────────────────────────────────────────────────────
+
+/// Build, sign, and publish a Merkle root over the tenant's audit chain.
+fn audit_publish_root(tenant: &str) -> Result<()> {
+    let signer =
+        host_signer::load_or_init().context("loading host signer to publish audit root")?;
+    let emitter = AuditEmitter::new(signer.signing).context("opening host audit emitter")?;
+    let signed = emitter
+        .publish_root(tenant)
+        .with_context(|| format!("publishing Merkle root for tenant '{tenant}'"))?;
+    let path = mvm_core::config::audit_root_path(tenant);
+    ui::success(&format!(
+        "published Merkle root for tenant '{tenant}': root {root} over {n} entries -> {path}",
+        root = signed.root_hash,
+        n = signed.tree_size,
+        path = path.display(),
+    ));
+    Ok(())
+}
+
+/// Build an inclusion proof for the selector-resolved leaf and print it
+/// (paired with the current signed root) as JSON, or a one-line summary.
+fn audit_prove(tenant: &str, selector: &str, json: bool) -> Result<()> {
+    use mvm_protocol::merkle::build_inclusion_proof;
+
+    let signer =
+        host_signer::load_or_init().context("loading host signer to build inclusion proof")?;
+    let dir = default_audit_dir()?;
+    // Read the verified leaf set once; the selector resolves against exactly
+    // the leaves the proof is built over, so indices can't drift.
+    let leaves = mvm_hostd::audit::merkle::read_leaves(&dir, tenant, &signer.verifying)
+        .with_context(|| format!("reading the verified audit chain for tenant '{tenant}'"))?;
+    let index = resolve_selector(&leaves, selector)?;
+    let proof = build_inclusion_proof(&leaves, index)
+        .map_err(|e| anyhow::anyhow!("building inclusion proof for leaf {index}: {e}"))?;
+
+    // Pair the proof with the currently-published signed root, if any, so a
+    // downstream `verify-inclusion` has both halves of the membership check.
+    let root_path = mvm_core::config::audit_root_path(tenant);
+    let signed_root: Option<SignedAuditRoot> = if root_path.exists() {
+        let raw = std::fs::read_to_string(&root_path)
+            .with_context(|| format!("reading signed root {}", root_path.display()))?;
+        Some(
+            serde_json::from_str(&raw)
+                .with_context(|| format!("decoding signed root {}", root_path.display()))?,
+        )
+    } else {
+        None
+    };
+
+    if json {
+        let out = serde_json::json!({ "proof": proof, "signed_root": signed_root });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else {
+        ui::info(&format!(
+            "inclusion proof: leaf {idx} of {n} (root {root})",
+            idx = proof.leaf_index,
+            n = proof.tree_size,
+            root = proof.root,
+        ));
+        if signed_root.is_none() {
+            ui::warn(&format!(
+                "no published root at {}; run `mvmctl trust audit publish-root` first \
+                 so `verify-inclusion` has a signed root to bind against.",
+                root_path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Resolve a `prove` selector to a 0-based leaf index over `leaves`.
+///
+/// Accepts a numeric line index, a `plan_id`, or `sha256:<hex>` of the exact
+/// audit line. Every non-numeric interpretation is collected across all
+/// lines; a selector matching more than one line is refused as ambiguous so
+/// the resolution is fail-closed.
+fn resolve_selector(leaves: &[String], selector: &str) -> Result<usize> {
+    use sha2::{Digest, Sha256};
+
+    // 1. numeric 0-based line index.
+    if let Ok(idx) = selector.parse::<usize>() {
+        if idx >= leaves.len() {
+            anyhow::bail!(
+                "line index {idx} out of range: the chain has {} entries",
+                leaves.len()
+            );
+        }
+        return Ok(idx);
+    }
+
+    // 2 & 3. a `sha256:<hex>` line hash and/or a plan_id. Collect every match.
+    let line_hash_want = selector
+        .strip_prefix("sha256:")
+        .map(str::to_ascii_lowercase);
+    let mut matches: Vec<usize> = Vec::new();
+    for (i, line) in leaves.iter().enumerate() {
+        let mut matched = false;
+        if let Some(want) = &line_hash_want {
+            let got = hex::encode(Sha256::digest(line.as_bytes()));
+            if &got == want {
+                matched = true;
+            }
+        }
+        if !matched
+            && let Ok(env) = serde_json::from_str::<SignedEnvelope>(line)
+            && env.entry.plan_id.0 == selector
+        {
+            matched = true;
+        }
+        if matched {
+            matches.push(i);
+        }
+    }
+
+    match matches.as_slice() {
+        [] => anyhow::bail!("selector '{selector}' matched no audit line in the chain"),
+        [only] => Ok(*only),
+        many => anyhow::bail!(
+            "selector '{selector}' is ambiguous: it matches {} lines (indices {many:?}); \
+             use a numeric line index or a `sha256:<hex>` line hash to disambiguate",
+            many.len()
+        ),
+    }
+}
+
+/// Verify an inclusion proof against a host-signed root — the full
+/// membership check. Loads the proof, the signed root, and the trusted host
+/// key, then enforces the composition via [`run_verify_inclusion`].
+fn audit_verify_inclusion(
+    proof_arg: &str,
+    root_path: Option<&std::path::Path>,
+    pubkey_path: Option<&std::path::Path>,
+    tenant: &str,
+) -> Result<()> {
+    // 1. load the inclusion proof (file or stdin).
+    let proof_raw = if proof_arg == "-" {
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+            .context("reading inclusion proof from stdin")?;
+        buf
+    } else {
+        std::fs::read_to_string(proof_arg)
+            .with_context(|| format!("reading inclusion proof {proof_arg}"))?
+    };
+    let proof: InclusionProof =
+        serde_json::from_str(&proof_raw).context("decoding inclusion-proof JSON")?;
+
+    // 2. load the signed root (default: ~/.mvm/audit/<tenant>.root.json).
+    let root_path = root_path
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| mvm_core::config::audit_root_path(tenant));
+    let root_raw = std::fs::read_to_string(&root_path)
+        .with_context(|| format!("reading signed root {}", root_path.display()))?;
+    let signed_root: SignedAuditRoot =
+        serde_json::from_str(&root_raw).context("decoding signed-root JSON")?;
+
+    // 3. load the trusted host verifying key (default: host-signer.pub).
+    let vk = match pubkey_path {
+        Some(p) => load_verifying_key(p)?,
+        None => {
+            host_signer::load_or_init()
+                .context("loading host signer public key")?
+                .verifying
+        }
+    };
+
+    // 4-6: the composition. Fail closed naming the failed check.
+    let message = run_verify_inclusion(&proof, &signed_root, &vk)?;
+    ui::success(&message);
+    Ok(())
+}
+
+/// The full inclusion-membership check as a pure function, so the security
+/// composition is unit-testable without touching the filesystem.
+///
+/// Enforces, in order and fail-closed:
+///   1. the signed root verifies under the trusted host key;
+///   2. the inclusion proof is internally consistent (folds to its own root);
+///   3. the proof binds to THIS signed root — `root_hash` and `tree_size`
+///      must match.
+///
+/// Only when all three hold does it return the success message. A proof that
+/// self-verifies but whose embedded root differs from the host-signed root is
+/// rejected at step 3 — self-consistency is not membership.
+fn run_verify_inclusion(
+    proof: &InclusionProof,
+    signed_root: &SignedAuditRoot,
+    vk: &VerifyingKey,
+) -> Result<String> {
+    verify_signed_root(signed_root, vk)
+        .map_err(|e| anyhow::anyhow!("signed-root verification failed: {e}"))?;
+    verify_inclusion(proof)
+        .map_err(|e| anyhow::anyhow!("inclusion-proof verification failed: {e}"))?;
+    if proof.root != signed_root.root_hash {
+        anyhow::bail!(
+            "root binding failed: proof root {} does not match the host-signed root {}",
+            proof.root,
+            signed_root.root_hash
+        );
+    }
+    if proof.tree_size != signed_root.tree_size {
+        anyhow::bail!(
+            "tree-size binding failed: proof tree_size {} does not match the host-signed \
+             tree_size {}",
+            proof.tree_size,
+            signed_root.tree_size
+        );
+    }
+    Ok(format!(
+        "verified: entry at index {idx} of {n} is in the host-signed log (root {root})",
+        idx = proof.leaf_index,
+        n = proof.tree_size,
+        root = signed_root.root_hash,
+    ))
+}
+
+/// Load a trusted Ed25519 verifying key from a file. Accepts the raw
+/// 32-byte form (`~/.mvm/keys/host-signer.pub`), 64-char hex, or base64.
+fn load_verifying_key(path: &std::path::Path) -> Result<VerifyingKey> {
+    let raw =
+        std::fs::read(path).with_context(|| format!("reading pubkey file {}", path.display()))?;
+    // Raw 32-byte key half — the on-disk host-signer.pub shape.
+    if raw.len() == 32 {
+        let arr: [u8; 32] = raw.as_slice().try_into().expect("length checked");
+        return VerifyingKey::from_bytes(&arr)
+            .with_context(|| format!("parsing raw pubkey {}", path.display()));
+    }
+    // Otherwise the file is text: hex (64 chars) or base64.
+    let text = String::from_utf8(raw).with_context(|| {
+        format!(
+            "pubkey file {} is neither 32 raw bytes nor UTF-8 text",
+            path.display()
+        )
+    })?;
+    let text = text.trim();
+    let bytes = hex::decode(text)
+        .ok()
+        .filter(|b| b.len() == 32)
+        .or_else(|| {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD
+                .decode(text)
+                .ok()
+                .or_else(|| {
+                    base64::engine::general_purpose::URL_SAFE_NO_PAD
+                        .decode(text)
+                        .ok()
+                })
+                .filter(|b| b.len() == 32)
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "pubkey file {} did not contain a 32-byte Ed25519 key (raw, hex, or base64)",
+                path.display()
+            )
+        })?;
+    let arr: [u8; 32] = bytes.as_slice().try_into().expect("length checked");
+    VerifyingKey::from_bytes(&arr).with_context(|| format!("parsing pubkey {}", path.display()))
 }
 
 /// Read a chain file and return a map from
@@ -996,5 +1321,298 @@ mod verify_cert_tests {
                 .map(String::as_str),
             Some("fp1")
         );
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Merkle transparency-log verbs: publish-root / prove / verify-inclusion
+// ──────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod merkle_verb_tests {
+    use super::*;
+    use base64::Engine;
+    use ed25519_dalek::{Signer, SigningKey};
+    use mvm_protocol::merkle::{build_inclusion_proof, merkle_root, root_signing_bytes};
+
+    fn fresh_key() -> SigningKey {
+        let mut seed = [0u8; 32];
+        rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut seed);
+        SigningKey::from_bytes(&seed)
+    }
+
+    fn lines(n: usize) -> Vec<String> {
+        (0..n).map(|i| format!(r#"{{"line":{i}}}"#)).collect()
+    }
+
+    /// Sign a root over `leaves` exactly the way `publish_root` does.
+    fn sign_root(key: &SigningKey, tenant: &str, leaves: &[String]) -> SignedAuditRoot {
+        sign_root_fields(
+            key,
+            tenant,
+            leaves.len() as u64,
+            &hex::encode(merkle_root(leaves)),
+        )
+    }
+
+    /// Sign a root over caller-chosen `tree_size` / `root_hash` (to isolate the
+    /// tree_size-binding check, which needs a validly-signed-but-mismatched root).
+    fn sign_root_fields(
+        key: &SigningKey,
+        tenant: &str,
+        tree_size: u64,
+        root_hash: &str,
+    ) -> SignedAuditRoot {
+        let timestamp = "2026-07-26T00:00:00Z".to_string();
+        let payload = root_signing_bytes(tenant, tree_size, root_hash, &timestamp).unwrap();
+        let sig = key.sign(&payload);
+        SignedAuditRoot {
+            tenant: tenant.to_string(),
+            tree_size,
+            root_hash: root_hash.to_string(),
+            timestamp,
+            signature: base64::engine::general_purpose::STANDARD.encode(sig.to_bytes()),
+            signer_pubkey: hex::encode(key.verifying_key().to_bytes()),
+        }
+    }
+
+    // ---- run_verify_inclusion composition ----
+
+    #[test]
+    fn composition_accepts_valid_proof_against_signed_root() {
+        let key = fresh_key();
+        let vk = key.verifying_key();
+        let leaves = lines(5);
+        let signed = sign_root(&key, "local", &leaves);
+        let proof = build_inclusion_proof(&leaves, 2).unwrap();
+        let msg = run_verify_inclusion(&proof, &signed, &vk).unwrap();
+        assert!(msg.contains("index 2 of 5"), "{msg}");
+        assert!(msg.contains(&signed.root_hash), "{msg}");
+    }
+
+    #[test]
+    fn composition_rejects_self_consistent_proof_over_a_different_root() {
+        // THE CRUX: a proof that self-verifies (verify_inclusion Ok) with the
+        // SAME tree_size as the signed root, but whose embedded root differs.
+        // Self-consistency is not membership — it must be rejected at the
+        // root-binding step.
+        let key = fresh_key();
+        let vk = key.verifying_key();
+        let signed = sign_root(&key, "local", &lines(5)); // root A, size 5
+        let foreign_leaves: Vec<String> = (0..5).map(|i| format!(r#"{{"forged":{i}}}"#)).collect(); // root B, size 5
+        let proof = build_inclusion_proof(&foreign_leaves, 2).unwrap();
+        // Sanity: the forged proof self-verifies and its size matches.
+        assert!(verify_inclusion(&proof).is_ok());
+        assert_eq!(proof.tree_size, signed.tree_size);
+        assert_ne!(proof.root, signed.root_hash);
+
+        let err = run_verify_inclusion(&proof, &signed, &vk).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("root binding failed"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn composition_rejects_tampered_signed_root() {
+        // Tamper the signed root's root_hash: the signature no longer covers
+        // it, so verify_signed_root refuses before the proof is even folded.
+        let key = fresh_key();
+        let vk = key.verifying_key();
+        let leaves = lines(5);
+        let mut signed = sign_root(&key, "local", &leaves);
+        let proof = build_inclusion_proof(&leaves, 0).unwrap();
+        signed.root_hash = hex::encode([0xabu8; 32]);
+        let err = run_verify_inclusion(&proof, &signed, &vk).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("signed-root verification failed"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn composition_rejects_signed_root_under_wrong_key() {
+        // The signed root is valid, but we hand verify the WRONG trusted key.
+        let key = fresh_key();
+        let leaves = lines(4);
+        let signed = sign_root(&key, "local", &leaves);
+        let proof = build_inclusion_proof(&leaves, 1).unwrap();
+        let wrong_vk = fresh_key().verifying_key();
+        let err = run_verify_inclusion(&proof, &signed, &wrong_vk).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("signed-root verification failed"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn composition_rejects_wrong_entry_proof() {
+        // A proof for a real tree whose leaf_index is re-pointed folds to a
+        // different root → verify_inclusion fails before any binding check.
+        let key = fresh_key();
+        let vk = key.verifying_key();
+        let leaves = lines(8);
+        let signed = sign_root(&key, "local", &leaves);
+        let mut proof = build_inclusion_proof(&leaves, 3).unwrap();
+        proof.leaf_index = 4;
+        let err = run_verify_inclusion(&proof, &signed, &vk).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("inclusion-proof verification failed"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn composition_rejects_tree_size_mismatch() {
+        // Isolate the tree_size binding: sign a root that claims the SAME
+        // root_hash the proof folds to, but a different tree_size. The
+        // signature is valid and the proof self-verifies, so only the
+        // tree_size bind can catch it.
+        let key = fresh_key();
+        let vk = key.verifying_key();
+        let leaves = lines(5);
+        let proof = build_inclusion_proof(&leaves, 0).unwrap();
+        let signed = sign_root_fields(&key, "local", 99, &proof.root);
+        let err = run_verify_inclusion(&proof, &signed, &vk).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("tree-size binding failed"),
+            "{err:#}"
+        );
+    }
+
+    // ---- resolve_selector ----
+
+    /// Seed a real chain of SignedEnvelope lines via `FileAuditSigner`,
+    /// returning the verified leaf set. `plan_ids` names each entry's plan_id.
+    fn seed_leaves(plan_ids: &[&str]) -> (tempfile::TempDir, Vec<String>) {
+        use mvm_hostd::supervisor::{AuditEntry, AuditSigner, FileAuditSigner};
+        use std::collections::BTreeMap;
+
+        let dir = tempfile::tempdir().unwrap();
+        let chain_dir = dir.path().join("audit");
+        std::fs::create_dir_all(&chain_dir).unwrap();
+        let key = fresh_key();
+        let vk = key.verifying_key();
+        let signer = FileAuditSigner::open(key, &chain_dir).unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        for (i, plan_id) in plan_ids.iter().enumerate() {
+            let entry = AuditEntry {
+                timestamp: chrono::Utc::now(),
+                tenant: mvm_core::plan::TenantId("local".to_string()),
+                plan_id: mvm_core::plan::PlanId(plan_id.to_string()),
+                plan_version: 1,
+                bundle_id: None,
+                bundle_version: None,
+                image_name: "img".to_string(),
+                image_sha256: "abc".to_string(),
+                event: format!("e-{i}"),
+                labels: BTreeMap::new(),
+            };
+            rt.block_on(signer.sign_and_emit(&entry)).unwrap();
+        }
+        let leaves = mvm_hostd::audit::merkle::read_leaves(&chain_dir, "local", &vk).unwrap();
+        (dir, leaves)
+    }
+
+    #[test]
+    fn resolve_selector_numeric_index() {
+        let leaves = lines(4);
+        assert_eq!(resolve_selector(&leaves, "0").unwrap(), 0);
+        assert_eq!(resolve_selector(&leaves, "3").unwrap(), 3);
+    }
+
+    #[test]
+    fn resolve_selector_numeric_out_of_range_refused() {
+        let leaves = lines(3);
+        let err = resolve_selector(&leaves, "3").unwrap_err();
+        assert!(format!("{err:#}").contains("out of range"), "{err:#}");
+    }
+
+    #[test]
+    fn resolve_selector_line_hash() {
+        use sha2::{Digest, Sha256};
+        let leaves = lines(4);
+        let want = format!(
+            "sha256:{}",
+            hex::encode(Sha256::digest(leaves[2].as_bytes()))
+        );
+        assert_eq!(resolve_selector(&leaves, &want).unwrap(), 2);
+    }
+
+    #[test]
+    fn resolve_selector_no_match_refused() {
+        let leaves = lines(3);
+        let err = resolve_selector(&leaves, "sha256:deadbeef").unwrap_err();
+        assert!(
+            format!("{err:#}").contains("matched no audit line"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn resolve_selector_unique_plan_id() {
+        let (_dir, leaves) = seed_leaves(&["plan-a", "plan-b", "plan-c"]);
+        assert_eq!(resolve_selector(&leaves, "plan-b").unwrap(), 1);
+    }
+
+    #[test]
+    fn resolve_selector_ambiguous_plan_id_refused() {
+        // Two lines carry the same plan_id → the selector is ambiguous and
+        // must be refused (fail closed) rather than silently proving one.
+        let (_dir, leaves) = seed_leaves(&["plan-x", "plan-dup", "plan-dup"]);
+        let err = resolve_selector(&leaves, "plan-dup").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("ambiguous"), "{msg}");
+    }
+
+    #[test]
+    fn prove_selector_to_verify_inclusion_round_trip() {
+        // End-to-end over real SignedEnvelope leaves: resolve a plan_id, build
+        // the proof over the exact leaf bytes, sign a matching root, and run
+        // the full composition. The leaf bytes fold to `merkle_root(leaves)`
+        // independent of which key signed the chain, so signing the root with
+        // a fresh key exercises the proof↔root binding faithfully.
+        let (_dir, leaves) = seed_leaves(&["plan-a", "plan-b", "plan-c", "plan-d"]);
+        let key = fresh_key();
+        let idx = resolve_selector(&leaves, "plan-c").unwrap();
+        assert_eq!(idx, 2);
+        let proof = build_inclusion_proof(&leaves, idx).unwrap();
+        let signed = sign_root(&key, "local", &leaves);
+        let msg = run_verify_inclusion(&proof, &signed, &key.verifying_key()).unwrap();
+        assert!(msg.contains("index 2 of 4"), "{msg}");
+    }
+
+    // ---- load_verifying_key ----
+
+    #[test]
+    fn load_verifying_key_raw_32_bytes() {
+        let key = fresh_key();
+        let vk = key.verifying_key();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("host-signer.pub");
+        std::fs::write(&path, vk.to_bytes()).unwrap();
+        let loaded = load_verifying_key(&path).unwrap();
+        assert_eq!(loaded.to_bytes(), vk.to_bytes());
+    }
+
+    #[test]
+    fn load_verifying_key_hex_text() {
+        let key = fresh_key();
+        let vk = key.verifying_key();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pub.hex");
+        std::fs::write(&path, format!("{}\n", hex::encode(vk.to_bytes()))).unwrap();
+        let loaded = load_verifying_key(&path).unwrap();
+        assert_eq!(loaded.to_bytes(), vk.to_bytes());
+    }
+
+    #[test]
+    fn load_verifying_key_rejects_garbage() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.pub");
+        std::fs::write(&path, "not-a-key").unwrap();
+        assert!(load_verifying_key(&path).is_err());
     }
 }

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1831,6 +1831,123 @@ fn test_audit_show_parses() {
 }
 
 #[test]
+fn test_audit_publish_root_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "trust", "audit", "publish-root"]).unwrap();
+    let Commands::Trust(tg) = cli.command else {
+        panic!("expected trust group")
+    };
+    match tg.action {
+        trust::TrustAction::Audit(audit::Args {
+            action: AuditAction::PublishRoot { tenant },
+        }) => assert_eq!(tenant, "local"),
+        _ => panic!("Expected Audit::PublishRoot"),
+    }
+}
+
+#[test]
+fn test_audit_prove_parses() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "trust",
+        "audit",
+        "prove",
+        "sha256:abc",
+        "--tenant",
+        "acme",
+        "--json",
+    ])
+    .unwrap();
+    let Commands::Trust(tg) = cli.command else {
+        panic!("expected trust group")
+    };
+    match tg.action {
+        trust::TrustAction::Audit(audit::Args {
+            action:
+                AuditAction::Prove {
+                    selector,
+                    tenant,
+                    json,
+                },
+        }) => {
+            assert_eq!(selector, "sha256:abc");
+            assert_eq!(tenant, "acme");
+            assert!(json);
+        }
+        _ => panic!("Expected Audit::Prove"),
+    }
+}
+
+#[test]
+fn test_audit_verify_inclusion_parses() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "trust",
+        "audit",
+        "verify-inclusion",
+        "--proof",
+        "proof.json",
+        "--root",
+        "root.json",
+        "--pubkey",
+        "host.pub",
+    ])
+    .unwrap();
+    let Commands::Trust(tg) = cli.command else {
+        panic!("expected trust group")
+    };
+    match tg.action {
+        trust::TrustAction::Audit(audit::Args {
+            action:
+                AuditAction::VerifyInclusion {
+                    proof,
+                    root,
+                    pubkey,
+                    tenant,
+                },
+        }) => {
+            assert_eq!(proof, "proof.json");
+            assert_eq!(root.as_deref(), Some(std::path::Path::new("root.json")));
+            assert_eq!(pubkey.as_deref(), Some(std::path::Path::new("host.pub")));
+            assert_eq!(tenant, "local");
+        }
+        _ => panic!("Expected Audit::VerifyInclusion"),
+    }
+}
+
+#[test]
+fn test_audit_verify_inclusion_defaults_optional_paths() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "trust",
+        "audit",
+        "verify-inclusion",
+        "--proof",
+        "-",
+    ])
+    .unwrap();
+    let Commands::Trust(tg) = cli.command else {
+        panic!("expected trust group")
+    };
+    match tg.action {
+        trust::TrustAction::Audit(audit::Args {
+            action:
+                AuditAction::VerifyInclusion {
+                    proof,
+                    root,
+                    pubkey,
+                    tenant,
+                },
+        }) => {
+            assert_eq!(proof, "-");
+            assert!(root.is_none());
+            assert!(pubkey.is_none());
+            assert_eq!(tenant, "local");
+        }
+        _ => panic!("Expected Audit::VerifyInclusion"),
+    }
+}
+
+#[test]
 fn test_audit_tail_no_log_prints_message() {
     // When no audit log exists, the command should succeed with a
     // helpful message rather than an error.

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -653,6 +653,15 @@ pub fn mvm_audit_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(mvm_home()).join("audit")
 }
 
+/// Published Merkle transparency-log root for a tenant's audit chain:
+/// `<mvm_home>/audit/<tenant>.root.json`. Sibling to the `<tenant>.jsonl`
+/// chain the root is computed over; the host writes it and an external
+/// auditor pins it. Shared so the writer (`publish_root`) and the reader
+/// (`mvmctl trust audit verify-inclusion`) can't drift on the location.
+pub fn audit_root_path(tenant: &str) -> std::path::PathBuf {
+    mvm_audit_dir().join(format!("{tenant}.root.json"))
+}
+
 /// Forensic transcript captures: `<mvm_home>/audit/transcripts/`. Each
 /// capture is `<tenant>/<vm>/<capture-id>/` holding `manifest.json` + encrypted
 /// chunk files. Kept under `audit/` since it is opt-in forensic evidence.
@@ -1030,6 +1039,23 @@ mod tests {
         env.set("MVM_HOME", temp.path());
         let dir = checkpoints_dir();
         assert_eq!(dir, temp.path().join("checkpoints"));
+        env.remove("MVM_HOME");
+    }
+
+    #[test]
+    fn audit_root_path_is_sibling_of_chain() {
+        let mut env = TestEnv::new();
+        let temp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", temp.path());
+        // The published root sits next to the `<tenant>.jsonl` chain it covers.
+        assert_eq!(
+            audit_root_path("local"),
+            temp.path().join("audit").join("local.root.json")
+        );
+        assert_eq!(
+            audit_root_path("local").parent(),
+            mvm_audit_dir().to_str().map(std::path::Path::new)
+        );
         env.remove("MVM_HOME");
     }
 

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -662,16 +662,26 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
         .and_then(|n| n.to_str())
         .ok_or_else(|| anyhow::anyhow!("path {} has no file name", path.display()))?;
     let tmp = dir.join(format!(".{file_name}.tmp.{}", std::process::id()));
-    {
+    // Best-effort: if any step before the rename fails, don't leave the
+    // partial temp file behind.
+    let write = (|| -> Result<()> {
         let mut f = std::fs::File::create(&tmp)
             .with_context(|| format!("creating temp file {}", tmp.display()))?;
         f.write_all(bytes)
             .with_context(|| format!("writing temp file {}", tmp.display()))?;
         f.sync_all()
             .with_context(|| format!("fsync temp file {}", tmp.display()))?;
+        Ok(())
+    })();
+    if let Err(e) = write {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
     }
-    std::fs::rename(&tmp, path)
-        .with_context(|| format!("renaming {} to {}", tmp.display(), path.display()))?;
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(anyhow::Error::from(e))
+            .with_context(|| format!("renaming {} to {}", tmp.display(), path.display()));
+    }
     Ok(())
 }
 

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -40,8 +40,11 @@ use std::path::{Path, PathBuf};
 
 use crate::supervisor::{AuditEntry, AuditSigner, FileAuditSigner};
 use anyhow::{Context, Result};
-use ed25519_dalek::SigningKey;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use ed25519_dalek::{Signer, SigningKey};
 use mvm_core::plan::ExecutionPlan;
+use mvm_protocol::merkle::{SignedAuditRoot, root_signing_bytes};
 
 /// Wire-stable event names and label keys for the checkpoint audit entries.
 /// Shared so the emitter (writer) and the lineage chain-anchor (reader) can't
@@ -201,11 +204,25 @@ pub fn audit_path_for_tenant(audit_dir: &Path, tenant: &str) -> PathBuf {
     audit_dir.join(format!("{tenant}.jsonl"))
 }
 
+/// Resolve the per-tenant published Merkle-root sidecar:
+/// `<audit_dir>/<tenant>.root.json`. Sibling to [`audit_path_for_tenant`];
+/// `mvm_core::config::audit_root_path` is the global-default counterpart the
+/// CLI reads.
+pub fn audit_root_path_for_tenant(audit_dir: &Path, tenant: &str) -> PathBuf {
+    audit_dir.join(format!("{tenant}.root.json"))
+}
+
 /// Host-side emitter wrapping `FileAuditSigner`. Owns its own signing
 /// key half (cloned from the host signer at construction); calls
 /// `tokio::runtime::Builder::new_current_thread()` per emit.
+///
+/// Also retains the signing key + primary audit directory so it can build
+/// and sign a published Merkle root over the tenant chain
+/// ([`Self::publish_root`]).
 pub struct AuditEmitter {
     signers: Vec<FileAuditSigner>,
+    signing_key: SigningKey,
+    audit_dir: PathBuf,
 }
 
 impl AuditEmitter {
@@ -236,10 +253,12 @@ impl AuditEmitter {
                 })?;
             }
         }
-        let signer = FileAuditSigner::open(signing_key, audit_dir)
+        let signer = FileAuditSigner::open(signing_key.clone(), audit_dir)
             .with_context(|| format!("opening FileAuditSigner at {}", audit_dir.display()))?;
         Ok(Self {
             signers: vec![signer],
+            signing_key,
+            audit_dir: audit_dir.to_path_buf(),
         })
     }
 
@@ -578,6 +597,39 @@ impl AuditEmitter {
         )
     }
 
+    /// Build, sign, and atomically publish a Merkle transparency-log root
+    /// over `tenant`'s chain-signed audit log.
+    ///
+    /// The root is built only over a `verify_audit_chain`-valid chain (see
+    /// [`crate::audit::merkle::build_root_in`]); a corrupt log refuses here.
+    /// The signature covers `root_signing_bytes(tenant, tree_size,
+    /// hex(root), timestamp)` under the host signer's Ed25519 key — the
+    /// exact bytes `mvm_protocol::merkle::verify_signed_root` re-checks. The
+    /// sidecar is written temp-then-fsync-then-rename to
+    /// `<audit_dir>/<tenant>.root.json` so a reader never observes a partial
+    /// file.
+    pub fn publish_root(&self, tenant: &str) -> Result<SignedAuditRoot> {
+        let vk = self.signing_key.verifying_key();
+        let (root, tree_size) = crate::audit::merkle::build_root_in(&self.audit_dir, tenant, &vk)?;
+        let root_hash = hex::encode(root);
+        let timestamp = chrono::Utc::now().to_rfc3339();
+        let payload = root_signing_bytes(tenant, tree_size, &root_hash, &timestamp)
+            .map_err(|e| anyhow::anyhow!("serializing Merkle root signing payload: {e}"))?;
+        let signature = self.signing_key.sign(&payload);
+        let signed = SignedAuditRoot {
+            tenant: tenant.to_string(),
+            tree_size,
+            root_hash,
+            timestamp,
+            signature: BASE64_STANDARD.encode(signature.to_bytes()),
+            signer_pubkey: hex::encode(vk.to_bytes()),
+        };
+        let path = audit_root_path_for_tenant(&self.audit_dir, tenant);
+        write_atomic(&path, serde_json::to_vec_pretty(&signed)?.as_slice())
+            .with_context(|| format!("publishing signed root to {}", path.display()))?;
+        Ok(signed)
+    }
+
     fn emit<E>(&self, plan: &ExecutionPlan, event: &str, extras: E) -> Result<()>
     where
         E: IntoIterator<Item = (String, String)>,
@@ -593,6 +645,34 @@ impl AuditEmitter {
         }
         Ok(())
     }
+}
+
+/// Write `bytes` to `path` atomically: a same-directory temp file is
+/// written, fsync'd, then `rename`d over `path`. A concurrent reader sees
+/// either the old file or the complete new one, never a torn write. The
+/// temp name carries the pid so two publishers don't collide on it.
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+    let dir = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("path {} has no parent directory", path.display()))?;
+    std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| anyhow::anyhow!("path {} has no file name", path.display()))?;
+    let tmp = dir.join(format!(".{file_name}.tmp.{}", std::process::id()));
+    {
+        let mut f = std::fs::File::create(&tmp)
+            .with_context(|| format!("creating temp file {}", tmp.display()))?;
+        f.write_all(bytes)
+            .with_context(|| format!("writing temp file {}", tmp.display()))?;
+        f.sync_all()
+            .with_context(|| format!("fsync temp file {}", tmp.display()))?;
+    }
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("renaming {} to {}", tmp.display(), path.display()))?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1205,5 +1285,66 @@ mod tests {
         assert!(content.contains("\"via\""));
         assert!(content.contains("revert"));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
+    }
+
+    #[test]
+    fn publish_root_writes_a_verifiable_signed_root() {
+        use mvm_protocol::merkle::{verify_inclusion, verify_signed_root};
+
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-ROOT");
+        emitter.emit_admitted(&plan, "host:test").unwrap();
+        emitter.emit_launched(&plan, "firecracker").unwrap();
+
+        let signed = emitter.publish_root("local").unwrap();
+        assert_eq!(signed.tenant, "local");
+        assert_eq!(signed.tree_size, 2);
+        assert_eq!(signed.signer_pubkey, hex::encode(vk.to_bytes()));
+        // The published signature verifies under the host key.
+        assert_eq!(verify_signed_root(&signed, &vk), Ok(()));
+
+        // The sidecar landed at `<audit_dir>/<tenant>.root.json` and
+        // round-trips to the same struct.
+        let root_path = dir.path().join("local.root.json");
+        assert!(root_path.exists(), "root sidecar must be written");
+        let on_disk: SignedAuditRoot =
+            serde_json::from_str(&std::fs::read_to_string(&root_path).unwrap()).unwrap();
+        assert_eq!(on_disk, signed);
+
+        // A host-built inclusion proof folds to the published root.
+        let proof = crate::audit::merkle::build_inclusion_in(dir.path(), "local", &vk, 1).unwrap();
+        assert_eq!(
+            hex::encode(verify_inclusion(&proof).unwrap()),
+            signed.root_hash
+        );
+        assert_eq!(proof.tree_size, signed.tree_size);
+    }
+
+    #[test]
+    fn publish_root_refuses_a_tampered_chain() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-ROOT2");
+        emitter.emit_admitted(&plan, "host:test").unwrap();
+
+        // Corrupt the chain, then a root must not be published.
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        std::fs::write(&path, content.replacen("plan.admitted", "plan.evil", 1)).unwrap();
+        assert!(emitter.publish_root("local").is_err());
+        // And no partial sidecar was left behind.
+        assert!(!dir.path().join("local.root.json").exists());
     }
 }

--- a/crates/mvm-hostd/src/audit/merkle.rs
+++ b/crates/mvm-hostd/src/audit/merkle.rs
@@ -1,0 +1,248 @@
+//! Host-side Merkle transparency-log root + inclusion-proof builder.
+//!
+//! The chain-signed audit log (`<audit_dir>/<tenant>.jsonl`) is a stream of
+//! [`SignedEnvelope`](crate::supervisor::SignedEnvelope) JSON lines. This
+//! module turns that stream into RFC 6962 transparency-log artifacts: a
+//! Merkle root over the whole log and an `O(log n)` inclusion proof for a
+//! single line. All the tree math lives in
+//! [`mvm_protocol::merkle`] (the same `no_std` code a browser runs); this
+//! module only supplies the leaf bytes and the fail-closed policy.
+//!
+//! ## Leaf bytes
+//!
+//! Each leaf is one `SignedEnvelope` JSON line **verbatim** — the exact
+//! bytes `verify_audit_chain` re-hashes to advance the chain, in file
+//! order. The verifier re-hashes `InclusionProof::leaf_line` the same way,
+//! so the host's leaf bytes and the verifier's leaf bytes are identical
+//! (the CI cross-check test pins this).
+//!
+//! ## Fail-closed
+//!
+//! A root is only ever built over a chain that
+//! [`verify_audit_chain`](crate::supervisor::verify_audit_chain) accepts.
+//! A tampered, reordered, or truncated chain refuses here rather than
+//! publishing a root that would attest a corrupt log.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use ed25519_dalek::VerifyingKey;
+use mvm_protocol::merkle::{InclusionProof, build_inclusion_proof, merkle_root};
+
+use crate::audit::{emitter, host_keypair};
+use crate::supervisor::verify_audit_chain;
+
+/// Read a tenant's audit lines as Merkle leaves, in file order, **after**
+/// verifying the chain is intact. Empty lines are skipped (matching
+/// `verify_audit_chain`), so every returned element is a genuine
+/// `SignedEnvelope` line — the exact bytes the verifier re-hashes.
+///
+/// Fails closed if the chain does not verify under `vk`: a corrupt log
+/// never yields a root. Public so the CLI `prove` verb can resolve a
+/// selector against the identical leaf set the root and proofs are built
+/// over (a single reader, so indices can't drift).
+pub fn read_leaves(audit_dir: &Path, tenant: &str, vk: &VerifyingKey) -> Result<Vec<String>> {
+    let path = emitter::audit_path_for_tenant(audit_dir, tenant);
+    verify_audit_chain(&path, vk).with_context(|| {
+        format!(
+            "refusing to build a Merkle root over an unverified audit chain at {}",
+            path.display()
+        )
+    })?;
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading audit chain {}", path.display()))?;
+    Ok(content
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// Build the Merkle root over `tenant`'s audit chain, returning the root
+/// hash and the number of leaves (`tree_size`). Loads the host signer to
+/// verify the chain first. See [`build_root_in`] for the injectable-dir
+/// test seam.
+pub fn build_root(tenant: &str) -> Result<([u8; 32], u64)> {
+    let signer = host_keypair::load_or_init().context("loading host signer to build audit root")?;
+    build_root_in(&emitter::default_audit_dir()?, tenant, &signer.verifying)
+}
+
+/// [`build_root`] against an explicit audit directory and verifying key.
+pub fn build_root_in(audit_dir: &Path, tenant: &str, vk: &VerifyingKey) -> Result<([u8; 32], u64)> {
+    let leaves = read_leaves(audit_dir, tenant, vk)?;
+    let tree_size = leaves.len() as u64;
+    Ok((merkle_root(&leaves), tree_size))
+}
+
+/// Build an inclusion proof for the leaf at `leaf_index` in `tenant`'s
+/// audit chain. Loads the host signer to verify the chain first. See
+/// [`build_inclusion_in`] for the injectable-dir test seam.
+pub fn build_inclusion(tenant: &str, leaf_index: usize) -> Result<InclusionProof> {
+    let signer =
+        host_keypair::load_or_init().context("loading host signer to build inclusion proof")?;
+    build_inclusion_in(
+        &emitter::default_audit_dir()?,
+        tenant,
+        &signer.verifying,
+        leaf_index,
+    )
+}
+
+/// [`build_inclusion`] against an explicit audit directory and verifying key.
+pub fn build_inclusion_in(
+    audit_dir: &Path,
+    tenant: &str,
+    vk: &VerifyingKey,
+    leaf_index: usize,
+) -> Result<InclusionProof> {
+    let leaves = read_leaves(audit_dir, tenant, vk)?;
+    build_inclusion_proof(&leaves, leaf_index)
+        .map_err(|e| anyhow::anyhow!("building inclusion proof for leaf {leaf_index}: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::supervisor::{AuditEntry, AuditSigner, FileAuditSigner};
+    use ed25519_dalek::SigningKey;
+    use mvm_core::plan::{PlanId, TenantId};
+    use mvm_protocol::merkle::{verify_inclusion, verify_signed_root};
+    use std::collections::BTreeMap;
+
+    fn fresh_key() -> SigningKey {
+        let mut seed = [0u8; 32];
+        rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut seed);
+        SigningKey::from_bytes(&seed)
+    }
+
+    fn entry(tenant: &str, event: &str) -> AuditEntry {
+        AuditEntry {
+            timestamp: chrono::Utc::now(),
+            tenant: TenantId(tenant.to_string()),
+            plan_id: PlanId(format!("plan-{event}")),
+            plan_version: 1,
+            bundle_id: None,
+            bundle_version: None,
+            image_name: "img".to_string(),
+            image_sha256: "abc123".to_string(),
+            event: event.to_string(),
+            labels: BTreeMap::new(),
+        }
+    }
+
+    /// Seed a real chain of `n` entries via `FileAuditSigner` and return the
+    /// dir, the signer's key, and the raw leaf lines.
+    fn seed_chain(n: usize) -> (tempfile::TempDir, SigningKey, Vec<String>) {
+        let dir = tempfile::tempdir().unwrap();
+        let key = fresh_key();
+        let signer = FileAuditSigner::open(key.clone(), dir.path()).unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        for i in 0..n {
+            rt.block_on(signer.sign_and_emit(&entry("local", &format!("e-{i}"))))
+                .unwrap();
+        }
+        let content = std::fs::read_to_string(dir.path().join("local.jsonl")).unwrap();
+        let lines: Vec<String> = content.lines().map(str::to_string).collect();
+        (dir, key, lines)
+    }
+
+    #[test]
+    fn build_root_matches_direct_merkle_root_over_lines() {
+        let (dir, key, lines) = seed_chain(5);
+        let vk = key.verifying_key();
+        let (root, size) = build_root_in(dir.path(), "local", &vk).unwrap();
+        assert_eq!(size, 5);
+        // The host builder's root is exactly `merkle_root` over the verbatim
+        // chain lines — no re-encoding of the leaf bytes.
+        assert_eq!(root, merkle_root(&lines));
+    }
+
+    #[test]
+    fn build_root_refuses_a_tampered_chain() {
+        let (dir, key, _lines) = seed_chain(3);
+        let vk = key.verifying_key();
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        std::fs::write(&path, content.replacen("e-0", "e-hijacked", 1)).unwrap();
+        // A chain that no longer verifies must not yield a root.
+        assert!(build_root_in(dir.path(), "local", &vk).is_err());
+        assert!(build_inclusion_in(dir.path(), "local", &vk, 0).is_err());
+    }
+
+    #[test]
+    fn build_root_refuses_wrong_key() {
+        let (dir, _key, _lines) = seed_chain(2);
+        let other = fresh_key().verifying_key();
+        assert!(build_root_in(dir.path(), "local", &other).is_err());
+    }
+
+    #[test]
+    fn every_built_proof_verifies_against_the_built_root() {
+        for n in [1usize, 2, 3, 5, 8] {
+            let (dir, key, _lines) = seed_chain(n);
+            let vk = key.verifying_key();
+            let (root, size) = build_root_in(dir.path(), "local", &vk).unwrap();
+            assert_eq!(size, n as u64);
+            for i in 0..n {
+                let proof = build_inclusion_in(dir.path(), "local", &vk, i).unwrap();
+                assert_eq!(proof.leaf_index, i as u64);
+                assert_eq!(proof.tree_size, n as u64);
+                let recomputed = verify_inclusion(&proof).expect("proof must verify");
+                assert_eq!(recomputed, root, "leaf {i} of {n} folded to the wrong root");
+                assert_eq!(proof.root, hex::encode(root));
+            }
+        }
+    }
+
+    // The anti-drift guarantee: build the root + a proof on the HOST side,
+    // then verify them with the `mvm_protocol::merkle` verifier (the exact
+    // code a browser runs). Agreement proves the host's leaf bytes == the
+    // verifier's leaf bytes. Sibling to
+    // `mvm_verify_matches_supervisor_chain` in `supervisor::audit_file`.
+    #[test]
+    fn host_built_artifacts_verify_with_no_std_verifier() {
+        let (dir, key, _lines) = seed_chain(6);
+        let vk = key.verifying_key();
+        let (root, size) = build_root_in(dir.path(), "local", &vk).unwrap();
+
+        // A host-built proof verifies through the wasm-clean verifier and
+        // folds to the same root.
+        let proof = build_inclusion_in(dir.path(), "local", &vk, 4).unwrap();
+        assert_eq!(verify_inclusion(&proof).unwrap(), root);
+        assert_eq!(proof.root, hex::encode(root));
+
+        // A proof for the WRONG leaf must not verify against the real root:
+        // re-point the leaf_index and the fold lands on a different root.
+        let mut wrong = build_inclusion_in(dir.path(), "local", &vk, 4).unwrap();
+        wrong.leaf_index = 2;
+        assert!(
+            verify_inclusion(&wrong).map(|r| r != root).unwrap_or(true),
+            "a wrong-leaf proof must not fold to the real root"
+        );
+
+        // And a host-signed root over the same tree verifies with the
+        // no_std signed-root verifier, then a byte-flip on the root_hash is
+        // rejected.
+        let timestamp = "2026-07-26T00:00:00Z";
+        let root_hex = hex::encode(root);
+        let payload =
+            mvm_protocol::merkle::root_signing_bytes("local", size, &root_hex, timestamp).unwrap();
+        use ed25519_dalek::Signer;
+        let sig = key.sign(&payload);
+        use base64::Engine;
+        let mut signed = mvm_protocol::merkle::SignedAuditRoot {
+            tenant: "local".to_string(),
+            tree_size: size,
+            root_hash: root_hex,
+            timestamp: timestamp.to_string(),
+            signature: base64::engine::general_purpose::STANDARD.encode(sig.to_bytes()),
+            signer_pubkey: hex::encode(vk.to_bytes()),
+        };
+        assert_eq!(verify_signed_root(&signed, &vk), Ok(()));
+        signed.root_hash = hex::encode([0xffu8; 32]);
+        assert!(verify_signed_root(&signed, &vk).is_err());
+    }
+}

--- a/crates/mvm-hostd/src/audit/merkle.rs
+++ b/crates/mvm-hostd/src/audit/merkle.rs
@@ -29,13 +29,16 @@ use anyhow::{Context, Result};
 use ed25519_dalek::VerifyingKey;
 use mvm_protocol::merkle::{InclusionProof, build_inclusion_proof, merkle_root};
 
-use crate::audit::{emitter, host_keypair};
-use crate::supervisor::verify_audit_chain;
+use crate::audit::emitter;
+use mvm_protocol::verify::verify_audit_chain_bytes;
 
 /// Read a tenant's audit lines as Merkle leaves, in file order, **after**
-/// verifying the chain is intact. Empty lines are skipped (matching
-/// `verify_audit_chain`), so every returned element is a genuine
-/// `SignedEnvelope` line — the exact bytes the verifier re-hashes.
+/// verifying the chain is intact — from the SAME bytes. The file is read
+/// once into a buffer; the chain is verified over that buffer and the leaves
+/// are derived from it, so the root is provably over exactly the verified
+/// bytes (no read → verify → re-read TOCTOU window). Empty lines are skipped
+/// (matching the chain verifier), so every returned element is a genuine
+/// `SignedEnvelope` line — the exact bytes the inclusion verifier re-hashes.
 ///
 /// Fails closed if the chain does not verify under `vk`: a corrupt log
 /// never yields a root. Public so the CLI `prove` verb can resolve a
@@ -43,14 +46,17 @@ use crate::supervisor::verify_audit_chain;
 /// over (a single reader, so indices can't drift).
 pub fn read_leaves(audit_dir: &Path, tenant: &str, vk: &VerifyingKey) -> Result<Vec<String>> {
     let path = emitter::audit_path_for_tenant(audit_dir, tenant);
-    verify_audit_chain(&path, vk).with_context(|| {
-        format!(
-            "refusing to build a Merkle root over an unverified audit chain at {}",
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading audit chain {}", path.display()))?;
+    // Byte-equivalent to the file-reading `verify_audit_chain` (CI-pinned by
+    // `mvm_verify_matches_supervisor_chain`), run over the buffer we then split
+    // into leaves — one read, one source of truth.
+    verify_audit_chain_bytes(&content, vk).map_err(|e| {
+        anyhow::anyhow!(
+            "refusing to build a Merkle root over an unverified audit chain at {}: {e}",
             path.display()
         )
     })?;
-    let content = std::fs::read_to_string(&path)
-        .with_context(|| format!("reading audit chain {}", path.display()))?;
     Ok(content
         .lines()
         .filter(|line| !line.is_empty())
@@ -58,37 +64,17 @@ pub fn read_leaves(audit_dir: &Path, tenant: &str, vk: &VerifyingKey) -> Result<
         .collect())
 }
 
-/// Build the Merkle root over `tenant`'s audit chain, returning the root
-/// hash and the number of leaves (`tree_size`). Loads the host signer to
-/// verify the chain first. See [`build_root_in`] for the injectable-dir
-/// test seam.
-pub fn build_root(tenant: &str) -> Result<([u8; 32], u64)> {
-    let signer = host_keypair::load_or_init().context("loading host signer to build audit root")?;
-    build_root_in(&emitter::default_audit_dir()?, tenant, &signer.verifying)
-}
-
-/// [`build_root`] against an explicit audit directory and verifying key.
+/// Build the Merkle root over `tenant`'s audit chain in `audit_dir`,
+/// returning the root hash and the number of leaves (`tree_size`). The chain
+/// is verified under `vk` first; a corrupt log yields no root.
 pub fn build_root_in(audit_dir: &Path, tenant: &str, vk: &VerifyingKey) -> Result<([u8; 32], u64)> {
     let leaves = read_leaves(audit_dir, tenant, vk)?;
     let tree_size = leaves.len() as u64;
     Ok((merkle_root(&leaves), tree_size))
 }
 
-/// Build an inclusion proof for the leaf at `leaf_index` in `tenant`'s
-/// audit chain. Loads the host signer to verify the chain first. See
-/// [`build_inclusion_in`] for the injectable-dir test seam.
-pub fn build_inclusion(tenant: &str, leaf_index: usize) -> Result<InclusionProof> {
-    let signer =
-        host_keypair::load_or_init().context("loading host signer to build inclusion proof")?;
-    build_inclusion_in(
-        &emitter::default_audit_dir()?,
-        tenant,
-        &signer.verifying,
-        leaf_index,
-    )
-}
-
-/// [`build_inclusion`] against an explicit audit directory and verifying key.
+/// Build an inclusion proof for the leaf at `leaf_index` in `tenant`'s audit
+/// chain in `audit_dir`. The chain is verified under `vk` first.
 pub fn build_inclusion_in(
     audit_dir: &Path,
     tenant: &str,

--- a/crates/mvm-hostd/src/audit/mod.rs
+++ b/crates/mvm-hostd/src/audit/mod.rs
@@ -5,4 +5,7 @@
 pub mod bind;
 pub mod emitter;
 pub mod host_keypair;
+/// RFC 6962 Merkle transparency-log root + inclusion-proof builder over a
+/// tenant's chain-signed audit log.
+pub mod merkle;
 pub mod plan_persist;

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -186,6 +186,9 @@ fail honestly instead of emitting fake numbers.
 | `mvmctl trust audit tail` | Show the last 20 audit events from /var/log/mvm/audit.jsonl |
 | `mvmctl trust audit tail -n <N>` | Show the last N audit events |
 | `mvmctl trust audit tail -f` | Follow audit log output (poll until Ctrl-C) |
+| `mvmctl trust audit publish-root [--tenant <t>]` | Build, sign, and publish a Merkle transparency-log root over the tenant's chain-signed audit log to `~/.mvm/audit/<tenant>.root.json`. Only builds over a chain that verifies clean |
+| `mvmctl trust audit prove <selector> [--tenant <t>] [--json]` | Emit an inclusion proof that one audit line is in the log, paired with the current signed root. `<selector>` is a numeric line index, a `plan_id`, or `sha256:<hex>` of the exact line; an ambiguous selector is refused |
+| `mvmctl trust audit verify-inclusion --proof <file\|-> [--root <file>] [--pubkey <file>] [--tenant <t>]` | Verify an inclusion proof against a host-signed root: verifies the signed root under the trusted host key, checks its tenant, verifies the proof, and binds root_hash + tree_size. Nonzero exit naming the failed check |
 
 ## Local Secrets
 

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -390,13 +390,20 @@ const TRANSCRIPT_SUB: &[(&str, AuditPosture)] = &[
 
 // `trust audit <sub>` — the chain inspection/verification verbs are read-only;
 // `transcript` is the one emitting subgroup (promoted to DelegatesToSub so its
-// emitting leaves are classified).
+// emitting leaves are classified). The Merkle transparency-log verbs
+// (`publish-root` / `prove` / `verify-inclusion`) emit no audit-chain entry of
+// their own: `publish-root` writes a signed-root sidecar derived from the chain
+// (not a new chain event), and `prove` / `verify-inclusion` are pure reads —
+// the same audit posture as `verify-cert`.
 const AUDIT_SUB: &[(&str, AuditPosture)] = &[
     ("tail", AuditPosture::ReadOnly),
     ("verify", AuditPosture::ReadOnly),
     ("show", AuditPosture::ReadOnly),
     ("posture", AuditPosture::ReadOnly),
     ("verify-cert", AuditPosture::ReadOnly),
+    ("publish-root", AuditPosture::ReadOnly),
+    ("prove", AuditPosture::ReadOnly),
+    ("verify-inclusion", AuditPosture::ReadOnly),
     ("transcript", AuditPosture::DelegatesToSub(TRANSCRIPT_SUB)),
 ];
 

--- a/web/audit-verify/Cargo.lock
+++ b/web/audit-verify/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +34,16 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -70,7 +86,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -151,10 +167,21 @@ name = "mvm-protocol"
 version = "0.18.0"
 dependencies = [
  "base64",
+ "chrono",
  "ed25519-dalek",
  "serde",
  "serde_json",
  "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -229,7 +256,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -280,6 +307,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,7 +381,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 

--- a/web/audit-verify/README.md
+++ b/web/audit-verify/README.md
@@ -55,9 +55,10 @@ whole chain:
   This is only half a membership check.
 - `verify_signed_root(root_json, pubkey_hex)` — checks the root's Ed25519
   signature under the trusted host key.
-- `verify_membership(proof_json, root_json, pubkey_hex)` — the full check:
-  verifies the signed root, verifies the proof, and binds the two
-  (`root` + `tree_size` must match). This is the exact composition
-  `mvmctl trust audit verify-inclusion` enforces host-side, so a
-  self-consistent proof over an unsigned root is rejected. `index.html`
-  wiring for this flow is a follow-up.
+- `verify_membership(proof_json, root_json, pubkey_hex, tenant)` — the full
+  check: verifies the signed root, checks it is for the intended `tenant`,
+  verifies the proof, and binds root + tree_size. This is the exact
+  composition `mvmctl trust audit verify-inclusion` enforces host-side, so a
+  root signed for a different tenant, or a self-consistent proof over an
+  unsigned root, is rejected. `index.html` wiring for this flow is a
+  follow-up.

--- a/web/audit-verify/README.md
+++ b/web/audit-verify/README.md
@@ -43,3 +43,21 @@ under the key. Any reordering, edit, or deletion fails. The equivalence
 is pinned by `mvm-supervisor`'s `mvm_verify_matches_supervisor_chain`
 test, so if the audit entry shape drifts, CI fails before the browser
 tool can silently disagree.
+
+## Merkle inclusion proofs
+
+Three further exports let a browser verify an `O(log n)` transparency-log
+inclusion proof (from `mvmctl trust audit prove`) against a host-signed
+Merkle root (`mvmctl trust audit publish-root`) without downloading the
+whole chain:
+
+- `verify_inclusion(proof_json)` — folds a proof to its own embedded root.
+  This is only half a membership check.
+- `verify_signed_root(root_json, pubkey_hex)` — checks the root's Ed25519
+  signature under the trusted host key.
+- `verify_membership(proof_json, root_json, pubkey_hex)` — the full check:
+  verifies the signed root, verifies the proof, and binds the two
+  (`root` + `tree_size` must match). This is the exact composition
+  `mvmctl trust audit verify-inclusion` enforces host-side, so a
+  self-consistent proof over an unsigned root is rejected. `index.html`
+  wiring for this flow is a follow-up.

--- a/web/audit-verify/src/lib.rs
+++ b/web/audit-verify/src/lib.rs
@@ -7,6 +7,10 @@
 //! Keeping the logic in `mvm-protocol` (a real, tested workspace crate)
 //! means this file stays a dumb adapter.
 
+use mvm_protocol::merkle::{
+    InclusionProof, SignedAuditRoot, verify_inclusion as merkle_verify_inclusion,
+    verify_signed_root as merkle_verify_signed_root,
+};
 use mvm_protocol::verify::{verify_audit_chain_bytes, verifying_key_from_hex};
 use wasm_bindgen::prelude::*;
 
@@ -30,5 +34,108 @@ pub fn verify(jsonl: &str, pubkey_hex: &str) -> String {
         })
         .to_string(),
         Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }).to_string(),
+    }
+}
+
+/// Verify that an [`InclusionProof`] is internally consistent — it folds to
+/// its own embedded root. This is only HALF a membership check: it does not
+/// prove membership in a real published log. Use [`verify_membership`] to
+/// bind the proof to a host-signed root.
+///
+/// `proof_json` is the serialized proof. Returns
+/// `{"ok":true,"leaf_index":i,"tree_size":n,"root":"<hex>"}` on success or
+/// `{"ok":false,"error":"…"}` otherwise.
+#[wasm_bindgen]
+pub fn verify_inclusion(proof_json: &str) -> String {
+    let outcome = serde_json::from_str::<InclusionProof>(proof_json)
+        .map_err(|e| format!("decode proof: {e}"))
+        .and_then(|proof| {
+            merkle_verify_inclusion(&proof)
+                .map(|_| proof)
+                .map_err(|e| e.to_string())
+        });
+    match outcome {
+        Ok(proof) => serde_json::json!({
+            "ok": true,
+            "leaf_index": proof.leaf_index,
+            "tree_size": proof.tree_size,
+            "root": proof.root,
+        })
+        .to_string(),
+        Err(e) => serde_json::json!({ "ok": false, "error": e }).to_string(),
+    }
+}
+
+/// Verify a [`SignedAuditRoot`]'s Ed25519 signature against a trusted host
+/// key. `pubkey_hex` is the 32-byte key as 64 hex chars. Returns
+/// `{"ok":true,"tenant":"…","tree_size":n,"root":"<hex>"}` on success or
+/// `{"ok":false,"error":"…"}` otherwise.
+#[wasm_bindgen]
+pub fn verify_signed_root(root_json: &str, pubkey_hex: &str) -> String {
+    let outcome = (|| -> Result<SignedAuditRoot, String> {
+        let vk = verifying_key_from_hex(pubkey_hex).map_err(|e| e.to_string())?;
+        let root: SignedAuditRoot =
+            serde_json::from_str(root_json).map_err(|e| format!("decode root: {e}"))?;
+        merkle_verify_signed_root(&root, &vk).map_err(|e| e.to_string())?;
+        Ok(root)
+    })();
+    match outcome {
+        Ok(root) => serde_json::json!({
+            "ok": true,
+            "tenant": root.tenant,
+            "tree_size": root.tree_size,
+            "root": root.root_hash,
+        })
+        .to_string(),
+        Err(e) => serde_json::json!({ "ok": false, "error": e }).to_string(),
+    }
+}
+
+/// The full inclusion-membership check a browser runs with no server: the
+/// exact composition `mvmctl trust audit verify-inclusion` enforces
+/// host-side. In order, fail-closed:
+///   1. the signed root verifies under the trusted host key;
+///   2. the inclusion proof is internally consistent;
+///   3. the proof binds to THIS signed root (`root` + `tree_size` match).
+///
+/// A self-consistent proof over a different (unsigned) root is rejected at
+/// step 3. Returns `{"ok":true,…}` naming the bound root on success, or
+/// `{"ok":false,"error":"<which check failed>"}`.
+#[wasm_bindgen]
+pub fn verify_membership(proof_json: &str, root_json: &str, pubkey_hex: &str) -> String {
+    let outcome = (|| -> Result<InclusionProof, String> {
+        let vk = verifying_key_from_hex(pubkey_hex).map_err(|e| e.to_string())?;
+        let proof: InclusionProof =
+            serde_json::from_str(proof_json).map_err(|e| format!("decode proof: {e}"))?;
+        let root: SignedAuditRoot =
+            serde_json::from_str(root_json).map_err(|e| format!("decode root: {e}"))?;
+        merkle_verify_signed_root(&root, &vk)
+            .map_err(|e| format!("signed-root verification failed: {e}"))?;
+        merkle_verify_inclusion(&proof)
+            .map_err(|e| format!("inclusion-proof verification failed: {e}"))?;
+        if proof.root != root.root_hash {
+            return Err(format!(
+                "root binding failed: proof root {} does not match the host-signed root {}",
+                proof.root, root.root_hash
+            ));
+        }
+        if proof.tree_size != root.tree_size {
+            return Err(format!(
+                "tree-size binding failed: proof tree_size {} does not match the host-signed \
+                 tree_size {}",
+                proof.tree_size, root.tree_size
+            ));
+        }
+        Ok(proof)
+    })();
+    match outcome {
+        Ok(proof) => serde_json::json!({
+            "ok": true,
+            "leaf_index": proof.leaf_index,
+            "tree_size": proof.tree_size,
+            "root": proof.root,
+        })
+        .to_string(),
+        Err(e) => serde_json::json!({ "ok": false, "error": e }).to_string(),
     }
 }

--- a/web/audit-verify/src/lib.rs
+++ b/web/audit-verify/src/lib.rs
@@ -95,14 +95,21 @@ pub fn verify_signed_root(root_json: &str, pubkey_hex: &str) -> String {
 /// exact composition `mvmctl trust audit verify-inclusion` enforces
 /// host-side. In order, fail-closed:
 ///   1. the signed root verifies under the trusted host key;
-///   2. the inclusion proof is internally consistent;
-///   3. the proof binds to THIS signed root (`root` + `tree_size` match).
+///   2. the signed root is for the `tenant` the caller intended;
+///   3. the inclusion proof is internally consistent;
+///   4. the proof binds to THIS signed root (`root` + `tree_size` match).
 ///
-/// A self-consistent proof over a different (unsigned) root is rejected at
-/// step 3. Returns `{"ok":true,…}` naming the bound root on success, or
-/// `{"ok":false,"error":"<which check failed>"}`.
+/// A genuinely-signed root for a different tenant is rejected at step 2; a
+/// self-consistent proof over a different (unsigned) root is rejected at
+/// step 4. Returns `{"ok":true,"tenant":..,"leaf_index":..,"tree_size":..,
+/// "root":..}` on success, or `{"ok":false,"error":"<which check failed>"}`.
 #[wasm_bindgen]
-pub fn verify_membership(proof_json: &str, root_json: &str, pubkey_hex: &str) -> String {
+pub fn verify_membership(
+    proof_json: &str,
+    root_json: &str,
+    pubkey_hex: &str,
+    tenant: &str,
+) -> String {
     let outcome = (|| -> Result<InclusionProof, String> {
         let vk = verifying_key_from_hex(pubkey_hex).map_err(|e| e.to_string())?;
         let proof: InclusionProof =
@@ -111,6 +118,12 @@ pub fn verify_membership(proof_json: &str, root_json: &str, pubkey_hex: &str) ->
             serde_json::from_str(root_json).map_err(|e| format!("decode root: {e}"))?;
         merkle_verify_signed_root(&root, &vk)
             .map_err(|e| format!("signed-root verification failed: {e}"))?;
+        if root.tenant != tenant {
+            return Err(format!(
+                "tenant binding failed: signed root is for tenant '{}', expected '{}'",
+                root.tenant, tenant
+            ));
+        }
         merkle_verify_inclusion(&proof)
             .map_err(|e| format!("inclusion-proof verification failed: {e}"))?;
         if proof.root != root.root_hash {
@@ -131,6 +144,7 @@ pub fn verify_membership(proof_json: &str, root_json: &str, pubkey_hex: &str) ->
     match outcome {
         Ok(proof) => serde_json::json!({
             "ok": true,
+            "tenant": tenant,
             "leaf_index": proof.leaf_index,
             "tree_size": proof.tree_size,
             "root": proof.root,


### PR DESCRIPTION
Closes #1811 — Slice 2, completing the Phase-1 Merkle transparency-log machinery
(Slice 1 = the `no_std` `mvm_protocol::merkle` module, #1848).

## What's here
- **Host builder** (`crates/mvm-hostd/src/audit/merkle.rs`): builds the Merkle
  tree over the host-lifecycle audit chain — reads the file **once**, verifies it
  (`verify_audit_chain_bytes`), and derives leaves from that same buffer, so the
  root is provably over exactly the verified bytes. Each `SignedEnvelope` line is
  a leaf verbatim (the bytes the verifier re-hashes).
- **`AuditEmitter::publish_root`**: host-Ed25519-signs a `SignedAuditRoot` to
  `~/.mvm/audit/<tenant>.root.json` (atomic write).
- **CLI** — `mvmctl trust audit publish-root` / `prove <selector>` /
  `verify-inclusion`. `verify-inclusion` is the full composition, **fail-closed**:
  verify the signed root against the caller's **trusted** host key (never the
  root's self-reported key), verify the inclusion proof, bind `proof.root ==
  root.root_hash`, bind `proof.tree_size == root.tree_size`, **and bind
  `signed_root.tenant == the intended tenant`** — so a genuinely-signed root+proof
  from another tenant is rejected.
- **Browser verifier** (`web/audit-verify`): `verify_membership` runs the same
  composition (incl. tenant binding) and surfaces `tenant` in its output.
- **CI cross-check**: a host-built root + proof verify through the `no_std`
  verifier (the same code the browser runs), pinning host↔verifier leaf-byte
  equality.

## Verification
Two-stage adversarial review (correctness + security). Security review found and
fixed a **cross-tenant substitution** gap (tenant now bound) and confirmed no
composition bypass + correct trusted-key provenance; correctness confirmed
leaf-byte equality (shared `.lines()` split with the chain verifier) and selector
resolution; both drove the double-read TOCTOU fix + dead-code removal.

`nextest --workspace` 7790 passed / 0 failed; `cargo build -p mvm-protocol
--target wasm32-unknown-unknown` + the wasm-verify shim build green; clippy
`--all-targets -D warnings`, nightly fmt, `check-content-address-determinism`,
`check-no-spec-refs-in-comments`, doctests all clean.

## Scope
Inclusion against a host-signed, **tenant-bound**, pinnable root over the
host-lifecycle chain. Deferred to **#1849**: RFC-6962 consistency proofs + an
external witness/gossip layer — the part that makes the log provably honest
against the host itself (needs external infrastructure).
