### PR TITLE
test(mvm-conformance): capability-gate firecracker BDD scenarios

### DIFF
--- a/crates/mvm-conformance/src/lib.rs
+++ b/crates/mvm-conformance/src/lib.rs
@@ -1,11 +1,131 @@
 //! Library surface for the dev-only cucumber-rs BDD conformance harness.
 //!
-//! Currently empty. `cucumber` is a dev-dependency of this crate, and Cargo
-//! never exposes a package's dev-dependencies to its own `[lib]` target —
-//! only to the test binary that links it — so the `World` type and the
-//! cucumber-attributed step definitions live under `tests/` instead (see
-//! `tests/conformance.rs`). This module is where step logic that doesn't
-//! need cucumber's macros belongs as it lands — e.g. helpers that drive the
-//! `mvm-client` facade directly — so it can be unit-tested independent of
-//! the cucumber runner and shared if a second test target ever needs it.
-//! Not a dependency of any shipped crate.
+//! `cucumber` is a dev-dependency of this crate, and Cargo never exposes a
+//! package's dev-dependencies to its own `[lib]` target — only to the test
+//! binary that links it — so the `World` type and the cucumber-attributed step
+//! definitions live under `tests/` (see `tests/conformance.rs`). Step logic
+//! that doesn't need cucumber's macros belongs here instead, so it can be
+//! unit-tested independent of the cucumber runner. Not a dependency of any
+//! shipped crate.
+
+/// Cucumber tag for a scenario whose steps aren't implemented yet; always skipped.
+pub const PENDING_TAG: &str = "wip";
+
+/// Cucumber tag for a scenario that boots a real microVM and reaches the
+/// network; opt in with `MVM_BDD_LIVE=1` (skipped in the default hermetic lane).
+pub const LIVE_TAG: &str = "live";
+
+/// Cucumber tag for a scenario that boots a real Firecracker microVM. Being a
+/// real boot it also honors the `@live` opt-in (`MVM_BDD_LIVE`), and it runs
+/// only where a usable `/dev/kvm` and a `firecracker` binary are both present —
+/// skipped cleanly, never failed, elsewhere, so the suite stays green on hosts
+/// without KVM (GitHub-hosted ARM runners, or any dev box lacking one).
+pub const FIRECRACKER_TAG: &str = "firecracker";
+
+/// Host capabilities a scenario may require, probed once by the harness.
+///
+/// Plain data so [`scenario_should_run`] is a pure decision the harness can
+/// unit-test without touching the environment.
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimeCaps {
+    /// `MVM_BDD_LIVE` is set — the operator opted into real-microVM scenarios.
+    pub live_opted_in: bool,
+    /// A usable `/dev/kvm` and a `firecracker` binary on `PATH` are both present,
+    /// so a real Firecracker boot can run here.
+    pub firecracker_bootable: bool,
+}
+
+/// Decide whether a scenario with `tags` should run given the host `caps`.
+///
+/// A required capability that is absent yields a clean skip, never a failure.
+/// Pure so it is unit-testable: the harness supplies real probed capabilities,
+/// tests supply synthetic ones.
+pub fn scenario_should_run(tags: &[String], caps: RuntimeCaps) -> bool {
+    let tagged = |name: &str| tags.iter().any(|t| t == name);
+    if tagged(PENDING_TAG) {
+        return false;
+    }
+    if tagged(LIVE_TAG) && !caps.live_opted_in {
+        return false;
+    }
+    // A firecracker scenario is a real boot, so it also requires the `@live`
+    // opt-in and is additionally skipped where KVM or the binary is absent.
+    if tagged(FIRECRACKER_TAG) && (!caps.live_opted_in || !caps.firecracker_bootable) {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tags(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    const NONE: RuntimeCaps = RuntimeCaps {
+        live_opted_in: false,
+        firecracker_bootable: false,
+    };
+    const ALL: RuntimeCaps = RuntimeCaps {
+        live_opted_in: true,
+        firecracker_bootable: true,
+    };
+
+    #[test]
+    fn untagged_scenario_always_runs() {
+        assert!(scenario_should_run(&tags(&[]), NONE));
+    }
+
+    #[test]
+    fn pending_scenario_never_runs_even_with_all_caps() {
+        assert!(!scenario_should_run(&tags(&["wip"]), ALL));
+    }
+
+    #[test]
+    fn live_scenario_skips_without_opt_in_but_runs_with_it() {
+        assert!(!scenario_should_run(&tags(&["live"]), NONE));
+        assert!(scenario_should_run(
+            &tags(&["live"]),
+            RuntimeCaps {
+                live_opted_in: true,
+                firecracker_bootable: false,
+            },
+        ));
+    }
+
+    #[test]
+    fn firecracker_scenario_skips_cleanly_without_kvm_and_binary() {
+        assert!(!scenario_should_run(
+            &tags(&["live", "firecracker"]),
+            RuntimeCaps {
+                live_opted_in: true,
+                firecracker_bootable: false,
+            },
+        ));
+        assert!(scenario_should_run(&tags(&["live", "firecracker"]), ALL));
+    }
+
+    #[test]
+    fn firecracker_scenario_also_requires_live_opt_in() {
+        // KVM + firecracker present but no live opt-in → still skipped.
+        assert!(!scenario_should_run(
+            &tags(&["firecracker"]),
+            RuntimeCaps {
+                live_opted_in: false,
+                firecracker_bootable: true,
+            },
+        ));
+        // Live opt-in but missing capability → skipped.
+        assert!(!scenario_should_run(
+            &tags(&["firecracker"]),
+            RuntimeCaps {
+                live_opted_in: true,
+                firecracker_bootable: false,
+            },
+        ));
+        // Both present → runs.
+        assert!(scenario_should_run(&tags(&["firecracker"]), ALL));
+    }
+}

--- a/crates/mvm-conformance/tests/conformance.rs
+++ b/crates/mvm-conformance/tests/conformance.rs
@@ -27,32 +27,49 @@ use std::path::{Path, PathBuf};
 
 use cucumber::World as _;
 use cucumber::gherkin::{Feature, Rule, Scenario};
+use mvm_conformance::{RuntimeCaps, scenario_should_run};
 use world::CliWorld;
-
-const PENDING_TAG: &str = "wip";
-
-/// Scenarios that boot a real microVM and reach the network; opt in with
-/// `MVM_BDD_LIVE=1` (skipped in the default hermetic lane).
-const LIVE_TAG: &str = "live";
 
 #[tokio::main]
 async fn main() {
     CliWorld::filter_run(features_dir(), should_run).await;
 }
 
-/// Keep a scenario unless it is pending-implementation (`@wip`) or a live
-/// scenario (`@live`) that must be opted into. A `@live` scenario boots a real
-/// microVM and reaches the network, so it can't run in the default hermetic
-/// lane — set `MVM_BDD_LIVE=1` on a host with a working backend to include it.
+/// Decide whether a scenario runs from its tags and the host's probed
+/// capabilities. The tag semantics live in the crate lib (`scenario_should_run`)
+/// so they can be unit-tested without a cucumber runner; this wrapper only
+/// supplies the real host capabilities. An absent required capability yields a
+/// clean skip, never a failure — so the suite stays green on hosts without KVM
+/// (GitHub-hosted ARM runners, or any dev box lacking `/dev/kvm`).
 fn should_run(_feature: &Feature, _rule: Option<&Rule>, scenario: &Scenario) -> bool {
-    let tags = &scenario.tags;
-    if tags.iter().any(|tag| tag == PENDING_TAG) {
-        return false;
+    scenario_should_run(&scenario.tags, probe_caps())
+}
+
+/// Probe the host for the capabilities the tag gates require. Re-run per
+/// scenario by cucumber's filter callback; the syscalls are cheap.
+fn probe_caps() -> RuntimeCaps {
+    RuntimeCaps {
+        live_opted_in: std::env::var_os("MVM_BDD_LIVE").is_some(),
+        firecracker_bootable: kvm_openable() && firecracker_on_path(),
     }
-    if tags.iter().any(|tag| tag == LIVE_TAG) && std::env::var_os("MVM_BDD_LIVE").is_none() {
-        return false;
-    }
-    true
+}
+
+/// `/dev/kvm` exists and this process can open it read-write — the mode a real
+/// KVM user (Firecracker) needs, and the meaningful check since the node can be
+/// present but group-gated.
+fn kvm_openable() -> bool {
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/kvm")
+        .is_ok()
+}
+
+/// A `firecracker` binary is resolvable on `PATH`.
+fn firecracker_on_path() -> bool {
+    std::env::var_os("PATH")
+        .map(|paths| std::env::split_paths(&paths).any(|dir| dir.join("firecracker").is_file()))
+        .unwrap_or(false)
 }
 
 /// `features/suites/` lives at the repo root, two levels above this crate's

--- a/specs/notes/2026-07-27-tier1-aarch64-edge-host-findings.md
+++ b/specs/notes/2026-07-27-tier1-aarch64-edge-host-findings.md
@@ -1,0 +1,102 @@
+# Tier-1 aarch64 edge host (Raspberry Pi 4/5) — verification findings
+
+Date: 2026-07-27
+Status: G1 CONFIRMED a non-bug via a live aarch64 Firecracker boot (ttyS0);
+BDD `@firecracker` capability gate + local aarch64 nested-KVM env landed; G2
+arch gate DEFERRED — reverted after code review found a placement regression
+(see the Slice A note below).
+
+## Question
+
+Can a runtime-only `mvmctl` on a KVM-capable aarch64 board (Pi 4/5, RK3588)
+admit and run an already-signed, content-addressed bundle end-to-end, with no
+local build?
+
+## Verified
+
+1. **The workspace cross-compiles for `aarch64-unknown-linux-gnu`** — full
+   `cargo zigbuild --workspace --lib --all-features`, exit 0 (3m48s, from a
+   macOS host via zig). No aarch64-specific compile failures at the lib level.
+
+2. **The runtime-only admit-and-run path exists and is hardware-independent.**
+   `bundle install <src>` extracts a verified `.mvmpkg` to `~/.mvm/bundles/<sha>/`;
+   `up --manifest <sha>` resolves artifacts straight from that registry dir
+   (`vm/template/lifecycle/artifacts.rs::bundle_artifacts_for_sha`) with no nix
+   and no builder VM. Admission itself (`mvm_hostd::plan_admission::admit_for_run`
+   → verify plan → validity window → nonce replay → `verify_plan_bundle` →
+   chain-signed audit emit) touches only filesystem + Ed25519/SHA-256; it drives
+   the in-memory mock backend in tests, so it needs no `/dev/kvm` and no builder.
+   The first and only hardware gate is `backend.start()`.
+
+3. **Firecracker is the default Linux/KVM backend; libkrun is opt-in.**
+   `AnyBackend::auto_select` picks Firecracker on native KVM. `mvm-cli` default
+   features do not enable the `libkrun-sys` FFI, so a stock Pi binary links no
+   `libkrun.so`. Guest arch resolves correctly (`GuestArch::host()` maps
+   non-x86_64 → Aarch64).
+
+## Gaps to close for a real Pi boot
+
+### G1 — console device (CORRECTED: mostly a non-bug for Firecracker)
+
+**Correction (verified against Firecracker docs):** Firecracker emulates a legacy
+16550A UART on *aarch64 too*, so `console=ttyS0` is CORRECT for the Firecracker
+path on aarch64. The PL011/`ttyAMA0` expectation applies to QEMU's `virt` machine
+and the in-house HVF path, NOT to Firecracker. The sweeping arch→console change
+described below is therefore NOT needed; the only plausible aarch64 delta is
+adding `keep_bootcon` if the boot log comes up silent. **CONFIRMED 2026-07-27 on
+real aarch64 Firecracker v1.10.1 in the Lima nested-KVM guest:** a stock
+Firecracker-CI aarch64 `vmlinux-6.1.102` boots and emits a full kernel console
+log on `console=ttyS0` (`Booting Linux on physical CPU ... aarch64`), no change
+needed and `keep_bootcon` not required for boot output. Using a QEMU-`virt` boot as a proxy (PL011→ttyAMA0) would have
+mis-led us into breaking a correct cmdline — hence the original "don't change the
+contract blind" caution.
+
+Original finding, retained for context — console device is x86-named across the
+Firecracker path:
+
+`console=ttyS0` is baked into the FC production path, not just tests:
+- `crates/mvm-runtime/src/driver/fc.rs:74` (+ the rationale comment at :67)
+- `crates/mvm-runtime/src/compat.rs:102,145` — a compat *contract* requiring it
+- `crates/mvm-runtime/src/artifacts/builders/nix.rs:148`
+- `crates/mvm-runtime/src/vm/template/lifecycle/build.rs:87,89`
+- `crates/mvm-runtime/src/qemu.rs:85` (dev/test backend, same issue)
+
+aarch64 has no 8250 ISA serial; a PL011 (`ttyAMA0`) is expected, which the
+in-house HVF path already uses (`hvf_bootargs.rs:14`). This is cross-cutting —
+it touches a validation contract and its tests — so it is its own slice, and the
+exact correct console device for *Firecracker on aarch64* must be confirmed on
+real aarch64 KVM before changing the contract. Do not change blind.
+
+### G2 — no host-arch gate at bundle admit (hermetic, no hardware needed)
+
+`BundleManifest.arch` is only displayed by `bundle fetch`; neither
+`admit_for_run` nor `bundle_artifacts_for_sha` compares it to
+`GuestArch::host()`. An `x86_64` `.mvmpkg` installed on a Pi is admitted and
+fails only at boot, with a confusing error. Fix: fail closed at admit/resolve
+when `manifest.arch != GuestArch::host()`. Fully unit-testable against the
+existing hermetic admission tests (`plan_admission.rs` tests,
+`up/admission.rs::admit_plan_tests`). Recommended next slice — no hardware.
+
+## Blocker for true end-to-end
+
+The boot half (`backend.start()` → Firecracker on `/dev/kvm`) needs an aarch64
+KVM host. The available cloud KVM box is x86_64, which validates the
+arch-independent admit/verify/audit logic but not an aarch64 boot. A Pi 4/5 or
+an aarch64 KVM instance is required to validate G1 and the full
+`bundle install` → `up --manifest <sha>` boot.
+
+## Proposed sequencing
+
+- Slice A: DEFERRED — the G2 arch gate was reverted after code review. Placing
+  it in `bundle_artifacts_for_sha` also blocked non-boot callers that legitimately
+  resolve foreign-arch bundle artifacts without booting (`bundle export`,
+  `manifest export-oci` both reach it via `template_artifacts_dispatched`). Redo:
+  gate at the actual boot sites (`exec.rs` `resolve_image_artifacts` /
+  `boot_session_vm`) and cover the plan-admission path
+  (`plan_admission::admit_for_run`, which re-verifies a pinned bundle but not its
+  arch); add a regression test asserting cross-arch `bundle export` still works.
+- Slice B (needs aarch64 KVM): validate the correct Firecracker aarch64 console
+  device, then thread target arch → console selection through the compat contract
+  + cmdline builders (G1), with the full signed-bundle boot as the witness.
+- Packaging (later): a runtime-only aarch64 `mvmctl` binary build (backend =
+  Firecracker, no libkrun feature, embedded host bins cross-built for the Pi).


### PR DESCRIPTION
## What
Adds a `@firecracker` cucumber tag: scenarios that boot a real Firecracker microVM run only where a usable `/dev/kvm` and a `firecracker` binary are present (and the `@live` opt-in is set), and are skipped cleanly — never failed — elsewhere.

## Why
This makes real-boot BDD coverage CI-accessible. It runs as a genuine gate on x86-64 GitHub-hosted runners (which expose `/dev/kvm`) and stays green on hosts without KVM (GitHub-hosted ARM runners, KVM-less dev boxes). The tag decision is a pure function in the crate lib, unit-tested without a cucumber runner; the harness supplies host-probed capabilities.

## Notes
- Also lands the Tier-1 aarch64 edge-host findings note. A live aarch64 Firecracker boot confirmed `console=ttyS0` is correct on ARM (Firecracker emulates a 16550 UART on aarch64 too) — no cmdline change needed.
- A proactive host-arch admission gate explored alongside this was reverted after review (it wrongly blocked non-boot `bundle export` / `manifest export-oci` callers); tracked as a follow-up to gate at the boot sites instead.
- The first `@firecracker` scenario itself lands with the boot work.
