### PR TITLE
feat(standby): give a claimed child the host channels a cold boot gets

### DIFF
--- a/crates/mvm-runtime/src/driver/fc.rs
+++ b/crates/mvm-runtime/src/driver/fc.rs
@@ -29,7 +29,7 @@ use crate::backend::FirecrackerBackend;
 use crate::driver::spec::KernelImage;
 use crate::driver::{
     BlockDev, ChildForkRequest, DuplexStream, RunningVm, StandbyParentSpawn, VmmDriver, VmmSpec,
-    VsockDirection,
+    VsockDirection, VsockPort,
 };
 use crate::microvm::{
     FirecrackerGuard, api_put_socket, balloon_body, boot_source_body, drive_body, fc_pid_path,
@@ -219,9 +219,17 @@ fn fc_guest_dial_socket(runtime_dir: &Path, port: u32) -> PathBuf {
 /// endpoint (the claim-critical one), and the host-services broker.
 /// `HostDials` ports (agent, dev-console) are not bridged here: the host
 /// dials those inbound through the CONNECT handshake on the mux socket.
-fn wire_guest_dial_bridges(spec: &VmmSpec, runtime_dir: &Path) -> Result<Vec<(PathBuf, PathBuf)>> {
+///
+/// Takes the channel list rather than a whole `VmmSpec` because both start
+/// paths need it and only one of them has a spec: a cold boot passes the spec it
+/// is about to boot, and a warm claim passes the channels the role layer
+/// resolved for a child whose device model comes from restored memory.
+fn wire_guest_dial_bridges(
+    channels: &[VsockPort],
+    runtime_dir: &Path,
+) -> Result<Vec<(PathBuf, PathBuf)>> {
     let mut created = Vec::new();
-    for port in &spec.vsock {
+    for port in channels {
         if port.direction != VsockDirection::GuestDials {
             continue;
         }
@@ -270,6 +278,26 @@ fn spawn_workload_exit_capture(runtime_dir: &Path, state_dir: &Path) {
             sock.display()
         ),
     }
+}
+
+/// Put the host end of every channel the guest dials in place, then arm the
+/// workload-exit capture — the whole host-side channel set a Firecracker guest
+/// needs before it is able to dial anything.
+///
+/// Both start paths run this, and both run it before the guest's vCPUs do
+/// anything: a cold boot before `InstanceStart`, a warm claim before the restore
+/// resumes the child. The claim's window is the tighter of the two, because a
+/// restored guest is already past its own boot — it can dial its egress
+/// endpoint, its broker, and its exit reporter the instant it resumes, whereas a
+/// cold-booted guest spends a kernel boot getting there.
+///
+/// A prior run's captured exit code is cleared first, so a reader observes this
+/// launch's exit status and never a stale one.
+fn arm_host_channels(channels: &[VsockPort], state_dir: &Path, runtime_dir: &Path) -> Result<()> {
+    let _ = std::fs::remove_file(mvm_core::exit_capture::exit_file_path(state_dir));
+    wire_guest_dial_bridges(channels, runtime_dir)?;
+    spawn_workload_exit_capture(runtime_dir, state_dir);
+    Ok(())
 }
 
 /// The stop signal to deliver to the Firecracker process during teardown.
@@ -519,6 +547,28 @@ impl VmmDriver for FcDriver {
             )));
         }
 
+        // Arm the child's host channel set before anything resumes it. The
+        // restore below brings the guest back already booted, so the moment its
+        // vCPUs run it can dial its egress endpoint, its broker and its exit
+        // reporter; a cold boot gets the same wiring, just with a whole kernel
+        // boot of slack. Wiring after the restore would leave a live guest
+        // dialing sockets that do not exist — egress dark, host services
+        // silently unavailable, and no exit code recorded.
+        let runtime_dir = req.child_dir.join("runtime");
+        std::fs::create_dir_all(&runtime_dir).map_err(|e| {
+            StandbyError::ClaimFailed(format!(
+                "fork child '{}': create runtime dir {}: {e}",
+                req.child_vm_name,
+                runtime_dir.display()
+            ))
+        })?;
+        arm_host_channels(req.channels, req.child_dir, &runtime_dir).map_err(|e| {
+            StandbyError::ClaimFailed(format!(
+                "fork child '{}': wiring its host channels: {e}",
+                req.child_vm_name
+            ))
+        })?;
+
         // Restore the parent's saved memory into a fresh VMM under the child's
         // own identity. The device-model guard between load and resume refuses
         // any snapshot carrying a network interface, so a restored child cannot
@@ -545,9 +595,9 @@ impl VmmDriver for FcDriver {
         let abs_dir = state_dir.to_string_lossy().into_owned();
         let pid_file = fc_pid_path(&spec.name)
             .ok_or_else(|| anyhow!("resolve Firecracker pid path for '{}'", spec.name))?;
-        // Clear any prior run's captured exit code and stale pid marker so `wait`
-        // and the readiness poll observe only this launch's.
-        let _ = std::fs::remove_file(mvm_core::exit_capture::exit_file_path(&state_dir));
+        // Clear the stale pid marker so the readiness poll observes only this
+        // launch's process (the captured exit code is cleared with the rest of
+        // the host channel set, in `arm_host_channels`).
         let _ = std::fs::remove_file(&pid_file);
 
         // Convert the workload kernel to an FC-loadable image (x86_64 bzImage →
@@ -579,11 +629,10 @@ impl VmmDriver for FcDriver {
                 .with_context(|| format!("Firecracker API PUT {}", put.path))?;
         }
 
-        // Wire the guest-dial egress/broker bridges, then bind the
-        // workload-exit capture — both must be in place before the guest boots
-        // and dials out.
-        wire_guest_dial_bridges(spec, &runtime_dir)?;
-        spawn_workload_exit_capture(&runtime_dir, &state_dir);
+        // Wire the guest-dial egress/broker bridges and bind the workload-exit
+        // capture — the whole host channel set must be in place before the guest
+        // boots and dials out.
+        arm_host_channels(&spec.vsock, &state_dir, &runtime_dir)?;
 
         // Boot the configured instance.
         api_put_socket(&socket, "/actions", r#"{"action_type": "InstanceStart"}"#)
@@ -770,7 +819,7 @@ impl RunningVm for FcRunningVm {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::driver::{ConsoleCapture, VsockPort};
+    use crate::driver::ConsoleCapture;
     use mvm_agentd::vsock::{BROKER_PORT, EGRESS_PORT};
 
     fn host_dials(guest_port: u32, uds: &str) -> VsockPort {
@@ -787,6 +836,17 @@ mod tests {
             host_uds: uds.into(),
             direction: VsockDirection::GuestDials,
         }
+    }
+
+    /// The four standing channels a workload VM carries: the agent RPC the host
+    /// dials, and the egress, broker and exit ports the guest dials.
+    fn workload_channels() -> Vec<VsockPort> {
+        vec![
+            host_dials(GUEST_AGENT_PORT, "/run/agent.sock"),
+            guest_dials(EGRESS_PORT, "/run/egress.sock"),
+            guest_dials(BROKER_PORT, "/run/broker.sock"),
+            guest_dials(WORKLOAD_EXIT_PORT, "/state/w/workload.exit"),
+        ]
     }
 
     fn spec_with(kernel: KernelImage, vsock: Vec<VsockPort>, blocks: Vec<BlockDev>) -> VmmSpec {
@@ -1059,17 +1119,7 @@ mod tests {
     fn wire_guest_dial_bridges_links_egress_and_broker_but_not_exit_or_agent() {
         let dir = tempfile::tempdir().unwrap();
         let runtime = dir.path();
-        let spec = spec_with(
-            KernelImage::Path("/img/vmlinux".into()),
-            vec![
-                host_dials(GUEST_AGENT_PORT, "/run/agent.sock"),
-                guest_dials(EGRESS_PORT, "/run/egress.sock"),
-                guest_dials(BROKER_PORT, "/run/broker.sock"),
-                guest_dials(WORKLOAD_EXIT_PORT, "/state/w/workload.exit"),
-            ],
-            vec![],
-        );
-        let created = wire_guest_dial_bridges(&spec, runtime).unwrap();
+        let created = wire_guest_dial_bridges(&workload_channels(), runtime).unwrap();
         assert_eq!(created.len(), 2, "only egress + broker are bridged");
 
         // Egress: v.sock_5253 → the runner's endpoint socket.
@@ -1511,6 +1561,7 @@ mod tests {
             child_vm_name: "child-vm-1",
             child_dir: &missing,
             genid: sample_generation_token(),
+            channels: &workload_channels(),
         };
 
         let err = FcDriver::new().fork_standby_child(&req).unwrap_err();
@@ -1533,6 +1584,7 @@ mod tests {
             child_vm_name: "child-vm-2",
             child_dir: &child_dir,
             genid: sample_generation_token(),
+            channels: &workload_channels(),
         };
 
         let err = FcDriver::new().fork_standby_child(&req).unwrap_err();
@@ -1540,6 +1592,84 @@ mod tests {
         assert!(
             matches!(err, StandbyError::ClaimFailed(ref m) if m.contains("memory")),
             "expected a ClaimFailed naming the missing memory image, got: {err:?}"
+        );
+    }
+
+    /// A restore resumes a guest that is already booted, so the host end of
+    /// every channel it dials has to exist before `restore_fork` runs — there is
+    /// no kernel boot to cover the gap the way a cold boot's does.
+    ///
+    /// Driven by letting the restore itself fail (no hypervisor here, and the
+    /// clone carries no device anchors): the bridges and the exit listener are
+    /// still on disk afterwards, which they could not be if the wiring ran after
+    /// the restore. The equality against the cold-boot wiring is asserted
+    /// alongside, so a claim cannot come to wire a different set.
+    #[test]
+    fn fork_standby_child_wires_the_childs_host_channels_before_it_attempts_the_restore() {
+        let tmp = tempfile::tempdir().unwrap();
+        let child_dir = tmp.path().join("child");
+        std::fs::create_dir_all(&child_dir).unwrap();
+        std::fs::write(child_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+        std::fs::write(child_dir.join("memory.bin"), b"saved-memory").unwrap();
+
+        let channels = workload_channels();
+        let req = ChildForkRequest {
+            child_vm_name: "child-vm-3",
+            child_dir: &child_dir,
+            genid: sample_generation_token(),
+            channels: &channels,
+        };
+
+        // The restore has no Firecracker to talk to and no device anchors to
+        // read, so it fails — the point is what survives on disk regardless.
+        FcDriver::new()
+            .fork_standby_child(&req)
+            .expect_err("no hypervisor here: the restore itself must fail");
+
+        let runtime = child_dir.join("runtime");
+        // Exactly the bridge set a cold boot of the same channels produces.
+        let cold = tempfile::tempdir().unwrap();
+        for (cold_link, _) in wire_guest_dial_bridges(&channels, cold.path()).unwrap() {
+            let name = cold_link.file_name().unwrap();
+            assert_eq!(
+                std::fs::read_link(runtime.join(name)).ok(),
+                std::fs::read_link(&cold_link).ok(),
+                "the fork must wire {} exactly as a cold boot does",
+                name.to_string_lossy()
+            );
+        }
+        // Named concretely too, so a failure says which channel went dark.
+        assert_eq!(
+            std::fs::read_link(fc_guest_dial_socket(&runtime, EGRESS_PORT)).unwrap(),
+            PathBuf::from("/run/egress.sock"),
+            "the child's egress endpoint must be reachable before it resumes"
+        );
+        assert_eq!(
+            std::fs::read_link(fc_guest_dial_socket(&runtime, BROKER_PORT)).unwrap(),
+            PathBuf::from("/run/broker.sock"),
+            "host.audit.v1 / host.secrets.v1 must be reachable before it resumes"
+        );
+        // The exit port is bound by the driver, not symlinked: a real socket.
+        let exit_sock = fc_guest_dial_socket(&runtime, WORKLOAD_EXIT_PORT);
+        assert!(
+            std::os::unix::net::UnixStream::connect(&exit_sock).is_ok(),
+            "the workload-exit listener must be bound before the child resumes, \
+             or the run reports UNKNOWN instead of the guest's exit code"
+        );
+    }
+
+    /// A factory parent carries no channel at all — it has no gating endpoint
+    /// and no broker to reach — so the same wiring call produces no bridge. The
+    /// parent/workload namespace split is what this preserves: the driver does
+    /// not invent a channel for a spec that names none.
+    #[test]
+    fn wiring_a_channel_less_boot_creates_no_bridge() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(wire_guest_dial_bridges(&[], dir.path()).unwrap().is_empty());
+        assert_eq!(
+            std::fs::read_dir(dir.path()).unwrap().count(),
+            0,
+            "a parent with no channels must leave the runtime dir empty"
         );
     }
 }

--- a/crates/mvm-runtime/src/driver/mock.rs
+++ b/crates/mvm-runtime/src/driver/mock.rs
@@ -17,7 +17,7 @@ use mvm_core::vm_backend::{
 
 use mvm_core::crypto::vmgenid::{GENID_BYTES, GenerationToken};
 
-use crate::driver::spec::VmmSpec;
+use crate::driver::spec::{VmmSpec, VsockPort};
 use crate::driver::traits::{
     ChildForkRequest, DuplexStream, RunningVm, StandbyParentSpawn, VmmDriver,
 };
@@ -46,14 +46,16 @@ fn rotated_child_identity() -> PostRestoreOutcome {
     }
 }
 
-/// A recorded `fork_standby_child` call: the child's fresh name plus the
-/// generation token the fork delivered, so a test can prove a claim delivered a
-/// fresh, content-bound token to the fork (and thus before the child's workload
-/// ran).
+/// A recorded `fork_standby_child` call: the child's fresh name, the generation
+/// token the fork delivered, and the host channel set the fork was asked to wire
+/// — so a test can prove a claim delivered a fresh, content-bound token to the
+/// fork (and thus before the child's workload ran) and handed it the same
+/// channels a cold boot wires.
 #[derive(Clone)]
 pub struct MockChildFork {
     pub child_vm_name: String,
     pub genid: GenerationToken,
+    pub channels: Vec<VsockPort>,
 }
 
 /// Hypervisor-free `VmmDriver` test double.
@@ -253,11 +255,13 @@ impl VmmDriver for MockDriver {
         &self,
         req: &ChildForkRequest<'_>,
     ) -> std::result::Result<(), StandbyError> {
-        // A hypervisor-free fork: record the child's fresh name + the delivered
-        // generation token so a test can prove the claim scrubbed identity and
-        // delivered a fresh, content-bound token to the fork (i.e. at boot,
-        // before the child's workload ran). The runner has already materialized
-        // the CoW clone into `req.child_dir`; the mock needs nothing on disk.
+        // A hypervisor-free fork: record the child's fresh name, the delivered
+        // generation token, and the host channel set the fork was asked to wire,
+        // so a test can prove the claim scrubbed identity, delivered a fresh
+        // content-bound token to the fork (i.e. at boot, before the child's
+        // workload ran), and handed down the channels a cold boot wires. The
+        // runner has already materialized the CoW clone into `req.child_dir`;
+        // the mock needs nothing on disk.
         if !req.child_dir.exists() {
             return Err(StandbyError::ClaimFailed(format!(
                 "fork child '{}': child dir {} was never materialized",
@@ -268,6 +272,7 @@ impl VmmDriver for MockDriver {
         self.forked.lock().unwrap().push(MockChildFork {
             child_vm_name: req.child_vm_name.to_string(),
             genid: req.genid.clone(),
+            channels: req.channels.to_vec(),
         });
         Ok(())
     }

--- a/crates/mvm-runtime/src/driver/traits.rs
+++ b/crates/mvm-runtime/src/driver/traits.rs
@@ -13,7 +13,7 @@ use mvm_core::vm_backend::{
     StandbyHandle, StandbySpec, VmCapabilities, VmExitStatus, VmId, VmStatus,
 };
 
-use crate::driver::spec::VmmSpec;
+use crate::driver::spec::{VmmSpec, VsockPort};
 use crate::vm::instance_snapshot::PostRestoreOutcome;
 
 /// What a driver needs to fork a materialized standby parent into a fresh child
@@ -34,6 +34,22 @@ pub struct ChildForkRequest<'a> {
     /// [`VmmDriver::deliver_child_identity`] before the claim is admissible.
     /// The request carries it so both halves read the same value.
     pub genid: GenerationToken,
+    /// The host end of every vsock channel the child is entitled to: the agent
+    /// RPC the host dials, the gated egress endpoint, the workload-exit report
+    /// and — for an admitted child — the host-services broker.
+    ///
+    /// This is not a boot recipe. A restored child inherits its device model and
+    /// kernel cmdline from the parent's saved memory, so the guest is already
+    /// configured to dial these ports; what is missing on the host is something
+    /// listening on the other end. The driver puts that in place **before** it
+    /// resumes the child: a restore brings back an already-booted guest, so
+    /// there is no kernel boot to cover the gap the way a cold boot's does.
+    ///
+    /// The list is assembled by the role layer from the same mapper a workload
+    /// boot's channel set comes from, never derived here — a second derivation
+    /// is free to drift, and a claimed child that dials a channel nobody bound
+    /// is silently less capable than a cold-booted one.
+    pub channels: &'a [VsockPort],
 }
 
 /// What a driver needs to boot a warm-pool factory parent. Grouped so the seam
@@ -106,6 +122,12 @@ pub trait VmmDriver: Send + Sync {
     /// fork/restore mechanics only: the role layer above has already admitted the
     /// plan, bound it to the parent, materialized the rootfs, and scrubbed the
     /// identity.
+    ///
+    /// Before it resumes anything the driver wires `req.channels` — the host end
+    /// of the channels the restored guest dials. A cold boot does the equivalent
+    /// before `InstanceStart`; a fork has a tighter window, because the guest it
+    /// brings back is already past its own boot and can dial the moment its
+    /// vCPUs run.
     ///
     /// The child comes back **still carrying the parent's random state**: a
     /// restore has no boot at which to seed it, and the guest is not reachable

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -2658,20 +2658,25 @@ mod tests {
         channels: &[crate::driver::VsockPort],
         vm: &str,
     ) -> Vec<(u32, crate::driver::VsockDirection, String)> {
-        let roots = [
-            ("socket-dir", mvm_core::config::vm_socket_dir(vm)),
-            ("state-dir", vm_state_dir(vm)),
-        ];
+        // Both roots collapse to one label on purpose. A VM's socket root is its
+        // state dir until the path grows long enough to overflow the Unix-socket
+        // limit, at which point it becomes a short hashed namespace instead —
+        // which of the two a given VM landed on is that fallback's business, not
+        // a difference in the channel set. Labelling them apart would report two
+        // VMs as carrying different channels whenever only one crossed the limit.
+        // Longest root first so an equal-or-nested root cannot mask a deeper one.
+        let mut roots = [mvm_core::config::vm_socket_dir(vm), vm_state_dir(vm)];
+        roots.sort_by_key(|r| std::cmp::Reverse(r.as_os_str().len()));
         channels
             .iter()
             .map(|p| {
                 let where_ = roots
                     .iter()
-                    .find_map(|(label, root)| {
+                    .find_map(|root| {
                         p.host_uds
                             .strip_prefix(root)
                             .ok()
-                            .map(|rest| format!("<{label}>/{}", rest.display()))
+                            .map(|rest| format!("<vm>/{}", rest.display()))
                     })
                     .unwrap_or_else(|| p.host_uds.display().to_string());
                 (p.guest_port, p.direction, where_)

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -44,7 +44,7 @@ use crate::workload_runner::claim::{
 use crate::workload_runner::cmdline;
 use crate::workload_runner::spec_map::{
     WorkloadSockets, WorkloadSpecInputs, console_data_sockets, ensure_no_dir_share_volumes,
-    workload_spec,
+    workload_spec, workload_vsock_ports,
 };
 use crate::workload_runner::standby_boot::{factory_parent_config, factory_parent_spec};
 
@@ -216,6 +216,27 @@ struct StandingSockets {
     console_data: Vec<(u32, PathBuf)>,
 }
 
+impl StandingSockets {
+    /// Bind these resolved sockets to `egress_uds` — the gating endpoint the
+    /// guest's `EGRESS_PORT` relays to — yielding the channel description both
+    /// start paths map through [`workload_vsock_ports`].
+    ///
+    /// The one place a workload's channel description is built. A cold boot
+    /// composes the mapped channels into the spec it boots; a warm claim hands
+    /// the same mapped channels to the fork, which wires them before the
+    /// restored child resumes. Adding a channel to the mapper therefore reaches
+    /// both, and neither path can grow one the other lacks.
+    fn with_egress<'a>(&'a self, egress_uds: &'a Path) -> WorkloadSockets<'a> {
+        WorkloadSockets {
+            agent: &self.agent,
+            egress_gateway: egress_uds,
+            exit: &self.exit,
+            broker: self.broker.as_deref(),
+            console_data: self.console_data.clone(),
+        }
+    }
+}
+
 fn standing_sockets(state_dir: &Path, config: &VmStartConfig) -> StandingSockets {
     StandingSockets {
         // Single source of truth shared with the host-side resolver so the
@@ -321,15 +342,9 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
         let socks = standing_sockets(&state_dir, inputs.config);
         let spec = workload_spec(&WorkloadSpecInputs {
             config: inputs.config,
-            sockets: WorkloadSockets {
-                agent: &socks.agent,
-                egress_gateway: endpoint.egress_uds(),
-                exit: &socks.exit,
-                broker: socks.broker.as_deref(),
-                console_data: socks.console_data,
-            },
+            sockets: socks.with_egress(endpoint.egress_uds()),
             cmdline: inputs.cmdline.clone(),
-            console_log: socks.console_log,
+            console_log: socks.console_log.clone(),
         });
 
         let vm = self.driver.boot(&spec)?;
@@ -360,10 +375,17 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
     /// digest to that verified parent (so the audit-recorded plan describes
     /// exactly what boots); mint a fresh, registry-unique identity; materialize
     /// the child's rootfs from the parent's own verified content; run the
-    /// host-side overlay-contract gate and spawn the child's own 0700
-    /// substitution endpoint keyed on its fresh id; then fork the VMM and require
-    /// the restored guest to prove it adopted a fresh VMGenID before the claim
-    /// commits, so the child's CSPRNG diverges from the parent's.
+    /// host-side overlay-contract gate, spawn the child's own 0700 substitution
+    /// endpoint keyed on its fresh id, resolve its host channel set and register
+    /// its host-services broker; then fork the VMM and require the restored
+    /// guest to prove it adopted a fresh VMGenID before the claim commits, so
+    /// the child's CSPRNG diverges from the parent's.
+    ///
+    /// The host-side plumbing is deliberately all on the near side of the fork.
+    /// A cold boot has a kernel boot between wiring its channels and the guest
+    /// dialing them; a restore has nothing — the guest comes back already booted
+    /// and runs the moment the fork resumes it. Anything wired afterwards would
+    /// be wired against a guest already dialing sockets that do not exist.
     ///
     /// Layering the runner does NOT own (enforced at their own layers, mirroring
     /// a cold boot): claim-8 admission of the child plan (CLI mint + supervisor
@@ -436,6 +458,31 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
             )
             .map_err(|e| StandbyError::ClaimFailed(format!("spawn child endpoint: {e}")))?;
 
+        // The child's host channel set, resolved under its own state dir and
+        // mapped through the one mapper a cold boot's set comes from. The fork
+        // wires these before it resumes the child; a restored guest is already
+        // booted, so it dials the instant its vCPUs run.
+        let socks = standing_sockets(&child_dir, &child_cfg);
+        let channels = workload_vsock_ports(&socks.with_egress(endpoint.egress_uds()));
+
+        // Register the child's host-services broker (host.audit.v1 /
+        // host.secrets.v1) — the same registration a cold boot performs, and for
+        // the same reason: without it the child would run silently short of the
+        // services an admitted workload is entitled to. Registered before the
+        // fork rather than after it, because the restore resumes a guest that
+        // can dial `BROKER_PORT` immediately. Best-effort inside `register` (a
+        // failure is logged, never a rollback); the guard reaps until the claim
+        // commits.
+        let mut broker_guard = self
+            .broker
+            .register(&BrokerRegisterRequest {
+                vm_name: &child.0,
+                state_dir: &child_dir,
+                tenant: child_cfg.tenant_id.as_deref(),
+                broker_listen_socket: socks.broker.as_deref(),
+            })
+            .map_err(|e| StandbyError::ClaimFailed(format!("register child broker: {e}")))?;
+
         // (6b) Mint a fresh VMGenID bound to the child's content-address and fork
         // the VMM. A fork restores a running guest out of the parent's saved
         // memory, so the child comes back holding the parent's CSPRNG state and
@@ -447,6 +494,7 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
             child_vm_name: &child.0,
             child_dir: &child_dir,
             genid,
+            channels: &channels,
         })?;
 
         // (7) Close that window before the claim commits: deliver the token to
@@ -463,10 +511,11 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
             return Err(refusal);
         }
 
-        // The child booted and proved a fresh identity: disarm the endpoint reaper
-        // (the stop path owns it now) and commit — the parent stays reserved and
-        // the child dir is real state.
+        // The child booted and proved a fresh identity: disarm the endpoint and
+        // broker reapers (the stop path owns them now) and commit — the parent
+        // stays reserved and the child dir is real state.
         endpoint.defuse();
+        broker_guard.defuse();
         cleanup.commit();
         Ok(child)
     }
@@ -2129,12 +2178,19 @@ mod tests {
         ));
 
         // The parent boots with no vsock channel at all: no egress relay, no
-        // broker port, so a stray guest dial to either stays ECONNREFUSED.
+        // broker port, no exit report — so a stray guest dial to any of them
+        // stays ECONNREFUSED. Only a claimed child gets those three; parents and
+        // workloads live in disjoint namespaces and this is where that holds.
         let booted = runner.driver.booted_specs();
         assert_eq!(booted.len(), 1);
         assert!(
             booted[0].vsock.is_empty(),
-            "parent boot must carry no vsock channel (no egress/broker endpoint)"
+            "parent boot must carry no vsock channel (no egress, broker or exit channel), got: {:?}",
+            booted[0]
+                .vsock
+                .iter()
+                .map(|p| p.guest_port)
+                .collect::<Vec<_>>()
         );
 
         // No substitution endpoint and no broker were stood up for the parent:
@@ -2589,6 +2645,204 @@ mod tests {
             pool.load("warm-parent").unwrap().state,
             StandbyState::Claimed,
             "the parent is reserved so a concurrent claim cannot double-claim it"
+        );
+    }
+
+    /// A channel set described independently of which VM owns it: each port's
+    /// number, direction, and where its host socket sits *relative to that VM's
+    /// own* socket and state dirs. Two VMs' descriptions compare equal exactly
+    /// when they carry the same channels wired to the same per-VM locations —
+    /// and the relativization keeps that true even when one VM's name is long
+    /// enough to push its sockets into the short hashed namespace.
+    fn channel_shape(
+        channels: &[crate::driver::VsockPort],
+        vm: &str,
+    ) -> Vec<(u32, crate::driver::VsockDirection, String)> {
+        let roots = [
+            ("socket-dir", mvm_core::config::vm_socket_dir(vm)),
+            ("state-dir", vm_state_dir(vm)),
+        ];
+        channels
+            .iter()
+            .map(|p| {
+                let where_ = roots
+                    .iter()
+                    .find_map(|(label, root)| {
+                        p.host_uds
+                            .strip_prefix(root)
+                            .ok()
+                            .map(|rest| format!("<{label}>/{}", rest.display()))
+                    })
+                    .unwrap_or_else(|| p.host_uds.display().to_string());
+                (p.guest_port, p.direction, where_)
+            })
+            .collect()
+    }
+
+    /// One cold boot and one warm claim on the same runner, so the two host
+    /// channel sets the driver was handed can be compared directly.
+    struct ColdAndWarm {
+        driver: MockDriver,
+        broker: Option<RecordedBroker>,
+        cold_vm: String,
+        child: VmId,
+        /// Held so the assertions resolve the same `MVM_HOME` the run did.
+        /// Declaration order is drop order: the home dir goes, then the env is
+        /// restored, then the lock is released.
+        _home: tempfile::TempDir,
+        _env: TestEnv,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    /// Boot an admitted workload cold, then claim a child off a clean audited
+    /// parent seeded from the same rootfs — both through one runner, with the
+    /// endpoint spawner that keys its socket on the VM name (as the real one
+    /// does), so the two channel sets differ only where the VM identity does.
+    ///
+    /// The isolated `MVM_HOME` is handed back alive, so the caller's assertions
+    /// resolve the same per-VM paths the run wrote.
+    fn cold_boot_then_claim() -> ColdAndWarm {
+        let lock = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
+        let store_root = tempfile::tempdir().unwrap();
+        let src = tempfile::tempdir().unwrap();
+        let (checkpoints, snapshots, parent_id, parent_meta) =
+            seed_audited_parent(store_root.path(), src.path(), true);
+        let parent_digest = parent_rootfs_digest(&parent_meta).unwrap().to_string();
+        let rootfs = src.path().join("rootfs.ext4");
+
+        let runner = WorkloadRunner::new(
+            MockDriver::default(),
+            KeyingSpawner::default(),
+            RecordingBrokerRegistrar::new(),
+        );
+
+        // The cold boot: an admitted launch (tenant set), so it carries the
+        // broker channel a claimed child must also get.
+        let cold_vm = "cold-admitted-workload".to_string();
+        runner
+            .start(&VmStartConfig {
+                name: cold_vm.clone(),
+                rootfs_path: rootfs.display().to_string(),
+                kernel_path: Some("/img/kernel".into()),
+                tenant_id: Some("tenant-x".into()),
+                cpus: 2,
+                memory_mib: 512,
+                ..Default::default()
+            })
+            .expect("the cold admitted workload boots");
+
+        let pool = SupervisorStandbyPool::at(store_root.path().join("pool"));
+        let handle = idle_parent_handle("warm-parent", &store_root.path().join("control.sock"));
+        pool.record(&handle).unwrap();
+        let registry_path = store_root.path().join("vm-names.json");
+        let anchor = ClaimTestAnchor::audited(&parent_meta);
+        let claim = admitted_child_claim(&rootfs, signed_child_plan_json(&parent_digest));
+
+        let child = runner
+            .claim_standby(
+                &ClaimContext {
+                    pool: &pool,
+                    checkpoints: &checkpoints,
+                    snapshots: &snapshots,
+                    anchor: &anchor,
+                    parent_checkpoint: &parent_id,
+                    registry_path: &registry_path,
+                },
+                &handle,
+                &claim,
+            )
+            .expect("claim");
+
+        ColdAndWarm {
+            driver: runner.driver.clone(),
+            broker: runner.broker.seen.lock().unwrap().take(),
+            cold_vm,
+            child,
+            _home: home,
+            _env: env,
+            _lock: lock,
+        }
+    }
+
+    /// A claimed child must reach the same host-side channels a cold-booted
+    /// workload does. Asserted as an equality against the cold boot's own set
+    /// rather than as a list of ports: a channel added to the workload's set and
+    /// not to the claim's would leave a claimed child silently less capable than
+    /// a cold-booted one, and only an equality catches that.
+    #[test]
+    fn claim_hands_the_child_the_same_host_channels_a_cold_boot_gets() {
+        use mvm_agentd::vsock::{GUEST_AGENT_PORT, WORKLOAD_EXIT_PORT};
+
+        let run = cold_boot_then_claim();
+
+        let booted = run.driver.booted_specs();
+        assert_eq!(booted.len(), 1, "one cold workload boot");
+        let cold = &booted[0].vsock;
+
+        // Non-vacuity: the fixture must actually exercise all four standing
+        // channels, or "the two match" would say nothing. These are the three
+        // the fork used to drop, plus the agent RPC.
+        let ports: Vec<u32> = cold.iter().map(|p| p.guest_port).collect();
+        for (port, what) in [
+            (EGRESS_PORT, "the gated egress endpoint"),
+            (BROKER_PORT, "host.audit.v1 / host.secrets.v1"),
+            (WORKLOAD_EXIT_PORT, "the guest's exit-code report"),
+            (GUEST_AGENT_PORT, "the agent RPC"),
+        ] {
+            assert!(
+                ports.contains(&port),
+                "fixture must exercise {what} (port {port}), got {ports:?}"
+            );
+        }
+
+        let forks = run.driver.forked_children();
+        assert_eq!(forks.len(), 1, "exactly one child fork");
+        assert_eq!(
+            channel_shape(&forks[0].channels, &run.child.0),
+            channel_shape(cold, &run.cold_vm),
+            "a claimed child must be handed exactly the channel set a cold boot wires"
+        );
+    }
+
+    /// The child's broker is registered on the very socket its `BROKER_PORT`
+    /// channel relays to, and under the claim's tenant — otherwise the guest
+    /// dials a path nothing is bound to and `host.audit.v1` / `host.secrets.v1`
+    /// are silently unavailable, a real degradation versus a cold boot.
+    #[test]
+    fn claim_registers_the_childs_broker_on_the_socket_it_wired() {
+        let run = cold_boot_then_claim();
+
+        let broker = run
+            .broker
+            .as_ref()
+            .expect("a claimed child registers a host-services broker");
+        assert_eq!(
+            broker.vm_name, run.child.0,
+            "the broker is registered for the child's own id, never the parent's"
+        );
+        assert_eq!(broker.tenant.as_deref(), Some("tenant-x"));
+
+        let wired = run.driver.forked_children()[0]
+            .channels
+            .iter()
+            .find(|p| p.guest_port == BROKER_PORT)
+            .map(|p| p.host_uds.clone())
+            .expect("the child carries a broker channel");
+        assert_eq!(
+            broker.broker_listen_socket.as_ref(),
+            Some(&wired),
+            "the broker must bind the same path the child's BROKER_PORT relays to"
+        );
+        assert_eq!(
+            wired,
+            mvm_core::config::vm_vsock_port_socket_at(&vm_state_dir(&run.child.0), BROKER_PORT),
+            "the broker socket lives under the child's own state dir"
         );
     }
 

--- a/crates/mvm-runtime/tests/fc_warm_pool_live.rs
+++ b/crates/mvm-runtime/tests/fc_warm_pool_live.rs
@@ -201,6 +201,11 @@ fn fc_warm_pool_spawn_and_claim() {
             token: [0u8; GENID_BYTES],
             content_hash: parent_checkpoint.as_str().to_string(),
         },
+        // This harness drives the driver seam directly and stands up none of
+        // the host-side processes a claim wires channels to — no gating
+        // endpoint, no broker — so it hands down the empty set the parent
+        // itself booted with. What it measures is the restore, not the wiring.
+        channels: &[],
     });
     if let Err(ref e) = fork_result {
         eprintln!("fork failed: {e:#}");


### PR DESCRIPTION
## What was broken

A cold boot binds three host-side channels before the guest runs:

- the guest-dial vsock bridges for **egress** and the **host-services broker** (`wire_guest_dial_bridges`)
- the **workload-exit** listener (`spawn_workload_exit_capture`)

Both are called only from `FcDriver::boot`. The warm claim goes through `fork_standby_child` → `FcForkRestorer::restore_fork` and bound **none** of them. Separately, `claim_standby` spawned the child's substitution endpoint but never threaded its `egress_uds` anywhere and never called `BrokerRegistrar::register`, which `start_workload` does.

So a claimed child would have come up with its egress endpoint dark (nothing on `v.sock_<EGRESS_PORT>`), `host.audit.v1` and `host.secrets.v1` silently unavailable — a real degradation versus a cold boot — and no listener for its exit report, so a run showed UNKNOWN instead of the guest's exit code. All fail-closed, none a security hole, but it made a claimed child strictly less capable than a cold-booted one.

## The two things that were easy to get wrong

**Ordering.** `restore_fork` *resumes* the child (it routes through `guarded_fork_load_resume`). A restore brings back an already-booted guest, so there is no kernel boot to cover the window a cold boot's covers — the host end must be listening *before* the resume, not after. The wiring is therefore armed before `restore_fork` is called.

**Where the channel list comes from.** `wire_guest_dial_bridges` needs the vsock port list, and `ChildForkRequest` carried only name/dir/genid. Rather than re-derive the list in the driver, it is assembled by the role layer from the **same mapper a workload boot's channel set comes from** and handed down. A second derivation is free to drift, and a claimed child that dials a channel nobody bound is silently less capable — the same class of bug as an earlier parent-boot divergence that ended in a kernel panic.

## Guards

- `claim_hands_the_child_the_same_host_channels_a_cold_boot_gets` — asserts **equality** with the cold-boot path, not mere presence, so the two cannot diverge silently.
- `fork_standby_child_wires_the_childs_host_channels_before_it_attempts_the_restore` — pins the ordering invariant.
- `claim_registers_the_childs_broker_on_the_socket_it_wired`.
- `wiring_a_channel_less_boot_creates_no_bridge` — negative case.
- A factory parent still gets no endpoint and no broker, so parents and workloads stay in disjoint namespaces.

## Unchanged

`standby_pool` stays **`false`** for every driver — this wires channels, it is not the capability flip. No guest NIC; the no-NIC device-model guard stays between snapshot load and resume. The fail-closed post-restore identity handshake (`acknowledged` + `reseeded` + `clock_resynced`) still gates the claim before it commits, and a refusal still stops the child.

## What still blocks arming the pool

One item remains: egress-allowing launches are excluded from the pool entirely. Worth recording what the investigation for that found, since it contradicts the earlier stated reason — the guest cmdline carries only the boolean `mvm.vsock_egress=1`, and the allow-list is resolved host-side by the gateway bridge's flow policy. There is no per-launch egress shape baked into a shared parent to leak, so the pool needs to partition on egress *enablement*, not on the allow-list. The one real subtlety: the token is gated on `allows_egress() && !state_has_bound_secrets(...)`, so a secrets-bearing launch gets no token cold-booted but would inherit one from a parent — that case must stay excluded or be folded into the compat key.
