### PR TITLE
fix(mvm-runtime): refuse a workload boot whose kernel cmdline would be truncated

### DIFF
--- a/crates/mvm-runtime/src/workload_runner/cmdline.rs
+++ b/crates/mvm-runtime/src/workload_runner/cmdline.rs
@@ -19,6 +19,30 @@ use std::path::{Path, PathBuf};
 
 use mvm_core::vm_backend::VmStartConfig;
 
+/// Bytes the guest kernel reserves for its command line (`COMMAND_LINE_SIZE`,
+/// 2048 on both x86_64 and arm64), including the trailing NUL.
+const KERNEL_CMDLINE_LIMIT: usize = 2048;
+
+/// `Some(reason)` when `cmdline` would not reach the guest intact.
+///
+/// The kernel copies at most `COMMAND_LINE_SIZE` bytes and drops the rest
+/// without a diagnostic. Truncation takes whatever was appended last, and the
+/// tokens appended last here are the security-bearing ones — the verb grant,
+/// its enforcement assertion, the host-signer trust anchor, the egress knob. A
+/// guest can therefore come up silently missing its trust anchor or its egress
+/// policy, and the only visible symptom is an unrelated-looking readiness
+/// timeout. Callers refuse the boot instead.
+pub(crate) fn cmdline_overflow(cmdline: &str) -> Option<String> {
+    (cmdline.len() + 1 > KERNEL_CMDLINE_LIMIT).then(|| {
+        format!(
+            "assembled kernel cmdline is {} bytes, past the guest kernel's \
+             {KERNEL_CMDLINE_LIMIT}-byte command line; the kernel would truncate it \
+             and silently drop the trailing security tokens",
+            cmdline.len()
+        )
+    })
+}
+
 /// Kernel cmdline token that turns on the in-guest vsock egress client.
 /// Emitted only when the run actually allows outbound egress and the workload
 /// carries no bound secrets, so the raw SOCKS path never contends with the
@@ -173,6 +197,28 @@ pub(crate) fn runner_cmdline(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cmdline_within_the_kernel_limit_is_accepted() {
+        assert_eq!(cmdline_overflow("console=ttyS0 root=/dev/vda"), None);
+        // Exactly fills the buffer alongside its NUL.
+        assert_eq!(
+            cmdline_overflow(&"a".repeat(KERNEL_CMDLINE_LIMIT - 1)),
+            None
+        );
+    }
+
+    #[test]
+    fn cmdline_past_the_kernel_limit_is_refused() {
+        // One byte more than the buffer can hold with its NUL.
+        let over = "a".repeat(KERNEL_CMDLINE_LIMIT);
+        let reason = cmdline_overflow(&over).expect("oversized cmdline must be refused");
+        assert!(
+            reason.contains(&KERNEL_CMDLINE_LIMIT.to_string()),
+            "{reason}"
+        );
+        assert!(reason.contains(&over.len().to_string()), "{reason}");
+    }
 
     #[test]
     fn vsock_egress_cmdline_token_only_when_policy_allows_egress() {

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -707,15 +707,20 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 
                 ),
             };
 
+        let cmdline = cmdline::runner_cmdline(config, &state_dir, |virtiofs_root, has_disk| {
+            self.driver.workload_base_bootargs(virtiofs_root, has_disk)
+        });
+        if let Some(problem) = cmdline::cmdline_overflow(&cmdline) {
+            anyhow::bail!("refusing to start VM {}: {problem}", config.name);
+        }
+
         let inputs = WorkloadLaunchInputs {
             config,
             tenant,
             secrets,
             redaction,
             network_policy: &config.network_policy,
-            cmdline: cmdline::runner_cmdline(config, &state_dir, |virtiofs_root, has_disk| {
-                self.driver.workload_base_bootargs(virtiofs_root, has_disk)
-            }),
+            cmdline,
         };
         // The supervisor + endpoint are detached/disk-backed; the live handle is
         // reconstructed by id via `attach`, so the boot handle is dropped here.


### PR DESCRIPTION
## Problem

The guest kernel copies at most `COMMAND_LINE_SIZE` bytes (2048 on x86_64 and arm64) and drops the rest without a diagnostic. Truncation takes whatever was appended **last** — and the tokens the shared assembler appends last are the security-bearing ones:

```
… mvm.runtime_source_policy=…  mvm.vsock_egress=1  mvm.verb_grant=<hex>  mvm.require_grant=1  mvm.host_signer_pub=<hex>
```

So an oversized cmdline can bring a guest up silently missing its trust anchor (`host_signer_pub`), its grant-enforcement assertion (`require_grant`), or its egress policy — with no error raised on either side. The only visible symptom is an unrelated-looking agent readiness timeout.

Nothing checked this on the workload path. The existing `MAX_BOOT_ARGS_LEN` guard is 4096 — deliberately generous, **twice** the real kernel limit — and it only covers artifact validation, not the cmdline the runner assembles at boot time.

This is not hypothetical headroom: a current aarch64 workload boot measures 1925 bytes, 94% of the 2048-byte budget. `VerbGrant.sig` serializes as a JSON array of 64 decimal numbers and the whole envelope is then hex-encoded, doubling it, so a full 16-verb grant pushes that single token to ~1739 bytes on its own.

## Fix

Add `cmdline_overflow()` beside the assembler and fail the boot from `WorkloadRunner::start` when the assembled cmdline would not reach the guest intact, naming the measured length and the limit. Fail closed rather than boot a mis-configured guest.

## Notes

This deliberately does not change `MAX_BOOT_ARGS_LEN`; that guard has a different job (catching malformed/runaway artifact boot_args) and its generous bound is documented as intentional.

Shrinking the encoding — base64 instead of hex, and a compact `sig` rather than a 64-number JSON array — would take the budget from ~94% to ~50% and is the natural follow-up. This change makes the failure loud in the meantime.
