### PR TITLE
feat(xtask): mutation-test the claim witnesses, not just their presence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,13 @@ jobs:
       - name: Conformance claim catalog
         run: cargo run -p xtask -- check-claim-catalog
 
+      # Surface pin only — milliseconds, no cargo-mutants needed. Fails when a
+      # claim's witnesses stop resolving to a mutable file, i.e. when a claim
+      # drops out of the nightly mutation lane's scope. The mutation run itself
+      # lives in security.yml because it costs hours.
+      - name: Claim mutation surface is pinned
+        run: cargo run -p xtask -- check-mutation-witnesses
+
       - name: Conformance model is the single source (R1)
         run: cargo run -p xtask -- check-conformance
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -511,6 +511,47 @@ jobs:
             crates/mvm-sdk/fuzz/corpus/
             crates/mvm-sdk/fuzz/artifacts/
 
+  # ── Lane 4b: Claim witnesses are mutation-tested ──────────────────
+  # check-claim-catalog (ci.yml) proves a claim's witness EXISTS. This
+  # lane asks whether it BITES: cargo-mutants breaks the enforcement
+  # code on purpose and a surviving mutant means the witness cannot
+  # detect its own property being violated. Sibling to the fuzz lane —
+  # fuzzing asks whether bad input is handled, mutation asks whether
+  # our own tests would notice the handling going away.
+  #
+  # The surface is derived from the claims ledger, and its pin is
+  # checked on every PR by ci.yml; only the mutation run itself is
+  # nightly, because it costs hours.
+  mutation-witnesses:
+    name: Claim witnesses — mutation-tested (ADR-001 claims ledger)
+    runs-on: ubuntu-latest
+    # NON-BLOCKING for now: accepted_misses is seeded only for the
+    # claim-10 anchor, so the first full runs will report holes in the
+    # not-yet-triaged files. Flip this off once the baseline covers the
+    # whole surface — tracked in specs/plans/272.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-mutation-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-mutation-
+
+      - name: Install cargo-mutants and nextest
+        run: cargo install --locked cargo-mutants cargo-nextest
+
+      - name: Mutate the claim surface and ratchet survivors
+        run: cargo run -p xtask -- check-mutation-witnesses --run
+
   # ── Lane 5: Hash-verify regression ─────────────────────────────────
   # ADR-001 §W5.1 — the unit tests that exercise the
   # download-and-verify code path live in mvm-cli. Run them in

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ specs/scratch.md
 # Default `mvmctl compile` output dir — generated flake + bundled src,
 # regenerable, never committed (header says "re-run `mvmctl compile`").
 /out/
+
+# cargo-mutants drops its per-run report tree here unless `--output` points
+# elsewhere. `xtask check-mutation-witnesses` always redirects it to a temp
+# dir; this guards a hand-run from leaving a report in the tree.
+mutants.out/

--- a/Justfile
+++ b/Justfile
@@ -232,6 +232,25 @@ clippy-bdd:
 # Format check + clippy + model gates (workspace + the feature-gated BDD target)
 lint: fmt-check clippy clippy-bdd model
 
+# ── Claim mutation testing ───────────────────────────────────────────────
+
+# Verify the committed mutation surface still matches the claims ledger.
+# Milliseconds, needs no cargo-mutants — this is the part CI runs per PR.
+mutation-surface:
+    cargo run -p xtask -- check-mutation-witnesses
+
+# Mutate the claim surface and ratchet survivors against the baseline.
+# HOURS: this is the nightly lane's command, not an inner-loop check.
+# Needs `cargo install cargo-mutants cargo-nextest`.
+mutation-witnesses:
+    cargo run -p xtask -- check-mutation-witnesses --run
+
+# Re-pin the surface after a witness legitimately moved. Cheap, and keeps
+# the stated reasons on existing accepted misses. Add --run to also
+# re-record the misses themselves (hours, and it discards those reasons).
+mutation-repin:
+    cargo run -p xtask -- check-mutation-witnesses --write-baseline
+
 # ── CI Gate ──────────────────────────────────────────────────────────────
 
 # Full CI gate: lint + test + doctests + hermetic BDD + model gates.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -46,6 +46,29 @@
       #1876 and #1878; tracked in
       `specs/plans/266-vsock-overload-hardening.md`.
 
