### PR TITLE
fix(mvm-runtime): make virtqueue used index device-owned across drains

### DIFF
--- a/crates/mvm-runtime/src/vmm/mod.rs
+++ b/crates/mvm-runtime/src/vmm/mod.rs
@@ -61,10 +61,10 @@ pub(crate) fn validated_queue_size(num: u32) -> Option<u16> {
 
 /// The guest-programmed split-virtqueue ring state a device hands to
 /// [`build_split_queue`]: the three ring base addresses plus the device-owned
-/// resume point in the available ring.
+/// resume points in both the available and used rings.
 ///
 /// Grouped into one type because every virtio-mmio device in this module keeps
-/// the same four values (block as flat fields, fs and vsock per queue) and they
+/// the same values (block as flat fields, fs and vsock per queue) and they
 /// only ever travel together.
 #[derive(Clone, Copy)]
 pub(crate) struct RingGeometry {
@@ -72,14 +72,16 @@ pub(crate) struct RingGeometry {
     pub(crate) avail: u64,
     pub(crate) used: u64,
     pub(crate) next_avail: u16,
+    pub(crate) next_used: u16,
 }
 
 /// Build a validated `virtio-queue` split [`SplitQueue`] from a device's
 /// guest-programmed ring geometry, shared by every virtio-mmio device here.
 ///
 /// `qsz` is the already-validated ring size (a power of two ≤ [`QUEUE_SIZE_MAX`]
-/// — see [`validated_queue_size`]); `next_avail` resumes from the device-owned
-/// index so iteration continues exactly where the previous drain stopped.
+/// — see [`validated_queue_size`]); `next_avail` and `next_used` resume from the
+/// device-owned indexes so both rings continue exactly where the previous drain
+/// stopped.
 /// Returns `None` if a ring address breaks virtio's alignment rules —
 /// `set_*_address` silently keeps the prior value in that case, so we refuse to
 /// service a geometry we could not faithfully program.
@@ -91,6 +93,7 @@ pub(crate) fn build_split_queue(ring: RingGeometry, qsz: u16) -> Option<SplitQue
     queue.set_avail_ring_address(Some(ring.avail as u32), Some((ring.avail >> 32) as u32));
     queue.set_used_ring_address(Some(ring.used as u32), Some((ring.used >> 32) as u32));
     queue.set_next_avail(ring.next_avail);
+    queue.set_next_used(ring.next_used);
     (queue.desc_table() == ring.desc
         && queue.avail_ring() == ring.avail
         && queue.used_ring() == ring.used)

--- a/crates/mvm-runtime/src/vmm/virtio.rs
+++ b/crates/mvm-runtime/src/vmm/virtio.rs
@@ -200,6 +200,7 @@ pub struct VirtioBlk {
     avail: u64,
     used: u64,
     last_avail: u16,
+    next_used: u16,
     interrupt_status: u32,
 }
 
@@ -230,6 +231,7 @@ impl VirtioBlk {
             avail: 0,
             used: 0,
             last_avail: 0,
+            next_used: 0,
             interrupt_status: 0,
         }
     }
@@ -291,8 +293,24 @@ impl VirtioBlk {
             R_DRIVER_FEATURES => {} // accept whatever the driver acks
             R_QUEUE_SEL => {}       // single queue (0)
             R_QUEUE_NUM => self.queue_num = v,
-            R_QUEUE_READY => self.queue_ready = v,
-            R_STATUS => self.status = v,
+            R_QUEUE_READY => {
+                if v != 0 && self.queue_ready == 0 {
+                    // The driver must zero the used ring before enabling the
+                    // queue. Reset the device-owned ring indexes so a stale
+                    // value cannot survive across a disable/enable cycle.
+                    self.last_avail = 0;
+                    self.next_used = 0;
+                }
+                self.queue_ready = v;
+            }
+            R_STATUS => {
+                if v == 0 {
+                    // Device reset: reinitialize queue state.
+                    self.last_avail = 0;
+                    self.next_used = 0;
+                }
+                self.status = v;
+            }
             R_INTERRUPT_ACK => self.interrupt_status &= !v,
             R_QUEUE_DESC_LO => self.desc = (self.desc & !0xffff_ffff) | u64::from(v),
             R_QUEUE_DESC_HI => self.desc = (self.desc & 0xffff_ffff) | (u64::from(v) << 32),
@@ -327,10 +345,6 @@ impl VirtioBlk {
         let Some(mut queue) = build_split_queue(self.ring(), qsz) else {
             return false;
         };
-        // Preserve the pre-migration used-ring behaviour, which read the completion
-        // index from guest RAM. Seed the now device-owned `next_used` from it so the
-        // used entries land at byte-identical slots for a conformant guest.
-        queue.set_next_used(self.rd_u16(self.used + 2));
 
         let debug = virtio_debug();
         if debug {
@@ -377,6 +391,7 @@ impl VirtioBlk {
             let _ = queue.add_used(&mem, head, written);
         }
         self.last_avail = queue.next_avail();
+        self.next_used = queue.next_used();
         if serviced {
             self.interrupt_status |= 1; // used-buffer notification
         }
@@ -391,6 +406,7 @@ impl VirtioBlk {
             avail: self.avail,
             used: self.used,
             next_avail: self.last_avail,
+            next_used: self.next_used,
         }
     }
 
@@ -510,6 +526,7 @@ struct FsQueue {
     avail: u64,
     used: u64,
     last_avail: u16,
+    next_used: u16,
 }
 
 impl FsQueue {
@@ -521,6 +538,7 @@ impl FsQueue {
             avail: self.avail,
             used: self.used,
             next_avail: self.last_avail,
+            next_used: self.next_used,
         }
     }
 }
@@ -621,8 +639,27 @@ impl VirtioFs {
             R_DRIVER_FEATURES_SEL | R_DRIVER_FEATURES => {}
             R_QUEUE_SEL => self.queue_sel = v,
             R_QUEUE_NUM => self.q_mut().num = v,
-            R_QUEUE_READY => self.q_mut().ready = v,
-            R_STATUS => self.status = v,
+            R_QUEUE_READY => {
+                let q = self.q_mut();
+                if v != 0 && q.ready == 0 {
+                    // The driver must zero the used ring before enabling the
+                    // queue. Reset the device-owned ring indexes so a stale
+                    // value cannot survive across a disable/enable cycle.
+                    q.last_avail = 0;
+                    q.next_used = 0;
+                }
+                q.ready = v;
+            }
+            R_STATUS => {
+                if v == 0 {
+                    // Device reset: reinitialize every queue's ring state.
+                    for q in &mut self.queues {
+                        q.last_avail = 0;
+                        q.next_used = 0;
+                    }
+                }
+                self.status = v;
+            }
             R_INTERRUPT_ACK => self.interrupt_status &= !v,
             R_QUEUE_DESC_LO => {
                 let d = self.q().desc;
@@ -676,9 +713,6 @@ impl VirtioFs {
         let Some(mut queue) = build_split_queue(q.ring(), qsz) else {
             return false;
         };
-        // Seed the now device-owned used index from guest RAM so the used entries
-        // land at byte-identical slots for a conformant guest.
-        queue.set_next_used(self.mem.rd_u16(q.used + 2));
 
         let mut completed: Vec<(u16, u32)> = Vec::new();
         {
@@ -711,6 +745,7 @@ impl VirtioFs {
             let _ = queue.add_used(&mem, head, written);
         }
         self.queues[qidx].last_avail = queue.next_avail();
+        self.queues[qidx].next_used = queue.next_used();
         if serviced {
             self.interrupt_status |= 1;
         }
@@ -1643,6 +1678,7 @@ mod tests {
             avail,
             used,
             last_avail: 0,
+            next_used: 0,
         };
         (avail, used)
     }
@@ -1780,5 +1816,364 @@ mod tests {
                 );
             }
         }
+    }
+
+    // ---- device-owned used index: lifecycle and cross-drain witnesses -----
+
+    /// Build a minimal virtio-blk request at `desc_head` whose data lands in
+    /// `(hdr, data, status)` and whose status byte lands at `status`. The tuple
+    /// keeps the helper under the clippy argument limit.
+    fn blk_put_request(
+        ram: &mut [u8],
+        base: u64,
+        desc: u64,
+        desc_head: u16,
+        gpa: (u64, u64, u64),
+        sector: u64,
+    ) {
+        let put = |ram: &mut [u8], gpa: u64, bytes: &[u8]| {
+            let off = (gpa - base) as usize;
+            ram[off..off + bytes.len()].copy_from_slice(bytes);
+        };
+        let (hdr_gpa, data_gpa, status_gpa) = gpa;
+        let mk = |addr: u64, len: u32, flags: u16, next: u16| {
+            let mut d = [0u8; 16];
+            d[0..8].copy_from_slice(&addr.to_le_bytes());
+            d[8..12].copy_from_slice(&len.to_le_bytes());
+            d[12..14].copy_from_slice(&flags.to_le_bytes());
+            d[14..16].copy_from_slice(&next.to_le_bytes());
+            d
+        };
+        let d0 = desc + u64::from(desc_head) * 16;
+        put(ram, d0, &mk(hdr_gpa, 16, DESC_F_NEXT, desc_head + 1));
+        put(
+            ram,
+            d0 + 16,
+            &mk(data_gpa, 512, DESC_F_NEXT | DESC_F_WRITE, desc_head + 2),
+        );
+        put(ram, d0 + 32, &mk(status_gpa, 1, DESC_F_WRITE, 0));
+        put(ram, hdr_gpa, &VIRTIO_BLK_T_IN.to_le_bytes());
+        put(ram, hdr_gpa + 8, &sector.to_le_bytes());
+    }
+
+    #[test]
+    fn blk_next_used_resets_on_queue_ready() {
+        const BASE: u64 = 0x4000_0000;
+        let mut ram = vec![0u8; 0x10000];
+        let put = |ram: &mut [u8], gpa: u64, bytes: &[u8]| {
+            let off = (gpa - BASE) as usize;
+            ram[off..off + bytes.len()].copy_from_slice(bytes);
+        };
+
+        let (desc, avail, used) = (BASE + 0x1000, BASE + 0x2000, BASE + 0x3000);
+        let (hdr, data, status) = (BASE + 0x4000, BASE + 0x5000, BASE + 0x6000);
+        blk_put_request(&mut ram, BASE, desc, 0, (hdr, data, status), 0);
+        put(&mut ram, avail + 2, &1u16.to_le_bytes());
+        put(&mut ram, avail + 4, &0u16.to_le_bytes());
+        // Hostile/synthetic driver pre-seeds a non-zero used index. Enabling the
+        // queue must reset the device-owned counter so completions start at 0.
+        put(&mut ram, used + 2, &7u16.to_le_bytes());
+
+        let mut disk = vec![0u8; 4096];
+        disk[..11].copy_from_slice(b"DISK-BYTES!");
+        let mut d = unsafe {
+            VirtioBlk::new(
+                0x0a00_0000,
+                48,
+                ram.as_mut_ptr(),
+                BASE,
+                ram.len(),
+                DiskImage::mem(disk),
+            )
+        };
+        d.write(R_QUEUE_NUM, 4);
+        d.write(R_QUEUE_DESC_LO, desc & 0xffff_ffff);
+        d.write(R_QUEUE_DRIVER_LO, avail & 0xffff_ffff);
+        d.write(R_QUEUE_DEVICE_LO, used & 0xffff_ffff);
+        d.write(R_QUEUE_READY, 1);
+
+        assert!(d.write(R_QUEUE_NOTIFY, 0));
+        assert_eq!(
+            u16::from_le_bytes(
+                ram[(used - BASE) as usize + 2..(used - BASE) as usize + 4]
+                    .try_into()
+                    .unwrap()
+            ),
+            1,
+            "QueueReady must reset next_used to 0"
+        );
+    }
+
+    #[test]
+    fn blk_next_used_resets_on_device_reset() {
+        const BASE: u64 = 0x4000_0000;
+        let mut ram = vec![0u8; 0x10000];
+        let put = |ram: &mut [u8], gpa: u64, bytes: &[u8]| {
+            let off = (gpa - BASE) as usize;
+            ram[off..off + bytes.len()].copy_from_slice(bytes);
+        };
+
+        let (desc, avail, used) = (BASE + 0x1000, BASE + 0x2000, BASE + 0x3000);
+        let (hdr, data, status) = (BASE + 0x4000, BASE + 0x5000, BASE + 0x6000);
+        blk_put_request(&mut ram, BASE, desc, 0, (hdr, data, status), 0);
+        put(&mut ram, avail + 2, &1u16.to_le_bytes());
+        put(&mut ram, avail + 4, &0u16.to_le_bytes());
+
+        let disk = vec![0u8; 4096];
+        let mut d = unsafe {
+            VirtioBlk::new(
+                0x0a00_0000,
+                48,
+                ram.as_mut_ptr(),
+                BASE,
+                ram.len(),
+                DiskImage::mem(disk),
+            )
+        };
+        d.write(R_QUEUE_NUM, 4);
+        d.write(R_QUEUE_DESC_LO, desc & 0xffff_ffff);
+        d.write(R_QUEUE_DRIVER_LO, avail & 0xffff_ffff);
+        d.write(R_QUEUE_DEVICE_LO, used & 0xffff_ffff);
+        d.write(R_QUEUE_READY, 1);
+        assert!(d.write(R_QUEUE_NOTIFY, 0));
+        assert_eq!(
+            u16::from_le_bytes(
+                ram[(used - BASE) as usize + 2..(used - BASE) as usize + 4]
+                    .try_into()
+                    .unwrap()
+            ),
+            1
+        );
+
+        // Device reset must reinitialize the device-owned used index.
+        d.write(R_STATUS, 0);
+        put(&mut ram, used + 2, &42u16.to_le_bytes());
+        assert!(d.write(R_QUEUE_NOTIFY, 0));
+        assert_eq!(
+            u16::from_le_bytes(
+                ram[(used - BASE) as usize + 2..(used - BASE) as usize + 4]
+                    .try_into()
+                    .unwrap()
+            ),
+            1,
+            "device reset must reset next_used to 0"
+        );
+    }
+
+    #[test]
+    fn blk_next_used_is_device_owned_across_drains() {
+        const BASE: u64 = 0x4000_0000;
+        let mut ram = vec![0u8; 0x10000];
+        let put = |ram: &mut [u8], gpa: u64, bytes: &[u8]| {
+            let off = (gpa - BASE) as usize;
+            ram[off..off + bytes.len()].copy_from_slice(bytes);
+        };
+        let get16 = |ram: &[u8], gpa: u64| {
+            let off = (gpa - BASE) as usize;
+            u16::from_le_bytes(ram[off..off + 2].try_into().unwrap())
+        };
+
+        let (desc, avail, used) = (BASE + 0x1000, BASE + 0x2000, BASE + 0x3000);
+        let (hdr0, data0, status0) = (BASE + 0x4000, BASE + 0x5000, BASE + 0x6000);
+        let (hdr1, data1, status1) = (BASE + 0x7000, BASE + 0x8000, BASE + 0x9000);
+        blk_put_request(&mut ram, BASE, desc, 0, (hdr0, data0, status0), 0);
+        blk_put_request(&mut ram, BASE, desc, 3, (hdr1, data1, status1), 1);
+        put(&mut ram, avail + 2, &1u16.to_le_bytes());
+        put(&mut ram, avail + 4, &0u16.to_le_bytes());
+        // First drain starts from the device-owned 0, ignoring the guest seed.
+        put(&mut ram, used + 2, &5u16.to_le_bytes());
+
+        let mut disk = vec![0u8; 8192];
+        disk[..512].copy_from_slice(&[0xAA; 512]);
+        disk[512..1024].copy_from_slice(&[0xBB; 512]);
+        let mut d = unsafe {
+            VirtioBlk::new(
+                0x0a00_0000,
+                48,
+                ram.as_mut_ptr(),
+                BASE,
+                ram.len(),
+                DiskImage::mem(disk),
+            )
+        };
+        d.write(R_QUEUE_NUM, 8);
+        d.write(R_QUEUE_DESC_LO, desc & 0xffff_ffff);
+        d.write(R_QUEUE_DRIVER_LO, avail & 0xffff_ffff);
+        d.write(R_QUEUE_DEVICE_LO, used & 0xffff_ffff);
+        d.write(R_QUEUE_READY, 1);
+
+        assert!(d.write(R_QUEUE_NOTIFY, 0));
+        assert_eq!(get16(&ram, used + 2), 1, "first drain lands at slot 0");
+        assert_eq!(get16(&ram, used + 4), 0, "first used id is head 0");
+
+        // After the first drain the guest rewrites used.idx. The next completion
+        // must continue at the device's own next slot, not the guest's value.
+        put(&mut ram, used + 2, &99u16.to_le_bytes());
+        put(&mut ram, avail + 2, &2u16.to_le_bytes());
+        put(&mut ram, avail + 6, &3u16.to_le_bytes());
+        assert!(d.write(R_QUEUE_NOTIFY, 0));
+        assert_eq!(
+            get16(&ram, used + 2),
+            2,
+            "second drain ignores bogus used idx"
+        );
+        assert_eq!(
+            get16(&ram, used + 4 + 8),
+            3,
+            "second used id is head 3 at slot 1"
+        );
+    }
+
+    fn fs_put_init_request(ram: &mut [u8], req_gpa: u64, unique: u64) {
+        let put32 = |r: &mut [u8], o: usize, v: u32| r[o..o + 4].copy_from_slice(&v.to_le_bytes());
+        let put64 = |r: &mut [u8], o: usize, v: u64| r[o..o + 8].copy_from_slice(&v.to_le_bytes());
+        let off = req_gpa as usize;
+        let req = &mut ram[off..off + 40 + 16];
+        put32(req, 0, (40 + 16) as u32); // len
+        put32(req, 4, 26); // opcode = FUSE_INIT
+        put64(req, 8, unique); // unique
+        put32(req, 40, 7); // init_in.major
+        put32(req, 44, 31); // init_in.minor
+    }
+
+    #[test]
+    fn fs_next_used_resets_on_queue_ready() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ram = vec![0u8; 0x10000];
+        fs_put_init_request(&mut ram, 0x4000, 1);
+
+        // desc[0] readable -> request @0x4000; desc[1] writable -> reply @0x5000.
+        ram[0x1000..0x1008].copy_from_slice(&0x4000u64.to_le_bytes());
+        ram[0x1008..0x100c].copy_from_slice(&56u32.to_le_bytes());
+        ram[0x100c..0x100e].copy_from_slice(&DESC_F_NEXT.to_le_bytes());
+        ram[0x100e..0x1010].copy_from_slice(&1u16.to_le_bytes());
+        ram[0x1010..0x1018].copy_from_slice(&0x5000u64.to_le_bytes());
+        ram[0x1018..0x101c].copy_from_slice(&256u32.to_le_bytes());
+        ram[0x101c..0x101e].copy_from_slice(&DESC_F_WRITE.to_le_bytes());
+        ram[0x2002..0x2004].copy_from_slice(&1u16.to_le_bytes());
+        ram[0x2004..0x2006].copy_from_slice(&0u16.to_le_bytes());
+        // Pre-seed a bogus used index; QueueReady must reset it.
+        ram[0x3002..0x3004].copy_from_slice(&7u16.to_le_bytes());
+
+        let ptr = ram.as_mut_ptr();
+        let mut fs = unsafe { VirtioFs::new(0, 5, ptr, 0, ram.len(), dir.path().to_path_buf()) };
+        fs.write(R_QUEUE_SEL, 1);
+        fs.write(R_QUEUE_NUM, 4);
+        fs.write(R_QUEUE_DESC_LO, 0x1000);
+        fs.write(R_QUEUE_DRIVER_LO, 0x2000);
+        fs.write(R_QUEUE_DEVICE_LO, 0x3000);
+        fs.write(R_QUEUE_READY, 1);
+        assert!(fs.write(R_QUEUE_NOTIFY, 1));
+        assert_eq!(
+            u16::from_le_bytes(ram[0x3002..0x3004].try_into().unwrap()),
+            1
+        );
+    }
+
+    #[test]
+    fn fs_next_used_resets_on_device_reset() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ram = vec![0u8; 0x10000];
+        fs_put_init_request(&mut ram, 0x4000, 1);
+
+        ram[0x1000..0x1008].copy_from_slice(&0x4000u64.to_le_bytes());
+        ram[0x1008..0x100c].copy_from_slice(&56u32.to_le_bytes());
+        ram[0x100c..0x100e].copy_from_slice(&DESC_F_NEXT.to_le_bytes());
+        ram[0x100e..0x1010].copy_from_slice(&1u16.to_le_bytes());
+        ram[0x1010..0x1018].copy_from_slice(&0x5000u64.to_le_bytes());
+        ram[0x1018..0x101c].copy_from_slice(&256u32.to_le_bytes());
+        ram[0x101c..0x101e].copy_from_slice(&DESC_F_WRITE.to_le_bytes());
+        ram[0x2002..0x2004].copy_from_slice(&1u16.to_le_bytes());
+        ram[0x2004..0x2006].copy_from_slice(&0u16.to_le_bytes());
+
+        let ptr = ram.as_mut_ptr();
+        let mut fs = unsafe { VirtioFs::new(0, 5, ptr, 0, ram.len(), dir.path().to_path_buf()) };
+        fs.write(R_QUEUE_SEL, 1);
+        fs.write(R_QUEUE_NUM, 4);
+        fs.write(R_QUEUE_DESC_LO, 0x1000);
+        fs.write(R_QUEUE_DRIVER_LO, 0x2000);
+        fs.write(R_QUEUE_DEVICE_LO, 0x3000);
+        fs.write(R_QUEUE_READY, 1);
+        assert!(fs.write(R_QUEUE_NOTIFY, 1));
+        assert_eq!(
+            u16::from_le_bytes(ram[0x3002..0x3004].try_into().unwrap()),
+            1
+        );
+
+        fs.write(R_STATUS, 0);
+        ram[0x3002..0x3004].copy_from_slice(&42u16.to_le_bytes());
+        assert!(fs.write(R_QUEUE_NOTIFY, 1));
+        assert_eq!(
+            u16::from_le_bytes(ram[0x3002..0x3004].try_into().unwrap()),
+            1,
+            "device reset must reset next_used to 0"
+        );
+    }
+
+    #[test]
+    fn fs_next_used_is_device_owned_across_drains() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ram = vec![0u8; 0x10000];
+        fs_put_init_request(&mut ram, 0x4000, 1);
+        fs_put_init_request(&mut ram, 0x6000, 2);
+
+        // Two descriptor chains: head 0 -> reply @0x5000, head 2 -> reply @0x7000.
+        ram[0x1000..0x1008].copy_from_slice(&0x4000u64.to_le_bytes());
+        ram[0x1008..0x100c].copy_from_slice(&56u32.to_le_bytes());
+        ram[0x100c..0x100e].copy_from_slice(&DESC_F_NEXT.to_le_bytes());
+        ram[0x100e..0x1010].copy_from_slice(&1u16.to_le_bytes());
+        ram[0x1010..0x1018].copy_from_slice(&0x5000u64.to_le_bytes());
+        ram[0x1018..0x101c].copy_from_slice(&256u32.to_le_bytes());
+        ram[0x101c..0x101e].copy_from_slice(&DESC_F_WRITE.to_le_bytes());
+
+        ram[0x1020..0x1028].copy_from_slice(&0x6000u64.to_le_bytes());
+        ram[0x1028..0x102c].copy_from_slice(&56u32.to_le_bytes());
+        ram[0x102c..0x102e].copy_from_slice(&DESC_F_NEXT.to_le_bytes());
+        ram[0x102e..0x1030].copy_from_slice(&3u16.to_le_bytes());
+        ram[0x1030..0x1038].copy_from_slice(&0x7000u64.to_le_bytes());
+        ram[0x1038..0x103c].copy_from_slice(&256u32.to_le_bytes());
+        ram[0x103c..0x103e].copy_from_slice(&DESC_F_WRITE.to_le_bytes());
+
+        ram[0x2002..0x2004].copy_from_slice(&1u16.to_le_bytes());
+        ram[0x2004..0x2006].copy_from_slice(&0u16.to_le_bytes());
+        // Pre-seed a bogus used index; the first drain must still start at 0.
+        ram[0x3002..0x3004].copy_from_slice(&5u16.to_le_bytes());
+
+        let ptr = ram.as_mut_ptr();
+        let mut fs = unsafe { VirtioFs::new(0, 5, ptr, 0, ram.len(), dir.path().to_path_buf()) };
+        fs.write(R_QUEUE_SEL, 1);
+        fs.write(R_QUEUE_NUM, 4);
+        fs.write(R_QUEUE_DESC_LO, 0x1000);
+        fs.write(R_QUEUE_DRIVER_LO, 0x2000);
+        fs.write(R_QUEUE_DEVICE_LO, 0x3000);
+        fs.write(R_QUEUE_READY, 1);
+
+        assert!(fs.write(R_QUEUE_NOTIFY, 1));
+        assert_eq!(
+            u16::from_le_bytes(ram[0x3002..0x3004].try_into().unwrap()),
+            1,
+            "first drain lands at slot 0"
+        );
+        assert_eq!(
+            u16::from_le_bytes(ram[0x3004..0x3006].try_into().unwrap()),
+            0,
+            "first used id is head 0"
+        );
+
+        // Guest rewrites used.idx between drains; the device must keep its own counter.
+        ram[0x3002..0x3004].copy_from_slice(&99u16.to_le_bytes());
+        ram[0x2002..0x2004].copy_from_slice(&2u16.to_le_bytes());
+        ram[0x2006..0x2008].copy_from_slice(&2u16.to_le_bytes());
+        assert!(fs.write(R_QUEUE_NOTIFY, 1));
+        assert_eq!(
+            u16::from_le_bytes(ram[0x3002..0x3004].try_into().unwrap()),
+            2,
+            "second drain ignores bogus used idx"
+        );
+        assert_eq!(
+            u16::from_le_bytes(ram[0x300c..0x300e].try_into().unwrap()),
+            2,
+            "second used id is head 2 at slot 1"
+        );
     }
 }

