### PR TITLE
feat(pool): let egress-allowing launches use the warm pool

### DIFF
--- a/crates/mvm-cli/examples/verification_loop.rs
+++ b/crates/mvm-cli/examples/verification_loop.rs
@@ -70,7 +70,8 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// What a standby must match to be claimable (kernel + fixed resources + image).
+/// What a standby must match to be claimable (kernel + fixed resources + image
+/// + whether the guest boots an egress client).
 fn standby_compat() -> StandbyCompat {
     StandbyCompat {
         template_id: None,
@@ -78,6 +79,7 @@ fn standby_compat() -> StandbyCompat {
         vcpus: 2,
         mem_mib: 512,
         image_sha256: None,
+        vsock_egress: false,
     }
 }
 

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -1432,6 +1432,9 @@ mod tests {
             vcpus: 2,
             mem_mib: 1024,
             image_sha256: None,
+            // These warms carry no launch, so they mirror a launch-less spawn:
+            // no plan to read an egress decision off, hence no guest token.
+            vsock_egress: false,
         };
         assert_eq!(
             pool.idle_count_compatible(&want).unwrap(),

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -5,15 +5,14 @@
 //! the standby re-verifies the attach plan against (claim 8). Builds a backend-agnostic
 //! `StandbySpec` and drives the `SupervisorStandbyPool` + `VmBackend` trait methods.
 //!
-//! v1 is default-shaped only: a standby is claimable by a launch whose kernel, resources
-//! **and rootfs image** all match (`StandbyCompat`, exact equality) and whose shape a
-//! shared parent can serve at all (`warm_eligible_launch` — no extra volumes, no
-//! virtio-fs root, no egress-allowing policy). Anything else cold-boots. Both halves of
+//! A standby is claimable by a launch whose kernel, resources, **rootfs image**
+//! and **guest egress enablement** all match (`StandbyCompat`, exact equality) and whose
+//! shape a shared parent can serve at all (`warm_eligible_launch` — no extra volumes, no
+//! virtio-fs root). Anything else cold-boots. Both halves of
 //! the pool build that key and that eligibility test through one function each, because
 //! a spawn and a claim that compute them separately are free to disagree, and a
-//! disagreement is invisible: the pool fills and never drains. Multi-kernel keying,
-//! honouring an explicit `--name`/volumes, and serving egress-allowing launches are
-//! deferred follow-ups.
+//! disagreement is invisible: the pool fills and never drains. Multi-kernel keying and
+//! honouring an explicit `--name`/volumes are deferred follow-ups.
 
 use std::path::Path;
 
@@ -97,6 +96,10 @@ pub struct StandbySpecParams<'a> {
     /// digest a claim computes for its own launch. `None` only alongside an
     /// absent `image_path`.
     pub image_sha256: Option<&'a str>,
+    /// Whether the parent boots its guest's vsock egress client — the compat
+    /// key's egress half, read off the launch's effective enablement. A restored
+    /// child inherits the token from the parent's memory, so this is fixed here.
+    pub vsock_egress: bool,
 }
 
 /// Build a `StandbySpec` from [`StandbySpecParams`]. The control UDS lives under
@@ -128,6 +131,7 @@ pub fn build_standby_spec(p: &StandbySpecParams<'_>) -> Result<StandbySpec> {
         binding_nonce: nonce,
         image_path: p.image_path.map(|p| p.to_string_lossy().into_owned()),
         image_sha256: p.image_sha256.map(str::to_string),
+        vsock_egress: p.vsock_egress,
         id,
     })
 }
@@ -204,6 +208,7 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
             vcpus: p.vcpus,
             mem_mib: p.mem_mib,
             image_sha256: None,
+            vsock_egress: false,
         },
     };
     let have = pool.idle_count_compatible(&want)? as u32;
@@ -231,6 +236,7 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
             signing_key_path: p.signing_key_path,
             image_path: image,
             image_sha256: want.image_sha256.as_deref(),
+            vsock_egress: want.vsock_egress,
         })?;
         match p.backend.spawn_standby_via_runner(&spawn_ctx, &spec) {
             Ok(handle) => {
@@ -406,38 +412,41 @@ fn compat_for_launch(backend: &dyn VmBackend, cfg: &VmStartConfig) -> Result<Sta
         vcpus: u8::try_from(cfg.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX),
         mem_mib: cfg.memory_mib,
         image_sha256: Some(image_identity(Path::new(cfg.rootfs_path.as_str()))?),
+        // Whether the guest boots an egress client, read off the launch's policy
+        // and its admitted plan through the same derivation the guest cmdline
+        // token comes from — never re-expressed here, because a second
+        // expression of it is free to drift from the token it must predict.
+        vsock_egress: mvm_runtime::egress_shared::effective_vsock_egress(cfg),
     })
 }
 
 /// Whether a warm parent can serve this launch shape at all.
 ///
-/// A parent is shared across claims and carries no workload authority, so it
-/// boots only what every eligible launch has in common. Both halves of the pool
-/// consult this — the claim to decide whether to look, the replenish to decide
-/// whether to spawn — because excluding a shape from one but not the other
-/// either fills the pool with parents nothing claims or claims parents that
-/// cannot serve the launch.
+/// A parent is shared across claims and carries no workload authority, so a
+/// launch shape whose guest a parent cannot boot is excluded here rather than
+/// keyed on. Both halves of the pool consult this — the claim to decide whether
+/// to look, the replenish to decide whether to spawn — because excluding a shape
+/// from one but not the other either fills the pool with parents nothing claims
+/// or claims parents that cannot serve the launch.
 ///
 /// Excluded:
 ///
 /// - **extra volumes** — the attach threads only the rootfs, so a volume disk
 ///   would be missing from the child;
-/// - **a virtio-fs root** — there is no rootfs image to capture;
-/// - **a policy that allows egress** — `mvm.vsock_egress=1` is a per-launch
-///   kernel-cmdline token, and a forked child inherits its parent's cmdline out
-///   of restored memory rather than deriving its own. A deny-all parent would
-///   hand every child a guest whose in-guest egress client never starts, so the
-///   workload would silently have no network. Carrying one launch's policy onto
-///   a shared parent instead would leak that launch's shape to the next claim,
-///   since the policy is not part of the compat key. Until a child can be told
-///   its own egress shape after the restore, such a launch cold-boots.
+/// - **a virtio-fs root** — there is no rootfs image to capture.
 ///
-/// The egress test is deliberately coarser than the token's own condition (the
-/// token is also suppressed when the workload has bound secrets): it depends
-/// only on the launch config, not on what is on disk at replenish time, and
-/// erring toward a cold boot is the safe direction.
+/// An egress-allowing policy is *not* excluded. `mvm.vsock_egress=1` is a
+/// kernel-cmdline token, and a forked child inherits its parent's cmdline out of
+/// restored memory rather than deriving its own — but the token carries only
+/// whether the guest starts an egress client, never a destination. So the pool
+/// partitions on that boolean instead of refusing the shape:
+/// [`StandbyCompat::vsock_egress`] makes a parent claimable only by launches
+/// whose guest boots the same way, and the destinations a workload may reach are
+/// resolved host-side on the claimed child's own egress endpoint, from that
+/// child's own policy. A shared parent therefore holds nothing per-launch that
+/// could reach the next claim.
 fn warm_eligible_launch(cfg: &VmStartConfig) -> bool {
-    cfg.volumes.is_empty() && cfg.virtiofs_root.is_none() && !cfg.network_policy.allows_egress()
+    cfg.volumes.is_empty() && cfg.virtiofs_root.is_none()
 }
 
 /// Attempt a warm-pool claim for this launch. Returns the claimed `VmId` (the standby-id
