### PR TITLE
fix(cache): verify the initramfs at admission and share one cross-root seed

### DIFF
--- a/crates/mvm-build/src/cache_install.rs
+++ b/crates/mvm-build/src/cache_install.rs
@@ -1,0 +1,244 @@
+//! How artifacts enter a cache root.
+//!
+//! Two conventions live here because both are shared by every cached
+//! artifact (the builder VM image, the runtime overlay, the universal
+//! initramfs) and both were previously reimplemented per artifact:
+//!
+//! 1. **The cross-root seed.** An isolated session (a worktree pointing
+//!    `MVM_HOME` at a tempdir) can populate its own cache root from the
+//!    host's shared one instead of rebuilding an expensive artifact. This
+//!    module owns the only derivation of that shared root, so the set of
+//!    places that can read `$HOME` while `MVM_HOME` is set stays exactly
+//!    one — see the `check-test-home-isolation` gate.
+//! 2. **The staging convention.** Installs stage into a sibling
+//!    `<arch>.tmp.<pid>` directory and rename it into place, so a crash
+//!    never leaves a half-written artifact where a resolver can find it.
+//!    The flip side is that a killed install orphans its staging dir, so
+//!    installers reap abandoned ones as they go.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// The cache root of the *default* mvm home (`$HOME/.mvm/cache`),
+/// deliberately ignoring the `MVM_HOME` override.
+///
+/// This is the single call site for that resolver in the whole workspace.
+/// Keeping it here means a new cross-root seed is a visible change to this
+/// module rather than a fresh `$HOME` read buried in an artifact module —
+/// which matters because a test that isolates only `MVM_HOME` still reads
+/// the developer's real cache through this path.
+pub(crate) fn default_cache_root() -> PathBuf {
+    PathBuf::from(mvm_core::config::default_mvm_cache_dir())
+}
+
+/// Populate `target_root` from `default_root` after a resolve miss.
+///
+/// Returns whether anything was installed, so the caller can retry its
+/// resolve exactly once and otherwise surface its original error unchanged.
+///
+/// A miss in the *default* root is not an error — seeding is opportunistic,
+/// and a host that has never built the artifact simply has nothing to give.
+/// That is why `resolve_default` yields an `Option` rather than a `Result`:
+/// the "nothing to seed" outcome is in the type instead of relying on every
+/// caller to remember to swallow it. An `install` failure, by contrast, means
+/// the target cache may be half-populated and does propagate.
+pub(crate) fn seed_on_miss<S, E>(
+    target_root: &Path,
+    default_root: &Path,
+    resolve_default: impl FnOnce(&Path) -> Option<S>,
+    install: impl FnOnce(S) -> Result<(), E>,
+) -> Result<bool, E> {
+    if target_root == default_root {
+        return Ok(false);
+    }
+    let Some(source) = resolve_default(default_root) else {
+        return Ok(false);
+    };
+    install(source)?;
+    Ok(true)
+}
+
+/// Name of this process's staging directory for `arch`.
+///
+/// The pid disambiguates concurrent installs. Two installs in the same
+/// process race on the post-staging rename, where the second one wins —
+/// the same semantics as installing twice.
+pub(crate) fn staging_dir_name(arch: &str) -> String {
+    format!("{}.tmp.{}", arch, std::process::id())
+}
+
+/// How long an abandoned staging directory must sit before an install reaps
+/// it. Staging is a handful of file copies, so anything this old belongs to a
+/// process that died before its rename.
+const STALE_STAGING_AGE: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// Remove staging directories for `arch` under `parent` that a previous run
+/// abandoned.
+///
+/// Age is the liveness signal rather than the pid embedded in the name: a
+/// portable pid check needs `libc` or `/proc`, and pid reuse makes it
+/// unreliable in the one direction that matters. Judging by age can only ever
+/// be wrong by leaving litter one cycle longer, never by deleting a live
+/// install's staging directory.
+///
+/// Best-effort by design — reaping litter must never fail an install, so
+/// every error here is dropped.
+pub(crate) fn reap_stale_staging(parent: &Path, arch: &str) {
+    reap_staging_older_than(parent, arch, STALE_STAGING_AGE);
+}
+
+/// The age threshold is a parameter so tests can drive the real selection
+/// logic without backdating filesystem timestamps.
+fn reap_staging_older_than(parent: &Path, arch: &str, max_age: Duration) {
+    let ours = staging_dir_name(arch);
+    let prefix = format!("{arch}.tmp.");
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if name == ours || !name.starts_with(&prefix) {
+            continue;
+        }
+        let abandoned = entry
+            .metadata()
+            .ok()
+            .filter(|meta| meta.is_dir())
+            .and_then(|meta| meta.modified().ok())
+            .and_then(|modified| modified.elapsed().ok())
+            .is_some_and(|age| age >= max_age);
+        if abandoned {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_on_miss_declines_when_target_is_the_default_root() {
+        let mut installed = false;
+        let seeded = seed_on_miss(
+            Path::new("/same"),
+            Path::new("/same"),
+            |_| Some(()),
+            |()| {
+                installed = true;
+                Ok::<(), ()>(())
+            },
+        )
+        .unwrap();
+        assert!(!seeded);
+        assert!(!installed, "must not install into the root it reads from");
+    }
+
+    #[test]
+    fn seed_on_miss_declines_when_the_default_root_has_nothing() {
+        let seeded = seed_on_miss(
+            Path::new("/target"),
+            Path::new("/default"),
+            |_| None::<()>,
+            |()| Ok::<(), ()>(()),
+        )
+        .unwrap();
+        assert!(!seeded, "a default-root miss is not an error");
+    }
+
+    #[test]
+    fn seed_on_miss_installs_and_reports_success() {
+        let mut seen = None;
+        let seeded = seed_on_miss(
+            Path::new("/target"),
+            Path::new("/default"),
+            |root| Some(root.to_path_buf()),
+            |root| {
+                seen = Some(root);
+                Ok::<(), ()>(())
+            },
+        )
+        .unwrap();
+        assert!(seeded);
+        assert_eq!(seen.as_deref(), Some(Path::new("/default")));
+    }
+
+    #[test]
+    fn seed_on_miss_propagates_install_failure() {
+        let result = seed_on_miss(
+            Path::new("/target"),
+            Path::new("/default"),
+            |_| Some(()),
+            |()| Err::<(), &str>("disk full"),
+        );
+        assert_eq!(result.unwrap_err(), "disk full");
+    }
+
+    #[test]
+    fn staging_dir_name_is_arch_scoped_and_pid_scoped() {
+        let name = staging_dir_name("aarch64");
+        assert!(name.starts_with("aarch64.tmp."));
+        assert!(name.ends_with(&std::process::id().to_string()));
+    }
+
+    #[test]
+    fn reap_leaves_fresh_and_foreign_dirs_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ours = tmp.path().join(staging_dir_name("aarch64"));
+        let fresh_other = tmp.path().join("aarch64.tmp.999999");
+        let other_arch = tmp.path().join("x86_64.tmp.999999");
+        let real = tmp.path().join("aarch64");
+        for dir in [&ours, &fresh_other, &other_arch, &real] {
+            std::fs::create_dir_all(dir).unwrap();
+        }
+
+        reap_stale_staging(tmp.path(), "aarch64");
+
+        assert!(ours.is_dir(), "our own staging dir must survive");
+        assert!(fresh_other.is_dir(), "a fresh orphan may still be in use");
+        assert!(other_arch.is_dir(), "another arch is not ours to reap");
+        assert!(
+            real.is_dir(),
+            "the installed artifact must never be touched"
+        );
+    }
+
+    #[test]
+    fn reap_removes_an_abandoned_staging_dir_with_its_contents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stale = tmp.path().join("aarch64.tmp.999999");
+        let ours = tmp.path().join(staging_dir_name("aarch64"));
+        let real = tmp.path().join("aarch64");
+        std::fs::create_dir_all(stale.join("nested")).unwrap();
+        std::fs::write(stale.join("nested").join("overlay.ext4"), b"partial").unwrap();
+        std::fs::create_dir_all(&ours).unwrap();
+        std::fs::create_dir_all(&real).unwrap();
+
+        // Everything is newly created, so a zero threshold makes every
+        // candidate eligible — proving selection is by name, not by age alone.
+        reap_staging_older_than(tmp.path(), "aarch64", Duration::ZERO);
+
+        assert!(!stale.exists(), "an abandoned staging dir must be reaped");
+        assert!(ours.is_dir(), "our own staging dir is never eligible");
+        assert!(
+            real.is_dir(),
+            "the installed artifact must never be touched"
+        );
+    }
+
+    #[test]
+    fn the_shipped_threshold_spares_a_dir_that_was_just_created() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fresh = tmp.path().join("aarch64.tmp.999999");
+        std::fs::create_dir_all(&fresh).unwrap();
+
+        reap_stale_staging(tmp.path(), "aarch64");
+
+        assert!(
+            fresh.is_dir(),
+            "a concurrent install's staging dir must survive the real threshold"
+        );
+    }
+}

