### PR TITLE
test(mvm-runtime): fuzz virtio-vsock virtqueue geometry + descriptor walk

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -479,6 +479,21 @@ jobs:
         # pinned by a unit test.
         run: cargo fuzz run --fuzz-dir fuzz-backend fuse_dispatch -- -max_total_time="$DURATION"
 
+      - name: Fuzz virtqueue geometry (virtio-vsock ring walk)
+        working-directory: crates/mvm-runtime
+        env:
+          DURATION: ${{ steps.duration.outputs.secs }}
+          RUSTUP_TOOLCHAIN: nightly-2026-06-11
+        # The guest programs the virtio-vsock queue size, ring base addresses, and
+        # descriptor table through untrusted MMIO writes + guest RAM. A hostile
+        # geometry (a QueueNum whose low 16 bits are zero, truncating to a zero
+        # modulus) or a hostile descriptor chain (cyclic next links, oversized
+        # lengths) must not panic the host VMM or drive it into unbounded
+        # allocation — both are guest-triggerable host DoS. This target is the
+        # regression guard for the validated-geometry gate and the bounded
+        # descriptor walk; it stays green once those hold.
+        run: cargo fuzz run --fuzz-dir fuzz-backend fuzz_virtqueue_geometry -- -max_total_time="$DURATION"
+
       - name: Upload corpus on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/crates/mvm-runtime/fuzz-backend/Cargo.lock
+++ b/crates/mvm-runtime/fuzz-backend/Cargo.lock
@@ -10,30 +10,30 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
  "crypto-common",
- "generic-array",
+ "inout",
 ]
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
  "aes",
@@ -136,59 +136,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.13.0",
- "cexpr",
- "clang-sys",
- "itertools",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex 1.3.0",
- "syn",
-]
 
 [[package]]
 name = "bit-vec"
@@ -213,11 +164,11 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -257,16 +208,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 2.0.1",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
+ "shlex",
 ]
 
 [[package]]
@@ -280,17 +222,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "chacha20"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.1",
-]
 
 [[package]]
 name = "chrono"
