### PR TITLE
test(hvf): clean up MVM_HVF_SUPERVISOR_PATH env after vsock-convergence tests

### DIFF
--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -2097,6 +2097,10 @@ mod tests {
             "OCI --image runs with outbound egress enabled",
         )
         .expect_err("unavailable hvf must fail closed before OCI work");
+        // SAFETY: test-only env mutation.
+        unsafe {
+            std::env::remove_var("MVM_HVF_SUPERVISOR_PATH");
+        }
         // HVF always advertises the NIC-less host-vsock-proxy egress caps (they
         // are unconditional — the fail-closed posture), so the capability
         // shortfall is empty and the refusal comes from the availability probe:

--- a/crates/mvm-runtime/src/hvf_backend.rs
+++ b/crates/mvm-runtime/src/hvf_backend.rs
@@ -768,6 +768,10 @@ mod tests {
         let mut env = TestEnv::new();
         env.set("MVM_HVF_SUPERVISOR_PATH", "/no/such/mvm-hvf-supervisor");
         let caps = HvfBackend.capabilities();
+        // SAFETY: test-only env mutation.
+        unsafe {
+            std::env::remove_var("MVM_HVF_SUPERVISOR_PATH");
+        }
         // Fail-closed: even a degraded host (unlaunchable supervisor) advertises
         // no routable NIC and the host vsock proxy, so egress can only ride the
         // per-VM endpoint — it never falls back to a guest NIC. Only the dev-tier


### PR DESCRIPTION
Rebases the HVF vsock-convergence branch onto main. The functional HVF converge + fail-closed egress changes were already merged via earlier work; this branch now contains only the test-side env cleanup that prevents `MVM_HVF_SUPERVISOR_PATH` from leaking between tests.

- Adds `std::env::remove_var` cleanup in `mvm-cli/src/exec.rs` and `mvm-runtime/src/hvf_backend.rs` tests.
- `cargo clippy -p mvm-runtime -p mvm-cli -- -D warnings` passes.
- `cargo nextest run -p mvm-runtime hvf` passes (91 tests).
- `cargo run -p xtask -- check-uniform-vsock-egress` passes.