--- a/crates/mvm-runtime/src/vmm/vsock_transport.rs
+++ b/crates/mvm-runtime/src/vmm/vsock_transport.rs
@@ -46,6 +46,7 @@ pub(crate) struct Queue {
     pub(crate) avail: u64,
     pub(crate) used: u64,
     pub(crate) last_avail: u16,
+    pub(crate) next_used: u16,
 }
 
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
@@ -186,8 +187,27 @@ impl VsockTransportCore {
             0x024 | 0x020 => {}
             0x030 => self.queue_sel = v,
             0x038 => self.cur_mut().num = v,
-            0x044 => self.cur_mut().ready = v,
-            0x070 => self.status = v,
+            0x044 => {
+                let q = self.cur_mut();
+                if v != 0 && q.ready == 0 {
+                    // The driver must zero the used ring before enabling the
+                    // queue. Reset the device-owned ring indexes so a stale
+                    // value cannot survive across a disable/enable cycle.
+                    q.last_avail = 0;
+                    q.next_used = 0;
+                }
+                q.ready = v;
+            }
+            0x070 => {
+                if v == 0 {
+                    // Device reset: reinitialize every queue's ring state.
+                    for q in &mut self.queues {
+                        q.last_avail = 0;
+                        q.next_used = 0;
+                    }
+                }
+                self.status = v;
+            }
             0x064 => self.interrupt_status &= !v,
             0x080 => set_lo(&mut self.cur_mut().desc, v),
             0x084 => set_hi(&mut self.cur_mut().desc, v),
@@ -221,10 +241,6 @@ impl VsockTransportCore {
         let Some(mut queue) = build_split_queue(&q, qsz) else {
             return Vec::new();
         };
-        // Preserve the pre-migration used-ring behaviour, which read the completion
-        // index from guest RAM. Seed the now device-owned `next_used` from it so the
-        // used entries land at byte-identical slots for a conformant guest.
-        queue.set_next_used(self.mem.rd_u16(q.used + 2));
 
         let mut packets = Vec::new();
         let mut completed = Vec::new();
@@ -259,6 +275,7 @@ impl VsockTransportCore {
             self.interrupt_status |= 1;
         }
         self.queues[TX].last_avail = queue.next_avail();
+        self.queues[TX].next_used = queue.next_used();
         packets
     }
 
@@ -362,9 +379,6 @@ impl VsockTransportCore {
         let Some(mut queue) = build_split_queue(&q, qsz) else {
             return false;
         };
-        // Seed the now device-owned used index from guest RAM so the used entries
-        // land at byte-identical slots for a conformant guest (mirrors the TX path).
-        queue.set_next_used(self.mem.rd_u16(q.used + 2));
 
         let mut completed = Vec::new();
         let mut delivered = false;
@@ -430,6 +444,7 @@ impl VsockTransportCore {
             self.interrupt_status |= 1;
         }
         self.queues[RX].last_avail = queue.next_avail();
+        self.queues[RX].next_used = queue.next_used();
         delivered
     }
 
@@ -483,6 +498,7 @@ fn build_split_queue(q: &Queue, qsz: u16) -> Option<SplitQueue> {
             avail: q.avail,
             used: q.used,
             next_avail: q.last_avail,
+            next_used: q.next_used,
         },
         qsz,
     )
