### PR TITLE
Reduce development GitHub Actions fan-out

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -12,8 +12,6 @@ name: Architecture invariants
 # day-to-day CI surface.
 
 on:
-  push:
-    branches: [main]
   pull_request:
   # Required for the merge queue: the Invariant check must run on merge_group.
   merge_group:

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,8 +1,8 @@
 name: Full CI (manual)
 
 on:
-  # Operator-triggered full matrix. Normal pushes use ci.yml, which is
-  # intentionally capped at four jobs so day-to-day pushes do not fan
+  # Operator-triggered full matrix. Pull requests use ci.yml, which is
+  # intentionally capped at four jobs so day-to-day changes do not fan
   # out into the platform, live-VM, and OCI ratification lanes.
   workflow_dispatch:
 
@@ -19,7 +19,7 @@ env:
   RUSTFLAGS: "-D warnings"
 
 # ── Lane shape ────────────────────────────────────────────────────────
-# Manual full-matrix workflow. Normal branch pushes intentionally do
+# Manual full-matrix workflow. Normal pull requests intentionally do
 # not invoke this file; they use ci.yml's four-job day-to-day surface.
 # Use this workflow when an operator wants all historical CI lanes
 # without cutting a release tag.
@@ -271,7 +271,7 @@ jobs:
 
   # Note: cargo-audit, cargo-deny, reproducibility, and prod-agent-no-exec
   # were duplicated here AND in security.yml. They now live only in
-  # security.yml (which fires on the same triggers — push to main + PRs).
+  # security.yml, which runs nightly and before release publication.
 
   # ── Lane: sealed-prod vsock allowlist locked (plan 76 Phase 1) ────
   # Plan 76 §"Phase 8 — Security regression gate" (partial). The big

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,12 @@
 name: CI
 
 on:
-  # Keep ordinary pushes cheap and predictable. This workflow is the
-  # day-to-day signal and is intentionally capped at four jobs:
+  # Keep pull-request validation cheap and predictable. This workflow is
+  # intentionally capped at four runner jobs:
   # lint, test, MCP smoke, and Nix eval. Expensive platform, live-VM,
   # OCI ratification, security, Windows, and release artifact jobs live
   # in release/manual workflows.
-  push:
-    # Exclude the merge-queue transient branches — covered by merge_group below.
-    branches: ["**", "!gh-readonly-queue/**"]
+  pull_request:
   # Required for the merge queue: checks must run against the merge_group event.
   merge_group:
   workflow_dispatch:
@@ -256,9 +254,14 @@ jobs:
       - name: Install system build deps
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update
-          sudo apt-get install -y libcap-ng-dev lld
+          sudo apt-get install -y attr cryptsetup-bin libcap-ng-dev lld
 
       - uses: ./.github/actions/install-zigbuild
+
+      - name: Install pinned no_std toolchain and targets
+        run: |
+          rustup toolchain install 1.96.0 --profile minimal \
+            --target wasm32-unknown-unknown,wasm32-wasip1,riscv32imac-unknown-none-elf
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -274,6 +277,11 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
 
       - name: Build
         run: cargo build --all-targets
@@ -302,55 +310,104 @@ jobs:
         # nextest does not run doctests; gate them separately.
         run: cargo test --workspace --doc
 
-  bdd-smoke:
-    name: BDD / conformance meta-gate smoke
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
-      - name: Install system build deps
+      - name: Install wasmtime (wasm32-wasip1 test runner)
+        env:
+          # Pinned to match the wasmtime crate version in Cargo.lock.
+          WASMTIME_VERSION: "46.0.1"
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
-          sudo apt-get update
-          sudo apt-get install -y libcap-ng-dev lld
+          set -euo pipefail
+          tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
+          base="wasmtime-v${WASMTIME_VERSION}-x86_64-linux"
+          curl -fsSL "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/${base}.tar.xz" \
+            | tar -xJf - -C "$tmpdir"
+          mkdir -p "$HOME/.wasmtime/bin"
+          mv "$tmpdir/${base}/wasmtime" "$HOME/.wasmtime/bin/wasmtime"
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
 
-      - uses: ./.github/actions/install-zigbuild
+      - name: mvm-protocol builds no_std + alloc on wasm and bare metal
+        run: |
+          cargo +1.96.0 build -p mvm-protocol --target wasm32-unknown-unknown
+          cargo +1.96.0 build -p mvm-protocol --lib \
+            --target riscv32imac-unknown-none-elf
 
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: just
+      - name: mvm-protocol tests run under wasm
+        run: cargo +1.96.0 test -p mvm-protocol --target wasm32-wasip1
 
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-bdd-smoke-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-bdd-smoke-
+      - name: Write a sample ext4 image
+        run: cargo run -p mvm-fs --example write_sample -- /tmp/sample.ext4 | tee /tmp/sample.out
 
