### PR TITLE
fix(mvm-runtime): frame Firecracker API responses on Content-Length, not EOF

### DIFF
--- a/crates/mvm-runtime/src/microvm/fc_api.rs
+++ b/crates/mvm-runtime/src/microvm/fc_api.rs
@@ -6,14 +6,24 @@
 //! critical section, which is a meaningful share of the restore latency budget.
 //!
 //! This talks to the socket directly. The wire format is small enough to build
-//! and parse by hand, so it costs no dependency: one request per connection
-//! with `Connection: close`, which means the response body is "everything until
-//! EOF" and no keep-alive or chunked-transfer state machine is needed.
+//! and parse by hand, so it costs no dependency.
 //!
-//! Request building and response parsing are pure functions so the wire format
-//! is unit-testable without a live VMM.
+//! **The body is framed by `Content-Length`, never by EOF.** Firecracker answers
+//! with `Connection: keep-alive` and holds the socket open even when the request
+//! asks it to close, so reading until EOF blocks until the socket timeout fires
+//! instead of returning the response. Observed against a live Firecracker:
+//!
+//! ```text
+//! HTTP/1.1 200
+//! Server: Firecracker API
+//! Connection: keep-alive
+//! Content-Length: 364
+//! ```
+//!
+//! Header parsing and body framing are pure functions over a `BufRead`, so the
+//! keep-alive behaviour is reproducible in unit tests without a live VMM.
 
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::time::Duration;
@@ -24,8 +34,13 @@ use anyhow::{Context, Result, bail};
 ///
 /// A live Firecracker answers these calls in well under a millisecond. This
 /// only exists so a wedged VMM surfaces as an error instead of hanging the
-/// caller forever — `curl` had no timeout here, so this is strictly tighter.
+/// caller forever; correct framing means it is not reached in normal operation.
 const IO_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Guard against a malformed or hostile `Content-Length` causing a huge
+/// allocation. Firecracker's largest response (`GET /vm/config`) is well under
+/// a kilobyte.
+const MAX_BODY_BYTES: usize = 1 << 20;
 
 /// A parsed Firecracker API response.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,8 +59,9 @@ impl FcResponse {
 
 /// Serialize a request. `body` is sent as JSON when present.
 ///
