### PR TITLE
feat(mvm-cli): add machine warm-restore verb for vm_full checkpoints

### DIFF
--- a/crates/mvm-cli/src/commands/machine/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/machine/checkpoint.rs
@@ -1,0 +1,68 @@
+//! User-facing warm fork/restore surface for `mvmctl machine warm-restore`.
+//!
+//! This routes into the Firecracker vm_full fork helpers in
+//! `commands::vm::checkpoint`, but presents a focused, backend-agnostic
+//! machine-level verb.
+
+use anyhow::{Context, Result, bail};
+use mvm_core::checkpoint::{CheckpointClass, CheckpointId};
+use mvm_core::config::vm_state_dir;
+use mvm_runtime::checkpoint::CheckpointStore;
+
+/// User-facing input to [`fork_vm_full_machine`].
+pub(in crate::commands) struct ForkVmFullMachineInput {
+    /// Checkpoint id to warm-restore.
+    pub checkpoint_id: String,
+    /// Desired child VM name; auto-generated if omitted.
+    pub child_vm_name: Option<String>,
+    /// Emit machine-readable JSON instead of human text.
+    pub json: bool,
+}
+
+/// User-facing Firecracker vm_full warm fork/restore.
+///
+/// Validates the checkpoint, generates a fresh child identity, admits a new
+/// claim-8 plan, restores the saved machine state through the FC fork path,
+/// and delivers the post-restore generation token. The user-facing verb
+/// implicitly opts into the experimental Firecracker vm_full fork path, so
+/// the lower-level env-var guard is bypassed here.
+pub(in crate::commands) fn fork_vm_full_machine(input: ForkVmFullMachineInput) -> Result<()> {
+    let checkpoint = crate::commands::vm::checkpoint::validated_checkpoint_id(&input.checkpoint_id)
+        .with_context(|| format!("invalid checkpoint id {:?}", input.checkpoint_id))?;
+    let store = CheckpointStore::open();
+    let parent_meta = store
+        .read_meta(&checkpoint)
+        .with_context(|| format!("reading checkpoint {}", input.checkpoint_id))?;
+
+    if parent_meta.class != CheckpointClass::VmFull {
+        bail!(
+            "checkpoint '{}' is class {:?}; warm-restore only supports vm_full checkpoints",
+            input.checkpoint_id,
+            parent_meta.class,
+        );
+    }
+
+    let now = crate::commands::vm::checkpoint::now_unix();
+    let child_vm_name = input
+        .child_vm_name
+        .unwrap_or_else(|| format!("{}-warm-{now}", checkpoint.as_str()));
+    mvm_core::naming::validate_vm_name(&child_vm_name)
+        .with_context(|| format!("invalid child VM name {child_vm_name:?}"))?;
+    let dest_dir = vm_state_dir(&child_vm_name);
+    let child_id = CheckpointId::new(format!("fork-{child_vm_name}-{now}"));
+
+    crate::commands::vm::checkpoint::fork_vm_full_arm_fc(
+        crate::commands::vm::checkpoint::ForkVmFullArmFcParams {
+            store: &store,
+            checkpoint: &checkpoint,
+            parent_meta,
+            child_vm_name,
+            dest_dir,
+            child_id,
+            now,
+            json: input.json,
+            bypass_experimental_guard: true,
+        },
+    )?;
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -14,6 +14,7 @@
 //! transient runner, while `exec` / `shell` / `stop` stay thin wrappers over
 //! the existing running-VM surfaces.
 
+mod checkpoint;
 mod lifecycle;
 mod portable;
 mod receipt;
@@ -50,6 +51,7 @@ use super::vm::host_signer::PUBLIC_FILENAME;
 use super::vm::host_signer::{host_signer_id, load_or_init};
 use super::vm::{console, down};
 use crate::ui;
+use checkpoint::{ForkVmFullMachineInput, fork_vm_full_machine};
 use lifecycle::{exec_machine, run_restart, run_start, shell_machine, stop_machine};
 #[cfg(test)]
 use receipt::verify_machine_start_receipt;
@@ -140,6 +142,11 @@ pub(in crate::commands) enum MachineAction {
     /// Advance one step: restore a child of the target (a fork needs `--to`).
     #[command(display_order = 17)]
     Advance(super::vm::checkpoint::AdvanceArgs),
+    /// Warm-restore a vm_full checkpoint into a fresh child VM.
+    /// The child inherits the saved machine state and receives a fresh
+    /// generation token; the parent must be stopped.
+    #[command(name = "warm-restore", display_order = 18)]
+    WarmRestore(MachineWarmRestoreArgs),
     /// Advanced single-VM operations (pause, snapshot, cp, fs, …). Hidden; use `machine <verb>` directly.
     #[command(flatten)]
     Vm(VmCmd),
@@ -173,6 +180,7 @@ impl MachineAction {
             MachineAction::Revert(_) => "revert",
             MachineAction::Rewind(_) => "rewind",
             MachineAction::Advance(_) => "advance",
+            MachineAction::WarmRestore(_) => "warm-restore",
         }
     }
 }