@@ -523,6 +539,7 @@ mod tests {
             avail,
             used,
             last_avail: 0,
+            next_used: 0,
         };
         core.mem.wr_u16(avail + 2, caps.len() as u16);
         for (index, cap) in caps.iter().enumerate() {
@@ -696,6 +713,7 @@ mod tests {
             avail: base + 0x200,
             used: base + 0x300,
             last_avail: 0,
+            next_used: 0,
         };
         core.mem.wr_u16(base + 0x200 + 2, 1);
     }
@@ -761,6 +779,7 @@ mod tests {
             avail,
             used,
             last_avail: 0,
+            next_used: 0,
         };
         core.mem.wr_u16(avail + 2, 1);
         core.mem.wr_u16(avail + 4, 0); // ring[0] = head 0
@@ -961,6 +980,7 @@ mod tests {
             avail,
             used,
             last_avail: 0,
+            next_used: 0,
         };
         let mut desc_idx: u16 = 0;
         let mut buf_off: u64 = 0;
@@ -1104,6 +1124,7 @@ mod tests {
             avail,
             used,
             last_avail: 0,
+            next_used: 0,
         };
         // 0 -> 1 -> 0 -> 1 -> ... with F_NEXT set on both: a cycle a 65535-hop
         // hand-rolled walk would have followed.