@@ -779,7 +788,6 @@ mod tests {
     /// pays for a parent boot and cold-boots anyway.
     #[test]
     fn claim_and_replenish_agree_on_which_launch_shapes_a_warm_parent_can_serve() {
-        use mvm_core::network_policy::{HostPort, NetworkPolicy};
         use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
 
         let ineligible = [
@@ -798,12 +806,6 @@ mod tests {
             ("virtiofs root", {
                 let mut c = eligible_cfg();
                 c.virtiofs_root = Some("/unpacked/root".into());
-                c
-            }),
-            ("egress-allowing policy", {
-                let mut c = eligible_cfg();
-                c.network_policy =
-                    NetworkPolicy::allow_list(vec![HostPort::new("api.example.com", 443)]);
                 c
             }),
         ];
@@ -828,6 +830,144 @@ mod tests {
                 "{why} must not spawn a parent nothing will claim"
             );
         }
+    }
+
+    /// The launch shape the pool used to refuse outright now warms and claims
+    /// like any other. It is keyed, not excluded: the guest cmdline carries only
+    /// whether an egress client starts, so a parent can boot that and the
+    /// destinations stay host-side on the child's own endpoint.
+    ///
+    /// The assertion is equality with the baseline eligible launch rather than a
+    /// hard-coded outcome: whatever a default-shaped launch does at each gate, an
+    /// egress-allowing one must do too, so this keeps holding as the gates move.
+    #[test]
+    fn an_egress_allowing_launch_is_warm_eligible_exactly_like_a_deny_all_one() {
+        use mvm_core::network_policy::{HostPort, NetworkPolicy, NetworkPreset};
+
+        let baseline = eligible_cfg();
+        assert!(warm_eligible_launch(&baseline));
+        let b = AnyBackend::from_hypervisor("libkrun");
+        // The disarmed pool refuses at the capability gate, which sits *after*
+        // the shape gate — so reaching the same verdict as the baseline is what
+        // proves the shape gate no longer short-circuits an egress launch.
+        let baseline_verdict = try_warm_claim(&b, &baseline, false).is_err();
+
+        for (why, policy) in [
+            (
+                "explicit allow-list",
+                NetworkPolicy::allow_list(vec![HostPort::new("api.example.com", 443)]),
+            ),
+            ("named preset", NetworkPolicy::preset(NetworkPreset::Dev)),
+            ("unrestricted", NetworkPolicy::unrestricted()),
+        ] {
+            let mut cfg = eligible_cfg();
+            cfg.network_policy = policy;
+            assert!(
+                cfg.network_policy.allows_egress(),
+                "{why} must actually allow egress, or this proves nothing"
+            );
+            assert!(warm_eligible_launch(&cfg), "{why} must be warm-eligible");
+            assert!(
+                should_replenish_inline(true, cfg.warm_pool_size, warm_eligible_launch(&cfg)),
+                "{why} must replenish, or the pool it claims from is never filled"
+            );
+            assert_eq!(
+                try_warm_claim(&b, &cfg, false).is_err(),
+                baseline_verdict,
+                "{why} must reach the same gate a deny-all launch does"
+            );
+        }
+    }
+
+    /// The compat key's egress half is the shared derivation, never a second
+    /// expression of it here — a copy in the CLI would be free to drift from the
+    /// guest cmdline token it exists to predict.
+    #[test]
+    fn the_compat_key_reads_egress_enablement_from_the_one_shared_derivation() {
+        use mvm_core::network_policy::{HostPort, NetworkPolicy, NetworkPreset};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let kernel = tmp.path().join("vmlinux");
+        std::fs::write(&kernel, b"kernel").unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"rootfs").unwrap();
+        let fc = AnyBackend::from_hypervisor("firecracker");
+
+        for policy in [
+            NetworkPolicy::deny_all(),
+            NetworkPolicy::allow_list(vec![]),
+            NetworkPolicy::allow_list(vec![HostPort::new("api.example.com", 443)]),
+            NetworkPolicy::preset(NetworkPreset::Dev),
+            NetworkPolicy::unrestricted(),
+        ] {
+            for plan in [None, Some("{}".to_string())] {
+                let mut cfg = eligible_cfg();
+                cfg.kernel_path = Some(kernel.to_string_lossy().into_owned());
+                cfg.rootfs_path = rootfs.to_string_lossy().into_owned();
+                cfg.network_policy = policy.clone();
+                cfg.plan_json = plan;
+                let want = compat_for_launch(fc.as_vm_backend(), &cfg).unwrap();
+                assert_eq!(
+                    want.vsock_egress,
+                    mvm_runtime::egress_shared::effective_vsock_egress(&cfg),
+                    "the compat key must not re-derive the guest's egress enablement"
+                );
+            }
+        }
+    }
+
+    /// A parent warmed for one egress enablement must not serve a launch of the
+    /// other. Both directions matter: the permissive one would hand a child
+    /// egress its cold boot would have denied, the restrictive one a workload
+    /// with silently no network.
+    #[test]
+    fn a_parent_of_the_wrong_egress_enablement_is_not_claimable() {
+        use mvm_core::network_policy::{HostPort, NetworkPolicy};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let kernel = tmp.path().join("vmlinux");
+        std::fs::write(&kernel, b"kernel").unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"rootfs").unwrap();
+        let fc = AnyBackend::from_hypervisor("firecracker");
+
+        let mut deny = eligible_cfg();
+        deny.kernel_path = Some(kernel.to_string_lossy().into_owned());
+        deny.rootfs_path = rootfs.to_string_lossy().into_owned();
+        let mut egress = deny.clone();
+        egress.network_policy =
+            NetworkPolicy::allow_list(vec![HostPort::new("api.example.com", 443)]);
+
+        let deny_key = compat_for_launch(fc.as_vm_backend(), &deny).unwrap();
+        let egress_key = compat_for_launch(fc.as_vm_backend(), &egress).unwrap();
+        assert!(!deny_key.vsock_egress);
+        assert!(egress_key.vsock_egress);
+        assert_ne!(
+            deny_key, egress_key,
+            "the two launches must not share a compat key"
+        );
+
+        // A recorded parent answers only its own key — the pool's compat test is
+        // exact equality, so this is what makes the mismatch a cold boot.
+        let mut parent = saved_idle_handle("standby-deny", &deny_key.kernel_sha256, "img");
+        parent.image_sha256 = deny_key.image_sha256.clone();
+        parent.vcpus = deny_key.vcpus;
+        parent.mem_mib = deny_key.mem_mib;
+        assert!(parent.is_compatible(&deny_key));
+        assert!(
+            !parent.is_compatible(&egress_key),
+            "a token-less parent must not serve an egress-allowing launch"
+        );
+
+        let egress_parent = StandbyHandle {
+            vsock_egress: true,
+            ..parent.clone()
+        };
+        assert!(egress_parent.is_compatible(&egress_key));
+        assert!(
+            !egress_parent.is_compatible(&deny_key),
+            "an egress-booted parent must not serve a launch whose guest wants none"
+        );
     }
 
     #[test]
@@ -871,6 +1011,7 @@ mod tests {
             signing_key_path: &tmp.path().join("key"),
             image_path: None,
             image_sha256: None,
+            vsock_egress: false,
         })
         .unwrap();
         // The socket lives under the nonce-derived `standby-<16hex>` dir; the filename is
@@ -943,6 +1084,7 @@ mod tests {
             state: StandbyState::Idle,
             image_sha256: None,
             parent_checkpoint: None,
+            vsock_egress: false,
         }
     }
 
@@ -960,6 +1102,7 @@ mod tests {
             state: StandbyState::Idle,
             image_sha256: Some(image.into()),
             parent_checkpoint: None,
+            vsock_egress: false,
         }
     }
 

--- a/crates/mvm-conformance/tests/steps/warm_claim.rs
+++ b/crates/mvm-conformance/tests/steps/warm_claim.rs
@@ -84,6 +84,7 @@ fn seed_parent(world: &mut CliWorld, chain_carries_creation_entry: bool) {
         state: StandbyState::Idle,
         image_sha256: None,
         parent_checkpoint: None,
+        vsock_egress: false,
     };
     pool.record(&handle).expect("record the standby parent");
 

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -627,6 +627,7 @@ mod tests {
             vm_state_dir: "/p/standby-x".into(),
             image_path: None,
             image_sha256: None,
+            vsock_egress: false,
         }
     }
 
@@ -667,6 +668,7 @@ mod tests {
                 state: StandbyState::Idle,
                 image_sha256: None,
                 parent_checkpoint: None,
+                vsock_egress: false,
             },
             &sample_standby_claim(),
         ) {

--- a/crates/mvm-hostd/tests/standby_pool_live.rs
+++ b/crates/mvm-hostd/tests/standby_pool_live.rs
@@ -45,6 +45,8 @@ fn spec(dir: &Path, nonce: &str) -> StandbySpec {
         vm_state_dir: dir.join("state").to_string_lossy().into_owned(),
         image_path: None,
         image_sha256: None,
+        // This scenario never claims, so the guest boots nothing: no egress client.
+        vsock_egress: false,
     }
 }
 

--- a/crates/mvm-protocol/src/protocol/vm_backend.rs
+++ b/crates/mvm-protocol/src/protocol/vm_backend.rs
@@ -718,6 +718,13 @@ pub struct StandbySpec {
     pub image_path: Option<String>,
     /// Sha256 hex of `image_path` for the compat key. `None` for libkrun.
     pub image_sha256: Option<String>,
+    /// Whether the parent boots the guest's vsock egress client on
+    /// (see [`StandbyCompat::vsock_egress`]).
+    ///
+    /// The spawn takes this from the compat key it is recording rather than
+    /// re-deriving it, so the parent that boots and the record a claim matches
+    /// can never describe different guests.
+    pub vsock_egress: bool,
 }
 
 /// The base-compat key — everything a standby fixes at spawn and must therefore match the
@@ -742,6 +749,22 @@ pub struct StandbyCompat {
     /// `Some(sha256-hex)` for a standby captured from a rootfs; `None` only for
     /// one that carries no rootfs.
     pub image_sha256: Option<String>,
+    /// Whether the guest boots with its in-guest vsock egress client started.
+    ///
+    /// A restored child inherits its kernel cmdline from the parent's saved
+    /// memory rather than deriving its own, so the one guest-visible egress
+    /// token (`mvm.vsock_egress=1`) is fixed at the parent's boot and cannot be
+    /// changed at claim time. A launch whose guest would start that client must
+    /// therefore claim a parent that started it, and a launch whose guest would
+    /// not must claim one that did not — hence a compat field rather than a
+    /// launch-shape exclusion.
+    ///
+    /// This is the *enablement* only. The set of destinations a workload may
+    /// reach is resolved host-side, on the claimed child's own egress endpoint,
+    /// from that launch's own policy — so a shared parent carries no launch's
+    /// allow-list and there is nothing per-launch here to leak to the next
+    /// claim.
+    pub vsock_egress: bool,
 }
 
 /// A recorded standby (persisted as `~/.mvm/pool/<id>/standby.json`).
@@ -776,6 +799,14 @@ pub struct StandbyHandle {
     /// lives a layer up; the runtime converts at its boundary.
     #[serde(default)]
     pub parent_checkpoint: Option<String>,
+    /// Whether this parent booted its guest's vsock egress client on
+    /// (see [`StandbyCompat::vsock_egress`]).
+    ///
+    /// Defaults to `false` so a record written before the field existed reads as
+    /// a parent that booted no egress client — which is what those parents did,
+    /// and which keeps them claimable only by launches whose guest wants none.
+    #[serde(default)]
+    pub vsock_egress: bool,
 }
 
 impl StandbyHandle {
@@ -787,11 +818,13 @@ impl StandbyHandle {
             vcpus: self.vcpus,
             mem_mib: self.mem_mib,
             image_sha256: self.image_sha256.clone(),
+            vsock_egress: self.vsock_egress,
         }
     }
 
-    /// A launch may claim this standby only if its kernel, fixed resources, and image
-    /// sha256 all match exactly — no silent wrong-kernel, wrong-size, or wrong-image boot.
+    /// A launch may claim this standby only if its kernel, fixed resources, image
+    /// sha256 and guest egress enablement all match exactly — no silent
+    /// wrong-kernel, wrong-size, wrong-image or no-network boot.
     pub fn is_compatible(&self, want: &StandbyCompat) -> bool {
         &self.compat() == want
     }
@@ -1053,6 +1086,7 @@ mod tests {
             state: StandbyState::Idle,
             image_sha256: None,
             parent_checkpoint: None,
+            vsock_egress: false,
         };
         let json = serde_json::to_string(&h).unwrap();
         let back: StandbyHandle = serde_json::from_str(&json).unwrap();
@@ -1064,6 +1098,7 @@ mod tests {
             vcpus: 2,
             mem_mib: 1024,
             image_sha256: None,
+            vsock_egress: false,
         };
         assert!(back.is_compatible(&want));
         // wrong kernel, wrong cpus, and wrong mem each break compat.
