### PR TITLE
feat(apple-container): stage-1 backend skeleton (plan 271)

### DIFF
--- a/crates/mvm-cli/src/doctor/warm_start.rs
+++ b/crates/mvm-cli/src/doctor/warm_start.rs
@@ -245,6 +245,7 @@ mod tests {
         assert_eq!(r.backends.get("qemu"), Some(&"unsupported"));
         assert_eq!(r.backends.get("hvf"), Some(&"unsupported"));
         assert_eq!(r.backends.get("wasm"), Some(&"unsupported"));
+        assert_eq!(r.backends.get("apple-container"), Some(&"unsupported"));
     }
 
     #[test]
@@ -254,6 +255,7 @@ mod tests {
         let ordered_standby_pool: Vec<_> = r.standby_pool.into_iter().collect();
 
         let mut expected_backends = vec![
+            ("apple-container".to_string(), "unsupported"),
             ("firecracker".to_string(), "unsupported"),
             ("hvf".to_string(), "unsupported"),
             ("libkrun".to_string(), "unsupported"),
@@ -261,6 +263,7 @@ mod tests {
             ("wasm".to_string(), "unsupported"),
         ];
         let mut expected_standby_pool = vec![
+            ("apple-container".to_string(), false),
             ("firecracker".to_string(), false),
             ("hvf".to_string(), false),
             ("libkrun".to_string(), false),
@@ -268,8 +271,8 @@ mod tests {
             ("wasm".to_string(), false),
         ];
         if cfg!(feature = "test-support") {
-            expected_backends.insert(3, ("mock".to_string(), "live-memory"));
-            expected_standby_pool.insert(3, ("mock".to_string(), false));
+            expected_backends.insert(4, ("mock".to_string(), "live-memory"));
+            expected_standby_pool.insert(4, ("mock".to_string(), false));
         }
         assert_eq!(ordered_backends, expected_backends);
         assert_eq!(ordered_standby_pool, expected_standby_pool);
@@ -291,7 +294,14 @@ mod tests {
         // Every selectable backend remains in the matrix, including explicit
         // unsupported recovery tiers.
         let names: Vec<_> = rows.iter().map(|r| r.backend.as_str()).collect();
-        let mut expected = vec!["firecracker", "hvf", "libkrun", "qemu", "wasm"];
+        let mut expected = vec![
+            "apple-container",
+            "firecracker",
+            "hvf",
+            "libkrun",
+            "qemu",
+            "wasm",
+        ];
         if cfg!(feature = "test-support") {
             expected.push("mock");
             expected.sort_unstable();

--- a/crates/mvm-protocol/src/protocol/vm_backend.rs
+++ b/crates/mvm-protocol/src/protocol/vm_backend.rs
@@ -1025,6 +1025,11 @@ pub enum BackendKind {
     /// portability/demo backend: opt-in only, never returned by auto-detect,
     /// no hardware isolation boundary.
     Wasm,
+    /// Apple Containerization-framework tier: workloads run inside Apple's
+    /// lightweight container VMs with `vminitd` as guest PID 1. The backend
+    /// drives the same activation contract through vminitd's gRPC API rather
+    /// than an mvm initramfs. Opt-in only; never returned by auto-detect.
+    AppleContainer,
 }
 
 #[cfg(test)]

--- a/crates/mvm-runtime/src/apple_container_backend.rs
+++ b/crates/mvm-runtime/src/apple_container_backend.rs
@@ -1,0 +1,370 @@
+//! Apple Containerization-framework backend — registered, honest skeleton.
+//!
+//! `AppleContainerBackend` is the selectable front door for running mvm
+//! workloads inside Apple's Containerization-framework VMs: lightweight,
+//! hardware-isolated Linux VMs whose kernel boot and guest PID 1 (`vminitd`,
+//! serving gRPC on vsock port 1024) are owned by Apple's Swift-only
+//! framework. Because the framework owns the boot path, the mvm initramfs
+//! does not apply verbatim here — activation will ride `vminitd`'s existing
+//! gRPC API instead, while the guest agent binary, the mount logic, the
+//! uid-901 privilege drop, the `NotActivated` RPC gate, and the operational
+//! RPC surface stay shared verbatim with every other backend.
+//!
+//! This is the skeleton stage of that backend: it is registered in the
+//! catalog and selectable via `--hypervisor apple-container`, but no
+//! Containerization-framework integration exists yet, so **every operation
+//! that would touch a real VM fails closed** with a typed
+//! [`AppleContainerError`] naming the milestone that provides it — mirroring
+//! how [`crate::wasm_backend::WasmBackend`] surfaces "not available" at
+//! first use rather than at construction. Construction itself does no I/O
+//! and touches no framework state, so the catalog/dispatch machinery every
+//! other backend goes through stays uniform.
+//!
+//! Honest reporting, not silent degradation: `capabilities()` advertises no
+//! snapshot, no standby pool, and no warm start; `security_profile()`
+//! reports every numbered claim as `DoesNotHold` until the boot path lands
+//! and can actually enforce them; and the backend is opt-in only —
+//! `AnyBackend::auto_select` never returns this kind. The trivially-true
+//! answers (`stop`, `stop_all`, `list`, `status`) are honest because
+//! `start` cannot succeed yet: nothing can be running.
+
+use anyhow::Result;
+use mvm_core::vm_backend::{
+    BackendKind, BackendSecurityProfile, ClaimStatus, LayerCoverage, SnapshotCapability, StartMode,
+    VmBackend, VmCapabilities, VmExitStatus, VmId, VmInfo, VmStartConfig, VmStatus,
+};
+use thiserror::Error;
+
+/// Typed, fail-closed errors for requests this backend cannot satisfy yet.
+/// Every error names the operation that was refused and the milestone that
+/// provides it, rather than silently falling back to another backend or
+/// panicking — see the module docs.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum AppleContainerError {
+    /// The operation is part of the backend's design but has no
+    /// implementation yet; `milestone` names the work that provides it.
+    #[error("apple-container backend cannot {operation} yet — {milestone}")]
+    NotImplemented {
+        operation: &'static str,
+        milestone: &'static str,
+    },
+}
+
+/// Apple Containerization-framework backend skeleton. See the module docs
+/// for the fail-closed contract and the opt-in/honest-reporting rules.
+#[derive(Debug, Default, Clone)]
+pub struct AppleContainerBackend;
+
+impl AppleContainerBackend {
+    /// Construct the backend skeleton. Side-effect free — no
+    /// Containerization-framework symbol is touched and no VM state is read.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl VmBackend for AppleContainerBackend {
+    fn name(&self) -> &str {
+        "apple-container"
+    }
+
+    fn kind(&self) -> BackendKind {
+        BackendKind::AppleContainer
+    }
+
+    fn capabilities(&self) -> VmCapabilities {
+        VmCapabilities {
+            // Framework VMs will route egress through the same host-mediated
+            // vsock endpoint seam every other backend uses — no routable
+            // guest NIC. Until the boot path lands this is vacuously true:
+            // the skeleton boots nothing, so nothing can reach a network.
+            no_routable_guest_nic: true,
+            snapshot_capability: SnapshotCapability::Unsupported,
+            standby_pool: false,
+            ..VmCapabilities::default()
+        }
+    }
+
+    fn start_with_mode(&self, _config: &VmStartConfig, _mode: StartMode) -> Result<VmId> {
+        Err(AppleContainerError::NotImplemented {
+            operation: "start a container VM",
+            milestone: "the Containerization Swift shim (stage 2)",
+        }
+        .into())
+    }
+
+    fn wait(&self, _id: &VmId) -> Result<VmExitStatus> {
+        Err(AppleContainerError::NotImplemented {
+            operation: "wait on a container VM",
+            milestone: "the vminitd gRPC transport (stage 3)",
+        }
+        .into())
+    }
+
+    fn pause(&self, _id: &VmId) -> Result<()> {
+        Err(AppleContainerError::NotImplemented {
+            operation: "pause a container VM",
+            milestone: "the Containerization Swift shim (stage 2)",
+        }
+        .into())
+    }
+
+    fn resume(&self, _id: &VmId) -> Result<()> {
+        Err(AppleContainerError::NotImplemented {
+            operation: "resume a container VM",
+            milestone: "the Containerization Swift shim (stage 2)",
+        }
+        .into())
+    }
+
+    fn stop(&self, _id: &VmId) -> Result<()> {
+        // Honest trivial answer: `start` cannot succeed yet, so no container
+        // VM this backend owns can be running.
+        Ok(())
+    }
+
+    fn stop_all(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn status(&self, _id: &VmId) -> Result<VmStatus> {
+        // No boot path exists, so every VM is trivially stopped.
+        Ok(VmStatus::Stopped)
+    }
+
+    fn list(&self) -> Result<Vec<VmInfo>> {
+        Ok(Vec::new())
+    }
+
+    fn logs(&self, _id: &VmId, _lines: u32, _hypervisor: bool) -> Result<String> {
+        Err(AppleContainerError::NotImplemented {
+            operation: "read container VM logs",
+            milestone: "the vminitd gRPC transport (stage 3)",
+        }
+        .into())
+    }
+
+    fn is_available(&self) -> Result<bool> {
+        // No boot path exists on any host yet; reporting `true` would let a
+        // probe conclude a workload could start here.
+        Ok(false)
+    }
+
+    fn install(&self) -> Result<()> {
+        Err(AppleContainerError::NotImplemented {
+            operation: "install the Apple Containerization runtime",
+            milestone: "the Containerization Swift shim (stage 2)",
+        }
+        .into())
+    }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        // Every numbered claim reports `DoesNotHold` until the boot path
+        // lands and can actually enforce them — the skeleton booted nothing,
+        // so nothing here may be claimed. Apple's framework VMs are
+        // hardware-isolated lightweight Linux VMs, which is the Tier 2
+        // shape this backend is being built toward; the tier string says so
+        // honestly rather than rounding the posture up.
+        BackendSecurityProfile {
+            claims: [ClaimStatus::DoesNotHold; 7],
+            layer_coverage: LayerCoverage::default(),
+            tier: "Tier 2 (Apple Containerization framework; skeleton — no boot path yet)",
+            notes: &[
+                "Apple Containerization-framework VMs are hardware-isolated lightweight \
+                 Linux VMs; the framework owns the kernel boot and `vminitd` as guest PID 1.",
+                "Activation will ride vminitd's gRPC API (vsock port 1024) instead of an \
+                 mvm initramfs; the guest agent, mount logic, uid-901 drop, and RPC gate \
+                 stay shared with every other backend.",
+                "Skeleton: every claim reports DoesNotHold until the boot path lands — \
+                 nothing here may carry an untrusted workload yet.",
+                "Opt-in only; never selected by auto-detect.",
+            ],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::AnyBackend;
+
+    fn cfg(name: &str) -> VmStartConfig {
+        VmStartConfig {
+            name: name.to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// Extract the typed error from the `anyhow` wrapper the trait returns,
+    /// so tests assert the exact variant, not a substring.
+    fn not_implemented(err: &anyhow::Error) -> &AppleContainerError {
+        err.downcast_ref::<AppleContainerError>()
+            .expect("apple-container failures must be the typed error")
+    }
+
+    #[test]
+    fn kind_and_name_are_apple_container() {
+        let b = AppleContainerBackend::new();
+        assert_eq!(b.name(), "apple-container");
+        assert_eq!(b.kind(), BackendKind::AppleContainer);
+    }
+
+    #[test]
+    fn selector_and_alias_resolve_through_any_backend() {
+        for sel in ["apple-container", "container"] {
+            let backend = AnyBackend::from_hypervisor(sel);
+            assert!(
+                matches!(backend, AnyBackend::AppleContainer(_)),
+                "selector {sel} must resolve to the apple-container backend"
+            );
+            assert_eq!(backend.name(), "apple-container");
+            assert_eq!(backend.kind(), BackendKind::AppleContainer);
+        }
+    }
+
+    #[test]
+    fn auto_select_never_returns_apple_container() {
+        // Opt-in only, same discipline as the wasm tier: `auto_select`'s
+        // ladder constructs Firecracker/Hvf/Libkrun and nothing else, so this
+        // holds on every platform the ladder can resolve to.
+        assert_ne!(
+            AnyBackend::auto_select().kind(),
+            BackendKind::AppleContainer,
+            "auto_select must never fall through to the apple-container skeleton"
+        );
+    }
+
+    #[test]
+    fn capabilities_are_honest_about_lacking_a_boot_path() {
+        let caps = AppleContainerBackend::new().capabilities();
+        assert!(!caps.pause_resume);
+        assert!(!caps.snapshots);
+        assert_eq!(caps.snapshot_capability, SnapshotCapability::Unsupported);
+        assert!(!caps.standby_pool);
+        assert!(!caps.vsock);
+        assert!(!caps.tap_networking);
+        assert!(!caps.balloon);
+        assert!(!caps.fs_quick_checkpoint);
+        assert!(!caps.host_vsock_proxy);
+        assert!(!caps.pty_exec);
+        assert!(!caps.production_ssh);
+        assert!(caps.no_routable_guest_nic);
+    }
+
+    #[test]
+    fn security_profile_carries_zero_numbered_claims() {
+        let profile = AppleContainerBackend::new().security_profile();
+        assert!(
+            profile
+                .claims
+                .iter()
+                .all(|c| matches!(c, ClaimStatus::DoesNotHold)),
+            "the skeleton must not claim any numbered security guarantee"
+        );
+        assert_eq!(profile.dropped_claims(), vec![1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(profile.layer_coverage, LayerCoverage::default());
+        assert!(
+            profile.tier.starts_with("Tier 2"),
+            "the tier string must agree with the catalog's Tier 2 classification: {}",
+            profile.tier
+        );
+    }
+
+    #[test]
+    fn snapshot_capability_defaults_to_unsupported() {
+        assert_eq!(
+            AppleContainerBackend::new().snapshot_capability(),
+            SnapshotCapability::Unsupported
+        );
+    }
+
+    #[test]
+    fn warm_start_fails_closed() {
+        use mvm_core::vm_backend::{SnapshotCapability, WarmStartError};
+        let b = AppleContainerBackend::new();
+        match b.warm_start(&VmStartConfig::default(), SnapshotCapability::DiskOnly) {
+            Err(WarmStartError::Unsupported { .. }) => {}
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn standby_pool_fails_closed() {
+        assert!(!AppleContainerBackend::new().supports_standby_pool());
+    }
+
+    #[test]
+    fn start_fails_closed_with_typed_error_naming_the_milestone() {
+        let b = AppleContainerBackend::new();
+        let err = b.start(&cfg("x")).unwrap_err();
+        assert_eq!(
+            not_implemented(&err),
+            &AppleContainerError::NotImplemented {
+                operation: "start a container VM",
+                milestone: "the Containerization Swift shim (stage 2)",
+            }
+        );
+        assert!(
+            err.to_string().contains("cannot start a container VM yet"),
+            "the display names the refused operation and the milestone: {err}"
+        );
+    }
+
+    #[test]
+    fn pause_resume_wait_logs_fail_closed_with_typed_errors() {
+        let b = AppleContainerBackend::new();
+        let id = VmId("x".to_string());
+        for err in [
+            b.pause(&id).unwrap_err(),
+            b.resume(&id).unwrap_err(),
+            b.wait(&id).unwrap_err(),
+            b.logs(&id, 10, false).unwrap_err(),
+        ] {
+            assert!(
+                matches!(
+                    not_implemented(&err),
+                    AppleContainerError::NotImplemented { .. }
+                ),
+                "expected a typed NotImplemented, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn trivially_true_operations_are_honest() {
+        // `start` cannot succeed, so nothing can be running: stop, status,
+        // and list answer trivially instead of inventing state.
+        let b = AppleContainerBackend::new();
+        let id = VmId("x".to_string());
+        assert!(b.stop(&id).is_ok());
+        assert!(b.stop_all().is_ok());
+        assert_eq!(b.status(&id).unwrap(), VmStatus::Stopped);
+        assert!(b.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn availability_is_honest_and_install_fails_closed() {
+        let b = AppleContainerBackend::new();
+        assert!(!b.is_available().unwrap(), "no boot path exists yet");
+        assert!(matches!(
+            not_implemented(&b.install().unwrap_err()),
+            AppleContainerError::NotImplemented { .. }
+        ));
+    }
+
+    #[test]
+    fn network_info_and_guest_channel_info_fail_closed_by_default() {
+        let b = AppleContainerBackend::new();
+        let id = VmId("x".to_string());
+        assert!(b.network_info(&id).is_err());
+        assert!(b.guest_channel_info(&id).is_err());
+    }
+
+    #[test]
+    fn balloon_ops_fail_closed_by_default() {
+        let b = AppleContainerBackend::new();
+        let id = VmId("x".to_string());
+        assert!(b.balloon_set_target(&id, 64).is_err());
+        assert!(b.balloon_state(&id).is_err());
+    }
+}

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -8,6 +8,7 @@ use mvm_core::vm_backend::{
 // Every backend variant + the FC support modules live in this crate.
 // `microvm`, `image` are siblings under `crate::`; the substrate
 // (`config`, `shell`, `runtime_meta`) lives in `crate::base`.
+use crate::apple_container_backend::AppleContainerBackend;
 use crate::base::config::{PortMapping, VmSlot};
 use crate::base::shell::run_in_vm_stdout;
 use crate::driver::{FcDriver, HvfDriver, LibkrunDriver};
@@ -410,6 +411,14 @@ pub enum AnyBackend {
     /// closed with a typed error the first time the backend is actually
     /// used, not at construction.
     Wasm(WasmBackend),
+    /// Apple Containerization-framework backend skeleton — see
+    /// [`crate::apple_container_backend`]. Selectable only via explicit
+    /// `--hypervisor apple-container` (alias `container`); `auto_select`
+    /// never falls through here. Always constructible and side-effect free;
+    /// every operation that would touch a real VM fails closed with a typed
+    /// error naming the milestone that provides it, since no
+    /// Containerization-framework integration exists yet.
+    AppleContainer(AppleContainerBackend),
 }
 
 impl AnyBackend {
@@ -560,6 +569,7 @@ impl AnyBackend {
             Self::Mock(backend) => backend,
             Self::Hvf(backend) => backend,
             Self::Wasm(backend) => backend,
+            Self::AppleContainer(backend) => backend,
         }
     }
 
@@ -576,6 +586,9 @@ impl AnyBackend {
             Self::Mock(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
             Self::Hvf(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
             Self::Wasm(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
+            Self::AppleContainer(backend) => {
+                std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>
+            }
         }
     }
 
@@ -634,6 +647,11 @@ impl AnyBackend {
             // egress seam). Barred from the admitted launch funnel until
             // then, the same carve-out as `Qemu`.
             AnyBackend::Wasm(_) => None,
+            // The apple-container skeleton has no boot path at all — it
+            // cannot carry an untrusted workload until the framework shim
+            // and the activation channel land, so it is barred from the
+            // admitted launch funnel the same way `Qemu`/`Wasm` are.
+            AnyBackend::AppleContainer(_) => None,
         }
     }
 
@@ -687,7 +705,7 @@ impl AnyBackend {
             #[cfg(feature = "test-support")]
             AnyBackend::Mock(backend) => backend.spawn_standby(spec),
             // Not workload-bearing backends — no warm pool, fail closed.
-            AnyBackend::Qemu(_) | AnyBackend::Wasm(_) => {
+            AnyBackend::Qemu(_) | AnyBackend::Wasm(_) | AnyBackend::AppleContainer(_) => {
                 Err(mvm_core::vm_backend::StandbyError::Unsupported {
                     backend: self.inner().name().to_string(),
                 })
@@ -729,7 +747,7 @@ impl AnyBackend {
             #[cfg(feature = "test-support")]
             AnyBackend::Mock(backend) => backend.claim_standby(handle, claim),
             // Not workload-bearing backends — no warm pool, fail closed.
-            AnyBackend::Qemu(_) | AnyBackend::Wasm(_) => {
+            AnyBackend::Qemu(_) | AnyBackend::Wasm(_) | AnyBackend::AppleContainer(_) => {
                 Err(mvm_core::vm_backend::StandbyError::Unsupported {
                     backend: self.inner().name().to_string(),
                 })
@@ -1029,7 +1047,14 @@ mod tests {
 
     #[test]
     fn require_hypervisor_selectable_allows_every_other_name() {
-        for name in ["firecracker", "libkrun", "qemu", "hvf", "unknown-typo"] {
+        for name in [
+            "firecracker",
+            "libkrun",
+            "qemu",
+            "hvf",
+            "apple-container",
+            "unknown-typo",
+        ] {
             assert!(
                 AnyBackend::require_hypervisor_selectable(name).is_ok(),
                 "{name}: must never be refused"
@@ -1161,6 +1186,15 @@ mod tests {
     }
 
     #[test]
+    fn auto_select_never_returns_apple_container() {
+        assert_ne!(
+            AnyBackend::auto_select().kind(),
+            mvm_core::vm_backend::BackendKind::AppleContainer,
+            "auto_select must never fall through to the apple-container skeleton"
+        );
+    }
+
+    #[test]
     fn backend_catalog_matrix_is_stable() {
         let actual: Vec<_> = catalog::descriptors()
             .iter()
@@ -1235,6 +1269,16 @@ mod tests {
                     "wasm",
                     Vec::new(),
                     BackendTier::Tier3,
+                    None,
+                    None,
+                    true,
+                    false,
+                    false,
+                ),
+                (
+                    "apple-container",
+                    vec!["container"],
+                    BackendTier::Tier2,
                     None,
                     None,
                     true,
@@ -1332,6 +1376,7 @@ mod tests {
     #[test]
     fn recovery_capability_matrix_is_explicit_for_every_selectable_backend() {
         let mut expected = vec![
+            ("apple-container", SnapshotCapability::Unsupported, false),
             ("firecracker", SnapshotCapability::Unsupported, false),
             ("hvf", SnapshotCapability::Unsupported, false),
             ("libkrun", SnapshotCapability::Unsupported, false),
@@ -1424,6 +1469,7 @@ mod tests {
     #[test]
     fn tier_classification_locks_each_backend_variant() {
         let mut cases: Vec<(&str, BackendTier)> = vec![
+            ("apple-container", BackendTier::Tier2),
             ("firecracker", BackendTier::Tier1),
             ("libkrun", BackendTier::Tier2),
             ("qemu", BackendTier::Tier2),
@@ -1448,7 +1494,7 @@ mod tests {
         // long-standing per-backend tier declaration. `AnyBackend::tier()`
         // is the closed-enum view of the same fact. Bumping one without
         // the other is a regression — keep them wired.
-        let mut names = vec!["firecracker", "libkrun", "qemu"];
+        let mut names = vec!["apple-container", "firecracker", "libkrun", "qemu"];
         if cfg!(feature = "test-support") {
             names.push("mock");
         }
@@ -1500,6 +1546,17 @@ mod tests {
         assert!(
             backend.as_workload_backend().is_none(),
             "qemu: dev/test VMM must not be a workload backend"
+        );
+    }
+
+    #[test]
+    fn as_workload_backend_none_for_apple_container_skeleton() {
+        // The skeleton has no boot path; it must not carry an untrusted
+        // workload until the framework shim and activation channel land.
+        let backend = AnyBackend::from_hypervisor("apple-container");
+        assert!(
+            backend.as_workload_backend().is_none(),
+            "apple-container: skeleton must not be a workload backend"
         );
     }
 
@@ -1577,6 +1634,10 @@ mod tests {
             ("libkrun", AnyBackend::Libkrun(libkrun_runner())),
             ("qemu", AnyBackend::Qemu(QemuBackend)),
             ("hvf", AnyBackend::Hvf(hvf_runner())),
+            (
+                "apple-container",
+                AnyBackend::AppleContainer(AppleContainerBackend::new()),
+            ),
         ];
         backends.extend(mock_variant_for_ssh_check());
         for (name, backend) in backends {
@@ -1714,7 +1775,7 @@ mod tests {
         #[test]
         fn fails_closed_for_non_workload_backends() {
             let s = Scaffold::new();
-            for name in ["qemu", "wasm"] {
+            for name in ["qemu", "wasm", "apple-container"] {
                 let backend = AnyBackend::from_hypervisor(name);
                 let err = backend
                     .claim_standby_via_runner(&s.ctx(), &idle_handle(), &minimal_claim())
@@ -1749,7 +1810,7 @@ mod tests {
                 image_sha256: None,
             };
 
-            for name in ["qemu", "wasm"] {
+            for name in ["qemu", "wasm", "apple-container"] {
                 let backend = AnyBackend::from_hypervisor(name);
                 let err = backend
                     .spawn_standby_via_runner(

--- a/crates/mvm-runtime/src/catalog.rs
+++ b/crates/mvm-runtime/src/catalog.rs
@@ -12,6 +12,7 @@
 //! constructor wiring; `VmBackend` owns runtime behavior; `AnyBackend` remains
 //! the closed enum for the few intentionally backend-specific operations.
 
+use crate::apple_container_backend::AppleContainerBackend;
 use crate::backend::{AnyBackend, BackendTier};
 #[cfg(feature = "test-support")]
 use crate::mock::MockBackend;
@@ -238,6 +239,23 @@ backend_catalog![
         bundled_kernel: false,
         needs_plan_json: false,
         is_workload: true
+    },
+    {
+        kind: AppleContainer,
+        selector: "apple-container",
+        aliases: ["container"],
+        constructor: AnyBackend::AppleContainer(AppleContainerBackend::new()),
+        tier: Tier2,
+        // No pid-file lifecycle — the skeleton boots nothing, and the real
+        // framework-driven path will track VM state out-of-band.
+        marker_file: None,
+        started_vm_probe_order: None,
+        list_all: true,
+        balloon_support: false,
+        warm_start_support: false,
+        bundled_kernel: false,
+        needs_plan_json: false,
+        is_workload: true
     }
 ];
 
@@ -358,7 +376,14 @@ mod tests {
         );
         assert_eq!(
             selectors(list_all_descriptors()),
-            ["firecracker", "libkrun", "qemu", "hvf", "wasm"]
+            [
+                "firecracker",
+                "libkrun",
+                "qemu",
+                "hvf",
+                "wasm",
+                "apple-container"
+            ]
         );
         // Started-VM probe is sorted by probe order, not declaration order.
         assert_eq!(

--- a/crates/mvm-runtime/src/lib.rs
+++ b/crates/mvm-runtime/src/lib.rs
@@ -28,6 +28,7 @@ pub mod vsock_transport;
 
 pub mod vm;
 
+pub mod apple_container_backend;
 pub mod artifacts;
 pub mod audit_substrate;
 /// Shared resolve-or-build for the per-VM helper binaries `mvmctl` spawns

--- a/public/src/content/docs/architecture/boot-flow.md
+++ b/public/src/content/docs/architecture/boot-flow.md
@@ -158,10 +158,18 @@ model in adapted form — or honestly not at all:
   refused by prod admission, and would carry its own explicitly weaker boot
   contract rather than sharing this one.
 - **Apple Container** — Apple's `container` framework boots lightweight Linux
-  VMs with its own init and networking/vsock stack. There is no backend
-  variant for it today. Future support means a driver that boots the same
-  kernel + universal initramfs (or runs `mvm-guest-agent` as the guest init)
-  and bridges the activation channel to the framework's vsock transport.
+  VMs with its own init (`vminitd` as guest PID 1, gRPC on vsock port 1024)
+  and networking/vsock stack. An honest, fail-closed backend skeleton now
+  exists behind `--hypervisor apple-container` (opt-in only, never
+  auto-selected; every operation fails with a typed error naming the
+  milestone that provides it) — see
+  `specs/plans/271-apple-container-backend.md` for the staged design. Full
+  support means driving the same activation contract through `vminitd`'s
+  gRPC API rather than an mvm initramfs: the host writes the serialized
+  `ActivateEnvironment` into the container VM and starts `mvm-guest-agent`
+  as a root process, and the agent performs the same mounts (dm-verity
+  rootfs + runtime overlay, virtio-fs volumes) and the same uid-901 drop as
+  on every other backend.
 - **WHP (Windows Hypervisor Platform)** — a future Windows-host backend. The
   guest side is unchanged: the same kernel + universal initramfs boot and the
   same `ActivateEnvironment`. The work is entirely host-side — a WHP

--- a/specs/notes/2026-07-29-universal-initramfs-future-tiers.md
+++ b/specs/notes/2026-07-29-universal-initramfs-future-tiers.md
@@ -36,15 +36,25 @@ backends").
 
 ## Apple Container
 
-- Today: no backend variant exists (`AnyBackend` enumerates Firecracker,
-  Libkrun, Qemu, Mock, Hvf, Wasm). Two doc comments in
+- Today: the stage-1 backend skeleton exists — `BackendKind::AppleContainer`
+  and `AnyBackend::AppleContainer` behind `--hypervisor apple-container`
+  (alias `container`), opt-in only and never auto-selected. Every operation
+  fails closed with a typed error naming the milestone that provides it;
+  capabilities and the security profile report honestly (no snapshot, no
+  standby pool, all seven claims `DoesNotHold`). The staged design lives in
+  `specs/plans/271-apple-container-backend.md`. Two doc comments in
   `crates/mvm-runtime/src/backend.rs` still name Apple Container
-  (`start` example, `for_started_vm` probe) — they are aspirational, and any
-  implementation should replace them with a real variant + probe marker.
-- Future support shape: a driver that boots the same kernel + universal
-  initramfs (or runs `mvm-guest-agent` as the guest init) and bridges the
-  activation channel to the framework's vsock transport. Capability and
-  security-profile honesty rules from ADR-024 apply verbatim.
+  (`start` example, `for_started_vm` probe) — they describe the real
+  variant's eventual shape (no pid-file marker; the framework tracks VM
+  state out-of-band).
+- Future support shape: Apple's Swift-only framework owns the kernel boot
+  and `vminitd` as guest PID 1 (gRPC on vsock port 1024), so the universal
+  initramfs does not apply verbatim — the **activation contract** rides
+  `vminitd`'s gRPC API instead. The host writes the serialized
+  `ActivateEnvironment` into the container VM, starts `mvm-guest-agent` as
+  a root process, and the agent performs the same mounts and the uid-901
+  drop unchanged. Capability and security-profile honesty rules from
+  ADR-024 apply verbatim.
 
 ## WHP (Windows Hypervisor Platform)
 

--- a/specs/plans/271-apple-container-backend.md
+++ b/specs/plans/271-apple-container-backend.md
@@ -1,0 +1,146 @@
+# Plan 271: Apple Container backend — same boot contract through vminitd
+
+**Status:** Stage 1 (backend skeleton) implemented; stages 2–4 designed below.
+**Owner:** mvm core.
+**Depends on:** universal initramfs + `ActivateEnvironment` (PR #1914).
+
+## Goal
+
+An `--hypervisor apple-container` backend that runs mvm workloads inside
+Apple's Containerization-framework VMs with the **same guest-visible
+functionality** as every other backend: a fail-closed init gate, an
+environment-activation step, dm-verity rootfs + runtime overlay, virtio-fs
+volumes, privilege drop to uid 901, and the standard operational RPC surface
+after activation.
+
+Apple's framework is Swift-only and owns two things we cannot replace:
+the kernel boot path and `vminitd` as guest PID 1. The universal initramfs
+therefore does not apply verbatim; the **activation contract** applies
+through `vminitd`'s existing gRPC API instead. The contract, the guest
+binaries, the mount logic (`mvm_agentd::guest_mount`), and the RPC surface
+are unchanged.
+
+## Design
+
+```text
+Firecracker / libkrun / HVF / QEMU / WHP:  kernel + universal initramfs
+                                           → agent is PID 1 → ActivateEnvironment over vsock:5252
+
+Apple Container:                           framework kernel + vminitd (PID 1, vsock:1024)
+                                           → host drives SandboxContext gRPC
+                                           → agent started as root process → same mounts → uid 901
+```
+
+Activation equivalence:
+
+| Contract step | Runner backends | Apple Container |
+| --- | --- | --- |
+| Fail-closed init gate | agent is PID 1; only `ActivateEnvironment` accepted | agent started only after host prepares env; agent's own RPC gate unchanged (`NotActivated` until activation completes) |
+| Root env delivery | `ActivateEnvironment` over vsock:5252 | serialized `ActivateEnvironment` written via `WriteFile` to `/run/mvm/activation.json`, then `CreateProcess`/`StartProcess` for the agent with `MVM_ACTIVATION_FILE` |
+| Rootfs + overlay mount | agent `guest_mount` (dm-verity, plain, virtiofs) | identical — the agent runs as root in the container VM, which has `CAP_SYS_ADMIN`; block devices are attached by the framework |
+| Pivot | `pivot_to_root` (PID 1 owns `/`) | agent `chroot`s workload children into the verified root; vminitd keeps `/` |
+| Privilege drop | uid/gid 901 | uid/gid 901 (same `WORKLOAD_UID`/`WORKLOAD_GID`) |
+| Operational RPCs | vsock:5252 | vsock:5252, reached through `ProxyVsock` or direct CID connect |
+| Egress gate | per-VM substitution endpoint | unchanged (host-side, same seam) |
+
+What is honestly different, and must be documented as such:
+
+- The kernel is supplied by the framework (or by us through the framework's
+  kernel slot), not bundled by mvm. Verified boot of the rootfs still holds —
+  dm-verity runs in-guest — but the *kernel image* chain of custody is the
+  framework's, exactly like libkrun's bundled kernel.
+- The fail-closed gate is weaker at the very first hop: `vminitd`'s own gRPC
+  listens from boot. That surface is Apple's signed component, not a
+  workload-reachable mvm verb; the mvm agent still refuses every operational
+  RPC until activation. This is recorded as a named caveat in the backend's
+  `security_profile()`, mirroring how Tier-2 caveats are recorded today.
+
+## Milestones
+
+### Stage 1 — Backend skeleton (this change)
+
+- `BackendKind::AppleContainer`; `AnyBackend::AppleContainer`.
+- `AppleContainerBackend` implementing `VmBackend`: construction does no I/O;
+  `capabilities()` reports nothing supported; `security_profile()` records
+  the tier honestly; every operation fails closed with a typed
+  `AppleContainerError` naming the milestone that provides it (mirrors
+  `WasmBackend`'s `NotCompiledIn` discipline).
+- Catalog descriptor: selector `apple-container`, aliases `["container"]`,
+  never auto-selected, not in `started_vm_probe_descriptors`, Tier 2.
+- Tests: selector resolves; auto-select never returns it; capabilities and
+  security profile are honest; `start`/`stop`/`wait`/`pause`/`resume`/
+  `snapshot`/`warm_start` all fail closed with the typed error.
+- Gate: workspace clippy + tests + policy xtasks green.
+
+### Stage 2 — Swift Containerization shim
+
+- New SwiftPM package `swift/container-shim/` vendoring
+  `github.com/apple/containerization` (pin to a tagged release; record the
+  pin and its SHA in the shim's `Package.swift` comment and in
+  `xtask check-forbidden-deps` allowance if the checker scans it).
+- `@_cdecl` exports: `mvm_ac_create(config_json) -> handle`,
+  `mvm_ac_start(handle)`, `mvm_ac_stop(handle)`,
+  `mvm_ac_vsock_fd(handle, port) -> fd`, `mvm_ac_destroy(handle)`.
+  Config JSON carries: kernel path, rootfs block, verity sidecar, overlay
+  pair, virtiofs shares, cpus/mem, vm name.
+- Rust binding crate `crates/mvm-runtime/src/apple_container/sys.rs`
+  (hand-written `extern "C"`, `// SAFETY:` per call) built by `build.rs`
+  invoking `swift build` behind the `apple-container` Cargo feature —
+  off by default so the default build has no SwiftPM dependency (same
+  discipline as `wasm-backend`).
+- Kernel: reuse the mvm workload kernel artifact
+  (`mvmctl kernel build --which workload`) in the framework's kernel slot.
+- Entitlements: add `com.apple.vm.networking` to
+  `assets/mvmctl.entitlements` only if the endpoint path needs vmnet;
+  document the codesign step in the milestone PR.
+- Verification: a macOS-only `#[cfg(all(target_os = "macos",
+  feature = "apple-container"))]` smoke test that creates and destroys a VM
+  running the stock container kernel — gated `MVM_AC_E2E=1`, ignored by
+  default (mirrors `MVM_LIBKRUN_E2E`).
+
+### Stage 3 — vminitd gRPC-over-vsock transport
+
+- Generate prost types from `crates/mvm-runtime/src/vm/proto/sandbox_context.proto`
+  (`prost-build` in the existing build pipeline; the proto is already
+  vendored).
+- Transport: HTTP/2 gRPC over the shim's vsock fd using `tonic` with a
+  custom connector, or `h2` hand-framed if the `tonic` dependency tree is
+  rejected at audit time — decision recorded in the stage-3 PR after
+  `cargo deny` output.
+- Fill `vm/vminitd_client.rs` (typed interface already exists): `WriteFile`,
+  `CreateProcess`, `StartProcess`, `WaitProcess`, `KillProcess`,
+  `ProxyVsock`, `Mount`.
+- Tests: in-process mock gRPC server over a Unix socket pair asserting the
+  exact request bytes for the activation sequence; no Apple framework
+  required.
+
+### Stage 4 — Activation through vminitd + driver wiring
+
+- `AppleContainerDriver: VmmDriver` assembling the framework VM config from
+  `VmmSpec` (blocks: rootfs `/dev/vda`, verity `/dev/vdb`, overlay
+  `/dev/vdc`+`/dev/vdd`; virtiofs shares; vsock ports 1024 + 5252).
+- Boot sequence: shim create/start → connect vminitd:1024 →
+  `WriteFile(/run/mvm/activation.json)` with the serialized
+  `ActivateEnvironment` (same builder as `microvm::activation`) →
+  `CreateProcess` + `StartProcess` for `/sbin/mvm-guest-agent
+  --activation-file /run/mvm/activation.json` as uid 0 → agent performs the
+  identical `guest_mount` sequence and drops to uid 901 → host connects
+  vsock:5252 and proceeds through the standard `WorkloadRunner` broker/exit
+  wiring.
+- Agent flag: `--activation-file <path>` added to `mvm-guest-agent` (reads
+  the env, applies it, then serves; fails closed on malformed JSON).
+- Verification: `MVM_AC_E2E=1` macOS smoke booting the dev image to
+  `Ping`; dm-verity sealed smoke reusing the existing
+  `mvm-ext4 output mounts on the real kernel` lane's artifacts where
+  possible; BDD scenario under `features/suites/` mirroring the
+  initramfs-cache feature.
+
+## Constraints that do not change
+
+- `ActivateEnvironment` semantics, `guest_mount`, uid 901, the
+  `NotActivated` gate, the egress endpoint, and the broker registration are
+  shared verbatim. No backend-specific fork of the guest agent.
+- Auto-select never returns this backend (opt-in only) until it carries a
+  production tier, same discipline as QEMU.
+- `BackendKind` exhaustiveness is load-bearing: the stage-1 ripple across
+  match sites is intentional and keeps every dispatch site honest.


### PR DESCRIPTION
Stage 1 of the Apple Container backend (plan: `specs/plans/271-apple-container-backend.md`).

## What changed

- `BackendKind::AppleContainer` + `AnyBackend::AppleContainer`, catalog descriptor behind explicit `--hypervisor apple-container` (alias `container`), never auto-selected.
- `AppleContainerBackend`: side-effect-free, honest capabilities (no snapshot, no standby pool, no warm start), security profile records all seven claims `DoesNotHold` until the boot path lands, and every operation fails closed with a typed `AppleContainerError` naming the milestone that provides it — the same pattern `WasmBackend` uses.
- Design: Apple's Containerization framework owns the kernel boot and `vminitd` (guest PID 1, gRPC on vsock:1024), so activation rides that API instead of an mvm initramfs; the guest agent binary, `guest_mount` dm-verity/virtiofs mounts, uid-901 drop, `NotActivated` gate, and RPC surface are shared unchanged with every other backend.

## Validation

- 16 apple-container tests pass; workspace clippy clean; policy xtasks (spec-refs, cli-runtime-surface, claim-catalog, two-surfaces, conformance, doc-claims) clean; Linux musl check compiles.

Stages 2–4 (Swift shim, vminitd gRPC-over-vsock transport, activation-through-vminitd driver wiring) follow in separate PRs per the plan doc.