### PR TITLE
docs(vsock): virtio-vsock device audit findings + staged hardening plan

### DIFF
--- a/specs/notes/2026-07-27-vsock-device-audit-findings.md
+++ b/specs/notes/2026-07-27-vsock-device-audit-findings.md
@@ -1,0 +1,282 @@
+# virtio-vsock device audit — findings (2026-07-27)
+
+Read-only security audit of the hand-rolled virtio-vsock device in the in-house
+(HVF/KVM) VMM. Scope: `crates/mvm-runtime/src/vmm/vsock.rs`,
+`vmm/vsock_handlers/mod.rs`, `vmm/vsock_transport.rs`, `vmm/vsock_io.rs`,
+`vmm/guest_mem.rs`, `vmm/virtio.rs`, plus the bridge implementations
+(`vmm/agent_bridge.rs`, `vmm/console_bridge.rs`,
+`vsock_egress_bridge/substitution_bridge.rs`) and the run-loop / hypervisor seam
+(`vmm/run.rs`, `vmm/hv.rs`, `vmm/device.rs`).
+
+The vsock device is the highest-risk trust boundary in the vsock-only security
+model: guest-programmed virtqueue geometry, descriptor addresses/lengths/flags,
+packet-header fields, and per-connection credit all cross from an untrusted
+guest into host code.
+
+**Threat-model note.** One guest = one workload = (effectively) one VMM process.
+So a guest crashing or OOMing *its own* VMM is primarily a self-DoS. The findings
+below are ranked with that in mind, but note that (a) a hostile-guest *panic* is
+materially worse than a clean guest halt — it can tear the host process down
+abruptly mid-flight (audit-log flush, endpoint sockets, temp state), and (b) the
+per-VM substitution/broker endpoint is a *shared host* process that a guest can
+drive into resource exhaustion (F2), which reaches beyond the single VM.
+
+---
+
+## URGENT — guest-triggerable divide-by-zero panic in the virtqueue ring walk (VMM DoS)
+
+**This is a live, trivially-reachable crash from a handful of guest MMIO register
+writes. It affects all three virtio devices (vsock, blk, fs) from one root
+cause, and it should reprioritize the hardening track toward adopting a validated
+queue primitive first.**
+
+### F1 — unvalidated `queue_num` truncated to `u16` is used as a modulus → panic
+
+Severity: **High** (availability; guest → host-process panic). Not memory
+corruption — see "Overall verdict".
+
+Untrusted-input path: the guest programs the queue size through the virtio-mmio
+`QueueNum` register. `write_register` stores it verbatim, with no clamp against
+the advertised maximum:
+
+- `vsock_transport.rs:147` — `0x038 => self.cur_mut().num = v,` (`v` is the raw
+  guest `u32`; no validation).
+- `vsock_transport.rs:131` — the `QueueNumMax` read returns `QUEUE_SIZE_MAX`
+  (256), but that is advisory; nothing enforces it on the write side.
+
+The size is then narrowed with a truncating cast and used as a divisor:
+
+- `take_tx_packets` — `vsock_transport.rs:168` `let qsz = q.num as u16;` then
+  `vsock_transport.rs:173` `let slot = last % qsz;`.
+- `flush_rx` — `vsock_transport.rs:242` / `:251`.
+- `complete` — `vsock_transport.rs:317` `let qsz = self.queues[q].num as u16;`
+  then `:319` `let slot = u64::from(used_idx % qsz);`.
+
+The early guards only reject `q.num == 0` (`vsock_transport.rs:165`, `:239`), not
+a *nonzero* `u32` whose low 16 bits are zero. Set `queue_num = 0x1_0000` (65536,
+or any multiple of it): `q.num == 0` is false, but `q.num as u16 == 0`, so
+`last % qsz` is `n % 0` → **integer divide-by-zero panic**.
+
+Concrete failure scenario (fully guest-driven, no host cooperation):
+1. Guest selects the TX queue, writes `QueueNum = 0x1_0000`, `QueueReady = 1`,
+   programs `desc/avail/used` base addresses, and writes an avail-ring index
+   (`avail + 2`) different from `last_avail`.
+2. Guest writes `QueueNotify = 1`.
+3. vCPU MMIO exit → `run::dispatch` (`run.rs:78`) → `VirtioVsock::write`
+   (`vsock.rs:289`) → `on_notify(1)` (`vsock.rs:110`) → `take_tx_packets` →
+   `last % qsz` with `qsz == 0` → panic on the vCPU thread.
+
+An even cheaper trigger goes through `flush_rx`: any handled `OP_REQUEST` queues a
+reply into `pending_rx` (`vsock.rs:129`), so with `RX` `queue_num = 0x1_0000` the
+next `on_notify` reaches `flush_rx`'s `last % qsz` (`vsock_transport.rs:251`) and
+panics.
+
+Impact: the panic unwinds the vCPU thread (the device code runs in Rust *after*
+`hv.step()` returns — `run.rs:128` — so it does not unwind across the HVF FFI
+boundary, i.e. not UB). But it kills the vCPU thread → the guest is dead, and the
+`Mutex<VsockShared>` is poisoned (tolerated everywhere via
+`unwrap_or_else(|e| e.into_inner())`, e.g. `vsock.rs:188`). Under a
+`panic = "abort"` profile the whole VMM process aborts. Either way this is a
+guest-controlled crash of host code, reachable in ~5 register writes.
+
+Sibling instances of the identical root cause (same fix eliminates all):
+- `VirtioBlk::process_queue` — `virtio.rs:286` (`R_QUEUE_NUM => queue_num = v`),
+  `virtio.rs:308` (`qsz = self.queue_num as u16`), `virtio.rs:319`
+  (`slot = self.last_avail % qsz`) and the used-ring slot at `:327`.
+- `VirtioFs::process_queue` — `virtio.rs:569`, `virtio.rs:611`, `virtio.rs:616`,
+  `virtio.rs:621`.
+
+Would an audited rust-vmm primitive eliminate the class? **Yes, entirely.**
+`virtio-queue`'s `Queue` validates the negotiated size (rejects zero, sizes above
+`max_size`, and non-power-of-two sizes) before the ring is usable, and its
+`DescriptorChain` iterator derives its live-descriptor budget from that validated
+size. A `queue_num` of 65536 is simply un-representable as an active queue, so the
+`% qsz` divide-by-zero cannot arise. This is the single strongest argument for the
+migration and motivates the first hardening slice.
+
+---
+
+## High / medium findings
+
+### F2 — unbounded host state and host FDs keyed by the guest-chosen `src_port` (resource-exhaustion DoS)
+
+Severity: **Medium-High** (availability; reaches the shared endpoint host
+process). Untrusted-input path: the guest fully controls `src_port` on every TX
+packet, and the device keys per-connection host state on it with no cap and only
+explicit-`OP_SHUTDOWN` eviction.
+
+- Credit map: `recv_cnt: HashMap<(u32,u32), u32>` grows one entry per distinct
+  `(dst_port, src_port)` via `add_recv` (`vsock_transport.rs:187-193`), removed
+  only on `OP_SHUTDOWN` (`vsock.rs:139-142`, `mod.rs:311`, `:357`). A guest that
+  streams `OP_RW` from a walking `src_port` (up to 2^32 values) without ever
+  sending `OP_SHUTDOWN` grows the map without bound.
+- Worse — real host file descriptors: the egress/broker `StreamRelayHandler`
+  opens a **new** `UnixStream` to the per-VM endpoint on the first frame of each
+  distinct `conn_id` (= guest `src_port`):
+  `substitution_bridge.rs:110-128` (`relay_guest_bytes` → `UnixStream::connect`),
+  stored in `conns` with no ceiling, plus a parallel `headers` map in the handler
+  (`mod.rs:321`, `:345`). Spraying distinct `src_port`s opens unbounded host
+  sockets → host FD exhaustion against the shared substitution/broker endpoint.
+
+Concrete scenario: guest sends N single-byte `OP_RW` frames on the egress port,
+each with a fresh `src_port`, never shutting down. The device opens N host
+`UnixStream`s and retains N `recv_cnt`/`headers` entries. N is bounded only by the
+per-process FD limit / host memory, not by any device policy.
+
+rust-vmm relevance: this is connection-tracking *policy*, not something
+`virtio-queue`/`vm-memory` fix directly. The remedy is a typed per-device
+connection table with a max-concurrent-streams cap (reject/`OP_RST` past the cap)
+and idle-eviction; sequence it in the hardening plan alongside the queue work.
+
+### F3 — descriptor-chain amplification: no `next` bound, cyclic chains, oversized `qsz` (memory-amplification DoS)
+
+Severity: **Medium** (availability). Untrusted-input path: guest-authored
+descriptor table walked by `read_chain`.
+
+`read_chain` (`vsock_transport.rs:296-313`) follows the chain via
+`idx = self.mem.rd_u16(da + 14)` (`:310`) with **no `next < qsz` bounds check** —
+the only stop conditions are `F_NEXT` clear or the iteration counter
+`guard > qsz` (`:307`). Because `qsz = q.num as u16` can be as large as 65535
+(F1), and `next` may point back into the same descriptor (a cycle), a guest can
+build a 65535-long chain whose descriptors each carry a large `len`. Each hop does
+`out.extend_from_slice(&self.mem.read_bytes(addr, len))` (`:305`); `read_bytes`
+bounds-checks `len` against the region (so `len ≤ ram_size` — `guest_mem.rs:86`),
+but the accumulated `out` Vec can reach ~`65535 × ram_size` → allocation blow-up /
+OOM.
+
+Notably, the sibling block/fs walkers *do* guard this: `virtio.rs:366`
+(`if next >= qsz { break; }`) and `virtio.rs:662`. The vsock `read_chain` omits
+the equivalent check.
+
+rust-vmm relevance: `virtio-queue`'s `DescriptorChain::next` returns `None` once
+`ttl == 0 || next_index >= queue_size` and decrements a `ttl` seeded from the
+*validated* queue size — verified from crate source. With a validated `max_size`
+of 256 this caps a chain at 256 descriptors and rejects any out-of-range `next`,
+eliminating both the cycle and the oversized-`qsz` amplification.
+
+### F4 — used-ring index re-read from guest RAM instead of device-owned state (used-ring integrity / correctness)
+
+Severity: **Low** (correctness; no host-memory unsafety). Untrusted-input path:
+the guest can write the used-ring index in its own RAM.
+
+`complete` reads the used index back out of guest memory each time
+(`vsock_transport.rs:318` `let used_idx = self.mem.rd_u16(used + 2);`) and writes
+`used_idx + 1` (`:325`). The used index is *device-owned* state in virtio; sourcing
+it from guest-writable memory lets a guest rewind or steer where used entries land
+(`slot = used_idx % qsz`, then writes at `used + 4 + slot*8` — all bounds-checked,
+so confined to the guest's own RAM). Same pattern in `virtio.rs:326`/`:332` and
+`virtio.rs:620`/`:627`. Not exploitable for host-memory corruption, but it lets the
+guest corrupt its own completion stream and defeats the point of a device-side
+index. `virtio-queue` keeps `next_used` in device state (`Queue::add_used`), which
+is the correct model.
+
+### F5 — RX delivery ignores descriptor writability / chaining and can silently drop packets (correctness)
+
+Severity: **Low** (correctness / data-loss; not unsafe). `flush_rx`
+(`vsock_transport.rs:237-278`) uses only the *head* descriptor
+(`da = q.desc + head*16`, `:253`), reads `addr` and `cap`, and never checks
+`VIRTQ_DESC_F_WRITE` nor follows a multi-descriptor RX buffer. If the guest posts
+an RX descriptor whose `addr` is out of range, `write_bytes` returns 0
+(`guest_mem.rs:74-83`) yet `complete` still advances the used ring (`:269`) — the
+host believes it delivered a packet the guest never received. The too-small-buffer
+case *is* handled (re-insert at `:256-262`), but the bogus-`addr` case is not.
+`virtio-queue`'s writable-descriptor iterator (`DescriptorChainRwIter`) plus a
+proper "no writable buffer available → leave queued" path fixes this.
+
+### F6 — O(n) `Vec::remove(0)` / `insert(0, …)` on the RX hot path (perf)
+
+Severity: **Low** (perf, guest-influenceable via backpressure). `flush_rx` does
+`self.pending_rx.remove(0)` (`:250`) and `insert(0, …)` (`:259`, `:271`) — each an
+O(n) shift of a `Vec`. Under many queued packets (which a guest can induce by
+withholding RX buffers) this is O(n²) per flush. A `VecDeque` (or the deferred
+`OP_RW` re-frame handled by `virtio-queue`'s own iteration) removes it.
+
+### F7 — per-packet / per-descriptor `std::env::var_os` in hot paths (perf)
+
+Severity: **Low**. `agent_dbg` (`mod.rs:517`), the bridges' `dbg_log`
+(`agent_bridge.rs:216`, `console_bridge.rs:249`), and the virtio-blk debug taps
+(`virtio.rs:310`, `:353`, `:374`) call `std::env::var_os(...)` on every
+packet/descriptor. Env access takes a process-global lock; on the per-packet path
+it should be read once and cached (e.g. a `OnceLock<bool>`).
+
+---
+
+## Areas reviewed and found sound (evidence)
+
+These are called out deliberately so the hardening work does not "fix" things that
+are already correct.
+
+- **Guest-memory access is uniformly bounds-checked; no unchecked pointer/offset
+  arithmetic.** Every guest-RAM read/write funnels through `GuestMem`
+  (`guest_mem.rs`). `host(gpa, len)` rejects `gpa < base`, computes the offset,
+  and rejects `off.checked_add(len)? > size` before returning a pointer
+  (`guest_mem.rs:29-39`) — `checked_add` closes the overflow path, and an
+  out-of-range access returns `None` (reads zero-fill, writes no-op). `rd_*`,
+  `wr_*`, `read_bytes`, `write_bytes` all go through it. This is why F1/F3 are
+  *panics/OOM* and not memory-corruption: the device is memory-safe by
+  construction on the guest-RAM boundary.
+- **Header vs. payload length lies are handled.** Every consumer clamps to the
+  real payload: `let n = (hdr.len as usize).min(payload.len())` at `vsock.rs:131`,
+  `mod.rs:304`, `:342`, `:413`, `:488`. A lying `hdr.len` cannot over-read.
+- **Fixed-width header parse cannot panic on short input.** `VsockHdr::from_bytes`
+  uses `try_into().expect(...)` (`vsock_transport.rs:71-87`) but is only ever
+  called on an exactly-`HDR_LEN` slice, guarded by `if buf.len() >= HDR_LEN`
+  (`vsock_transport.rs:176`). The exit-code parse is guarded by `payload.len() >= 4`
+  (`mod.rs:80`).
+- **Descriptor-index reads are bounds-checked even when unbounded by `qsz`.**
+  `head`/`next`/`idx` are `u16`, and `desc + idx*16` is always run through the
+  checked `GuestMem`, so an out-of-table index reads zeros rather than host memory.
+- **vCPU/host-I/O concurrency is correctly serialized.** All guest-RAM and
+  virtqueue access happens under `Mutex<VsockShared>`; the dedicated I/O thread
+  and the vCPU thread both take it (`vsock.rs:187`, `vsock_io.rs:107-122`), and the
+  I/O thread is joined before guest RAM is freed (`vsock_io.rs:56-62`, documented
+  at `guest_mem.rs:12-18`). No data race on guest memory or the rings.
+- **Egress fails closed.** With no endpoint configured, `relay_guest_bytes`
+  returns `Refused` and the stream is `OP_RST`-reset
+  (`substitution_bridge.rs:115-117`, `mod.rs:348-351`) — consistent with the
+  default-deny egress claim.
+
+Two items in scope that are **not applicable** as the code stands:
+- **Snapshot/restore.** This device implements no snapshot serialization in scope
+  (no state `get`/`set`). The live connection state (`recv_cnt`, `pending_rx`,
+  `conns`, `headers`, `last_avail`) is purely in-memory. If device snapshotting is
+  added later, that state must be captured/restored — and `virtio-queue`'s
+  `QueueState` (`state()`/`set_state()`) would make the ring half of that
+  correct-by-construction. No defect today; a forward note.
+- **IRQ delivery / wakeup races.** `interrupt_status` is maintained under the lock;
+  the I/O thread raises the SPI *after* releasing the lock (`vsock_io.rs:119-125`),
+  and missed edges are covered by the timer/heartbeat `poll()` fallback
+  (`run.rs:129-159`) plus `notify_io()` on every MMIO write (`vsock.rs:291`). No
+  concrete lost-notification or double-delivery bug was found; the edge-vs-level
+  coalescing is subtle enough to be worth preserving byte-for-byte across any
+  migration (call it out as a regression risk, not a current defect).
+
+---
+
+## Overall verdict
+
+The device is **memory-safe by construction** on the untrusted-guest boundary:
+because every guest-RAM access is routed through the bounds-checked `GuestMem`,
+and every header/payload length is clamped to the real buffer, I found **no
+host-memory-corruption bug** reachable from guest bytes — no OOB read/write, no
+unchecked cast into a pointer, no over-read from a lying length.
+
+It is **not robust against a hostile guest on availability**. It trusts
+guest-programmed queue geometry and connection identifiers, which yields a
+trivially-reachable panic (F1), a descriptor-amplification OOM (F3), and unbounded
+host-resource growth against a shared endpoint (F2). These are precisely the
+classes that audited rust-vmm primitives remove wholesale: `virtio-queue`'s
+validated `Queue` + `ttl`/bounds-guarded `DescriptorChain` kill F1, F3, and F4;
+`vm-memory`'s checked `GuestMemory` is the audited equivalent of the (already
+sound) `GuestMem`; `virtio-vsock`'s typed `VsockPacket` replaces the hand-rolled
+44-byte header parse. F2 and F5–F7 are device-policy/quality items the migration
+should carry alongside.
+
+**Recommended first hardening slice:** land a validated queue-geometry gate that
+rejects `queue_num == 0`, `> QUEUE_SIZE_MAX`, and non-power-of-two before the ring
+is serviced (a safe no-op / non-service for hostile input, byte-for-byte identical
+for every conformant Linux guest, which always negotiates a power-of-two size
+≤ 256). This is a tiny, isolated, unit-testable change that removes the URGENT
+panic across vsock + blk + fs immediately, and it is the natural on-ramp to
+replacing the hand-rolled ring walk with `virtio-queue`'s `Queue` (which subsumes
+the same validation). Details and sequencing in the companion hardening plan.