@@ -1092,6 +1127,23 @@ mod tests {
         assert!(!hvf_handle.is_compatible(&want)); // None ≠ Some
         assert!(!hvf_handle.is_compatible(&StandbyCompat {
             image_sha256: Some("d".repeat(64)),
+            ..want.clone()
+        }));
+        // Guest egress enablement partitions the pool in both directions: a
+        // parent that booted no egress client cannot serve a launch whose guest
+        // wants one (the child would silently have no network), and a parent
+        // that booted one cannot serve a launch whose guest must not have it.
+        assert!(!h.is_compatible(&StandbyCompat {
+            vsock_egress: true,
+            ..want.clone()
+        }));
+        let egress_parent = StandbyHandle {
+            vsock_egress: true,
+            ..h.clone()
+        };
+        assert!(!egress_parent.is_compatible(&want));
+        assert!(egress_parent.is_compatible(&StandbyCompat {
+            vsock_egress: true,
             ..want
         }));
     }
@@ -1119,8 +1171,9 @@ mod tests {
         assert!(!StandbyState::Claimed.is_claimable());
     }
 
-    /// Old standby.json records written before the image_sha256 field was added
-    /// must still deserialise cleanly via `#[serde(default)]`.
+    /// Old standby.json records written before the image_sha256 and
+    /// vsock_egress fields were added must still deserialise cleanly via
+    /// `#[serde(default)]`.
     #[test]
     fn standby_handle_old_record_without_image_sha_deserialises_as_none() {
         let old_json = r#"{
@@ -1136,6 +1189,10 @@ mod tests {
         }"#;
         let h: StandbyHandle = serde_json::from_str(old_json).unwrap();
         assert_eq!(h.image_sha256, None, "absent field must default to None");
+        assert!(
+            !h.vsock_egress,
+            "a record from before the field existed booted no egress client"
+        );
         assert!(!h.is_saved_state(), "pid != 0 → live standby");
         // An old libkrun standby is compatible with a libkrun launch (both None).
         let want = StandbyCompat {
@@ -1144,8 +1201,16 @@ mod tests {
             vcpus: 2,
             mem_mib: 1024,
             image_sha256: None,
+            vsock_egress: false,
         };
         assert!(h.is_compatible(&want));
+        assert!(
+            !h.is_compatible(&StandbyCompat {
+                vsock_egress: true,
+                ..want
+            }),
+            "an old record must never satisfy a launch whose guest needs egress"
+        );
     }
 
     /// An HVF saved-standby uses pid=0 (no running supervisor) and must be treated
@@ -1165,6 +1230,7 @@ mod tests {
             state: StandbyState::Idle,
             image_sha256: Some("dd".repeat(32)),
             parent_checkpoint: None,
+            vsock_egress: false,
         };
         assert!(saved.is_saved_state());
         // serde roundtrip preserves the image sha and pid=0.

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -1691,6 +1691,7 @@ mod tests {
                 state: StandbyState::Idle,
                 image_sha256: None,
                 parent_checkpoint: None,
+                vsock_egress: false,
             }
         }
 
@@ -1808,6 +1809,7 @@ mod tests {
                 vm_state_dir: "/tmp/does-not-exist".into(),
                 image_path: None,
                 image_sha256: None,
+                vsock_egress: false,
             };
 
             for name in ["qemu", "wasm", "apple-container"] {

--- a/crates/mvm-runtime/src/driver/fc.rs
+++ b/crates/mvm-runtime/src/driver/fc.rs
@@ -516,6 +516,7 @@ impl VmmDriver for FcDriver {
             spawned_unix_secs: now_unix_secs(),
             state: StandbyState::Idle,
             image_sha256: spec.image_sha256.clone(),
+            vsock_egress: spec.vsock_egress,
             // The caller captures the parent and stamps this.
             parent_checkpoint: None,
         })
@@ -1507,6 +1508,7 @@ mod tests {
             vm_state_dir: tmp.path().join("standby-parent-1").display().to_string(),
             image_path: Some(image.display().to_string()),
             image_sha256: Some("c".repeat(64)),
+            vsock_egress: crate::egress_shared::effective_vsock_egress(&launch),
         };
 
         let parent_cfg = factory_parent_config(&launch, &spec).unwrap();
@@ -1519,6 +1521,112 @@ mod tests {
 
         let control = crate::firecracker::FcVmFullControl::new(&spec.id);
         assert_eq!(control.rootfs_path().unwrap(), image);
+    }
+
+    /// A parent warmed for an egress-allowing launch boots the guest's egress
+    /// client — and that is the *only* thing the enablement changes.
+    ///
+    /// The enablement reaches the parent as a policy that answers "egress
+    /// allowed", because that is what the cmdline token is derived from. This
+    /// pins that the policy buys the parent nothing else: flipping it leaves the
+    /// device set the driver configures byte-identical, so an egress-enabled
+    /// parent hands a restored child the same vsock-only machine a deny-all one
+    /// does. (That the set itself carries no guest NIC is enforced structurally
+    /// by the workspace's vsock-only-egress token gate over this file.)
+    #[test]
+    fn an_egress_enabled_parent_boots_the_token_and_nothing_else_changes() {
+        use crate::workload_runner::{factory_parent_config, factory_parent_spec};
+        use mvm_core::network_policy::{HostPort, NetworkPolicy};
+        use mvm_core::util::test_env::TestEnv;
+        use mvm_core::vm_backend::{StandbySpec, VmStartConfig};
+
+        let mut env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        let image = tmp.path().join("rootfs.ext4");
+        std::fs::write(&image, b"fake-rootfs").unwrap();
+
+        let deny_all_launch = VmStartConfig {
+            name: "workload-a".into(),
+            rootfs_path: image.display().to_string(),
+            kernel_path: Some("/img/vmlinux".into()),
+            cpus: 2,
+            memory_mib: 512,
+            ..Default::default()
+        };
+        let egress_launch = VmStartConfig {
+            network_policy: NetworkPolicy::allow_list(vec![HostPort::new("api.example.com", 443)]),
+            ..deny_all_launch.clone()
+        };
+        let spec_for = |launch: &VmStartConfig| StandbySpec {
+            id: "standby-egress-parent".into(),
+            template_id: None,
+            kernel_path: "/img/vmlinux".into(),
+            kernel_sha256: "a".repeat(64),
+            vcpus: 2,
+            mem_mib: 512,
+            signing_key_path: "/keys/host-signer.ed25519".into(),
+            signer_id: "host:test".into(),
+            binding_nonce: "b".repeat(64),
+            control_socket: tmp.path().join("control.sock").display().to_string(),
+            vm_state_dir: tmp
+                .path()
+                .join("standby-egress-parent")
+                .display()
+                .to_string(),
+            image_path: Some(image.display().to_string()),
+            image_sha256: Some("c".repeat(64)),
+            vsock_egress: crate::egress_shared::effective_vsock_egress(launch),
+        };
+        let parent_boot = |launch: &VmStartConfig| {
+            let spec = spec_for(launch);
+            let cfg = factory_parent_config(launch, &spec).unwrap();
+            let boot = factory_parent_spec(
+                &cfg,
+                std::path::Path::new(&spec.vm_state_dir),
+                |virtiofs_root, has_disk| {
+                    FcDriver::new().workload_base_bootargs(virtiofs_root, has_disk)
+                },
+            );
+            (spec.vsock_egress, boot)
+        };
+
+        let (deny_enabled, deny_boot) = parent_boot(&deny_all_launch);
+        let (egress_enabled, egress_boot) = parent_boot(&egress_launch);
+        assert!(!deny_enabled);
+        assert!(
+            egress_enabled,
+            "fixture must warm an egress-enabled parent, or it proves nothing"
+        );
+
+        assert!(
+            egress_boot.cmdline.contains("mvm.vsock_egress=1"),
+            "the parent must boot the guest egress client: {}",
+            egress_boot.cmdline
+        );
+        assert!(
+            !egress_boot.cmdline.contains("api.example.com"),
+            "the parent's cmdline must name no destination: {}",
+            egress_boot.cmdline
+        );
+
+        // Everything the driver would configure apart from the boot args is
+        // identical between the two enablements. `/boot-source` is excluded
+        // because it is where the cmdline lands, and that the cmdline matches the
+        // workload's is asserted where both are assembled, not here.
+        let device_set = |boot: &VmmSpec| {
+            config_puts(boot)
+                .into_iter()
+                .filter(|p| p.path != "/boot-source")
+                .map(|p| (p.path, p.body))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            device_set(&egress_boot),
+            device_set(&deny_boot),
+            "the egress enablement must add no device to a warm parent"
+        );
     }
 
     /// A pid that can't be read after a successful boot is a real failure, not

--- a/crates/mvm-runtime/src/driver/mock.rs
+++ b/crates/mvm-runtime/src/driver/mock.rs
@@ -247,6 +247,7 @@ impl VmmDriver for MockDriver {
             spawned_unix_secs: now_unix_secs(),
             state: StandbyState::Idle,
             image_sha256: spec.image_sha256.clone(),
+            vsock_egress: spec.vsock_egress,
             parent_checkpoint: None,
         })
     }

--- a/crates/mvm-runtime/src/egress_shared.rs
+++ b/crates/mvm-runtime/src/egress_shared.rs
@@ -7,6 +7,25 @@
 use anyhow::Result;
 use std::path::Path;
 
