### PR TITLE
perf(verb-grant): serialize the signature as base64 instead of a number array

### DIFF
--- a/crates/mvm-protocol/src/plan/verb_grant.rs
+++ b/crates/mvm-protocol/src/plan/verb_grant.rs
@@ -24,8 +24,35 @@ pub struct VerbGrant {
     pub plan_nonce: Nonce,
     pub not_after: DateTime<Utc>,
     pub verbs: Vec<VerbId>,
-    /// Raw Ed25519 signature bytes (64) over signing_bytes(); serialized as a JSON array.
+    /// Raw Ed25519 signature bytes (64) over signing_bytes(), serialized as
+    /// base64. A `Vec<u8>` would otherwise render as a JSON array of 64 decimal
+    /// numbers — roughly 230 characters against base64's 88 — and this grant
+    /// rides the guest kernel cmdline, where the budget is finite and silently
+    /// enforced. `sig` is excluded from `signing_bytes`, so how it is encoded
+    /// cannot affect signature validity.
+    #[serde(with = "sig_base64")]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
     pub sig: Vec<u8>,
+}
+
+/// Serializes the raw signature bytes as a base64 string rather than a JSON
+/// array of numbers.
+mod sig_base64 {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD as B64;
+    use serde::{Deserialize as _, Deserializer, Serialize as _, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+        B64.encode(bytes).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
+        let encoded = String::deserialize(deserializer)?;
+        B64.decode(encoded.as_bytes())
+            .map_err(serde::de::Error::custom)
+    }
 }
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -128,6 +155,46 @@ mod tests {
         assert!(
             g.verify(&k.verifying_key(), "sess-A", &nonce(), now)
                 .is_ok()
+        );
+    }
+
+    #[test]
+    fn sig_serializes_as_base64_and_still_verifies_after_a_round_trip() {
+        let now = Utc::now();
+        let (g, k) = signed(now, vec!["run-entrypoint"]);
+
+        let json = serde_json::to_string(&g).expect("grant serializes");
+        // A base64 string, not the JSON array of 64 numbers a bare Vec<u8> emits.
+        let expected = {
+            use base64::Engine as _;
+            base64::engine::general_purpose::STANDARD.encode(&g.sig)
+        };
+        assert!(
+            json.contains(&alloc::format!("\"sig\":\"{expected}\"")),
+            "sig is not base64-encoded: {json}"
+        );
+
+        let back: VerbGrant = serde_json::from_str(&json).expect("grant round-trips");
+        assert_eq!(
+            back.sig, g.sig,
+            "signature bytes must survive the round trip"
+        );
+        assert!(
+            back.verify(&k.verifying_key(), "sess-A", &nonce(), now)
+                .is_ok(),
+            "a round-tripped grant must still verify"
+        );
+    }
+
+    #[test]
+    fn sig_rejects_non_base64() {
+        let now = Utc::now();
+        let (g, _) = signed(now, vec!["ping"]);
+        let json = serde_json::to_string(&g).expect("grant serializes");
+        let broken = json.replace("\"sig\":\"", "\"sig\":\"!!!");
+        assert!(
+            serde_json::from_str::<VerbGrant>(&broken).is_err(),
+            "malformed base64 must fail closed"
         );
     }
 

--- a/crates/mvm-sdk/sdks/python/mvm/_protocol/protocol.py
+++ b/crates/mvm-sdk/sdks/python/mvm/_protocol/protocol.py
@@ -1417,7 +1417,7 @@ class VerbGrant:
     not_after: str
     plan_nonce: Nonce
     session_id: str
-    sig: List[int]
+    sig: str
     verbs: List[VerbId]
 
 

--- a/crates/mvm-sdk/sdks/typescript/src/protocol/protocol.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/protocol/protocol.ts
@@ -665,9 +665,9 @@ not_after: string
 plan_nonce: Nonce
 session_id: string
 /**
- * Raw Ed25519 signature bytes (64) over signing_bytes(); serialized as a JSON array.
+ * Raw Ed25519 signature bytes (64) over signing_bytes(), serialized as base64. A `Vec<u8>` would otherwise render as a JSON array of 64 decimal numbers — roughly 230 characters against base64's 88 — and this grant rides the guest kernel cmdline, where the budget is finite and silently enforced. `sig` is excluded from `signing_bytes`, so how it is encoded cannot affect signature validity.
  */
-sig: number[]
+sig: string
 verbs: VerbId[]
 }
 /**

--- a/schema/protocol-v0.json
+++ b/schema/protocol-v0.json
@@ -3531,13 +3531,8 @@
           "type": "string"
         },
         "sig": {
-          "description": "Raw Ed25519 signature bytes (64) over signing_bytes(); serialized as a JSON array.",
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          }
+          "description": "Raw Ed25519 signature bytes (64) over signing_bytes(), serialized as base64. A `Vec<u8>` would otherwise render as a JSON array of 64 decimal numbers — roughly 230 characters against base64's 88 — and this grant rides the guest kernel cmdline, where the budget is finite and silently enforced. `sig` is excluded from `signing_bytes`, so how it is encoded cannot affect signature validity.",
+          "type": "string"
         },
         "verbs": {
           "type": "array",


### PR DESCRIPTION
## Problem

`VerbGrant.sig` is 64 raw Ed25519 bytes held in a `Vec<u8>`, which serde renders as a JSON array of 64 decimal numbers. Measured on a real envelope captured from a live boot, that one field is **238 characters** where base64 needs **96**.

It matters because this grant rides the guest kernel cmdline, where the budget is finite and the kernel enforces it silently — the companion guard PR turns an overflow into a loud failure, and #1895 halved the transport encoding, but the payload itself was still carrying an inflated signature.

## Change

Serialize `sig` as base64 via a small `serde(with = ...)` module. Measured, from that same real envelope:

| | before | after |
|---|---|---|
| `sig` field | 238 chars | 96 chars |
| envelope JSON | 818 bytes | 676 bytes |
| `mvm.verb_grant=` token | 1092 chars | 904 chars |
| whole cmdline | 1381 bytes (67%) | **1193 bytes (58%)** |

Together with #1895 that takes the cmdline from its original 1925 bytes (94% of the 2048-byte `COMMAND_LINE_SIZE`) to 1193 (58%).

## Safety

`sig` is **excluded from `signing_bytes()`** — that function builds a separate `VerbGrantSigned` from session id, nonce, expiry and verbs, and there is an existing test asserting exactly that (`signing_bytes_are_stable_and_exclude_sig`). So how the signature is encoded cannot affect what is signed or whether verification succeeds.

New tests cover it directly: a grant round-trips through JSON with byte-identical signature bytes and **still verifies**, and malformed base64 fails closed. The pre-existing signature tests (valid, forged-key, wrong-session, wrong-nonce, expired) all still pass.

`mvm-protocol` remains `no_std` — the helper uses `alloc` only. Verified against both the bare-metal `riscv32imac-unknown-none-elf` target and `wasm32-unknown-unknown`.

## Scope

The only place a `VerbGrant` is persisted is the per-boot `verb-grant.json` sidecar in the host state dir, minted fresh on every admission, so there is no stored artifact to migrate. Regenerated SDK stubs are included (the schema type moves from a number array to a string).