--- a/specs/notes/2026-07-27-vsock-device-hardening-plan.md
+++ b/specs/notes/2026-07-27-vsock-device-hardening-plan.md
@@ -1,0 +1,217 @@
+# virtio-vsock device hardening — staged adoption of audited rust-vmm primitives (2026-07-27)
+
+Companion to `2026-07-27-vsock-device-audit-findings.md`. Goal: replace the
+hand-rolled virtqueue/guest-memory/packet code in the in-house VMM's virtio-vsock
+device with audited rust-vmm primitives, **behavior-preserving**, in bounded
+individually-reviewable slices, each gated by an equivalence test that proves
+unchanged behavior for conformant guests and safe rejection of the hostile input
+the audit found.
+
+This plan is scoped to the vsock device but is written so the same primitives
+land once and are reused by the block/fs devices (they share `GuestMem` and the
+same divide-by-zero root cause — F1).
+
+## Primitives (verified from primary sources, 2026-07-27)
+
+All three are rust-vmm crates under the `rust-vmm/vm-virtio` and
+`rust-vmm/vm-memory` repos, permissively licensed (Apache-2.0 / BSD-3-Clause).
+
+- **`virtio-queue` 0.18.0** — split-virtqueue `Queue`, `Descriptor`,
+  `DescriptorChain`, and the `DescriptorChainRwIter` readable/writable
+  abstraction. Depends on `vm-memory ^0.18`. Verified from the crate source that
+  `DescriptorChain::next` returns `None` once `ttl == 0 || next_index >=
+  queue_size` and seeds/decrements `ttl` from the queue size — i.e. it structurally
+  prevents both descriptor loops and out-of-range `next` indices (kills F3), and
+  the validated `Queue` size makes a zero/oversized `qsz` un-representable (kills
+  F1). `Queue::add_used` keeps the used index in device state (kills F4).
+- **`vm-memory` 0.18.0** — `GuestMemory`/`GuestMemoryMmap`, `GuestAddress`, the
+  `Bytes` trait (`read_obj`/`write_obj`/`read_slice`/`write_slice`), and
+  `VolatileSlice` (a safe wrapper over raw guest pointers). This is the audited
+  equivalent of the in-repo `GuestMem`. It can wrap an externally-owned mapping
+  via `MmapRegion`'s raw-pointer constructor, which is required here because the
+  RAM pointer is owned by the HVF/KVM mapping, not allocated by vm-memory.
+- **`virtio-vsock` 0.11.0** — `VsockPacket`, parsed from a TX/RX descriptor chain
+  (stream sockets only), header + optional data represented as `VolatileSlice`s.
+  Replaces the hand-rolled 44-byte `VsockHdr::from_bytes/to_bytes` and `HDR_LEN`.
+
+**Oracle, not a dependency:** a sibling in-house virtio-vsock reference
+implementation (the "arcbox" oracle named in the tasking) is used only to
+cross-check semantics during migration. It is **not** taken as a dependency
+pending its own audit; do not add it to `Cargo.toml`.
+
+## Cross-cutting constraints (must hold for every slice)
+
+- **Closure budget + supply chain.** The repo gates default-binary crate count and
+  audits every dependency (`deny.toml`, the `deny`/`audit` CI jobs, ADR-002
+  "limit dependencies"). These three crates must land **only** on the host VMM
+  path (`mvm-runtime`'s `vmm`/`hvf`), never in the sealed guest agent
+  (`mvm-agentd` stays tokio/dep-free), `mvm-core` (no async), or the embedded
+  cross-compiled host-vm bins. Concretely, before merging Slice 1: capture
+  `cargo tree -p mvm-runtime -e no-dev` and the default-binary crate-count metric,
+  add the exact crate + transitive additions to the `deny.toml` allowlist, and get
+  maintainer sign-off on the closure delta. `vm-memory` pulls a small tree
+  (`libc`, `thiserror`); `virtio-queue` adds `log`; `virtio-vsock` adds only those
+  two. Feature-gate them (e.g. a `vmm-rustvmm-queue` feature) if the count needs to
+  stay off by default during migration.
+- **HVF must not regress.** (a) *Startup latency* — per-VM device construction must
+  stay cheap; `Queue::new(max_size)` and wrapping the existing mapping in a
+  `GuestRegionMmap` are O(1), no allocation of guest RAM. (b) *IRQ behavior* — do
+  not touch the `IrqLine`/SPI edge semantics or the `poll()`/heartbeat fallback;
+  the queue crate does not raise interrupts, so keep the existing
+  `interrupt_status |= 1` + `set_irq`/`signal` exactly as-is. (c) *Snapshots* — the
+  device does not snapshot today; if/when it does, prefer `virtio-queue`'s
+  `QueueState` over re-deriving ring state. (d) *Cross-platform builds* — these
+  deps are host-side and std-only; verify `just check-linux` (zigbuild
+  x86_64/aarch64-gnu) stays green and that the `aarch64-unknown-linux-musl`
+  embedded host-vm bins (which do not touch this code) are unaffected.
+- **Behavior preservation is the acceptance bar.** For a conformant guest (Linux
+  always negotiates a power-of-two queue size ≤ the advertised max, posts a header
+  descriptor + data descriptors, etc.) every slice must produce byte-identical
+  used-ring updates and byte-identical extracted TX packets / delivered RX bytes.
+  The only *intended* behavior change is that the hostile inputs from F1/F3 stop
+  panicking/OOMing and instead fail closed (no service, or `OP_RST`).
+
+## Equivalence-test methodology (used by every slice)
+
+Each slice ships a test that builds a virtqueue in a scratch RAM buffer (the
+existing tests already do this — see `vsock_transport.rs::configure_rx_buffers`
+and `virtio.rs::services_a_block_read_through_the_split_virtqueue`) and asserts the
+new path is observationally identical to the old one:
+
+1. **Golden replay.** Program a representative queue (sizes 1, 2, 128, 256; single
+   and multi-descriptor chains; empty and full payloads; split RX payloads as in
+   `flush_rx_splits_large_stream_payload_across_guest_buffers`). Capture used-ring
+   bytes + extracted packets from the *current* code as golden vectors; assert the
+   new code reproduces them exactly.
+2. **Differential during migration.** While both implementations coexist (behind a
+   feature), run both over the same RAM image in one test and `assert_eq!` their
+   outputs — the strongest proof of equivalence.
+3. **Hostile-input regression.** Assert the specific audit triggers now fail
+   closed: `queue_num = 0x1_0000` (F1) services nothing / no panic; a cyclic
+   65535-hop chain (F3) is capped and does not allocate unboundedly.
+
+## Slices
+
+### Slice 1 — validated queue-geometry gate (kills the URGENT F1; no new deps yet)
+
+Smallest possible change that removes the panic. Introduce a
+`ValidatedQueueSize`/`QueueGeometry` newtype (make illegal states
+unrepresentable) constructed at `QueueReady`/notify time that rejects
+`num == 0`, `num > QUEUE_SIZE_MAX`, and non-power-of-two `num`. The service paths
+(`take_tx_packets`, `flush_rx`, `complete`, and the `virtio.rs` block/fs
+equivalents) consult the validated size; an invalid geometry services nothing,
+exactly mirroring the existing `if q.ready == 0 || q.num == 0 { return }` early
+outs. No behavior change for any conformant guest.
+
+- Removes: F1 across vsock + blk + fs; caps F3's `qsz` at 256 as a side effect.
+- Tests: golden replay for sizes {1,2,128,256}; regression asserting
+  `queue_num ∈ {0, 0x1_0000, 3, 257}` services nothing and does not panic.
+- Deps/closure impact: none. This slice is deliberately dependency-free so the
+  URGENT fix is not blocked on the closure-budget review.
+- Reviewable in isolation; strictly additive validation.
+
+### Slice 2 — adopt `vm-memory` behind the `GuestMem` seam
+
+Replace the internals of `GuestMem` (`guest_mem.rs`) with `vm-memory`: wrap the
+externally-owned RAM mapping in a `GuestRegionMmap`/`GuestMemoryMmap` built from
+the raw pointer + size, and route `rd_*`/`wr_*`/`read_bytes`/`write_bytes` through
+`read_obj`/`write_obj`/`VolatileSlice`. Keep the public method surface and the
+current *semantics* (out-of-range read → zero-fill, write → no-op) so callers are
+untouched; the `unsafe impl Send` + "joined before RAM freed" invariant
+(`guest_mem.rs:12-18`) is preserved and re-documented against vm-memory's model.
+
+- Removes: the last hand-rolled `unsafe` pointer arithmetic on the guest boundary
+  (already sound — this is defense-in-depth + shrinks the audited surface).
+- Tests: property test over random `(gpa, len)` pairs asserting the vm-memory-backed
+  `GuestMem` returns identical results (including the zero-fill/no-op edge
+  behavior) to the current one.
+- Do this before the queue swap so the queue slice can hand `virtio-queue` a real
+  `GuestMemory` rather than a bespoke shim.
+
+### Slice 3 — `virtio-queue` for the vsock TX path
+
+Replace `take_tx_packets` + `read_chain` (`vsock_transport.rs:163-185`, `:296-313`)
+with `Queue::iter(mem)` yielding `DescriptorChain`s, gathering readable descriptors
+into the TX buffer. The `ttl`/`next_index` guard subsumes the hand-rolled `guard`
+counter and adds the missing `next < queue_size` bound (kills F3 on TX).
+
+- Tests: differential test — same avail-ring + descriptor table through both the
+  old `take_tx_packets` and the `virtio-queue` iterator; `assert_eq!` on the
+  `(VsockHdr, payload)` list. Cyclic/oversized-chain regression.
+
+### Slice 4 — `virtio-queue` for the vsock RX path
+
+Replace `flush_rx` + `complete` (`vsock_transport.rs:237-278`, `:315-327`) with
+`DescriptorChainRwIter` (writable descriptors) + `Queue::add_used`. This also fixes
+F4 (used index becomes device-owned) and F5 (writable-descriptor validation +
+proper "no RX buffer → leave queued" instead of silent drop) and lets the deferred
+`OP_RW` re-frame drop the O(n) `Vec::remove(0)` (F6, switch `pending_rx` to
+`VecDeque`).
+
+- Tests: golden replay of `flush_rx_splits_large_stream_payload_across_guest_buffers`
+  (byte-identical split across guest buffers); regression for bogus-`addr` RX
+  descriptor now leaving the packet queued rather than advancing used.
+
+### Slice 5 — `virtio-vsock` typed packet parse/format
+
+Replace `VsockHdr::{from_bytes,to_bytes}` + `HDR_LEN` (`vsock_transport.rs:41-88`)
+with `virtio-vsock`'s `VsockPacket`. Cross-check field-for-field against the
+sibling reference implementation (oracle only). Keep the device's op-dispatch
+(`handle_packet`, the handler registry) unchanged — only the wire parse/format is
+swapped.
+
+- Tests: round-trip a matrix of headers (all ops, boundary `len`/`buf_alloc`/
+  `fwd_cnt`) and assert byte-identical framing vs the current `to_bytes`.
+
+### Slice 6 — connection-table caps (F2; not a rust-vmm primitive)
+
+Independent of the queue work: give the per-device connection state
+(`recv_cnt`, the bridges' `conns`/`headers`) a typed table with a
+max-concurrent-streams ceiling and idle eviction. Past the cap, refuse with
+`OP_RST` instead of opening another host `UnixStream` / map entry. This closes the
+shared-endpoint FD-exhaustion path.
+
+- Tests: assert that N distinct `src_port`s past the cap yield `OP_RST` and open no
+  further host sockets; assert `OP_SHUTDOWN`/idle frees slots.
+
+## Fuzzing (extend the existing harness)
+
+The repo already fuzzes `GuestRequest`, `AuthenticatedFrame`, and the host-side
+`SupervisorConfig` (frozen fuzz lane, pinned nightly, workspace-excluded). Add,
+using the same lane conventions:
+
+- **Virtqueue-geometry + descriptor-table fuzzer** — feed a random RAM image plus a
+  random register-programming sequence into `VsockTransportCore` (drive
+  `write_register` + `on_notify`) and assert no panic / no unbounded allocation.
+  This target reproduces F1 and F3 and becomes the regression guard for Slices 1,
+  3, 4. Land it **before** Slice 1 so it demonstrably catches the divide-by-zero,
+  then goes green after the fix.
+- **Differential queue fuzzer** — during Slices 3–4, fuzz a RAM image through both
+  the hand-rolled and `virtio-queue` paths and assert identical output; retire it
+  once the old path is deleted.
+- **Packet-parse fuzzer** — fuzz `VsockHdr::from_bytes` / `VsockPacket` on arbitrary
+  ≥`HDR_LEN` byte strings (Slice 5), asserting parse never panics and round-trips.
+
+## Sequencing summary
+
+1. Slice 1 (validated geometry) + the geometry fuzzer — removes the URGENT panic,
+   no deps, unblocked by closure review.
+2. Closure-budget + `deny.toml` review; land `vm-memory` (Slice 2).
+3. `virtio-queue` TX then RX (Slices 3–4) behind differential tests.
+4. `virtio-vsock` packet parse (Slice 5).
+5. Connection-table caps (Slice 6), independent, schedulable anytime after Slice 1.
+
+Each slice is independently revertible and leaves the tree green. The block and fs
+devices reuse the Slice 1 gate and the Slice 2 `vm-memory` seam directly, and can
+follow the same TX/RX queue migration once the vsock path proves the pattern.
+
+## Sources
+
+- [virtio-queue on crates.io](https://crates.io/crates/virtio-queue) /
+  [docs.rs](https://docs.rs/virtio-queue) — 0.18.0.
+- [rust-vmm/vm-virtio `virtio-queue` chain iterator source](https://raw.githubusercontent.com/rust-vmm/vm-virtio/main/virtio-queue/src/chain.rs)
+  — `ttl` + `next_index >= queue_size` guard.
+- [vm-memory on docs.rs](https://docs.rs/crate/vm-memory/latest) — 0.18.0.
+- [virtio-vsock on crates.io](https://crates.io/crates/virtio-vsock) /
+  [docs.rs](https://docs.rs/virtio-vsock) — 0.11.0 (`VsockPacket`).
+- [rust-vmm/vm-virtio](https://github.com/rust-vmm/vm-virtio).


### PR DESCRIPTION
Read-only security audit of the hand-rolled virtio-vsock device (untrusted guest bytes → host memory), plus a staged, dependency-free-first plan to adopt audited rust-vmm primitives (`virtio-queue`, `vm-memory`, `virtio-vsock`).

**Verdict:** memory-safe by construction — every guest-RAM access funnels through the bounds-checked `GuestMem`, so no host-memory-corruption / RCE path was found. The defects are availability-class (self-DoS in the one-guest-per-VMM model):

- **F1 (high)** — queue-geometry `% 0` panic. **Fixed in #1860.**
- **F2 (med-high)** — unbounded host state + FDs keyed by guest-chosen `src_port`.
- **F3 (med)** — descriptor-chain walk without a `next < qsz` bound → memory-amplification OOM.
- **F4–F7 (low)** — used-ring re-read, RX drop on bad addr, O(n) hot-path list ops, per-packet env lookup.

The staged plan sequences the rust-vmm adoption into behavior-preserving, individually-reviewable slices, ADR-gated (supply-chain + closure-budget), with fuzz coverage. Docs only.