### PR TITLE
test(runtime): assert a grant-less launch still pins the host anchor

### DIFF
--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -1255,6 +1255,77 @@ mod tests {
         std::fs::write(keys_dir.join("host-signer.pub"), [0xEEu8; 32]).unwrap();
     }
 
+    /// Seed only the host key — no verb-grant sidecar. Models the transient
+    /// `machine run` path, which mints no grant.
+    fn seed_host_key_only() {
+        let keys_dir = mvm_core::config::mvm_keys_dir();
+        std::fs::create_dir_all(&keys_dir).unwrap();
+        std::fs::write(keys_dir.join("host-signer.pub"), [0xEEu8; 32]).unwrap();
+    }
+
+    /// A launch that mints no verb grant must still carry the host-signer
+    /// anchor, or its guest agent has no pinned key to authenticate the control
+    /// channel against, rejects every connection, and the run dies at its first
+    /// RPC.
+    ///
+    /// The sibling test below covers the grant-*bearing* launch, and that was
+    /// exactly the gap: the anchor used to be gated on the grant sidecar, so the
+    /// grant-less shape shipped no anchor and nothing at this level noticed.
+    /// Asserting the token builder alone did not catch it either — the
+    /// regression only surfaced in an assembled cmdline.
+    #[test]
+    fn start_carries_the_host_anchor_without_a_grant_but_grants_no_authority() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
+        let rootfs_dir = tempfile::tempdir().unwrap();
+        let rootfs = rootfs_dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"rootfs").unwrap();
+        let vm_name = "runner-grantless-anchor";
+        mvm_build::builder_vm::GuestSidecar::for_oci_run(vm_name, false, true)
+            .write_to_dir(rootfs_dir.path())
+            .unwrap();
+
+        seed_host_key_only();
+
+        let cfg = VmStartConfig {
+            name: vm_name.into(),
+            rootfs_path: rootfs.display().to_string(),
+            network_policy: NetworkPolicy::preset(mvm_core::network_policy::NetworkPreset::Dev),
+            ..Default::default()
+        };
+
+        let runner = WorkloadRunner::new(
+            MockDriver::default(),
+            RecordingSpawner::new("/run/ep.sock"),
+            RecordingBrokerRegistrar::new(),
+        );
+        runner.start(&cfg).expect("start succeeds");
+
+        let specs = runner.driver.booted_specs();
+        assert_eq!(specs.len(), 1);
+        let cmdline = &specs[0].cmdline;
+
+        assert!(
+            cmdline.contains("mvm.host_signer_pub="),
+            "a grant-less launch must still pin the host anchor, or the agent \
+             rejects every control connection: {cmdline}"
+        );
+        // Reachable, but no more privileged: authority stays sidecar-gated.
+        assert!(
+            !cmdline.contains("mvm.verb_grant="),
+            "no grant was minted, so no grant token may appear: {cmdline}"
+        );
+        assert!(
+            !cmdline.contains("mvm.require_grant="),
+            "no grant was minted, so enforcement must not be demanded: {cmdline}"
+        );
+    }
+
     /// `WorkloadRunner::start` (the `VmBackend::start` production path) must
     /// assemble the same security-bearing kernel cmdline the raw HVF backend
     /// does — dm-verity, the plan-bound grant triple, vsock egress, and the


### PR DESCRIPTION
## Why

#1907 fixed a live regression: a launch that mints no verb grant shipped no `mvm.host_signer_pub` anchor, so the guest agent rejected every control connection and `machine run` died at its first RPC on Linux/KVM. That broke the primary Firecracker path on `main` and was only caught by running against real hardware.

It should have been caught at PR time, and this closes that gap.

## The gap

`start_assembles_the_security_cmdline_tokens_via_the_shared_assembler` already asserts the assembled cmdline carries `mvm.host_signer_pub=` — but only for a launch that **has** a grant sidecar (`"sidecar present ⇒ enforcement token"`). The grant-less shape, which is exactly what the transient `machine run` path produces, was never asserted at the assembly level. The token-builder unit tests didn't catch it either: the regression only appears in a fully assembled cmdline.

## The test

`start_carries_the_host_anchor_without_a_grant_but_grants_no_authority` drives the real `VmBackend::start` path through `MockDriver` with a host key but **no** grant sidecar, and asserts both halves of the invariant:

- `mvm.host_signer_pub=` **is** present — identity, so the guest can authenticate the control channel;
- `mvm.verb_grant=` / `mvm.require_grant=` are **absent** — authority stays sidecar-gated, so reachable does not mean privileged.

Hermetic, ~13 ms, no VM — it runs in the existing workspace suite on every PR.

## Verified to actually catch it

Temporarily restoring the pre-#1907 gating makes it fail with the offending cmdline:

```
FAIL start_carries_the_host_anchor_without_a_grant_but_grants_no_authority
  a grant-less launch must still pin the host anchor, or the agent rejects every
  control connection: console=hvc0 panic=-1 nokaslr loglevel=8 root=/dev/vda rw
  init=/init mvm.runtime_source_policy=rootfs_only mvm.vsock_egress=1
```

Restoring the fix turns it green. A test that has never been seen to fail isn't a guard.

## Testing

`cargo nextest run --workspace`: 7957 passed. The three `mvm-build` `ensure_builder_vm_image_*` failures are pre-existing and untouched by this branch.

## Note on the live lane

`workload-spawn-smoke-linux` does boot real Firecracker with `/dev/kvm`, but it's `workflow_dispatch`-only and boots an empty 64 MiB ext4 rootfs, asserting only a kernel-boot marker — there is no guest agent in it, so it could not have caught this regardless. A true guest-RPC gate in CI would need real guest artifacts (OCI rootfs + runtime overlay + verity initrd + agent build); that's a larger piece of work, and this hermetic assertion covers the specific bug class for zero CI cost.
