### PR TITLE
fix(pool): stop the CLI and the runner both reserving the same warm parent

### DIFF
--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -323,7 +323,16 @@ where
         })
         .context("requested standby-pool recovery"));
     }
-    let Some(handle) = pool.claim_idle_compatible(want)? else {
+    // Select without reserving. The runner reserves this parent itself, in the
+    // same locked section it verifies it in, and refuses a parent that is
+    // already `Claimed` — so reserving here too made every warm claim fail with
+    // "parent is not in a claimable state". One reservation owner, and it is the
+    // one that also verifies.
+    //
+    // Two launchers can still both select the same idle parent; the runner's
+    // lock serializes them and the loser is refused into a cold boot, which is
+    // the same outcome reserving here bought, without deadlocking the winner.
+    let Some(handle) = pool.select_idle_compatible(want)? else {
         return Ok(LaunchDecision::ColdBoot);
     };
     let claim = match make_claim(&handle) {
@@ -1080,6 +1089,77 @@ mod tests {
         other.rootfs_path = other_rootfs.display().to_string();
         let other_want = compat_for_launch(backend.as_vm_backend(), &other).unwrap();
         assert_ne!(other_want, want);
+    }
+
+    /// `claim_or_cold` must hand the runner a parent that is still claimable.
+    ///
+    /// The runner reserves the parent itself, in the same locked section it
+    /// verifies it in, and refuses one that is already `Claimed`. Reserving here
+    /// as well meant every warm claim on a runner-backed backend died with
+    /// "parent is not in a claimable state": the pool filled and never drained.
+    ///
+    /// Nothing caught it because the mock backend services a claim from its own
+    /// in-memory state and never runs the runner's reserve, so the two-layer
+    /// interaction only existed on a live host. This asserts the seam directly:
+    /// at the moment the claim is built the runner has not run, so the parent
+    /// must still be claimable on disk.
+    #[cfg(feature = "test-support")]
+    #[test]
+    fn claim_or_cold_leaves_the_parent_claimable_for_the_runner_to_reserve() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path().join("pool"));
+        let kernel = tmp.path().join("vmlinux");
+        std::fs::write(&kernel, b"warm-kernel").unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"warm-rootfs").unwrap();
+        let key = tmp.path().join("host-signer.ed25519");
+        std::fs::write(&key, b"fake-key").unwrap();
+
+        let mut cfg = eligible_cfg();
+        cfg.kernel_path = Some(kernel.display().to_string());
+        cfg.rootfs_path = rootfs.display().to_string();
+
+        let backend = AnyBackend::Mock(mvm_runtime::mock::MockBackend::new().with_standby());
+        assert_eq!(
+            warm_to_target(
+                &pool,
+                &WarmParams {
+                    backend: &backend,
+                    template_id: cfg.template_id.as_deref(),
+                    kernel: &kernel,
+                    vcpus: 2,
+                    mem_mib: 1024,
+                    signer_id: "host:test",
+                    signing_key_path: &key,
+                    target: 1,
+                    launch: Some(&cfg),
+                },
+            )
+            .unwrap()
+            .spawned,
+            1,
+            "the fixture must warm one parent, or this asserts nothing"
+        );
+
+        let want = compat_for_launch(backend.as_vm_backend(), &cfg).unwrap();
+        let observed: std::cell::Cell<Option<StandbyState>> = std::cell::Cell::new(None);
+        let decision = claim_or_cold(&pool, &backend, &want, |handle| {
+            observed.set(Some(pool.load(&handle.id).unwrap().state));
+            // Stop here: the reservation state is the whole subject of this test.
+            anyhow::bail!("halt after inspecting the reservation state")
+        })
+        .unwrap();
+
+        assert_eq!(
+            observed.get(),
+            Some(StandbyState::Idle),
+            "the parent must still be claimable when the runner is handed it; \
+             reserving it here is what made every warm claim refuse"
+        );
+        assert!(
+            matches!(decision, LaunchDecision::ColdBoot),
+            "a halted claim falls back to a cold boot"
+        );
     }
 
     #[cfg(feature = "test-support")]

