### PR TITLE
ci: pin bare-metal no_std job to the 1.96.0 toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: riscv32imac-unknown-none-elf
 


### PR DESCRIPTION
Fixes a systemic red check across open PRs. The `baremetal-no-std-boundary` job installs `riscv32imac-unknown-none-elf` via `dtolnay/rust-toolchain@stable`, but the repo pins **1.96.0** (#1862), so `cargo build` runs on 1.96.0 — which doesn't have that target — and fails with `error[E0463]: can't find crate for core`. The job (added by #1869 after the pin) used `@stable`, slipping past the pin sweep. One-line align to `@1.96.0`, matching the sibling wasm job. Self-validating: this PR's own bare-metal check runs the fixed job.