+use mvm_core::vm_backend::VmStartConfig;
+
+/// Read the admitted plan a VM's state dir carries, if any.
+///
+/// `Ok(None)` for a state dir with no `plan.json` (legacy / non-admitted boot).
+/// A read error other than "not found" is an error rather than a silent no-op,
+/// because a plan that exists but cannot be read must not read as "no secrets".
+fn read_plan_json_from_state(state_dir: &Path) -> Result<Option<String>> {
+    let plan_path = state_dir.join("plan.json");
+    match std::fs::read_to_string(&plan_path) {
+        Ok(s) => Ok(Some(s)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(anyhow::anyhow!(
+            "read plan.json at {} for egress substitution: {e}",
+            plan_path.display()
+        )),
+    }
+}
+
 /// Decode the admitted plan's egress secret bindings from `<state_dir>/plan.json`.
 ///
 /// `Some((secrets, redaction, tenant))` when the admitted plan carries egress
@@ -22,16 +41,8 @@ pub fn decode_plan_secrets_from_state(
         String,
     )>,
 > {
-    let plan_path = state_dir.join("plan.json");
-    let plan_json = match std::fs::read_to_string(&plan_path) {
-        Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => {
-            return Err(anyhow::anyhow!(
-                "read plan.json at {} for egress substitution: {e}",
-                plan_path.display()
-            ));
-        }
+    let Some(plan_json) = read_plan_json_from_state(state_dir)? else {
+        return Ok(None);
     };
     // Both producers land here: the pre-start persist writes the bare
     // `ExecutionPlan` (the shape the firecracker bridge parses too) and the
@@ -49,14 +60,51 @@ pub fn decode_plan_secrets_from_state(
     Ok(Some((plan.secrets, plan.redaction, plan.tenant.0)))
 }
 
+/// True when `plan_json` — an admitted plan in either the bare or the signed
+/// shape — binds at least one egress secret.
+///
+/// The single predicate behind both [`state_has_bound_secrets`], which asks it
+/// of the bytes a VM's state dir already holds, and [`effective_vsock_egress`],
+/// which asks it of the same bytes while they are still only in the launch
+/// config. An undecodable plan answers `false`, matching the substitution path's
+/// own treatment of a placeholder plan.
+pub fn plan_json_has_bound_secrets(plan_json: &str) -> bool {
+    mvm_core::plan::plan_from_admitted_json(plan_json).is_ok_and(|plan| !plan.secrets.is_empty())
+}
+
 /// True when the workload's persisted plan carries at least one bound secret
 /// (i.e. the credential-substitution endpoint will own `EGRESS_PORT`). The
 /// transparent-TCP vsock egress path (Phase A) is scoped to the `false` case so
 /// the two never contend for the port.
 pub fn state_has_bound_secrets(state_dir: &Path) -> Result<bool> {
-    Ok(decode_plan_secrets_from_state(state_dir)?
-        .map(|(secrets, _, _)| !secrets.is_empty())
-        .unwrap_or(false))
+    Ok(read_plan_json_from_state(state_dir)?
+        .as_deref()
+        .is_some_and(plan_json_has_bound_secrets))
+}
+
+/// Whether this launch's guest boots with its in-guest vsock egress client
+/// started — the *effective* egress enablement, not the raw policy.
+///
+/// The guest starts that client iff the launch allows egress **and** carries no
+/// bound secrets: a secret-bearing workload's egress goes through the host-side
+/// substitution endpoint, which owns the shared egress port, so the raw client
+/// stays off and must not contend for it. Both conditions are read off the
+/// launch config alone — the policy, and the admitted plan the config already
+/// carries — so this is answerable at warm-claim decision time, before the
+/// child has a state dir of its own.
+///
+/// This is the value the warm pool partitions on. It is the same predicate the
+/// guest's cmdline token is derived from, with the plan read from the config
+/// instead of from disk; when the two sources can disagree (a launch path that
+/// has not persisted its plan beside the VM yet) this is the *conservative*
+/// side — it can only withhold the client from a warm child that a cold boot
+/// would have started it for, never the reverse.
+pub fn effective_vsock_egress(config: &VmStartConfig) -> bool {
+    config.network_policy.allows_egress()
+        && !config
+            .plan_json
+            .as_deref()
+            .is_some_and(plan_json_has_bound_secrets)
 }
 
 #[cfg(test)]
@@ -85,14 +133,136 @@ mod tests {
     }
 }
 
+/// An admitted plan in the bare shape, carrying one bound egress secret — the
+/// shape `plan.json` holds beside a secret-bearing workload. Shared with the
+/// warm-pool tests, which need the same plan on both the launch config and the
+/// state dir to compare a warm parent's boot against a cold one's.
+#[cfg(test)]
+pub(crate) fn plan_json_with_one_bound_secret() -> String {
+    use mvm_core::plan::test_support::PlanFixture;
+    use mvm_core::plan::{SecretBinding, SecretSource};
+
+    let plan = PlanFixture::new()
+        .secrets(vec![SecretBinding {
+            name: "API_KEY".into(),
+            source: SecretSource::Keystore {
+                address: "test-key".into(),
+            },
+        }])
+        .build();
+    serde_json::to_string(&plan).expect("serialize admitted plan fixture")
+}
+
+/// The same admitted plan with no secret bound at all.
+#[cfg(test)]
+pub(crate) fn plan_json_without_secrets() -> String {
+    let plan = mvm_core::plan::test_support::PlanFixture::new().build();
+    serde_json::to_string(&plan).expect("serialize admitted plan fixture")
+}
+
 #[cfg(test)]
 mod phase_a_tests {
-    use super::state_has_bound_secrets;
+    use super::*;
+
+    use mvm_core::network_policy::{HostPort, NetworkPolicy};
 
     #[test]
     fn state_has_bound_secrets_is_false_for_empty_state() {
         let dir = tempfile::tempdir().unwrap();
         // No plan file written → no secrets.
         assert!(!state_has_bound_secrets(dir.path()).unwrap());
+    }
+
+    /// The one predicate must answer identically whether it is asked of the
+    /// launch config's bytes or of the same bytes on disk — that equality is
+    /// what lets the warm pool decide at claim time what a cold boot would only
+    /// discover at start time.
+    #[test]
+    fn the_secret_predicate_agrees_between_the_launch_config_and_the_state_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        for (json, want) in [
+            (plan_json_with_one_bound_secret(), true),
+            (plan_json_without_secrets(), false),
+            ("not a plan".to_string(), false),
+        ] {
+            std::fs::write(dir.path().join("plan.json"), &json).unwrap();
+            assert_eq!(plan_json_has_bound_secrets(&json), want);
+            assert_eq!(state_has_bound_secrets(dir.path()).unwrap(), want);
+        }
+    }
+
+    fn allow_list_launch(plan_json: Option<String>) -> VmStartConfig {
+        VmStartConfig {
+            network_policy: NetworkPolicy::allow_list(vec![HostPort::new("api.example.com", 443)]),
+            plan_json,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn effective_egress_is_on_for_an_egress_launch_carrying_no_bound_secret() {
+        assert!(effective_vsock_egress(&allow_list_launch(None)));
+        assert!(effective_vsock_egress(&allow_list_launch(Some(
+            plan_json_without_secrets()
+        ))));
+    }
+
+    /// The case that must never come out permissive: a secret-bearing workload's
+    /// outbound traffic belongs to the host-side substitution endpoint, so the
+    /// guest's own egress client stays off even though the policy allows egress.
+    #[test]
+    fn effective_egress_is_off_when_the_admitted_plan_binds_a_secret() {
+        let cfg = allow_list_launch(Some(plan_json_with_one_bound_secret()));
+        assert!(
+            cfg.network_policy.allows_egress(),
+            "fixture must exercise the suppression, not a deny-all policy"
+        );
+        assert!(!effective_vsock_egress(&cfg));
+    }
+
+    #[test]
+    fn effective_egress_is_off_under_deny_all_whatever_the_plan_says() {
+        for plan in [
+            None,
+            Some(plan_json_without_secrets()),
+            Some(plan_json_with_one_bound_secret()),
+        ] {
+            let cfg = VmStartConfig {
+                plan_json: plan,
+                ..Default::default()
+            };
+            assert!(!cfg.network_policy.allows_egress(), "default is deny-all");
+            assert!(!effective_vsock_egress(&cfg));
+        }
+    }
+
+    /// The effective value can never exceed the policy: whatever the plan says,
+    /// a launch that is not allowed off the box never boots the egress client.
+    #[test]
+    fn effective_egress_never_exceeds_the_policy() {
+        for policy in [
+            NetworkPolicy::deny_all(),
+            NetworkPolicy::allow_list(vec![]),
+            NetworkPolicy::allow_list(vec![HostPort::new("api.example.com", 443)]),
+            NetworkPolicy::unrestricted(),
+        ] {
+            for plan in [
+                None,
+                Some(plan_json_without_secrets()),
+                Some(plan_json_with_one_bound_secret()),
+                Some("{}".to_string()),
+            ] {
+                let cfg = VmStartConfig {
+                    network_policy: policy.clone(),
+                    plan_json: plan,
+                    ..Default::default()
+                };
+                assert!(
+                    !effective_vsock_egress(&cfg) || cfg.network_policy.allows_egress(),
+                    "effective egress must imply the policy allows it: {:?}",
+                    cfg.network_policy
+                );
+            }
+        }
     }
 }

--- a/crates/mvm-runtime/src/libkrun.rs
+++ b/crates/mvm-runtime/src/libkrun.rs
@@ -1239,7 +1239,8 @@ impl VmBackend for LibkrunBackend {
             binding_nonce: spec.binding_nonce.clone(),
             spawned_unix_secs: now_unix_secs(),
             state: StandbyState::Idle,
-            image_sha256: None,      // libkrun standbys are image-agnostic
+            image_sha256: None, // libkrun standbys are image-agnostic
+            vsock_egress: spec.vsock_egress,
             parent_checkpoint: None, // this spawn path does not capture a checkpoint yet
         })
     }
@@ -1436,6 +1437,7 @@ mod tests {
             vm_state_dir: "/vms/standby-x".into(),
             image_path: None,
             image_sha256: None,
+            vsock_egress: false,
         }
     }
 

--- a/crates/mvm-runtime/src/mock.rs
+++ b/crates/mvm-runtime/src/mock.rs
@@ -229,6 +229,7 @@ impl VmBackend for MockBackend {
             spawned_unix_secs: 1,
             state: StandbyState::Idle,
             image_sha256: spec.image_sha256.clone(),
+            vsock_egress: spec.vsock_egress,
             parent_checkpoint: None,
         })
     }
@@ -571,6 +572,7 @@ mod tests {
             vm_state_dir: "/tmp/does-not-exist".into(),
             image_path: None,
             image_sha256: None,
+            vsock_egress: false,
         }
     }
 

--- a/crates/mvm-runtime/src/standby_pool.rs
+++ b/crates/mvm-runtime/src/standby_pool.rs
@@ -317,6 +317,7 @@ mod tests {
             state,
             image_sha256: None,
             parent_checkpoint: None,
+            vsock_egress: false,
         }
     }
 
