### PR TITLE
feat(docker): opt-in dev-tier container backend with agent-as-PID-1 activation (ADR-034)

### DIFF
--- a/crates/mvm-agentd/Cargo.toml
+++ b/crates/mvm-agentd/Cargo.toml
@@ -222,6 +222,7 @@ nix = { version = "0.29", features = ["socket"] }
 
 [dev-dependencies]
 tempfile.workspace = true
+mvm-core = { path = "../mvm-core", features = ["test-support"] }
 
 [lints]
 workspace = true

--- a/crates/mvm-agentd/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent.rs
@@ -44,10 +44,11 @@ mod signals;
 mod socket;
 #[path = "mvm-guest-agent/state.rs"]
 mod state;
+#[path = "mvm-guest-agent/transport.rs"]
+mod transport;
 
 use ed25519_dalek::SigningKey;
 use std::io::Write;
-use std::mem::size_of;
 use std::os::fd::{FromRawFd, RawFd};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -109,11 +110,9 @@ use crate::globals::{
 };
 use crate::monitoring::monitoring_loop;
 use crate::signals::{apply_reload, install_signal_handlers, shutdown_subsystems};
-use crate::socket::{
-    AF_VSOCK, AuthenticatedWriter, SOCK_STREAM, SockAddrVm, VMADDR_CID_ANY, accept, bind, close,
-    listen, peer_cid_is_authorized, socket, write_response,
-};
+use crate::socket::{AuthenticatedWriter, close, write_response};
 use crate::state::{ActivationState, AgentBootState, AgentState, IntegrationState, ProbeState};