--- a/crates/mvm-build/src/initramfs.rs
+++ b/crates/mvm-build/src/initramfs.rs
@@ -88,26 +88,23 @@ fn seed_from_default_cache(
     version: &str,
     arch: GuestArch,
 ) -> Result<bool, InitramfsBuildError> {
-    let default_cache_root =
-        PathBuf::from(mvm_core::config::default_mvm_cache_dir()).join("initramfs");
-    if cache_root == default_cache_root {
-        return Ok(false);
-    }
-
-    let source = InitramfsResolver::new(default_cache_root, version).resolve(&arch.to_string());
-    let Ok(source) = source else {
-        return Ok(false);
-    };
-
-    let source_dir = source.image_path.parent().ok_or_else(|| {
-        InitramfsBuildError::Io(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "resolved initramfs image has no parent directory",
-        ))
-    })?;
-
-    install_initramfs_into_cache(source_dir, cache_root, version, arch)?;
-    Ok(true)
+    let arch_dir = arch.to_string();
+    crate::cache_install::seed_on_miss(
+        cache_root,
+        &crate::cache_install::default_cache_root().join("initramfs"),
+        |root| {
+            // Ask the resolver for the directory rather than recovering it
+            // from a resolved file path — it is the type that owns the layout.
+            let resolver = InitramfsResolver::new(root, version);
+            resolver
+                .resolve(&arch_dir)
+                .ok()
+                .map(|_| resolver.artifact_dir(&arch_dir))
+        },
+        |source_dir| {
+            install_initramfs_into_cache(&source_dir, cache_root, version, arch).map(|_| ())
+        },
+    )
 }
 
 /// Resolve a cached universal initramfs, or return an error describing why it
