### PR TITLE
perf(verb-grant): base64 the cmdline envelope instead of hex

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-oci-init.rs
@@ -179,10 +179,12 @@ mod linux {
     }
 
     fn provision_verb_grant() {
-        let Some(hex) = cmdline_value("mvm.verb_grant") else {
+        let Some(b64) = cmdline_value("mvm.verb_grant") else {
             return;
         };
-        let Ok(grant) = hex_decode(&hex) else {
+        // base64, not hex: the envelope is the largest cmdline token and the
+        // kernel silently truncates past COMMAND_LINE_SIZE.
+        let Ok(grant) = base64_decode(&b64) else {
             eprintln!("mvm-oci-init: malformed verb-grant token");
             return;
         };
@@ -437,6 +439,51 @@ mod linux {
         }
     }
 
+    /// Standard-alphabet base64 decode, hand-rolled to keep this PID 1 free of
+    /// external crates (see the module doc). Rejects a character after padding,
+    /// a trailing partial character, and non-zero padding bits.
+    fn base64_decode(input: &str) -> Result<Vec<u8>, ()> {
+        let mut acc: u32 = 0;
+        let mut nbits: u32 = 0;
+        let mut seen_pad = false;
+        let mut out = Vec::with_capacity(input.len() / 4 * 3);
+        for &b in input.as_bytes() {
+            if b.is_ascii_whitespace() {
+                continue;
+            }
+            if b == b'=' {
+                seen_pad = true;
+                continue;
+            }
+            if seen_pad {
+                return Err(());
+            }
+            acc = (acc << 6) | u32::from(base64_val(b)?);
+            nbits += 6;
+            if nbits >= 8 {
+                nbits -= 8;
+                out.push(((acc >> nbits) & 0xff) as u8);
+            }
+        }
+        // A lone trailing character carries 6 unusable bits, and whatever bits
+        // remain must be the encoder's zero padding.
+        if nbits >= 6 || acc & ((1u32 << nbits) - 1) != 0 {
+            return Err(());
+        }
+        Ok(out)
+    }
+
+    fn base64_val(b: u8) -> Result<u8, ()> {
+        match b {
+            b'A'..=b'Z' => Ok(b - b'A'),
+            b'a'..=b'z' => Ok(b - b'a' + 26),
+            b'0'..=b'9' => Ok(b - b'0' + 52),
+            b'+' => Ok(62),
+            b'/' => Ok(63),
+            _ => Err(()),
+        }
+    }
+
     fn bring_loopback_up() {
         if let Err(e) = mvm_agentd::guest_net::bring_iface_up("lo") {
             eprintln!("mvm-oci-init: bring loopback up: {e}");
@@ -524,6 +571,26 @@ mod linux {
             assert_eq!(hex_decode("2F").unwrap(), b"/");
             assert!(hex_decode("0").is_err());
             assert!(hex_decode("zz").is_err());
+        }
+
+        #[test]
+        fn base64_decode_round_trips_each_padding_length() {
+            // 0, 1 and 2 bytes of padding respectively.
+            assert_eq!(base64_decode("Zm9vYmFy").unwrap(), b"foobar");
+            assert_eq!(base64_decode("Zm9vYmE=").unwrap(), b"fooba");
+            assert_eq!(base64_decode("Zm9vYg==").unwrap(), b"foob");
+            assert_eq!(base64_decode("").unwrap(), b"");
+            // Both non-alphanumeric alphabet characters.
+            assert_eq!(base64_decode("+/8=").unwrap(), [0xfb, 0xff]);
+        }
+
+        #[test]
+        fn base64_decode_rejects_malformed_input() {
+            assert!(base64_decode("Zm9v!mFy").is_err(), "invalid character");
+            assert!(base64_decode("Zm9vYmFyZ").is_err(), "trailing partial char");
+            assert!(base64_decode("Zm9v=YmFy").is_err(), "data after padding");
+            // Non-zero bits under the padding.
+            assert!(base64_decode("Zm9vYh==").is_err(), "dirty padding bits");
         }
 
         #[test]

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -14,6 +14,8 @@
 //! itself lives in `mvm-protocol`.
 
 use anyhow::Result;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
 use serde::{Deserialize, Serialize};
 
 pub use mvm_protocol::protocol::vm_backend::{
@@ -234,12 +236,14 @@ pub struct VmStartConfig {
     pub dev_console: bool,
 }
 
-/// Envelope carried in the `mvm.verb_grant=<hex(JSON)>` kernel-cmdline token.
+/// Envelope carried in the `mvm.verb_grant=<base64(JSON)>` kernel-cmdline token.
 ///
-/// The host hex-encodes the JSON so the value is a single space/newline-free
-/// token that `/proc/cmdline` round-trips without quoting. The guest decodes
-/// the hex, parses the JSON with `deny_unknown_fields`, then passes the inner
-/// `VerbGrant` to `pin_verb_grant` for signature verification before use.
+/// The host base64-encodes the JSON so the value is a single space/newline-free
+/// token that `/proc/cmdline` round-trips without quoting. base64 rather than
+/// hex because this is the largest token on the cmdline and the kernel silently
+/// drops anything past `COMMAND_LINE_SIZE`. The guest decodes it, parses the
+/// JSON with `deny_unknown_fields`, then passes the inner `VerbGrant` to
+/// `pin_verb_grant` for signature verification before use.
 ///
 /// `pubkey_hex` is the 32-byte Ed25519 verifying key in lowercase hex.
 /// `plan_nonce_hex` is the `Nonce::as_hex()` of the plan nonce the grant was
@@ -260,36 +264,32 @@ pub struct VerbGrantEnvelope {
     pub grant: crate::plan::VerbGrant,
 }
 
-/// Encode a `VerbGrantEnvelope` as a single `mvm.verb_grant=<hex(JSON)>`
+/// Encode a `VerbGrantEnvelope` as a single `mvm.verb_grant=<base64(JSON)>`
 /// kernel-cmdline token. Returns `None` if `env.pubkey_hex` is empty (no
-/// key ⇒ nothing to verify against) or if serialization fails. The hex
-/// encoding keeps the token space/newline-free for `/proc/cmdline`.
+/// key ⇒ nothing to verify against) or if serialization fails.
+///
+/// base64 rather than hex: this envelope is by far the largest thing on the
+/// guest cmdline, and the kernel silently drops everything past
+/// `COMMAND_LINE_SIZE`. Hex doubles the payload; base64 costs ~4/3, which buys
+/// back roughly a quarter of the whole budget. The standard alphabet is
+/// space- and newline-free, so the token stays a single `/proc/cmdline` word,
+/// and `=` padding is only ever trailing — the kernel splits a parameter on
+/// its first `=`, and the guest captures to the next space.
 pub fn encode_verb_grant_cmdline(env: &VerbGrantEnvelope) -> Option<String> {
     if env.pubkey_hex.is_empty() {
         return None;
     }
     let json = serde_json::to_vec(env).ok()?;
-    let hex: String = json.iter().map(|b| format!("{b:02x}")).collect();
-    Some(format!("mvm.verb_grant={hex}"))
+    Some(format!("mvm.verb_grant={}", B64.encode(&json)))
 }
 
-/// Decode the hex value of a `mvm.verb_grant=` cmdline token (the part after
-/// the `=`) into a `VerbGrantEnvelope`. Returns `Err` on malformed hex or
-/// unknown JSON fields (fail-closed).
-pub fn decode_verb_grant_cmdline(token_value_hex: &str) -> anyhow::Result<VerbGrantEnvelope> {
-    let bytes: Result<Vec<u8>, _> = (0..token_value_hex.len())
-        .step_by(2)
-        .map(|i| {
-            token_value_hex
-                .get(i..i + 2)
-                .ok_or_else(|| anyhow::anyhow!("odd-length hex"))
-                .and_then(|pair| {
-                    u8::from_str_radix(pair, 16)
-                        .map_err(|_| anyhow::anyhow!("non-hex byte at position {i}"))
-                })
-        })
-        .collect();
-    let bytes = bytes?;
+/// Decode the base64 value of a `mvm.verb_grant=` cmdline token (the part
+/// after the first `=`) into a `VerbGrantEnvelope`. Returns `Err` on malformed
+/// base64 or unknown JSON fields (fail-closed).
+pub fn decode_verb_grant_cmdline(token_value_b64: &str) -> anyhow::Result<VerbGrantEnvelope> {
+    let bytes = B64
+        .decode(token_value_b64.trim())
+        .map_err(|e| anyhow::anyhow!("malformed base64 verb-grant token: {e}"))?;
     let env: VerbGrantEnvelope = serde_json::from_slice(&bytes)?;
     Ok(env)
 }
@@ -999,8 +999,8 @@ mod tests {
         // Single cmdline token — no spaces or newlines.
         assert!(!token.contains(' ') && !token.contains('\n'));
 
-        let hex_value = token.strip_prefix("mvm.verb_grant=").unwrap();
-        let decoded = decode_verb_grant_cmdline(hex_value).unwrap();
+        let encoded_value = token.strip_prefix("mvm.verb_grant=").unwrap();
+        let decoded = decode_verb_grant_cmdline(encoded_value).unwrap();
 
         assert_eq!(decoded.pubkey_hex, pubkey_hex);
         assert_eq!(decoded.plan_nonce_hex, plan_nonce_hex);
@@ -1010,17 +1010,20 @@ mod tests {
     }
 
     #[test]
-    fn decode_rejects_malformed_hex() {
-        let result = decode_verb_grant_cmdline("zzzz");
-        assert!(result.is_err(), "non-hex input must be rejected");
+    fn decode_rejects_malformed_base64() {
+        // `!` is outside the standard alphabet. (Note `zzzz` would *not* do:
+        // those are legal base64 characters and would fail later, at JSON.)
+        assert!(
+            decode_verb_grant_cmdline("!!!!").is_err(),
+            "non-base64 input must be rejected"
+        );
     }
 
     #[test]
     fn decode_rejects_unknown_field() {
         // Build valid JSON with an extra field; deny_unknown_fields must reject it.
         let bad = r#"{"pubkey_hex":"aa","plan_nonce_hex":"bb","grant":{},"extra":"bad"}"#;
-        let hex: String = bad.bytes().map(|b| format!("{b:02x}")).collect();
-        let result = decode_verb_grant_cmdline(&hex);
+        let result = decode_verb_grant_cmdline(&B64.encode(bad));
         assert!(result.is_err(), "unknown field must be rejected");
     }
 }

--- a/crates/mvm-runtime/src/microvm/egress_bridge.rs
+++ b/crates/mvm-runtime/src/microvm/egress_bridge.rs
@@ -4,7 +4,7 @@
 //! was retired with the raw launch path. These tokens remain shared by the
 //! runner-backed libkrun, HVF, and QEMU command-line builders.
 
-/// The `mvm.verb_grant=<hex>` kernel-cmdline token for `vm_name`.
+/// The `mvm.verb_grant=<base64>` kernel-cmdline token for `vm_name`.
 pub(crate) fn verb_grant_cmdline_token(vm_name: &str) -> Option<String> {
     let path = mvm_core::config::vm_state_dir(vm_name).join("verb-grant.json");
     let bytes = std::fs::read(&path).ok()?;

--- a/crates/mvm-sdk/sdks/typescript/src/protocol/protocol.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/protocol/protocol.ts
@@ -641,9 +641,9 @@ mode: number
 path: string
 }
 /**
- * Envelope carried in the `mvm.verb_grant=<hex(JSON)>` kernel-cmdline token.
+ * Envelope carried in the `mvm.verb_grant=<base64(JSON)>` kernel-cmdline token.
  * 
- * The host hex-encodes the JSON so the value is a single space/newline-free token that `/proc/cmdline` round-trips without quoting. The guest decodes the hex, parses the JSON with `deny_unknown_fields`, then passes the inner `VerbGrant` to `pin_verb_grant` for signature verification before use.
+ * The host base64-encodes the JSON so the value is a single space/newline-free token that `/proc/cmdline` round-trips without quoting. base64 rather than hex because this is the largest token on the cmdline and the kernel silently drops anything past `COMMAND_LINE_SIZE`. The guest decodes it, parses the JSON with `deny_unknown_fields`, then passes the inner `VerbGrant` to `pin_verb_grant` for signature verification before use.
  * 
  * `pubkey_hex` is the 32-byte Ed25519 verifying key in lowercase hex. `plan_nonce_hex` is the `Nonce::as_hex()` of the plan nonce the grant was issued under — the guest uses it as the `plan_nonce` argument to `VerbGrant::verify`. Fixed-field-order struct: `serde_json::to_vec` output is byte-deterministic with no external canonicalizer.
  */

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -571,16 +571,18 @@ let
 
     # Stage 2.475 — provision the per-run verb-grant inputs.
     #
-    # The launcher writes `mvm.verb_grant=<hex(JSON)>` onto the kernel cmdline
-    # using the same hex encoding as stages 2.46/2.47. We decode the JSON blob
+    # The launcher writes `mvm.verb_grant=<base64(JSON)>` onto the kernel
+    # cmdline — base64 rather than the hex used by stages 2.46/2.47 because this
+    # envelope is the largest thing on the cmdline and the kernel silently drops
+    # whatever runs past COMMAND_LINE_SIZE. We decode the JSON blob
     # to `/run/mvm/verb-grant.json` (tmpfs, mode 0644). The host-signer public
     # key lands in the same tmpfs so the agent verifies the grant against an
     # out-of-band key: from the read-only config drive when one is attached,
     # otherwise from the cmdline. A vsock-only guest has no config drive, so
     # there the cmdline is the only carrier — without this the agent finds no
     # key, refuses every control RPC, and the host's readiness probe times out.
-    MVM_VERB_GRANT_HEX=$(/bin/busybox sed -n 's/.*\bmvm\.verb_grant=\([^ ]*\).*/\1/p' /proc/cmdline)
-    if [ -n "$MVM_VERB_GRANT_HEX" ]; then
+    MVM_VERB_GRANT_B64=$(/bin/busybox sed -n 's/.*\bmvm\.verb_grant=\([^ ]*\).*/\1/p' /proc/cmdline)
+    if [ -n "$MVM_VERB_GRANT_B64" ]; then
       /bin/busybox mkdir -p /run/mvm
       if [ -r /mnt/config/host-signer.pub ]; then
         /bin/busybox cp /mnt/config/host-signer.pub /run/mvm/host-signer.pub
@@ -593,7 +595,7 @@ let
           /bin/busybox chmod 0644 /run/mvm/host-signer.pub
         fi
       fi
-      printf '%b' "$(echo "$MVM_VERB_GRANT_HEX" | /bin/busybox sed 's/../\\x&/g')" \
+      printf '%s' "$MVM_VERB_GRANT_B64" | /bin/busybox base64 -d \
         > /run/mvm/verb-grant.json
       /bin/busybox chmod 0644 /run/mvm/verb-grant.json
       echo "mvm-init: provisioned verb-grant"

--- a/schema/protocol-v0.json
+++ b/schema/protocol-v0.json
@@ -3549,7 +3549,7 @@
       "additionalProperties": false
     },
     "VerbGrantEnvelope": {
-      "description": "Envelope carried in the `mvm.verb_grant=<hex(JSON)>` kernel-cmdline token.\n\nThe host hex-encodes the JSON so the value is a single space/newline-free token that `/proc/cmdline` round-trips without quoting. The guest decodes the hex, parses the JSON with `deny_unknown_fields`, then passes the inner `VerbGrant` to `pin_verb_grant` for signature verification before use.\n\n`pubkey_hex` is the 32-byte Ed25519 verifying key in lowercase hex. `plan_nonce_hex` is the `Nonce::as_hex()` of the plan nonce the grant was issued under — the guest uses it as the `plan_nonce` argument to `VerbGrant::verify`. Fixed-field-order struct: `serde_json::to_vec` output is byte-deterministic with no external canonicalizer.",
+      "description": "Envelope carried in the `mvm.verb_grant=<base64(JSON)>` kernel-cmdline token.\n\nThe host base64-encodes the JSON so the value is a single space/newline-free token that `/proc/cmdline` round-trips without quoting. base64 rather than hex because this is the largest token on the cmdline and the kernel silently drops anything past `COMMAND_LINE_SIZE`. The guest decodes it, parses the JSON with `deny_unknown_fields`, then passes the inner `VerbGrant` to `pin_verb_grant` for signature verification before use.\n\n`pubkey_hex` is the 32-byte Ed25519 verifying key in lowercase hex. `plan_nonce_hex` is the `Nonce::as_hex()` of the plan nonce the grant was issued under — the guest uses it as the `plan_nonce` argument to `VerbGrant::verify`. Fixed-field-order struct: `serde_json::to_vec` output is byte-deterministic with no external canonicalizer.",
       "type": "object",
       "required": [
         "grant",


### PR DESCRIPTION
## Problem

The verb-grant envelope is by far the largest token on the guest kernel cmdline, and it was hex-encoded — which doubles it. A current aarch64 workload boot measures **1925 of the kernel's 2048-byte `COMMAND_LINE_SIZE`, i.e. 94% of budget**, with the grant token alone accounting for 1636 of those bytes.

The kernel drops anything past that limit without a diagnostic, and the tokens appended last are the security-bearing ones (grant, its enforcement assertion, the host-signer anchor, the egress knob). The companion guard PR makes that failure loud; this one gets the payload back under control.

## Change

base64 instead of hex for the `mvm.verb_grant=` value — ~4/3 expansion rather than 2×.

Measured on the same 818-byte envelope:

| | chars |
|---|---|
| hex | 1636 |
| base64 | 1092 |

Whole cmdline: **1925 → 1381 bytes, 94% → 67%** of the 2048-byte budget.

Standard alphabet: space- and newline-free, so the token stays a single `/proc/cmdline` word. `=` padding is only ever trailing — the kernel splits a parameter at its first `=`, and both guest decoders capture to the next space.

Both guest sides are updated to match:
- the nix guest `/init` decodes with busybox's `base64` applet (verified present in the built guest image: BusyBox v1.36.1 ships `base64`, plus a `/bin/base64` symlink)
- `mvm-oci-init` gets a hand-rolled decoder, because that PID 1 deliberately depends on **no external crates** (it is injected into arbitrary OCI rootfs trees) — so pulling in the `base64` crate there would break that property

## Notes

This does not touch `VerbGrant.sig`, which still serializes as a JSON array of 64 decimal numbers (~230 chars before encoding). Switching that to a compact form is the natural follow-up and would take the budget from ~67% to roughly ~58%; it is a separate change because it alters the envelope's JSON shape rather than just its transport encoding.

A stale guest paired with a new host fails closed rather than misbehaving: it would find no parseable grant and refuse control RPCs.