-      # Hermetic BDD: no live microVMs. @live/@firecracker/@bundle scenarios
-      # are skipped because MVM_BDD_LIVE is unset and no bundle fixture is
-      # supplied. The meta-gate validates R3 (register ↔ scenarios ↔ witnesses).
-      - name: Conformance meta-gate (R3)
+      - name: Loop-mount read-only and verify the ext4 tree
+        run: |
+          set -euo pipefail
+          mnt=$(mktemp -d)
+          sudo mount -o ro,loop /tmp/sample.ext4 "$mnt"
+          trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
+          [ "$(cat "$mnt/etc/hosts")" = "127.0.0.1 localhost" ]
+          diff <(printf 'hi from pure-rust ext4\n') "$mnt/hello"
+          [ "$(readlink "$mnt/etc/localhost")" = "hosts" ]
+          [ -d "$mnt/bin" ] && [ -d "$mnt/etc" ]
+          [ "$(stat -c '%a' "$mnt/hello")" = "755" ]
+          [ "$(stat -c '%a' "$mnt/etc/hosts")" = "644" ]
+          [ "$(stat -c '%s' "$mnt/big")" = "716800" ]
+          cap=$(sudo getfattr --absolute-names -n security.capability -e hex "$mnt/bin/ping" \
+            | grep '^security.capability=' | cut -d= -f2)
+          echo "security.capability=$cap"
+          [ "$cap" = "0x0000000200300000000000000000000000000000" ]
+
+      - name: Match dm-verity output against veritysetup
+        run: |
+          set -euo pipefail
+          ours=$(grep '^ROOTHASH ' /tmp/sample.out | awk '{print $2}')
+          theirs=$(veritysetup format --no-superblock \
+              --data-block-size=4096 --hash-block-size=4096 \
+              --salt=0000000000000000000000000000000000000000000000000000000000000000 \
+              /tmp/sample.ext4 /tmp/vs.verity \
+            | awk '/^Root hash:/ {print $3}')
+          echo "ours=$ours theirs=$theirs"
+          [ -n "$ours" ] && [ "$ours" = "$theirs" ]
+          if ! cmp -s /tmp/sample.ext4.verity /tmp/vs.verity; then
+            echo "::error::hash tree differs from veritysetup"
+            ls -l /tmp/sample.ext4.verity /tmp/vs.verity
+            cmp -l /tmp/sample.ext4.verity /tmp/vs.verity | head -20 || true
+            exit 1
+          fi
+
+      - name: Loop-mount a multi-block-group ext4 image
+        run: |
+          set -euo pipefail
+          cargo run -p mvm-fs --example write_multigroup -- /tmp/multigroup.ext4
+          [ "$(stat -c '%s' /tmp/multigroup.ext4)" -gt 134217728 ]
+          mnt=$(mktemp -d)
+          sudo mount -o ro,loop /tmp/multigroup.ext4 "$mnt"
+          trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
+          [ "$(cat "$mnt/etc/marker")" = "multi-group marker" ]
+          [ "$(stat -c '%s' "$mnt/big")" = "136314880" ]
+          off=134000000
+          got=$(dd if="$mnt/big" bs=1 skip=$off count=1 2>/dev/null | od -An -tu1 | tr -d ' ')
+          [ "$got" = "$((off % 251))" ]
+
+      - name: Loop-mount a depth-1 extent-tree ext4 image
+        run: |
+          set -euo pipefail
+          cargo run -p mvm-fs --example write_extent_tree -- /tmp/extent_tree.ext4
+          [ "$(stat -c '%s' /tmp/extent_tree.ext4)" -gt 536870912 ]
+          mnt=$(mktemp -d)
+          sudo mount -o ro,loop /tmp/extent_tree.ext4 "$mnt"
+          trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
+          [ "$(cat "$mnt/etc/marker")" = "extent-tree marker" ]
+          [ "$(stat -c '%s' "$mnt/huge")" = "545259520" ]
+          off=537000000
+          got=$(dd if="$mnt/huge" bs=1 skip=$off count=1 2>/dev/null | od -An -tu1 | tr -d ' ')
+          [ "$got" = "$((off % 251))" ]
+
+      # Hermetic BDD: live microVM and bundle scenarios remain opt-in. The
+      # meta-gate validates the claim register against scenarios and witnesses.
+      - name: Conformance meta-gate
         run: cargo test -p mvm-conformance --test meta
 
       - name: Hermetic BDD scenarios
         run: just bdd