@@ -336,6 +337,7 @@ mod tests {
             state: StandbyState::Idle,
             image_sha256: None,
             parent_checkpoint: None,
+            vsock_egress: false,
         }
     }
 
@@ -346,6 +348,7 @@ mod tests {
             vcpus: 2,
             mem_mib: 1024,
             image_sha256: None,
+            vsock_egress: false,
         }
     }
 
@@ -395,6 +398,49 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    /// A restored child inherits its guest's egress enablement from the parent's
+    /// saved memory, so the pool partitions on it: neither enablement may be
+    /// served by a parent of the other, and the replenish counts them separately
+    /// so each half fills its own set.
+    #[test]
+    fn egress_enablement_partitions_the_pool_in_both_directions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        let deny_key = compat("aa");
+        let egress_key = StandbyCompat {
+            vsock_egress: true,
+            ..deny_key.clone()
+        };
+
+        pool.record(&handle("no-egress-parent", "aa", StandbyState::Idle))
+            .unwrap();
+        assert!(
+            pool.select_idle_compatible(&egress_key).unwrap().is_none(),
+            "a parent that booted no egress client must not serve a launch needing one"
+        );
+        assert_eq!(pool.idle_count_compatible(&egress_key).unwrap(), 0);
+        assert_eq!(pool.idle_count_compatible(&deny_key).unwrap(), 1);
+
+        let mut egress_parent = handle("egress-parent", "aa", StandbyState::Idle);
+        egress_parent.vsock_egress = true;
+        pool.record(&egress_parent).unwrap();
+        assert_eq!(
+            pool.select_idle_compatible(&egress_key)
+                .unwrap()
+                .map(|h| h.id),
+            Some("egress-parent".to_string())
+        );
+        assert_eq!(
+            pool.select_idle_compatible(&deny_key)
+                .unwrap()
+                .map(|h| h.id),
+            Some("no-egress-parent".to_string()),
+            "and the egress parent must not be handed to the deny-all launch either"
+        );
+        assert_eq!(pool.idle_count_compatible(&egress_key).unwrap(), 1);
+        assert_eq!(pool.idle_count_compatible(&deny_key).unwrap(), 1);
     }
 
     #[test]
@@ -580,6 +626,7 @@ mod tests {
             state,
             image_sha256: Some(image.into()),
             parent_checkpoint: None,
+            vsock_egress: false,
         }
     }
 
@@ -590,6 +637,7 @@ mod tests {
             vcpus: 2,
             mem_mib: 1024,
             image_sha256: Some(image.into()),
+            vsock_egress: false,
         }
     }
 

--- a/crates/mvm-runtime/src/vm/lease.rs
+++ b/crates/mvm-runtime/src/vm/lease.rs
@@ -169,6 +169,7 @@ mod tests {
             vcpus: 2,
             mem_mib: 512,
             image_sha256: None,
+            vsock_egress: false,
         }
     }
 
@@ -187,6 +188,7 @@ mod tests {
             state: StandbyState::Idle,
             image_sha256: c.image_sha256,
             parent_checkpoint: None,
+            vsock_egress: c.vsock_egress,
         }
     }
 

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -2075,7 +2075,7 @@ mod tests {
             RecordingBrokerRegistrar::new(),
         );
         let launch = standby_launch_config(&rootfs);
-        let spec = sample_standby_spec("parent-a", tmp.path(), &rootfs);
+        let spec = standby_spec_for("parent-a", tmp.path(), &launch);
 
         let handle = runner
             .spawn_standby_captured(
@@ -2120,6 +2120,9 @@ mod tests {
         }
     }
 
+    /// A pool record for a parent of `rootfs`, booting no guest egress client.
+    /// Tests that warm a parent *for a launch* go through [`standby_spec_for`]
+    /// instead, so the record they match on is the one a real spawn would write.
     fn sample_standby_spec(
         id: &str,
         vm_state_dir: &Path,
@@ -2139,6 +2142,21 @@ mod tests {
             vm_state_dir: vm_state_dir.display().to_string(),
             image_path: Some(rootfs.display().to_string()),
             image_sha256: Some("c".repeat(64)),
+            vsock_egress: false,
+        }
+    }
+
+    /// The pool record a spawn for `launch` would write: the base fixture plus
+    /// the egress enablement the compat-key builder derives from that launch, so
+    /// the parent boots the value a claim for the same launch would match on.
+    fn standby_spec_for(
+        id: &str,
+        vm_state_dir: &Path,
+        launch: &VmStartConfig,
+    ) -> mvm_core::vm_backend::StandbySpec {
+        mvm_core::vm_backend::StandbySpec {
+            vsock_egress: crate::egress_shared::effective_vsock_egress(launch),
+            ..sample_standby_spec(id, vm_state_dir, Path::new(&launch.rootfs_path))
         }
     }
 
@@ -2167,7 +2185,7 @@ mod tests {
             RecordingBrokerRegistrar::new(),
         );
         let launch = standby_launch_config(&rootfs);
