### PR TITLE
feat(mvm-runtime): adopt vm-memory behind the GuestMem seam (Slice 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,6 +2993,7 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "uuid",
+ "vm-memory",
  "wasmtime",
  "wasmtime-wasi",
  "which",
@@ -5486,6 +5487,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vm-memory"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b55e753c7725603745cb32b2287ef7ef3da05c03c7702cda3fa8abe25ae0465"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "vmm-sys-util"

--- a/crates/mvm-runtime/Cargo.toml
+++ b/crates/mvm-runtime/Cargo.toml
@@ -88,6 +88,11 @@ tokio = { workspace = true, features = ["fs"] }
 fs2.workspace = true
 # DEK held in `EncryptedStorage` is zeroized on drop.
 zeroize.workspace = true
+# Audited rust-vmm guest-memory primitive behind the in-house VMM's `GuestMem`
+# seam (host-side, std-only). Only `VolatileSlice` — the safe wrapper over the
+# externally-owned HVF/KVM RAM pointer — is used, so the default (mmap-less)
+# feature set is kept; no `GuestMemoryMmap`/`MmapRegion` is pulled in.
+vm-memory = { version = "0.18", default-features = false }
 
 [dev-dependencies]
 mvm-core = { workspace = true, features = ["test-support"] }

--- a/crates/mvm-runtime/src/vmm/guest_mem.rs
+++ b/crates/mvm-runtime/src/vmm/guest_mem.rs
@@ -1,5 +1,19 @@
 //! Bounds-checked guest-physical memory access over the single mapped RAM
 //! region, shared by the virtio devices for virtqueue + buffer DMA.
+//!
+//! Every read/write is gated by the same bounds check and then performed through
+//! `vm-memory`'s [`VolatileSlice`] — the audited safe wrapper over a raw guest
+//! pointer — rather than hand-rolled `ptr::copy_nonoverlapping`. The bounds gate
+//! and the out-of-range semantics (read → zero-fill, write → no-op) are preserved
+//! byte-for-byte, so callers are unaffected.
+//!
+//! `VolatileSlice::new` is used rather than `MmapRegion::build_raw` because the
+//! latter hard-requires a page-aligned pointer, whereas this view also wraps the
+//! `Vec`-backed scratch RAM the device unit tests build; the volatile slice is
+//! `vm-memory`'s raw-pointer access primitive and imposes no alignment
+//! constraint.
+
+use vm_memory::VolatileSlice;
 
 /// A view onto guest RAM mapped at `base .. base+size` via host pointer `ram`.
 #[derive(Clone, Copy)]
@@ -15,6 +29,9 @@ pub(super) struct GuestMem {
 // under the device's `Mutex<VsockShared>`, and the I/O thread is joined before the
 // RAM is unmapped/freed (`VirtioVsock::shutdown` runs before `dealloc`). So the
 // pointer is only ever dereferenced by one thread at a time and never dangles.
+// This is the same externally-owned-mapping invariant `vm-memory` itself relies on
+// for `MmapRegion`'s `unsafe impl Send`; routing accesses through `VolatileSlice`
+// does not weaken it.
 unsafe impl Send for GuestMem {}
 
 impl GuestMem {
@@ -25,8 +42,9 @@ impl GuestMem {
         Self { ram, base, size }
     }
 
-    /// Host pointer for a guest-physical range, bounds-checked against RAM.
-    pub(super) fn host(&self, gpa: u64, len: usize) -> Option<*mut u8> {
+    /// Byte offset of `[gpa, gpa+len)` within the mapping, or `None` when the
+    /// range starts below `base`, runs past `size`, or `gpa + len` overflows.
+    fn offset(&self, gpa: u64, len: usize) -> Option<usize> {
         if gpa < self.base {
             return None;
         }
@@ -34,15 +52,32 @@ impl GuestMem {
         if off.checked_add(len)? > self.size {
             return None;
         }
-        // SAFETY: offset + len are within the mapped region by the checks above.
-        Some(unsafe { self.ram.add(off) })
+        Some(off)
+    }
+
+    /// Host pointer for a guest-physical range, bounds-checked against RAM.
+    pub(super) fn host(&self, gpa: u64, len: usize) -> Option<*mut u8> {
+        // SAFETY: `off + len` are within the mapped region by `offset`'s checks.
+        self.offset(gpa, len)
+            .map(|off| unsafe { self.ram.add(off) })
+    }
+
+    /// A [`VolatileSlice`] over an in-range `[gpa, gpa+len)`, or `None` when the
+    /// range is out of bounds. Callers copy through the slice, so an out-of-range
+    /// access yields no copy — reproducing the zero-fill/no-op semantics.
+    fn slice(&self, gpa: u64, len: usize) -> Option<VolatileSlice<'_>> {
+        let ptr = self.host(gpa, len)?;
+        // SAFETY: `ptr` is valid for `len` bytes (bounds-checked by `host`) and
+        // lives as long as the mapping. Every guest-RAM access in this module goes
+        // through a `VolatileSlice`, honouring the volatile-only-access contract.
+        Some(unsafe { VolatileSlice::new(ptr, len) })
     }
 
     fn rd<const N: usize>(&self, gpa: u64) -> [u8; N] {
         let mut b = [0u8; N];
-        if let Some(p) = self.host(gpa, N) {
-            // SAFETY: `p` is valid for N bytes.
-            unsafe { core::ptr::copy_nonoverlapping(p, b.as_mut_ptr(), N) };
+        if let Some(vs) = self.slice(gpa, N) {
+            // In range: copy all N bytes out. Out of range: `b` stays zero-filled.
+            vs.copy_to(&mut b);
         }
         b
     }
@@ -58,24 +93,21 @@ impl GuestMem {
     }
 
     pub(super) fn wr_u8(&self, gpa: u64, v: u8) {
-        if let Some(p) = self.host(gpa, 1) {
-            // SAFETY: `p` valid for 1 byte.
-            unsafe { *p = v };
+        if let Some(vs) = self.slice(gpa, 1) {
+            vs.copy_from(&[v]);
         }
     }
     pub(super) fn wr_u16(&self, gpa: u64, v: u16) {
-        if let Some(p) = self.host(gpa, 2) {
-            // SAFETY: `p` valid for 2 bytes.
-            unsafe { core::ptr::copy_nonoverlapping(v.to_le_bytes().as_ptr(), p, 2) };
+        if let Some(vs) = self.slice(gpa, 2) {
+            vs.copy_from(&v.to_le_bytes());
         }
     }
 
     /// Copy `bytes` into guest memory at `gpa` (truncated to what fits).
     pub(super) fn write_bytes(&self, gpa: u64, bytes: &[u8]) -> usize {
-        match self.host(gpa, bytes.len()) {
-            Some(p) => {
-                // SAFETY: `p` valid for bytes.len().
-                unsafe { core::ptr::copy_nonoverlapping(bytes.as_ptr(), p, bytes.len()) };
+        match self.slice(gpa, bytes.len()) {
+            Some(vs) => {
+                vs.copy_from(bytes);
                 bytes.len()
             }
             None => 0,
@@ -84,14 +116,210 @@ impl GuestMem {
 
     /// Read `len` bytes from guest memory at `gpa`.
     pub(super) fn read_bytes(&self, gpa: u64, len: usize) -> Vec<u8> {
-        match self.host(gpa, len) {
-            Some(p) => {
+        match self.slice(gpa, len) {
+            Some(vs) => {
                 let mut v = vec![0u8; len];
-                // SAFETY: `p` valid for len.
-                unsafe { core::ptr::copy_nonoverlapping(p, v.as_mut_ptr(), len) };
+                vs.copy_to(&mut v);
                 v
             }
             None => Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GuestMem;
+
+    const BASE: u64 = 0x4000_0000;
+    const SIZE: usize = 256;
+
+    /// Independent reference model of the documented `GuestMem` semantics: an
+    /// in-range `[gpa, gpa+len)` reads/writes the exact bytes; any range starting
+    /// below `base`, running past `size`, or whose `gpa + len` overflows reads as
+    /// zero and writes as a no-op.
+    struct RefMem {
+        data: Vec<u8>,
+        base: u64,
+    }
+
+    impl RefMem {
+        fn offset(&self, gpa: u64, len: usize) -> Option<usize> {
+            if gpa < self.base {
+                return None;
+            }
+            let off = (gpa - self.base) as usize;
+            if off.checked_add(len)? > self.data.len() {
+                return None;
+            }
+            Some(off)
+        }
+
+        fn read_bytes(&self, gpa: u64, len: usize) -> Vec<u8> {
+            match self.offset(gpa, len) {
+                Some(off) => self.data[off..off + len].to_vec(),
+                None => Vec::new(),
+            }
+        }
+
+        fn rd<const N: usize>(&self, gpa: u64) -> [u8; N] {
+            let mut b = [0u8; N];
+            if let Some(off) = self.offset(gpa, N) {
+                b.copy_from_slice(&self.data[off..off + N]);
+            }
+            b
+        }
+
+        fn write_bytes(&mut self, gpa: u64, bytes: &[u8]) -> usize {
+            match self.offset(gpa, bytes.len()) {
+                Some(off) => {
+                    self.data[off..off + bytes.len()].copy_from_slice(bytes);
+                    bytes.len()
+                }
+                None => 0,
+            }
+        }
+    }
+
+    /// The `(gpa, len)` matrix: below-base, in-range, straddling the end, exactly
+    /// at the boundary, fully out-of-range, zero-length, and `gpa + len` overflow.
+    fn cases() -> Vec<(u64, usize)> {
+        let lens = [0usize, 1, 2, 4, 8, 16, 255, 256, 300];
+        let gpas = [
+            0,                      // far below base
+            BASE - 2,               // just below base
+            BASE - 1,               // one below base
+            BASE,                   // start of RAM
+            BASE + 1,               // in range
+            BASE + 100,             // mid range
+            BASE + 248,             // near end, straddles for len >= 8
+            BASE + 254,             // straddles for len >= 2
+            BASE + 255,             // last byte
+            BASE + SIZE as u64,     // one past end (boundary)
+            BASE + SIZE as u64 + 8, // fully out of range
+            u64::MAX - 4,           // gpa + len overflows for len > 4
+            u64::MAX,               // gpa + len overflows for any len > 0
+        ];
+        let mut out = Vec::new();
+        for &g in &gpas {
+            for &l in &lens {
+                out.push((g, l));
+            }
+        }
+        out
+    }
+
+    fn pattern(size: usize) -> Vec<u8> {
+        // Deterministic, non-trivial content so little-endian reads are meaningful.
+        (0..size)
+            .map(|i| (i as u8).wrapping_mul(7).wrapping_add(3))
+            .collect()
+    }
+
+    #[test]
+    fn reads_match_documented_semantics() {
+        let mut ram = pattern(SIZE);
+        let reference = RefMem {
+            data: ram.clone(),
+            base: BASE,
+        };
+        // SAFETY: `ram` is `SIZE` bytes and outlives `gm` within this test.
+        let gm = unsafe { GuestMem::new(ram.as_mut_ptr(), BASE, SIZE) };
+
+        for (gpa, len) in cases() {
+            assert_eq!(
+                gm.read_bytes(gpa, len),
+                reference.read_bytes(gpa, len),
+                "read_bytes mismatch at gpa={gpa:#x} len={len}"
+            );
+            assert_eq!(
+                gm.rd_u16(gpa),
+                u16::from_le_bytes(reference.rd(gpa)),
+                "rd_u16 mismatch at gpa={gpa:#x}"
+            );
+            assert_eq!(
+                gm.rd_u32(gpa),
+                u32::from_le_bytes(reference.rd(gpa)),
+                "rd_u32 mismatch at gpa={gpa:#x}"
+            );
+            assert_eq!(
+                gm.rd_u64(gpa),
+                u64::from_le_bytes(reference.rd(gpa)),
+                "rd_u64 mismatch at gpa={gpa:#x}"
+            );
+        }
+    }
+
+    #[test]
+    fn writes_match_documented_semantics() {
+        // Each write case runs against a fresh zeroed buffer + mirror so an
+        // out-of-range write leaves both untouched and an in-range write lands
+        // byte-identically, then the whole buffer is compared to the mirror.
+        for (gpa, len) in cases() {
+            let payload: Vec<u8> = (0..len).map(|i| (i as u8) ^ 0xA5).collect();
+
+            let mut ram = vec![0u8; SIZE];
+            let mut reference = RefMem {
+                data: vec![0u8; SIZE],
+                base: BASE,
+            };
+            // SAFETY: `ram` is `SIZE` bytes and outlives `gm` within this loop body.
+            let gm = unsafe { GuestMem::new(ram.as_mut_ptr(), BASE, SIZE) };
+
+            let got = gm.write_bytes(gpa, &payload);
+            let want = reference.write_bytes(gpa, &payload);
+            assert_eq!(
+                got, want,
+                "write_bytes return mismatch at gpa={gpa:#x} len={len}"
+            );
+            assert_eq!(
+                ram, reference.data,
+                "RAM diverged after write at gpa={gpa:#x} len={len}"
+            );
+        }
+
+        // wr_u8 / wr_u16 against the boundary and overflow cases.
+        for &(gpa, _) in &cases() {
+            let mut ram = vec![0u8; SIZE];
+            let mut reference = RefMem {
+                data: vec![0u8; SIZE],
+                base: BASE,
+            };
+            // SAFETY: `ram` is `SIZE` bytes and outlives `gm` within this loop body.
+            let gm = unsafe { GuestMem::new(ram.as_mut_ptr(), BASE, SIZE) };
+
+            gm.wr_u8(gpa, 0x5C);
+            reference.write_bytes(gpa, &[0x5C]);
+            assert_eq!(ram, reference.data, "wr_u8 diverged at gpa={gpa:#x}");
+
+            let mut ram2 = vec![0u8; SIZE];
+            let mut reference2 = RefMem {
+                data: vec![0u8; SIZE],
+                base: BASE,
+            };
+            // SAFETY: `ram2` is `SIZE` bytes and outlives `gm2` within this loop body.
+            let gm2 = unsafe { GuestMem::new(ram2.as_mut_ptr(), BASE, SIZE) };
+            gm2.wr_u16(gpa, 0xBEEF);
+            reference2.write_bytes(gpa, &0xBEEFu16.to_le_bytes());
+            assert_eq!(ram2, reference2.data, "wr_u16 diverged at gpa={gpa:#x}");
+        }
+    }
+
+    #[test]
+    fn host_pointer_bounds_match_offset_check() {
+        let mut ram = pattern(SIZE);
+        // SAFETY: `ram` is `SIZE` bytes and outlives `gm` within this test.
+        let gm = unsafe { GuestMem::new(ram.as_mut_ptr(), BASE, SIZE) };
+        for (gpa, len) in cases() {
+            let in_range = gm.host(gpa, len).is_some();
+            let expected = gpa >= BASE
+                && ((gpa - BASE) as usize)
+                    .checked_add(len)
+                    .is_some_and(|end| end <= SIZE);
+            assert_eq!(
+                in_range, expected,
+                "host() bounds mismatch at gpa={gpa:#x} len={len}"
+            );
         }
     }
 }

--- a/specs/adrs/033-rust-vmm-virtio-primitives.md
+++ b/specs/adrs/033-rust-vmm-virtio-primitives.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-Proposed. This ADR is the gate: it records the decision to adopt three
+Accepted. This ADR is the gate: it records the decision to adopt three
 rust-vmm crates on the host VMM path and the supply-chain sign-off that
-adoption requires. No code and no dependency lands until it is accepted.
+adoption requires. Acceptance landed with Slice 2 (`vm-memory` behind the
+`GuestMem` seam); the remaining slices adopt `virtio-queue` and
+`virtio-vsock` on the same terms.
 The staged implementation lives in
 `specs/notes/2026-07-27-vsock-device-hardening-plan.md`; the audit that
 motivates it in `specs/notes/2026-07-27-vsock-device-audit-findings.md`.

--- a/specs/notes/2026-07-27-vsock-device-hardening-plan.md
+++ b/specs/notes/2026-07-27-vsock-device-hardening-plan.md
@@ -30,9 +30,11 @@ All three are rust-vmm crates under the `rust-vmm/vm-virtio` and
   equivalent of the in-repo `GuestMem`. It can wrap an externally-owned mapping
   via `MmapRegion`'s raw-pointer constructor, which is required here because the
   RAM pointer is owned by the HVF/KVM mapping, not allocated by vm-memory.
-- **`virtio-vsock` 0.11.0** — `VsockPacket`, parsed from a TX/RX descriptor chain
+- **`virtio-vsock` 0.12.0** — `VsockPacket`, parsed from a TX/RX descriptor chain
   (stream sockets only), header + optional data represented as `VolatileSlice`s.
   Replaces the hand-rolled 44-byte `VsockHdr::from_bytes/to_bytes` and `HDR_LEN`.
+  Tracks the 0.18 `vm-memory`/`virtio-queue` line (ADR-033 realigned the note's
+  original 0.11 pin, which pulled duplicate `vm-memory`/`virtio-queue` majors).
 
 **Oracle, not a dependency:** a sibling in-house virtio-vsock reference
 implementation (the "arcbox" oracle named in the tasking) is used only to
@@ -213,5 +215,5 @@ follow the same TX/RX queue migration once the vsock path proves the pattern.
   — `ttl` + `next_index >= queue_size` guard.
 - [vm-memory on docs.rs](https://docs.rs/crate/vm-memory/latest) — 0.18.0.
 - [virtio-vsock on crates.io](https://crates.io/crates/virtio-vsock) /
-  [docs.rs](https://docs.rs/virtio-vsock) — 0.11.0 (`VsockPacket`).
+  [docs.rs](https://docs.rs/virtio-vsock) — 0.12.0 (`VsockPacket`).
 - [rust-vmm/vm-virtio](https://github.com/rust-vmm/vm-virtio).

--- a/xtask/src/check_closure_budget.rs
+++ b/xtask/src/check_closure_budget.rs
@@ -46,7 +46,13 @@ const BUDGET_TARGET: &str = "x86_64-unknown-linux-gnu";
 /// deleting the hand-rolled `sockaddr_vm` + raw-`libc`
 /// socket/connect/bind/listen/accept boilerplate — nix exposes no AF_VSOCK API
 /// without the `socket` feature. Lower it freely as deps drop.
-const CLOSURE_BUDGET: usize = 267;
+///
+/// 268 (was 267): adopting the audited `vm-memory` crate behind the in-house
+/// VMM's `GuestMem` seam (the accepted rust-vmm primitives migration). Only
+/// `vm-memory` itself is new on the default closure — its `libc`/`thiserror`
+/// tree is already present — so the measured delta is +1. Lower it freely as
+/// deps drop.
+const CLOSURE_BUDGET: usize = 268;
 
 pub fn run(workspace: &Path) -> Result<()> {
     let count = default_closure_crate_count(workspace)?;


### PR DESCRIPTION
First slice of the accepted rust-vmm migration (ADR-033). **Behavior-preserving.**

Routes the in-house VMM's guest-memory access through `vm_memory::VolatileSlice` (the audited safe wrapper over a raw guest pointer) instead of hand-rolled `ptr::copy_nonoverlapping`. `GuestMem` keeps its `(*mut u8, base, size)` fields (stays `Copy`, `host()` byte-identical for the block-DMA path); the bounds check moves into one `offset()` helper, and a `slice()→Option<VolatileSlice>` returns `None` out-of-range so the zero-fill (reads) / no-op (writes) semantics are preserved structurally.

- **Equivalence test** (the acceptance bar): a `RefMem` reference model over a `(gpa,len)` matrix — below/at base, mid, straddling the end, one-past, fully out-of-range, and overflow — cross `len ∈ {0,1,2,4,8,16,255,256,300}`; asserts identical reads/writes/host-pointer results.
- **Closure:** 267 → **268** (+1, only `vm-memory 0.18.0`; its `libc`/`thiserror` already present). Budget bumped with justification. `default-features = false` (no `backend-mmap` needed).
- **ADR-033 → Accepted**; plan note `virtio-vsock 0.11`→`0.12`.
- Gates green (rustup 1.96): fmt, `clippy --workspace -D warnings`, `nextest -p mvm-runtime` 1010 pass, closure-budget 268, `check-vsock-only-egress`, `check-no-spec-refs`, zigbuild aarch64-musl.

**Two notes for review:** (1) Used `VolatileSlice::new` not `MmapRegion::build_raw` — the latter requires page-aligned pointers, incompatible with the `Vec`-backed test harnesses; Slice 3 will construct the real `GuestMemoryMmap` (enabling `backend-mmap`) from the production page-aligned RAM. (2) `cargo deny check` reports a **pre-existing** bans failure (`cpufeatures`/`curve25519-dalek`/`fiat-crypto` duplicates, reproduces on main with these deps stashed); vm-memory pulls none of them and needs no `deny.toml` change.