@@ -243,10 +240,14 @@ pub fn install_initramfs_into_cache(
     })?;
     std::fs::create_dir_all(parent)?;
 
-    let staging = parent.join(staging_dir_name(&arch.to_string()));
+    let arch_dir = arch.to_string();
+    let staging = parent.join(crate::cache_install::staging_dir_name(&arch_dir));
     if staging.exists() {
         std::fs::remove_dir_all(&staging)?;
     }
+    // A run killed between here and the rename below orphans its staging dir
+    // under another pid, which nothing else would ever clean up.
+    crate::cache_install::reap_stale_staging(parent, &arch_dir);
     std::fs::create_dir(&staging)?;
 
     for file in [
@@ -259,6 +260,10 @@ pub fn install_initramfs_into_cache(
         set_cache_perms(&staging.join(file))?;
     }
 
+    // Verify before the rename, so a corrupt artifact never becomes visible
+    // to a resolver.
+    verify_staged_image_hash(&staging)?;
+
     if target_dir.exists() {
         std::fs::remove_dir_all(&target_dir)?;
     }
@@ -267,8 +272,51 @@ pub fn install_initramfs_into_cache(
     mvm_fs::initramfs::read_initramfs_artifact_from_dir(&target_dir).map_err(Into::into)
 }
 
-fn staging_dir_name(arch: &str) -> String {
-    format!("{}.tmp.{}", arch, std::process::id())
+/// Check the staged image against its `initramfs.hash` sidecar.
+///
+/// This is the one choke point every artifact passes through on its way into
+/// a cache root — the download, the local build, and the cross-root seed all
+/// land here — so verifying here covers all three without putting the cost on
+/// the boot path. `resolve()` deliberately stays cheap: it runs on every VM
+/// start, and a decompress-and-hash per start is not affordable.
+///
+/// The build hashes the *uncompressed* cpio, so this decompresses rather than
+/// hashing the compressed file. (`initramfs.size`, checked by the resolver, is
+/// the compressed length — the two sidecars describe different bytes.)
+fn verify_staged_image_hash(staging: &Path) -> Result<(), InitramfsBuildError> {
+    let expected = std::fs::read_to_string(staging.join(mvm_fs::initramfs::INITRAMFS_HASH_FILE))?
+        .trim()
+        .to_ascii_lowercase();
+    let image = staging.join(mvm_fs::initramfs::INITRAMFS_IMAGE_FILE);
+    let actual = sha256_of_gunzipped(&image)?;
+    if actual != expected {
+        return Err(InitramfsBuildError::ChecksumMismatch {
+            name: format!("{} (uncompressed)", mvm_fs::initramfs::INITRAMFS_IMAGE_FILE),
+            expected,
+            actual,
+        });
+    }
+    Ok(())
+}
+
+/// SHA-256 over the gunzipped contents of `path`, streamed so a large
+/// initramfs never lands in memory whole.
+fn sha256_of_gunzipped(path: &Path) -> Result<String, InitramfsBuildError> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read as _;
+
+    let file = std::io::BufReader::new(std::fs::File::open(path)?);
+    let mut decoder = flate2::read::GzDecoder::new(file);
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 65536];
+    loop {
+        let read = decoder.read(&mut buf)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+    }
+    Ok(hex::encode(hasher.finalize()))
 }
 
 #[cfg(unix)]
@@ -552,11 +600,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let source = tmp.path().join("source");
         let cache_root = tmp.path().join("cache");
-        std::fs::create_dir_all(&source).unwrap();
-        std::fs::write(source.join("initramfs.cpio.gz"), b"image").unwrap();
-        std::fs::write(source.join("initramfs.hash"), b"hash").unwrap();
-        std::fs::write(source.join("initramfs.size"), "5").unwrap();
-        std::fs::write(source.join("VERSION"), "0.18.0").unwrap();
+        write_initramfs_artifact(&source, "0.18.0", b"cpio-payload");
 
         let artifact =
             install_initramfs_into_cache(&source, &cache_root, "0.18.0", GuestArch::Aarch64)
