### PR TITLE
feat(mvm-runtime): un-bail Firecracker fork restore behind the no-NIC guard

### DIFF
--- a/crates/mvm-runtime/src/microvm/snapshot.rs
+++ b/crates/mvm-runtime/src/microvm/snapshot.rs
@@ -5,23 +5,27 @@
 //! loading a snapshot paused and resuming it — see there for the full
 //! ordering. That path backs the live `mvmctl pause`/`resume` cycle today.
 //!
-//! The template and fork restore entry points below stay refused. Neither
-//! one's sealed content is verified by that same instance-HMAC path: a
-//! template snapshot carries its own Ed25519 + HMAC sidecar (a stronger,
-//! separate check), and a forked checkpoint is content-addressed and
-//! audit-chain-verified upstream of these calls (see the checkpoint lineage
-//! module) rather than instance-HMAC-sealed. Routing either through the
-//! instance verifier would either silently drop a check it currently gets or
-//! fail closed on content that verifier was never meant to see. Re-enabling
-//! them needs a design that keeps each path's own integrity check and adds
-//! the same load-paused → read-device-model → guard → resume ordering on top
-//! of it.
+//! `warm_restore_instance_from_path` reuses the same load → guard → resume
+//! ordering via `guarded_load_resume`, but skips the instance-snapshot HMAC
+//! verify: its caller (the fork restore path) already established the
+//! content's integrity upstream via the checkpoint lineage's content-address
+//! and audit-chain checks, so a second verifier here would either be
+//! redundant or fail closed on content it was never meant to see.
+//!
+//! The template restore entry point and the bare `warm_restore_instance`
+//! stay refused. A template snapshot carries its own Ed25519 + HMAC sidecar
+//! (a separate, stronger check) that isn't wired up yet; `warm_restore_instance`
+//! has no caller. Re-enabling either needs a design that keeps its own
+//! integrity check and adds the same guard ordering on top of it.
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use tracing::instrument;
 
 use crate::base::shell::shell_quote;
+use crate::vm::instance_snapshot::{
+    FirecrackerIO, VsockPostRestoreSignal, guarded_load_resume, signal_post_restore,
+};
 
 use super::daemon::api_put_socket;
 use super::{abs_vms_dir, require_linux_env};
@@ -48,16 +52,14 @@ pub fn restore_from_template_snapshot(
     );
 }
 
-/// Refuse live-memory restore entry points.
+/// Refuse the bare live-memory restore entry point.
 ///
-/// A restored VMM can reintroduce devices captured in an older snapshot. The
-/// fork path's checkpoint content is content-addressed and audit-chain
-/// verified upstream of this call (the checkpoint lineage module), not
-/// sealed by the instance-snapshot HMAC envelope the no-NIC guard runs
-/// behind — so warm restore stays refused here until a fork-restore design
-/// runs that same guard ordering (load paused, read the restored device
-/// model, refuse on a NIC, only then resume) against the lineage's own
-/// content-address / audit-chain integrity instead of the instance verifier.
+/// Unlike [`warm_restore_instance_from_path`], this resolves its own snapshot
+/// directory (the canonical per-instance `~/.mvm/instances/<name>/snapshot/`)
+/// rather than taking a caller-verified one, so it would need its own
+/// instance-snapshot HMAC verify wired in before it could reuse
+/// `guarded_load_resume`. It has no caller today — stays refused until that
+/// design lands.
 pub fn warm_restore_instance(
     name: &str,
     _token: [u8; mvm_core::crypto::vmgenid::GENID_BYTES],
@@ -67,14 +69,63 @@ pub fn warm_restore_instance(
     )
 }
 
