### PR TITLE
docs: close vsock overload hardening track

### DIFF
--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -24,12 +24,11 @@
       workload)` so hot plan revisions replace prior rules without orphaning
       firewalls. Focused regression coverage, workspace check, full tests,
       clippy, and formatting pass; published as PR #1847 for review.
-- [ ] #1827 vsock overload hardening: bound guest-selected connection state and
-      host bridge sockets first, then add idle eviction, egress budgets, and
-      teardown cancellation. The cap and idle-eviction slices are implemented
-      in the stacked follow-up; egress budgets are implemented in the next
-      slice; teardown cancellation is implemented and null-node routing was
-      evaluated and deferred with no production-path change. Tracked in
+- [x] #1827 vsock overload hardening is complete: guest-selected connection
+      state and host bridge sockets are capped; idle eviction, shared egress
+      budgets, and teardown cancellation are implemented. Null-node routing was
+      evaluated and deferred with no production-path change. Delivered through
+      #1876 and #1878; tracked in
       `specs/plans/266-vsock-overload-hardening.md`.
 
 ---

--- a/specs/plans/266-vsock-overload-hardening.md
+++ b/specs/plans/266-vsock-overload-hardening.md
@@ -2,7 +2,7 @@
 
 Issue: #1827
 
-Status: IN PROGRESS
+Status: COMPLETE
 
 ## Goal
 
@@ -37,8 +37,10 @@ remain NIC-less; the authenticated vsock seam is the primary enforcement point.
       added: the packet-forwarding gateway was removed, rejected vsock streams
       already reset at the authenticated seam, and a guest-wide default
       blackhole would also break the admitted loopback egress client.
-- [ ] Run the workspace check, tests, formatting, and Linux-builder clippy
-      gates; resolve any failures attributable to this plan.
+- [x] Run the workspace check, tests, formatting, and Linux-builder clippy
+      gates; the required GitHub CI gates passed on #1878. The one local full
+      runtime-test failure was environment-only: the `mvm-substitution-endpoint`
+      helper is not built in the source checkout.
 
 ## First slice
 


### PR DESCRIPTION
## Summary
- mark Plan 266 complete after the cap and follow-up PRs merged
- update the sprint rollup with the delivered safeguards and deferred null-node decision
- record the required CI gate result and the known local helper-environment limitation

Closes the documentation follow-up for #1827; the issue itself is being closed separately as implemented/deferred.