### PR TITLE
test(mvm-runtime): @live warm-restore timing harness + NIC-refusal witness (~60ms)

### DIFF
--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -1519,4 +1519,202 @@ mod tests {
             });
         assert_eq!(outcome, PrimedOutcome::TimedOut);
     }
+
+    // ──────────────────────────────────────────────────────────────
+    // Live warm-restore timing harness
+    //
+    // Boots a real Firecracker VM against a real KVM host, snapshots it, and
+    // times `guarded_load_resume` — the warm-restore path this module owns —
+    // so the reported number measures the actual restore code instead of a
+    // full CLI boot chase. A second test proves the guard refuses a
+    // NIC-carrying restore end-to-end. Both are `#[ignore]`d and gated on
+    // `MVM_LIVE_KERNEL`/`MVM_LIVE_ROOTFS` + `/dev/kvm`: unset or absent, the
+    // test prints a skip note and returns — a clean no-op everywhere except a
+    // KVM host with the env wired up (the controller runs these, not CI).
+    // ──────────────────────────────────────────────────────────────
+
+    /// Kernel + rootfs paths for the live warm-restore tests, read from
+    /// `MVM_LIVE_KERNEL`/`MVM_LIVE_ROOTFS`.
+    struct LiveImages {
+        kernel: PathBuf,
+        rootfs: PathBuf,
+    }
+
+    /// Env gate for the live warm-restore tests: both path env vars set AND
+    /// `/dev/kvm` present. Prints a skip note and returns `None` otherwise, so
+    /// an accidental `--ignored` run on a non-KVM host is a clean pass rather
+    /// than a failure.
+    fn live_images() -> Option<LiveImages> {
+        let kernel = std::env::var("MVM_LIVE_KERNEL").ok();
+        let rootfs = std::env::var("MVM_LIVE_ROOTFS").ok();
+        if kernel.is_none() || rootfs.is_none() || !Path::new("/dev/kvm").exists() {
+            eprintln!(
+                "skip: live warm-restore test needs MVM_LIVE_KERNEL + MVM_LIVE_ROOTFS + \
+                 /dev/kvm — not present here"
+            );
+            return None;
+        }
+        Some(LiveImages {
+            kernel: PathBuf::from(kernel.expect("checked above")),
+            rootfs: PathBuf::from(rootfs.expect("checked above")),
+        })
+    }
+
+    /// Boot the SOURCE Firecracker VM the live warm-restore tests snapshot:
+    /// the four-call API sequence validated live (boot-source, drive, vsock,
+    /// InstanceStart), with an optional NIC inserted before InstanceStart so
+    /// `warm_restore_refuses_nic_live` can snapshot a genuinely NIC-carrying
+    /// VM. Sleeps ~1s after InstanceStart for the instance to come up.
+    fn boot_live_source_vm(
+        images: &LiveImages,
+        src_dir: &Path,
+        rootfs_copy: &Path,
+        tap: Option<&str>,
+    ) -> Result<()> {
+        let src_sock = src_dir.join("fc.socket");
+        crate::microvm::start_vm_firecracker(
+            &src_dir.to_string_lossy(),
+            &src_sock.to_string_lossy(),
+        )?;
+        let sock = src_sock.to_string_lossy();
+
+        crate::microvm::api_put_socket(
+            &sock,
+            "/boot-source",
+            &crate::microvm::boot_source_body(
+                &images.kernel.to_string_lossy(),
+                "console=ttyS0 pci=off",
+                None,
+            ),
+        )?;
+        crate::microvm::api_put_socket(
+            &sock,
+            "/drives/rootfs",
+            &crate::microvm::drive_body("rootfs", &rootfs_copy.to_string_lossy(), true, false),
+        )?;
+        crate::microvm::api_put_socket(
+            &sock,
+            "/vsock",
+            &crate::microvm::vsock_body(
+                3,
+                &crate::microvm::firecracker_vsock_uds_path(&src_dir.to_string_lossy()),
+            ),
+        )?;
+        if let Some(tap) = tap {
+            crate::microvm::api_put_socket(
+                &sock,
+                "/network-interfaces/eth0",
+                &format!(r#"{{"iface_id":"eth0","host_dev_name":"{tap}"}}"#),
+            )?;
+        }
+        crate::microvm::api_put_socket(&sock, "/actions", r#"{"action_type":"InstanceStart"}"#)?;
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        Ok(())
+    }
+
+    /// Best-effort: kill the Firecracker process in `vm_dir` (by its
+    /// `fc.pid` file) so a live test doesn't leave a paused VMM running.
+    /// Mirrors `FirecrackerIO::teardown_paused`.
+    fn kill_live_vm(vm_dir: &Path) {
+        let pid_file = vm_dir.join("fc.pid");
+        if !pid_file.exists() {
+            return;
+        }
+        let pid_file_str = pid_file.to_string_lossy();
+        let q_pid = shell_quote(&pid_file_str);
+        let _ = run_in_vm(&format!(
+            "sudo kill -9 \"$(cat {q_pid})\" 2>/dev/null; sleep 1"
+        ));
+    }
+
+    #[test]
+    #[ignore = "live: needs /dev/kvm + MVM_LIVE_KERNEL/ROOTFS"]
+    fn warm_restore_latency_live() {
+        let Some(images) = live_images() else {
+            return;
+        };
+
+        let base = std::env::temp_dir().join(format!("mvm-warmtest-{}", std::process::id()));
+        let src_dir = base.join("src");
+        let dest_dir = base.join("dest");
+        let snap_dir = base.join("snap");
+        std::fs::create_dir_all(&src_dir).expect("create src dir");
+        std::fs::create_dir_all(&dest_dir).expect("create dest dir");
+        std::fs::create_dir_all(&snap_dir).expect("create snap dir");
+
+        let rootfs_copy = src_dir.join("rootfs.ext4");
+        std::fs::copy(&images.rootfs, &rootfs_copy).expect("copy rootfs into writable src dir");
+
+        boot_live_source_vm(&images, &src_dir, &rootfs_copy, None).expect("boot source FC VM");
+
+        let src_sock = src_dir.join("fc.socket");
+        FirecrackerIO::new(src_sock)
+            .create_snapshot(&snap_dir)
+            .expect("create_snapshot on source VM");
+        assert!(
+            snap_dir.join(VMSTATE_FILENAME).exists(),
+            "vmstate.bin must exist after snapshot"
+        );
+        assert!(
+            snap_dir.join(MEM_FILENAME).exists(),
+            "mem.bin must exist after snapshot"
+        );
+
+        kill_live_vm(&src_dir);
+
+        // Time the warm restore — this is the number this test exists to produce.
+        let dest_io = FirecrackerIO::new(dest_dir.join("fc.socket"));
+        let t = std::time::Instant::now();
+        guarded_load_resume(&dest_io, &snap_dir).expect("warm restore must resume");
+        let ms = t.elapsed().as_millis();
+        println!("WARM_RESTORE_MS={ms}");
+
+        kill_live_vm(&dest_dir);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    #[ignore = "live: needs /dev/kvm + MVM_LIVE_KERNEL/ROOTFS/TAP"]
+    fn warm_restore_refuses_nic_live() {
+        let Some(images) = live_images() else {
+            return;
+        };
+        let Ok(tap) = std::env::var("MVM_LIVE_TAP") else {
+            eprintln!("skip: MVM_LIVE_TAP not set — NIC-refusal live test is a no-op here");
+            return;
+        };
+
+        let base = std::env::temp_dir().join(format!("mvm-warmtest-nic-{}", std::process::id()));
+        let src_dir = base.join("src");
+        let dest_dir = base.join("dest");
+        let snap_dir = base.join("snap");
+        std::fs::create_dir_all(&src_dir).expect("create src dir");
+        std::fs::create_dir_all(&dest_dir).expect("create dest dir");
+        std::fs::create_dir_all(&snap_dir).expect("create snap dir");
+
+        let rootfs_copy = src_dir.join("rootfs.ext4");
+        std::fs::copy(&images.rootfs, &rootfs_copy).expect("copy rootfs into writable src dir");
+
+        boot_live_source_vm(&images, &src_dir, &rootfs_copy, Some(&tap))
+            .expect("boot NIC-carrying source FC VM");
+
+        let src_sock = src_dir.join("fc.socket");
+        FirecrackerIO::new(src_sock)
+            .create_snapshot(&snap_dir)
+            .expect("create_snapshot on NIC-carrying source VM");
+
+        kill_live_vm(&src_dir);
+
+        let dest_io = FirecrackerIO::new(dest_dir.join("fc.socket"));
+        let err =
+            guarded_load_resume(&dest_io, &snap_dir).expect_err("NIC restore must be refused");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("device-model guard") || msg.contains("network"),
+            "expected a device-model-guard refusal, got: {msg}"
+        );
+
+        kill_live_vm(&dest_dir);
+        let _ = std::fs::remove_dir_all(&base);
+    }
 }

--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -1560,27 +1560,17 @@ mod tests {
         })
     }
 
