### PR TITLE
fix(cache): verify the builder image at admission and keep its sidecars

### DIFF
--- a/crates/mvm-build/src/cache_install.rs
+++ b/crates/mvm-build/src/cache_install.rs
@@ -15,6 +15,10 @@
 //!    never leaves a half-written artifact where a resolver can find it.
 //!    The flip side is that a killed install orphans its staging dir, so
 //!    installers reap abandoned ones as they go.
+//! 3. **Digest manifests.** Artifacts carry a `sha256sum`-format sidecar.
+//!    Checking it belongs at admission — the one moment bytes cross into a
+//!    cache root — and not on resolve, which runs on every VM start where
+//!    re-hashing a multi-hundred-megabyte image is not affordable.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -56,6 +60,108 @@ pub(crate) fn seed_on_miss<S, E>(
     };
     install(source)?;
     Ok(true)
+}
+
+/// The `sha256sum`-format sidecar covering [`BUILDER_VM_CACHE_ARTIFACTS`].
+pub const BUILDER_VM_ARTIFACT_DIGEST_FILE: &str = ".mvm-artifacts.sha256";
+
+/// The artifacts a builder-VM cache directory must carry, and which the digest
+/// sidecar commits to.
+///
+/// This lives here, rather than beside the builder code, because both sides of
+/// a feature boundary need it: the seed in `libkrun_builder` is gated on
+/// `builder-vm`, while the bootstrap readiness check also compiles under a
+/// bare `test` cfg. One ungated list is the only way the two cannot disagree
+/// about what a complete cache dir contains.
+pub const BUILDER_VM_CACHE_ARTIFACTS: &[&str] =
+    &["vmlinux", "rootfs.ext4", "cmdline.txt", "manifest.json"];
+
+/// Integrity/provenance sidecars written next to the artifacts. Copied along
+/// with them so a seeded cache stays verifiable, and so the bootstrap
+/// readiness check recognises the seeded copy instead of rebuilding over it.
+pub const BUILDER_VM_CACHE_SIDECARS: &[&str] = &[
+    BUILDER_VM_ARTIFACT_DIGEST_FILE,
+    ".mvm-provenance.json",
+    ".mvm-source.sha256",
+];
+
+/// Recompute the `sha256sum`-format manifest covering `names` in `dir`.
+///
+/// Hashing streams via `mvm_fs`'s helper rather than reading each file whole:
+/// one of these artifacts is a multi-hundred-megabyte rootfs.
+pub fn digest_manifest(dir: &Path, names: &[&str]) -> std::io::Result<String> {
+    let mut lines = Vec::with_capacity(names.len());
+    for name in names {
+        let digest = mvm_fs::overlay::compute_file_sha256(&dir.join(name))?;
+        lines.push(format!("{digest}  {name}"));
+    }
+    Ok(format!("{}\n", lines.join("\n")))
+}
+
+/// What comparing a recorded digest manifest against the bytes on disk found.
+///
+/// An enum rather than a bool because the two callers need different
+/// branches: a seed treats a missing manifest as "nothing to check here" but
+/// a drifted digest as "refuse", while the bootstrap readiness check reports
+/// those as distinct reason codes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DigestManifestCheck {
+    /// Every named file matches the digest recorded for it.
+    Match,
+    /// No manifest exists at the expected path.
+    ManifestAbsent,
+    /// The manifest exists but records nothing for a required name.
+    EntryAbsent { name: String },
+    /// A file's bytes drifted from the digest the manifest committed to.
+    Mismatch {
+        name: String,
+        expected: String,
+        actual: String,
+    },
+    /// A named file could not be read to hash it.
+    Unreadable { name: String, reason: String },
+}
+
+/// Compare `names` in `dir` against the manifest at `dir/manifest_file`.
+///
+/// Never returns `Err`: every failure mode is a variant the caller has to
+/// decide about, and collapsing them into an io error loses the distinction
+/// between "this cache predates the sidecar" and "these bytes changed".
+pub fn verify_digest_manifest(
+    dir: &Path,
+    manifest_file: &str,
+    names: &[&str],
+) -> DigestManifestCheck {
+    let Ok(body) = std::fs::read_to_string(dir.join(manifest_file)) else {
+        return DigestManifestCheck::ManifestAbsent;
+    };
+    let recorded = mvm_fs::overlay::parse_checksums_manifest(&body);
+    for name in names {
+        let Some(expected) = recorded.get(*name) else {
+            return DigestManifestCheck::EntryAbsent {
+                name: (*name).to_string(),
+            };
+        };
+        // Compare per-entry rather than whole-manifest strings so a reordered
+        // or differently-terminated manifest is not mistaken for tampering.
+        let actual = match mvm_fs::overlay::compute_file_sha256(&dir.join(name)) {
+            Ok(actual) => actual,
+            Err(e) => {
+                return DigestManifestCheck::Unreadable {
+                    name: (*name).to_string(),
+                    reason: e.to_string(),
+                };
+            }
+        };
+        if &actual != expected {
+            return DigestManifestCheck::Mismatch {
+                name: (*name).to_string(),
+                expected: expected.clone(),
+                actual,
+            };
+        }
+    }
+    DigestManifestCheck::Match
 }
 
 /// Name of this process's staging directory for `arch`.