@@ -568,6 +612,41 @@ mod tests {
         assert!(target_dir.join("initramfs.cpio.gz").is_file());
         assert_eq!(artifact.image_path, target_dir.join("initramfs.cpio.gz"));
         assert_eq!(artifact.version, "0.18.0");
+    }
+
+    #[test]
+    fn install_refuses_an_image_that_does_not_match_its_hash_sidecar() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let cache_root = tmp.path().join("cache");
+        write_initramfs_artifact(&source, "0.18.0", b"cpio-payload");
+
+        // Swap in a different payload, leaving the sidecar hash untouched —
+        // the substitution a size check alone cannot see, because the
+        // replacement is written to the same compressed length.
+        let (honest, ..) = initramfs_fixture(b"cpio-payload");
+        let (tampered, ..) = initramfs_fixture(b"evil-payload");
+        assert_eq!(
+            honest.len(),
+            tampered.len(),
+            "fixture must keep the compressed length identical"
+        );
+        std::fs::write(source.join("initramfs.cpio.gz"), &tampered).unwrap();
+
+        let err = install_initramfs_into_cache(&source, &cache_root, "0.18.0", GuestArch::Aarch64)
+            .unwrap_err();
+
+        assert!(
+            matches!(err, InitramfsBuildError::ChecksumMismatch { .. }),
+            "expected a checksum mismatch, got {err:?}"
+        );
+        let target_dir = cache_root
+            .join("0.18.0")
+            .join(GuestArch::Aarch64.to_string());
+        assert!(
+            !target_dir.exists(),
+            "a refused artifact must never become visible to a resolver"
+        );
     }
 
     #[test]
