### PR TITLE
feat(mvm-runtime): no-NIC device-model guard on the pause/resume restore path

### DIFF
--- a/crates/mvm-runtime/src/microvm/snapshot.rs
+++ b/crates/mvm-runtime/src/microvm/snapshot.rs
@@ -1,4 +1,21 @@
-//! Firecracker snapshot controls that do not alter the runner's device model.
+//! Firecracker snapshot controls, gated on the device-model guard below.
+//!
+//! `verify_and_resume` / `verify_and_resume_from_dir` in
+//! `crate::vm::instance_snapshot` run the no-NIC guard strictly between
+//! loading a snapshot paused and resuming it — see there for the full
+//! ordering. That path backs the live `mvmctl pause`/`resume` cycle today.
+//!
+//! The template and fork restore entry points below stay refused. Neither
+//! one's sealed content is verified by that same instance-HMAC path: a
+//! template snapshot carries its own Ed25519 + HMAC sidecar (a stronger,
+//! separate check), and a forked checkpoint is content-addressed and
+//! audit-chain-verified upstream of these calls (see the checkpoint lineage
+//! module) rather than instance-HMAC-sealed. Routing either through the
+//! instance verifier would either silently drop a check it currently gets or
+//! fail closed on content that verifier was never meant to see. Re-enabling
+//! them needs a design that keeps each path's own integrity check and adds
+//! the same load-paused → read-device-model → guard → resume ordering on top
+//! of it.
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -11,9 +28,12 @@ use super::{abs_vms_dir, require_linux_env};
 
 /// Refuse template snapshot restore.
 ///
