### PR TITLE
feat(mvm-runtime): Plan 265 warm restore — no-NIC guard on pause/resume + fork un-bail + live @live harness + positioning docs

### DIFF
--- a/crates/mvm-runtime/src/microvm/snapshot.rs
+++ b/crates/mvm-runtime/src/microvm/snapshot.rs
@@ -5,23 +5,27 @@
 //! loading a snapshot paused and resuming it — see there for the full
 //! ordering. That path backs the live `mvmctl pause`/`resume` cycle today.
 //!
-//! The template and fork restore entry points below stay refused. Neither
-//! one's sealed content is verified by that same instance-HMAC path: a
-//! template snapshot carries its own Ed25519 + HMAC sidecar (a stronger,
-//! separate check), and a forked checkpoint is content-addressed and
-//! audit-chain-verified upstream of these calls (see the checkpoint lineage
-//! module) rather than instance-HMAC-sealed. Routing either through the
-//! instance verifier would either silently drop a check it currently gets or
-//! fail closed on content that verifier was never meant to see. Re-enabling
-//! them needs a design that keeps each path's own integrity check and adds
-//! the same load-paused → read-device-model → guard → resume ordering on top
-//! of it.
+//! `warm_restore_instance_from_path` reuses the same load → guard → resume
+//! ordering via `guarded_load_resume`, but skips the instance-snapshot HMAC
+//! verify: its caller (the fork restore path) already established the
+//! content's integrity upstream via the checkpoint lineage's content-address
+//! and audit-chain checks, so a second verifier here would either be
+//! redundant or fail closed on content it was never meant to see.
+//!
+//! The template restore entry point and the bare `warm_restore_instance`
+//! stay refused. A template snapshot carries its own Ed25519 + HMAC sidecar
+//! (a separate, stronger check) that isn't wired up yet; `warm_restore_instance`
+//! has no caller. Re-enabling either needs a design that keeps its own
+//! integrity check and adds the same guard ordering on top of it.
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use tracing::instrument;
 
 use crate::base::shell::shell_quote;
+use crate::vm::instance_snapshot::{
+    FirecrackerIO, VsockPostRestoreSignal, guarded_load_resume, signal_post_restore,
+};
 
 use super::daemon::api_put_socket;
 use super::{abs_vms_dir, require_linux_env};
@@ -48,16 +52,14 @@ pub fn restore_from_template_snapshot(
     );
 }
 
-/// Refuse live-memory restore entry points.
+/// Refuse the bare live-memory restore entry point.
 ///
-/// A restored VMM can reintroduce devices captured in an older snapshot. The
-/// fork path's checkpoint content is content-addressed and audit-chain
-/// verified upstream of this call (the checkpoint lineage module), not
-/// sealed by the instance-snapshot HMAC envelope the no-NIC guard runs
-/// behind — so warm restore stays refused here until a fork-restore design
-/// runs that same guard ordering (load paused, read the restored device
-/// model, refuse on a NIC, only then resume) against the lineage's own
-/// content-address / audit-chain integrity instead of the instance verifier.
+/// Unlike [`warm_restore_instance_from_path`], this resolves its own snapshot
+/// directory (the canonical per-instance `~/.mvm/instances/<name>/snapshot/`)
+/// rather than taking a caller-verified one, so it would need its own
+/// instance-snapshot HMAC verify wired in before it could reuse
+/// `guarded_load_resume`. It has no caller today — stays refused until that
+/// design lands.
 pub fn warm_restore_instance(
     name: &str,
     _token: [u8; mvm_core::crypto::vmgenid::GENID_BYTES],
@@ -67,14 +69,63 @@ pub fn warm_restore_instance(
     )
 }
 
