### PR TITLE
fix(runtime): pin the host-signer anchor even when no verb grant is minted

### DIFF
--- a/crates/mvm-runtime/src/microvm/egress_bridge.rs
+++ b/crates/mvm-runtime/src/microvm/egress_bridge.rs
@@ -21,12 +21,22 @@ pub(crate) fn require_grant_cmdline_token(vm_name: &str) -> Option<String> {
 
 const HOST_SIGNER_PUBKEY_FILENAME: &str = "host-signer.pub";
 
-/// The public host-signer key token used to verify an admitted verb grant.
+/// The host's public signing key, pinned into every guest as the anchor its
+/// agent authenticates the control channel against.
+///
+/// Deliberately NOT gated on the verb-grant sidecar. The host-signer key is host
+/// *identity* — who the guest is talking to — while a verb grant is workload
+/// *authority*, what that workload may ask for. They are separate questions, and
+/// tying the anchor to the grant meant a launch that mints no grant (the
+/// transient run path, and a factory standby parent) shipped no anchor either:
+/// the agent then rejects every control connection for want of a pinned key and
+/// the run dies at the first RPC.
+///
+/// Withholding the grant still withholds authority — `mvm.verb_grant` and
+/// `mvm.require_grant` below remain sidecar-gated, so a guest that gets only
+/// this token is reachable but no more privileged than before.
 pub(crate) fn host_signer_pub_cmdline_token(vm_name: &str) -> Option<String> {
-    let sidecar = mvm_core::config::vm_state_dir(vm_name).join("verb-grant.json");
-    if !sidecar.exists() {
-        return None;
-    }
+    let _ = vm_name;
     let pubkey_path = mvm_core::config::mvm_keys_dir().join(HOST_SIGNER_PUBKEY_FILENAME);
     let bytes = std::fs::read(&pubkey_path).ok()?;
     if bytes.len() != 32 {
@@ -40,6 +50,7 @@ pub(crate) fn host_signer_pub_cmdline_token(vm_name: &str) -> Option<String> {
 mod tests {
     use super::*;
 
+    /// Authority tokens stay sidecar-gated: no grant, no verbs.
     #[test]
     fn grant_tokens_require_the_sidecar() {
         let dir = tempfile::tempdir().unwrap();
@@ -48,7 +59,39 @@ mod tests {
         let vm_name = "missing-grant";
         assert!(verb_grant_cmdline_token(vm_name).is_none());
         assert!(require_grant_cmdline_token(vm_name).is_none());
-        assert!(host_signer_pub_cmdline_token(vm_name).is_none());
+    }
+
+    /// The host-identity anchor ships even when no grant is minted. Gating it on
+    /// the sidecar left the transient run path (which mints none) with no pinned
+    /// key, so the agent refused every control connection and the run died at
+    /// its first RPC. Identity is not authority.
+    #[test]
+    fn host_signer_token_ships_without_a_grant_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", dir.path());
+        let keys = mvm_core::config::mvm_keys_dir();
+        std::fs::create_dir_all(&keys).unwrap();
+        std::fs::write(keys.join(HOST_SIGNER_PUBKEY_FILENAME), [0xABu8; 32]).unwrap();
+
+        let vm_name = "no-grant-but-reachable";
+        assert!(
+            host_signer_pub_cmdline_token(vm_name).is_some(),
+            "a guest with no verb grant must still be able to authenticate the host"
+        );
+        // ...and it gains no authority from that.
+        assert!(verb_grant_cmdline_token(vm_name).is_none());
+        assert!(require_grant_cmdline_token(vm_name).is_none());
+    }
+
+    /// No host key on disk is still no token — the anchor is only emitted when
+    /// there is a real key to pin.
+    #[test]
+    fn host_signer_token_absent_when_the_host_has_no_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", dir.path());
+        assert!(host_signer_pub_cmdline_token("no-key").is_none());
     }
 
     #[test]
@@ -71,9 +114,6 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut env = mvm_core::util::test_env::TestEnv::new();
         env.set("MVM_HOME", dir.path());
-        let state = mvm_core::config::vm_state_dir("grant");
-        std::fs::create_dir_all(&state).unwrap();
-        std::fs::write(state.join("verb-grant.json"), b"{}").unwrap();
         let keys = mvm_core::config::mvm_keys_dir();
         std::fs::create_dir_all(&keys).unwrap();
         std::fs::write(keys.join(HOST_SIGNER_PUBKEY_FILENAME), [0u8; 31]).unwrap();

--- a/crates/mvm-runtime/src/workload_runner/cmdline.rs
+++ b/crates/mvm-runtime/src/workload_runner/cmdline.rs
@@ -373,6 +373,11 @@ mod tests {
     #[test]
     fn runner_cmdline_synthesizes_a_base_when_workload_cmdline_takes_the_shortcut() {
         let dir = tempfile::tempdir().unwrap();
+        // Isolate MVM_HOME: the host-signer anchor is read from the keys dir, so
+        // without this the assertions depend on whether the developer running the
+        // suite happens to have a host key on disk.
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", dir.path());
         let config = VmStartConfig {
             rootfs_path: "/img/rootfs.ext4".into(),
             volumes: vec![disk_volume("/vol/data.img", "/data")],
@@ -398,6 +403,10 @@ mod tests {
     #[test]
     fn runner_cmdline_is_empty_when_neither_base_nor_volumes_are_present() {
         let dir = tempfile::tempdir().unwrap();
+        // See the note above: an un-isolated MVM_HOME leaks the real host key in
+        // as a `mvm.host_signer_pub=` token and this is no longer empty.
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", dir.path());
         let config = VmStartConfig::default();
         assert_eq!(
             runner_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs),


### PR DESCRIPTION
## What's broken

Since authenticated vsock control landed (#1834), the guest agent refuses any control connection without a pinned host key:

```rust
let Some(host_signer_key) = boot_state.host_signer_key() else {
    eprintln!("mvm-guest-agent: rejecting control connection without a pinned host key");
```

It takes that key from `mvm.host_signer_pub=<hex>` on the kernel cmdline — but the token was gated on the per-VM **verb-grant sidecar**:

```rust
pub(crate) fn host_signer_pub_cmdline_token(vm_name: &str) -> Option<String> {
    let sidecar = ...join("verb-grant.json");
    if !sidecar.exists() { return None; }   // no sidecar => no host identity
```

The transient `machine run` path mints no grant (grants are for entrypoint-prod runs), so it shipped no anchor either. The agent then rejected every control connection and the run died at its first RPC.

**This is live on `main` today**, not a branch regression — reproduced on a KVM host against real Firecracker at `e985cb5eb`:

```
$ mvmctl machine run --image docker.io/library/alpine:latest \
      --hypervisor firecracker echo hello-from-guest
Error: Failed to read frame length
EXIT=1
```

## The change

The host-signer key is host **identity** — who the guest is talking to. A verb grant is workload **authority** — what that workload may ask for. Gating the anchor on the grant conflated them, so withholding authority silently withheld the ability to authenticate at all.

The anchor now ships whenever the host has a key. `mvm.verb_grant` and `mvm.require_grant` stay sidecar-gated exactly as before, so a guest without a grant becomes **reachable without becoming more privileged** — asserted directly in `host_signer_token_ships_without_a_grant_sidecar`.

## Proof

Same host, same command, same isolated `MVM_HOME`; only the commit differs:

```
$ mvmctl machine run --image docker.io/library/alpine:latest \
      --hypervisor firecracker echo hello-from-guest
hello-from-guest
EXIT=0
```

## Testing

`cargo nextest run --workspace`: 7956 passed. Three pre-existing `mvm-build` `ensure_builder_vm_image_*` failures are unrelated and untouched by this branch (they assert `ensure_builder_vm_image()` errors without a `cmdline.txt`, but it now synthesizes one).

## A latent test bug this surfaced

Two `runner_cmdline` tests asserted an empty cmdline while never isolating `MVM_HOME`, so they had been reading the developer's real `~/.mvm/keys/host-signer.pub`; the old sidecar gate happened to mask it. They now set `MVM_HOME` like their neighbours — otherwise they pass or fail depending on whether the machine running the suite has a host key.

## Also unblocks

This is the same decoupling Plan 255's live-FC validation identified for its first blocker (a restored standby child is structurally unauthorizable because a factory parent boots with no host-signer anchor). Fixing it here should dissolve that blocker too.