@@ -174,6 +280,118 @@ mod tests {
             |()| Err::<(), &str>("disk full"),
         );
         assert_eq!(result.unwrap_err(), "disk full");
+    }
+
+    fn artifact_dir(files: &[(&str, &[u8])]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        for (name, bytes) in files {
+            std::fs::write(tmp.path().join(name), bytes).unwrap();
+        }
+        tmp
+    }
+
+    #[test]
+    fn digest_manifest_emits_sha256sum_format_for_each_name() {
+        let tmp = artifact_dir(&[("a", b"alpha"), ("b", b"beta")]);
+        let manifest = digest_manifest(tmp.path(), &["a", "b"]).unwrap();
+
+        let lines: Vec<&str> = manifest.trim_end().lines().collect();
+        assert_eq!(lines.len(), 2);
+        for (line, name) in lines.iter().zip(["a", "b"]) {
+            let (hash, listed) = line.split_once("  ").expect("two-space separator");
+            assert_eq!(listed, name);
+            assert_eq!(hash.len(), 64, "{line}");
+            assert!(hash.chars().all(|c| c.is_ascii_hexdigit()), "{line}");
+        }
+        assert!(manifest.ends_with('\n'));
+    }
+
+    #[test]
+    fn verify_accepts_a_directory_matching_its_manifest() {
+        let tmp = artifact_dir(&[("a", b"alpha"), ("b", b"beta")]);
+        let manifest = digest_manifest(tmp.path(), &["a", "b"]).unwrap();
+        std::fs::write(tmp.path().join("sums"), &manifest).unwrap();
+
+        assert_eq!(
+            verify_digest_manifest(tmp.path(), "sums", &["a", "b"]),
+            DigestManifestCheck::Match
+        );
+    }
+
+    #[test]
+    fn verify_tolerates_a_reordered_manifest() {
+        // The previous implementation compared whole manifest strings, so a
+        // reordered-but-correct manifest read as tampering.
+        let tmp = artifact_dir(&[("a", b"alpha"), ("b", b"beta")]);
+        let forward = digest_manifest(tmp.path(), &["a", "b"]).unwrap();
+        let reversed: Vec<&str> = forward.trim_end().lines().rev().collect();
+        std::fs::write(
+            tmp.path().join("sums"),
+            format!("{}\n", reversed.join("\n")),
+        )
+        .unwrap();
+
+        assert_eq!(
+            verify_digest_manifest(tmp.path(), "sums", &["a", "b"]),
+            DigestManifestCheck::Match
+        );
+    }
+
+    #[test]
+    fn verify_reports_an_absent_manifest_distinctly_from_drift() {
+        let tmp = artifact_dir(&[("a", b"alpha")]);
+        assert_eq!(
+            verify_digest_manifest(tmp.path(), "sums", &["a"]),
+            DigestManifestCheck::ManifestAbsent,
+            "a cache predating the sidecar is not evidence of tampering"
+        );
+    }
+
+    #[test]
+    fn verify_detects_drifted_bytes() {
+        let tmp = artifact_dir(&[("a", b"alpha")]);
+        let manifest = digest_manifest(tmp.path(), &["a"]).unwrap();
+        std::fs::write(tmp.path().join("sums"), &manifest).unwrap();
+        std::fs::write(tmp.path().join("a"), b"tampered").unwrap();
+
+        match verify_digest_manifest(tmp.path(), "sums", &["a"]) {
+            DigestManifestCheck::Mismatch {
+                name,
+                expected,
+                actual,
+            } => {
+                assert_eq!(name, "a");
+                assert_ne!(expected, actual);
+            }
+            other => panic!("expected a mismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_reports_a_name_the_manifest_does_not_cover() {
+        let tmp = artifact_dir(&[("a", b"alpha"), ("b", b"beta")]);
+        let manifest = digest_manifest(tmp.path(), &["a"]).unwrap();
+        std::fs::write(tmp.path().join("sums"), &manifest).unwrap();
+
+        assert_eq!(
+            verify_digest_manifest(tmp.path(), "sums", &["a", "b"]),
+            DigestManifestCheck::EntryAbsent {
+                name: "b".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn verify_reports_an_artifact_that_vanished() {
+        let tmp = artifact_dir(&[("a", b"alpha")]);
+        let manifest = digest_manifest(tmp.path(), &["a"]).unwrap();
+        std::fs::write(tmp.path().join("sums"), &manifest).unwrap();
+        std::fs::remove_file(tmp.path().join("a")).unwrap();
+
+        assert!(matches!(
+            verify_digest_manifest(tmp.path(), "sums", &["a"]),
+            DigestManifestCheck::Unreadable { name, .. } if name == "a"
+        ));
     }
 
     #[test]

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -31,9 +31,9 @@ pub mod builderd_client;
 pub mod builderd_protocol;
 pub mod cache;
 /// Shared conventions for admitting an artifact into a cache root: the
-/// cross-root seed from the host's shared cache, and the staging-directory
-/// dance every install uses.
-mod cache_install;
+/// cross-root seed from the host's shared cache, the staging-directory dance
+/// every install uses, and the digest-manifest check that gates admission.
+pub mod cache_install;
 /// Builder-VM egress allowlist proxy — the lib half of the
 /// `mvm-egress-proxy` bin. Kept as a lib module (not bin-inlined) so
 /// its pub API is dead-code-clean on non-Linux and its tests run

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -2302,12 +2302,50 @@ fn seed_builder_vm_image_from_default_cache(arch_dir: &Path) -> Result<bool, Bui
             // shared cache is stale or malformed, skip it and let
             // source-checkout auto-bootstrap build a fresh image into the
             // isolated target cache. A missing dir fails validation too.
-            validate_builder_vm_image_cache(source_arch_dir)
-                .ok()
-                .map(|_| source_arch_dir.to_path_buf())
+            validate_builder_vm_image_cache(source_arch_dir).ok()?;
+            // Same policy for a shared cache whose recorded digests no longer
+            // describe its bytes: decline the seed rather than propagate it.
+            // Declining (not erroring) matters — an error here would abort the
+            // build instead of falling through to a fresh local build.
+            if !shared_cache_digests_are_trustworthy(source_arch_dir) {
+                return None;
+            }
+            Some(source_arch_dir.to_path_buf())
         },
         |source_arch_dir| copy_builder_vm_image_files(&source_arch_dir, arch_dir),
     )
+}
+
+/// Does the host's shared cache still match the digests it recorded?
+///
+/// This is the admission boundary — the one moment bytes cross from the shared
+/// cache into an isolated root — so it is where the check belongs. It is
+/// deliberately not in `validate_builder_vm_image_cache`, which runs on every
+/// builder VM start: re-hashing a multi-hundred-megabyte rootfs per start is
+/// not a trade worth making on a host the threat model already trusts.
+///
+/// A cache carrying no manifest at all predates the sidecar or came from
+/// another populator. Absence is not evidence of tampering, so it passes.
+fn shared_cache_digests_are_trustworthy(source_arch_dir: &Path) -> bool {
+    let check = crate::cache_install::verify_digest_manifest(
+        source_arch_dir,
+        crate::cache_install::BUILDER_VM_ARTIFACT_DIGEST_FILE,
+        crate::cache_install::BUILDER_VM_CACHE_ARTIFACTS,
+    );
+    match check {
+        crate::cache_install::DigestManifestCheck::Match
+        | crate::cache_install::DigestManifestCheck::ManifestAbsent => true,
+        rejected => {
+            // A silently declined seed is invisible otherwise, and this one
+            // means someone's shared cache is damaged.
+            tracing::debug!(
+                source = %source_arch_dir.display(),
+                verdict = ?rejected,
+                "declining to seed builder image from shared cache: recorded digests do not match"
+            );
+            false
+        }
+    }
 }
 
 fn copy_builder_vm_image_files(
@@ -2318,7 +2356,7 @@ fn copy_builder_vm_image_files(
         BuilderVmError::ExtractionFailed(format!("create {}: {e}", arch_dir.display()))
     })?;
 
-    for name in ["vmlinux", "rootfs.ext4", "cmdline.txt", "manifest.json"] {
+    for name in crate::cache_install::BUILDER_VM_CACHE_ARTIFACTS {
         let src = source_arch_dir.join(name);
         let dst = arch_dir.join(name);
         std::fs::copy(&src, &dst).map_err(|e| {
@@ -2328,6 +2366,15 @@ fn copy_builder_vm_image_files(
                 dst.display(),
             ))
         })?;
+    }
+    // Sidecars are best-effort: a source lacking them still yields a bootable
+    // image, and failing the seed over an absent provenance file would be
+    // worse than seeding without it.
+    for name in crate::cache_install::BUILDER_VM_CACHE_SIDECARS {
+        let src = source_arch_dir.join(name);
+        if src.is_file() {
+            let _ = std::fs::copy(&src, arch_dir.join(name));
+        }
     }
     Ok(())
 }
@@ -5726,6 +5773,111 @@ mod tests {
             }
             BuilderVmImage::RootDir { .. } => panic!("expected rootfs builder image"),
         }
