### PR TITLE
test(mvm-conformance): signed-bundle boot scenario + gate the BDD target on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,16 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      # The cucumber runner is `harness = false`, so it sits behind the `bdd`
+      # feature to keep it out of `cargo nextest run --workspace` — nextest
+      # enumerates tests with `--list`, which that target cannot answer. The
+      # step above does not reach it either, since `--all-targets` still honors
+      # `required-features`. Nothing else on a pull request builds it, so a
+      # struct or signature change anywhere in the workspace can break the BDD
+      # suite unnoticed and only surface in a release run. Compile it here.
+      - name: Clippy (BDD conformance target)
+        run: cargo clippy -p mvm-conformance --tests --features bdd -- -D warnings
+
       - name: ADR coverage (informational)
         continue-on-error: true
         run: cargo run -p xtask -- check-adr-coverage

--- a/Justfile
+++ b/Justfile
@@ -200,8 +200,16 @@ fmt-check:
 clippy:
     cargo clippy --workspace --all-targets -- -D warnings
 
-# Format check + clippy
-lint: fmt-check clippy
+# Compile the cucumber conformance target. It sits behind the `bdd` feature to
+# stay out of `cargo nextest run --workspace` (nextest lists tests via `--list`,
+# which a `harness = false` target cannot answer), and `--all-targets` above
+# honors `required-features`, so nothing else builds it — a struct change
+# elsewhere in the workspace can break it unnoticed.
+clippy-bdd:
+    cargo clippy -p mvm-conformance --tests --features bdd -- -D warnings
+
+# Format check + clippy (workspace + the feature-gated BDD target)
+lint: fmt-check clippy clippy-bdd
 
 # ── CI Gate ──────────────────────────────────────────────────────────────
 

--- a/crates/mvm-conformance/src/lib.rs
+++ b/crates/mvm-conformance/src/lib.rs
@@ -22,6 +22,12 @@ pub const LIVE_TAG: &str = "live";
 /// without KVM (GitHub-hosted ARM runners, or any dev box lacking one).
 pub const FIRECRACKER_TAG: &str = "firecracker";
 
+/// Cucumber tag for a scenario that boots from a pre-built signed bundle.
+/// Sealing a bundle means a full image build, far too slow to run inline, so
+/// the operator supplies one with `MVM_BDD_BUNDLE=<path to .mvmpkg>` and the
+/// scenario is skipped cleanly when that is absent.
+pub const BUNDLE_TAG: &str = "bundle";
+
 /// Host capabilities a scenario may require, probed once by the harness.
 ///
 /// Plain data so [`scenario_should_run`] is a pure decision the harness can
@@ -33,6 +39,9 @@ pub struct RuntimeCaps {
     /// A usable `/dev/kvm` and a `firecracker` binary on `PATH` are both present,
     /// so a real Firecracker boot can run here.
     pub firecracker_bootable: bool,
+    /// `MVM_BDD_BUNDLE` names a readable `.mvmpkg`, so a bundle-boot scenario
+    /// has something to install.
+    pub bundle_fixture: bool,
 }
 
 /// Decide whether a scenario with `tags` should run given the host `caps`.
@@ -53,6 +62,9 @@ pub fn scenario_should_run(tags: &[String], caps: RuntimeCaps) -> bool {
     if tagged(FIRECRACKER_TAG) && (!caps.live_opted_in || !caps.firecracker_bootable) {
         return false;
     }
+    if tagged(BUNDLE_TAG) && !caps.bundle_fixture {
+        return false;
+    }
     true
 }
 
@@ -67,11 +79,29 @@ mod tests {
     const NONE: RuntimeCaps = RuntimeCaps {
         live_opted_in: false,
         firecracker_bootable: false,
+        bundle_fixture: false,
     };
     const ALL: RuntimeCaps = RuntimeCaps {
         live_opted_in: true,
         firecracker_bootable: true,
+        bundle_fixture: true,
     };
+
+    #[test]
+    fn bundle_scenario_skips_without_a_fixture() {
+        // Everything else in place, but no `.mvmpkg` to install.
+        assert!(!scenario_should_run(
+            &tags(&["live", "firecracker", "bundle"]),
+            RuntimeCaps {
+                bundle_fixture: false,
+                ..ALL
+            },
+        ));
+        assert!(scenario_should_run(
+            &tags(&["live", "firecracker", "bundle"]),
+            ALL
+        ));
+    }
 
     #[test]
     fn untagged_scenario_always_runs() {
@@ -91,6 +121,7 @@ mod tests {
             RuntimeCaps {
                 live_opted_in: true,
                 firecracker_bootable: false,
+                bundle_fixture: false,
             },
         ));
     }