@@ -847,6 +855,18 @@ pub(in crate::commands) struct MachineReconfigureArgs {
     #[arg(long, value_name = "HYPERVISOR")]
     pub hypervisor: Option<String>,
 }
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct MachineWarmRestoreArgs {
+    /// vm_full checkpoint id to restore.
+    #[arg(value_name = "CHECKPOINT_ID")]
+    pub checkpoint: String,
+    /// Name for the fresh child VM (auto-generated if omitted).
+    #[arg(long, value_name = "NAME")]
+    pub name: Option<String>,
+    /// Output the result as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
 
 #[derive(Debug, Serialize)]
 struct MachineRemoveSummary {
@@ -1315,10 +1335,21 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
         MachineAction::Advance(a) => {
             complete_revert(cli, cfg, super::vm::checkpoint::run_advance(a)?)
         }
+        MachineAction::WarmRestore(args) => run_warm_restore(args),
         MachineAction::Vm(cmd) => {
             super::vm::group::run(cli, super::vm::group::Args { action: cmd }, cfg)
         }
     }
+}
+
+/// Run `machine warm-restore`: fork a vm_full checkpoint into a fresh child VM.
+fn run_warm_restore(args: MachineWarmRestoreArgs) -> Result<()> {
+    fork_vm_full_machine(ForkVmFullMachineInput {
+        checkpoint_id: args.checkpoint,
+        child_vm_name: args.name,
+        json: args.json,
+    })?;
+    Ok(())
 }
 
 /// Finish a restore. A checkpoint restore completes inside the engine (the fork

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -95,6 +95,7 @@ fn machine_subcommand(action: &MachineAction) -> &'static str {
         MachineAction::Revert(_) => "revert",
         MachineAction::Rewind(_) => "rewind",
         MachineAction::Advance(_) => "advance",
+        MachineAction::WarmRestore(_) => "warm-restore",
         MachineAction::Vm(_) => "vm",
     }
 }

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -238,7 +238,7 @@ struct CheckpointForkJson<'a> {
 /// otherwise produce an unsafe on-disk directory name. The id becomes a
 /// directory component under `checkpoints_dir()`, so path-traversal and
 /// control bytes must never reach the filesystem.
