### PR TITLE
fix(bundle): carry the guest sidecar so exported bundles can boot

### DIFF
--- a/crates/mvm-cli/src/commands/bundle/export.rs
+++ b/crates/mvm-cli/src/commands/bundle/export.rs
@@ -143,6 +143,25 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         (None, None) => None,
     };
 
+    // The runtime refuses to boot a rootfs whose `mvm-meta.json` sidecar is
+    // missing, so a bundle exported without it is unbootable on arrival —
+    // `bundle install` succeeds and the failure only surfaces at admission on
+    // the target host. Carry it, and fail here if the template hasn't got one.
+    let sidecar_src = sidecar_path_for_rootfs(&rootfs)?;
+    let sidecar_bytes = std::fs::read(&sidecar_src).with_context(|| {
+        format!(
+            "reading guest sidecar at {} — rebuild the template before exporting",
+            sidecar_src.display()
+        )
+    })?;
+    push(
+        &mut artifacts,
+        &mut payload,
+        mvm_build::builder_vm::SIDECAR_FILENAME,
+        ArtifactRole::Other,
+        sidecar_bytes,
+    );
+
     // Bake the template's declared resources into the bundle so
     // `mvmctl up <bundle-sha>` on another host gets sensible
     // defaults without re-discovering them. CLI `--cpus` /
@@ -188,4 +207,31 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     );
 
     Ok(())
+}
+
+/// The guest sidecar the runtime admission gate looks for sits beside the
+/// rootfs image the template resolved to.
+fn sidecar_path_for_rootfs(rootfs: &str) -> Result<std::path::PathBuf> {
+    std::path::Path::new(rootfs)
+        .parent()
+        .map(|dir| dir.join(mvm_build::builder_vm::SIDECAR_FILENAME))
+        .ok_or_else(|| anyhow::anyhow!("rootfs path {rootfs} has no parent directory"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sidecar_resolves_beside_the_rootfs() {
+        assert_eq!(
+            sidecar_path_for_rootfs("/slots/abc/artifacts/rootfs.ext4").unwrap(),
+            std::path::Path::new("/slots/abc/artifacts/mvm-meta.json")
+        );
+    }
+
+    #[test]
+    fn rootfs_without_a_parent_directory_is_refused() {
+        assert!(sidecar_path_for_rootfs("/").is_err());
+    }
 }


### PR DESCRIPTION
## Problem

`mvmctl bundle export` produced **unbootable bundles**. The export carried the kernel, rootfs, optional initrd and verity sidecar — but not the `mvm-meta.json` guest sidecar. The runtime's admission gate requires that sidecar next to the rootfs, so the failure only surfaced on the target host, after a successful-looking export and install:

```
refusing to start VM: rootfs at .../artifacts has no `mvm-meta.json` sidecar.
```

That breaks the whole export → install → run path a remote/edge host depends on, and it can't be worked around inside an automated scenario (the `@firecracker` BDD gate exists to run exactly this chain).

## Fix

Carry `mvm-meta.json` in the bundle as an `Other`-role artifact named for the sidecar, so it unpacks beside `rootfs.ext4` where the gate looks. Export now fails with actionable guidance when the template has no sidecar, rather than shipping a bundle that cannot boot — the same posture the neighbouring verity check already takes for an incomplete dm-verity binding.

## Verification

Live aarch64 Firecracker boot, no manual intervention:

- archive now contains `artifacts/mvm-meta.json` (`bundle install` reports **3 artifacts**, was 2)
- `machine run --manifest <sha>` clears the gate and boots:

```
GATE PASSED (no sidecar error)
Firecracker started
mvm-init: provisioned verb-grant
mvm-init: mounted runtime overlay /dev/vdb at /mvm/runtime (ro)
mvm-guest-agent: control plane ready (37ms)
```

Previously this same chain required hand-copying the sidecar into the installed bundle directory.

Unit tests cover the sidecar path derivation, including the refusal when the rootfs path has no parent directory.