@@ -102,6 +133,7 @@ mod tests {
             RuntimeCaps {
                 live_opted_in: true,
                 firecracker_bootable: false,
+                bundle_fixture: false,
             },
         ));
         assert!(scenario_should_run(&tags(&["live", "firecracker"]), ALL));
@@ -115,6 +147,7 @@ mod tests {
             RuntimeCaps {
                 live_opted_in: false,
                 firecracker_bootable: true,
+                bundle_fixture: false,
             },
         ));
         // Live opt-in but missing capability → skipped.
@@ -123,6 +156,7 @@ mod tests {
             RuntimeCaps {
                 live_opted_in: true,
                 firecracker_bootable: false,
+                bundle_fixture: false,
             },
         ));
         // Both present → runs.

--- a/crates/mvm-conformance/tests/conformance.rs
+++ b/crates/mvm-conformance/tests/conformance.rs
@@ -51,7 +51,15 @@ fn probe_caps() -> RuntimeCaps {
     RuntimeCaps {
         live_opted_in: std::env::var_os("MVM_BDD_LIVE").is_some(),
         firecracker_bootable: kvm_openable() && firecracker_on_path(),
+        bundle_fixture: bundle_fixture_path().is_some(),
     }
+}
+
+/// The operator-supplied `.mvmpkg` a bundle-boot scenario installs, when
+/// `MVM_BDD_BUNDLE` names one that actually exists.
+pub(crate) fn bundle_fixture_path() -> Option<std::path::PathBuf> {
+    let path = std::path::PathBuf::from(std::env::var_os("MVM_BDD_BUNDLE")?);
+    path.is_file().then_some(path)
 }
 
 /// `/dev/kvm` exists and this process can open it read-write — the mode a real

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -136,6 +136,71 @@ fn run_mvmctl_isolated_live_home(world: &mut CliWorld, args: String) {
     world.last_run = Some(output);
 }
 
