### PR TITLE
refactor(mvm-runtime): put the fork load behind SnapshotIO so the guard is testable

### DIFF
--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -127,6 +127,15 @@ pub trait SnapshotIO {
     /// [`resume`](Self::resume).
     fn load_snapshot_paused(&self, dir: &Path) -> Result<()>;
 
+    /// Load a forked child's snapshot, leaving vCPUs PAUSED.
+    ///
+    /// Same contract as
+    /// [`load_snapshot_paused`](Self::load_snapshot_paused) — the guard still
+    /// has to run before [`resume`](Self::resume) — but the child's device
+    /// paths are already bind-mounted into its private mount namespace, so
+    /// this variant must not re-create the host vsock socket underneath them.
+    fn load_snapshot_for_fork_paused(&self, dir: &Path) -> Result<()>;
+
     /// The restored VM's device model, read after load, before
     /// resume — the input to `assert_vsock_only_device_model`.
     fn restored_device_model(&self) -> Result<crate::microvm::RestoredDeviceModel>;
@@ -292,9 +301,9 @@ pub fn guarded_load_resume<IO: SnapshotIO + ?Sized>(io: &IO, dir: &Path) -> Resu
 /// way a plain instance restore does. Only the load differs — the guard and the
 /// resume are the same, so a fork cannot reach userspace unchecked or stay
 /// paused forever.
-pub(crate) fn guarded_fork_load_resume(io: &FirecrackerIO, dir: &Path) -> Result<()> {
-    io.load_snapshot_for_fork(dir)
-        .with_context(|| format!("load_snapshot_for_fork({})", dir.display()))?;
+pub(crate) fn guarded_fork_load_resume<IO: SnapshotIO + ?Sized>(io: &IO, dir: &Path) -> Result<()> {
+    io.load_snapshot_for_fork_paused(dir)
+        .with_context(|| format!("load_snapshot_for_fork_paused({})", dir.display()))?;
     guard_and_resume(io)
 }
 
@@ -784,6 +793,9 @@ impl SnapshotIO for CannedIO {
     fn load_snapshot_paused(&self, _dir: &Path) -> Result<()> {
         Ok(())
     }
+    fn load_snapshot_for_fork_paused(&self, _dir: &Path) -> Result<()> {
+        Ok(())
+    }
     fn restored_device_model(&self) -> Result<crate::microvm::RestoredDeviceModel> {
         Ok(crate::microvm::RestoredDeviceModel {
             network_interfaces: Vec::new(),
@@ -823,12 +835,6 @@ impl FirecrackerIO {
             );
         }
         Ok(())
-    }
-
-    /// Load a forked snapshot after its recorded device paths have been
-    /// remapped in the child's private mount namespace.
-    pub(crate) fn load_snapshot_for_fork(&self, dir: &Path) -> Result<()> {
-        self.load_snapshot_inner(dir, false)
     }
 
     /// Load a sealed snapshot into a fresh VMM, leaving vCPUs paused.
@@ -904,6 +910,10 @@ impl SnapshotIO for FirecrackerIO {
 
     fn load_snapshot_paused(&self, dir: &Path) -> Result<()> {
         self.load_snapshot_inner(dir, true)
+    }
+
+    fn load_snapshot_for_fork_paused(&self, dir: &Path) -> Result<()> {
+        self.load_snapshot_inner(dir, false)
     }
 
     fn restored_device_model(&self) -> Result<crate::microvm::RestoredDeviceModel> {
@@ -1158,6 +1168,10 @@ mod tests {
             self.calls.borrow_mut().push("load_paused");
             Ok(())
         }
+        fn load_snapshot_for_fork_paused(&self, _dir: &Path) -> Result<()> {
+            self.calls.borrow_mut().push("load_fork_paused");
+            Ok(())
+        }
         fn restored_device_model(&self) -> Result<crate::microvm::RestoredDeviceModel> {
             self.calls.borrow_mut().push("restored_device_model");
             let network_interfaces = if self.nic_on_restore {
@@ -1260,6 +1274,42 @@ mod tests {
             calls,
             vec!["load_paused", "restored_device_model", "resume"],
             "load, guard, then resume — in order"
+        );
+    }
+
+    /// A fork inherits its parent's device model, so it gets the same guard.
+    /// The fork load is the one that preserves the child's already-remapped
+    /// vsock path, which is why it is a distinct call from `load_paused`.
+    #[test]
+    fn guarded_fork_load_resume_resumes_when_vsock_only() {
+        let spy = SpyIO::new(false);
+        let dir = tempfile::tempdir().unwrap();
+        guarded_fork_load_resume(&spy, dir.path()).expect("a no-NIC fork must resume");
+        let calls = spy.calls();
+        assert_eq!(
+            calls,
+            vec!["load_fork_paused", "restored_device_model", "resume"],
+            "fork load, guard, then resume — in order"
+        );
+    }
+
+    /// The regression this guards: a fork that loads paused and is never
+    /// checked would either sit paused forever or, once resumed, reach
+    /// userspace carrying an unaudited NIC.
+    #[test]
+    fn guarded_fork_load_resume_refuses_nic_on_restore() {
+        let spy = SpyIO::new(true);
+        let dir = tempfile::tempdir().unwrap();
+        let err = guarded_fork_load_resume(&spy, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("device-model guard"), "got: {err}");
+        let calls = spy.calls();
+        assert!(
+            calls.contains(&"teardown_paused"),
+            "a refused fork must tear down the paused VMM: {calls:?}"
+        );
+        assert!(
+            !calls.contains(&"resume"),
+            "resume must never run when the guard refuses a fork: {calls:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to the FC fork-restore guard fix that landed with #1874.

`guarded_fork_load_resume` took a concrete `FirecrackerIO`, so the one property
worth asserting — that the fork path actually reaches the no-NIC device-model
guard — could not be exercised with a test double. Only the guard's internals
were covered; the wiring into it was not. That gap is precisely how the fork
path was able to skip the guard silently in the first place.

## What changed

- `load_snapshot_for_fork_paused` moves onto the `SnapshotIO` trait, beside
  `load_snapshot_paused` and under the same contract: load, leave vCPUs paused,
  let the caller run the guard before resuming.
- `FirecrackerIO` implements it as the `clean_vsock=false` load. That is the
  whole reason the fork variant exists — the child's device paths are already
  bind-mounted into its private mount namespace, so re-creating the host vsock
  socket underneath them breaks the fork.
- `guarded_fork_load_resume` is now generic over `SnapshotIO`, and the inherent
  `FirecrackerIO::load_snapshot_for_fork` is gone. There is exactly one way to
  load a fork and it goes through the guard.

## Tests

Two new `SpyIO` tests covering the previously untestable wiring:

- `guarded_fork_load_resume_resumes_when_vsock_only` — asserts the call order
  `load_fork_paused` → `restored_device_model` → `resume`.
- `guarded_fork_load_resume_refuses_nic_on_restore` — a fork whose restored
  device model carries a NIC is refused, torn down, and never resumed. This is
  the test that would have caught the original bug.

## Validation

- `cargo test -p mvm-runtime --lib -- --test-threads=1` — 1,062 passed, 4 ignored.
- `cargo check --workspace --all-targets` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo +nightly fmt --all -- --check` — clean.