-        let spec = sample_standby_spec("standby-test", &tmp.path().join("vm"), &rootfs);
+        let spec = standby_spec_for("standby-test", &tmp.path().join("vm"), &launch);
 
         let handle = runner
             .spawn_standby_captured(
@@ -2267,7 +2285,11 @@ mod tests {
             serde_json::to_vec(&envelope).unwrap(),
         )
         .unwrap();
-        let spec = sample_standby_spec("parent-oversized", tmp.path(), &rootfs);
+        // Derive the spec from this launch: the compat key now carries the
+        // launch's egress enablement, so a spec built from the rootfs alone
+        // could refuse for a mismatched key rather than the oversized cmdline
+        // this test is about.
+        let spec = standby_spec_for("parent-oversized", tmp.path(), &launch);
 
         let err = runner
             .spawn_standby_captured(
@@ -2371,10 +2393,10 @@ mod tests {
         );
 
         runner.start(&launch).expect("workload boots");
-        let spec = sample_standby_spec(
+        let spec = standby_spec_for(
             "standby-parity",
             &home.path().join("standby-parity"),
-            Path::new(&rootfs),
+            &launch,
         );
         runner
             .spawn_standby_captured(
@@ -2413,6 +2435,93 @@ mod tests {
         );
         assert_eq!(parent.kernel, workload.kernel);
         assert_eq!(parent.initramfs, workload.initramfs);
+    }
+
+    /// The same parity, for the launch shape the pool used to refuse: one whose
+    /// policy allows egress.
+    ///
+    /// A restored child inherits its cmdline from the parent's saved memory, so
+    /// the only way a warm child ends up with the guest egress client a cold boot
+    /// would have started is for the parent to have started it. This drives both
+    /// paths through the real runner wiring and requires the two specs to be
+    /// equal — and it names the token, so a failure says which side lost it. The
+    /// parent still gets no substitution endpoint and no broker: what it boots is
+    /// the enablement, not the authority.
+    #[test]
+    fn a_parent_warmed_for_an_egress_allowing_launch_boots_that_launchs_shape() {
+        use mvm_core::network_policy::HostPort;
+
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
+        // `_dir` holds the rootfs's temp dir alive for the whole test.
+        let (_dir, rootfs) = overlay_aware_rootfs("egress-parity");
+        let launch = VmStartConfig {
+            name: "egress-parity".into(),
+            rootfs_path: rootfs.clone(),
+            kernel_path: Some("/img/kernel".into()),
+            network_policy: NetworkPolicy::allow_list(vec![HostPort::new("api.example.com", 443)]),
+            cpus: 2,
+            memory_mib: 512,
+            ..Default::default()
+        };
+
+        let store = CheckpointStore::at(home.path().join("checkpoints"));
+        let runner = WorkloadRunner::new(
+            MockDriver::default().with_vm_full_rootfs(Path::new(&rootfs)),
+            RecordingSpawner::new("/run/ep.sock"),
+            RecordingBrokerRegistrar::new(),
+        );
+
+        runner.start(&launch).expect("workload boots");
+        let spec = standby_spec_for(
+            "standby-egress-parity",
+            &home.path().join("standby-egress-parity"),
+            &launch,
+        );
+        assert!(
+            spec.vsock_egress,
+            "the compat key for this launch must ask for an egress-enabled parent"
+        );
+        runner
+            .spawn_standby_captured(
+                &SpawnContext {
+                    checkpoints: &store,
+                    launch: Some(&launch),
+                },
+                &spec,
+            )
+            .expect("warm parent spawns for an egress-allowing launch");
+
+        let booted = runner.driver.booted_specs();
+        assert_eq!(booted.len(), 2, "one workload boot, then one parent boot");
+        let (workload, parent) = (&booted[0], &booted[1]);
+        assert!(
+            workload.cmdline.contains("mvm.vsock_egress=1"),
+            "fixture must boot the guest egress client: {}",
+            workload.cmdline
+        );
+        assert!(
+            parent.cmdline.contains("mvm.vsock_egress=1"),
+            "the parent must boot it too, or every child restored from it has no network: {}",
+            parent.cmdline
+        );
+        assert_eq!(parent.cmdline, workload.cmdline);
+        assert_eq!(parent.blocks, workload.blocks);
+        assert!(
+            !parent.cmdline.contains("api.example.com"),
+            "the parent's cmdline must name no destination: {}",
+            parent.cmdline
+        );
+        assert!(
+            parent.vsock.is_empty(),
+            "an egress-enabled parent still wires no egress channel to dial"
+        );
+        assert!(!parent.trusted_builder);
     }
 
     // ── Warm claim: the guarded fork of a clean parent into a fresh child ──────
@@ -2544,6 +2653,7 @@ mod tests {
             state: StandbyState::Idle,
             image_sha256: None,
             parent_checkpoint: None,
+            vsock_egress: false,
         }
     }
 
@@ -2678,6 +2788,75 @@ mod tests {
             pool.load("warm-parent").unwrap().state,
             StandbyState::Claimed,
             "the parent is reserved so a concurrent claim cannot double-claim it"
+        );
+    }
+
+    /// Where a claimed child's egress *destinations* come from: its own launch
+    /// policy, threaded into its own endpoint at claim time.
+    ///
+    /// This is what makes keying the pool on the enablement boolean sound. The
+    /// parent boots only whether a guest egress client starts; every host:port a
+    /// workload may reach is resolved here, per child, from that child's policy —
+    /// so a shared parent has no launch's allow-list to hand to the next claim.
+    #[test]
+    fn a_claimed_childs_endpoint_gets_its_own_launchs_allow_list() {
+        use mvm_core::network_policy::HostPort;
+
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
+        let store_root = tempfile::tempdir().unwrap();
+        let src = tempfile::tempdir().unwrap();
+        let (checkpoints, snapshots, parent_id, parent_meta) =
+            seed_audited_parent(store_root.path(), src.path(), true);
+        let parent_digest = parent_rootfs_digest(&parent_meta).unwrap().to_string();
+
+        let pool = SupervisorStandbyPool::at(store_root.path().join("pool"));
+        let mut handle = idle_parent_handle("warm-parent", &store_root.path().join("control.sock"));
+        // The parent was warmed for an egress-enabled launch, so it is claimable
+        // by one.
+        handle.vsock_egress = true;
+        pool.record(&handle).unwrap();
+        let registry_path = store_root.path().join("vm-names.json");
+        let anchor = ClaimTestAnchor::audited(&parent_meta);
+
+        let policy = NetworkPolicy::allow_list(vec![
+            HostPort::new("api.example.com", 443),
+            HostPort::new("logs.example.com", 443),
+        ]);
+        let mut claim = admitted_child_claim(
+            &src.path().join("rootfs.ext4"),
+            signed_child_plan_json(&parent_digest),
+        );
+        claim.network_policy = policy.clone();
+
+        let runner = WorkloadRunner::new(
+            MockDriver::default(),
+            RecordingSpawner::new("/run/ep.sock"),
+            RecordingBrokerRegistrar::new(),
+        );
+        let ctx = ClaimContext {
+            pool: &pool,
+            checkpoints: &checkpoints,
+            snapshots: &snapshots,
+            anchor: &anchor,
+            parent_checkpoint: &parent_id,
+            registry_path: &registry_path,
+        };
+
+        runner
+            .claim_standby(&ctx, &handle, &claim)
+            .expect("claim an egress-enabled parent");
+
+        let seen = runner.spawner.seen.lock().unwrap();
+        let recorded = seen.as_ref().expect("the child got its own endpoint");
+        assert_eq!(
+            recorded.policy, policy,
+            "the child's endpoint must enforce the launch's own allow-list, not the parent's"
         );
     }
 

--- a/crates/mvm-runtime/src/workload_runner/standby_boot.rs
+++ b/crates/mvm-runtime/src/workload_runner/standby_boot.rs
@@ -70,15 +70,40 @@ fn ensure_parent_can_reach_an_agent(
     Ok(())
 }
 
+/// The parent's stand-in for the launch's egress *enablement*, and nothing else.
+///
+/// The guest's `mvm.vsock_egress=1` token is derived from
+/// `network_policy.allows_egress()`, and a restored child inherits its cmdline
+/// out of the parent's saved memory rather than deriving its own — so whether a
+/// child's guest runs an egress client at all is settled at the parent's boot.
+/// The parent therefore has to boot the token the launch would, which means its
+/// config has to answer `allows_egress()` the way the launch's effective
+/// enablement does.
+///
+/// What it must *not* carry is any destination. There is no "egress on, no
+/// hosts" policy shape, so the enablement rides the only host-free one: it names
+/// nothing the launch asked for, and a parent has no NIC, no egress endpoint and
+/// no gateway to route a destination to in any case. The allow-list stays where
+/// it is enforced — host-side, on the claimed child's own endpoint, from that
+/// child's own launch policy — so a shared parent holds nothing per-launch to
+/// hand to the next claim, and the pool partitions on the boolean alone.
+fn parent_egress_enablement(enabled: bool) -> NetworkPolicy {
+    if enabled {
+        NetworkPolicy::unrestricted()
+    } else {
+        NetworkPolicy::deny_all()
+    }
+}
+
 /// Reduce `launch` to the launch config of the factory parent recorded as
 /// `spec`: the guest's boot shape carried verbatim, every field that carries
 /// workload authority or per-launch identity dropped.
 ///
-/// The parent's identity, resources, kernel and rootfs are taken from `spec`
-/// rather than from `launch`, because those four are the pool's own compat key
-/// — a claim matches a parent on them. Sourcing them from the record that will
-/// be matched is what stops the recorded key from describing something other
-/// than what actually booted.
+/// The parent's identity, resources, kernel, rootfs and guest egress enablement
+/// are taken from `spec` rather than from `launch`, because those are the pool's
+/// own compat key — a claim matches a parent on them. Sourcing them from the
+/// record that will be matched is what stops the recorded key from describing
+/// something other than what actually booted.
 pub fn factory_parent_config(
     launch: &VmStartConfig,
     spec: &StandbySpec,
@@ -90,10 +115,12 @@ pub fn factory_parent_config(
     let VmStartConfig {
         // ── Per-launch identity and workload authority. A factory parent runs
         // no workload: it holds no plan, no tenant, no secrets, no volumes and
-        // no ports; its egress is deny-all because it has no gated endpoint to
-        // route through; it pre-opens no console listeners; and it never
-        // replenishes a pool of its own. Each is dropped here, so a parent is
-        // incapable of carrying one rather than merely expected not to.
+        // no ports; it pre-opens no console listeners; and it never replenishes a
+        // pool of its own. Each is dropped here, so a parent is incapable of
+        // carrying one rather than merely expected not to. `network_policy` is
+        // dropped for the same reason and its enablement half re-derived from
+        // `spec` below — a parent boots whether the guest runs an egress client,
+        // never which destinations one may reach.
         name: _,
         template_id: _,
         rootfs_path: _,
@@ -157,7 +184,7 @@ pub fn factory_parent_config(
         plan_json: None,
         bundle_json: None,
         warm_pool_size: 0,
-        network_policy: NetworkPolicy::deny_all(),
+        network_policy: parent_egress_enablement(spec.vsock_egress),
         dev_console: false,
     };
 
@@ -190,6 +217,12 @@ pub fn factory_parent_config(
 /// restored memory rather than deriving its own, so that divergence would reach
 /// every child; resolving it is part of the work that must land before a warm
 /// pool is armed.
+///
+/// `state_dir` is also the second input to the guest's egress token, which is
+/// suppressed for a state dir holding a secret-bearing plan. A factory parent
+/// holds no plan, so nothing writes one beside it and that half is inert here:
+/// the parent's token follows [`StandbySpec::vsock_egress`] alone, which is
+/// exactly the value a claim matches on.
 pub fn factory_parent_spec(
     config: &VmStartConfig,
     state_dir: &Path,
@@ -268,6 +301,10 @@ mod tests {
         }
     }
 
+    /// The pool record a spawn for `launch` would write. `vsock_egress` comes
+    /// from the same shared derivation the CLI's compat-key builder uses, so
+    /// these fixtures exercise the value a real claim would match on rather than
+    /// one hand-set here.
     fn standby_spec_for(launch: &VmStartConfig, dir: &Path) -> StandbySpec {
         StandbySpec {
             id: "standby-abc".into(),
@@ -283,6 +320,7 @@ mod tests {
             vm_state_dir: dir.join("standby-abc").display().to_string(),
             image_path: Some(launch.rootfs_path.clone()),
             image_sha256: Some("e".repeat(64)),
+            vsock_egress: crate::egress_shared::effective_vsock_egress(launch),
         }
     }
 
@@ -338,31 +376,17 @@ mod tests {
         assert!(!parent.trusted_builder);
     }
 
-    /// The one boot-shape difference a factory parent cannot close, pinned so
-    /// the launch-path gate that exists for it is not dropped as redundant.
+    /// An egress-allowing launch: the parent must boot the *identical* cmdline
+    /// the workload does, egress token included.
     ///
-    /// `mvm.vsock_egress=1` starts the guest's in-guest egress client, and it is
-    /// emitted iff the launch's policy allows egress. A parent is deny-all by
-    /// construction: it has no gated endpoint to route through, and it is shared
-    /// across claims, so carrying one launch's policy would hand that launch's
-    /// shape to the next claim — the policy is not part of the compat key. Since
-    /// a child inherits its parent's cmdline out of restored memory rather than
-    /// deriving its own, an egress-allowing launch served warm would come up
-    /// with no network at all, silently. `warm_eligible_launch` on the CLI side
-    /// therefore refuses that shape outright and it cold-boots.
-    ///
-    /// What this asserts is narrower than it looks: for *this fixture*, which
-    /// carries no verb-grant sidecar on either side, the egress token is the
-    /// only difference. It is not a claim that the two cmdlines can differ by at
-    /// most one token in production — the per-VM grant tokens
-    /// (`mvm.verb_grant=`, `mvm.require_grant=`, `mvm.host_signer_pub=`) come
-    /// from a sidecar a factory parent never has, so a workload carrying one
-    /// diverges by those too, silently and without failing anything here. See
-    /// [`factory_parent_spec`]'s note. Within the covered surface, a second
-    /// token appearing here means something else has started depending on the
-    /// parent's stripped-down config.
+    /// `mvm.vsock_egress=1` starts the guest's in-guest egress client, and a
+    /// restored child inherits it from the parent's saved memory rather than
+    /// deriving its own — so a parent that dropped the token would hand every
+    /// child a guest with no network at all, silently. Equality is the assertion
+    /// (not "contains the token") because that is the property a child depends
+    /// on: whatever the workload path adds, the parent adds too.
     #[test]
-    fn an_egress_allowing_launch_diverges_by_one_token_which_is_why_the_pool_refuses_it() {
+    fn a_parent_warmed_for_an_egress_allowing_launch_boots_the_launchs_own_cmdline() {
         let _home = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
         let mut launch = sealed_launch(tmp.path());
@@ -370,34 +394,143 @@ mod tests {
             mvm_core::network_policy::HostPort::new("api.example.com", 443),
         ]);
         let spec = standby_spec_for(&launch, tmp.path());
+        assert!(
+            spec.vsock_egress,
+            "fixture must warm an egress-enabled parent, or it proves nothing"
+        );
 
         let workload = workload_boot(&launch, &tmp.path().join("workload-a"));
         let parent_cfg = factory_parent_config(&launch, &spec).unwrap();
         let parent = factory_parent_spec(&parent_cfg, Path::new(&spec.vm_state_dir), fc_base);
 
         assert!(
-            !parent_cfg.network_policy.allows_egress(),
-            "a parent has no gated endpoint and is shared, so it stays deny-all"
-        );
-        assert!(
             workload.cmdline.contains("mvm.vsock_egress=1"),
             "fixture must exercise the egress token: {}",
             workload.cmdline
         );
-        assert!(
-            !parent.cmdline.contains("mvm.vsock_egress"),
-            "a deny-all parent must not carry the egress token: {}",
-            parent.cmdline
-        );
         assert_eq!(
-            workload.cmdline,
-            format!("{} mvm.vsock_egress=1", parent.cmdline),
-            "the egress token must be the only difference between the two cmdlines"
+            parent.cmdline, workload.cmdline,
+            "a parent warmed for an egress-allowing launch must boot that launch's cmdline"
         );
         assert_eq!(
             parent.blocks, workload.blocks,
             "the disk stack must still match — the policy changes no device"
         );
+    }
+
+    /// The enablement the parent carries names no destination the launch asked
+    /// for. A parent is shared across claims, so anything per-launch on it would
+    /// reach the next claim; the allow-list is resolved host-side on the claimed
+    /// child's own endpoint instead, and never rides the parent.
+    #[test]
+    fn the_parent_carries_the_egress_enablement_but_none_of_the_launchs_destinations() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut launch = sealed_launch(tmp.path());
+        launch.network_policy = mvm_core::network_policy::NetworkPolicy::allow_list(vec![
+            mvm_core::network_policy::HostPort::new("api.example.com", 443),
+            mvm_core::network_policy::HostPort::new("secret.internal", 8443),
+        ]);
+        let spec = standby_spec_for(&launch, tmp.path());
+
+        let parent_cfg = factory_parent_config(&launch, &spec).unwrap();
+
+        assert!(
+            parent_cfg.network_policy.allows_egress(),
+            "the parent must boot the launch's egress enablement"
+        );
+        let label = parent_cfg.network_policy.posture_label();
+        for host in ["api.example.com", "secret.internal"] {
+            assert!(
+                !label.contains(host),
+                "a shared parent must carry no launch destination, got: {label}"
+            );
+        }
+        assert_ne!(
+            parent_cfg.network_policy, launch.network_policy,
+            "the parent must not be handed the launch's own policy"
+        );
+    }
+
+    /// A deny-all launch's parent stays deny-all, and its cmdline still matches
+    /// the workload's exactly — the enablement is a boolean, so flipping it must
+    /// not perturb anything else.
+    #[test]
+    fn a_parent_warmed_for_a_deny_all_launch_boots_no_egress_client() {
+        let _home = isolated_home();
+        let tmp = tempfile::tempdir().unwrap();
+        let launch = sealed_launch(tmp.path());
+        let spec = standby_spec_for(&launch, tmp.path());
+        assert!(
+            !spec.vsock_egress,
+            "the default launch policy is deny-all, so no egress client is warmed"
+        );
+
+        let workload = workload_boot(&launch, &tmp.path().join("workload-a"));
+        let parent_cfg = factory_parent_config(&launch, &spec).unwrap();
+        let parent = factory_parent_spec(&parent_cfg, Path::new(&spec.vm_state_dir), fc_base);
+
+        assert!(!parent_cfg.network_policy.allows_egress());
+        assert!(
+            !workload.cmdline.contains("mvm.vsock_egress"),
+            "a deny-all workload boots no egress client: {}",
+            workload.cmdline
+        );
+        assert_eq!(parent.cmdline, workload.cmdline);
+    }
+
+    /// The case that must never come out permissive. A secret-bearing workload's
+    /// outbound traffic belongs to the host-side substitution endpoint, so a cold
+    /// boot suppresses the guest's own egress client even though the policy allows
+    /// egress. The pool keys on that *effective* value, so the parent warmed for
+    /// such a launch suppresses it too — and the two cmdlines come out equal, not
+    /// merely both token-less.
+    #[test]
+    fn a_secret_bearing_launch_warms_a_parent_with_no_egress_client_either() {
+        let _home = isolated_home();
+        let tmp = tempfile::tempdir().unwrap();
+        let mut launch = sealed_launch(tmp.path());
+        launch.network_policy = mvm_core::network_policy::NetworkPolicy::allow_list(vec![
+            mvm_core::network_policy::HostPort::new("api.example.com", 443),
+        ]);
+        launch.plan_json = Some(crate::egress_shared::plan_json_with_one_bound_secret());
+        let spec = standby_spec_for(&launch, tmp.path());
+        assert!(
+            launch.network_policy.allows_egress(),
+            "fixture must exercise the suppression, not a deny-all policy"
+        );
+        assert!(
+            !spec.vsock_egress,
+            "a secret-bearing launch must warm a parent with no egress client"
+        );
+
+        // The cold boot the parent is compared against: the admitted plan is
+        // persisted beside the VM before it starts, which is what makes the
+        // cold-boot token suppress itself.
+        let workload_dir = tmp.path().join("workload-a");
+        std::fs::create_dir_all(&workload_dir).unwrap();
+        std::fs::write(
+            workload_dir.join("plan.json"),
+            launch.plan_json.as_deref().unwrap(),
+        )
+        .unwrap();
+        let workload = workload_boot(&launch, &workload_dir);
+
+        let parent_cfg = factory_parent_config(&launch, &spec).unwrap();
+        let parent = factory_parent_spec(&parent_cfg, Path::new(&spec.vm_state_dir), fc_base);
+
+        assert!(
+            !workload.cmdline.contains("mvm.vsock_egress"),
+            "a secret-bearing cold boot suppresses the guest egress client: {}",
+            workload.cmdline
+        );
+        assert!(
+            !parent.cmdline.contains("mvm.vsock_egress"),
+            "so must the parent warmed for it: {}",
+            parent.cmdline
+        );
+        assert_eq!(parent.cmdline, workload.cmdline);
+        assert!(!parent_cfg.network_policy.allows_egress());
+        assert_eq!(parent_cfg.plan_json, None, "a parent still holds no plan");
     }
 
     /// The same guard, stated against the concrete symptoms the live run
@@ -473,15 +606,14 @@ mod tests {
         assert!(parent_cfg.volumes.is_empty());
         assert!(parent_cfg.secret_files.is_empty());
         assert!(parent_cfg.config_files.is_empty());
-        assert!(
-            !parent_cfg.network_policy.allows_egress(),
-            "a parent has no gated endpoint, so it must not be allowed off the box"
-        );
 
         let parent = factory_parent_spec(&parent_cfg, Path::new(&spec.vm_state_dir), fc_base);
+        // The enablement the guest boots with is all the parent takes from the
+        // launch's policy, and it buys the parent no reach: a parent wires no
+        // egress channel at all, so the guest's client has nothing to dial.
         assert!(
             parent.vsock.is_empty(),
-            "a factory parent wires no host channels: no endpoint, no broker"
+            "a factory parent wires no host channels: no egress, no broker"
         );
         assert_eq!(
             parent.blocks.len(),

--- a/crates/mvm-runtime/tests/fc_warm_pool_live.rs
+++ b/crates/mvm-runtime/tests/fc_warm_pool_live.rs
@@ -108,6 +108,9 @@ fn standby_spec(id: &str, images: &LiveImages, home: &Path) -> StandbySpec {
             .into_owned(),
         image_path: Some(images.rootfs.to_string_lossy().into_owned()),
         image_sha256: Some(sha256(&images.rootfs)),
+        // The live launch this parent mirrors is deny-all, so the guest boots no
+        // egress client.
+        vsock_egress: false,
     }
 }
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -470,7 +470,30 @@ Then unify + retire the old paths:
       Phase 2 slice one — the runner-side warm-pool claim substrate
       (`specs/plans/255-phase2-warm-pool-substrate.md`) — landed on branch
       `feat/plan-255-phase2-warm-pool`, with the live FC warm pool + capability
-      flip a follow-up slice.
+      flip a follow-up slice. That follow-up
+      (`specs/plans/255-live-fc-warm-claim.md`) built spawn/capture/fork/reseed
+      and then **failed its live KVM validation**
+      (`specs/notes/2026-07-28-plan-255-live-fc-warm-claim-validation.md`): the
+      standby parent booted a bare rootfs and panicked for want of the runtime
+      overlay that carries the guest agent. The parent's boot inputs now come
+      from the launch's own `VmStartConfig` through the same mappers a workload
+      boot uses, guarded by shape-equality tests, and a later live run on the
+      same host confirms that half — the parent boots, reaches its guest agent,
+      and the capture writes a `vm_full` checkpoint carrying a 512 MiB
+      `memory.bin`, then releases the parent.
+      Since then the recorded reductions have closed: a claimed child is wired
+      the host channels a cold boot gets (#1917); an egress-allowing launch is
+      **keyed** into the pool rather than excluded from it —
+      `StandbyCompat::vsock_egress` (the launch's *effective* enablement: the
+      policy allows egress **and** the admitted plan binds no secret) partitions
+      the warm set, the parent boots that boolean and no destination, and the
+      allow-list stays host-side on the claimed child's own egress endpoint; and
+      the CLI no longer reserves a parent the runner is about to reserve (#1922),
+      which had made every warm claim refuse with "parent is not in a claimable
+      state" so the pool filled and never drained.
+      `standby_pool` stays **`false`**: the **claim** half has still never
+      executed live, so the post-restore handshake and the child's egress/broker/
+      exit channels remain unproven. The flip is gated on that run.
 - [ ] A clean **external API** (`Image` / `Vm` / `Pool` / `ExecBuilder`-style) on `mvm-client`, so library and CLI share one surface.
 - [ ] **Simple, fast install:** a one-line installer + `mvmctl upgrade`.
 - Gate: the timed e2e proves sub-second launch on both hosts; warm-start + snapshot restore measured; the external API is documented and BDD-covered.

--- a/specs/notes/2026-07-28-plan-255-live-fc-warm-claim-validation.md
+++ b/specs/notes/2026-07-28-plan-255-live-fc-warm-claim-validation.md
@@ -735,12 +735,28 @@ reading the pool code:
   halves now build the key through one function (`compat_for_launch`), keyed on
   the same digest claim-8 admission puts on `plan.image.sha256` and that
   `bind_plan_to_parent` checks the captured parent against.
-- **`mvm.vsock_egress=1` was a second cmdline divergence.** A factory parent is
+- **`mvm.vsock_egress=1` was a second cmdline divergence.** A factory parent was
   deny-all by construction, so a launch with `--network-allow` would boot the
   workload with the token and the parent without it — and a child inheriting the
-  parent's cmdline would come up with no network, silently. Such launches are
-  now excluded from the warm pool at both ends (claim and replenish) rather than
-  served with the wrong shape.
+  parent's cmdline would come up with no network, silently. Such launches were
+  first excluded from the warm pool at both ends (claim and replenish) rather
+  than served with the wrong shape.
+
+  **Since resolved by keying instead of excluding.** The exclusion assumed the
+  parent could not carry the launch's egress without leaking that launch's shape
+  to the next claim. The token is a bare boolean — no host, no allow-list reaches
+  the guest — and the destination set is resolved host-side per child, on the
+  egress endpoint the claim wires from that child's own launch config. So the pool
+  partitions on egress **enablement** alone:
+  `StandbyCompat::vsock_egress` makes a parent claimable only by launches whose
+  guest boots the same way, `factory_parent_config` takes that enablement from the
+  matched record (`spec.vsock_egress`) and carries no destination, and
+  `warm_eligible_launch` no longer refuses the shape. The key is the *effective*
+  enablement (`egress_shared::effective_vsock_egress`: the policy allows egress
+  **and** the admitted plan binds no secret), which is the same condition the token
+  itself is derived from — so a secret-bearing launch keys token-less exactly as
+  its cold boot boots, and the key can never be more permissive than the cold boot
+  it stands in for.
 
 ---
 

--- a/specs/plans/255-live-fc-warm-claim.md
+++ b/specs/plans/255-live-fc-warm-claim.md
@@ -1064,17 +1064,73 @@ live run did not catch it because the hand-seeded fixture carried
 Both halves now build the key through one function (`compat_for_launch`), keyed
 on the same digest claim-8 admission puts on `plan.image.sha256`.
 
-**Accepted reduction: egress-allowing launches are excluded from the pool.**
-`mvm.vsock_egress=1` is a per-launch cmdline token and a child inherits its
-parent's cmdline out of restored memory, so a deny-all parent would hand an
-egress-allowing launch a guest whose in-guest egress client never starts —
-silently no network. Carrying one launch's policy onto a shared parent instead
-would leak that launch's shape to the next claim, since the policy is not part
-of the compat key. So `warm_eligible_launch` now refuses those launches at both
-ends (claim and replenish) and they cold-boot. That is **most real workloads**:
-the warm pool as it stands serves only the no-egress, no-extra-volume,
-no-virtio-fs-root shape. Serving an egress-allowing launch needs a child that
-can be told its own egress shape after the restore, which is its own slice.
+**Resolved (superseding the accepted reduction below): egress-allowing launches
+are keyed into the pool, not excluded.** The reduction as recorded —
+`warm_eligible_launch` refusing any launch whose policy allows egress, i.e. most
+real workloads — rested on the premise that carrying a launch's egress onto a
+shared parent would leak that launch's shape to the next claim. It does not. The
+guest cmdline carries only the **boolean** `mvm.vsock_egress=1`
+(`vsock_egress_cmdline_token`); no host and no allow-list ever reaches the guest,
+and the destination set is resolved host-side, per child, on the egress endpoint
+the claim wires from that child's own launch config
+(`PlanFlowPolicy::from_network_policy` reduces the whole policy to one
+`egress_permitted` bit, and `resolve_bare_dns_pins` resolves the allow-list from
+the launch's own policy at bridge launch). So the pool only has to partition on
+egress **enablement**.
+
+It now does. `StandbyCompat` — and `StandbySpec`/`StandbyHandle` with it — carries
+a `vsock_egress: bool`, exact-equality like every other compat field, so a
+token-less parent can never serve a launch whose guest needs the client and an
+egress-booted parent can never serve one whose guest must not have it.
+`factory_parent_config` derives the parent's enablement from `spec.vsock_egress` —
+the same value a claim matches on, sourced from the record that will be matched
+rather than re-derived — and carries no destination onto the parent.
+`warm_eligible_launch` drops the egress test, leaving only the two shapes a parent
+genuinely cannot boot: extra volumes and a virtio-fs root.
+
+The key is the **effective** enablement, not the raw policy:
+`egress_shared::effective_vsock_egress` is `allows_egress() && the admitted plan
+binds no secret` — the same condition the guest cmdline token is derived from, with
+the plan read from the launch config instead of from the state dir. That resolves
+the bound-secrets asymmetry with no special case (a secret-bearing launch keys to
+`false` and claims a token-less parent, which is exactly what its cold boot boots),
+and it is the conservative side of the one place the two sources can disagree: on
+a launch path that has not yet persisted its plan beside the VM, this can only
+*withhold* the client from a warm child, never grant one a cold boot would have
+denied.
+
+**One pre-existing inconsistency this exposes, and which side the key takes.**
+Two producers answer "does this workload bind a secret" from different sources.
+The `up` / OCI paths persist the admitted plan beside the VM
+(`stash_plan_for_bridge`) before `backend.start()`, so the cold-boot token reads
+the plan and suppresses itself for a secret-bearing workload. The transient
+`machine run` path — the only path that claims from the pool — does not persist it
+before start, so `state_has_bound_secrets` reads an absent file and the cold boot
+emits the token *and* spawns a raw-egress endpoint even for a secret-bearing plan.
+The compat key sides with the plan the launch config carries, because that is the
+authoritative statement of what the workload binds. For a secret-bearing
+egress-allowing transient launch the warm child therefore comes up token-less with
+a substitution endpoint (its endpoint's secrets are decoded from `claim.plan_json`,
+not from disk) where the cold boot comes up with the token and a raw endpoint. The
+warm shape is the narrower of the two — destination-bound signed credentials rather
+than raw TCP — so no warm child gets egress its cold boot would have denied. Making
+the transient path persist its plan before start, so both sides read one source, is
+the follow-up that removes the divergence outright; it is not a prerequisite for
+this key, which is already the conservative side of it.
+
+The original reduction, kept for the record:
+
+> **Accepted reduction: egress-allowing launches are excluded from the pool.**
+> `mvm.vsock_egress=1` is a per-launch cmdline token and a child inherits its
+> parent's cmdline out of restored memory, so a deny-all parent would hand an
+> egress-allowing launch a guest whose in-guest egress client never starts —
+> silently no network. Carrying one launch's policy onto a shared parent instead
+> would leak that launch's shape to the next claim, since the policy is not part
+> of the compat key. So `warm_eligible_launch` now refuses those launches at both
+> ends (claim and replenish) and they cold-boot. That is **most real workloads**:
+> the warm pool as it stands serves only the no-egress, no-extra-volume,
+> no-virtio-fs-root shape. Serving an egress-allowing launch needs a child that
+> can be told its own egress shape after the restore, which is its own slice.
 
 **Measured:** cold boot → agent-ready median 2096 ms (2079–2253, n=7). Warm claim
 not measurable. Enabling the pool today adds ~2.6 s median per run for nothing.


### PR DESCRIPTION
## What was broken

`warm_eligible_launch` excluded any launch whose network policy allows egress — which is most real workloads, so the pool was close to useless:

```rust
cfg.volumes.is_empty() && cfg.virtiofs_root.is_none() && !cfg.network_policy.allows_egress()
```

The exclusion existed because `factory_parent_config` hardcoded `NetworkPolicy::deny_all()`, so a parent booted without the `mvm.vsock_egress=1` token while an egress-allowing workload booted with it. A restored child inherits its cmdline from the parent's saved memory, so such a child would silently have had no egress.

## Why the fix is small

The stated reason for excluding rather than fixing was that a parent is shared, so carrying a launch's policy onto it would leak one launch's egress shape to the next claim. That turns out not to hold: the guest cmdline carries only the **boolean** `mvm.vsock_egress=1` — no hosts, no allow-list. The allow-list is resolved **host-side** by the gateway bridge's flow policy, on the per-child egress endpoint the claim path wires from the launch's own config. There is no per-launch egress shape baked into a shared parent to leak, so the pool needs to partition on egress *enablement* only.

## The design

The token is gated on two conditions: `allows_egress() && !has_bound_secrets`. The pool keys on that **effective** value rather than raw policy, which makes the bound-secrets asymmetry resolve itself:

| launch | effective | claims | cold boot | 
|---|---|---|---|
| egress, no secrets | true | parent with token | token | match |
| egress, **with** secrets | false | token-less parent | token suppressed | match |
| deny-all | false | token-less parent | no token | match |

So no special-case exclusion is needed. Both halves compute the key through the single `compat_for_launch` builder — spawn and claim deriving it separately is how the pool silently never drained once before.

## The secrets-timing question, and one honest divergence

The effective value is knowable at claim time, but **not** from a state dir: the child has none yet, and a restored child never recomputes its cmdline (it was fixed at the parent's boot). It comes from `cfg.plan_json`, which `try_warm_claim` already requires and which is byte-identical to what `stash_plan_for_bridge` later writes. `state_has_bound_secrets` now delegates to that one predicate.

That leaves a divergence worth stating plainly. The `up`/OCI paths persist the plan before `backend.start()`, so cold boot and the key agree exactly. The transient `machine run` path — the only claimer — does not, so its cold boot emits the token *and* a raw-egress endpoint even for a secret-bearing plan. The key sides with the plan, so such a warm child comes up token-less with a substitution endpoint: **strictly narrower** than the cold boot's raw endpoint. It can only ever withhold egress, never grant what a cold boot denied, and `effective_egress_never_exceeds_the_policy` pins that direction.

Follow-up recorded in the plan: make the transient path persist its plan before start so both sides read one source.

## Unchanged

`standby_pool` stays **`false`** for every driver. A factory parent still gets no plan, no endpoint, no broker, and never `trusted_builder: true`. No guest NIC; the no-NIC device-model guard stays between snapshot load and resume. The fail-closed post-restore handshake (`acknowledged` + `reseeded` + `clock_resynced`) still gates the claim before it commits.

## Tests

New tests were verified red before the fix in both directions. Full `cargo nextest run --workspace --no-fail-fast` → 8025 run, 8022 passed; the 3 failures are the known pre-existing `mvm-build ensure_builder_vm_image_*` trio in a crate this does not touch. fmt (stable + nightly), clippy `-D warnings` including the BDD target, `--doc`, and all 33 `xtask check-*` policy gates clean.