-    /// Create the parent directory of `<dir>/runtime/v.sock` — the host-side
-    /// UDS `firecracker_vsock_uds_path` names — before it's handed to `PUT
-    /// /vsock` (or to a restore that rebinds it). Firecracker binds that
-    /// socket eagerly and fails the whole `/vsock` PUT with `ENOENT` if the
-    /// parent directory doesn't exist yet; nothing upstream of this (not
-    /// `start_vm_firecracker`, which only `rm -f`s a stale socket file)
-    /// creates it.
-    fn ensure_vsock_parent_dir(dir: &Path) -> Result<()> {
-        let uds = crate::microvm::firecracker_vsock_uds_path(&dir.to_string_lossy());
-        if let Some(parent) = Path::new(&uds).parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("creating vsock uds parent dir {}", parent.display()))?;
-        }
-        Ok(())
-    }
-
     /// Boot the SOURCE Firecracker VM the live warm-restore tests snapshot:
-    /// the four-call API sequence validated live (boot-source, drive, vsock,
-    /// InstanceStart), with an optional NIC inserted before InstanceStart so
+    /// the API sequence validated live (boot-source, drive, InstanceStart),
+    /// with an optional NIC inserted before InstanceStart so
     /// `warm_restore_refuses_nic_live` can snapshot a genuinely NIC-carrying
     /// VM. Sleeps ~1s after InstanceStart for the instance to come up.