--- a/specs/notes/2026-07-28-plan-255-live-fc-warm-claim-validation.md
+++ b/specs/notes/2026-07-28-plan-255-live-fc-warm-claim-validation.md
@@ -786,3 +786,88 @@ hard gate.
 In short: BUG-1 is fixed and live-proven; BUG-2 and BLOCKER-3 are both open and
 each independently prevents a claim from ever completing; BLOCKER-4 lets a claim
 complete but returns a child wired none of the host channels a cold boot gets.
+
+---
+
+## Fourth live run (2026-07-30) — capture proven on the full blocker set; claim blocked by a double reservation
+
+Host: Linux 6.8.0-124, Firecracker v1.14.1, `/dev/kvm`, release build of the
+four-blocker state (`65a43af1d`). Capability flipped to `true` **on the test host
+only**; the committed default stays `false`. Isolated `MVM_HOME=/root/mvm-live-home`
+with the runtime-overlay cache symlinked in.
+
+### Capture: works, reproduced on the complete blocker set
+
+`MVM_RESIDENCY=warm mvmctl machine run --image docker.io/library/alpine:latest
+--hypervisor firecracker echo hello-live` → workload ran, `EXIT=0`. The log shows
+`plan admitted`, then `runtime_source_status="overlay-required"` with
+`overlay_attached=true` — the overlay attachment whose absence made the parent
+kernel-panic in the second run. `replenish_after_launch` then spawned and captured
+a parent:
+
+```
+pool/standby-ecee9d16f0fa5f70/standby.json
+  state=idle  pid=0  parent_checkpoint=standby-standby-ecee9d16f0fa5f70
+checkpoints/standby-standby-ecee9d16f0fa5f70/meta.json
+  class=vm_full  blobs=[rootfs.ext4, memory.bin, vmstate.bin, mvm-meta.json,
+                        rootfs.verity, rootfs.roothash, device-anchors.json]
+  content/memory.bin  536870912 bytes
+```
+
+`pid=0` is the release-after-capture the design intends: a pool slot costs disk,
+not a resident VM.
+
+### Claim: refused, and the cause is a double reservation
+
+The second identical run refused:
+
+```
+WARN standby claim failed; cold-booting standby=standby-ecee9d16f0fa5f70
+     error=claim standby: parent is not in a claimable state
+```
+
+Two layers each reserve the parent:
+
+- `SupervisorStandbyPool::claim_idle_compatible` (`standby_pool.rs:106`) selects
+  **and** reserves — `mark_claimed` at `:115`, `state = Claimed` at `:116`.
+- `reserve_and_verify_parent` (`runner.rs:789`) then loads that parent, finds
+  `!state.is_claimable()` at `:800`, and refuses `ParentNotClaimable`.
+
+So a warm claim on a runner-backed backend can never succeed. The CLI then removes
+the parent as spent and cold-boots, and the next replenish warms a fresh one — the
+pool fills and never drains, indefinitely.
+
+Both halves are correct alone. The runner's reserve is the one to keep: it reserves
+and verifies inside a single locked section, which is strictly stronger. The CLI
+should select without reserving (`select_idle_compatible`, `:92`). Two launchers
+can then both select one parent; the runner's lock serializes them and the loser is
+refused into a cold boot — the same outcome the CLI-side reservation bought, without
+deadlocking the winner.
+
+**Why no test caught it.** The `claim_or_cold` tests drive `AnyBackend::Mock`, whose
+`claim_standby` answers from its own in-memory state and never runs the runner's
+reserve. The two-layer interaction existed only on a live host.
+
+### Not yet exercised
+
+The post-restore handshake (`acknowledged` + `reseeded` + `clock_resynced`) and the
+child's egress/broker/exit channels still have not run: the claim never got far
+enough. They remain the open live question after this fix.
+
+### Two incidental findings
+
+- `host-agent registration failed; host.audit.v1 unavailable for this VM — could
+  not locate the mvm-host-agent binary (set MVM_HOST_AGENT_PATH)`. This fires on the
+  **cold** boot too, so it is an environment gap on this host rather than a claim-path
+  defect — but it means broker reachability cannot be judged from this run either way.
+- 14 orphaned `firecracker --api-sock /tmp/.tmpXXXX/vms/mvm-forkblank-parent-*`
+  processes are alive on the box. That is a test-fixture name, so a live harness leaks
+  its parent VMs instead of reaping them; each holds guest memory.
+
+### Timings (not a warm-vs-cold comparison yet)
+
+Run 1 wall clock 173 s, dominated by a runtime-overlay rebuild from source
+("source-built cache is stale") plus image work — not a boot measurement. Run 2,
+with the overlay cached, was 10.0 s for cold boot + capture + replenish. The earlier
+cold-boot-to-agent-ready baseline of 2096 ms median (n=7) still stands as the number
+to beat; a warm figure needs the claim to succeed.