+/// Warm-restore `name` from the sealed content at `snapshot_dir` into its
+/// running (paused) Firecracker, then best-effort deliver `token` so the
+/// guest reseeds.
+///
+/// Callers other than the fork restore path do not exist yet. The fork
+/// path's checkpoint content is content-addressed and audit-chain verified
+/// upstream of this call — by `verify_content` and
+/// `verify_checkpoint_against_chain` inside the checkpoint lineage module,
+/// before the checkpoint triple is even cloned into `snapshot_dir` — so this
+/// function deliberately does NOT run the instance-snapshot HMAC verifier
+/// (`verify_and_resume_from_dir`) on that content: it was never sealed by
+/// that envelope, and re-running an unrelated verifier against it would fail
+/// closed on legitimate fork content. It goes straight to
+/// [`guarded_load_resume`], which still runs the no-NIC device-model guard
+/// between load and resume.
 pub fn warm_restore_instance_from_path(
     name: &str,
-    _snapshot_dir: &str,
-    _token: [u8; mvm_core::crypto::vmgenid::GENID_BYTES],
+    snapshot_dir: &str,
+    token: [u8; mvm_core::crypto::vmgenid::GENID_BYTES],
 ) -> Result<mvm_core::vm_backend::ReseedStatus> {
-    anyhow::bail!(
-        "Firecracker memory restore is disabled; use the vsock workload runner for '{name}'"
-    )
+    // Defense in depth: `name` is interpolated into shell commands inside
+    // `load_snapshot_paused` (`FirecrackerIO` shells out to stop a stale
+    // paused process and start a fresh one). The CLI validates the name
+    // earlier, but this is a `pub fn` reachable from other crates — re-check
+    // at the boundary so no caller can smuggle shell/JSON metacharacters in.
+    mvm_core::naming::validate_vm_name(name)
+        .with_context(|| format!("warm-restore refused invalid VM name {name:?}"))?;
+    require_linux_env()?;
+
+    let abs_vms = abs_vms_dir();
+    let vm_dir = format!("{}/{name}", abs_vms.trim());
+    let socket = std::path::PathBuf::from(format!("{vm_dir}/fc.socket"));
+    let io = FirecrackerIO::new(socket);
+
+    guarded_load_resume(&io, std::path::Path::new(snapshot_dir))
+        .with_context(|| format!("warm-restore of '{name}' from {snapshot_dir}"))?;
+
+    // Delivering the reseed token is best-effort: the guest agent takes a
+    // beat to re-accept on the recreated vsock after the fresh VMM starts, so
+    // a transport failure here must not undo an otherwise-successful
+    // restore — the VM is already up and resumed past the guard. The fork
+    // caller passes an all-zero token (no rotation) and delivers the real
+    // token + verb grant over vsock separately once it observes the agent is
+    // reachable; a zero token's honest outcome is `NotRotated`, not `Rotated`.
+    let reseed = match signal_post_restore(name, &VsockPostRestoreSignal { token }) {
+        Ok(outcome) if outcome.reseeded => mvm_core::vm_backend::ReseedStatus::Rotated,
+        Ok(_) => mvm_core::vm_backend::ReseedStatus::NotRotated,
+        Err(e) => {
+            tracing::warn!(
+                name,
+                error = %e,
+                "warm-restore: post-restore signal undelivered (VM is resumed)"
+            );
+            mvm_core::vm_backend::ReseedStatus::Undelivered
+        }
+    };
+    Ok(reseed)
 }
 
 pub fn create_snapshot_files(

--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -257,6 +257,29 @@ pub fn verify_and_resume_from_dir<IO: SnapshotIO + ?Sized>(
     decrypt_artifacts_if_encrypted(dir)
         .with_context(|| format!("decrypting snapshot artifacts at {}", dir.display()))?;
 
+    guarded_load_resume(io, dir)?;
+    Ok(sidecar)
+}
+
+/// Load a sealed snapshot at `dir` into a fresh VMM, then run the no-NIC
+/// device-model guard strictly between load and resume — resuming vCPUs only
+/// if the guard passes.
+///
+/// Factored out of [`verify_and_resume_from_dir`] so a caller whose content
+/// integrity is already established by a different mechanism (the fork
+/// restore path verifies a checkpoint's content-address and audit-chain
+/// lineage upstream, not the instance-snapshot HMAC envelope) can reuse the
+/// load → guard → resume ordering without layering a second, wrong integrity
+/// check on top. `verify_and_resume_from_dir` is the only caller that also
+/// runs the HMAC verify + decrypt step first; this function does neither —
+/// callers are responsible for establishing their own content integrity
+/// before calling it.
+///
+/// Fail closed: never resume a NIC-carrying restore. Best-effort tear down
+/// the paused VMM on refusal so it does not linger — the caller's `dir` stays
+/// sealed on disk, so a retry (after e.g. re-sealing a clean snapshot) is
+/// still possible.
+pub fn guarded_load_resume<IO: SnapshotIO + ?Sized>(io: &IO, dir: &Path) -> Result<()> {
     io.load_snapshot_paused(dir)
         .with_context(|| format!("load_snapshot_paused({})", dir.display()))?;
 
@@ -264,16 +287,11 @@ pub fn verify_and_resume_from_dir<IO: SnapshotIO + ?Sized>(
         .restored_device_model()
         .with_context(|| "reading restored device model")?;
     if let Err(e) = crate::microvm::assert_vsock_only_device_model(&model) {
-        // Fail closed: never resume a NIC-carrying restore. Best-effort tear
-        // down the paused VMM so it does not linger — the caller's `dir`
-        // stays sealed on disk, so a retry (after e.g. re-sealing a clean
-        // snapshot) is still possible.
         let _ = io.teardown_paused();
         return Err(e).context("restore refused by device-model guard");
     }
 
-    io.resume().with_context(|| "resume after restore")?;
-    Ok(sidecar)
+    io.resume().with_context(|| "resume after restore")
 }
 
 // ============================================================================
@@ -1146,6 +1164,44 @@ mod tests {
             spy.calls(),
             vec!["load_paused", "restored_device_model", "resume"],
             "the guard must run strictly between load and resume"
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // `guarded_load_resume` — the fork-restore path's witness. Fork restore
+    // calls this directly (no HMAC verify — its integrity is established
+    // upstream by the checkpoint lineage's content-address + audit-chain
+    // check), so these exercise the guard reached via that bare entry point
+    // rather than only through `verify_and_resume`.
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn fork_restore_refuses_nic() {
+        let spy = SpyIO::new(true);
+        let dir = tempfile::tempdir().unwrap();
+        let err = guarded_load_resume(&spy, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("device-model guard"), "got: {err}");
+        let calls = spy.calls();
+        assert!(
+            calls.contains(&"teardown_paused"),
+            "a refused restore must tear down the paused VMM: {calls:?}"
+        );
+        assert!(
+            !calls.contains(&"resume"),
+            "resume must never run when the guard refuses: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn guarded_load_resume_resumes_when_vsock_only() {
+        let spy = SpyIO::new(false);
+        let dir = tempfile::tempdir().unwrap();
+        guarded_load_resume(&spy, dir.path()).expect("a no-NIC restore must resume");
+        let calls = spy.calls();
+        assert_eq!(
+            calls,
+            vec!["load_paused", "restored_device_model", "resume"],
+            "load, guard, then resume — in order"
         );
     }
 


### PR DESCRIPTION
## What this is

Re-enables the Firecracker **fork** restore path behind the no-NIC device-model guard, so a `vm_full` checkpoint can be CoW-forked into a fresh child VM that actually restores. Builds on the guard-hardening in the base PR.

**Stacked on #1858** (base is its branch); GitHub retargets this once #1858 lands.

## Change

- Factors `guarded_load_resume(io, dir)` out of `verify_and_resume_from_dir` — `load_snapshot_paused` → `restored_device_model` (`GET /vm/config`) → `assert_vsock_only_device_model` (teardown + error on refusal) → `resume`. The pause/resume path is a **pure refactor** (behaviourally identical: HMAC verify + decrypt + `guarded_load_resume`).
- Un-bails `warm_restore_instance_from_path` to call `guarded_load_resume` **directly, without the HMAC verify** — because fork content is already integrity-verified upstream by `fork_vm_full_fc` (`verify_content` sha256 content-address + `verify_checkpoint_against_chain` against the signed audit chain) before `restore_fork` is ever called. Re-running the instance-snapshot HMAC verifier on fork content (which has no `integrity.json`/`.epoch`) would fail closed on legitimate forks.
- `name` is validated (`validate_vm_name`, strict `[a-z0-9-]`) before it can interpolate into any shell command.

## Scope (deliberate)

The bare `warm_restore_instance` (no caller) and `restore_from_template_snapshot` stay `bail!`. Template restore is a further follow-up (it needs its own Ed25519 `base::snapshot_integrity` verify paired with `guarded_load_resume`).

## Verification

- Reviewed (security): pure-refactor invariant holds; fork ordering is fail-closed (no `resume()` without passing the guard); the full caller chain was traced to confirm no path reaches `warm_restore_instance_from_path` without the upstream lineage/audit-chain verification.
- Guard mechanics already **live-validated on real Firecracker v1.14.1 + `/dev/kvm`** (base PR): a snapshot-captured NIC surfaces in the restored `GET /vm/config` and is refused before resume.
- `fork_restore_refuses_nic` exercises the guard via `guarded_load_resume` (NIC → error, teardown called, resume not called).

## Follow-ups

- Full live fork e2e on KVM (checkpoint a `vm_full` VM → fork → child reachable) — produces the first warm-start number.
- Harden the single-shot post-restore reseed with a retry/poll.
- Template restore un-bail with Ed25519 integrity + this guard.
- Consider moving the content-address/audit-chain check onto the restorer seam for defense-in-depth.
