### PR TITLE
Reference Rust engineering best practices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,10 +247,12 @@ match the surrounding naming, idiom, and module layout. Consistency is a feature
 
 ## Rust Best Practices
 
-Standing guidelines for every Rust change in this repo — write new code toward
-them and pull existing code their way as you touch it. Where a dedicated section
-already states a stricter rule (Clippy suppressions, `unwrap()`, reuse-first),
-that section governs; the points below extend it, never relax it.
+Use the [Rust Engineering Best Practices](https://gist.github.com/auser/c3161f55a8393faa8af5ddda68c6befa)
+as the development reference for every Rust change in this repo: write new code
+toward those practices and pull existing code their way as you touch it. Where a
+dedicated section in this file states a stricter or repository-specific rule
+(Clippy suppressions, `unwrap()`, reuse-first), this file governs; the points
+below extend the external guide, never relax it.
 
 ### API & type design
 


### PR DESCRIPTION
## What changed

- Link the repository working agreement to the Rust Engineering Best Practices guide.
- Clarify that stricter or repository-specific rules in `AGENTS.md` take precedence.

## Why

This makes the external Rust development standard explicit and keeps its relationship to the repository's existing requirements unambiguous.

## Impact

Agents and contributors now have a canonical external reference for Rust engineering practices while retaining the repository's stricter local rules.

## Validation

- `git diff --check origin/main...HEAD`
- Documentation-only change; no code tests required.
