### PR TITLE
feat: Plan 265 fast-start foundation — no-NIC restore guard, page-merge policy, SLO helper

### DIFF
--- a/crates/mvm-cli/src/commands/vm/phase_timing.rs
+++ b/crates/mvm-cli/src/commands/vm/phase_timing.rs
@@ -119,6 +119,49 @@ impl RunPhaseTimings {
     }
 }
 
+/// p50 latency budget for a warm-started run's hot-start window (backend
+/// boot + boot-to-agent-reachable). Tighter than [`DISPATCH_BAR_MS`], which
+/// bounds dispatch-window regressions on any run regardless of warm/cold
+/// origin — this is the target a claimed warm start must clear.
+///
+/// Unused outside this module's tests until the warm-start measurement
+/// harness that consumes it lands.
+#[allow(dead_code)]
+pub const WARM_START_P50_BUDGET_MS: u64 = 30;
+
+/// Comparison of a warm-started run's hot-start latency against a cold
+/// run's: whether the warm run clears the [`WARM_START_P50_BUDGET_MS`]
+/// budget, and how much faster it was.
+#[allow(dead_code)]
+#[derive(Debug, PartialEq)]
+pub struct WarmVsColdReport {
+    pub warm_hot_ms: u64,
+    pub cold_hot_ms: u64,
+    pub clears_slo: bool,
+    pub speedup: f64,
+}
+
+/// Compare a warm-started run's hot-start latency against a cold run's.
+/// Hot-start latency is [`RunPhaseTimings::dispatch_window_ms`] — backend
+/// boot plus boot-to-agent-reachable, the part a warm start improves.
+/// Pure: reads only the two timings, no clock or I/O.
+#[allow(dead_code)]
+pub fn warm_vs_cold(warm: &RunPhaseTimings, cold: &RunPhaseTimings) -> WarmVsColdReport {
+    let warm_hot_ms = warm.dispatch_window_ms().round() as u64;
+    let cold_hot_ms = cold.dispatch_window_ms().round() as u64;
+    let speedup = if warm_hot_ms == 0 {
+        f64::INFINITY
+    } else {
+        cold_hot_ms as f64 / warm_hot_ms as f64
+    };
+    WarmVsColdReport {
+        warm_hot_ms,
+        cold_hot_ms,
+        clears_slo: warm_hot_ms <= WARM_START_P50_BUDGET_MS,
+        speedup,
+    }
+}
+
 /// Whether phase timing is enabled, pure over the raw env value so the gate
 /// is testable without mutating process env.
 fn timing_enabled_from(value: Option<&str>) -> bool {
@@ -278,5 +321,38 @@ mod tests {
         assert!(!timing_enabled_from(Some("")));
         assert!(!timing_enabled_from(Some("yes")));
         assert!(!timing_enabled_from(None));
+    }
+
+    #[test]
+    fn warm_vs_cold_clears_slo_when_hot_under_budget() {
+        let warm = timings_with_dispatch_window(15.0, 10.0); // hot = 25ms
+        let cold = timings_with_dispatch_window(370.0, 30.0); // hot = 400ms
+        let report = warm_vs_cold(&warm, &cold);
+        assert_eq!(report.warm_hot_ms, 25);
+        assert_eq!(report.cold_hot_ms, 400);
+        assert!(
+            report.clears_slo,
+            "25ms warm hot-start must clear the 30ms budget"
+        );
+        approx(report.speedup, 16.0);
+    }
+
+    #[test]
+    fn warm_vs_cold_fails_slo_when_hot_over_budget() {
+        let warm = timings_with_dispatch_window(45.0, 0.0); // hot = 45ms
+        let cold = timings_with_dispatch_window(370.0, 30.0);
+        let report = warm_vs_cold(&warm, &cold);
+        assert!(
+            !report.clears_slo,
+            "45ms warm hot-start must miss the 30ms budget"
+        );
+    }
+
+    #[test]
+    fn warm_vs_cold_speedup_infinite_when_warm_zero() {
+        let warm = timings_with_dispatch_window(0.0, 0.0); // hot = 0ms
+        let cold = timings_with_dispatch_window(370.0, 30.0);
+        let report = warm_vs_cold(&warm, &cold);
+        assert!(report.speedup.is_infinite());
     }
 }

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -64,6 +64,11 @@ pub mod pack_cache;
 pub mod pack_revocation;
 pub mod pack_trust;
 pub mod packs;
+/// Same-page-merge confinement policy: whether two guest-memory merge
+/// candidates (tenant + sealed image + fork family) may be host-wide
+/// same-page merged. Pure decision only, fails closed to `Refuse`; no
+/// kernel/`madvise` enforcement lives here.
+pub mod page_merge;
 /// Compiled-in release-signing identity: the OIDC issuer and identity
 /// templates a stock binary trusts for its own release packs, with
 /// version interpolation.

