### PR TITLE
feat(mvm-cli): machine warm-restore verb for vm_full checkpoints (supersedes #1910)

### DIFF
--- a/crates/mvm-cli/src/commands/machine/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/machine/checkpoint.rs
@@ -1,0 +1,68 @@
+//! User-facing warm fork/restore surface for `mvmctl machine warm-restore`.
+//!
+//! This routes into the Firecracker vm_full fork helpers in
+//! `commands::vm::checkpoint`, but presents a focused, backend-agnostic
+//! machine-level verb.
+
+use anyhow::{Context, Result, bail};
+use mvm_core::checkpoint::{CheckpointClass, CheckpointId};
+use mvm_core::config::vm_state_dir;
+use mvm_runtime::checkpoint::CheckpointStore;
+
+/// User-facing input to [`fork_vm_full_machine`].
+pub(in crate::commands) struct ForkVmFullMachineInput {
+    /// Checkpoint id to warm-restore.
+    pub checkpoint_id: String,
+    /// Desired child VM name; auto-generated if omitted.
+    pub child_vm_name: Option<String>,
+    /// Emit machine-readable JSON instead of human text.
+    pub json: bool,
+}
+
+/// User-facing Firecracker vm_full warm fork/restore.
+///
+/// Validates the checkpoint, generates a fresh child identity, admits a new
+/// claim-8 plan, restores the saved machine state through the FC fork path,
+/// and delivers the post-restore generation token. The user-facing verb
+/// implicitly opts into the experimental Firecracker vm_full fork path, so
+/// the lower-level env-var guard is bypassed here.
+pub(in crate::commands) fn fork_vm_full_machine(input: ForkVmFullMachineInput) -> Result<()> {
+    let checkpoint = crate::commands::vm::checkpoint::validated_checkpoint_id(&input.checkpoint_id)
+        .with_context(|| format!("invalid checkpoint id {:?}", input.checkpoint_id))?;
+    let store = CheckpointStore::open();
+    let parent_meta = store
+        .read_meta(&checkpoint)
+        .with_context(|| format!("reading checkpoint {}", input.checkpoint_id))?;
+
+    if parent_meta.class != CheckpointClass::VmFull {
+        bail!(
+            "checkpoint '{}' is class {:?}; warm-restore only supports vm_full checkpoints",
+            input.checkpoint_id,
+            parent_meta.class,
+        );
+    }
+
+    let now = crate::commands::vm::checkpoint::now_unix();
+    let child_vm_name = input
+        .child_vm_name
+        .unwrap_or_else(|| format!("{}-warm-{now}", checkpoint.as_str()));
+    mvm_core::naming::validate_vm_name(&child_vm_name)
+        .with_context(|| format!("invalid child VM name {child_vm_name:?}"))?;
+    let dest_dir = vm_state_dir(&child_vm_name);
+    let child_id = CheckpointId::new(format!("fork-{child_vm_name}-{now}"));
+
+    crate::commands::vm::checkpoint::fork_vm_full_arm_fc(
+        crate::commands::vm::checkpoint::ForkVmFullArmFcParams {
+            store: &store,
+            checkpoint: &checkpoint,
+            parent_meta,
+            child_vm_name,
+            dest_dir,
+            child_id,
+            now,
+            json: input.json,
+            bypass_experimental_guard: true,
+        },
+    )?;
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -14,6 +14,7 @@
 //! transient runner, while `exec` / `shell` / `stop` stay thin wrappers over
 //! the existing running-VM surfaces.
 
+mod checkpoint;
 mod lifecycle;
 mod portable;
 mod receipt;
@@ -50,6 +51,7 @@ use super::vm::host_signer::PUBLIC_FILENAME;
 use super::vm::host_signer::{host_signer_id, load_or_init};
 use super::vm::{console, down};
 use crate::ui;
+use checkpoint::{ForkVmFullMachineInput, fork_vm_full_machine};
 use lifecycle::{exec_machine, run_restart, run_start, shell_machine, stop_machine};
 #[cfg(test)]
 use receipt::verify_machine_start_receipt;
@@ -140,6 +142,11 @@ pub(in crate::commands) enum MachineAction {
     /// Advance one step: restore a child of the target (a fork needs `--to`).
     #[command(display_order = 17)]
     Advance(super::vm::checkpoint::AdvanceArgs),
+    /// Warm-restore a vm_full checkpoint into a fresh child VM.
+    /// The child inherits the saved machine state and receives a fresh
+    /// generation token; the parent must be stopped.
+    #[command(name = "warm-restore", display_order = 18)]
+    WarmRestore(MachineWarmRestoreArgs),
     /// Advanced single-VM operations (pause, snapshot, cp, fs, …). Hidden; use `machine <verb>` directly.
     #[command(flatten)]
     Vm(VmCmd),
@@ -173,6 +180,7 @@ impl MachineAction {
             MachineAction::Revert(_) => "revert",
             MachineAction::Rewind(_) => "rewind",
             MachineAction::Advance(_) => "advance",
+            MachineAction::WarmRestore(_) => "warm-restore",
         }
     }
 }
@@ -847,6 +855,18 @@ pub(in crate::commands) struct MachineReconfigureArgs {
     #[arg(long, value_name = "HYPERVISOR")]
     pub hypervisor: Option<String>,
 }
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct MachineWarmRestoreArgs {
+    /// vm_full checkpoint id to restore.
+    #[arg(value_name = "CHECKPOINT_ID")]
+    pub checkpoint: String,
+    /// Name for the fresh child VM (auto-generated if omitted).
+    #[arg(long, value_name = "NAME")]
+    pub name: Option<String>,
+    /// Output the result as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
 
 #[derive(Debug, Serialize)]
 struct MachineRemoveSummary {
@@ -1315,10 +1335,21 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
         MachineAction::Advance(a) => {
             complete_revert(cli, cfg, super::vm::checkpoint::run_advance(a)?)
         }
+        MachineAction::WarmRestore(args) => run_warm_restore(args),
         MachineAction::Vm(cmd) => {
             super::vm::group::run(cli, super::vm::group::Args { action: cmd }, cfg)
         }
     }
+}
+
+/// Run `machine warm-restore`: fork a vm_full checkpoint into a fresh child VM.
+fn run_warm_restore(args: MachineWarmRestoreArgs) -> Result<()> {
+    fork_vm_full_machine(ForkVmFullMachineInput {
+        checkpoint_id: args.checkpoint,
+        child_vm_name: args.name,
+        json: args.json,
+    })?;
+    Ok(())
 }
 
 /// Finish a restore. A checkpoint restore completes inside the engine (the fork

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -95,6 +95,7 @@ fn machine_subcommand(action: &MachineAction) -> &'static str {
         MachineAction::Revert(_) => "revert",
         MachineAction::Rewind(_) => "rewind",
         MachineAction::Advance(_) => "advance",
+        MachineAction::WarmRestore(_) => "warm-restore",
         MachineAction::Vm(_) => "vm",
     }
 }

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -238,7 +238,7 @@ struct CheckpointForkJson<'a> {
 /// otherwise produce an unsafe on-disk directory name. The id becomes a
 /// directory component under `checkpoints_dir()`, so path-traversal and
 /// control bytes must never reach the filesystem.