+    }
+
+    /// A shared-cache source dir as the real populators write it: the four
+    /// artifacts plus the digest and provenance sidecars.
+    fn write_shared_cache_source(source_arch_dir: &Path) {
+        std::fs::create_dir_all(source_arch_dir).unwrap();
+        std::fs::write(source_arch_dir.join("vmlinux"), b"kernel").unwrap();
+        std::fs::write(source_arch_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+        std::fs::write(
+            source_arch_dir.join("cmdline.txt"),
+            "console=hvc0 root=/dev/vda ro rootfstype=ext4 rootwait panic=-1 loglevel=8 init=/init mvm.chain_init=/sbin/mvm-host-vm-init\n",
+        )
+        .unwrap();
+        std::fs::write(
+            source_arch_dir.join("manifest.json"),
+            r#"{"cache_contract_version":3,"runtime_overlay_ready":true,"vsock_egress_ready":true}"#,
+        )
+        .unwrap();
+        let sums = crate::cache_install::digest_manifest(
+            source_arch_dir,
+            crate::cache_install::BUILDER_VM_CACHE_ARTIFACTS,
+        )
+        .unwrap();
+        std::fs::write(
+            source_arch_dir.join(crate::cache_install::BUILDER_VM_ARTIFACT_DIGEST_FILE),
+            sums,
+        )
+        .unwrap();
+        std::fs::write(source_arch_dir.join(".mvm-provenance.json"), b"{}").unwrap();
+        std::fs::write(source_arch_dir.join(".mvm-source.sha256"), b"fingerprint\n").unwrap();
+    }
+
+    #[test]
+    fn seeding_carries_the_integrity_sidecars_into_the_isolated_cache() {
+        let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
+        let scratch = TempDir::new().unwrap();
+        env.set("HOME", scratch.path());
+        env.set("MVM_HOME", scratch.path().join("isolated-cache"));
+
+        let arch = host_arch_tag().to_string();
+        write_shared_cache_source(
+            &crate::cache_install::default_cache_root()
+                .join("builder-vm")
+                .join(&arch),
+        );
+
+        ensure_builder_vm_image().expect("seed from default cache");
+
+        // Without these the seeded copy cannot be verified afterwards, and the
+        // bootstrap readiness check reads it as incomplete and rebuilds over
+        // the image the seed just copied.
+        let target_arch_dir = scratch
+            .path()
+            .join("isolated-cache")
+            .join("cache")
+            .join("builder-vm")
+            .join(&arch);
+        for name in crate::cache_install::BUILDER_VM_CACHE_SIDECARS {
+            assert!(
+                target_arch_dir.join(name).is_file(),
+                "seeded cache is missing {name}"
+            );
+        }
+        assert!(matches!(
+            crate::cache_install::verify_digest_manifest(
+                &target_arch_dir,
+                crate::cache_install::BUILDER_VM_ARTIFACT_DIGEST_FILE,
+                crate::cache_install::BUILDER_VM_CACHE_ARTIFACTS,
+            ),
+            crate::cache_install::DigestManifestCheck::Match
+        ));
+    }
+
+    #[test]
+    fn seeding_declines_a_shared_cache_whose_digests_no_longer_match() {
+        let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
+        let scratch = TempDir::new().unwrap();
+        env.set("HOME", scratch.path());
+        env.set("MVM_HOME", scratch.path().join("isolated-cache"));
+
+        let arch = host_arch_tag().to_string();
+        let source_arch_dir = crate::cache_install::default_cache_root()
+            .join("builder-vm")
+            .join(&arch);
+        write_shared_cache_source(&source_arch_dir);
+        // Same length, so only the digest can catch it.
+        std::fs::write(source_arch_dir.join("rootfs.ext4"), b"r00tfs").unwrap();
+
+        let err = ensure_builder_vm_image().expect_err("drifted shared cache must not seed");
+
+        // Declined, not propagated: the caller falls through to a fresh local
+        // build, so the surfaced error is the original cache miss rather than
+        // a digest complaint.
+        let target_arch_dir = scratch
+            .path()
+            .join("isolated-cache")
+            .join("cache")
+            .join("builder-vm")
+            .join(&arch);
+        assert!(
+            !target_arch_dir.join("rootfs.ext4").exists(),
+            "drifted bytes must not reach the isolated cache: {err}"
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/env/builder_vm/stage0_cache.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/stage0_cache.rs
@@ -1,8 +1,5 @@
 use super::*;
 
-const BUILDER_VM_CACHE_REQUIRED_ARTIFACTS: &[&str] =
-    &["vmlinux", "rootfs.ext4", "cmdline.txt", "manifest.json"];
-
 /// Which phase of Stage 0 failed. Each variant maps to a
 /// `stage=...` value in the `Stage0Failed` audit detail so a dashboard
 /// can break down "Stage 0 reliability" by failure phase. String
@@ -617,12 +614,16 @@ pub(super) fn builder_vm_source_cache_status(
         return BuilderVmSourceCacheStatus::FingerprintMismatch;
     }
 
-    let digest_path = dir.join(BUILDER_VM_ARTIFACT_DIGEST_FILE);
-    if !digest_path.exists() {
-        return BuilderVmSourceCacheStatus::MissingArtifactDigestManifest;
-    }
-    if !builder_vm_artifact_digest_manifest_matches(dir) {
-        return BuilderVmSourceCacheStatus::ArtifactDigestMismatch;
+    match mvm_build::cache_install::verify_digest_manifest(
+        dir,
+        BUILDER_VM_ARTIFACT_DIGEST_FILE,
+        mvm_build::cache_install::BUILDER_VM_CACHE_ARTIFACTS,
+    ) {
+        mvm_build::cache_install::DigestManifestCheck::Match => {}
+        mvm_build::cache_install::DigestManifestCheck::ManifestAbsent => {
+            return BuilderVmSourceCacheStatus::MissingArtifactDigestManifest;
+        }
+        _ => return BuilderVmSourceCacheStatus::ArtifactDigestMismatch,
     }
 
     let provenance_path = dir.join(BUILDER_VM_PROVENANCE_FILE);
@@ -666,28 +667,29 @@ pub(super) fn write_builder_vm_source_fingerprint(
     .with_context(|| format!("writing builder VM source fingerprint in {}", dir.display()))
 }
 
+// Both helpers below are reached only from the builder-VM bootstrap paths;
+// the readiness check consults the shared verifier directly.
+#[cfg(any(feature = "builder-vm", test))]
 fn builder_vm_artifact_digest_manifest(dir: &std::path::Path) -> Result<String> {
-    let mut lines = Vec::new();
-    for name in BUILDER_VM_CACHE_REQUIRED_ARTIFACTS {
-        let path = dir.join(name);
-        if !path.exists() {
-            anyhow::bail!("builder VM artifact digest missing {}", path.display());
-        }
-        let bytes = std::fs::read(&path)
-            .with_context(|| format!("reading builder VM artifact {}", path.display()))?;
-        lines.push(format!("{}  {name}", hex::encode(Sha256::digest(&bytes))));
-    }
-    Ok(format!("{}\n", lines.join("\n")))
+    mvm_build::cache_install::digest_manifest(
+        dir,
+        mvm_build::cache_install::BUILDER_VM_CACHE_ARTIFACTS,
+    )
+    .with_context(|| format!("hashing builder VM artifacts in {}", dir.display()))
 }
 
+/// Whole-directory verdict collapsed to a bool, for the callers that only need
+/// "is this dir self-consistent" and have their own error to raise.
+#[cfg(any(feature = "builder-vm", test))]
 fn builder_vm_artifact_digest_manifest_matches(dir: &std::path::Path) -> bool {
-    let expected = match builder_vm_artifact_digest_manifest(dir) {
-        Ok(expected) => expected,
-        Err(_) => return false,
-    };
-    std::fs::read_to_string(dir.join(BUILDER_VM_ARTIFACT_DIGEST_FILE))
-        .map(|actual| actual == expected)
-        .unwrap_or(false)
+    matches!(
+        mvm_build::cache_install::verify_digest_manifest(
+            dir,
+            BUILDER_VM_ARTIFACT_DIGEST_FILE,
+            mvm_build::cache_install::BUILDER_VM_CACHE_ARTIFACTS,
+        ),
+        mvm_build::cache_install::DigestManifestCheck::Match
+    )
 }
 
 #[cfg(any(feature = "builder-vm", test))]
@@ -720,7 +722,7 @@ fn builder_vm_source_cache_provenance(
 
 fn builder_vm_artifact_names_present(dir: &std::path::Path) -> Result<Vec<String>> {
     let mut names = Vec::new();
-    for name in BUILDER_VM_CACHE_REQUIRED_ARTIFACTS {
+    for name in mvm_build::cache_install::BUILDER_VM_CACHE_ARTIFACTS {
         let path = dir.join(name);
         if !path.exists() {
             anyhow::bail!("builder VM provenance missing artifact {}", path.display());

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -82,6 +82,22 @@
       test fixtures had to become realistic — they wrote `b"image"` with a
       `b"hash"` sidecar, which is why the gap survived review.
 
+- [x] Builder-image seed verified at admission (#1932). The cross-root seed
+      copied four artifacts and left the integrity sidecars behind, so the
+      seeded cache could not be verified afterwards *and* read as
+      `MissingArtifactDigestManifest` to a later bootstrap — which then
+      rebuilt the ~775 MB it had just copied. The seed now carries the
+      sidecars and checks `.mvm-artifacts.sha256` before admitting bytes,
+      declining (not erroring) on drift so a damaged shared cache falls
+      through to a fresh local build. Measured cost of digesting the image is
+      ~2.1s, which is why the check sits at admission and not in
+      `validate_builder_vm_image_cache`, which runs on every builder VM
+      start. The digest logic moved into `mvm_build::cache_install` and is
+      now shared with the bootstrap readiness check — that also fixed two
+      latent defects in it: the old version read each artifact wholly into
+      memory (775 MB) instead of streaming, and compared whole manifest
+      strings, so a reordered manifest read as tampering.
+
 - [ ] Tier-1 edge path: the build → sign → export → install-on-another-host →
       admit → boot chain now runs end to end on aarch64, delivered through
       #1888 (ARM64 `Image` kernels reach Firecracker), #1891 (guest reads the


### PR DESCRIPTION
Closes #1932. #1930 has merged, so this is rebased onto `main` and targets it directly. It builds on the `cache_install` module and the `copy_builder_vm_image_files` extraction from that PR.

## The bug is not primarily about integrity

The cross-root seed copied four artifacts out of the host's shared cache and left the integrity sidecars behind. Two consequences:

1. Nothing could verify the seeded copy afterwards — the digest manifest describing those bytes stayed in the source directory.
2. `builder_vm_source_cache_ready` reads a sidecar-less directory as `MissingArtifactDigestManifest`, i.e. **not ready**. So a later `mvmctl bootstrap` rebuilt the ~775 MB the seed had just copied.

The second one defeats the purpose of seeding. That is the part worth fixing regardless of threat model.

## What changed

The seed now carries the sidecars and verifies `.mvm-artifacts.sha256` before admitting anything.

**On drift it declines rather than errors.** This mattered and I had it wrong at first: returning an `Err` propagates through `ensure_builder_vm_image`'s `?` and aborts the build, where declining falls through to a fresh local build. Declining is also the existing policy for a stale or malformed shared cache, so the digest check now sits in the same probe as `validate_builder_vm_image_cache` rather than in the copy.

**A directory with no manifest still seeds.** Absence predates the sidecar or means another populator wrote the cache; it is not evidence of tampering, and refusing would silently turn an integrity improvement into a surprise rebuild for anyone holding an older cache.

**The check is deliberately not in `validate_builder_vm_image_cache`**, which runs on every builder VM start. Measured on this host:

| file | size | sha256 |
|---|---|---|
| `rootfs.ext4` | 775 MB | 2.05 s |
| `vmlinux` | 17 MB | 0.058 s |

Admission is the one moment bytes cross into a cache root, so it is where paying ~2.1 s buys something. Same conclusion, and same reasoning, as #1925 reached for the initramfs.

## Two latent defects fixed on the way

Sharing the logic with the bootstrap readiness check meant moving it into `mvm_build::cache_install`. The old implementation had two problems that only showed up once I read it closely:

- it did `std::fs::read(&path)` per artifact — pulling the whole 775 MB rootfs into memory. It now streams through `mvm_fs::overlay::compute_file_sha256`.
- it compared **whole manifest strings** for equality, so a reordered or differently-terminated but entirely correct manifest read as tampering. It now compares parsed entries. There is a test for exactly that.

The verdict is an enum rather than a bool because the two callers need different branches: "no manifest" is benign to the seed and a distinct reason code to the readiness check.

## One placement decision worth flagging

The artifact-name list lives in the **ungated** `cache_install` module rather than beside the builder code. Both sides of a feature boundary need it — the seed is gated on `builder-vm`, while the readiness check also compiles under a bare `test` cfg — and that is exactly how the list came to be duplicated in the first place. One ungated list is the only arrangement where the two cannot drift about what a complete cache directory contains. It costs a little cohesion (builder-specific names in a generic module) and the comment says why.

## Verification

Negative controls, because a check never seen to fail is decoration:

| removed | result |
|---|---|
| the digest check in the seed probe | `seeding_declines_a_shared_cache_whose_digests_no_longer_match` → **RED** |
| the sidecar copy loop | `seeding_carries_the_integrity_sidecars_into_the_isolated_cache` → **RED** |
| both restored | **GREEN** |

The drift fixture rewrites `rootfs.ext4` to the same byte length, so only the digest can catch it — the structural validation and any size check pass.

- **8167/8167 nextest, 0 failed** on a host with a populated `~/.mvm`, re-run after rebasing onto the merged main.
- 25 targeted tests green under `--features builder-vm` (the gate that hid these tests from a plain `-p mvm-build` run).
- clippy `-D warnings` clean at workspace default **and** with `builder-vm`; doctests clean; `check-single-home`, `check-test-home-isolation` and `check-no-spec-refs-in-comments` clean.

The spec-ref gate caught a threat-model citation in one of my own doc comments — reworded to keep the reasoning and drop the reference.

No new dependencies.


## A CI failure worth recording

The first push failed the Lint job on a feature combination my local gates missed:

```
error: function `builder_vm_artifact_digest_manifest` is never used
error: function `builder_vm_artifact_digest_manifest_matches` is never used
```

Routing the readiness check at the shared verifier removed the last *ungated* caller of those two helpers. Their remaining callers are `#[cfg(any(feature = "builder-vm", test))]`, so under `cargo test --package xtask --features man` — which builds mvm-cli without `builder-vm` — they became dead code and `-D warnings` failed. Both now carry the matching gate.

Worth noting because a plain `cargo clippy --workspace --all-targets` does not catch it: the failing combination has to be built explicitly. I now reproduce CI's exact command locally, and `cargo build -p mvm-cli --no-default-features` alongside it.
