### PR TITLE
refactor(mvm-agentd): consolidate guest AF_VSOCK sites onto a nix leaf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,6 +2676,7 @@ dependencies = [
  "libc",
  "mvm-core",
  "mvm-protocol",
+ "nix 0.29.0",
  "rand 0.8.6",
  "schemars",
  "seccompiler",
@@ -3072,6 +3073,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/crates/mvm-agentd/Cargo.toml
+++ b/crates/mvm-agentd/Cargo.toml
@@ -212,6 +212,13 @@ seccompiler = { workspace = true }
 # it enters only the `addons` closure — the sealed agent's default tree stays
 # tokio-free. Reuses the workspace tokio.
 tokio-vsock = { version = "0.7", optional = true }
+# AF_VSOCK socket primitives for the guest's synchronous vsock leaf
+# (`vsock/sys.rs`): the forward-proxy dial, the one-shot exit reporter, and
+# the builder agent's listener share one nix-backed path instead of three
+# hand-rolled `sockaddr_vm` + raw-`libc` sites. Same 0.29 the runtime and
+# build crates already vendor; its `socket` feature pulls one small transitive
+# (`memoffset`), accounted for in the closure budget.
+nix = { version = "0.29", features = ["socket"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/mvm-agentd/src/bin/mvm-builder-agent.rs
+++ b/crates/mvm-agentd/src/bin/mvm-builder-agent.rs
@@ -1,37 +1,25 @@
+// The vsock leaf (`sys`) is Linux-only, so the accept loop lives behind a
+// Linux `main`; the request-handling helpers stay compiled (but unused) off
+// Linux so the workspace still builds on macOS dev hosts.
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
 use std::io::{BufRead, BufReader, Write};
-use std::mem::size_of;
-use std::os::fd::{FromRawFd, RawFd};
+use std::os::fd::OwnedFd;
 use std::process::{Command, Stdio};
 
 use mvm_agentd::builder_agent::{
     HostVmRequest, HostVmResponse, load_security_policy, validate_build_attr, validate_flake_ref,
 };
+#[cfg(target_os = "linux")]
+use mvm_agentd::vsock::sys;
 
-const AF_VSOCK: i32 = 40;
-const SOCK_STREAM: i32 = 1;
-const VMADDR_CID_ANY: u32 = 0xFFFF_FFFF;
 const PORT: u32 = mvm_agentd::builder_agent::BUILDER_AGENT_PORT;
 
-#[repr(C)]
-struct SockAddrVm {
-    svm_family: u16,
-    svm_reserved1: u16,
-    svm_port: u32,
-    svm_cid: u32,
-    svm_zero: [u8; 4],
-}
+/// Accept-queue depth for the builder-agent listener.
+const LISTEN_BACKLOG: i32 = 16;
 
-unsafe extern "C" {
-    fn socket(domain: i32, typ: i32, protocol: i32) -> i32;
-    fn bind(sockfd: i32, addr: *const core::ffi::c_void, addrlen: u32) -> i32;
-    fn listen(sockfd: i32, backlog: i32) -> i32;
-    fn accept(sockfd: i32, addr: *mut core::ffi::c_void, addrlen: *mut u32) -> i32;
-    fn close(fd: i32) -> i32;
-}
-
-fn handle_client(fd: RawFd) {
-    // SAFETY: fd comes from accept and is a valid file descriptor owned by this function.
-    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+fn handle_client(conn: OwnedFd) {
+    let file = std::fs::File::from(conn);
     let mut reader = BufReader::new(file);
     let mut line = String::new();
 
@@ -393,55 +381,27 @@ fn run_build(
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
 fn main() {
-    // SAFETY: libc call, arguments are constant values.
-    let fd = unsafe { socket(AF_VSOCK, SOCK_STREAM, 0) };
-    if fd < 0 {
-        eprintln!("failed to create vsock socket");
-        std::process::exit(1);
-    }
-
-    let addr = SockAddrVm {
-        svm_family: AF_VSOCK as u16,
-        svm_reserved1: 0,
-        svm_port: PORT,
-        svm_cid: VMADDR_CID_ANY,
-        svm_zero: [0; 4],
-    };
-
-    // SAFETY: pointers are valid for the specified size.
-    let bind_rc = unsafe {
-        bind(
-            fd,
-            &addr as *const SockAddrVm as *const core::ffi::c_void,
-            size_of::<SockAddrVm>() as u32,
-        )
-    };
-    if bind_rc != 0 {
-        eprintln!("failed to bind vsock socket");
-        // SAFETY: fd is valid.
-        unsafe {
-            close(fd);
+    let listener = match sys::bind_listen(sys::ANY_CID, PORT, LISTEN_BACKLOG) {
+        Ok(listener) => listener,
+        Err(e) => {
+            eprintln!("failed to bind/listen vsock socket: {e}");
+            std::process::exit(1);
         }
-        std::process::exit(1);
-    }
-
-    // SAFETY: fd is valid.
-    if unsafe { listen(fd, 16) } != 0 {
-        eprintln!("failed to listen on vsock socket");
-        // SAFETY: fd is valid.
-        unsafe {
-            close(fd);
-        }
-        std::process::exit(1);
-    }
+    };
 
     loop {
-        // SAFETY: null addr pointers are allowed for accept when peer addr is not needed.
-        let cfd = unsafe { accept(fd, std::ptr::null_mut(), std::ptr::null_mut()) };
-        if cfd < 0 {
-            continue;
+        match sys::accept(&listener) {
+            Ok(conn) => handle_client(conn),
+            // A transient accept failure is not fatal; keep serving.
+            Err(_) => continue,
         }
-        handle_client(cfd);
     }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("mvm-builder-agent: Linux-only binary (AF_VSOCK); not buildable on this target");
+    std::process::exit(1);
 }

--- a/crates/mvm-agentd/src/bin/mvm-exit-report.rs
+++ b/crates/mvm-agentd/src/bin/mvm-exit-report.rs
@@ -28,39 +28,13 @@ fn main() -> ExitCode {
 fn report(code: i32) -> std::io::Result<()> {
     use std::io::Write;
     use std::net::TcpStream;
-    use std::os::fd::FromRawFd;
 
-    // Must match mvm_agentd::vsock::WORKLOAD_EXIT_PORT — duplicated here so
-    // this one-shot helper stays a minimal, dependency-free syscall path.
-    // Keep in sync manually.
-    const WORKLOAD_EXIT_PORT: u32 = 5251;
-    const VMADDR_CID_HOST: u32 = 2;
+    use mvm_agentd::vsock::{HOST_CID, WORKLOAD_EXIT_PORT, sys};
 
-    let fd = unsafe { libc::socket(libc::AF_VSOCK, libc::SOCK_STREAM, 0) };
-    if fd < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    let addr = libc::sockaddr_vm {
-        svm_family: libc::AF_VSOCK as libc::sa_family_t,
-        svm_reserved1: 0,
-        svm_port: WORKLOAD_EXIT_PORT,
-        svm_cid: VMADDR_CID_HOST,
-        svm_zero: [0; 4],
-    };
-    let rc = unsafe {
-        libc::connect(
-            fd,
-            (&addr as *const libc::sockaddr_vm).cast::<libc::sockaddr>(),
-            std::mem::size_of::<libc::sockaddr_vm>() as libc::socklen_t,
-        )
-    };
-    if rc < 0 {
-        let err = std::io::Error::last_os_error();
-        unsafe { libc::close(fd) };
-        return Err(err);
-    }
-    // SAFETY: fd is a valid connected AF_VSOCK stream we own.
-    let mut stream = unsafe { TcpStream::from_raw_fd(fd) };
+    let fd = sys::dial(HOST_CID, WORKLOAD_EXIT_PORT)?;
+    // A vsock SOCK_STREAM fd wrapped as a `TcpStream` for its `Read`/`Write`;
+    // read/write hit the same syscalls regardless of the wrapper type.
+    let mut stream = TcpStream::from(fd);
     stream.write_all(&code.to_le_bytes())?;
     stream.flush()?;
     // Wait (bounded) for the host's ack so /init doesn't poweroff until

--- a/crates/mvm-agentd/src/vsock/connection.rs
+++ b/crates/mvm-agentd/src/vsock/connection.rs
@@ -256,58 +256,10 @@ pub const HOST_CID: u32 = 2;
 /// length-prefixed frame helpers ([`read_frame`]/[`write_frame`]) work over it
 /// unchanged.
 pub fn connect_host_vsock(port: u32, timeout_secs: u64) -> Result<UnixStream> {
-    use std::os::fd::FromRawFd;
-
-    const AF_VSOCK: libc::c_int = 40;
-    // Kernel uapi `struct sockaddr_vm`: family u16 + reserved u16 + port u32 +
-    // cid u32 + 4-byte pad = 16 (== sizeof(struct sockaddr)).
-    #[repr(C)]
-    struct SockaddrVm {
-        svm_family: libc::sa_family_t,
-        svm_reserved1: u16,
-        svm_port: u32,
-        svm_cid: u32,
-        svm_zero: [u8; 4],
-    }
-    const _: () = assert!(std::mem::size_of::<SockaddrVm>() == 16);
-
     let mut last_err = None;
     let mut stream = None;
     for attempt in 0..CONNECT_RETRIES {
-        // SAFETY: standard socket(2)/connect(2) on AF_VSOCK; `addr` is fully
-        // initialized and sized exactly. The fd is adopted by `UnixStream` on
-        // success (closed on its drop) or closed explicitly on the error path.
-        let connect_result = unsafe {
-            let fd = libc::socket(AF_VSOCK, libc::SOCK_STREAM, 0);
-            if fd < 0 {
-                Err(anyhow::Error::from(std::io::Error::last_os_error())
-                    .context("AF_VSOCK socket()"))
-            } else {
-                let addr = SockaddrVm {
-                    svm_family: AF_VSOCK as libc::sa_family_t,
-                    svm_reserved1: 0,
-                    svm_port: port,
-                    svm_cid: HOST_CID,
-                    svm_zero: [0; 4],
-                };
-                let rc = libc::connect(
-                    fd,
-                    std::ptr::addr_of!(addr).cast::<libc::sockaddr>(),
-                    std::mem::size_of::<SockaddrVm>() as libc::socklen_t,
-                );
-                if rc < 0 {
-                    let err = std::io::Error::last_os_error();
-                    libc::close(fd);
-                    Err(anyhow::Error::from(err).context(format!(
-                        "AF_VSOCK connect to host CID {HOST_CID} port {port}"
-                    )))
-                } else {
-                    Ok(UnixStream::from_raw_fd(fd))
-                }
-            }
-        };
-
-        match connect_result {
+        match dial_host_once(port) {
             Ok(open_stream) => {
                 stream = Some(open_stream);
                 break;
@@ -337,6 +289,23 @@ pub fn connect_host_vsock(port: u32, timeout_secs: u64) -> Result<UnixStream> {
     stream.set_read_timeout(Some(timeout)).ok();
     stream.set_write_timeout(Some(timeout)).ok();
     Ok(stream)
+}
+
+/// One guest→host AF_VSOCK dial attempt, wrapping the leaf's owned fd as a
+/// [`UnixStream`]. The `anyhow` context carries the io::Error as its root
+/// cause so [`connect_host_vsock`]'s transient-error classifier keys on it.
+#[cfg(target_os = "linux")]
+fn dial_host_once(port: u32) -> Result<UnixStream> {
+    let fd = crate::vsock::sys::dial(HOST_CID, port)
+        .with_context(|| format!("AF_VSOCK connect to host CID {HOST_CID} port {port}"))?;
+    Ok(UnixStream::from(fd))
+}
+
+/// The guest→host vsock path is Linux-only; the workspace still compiles on
+/// macOS dev hosts, where this direction is never dialed.
+#[cfg(not(target_os = "linux"))]
+fn dial_host_once(port: u32) -> Result<UnixStream> {
+    bail!("guest→host AF_VSOCK dial to port {port} is Linux-only")
 }
 
 /// Connect to the guest vsock agent via the fleet-mode instance directory convention.

--- a/crates/mvm-agentd/src/vsock/mod.rs
+++ b/crates/mvm-agentd/src/vsock/mod.rs
@@ -19,6 +19,10 @@ mod request_policy;
 mod response;
 mod response_payloads;
 mod rpc;
+/// AF_VSOCK socket primitives shared by the guest's synchronous vsock sites
+/// (forward-proxy dial, exit reporter, builder-agent listener). Linux-only;
+/// an empty module elsewhere. Public so the one-shot guest bins can reach it.
+pub mod sys;
 mod verb_grant;
 
 pub use api::{

--- a/crates/mvm-agentd/src/vsock/sys.rs
+++ b/crates/mvm-agentd/src/vsock/sys.rs
@@ -1,0 +1,102 @@
+//! AF_VSOCK socket primitives shared by the guest's synchronous vsock sites.
+//!
+//! One leaf backing three callers — the forward-proxy client dial, the
+//! one-shot workload-exit reporter, and the builder agent's listener — so the
+//! `sockaddr_vm` layout and the socket/connect/bind/listen/accept syscalls
+//! live in exactly one place instead of three hand-rolled copies. Depends only
+//! on `nix` and `std`: no framing, serde, or async runtime, so the minimal
+//! one-shot bins that call it keep a lean closure.
+//!
+//! `nix::sys::socket::socket` hands back an [`OwnedFd`], so each caller wraps
+//! the result in whatever stream type it already exposes (`UnixStream`,
+//! `TcpStream`, `File`) with a safe `From<OwnedFd>` conversion — the manual
+//! `close`-on-error and the raw-`libc` `unsafe` blocks disappear.
+
+#![cfg(target_os = "linux")]
+
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+use nix::sys::socket as sock;
+
+/// Bind CID that accepts connections from any peer (`VMADDR_CID_ANY`).
+/// Servers listen on this rather than a specific CID.
+pub const ANY_CID: u32 = libc::VMADDR_CID_ANY;
+
+/// Create a blocking AF_VSOCK stream socket as an owned fd.
+fn vsock_stream_socket() -> io::Result<OwnedFd> {
+    // `socket()` infers the protocol slot from `None`; vsock has a single
+    // stream protocol so an explicit protocol is neither needed nor accepted.
+    let protocol: Option<sock::SockProtocol> = None;
+    sock::socket(
+        sock::AddressFamily::Vsock,
+        sock::SockType::Stream,
+        sock::SockFlag::empty(),
+        protocol,
+    )
+    .map_err(io::Error::from)
+}
+
+/// Open a connected AF_VSOCK stream to `(cid, port)`.
+///
+/// The returned [`OwnedFd`] closes on drop, so a failure mid-dial (whether at
+/// `socket()` or `connect()`) needs no manual cleanup.
+pub fn dial(cid: u32, port: u32) -> io::Result<OwnedFd> {
+    let fd = vsock_stream_socket()?;
+    sock::connect(fd.as_raw_fd(), &sock::VsockAddr::new(cid, port)).map_err(io::Error::from)?;
+    Ok(fd)
+}
+
+/// Bind an AF_VSOCK stream socket to `(cid, port)` and start listening.
+///
+/// `backlog` is the accept-queue depth. Returns the listening socket as an
+/// [`OwnedFd`].
+pub fn bind_listen(cid: u32, port: u32, backlog: i32) -> io::Result<OwnedFd> {
+    let fd = vsock_stream_socket()?;
+    sock::bind(fd.as_raw_fd(), &sock::VsockAddr::new(cid, port)).map_err(io::Error::from)?;
+    let backlog = sock::Backlog::new(backlog).map_err(io::Error::from)?;
+    sock::listen(&fd, backlog).map_err(io::Error::from)?;
+    Ok(fd)
+}
+
+/// Accept one connection from a listening AF_VSOCK socket.
+pub fn accept(listener: &OwnedFd) -> io::Result<OwnedFd> {
+    let raw = sock::accept(listener.as_raw_fd()).map_err(io::Error::from)?;
+    // SAFETY: `accept(2)` returns a fresh descriptor this process exclusively
+    // owns; adopting it into an `OwnedFd` gives it RAII close-on-drop. nix's
+    // `accept` returns a bare `RawFd`, so this is the one place the fresh fd
+    // must be taken ownership of explicitly.
+    Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nix::sys::socket::{AddressFamily, SockaddrLike, VsockAddr};
+
+    #[test]
+    fn vsock_addr_maps_family_cid_port() {
+        let addr = VsockAddr::new(2, 5251);
+        assert_eq!(addr.family(), Some(AddressFamily::Vsock));
+        assert_eq!(addr.cid(), 2);
+        assert_eq!(addr.port(), 5251);
+    }
+
+    #[test]
+    fn any_cid_is_the_wildcard_bind_value() {
+        assert_eq!(ANY_CID, 0xFFFF_FFFF);
+    }
+
+    #[test]
+    fn dial_to_dead_port_surfaces_os_error() {
+        // Nothing binds this (cid, port): the runner either lacks AF_VSOCK
+        // (socket() fails) or refuses/resets the connect — both must surface
+        // as an OS-level io::Error rather than panic, and the transient
+        // classifier in `connection.rs` keys on exactly that io::Error.
+        let err = dial(2, 9).expect_err("dial to an unbound vsock port must fail");
+        assert!(
+            err.raw_os_error().is_some(),
+            "expected an OS error, got {err:?}"
+        );
+    }
+}

--- a/xtask/src/check_closure_budget.rs
+++ b/xtask/src/check_closure_budget.rs
@@ -38,7 +38,15 @@ const BUDGET_TARGET: &str = "x86_64-unknown-linux-gnu";
 /// `x25519-dalek` for ephemeral host↔guest key agreement; the three-crate
 /// increase is the measured cost of keeping that security boundary in the
 /// default control path.
-const CLOSURE_BUDGET: usize = 266;
+///
+/// 267 (was 266): consolidating the guest's three hand-rolled AF_VSOCK sites
+/// onto one `nix::sys::socket` leaf enables nix's `socket` feature, whose lone
+/// build-time transitive (`memoffset`, an `offset_of!` helper with no further
+/// deps) enters the default Linux closure. That one crate is the cost of
+/// deleting the hand-rolled `sockaddr_vm` + raw-`libc`
+/// socket/connect/bind/listen/accept boilerplate — nix exposes no AF_VSOCK API
+/// without the `socket` feature. Lower it freely as deps drop.
+const CLOSURE_BUDGET: usize = 267;
 
 pub fn run(workspace: &Path) -> Result<()> {
     let count = default_closure_crate_count(workspace)?;


### PR DESCRIPTION
Three guest sites each hand-rolled a `sockaddr_vm` layout + raw-`libc` socket/connect/bind/listen/accept with their own `AF_VSOCK` constants: the forward-proxy dial (`connection.rs`), the one-shot `mvm-exit-report`, and the `mvm-builder-agent` listener. This replaces all three with one Linux-gated `vsock/sys.rs` leaf over `nix::sys::socket` (`dial` / `bind_listen` / `accept`) returning `OwnedFd`, so the manual `close`-on-error and the raw `unsafe` blocks disappear — one justified `unsafe` remains for adopting `accept`'s fresh fd. The leaf depends only on `nix` + `std` (no serde/framing), so the minimal one-shot bins keep a lean closure.

Cost: enabling nix's `socket` feature pulls **`memoffset`** (an `offset_of!` helper, no further deps) into the default closure, so `check-closure-budget` is bumped 266→267 with a justification. Not free, but it's the price of deleting three copies of unsafe ABI boilerplate.

Verified (rustup 1.96): fmt, `clippy --workspace -D warnings`, `nextest -p mvm-agentd` 460 pass, `check-guest-agent-runtime-free` clean (still no tokio), `check-closure-budget` 267, `check-no-spec-refs-in-comments` clean, and `cargo zigbuild --target aarch64-unknown-linux-musl` compiles the Linux-only `sys.rs` for the real guest target. Overlaps `mvm-agentd/Cargo.toml` with #1863 (both add a Linux dep) — trivial conflict, resolved at merge.