### PR TITLE
ci: pin Rust toolchain to 1.96.0 for reproducible builds

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -801,7 +801,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: steps.filter.outputs.spawn == 'true' || github.ref == 'refs/heads/main'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Install firecracker
         if: steps.filter.outputs.spawn == 'true' || github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: wasm32-unknown-unknown,wasm32-wasip1
 
@@ -400,7 +400,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
       - name: Write a sample image with the pure-Rust ext4 writer
         run: cargo run -p mvm-fs --example write_sample -- /tmp/sample.ext4 | tee /tmp/sample.out
       - name: Loop-mount read-only and verify the tree on the real kernel

--- a/.github/workflows/kernel-cve-watch.yml
+++ b/.github/workflows/kernel-cve-watch.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Install Nix
         # So the watcher can read the nixpkgs linux_6_12 pin (a Nix eval), not

--- a/.github/workflows/pack-signing-smoke.yml
+++ b/.github/workflows/pack-signing-smoke.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: ${{ matrix.target }}
 
@@ -283,7 +283,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
@@ -504,7 +504,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
@@ -637,7 +637,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Install cargo-cyclonedx
         run: cargo install cargo-cyclonedx --locked

--- a/.github/workflows/revocations.yml
+++ b/.github/workflows/revocations.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -867,7 +867,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: env.TARGET_TAG != ''
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - uses: ./.github/actions/install-zigbuild
         if: env.TARGET_TAG != ''
@@ -1035,7 +1035,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: env.TARGET_TAG != ''
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Rebuild the default microVM image from source at the target tag
         if: env.TARGET_TAG != ''

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache cargo
         uses: actions/cache@v5

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.96.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Makes the toolchain reproducible across CI, releases, and contributor machines instead of floating on `stable`.

- Swaps all 14 `dtolnay/rust-toolchain@stable` refs to `@1.96.0` (ci, ci-full, release, windows, security, kernel-cve-watch, pack-signing-smoke, revocations). The action sets `RUSTUP_TOOLCHAIN`, which is what actually pins the stable CI/release jobs.
- Sets `rust-toolchain.toml` `channel = "stable"` -> `"1.96.0"` to pin local rustup contributors.
- Leaves the intentional `@nightly` jobs (rustfmt, fuzz, sanitizers) and the pinned `nightly-2026-06-11` fuzz lane untouched.

`@1.96.0` is a valid dtolnay/rust-toolchain branch ref (verified). Bump deliberately when adopting a newer stable — this PR's own CI exercises the new refs.