### PR TITLE
test(mvm-build): isolate HOME so the builder-image refusals are hermetic

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -5344,6 +5344,13 @@ mod tests {
         let mut env = TestEnv::new();
         let scratch = TempDir::new().unwrap();
         env.set("MVM_HOME", scratch.path());
+        // `ensure_builder_vm_image` falls back to seeding from the *default*
+        // cache, which is `$HOME/.mvm/cache` and deliberately ignores MVM_HOME.
+        // Without isolating HOME too, a developer with a real builder image on
+        // disk gets it copied in - cmdline.txt and all - so the refusal under
+        // test never happens and this passes only on a machine that has never
+        // built one. CI is such a machine; a contributor's laptop is not.
+        env.set("HOME", scratch.path());
 
         let arch_dir = scratch
             .path()
@@ -5367,6 +5374,13 @@ mod tests {
         let mut env = TestEnv::new();
         let scratch = TempDir::new().unwrap();
         env.set("MVM_HOME", scratch.path());
+        // `ensure_builder_vm_image` falls back to seeding from the *default*
+        // cache, which is `$HOME/.mvm/cache` and deliberately ignores MVM_HOME.
+        // Without isolating HOME too, a developer with a real builder image on
+        // disk gets it copied in - cmdline.txt and all - so the refusal under
+        // test never happens and this passes only on a machine that has never
+        // built one. CI is such a machine; a contributor's laptop is not.
+        env.set("HOME", scratch.path());
 
         let arch_dir = scratch
             .path()
@@ -5400,6 +5414,13 @@ mod tests {
         let mut env = TestEnv::new();
         let scratch = TempDir::new().unwrap();
         env.set("MVM_HOME", scratch.path());
+        // `ensure_builder_vm_image` falls back to seeding from the *default*
+        // cache, which is `$HOME/.mvm/cache` and deliberately ignores MVM_HOME.
+        // Without isolating HOME too, a developer with a real builder image on
+        // disk gets it copied in - cmdline.txt and all - so the refusal under
+        // test never happens and this passes only on a machine that has never
+        // built one. CI is such a machine; a contributor's laptop is not.
+        env.set("HOME", scratch.path());
 
         let arch_dir = scratch
             .path()
@@ -5434,6 +5455,13 @@ mod tests {
         let mut env = TestEnv::new();
         let scratch = TempDir::new().unwrap();
         env.set("MVM_HOME", scratch.path());
+        // `ensure_builder_vm_image` falls back to seeding from the *default*
+        // cache, which is `$HOME/.mvm/cache` and deliberately ignores MVM_HOME.
+        // Without isolating HOME too, a developer with a real builder image on
+        // disk gets it copied in - cmdline.txt and all - so the refusal under
+        // test never happens and this passes only on a machine that has never
+        // built one. CI is such a machine; a contributor's laptop is not.
+        env.set("HOME", scratch.path());
 
         let arch_dir = scratch
             .path()
@@ -5482,6 +5510,13 @@ mod tests {
         let mut env = TestEnv::new();
         let scratch = TempDir::new().unwrap();
         env.set("MVM_HOME", scratch.path());
+        // `ensure_builder_vm_image` falls back to seeding from the *default*
+        // cache, which is `$HOME/.mvm/cache` and deliberately ignores MVM_HOME.
+        // Without isolating HOME too, a developer with a real builder image on
+        // disk gets it copied in - cmdline.txt and all - so the refusal under
+        // test never happens and this passes only on a machine that has never
+        // built one. CI is such a machine; a contributor's laptop is not.
+        env.set("HOME", scratch.path());
 
         let arch = host_arch_tag().to_string();
         let cache_root = scratch.path().join("cache");


### PR DESCRIPTION
## The symptom

Three `mvm-build` tests fail on a developer machine while CI stays green:

```
FAIL mvm-build libkrun_builder::tests::ensure_builder_vm_image_requires_cmdline_txt
FAIL mvm-build libkrun_builder::tests::ensure_builder_vm_image_refuses_stale_manifest_capabilities
FAIL mvm-build libkrun_builder::tests::ensure_builder_vm_image_refuses_old_manifest_contract_version
```

They have been red locally across many merges. Three red tests that everyone learns to ignore is how a real failure gets missed, so this makes them hermetic rather than leaving them as background noise.

## Why they only fail locally

Each test isolates `MVM_HOME` to a temp dir, seeds it with `vmlinux` + `rootfs.ext4` but no `cmdline.txt`, and asserts `ensure_builder_vm_image()` refuses.

But on a cache miss `ensure_builder_vm_image` calls `seed_builder_vm_image_from_default_cache`, whose source is `default_builder_vm_cache_dir()` → `default_mvm_cache_dir()` → `$HOME/.mvm/cache`. That path **deliberately ignores `MVM_HOME`** (there is a test in `mvm-core` asserting exactly that). It copies `vmlinux`, `rootfs.ext4`, `cmdline.txt`, and `manifest.json` into the isolated dir, so the refusal under test never happens and the call returns `Ok`.

So the assertion holds only on a machine that has never built a builder image. CI is such a machine; a contributor's laptop is not.

## The fix

Test-only: isolate `HOME` alongside `MVM_HOME`, so the default-cache seed points at an empty temp dir, returns `Ok(false)`, and the real refusal surfaces. No production behaviour changes — the opportunistic seed is correct for real use, it just has to be out of reach of a test asserting its absence.

Applied to the five setups sharing that pattern (three failing, two latently non-hermetic for the same reason).

## Testing

`cargo nextest run --workspace`: **8010 passed, 0 failed** — a fully green workspace locally, which it has not been. `cargo nextest run -p mvm-build`: 674/674.
