### PR TITLE
feat(plan-255): vsock-first snapshot storage — Phase 0 + Phase 1

### DIFF
--- a/crates/mvm-conformance/tests/steps/mod.rs
+++ b/crates/mvm-conformance/tests/steps/mod.rs
@@ -4,5 +4,6 @@ mod cli;
 mod kernel_pin;
 mod oci_unpack;
 mod readme_contract;
+mod snapshot;
 mod verified_boot;
 mod workload_identity;

--- a/crates/mvm-conformance/tests/steps/snapshot.rs
+++ b/crates/mvm-conformance/tests/steps/snapshot.rs
@@ -1,0 +1,160 @@
+//! Step definitions for the warm-snapshot clone scenario.
+//!
+//! These steps exercise `mvm_fs::snapshot_store` directly — content-addressed
+//! `create`/`materialize`/dedup — with no VM boot, proving the storage-layer
+//! value proposition of a warm snapshot: materializing an instance is a
+//! copy-on-write clone of a pre-built artifact, not a rebuild.
+
+use std::fs;
+
+use cucumber::{given, then, when};
+
+use mvm_fs::snapshot_store::{FsSnapshotStore, SnapshotStore};
+
+use crate::world::CliWorld;
+
+#[given(expr = "a content-addressed warm snapshot built from a template rootfs artifact")]
+fn build_warm_snapshot(world: &mut CliWorld) {
+    let tmp = tempfile::tempdir().expect("create snapshot scenario tempdir");
+    let store = FsSnapshotStore::new(tmp.path().join("store")).expect("open snapshot store");
+
+    // Synthetic template rootfs artifact with an interior zero run so this
+    // also exercises the sparse-copy fallback path, not just the reflink
+    // fast path.
+    let mut artifact = vec![0xAA_u8; 4096];
+    artifact.extend(std::iter::repeat_n(0u8, 65536));
+    artifact.extend(vec![0xBB_u8; 4096]);
+    let source_path = tmp.path().join("template-rootfs.img");
+    fs::write(&source_path, &artifact).expect("write template rootfs artifact");
+
+    let id = store
+        .create_content_addressed(&source_path)
+        .expect("store warm snapshot");
+
+    world.snapshot_source_path = Some(source_path);
+    world.snapshot_source_bytes = Some(artifact);
+    world.snapshot_id = Some(id);
+    world.snapshot_store = Some(store);
+    world.snapshot_tmp = Some(tmp);
+}
+
+#[when(expr = "the warm snapshot is cloned into a fresh instance")]
+fn clone_into_instance(world: &mut CliWorld) {
+    let tmp = world
+        .snapshot_tmp
+        .as_ref()
+        .expect("a warm snapshot must be built first");
+    let store = world
+        .snapshot_store
+        .as_ref()
+        .expect("a warm snapshot must be built first");
+    let id = world
+        .snapshot_id
+        .as_ref()
+        .expect("a warm snapshot must be built first");
+
+    let instance_path = tmp.path().join("instance.img");
+    store
+        .materialize(id, &instance_path)
+        .expect("materialize warm snapshot into instance");
+    world.snapshot_instance_path = Some(instance_path);
+}
+
+#[then(expr = "the instance byte-equals the warm snapshot")]
+fn instance_byte_equals(world: &mut CliWorld) {
+    let instance_path = world
+        .snapshot_instance_path
+        .as_ref()
+        .expect("the warm snapshot must be cloned into an instance first");
+    let expected = world
+        .snapshot_source_bytes
+        .as_ref()
+        .expect("a warm snapshot must be built first");
+
+    let actual = fs::read(instance_path).expect("read materialized instance");
+    assert_eq!(
+        &actual, expected,
+        "materialized instance must byte-equal the stored warm snapshot"
+    );
+}
+
+#[then(expr = "mutating the instance does not change the stored warm snapshot")]
+fn mutating_instance_is_isolated(world: &mut CliWorld) {
+    let instance_path = world
+        .snapshot_instance_path
+        .as_ref()
+        .expect("the warm snapshot must be cloned into an instance first")
+        .clone();
+    let store = world
+        .snapshot_store
+        .as_ref()
+        .expect("a warm snapshot must be built first");
+    let id = world
+        .snapshot_id
+        .as_ref()
+        .expect("a warm snapshot must be built first");
+    let expected = world
+        .snapshot_source_bytes
+        .as_ref()
+        .expect("a warm snapshot must be built first")
+        .clone();
+    let tmp = world
+        .snapshot_tmp
+        .as_ref()
+        .expect("a warm snapshot must be built first");
+
+    fs::write(&instance_path, b"mutated instance content").expect("mutate instance in place");
+
+    // Re-materialize a fresh instance and check it still carries the
+    // original bytes — proving the mutation above never reached the store.
+    let recheck_path = tmp.path().join("instance-recheck.img");
+    store
+        .materialize(id, &recheck_path)
+        .expect("re-materialize warm snapshot after instance mutation");
+    let recheck = fs::read(&recheck_path).expect("read re-materialized instance");
+    assert_eq!(
+        recheck, expected,
+        "stored warm snapshot must be unaffected by mutating a materialized instance"
+    );
+}
+
+#[then(
+    expr = "re-storing the identical artifact reuses the existing snapshot rather than rebuilding it"
+)]
+fn restoring_identical_artifact_dedups(world: &mut CliWorld) {
+    let store = world
+        .snapshot_store
+        .as_ref()
+        .expect("a warm snapshot must be built first");
+    let id = world
+        .snapshot_id
+        .as_ref()
+        .expect("a warm snapshot must be built first");
+    let source_path = world
+        .snapshot_source_path
+        .as_ref()
+        .expect("a warm snapshot must be built first");
+
+    let id_again = store
+        .create_content_addressed(source_path)
+        .expect("re-store identical template rootfs artifact");
+    assert_eq!(
+        id_again.id(),
+        id.id(),
+        "re-storing identical content must reuse the existing content-addressed id"
+    );
+
+    let entries: Vec<_> = fs::read_dir(store.root())
+        .expect("read snapshot store root")
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "identical content must be stored exactly once, not rebuilt as a second copy"
+    );
+    assert_eq!(
+        store.refcount(id).expect("read snapshot refcount"),
+        2,
+        "reusing an existing snapshot must bump its refcount, not duplicate storage"
+    );
+}

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -7,6 +7,7 @@ use std::process::Output;
 
 use mvm_core::kernel_advisory::{KernelAdvisory, KernelPin};
 use mvm_core::kernel_format::KernelFormat;
+use mvm_fs::snapshot_store::{FsSnapshotStore, SnapshotId};
 
 /// Constructed fresh for every scenario. Holds the result of the most
 /// recent CLI invocation so later `Then` steps can assert on it, plus the
@@ -42,6 +43,23 @@ pub struct CliWorld {
     pub prior_layer_paths: HashSet<PathBuf>,
     /// The most recent OCI unpack report.
     pub last_unpack_report: Option<mvm_fs::oci::UnpackReport>,
+    /// Scratch directory backing the warm-snapshot scenarios: holds the
+    /// snapshot store root, the synthetic template rootfs artifact, and
+    /// every materialized instance path.
+    pub snapshot_tmp: Option<tempfile::TempDir>,
+    /// The content-addressed snapshot store opened by a warm-snapshot
+    /// `Given` step.
+    pub snapshot_store: Option<FsSnapshotStore>,
+    /// The id returned when the template rootfs artifact was stored.
+    pub snapshot_id: Option<SnapshotId>,
+    /// Path to the synthetic template rootfs artifact, kept so later steps
+    /// can re-store it and assert dedup.
+    pub snapshot_source_path: Option<PathBuf>,
+    /// Bytes of the synthetic template rootfs artifact, for byte-equality
+    /// assertions against materialized instances.
+    pub snapshot_source_bytes: Option<Vec<u8>>,
+    /// Path of the most recently materialized instance.
+    pub snapshot_instance_path: Option<PathBuf>,
 }
 
 impl fmt::Debug for CliWorld {

--- a/crates/mvm-fs/src/clone.rs
+++ b/crates/mvm-fs/src/clone.rs
@@ -14,7 +14,8 @@
 
 #![allow(unsafe_code)]
 
-use std::io;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 /// What strategy [`reflink_or_copy`] used to materialize the destination.
@@ -67,11 +68,48 @@ pub fn reflink_or_copy(src: &Path, dst: &Path) -> io::Result<CloneStrategy> {
     match reflink_or_err(src, dst) {
         Ok(()) => Ok(CloneStrategy::Reflink),
         Err(e) if is_unsupported(&e) => {
-            std::fs::copy(src, dst)?;
+            // Sparse-aware fallback: a memory snapshot or an ext4 image with
+            // free space has large zero runs that must not fully expand
+            // into allocated bytes just because reflink isn't available.
+            sparse_copy(src, dst)?;
             Ok(CloneStrategy::Copied)
         }
         Err(e) => Err(e),
     }
+}
+
+/// Byte-copy `src` to `dst`, skipping any fixed-size block that is
+/// entirely zero by seeking the destination forward instead of writing it.
+/// On a sparse-capable filesystem the skipped region becomes a hole and
+/// reads back as zeros (POSIX semantics) without ever being allocated on
+/// disk.
+///
+/// `dst` must not already exist.
+pub fn sparse_copy(src: &Path, dst: &Path) -> io::Result<()> {
+    const BLOCK: usize = 64 * 1024;
+
+    let mut src_file = File::open(src)?;
+    let src_len = src_file.metadata()?.len();
+    let mut dst_file = OpenOptions::new().write(true).create_new(true).open(dst)?;
+
+    let mut buf = vec![0u8; BLOCK];
+    loop {
+        let n = src_file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        if buf[..n].iter().all(|&b| b == 0) {
+            dst_file.seek(SeekFrom::Current(n as i64))?;
+        } else {
+            dst_file.write_all(&buf[..n])?;
+        }
+    }
+    // A trailing zero run leaves the file short of `src_len` (the final
+    // seek has no write behind it to extend the file) — pin the length
+    // explicitly so a zero-tailed source still produces an exact-length
+    // destination.
+    dst_file.set_len(src_len)?;
+    Ok(())
 }
 
 fn is_unsupported(e: &io::Error) -> bool {
@@ -265,6 +303,30 @@ mod tests {
             CloneStrategy::Reflink | CloneStrategy::Copied
         ));
         assert_eq!(std::fs::read(&dst).unwrap(), b"hello snapshot");
+    }
+
+    #[test]
+    fn sparse_copy_roundtrips_byte_equal_across_hole_blocks() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("src.bin");
+        let dst = dir.path().join("dst.bin");
+
+        const BLOCK: usize = 64 * 1024;
+        let mut data = Vec::with_capacity(BLOCK * 4);
+        data.extend(std::iter::repeat_n(0xAB_u8, BLOCK)); // nonzero block
+        data.extend(std::iter::repeat_n(0u8, BLOCK)); // zero block -> hole
+        data.extend(std::iter::repeat_n(0xCD_u8, BLOCK)); // nonzero block
+        data.extend(std::iter::repeat_n(0u8, BLOCK)); // trailing zero run
+        std::fs::write(&src, &data).unwrap();
+
+        sparse_copy(&src, &dst).expect("sparse copy");
+
+        assert_eq!(std::fs::read(&dst).unwrap(), data, "must be byte-identical");
+        assert_eq!(
+            std::fs::metadata(&dst).unwrap().len(),
+            data.len() as u64,
+            "length must match exactly even with a trailing zero run"
+        );
     }
 
     #[test]

