### PR TITLE
fix(vmm): validate virtqueue geometry so a hostile QueueNum can't panic the host

### DIFF
--- a/crates/mvm-runtime/src/vmm/mod.rs
+++ b/crates/mvm-runtime/src/vmm/mod.rs
@@ -29,3 +29,56 @@ pub mod vsock;
 pub(crate) mod vsock_handlers;
 mod vsock_io;
 pub(crate) mod vsock_transport;
+
+/// Maximum virtqueue size advertised to the guest via the `QueueNumMax`
+/// register, shared by every virtio-mmio device in this module.
+///
+/// The split-virtqueue layout requires the driver-chosen queue size to be a
+/// power of two not exceeding this maximum. See [`validated_queue_size`].
+pub(crate) const QUEUE_SIZE_MAX: u32 = 256;
+
+/// Validate a guest-programmed `QueueNum` into a usable ring size, or `None`
+/// when the geometry is illegal.
+///
+/// A guest programs `QueueNum` as a raw 32-bit MMIO register, but the devices
+/// index the ring with `slot % size` where `size` is a `u16`. A naive
+/// `queue_num as u16` cast truncates, so a value whose low 16 bits are zero —
+/// e.g. `0x1_0000` — is nonzero yet becomes `0`, and `slot % 0` divides by zero
+/// and aborts the host process in a handful of register writes. Accepting only a
+/// power-of-two size within the advertised maximum keeps every conformant guest
+/// byte-identical (real ring sizes are always such) while making a zero (or
+/// otherwise illegal) ring size unrepresentable in the service paths; an illegal
+/// ring is simply left unserviced.
+pub(crate) fn validated_queue_size(num: u32) -> Option<u16> {
+    if num != 0 && num <= QUEUE_SIZE_MAX && num.is_power_of_two() {
+        Some(num as u16)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validated_queue_size;
+
+    #[test]
+    fn accepts_power_of_two_sizes_within_the_maximum() {
+        assert_eq!(validated_queue_size(1), Some(1));
+        assert_eq!(validated_queue_size(2), Some(2));
+        assert_eq!(validated_queue_size(128), Some(128));
+        assert_eq!(validated_queue_size(256), Some(256));
+    }
+
+    #[test]
+    fn rejects_zero_oversized_and_non_power_of_two_sizes() {
+        assert_eq!(validated_queue_size(0), None);
+        assert_eq!(validated_queue_size(3), None);
+        assert_eq!(validated_queue_size(300), None);
+        // A power of two, but above the advertised maximum.
+        assert_eq!(validated_queue_size(512), None);
+        // Nonzero, but the low 16 bits are zero — the truncation trap.
+        assert_eq!(validated_queue_size(0x1_0000), None);
+        assert_eq!(validated_queue_size(0xffff_0000), None);
+        assert_eq!(validated_queue_size(u32::MAX), None);
+    }
+}

--- a/crates/mvm-runtime/src/vmm/virtio.rs
+++ b/crates/mvm-runtime/src/vmm/virtio.rs
@@ -46,7 +46,6 @@ const R_QUEUE_DEVICE_HI: u64 = 0x0a4;
 const R_CONFIG: u64 = 0x100; // block config: capacity (u64 sectors) at +0
 
 const MMIO_LEN: u64 = 0x200;
-const QUEUE_SIZE_MAX: u32 = 256;
 const SECTOR: u64 = 512;
 
 const VIRTQ_DESC_F_NEXT: u16 = 1;
@@ -263,7 +262,7 @@ impl VirtioBlk {
             R_DEVICE_FEATURES if self.device_features_sel == 1 => 1,
             R_DEVICE_FEATURES if self.disk.read_only() => VIRTIO_BLK_F_RO,
             R_DEVICE_FEATURES => 0,
-            R_QUEUE_NUM_MAX => QUEUE_SIZE_MAX,
+            R_QUEUE_NUM_MAX => super::QUEUE_SIZE_MAX,
             R_QUEUE_READY => self.queue_ready,
             R_INTERRUPT_STATUS => self.interrupt_status,
             R_STATUS => self.status,
@@ -302,10 +301,12 @@ impl VirtioBlk {
     /// Drain the available ring, servicing each block request. Returns whether
     /// any request completed (and thus the guest needs an interrupt).
     fn process_queue(&mut self) -> bool {
-        if self.queue_ready == 0 || self.queue_num == 0 {
+        if self.queue_ready == 0 {
             return false;
         }
-        let qsz = self.queue_num as u16;
+        let Some(qsz) = super::validated_queue_size(self.queue_num) else {
+            return false;
+        };
         let avail_idx = self.rd_u16(self.avail + 2);
         let debug = std::env::var_os("MVM_HVF_VIRTIO_DEBUG").is_some();
         if debug {
@@ -544,7 +545,7 @@ impl VirtioFs {
             // Only VIRTIO_F_VERSION_1 (high feature word); no low-word features.
             R_DEVICE_FEATURES if self.device_features_sel == 1 => 1,
             R_DEVICE_FEATURES => 0,
-            R_QUEUE_NUM_MAX => QUEUE_SIZE_MAX,
+            R_QUEUE_NUM_MAX => super::QUEUE_SIZE_MAX,
             R_QUEUE_READY => self.q().ready,
             R_INTERRUPT_STATUS => self.interrupt_status,
             R_STATUS => self.status,
@@ -605,10 +606,12 @@ impl VirtioFs {
             return false;
         }
         let q = self.queues[qidx];
-        if q.ready == 0 || q.num == 0 {
+        if q.ready == 0 {
             return false;
         }
-        let qsz = q.num as u16;
+        let Some(qsz) = super::validated_queue_size(q.num) else {
+            return false;
+        };
         let avail_idx = self.mem.rd_u16(q.avail + 2);
         let mut last_avail = q.last_avail;
         let mut serviced = false;
@@ -953,5 +956,86 @@ mod tests {
         let mut w = dev(vec![0u8; 512]);
         w.write(R_DEVICE_FEATURES_SEL, 0);
         assert_eq!(w.read(R_DEVICE_FEATURES) as u32, 0);
+    }
+
+    /// Queue sizes a hostile guest can program that are illegal geometry: zero,
+    /// values whose low 16 bits are zero (which truncate to a zero `u16`), and
+    /// sizes above the advertised maximum or not a power of two.
+    const ILLEGAL_QUEUE_SIZES: [u32; 6] = [0, 0x1_0000, 0x2_0000, 0xffff_0000, 300, 512];
+
+    /// Program a virtio-blk request queue with raw `QueueNum` and an `avail_idx`
+    /// of 1 (so the drain loop body, which indexes with `last % qsz`, runs), then
+    /// notify. Returns whether the device signalled an interrupt (serviced the
+    /// ring). Must never panic.
+    fn blk_notify_with_queue_num(num: u32) -> bool {
+        const BASE: u64 = 0x4000_0000;
+        let mut ram = vec![0u8; 0x10000];
+        ram[0x2002..0x2004].copy_from_slice(&1u16.to_le_bytes());
+        // SAFETY: ram outlives the device for the duration of this call.
+        let mut d = unsafe {
+            VirtioBlk::new(
+                0x0a00_0000,
+                48,
+                ram.as_mut_ptr(),
+                BASE,
+                ram.len(),
+                DiskImage::mem(vec![0u8; 4096]),
+            )
+        };
+        d.write(R_QUEUE_NUM, u64::from(num));
+        d.write(R_QUEUE_DESC_LO, (BASE + 0x1000) & 0xffff_ffff);
+        d.write(R_QUEUE_DRIVER_LO, (BASE + 0x2000) & 0xffff_ffff);
+        d.write(R_QUEUE_DEVICE_LO, (BASE + 0x3000) & 0xffff_ffff);
+        d.write(R_QUEUE_READY, 1);
+        d.write(R_QUEUE_NOTIFY, 0)
+    }
+
+    #[test]
+    fn virtio_blk_rejects_queue_size_that_truncates_to_zero() {
+        assert!(!blk_notify_with_queue_num(0x1_0000));
+    }
+
+    #[test]
+    fn virtio_blk_rejects_illegal_queue_geometry() {
+        for num in ILLEGAL_QUEUE_SIZES {
+            assert!(
+                !blk_notify_with_queue_num(num),
+                "blk queue size {num:#x} must not be serviced"
+            );
+        }
+    }
+
+    /// Program the virtio-fs request queue (index 1) with raw `QueueNum` and an
+    /// `avail_idx` of 1, then notify. Returns whether an interrupt was signalled.
+    /// Must never panic.
+    fn fs_notify_with_queue_num(num: u32) -> bool {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ram = vec![0u8; 0x10000];
+        ram[0x2002..0x2004].copy_from_slice(&1u16.to_le_bytes());
+        let ptr = ram.as_mut_ptr();
+        // SAFETY: ram outlives fs for the duration of this call.
+        let mut fs = unsafe { VirtioFs::new(0, 5, ptr, 0, ram.len(), dir.path().to_path_buf()) };
+        fs.write(R_QUEUE_SEL, 1);
+        fs.write(R_QUEUE_NUM, u64::from(num));
+        fs.write(R_QUEUE_DESC_LO, 0x1000);
+        fs.write(R_QUEUE_DRIVER_LO, 0x2000);
+        fs.write(R_QUEUE_DEVICE_LO, 0x3000);
+        fs.write(R_QUEUE_READY, 1);
+        fs.write(R_QUEUE_NOTIFY, 1)
+    }
+
+    #[test]
+    fn virtio_fs_rejects_queue_size_that_truncates_to_zero() {
+        assert!(!fs_notify_with_queue_num(0x1_0000));
+    }
+
+    #[test]
+    fn virtio_fs_rejects_illegal_queue_geometry() {
+        for num in ILLEGAL_QUEUE_SIZES {
+            assert!(
+                !fs_notify_with_queue_num(num),
+                "fs queue size {num:#x} must not be serviced"
+            );
+        }
     }
 }

--- a/crates/mvm-runtime/src/vmm/vsock_transport.rs
+++ b/crates/mvm-runtime/src/vmm/vsock_transport.rs
@@ -7,7 +7,6 @@ pub(crate) const VIRTIO_VERSION: u32 = 2;
 pub(crate) const VIRTIO_ID_VSOCK: u32 = 19;
 pub(crate) const VIRTIO_VENDOR: u32 = 0x4d56_4d76;
 
-pub(crate) const QUEUE_SIZE_MAX: u32 = 256;
 pub(crate) const NUM_QUEUES: usize = 3;
 const RX: usize = 0;
 const TX: usize = 1;
@@ -128,7 +127,7 @@ impl VsockTransportCore {
             0x00c => VIRTIO_VENDOR,
             0x010 if self.device_features_sel == 1 => 1,
             0x010 => 0,
-            0x034 => QUEUE_SIZE_MAX,
+            0x034 => super::QUEUE_SIZE_MAX,
             0x044 => self.cur().ready,
             0x060 => self.interrupt_status,
             0x070 => self.status,
@@ -162,10 +161,12 @@ impl VsockTransportCore {
 
     pub(crate) fn take_tx_packets(&mut self) -> Vec<(VsockHdr, Vec<u8>)> {
         let q = self.queues[TX];
-        if q.ready == 0 || q.num == 0 {
+        if q.ready == 0 {
             return Vec::new();
         }
-        let qsz = q.num as u16;
+        let Some(qsz) = super::validated_queue_size(q.num) else {
+            return Vec::new();
+        };
         let avail_idx = self.mem.rd_u16(q.avail + 2);
         let mut last = q.last_avail;
         let mut packets = Vec::new();
@@ -177,7 +178,7 @@ impl VsockTransportCore {
                 let hdr = VsockHdr::from_bytes(&buf[..HDR_LEN]);
                 packets.push((hdr, buf[HDR_LEN..].to_vec()));
             }
-            self.complete(TX, head, 0);
+            self.complete(TX, head, 0, qsz);
             last = last.wrapping_add(1);
         }
         self.queues[TX].last_avail = last;
@@ -236,10 +237,12 @@ impl VsockTransportCore {
 
     pub(crate) fn flush_rx(&mut self) -> bool {
         let q = self.queues[RX];
-        if q.ready == 0 || q.num == 0 || self.pending_rx.is_empty() {
+        if q.ready == 0 || self.pending_rx.is_empty() {
             return false;
         }
-        let qsz = q.num as u16;
+        let Some(qsz) = super::validated_queue_size(q.num) else {
+            return false;
+        };
         let mut last = q.last_avail;
         let mut delivered = false;
         while !self.pending_rx.is_empty() {
@@ -266,7 +269,7 @@ impl VsockTransportCore {
             let mut bytes = hdr.to_bytes().to_vec();
             bytes.extend_from_slice(&payload[..send_len]);
             self.mem.write_bytes(addr, &bytes);
-            self.complete(RX, head, bytes.len() as u32);
+            self.complete(RX, head, bytes.len() as u32, qsz);
             if !remainder.is_empty() {
                 self.pending_rx.insert(0, (hdr, remainder));
             }
@@ -312,9 +315,8 @@ impl VsockTransportCore {
         out
     }
 
-    fn complete(&mut self, q: usize, head: u16, written: u32) {
+    fn complete(&mut self, q: usize, head: u16, written: u32, qsz: u16) {
         let used = self.queues[q].used;
-        let qsz = self.queues[q].num as u16;
         let used_idx = self.mem.rd_u16(used + 2);
         let slot = u64::from(used_idx % qsz);
         self.mem.wr_u16(used + 4 + slot * 8, head);
@@ -405,5 +407,68 @@ mod tests {
         assert_eq!(second_hdr.op, OP_RW);
         assert_eq!(second_hdr.len, 4);
         assert_eq!(&second[HDR_LEN..], b"ghij");
+    }
+
+    /// Program a drainable ring (`RX` or `TX`) whose `avail_idx` is one past
+    /// `last_avail`, so the drain loop body — where the ring is indexed with
+    /// `last % qsz` — is entered. `num` is the raw guest-programmed `QueueNum`.
+    fn program_ring(core: &mut VsockTransportCore, slot: usize, num: u32) {
+        let base = 0x4000_0000;
+        core.queues[slot] = Queue {
+            num,
+            ready: 1,
+            desc: base + 0x100,
+            avail: base + 0x200,
+            used: base + 0x300,
+            last_avail: 0,
+        };
+        core.mem.wr_u16(base + 0x200 + 2, 1);
+    }
+
+    /// Queue sizes a hostile guest can program that are illegal geometry: zero,
+    /// values whose low 16 bits are zero (which truncate to a zero `u16`), and
+    /// sizes that are above the advertised maximum or not a power of two.
+    const ILLEGAL_QUEUE_SIZES: [u32; 6] = [0, 0x1_0000, 0x2_0000, 0xffff_0000, 300, 512];
+
+    #[test]
+    fn take_tx_packets_rejects_queue_size_that_truncates_to_zero() {
+        let mut core = transport();
+        program_ring(&mut core, TX, 0x1_0000);
+        assert!(core.take_tx_packets().is_empty());
+    }
+
+    #[test]
+    fn take_tx_packets_rejects_illegal_queue_geometry() {
+        for num in ILLEGAL_QUEUE_SIZES {
+            let mut core = transport();
+            program_ring(&mut core, TX, num);
+            assert!(
+                core.take_tx_packets().is_empty(),
+                "TX queue size {num:#x} must not be serviced"
+            );
+        }
+    }
+
+    #[test]
+    fn flush_rx_rejects_queue_size_that_truncates_to_zero() {
+        let mut core = transport();
+        program_ring(&mut core, RX, 0x1_0000);
+        core.queue_host_packet(1, 2, OP_RW, b"x");
+        assert!(!core.flush_rx());
+        assert_eq!(core.pending_rx.len(), 1, "packet stays queued, not dropped");
+    }
+
+    #[test]
+    fn flush_rx_rejects_illegal_queue_geometry() {
+        for num in ILLEGAL_QUEUE_SIZES {
+            let mut core = transport();
+            program_ring(&mut core, RX, num);
+            core.queue_host_packet(1, 2, OP_RW, b"x");
+            assert!(
+                !core.flush_rx(),
+                "RX queue size {num:#x} must not be serviced"
+            );
+            assert_eq!(core.pending_rx.len(), 1);
+        }
     }
 }


### PR DESCRIPTION
A guest programs the virtio-mmio `QueueNum` register as a raw `u32`, but the devices index rings with `slot % size` where `size` is a `u16`. The old `queue_num as u16` cast **truncates**, so a nonzero value whose low 16 bits are zero (e.g. `0x1_0000`) becomes `qsz = 0` and `slot % 0` aborts the host VMM process — reachable from the guest in a handful of register writes. The `== 0` guards missed it. Same pattern in vsock, virtio-blk, and virtio-fs. (All guest-RAM access is bounds-checked, so this is availability/self-DoS, not memory corruption.)

Fix: one shared `validated_queue_size(num) -> Option<u16>` (`num != 0 && num <= QUEUE_SIZE_MAX && num.is_power_of_two()`), consolidating the duplicated max constant. Every service path validates once at the seam and consumes the checked `u16`; an illegal ring is left unserviced instead of panicking. The split-virtqueue spec requires a power-of-two size within the max, so conformant guests are byte-identical.

TDD: regression tests across vsock TX/RX + virtio-blk + virtio-fs fail red on the current code (`remainder with a divisor of zero`) and pass after; existing positive tests (num=2/4) still pass through the changed paths. Gates green (rustup 1.96): fmt, `clippy --workspace -D warnings`, `check-vsock-only-egress`, `check-no-spec-refs-in-comments`.

Follow-up: no `vmm` fuzz harness exists yet; a `fuzz_virtqueue_geometry` target is the natural next step. Surfaced by the device audit (findings F1).