### PR TITLE
fix(vmm): make the virtqueue used index device-owned across drains

### DIFF
--- a/crates/mvm-runtime/src/vmm/mod.rs
+++ b/crates/mvm-runtime/src/vmm/mod.rs
@@ -61,10 +61,10 @@ pub(crate) fn validated_queue_size(num: u32) -> Option<u16> {
 
 /// The guest-programmed split-virtqueue ring state a device hands to
 /// [`build_split_queue`]: the three ring base addresses plus the device-owned
-/// resume point in the available ring.
+/// resume points in the available and used rings.
 ///
 /// Grouped into one type because every virtio-mmio device in this module keeps
-/// the same four values (block as flat fields, fs and vsock per queue) and they
+/// the same five values (block as flat fields, fs and vsock per queue) and they
 /// only ever travel together.
 #[derive(Clone, Copy)]
 pub(crate) struct RingGeometry {
@@ -72,14 +72,18 @@ pub(crate) struct RingGeometry {
     pub(crate) avail: u64,
     pub(crate) used: u64,
     pub(crate) next_avail: u16,
+    pub(crate) next_used: u16,
 }
 
 /// Build a validated `virtio-queue` split [`SplitQueue`] from a device's
 /// guest-programmed ring geometry, shared by every virtio-mmio device here.
 ///
 /// `qsz` is the already-validated ring size (a power of two ≤ [`QUEUE_SIZE_MAX`]
-/// — see [`validated_queue_size`]); `next_avail` resumes from the device-owned
-/// index so iteration continues exactly where the previous drain stopped.
+/// — see [`validated_queue_size`]); `next_avail` and `next_used` resume from the
+/// device-owned cursors so both iteration and completion continue exactly where
+/// the previous drain stopped. Neither cursor is ever recovered from guest RAM:
+/// the used ring is guest-writable, so re-reading `used.idx` would let the guest
+/// pick which slot the next completion overwrites.
 /// Returns `None` if a ring address breaks virtio's alignment rules —
 /// `set_*_address` silently keeps the prior value in that case, so we refuse to
 /// service a geometry we could not faithfully program.
@@ -91,6 +95,7 @@ pub(crate) fn build_split_queue(ring: RingGeometry, qsz: u16) -> Option<SplitQue
     queue.set_avail_ring_address(Some(ring.avail as u32), Some((ring.avail >> 32) as u32));
     queue.set_used_ring_address(Some(ring.used as u32), Some((ring.used >> 32) as u32));
     queue.set_next_avail(ring.next_avail);
+    queue.set_next_used(ring.next_used);
     (queue.desc_table() == ring.desc
         && queue.avail_ring() == ring.avail
         && queue.used_ring() == ring.used)

--- a/crates/mvm-runtime/src/vmm/virtio.rs
+++ b/crates/mvm-runtime/src/vmm/virtio.rs
@@ -200,6 +200,7 @@ pub struct VirtioBlk {
     avail: u64,
     used: u64,
     last_avail: u16,
+    next_used: u16,
     interrupt_status: u32,
 }
 
@@ -230,6 +231,7 @@ impl VirtioBlk {
             avail: 0,
             used: 0,
             last_avail: 0,
+            next_used: 0,
             interrupt_status: 0,
         }
     }
@@ -291,8 +293,18 @@ impl VirtioBlk {
             R_DRIVER_FEATURES => {} // accept whatever the driver acks
             R_QUEUE_SEL => {}       // single queue (0)
             R_QUEUE_NUM => self.queue_num = v,
-            R_QUEUE_READY => self.queue_ready = v,
-            R_STATUS => self.status = v,
+            R_QUEUE_READY => {
+                self.queue_ready = v;
+                if v == 0 {
+                    self.rewind_ring_cursors();
+                }
+            }
+            R_STATUS => {
+                self.status = v;
+                if v == 0 {
+                    self.rewind_ring_cursors();
+                }
+            }
             R_INTERRUPT_ACK => self.interrupt_status &= !v,
             R_QUEUE_DESC_LO => self.desc = (self.desc & !0xffff_ffff) | u64::from(v),
             R_QUEUE_DESC_HI => self.desc = (self.desc & 0xffff_ffff) | (u64::from(v) << 32),
@@ -327,10 +339,6 @@ impl VirtioBlk {
         let Some(mut queue) = build_split_queue(self.ring(), qsz) else {
             return false;
         };
-        // Preserve the pre-migration used-ring behaviour, which read the completion
-        // index from guest RAM. Seed the now device-owned `next_used` from it so the
-        // used entries land at byte-identical slots for a conformant guest.
-        queue.set_next_used(self.rd_u16(self.used + 2));
 
         let debug = virtio_debug();
         if debug {
@@ -377,6 +385,7 @@ impl VirtioBlk {
             let _ = queue.add_used(&mem, head, written);
         }
         self.last_avail = queue.next_avail();
+        self.next_used = queue.next_used();
         if serviced {
             self.interrupt_status |= 1; // used-buffer notification
         }
@@ -391,7 +400,23 @@ impl VirtioBlk {
             avail: self.avail,
             used: self.used,
             next_avail: self.last_avail,
+            next_used: self.next_used,
         }
+    }
+
+    /// Rewind both device-owned ring cursors to the start of a fresh ring.
+    ///
+    /// The cursors are zero at construction and are re-zeroed on exactly the two
+    /// register writes by which a driver hands the device a newly-programmed
+    /// ring: detaching the queue (`QueueReady` ← 0, after which the driver frees
+    /// the ring and any later activation programs zeroed memory) and resetting
+    /// the device (`Status` ← 0, after which the driver re-runs the whole
+    /// initialization sequence). Every other register write leaves them alone, so
+    /// a redundant `QueueReady` ← 1 on a live queue cannot rewind the device onto
+    /// used slots the driver still owns.
+    fn rewind_ring_cursors(&mut self) {
+        self.last_avail = 0;
+        self.next_used = 0;
     }
 
     /// Service one virtio-blk request, given its chain's device-readable and
@@ -510,6 +535,7 @@ struct FsQueue {
     avail: u64,
     used: u64,
     last_avail: u16,
+    next_used: u16,
 }
 
 impl FsQueue {
@@ -521,7 +547,17 @@ impl FsQueue {
             avail: self.avail,
             used: self.used,
             next_avail: self.last_avail,
+            next_used: self.next_used,
         }
+    }
+
+    /// Rewind both device-owned ring cursors to the start of a fresh ring, on the
+    /// same two transitions as [`VirtioBlk::rewind_ring_cursors`]: this queue
+    /// being detached (`QueueReady` ← 0) and the device being reset
+    /// (`Status` ← 0).
+    fn rewind_cursors(&mut self) {
+        self.last_avail = 0;
+        self.next_used = 0;
     }
 }
 
@@ -621,8 +657,21 @@ impl VirtioFs {
             R_DRIVER_FEATURES_SEL | R_DRIVER_FEATURES => {}
             R_QUEUE_SEL => self.queue_sel = v,
             R_QUEUE_NUM => self.q_mut().num = v,
-            R_QUEUE_READY => self.q_mut().ready = v,
-            R_STATUS => self.status = v,
+            R_QUEUE_READY => {
+                let q = self.q_mut();
+                q.ready = v;
+                if v == 0 {
+                    q.rewind_cursors();
+                }
+            }
+            R_STATUS => {
+                self.status = v;
+                if v == 0 {
+                    // A device reset returns every queue to its pre-init state, not
+                    // just the one currently selected.
+                    self.queues.iter_mut().for_each(FsQueue::rewind_cursors);
+                }
+            }
             R_INTERRUPT_ACK => self.interrupt_status &= !v,
             R_QUEUE_DESC_LO => {
                 let d = self.q().desc;
@@ -676,9 +725,6 @@ impl VirtioFs {
         let Some(mut queue) = build_split_queue(q.ring(), qsz) else {
             return false;
         };
-        // Seed the now device-owned used index from guest RAM so the used entries
-        // land at byte-identical slots for a conformant guest.
-        queue.set_next_used(self.mem.rd_u16(q.used + 2));
 
         let mut completed: Vec<(u16, u32)> = Vec::new();
         {
@@ -711,6 +757,7 @@ impl VirtioFs {
             let _ = queue.add_used(&mem, head, written);
         }
         self.queues[qidx].last_avail = queue.next_avail();
+        self.queues[qidx].next_used = queue.next_used();
         if serviced {
             self.interrupt_status |= 1;
         }
@@ -1227,6 +1274,14 @@ mod tests {
     /// used-ring completion, kept as the differential oracle. The migrated
     /// `process_queue` must reproduce its guest-RAM writes, disk writes,
     /// used-ring bytes, used index, `last_avail`, and interrupt bit exactly.
+    ///
+    /// The oracle re-reads `used.idx` from guest RAM before every completion
+    /// where the migrated path uses its own cursor. The two stay in lockstep for
+    /// every layout here because each fixture starts from a zeroed used ring
+    /// that no guest buffer aliases — exactly the conformant case. A fixture
+    /// that pre-seeds a non-zero `used.idx`, or aims a device-writable buffer at
+    /// the used ring, is expected to diverge; those cases are asserted as
+    /// device-owned wins by the ring-cursor tests below.
     fn reference_blk_process_queue(d: &mut VirtioBlk) -> bool {
         if d.queue_ready == 0 {
             return false;
@@ -1446,6 +1501,160 @@ mod tests {
         );
     }
 
+    // ---- device-owned ring cursors: cross-drain + lifecycle -----------------
+
+    /// Two conformant single-payload read chains. Laid out by
+    /// [`program_blk_queue`], chain 0 takes descriptors 0..3 (head 0) and
+    /// chain 1 takes 3..6 (head 3).
+    fn blk_two_read_chains() -> Vec<BlkChain> {
+        (0..2)
+            .map(|sector| BlkChain {
+                req_type: VIRTIO_BLK_T_IN,
+                sector,
+                data: vec![512],
+                status: true,
+            })
+            .collect()
+    }
+
+    /// A block device carrying [`blk_two_read_chains`], drained once — so both
+    /// device-owned cursors sit at 1 with one chain still unpublished. Returns
+    /// the device and its (available ring, used ring) addresses.
+    fn blk_drained_once(qsz: u16) -> (VirtioBlk, u64, u64) {
+        let mut d = blk_dev(blk_disk());
+        let (avail, used) = program_blk_queue(&mut d, qsz, &blk_two_read_chains());
+        d.mem.wr_u16(avail + 2, 1);
+        assert!(d.process_queue(), "first drain services one chain");
+        (d, avail, used)
+    }
+
+    /// The used cursor is device state **across** drains, not just within one:
+    /// the device never recovers it from the guest-writable used ring. A guest
+    /// that rewrites `used.idx` between two notifies cannot make the next
+    /// completion overwrite a record it has not consumed.
+    #[test]
+    fn blk_used_index_is_device_owned_across_drains() {
+        let qsz = 8u16;
+        let (mut d, avail, used) = blk_drained_once(qsz);
+        assert_eq!(d.mem.rd_u16(used + 2), 1, "first drain published index 1");
+        assert_eq!(d.mem.rd_u32(used + 4), 0, "slot 0 records the first head");
+
+        // Between drains the guest scribbles its own value into `used.idx`,
+        // aiming the next completion back at slot 0.
+        d.mem.wr_u16(used + 2, 0);
+
+        d.mem.wr_u16(avail + 2, 2);
+        assert!(d.process_queue(), "second drain services the second chain");
+        assert_eq!(
+            d.mem.rd_u16(used + 2),
+            2,
+            "the device republished its own count, not the guest's"
+        );
+        assert_eq!(
+            d.mem.rd_u32(used + 4),
+            0,
+            "slot 0 still holds the first completion"
+        );
+        assert_eq!(
+            d.mem.rd_u32(used + 12),
+            3,
+            "the second completion landed at the device's next slot"
+        );
+        assert_eq!(d.next_used, 2, "device cursor counted both completions");
+
+        // The pre-migration walk re-read the index from guest RAM per
+        // completion, so the same scribble steered its second completion on top
+        // of the first.
+        let mut d_ref = blk_dev(blk_disk());
+        program_blk_queue(&mut d_ref, qsz, &blk_two_read_chains());
+        d_ref.mem.wr_u16(avail + 2, 1);
+        assert!(reference_blk_process_queue(&mut d_ref));
+        d_ref.mem.wr_u16(used + 2, 0);
+        d_ref.mem.wr_u16(avail + 2, 2);
+        assert!(reference_blk_process_queue(&mut d_ref));
+        assert_eq!(
+            d_ref.mem.rd_u16(used + 2),
+            1,
+            "the retired walk followed the guest's index"
+        );
+        assert_eq!(
+            d_ref.mem.rd_u32(used + 4),
+            3,
+            "and overwrote slot 0 with the second head"
+        );
+    }
+
+    #[test]
+    fn blk_queue_ready_zero_rewinds_the_ring_cursors() {
+        let (mut d, avail, used) = blk_drained_once(8);
+        assert_eq!(
+            (d.last_avail, d.next_used),
+            (1, 1),
+            "one chain consumed and completed"
+        );
+
+        d.write(R_QUEUE_READY, 0);
+        assert_eq!(d.queue_ready, 0);
+        assert_eq!(
+            (d.last_avail, d.next_used),
+            (0, 0),
+            "detaching the queue rewinds both cursors"
+        );
+
+        // The driver reactivates with a freshly-zeroed ring: the first chain is
+        // serviced again and its completion lands at used slot 0.
+        d.mem.wr_u16(used + 2, 0);
+        d.mem.wr_u16(avail + 2, 0);
+        d.write(R_QUEUE_READY, 1);
+        d.mem.wr_u16(avail + 2, 1);
+        assert!(d.process_queue());
+        assert_eq!(d.mem.rd_u16(used + 2), 1, "completion published at index 1");
+        assert_eq!(d.mem.rd_u32(used + 4), 0, "and recorded at slot 0");
+    }
+
+    #[test]
+    fn blk_device_reset_rewinds_the_ring_cursors() {
+        let (mut d, _avail, _used) = blk_drained_once(8);
+        assert_eq!((d.last_avail, d.next_used), (1, 1));
+
+        // A driver walking the status bits up to DRIVER_OK must not be rewound.
+        d.write(R_STATUS, 0xf);
+        assert_eq!(
+            (d.last_avail, d.next_used),
+            (1, 1),
+            "a non-zero status write leaves the cursors alone"
+        );
+
+        d.write(R_STATUS, 0);
+        assert_eq!(
+            (d.last_avail, d.next_used),
+            (0, 0),
+            "a device reset rewinds both cursors"
+        );
+    }
+
+    #[test]
+    fn blk_redundant_queue_ready_write_does_not_rewind_a_live_ring() {
+        let (mut d, avail, used) = blk_drained_once(8);
+
+        d.write(R_QUEUE_READY, 1);
+        assert_eq!(
+            (d.last_avail, d.next_used),
+            (1, 1),
+            "re-arming an already-ready queue must not rewind it"
+        );
+
+        // The next drain resumes at the second chain and the device's next slot.
+        d.mem.wr_u16(avail + 2, 2);
+        assert!(d.process_queue());
+        assert_eq!(d.mem.rd_u16(used + 2), 2);
+        assert_eq!(
+            d.mem.rd_u32(used + 12),
+            3,
+            "slot 1 records the second chain's head"
+        );
+    }
+
     // ---- virtio-fs queue migration: differential equivalence ----------------
 
     const FUSE_LOOKUP: u32 = 1;
@@ -1643,12 +1852,15 @@ mod tests {
             avail,
             used,
             last_avail: 0,
+            next_used: 0,
         };
         (avail, used)
     }
 
     /// Faithful copy of the pre-migration hand-rolled virtio-fs drain loop and
-    /// used-ring completion, kept as the differential oracle.
+    /// used-ring completion, kept as the differential oracle. Byte-identity with
+    /// the migrated path holds under the same precondition as the block oracle:
+    /// a zeroed, un-aliased used ring.
     fn reference_fs_process_queue(fs: &mut VirtioFs, qidx: usize) -> bool {
         if qidx >= FS_NUM_QUEUES {
             return false;
@@ -1780,5 +1992,184 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The virtio-fs request queue (queue 0 is hiprio).
+    const FS_REQ_QIDX: usize = 1;
+
+    /// Two conformant FUSE INIT chains, each a request descriptor plus a reply
+    /// buffer. Chain 0 takes descriptors 0..2 (head 0), chain 1 takes 2..4
+    /// (head 2).
+    fn fs_two_init_chains() -> Vec<FsChain> {
+        let init = fuse_request(FUSE_INIT, 1, 0, &init_body());
+        vec![
+            FsChain {
+                req: vec![init.clone()],
+                reply: vec![256],
+            },
+            FsChain {
+                req: vec![init],
+                reply: vec![256],
+            },
+        ]
+    }
+
+    /// A virtio-fs device carrying [`fs_two_init_chains`] on its request queue,
+    /// drained once — so both device-owned cursors sit at 1 with one chain still
+    /// unpublished. Returns the device and its (available ring, used ring)
+    /// addresses.
+    fn fs_drained_once(root: &Path, qsz: u16) -> (VirtioFs, u64, u64) {
+        let mut fs = fs_dev(root);
+        let (avail, used) = program_fs_queue(&mut fs, FS_REQ_QIDX, qsz, &fs_two_init_chains());
+        fs.mem.wr_u16(avail + 2, 1);
+        assert!(
+            fs.process_queue(FS_REQ_QIDX),
+            "first drain services one chain"
+        );
+        (fs, avail, used)
+    }
+
+    /// Select the request queue, so the `QueueNum`/`QueueReady`/address register
+    /// writes that follow apply to it.
+    fn fs_select_request_queue(fs: &mut VirtioFs) {
+        fs.write(R_QUEUE_SEL, FS_REQ_QIDX as u64);
+    }
+
+    /// Cross-drain witness: a guest that rewrites `used.idx` between two
+    /// notifies cannot steer where the fs device records its next completion.
+    #[test]
+    fn fs_used_index_is_device_owned_across_drains() {
+        let dir = tempfile::tempdir().unwrap();
+        let qsz = 8u16;
+        let (mut fs, avail, used) = fs_drained_once(dir.path(), qsz);
+        assert_eq!(fs.mem.rd_u16(used + 2), 1, "first drain published index 1");
+        assert_eq!(fs.mem.rd_u32(used + 4), 0, "slot 0 records the first head");
+
+        fs.mem.wr_u16(used + 2, 0);
+
+        fs.mem.wr_u16(avail + 2, 2);
+        assert!(fs.process_queue(FS_REQ_QIDX));
+        assert_eq!(
+            fs.mem.rd_u16(used + 2),
+            2,
+            "the device republished its own count, not the guest's"
+        );
+        assert_eq!(
+            fs.mem.rd_u32(used + 4),
+            0,
+            "slot 0 still holds the first completion"
+        );
+        assert_eq!(
+            fs.mem.rd_u32(used + 12),
+            2,
+            "the second completion landed at the device's next slot"
+        );
+        assert_eq!(fs.queues[FS_REQ_QIDX].next_used, 2);
+
+        // The pre-migration walk re-read the index per completion, so the same
+        // scribble steered its second completion on top of the first.
+        let mut fs_ref = fs_dev(dir.path());
+        program_fs_queue(&mut fs_ref, FS_REQ_QIDX, qsz, &fs_two_init_chains());
+        fs_ref.mem.wr_u16(avail + 2, 1);
+        assert!(reference_fs_process_queue(&mut fs_ref, FS_REQ_QIDX));
+        fs_ref.mem.wr_u16(used + 2, 0);
+        fs_ref.mem.wr_u16(avail + 2, 2);
+        assert!(reference_fs_process_queue(&mut fs_ref, FS_REQ_QIDX));
+        assert_eq!(
+            fs_ref.mem.rd_u16(used + 2),
+            1,
+            "the retired walk followed the guest's index"
+        );
+        assert_eq!(
+            fs_ref.mem.rd_u32(used + 4),
+            2,
+            "and overwrote slot 0 with the second head"
+        );
+    }
+
+    #[test]
+    fn fs_queue_ready_zero_rewinds_the_ring_cursors() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut fs, avail, used) = fs_drained_once(dir.path(), 8);
+        let cursors = |fs: &VirtioFs| {
+            (
+                fs.queues[FS_REQ_QIDX].last_avail,
+                fs.queues[FS_REQ_QIDX].next_used,
+            )
+        };
+        assert_eq!(cursors(&fs), (1, 1), "one chain consumed and completed");
+
+        fs_select_request_queue(&mut fs);
+        fs.write(R_QUEUE_READY, 0);
+        assert_eq!(fs.queues[FS_REQ_QIDX].ready, 0);
+        assert_eq!(
+            cursors(&fs),
+            (0, 0),
+            "detaching the queue rewinds both cursors"
+        );
+
+        fs.mem.wr_u16(used + 2, 0);
+        fs.mem.wr_u16(avail + 2, 0);
+        fs.write(R_QUEUE_READY, 1);
+        fs.mem.wr_u16(avail + 2, 1);
+        assert!(fs.process_queue(FS_REQ_QIDX));
+        assert_eq!(
+            fs.mem.rd_u16(used + 2),
+            1,
+            "completion published at index 1"
+        );
+        assert_eq!(fs.mem.rd_u32(used + 4), 0, "and recorded at slot 0");
+    }
+
+    #[test]
+    fn fs_device_reset_rewinds_every_queues_ring_cursors() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut fs, _avail, _used) = fs_drained_once(dir.path(), 8);
+        // The hiprio queue is never notified by these fixtures; give it cursors
+        // of its own so the reset is observed across the whole device.
+        fs.queues[0].last_avail = 5;
+        fs.queues[0].next_used = 5;
+
+        fs.write(R_STATUS, 0xf);
+        assert_eq!(
+            (fs.queues[FS_REQ_QIDX].last_avail, fs.queues[0].next_used),
+            (1, 5),
+            "a non-zero status write leaves the cursors alone"
+        );
+
+        fs.write(R_STATUS, 0);
+        for (qidx, q) in fs.queues.iter().enumerate() {
+            assert_eq!(
+                (q.last_avail, q.next_used),
+                (0, 0),
+                "queue {qidx} not rewound by the device reset"
+            );
+        }
+    }
+
+    #[test]
+    fn fs_redundant_queue_ready_write_does_not_rewind_a_live_ring() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut fs, avail, used) = fs_drained_once(dir.path(), 8);
+
+        fs_select_request_queue(&mut fs);
+        fs.write(R_QUEUE_READY, 1);
+        assert_eq!(
+            (
+                fs.queues[FS_REQ_QIDX].last_avail,
+                fs.queues[FS_REQ_QIDX].next_used
+            ),
+            (1, 1),
+            "re-arming an already-ready queue must not rewind it"
+        );
+
+        fs.mem.wr_u16(avail + 2, 2);
+        assert!(fs.process_queue(FS_REQ_QIDX));
+        assert_eq!(fs.mem.rd_u16(used + 2), 2);
+        assert_eq!(
+            fs.mem.rd_u32(used + 12),
+            2,
+            "slot 1 records the second chain's head"
+        );
     }
 }

--- a/crates/mvm-runtime/src/vmm/vsock_transport.rs
+++ b/crates/mvm-runtime/src/vmm/vsock_transport.rs
@@ -46,6 +46,17 @@ pub(crate) struct Queue {
     pub(crate) avail: u64,
     pub(crate) used: u64,
     pub(crate) last_avail: u16,
+    pub(crate) next_used: u16,
+}
+
+impl Queue {
+    /// Rewind both device-owned ring cursors to the start of a fresh ring, on the
+    /// same two transitions the block and fs devices use: this queue being
+    /// detached (`QueueReady` ← 0) and the device being reset (`Status` ← 0).
+    fn rewind_cursors(&mut self) {
+        self.last_avail = 0;
+        self.next_used = 0;
+    }
 }
 
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
@@ -186,8 +197,21 @@ impl VsockTransportCore {
             0x024 | 0x020 => {}
             0x030 => self.queue_sel = v,
             0x038 => self.cur_mut().num = v,
-            0x044 => self.cur_mut().ready = v,
-            0x070 => self.status = v,
+            0x044 => {
+                let q = self.cur_mut();
+                q.ready = v;
+                if v == 0 {
+                    q.rewind_cursors();
+                }
+            }
+            0x070 => {
+                self.status = v;
+                if v == 0 {
+                    // A device reset returns every queue to its pre-init state, not
+                    // just the one currently selected.
+                    self.queues.iter_mut().for_each(Queue::rewind_cursors);
+                }
+            }
             0x064 => self.interrupt_status &= !v,
             0x080 => set_lo(&mut self.cur_mut().desc, v),
             0x084 => set_hi(&mut self.cur_mut().desc, v),
@@ -221,10 +245,6 @@ impl VsockTransportCore {
         let Some(mut queue) = build_split_queue(&q, qsz) else {
             return Vec::new();
         };
-        // Preserve the pre-migration used-ring behaviour, which read the completion
-        // index from guest RAM. Seed the now device-owned `next_used` from it so the
-        // used entries land at byte-identical slots for a conformant guest.
-        queue.set_next_used(self.mem.rd_u16(q.used + 2));
 
         let mut packets = Vec::new();
         let mut completed = Vec::new();
@@ -259,6 +279,7 @@ impl VsockTransportCore {
             self.interrupt_status |= 1;
         }
         self.queues[TX].last_avail = queue.next_avail();
+        self.queues[TX].next_used = queue.next_used();
         packets
     }
 
@@ -362,9 +383,6 @@ impl VsockTransportCore {
         let Some(mut queue) = build_split_queue(&q, qsz) else {
             return false;
         };
-        // Seed the now device-owned used index from guest RAM so the used entries
-        // land at byte-identical slots for a conformant guest (mirrors the TX path).
-        queue.set_next_used(self.mem.rd_u16(q.used + 2));
 
         let mut completed = Vec::new();
         let mut delivered = false;
@@ -430,6 +448,7 @@ impl VsockTransportCore {
             self.interrupt_status |= 1;
         }
         self.queues[RX].last_avail = queue.next_avail();
+        self.queues[RX].next_used = queue.next_used();
         delivered
     }
 
@@ -483,6 +502,7 @@ fn build_split_queue(q: &Queue, qsz: u16) -> Option<SplitQueue> {
             avail: q.avail,
             used: q.used,
             next_avail: q.last_avail,
+            next_used: q.next_used,
         },
         qsz,
     )
@@ -523,6 +543,7 @@ mod tests {
             avail,
             used,
             last_avail: 0,
+            next_used: 0,
         };
         core.mem.wr_u16(avail + 2, caps.len() as u16);
         for (index, cap) in caps.iter().enumerate() {
@@ -696,6 +717,7 @@ mod tests {
             avail: base + 0x200,
             used: base + 0x300,
             last_avail: 0,
+            next_used: 0,
         };
         core.mem.wr_u16(base + 0x200 + 2, 1);
     }
@@ -761,6 +783,7 @@ mod tests {
             avail,
             used,
             last_avail: 0,
+            next_used: 0,
         };
         core.mem.wr_u16(avail + 2, 1);
         core.mem.wr_u16(avail + 4, 0); // ring[0] = head 0
@@ -961,6 +984,7 @@ mod tests {
             avail,
             used,
             last_avail: 0,
+            next_used: 0,
         };
         let mut desc_idx: u16 = 0;
         let mut buf_off: u64 = 0;
@@ -1039,6 +1063,12 @@ mod tests {
         out
     }
 
+    /// The pre-migration completion, shared by the TX and RX oracles: it
+    /// recovers the used index from guest RAM where the migrated path uses the
+    /// device-owned cursor. The two agree for every fixture here because each
+    /// starts from a zeroed used ring that no guest buffer aliases — the
+    /// conformant case. Divergence under a scribbled index is asserted as a
+    /// device-owned win by the ring-cursor tests below.
     fn reference_complete(core: &VsockTransportCore, used: u64, head: u16, written: u32, qsz: u16) {
         let mem = &core.mem;
         let used_idx = mem.rd_u16(used + 2);
@@ -1104,6 +1134,7 @@ mod tests {
             avail,
             used,
             last_avail: 0,
+            next_used: 0,
         };
         // 0 -> 1 -> 0 -> 1 -> ... with F_NEXT set on both: a cycle a 65535-hop
         // hand-rolled walk would have followed.
@@ -1145,6 +1176,7 @@ mod tests {
             avail,
             used,
             last_avail: 0,
+            next_used: 0,
         };
         // Head descriptor claims a `next` index past the ring; the validated walk
         // must stop after the head rather than follow the out-of-range link (the
@@ -1360,6 +1392,7 @@ mod tests {
                 avail,
                 used,
                 last_avail: 0,
+                next_used: 0,
             };
             core.mem.wr_u16(avail + 2, 1);
             core.mem.wr_u16(avail + 4, 0);
@@ -1391,5 +1424,173 @@ mod tests {
             "last_avail not advanced past the un-consumed entry"
         );
         assert_eq!(core_new.queues[RX].last_avail, 0);
+    }
+
+    // ---- device-owned ring cursors: cross-drain + lifecycle -----------------
+
+    /// MMIO register offsets the lifecycle tests drive, named for readability
+    /// (the device's `write_register` matches on the raw offsets).
+    const R_QUEUE_SEL: u64 = 0x030;
+    const R_QUEUE_READY: u64 = 0x044;
+    const R_STATUS: u64 = 0x070;
+
+    /// A transport with two single-descriptor TX chains programmed, drained once
+    /// — so both device-owned TX cursors sit at 1 with one chain unpublished.
+    /// Returns the core and its (available ring, used ring) addresses.
+    fn tx_drained_once(qsz: u16) -> (VsockTransportCore, u64, u64) {
+        let base = 0x4000_0000u64;
+        let chains = vec![single_chain(1000, b"first"), single_chain(1001, b"second")];
+        let mut core = transport_with_ram(0x10000);
+        let used = program_tx_queue(&mut core, base, qsz, &chains);
+        let avail = base + 0x4000;
+        core.mem.wr_u16(avail + 2, 1);
+        assert_eq!(
+            core.take_tx_packets().len(),
+            1,
+            "first drain takes one packet"
+        );
+        (core, avail, used)
+    }
+
+    /// Read the selected queue's cursors as a pair.
+    fn cursors(core: &VsockTransportCore, slot: usize) -> (u16, u16) {
+        (core.queues[slot].last_avail, core.queues[slot].next_used)
+    }
+
+    /// Cross-drain witness: a guest that rewrites `used.idx` between two TX
+    /// notifies cannot steer where the device records its next completion.
+    #[test]
+    fn take_tx_packets_used_index_is_device_owned_across_drains() {
+        let (mut core, avail, used) = tx_drained_once(4);
+        assert_eq!(
+            core.mem.rd_u16(used + 2),
+            1,
+            "first drain published index 1"
+        );
+        assert_eq!(
+            core.mem.rd_u32(used + 4),
+            0,
+            "slot 0 records the first head"
+        );
+
+        // Between drains the guest scribbles its own value into `used.idx`.
+        core.mem.wr_u16(used + 2, 0);
+
+        core.mem.wr_u16(avail + 2, 2);
+        assert_eq!(core.take_tx_packets().len(), 1);
+        assert_eq!(
+            core.mem.rd_u16(used + 2),
+            2,
+            "the device republished its own count, not the guest's"
+        );
+        assert_eq!(
+            core.mem.rd_u32(used + 4),
+            0,
+            "slot 0 still holds the first completion"
+        );
+        assert_eq!(
+            core.mem.rd_u32(used + 12),
+            1,
+            "the second completion landed at the device's next slot"
+        );
+        assert_eq!(cursors(&core, TX), (2, 2));
+
+        // The pre-migration walk re-read the index per completion, so the same
+        // scribble steered its second completion on top of the first.
+        let (core_ref, avail_ref, used_ref) = tx_drained_once(4);
+        core_ref.mem.wr_u16(used_ref + 2, 0);
+        core_ref.mem.wr_u16(avail_ref + 2, 2);
+        let (_, _, interrupted) = reference_take_tx_packets(&core_ref, 4);
+        assert!(interrupted);
+        assert_eq!(
+            core_ref.mem.rd_u16(used_ref + 2),
+            1,
+            "the retired walk followed the guest's index"
+        );
+        assert_eq!(
+            core_ref.mem.rd_u32(used_ref + 4),
+            1,
+            "and overwrote slot 0 with the second head"
+        );
+    }
+
+    #[test]
+    fn queue_ready_zero_rewinds_the_ring_cursors() {
+        let (mut core, avail, used) = tx_drained_once(4);
+        assert_eq!(
+            cursors(&core, TX),
+            (1, 1),
+            "one chain consumed and completed"
+        );
+
+        core.write_register(R_QUEUE_SEL, TX as u64);
+        core.write_register(R_QUEUE_READY, 0);
+        assert_eq!(core.queues[TX].ready, 0);
+        assert_eq!(
+            cursors(&core, TX),
+            (0, 0),
+            "detaching the queue rewinds both cursors"
+        );
+
+        // The driver reactivates with a freshly-zeroed ring: the first chain is
+        // taken again and its completion lands at used slot 0.
+        core.mem.wr_u16(used + 2, 0);
+        core.mem.wr_u16(avail + 2, 0);
+        core.write_register(R_QUEUE_READY, 1);
+        core.mem.wr_u16(avail + 2, 1);
+        assert_eq!(core.take_tx_packets().len(), 1);
+        assert_eq!(
+            core.mem.rd_u16(used + 2),
+            1,
+            "completion published at index 1"
+        );
+        assert_eq!(core.mem.rd_u32(used + 4), 0, "and recorded at slot 0");
+    }
+
+    #[test]
+    fn device_reset_rewinds_every_queues_ring_cursors() {
+        let (mut core, _avail, _used) = tx_drained_once(4);
+        // The RX queue is not exercised by the TX fixture; give it cursors of its
+        // own so the reset is observed across the whole device.
+        core.queues[RX].last_avail = 5;
+        core.queues[RX].next_used = 5;
+
+        core.write_register(R_STATUS, 0xf);
+        assert_eq!(
+            (core.queues[TX].last_avail, core.queues[RX].next_used),
+            (1, 5),
+            "a non-zero status write leaves the cursors alone"
+        );
+
+        core.write_register(R_STATUS, 0);
+        for slot in 0..NUM_QUEUES {
+            assert_eq!(
+                cursors(&core, slot),
+                (0, 0),
+                "queue {slot} not rewound by the device reset"
+            );
+        }
+    }
+
+    #[test]
+    fn redundant_queue_ready_write_does_not_rewind_a_live_ring() {
+        let (mut core, avail, used) = tx_drained_once(4);
+
+        core.write_register(R_QUEUE_SEL, TX as u64);
+        core.write_register(R_QUEUE_READY, 1);
+        assert_eq!(
+            cursors(&core, TX),
+            (1, 1),
+            "re-arming an already-ready queue must not rewind it"
+        );
+
+        core.mem.wr_u16(avail + 2, 2);
+        assert_eq!(core.take_tx_packets().len(), 1);
+        assert_eq!(core.mem.rd_u16(used + 2), 2);
+        assert_eq!(
+            core.mem.rd_u32(used + 12),
+            1,
+            "slot 1 records the second chain's head"
+        );
     }
 }

--- a/specs/adrs/033-rust-vmm-virtio-primitives.md
+++ b/specs/adrs/033-rust-vmm-virtio-primitives.md
@@ -56,7 +56,9 @@ state:
 - **F4.** The used-ring index is re-read from guest-writable RAM each
   completion instead of being device-owned, letting a guest rewind or
   steer where used entries land (confined to its own RAM, so not host
-  unsafety — a correctness defect).
+  unsafety — a correctness defect). Closed in two steps: within a drain by
+  the `virtio-queue` adoption below, and across drains by the ring-cursor
+  ownership decision that follows it.
 
 The through-line: **hand-rolled virtqueue and guest-memory code re-derives,
 per device, invariants that a validated queue primitive enforces once.**
