### PR TITLE
test: close the non-hermetic $HOME test class and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,9 @@ jobs:
       - name: Single MVM_HOME root (no resolver bypass)
         run: cargo run -p xtask -- check-single-home
 
+      - name: Tests that move MVM_HOME also isolate HOME
+        run: cargo run -p xtask -- check-test-home-isolation
+
       - name: No baked network literals (IPs/ports/tmp-sockets)
         run: cargo run -p xtask -- check-no-network-literals
 

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -7082,7 +7082,7 @@ mod tests {
             Some(tempfile::tempdir().expect("bootstrap cache tempdir"))
         };
         if let Some(cache) = &bootstrap_cache {
-            env.set("MVM_HOME", cache.path());
+            env.isolate_mvm_home(cache.path());
         }
 
         let workspace_root =

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -1527,7 +1527,7 @@ mod tests {
 
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let mut plan = PlanFixture::new()
             .tenant("local")
@@ -1561,7 +1561,7 @@ mod tests {
 
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let store = mvm_runtime::checkpoint::CheckpointStore::open();
         let meta = mvm_core::checkpoint::CheckpointMeta::builder(
@@ -1604,7 +1604,7 @@ mod tests {
     fn stopped_vm_is_quiesced() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
         assert!(
             vm_is_quiesced("no-such-vm-stopped"),
             "stopped VM must be quiesced"
@@ -1619,7 +1619,7 @@ mod tests {
     fn fc_paused_vm_with_matching_marker_is_quiesced() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let pid = unsafe { libc::getpid() };
         let pid_str = pid.to_string();
@@ -1651,7 +1651,7 @@ mod tests {
     fn fc_running_without_marker_is_not_quiesced() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let pid = unsafe { libc::getpid() };
 
@@ -1679,7 +1679,7 @@ mod tests {
     fn fc_stale_marker_is_not_quiesced() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let live_pid = unsafe { libc::getpid() };
         let stale_pid = live_pid.saturating_add(1);
@@ -1711,7 +1711,7 @@ mod tests {
     fn resolve_rootfs_from_mode_json_when_present() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let vm_name = "mode-json-rootfs-vm";
         let state_dir = mvm_core::config::vm_state_dir(vm_name);
@@ -1745,7 +1745,7 @@ mod tests {
     fn mode_json_rootfs_path_missing_on_disk_produces_actionable_error() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let vm_name = "mode-json-gone-vm";
         let state_dir = mvm_core::config::vm_state_dir(vm_name);
@@ -1804,7 +1804,7 @@ mod tests {
     fn resource_shape_no_plan_no_flags_uses_defaults() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let store = CheckpointStore::at(tmp.path().join("store"));
         let ckpt_id = seed_checkpoint(&store, "origin-vm");
@@ -2070,7 +2070,7 @@ mod tests {
     fn read_grant_envelope_for_returns_none_when_absent() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let result = read_grant_envelope_for("no-such-vm-read-grant-test");
         assert!(result.is_none());
@@ -2084,7 +2084,7 @@ mod tests {
 
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let vm_name = "test-fork-grant-read-sidecar";
         let state_dir = mvm_core::config::vm_state_dir(vm_name);
@@ -2122,7 +2122,7 @@ mod tests {
 
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let vm_name = "test-fork-grant-predecessor";
         let state_dir = mvm_core::config::vm_state_dir(vm_name);
@@ -2206,7 +2206,7 @@ mod tests {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
         // Point MVM_HOME somewhere clean so the per-VM dirs have no stale pids.
-        env.set("MVM_HOME", tmp.path().join("mvm"));
+        env.isolate_mvm_home(tmp.path().join("mvm"));
 
         // Construct <mvm_home>/vms/<name>/fc.pid with the current process PID.
         let vm_name = "live-fc-vm-quiesce-test";
@@ -2226,7 +2226,7 @@ mod tests {
     fn resolve_quiesced_vm_rootfs_refuses_live_fc_vm() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path().join("mvm"));
+        env.isolate_mvm_home(tmp.path().join("mvm"));
 
         let vm_name = "live-fc-refuse-test";
         let fc_vms_dir = tmp.path().join("mvm").join("vms").join(vm_name);
@@ -2249,7 +2249,7 @@ mod tests {
     fn stopped_fc_vm_is_quiesced() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path().join("mvm"));
+        env.isolate_mvm_home(tmp.path().join("mvm"));
 
         // No fc.pid written — VM is stopped.
         assert!(
@@ -2320,7 +2320,7 @@ mod tests {
     fn signed_chain_anchor_indexes_a_real_created_entry_and_verify_passes() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let store = CheckpointStore::open();
         let meta = seed_audited_checkpoint(&store, "ckpt-anchor-1", "aa");
@@ -2343,7 +2343,7 @@ mod tests {
     fn chain_anchor_catches_a_fully_consistent_local_reforge() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let store = CheckpointStore::open();
         // The audited original: the chain records ITS content-address.
@@ -2425,7 +2425,7 @@ mod tests {
     fn image_lineage_verifies_against_a_real_signed_chain() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let store = ImageStore::open();
         let g0 = image_node("slot-a", "rev-1", None);
@@ -2456,7 +2456,7 @@ mod tests {
     fn image_lineage_refuses_a_node_absent_from_the_signed_chain() {
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let store = ImageStore::open();
         let g0 = image_node("slot-a", "rev-1", None);
@@ -2481,7 +2481,7 @@ mod tests {
 
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let store = ImageStore::open();
         let signer = super::super::host_signer::load_or_init().unwrap();
@@ -2583,7 +2583,7 @@ mod tests {
 
         let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
+        env.isolate_mvm_home(tmp.path());
 
         let store = ImageStore::open();
         let signer = super::super::host_signer::load_or_init().unwrap();

--- a/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
+++ b/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
@@ -398,7 +398,7 @@ mod runtime_source_policy_for_workload_boot_tests {
 
         let cache = tempfile::tempdir().unwrap();
         let mut env = TestEnv::new();
-        env.set("MVM_HOME", cache.path());
+        env.isolate_mvm_home(cache.path());
         env.set(
             crate::commands::runtime_overlay::RUNTIME_OVERLAY_ACQUIRE_MODE_ENV,
             "download",
@@ -449,7 +449,7 @@ mod runtime_source_policy_for_workload_boot_tests {
 
         let cache = tempfile::tempdir().unwrap();
         let mut env = TestEnv::new();
-        env.set("MVM_HOME", cache.path());
+        env.isolate_mvm_home(cache.path());
         env.set(
             crate::commands::runtime_overlay::RUNTIME_OVERLAY_ACQUIRE_MODE_ENV,
             "build",

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -742,7 +742,7 @@ mod runtime_overlay_attach_tests {
         let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let mut env = TestEnv::new();
         let dir = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", dir.path());
+        env.isolate_mvm_home(dir.path());
 
         let current = env!("CARGO_PKG_VERSION");
         let pinned = if current == "0.17.0" {
@@ -784,7 +784,10 @@ mod runtime_overlay_attach_tests {
         let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let mut env = TestEnv::new();
         let dir = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", dir.path());
+        // Asserting an *absence*, so HOME has to move with MVM_HOME: the
+        // overlay resolver seeds a cold cache from `$HOME/.mvm/cache`, which
+        // would supply the very version this test requires to be missing.
+        env.isolate_mvm_home(dir.path());
 
         let current = env!("CARGO_PKG_VERSION");
         let missing = if current == "0.17.0" {
@@ -820,7 +823,7 @@ mod runtime_overlay_attach_tests {
         let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let mut env = TestEnv::new();
         let dir = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", dir.path());
+        env.isolate_mvm_home(dir.path());
         env.set(RUNTIME_OVERLAY_ACQUIRE_MODE_ENV, "download");
 
         let current = env!("CARGO_PKG_VERSION");
@@ -859,7 +862,7 @@ mod runtime_overlay_attach_tests {
         let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let mut env = TestEnv::new();
         let dir = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", dir.path());
+        env.isolate_mvm_home(dir.path());
         env.set(RUNTIME_OVERLAY_ACQUIRE_MODE_ENV, "download");
 
         let current = env!("CARGO_PKG_VERSION");
@@ -945,7 +948,9 @@ mod universal_initramfs_attach_tests {
     fn attach_universal_initramfs_if_cached_cold_cache_is_non_fatal() {
         let mut env = TestEnv::new();
         let dir = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", dir.path());
+        // HOME moves with MVM_HOME or the cache under test is not cold: the
+        // initramfs resolver seeds a miss from `$HOME/.mvm/cache`.
+        env.isolate_mvm_home(dir.path());
 
         let mut sc = VmStartConfig::default();
         // Must never return an error: a cold cache falls back to legacy boot
@@ -957,7 +962,7 @@ mod universal_initramfs_attach_tests {
     fn attach_universal_initramfs_if_cached_attaches_from_cache() {
         let mut env = TestEnv::new();
         let dir = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", dir.path());
+        env.isolate_mvm_home(dir.path());
 
         let version = env!("CARGO_PKG_VERSION");
         let arch = GuestArch::host();

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -2909,7 +2909,7 @@ mod tests {
 
         let cache = tempfile::tempdir().unwrap();
         let mut env = mvm_core::util::test_env::TestEnv::new();
-        env.set("MVM_HOME", cache.path());
+        env.isolate_mvm_home(cache.path());
         env.set("MVM_RUNTIME_OVERLAY_ACQUIRE_MODE", "download");
         let initrd_dir = cache
             .path()

--- a/crates/mvm-core/src/util/test_env.rs
+++ b/crates/mvm-core/src/util/test_env.rs
@@ -40,6 +40,27 @@ impl TestEnv {
         unsafe { std::env::set_var(key, value) };
     }
 
+    /// Point the whole mvm world at `root`: sets `MVM_HOME` **and** `HOME`.
+    ///
+    /// `MVM_HOME` on its own does not isolate a test. A few resolvers
+    /// deliberately ignore it and read `$HOME/.mvm/cache` directly so an
+    /// isolated session can seed expensive artifacts — the builder VM image,
+    /// the runtime overlay — from the host's shared cache instead of
+    /// rebuilding them. That seed is correct for real use and wrong under
+    /// test: a test that moves only `MVM_HOME` still reads the developer's
+    /// real cache through it, so an assertion that an artifact is *absent*
+    /// holds only on a machine that has never built one. CI is such a
+    /// machine and a contributor's laptop is not, which is how a green
+    /// suite ends up hiding a live regression.
+    pub fn isolate_mvm_home<V>(&mut self, root: V)
+    where
+        V: AsRef<OsStr>,
+    {
+        let root = root.as_ref();
+        self.set("MVM_HOME", root);
+        self.set("HOME", root);
+    }
+
     pub fn remove<K>(&mut self, key: K)
     where
         K: AsRef<OsStr>,
@@ -125,6 +146,25 @@ mod tests {
         assert_eq!(std::env::var(&key).as_deref(), Ok("before"));
         // SAFETY: cleanup for the same process-unique variable used by this test.
         unsafe { std::env::remove_var(&key) };
+    }
+
+    #[test]
+    fn isolate_mvm_home_sets_both_roots_and_restores_them() {
+        let before_home = std::env::var_os("HOME");
+        let before_mvm_home = std::env::var_os("MVM_HOME");
+        let root = "/tmp/mvm-test-env-isolate-both";
+
+        {
+            let mut env = TestEnv::new();
+            env.isolate_mvm_home(root);
+            assert_eq!(std::env::var("MVM_HOME").as_deref(), Ok(root));
+            // The whole point: HOME moves too, so the MVM_HOME-ignoring
+            // default-cache resolvers cannot reach the real one.
+            assert_eq!(std::env::var("HOME").as_deref(), Ok(root));
+        }
+
+        assert_eq!(std::env::var_os("MVM_HOME"), before_mvm_home);
+        assert_eq!(std::env::var_os("HOME"), before_home);
     }
 
     #[test]

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -46,6 +46,24 @@
       #1876 and #1878; tracked in
       `specs/plans/266-vsock-overload-hardening.md`.
 
+- [x] Non-hermetic `$HOME` test class closed. `default_mvm_cache_dir` is the
+      only resolver that reads `$HOME` while `MVM_HOME` is set (it seeds the
+      builder image / runtime overlay from the host's shared cache), so a test
+      that moved only `MVM_HOME` still read the developer's real cache — an
+      assertion that an artifact is *absent* then passed only on a machine that
+      had never built one. Added `TestEnv::isolate_mvm_home` (sets both roots),
+      migrated the 25 tests in files that provably reach a seed site, and added
+      the `check-test-home-isolation` xtask gate: `default_mvm_cache_dir` is now
+      allowlist-only, and tests in seed-reaching files must isolate `HOME`.
+      Reachability was measured empirically by running the suite against an
+      empty vs. a populated fixture `$HOME` rather than inferred from the call
+      graph. 8021/8021 nextest on a host with a populated `~/.mvm`.
+      **Deferred:** `mvmctl::audit_emissions_live
+      update_check_does_not_emit_audit_entry` fails intermittently under full
+      workspace concurrency and is *not* in this class — its `AuditSandbox`
+      already isolates both roots, and the test binary passed 47/47 across four
+      consecutive runs. Needs separate triage as a concurrency flake.
+
 - [ ] Tier-1 edge path: the build → sign → export → install-on-another-host →
       admit → boot chain now runs end to end on aarch64, delivered through
       #1888 (ARM64 `Image` kernels reach Firecracker), #1891 (guest reads the

--- a/xtask/src/check_single_home.rs
+++ b/xtask/src/check_single_home.rs
@@ -71,6 +71,11 @@ const EXEMPTIONS: &[(&str, &[Rule], &str)] = &[
         "defines the very patterns it scans for",
     ),
     (
+        "crates/mvm-core/src/util/test_env.rs",
+        &[Rule::HomeRead],
+        "the test env-guard's own unit test reads HOME to assert isolate_mvm_home sets it and Drop restores it; it derives no mvm path",
+    ),
+    (
         "crates/mvm-cli/src/shell_init.rs",
         &[Rule::HomeRead],
         "writes the user's shell rc file (~/.zshrc / ~/.bashrc); $HOME locates the rc file, not an mvm base dir",

--- a/xtask/src/check_test_home_isolation.rs
+++ b/xtask/src/check_test_home_isolation.rs
@@ -1,0 +1,353 @@
+//! `xtask check-test-home-isolation`
+//!
+//! `MVM_HOME` relocates the whole mvm tree, so a test that points it at a
+//! tempdir looks isolated. It isn't. `default_mvm_cache_dir` deliberately
+//! ignores `MVM_HOME` and reads `$HOME/.mvm/cache` directly, so an isolated
+//! session can seed expensive artifacts — the builder VM image, the runtime
+//! overlay — from the host's shared cache instead of rebuilding them. That
+//! seed is correct for real use and ruinous under test: a test asserting an
+//! artifact is *absent* gets a real one copied in behind its back and passes
+//! for the wrong reason. It passes only on a machine that has never built
+//! one. CI is such a machine and a contributor's laptop is not, so the suite
+//! reads green in CI while the same test is red for everyone else — and a
+//! genuine regression in the code under test is masked either way.
+//!
+//! Two rules keep that class closed:
+//!
+//! 1. `default-cache-caller` — `default_mvm_cache_dir` is the only resolver
+//!    that reads `$HOME` while `MVM_HOME` is set, so it is the only door the
+//!    class can grow through. It may be named only from an allowlisted seed
+//!    site. Adding an entry is the signal that a new cross-root seed exists,
+//!    and it drags that file's tests under rule 2.
+//! 2. `test-home-isolation` — in a file that can reach a seed site, a test
+//!    that moves `MVM_HOME` must move `HOME` with it.
+//!    `TestEnv::isolate_mvm_home` does both; an explicit `HOME` set counts.
+//!
+//! Scope, stated plainly: rule 2 reads `#[test]` bodies, so it covers the
+//! in-process `TestEnv` pattern that the known failures came from. A
+//! subprocess fixture that exports `MVM_HOME` from a shared helper outside
+//! any `#[test]` body is not matched.
+
+use anyhow::{Result, bail};
+use std::path::Path;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Rule {
+    DefaultCacheCaller,
+    TestHomeIsolation,
+}
+
+impl Rule {
+    fn label(self) -> &'static str {
+        match self {
+            Rule::DefaultCacheCaller => "default-cache-caller",
+            Rule::TestHomeIsolation => "test-home-isolation",
+        }
+    }
+}
+
+/// The single resolver that reads `$HOME` even when `MVM_HOME` is set.
+const DEFAULT_CACHE_FN: &str = "default_mvm_cache_dir";
+
+/// Files allowed to name [`DEFAULT_CACHE_FN`], with the reason.
+const SEED_SITES: &[(&str, &str)] = &[
+    (
+        "crates/mvm-core/src/config.rs",
+        "defines the resolver and owns the deliberate MVM_HOME bypass",
+    ),
+    (
+        "crates/mvm-build/src/libkrun_builder.rs",
+        "seeds the builder VM image from the host's shared cache",
+    ),
+    (
+        "crates/mvm-build/src/runtime_overlay.rs",
+        "seeds the runtime overlay from the host's shared cache",
+    ),
+    (
+        "crates/mvm-build/src/initramfs.rs",
+        "seeds the universal initramfs from the host's shared cache",
+    ),
+    (
+        "xtask/src/check_test_home_isolation.rs",
+        "defines the very patterns it scans for",
+    ),
+];
+
+/// Symbols whose call reaches [`DEFAULT_CACHE_FN`]. A file naming any of
+/// them can seed from the real `$HOME`, so its tests must isolate `HOME`.
+/// `attach_runtime_overlay` is matched as a prefix so it also covers the
+/// `_if_cached` / `_if_cached_version` wrappers the CLI actually calls.
+const SEED_ANCHORS: &[&str] = &[
+    DEFAULT_CACHE_FN,
+    "ensure_builder_vm_image",
+    "resolve_or_seed_from_default_cache",
+    "attach_runtime_overlay",
+];
+
+/// Files exempt from `test-home-isolation`, with the reason.
+const ISOLATION_EXEMPT: &[(&str, &str)] = &[(
+    "crates/mvm-core/src/config.rs",
+    "the resolver's own unit tests assert string derivation and never touch \
+     the filesystem; some deliberately diverge HOME from MVM_HOME to pin the \
+     ignore-override contract",
+)];
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let mut hits: Vec<String> = Vec::new();
+
+    for root in ["crates", "src", "xtask", "tests"] {
+        walk(&workspace.join(root), &mut |path| {
+            scan_file(workspace, path, &mut hits);
+        })?;
+    }
+
+    if !hits.is_empty() {
+        bail!(
+            "check-test-home-isolation: {} site(s) can read the developer's real $HOME.\n\
+             A test that moves MVM_HOME must move HOME with it — use\n\
+             `TestEnv::isolate_mvm_home(root)`, which sets both.\n\
+             A genuinely new cross-root seed gets a SEED_SITES entry in\n\
+             xtask/src/check_test_home_isolation.rs, with a reason.\n{}",
+            hits.len(),
+            hits.join("\n")
+        );
+    }
+    eprintln!(
+        "check-test-home-isolation: clean (every MVM_HOME test that can reach the default cache also isolates HOME)"
+    );
+    Ok(())
+}
+
+fn scan_file(workspace: &Path, path: &Path, hits: &mut Vec<String>) {
+    if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+        return;
+    }
+    let rel = path
+        .strip_prefix(workspace)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/");
+    let Ok(src) = std::fs::read_to_string(path) else {
+        return;
+    };
+    hits.extend(scan_source(&rel, &src));
+}
+
+/// Scan one file's source; returns formatted hit lines. Pure so the unit
+/// tests can drive it with fixture text.
+fn scan_source(rel: &str, src: &str) -> Vec<String> {
+    let mut hits = Vec::new();
+    let push = |hits: &mut Vec<String>, line: usize, rule: Rule, detail: String| {
+        hits.push(format!("  {rel}:{line}: [{}] {detail}", rule.label()));
+    };
+
+    if !SEED_SITES.iter().any(|(path, _)| *path == rel) {
+        for (idx, text) in src.lines().enumerate() {
+            // A prose mention in a comment is not a call.
+            if text.trim_start().starts_with("//") {
+                continue;
+            }
+            if text.contains(DEFAULT_CACHE_FN) {
+                push(
+                    &mut hits,
+                    idx + 1,
+                    Rule::DefaultCacheCaller,
+                    format!(
+                        "{DEFAULT_CACHE_FN} ignores MVM_HOME; declare this seed site: {}",
+                        text.trim()
+                    ),
+                );
+            }
+        }
+    }
+
+    if ISOLATION_EXEMPT.iter().any(|(path, _)| *path == rel) {
+        return hits;
+    }
+    if !SEED_ANCHORS.iter().any(|anchor| src.contains(anchor)) {
+        return hits;
+    }
+
+    for block in test_blocks(src) {
+        if sets_mvm_home(block.body) && !isolates_home(block.body) {
+            push(
+                &mut hits,
+                block.line,
+                Rule::TestHomeIsolation,
+                format!(
+                    "test `{}` moves MVM_HOME but not HOME, and this file can reach the default cache",
+                    block.name
+                ),
+            );
+        }
+    }
+    hits
+}
+
+struct TestBlock<'a> {
+    line: usize,
+    name: &'a str,
+    body: &'a str,
+}
+
+/// Split `src` into one block per `#[test]`, each running to the next
+/// `#[test]` or end of file. Coarse, but a test's env setup always sits
+/// between its own attribute and the next one.
+fn test_blocks(src: &str) -> Vec<TestBlock<'_>> {
+    let starts: Vec<usize> = src.match_indices("#[test]").map(|(at, _)| at).collect();
+    starts
+        .iter()
+        .enumerate()
+        .map(|(n, &start)| {
+            let end = starts.get(n + 1).copied().unwrap_or(src.len());
+            TestBlock {
+                line: src[..start].lines().count() + 1,
+                name: test_fn_name(&src[start..end]).unwrap_or("<unnamed>"),
+                body: &src[start..end],
+            }
+        })
+        .collect()
+}
+
+fn test_fn_name(body: &str) -> Option<&str> {
+    let at = body.find("fn ")?;
+    let rest = &body[at + "fn ".len()..];
+    let end = rest.find(|c: char| !c.is_alphanumeric() && c != '_')?;
+    Some(&rest[..end])
+}
+
+fn sets_mvm_home(body: &str) -> bool {
+    [
+        "set(\"MVM_HOME\"",
+        "set_var(\"MVM_HOME\"",
+        "env(\"MVM_HOME\"",
+    ]
+    .iter()
+    .any(|pattern| body.contains(pattern))
+}
+
+fn isolates_home(body: &str) -> bool {
+    body.contains("isolate_mvm_home")
+        || ["set(\"HOME\"", "set_var(\"HOME\"", "env(\"HOME\""]
+            .iter()
+            .any(|pattern| body.contains(pattern))
+}
+
+fn walk(dir: &Path, f: &mut dyn FnMut(&Path)) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let path = entry?.path();
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if path.is_dir() {
+            if matches!(name, "target" | ".git" | "node_modules") {
+                continue;
+            }
+            walk(&path, f)?;
+        } else {
+            f(&path);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ANCHORED: &str = "fn helper() { ensure_builder_vm_image() }\n";
+
+    #[test]
+    fn flags_mvm_home_without_home_in_a_file_that_reaches_the_seed() {
+        let src = format!(
+            "{ANCHORED}\
+             #[test]\nfn refuses_missing_image() {{\n    env.set(\"MVM_HOME\", d);\n}}\n"
+        );
+        let hits = scan_source("crates/mvm-build/src/other.rs", &src);
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert!(hits[0].contains("test-home-isolation"), "{hits:?}");
+        assert!(hits[0].contains("refuses_missing_image"), "{hits:?}");
+    }
+
+    #[test]
+    fn accepts_isolate_mvm_home_helper() {
+        let src = format!(
+            "{ANCHORED}\
+             #[test]\nfn refuses_missing_image() {{\n    env.isolate_mvm_home(d);\n}}\n"
+        );
+        assert!(scan_source("crates/mvm-build/src/other.rs", &src).is_empty());
+    }
+
+    #[test]
+    fn accepts_explicit_home_set_alongside_mvm_home() {
+        let src = format!(
+            "{ANCHORED}\
+             #[test]\nfn refuses_missing_image() {{\n    env.set(\"MVM_HOME\", d);\n    env.set(\"HOME\", d);\n}}\n"
+        );
+        assert!(scan_source("crates/mvm-build/src/other.rs", &src).is_empty());
+    }
+
+    #[test]
+    fn accepts_subprocess_env_pair() {
+        let src = format!(
+            "{ANCHORED}\
+             #[test]\nfn spawns() {{\n    c.env(\"HOME\", h).env(\"MVM_HOME\", r);\n}}\n"
+        );
+        assert!(scan_source("crates/mvm-build/src/other.rs", &src).is_empty());
+    }
+
+    #[test]
+    fn ignores_files_that_cannot_reach_the_seed() {
+        let src = "#[test]\nfn unrelated() {\n    env.set(\"MVM_HOME\", d);\n}\n";
+        assert!(scan_source("crates/mvm-core/src/domain/session.rs", src).is_empty());
+    }
+
+    #[test]
+    fn flags_an_undeclared_default_cache_caller() {
+        let src = "fn sneak() { let p = default_mvm_cache_dir(); }\n";
+        let hits = scan_source("crates/mvm-runtime/src/somewhere.rs", src);
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert!(hits[0].contains("default-cache-caller"), "{hits:?}");
+    }
+
+    #[test]
+    fn ignores_a_resolver_mention_in_a_comment() {
+        let src =
+            "// default_mvm_cache_dir() resolves to ~/.mvm/cache, so point HOME at a tmpdir\n";
+        assert!(scan_source("crates/mvm-runtime/src/somewhere.rs", src).is_empty());
+    }
+
+    #[test]
+    fn allows_declared_seed_sites_to_name_the_resolver() {
+        let src = "fn seed() { let p = default_mvm_cache_dir(); }\n";
+        assert!(scan_source("crates/mvm-build/src/runtime_overlay.rs", src).is_empty());
+    }
+
+    #[test]
+    fn exempt_file_skips_the_isolation_rule() {
+        let src = format!(
+            "{ANCHORED}\
+             #[test]\nfn ignores_override() {{\n    env.set(\"MVM_HOME\", d);\n}}\n"
+        );
+        assert!(scan_source("crates/mvm-core/src/config.rs", &src).is_empty());
+    }
+
+    #[test]
+    fn test_fn_name_reads_the_first_fn_after_the_attribute() {
+        assert_eq!(
+            test_fn_name("#[test]\n    fn some_case_name() {\n"),
+            Some("some_case_name")
+        );
+    }
+
+    #[test]
+    fn test_blocks_splits_on_each_attribute() {
+        let src = "#[test]\nfn a() {}\n#[test]\nfn b() {}\n";
+        let blocks = test_blocks(src);
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].name, "a");
+        assert_eq!(blocks[1].name, "b");
+        assert!(blocks[1].line > blocks[0].line);
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -41,6 +41,7 @@ mod check_no_string_backend_dispatch;
 mod check_require_grant_token_allowlist;
 mod check_runtime_overlay_version;
 mod check_single_home;
+mod check_test_home_isolation;
 mod check_trust_gradient;
 mod check_two_surfaces;
 mod check_uniform_vsock_egress;
@@ -161,6 +162,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_single_home::run(&workspace)
         }
+        Some("check-test-home-isolation") => {
+            let workspace = workspace_root();
+            check_test_home_isolation::run(&workspace)
+        }
         Some("check-no-network-literals") => {
             let workspace = workspace_root();
             check_no_network_literals::run(&workspace)
@@ -234,7 +239,7 @@ fn main() -> Result<()> {
             ir_parity::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-conformance, check-trust-gradient, check-vsock-only-egress, check-uniform-vsock-egress, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-conformance, check-trust-gradient, check-vsock-only-egress, check-uniform-vsock-egress, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {
@@ -311,6 +316,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-single-home                      Reject host-path derivations that bypass mvm-core::config's single MVM_HOME root"
+            );
+            eprintln!(
+                "  check-test-home-isolation              Reject tests that move MVM_HOME but not HOME in files that can reach the MVM_HOME-ignoring default cache"
             );
             eprintln!(
                 "  check-cli-runtime-surface              Reject mvm_runtime::vm::name_registry + AnyBackend reaches in mvm-cli drive-a-machine code — route through the mvm-client facade"


### PR DESCRIPTION
Closes the class of tests that read the developer's real `$HOME`, and adds a gate so it can't come back.

#1920 has merged, so this is now rebased onto `main` and targets it directly. Its five `libkrun_builder` fixes are in `main`; this PR is the structural half.

## The class

`mvm_core::config::default_mvm_cache_dir()` is the **only** production function that reads `$HOME` while `MVM_HOME` is set. `home_dir()` has two callers: `mvm_home()`, which consults `MVM_HOME` first and so is unreachable from an isolated test, and `default_mvm_cache_dir()`, which ignores `MVM_HOME` on purpose. That's deliberate and correct — it lets a worktree-isolated session seed the builder VM image and the runtime overlay from the host's shared cache instead of re-bootstrapping. It has exactly two consumers, both opportunistic seeds:

- `libkrun_builder::seed_builder_vm_image_from_default_cache` ← `ensure_builder_vm_image()`
- `runtime_overlay::seed_from_default_cache` ← `resolve_or_seed_from_default_cache()`
- `initramfs::seed_from_default_cache` ← the universal-initramfs resolver (arrived with #1914; see below)

A test that moves only `MVM_HOME` still reads the real cache through those. So an assertion that an artifact is *absent* gets a real one copied in behind its back and passes for the wrong reason — on any machine that has ever run a build. CI has never run one, which is why the suite was green in CI and red on every contributor laptop, and why a genuine `ensure_builder_vm_image` regression would have been masked indefinitely.

The five lint-exempt non-mvm `$HOME` readers (shell rc, toolchain discovery, two tilde-expansions, an FFI example) read `$HOME` regardless of `MVM_HOME`, but none derives an mvm base dir, so none can fabricate an image or overlay. Different, much weaker hazard; deliberately not touched.

## Reachability was measured, not inferred

78 files set `MVM_HOME`. Blanket-patching them would be noise, and tracing the call graph by hand rots. So instead: run the whole suite with `$HOME` pointed at an **empty** fixture home, then at one **populated** with a valid builder image and overlays, and diff. Tests whose outcome changes are exactly the non-hermetic ones.

| `$HOME` | result |
|---|---|
| empty fixture | 8010/8010 pass — reproduces CI's false green exactly |
| populated fixture | 4 failed |
| real `~/.mvm` | 4 failed |

That found one live failure beyond the known trio: `attach_runtime_overlay_if_cached_version_refuses_drift_to_other_cached_version`. It seeds only the current version, asks for a different one, and asserts refusal — green on my host only because the real cache happened not to hold `0.17.0`. Plant that version and it fails. Same bug, one `$HOME` away.

## Changes

- **`TestEnv::isolate_mvm_home(root)`** sets `MVM_HOME` and `HOME` together, with the reason in its doc comment. Introducing a named helper rather than making `set("MVM_HOME", …)` implicitly move `HOME`: a general-purpose env guard should set what it's asked to, and one test deliberately diverges the two to pin the ignore-override contract.
- **27 tests migrated** across `checkpoint.rs` (21), `oci_persist.rs` (2), `exec.rs` (1) and `libkrun_builder.rs` (1), plus 6 in `runtime_source.rs` — every test in a file that provably reaches a seed site.
- **New `check-test-home-isolation` xtask gate**, wired into CI's Lint job beside `check-single-home`:
  1. `default-cache-caller` — `default_mvm_cache_dir` may only be named from an allowlisted seed site. It is the only door this class can grow through, so locking it bounds the class; adding an entry is the signal a new cross-root seed exists, and drags that file's tests under rule 2.
  2. `test-home-isolation` — in a file that can reach a seed site, a test moving `MVM_HOME` must move `HOME` too.

  The gate independently rediscovered #1920's exact five tests.

Test-only plus tooling; no production behaviour changes. The seed stays exactly as it was — it's now simply out of reach of a test asserting its absence.

## Verification

Green suites prove nothing here, so:

- **Red-then-green, same binary, one line apart.** Reverting just that one call site to a bare `MVM_HOME` set, under the populated fixture `$HOME`: `FAIL`. Restored: `PASS`.
- **8063/8063, 0 failed** with a real populated `~/.mvm`. Baseline on the same host was 8006 passed / 4 failed of 8010. The new tests are the gate's 11 unit tests plus one for `isolate_mvm_home` (asserts both roots are set *and* both restored on drop).
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --doc`, `check-single-home`, `check-test-home-isolation`, `check-no-spec-refs-in-comments` all clean. No assertion was weakened — the refusals are real.

`check-single-home` gained one narrow exemption: the env-guard's own unit test reads `HOME` to assert isolation and restoration, deriving no mvm path.

## Deferred, and not this class

`mvmctl::audit_emissions_live update_check_does_not_emit_audit_entry` failed in the pre-change full run under a real `$HOME`, which is why the local baseline was 4 failed rather than the 3 expected. It is **not** in this class: its `AuditSandbox` already exports both `HOME` and `MVM_HOME` to the subprocess, it passes in isolation, and its binary passed 47/47 across four consecutive runs. It's a full-workspace concurrency flake needing separate triage. Noted in `specs/SPRINT.md`.

One honest limit of the gate, stated in its module doc: rule 2 reads `#[test]` bodies, so it covers the in-process `TestEnv` pattern the real failures came from. A subprocess fixture exporting `MVM_HOME` from a shared helper outside any `#[test]` body is not matched.

## The guard, seen to fail

A guard never observed failing is decoration, so — negative control on the real tree, restoring between each:

| state | guard |
|---|---|
| tree as committed | GREEN |
| `HOME` isolation stripped from `ensure_builder_vm_image_requires_cmdline_txt` | **RED**, naming that test |
| restored | GREEN |
| undeclared `default_mvm_cache_dir()` caller added to `name_registry.rs` | **RED**, 3 hits |
| restored | GREEN |

The second case shows it is more than a grep: one added call produced three failures — the undeclared caller, *plus* that file's two pre-existing `MVM_HOME` tests, which became at-risk the moment the file could reach the default cache. That cascade is the class-killer. A new seed site cannot land without both declaring itself and hardening its own tests.

There are also 11 unit tests on the scanner, including a permanent negative control per rule.

## It earned its place on the rebase

Rebasing onto a `main` that had gained #1914 (universal initramfs) made the gate fail immediately, on work landed hours earlier:

- **A third cross-root seed**, `initramfs.rs`, calling `default_mvm_cache_dir()` — now declared in `SEED_SITES`.
- **Two new tests moving `MVM_HOME` alone**, including `attach_universal_initramfs_if_cached_cold_cache_is_non_fatal`, which asserts a *cold* cache while leaving `$HOME` real. `~/.mvm/cache/initramfs` happens to be absent on my host, so it is green by luck — exactly the 0.17.0 shape, and it would silently start exercising the warm path on any host that has built an initramfs. Both are fixed here.

That is the class recurring within a day, caught by the gate rather than by someone's laptop months later.

One refinement from that run: undeclared-caller hits now skip comment lines, so a prose mention of the resolver isn't reported as a call.

## On the alternative (implicit `TestEnv`)

Making `set("MVM_HOME", …)` implicitly move `HOME` was considered. No test needs the real `$HOME` — the real-`$HOME` consumers (`ziglang_mise_path`, `zig_pin`, `rustup_path`, `shell_init`) appear in zero files that also set `MVM_HOME` — so nothing would have broken and no opt-out was needed. It was rejected because it cannot fail a build: it only helps callers that go through `TestEnv`, so subprocess tests doing `.env("MVM_HOME", …)` on a `Command` bypass it, and nothing stops a fresh `std::env::set_var`. `isolate_mvm_home` is that idea in explicit form; the lint is what makes the wrong thing fail CI.