-
-  sdk-release-dry-run:
-    name: SDK release dry-run
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/publish-sdk.yml
-    with:
-      dry_run: true
 
   mcp-server-smoke:
     name: MCP server stdio roundtrip
@@ -407,190 +464,3 @@ jobs:
           set -euo pipefail
           nix build --print-build-logs \
             ./nix#checks.x86_64-linux.guest-rootfs-no-glibc
-
-  # `mvm-protocol` is `no_std` + `alloc` (the IR, wire protocol, policy/audit
-  # DTOs, and the audit-log verifier) so the same logic can run in a browser.
-  # A `std`/OS-only API creeping into its default build is the one thing that
-  # would break that — and the wasm32-unknown-unknown *build itself* is the
-  # proof: it only succeeds if the crate stays no_std-clean, so no separate
-  # lint is needed. The crate also goes `std` under `cfg(test)` (libtest
-  # needs `std` to link), so its tests run for real under wasm on
-  # wasm32-wasip1 via wasmtime, confirming the no_std surface behaves
-  # correctly and not just that it compiles.
-  wasm-no-std-boundary:
-    name: mvm-protocol wasm32 no_std boundary
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
-        with:
-          targets: wasm32-unknown-unknown,wasm32-wasip1
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-wasm-
-
-      - name: Install wasmtime (wasm32-wasip1 test runner)
-        env:
-          # Pinned to match the wasmtime crate version in Cargo.lock.
-          # Bump intentionally when the wasmtime dependency is updated.
-          WASMTIME_VERSION: "46.0.1"
-        run: |
-          set -euo pipefail
-          tmpdir="$(mktemp -d)"
-          trap 'rm -rf "$tmpdir"' EXIT
-          base="wasmtime-v${WASMTIME_VERSION}-x86_64-linux"
-          curl -fsSL "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/${base}.tar.xz" \
-            | tar -xJf - -C "$tmpdir"
-          mkdir -p "$HOME/.wasmtime/bin"
-          mv "$tmpdir/${base}/wasmtime" "$HOME/.wasmtime/bin/wasmtime"
-          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
-
-      - name: mvm-protocol builds no_std + alloc on wasm32-unknown-unknown
-        run: cargo build -p mvm-protocol --target wasm32-unknown-unknown
-
-      - name: mvm-protocol tests run under wasm (wasm32-wasip1, via wasmtime)
-        run: cargo test -p mvm-protocol --target wasm32-wasip1
-
-  # A bare-metal `*-none-*` target is a stricter no_std proof than wasm32:
-  # wasm32-unknown-unknown still ships a partial `std`, so a stray `std::` path
-  # can slip through there, whereas a `-none-elf` target has no `std` to leak
-  # into at all — only `core` + `alloc`. This gate is what lets the verifier
-  # (chain-signed audit log + Merkle inclusion proofs) run on a
-  # microcontroller-class device that provides no operating system. riscv32imac
-  # is the closest mainline target to the RISC-V microcontrollers this is aimed
-  # at and needs no out-of-tree toolchain, so the gate stays hermetic. A
-  # lib-only build (rlib, no final link) needs no cross-linker, keeping the
-  # check fast and dependency-light.
-  baremetal-no-std-boundary:
-    name: mvm-protocol bare-metal no_std boundary
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
-        with:
-          targets: riscv32imac-unknown-none-elf
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-baremetal-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-baremetal-
-
-      - name: mvm-protocol builds no_std + alloc on riscv32imac-unknown-none-elf
-        run: cargo build -p mvm-protocol --lib --target riscv32imac-unknown-none-elf
-
-  # The pure-Rust `mvm-ext4` writer (Plan 221) must produce an image the real
-  # Linux kernel mounts — the strongest correctness oracle, beyond the in-process
-  # `am-fs-ext4` read oracle. Write a fixed sample image and loop-mount it.
-  ext4-real-mount:
-    name: mvm-ext4 output mounts on the real kernel
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
-      - name: Write a sample image with the pure-Rust ext4 writer
-        run: cargo run -p mvm-fs --example write_sample -- /tmp/sample.ext4 | tee /tmp/sample.out
-      - name: Loop-mount read-only and verify the tree on the real kernel
-        run: |
-          set -euo pipefail
-          mnt=$(mktemp -d)
-          sudo mount -o ro,loop /tmp/sample.ext4 "$mnt"
-          trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
-          # File contents ($() strips the trailing newline).
-          [ "$(cat "$mnt/etc/hosts")" = "127.0.0.1 localhost" ]
-          diff <(printf 'hi from pure-rust ext4\n') "$mnt/hello"
-          # Symlink resolves to its target.
-          [ "$(readlink "$mnt/etc/localhost")" = "hosts" ]
-          # Directories present.
-          [ -d "$mnt/bin" ] && [ -d "$mnt/etc" ]
-          # Permissions preserved.
-          [ "$(stat -c '%a' "$mnt/hello")" = "755" ]
-          [ "$(stat -c '%a' "$mnt/etc/hosts")" = "644" ]
-          [ "$(stat -c '%s' "$mnt/big")" = "716800" ]
-          # Inline xattr: the real kernel reads back the security.capability the
-          # writer emitted, byte-for-byte (getfattr reads raw bytes — no cap
-          # validation — so an arbitrary fixed blob round-trips deterministically).
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y attr
-          cap=$(sudo getfattr --absolute-names -n security.capability -e hex "$mnt/bin/ping" \
-            | grep '^security.capability=' | cut -d= -f2)
-          echo "security.capability=$cap"
-          [ "$cap" = "0x0000000200300000000000000000000000000000" ]
-          echo "pure-Rust ext4 mounted + verified on the real Linux kernel"
-      - name: dm-verity root hash + hash tree match real veritysetup
-        run: |
-          set -euo pipefail
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y cryptsetup-bin
-          # Our writer printed `ROOTHASH <hex>` and wrote the no-superblock hash
-          # tree to `<image>.verity`.
-          ours=$(grep '^ROOTHASH ' /tmp/sample.out | awk '{print $2}')
-          # Real veritysetup, same params (v1, sha256, 4 KiB data+hash blocks,
-          # 32-byte zero salt). --no-superblock keeps the tree deterministic (no
-          # random UUID) and matches our `format()` layout.
-          theirs=$(veritysetup format --no-superblock \
-              --data-block-size=4096 --hash-block-size=4096 \
-              --salt=0000000000000000000000000000000000000000000000000000000000000000 \
-              /tmp/sample.ext4 /tmp/vs.verity \
-            | awk '/^Root hash:/ {print $3}')
-          echo "ours=$ours theirs=$theirs"
-          [ -n "$ours" ] && [ "$ours" = "$theirs" ]
-          # Hash-tree bytes must match byte-for-byte.
-          if ! cmp -s /tmp/sample.ext4.verity /tmp/vs.verity; then
-            echo "::error::hash tree differs from veritysetup"
-            ls -l /tmp/sample.ext4.verity /tmp/vs.verity
-            cmp -l /tmp/sample.ext4.verity /tmp/vs.verity | head -20 || true
-            exit 1
-          fi
-          echo "pure-Rust dm-verity root hash + hash tree == veritysetup"
-      - name: Write + loop-mount a MULTI-block-group image (> 128 MiB)
-        run: |
-          set -euo pipefail
-          cargo run -p mvm-fs --example write_multigroup -- /tmp/multigroup.ext4
-          # Sanity: bigger than one group's 128 MiB.
-          [ "$(stat -c '%s' /tmp/multigroup.ext4)" -gt 134217728 ]
-          mnt=$(mktemp -d)
-          sudo mount -o ro,loop /tmp/multigroup.ext4 "$mnt"
-          trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
-          [ "$(cat "$mnt/etc/marker")" = "multi-group marker" ]
-          # The big file spans two block groups as two extents — size + a byte
-          # past the group boundary must read back correctly.
-          [ "$(stat -c '%s' "$mnt/big")" = "136314880" ]
-          # Byte at offset 130 MiB-ish (well past the first group) follows the
-          # i%251 pattern the example wrote.
-          off=134000000
-          got=$(dd if="$mnt/big" bs=1 skip=$off count=1 2>/dev/null | od -An -tu1 | tr -d ' ')
-          [ "$got" = "$((off % 251))" ]
-          echo "multi-group pure-Rust ext4 mounted + verified on the real Linux kernel"
-      - name: Write + loop-mount a DEPTH-1 extent-tree image (>512 MiB single file)
-        run: |
-          set -euo pipefail
-          cargo run -p mvm-fs --example write_extent_tree -- /tmp/extent_tree.ext4
-          # >4 groups → the single file needs a depth-1 extent tree.
-          [ "$(stat -c '%s' /tmp/extent_tree.ext4)" -gt 536870912 ]
-          mnt=$(mktemp -d)
-          sudo mount -o ro,loop /tmp/extent_tree.ext4 "$mnt"
-          trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
-          [ "$(cat "$mnt/etc/marker")" = "extent-tree marker" ]
-          # The huge file is 520 MiB and must read back through the extent tree.
-          [ "$(stat -c '%s' "$mnt/huge")" = "545259520" ]
-          # A byte well past the 4th group boundary (~513 MiB in) must follow the
-          # i%251 pattern — proves the depth-1 leaf extents resolve correctly.
-          off=537000000
-          got=$(dd if="$mnt/huge" bs=1 skip=$off count=1 2>/dev/null | od -An -tu1 | tr -d ' ')
-          [ "$got" = "$((off % 251))" ]
-          echo "depth-1 extent-tree pure-Rust ext4 mounted + verified on the real Linux kernel"

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -15,9 +15,15 @@
       `xtask` gates for R1 (`check-conformance`), R2 (`check-honesty`), and R4
       (`check-deferrals`). Added an R3 meta-gate in `mvm-conformance/tests/meta.rs`
       tying registered IDs to Gherkin scenarios and witnesses. Wired the gates