+/// Install the operator-supplied `.mvmpkg` into an isolated home and remember
+/// the content address it registered under. The `@bundle` capability gate
+/// guarantees the fixture exists before this scenario is selected.
+#[when(expr = "I install the bundle fixture")]
+fn install_bundle_fixture(world: &mut CliWorld) {
+    let fixture = crate::bundle_fixture_path()
+        .expect("`@bundle` scenarios only run when MVM_BDD_BUNDLE names a real file");
+    if world.isolated_home.is_none() {
+        world.isolated_home = Some(tempfile::tempdir().expect("create isolated MVM_HOME"));
+    }
+    let home = world
+        .isolated_home
+        .as_ref()
+        .expect("isolated home is set above");
+    let output = mvmctl_command()
+        .current_dir(workspace_root())
+        .args(["bundle", "install"])
+        .arg(&fixture)
+        .env("MVM_HOME", home.path())
+        .output()
+        .expect("failed to spawn mvmctl");
+    // `Installed bundle <sha> (N artifacts, publisher key_id=...)`
+    world.bundle_sha = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find_map(|line| line.strip_prefix("Installed bundle "))
+        .and_then(|rest| rest.split_whitespace().next())
+        .map(str::to_string);
+    world.last_run = Some(output);
+}
+
+#[then(expr = "the install reports a bundle content address")]
+fn install_reports_bundle_sha(world: &mut CliWorld) {
+    let sha = world
+        .bundle_sha
+        .as_deref()
+        .expect("bundle install printed no content address");
+    assert_eq!(sha.len(), 64, "expected a 64-char sha256, got {sha:?}");
+    assert!(
+        sha.chars().all(|c| c.is_ascii_hexdigit()),
+        "content address is not hex: {sha:?}"
+    );
+}
+
+/// Boot the bundle the previous step installed, by content address. `args` is
+/// appended after `machine run --manifest <sha>`.
+#[when(expr = "I boot the installed bundle with {string}")]
+fn boot_installed_bundle(world: &mut CliWorld, args: String) {
+    let sha = world
+        .bundle_sha
+        .clone()
+        .expect("no installed bundle — run the install step first");
+    let home = world
+        .isolated_home
+        .as_ref()
+        .expect("install step creates the isolated home");
+    let output = mvmctl_command()
+        .current_dir(workspace_root())
+        .args(["machine", "run", "--manifest", &sha])
+        .args(args.split_whitespace())
+        .env("MVM_HOME", home.path())
+        .output()
+        .expect("failed to spawn mvmctl");
+    world.last_run = Some(output);
+}
+
 #[then(expr = "the isolated mvm home does not contain directory {string}")]
 fn isolated_home_no_dir(world: &mut CliWorld, rel: String) {
     let home = world

--- a/crates/mvm-conformance/tests/steps/warm_claim.rs
+++ b/crates/mvm-conformance/tests/steps/warm_claim.rs
@@ -72,6 +72,8 @@ fn seed_parent(world: &mut CliWorld, chain_carries_creation_entry: bool) {
     let pool = SupervisorStandbyPool::at(store_root.path().join("pool"));
     let handle = StandbyHandle {
         id: "warm-parent".into(),
+        // Not template-bound: this fixture claims by kernel identity.
+        template_id: None,
         control_socket: store_root.path().join("control.sock").display().to_string(),
         pid: 0,
         kernel_sha256: "k".repeat(64),

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -34,6 +34,9 @@ pub struct CliWorld {
     pub isolated_home: Option<tempfile::TempDir>,
     /// Whether live CLI steps should keep one warm standby for the next run.
     pub warm_residency: bool,
+    /// Content address of the bundle a `bundle install` step registered, so the
+    /// boot step can name it as `machine run --manifest <sha>`.
+    pub bundle_sha: Option<String>,
     /// Local kernel pins accumulated by the freshness-watcher scenarios.
     pub kernel_pins: Vec<KernelPin>,
     /// Latest upstream point release per `MAJOR.MINOR` series, as those same

--- a/features/suites/s13_bundle_boot/signed_bundle_boot.feature
+++ b/features/suites/s13_bundle_boot/signed_bundle_boot.feature
@@ -1,0 +1,20 @@
+Feature: Signed bundle boot on a runtime-only host
+
+  The edge/runtime-only path: a host that never builds anything installs a
+  signed, content-addressed `.mvmpkg` and boots it by content address. This is
+  what a remote host does with a bundle published from a build machine — verify,
+  admit, boot — with no flake, no builder VM and no network fetch of an image.
+
+  Sealing a bundle is a full image build, far too slow to do inline, so the
+  archive is supplied by the operator with `MVM_BDD_BUNDLE=<path to .mvmpkg>`.
+  These scenarios boot a real Firecracker microVM, so on top of that they need
+  `MVM_BDD_LIVE`, a usable `/dev/kvm` and a `firecracker` binary; the harness
+  skips them cleanly wherever any of that is missing.
+
+  @live @firecracker @bundle
+  Scenario: a published bundle installs by content address and boots
+    When I install the bundle fixture
+    Then the command exits with code 0
+    And the install reports a bundle content address
+    When I boot the installed bundle with "--entrypoint --timeout 120"
+    Then the command exits with code 0


### PR DESCRIPTION
## What

The first BDD scenario for the runtime-only edge path: a host that never builds anything installs a signed, content-addressed `.mvmpkg` and boots it by content address.

```gherkin
@live @firecracker @bundle
Scenario: a published bundle installs by content address and boots
  When I install the bundle fixture
  Then the command exits with code 0
  And the install reports a bundle content address
  When I boot the installed bundle with "--entrypoint --timeout 120"
  Then the command exits with code 0
```

## Why now

This chain did not work until recently — `bundle export` shipped bundles the runtime refused (missing guest sidecar), Firecracker rejected ARM64 kernels outright, and the guest agent could not find its trust anchor on a vsock-only boot. With those fixed, the export → install → admit → boot path runs end to end, so it is worth pinning down against regression.

## Fixture gating

Sealing a bundle is a full image build — far too slow to do inline in a scenario — so the archive is operator-supplied via `MVM_BDD_BUNDLE=<path to .mvmpkg>`. That becomes a third capability on the existing `RuntimeCaps` probe, alongside the live opt-in and the KVM/firecracker check, so the scenario runs where a fixture exists and is **skipped cleanly, never failed**, everywhere else. Same fail-soft philosophy as the `@firecracker` gate.

The gate stays a pure, unit-tested function; only the harness touches the environment.

## Also fixes a broken build on main

The conformance test target does not currently compile on `main`:

```
error[E0063]: missing field `template_id` in initializer of `StandbyHandle`
  --> crates/mvm-conformance/tests/steps/warm_claim.rs:73
```

`StandbyHandle` gained `template_id` in #1874 without the conformance fixture being updated. It went unnoticed because the BDD job is `workflow_call`-only — it is invoked by the release/publish workflows and never runs on a PR, so nothing gates it. One-line fix included here because it blocks verifying anything in this crate.

Worth considering separately: running the hermetic BDD lane on PRs would have caught this at the source. It is cheap — it boots no VMs.

## Verification

- gate unit tests cover the new capability, including "everything else present but no fixture ⇒ skipped"
- the hermetic BDD lane still passes with the scenario skipped (no `MVM_BDD_LIVE`, no fixture)
- the underlying chain was exercised by hand on a live aarch64 Firecracker boot: install reports 3 artifacts, admission passes, guest reaches `control plane ready`