@@ -1145,6 +1166,7 @@ mod tests {
             avail,
             used,
             last_avail: 0,
+            next_used: 0,
         };
         // Head descriptor claims a `next` index past the ring; the validated walk
         // must stop after the head rather than follow the out-of-range link (the
@@ -1360,6 +1382,7 @@ mod tests {
                 avail,
                 used,
                 last_avail: 0,
+                next_used: 0,
             };
             core.mem.wr_u16(avail + 2, 1);
             core.mem.wr_u16(avail + 4, 0);
@@ -1391,5 +1414,164 @@ mod tests {
             "last_avail not advanced past the un-consumed entry"
         );
         assert_eq!(core_new.queues[RX].last_avail, 0);
+    }
+
+    // ---- device-owned used index: lifecycle and cross-drain witnesses -----
+
+    #[test]
+    fn take_tx_packets_ignores_guest_used_index() {
+        let base = 0x4000_0000u64;
+        let mut core = transport_with_ram(0x10000);
+        let chains = vec![single_chain(1000, b"hello")];
+        let used = program_tx_queue(&mut core, base, 4, &chains);
+        // Hostile/synthetic driver pre-seeds a non-zero used index. The device
+        // must still start its own counter at 0.
+        core.mem.wr_u16(used + 2, 7);
+
+        let packets = core.take_tx_packets();
+        assert_eq!(packets.len(), 1);
+        assert_eq!(
+            core.mem.rd_u16(used + 2),
+            1,
+            "device-owned next_used starts at 0"
+        );
+    }
+
+    #[test]
+    fn take_tx_packets_device_owned_across_drains() {
+        let base = 0x4000_0000u64;
+        let qsz = 4u16;
+        let mut core = transport_with_ram(0x10000);
+        let used = program_tx_queue(&mut core, base, qsz, &[single_chain(1000, b"first")]);
+
+        let packets1 = core.take_tx_packets();
+        assert_eq!(packets1.len(), 1);
+        assert_eq!(core.mem.rd_u16(used + 2), 1, "first drain lands at slot 0");
+        assert_eq!(core.mem.rd_u16(used + 4), 0, "first used id is head 0");
+
+        // Guest rewrites used.idx between drains; the device must keep its own counter.
+        core.mem.wr_u16(used + 2, 99);
+        let desc = base + 0x1000;
+        let avail = base + 0x4000;
+        let buf_base = base + 0x6000;
+        let mut seg = tx_hdr(1001, 6).to_bytes().to_vec();
+        seg.extend_from_slice(b"second");
+        let addr = buf_base + 0x100;
+        core.mem.write_bytes(desc + 16, &addr.to_le_bytes());
+        core.mem
+            .write_bytes(desc + 24, &(seg.len() as u32).to_le_bytes());
+        core.mem.wr_u16(desc + 28, 0); // no NEXT
+        core.mem.write_bytes(addr, &seg);
+        core.mem.wr_u16(avail + 4 + 2, 1); // ring[1] = head 1
+        core.mem.wr_u16(avail + 2, 2);
+
+        let packets2 = core.take_tx_packets();
+        assert_eq!(packets2.len(), 1);
+        assert_eq!(
+            core.mem.rd_u16(used + 2),
+            2,
+            "second drain ignores bogus used idx"
+        );
+        assert_eq!(
+            core.mem.rd_u16(used + 4 + 8),
+            1,
+            "second used id is head 1 at slot 1"
+        );
+    }
+
+    #[test]
+    fn flush_rx_ignores_guest_used_index() {
+        let mut core = transport();
+        let _buffers = configure_rx_buffers(&mut core, &[HDR_LEN + 8]);
+        let used = core.queues[RX].used;
+        core.mem.wr_u16(used + 2, 7);
+        core.queue_host_packet(1, 2, OP_RW, b"payload!");
+
+        assert!(core.flush_rx());
+        assert_eq!(
+            core.mem.rd_u16(used + 2),
+            1,
+            "device-owned next_used starts at 0"
+        );
+    }
+
+    #[test]
+    fn flush_rx_device_owned_across_drains() {
+        let mut core = transport();
+        let buffers = configure_rx_buffers(&mut core, &[HDR_LEN + 8, HDR_LEN + 8]);
+        let used = core.queues[RX].used;
+
+        core.queue_host_packet(1, 2, OP_RW, b"first!");
+        assert!(core.flush_rx());
+        assert_eq!(core.mem.rd_u16(used + 2), 1, "first drain lands at slot 0");
+
+        // Guest rewrites used.idx between drains; the device must keep its own counter.
+        core.mem.wr_u16(used + 2, 99);
+        core.queue_host_packet(1, 2, OP_RW, b"second!");
+        assert!(core.flush_rx());
+        assert_eq!(
+            core.mem.rd_u16(used + 2),
+            2,
+            "second drain ignores bogus used idx"
+        );
+
+        let second = core.mem.read_bytes(buffers[1], HDR_LEN + 8);
+        let hdr = VsockHdr::from_bytes(&second[..HDR_LEN]);
+        assert_eq!(hdr.op, OP_RW);
+        assert_eq!(hdr.len, 7);
+        assert_eq!(&second[HDR_LEN..HDR_LEN + 7], b"second!");
+    }
+
+    #[test]
+    fn vsock_next_used_resets_on_queue_ready() {
+        let base = 0x4000_0000u64;
+        let mut core = transport_with_ram(0x10000);
+        let (desc, avail, used, buf) = (base + 0x1000, base + 0x2000, base + 0x3000, base + 0x4000);
+
+        core.write_register(0x030, TX as u64); // QueueSel = TX
+        core.write_register(0x038, 1); // QueueNum
+        core.write_register(0x080, desc & 0xffff_ffff); // desc_lo
+        core.write_register(0x090, avail & 0xffff_ffff); // avail_lo
+        core.write_register(0x0a0, used & 0xffff_ffff); // used_lo
+
+        let mut seg = tx_hdr(1000, 5).to_bytes().to_vec();
+        seg.extend_from_slice(b"hello");
+        core.mem.write_bytes(desc, &buf.to_le_bytes());
+        core.mem
+            .write_bytes(desc + 8, &(seg.len() as u32).to_le_bytes());
+        core.mem.write_bytes(buf, &seg);
+        core.mem.wr_u16(avail + 4, 0); // ring[0] = head 0
+        core.mem.wr_u16(avail + 2, 1); // avail_idx = 1
+        core.mem.wr_u16(used + 2, 7); // bogus used index
+
+        core.write_register(0x044, 1); // QueueReady = 1
+        let packets = core.take_tx_packets();
+        assert_eq!(packets.len(), 1);
+        assert_eq!(
+            core.mem.rd_u16(used + 2),
+            1,
+            "QueueReady must reset next_used to 0"
+        );
+    }
+
+    #[test]
+    fn vsock_next_used_resets_on_device_reset() {
+        let base = 0x4000_0000u64;
+        let mut core = transport_with_ram(0x10000);
+        let used = program_tx_queue(&mut core, base, 4, &[single_chain(1000, b"hello")]);
+
+        let packets1 = core.take_tx_packets();
+        assert_eq!(packets1.len(), 1);
+        assert_eq!(core.mem.rd_u16(used + 2), 1);
+
+        core.write_register(0x070, 0); // Status = 0 (device reset)
+        core.mem.wr_u16(used + 2, 42); // bogus used index
+        let packets2 = core.take_tx_packets();
+        assert_eq!(packets2.len(), 1);
+        assert_eq!(
+            core.mem.rd_u16(used + 2),
+            1,
+            "device reset must reset next_used to 0"
+        );
     }
 }