+- [x] Claim witnesses are now mutation-tested, not merely present.
+      `check-claim-catalog` proves a witness exists; nothing proved it can
+      fail. Added `xtask check-mutation-witnesses`, which derives the
+      mutation surface *from the claims ledger* (each `fn:` witness resolves
+      to its declaring file — this repo keeps `#[cfg(test)] mod tests`
+      beside the implementation, so a witness lands on the code it guards)
+      and pins it to `xtask/mutation-witness-baseline.json`: 26 files across
+      8 packages. The cheap default mode runs on every PR and fails when the
+      surface moves, so a claim quietly leaving mutation coverage is a
+      reviewable diff; `--run` mutates the surface nightly in `security.yml`
+      and ratchets survivors, failing only on a *new* hole. Claims that reach
+      no mutable file are reported and pinned rather than silently absent:
+      4, 5 and 7 are witnessed only by CI lanes, and claim 16's three
+      witnesses all live in an integration test, which cargo-mutants does not
+      mutate. The first real run (claim-10 anchor, 52 mutants) found **4
+      survivors** — including `NetworkPreset::is_deny_all` surviving
+      replacement by both `true` and `false`, because it has no production
+      caller anywhere in the tree and its only assertion lives in another
+      crate's tests. Seeded as triaged baseline entries; the nightly lane
+      ships `continue-on-error` until the baseline covers the whole surface.
+      Also extracted the shared ledger parser into `xtask/src/claims_ledger.rs`
+      so both gates read one table. `specs/plans/272-mutation-tested-claim-witnesses.md`.
+      307/307 xtask nextest.
 - [x] Non-hermetic `$HOME` test class closed. `default_mvm_cache_dir` is the
       only resolver that reads `$HOME` while `MVM_HOME` is set (it seeds the
       builder image / runtime overlay from the host's shared cache), so a test

--- a/specs/plans/272-mutation-tested-claim-witnesses.md
+++ b/specs/plans/272-mutation-tested-claim-witnesses.md
@@ -1,0 +1,177 @@
+# Plan 272: Mutation-tested claim witnesses
+
+**Status:** WS-1 (gate + surface pin) implemented; WS-2 (full-surface baseline) pending a nightly run.
+**Owner:** mvm core.
+**Depends on:** the claims ledger in `specs/adrs/001-microvm-security-posture.md`
+(`<!-- claims-catalog:begin -->`) and `xtask check-claim-catalog`.
+
+## Goal
+
+`check-claim-catalog` proves a named witness *exists*. Nothing proves the
+witness *bites*. A test can name the right symbol, exercise the happy path,
+and pass forever while the property it supposedly ratifies is broken — the
+claim stays green because the assertion never had the power to fail.
+
+This plan closes that gap with mutation testing scoped to the claim surface:
+deliberately break the enforcement code, then check that a claim witness
+notices. A surviving mutant is a claim whose witness cannot detect its own
+property being violated.
+
+The scope is derived from the ledger, not hand-listed. Each `fn:` witness
+resolves to the file that declares it; the union of those files is the
+mutation surface. This repo keeps `#[cfg(test)] mod tests` in the same file
+as the implementation, so resolving a witness lands on the enforcement code
+it guards — no second list to drift out of sync with the ledger.
+
+## Why not just run cargo-mutants over the workspace
+
+Cost. A full-workspace run rebuilds and re-tests once per mutant across a
+~4,350-test suite; there are thousands of mutants. Scoping to the claim
+surface keeps the run affordable enough to be a real recurring gate instead
+of an aspiration, and it targets the code where a vacuous test is most
+expensive — the fifteen security claims.
+
+## Design
+
+Three modes, one gate:
+
+| Invocation | Cost | Lane |
+| --- | --- | --- |
+| `check-mutation-witnesses` | milliseconds | every PR |
+| `check-mutation-witnesses --run` | hours | nightly |
+| `check-mutation-witnesses --write-baseline` | hours | manual, by a maintainer |
+
+The cheap default mode is the part that runs on a PR. It resolves the
+surface from the ledger and compares it against the surface committed in
+`xtask/mutation-witness-baseline.json`. That makes two failure modes
+reviewable in a diff:
+
+- A claim's witnesses stop resolving to any mutable file — the claim has
+  dropped out of mutation coverage entirely.
+- The surface changed — a witness moved, was renamed, or a claim's anchor
+  shifted to a different file. The diff shows exactly which claim moved.
+
+Without the committed surface, a claim could silently leave the expensive
+lane's scope and the nightly run would keep reporting success over a smaller
+and smaller surface. Pinning it is what stops "the gate is green" from
+drifting away from "the gate covers the claims".
+
+`--run` additionally shells out to cargo-mutants once per surface file,
+scoped with `-p <owning crate> --file <path>`, and ratchets the observed
+missed mutants against `accepted_misses` in the baseline:
+
+- A missed mutant not in the baseline fails the gate. That is a new hole.
+- A baseline entry that is now caught is reported, not failed, with a note
+  to shrink the baseline. Ratchet down, never silently up.
+
+Mutant identity is `file` + description with `line:col` stripped
+(`replace == with != in resolve_network_policy`), so unrelated edits above a
+mutant in the same file do not invalidate the baseline. Two mutants that
+differ only in position collapse to one identity; that is deliberate — it
+keeps the baseline stable and a genuinely new hole still shows up as a new
+description.
+
+### What a "miss" means here
+
+Each invocation is scoped `-p <owning crate> --file <path>`, so the tests
+that get a chance to catch a mutant are the owning crate's own. A surviving
+mutant therefore means *the crate that owns the invariant does not test it* —
+not that nothing in the workspace would notice. A cross-crate test may well
+catch it.
+
+That is a deliberate trade. Running the full workspace suite per mutant is
+roughly an order of magnitude more expensive and would put the lane out of
+reach; and the narrower question is the more useful one, because a claim
+whose enforcement is only ever exercised from another crate is fragile by
+construction. The claim-10 anchor is a live example: `is_deny_all`'s only
+assertion lives in a different crate, and it survives both constant
+replacements here.
+
+The cost of the trade is that a "miss" is not automatically a hole, so a
+baseline entry must say which it is. That is why `reason` is mandatory and
+why the gate fails on an empty one.
+
+## Deliberate non-goals
+
+- **Not PR-blocking on mutation results.** Hours-long lanes do not belong on
+  a PR. The PR-visible half is the surface pin; the mutation result is
+  nightly. This is stated rather than implied because a gate whose expensive
+  half never runs on a PR is exactly the failure mode this plan exists to
+  catch elsewhere — see the honesty note below.
+- **Not a coverage percentage.** A mutation *score* invites tuning the
+  threshold. The ratchet asks a sharper question: is there a new hole?
+
+## Honesty note
+
+The nightly lane lives in `security.yml`, which runs on release tags and a
+nightly cron and is therefore invisible on a PR. That is a pre-existing
+property of that workflow, not something this plan fixes, and it is the
+reason the surface pin is a separate cheap mode wired into the PR lint lane.
+The claim this gate supports is "a new hole in a claim witness is detected
+within a day", not "within a PR".
+
+## Workstreams
+
+### WS-1 — gate + surface pin (PR-visible)
+
+- [x] Extract the ledger parser out of `check_claim_catalog` into
+      `xtask/src/claims_ledger.rs` so both gates read one parser.
+- [x] `xtask/src/check_mutation_witnesses.rs`: resolve `fn:` witnesses to
+      declaring files, derive the owning crate, pin the surface.
+- [x] Report and pin the claims that reach *no* mutable file, so "the
+      mutation lane is green" cannot quietly mean "over 22 of 26 files
+      and 12 of 16 claims". Claims 4, 5 and 7 are witnessed only by CI
+      lanes (a symbol grep and a fuzz job have no function to mutate);
+      claim 16's three witnesses all live in
+      `crates/mvm-hostd/tests/egress_secret_leak_gate.rs`, and
+      cargo-mutants does not mutate test targets.
+- [x] `mutants.out/` in `.gitignore` — the gate always redirects
+      cargo-mutants to a temp dir, but a hand-run would otherwise leave a
+      report tree in the working copy. No `mutants.toml`: the gate passes
+      `-p`, `--file`, `--test-tool` and `--timeout` explicitly, so a
+      config file would carry nothing.
+- [x] Wire `check-mutation-witnesses` into `xtask/src/main.rs` and the
+      `Justfile` (`mutation-surface`, `mutation-witnesses`,
+      `mutation-repin`).
+- [x] Unit tests: surface resolution, owning-crate derivation, mutant
+      identity normalization, ratchet verdicts.
+- [x] Add the gate to the PR lint lane in `ci.yml`.
+
+### WS-2 — full-surface baseline (nightly)
+
+- [x] Nightly `mutation-witnesses` job in `security.yml`, marked
+      `continue-on-error` until the baseline covers the whole surface.
+- [x] Seed `accepted_misses` from a real run of the claim-10 anchor
+      (`crates/mvm-protocol/src/policy/network_policy.rs`): 52 mutants,
+      35 caught, 12 unviable, 1 timeout, **4 missed**.
+- [ ] Populate `accepted_misses` for the remaining 25 surface files from
+      the first full nightly runs, then drop `continue-on-error` so a new
+      hole fails the lane.
+- [ ] Triage the four seeded misses. What the first run already shows:
+  - [ ] `is_banned_ssh_port -> false` survives. Only the negative
+        direction is asserted inside mvm-protocol, so pinning the
+        predicate to false goes unnoticed while flipping its `==` is
+        caught. The SSH ban has real callers in mvm-core and mvm-cli;
+        the owning crate should assert port 22 *is* banned.
+  - [ ] `NetworkPreset::is_deny_all` survives being replaced by **both**
+        `true` and `false`. It has no production caller anywhere in the
+        tree — its only use is an assertion in mvm-core's
+        `security_profile` tests. Either it is load-bearing and wants a
+        caller, or it is dead code wearing a claim-shaped name.
+  - [ ] `NetworkPolicy::trusted_build_egress -> Default::default()`
+        survives. The mutant substitutes the deny-all default, so it
+        makes the policy *stricter*: a functional coverage gap, not a
+        security hole. Worth recording as exactly that.
+
+### WS-3 — deferred follow-ups
+
+- [ ] Consolidate the seven private `walk()` helpers duplicated across
+      `xtask/src/check_*.rs` into one shared xtask util. This plan adds no
+      new copy — `check_mutation_witnesses` reuses the ledger module's
+      walker — but the existing duplication remains.
+- [ ] Consider a `mutate:` witness kind in the ledger for claims whose
+      enforcement lives in a different file from their anchor test, so the
+      surface can name enforcement code directly instead of inferring it.
+- [ ] `substitute` resolves to four files (an overloaded name across the
+      agent, keyholder, and supervisor network stages). All four land in the
+      surface today. A more specific witness token would narrow it.

--- a/xtask/mutation-witness-baseline.json
+++ b/xtask/mutation-witness-baseline.json
@@ -1,0 +1,229 @@
+{
+  "surface": [
+    {
+      "path": "crates/mvm-agentd/src/bin/mvm-seccomp-apply.rs",
+      "package": "mvm-agentd",
+      "claims": [
+        2
+      ]
+    },
+    {
+      "path": "crates/mvm-agentd/src/substitution_client.rs",
+      "package": "mvm-agentd",
+      "claims": [
+        13
+      ]
+    },
+    {
+      "path": "crates/mvm-build/src/app_deps_gate.rs",
+      "package": "mvm-build",
+      "claims": [
+        11
+      ]
+    },
+    {
+      "path": "crates/mvm-build/src/bin/mvm-host-vm-init.rs",
+      "package": "mvm-build",
+      "claims": [
+        2
+      ]
+    },
+    {
+      "path": "crates/mvm-build/src/runtime_overlay.rs",
+      "package": "mvm-build",
+      "claims": [
+        6
+      ]
+    },
+    {
+      "path": "crates/mvm-cli/src/commands/image/pull_core.rs",
+      "package": "mvm-cli",
+      "claims": [
+        14
+      ]
+    },
+    {
+      "path": "crates/mvm-cli/src/commands/shared/parse.rs",
+      "package": "mvm-cli",
+      "claims": [
+        1
+      ]
+    },
+    {
+      "path": "crates/mvm-cli/src/commands/shared/resolve.rs",
+      "package": "mvm-cli",
+      "claims": [
+        10
+      ]
+    },
+    {
+      "path": "crates/mvm-cli/src/commands/vm/console.rs",
+      "package": "mvm-cli",
+      "claims": [
+        15
+      ]
+    },
+    {
+      "path": "crates/mvm-core/src/plan/bundle.rs",
+      "package": "mvm-core",
+      "claims": [
+        9
+      ]
+    },
+    {
+      "path": "crates/mvm-core/src/plan/synthesis.rs",
+      "package": "mvm-core",
+      "claims": [
+        8
+      ]
+    },
+    {
+      "path": "crates/mvm-core/src/policy/dns_guard.rs",
+      "package": "mvm-core",
+      "claims": [
+        10
+      ]
+    },
+    {
+      "path": "crates/mvm-hostd/src/broker/registry.rs",
+      "package": "mvm-hostd",
+      "claims": [
+        12
+      ]
+    },
+    {
+      "path": "crates/mvm-hostd/src/keyholder/substitution.rs",
+      "package": "mvm-hostd",
+      "claims": [
+        13
+      ]
+    },
+    {
+      "path": "crates/mvm-hostd/src/plan_admission.rs",
+      "package": "mvm-hostd",
+      "claims": [
+        1,
+        8
+      ]
+    },
+    {
+      "path": "crates/mvm-hostd/src/supervisor/audit_file.rs",
+      "package": "mvm-hostd",
+      "claims": [
+        8
+      ]
+    },
+    {
+      "path": "crates/mvm-hostd/src/supervisor/dns_audit.rs",
+      "package": "mvm-hostd",
+      "claims": [
+        10
+      ]
+    },
+    {
+      "path": "crates/mvm-hostd/src/supervisor/network/pipeline.rs",
+      "package": "mvm-hostd",
+      "claims": [
+        13
+      ]
+    },
+    {
+      "path": "crates/mvm-hostd/src/supervisor/network/stages.rs",
+      "package": "mvm-hostd",
+      "claims": [
+        13
+      ]
+    },
+    {
+      "path": "crates/mvm-protocol/src/policy/network_policy.rs",
+      "package": "mvm-protocol",
+      "claims": [
+        10
+      ]
+    },
+    {
+      "path": "crates/mvm-protocol/src/protocol/broker.rs",
+      "package": "mvm-protocol",
+      "claims": [
+        12
+      ]
+    },
+    {
+      "path": "crates/mvm-protocol/src/protocol/vm_backend.rs",
+      "package": "mvm-protocol",
+      "claims": [
+        13
+      ]
+    },
+    {
+      "path": "crates/mvm-runtime/src/libkrun.rs",
+      "package": "mvm-runtime",
+      "claims": [
+        1,
+        15
+      ]
+    },
+    {
+      "path": "crates/mvm-runtime/src/microvm/snapshot.rs",
+      "package": "mvm-runtime",
+      "claims": [
+        10
+      ]
+    },
+    {
+      "path": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "package": "mvm-runtime",
+      "claims": [
+        3,
+        10
+      ]
+    },
+    {
+      "path": "crates/mvm-sdk/src/compile/deps_audit.rs",
+      "package": "mvm-sdk",
+      "claims": [
+        11
+      ]
+    }
+  ],
+  "uncovered_claims": [
+    {
+      "number": 4,
+      "why": "no fn: witness — witnessed by CI lanes only, nothing to mutate"
+    },
+    {
+      "number": 5,
+      "why": "no fn: witness — witnessed by CI lanes only, nothing to mutate"
+    },
+    {
+      "number": 7,
+      "why": "no fn: witness — witnessed by CI lanes only, nothing to mutate"
+    },
+    {
+      "number": 16,
+      "why": "every fn: witness lives in crates/*/tests/, which cargo-mutants does not mutate"
+    }
+  ],
+  "accepted_misses": [
+    {
+      "file": "crates/mvm-protocol/src/policy/network_policy.rs",
+      "mutant": "replace is_banned_ssh_port -> bool with false",
+      "reason": "Observed 2026-07-29. mvm-protocol's own tests only assert the negative direction (a non-22 port is not banned), so pinning the predicate to false survives while flipping its == does not. The SSH ban has production callers in mvm-core and mvm-cli; the owning crate should assert port 22 IS banned. Untriaged."
+    },
+    {
+      "file": "crates/mvm-protocol/src/policy/network_policy.rs",
+      "mutant": "replace NetworkPreset::is_deny_all -> bool with false",
+      "reason": "Observed 2026-07-29. NetworkPreset::is_deny_all has no production caller anywhere in the tree; its only use is an assertion inside mvm-core's security_profile tests. Nothing in mvm-protocol calls it, so the constant survives. Untriaged: either give the predicate a caller or drop it."
+    },
+    {
+      "file": "crates/mvm-protocol/src/policy/network_policy.rs",
+      "mutant": "replace NetworkPreset::is_deny_all -> bool with true",
+      "reason": "Observed 2026-07-29. Same uncalled predicate as the `with false` entry; neither constant is detectable from the owning crate. Untriaged."
+    },
+    {
+      "file": "crates/mvm-protocol/src/policy/network_policy.rs",
+      "mutant": "replace NetworkPolicy::trusted_build_egress -> Self with Default::default()",
+      "reason": "Observed 2026-07-29. No mvm-protocol test asserts the shape of the trusted-build egress policy. The mutant substitutes the deny-all default, so it makes the policy stricter, not weaker — a functional coverage gap rather than a security hole. Untriaged."
+    }
+  ]
+}

--- a/xtask/src/check_claim_catalog.rs
+++ b/xtask/src/check_claim_catalog.rs
@@ -4,19 +4,16 @@
 //! by named tests and CI lanes. Prose drifts: a witness gets renamed,
 //! the claim paragraph still names the old one, and nothing notices.
 //! This lint makes the claims ledger table embedded in
-//! `specs/adrs/001-microvm-security-posture.md` (between the
-//! `<!-- claims-catalog:begin -->` / `<!-- claims-catalog:end -->`
-//! markers) the machine-checked map from each claim to its witnesses
-//! and fails when a named witness no longer exists in the tree — the
-//! same "catalog can't outrun reality" discipline an arc42 Ch.10
-//! architecture doc enforces, scoped to what's mechanically checkable.
+//! `specs/adrs/001-microvm-security-posture.md` the machine-checked map
+//! from each claim to its witnesses and fails when a named witness no
+//! longer exists in the tree — the same "catalog can't outrun reality"
+//! discipline an arc42 Ch.10 architecture doc enforces, scoped to what
+//! is mechanically checkable.
 //!
-//! Catalog row shape (a 5-column markdown table):
-//!   | # | Claim | Witnesses | Authority | Status |
-//! `Witnesses` is a comma-separated list of typed tokens:
-//!   - `fn:NAME` — must appear as `fn NAME(` somewhere under `crates/`
-//!     (a test fn or the impl symbol the claim exercises).
-//!   - `ci:NAME` — must appear literally in some `.github/workflows/*`.
+//! The table parser lives in `claims_ledger`, shared with
+//! `check-mutation-witnesses`, which derives its mutation surface from
+//! the same rows. This gate asserts a witness *exists*; that one asks
+//! whether the witness can actually detect the property breaking.
 //!
 //! The ledger also carries degenerate claim frontmatter (status
 //! `Shipped`, no gated phrases) so `check-no-overclaim` — which scans
@@ -24,29 +21,14 @@
 //! it as an inert, already-shipped claim rather than choking on missing
 //! frontmatter.
 
-use anyhow::{Context, Result, bail};
+use crate::claims_ledger::{self, Row, Witness};
+use anyhow::{Result, bail};
 use std::path::Path;
 
 const KNOWN_STATUSES: [&str; 4] = ["Shipped", "Preview", "Planned", "Not-claimed"];
-const BEGIN_MARKER: &str = "<!-- claims-catalog:begin -->";
-const END_MARKER: &str = "<!-- claims-catalog:end -->";
 
 pub fn run(workspace: &Path) -> Result<()> {
-    let adr_path = workspace
-        .join("specs")
-        .join("adrs")
-        .join("001-microvm-security-posture.md");
-    let source = std::fs::read_to_string(&adr_path)
-        .with_context(|| format!("reading {}", adr_path.display()))?;
-    let ledger = extract_ledger_section(&source).with_context(|| {
-        format!(
-            "locating the claims ledger between `{BEGIN_MARKER}` and `{END_MARKER}` in {}",
-            adr_path.display()
-        )
-    })?;
-
-    let rows = parse_rows(ledger)
-        .with_context(|| format!("parsing the claims ledger table in {}", adr_path.display()))?;
+    let rows = claims_ledger::load(workspace)?;
 
     let mut errors: Vec<String> = Vec::new();
     structural_checks(&rows, &mut errors);
@@ -86,47 +68,6 @@ pub fn run(workspace: &Path) -> Result<()> {
         needles.len()
     );
     Ok(())
-}
-
-/// Slice out the text strictly between `BEGIN_MARKER` and `END_MARKER`.
-/// The ADR carries several other markdown tables (STRIDE threat-model
-/// rows, compliance mappings) with their own pipe-delimited rows;
-/// scoping to the marker-delimited region keeps those from ever being
-/// mistaken for claim-catalog rows.
-fn extract_ledger_section(source: &str) -> Result<&str> {
-    let start = source
-        .find(BEGIN_MARKER)
-        .ok_or_else(|| anyhow::anyhow!("begin marker not found"))?
-        + BEGIN_MARKER.len();
-    let end = source[start..]
-        .find(END_MARKER)
-        .ok_or_else(|| anyhow::anyhow!("end marker not found"))?;
-    Ok(&source[start..start + end])
-}
-
-struct Row {
-    number: u32,
-    claim: String,
-    witnesses: Vec<Witness>,
-    authority: String,
-    status: String,
-}
-
-#[derive(Clone)]
-enum Witness {
-    /// `fn:NAME` — resolves to `fn NAME(` anywhere under `crates/`.
-    Fn(String),
-    /// `ci:NAME` — resolves to the literal NAME in any workflow file.
-    Ci(String),
-}
-
-impl Witness {
-    fn token(&self) -> String {
-        match self {
-            Self::Fn(n) => format!("fn:{n}"),
-            Self::Ci(n) => format!("ci:{n}"),
-        }
-    }
 }
 
 struct Needle {
@@ -198,84 +139,12 @@ fn structural_checks(rows: &[Row], errors: &mut Vec<String>) {
     }
 }
 
-fn parse_rows(source: &str) -> Result<Vec<Row>> {
-    let mut rows = Vec::new();
-    for line in source.lines() {
-        let line = line.trim();
-        if !line.starts_with('|') {
-            continue;
-        }
-        let cells = split_row(line);
-        if cells.len() != 5 {
-            continue; // prose pipe or malformed line — not a catalog row
-        }
-        if is_separator(&cells) || cells[0].eq_ignore_ascii_case("#") {
-            continue;
-        }
-        let Ok(number) = cells[0].parse::<u32>() else {
-            continue; // header variants / non-numeric first cell
-        };
-        let witnesses = parse_witnesses(&cells[2])
-            .with_context(|| format!("claim {number}: bad witnesses cell"))?;
-        rows.push(Row {
-            number,
-            claim: cells[1].clone(),
-            witnesses,
-            authority: cells[3].clone(),
-            status: cells[4].clone(),
-        });
-    }
-    if rows.is_empty() {
-        bail!("no data rows found (expected a 5-column markdown table)");
-    }
-    Ok(rows)
-}
-
-/// Split a `| a | b |` line into trimmed inner cells.
-fn split_row(line: &str) -> Vec<String> {
-    let t = line.strip_prefix('|').unwrap_or(line);
-    let t = t.strip_suffix('|').unwrap_or(t);
-    t.split('|').map(|c| c.trim().to_string()).collect()
-}
-
-/// True for a `|---|---|` markdown separator row.
-fn is_separator(cells: &[String]) -> bool {
-    cells.iter().all(|c| {
-        !c.is_empty()
-            && c.chars()
-                .all(|ch| ch == '-' || ch == ':' || ch.is_whitespace())
-    })
-}
-
-fn parse_witnesses(cell: &str) -> Result<Vec<Witness>> {
-    let mut out = Vec::new();
-    for tok in cell.split(',') {
-        let tok = tok.trim().trim_matches('`').trim();
-        if tok.is_empty() {
-            continue;
-        }
-        let (kind, name) = tok.split_once(':').ok_or_else(|| {
-            anyhow::anyhow!("witness {tok:?} missing a `kind:` prefix (want fn:NAME or ci:NAME)")
-        })?;
-        let name = name.trim();
-        if name.is_empty() {
-            bail!("witness {tok:?} has an empty name");
-        }
-        match kind.trim() {
-            "fn" => out.push(Witness::Fn(name.to_string())),
-            "ci" => out.push(Witness::Ci(name.to_string())),
-            other => bail!("witness {tok:?}: unknown kind {other:?} (expected fn or ci)"),
-        }
-    }
-    Ok(out)
-}
-
 fn resolve_fn_needles(workspace: &Path, needles: &mut [Needle]) -> Result<()> {
     if !needles.iter().any(|n| matches!(n.kind, Kind::Fn)) {
         return Ok(());
     }
     let crates = workspace.join("crates");
-    for_each_file(&crates, Some("rs"), &mut |content| {
+    claims_ledger::for_each_file(&crates, Some("rs"), &mut |_, content| {
         mark(needles, Kind::Fn, content);
     })?;
     Ok(())
@@ -286,7 +155,7 @@ fn resolve_ci_needles(workspace: &Path, needles: &mut [Needle]) -> Result<()> {
         return Ok(());
     }
     let workflows = workspace.join(".github").join("workflows");
-    for_each_file(&workflows, None, &mut |content| {
+    claims_ledger::for_each_file(&workflows, None, &mut |_, content| {
         mark(needles, Kind::Ci, content);
     })?;
     Ok(())
@@ -301,77 +170,10 @@ fn mark(needles: &mut [Needle], kind: Kind, content: &str) {
     }
 }
 
-/// Walk `dir` recursively, calling `cb` with the text of every file
-/// whose extension matches `ext` (or every file when `ext` is `None`).
-/// Skips heavy build/VCS dirs. Missing dirs are not an error.
-fn for_each_file(dir: &Path, ext: Option<&str>, cb: &mut dyn FnMut(&str)) -> Result<()> {
-    if !dir.exists() {
-        return Ok(());
-    }
-    for entry in std::fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_dir() {
-            let name = path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or_default();
-            if matches!(name, "target" | ".git" | "node_modules") {
-                continue;
-            }
-            for_each_file(&path, ext, cb)?;
-        } else {
-            let matches_ext = match ext {
-                Some(want) => path.extension().and_then(|e| e.to_str()) == Some(want),
-                None => true,
-            };
-            if matches_ext && let Ok(content) = std::fs::read_to_string(&path) {
-                cb(&content);
-            }
-        }
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    const TABLE: &str = "\
-| # | Claim | Witnesses | Authority | Status |
-|---|-------|-----------|-----------|--------|
-| 1 | First claim | fn:foo_one, ci:lane-a | seccomp | Shipped |
-| 2 | Second claim | fn:bar_two | Ed25519 | Shipped |
-";
-
-    fn rows() -> Vec<Row> {
-        parse_rows(TABLE).unwrap()
-    }
-
-    #[test]
-    fn parses_data_rows_and_skips_header_and_separator() {
-        let rows = rows();
-        assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0].number, 1);
-        assert_eq!(rows[0].claim, "First claim");
-        assert_eq!(rows[0].witnesses.len(), 2);
-        assert_eq!(rows[1].status, "Shipped");
-    }
-
-    #[test]
-    fn witness_kinds_route_by_prefix() {
-        let ws = parse_witnesses("fn:foo, ci:my-lane, `fn:baz`").unwrap();
-        assert!(matches!(ws[0], Witness::Fn(ref n) if n == "foo"));
-        assert!(matches!(ws[1], Witness::Ci(ref n) if n == "my-lane"));
-        assert!(matches!(ws[2], Witness::Fn(ref n) if n == "baz"));
-    }
-
-    #[test]
-    fn witness_rejects_unknown_kind_and_missing_prefix() {
-        assert!(parse_witnesses("wat:foo").is_err());
-        assert!(parse_witnesses("nokind").is_err());
-        assert!(parse_witnesses("fn:").is_err());
-    }
+    use crate::claims_ledger::{extract_ledger_section, parse_rows};
 
     #[test]
     fn structural_flags_noncontiguous_and_bad_status() {
@@ -440,11 +242,6 @@ mod tests {
         resolve_ci_needles(tmp.path(), &mut needles).unwrap();
         assert!(needles[0].found);
         assert!(!needles[1].found);
-    }
-
-    #[test]
-    fn split_row_drops_outer_pipes() {
-        assert_eq!(split_row("| a | b |"), vec!["a", "b"]);
     }
 
     #[test]

--- a/xtask/src/check_mutation_witnesses.rs
+++ b/xtask/src/check_mutation_witnesses.rs
@@ -1,0 +1,966 @@
+//! `xtask check-mutation-witnesses`
+//!
+//! `check-claim-catalog` proves a claim's witness *exists*. Nothing
+//! proves it *bites*: a test can name the right symbol, exercise the
+//! happy path, pass forever, and never have had the power to fail. The
+//! claim stays green while the property rots.
+//!
+//! This gate breaks the enforcement code on purpose and asks whether a
+//! witness notices. A surviving mutant is a claim whose witness cannot
+//! detect its own property being violated.
+//!
+//! The surface is derived from the ledger, never hand-listed. Each `fn:`
+//! witness resolves to the file declaring it, and this repo keeps
+//! `#[cfg(test)] mod tests` beside the implementation, so a witness
+//! lands on the enforcement code it guards.
+//!
+//! Three modes:
+//!
+//! - default — resolve the surface and compare it against the committed
+//!   surface. Milliseconds, no cargo-mutants needed, safe on a PR. This
+//!   is what stops a claim from silently dropping out of the expensive
+//!   lane's scope: the surface is a committed file, so a claim leaving
+//!   coverage is a reviewable diff.
+//! - `--run` — additionally run cargo-mutants over the surface and
+//!   ratchet observed misses against the baseline. Hours; nightly.
+//! - `--write-baseline` — re-pin the surface, keeping the stated reasons
+//!   on existing accepted misses. Cheap: a witness moving should not
+//!   cost a mutation run. Add `--run` to also re-record the misses,
+//!   which discards those reasons and so is a deliberate reset.
+
+use crate::claims_ledger::{self, Witness};
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+/// Where the pinned surface and accepted misses live.
+const BASELINE_REL: &str = "xtask/mutation-witness-baseline.json";
+
+/// Per-mutant test timeout handed to cargo-mutants. A mutant that hangs
+/// is a caught mutant as far as this gate cares, but without a bound a
+/// single infinite loop stalls the whole lane.
+const MUTANT_TIMEOUT_SECS: u32 = 300;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Resolve the surface and compare against the committed pin.
+    /// Milliseconds; needs no cargo-mutants.
+    PinOnly,
+    /// Also run cargo-mutants and ratchet against accepted misses.
+    Run,
+    /// Re-pin the surface, keeping the accepted misses. Cheap, and the
+    /// common maintenance case: a witness moved and the pin needs to
+    /// catch up, which should not cost a mutation run.
+    RepinSurface,
+    /// Re-pin the surface *and* re-record accepted misses from a fresh
+    /// run. Hours, and it forgets previously stated reasons, so it is
+    /// the rare deliberate reset rather than the routine fix.
+    RewriteBaseline,
+}
+
+/// A file carrying at least one claim witness.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SurfaceFile {
+    /// Workspace-relative, forward-slashed.
+    pub path: String,
+    /// The cargo package that owns it.
+    pub package: String,
+    /// Claim numbers whose witnesses resolve here.
+    pub claims: Vec<u32>,
+}
+
+/// A mutant that survived, with a stated reason for tolerating it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct AcceptedMiss {
+    pub file: String,
+    /// Description with `line:col` stripped — see [`mutant_identity`].
+    pub mutant: String,
+    /// Why this hole is tolerated. Empty is a gate failure: an
+    /// unexplained entry is how a baseline turns into a dumping ground.
+    pub reason: String,
+}
+
+/// A claim that contributes nothing to the mutation surface.
+///
+/// Not a failure: a claim witnessed only by a CI lane (a symbol grep, a
+/// fuzz job) has no function to mutate. But it must be *stated*, because
+/// "the mutation lane is green" over 12 of 16 claims reads as coverage it
+/// does not have. Pinned alongside the surface so a newly added claim
+/// with no coverage shows up in review instead of passing unnoticed.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct UncoveredClaim {
+    pub number: u32,
+    pub why: String,
+}
+
+/// Why a claim's `fn:` witnesses yield nothing mutable.
+const WHY_NO_FN_WITNESS: &str = "no fn: witness — witnessed by CI lanes only, nothing to mutate";
+const WHY_ONLY_INTEGRATION_TESTS: &str =
+    "every fn: witness lives in crates/*/tests/, which cargo-mutants does not mutate";
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Baseline {
+    pub surface: Vec<SurfaceFile>,
+    pub uncovered_claims: Vec<UncoveredClaim>,
+    pub accepted_misses: Vec<AcceptedMiss>,
+}
+
+/// The resolved mutation surface plus the claims it does not reach.
+#[derive(Debug, Default)]
+pub struct Surface {
+    pub files: Vec<SurfaceFile>,
+    pub uncovered: Vec<UncoveredClaim>,
+}
+
+/// One observed surviving mutant.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Miss {
+    pub file: String,
+    pub mutant: String,
+}
+
+pub fn run(workspace: &Path, mode: Mode) -> Result<()> {
+    let Surface {
+        files: resolved,
+        uncovered,
+    } = resolve_surface(workspace)?;
+    if resolved.is_empty() {
+        bail!(
+            "check-mutation-witnesses: the claims ledger resolved to no mutable files at all — \
+             either every `fn:` witness is missing from the tree (run check-claim-catalog) or the \
+             ledger is empty"
+        );
+    }
+
+    let baseline_path = workspace.join(BASELINE_REL);
+
+    if matches!(mode, Mode::RepinSurface | Mode::RewriteBaseline) {
+        // Re-pinning keeps the stated reasons; a full rewrite discards
+        // them on purpose, having just re-observed the ground truth.
+        let accepted_misses = if mode == Mode::RewriteBaseline {
+            seed_accepted(&run_mutants_over(workspace, &resolved)?)
+        } else {
+            read_baseline(&baseline_path)
+                .map(|b| b.accepted_misses)
+                .unwrap_or_default()
+        };
+        let baseline = Baseline {
+            surface: resolved,
+            uncovered_claims: uncovered,
+            accepted_misses,
+        };
+        write_baseline(&baseline_path, &baseline)?;
+        eprintln!(
+            "check-mutation-witnesses: wrote {} ({} surface files, {} accepted misses)",
+            BASELINE_REL,
+            baseline.surface.len(),
+            baseline.accepted_misses.len()
+        );
+        return Ok(());
+    }
+
+    let baseline = read_baseline(&baseline_path)?;
+    let mut errors = check_accepted_reasons(&baseline.accepted_misses);
+    errors.extend(diff_surface(&baseline.surface, &resolved));
+    errors.extend(diff_uncovered(&baseline.uncovered_claims, &uncovered));
+
+    for u in &uncovered {
+        eprintln!(
+            "[note] claim {} has no mutation surface: {}",
+            u.number, u.why
+        );
+    }
+
+    if mode == Mode::Run {
+        let observed = run_mutants_over(workspace, &resolved)?;
+        let verdict = ratchet(&baseline.accepted_misses, &observed);
+        for m in &verdict.new_misses {
+            errors.push(format!(
+                "new surviving mutant in {}: {} — a claim witness does not detect this change",
+                m.file, m.mutant
+            ));
+        }
+        for m in &verdict.now_caught {
+            eprintln!(
+                "[note] {} :: {} is now caught — drop it from {BASELINE_REL}",
+                m.file, m.mutant
+            );
+        }
+    }
+
+    if !errors.is_empty() {
+        for e in &errors {
+            eprintln!("[error] {e}");
+        }
+        bail!(
+            "check-mutation-witnesses: {} problem(s); if the surface moved on purpose, \
+             re-pin with `cargo run -p xtask -- check-mutation-witnesses --write-baseline`",
+            errors.len()
+        );
+    }
+
+    eprintln!(
+        "check-mutation-witnesses: surface pinned and clean ({} files across {} packages, {} accepted misses)",
+        resolved.len(),
+        resolved
+            .iter()
+            .map(|s| s.package.as_str())
+            .collect::<BTreeSet<_>>()
+            .len(),
+        baseline.accepted_misses.len()
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// Surface resolution
+// ---------------------------------------------------------------------
+
+/// Map every `fn:` witness in the ledger to the file that declares it.
+pub fn resolve_surface(workspace: &Path) -> Result<Surface> {
+    let rows = claims_ledger::load(workspace)?;
+
+    // fn name -> claim numbers naming it.
+    let mut wanted: BTreeMap<String, BTreeSet<u32>> = BTreeMap::new();
+    // Claims with no `fn:` witness at all have nothing to resolve.
+    let mut claims_with_fn_witness: BTreeSet<u32> = BTreeSet::new();
+    for row in &rows {
+        for w in &row.witnesses {
+            if let Witness::Fn(name) = w {
+                wanted.entry(name.clone()).or_default().insert(row.number);
+                claims_with_fn_witness.insert(row.number);
+            }
+        }
+    }
+
+    // path -> claim numbers whose witnesses live there. Integration-test
+    // paths are collected too, so a claim witnessed *only* by an
+    // integration test can be reported as uncovered rather than
+    // silently vanishing.
+    let mut hits: BTreeMap<String, BTreeSet<u32>> = BTreeMap::new();
+    let crates = workspace.join("crates");
+    claims_ledger::for_each_file(&crates, Some("rs"), &mut |path, content| {
+        for (name, claims) in &wanted {
+            if content.contains(&format!("fn {name}(")) {
+                let Some(rel) = workspace_relative(workspace, path) else {
+                    continue;
+                };
+                hits.entry(rel).or_default().extend(claims.iter().copied());
+            }
+        }
+    })?;
+
+    let mut files: Vec<SurfaceFile> = hits
+        .iter()
+        .filter(|(path, _)| !is_integration_test(path))
+        .filter_map(|(path, claims)| {
+            Some(SurfaceFile {
+                path: path.clone(),
+                package: package_for(path)?,
+                claims: claims.iter().copied().collect(),
+            })
+        })
+        .collect();
+    files.sort();
+
+    let covered: BTreeSet<u32> = files
+        .iter()
+        .flat_map(|f| f.claims.iter().copied())
+        .collect();
+    let uncovered = rows
+        .iter()
+        .map(|r| r.number)
+        .filter(|n| !covered.contains(n))
+        .map(|number| UncoveredClaim {
+            why: if claims_with_fn_witness.contains(&number) {
+                WHY_ONLY_INTEGRATION_TESTS.to_string()
+            } else {
+                WHY_NO_FN_WITNESS.to_string()
+            },
+            number,
+        })
+        .collect();
+
+    Ok(Surface { files, uncovered })
+}
+
+/// `crates/mvm-protocol/src/policy/network_policy.rs` -> `mvm-protocol`.
+pub fn package_for(rel_path: &str) -> Option<String> {
+    let mut parts = rel_path.split('/');
+    if parts.next()? != "crates" {
+        return None;
+    }
+    let first = parts.next()?;
+    // `crates/deps/libkrun-sys/...` nests one level deeper.
+    if first == "deps" {
+        return parts.next().map(str::to_string);
+    }
+    Some(first.to_string())
+}
+
+/// True for `crates/<pkg>/tests/...`, which cargo-mutants never mutates.
+pub fn is_integration_test(rel_path: &str) -> bool {
+    rel_path.split('/').nth(2) == Some("tests")
+}
+
+fn workspace_relative(workspace: &Path, path: &Path) -> Option<String> {
+    let rel = path.strip_prefix(workspace).ok()?;
+    Some(rel.to_string_lossy().replace('\\', "/"))
+}
+
+/// Human-readable differences between the pinned and resolved surfaces.
+pub fn diff_surface(committed: &[SurfaceFile], resolved: &[SurfaceFile]) -> Vec<String> {
+    let mut errors = Vec::new();
+    let by_path = |v: &[SurfaceFile]| -> BTreeMap<String, SurfaceFile> {
+        v.iter().map(|s| (s.path.clone(), s.clone())).collect()
+    };
+    let old = by_path(committed);
+    let new = by_path(resolved);
+
+    for path in new.keys() {
+        if !old.contains_key(path) {
+            errors.push(format!("surface gained {path} (not in the committed pin)"));
+        }
+    }
+    for (path, was) in &old {
+        match new.get(path) {
+            None => errors.push(format!(
+                "surface lost {path} — claim(s) {:?} no longer resolve there, so they have \
+                 dropped out of mutation coverage",
+                was.claims
+            )),
+            Some(now) if now.claims != was.claims => errors.push(format!(
+                "surface {path} changed claims {:?} -> {:?}",
+                was.claims, now.claims
+            )),
+            Some(now) if now.package != was.package => errors.push(format!(
+                "surface {path} changed package {} -> {}",
+                was.package, now.package
+            )),
+            Some(_) => {}
+        }
+    }
+    errors
+}
+
+/// Differences between the pinned and resolved uncovered-claim sets.
+///
+/// A claim gaining coverage is progress and only worth re-pinning; a
+/// claim *losing* it means the nightly lane silently stopped asking
+/// anything about that claim.
+pub fn diff_uncovered(committed: &[UncoveredClaim], resolved: &[UncoveredClaim]) -> Vec<String> {
+    let old: BTreeSet<u32> = committed.iter().map(|u| u.number).collect();
+    let mut errors = Vec::new();
+    for u in resolved {
+        if !old.contains(&u.number) {
+            errors.push(format!(
+                "claim {} lost its mutation surface ({}) — the nightly lane no longer asks \
+                 anything about it",
+                u.number, u.why
+            ));
+        }
+    }
+    let now: BTreeSet<u32> = resolved.iter().map(|u| u.number).collect();
+    for n in old.difference(&now) {
+        errors.push(format!(
+            "claim {n} gained a mutation surface — re-pin so the baseline records it"
+        ));
+    }
+    errors
+}
+
+/// Every accepted miss must say why. An unexplained entry is how a
+/// ratchet baseline degrades into a suppression list.
+pub fn check_accepted_reasons(accepted: &[AcceptedMiss]) -> Vec<String> {
+    accepted
+        .iter()
+        .filter(|a| a.reason.trim().is_empty())
+        .map(|a| {
+            format!(
+                "accepted miss {} :: {} has no reason — state why the hole is tolerable",
+                a.file, a.mutant
+            )
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------
+// Ratchet
+// ---------------------------------------------------------------------
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Verdict {
+    /// Survived, and not in the baseline. These fail the gate.
+    pub new_misses: Vec<Miss>,
+    /// In the baseline, but caught now. Reported so the baseline shrinks.
+    pub now_caught: Vec<AcceptedMiss>,
+}
+
+pub fn ratchet(accepted: &[AcceptedMiss], observed: &[Miss]) -> Verdict {
+    let accepted_keys: BTreeSet<(&str, &str)> = accepted
+        .iter()
+        .map(|a| (a.file.as_str(), a.mutant.as_str()))
+        .collect();
+    let observed_keys: BTreeSet<(&str, &str)> = observed
+        .iter()
+        .map(|m| (m.file.as_str(), m.mutant.as_str()))
+        .collect();
+
+    Verdict {
+        new_misses: observed
+            .iter()
+            .filter(|m| !accepted_keys.contains(&(m.file.as_str(), m.mutant.as_str())))
+            .cloned()
+            .collect(),
+        now_caught: accepted
+            .iter()
+            .filter(|a| !observed_keys.contains(&(a.file.as_str(), a.mutant.as_str())))
+            .cloned()
+            .collect(),
+    }
+}
+
+fn seed_accepted(misses: &[Miss]) -> Vec<AcceptedMiss> {
+    misses
+        .iter()
+        .map(|m| AcceptedMiss {
+            file: m.file.clone(),
+            mutant: m.mutant.clone(),
+            reason: "untriaged: seeded from the first observed run".to_string(),
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------
+// cargo-mutants invocation and output parsing
+// ---------------------------------------------------------------------
+
+/// Split a cargo-mutants report line into (file, description), dropping
+/// `line:col`. Identity without position survives edits elsewhere in the
+/// same file, so an unrelated change above a mutant does not invalidate
+/// the baseline.
+///
+/// `crates/a/src/b.rs:23:5: replace f -> bool with true`
+///   -> ("crates/a/src/b.rs", "replace f -> bool with true")
+pub fn mutant_identity(line: &str) -> Option<Miss> {
+    let line = line.trim();
+    if line.is_empty() {
+        return None;
+    }
+    // Walk from the left: path, then two numeric fields, then the rest.
+    // A description can itself contain colons (`Foo::bar`), so splitting
+    // naively on ':' and taking a fixed field count is wrong.
+    let mut rest = line;
+    let mut fields = Vec::new();
+    for _ in 0..3 {
+        let (head, tail) = rest.split_once(':')?;
+        fields.push(head);
+        rest = tail;
+    }
+    let (line_no, col_no) = (fields[1], fields[2]);
+    if line_no.parse::<u32>().is_err() || col_no.parse::<u32>().is_err() {
+        return None;
+    }
+    let description = rest.trim();
+    if description.is_empty() {
+        return None;
+    }
+    Some(Miss {
+        file: fields[0].to_string(),
+        mutant: description.to_string(),
+    })
+}
+
+pub fn parse_missed(report: &str) -> Vec<Miss> {
+    let mut out: Vec<Miss> = report.lines().filter_map(mutant_identity).collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Run cargo-mutants once per surface file and collect the misses.
+///
+/// Scoped per file with `-p <package> --file <path>`: the package scope
+/// keeps each invocation from re-testing the whole workspace, and it is
+/// the stricter question — the owning crate's own tests must catch the
+/// tampering.
+fn run_mutants_over(workspace: &Path, surface: &[SurfaceFile]) -> Result<Vec<Miss>> {
+    ensure_cargo_mutants()?;
+    let out_root = std::env::temp_dir().join("mvm-mutation-witnesses");
+    std::fs::create_dir_all(&out_root)
+        .with_context(|| format!("creating {}", out_root.display()))?;
+
+    let mut all = Vec::new();
+    for (i, file) in surface.iter().enumerate() {
+        eprintln!(
+            "[{}/{}] mutating {} (package {}, claims {:?})",
+            i + 1,
+            surface.len(),
+            file.path,
+            file.package,
+            file.claims
+        );
+        let out_dir = out_root.join(file.path.replace('/', "_"));
+        all.extend(run_mutants_for_file(workspace, file, &out_dir)?);
+    }
+    all.sort();
+    all.dedup();
+    Ok(all)
+}
+
+fn run_mutants_for_file(workspace: &Path, file: &SurfaceFile, out_dir: &Path) -> Result<Vec<Miss>> {
+    let status = std::process::Command::new("cargo")
+        .current_dir(workspace)
+        .arg("mutants")
+        .args(["-p", &file.package])
+        .args(["--file", &file.path])
+        .args(["--test-tool", "nextest"])
+        .args(["--timeout", &MUTANT_TIMEOUT_SECS.to_string()])
+        .arg("--output")
+        .arg(out_dir)
+        // The embedded host-vm binaries are cross-compiled by
+        // mvm-cli's build.rs; a mutation run rebuilds per mutant and
+        // does not boot a VM, so paying that cost every time is waste.
+        .env("MVM_SKIP_EMBED_BINARIES", "1")
+        .status()
+        .context("spawning `cargo mutants`")?;
+
+    // Exit status is deliberately not the signal: cargo-mutants exits
+    // nonzero merely because mutants survived, which is the case this
+    // gate exists to report. The report files are the signal, and their
+    // absence means the run genuinely failed.
+    let missed = out_dir.join("mutants.out").join("missed.txt");
+    let caught = out_dir.join("mutants.out").join("caught.txt");
+    if !missed.exists() && !caught.exists() {
+        bail!(
+            "cargo mutants produced no report for {} (exit {:?}); expected {} or {}",
+            file.path,
+            status.code(),
+            missed.display(),
+            caught.display()
+        );
+    }
+    let report = if missed.exists() {
+        std::fs::read_to_string(&missed).with_context(|| format!("reading {}", missed.display()))?
+    } else {
+        String::new()
+    };
+    Ok(parse_missed(&report))
+}
+
+fn ensure_cargo_mutants() -> Result<()> {
+    let ok = std::process::Command::new("cargo")
+        .args(["mutants", "--version"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !ok {
+        bail!("cargo-mutants is not installed — `cargo install cargo-mutants --locked`");
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// Baseline I/O
+// ---------------------------------------------------------------------
+
+fn read_baseline(path: &Path) -> Result<Baseline> {
+    let raw = std::fs::read_to_string(path).with_context(|| {
+        format!(
+            "reading {} — seed it with `cargo run -p xtask -- check-mutation-witnesses \
+             --write-baseline`",
+            path.display()
+        )
+    })?;
+    serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn write_baseline(path: &Path, baseline: &Baseline) -> Result<()> {
+    let mut json = serde_json::to_string_pretty(baseline)
+        .context("serializing the mutation-witness baseline")?;
+    json.push('\n');
+    std::fs::write(path, json).with_context(|| format!("writing {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_strips_line_and_column() {
+        let m = mutant_identity("crates/a/src/b.rs:23:5: replace f -> bool with true").unwrap();
+        assert_eq!(m.file, "crates/a/src/b.rs");
+        assert_eq!(m.mutant, "replace f -> bool with true");
+    }
+
+    #[test]
+    fn identity_keeps_colons_inside_the_description() {
+        let m = mutant_identity("crates/a/src/b.rs:9:1: replace == with != in Foo::bar").unwrap();
+        assert_eq!(m.mutant, "replace == with != in Foo::bar");
+    }
+
+    #[test]
+    fn identity_rejects_non_report_lines() {
+        assert!(mutant_identity("").is_none());
+        assert!(mutant_identity("just prose").is_none());
+        assert!(mutant_identity("path:notanumber:5: replace x").is_none());
+        assert!(mutant_identity("crates/a.rs:1:2: ").is_none());
+    }
+
+    #[test]
+    fn identity_collapses_two_positions_of_the_same_change() {
+        // Same description at different positions is one identity: that
+        // is what keeps the baseline stable under code motion.
+        let a = mutant_identity("f.rs:1:1: replace == with !=").unwrap();
+        let b = mutant_identity("f.rs:90:7: replace == with !=").unwrap();
+        assert_eq!(a, b);
+    }
+
+    /// Verbatim `mutants.out/missed.txt` from a real cargo-mutants 27.1
+    /// run over the claim-10 anchor. A hand-written fixture would only
+    /// prove the parser matches my assumption about the format; this
+    /// proves it matches the tool.
+    const REAL_MISSED_REPORT: &str = "\
+crates/mvm-protocol/src/policy/network_policy.rs:92:5: replace is_banned_ssh_port -> bool with false
+crates/mvm-protocol/src/policy/network_policy.rs:140:9: replace NetworkPreset::is_deny_all -> bool with false
+crates/mvm-protocol/src/policy/network_policy.rs:140:9: replace NetworkPreset::is_deny_all -> bool with true
+crates/mvm-protocol/src/policy/network_policy.rs:271:9: replace NetworkPolicy::trusted_build_egress -> Self with Default::default()
+";
+
+    #[test]
+    fn real_tool_output_parses_into_four_distinct_identities() {
+        let misses = parse_missed(REAL_MISSED_REPORT);
+        assert_eq!(
+            misses.len(),
+            4,
+            "two is_deny_all mutants differ by replacement"
+        );
+        assert!(
+            misses
+                .iter()
+                .all(|m| m.file == "crates/mvm-protocol/src/policy/network_policy.rs")
+        );
+        // The `-> Self with Default::default()` form carries both `::`
+        // and `()`; a naive field split would truncate it.
+        assert!(misses.iter().any(|m| m.mutant
+            == "replace NetworkPolicy::trusted_build_egress -> Self with Default::default()"));
+    }
+
+    #[test]
+    fn real_tool_output_ratchets_clean_against_matching_accepted_entries() {
+        let observed = parse_missed(REAL_MISSED_REPORT);
+        let accepted: Vec<AcceptedMiss> = observed
+            .iter()
+            .map(|m| AcceptedMiss {
+                file: m.file.clone(),
+                mutant: m.mutant.clone(),
+                reason: "triaged".into(),
+            })
+            .collect();
+        let v = ratchet(&accepted, &observed);
+        assert!(v.new_misses.is_empty(), "identities must round-trip");
+        assert!(v.now_caught.is_empty());
+    }
+
+    #[test]
+    fn parse_missed_sorts_and_dedupes() {
+        let report = "\
+z.rs:2:1: replace b with c
+a.rs:1:1: replace x with y
+a.rs:5:1: replace x with y
+";
+        let misses = parse_missed(report);
+        assert_eq!(misses.len(), 2);
+        assert_eq!(misses[0].file, "a.rs");
+        assert_eq!(misses[1].file, "z.rs");
+    }
+
+    #[test]
+    fn package_derivation_handles_flat_and_nested_crates() {
+        assert_eq!(
+            package_for("crates/mvm-protocol/src/policy/network_policy.rs").as_deref(),
+            Some("mvm-protocol")
+        );
+        assert_eq!(
+            package_for("crates/deps/libkrun-sys/src/sys.rs").as_deref(),
+            Some("libkrun-sys")
+        );
+        assert_eq!(package_for("src/lib.rs"), None);
+        assert_eq!(package_for("xtask/src/main.rs"), None);
+    }
+
+    #[test]
+    fn integration_tests_are_not_part_of_the_surface() {
+        assert!(is_integration_test("crates/mvm-cli/tests/cli.rs"));
+        assert!(!is_integration_test("crates/mvm-cli/src/lib.rs"));
+    }
+
+    fn miss(file: &str, mutant: &str) -> Miss {
+        Miss {
+            file: file.into(),
+            mutant: mutant.into(),
+        }
+    }
+
+    fn accepted(file: &str, mutant: &str) -> AcceptedMiss {
+        AcceptedMiss {
+            file: file.into(),
+            mutant: mutant.into(),
+            reason: "known".into(),
+        }
+    }
+
+    #[test]
+    fn ratchet_flags_a_new_miss() {
+        let v = ratchet(&[], &[miss("a.rs", "replace x")]);
+        assert_eq!(v.new_misses, vec![miss("a.rs", "replace x")]);
+        assert!(v.now_caught.is_empty());
+    }
+
+    #[test]
+    fn ratchet_accepts_a_baselined_miss() {
+        let v = ratchet(
+            &[accepted("a.rs", "replace x")],
+            &[miss("a.rs", "replace x")],
+        );
+        assert!(v.new_misses.is_empty());
+        assert!(v.now_caught.is_empty());
+    }
+
+    #[test]
+    fn ratchet_reports_a_baselined_miss_that_is_now_caught() {
+        let v = ratchet(&[accepted("a.rs", "replace x")], &[]);
+        assert!(v.new_misses.is_empty());
+        assert_eq!(v.now_caught.len(), 1);
+    }
+
+    #[test]
+    fn ratchet_distinguishes_same_mutant_in_different_files() {
+        let v = ratchet(
+            &[accepted("a.rs", "replace x")],
+            &[miss("b.rs", "replace x")],
+        );
+        assert_eq!(v.new_misses, vec![miss("b.rs", "replace x")]);
+    }
+
+    fn surface(path: &str, claims: Vec<u32>) -> SurfaceFile {
+        SurfaceFile {
+            path: path.into(),
+            package: package_for(path).unwrap_or_else(|| "unknown".into()),
+            claims,
+        }
+    }
+
+    #[test]
+    fn surface_diff_is_empty_when_pinned() {
+        let s = vec![surface("crates/a/src/l.rs", vec![1])];
+        assert!(diff_surface(&s, &s).is_empty());
+    }
+
+    #[test]
+    fn surface_diff_reports_a_lost_file_as_lost_coverage() {
+        let old = vec![surface("crates/a/src/l.rs", vec![10])];
+        let errs = diff_surface(&old, &[]);
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("surface lost"));
+        assert!(errs[0].contains("dropped out of mutation coverage"));
+    }
+
+    #[test]
+    fn surface_diff_reports_a_gained_file() {
+        let new = vec![surface("crates/a/src/l.rs", vec![1])];
+        let errs = diff_surface(&[], &new);
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("surface gained"));
+    }
+
+    #[test]
+    fn surface_diff_reports_a_claim_set_change() {
+        let old = vec![surface("crates/a/src/l.rs", vec![1])];
+        let new = vec![surface("crates/a/src/l.rs", vec![1, 2])];
+        let errs = diff_surface(&old, &new);
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("changed claims"));
+    }
+
+    #[test]
+    fn accepted_misses_must_state_a_reason() {
+        let bad = vec![AcceptedMiss {
+            file: "a.rs".into(),
+            mutant: "replace x".into(),
+            reason: "  ".into(),
+        }];
+        let errs = check_accepted_reasons(&bad);
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("no reason"));
+        assert!(check_accepted_reasons(&[accepted("a.rs", "replace x")]).is_empty());
+    }
+
+    #[test]
+    fn seeded_misses_carry_a_reason_so_the_gate_accepts_them() {
+        let seeded = seed_accepted(&[miss("a.rs", "replace x")]);
+        assert!(check_accepted_reasons(&seeded).is_empty());
+    }
+
+    #[test]
+    fn baseline_round_trips_through_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("baseline.json");
+        let baseline = Baseline {
+            surface: vec![surface("crates/a/src/l.rs", vec![1, 2])],
+            uncovered_claims: vec![uncovered(7)],
+            accepted_misses: vec![accepted("crates/a/src/l.rs", "replace x")],
+        };
+        write_baseline(&path, &baseline).unwrap();
+        let back = read_baseline(&path).unwrap();
+        assert_eq!(back.surface, baseline.surface);
+        assert_eq!(back.uncovered_claims, baseline.uncovered_claims);
+        assert_eq!(back.accepted_misses, baseline.accepted_misses);
+    }
+
+    #[test]
+    fn missing_baseline_names_the_command_that_seeds_it() {
+        let err = read_baseline(Path::new("/nonexistent/baseline.json")).unwrap_err();
+        assert!(format!("{err}").contains("--write-baseline"));
+    }
+
+    /// A temp workspace carrying just a claims ledger with `rows`.
+    fn ledger_tree(rows: &str) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        let adr = tmp.path().join("specs").join("adrs");
+        std::fs::create_dir_all(&adr).unwrap();
+        std::fs::write(
+            adr.join("001-microvm-security-posture.md"),
+            format!(
+                "<!-- claims-catalog:begin -->\n\
+                 | # | Claim | Witnesses | Authority | Status |\n\
+                 |---|-------|-----------|-----------|--------|\n\
+                 {rows}<!-- claims-catalog:end -->\n"
+            ),
+        )
+        .unwrap();
+        tmp
+    }
+
+    #[test]
+    fn surface_resolves_witnesses_to_their_declaring_file() {
+        let tmp = ledger_tree(
+            "\
+| 1 | one | fn:enforces_it, ci:some-lane | auth | Shipped |
+| 2 | two | fn:elsewhere | auth | Shipped |
+",
+        );
+        let src = tmp.path().join("crates").join("demo").join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("lib.rs"), "fn enforces_it() {}\n").unwrap();
+        std::fs::write(src.join("other.rs"), "fn elsewhere() {}\n").unwrap();
+        // An integration test naming the same witness must not widen
+        // the surface: cargo-mutants never mutates a test target.
+        let itest = tmp.path().join("crates").join("demo").join("tests");
+        std::fs::create_dir_all(&itest).unwrap();
+        std::fs::write(itest.join("it.rs"), "fn enforces_it() {}\n").unwrap();
+
+        let surface = resolve_surface(tmp.path()).unwrap();
+        let paths: Vec<&str> = surface.files.iter().map(|s| s.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            ["crates/demo/src/lib.rs", "crates/demo/src/other.rs"]
+        );
+        assert_eq!(surface.files[0].claims, vec![1]);
+        assert_eq!(surface.files[0].package, "demo");
+        assert_eq!(surface.files[1].claims, vec![2]);
+        assert!(surface.uncovered.is_empty());
+    }
+
+    /// A claim witnessed only by a CI lane has nothing to mutate. That is
+    /// legitimate, but it must be reported rather than silently absent.
+    #[test]
+    fn a_ci_only_claim_is_reported_as_uncovered() {
+        let tmp = ledger_tree(
+            "\
+| 1 | one | fn:enforces_it | auth | Shipped |
+| 2 | two | ci:some-lane | auth | Shipped |
+",
+        );
+        let src = tmp.path().join("crates").join("demo").join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("lib.rs"), "fn enforces_it() {}\n").unwrap();
+
+        let surface = resolve_surface(tmp.path()).unwrap();
+        assert_eq!(surface.files.len(), 1);
+        assert_eq!(surface.uncovered.len(), 1);
+        assert_eq!(surface.uncovered[0].number, 2);
+        assert_eq!(surface.uncovered[0].why, WHY_NO_FN_WITNESS);
+    }
+
+    /// A claim whose only `fn:` witnesses are integration tests gets no
+    /// mutation surface, because cargo-mutants does not mutate test
+    /// targets. Distinguished from the CI-only case so the report says
+    /// which fix applies.
+    #[test]
+    fn an_integration_test_only_claim_is_reported_as_uncovered() {
+        let tmp = ledger_tree(
+            "\
+| 1 | one | fn:enforces_it | auth | Shipped |
+| 2 | two | fn:only_in_a_test | auth | Shipped |
+",
+        );
+        let demo = tmp.path().join("crates").join("demo");
+        std::fs::create_dir_all(demo.join("src")).unwrap();
+        std::fs::create_dir_all(demo.join("tests")).unwrap();
+        std::fs::write(demo.join("src").join("lib.rs"), "fn enforces_it() {}\n").unwrap();
+        std::fs::write(demo.join("tests").join("it.rs"), "fn only_in_a_test() {}\n").unwrap();
+
+        let surface = resolve_surface(tmp.path()).unwrap();
+        assert_eq!(surface.uncovered.len(), 1);
+        assert_eq!(surface.uncovered[0].number, 2);
+        assert_eq!(surface.uncovered[0].why, WHY_ONLY_INTEGRATION_TESTS);
+    }
+
+    fn uncovered(number: u32) -> UncoveredClaim {
+        UncoveredClaim {
+            number,
+            why: WHY_NO_FN_WITNESS.to_string(),
+        }
+    }
+
+    #[test]
+    fn uncovered_diff_fails_when_a_claim_loses_its_surface() {
+        let errs = diff_uncovered(&[], &[uncovered(10)]);
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("claim 10 lost its mutation surface"));
+    }
+
+    #[test]
+    fn uncovered_diff_asks_for_a_repin_when_a_claim_gains_a_surface() {
+        let errs = diff_uncovered(&[uncovered(10)], &[]);
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("gained a mutation surface"));
+    }
+
+    #[test]
+    fn uncovered_diff_is_empty_when_pinned() {
+        let pinned = [uncovered(4), uncovered(5)];
+        assert!(diff_uncovered(&pinned, &pinned).is_empty());
+    }
+
+    #[test]
+    fn one_file_serving_two_claims_records_both() {
+        let tmp = ledger_tree(
+            "\
+| 1 | one | fn:alpha | auth | Shipped |
+| 2 | two | fn:beta | auth | Shipped |
+",
+        );
+        let src = tmp.path().join("crates").join("demo").join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("lib.rs"), "fn alpha() {}\nfn beta() {}\n").unwrap();
+
+        let surface = resolve_surface(tmp.path()).unwrap();
+        assert_eq!(surface.files.len(), 1);
+        assert_eq!(surface.files[0].claims, vec![1, 2]);
+    }
+}

--- a/xtask/src/claims_ledger.rs
+++ b/xtask/src/claims_ledger.rs
@@ -1,0 +1,270 @@
+//! The claims ledger: one parser for the machine-checked claim →
+//! witness map embedded in `specs/adrs/001-microvm-security-posture.md`.
+//!
+//! Two gates read this table and they must agree on what it says.
+//! `check-claim-catalog` asserts every named witness still exists;
+//! `check-mutation-witnesses` derives the mutation surface from the same
+//! rows. A second parser would let the two disagree about which claims
+//! exist, which is precisely the drift the ledger is meant to prevent.
+//!
+//! Row shape (a 5-column markdown table):
+//!   | # | Claim | Witnesses | Authority | Status |
+//! `Witnesses` is a comma-separated list of typed tokens:
+//!   - `fn:NAME` — a `fn NAME(` must exist under `crates/`.
+//!   - `ci:NAME` — NAME must appear literally in some `.github/workflows/*`.
+
+use anyhow::{Context, Result, bail};
+use std::path::{Path, PathBuf};
+
+pub const BEGIN_MARKER: &str = "<!-- claims-catalog:begin -->";
+pub const END_MARKER: &str = "<!-- claims-catalog:end -->";
+
+pub struct Row {
+    pub number: u32,
+    pub claim: String,
+    pub witnesses: Vec<Witness>,
+    pub authority: String,
+    pub status: String,
+}
+
+#[derive(Clone)]
+pub enum Witness {
+    /// `fn:NAME` — resolves to `fn NAME(` anywhere under `crates/`.
+    Fn(String),
+    /// `ci:NAME` — resolves to the literal NAME in any workflow file.
+    Ci(String),
+}
+
+impl Witness {
+    pub fn token(&self) -> String {
+        match self {
+            Self::Fn(n) => format!("fn:{n}"),
+            Self::Ci(n) => format!("ci:{n}"),
+        }
+    }
+}
+
+/// The ADR that carries the ledger.
+pub fn ledger_path(workspace: &Path) -> PathBuf {
+    workspace
+        .join("specs")
+        .join("adrs")
+        .join("001-microvm-security-posture.md")
+}
+
+/// Read and parse the ledger rows.
+pub fn load(workspace: &Path) -> Result<Vec<Row>> {
+    let path = ledger_path(workspace);
+    let source =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let ledger = extract_ledger_section(&source).with_context(|| {
+        format!(
+            "locating the claims ledger between `{BEGIN_MARKER}` and `{END_MARKER}` in {}",
+            path.display()
+        )
+    })?;
+    parse_rows(ledger)
+        .with_context(|| format!("parsing the claims ledger table in {}", path.display()))
+}
+
+/// Slice out the text strictly between the begin and end markers. The ADR
+/// carries several other markdown tables (STRIDE threat-model rows,
+/// compliance mappings) with their own pipe-delimited rows; scoping to the
+/// marker-delimited region keeps those from ever being mistaken for
+/// claim-catalog rows.
+pub fn extract_ledger_section(source: &str) -> Result<&str> {
+    let start = source
+        .find(BEGIN_MARKER)
+        .ok_or_else(|| anyhow::anyhow!("begin marker not found"))?
+        + BEGIN_MARKER.len();
+    let end = source[start..]
+        .find(END_MARKER)
+        .ok_or_else(|| anyhow::anyhow!("end marker not found"))?;
+    Ok(&source[start..start + end])
+}
+
+pub fn parse_rows(source: &str) -> Result<Vec<Row>> {
+    let mut rows = Vec::new();
+    for line in source.lines() {
+        let line = line.trim();
+        if !line.starts_with('|') {
+            continue;
+        }
+        let cells = split_row(line);
+        if cells.len() != 5 {
+            continue; // prose pipe or malformed line — not a catalog row
+        }
+        if is_separator(&cells) || cells[0].eq_ignore_ascii_case("#") {
+            continue;
+        }
+        let Ok(number) = cells[0].parse::<u32>() else {
+            continue; // header variants / non-numeric first cell
+        };
+        let witnesses = parse_witnesses(&cells[2])
+            .with_context(|| format!("claim {number}: bad witnesses cell"))?;
+        rows.push(Row {
+            number,
+            claim: cells[1].clone(),
+            witnesses,
+            authority: cells[3].clone(),
+            status: cells[4].clone(),
+        });
+    }
+    if rows.is_empty() {
+        bail!("no data rows found (expected a 5-column markdown table)");
+    }
+    Ok(rows)
+}
+
+/// Split a `| a | b |` line into trimmed inner cells.
+fn split_row(line: &str) -> Vec<String> {
+    let t = line.strip_prefix('|').unwrap_or(line);
+    let t = t.strip_suffix('|').unwrap_or(t);
+    t.split('|').map(|c| c.trim().to_string()).collect()
+}
+
+/// True for a `|---|---|` markdown separator row.
+fn is_separator(cells: &[String]) -> bool {
+    cells.iter().all(|c| {
+        !c.is_empty()
+            && c.chars()
+                .all(|ch| ch == '-' || ch == ':' || ch.is_whitespace())
+    })
+}
+
+pub fn parse_witnesses(cell: &str) -> Result<Vec<Witness>> {
+    let mut out = Vec::new();
+    for tok in cell.split(',') {
+        let tok = tok.trim().trim_matches('`').trim();
+        if tok.is_empty() {
+            continue;
+        }
+        let (kind, name) = tok.split_once(':').ok_or_else(|| {
+            anyhow::anyhow!("witness {tok:?} missing a `kind:` prefix (want fn:NAME or ci:NAME)")
+        })?;
+        let name = name.trim();
+        if name.is_empty() {
+            bail!("witness {tok:?} has an empty name");
+        }
+        match kind.trim() {
+            "fn" => out.push(Witness::Fn(name.to_string())),
+            "ci" => out.push(Witness::Ci(name.to_string())),
+            other => bail!("witness {tok:?}: unknown kind {other:?} (expected fn or ci)"),
+        }
+    }
+    Ok(out)
+}
+
+/// Walk `dir` recursively, calling `cb` with the path and text of every
+/// file whose extension matches `ext` (or every file when `ext` is
+/// `None`). Skips heavy build/VCS dirs. Missing dirs are not an error.
+pub fn for_each_file(dir: &Path, ext: Option<&str>, cb: &mut dyn FnMut(&Path, &str)) -> Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(dir)
+        .with_context(|| format!("reading {}", dir.display()))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .collect();
+    // Deterministic order: the mutation surface is committed to a file, so
+    // two runs on the same tree must resolve witnesses identically.
+    entries.sort();
+    for path in entries {
+        if path.is_dir() {
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default();
+            if matches!(name, "target" | ".git" | "node_modules") {
+                continue;
+            }
+            for_each_file(&path, ext, cb)?;
+        } else {
+            let matches_ext = match ext {
+                Some(want) => path.extension().and_then(|e| e.to_str()) == Some(want),
+                None => true,
+            };
+            if matches_ext && let Ok(content) = std::fs::read_to_string(&path) {
+                cb(&path, &content);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TABLE: &str = "\
+| # | Claim | Witnesses | Authority | Status |
+|---|-------|-----------|-----------|--------|
+| 1 | First claim | fn:foo_one, ci:lane-a | seccomp | Shipped |
+| 2 | Second claim | fn:bar_two | Ed25519 | Shipped |
+";
+
+    #[test]
+    fn parses_data_rows_and_skips_header_and_separator() {
+        let rows = parse_rows(TABLE).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].number, 1);
+        assert_eq!(rows[0].claim, "First claim");
+        assert_eq!(rows[0].witnesses.len(), 2);
+        assert_eq!(rows[1].status, "Shipped");
+    }
+
+    #[test]
+    fn witness_kinds_route_by_prefix() {
+        let ws = parse_witnesses("fn:foo, ci:my-lane, `fn:baz`").unwrap();
+        assert!(matches!(ws[0], Witness::Fn(ref n) if n == "foo"));
+        assert!(matches!(ws[1], Witness::Ci(ref n) if n == "my-lane"));
+        assert!(matches!(ws[2], Witness::Fn(ref n) if n == "baz"));
+    }
+
+    #[test]
+    fn witness_rejects_unknown_kind_and_missing_prefix() {
+        assert!(parse_witnesses("wat:foo").is_err());
+        assert!(parse_witnesses("nokind").is_err());
+        assert!(parse_witnesses("fn:").is_err());
+    }
+
+    #[test]
+    fn witness_token_round_trips_its_prefix() {
+        assert_eq!(Witness::Fn("a".into()).token(), "fn:a");
+        assert_eq!(Witness::Ci("b".into()).token(), "ci:b");
+    }
+
+    #[test]
+    fn extract_section_requires_both_markers() {
+        let src = format!("pre {BEGIN_MARKER} body {END_MARKER} post");
+        assert_eq!(extract_ledger_section(&src).unwrap().trim(), "body");
+        assert!(extract_ledger_section("no markers").is_err());
+        assert!(extract_ledger_section(&format!("{BEGIN_MARKER} unterminated")).is_err());
+    }
+
+    #[test]
+    fn split_row_drops_outer_pipes() {
+        assert_eq!(split_row("| a | b |"), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn parse_rows_rejects_a_table_with_no_data_rows() {
+        assert!(parse_rows("| # | Claim | Witnesses | Authority | Status |\n").is_err());
+    }
+
+    #[test]
+    fn walker_yields_paths_in_deterministic_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("crates");
+        std::fs::create_dir_all(&dir).unwrap();
+        for name in ["c.rs", "a.rs", "b.rs", "skip.txt"] {
+            std::fs::write(dir.join(name), "fn x() {}").unwrap();
+        }
+        let mut seen = Vec::new();
+        for_each_file(&dir, Some("rs"), &mut |path, _| {
+            seen.push(path.file_name().unwrap().to_string_lossy().to_string());
+        })
+        .unwrap();
+        assert_eq!(seen, ["a.rs", "b.rs", "c.rs"]);
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -31,6 +31,7 @@ mod check_honesty;
 mod check_kernel_config_budget;
 mod check_kernel_pin_freshness;
 mod check_machine_doc_guards;
+mod check_mutation_witnesses;
 mod check_mvm_host_binaries_sync;
 mod check_no_display_on_secret_types;
 mod check_no_host_nix;
@@ -46,6 +47,7 @@ mod check_trust_gradient;
 mod check_two_surfaces;
 mod check_uniform_vsock_egress;
 mod check_vsock_only_egress;
+mod claims_ledger;
 mod gen_stubs;
 mod ir_parity;
 mod perf;
@@ -178,6 +180,21 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_claim_catalog::run(&workspace)
         }
+        Some("check-mutation-witnesses") => {
+            let workspace = workspace_root();
+            // Default is the cheap surface pin, so the PR lint lane can
+            // run this without cargo-mutants installed. The mutation run
+            // itself is opt-in because it costs hours.
+            let write = args.iter().any(|a| a == "--write-baseline");
+            let run = args.iter().any(|a| a == "--run");
+            let mode = match (write, run) {
+                (true, true) => check_mutation_witnesses::Mode::RewriteBaseline,
+                (true, false) => check_mutation_witnesses::Mode::RepinSurface,
+                (false, true) => check_mutation_witnesses::Mode::Run,
+                (false, false) => check_mutation_witnesses::Mode::PinOnly,
+            };
+            check_mutation_witnesses::run(&workspace, mode)
+        }
         Some("check-conformance") => {
             let workspace = workspace_root();
             let write = args.iter().any(|a| a == "--write");
@@ -239,7 +256,7 @@ fn main() -> Result<()> {
             ir_parity::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-conformance, check-trust-gradient, check-vsock-only-egress, check-uniform-vsock-egress, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-mutation-witnesses, check-conformance, check-trust-gradient, check-vsock-only-egress, check-uniform-vsock-egress, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {
@@ -328,6 +345,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-claim-catalog                    Verify the claims ledger embedded in specs/adrs/001-microvm-security-posture.md — witnesses still exist in the tree"
+            );
+            eprintln!(
+                "  check-mutation-witnesses               Pin the mutation surface derived from the claims ledger; --run mutates it and ratchets survivors; --write-baseline re-pins (add --run to also re-record misses)"
             );
             eprintln!(
                 "  check-conformance                      Verify model/*.toml is the single source and CONFORMANCE.md is up to date"


### PR DESCRIPTION
## Why

`check-claim-catalog` proves a claim's witness **exists**. Nothing proved it can **fail**. A test can name the right symbol, exercise the happy path, pass forever, and never have had the power to detect the property breaking — the claim stays green while the property rots.

This adds mutation testing scoped to the claim surface: break the enforcement code on purpose, then check that a claim witness notices. A surviving mutant is a claim whose witness cannot detect its own property being violated.

## What it does

`xtask check-mutation-witnesses` derives the mutation surface **from the claims ledger** rather than a hand-kept list. Each `fn:` witness resolves to its declaring file, and because this repo keeps `#[cfg(test)] mod tests` beside the implementation, a witness lands on the enforcement code it guards. 26 files across 8 packages.

| Mode | Cost | Lane |
| --- | --- | --- |
| default (surface pin) | milliseconds, no cargo-mutants | every PR |
| `--run` | hours | nightly (`security.yml`) |
| `--write-baseline` | milliseconds (re-pin, keeps reasons) | manual |
| `--write-baseline --run` | hours (re-record misses) | manual reset |

The **surface pin** is the part that runs per PR, and it is what stops a claim from quietly leaving the expensive lane's scope: the surface is committed, so a claim losing coverage is a reviewable diff instead of a silently smaller surface. `--run` ratchets survivors — a new hole fails, a baselined miss that is now caught is reported so the baseline shrinks.

Claims that reach **no** mutable file are reported and pinned rather than silently absent: 4, 5 and 7 are witnessed only by CI lanes (a symbol grep and a fuzz job have no function to mutate), and claim 16's three witnesses all live in `crates/mvm-hostd/tests/egress_secret_leak_gate.rs`, which cargo-mutants does not mutate. Without this, "the mutation lane is green" would read as coverage of all sixteen claims.

## What the first real run found

Over the claim-10 anchor (`crates/mvm-protocol/src/policy/network_policy.rs`) — 52 mutants: 35 caught, 12 unviable, 1 timeout, **4 survived**:

- **`NetworkPreset::is_deny_all` survives replacement by both `true` and `false`.** It has no production caller anywhere in the tree; its only use is an assertion inside mvm-core's `security_profile` tests. Either it is load-bearing and wants a caller, or it is dead code wearing a claim-shaped name.
- **`is_banned_ssh_port -> false` survives** — only the negative direction is asserted inside mvm-protocol, so pinning the predicate to false goes unnoticed while flipping its `==` is caught. The SSH ban has real callers in mvm-core and mvm-cli.
- **`trusted_build_egress -> Default::default()` survives** — but that mutant substitutes the deny-all default, making the policy *stricter*. A functional coverage gap, not a security hole, and recorded as exactly that.

These are seeded as triaged baseline entries with stated reasons; fixing them is deliberately **not** in this PR so the gate and the holes it found review separately.

## Honest limits

- **Scoping.** Each invocation is `-p <owning crate> --file <path>`, so a survivor means the crate owning the invariant does not test it — not that nothing in the workspace would notice. Full-workspace tests per mutant is roughly an order of magnitude more expensive and would put the lane out of reach, and the narrower question is the more useful one (a claim exercised only from another crate is fragile by construction — `is_deny_all` above is the live example). The cost is that a "miss" is not automatically a hole, which is why `reason` is mandatory and an empty one fails the gate.
- **Nightly, not PR-blocking.** The mutation run is hours; only the pin is PR-visible. `security.yml` runs on tags and a nightly cron, so the property this supports is "a new hole is detected within a day", not "within a PR".
- **`continue-on-error` for now.** The baseline covers only the claim-10 anchor, so the first full runs will report untriaged holes elsewhere. Dropping the flag once the baseline covers the surface is tracked in the plan.

## Also

Extracts the shared ledger parser into `xtask/src/claims_ledger.rs` so `check-claim-catalog` and the new gate read one table — a second parser would let them disagree about which claims exist, which is the drift the ledger exists to prevent.

## Verification

- `cargo nextest run -p xtask` — **307/307**, including identity normalization validated against **verbatim cargo-mutants output** rather than a hand-written fixture (a fixture encoding my assumption about the format could not falsify it).
- `cargo nextest run --workspace` — 8149/8152. Three failures are pre-existing non-hermetic classes unrelated to this change (`install_sh_*` fail on a network fetch with `curl: (22) ... 404`; `wait_for_ready_succeeds_after_initial_failures` is process-timing sensitive under full load). All three pass in isolation, and the failing set varied between runs.
- `cargo test --workspace --doc` — clean. `cargo +nightly fmt --all --check` — clean. Full-workspace `cargo clippy --all-targets -- -D warnings` — clean (via pre-commit hook).
- Gates: `check-no-spec-refs-in-comments`, `check-file-size`, `check-claim-catalog`, `check-mutation-witnesses`, `check-honesty`, `check-deferrals` — all pass.
- `--output` layout and re-pin idempotency verified against real cargo-mutants 27.1 runs.

Plan: `specs/plans/272-mutation-tested-claim-witnesses.md`