@@ -123,6 +125,47 @@ duration of the migration, so the default-binary closure delta stays
 feature on by default — and delete the hand-rolled path — only once
 Slice 5 lands and the old code is dead. This decouples the closure-budget
 step below from every intermediate slice.
+
+### Used-index ownership across drains, and ring-cursor lifecycle
+
+The initial migration closed F4 only *within* a drain: each device still
+seeded the per-drain `Queue`'s `next_used` from `used.idx` in guest RAM,
+to keep the used entries byte-identical to the retired hand-rolled walk.
+That left the index guest-recoverable between drains. It is now **device
+state across drains**, exactly as `next_avail` already was: every device
+carries a `next_used` sibling to its `last_avail`, feeds both into the
+shared `RingGeometry` that `build_split_queue` programs, and writes both
+back from `Queue::{next_avail,next_used}` after the drain. No device reads
+`used.idx` from guest memory on any path. For a conformant guest this is
+byte-identical — Linux zeroes the used ring before setting `QueueReady`
+and never writes `used.idx` afterward, so the seed being removed only ever
+read back what the device itself last wrote.
+
+**Cursor lifecycle.** Both cursors are zero at device construction and are
+re-zeroed on exactly the two register writes by which a driver hands the
+device a freshly-programmed ring:
+
+1. `QueueReady ← 0` — the driver detaching that queue. It then frees the
+   ring, and any later activation programs newly-allocated (zeroed)
+   memory, so the next drain must start at slot 0. Only the selected queue
+   is rewound.
+2. `Status ← 0` — a device reset. The driver re-runs the whole
+   initialization sequence afterwards, so **every** queue is rewound.
+
+Every other register write leaves the cursors alone. In particular a
+redundant `QueueReady ← 1` on an already-ready queue is a no-op: making
+activation rather than deactivation the trigger would let a mid-stream
+write rewind the device onto used slots the driver still owns — a worse
+defect than the one F4 describes. Zeroing on the 0-write covers both
+orderings, since after it any subsequent activation already sits at zero.
+
+The same lifecycle now applies to `last_avail`, which until this change
+was zeroed only at construction and never on queue teardown or device
+reset; the two cursors move together by construction rather than by
+convention. Each of the three devices carries a cross-drain witness (a
+scribbled `used.idx` between two drains does not move the next completion)
+plus tests for both rewind transitions and for the redundant-activation
+no-op.
 
 ## Supply chain and closure (ADR-002 / ADR-031 compliance)
 


