### PR TITLE
fix(vsock): bound egress budgets and teardown

### DIFF
--- a/crates/mvm-runtime/src/vmm/agent_bridge.rs
+++ b/crates/mvm-runtime/src/vmm/agent_bridge.rs
@@ -23,8 +23,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
 
-use super::vsock_transport::MAX_CONNECTIONS;
+use super::vsock_transport::{CONNECTION_IDLE_TIMEOUT, MAX_CONNECTIONS};
 
 /// Per-drain read budget per host connection.
 const READ_CHUNK: usize = 16 * 1024;
@@ -37,6 +38,7 @@ struct AgentConn {
     stream: UnixStream,
     /// The guest accepted (`OP_RESPONSE` seen); only then do we read host bytes.
     established: bool,
+    last_activity: Instant,
 }
 
 /// Host→guest agent stream bridge for one guest: a Unix listener plus the open
@@ -121,6 +123,7 @@ impl AgentBridge {
     /// Returns the new conn ids — the device sends an `OP_REQUEST` to the guest
     /// agent (dst_port [`GUEST_AGENT_PORT`]) for each. No-op without a listener.
     pub fn accept_new(&mut self) -> Vec<u32> {
+        self.evict_idle_at(Instant::now());
         let mut opened = Vec::new();
         let Some(listener) = &self.listener else {
             dbg_log("accept_new: no listener bound on this bridge");
@@ -142,6 +145,7 @@ impl AgentBridge {
                         AgentConn {
                             stream,
                             established: false,
+                            last_activity: Instant::now(),
                         },
                     );
                     self.bump(1);
@@ -160,6 +164,7 @@ impl AgentBridge {
     pub fn on_established(&mut self, conn_id: u32) {
         if let Some(c) = self.conns.get_mut(&conn_id) {
             c.established = true;
+            c.last_activity = Instant::now();
         }
     }
 
@@ -167,6 +172,7 @@ impl AgentBridge {
     /// `(conn_id, bytes)` for the device to `OP_RW` to the guest. A peer EOF/error
     /// closes that stream in place (dropping it from the open set).
     pub fn drain_host(&mut self) -> Vec<(u32, Vec<u8>)> {
+        self.evict_idle_at(Instant::now());
         let mut ready = Vec::new();
         let mut closed = Vec::new();
         for (conn_id, c) in self.conns.iter_mut() {
@@ -178,6 +184,7 @@ impl AgentBridge {
                 Ok(0) => closed.push(*conn_id),
                 Ok(n) => {
                     buf.truncate(n);
+                    c.last_activity = Instant::now();
                     ready.push((*conn_id, buf));
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
@@ -196,6 +203,7 @@ impl AgentBridge {
     pub fn write_to_host(&mut self, conn_id: u32, payload: &[u8]) {
         if let Some(c) = self.conns.get_mut(&conn_id) {
             write_nonblocking(&mut c.stream, payload);
+            c.last_activity = Instant::now();
         }
     }
 
@@ -203,6 +211,21 @@ impl AgentBridge {
     pub fn close(&mut self, conn_id: u32) {
         if self.conns.remove(&conn_id).is_some() {
             self.bump(-1);
+        }
+    }
+
+    fn evict_idle_at(&mut self, now: Instant) {
+        let expired: Vec<u32> = self
+            .conns
+            .iter()
+            .filter(|(_, conn)| {
+                now.saturating_duration_since(conn.last_activity) >= CONNECTION_IDLE_TIMEOUT
+            })
+            .map(|(&conn_id, _)| conn_id)
+            .collect();
+        for conn_id in expired {
+            self.close(conn_id);
+            self.host_closed.push(conn_id);
         }
     }
 
@@ -425,5 +448,25 @@ mod tests {
         bridge.on_established(conn_id);
         let after_established = bridge.poll_fds();
         assert_eq!(after_established.len(), 2, "listener plus established conn");
+    }
+
+    #[test]
+    fn idle_agent_stream_is_surfaced_for_guest_reset() {
+        let mut bridge = AgentBridge::new();
+        let (stream, _peer) = UnixStream::pair().unwrap();
+        let conn_id = FIRST_HOST_PORT;
+        bridge.conns.insert(
+            conn_id,
+            AgentConn {
+                stream,
+                established: true,
+                last_activity: Instant::now() - CONNECTION_IDLE_TIMEOUT - Duration::from_secs(1),
+            },
+        );
+
+        bridge.drain_host();
+
+        assert_eq!(bridge.take_host_closed(), vec![conn_id]);
+        assert!(!bridge.is_agent_stream(conn_id));
     }
 }

--- a/crates/mvm-runtime/src/vmm/agent_bridge.rs
+++ b/crates/mvm-runtime/src/vmm/agent_bridge.rs
@@ -214,6 +214,14 @@ impl AgentBridge {
         }
     }
 
+    pub fn close_all(&mut self) {
+        let conn_ids: Vec<u32> = self.conns.keys().copied().collect();
+        for conn_id in conn_ids {
+            self.close(conn_id);
+        }
+        self.host_closed.clear();
+    }
+
     fn evict_idle_at(&mut self, now: Instant) {
         let expired: Vec<u32> = self
             .conns

--- a/crates/mvm-runtime/src/vmm/console_bridge.rs
+++ b/crates/mvm-runtime/src/vmm/console_bridge.rs
@@ -31,9 +31,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
 
 use super::agent_bridge::write_nonblocking;
-use super::vsock_transport::MAX_CONNECTIONS;
+use super::vsock_transport::{CONNECTION_IDLE_TIMEOUT, MAX_CONNECTIONS};
 
 /// Per-drain read budget per host connection.
 const READ_CHUNK: usize = 16 * 1024;
@@ -51,6 +52,7 @@ struct ConsoleConn {
     guest_port: u32,
     /// The guest accepted (`OP_RESPONSE` seen); only then do we read host bytes.
     established: bool,
+    last_activity: Instant,
 }
 
 /// Host→guest console stream bridge for one guest: a per-guest-port set of Unix
@@ -68,6 +70,8 @@ pub(crate) struct ConsoleBridge {
     /// console stream keeps the loop waking an idle guest (the same counter the
     /// agent/substitution paths use).
     active: Option<Arc<AtomicUsize>>,
+    /// Host-side EOF/error/idle closures waiting for a guest `OP_RST`.
+    host_closed: Vec<(u32, u32)>,
 }
 
 impl ConsoleBridge {
@@ -77,6 +81,7 @@ impl ConsoleBridge {
             conns: HashMap::new(),
             next_port: FIRST_CONSOLE_HOST_PORT,
             active: None,
+            host_closed: Vec::new(),
         }
     }
 
@@ -149,6 +154,7 @@ impl ConsoleBridge {
     /// each — the device sends an `OP_REQUEST` to the guest console listener on
     /// `guest_port`. No-op when no listeners are bound (sealed prod).
     pub fn accept_new(&mut self) -> Vec<(u32, u32)> {
+        self.evict_idle_at(Instant::now());
         // Two phases: first drain every listener to `WouldBlock` (borrows only
         // `self.listeners`), then register the accepted streams (borrows
         // `self.conns` / `self.next_port`) — the split keeps the borrow checker
@@ -180,6 +186,7 @@ impl ConsoleBridge {
                     stream,
                     guest_port,
                     established: false,
+                    last_activity: Instant::now(),
                 },
             );
             self.bump(1);
@@ -194,6 +201,7 @@ impl ConsoleBridge {
     pub fn on_established(&mut self, conn_id: u32) {
         if let Some(c) = self.conns.get_mut(&conn_id) {
             c.established = true;
+            c.last_activity = Instant::now();
         }
     }
 
@@ -201,6 +209,7 @@ impl ConsoleBridge {
     /// `(conn_id, guest_port, bytes)` for the device to `OP_RW` to the guest on the
     /// right console port. A peer EOF/error closes that stream in place.
     pub fn drain_host(&mut self) -> Vec<(u32, u32, Vec<u8>)> {
+        self.evict_idle_at(Instant::now());
         let mut ready = Vec::new();
         let mut closed = Vec::new();
         for (conn_id, c) in self.conns.iter_mut() {
@@ -209,17 +218,19 @@ impl ConsoleBridge {
             }
             let mut buf = vec![0u8; READ_CHUNK];
             match c.stream.read(&mut buf) {
-                Ok(0) => closed.push(*conn_id),
+                Ok(0) => closed.push((*conn_id, c.guest_port)),
                 Ok(n) => {
                     buf.truncate(n);
+                    c.last_activity = Instant::now();
                     ready.push((*conn_id, c.guest_port, buf));
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
-                Err(_) => closed.push(*conn_id),
+                Err(_) => closed.push((*conn_id, c.guest_port)),
             }
         }
-        for conn_id in closed {
+        for (conn_id, guest_port) in closed {
             self.close(conn_id);
+            self.host_closed.push((conn_id, guest_port));
         }
         ready
     }
@@ -228,13 +239,34 @@ impl ConsoleBridge {
     pub fn write_to_host(&mut self, conn_id: u32, payload: &[u8]) {
         if let Some(c) = self.conns.get_mut(&conn_id) {
             write_nonblocking(&mut c.stream, payload);
+            c.last_activity = Instant::now();
         }
+    }
+
+    /// Drain host-side closures so the device can reset the guest stream.
+    pub fn take_host_closed(&mut self) -> Vec<(u32, u32)> {
+        std::mem::take(&mut self.host_closed)
     }
 
     /// Close a stream (guest `OP_SHUTDOWN`/`OP_RST`, or a host EOF/error).
     pub fn close(&mut self, conn_id: u32) {
         if self.conns.remove(&conn_id).is_some() {
             self.bump(-1);
+        }
+    }
+
+    fn evict_idle_at(&mut self, now: Instant) {
+        let expired: Vec<(u32, u32)> = self
+            .conns
+            .iter()
+            .filter(|(_, conn)| {
+                now.saturating_duration_since(conn.last_activity) >= CONNECTION_IDLE_TIMEOUT
+            })
+            .map(|(&conn_id, conn)| (conn_id, conn.guest_port))
+            .collect();
+        for (conn_id, guest_port) in expired {
+            self.close(conn_id);
+            self.host_closed.push((conn_id, guest_port));
         }
     }
 
@@ -492,5 +524,26 @@ mod tests {
         bridge.bind_ports([]).unwrap();
         assert!(bridge.accept_new().is_empty());
         assert!(!bridge.is_console_stream(FIRST_CONSOLE_HOST_PORT));
+    }
+
+    #[test]
+    fn idle_console_stream_is_surfaced_for_guest_reset() {
+        let mut bridge = ConsoleBridge::new();
+        let (stream, _peer) = UnixStream::pair().unwrap();
+        let conn_id = FIRST_CONSOLE_HOST_PORT;
+        bridge.conns.insert(
+            conn_id,
+            ConsoleConn {
+                stream,
+                guest_port: 20_001,
+                established: true,
+                last_activity: Instant::now() - CONNECTION_IDLE_TIMEOUT - Duration::from_secs(1),
+            },
+        );
+
+        bridge.drain_host();
+
+        assert_eq!(bridge.take_host_closed(), vec![(conn_id, 20_001)]);
+        assert!(!bridge.is_console_stream(conn_id));
     }
 }

--- a/crates/mvm-runtime/src/vmm/console_bridge.rs
+++ b/crates/mvm-runtime/src/vmm/console_bridge.rs
@@ -255,6 +255,14 @@ impl ConsoleBridge {
         }
     }
 
+    pub fn close_all(&mut self) {
+        let conn_ids: Vec<u32> = self.conns.keys().copied().collect();
+        for conn_id in conn_ids {
+            self.close(conn_id);
+        }
+        self.host_closed.clear();
+    }
+
     fn evict_idle_at(&mut self, now: Instant) {
         let expired: Vec<(u32, u32)> = self
             .conns

--- a/crates/mvm-runtime/src/vmm/vsock.rs
+++ b/crates/mvm-runtime/src/vmm/vsock.rs
@@ -152,6 +152,12 @@ impl VsockShared {
         self.handlers.service_host_io(&mut ctx)
     }
 
+    pub(super) fn cancel(&mut self) {
+        self.handlers.cancel();
+        self.transport.recv_cnt.clear();
+        self.transport.pending_rx.clear();
+    }
+
     pub(super) fn poll_fds(&self) -> Vec<std::os::fd::RawFd> {
         self.handlers.poll_fds()
     }
@@ -260,6 +266,7 @@ impl VirtioVsock {
         if let Some(io) = self.io.take() {
             io.stop();
         }
+        self.lock().cancel();
     }
 
     pub fn received(&self) -> Vec<u8> {
@@ -561,6 +568,31 @@ mod tests {
         d.handle_packet(rw, b"93.184.216.34:80");
         assert!(d.lifecycle.received.is_empty());
         assert!(d.transport.pending_rx.iter().any(|(h, _)| h.op == OP_RST));
+    }
+
+    #[test]
+    fn teardown_cancellation_clears_vsock_state() {
+        let mut d = dev();
+        d.handle_packet(
+            VsockHdr {
+                src_cid: GUEST_CID,
+                dst_cid: HOST_CID,
+                src_port: 2000,
+                dst_port: mvm_agentd::vsock::WORKLOAD_EXIT_PORT,
+                len: 1,
+                op: OP_RW,
+                typ: TYPE_STREAM,
+                ..Default::default()
+            },
+            b"x",
+        );
+        assert!(!d.transport.recv_cnt.is_empty());
+        assert!(!d.transport.pending_rx.is_empty());
+
+        d.cancel();
+
+        assert!(d.transport.recv_cnt.is_empty());
+        assert!(d.transport.pending_rx.is_empty());
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vmm/vsock_handlers/mod.rs
+++ b/crates/mvm-runtime/src/vmm/vsock_handlers/mod.rs
@@ -54,6 +54,14 @@ impl<'a> VsockHandlerContext<'a> {
         self.transport.remove_recv(host_port, guest_port);
     }
 
+    pub(crate) fn evict_idle_recv(&mut self) -> Vec<(u32, u32)> {
+        self.transport
+            .evict_idle_recv()
+            .into_iter()
+            .map(|key| (key.host_port, key.guest_port))
+            .collect()
+    }
+
     pub(crate) fn queue_reply(&mut self, inbound: &VsockHdr, op: u16, payload: &[u8]) {
         self.transport.queue_reply(inbound, op, payload);
     }
@@ -242,6 +250,10 @@ impl VsockHandlerRegistry {
         for handler in self.guest_ports.values_mut() {
             delivered |= handler.drain(ctx).is_some();
         }
+        for (host_port, guest_port) in ctx.evict_idle_recv() {
+            ctx.queue_host_packet(host_port, guest_port, OP_RST, &[]);
+            delivered = true;
+        }
         delivered
     }
 
@@ -385,7 +397,10 @@ impl GuestPortHandler for StreamRelayHandler {
             }
         }
         for conn_id in drained.closed {
-            self.headers.remove(&conn_id);
+            if let Some(hdr) = self.headers.remove(&conn_id) {
+                ctx.remove_recv(hdr.dst_port, hdr.src_port);
+                ctx.queue_reply(&hdr, OP_RST, &[]);
+            }
         }
         if ctx.flush_rx() { Some(0) } else { None }
     }
@@ -464,6 +479,7 @@ impl HostInitiatedHandler for AgentVsockHandler {
         }
         for conn_id in self.bridge.take_host_closed() {
             agent_dbg(&format!("host closed stream {conn_id} → OP_RST to guest"));
+            ctx.remove_recv(conn_id, mvm_agentd::vsock::GUEST_AGENT_PORT);
             ctx.queue_host_packet(conn_id, mvm_agentd::vsock::GUEST_AGENT_PORT, OP_RST, &[]);
         }
         if ctx.flush_rx() { Some(0) } else { None }
@@ -523,6 +539,10 @@ impl HostInitiatedHandler for ConsoleVsockHandler {
         }
         for (conn_id, guest_port, bytes) in self.bridge.drain_host() {
             ctx.queue_host_packet(conn_id, guest_port, OP_RW, &bytes);
+        }
+        for (conn_id, guest_port) in self.bridge.take_host_closed() {
+            ctx.remove_recv(conn_id, guest_port);
+            ctx.queue_host_packet(conn_id, guest_port, OP_RST, &[]);
         }
         if ctx.flush_rx() { Some(0) } else { None }
     }

--- a/crates/mvm-runtime/src/vmm/vsock_handlers/mod.rs
+++ b/crates/mvm-runtime/src/vmm/vsock_handlers/mod.rs
@@ -8,7 +8,9 @@ use std::sync::atomic::AtomicBool;
 
 use super::agent_bridge::AgentBridge;
 use super::console_bridge::ConsoleBridge;
-use super::substitution_bridge::{EndpointRelayAction, GuestEndpointRelay, SubstitutionBridge};
+use super::substitution_bridge::{
+    EgressBudget, EndpointRelayAction, GuestEndpointRelay, SubstitutionBridge,
+};
 use super::vsock_transport::{
     OP_CREDIT_REQUEST, OP_CREDIT_UPDATE, OP_REQUEST, OP_RESPONSE, OP_RST, OP_RW, OP_SHUTDOWN,
     VsockHdr, VsockTransportCore,
@@ -103,6 +105,7 @@ pub(crate) trait GuestPortHandler: Any + Send {
     fn drain(&mut self, _ctx: &mut VsockHandlerContext<'_>) -> Option<u32> {
         None
     }
+    fn cancel(&mut self) {}
     fn poll_fds(&self) -> Vec<RawFd> {
         Vec::new()
     }
@@ -113,6 +116,7 @@ pub(crate) trait HostInitiatedHandler: Any + Send {
     fn accepts_stream(&self, conn_id: u32) -> bool;
     fn on_packet(&mut self, ctx: &mut VsockHandlerContext<'_>, hdr: VsockHdr, payload: &[u8]);
     fn drain(&mut self, ctx: &mut VsockHandlerContext<'_>) -> Option<u32>;
+    fn cancel(&mut self) {}
     fn poll_fds(&self) -> Vec<RawFd> {
         Vec::new()
     }
@@ -130,13 +134,20 @@ impl VsockHandlerRegistry {
             mvm_agentd::vsock::WORKLOAD_EXIT_PORT,
             Box::new(WorkloadExitHandler::new()),
         );
+        let egress_budget = EgressBudget::new();
         guest_ports.insert(
             mvm_agentd::vsock::EGRESS_PORT,
-            Box::new(StreamRelayHandler::new(mvm_agentd::vsock::EGRESS_PORT)),
+            Box::new(StreamRelayHandler::with_budget(
+                mvm_agentd::vsock::EGRESS_PORT,
+                egress_budget.clone(),
+            )),
         );
         guest_ports.insert(
             mvm_agentd::vsock::BROKER_PORT,
-            Box::new(StreamRelayHandler::new(mvm_agentd::vsock::BROKER_PORT)),
+            Box::new(StreamRelayHandler::with_budget(
+                mvm_agentd::vsock::BROKER_PORT,
+                egress_budget,
+            )),
         );
 
         let host_initiated: Vec<Box<dyn HostInitiatedHandler>> = vec![
@@ -257,6 +268,15 @@ impl VsockHandlerRegistry {
         delivered
     }
 
+    pub(crate) fn cancel(&mut self) {
+        for handler in &mut self.host_initiated {
+            handler.cancel();
+        }
+        for handler in self.guest_ports.values_mut() {
+            handler.cancel();
+        }
+    }
+
     pub(crate) fn poll_fds(&self) -> Vec<RawFd> {
         let mut fds = Vec::new();
         for handler in &self.host_initiated {
@@ -338,9 +358,9 @@ struct StreamRelayHandler {
 }
 
 impl StreamRelayHandler {
-    fn new(_guest_port: u32) -> Self {
+    fn with_budget(_guest_port: u32, budget: EgressBudget) -> Self {
         Self {
-            bridge: SubstitutionBridge::new(),
+            bridge: SubstitutionBridge::with_budget(budget),
             headers: HashMap::new(),
         }
     }
@@ -368,6 +388,7 @@ impl GuestPortHandler for StreamRelayHandler {
                         ctx.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]);
                     }
                     EndpointRelayAction::Refused => {
+                        self.bridge.close_connection(hdr.src_port);
                         ctx.remove_recv(hdr.dst_port, hdr.src_port);
                         self.headers.remove(&hdr.src_port);
                         ctx.queue_reply(&hdr, OP_RST, &[]);
@@ -403,6 +424,11 @@ impl GuestPortHandler for StreamRelayHandler {
             }
         }
         if ctx.flush_rx() { Some(0) } else { None }
+    }
+
+    fn cancel(&mut self) {
+        self.bridge.close_all();
+        self.headers.clear();
     }
 
     fn poll_fds(&self) -> Vec<RawFd> {
@@ -485,6 +511,10 @@ impl HostInitiatedHandler for AgentVsockHandler {
         if ctx.flush_rx() { Some(0) } else { None }
     }
 
+    fn cancel(&mut self) {
+        self.bridge.close_all();
+    }
+
     fn poll_fds(&self) -> Vec<RawFd> {
         self.bridge.poll_fds()
     }
@@ -545,6 +575,10 @@ impl HostInitiatedHandler for ConsoleVsockHandler {
             ctx.queue_host_packet(conn_id, guest_port, OP_RST, &[]);
         }
         if ctx.flush_rx() { Some(0) } else { None }
+    }
+
+    fn cancel(&mut self) {
+        self.bridge.close_all();
     }
 
     fn poll_fds(&self) -> Vec<RawFd> {

--- a/crates/mvm-runtime/src/vmm/vsock_transport.rs
+++ b/crates/mvm-runtime/src/vmm/vsock_transport.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
 
 use super::guest_mem::GuestMem;
 
@@ -21,6 +22,7 @@ pub(crate) const HOST_BUF_ALLOC: u32 = 256 * 1024;
 /// device. A guest can choose the source port, so this is a host resource
 /// boundary rather than a protocol limit.
 pub(crate) const MAX_CONNECTIONS: usize = 256;
+pub(crate) const CONNECTION_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub(crate) const OP_REQUEST: u16 = 1;
 pub(crate) const OP_RESPONSE: u16 = 2;
@@ -102,14 +104,19 @@ pub(crate) struct VsockTransportCore {
     pub(crate) queue_sel: u32,
     pub(crate) queues: [Queue; NUM_QUEUES],
     pub(crate) interrupt_status: u32,
-    pub(crate) recv_cnt: HashMap<VsockConnectionKey, u32>,
+    pub(crate) recv_cnt: HashMap<VsockConnectionKey, RecvCredit>,
     pub(crate) pending_rx: VecDeque<(VsockHdr, Vec<u8>)>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct VsockConnectionKey {
-    host_port: u32,
-    guest_port: u32,
+    pub(crate) host_port: u32,
+    pub(crate) guest_port: u32,
+}
+
+pub(crate) struct RecvCredit {
+    bytes: u32,
+    last_activity: Instant,
 }
 
 impl VsockTransportCore {
@@ -196,6 +203,10 @@ impl VsockTransportCore {
     }
 
     pub(crate) fn try_add_recv(&mut self, inbound: &VsockHdr, n: u32) -> bool {
+        self.try_add_recv_at(inbound, n, Instant::now())
+    }
+
+    fn try_add_recv_at(&mut self, inbound: &VsockHdr, n: u32, now: Instant) -> bool {
         let key = VsockConnectionKey {
             host_port: inbound.dst_port,
             guest_port: inbound.src_port,
@@ -203,9 +214,30 @@ impl VsockTransportCore {
         if !self.recv_cnt.contains_key(&key) && self.recv_cnt.len() >= MAX_CONNECTIONS {
             return false;
         }
-        let entry = self.recv_cnt.entry(key).or_default();
-        *entry = entry.saturating_add(n);
+        let entry = self.recv_cnt.entry(key).or_insert(RecvCredit {
+            bytes: 0,
+            last_activity: now,
+        });
+        entry.bytes = entry.bytes.saturating_add(n);
+        entry.last_activity = now;
         true
+    }
+
+    pub(crate) fn evict_idle_recv(&mut self) -> Vec<VsockConnectionKey> {
+        self.evict_idle_recv_at(Instant::now())
+    }
+
+    fn evict_idle_recv_at(&mut self, now: Instant) -> Vec<VsockConnectionKey> {
+        let mut expired = Vec::new();
+        self.recv_cnt.retain(|key, credit| {
+            let keep =
+                now.saturating_duration_since(credit.last_activity) < CONNECTION_IDLE_TIMEOUT;
+            if !keep {
+                expired.push(*key);
+            }
+            keep
+        });
+        expired
     }
 
     pub(crate) fn remove_recv(&mut self, host_port: u32, guest_port: u32) {
@@ -323,7 +355,7 @@ impl VsockTransportCore {
                 host_port,
                 guest_port,
             })
-            .copied()
+            .map(|credit| credit.bytes)
             .unwrap_or(0)
     }
 
@@ -591,5 +623,30 @@ mod tests {
         }
         assert_eq!(core.recv_cnt.len(), MAX_CONNECTIONS);
         assert!(core.try_add_recv(&existing, 1));
+    }
+
+    #[test]
+    fn idle_recv_credit_is_evicted_and_releases_identity() {
+        let mut core = transport();
+        let now = Instant::now();
+        let hdr = VsockHdr {
+            dst_port: 9000,
+            src_port: 7,
+            ..Default::default()
+        };
+        core.try_add_recv_at(
+            &hdr,
+            1,
+            now - CONNECTION_IDLE_TIMEOUT - Duration::from_secs(1),
+        );
+
+        assert_eq!(
+            core.evict_idle_recv_at(now),
+            vec![VsockConnectionKey {
+                host_port: 9000,
+                guest_port: 7,
+            }]
+        );
+        assert!(core.recv_cnt.is_empty());
     }
 }

--- a/crates/mvm-runtime/src/vsock_egress_bridge/substitution_bridge.rs
+++ b/crates/mvm-runtime/src/vsock_egress_bridge/substitution_bridge.rs
@@ -14,6 +14,7 @@ use std::os::fd::{AsRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
@@ -22,6 +23,12 @@ use crate::vmm::vsock_transport::MAX_CONNECTIONS;
 
 /// Per-drain read budget per endpoint connection.
 const READ_CHUNK: usize = 16 * 1024;
+/// Maximum number of active raw/SOCKS5/DNS/substitution streams per workload.
+pub(crate) const MAX_EGRESS_STREAMS: usize = 128;
+/// Sustained egress byte budget shared by all host-mediated workload streams.
+pub(crate) const EGRESS_BYTES_PER_SECOND: u64 = 4 * 1024 * 1024;
+/// Maximum burst accepted before the sustained budget must refill.
+pub(crate) const EGRESS_BURST_BYTES: u64 = 8 * 1024 * 1024;
 
 /// What the device should signal the guest after an inbound endpoint-relay frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -39,6 +46,73 @@ pub(crate) struct EndpointRelayDrain {
     pub ready: Vec<(u32, Vec<u8>)>,
     /// Connection ids that hit EOF / error and were closed.
     pub closed: Vec<u32>,
+}
+
+/// Shared per-workload egress budget. The egress and broker ports use one
+/// instance so a workload cannot multiply its allowance by opening both paths.
+#[derive(Clone)]
+pub(crate) struct EgressBudget {
+    state: Arc<Mutex<EgressBudgetState>>,
+}
+
+struct EgressBudgetState {
+    active_streams: usize,
+    byte_tokens: u64,
+    last_refill: Instant,
+}
+
+impl EgressBudget {
+    pub(crate) fn new() -> Self {
+        Self::new_at(Instant::now())
+    }
+
+    fn new_at(now: Instant) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(EgressBudgetState {
+                active_streams: 0,
+                byte_tokens: EGRESS_BURST_BYTES,
+                last_refill: now,
+            })),
+        }
+    }
+
+    fn try_reserve_stream(&self) -> bool {
+        let mut state = self.state.lock().expect("egress budget mutex poisoned");
+        if state.active_streams >= MAX_EGRESS_STREAMS {
+            return false;
+        }
+        state.active_streams += 1;
+        true
+    }
+
+    fn release_stream(&self) {
+        let mut state = self.state.lock().expect("egress budget mutex poisoned");
+        state.active_streams = state.active_streams.saturating_sub(1);
+    }
+
+    fn try_consume(&self, bytes: usize) -> bool {
+        self.try_consume_at(bytes, Instant::now())
+    }
+
+    fn try_consume_at(&self, bytes: usize, now: Instant) -> bool {
+        let mut state = self.state.lock().expect("egress budget mutex poisoned");
+        let elapsed_nanos = now.saturating_duration_since(state.last_refill).as_nanos();
+        let refill =
+            elapsed_nanos.saturating_mul(u128::from(EGRESS_BYTES_PER_SECOND)) / 1_000_000_000;
+        let refill = u64::try_from(refill).unwrap_or(u64::MAX);
+        state.byte_tokens = state
+            .byte_tokens
+            .saturating_add(refill)
+            .min(EGRESS_BURST_BYTES);
+        state.last_refill = now;
+
+        let bytes = u64::try_from(bytes).unwrap_or(u64::MAX);
+        if bytes > state.byte_tokens {
+            return false;
+        }
+        state.byte_tokens -= bytes;
+        true
+    }
 }
 
 /// Backend-side byte relay between a guest connection id and a per-VM endpoint.
@@ -71,6 +145,7 @@ pub(crate) struct SubstitutionBridge {
     /// Open-connection count, published for the run loop heartbeat so it keeps
     /// waking an idle guest while there's an endpoint reply to deliver.
     active: Option<Arc<AtomicUsize>>,
+    budget: EgressBudget,
 }
 
 struct EndpointConn {
@@ -79,11 +154,17 @@ struct EndpointConn {
 }
 
 impl SubstitutionBridge {
+    #[cfg(test)]
     pub fn new() -> Self {
+        Self::with_budget(EgressBudget::new())
+    }
+
+    pub(crate) fn with_budget(budget: EgressBudget) -> Self {
         Self {
             endpoint: None,
             conns: HashMap::new(),
             active: None,
+            budget,
         }
     }
 
@@ -117,9 +198,17 @@ impl SubstitutionBridge {
             keep
         });
         for _ in &expired {
+            self.budget.release_stream();
             self.bump(-1);
         }
         expired
+    }
+
+    pub(crate) fn close_all(&mut self) {
+        let conn_ids: Vec<u32> = self.conns.keys().copied().collect();
+        for conn_id in conn_ids {
+            self.close_connection(conn_id);
+        }
     }
 }
 
@@ -136,6 +225,9 @@ impl SubstitutionBridge {
 impl GuestEndpointRelay for SubstitutionBridge {
     fn relay_guest_bytes(&mut self, conn_id: u32, payload: &[u8]) -> EndpointRelayAction {
         if let Some(conn) = self.conns.get_mut(&conn_id) {
+            if !self.budget.try_consume(payload.len()) {
+                return EndpointRelayAction::Refused;
+            }
             write_nonblocking(&mut conn.stream, payload);
             conn.last_activity = Instant::now();
             return EndpointRelayAction::Relayed;
@@ -143,12 +235,20 @@ impl GuestEndpointRelay for SubstitutionBridge {
         if self.conns.len() >= MAX_CONNECTIONS {
             return EndpointRelayAction::Refused;
         }
+        if !self.budget.try_reserve_stream() {
+            return EndpointRelayAction::Refused;
+        }
         let Some(path) = self.endpoint.clone() else {
+            self.budget.release_stream();
             return EndpointRelayAction::Refused;
         };
         match UnixStream::connect(&path) {
             Ok(stream) => {
                 let _ = stream.set_nonblocking(true);
+                if !self.budget.try_consume(payload.len()) {
+                    self.budget.release_stream();
+                    return EndpointRelayAction::Refused;
+                }
                 let conn = self.conns.entry(conn_id).or_insert(EndpointConn {
                     stream,
                     last_activity: Instant::now(),
@@ -158,7 +258,10 @@ impl GuestEndpointRelay for SubstitutionBridge {
                 self.bump(1);
                 EndpointRelayAction::Relayed
             }
-            Err(_) => EndpointRelayAction::Refused,
+            Err(_) => {
+                self.budget.release_stream();
+                EndpointRelayAction::Refused
+            }
         }
     }
 
@@ -171,8 +274,12 @@ impl GuestEndpointRelay for SubstitutionBridge {
                 Ok(0) => closed.push(*conn_id),
                 Ok(n) => {
                     buf.truncate(n);
-                    conn.last_activity = Instant::now();
-                    ready.push((*conn_id, buf));
+                    if self.budget.try_consume(n) {
+                        conn.last_activity = Instant::now();
+                        ready.push((*conn_id, buf));
+                    } else {
+                        closed.push(*conn_id);
+                    }
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
                 Err(_) => closed.push(*conn_id),
@@ -186,6 +293,7 @@ impl GuestEndpointRelay for SubstitutionBridge {
 
     fn close_connection(&mut self, conn_id: u32) {
         if self.conns.remove(&conn_id).is_some() {
+            self.budget.release_stream();
             self.bump(-1);
         }
     }
@@ -390,5 +498,54 @@ mod tests {
         assert_eq!(expired, vec![7]);
         assert!(!b.is_active());
         assert_eq!(active.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn egress_budget_caps_concurrency_and_releases_slots() {
+        let budget = EgressBudget::new();
+        for _ in 0..MAX_EGRESS_STREAMS {
+            assert!(budget.try_reserve_stream());
+        }
+        assert!(!budget.try_reserve_stream());
+        budget.release_stream();
+        assert!(budget.try_reserve_stream());
+    }
+
+    #[test]
+    fn egress_budget_refills_bytes_at_a_fixed_rate() {
+        let now = Instant::now();
+        let budget = EgressBudget::new_at(now);
+        assert!(budget.try_consume_at(EGRESS_BURST_BYTES as usize, now));
+        assert!(!budget.try_consume_at(1, now));
+        assert!(budget.try_consume_at(
+            EGRESS_BYTES_PER_SECOND as usize,
+            now + Duration::from_secs(1)
+        ));
+        assert!(!budget.try_consume_at(1, now + Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn close_all_releases_every_endpoint_slot() {
+        let mut bridge = SubstitutionBridge::new();
+        let active = Arc::new(AtomicUsize::new(0));
+        bridge.set_activity(active.clone());
+        for conn_id in 0..3 {
+            let (stream, _peer) = UnixStream::pair().unwrap();
+            bridge.conns.insert(
+                conn_id,
+                EndpointConn {
+                    stream,
+                    last_activity: Instant::now(),
+                },
+            );
+            assert!(bridge.budget.try_reserve_stream());
+            bridge.bump(1);
+        }
+
+        bridge.close_all();
+
+        assert!(!bridge.is_active());
+        assert_eq!(active.load(Ordering::Relaxed), 0);
+        assert!(bridge.budget.try_reserve_stream());
     }
 }

--- a/crates/mvm-runtime/src/vsock_egress_bridge/substitution_bridge.rs
+++ b/crates/mvm-runtime/src/vsock_egress_bridge/substitution_bridge.rs
@@ -15,7 +15,9 @@ use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
 
+use crate::vmm::vsock_transport::CONNECTION_IDLE_TIMEOUT;
 use crate::vmm::vsock_transport::MAX_CONNECTIONS;
 
 /// Per-drain read budget per endpoint connection.
@@ -65,10 +67,15 @@ pub(crate) struct SubstitutionBridge {
     /// Per-VM `mvm-substitution-endpoint` socket. `None` ⇒ no endpoint, fail-closed.
     endpoint: Option<PathBuf>,
     /// Open endpoint connections keyed by the guest vsock `src_port`.
-    conns: HashMap<u32, UnixStream>,
+    conns: HashMap<u32, EndpointConn>,
     /// Open-connection count, published for the run loop heartbeat so it keeps
     /// waking an idle guest while there's an endpoint reply to deliver.
     active: Option<Arc<AtomicUsize>>,
+}
+
+struct EndpointConn {
+    stream: UnixStream,
+    last_activity: Instant,
 }
 
 impl SubstitutionBridge {
@@ -99,19 +106,38 @@ impl SubstitutionBridge {
             }
         }
     }
+
+    fn evict_idle_at(&mut self, now: Instant) -> Vec<u32> {
+        let mut expired = Vec::new();
+        self.conns.retain(|conn_id, conn| {
+            let keep = now.saturating_duration_since(conn.last_activity) < CONNECTION_IDLE_TIMEOUT;
+            if !keep {
+                expired.push(*conn_id);
+            }
+            keep
+        });
+        for _ in &expired {
+            self.bump(-1);
+        }
+        expired
+    }
 }
 
 impl SubstitutionBridge {
     /// Fds the host-I/O thread should watch for endpoint replies.
     pub fn poll_fds(&self) -> Vec<RawFd> {
-        self.conns.values().map(AsRawFd::as_raw_fd).collect()
+        self.conns
+            .values()
+            .map(|conn| conn.stream.as_raw_fd())
+            .collect()
     }
 }
 
 impl GuestEndpointRelay for SubstitutionBridge {
     fn relay_guest_bytes(&mut self, conn_id: u32, payload: &[u8]) -> EndpointRelayAction {
-        if let Some(up) = self.conns.get_mut(&conn_id) {
-            write_nonblocking(up, payload);
+        if let Some(conn) = self.conns.get_mut(&conn_id) {
+            write_nonblocking(&mut conn.stream, payload);
+            conn.last_activity = Instant::now();
             return EndpointRelayAction::Relayed;
         }
         if self.conns.len() >= MAX_CONNECTIONS {
@@ -123,8 +149,12 @@ impl GuestEndpointRelay for SubstitutionBridge {
         match UnixStream::connect(&path) {
             Ok(stream) => {
                 let _ = stream.set_nonblocking(true);
-                let up = self.conns.entry(conn_id).or_insert(stream);
-                write_nonblocking(up, payload);
+                let conn = self.conns.entry(conn_id).or_insert(EndpointConn {
+                    stream,
+                    last_activity: Instant::now(),
+                });
+                write_nonblocking(&mut conn.stream, payload);
+                conn.last_activity = Instant::now();
                 self.bump(1);
                 EndpointRelayAction::Relayed
             }
@@ -134,13 +164,14 @@ impl GuestEndpointRelay for SubstitutionBridge {
 
     fn drain_endpoint_bytes(&mut self) -> EndpointRelayDrain {
         let mut ready = Vec::new();
-        let mut closed = Vec::new();
-        for (conn_id, up) in self.conns.iter_mut() {
+        let mut closed = self.evict_idle_at(Instant::now());
+        for (conn_id, conn) in self.conns.iter_mut() {
             let mut buf = vec![0u8; READ_CHUNK];
-            match up.read(&mut buf) {
+            match conn.stream.read(&mut buf) {
                 Ok(0) => closed.push(*conn_id),
                 Ok(n) => {
                     buf.truncate(n);
+                    conn.last_activity = Instant::now();
                     ready.push((*conn_id, buf));
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
@@ -205,7 +236,13 @@ mod tests {
         let mut peers = Vec::with_capacity(MAX_CONNECTIONS);
         for conn_id in 0..MAX_CONNECTIONS as u32 {
             let (stream, peer) = UnixStream::pair().unwrap();
-            b.conns.insert(conn_id, stream);
+            b.conns.insert(
+                conn_id,
+                EndpointConn {
+                    stream,
+                    last_activity: Instant::now(),
+                },
+            );
             peers.push(peer);
         }
 
@@ -332,5 +369,26 @@ mod tests {
         bridge.close_connection(7);
         assert!(bridge.poll_fds().is_empty());
         server.join().unwrap();
+    }
+
+    #[test]
+    fn idle_endpoint_stream_is_evicted_and_activity_drops() {
+        let mut b = SubstitutionBridge::new();
+        let active = Arc::new(AtomicUsize::new(1));
+        b.set_activity(active.clone());
+        let (stream, _peer) = UnixStream::pair().unwrap();
+        b.conns.insert(
+            7,
+            EndpointConn {
+                stream,
+                last_activity: Instant::now() - CONNECTION_IDLE_TIMEOUT - Duration::from_secs(1),
+            },
+        );
+
+        let expired = b.evict_idle_at(Instant::now());
+
+        assert_eq!(expired, vec![7]);
+        assert!(!b.is_active());
+        assert_eq!(active.load(Ordering::Relaxed), 0);
     }
 }

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -27,8 +27,9 @@
 - [ ] #1827 vsock overload hardening: bound guest-selected connection state and
       host bridge sockets first, then add idle eviction, egress budgets, and
       teardown cancellation. The cap and idle-eviction slices are implemented
-      in the stacked follow-up; egress budgets, teardown cancellation, and
-      optional null-node routing remain. Tracked in
+      in the stacked follow-up; egress budgets are implemented in the next
+      slice; teardown cancellation is implemented and null-node routing was
+      evaluated and deferred with no production-path change. Tracked in
       `specs/plans/266-vsock-overload-hardening.md`.
 
 ---

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -26,7 +26,10 @@
       clippy, and formatting pass; published as PR #1847 for review.
 - [ ] #1827 vsock overload hardening: bound guest-selected connection state and
       host bridge sockets first, then add idle eviction, egress budgets, and
-      teardown cancellation. Tracked in `specs/plans/266-vsock-overload-hardening.md`.
+      teardown cancellation. The cap and idle-eviction slices are implemented
+      in the stacked follow-up; egress budgets, teardown cancellation, and
+      optional null-node routing remain. Tracked in
+      `specs/plans/266-vsock-overload-hardening.md`.
 
 ---
 

--- a/specs/plans/266-vsock-overload-hardening.md
+++ b/specs/plans/266-vsock-overload-hardening.md
@@ -24,12 +24,19 @@ remain NIC-less; the authenticated vsock seam is the primary enforcement point.
       60-second window covers substitution, agent, console, and transport-credit
       state; host-side EOF and idle expiry both remove the credit identity before
       the reset is queued.
-- [ ] Add per-workload concurrent-stream and byte-rate budgets around raw,
+- [x] Add per-workload concurrent-stream and byte-rate budgets around raw,
       SOCKS5, DNS, and substitution egress, preserving kernel backpressure.
-- [ ] Cancel active egress sessions as part of VM teardown and prove that a
+      The egress and broker vsock ports share a 128-stream ceiling, an 8 MiB
+      burst, and a 4 MiB/s token refill; refusal closes the stream fail-closed.
+- [x] Cancel active egress sessions as part of VM teardown and prove that a
       dead workload cannot retain host sockets after its stop path completes.
-- [ ] Evaluate null-node routing for the optional packet gateway path; it is
-      separate from the production NIC-less vsock path.
+      `VirtioVsock::shutdown` now stops the host-I/O thread and explicitly closes
+      agent, console, broker, and egress bridge state before guest RAM is freed.
+- [x] Evaluate null-node routing for the optional packet gateway path; it is
+      separate from the production NIC-less vsock path. No production route is
+      added: the packet-forwarding gateway was removed, rejected vsock streams
+      already reset at the authenticated seam, and a guest-wide default
+      blackhole would also break the admitted loopback egress client.
 - [ ] Run the workspace check, tests, formatting, and Linux-builder clippy
       gates; resolve any failures attributable to this plan.
 
@@ -50,3 +57,28 @@ and sends one `OP_RST` to the guest. The transport credit table runs the same
 idle sweep at the end of host-I/O service, so guest-selected identities cannot
 remain allocated after their bridge state disappears. Tests use injected
 `Instant` values at the timeout boundary rather than wall-clock sleeps.
+
+## Egress budget slice
+
+The egress and broker relays share one budget per workload, so opening both
+authenticated vsock paths cannot multiply the allowance. A stream reserves a
+concurrency slot before the endpoint socket is opened and releases it on EOF,
+reset, or idle expiry. Both relay directions consume the same monotonic token
+bucket; a depleted bucket resets the stream instead of buffering an unbounded
+host-side queue. The existing non-blocking socket relay remains the only writer,
+so the budget limits admission while the kernel retains normal socket
+backpressure.
+
+## Teardown and null-node decision
+
+`VirtioVsock::shutdown` first joins the host-I/O worker and then cancels every
+bridge, releasing connection slots and dropping endpoint sockets. The transport
+credit table and pending receive packets are cleared before the VMM returns;
+the backend stop path separately reaps the per-workload endpoint process.
+
+The requested null-node route belongs to the retired packet-forwarding gateway,
+not to the current production path. Workloads are NIC-less and rejected traffic
+is reset at the authenticated vsock seam; adding a default guest blackhole
+would also blackhole the loopback proxy used by admitted egress. Keep this as a
+future, explicitly admitted packet-gateway feature rather than widening the
+production networking boundary.

--- a/specs/plans/266-vsock-overload-hardening.md
+++ b/specs/plans/266-vsock-overload-hardening.md
@@ -19,8 +19,11 @@ remain NIC-less; the authenticated vsock seam is the primary enforcement point.
 - [x] Bound substitution, host-agent, and dev-console bridge connection sets
       to the same per-device ceiling; refuse before opening another host socket.
 - [x] Add focused cap, slot-reuse, existing-stream, and bridge refusal tests.
-- [ ] Add idle timestamps and deterministic eviction for inactive bridge and
-      credit-table entries, with `OP_RST` cleanup for the guest side.
+- [x] Add idle timestamps and deterministic eviction for inactive bridge and
+      credit-table entries, with `OP_RST` cleanup for the guest side. The fixed
+      60-second window covers substitution, agent, console, and transport-credit
+      state; host-side EOF and idle expiry both remove the credit identity before
+      the reset is queued.
 - [ ] Add per-workload concurrent-stream and byte-rate budgets around raw,
       SOCKS5, DNS, and substitution egress, preserving kernel backpressure.
 - [ ] Cancel active egress sessions as part of VM teardown and prove that a
@@ -38,3 +41,12 @@ resource-exhaustion primitive. The cap is fail-closed: a new identity gets an
 `OP_RST`, an existing identity continues to make progress, and `OP_SHUTDOWN`
 releases the slot. No raw packet forwarding or host NIC is introduced.
 
+## Idle eviction slice
+
+Each tracked stream records monotonic last activity. The host bridges expire
+inactive Unix sockets before accepting more work and surface the closed
+connection to the handler, which removes the matching receive-credit identity
+and sends one `OP_RST` to the guest. The transport credit table runs the same
+idle sweep at the end of host-I/O service, so guest-selected identities cannot
+remain allocated after their bridge state disappears. Tests use injected
+`Instant` values at the timeout boundary rather than wall-clock sleeps.


### PR DESCRIPTION
## What
- evict idle credit, substitution, agent, and console state with guest resets
- share a 128-stream / 8 MiB burst / 4 MiB/s egress budget across egress and broker vsock relays
- cancel bridge and transport state during VirtioVsock teardown
- document why null-node routing is deferred while the production path remains NIC-less vsock

## Why
Dead or unresponsive workloads must not retain host sockets, guest-selected credit identities, or unlimited host-mediated egress state.

## Validation
- `cargo check -p mvm-runtime --all-targets`
- `cargo clippy -p mvm-runtime --all-targets -- -D warnings`
- focused budget, idle-eviction, and teardown tests
- `cargo test -p mvm-runtime --lib`: 1008 passed, 1 pre-existing environment failure because `mvm-substitution-endpoint` is not built in the source checkout

The connection-state cap landed in #1876; this follow-up now targets `main`. 