### PR TITLE
ci(mvm-protocol): gate bare-metal no_std build for embedded targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,40 @@ jobs:
       - name: mvm-protocol tests run under wasm (wasm32-wasip1, via wasmtime)
         run: cargo test -p mvm-protocol --target wasm32-wasip1
 
+  # A bare-metal `*-none-*` target is a stricter no_std proof than wasm32:
+  # wasm32-unknown-unknown still ships a partial `std`, so a stray `std::` path
+  # can slip through there, whereas a `-none-elf` target has no `std` to leak
+  # into at all — only `core` + `alloc`. This gate is what lets the verifier
+  # (chain-signed audit log + Merkle inclusion proofs) run on a
+  # microcontroller-class device that provides no operating system. riscv32imac
+  # is the closest mainline target to the RISC-V microcontrollers this is aimed
+  # at and needs no out-of-tree toolchain, so the gate stays hermetic. A
+  # lib-only build (rlib, no final link) needs no cross-linker, keeping the
+  # check fast and dependency-light.
+  baremetal-no-std-boundary:
+    name: mvm-protocol bare-metal no_std boundary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: riscv32imac-unknown-none-elf
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-baremetal-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-baremetal-
+
+      - name: mvm-protocol builds no_std + alloc on riscv32imac-unknown-none-elf
+        run: cargo build -p mvm-protocol --lib --target riscv32imac-unknown-none-elf
+
   # The pure-Rust `mvm-ext4` writer (Plan 221) must produce an image the real
   # Linux kernel mounts — the strongest correctness oracle, beyond the in-process
   # `am-fs-ext4` read oracle. Write a fixed sample image and loop-mount it.

--- a/Justfile
+++ b/Justfile
@@ -53,6 +53,17 @@ check:
 check-linux TARGET="x86_64-unknown-linux-gnu":
     cargo zigbuild --target {{TARGET}} --workspace --lib --all-features
 
+# Bare-metal no_std proof for the embeddable foundation crate (mvm-protocol).
+# A `-none-elf` target exposes only core + alloc with no std to leak into, so
+# this is a stricter no_std check than the wasm32 gate. riscv32imac is the
+# mainline stand-in for the RISC-V microcontrollers the on-device verifier
+# targets; lib-only means an rlib with no final link, so no cross-linker is
+# needed. Note: riscv32imc parts (no atomics) and Xtensa parts need extra
+# shims/toolchains — see specs/notes for the embedding track.
+check-embedded TARGET="riscv32imac-unknown-none-elf":
+    rustup target add {{TARGET}}
+    cargo build -p mvm-protocol --lib --target {{TARGET}}
+
 # Run mvmctl with arguments
 run *ARGS:
     cargo run -- {{ARGS}}