### PR DESCRIPTION
Closes the residual half of audit finding F4. The rust-vmm migration made the used index device-owned *within* a drain, but all three devices still seeded it from guest-writable RAM at the start of every drain (`queue.set_next_used(rd_u16(used+2))` — 4 sites: blk, fs, vsock TX, vsock RX). A guest could therefore steer where the *next* drain's completions land.

**Severity is low** — every write is bounds-checked by `GuestMem`, so the guest can only corrupt its own RAM near a used ring it programmed itself. This is correctness/robustness work, not an urgent fix.

The asymmetry was the bug: `last_avail` was already device state carried across drains; `next_used` was the one cursor round-tripped through guest memory. `next_used` is now a sibling field following the identical path (init 0 → seeded into the shared `RingGeometry` → written back from `queue.next_used()`), so no restructuring.

### ⚠️ Scope note for reviewers — this changes `last_avail` reset behavior too
Investigating the lifecycle turned up a pre-existing gap: **no device had any reset path at all** — `R_STATUS => self.status = v` merely stored the byte, and `last_avail` was never reset, only initialized. Resetting `next_used` while leaving `last_avail` stale would have created a *new* asymmetry (a stale avail cursor against a fresh used cursor desynchronizes the ring), so both are now rewound together behind one `rewind_cursors()` per queue.