-fn validated_checkpoint_id(raw: &str) -> Result<CheckpointId> {
+pub(in crate::commands) fn validated_checkpoint_id(raw: &str) -> Result<CheckpointId> {
     if raw.is_empty() {
         bail!("invalid checkpoint id: empty");
     }
@@ -255,7 +255,7 @@ fn validated_checkpoint_id(raw: &str) -> Result<CheckpointId> {
     Ok(CheckpointId::new(raw.to_string()))
 }
 
-fn now_unix() -> u64 {
+pub(in crate::commands) fn now_unix() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -881,10 +881,59 @@ fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
 
     let parent_meta = p.store.read_meta(p.checkpoint)?;
 
+    fork_vm_full_arm_fc(ForkVmFullArmFcParams {
+        store: p.store,
+        checkpoint: p.checkpoint,
+        parent_meta,
+        child_vm_name,
+        dest_dir,
+        child_id,
+        now,
+        json: p.json,
+        bypass_experimental_guard: false,
+    })?;
+    Ok(())
+}
+
+/// Inputs for [`fork_vm_full_arm_fc`]. Grouped to stay under the
+/// `clippy::too_many_arguments` workspace ceiling.
+pub(in crate::commands) struct ForkVmFullArmFcParams<'a> {
+    pub(in crate::commands) store: &'a CheckpointStore,
+    pub(in crate::commands) checkpoint: &'a CheckpointId,
+    pub(in crate::commands) parent_meta: mvm_core::checkpoint::CheckpointMeta,
+    pub(in crate::commands) child_vm_name: String,
+    pub(in crate::commands) dest_dir: std::path::PathBuf,
+    pub(in crate::commands) child_id: CheckpointId,
+    pub(in crate::commands) now: u64,
+    pub(in crate::commands) json: bool,
+    /// When true, skip the `MVM_FORK_VMFULL_FC_EXPERIMENTAL` guard. The guard
+    /// stays on the lower-level `vm checkpoint fork` path; the user-facing
+    /// `machine warm-restore` verb opts in explicitly.
+    pub(in crate::commands) bypass_experimental_guard: bool,
+}
+
+/// FC vm_full fork: clone the captured triple, admit a fresh claim-8 plan for
+/// the child, rename `memory.bin` → `mem.bin`, and boot the child via a fresh
+/// Firecracker VMM loaded from the checkpoint snapshot.
+pub(in crate::commands) fn fork_vm_full_arm_fc(
+    p: ForkVmFullArmFcParams<'_>,
+) -> Result<mvm_core::checkpoint::CheckpointMeta> {
+    // FC vm_full fork loads a snapshot that still carries the parent's TAP
+    // name and guest MAC in bitcode. Remapping backing files is not enough to
+    // make a live-parent fork safe, so require the parent to be stopped first.
+    // The device-path remapping happens in a private mount namespace before
+    // the child Firecracker starts.
+    if vm_is_running(&p.parent_meta.vm_name) {
+        anyhow::bail!(
+            "Firecracker vm_full fork requires the parent VM '{}' to be stopped first;              live-parent fork would collide on the parent's TAP/MAC",
+            p.parent_meta.vm_name
+        );
+    }
+
     // Checkpoints captured under the removed Apple-Virtualization backend carry
     // a supervisor-config.json blob. Their full-VM fork is being re-homed onto
     // the in-house HVF VMM and is unavailable for now — refuse cleanly.
-    if checkpoint_is_vz(&parent_meta) {
+    if checkpoint_is_vz(&p.parent_meta) {
         anyhow::bail!(
             "this vm_full checkpoint was captured under a backend that has been removed; \
              its full-VM fork is being re-homed onto the in-house HVF VMM and is \
@@ -899,8 +948,9 @@ fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
     // side is remappable, but re-IP'ing the guest is a per-child network-model
     // decision that is not yet settled — refuse cleanly rather than boot a
     // colliding child. The restore mechanism stays reachable behind an explicit
-    // opt-in for isolated single-child testing on that model.
-    if !fc_vm_full_fork_experimental_enabled() {
+    // opt-in for isolated single-child testing on that model, unless the caller
+    // has already opted in (the user-facing `machine warm-restore` path).
+    if !p.bypass_experimental_guard && !fc_vm_full_fork_experimental_enabled() {
         anyhow::bail!(
             "forking a vm_full checkpoint on Firecracker is not yet supported: the \
              forked child inherits the parent's guest IP/MAC from the saved memory \
@@ -908,46 +958,6 @@ fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
              with the parent on the shared bridge. Use an fs_quick fork, or set \
              MVM_FORK_VMFULL_FC_EXPERIMENTAL=1 to exercise the restore on an isolated \
              single-child network."
-        );
-    }
-    fork_vm_full_arm_fc(ForkVmFullArmFcParams {
-        store: p.store,
-        checkpoint: p.checkpoint,
-        parent_meta,
-        child_vm_name,
-        dest_dir,
-        child_id,
-        now,
-        json: p.json,
-    })
-}
-
-/// Inputs for [`fork_vm_full_arm_fc`]. Grouped to stay under the
-/// `clippy::too_many_arguments` workspace ceiling.
-struct ForkVmFullArmFcParams<'a> {
-    store: &'a CheckpointStore,
-    checkpoint: &'a CheckpointId,
-    parent_meta: mvm_core::checkpoint::CheckpointMeta,
-    child_vm_name: String,
-    dest_dir: std::path::PathBuf,
-    child_id: CheckpointId,
-    now: u64,
-    json: bool,
-}
-
-/// FC vm_full fork: clone the captured triple, admit a fresh claim-8 plan for
-/// the child, rename `memory.bin` → `mem.bin`, and boot the child via a fresh
-/// Firecracker VMM loaded from the checkpoint snapshot.
-fn fork_vm_full_arm_fc(p: ForkVmFullArmFcParams<'_>) -> Result<()> {
-    // FC vm_full fork loads a snapshot that still carries the parent's TAP
-    // name and guest MAC in bitcode. Remapping backing files is not enough to
-    // make a live-parent fork safe, so require the parent to be stopped first.
-    // The device-path remapping happens in a private mount namespace before
-    // the child Firecracker starts.
-    if vm_is_running(&p.parent_meta.vm_name) {
-        anyhow::bail!(
-            "Firecracker vm_full fork requires the parent VM '{}' to be stopped first;              live-parent fork would collide on the parent's TAP/MAC",
-            p.parent_meta.vm_name
         );
     }
 
@@ -1093,7 +1103,7 @@ fn fork_vm_full_arm_fc(p: ForkVmFullArmFcParams<'_>) -> Result<()> {
             p.child_vm_name
         ));
     }
-    Ok(())
+    Ok(meta)
 }
 
 fn deliver_fc_fork_post_restore(

--- a/crates/mvm-cli/tests/cli.rs
+++ b/crates/mvm-cli/tests/cli.rs
@@ -192,3 +192,70 @@ fn ops_help_no_longer_lists_bench() {
         "ops help still lists the removed bench verb:\n{text}"
     );
 }
+
+/// `machine warm-restore --help` advertises the expected usage.
+#[test]
+fn machine_warm_restore_help_lists_args() {
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .args(["machine", "warm-restore", "--help"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "machine warm-restore --help must exit 0, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(help.contains("warm-restore"));
+    assert!(help.contains("CHECKPOINT_ID"));
+    assert!(help.contains("--name"));
+    assert!(help.contains("--json"));
+}
+
+/// A non-existent checkpoint id fails gracefully rather than panicking.
+#[test]
+fn machine_warm_restore_rejects_missing_checkpoint() {
+    let tmp = std::env::temp_dir().join(format!("mvm-warm-restore-test-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .env("MVM_HOME", &tmp)
+        .args(["machine", "warm-restore", "no-such-checkpoint"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "warm-restore must fail for a missing checkpoint; stderr: {stderr}"
+    );
+    assert!(!stderr.contains("panic"), "warm-restore panicked: {stderr}");
+    assert!(
+        !stderr.contains("thread panicked"),
+        "warm-restore panicked: {stderr}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// The `--json` output flag is accepted by the parser.
+#[test]
+fn machine_warm_restore_json_flag_parses() {
+    let tmp =
+        std::env::temp_dir().join(format!("mvm-warm-restore-json-test-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .env("MVM_HOME", &tmp)
+        .args(["machine", "warm-restore", "no-such-checkpoint", "--json"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("unexpected argument") && !stderr.contains("unrecognized"),
+        "--json must parse cleanly, stderr: {stderr}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/specs/plans/265-fast-start-slo-sequencing-positioning.md
+++ b/specs/plans/265-fast-start-slo-sequencing-positioning.md
@@ -109,9 +109,11 @@ Firecracker spawn per restore; neither alone reaches the SLO.
 
 ### WS4 — Witnesses (prerequisite-gated)
 
-- [ ] Prerequisite: wire a `machine` CLI verb that drives the vm_full warm
-      fork/restore — there is no user-facing warm-restore verb today; the number
-      comes only from the Rust `@live` harness.
+- [x] Prerequisite: wire a `machine` CLI verb that drives the vm_full warm
+      fork/restore — `machine warm-restore` added in `crates/mvm-cli` with
+      JSON/text output, unit/CLI tests, and claim-catalog/clippy/fmt gates green.
+      The lower-level env-var guard is bypassed internally because the verb
+      itself is the explicit opt-in.
 - [ ] Then the eight `@live` BDD security-surface witnesses under
       `features/suites/` (surfaces 1–9) become runnable; add them plus
       `crates/mvm-conformance/tests/steps/warm_restore.rs`.

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -229,6 +229,13 @@ const MACHINE_SUB: &[(&str, AuditPosture)] = &[
         "advance",
         AuditPosture::Emits("CheckpointRestored+image.reverted"),
     ),
+    // Warm fork/restore of a vm_full checkpoint into a fresh child VM. The
+    // fork emits `checkpoint.forked` against the parent plan and the restored
+    // child follows the normal admitted launch trail (`plan.launched`).
+    (
+        "warm-restore",
+        AuditPosture::Emits("CheckpointForked+plan.launched"),
+    ),
     // Advanced single-VM verbs folded under `machine` (hidden from default help).
     // The audit postures are unchanged from when these lived under `vm <sub>`.
     ("pause", AuditPosture::Emits("VmStop")),


### PR DESCRIPTION
Adds the user-facing `mvmctl machine warm-restore <CHECKPOINT_ID>` verb that drives the existing Firecracker vm_full warm fork/restore path.

- New `commands/machine/checkpoint.rs` wraps the audited fork helpers from `commands/vm/checkpoint.rs`.
- The verb auto-generates a child VM name, validates the checkpoint class, admits a fresh claim-8 plan, verifies lineage, restores via `FcForkRestorer`, and delivers the post-restore generation token.
- The lower-level `MVM_FORK_VMFULL_FC_EXPERIMENTAL` guard is bypassed internally because the verb itself is the explicit opt-in.
- Exposed the required vm_full fork helpers as `pub(in crate::commands)` and removed the duplicate wrapper from `vm/checkpoint.rs`.
- Added CLI contract tests for help output, `--json`, and graceful failure on a missing checkpoint.
- Updated `machine/tests.rs` and `tests/audit_total_coverage.rs` to cover the new `WarmRestore` action.

Validation:
- `cargo check -p mvm-cli`
- `cargo test -p mvm-cli commands::machine`
- `cargo test -p mvm-cli --test cli`
- `cargo test -p mvmctl --test audit_total_coverage`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo run -p xtask -- check-claim-catalog` (clean)
- Pre-commit hook passed.

The live KVM warm-pool timing harness was not run because the test box is currently unreachable.