--- a/specs/notes/2026-07-27-mvm-protocol-baremetal-embedding.md
+++ b/specs/notes/2026-07-27-mvm-protocol-baremetal-embedding.md
@@ -1,0 +1,94 @@
+# mvm-protocol on bare-metal embedded targets — verifier-at-the-edge track
+
+Date: 2026-07-27
+Status: slice 1 landed (bare-metal build proven + CI-gated); follow-ups open
+
+## Goal
+
+Extend the trust/attestation surface to microcontroller-class edge devices
+without moving any workload execution there. Two device tiers:
+
+- **Tier 1 — workload host.** A KVM-capable aarch64 board (Raspberry Pi 4/5,
+  RK3588-class SBCs) runs real microVM workloads. This is the existing
+  Linux/KVM/Firecracker path on aarch64; the work there is packaging +
+  runtime-only admission of signed, content-addressed bundles, not a new
+  backend. Tracked separately.
+- **Tier 2 — verifying client.** A microcontroller (ESP32-class) cannot host
+  a microVM (no MMU, no virtualization, single-digit MB RAM) but can *verify*:
+  check a chain-signed audit log and Merkle inclusion proofs, hold a device
+  identity, and act as a policy-enforcing client that submits work to a Tier 1
+  host and cryptographically confirms the signed result. Execution stays on the
+  MMU/EL2 device; verification pushes down to the smallest one. This mirrors the
+  execute-vs-verify split the whole security model already draws (signed
+  `ExecutionPlan`s, content-addressed signed bundles, the no_std/wasm protocol
+  crate, the Merkle transparency log).
+
+`mvm-protocol` is the crate that runs on Tier 2. It is already `#![no_std]` +
+`alloc`, `forbid(unsafe_code)`, and hosts the audit-log verifier, the Workload
+IR, the wire/policy DTOs, and the RFC 6962 Merkle inclusion-proof module.
+
+## Result (slice 1)
+
+`mvm-protocol` compiles for `riscv32imac-unknown-none-elf` — a true bare-metal
+`*-none-*` target with no operating system and no `std` — with **zero code
+changes**. The full dependency graph is already bare-metal-clean:
+`ed25519-dalek` (verify path), `curve25519-dalek`, `sha2`, `serde` /
+`serde_json` (alloc), `chrono` (no clock), `base64`. This is a stricter proof
+than the existing wasm32 gate: `wasm32-unknown-unknown` still ships a partial
+`std`, so a stray `std::` path can slip through there, whereas a `-none-elf`
+target exposes only `core` + `alloc`.
+
+Landed here:
+
+- CI gate `baremetal-no-std-boundary` in `.github/workflows/ci.yml` — builds
+  the crate lib for `riscv32imac-unknown-none-elf` on every PR, so a `std` leak
+  can never regress the embedding surface.
+- `just check-embedded [TARGET]` recipe for the same check locally.
+
+`riscv32imac` is the mainline stand-in for the RISC-V microcontrollers this
+targets and needs no out-of-tree toolchain, so both the gate and the recipe
+stay hermetic. A lib-only build is an rlib with no final link, so no
+cross-linker is required.
+
+### Local toolchain gotcha
+
+On a macOS host with Homebrew's Rust installed, `/opt/homebrew/bin/rustc`
+shadows the rustup proxy in PATH, and Homebrew's rustc has no rustup-managed
+bare-metal `core`. The target itself is present on the pinned toolchain — the
+build fails with a misleading "can't find crate for `core`". Fix: pin
+`RUSTC=$HOME/.cargo/bin/rustc` and put `$HOME/.cargo/bin` first in PATH. CI is
+unaffected (clean rustup toolchain, no Homebrew Rust).
+
+## Open follow-ups
+
+- **Footprint measurement (the "how small" question).** An rlib doesn't link,
+  so it carries no measurable code size on its own. Build a real `#![no_std]`
+  `#![no_main]` binary (global allocator + panic handler + target linker
+  script) that exercises the verify + Merkle path against a fixture, then
+  measure `.text`/`.rodata`. That number is the actual on-device budget and the
+  input to any flash/RAM sizing for the target part.
+- **riscv32imc (ESP32-C3) has no atomics.** The `imac` proof target has the `a`
+  extension; the C3 is `imc` (no hardware atomics). Any transitive
+  `core::sync::atomic` use needs `portable-atomic` + `critical-section` shims.
+  Add a second (allowed-to-be-harder) build against `riscv32imc-unknown-none-elf`
+  to surface this before real hardware.
+- **Xtensa (ESP32 / ESP32-S3) needs the esp-rs rustc fork.** Out-of-tree
+  toolchain, so it cannot gate in mainline CI. Keep the mainline RISC-V gate as
+  the portable proof; validate Xtensa out-of-band on hardware.
+- **Verify-only means no entropy source.** Signature *verification* and Merkle
+  proof checking need no RNG, so no `getrandom` backend is required on-device —
+  a real simplification. Signing would need entropy; the edge device never
+  signs, it verifies.
+- **Transport.** vsock is a hypervisor construct and is absent off a VMM. The
+  ESP32↔Pi link speaks the same protocol framing over a device-appropriate
+  transport (TCP/serial/BLE). The DTOs and verifier are transport-agnostic
+  already; the transport seam is the next design question for Tier 2.
+
+## Related architecture decisions
+
+- Tier matrix and per-backend claim coverage: ADR-001.
+- Target-architecture posture: ADR-022.
+- Minimal-memory profile for Tier 1 hosts (a resource profile, orthogonal to
+  ADR-001's trust tiers, gated on an empirical boot-floor measurement) is a
+  separate open decision — light path is a plan + a validated `MIN_MEM_MIB`;
+  the heavy path (a distinct size-optimized guest kernel) would amend ADR-001.


### PR DESCRIPTION
## What
Adds a CI gate + a `just check-embedded` recipe proving `mvm-protocol` builds for a true bare-metal `*-none-*` target (`riscv32imac-unknown-none-elf`).

## Why
`mvm-protocol` is the `no_std` + `alloc` foundation (audit-chain + Merkle inclusion-proof verifier, Workload IR). It already builds for wasm32, but that target ships a partial `std`, so a stray `std::` path can slip through. A `-none-elf` target has no `std` to leak into — only `core` + `alloc` — exactly what's needed to run the verifier on a microcontroller-class device with no OS (an edge attestation endpoint that verifies a signed audit chain without executing any workload).

## Notes
- No source changes were required — the full crypto/serde graph (ed25519-dalek, curve25519-dalek, sha2, serde/serde_json, chrono, base64) is already bare-metal-clean.
- Lib-only build (rlib, no final link), so no cross-linker; `riscv32imac` is mainline so the gate stays hermetic.
- Follow-ups (on-device footprint measurement; `riscv32imc`/Xtensa toolchains) are captured in the accompanying findings note.