@@ -601,17 +680,25 @@ mod tests {
         std::fs::create_dir_all(&release_dir).unwrap();
 
         let names = InitramfsArtifactNames::for_arch(&arch.to_string());
-        let ext4_bytes = b"downloaded-cpio";
-        let hash_text = b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-";
-        let size_text = b"15
-";
+        let (image_bytes, hash, size) = initramfs_fixture(b"downloaded-cpio-payload");
+        let hash_text = format!(
+            "{hash}
+"
+        );
+        let size_text = format!(
+            "{size}
+"
+        );
         let version_text = format!(
             "{version}
 "
         );
-        let archive_bytes =
-            initramfs_archive_bytes(ext4_bytes, hash_text, size_text, version_text.as_bytes());
+        let archive_bytes = initramfs_archive_bytes(
+            &image_bytes,
+            hash_text.as_bytes(),
+            size_text.as_bytes(),
+            version_text.as_bytes(),
+        );
         std::fs::write(release_dir.join(&names.archive), &archive_bytes).unwrap();
         std::fs::write(
             release_dir.join(&names.archive_checksum),
@@ -658,6 +745,30 @@ mod tests {
         hex::encode(Sha256::digest(bytes))
     }
 
+    /// The three sidecar values the nix build emits for a cpio payload: a real
+    /// gzip stream, the SHA-256 of the *uncompressed* payload, and the length
+    /// of the *compressed* file. Fixtures have to match that shape or they
+    /// cannot exercise the install-time hash check.
+    fn initramfs_fixture(payload: &[u8]) -> (Vec<u8>, String, String) {
+        use std::io::Write as _;
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(payload).unwrap();
+        let image = encoder.finish().unwrap();
+        let hash = sha256_hex(payload);
+        let size = image.len().to_string();
+        (image, hash, size)
+    }
+
+    /// Write a complete, self-consistent artifact directory.
+    fn write_initramfs_artifact(dir: &std::path::Path, version: &str, payload: &[u8]) {
+        let (image, hash, size) = initramfs_fixture(payload);
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join("initramfs.cpio.gz"), &image).unwrap();
+        std::fs::write(dir.join("initramfs.hash"), format!("{hash}\n")).unwrap();
+        std::fs::write(dir.join("initramfs.size"), format!("{size}\n")).unwrap();
+        std::fs::write(dir.join("VERSION"), format!("{version}\n")).unwrap();
+    }
+
     fn append_archive_file<W: std::io::Write>(tar: &mut tar::Builder<W>, path: &str, bytes: &[u8]) {
         let mut header = tar::Header::new_gnu();
         header.set_mode(0o644);
@@ -678,20 +789,11 @@ mod tests {
         let home = tmp.path().join("home");
         std::fs::create_dir_all(&home).unwrap();
         env.set("HOME", &home);
-        let default_mvm =
-            PathBuf::from(mvm_core::config::default_mvm_cache_dir()).join("initramfs");
+        let default_mvm = crate::cache_install::default_cache_root().join("initramfs");
         let default_artifact_dir = default_mvm
             .join("0.18.0")
             .join(GuestArch::Aarch64.to_string());
-        std::fs::create_dir_all(&default_artifact_dir).unwrap();
-        std::fs::write(
-            default_artifact_dir.join("initramfs.cpio.gz"),
-            b"default-image",
-        )
-        .unwrap();
-        std::fs::write(default_artifact_dir.join("initramfs.hash"), b"hash").unwrap();
-        std::fs::write(default_artifact_dir.join("initramfs.size"), "13").unwrap();
-        std::fs::write(default_artifact_dir.join("VERSION"), "0.18.0").unwrap();
+        write_initramfs_artifact(&default_artifact_dir, "0.18.0", b"default-cpio-payload");
 
         let artifact =
             resolve_or_seed_from_default_cache(&isolated_cache, "0.18.0", GuestArch::Aarch64)

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -30,6 +30,10 @@ pub mod builderd_client;
 /// controlled-shell-job channel in `builder_protocol`).
 pub mod builderd_protocol;
 pub mod cache;
+/// Shared conventions for admitting an artifact into a cache root: the
+/// cross-root seed from the host's shared cache, and the staging-directory
+/// dance every install uses.
+mod cache_install;
 /// Builder-VM egress allowlist proxy — the lib half of the
 /// `mvm-egress-proxy` bin. Kept as a lib module (not bin-inlined) so
 /// its pub API is dead-code-clean on non-Linux and its tests run

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -2290,22 +2290,30 @@ fn builder_vm_source_checkout_root() -> Option<PathBuf> {
 }
 
 fn default_builder_vm_cache_dir() -> PathBuf {
-    PathBuf::from(mvm_core::config::default_mvm_cache_dir()).join("builder-vm")
+    crate::cache_install::default_cache_root().join("builder-vm")
 }
 
 fn seed_builder_vm_image_from_default_cache(arch_dir: &Path) -> Result<bool, BuilderVmError> {
-    let source_arch_dir = default_builder_vm_cache_dir().join(host_arch_tag());
-    let target_arch_dir = builder_vm_cache_dir().join(host_arch_tag());
-    if source_arch_dir == target_arch_dir || !source_arch_dir.is_dir() {
-        return Ok(false);
-    }
+    crate::cache_install::seed_on_miss(
+        &builder_vm_cache_dir().join(host_arch_tag()),
+        &default_builder_vm_cache_dir().join(host_arch_tag()),
+        |source_arch_dir| {
+            // Seeding from the default cache is opportunistic. If the host's
+            // shared cache is stale or malformed, skip it and let
+            // source-checkout auto-bootstrap build a fresh image into the
+            // isolated target cache. A missing dir fails validation too.
+            validate_builder_vm_image_cache(source_arch_dir)
+                .ok()
+                .map(|_| source_arch_dir.to_path_buf())
+        },
+        |source_arch_dir| copy_builder_vm_image_files(&source_arch_dir, arch_dir),
+    )
+}
 
-    // Seeding from the default cache is opportunistic. If the host's shared
-    // cache is stale or malformed, skip it and let source-checkout
-    // auto-bootstrap build a fresh image into the isolated target cache.
-    if validate_builder_vm_image_cache(&source_arch_dir).is_err() {
-        return Ok(false);
-    }
+fn copy_builder_vm_image_files(
+    source_arch_dir: &Path,
+    arch_dir: &Path,
+) -> Result<(), BuilderVmError> {
     std::fs::create_dir_all(arch_dir).map_err(|e| {
         BuilderVmError::ExtractionFailed(format!("create {}: {e}", arch_dir.display()))
     })?;
@@ -2321,7 +2329,7 @@ fn seed_builder_vm_image_from_default_cache(arch_dir: &Path) -> Result<bool, Bui
             ))
         })?;
     }
