### PR TITLE
fix(vsock): bound guest-selected connection state

### DIFF
--- a/crates/mvm-runtime/src/vmm/agent_bridge.rs
+++ b/crates/mvm-runtime/src/vmm/agent_bridge.rs
@@ -23,6 +23,8 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use super::vsock_transport::MAX_CONNECTIONS;
+
 /// Per-drain read budget per host connection.
 const READ_CHUNK: usize = 16 * 1024;
 /// First host-assigned vsock port. Host-initiated streams take ports from here up
@@ -124,6 +126,9 @@ impl AgentBridge {
             return opened;
         };
         loop {
+            if self.conns.len() >= MAX_CONNECTIONS {
+                break;
+            }
             match listener.accept() {
                 Ok((stream, _)) => {
                     if stream.set_nonblocking(true).is_err() {

--- a/crates/mvm-runtime/src/vmm/console_bridge.rs
+++ b/crates/mvm-runtime/src/vmm/console_bridge.rs
@@ -32,6 +32,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::agent_bridge::write_nonblocking;
+use super::vsock_transport::MAX_CONNECTIONS;
 
 /// Per-drain read budget per host connection.
 const READ_CHUNK: usize = 16 * 1024;
@@ -152,8 +153,11 @@ impl ConsoleBridge {
         // `self.conns` / `self.next_port`) — the split keeps the borrow checker
         // happy without holding a listener borrow across the `conns` mutation.
         let mut accepted: Vec<(u32, UnixStream)> = Vec::new();
-        for (&guest_port, listener) in self.listeners.iter() {
+        'listeners: for (&guest_port, listener) in self.listeners.iter() {
             loop {
+                if self.conns.len() + accepted.len() >= MAX_CONNECTIONS {
+                    break 'listeners;
+                }
                 match listener.accept() {
                     Ok((stream, _)) => {
                         if stream.set_nonblocking(true).is_ok() {

--- a/crates/mvm-runtime/src/vmm/vsock.rs
+++ b/crates/mvm-runtime/src/vmm/vsock.rs
@@ -130,8 +130,11 @@ impl VsockShared {
             OP_RW => {
                 let n = (hdr.len as usize).min(payload.len());
                 ctx.record_received(&payload[..n]);
-                ctx.add_recv(&hdr, n as u32);
-                ctx.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]);
+                if ctx.try_add_recv(&hdr, n as u32) {
+                    ctx.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]);
+                } else {
+                    ctx.queue_reply(&hdr, OP_RST, &[]);
+                }
             }
             super::vsock_transport::OP_CREDIT_REQUEST => {
                 ctx.queue_reply(&hdr, OP_CREDIT_UPDATE, &[])
@@ -311,6 +314,7 @@ impl Drop for VirtioVsock {
 mod tests {
     use super::*;
     use crate::test_support::{bind_unix_listener, error_chain_has_permission_denied};
+    use crate::vmm::vsock_transport::MAX_CONNECTIONS;
 
     fn dev() -> VsockShared {
         let ram = vec![0u8; 0x1000].leak();
@@ -380,6 +384,46 @@ mod tests {
         };
         d.handle_packet(rw, b"hello");
         assert_eq!(d.lifecycle.received, b"hello");
+    }
+
+    #[test]
+    fn guest_stream_cap_returns_reset_for_a_new_identity() {
+        let mut d = dev();
+        for src_port in 0..MAX_CONNECTIONS as u32 {
+            d.handle_packet(
+                VsockHdr {
+                    src_cid: GUEST_CID,
+                    dst_cid: HOST_CID,
+                    src_port,
+                    dst_port: mvm_agentd::vsock::WORKLOAD_EXIT_PORT,
+                    len: 1,
+                    typ: TYPE_STREAM,
+                    op: OP_RW,
+                    ..Default::default()
+                },
+                b"x",
+            );
+        }
+
+        d.handle_packet(
+            VsockHdr {
+                src_cid: GUEST_CID,
+                dst_cid: HOST_CID,
+                src_port: MAX_CONNECTIONS as u32,
+                dst_port: mvm_agentd::vsock::WORKLOAD_EXIT_PORT,
+                len: 1,
+                typ: TYPE_STREAM,
+                op: OP_RW,
+                ..Default::default()
+            },
+            b"x",
+        );
+
+        assert_eq!(d.transport.pending_rx.len(), MAX_CONNECTIONS + 1);
+        assert_eq!(
+            d.transport.pending_rx.last().map(|(hdr, _)| hdr.op),
+            Some(OP_RST)
+        );
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vmm/vsock_handlers/mod.rs
+++ b/crates/mvm-runtime/src/vmm/vsock_handlers/mod.rs
@@ -45,8 +45,8 @@ impl<'a> VsockHandlerContext<'a> {
         }
     }
 
-    pub(crate) fn add_recv(&mut self, inbound: &VsockHdr, n: u32) {
-        self.transport.add_recv(inbound, n);
+    pub(crate) fn try_add_recv(&mut self, inbound: &VsockHdr, n: u32) -> bool {
+        self.transport.try_add_recv(inbound, n)
     }
 
     pub(crate) fn remove_recv(&mut self, host_port: u32, guest_port: u32) {
@@ -303,8 +303,11 @@ impl GuestPortHandler for WorkloadExitHandler {
             OP_RW => {
                 let n = (hdr.len as usize).min(payload.len());
                 ctx.record_workload_exit(&payload[..n]);
-                ctx.add_recv(&hdr, n as u32);
-                ctx.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]);
+                if ctx.try_add_recv(&hdr, n as u32) {
+                    ctx.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]);
+                } else {
+                    ctx.queue_reply(&hdr, OP_RST, &[]);
+                }
             }
             OP_CREDIT_REQUEST => ctx.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]),
             OP_SHUTDOWN => {
@@ -340,17 +343,23 @@ impl GuestPortHandler for StreamRelayHandler {
             OP_REQUEST => ctx.queue_reply(&hdr, OP_RESPONSE, &[]),
             OP_RW => {
                 let n = (hdr.len as usize).min(payload.len());
+                if !ctx.try_add_recv(&hdr, n as u32) {
+                    self.bridge.close_connection(hdr.src_port);
+                    self.headers.remove(&hdr.src_port);
+                    ctx.queue_reply(&hdr, OP_RST, &[]);
+                    return;
+                }
                 match self.bridge.relay_guest_bytes(hdr.src_port, &payload[..n]) {
                     EndpointRelayAction::Relayed => {
                         self.headers.insert(hdr.src_port, hdr);
                         ctx.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]);
                     }
                     EndpointRelayAction::Refused => {
+                        ctx.remove_recv(hdr.dst_port, hdr.src_port);
                         self.headers.remove(&hdr.src_port);
                         ctx.queue_reply(&hdr, OP_RST, &[]);
                     }
                 }
-                ctx.add_recv(&hdr, n as u32);
             }
             OP_CREDIT_REQUEST => ctx.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]),
             OP_SHUTDOWN => {
@@ -411,8 +420,12 @@ impl HostInitiatedHandler for AgentVsockHandler {
             OP_RESPONSE => self.bridge.on_established(hdr.dst_port),
             OP_RW => {
                 let n = (hdr.len as usize).min(payload.len());
+                if !ctx.try_add_recv(&hdr, n as u32) {
+                    self.bridge.close(hdr.dst_port);
+                    ctx.queue_reply(&hdr, OP_RST, &[]);
+                    return;
+                }
                 self.bridge.write_to_host(hdr.dst_port, &payload[..n]);
-                ctx.add_recv(&hdr, n as u32);
                 ctx.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]);
             }
             OP_SHUTDOWN | OP_RST => {
@@ -486,8 +499,12 @@ impl HostInitiatedHandler for ConsoleVsockHandler {
             OP_RESPONSE => self.bridge.on_established(hdr.dst_port),
             OP_RW => {
                 let n = (hdr.len as usize).min(payload.len());
+                if !ctx.try_add_recv(&hdr, n as u32) {
+                    self.bridge.close(hdr.dst_port);
+                    ctx.queue_reply(&hdr, OP_RST, &[]);
+                    return;
+                }
                 self.bridge.write_to_host(hdr.dst_port, &payload[..n]);
-                ctx.add_recv(&hdr, n as u32);
                 ctx.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]);
             }
             OP_SHUTDOWN | OP_RST => {

--- a/crates/mvm-runtime/src/vmm/vsock_transport.rs
+++ b/crates/mvm-runtime/src/vmm/vsock_transport.rs
@@ -17,6 +17,10 @@ pub(crate) const HDR_LEN: usize = 44;
 pub(crate) const HOST_CID: u64 = 2;
 pub(crate) const GUEST_CID: u64 = 3;
 pub(crate) const HOST_BUF_ALLOC: u32 = 256 * 1024;
+/// Maximum number of guest-selected vsock stream identities tracked by one
+/// device. A guest can choose the source port, so this is a host resource
+/// boundary rather than a protocol limit.
+pub(crate) const MAX_CONNECTIONS: usize = 256;
 
 pub(crate) const OP_REQUEST: u16 = 1;
 pub(crate) const OP_RESPONSE: u16 = 2;
@@ -98,8 +102,14 @@ pub(crate) struct VsockTransportCore {
     pub(crate) queue_sel: u32,
     pub(crate) queues: [Queue; NUM_QUEUES],
     pub(crate) interrupt_status: u32,
-    pub(crate) recv_cnt: HashMap<(u32, u32), u32>,
+    pub(crate) recv_cnt: HashMap<VsockConnectionKey, u32>,
     pub(crate) pending_rx: Vec<(VsockHdr, Vec<u8>)>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct VsockConnectionKey {
+    host_port: u32,
+    guest_port: u32,
 }
 
 impl VsockTransportCore {
@@ -185,16 +195,24 @@ impl VsockTransportCore {
         packets
     }
 
-    pub(crate) fn add_recv(&mut self, inbound: &VsockHdr, n: u32) {
-        let entry = self
-            .recv_cnt
-            .entry((inbound.dst_port, inbound.src_port))
-            .or_default();
-        *entry = entry.wrapping_add(n);
+    pub(crate) fn try_add_recv(&mut self, inbound: &VsockHdr, n: u32) -> bool {
+        let key = VsockConnectionKey {
+            host_port: inbound.dst_port,
+            guest_port: inbound.src_port,
+        };
+        if !self.recv_cnt.contains_key(&key) && self.recv_cnt.len() >= MAX_CONNECTIONS {
+            return false;
+        }
+        let entry = self.recv_cnt.entry(key).or_default();
+        *entry = entry.saturating_add(n);
+        true
     }
 
     pub(crate) fn remove_recv(&mut self, host_port: u32, guest_port: u32) {
-        self.recv_cnt.remove(&(host_port, guest_port));
+        self.recv_cnt.remove(&VsockConnectionKey {
+            host_port,
+            guest_port,
+        });
     }
 
     pub(crate) fn queue_host_packet(
@@ -291,7 +309,10 @@ impl VsockTransportCore {
 
     fn fwd_cnt_for(&self, host_port: u32, guest_port: u32) -> u32 {
         self.recv_cnt
-            .get(&(host_port, guest_port))
+            .get(&VsockConnectionKey {
+                host_port,
+                guest_port,
+            })
             .copied()
             .unwrap_or(0)
     }
@@ -470,5 +491,52 @@ mod tests {
             );
             assert_eq!(core.pending_rx.len(), 1);
         }
+    }
+
+    #[test]
+    fn recv_credit_table_rejects_new_connection_ids_at_the_cap() {
+        let mut core = transport();
+        for guest_port in 0..MAX_CONNECTIONS as u32 {
+            let hdr = VsockHdr {
+                dst_port: 9000,
+                src_port: guest_port,
+                ..Default::default()
+            };
+            assert!(core.try_add_recv(&hdr, 1));
+        }
+
+        let new_connection = VsockHdr {
+            dst_port: 9000,
+            src_port: MAX_CONNECTIONS as u32,
+            ..Default::default()
+        };
+        assert!(!core.try_add_recv(&new_connection, 1));
+        assert_eq!(core.recv_cnt.len(), MAX_CONNECTIONS);
+
+        // A normal close frees the slot, allowing a new stream to make progress.
+        core.remove_recv(9000, 0);
+        assert!(core.try_add_recv(&new_connection, 1));
+        assert_eq!(core.recv_cnt.len(), MAX_CONNECTIONS);
+    }
+
+    #[test]
+    fn recv_credit_for_existing_connection_remains_available_at_the_cap() {
+        let mut core = transport();
+        let existing = VsockHdr {
+            dst_port: 9000,
+            src_port: 7,
+            ..Default::default()
+        };
+        assert!(core.try_add_recv(&existing, 1));
+        for guest_port in 8..(MAX_CONNECTIONS as u32 + 7) {
+            let hdr = VsockHdr {
+                dst_port: 9000,
+                src_port: guest_port,
+                ..Default::default()
+            };
+            assert!(core.try_add_recv(&hdr, 1));
+        }
+        assert_eq!(core.recv_cnt.len(), MAX_CONNECTIONS);
+        assert!(core.try_add_recv(&existing, 1));
     }
 }

--- a/crates/mvm-runtime/src/vsock_egress_bridge/substitution_bridge.rs
+++ b/crates/mvm-runtime/src/vsock_egress_bridge/substitution_bridge.rs
@@ -16,6 +16,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use crate::vmm::vsock_transport::MAX_CONNECTIONS;
+
 /// Per-drain read budget per endpoint connection.
 const READ_CHUNK: usize = 16 * 1024;
 
@@ -112,6 +114,9 @@ impl GuestEndpointRelay for SubstitutionBridge {
             write_nonblocking(up, payload);
             return EndpointRelayAction::Relayed;
         }
+        if self.conns.len() >= MAX_CONNECTIONS {
+            return EndpointRelayAction::Refused;
+        }
         let Some(path) = self.endpoint.clone() else {
             return EndpointRelayAction::Refused;
         };
@@ -192,6 +197,23 @@ mod tests {
             EndpointRelayAction::Refused
         );
         assert!(!b.is_active());
+    }
+
+    #[test]
+    fn refuses_new_streams_at_the_connection_cap() {
+        let mut b = SubstitutionBridge::new();
+        let mut peers = Vec::with_capacity(MAX_CONNECTIONS);
+        for conn_id in 0..MAX_CONNECTIONS as u32 {
+            let (stream, peer) = UnixStream::pair().unwrap();
+            b.conns.insert(conn_id, stream);
+            peers.push(peer);
+        }
+
+        assert_eq!(
+            b.relay_guest_bytes(MAX_CONNECTIONS as u32, b"data"),
+            EndpointRelayAction::Refused
+        );
+        assert_eq!(b.conns.len(), MAX_CONNECTIONS);
     }
 
     /// A raw first frame (not a WireRequest) is relayed byte-for-byte to the

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -24,6 +24,9 @@
       workload)` so hot plan revisions replace prior rules without orphaning
       firewalls. Focused regression coverage, workspace check, full tests,
       clippy, and formatting pass; published as PR #1847 for review.
+- [ ] #1827 vsock overload hardening: bound guest-selected connection state and
+      host bridge sockets first, then add idle eviction, egress budgets, and
+      teardown cancellation. Tracked in `specs/plans/266-vsock-overload-hardening.md`.
 
 ---
 

--- a/specs/plans/266-vsock-overload-hardening.md
+++ b/specs/plans/266-vsock-overload-hardening.md
@@ -1,0 +1,40 @@
+# Vsock overload hardening
+
+Issue: #1827
+
+Status: IN PROGRESS
+
+## Goal
+
+Keep guest-generated traffic from exhausting host sockets, connection state, or
+the host-side network path when a workload is dead, unresponsive, or sending
+more traffic than its approved egress path can deliver. Production workloads
+remain NIC-less; the authenticated vsock seam is the primary enforcement point.
+
+## Delivery checklist
+
+- [x] Bound the per-device received-credit table to 256 connection identities,
+      use a typed connection key, saturate credit accounting, and refuse new
+      identities with `OP_RST` once the table is full.
+- [x] Bound substitution, host-agent, and dev-console bridge connection sets
+      to the same per-device ceiling; refuse before opening another host socket.
+- [x] Add focused cap, slot-reuse, existing-stream, and bridge refusal tests.
+- [ ] Add idle timestamps and deterministic eviction for inactive bridge and
+      credit-table entries, with `OP_RST` cleanup for the guest side.
+- [ ] Add per-workload concurrent-stream and byte-rate budgets around raw,
+      SOCKS5, DNS, and substitution egress, preserving kernel backpressure.
+- [ ] Cancel active egress sessions as part of VM teardown and prove that a
+      dead workload cannot retain host sockets after its stop path completes.
+- [ ] Evaluate null-node routing for the optional packet gateway path; it is
+      separate from the production NIC-less vsock path.
+- [ ] Run the workspace check, tests, formatting, and Linux-builder clippy
+      gates; resolve any failures attributable to this plan.
+
+## First slice
+
+The first slice is intentionally transport-local. A guest controls its vsock
+source port, so an unbounded map or bridge set turns that field into a host
+resource-exhaustion primitive. The cap is fail-closed: a new identity gets an
+`OP_RST`, an existing identity continues to make progress, and `OP_SHUTDOWN`
+releases the slot. No raw packet forwarding or host NIC is introduced.
+


### PR DESCRIPTION
## Summary

- Bound each hand-rolled virtio-vsock device's guest-selected connection table to 256 identities.
- Return `OP_RST` for new identities past the cap while preserving existing streams and normal shutdown slot reuse.
- Apply the same ceiling before substitution, host-agent, and dev-console bridges open another host Unix socket.
- Use typed connection keys and saturating credit accounting.

This is the first slice of #1827. Production workloads remain NIC-less; this closes the host-state and host-FD exhaustion path at the authenticated vsock seam.

## Validation

- Focused connection-cap and handler tests pass.
- `cargo check -p mvm-runtime --all-targets`
- `cargo clippy -p mvm-runtime --all-targets -- -D warnings`
- Repository pre-commit workspace all-target clippy gate passed.
- Full `mvm-runtime` library coverage has one unrelated environment-dependent failure requiring the generated `mvm-substitution-endpoint` helper.

Follow-ups are tracked in `specs/plans/266-vsock-overload-hardening.md`: idle eviction, egress budgets, teardown cancellation, and optional packet-gateway null-node routing.