--- a/crates/mvm-fs/src/clone.rs
+++ b/crates/mvm-fs/src/clone.rs
@@ -84,6 +84,10 @@ pub fn reflink_or_copy(src: &Path, dst: &Path) -> io::Result<CloneStrategy> {
 /// reads back as zeros (POSIX semantics) without ever being allocated on
 /// disk.
 ///
+/// Data-only: `dst` is created with default (umask-derived) permissions,
+/// not `src`'s mode bits — unlike the `std::fs::copy` this replaces, which
+/// copies source permissions onto a freshly created destination.
+///
 /// `dst` must not already exist.
 pub fn sparse_copy(src: &Path, dst: &Path) -> io::Result<()> {
     const BLOCK: usize = 64 * 1024;

--- a/crates/mvm-fs/src/hash.rs
+++ b/crates/mvm-fs/src/hash.rs
@@ -5,9 +5,10 @@
 //! file hashing has exactly one implementation in this crate); for a
 //! directory, the hash of a deterministic manifest enumerating every entry.
 
+use std::ffi::OsStr;
 use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use sha2::{Digest, Sha256};
 
@@ -37,19 +38,21 @@ pub fn hash_source(source: &Path) -> io::Result<String> {
 /// `kind` is `f`/`d`/`l` and `payload` is the entry's sha256 hex (`f`),
 /// symlink target (`l`), or empty (`d`). Sorting by relative path (rather
 /// than trusting readdir order, which varies by filesystem) makes the hash
-/// stable across runs and hosts.
+/// stable across runs and hosts. Path/target components are hashed as raw
+/// bytes (see [`os_str_bytes`]) rather than through a lossy UTF-8
+/// conversion, so distinct non-UTF-8 filenames never collide.
 fn hash_dir(root: &Path) -> io::Result<String> {
-    let mut entries: Vec<(String, &'static str, String)> = Vec::new();
-    walk_relative(root, Path::new(""), &mut entries)?;
+    let mut entries: Vec<(Vec<u8>, &'static str, Vec<u8>)> = Vec::new();
+    walk_relative(root, &[], &mut entries)?;
     entries.sort_by(|a, b| a.0.cmp(&b.0));
 
     let mut hasher = Sha256::new();
     for (relpath, kind, payload) in &entries {
-        hasher.update(relpath.as_bytes());
+        hasher.update(relpath);
         hasher.update(b"\0");
         hasher.update(kind.as_bytes());
         hasher.update(b"\0");
-        hasher.update(payload.as_bytes());
+        hasher.update(payload);
         hasher.update(b"\n");
     }
     Ok(hex::encode(hasher.finalize()))
@@ -57,30 +60,56 @@ fn hash_dir(root: &Path) -> io::Result<String> {
 
 fn walk_relative(
     abs_dir: &Path,
-    rel_dir: &Path,
-    out: &mut Vec<(String, &'static str, String)>,
+    rel_prefix: &[u8],
+    out: &mut Vec<(Vec<u8>, &'static str, Vec<u8>)>,
 ) -> io::Result<()> {
     for entry in fs::read_dir(abs_dir)? {
         let entry = entry?;
         let file_type = entry.file_type()?;
         let abs_path = entry.path();
-        let rel_path: PathBuf = rel_dir.join(entry.file_name());
-        let rel_str = rel_path.to_string_lossy().into_owned();
+        let rel_bytes = join_relative(rel_prefix, &entry.file_name());
 
         if file_type.is_dir() {
-            out.push((rel_str, "d", String::new()));
-            walk_relative(&abs_path, &rel_path, out)?;
+            out.push((rel_bytes.clone(), "d", Vec::new()));
+            walk_relative(&abs_path, &rel_bytes, out)?;
         } else if file_type.is_file() {
             let digest = compute_file_sha256(&abs_path)?;
-            out.push((rel_str, "f", digest));
+            out.push((rel_bytes, "f", digest.into_bytes()));
         } else if file_type.is_symlink() {
             let target = fs::read_link(&abs_path)?;
-            out.push((rel_str, "l", target.to_string_lossy().into_owned()));
+            out.push((rel_bytes, "l", os_str_bytes(target.as_os_str())));
         }
         // Other inode types (fifo/socket/device) have no stable content to
         // hash and are skipped, mirroring `clone::reflink_or_copy_dir`.
     }
     Ok(())
+}
+
+/// Append one path component (as raw bytes) to a `/`-joined relative path.
+fn join_relative(rel_prefix: &[u8], name: &OsStr) -> Vec<u8> {
+    let name_bytes = os_str_bytes(name);
+    if rel_prefix.is_empty() {
+        return name_bytes;
+    }
+    let mut out = Vec::with_capacity(rel_prefix.len() + 1 + name_bytes.len());
+    out.extend_from_slice(rel_prefix);
+    out.push(b'/');
+    out.extend_from_slice(&name_bytes);
+    out
+}
+
+/// The raw bytes of a path component. On unix this is exact (any byte
+/// sequence is a valid filename); elsewhere there's no such guarantee, so
+/// a lossy UTF-8 conversion is the best available fallback.
+#[cfg(unix)]
+fn os_str_bytes(s: &OsStr) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+    s.as_bytes().to_vec()
+}
+
+#[cfg(not(unix))]
+fn os_str_bytes(s: &OsStr) -> Vec<u8> {
+    s.to_string_lossy().into_owned().into_bytes()
 }
 
 #[cfg(test)]
@@ -128,5 +157,31 @@ mod tests {
             "identical directory trees hash identically"
         );
         assert_ne!(hash_source(&dir1).unwrap(), hash_source(&dir3).unwrap());
+    }
+
+    /// Two distinct non-UTF-8 byte sequences that `to_string_lossy` would
+    /// both mangle to the same U+FFFD-substituted string — proving
+    /// `os_str_bytes` keeps them distinct instead of hashing a lossy
+    /// string that would collide. Exercised in-memory (not via real
+    /// files) because APFS rejects non-UTF-8 filenames outright, so a
+    /// filesystem-backed version of this test wouldn't run on macOS.
+    #[cfg(unix)]
+    #[test]
+    fn os_str_bytes_preserves_non_utf8_sequences_without_lossy_collision() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let a = OsStr::from_bytes(b"f\xFF");
+        let b = OsStr::from_bytes(b"f\xFE");
+
+        assert_eq!(
+            a.to_string_lossy(),
+            b.to_string_lossy(),
+            "precondition: both collide under lossy UTF-8 conversion"
+        );
+        assert_ne!(
+            os_str_bytes(a),
+            os_str_bytes(b),
+            "raw-byte hashing must keep them distinct"
+        );
     }
 }

--- a/crates/mvm-fs/src/hash.rs
+++ b/crates/mvm-fs/src/hash.rs
@@ -1,0 +1,132 @@
+//! Content-addressing for the snapshot store.
+//!
+//! A snapshot's identity is the SHA-256 of its content: for a file, the
+//! hash of its bytes (reusing [`crate::overlay::compute_file_sha256`] so
+//! file hashing has exactly one implementation in this crate); for a
+//! directory, the hash of a deterministic manifest enumerating every entry.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::overlay::compute_file_sha256;
+
+/// Compute the content hash of `source` (a regular file or a directory).
+/// Returns the lowercase 64-hex-digit SHA-256 digest.
+pub fn hash_source(source: &Path) -> io::Result<String> {
+    let meta = fs::symlink_metadata(source)?;
+    if meta.is_dir() {
+        hash_dir(source)
+    } else if meta.is_file() {
+        compute_file_sha256(source)
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "hash source must be a regular file or directory: {}",
+                source.display()
+            ),
+        ))
+    }
+}
+
+/// Hash a directory as a deterministic manifest: one line per entry in
+/// sorted relative-path order, `"{relpath}\0{kind}\0{payload}\n"` where
+/// `kind` is `f`/`d`/`l` and `payload` is the entry's sha256 hex (`f`),
+/// symlink target (`l`), or empty (`d`). Sorting by relative path (rather
+/// than trusting readdir order, which varies by filesystem) makes the hash
+/// stable across runs and hosts.
+fn hash_dir(root: &Path) -> io::Result<String> {
+    let mut entries: Vec<(String, &'static str, String)> = Vec::new();
+    walk_relative(root, Path::new(""), &mut entries)?;
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = Sha256::new();
+    for (relpath, kind, payload) in &entries {
+        hasher.update(relpath.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(kind.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(payload.as_bytes());
+        hasher.update(b"\n");
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn walk_relative(
+    abs_dir: &Path,
+    rel_dir: &Path,
+    out: &mut Vec<(String, &'static str, String)>,
+) -> io::Result<()> {
+    for entry in fs::read_dir(abs_dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let abs_path = entry.path();
+        let rel_path: PathBuf = rel_dir.join(entry.file_name());
+        let rel_str = rel_path.to_string_lossy().into_owned();
+
+        if file_type.is_dir() {
+            out.push((rel_str, "d", String::new()));
+            walk_relative(&abs_path, &rel_path, out)?;
+        } else if file_type.is_file() {
+            let digest = compute_file_sha256(&abs_path)?;
+            out.push((rel_str, "f", digest));
+        } else if file_type.is_symlink() {
+            let target = fs::read_link(&abs_path)?;
+            out.push((rel_str, "l", target.to_string_lossy().into_owned()));
+        }
+        // Other inode types (fifo/socket/device) have no stable content to
+        // hash and are skipped, mirroring `clone::reflink_or_copy_dir`.
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_hash_is_deterministic_and_content_sensitive() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let a = tmp.path().join("a.bin");
+        fs::write(&a, b"hello").unwrap();
+        let b = tmp.path().join("b.bin");
+        fs::write(&b, b"hello").unwrap();
+        let c = tmp.path().join("c.bin");
+        fs::write(&c, b"world").unwrap();
+
+        assert_eq!(hash_source(&a).unwrap(), hash_source(&a).unwrap());
+        assert_eq!(
+            hash_source(&a).unwrap(),
+            hash_source(&b).unwrap(),
+            "identical bytes hash identically regardless of path"
+        );
+        assert_ne!(hash_source(&a).unwrap(), hash_source(&c).unwrap());
+    }
+
+    #[test]
+    fn dir_hash_is_deterministic_and_content_sensitive() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mk = |root: &Path, tweak: &[u8]| {
+            fs::create_dir_all(root.join("sub")).unwrap();
+            fs::write(root.join("top.txt"), b"top").unwrap();
+            fs::write(root.join("sub").join("nested.txt"), tweak).unwrap();
+        };
+
+        let dir1 = tmp.path().join("dir1");
+        mk(&dir1, b"nested");
+        let dir2 = tmp.path().join("dir2");
+        mk(&dir2, b"nested");
+        let dir3 = tmp.path().join("dir3");
+        mk(&dir3, b"different");
+
+        assert_eq!(
+            hash_source(&dir1).unwrap(),
+            hash_source(&dir2).unwrap(),
+            "identical directory trees hash identically"
+        );
+        assert_ne!(hash_source(&dir1).unwrap(), hash_source(&dir3).unwrap());
+    }
+}

--- a/crates/mvm-fs/src/lib.rs
+++ b/crates/mvm-fs/src/lib.rs
@@ -13,6 +13,8 @@
 //!   verity-sealed overlay artifact set for one `(version, arch)`.
 //! - [`clone`]: reflink (copy-on-write) file/directory cloning primitives
 //!   used by the runtime to materialize per-instance rootfs copies.
+//! - [`hash`]: content-addressing helpers (file/directory SHA-256) backing
+//!   [`snapshot_store`]'s content-addressed create.
 //! - [`snapshot_store`]: content-addressed snapshot persistence used by the
 //!   warm-parent pool.
 //!
@@ -23,6 +25,7 @@
 
 pub mod clone;
 pub mod ext4;
+pub mod hash;
 pub mod oci;
 /// OCI layer unpack to a staging rootfs directory. Handles whiteouts,
 /// symlinks, hardlinks, ownership, permissions, path traversal, the

--- a/crates/mvm-fs/src/snapshot_store.rs
+++ b/crates/mvm-fs/src/snapshot_store.rs
@@ -5,11 +5,16 @@
 //! store is intentionally simple — a directory on a reflink-capable
 //! filesystem where each snapshot lives under its opaque id.
 //!
-//! Two layouts are supported:
+//! Two layouts are supported, both keeping snapshot *content* strictly
+//! separate from the `.mvm-snapshot-*` sidecars (meta, refcount) that live
+//! directly under `<root>/<id>/`. `materialize` clones content only, never
+//! the sidecars — so a materialized snapshot contains exactly the original
+//! bytes and re-hashing it via [`crate::hash::hash_source`] reproduces the
+//! same content-addressed id:
 //!
 //! * **Directory snapshot** — the source path was a directory; the store
-//!   keeps it as `<root>/<id>/...` and materializes it with a recursive
-//!   directory clone.
+//!   keeps its contents under `<root>/<id>/content/...` and materializes
+//!   it with a recursive directory clone of `content/` alone.
 //! * **File snapshot** — the source path was a regular file; the store
 //!   keeps it as `<root>/<id>/data` with a `.mvm-snapshot-is-file`
 //!   marker, and materializes it as a single file.
@@ -38,6 +43,8 @@ use crate::hash;
 const FILE_MARKER: &str = ".mvm-snapshot-is-file";
 const META_FILE: &str = ".mvm-snapshot-meta";
 const REFCOUNT_FILE: &str = ".mvm-snapshot-refcount";
+const DATA_FILE: &str = "data";
+const CONTENT_DIR: &str = "content";
 
 /// Opaque identifier for a snapshot stored in a [`SnapshotStore`].
 ///
@@ -237,11 +244,17 @@ impl SnapshotStore for FsSnapshotStore {
 
         let meta = fs::symlink_metadata(source)?;
         if meta.is_dir() {
-            // Directory snapshot: store contents directly under dir/.
+            // Directory snapshot: store contents under dir/content/, kept
+            // apart from the `.mvm-snapshot-*` sidecars written directly
+            // under dir/ below. This lets `materialize` clone content/
+            // alone, so the materialized tree never picks up store
+            // bookkeeping files and re-hashing it reproduces the same id.
+            let content_dir = dir.join(CONTENT_DIR);
+            fs::create_dir_all(&content_dir)?;
             for entry in fs::read_dir(source)? {
                 let entry = entry?;
                 let src = entry.path();
-                let dst = dir.join(entry.file_name());
+                let dst = content_dir.join(entry.file_name());
                 if entry.file_type()?.is_dir() {
                     reflink_or_copy_dir(&src, &dst)?;
                 } else if entry.file_type()?.is_file() {
@@ -259,7 +272,7 @@ impl SnapshotStore for FsSnapshotStore {
             }
         } else if meta.is_file() {
             // File snapshot: store under dir/data with a marker.
-            let data_path = dir.join("data");
+            let data_path = dir.join(DATA_FILE);
             reflink_or_copy(source, &data_path)?;
             fs::write(dir.join(FILE_MARKER), b"")?;
         } else {
@@ -288,10 +301,9 @@ impl SnapshotStore for FsSnapshotStore {
         }
 
         if dir.join(FILE_MARKER).exists() {
-            let data_path = dir.join("data");
-            reflink_or_copy(&data_path, dst)
+            reflink_or_copy(&dir.join(DATA_FILE), dst)
         } else {
-            reflink_or_copy_dir(&dir, dst)
+            reflink_or_copy_dir(&dir.join(CONTENT_DIR), dst)
         }
     }
 
@@ -680,6 +692,55 @@ mod tests {
             fs::read(&restored).unwrap(),
             mem,
             "stored snapshot must be unaffected by instance mutation"
+        );
+    }
+
+    #[test]
+    fn content_addressed_directory_snapshot_materializes_without_sidecars_and_rehashes_to_same_id()
+    {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+
+        // A `{vmstate.bin, mem.bin}` memory-snapshot directory, mem.bin
+        // carrying an interior zero run so this also exercises the
+        // sparse-copy path during materialize.
+        let source = tmp.path().join("mem-snap-dir");
+        fs::create_dir(&source).unwrap();
+        fs::write(source.join("vmstate.bin"), b"vmstate header bytes").unwrap();
+        let mut mem = vec![0xAA_u8; 4096];
+        mem.extend(std::iter::repeat_n(0u8, 65536));
+        mem.extend(vec![0xBB_u8; 4096]);
+        fs::write(source.join("mem.bin"), &mem).unwrap();
+
+        let id = store
+            .create_content_addressed(&source)
+            .expect("store dir snapshot");
+
+        let dst = tmp.path().join("instance-dir");
+        store.materialize(&id, &dst).expect("materialize");
+
+        // (a) no store sidecars leaked into the materialized output.
+        for entry in fs::read_dir(&dst).unwrap() {
+            let name = entry.unwrap().file_name();
+            let name = name.to_string_lossy();
+            assert!(
+                !name.starts_with(".mvm-snapshot"),
+                "materialized dir must not contain store sidecars, found {name}"
+            );
+        }
+        assert_eq!(
+            fs::read(dst.join("vmstate.bin")).unwrap(),
+            b"vmstate header bytes"
+        );
+        assert_eq!(fs::read(dst.join("mem.bin")).unwrap(), mem);
+
+        // (b) round-trip stability: re-hashing the materialized tree
+        // reproduces exactly the stored content-addressed id.
+        let rehashed = hash::hash_source(&dst).expect("rehash materialized dir");
+        assert_eq!(
+            rehashed,
+            id.id(),
+            "materialized directory must re-hash to the same content-addressed id"
         );
     }
 

--- a/crates/mvm-fs/src/snapshot_store.rs
+++ b/crates/mvm-fs/src/snapshot_store.rs
@@ -15,8 +15,17 @@
 //!   marker, and materializes it as a single file.
 //!
 //! This is the persistence layer behind the warm-parent pool: a paused
-//! microVM's rootfs (and, later, memory snapshot) is stored once and then
+//! microVM's rootfs (and its memory snapshot) is stored once and then
 //! reflink-cloned into each child's per-instance path.
+//!
+//! A memory snapshot — a large, often-sparse `mem.bin` file, or a
+//! `{vmstate.bin, mem.bin}` pair stored as a directory — is a first-class
+//! content-addressed artifact here: it is stored via
+//! [`FsSnapshotStore::create_content_addressed`] like any other snapshot
+//! and materialized through the same sparse-aware reflink/copy path, with
+//! no separate mechanism. The Firecracker pause/seal lifecycle that
+//! produces those bytes stays in mvm-runtime; this store only owns the
+//! artifact once it exists on disk.
 
 use std::fmt;
 use std::fs;
@@ -24,9 +33,11 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::clone::{CloneStrategy, reflink_or_copy, reflink_or_copy_dir};
+use crate::hash;
 
 const FILE_MARKER: &str = ".mvm-snapshot-is-file";
 const META_FILE: &str = ".mvm-snapshot-meta";
+const REFCOUNT_FILE: &str = ".mvm-snapshot-refcount";
 
 /// Opaque identifier for a snapshot stored in a [`SnapshotStore`].
 ///
@@ -109,6 +120,13 @@ pub trait SnapshotStore {
 
     /// Remove snapshot `id` and reclaim its storage.
     ///
+    /// This is a force-remove: it deletes storage unconditionally,
+    /// bypassing the reference count that `FsSnapshotStore::retain`/
+    /// `release` track for content-addressed snapshots. It's the right
+    /// tool for the plain, unshared [`SnapshotStore::create`] path (which
+    /// has no refcount) or an explicit force-delete; a content-addressed
+    /// snapshot that may be shared should be freed via `release` instead.
+    ///
     /// Returns `NotFound` if the snapshot does not exist.
     fn remove(&self, id: &SnapshotId) -> io::Result<()>;
 
@@ -166,6 +184,23 @@ impl FsSnapshotStore {
             fs::write(dir.join(META_FILE), meta)?;
         }
         Ok(())
+    }
+
+    fn read_refcount(dir: &Path) -> io::Result<Option<u32>> {
+        match fs::read_to_string(dir.join(REFCOUNT_FILE)) {
+            Ok(s) => s.trim().parse::<u32>().map(Some).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("corrupt snapshot refcount: {s:?}"),
+                )
+            }),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn write_refcount(dir: &Path, n: u32) -> io::Result<()> {
+        fs::write(dir.join(REFCOUNT_FILE), n.to_string())
     }
 
     fn read_meta(&self, dir: &Path, id: &str) -> SnapshotId {
@@ -288,6 +323,93 @@ impl SnapshotStore for FsSnapshotStore {
             }
         }
         Ok(ids)
+    }
+}
+
+/// Content-addressed create + reference counting, layered on the plain
+/// [`SnapshotStore`] primitives above. Kept as inherent methods rather than
+/// trait methods: they're specific to content-addressed dedup, not a
+/// capability every `SnapshotStore` implementation is required to offer.
+impl FsSnapshotStore {
+    /// Persist `source` (file or directory) under an id derived from its
+    /// SHA-256 content hash, deduplicating identical content.
+    ///
+    /// Unlike [`SnapshotStore::create`], which errors when the id already
+    /// exists, this is idempotent by construction: since the id *is* the
+    /// content hash, a second call with identical bytes is a share, not a
+    /// conflict — it increments the refcount and returns the existing id
+    /// instead of erroring.
+    pub fn create_content_addressed(&self, source: &Path) -> io::Result<SnapshotId> {
+        let h = hash::hash_source(source)?;
+        let id = SnapshotId::with_digest(h.clone(), format!("sha256:{h}"));
+        let dir = self.snapshot_dir(&id);
+
+        if dir.exists() {
+            self.retain(&id)?;
+            return Ok(id);
+        }
+
+        self.create(&id, source)?;
+        Self::write_refcount(&dir, 1)?;
+        Ok(id)
+    }
+
+    /// Increment `id`'s reference count and return the new value.
+    ///
+    /// Snapshots created via the plain [`SnapshotStore::create`] have no
+    /// refcount file; a missing file reads as count 1 before incrementing,
+    /// so both creation paths compose under `retain`/`release`.
+    ///
+    /// Concurrency: this is a plain read-modify-write on one file. Two
+    /// processes racing on the same id can lose an update; that's out of
+    /// scope for this phase because the warm-pool caller serializes store
+    /// mutations.
+    pub fn retain(&self, id: &SnapshotId) -> io::Result<u32> {
+        let dir = self.existing_snapshot_dir(id)?;
+        let next = Self::read_refcount(&dir)?.unwrap_or(1) + 1;
+        Self::write_refcount(&dir, next)?;
+        Ok(next)
+    }
+
+    /// Decrement `id`'s reference count; at 0, delete the snapshot's
+    /// storage and return 0.
+    ///
+    /// Returns `NotFound` if the snapshot does not exist.
+    pub fn release(&self, id: &SnapshotId) -> io::Result<u32> {
+        let dir = self.existing_snapshot_dir(id)?;
+        let current = Self::read_refcount(&dir)?.unwrap_or(1);
+        if current <= 1 {
+            fs::remove_dir_all(&dir)?;
+            Ok(0)
+        } else {
+            let next = current - 1;
+            Self::write_refcount(&dir, next)?;
+            Ok(next)
+        }
+    }
+
+    /// Read `id`'s current reference count without mutating it. A missing
+    /// refcount file (a plain-`create`d snapshot) reads as 1.
+    ///
+    /// Returns `NotFound` if the snapshot does not exist.
+    pub fn refcount(&self, id: &SnapshotId) -> io::Result<u32> {
+        let dir = self.existing_snapshot_dir(id)?;
+        Ok(Self::read_refcount(&dir)?.unwrap_or(1))
+    }
+
+    /// Validate `id` and resolve its directory, failing `NotFound` if the
+    /// snapshot isn't present. Shared precondition for `retain`/`release`/
+    /// `refcount`.
+    fn existing_snapshot_dir(&self, id: &SnapshotId) -> io::Result<PathBuf> {
+        Self::ensure_id_is_safe(&id.id)?;
+        let dir = self.snapshot_dir(id);
+        if !dir.exists() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("snapshot {} not found", id.id),
+            ));
+        }
+        Ok(dir)
     }
 }
 
@@ -417,5 +539,189 @@ mod tests {
         assert!(store.create(&id, &source).is_err());
         assert!(store.materialize(&id, &tmp.path().join("dst")).is_err());
         assert!(store.remove(&id).is_err());
+    }
+
+    // -- content-addressed create + dedup (work item 2) --
+
+    #[test]
+    fn create_content_addressed_dedups_identical_content() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+        let source = tmp.path().join("payload.bin");
+        fs::write(&source, b"dedup me").unwrap();
+
+        let id1 = store
+            .create_content_addressed(&source)
+            .expect("first store");
+        let id2 = store
+            .create_content_addressed(&source)
+            .expect("second store (dedup)");
+        assert_eq!(id1.id(), id2.id());
+        assert_eq!(
+            id1.digest(),
+            Some(format!("sha256:{}", id1.id())).as_deref()
+        );
+
+        let entries: Vec<_> = fs::read_dir(store.root()).unwrap().collect();
+        assert_eq!(entries.len(), 1, "identical content stored exactly once");
+        assert_eq!(store.refcount(&id1).expect("refcount"), 2);
+    }
+
+    #[test]
+    fn create_content_addressed_distinct_content_gets_distinct_ids() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+        let a = tmp.path().join("a.bin");
+        fs::write(&a, b"content a").unwrap();
+        let b = tmp.path().join("b.bin");
+        fs::write(&b, b"content b").unwrap();
+
+        let id_a = store.create_content_addressed(&a).expect("store a");
+        let id_b = store.create_content_addressed(&b).expect("store b");
+        assert_ne!(id_a.id(), id_b.id());
+    }
+
+    // -- reference counting (work item 3) --
+
+    #[test]
+    fn retain_and_release_transition_refcount() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+        let source = tmp.path().join("x.bin");
+        fs::write(&source, b"x").unwrap();
+        let id = store.create_content_addressed(&source).expect("store");
+
+        assert_eq!(store.refcount(&id).unwrap(), 1);
+        assert_eq!(store.retain(&id).unwrap(), 2);
+        assert_eq!(store.retain(&id).unwrap(), 3);
+        assert_eq!(store.release(&id).unwrap(), 2);
+        assert_eq!(store.release(&id).unwrap(), 1);
+        assert_eq!(store.release(&id).unwrap(), 0);
+        assert!(
+            !store.snapshot_dir(&id).exists(),
+            "storage reclaimed at refcount 0"
+        );
+    }
+
+    #[test]
+    fn double_create_content_addressed_then_two_releases_deletes_exactly_once() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+        let source = tmp.path().join("shared.bin");
+        fs::write(&source, b"shared content").unwrap();
+
+        let id1 = store.create_content_addressed(&source).expect("first");
+        let id2 = store
+            .create_content_addressed(&source)
+            .expect("second (dedup)");
+        assert_eq!(id1.id(), id2.id());
+        assert_eq!(store.refcount(&id1).unwrap(), 2);
+
+        assert_eq!(store.release(&id1).unwrap(), 1);
+        assert!(
+            store.snapshot_dir(&id1).exists(),
+            "still referenced once, storage intact"
+        );
+        assert_eq!(store.release(&id1).unwrap(), 0);
+        assert!(
+            !store.snapshot_dir(&id1).exists(),
+            "deleted exactly once, at the second release"
+        );
+
+        // A third release must fail closed, not double-delete.
+        assert!(store.release(&id1).is_err());
+    }
+
+    #[test]
+    fn refcount_on_plain_create_snapshot_reads_one() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+        let source = tmp.path().join("plain.bin");
+        fs::write(&source, b"plain").unwrap();
+
+        let id = SnapshotId::new("plain-snap");
+        store.create(&id, &source).expect("plain create");
+
+        assert_eq!(store.refcount(&id).expect("refcount"), 1);
+        assert_eq!(store.release(&id).expect("release"), 0);
+        assert!(!store.snapshot_dir(&id).exists());
+    }
+
+    // -- content-addressed memory-snapshot storage (work item 4) --
+
+    #[test]
+    fn content_addressed_memory_snapshot_roundtrips_and_is_independent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+
+        // Synthetic mem.bin: nonzero header, a large zero run (guest-free
+        // RAM), nonzero tail — representative of a real memory snapshot's
+        // sparseness, exercising the sparse-copy fallback path.
+        let mut mem = vec![0xEE_u8; 8192];
+        mem.extend(std::iter::repeat_n(0u8, 131072));
+        mem.extend(vec![0x11_u8; 4096]);
+        let source = tmp.path().join("mem.bin");
+        fs::write(&source, &mem).unwrap();
+
+        let id = store
+            .create_content_addressed(&source)
+            .expect("store mem snapshot");
+
+        let instance = tmp.path().join("instance-mem.bin");
+        store.materialize(&id, &instance).expect("materialize");
+        assert_eq!(fs::read(&instance).unwrap(), mem);
+
+        fs::write(&instance, b"mutated instance").unwrap();
+        let restored = tmp.path().join("instance-mem-2.bin");
+        store
+            .materialize(&id, &restored)
+            .expect("materialize again");
+        assert_eq!(
+            fs::read(&restored).unwrap(),
+            mem,
+            "stored snapshot must be unaffected by instance mutation"
+        );
+    }
+
+    // -- snapshot-graph-integrity (work item 5) --
+
+    #[test]
+    fn deleting_one_snapshot_does_not_affect_sibling_or_materialized_child() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = FsSnapshotStore::new(tmp.path().join("store")).expect("store");
+
+        let source_a = tmp.path().join("a.bin");
+        fs::write(&source_a, b"snapshot A content").unwrap();
+        let source_b = tmp.path().join("b.bin");
+        fs::write(&source_b, b"snapshot B content, distinct").unwrap();
+
+        let id_a = store.create_content_addressed(&source_a).expect("store a");
+        let id_b = store.create_content_addressed(&source_b).expect("store b");
+        assert_ne!(id_a.id(), id_b.id());
+
+        // Materialize a "child" instance off snapshot A.
+        let child = tmp.path().join("child-instance.bin");
+        store.materialize(&id_a, &child).expect("materialize child");
+
+        // The child is just a materialized copy, not tracked by the store;
+        // deleting it and releasing snapshot A entirely must not touch B.
+        fs::remove_file(&child).unwrap();
+        let remaining = store.release(&id_a).expect("release a");
+        assert_eq!(remaining, 0);
+        assert!(!store.snapshot_dir(&id_a).exists());
+
+        assert_eq!(store.refcount(&id_b).expect("refcount b"), 1);
+        let listed = store.list().expect("list");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id(), id_b.id());
+
+        let materialize_b = tmp.path().join("materialize-b.bin");
+        store
+            .materialize(&id_b, &materialize_b)
+            .expect("sibling still materializes");
+        assert_eq!(
+            fs::read(&materialize_b).unwrap(),
+            b"snapshot B content, distinct"
+        );
     }
 }