-    Ok(true)
+    Ok(())
 }
 
 fn auto_bootstrap_builder_vm_image(arch_dir: &Path) -> Result<bool, BuilderVmError> {
@@ -5674,7 +5682,7 @@ mod tests {
         env.set("MVM_HOME", scratch.path().join("isolated-cache"));
 
         let arch = host_arch_tag().to_string();
-        let source_arch_dir = std::path::PathBuf::from(mvm_core::config::default_mvm_cache_dir())
+        let source_arch_dir = crate::cache_install::default_cache_root()
             .join("builder-vm")
             .join(&arch);
         std::fs::create_dir_all(&source_arch_dir).unwrap();
@@ -5731,7 +5739,7 @@ mod tests {
         env.set("MVM_HOME", scratch.path().join("isolated-cache"));
 
         let arch = host_arch_tag().to_string();
-        let source_arch_dir = std::path::PathBuf::from(mvm_core::config::default_mvm_cache_dir())
+        let source_arch_dir = crate::cache_install::default_cache_root()
             .join("builder-vm")
             .join(&arch);
         std::fs::create_dir_all(&source_arch_dir).unwrap();

--- a/crates/mvm-build/src/runtime_overlay.rs
+++ b/crates/mvm-build/src/runtime_overlay.rs
@@ -145,20 +145,20 @@ fn seed_from_default_cache(
     resolver: &RuntimeOverlayResolver,
     arch_dir: &str,
 ) -> Result<bool, RuntimeOverlayError> {
-    let default_cache_root = PathBuf::from(mvm_core::config::default_mvm_cache_dir());
-    if resolver.cache_root() == default_cache_root {
-        return Ok(false);
-    }
-
-    let source =
-        RuntimeOverlayResolver::new(default_cache_root, resolver.expected_version().to_string())
-            .resolve(arch_dir);
-    let Ok(source) = source else {
-        return Ok(false);
-    };
-
-    install_overlay_into_cache(&source, resolver.cache_root(), &InstallOptions::default())?;
-    Ok(true)
+    let version = resolver.expected_version().to_string();
+    crate::cache_install::seed_on_miss(
+        resolver.cache_root(),
+        &crate::cache_install::default_cache_root(),
+        |root| {
+            RuntimeOverlayResolver::new(root.to_path_buf(), version.clone())
+                .resolve(arch_dir)
+                .ok()
+        },
+        |source| {
+            install_overlay_into_cache(&source, resolver.cache_root(), &InstallOptions::default())
+                .map(|_| ())
+        },
+    )
 }
 
 #[cfg(feature = "pure-mkfs")]
@@ -727,12 +727,15 @@ pub fn install_overlay_into_cache(
     // PID + a small random suffix. Multiple concurrent installs
     // for the same (version, arch) get distinct staging dirs and
     // the last rename wins atomically.
-    let staging = parent.join(staging_dir_name(&source.arch));
+    let staging = parent.join(crate::cache_install::staging_dir_name(&source.arch));
     // Belt-and-braces: if a previous interrupted install left a
     // staging dir at the same name, blow it away.
     if staging.exists() {
         std::fs::remove_dir_all(&staging)?;
     }
+    // A run killed between here and the rename below orphans its staging dir
+    // under another pid, which nothing else would ever clean up.
+    crate::cache_install::reap_stale_staging(parent, &source.arch);
     std::fs::create_dir(&staging)?;
 
     install_file_with_perms(&source.overlay_ext4, &staging.join("overlay.ext4"))?;
@@ -772,14 +775,6 @@ fn all_required_files_present(layout: &RuntimeOverlayLayout) -> bool {
         && layout.roothash_file.is_file()
         && layout.version_file.is_file()
         && layout.checksum_manifest_file.is_file()
-}
-
-fn staging_dir_name(arch: &str) -> String {
-    // PID alone is enough to disambiguate per-process; if two
-    // installs in the same process race, the second one wins on
-    // the post-staging rename, which is the same semantics as
-    // calling install_overlay_into_cache(overwrite=true) twice.
-    format!("{}.tmp.{}", arch, std::process::id())
 }
 
 fn install_file_with_perms(src: &Path, dst: &Path) -> Result<(), RuntimeOverlayError> {
@@ -1582,8 +1577,7 @@ mod tests {
         env.set("MVM_HOME", scratch.path().join("isolated-cache"));
 
         let (_keep, source) = make_source_artifact("0.14.0", GuestArch::Aarch64, FAKE_ROOTHASH);
-        let default_cache_root =
-            std::path::PathBuf::from(mvm_core::config::default_mvm_cache_dir());
+        let default_cache_root = crate::cache_install::default_cache_root();
         install_overlay_into_cache(&source, &default_cache_root, &InstallOptions::default())
             .expect("install source into default cache");
 
@@ -1650,7 +1644,7 @@ mod tests {
         let cache = TempDir::new().unwrap();
         let parent = cache.path().join("runtime-overlay/0.14.0");
         std::fs::create_dir_all(&parent).unwrap();
-        let staging = parent.join(staging_dir_name("aarch64"));
+        let staging = parent.join(crate::cache_install::staging_dir_name("aarch64"));
         std::fs::create_dir_all(&staging).unwrap();
         std::fs::write(staging.join("garbage"), b"left over from a crash").unwrap();
 

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -968,9 +968,23 @@ mod universal_initramfs_attach_tests {
         let arch = GuestArch::host();
         let source = dir.path().join("source");
         std::fs::create_dir_all(&source).unwrap();
-        std::fs::write(source.join("initramfs.cpio.gz"), b"image").unwrap();
-        std::fs::write(source.join("initramfs.hash"), b"hash").unwrap();
-        std::fs::write(source.join("initramfs.size"), "5").unwrap();
+        // The installer verifies the image against its hash sidecar, so the
+        // fixture has to match what the build emits: a real gzip stream, the
+        // SHA-256 of the uncompressed payload, and the compressed length.
+        let payload = b"cpio-payload";
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        std::io::Write::write_all(&mut encoder, payload).unwrap();
+        let image = encoder.finish().unwrap();
+        std::fs::write(source.join("initramfs.cpio.gz"), &image).unwrap();
+        std::fs::write(
+            source.join("initramfs.hash"),
+            format!(
+                "{}\n",
+                hex::encode(<sha2::Sha256 as sha2::Digest>::digest(payload))
+            ),
+        )
+        .unwrap();
+        std::fs::write(source.join("initramfs.size"), format!("{}\n", image.len())).unwrap();
         std::fs::write(source.join("VERSION"), version).unwrap();
 
         let cache_root = dir.path().join("cache").join("initramfs");

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -64,6 +64,24 @@
       already isolates both roots, and the test binary passed 47/47 across four
       consecutive runs. Needs separate triage as a concurrency flake.
 
+- [x] Cross-root cache-seed hardening (#1925, #1926, #1927, #1928). The three
+      opportunistic seeds that populate an isolated cache root from the host's
+      shared one now share `mvm_build::cache_install`, which owns the single
+      derivation of the default cache root — so the set of places that can read
+      `$HOME` while `MVM_HOME` is set is exactly one, and the
+      `check-test-home-isolation` allowlist shrank from four entries to two.
+      `install_initramfs_into_cache` now verifies the staged image against its
+      `initramfs.hash` sidecar before the rename, closing the one real
+      integrity asymmetry: the hash is SHA-256 of the *uncompressed* cpio (the
+      size sidecar is the compressed length), so this gunzips rather than
+      hashing the file, and it runs at cache-root admission rather than on
+      every resolve to keep a decompress off the boot path. Abandoned
+      `<arch>.tmp.<pid>` staging dirs are now reaped by age (a real 6-day-old
+      orphan was found on a dev host), and the initramfs seed asks the resolver
+      for its artifact dir instead of recovering it from a file path. Three
+      test fixtures had to become realistic — they wrote `b"image"` with a
+      `b"hash"` sidecar, which is why the gap survived review.
+
 - [ ] Tier-1 edge path: the build → sign → export → install-on-another-host →
       admit → boot chain now runs end to end on aarch64, delivered through
       #1888 (ARM64 `Image` kernels reach Firecracker), #1891 (guest reads the

--- a/xtask/src/check_test_home_isolation.rs
+++ b/xtask/src/check_test_home_isolation.rs
@@ -56,16 +56,8 @@ const SEED_SITES: &[(&str, &str)] = &[
         "defines the resolver and owns the deliberate MVM_HOME bypass",
     ),
     (
-        "crates/mvm-build/src/libkrun_builder.rs",
-        "seeds the builder VM image from the host's shared cache",
-    ),
-    (
-        "crates/mvm-build/src/runtime_overlay.rs",
-        "seeds the runtime overlay from the host's shared cache",
-    ),
-    (
-        "crates/mvm-build/src/initramfs.rs",
-        "seeds the universal initramfs from the host's shared cache",
+        "crates/mvm-build/src/cache_install.rs",
+        "owns the only cross-root seed: the one derivation of the shared cache root",
     ),
     (
         "xtask/src/check_test_home_isolation.rs",
@@ -75,13 +67,17 @@ const SEED_SITES: &[(&str, &str)] = &[
 
 /// Symbols whose call reaches [`DEFAULT_CACHE_FN`]. A file naming any of
 /// them can seed from the real `$HOME`, so its tests must isolate `HOME`.
-/// `attach_runtime_overlay` is matched as a prefix so it also covers the
-/// `_if_cached` / `_if_cached_version` wrappers the CLI actually calls.
+/// `attach_runtime_overlay` and `attach_universal_initramfs` are matched as
+/// prefixes so they also cover the `_if_cached` / `_if_cached_version`
+/// wrappers the CLI actually calls.
 const SEED_ANCHORS: &[&str] = &[
     DEFAULT_CACHE_FN,
+    "default_cache_root",
+    "seed_on_miss",
     "ensure_builder_vm_image",
     "resolve_or_seed_from_default_cache",
     "attach_runtime_overlay",
+    "attach_universal_initramfs",
 ];
 
 /// Files exempt from `test-home-isolation`, with the reason.
@@ -321,7 +317,7 @@ mod tests {
     #[test]
     fn allows_declared_seed_sites_to_name_the_resolver() {
         let src = "fn seed() { let p = default_mvm_cache_dir(); }\n";
-        assert!(scan_source("crates/mvm-build/src/runtime_overlay.rs", src).is_empty());
+        assert!(scan_source("crates/mvm-build/src/cache_install.rs", src).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #1925, closes #1926, closes #1927, closes #1928.

#1923 has merged, so this is rebased onto `main` and targets it directly. #1928's fix shrinks the `check-test-home-isolation` allowlist that #1923 introduced.

## Why these four travelled together

They are one seam seen from four angles. Three artifacts — the builder VM image, the runtime overlay, the universal initramfs — each carried a private copy of the same cross-root seed sequence, and the copies had already drifted apart on the part that matters: what they verify.

`mvm_build::cache_install` now owns that sequence plus the single derivation of the default cache root.

## #1928 — one seed, and a tighter gate

Two consequences beyond deleting duplication:

- `default_mvm_cache_dir` — the only resolver that reads `$HOME` while `MVM_HOME` is set — is now named in **exactly one place** in the workspace.
- The `check-test-home-isolation` allowlist drops from four entries to two. The allowlist is a proxy for "how many places can do this at all", so the gate got tighter, not just tidier.

Test code routes through the same helper. That was not planned — the gate flagged four hand-rolled derivations still sitting in test bodies after the production move, which is a small demonstration of it working.

`seed_on_miss` takes the default-root probe as a closure returning `Option`, which puts "a host that has never built this has nothing to give" in the type instead of asking every caller to remember to swallow that error. `libkrun_builder` fits without contortion: its `validate_builder_vm_image_cache` pre-check *is* the probe, and a missing directory fails validation anyway, so its old separate `!is_dir()` guard folded in.

## #1925 — verify the initramfs, at the right place

`install_initramfs_into_cache` now checks the staged image against its `initramfs.hash` sidecar before the rename, so a corrupt artifact never becomes visible to a resolver. Two details shaped this:

- **The hash is SHA-256 of the *uncompressed* cpio; the size sidecar is the *compressed* length.** The two sidecars describe different bytes. Hashing `initramfs.cpio.gz` would never match, so this gunzips and streams. (The existing size check was correct as written.)
- **It runs at admission into a cache root, not on resolve.** Admission is the single choke point the download, local-build and cross-root seed paths all pass through. `resolve()` runs on every VM start, and this repo carries an interaction-latency gate and a warm-restore SLO — a decompress-and-hash per start is not affordable. Verifying on arrival *and* at every read is what the overlay does, but its sidecar is a plain file hash over 8 MB, not a decompress.

Scope note: `validate_builder_vm_image_cache` still ignores its `.mvm-artifacts.sha256` sidecar. Deliberately left alone — that rootfs is ~775 MB and hashing it on every builder start is a different tradeoff that deserves its own decision.

## #1926 — reap abandoned staging dirs

Installs stage into `<arch>.tmp.<pid>` and rename. The overlay's own doc comment already promised a stale staging dir "can be safely cleaned up by a future call"; nothing implemented it. A 6-day-old orphan was sitting in a dev host's cache.

Reaping keys on **age, not the pid in the name**: a portable pid-liveness check needs `libc` or `/proc`, and pid reuse makes it unreliable in the one direction that matters. Age can only ever be wrong by leaving litter one cycle longer — never by deleting a live install's staging directory. Best-effort throughout; reaping litter must never fail an install.

## #1927 — ask the resolver for its own layout

The initramfs seed recovered its source *directory* by taking `.parent()` of a resolved file path. It now asks `InitramfsResolver::artifact_dir`, which drops an `ok_or_else` arm that could not fire.

## The fixtures were the reason this survived review

Three fixtures wrote `b"image"` as the image with `b"hash"` as its sidecar — not gzip, not a hash of anything. A fixture encoding the assumption cannot falsify it, which is exactly why an unverified image went unnoticed. They now emit a real gzip stream with matching sidecars.

The tamper test is built so it **cannot pass for the wrong reason**: the substituted payload is chosen to compress to an identical length, and the test asserts that, so it fails the hash check rather than incidentally tripping the size check.

## Verification

- **Negative control on #1925**: removing the `verify_staged_image_hash` call makes the tamper test go **RED**; restoring it goes **GREEN**. The check is load-bearing, not decoration.
- **Negative control on the gate after the allowlist collapse**: a reintroduced `default_mvm_cache_dir()` call still produces hits; clean once reverted.
- **8129/8129 nextest, 0 failed**, on a host with a populated `~/.mvm` (re-run after rebasing onto a main that had gained #1918 and #1924).
- `cargo clippy --workspace --all-targets -- -D warnings` clean, doctests clean (15 crates), `check-single-home` / `check-test-home-isolation` / `check-no-spec-refs-in-comments` clean.

No new dependencies: `flate2`, `sha2` and `hex` were already dependencies of every crate involved.


## Follow-up filed, not fixed here

#1932 — the builder image's own cross-root seed drops its integrity sidecars (`.mvm-artifacts.sha256` and friends) and is never digest-verified. Investigating it corrected something I had assumed: that manifest *is* verified, by `mvm-cli`'s Stage 0 readiness check — just not on the `mvm-build` path the seed uses. The seeded copy also arrives without the sidecars, so it reads as not-ready to a later `mvmctl bootstrap`, which then rebuilds the ~775 MB it just copied.

Measured cost of digesting that image: 2.05 s for `rootfs.ext4` plus 0.058 s for `vmlinux`. `validate_builder_vm_image_cache` runs on every builder VM start, so verification belongs at admission there too — same conclusion as #1925. Left separate because sharing the existing digest logic means moving it from `mvm-cli` down into `mvm-build`, which is the bulk of that work.