### PR DESCRIPTION
Makes the virtio used-ring index device-owned for the in-house VMM's blk, fs, and vsock devices.

Previously each device re-read the used index from guest-writable RAM at the start of every drain/completion. Now it is carried in per-queue device state, mirroring how `last_avail` is already handled.

Lifecycle semantics:
- `next_used` is initialized to 0 when queue state is created.
- It resets to 0 when QueueReady transitions 0 -> 1 (driver must zero the used ring before enabling) and when the device is reset (Status = 0).
- It is carried across drains within an enabled queue.

For vsock, `build_split_queue` now seeds the virtio-queue `Queue` with both `next_avail` (from `last_avail`) and `next_used` (from `q.next_used`); the per-drain callers no longer read the guest's used index.

Tests:
- Added QueueReady-reset and device-reset lifecycle tests for each device.
- Added cross-drain witnesses for each device: guest scribbles a bogus used index between drains, and completions continue at the device's own next slot.
- The vsock differential tests remain byte-identical for conformant/zero-seeded cases. New "device-owned wins" tests cover the non-zero pre-seed divergent case.

Note on CI/gates: `cargo nextest run -p mvm-runtime` shows one unrelated failure in `workload_runner::claim::tests::claim_guards_spawn_endpoint_keys_the_socket_on_the_given_vm`; this reproduces on main when `MVM_HOME` is a deep worktree path (the socket-dir helper falls back to a hashed /tmp path). All virtio/vsock tests pass.