### PR TITLE
feat(qemu): converge onto the unified workload runner + vsock activation

### DIFF
--- a/crates/mvm-cli/src/commands/qemu_bridge.rs
+++ b/crates/mvm-cli/src/commands/qemu_bridge.rs
@@ -2,10 +2,14 @@
 //!
 //! Hidden helper spawned (detached) by the QEMU workload backend
 //! (`mvm_runtime::qemu`). QEMU's virtio-vsock speaks real AF_VSOCK, but
-//! the shared agent client connects to the per-port UNIX socket that
-//! libkrun/Firecracker expose. This process bridges the two: it listens
-//! on the UNIX socket and splices each connection to the guest's
-//! `AF_VSOCK(cid, port)`, exiting when the watched qemu process dies.
+//! the shared agent client and the runner's channel set are expressed as
+//! per-port UNIX sockets. This process bridges the two, in both
+//! directions, following the JSON `QemuBridgeSpec` the backend wrote next
+//! to the VM's pid file: it listens on each host-dialed UNIX socket and
+//! splices to the guest's `AF_VSOCK(cid, port)`, terminates each
+//! guest-dialed AF_VSOCK channel and splices to its runner-bound UNIX
+//! listener, captures the workload-exit report, and exits when the watched
+//! qemu process dies.
 //!
 //! The AF_VSOCK + splice logic lives in `mvm_runtime::qemu` (beside the
 //! backend that needs it); this is just the argument surface + forward.
@@ -16,20 +20,11 @@ use std::path::PathBuf;
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
-    /// UNIX socket to listen on (the agent client connects here).
+    /// Path to the JSON `QemuBridgeSpec` the backend wrote for this VM.
     #[arg(long)]