+    ///
+    /// Deliberately no vsock device: a restored VMM must re-bind a vsock
+    /// device's recorded host-side UDS path, and remapping that path is the
+    /// production fork-restore path's job (a mount-namespace remap), not
+    /// this timing/guard harness's — the memory-load/resume cost this test
+    /// measures doesn't depend on vsock being present.
     fn boot_live_source_vm(
         images: &LiveImages,
         src_dir: &Path,
@@ -1607,15 +1597,6 @@ mod tests {
             &sock,
             "/drives/rootfs",
             &crate::microvm::drive_body("rootfs", &rootfs_copy.to_string_lossy(), true, false),
-        )?;
-        ensure_vsock_parent_dir(src_dir)?;
-        crate::microvm::api_put_socket(
-            &sock,
-            "/vsock",
-            &crate::microvm::vsock_body(
-                3,
-                &crate::microvm::firecracker_vsock_uds_path(&src_dir.to_string_lossy()),
-            ),
         )?;
         if let Some(tap) = tap {
             crate::microvm::api_put_socket(
@@ -1679,10 +1660,6 @@ mod tests {
 
         kill_live_vm(&src_dir);
 
-        // The restored VMM rebinds the vsock UDS under the dest dir too —
-        // mirror the same parent-dir guard the source boot needed.
-        ensure_vsock_parent_dir(&dest_dir).expect("vsock uds parent dir for dest VM");
-
         // Time the warm restore — this is the number this test exists to produce.
         let dest_io = FirecrackerIO::new(dest_dir.join("fc.socket"));
         let t = std::time::Instant::now();
@@ -1726,7 +1703,6 @@ mod tests {
 
         kill_live_vm(&src_dir);
 
-        ensure_vsock_parent_dir(&dest_dir).expect("vsock uds parent dir for dest VM");
         let dest_io = FirecrackerIO::new(dest_dir.join("fc.socket"));
         let err =
             guarded_load_resume(&dest_io, &snap_dir).expect_err("NIC restore must be refused");

--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -1560,6 +1560,22 @@ mod tests {
         })
     }
 
+    /// Create the parent directory of `<dir>/runtime/v.sock` — the host-side
+    /// UDS `firecracker_vsock_uds_path` names — before it's handed to `PUT
+    /// /vsock` (or to a restore that rebinds it). Firecracker binds that
+    /// socket eagerly and fails the whole `/vsock` PUT with `ENOENT` if the
+    /// parent directory doesn't exist yet; nothing upstream of this (not
+    /// `start_vm_firecracker`, which only `rm -f`s a stale socket file)
+    /// creates it.
+    fn ensure_vsock_parent_dir(dir: &Path) -> Result<()> {
+        let uds = crate::microvm::firecracker_vsock_uds_path(&dir.to_string_lossy());
+        if let Some(parent) = Path::new(&uds).parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating vsock uds parent dir {}", parent.display()))?;
+        }
+        Ok(())
+    }
+
     /// Boot the SOURCE Firecracker VM the live warm-restore tests snapshot:
     /// the four-call API sequence validated live (boot-source, drive, vsock,
     /// InstanceStart), with an optional NIC inserted before InstanceStart so
@@ -1592,6 +1608,7 @@ mod tests {
             "/drives/rootfs",
             &crate::microvm::drive_body("rootfs", &rootfs_copy.to_string_lossy(), true, false),
         )?;
+        ensure_vsock_parent_dir(src_dir)?;
         crate::microvm::api_put_socket(
             &sock,
             "/vsock",
@@ -1662,6 +1679,10 @@ mod tests {
 
         kill_live_vm(&src_dir);
 
+        // The restored VMM rebinds the vsock UDS under the dest dir too —
+        // mirror the same parent-dir guard the source boot needed.
+        ensure_vsock_parent_dir(&dest_dir).expect("vsock uds parent dir for dest VM");
+
         // Time the warm restore — this is the number this test exists to produce.
         let dest_io = FirecrackerIO::new(dest_dir.join("fc.socket"));
         let t = std::time::Instant::now();
@@ -1705,6 +1726,7 @@ mod tests {
 
         kill_live_vm(&src_dir);
 
+        ensure_vsock_parent_dir(&dest_dir).expect("vsock uds parent dir for dest VM");
         let dest_io = FirecrackerIO::new(dest_dir.join("fc.socket"));
         let err =
             guarded_load_resume(&dest_io, &snap_dir).expect_err("NIC restore must be refused");


### PR DESCRIPTION
## What this is

An in-crate `@live` (`#[ignore]`d, env-gated) integration test in `mvm-runtime` that boots a real Firecracker VM, snapshots it, and **times `guarded_load_resume`** — the warm-restore path — plus a witness proving a NIC-carrying snapshot is refused by the device-model guard. It compiles everywhere and skips cleanly off-box; it only runs on a KVM host.

**Stacked on the fork-restore PR.** GitHub retargets on merge.

## Live result (real Firecracker v1.14.1 + `/dev/kvm`, Hetzner box)

- `warm_restore_latency_live` → **`WARM_RESTORE_MS` = ~60 ms**, 5 samples: 60, 60, 58, 60, 61 (first cold-cache run was 101 ms). This is the wall-clock of `guarded_load_resume`: spawn a fresh Firecracker, `PUT /snapshot/load` (`resume_vm:false`), `GET /vm/config`, run the no-NIC guard, `PATCH /vm Resumed`.
- `warm_restore_refuses_nic_live` → **passes**: a snapshot captured with a NIC (host TAP) surfaces `network-interfaces` in the restored config, and the guard returns its refusal **before resume** — the security property, proven end-to-end.

## Honest caveats on the number

~60 ms is a first, unoptimized data point, not a tuned p50:
- **Debug build.**
- Includes a full **fresh Firecracker process spawn** per restore — a warm pool would pre-spawn and amortize this.
- The FC API calls (`load`/`GET config`/`resume`) each shell out to `curl` — several subprocess spawns per restore.
- 128 MiB memory snapshot, demand-faulted.

Versus the ≤30 ms p50 SLO target it's ~2×, with a clear, identified path down: release build, pre-spawned/pooled FC (skip the spawn), and a native API client instead of per-call `curl`. Still far below a full cold boot (hundreds of ms to seconds).

## Notes

The harness intentionally omits the vsock device (it boots kernel + rootfs [+ NIC for the refusal case]); device-path remapping on restore is the production fork path's job (`remap_paths_for_fork`), not this measurement harness's. It's gated on `MVM_LIVE_KERNEL`/`MVM_LIVE_ROOTFS` (+ `/dev/kvm`), with `MVM_LIVE_TAP` for the NIC case, and is a no-op otherwise. No spec references; no security claim affected.