--- a/crates/mvm-core/src/page_merge.rs
+++ b/crates/mvm-core/src/page_merge.rs
@@ -1,0 +1,115 @@
+//! Same-page-merge confinement policy: the pure decision of whether two
+//! guest-memory merge candidates may have their pages host-wide merged
+//! (KSM-style content-based deduplication).
+//!
+//! Density benefits from sharing identical guest pages, but host-wide
+//! same-page merging across unrelated guests is a cross-VM timing side
+//! channel: a write to a merged page faults measurably slower than a write to
+//! an unmerged one, leaking co-residency and page contents across the
+//! boundary and amplifying rowhammer. This module answers only "may these two
+//! scopes share pages" as a pure function of their identity; it does not
+//! touch the kernel merge knob, `madvise`, or fault timing, and it performs no
+//! I/O — the runtime enforcement that actually enables or disables merging is
+//! a separate concern.
+//!
+//! Confinement rule: page sharing is permitted only *within a single fork
+//! family* — the paused parent and every child forked from it, all running
+//! the same sealed image for the same tenant. It is refused across tenants
+//! and across distinct workload images, even when the fork family happens to
+//! coincide (which should not otherwise occur, but the check does not assume
+//! it).
+
+use crate::checkpoint::CheckpointId;
+use crate::plan::{SignedImageRef, TenantId};
+
+/// Identity of one merge candidate: the tenant it belongs to, the sealed
+/// image it runs, and the fork family it descends from.
+///
+/// `fork_family` is keyed on the paused parent's [`CheckpointId`]: every
+/// sibling forked from the same paused parent carries that parent's
+/// checkpoint id here, so "same fork family" reduces to "forked from the same
+/// paused parent" rather than a separately maintained identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PageMergeScope {
+    pub tenant: TenantId,
+    pub image: SignedImageRef,
+    pub fork_family: CheckpointId,
+}
+
+/// Whether same-page merging may occur between two [`PageMergeScope`]s.
+///
+/// Fails closed: [`Default`] resolves to `Refuse`, never `Permit`, so any
+/// code path that constructs a decision without explicitly reaching
+/// `Permit` — an unconfigured policy, a placeholder, a future variant this
+/// module doesn't yet model — refuses merging rather than allowing it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MergeDecision {
+    Permit,
+    #[default]
+    Refuse,
+}
+
+/// Decide whether pages from `a` and `b` may be same-page-merged.
+///
+/// `Permit` iff `a` and `b` agree on tenant, sealed image, and fork family.
+/// Any mismatch on any field — including ones this function doesn't
+/// distinguish by name — refuses, since equality across every field is the
+/// only path to `Permit`.
+pub fn may_merge(a: &PageMergeScope, b: &PageMergeScope) -> MergeDecision {
+    if a.tenant == b.tenant && a.image == b.image && a.fork_family == b.fork_family {
+        MergeDecision::Permit
+    } else {
+        MergeDecision::Refuse
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scope(tenant: &str, image_sha256: &str, fork_family: &str) -> PageMergeScope {
+        PageMergeScope {
+            tenant: TenantId(tenant.to_string()),
+            image: SignedImageRef {
+                name: "example-image".to_string(),
+                sha256: image_sha256.to_string(),
+                cosign_bundle: None,
+                entrypoint_present: true,
+            },
+            fork_family: CheckpointId::new(fork_family),
+        }
+    }
+
+    #[test]
+    fn may_merge_permits_same_family_same_image_same_tenant() {
+        let a = scope("tenant-a", "deadbeef", "parent-1");
+        let b = scope("tenant-a", "deadbeef", "parent-1");
+        assert_eq!(may_merge(&a, &b), MergeDecision::Permit);
+    }
+
+    #[test]
+    fn may_merge_refuses_different_tenant() {
+        let a = scope("tenant-a", "deadbeef", "parent-1");
+        let b = scope("tenant-b", "deadbeef", "parent-1");
+        assert_eq!(may_merge(&a, &b), MergeDecision::Refuse);
+    }
+
+    #[test]
+    fn may_merge_refuses_different_image() {
+        let a = scope("tenant-a", "deadbeef", "parent-1");
+        let b = scope("tenant-a", "cafef00d", "parent-1");
+        assert_eq!(may_merge(&a, &b), MergeDecision::Refuse);
+    }
+
+    #[test]
+    fn may_merge_refuses_different_fork_family() {
+        let a = scope("tenant-a", "deadbeef", "parent-1");
+        let b = scope("tenant-a", "deadbeef", "parent-2");
+        assert_eq!(may_merge(&a, &b), MergeDecision::Refuse);
+    }
+
+    #[test]
+    fn default_decision_is_refuse() {
+        assert_eq!(MergeDecision::default(), MergeDecision::Refuse);
+    }
+}

--- a/crates/mvm-runtime/src/microvm/snapshot.rs
+++ b/crates/mvm-runtime/src/microvm/snapshot.rs
@@ -1,6 +1,7 @@
 //! Firecracker snapshot controls that do not alter the runner's device model.
 
 use anyhow::{Context, Result};
+use serde::Deserialize;
 use tracing::instrument;
 
 use crate::base::shell::shell_quote;
@@ -92,6 +93,40 @@ pub fn create_snapshot_files(
     Ok(())
 }
 
+/// Partial view of Firecracker's own restored-VM configuration (the shape
+/// `GET /vm/config` reports once a snapshot is loaded), carrying only the
+/// `network-interfaces` array.
+///
+/// This is intentionally not `#[serde(deny_unknown_fields)]`: it is a slice
+/// of Firecracker's own config schema (which also carries `boot-source`,
+/// `drives`, `machine-config`, `vsock`, and more), not a host↔snapshot
+/// type mvm controls end to end. Rejecting the fields we don't read would
+/// make this view brittle against upstream additions.
+#[derive(Debug, Deserialize)]
+pub struct RestoredDeviceModel {
+    #[serde(rename = "network-interfaces", default)]
+    pub network_interfaces: Vec<serde_json::Value>,
+}
+
+/// Refuse to restore a snapshot whose device model carries a network
+/// interface.
+///
+/// A restored VMM reconstructs whatever devices the snapshot captured. Any
+/// network interface would let guest traffic reach a device outside the
+/// vsock transport, bypassing the sole auditable egress boundary — so a
+/// non-empty `network-interfaces` list is a hard refusal, not a warning.
+///
+/// Pure: inspects only the passed-in config. No I/O, no VM, no clock.
+pub fn assert_vsock_only_device_model(config: &RestoredDeviceModel) -> Result<()> {
+    let count = config.network_interfaces.len();
+    anyhow::ensure!(
+        count == 0,
+        "restore refused: the snapshot's device model carries {count} network \
+         interface(s) — a network interface would bypass the vsock-only egress boundary"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -101,5 +136,74 @@ mod tests {
         let err = warm_restore_instance("vm", [0u8; mvm_core::crypto::vmgenid::GENID_BYTES])
             .expect_err("legacy restore must refuse");
         assert!(err.to_string().contains("disabled"));
+    }
+
+    fn device_model_with(network_interfaces: Vec<serde_json::Value>) -> RestoredDeviceModel {
+        RestoredDeviceModel { network_interfaces }
+    }
+
+    #[test]
+    fn restore_refuses_nic_device_model() {
+        let config = device_model_with(vec![serde_json::json!({
+            "iface_id": "eth0",
+            "host_dev_name": "tap0",
+        })]);
+        let err =
+            assert_vsock_only_device_model(&config).expect_err("a NIC in the model must refuse");
+        assert!(
+            err.to_string().contains("vsock-only egress boundary"),
+            "expected the vsock-boundary refusal, got: {err}"
+        );
+    }
+
+    #[test]
+    fn restore_accepts_vsock_only_device_model() {
+        let config = device_model_with(Vec::new());
+        assert_vsock_only_device_model(&config).expect("no NIC must be admitted");
+    }
+
+    #[test]
+    fn restore_refuses_multiple_nic_device_model() {
+        let config = device_model_with(vec![
+            serde_json::json!({"iface_id": "eth0"}),
+            serde_json::json!({"iface_id": "eth1"}),
+        ]);
+        let err = assert_vsock_only_device_model(&config)
+            .expect_err("multiple NICs in the model must refuse");
+        assert!(err.to_string().contains('2'), "count in message: {err}");
+    }
+
+    #[test]
+    fn restored_device_model_parses_network_interfaces_from_full_vm_config_json() {
+        // Shaped after Firecracker's own `GET /vm/config` response: several
+        // sibling sections this view does not model at all. Deserializing
+        // must succeed and ignore everything but `network-interfaces`.
+        let raw = serde_json::json!({
+            "boot-source": {"kernel_image_path": "/vmlinux", "boot_args": "console=ttyS0"},
+            "drives": [{"drive_id": "rootfs", "path_on_host": "/rootfs.ext4"}],
+            "machine-config": {"vcpu_count": 2, "mem_size_mib": 1024},
+            "network-interfaces": [{"iface_id": "eth0", "host_dev_name": "tap0"}],
+            "vsock": {"vsock_id": "vsock0", "guest_cid": 3, "uds_path": "/v.sock"},
+        })
+        .to_string();
+
+        let config: RestoredDeviceModel = serde_json::from_str(&raw).unwrap();
+        assert_eq!(config.network_interfaces.len(), 1);
+        assert!(assert_vsock_only_device_model(&config).is_err());
+    }
+
+    #[test]
+    fn restored_device_model_defaults_to_empty_when_field_absent() {
+        // Older/minimal config bodies may omit `network-interfaces` entirely
+        // (Firecracker only includes devices that were actually attached);
+        // absence must mean "no NIC", not a deserialization failure.
+        let raw = serde_json::json!({
+            "boot-source": {"kernel_image_path": "/vmlinux", "boot_args": "console=ttyS0"},
+        })
+        .to_string();
+
+        let config: RestoredDeviceModel = serde_json::from_str(&raw).unwrap();
+        assert!(config.network_interfaces.is_empty());
+        assert!(assert_vsock_only_device_model(&config).is_ok());
     }
 }

--- a/specs/adrs/025-warm-snapshot-prior-art-adoption-boundary.md
+++ b/specs/adrs/025-warm-snapshot-prior-art-adoption-boundary.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Proposed. Records a design boundary for future warm-path work; nothing
-in this ADR has shipped yet.
+Accepted. Records the adopt/refuse/constrain boundary for warm-path work;
+implementation is sequenced in Plan 265.
 
 ## Context
 
@@ -135,6 +135,20 @@ mechanism is refused for the same reason as above: it would move
 enforcement off the vsock seam and change the guest's trust model,
 exactly what this refusal rejects.
 
+### Constrain — same-page merging confined to a fork family
+
+Density benefits from sharing identical guest pages, but host-wide
+same-page merging across unrelated guests is a cross-VM side channel: a
+write to a merged page faults measurably slower, leaking co-residency and
+page contents over a timing channel and amplifying rowhammer. mvm
+therefore constrains page sharing to copy-on-write *within a single fork
+family* — the paused parent and the children forked from it, all the same
+sealed image — and refuses merging across tenants or across distinct
+workload images. This keeps the density win that CoW fork already provides
+(children share the parent's pages intrinsically, same-image) without
+opening a cross-workload channel. The policy gate fails closed: absent an
+explicit same-family scope, no merging occurs.
+
 ## Out of scope
 
 Warm-pool sizing and admission policy at the fleet level; the warmed-
@@ -146,7 +160,10 @@ that owns it, not this one.
 
 ## Consequences
 
-Page-cache priming at freeze time is a deferred follow-up on mvm's
-existing warm-snapshot design; no code or schema exists yet. No security
-claim changes as a result of this ADR — it is a prior-art boundary
-record, not a security-claim ADR.
+Page-cache priming at freeze time, the same-page-merging constraint, and
+the warm snapshot-fork restore path are implemented and sequenced in Plan
+265, which lands the restore-path security witnesses. No existing security
+claim is relaxed: the constraints above gate the warm path more tightly
+than cold boot, extending claims 1, 3, 8, 10, and 13 into the restore path
+rather than weakening them. The full surface-by-surface enumeration lives
+in `specs/notes/2026-07-26-fast-start-warm-snapshot-design.md`.

--- a/specs/notes/2026-07-26-fast-start-warm-snapshot-design.md
+++ b/specs/notes/2026-07-26-fast-start-warm-snapshot-design.md
@@ -21,7 +21,7 @@ tens of milliseconds, versus today's unoptimized cold boot.
 
 This is not greenfield. Two documents already scope most of the substrate:
 
-- `specs/plans/255-vsock-first-snapshot-egress-adoption.md` (Draft) — the
+- `specs/plans/255-vsock-first-snapshot-egress-adoption.md` (Active; Phase 0–1 merged) — the
   snapshot-first storage model, warm pool of paused clean parents, fork
   identity hygiene, egress enrichment, OCI template path. It is the substrate
   plan and stays so.

--- a/specs/notes/2026-07-26-fast-start-warm-snapshot-design.md
+++ b/specs/notes/2026-07-26-fast-start-warm-snapshot-design.md
@@ -1,0 +1,238 @@
+# Fast-start & density design — warm snapshot-fork within the vsock-only invariants
+
+Date: 2026-07-26. Status: design agreed, pending spec review.
+
+## Goal
+
+Make mvm the default choice for running untrusted workloads by driving
+start-up latency and memory density to the fastest achievable point *within*
+the standing security invariants — not by adopting the no-OS / no-kernel
+micro-isolation model of the sub-millisecond function-sandbox tier. mvm keeps
+a full Linux guest (its whole value: run any unmodified OCI image, verified
+boot, netfilter-grade egress, a real audit and secret-substitution chain), and
+competes on being *fast enough that latency stops being the deciding factor*
+while staying provably isolated.
+
+Target shape: warm snapshot-fork pools + page-cache priming + density, across
+Firecracker, the in-house HVF VMM, and libkrun. Realistic warm-start target is
+tens of milliseconds, versus today's unoptimized cold boot.
+
+## Where this sits relative to existing work
+
+This is not greenfield. Two documents already scope most of the substrate:
+
+- `specs/plans/255-vsock-first-snapshot-egress-adoption.md` (Draft) — the
+  snapshot-first storage model, warm pool of paused clean parents, fork
+  identity hygiene, egress enrichment, OCI template path. It is the substrate
+  plan and stays so.
+- `specs/adrs/025-warm-snapshot-prior-art-adoption-boundary.md` (Proposed) —
+  the adopt/refuse boundary: adopt page-cache priming confined to the sealed
+  rootfs; refuse warm-*guest* reuse; refuse host-socket networking.
+
+Neither covers three things this design adds:
+
+1. The Firecracker memory-snapshot restore path is **hard-disabled today**
+   (`crates/mvm-runtime/src/microvm/snapshot.rs` bails on every restore entry
+   point) because restoring a VMM can reintroduce the retired NIC and break
+   the vsock-only / claim-10 boundary. Plan 255 assumes restore works; it does
+   not. Re-enabling it safely is the load-bearing engineering task.
+2. Backend sequencing, concrete latency/density SLOs gated in CI, and the
+   density mechanisms (boot-time balloon, confined same-page sharing).
+3. The competitive-positioning deliverables (reproducible benchmark + the
+   security/compatibility comparison) that make "default choice" evidence-
+   backed rather than asserted.
+
+## Decisions (agreed)
+
+- **Approach:** fastest *within* the invariants. No warm-guest reuse, no no-OS
+  tier, no threat-model change. The sanctioned fast path is a warm memory
+  snapshot forked into a fresh, signed, admitted identity.
+- **Backend order:** Firecracker first (most mature snapshot tech, live-
+  validatable on the KVM box), then the in-house HVF VMM (the strategic
+  destination, vsock-pure so the no-NIC invariant is free), then libkrun (via
+  its existing pool wiring).
+- **Success = engineering + positioning.** Land the warm-start/density work
+  behind CI-gated SLOs, and publish a reproducible benchmark plus a
+  security-claim / workload-compatibility comparison against the no-OS tier.
+
+## The invariant-safe fast path (technical crux)
+
+FC restore is disabled because a restored full-VMM snapshot can reintroduce a
+NIC → un-audited egress. The unlock is that the tree is already converging
+every workload to NIC-less/vsock-only (plans 255/258). Therefore:
+
+1. **Snapshot only vsock-only device models.** A device model with no NIC at
+   freeze time cannot reintroduce one on restore. Re-enable restore behind a
+   verified "restored device model contains no NIC" invariant, checked at
+   restore, not only at capture.
+2. **Snapshot-fork with fresh identity.** Each forked child boots a freshly
+   synthesized, signed, admitted execution plan (new nonce, boot id,
+   generation id, per-instance secrets disposition) — never the parent's. The
+   existing warm-attach path already re-verifies the signed plan, so this
+   slots in.
+3. **Page-cache priming at freeze**, confined to the read-only verity-sealed
+   rootfs (per ADR-025), so the restored child skips cold page-fault cost on
+   its working set with no shared mutable/secret state.
+4. **Warm pool = clean paused parents.** A parent is a factory, never a
+   workload; on release the child is destroyed and a fresh parent replenished.
+
+## Backends
+
+Shared, backend-agnostic core (already partly built): the `CheckpointStore`,
+the `VmFull` snapshot class (today reserved), the warm pool + `WarmLease`, the
+memory accountant, identity-scrub-on-fork. Wired into the `VmBackend` trait so
+all three backends inherit it (only libkrun implements the pool today).
+
+- **Firecracker (lead, on the KVM box).** Un-bail `microvm/snapshot.rs` behind
+  the no-NIC-on-restore invariant; land `create_snapshot` / `load_snapshot`
+  behind the existing `SnapshotIO` trait seam; page-cache priming; **first
+  published warm-start number.**
+- **In-house HVF VMM.** Prerequisite: it needs a root filesystem (virtio-blk /
+  initramfs — today it panics with no root fs) before snapshot is meaningful.
+  Then native snapshot-fork; vsock-pure by construction, so the no-NIC
+  invariant costs nothing.
+- **libkrun.** Adopt the same seam through its existing standby-pool wiring.
+
+## Density
+
+- Boot-time balloon: commit `mem_initial_mib` at boot instead of the full cap
+  (mechanism already present), inflate on demand under the existing
+  Inflate/Hold/Deflate policy.
+- CoW page sharing across a fork family is intrinsic (children share the
+  parent's pages copy-on-write) and same-image, so it is the primary density
+  lever and carries no cross-tenant exposure.
+- Host-wide same-page merging (KSM) is **constrained, not adopted wholesale** —
+  see security surface 6 below.
+- Keep the memory accountant charging *measured* CoW resident, not the
+  configured cap, so density accounting reflects reality.
+- The minimal all-built-in kernel (`optimizeForSize`) already exists and stays
+  the guest baseline.
+
+## Security surfaces opened or widened by this work
+
+Warm snapshot-fork adds attack surface that cold boot does not have. Each item
+below is stated with its failure mode, the mitigation, and the claim or
+witness that must cover it. Items marked NEW need a new CI witness; the rest
+extend an existing claim into the restore path.
+
+1. **Snapshot integrity — restore executes attacker-influenced memory.**
+   A tampered memory image yields arbitrary guest register/memory state on
+   restore, potentially forging an already-admitted state. Mitigation: gate
+   every restore on the existing HMAC seal (`instance_snapshot.rs`
+   integrity.json + snapshot_hmac), fail closed on mismatch; add AES-GCM
+   confidentiality (currently absent) so snapshots-at-rest do not leak guest
+   memory. Extends claim 8 into the restore path. NEW witness: restore refuses
+   a byte-flipped snapshot.
+
+2. **NIC reintroduction on restore — vsock-only / claim-10 bypass.** The reason
+   restore is disabled today. Mitigation: snapshot only NIC-less device models;
+   verify no NIC in the *restored* device model, refuse otherwise. Claim 10.
+   NEW witness: restore of a snapshot whose device model carries a NIC is
+   refused.
+
+3. **Fork identity confusion / plan replay.** A child inheriting the parent's
+   nonce/keys/audit position could replay a prior admission or carry a stale
+   validity window. Mitigation: fresh signed+admitted plan per fork; nonce
+   replay store; monotonic snapshot epoch enforced at restore to refuse
+   rollback; fork lineage anchored to the chain-signed audit log so a fork
+   fails closed on an un-audited or tampered parent. Claim 8 + existing
+   checkpoint-lineage anchoring.
+
+4. **Cross-fork residue.** The parent's memory is CoW-shared into every child;
+   anything in the snapshotted parent RAM or primed cache is present in all
+   children. Mitigation: snapshot only *clean pre-workload* parents (captured
+   before any workload admission); priming confined to the read-only verity
+   rootfs; per-instance mutable volumes never shared; secrets never enter guest
+   memory (host-side substitution). ADR-001 one-guest-one-workload +
+   secrets-never-in-guest; claim 13. NEW witness: a parent snapshot captured
+   after a workload ran is refused for forking.
+
+5. **Page-cache priming vs verified boot.** If primed content is not the
+   verity-sealed rootfs, restore serves unverified pages. Mitigation: prime
+   strictly from the dm-verity sealed read-only root; a declared working set
+   resolving outside it is rejected; the restored rootfs stays verity-backed.
+   Claim 3.
+
+6. **Same-page merging (KSM) as a cross-VM side channel.** NEW boundary
+   decision (absent from ADR-025). Host-wide KSM merges identical pages across
+   VMs; a write to a merged page faults measurably slower — a memory-
+   deduplication timing side channel (cross-VM disclosure, Rowhammer
+   amplification). Mitigation: confine same-page sharing to a single fork
+   family / same image (intrinsic CoW), never merge across tenants or distinct
+   workload images. Recorded as a new "Constrain" decision in ADR-025.
+
+7. **Snapshot at rest — disclosure and rollback.** Snapshots hold full guest
+   memory; a local reader gets disclosure, and a rollback swap to an older
+   snapshot could resurrect revoked credentials or known-vuln state.
+   Mitigation: `~/.mvm` 0700 (existing W1.5); HMAC seal + AES-GCM
+   confidentiality; monotonic epoch anti-rollback enforced at restore.
+
+8. **Warm-pool control channel is untrusted.** A local attacker reaching the
+   pool control UDS could try to claim or redirect a standby. Mitigation: pool
+   dir + sockets mode 0700; the warm-attach path re-verifies the signed
+   execution plan (already implemented) — the control UDS is explicitly not a
+   trusted channel.
+
+9. **Confinement re-application on restore.** A restored VMM that skips
+   re-applying seccomp / jailer / per-service uid would come up less confined
+   than a cold boot. Mitigation: treat restore as equivalent to boot for
+   confinement — re-apply seccomp, jailer, and uid hardening on every restore.
+   Claim 1. (ADR-025 lists seccomp-on-restore as an open restore-correctness
+   gap; this closes it.)
+
+10. **Host TCB growth in the snapshot-load path.** New snapshot-load code parses
+    untrusted snapshot files. Mitigation: a cargo-fuzz target on the snapshot
+    header/metadata parser (sibling to the existing SupervisorConfig fuzz);
+    `#[serde(deny_unknown_fields)]` on every snapshot type. NEW fuzz witness.
+
+11. **Density DoS via balloon (availability only).** A guest resisting balloon
+    inflation under host pressure could starve the host. Mitigation: the
+    existing balloon policy plus the host memory budget and spawn-concurrency
+    gate cap oversubscription. No confidentiality impact.
+
+Net: surfaces 1, 2, 4, 6, and 10 need new CI witnesses; the rest extend claims
+3, 8, 10, 13, and W1.x into the restore path. None of them requires relaxing an
+existing claim — the fast path is gated *harder* than cold boot, not softer.
+
+## SLOs (design targets, tuned on the KVM box)
+
+- Warm start p50 ≤ ~30 ms, p99 ≤ ~50 ms, measured through the existing
+  `phase_timing` harness (`MVM_PHASE_TIMING=1`), versus the current
+  unoptimized cold boot.
+- Density: guests-per-GB via the memory accountant's measured resident, on a
+  representative same-image fork family.
+- These are starting targets; ratchet them from real measurement.
+
+## Positioning (the "default choice" evidence)
+
+- Reproducible benchmark harness, runnable on the KVM box, reporting warm start
+  vs mvm's own cold-boot baseline and honestly placing both against the no-OS
+  tier (no apples-to-oranges).
+- A comparison doc: the machine-checked security claims + workload
+  compatibility (any unmodified OCI image) matrix vs the no-OS tier. This is
+  where mvm's already-built moat becomes visible. The no-OS tier is referred to
+  obliquely throughout — no product proper noun in any committed file.
+
+## Plan of record (artifacts to write)
+
+1. **ADR-025 → Accepted**, plus a new "Constrain — same-page merging confined
+   to a fork family" decision (surface 6) and a pointer to the security-surface
+   enumeration.
+2. **Plan 255 → Active**, minimal edits: add the FC-restore re-enable +
+   no-NIC-on-restore task (the crux Plan 255 currently omits), and a cross-
+   reference to Plan 265 for sequencing / SLOs / security surfaces.
+3. **New Plan 265 — "Fast-start SLO, backend sequencing & competitive
+   positioning."** Owns backend sequencing (FC → HVF → libkrun), the SLO CI
+   gates, the density workstream, the security-surfaces section (mapping each
+   surface to its claim/witness/fuzz), the benchmark harness, and the
+   comparison doc. References Plan 255 for the substrate and ADR-025 for the
+   boundary.
+
+## Non-goals
+
+- No warm-guest reuse; no no-OS / no-kernel tier; no Wasm micro-tier (unless a
+  real use case later pulls for it).
+- No relaxation of any existing security claim.
+- No NIC/TAP/bridge or host-socket data plane; vsock stays the sole boundary.
+- No product proper noun for the no-OS competitor in any committed file or
+  commit message.

--- a/specs/plans/255-vsock-first-snapshot-egress-adoption.md
+++ b/specs/plans/255-vsock-first-snapshot-egress-adoption.md
@@ -2,7 +2,12 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Status:** Draft.
+**Status:** Active.
+
+> Backend sequencing, the concrete warm-start/density SLOs, the new
+> restore-path security witnesses, and the competitive-positioning
+> deliverables live in Plan 265, which depends on this plan's substrate
+> (Phases 1–2). See `specs/notes/2026-07-26-fast-start-warm-snapshot-design.md`.
 
 ## Goal
 
@@ -258,6 +263,11 @@ un-audited or tampered parent; no second provenance graph is introduced (reuses
       teardown, and fresh handshake.
 - [ ] Add a hard guard that refuses to resume a warm parent as a workload
       (different code path / enum variant).
+- [ ] Re-enable memory-snapshot restore behind a verified no-NIC-on-restore
+      invariant: a restored device model that carries a network device is
+      refused, so restore can never reintroduce an un-audited egress path.
+      (Restore is hard-disabled today in `crates/mvm-runtime/src/microvm/snapshot.rs`.)
+      Backend-specific restore engineering and sequencing are tracked in Plan 265.
 - [ ] Add unit tests for identity freshness and replay refusal; add BDD
       scenarios for sub-second warm launch and for fork isolation.
 - [ ] `fork_from_parent` mints or inherits a fresh signed `ExecutionPlan` for

--- a/specs/plans/265-fast-start-slo-sequencing-positioning.md
+++ b/specs/plans/265-fast-start-slo-sequencing-positioning.md
@@ -1,0 +1,299 @@
+# Plan 265 — Fast-start SLO, backend sequencing & competitive positioning
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Status:** Draft.
+
+**Goal:** Drive mvm workload start-up to a warm-start latency and memory
+density where latency is no longer the deciding factor against the no-OS /
+no-kernel micro-isolation tier, while keeping the full-Linux guest and every
+standing security invariant — then publish the evidence that makes mvm the
+default choice.
+
+**Architecture:** Re-enable memory-snapshot restore on a *vsock-only* device
+model (no NIC to reintroduce), fork it into a fresh signed+admitted identity,
+and prime the read-only rootfs page cache at freeze. Sequence the restore
+engineering Firecracker → in-house HVF VMM → libkrun. Gate a warm-start and
+density SLO in CI, and back the positioning with a reproducible benchmark and a
+security/compatibility comparison.
+
+**Tech Stack:** Rust workspace; Firecracker snapshot API; the in-house HVF VMM
+(`crates/mvm-runtime/src/vmm/` + `hvf/`); libkrun standby pool; cucumber-rs BDD
+(`crates/mvm-conformance`, `features/suites/`); cargo-fuzz; the `phase_timing`
+harness.
+
+## Relationship to existing work
+
+- **Plan 255** (vsock-first snapshot, egress, warm-start adoption) owns the
+  *substrate*: `SnapshotStore` (reflink/fallback), memory-snapshot file
+  handling, the paused-parent warm pool, and fork identity hygiene. This plan
+  depends on Plan 255 Phases 1–2 and does **not** re-own them.
+- This plan (265) owns what makes the substrate *fast and safe per backend*:
+  the vsock-safe restore re-enable, the no-NIC-on-restore invariant, backend
+  sequencing, page-cache priming, the density mechanisms, the SLO CI gates, the
+  new security witnesses, and the positioning deliverables.
+- **ADR-025** records the adopt/refuse boundary and (updated alongside this
+  plan) the same-page-merging constraint. Design note:
+  `specs/notes/2026-07-26-fast-start-warm-snapshot-design.md`.
+
+## Global Constraints
+
+Copied verbatim from the design note and the standing invariants; every task
+below implicitly includes these.
+
+- **Vsock is the sole guest↔host and egress boundary.** No NIC/TAP/bridge or
+  host-socket data plane, ever — including on any restored device model.
+- **One guest = one workload.** No warm-*guest* reuse. The fast path forks a
+  warm *snapshot* into a fresh, signed, admitted identity; a paused parent is a
+  factory, never a workload.
+- **Guest sees no secrets.** Credential substitution stays host-side; secrets
+  never enter guest memory, disk, snapshot, or logs.
+- **No existing security claim is relaxed.** The warm path is gated *harder*
+  than cold boot, not softer. `check-claim-catalog` stays green.
+- **No proper noun for the no-OS tier** in any committed file, `.feature`
+  scenario text, or commit message — refer to it obliquely.
+- **No spec references in code comments or `.feature`/step files.** The
+  `check-no-spec-refs` gate bans `Plan N`, `ADR-\d+`, `#NNNN`, `W\d.` in code;
+  phrase the concept, not the spec pointer.
+- **No task is done without tests**, and every user-facing behavior lands a
+  cucumber scenario runnable via `just bdd`, not only unit tests.
+- **SLO targets** (tunable on the KVM box): warm start p50 ≤ 30 ms, p99 ≤ 50
+  ms via `MVM_PHASE_TIMING=1`; density measured as guests-per-GB on a same-image
+  fork family via the memory accountant's measured resident.
+
+## Security surfaces → mitigation → witness
+
+Each surface opened or widened by warm restore, with the witness that must
+cover it. "NEW" = a new CI witness this plan lands; the rest extend an existing
+claim into the restore path. Scenario paths are under `features/suites/`.
+
+| # | Surface | Mitigation | Witness |
+|---|---------|-----------|---------|
+| 1 | Restore executes attacker-influenced memory | HMAC seal via `verify_and_resume`; add AES-GCM confidentiality | NEW `s11_warm_restore/integrity_byteflip_refused.feature` + `instance_snapshot` unit |
+| 2 | NIC reintroduction on restore (claim 10 bypass) | snapshot only NIC-less device models; verify no-NIC on *restore* | NEW `s2_egress_vsock/warm_restore_no_nic.feature` |
+| 3 | Fork identity confusion / plan replay | fresh signed+admitted plan per fork; epoch anti-rollback; lineage anchored to audit chain | `s6_admission_audit/fork_identity_replay.feature` (extends claim 8) |
+| 4 | Cross-fork memory residue | snapshot clean pre-workload parents only; priming rootfs-only; per-instance volumes | NEW `s3_secrets_pii/fork_no_residue.feature` |
+| 5 | Priming vs verified boot | prime only the dm-verity sealed rootfs; reject working set outside it | `s4_verified_boot/prime_within_verity_only.feature` (extends claim 3) |
+| 6 | Same-page merging (KSM) cross-VM side channel | confine merging to one fork family / same image; never cross-tenant | NEW `s3_secrets_pii/no_cross_tenant_page_merge.feature` + config gate |
+| 7 | Snapshot at rest — disclosure / rollback | `~/.mvm` 0700; HMAC + AES-GCM; monotonic epoch anti-rollback | `s11_warm_restore/epoch_rollback_refused.feature` |
+| 8 | Warm-pool control UDS untrusted | 0700 sockets; re-verify signed plan on attach (`prelaunch`) | `s6_admission_audit/warm_attach_reverifies_plan.feature` |
+| 9 | Confinement re-application on restore | re-apply seccomp/jailer/uid on every restore | `s5_lifecycle/restore_reapplies_confinement.feature` (extends claim 1) |
+| 10 | Host TCB growth in snapshot-load parser | extend `fuzz_snapshot_frame` to the restore-load metadata; `deny_unknown_fields` | NEW fuzz coverage in `crates/mvm-core/fuzz/fuzz_targets/fuzz_snapshot_frame.rs` |
+| 11 | Balloon density DoS (availability only) | existing balloon policy + host memory budget + spawn gate | `s5_lifecycle/density_balloon.feature` |
+
+---
+
+## Phase 0 — Baseline & SLO gate scaffold
+
+Establish the number we are beating before optimizing anything.
+
+- [ ] Capture the current cold-boot phase breakdown on the KVM box with
+      `MVM_PHASE_TIMING=1` through `crates/mvm-cli/src/commands/vm/phase_timing.rs`;
+      record `resolve_ms/drives_ms/admit_ms/backend_start_ms/vsock_wait_ms` for
+      Firecracker into the benchmark fixture (`benches/` or the harness in
+      Phase 6). Document the baseline in this plan.
+- [ ] Add a `warm_vs_cold` assertion helper to `phase_timing` that, given a
+      warm and a cold run, asserts warm `backend_start_ms + vsock_wait_ms`
+      clears the SLO. Unit-test it with canned timings (no VM).
+- [ ] Add `features/suites/s5_lifecycle/warm_faster_than_cold.feature` tagged
+      `@live @wip` (implemented in Phase 1) asserting warm start beats cold on
+      the same image.
+
+**Acceptance gate:** baseline recorded; `warm_vs_cold` helper unit-tested;
+`cargo nextest run -p mvm-cli` green; new `@wip` scenario parses under
+`just bdd`.
+
+## Phase 1 — Firecracker vsock-safe warm restore (hero path, KVM box)
+
+The load-bearing phase. Turns the disabled restore into a gated, integrity-
+checked, NIC-free warm start.
+
+- [ ] **No-NIC-on-restore invariant.** In `crates/mvm-runtime/src/microvm/snapshot.rs`,
+      add `fn assert_vsock_only_device_model(&SnapshotManifest) -> Result<()>`
+      that refuses any restored device model carrying a network device. Write
+      the failing unit test first (`restore_refuses_nic_device_model`), verify
+      red, implement, verify green.
+- [ ] **Real `FirecrackerIO`.** Implement `SnapshotIO::create_snapshot` /
+      `load_snapshot` for `FirecrackerIO` in
+      `crates/mvm-runtime/src/vm/instance_snapshot.rs` (today the seam exists;
+      the FC API calls are stubbed) using the Firecracker snapshot HTTP API,
+      driven through the existing microVM driver. Unit-test create/load against
+      a `CannedIO` fake for the state-machine, and behind a `@live` scenario for
+      the real API.
+- [ ] **Un-bail warm restore.** Replace the `bail!` bodies of
+      `warm_restore_instance` / `warm_restore_instance_from_path`
+      (`microvm/snapshot.rs`) with a path that calls `verify_and_resume`
+      (HMAC + monotonic epoch, already in `instance_snapshot.rs`) then
+      `assert_vsock_only_device_model` before resuming. Integrity/rollback
+      refusal is reused, not reinvented.
+- [ ] **Page-cache priming (rootfs-only).** At freeze in the warm-parent
+      producer, touch the template's declared working set confined to the
+      verity-sealed read-only rootfs; reject a working-set path resolving
+      outside it. Unit-test the rejection.
+- [ ] **Identity-scrub fork.** Ensure the forked child synthesizes a fresh
+      signed+admitted `ExecutionPlan` (new nonce, boot id, generation id,
+      per-instance secrets disposition) via the Plan 255 fork path, and anchors
+      the fork to the chain-signed audit log so an un-audited/tampered parent
+      fails closed. Unit-test fresh-nonce + replay refusal.
+- [ ] **Confinement on restore.** Re-apply seccomp, jailer, and per-service uid
+      on restore, identical to cold boot. Unit-test that a restored instance
+      carries the same seccomp profile + uid as a cold-booted one.
+- [ ] **Security witnesses (BDD).** Add and implement, with step defs in
+      `crates/mvm-conformance/tests/steps/warm_restore.rs` (new, wired in
+      `conformance.rs`):
+      - `s2_egress_vsock/warm_restore_no_nic.feature` (surface 2)
+      - `s11_warm_restore/integrity_byteflip_refused.feature` (surface 1)
+      - `s11_warm_restore/epoch_rollback_refused.feature` (surface 7)
+      - `s6_admission_audit/fork_identity_replay.feature` (surface 3)
+      - `s6_admission_audit/warm_attach_reverifies_plan.feature` (surface 8)
+      - `s3_secrets_pii/fork_no_residue.feature` (surface 4)
+      - `s4_verified_boot/prime_within_verity_only.feature` (surface 5)
+      - `s5_lifecycle/restore_reapplies_confinement.feature` (surface 9)
+- [ ] **First warm-start number.** Un-`@wip` the `warm_faster_than_cold`
+      scenario, run it `@live` on the KVM box, record warm p50/p99 against the
+      SLO in this plan.
+
+**Acceptance gate:** FC warm restore works on the KVM box; every surface-1..9
+witness above passes (negative paths refuse, positive path boots); warm start
+clears the SLO; `check-claim-catalog` green with the new witnesses registered;
+clippy/nextest/doctests green.
+
+## Phase 2 — In-house HVF VMM snapshot-fork
+
+The strategic destination; vsock-pure, so the no-NIC invariant is free.
+
+- [ ] **Rootfs prerequisite.** Give the in-house VMM a root filesystem
+      (virtio-blk or initramfs) in `crates/mvm-runtime/src/hvf/kernel_boot.rs` /
+      `crates/mvm-runtime/src/vmm/` so it reaches userspace instead of panicking
+      at `prepare_namespace`. `@live` boot scenario on Apple Silicon +
+      the KVM box.
+- [ ] **Native snapshot-fork.** Implement the `SnapshotIO` seam for the
+      in-house VMM (capture/restore guest RAM + vcpu state through the HVF
+      backend), reusing `verify_and_resume` and `assert_vsock_only_device_model`
+      from Phase 1. No NIC exists in this device model, so the invariant is
+      satisfied by construction — still assert it.
+- [ ] **Wire the warm pool into the `VmBackend` trait for HVF.** Override
+      `spawn_standby`/`claim_standby` in the HVF backend (today they hit the
+      fail-closed `Unsupported` default in
+      `crates/mvm-core/src/protocol/vm_backend.rs`).
+- [ ] **Re-run the Phase 1 witness suite against the HVF backend** (the same
+      `.feature` files, parameterized by backend in the `World`).
+
+**Acceptance gate:** in-house HVF VMM boots a real rootfs and warm-forks;
+Phase 1 witnesses pass against HVF; warm start clears the SLO on Apple Silicon;
+clippy/nextest/doctests green.
+
+## Phase 3 — libkrun adoption
+
+- [ ] Adopt the Phase 1 restore seam through libkrun's existing standby pool
+      (`crates/mvm-runtime/src/libkrun.rs` `spawn_standby`/`claim_standby`),
+      routing restore through `verify_and_resume` + the no-NIC assertion.
+- [ ] Re-run the Phase 1 witness suite against the libkrun backend.
+
+**Acceptance gate:** libkrun warm-forks with the same witnesses green;
+clippy/nextest/doctests green.
+
+## Phase 4 — Density
+
+- [ ] **Boot-time balloon default for warm forks.** Have the fork path set
+      `VmStartConfig.mem_initial_mib` so children commit less at boot, inflating
+      on demand under the existing `crates/mvm-hostd/src/supervisor/balloon.rs`
+      policy. Unit-test the commit-vs-cap accounting.
+- [ ] **Confined same-page sharing (surface 6).** Introduce a
+      `PageMergePolicy` that permits same-page sharing only within one fork
+      family / same image and refuses cross-tenant / cross-image merging.
+      Wire the config gate so host-wide KSM cannot be enabled across tenants.
+      Add `features/suites/s3_secrets_pii/no_cross_tenant_page_merge.feature`.
+- [ ] **Density SLO gate.** Extend `crates/mvm-core/src/memory_budget.rs`
+      reporting so a same-image fork family reports guests-per-GB from measured
+      resident; add `features/suites/s5_lifecycle/density_balloon.feature`
+      (`@live`) asserting the density target on the KVM box.
+
+**Acceptance gate:** balloon commit accounting unit-tested; cross-tenant merge
+refused (witness); density target met and gated; clippy/nextest green.
+
+## Phase 5 — Security witness consolidation & fuzz
+
+- [ ] Register every NEW witness (surfaces 1, 2, 4, 6, 10) in
+      `specs/claims/catalog.md` so `xtask check-claim-catalog` binds them; keep
+      the claim numbering table consistent (extends claims 1, 3, 8, 10, 13 into
+      the restore path — no new numbered claim, no relaxation).
+- [ ] Extend `crates/mvm-core/fuzz/fuzz_targets/fuzz_snapshot_frame.rs` to cover
+      the restore-load manifest/metadata path (surface 10); confirm every
+      host↔snapshot type carries `#[serde(deny_unknown_fields)]`.
+- [ ] Re-run the existing claim 3 / 8 / 10 / 13 / 15 witnesses to prove the warm
+      path does not regress the threat model.
+
+**Acceptance gate:** `check-claim-catalog` green with new witnesses; fuzz target
+builds under the pinned nightly and runs a smoke corpus; all pre-existing claim
+witnesses still pass.
+
+## Phase 6 — Positioning: benchmark & comparison
+
+- [ ] **Reproducible benchmark harness** under `benches/warm_start/` (or a
+      `just bench-warm-start` recipe) that runs on the KVM box, reports warm
+      start vs mvm's own cold-boot baseline (Phase 0), and emits a JSON result
+      for tracking. It must be honest about the no-OS tier — report the tier
+      difference, do not present an apples-to-oranges number.
+- [ ] **Comparison doc** at `public/src/content/docs/reference/isolation-tiers.md`:
+      the machine-checked security-claim matrix + workload-compatibility (any
+      unmodified OCI image) vs the no-OS tier, referring to that tier obliquely.
+      This is the "default choice" evidence.
+- [ ] Update `public/src/content/docs/**` for warm start, snapshots, and the
+      density knobs; ensure the doc-guard Rust tests
+      (`tests/nix_flake_structure.rs` heading asserts) stay green if touched.
+
+**Acceptance gate:** benchmark runs reproducibly on the KVM box and emits a
+result; comparison doc reviewed; no proper noun for the no-OS tier anywhere;
+doc-guard tests green.
+
+## Phase 7 — Close-out
+
+- [ ] Tick this plan's checkboxes and Plan 255's cross-referenced items; update
+      `specs/SPRINT.md`.
+- [ ] File/close the tracking issue with the recorded warm-start and density
+      numbers as evidence.
+
+## Verification gates
+
+No phase closes without:
+
+- `cargo fmt --all -- --check` (nightly rustfmt, per CI Lint)
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo nextest run --workspace` + `cargo test --workspace --doc`
+- touched cucumber scenarios green via `just bdd`
+- `xtask check-claim-catalog` green (no claim regressed; new witnesses bound)
+- `xtask check-no-spec-refs` green (no spec pointers in code/`.feature`/steps)
+- `check-cli-runtime-surface` green (CLI stays behind `mvm-client`)
+- `check-core-runtime-free` green (no async runtime leaks into the default build)
+- `cargo build --all-targets` clean under `-D warnings`, incl. the Linux target
+  cross-check (`just check-linux`)
+
+## Risks
+
+- **Restore reintroducing a NIC.** The entire claim-10 boundary. Mitigated by
+  asserting no-NIC on the *restored* device model, not only at capture, and by
+  the vsock-only convergence making workloads NIC-less anyway.
+- **Warm start still bounded by `vsock_wait_ms`.** Boot-to-agent-reachable may
+  dominate once backend restore is fast; page-cache priming and a pre-warmed
+  agent handshake must be measured, not assumed.
+- **Snapshot size / demand-fault cost.** Restore is only fast if the memory
+  snapshot demand-faults; measure resident growth, do not eagerly map.
+- **KSM side channel if the confinement leaks.** The `PageMergePolicy` gate must
+  fail closed — default no cross-family merging — and be witnessed.
+- **HVF rootfs bring-up is the long pole** for Phase 2; it is a real
+  prerequisite, not a formality.
+
+## Non-goals
+
+- Warm-*guest* reuse; a no-OS / no-kernel tier; a Wasm micro-tier.
+- Relaxing any existing security claim.
+- Any NIC/TAP/bridge or host-socket data plane; vsock stays the sole boundary.
+- AES-GCM confidentiality is *in* scope as a restore-integrity item, but a full
+  confidential-computing / memory-encryption story is not.
+
+## Deferred follow-ups
+
+- Fleet-level warm-pool sizing and admission policy (lives in mvmd).
+- Confidential-VM / hardware memory encryption for snapshots at rest.
+- A declarative warmup contract + ready probe for the warm-parent producer.

--- a/specs/plans/265-fast-start-slo-sequencing-positioning.md
+++ b/specs/plans/265-fast-start-slo-sequencing-positioning.md
@@ -69,13 +69,13 @@ claim into the restore path. Scenario paths are under `features/suites/`.
 
 | # | Surface | Mitigation | Witness |
 |---|---------|-----------|---------|
-| 1 | Restore executes attacker-influenced memory | HMAC seal via `verify_and_resume`; add AES-GCM confidentiality | NEW `s11_warm_restore/integrity_byteflip_refused.feature` + `instance_snapshot` unit |
+| 1 | Restore executes attacker-influenced memory | HMAC seal via `verify_and_resume`; add AES-GCM confidentiality | NEW `s11_snapshot/integrity_byteflip_refused.feature` + `instance_snapshot` unit |
 | 2 | NIC reintroduction on restore (claim 10 bypass) | snapshot only NIC-less device models; verify no-NIC on *restore* | NEW `s2_egress_vsock/warm_restore_no_nic.feature` |
 | 3 | Fork identity confusion / plan replay | fresh signed+admitted plan per fork; epoch anti-rollback; lineage anchored to audit chain | `s6_admission_audit/fork_identity_replay.feature` (extends claim 8) |
 | 4 | Cross-fork memory residue | snapshot clean pre-workload parents only; priming rootfs-only; per-instance volumes | NEW `s3_secrets_pii/fork_no_residue.feature` |
 | 5 | Priming vs verified boot | prime only the dm-verity sealed rootfs; reject working set outside it | `s4_verified_boot/prime_within_verity_only.feature` (extends claim 3) |
 | 6 | Same-page merging (KSM) cross-VM side channel | confine merging to one fork family / same image; never cross-tenant | NEW `s3_secrets_pii/no_cross_tenant_page_merge.feature` + config gate |
-| 7 | Snapshot at rest — disclosure / rollback | `~/.mvm` 0700; HMAC + AES-GCM; monotonic epoch anti-rollback | `s11_warm_restore/epoch_rollback_refused.feature` |
+| 7 | Snapshot at rest — disclosure / rollback | `~/.mvm` 0700; HMAC + AES-GCM; monotonic epoch anti-rollback | `s11_snapshot/epoch_rollback_refused.feature` |
 | 8 | Warm-pool control UDS untrusted | 0700 sockets; re-verify signed plan on attach (`prelaunch`) | `s6_admission_audit/warm_attach_reverifies_plan.feature` |
 | 9 | Confinement re-application on restore | re-apply seccomp/jailer/uid on every restore | `s5_lifecycle/restore_reapplies_confinement.feature` (extends claim 1) |
 | 10 | Host TCB growth in snapshot-load parser | extend `fuzz_snapshot_frame` to the restore-load metadata; `deny_unknown_fields` | NEW fuzz coverage in `crates/mvm-core/fuzz/fuzz_targets/fuzz_snapshot_frame.rs` |
@@ -142,8 +142,8 @@ checked, NIC-free warm start.
       `crates/mvm-conformance/tests/steps/warm_restore.rs` (new, wired in
       `conformance.rs`):
       - `s2_egress_vsock/warm_restore_no_nic.feature` (surface 2)
-      - `s11_warm_restore/integrity_byteflip_refused.feature` (surface 1)
-      - `s11_warm_restore/epoch_rollback_refused.feature` (surface 7)
+      - `s11_snapshot/integrity_byteflip_refused.feature` (surface 1)
+      - `s11_snapshot/epoch_rollback_refused.feature` (surface 7)
       - `s6_admission_audit/fork_identity_replay.feature` (surface 3)
       - `s6_admission_audit/warm_attach_reverifies_plan.feature` (surface 8)
       - `s3_secrets_pii/fork_no_residue.feature` (surface 4)


### PR DESCRIPTION
## What this is

The **locally-verifiable foundation slice of Plan 265** (fast-start & density — making warm VM start fast enough to compete on latency *within* the standing security invariants, without adopting a no-OS model). Opened **draft**: the runtime-wiring and live-number work is hardware-gated and intentionally not in this branch.

New specs: `Plan 265` (fast-start SLO, backend sequencing FC→HVF→libkrun, the security-surface→witness map, positioning), a design note with the full security-surface enumeration, and an `ADR-025` addition (the same-page-merging / KSM cross-VM side-channel constraint). Builds on Plan 255's snapshot substrate (Phase 0–1, already merged).

## Code landed (3 commits, each reviewed)

| Crate | Change | Tests |
|-------|--------|-------|
| mvm-cli | `warm_vs_cold` hot-start SLO comparison helper (30 ms p50 budget), reusing the existing `dispatch_window_ms()` | 3/3 |
| mvm-runtime | `assert_vsock_only_device_model` — pure guard refusing snapshot restore when the device model carries a NIC (enforces the vsock-only egress boundary); fail-closed direction verified | 2/2 (6/6 incl. edges) |
| mvm-core | `PageMergePolicy` / `may_merge` — confines guest same-page merging to one fork family (same tenant + image + fork family), closing a cross-VM side channel; fail-closed default | 4/4 (5/5 incl. default) |

These are the plan's pure primitives: the measurement gate, the security crux (the no-NIC restore unlock), and the density side-channel guard. The runtime **wiring** of each (un-bailing restore + real Firecracker snapshot API, calling the policy from the KSM path) is deliberately out of scope here.

## Not in this PR — hardware-gated remainder (Plan 265)

Needs the KVM box / Apple Silicon; tracked in Plan 265:

- [ ] Un-bail Firecracker restore + real `FirecrackerIO` create/load, gated on the no-NIC invariant (this PR's guard) — first warm-start number
- [ ] Page-cache priming at freeze (rootfs-only); identity-scrub fork; confinement re-application on restore
- [ ] In-house HVF VMM: rootfs prereq → native snapshot-fork
- [ ] libkrun adoption via the existing standby pool
- [ ] Density: boot-time balloon default; wire `PageMergePolicy` into the KSM path; density SLO gate
- [ ] The `s11_snapshot` restore-path BDD witnesses + `fuzz_snapshot_frame` restore-metadata extension + claim-catalog registration
- [ ] Benchmark harness + isolation-tiers comparison doc

## Deferred minors (for the wiring task)

- Drop `#[allow(dead_code)]` on the SLO helper once a caller wires it.
- Confirm live Firecracker `network-interfaces` response shape (omitted vs `[]`) — both currently resolve to allow-restore correctly.
- The page-merge `fork_family` scope keys off `CheckpointId`; wiring must populate the *parent's* id, not the child's (mis-keying only over-refuses — fail-closed-safe).

## Notes

- No existing security claim is relaxed; both new guards fail closed with no false-permit path (final Opus whole-branch review confirmed merge-ready).
- The no-OS competitor tier is referred to obliquely throughout — no proper noun in any committed file.
- Local verification: clean build of the three crates against `main`, new tests green. CI runs the authoritative full-workspace gate.