-    uds: PathBuf,
-    /// Guest CID to dial over AF_VSOCK.
-    #[arg(long)]
-    cid: u32,
-    /// Guest vsock port to dial.
-    #[arg(long)]
-    port: u32,
-    /// Exit when this PID file's process is no longer alive (the VM is gone).
-    #[arg(long)]
-    watch_pid_file: PathBuf,
+    spec: PathBuf,
 }
 
 pub(in crate::commands) fn run(args: &Args) -> Result<()> {
-    mvm_runtime::qemu::run_vsock_bridge(&args.uds, args.cid, args.port, &args.watch_pid_file)
+    mvm_runtime::qemu::run_vsock_bridge_from_spec_file(&args.spec)
 }

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -4129,14 +4129,8 @@ fn internal_helper_commands_short_circuit_before_startup_side_effects() {
     assert!(exits_early(&[
         "mvmctl",
         "__qemu-vsock-bridge",
-        "--uds",
-        "/tmp/bridge.sock",
-        "--cid",
-        "3",
-        "--port",
-        "5252",
-        "--watch-pid-file",
-        "/tmp/qemu.pid",
+        "--spec",
+        "/tmp/qemu-vsock-bridge.json",
     ]));
     assert!(!exits_early(&["mvmctl", "doctor"]));
     assert!(!exits_early(&[

--- a/crates/mvm-core/src/exit_capture.rs
+++ b/crates/mvm-core/src/exit_capture.rs
@@ -36,8 +36,20 @@ pub fn capture_once(
     listener: &std::os::unix::net::UnixListener,
     vm_state_dir: &Path,
 ) -> std::io::Result<i32> {
-    use std::io::Read as _;
-    let (mut stream, _addr) = listener.accept()?;
+    let (stream, _addr) = listener.accept()?;
+    capture_stream(stream, vm_state_dir)
+}
+
+/// Read one guest exit report (4-byte LE i32) from an already-connected
+/// stream, persist it to `<vm_state_dir>/workload.exit`, and ack. Returns
+/// the code. The stream half of [`capture_once`], split out so a capture
+/// site whose control channel is not a `UnixListener` (e.g. an accepted
+/// AF_VSOCK connection) persists and acks with the identical protocol and
+/// file-then-ack ordering.
+pub fn capture_stream(
+    mut stream: impl std::io::Read + std::io::Write,
+    vm_state_dir: &Path,
+) -> std::io::Result<i32> {
     let mut buf = [0u8; 4];
     stream.read_exact(&mut buf)?;
     let code = i32::from_le_bytes(buf);
@@ -46,7 +58,6 @@ pub fn capture_once(
     // powering off, so a supervisor's start_enter->exit() can't race the file
     // write. Best-effort — a failed ack just means the guest times out and
     // powers off (file already written).
-    use std::io::Write as _;
     let _ = stream.write_all(&[1u8]);
     let _ = stream.flush();
     Ok(code)
@@ -94,5 +105,23 @@ mod tests {
         handle.join().unwrap();
         assert_eq!(code, -7);
         assert_eq!(read_captured(dir.path()), Some(-7));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capture_stream_persists_le_i32_from_any_connected_stream() {
+        use std::io::Write;
+        use std::os::unix::net::UnixStream;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (mut guest, host) = UnixStream::pair().unwrap();
+        let handle = std::thread::spawn(move || {
+            guest.write_all(&42i32.to_le_bytes()).unwrap();
+        });
+
+        let code = capture_stream(host, dir.path()).unwrap();
+        handle.join().unwrap();
+        assert_eq!(code, 42);
+        assert_eq!(read_captured(dir.path()), Some(42));
     }
 }

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -10,12 +10,11 @@ use mvm_core::vm_backend::{
 // (`config`, `shell`, `runtime_meta`) lives in `crate::base`.
 use crate::base::config::{PortMapping, VmSlot};
 use crate::base::shell::run_in_vm_stdout;
-use crate::driver::{FcDriver, HvfDriver, LibkrunDriver};
+use crate::driver::{FcDriver, HvfDriver, LibkrunDriver, QemuDriver};
 use crate::image::RuntimeVolume;
 use crate::microvm::{DriveFile, FlakeRunConfig};
 #[cfg(feature = "test-support")]
 use crate::mock::MockBackend;
-use crate::qemu::QemuBackend;
 use crate::wasm_backend::WasmBackend;
 use crate::workload_runner::{RealBrokerRegistrar, RealEndpointSpawner, WorkloadRunner};
 use crate::{firecracker, microvm};
@@ -55,6 +54,23 @@ pub(crate) fn libkrun_runner() -> LibkrunRunner {
         RealEndpointSpawner,
         RealBrokerRegistrar,
     )
+}
+
+/// QEMU (Linux dev/test substrate; KVM where present, TCG fallback) driven
+/// through the same unified workload-runner role — qemu's sole workload launch
+/// path (`--hypervisor qemu` / `MVM_BACKEND=qemu`; `auto_select` never picks
+/// it). NIC-less: the converged boot attaches no slirp user-mode network, so
+/// egress routes to the per-VM gating endpoint over vsock only, through the
+/// per-VM AF_VSOCK↔UNIX bridge. The raw [`QemuBackend`](crate::qemu::QemuBackend)
+/// stays behind the driver as its identity delegate, unreached via this enum.
+type QemuRunner = WorkloadRunner<QemuDriver, RealEndpointSpawner, RealBrokerRegistrar>;
+
+/// Construct QEMU's workload runner. Like [`libkrun_runner`] the runner is not
+/// const-constructible, so this helper is the one construction site the enum
+/// variant, `from_build_output`, the descriptor catalog, and the capability
+/// selector all call.
+pub(crate) fn qemu_runner() -> QemuRunner {
+    WorkloadRunner::new(QemuDriver::new(), RealEndpointSpawner, RealBrokerRegistrar)
 }
 
 /// Firecracker (Linux KVM) driven through the same unified workload-runner role
@@ -377,11 +393,16 @@ pub enum AnyBackend {
     /// the endpoint); no transparent `:80/:443` terminator.
     Libkrun(LibkrunRunner),
     /// QEMU workload runtime — Linux dev/test substrate (KVM where
-    /// present, TCG fallback). Opt-in via `--hypervisor qemu` /
-    /// `MVM_BACKEND=qemu`; `auto_select` never picks it (Firecracker
-    /// stays the production runtime). Dev tier only, outside the
-    /// security claims.
-    Qemu(QemuBackend),
+    /// present, TCG fallback), driven through the unified `WorkloadRunner`
+    /// over the driver seam — qemu's sole workload path, selected by
+    /// `--hypervisor qemu` / `MVM_BACKEND=qemu`; `auto_select` never picks
+    /// it (Firecracker stays the production runtime). The boot attaches the
+    /// universal initramfs and receives `ActivateEnvironment` over vsock
+    /// (via the AF_VSOCK↔UNIX bridge), exactly like the other runner
+    /// backends. Dev tier only, outside the security claims. The raw
+    /// [`QemuBackend`](crate::qemu::QemuBackend) stays behind the driver as
+    /// its identity delegate, unreached via this enum.
+    Qemu(QemuRunner),
     /// In-memory mock — test-only. Records `start`/`stop`/`pause`/
     /// `resume` calls against a `Mutex<HashMap>` and never touches
     /// the host. Selected only via explicit `--hypervisor mock`;
@@ -423,7 +444,7 @@ impl AnyBackend {
     /// backend (TCG where KVM is absent); otherwise Firecracker.
     pub fn from_build_output(has_runner: bool) -> Self {
         if has_runner {
-            Self::Qemu(QemuBackend)
+            Self::Qemu(qemu_runner())
         } else {
             Self::Firecracker(fc_runner())
         }
@@ -1575,7 +1596,7 @@ mod tests {
         let mut backends: Vec<(&str, AnyBackend)> = vec![
             ("firecracker", AnyBackend::Firecracker(fc_runner())),
             ("libkrun", AnyBackend::Libkrun(libkrun_runner())),
-            ("qemu", AnyBackend::Qemu(QemuBackend)),
+            ("qemu", AnyBackend::Qemu(qemu_runner())),
             ("hvf", AnyBackend::Hvf(hvf_runner())),
         ];
         backends.extend(mock_variant_for_ssh_check());

--- a/crates/mvm-runtime/src/catalog.rs
+++ b/crates/mvm-runtime/src/catalog.rs
@@ -15,7 +15,6 @@
 use crate::backend::{AnyBackend, BackendTier};
 #[cfg(feature = "test-support")]
 use crate::mock::MockBackend;
-use crate::qemu::QemuBackend;
 use crate::wasm_backend::WasmBackend;
 use mvm_core::vm_backend::VmBackend;
 
@@ -181,7 +180,7 @@ backend_catalog![
         kind: Qemu,
         selector: "qemu",
         aliases: [],
-        constructor: AnyBackend::Qemu(QemuBackend),
+        constructor: AnyBackend::Qemu(crate::backend::qemu_runner()),
         tier: Tier2,
         marker_file: Some("qemu.pid"),
         started_vm_probe_order: Some(1),

--- a/crates/mvm-runtime/src/driver/mod.rs
+++ b/crates/mvm-runtime/src/driver/mod.rs
@@ -6,6 +6,7 @@ pub mod fc;
 pub mod hvf;
 pub mod libkrun;
 pub mod mock;
+pub mod qemu;
 pub mod spec;
 pub mod traits;
 
@@ -13,5 +14,6 @@ pub use fc::FcDriver;
 pub use hvf::HvfDriver;
 pub use libkrun::LibkrunDriver;
 pub use mock::{MockDriver, MockRunningVm};
+pub use qemu::QemuDriver;
 pub use spec::{BlockDev, ConsoleCapture, KernelImage, VmmSpec, VsockDirection, VsockPort};
 pub use traits::{ChildForkRequest, DuplexStream, RunningVm, StandbyParentSpawn, VmmDriver};

--- a/crates/mvm-runtime/src/driver/qemu.rs
+++ b/crates/mvm-runtime/src/driver/qemu.rs
@@ -1,0 +1,863 @@
+//! `QemuDriver` — the `VmmDriver` for the QEMU dev/test VMM (Linux; KVM
+//! where present, TCG software-emulation fallback otherwise). Identity and
+//! capabilities delegate to the proven [`QemuBackend`]. `boot` maps a
+//! policy-free `VmmSpec` to `qemu-system` argv reusing the raw backend's
+//! machinery (guest-CID allocation, argv assembly, pid-file lifecycle),
+//! spawns the detached AF_VSOCK↔UNIX bridge set so the host reaches the
+//! guest agent and the guest reaches its egress/exit/broker channels, and
+//! returns a live handle. The claim-10 egress gate and secret substitution
+//! live in the host-side endpoint the runner binds to the spec's
+//! `EGRESS_PORT` socket; the driver only relays that channel through the
+//! bridge — it carries no policy and never sees a `NetworkPolicy`.
+//!
+//! No NIC: the converged spec carries no networking (a guest's only path
+//! off the box is the gated vsock egress endpoint), so the slirp
+//! user-mode network the raw backend attaches is deliberately absent here —
+//! the same NIC-less posture the other runner drivers boot.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow, bail};
+use mvm_agentd::vsock::{
+    CONSOLE_PORT_BASE, GUEST_AGENT_PORT, WORKLOAD_EXIT_PORT, dev_console_data_ports,
+};
+use mvm_core::config::{vm_state_dir, vm_vsock_port_socket_at};
+use mvm_core::vm_backend::{
+    BackendKind, BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, VmBackend,
+    VmCapabilities, VmExitStatus, VmId, VmStatus,
+};
+
+use crate::base::ui;
+use crate::driver::spec::KernelImage;
+use crate::driver::{DuplexStream, RunningVm, VmmDriver, VmmSpec, VsockDirection, VsockPort};
+use crate::libkrun::open_console_capture;
+use crate::qemu::{
+    self, QEMU_LOG_FILE, QEMU_PID_FILE, QemuBackend, QemuBridgeGuestDial, QemuBridgeHostDial,
+    QemuBridgeSpec,
+};
+
+/// The QEMU VMM driver: pure VMM mechanics, no policy and no admission. It
+/// boots what a `VmmSpec` describes and relays the guest's channels through
+/// the vsock bridge; the claim-10 gate and substitution live in the
+/// endpoint behind those channels, not here.
+pub struct QemuDriver {
+    backend: QemuBackend,
+}
+
+impl QemuDriver {
+    pub fn new() -> Self {
+        Self {
+            backend: QemuBackend,
+        }
+    }
+}
+
+impl Default for QemuDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The default base kernel cmdline for a QEMU workload boot. QEMU guests use
+/// the `ttyS0` serial console (same serial line Firecracker uses), and carry
+/// no NIC tokens — the converged path attaches no guest NIC. The root/init
+/// selection follows the boot shape; the shared cmdline assembler layers
+/// verity/grants/egress/uvols tokens on top of this.
+fn qemu_base_bootargs(virtiofs_root: bool, has_disk: bool) -> String {
+    // Serial console + reboot/panic behavior + stable interface naming.
+    let console = "console=ttyS0 reboot=k panic=1 net.ifnames=0";
+    if virtiofs_root {
+        format!("{console} rootfstype=virtiofs root=mvmroot rw init=/init")
+    } else if has_disk {
+        format!("{console} root=/dev/vda rw rootwait init=/init")
+    } else {
+        // Verity / initramfs boot: the initramfs PID 1 owns root/init selection,
+        // so only the serial-console base is emitted here.
+        console.to_string()
+    }
+}
+
+/// Assemble the `qemu-system` argv for a spec boot (everything after the
+/// binary name). Pure so the whole spec→argv mapping is unit-testable
+/// without a hypervisor. No `-netdev`: the converged spec carries no NIC.
+fn qemu_boot_argv(
+    spec: &VmmSpec,
+    kernel: &Path,
+    cid: u32,
+    kvm: bool,
+    pid_file: &Path,
+) -> Vec<String> {
+    let mut args: Vec<String> = Vec::new();
+    args.push("-m".into());
+    args.push(spec.memory_mib.to_string());
+    let vcpus = spec.vcpus.clamp(1, u32::from(u8::MAX));
+    args.push("-smp".into());
+    args.push(vcpus.to_string());
+    if kvm {
+        args.push("-enable-kvm".into());
+        args.push("-cpu".into());
+        args.push("host".into());
+    } else {
+        args.push("-cpu".into());
+        args.push("max".into());
+    }
+    args.push("-kernel".into());
+    args.push(kernel.to_string_lossy().into_owned());
+    if let Some(initramfs) = &spec.initramfs {
+        args.push("-initrd".into());
+        args.push(initramfs.to_string_lossy().into_owned());
+    }
+    // An empty spec cmdline means "the driver supplies its own default base";
+    // a non-empty one already carries the console + root/init base plus every
+    // layered token, so it is threaded verbatim.
+    let has_disk = spec.initramfs.is_none() && !spec.blocks.is_empty();
+    let trimmed = spec.cmdline.trim();
+    let cmdline = if trimmed.is_empty() {
+        qemu_base_bootargs(false, has_disk)
+    } else {
+        trimmed.to_string()
+    };
+    args.push("-append".into());
+    args.push(cmdline);
+
+    // Slot-ordered virtio-blk layout: the guest device letters follow the
+    // `-drive` order (first → /dev/vda, next → /dev/vdb, …), so the device
+    // nodes line up with the slot model the activation message names. QEMU
+    // serves every disk from its host file — there is no RAM-backed mode, so
+    // `BlockDev::ephemeral` is not representable here; workload blocks are
+    // read-only + non-ephemeral, so nothing is dropped.
+    let mut ordered: Vec<&crate::driver::BlockDev> = spec.blocks.iter().collect();
+    ordered.sort_by_key(|b| b.slot);
+    for block in ordered {
+        let mut drive = format!("file={},if=virtio,format=raw", block.source.display());
+        if block.read_only {
+            drive.push_str(",readonly=on");
+        }
+        args.push("-drive".into());
+        args.push(drive);
+    }
+
+    // virtio-vsock on the per-VM guest CID. The host reaches the guest's
+    // listeners through the AF_VSOCK↔UNIX bridge spawned after the boot.
+    args.push("-device".into());
+    args.push(format!("vhost-vsock-pci,guest-cid={cid}"));
+
+    args.push("-display".into());
+    args.push("none".into());
+    args.push("-monitor".into());
+    args.push("none".into());
+    args.push("-no-reboot".into());
+    // Write-only console sink (claim 15): qemu opens `-serial file:` for
+    // output only; there is no host fd from which the guest could read
+    // console input.
+    args.push("-serial".into());
+    args.push(format!("file:{}", spec.console.log_path.display()));
+    args.push("-D".into());
+    args.push(
+        pid_file
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(QEMU_LOG_FILE)
+            .to_string_lossy()
+            .into_owned(),
+    );
+    // qemu forks into the background and writes its own pidfile.
+    args.push("-daemonize".into());
+    args.push("-pidfile".into());
+    args.push(pid_file.to_string_lossy().into_owned());
+    args
+}
+
+/// Assemble the bridge wiring plan for a spec boot: every host-dialed
+/// channel (agent RPC, dev console data) binds the per-port UNIX socket
+/// convention the shared client probes, every guest-dialed channel (egress,
+/// broker) splices to the runner-bound listener named in the spec, and the
+/// workload-exit port is captured under the state dir when the spec carries
+/// it.
+fn bridge_spec_for_vsock(cid: u32, state_dir: &Path, channels: &[VsockPort]) -> QemuBridgeSpec {
+    let mut host_dials = Vec::new();
+    let mut guest_dials = Vec::new();
+    let mut exit_capture_state_dir = None;
+    for port in channels {
+        match port.direction {
+            VsockDirection::HostDials => host_dials.push(QemuBridgeHostDial {
+                guest_port: port.guest_port,
+                // Re-derived from the state dir (the flat `vsock-<port>.sock`
+                // convention the host-side resolver probes), never the spec's
+                // backend-neutral hint — the same discipline the hvf, libkrun,
+                // and Firecracker drivers apply to the agent socket, so binder
+                // and resolver can't drift.
+                listen_uds: vm_vsock_port_socket_at(state_dir, port.guest_port),
+            }),
+            // The workload-exit port has no runner-bound listener — its
+            // `host_uds` is the captured-code output file, not a socket. The
+            // bridge accepts the report and persists it (see qemu.rs).
+            VsockDirection::GuestDials if port.guest_port == WORKLOAD_EXIT_PORT => {
+                exit_capture_state_dir = Some(state_dir.to_path_buf());
+            }
+            VsockDirection::GuestDials => guest_dials.push(QemuBridgeGuestDial {
+                guest_port: port.guest_port,
+                target_uds: port.host_uds.clone(),
+            }),
+        }
+    }
+    QemuBridgeSpec {
+        cid,
+        watch_pid_file: state_dir.join(QEMU_PID_FILE),
+        host_dials,
+        guest_dials,
+        exit_capture_state_dir,
+    }
+}
+
+impl VmmDriver for QemuDriver {
+    fn name(&self) -> &str {
+        self.backend.name()
+    }
+
+    fn kind(&self) -> BackendKind {
+        self.backend.kind()
+    }
+
+    fn is_available(&self) -> Result<bool> {
+        self.backend.is_available()
+    }
+
+    fn capabilities(&self) -> VmCapabilities {
+        // The runner-backed, NIC-less profile: the converged QEMU boot
+        // attaches no slirp user-mode network (the raw backend's dev
+        // convenience), so nothing in the guest can reach the network by IP
+        // and egress rides the vsock endpoint exactly like the other runner
+        // backends. Pause/resume stays false (no QMP monitor wired);
+        // snapshots and the standby pool stay unsupported.
+        let mut capabilities = self.backend.capabilities();
+        capabilities.no_routable_guest_nic = true;
+        capabilities.host_vsock_proxy = true;
+        capabilities
+    }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        // Same claim coverage as the raw backend — Tier 2 best-case (KVM),
+        // claim 3 (verified boot) targeting Firecracker — with the notes
+        // updated for the converged boot path. The TCG (no-KVM) mode is a
+        // runtime Tier-3 degradation surfaced by the boot banner + doctor,
+        // not by this compile-time tier.
+        BackendSecurityProfile {
+            claims: [
+                ClaimStatus::Holds,       // 1
+                ClaimStatus::Holds,       // 2
+                ClaimStatus::DoesNotHold, // 3 — verified boot targets Firecracker
+                ClaimStatus::Holds,       // 4
+                ClaimStatus::Holds,       // 5
+                ClaimStatus::Holds,       // 6
+                ClaimStatus::Holds,       // 7
+            ],
+            layer_coverage: LayerCoverage::all_layers(),
+            tier: "Tier 2",
+            notes: &[
+                "QEMU workload runtime; dev/test tier only, opt-in via --hypervisor qemu, never auto-selected.",
+                "Boots through the unified workload runner: attaches the universal initramfs and \
+                 receives ActivateEnvironment over vsock, exactly like Firecracker/libkrun/HVF — \
+                 QEMU's vhost-vsock speaks AF_VSOCK, so the channels ride the per-VM \
+                 AF_VSOCK↔UNIX bridge into the same per-port UNIX-socket convention.",
+                "KVM-accelerated where /dev/kvm is present; TCG software-emulation fallback \
+                 otherwise (runtime Tier-3, banner-flagged).",
+                "Larger device model than Firecracker → higher L2 audit cost; outside the \
+                 CI-enforced claim set. Never a production runtime.",
+            ],
+        }
+    }
+
+    fn workload_base_bootargs(&self, virtiofs_root: bool, has_disk: bool) -> String {
+        qemu_base_bootargs(virtiofs_root, has_disk)
+    }
+
+    fn boot(&self, spec: &VmmSpec) -> Result<Box<dyn RunningVm>> {
+        // QEMU has no bundled kernel (libkrun's libkrunfw is the only
+        // bundled-kernel backend): a `Bundled` spec takes the same cached
+        // builder-kernel fallback the raw path uses for a kernel-less
+        // workload rootfs.
+        let kernel = match &spec.kernel {
+            KernelImage::Path(p) => p.clone(),
+            KernelImage::Bundled => qemu::resolve_workload_kernel_path(&spec.name, None)?,
+        };
+        let qemu_bin = qemu::locate_qemu()?;
+
+        let state_dir = vm_state_dir(&spec.name);
+        std::fs::create_dir_all(&state_dir)
+            .map_err(|e| anyhow!("create state dir {}: {e}", state_dir.display()))?;
+        // Clear any prior run's captured exit code so `wait` reads only this
+        // launch's, and pre-create the write-only console sink so the
+        // invariant + truncate-on-boot match the other backends.
+        let _ = std::fs::remove_file(mvm_core::exit_capture::exit_file_path(&state_dir));
+        drop(
+            open_console_capture(&spec.console.log_path).map_err(|e| {
+                anyhow!("open console sink {}: {e}", spec.console.log_path.display())
+            })?,
+        );
+
+        let kvm = qemu::kvm_available();
+        if !kvm {
+            // Loud Tier-3 banner for the unaccelerated TCG fallback — the
+            // same runtime-tier signal the raw path emits.
+            ui::warn(&format!(
+                "QEMU workload '{}' is running UNACCELERATED (TCG — no /dev/kvm). \
+                 This is a Tier-3 dev/test fallback: slow, and unaudited vs the \
+                 production security posture. For production use a /dev/kvm host \
+                 (Firecracker).",
+                spec.name
+            ));
+        }
+
+        let cid = qemu::allocate_cid(&spec.name)?;
+        let pid_file = state_dir.join(QEMU_PID_FILE);
+        let _ = std::fs::remove_file(&pid_file);
+
+        let argv = qemu_boot_argv(spec, &kernel, cid, kvm, &pid_file);
+        let status = Command::new(&qemu_bin)
+            .args(&argv)
+            .status()
+            .map_err(|e| anyhow!("spawn qemu ({qemu_bin}): {e}"))?;
+        if !status.success() {
+            bail!(
+                "qemu-system exited {} before daemonizing workload '{}'; see {}",
+                status.code().unwrap_or(-1),
+                spec.name,
+                state_dir.join(QEMU_LOG_FILE).display()
+            );
+        }
+
+        // `-daemonize` returns only after the pidfile is written, but poll
+        // defensively so a slow fork doesn't race the bridge spawn below.
+        let deadline = Instant::now() + qemu::PID_FILE_TIMEOUT;
+        while !pid_file.exists() {
+            if Instant::now() >= deadline {
+                bail!(
+                    "qemu did not write pidfile {} within {:?}",
+                    pid_file.display(),
+                    qemu::PID_FILE_TIMEOUT
+                );
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        // Wire the whole channel set through the bridge. If the bridge can't
+        // come up, the already-daemonized qemu would be orphaned (a failed
+        // `boot` won't be followed by `stop`). Roll back: kill qemu + drop
+        // the pid/cid sidecars so a retry re-allocates a CID instead of
+        // pinning the (possibly conflicting) one this attempt wrote.
+        let bridge_spec = bridge_spec_for_vsock(cid, &state_dir, &spec.vsock);
+        if let Err(e) = qemu::spawn_vsock_bridges(&spec.name, &state_dir, &bridge_spec) {
+            if let Some(pid) = qemu::read_pid(&pid_file) {
+                qemu::send_signal(pid, libc::SIGTERM);
+            }
+            let _ = std::fs::remove_file(&pid_file);
+            let _ = std::fs::remove_file(state_dir.join(qemu::QEMU_CID_FILE));
+            return Err(e);
+        }
+
+        Ok(Box::new(QemuRunningVm {
+            id: VmId(spec.name.clone()),
+            state_dir,
+            pid_file,
+        }))
+    }
+
+    fn attach(&self, id: &VmId) -> Result<Box<dyn RunningVm>> {
+        // The handle is entirely disk-backed (the qemu pid file + the
+        // persisted workload-exit code under the VM's state dir), so
+        // reattaching is just re-deriving those paths — no live boot state
+        // to recover.
+        let state_dir = vm_state_dir(&id.0);
+        Ok(Box::new(QemuRunningVm {
+            pid_file: state_dir.join(QEMU_PID_FILE),
+            state_dir,
+            id: id.clone(),
+        }))
+    }
+
+    fn guest_channel_info(&self, id: &VmId) -> Result<GuestChannelInfo> {
+        self.backend.guest_channel_info(id)
+    }
+}
+
+/// A live QEMU VM: the daemonized `qemu-system` process tracked by its PID
+/// file, with the workload's exit code persisted under its state dir and the
+/// detached bridge serving its vsock channels.
+struct QemuRunningVm {
+    id: VmId,
+    state_dir: PathBuf,
+    pid_file: PathBuf,
+}
+
+impl RunningVm for QemuRunningVm {
+    fn id(&self) -> &VmId {
+        &self.id
+    }
+
+    fn wait(&self) -> Result<VmExitStatus> {
+        Ok(crate::workload_wait::wait_for_workload_exit(
+            &self.state_dir,
+        ))
+    }
+
+    fn kill(&self) -> Result<()> {
+        // Reap the bridge first so it can't keep serving a half-dead VM.
+        // Guard on liveness so a stale pidfile (crash without cleanup) whose
+        // PID the OS has since recycled isn't signalled by mistake.
+        if let Some(bridge_pid) = qemu::read_pid(&self.state_dir.join(qemu::BRIDGE_PID_FILE))
+            && qemu::pid_alive(bridge_pid)
+        {
+            qemu::send_signal(bridge_pid, libc::SIGTERM);
+        }
+        let _ = std::fs::remove_file(self.state_dir.join(qemu::BRIDGE_PID_FILE));
+
+        // SIGTERM → grace → SIGKILL, the escalation the raw stop path uses:
+        // SIGTERM gives qemu a chance to close its virtio-blk fds, then
+        // SIGKILL if it ignores us within the grace window.
+        if let Some(pid) = qemu::read_pid(&self.pid_file)
+            && qemu::pid_alive(pid)
+        {
+            qemu::send_signal(pid, libc::SIGTERM);
+            let deadline = Instant::now() + qemu::STOP_TIMEOUT;
+            while Instant::now() < deadline && qemu::pid_alive(pid) {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            if qemu::pid_alive(pid) {
+                qemu::send_signal(pid, libc::SIGKILL);
+            }
+        }
+        let _ = std::fs::remove_file(&self.pid_file);
+        Ok(())
+    }
+
+    fn pause(&self) -> Result<()> {
+        bail!("pause is not supported by the qemu backend (QMP monitor not wired)")
+    }
+
+    fn resume(&self) -> Result<()> {
+        bail!("resume is not supported by the qemu backend (QMP monitor not wired)")
+    }
+
+    fn status(&self) -> Result<VmStatus> {
+        Ok(match qemu::read_pid(&self.pid_file) {
+            Some(pid) if qemu::pid_alive(pid) => VmStatus::Running,
+            _ => VmStatus::Stopped,
+        })
+    }
+
+    fn vsock_connect(&self, guest_port: u32) -> Result<Box<dyn DuplexStream>> {
+        // The bridge binds every host-dialed channel on the flat
+        // `<state_dir>/vsock-<port>.sock` convention — the same path the
+        // host-side resolver probes. Restricted to the agent port and the
+        // dev-only console data ports (claim 15: a sealed prod boot
+        // registers no console listeners), mirroring the other drivers'
+        // allow-list.
+        if guest_port != GUEST_AGENT_PORT && !dev_console_data_ports().any(|p| p == guest_port) {
+            bail!(
+                "qemu driver vsock_connect supports only the agent port \
+                 ({GUEST_AGENT_PORT}) and dev console data ports ({}..={}); got {guest_port}",
+                CONSOLE_PORT_BASE + 1,
+                CONSOLE_PORT_BASE + 128,
+            );
+        }
+        let socket_path = vm_vsock_port_socket_at(&self.state_dir, guest_port);
+        let stream = std::os::unix::net::UnixStream::connect(&socket_path).with_context(|| {
+            format!(
+                "connect to qemu vsock bridge socket {}",
+                socket_path.display()
+            )
+        })?;
+        Ok(Box::new(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::{BlockDev, ConsoleCapture};
+    use mvm_agentd::vsock::{BROKER_PORT, EGRESS_PORT};
+    use mvm_core::vm_backend::SnapshotCapability;
+
+    fn host_dials(guest_port: u32, uds: &str) -> VsockPort {
+        VsockPort {
+            guest_port,
+            host_uds: uds.into(),
+            direction: VsockDirection::HostDials,
+        }
+    }
+
+    fn guest_dials(guest_port: u32, uds: &str) -> VsockPort {
+        VsockPort {
+            guest_port,
+            host_uds: uds.into(),
+            direction: VsockDirection::GuestDials,
+        }
+    }
+
+    fn spec_with(kernel: KernelImage, vsock: Vec<VsockPort>, blocks: Vec<BlockDev>) -> VmmSpec {
+        VmmSpec {
+            name: "w".into(),
+            kernel,
+            initramfs: Some("/img/initramfs.cpio.gz".into()),
+            cmdline: String::new(),
+            vcpus: 2,
+            memory_mib: 512,
+            mem_initial_mib: None,
+            blocks,
+            vsock,
+            console: ConsoleCapture {
+                log_path: "/state/w/console.log".into(),
+            },
+            trusted_builder: false,
+        }
+    }
+
+    fn block(source: &str, read_only: bool, slot: u8) -> BlockDev {
+        BlockDev {
+            source: source.into(),
+            read_only,
+            ephemeral: false,
+            slot,
+        }
+    }
+
+    fn argvalue<'a>(argv: &'a [String], flag: &str) -> Option<&'a str> {
+        argv.iter()
+            .position(|a| a == flag)
+            .and_then(|i| argv.get(i + 1))
+            .map(String::as_str)
+    }
+
+    #[test]
+    fn identity_and_capabilities_delegate_then_flip_to_the_nic_less_profile() {
+        let d = QemuDriver::new();
+        assert_eq!(d.name(), "qemu");
+        assert_eq!(d.kind(), BackendKind::Qemu);
+        let caps = d.capabilities();
+        assert!(caps.vsock);
+        // The converged boot attaches no slirp NIC: no routable guest NIC,
+        // egress rides the vsock endpoint like every other runner backend.
+        assert!(caps.no_routable_guest_nic);
+        assert!(caps.host_vsock_proxy);
+        assert!(!caps.tap_networking);
+        assert!(!caps.pause_resume);
+        assert!(!caps.snapshots);
+        assert_eq!(caps.snapshot_capability, SnapshotCapability::Unsupported);
+        assert!(!caps.standby_pool);
+    }
+
+    #[test]
+    fn security_profile_matches_the_raw_backend_claims_with_runner_notes() {
+        let d = QemuDriver::new();
+        let profile = d.security_profile();
+        assert!(profile.tier.starts_with("Tier 2"));
+        // Claim 3 (verified boot) targets Firecracker — same coverage as the
+        // raw backend reports.
+        assert_eq!(profile.dropped_claims(), vec![3]);
+        assert_eq!(
+            format!("{:?}", profile.claims),
+            format!("{:?}", QemuBackend.security_profile().claims)
+        );
+        assert!(
+            profile
+                .notes
+                .iter()
+                .any(|n| n.contains("ActivateEnvironment")),
+            "notes must record the unified vsock-activation boot path"
+        );
+    }
+
+    #[test]
+    fn base_bootargs_follow_the_boot_shape_with_no_nic_or_roothash_tokens() {
+        let d = QemuDriver::new();
+        let disk = d.workload_base_bootargs(false, true);
+        assert!(disk.contains("console=ttyS0"), "got: {disk}");
+        assert!(disk.contains("root=/dev/vda"), "got: {disk}");
+        assert!(disk.contains("init=/init"), "got: {disk}");
+        assert!(!disk.contains("mvm.roothash="), "got: {disk}");
+        assert!(!disk.contains("mvm.ip="), "got: {disk}");
+
+        // Verity / initramfs base: serial console only, no root/init token.
+        let verity = d.workload_base_bootargs(false, false);
+        assert!(!verity.contains("root="), "got: {verity}");
+        assert!(!verity.contains("init=/init"), "got: {verity}");
+        assert!(verity.contains("console=ttyS0"), "got: {verity}");
+
+        let virtiofs = d.workload_base_bootargs(true, false);
+        assert!(virtiofs.contains("console=ttyS0"), "got: {virtiofs}");
+        assert!(virtiofs.contains("rootfstype=virtiofs"), "got: {virtiofs}");
+        assert!(virtiofs.contains("root=mvmroot"), "got: {virtiofs}");
+    }
+
+    #[test]
+    fn argv_maps_the_spec_verbatim_and_carries_no_nic() {
+        let spec = spec_with(
+            KernelImage::Path("/img/vmlinux".into()),
+            vec![],
+            vec![
+                // Out of slot order, mixed read-only policy — proves sorting
+                // and per-disk flags land in device-letter order.
+                block("/img/rootfs.verity", true, 1),
+                block("/img/rootfs.ext4", true, 0),
+                block("/vol/data.img", false, 2),
+            ],
+        );
+        let spec = VmmSpec {
+            cmdline: "  console=ttyS0 mvm.runtime_source_policy=required_overlay  ".into(),
+            ..spec
+        };
+        let argv = qemu_boot_argv(
+            &spec,
+            Path::new("/img/vmlinux"),
+            7,
+            true,
+            Path::new("/state/w/qemu.pid"),
+        );
+
+        assert_eq!(argvalue(&argv, "-kernel"), Some("/img/vmlinux"));
+        assert_eq!(argvalue(&argv, "-initrd"), Some("/img/initramfs.cpio.gz"));
+        // Non-empty spec cmdline is threaded verbatim (trimmed).
+        assert_eq!(
+            argvalue(&argv, "-append"),
+            Some("console=ttyS0 mvm.runtime_source_policy=required_overlay")
+        );
+        assert_eq!(argvalue(&argv, "-m"), Some("512"));
+        assert_eq!(argvalue(&argv, "-smp"), Some("2"));
+        assert!(argv.contains(&"-enable-kvm".to_string()));
+        assert_eq!(argvalue(&argv, "-cpu"), Some("host"));
+
+        // Drives in slot order (device letters follow -drive order), each
+        // carrying its own read-only policy.
+        let drives: Vec<&str> = argv
+            .iter()
+            .zip(argv.iter().skip(1))
+            .filter(|(flag, _)| flag.as_str() == "-drive")
+            .map(|(_, value)| value.as_str())
+            .collect();
+        assert_eq!(
+            drives,
+            vec![
+                "file=/img/rootfs.ext4,if=virtio,format=raw,readonly=on",
+                "file=/img/rootfs.verity,if=virtio,format=raw,readonly=on",
+                "file=/vol/data.img,if=virtio,format=raw",
+            ]
+        );
+
+        // virtio-vsock on the allocated guest CID; no NIC of any kind.
+        assert!(
+            argv.iter().any(|a| a == "vhost-vsock-pci,guest-cid=7"),
+            "argv: {argv:?}"
+        );
+        assert!(!argv.iter().any(|a| a == "-netdev"), "argv: {argv:?}");
+        assert!(
+            !argv.iter().any(|a| a.contains("virtio-net")),
+            "argv: {argv:?}"
+        );
+
+        // Daemonized, pid-filed, write-only serial capture, qemu log.
+        assert!(argv.contains(&"-daemonize".to_string()));
+        assert_eq!(argvalue(&argv, "-pidfile"), Some("/state/w/qemu.pid"));
+        assert_eq!(
+            argvalue(&argv, "-serial"),
+            Some("file:/state/w/console.log")
+        );
+        assert_eq!(argvalue(&argv, "-D"), Some("/state/w/qemu.log"));
+    }
+
+    #[test]
+    fn argv_defaults_the_cmdline_base_by_boot_shape_and_uses_tcg_without_kvm() {
+        // Empty cmdline + an initramfs (no disk root) ⇒ console-only base.
+        let spec = spec_with(KernelImage::Path("/img/vmlinux".into()), vec![], vec![]);
+        let argv = qemu_boot_argv(
+            &spec,
+            Path::new("/img/vmlinux"),
+            3,
+            false,
+            Path::new("/state/w/qemu.pid"),
+        );
+        let append = argvalue(&argv, "-append").expect("append");
+        assert!(append.contains("console=ttyS0"), "got: {append}");
+        assert!(!append.contains("root="), "got: {append}");
+        // No KVM: software emulation, no -enable-kvm.
+        assert!(!argv.contains(&"-enable-kvm".to_string()));
+        assert_eq!(argvalue(&argv, "-cpu"), Some("max"));
+
+        // Empty cmdline + a disk and no initramfs ⇒ the disk-root base.
+        let mut spec = spec_with(
+            KernelImage::Path("/img/vmlinux".into()),
+            vec![],
+            vec![block("/img/rootfs.ext4", true, 0)],
+        );
+        spec.initramfs = None;
+        let argv = qemu_boot_argv(
+            &spec,
+            Path::new("/img/vmlinux"),
+            3,
+            true,
+            Path::new("/state/w/qemu.pid"),
+        );
+        let append = argvalue(&argv, "-append").expect("append");
+        assert!(append.contains("root=/dev/vda"), "got: {append}");
+        assert!(append.contains("init=/init"), "got: {append}");
+        assert!(!argv.contains(&"-initrd".to_string()));
+    }
+
+    #[test]
+    fn bridge_spec_maps_channels_by_direction_and_re_derives_host_sockets() {
+        let state_dir = Path::new("/state/w");
+        let channels = vec![
+            host_dials(GUEST_AGENT_PORT, "/run/agent-hint.sock"),
+            guest_dials(EGRESS_PORT, "/run/egress.sock"),
+            guest_dials(WORKLOAD_EXIT_PORT, "/state/w/workload.exit"),
+            guest_dials(BROKER_PORT, "/run/broker.sock"),
+            host_dials(CONSOLE_PORT_BASE + 1, "/run/console-hint.sock"),
+        ];
+        let spec = bridge_spec_for_vsock(9, state_dir, &channels);
+
+        assert_eq!(spec.cid, 9);
+        assert_eq!(spec.watch_pid_file, PathBuf::from("/state/w/qemu.pid"));
+
+        // Host-dialed channels bind the re-derived per-port socket, never
+        // the spec's backend-neutral hint.
+        assert_eq!(spec.host_dials.len(), 2);
+        assert_eq!(spec.host_dials[0].guest_port, GUEST_AGENT_PORT);
+        assert_eq!(
+            spec.host_dials[0].listen_uds,
+            vm_vsock_port_socket_at(state_dir, GUEST_AGENT_PORT)
+        );
+        assert_eq!(spec.host_dials[1].guest_port, CONSOLE_PORT_BASE + 1);
+        assert_eq!(
+            spec.host_dials[1].listen_uds,
+            vm_vsock_port_socket_at(state_dir, CONSOLE_PORT_BASE + 1)
+        );
+
+        // Guest-dialed channels splice to the runner-bound listener verbatim;
+        // the exit port is captured, not relayed.
+        assert_eq!(
+            spec.guest_dials,
+            vec![
+                QemuBridgeGuestDial {
+                    guest_port: EGRESS_PORT,
+                    target_uds: PathBuf::from("/run/egress.sock"),
+                },
+                QemuBridgeGuestDial {
+                    guest_port: BROKER_PORT,
+                    target_uds: PathBuf::from("/run/broker.sock"),
+                },
+            ]
+        );
+        assert_eq!(spec.exit_capture_state_dir, Some(PathBuf::from("/state/w")));
+    }
+
+    #[test]
+    fn bridge_spec_without_an_exit_port_captures_nothing() {
+        let spec = bridge_spec_for_vsock(
+            3,
+            Path::new("/state/w"),
+            &[host_dials(GUEST_AGENT_PORT, "/run/agent.sock")],
+        );
+        assert_eq!(spec.exit_capture_state_dir, None);
+        assert!(spec.guest_dials.is_empty());
+    }
+
+    #[test]
+    fn bundled_kernel_resolves_the_cached_builder_fallback() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", dir.path());
+
+        // Missing cache entry ⇒ a clear, named failure.
+        let err = qemu::resolve_workload_kernel_path("w", None).unwrap_err();
+        assert!(
+            err.to_string().contains("no bootable kernel"),
+            "unexpected error: {err}"
+        );
+
+        // Seed the cached builder kernel ⇒ the fallback resolves it.
+        let cached = dir
+            .path()
+            .join("cache")
+            .join("builder-vm")
+            .join(if cfg!(target_arch = "aarch64") {
+                "aarch64"
+            } else {
+                "x86_64"
+            })
+            .join("vmlinux");
+        std::fs::create_dir_all(cached.parent().expect("cache parent")).unwrap();
+        std::fs::write(&cached, b"kernel").unwrap();
+        assert_eq!(
+            qemu::resolve_workload_kernel_path("w", None).unwrap(),
+            cached
+        );
+    }
+
+    #[test]
+    fn attach_builds_a_disk_backed_handle_that_reports_stopped_for_a_missing_vm() {
+        let vm = QemuDriver::new()
+            .attach(&VmId("qemu-nonexistent-attach-test-vm".into()))
+            .unwrap();
+        assert_eq!(vm.id().0, "qemu-nonexistent-attach-test-vm");
+        assert_eq!(vm.status().unwrap(), VmStatus::Stopped);
+        // Killing a VM with no pid file is a no-op, not an error.
+        assert!(vm.kill().is_ok());
+    }
+
+    #[test]
+    fn guest_channel_info_delegates_to_the_qemu_backend() {
+        let d = QemuDriver::new();
+        let id = VmId("qemu-guest-channel-info-test-vm".into());
+        // GuestChannelInfo has no PartialEq; compare the Debug rendering to
+        // assert the driver relays the backend's channel verbatim.
+        assert_eq!(
+            format!("{:?}", d.guest_channel_info(&id).unwrap()),
+            format!("{:?}", QemuBackend.guest_channel_info(&id).unwrap())
+        );
+    }
+
+    #[test]
+    fn vsock_connect_reaches_the_bridge_socket_and_rejects_other_ports() {
+        use crate::test_support::bind_unix_listener;
+        use std::io::{Read, Write};
+
+        let dir = tempfile::tempdir().unwrap();
+        // The bridge's agent listener: <state_dir>/vsock-<port>.sock.
+        let sock = vm_vsock_port_socket_at(dir.path(), GUEST_AGENT_PORT);
+        let Some(listener) = bind_unix_listener(&sock) else {
+            return;
+        };
+        let server = std::thread::spawn(move || {
+            if let Ok((mut c, _)) = listener.accept() {
+                let mut b = [0u8; 1];
+                if c.read_exact(&mut b).is_ok() {
+                    let _ = c.write_all(&b);
+                }
+            }
+        });
+
+        let vm = QemuRunningVm {
+            id: VmId("agent-vm".into()),
+            state_dir: dir.path().to_path_buf(),
+            pid_file: dir.path().join(QEMU_PID_FILE),
+        };
+
+        // The agent port connects + round-trips through the bridge socket —
+        // the seam ActivateEnvironment rides.
+        let mut s = vm.vsock_connect(GUEST_AGENT_PORT).unwrap();
+        s.write_all(b"x").unwrap();
+        let mut got = [0u8; 1];
+        s.read_exact(&mut got).unwrap();
+        assert_eq!(&got, b"x");
+        server.join().unwrap();
+
+        // Ports outside the agent + console data range are not host-dialable.
+        assert!(vm.vsock_connect(GUEST_AGENT_PORT + 1).is_err());
+        assert!(vm.vsock_connect(9999).is_err());
+    }
+}

--- a/crates/mvm-runtime/src/qemu.rs
+++ b/crates/mvm-runtime/src/qemu.rs
@@ -8,6 +8,14 @@
 //! (`--hypervisor qemu` / `MVM_BACKEND=qemu`) and `auto_select` never
 //! picks it.
 //!
+//! The selectable launch path is the unified workload runner over
+//! [`crate::driver::QemuDriver`] — a QEMU boot attaches the universal
+//! initramfs and receives `ActivateEnvironment` over vsock exactly like
+//! Firecracker/libkrun/HVF. This raw backend remains as the driver's
+//! identity delegate and owns the shared QEMU machinery both paths use:
+//! guest-CID allocation, the AF_VSOCK↔UNIX bridge, and the pid-file
+//! lifecycle.
+//!
 //! ## Tier
 //!
 //! Dev tier only, outside the security claims. `AnyBackend::tier()` reports
@@ -29,17 +37,21 @@
 //!   (a detached `mvmctl` subprocess) so the shared UNIX-socket agent
 //!   client reaches the guest agent exactly as it does under
 //!   libkrun/Firecracker — QEMU's `vhost-vsock` speaks real AF_VSOCK, not
-//!   the per-port UNIX sockets those VMMs expose.
+//!   the per-port UNIX sockets those VMMs expose. The bridge is
+//!   spec-driven ([`QemuBridgeSpec`]): the runner's driver additionally
+//!   relays the guest-dialed channels (egress, broker) and captures the
+//!   workload-exit report through the same process.
 //! - `stop` SIGTERMs the qemu PID (then SIGKILL), reaps the bridge.
 //! - `status` probes the qemu PID; `list` walks `~/.mvm/vms/*/qemu.pid`.
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use mvm_core::config::{vm_console_log, vm_state_dir, vms_dir};
 use mvm_core::vm_backend::{
     BackendKind, BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage,
     SnapshotCapability, StartMode, VmBackend, VmCapabilities, VmId, VmInfo, VmStartConfig,
     VmStatus,
 };
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -50,16 +62,16 @@ use crate::libkrun::open_console_capture;
 /// QEMU workload backend (Linux dev/test; KVM where present, TCG fallback).
 pub struct QemuBackend;
 
-/// How long [`QemuBackend::start`] waits for qemu's `-pidfile` to appear
+/// How long a boot waits for qemu's `-pidfile` to appear
 /// before declaring the boot failed.
-const PID_FILE_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const PID_FILE_TIMEOUT: Duration = Duration::from_secs(10);
 /// How long the host AF_VSOCK↔UNIX bridge gets to bind its listening UNIX
-/// socket before `start` returns. The socket existing means the agent
+/// socket before the boot returns. The socket existing means the agent
 /// client has somewhere to connect; the guest agent coming up is raced by
 /// the client's own retry, exactly as under libkrun.
-const BRIDGE_SOCKET_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const BRIDGE_SOCKET_TIMEOUT: Duration = Duration::from_secs(5);
 /// SIGTERM→SIGKILL grace on `stop`.
-const STOP_TIMEOUT: Duration = Duration::from_secs(3);
+pub(crate) const STOP_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// QEMU's unprivileged user-mode network gives dev/test guests transparent
 /// TCP and UDP without requiring a host TAP device or elevated setup.
@@ -73,10 +85,12 @@ fn qemu_user_network_args() -> [&'static str; 4] {
 }
 
 /// Per-VM file names under `vm_state_dir(name)`.
-const QEMU_PID_FILE: &str = "qemu.pid";
-const QEMU_LOG_FILE: &str = "qemu.log";
-const QEMU_CID_FILE: &str = "qemu.cid";
-const BRIDGE_PID_FILE: &str = "qemu-vsock-bridge.pid";
+pub(crate) const QEMU_PID_FILE: &str = "qemu.pid";
+pub(crate) const QEMU_LOG_FILE: &str = "qemu.log";
+pub(crate) const QEMU_CID_FILE: &str = "qemu.cid";
+pub(crate) const BRIDGE_PID_FILE: &str = "qemu-vsock-bridge.pid";
+/// The JSON wiring plan the detached bridge process reads at startup.
+pub(crate) const BRIDGE_SPEC_FILE: &str = "qemu-vsock-bridge.json";
 
 /// Default workload kernel cmdline. `console=ttyS0` is QEMU's serial line
 /// (vs libkrun's `hvc0`); `root=/dev/vda rw init=/init` matches the same
@@ -380,7 +394,8 @@ impl VmBackend for QemuBackend {
         // orphaned (a failed `start` won't be followed by `stop`). Roll back:
         // kill qemu + drop the pid/cid sidecars so a retry re-allocates a CID
         // instead of pinning the (possibly conflicting) one this attempt wrote.
-        if let Err(e) = spawn_vsock_bridge(&config.name, cid, &state_dir) {
+        let bridge_spec = QemuBridgeSpec::agent_only(&config.name, cid, &state_dir);
+        if let Err(e) = spawn_vsock_bridges(&config.name, &state_dir, &bridge_spec) {
             if let Some(pid) = read_pid(&pid_file) {
                 send_signal(pid, libc::SIGTERM);
             }
@@ -583,9 +598,17 @@ fn host_arch() -> &'static str {
     }
 }
 
+/// Resolve the kernel to boot the workload under QEMU from a start config:
+/// the build's emitted `vmlinux` when there is one, else the cached builder
+/// fallback. Thin wrapper over [`resolve_workload_kernel_path`] for the
+/// config-carrying raw path.
+fn resolve_workload_kernel(config: &VmStartConfig) -> Result<PathBuf> {
+    resolve_workload_kernel_path(&config.name, config.kernel_path.as_deref().map(Path::new))
+}
+
 /// Resolve the kernel to boot the workload under QEMU.
 ///
-/// `config.kernel_path` is the build's emitted `vmlinux` when there is one
+/// `kernel_path` is the build's emitted `vmlinux` when there is one
 /// (builder/interactive images). A plain `mkGuest` **workload** is a bare
 /// rootfs with no kernel — libkrun boots it with libkrunfw's bundled
 /// kernel, but QEMU has none. For the dev tier we fall back to the cached
@@ -594,12 +617,19 @@ fn host_arch() -> &'static str {
 /// (`root=/dev/vda init=/init`) just fine — the Linux analog of
 /// libkrunfw's bundled kernel. Production uses a workload kernel via
 /// Firecracker; QEMU is dev/test only.
-fn resolve_workload_kernel(config: &VmStartConfig) -> Result<PathBuf> {
-    if let Some(k) = config.kernel_path.as_deref() {
-        let p = PathBuf::from(k);
-        if p.is_file() {
-            return Ok(p);
-        }
+///
+/// Shared by the raw backend (`VmStartConfig::kernel_path`) and the
+/// `VmmDriver` (`KernelImage::Bundled` — QEMU has no libkrunfw, so the
+/// cached-builder fallback IS its bundled kernel) so both boot paths
+/// resolve the same file.
+pub(crate) fn resolve_workload_kernel_path(
+    name: &str,
+    kernel_path: Option<&Path>,
+) -> Result<PathBuf> {
+    if let Some(p) = kernel_path
+        && p.is_file()
+    {
+        return Ok(p.to_path_buf());
     }
     // ~/.mvm/cache/builder-vm/<arch>/vmlinux — same layout
     // `mvm_build::libkrun_builder::ensure_builder_vm_image` promotes to.
@@ -611,17 +641,15 @@ fn resolve_workload_kernel(config: &VmStartConfig) -> Result<PathBuf> {
         return Ok(builder_kernel);
     }
     bail!(
-        "qemu workload '{}' has no bootable kernel: the build produced no vmlinux \
-         ({:?}) and no cached builder kernel exists at {}. Run a build / `mvmctl bootstrap` \
+        "qemu workload '{name}' has no bootable kernel: the build produced no vmlinux \
+         ({kernel_path:?}) and no cached builder kernel exists at {}. Run a build / `mvmctl bootstrap` \
          to populate the builder VM image first.",
-        config.name,
-        config.kernel_path,
         builder_kernel.display()
     )
 }
 
 /// `qemu-system-<host-arch>` on `$PATH`.
-fn locate_qemu() -> Result<String> {
+pub(crate) fn locate_qemu() -> Result<String> {
     let bin = match std::env::consts::ARCH {
         "x86_64" => "qemu-system-x86_64",
         "aarch64" => "qemu-system-aarch64",
@@ -652,7 +680,7 @@ pub(crate) fn kvm_available() -> bool {
 /// duplicate CIDs across live VMs, so we pick the lowest CID ≥ 3 not
 /// recorded by another VM's `qemu.cid` sidecar and persist it. Reuses the
 /// VM's own recorded CID on restart.
-fn allocate_cid(name: &str) -> Result<u32> {
+pub(crate) fn allocate_cid(name: &str) -> Result<u32> {
     if let Some(existing) = read_cid(name) {
         return Ok(existing);
     }
@@ -715,7 +743,7 @@ fn used_cids() -> std::collections::HashSet<u32> {
     set
 }
 
-fn read_cid(name: &str) -> Option<u32> {
+pub(crate) fn read_cid(name: &str) -> Option<u32> {
     std::fs::read_to_string(vm_state_dir(name).join(QEMU_CID_FILE))
         .ok()?
         .trim()
@@ -725,33 +753,102 @@ fn read_cid(name: &str) -> Option<u32> {
 
 // ─── host AF_VSOCK ↔ UNIX bridge ────────────────────────────────────
 
-/// Spawn the detached host-side AF_VSOCK↔UNIX bridge for this VM. QEMU's
-/// virtio-vsock speaks real AF_VSOCK, but the shared agent client
-/// (`mvm::vsock_transport`) connects to the per-port UNIX socket that
-/// libkrun/Firecracker expose. The bridge listens on that UNIX socket
-/// (`vm_vsock_port_socket`) and splices each connection to
-/// `AF_VSOCK(cid, GUEST_AGENT_PORT)`, so the client is backend-agnostic.
+/// One host-dialed vsock channel the bridge serves: it listens on
+/// `listen_uds` (the per-port UNIX socket the shared agent client connects
+/// to, `vm_vsock_port_socket`) and splices each accepted connection to
+/// `AF_VSOCK(cid, guest_port)`, so the client stays backend-agnostic.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QemuBridgeHostDial {
+    pub guest_port: u32,
+    pub listen_uds: PathBuf,
+}
+
+/// One guest-dialed vsock channel the bridge serves: it listens on
+/// `AF_VSOCK(VMADDR_CID_ANY, guest_port)` on the host and splices each
+/// accepted connection to `target_uds` — the runner-bound listener (the
+/// egress endpoint, the host-services broker) that owns the channel's
+/// policy. QEMU's `vhost-vsock` exposes no per-port host sockets for the
+/// guest's outbound dials, so the bridge terminates them here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QemuBridgeGuestDial {
+    pub guest_port: u32,
+    pub target_uds: PathBuf,
+}
+
+/// The detached bridge process's wiring plan for one VM, written as JSON
+/// next to the VM's pid file and passed to `mvmctl __qemu-vsock-bridge
+/// --spec`. QEMU's virtio-vsock speaks real AF_VSOCK, but the shared agent
+/// client and the runner's channel set are expressed as per-port UNIX
+/// sockets; the bridge is the translation layer between the two, in both
+/// directions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QemuBridgeSpec {
+    /// The VM's guest CID (host-dialed channels dial `AF_VSOCK(cid, port)`).
+    pub cid: u32,
+    /// Exit when this PID file's process is no longer alive (the VM is gone).
+    pub watch_pid_file: PathBuf,
+    /// Channels the host dials into the guest (agent RPC, dev console data).
+    pub host_dials: Vec<QemuBridgeHostDial>,
+    /// Channels the guest dials out to the host (egress, broker).
+    pub guest_dials: Vec<QemuBridgeGuestDial>,
+    /// When the spec carries the workload-exit port, the bridge accepts one
+    /// connection on it and persists the guest's exit code under this state
+    /// dir (`workload.exit`), mirroring the other drivers' capture.
+    pub exit_capture_state_dir: Option<PathBuf>,
+}
+
+impl QemuBridgeSpec {
+    /// The bridge plan for the raw (pre-runner) boot path: only the agent
+    /// RPC channel, in the host-dialed direction — exactly what the legacy
+    /// single-port bridge served.
+    fn agent_only(name: &str, cid: u32, state_dir: &Path) -> Self {
+        Self {
+            cid,
+            watch_pid_file: state_dir.join(QEMU_PID_FILE),
+            host_dials: vec![QemuBridgeHostDial {
+                guest_port: mvm_agentd::vsock::GUEST_AGENT_PORT,
+                listen_uds: mvm_core::config::vm_vsock_port_socket(
+                    name,
+                    mvm_agentd::vsock::GUEST_AGENT_PORT,
+                ),
+            }],
+            guest_dials: Vec::new(),
+            exit_capture_state_dir: None,
+        }
+    }
+}
+
+/// Spawn the detached host-side AF_VSOCK↔UNIX bridge for this VM.
 ///
-/// It runs as a detached `mvmctl __qemu-vsock-bridge` subprocess so it
-/// outlives the `mvmctl up` invocation, exactly as qemu (`-daemonize`)
-/// does. `stop` reaps it via `BRIDGE_PID_FILE`.
-fn spawn_vsock_bridge(name: &str, cid: u32, state_dir: &Path) -> Result<()> {
-    let uds = mvm_core::config::vm_vsock_port_socket(name, mvm_agentd::vsock::GUEST_AGENT_PORT);
-    let _ = std::fs::remove_file(&uds);
+/// Writes `spec` as JSON next to the VM's pid file and launches a detached
+/// `mvmctl __qemu-vsock-bridge` subprocess so it outlives the invoking
+/// `mvmctl`, exactly as qemu (`-daemonize`) does. `stop` reaps it via
+/// `BRIDGE_PID_FILE`. When the plan serves at least one host-dialed
+/// channel, this waits for the first channel's UNIX socket to appear so an
+/// immediately-following console/agent connect doesn't race a
+/// not-yet-bound socket — the socket existing means the client has
+/// somewhere to connect; the guest agent coming up is raced by the
+/// client's own retry, exactly as under libkrun.
+pub(crate) fn spawn_vsock_bridges(
+    name: &str,
+    state_dir: &Path,
+    spec: &QemuBridgeSpec,
+) -> Result<()> {
+    let spec_path = state_dir.join(BRIDGE_SPEC_FILE);
+    let json = serde_json::to_string(spec)
+        .map_err(|e| anyhow!("serialize qemu bridge spec for '{name}': {e}"))?;
+    std::fs::write(&spec_path, json).map_err(|e| anyhow!("write {}: {e}", spec_path.display()))?;
+    for dial in &spec.host_dials {
+        let _ = std::fs::remove_file(&dial.listen_uds);
+    }
     let bridge_pid_file = state_dir.join(BRIDGE_PID_FILE);
 
     let exe =
         std::env::current_exe().map_err(|e| anyhow!("resolve current exe for bridge: {e}"))?;
     let mut cmd = Command::new(&exe);
     cmd.arg("__qemu-vsock-bridge")
-        .arg("--uds")
-        .arg(&uds)
-        .arg("--cid")
-        .arg(cid.to_string())
-        .arg("--port")
-        .arg(mvm_agentd::vsock::GUEST_AGENT_PORT.to_string())
-        .arg("--watch-pid-file")
-        .arg(state_dir.join(QEMU_PID_FILE))
+        .arg("--spec")
+        .arg(&spec_path)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
@@ -770,14 +867,18 @@ fn spawn_vsock_bridge(name: &str, cid: u32, state_dir: &Path) -> Result<()> {
     std::fs::write(&bridge_pid_file, child.id().to_string())
         .map_err(|e| anyhow!("write {}: {e}", bridge_pid_file.display()))?;
 
-    // Wait for the bridge to bind its UNIX socket so an immediately-
-    // following console/agent connect doesn't race a not-yet-bound socket.
+    // Wait for the first host-dialed channel's socket (always the agent RPC
+    // channel on every real plan) so a following connect doesn't race the
+    // bind. A plan with no host-dialed channels has nothing to wait on.
+    let Some(first) = spec.host_dials.first() else {
+        return Ok(());
+    };
     let deadline = Instant::now() + BRIDGE_SOCKET_TIMEOUT;
-    while !uds.exists() {
+    while !first.listen_uds.exists() {
         if Instant::now() >= deadline {
             bail!(
                 "qemu vsock bridge did not bind {} within {:?}",
-                uds.display(),
+                first.listen_uds.display(),
                 BRIDGE_SOCKET_TIMEOUT
             );
         }
@@ -786,30 +887,65 @@ fn spawn_vsock_bridge(name: &str, cid: u32, state_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Body of the `mvmctl __qemu-vsock-bridge` subcommand. Listens on the
-/// UNIX socket `uds` and, for each accepted connection, dials
-/// `AF_VSOCK(cid, port)` and splices the two halves bidirectionally.
-/// Exits when `watch_pid_file`'s process dies (the VM is gone).
+/// Read a [`QemuBridgeSpec`] JSON file and run the bridge — the body of the
+/// `mvmctl __qemu-vsock-bridge --spec <path>` subcommand.
 ///
 /// Lives here (not in mvm-cli) so the AF_VSOCK plumbing sits beside the
-/// backend that needs it; mvm-cli's hidden subcommand just forwards args.
-pub fn run_vsock_bridge(uds: &Path, cid: u32, port: u32, watch_pid_file: &Path) -> Result<()> {
-    use std::os::unix::net::UnixListener;
+/// backend that needs it; mvm-cli's hidden subcommand just forwards the path.
+pub fn run_vsock_bridge_from_spec_file(spec_path: &Path) -> Result<()> {
+    let json = std::fs::read_to_string(spec_path)
+        .with_context(|| format!("read qemu bridge spec {}", spec_path.display()))?;
+    let spec: QemuBridgeSpec = serde_json::from_str(&json)
+        .with_context(|| format!("parse qemu bridge spec {}", spec_path.display()))?;
+    run_vsock_bridge(&spec)
+}
 
-    let _ = std::fs::remove_file(uds);
-    let listener = UnixListener::bind(uds).map_err(|e| anyhow!("bind {}: {e}", uds.display()))?;
-    listener
-        .set_nonblocking(true)
-        .map_err(|e| anyhow!("set_nonblocking on {}: {e}", uds.display()))?;
+/// Body of the `mvmctl __qemu-vsock-bridge` subcommand: bind every channel
+/// in the plan, then watch the VM's pid file and exit (cleaning up the
+/// host-dialed sockets) when the VM is gone.
+fn run_vsock_bridge(spec: &QemuBridgeSpec) -> Result<()> {
+    // Host-dialed channels: one UNIX listener per channel; each accepted
+    // connection is spliced to AF_VSOCK(cid, guest_port).
+    for dial in &spec.host_dials {
+        let listener = std::os::unix::net::UnixListener::bind(&dial.listen_uds)
+            .with_context(|| format!("bind {}", dial.listen_uds.display()))?;
+        let cid = spec.cid;
+        let port = dial.guest_port;
+        std::thread::spawn(move || serve_host_dial(listener, cid, port));
+    }
+    // Guest-dialed channels: one AF_VSOCK listener per channel; each
+    // accepted connection is spliced to the runner-bound UNIX listener.
+    for dial in &spec.guest_dials {
+        let listener = VsockListener::bind(dial.guest_port)
+            .with_context(|| format!("bind AF_VSOCK port {}", dial.guest_port))?;
+        let target = dial.target_uds.clone();
+        std::thread::spawn(move || serve_guest_dial(listener, target));
+    }
+    // Workload-exit capture: accept the guest's single exit report and
+    // persist it where `wait_for_workload_exit` reads it.
+    if let Some(state_dir) = &spec.exit_capture_state_dir {
+        let listener = VsockListener::bind(mvm_agentd::vsock::WORKLOAD_EXIT_PORT)
+            .context("bind AF_VSOCK workload-exit port")?;
+        let state_dir = state_dir.clone();
+        std::thread::spawn(move || {
+            match listener
+                .accept()
+                .and_then(|stream| mvm_core::exit_capture::capture_stream(stream, &state_dir))
+            {
+                Ok(code) => tracing::info!(code, "qemu workload exit captured"),
+                Err(e) => tracing::warn!("qemu workload exit capture failed: {e}"),
+            }
+        });
+    }
 
+    // Watch loop: stop when the watched VM is gone. Re-read the pidfile each
+    // iteration so a transient partial read at startup doesn't latch
+    // (the old read-once approach could loop forever on a one-off None).
+    // Distinguish the cases: file *missing* or a *dead* pid → the VM is
+    // torn down, exit; file present but momentarily unparseable → treat
+    // as still-alive and retry (don't exit on a transient bad read).
     loop {
-        // Stop when the watched VM is gone. Re-read the pidfile each
-        // iteration so a transient partial read at startup doesn't latch
-        // (the old read-once approach could loop forever on a one-off None).
-        // Distinguish the cases: file *missing* or a *dead* pid → the VM is
-        // torn down, exit; file present but momentarily unparseable → treat
-        // as still-alive and retry (don't exit on a transient bad read).
-        let vm_gone = match std::fs::read_to_string(watch_pid_file) {
+        let vm_gone = match std::fs::read_to_string(&spec.watch_pid_file) {
             Err(_) => true, // pidfile removed → VM torn down
             Ok(s) => match s.trim().parse::<libc::pid_t>() {
                 Ok(pid) => !pid_alive(pid),
@@ -817,22 +953,145 @@ pub fn run_vsock_bridge(uds: &Path, cid: u32, port: u32, watch_pid_file: &Path) 
             },
         };
         if vm_gone {
-            let _ = std::fs::remove_file(uds);
+            for dial in &spec.host_dials {
+                let _ = std::fs::remove_file(&dial.listen_uds);
+            }
             return Ok(());
         }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// Accept loop for one host-dialed channel: splice each UNIX connection to
+/// `AF_VSOCK(cid, port)`. A failed guest dial (agent not up yet) drops the
+/// client; the caller retries.
+fn serve_host_dial(listener: std::os::unix::net::UnixListener, cid: u32, port: u32) {
+    loop {
         match listener.accept() {
             Ok((client, _)) => {
                 if let Ok(guest) = dial_vsock(cid, port) {
                     std::thread::spawn(move || splice_bidirectional(client, guest));
                 }
-                // If the guest dial fails (agent not up yet), drop the
-                // client; the caller retries.
             }
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                std::thread::sleep(Duration::from_millis(100));
+            Err(e) => {
+                tracing::warn!("qemu bridge accept on host-dial port {port} failed: {e}");
+                return;
             }
-            Err(e) => return Err(anyhow!("accept on {}: {e}", uds.display())),
         }
+    }
+}
+
+/// Accept loop for one guest-dialed channel: splice each AF_VSOCK
+/// connection to the runner-bound UNIX listener. A failed target connect
+/// (endpoint not bound yet) drops the guest's dial; the guest retries.
+fn serve_guest_dial(listener: VsockListener, target_uds: PathBuf) {
+    loop {
+        match listener.accept() {
+            Ok(guest) => {
+                if let Ok(host) = std::os::unix::net::UnixStream::connect(&target_uds) {
+                    std::thread::spawn(move || splice_bidirectional(host, guest));
+                }
+            }
+            Err(e) => {
+                tracing::warn!("qemu bridge accept on guest-dial listener failed: {e}");
+                return;
+            }
+        }
+    }
+}
+
+/// The Linux `struct sockaddr_vm` wire layout, hoisted so the dial and the
+/// listener share one definition. Pinned against the kernel uapi (family
+/// u16 + reserved u16 + port u32 + cid u32 + 4-byte pad = 16, ==
+/// sizeof(struct sockaddr)): a future field edit that desyncs the `socklen`
+/// passed to connect(2)/bind(2) trips this at compile time.
+#[repr(C)]
+struct SockaddrVm {
+    svm_family: libc::sa_family_t,
+    svm_reserved1: u16,
+    svm_port: u32,
+    svm_cid: u32,
+    svm_zero: [u8; 4],
+}
+const _: () = assert!(std::mem::size_of::<SockaddrVm>() == 16);
+
+const AF_VSOCK: libc::c_int = 40;
+
+fn sockaddr_vm(cid: u32, port: u32) -> SockaddrVm {
+    SockaddrVm {
+        svm_family: AF_VSOCK as libc::sa_family_t,
+        svm_reserved1: 0,
+        svm_port: port,
+        svm_cid: cid,
+        svm_zero: [0; 4],
+    }
+}
+
+fn vsock_socket() -> std::io::Result<libc::c_int> {
+    // SAFETY: standard socket(2) on AF_VSOCK.
+    let fd = unsafe { libc::socket(AF_VSOCK, libc::SOCK_STREAM, 0) };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(fd)
+}
+
+/// A bound host-side AF_VSOCK listener: the host end of the channels the
+/// guest dials out to (egress, broker, workload-exit). QEMU's
+/// `vhost-vsock-pci` delivers a guest's `connect(cid=host, port)` to a host
+/// process listening here, so the bridge terminates those dials and
+/// splices them to the runner-bound UNIX listeners.
+struct VsockListener {
+    fd: libc::c_int,
+}
+
+impl VsockListener {
+    /// Bind `AF_VSOCK(VMADDR_CID_ANY, port)` and start listening.
+    fn bind(port: u32) -> std::io::Result<Self> {
+        const VMADDR_CID_ANY: u32 = 0xFFFF_FFFF;
+        let fd = vsock_socket()?;
+        let addr = sockaddr_vm(VMADDR_CID_ANY, port);
+        // SAFETY: bind(2)/listen(2) on a valid fd; addr is fully initialized
+        // and sized exactly. On failure the fd is closed before returning.
+        unsafe {
+            let rc = libc::bind(
+                fd,
+                std::ptr::addr_of!(addr).cast::<libc::sockaddr>(),
+                std::mem::size_of::<SockaddrVm>() as libc::socklen_t,
+            );
+            if rc < 0 {
+                let err = std::io::Error::last_os_error();
+                libc::close(fd);
+                return Err(err);
+            }
+            if libc::listen(fd, 16) < 0 {
+                let err = std::io::Error::last_os_error();
+                libc::close(fd);
+                return Err(err);
+            }
+        }
+        Ok(Self { fd })
+    }
+
+    /// Accept one guest connection, wrapped in a [`std::net::TcpStream`]
+    /// (an owned fd with read/write + shutdown; no TCP methods are used).
+    fn accept(&self) -> std::io::Result<std::net::TcpStream> {
+        use std::os::fd::FromRawFd;
+        // SAFETY: accept(2) on a listening fd; the returned fd is owned and
+        // wrapped exactly once.
+        let conn = unsafe { libc::accept(self.fd, std::ptr::null_mut(), std::ptr::null_mut()) };
+        if conn < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: `conn` is a fresh, owned descriptor from accept.
+        Ok(unsafe { std::net::TcpStream::from_raw_fd(conn) })
+    }
+}
+
+impl Drop for VsockListener {
+    fn drop(&mut self) {
+        // SAFETY: `fd` is owned by this listener and closed exactly once.
+        unsafe { libc::close(self.fd) };
     }
 }
 
@@ -842,35 +1101,11 @@ pub fn run_vsock_bridge(uds: &Path, cid: u32, port: u32, watch_pid_file: &Path) 
 fn dial_vsock(cid: u32, port: u32) -> std::io::Result<std::net::TcpStream> {
     use std::os::fd::FromRawFd;
 
-    const AF_VSOCK: libc::c_int = 40;
-    #[repr(C)]
-    struct SockaddrVm {
-        svm_family: libc::sa_family_t,
-        svm_reserved1: u16,
-        svm_port: u32,
-        svm_cid: u32,
-        svm_zero: [u8; 4],
-    }
-    // Pin the wire layout against the kernel uapi `struct sockaddr_vm`
-    // (family u16 + reserved u16 + port u32 + cid u32 + 4-byte pad = 16,
-    // == sizeof(struct sockaddr)). A future field edit that desyncs the
-    // `socklen` passed to connect(2) trips this at compile time.
-    const _: () = assert!(std::mem::size_of::<SockaddrVm>() == 16);
-
-    // SAFETY: standard socket(2)/connect(2) on AF_VSOCK; addr is fully
-    // initialized and sized exactly.
+    let fd = vsock_socket()?;
+    let addr = sockaddr_vm(cid, port);
+    // SAFETY: connect(2) on a valid fd; addr is fully initialized and sized
+    // exactly. On failure the fd is closed before returning.
     unsafe {
-        let fd = libc::socket(AF_VSOCK, libc::SOCK_STREAM, 0);
-        if fd < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        let addr = SockaddrVm {
-            svm_family: AF_VSOCK as libc::sa_family_t,
-            svm_reserved1: 0,
-            svm_port: port,
-            svm_cid: cid,
-            svm_zero: [0; 4],
-        };
         let rc = libc::connect(
             fd,
             std::ptr::addr_of!(addr).cast::<libc::sockaddr>(),
@@ -915,15 +1150,15 @@ fn splice_bidirectional(a: std::os::unix::net::UnixStream, b: std::net::TcpStrea
 
 // ─── pid helpers (local copies — libkrun's are private) ─────────────
 
-fn read_pid(path: &Path) -> Option<libc::pid_t> {
+pub(crate) fn read_pid(path: &Path) -> Option<libc::pid_t> {
     std::fs::read_to_string(path).ok()?.trim().parse().ok()
 }
 
-fn pid_alive(pid: libc::pid_t) -> bool {
+pub(crate) fn pid_alive(pid: libc::pid_t) -> bool {
     unsafe { libc::kill(pid, 0) == 0 }
 }
 
-fn send_signal(pid: libc::pid_t, sig: libc::c_int) {
+pub(crate) fn send_signal(pid: libc::pid_t, sig: libc::c_int) {
     unsafe {
         libc::kill(pid, sig);
     }

--- a/crates/mvm-runtime/src/selection.rs
+++ b/crates/mvm-runtime/src/selection.rs
@@ -7,8 +7,7 @@
 
 use mvm_core::vm_backend::{RequiredCapabilities, VmCapabilities};
 
-use crate::backend::{AnyBackend, fc_runner, hvf_runner, libkrun_runner};
-use crate::qemu::QemuBackend;
+use crate::backend::{AnyBackend, fc_runner, hvf_runner, libkrun_runner, qemu_runner};
 
 /// No backend could be selected: every candidate lacked a required capability.
 /// Carries the per-candidate shortfall so the caller gets a recovery action
@@ -65,7 +64,7 @@ impl AnyBackend {
             AnyBackend::Firecracker(fc_runner()),
             AnyBackend::Hvf(hvf_runner()),
             AnyBackend::Libkrun(libkrun_runner()),
-            AnyBackend::Qemu(QemuBackend),
+            AnyBackend::Qemu(qemu_runner()),
         ]
     }
 

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -1090,7 +1090,7 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
-    use mvm_agentd::vsock::EGRESS_PORT;
+    use mvm_agentd::vsock::{EGRESS_PORT, GUEST_AGENT_PORT};
     use mvm_core::plan::{Nonce, SecretBinding, SecretSource, VerbGrant, VerbId};
     use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
     use mvm_core::util::test_env::TestEnv;
@@ -1704,6 +1704,150 @@ mod tests {
         assert!(
             !cmdline.contains("ttyAMA0"),
             "cmdline carried the hardcoded HVF console rather than the driver's: {cmdline}"
+        );
+    }
+
+    /// A boot that attached the universal initramfs must be sent
+    /// `ActivateEnvironment` over the agent vsock port before the launch
+    /// returns — proven by driving `start_workload` through the `MockDriver`
+    /// loopback and answering as the guest: the host's request must BE the
+    /// activation verb (not an operational RPC), and the launch must succeed
+    /// on the ACK. This is the contract every runner driver (Firecracker,
+    /// libkrun, HVF, QEMU) inherits: the driver's only part is a working
+    /// `vsock_connect(GUEST_AGENT_PORT)`.
+    #[test]
+    fn start_workload_sends_activate_environment_for_a_universal_initramfs_boot() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
+        // The activation handshake authenticates against the host signer;
+        // seed one so both ends of the loopback share the identity.
+        let host_signer = [7u8; 32];
+        let keys_dir = mvm_core::config::mvm_keys_dir();
+        std::fs::create_dir_all(&keys_dir).unwrap();
+        std::fs::write(keys_dir.join("host-signer.ed25519"), host_signer).unwrap();
+
+        // An initramfs artifact under the shared cache is the discriminant
+        // for the universal-initramfs boot path.
+        let initrd = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir())
+            .join("initramfs")
+            .join("test-version")
+            .join("initramfs.cpio.gz");
+        std::fs::create_dir_all(initrd.parent().expect("initramfs cache parent")).unwrap();
+        std::fs::write(&initrd, b"initramfs").unwrap();
+
+        let driver = MockDriver::default();
+        let runner = WorkloadRunner::new(
+            driver.clone(),
+            RecordingSpawner::new("/run/ep.sock"),
+            RecordingBrokerRegistrar::new(),
+        );
+        let cfg = VmStartConfig {
+            name: "runner-activation".into(),
+            initrd_path: Some(initrd.to_string_lossy().into_owned()),
+            ..config("runner-activation")
+        };
+        let policy = NetworkPolicy::deny_all();
+        let redaction = RedactionPolicy::default();
+
+        // The guest side of the loopback: authenticate, assert the request
+        // is exactly the activation verb, ACK it.
+        let guest = std::thread::spawn(move || {
+            use ed25519_dalek::SigningKey;
+            use mvm_agentd::vsock::{AuthenticatedSession, GuestRequest, GuestResponse};
+
+            let mut stream = {
+                let mut found = None;
+                for _ in 0..200 {
+                    if let Some(end) =
+                        driver.take_guest_end(&VmId("runner-activation".into()), GUEST_AGENT_PORT)
+                    {
+                        found = Some(end);
+                        break;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                found.expect("the runner connected to the guest agent port")
+            };
+            let host_key = SigningKey::from_bytes(&host_signer).verifying_key();
+            let mut session = AuthenticatedSession::guest(
+                &mut stream,
+                SigningKey::from_bytes(&[9u8; 32]),
+                &host_key,
+            )
+            .expect("guest handshake");
+            let req: GuestRequest = session.read(&mut stream).expect("read request");
+            assert!(
+                matches!(req, GuestRequest::ActivateEnvironment(_)),
+                "the first post-boot verb must be ActivateEnvironment, got: {req:?}"
+            );
+            session
+                .write(&mut stream, &GuestResponse::ActivateEnvironmentAck)
+                .expect("write ack");
+        });
+
+        runner
+            .start_workload(&WorkloadLaunchInputs {
+                config: &cfg,
+                tenant: "local",
+                secrets: &[],
+                redaction: &redaction,
+                network_policy: &policy,
+                cmdline: String::new(),
+            })
+            .expect("start_workload succeeds once activation is ACKed");
+        guest.join().expect("guest thread");
+    }
+
+    /// A legacy per-rootfs initramfs boot (an initrd NOT under the shared
+    /// cache) is never sent `ActivateEnvironment` — the guest keeps its own
+    /// PID 1 and the launch proceeds without the handshake.
+    #[test]
+    fn start_workload_skips_activation_for_a_legacy_initramfs_boot() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
+        let legacy = home.path().join("rootfs.initrd");
+        std::fs::write(&legacy, b"initrd").unwrap();
+
+        let driver = MockDriver::default();
+        let runner = WorkloadRunner::new(
+            driver.clone(),
+            RecordingSpawner::new("/run/ep.sock"),
+            RecordingBrokerRegistrar::new(),
+        );
+        let cfg = VmStartConfig {
+            name: "runner-legacy-initrd".into(),
+            initrd_path: Some(legacy.to_string_lossy().into_owned()),
+            ..config("runner-legacy-initrd")
+        };
+        let policy = NetworkPolicy::deny_all();
+        let redaction = RedactionPolicy::default();
+        runner
+            .start_workload(&WorkloadLaunchInputs {
+                config: &cfg,
+                tenant: "local",
+                secrets: &[],
+                redaction: &redaction,
+                network_policy: &policy,
+                cmdline: String::new(),
+            })
+            .expect("a legacy initramfs boot needs no activation handshake");
+        // No vsock connect was ever made for activation: the loopback guest
+        // end registry is empty.
+        assert!(
+            driver
+                .take_guest_end(&VmId("runner-legacy-initrd".into()), GUEST_AGENT_PORT)
+                .is_none(),
+            "a legacy initramfs boot must not connect for activation"
         );
     }
 

--- a/public/src/content/docs/architecture/boot-flow.md
+++ b/public/src/content/docs/architecture/boot-flow.md
@@ -6,7 +6,12 @@ description: How a microVM boots the universal initramfs, receives its environme
 This page describes the current boot and execution path for workload microVMs.
 It replaces the older per-rootfs init schemes (`mvm-verity-init`, `mvm-oci-init`,
 busybox `/init`) with a single **universal initramfs** and a fail-closed
-activation step over vsock.
+activation step over vsock. Every runner backend boots this contract —
+Firecracker, libkrun, HVF, and QEMU (dev/test tier) all attach the universal
+initramfs and deliver `ActivateEnvironment` over vsock. QEMU's `vhost-vsock`
+speaks real `AF_VSOCK`, so its channels ride a per-VM `AF_VSOCK`↔UNIX bridge
+into the same per-port UNIX-socket convention the other backends expose
+natively.
 
 ## The universal initramfs
 

--- a/specs/notes/2026-07-29-universal-initramfs-future-tiers.md
+++ b/specs/notes/2026-07-29-universal-initramfs-future-tiers.md
@@ -46,6 +46,25 @@ backends").
   activation channel to the framework's vsock transport. Capability and
   security-profile honesty rules from ADR-024 apply verbatim.
 
+## QEMU (converged onto the unified runner)
+
+- Today: QEMU boots through the unified `WorkloadRunner` via
+  `crates/mvm-runtime/src/driver/qemu.rs` (`QemuDriver`), the same seam as
+  Firecracker/libkrun/HVF. A QEMU boot attaches the universal initramfs and
+  receives `ActivateEnvironment` over vsock exactly like the other backends;
+  the legacy `mvm.roothash=`/`mvm.data=`/`mvm.hash=` cmdline tokens are no
+  longer built by this path. Because QEMU's `vhost-vsock` speaks real
+  `AF_VSOCK`, the driver spawns a spec-driven per-VM `AF_VSOCK`↔UNIX bridge
+  (one detached `mvmctl __qemu-vsock-bridge` process) that serves the
+  host-dialed agent channel, relays the guest-dialed egress/broker channels
+  to the runner-bound listeners, and captures the workload-exit report.
+- Tier/status unchanged: dev/test tier only (Tier 2 best-case on KVM, TCG
+  runtime fallback banner-flagged), opt-in via `--hypervisor qemu`, never
+  auto-selected, and still barred from the admitted workload funnel. The
+  converged boot attaches no slirp user-mode NIC — egress routes solely
+  through the per-VM vsock endpoint, matching the other runner backends.
+  The raw `QemuBackend` remains as the driver's identity delegate.
+
 ## WHP (Windows Hypervisor Platform)
 
 - Guest side: unchanged — same kernel + universal initramfs, same


### PR DESCRIPTION
QEMU joins Firecracker, libkrun, and HVF on the unified `WorkloadRunner`: a QEMU boot now attaches the universal initramfs and receives `ActivateEnvironment` over vsock, instead of building legacy `mvm.roothash=` cmdline tokens itself.

## What changed

- **New `crates/mvm-runtime/src/driver/qemu.rs`**: `QemuDriver` behind the `VmmDriver` seam — pure spec→argv mapper (microvm machine type, `vhost-vsock-pci,guest-cid`, no NIC in the spec), serial base bootargs, disk-backed `RunningVm` with allow-listed `vsock_connect` to the bridge's per-port UNIX sockets.
- **Spec-driven multi-channel vsock bridge** (reused by the raw backend and the driver): one detached bridge process per VM handles host-dialed channels (agent, console data), guest-dialed channels (egress, broker), and exit-stream capture via a new shared `mvm_core::exit_capture::capture_stream`.
- **Registration**: `AnyBackend::Qemu(qemu_runner())` in backend/catalog/selection; raw `QemuBackend` kept as the identity delegate. QEMU stays dev/test tier, never auto-selected, barred from the admitted prod funnel.
- **Behavior note**: the converged boot drops QEMU's slirp user-mode NIC — guests route egress through the per-VM gating endpoint like every other runner backend (same precedent as the Firecracker convergence). Raw `QemuBackend` argv is untouched.

## Validation

- 1145 mvm-runtime tests pass (11 new driver tests + 2 new runner activation tests proving the first post-boot verb is `ActivateEnvironment` for a universal-initramfs boot and skipped for a legacy initrd).
- Workspace clippy clean; policy xtasks clean; Linux musl check compiles.