### PR TITLE
fix(vmm-vsock): harden RX/descriptor paths (F3/F5/F6/F7)

### DIFF
--- a/crates/mvm-runtime/src/vmm/agent_bridge.rs
+++ b/crates/mvm-runtime/src/vmm/agent_bridge.rs
@@ -19,8 +19,9 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::os::fd::{AsRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::vsock_transport::MAX_CONNECTIONS;
@@ -216,18 +217,28 @@ impl AgentBridge {
     }
 }
 
+/// Resolved `MVM_HVF_AGENT_DEBUG` trace-file path, read from the environment once
+/// and cached so the accept/drain path never takes the process-global env lock
+/// per connection.
+fn debug_path() -> Option<&'static Path> {
+    static PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
+    PATH.get_or_init(|| std::env::var_os("MVM_HVF_AGENT_DEBUG").map(PathBuf::from))
+        .as_deref()
+}
+
 /// Debug trace gated on `MVM_HVF_AGENT_DEBUG` (a file path), mirroring the vsock
 /// device's `agent_dbg`. Silent in normal operation.
 fn dbg_log(msg: &str) {
-    if let Some(path) = std::env::var_os("MVM_HVF_AGENT_DEBUG") {
-        use std::io::Write as _;
-        if let Ok(mut f) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-        {
-            let _ = writeln!(f, "[agent-bridge] {msg}");
-        }
+    let Some(path) = debug_path() else {
+        return;
+    };
+    use std::io::Write as _;
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        let _ = writeln!(f, "[agent-bridge] {msg}");
     }
 }
 

--- a/crates/mvm-runtime/src/vmm/console_bridge.rs
+++ b/crates/mvm-runtime/src/vmm/console_bridge.rs
@@ -27,8 +27,9 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::os::fd::{AsRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::agent_bridge::write_nonblocking;
@@ -248,18 +249,28 @@ impl ConsoleBridge {
     }
 }
 
+/// Resolved `MVM_HVF_AGENT_DEBUG` trace-file path, read from the environment once
+/// and cached so the bind/accept path never takes the process-global env lock per
+/// call.
+fn debug_path() -> Option<&'static Path> {
+    static PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
+    PATH.get_or_init(|| std::env::var_os("MVM_HVF_AGENT_DEBUG").map(PathBuf::from))
+        .as_deref()
+}
+
 /// Debug trace gated on `MVM_HVF_AGENT_DEBUG` (a file path), mirroring the agent
 /// bridge's tracer. Silent in normal operation.
 fn dbg_log(msg: &str) {
-    if let Some(path) = std::env::var_os("MVM_HVF_AGENT_DEBUG") {
-        use std::io::Write as _;
-        if let Ok(mut f) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-        {
-            let _ = writeln!(f, "[console-bridge] {msg}");
-        }
+    let Some(path) = debug_path() else {
+        return;
+    };
+    use std::io::Write as _;
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        let _ = writeln!(f, "[console-bridge] {msg}");
     }
 }
 

--- a/crates/mvm-runtime/src/vmm/virtio.rs
+++ b/crates/mvm-runtime/src/vmm/virtio.rs
@@ -12,8 +12,17 @@
 use std::fs::{File, OpenOptions};
 use std::os::unix::fs::FileExt;
 use std::path::Path;
+use std::sync::OnceLock;
 
 use super::guest_mem::GuestMem;
+
+/// Whether the per-descriptor virtio trace is enabled (`MVM_HVF_VIRTIO_DEBUG`).
+/// Read from the environment once and cached — the request/descriptor hot path
+/// must not take the process-global env lock per descriptor.
+fn virtio_debug() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("MVM_HVF_VIRTIO_DEBUG").is_some())
+}
 
 const VIRTIO_MAGIC: u32 = 0x7472_6976; // "virt"
 const VIRTIO_VERSION: u32 = 2;
@@ -308,7 +317,7 @@ impl VirtioBlk {
             return false;
         };
         let avail_idx = self.rd_u16(self.avail + 2);