@@ -308,42 +239,20 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
+ "block-buffer",
  "crypto-common",
  "inout",
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
+name = "cmov"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "colored"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
-dependencies = [
- "windows-sys 0.61.2",
-]
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "combine"
@@ -356,31 +265,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
-dependencies = [
- "encode_unicode",
- "libc",
- "unicode-width",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "const-oid"
-version = "0.9.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -397,6 +285,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -441,50 +335,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
-dependencies = [
- "bitflags 2.13.0",
- "crossterm_winapi",
- "derive_more",
- "document-features",
- "mio",
- "parking_lot",
- "rustix 1.1.4",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "typenum",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -496,8 +372,23 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
  "digest",
- "fiat-crypto",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -521,16 +412,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
 name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,36 +432,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
-]
-
-[[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
@@ -595,21 +455,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,24 +462,21 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0",
  "ed25519",
- "rand_core 0.6.4",
- "serde",
  "sha2",
  "subtle",
  "zeroize",
@@ -645,12 +487,6 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_home"
@@ -697,6 +533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,12 +582,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -797,35 +633,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuzzy-matcher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
-dependencies = [
- "thread_local",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -835,28 +650,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "rand_core 0.10.1",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -885,20 +691,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -939,6 +736,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1136,39 +942,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.18.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
-dependencies = [
- "console",
- "portable-atomic",
- "unicode-width",
- "unit-prefix",
- "web-time",
-]
-
-[[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "inquire"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
-dependencies = [
- "bitflags 2.13.0",
- "crossterm",
- "dyn-clone",
- "fuzzy-matcher",
- "unicode-segmentation",
- "unicode-width",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1178,15 +957,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1320,32 +1090,15 @@ dependencies = [
 
 [[package]]
 name = "libkrun-sys"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
- "bindgen",
  "libc",
  "mvm-core",
  "serde",
  "serde_json",
  "tracing",
- "which 7.0.3",
+ "which",
 ]
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1360,31 +1113,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rs"
@@ -1410,6 +1142,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1440,61 +1181,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "mvm-backend"
-version = "0.17.0"
+name = "mvm-agentd"
+version = "0.18.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
- "colored",
- "ext4-view",
- "indicatif",
- "inquire",
- "kvm-bindings",
- "kvm-ioctls",
+ "base64",
+ "chrono",
+ "ed25519-dalek",
+ "ipnet",
  "libc",
- "libkrun-sys",
- "mio",
- "mvm-build",
  "mvm-core",
- "mvm-guest",
- "mvm-network",
- "mvm-storage",
- "secrecy",
+ "mvm-protocol",
+ "nix",
+ "rand",
+ "seccompiler",
  "serde",
  "serde_json",
  "sha2",
- "tempfile",
- "thiserror 1.0.69",
- "toml",
+ "thiserror 2.0.18",
  "tracing",
- "uuid",
- "which 7.0.3",
-]
-
-[[package]]
-name = "mvm-backend-fuzz"
-version = "0.0.0"
-dependencies = [
- "libfuzzer-sys",
- "mvm-backend",
- "tempfile",
+ "tracing-subscriber",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
 name = "mvm-build"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "chrono",
  "ed25519-dalek",
+ "ext4-view",
  "flate2",
  "fs2",
  "hex",
  "libc",
  "libkrun-sys",
  "lzma-rs",
+ "mvm-agentd",
  "mvm-core",
- "mvm-guest",
- "mvm-network",
+ "mvm-fs",
+ "mvm-net",
  "mvm-sdk",
  "nix",
  "reqwest",
@@ -1504,15 +1233,16 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
  "toml",
  "tracing",
  "uuid",
- "which 6.0.3",
+ "which",
 ]
 
 [[package]]
 name = "mvm-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -1525,7 +1255,8 @@ dependencies = [
  "hmac",
  "ipnet",
  "keyring",
- "rand 0.8.6",
+ "mvm-protocol",
+ "rand",
  "rcgen",
  "regex",
  "secrecy",
@@ -1535,78 +1266,131 @@ dependencies = [
  "sha2",
  "tar",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "unicode-normalization",
  "uuid",
  "zeroize",
 ]
 
 [[package]]
-name = "mvm-guest"
-version = "0.17.0"
+name = "mvm-fs"
+version = "0.18.0"
 dependencies = [
- "anyhow",
- "base64",
- "chrono",
- "ed25519-dalek",
- "ipnet",
+ "async-trait",
+ "ext4-view",
+ "hex",
  "libc",
- "mvm-core",
- "rand 0.8.6",
- "seccompiler",
+ "reqwest",
+ "rustix",
+ "rustls",
+ "secrecy",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
- "tracing",
+ "sha2",
+ "tar",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+ "xattr",
 ]
 
 [[package]]
-name = "mvm-network"
-version = "0.17.0"
+name = "mvm-net"
+version = "0.18.0"
 dependencies = [
  "mvm-core",
- "mvm-sdk",
+ "mvm-protocol",
+]
+
+[[package]]
+name = "mvm-protocol"
+version = "0.18.0"
+dependencies = [
+ "base64",
+ "chrono",
+ "ed25519-dalek",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "mvm-runtime"
+version = "0.18.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "ed25519-dalek",
+ "ext4-view",
+ "fs2",
+ "hex",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "libkrun-sys",
+ "mio",
+ "mvm-agentd",
+ "mvm-build",
+ "mvm-core",
+ "mvm-fs",
+ "mvm-protocol",
+ "nix",
+ "rand",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+ "uuid",
+ "which",
+ "zeroize",
+]
+
+[[package]]
+name = "mvm-runtime-fuzz-backend"
+version = "0.0.0"
+dependencies = [
+ "arbitrary",
+ "libfuzzer-sys",
+ "mvm-runtime",
+ "tempfile",
 ]
 
 [[package]]
 name = "mvm-sdk"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64",
  "flate2",
  "globset",
  "hex",
  "mvm-core",
+ "mvm-protocol",
  "schemars",
  "serde",
  "serde_json",
  "sha2",
  "tar",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "toml",
  "tree-sitter",
  "tree-sitter-javascript",
  "tree-sitter-nix",
  "tree-sitter-python",
  "tree-sitter-typescript",
-]
-
-[[package]]
-name = "mvm-storage"
-version = "0.17.0"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "mvm-core",
- "mvm-sdk",
- "sha2",
- "tempfile",
- "tokio",
- "zeroize",
 ]
 
 [[package]]
@@ -1619,6 +1403,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1690,39 +1475,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "pem"
@@ -1747,38 +1503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpubits",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1805,79 +1538,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1907,17 +1573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
-dependencies = [
- "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,15 +1598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rcgen"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,15 +1609,6 @@ dependencies = [
  "time",
  "x509-parser",
  "yasna",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2024,7 +1661,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2057,12 +1693,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,19 +1712,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.13.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2102,7 +1719,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -2112,8 +1729,8 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
- "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2138,7 +1755,6 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -2175,7 +1791,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2217,6 +1832,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "schemars_derive",
  "serde",
@@ -2234,12 +1850,6 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seccompiler"
@@ -2366,12 +1976,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "digest",
 ]
 
@@ -2386,55 +1996,15 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
@@ -2478,16 +2048,6 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -2559,7 +2119,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -2677,7 +2237,6 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -2943,31 +2502,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
+name = "unicode-normalization"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unit-prefix"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
@@ -3011,12 +2561,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmm-sys-util"
@@ -3119,16 +2663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki-root-certs"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,25 +2673,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "6.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
-dependencies = [
- "either",
- "home",
- "rustix 0.38.44",
- "winsafe",
-]
-
-[[package]]
-name = "which"
 version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix 1.1.4",
+ "rustix",
  "winsafe",
 ]
 
@@ -3262,15 +2784,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3364,6 +2877,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3388,7 +2913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]

--- a/crates/mvm-runtime/fuzz-backend/Cargo.toml
+++ b/crates/mvm-runtime/fuzz-backend/Cargo.toml
@@ -15,6 +15,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 tempfile = "3"
+arbitrary = "1"
 
 [dependencies.mvm-runtime]
 path = ".."
@@ -25,6 +26,18 @@ path = ".."
 [[bin]]
 name = "fuse_dispatch"
 path = "fuzz_targets/fuse_dispatch.rs"
+test = false
+doc = false
+bench = false
+
+# virtio-vsock queue-geometry + descriptor-table hardening guard. Feeds a random
+# RAM image plus a random register-programming sequence into the vsock transport
+# and asserts no panic / no unbounded allocation — the regression guard for the
+# validated queue-geometry gate (hostile `QueueNum` truncating to a zero
+# modulus) and the descriptor-chain bound (cyclic / oversized chains).
+[[bin]]
+name = "fuzz_virtqueue_geometry"
+path = "fuzz_targets/fuzz_virtqueue_geometry.rs"
 test = false
 doc = false
 bench = false

--- a/crates/mvm-runtime/fuzz-backend/fuzz_targets/fuzz_virtqueue_geometry.rs
+++ b/crates/mvm-runtime/fuzz-backend/fuzz_targets/fuzz_virtqueue_geometry.rs
@@ -1,0 +1,217 @@
+// Fuzz the virtio-vsock device's virtqueue geometry + descriptor-table walk.
+//
+// The guest programs queue size, the descriptor/avail/used ring base addresses,
+// and the descriptor table itself through untrusted MMIO writes and guest RAM.
+// A hostile geometry (a `QueueNum` whose low 16 bits are zero, so it is nonzero
+// yet truncates to a zero modulus) or a hostile descriptor chain (cyclic `next`
+// links, oversized lengths) must not panic the host VMM process or drive it into
+// an unbounded allocation — both are guest-triggerable host DoS.
+//
+// This target feeds a random RAM image (the descriptor/avail/used rings live in
+// it) plus a random register-programming sequence into the transport and asserts
+// the run completes with no panic. Termination and bounded allocation are
+// structural: the validated-geometry gate leaves an illegal ring unserviced, and
+// the descriptor walk's live-descriptor budget caps a chain at the (validated,
+// <= 256) queue size regardless of cyclic links. The scratch RAM, avail-index,
+// descriptor count, and payloads are all bounded so no single input can force a
+// large-but-"legal" allocation that would mask the property under test.
+
+#![no_main]
+
+use arbitrary::Unstructured;
+use libfuzzer_sys::fuzz_target;
+use mvm_runtime::vmm::vsock::FuzzTransportDriver;
+
+// Guest RAM image size. Small on purpose: it bounds every read the transport can
+// make (out-of-range reads zero-fill), so the accumulated descriptor-walk buffer
+// stays a small multiple of this even for the most hostile chain.
+const RAM_SIZE: usize = 0x8000;
+const RAM_BASE: u64 = 0;
+
+// Fixed in-RAM layout the harness programs the rings at. Kept within RAM so the
+// transport actually walks the fuzz-authored tables (out-of-RAM bases would just
+// read zeros and service nothing).
+const DESC_OFF: u64 = 0x0000; // 256 descriptors * 16 bytes = 0x1000
+const AVAIL_OFF: u64 = 0x1000;
+const USED_OFF: u64 = 0x1400;
+const BUF_OFF: usize = 0x2000; // remainder: buffers descriptors can point at
+
+// Register offsets in the virtio-mmio window (see `VsockTransportCore::write_register`).
+const R_QUEUE_SEL: u64 = 0x030;
+const R_QUEUE_NUM: u64 = 0x038;
+const R_QUEUE_READY: u64 = 0x044;
+const R_DESC_LO: u64 = 0x080;
+const R_DESC_HI: u64 = 0x084;
+const R_AVAIL_LO: u64 = 0x090;
+const R_AVAIL_HI: u64 = 0x094;
+const R_USED_LO: u64 = 0x0a0;
+const R_USED_HI: u64 = 0x0a4;
+
+const QUEUE_RX: u64 = 0;
+const QUEUE_TX: u64 = 1;
+
+// Bounds that keep any single input's work (and thus allocation) finite while
+// still reaching both the divide-by-zero arms and the descriptor-chain walk.
+const MAX_DESC: usize = 256; // one full descriptor table
+const MAX_AVAIL: usize = 16; // avail-ring entries serviced per notify
+const MAX_PKTS: usize = 32; // pre-queued host->guest packets
+const MAX_PAYLOAD: usize = 512;
+const MAX_REGS: usize = 64; // free-form extra register writes
+
+struct Desc {
+    addr: u64,
+    len: u32,
+    flags: u16,
+    next: u16,
+}
+
+struct HostPkt {
+    src_port: u32,
+    dst_port: u32,
+    op: u16,
+    payload: Vec<u8>,
+}
+
+fuzz_target!(|data: &[u8]| {
+    // A short/empty input just exercises the empty-ring early-outs; that is fine.
+    let _ = drive(Unstructured::new(data));
+});
+
+fn drive(mut u: Unstructured) -> arbitrary::Result<()> {
+    // ---- parse the whole input up front (nothing here touches guest RAM) ----
+    let queue_num: u32 = u.arbitrary()?;
+
+    let ndesc = u.int_in_range(0..=MAX_DESC)?;
+    let mut descs = Vec::with_capacity(ndesc);
+    for _ in 0..ndesc {
+        descs.push(Desc {
+            addr: u.arbitrary()?,
+            len: u.arbitrary()?,
+            flags: u.arbitrary()?,
+            next: u.arbitrary()?,
+        });
+    }
+
+    let navail = u.int_in_range(0..=MAX_AVAIL)?;
+    let mut heads = Vec::with_capacity(navail);
+    for _ in 0..navail {
+        heads.push(u.arbitrary::<u16>()?);
+    }
+
+    let npkt = u.int_in_range(0..=MAX_PKTS)?;
+    let mut pkts = Vec::with_capacity(npkt);
+    for _ in 0..npkt {
+        let src_port = u.arbitrary()?;
+        let dst_port = u.arbitrary()?;
+        let op = u.arbitrary()?;
+        let plen = u.int_in_range(0..=MAX_PAYLOAD.min(u.len()))?;
+        let payload = u.bytes(plen)?.to_vec();
+        pkts.push(HostPkt {
+            src_port,
+            dst_port,
+            op,
+            payload,
+        });
+    }
+
+    let nreg = u.int_in_range(0..=MAX_REGS)?;
+    let mut regs = Vec::with_capacity(nreg);
+    for _ in 0..nreg {
+        regs.push((u.arbitrary::<u16>()?, u.arbitrary::<u64>()?));
+    }
+
+    // Remaining bytes seed the buffer region descriptors can point at.
+    let seed = u.take_rest();
+
+    // ---- lay out guest RAM (must complete before the transport holds the ptr) ----
+    let mut ram = vec![0u8; RAM_SIZE];
+    let seed_len = seed.len().min(RAM_SIZE - BUF_OFF);
+    ram[BUF_OFF..BUF_OFF + seed_len].copy_from_slice(&seed[..seed_len]);
+    write_descriptors(&mut ram, &descs);
+    write_avail_ring(&mut ram, &heads);
+
+    // ---- construct the transport over the laid-out RAM and drive it ----
+    // SAFETY: `ram` is a live, unmoved, writable allocation of `RAM_SIZE` bytes
+    // that outlives `drv`; nothing else aliases it once the driver holds the ptr.
+    let mut drv = unsafe { FuzzTransportDriver::new(ram.as_mut_ptr(), RAM_BASE, RAM_SIZE) };
+
+    for p in &pkts {
+        drv.queue_host_packet(p.src_port, p.dst_port, p.op, &p.payload);
+    }
+
+    // Program both workload queues with the (possibly hostile) geometry so every
+    // run drives `QueueNum` into both the TX (`take_tx_packets`) and RX
+    // (`flush_rx`) service paths, plus the descriptor walk.
+    program_queue(&mut drv, QUEUE_RX, queue_num);
+    program_queue(&mut drv, QUEUE_TX, queue_num);
+
+    // Free-form register writes exercise the rest of the register decode. The
+    // ring-base and queue-size registers are excluded: re-pointing a base out of
+    // the bounded scratch layout could aim the avail index at a large in-RAM
+    // value and drive the (accepted, u16-bounded) per-notify slot count into a
+    // huge allocation that is neither the panic nor the single-chain class this
+    // target guards.
+    for (offset, value) in &regs {
+        let off = u64::from(*offset);
+        if is_ring_geometry_register(off) {
+            continue;
+        }
+        drv.write_register(off, *value);
+    }
+
+    // Service both queues (a notify to queue 1 runs TX then RX).
+    drv.notify(QUEUE_TX as u32);
+    drv.notify(QUEUE_RX as u32);
+
+    // The only host-retained buffer is the pending-RX queue; RX servicing must
+    // drain (never grow) it, so it stays bounded by what we pre-queued.
+    assert!(
+        drv.pending_rx_len() <= pkts.len(),
+        "pending_rx grew during servicing: {} > {}",
+        drv.pending_rx_len(),
+        pkts.len()
+    );
+
+    Ok(())
+}
+
+fn write_descriptors(ram: &mut [u8], descs: &[Desc]) {
+    for (i, d) in descs.iter().take(MAX_DESC).enumerate() {
+        let da = DESC_OFF as usize + i * 16;
+        ram[da..da + 8].copy_from_slice(&d.addr.to_le_bytes());
+        ram[da + 8..da + 12].copy_from_slice(&d.len.to_le_bytes());
+        ram[da + 12..da + 14].copy_from_slice(&d.flags.to_le_bytes());
+        ram[da + 14..da + 16].copy_from_slice(&d.next.to_le_bytes());
+    }
+}
+
+fn write_avail_ring(ram: &mut [u8], heads: &[u16]) {
+    let n = heads.len().min(MAX_AVAIL);
+    let base = AVAIL_OFF as usize;
+    // avail.idx at +2 — set one past the last serviced slot so the drain loop
+    // runs (and, under a hostile size, reaches the modulus).
+    ram[base + 2..base + 4].copy_from_slice(&(n as u16).to_le_bytes());
+    for (i, head) in heads.iter().take(n).enumerate() {
+        let ao = base + 4 + i * 2;
+        ram[ao..ao + 2].copy_from_slice(&head.to_le_bytes());
+    }
+}
+
+fn program_queue(drv: &mut FuzzTransportDriver, sel: u64, queue_num: u32) {
+    drv.write_register(R_QUEUE_SEL, sel);
+    drv.write_register(R_QUEUE_NUM, u64::from(queue_num));
+    drv.write_register(R_DESC_LO, DESC_OFF & 0xffff_ffff);
+    drv.write_register(R_DESC_HI, DESC_OFF >> 32);
+    drv.write_register(R_AVAIL_LO, AVAIL_OFF & 0xffff_ffff);
+    drv.write_register(R_AVAIL_HI, AVAIL_OFF >> 32);
+    drv.write_register(R_USED_LO, USED_OFF & 0xffff_ffff);
+    drv.write_register(R_USED_HI, USED_OFF >> 32);
+    drv.write_register(R_QUEUE_READY, 1);
+}
+
+fn is_ring_geometry_register(offset: u64) -> bool {
+    matches!(
+        offset,
+        R_QUEUE_NUM | R_DESC_LO | R_DESC_HI | R_AVAIL_LO | R_AVAIL_HI | R_USED_LO | R_USED_HI
+    )
+}

--- a/crates/mvm-runtime/src/vmm/vsock.rs
+++ b/crates/mvm-runtime/src/vmm/vsock.rs
@@ -307,6 +307,60 @@ impl Drop for VirtioVsock {
     }
 }
 
+/// Fuzz-only driver over the vsock [`VsockTransportCore`].
+///
+/// Exposes exactly the untrusted-guest entry points — MMIO register programming
+/// and the queue-notify service paths — so a fuzz harness can drive hostile
+/// virtqueue geometry and descriptor tables against the device without a live
+/// hypervisor or the host-I/O handlers. It is not part of the device's supported
+/// API: hidden from docs, and only reachable by the workspace-excluded fuzz
+/// crate. Everything it wraps stays crate-private.
+#[doc(hidden)]
+pub struct FuzzTransportDriver(VsockTransportCore);
+
+#[doc(hidden)]
+impl FuzzTransportDriver {
+    /// # Safety
+    /// `ram` must point to `ram_size` writable bytes mapped at `ram_base` and
+    /// stay valid (unmoved, unfreed) for the lifetime of the returned driver.
+    pub unsafe fn new(ram: *mut u8, ram_base: u64, ram_size: usize) -> Self {
+        // SAFETY: forwarded to the caller's contract.
+        Self(unsafe { VsockTransportCore::new(ram, ram_base, ram_size) })
+    }
+
+    /// Apply one MMIO register write. A write to the queue-notify register drives
+    /// the same TX/RX service dispatch the vCPU MMIO exit path runs.
+    pub fn write_register(&mut self, offset: u64, value: u64) {
+        match self.0.write_register(offset, value) {
+            RegisterWrite::None => {}
+            RegisterWrite::Notify(queue) => self.notify(queue),
+        }
+    }
+
+    /// Drive the queue-notify service paths directly (queue `1` is TX). Mirrors
+    /// the device's on-notify dispatch minus the packet handlers, which are out
+    /// of scope for the queue-geometry / descriptor-table surface.
+    pub fn notify(&mut self, queue: u32) {
+        if queue == 1 {
+            let _ = self.0.take_tx_packets();
+        }
+        let _ = self.0.flush_rx();
+    }
+
+    /// Pre-queue a host→guest packet so the RX flush path has work to service
+    /// (the RX arm of the queue-geometry divide-by-zero only runs with a
+    /// non-empty pending-RX buffer).
+    pub fn queue_host_packet(&mut self, src_port: u32, dst_port: u32, op: u16, payload: &[u8]) {
+        self.0.queue_host_packet(src_port, dst_port, op, payload);
+    }
+
+    /// Number of host→guest packets still queued — the accumulating buffer the
+    /// fuzz target observes to prove RX servicing never grows it without bound.
+    pub fn pending_rx_len(&self) -> usize {
+        self.0.pending_rx.len()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Adds the regression-guard fuzz target called for in the vsock device-hardening plan: it drives hostile virtqueue geometry and descriptor tables into the in-house VMM's virtio-vsock device and asserts no panic / no unbounded allocation. Reproduces the audit's F1 (queue-geometry `%0` panic) and F3 (descriptor amplification) — both already fixed on main, so this lands **green** as the guard against re-introducing them.

- Target `fuzz_virtqueue_geometry` added to the existing (workspace-excluded) `crates/mvm-runtime/fuzz-backend/` crate, alongside `fuse_dispatch`.
- Device reached via a minimal `#[doc(hidden)] pub FuzzTransportDriver` shim in `vmm/vsock.rs` (re-exposes only `write_register`/`notify`/`queue_host_packet`/`pending_rx_len`); everything it wraps stays `pub(crate)`, production API unchanged. RAM/desc-count/payload sizes are capped so no legal-but-large allocation masks the property.
- Wired into `security.yml`'s enumerated `fuzz` job (nightly-2026-06-11, mirrors `fuse_dispatch`).
- Local: `cargo fuzz run … -runs=20000` — no crash, RSS bounded ~447MB. `clippy -p mvm-runtime -D warnings` clean; vsock/vmm tests pass.

Note: the large `fuzz-backend/Cargo.lock` churn is a regeneration of a stale lock (its package name predated the mvm-backend→mvm-runtime consolidation); the fuzz crate is workspace-excluded, so no effect on the default closure budget.