+use crate::transport::{AgentListener, accept_control, bind_listener};
 
 use handlers::{
     handle_checkpoint_integrations, handle_entrypoint_status, handle_fs_diff, handle_fs_list,
@@ -535,10 +534,19 @@ fn main() {
         .unwrap_or_else(|| mvm_core::security::SecurityPolicy::dev_defaults().profile);
     eprintln!("mvm-guest-agent: profile={:?}", active_profile);
 
-    eprintln!(
-        "mvm-guest-agent: starting on vsock port {} (threshold={}, interval={}s)",
-        cfg.port, cfg.busy_threshold, cfg.sample_interval_secs
-    );
+    if crate::transport::unix_transport_selected() {
+        eprintln!(
+            "mvm-guest-agent: starting on unix socket {} (threshold={}, interval={}s)",
+            crate::transport::unix_socket_path().display(),
+            cfg.busy_threshold,
+            cfg.sample_interval_secs
+        );
+    } else {
+        eprintln!(
+            "mvm-guest-agent: starting on vsock port {} (threshold={}, interval={}s)",
+            cfg.port, cfg.busy_threshold, cfg.sample_interval_secs
+        );
+    }
 
     // PID-1 initramfs setup: mount early filesystems and install the
     // SIGCHLD reaper before the control plane comes up.  On non-PID-1
@@ -551,47 +559,18 @@ fn main() {
     // might want clean teardown.
     install_signal_handlers();
 
-    // SAFETY: libc call, arguments are constant values.
-    let fd = unsafe { socket(AF_VSOCK, SOCK_STREAM, 0) };
-    if fd < 0 {
-        eprintln!("failed to create vsock socket");
-        std::process::exit(1);
-    }
-
-    let addr = SockAddrVm {
-        svm_family: AF_VSOCK as u16,
-        svm_reserved1: 0,
-        svm_port: cfg.port,
-        svm_cid: VMADDR_CID_ANY,
-        svm_zero: [0; 4],
-    };
-
-    // SAFETY: pointers are valid for the specified size.
-    let bind_rc = unsafe {
-        bind(
-            fd,
-            &addr as *const SockAddrVm as *const core::ffi::c_void,
-            size_of::<SockAddrVm>() as u32,
-        )
-    };
-    if bind_rc != 0 {
-        eprintln!("failed to bind vsock port {}", cfg.port);
-        // SAFETY: `fd` is the vsock socket created above, not yet wrapped in an
-        // owning type; close takes no pointers.
-        unsafe {
-            close(fd);
+    // Bind the control-plane listener: AF_VSOCK on microVM backends,
+    // AF_UNIX on the shared-kernel container tier (see transport.rs).
+    let listener = match bind_listener(cfg.port) {
+        Ok(listener) => listener,
+        Err(e) => {
+            eprintln!(
+                "failed to bind control-plane listener (port {}): {e}",
+                cfg.port
+            );
+            std::process::exit(1);
         }
-        std::process::exit(1);
-    }
-
-    // SAFETY: fd is valid.
-    if unsafe { listen(fd, 16) } != 0 {
-        eprintln!("failed to listen on vsock socket");
-        unsafe {
-            close(fd);
-        }
-        std::process::exit(1);
-    }
+    };
 
     // Record boot time for startup grace period tracking.
     let boot_at = std::time::Instant::now();
@@ -720,10 +699,16 @@ fn main() {
     // Port forwarders are started on-demand via StartPortForward requests
     // from the host (works with all backends, no config drive needed).
 
-    eprintln!(
-        "mvm-guest-agent: listening on vsock port {} (entrypoint, warm pool, integrations, probes initializing in background)",
-        cfg.port
-    );
+    match &listener {
+        AgentListener::Vsock(_) => eprintln!(
+            "mvm-guest-agent: listening on vsock port {} (entrypoint, warm pool, integrations, probes initializing in background)",
+            cfg.port
+        ),
+        AgentListener::Unix(_) => eprintln!(
+            "mvm-guest-agent: listening on unix socket {} (entrypoint, warm pool, integrations, probes initializing in background)",
+            crate::transport::unix_socket_path().display()
+        ),
+    }
 
     // Every accepted connection gets its own bounded worker so a long-running
     // data stream cannot prevent Ping, readiness, sleep, or shutdown requests
@@ -749,56 +734,18 @@ fn main() {
         {
             apply_reload();
         }
-        // Accept into a `sockaddr_vm` so the peer CID is captured: the control
-        // port is host-only, and a guest-local workload on a loopback-capable
-        // kernel could otherwise dial it and inject any GuestRequest.
-        let mut peer = SockAddrVm {
-            svm_family: 0,
-            svm_reserved1: 0,
-            svm_port: 0,
-            svm_cid: 0,
-            svm_zero: [0; 4],
-        };
-        let mut peer_len = size_of::<SockAddrVm>() as u32;
-        // SAFETY: `peer` is a fully-owned, correctly-sized `sockaddr_vm`; the
-        // kernel writes at most `peer_len` bytes and updates it to the actual
-        // length.
-        let cfd = unsafe {
-            accept(
-                fd,
-                &mut peer as *mut SockAddrVm as *mut core::ffi::c_void,
-                &mut peer_len,
-            )
-        };
-        if cfd < 0 {
-            // Most common reason: EINTR from a signal. Re-check the
-            // flag immediately so a SIGTERM that landed mid-accept
-            // breaks the loop without waiting for the next accept
-            // to start.
+        // Accept one control connection; the transport applies its own
+        // peer authorization (the vsock host-CID gate, or the unix socket
+        // directory boundary — see transport.rs). `None` covers both EINTR
+        // and a rejected peer: re-check the shutdown flag and retry.
+        let Some(cfd) = accept_control(&listener) else {
             if SHUTDOWN_REQUESTED.load(Ordering::Acquire) {
                 break;
             }
             // Same fast-path for SIGHUP — apply the reload on the
             // next iteration's compare_exchange.
             continue;
-        }
-        // Fail closed: reject unless the kernel filled a full AF_VSOCK address
-        // whose peer CID is the host. A truncated/unfamiliar address leaves the
-        // peer unknown, so it is treated as unauthorized.
-        let peer_known =
-            peer_len >= size_of::<SockAddrVm>() as u32 && peer.svm_family == AF_VSOCK as u16;
-        if !peer_known || !peer_cid_is_authorized(peer.svm_cid) {
-            eprintln!(
-                "mvm-guest-agent: rejecting control connection from non-host peer (cid={}, family={})",
-                peer.svm_cid, peer.svm_family
-            );
-            // SAFETY: `cfd` is the just-accepted connection fd, not yet wrapped
-            // in an owning type; close takes no pointers.
-            unsafe {
-                close(cfd);
-            }
-            continue;
-        }
+        };
         // Stamp first-accept timing once. Idempotent inside
         // `AgentBootState` — subsequent calls are no-ops.
         boot_state.mark_first_accept();
@@ -830,9 +777,12 @@ fn main() {
 
     // Close the listening socket so any in-flight accept on a
     // peer thread (warm-process accept-thread-per-conn mode) wakes.
-    // SAFETY: fd was created by socket() and is owned by us.
-    unsafe {
-        close(fd);
+    if let AgentListener::Vsock(fd) = listener {
+        // SAFETY: fd was created by socket() and is owned by us. The AF_UNIX
+        // variant closes on drop.
+        unsafe {
+            close(fd);
+        }
     }
     shutdown_subsystems(DEFAULT_SHUTDOWN_GRACE);
 }

--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
@@ -42,7 +42,16 @@ pub(crate) fn early_setup() {
 
     #[cfg(target_os = "linux")]
     {
-        if let Err(e) = guest_mount::mount_early_filesystems() {
+        if crate::transport::unix_transport_selected() {
+            // A shared-kernel container runtime has already mounted /proc,
+            // /sys, and /dev for the namespace and drops CAP_SYS_ADMIN, so
+            // the initramfs early mounts would fail with EPERM. The agent
+            // is still PID 1 of the container's PID namespace, so the
+            // SIGCHLD reaper is still required.
+            eprintln!(
+                "mvm-guest-agent: unix transport — container runtime provides early filesystems"
+            );
+        } else if let Err(e) = guest_mount::mount_early_filesystems() {
             fatal(&format!("early filesystem mount failed: {e}"));
         }
         install_sigchld_handler();
@@ -71,7 +80,14 @@ pub(crate) fn apply_activation(
     let new_root = guest_mount::mount_rootfs(&env.rootfs)?;
     guest_mount::mount_runtime_overlay(env.runtime.as_ref(), &new_root)?;
     guest_mount::mount_volumes(&env.volumes, &new_root)?;
-    guest_mount::pivot_to_root(&new_root)?;
+    if env.rootfs.in_place {
+        // Shared-kernel container: the runtime already owns `/`, so there is
+        // no staged root to pivot into — activation is the privilege drop
+        // and the gate flip only.
+        eprintln!("mvm-guest-agent: in-place root, skipping pivot");
+    } else {
+        guest_mount::pivot_to_root(&new_root)?;
+    }
     guest_mount::drop_privilege(WORKLOAD_UID, WORKLOAD_GID)?;
 
     boot_state.set_activation(ActivationState::Activated);

--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/transport.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/transport.rs
@@ -1,0 +1,231 @@
+//! Listener transport selection: AF_VSOCK on microVM backends, AF_UNIX on
+//! the shared-kernel container tier.
+//!
+//! A container has no vsock: the host reaches the guest agent through a
+//! Unix socket that lives on a host-owned directory bind-mounted into the
+//! container. Everything above the accept — the frame I/O, the
+//! authenticated session, the `NotActivated` gate, the verb dispatch — is
+//! transport-agnostic and unchanged; only the socket family and the peer
+//! authorization differ:
+//!
+//! - **AF_VSOCK**: the kernel reports a peer CID per accepted connection,
+//!   and [`peer_cid_is_authorized`] rejects anything that is not the host.
+//! - **AF_UNIX**: there is no peer identity to check. The boundary is the
+//!   socket file's location on a host-owned directory (created 0700 by the
+//!   host backend) — plus the authenticated session every connection still
+//!   performs. That is a deliberately weaker boundary than the CID gate,
+//!   which is exactly why the container tier is dev-only and prod-refused.
+
+use std::os::fd::RawFd;
+use std::os::unix::net::UnixListener;
+use std::path::{Path, PathBuf};
+
+use crate::socket::{
+    AF_VSOCK, SOCK_STREAM, SockAddrVm, VMADDR_CID_ANY, accept, bind, close, listen,
+    peer_cid_is_authorized, socket,
+};
+use std::mem::size_of;
+
+/// Environment variable selecting the listener transport. The only
+/// non-default value is `unix`; anything else (or unset) keeps the vsock
+/// listener the microVM backends use.
+pub(crate) const TRANSPORT_ENV: &str = "MVM_AGENT_TRANSPORT";
+/// Environment variable naming the AF_UNIX socket path in unix mode.
+pub(crate) const UNIX_SOCK_ENV: &str = "MVM_AGENT_UNIX_SOCK";
+/// Default AF_UNIX socket path: the shared run dir the host backend
+/// bind-mounts into the container.
+pub(crate) const DEFAULT_UNIX_SOCK: &str = "/run/mvm/agent.sock";
+
+/// Whether the agent should listen on AF_UNIX instead of AF_VSOCK.
+pub(crate) fn unix_transport_selected() -> bool {
+    std::env::var(TRANSPORT_ENV).ok().as_deref() == Some("unix")
+}
+
+/// The AF_UNIX socket path to bind in unix mode.
+pub(crate) fn unix_socket_path() -> PathBuf {
+    std::env::var(UNIX_SOCK_ENV)
+        .ok()
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_UNIX_SOCK))
+}
+
+/// The control-plane listener, bound at startup.
+pub(crate) enum AgentListener {
+    /// AF_VSOCK listener fd (microVM backends; the peer-CID gate applies).
+    Vsock(RawFd),
+    /// AF_UNIX listener (shared-kernel container tier).
+    Unix(UnixListener),
+}
+
+/// Bind the control-plane listener for the selected transport. `vsock_port`
+/// is the agent's configured port; it is ignored in unix mode.
+pub(crate) fn bind_listener(vsock_port: u32) -> std::io::Result<AgentListener> {
+    if unix_transport_selected() {
+        return bind_unix_listener(&unix_socket_path()).map(AgentListener::Unix);
+    }
+    // SAFETY: libc call, arguments are constant values.
+    let fd = unsafe { socket(AF_VSOCK, SOCK_STREAM, 0) };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let addr = SockAddrVm {
+        svm_family: AF_VSOCK as u16,
+        svm_reserved1: 0,
+        svm_port: vsock_port,
+        svm_cid: VMADDR_CID_ANY,
+        svm_zero: [0; 4],
+    };
+    // SAFETY: pointers are valid for the specified size; on failure the fd
+    // is closed before returning.
+    let bind_rc = unsafe {
+        bind(
+            fd,
+            &addr as *const SockAddrVm as *const core::ffi::c_void,
+            size_of::<SockAddrVm>() as u32,
+        )
+    };
+    if bind_rc != 0 {
+        let err = std::io::Error::last_os_error();
+        // SAFETY: `fd` is the vsock socket created above, not yet wrapped in
+        // an owning type; close takes no pointers.
+        unsafe {
+            close(fd);
+        }
+        return Err(err);
+    }
+    // SAFETY: fd is valid; on failure it is closed before returning.
+    if unsafe { listen(fd, 16) } != 0 {
+        let err = std::io::Error::last_os_error();
+        unsafe {
+            close(fd);
+        }
+        return Err(err);
+    }
+    Ok(AgentListener::Vsock(fd))
+}
+
+/// Bind an AF_UNIX listener at `path`, creating the parent directory if
+/// needed and replacing any stale socket file. Split from
+/// [`bind_listener`] so the unix-mode bind is unit-testable without the
+/// env override.
+pub(crate) fn bind_unix_listener(path: &Path) -> std::io::Result<UnixListener> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // A stale socket from a previous container run would fail the bind with
+    // EADDRINUSE. Best-effort removal.
+    let _ = std::fs::remove_file(path);
+    UnixListener::bind(path)
+}
+
+/// Accept one control connection, enforcing the transport's peer
+/// authorization. `None` means "no usable connection this round" — an
+/// interrupted accept or an unauthorized peer that was rejected and
+/// closed; the caller re-checks its shutdown flags and retries.
+pub(crate) fn accept_control(listener: &AgentListener) -> Option<RawFd> {
+    match listener {
+        AgentListener::Vsock(fd) => accept_control_vsock(*fd),
+        AgentListener::Unix(listener) => accept_control_unix(listener),
+    }
+}
+
+/// AF_VSOCK accept + the host-only peer-CID gate (unchanged semantics from
+/// the original inline loop).
+fn accept_control_vsock(fd: RawFd) -> Option<RawFd> {
+    // Accept into a `sockaddr_vm` so the peer CID is captured: the control
+    // port is host-only, and a guest-local workload on a loopback-capable
+    // kernel could otherwise dial it and inject any GuestRequest.
+    let mut peer = SockAddrVm {
+        svm_family: 0,
+        svm_reserved1: 0,
+        svm_port: 0,
+        svm_cid: 0,
+        svm_zero: [0; 4],
+    };
+    let mut peer_len = size_of::<SockAddrVm>() as u32;
+    // SAFETY: `peer` is a fully-owned, correctly-sized `sockaddr_vm`; the
+    // kernel writes at most `peer_len` bytes and updates it to the actual
+    // length.
+    let cfd = unsafe {
+        accept(
+            fd,
+            &mut peer as *mut SockAddrVm as *mut core::ffi::c_void,
+            &mut peer_len,
+        )
+    };
+    if cfd < 0 {
+        // Most common reason: EINTR from a signal. The caller re-checks its
+        // shutdown flag immediately.
+        return None;
+    }
+    // Fail closed: reject unless the kernel filled a full AF_VSOCK address
+    // whose peer CID is the host. A truncated/unfamiliar address leaves the
+    // peer unknown, so it is treated as unauthorized.
+    let peer_known =
+        peer_len >= size_of::<SockAddrVm>() as u32 && peer.svm_family == AF_VSOCK as u16;
+    if !peer_known || !peer_cid_is_authorized(peer.svm_cid) {
+        eprintln!(
+            "mvm-guest-agent: rejecting control connection from non-host peer (cid={}, family={})",
+            peer.svm_cid, peer.svm_family
+        );
+        // SAFETY: `cfd` is the just-accepted connection fd, not yet wrapped
+        // in an owning type; close takes no pointers.
+        unsafe {
+            close(cfd);
+        }
+        return None;
+    }
+    Some(cfd)
+}
+
+/// AF_UNIX accept. There is no peer CID to authorize — see the module docs
+/// for the boundary that replaces it.
+fn accept_control_unix(listener: &UnixListener) -> Option<RawFd> {
+    use std::os::fd::IntoRawFd;
+    match listener.accept() {
+        Ok((stream, _addr)) => Some(stream.into_raw_fd()),
+        Err(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::os::fd::FromRawFd;
+
+    #[test]
+    fn unix_listener_round_trips_a_byte_stream() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("nested").join("agent.sock");
+        // bind_unix_listener creates the missing parent dir.
+        let listener = bind_unix_listener(&sock).expect("bind unix listener");
+        assert!(sock.exists());
+
+        let client = std::thread::spawn(move || {
+            let mut c = std::os::unix::net::UnixStream::connect(&sock).unwrap();
+            c.write_all(b"x").unwrap();
+            let mut got = [0u8; 1];
+            c.read_exact(&mut got).unwrap();
+            assert_eq!(&got, b"x");
+        });
+
+        let cfd = accept_control(&AgentListener::Unix(listener)).expect("accept");
+        // SAFETY: `cfd` is the just-accepted connection fd, owned here.
+        let mut conn = unsafe { std::fs::File::from_raw_fd(cfd) };
+        let mut b = [0u8; 1];
+        conn.read_exact(&mut b).unwrap();
+        conn.write_all(&b).unwrap();
+        client.join().unwrap();
+    }
+
+    #[test]
+    fn bind_unix_listener_replaces_a_stale_socket_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("agent.sock");
+        std::fs::write(&sock, b"stale").unwrap();
+        let listener = bind_unix_listener(&sock);
+        assert!(listener.is_ok(), "stale file must be replaced");
+    }
+}

--- a/crates/mvm-agentd/src/forward_proxy.rs
+++ b/crates/mvm-agentd/src/forward_proxy.rs
@@ -160,14 +160,46 @@ fn reason_phrase(status: u16) -> &'static str {
     }
 }
 
+/// Environment variable naming the host substitution endpoint's Unix
+/// socket on the shared-kernel container tier: the endpoint lives on a
+/// host-owned directory bind-mounted into the container, so the forward
+/// proxy relays to it over AF_UNIX instead of the vsock `EGRESS_PORT` (a
+/// container has no vsock). Unset on microVM backends, which keep the
+/// vsock path.
+pub const EGRESS_ENDPOINT_SOCK_ENV: &str = "MVM_AGENT_EGRESS_ENDPOINT_SOCK";
+
+/// The bind-mounted substitution-endpoint socket a shared-kernel container
+/// relays egress through, when the host backend configured one. `None` on
+/// microVM backends and on container boots with no endpoint (no bound
+/// secrets and a deny-egress policy), where every proxied request must
+/// fail closed rather than silently bypass the gate.
+pub fn egress_endpoint_socket() -> Option<std::path::PathBuf> {
+    let path = std::env::var(EGRESS_ENDPOINT_SOCK_ENV).ok()?;
+    (!path.is_empty()).then_some(std::path::PathBuf::from(path))
+}
+
 /// Start the guest-local forward proxy: bind loopback [`FORWARD_PROXY_PORT`] and
-/// serve, relaying each request to the host substitution endpoint over a
-/// guest→host AF_VSOCK connection. Blocks; the guest init runs it on its own
+/// serve, relaying each request to the host substitution endpoint — over a
+/// guest→host AF_VSOCK connection on microVM backends, or over the
+/// bind-mounted endpoint Unix socket on the shared-kernel container tier.
+/// Blocks; the guest init runs it on its own
 /// thread. This is the production entry point — `serve` +
 /// `substitution_client::substitute` are the unit-tested parts it composes.
 pub fn start_forward_proxy(relay_timeout_secs: u64) -> Result<()> {
     let listener = TcpListener::bind(("127.0.0.1", FORWARD_PROXY_PORT))
         .with_context(|| format!("binding forward proxy on 127.0.0.1:{FORWARD_PROXY_PORT}"))?;
+    if let Some(endpoint_sock) = egress_endpoint_socket() {
+        return serve(&listener, move |req| {
+            let mut stream =
+                std::os::unix::net::UnixStream::connect(&endpoint_sock).with_context(|| {
+                    format!(
+                        "connect to substitution endpoint {}",
+                        endpoint_sock.display()
+                    )
+                })?;
+            substitution_client::relay(&mut stream, req)
+        });
+    }
     serve(&listener, move |req| {
         substitution_client::substitute(req, relay_timeout_secs)
     })
@@ -276,6 +308,56 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn egress_endpoint_socket_reads_the_env_only_when_set_and_non_empty() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+
+        env.remove(EGRESS_ENDPOINT_SOCK_ENV);
+        assert_eq!(egress_endpoint_socket(), None);
+        env.set(EGRESS_ENDPOINT_SOCK_ENV, "");
+        assert_eq!(egress_endpoint_socket(), None);
+        env.set(
+            EGRESS_ENDPOINT_SOCK_ENV,
+            "/run/mvm/substitution-endpoint.sock",
+        );
+        assert_eq!(
+            egress_endpoint_socket(),
+            Some(std::path::PathBuf::from(
+                "/run/mvm/substitution-endpoint.sock"
+            ))
+        );
+    }
+
+    #[test]
+    fn relay_over_a_unix_stream_round_trips_like_the_vsock_path() {
+        // The container tier's upstream: `substitution_client::relay` speaks
+        // the identical framed wire protocol over a plain UnixStream, so a
+        // bind-mounted endpoint socket behaves exactly like the vsock leg.
+        use mvm_core::substitution_wire::WireResponse;
+
+        let (mut host_side, mut endpoint_side) = std::os::unix::net::UnixStream::pair().unwrap();
+        let server = std::thread::spawn(move || {
+            let req: WireRequest = crate::vsock::read_frame(&mut endpoint_side).unwrap();
+            let resp = WireResponse::Ok {
+                status: 200,
+                headers: vec![],
+                body_b64: String::new(),
+            };
+            crate::vsock::write_frame(&mut endpoint_side, &resp).unwrap();
+            req
+        });
+
+        let req = WireRequest {
+            method: "GET".into(),
+            url: "https://example.test/".into(),
+            headers: vec![],
+            body_b64: String::new(),
+        };
+        let resp = substitution_client::relay(&mut host_side, &req).unwrap();
+        assert!(matches!(resp, WireResponse::Ok { status: 200, .. }));
+        assert_eq!(server.join().unwrap(), req);
+    }
 
     #[test]
     fn parses_a_get_with_absolute_url_and_headers() {

--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -34,6 +34,9 @@ pub enum MountError {
     /// A required filesystem type is unavailable.
     #[error("unsupported filesystem: {0}")]
     UnsupportedFilesystem(String),
+    /// The activation message itself is contradictory or malformed.
+    #[error("invalid activation config: {0}")]
+    InvalidConfig(String),
 }
 
 impl MountError {
@@ -104,13 +107,33 @@ pub fn mount_early_filesystems() -> Result<()> {
 
 /// Mount the rootfs, returning the staging path (`/mnt/root`).
 ///
-/// Three shapes, selected by the config's optional fields: a dm-verity block
-/// root (`roothash` + `hash_dev` set — create the `root` target and mount it
-/// read-only), an unverified plain-block root (neither set — mount the data
-/// device read-only directly), or a virtio-fs root (`virtiofs_tag` set —
-/// mount the tag read-only).  On non-Linux platforms it is a no-op stub so
-/// the workspace compiles.
+/// Three mount shapes, selected by the config's optional fields: a
+/// dm-verity block root (`roothash` + `hash_dev` set — create the `root`
+/// target and mount it read-only), an unverified plain-block root
+/// (neither set — mount the data device read-only directly), or a
+/// virtio-fs root (`virtiofs_tag` set — mount the tag read-only). The
+/// fourth shape, `in_place`, mounts nothing and returns `/` directly: the
+/// runtime already owns the root (a shared-kernel container whose root is
+/// the image). On non-Linux platforms it is a no-op stub so the workspace
+/// compiles.
 pub fn mount_rootfs(rootfs: &RootfsConfig) -> Result<PathBuf> {
+    if rootfs.in_place {
+        // Mutually exclusive with every mount-carrying field: a host that
+        // sets both gets a loud validation error, never a silent choice
+        // between "mount this device" and "the root is already there".
+        if !rootfs.data_dev.is_empty()
+            || rootfs.hash_dev.is_some()
+            || rootfs.roothash.is_some()
+            || rootfs.virtiofs_tag.is_some()
+        {
+            return Err(MountError::InvalidConfig(
+                "rootfs.in_place is mutually exclusive with data_dev/hash_dev/roothash/virtiofs_tag"
+                    .to_string(),
+            ));
+        }
+        return Ok(PathBuf::from("/"));
+    }
+
     ensure_dir(ROOTFS_STAGING)?;
 
     #[cfg(not(target_os = "linux"))]
@@ -797,6 +820,58 @@ mod tests {
     #[test]
     fn validate_roothash_accepts_64_lowercase_hex() {
         assert!(validate_roothash(FAKE_HASH, "test").is_ok());
+    }
+
+    #[test]
+    fn in_place_rootfs_mounts_nothing_and_returns_root() {
+        let cfg = RootfsConfig {
+            data_dev: String::new(),
+            hash_dev: None,
+            roothash: None,
+            virtiofs_tag: None,
+            in_place: true,
+        };
+        assert_eq!(mount_rootfs(&cfg).unwrap(), PathBuf::from("/"));
+    }
+
+    #[test]
+    fn in_place_rootfs_rejects_mount_carrying_fields() {
+        for cfg in [
+            RootfsConfig {
+                data_dev: "/dev/vda".to_string(),
+                hash_dev: None,
+                roothash: None,
+                virtiofs_tag: None,
+                in_place: true,
+            },
+            RootfsConfig {
+                data_dev: String::new(),
+                hash_dev: Some("/dev/vdb".to_string()),
+                roothash: None,
+                virtiofs_tag: None,
+                in_place: true,
+            },
+            RootfsConfig {
+                data_dev: String::new(),
+                hash_dev: None,
+                roothash: Some(FAKE_HASH.to_string()),
+                virtiofs_tag: None,
+                in_place: true,
+            },
+            RootfsConfig {
+                data_dev: String::new(),
+                hash_dev: None,
+                roothash: None,
+                virtiofs_tag: Some("mvmroot".to_string()),
+                in_place: true,
+            },
+        ] {
+            let err = mount_rootfs(&cfg).unwrap_err();
+            assert!(
+                matches!(err, MountError::InvalidConfig(_)),
+                "expected InvalidConfig, got: {err}"
+            );
+        }
     }
 
     #[test]

--- a/crates/mvm-agentd/src/vsock/activation.rs
+++ b/crates/mvm-agentd/src/vsock/activation.rs
@@ -34,8 +34,8 @@ pub struct ActivateEnvironment {
     pub verb_grant_envelope: Option<mvm_core::protocol::vm_backend::VerbGrantEnvelope>,
 }
 
-/// Root device the guest mounts as `/`.  Three shapes, selected by which
-/// optional fields are set:
+/// Root device the guest mounts as `/`.  Three mount shapes, selected by
+/// which optional fields are set, plus one mount-free shape:
 ///
 /// - **dm-verity block** (`roothash` + `hash_dev`): create the `root`
 ///   dm-verity target and mount it read-only.
@@ -43,6 +43,10 @@ pub struct ActivateEnvironment {
 ///   verification (unverified dev-tier boot).
 /// - **virtio-fs root** (`virtiofs_tag`): mount the virtio-fs tag read-only
 ///   as the root — the block-less dev-tier boot.
+/// - **in place** (`in_place`): the runtime already owns `/` — a
+///   shared-kernel container whose root is the image itself. Nothing is
+///   mounted and no pivot happens; activation is the privilege drop and
+///   the gate flip only.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -60,6 +64,12 @@ pub struct RootfsConfig {
     /// virtio-fs tag to mount as the root instead of a block device.
     #[serde(default)]
     pub virtiofs_tag: Option<String>,
+    /// The root is already in place (shared-kernel container tier): skip
+    /// the rootfs mount and the pivot entirely. Mutually exclusive with
+    /// every other field — a host that sets this alongside a device, hash,
+    /// or tag gets a validation error from the agent, not a silent choice.
+    #[serde(default)]
+    pub in_place: bool,
 }
 
 /// dm-verity runtime-overlay target.  The runtime overlay is always
@@ -102,6 +112,7 @@ mod tests {
                 hash_dev: Some("/dev/vdb".to_string()),
                 roothash: Some("a".repeat(64)),
                 virtiofs_tag: None,
+                in_place: false,
             },
             runtime: Some(RuntimeOverlayConfig {
                 data_dev: "/dev/vdc".to_string(),
@@ -136,6 +147,7 @@ mod tests {
                 hash_dev: None,
                 roothash: None,
                 virtiofs_tag: None,
+                in_place: false,
             },
             runtime: None,
             volumes: Vec::new(),
@@ -154,6 +166,7 @@ mod tests {
                 hash_dev: None,
                 roothash: None,
                 virtiofs_tag: Some("mvmroot".to_string()),
+                in_place: false,
             },
             runtime: None,
             volumes: Vec::new(),
@@ -162,6 +175,32 @@ mod tests {
         let json = serde_json::to_string(&env).expect("serialize");
         let parsed: ActivateEnvironment = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(parsed.rootfs.virtiofs_tag.as_deref(), Some("mvmroot"));
+    }
+
+    #[test]
+    fn in_place_root_roundtrips_and_defaults_absent() {
+        // In-place (container) root: only the flag is set.
+        let env = ActivateEnvironment {
+            rootfs: RootfsConfig {
+                data_dev: String::new(),
+                hash_dev: None,
+                roothash: None,
+                virtiofs_tag: None,
+                in_place: true,
+            },
+            runtime: None,
+            volumes: Vec::new(),
+            verb_grant_envelope: None,
+        };
+        let json = serde_json::to_string(&env).expect("serialize");
+        let parsed: ActivateEnvironment = serde_json::from_str(&json).expect("deserialize");
+        assert!(parsed.rootfs.in_place);
+
+        // Older messages carry no `in_place` key at all; it defaults to the
+        // mount-owning boot shapes.
+        let legacy = r#"{"rootfs":{"data_dev":"/dev/vda"}}"#;
+        let parsed: ActivateEnvironment = serde_json::from_str(legacy).expect("deserialize");
+        assert!(!parsed.rootfs.in_place);
     }
 
     #[test]

--- a/crates/mvm-agentd/src/vsock/request.rs
+++ b/crates/mvm-agentd/src/vsock/request.rs
@@ -1284,6 +1284,7 @@ mod tests {
                 hash_dev: Some("/dev/vdb".to_string()),
                 roothash: Some("a".repeat(64)),
                 virtiofs_tag: None,
+                in_place: false,
             },
             runtime: Some(RuntimeOverlayConfig {
                 data_dev: "/dev/vdc".to_string(),

--- a/crates/mvm-agentd/src/vsock/request_policy.rs
+++ b/crates/mvm-agentd/src/vsock/request_policy.rs
@@ -623,6 +623,7 @@ mod tests {
                 hash_dev: Some("/dev/vdb".to_string()),
                 roothash: Some("a".repeat(64)),
                 virtiofs_tag: None,
+                in_place: false,
             },
             runtime: Some(RuntimeOverlayConfig {
                 data_dev: "/dev/vdc".to_string(),

--- a/crates/mvm-cli/src/doctor/warm_start.rs
+++ b/crates/mvm-cli/src/doctor/warm_start.rs
@@ -240,6 +240,7 @@ mod tests {
     #[test]
     fn collect_warm_start_support_reports_per_backend_tier() {
         let r = collect_warm_start_support();
+        assert_eq!(r.backends.get("docker"), Some(&"unsupported"));
         assert_eq!(r.backends.get("firecracker"), Some(&"unsupported"));
         assert_eq!(r.backends.get("libkrun"), Some(&"unsupported"));
         assert_eq!(r.backends.get("qemu"), Some(&"unsupported"));
@@ -254,6 +255,7 @@ mod tests {
         let ordered_standby_pool: Vec<_> = r.standby_pool.into_iter().collect();
 
         let mut expected_backends = vec![
+            ("docker".to_string(), "unsupported"),
             ("firecracker".to_string(), "unsupported"),
             ("hvf".to_string(), "unsupported"),
             ("libkrun".to_string(), "unsupported"),
@@ -261,6 +263,7 @@ mod tests {
             ("wasm".to_string(), "unsupported"),
         ];
         let mut expected_standby_pool = vec![
+            ("docker".to_string(), false),
             ("firecracker".to_string(), false),
             ("hvf".to_string(), false),
             ("libkrun".to_string(), false),
@@ -268,8 +271,8 @@ mod tests {
             ("wasm".to_string(), false),
         ];
         if cfg!(feature = "test-support") {
-            expected_backends.insert(3, ("mock".to_string(), "live-memory"));
-            expected_standby_pool.insert(3, ("mock".to_string(), false));
+            expected_backends.insert(4, ("mock".to_string(), "live-memory"));
+            expected_standby_pool.insert(4, ("mock".to_string(), false));
         }
         assert_eq!(ordered_backends, expected_backends);
         assert_eq!(ordered_standby_pool, expected_standby_pool);
@@ -291,7 +294,7 @@ mod tests {
         // Every selectable backend remains in the matrix, including explicit
         // unsupported recovery tiers.
         let names: Vec<_> = rows.iter().map(|r| r.backend.as_str()).collect();
-        let mut expected = vec!["firecracker", "hvf", "libkrun", "qemu", "wasm"];
+        let mut expected = vec!["docker", "firecracker", "hvf", "libkrun", "qemu", "wasm"];
         if cfg!(feature = "test-support") {
             expected.push("mock");
             expected.sort_unstable();

--- a/crates/mvm-cli/src/doctor/warm_start.rs
+++ b/crates/mvm-cli/src/doctor/warm_start.rs
@@ -274,8 +274,8 @@ mod tests {
             ("wasm".to_string(), false),
         ];
         if cfg!(feature = "test-support") {
-            expected_backends.insert(4, ("mock".to_string(), "live-memory"));
-            expected_standby_pool.insert(4, ("mock".to_string(), false));
+            expected_backends.insert(5, ("mock".to_string(), "live-memory"));
+            expected_standby_pool.insert(5, ("mock".to_string(), false));
         }
         assert_eq!(ordered_backends, expected_backends);
         assert_eq!(ordered_standby_pool, expected_standby_pool);

--- a/crates/mvm-protocol/src/protocol/vm_backend.rs
+++ b/crates/mvm-protocol/src/protocol/vm_backend.rs
@@ -1025,6 +1025,13 @@ pub enum BackendKind {
     /// portability/demo backend: opt-in only, never returned by auto-detect,
     /// no hardware isolation boundary.
     Wasm,
+    /// Shared-kernel container dev tier: the workload runs in a Docker
+    /// container with `mvm-guest-agent` as PID 1, receiving activation over
+    /// a host bind-mounted Unix socket instead of vsock. Opt-in only, never
+    /// returned by auto-detect, refused by production admission; none of
+    /// the hardware-isolation claims hold (the guest shares the host
+    /// kernel).
+    Docker,
 }
 
 #[cfg(test)]

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -10,6 +10,7 @@ use mvm_core::vm_backend::{
 // (`config`, `shell`, `runtime_meta`) lives in `crate::base`.
 use crate::base::config::{PortMapping, VmSlot};
 use crate::base::shell::run_in_vm_stdout;
+use crate::docker_backend::DockerBackend;
 use crate::driver::{FcDriver, HvfDriver, LibkrunDriver};
 use crate::image::RuntimeVolume;
 use crate::microvm::{DriveFile, FlakeRunConfig};
@@ -410,6 +411,13 @@ pub enum AnyBackend {
     /// closed with a typed error the first time the backend is actually
     /// used, not at construction.
     Wasm(WasmBackend),
+    /// Docker shared-kernel container dev tier — see
+    /// [`crate::docker_backend`]. Selectable only via explicit
+    /// `--hypervisor docker` / `MVM_BACKEND=docker`; `auto_select` never
+    /// falls through here, and production admission refuses it (no
+    /// workload-backend surface). Always constructible; every launch
+    /// request the tier cannot satisfy fails closed with a typed error.
+    Docker(DockerBackend),
 }
 
 impl AnyBackend {
@@ -560,6 +568,7 @@ impl AnyBackend {
             Self::Mock(backend) => backend,
             Self::Hvf(backend) => backend,
             Self::Wasm(backend) => backend,
+            Self::Docker(backend) => backend,
         }
     }
 
@@ -576,6 +585,7 @@ impl AnyBackend {
             Self::Mock(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
             Self::Hvf(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
             Self::Wasm(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
+            Self::Docker(backend) => std::sync::Arc::new(backend) as std::sync::Arc<dyn VmBackend>,
         }
     }
 
@@ -634,6 +644,12 @@ impl AnyBackend {
             // egress seam). Barred from the admitted launch funnel until
             // then, the same carve-out as `Qemu`.
             AnyBackend::Wasm(_) => None,
+            // Docker is a shared-kernel container dev tier: namespaces are
+            // not a hardware boundary, so it must never carry an untrusted
+            // production workload. Barred from the admitted launch funnel
+            // permanently — the same carve-out as `Qemu`, with no
+            // promotion path.
+            AnyBackend::Docker(_) => None,
         }
     }
 
@@ -687,7 +703,7 @@ impl AnyBackend {
             #[cfg(feature = "test-support")]
             AnyBackend::Mock(backend) => backend.spawn_standby(spec),
             // Not workload-bearing backends — no warm pool, fail closed.
-            AnyBackend::Qemu(_) | AnyBackend::Wasm(_) => {
+            AnyBackend::Qemu(_) | AnyBackend::Wasm(_) | AnyBackend::Docker(_) => {
                 Err(mvm_core::vm_backend::StandbyError::Unsupported {
                     backend: self.inner().name().to_string(),
                 })
@@ -729,7 +745,7 @@ impl AnyBackend {
             #[cfg(feature = "test-support")]
             AnyBackend::Mock(backend) => backend.claim_standby(handle, claim),
             // Not workload-bearing backends — no warm pool, fail closed.
-            AnyBackend::Qemu(_) | AnyBackend::Wasm(_) => {
+            AnyBackend::Qemu(_) | AnyBackend::Wasm(_) | AnyBackend::Docker(_) => {
                 Err(mvm_core::vm_backend::StandbyError::Unsupported {
                     backend: self.inner().name().to_string(),
                 })
@@ -1029,7 +1045,14 @@ mod tests {
 
     #[test]
     fn require_hypervisor_selectable_allows_every_other_name() {
-        for name in ["firecracker", "libkrun", "qemu", "hvf", "unknown-typo"] {
+        for name in [
+            "firecracker",
+            "libkrun",
+            "qemu",
+            "hvf",
+            "docker",
+            "unknown-typo",
+        ] {
             assert!(
                 AnyBackend::require_hypervisor_selectable(name).is_ok(),
                 "{name}: must never be refused"
@@ -1161,6 +1184,15 @@ mod tests {
     }
 
     #[test]
+    fn auto_select_never_returns_docker() {
+        assert_ne!(
+            AnyBackend::auto_select().kind(),
+            mvm_core::vm_backend::BackendKind::Docker,
+            "auto_select must never fall through to the docker shared-kernel dev tier"
+        );
+    }
+
+    #[test]
     fn backend_catalog_matrix_is_stable() {
         let actual: Vec<_> = catalog::descriptors()
             .iter()
@@ -1233,6 +1265,16 @@ mod tests {
                 ),
                 (
                     "wasm",
+                    Vec::new(),
+                    BackendTier::Tier3,
+                    None,
+                    None,
+                    true,
+                    false,
+                    false,
+                ),
+                (
+                    "docker",
                     Vec::new(),
                     BackendTier::Tier3,
                     None,
@@ -1332,6 +1374,7 @@ mod tests {
     #[test]
     fn recovery_capability_matrix_is_explicit_for_every_selectable_backend() {
         let mut expected = vec![
+            ("docker", SnapshotCapability::Unsupported, false),
             ("firecracker", SnapshotCapability::Unsupported, false),
             ("hvf", SnapshotCapability::Unsupported, false),
             ("libkrun", SnapshotCapability::Unsupported, false),
@@ -1424,6 +1467,7 @@ mod tests {
     #[test]
     fn tier_classification_locks_each_backend_variant() {
         let mut cases: Vec<(&str, BackendTier)> = vec![
+            ("docker", BackendTier::Tier3),
             ("firecracker", BackendTier::Tier1),
             ("libkrun", BackendTier::Tier2),
             ("qemu", BackendTier::Tier2),
@@ -1448,7 +1492,7 @@ mod tests {
         // long-standing per-backend tier declaration. `AnyBackend::tier()`
         // is the closed-enum view of the same fact. Bumping one without
         // the other is a regression — keep them wired.
-        let mut names = vec!["firecracker", "libkrun", "qemu"];
+        let mut names = vec!["docker", "firecracker", "libkrun", "qemu"];
         if cfg!(feature = "test-support") {
             names.push("mock");
         }
@@ -1500,6 +1544,17 @@ mod tests {
         assert!(
             backend.as_workload_backend().is_none(),
             "qemu: dev/test VMM must not be a workload backend"
+        );
+    }
+
+    #[test]
+    fn as_workload_backend_none_for_docker() {
+        // docker is a shared-kernel container dev tier: it must never carry
+        // an untrusted production workload.
+        let backend = AnyBackend::from_hypervisor("docker");
+        assert!(
+            backend.as_workload_backend().is_none(),
+            "docker: shared-kernel dev tier must not be a workload backend"
         );
     }
 
@@ -1577,6 +1632,7 @@ mod tests {
             ("libkrun", AnyBackend::Libkrun(libkrun_runner())),
             ("qemu", AnyBackend::Qemu(QemuBackend)),
             ("hvf", AnyBackend::Hvf(hvf_runner())),
+            ("docker", AnyBackend::Docker(DockerBackend::new())),
         ];
         backends.extend(mock_variant_for_ssh_check());
         for (name, backend) in backends {
@@ -1714,7 +1770,7 @@ mod tests {
         #[test]
         fn fails_closed_for_non_workload_backends() {
             let s = Scaffold::new();
-            for name in ["qemu", "wasm"] {
+            for name in ["qemu", "wasm", "docker"] {
                 let backend = AnyBackend::from_hypervisor(name);
                 let err = backend
                     .claim_standby_via_runner(&s.ctx(), &idle_handle(), &minimal_claim())
@@ -1749,7 +1805,7 @@ mod tests {
                 image_sha256: None,
             };
 
-            for name in ["qemu", "wasm"] {
+            for name in ["qemu", "wasm", "docker"] {
                 let backend = AnyBackend::from_hypervisor(name);
                 let err = backend
                     .spawn_standby_via_runner(

--- a/crates/mvm-runtime/src/catalog.rs
+++ b/crates/mvm-runtime/src/catalog.rs
@@ -13,6 +13,7 @@
 //! the closed enum for the few intentionally backend-specific operations.
 
 use crate::backend::{AnyBackend, BackendTier};
+use crate::docker_backend::DockerBackend;
 #[cfg(feature = "test-support")]
 use crate::mock::MockBackend;
 use crate::qemu::QemuBackend;
@@ -238,6 +239,23 @@ backend_catalog![
         bundled_kernel: false,
         needs_plan_json: false,
         is_workload: true
+    },
+    {
+        kind: Docker,
+        selector: "docker",
+        aliases: [],
+        constructor: AnyBackend::Docker(DockerBackend::new()),
+        tier: Tier3,
+        // Container state lives in the Docker daemon; there is no mvm-side
+        // pid file to probe.
+        marker_file: None,
+        started_vm_probe_order: None,
+        list_all: true,
+        balloon_support: false,
+        warm_start_support: false,
+        bundled_kernel: false,
+        needs_plan_json: false,
+        is_workload: false
     }
 ];
 
@@ -358,7 +376,7 @@ mod tests {
         );
         assert_eq!(
             selectors(list_all_descriptors()),
-            ["firecracker", "libkrun", "qemu", "hvf", "wasm"]
+            ["firecracker", "libkrun", "qemu", "hvf", "wasm", "docker"]
         );
         // Started-VM probe is sorted by probe order, not declaration order.
         assert_eq!(

--- a/crates/mvm-runtime/src/docker_backend.rs
+++ b/crates/mvm-runtime/src/docker_backend.rs
@@ -1,0 +1,1121 @@
+//! Docker **shared-kernel container** dev tier.
+//!
+//! `DockerBackend` runs a workload in a Docker container with the same
+//! guest-visible contract as the microVM backends: the identical static
+//! `mvm-guest-agent` binary is the container's PID 1 (bind-mounted
+//! read-only as `/init`), the host delivers the identical
+//! `ActivateEnvironment` after start — over a Unix socket on a
+//! host-owned 0700 directory bind-mounted into the container, because a
+//! container has no vsock — and the agent applies the identical uid-901
+//! privilege drop, keeps the identical `NotActivated` gate, and serves the
+//! identical operational RPC surface. The runtime overlay and declared
+//! volumes are host bind mounts (read-only honored), and the container
+//! runs `--network none`: egress, when the launch policy allows it, rides
+//! the same per-VM substitution endpoint over a bind-mounted socket.
+//!
+//! Honesty rules, mirroring the claim-free wasm tier's discipline:
+//!
+//! - **Opt-in only, never auto-selected.** `AnyBackend::auto_select` and
+//!   capability-driven selection never return this kind; a caller must
+//!   name `--hypervisor docker` explicitly.
+//! - **Refused by production admission.** The backend does not implement
+//!   the workload-backend surface (`AnyBackend::as_workload_backend` is
+//!   `None` for it, the same carve-out as QEMU and Wasm), and its catalog
+//!   descriptor marks it non-workload Tier 3.
+//! - **Capabilities and claims say what it is.** A shared kernel means no
+//!   hardware isolation boundary, no guest kernel, no dm-verity block
+//!   boot, and no mvm hash verification of the image reference — the
+//!   security profile reports exactly that, and keeps reporting the
+//!   substrate-independent claims that still hold (no `do_exec` in the
+//!   production agent, fuzzed framing, audited dependencies).
+//! - **Fail closed, never silently degrade.** Anything this tier cannot
+//!   do — kernel/initrd boot, dm-verity, block volumes, snapshots,
+//!   pause/resume, warm start, standby pool — fails with a typed
+//!   [`DockerBackendError`] naming the limitation and the supported
+//!   alternative.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow, bail};
+use mvm_core::config::{mvm_cache_dir, vm_state_dir};
+use mvm_core::vm_backend::{
+    BackendKind, BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage,
+    SnapshotCapability, StartMode, VmBackend, VmCapabilities, VmExitStatus, VmId, VmInfo,
+    VmStartConfig, VmStatus, VmVolumeKind,
+};
+use thiserror::Error;
+
+/// Container path the host-built static agent binary is mounted at. It is
+/// the container's `--entrypoint`, so the agent is PID 1 of the container's
+/// PID namespace — the same role it plays as `/init` in the initramfs.
+const AGENT_CONTAINER_PATH: &str = "/init";
+/// Container path the per-VM run directory (agent socket, agent config,
+/// substitution-endpoint socket) is bind-mounted at.
+const RUN_DIR_CONTAINER_PATH: &str = "/run/mvm";
+/// Container path of the agent's AF_UNIX control socket (the agent's unix
+/// transport default; kept in sync with `MVM_AGENT_UNIX_SOCK`).
+const AGENT_SOCK_CONTAINER_PATH: &str = "/run/mvm/agent.sock";
+/// File name (inside the run directory) of the substitution-endpoint socket.
+const ENDPOINT_SOCK_NAME: &str = "substitution-endpoint.sock";
+/// Container path the runtime-overlay guest binaries are bind-mounted at
+/// read-only — the same location the dm-verity overlay occupies on microVM
+/// backends.
+const RUNTIME_OVERLAY_CONTAINER_PATH: &str = "/mvm/runtime";
+/// How long `start` waits for the guest agent to bind its Unix socket
+/// before declaring the boot failed.
+const AGENT_SOCKET_TIMEOUT: Duration = Duration::from_secs(30);
+/// Grace `docker stop` gives the agent before docker escalates to SIGKILL.
+const STOP_GRACE_SECS: u32 = 3;
+
+/// Typed, fail-closed errors for requests this tier cannot satisfy. Every
+/// variant names the limitation and the supported alternative rather than
+/// silently dropping the request — see the module docs.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DockerBackendError {
+    /// The `docker` CLI is not on `$PATH`.
+    #[error(
+        "docker backend requires the `docker` CLI on $PATH — install Docker, or select a \
+         microVM backend (firecracker, libkrun, hvf, qemu)"
+    )]
+    NotAvailable,
+
+    /// `VmStartConfig::rootfs_path` — reused here to name the OCI image
+    /// reference, since this tier has no root filesystem — is empty.
+    #[error(
+        "docker backend has no image to run — set VmStartConfig::rootfs_path to the OCI \
+         image reference (e.g. alpine:3.20); this tier has no root filesystem"
+    )]
+    ImageRefMissing,
+
+    #[error(
+        "docker backend has no kernel/initrd boot path — a container shares the host kernel; \
+         drop --kernel/--initrd or select a microVM backend"
+    )]
+    KernelBootNotSupported,
+
+    #[error(
+        "docker backend has no dm-verity verified boot — a container shares the host kernel; \
+         select a microVM backend (firecracker, libkrun, hvf) for a verified rootfs"
+    )]
+    VerifiedBootNotSupported,
+
+    #[error(
+        "docker backend cannot attach block volume '{host}' — a container has no virtio-blk; \
+         use a directory-share volume instead"
+    )]
+    DiskVolumeNotSupported { host: String },
+
+    #[error(
+        "docker backend does not support pause/resume — docker's cgroup freezer is not \
+         wired into the backend; stop and start the workload instead"
+    )]
+    PauseResumeNotSupported,
+
+    #[error(
+        "docker backend cannot resolve the runtime-overlay guest binaries: {reason}. They \
+         cross-compile from a source checkout (or a warm cache) — run one `mvmctl build` / \
+         OCI `machine run` to populate the cache, or select a microVM backend"
+    )]
+    RuntimeOverlayUnavailable { reason: String },
+}
+
+/// Reject every launch request this tier cannot honestly satisfy before
+/// touching the docker CLI. Each check names the supported alternative.
+fn reject_unsupported_start_config(
+    config: &VmStartConfig,
+) -> std::result::Result<(), DockerBackendError> {
+    if config.kernel_path.is_some() || config.initrd_path.is_some() {
+        return Err(DockerBackendError::KernelBootNotSupported);
+    }
+    if config.verity_path.is_some() || config.roothash.is_some() {
+        return Err(DockerBackendError::VerifiedBootNotSupported);
+    }
+    if let Some(volume) = config
+        .volumes
+        .iter()
+        .find(|v| matches!(v.kind, VmVolumeKind::Disk))
+    {
+        return Err(DockerBackendError::DiskVolumeNotSupported {
+            host: volume.host.clone(),
+        });
+    }
+    if config.rootfs_path.trim().is_empty() {
+        return Err(DockerBackendError::ImageRefMissing);
+    }
+    Ok(())
+}
+
+/// `docker` on `$PATH`, or the typed not-available error.
+fn locate_docker() -> std::result::Result<String, DockerBackendError> {
+    which::which("docker")
+        .map(|_| "docker".to_string())
+        .map_err(|_| DockerBackendError::NotAvailable)
+}
+
+/// Owned inputs for one container's `docker run` argv, decided once so the
+/// argv mapping stays a pure, unit-testable function.
+#[derive(Debug, Clone)]
+struct DockerRunPlan {
+    name: String,
+    image: String,
+    agent_binary: PathBuf,
+    run_dir: PathBuf,
+    overlay_bins_dir: Option<PathBuf>,
+    /// Host path of the spawned substitution endpoint's socket (empty when
+    /// the launch has nothing to mediate — see the endpoint skip rule).
+    egress_endpoint_sock: Option<PathBuf>,
+    /// Directory-share volumes, validated as the only volume kind.
+    dir_shares: Vec<mvm_core::vm_backend::VmVolume>,
+    cpus: u32,
+    memory_mib: u32,
+}
+
+/// Assemble the `docker run` argv for a container (everything after
+/// `docker`). Pure so the whole plan→argv mapping is unit-testable with no
+/// docker daemon. The container runs with no NIC (`--network none`): the
+/// only path off it is the bind-mounted substitution-endpoint socket.
+fn docker_run_argv(plan: &DockerRunPlan) -> Vec<String> {
+    let mut args: Vec<String> = vec![
+        "run".into(),
+        "-d".into(),
+        "--name".into(),
+        plan.name.clone(),
+        "--network".into(),
+        "none".into(),
+        // The agent is PID 1. `--entrypoint` plus an explicit `--config`
+        // argument below also replaces the image's own entrypoint+cmd.
+        "--entrypoint".into(),
+        AGENT_CONTAINER_PATH.into(),
+        // Hardening baseline: the workload (uid 901) must not regain
+        // privilege through setuid binaries or file capabilities.
+        "--security-opt".into(),
+        "no-new-privileges".into(),
+        "-v".into(),
+        format!("{}:{AGENT_CONTAINER_PATH}:ro", plan.agent_binary.display()),
+        "-v".into(),
+        format!("{}:{RUN_DIR_CONTAINER_PATH}", plan.run_dir.display()),
+    ];
+    if let Some(dir) = &plan.overlay_bins_dir {
+        args.push("-v".into());
+        args.push(format!(
+            "{}:{RUNTIME_OVERLAY_CONTAINER_PATH}:ro",
+            dir.display()
+        ));
+    }
+    for volume in &plan.dir_shares {
+        let mut spec = format!("{}:{}", volume.host, volume.guest);
+        if volume.read_only {
+            spec.push_str(":ro");
+        }
+        args.push("-v".into());
+        args.push(spec);
+    }
+    if plan.memory_mib > 0 {
+        args.push("--memory".into());
+        args.push(format!("{}m", plan.memory_mib));
+    }
+    if plan.cpus > 0 {
+        args.push("--cpus".into());
+        args.push(plan.cpus.to_string());
+    }
+    args.push("-e".into());
+    args.push("MVM_AGENT_TRANSPORT=unix".into());
+    args.push("-e".into());
+    args.push(format!("MVM_AGENT_UNIX_SOCK={AGENT_SOCK_CONTAINER_PATH}"));
+    if plan.egress_endpoint_sock.is_some() {
+        args.push("-e".into());
+        args.push(format!(
+            "MVM_AGENT_EGRESS_ENDPOINT_SOCK={RUN_DIR_CONTAINER_PATH}/{ENDPOINT_SOCK_NAME}"
+        ));
+    }
+    args.push(plan.image.clone());
+    // Explicit command: overrides the image's CMD and points the agent at
+    // its (defaults-only) config file in the run dir.
+    args.push("--config".into());
+    args.push(format!("{RUN_DIR_CONTAINER_PATH}/agent.json"));
+    args
+}
+
+/// Record of a container this backend started. Docker itself is the source
+/// of truth for liveness (queried via `docker inspect`); the map exists so
+/// `list`/`stop_all`/`wait` know which containers this process started.
+#[derive(Debug, Clone)]
+struct DockerRun {
+    container_id: String,
+}
+
+/// Docker shared-kernel container backend. See the module docs for the
+/// tier's scope and the opt-in/prod-refused/fail-closed contract.
+#[derive(Debug, Default, Clone)]
+pub struct DockerBackend {
+    runs: Arc<Mutex<HashMap<String, DockerRun>>>,
+}
+
+impl DockerBackend {
+    /// Construct an empty backend. Side-effect free — no docker CLI is
+    /// probed and no daemon is contacted until a container actually runs.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock_runs(&self) -> Result<std::sync::MutexGuard<'_, HashMap<String, DockerRun>>> {
+        self.runs
+            .lock()
+            .map_err(|_| anyhow!("docker backend state mutex poisoned"))
+    }
+
+    /// The docker identifier to operate on for `id`: the container id when
+    /// this process started the container, else the VM name (which is also
+    /// the container name, so a later CLI invocation still resolves it).
+    fn docker_target(&self, id: &VmId) -> String {
+        self.runs
+            .lock()
+            .ok()
+            .and_then(|runs| runs.get(&id.0).map(|run| run.container_id.clone()))
+            .unwrap_or_else(|| id.0.clone())
+    }
+}
+
+/// Owned inputs for a docker run's per-VM substitution-endpoint spawn,
+/// decided once by [`docker_endpoint_plan`] so the skip/spawn branch is
+/// unit-testable without touching a subprocess. Mirrors the wasm tier's
+/// plan exactly, except the socket lives inside the bind-mounted run
+/// directory so the in-container forward proxy can reach it.
+struct DockerEndpointPlan {
+    vm_name: String,
+    state_dir: PathBuf,
+    tenant: String,
+    secrets: Vec<mvm_core::plan::SecretBinding>,
+    redaction: mvm_core::policy::RedactionPolicy,
+    socket_path: PathBuf,
+}
+
+/// Decide whether a docker run needs the per-VM substitution endpoint, and
+/// if so, the owned inputs the spawn needs. Mirrors the runner's and the
+/// wasm tier's skip logic exactly: nothing to mediate — no bound secrets
+/// and the resolved policy denies egress — is a no-op, returning `None`.
+/// `start` then sets no endpoint env var, so every proxied request in the
+/// container fails closed (and `--network none` leaves no other path).
+fn docker_endpoint_plan(
+    config: &VmStartConfig,
+    state_dir: &Path,
+    run_dir: &Path,
+) -> Result<Option<DockerEndpointPlan>> {
+    let default_redaction = mvm_core::policy::RedactionPolicy::default();
+    let decoded = crate::egress_shared::decode_plan_secrets_from_state(state_dir)?;
+    let (secrets, redaction, tenant) = match decoded {
+        Some((secrets, redaction, tenant)) => (secrets, redaction, tenant),
+        None => (
+            Vec::new(),
+            default_redaction,
+            match config.tenant_id.as_deref() {
+                Some(t) if !t.is_empty() => t.to_string(),
+                _ => "local".to_string(),
+            },
+        ),
+    };
+    if secrets.is_empty() && !config.network_policy.allows_egress() {
+        return Ok(None);
+    }
+    Ok(Some(DockerEndpointPlan {
+        vm_name: config.name.clone(),
+        state_dir: state_dir.to_path_buf(),
+        tenant,
+        secrets,
+        redaction,
+        socket_path: run_dir.join(ENDPOINT_SOCK_NAME),
+    }))
+}
+
+/// Build the [`crate::substitution_spawn::SubstitutionSpawnParams`] a docker
+/// run's endpoint spawn needs from a decided [`DockerEndpointPlan`]. Pure
+/// (no I/O) so the docker-specific literal fields are unit-testable: always
+/// `Uds` inside the bind-mounted run dir (the in-container forward proxy
+/// connects to it directly), no terminator (no NIC to redirect), no TLS
+/// intermediate, and `raw_egress` unconditionally `false` — the agent's
+/// forward proxy always speaks the `WireRequest` wire protocol, never a
+/// raw byte relay.
+fn docker_substitution_spawn_params<'a>(
+    plan: &'a DockerEndpointPlan,
+    network_policy: &'a mvm_core::network_policy::NetworkPolicy,
+) -> crate::substitution_spawn::SubstitutionSpawnParams<'a> {
+    crate::substitution_spawn::SubstitutionSpawnParams {
+        vm_name: &plan.vm_name,
+        state_dir: &plan.state_dir,
+        tenant: &plan.tenant,
+        secrets: &plan.secrets,
+        redaction: &plan.redaction,
+        transport: crate::substitution_spawn::EndpointTransport::Uds {
+            path: plan.socket_path.clone(),
+        },
+        terminator_listen: None,
+        tls_intermediate: None,
+        network_policy: Some(network_policy),
+        raw_egress: false,
+    }
+}
+
+/// Spawn the per-VM substitution endpoint for a docker run and return the
+/// socket path to wire into the container's `MVM_AGENT_EGRESS_ENDPOINT_SOCK`
+/// env. `None` when [`docker_endpoint_plan`] finds nothing to mediate; the
+/// container then boots with no endpoint socket and every proxied request
+/// fails closed.
+fn spawn_docker_egress_endpoint_if_needed(
+    config: &VmStartConfig,
+    state_dir: &Path,
+    run_dir: &Path,
+) -> Result<Option<PathBuf>> {
+    let Some(plan) = docker_endpoint_plan(config, state_dir, run_dir)? else {
+        return Ok(None);
+    };
+    let params = docker_substitution_spawn_params(&plan, &config.network_policy);
+    crate::substitution_spawn::spawn_substitution_endpoint(params)?;
+    Ok(Some(plan.socket_path))
+}
+
+/// Resolve the runtime-overlay guest binaries as a host directory to
+/// bind-mount read-only at `/mvm/runtime`. Fails closed with a typed error
+/// when the set can't be resolved (no source checkout and a cold cache) —
+/// booting without it would silently hand the workload a lesser
+/// environment than the launch contract promises.
+fn resolve_overlay_bins_dir(cache_root: &Path) -> std::result::Result<PathBuf, DockerBackendError> {
+    let arch = mvm_core::arch::GuestArch::host();
+    let Some(workspace) = mvm_build::guest_agent_build::detect_source_workspace() else {
+        return Err(DockerBackendError::RuntimeOverlayUnavailable {
+            reason: "no source checkout detected to build the guest binaries from".to_string(),
+        });
+    };
+    let binaries = mvm_build::guest_agent_build::resolve_or_build_runtime_overlay_guest_binaries(
+        cache_root,
+        env!("CARGO_PKG_VERSION"),
+        arch,
+        &workspace,
+    )
+    .map_err(|e| DockerBackendError::RuntimeOverlayUnavailable {
+        reason: e.to_string(),
+    })?;
+    // Every binary in the set lives in the layout's own cache dir.
+    let dir = binaries
+        .agent
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| DockerBackendError::RuntimeOverlayUnavailable {
+            reason: "resolved agent path has no parent directory".to_string(),
+        })?;
+    Ok(dir)
+}
+
+/// Create the per-VM run directory with owner-only permissions: it holds
+/// the agent's control socket, so its permissions ARE the peer
+/// authorization boundary on this tier (there is no vsock peer CID).
+fn create_run_dir(state_dir: &Path) -> Result<PathBuf> {
+    let run_dir = state_dir.join("docker-run");
+    std::fs::create_dir_all(&run_dir)
+        .map_err(|e| anyhow!("create docker run dir {}: {e}", run_dir.display()))?;
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&run_dir, std::fs::Permissions::from_mode(0o700))
+            .map_err(|e| anyhow!("chmod 0700 docker run dir {}: {e}", run_dir.display()))?;
+    }
+    Ok(run_dir)
+}
+
+/// Connect the agent's bind-mounted Unix socket (retrying while the
+/// container boots, failing fast if the container died) and deliver the
+/// activation message, requiring the ACK.
+fn activate_container(run_dir: &Path, config: &VmStartConfig, docker: &str) -> Result<()> {
+    let env = crate::microvm::build_container_activation_environment(config)?;
+    let sock = run_dir.join("agent.sock");
+    let deadline = Instant::now() + AGENT_SOCKET_TIMEOUT;
+    loop {
+        match std::os::unix::net::UnixStream::connect(&sock) {
+            Ok(mut stream) => {
+                return crate::microvm::activate_over_stream(&mut stream, &env)
+                    .context("activate container workload");
+            }
+            Err(connect_err) => {
+                if Instant::now() >= deadline {
+                    bail!(
+                        "docker guest agent did not bind {} within {AGENT_SOCKET_TIMEOUT:?}: {connect_err}",
+                        sock.display()
+                    );
+                }
+                if !container_running(docker, &config.name)? {
+                    bail!(
+                        "docker container '{}' exited before its guest agent came up; \
+                         see `docker logs {}`",
+                        config.name,
+                        config.name
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+}
+
+/// `docker inspect` liveness probe: true when the named container exists
+/// and is running. A missing container reports `false` (not an error) so
+/// `status`/`activate` read it as Stopped/died.
+fn container_running(docker: &str, name: &str) -> Result<bool> {
+    let out = Command::new(docker)
+        .args(["inspect", "-f", "{{.State.Running}}", name])
+        .output()
+        .map_err(|e| anyhow!("spawn docker inspect for '{name}': {e}"))?;
+    if !out.status.success() {
+        // inspect fails when the container does not exist.
+        return Ok(false);
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim() == "true")
+}
+
+impl VmBackend for DockerBackend {
+    fn name(&self) -> &str {
+        "docker"
+    }
+
+    fn kind(&self) -> BackendKind {
+        BackendKind::Docker
+    }
+
+    fn capabilities(&self) -> VmCapabilities {
+        VmCapabilities {
+            // `--network none`: nothing in the container can reach the
+            // network by IP. Egress, when the policy allows it, rides the
+            // substitution endpoint over the bind-mounted socket dir — a
+            // host-mediated channel, but over a Unix socket rather than
+            // vsock, so `host_vsock_proxy` honestly stays false.
+            no_routable_guest_nic: true,
+            snapshot_capability: SnapshotCapability::Unsupported,
+            standby_pool: false,
+            ..VmCapabilities::default()
+        }
+    }
+
+    fn start_with_mode(&self, config: &VmStartConfig, _mode: StartMode) -> Result<VmId> {
+        reject_unsupported_start_config(config)?;
+        let docker = locate_docker()?;
+
+        let state_dir = vm_state_dir(&config.name);
+        std::fs::create_dir_all(&state_dir)
+            .map_err(|e| anyhow!("create per-VM state dir {}: {e}", state_dir.display()))?;
+        // Record per-VM runtime metadata (the sidecar accessibility bit +
+        // boot contract) so the `mvmctl console` accessible/sealed gate
+        // holds on docker-launched containers too, matching the other
+        // backends' start paths.
+        crate::base::runtime_meta::record_from_start_config(
+            &config.name,
+            StartMode::Detached,
+            config,
+        )?;
+
+        let run_dir = create_run_dir(&state_dir)?;
+        // A defaults-only agent config: the run dir is bind-mounted, so the
+        // explicit `--config` that overrides the image's CMD parses this.
+        std::fs::write(run_dir.join("agent.json"), "{}")
+            .map_err(|e| anyhow!("write agent config in {}: {e}", run_dir.display()))?;
+
+        let cache_root = PathBuf::from(mvm_cache_dir());
+        let binaries = mvm_build::run_image::resolve_guest_binaries(&cache_root, None)
+            .context("resolve the mvm-guest-agent binary for the container")?;
+        let overlay_bins_dir = resolve_overlay_bins_dir(&cache_root)?;
+        let egress_endpoint_sock =
+            spawn_docker_egress_endpoint_if_needed(config, &state_dir, &run_dir)?;
+
+        let plan = DockerRunPlan {
+            name: config.name.clone(),
+            image: config.rootfs_path.trim().to_string(),
+            agent_binary: binaries.agent,
+            run_dir: run_dir.clone(),
+            overlay_bins_dir: Some(overlay_bins_dir),
+            egress_endpoint_sock,
+            dir_shares: config.volumes.clone(),
+            cpus: config.cpus,
+            memory_mib: config.memory_mib,
+        };
+        let argv = docker_run_argv(&plan);
+        let out = Command::new(&docker)
+            .args(&argv)
+            .output()
+            .map_err(|e| anyhow!("spawn docker run for '{}': {e}", config.name))?;
+        if !out.status.success() {
+            // Roll back a half-spawned endpoint so a failed start leaves no
+            // decrypted-secret process behind.
+            crate::substitution_spawn::reap_substitution_endpoint(&state_dir, &config.name);
+            bail!(
+                "docker run failed for workload '{}': {}",
+                config.name,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        let container_id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+
+        // Deliver activation; on failure tear the container and endpoint
+        // down so a failed start leaves nothing running.
+        if let Err(e) = activate_container(&run_dir, config, &docker) {
+            let _ = Command::new(&docker)
+                .args(["rm", "-f", &config.name])
+                .output();
+            crate::substitution_spawn::reap_substitution_endpoint(&state_dir, &config.name);
+            return Err(e);
+        }
+
+        self.lock_runs()?
+            .insert(config.name.clone(), DockerRun { container_id });
+        Ok(VmId(config.name.clone()))
+    }
+
+    fn wait(&self, id: &VmId) -> Result<VmExitStatus> {
+        let docker = locate_docker()?;
+        let target = self.docker_target(id);
+        let out = Command::new(&docker)
+            .args(["wait", &target])
+            .output()
+            .map_err(|e| anyhow!("spawn docker wait for '{}': {e}", id.0))?;
+        if !out.status.success() {
+            bail!(
+                "docker wait failed for '{}': {}",
+                id.0,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        let first_line = String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        let code: i32 = first_line.parse().map_err(|_| {
+            anyhow!(
+                "docker wait for '{}' returned unparseable exit status {first_line:?}",
+                id.0
+            )
+        })?;
+        Ok(VmExitStatus {
+            code: Some(code),
+            success: code == 0,
+        })
+    }
+
+    fn pause(&self, _id: &VmId) -> Result<()> {
+        Err(DockerBackendError::PauseResumeNotSupported.into())
+    }
+
+    fn resume(&self, _id: &VmId) -> Result<()> {
+        Err(DockerBackendError::PauseResumeNotSupported.into())
+    }
+
+    fn stop(&self, id: &VmId) -> Result<()> {
+        // Reap the per-VM substitution endpoint first, so a crashed
+        // container's decrypted-secret process can't outlive it. Idempotent
+        // + a no-op when the run spawned none.
+        crate::substitution_spawn::reap_substitution_endpoint(&vm_state_dir(&id.0), &id.0);
+        let docker = locate_docker()?;
+        let target = self.docker_target(id);
+        // Graceful stop, then remove the container so the name can be
+        // reused. Both are best-effort: an already-gone container is the
+        // desired end state.
+        let _ = Command::new(&docker)
+            .args(["stop", "-t", &STOP_GRACE_SECS.to_string(), &target])
+            .output();
+        let out = Command::new(&docker)
+            .args(["rm", "-f", &target])
+            .output()
+            .map_err(|e| anyhow!("spawn docker rm for '{}': {e}", id.0))?;
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            // "No such container" is the desired end state, not an error.
+            if !stderr.contains("No such container") {
+                bail!("docker rm failed for '{}': {stderr}", id.0);
+            }
+        }
+        self.lock_runs()?.remove(&id.0);
+        Ok(())
+    }
+
+    fn stop_all(&self) -> Result<()> {
+        let names: Vec<String> = self.lock_runs()?.keys().cloned().collect();
+        let mut last_err = None;
+        for name in names {
+            if let Err(e) = self.stop(&VmId(name.clone())) {
+                tracing::warn!(name, error = %e, "docker stop_all: stop failed");
+                last_err = Some(e);
+            }
+        }
+        last_err.map_or(Ok(()), Err)
+    }
+
+    fn status(&self, id: &VmId) -> Result<VmStatus> {
+        let docker = locate_docker()?;
+        Ok(match container_running(&docker, &self.docker_target(id))? {
+            true => VmStatus::Running,
+            false => VmStatus::Stopped,
+        })
+    }
+
+    fn list(&self) -> Result<Vec<VmInfo>> {
+        let docker = locate_docker()?;
+        let names: Vec<String> = self.lock_runs()?.keys().cloned().collect();
+        let mut vms = Vec::with_capacity(names.len());
+        for name in names {
+            let status = match container_running(&docker, &name) {
+                Ok(true) => VmStatus::Running,
+                _ => VmStatus::Stopped,
+            };
+            vms.push(VmInfo {
+                id: VmId(name.clone()),
+                name,
+                status,
+                guest_ip: None,
+                cpus: 0,
+                memory_mib: 0,
+                profile: None,
+                revision: None,
+                flake_ref: None,
+                ports: Vec::new(),
+            });
+        }
+        Ok(vms)
+    }
+
+    fn logs(&self, id: &VmId, lines: u32, _hypervisor: bool) -> Result<String> {
+        // One log stream: the container's stdout/stderr (the agent's
+        // console), whether the caller asked for the "hypervisor" log or not.
+        let docker = locate_docker()?;
+        let out = Command::new(&docker)
+            .args([
+                "logs",
+                "--tail",
+                &lines.to_string(),
+                &self.docker_target(id),
+            ])
+            .output()
+            .map_err(|e| anyhow!("spawn docker logs for '{}': {e}", id.0))?;
+        if !out.status.success() {
+            bail!(
+                "docker logs failed for '{}': {}",
+                id.0,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        let mut body = String::from_utf8_lossy(&out.stdout).into_owned();
+        if !out.stderr.is_empty() {
+            body.push_str(&String::from_utf8_lossy(&out.stderr));
+        }
+        Ok(body)
+    }
+
+    fn guest_channel_info(&self, id: &VmId) -> Result<GuestChannelInfo> {
+        // The agent's control socket on the host side of the bind-mounted
+        // run directory — the AF_UNIX analog of the vsock agent channel the
+        // microVM backends report.
+        Ok(GuestChannelInfo::UnixSocket {
+            path: vm_state_dir(&id.0)
+                .join("docker-run")
+                .join("agent.sock")
+                .to_string_lossy()
+                .into_owned(),
+        })
+    }
+
+    fn is_available(&self) -> Result<bool> {
+        Ok(locate_docker().is_ok())
+    }
+
+    fn install(&self) -> Result<()> {
+        crate::base::ui::info(
+            "Docker must be installed via the host package manager or Docker Desktop \
+             (`apt install docker.io` / https://docs.docker.com/get-docker/).",
+        );
+        Ok(())
+    }
+
+    fn security_profile(&self) -> BackendSecurityProfile {
+        // Shared kernel ⇒ the hardware-isolation claims do not hold:
+        // namespaces are not a security boundary against the host (1),
+        // uid-0-in-container is host-kernel-mediated (2), and there is no
+        // dm-verity block boot (3) nor mvm hash verification of the image
+        // reference (6). The substrate-independent claims still hold: the
+        // production agent carries no `do_exec` (4), the RPC framing is the
+        // same fuzzed wire (5), and the agent is the same audited build (7).
+        BackendSecurityProfile {
+            claims: [
+                ClaimStatus::DoesNotHold, // 1 — shared kernel: host-fs isolation is namespace-only
+                ClaimStatus::DoesNotHold, // 2 — shared kernel: no hardware boundary on uid 0
+                ClaimStatus::DoesNotHold, // 3 — no dm-verity block boot
+                ClaimStatus::Holds,       // 4 — same agent binary, no do_exec in prod builds
+                ClaimStatus::Holds,       // 5 — same fuzzed RPC framing
+                ClaimStatus::DoesNotHold, // 6 — image refs are tag-based, not mvm hash-verified
+                ClaimStatus::Holds,       // 7 — same audited dependency tree
+            ],
+            layer_coverage: LayerCoverage {
+                // The guest-agent (uid 901 drop, no_new_privs) and workload
+                // confinement layers are real and unchanged; the hypervisor,
+                // VMM, and guest-kernel layers collapse into the shared host
+                // kernel.
+                l4_guest_agent: true,
+                l5_workload: true,
+                ..LayerCoverage::default()
+            },
+            tier: "Tier 3 (shared-kernel container, dev tier — opt-in, prod-refused)",
+            notes: &[
+                "Runs the workload in a Docker container with mvm-guest-agent as PID 1; the \
+                 guest shares the host kernel — namespaces are not a hardware boundary.",
+                "Opt-in only; never selected by auto-detect. Refused by production admission \
+                 (no workload-backend surface), the same carve-out as QEMU and Wasm.",
+                "Activation rides a host bind-mounted Unix socket (no vsock in a container); \
+                 the socket directory's 0700 permissions are the peer boundary, a deliberately \
+                 weaker check than the vsock host-CID gate.",
+                "Runs --network none; egress, when the policy allows it, rides the per-VM \
+                 substitution endpoint over the bind-mounted socket dir.",
+                "For development, demo, and CI-sandbox use only — never an isolation tier.",
+            ],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::AnyBackend;
+
+    fn cfg(name: &str, image: &str) -> VmStartConfig {
+        VmStartConfig {
+            name: name.to_string(),
+            rootfs_path: image.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn sample_plan() -> DockerRunPlan {
+        DockerRunPlan {
+            name: "web".into(),
+            image: "alpine:3.20".into(),
+            agent_binary: PathBuf::from("/cache/guest-agent/mvm-guest-agent"),
+            run_dir: PathBuf::from("/state/web/docker-run"),
+            overlay_bins_dir: Some(PathBuf::from("/cache/runtime-overlay-bins")),
+            egress_endpoint_sock: Some(PathBuf::from(
+                "/state/web/docker-run/substitution-endpoint.sock",
+            )),
+            dir_shares: vec![
+                mvm_core::vm_backend::VmVolume {
+                    host: "/host/share".into(),
+                    guest: "/mnt/share".into(),
+                    size: String::new(),
+                    read_only: true,
+                    kind: VmVolumeKind::DirShare,
+                    encrypted: false,
+                },
+                mvm_core::vm_backend::VmVolume {
+                    host: "/host/data".into(),
+                    guest: "/mnt/data".into(),
+                    size: String::new(),
+                    read_only: false,
+                    kind: VmVolumeKind::DirShare,
+                    encrypted: false,
+                },
+            ],
+            cpus: 2,
+            memory_mib: 512,
+        }
+    }
+
+    #[test]
+    fn kind_and_name_are_docker() {
+        let b = DockerBackend::new();
+        assert_eq!(b.name(), "docker");
+        assert_eq!(b.kind(), BackendKind::Docker);
+    }
+
+    #[test]
+    fn selector_resolves_and_auto_select_never_returns_docker() {
+        let backend = AnyBackend::from_hypervisor("docker");
+        assert!(matches!(backend, AnyBackend::Docker(_)));
+        assert_eq!(backend.name(), "docker");
+        assert_eq!(backend.kind(), BackendKind::Docker);
+        // Opt-in only, same discipline as the wasm tier: auto_select's
+        // ladder constructs Firecracker/Hvf/Libkrun and nothing else.
+        assert_ne!(
+            AnyBackend::auto_select().kind(),
+            BackendKind::Docker,
+            "auto_select must never fall through to the docker dev tier"
+        );
+    }
+
+    #[test]
+    fn prod_funnel_excludes_the_docker_tier() {
+        let backend = AnyBackend::from_hypervisor("docker");
+        assert!(
+            backend.as_workload_backend().is_none(),
+            "docker must be barred from the admitted workload funnel"
+        );
+    }
+
+    #[test]
+    fn capabilities_are_honest_about_the_shared_kernel() {
+        let caps = DockerBackend::new().capabilities();
+        assert!(!caps.pause_resume);
+        assert!(!caps.snapshots);
+        assert_eq!(caps.snapshot_capability, SnapshotCapability::Unsupported);
+        assert!(!caps.standby_pool);
+        assert!(!caps.vsock);
+        assert!(!caps.tap_networking);
+        assert!(!caps.balloon);
+        assert!(!caps.host_vsock_proxy);
+        assert!(!caps.pty_exec);
+        assert!(!caps.production_ssh);
+        assert!(caps.no_routable_guest_nic);
+    }
+
+    #[test]
+    fn security_profile_drops_only_the_isolation_claims() {
+        let profile = DockerBackend::new().security_profile();
+        assert_eq!(profile.dropped_claims(), vec![1, 2, 3, 6]);
+        assert!(
+            !profile.layer_coverage.is_microvm(),
+            "a shared-kernel container must not report microVM layers"
+        );
+        // The agent/workload confinement layers are real and unchanged.
+        assert!(profile.layer_coverage.l4_guest_agent);
+        assert!(profile.layer_coverage.l5_workload);
+        assert!(
+            profile.tier.starts_with("Tier 3"),
+            "the tier string must agree with the catalog's Tier 3 classification: {}",
+            profile.tier
+        );
+        assert!(profile.tier.contains("shared-kernel"));
+    }
+
+    #[test]
+    fn snapshot_and_standby_fail_closed() {
+        use mvm_core::vm_backend::WarmStartError;
+        let b = DockerBackend::new();
+        assert_eq!(b.snapshot_capability(), SnapshotCapability::Unsupported);
+        match b.warm_start(&VmStartConfig::default(), SnapshotCapability::DiskOnly) {
+            Err(WarmStartError::Unsupported { .. }) => {}
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+        assert!(!b.supports_standby_pool());
+    }
+
+    #[test]
+    fn pause_resume_fail_closed_with_typed_error() {
+        let b = DockerBackend::new();
+        let id = VmId("x".into());
+        let err = b.pause(&id).unwrap_err();
+        assert_eq!(
+            err.downcast_ref::<DockerBackendError>(),
+            Some(&DockerBackendError::PauseResumeNotSupported)
+        );
+        let err = b.resume(&id).unwrap_err();
+        assert_eq!(
+            err.downcast_ref::<DockerBackendError>(),
+            Some(&DockerBackendError::PauseResumeNotSupported)
+        );
+    }
+
+    #[test]
+    fn missing_image_ref_fails_closed() {
+        let err = reject_unsupported_start_config(&cfg("x", "   ")).unwrap_err();
+        assert_eq!(err, DockerBackendError::ImageRefMissing);
+    }
+
+    #[test]
+    fn kernel_request_fails_closed() {
+        let mut config = cfg("x", "alpine:3.20");
+        config.kernel_path = Some("/some/vmlinux".into());
+        assert_eq!(
+            reject_unsupported_start_config(&config),
+            Err(DockerBackendError::KernelBootNotSupported)
+        );
+        config.kernel_path = None;
+        config.initrd_path = Some("/some/initrd".into());
+        assert_eq!(
+            reject_unsupported_start_config(&config),
+            Err(DockerBackendError::KernelBootNotSupported)
+        );
+    }
+
+    #[test]
+    fn verified_boot_request_fails_closed() {
+        let mut config = cfg("x", "alpine:3.20");
+        config.roothash = Some("a".repeat(64));
+        assert_eq!(
+            reject_unsupported_start_config(&config),
+            Err(DockerBackendError::VerifiedBootNotSupported)
+        );
+        config.roothash = None;
+        config.verity_path = Some("/img/rootfs.verity".into());
+        assert_eq!(
+            reject_unsupported_start_config(&config),
+            Err(DockerBackendError::VerifiedBootNotSupported)
+        );
+    }
+
+    #[test]
+    fn disk_volume_fails_closed_dir_share_passes() {
+        let mut config = cfg("x", "alpine:3.20");
+        config.volumes = vec![mvm_core::vm_backend::VmVolume {
+            host: "/host/disk.img".into(),
+            guest: "/mnt/disk".into(),
+            size: "1G".into(),
+            read_only: false,
+            kind: VmVolumeKind::Disk,
+            encrypted: false,
+        }];
+        assert_eq!(
+            reject_unsupported_start_config(&config),
+            Err(DockerBackendError::DiskVolumeNotSupported {
+                host: "/host/disk.img".into()
+            })
+        );
+
+        config.volumes[0].kind = VmVolumeKind::DirShare;
+        assert!(reject_unsupported_start_config(&config).is_ok());
+    }
+
+    #[test]
+    fn argv_maps_the_full_plan_verbatim() {
+        let argv = docker_run_argv(&sample_plan());
+        let joined = argv.join(" ");
+
+        // Detached, named, no NIC, agent as entrypoint, hardened.
+        assert!(joined.contains("run -d --name web"));
+        assert!(joined.contains("--network none"));
+        assert!(joined.contains("--entrypoint /init"));
+        assert!(joined.contains("--security-opt no-new-privileges"));
+        // Bind mounts: agent RO, run dir RW, overlay RO, volumes with ro honored.
+        assert!(joined.contains("-v /cache/guest-agent/mvm-guest-agent:/init:ro"));
+        assert!(joined.contains("-v /state/web/docker-run:/run/mvm"));
+        assert!(joined.contains("-v /cache/runtime-overlay-bins:/mvm/runtime:ro"));
+        assert!(joined.contains("-v /host/share:/mnt/share:ro"));
+        assert!(joined.contains("-v /host/data:/mnt/data"));
+        // Resource limits.
+        assert!(joined.contains("--memory 512m"));
+        assert!(joined.contains("--cpus 2"));
+        // Transport env + the egress endpoint socket.
+        assert!(joined.contains("-e MVM_AGENT_TRANSPORT=unix"));
+        assert!(joined.contains("-e MVM_AGENT_UNIX_SOCK=/run/mvm/agent.sock"));
+        assert!(
+            joined
+                .contains("-e MVM_AGENT_EGRESS_ENDPOINT_SOCK=/run/mvm/substitution-endpoint.sock")
+        );
+        // Image, then the explicit agent config override — and never a NIC,
+        // never privileged.
+        assert!(joined.ends_with("alpine:3.20 --config /run/mvm/agent.json"));
+        assert!(!joined.contains("--privileged"));
+        assert!(!joined.contains("--net="));
+    }
+
+    #[test]
+    fn argv_minimal_plan_carries_no_overlay_no_endpoint_no_volumes() {
+        let plan = DockerRunPlan {
+            overlay_bins_dir: None,
+            egress_endpoint_sock: None,
+            dir_shares: Vec::new(),
+            cpus: 0,
+            memory_mib: 0,
+            ..sample_plan()
+        };
+        let argv = docker_run_argv(&plan);
+        let joined = argv.join(" ");
+        assert!(!joined.contains("/mvm/runtime"));
+        assert!(!joined.contains("MVM_AGENT_EGRESS_ENDPOINT_SOCK"));
+        assert!(!joined.contains("--memory"));
+        assert!(!joined.contains("--cpus"));
+        assert!(joined.ends_with("alpine:3.20 --config /run/mvm/agent.json"));
+    }
+
+    // ── endpoint plan / spawn params (mirrors the wasm tier's tests) ──
+
+    #[test]
+    fn endpoint_plan_is_none_when_no_secrets_and_no_egress() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_dir = dir.path().join("docker-run");
+        let config = VmStartConfig {
+            name: "no-secrets-docker-vm".to_string(),
+            ..Default::default()
+        };
+        let plan = docker_endpoint_plan(&config, dir.path(), &run_dir).unwrap();
+        assert!(
+            plan.is_none(),
+            "deny-all policy with no bound secrets must skip the endpoint spawn"
+        );
+    }
+
+    #[test]
+    fn endpoint_plan_sockets_inside_the_bind_mounted_run_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_dir = dir.path().join("docker-run");
+        let config = VmStartConfig {
+            name: "policy-allow-docker-vm".to_string(),
+            network_policy: mvm_core::network_policy::NetworkPolicy::preset(
+                mvm_core::network_policy::NetworkPreset::Dev,
+            ),
+            ..Default::default()
+        };
+        let plan = docker_endpoint_plan(&config, dir.path(), &run_dir)
+            .unwrap()
+            .expect("a policy allowing egress must produce a spawn plan");
+        assert!(plan.secrets.is_empty());
+        assert_eq!(plan.tenant, "local");
+        assert_eq!(
+            plan.socket_path,
+            run_dir.join("substitution-endpoint.sock"),
+            "the endpoint socket must live inside the bind-mounted run dir"
+        );
+
+        let params = docker_substitution_spawn_params(&plan, &config.network_policy);
+        assert_eq!(
+            params.transport,
+            crate::substitution_spawn::EndpointTransport::Uds {
+                path: plan.socket_path.clone(),
+            }
+        );
+        assert!(params.terminator_listen.is_none(), "no NIC to redirect");
+        assert!(params.tls_intermediate.is_none());
+        assert!(params.network_policy.is_some());
+        assert!(
+            !params.raw_egress,
+            "the forward proxy always speaks WireRequest wire mode"
+        );
+    }
+
+    #[test]
+    fn run_dir_is_created_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_dir = create_run_dir(dir.path()).unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&run_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "the socket dir IS the peer boundary");
+    }
+
+    #[test]
+    fn guest_channel_info_reports_the_run_dir_agent_socket() {
+        let b = DockerBackend::new();
+        let info = b.guest_channel_info(&VmId("chan-vm".into())).unwrap();
+        let expected = vm_state_dir("chan-vm")
+            .join("docker-run")
+            .join("agent.sock")
+            .to_string_lossy()
+            .into_owned();
+        match info {
+            GuestChannelInfo::UnixSocket { path } => assert_eq!(path, expected),
+            other => panic!("expected a unix socket channel, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn is_available_tracks_the_docker_cli() {
+        // Tautological-looking, but pins the contract: `is_available` must
+        // track whether the docker CLI resolves, never a hardcoded bool.
+        assert_eq!(
+            DockerBackend::new().is_available().unwrap(),
+            locate_docker().is_ok()
+        );
+    }
+}

--- a/crates/mvm-runtime/src/lib.rs
+++ b/crates/mvm-runtime/src/lib.rs
@@ -45,6 +45,7 @@ pub mod catalog;
 pub mod checkpoint;
 pub mod codesign;
 pub mod compat;
+pub mod docker_backend;
 pub mod driver;
 /// Per-VM transparent egress redirect used by the legacy libkrun gateway path.
 pub mod egress_redirect;

--- a/crates/mvm-runtime/src/microvm/activation.rs
+++ b/crates/mvm-runtime/src/microvm/activation.rs
@@ -50,9 +50,22 @@ pub fn activate_workload(vm: &dyn RunningVm, config: &VmStartConfig) -> Result<(
     let mut stream = vm
         .vsock_connect(mvm_agentd::vsock::GUEST_AGENT_PORT)
         .context("connect to guest agent for activation")?;
+    activate_over_stream(&mut stream, &env)
+}
+
+/// Send a pre-built [`ActivateEnvironment`] over an already-connected
+/// stream and require the ACK. Shared by [`activate_workload`] (whose
+/// stream comes from a `RunningVm` vsock connection) and by backends whose
+/// agent channel is not a vsock at all — the shared-kernel container tier
+/// reaches the agent over a host bind-mounted Unix socket, through the
+/// identical authenticated framing.
+pub fn activate_over_stream<S>(stream: &mut S, env: &ActivateEnvironment) -> Result<()>
+where
+    S: std::io::Read + std::io::Write + Send,
+{
     let response = mvm_agentd::vsock::send_request_stream(
-        &mut stream,
-        &GuestRequest::ActivateEnvironment(env),
+        stream,
+        &GuestRequest::ActivateEnvironment(env.clone()),
     )
     .context("send ActivateEnvironment to guest")?;
     match response {
@@ -62,6 +75,32 @@ pub fn activate_workload(vm: &dyn RunningVm, config: &VmStartConfig) -> Result<(
         }
         other => bail!("unexpected response to ActivateEnvironment: {other:?}"),
     }
+}
+
+/// Build the activation message for a shared-kernel container boot
+/// (the Docker dev tier). The container runtime already owns `/`, the
+/// runtime overlay, and the volume mountpoints — the host bind-mounted all
+/// three at container-create time — so the message carries none of them:
+/// the root is `in_place` (no mount, no pivot), and only the verb-grant
+/// envelope travels. What remains load-bearing is the agent's uid-901
+/// privilege drop and the `NotActivated` gate flip, identical to every
+/// other backend.
+pub fn build_container_activation_environment(
+    config: &VmStartConfig,
+) -> Result<ActivateEnvironment> {
+    let verb_grant_envelope = read_verb_grant_envelope(&config.name)?;
+    Ok(ActivateEnvironment {
+        rootfs: RootfsConfig {
+            data_dev: String::new(),
+            hash_dev: None,
+            roothash: None,
+            virtiofs_tag: None,
+            in_place: true,
+        },
+        runtime: None,
+        volumes: Vec::new(),
+        verb_grant_envelope,
+    })
 }
 
 /// Build an [`ActivateEnvironment`] from the admitted launch config.
@@ -82,6 +121,7 @@ fn build_activation_environment(config: &VmStartConfig) -> Result<ActivateEnviro
             hash_dev: None,
             roothash: None,
             virtiofs_tag: Some(VIRTIOFS_ROOT_TAG.to_string()),
+            in_place: false,
         }
     } else if config.verity_path.is_some() {
         let roothash = resolve_rootfs_roothash(config)
@@ -91,6 +131,7 @@ fn build_activation_environment(config: &VmStartConfig) -> Result<ActivateEnviro
             hash_dev: Some(ROOTFS_HASH_DEV.to_string()),
             roothash: Some(roothash),
             virtiofs_tag: None,
+            in_place: false,
         }
     } else {
         RootfsConfig {
@@ -98,6 +139,7 @@ fn build_activation_environment(config: &VmStartConfig) -> Result<ActivateEnviro
             hash_dev: None,
             roothash: None,
             virtiofs_tag: None,
+            in_place: false,
         }
     };
 
@@ -374,6 +416,58 @@ mod tests {
 
         let env = build_activation_environment(&config).unwrap();
         assert!(env.verb_grant_envelope.is_some());
+    }
+
+    #[test]
+    fn container_activation_environment_is_in_place_and_carries_only_the_grant() {
+        let (_env, _dir) = test_env();
+        let env = build_container_activation_environment(&base_config()).unwrap();
+        assert!(env.rootfs.in_place);
+        assert!(env.rootfs.data_dev.is_empty());
+        assert_eq!(env.rootfs.hash_dev, None);
+        assert_eq!(env.rootfs.roothash, None);
+        assert_eq!(env.rootfs.virtiofs_tag, None);
+        assert!(env.runtime.is_none());
+        assert!(env.volumes.is_empty());
+        assert!(env.verb_grant_envelope.is_none());
+    }
+
+    #[test]
+    fn activate_over_stream_requires_the_ack_and_fails_closed_otherwise() {
+        // Error response ⇒ the boot fails closed with the guest's message.
+        let (mut host, mut guest) = std::os::unix::net::UnixStream::pair().unwrap();
+        let server = std::thread::spawn(move || {
+            let guest_key = ed25519_dalek::SigningKey::from_bytes(&[9u8; 32]);
+            let host_key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]).verifying_key();
+            let mut session =
+                mvm_agentd::vsock::AuthenticatedSession::guest(&mut guest, guest_key, &host_key)
+                    .unwrap();
+            let req: GuestRequest = session.read(&mut guest).unwrap();
+            assert!(matches!(req, GuestRequest::ActivateEnvironment(_)));
+            session
+                .write(
+                    &mut guest,
+                    &GuestResponse::ActivateEnvironmentError {
+                        message: "mount failed".into(),
+                    },
+                )
+                .unwrap();
+        });
+
+        let (_env, dir) = test_env();
+        // The host side of the handshake reads its signer from the keys dir.
+        let keys = mvm_core::config::mvm_keys_dir();
+        std::fs::create_dir_all(&keys).unwrap();
+        std::fs::write(keys.join("host-signer.ed25519"), [7u8; 32]).unwrap();
+        let _ = dir;
+
+        let env = build_container_activation_environment(&base_config()).unwrap();
+        let err = activate_over_stream(&mut host, &env).unwrap_err();
+        assert!(
+            err.to_string().contains("mount failed"),
+            "expected the guest's error to fail the boot: {err}"
+        );
+        server.join().unwrap();
     }
 
     trait VolumeExt {

--- a/crates/mvm-sdk/sdks/python/mvm/_protocol/protocol.py
+++ b/crates/mvm-sdk/sdks/python/mvm/_protocol/protocol.py
@@ -1149,6 +1149,7 @@ class ReadinessReport:
 class RootfsConfig:
     data_dev: str
     hash_dev: Optional[str] = None
+    in_place: Optional[bool] = False
     roothash: Optional[str] = None
     virtiofs_tag: Optional[str] = None
 

--- a/crates/mvm-sdk/sdks/typescript/src/protocol/protocol.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/protocol/protocol.ts
@@ -660,9 +660,9 @@ verb_grant_envelope?: (VerbGrantEnvelope | null)
 volumes?: VolumeConfig[]
 }
 /**
- * Root device the guest mounts as `/`.  Three shapes, selected by which optional fields are set:
+ * Root device the guest mounts as `/`.  Three mount shapes, selected by which optional fields are set, plus one mount-free shape:
  * 
- * - **dm-verity block** (`roothash` + `hash_dev`): create the `root` dm-verity target and mount it read-only. - **plain block** (neither): mount `data_dev` read-only without verification (unverified dev-tier boot). - **virtio-fs root** (`virtiofs_tag`): mount the virtio-fs tag read-only as the root — the block-less dev-tier boot.
+ * - **dm-verity block** (`roothash` + `hash_dev`): create the `root` dm-verity target and mount it read-only. - **plain block** (neither): mount `data_dev` read-only without verification (unverified dev-tier boot). - **virtio-fs root** (`virtiofs_tag`): mount the virtio-fs tag read-only as the root — the block-less dev-tier boot. - **in place** (`in_place`): the runtime already owns `/` — a shared-kernel container whose root is the image itself. Nothing is mounted and no pivot happens; activation is the privilege drop and the gate flip only.
  */
 export interface RootfsConfig {
 /**
@@ -673,6 +673,10 @@ data_dev: string
  * Hash-tree device path, e.g. `/dev/vdb`.  Present only for a dm-verity rootfs.
  */
 hash_dev?: (string | null)
+/**
+ * The root is already in place (shared-kernel container tier): skip the rootfs mount and the pivot entirely. Mutually exclusive with every other field — a host that sets this alongside a device, hash, or tag gets a validation error from the agent, not a silent choice.
+ */
+in_place?: boolean
 /**
  * 64-character lowercase hex dm-verity root hash.  Absent for an unverified plain-block root.
  */

--- a/public/src/content/docs/architecture/boot-flow.md
+++ b/public/src/content/docs/architecture/boot-flow.md
@@ -149,14 +149,20 @@ model in adapted form — or honestly not at all:
   kernel/verified-boot/vsock request fails closed. Per ADR-024 it stays
   opt-in, claim-free, and — if it ever executes real workloads — the engine
   runs in-guest, never as a host process dependency.
-- **Docker / shared-kernel containers** — there is no container fallback and
-  none is planned: a shared-kernel container is not a microVM (see
-  [Matryoshka model](/security/matryoshka/)). Its init is not
-  `mvm-guest-agent` and its mounts are host-kernel namespaces, not dm-verity
-  block devices, so this boot contract cannot apply without becoming a
-  microVM. A container tier, if one is ever admitted, would be dev-tier only,
-  refused by prod admission, and would carry its own explicitly weaker boot
-  contract rather than sharing this one.
+- **Docker / shared-kernel containers** — an opt-in dev tier now exists
+  (ADR-034, `specs/adrs/034-docker-dev-tier-backend.md`): `--hypervisor
+  docker` runs the identical `mvm-guest-agent` as the container's PID 1 and
+  delivers the identical `ActivateEnvironment` — over a host bind-mounted
+  Unix socket instead of vsock — with the runtime overlay and volumes as
+  host bind mounts, `--network none`, and egress through the same
+  substitution endpoint. It carries the activation contract in adapted
+  form: the container already owns its root, so activation is the uid-901
+  drop and the gate flip (an in-place root), with no dm-verity and no
+  hardware boundary. It is never auto-selected, is refused by production
+  admission, and reports the hardware-isolation claims as not holding (see
+  [Matryoshka model](/security/matryoshka/)). A shared-kernel container is
+  still not a microVM; this tier exists so KVM-less dev/CI hosts can
+  exercise the real agent and RPC surface, never as an isolation story.
 - **Apple Container** — Apple's `container` framework boots lightweight Linux
   VMs with its own init and networking/vsock stack. There is no backend
   variant for it today. Future support means a driver that boots the same

--- a/public/src/content/docs/security/matryoshka.md
+++ b/public/src/content/docs/security/matryoshka.md
@@ -70,14 +70,16 @@ mvm runs on multiple backends. Not all backends carry all seven claims. The tier
 
 ### No container fallback
 
-mvm has **no Tier 3** and no container/Docker fallback. A shared-kernel container is not a microVM: its isolation comes from the host kernel's namespace and cgroup machinery, which is shared with the host. In 2024–2025 the container ecosystem produced multiple CVEs (Leaky Vessels, NVIDIAScape, runc race conditions, Docker Desktop priv-esc, runc masked-path) that yielded **host escape** from inside a container — none of which matter inside a microVM, where the guest kernel is isolated by hardware. If a host has no microVM-capable backend, mvm does not silently drop to a weaker boundary; it fails closed.
+On every default and production path, mvm has **no Tier 3** and no container/Docker fallback. A shared-kernel container is not a microVM: its isolation comes from the host kernel's namespace and cgroup machinery, which is shared with the host. In 2024–2025 the container ecosystem produced multiple CVEs (Leaky Vessels, NVIDIAScape, runc race conditions, Docker Desktop priv-esc, runc masked-path) that yielded **host escape** from inside a container — none of which matter inside a microVM, where the guest kernel is isolated by hardware. If a host has no microVM-capable backend, mvm does not silently drop to a weaker boundary; it fails closed.
+
+The one carve-out is an **explicitly selected dev tier** (ADR-034): `--hypervisor docker` runs the real `mvm-guest-agent` as a container's PID 1 with the real activation contract and RPC surface, so KVM-less dev and CI hosts can exercise workloads against the same code production runs. It is opt-in only (auto-detection never picks it), refused by production admission, labeled Tier 3 shared-kernel everywhere the tier is shown, and carries none of the hardware-isolation claims. It is a development substrate, not a fallback: nothing routes to it by default, by accident, or under production admission.
 
 ### Choosing a tier
 
 - **Production / untrusted code** → Tier 1. Linux + KVM + Firecracker. No exceptions.
 - **macOS dev or CI on Apple Silicon** → Tier 2 (HVF or libkrun). Verified boot is the open item.
 - **Linux dev/test without `/dev/kvm`** → Tier 2 QEMU (`--hypervisor qemu`, TCG software emulation). A real microVM, slower; dev/test only.
-- **macOS Intel / native Windows** → unsupported for local microVM isolation today (no container fallback). WSL2 with nested `/dev/kvm` is the supported Windows-adjacent libkrun workload path; a Hyper-V managed Linux builder remains future backend work.
+- **macOS Intel / native Windows** → unsupported for local microVM isolation today (no container fallback on any default path — only the explicitly selected ADR-034 dev tier). WSL2 with nested `/dev/kvm` is the supported Windows-adjacent libkrun workload path; a Hyper-V managed Linux builder remains future backend work.
 
 `mvmctl doctor` reports your current tier on the running host.
 

--- a/schema/protocol-v0.json
+++ b/schema/protocol-v0.json
@@ -3520,7 +3520,7 @@
       "additionalProperties": false
     },
     "RootfsConfig": {
-      "description": "Root device the guest mounts as `/`.  Three shapes, selected by which optional fields are set:\n\n- **dm-verity block** (`roothash` + `hash_dev`): create the `root` dm-verity target and mount it read-only. - **plain block** (neither): mount `data_dev` read-only without verification (unverified dev-tier boot). - **virtio-fs root** (`virtiofs_tag`): mount the virtio-fs tag read-only as the root — the block-less dev-tier boot.",
+      "description": "Root device the guest mounts as `/`.  Three mount shapes, selected by which optional fields are set, plus one mount-free shape:\n\n- **dm-verity block** (`roothash` + `hash_dev`): create the `root` dm-verity target and mount it read-only. - **plain block** (neither): mount `data_dev` read-only without verification (unverified dev-tier boot). - **virtio-fs root** (`virtiofs_tag`): mount the virtio-fs tag read-only as the root — the block-less dev-tier boot. - **in place** (`in_place`): the runtime already owns `/` — a shared-kernel container whose root is the image itself. Nothing is mounted and no pivot happens; activation is the privilege drop and the gate flip only.",
       "type": "object",
       "required": [
         "data_dev"
@@ -3537,6 +3537,11 @@
             "string",
             "null"
           ]
+        },
+        "in_place": {
+          "description": "The root is already in place (shared-kernel container tier): skip the rootfs mount and the pivot entirely. Mutually exclusive with every other field — a host that sets this alongside a device, hash, or tag gets a validation error from the agent, not a silent choice.",
+          "default": false,
+          "type": "boolean"
         },
         "roothash": {
           "description": "64-character lowercase hex dm-verity root hash.  Absent for an unverified plain-block root.",

--- a/specs/adrs/034-docker-dev-tier-backend.md
+++ b/specs/adrs/034-docker-dev-tier-backend.md
@@ -1,0 +1,130 @@
+# ADR-034: An opt-in, prod-refused Docker dev-tier backend
+
+## Status
+
+Accepted — boundary ratified; scoped as the **shared-kernel container dev
+tier** (opt-in, never auto-selected, refused by production admission,
+honest capabilities, none of the hardware-isolation claims). Implemented
+by `DockerBackend` (`mvm_runtime::docker_backend`), selectable only via
+`--hypervisor docker` / `MVM_BACKEND=docker`.
+
+This ADR deliberately narrows two older statements: ADR-007's "no Docker
+backend anywhere on the execution path" and the security posture doc's "no
+container fallback". Both stand for the **production and default** paths;
+what changes is that a clearly-labeled, explicitly-selected container tier
+now exists for development, demo, and CI-sandbox use. The production rule
+is unchanged: a host with no microVM substrate still fails closed on every
+path it did not explicitly opt out of.
+
+## Context
+
+mvm's backends provide hardware-isolated microVMs: Firecracker on Linux
+`/dev/kvm`, libkrun and HVF on macOS, QEMU as a Linux dev/test substrate.
+Hosts with none of these — a Linux CI runner without KVM, a developer
+machine where only a container runtime is installed — currently have no
+way to exercise an mvm workload at all: auto-detection fails closed and
+the security model has no Tier 3. The recurring ask is a way to develop
+and smoke-test workloads on such hosts without pretending the boundary is
+something it is not.
+
+A shared-kernel container is not a microVM. Its isolation is the host
+kernel's namespace and cgroup machinery, which the workload shares with
+the host and every other container; the container-escape CVE record (Leaky
+Vessels, runc races, masked-path) applies to it and to nothing behind a
+hardware boundary. A Docker-backed tier therefore cannot honestly carry
+any of the hardware-isolation claims, and must never be reachable by
+accident.
+
+ADR-024 already established the discipline for a tier like this: opt-in
+only, never auto-selected, honest capabilities, claim-free, failing closed
+on anything it cannot do. This ADR applies the same discipline to a
+container substrate and adds the guest-side compatibility story: the same
+`mvm-guest-agent`, the same activation contract, the same operational RPC
+surface — over a Unix socket, because a container has no vsock.
+
+## Decision
+
+**A Docker backend may exist, bound by five constraints, decided now so
+they cannot be relitigated case by case later:**
+
+1. **It is opt-in only and never auto-selected.** Backend auto-detection
+   (the platform ladder) and capability-driven selection never resolve to
+   it; a caller must name it explicitly with `--hypervisor docker` or
+   `MVM_BACKEND=docker`. It is never a fallback: a host with no microVM
+   substrate still fails closed unless the operator explicitly chose the
+   container tier.
+2. **Production admission refuses it, structurally.** The backend does not
+   implement the workload-backend surface the admitted launch funnel
+   requires (`as_workload_backend` → `None`, the same carve-out as QEMU
+   and Wasm), its catalog descriptor marks it non-workload and Tier 3, and
+   `doctor`/launch surfaces label it a shared-kernel container wherever
+   the tier is shown. An untrusted production workload cannot be routed to
+   it by config drift, by default, or by accident.
+3. **It reports its capabilities and claims honestly.** Shared kernel ⇒
+   the host-filesystem-isolation, no-uid-0-escape, and verified-boot
+   claims do not hold; there is no dm-verity block boot, no guest kernel,
+   no hardware boundary, and image references are tag-based and not
+   hash-verified by mvm. The claims that are substrate-independent and
+   still true — the production agent carries no `do_exec`, the RPC framing
+   is fuzzed, dependencies are audited — are reported as holding, exactly
+   as they are for the microVM backends. The tier string and doctor output
+   say "shared-kernel container, dev tier" plainly.
+4. **The guest-visible contract is the same, not a fork.** The container
+   runs the identical `mvm-guest-agent` binary as PID 1 (bind-mounted
+   read-only as `/init`), receives the identical `ActivateEnvironment`
+   message — over an AF_UNIX listener instead of vsock, the only
+   guest-side change — applies the identical uid-901 privilege drop, keeps
+   the identical `NotActivated` fail-closed gate, and serves the identical
+   operational RPC surface. The runtime overlay and declared volumes are
+   host bind mounts (read-only honored); there is no NIC (`--network
+   none`), so egress — when the launch policy allows it — rides the same
+   per-VM substitution endpoint over a bind-mounted socket. Anything the
+   tier cannot do (kernel/initrd boot, dm-verity, block volumes,
+   snapshots, pause/resume, warm start, standby pool) fails closed with a
+   typed error naming the limitation.
+5. **It never dilutes the microVM tiers.** No documentation, doctor
+   output, or marketing may present the container tier as an isolation
+   tier, and no microVM-tier claim may cite a container-tier run as
+   evidence. The security posture doc's "no container fallback" section is
+   amended to carve out this opt-in tier explicitly rather than silently
+   contradicted.
+
+**If this tier is ever asked to execute untrusted production workloads,
+the answer is no at the admission layer, not a better container.** The
+promotion path for such a workload is a real microVM backend; hardening
+containers into an isolation boundary is out of scope permanently.
+
+## Alternatives considered
+
+- **Keep "no container fallback" absolute.** Rejected: it leaves
+  KVM-less/dev-container-only hosts with no workflow at all, which in
+  practice pushes users to run the real thing with `--privileged` hacks or
+  to fork the tooling — both worse than an honest, fenced-off dev tier.
+- **A container tier that shares the microVM boot contract literally**
+  (initramfs, dm-verity inside the container). Rejected: privileged
+  containers or CAP_SYS_ADMIN would be required, which is a *worse*
+  security posture than the honest shared-kernel label and still not
+  hardware isolation.
+- **Silent capability degradation** — accept kernel/verity/block-volume
+  requests and ignore them. Rejected: violates the standing rule that a
+  backend never silently drops a security-relevant requirement.
+- **Rootless/privileged-hardened container runtime as an isolation
+  boundary.** Rejected: it is still the host kernel's namespaces; the CVE
+  record above applies, and the honest label stays "shared kernel".
+
+## Consequences
+
+- The execution path now contains a Tier 3 by construction, fenced by the
+  admission type-bar rather than by convention: the prod funnel cannot
+  name it, auto-detect cannot pick it, and the caller must type `docker`
+  to get it.
+- The guest agent gains exactly one transport variant (AF_UNIX listener,
+  selected by environment) with the peer-CID authorization check replaced
+  by the host-owned 0700 socket-directory boundary — documented as the
+  weaker boundary it is.
+- Dev, demo, and CI-sandbox workflows on KVM-less hosts can exercise the
+  real agent, the real activation contract, and the real RPC surface, so
+  most workload bugs are found against the same code production runs.
+- The "no container fallback" posture doc and ADR-007 are superseded
+  *only* for this opt-in tier; every default and production path keeps
+  failing closed on hosts with no microVM substrate.

--- a/specs/notes/2026-07-29-universal-initramfs-future-tiers.md
+++ b/specs/notes/2026-07-29-universal-initramfs-future-tiers.md
@@ -24,15 +24,35 @@ backends").
 
 ## Docker / shared-kernel containers
 
-- Constraint source: `public/src/content/docs/security/matryoshka.md` ("No
-  container fallback") — mvm has no Tier 3; a host with no microVM backend
-  fails closed rather than dropping to a weaker boundary.
-- Boot contract: cannot apply without becoming a microVM. Container init is
-  not `mvm-guest-agent`; mounts are host-kernel namespaces, not dm-verity
-  block devices. A future container tier would be dev-tier only, refused by
-  prod admission (same discipline as the Lima test-tier exception in
-  `AGENTS.md`), and would carry its own explicitly weaker boot contract
-  rather than sharing the universal initramfs.
+- Constraint source: ADR-034 (`specs/adrs/034-docker-dev-tier-backend.md`) —
+  an opt-in, never-auto-selected, prod-refused shared-kernel container dev
+  tier, applying the ADR-024 discipline (honest capabilities, fail closed,
+  none of the hardware-isolation claims) to a Docker substrate. The default
+  and production rules are unchanged: a host with no microVM backend still
+  fails closed on every path it did not explicitly opt out of.
+- Implemented design: `DockerBackend` (`crates/mvm-runtime/src/docker_backend.rs`)
+  runs the container with the identical static `mvm-guest-agent` bind-mounted
+  read-only as `/init` (PID 1 of the container's PID namespace),
+  `--network none`, `--security-opt no-new-privileges`, the runtime-overlay
+  guest binaries bind-mounted read-only at `/mvm/runtime`, and DirShare
+  volumes as read-only-honored bind mounts. The agent listens on AF_UNIX
+  (`MVM_AGENT_TRANSPORT=unix`) instead of vsock — the only guest-side
+  transport change; the socket lives on a host-owned 0700 directory
+  bind-mounted into the container, and that directory's permissions are the
+  peer boundary (deliberately weaker than the vsock host-CID gate). After
+  start the host delivers `ActivateEnvironment` over that socket: the root
+  is `in_place` (the container already owns `/` — no mount, no pivot), so
+  activation is the uid-901 drop and the `NotActivated` gate flip. Egress,
+  when the policy allows it, rides the same per-VM substitution endpoint
+  over a bind-mounted socket the in-container forward proxy relays to.
+  Kernel/initrd boot, dm-verity, block volumes, snapshots, pause/resume,
+  warm start, and the standby pool all fail closed with typed errors.
+- Boot contract: adapted, not shared literally. Container init IS
+  `mvm-guest-agent` (unlike the arbitrary container this note originally
+  considered), but mounts are host bind mounts, not dm-verity block
+  devices, and claims 1/2/3/6 report `DoesNotHold`. Prod admission refuses
+  the tier structurally (`as_workload_backend` → `None`, Tier 3,
+  `is_workload: false`).
 
 ## Apple Container
 


### PR DESCRIPTION
A Docker dev-tier backend that gives a container the same guest-visible functionality as the microVM backends: `mvm-guest-agent` as container PID 1, runtime overlay + volumes mounted inside, activation after start, uid-901 drop, and the standard operational RPC surface — over a host Unix socket instead of vsock.

**ADR-034** (`specs/adrs/034-docker-dev-tier-backend.md`) ratifies the tier: opt-in only, never auto-selected, prod-refused, honestly labeled shared-kernel dev tier. It narrows ADR-007's "no Docker backend" and matryoshka's "no container fallback" *for the opt-in tier only* — default paths still fail closed.

## What changed

- **Agent** (`mvm-guest-agent`): new `transport.rs` listener abstraction (vsock unchanged, byte-for-byte; AF_UNIX opt-in via `MVM_AGENT_TRANSPORT=unix`, run-dir 0700 perms as the peer boundary); init skips runtime-provided mounts/pivot for in-place roots; forward proxy relays egress to the endpoint UDS (`MVM_AGENT_EGRESS_ENDPOINT_SOCK`).
- **Wire**: `RootfsConfig.in_place` (serde-defaulted, wire-compatible) — a container already owns its root; activation is the uid-901 drop + gate flip. Mutually exclusive with device/hash/tag fields, validated loudly. Schema + SDK stubs regenerated.
- **`DockerBackend`** (direct `VmBackend`, wasm-tier pattern): `docker run --entrypoint /init --network none` with the static agent binary, overlay (RO), volume bind mounts, and the per-VM endpoint UDS; activation over the bind-mounted `agent.sock` via shared `activate_over_stream`; typed errors (DockerNotAvailable, DiskVolumeNotSupported, RuntimeOverlayUnavailable, …). Volumes are create-time bind mounts; block volumes fail closed.
- **Posture**: claims 1/2/3/6 `DoesNotHold`, 4/5/7 `Holds`; prod refusal is structural in four places (`as_workload_backend → None`, catalog `is_workload: false` + Tier3, `BackendKind::Docker` doc, standby fail-closed), each pinned by a test.

## Validation

1154 mvm-runtime tests + 45 agent tests pass; workspace clippy clean; all 9 policy xtasks clean (incl. `check-adr-coverage`); Linux musl check compiles. No live-docker e2e (hypervisor-free tests only).