-      into `just lint`, added a hermetic BDD smoke job to PR CI, and documented
-      falsifiability in `specs/VERIFICATION.md`. Full workspace clippy, xtask
-      tests, and the meta-gate pass.
+      into `just lint`, added hermetic BDD smoke coverage to PR CI's existing
+      test runner, and documented falsifiability in `specs/VERIFICATION.md`.
+      Full workspace clippy, xtask tests, and the meta-gate pass.
+
+- [x] Restore the accepted four-job development CI budget: consolidate
+      no-std and real-kernel filesystem checks into the existing test runner,
+      keep the SDK publication dry-run in the manual full matrix, and remove
+      speculative pre-PR and redundant post-merge `main` runs without changing
+      required check names.
 
 - [x] #1840 faithful flake-image revert: boot the recorded slot revision,
       reconcile signed artifact hashes, and preserve the admitted restore path.

--- a/specs/adrs/012-ci-execution-policy.md
+++ b/specs/adrs/012-ci-execution-policy.md
@@ -1,4 +1,4 @@
-# ADR-012: CI execution policy — push runs a lean lane; the full matrix and release gates are separately triggered
+# ADR-012: CI execution policy — pull requests run a lean lane; the full matrix and release gates are separately triggered
 
 ## Status
 
@@ -6,11 +6,14 @@ Accepted.
 
 ## Context
 