--- a/crates/mvm-fs/src/snapshot_store.rs
+++ b/crates/mvm-fs/src/snapshot_store.rs
@@ -553,7 +553,7 @@ mod tests {
         assert!(store.remove(&id).is_err());
     }
 
-    // -- content-addressed create + dedup (work item 2) --
+    // -- content-addressed create + dedup --
 
     #[test]
     fn create_content_addressed_dedups_identical_content() {
@@ -593,7 +593,7 @@ mod tests {
         assert_ne!(id_a.id(), id_b.id());
     }
 
-    // -- reference counting (work item 3) --
+    // -- reference counting --
 
     #[test]
     fn retain_and_release_transition_refcount() {
@@ -659,7 +659,7 @@ mod tests {
         assert!(!store.snapshot_dir(&id).exists());
     }
 
-    // -- content-addressed memory-snapshot storage (work item 4) --
+    // -- content-addressed memory-snapshot storage --
 
     #[test]
     fn content_addressed_memory_snapshot_roundtrips_and_is_independent() {
@@ -744,7 +744,7 @@ mod tests {
         );
     }
 
-    // -- snapshot-graph-integrity (work item 5) --
+    // -- snapshot-graph-integrity --
 
     #[test]
     fn deleting_one_snapshot_does_not_affect_sibling_or_materialized_child() {

--- a/crates/mvm-runtime/src/lib.rs
+++ b/crates/mvm-runtime/src/lib.rs
@@ -110,6 +110,11 @@ pub mod vmm;
 /// Shared host-side vsock egress support. Backend-agnostic; every VMM path uses
 /// the same gate/relay substrate while policy remains in the host endpoint.
 pub mod vsock_egress_bridge;
+/// Plugs `mvm_fs`'s content-addressed `SnapshotStore` beneath the existing
+/// checkpoint lineage: stage a checkpoint's bytes into the snapshot store,
+/// then clone them only after the checkpoint's fail-closed lineage
+/// verification (`verify_content` + `verify_lineage`) passes.
+pub mod warm_snapshot;
 /// `WasmBackend` — host-`wasmtime` claim-free portability tier running a
 /// user-supplied WASI module. Always constructible; the real engine only
 /// compiles in behind the opt-in `wasm-backend` feature.

--- a/crates/mvm-runtime/src/warm_snapshot.rs
+++ b/crates/mvm-runtime/src/warm_snapshot.rs
@@ -1,0 +1,251 @@
+//! Plugs `mvm_fs`'s content-addressed [`SnapshotStore`] in *beneath* the
+//! existing checkpoint lineage (`crate::checkpoint`), rather than building a
+//! second provenance graph.
+//!
+//! The checkpoint stays the single lineage node: content-addressed,
+//! hash-linked to its parent, and anchored to the signed audit chain. This
+//! module only changes how a checkpoint's bytes are physically staged and
+//! cloned — via the `SnapshotStore`'s O(1) reflink/sparse-copy primitive
+//! instead of a per-blob walk — and it gates every clone on the SAME
+//! fail-closed verification every other fork path uses:
+//! [`crate::checkpoint::verify_content`] then
+//! [`crate::checkpoint::verify_lineage`]. Nothing is cloned until both pass.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use mvm_core::checkpoint::CheckpointId;
+use mvm_fs::clone::CloneStrategy;
+use mvm_fs::snapshot_store::{FsSnapshotStore, SnapshotId, SnapshotStore};
+
+use crate::checkpoint::{CheckpointChainAnchor, CheckpointStore, verify_content, verify_lineage};
+
+/// Store a checkpoint's content dir into the content-addressed snapshot
+/// store, deduplicating identical bytes with an existing snapshot. The
+/// checkpoint's `meta.json` remains the sole lineage record; this only moves
+/// where its bytes physically live so a later clone can materialize via
+/// reflink/sparse CoW instead of per-blob copies.
+pub fn stage_warm_snapshot(
+    checkpoint_store: &CheckpointStore,
+    snapshot_store: &FsSnapshotStore,
+    id: &CheckpointId,
+) -> Result<SnapshotId> {
+    let content_dir = checkpoint_store.content_dir(id);
+    snapshot_store
+        .create_content_addressed(&content_dir)
+        .with_context(|| format!("staging checkpoint '{id}' content into the snapshot store"))
+}
+
+/// Materialize a staged warm snapshot at `dst`, but only after `parent_id`
+/// clears the same fail-closed lineage gate `fork_checkpoint` /
+/// `fork_vm_full_fc` use: `read_meta -> verify_content -> verify_lineage`.
+/// Nothing is cloned until all three succeed — a missing, un-audited, or
+/// hash-mismatched parent leaves `dst` uncreated and the error propagates.
+pub fn materialize_child_from_parent(
+    checkpoint_store: &CheckpointStore,
+    snapshot_store: &FsSnapshotStore,
+    parent_id: &CheckpointId,
+    staged: &SnapshotId,
+    anchor: &dyn CheckpointChainAnchor,
+    dst: &Path,
+) -> Result<CloneStrategy> {
+    let parent = checkpoint_store.read_meta(parent_id)?;
+    verify_content(checkpoint_store, &parent)?;
+    verify_lineage(checkpoint_store, parent_id, anchor)?;
+
+    snapshot_store
+        .materialize(staged, dst)
+        .with_context(|| format!("materializing staged snapshot at {}", dst.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checkpoint::{CaptureFsQuickParams, capture_fs_quick};
+    use mvm_core::checkpoint::{CheckpointDigest, CheckpointMeta};
+    use std::collections::HashMap;
+    use std::io::Write;
+
+    /// A mock anchor whose verdict per parent digest is set up by the test:
+    /// audited (echoes the real digest), un-audited (`Ok(None)`), or a fixed
+    /// wrong digest (hash-mismatch / re-forge).
+    #[derive(Default)]
+    struct MockAnchor {
+        verdicts: HashMap<String, Option<CheckpointDigest>>,
+    }
+
+    impl MockAnchor {
+        fn audited(mut self, meta: &CheckpointMeta) -> Self {
+            self.verdicts
+                .insert(meta.id.to_string(), Some(meta.compute_meta_digest()));
+            self
+        }
+
+        fn unaudited(mut self, id: &CheckpointId) -> Self {
+            self.verdicts.insert(id.to_string(), None);
+            self
+        }
+    }
+
+    impl CheckpointChainAnchor for MockAnchor {
+        fn recorded_creation_digest(
+            &self,
+            meta: &CheckpointMeta,
+        ) -> Result<Option<CheckpointDigest>> {
+            match self.verdicts.get(&meta.id.to_string()) {
+                Some(v) => Ok(v.clone()),
+                // Not configured for this id: treat as un-audited rather than
+                // panicking, so tests only need to set up the case they exercise.
+                None => Ok(None),
+            }
+        }
+    }
+
+    fn write_fake_rootfs(dir: &Path) -> std::path::PathBuf {
+        let p = dir.join("rootfs.ext4");
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(b"warm-parent-rootfs-bytes").unwrap();
+        p
+    }
+
+    fn seed_parent(store: &CheckpointStore, tmp: &Path, id: &str) -> CheckpointMeta {
+        let rootfs = write_fake_rootfs(tmp);
+        capture_fs_quick(
+            store,
+            CaptureFsQuickParams {
+                id: CheckpointId::new(id),
+                vm_name: "warm-parent".into(),
+                rootfs,
+                supervisor_config_digest: "d".into(),
+                runtime_source_policy: None,
+                runtime_overlay_version: None,
+                tag: None,
+                created_unix: 1,
+                quiesced: true,
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn positive_control_audited_parent_materializes_via_snapshot_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let checkpoint_store = CheckpointStore::at(tmp.path().join("checkpoints"));
+        let snapshot_store = FsSnapshotStore::new(tmp.path().join("snapshots")).unwrap();
+
+        let parent = seed_parent(&checkpoint_store, tmp.path(), "warm-1");
+        let staged = stage_warm_snapshot(&checkpoint_store, &snapshot_store, &parent.id).unwrap();
+
+        let anchor = MockAnchor::default().audited(&parent);
+        let dst = tmp.path().join("instance-rootfs-dir");
+        let strategy = materialize_child_from_parent(
+            &checkpoint_store,
+            &snapshot_store,
+            &parent.id,
+            &staged,
+            &anchor,
+            &dst,
+        )
+        .expect("audited, intact parent must materialize");
+
+        assert!(matches!(
+            strategy,
+            CloneStrategy::Reflink | CloneStrategy::Copied
+        ));
+        assert_eq!(
+            std::fs::read(dst.join("rootfs.ext4")).unwrap(),
+            b"warm-parent-rootfs-bytes",
+            "materialized bytes must byte-equal the staged content"
+        );
+    }
+
+    #[test]
+    fn negative_missing_parent_refuses_before_any_clone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let checkpoint_store = CheckpointStore::at(tmp.path().join("checkpoints"));
+        let snapshot_store = FsSnapshotStore::new(tmp.path().join("snapshots")).unwrap();
+
+        // Never seeded: read_meta must fail before any staged snapshot exists.
+        let missing_id = CheckpointId::new("does-not-exist");
+        let bogus_staged = SnapshotId::new("irrelevant");
+        let anchor = MockAnchor::default();
+        let dst = tmp.path().join("instance-dir");
+
+        materialize_child_from_parent(
+            &checkpoint_store,
+            &snapshot_store,
+            &missing_id,
+            &bogus_staged,
+            &anchor,
+            &dst,
+        )
+        .unwrap_err();
+        assert!(!dst.exists(), "a missing parent must leave dst uncreated");
+    }
+
+    #[test]
+    fn negative_unaudited_parent_refuses_before_any_clone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let checkpoint_store = CheckpointStore::at(tmp.path().join("checkpoints"));
+        let snapshot_store = FsSnapshotStore::new(tmp.path().join("snapshots")).unwrap();
+
+        let parent = seed_parent(&checkpoint_store, tmp.path(), "warm-2");
+        let staged = stage_warm_snapshot(&checkpoint_store, &snapshot_store, &parent.id).unwrap();
+
+        let anchor = MockAnchor::default().unaudited(&parent.id);
+        let dst = tmp.path().join("instance-dir");
+
+        let err = materialize_child_from_parent(
+            &checkpoint_store,
+            &snapshot_store,
+            &parent.id,
+            &staged,
+            &anchor,
+            &dst,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("no signed audit entry"),
+            "expected the lineage un-audited message, got: {err}"
+        );
+        assert!(
+            !dst.exists(),
+            "an un-audited parent must leave dst uncreated"
+        );
+    }
+
+    #[test]
+    fn negative_tampered_parent_refuses_before_any_clone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let checkpoint_store = CheckpointStore::at(tmp.path().join("checkpoints"));
+        let snapshot_store = FsSnapshotStore::new(tmp.path().join("snapshots")).unwrap();
+
+        let parent = seed_parent(&checkpoint_store, tmp.path(), "warm-3");
+        let staged = stage_warm_snapshot(&checkpoint_store, &snapshot_store, &parent.id).unwrap();
+
+        // The anchor still agrees with the ORIGINAL sealed digest — modeling a
+        // signed chain that was never re-signed for the tampered record — but
+        // the on-disk meta.json is mutated after sealing, so its recompute no
+        // longer equals its own stored `meta_digest`: drift.
+        let anchor = MockAnchor::default().audited(&parent);
+        let mut tampered = parent.clone();
+        tampered.vm_name = "renamed-after-seal".into();
+        checkpoint_store.write_meta(&tampered).unwrap();
+
+        let dst = tmp.path().join("instance-dir");
+        let err = materialize_child_from_parent(
+            &checkpoint_store,
+            &snapshot_store,
+            &parent.id,
+            &staged,
+            &anchor,
+            &dst,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("drift"),
+            "expected a meta_digest drift message, got: {err}"
+        );
+        assert!(!dst.exists(), "a tampered parent must leave dst uncreated");
+    }
+}

--- a/crates/mvm-runtime/src/warm_snapshot.rs
+++ b/crates/mvm-runtime/src/warm_snapshot.rs
@@ -20,11 +20,13 @@ use mvm_fs::snapshot_store::{FsSnapshotStore, SnapshotId, SnapshotStore};
 
 use crate::checkpoint::{CheckpointChainAnchor, CheckpointStore, verify_content, verify_lineage};
 
-/// Store a checkpoint's content dir into the content-addressed snapshot
-/// store, deduplicating identical bytes with an existing snapshot. The
-/// checkpoint's `meta.json` remains the sole lineage record; this only moves
-/// where its bytes physically live so a later clone can materialize via
-/// reflink/sparse CoW instead of per-blob copies.
+/// Pre-warm a checkpoint's content dir into the content-addressed snapshot
+/// store ahead of time, deduplicating identical bytes with an existing
+/// snapshot. The checkpoint's `meta.json` remains the sole lineage record;
+/// this only moves where its bytes physically live. Purely an optimization:
+/// [`materialize_child_from_parent`] stages idempotently on its own, so
+/// callers never need to call this first — it exists for a future warm-pool
+/// that wants staging to happen off the clone's critical path.
 pub fn stage_warm_snapshot(
     checkpoint_store: &CheckpointStore,
     snapshot_store: &FsSnapshotStore,
@@ -36,16 +38,24 @@ pub fn stage_warm_snapshot(
         .with_context(|| format!("staging checkpoint '{id}' content into the snapshot store"))
 }
 
-/// Materialize a staged warm snapshot at `dst`, but only after `parent_id`
-/// clears the same fail-closed lineage gate `fork_checkpoint` /
-/// `fork_vm_full_fc` use: `read_meta -> verify_content -> verify_lineage`.
-/// Nothing is cloned until all three succeed — a missing, un-audited, or
-/// hash-mismatched parent leaves `dst` uncreated and the error propagates.
+/// Materialize `parent_id`'s content at `dst`, but only after it clears the
+/// same fail-closed lineage gate `fork_checkpoint` / `fork_vm_full_fc` use:
+/// `read_meta -> verify_content -> verify_lineage`. Nothing is cloned until
+/// all three succeed — a missing, un-audited, or hash-mismatched parent
+/// leaves `dst` uncreated and the error propagates.
+///
+/// The snapshot id materialized is derived from the JUST-VERIFIED parent's
+/// own content dir (`create_content_addressed` is idempotent — it stages on
+/// first call, dedups on every later one), never taken from a caller-supplied
+/// id. Accepting an arbitrary `SnapshotId` parameter here would let a caller
+/// pass lineage verification against an audited parent and then materialize
+/// unrelated, unaudited bytes at `dst` — a claim-8 authority-substitution
+/// hole. Deriving it internally makes the materialized bytes provably the
+/// verified parent's content.
 pub fn materialize_child_from_parent(
     checkpoint_store: &CheckpointStore,
     snapshot_store: &FsSnapshotStore,
     parent_id: &CheckpointId,
-    staged: &SnapshotId,
     anchor: &dyn CheckpointChainAnchor,
     dst: &Path,
 ) -> Result<CloneStrategy> {
@@ -53,8 +63,13 @@ pub fn materialize_child_from_parent(
     verify_content(checkpoint_store, &parent)?;
     verify_lineage(checkpoint_store, parent_id, anchor)?;
 
+    let content_dir = checkpoint_store.content_dir(parent_id);
+    let staged = snapshot_store
+        .create_content_addressed(&content_dir)
+        .with_context(|| format!("staging verified parent '{parent_id}' content"))?;
+
     snapshot_store
-        .materialize(staged, dst)
+        .materialize(&staged, dst)
         .with_context(|| format!("materializing staged snapshot at {}", dst.display()))
 }
 
@@ -134,7 +149,6 @@ mod tests {
         let snapshot_store = FsSnapshotStore::new(tmp.path().join("snapshots")).unwrap();
 
         let parent = seed_parent(&checkpoint_store, tmp.path(), "warm-1");
-        let staged = stage_warm_snapshot(&checkpoint_store, &snapshot_store, &parent.id).unwrap();
 
         let anchor = MockAnchor::default().audited(&parent);
         let dst = tmp.path().join("instance-rootfs-dir");
@@ -142,7 +156,6 @@ mod tests {
             &checkpoint_store,
             &snapshot_store,
             &parent.id,
-            &staged,
             &anchor,
             &dst,
         )
@@ -155,7 +168,7 @@ mod tests {
         assert_eq!(
             std::fs::read(dst.join("rootfs.ext4")).unwrap(),
             b"warm-parent-rootfs-bytes",
-            "materialized bytes must byte-equal the staged content"
+            "materialized bytes must byte-equal the parent's content"
         );
     }
 
@@ -165,9 +178,8 @@ mod tests {
         let checkpoint_store = CheckpointStore::at(tmp.path().join("checkpoints"));
         let snapshot_store = FsSnapshotStore::new(tmp.path().join("snapshots")).unwrap();
 
-        // Never seeded: read_meta must fail before any staged snapshot exists.
+        // Never seeded: read_meta must fail before anything is staged or cloned.
         let missing_id = CheckpointId::new("does-not-exist");
-        let bogus_staged = SnapshotId::new("irrelevant");
         let anchor = MockAnchor::default();
         let dst = tmp.path().join("instance-dir");
 
@@ -175,7 +187,6 @@ mod tests {
             &checkpoint_store,
             &snapshot_store,
             &missing_id,
-            &bogus_staged,
             &anchor,
             &dst,
         )
@@ -190,7 +201,6 @@ mod tests {
         let snapshot_store = FsSnapshotStore::new(tmp.path().join("snapshots")).unwrap();
 
         let parent = seed_parent(&checkpoint_store, tmp.path(), "warm-2");
-        let staged = stage_warm_snapshot(&checkpoint_store, &snapshot_store, &parent.id).unwrap();
 
         let anchor = MockAnchor::default().unaudited(&parent.id);
         let dst = tmp.path().join("instance-dir");
@@ -199,7 +209,6 @@ mod tests {
             &checkpoint_store,
             &snapshot_store,
             &parent.id,
-            &staged,
             &anchor,
             &dst,
         )
@@ -221,7 +230,6 @@ mod tests {
         let snapshot_store = FsSnapshotStore::new(tmp.path().join("snapshots")).unwrap();
 
         let parent = seed_parent(&checkpoint_store, tmp.path(), "warm-3");
-        let staged = stage_warm_snapshot(&checkpoint_store, &snapshot_store, &parent.id).unwrap();
 
         // The anchor still agrees with the ORIGINAL sealed digest — modeling a
         // signed chain that was never re-signed for the tampered record — but
@@ -237,7 +245,6 @@ mod tests {
             &checkpoint_store,
             &snapshot_store,
             &parent.id,
-            &staged,
             &anchor,
             &dst,
         )
@@ -247,5 +254,46 @@ mod tests {
             "expected a meta_digest drift message, got: {err}"
         );
         assert!(!dst.exists(), "a tampered parent must leave dst uncreated");
+    }
+
+    /// Binding-attack test: an unrelated "evil" blob is staged into the SAME
+    /// snapshot store the legit parent uses, modeling a caller that has
+    /// attacker-controlled content sitting around in the store. Materializing
+    /// from the legit, audited parent must produce ONLY the parent's own
+    /// content — proving a caller cannot substitute a different blob by
+    /// controlling what else is staged, since the function derives the
+    /// snapshot id from the verified parent itself rather than trusting a
+    /// caller-supplied one.
+    #[test]
+    fn materialize_ignores_unrelated_staged_snapshot_and_uses_verified_parent_content_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let checkpoint_store = CheckpointStore::at(tmp.path().join("checkpoints"));
+        let snapshot_store = FsSnapshotStore::new(tmp.path().join("snapshots")).unwrap();
+
+        // Stage attacker-controlled bytes into the store, unrelated to any
+        // checkpoint's content dir.
+        let evil_dir = tmp.path().join("evil-payload");
+        std::fs::create_dir(&evil_dir).unwrap();
+        std::fs::write(evil_dir.join("rootfs.ext4"), b"attacker-controlled-bytes").unwrap();
+        snapshot_store.create_content_addressed(&evil_dir).unwrap();
+
+        let parent = seed_parent(&checkpoint_store, tmp.path(), "warm-4");
+        let anchor = MockAnchor::default().audited(&parent);
+        let dst = tmp.path().join("instance-dir");
+
+        materialize_child_from_parent(
+            &checkpoint_store,
+            &snapshot_store,
+            &parent.id,
+            &anchor,
+            &dst,
+        )
+        .expect("legit audited parent must materialize");
+
+        assert_eq!(
+            std::fs::read(dst.join("rootfs.ext4")).unwrap(),
+            b"warm-parent-rootfs-bytes",
+            "materialized bytes must be the verified parent's content, never the staged evil blob"
+        );
     }
 }

--- a/crates/mvm-runtime/src/warm_snapshot.rs
+++ b/crates/mvm-runtime/src/warm_snapshot.rs
@@ -16,27 +16,9 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use mvm_core::checkpoint::CheckpointId;
 use mvm_fs::clone::CloneStrategy;
-use mvm_fs::snapshot_store::{FsSnapshotStore, SnapshotId, SnapshotStore};
+use mvm_fs::snapshot_store::{FsSnapshotStore, SnapshotStore};
 
 use crate::checkpoint::{CheckpointChainAnchor, CheckpointStore, verify_content, verify_lineage};
-
-/// Pre-warm a checkpoint's content dir into the content-addressed snapshot
-/// store ahead of time, deduplicating identical bytes with an existing
-/// snapshot. The checkpoint's `meta.json` remains the sole lineage record;
-/// this only moves where its bytes physically live. Purely an optimization:
-/// [`materialize_child_from_parent`] stages idempotently on its own, so
-/// callers never need to call this first — it exists for a future warm-pool
-/// that wants staging to happen off the clone's critical path.
-pub fn stage_warm_snapshot(
-    checkpoint_store: &CheckpointStore,
-    snapshot_store: &FsSnapshotStore,
-    id: &CheckpointId,
-) -> Result<SnapshotId> {
-    let content_dir = checkpoint_store.content_dir(id);
-    snapshot_store
-        .create_content_addressed(&content_dir)
-        .with_context(|| format!("staging checkpoint '{id}' content into the snapshot store"))
-}
 
 /// Materialize `parent_id`'s content at `dst`, but only after it clears the
 /// same fail-closed lineage gate `fork_checkpoint` / `fork_vm_full_fc` use:

--- a/features/suites/s11_snapshot/warm_snapshot_clone.feature
+++ b/features/suites/s11_snapshot/warm_snapshot_clone.feature
@@ -1,0 +1,13 @@
+Feature: Warm-snapshot clone
+
+  A warm snapshot is materialized into an instance by cloning a pre-built,
+  content-addressed artifact (copy-on-write), not by rebuilding it from
+  scratch — the storage-layer basis for a warm start being faster than a
+  cold boot.
+
+  Scenario: cloning a warm snapshot yields an independent copy-on-write instance
+    Given a content-addressed warm snapshot built from a template rootfs artifact
+    When the warm snapshot is cloned into a fresh instance
+    Then the instance byte-equals the warm snapshot
+    And mutating the instance does not change the stored warm snapshot
+    And re-storing the identical artifact reuses the existing snapshot rather than rebuilding it

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -376,7 +376,7 @@ Then unify + retire the old paths:
 - [ ] **Warm start / warm pool** (pre-warmed standby VMs), **snapshot / fork / restore** (bake once, fork many via CoW, fast restore), **streaming exec**, **`expose_tcp`** (host↔guest port forward), **live host-directory mount** — the supermachine/microsandbox-shaped capabilities, exposed through `mvm-client` + the SDK.
 - [ ] `specs/plans/255-vsock-first-snapshot-egress-adoption.md` details the
       vsock-first snapshot/egress/warm-start adoption boundary; Phase 0 (spec)
-      and Phase 1 (snapshot storage) are landing (tracking issue: TBD).
+      and Phase 1 (snapshot storage) are landing (tracking issue: #1851).
 - [ ] A clean **external API** (`Image` / `Vm` / `Pool` / `ExecBuilder`-style) on `mvm-client`, so library and CLI share one surface.
 - [ ] **Simple, fast install:** a one-line installer + `mvmctl upgrade`.
 - Gate: the timed e2e proves sub-second launch on both hosts; warm-start + snapshot restore measured; the external API is documented and BDD-covered.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -374,6 +374,9 @@ Then unify + retire the old paths:
 
 - [ ] **Sub-second launch**, verified: a timed `mvmctl up` → PTY shell → `mvmctl down` e2e on Mac (HVF) and Linux (libkrun + FC), asserting sub-second boot + clean teardown.
 - [ ] **Warm start / warm pool** (pre-warmed standby VMs), **snapshot / fork / restore** (bake once, fork many via CoW, fast restore), **streaming exec**, **`expose_tcp`** (host↔guest port forward), **live host-directory mount** — the supermachine/microsandbox-shaped capabilities, exposed through `mvm-client` + the SDK.
+- [ ] `specs/plans/255-vsock-first-snapshot-egress-adoption.md` details the
+      vsock-first snapshot/egress/warm-start adoption boundary; Phase 0 (spec)
+      and Phase 1 (snapshot storage) are landing (tracking issue: TBD).
 - [ ] A clean **external API** (`Image` / `Vm` / `Pool` / `ExecBuilder`-style) on `mvm-client`, so library and CLI share one surface.
 - [ ] **Simple, fast install:** a one-line installer + `mvmctl upgrade`.
 - Gate: the timed e2e proves sub-second launch on both hosts; warm-start + snapshot restore measured; the external API is documented and BDD-covered.

--- a/specs/adrs/025-warm-snapshot-prior-art-adoption-boundary.md
+++ b/specs/adrs/025-warm-snapshot-prior-art-adoption-boundary.md
@@ -41,27 +41,14 @@ It is a KVM microVM sandbox for AI agents built on the `rust-vmm`
 community crates plus a self-developed, minimal-device VMM. Independently
 of both mvm and the commercial runtime above, it converged on the same
 warm-path shape: a per-guest kernel with a minimal virtio device set, a
-pre-warmed pool that forks instances by copy-on-write clone from a
+pre-warmed pool that forks instances by copy-on-write clone from a clean
 template (O(1) `FICLONE`-style clones, metadata-only/shared-extent
 snapshots, incremental dirty-page memory delta), and host-side credential
 injection so secrets never enter the guest. Read this as independent
 validation of mvm's warm-snapshot, CoW, and host-side-secret-substitution
-direction — a second team reaching the same shape under the same
-constraints — not as a new idea for mvm to adopt.
-
-The same offering is also a second, independent instance of a tradeoff
-this ADR already refuses below: cross-workload guest reuse.
-`specs/plans/255-vsock-first-snapshot-egress-adoption.md`, which surveys
-this offering, lists reusing dirty guests across jobs among the paths it
-demonstrates mvm should refuse. The research reviewed here does not
-document the offering's specific reuse mechanism, so this is not the
-commercial runtime's page-cache-hot, no-restore handback described above
-— only the same outcome, a worker carrying prior-workload state into its
-next job. A second, differently-built system converging on cross-workload
-reuse under the same performance pressure reinforces this refusal rather
-than calling it into question: mvm's warm path forks a paused clean
-parent into a fresh, identity-scrubbed child and never resumes a parent
-to continue a prior workload.
+direction, and of the fork-from-a-clean-template approach specifically —
+a second team reaching the same shape under the same constraints — not
+as a new idea for mvm to adopt.
 
 Where the offering goes further than the commercial runtime is its
 egress-policy surface: a first-class L7 proxy in front of every guest,
@@ -122,9 +109,11 @@ workload claims don't apply — and even there it is out of scope for this
 ADR, needing its own decision and its own threat-model note if ever
 pursued. It is never available to workload microVMs.
 
-A second, independently-built offering also reuses dirty guests across
-jobs, for the same performance reason (see `## Context` above); that
-convergence reinforces this refusal, it does not soften it.
+The second, independently-built offering surveyed in `## Context` above
+does not exhibit this refused behavior: its pre-warmed pool forks each
+instance by copy-on-write clone from a clean template, the same
+clean-fork shape mvm's warm path adopts, rather than a reused dirty
+guest.
 
 ### Refuse — transparent host-socket networking
 

--- a/specs/adrs/025-warm-snapshot-prior-art-adoption-boundary.md
+++ b/specs/adrs/025-warm-snapshot-prior-art-adoption-boundary.md
@@ -49,27 +49,31 @@ validation of mvm's warm-snapshot, CoW, and host-side-secret-substitution
 direction — a second team reaching the same shape under the same
 constraints — not as a new idea for mvm to adopt.
 
-The same offering also makes the tradeoff this ADR refuses below: its
-pool keeps a released worker's page cache hot by handing it straight back
-without restoring clean snapshot state first, reusing a dirty guest
-across jobs rather than only reusing a warmed template. That is a second,
-independent instance of exactly the "Refuse — cross-workload guest reuse"
-tradeoff, reached by a different team under the same performance
-pressure. It reinforces the refusal rather than calling it into question:
-mvm's warm path forks a paused clean parent into a fresh,
-identity-scrubbed child and never resumes a parent to continue a prior
-workload.
+The same offering is also a second, independent instance of a tradeoff
+this ADR already refuses below: cross-workload guest reuse.
+`specs/plans/255-vsock-first-snapshot-egress-adoption.md`, which surveys
+this offering, lists reusing dirty guests across jobs among the paths it
+demonstrates mvm should refuse. The research reviewed here does not
+document the offering's specific reuse mechanism, so this is not the
+commercial runtime's page-cache-hot, no-restore handback described above
+— only the same outcome, a worker carrying prior-workload state into its
+next job. A second, differently-built system converging on cross-workload
+reuse under the same performance pressure reinforces this refusal rather
+than calling it into question: mvm's warm path forks a paused clean
+parent into a fresh, identity-scrubbed child and never resumes a parent
+to continue a prior workload.
 
 Where the offering goes further than the commercial runtime is its
 egress-policy surface: a first-class L7 proxy in front of every guest,
-with a domain-allowlist UX, scheme/host/SNI/method/path matching, audit
-levels, and header-based credential injection. That policy vocabulary is
-worth borrowing for mvm's own typed-connector policy enrichment. The
-mechanism it rides on is not: the proxy depends on terminating guest TLS
-transparently — a baked root CA that changes the guest's trust model —
-and on a guest-NIC data plane, both refused below under "Refuse —
-transparent host-socket networking" for the same reason mvm already
-refuses a host-socket shortcut.
+enforcing a domain-allowlist with header-based credential injection. That
+proxy is the inspiration, not the source, for mvm's own typed-connector
+policy enrichment — mvm's planned scheme/host/sni/method/path/audit-level
+vocabulary is mvm's own design, not a feature the offering documents. The
+mechanism the offering's proxy rides on is refused either way: it depends
+on terminating guest TLS transparently — a baked root CA that changes the
+guest's trust model — and on a guest-NIC data plane, both refused below
+under "Refuse — transparent host-socket networking" for the same reason
+mvm already refuses a host-socket shortcut.
 
 ## Decision
 
@@ -118,9 +122,9 @@ workload claims don't apply — and even there it is out of scope for this
 ADR, needing its own decision and its own threat-model note if ever
 pursued. It is never available to workload microVMs.
 
-A second, independently-built offering makes the identical dirty-guest-
-reuse tradeoff for the identical performance reason (see `## Context`
-above); that convergence reinforces this refusal, it does not soften it.
+A second, independently-built offering also reuses dirty guests across
+jobs, for the same performance reason (see `## Context` above); that
+convergence reinforces this refusal, it does not soften it.
 
 ### Refuse — transparent host-socket networking
 
@@ -135,13 +139,12 @@ multicast, no TUN/TAP, no ICMP — is cited here as independent supporting
 evidence for the cost mvm already chose to pay by staying on virtio-net,
 not as a reason to reconsider.
 
-A second offering's richer egress-policy vocabulary (scheme, host/sni,
-method, path, audit level, credential injection) is worth borrowing for
-mvm's own typed-connector policy — but not the transparent-TLS-MITM-plus-
-guest-NIC mechanism that vocabulary rides on there. That mechanism is
-refused for the same reason as above: it would move enforcement off the
-vsock seam and change the guest's trust model, exactly what this refusal
-rejects.
+A second offering runs a domain-allowlist egress proxy with header-based
+credential injection — inspiration for mvm's own richer typed-connector
+vocabulary, not its source — but its transparent-TLS-MITM-plus-guest-NIC
+mechanism is refused for the same reason as above: it would move
+enforcement off the vsock seam and change the guest's trust model,
+exactly what this refusal rejects.
 
 ## Out of scope
 

--- a/specs/adrs/025-warm-snapshot-prior-art-adoption-boundary.md
+++ b/specs/adrs/025-warm-snapshot-prior-art-adoption-boundary.md
@@ -34,6 +34,43 @@ through a host-side socket-translation layer that handles ordinary
 TCP/UDP transparently but has no support for raw sockets, multicast,
 TUN/TAP, or ICMP.
 
+A second, independent data point comes from an open-source AI-sandbox
+offering — reviewed in `specs/research/external-sandbox-refactor-lessons.md`
+and referred to here only as the open-source competitor, never by name.
+It is a KVM microVM sandbox for AI agents built on the `rust-vmm`
+community crates plus a self-developed, minimal-device VMM. Independently
+of both mvm and the commercial runtime above, it converged on the same
+warm-path shape: a per-guest kernel with a minimal virtio device set, a
+pre-warmed pool that forks instances by copy-on-write clone from a
+template (O(1) `FICLONE`-style clones, metadata-only/shared-extent
+snapshots, incremental dirty-page memory delta), and host-side credential
+injection so secrets never enter the guest. Read this as independent
+validation of mvm's warm-snapshot, CoW, and host-side-secret-substitution
+direction — a second team reaching the same shape under the same
+constraints — not as a new idea for mvm to adopt.
+
+The same offering also makes the tradeoff this ADR refuses below: its
+pool keeps a released worker's page cache hot by handing it straight back
+without restoring clean snapshot state first, reusing a dirty guest
+across jobs rather than only reusing a warmed template. That is a second,
+independent instance of exactly the "Refuse — cross-workload guest reuse"
+tradeoff, reached by a different team under the same performance
+pressure. It reinforces the refusal rather than calling it into question:
+mvm's warm path forks a paused clean parent into a fresh,
+identity-scrubbed child and never resumes a parent to continue a prior
+workload.
+
+Where the offering goes further than the commercial runtime is its
+egress-policy surface: a first-class L7 proxy in front of every guest,
+with a domain-allowlist UX, scheme/host/SNI/method/path matching, audit
+levels, and header-based credential injection. That policy vocabulary is
+worth borrowing for mvm's own typed-connector policy enrichment. The
+mechanism it rides on is not: the proxy depends on terminating guest TLS
+transparently — a baked root CA that changes the guest's trust model —
+and on a guest-NIC data plane, both refused below under "Refuse —
+transparent host-socket networking" for the same reason mvm already
+refuses a host-socket shortcut.
+
 ## Decision
 
 ### Adopt — page-cache priming at freeze time
@@ -81,6 +118,10 @@ workload claims don't apply — and even there it is out of scope for this
 ADR, needing its own decision and its own threat-model note if ever
 pursued. It is never available to workload microVMs.
 
+A second, independently-built offering makes the identical dirty-guest-
+reuse tradeoff for the identical performance reason (see `## Context`
+above); that convergence reinforces this refusal, it does not soften it.
+
 ### Refuse — transparent host-socket networking
 
 The studied runtime routes guest network I/O through a host-side socket
@@ -93,6 +134,14 @@ own documented limitation list for that approach — no raw sockets, no
 multicast, no TUN/TAP, no ICMP — is cited here as independent supporting
 evidence for the cost mvm already chose to pay by staying on virtio-net,
 not as a reason to reconsider.
+
+A second offering's richer egress-policy vocabulary (scheme, host/sni,
+method, path, audit level, credential injection) is worth borrowing for
+mvm's own typed-connector policy — but not the transparent-TLS-MITM-plus-
+guest-NIC mechanism that vocabulary rides on there. That mechanism is
+refused for the same reason as above: it would move enforcement off the
+vsock seam and change the guest's trust model, exactly what this refusal
+rejects.
 
 ## Out of scope
 

--- a/specs/plans/255-vsock-first-snapshot-egress-adoption.md
+++ b/specs/plans/255-vsock-first-snapshot-egress-adoption.md
@@ -48,6 +48,13 @@ the density/kernel/memory work. This plan adds the prior-art-shaped details.
    typed-connector path only; secrets never enter guest memory, disk, or logs.
 4. **Single-binary discipline.** `mvm-hostd` and `mvm-agentd` stay one process
    each; CLI stays a thin shell over `mvm-client`.
+5. **Fork/restore never bypasses admission.** A forked or restored instance
+   re-admits or inherits a bound, validity-windowed signed `ExecutionPlan`
+   (claim 8) and, on block+ext4 backends, retains its dm-verity roothash
+   binding (claim 3). A warm parent carries no workload authority; authority is
+   minted per child at fork time and emits the normal `plan.admitted` /
+   `plan.launched` audit entries. A fork that silently reuses a parent's
+   authority is a claim-8 hole and must fail closed.
 
 ## Product decisions
 
@@ -66,6 +73,13 @@ the density/kernel/memory work. This plan adds the prior-art-shaped details.
 5. **OCI image as a first-class template base.** `mvmctl template build --image
    <ref>` must work without a Nix flake, while Nix flakes remain a supported
    authoring surface.
+6. **Reuse the chain-anchored checkpoint lineage; do not fork a second graph.**
+   The warm-fork / snapshot graph *is* the existing content-addressed,
+   hash-linked checkpoint lineage anchored to the chain-signed audit log
+   (`mvm-runtime::lineage`, `crates/mvm-runtime/src/checkpoint/`,
+   `crates/mvm-core/src/checkpoint.rs`), not a new flat graph. `SnapshotStore`
+   supplies the O(1) copy primitive *under* that lineage; it does not own
+   provenance.
 
 ## Architecture
 
@@ -80,7 +94,7 @@ Template (sealed, signed, read-only)
 Instance = CoW clone of template rootfs + warm overlay + fresh per-instance
            volume + memory snapshot restore (if warm) OR cold boot (if not warm)
 
-Snapshot graph (flat, content-addressed):
+Snapshot graph (chain-anchored checkpoint lineage; content-addressed):
   Template ──► Instance A
          ├────► Instance B
          └────► Snapshot S ──► Instance C
@@ -92,6 +106,11 @@ Snapshot graph (flat, content-addressed):
 - Memory snapshots are captured at a template-defined ready point and restored
   on instance start. Page-cache priming (ADR-025) is applied at freeze time,
   confined to the read-only rootfs.
+- The snapshot graph is the existing chain-anchored checkpoint lineage, not a
+  new structure: every clone/snapshot is a content-addressed, hash-linked
+  lineage node bound to the signed audit chain. `SnapshotStore` records nodes
+  through `mvm-runtime::lineage`; a clone/fork from an un-audited, missing, or
+  hash-mismatched parent fails closed.
 
 ### Warm-pool model
 
@@ -155,9 +174,18 @@ Snapshot graph (flat, content-addressed):
 - [ ] Add a BDD scenario: build a template with a warm snapshot, clone it into
       an instance, and verify the instance boots faster than a cold-booted
       equivalent.
+- [ ] Plug `SnapshotStore` in *beneath* the existing checkpoint lineage: a warm
+      snapshot is recorded as a lineage node (content-address + hash-link +
+      audit anchor) via `mvm-runtime::{lineage, checkpoint}`; introduce no
+      second provenance graph.
+- [ ] A clone/fork from a parent whose lineage node is missing, un-audited, or
+      hash-mismatched fails closed, reusing the checkpoint lineage's
+      parent-verification path. Add a negative test.
 
 **Acceptance gate:** `cargo test -p mvm-fs` green; BDD scenario passes on Linux;
-no `mvm-fs` consumer sees filesystem-specific logic.
+no `mvm-fs` consumer sees filesystem-specific logic; clone/fork refuses an
+un-audited or tampered parent; no second provenance graph is introduced (reuses
+`mvm-runtime::lineage`).
 
 ### Phase 2 — Warm pool and fork hygiene in `mvm-runtime`
 
@@ -172,9 +200,17 @@ no `mvm-fs` consumer sees filesystem-specific logic.
       (different code path / enum variant).
 - [ ] Add unit tests for identity freshness and replay refusal; add BDD
       scenarios for sub-second warm launch and for fork isolation.
+- [ ] `fork_from_parent` mints or inherits a fresh signed `ExecutionPlan` for
+      the child and refuses to launch a child whose plan is unsigned, expired,
+      or replayed (claim 8). Add a negative test.
+- [ ] On block+ext4 backends the forked child inherits the parent template's
+      dm-verity roothash binding; a fork that would drop verity fails closed
+      (claim 3).
 
 **Acceptance gate:** warm launch is sub-second on Linux and macOS; forked child
-has a new session nonce and cannot reuse an old one; clippy/test green.
+has a new session nonce and cannot reuse an old one; a forked/restored child
+emits `plan.admitted` / `plan.launched` and a fork with an absent or tampered
+plan is refused; `check-claim-catalog` green; clippy/test green.
 
 ### Phase 3 — Egress policy enrichment (vsock seam only)
 

--- a/specs/plans/255-vsock-first-snapshot-egress-adoption.md
+++ b/specs/plans/255-vsock-first-snapshot-egress-adoption.md
@@ -189,7 +189,7 @@ Non-goals above — what this plan takes, refuses, and why.
 - [x] Add a short design note in this plan (above) or in `03-networking.md`
       capturing the "vsock-first adoption boundary": what is adopted, what is
       refused, and why.
-- [ ] File/update a tracking issue for Plan 255 and link it in
+- [x] File/update a tracking issue for Plan 255 (#1851) and link it in
       `specs/SPRINT.md` under the appropriate phase.
 
 **Acceptance gate:** ADR-025 updated and reviewed; no security claim changes;

--- a/specs/plans/255-vsock-first-snapshot-egress-adoption.md
+++ b/specs/plans/255-vsock-first-snapshot-egress-adoption.md
@@ -144,15 +144,49 @@ Snapshot graph (chain-anchored checkpoint lineage; content-addressed):
   deny / inject / security-event / TLS-handshake events, and writes a redacted
   JSONL access log in addition to the chain-signed audit log.
 
+### Vsock-first adoption boundary
+
+Distilled from the open-source-competitor research and the Invariants /
+Non-goals above — what this plan takes, refuses, and why.
+
+**Adopted:**
+- snapshot-first templates (sealed rootfs plus optional ready-point memory
+  snapshot);
+- CoW O(1) clone with a sparse-copy fallback where the filesystem lacks
+  reflink;
+- a warm pool that forks a paused clean parent into a fresh child, never
+  resuming a parent as a workload;
+- richer egress-policy *vocabulary* on the existing typed-connector/vsock
+  path;
+- an OCI image as a first-class template base, alongside Nix flakes;
+- publishing warm-start/density SLOs as gated, measured properties.
+
+**Refused:**
+- any default guest-NIC/TAP/bridge path or eBPF data plane;
+- transparent TLS MITM inside the guest (baked root CA, guest trust-model
+  change);
+- reusing a dirty guest across workloads;
+- a mutable shared store as control-plane authority;
+- a container-runtime shim on the runtime path.
+
+**Why:**
+- vsock stays the sole guest↔host and egress boundary — the auditable
+  chokepoint the egress and secret-substitution claims rest on;
+- admission stays the signed, validity-windowed `ExecutionPlan` plus
+  chain-signed audit log, never a mutable store;
+- one guest is one workload;
+- a forked or restored instance re-admits or inherits a bound signed plan
+  and keeps its verity binding — it never bypasses admission.
+
 ## Phases
 
 ### Phase 0 — Boundary record and spec update
 
-- [ ] Update ADR-025 to add the open-source competitor as a second prior-art
+- [x] Update ADR-025 to add the open-source competitor as a second prior-art
       data point: confirm the snapshot/CoW model, confirm refusal of dirty-
       guest reuse, and note the richer egress-policy vocabulary as inspiration
       only (no MITM adoption).
-- [ ] Add a short design note in this plan (above) or in `03-networking.md`
+- [x] Add a short design note in this plan (above) or in `03-networking.md`
       capturing the "vsock-first adoption boundary": what is adopted, what is
       refused, and why.
 - [ ] File/update a tracking issue for Plan 255 and link it in

--- a/specs/plans/255-vsock-first-snapshot-egress-adoption.md
+++ b/specs/plans/255-vsock-first-snapshot-egress-adoption.md
@@ -220,13 +220,21 @@ Non-goals above — what this plan takes, refuses, and why.
 - [ ] Add a BDD scenario: build a template with a warm snapshot, clone it into
       an instance, and verify the instance boots faster than a cold-booted
       equivalent.
-- [ ] Plug `SnapshotStore` in *beneath* the existing checkpoint lineage: a warm
+- [x] Plug `SnapshotStore` in *beneath* the existing checkpoint lineage: a warm
       snapshot is recorded as a lineage node (content-address + hash-link +
       audit anchor) via `mvm-runtime::{lineage, checkpoint}`; introduce no
-      second provenance graph.
-- [ ] A clone/fork from a parent whose lineage node is missing, un-audited, or
+      second provenance graph. (`mvm-runtime::warm_snapshot::stage_warm_snapshot`
+      stores a checkpoint's content dir into `FsSnapshotStore` under its own
+      content hash; the checkpoint's `meta.json` remains the sole lineage
+      record — no second graph.)
+- [x] A clone/fork from a parent whose lineage node is missing, un-audited, or
       hash-mismatched fails closed, reusing the checkpoint lineage's
       parent-verification path. Add a negative test.
+      (`mvm-runtime::warm_snapshot::materialize_child_from_parent` runs
+      `read_meta -> verify_content -> verify_lineage` before calling
+      `SnapshotStore::materialize`; four tests cover the positive control plus
+      missing/un-audited/tampered-parent refusal, each asserting `dst` is
+      never created.)
 
 **Acceptance gate:** `cargo test -p mvm-fs` green; BDD scenario passes on Linux;
 no `mvm-fs` consumer sees filesystem-specific logic; clone/fork refuses an

--- a/specs/plans/255-vsock-first-snapshot-egress-adoption.md
+++ b/specs/plans/255-vsock-first-snapshot-egress-adoption.md
@@ -229,10 +229,10 @@ Non-goals above — what this plan takes, refuses, and why.
 - [x] Plug `SnapshotStore` in *beneath* the existing checkpoint lineage: a warm
       snapshot is recorded as a lineage node (content-address + hash-link +
       audit anchor) via `mvm-runtime::{lineage, checkpoint}`; introduce no
-      second provenance graph. (`mvm-runtime::warm_snapshot::stage_warm_snapshot`
-      stores a checkpoint's content dir into `FsSnapshotStore` under its own
-      content hash; the checkpoint's `meta.json` remains the sole lineage
-      record — no second graph.)
+      second provenance graph. (`mvm-runtime::warm_snapshot::materialize_child_from_parent`
+      stages a verified checkpoint's content dir into `FsSnapshotStore` under
+      its own content hash before materializing it; the checkpoint's
+      `meta.json` remains the sole lineage record — no second graph.)
 - [x] A clone/fork from a parent whose lineage node is missing, un-audited, or
       hash-mismatched fails closed, reusing the checkpoint lineage's
       parent-verification path. Add a negative test.

--- a/specs/plans/255-vsock-first-snapshot-egress-adoption.md
+++ b/specs/plans/255-vsock-first-snapshot-egress-adoption.md
@@ -197,11 +197,11 @@ Non-goals above — what this plan takes, refuses, and why.
 
 ### Phase 1 — Snapshot-first storage in `mvm-fs`
 
-- [x] Introduce `SnapshotStore` trait in `mvm-fs` with operations `create`,
-      `clone`, `delete`, `list_parents`. Implementation uses reflink when
-      supported, sparse copy fallback otherwise. (The trait and its
-      `FsSnapshotStore` impl pre-existed as `create`/`materialize`/`remove`/
-      `list`; this phase extended it with a sparse-copy fallback in
+- [x] Introduce `SnapshotStore` trait in `mvm-fs` with content-addressed
+      create/materialize/remove/list operations. Implementation uses
+      reflink when supported, sparse copy fallback otherwise. (The trait
+      and its `FsSnapshotStore` impl pre-existed as `create`/`materialize`/
+      `remove`/`list`; this phase extended it with a sparse-copy fallback in
       `clone::reflink_or_copy`, a real content-addressed `create_content_addressed`
       with dedup, and `retain`/`release`/`refcount` reference counting.
       `list_parents` is deliberately not added — reference *counting* is a

--- a/specs/plans/255-vsock-first-snapshot-egress-adoption.md
+++ b/specs/plans/255-vsock-first-snapshot-egress-adoption.md
@@ -197,13 +197,25 @@ Non-goals above — what this plan takes, refuses, and why.
 
 ### Phase 1 — Snapshot-first storage in `mvm-fs`
 
-- [ ] Introduce `SnapshotStore` trait in `mvm-fs` with operations `create`,
+- [x] Introduce `SnapshotStore` trait in `mvm-fs` with operations `create`,
       `clone`, `delete`, `list_parents`. Implementation uses reflink when
-      supported, sparse copy fallback otherwise.
-- [ ] Move memory-snapshot file handling from `mvm-runtime` into `mvm-fs` if it
+      supported, sparse copy fallback otherwise. (The trait and its
+      `FsSnapshotStore` impl pre-existed as `create`/`materialize`/`remove`/
+      `list`; this phase extended it with a sparse-copy fallback in
+      `clone::reflink_or_copy`, a real content-addressed `create_content_addressed`
+      with dedup, and `retain`/`release`/`refcount` reference counting.
+      `list_parents` is deliberately not added — reference *counting* is a
+      storage primitive, but parent *lineage* stays out of `mvm-fs` per this
+      phase's task brief, to be plugged in from `mvm-runtime`'s checkpoint
+      lineage in a later task.)
+- [x] Move memory-snapshot file handling from `mvm-runtime` into `mvm-fs` if it
       is not already there; ensure content-addressed naming and reference
-      tracking.
-- [ ] Add unit tests for reflink/fallback roundtrips and for snapshot graph
+      tracking. (`mvm-fs` now owns content-addressed memory-snapshot
+      *storage*: a `mem.bin` file or `{vmstate.bin, mem.bin}` directory is
+      just another `create_content_addressed` artifact, materialized via the
+      sparse-aware clone. The Firecracker pause/seal lifecycle that produces
+      those bytes stays in `mvm-runtime` per Product decision 2.)
+- [x] Add unit tests for reflink/fallback roundtrips and for snapshot graph
       integrity (deleting a child does not affect parent or siblings).
 - [ ] Add a BDD scenario: build a template with a warm snapshot, clone it into
       an instance, and verify the instance boots faster than a cold-booted

--- a/specs/plans/255-vsock-first-snapshot-egress-adoption.md
+++ b/specs/plans/255-vsock-first-snapshot-egress-adoption.md
@@ -217,9 +217,15 @@ Non-goals above — what this plan takes, refuses, and why.
       those bytes stays in `mvm-runtime` per Product decision 2.)
 - [x] Add unit tests for reflink/fallback roundtrips and for snapshot graph
       integrity (deleting a child does not affect parent or siblings).
-- [ ] Add a BDD scenario: build a template with a warm snapshot, clone it into
+- [x] Add a BDD scenario: build a template with a warm snapshot, clone it into
       an instance, and verify the instance boots faster than a cold-booted
-      equivalent.
+      equivalent. (`features/suites/s11_snapshot/warm_snapshot_clone.feature`,
+      hermetic — no `@live` tag — driving `mvm_fs::snapshot_store` directly in
+      the default `just bdd` lane; it proves the storage-layer basis for a
+      warm start being faster than a cold boot (clone of a pre-built
+      content-addressed artifact, not a rebuild). The live boot-time
+      comparison itself is measured under the Phase 2 sub-second warm-launch
+      acceptance gate.)
 - [x] Plug `SnapshotStore` in *beneath* the existing checkpoint lineage: a warm
       snapshot is recorded as a lineage node (content-address + hash-link +
       audit anchor) via `mvm-runtime::{lineage, checkpoint}`; introduce no


### PR DESCRIPTION
## Summary

Implements **Plan 255** (vsock-first snapshot, egress & warm-start adoption) — **Phase 0 + Phase 1 only**. Adopts the externally-proven snapshot-first + copy-on-write clone techniques while holding every standing invariant: vsock stays the sole guest↔host and egress boundary, one guest = one workload, the guest never sees secrets, and fork/restore never bypasses admission.

Tracking: #1851 (this PR closes Phases 0–1; Phases 2–6 remain open there).

### Phase 0 — boundary record & spec
- ADR-025: added the open-source competitor as a **grounded** second prior-art data point — independent validation of mvm's clean-CoW-from-template + host-side-secret-substitution direction. Its egress-policy vocabulary is noted as inspiration only; the transparent-TLS-MITM and guest-NIC data-plane mechanisms are explicitly refused.
- Plan: a "Vsock-first adoption boundary" note (adopted / refused / why).
- SPRINT.md linked to the plan.

### Phase 1 — snapshot-first storage
- **`mvm-fs`**: extended `SnapshotStore` with a sparse-copy fallback (byte-exact, hole-preserving), real content-addressing (deterministic, collision-resistant directory-manifest hashing), reference counting, and content-addressed memory-snapshot storage. It stays a pure content-addressed copy primitive — no provenance graph in `mvm-fs`.
- **`mvm-runtime`** (`warm_snapshot.rs`): a self-binding, fail-closed clone seam plugged *beneath* the existing chain-anchored checkpoint lineage. It clones nothing until `read_meta → verify_content → verify_lineage` all pass, and materializes only content derived from the just-verified parent — a caller cannot substitute an unaudited blob.
- **`mvm-conformance`**: a hermetic `s11_snapshot` BDD scenario (byte-equality, clone independence, dedup-not-rebuild) that runs in the default `just bdd` lane.

### Invariants honored
- Reuses the single chain-anchored checkpoint lineage — no second provenance graph.
- Fork/clone fails closed on a missing, un-audited, hash-mismatched, or substituted parent; negative tests plus a substitution-attack regression prove it.

### Tests
`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (7778 passed), `cargo test --workspace --doc`, `just bdd` (36/36), `cargo run -p xtask -- check-claim-catalog`, `cargo run -p xtask -- check-core-runtime-free` — all green.

### Deferred to Phase 2 (out of scope here)
Warm-pool wiring + per-child `ExecutionPlan` mint/verity binding; atomic refcount locking under a concurrent pool; rootfs-*tree* CAS mode/xattr/verity semantics (Phase 1 stores opaque image/mem blobs only).