-/// `Connection: close` is deliberate — it lets the reader treat EOF as the end
-/// of the body rather than tracking keep-alive framing.
+/// `Connection: close` states the intent to use one request per connection.
+/// Firecracker does not honour it, which is why the reader must not depend on
+/// the server closing.
 fn build_request(method: &str, path: &str, body: Option<&str>) -> Vec<u8> {
     let mut req = format!(
         "{method} {path} HTTP/1.1\r\nHost: localhost\r\nAccept: application/json\r\nConnection: close\r\n"
@@ -64,38 +80,88 @@ fn build_request(method: &str, path: &str, body: Option<&str>) -> Vec<u8> {
     out
 }
 
-/// Parse a raw HTTP/1.1 response into its status and body.
-///
-/// Tolerates a body that is absent (204 and most Firecracker PUTs) and does not
-/// require `Content-Length`, since the connection close delimits the body.
-fn parse_response(raw: &[u8]) -> Result<FcResponse> {
-    let split = raw
-        .windows(4)
-        .position(|w| w == b"\r\n\r\n")
-        .context("malformed HTTP response: no header/body separator")?;
-    let head = std::str::from_utf8(&raw[..split])
-        .context("malformed HTTP response: headers are not valid UTF-8")?;
-    let body = String::from_utf8_lossy(&raw[split + 4..]).into_owned();
-
+/// Pull the status code out of a response head.
+fn parse_status(head: &str) -> Result<u16> {
     let status_line = head
         .lines()
         .next()
         .context("malformed HTTP response: empty status line")?;
     // "HTTP/1.1 204 No Content" -> 204
-    let status: u16 = status_line
+    status_line
         .split_whitespace()
         .nth(1)
         .context("malformed HTTP response: status line has no code")?
         .parse()
-        .with_context(|| format!("malformed HTTP response: bad status line {status_line:?}"))?;
+        .with_context(|| format!("malformed HTTP response: bad status line {status_line:?}"))
+}
+
+/// How many body bytes the response head promises.
+///
+/// `None` means no `Content-Length` header, which for Firecracker means an
+/// empty body (its `204`s carry no length). A `Transfer-Encoding` response
+/// would need chunked decoding; Firecracker never sends one, so it is rejected
+/// loudly rather than mis-framed silently.
+fn body_length(head: &str) -> Result<Option<usize>> {
+    let mut len = None;
+    for line in head.lines().skip(1) {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let name = name.trim();
+        let value = value.trim();
+        if name.eq_ignore_ascii_case("transfer-encoding") {
+            bail!("unsupported Transfer-Encoding {value:?} in Firecracker response");
+        }
+        if name.eq_ignore_ascii_case("content-length") {
+            let parsed: usize = value
+                .parse()
+                .with_context(|| format!("malformed Content-Length {value:?}"))?;
+            if parsed > MAX_BODY_BYTES {
+                bail!("Firecracker response Content-Length {parsed} exceeds {MAX_BODY_BYTES}");
+            }
+            len = Some(parsed);
+        }
+    }
+    Ok(len)
+}
+
+/// Read one response: headers up to the blank line, then exactly as many body
+/// bytes as `Content-Length` promises.
+///
+/// Never reads to EOF — the server keeps the connection open, so an EOF-framed
+/// read would block until the socket timeout.
+fn read_response<R: BufRead>(reader: &mut R) -> Result<FcResponse> {
+    let mut head = String::new();
+    loop {
+        let mut line = String::new();
+        let n = reader
+            .read_line(&mut line)
+            .context("reading Firecracker response headers")?;
+        if n == 0 {
+            bail!("Firecracker closed the connection before finishing the response headers");
+        }
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+        head.push_str(&line);
+    }
+
+    let status = parse_status(&head)?;
+    let body = match body_length(&head)? {
+        Some(0) | None => String::new(),
+        Some(len) => {
+            let mut buf = vec![0u8; len];
+            reader.read_exact(&mut buf).with_context(|| {
+                format!("reading {len} body byte(s) from the Firecracker response")
+            })?;
+            String::from_utf8_lossy(&buf).into_owned()
+        }
+    };
 
     Ok(FcResponse { status, body })
 }
 
 /// Send one request to the Firecracker API socket and read the response.
-///
-/// Returns the parsed response whatever the status — status interpretation is
-/// the caller's job via [`call`].
 fn round_trip(socket: &Path, method: &str, path: &str, body: Option<&str>) -> Result<FcResponse> {
     let mut stream = UnixStream::connect(socket)
         .with_context(|| format!("connecting to Firecracker API socket {}", socket.display()))?;
@@ -111,12 +177,9 @@ fn round_trip(socket: &Path, method: &str, path: &str, body: Option<&str>) -> Re
         .flush()
         .with_context(|| format!("flushing {method} {path} to Firecracker"))?;
 
-    let mut raw = Vec::new();
-    stream
-        .read_to_end(&mut raw)
-        .with_context(|| format!("reading Firecracker response to {method} {path}"))?;
-
-    parse_response(&raw).with_context(|| format!("parsing Firecracker response to {method} {path}"))
+    let mut reader = BufReader::new(&stream);
+    read_response(&mut reader)
+        .with_context(|| format!("reading Firecracker response to {method} {path}"))
 }
 
 /// Call the Firecracker API, failing on any non-2xx status.
@@ -134,8 +197,9 @@ pub(crate) fn call(socket: &Path, method: &str, path: &str, body: Option<&str>) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::BufRead;
+    use std::io::{Cursor, Read};
     use std::os::unix::net::UnixListener;
+    use std::sync::mpsc;
 
     #[test]
     fn build_request_without_body_sends_no_content_length() {
@@ -180,98 +244,143 @@ mod tests {
         );
     }
 
+    /// The regression. A real Firecracker answers `Connection: keep-alive` and
+    /// leaves the socket open, so more bytes may sit in the stream after this
+    /// response. Framing on `Content-Length` must stop exactly at the body; a
+    /// reader that consumed to EOF would swallow the trailing bytes.
     #[test]
-    fn parse_response_reads_status_and_body() {
-        let raw = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"vcpu_count\":2}";
-        let resp = parse_response(raw).unwrap();
+    fn read_response_stops_at_content_length_and_ignores_trailing_bytes() {
+        let wire = concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "Server: Firecracker API\r\n",
+            "Connection: keep-alive\r\n",
+            "Content-Length: 16\r\n",
+            "\r\n",
+            r#"{"vcpu_count":2}"#,
+            "HTTP/1.1 200 OK\r\n\r\nLEFTOVER-FROM-NEXT-RESPONSE",
+        );
+        let mut cur = Cursor::new(wire.as_bytes());
+        let resp = read_response(&mut cur).unwrap();
         assert_eq!(resp.status, 200);
-        assert_eq!(resp.body, r#"{"vcpu_count":2}"#);
+        assert_eq!(
+            resp.body, r#"{"vcpu_count":2}"#,
+            "body must stop at Content-Length, not run to EOF"
+        );
     }
 
-    /// Firecracker answers most PUT/PATCH calls with an empty 204.
+    /// Firecracker answers most PUT/PATCH calls with an empty 204 and no
+    /// `Content-Length`.
     #[test]
-    fn parse_response_handles_empty_body() {
-        let resp = parse_response(b"HTTP/1.1 204 No Content\r\n\r\n").unwrap();
+    fn read_response_treats_absent_content_length_as_empty_body() {
+        let wire = "HTTP/1.1 204 No Content\r\nConnection: keep-alive\r\n\r\n";
+        let mut cur = Cursor::new(wire.as_bytes());
+        let resp = read_response(&mut cur).unwrap();
         assert_eq!(resp.status, 204);
         assert_eq!(resp.body, "");
         assert!(resp.is_success());
     }
 
     #[test]
-    fn parse_response_surfaces_error_status() {
-        let raw = b"HTTP/1.1 400 Bad Request\r\n\r\n{\"fault_message\":\"nope\"}";
-        let resp = parse_response(raw).unwrap();
+    fn read_response_surfaces_error_status_with_its_fault_body() {
+        let body = r#"{"fault_message":"nope"}"#;
+        let wire = format!(
+            "HTTP/1.1 400 Bad Request\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut cur = Cursor::new(wire.as_bytes());
+        let resp = read_response(&mut cur).unwrap();
         assert_eq!(resp.status, 400);
         assert!(!resp.is_success());
+        assert!(resp.body.contains("nope"));
     }
 
     #[test]
-    fn parse_response_rejects_garbage() {
-        assert!(parse_response(b"not http at all").is_err());
+    fn read_response_rejects_garbage_and_truncation() {
+        assert!(read_response(&mut Cursor::new(&b"not http at all"[..])).is_err());
         assert!(
-            parse_response(b"HTTP/1.1\r\n\r\n").is_err(),
+            read_response(&mut Cursor::new(&b"HTTP/1.1\r\n\r\n"[..])).is_err(),
             "no status code"
         );
+        assert!(
+            read_response(&mut Cursor::new(
+                &b"HTTP/1.1 200 OK\r\nContent-Length: 99\r\n\r\nshort"[..]
+            ))
+            .is_err(),
+            "body shorter than Content-Length must fail, not silently truncate"
+        );
     }
 
-    /// Serve one canned response on a real Unix socket, so the client is
-    /// exercised end to end — connect, write, read, parse — without a VMM.
-    fn serve_once(
-        dir: &Path,
-        response: &'static str,
-    ) -> (std::path::PathBuf, std::thread::JoinHandle<String>) {
-        let sock = dir.join("fc.socket");
-        let listener = UnixListener::bind(&sock).unwrap();
-        let handle = std::thread::spawn(move || {
-            let (mut conn, _) = listener.accept().unwrap();
-            // Read just the request head; the client sends Connection: close
-            // but keeps the socket open for the reply.
-            let mut reader = std::io::BufReader::new(conn.try_clone().unwrap());
-            let mut request = String::new();
-            loop {
-                let mut line = String::new();
-                if reader.read_line(&mut line).unwrap() == 0 || line == "\r\n" {
-                    break;
-                }
-                request.push_str(&line);
-            }
-            conn.write_all(response.as_bytes()).unwrap();
-            conn.flush().unwrap();
-            drop(conn);
-            request
-        });
-        (sock, handle)
+    /// Chunked framing would be mis-read as an empty body. Fail loudly instead.
+    #[test]
+    fn read_response_rejects_chunked_transfer_encoding() {
+        let wire = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nabcd\r\n0\r\n\r\n";
+        let err = read_response(&mut Cursor::new(wire.as_bytes())).unwrap_err();
+        assert!(err.to_string().contains("Transfer-Encoding"), "got: {err}");
     }
 
     #[test]
-    fn call_round_trips_against_a_real_socket() {
-        let dir = tempfile::tempdir().unwrap();
-        let (sock, server) =
-            serve_once(dir.path(), "HTTP/1.1 200 OK\r\n\r\n{\"machine-config\":{}}");
+    fn body_length_rejects_absurd_content_length() {
+        let head = format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n", usize::MAX);
+        assert!(body_length(&head).is_err());
+    }
 
-        let body = call(&sock, "GET", "/vm/config", None).unwrap();
+    /// Serve one canned response over a real socket **without closing it**,
+    /// mirroring Firecracker's keep-alive behaviour. The connection is held
+    /// open until the test releases it, so a client that framed on EOF would
+    /// block here instead of returning.
+    fn serve_keep_alive(
+        dir: &Path,
+        response: &'static str,
+    ) -> (
+        std::path::PathBuf,
+        mpsc::Sender<()>,
+        std::thread::JoinHandle<()>,
+    ) {
+        let sock = dir.join("fc.socket");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let handle = std::thread::spawn(move || {
+            let (mut conn, _) = listener.accept().unwrap();
+            let mut req = [0u8; 1024];
+            let _ = conn.read(&mut req);
+            conn.write_all(response.as_bytes()).unwrap();
+            conn.flush().unwrap();
+            // Hold the connection open — this is what reproduces the bug.
+            let _ = release_rx.recv();
+        });
+        (sock, release_tx, handle)
+    }
+
+    #[test]
+    fn call_returns_against_a_keep_alive_server() {
+        let dir = tempfile::tempdir().unwrap();
+        let (sock, release, server) = serve_keep_alive(
+            dir.path(),
+            "HTTP/1.1 200 OK\r\nServer: Firecracker API\r\nConnection: keep-alive\r\nContent-Length: 21\r\n\r\n{\"machine-config\":{}}",
+        );
+
+        let body = call(&sock, "GET", "/vm/config", None).expect("must not hang on keep-alive");
         assert_eq!(body, r#"{"machine-config":{}}"#);
 
-        let request = server.join().unwrap();
-        assert!(
-            request.starts_with("GET /vm/config HTTP/1.1\r\n"),
-            "server saw: {request:?}"
-        );
+        let _ = release.send(());
+        server.join().unwrap();
     }
 
     #[test]
     fn call_fails_on_non_2xx_and_reports_the_fault_body() {
         let dir = tempfile::tempdir().unwrap();
-        let (sock, server) = serve_once(
+        let (sock, release, server) = serve_keep_alive(
             dir.path(),
-            "HTTP/1.1 400 Bad Request\r\n\r\n{\"fault_message\":\"bad drive\"}",
+            "HTTP/1.1 400 Bad Request\r\nConnection: keep-alive\r\nContent-Length: 28\r\n\r\n{\"fault_message\":\"bad drive\"}",
         );
 
         let err = call(&sock, "PUT", "/drives/rootfs", Some("{}")).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("400"), "got: {msg}");
         assert!(msg.contains("bad drive"), "fault body must surface: {msg}");
-        let _ = server.join().unwrap();
+
+        let _ = release.send(());
+        server.join().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a regression I introduced in #1901. The native Firecracker API client sent
`Connection: close` and then read to EOF, treating the close as the body
delimiter. **Firecracker ignores that header** — it answers `Connection:
keep-alive` and holds the socket open — so EOF never arrives, every call blocked
until the 30 s socket timeout, and then failed.

Confirmed against a live Firecracker on the KVM box:

```
HTTP/1.1 200
Server: Firecracker API
Connection: keep-alive
Content-Length: 364
→ no EOF: read_to_end blocks until timeout
```

All four `FirecrackerIO` calls were affected — pause, snapshot create,
device-model read, resume — so the warm-restore path was **worse off than the
`curl` subprocesses it replaced**.

## The fix

Read the head line by line, then exactly the number of body bytes
`Content-Length` promises. An absent length means an empty body, which is what
Firecracker's `204`s carry. `Transfer-Encoding` is rejected loudly rather than
silently mis-framed, and an absurd `Content-Length` is refused before
allocating.

## Why the original tests missed it

The server double did `drop(conn)` after writing — it **closed the connection**,
which is exactly the assumption under test and exactly what Firecracker does not
do. Ten green tests, none of which exercised the real framing. A double that
mirrors the belief can't falsify it.

Now:

- `serve_keep_alive` holds the connection open until the test releases it,
  reproducing Firecracker's behaviour.
- Framing is exercised through a `BufRead`, so `read_response` is testable
  without a socket at all — including a response followed by trailing bytes from
  a "next" response, which an EOF reader would swallow.
- Added coverage for chunked rejection, truncated bodies, and oversized
  `Content-Length`.

**The regression test was verified to actually catch the bug:** against the
previous EOF-framed implementation `call_returns_against_a_keep_alive_server`
fails (hangs to the timeout); against this one it passes.

## Validation

- `cargo test -p mvm-runtime --lib -- --test-threads=1` — 1,088 passed, 4 ignored.
- `cargo check --workspace --all-targets` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo +nightly fmt --all -- --check` — clean.

Credit: a parallel session independently spotted the same keep-alive behaviour.