**Lifecycle chosen:** both cursors zero at construction and re-zero on exactly two writes — `QueueReady ← 0` (driver detaching that queue, which then frees the ring) and `Status ← 0` (device reset, rewinds every queue). Deliberately **not** on activation: rewinding on any `QueueReady` write would let a mid-stream write rewind onto used slots the driver still owns — strictly worse than the bug being fixed. This matches Linux `virtio_mmio`: `vm_del_vq` writes `QueueReady=0` before freeing, `vm_setup_vq` writes `1` only after programming a fresh ring, and `virtio_reset_device` writes `Status=0` before any queue is programmed.

### Tests
- **All four differential byte-identity tests pass unmodified** — zero assertions changed or removed (assertion counts grew 64→114 and 68→92). No fixture pre-seeds a nonzero `used.idx`, and every used ring is disjoint from its buffers, so the oracles' per-completion re-read still returns exactly what the device wrote. Their doc comments now state that precondition so a future fixture author can't silently weaken them.
- 3 cross-drain witnesses (one per device): drain, guest scribbles `used+2`, drain again → completion lands at the device's slot, with the retained oracle shown diverging on the same input.
- 9 lifecycle tests incl. negative controls (a redundant `QueueReady←1` must NOT rewind a live ring; a nonzero status write must not reset).
- **Mutation-verified load-bearing:** re-adding the seed + dropping the rewinds fails 9 of 12; changing the trigger to rewind on any `QueueReady` write fails exactly the 3 negative controls.

Gates green: 1072 tests, stable+nightly fmt, workspace clippy `-D warnings`, closure **272 unchanged** (no new deps), check-duplicate-majors, check-vsock-only-egress, check-no-spec-refs, zigbuild aarch64-musl. IRQ, geometry gate, DMA, and readable/writable partitioning untouched. ADR-033 updated with the lifecycle decision.