### PR TITLE
refactor(mvm-agentd): native tokio-vsock dial for guest host-vsock session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2609,6 +2609,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,6 +2685,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-vsock",
  "tracing",
  "tracing-subscriber",
  "x25519-dalek",
@@ -2702,7 +2712,7 @@ dependencies = [
  "mvm-fs",
  "mvm-net",
  "mvm-sdk",
- "nix",
+ "nix 0.29.0",
  "rand 0.8.6",
  "reqwest 0.13.4",
  "serde",
@@ -2969,7 +2979,7 @@ dependencies = [
  "mvm-core",
  "mvm-fs",
  "mvm-protocol",
- "nix",
+ "nix 0.29.0",
  "object_store",
  "rand 0.8.6",
  "secrecy",
@@ -3062,6 +3072,19 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -5050,6 +5073,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-vsock"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b319ef9394889dab2e1b4f0085b45ba11d0c79dc9d1a9d1afc057d009d0f1c7"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5457,6 +5493,16 @@ checksum = "1d1435039746e20da4f8d507a72ee1b916f7b4b05af7a91c093d2c6561934ede"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+]
+
+[[package]]
+name = "vsock"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
+dependencies = [
+ "libc",
+ "nix 0.31.3",
 ]
 
 [[package]]

--- a/crates/mvm-agentd/Cargo.toml
+++ b/crates/mvm-agentd/Cargo.toml
@@ -156,7 +156,7 @@ schema = ["dep:schemars", "mvm-core/schema"]
 # async runtime. The helper bins are separate processes launched by
 # `/init`, never linked into `mvm-guest-agent`, so gating them here costs
 # the sealed agent nothing.
-addons = ["dep:tokio", "dep:hickory-proto"]
+addons = ["dep:tokio", "dep:hickory-proto", "dep:tokio-vsock"]
 
 [dependencies]
 mvm-core.workspace = true
@@ -207,6 +207,11 @@ ipnet.workspace = true
 # async runtime. Nothing extra is needed here.
 [target.'cfg(target_os = "linux")'.dependencies]
 seccompiler = { workspace = true }
+# Native async AF_VSOCK stream for the guest→host dial in the addon/egress
+# helper bins. Linux-only (AF_VSOCK is a Linux guest facility) and optional so
+# it enters only the `addons` closure — the sealed agent's default tree stays
+# tokio-free. Reuses the workspace tokio.
+tokio-vsock = { version = "0.7", optional = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/mvm-agentd/src/egress_client.rs
+++ b/crates/mvm-agentd/src/egress_client.rs
@@ -16,7 +16,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
 
-use crate::guest_vsock_session::HostVsockSession;
+use crate::guest_vsock_session::{HostVsockSession, HostVsockStream};
 use mvm_core::guest_netd::ConnectAck;
 use mvm_core::socks5_udp::{self, Datagram};
 
@@ -541,7 +541,9 @@ where
     Ok(body)
 }
 
-async fn connect_to_host_egress(target: &str) -> std::io::Result<HostVsockSession<TcpStream>> {
+async fn connect_to_host_egress(
+    target: &str,
+) -> std::io::Result<HostVsockSession<HostVsockStream>> {
     let target_line = format!("{target}\n");
     HostVsockSession::connect(configured_egress_vsock_port())
         .await?

--- a/crates/mvm-agentd/src/guest_vsock_session.rs
+++ b/crates/mvm-agentd/src/guest_vsock_session.rs
@@ -7,19 +7,29 @@
 //! host stays responsible for all admission/policy decisions.
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use tokio::net::TcpStream;
-
-#[cfg(target_os = "linux")]
-use std::os::fd::FromRawFd;
 
 use mvm_core::guest_netd::ConnectAck;
+
+/// Guest→host vsock stream. A native async AF_VSOCK stream on Linux guests
+/// (the only place a microVM ever runs), and a never-constructed stand-in on
+/// other hosts so the addon helper bins still `cargo check` during macOS
+/// development — there `connect` fails closed with `Unsupported` and this type
+/// is a signature placeholder that is never built.
+#[cfg(target_os = "linux")]
+pub type HostVsockStream = tokio_vsock::VsockStream;
+#[cfg(not(target_os = "linux"))]
+pub type HostVsockStream = tokio::net::TcpStream;
+
+/// CID of the host end of an AF_VSOCK link, as seen from inside a guest.
+#[cfg(target_os = "linux")]
+const HOST_CID: u32 = 2;
 
 /// One guest-initiated session to a host AF_VSOCK port.
 pub struct HostVsockSession<U> {
     upstream: U,
 }
 
-impl HostVsockSession<TcpStream> {
+impl HostVsockSession<HostVsockStream> {
     /// Dial a host AF_VSOCK stream to `port`.
     pub async fn connect(port: u32) -> std::io::Result<Self> {
         Ok(Self {
@@ -71,51 +81,30 @@ where
     }
 }
 
-/// Open a stream to the host over AF_VSOCK.
-pub async fn connect_host_vsock(port: u32) -> std::io::Result<TcpStream> {
-    tokio::task::spawn_blocking(move || connect_host_vsock_blocking(port))
-        .await
-        .map_err(|e| std::io::Error::other(format!("vsock dial task failed: {e}")))?
-}
-
+/// Open a native async AF_VSOCK stream to the host.
+///
+/// The error is left with its OS `ErrorKind` intact — a caller can still tell
+/// connect-refused / timed-out / reset apart — and carries the host CID+port as
+/// context.
 #[cfg(target_os = "linux")]
-fn connect_host_vsock_blocking(port: u32) -> std::io::Result<TcpStream> {
-    const VMADDR_CID_HOST: u32 = 2;
+pub async fn connect_host_vsock(port: u32) -> std::io::Result<HostVsockStream> {
+    use tokio_vsock::{VsockAddr, VsockStream};
 
-    let fd = unsafe { libc::socket(libc::AF_VSOCK, libc::SOCK_STREAM, 0) };
-    if fd < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-
-    let addr = libc::sockaddr_vm {
-        svm_family: libc::AF_VSOCK as libc::sa_family_t,
-        svm_reserved1: 0,
-        svm_port: port,
-        svm_cid: VMADDR_CID_HOST,
-        svm_zero: [0; 4],
-    };
-    let rc = unsafe {
-        libc::connect(
-            fd,
-            (&addr as *const libc::sockaddr_vm).cast::<libc::sockaddr>(),
-            std::mem::size_of::<libc::sockaddr_vm>() as libc::socklen_t,
-        )
-    };
-    if rc < 0 {
-        let err = std::io::Error::last_os_error();
-        unsafe {
-            libc::close(fd);
-        }
-        return Err(err);
-    }
-
-    let stream = unsafe { std::net::TcpStream::from_raw_fd(fd) };
-    stream.set_nonblocking(true)?;
-    TcpStream::from_std(stream)
+    VsockStream::connect(VsockAddr::new(HOST_CID, port))
+        .await
+        .map_err(|err| {
+            std::io::Error::new(
+                err.kind(),
+                format!("AF_VSOCK dial to host cid={HOST_CID} port={port} failed: {err}"),
+            )
+        })
 }
 
+/// Non-Linux hosts have no AF_VSOCK guest endpoint. Fail closed so the addon
+/// helper bins compile during macOS development but never pretend to reach a
+/// host.
 #[cfg(not(target_os = "linux"))]
-fn connect_host_vsock_blocking(_port: u32) -> std::io::Result<TcpStream> {
+pub async fn connect_host_vsock(_port: u32) -> std::io::Result<HostVsockStream> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,
         "AF_VSOCK guest dialing is only available on Linux guests",
@@ -160,5 +149,29 @@ mod tests {
         drop(client_side);
         drop(upstream_side);
         task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn read_connect_ack_maps_host_byte() {
+        let (mut host_side, guest_bridge) = tokio::io::duplex(8);
+        let mut session = HostVsockSession::new(guest_bridge);
+
+        host_side
+            .write_all(&[ConnectAck::Ok.as_byte()])
+            .await
+            .unwrap();
+        assert_eq!(session.read_connect_ack().await, ConnectAck::Ok);
+
+        host_side.write_all(&[0xFF]).await.unwrap();
+        assert_eq!(session.read_connect_ack().await, ConnectAck::Fail);
+    }
+
+    #[tokio::test]
+    async fn read_connect_ack_treats_eof_as_fail() {
+        let (host_side, guest_bridge) = tokio::io::duplex(8);
+        let mut session = HostVsockSession::new(guest_bridge);
+
+        drop(host_side);
+        assert_eq!(session.read_connect_ack().await, ConnectAck::Fail);
     }
 }


### PR DESCRIPTION
Replaces the guest's async host-vsock dial — which wrapped a raw `libc::socket(AF_VSOCK)`/`connect` in `spawn_blocking` and then presented the fd as a fake `tokio::net::TcpStream` — with a native `tokio_vsock::VsockStream::connect(VsockAddr::new(HOST_CID, port))`. The `HostVsockSession<U>` `AsyncRead + AsyncWrite` seam, `copy_bidirectional` splice, prelude, and connect-ack logic are unchanged; only the concrete constructor's stream type changes (a `HostVsockStream` alias = `VsockStream` on Linux, `TcpStream` off-Linux). Error `kind()` is preserved so refused/timeout/reset stay distinguishable.

`tokio-vsock` (0.7.2, verified on crates.io/docs.rs; reuses the workspace tokio) is an **optional, Linux-target-gated, `addons`-feature-only** dep — it never enters the sealed default closure:

```
DEFAULT closure (aarch64-unknown-linux-musl): 0 tokio-vsock lines
ADDONS closure: tokio-vsock v0.7.2 present
check-guest-agent-runtime-free: clean   check-closure-budget: 266 (at budget)
```

Gates (rustup 1.96): fmt, clippy (default + `--features addons` + workspace) all `-D warnings` clean; `nextest -p mvm-agentd` 460 pass / `--features addons` 515 pass; and `cargo zigbuild --target aarch64-unknown-linux-musl --features addons` compiles the native path for the real guest target. Note: overlaps `mvm-agentd/Cargo.toml` with the nix-consolidation branch — trivial dep-list conflict, resolved at merge.