-A push with no PR open still needs fast feedback, and every push
-shouldn't pay for platform lanes (macOS, live KVM), OCI ratification, or
-a dependency audit that only need to run before a release or on
-deliberate request. Heavy, expensive lanes running on every push slow
-down day-to-day iteration for no proportional benefit.
+Hosted CI should produce merge signal, not run speculatively on every
+development-branch push. Contributors can run `just ci` locally or
+dispatch a workflow manually before opening a pull request. Once a pull
+request exists, each update still needs fast feedback, but it should not
+pay for platform lanes (macOS, live KVM), OCI ratification, or a
+dependency audit that only need to run before a release or on deliberate
+request. Heavy, expensive lanes running during every iteration slow down
+day-to-day development for no proportional benefit.
 
 ## Decision
 
@@ -18,8 +21,8 @@ down day-to-day iteration for no proportional benefit.
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `ci.yml` | `push` (any branch, excluding merge-queue transient refs) + `merge_group` + `workflow_dispatch` | day-to-day signal on every push; a required merge-queue check |
-| `architecture.yml` | `push: main` + `pull_request` + `merge_group` + `workflow_dispatch` | structural/architectural invariants; a required merge-queue check |
+| `ci.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | day-to-day pull-request signal; a required merge-queue check |
+| `architecture.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | structural/architectural invariants; a required merge-queue check |
 | `ci-full.yml` | `workflow_dispatch` only | the full platform + live-VM + OCI-ratification matrix; operator-triggered, never automatic |
 | `security.yml` | `push: tags: v*` + nightly cron + `workflow_dispatch` | dependency audit / advisory scan; release-time backstop plus nightly catch for new advisories |
 | `windows.yml` | `push: tags: v*` + `workflow_dispatch` | non-blocking informational Windows build check; never a required check |