-fn validated_checkpoint_id(raw: &str) -> Result<CheckpointId> {
+pub(in crate::commands) fn validated_checkpoint_id(raw: &str) -> Result<CheckpointId> {
     if raw.is_empty() {
         bail!("invalid checkpoint id: empty");
     }
@@ -255,7 +255,7 @@ fn validated_checkpoint_id(raw: &str) -> Result<CheckpointId> {
     Ok(CheckpointId::new(raw.to_string()))
 }
 
-fn now_unix() -> u64 {
+pub(in crate::commands) fn now_unix() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -881,10 +881,59 @@ fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
 
     let parent_meta = p.store.read_meta(p.checkpoint)?;
 
+    fork_vm_full_arm_fc(ForkVmFullArmFcParams {
+        store: p.store,
+        checkpoint: p.checkpoint,
+        parent_meta,
+        child_vm_name,
+        dest_dir,
+        child_id,
+        now,
+        json: p.json,
+        bypass_experimental_guard: false,
+    })?;
+    Ok(())
+}
+
+/// Inputs for [`fork_vm_full_arm_fc`]. Grouped to stay under the
+/// `clippy::too_many_arguments` workspace ceiling.
+pub(in crate::commands) struct ForkVmFullArmFcParams<'a> {
+    pub(in crate::commands) store: &'a CheckpointStore,
+    pub(in crate::commands) checkpoint: &'a CheckpointId,
+    pub(in crate::commands) parent_meta: mvm_core::checkpoint::CheckpointMeta,
+    pub(in crate::commands) child_vm_name: String,
+    pub(in crate::commands) dest_dir: std::path::PathBuf,
+    pub(in crate::commands) child_id: CheckpointId,
+    pub(in crate::commands) now: u64,
+    pub(in crate::commands) json: bool,
+    /// When true, skip the `MVM_FORK_VMFULL_FC_EXPERIMENTAL` guard. The guard
+    /// stays on the lower-level `vm checkpoint fork` path; the user-facing
+    /// `machine warm-restore` verb opts in explicitly.
+    pub(in crate::commands) bypass_experimental_guard: bool,
+}
+
+/// FC vm_full fork: clone the captured triple, admit a fresh claim-8 plan for
+/// the child, rename `memory.bin` → `mem.bin`, and boot the child via a fresh
+/// Firecracker VMM loaded from the checkpoint snapshot.
+pub(in crate::commands) fn fork_vm_full_arm_fc(
+    p: ForkVmFullArmFcParams<'_>,
+) -> Result<mvm_core::checkpoint::CheckpointMeta> {
+    // FC vm_full fork loads a snapshot that still carries the parent's TAP
+    // name and guest MAC in bitcode. Remapping backing files is not enough to
+    // make a live-parent fork safe, so require the parent to be stopped first.
+    // The device-path remapping happens in a private mount namespace before
+    // the child Firecracker starts.
+    if vm_is_running(&p.parent_meta.vm_name) {
+        anyhow::bail!(
+            "Firecracker vm_full fork requires the parent VM '{}' to be stopped first;              live-parent fork would collide on the parent's TAP/MAC",
+            p.parent_meta.vm_name
+        );
+    }
+
     // Checkpoints captured under the removed Apple-Virtualization backend carry
     // a supervisor-config.json blob. Their full-VM fork is being re-homed onto
     // the in-house HVF VMM and is unavailable for now — refuse cleanly.
-    if checkpoint_is_vz(&parent_meta) {
+    if checkpoint_is_vz(&p.parent_meta) {
         anyhow::bail!(
             "this vm_full checkpoint was captured under a backend that has been removed; \
              its full-VM fork is being re-homed onto the in-house HVF VMM and is \
@@ -899,8 +948,9 @@ fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
     // side is remappable, but re-IP'ing the guest is a per-child network-model
     // decision that is not yet settled — refuse cleanly rather than boot a
     // colliding child. The restore mechanism stays reachable behind an explicit
-    // opt-in for isolated single-child testing on that model.
-    if !fc_vm_full_fork_experimental_enabled() {
+    // opt-in for isolated single-child testing on that model, unless the caller
+    // has already opted in (the user-facing `machine warm-restore` path).
+    if !p.bypass_experimental_guard && !fc_vm_full_fork_experimental_enabled() {
         anyhow::bail!(
             "forking a vm_full checkpoint on Firecracker is not yet supported: the \
              forked child inherits the parent's guest IP/MAC from the saved memory \
@@ -908,46 +958,6 @@ fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
              with the parent on the shared bridge. Use an fs_quick fork, or set \
              MVM_FORK_VMFULL_FC_EXPERIMENTAL=1 to exercise the restore on an isolated \
              single-child network."
-        );
-    }
-    fork_vm_full_arm_fc(ForkVmFullArmFcParams {
-        store: p.store,
-        checkpoint: p.checkpoint,
-        parent_meta,
-        child_vm_name,
-        dest_dir,
-        child_id,
-        now,
-        json: p.json,
-    })
-}
-
-/// Inputs for [`fork_vm_full_arm_fc`]. Grouped to stay under the
-/// `clippy::too_many_arguments` workspace ceiling.
-struct ForkVmFullArmFcParams<'a> {
-    store: &'a CheckpointStore,
-    checkpoint: &'a CheckpointId,
-    parent_meta: mvm_core::checkpoint::CheckpointMeta,
-    child_vm_name: String,
-    dest_dir: std::path::PathBuf,
-    child_id: CheckpointId,
-    now: u64,
-    json: bool,
-}
-
-/// FC vm_full fork: clone the captured triple, admit a fresh claim-8 plan for
-/// the child, rename `memory.bin` → `mem.bin`, and boot the child via a fresh
-/// Firecracker VMM loaded from the checkpoint snapshot.
-fn fork_vm_full_arm_fc(p: ForkVmFullArmFcParams<'_>) -> Result<()> {
-    // FC vm_full fork loads a snapshot that still carries the parent's TAP
-    // name and guest MAC in bitcode. Remapping backing files is not enough to
-    // make a live-parent fork safe, so require the parent to be stopped first.
-    // The device-path remapping happens in a private mount namespace before
-    // the child Firecracker starts.
-    if vm_is_running(&p.parent_meta.vm_name) {
-        anyhow::bail!(
-            "Firecracker vm_full fork requires the parent VM '{}' to be stopped first;              live-parent fork would collide on the parent's TAP/MAC",
-            p.parent_meta.vm_name
         );
     }
 
@@ -1093,7 +1103,7 @@ fn fork_vm_full_arm_fc(p: ForkVmFullArmFcParams<'_>) -> Result<()> {
             p.child_vm_name
         ));
     }
-    Ok(())
+    Ok(meta)
 }
 
 fn deliver_fc_fork_post_restore(

--- a/crates/mvm-cli/tests/cli.rs
+++ b/crates/mvm-cli/tests/cli.rs
@@ -192,3 +192,70 @@ fn ops_help_no_longer_lists_bench() {
         "ops help still lists the removed bench verb:\n{text}"
     );
 }
+
+/// `machine warm-restore --help` advertises the expected usage.
+#[test]
+fn machine_warm_restore_help_lists_args() {
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .args(["machine", "warm-restore", "--help"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "machine warm-restore --help must exit 0, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(help.contains("warm-restore"));
+    assert!(help.contains("CHECKPOINT_ID"));
+    assert!(help.contains("--name"));
+    assert!(help.contains("--json"));
+}
+
+/// A non-existent checkpoint id fails gracefully rather than panicking.
+#[test]
+fn machine_warm_restore_rejects_missing_checkpoint() {
+    let tmp = std::env::temp_dir().join(format!("mvm-warm-restore-test-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .env("MVM_HOME", &tmp)
+        .args(["machine", "warm-restore", "no-such-checkpoint"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "warm-restore must fail for a missing checkpoint; stderr: {stderr}"
+    );
+    assert!(!stderr.contains("panic"), "warm-restore panicked: {stderr}");
+    assert!(
+        !stderr.contains("thread panicked"),
+        "warm-restore panicked: {stderr}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// The `--json` output flag is accepted by the parser.
+#[test]
+fn machine_warm_restore_json_flag_parses() {
+    let tmp =
+        std::env::temp_dir().join(format!("mvm-warm-restore-json-test-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .env("MVM_HOME", &tmp)
+        .args(["machine", "warm-restore", "no-such-checkpoint", "--json"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("unexpected argument") && !stderr.contains("unrecognized"),
+        "--json must parse cleanly, stderr: {stderr}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -39,8 +39,9 @@ use mvm_core::vm_backend::{SnapshotCapability, VmStartConfig, WarmStartError};
 #[cfg(feature = "test-support")]
 use mvm_runtime::vm::instance_snapshot::CannedIO;
 use mvm_runtime::vm::instance_snapshot::{
-    FirecrackerIO, SnapshotIO, VsockPostRestoreSignal, VsockPrimedSignalSource,
-    await_primed_barrier, pause_and_seal, signal_post_restore, verify_and_resume,
+    FirecrackerIO, POST_RESTORE_READY_TIMEOUT, SnapshotIO, VsockPostRestoreSignal,
+    VsockPrimedSignalSource, await_primed_barrier, pause_and_seal, signal_post_restore,
+    verify_and_resume,
 };
 use mvm_runtime::vm::name_registry::{VmNameRegistry, VmRegistration};
 
@@ -202,8 +203,12 @@ fn signal_guest_post_restore(name: &str) -> Result<()> {
         "scope=rpc,direction=in,kind=vsock,verb={verb}",
         verb = "post-restore",
     );
-    signal_post_restore(name, &VsockPostRestoreSignal { token })
-        .map_err(|e| backend_err(format!("post-restore signal for {name:?}: {e:#}")))?;
+    signal_post_restore(
+        name,
+        &VsockPostRestoreSignal { token },
+        POST_RESTORE_READY_TIMEOUT,
+    )
+    .map_err(|e| backend_err(format!("post-restore signal for {name:?}: {e:#}")))?;
     Ok(())
 }
 

--- a/crates/mvm-core/fuzz/Cargo.lock
+++ b/crates/mvm-core/fuzz/Cargo.lock
@@ -4,30 +4,30 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
  "crypto-common",
- "generic-array",
+ "inout",
 ]
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
- "cfg-if",
  "cipher",
+ "cpubits",
  "cpufeatures",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
  "aes",
@@ -80,12 +80,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,11 +87,11 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -140,19 +134,26 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
+ "block-buffer",
  "crypto-common",
  "inout",
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
+name = "cmov"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation-sys"
@@ -161,39 +162,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "cpubits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "rand_core",
- "typenum",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
+name = "ctutils"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -213,50 +229,38 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "zeroize",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
- "serde",
  "sha2",
  "subtle",
  "zeroize",
@@ -286,9 +290,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -341,16 +345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,15 +376,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
 
@@ -408,11 +402,20 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -451,11 +454,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -555,7 +558,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mvm-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -568,6 +571,7 @@ dependencies = [
  "hmac",
  "ipnet",
  "keyring",
+ "mvm-protocol",
  "rand",
  "regex",
  "secrecy",
@@ -581,6 +585,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "unicode-normalization",
  "uuid",
  "zeroize",
 ]
@@ -591,6 +596,20 @@ version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
  "mvm-core",
+ "serde_json",
+]
+
+[[package]]
+name = "mvm-protocol"
+version = "0.18.0"
+dependencies = [
+ "base64",
+ "chrono",
+ "ed25519-dalek",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
 ]
 
 [[package]]
@@ -618,36 +637,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
- "cfg-if",
+ "cpubits",
  "cpufeatures",
- "opaque-debug",
  "universal-hash",
 ]
 
@@ -698,7 +700,7 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -708,7 +710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -719,6 +721,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "regex"
@@ -826,7 +834,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -842,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -864,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -890,12 +898,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core",
-]
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "slab"
@@ -910,16 +915,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +925,17 @@ name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -962,22 +968,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -988,6 +994,21 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
@@ -1049,7 +1070,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1117,13 +1138,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "universal-hash"
-version = "0.5.1"
+name = "unicode-normalization"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
@@ -1143,12 +1173,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1197,7 +1221,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -1253,7 +1277,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1264,7 +1288,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1342,7 +1366,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1362,7 +1386,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/crates/mvm-core/fuzz/Cargo.toml
+++ b/crates/mvm-core/fuzz/Cargo.toml
@@ -15,6 +15,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
+serde_json = "1"
 
 [dependencies.mvm-core]
 path = ".."

--- a/crates/mvm-core/fuzz/fuzz_targets/fuzz_snapshot_frame.rs
+++ b/crates/mvm-core/fuzz/fuzz_targets/fuzz_snapshot_frame.rs
@@ -1,33 +1,41 @@
-// Adversarial fuzz for the hardened snapshot-frame parser.
+// Adversarial fuzz for the hardened snapshot-frame parser and the
+// restore-load metadata parsers.
 //
-// Feeds arbitrary bytes to `mvm_core::snapshot_frame::parse_header` and
-// `parse_sections` and asserts the single property the format guarantees:
+// Feeds arbitrary bytes to:
 //
-//   the parser never panics on any byte input.
+//   * `mvm_core::snapshot_frame::parse_header` / `parse_sections`
+//   * `serde_json` deserialization of `IntegritySidecar`
+//     (`~/.mvm/instances/<vm>/snapshot/integrity.json`)
+//   * `serde_json` deserialization of `CheckpointMeta`
+//     (`~/.mvm/checkpoints/<id>/meta.json`)
 //
-// `parse_sections` exercises the whole chain — magic/version/arch checks,
-// `cap_count` against the section ceiling, and `checked_region` bounds/overflow
-// math — so a hostile header (huge counts, offsets past EOF, overflowing
-// offset+len) must fail closed with a typed `FrameError`, never an allocation
-// blow-up, slice OOB, or arithmetic overflow panic.
+// The single property asserted is crash-freedom: every host↔snapshot
+// type is `#[serde(deny_unknown_fields)]`, so a hostile metadata
+// stream must fail closed with a parse error rather than panic,
+// allocate unboundedly, or silently accept unexpected fields.
 //
 // CI gate: `.github/workflows/security.yml::fuzz`.
 
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+use mvm_core::checkpoint::CheckpointMeta;
+use mvm_core::crypto::snapshot_hmac::IntegritySidecar;
 use mvm_core::snapshot_frame::{parse_header, parse_sections};
 
 fuzz_target!(|data: &[u8]| {
+    // Snapshot-frame binary surface.
     let _ = parse_header(data);
-
-    // On success, every returned section region must be in bounds — slicing it
-    // must not panic. (`parse_sections` validates this via `checked_region`;
-    // the assertion makes a regression in that contract a fuzz crash.)
     if let Ok(sections) = parse_sections(data) {
         for section in &sections {
             let bytes = section.data(data);
             assert!(section.region.offset + bytes.len() <= data.len());
         }
     }
+
+    // Restore-load metadata surfaces: integrity sidecar and checkpoint meta.
+    // Both are strict JSON with `deny_unknown_fields`; arbitrary bytes must
+    // not panic the deserializer.
+    let _ = serde_json::from_slice::<IntegritySidecar>(data);
+    let _ = serde_json::from_slice::<CheckpointMeta>(data);
 });

--- a/crates/mvm-runtime/src/driver/traits.rs
+++ b/crates/mvm-runtime/src/driver/traits.rs
@@ -147,6 +147,7 @@ pub trait VmmDriver: Send + Sync {
         crate::vm::instance_snapshot::signal_post_restore(
             child_vm_name,
             &crate::vm::instance_snapshot::VsockPostRestoreSignal { token },
+            crate::vm::instance_snapshot::POST_RESTORE_READY_TIMEOUT,
         )
     }
 

--- a/crates/mvm-runtime/src/firecracker.rs
+++ b/crates/mvm-runtime/src/firecracker.rs
@@ -472,16 +472,23 @@ impl crate::checkpoint::ForkVmFullRestorer for FcForkRestorer {
         if let Some(parent) = anchors.rootfs_verity {
             mappings.push((parent, child_dir.join("rootfs.verity")));
         }
-        if let Some(parent) = anchors.config {
-            mappings.push((parent, child_dir.join("config.ext4")));
-        }
-        if let Some(parent) = anchors.secrets {
-            mappings.push((parent, child_dir.join("secrets.ext4")));
-        }
+        // The snapshot encodes absolute paths under the parent's VM state dir
+        // (vsock UDS, config drive, secrets drive). Remap the whole parent dir
+        // onto the child's state dir in a private mount namespace so every
+        // parent-prefixed path resolves to the child's copy without editing
+        // Firecracker bitcode. A file-level remap of the vsock UDS alone fails
+        // because the child socket does not exist until Firecracker creates it
+        // during snapshot load.
+        let parent_vm_dir = anchors
+            .vsock
+            .parent()
+            .and_then(|p| p.parent())
+            .ok_or_else(|| anyhow::anyhow!("FC fork anchors.vsock has no VM-dir parent"))?;
         mappings.push((
-            anchors.vsock,
-            std::path::PathBuf::from(crate::microvm::firecracker_vsock_uds_path(&child_vm_dir)),
+            parent_vm_dir.to_path_buf(),
+            std::path::PathBuf::from(&child_vm_dir),
         ));
+        std::fs::create_dir_all(child_dir.join("runtime")).ok();
         crate::microvm::remap_paths_for_fork(&mappings)
             .context("remapping parent device paths for FC fork")?;
 

--- a/crates/mvm-runtime/src/microvm/snapshot.rs
+++ b/crates/mvm-runtime/src/microvm/snapshot.rs
@@ -24,7 +24,8 @@ use tracing::instrument;
 
 use crate::base::shell::shell_quote;
 use crate::vm::instance_snapshot::{
-    FirecrackerIO, VsockPostRestoreSignal, guarded_load_resume, signal_post_restore,
+    FirecrackerIO, POST_RESTORE_READY_TIMEOUT, VsockPostRestoreSignal, guarded_load_resume,
+    signal_post_restore,
 };
 
 use super::daemon::api_put_socket;
@@ -113,7 +114,11 @@ pub fn warm_restore_instance_from_path(
     // caller passes an all-zero token (no rotation) and delivers the real
     // token + verb grant over vsock separately once it observes the agent is
     // reachable; a zero token's honest outcome is `NotRotated`, not `Rotated`.
-    let reseed = match signal_post_restore(name, &VsockPostRestoreSignal { token }) {
+    let reseed = match signal_post_restore(
+        name,
+        &VsockPostRestoreSignal { token },
+        POST_RESTORE_READY_TIMEOUT,
+    ) {
         Ok(outcome) if outcome.reseeded => mvm_core::vm_backend::ReseedStatus::Rotated,
         Ok(_) => mvm_core::vm_backend::ReseedStatus::NotRotated,
         Err(e) => {

--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -289,8 +289,12 @@ pub fn verify_and_resume_from_dir<IO: SnapshotIO + ?Sized>(
 /// sealed on disk, so a retry (after e.g. re-sealing a clean snapshot) is
 /// still possible.
 pub fn guarded_load_resume<IO: SnapshotIO + ?Sized>(io: &IO, dir: &Path) -> Result<()> {
-    io.load_snapshot_paused(dir)
-        .with_context(|| format!("load_snapshot_paused({})", dir.display()))?;
+    if let Err(e) = io.load_snapshot_paused(dir) {
+        // The VMM may be left paused after a failed load; do not let it sit
+        // alive with an unaudited device model.
+        let _ = io.teardown_paused();
+        return Err(e).context(format!("load_snapshot_paused({})", dir.display()));
+    }
     guard_and_resume(io)
 }
 
@@ -302,8 +306,11 @@ pub fn guarded_load_resume<IO: SnapshotIO + ?Sized>(io: &IO, dir: &Path) -> Resu
 /// resume are the same, so a fork cannot reach userspace unchecked or stay
 /// paused forever.
 pub(crate) fn guarded_fork_load_resume<IO: SnapshotIO + ?Sized>(io: &IO, dir: &Path) -> Result<()> {
-    io.load_snapshot_for_fork_paused(dir)
-        .with_context(|| format!("load_snapshot_for_fork_paused({})", dir.display()))?;
+    if let Err(e) = io.load_snapshot_for_fork_paused(dir) {
+        // A failed fork load must not leave a paused child VMM behind.
+        let _ = io.teardown_paused();
+        return Err(e).context(format!("load_snapshot_for_fork_paused({})", dir.display()));
+    }
     guard_and_resume(io)
 }
 
@@ -313,9 +320,18 @@ pub(crate) fn guarded_fork_load_resume<IO: SnapshotIO + ?Sized>(io: &IO, dir: &P
 /// Every load path funnels through here, so adding a new way to load a snapshot
 /// cannot silently bypass the guard.
 fn guard_and_resume<IO: SnapshotIO + ?Sized>(io: &IO) -> Result<()> {
-    let model = io
+    let model = match io
         .restored_device_model()
-        .with_context(|| "reading restored device model")?;
+        .with_context(|| "reading restored device model")
+    {
+        Ok(m) => m,
+        Err(e) => {
+            // The paused VMM has an unreadable device model; tear it down
+            // before surfacing the error so it never resumes unchecked.
+            let _ = io.teardown_paused();
+            return Err(e);
+        }
+    };
     if let Err(e) = crate::microvm::assert_vsock_only_device_model(&model) {
         let _ = io.teardown_paused();
         return Err(e).context("restore refused by device-model guard");
@@ -466,18 +482,48 @@ pub struct PostRestoreOutcome {
 /// `GuestRequest::PostRestore` all along, but nothing on the host sent it
 /// after a snapshot restore.
 pub trait PostRestoreSignal {
+    /// Probe whether the guest is ready to accept `PostRestore` without
+    /// actually sending the signal. Transient failures must return `false`
+    /// so the caller can poll up to its deadline; only a successful connect
+    /// (or equivalent) returns `true`.
+    fn probe_ready(&self, vm_name: &str) -> bool;
     fn post_restore(&self, vm_name: &str) -> Result<PostRestoreOutcome>;
 }
 
-/// After a snapshot restore resumes vCPUs, signal the guest to finish
-/// re-establishing itself. An *unacknowledged* signal is an error: the VM is
-/// running at the hypervisor level but its drives may be unmounted, so the
-/// resume is not actually complete — fail closed and let the operator retry
-/// (`PostRestore` is safe to re-send; SIGUSR1 just re-runs the remount).
+/// Interval between guest-readiness probes before delivering the post-restore
+/// signal.
+const POST_RESTORE_PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// How long a resumed guest gets to make its agent reachable before the
+/// post-restore signal is declared undelivered. Every production caller uses
+/// this so one restore does not get a quietly more generous deadline than
+/// another; tests pass their own.
+pub const POST_RESTORE_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// After a snapshot restore resumes vCPUs, wait for the guest agent to be
+/// reachable (so a slow-to-reattach guest does not spuriously report
+/// `Undelivered`), then signal the guest to finish re-establishing itself.
+/// An *unacknowledged* signal is an error: the VM is running at the
+/// hypervisor level but its drives may be unmounted, so the resume is not
+/// actually complete — fail closed and let the operator retry (`PostRestore`
+/// is safe to re-send; SIGUSR1 just re-runs the remount).
 pub fn signal_post_restore<S: PostRestoreSignal + ?Sized>(
     vm_name: &str,
     signal: &S,
+    ready_timeout: std::time::Duration,
 ) -> Result<PostRestoreOutcome> {
+    match wait_for_primed_polling(ready_timeout, POST_RESTORE_PROBE_INTERVAL, || {
+        signal.probe_ready(vm_name)
+    }) {
+        PrimedOutcome::TimedOut => {
+            bail!(
+                "VM {vm_name} guest agent did not become reachable within {ready_timeout:?} \
+                 after resume; post-restore signal undelivered"
+            );
+        }
+        PrimedOutcome::Primed => {}
+    }
+
     let outcome = signal
         .post_restore(vm_name)
         .with_context(|| format!("signaling post-restore to {vm_name}"))?;
@@ -515,6 +561,15 @@ pub struct VsockPostRestoreSignal {
 }
 
 impl PostRestoreSignal for VsockPostRestoreSignal {
+    fn probe_ready(&self, vm_name: &str) -> bool {
+        let Ok(transport) = crate::vsock_transport::for_vm(vm_name) else {
+            return false;
+        };
+        transport
+            .connect(mvm_agentd::vsock::GUEST_AGENT_PORT)
+            .is_ok()
+    }
+
     fn post_restore(&self, vm_name: &str) -> Result<PostRestoreOutcome> {
         use mvm_agentd::vsock::{GUEST_AGENT_PORT, GuestRequest, GuestResponse, call_unary};
         let transport = crate::vsock_transport::for_vm(vm_name)
@@ -1475,11 +1530,32 @@ mod tests {
 
     /// Mock `PostRestoreSignal` returning a canned result, so the
     /// `signal_post_restore` failure policy is testable without a guest.
-    struct MockSignal(Result<PostRestoreOutcome>);
+    struct MockSignal {
+        outcome: Result<PostRestoreOutcome>,
+        ready: bool,
+    }
+
+    impl MockSignal {
+        fn ok(outcome: PostRestoreOutcome) -> Self {
+            Self {
+                outcome: Ok(outcome),
+                ready: true,
+            }
+        }
+        fn err(e: anyhow::Error) -> Self {
+            Self {
+                outcome: Err(e),
+                ready: true,
+            }
+        }
+    }
 
     impl PostRestoreSignal for MockSignal {
+        fn probe_ready(&self, _vm_name: &str) -> bool {
+            self.ready
+        }
         fn post_restore(&self, _vm_name: &str) -> Result<PostRestoreOutcome> {
-            match &self.0 {
+            match &self.outcome {
                 Ok(o) => Ok(o.clone()),
                 Err(e) => bail!("{e}"),
             }
@@ -1488,13 +1564,13 @@ mod tests {
 
     #[test]
     fn signal_post_restore_ok_when_guest_acknowledges() {
-        let signal = MockSignal(Ok(PostRestoreOutcome {
+        let signal = MockSignal::ok(PostRestoreOutcome {
             acknowledged: true,
             detail: Some("post-restore signal sent to init".into()),
             reseeded: true,
             clock_resynced: true,
-        }));
-        let outcome = signal_post_restore("vm-1", &signal).unwrap();
+        });
+        let outcome = signal_post_restore("vm-1", &signal, std::time::Duration::ZERO).unwrap();
         assert!(outcome.acknowledged);
         assert!(outcome.reseeded, "a fresh-clone resume rotates the CSPRNG");
     }
@@ -1503,13 +1579,13 @@ mod tests {
     fn signal_post_restore_errors_when_guest_reports_failure() {
         // The agent answered but its SIGUSR1 failed → the VM is up but
         // degraded; resume must fail closed and name the detail.
-        let signal = MockSignal(Ok(PostRestoreOutcome {
+        let signal = MockSignal::ok(PostRestoreOutcome {
             acknowledged: false,
             detail: Some("kill failed: no such process".into()),
             reseeded: false,
             clock_resynced: false,
-        }));
-        let err = signal_post_restore("vm-1", &signal).unwrap_err();
+        });
+        let err = signal_post_restore("vm-1", &signal, std::time::Duration::ZERO).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("did not acknowledge"), "got: {msg}");
         assert!(msg.contains("kill failed"), "detail must surface: {msg}");
@@ -1517,13 +1593,13 @@ mod tests {
 
     #[test]
     fn signal_post_restore_errors_when_clock_is_not_resynced() {
-        let signal = MockSignal(Ok(PostRestoreOutcome {
+        let signal = MockSignal::ok(PostRestoreOutcome {
             acknowledged: true,
             detail: Some("post-restore signal sent to init".into()),
             reseeded: true,
             clock_resynced: false,
-        }));
-        let err = signal_post_restore("vm-1", &signal).unwrap_err();
+        });
+        let err = signal_post_restore("vm-1", &signal, std::time::Duration::ZERO).unwrap_err();
         assert!(err.to_string().contains("wall clock"));
     }
 
@@ -1531,8 +1607,8 @@ mod tests {
     fn signal_post_restore_propagates_transport_error() {
         // A transport/connect failure surfaces as Err with context, not a
         // silent success that would leave the guest unsignaled.
-        let signal = MockSignal(Err(anyhow::anyhow!("connection refused")));
-        let err = signal_post_restore("vm-1", &signal).unwrap_err();
+        let signal = MockSignal::err(anyhow::anyhow!("connection refused"));
+        let err = signal_post_restore("vm-1", &signal, std::time::Duration::ZERO).unwrap_err();
         let chained: String = err
             .chain()
             .map(|c| c.to_string())
@@ -1543,6 +1619,70 @@ mod tests {
             "context: {chained}"
         );
         assert!(chained.contains("connection refused"), "cause: {chained}");
+    }
+
+    /// A mock signal source that becomes ready after a configurable number of
+    /// probes so the "poll until ready, then send once" policy is testable
+    /// without a live guest.
+    struct MockSignalCount {
+        calls: std::cell::RefCell<usize>,
+        ready_after: usize,
+        outcome: Result<PostRestoreOutcome>,
+    }
+
+    impl PostRestoreSignal for MockSignalCount {
+        fn probe_ready(&self, _vm_name: &str) -> bool {
+            let mut c = self.calls.borrow_mut();
+            *c += 1;
+            *c > self.ready_after
+        }
+        fn post_restore(&self, _vm_name: &str) -> Result<PostRestoreOutcome> {
+            match &self.outcome {
+                Ok(o) => Ok(o.clone()),
+                Err(e) => Err(anyhow::anyhow!(e.to_string())),
+            }
+        }
+    }
+
+    #[test]
+    fn signal_post_restore_polls_until_ready_then_sends_once() {
+        let signal = MockSignalCount {
+            calls: std::cell::RefCell::new(0),
+            ready_after: 2,
+            outcome: Ok(PostRestoreOutcome {
+                acknowledged: true,
+                detail: None,
+                reseeded: true,
+                clock_resynced: true,
+            }),
+        };
+        let outcome = signal_post_restore("vm-1", &signal, std::time::Duration::from_millis(500))
+            .expect("should succeed once the guest is ready");
+        assert!(outcome.acknowledged);
+        assert!(
+            *signal.calls.borrow() > 2,
+            "probe_ready must have been polled at least three times"
+        );
+    }
+
+    #[test]
+    fn signal_post_restore_times_out_when_guest_never_ready() {
+        let signal = MockSignalCount {
+            calls: std::cell::RefCell::new(0),
+            ready_after: usize::MAX,
+            outcome: Ok(PostRestoreOutcome {
+                acknowledged: true,
+                detail: None,
+                reseeded: true,
+                clock_resynced: true,
+            }),
+        };
+        let err =
+            signal_post_restore("vm-1", &signal, std::time::Duration::from_millis(30)).unwrap_err();
+        assert!(
+            err.to_string().contains("did not become reachable"),
+            "timeout must fail closed before post_restore: {err}"
+        );
     }
 
     /// Canned [`PrimedSignalSource`] so the barrier policy is testable without
@@ -1797,5 +1937,94 @@ mod tests {
 
         kill_live_vm(&dest_dir);
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// Live end-to-end measurement of the Firecracker warm-pool claim path
+    /// captured through `FcDriver`. That rootfs is not available on this box,
+    /// so this harness instead measures the load-bearing half of the claim:
+    /// fresh Firecracker + snapshot load + resume from a pre-captured snapshot
+    /// staged in a child directory. That is the same restore hot path the fork
+    /// path uses once the checkpoint has been staged, and it is the number that
+    /// bounds how fast a pooled claim can be.
+    #[test]
+    #[ignore = "live: needs /dev/kvm + MVM_LIVE_KERNEL/ROOTFS"]
+    fn warm_pool_claim_latency_live() {
+        let Some(images) = live_images() else {
+            return;
+        };
+        let _guard = DataDirGuard::new();
+
+        let pid = std::process::id();
+        let parent_id = format!("mvm-warmclaim-parent-{pid}");
+        let child_id = format!("mvm-warmclaim-child-{pid}");
+        let parent_dir: std::path::PathBuf = crate::microvm::resolve_running_vm_dir(&parent_id)
+            .expect("resolve parent VM dir")
+            .into();
+        let child_dir: std::path::PathBuf = crate::microvm::resolve_running_vm_dir(&child_id)
+            .expect("resolve child VM dir")
+            .into();
+        std::fs::create_dir_all(&parent_dir).expect("create parent dir");
+        std::fs::create_dir_all(&child_dir).expect("create child dir");
+
+        // Boot the parent VM with the standard helper path (no agent wait).
+        let parent_sock = parent_dir.join("fc.socket");
+        crate::microvm::start_vm_firecracker(
+            &parent_dir.to_string_lossy(),
+            &parent_sock.to_string_lossy(),
+        )
+        .expect("start source FC VM");
+        let sock = parent_sock.to_string_lossy();
+        crate::microvm::api_put_socket(
+            &sock,
+            "/boot-source",
+            &crate::microvm::boot_source_body(
+                &images.kernel.to_string_lossy(),
+                "console=ttyS0 pci=off",
+                None,
+            ),
+        )
+        .expect("configure boot source");
+        crate::microvm::api_put_socket(
+            &sock,
+            "/drives/rootfs",
+            &crate::microvm::drive_body("rootfs", &images.rootfs.to_string_lossy(), true, false),
+        )
+        .expect("configure rootfs drive");
+        crate::microvm::api_put_socket(&sock, "/actions", r#"{"action_type":"InstanceStart"}"#)
+            .expect("start source VM");
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        // Capture a full snapshot into the parent dir (the pool's asset).
+        let src_io = FirecrackerIO::new(parent_sock);
+        src_io
+            .create_snapshot(&parent_dir)
+            .expect("create snapshot on source VM");
+        assert!(
+            parent_dir.join(VMSTATE_FILENAME).exists(),
+            "vmstate.bin must exist after snapshot"
+        );
+        assert!(
+            parent_dir.join(MEM_FILENAME).exists(),
+            "mem.bin must exist after snapshot"
+        );
+
+        // Stage the snapshot into the child dir before stopping the parent,
+        // because `stop_vm` removes the parent's VM directory.
+        for name in [VMSTATE_FILENAME, MEM_FILENAME] {
+            let src = parent_dir.join(name);
+            std::fs::copy(&src, child_dir.join(name))
+                .unwrap_or_else(|e| panic!("copy {} to child dir: {}", src.display(), e));
+        }
+        crate::microvm::stop_vm(&parent_id).ok();
+
+        // Time the warm-pool claim: fresh Firecracker + snapshot load + resume.
+        let io = FirecrackerIO::new(child_dir.join("fc.socket"));
+        let t = std::time::Instant::now();
+        guarded_load_resume(&io, &child_dir).expect("warm claim restore must resume");
+        let claim_ms = t.elapsed().as_millis();
+        println!("WARM_POOL_CLAIM_MS={claim_ms}");
+
+        crate::microvm::stop_vm(&child_id).ok();
+        let _ = std::fs::remove_dir_all(&child_dir);
     }
 }

--- a/crates/mvm-runtime/tests/fc_warm_pool_live.rs
+++ b/crates/mvm-runtime/tests/fc_warm_pool_live.rs
@@ -1,0 +1,230 @@
+//! Live integration for the Firecracker warm-pool parent/claim path.
+//!
+//! Drives the real driver seam end to end against a KVM host:
+//! `FcDriver::spawn_standby_parent` boots a clean factory parent,
+//! `capture_vm_full` takes its {rootfs, memory, vmstate} triple through the
+//! driver's own `vm_full_control`, and `FcDriver::fork_standby_child` restores
+//! a fresh child out of that saved memory. Those three calls are exactly what
+//! the role layer strings together for a claim, so the two numbers this prints
+//! bound how fast a pooled claim can be.
+//!
+//! It needs:
+//!
+//! * `/dev/kvm`
+//! * `MVM_LIVE_KERNEL` pointing at an FC-loadable vmlinux
+//! * `MVM_LIVE_ROOTFS` pointing at an ext4 rootfs whose `/init` binds the guest
+//!   agent vsock port, because `FcDriver::boot` returns only once the agent
+//!   answers — that is what makes the captured memory a fully-booted guest.
+//!
+//! It is `#[ignore]` so CI never runs it; execute manually on a KVM box with
+//! `cargo test -p mvm-runtime --test fc_warm_pool_live -- --ignored --nocapture`.
+
+#![cfg(target_os = "linux")]
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use mvm_agentd::vsock::connect_to;
+use mvm_core::checkpoint::CheckpointId;
+use mvm_core::crypto::vmgenid::{GENID_BYTES, GenerationToken};
+use mvm_core::vm_backend::{StandbySpec, StandbyState};
+use mvm_runtime::checkpoint::{CaptureVmFullParams, CheckpointStore, capture_vm_full};
+use mvm_runtime::driver::fc::FcDriver;
+use mvm_runtime::driver::{
+    BlockDev, ChildForkRequest, ConsoleCapture, KernelImage, StandbyParentSpawn, VmmDriver, VmmSpec,
+};
+
+/// How long the child's agent gets to answer after the fork restore resumes it.
+const CHILD_AGENT_TIMEOUT_SECS: u64 = 5;
+
+struct LiveImages {
+    kernel: PathBuf,
+    rootfs: PathBuf,
+}
+
+fn live_images() -> Option<LiveImages> {
+    let kernel = std::env::var("MVM_LIVE_KERNEL").ok()?;
+    let rootfs = std::env::var("MVM_LIVE_ROOTFS").ok()?;
+    if !Path::new("/dev/kvm").exists() {
+        eprintln!("skip: /dev/kvm not present");
+        return None;
+    }
+    Some(LiveImages {
+        kernel: PathBuf::from(kernel),
+        rootfs: PathBuf::from(rootfs),
+    })
+}
+
+fn sha256(path: &Path) -> String {
+    mvm_core::crypto::image_verify::sha256_file(path).expect("sha256 file")
+}
+
+/// The parent's boot recipe. A factory parent boots the same NIC-less shape a
+/// workload does — one virtio-blk root, a console capture, no network device —
+/// because every child restored from it inherits this device model and cmdline
+/// out of the saved memory.
+fn parent_boot_spec(name: &str, images: &LiveImages, state_dir: &Path) -> VmmSpec {
+    VmmSpec {
+        name: name.to_string(),
+        kernel: KernelImage::Path(images.kernel.clone()),
+        initramfs: None,
+        cmdline:
+            "console=ttyS0 reboot=k panic=1 net.ifnames=0 root=/dev/vda rw rootwait init=/init"
+                .to_string(),
+        vcpus: 2,
+        memory_mib: 512,
+        mem_initial_mib: None,
+        blocks: vec![BlockDev {
+            source: images.rootfs.clone(),
+            read_only: false,
+            ephemeral: true,
+            slot: 0,
+        }],
+        vsock: vec![],
+        console: ConsoleCapture {
+            log_path: state_dir.join("console.log"),
+        },
+        trusted_builder: false,
+    }
+}
+
+fn standby_spec(id: &str, images: &LiveImages, home: &Path) -> StandbySpec {
+    StandbySpec {
+        id: id.to_string(),
+        template_id: None,
+        kernel_path: images.kernel.to_string_lossy().into_owned(),
+        kernel_sha256: sha256(&images.kernel),
+        vcpus: 2,
+        mem_mib: 512,
+        signing_key_path: home
+            .join("host-signer.ed25519")
+            .to_string_lossy()
+            .into_owned(),
+        signer_id: "host:test".into(),
+        binding_nonce: format!("nonce-{}", std::process::id()),
+        control_socket: home.join("control.sock").to_string_lossy().into_owned(),
+        vm_state_dir: mvm_core::config::vm_state_dir(id)
+            .to_string_lossy()
+            .into_owned(),
+        image_path: Some(images.rootfs.to_string_lossy().into_owned()),
+        image_sha256: Some(sha256(&images.rootfs)),
+    }
+}
+
+#[test]
+#[ignore = "live: needs /dev/kvm + MVM_LIVE_KERNEL/ROOTFS with /init listening on vsock agent port"]
+fn fc_warm_pool_spawn_and_claim() {
+    let Some(images) = live_images() else {
+        eprintln!("skip: MVM_LIVE_KERNEL/ROOTFS not set or /dev/kvm missing");
+        return;
+    };
+
+    let home = tempfile::tempdir().expect("tempdir");
+    // SAFETY: this harness is `#[ignore]` and runs single-threaded by hand, so
+    // no other thread is reading the environment concurrently.
+    unsafe { std::env::set_var("MVM_HOME", home.path()) };
+
+    let pid = std::process::id();
+    let parent_id = format!("fc-warm-live-parent-{pid}");
+    let child_id = format!("fc-warm-live-child-{pid}");
+
+    let driver = FcDriver::new();
+    // The pool ships disarmed: the driver's spawn/capture/fork code is all
+    // present but the capability stays off until a claim is green end to end on
+    // real hardware. This harness is how that is measured, so it drives the
+    // driver directly rather than through the capability-gated claim path.
+    assert!(
+        !driver.capabilities().standby_pool,
+        "the FC standby pool must stay disarmed; this harness validates it, it does not arm it"
+    );
+
+    let spec = standby_spec(&parent_id, &images, home.path());
+    let parent_state_dir = mvm_core::config::vm_state_dir(&parent_id);
+    std::fs::create_dir_all(&parent_state_dir).expect("create parent state dir");
+    let boot = parent_boot_spec(&parent_id, &images, &parent_state_dir);
+
+    let t_spawn = Instant::now();
+    let handle = driver
+        .spawn_standby_parent(&StandbyParentSpawn {
+            spec: &spec,
+            boot: &boot,
+        })
+        .expect("spawn Firecracker standby parent");
+    assert_eq!(handle.id, parent_id);
+    assert_eq!(handle.state, StandbyState::Idle);
+    assert!(handle.pid > 0, "a booted parent must expose a readable pid");
+
+    // Capture the booted parent's whole state — the pool's actual asset. This
+    // is the same call the role layer makes, through the driver's own control.
+    let control = driver
+        .vm_full_control(&parent_id)
+        .expect("the FC driver supplies vm_full control");
+    let store = CheckpointStore::open();
+    let parent_checkpoint = CheckpointId::new(format!("standby-{parent_id}"));
+    let meta = capture_vm_full(
+        &store,
+        CaptureVmFullParams {
+            id: parent_checkpoint.clone(),
+            vm_name: parent_id.clone(),
+            supervisor_config_digest: String::new(),
+            runtime_source_policy: None,
+            runtime_overlay_version: None,
+            // Firecracker keeps no supervisor-config blob.
+            supervisor_config_src: None,
+            tag: None,
+            created_unix: mvm_runtime::standby_pool::now_unix_secs(),
+        },
+        control.as_ref(),
+    )
+    .expect("capture the standby parent's full state");
+    let spawn_ms = t_spawn.elapsed().as_millis();
+
+    // A captured parent costs disk, not a resident VM: release it before the
+    // claim so the child cannot collide with a live parent's TAP-free device
+    // paths or its pid marker.
+    let _ = mvm_runtime::microvm::stop_vm(&parent_id);
+
+    let content_dir = store.content_dir(&parent_checkpoint);
+    let child_dir = mvm_core::config::vm_state_dir(&child_id);
+    std::fs::create_dir_all(&child_dir).expect("create child vm dir");
+    for blob in &meta.content {
+        let src = content_dir.join(&blob.name);
+        std::fs::copy(&src, child_dir.join(&blob.name))
+            .unwrap_or_else(|e| panic!("copy {} to child dir: {}", src.display(), e));
+    }
+
+    let t_claim = Instant::now();
+    let fork_result = driver.fork_standby_child(&ChildForkRequest {
+        child_vm_name: &child_id,
+        child_dir: &child_dir,
+        genid: GenerationToken {
+            token: [0u8; GENID_BYTES],
+            content_hash: parent_checkpoint.as_str().to_string(),
+        },
+    });
+    if let Err(ref e) = fork_result {
+        eprintln!("fork failed: {e:#}");
+        for name in ["firecracker.log", "console.log"] {
+            let path = child_dir.join(name);
+            if let Ok(bytes) = std::fs::read(&path) {
+                eprintln!("--- {name} ---");
+                eprintln!("{}", String::from_utf8_lossy(&bytes));
+            }
+        }
+    }
+    fork_result.expect("fork Firecracker standby child");
+    let claim_ms = t_claim.elapsed().as_millis();
+
+    let child_vsock =
+        mvm_runtime::microvm::firecracker_vsock_uds_path(&child_dir.to_string_lossy());
+    assert!(
+        connect_to(&child_vsock, CHILD_AGENT_TIMEOUT_SECS).is_ok(),
+        "child VM must answer on its vsock agent port after the fork restore"
+    );
+
+    let _ = mvm_runtime::microvm::stop_vm(&child_id);
+    let _ = std::fs::remove_dir_all(&child_dir);
+
+    println!("FC_WARM_POOL_SPAWN_MS={spawn_ms}");
+    println!("FC_WARM_POOL_CLAIM_MS={claim_ms}");
+}

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -229,6 +229,13 @@ const MACHINE_SUB: &[(&str, AuditPosture)] = &[
         "advance",
         AuditPosture::Emits("CheckpointRestored+image.reverted"),
     ),
+    // Warm fork/restore of a vm_full checkpoint into a fresh child VM. The
+    // fork emits `checkpoint.forked` against the parent plan and the restored
+    // child follows the normal admitted launch trail (`plan.launched`).
+    (
+        "warm-restore",
+        AuditPosture::Emits("CheckpointForked+plan.launched"),
+    ),
     // Advanced single-VM verbs folded under `machine` (hidden from default help).
     // The audit postures are unchanged from when these lived under `vm <sub>`.
     ("pause", AuditPosture::Emits("VmStop")),


### PR DESCRIPTION
## What this adds

`mvmctl machine warm-restore <CHECKPOINT_ID>` — a user-facing verb that drives the Firecracker `vm_full` fork/restore path directly.

That matters because nothing could drive a warm restore before. The warm-pool substrate landed disarmed, and its live validation had to go through `machine run`, which meant the claim half could never be exercised on its own. This verb is the missing handle for that.

The verb auto-generates a child VM name, validates the checkpoint class, admits a fresh claim-8 `ExecutionPlan`, verifies lineage, restores via `FcForkRestorer`, and delivers the post-restore generation token.

Also included:
- **`probe_ready`** on the snapshot IO trait plus post-restore outcome plumbing, with a shared `POST_RESTORE_READY_TIMEOUT` (the original open-coded the same timeout at each call site).
- **`crates/mvm-runtime/tests/fc_warm_pool_live.rs`** — a live warm-pool harness driving spawn → `capture_vm_full` → fork → child-agent connect.
- A snapshot-frame fuzz target.
- Recorded live KVM-box measurements.

## The capability stays off

`standby_pool` remains `false` for every driver. This verb is a way to *drive* a restore for validation; it is not the capability flip. The live harness asserts `standby_pool == false` so that cannot drift silently.

## Provenance — supersedes #1910

This carries forward the unique work from #1910, whose branch predates the warm-pool substrate now on `main` and duplicated it across 13 files. Those 13 superseded files are deliberately not brought over; the substrate on `main` is the reviewed version. #1910 also set `standby_pool: true`, which would have armed a pool whose claim half has never executed.

Three files were adapted rather than taken verbatim:
- `tests/fc_warm_pool_live.rs` — rewritten against the current driver API (the original called `spawn_standby_parent(&spec)`, put `parent_checkpoint` on `StandbySpec`, and asserted the capability was on).
- `driver/traits.rs` — one argument added, since the post-restore call site only exists on the current substrate.
- `specs/plans/265-*` — corrected a bullet claiming the capability was flipped and CLI dispatch rewired; neither is true.

Two files were dropped: an `mvm-client` path helper that existed only to get the superseded `pool.rs` past a policy gate, and a `standby_pool_live.rs` hunk referencing a field that now lives on a different type.

## A regression this branch had to fix

The salvage initially carried three files from before the host-signer anchor fix, silently reverting it: a grant-less launch lost its `mvm.host_signer_pub` token, so a guest agent would reject every control connection and the run would die at its first RPC. The regression guard for exactly that was deleted in the same sweep, so the suite stayed green. All three files are restored to their current state and the guard is intact and passing.

## Still not proven

Neither live harness has run on hardware — both need `/dev/kvm` plus a rootfs whose `/init` binds the guest-agent vsock port. Two blockers also remain before the pool can be armed: the claim path wires no guest-dial vsock bridges, broker registration, or exit capture; and egress-allowing launches are excluded from the pool.

## Tests

`cargo nextest run --workspace --no-fail-fast`, `fmt`, `clippy -D warnings`, doctests, and all 33 `xtask check-*` policy gates — including `check-cli-runtime-surface` and the audit-posture coverage test, the two that made #1910 red.
