### PR TITLE
docs(contributing): pinned toolchain-embed + cross-target re-add note

### DIFF
--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -29,15 +29,27 @@ for anything missing — run it first and follow what it says.
 ### Getting started
 
 ```bash
-# Install zig + cargo-zigbuild if exercising source-checkout runtime builds
-brew install zig && cargo install cargo-zigbuild
-
 git clone https://github.com/tinylabscom/mvm.git
 cd mvm
+
+# Source-checkout contributors exercising Linux helper/release builds:
+# install the *pinned* zig + the Linux cross-targets for the active
+# toolchain. Do NOT `brew install zig` — Homebrew's zig drifts off the
+# pinned cargo-zigbuild and fails with a cryptic CacheCheckFailed.
+just toolchain-embed
+
 cargo build
 cargo run -- doctor     # reports the builder backend + anything missing
 cargo run -- bootstrap  # pre-fetch the builder VM image (optional — builds auto-bootstrap it)
 ```
+
+> **Note — after a toolchain-version change.** `rust-toolchain.toml` pins an
+> exact Rust version, and rustup keys installed cross-targets per toolchain
+> *name*. When that pin changes (a version bump), rustup resolves a fresh
+> toolchain that carries none of the Linux cross-targets, so `just check-linux`
+> or an `mvmctl` build fails with `error[E0463]: can't find crate for core …
+> target may not be installed`. Re-run `just toolchain-embed` to reinstall the
+> targets for the new toolchain.
 
 Or run the bootstrap script on a fresh machine:
 


### PR DESCRIPTION
Two fixes to the contributor Getting Started flow, prompted by the 1.96.0 pin (#1862):

- The setup block said `brew install zig`, which is the exact drift the project warns against — Homebrew's zig moves off the pinned `cargo-zigbuild` and fails with a cryptic `CacheCheckFailed`. Replaced with `just toolchain-embed` (installs the pinned zig from the `ziglang` package + the musl cross-targets), reordered after `cd mvm` since the recipe reads the repo's pinned version.
- Added a note: rustup keys installed cross-targets per toolchain **name**, so pinning `rust-toolchain.toml` to an explicit version resolves a fresh toolchain with none of the Linux targets — `just check-linux` / an `mvmctl` build then fails with `error[E0463]: can't find crate for core … target may not be installed` until `just toolchain-embed` is re-run. (Hit exactly this rebasing #1864 onto the newly-pinned main.)

Docs-only.