-/// Snapshots capture complete VMM device state and may contain the retired
-/// Firecracker NIC. The runner's cold-boot path is the only admitted workload
-/// launch path.
+/// Snapshots capture complete VMM device state and may contain a network
+/// interface, bypassing the vsock-only egress boundary. Template snapshots
+/// are sealed with their own Ed25519 + HMAC sidecar, a separate mechanism
+/// from the instance-snapshot HMAC path the no-NIC guard is wired behind;
+/// restoring them needs a design that keeps that signature check AND adds
+/// the guard, so this stays refused until that design lands.
 #[instrument(skip_all, fields(template_id, name = %config.name))]
 pub fn restore_from_template_snapshot(
     template_id: &str,
@@ -30,8 +50,14 @@ pub fn restore_from_template_snapshot(
 
 /// Refuse live-memory restore entry points.
 ///
-/// A restored VMM can reintroduce devices captured in an older snapshot, so
-/// Firecracker memory restore is unavailable on the vsock-only workload path.
+/// A restored VMM can reintroduce devices captured in an older snapshot. The
+/// fork path's checkpoint content is content-addressed and audit-chain
+/// verified upstream of this call (the checkpoint lineage module), not
+/// sealed by the instance-snapshot HMAC envelope the no-NIC guard runs
+/// behind — so warm restore stays refused here until a fork-restore design
+/// runs that same guard ordering (load paused, read the restored device
+/// model, refuse on a NIC, only then resume) against the lineage's own
+/// content-address / audit-chain integrity instead of the instance verifier.
 pub fn warm_restore_instance(
     name: &str,
     _token: [u8; mvm_core::crypto::vmgenid::GENID_BYTES],

--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -101,17 +101,47 @@ pub fn files_for(vm_name: &str) -> SnapshotFiles {
 }
 
 /// Trait the pause/resume orchestrator uses to talk to Firecracker.
-/// Production wires `FirecrackerIO`; tests use `MemoryIO` which
+/// Production wires `FirecrackerIO`; tests use `CannedIO` which
 /// just writes canned bytes into the snapshot files.
+///
+/// `load_snapshot` used to load the bytes AND resume vCPUs in one call. It is
+/// split into [`load_snapshot_paused`](Self::load_snapshot_paused) and
+/// [`resume`](Self::resume) so the device-model guard
+/// (`assert_vsock_only_device_model`) can run against the restored VMM's
+/// config in the gap between the two — after the snapshot's devices exist to
+/// inspect, but before vCPUs execute a single instruction. A restored VMM
+/// reconstructs whatever devices the snapshot captured; if that includes a
+/// network interface, resuming it would bypass the vsock-only egress
+/// boundary. See
+/// [`crate::vm::instance_snapshot::verify_and_resume_from_dir`] for where the
+/// three calls are sequenced.
 pub trait SnapshotIO {
     /// Quiesce the running VM, write `vmstate.bin` + `mem.bin` into
     /// `dir`, leave the VM in a paused-and-shutdown state.
     fn create_snapshot(&self, dir: &Path) -> Result<()>;
 
-    /// Load the bytes at `<dir>/{vmstate,mem}.bin` into a fresh VM
-    /// and resume vCPUs. The agent's `PostRestore` path takes care
-    /// of vsock auth re-establishment after this returns.
-    fn load_snapshot(&self, dir: &Path) -> Result<()>;
+    /// Load the sealed snapshot at `<dir>/{vmstate,mem}.bin` into a
+    /// fresh VMM, leaving vCPUs PAUSED. The caller must inspect
+    /// [`restored_device_model`](Self::restored_device_model) and run
+    /// the device-model guard before calling
+    /// [`resume`](Self::resume).
+    fn load_snapshot_paused(&self, dir: &Path) -> Result<()>;
+
+    /// The restored VM's device model, read after load, before
+    /// resume — the input to `assert_vsock_only_device_model`.
+    fn restored_device_model(&self) -> Result<crate::microvm::RestoredDeviceModel>;
+
+    /// Resume vCPUs. Only called after the device-model guard passes;
+    /// calling this before the guard runs would let a NIC-carrying
+    /// restore execute.
+    fn resume(&self) -> Result<()>;
+
+    /// Best-effort teardown of a VMM left paused by
+    /// [`load_snapshot_paused`](Self::load_snapshot_paused) — used
+    /// when the device-model guard refuses the restore, so the
+    /// never-resumed VMM does not linger. Errors here are swallowed
+    /// by the caller; this exists to clean up, not to report status.
+    fn teardown_paused(&self) -> Result<()>;
 }
 
 /// Pause + seal one VM's snapshot. Returns the sealed sidecar so
@@ -158,9 +188,11 @@ pub fn pause_and_seal<IO: SnapshotIO + ?Sized>(vm_name: &str, io: &IO) -> Result
     Ok(sidecar)
 }
 
-/// Verify + load one VM's snapshot. Honours
-/// `MVM_ALLOW_STALE_SNAPSHOT=1` for both the version-mismatch and
-/// the epoch-rollback branches; refuses both by default.
+/// Verify + load one VM's own instance snapshot (`~/.mvm/instances/<vm-name>/snapshot/`).
+/// Thin wrapper around [`verify_and_resume_from_dir`] for the common case
+/// where the sealed envelope lives at the canonical per-VM path; the fork and
+/// template-restore paths hold their sealed envelope elsewhere and call
+/// [`verify_and_resume_from_dir`] directly.
 ///
 /// Returns the verified sidecar so the caller can audit it before
 /// resuming Firecracker.
@@ -169,6 +201,27 @@ pub fn verify_and_resume<IO: SnapshotIO + ?Sized>(
     io: &IO,
 ) -> Result<IntegritySidecar> {
     let dir = snapshot_dir(vm_name);
+    verify_and_resume_from_dir(&dir, io)
+}
+
+/// Verify + load a sealed snapshot at a caller-supplied `dir`, then run the
+/// device-model guard before resuming vCPUs.
+///
+/// Honours `MVM_ALLOW_STALE_SNAPSHOT=1` for both the version-mismatch and the
+/// epoch-rollback branches; refuses both by default.
+///
+/// Ordering is the security property this function exists to enforce:
+/// verify the HMAC envelope → decrypt → load the snapshot PAUSED → read the
+/// restored device model → refuse (and tear down) on any NIC → only then
+/// resume vCPUs. A NIC-carrying snapshot must never execute a single guest
+/// instruction, so `resume` is reachable only past the guard.
+///
+/// Returns the verified sidecar so the caller can audit it before
+/// resuming Firecracker.
+pub fn verify_and_resume_from_dir<IO: SnapshotIO + ?Sized>(
+    dir: &Path,
+    io: &IO,
+) -> Result<IntegritySidecar> {
     if !dir.exists() {
         bail!(
             "no instance snapshot directory at {} — pause the VM first",
@@ -179,7 +232,7 @@ pub fn verify_and_resume<IO: SnapshotIO + ?Sized>(
         mvm_core::crypto::snapshot_hmac::default_key_path(Path::new(&mvm_core::config::mvm_home()));
     let key = load_or_init_key(&key_path)
         .with_context(|| format!("loading HMAC key {}", key_path.display()))?;
-    let files = files_in(&dir);
+    let files = files_in(dir);
     let mvmctl_version = env!("CARGO_PKG_VERSION");
     let allow_stale = std::env::var("MVM_ALLOW_STALE_SNAPSHOT").as_deref() == Ok("1");
 
@@ -187,7 +240,7 @@ pub fn verify_and_resume<IO: SnapshotIO + ?Sized>(
     let min_epoch = store.load();
 
     let sidecar = match verify(
-        &dir,
+        dir,
         &files,
         min_epoch,
         mvmctl_version,
@@ -195,17 +248,31 @@ pub fn verify_and_resume<IO: SnapshotIO + ?Sized>(
         allow_stale,
     ) {
         Ok(s) => s,
-        Err(e) => return Err(map_verify_error(e, &dir)),
+        Err(e) => return Err(map_verify_error(e, dir)),
     };
 
     // HMAC verify passed → the artifacts on disk are the bytes that
     // were sealed. If they're AES-GCM-encrypted (MVSE magic),
     // decrypt them in place before handing to Firecracker.
-    decrypt_artifacts_if_encrypted(&dir)
+    decrypt_artifacts_if_encrypted(dir)
         .with_context(|| format!("decrypting snapshot artifacts at {}", dir.display()))?;
 
-    io.load_snapshot(&dir)
-        .with_context(|| format!("Firecracker load_snapshot({})", dir.display()))?;
+    io.load_snapshot_paused(dir)
+        .with_context(|| format!("load_snapshot_paused({})", dir.display()))?;
+
+    let model = io
+        .restored_device_model()
+        .with_context(|| "reading restored device model")?;
+    if let Err(e) = crate::microvm::assert_vsock_only_device_model(&model) {
+        // Fail closed: never resume a NIC-carrying restore. Best-effort tear
+        // down the paused VMM so it does not linger — the caller's `dir`
+        // stays sealed on disk, so a retry (after e.g. re-sealing a clean
+        // snapshot) is still possible.
+        let _ = io.teardown_paused();
+        return Err(e).context("restore refused by device-model guard");
+    }
+
+    io.resume().with_context(|| "resume after restore")?;
     Ok(sidecar)
 }
 
@@ -642,7 +709,11 @@ fn map_verify_error(err: VerifyError, dir: &Path) -> anyhow::Error {
 
 /// `SnapshotIO` impl that just writes canned bytes. Used by the
 /// unit tests below and by integration tests that want to exercise
-/// the seal/verify flow without a live Firecracker.
+/// the seal/verify flow without a live Firecracker. Always reports a
+/// vsock-only (no-NIC) restored device model — tests that need to
+/// drive the guard's refusal path use the `SpyIO` double instead,
+/// since exercising the refuse/teardown/no-resume ordering needs
+/// call-order observation `CannedIO` doesn't provide.
 pub struct CannedIO {
     pub vmstate_bytes: Vec<u8>,
     pub mem_bytes: Vec<u8>,
@@ -654,7 +725,18 @@ impl SnapshotIO for CannedIO {
         std::fs::write(dir.join(MEM_FILENAME), &self.mem_bytes)?;
         Ok(())
     }
-    fn load_snapshot(&self, _dir: &Path) -> Result<()> {
+    fn load_snapshot_paused(&self, _dir: &Path) -> Result<()> {
+        Ok(())
+    }
+    fn restored_device_model(&self) -> Result<crate::microvm::RestoredDeviceModel> {
+        Ok(crate::microvm::RestoredDeviceModel {
+            network_interfaces: Vec::new(),
+        })
+    }
+    fn resume(&self) -> Result<()> {
+        Ok(())
+    }
+    fn teardown_paused(&self) -> Result<()> {
         Ok(())
     }
 }
@@ -708,7 +790,7 @@ impl SnapshotIO for FirecrackerIO {
         Ok(())
     }
 
-    fn load_snapshot(&self, dir: &Path) -> Result<()> {
+    fn load_snapshot_paused(&self, dir: &Path) -> Result<()> {
         let vm_dir = self
             .socket_path
             .parent()
@@ -731,17 +813,53 @@ impl SnapshotIO for FirecrackerIO {
         crate::microvm::start_vm_firecracker(&vm_dir.to_string_lossy(), &socket_str)
             .with_context(|| "starting fresh Firecracker for snapshot restore")?;
 
+        // `resume_vm: false` — vCPUs stay paused so the device-model guard in
+        // `verify_and_resume_from_dir` can inspect `GET /vm/config` before
+        // anything executes.
         let body = serde_json::json!({
             "snapshot_path": format!("{}/{}", dir.display(), VMSTATE_FILENAME),
             "mem_backend": {
                 "backend_type": "File",
                 "backend_path": format!("{}/{}", dir.display(), MEM_FILENAME),
             },
-            "resume_vm": true,
+            "resume_vm": false,
         })
         .to_string();
         crate::microvm::api_put_socket(&socket_str, "/snapshot/load", &body)
             .with_context(|| "PUT /snapshot/load")?;
+        Ok(())
+    }
+
+    fn restored_device_model(&self) -> Result<crate::microvm::RestoredDeviceModel> {
+        self.ensure_socket()?;
+        let body = run_curl_capture(&self.socket_path, "GET", "/vm/config")
+            .with_context(|| "GET /vm/config")?;
+        serde_json::from_str(&body).with_context(|| "parsing GET /vm/config response")
+    }
+
+    fn resume(&self) -> Result<()> {
+        self.ensure_socket()?;
+        run_curl(&self.socket_path, "PATCH", "/vm", r#"{"state":"Resumed"}"#)
+            .with_context(|| "PATCH /vm Resumed")?;
+        Ok(())
+    }
+
+    fn teardown_paused(&self) -> Result<()> {
+        // Best-effort: this restore attempt's fresh FC process must not
+        // linger paused once the guard has refused it — a NIC-carrying VMM
+        // sitting paused is exactly the state this guard exists to prevent
+        // from ever resuming. Never surfaced to the caller (`verify_and_resume_from_dir`
+        // discards this `Result`), so any failure here is logged, not propagated.
+        let Some(vm_dir) = self.socket_path.parent() else {
+            return Ok(());
+        };
+        let pid_file = vm_dir.join("fc.pid");
+        if !pid_file.exists() {
+            return Ok(());
+        }
+        let pid_file_str = pid_file.to_string_lossy();
+        let q_pid = shell_quote(&pid_file_str);
+        let _ = run_in_vm(&format!("sudo kill -9 \"$(cat {q_pid})\" 2>/dev/null"));
         Ok(())
     }
 }
@@ -769,6 +887,31 @@ fn run_curl(socket: &Path, method: &str, endpoint: &str, body: &str) -> Result<(
         );
     }
     Ok(())
+}
+
+/// Like [`run_curl`] but returns the captured response body instead of
+/// discarding it. `run_curl` only asserts the request succeeded; the
+/// device-model guard needs the actual `GET /vm/config` body to parse a
+/// [`crate::microvm::RestoredDeviceModel`] out of.
+fn run_curl_capture(socket: &Path, method: &str, endpoint: &str) -> Result<String> {
+    use std::process::Command;
+    let url = format!("http://localhost{endpoint}");
+    let out = Command::new("curl")
+        .arg("--unix-socket")
+        .arg(socket)
+        .arg("-fsS")
+        .arg("-X")
+        .arg(method)
+        .arg(&url)
+        .output()
+        .with_context(|| format!("invoking curl for {method} {endpoint}"))?;
+    if !out.status.success() {
+        bail!(
+            "{method} {endpoint} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }
 
 #[cfg(test)]
@@ -900,6 +1043,110 @@ mod tests {
         let _g = DataDirGuard::new();
         let err = verify_and_resume("nope", &canned()).unwrap_err();
         assert!(err.to_string().contains("no instance snapshot directory"));
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Device-model guard ordering (load_paused → guard → resume)
+    // ──────────────────────────────────────────────────────────────
+
+    /// `SnapshotIO` double that logs call order and lets a test force a
+    /// NIC-carrying restored device model — so the guard's refusal path
+    /// (teardown, never resume) and the load→guard→resume ordering are
+    /// unit-testable without a live Firecracker. `CannedIO` can't do this: it
+    /// always reports a no-NIC model and doesn't observe call order.
+    struct SpyIO {
+        nic_on_restore: bool,
+        calls: std::cell::RefCell<Vec<&'static str>>,
+    }
+
+    impl SpyIO {
+        fn new(nic_on_restore: bool) -> Self {
+            Self {
+                nic_on_restore,
+                calls: std::cell::RefCell::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<&'static str> {
+            self.calls.borrow().clone()
+        }
+    }
+
+    impl SnapshotIO for SpyIO {
+        fn create_snapshot(&self, dir: &Path) -> Result<()> {
+            std::fs::write(dir.join(VMSTATE_FILENAME), b"spy-vmstate")?;
+            std::fs::write(dir.join(MEM_FILENAME), b"spy-mem")?;
+            Ok(())
+        }
+        fn load_snapshot_paused(&self, _dir: &Path) -> Result<()> {
+            self.calls.borrow_mut().push("load_paused");
+            Ok(())
+        }
+        fn restored_device_model(&self) -> Result<crate::microvm::RestoredDeviceModel> {
+            self.calls.borrow_mut().push("restored_device_model");
+            let network_interfaces = if self.nic_on_restore {
+                vec![serde_json::json!({"iface_id": "eth0", "host_dev_name": "tap0"})]
+            } else {
+                Vec::new()
+            };
+            Ok(crate::microvm::RestoredDeviceModel { network_interfaces })
+        }
+        fn resume(&self) -> Result<()> {
+            self.calls.borrow_mut().push("resume");
+            Ok(())
+        }
+        fn teardown_paused(&self) -> Result<()> {
+            self.calls.borrow_mut().push("teardown_paused");
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn verify_and_resume_refuses_nic_on_restore() {
+        let _g = DataDirGuard::new();
+        pause_and_seal("vm-nic", &canned()).unwrap();
+        let spy = SpyIO::new(true);
+        let err = verify_and_resume("vm-nic", &spy).unwrap_err();
+        assert!(err.to_string().contains("device-model guard"), "got: {err}");
+        let calls = spy.calls();
+        assert!(
+            calls.contains(&"teardown_paused"),
+            "a refused restore must tear down the paused VMM: {calls:?}"
+        );
+        assert!(
+            !calls.contains(&"resume"),
+            "resume must never run when the guard refuses: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn verify_and_resume_resumes_vsock_only_restore() {
+        let _g = DataDirGuard::new();
+        pause_and_seal("vm-clean", &canned()).unwrap();
+        let spy = SpyIO::new(false);
+        verify_and_resume("vm-clean", &spy).expect("a no-NIC restore must resume");
+        let calls = spy.calls();
+        assert!(
+            calls.contains(&"resume"),
+            "a clean restore must resume: {calls:?}"
+        );
+        assert!(
+            !calls.contains(&"teardown_paused"),
+            "a clean restore must not tear down: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn load_guard_resume_ordering() {
+        let _g = DataDirGuard::new();
+        pause_and_seal("vm-order", &canned()).unwrap();
+        let spy = SpyIO::new(false);
+        verify_and_resume("vm-order", &spy).unwrap();
+        assert_eq!(
+            spy.calls(),
+            vec!["load_paused", "restored_device_model", "resume"],
+            "the guard must run strictly between load and resume"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What this is

Wires the no-NIC device-model guard (added in the base PR) into the live Firecracker restore path, as defense-in-depth. It splits `SnapshotIO` load-from-resume so the guard runs **after** the snapshot loads but **before** vCPUs resume, and refuses (tearing down the paused VMM) any restored device model that carries a network interface — a NIC would bypass the vsock-only egress boundary.

**Stacked on #1855** (base is its branch); GitHub will retarget this to `main` once #1855 merges.

## Change

- `SnapshotIO`: `load_snapshot` (atomic load+resume) → `load_snapshot_paused` + `restored_device_model` (`GET /vm/config`) + `resume` + `teardown_paused`.
- The guard `assert_vsock_only_device_model` is now enforced inside `verify_and_resume`/`verify_and_resume_from_dir` — the single canonical restore that the live `mvmctl pause`/`resume` path calls. There is no code path that reaches `resume()` without passing the guard; on refusal the paused VMM is torn down and restore returns an error.
- Tests (`SpyIO` double): refusal path (NIC → `Err`, `teardown` called, `resume` **not** called), happy path, and a strict load→model→resume ordering assertion.

## Scope (deliberate)

The disabled fork and template restore entry points **stay disabled** here. Routing them through the instance-snapshot verifier would drop the template's Ed25519 signature check and fail closed on fork checkpoints (which are integrity-verified by the checkpoint lineage, not HMAC-sealed). Re-enabling them — pairing each path's own integrity mechanism with this same guard ordering — is a separate follow-up. This PR is the guard + its enforcement on the one path that legitimately uses the instance-snapshot mechanism.

## Verification

- Reviewed for the security property (no resume-before-guard / resume-on-error path).
- **Live-validated on real Firecracker v1.14.1 + `/dev/kvm`:** configured a VM with a NIC → snapshot → load with `resume_vm:false` → `GET /vm/config` returned `"network-interfaces":[{"iface_id":"eth0",...}]`. A snapshot-captured NIC is surfaced post-restore exactly as `RestoredDeviceModel` parses it, so the guard detects and refuses it before resume.
- No existing security claim is relaxed; the no-OS competitor tier is referred to obliquely; no spec references in code.

## Follow-ups

- Un-bail fork + template restore, each with its own integrity check + this guard.
- Harden the single-shot post-restore reseed with a retry/poll.
- Tear down the paused VMM on pre-guard error branches too (currently only on guard refusal — fail-closed-safe either way).