@@ -28,11 +31,19 @@ down day-to-day iteration for no proportional benefit.
 ### `ci.yml` is capped at four jobs
 
 `lint` (fmt, clippy, and the full battery of `xtask` architectural
-checks — see ADR-010), `test` (the workspace nextest run),
-`mcp-server-smoke`, and `nix-flake-check`. Nothing
-platform-specific (macOS, live KVM, Windows) or slow (OCI ratification,
-dependency audit, the full builder-VM image build) runs on every push —
-those live in `ci-full.yml`, run only by explicit `workflow_dispatch`.
+checks — see ADR-010), `test` (the workspace nextest run, doctests,
+hermetic BDD, no-std target checks, and real-kernel ext4 checks),
+`mcp-server-smoke`, and `nix-flake-check`. The SDK publication dry-run
+is part of the manual full matrix rather than the development lane.
+Nothing platform-specific (macOS, live KVM, Windows) or slow (OCI
+ratification, dependency audit, the full builder-VM image build) runs on
+every pull request — those live in `ci-full.yml`, run only by explicit
+`workflow_dispatch`.
+
+Checks that need the same Linux and Rust environment are steps in one of
+these four jobs, not standalone jobs. This shares checkout, toolchain,
+dependency installation, and cache overhead while retaining the same
+behavioral coverage.
 
 ### The merge queue's required checks
 
@@ -55,23 +66,29 @@ slow to run on every commit.
 
 ### `just ci`
 
-`just ci` (`lint`, `test`, `test-doc`, `bdd`) reproduces what `ci.yml`'s
-push lane checks, so a contributor can sanity-check locally before
-pushing.
+`just ci` (`lint`, `test`, `test-doc`, `bdd`) reproduces the core Rust
+checks from `ci.yml`, so a contributor can sanity-check locally before
+pushing. The workflow additionally exercises Linux-only real-kernel
+filesystem behavior, no-std cross-target boundaries, MCP stdio, and Nix
+evaluation on the hosted Linux runner.
 
 ## Consequences
 
-An ordinary push gets fast, complete feedback from the checks that
+A pull-request update gets fast, complete feedback from the checks that
 matter for almost every change — four Linux-only jobs plus the
-architecture-invariant lane. An operator opts into the expensive
-platform, live-VM, and OCI-ratification matrix deliberately through
-`ci-full.yml`, rather than paying for it on every push.
+architecture-invariant lane. Development branches without a pull request
+consume no hosted runners unless an operator dispatches CI manually. The
+merge queue runs the same five required checks against the final merge
+group. Landing that already-checked commit on `main` does not run them a
+third time. An operator opts into the expensive platform, live-VM,
+SDK-publication dry-run, and OCI-ratification matrix deliberately through
+`ci-full.yml`, rather than paying for it on every update.
 
 A change that only breaks on macOS or under live KVM is not caught until
 someone runs `ci-full.yml`, or until a release-time gate runs — there is
-a real gap between "push is green" and "every platform has been
+a real gap between "the PR is green" and "every platform has been
 exercised."
 
 Release-time-only gates (`security.yml`, `windows.yml`, `release.yml`)
-stay timed to minimize per-push cost while still forming a hard backstop
+stay timed to minimize development cost while still forming a hard backstop
 before anything ships.


### PR DESCRIPTION
## What changed

- run development CI only for pull requests, merge groups, and manual dispatches
- restore the accepted four-job CI budget by folding wasm, bare-metal, and real-kernel ext4 checks into the existing test runner
- keep the SDK publication dry-run in the manual full matrix
- stop rerunning architecture and CI checks after an already-validated merge lands on `main`
- update ADR-012 and the sprint status to match the execution policy

## Why

The development workflow had drifted from four CI runner jobs to ten, plus the architecture invariant job. A typical one-push PR was validated on the branch, in the merge queue, and again after landing on `main`, creating roughly 33 runner jobs for one change.

This reduces each validation event to the five existing required checks and removes speculative pre-PR and redundant post-merge runs. A typical one-push PR now uses roughly 10 runner jobs across PR validation and the merge queue, about 70% fewer, without changing branch-protection check names.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/ci-full.yml .github/workflows/architecture.yml`
- parsed all workflow YAML files
- verified all five live branch-protection contexts are still produced
- built `mvm-protocol` for `wasm32-unknown-unknown` and `riscv32imac-unknown-none-elf`
- ran 365 `mvm-protocol` tests under `wasm32-wasip1` via wasmtime
- `git diff --check`