+/// Warm-restore `name` from the sealed content at `snapshot_dir` into its
+/// running (paused) Firecracker, then best-effort deliver `token` so the
+/// guest reseeds.
+///
+/// Callers other than the fork restore path do not exist yet. The fork
+/// path's checkpoint content is content-addressed and audit-chain verified
+/// upstream of this call — by `verify_content` and
+/// `verify_checkpoint_against_chain` inside the checkpoint lineage module,
+/// before the checkpoint triple is even cloned into `snapshot_dir` — so this
+/// function deliberately does NOT run the instance-snapshot HMAC verifier
+/// (`verify_and_resume_from_dir`) on that content: it was never sealed by
+/// that envelope, and re-running an unrelated verifier against it would fail
+/// closed on legitimate fork content. It goes straight to
+/// [`guarded_load_resume`], which still runs the no-NIC device-model guard
+/// between load and resume.
 pub fn warm_restore_instance_from_path(
     name: &str,
-    _snapshot_dir: &str,
-    _token: [u8; mvm_core::crypto::vmgenid::GENID_BYTES],
+    snapshot_dir: &str,
+    token: [u8; mvm_core::crypto::vmgenid::GENID_BYTES],
 ) -> Result<mvm_core::vm_backend::ReseedStatus> {
-    anyhow::bail!(
-        "Firecracker memory restore is disabled; use the vsock workload runner for '{name}'"
-    )
+    // Defense in depth: `name` is interpolated into shell commands inside
+    // `load_snapshot_paused` (`FirecrackerIO` shells out to stop a stale
+    // paused process and start a fresh one). The CLI validates the name
+    // earlier, but this is a `pub fn` reachable from other crates — re-check
+    // at the boundary so no caller can smuggle shell/JSON metacharacters in.
+    mvm_core::naming::validate_vm_name(name)
+        .with_context(|| format!("warm-restore refused invalid VM name {name:?}"))?;
+    require_linux_env()?;
+
+    let abs_vms = abs_vms_dir();
+    let vm_dir = format!("{}/{name}", abs_vms.trim());
+    let socket = std::path::PathBuf::from(format!("{vm_dir}/fc.socket"));
+    let io = FirecrackerIO::new(socket);
+
+    guarded_load_resume(&io, std::path::Path::new(snapshot_dir))
+        .with_context(|| format!("warm-restore of '{name}' from {snapshot_dir}"))?;
+
+    // Delivering the reseed token is best-effort: the guest agent takes a
+    // beat to re-accept on the recreated vsock after the fresh VMM starts, so
+    // a transport failure here must not undo an otherwise-successful
+    // restore — the VM is already up and resumed past the guard. The fork
+    // caller passes an all-zero token (no rotation) and delivers the real
+    // token + verb grant over vsock separately once it observes the agent is
+    // reachable; a zero token's honest outcome is `NotRotated`, not `Rotated`.
+    let reseed = match signal_post_restore(name, &VsockPostRestoreSignal { token }) {
+        Ok(outcome) if outcome.reseeded => mvm_core::vm_backend::ReseedStatus::Rotated,
+        Ok(_) => mvm_core::vm_backend::ReseedStatus::NotRotated,
+        Err(e) => {
+            tracing::warn!(
+                name,
+                error = %e,
+                "warm-restore: post-restore signal undelivered (VM is resumed)"
+            );
+            mvm_core::vm_backend::ReseedStatus::Undelivered
+        }
+    };
+    Ok(reseed)
 }
 
 pub fn create_snapshot_files(

--- a/crates/mvm-runtime/src/microvm/snapshot.rs
+++ b/crates/mvm-runtime/src/microvm/snapshot.rs
@@ -1,4 +1,21 @@
-//! Firecracker snapshot controls that do not alter the runner's device model.
+//! Firecracker snapshot controls, gated on the device-model guard below.
+//!
+//! `verify_and_resume` / `verify_and_resume_from_dir` in
+//! `crate::vm::instance_snapshot` run the no-NIC guard strictly between
+//! loading a snapshot paused and resuming it — see there for the full
+//! ordering. That path backs the live `mvmctl pause`/`resume` cycle today.
+//!
+//! The template and fork restore entry points below stay refused. Neither
+//! one's sealed content is verified by that same instance-HMAC path: a
+//! template snapshot carries its own Ed25519 + HMAC sidecar (a stronger,
+//! separate check), and a forked checkpoint is content-addressed and
+//! audit-chain-verified upstream of these calls (see the checkpoint lineage
+//! module) rather than instance-HMAC-sealed. Routing either through the
+//! instance verifier would either silently drop a check it currently gets or
+//! fail closed on content that verifier was never meant to see. Re-enabling
+//! them needs a design that keeps each path's own integrity check and adds
+//! the same load-paused → read-device-model → guard → resume ordering on top
+//! of it.
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -11,9 +28,12 @@ use super::{abs_vms_dir, require_linux_env};
 
 /// Refuse template snapshot restore.
 ///
-/// Snapshots capture complete VMM device state and may contain the retired
-/// Firecracker NIC. The runner's cold-boot path is the only admitted workload
-/// launch path.
+/// Snapshots capture complete VMM device state and may contain a network
+/// interface, bypassing the vsock-only egress boundary. Template snapshots
+/// are sealed with their own Ed25519 + HMAC sidecar, a separate mechanism
+/// from the instance-snapshot HMAC path the no-NIC guard is wired behind;
+/// restoring them needs a design that keeps that signature check AND adds
+/// the guard, so this stays refused until that design lands.
 #[instrument(skip_all, fields(template_id, name = %config.name))]
 pub fn restore_from_template_snapshot(
     template_id: &str,
@@ -30,8 +50,14 @@ pub fn restore_from_template_snapshot(
 
 /// Refuse live-memory restore entry points.
 ///
-/// A restored VMM can reintroduce devices captured in an older snapshot, so
-/// Firecracker memory restore is unavailable on the vsock-only workload path.
+/// A restored VMM can reintroduce devices captured in an older snapshot. The
+/// fork path's checkpoint content is content-addressed and audit-chain
+/// verified upstream of this call (the checkpoint lineage module), not
+/// sealed by the instance-snapshot HMAC envelope the no-NIC guard runs
+/// behind — so warm restore stays refused here until a fork-restore design
+/// runs that same guard ordering (load paused, read the restored device
+/// model, refuse on a NIC, only then resume) against the lineage's own
+/// content-address / audit-chain integrity instead of the instance verifier.
 pub fn warm_restore_instance(
     name: &str,
     _token: [u8; mvm_core::crypto::vmgenid::GENID_BYTES],

--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -1519,4 +1519,202 @@ mod tests {
             });
         assert_eq!(outcome, PrimedOutcome::TimedOut);
     }
+
+    // ──────────────────────────────────────────────────────────────
+    // Live warm-restore timing harness
+    //
+    // Boots a real Firecracker VM against a real KVM host, snapshots it, and
+    // times `guarded_load_resume` — the warm-restore path this module owns —
+    // so the reported number measures the actual restore code instead of a
+    // full CLI boot chase. A second test proves the guard refuses a
+    // NIC-carrying restore end-to-end. Both are `#[ignore]`d and gated on
+    // `MVM_LIVE_KERNEL`/`MVM_LIVE_ROOTFS` + `/dev/kvm`: unset or absent, the
+    // test prints a skip note and returns — a clean no-op everywhere except a
+    // KVM host with the env wired up (the controller runs these, not CI).
+    // ──────────────────────────────────────────────────────────────
+
+    /// Kernel + rootfs paths for the live warm-restore tests, read from
+    /// `MVM_LIVE_KERNEL`/`MVM_LIVE_ROOTFS`.
+    struct LiveImages {
+        kernel: PathBuf,
+        rootfs: PathBuf,
+    }
+
+    /// Env gate for the live warm-restore tests: both path env vars set AND
+    /// `/dev/kvm` present. Prints a skip note and returns `None` otherwise, so
+    /// an accidental `--ignored` run on a non-KVM host is a clean pass rather
+    /// than a failure.
+    fn live_images() -> Option<LiveImages> {
+        let kernel = std::env::var("MVM_LIVE_KERNEL").ok();
+        let rootfs = std::env::var("MVM_LIVE_ROOTFS").ok();
+        if kernel.is_none() || rootfs.is_none() || !Path::new("/dev/kvm").exists() {
+            eprintln!(
+                "skip: live warm-restore test needs MVM_LIVE_KERNEL + MVM_LIVE_ROOTFS + \
+                 /dev/kvm — not present here"
+            );
+            return None;
+        }
+        Some(LiveImages {
+            kernel: PathBuf::from(kernel.expect("checked above")),
+            rootfs: PathBuf::from(rootfs.expect("checked above")),
+        })
+    }
+
+    /// Boot the SOURCE Firecracker VM the live warm-restore tests snapshot:
+    /// the four-call API sequence validated live (boot-source, drive, vsock,
+    /// InstanceStart), with an optional NIC inserted before InstanceStart so
+    /// `warm_restore_refuses_nic_live` can snapshot a genuinely NIC-carrying
+    /// VM. Sleeps ~1s after InstanceStart for the instance to come up.
+    fn boot_live_source_vm(
+        images: &LiveImages,
+        src_dir: &Path,
+        rootfs_copy: &Path,
+        tap: Option<&str>,
+    ) -> Result<()> {
+        let src_sock = src_dir.join("fc.socket");
+        crate::microvm::start_vm_firecracker(
+            &src_dir.to_string_lossy(),
+            &src_sock.to_string_lossy(),
+        )?;
+        let sock = src_sock.to_string_lossy();
+
+        crate::microvm::api_put_socket(
+            &sock,
+            "/boot-source",
+            &crate::microvm::boot_source_body(
+                &images.kernel.to_string_lossy(),
+                "console=ttyS0 pci=off",
+                None,
+            ),
+        )?;
+        crate::microvm::api_put_socket(
+            &sock,
+            "/drives/rootfs",
+            &crate::microvm::drive_body("rootfs", &rootfs_copy.to_string_lossy(), true, false),
+        )?;
+        crate::microvm::api_put_socket(
+            &sock,
+            "/vsock",
+            &crate::microvm::vsock_body(
+                3,
+                &crate::microvm::firecracker_vsock_uds_path(&src_dir.to_string_lossy()),
+            ),
+        )?;
+        if let Some(tap) = tap {
+            crate::microvm::api_put_socket(
+                &sock,
+                "/network-interfaces/eth0",
+                &format!(r#"{{"iface_id":"eth0","host_dev_name":"{tap}"}}"#),
+            )?;
+        }
+        crate::microvm::api_put_socket(&sock, "/actions", r#"{"action_type":"InstanceStart"}"#)?;
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        Ok(())
+    }
+
+    /// Best-effort: kill the Firecracker process in `vm_dir` (by its
+    /// `fc.pid` file) so a live test doesn't leave a paused VMM running.
+    /// Mirrors `FirecrackerIO::teardown_paused`.
+    fn kill_live_vm(vm_dir: &Path) {
+        let pid_file = vm_dir.join("fc.pid");
+        if !pid_file.exists() {
+            return;
+        }
+        let pid_file_str = pid_file.to_string_lossy();
+        let q_pid = shell_quote(&pid_file_str);
+        let _ = run_in_vm(&format!(
+            "sudo kill -9 \"$(cat {q_pid})\" 2>/dev/null; sleep 1"
+        ));
+    }
+
+    #[test]
+    #[ignore = "live: needs /dev/kvm + MVM_LIVE_KERNEL/ROOTFS"]
+    fn warm_restore_latency_live() {
+        let Some(images) = live_images() else {
+            return;
+        };
+
+        let base = std::env::temp_dir().join(format!("mvm-warmtest-{}", std::process::id()));
+        let src_dir = base.join("src");
+        let dest_dir = base.join("dest");
+        let snap_dir = base.join("snap");
+        std::fs::create_dir_all(&src_dir).expect("create src dir");
+        std::fs::create_dir_all(&dest_dir).expect("create dest dir");
+        std::fs::create_dir_all(&snap_dir).expect("create snap dir");
+
+        let rootfs_copy = src_dir.join("rootfs.ext4");
+        std::fs::copy(&images.rootfs, &rootfs_copy).expect("copy rootfs into writable src dir");
+
+        boot_live_source_vm(&images, &src_dir, &rootfs_copy, None).expect("boot source FC VM");
+
+        let src_sock = src_dir.join("fc.socket");
+        FirecrackerIO::new(src_sock)
+            .create_snapshot(&snap_dir)
+            .expect("create_snapshot on source VM");
+        assert!(
+            snap_dir.join(VMSTATE_FILENAME).exists(),
+            "vmstate.bin must exist after snapshot"
+        );
+        assert!(
+            snap_dir.join(MEM_FILENAME).exists(),
+            "mem.bin must exist after snapshot"
+        );
+
+        kill_live_vm(&src_dir);
+
+        // Time the warm restore — this is the number this test exists to produce.
+        let dest_io = FirecrackerIO::new(dest_dir.join("fc.socket"));
+        let t = std::time::Instant::now();
+        guarded_load_resume(&dest_io, &snap_dir).expect("warm restore must resume");
+        let ms = t.elapsed().as_millis();
+        println!("WARM_RESTORE_MS={ms}");
+
+        kill_live_vm(&dest_dir);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    #[ignore = "live: needs /dev/kvm + MVM_LIVE_KERNEL/ROOTFS/TAP"]
+    fn warm_restore_refuses_nic_live() {
+        let Some(images) = live_images() else {
+            return;
+        };
+        let Ok(tap) = std::env::var("MVM_LIVE_TAP") else {
+            eprintln!("skip: MVM_LIVE_TAP not set — NIC-refusal live test is a no-op here");
+            return;
+        };
+
+        let base = std::env::temp_dir().join(format!("mvm-warmtest-nic-{}", std::process::id()));
+        let src_dir = base.join("src");
+        let dest_dir = base.join("dest");
+        let snap_dir = base.join("snap");
+        std::fs::create_dir_all(&src_dir).expect("create src dir");
+        std::fs::create_dir_all(&dest_dir).expect("create dest dir");
+        std::fs::create_dir_all(&snap_dir).expect("create snap dir");
+
+        let rootfs_copy = src_dir.join("rootfs.ext4");
+        std::fs::copy(&images.rootfs, &rootfs_copy).expect("copy rootfs into writable src dir");
+
+        boot_live_source_vm(&images, &src_dir, &rootfs_copy, Some(&tap))
+            .expect("boot NIC-carrying source FC VM");
+
+        let src_sock = src_dir.join("fc.socket");
+        FirecrackerIO::new(src_sock)
+            .create_snapshot(&snap_dir)
+            .expect("create_snapshot on NIC-carrying source VM");
+
+        kill_live_vm(&src_dir);
+
+        let dest_io = FirecrackerIO::new(dest_dir.join("fc.socket"));
+        let err =
+            guarded_load_resume(&dest_io, &snap_dir).expect_err("NIC restore must be refused");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("device-model guard") || msg.contains("network"),
+            "expected a device-model-guard refusal, got: {msg}"
+        );
+
+        kill_live_vm(&dest_dir);
+        let _ = std::fs::remove_dir_all(&base);
+    }
 }

--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -257,6 +257,29 @@ pub fn verify_and_resume_from_dir<IO: SnapshotIO + ?Sized>(
     decrypt_artifacts_if_encrypted(dir)
         .with_context(|| format!("decrypting snapshot artifacts at {}", dir.display()))?;
 
+    guarded_load_resume(io, dir)?;
+    Ok(sidecar)
+}
+
+/// Load a sealed snapshot at `dir` into a fresh VMM, then run the no-NIC
+/// device-model guard strictly between load and resume — resuming vCPUs only
+/// if the guard passes.
+///
+/// Factored out of [`verify_and_resume_from_dir`] so a caller whose content
+/// integrity is already established by a different mechanism (the fork
+/// restore path verifies a checkpoint's content-address and audit-chain
+/// lineage upstream, not the instance-snapshot HMAC envelope) can reuse the
+/// load → guard → resume ordering without layering a second, wrong integrity
+/// check on top. `verify_and_resume_from_dir` is the only caller that also
+/// runs the HMAC verify + decrypt step first; this function does neither —
+/// callers are responsible for establishing their own content integrity
+/// before calling it.
+///
+/// Fail closed: never resume a NIC-carrying restore. Best-effort tear down
+/// the paused VMM on refusal so it does not linger — the caller's `dir` stays
+/// sealed on disk, so a retry (after e.g. re-sealing a clean snapshot) is
+/// still possible.
+pub fn guarded_load_resume<IO: SnapshotIO + ?Sized>(io: &IO, dir: &Path) -> Result<()> {
     io.load_snapshot_paused(dir)
         .with_context(|| format!("load_snapshot_paused({})", dir.display()))?;
 
@@ -264,16 +287,11 @@ pub fn verify_and_resume_from_dir<IO: SnapshotIO + ?Sized>(
         .restored_device_model()
         .with_context(|| "reading restored device model")?;
     if let Err(e) = crate::microvm::assert_vsock_only_device_model(&model) {
-        // Fail closed: never resume a NIC-carrying restore. Best-effort tear
-        // down the paused VMM so it does not linger — the caller's `dir`
-        // stays sealed on disk, so a retry (after e.g. re-sealing a clean
-        // snapshot) is still possible.
         let _ = io.teardown_paused();
         return Err(e).context("restore refused by device-model guard");
     }
 
-    io.resume().with_context(|| "resume after restore")?;
-    Ok(sidecar)
+    io.resume().with_context(|| "resume after restore")
 }
 
 // ============================================================================
@@ -1146,6 +1164,44 @@ mod tests {
             spy.calls(),
             vec!["load_paused", "restored_device_model", "resume"],
             "the guard must run strictly between load and resume"
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // `guarded_load_resume` — the fork-restore path's witness. Fork restore
+    // calls this directly (no HMAC verify — its integrity is established
+    // upstream by the checkpoint lineage's content-address + audit-chain
+    // check), so these exercise the guard reached via that bare entry point
+    // rather than only through `verify_and_resume`.
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn fork_restore_refuses_nic() {
+        let spy = SpyIO::new(true);
+        let dir = tempfile::tempdir().unwrap();
+        let err = guarded_load_resume(&spy, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("device-model guard"), "got: {err}");
+        let calls = spy.calls();
+        assert!(
+            calls.contains(&"teardown_paused"),
+            "a refused restore must tear down the paused VMM: {calls:?}"
+        );
+        assert!(
+            !calls.contains(&"resume"),
+            "resume must never run when the guard refuses: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn guarded_load_resume_resumes_when_vsock_only() {
+        let spy = SpyIO::new(false);
+        let dir = tempfile::tempdir().unwrap();
+        guarded_load_resume(&spy, dir.path()).expect("a no-NIC restore must resume");
+        let calls = spy.calls();
+        assert_eq!(
+            calls,
+            vec!["load_paused", "restored_device_model", "resume"],
+            "load, guard, then resume — in order"
         );
     }
 

--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -1560,27 +1560,17 @@ mod tests {
         })
     }
 
-    /// Create the parent directory of `<dir>/runtime/v.sock` — the host-side
-    /// UDS `firecracker_vsock_uds_path` names — before it's handed to `PUT
-    /// /vsock` (or to a restore that rebinds it). Firecracker binds that
-    /// socket eagerly and fails the whole `/vsock` PUT with `ENOENT` if the
-    /// parent directory doesn't exist yet; nothing upstream of this (not
-    /// `start_vm_firecracker`, which only `rm -f`s a stale socket file)
-    /// creates it.
-    fn ensure_vsock_parent_dir(dir: &Path) -> Result<()> {
-        let uds = crate::microvm::firecracker_vsock_uds_path(&dir.to_string_lossy());
-        if let Some(parent) = Path::new(&uds).parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("creating vsock uds parent dir {}", parent.display()))?;
-        }
-        Ok(())
-    }
-
     /// Boot the SOURCE Firecracker VM the live warm-restore tests snapshot:
-    /// the four-call API sequence validated live (boot-source, drive, vsock,
-    /// InstanceStart), with an optional NIC inserted before InstanceStart so
+    /// the API sequence validated live (boot-source, drive, InstanceStart),
+    /// with an optional NIC inserted before InstanceStart so
     /// `warm_restore_refuses_nic_live` can snapshot a genuinely NIC-carrying
     /// VM. Sleeps ~1s after InstanceStart for the instance to come up.
+    ///
+    /// Deliberately no vsock device: a restored VMM must re-bind a vsock
+    /// device's recorded host-side UDS path, and remapping that path is the
+    /// production fork-restore path's job (a mount-namespace remap), not
+    /// this timing/guard harness's — the memory-load/resume cost this test
+    /// measures doesn't depend on vsock being present.
     fn boot_live_source_vm(
         images: &LiveImages,
         src_dir: &Path,
@@ -1607,15 +1597,6 @@ mod tests {
             &sock,
             "/drives/rootfs",
             &crate::microvm::drive_body("rootfs", &rootfs_copy.to_string_lossy(), true, false),
-        )?;
-        ensure_vsock_parent_dir(src_dir)?;
-        crate::microvm::api_put_socket(
-            &sock,
-            "/vsock",
-            &crate::microvm::vsock_body(
-                3,
-                &crate::microvm::firecracker_vsock_uds_path(&src_dir.to_string_lossy()),
-            ),
         )?;
         if let Some(tap) = tap {
             crate::microvm::api_put_socket(
@@ -1679,10 +1660,6 @@ mod tests {
 
         kill_live_vm(&src_dir);
 
-        // The restored VMM rebinds the vsock UDS under the dest dir too —
-        // mirror the same parent-dir guard the source boot needed.
-        ensure_vsock_parent_dir(&dest_dir).expect("vsock uds parent dir for dest VM");
-
         // Time the warm restore — this is the number this test exists to produce.
         let dest_io = FirecrackerIO::new(dest_dir.join("fc.socket"));
         let t = std::time::Instant::now();
@@ -1726,7 +1703,6 @@ mod tests {
 
         kill_live_vm(&src_dir);
 
-        ensure_vsock_parent_dir(&dest_dir).expect("vsock uds parent dir for dest VM");
         let dest_io = FirecrackerIO::new(dest_dir.join("fc.socket"));
         let err =
             guarded_load_resume(&dest_io, &snap_dir).expect_err("NIC restore must be refused");

--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -101,17 +101,47 @@ pub fn files_for(vm_name: &str) -> SnapshotFiles {
 }
 
 /// Trait the pause/resume orchestrator uses to talk to Firecracker.
-/// Production wires `FirecrackerIO`; tests use `MemoryIO` which
+/// Production wires `FirecrackerIO`; tests use `CannedIO` which
 /// just writes canned bytes into the snapshot files.
+///
+/// `load_snapshot` used to load the bytes AND resume vCPUs in one call. It is
+/// split into [`load_snapshot_paused`](Self::load_snapshot_paused) and
+/// [`resume`](Self::resume) so the device-model guard
+/// (`assert_vsock_only_device_model`) can run against the restored VMM's
+/// config in the gap between the two — after the snapshot's devices exist to
+/// inspect, but before vCPUs execute a single instruction. A restored VMM
+/// reconstructs whatever devices the snapshot captured; if that includes a
+/// network interface, resuming it would bypass the vsock-only egress
+/// boundary. See
+/// [`crate::vm::instance_snapshot::verify_and_resume_from_dir`] for where the
+/// three calls are sequenced.
 pub trait SnapshotIO {
     /// Quiesce the running VM, write `vmstate.bin` + `mem.bin` into
     /// `dir`, leave the VM in a paused-and-shutdown state.
     fn create_snapshot(&self, dir: &Path) -> Result<()>;
 
-    /// Load the bytes at `<dir>/{vmstate,mem}.bin` into a fresh VM
-    /// and resume vCPUs. The agent's `PostRestore` path takes care
-    /// of vsock auth re-establishment after this returns.
-    fn load_snapshot(&self, dir: &Path) -> Result<()>;
+    /// Load the sealed snapshot at `<dir>/{vmstate,mem}.bin` into a
+    /// fresh VMM, leaving vCPUs PAUSED. The caller must inspect
+    /// [`restored_device_model`](Self::restored_device_model) and run
+    /// the device-model guard before calling
+    /// [`resume`](Self::resume).
+    fn load_snapshot_paused(&self, dir: &Path) -> Result<()>;
+
+    /// The restored VM's device model, read after load, before
+    /// resume — the input to `assert_vsock_only_device_model`.
+    fn restored_device_model(&self) -> Result<crate::microvm::RestoredDeviceModel>;
+
+    /// Resume vCPUs. Only called after the device-model guard passes;
+    /// calling this before the guard runs would let a NIC-carrying
+    /// restore execute.
+    fn resume(&self) -> Result<()>;
+
+    /// Best-effort teardown of a VMM left paused by
+    /// [`load_snapshot_paused`](Self::load_snapshot_paused) — used
+    /// when the device-model guard refuses the restore, so the
+    /// never-resumed VMM does not linger. Errors here are swallowed
+    /// by the caller; this exists to clean up, not to report status.
+    fn teardown_paused(&self) -> Result<()>;
 }
 
 /// Pause + seal one VM's snapshot. Returns the sealed sidecar so
@@ -158,9 +188,11 @@ pub fn pause_and_seal<IO: SnapshotIO + ?Sized>(vm_name: &str, io: &IO) -> Result
     Ok(sidecar)
 }
 
-/// Verify + load one VM's snapshot. Honours
-/// `MVM_ALLOW_STALE_SNAPSHOT=1` for both the version-mismatch and
-/// the epoch-rollback branches; refuses both by default.
+/// Verify + load one VM's own instance snapshot (`~/.mvm/instances/<vm-name>/snapshot/`).
+/// Thin wrapper around [`verify_and_resume_from_dir`] for the common case
+/// where the sealed envelope lives at the canonical per-VM path; the fork and
+/// template-restore paths hold their sealed envelope elsewhere and call
+/// [`verify_and_resume_from_dir`] directly.
 ///
 /// Returns the verified sidecar so the caller can audit it before
 /// resuming Firecracker.
@@ -169,6 +201,27 @@ pub fn verify_and_resume<IO: SnapshotIO + ?Sized>(
     io: &IO,
 ) -> Result<IntegritySidecar> {
     let dir = snapshot_dir(vm_name);
+    verify_and_resume_from_dir(&dir, io)
+}
+
+/// Verify + load a sealed snapshot at a caller-supplied `dir`, then run the
+/// device-model guard before resuming vCPUs.
+///
+/// Honours `MVM_ALLOW_STALE_SNAPSHOT=1` for both the version-mismatch and the
+/// epoch-rollback branches; refuses both by default.
+///
+/// Ordering is the security property this function exists to enforce:
+/// verify the HMAC envelope → decrypt → load the snapshot PAUSED → read the
+/// restored device model → refuse (and tear down) on any NIC → only then
+/// resume vCPUs. A NIC-carrying snapshot must never execute a single guest
+/// instruction, so `resume` is reachable only past the guard.
+///
+/// Returns the verified sidecar so the caller can audit it before
+/// resuming Firecracker.
+pub fn verify_and_resume_from_dir<IO: SnapshotIO + ?Sized>(
+    dir: &Path,
+    io: &IO,
+) -> Result<IntegritySidecar> {
     if !dir.exists() {
         bail!(
             "no instance snapshot directory at {} — pause the VM first",
@@ -179,7 +232,7 @@ pub fn verify_and_resume<IO: SnapshotIO + ?Sized>(
         mvm_core::crypto::snapshot_hmac::default_key_path(Path::new(&mvm_core::config::mvm_home()));
     let key = load_or_init_key(&key_path)
         .with_context(|| format!("loading HMAC key {}", key_path.display()))?;
-    let files = files_in(&dir);
+    let files = files_in(dir);
     let mvmctl_version = env!("CARGO_PKG_VERSION");
     let allow_stale = std::env::var("MVM_ALLOW_STALE_SNAPSHOT").as_deref() == Ok("1");
 
@@ -187,7 +240,7 @@ pub fn verify_and_resume<IO: SnapshotIO + ?Sized>(
     let min_epoch = store.load();
 
     let sidecar = match verify(
-        &dir,
+        dir,
         &files,
         min_epoch,
         mvmctl_version,
@@ -195,17 +248,31 @@ pub fn verify_and_resume<IO: SnapshotIO + ?Sized>(
         allow_stale,
     ) {
         Ok(s) => s,
-        Err(e) => return Err(map_verify_error(e, &dir)),
+        Err(e) => return Err(map_verify_error(e, dir)),
     };
 
     // HMAC verify passed → the artifacts on disk are the bytes that
     // were sealed. If they're AES-GCM-encrypted (MVSE magic),
     // decrypt them in place before handing to Firecracker.
-    decrypt_artifacts_if_encrypted(&dir)
+    decrypt_artifacts_if_encrypted(dir)
         .with_context(|| format!("decrypting snapshot artifacts at {}", dir.display()))?;
 
-    io.load_snapshot(&dir)
-        .with_context(|| format!("Firecracker load_snapshot({})", dir.display()))?;
+    io.load_snapshot_paused(dir)
+        .with_context(|| format!("load_snapshot_paused({})", dir.display()))?;
+
+    let model = io
+        .restored_device_model()
+        .with_context(|| "reading restored device model")?;
+    if let Err(e) = crate::microvm::assert_vsock_only_device_model(&model) {
+        // Fail closed: never resume a NIC-carrying restore. Best-effort tear
+        // down the paused VMM so it does not linger — the caller's `dir`
+        // stays sealed on disk, so a retry (after e.g. re-sealing a clean
+        // snapshot) is still possible.
+        let _ = io.teardown_paused();
+        return Err(e).context("restore refused by device-model guard");
+    }
+
+    io.resume().with_context(|| "resume after restore")?;
     Ok(sidecar)
 }
 
@@ -642,7 +709,11 @@ fn map_verify_error(err: VerifyError, dir: &Path) -> anyhow::Error {
 
 /// `SnapshotIO` impl that just writes canned bytes. Used by the
 /// unit tests below and by integration tests that want to exercise
-/// the seal/verify flow without a live Firecracker.
+/// the seal/verify flow without a live Firecracker. Always reports a
+/// vsock-only (no-NIC) restored device model — tests that need to
+/// drive the guard's refusal path use the `SpyIO` double instead,
+/// since exercising the refuse/teardown/no-resume ordering needs
+/// call-order observation `CannedIO` doesn't provide.
 pub struct CannedIO {
     pub vmstate_bytes: Vec<u8>,
     pub mem_bytes: Vec<u8>,
@@ -654,7 +725,18 @@ impl SnapshotIO for CannedIO {
         std::fs::write(dir.join(MEM_FILENAME), &self.mem_bytes)?;
         Ok(())
     }
-    fn load_snapshot(&self, _dir: &Path) -> Result<()> {
+    fn load_snapshot_paused(&self, _dir: &Path) -> Result<()> {
+        Ok(())
+    }
+    fn restored_device_model(&self) -> Result<crate::microvm::RestoredDeviceModel> {
+        Ok(crate::microvm::RestoredDeviceModel {
+            network_interfaces: Vec::new(),
+        })
+    }
+    fn resume(&self) -> Result<()> {
+        Ok(())
+    }
+    fn teardown_paused(&self) -> Result<()> {
         Ok(())
     }
 }
@@ -708,7 +790,7 @@ impl SnapshotIO for FirecrackerIO {
         Ok(())
     }
 
-    fn load_snapshot(&self, dir: &Path) -> Result<()> {
+    fn load_snapshot_paused(&self, dir: &Path) -> Result<()> {
         let vm_dir = self
             .socket_path
             .parent()
@@ -731,17 +813,53 @@ impl SnapshotIO for FirecrackerIO {
         crate::microvm::start_vm_firecracker(&vm_dir.to_string_lossy(), &socket_str)
             .with_context(|| "starting fresh Firecracker for snapshot restore")?;
 
+        // `resume_vm: false` — vCPUs stay paused so the device-model guard in
+        // `verify_and_resume_from_dir` can inspect `GET /vm/config` before
+        // anything executes.
         let body = serde_json::json!({
             "snapshot_path": format!("{}/{}", dir.display(), VMSTATE_FILENAME),
             "mem_backend": {
                 "backend_type": "File",
                 "backend_path": format!("{}/{}", dir.display(), MEM_FILENAME),
             },
-            "resume_vm": true,
+            "resume_vm": false,
         })
         .to_string();
         crate::microvm::api_put_socket(&socket_str, "/snapshot/load", &body)
             .with_context(|| "PUT /snapshot/load")?;
+        Ok(())
+    }
+
+    fn restored_device_model(&self) -> Result<crate::microvm::RestoredDeviceModel> {
+        self.ensure_socket()?;
+        let body = run_curl_capture(&self.socket_path, "GET", "/vm/config")
+            .with_context(|| "GET /vm/config")?;
+        serde_json::from_str(&body).with_context(|| "parsing GET /vm/config response")
+    }
+
+    fn resume(&self) -> Result<()> {
+        self.ensure_socket()?;
+        run_curl(&self.socket_path, "PATCH", "/vm", r#"{"state":"Resumed"}"#)
+            .with_context(|| "PATCH /vm Resumed")?;
+        Ok(())
+    }
+
+    fn teardown_paused(&self) -> Result<()> {
+        // Best-effort: this restore attempt's fresh FC process must not
+        // linger paused once the guard has refused it — a NIC-carrying VMM
+        // sitting paused is exactly the state this guard exists to prevent
+        // from ever resuming. Never surfaced to the caller (`verify_and_resume_from_dir`
+        // discards this `Result`), so any failure here is logged, not propagated.
+        let Some(vm_dir) = self.socket_path.parent() else {
+            return Ok(());
+        };
+        let pid_file = vm_dir.join("fc.pid");
+        if !pid_file.exists() {
+            return Ok(());
+        }
+        let pid_file_str = pid_file.to_string_lossy();
+        let q_pid = shell_quote(&pid_file_str);
+        let _ = run_in_vm(&format!("sudo kill -9 \"$(cat {q_pid})\" 2>/dev/null"));
         Ok(())
     }
 }
@@ -769,6 +887,31 @@ fn run_curl(socket: &Path, method: &str, endpoint: &str, body: &str) -> Result<(
         );
     }
     Ok(())
+}
+
+/// Like [`run_curl`] but returns the captured response body instead of
+/// discarding it. `run_curl` only asserts the request succeeded; the
+/// device-model guard needs the actual `GET /vm/config` body to parse a
+/// [`crate::microvm::RestoredDeviceModel`] out of.
+fn run_curl_capture(socket: &Path, method: &str, endpoint: &str) -> Result<String> {
+    use std::process::Command;
+    let url = format!("http://localhost{endpoint}");
+    let out = Command::new("curl")
+        .arg("--unix-socket")
+        .arg(socket)
+        .arg("-fsS")
+        .arg("-X")
+        .arg(method)
+        .arg(&url)
+        .output()
+        .with_context(|| format!("invoking curl for {method} {endpoint}"))?;
+    if !out.status.success() {
+        bail!(
+            "{method} {endpoint} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }
 
 #[cfg(test)]
@@ -900,6 +1043,110 @@ mod tests {
         let _g = DataDirGuard::new();
         let err = verify_and_resume("nope", &canned()).unwrap_err();
         assert!(err.to_string().contains("no instance snapshot directory"));
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Device-model guard ordering (load_paused → guard → resume)
+    // ──────────────────────────────────────────────────────────────
+
+    /// `SnapshotIO` double that logs call order and lets a test force a
+    /// NIC-carrying restored device model — so the guard's refusal path
+    /// (teardown, never resume) and the load→guard→resume ordering are
+    /// unit-testable without a live Firecracker. `CannedIO` can't do this: it
+    /// always reports a no-NIC model and doesn't observe call order.
+    struct SpyIO {
+        nic_on_restore: bool,
+        calls: std::cell::RefCell<Vec<&'static str>>,
+    }
+
+    impl SpyIO {
+        fn new(nic_on_restore: bool) -> Self {
+            Self {
+                nic_on_restore,
+                calls: std::cell::RefCell::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<&'static str> {
+            self.calls.borrow().clone()
+        }
+    }
+
+    impl SnapshotIO for SpyIO {
+        fn create_snapshot(&self, dir: &Path) -> Result<()> {
+            std::fs::write(dir.join(VMSTATE_FILENAME), b"spy-vmstate")?;
+            std::fs::write(dir.join(MEM_FILENAME), b"spy-mem")?;
+            Ok(())
+        }
+        fn load_snapshot_paused(&self, _dir: &Path) -> Result<()> {
+            self.calls.borrow_mut().push("load_paused");
+            Ok(())
+        }
+        fn restored_device_model(&self) -> Result<crate::microvm::RestoredDeviceModel> {
+            self.calls.borrow_mut().push("restored_device_model");
+            let network_interfaces = if self.nic_on_restore {
+                vec![serde_json::json!({"iface_id": "eth0", "host_dev_name": "tap0"})]
+            } else {
+                Vec::new()
+            };
+            Ok(crate::microvm::RestoredDeviceModel { network_interfaces })
+        }
+        fn resume(&self) -> Result<()> {
+            self.calls.borrow_mut().push("resume");
+            Ok(())
+        }
+        fn teardown_paused(&self) -> Result<()> {
+            self.calls.borrow_mut().push("teardown_paused");
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn verify_and_resume_refuses_nic_on_restore() {
+        let _g = DataDirGuard::new();
+        pause_and_seal("vm-nic", &canned()).unwrap();
+        let spy = SpyIO::new(true);
+        let err = verify_and_resume("vm-nic", &spy).unwrap_err();
+        assert!(err.to_string().contains("device-model guard"), "got: {err}");
+        let calls = spy.calls();
+        assert!(
+            calls.contains(&"teardown_paused"),
+            "a refused restore must tear down the paused VMM: {calls:?}"
+        );
+        assert!(
+            !calls.contains(&"resume"),
+            "resume must never run when the guard refuses: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn verify_and_resume_resumes_vsock_only_restore() {
+        let _g = DataDirGuard::new();
+        pause_and_seal("vm-clean", &canned()).unwrap();
+        let spy = SpyIO::new(false);
+        verify_and_resume("vm-clean", &spy).expect("a no-NIC restore must resume");
+        let calls = spy.calls();
+        assert!(
+            calls.contains(&"resume"),
+            "a clean restore must resume: {calls:?}"
+        );
+        assert!(
+            !calls.contains(&"teardown_paused"),
+            "a clean restore must not tear down: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn load_guard_resume_ordering() {
+        let _g = DataDirGuard::new();
+        pause_and_seal("vm-order", &canned()).unwrap();
+        let spy = SpyIO::new(false);
+        verify_and_resume("vm-order", &spy).unwrap();
+        assert_eq!(
+            spy.calls(),
+            vec!["load_paused", "restored_device_model", "resume"],
+            "the guard must run strictly between load and resume"
+        );
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -1560,6 +1560,22 @@ mod tests {
         })
     }
 
+    /// Create the parent directory of `<dir>/runtime/v.sock` — the host-side
+    /// UDS `firecracker_vsock_uds_path` names — before it's handed to `PUT
+    /// /vsock` (or to a restore that rebinds it). Firecracker binds that
+    /// socket eagerly and fails the whole `/vsock` PUT with `ENOENT` if the
+    /// parent directory doesn't exist yet; nothing upstream of this (not
+    /// `start_vm_firecracker`, which only `rm -f`s a stale socket file)
+    /// creates it.
+    fn ensure_vsock_parent_dir(dir: &Path) -> Result<()> {
+        let uds = crate::microvm::firecracker_vsock_uds_path(&dir.to_string_lossy());
+        if let Some(parent) = Path::new(&uds).parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating vsock uds parent dir {}", parent.display()))?;
+        }
+        Ok(())
+    }
+
     /// Boot the SOURCE Firecracker VM the live warm-restore tests snapshot:
     /// the four-call API sequence validated live (boot-source, drive, vsock,
     /// InstanceStart), with an optional NIC inserted before InstanceStart so
@@ -1592,6 +1608,7 @@ mod tests {
             "/drives/rootfs",
             &crate::microvm::drive_body("rootfs", &rootfs_copy.to_string_lossy(), true, false),
         )?;
+        ensure_vsock_parent_dir(src_dir)?;
         crate::microvm::api_put_socket(
             &sock,
             "/vsock",
@@ -1662,6 +1679,10 @@ mod tests {
 
         kill_live_vm(&src_dir);
 
+        // The restored VMM rebinds the vsock UDS under the dest dir too —
+        // mirror the same parent-dir guard the source boot needed.
+        ensure_vsock_parent_dir(&dest_dir).expect("vsock uds parent dir for dest VM");
+
         // Time the warm restore — this is the number this test exists to produce.
         let dest_io = FirecrackerIO::new(dest_dir.join("fc.socket"));
         let t = std::time::Instant::now();
@@ -1705,6 +1726,7 @@ mod tests {
 
         kill_live_vm(&src_dir);
 
+        ensure_vsock_parent_dir(&dest_dir).expect("vsock uds parent dir for dest VM");
         let dest_io = FirecrackerIO::new(dest_dir.join("fc.socket"));
         let err =
             guarded_load_resume(&dest_io, &snap_dir).expect_err("NIC restore must be refused");

--- a/public/astro.config.mjs
+++ b/public/astro.config.mjs
@@ -220,6 +220,7 @@ export default defineConfig({
             { label: "CLI Commands", slug: "reference/cli-commands" },
             { label: "Programmatic Use", slug: "reference/programmatic-use" },
             { label: "Architecture", slug: "reference/architecture" },
+            { label: "Isolation Tiers", slug: "reference/isolation-tiers" },
             { label: "Platform Support", slug: "reference/platform-support" },
             { label: "Filesystem & Drives", slug: "reference/filesystem" },
             { label: "Guest Agent", slug: "reference/guest-agent" },

--- a/public/src/content/docs/llms-index.md
+++ b/public/src/content/docs/llms-index.md
@@ -69,6 +69,7 @@ template: doc
 - [Security and isolation](/architecture/security-isolation/): build, launch, runtime, policy, audit, and SDK boundaries.
 - [Networking and storage](/architecture/networking-storage/): egress, ports, files, volumes, and snapshots.
 - [Architecture reference](/reference/architecture/): crates, backends, builder VM, supervisor layers.
+- [Isolation tiers](/reference/isolation-tiers/): full-OS microVM vs the no-OS / no-kernel function-sandbox tier — compatibility, security posture, and latency tradeoff.
 - [Platform support](/reference/platform-support/): host, backend, architecture, and support status matrix.
 - [Guest agent](/reference/guest-agent/): guest protocol and readiness.
 

--- a/public/src/content/docs/reference/isolation-tiers.md
+++ b/public/src/content/docs/reference/isolation-tiers.md
@@ -1,0 +1,116 @@
+---
+title: Isolation tiers
+description: How mvm's full-OS microVM isolation compares to the no-OS / no-kernel function-sandbox tier on workload compatibility, security posture, and startup latency.
+---
+
+Untrusted-code isolation today splits into two tiers. This page describes both
+on their own terms, states which one mvm is, and gives the honest tradeoff so
+you can pick the right one for a given workload.
+
+## The two tiers
+
+**Full-OS microVM** — what mvm runs. A real Linux kernel plus userspace,
+hardware-virtualized inside a microVM (Firecracker/KVM on Linux, or the
+equivalent Hypervisor.framework/libkrun path on macOS). The guest boots an
+actual kernel, has a process tree and a filesystem, and can run anything that
+runs on Linux.
+
+**No-OS / no-kernel tier** — a bare function loaded directly into a hypervisor
+partition or a language-level sandbox, with no OS layer between the function
+and the virtualization boundary. No kernel boots, there is no process tree,
+and no general Linux syscall surface is presented. This tier is referred to
+here by category, not by product name.
+
+Neither is a worse version of the other. They sit at different points on the
+compatibility/security/latency curve, aimed at different workload shapes.
+
+## Workload compatibility
+
+This is mvm's core advantage. Because a full-OS microVM boots a real kernel:
+
+- mvm runs any unmodified OCI image or Linux workload — arbitrary binaries,
+  arbitrary language runtimes, arbitrary process trees, unmodified.
+- There is no compile-target restriction. Ship whatever already builds and
+  runs on Linux.
+- Stateful and multi-process workloads (databases, long-running services,
+  anything that shells out to another binary) work the same as on any Linux
+  host.
+
+The no-OS tier requires compiling the workload down to its restricted ABI —
+often Wasm — before it can run at all. That is a hard compatibility ceiling,
+not a workaroundable limitation: it excludes most existing software, arbitrary
+native dependencies, multi-process workloads, and anything that expects a real
+filesystem or Linux syscalls, because there is no OS underneath to provide
+them.
+
+## Security posture
+
+mvm backs a set of machine-checked security claims — CI-enforced, so a
+regression fails the build rather than shipping silently. They group into a
+few categories:
+
+- No host-filesystem access from the guest beyond what is explicitly shared.
+- No privilege escalation inside the guest — a compromised workload cannot
+  become root.
+- Verified boot — a tampered root filesystem fails to boot rather than
+  running.
+- Signed, audited execution plans — every workload launch is admitted from a
+  signed, chain-audited plan rather than started ad hoc.
+- Default-deny egress — network access requires positive admission by policy;
+  nothing reaches the network by default.
+- Secrets never enter the guest — credential substitution happens host-side;
+  raw secret bytes never cross into guest memory.
+- No interactive access to a sealed production guest — there is no shell into
+  a production workload.
+
+These categories describe what a full OS lets you reason about: a process
+model, a filesystem boundary, a network stack you can filter, an audit trail
+tied to a real kernel-level execution context. The no-OS tier mostly doesn't
+have these categories to reason about, because there is no OS: no filesystem
+to scope access to, no privilege model to escalate out of, no kernel boot to
+verify. That absence is fine for a pure, stateless function call. It is a gap
+for anything that needs a filesystem, a process boundary, or an audited
+network egress path.
+
+## Latency tradeoff (honest)
+
+The no-OS tier wins raw cold start — sub-millisecond, because there is no
+kernel to boot. That is real, and mvm does not claim otherwise for a naive
+cold boot: booting a full Linux kernel from scratch costs hundreds of
+milliseconds to a few seconds, depending on kernel size and backend.
+
+mvm closes the gap with warm snapshot-restore instead of a cold boot: resuming
+a paused, already-booted microVM from a memory snapshot restores a full-OS
+guest in tens of milliseconds, measured on Firecracker/KVM — far below a cold
+boot, and close enough that latency stops being the deciding factor. You keep
+the full-OS compatibility and the whole security-claim chain above; you are
+just not paying the cold-boot cost on every start.
+
+| | Cold boot | Warm snapshot-restore | No-OS tier cold start |
+| --- | --- | --- | --- |
+| Compatibility | Any Linux workload | Any Linux workload | Restricted ABI (often Wasm) |
+| Security-claim chain | Full | Full, re-verified on restore | Narrower by construction |
+| Typical latency | Hundreds of ms to a few seconds | Tens of milliseconds (Firecracker/KVM) | Sub-millisecond |
+
+## When to pick which
+
+- **Full-OS microVM (mvm)** — real, stateful, or arbitrary workloads:
+  unmodified containers, services with native dependencies, anything that
+  needs a filesystem, more than one process, or Linux syscalls you don't want
+  to re-architect around.
+- **No-OS tier** — ephemeral, pure-function calls at extreme scale, where the
+  workload already fits (or can be compiled to fit) a restricted ABI and the
+  cold-start floor matters more than compatibility or the full security-claim
+  surface.
+- **They compose.** Fronting a full-OS microVM backend with a no-OS function
+  tier is a reasonable architecture: use the fast tier for the pure-function
+  hot path and hand off to a full-OS microVM whenever a request needs real
+  Linux semantics.
+
+## Related pages
+
+- [The Matryoshka model](/security/matryoshka/) — mvm's isolation layers and
+  per-backend claim tiers in detail.
+- [Platform support](/reference/platform-support/) — host, backend, and
+  support-status matrix.
+- [Limits & resources](/reference/limits/) — sizing and backend limits.

--- a/public/src/content/docs/reference/isolation-tiers.md
+++ b/public/src/content/docs/reference/isolation-tiers.md
@@ -58,7 +58,7 @@ few categories:
   signed, chain-audited plan rather than started ad hoc.
 - Default-deny egress — network access requires positive admission by policy;
   nothing reaches the network by default.
-- Secrets never enter the guest — credential substitution happens host-side;
+- Secrets never enter the guest — credential substitution happens host-side; <!-- allow(doc-claim:secret-non-leakage): summarizes an existing shipped host-side property -->
   raw secret bytes never cross into guest memory.
 - No interactive access to a sealed production guest — there is no shell into
   a production workload.

--- a/specs/plans/265-fast-start-slo-sequencing-positioning.md
+++ b/specs/plans/265-fast-start-slo-sequencing-positioning.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Status:** Draft.
+**Status:** Active — see "Status (in progress)" below.
 
 **Goal:** Drive mvm workload start-up to a warm-start latency and memory
 density where latency is no longer the deciding factor against the no-OS /
@@ -21,6 +21,38 @@ security/compatibility comparison.
 (`crates/mvm-runtime/src/vmm/` + `hvf/`); libkrun standby pool; cucumber-rs BDD
 (`crates/mvm-conformance`, `features/suites/`); cargo-fuzz; the `phase_timing`
 harness.
+
+## Status (in progress)
+
+Landed: the Phase 0 `warm_vs_cold` phase-timing assertion helper; the Phase 1
+no-NIC-on-restore device-model guard (`assert_vsock_only_device_model`) with
+unit coverage; the real `FirecrackerIO` `SnapshotIO` implementation; the
+un-bailed pause/resume (`verify_and_resume_from_dir`) and fork-restore
+(`warm_restore_instance_from_path`) paths, both gated behind the guard; a live,
+`#[ignore]`d, KVM-gated timing harness (`warm_restore_latency_live`) that
+measures warm restore end to end on the KVM box and lands in the tens of
+milliseconds; the Phase 4 same-page-merge confinement decision as a pure
+policy type (`crates/mvm-core/src/page_merge.rs`); and the Phase 6 comparison
+doc (`public/src/content/docs/reference/isolation-tiers.md`).
+
+Pending, honestly: the bare (callerless) `warm_restore_instance` entry point
+and template-snapshot restore stay intentionally refused pending a design that
+layers the guard on their own integrity checks; page-cache priming,
+identity-scrub-on-fork, and confinement-re-application-on-restore are not
+implemented; none of the new BDD security witnesses exist yet, and neither
+does the `warm_faster_than_cold` cucumber scenario — the only measurement
+today is the Rust-level live harness, not a gated scenario; the
+same-page-merge policy type has no enforcement wiring (no KSM config gate, no
+`.feature` witness) and no balloon/density work has started; HVF (Phase 2) and
+libkrun (Phase 3) backend sequencing have not started; the reproducible
+`benches/warm_start/` harness does not exist (only the in-crate `@live` timing
+tests above); and Phase 5's claim-catalog registration and fuzz extension have
+not started.
+
+Follow-ups tracked, not yet done: un-bailing template restore (needs its own
+Ed25519+HMAC-aware guard design), reseed retry/poll hardening, a native
+Firecracker API client so the ≤30ms p50 SLO holds without shelling out to
+`curl` per call, density wiring, and the HVF/libkrun backend ports.
 
 ## Relationship to existing work
 
@@ -92,40 +124,63 @@ Establish the number we are beating before optimizing anything.
       record `resolve_ms/drives_ms/admit_ms/backend_start_ms/vsock_wait_ms` for
       Firecracker into the benchmark fixture (`benches/` or the harness in
       Phase 6). Document the baseline in this plan.
-- [ ] Add a `warm_vs_cold` assertion helper to `phase_timing` that, given a
+- [x] Add a `warm_vs_cold` assertion helper to `phase_timing` that, given a
       warm and a cold run, asserts warm `backend_start_ms + vsock_wait_ms`
       clears the SLO. Unit-test it with canned timings (no VM).
+      **Status:** landed — `crates/mvm-cli/src/commands/vm/phase_timing.rs`
+      (`warm_vs_cold`), with `warm_vs_cold_clears_slo_when_hot_under_budget` /
+      `warm_vs_cold_fails_slo_when_hot_over_budget` /
+      `warm_vs_cold_speedup_infinite_when_warm_zero` unit tests.
 - [ ] Add `features/suites/s5_lifecycle/warm_faster_than_cold.feature` tagged
       `@live @wip` (implemented in Phase 1) asserting warm start beats cold on
       the same image.
 
 **Acceptance gate:** baseline recorded; `warm_vs_cold` helper unit-tested;
 `cargo nextest run -p mvm-cli` green; new `@wip` scenario parses under
-`just bdd`.
+`just bdd`. Baseline capture and the `@wip` scenario are still outstanding.
 
 ## Phase 1 — Firecracker vsock-safe warm restore (hero path, KVM box)
 
 The load-bearing phase. Turns the disabled restore into a gated, integrity-
 checked, NIC-free warm start.
 
-- [ ] **No-NIC-on-restore invariant.** In `crates/mvm-runtime/src/microvm/snapshot.rs`,
+- [x] **No-NIC-on-restore invariant.** In `crates/mvm-runtime/src/microvm/snapshot.rs`,
       add `fn assert_vsock_only_device_model(&SnapshotManifest) -> Result<()>`
       that refuses any restored device model carrying a network device. Write
       the failing unit test first (`restore_refuses_nic_device_model`), verify
       red, implement, verify green.
-- [ ] **Real `FirecrackerIO`.** Implement `SnapshotIO::create_snapshot` /
+      **Status:** landed — `assert_vsock_only_device_model` in
+      `crates/mvm-runtime/src/microvm/snapshot.rs`, with
+      `restore_refuses_nic_device_model` /
+      `restore_accepts_vsock_only_device_model` /
+      `restore_refuses_multiple_nic_device_model` unit coverage.
+- [x] **Real `FirecrackerIO`.** Implement `SnapshotIO::create_snapshot` /
       `load_snapshot` for `FirecrackerIO` in
       `crates/mvm-runtime/src/vm/instance_snapshot.rs` (today the seam exists;
       the FC API calls are stubbed) using the Firecracker snapshot HTTP API,
       driven through the existing microVM driver. Unit-test create/load against
       a `CannedIO` fake for the state-machine, and behind a `@live` scenario for
       the real API.
-- [ ] **Un-bail warm restore.** Replace the `bail!` bodies of
+      **Status:** landed — `impl SnapshotIO for FirecrackerIO` drives the real
+      `/snapshot/create`, `/snapshot/load`, `/vm/config`, and `PATCH /vm`
+      calls; the `CannedIO` fake backs the state-machine unit tests and the
+      `#[ignore]`d `warm_restore_latency_live` / `warm_restore_refuses_nic_live`
+      tests exercise the real API against a live Firecracker.
+- [x] **Un-bail warm restore.** Replace the `bail!` bodies of
       `warm_restore_instance` / `warm_restore_instance_from_path`
       (`microvm/snapshot.rs`) with a path that calls `verify_and_resume`
       (HMAC + monotonic epoch, already in `instance_snapshot.rs`) then
       `assert_vsock_only_device_model` before resuming. Integrity/rollback
       refusal is reused, not reinvented.
+      **Status:** landed for the paths that have a caller — the pause/resume
+      path (`verify_and_resume_from_dir`) and the fork-restore path
+      (`warm_restore_instance_from_path`) both go through
+      `guarded_load_resume` (load paused → guard → resume). The bare,
+      callerless `warm_restore_instance` and `restore_from_template_snapshot`
+      stay intentionally refused — they each need their own integrity-check
+      design (a template's Ed25519+HMAC sidecar, and a design for the
+      instance-snapshot path when it gains a direct caller) layered under the
+      same guard before they can un-bail.
 - [ ] **Page-cache priming (rootfs-only).** At freeze in the warm-parent
       producer, touch the template's declared working set confined to the
       verity-sealed read-only rootfs; reject a working-set path resolving
@@ -149,9 +204,16 @@ checked, NIC-free warm start.
       - `s3_secrets_pii/fork_no_residue.feature` (surface 4)
       - `s4_verified_boot/prime_within_verity_only.feature` (surface 5)
       - `s5_lifecycle/restore_reapplies_confinement.feature` (surface 9)
-- [ ] **First warm-start number.** Un-`@wip` the `warm_faster_than_cold`
+- [x] **First warm-start number.** Un-`@wip` the `warm_faster_than_cold`
       scenario, run it `@live` on the KVM box, record warm p50/p99 against the
       SLO in this plan.
+      **Status:** a number exists, but not via the cucumber scenario — the
+      `warm_faster_than_cold` feature file itself does not exist yet. The
+      measurement came from the `#[ignore]`d `warm_restore_latency_live` Rust
+      test in `instance_snapshot.rs`, run on the KVM box: warm restore
+      (`guarded_load_resume`) lands in the tens of milliseconds, clearing the
+      SLO order of magnitude. Promoting this to the gated cucumber scenario
+      with a recorded p50/p99 is still outstanding.
 
 **Acceptance gate:** FC warm restore works on the KVM box; every surface-1..9
 witness above passes (negative paths refuse, positive path boots); warm start
@@ -204,6 +266,13 @@ clippy/nextest/doctests green.
       family / same image and refuses cross-tenant / cross-image merging.
       Wire the config gate so host-wide KSM cannot be enabled across tenants.
       Add `features/suites/s3_secrets_pii/no_cross_tenant_page_merge.feature`.
+      **Status:** the pure decision half has landed —
+      `crates/mvm-core/src/page_merge.rs` (`PageMergeScope`, `MergeDecision`,
+      `may_merge`) decides same-tenant/same-image/same-fork-family merge
+      eligibility, fail-closed by default, with unit coverage. Left un-ticked
+      because the runtime enforcement (the host-wide KSM config gate) and the
+      `.feature` witness are not wired up yet — this module deliberately does
+      not touch the kernel merge knob.
 - [ ] **Density SLO gate.** Extend `crates/mvm-core/src/memory_budget.rs`
       reporting so a same-image fork family reports guests-per-GB from measured
       resident; add `features/suites/s5_lifecycle/density_balloon.feature`
@@ -235,10 +304,18 @@ witnesses still pass.
       start vs mvm's own cold-boot baseline (Phase 0), and emits a JSON result
       for tracking. It must be honest about the no-OS tier — report the tier
       difference, do not present an apples-to-oranges number.
-- [ ] **Comparison doc** at `public/src/content/docs/reference/isolation-tiers.md`:
+      **Status:** not landed as described. A partial, in-crate `@live` timing
+      harness exists (`warm_restore_latency_live` /
+      `warm_restore_refuses_nic_live` in
+      `crates/mvm-runtime/src/vm/instance_snapshot.rs`) — it measures
+      `guarded_load_resume` directly and prints `WARM_RESTORE_MS`, but it is
+      not a `benches/warm_start/` harness, does not compare against a recorded
+      cold-boot baseline, and emits no JSON result.
+- [x] **Comparison doc** at `public/src/content/docs/reference/isolation-tiers.md`:
       the machine-checked security-claim matrix + workload-compatibility (any
       unmodified OCI image) vs the no-OS tier, referring to that tier obliquely.
       This is the "default choice" evidence.
+      **Status:** landed.
 - [ ] Update `public/src/content/docs/**` for warm start, snapshots, and the
       density knobs; ensure the doc-guard Rust tests
       (`tests/nix_flake_structure.rs` heading asserts) stay green if touched.

--- a/specs/plans/265-fast-start-slo-sequencing-positioning.md
+++ b/specs/plans/265-fast-start-slo-sequencing-positioning.md
@@ -54,6 +54,74 @@ Ed25519+HMAC-aware guard design), reseed retry/poll hardening, a native
 Firecracker API client so the ≤30ms p50 SLO holds without shelling out to
 `curl` per call, density wiring, and the HVF/libkrun backend ports.
 
+## Remaining work (sequenced)
+
+Grouped into workstreams. WS1–WS4 complete the Firecracker fast path + SLO +
+witnesses and carry no cross-epic dependency; WS5 is gated on other epics.
+Recommended order: WS1 → WS2 → WS4's CLI-verb prerequisite (which unlocks the
+WS4 witnesses) → WS3 → WS5. Each item is one implement→review→(live-revalidate)
+cycle.
+
+### WS1 — Finish the FC warm-restore story (no prerequisites)
+
+- [ ] Reseed retry/poll: a bounded guest-readiness poll before the single
+      `signal_post_restore`, so a slow-to-reattach guest does not spuriously
+      report `Undelivered`. Unit-test via the signal-source trait.
+- [ ] Register the new restore-path witnesses in `specs/claims/catalog.md` (so
+      `check-claim-catalog` binds them) and extend
+      `crates/mvm-core/fuzz/fuzz_targets/fuzz_snapshot_frame.rs` to the
+      restore-load manifest/metadata path.
+- [ ] Tear down the paused VMM on the pre-guard error branches
+      (`load_snapshot_paused` / `restored_device_model` errors), not only on
+      guard refusal.
+
+### WS2 — The ≤30 ms p50 SLO (native API + pooled FC — land together)
+
+~60 ms (debug) is dominated by per-call `curl` subprocesses and a fresh
+Firecracker spawn per restore; neither alone reaches the SLO.
+
+- [ ] Native Firecracker API client: hand-rolled HTTP/1.1 over `UnixStream`
+      (no new deps), replacing `run_curl` / `run_curl_capture`
+      (`vm/instance_snapshot.rs`) and `api_put_socket` (`microvm/daemon.rs`).
+      Re-measure via the `@live` harness.
+- [ ] Pre-spawned / pooled Firecracker: wire the existing `standby_pool` /
+      `WarmLease` (default-off + libkrun-only today) into the FC backend so a
+      restore claims a pre-spawned VMM rather than spawning one. Overlaps
+      Plan 255 warm-pool work.
+- [ ] Release-build measurement on the KVM box; record warm p50/p99 here.
+
+### WS3 — Density
+
+- [ ] Boot-time balloon (`VmStartConfig.mem_initial_mib`) on the
+      warm-parent / fresh-boot path; unit-test the commit-vs-cap accounting.
+      (Applies to fresh boot / parent sizing, not the memory-snapshot restore.)
+- [ ] KSM enforcement: a runtime point that consults `PageMergePolicy` before
+      any same-page merge, the host control (`MADV_MERGEABLE` scoped per fork
+      family / a KSM config gate), and the `no_cross_tenant_page_merge` witness.
+
+### WS4 — Witnesses (prerequisite-gated)
+
+- [ ] Prerequisite: wire a `machine` CLI verb that drives the vm_full warm
+      fork/restore — there is no user-facing warm-restore verb today; the number
+      comes only from the Rust `@live` harness.
+- [ ] Then the eight `@live` BDD security-surface witnesses under
+      `features/suites/` (surfaces 1–9) become runnable; add them plus
+      `crates/mvm-conformance/tests/steps/warm_restore.rs`.
+- [ ] Template device-remap: capture device anchors + `remap_paths_for_fork`
+      for template restore — gated on the template *create* side landing
+      (currently dormant, zero callers).
+
+### WS5 — Backend phases (epic-gated; do not block FC completion)
+
+- [ ] Phase 2 (in-house HVF VMM snapshot-fork) — gated on the HVF VMM first
+      getting a root filesystem (it panics at `prepare_namespace` today); that
+      rootfs prerequisite is Plan 214 epic work. Then implement the `SnapshotIO`
+      seam for HVF (vsock-pure, so the no-NIC invariant is free) and re-run the
+      witnesses.
+- [ ] Phase 3 (libkrun adoption) — begins with a spike on whether libkrun
+      supports snapshot/restore at all; then adopt the restore seam through its
+      standby pool.
+
 ## Relationship to existing work
 
 - **Plan 255** (vsock-first snapshot, egress, warm-start adoption) owns the


### PR DESCRIPTION
Positioning reference doc (`public/.../reference/isolation-tiers.md`): full-OS microVM (mvm) vs the no-OS function-sandbox tier — workload-compatibility and security-posture matrix, and an honest latency tradeoff (warm snapshot-restore in tens of ms closes the gap while keeping full-OS compat + the security chain). Plus Plan 265 close-out: ticks the genuinely-done checkboxes with an in-progress status note listing honest follow-ups. Docs/specs only; oblique competitor naming; no debug numbers in the public doc; `nix_flake_structure` doc-guard passes 27/27.