-        let debug = std::env::var_os("MVM_HVF_VIRTIO_DEBUG").is_some();
+        let debug = virtio_debug();
         if debug {
             eprintln!(
                 "virtio: notify qsz={qsz} ready={} avail_idx={avail_idx} last_avail={} desc={:#x} avail={:#x} used={:#x}",
@@ -351,7 +360,7 @@ impl VirtioBlk {
         // request header: type u32 @0, reserved u32 @4, sector u64 @8.
         let req_type = self.rd_u32(hdr_addr);
         let mut sector = self.rd_u64(hdr_addr + 8);
-        if std::env::var_os("MVM_HVF_VIRTIO_DEBUG").is_some() {
+        if virtio_debug() {
             eprintln!("virtio:   req hdr@{hdr_addr:#x} type={req_type} sector={sector}");
         }
 
@@ -372,7 +381,7 @@ impl VirtioBlk {
             let addr = self.rd_u64(da);
             let len = self.rd_u32(da + 8);
             let dflags = self.rd_u16(da + 12);
-            if std::env::var_os("MVM_HVF_VIRTIO_DEBUG").is_some() {
+            if virtio_debug() {
                 eprintln!("virtio:     desc[{next}] addr={addr:#x} len={len} flags={dflags:#x}");
             }
             if dflags & VIRTQ_DESC_F_NEXT == 0 {

--- a/crates/mvm-runtime/src/vmm/vsock.rs
+++ b/crates/mvm-runtime/src/vmm/vsock.rs
@@ -421,7 +421,7 @@ mod tests {
 
         assert_eq!(d.transport.pending_rx.len(), MAX_CONNECTIONS + 1);
         assert_eq!(
-            d.transport.pending_rx.last().map(|(hdr, _)| hdr.op),
+            d.transport.pending_rx.back().map(|(hdr, _)| hdr.op),
             Some(OP_RST)
         );
     }
@@ -738,7 +738,7 @@ mod tests {
         let mut hdr = None;
         for _ in 0..200 {
             let _ = d.service_host_io();
-            if let Some((h, _)) = d.transport.pending_rx.first() {
+            if let Some((h, _)) = d.transport.pending_rx.front() {
                 hdr = Some(*h);
                 break;
             }
@@ -798,7 +798,7 @@ mod tests {
         let mut hdr = None;
         for _ in 0..200 {
             let _ = d.service_host_io();
-            if let Some((h, _)) = d.transport.pending_rx.first() {
+            if let Some((h, _)) = d.transport.pending_rx.front() {
                 hdr = Some(*h);
                 break;
             }

--- a/crates/mvm-runtime/src/vmm/vsock_handlers/mod.rs
+++ b/crates/mvm-runtime/src/vmm/vsock_handlers/mod.rs
@@ -1,8 +1,9 @@
 use std::any::Any;
 use std::collections::{BTreeMap, HashMap};
 use std::os::fd::RawFd;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::atomic::AtomicBool;
 
 use super::agent_bridge::AgentBridge;
@@ -531,15 +532,25 @@ impl HostInitiatedHandler for ConsoleVsockHandler {
     }
 }
 
+/// Resolved `MVM_HVF_AGENT_DEBUG` trace-file path, read from the environment once
+/// and cached — the per-packet drain path must not take the process-global env
+/// lock on every call.
+fn agent_debug_path() -> Option<&'static Path> {
+    static PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
+    PATH.get_or_init(|| std::env::var_os("MVM_HVF_AGENT_DEBUG").map(PathBuf::from))
+        .as_deref()
+}
+
 fn agent_dbg(msg: &str) {
-    if let Some(path) = std::env::var_os("MVM_HVF_AGENT_DEBUG") {
-        use std::io::Write as _;
-        if let Ok(mut f) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-        {
-            let _ = writeln!(f, "[agent-bridge] {msg}");
-        }
+    let Some(path) = agent_debug_path() else {
+        return;
+    };
+    use std::io::Write as _;
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        let _ = writeln!(f, "[agent-bridge] {msg}");
     }
 }

--- a/crates/mvm-runtime/src/vmm/vsock_transport.rs
+++ b/crates/mvm-runtime/src/vmm/vsock_transport.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 use super::guest_mem::GuestMem;
 
@@ -103,7 +103,7 @@ pub(crate) struct VsockTransportCore {
     pub(crate) queues: [Queue; NUM_QUEUES],
     pub(crate) interrupt_status: u32,
     pub(crate) recv_cnt: HashMap<VsockConnectionKey, u32>,
-    pub(crate) pending_rx: Vec<(VsockHdr, Vec<u8>)>,
+    pub(crate) pending_rx: VecDeque<(VsockHdr, Vec<u8>)>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -125,7 +125,7 @@ impl VsockTransportCore {
             queues: [Queue::default(); NUM_QUEUES],
             interrupt_status: 0,
             recv_cnt: HashMap::new(),
-            pending_rx: Vec::new(),
+            pending_rx: VecDeque::new(),
         }
     }
 
@@ -234,7 +234,7 @@ impl VsockTransportCore {
             buf_alloc: HOST_BUF_ALLOC,
             fwd_cnt: self.fwd_cnt_for(src_port, dst_port),
         };
-        self.pending_rx.push((hdr, payload.to_vec()));
+        self.pending_rx.push_back((hdr, payload.to_vec()));
     }
 
     pub(crate) fn queue_reply(&mut self, inbound: &VsockHdr, op: u16, payload: &[u8]) {
@@ -250,7 +250,7 @@ impl VsockTransportCore {
             buf_alloc: HOST_BUF_ALLOC,
             fwd_cnt: self.fwd_cnt_for(inbound.dst_port, inbound.src_port),
         };
-        self.pending_rx.push((reply, payload.to_vec()));
+        self.pending_rx.push_back((reply, payload.to_vec()));
     }
 
     pub(crate) fn flush_rx(&mut self) -> bool {
@@ -268,7 +268,10 @@ impl VsockTransportCore {
             if last == avail_idx {
                 break;
             }
-            let (mut hdr, payload) = self.pending_rx.remove(0);
+            let (hdr, payload) = self
+                .pending_rx
+                .pop_front()
+                .expect("loop guard checked non-empty");
             let slot = last % qsz;
             let head = self.mem.rd_u16(q.avail + 4 + u64::from(slot) * 2);
             let da = q.desc + u64::from(head) * 16;
@@ -277,19 +280,26 @@ impl VsockTransportCore {
             let payload_cap = match cap.checked_sub(HDR_LEN) {
                 Some(payload_cap) if payload_cap > 0 || payload.is_empty() => payload_cap,
                 _ => {
-                    self.pending_rx.insert(0, (hdr, payload));
+                    self.pending_rx.push_front((hdr, payload));
                     break;
                 }
             };
             let send_len = payload.len().min(payload_cap);
-            let remainder = payload[send_len..].to_vec();
-            hdr.len = send_len as u32;
-            let mut bytes = hdr.to_bytes().to_vec();
+            let mut framed = hdr;
+            framed.len = send_len as u32;
+            let mut bytes = framed.to_bytes().to_vec();
             bytes.extend_from_slice(&payload[..send_len]);
-            self.mem.write_bytes(addr, &bytes);
+            if self.mem.write_bytes(addr, &bytes) == 0 {
+                // Out-of-range RX descriptor addr: nothing was delivered. Leave the
+                // packet queued and stop instead of advancing the used ring for a
+                // packet the guest never received (mirrors the too-small-buffer path).
+                self.pending_rx.push_front((hdr, payload));
+                break;
+            }
             self.complete(RX, head, bytes.len() as u32, qsz);
+            let remainder = &payload[send_len..];
             if !remainder.is_empty() {
-                self.pending_rx.insert(0, (hdr, remainder));
+                self.pending_rx.push_front((framed, remainder.to_vec()));
             }
             last = last.wrapping_add(1);
             delivered = true;
@@ -331,7 +341,11 @@ impl VsockTransportCore {
             if flags & VIRTQ_DESC_F_NEXT == 0 || guard > u32::from(qsz) {
                 break;
             }
-            idx = self.mem.rd_u16(da + 14);
+            let next = self.mem.rd_u16(da + 14);
+            if next >= qsz {
+                break;
+            }
+            idx = next;
         }
         out
     }
@@ -412,7 +426,7 @@ mod tests {
             buf_alloc: HOST_BUF_ALLOC,
             fwd_cnt: 12,
         };
-        core.pending_rx.push((hdr, b"abcdefghij".to_vec()));
+        core.pending_rx.push_back((hdr, b"abcdefghij".to_vec()));
 
         assert!(core.flush_rx());
         assert!(core.pending_rx.is_empty());
@@ -491,6 +505,45 @@ mod tests {
             );
             assert_eq!(core.pending_rx.len(), 1);
         }
+    }
+
+    #[test]
+    fn flush_rx_leaves_packet_queued_on_out_of_range_rx_descriptor() {
+        let mut core = transport();
+        let base = 0x4000_0000;
+        let desc = base + 0x100;
+        let avail = base + 0x200;
+        let used = base + 0x300;
+        core.queues[RX] = Queue {
+            num: 1,
+            ready: 1,
+            desc,
+            avail,
+            used,
+            last_avail: 0,
+        };
+        core.mem.wr_u16(avail + 2, 1);
+        core.mem.wr_u16(avail + 4, 0); // ring[0] = head 0
+        // Head descriptor addr points past the mapped RAM region; the capacity is
+        // large enough to pass the buffer-size check, so the write is attempted and
+        // delivers 0 bytes.
+        let bogus = base + 0x1_0000;
+        core.mem.write_bytes(desc, &bogus.to_le_bytes());
+        core.mem
+            .write_bytes(desc + 8, &((HDR_LEN + 8) as u32).to_le_bytes());
+        core.queue_host_packet(1, 2, OP_RW, b"payload!");
+
+        assert!(!core.flush_rx(), "bogus addr delivers nothing");
+        assert_eq!(core.pending_rx.len(), 1, "packet left queued, not dropped");
+        assert_eq!(core.mem.rd_u16(used + 2), 0, "used ring not advanced");
+
+        // Repointing the descriptor at valid RAM delivers the same packet and now
+        // advances the used ring.
+        let good = base + 0x400;
+        core.mem.write_bytes(desc, &good.to_le_bytes());
+        assert!(core.flush_rx());
+        assert!(core.pending_rx.is_empty());
+        assert_eq!(core.mem.rd_u16(used + 2), 1, "valid path advances used");
     }
 
     #[test]


### PR DESCRIPTION
The dependency-free device-audit findings for the in-house VMM's virtio-vsock device, **minus F2** — the connection-cap finding is now owned by #1876 (Plan 266), which merged first, so this drops my redundant `GuestConnTable` and keeps only the four findings nobody else fixed:

- **F3** — `read_chain` breaks on `next >= qsz` (parity with the block/fs walkers), killing cyclic/out-of-range descriptor-chain amplification.
- **F5** — `flush_rx` no longer advances the used ring for an RX descriptor whose addr is out of range (delivered 0 bytes); it re-queues instead of silently dropping.
- **F6** — `pending_rx` `Vec` → `VecDeque` (removes the O(n²) `remove(0)`/`insert(0)` on the RX hot path).
- **F7** — per-packet `env::var_os` debug taps cached in `OnceLock`.

Rebuilt cleanly on top of #1876's landed F2 (no overlap — different functions; the only touch to #1876's code was mechanically converting 3 `Vec`→`VecDeque` call sites in its tests). Gates green (rustup 1.96): fmt, `clippy --workspace -D warnings`, `nextest -p mvm-runtime` 1007 pass, `check-vsock-only-egress`, `check-no-spec-refs`, closure-budget 267 (unchanged). Independent of the fuzzer #1879.