### PR DESCRIPTION
## What a live run found

The first end-to-end warm claim on a real Firecracker host refused, every time:

```
WARN standby claim failed; cold-booting standby=standby-ecee9d16f0fa5f70
     error=claim standby: parent is not in a claimable state
```

**Two layers each reserve the parent.** `SupervisorStandbyPool::claim_idle_compatible` selects *and* reserves — `mark_claimed` then `state = Claimed`. `reserve_and_verify_parent` then loads that same parent, finds `!state.is_claimable()`, and refuses `ParentNotClaimable`.

So a warm claim on a runner-backed backend could **never** succeed. The CLI then dropped the parent as spent and cold-booted, and the next replenish warmed a fresh one to meet the same fate — the pool filling and never draining, indefinitely. Not an edge case: the feature was categorically impossible.

## The fix

Select without reserving; leave the runner as the sole reserver. It reserves **and verifies** inside one locked section, which is the stronger guarantee — that atomic guarded reserve is the whole point of the claim substrate.

The CLI-side reservation existed to stop two launchers grabbing one parent. That property survives: both can still select it, the runner's lock serializes them, and the loser is refused into a cold boot — the same outcome, without deadlocking the winner.

## Why nothing caught it

Every `claim_or_cold` test drives `AnyBackend::Mock`, whose `claim_standby` answers from its own in-memory state and never runs the runner's reserve. The two-layer interaction existed only on a live host.

The new test asserts the seam directly: at the moment the claim is built, the runner has not run, so the parent must still be claimable on disk. **Verified red against the old call** — reintroducing `claim_idle_compatible` there makes it fail.

## What the same live run did prove

Capture works end to end on the full blocker set. A parent boots to agent-ready with `overlay_attached=true`, is paused, captured, and released:

```
class=vm_full  blobs=[rootfs.ext4, memory.bin, vmstate.bin, device-anchors.json, ...]
content/memory.bin  536870912 bytes
pool/<id>/standby.json  state=idle  pid=0  parent_checkpoint=<id>
```

`pid=0` is the intended release-after-capture: a pool slot costs disk, not a resident VM.

## Still unproven

The post-restore handshake (`acknowledged` + `reseeded` + `clock_resynced`) and the child's egress/broker/exit channels have still never executed — the claim never got far enough. They are the next live question once this lands.

Two incidental findings are recorded in the validation note: the `host.audit.v1` unavailable warning fires on the **cold** boot too, so it is an environment gap on that host rather than a claim-path defect; and 14 orphaned `mvm-forkblank-parent` Firecracker processes are alive there, so a live harness leaks its parents instead of reaping them.

`standby_pool` remains **`false`** — the flip stays gated on a successful live claim.
