### PR TITLE
feat(apple-container): stage 2 — Swift Containerization shim + Rust client + vminitd injection

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -176,6 +176,13 @@ build-supervisors:
     cargo build -p mvm-vm-host --bin mvm-hvf-supervisor
     cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys
 
+# Build the Apple Containerization shim (Swift) and install it codesigned
+# into the mvm cache (<MVM_HOME>/cache/apple-container/bin/). Kernel and
+# initfs artifacts land beside it; the backend's ArtifactMissing errors
+# name their fetch steps.
+apple-container-shim:
+    bash scripts/build-apple-container-shim.sh
+
 # Build the dm-verity-capable workload kernel into the local mvm cache.
 kernel-workload:
     cargo run -- kernel build --which workload

--- a/crates/mvm-core/src/util/test_env.rs
+++ b/crates/mvm-core/src/util/test_env.rs
@@ -150,12 +150,17 @@ mod tests {
 
     #[test]
     fn isolate_mvm_home_sets_both_roots_and_restores_them() {
-        let before_home = std::env::var_os("HOME");
-        let before_mvm_home = std::env::var_os("MVM_HOME");
         let root = "/tmp/mvm-test-env-isolate-both";
 
+        // The before-values must be read with the guard already held: an
+        // unlocked read can observe another thread's in-flight mutation and
+        // the final restore check would then compare against that thread's
+        // value rather than the value this thread will actually restore.
+        let mut env = TestEnv::new();
+        let before_home = std::env::var_os("HOME");
+        let before_mvm_home = std::env::var_os("MVM_HOME");
+
         {
-            let mut env = TestEnv::new();
             env.isolate_mvm_home(root);
             assert_eq!(std::env::var("MVM_HOME").as_deref(), Ok(root));
             // The whole point: HOME moves too, so the MVM_HOME-ignoring
@@ -163,6 +168,10 @@ mod tests {
             assert_eq!(std::env::var("HOME").as_deref(), Ok(root));
         }
 
+        drop(env);
+        // Re-acquire the guard for the restore assertions too: without it a
+        // concurrent mutation could land between the drop and the read.
+        let _guard = TestEnv::new();
         assert_eq!(std::env::var_os("MVM_HOME"), before_mvm_home);
         assert_eq!(std::env::var_os("HOME"), before_home);
     }

--- a/crates/mvm-runtime/Cargo.toml
+++ b/crates/mvm-runtime/Cargo.toml
@@ -127,6 +127,10 @@ storage-s3 = ["dep:object_store", "dep:futures"]
 # The claim-free host-wasmtime portability tier (`WasmBackend`). Off by
 # default; pulls the wasmtime + wasmtime-wasi closure only when enabled.
 wasm-backend = ["dep:wasmtime", "dep:wasmtime-wasi"]
+# Apple Containerization-framework tier's live-boot smoke test. Off by
+# default; the shim is a separate Swift build, so this gates only the
+# artifact-requiring e2e hook (itself `#[ignore]`d behind `MVM_AC_E2E`).
+apple-container = []
 # The hermetic in-memory `MockBackend`/`MockGuestAgent` test double + the
 # `AnyBackend::Mock` variant that selects it. Off by default so the mock — a
 # Tier-3 backend satisfying none of the security claims (no guest, no

--- a/crates/mvm-runtime/src/apple_container/mod.rs
+++ b/crates/mvm-runtime/src/apple_container/mod.rs
@@ -1,0 +1,6 @@
+//! Apple Container backend internals: the boot-spec mapping and the
+//! container-shim client. See `crate::apple_container_backend` for the
+//! selectable backend itself.
+
+pub mod shim_client;
+pub mod spec;

--- a/crates/mvm-runtime/src/apple_container/shim_client.rs
+++ b/crates/mvm-runtime/src/apple_container/shim_client.rs
@@ -1,0 +1,551 @@
+//! Host-side client for the container shim's control protocol.
+//!
+//! The shim (`swift/mvm-container-shim`) is spawned detached per VM with a
+//! `--spec` JSON file, then spoken to over its control Unix socket using
+//! newline-delimited JSON: one request line in (`{"id":N,"op":…}`), one
+//! response line out (`{"id":N,"ok":true}` or `{"id":N,"ok":false,
+//! "error":…}`). The only op that transfers more than JSON is
+//! `dial_vsock`: after the ok response line, the shim sends one sendmsg
+//! carrying a single dummy payload byte plus the connected vsock fd in an
+//! SCM_RIGHTS control message — this module implements the symmetric
+//! recvmsg. The framing codec is pure and unit-tested against an
+//! in-process mock server; no Swift is needed to test it.
+
+use std::io::{Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::apple_container_backend::AppleContainerError;
+
+/// How long `connect` waits for the shim to bind its control socket before
+/// declaring the boot failed.
+const CONTROL_SOCKET_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Per-request I/O deadline on the control socket. `wait`-family ops can
+/// legitimately block for the life of the workload; they run with no
+/// deadline instead.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Spawn the shim detached for `spec_path`, record its pid in `pid_file`,
+/// and connect to its control socket once bound. Rolling back is the
+/// caller's job on any later failure (the shim stops its VM on exit, so
+/// killing the shim is sufficient).
+pub fn spawn_shim(
+    shim_bin: &Path,
+    spec_path: &Path,
+    control_socket: &Path,
+    pid_file: &Path,
+) -> Result<ShimClient, AppleContainerError> {
+    let shim = |reason: String| AppleContainerError::Shim {
+        op: "spawn",
+        reason,
+    };
+    let mut cmd = Command::new(shim_bin);
+    cmd.arg("--spec")
+        .arg(spec_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    // Detach into its own session so it survives this process, exactly as
+    // the other per-VM supervisors do.
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        cmd.pre_exec(|| {
+            // SAFETY: post-fork, pre-exec; setsid has no preconditions.
+            libc::setsid();
+            Ok(())
+        });
+    }
+    let child = cmd
+        .spawn()
+        .map_err(|e| shim(format!("spawn {}: {e}", shim_bin.display())))?;
+    std::fs::write(pid_file, child.id().to_string())
+        .map_err(|e| shim(format!("write {}: {e}", pid_file.display())))?;
+    ShimClient::connect(control_socket, CONTROL_SOCKET_TIMEOUT)
+}
+
+/// A live control connection to a shim.
+pub struct ShimClient {
+    stream: UnixStream,
+    next_id: u64,
+}
+
+impl ShimClient {
+    /// Connect to an already-running shim, waiting for the control socket
+    /// to appear (the shim binds it a beat after its VM starts).
+    pub fn connect(control_socket: &Path, timeout: Duration) -> Result<Self, AppleContainerError> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match UnixStream::connect(control_socket) {
+                Ok(stream) => {
+                    return Ok(Self { stream, next_id: 1 });
+                }
+                Err(e) => {
+                    if Instant::now() >= deadline {
+                        return Err(AppleContainerError::Shim {
+                            op: "connect",
+                            reason: format!(
+                                "shim did not bind {} within {timeout:?}: {e}",
+                                control_socket.display()
+                            ),
+                        });
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+            }
+        }
+    }
+
+    /// One request/response round trip. Returns the response's result
+    /// fields (empty for ack-only ops).
+    fn request(
+        &mut self,
+        op: serde_json::Value,
+        deadline: Option<Duration>,
+    ) -> Result<serde_json::Value, AppleContainerError> {
+        self.request_impl(op, deadline)
+            .map_err(|e| AppleContainerError::Shim {
+                op: "request",
+                reason: e.to_string(),
+            })
+    }
+
+    fn request_impl(
+        &mut self,
+        op: serde_json::Value,
+        deadline: Option<Duration>,
+    ) -> Result<serde_json::Value> {
+        let id = self.next_id;
+        self.next_id += 1;
+        let line = encode_request_line(id, &op)?;
+        self.stream
+            .set_read_timeout(deadline)
+            .context("set read timeout on shim control socket")?;
+        self.stream
+            .set_write_timeout(deadline)
+            .context("set write timeout on shim control socket")?;
+        self.stream.write_all(&line).context("write shim request")?;
+        let resp_line = read_line(&mut self.stream).context("read shim response")?;
+        let resp = parse_response_line(&resp_line).context("parse shim response")?;
+        if resp.id != id {
+            bail!(
+                "shim response id {} does not match request id {id}",
+                resp.id
+            );
+        }
+        match resp.error {
+            Some(error) => bail!("shim: {error}"),
+            None => Ok(resp.result.unwrap_or_else(|| json!({}))),
+        }
+    }
+
+    /// Liveness probe.
+    pub fn ping(&mut self) -> Result<(), AppleContainerError> {
+        self.request(json!({"op": "ping"}), Some(REQUEST_TIMEOUT))?;
+        Ok(())
+    }
+
+    /// Stop the container VM and let the shim exit.
+    pub fn stop(&mut self) -> Result<(), AppleContainerError> {
+        self.request(json!({"op": "stop"}), Some(REQUEST_TIMEOUT))?;
+        Ok(())
+    }
+
+    /// SIGKILL the container VM.
+    pub fn kill(&mut self) -> Result<(), AppleContainerError> {
+        self.request(json!({"op": "kill"}), Some(REQUEST_TIMEOUT))?;
+        Ok(())
+    }
+
+    /// Wait for the container VM to exit and return its exit code. Runs
+    /// with no deadline — a workload's life is unbounded.
+    pub fn wait(&mut self) -> Result<i64, AppleContainerError> {
+        let result = self.request(json!({"op": "wait"}), None)?;
+        Ok(result
+            .get("exit_code")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(-1))
+    }
+
+    /// Inject a file into the guest (whole-file write; the shim streams it
+    /// via the container's copy channel, so no chunking is needed).
+    pub fn write_file(
+        &mut self,
+        path: &str,
+        data: &[u8],
+        mode: u32,
+    ) -> Result<(), AppleContainerError> {
+        use base64::Engine;
+        self.request(
+            json!({
+                "op": "vminitd_write_file",
+                "path": path,
+                "data_b64": base64::engine::general_purpose::STANDARD.encode(data),
+                "mode": mode,
+            }),
+            Some(REQUEST_TIMEOUT),
+        )?;
+        Ok(())
+    }
+
+    /// Create a directory in the guest (optionally with parents).
+    pub fn mkdir(&mut self, path: &str, all: bool, perms: u32) -> Result<(), AppleContainerError> {
+        self.request(
+            json!({"op": "vminitd_mkdir", "path": path, "all": all, "perms": perms}),
+            Some(REQUEST_TIMEOUT),
+        )?;
+        Ok(())
+    }
+
+    /// Create (not start) a guest process.
+    pub fn create_process(&mut self, proc: &ProcessSpec<'_>) -> Result<(), AppleContainerError> {
+        self.request(
+            json!({
+                "op": "vminitd_create_process",
+                "proc_id": proc.id,
+                "path": proc.path,
+                "args": proc.args,
+                "env": proc.env,
+                "cwd": proc.cwd,
+            }),
+            Some(REQUEST_TIMEOUT),
+        )?;
+        Ok(())
+    }
+
+    /// Start a created guest process, returning its pid.
+    pub fn start_process(&mut self, proc_id: &str) -> Result<i32, AppleContainerError> {
+        let result = self.request(
+            json!({"op": "vminitd_start_process", "proc_id": proc_id}),
+            Some(REQUEST_TIMEOUT),
+        )?;
+        Ok(result
+            .get("pid")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(-1) as i32)
+    }
+
+    /// Wait for a guest process to exit, returning its exit code.
+    pub fn wait_process(&mut self, proc_id: &str) -> Result<i64, AppleContainerError> {
+        let result = self.request(
+            json!({"op": "vminitd_wait_process", "proc_id": proc_id}),
+            None,
+        )?;
+        Ok(result
+            .get("exit_code")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(-1))
+    }
+
+    /// Signal a guest process.
+    pub fn signal_process(
+        &mut self,
+        proc_id: &str,
+        signal: i32,
+    ) -> Result<(), AppleContainerError> {
+        self.request(
+            json!({"op": "vminitd_signal", "proc_id": proc_id, "signal": signal}),
+            Some(REQUEST_TIMEOUT),
+        )?;
+        Ok(())
+    }
+
+    /// Dial a guest vsock port, returning the connected socket. After the
+    /// ok response line, the shim hands the fd over SCM_RIGHTS (see the
+    /// module docs for the wire convention).
+    pub fn dial_vsock(&mut self, port: u32) -> Result<UnixStream, AppleContainerError> {
+        self.request(
+            json!({"op": "dial_vsock", "port": port}),
+            Some(REQUEST_TIMEOUT),
+        )?;
+        self.stream
+            .set_read_timeout(Some(REQUEST_TIMEOUT))
+            .map_err(|e| AppleContainerError::Shim {
+                op: "dial_vsock",
+                reason: format!("set read timeout: {e}"),
+            })?;
+        recv_fd(self.stream.as_raw_fd()).map_err(|e| AppleContainerError::Shim {
+            op: "dial_vsock",
+            reason: format!("receive vsock fd: {e}"),
+        })
+    }
+}
+
+/// The process description `create_process` takes. Borrows so a caller
+/// assembling it inline pays no copies.
+pub struct ProcessSpec<'a> {
+    pub id: &'a str,
+    pub path: &'a str,
+    pub args: &'a [String],
+    pub env: &'a [String],
+    pub cwd: &'a str,
+}
+
+// ---------------------------------------------------------------------------
+// Framing (pure, unit-tested)
+// ---------------------------------------------------------------------------
+
+/// Encode one request line (with trailing newline).
+pub fn encode_request_line(id: u64, op: &serde_json::Value) -> Result<Vec<u8>> {
+    let mut value = op.clone();
+    value["id"] = json!(id);
+    let mut bytes = serde_json::to_vec(&value).context("encode shim request")?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+/// A decoded response line.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RawResponse {
+    pub id: u64,
+    pub ok: bool,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(flatten)]
+    pub result: Option<serde_json::Value>,
+}
+
+/// Decode one response line.
+pub fn parse_response_line(line: &[u8]) -> Result<RawResponse> {
+    serde_json::from_slice(line).context("shim response is not valid JSON")
+}
+
+/// Read one newline-terminated line (without the newline).
+fn read_line(stream: &mut impl Read) -> Result<Vec<u8>> {
+    let mut out = Vec::with_capacity(256);
+    let mut byte = [0u8; 1];
+    loop {
+        let n = stream
+            .read(&mut byte)
+            .context("read from shim control socket")?;
+        if n == 0 {
+            bail!("shim closed the control socket");
+        }
+        if byte[0] == b'\n' {
+            return Ok(out);
+        }
+        out.push(byte[0]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SCM_RIGHTS receive (the dial_vsock fd handoff)
+// ---------------------------------------------------------------------------
+
+/// CMSG helpers mirroring CMSG_ALIGN/CMSG_SPACE from <sys/socket.h>.
+const fn cmsg_align(n: usize) -> usize {
+    n.next_multiple_of(std::mem::size_of::<libc::size_t>())
+}
+
+const fn cmsg_space(payload: usize) -> usize {
+    cmsg_align(std::mem::size_of::<libc::cmsghdr>()) + cmsg_align(payload)
+}
+
+const fn cmsg_len(payload: usize) -> usize {
+    cmsg_align(std::mem::size_of::<libc::cmsghdr>()) + payload
+}
+
+/// Aligned control-message buffer: a bare `[u8; N]` stack array has no
+/// alignment guarantee, and an unaligned `cmsghdr` is EINVAL on both
+/// sendmsg and recvmsg.
+#[repr(align(8))]
+struct AlignedControl([u8; cmsg_space(std::mem::size_of::<RawFd>())]);
+
+impl AlignedControl {
+    fn new() -> Self {
+        Self([0u8; cmsg_space(std::mem::size_of::<RawFd>())])
+    }
+
+    fn as_ptr(&mut self) -> *mut libc::c_void {
+        self.0.as_mut_ptr().cast()
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+/// Receive one message of exactly one dummy payload byte plus one fd in an
+/// SCM_RIGHTS control message — the symmetric half of the shim's sendFd.
+fn recv_fd(socket: RawFd) -> Result<UnixStream> {
+    let mut dummy = [0u8; 1];
+    let mut iov = libc::iovec {
+        iov_base: dummy.as_mut_ptr().cast(),
+        iov_len: 1,
+    };
+    let mut control = AlignedControl::new();
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = control.as_ptr();
+    msg.msg_controllen = control.len() as _;
+
+    // SAFETY: recvmsg(2) on a valid socket fd; `msg` points at valid,
+    // fully-sized buffers for the duration of the call.
+    let n = unsafe { libc::recvmsg(socket, &mut msg, 0) };
+    if n < 0 {
+        return Err(anyhow!("recvmsg: {}", std::io::Error::last_os_error()));
+    }
+    if n == 0 {
+        bail!("shim closed the control socket instead of passing an fd");
+    }
+
+    // SAFETY: CMSG_FIRSTHDR equivalent — the control buffer is
+    // cmsg_space-sized and the kernel filled the header.
+    let cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+    if cmsg.is_null() {
+        bail!("no control message in shim fd handoff");
+    }
+    let (level, ty, len) = unsafe { ((*cmsg).cmsg_level, (*cmsg).cmsg_type, (*cmsg).cmsg_len) };
+    if level != libc::SOL_SOCKET
+        || ty != libc::SCM_RIGHTS
+        || (len as usize) < cmsg_len(std::mem::size_of::<RawFd>())
+    {
+        bail!(
+            "unexpected control message in shim fd handoff (level={level}, type={ty}, len={len})"
+        );
+    }
+    // SAFETY: the header checks above prove one fd-sized payload follows
+    // the aligned header.
+    let fd = unsafe { libc::CMSG_DATA(cmsg).cast::<RawFd>().read_unaligned() };
+    // SAFETY: `fd` is a fresh, owned descriptor received via SCM_RIGHTS.
+    Ok(unsafe { UnixStream::from_raw_fd(fd) })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::net::UnixListener;
+    use std::path::PathBuf;
+
+    /// A stub shim: answer requests from canned responses, one per line.
+    fn spawn_stub(answers: Vec<serde_json::Value>) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("shim.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            for answer in answers {
+                let _line = read_line(&mut stream).unwrap();
+                let mut bytes = serde_json::to_vec(&answer).unwrap();
+                bytes.push(b'\n');
+                stream.write_all(&bytes).unwrap();
+            }
+        });
+        let path = sock;
+        (dir, path)
+    }
+
+    #[test]
+    fn request_line_carries_id_and_op() {
+        let line = encode_request_line(7, &json!({"op": "ping"})).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&line[..line.len() - 1]).unwrap();
+        assert_eq!(parsed["id"], 7);
+        assert_eq!(parsed["op"], "ping");
+        assert_eq!(*line.last().unwrap(), b'\n');
+    }
+
+    #[test]
+    fn response_line_decodes_ok_error_and_result() {
+        let ok = parse_response_line(br#"{"id":1,"ok":true,"pid":42}"#).unwrap();
+        assert!(ok.ok);
+        assert_eq!(ok.error, None);
+        assert_eq!(ok.result.unwrap()["pid"], 42);
+
+        let err = parse_response_line(br#"{"id":2,"ok":false,"error":"boom"}"#).unwrap();
+        assert!(!err.ok);
+        assert_eq!(err.error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn round_trip_ok_error_and_id_mismatch() {
+        let (_dir, sock) = spawn_stub(vec![
+            json!({"id": 1, "ok": true}),
+            json!({"id": 2, "ok": false, "error": "nope"}),
+            json!({"id": 99, "ok": true}),
+        ]);
+        let mut client = ShimClient::connect(&sock, Duration::from_secs(2)).unwrap();
+        client.ping().unwrap();
+        let err = client.ping().unwrap_err();
+        assert!(
+            matches!(err, AppleContainerError::Shim { .. }),
+            "error responses surface as typed Shim errors: {err}"
+        );
+        let err = client.ping().unwrap_err();
+        assert!(
+            matches!(err, AppleContainerError::Shim { .. }),
+            "id mismatch: {err}"
+        );
+    }
+
+    #[test]
+    fn dial_vsock_receives_the_passed_fd() {
+        // Stub shim: answer the request line, then pass one end of a
+        // socketpair over SCM_RIGHTS (the symmetric half of the client's
+        // recv_fd).
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("shim.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let _line = read_line(&mut stream).unwrap();
+            stream.write_all(br#"{"id":1,"ok":true}"#.as_ref()).unwrap();
+            stream.write_all(b"\n").unwrap();
+            let (mut a, b) = UnixStream::pair().unwrap();
+            send_fd(stream.as_raw_fd(), b.as_raw_fd()).unwrap();
+            drop(b);
+            // Echo one byte back through the passed fd's other end.
+            let mut byte = [0u8; 1];
+            a.read_exact(&mut byte).unwrap();
+            a.write_all(&byte).unwrap();
+        });
+
+        let mut client = ShimClient::connect(&sock, Duration::from_secs(2)).unwrap();
+        let mut conn = client.dial_vsock(5252).unwrap();
+        conn.write_all(b"x").unwrap();
+        let mut got = [0u8; 1];
+        conn.read_exact(&mut got).unwrap();
+        assert_eq!(&got, b"x", "the passed fd is a live duplex channel");
+    }
+
+    /// Test-side mirror of the shim's sendFd: one dummy payload byte + one
+    /// fd in an SCM_RIGHTS cmsg.
+    fn send_fd(socket: RawFd, fd: RawFd) -> Result<()> {
+        let mut dummy = [0u8; 1];
+        let mut iov = libc::iovec {
+            iov_base: dummy.as_mut_ptr().cast(),
+            iov_len: 1,
+        };
+        let mut control = AlignedControl::new();
+        let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+        msg.msg_iov = &mut iov;
+        msg.msg_iovlen = 1;
+        msg.msg_control = control.as_ptr();
+        // macOS rejects CMSG_SPACE here (EINVAL): msg_controllen must be
+        // the single header's CMSG_LEN, not the padded buffer size.
+        msg.msg_controllen = cmsg_len(std::mem::size_of::<RawFd>()) as _;
+
+        // SAFETY: one cmsg at the head of a cmsg_space-sized buffer.
+        let cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+        assert!(!cmsg.is_null());
+        unsafe {
+            (*cmsg).cmsg_level = libc::SOL_SOCKET;
+            (*cmsg).cmsg_type = libc::SCM_RIGHTS;
+            (*cmsg).cmsg_len = cmsg_len(std::mem::size_of::<RawFd>()) as _;
+            libc::CMSG_DATA(cmsg).cast::<RawFd>().write_unaligned(fd);
+        }
+        // SAFETY: sendmsg(2) on a valid socket; buffers are valid for the call.
+        let rc = unsafe { libc::sendmsg(socket, &msg, 0) };
+        if rc < 0 {
+            return Err(anyhow!("sendmsg: {}", std::io::Error::last_os_error()));
+        }
+        Ok(())
+    }
+}

--- a/crates/mvm-runtime/src/apple_container/spec.rs
+++ b/crates/mvm-runtime/src/apple_container/spec.rs
@@ -1,0 +1,374 @@
+//! The boot spec the backend hands the container shim (`--spec <path>`).
+//!
+//! Mirrors the Swift `ShimSpec` in `swift/mvm-container-shim` field for
+//! field (snake_case JSON): kernel + initfs for the framework's
+//! Virtualization.framework manager, the container rootfs, extra blocks,
+//! virtio-fs shares, the control socket, the guest-agent vsock port, and
+//! the boot-log directory. The mapping from an admitted `VmStartConfig` is
+//! pure so every shape (sealed, plain, volumes, refusals) is unit-testable
+//! without a hypervisor.
+//!
+//! Block order is load-bearing: the framework hands out virtio-blk device
+//! letters in attach order, so the layout matches every other backend —
+//! rootfs `/dev/vda`, rootfs verity `/dev/vdb`, runtime overlay
+//! `/dev/vdc`, overlay verity `/dev/vdd`. Verity sidecars are marked
+//! `device_only`: they are not filesystems and must never become an OCI
+//! runtime mount.
+
+use std::path::{Path, PathBuf};
+
+use mvm_core::vm_backend::{VmStartConfig, VmVolumeKind};
+use serde::{Deserialize, Serialize};
+
+use crate::apple_container_backend::AppleContainerError;
+
+/// The container's root filesystem (mounted at the guest root).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootfsSpec {
+    pub path: PathBuf,
+    pub read_only: bool,
+}
+
+/// One extra virtio-blk device, in attach order (`/dev/vdb` onward).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockSpec {
+    pub path: PathBuf,
+    pub read_only: bool,
+    /// True for blocks that are not mountable filesystems (dm-verity hash
+    /// sidecars): the shim defers their attach rather than letting the OCI
+    /// runtime try — and fail — to mount them.
+    pub device_only: bool,
+}
+
+/// One virtio-fs share. `tag` is mvm's activation-contract tag
+/// (`uvol{idx}`); `guest_path` is where the framework mounts the share.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShareSpec {
+    pub tag: String,
+    pub host_path: PathBuf,
+    pub guest_path: String,
+    pub read_only: bool,
+}
+
+/// The shim's boot description, serialized as snake_case JSON.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppleContainerSpec {
+    pub vm_name: String,
+    pub kernel_path: PathBuf,
+    pub initfs_path: PathBuf,
+    pub cpus: u32,
+    pub memory_mib: u64,
+    pub rootfs: RootfsSpec,
+    #[serde(default)]
+    pub blocks: Vec<BlockSpec>,
+    #[serde(default)]
+    pub virtiofs_shares: Vec<ShareSpec>,
+    pub control_socket: PathBuf,
+    pub agent_port: u32,
+    pub boot_log_dir: PathBuf,
+}
+
+/// Everything the spec mapping needs that does not come from the launch
+/// config: the resolved artifact paths (framework kernel + initfs) and the
+/// host paths the shim binds (control socket, boot-log dir). Grouped so
+/// the mapping takes one value instead of a positional list.
+#[derive(Debug, Clone)]
+pub struct SpecInputs<'a> {
+    pub kernel_path: &'a Path,
+    pub initfs_path: &'a Path,
+    pub control_socket: &'a Path,
+    pub boot_log_dir: &'a Path,
+    /// The guest-agent vsock port the shim reports and the backend dials.
+    pub agent_port: u32,
+}
+
+/// Refuse every launch shape this backend cannot honestly boot, before
+/// any artifact resolution or side effect. Mirrors the wasm/docker tiers'
+/// reject-then-build discipline: each check names the limitation.
+pub fn reject_unsupported_start_config(
+    config: &VmStartConfig,
+) -> std::result::Result<(), AppleContainerError> {
+    if config.initrd_path.is_some() {
+        return Err(AppleContainerError::NotImplemented {
+            operation: "boot a caller-supplied initramfs (the framework initfs is fixed)",
+            milestone: "a custom-initfs artifact channel",
+        });
+    }
+    if config.virtiofs_root.is_some() {
+        return Err(AppleContainerError::VirtiofsRootNotSupported);
+    }
+    if let Some(volume) = config
+        .volumes
+        .iter()
+        .find(|v| matches!(v.kind, VmVolumeKind::Disk))
+    {
+        return Err(AppleContainerError::DiskVolumeNotSupported {
+            host: volume.host.clone(),
+        });
+    }
+    if config.dev_console {
+        return Err(AppleContainerError::NotImplemented {
+            operation: "attach an interactive console",
+            milestone: "a console transport through the shim",
+        });
+    }
+    if config.rootfs_path.trim().is_empty() {
+        return Err(AppleContainerError::NotImplemented {
+            operation: "boot without a rootfs",
+            milestone: "an initramfs-only boot path",
+        });
+    }
+    Ok(())
+}
+
+/// Map an admitted launch config to the shim's boot spec. Pure — the
+/// caller has already run [`reject_unsupported_start_config`] and resolved
+/// the artifact paths in `inputs`.
+pub fn build_apple_container_spec(
+    config: &VmStartConfig,
+    inputs: &SpecInputs<'_>,
+) -> AppleContainerSpec {
+    let rootfs = RootfsSpec {
+        path: PathBuf::from(&config.rootfs_path),
+        // A workload rootfs is sealed: always hypervisor-enforced read-only.
+        read_only: true,
+    };
+
+    let mut blocks = Vec::new();
+    if let Some(verity) = &config.verity_path {
+        blocks.push(BlockSpec {
+            path: PathBuf::from(verity),
+            read_only: true,
+            device_only: true,
+        });
+    }
+    // The runtime overlay rides only as a complete triple — the same
+    // all-three-or-none rule the other backends apply.
+    if let (Some(overlay), Some(overlay_verity), Some(_)) = (
+        &config.runtime_overlay_path,
+        &config.runtime_overlay_verity_path,
+        &config.runtime_overlay_roothash,
+    ) {
+        blocks.push(BlockSpec {
+            path: PathBuf::from(overlay),
+            read_only: true,
+            device_only: false,
+        });
+        blocks.push(BlockSpec {
+            path: PathBuf::from(overlay_verity),
+            read_only: true,
+            device_only: true,
+        });
+    }
+
+    let virtiofs_shares = config
+        .volumes
+        .iter()
+        .enumerate()
+        .filter(|(_, v)| matches!(v.kind, VmVolumeKind::DirShare))
+        .map(|(idx, v)| ShareSpec {
+            tag: format!("uvol{idx}"),
+            host_path: PathBuf::from(&v.host),
+            guest_path: v.guest.clone(),
+            read_only: v.read_only,
+        })
+        .collect();
+
+    AppleContainerSpec {
+        vm_name: config.name.clone(),
+        kernel_path: inputs.kernel_path.to_path_buf(),
+        initfs_path: inputs.initfs_path.to_path_buf(),
+        cpus: config.cpus,
+        memory_mib: u64::from(config.memory_mib),
+        rootfs,
+        blocks,
+        virtiofs_shares,
+        control_socket: inputs.control_socket.to_path_buf(),
+        agent_port: inputs.agent_port,
+        boot_log_dir: inputs.boot_log_dir.to_path_buf(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::vm_backend::{RuntimeSourcePolicy, VmVolume};
+
+    fn cfg(name: &str) -> VmStartConfig {
+        VmStartConfig {
+            name: name.to_string(),
+            rootfs_path: "/img/rootfs.ext4".into(),
+            ..Default::default()
+        }
+    }
+
+    fn inputs() -> SpecInputs<'static> {
+        SpecInputs {
+            kernel_path: Path::new("/cache/vmlinux"),
+            initfs_path: Path::new("/cache/initfs.ext4"),
+            control_socket: Path::new("/state/x/ac-shim.sock"),
+            boot_log_dir: Path::new("/state/x/bootlog"),
+            agent_port: 5252,
+        }
+    }
+
+    fn dir_share(host: &str, guest: &str, read_only: bool) -> VmVolume {
+        VmVolume {
+            host: host.into(),
+            guest: guest.into(),
+            size: String::new(),
+            read_only,
+            kind: VmVolumeKind::DirShare,
+            encrypted: false,
+        }
+    }
+
+    fn disk_volume(host: &str) -> VmVolume {
+        VmVolume {
+            host: host.into(),
+            guest: "/mnt/disk".into(),
+            size: "1G".into(),
+            read_only: false,
+            kind: VmVolumeKind::Disk,
+            encrypted: false,
+        }
+    }
+
+    #[test]
+    fn reject_initrd_and_virtiofs_root_and_disk_volumes_and_console_and_empty_rootfs() {
+        let mut c = cfg("x");
+        c.initrd_path = Some("/img/initrd".into());
+        assert!(matches!(
+            reject_unsupported_start_config(&c),
+            Err(AppleContainerError::NotImplemented { .. })
+        ));
+
+        let mut c = cfg("x");
+        c.virtiofs_root = Some("/host/oci".into());
+        assert_eq!(
+            reject_unsupported_start_config(&c),
+            Err(AppleContainerError::VirtiofsRootNotSupported)
+        );
+
+        let mut c = cfg("x");
+        c.volumes = vec![disk_volume("/host/disk.img")];
+        assert_eq!(
+            reject_unsupported_start_config(&c),
+            Err(AppleContainerError::DiskVolumeNotSupported {
+                host: "/host/disk.img".into()
+            })
+        );
+
+        let mut c = cfg("x");
+        c.dev_console = true;
+        assert!(matches!(
+            reject_unsupported_start_config(&c),
+            Err(AppleContainerError::NotImplemented { .. })
+        ));
+
+        let mut c = cfg("x");
+        c.rootfs_path = "  ".into();
+        assert!(matches!(
+            reject_unsupported_start_config(&c),
+            Err(AppleContainerError::NotImplemented { .. })
+        ));
+    }
+
+    #[test]
+    fn plain_config_maps_to_rootfs_only() {
+        let spec = build_apple_container_spec(&cfg("plain"), &inputs());
+        assert_eq!(spec.vm_name, "plain");
+        assert_eq!(spec.rootfs.path, PathBuf::from("/img/rootfs.ext4"));
+        assert!(spec.rootfs.read_only, "workload rootfs is sealed ro");
+        assert!(spec.blocks.is_empty());
+        assert!(spec.virtiofs_shares.is_empty());
+        assert_eq!(spec.kernel_path, PathBuf::from("/cache/vmlinux"));
+        assert_eq!(spec.initfs_path, PathBuf::from("/cache/initfs.ext4"));
+        assert_eq!(spec.control_socket, PathBuf::from("/state/x/ac-shim.sock"));
+        assert_eq!(spec.agent_port, 5252);
+    }
+
+    #[test]
+    fn sealed_config_orders_verity_then_overlay_then_overlay_verity() {
+        let mut c = cfg("sealed");
+        c.verity_path = Some("/img/rootfs.verity".into());
+        c.roothash = Some("ab".repeat(32));
+        c.runtime_overlay_path = Some("/img/runtime.ext4".into());
+        c.runtime_overlay_verity_path = Some("/img/runtime.verity".into());
+        c.runtime_overlay_roothash = Some("cd".repeat(32));
+        c.runtime_source_policy = RuntimeSourcePolicy::RequiredOverlay;
+
+        let spec = build_apple_container_spec(&c, &inputs());
+        let paths: Vec<&Path> = spec.blocks.iter().map(|b| b.path.as_path()).collect();
+        assert_eq!(
+            paths,
+            vec![
+                Path::new("/img/rootfs.verity"),
+                Path::new("/img/runtime.ext4"),
+                Path::new("/img/runtime.verity"),
+            ],
+            "verity, overlay, overlay-verity = vdb, vdc, vdd in attach order"
+        );
+        assert!(spec.blocks[0].device_only);
+        assert!(!spec.blocks[1].device_only, "the overlay is mountable ext4");
+        assert!(spec.blocks[2].device_only);
+        assert!(spec.blocks.iter().all(|b| b.read_only));
+    }
+
+    #[test]
+    fn partial_overlay_triple_is_treated_as_no_overlay() {
+        let mut c = cfg("partial");
+        c.runtime_overlay_path = Some("/img/runtime.ext4".into());
+        c.runtime_overlay_verity_path = Some("/img/runtime.verity".into());
+        let spec = build_apple_container_spec(&c, &inputs());
+        assert!(spec.blocks.is_empty());
+    }
+
+    #[test]
+    fn dir_share_volumes_map_to_shares_with_tags_and_ro_honored() {
+        let mut c = cfg("vols");
+        c.volumes = vec![
+            dir_share("/host/share", "/mnt/share", true),
+            dir_share("/host/data", "/mnt/data", false),
+        ];
+        let spec = build_apple_container_spec(&c, &inputs());
+        assert_eq!(spec.virtiofs_shares.len(), 2);
+        assert_eq!(spec.virtiofs_shares[0].tag, "uvol0");
+        assert_eq!(
+            spec.virtiofs_shares[0].host_path,
+            PathBuf::from("/host/share")
+        );
+        assert_eq!(spec.virtiofs_shares[0].guest_path, "/mnt/share");
+        assert!(spec.virtiofs_shares[0].read_only);
+        assert_eq!(spec.virtiofs_shares[1].tag, "uvol1");
+        assert!(!spec.virtiofs_shares[1].read_only);
+    }
+
+    #[test]
+    fn spec_json_uses_snake_case_keys_the_swift_side_decodes() {
+        let mut c = cfg("wire");
+        c.verity_path = Some("/img/rootfs.verity".into());
+        c.volumes = vec![dir_share("/host/share", "/mnt/share", true)];
+        let spec = build_apple_container_spec(&c, &inputs());
+        let json = serde_json::to_string(&spec).unwrap();
+        for key in [
+            "vm_name",
+            "kernel_path",
+            "initfs_path",
+            "memory_mib",
+            "read_only",
+            "device_only",
+            "virtiofs_shares",
+            "host_path",
+            "guest_path",
+            "control_socket",
+            "agent_port",
+            "boot_log_dir",
+        ] {
+            assert!(
+                json.contains(&format!("\"{key}\"")),
+                "missing key {key}: {json}"
+            );
+        }
+    }
+}

--- a/crates/mvm-runtime/src/apple_container_backend.rs
+++ b/crates/mvm-runtime/src/apple_container_backend.rs
@@ -1,44 +1,62 @@
-//! Apple Containerization-framework backend — registered, honest skeleton.
+//! Apple Containerization-framework backend — shim-wired boot path.
 //!
-//! `AppleContainerBackend` is the selectable front door for running mvm
-//! workloads inside Apple's Containerization-framework VMs: lightweight,
-//! hardware-isolated Linux VMs whose kernel boot and guest PID 1 (`vminitd`,
-//! serving gRPC on vsock port 1024) are owned by Apple's Swift-only
-//! framework. Because the framework owns the boot path, the mvm initramfs
-//! does not apply verbatim here — activation will ride `vminitd`'s existing
-//! gRPC API instead, while the guest agent binary, the mount logic, the
-//! uid-901 privilege drop, the `NotActivated` RPC gate, and the operational
-//! RPC surface stay shared verbatim with every other backend.
+//! `AppleContainerBackend` runs mvm workloads inside Apple's
+//! Containerization-framework VMs: lightweight, hardware-isolated Linux
+//! VMs whose kernel boot and guest PID 1 (`vminitd`, serving gRPC on vsock
+//! port 1024) are owned by Apple's Swift-only framework. Because the
+//! framework owns the boot path, the mvm initramfs does not apply verbatim
+//! here — activation rides `vminitd`'s API instead, while the guest agent
+//! binary, the mount logic, the uid-901 privilege drop, the `NotActivated`
+//! RPC gate, and the operational RPC surface stay shared verbatim with
+//! every other backend.
 //!
-//! This is the skeleton stage of that backend: it is registered in the
-//! catalog and selectable via `--hypervisor apple-container`, but no
-//! Containerization-framework integration exists yet, so **every operation
-//! that would touch a real VM fails closed** with a typed
-//! [`AppleContainerError`] naming the milestone that provides it — mirroring
-//! how [`crate::wasm_backend::WasmBackend`] surfaces "not available" at
-//! first use rather than at construction. Construction itself does no I/O
-//! and touches no framework state, so the catalog/dispatch machinery every
-//! other backend goes through stays uniform.
+//! This stage wires the real boot machinery through the container shim
+//! (`swift/mvm-container-shim`, one detached process per VM, mirroring the
+//! other per-VM supervisors): artifact resolution with typed
+//! `ArtifactMissing` errors, spec mapping, shim spawn, and guest file
+//! injection (the static musl guest agent and the serialized
+//! `ActivateEnvironment` every other backend builds). What is still
+//! fail-closed is the agent bring-up itself: the guest agent has no
+//! activation-file entry point yet, so `start_with_mode` injects
+//! everything and then returns a typed [`AppleContainerError`] naming the
+//! milestone — after tearing the VM down, so a half-boot never lingers.
 //!
-//! Honest reporting, not silent degradation: `capabilities()` advertises no
-//! snapshot, no standby pool, and no warm start; `security_profile()`
-//! reports every numbered claim as `DoesNotHold` until the boot path lands
-//! and can actually enforce them; and the backend is opt-in only —
-//! `AnyBackend::auto_select` never returns this kind. The trivially-true
-//! answers (`stop`, `stop_all`, `list`, `status`) are honest because
-//! `start` cannot succeed yet: nothing can be running.
+//! Honest reporting, unchanged from the skeleton: `capabilities()` and
+//! `security_profile()` still report no snapshot, no standby pool, and
+//! every numbered claim as `DoesNotHold` until a workload actually boots
+//! and can enforce them; the backend stays opt-in only —
+//! `AnyBackend::auto_select` never returns this kind.
 
-use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use mvm_core::config::{mvm_cache_dir, vm_state_dir, vms_dir};
 use mvm_core::vm_backend::{
     BackendKind, BackendSecurityProfile, ClaimStatus, LayerCoverage, SnapshotCapability, StartMode,
     VmBackend, VmCapabilities, VmExitStatus, VmId, VmInfo, VmStartConfig, VmStatus,
 };
 use thiserror::Error;
 
-/// Typed, fail-closed errors for requests this backend cannot satisfy yet.
-/// Every error names the operation that was refused and the milestone that
-/// provides it, rather than silently falling back to another backend or
-/// panicking — see the module docs.
+use crate::apple_container::shim_client::{ShimClient, spawn_shim};
+use crate::apple_container::spec::{
+    AppleContainerSpec, SpecInputs, build_apple_container_spec, reject_unsupported_start_config,
+};
+
+/// Per-VM shim state-file names under `vm_state_dir(name)`.
+const SHIM_PID_FILE: &str = "ac-shim.pid";
+const SHIM_SPEC_FILE: &str = "ac-shim-spec.json";
+const SHIM_CONTROL_SOCKET: &str = "ac-shim.sock";
+const SHIM_BOOT_LOG_DIR: &str = "bootlog";
+
+/// Guest paths the injection writes.
+const GUEST_RUN_DIR: &str = "/run/mvm";
+const GUEST_AGENT_PATH: &str = "/run/mvm/mvm-guest-agent";
+const GUEST_ACTIVATION_PATH: &str = "/run/mvm/activation.json";
+
+/// Typed, fail-closed errors for requests this backend cannot satisfy.
+/// Every error names the operation refused and the missing piece, rather
+/// than silently falling back to another backend or panicking — see the
+/// module docs.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum AppleContainerError {
     /// The operation is part of the backend's design but has no
@@ -48,19 +66,182 @@ pub enum AppleContainerError {
         operation: &'static str,
         milestone: &'static str,
     },
+
+    /// A boot artifact is absent from the cache; `hint` names the exact
+    /// fetch/build step that provides it.
+    #[error("apple-container artifact missing: {what} at {path} — {hint}")]
+    ArtifactMissing {
+        what: &'static str,
+        path: String,
+        hint: &'static str,
+    },
+
+    #[error(
+        "apple-container backend cannot attach block volume '{host}' — the framework \
+         attaches block devices only; use a directory-share volume instead"
+    )]
+    DiskVolumeNotSupported { host: String },
+
+    #[error(
+        "apple-container backend has no virtiofs-root boot — the framework boots a block \
+         rootfs or shares host directories; select a microVM backend for virtiofs-root"
+    )]
+    VirtiofsRootNotSupported,
+
+    /// The shim failed or could not be reached for `op`.
+    #[error("apple-container shim {op} failed: {reason}")]
+    Shim { op: &'static str, reason: String },
 }
 
-/// Apple Containerization-framework backend skeleton. See the module docs
-/// for the fail-closed contract and the opt-in/honest-reporting rules.
+/// Apple Containerization-framework backend. See the module docs for what
+/// is wired and what still fails closed.
 #[derive(Debug, Default, Clone)]
 pub struct AppleContainerBackend;
 
 impl AppleContainerBackend {
-    /// Construct the backend skeleton. Side-effect free — no
-    /// Containerization-framework symbol is touched and no VM state is read.
+    /// Construct the backend. Side-effect free — no Containerization
+    /// symbol is touched and no VM state is read.
     pub fn new() -> Self {
         Self
     }
+}
+
+/// The shim cache root: `<mvm_cache_dir>/apple-container`.
+fn apple_container_cache_dir() -> PathBuf {
+    PathBuf::from(mvm_cache_dir()).join("apple-container")
+}
+
+/// Resolve the shim binary, failing closed with the exact build step.
+fn resolve_shim_binary() -> std::result::Result<PathBuf, AppleContainerError> {
+    let path = apple_container_cache_dir().join("bin/mvm-container-shim");
+    if path.is_file() {
+        return Ok(path);
+    }
+    Err(AppleContainerError::ArtifactMissing {
+        what: "the container shim",
+        path: path.display().to_string(),
+        hint: "run `just apple-container-shim` to build and codesign it",
+    })
+}
+
+/// Resolve the framework kernel: the launch's explicit kernel when given
+/// (the CLI-resolved workload kernel), else the cached artifact.
+fn resolve_kernel(config: &VmStartConfig) -> std::result::Result<PathBuf, AppleContainerError> {
+    if let Some(k) = config.kernel_path.as_deref() {
+        let path = PathBuf::from(k);
+        if path.is_file() {
+            return Ok(path);
+        }
+    }
+    let path = apple_container_cache_dir().join("vmlinux");
+    if path.is_file() {
+        return Ok(path);
+    }
+    Err(AppleContainerError::ArtifactMissing {
+        what: "the framework kernel",
+        path: path.display().to_string(),
+        hint: "run `mvmctl kernel build --which workload` and copy the artifact here",
+    })
+}
+
+/// Resolve the framework initfs (carrying `/sbin/vminitd` + `/sbin/vmexec`).
+fn resolve_initfs() -> std::result::Result<PathBuf, AppleContainerError> {
+    let path = apple_container_cache_dir().join("initfs.ext4");
+    if path.is_file() {
+        return Ok(path);
+    }
+    Err(AppleContainerError::ArtifactMissing {
+        what: "the framework initfs",
+        path: path.display().to_string(),
+        hint: "build it with `make init` in apple/containerization (needs the Swift static Linux SDK) and copy it here",
+    })
+}
+
+/// Resolve the static musl guest-agent binary through the shared
+/// resolve-or-build helper (never a forked copy).
+fn resolve_guest_agent_binary() -> Result<PathBuf> {
+    let cache_root = PathBuf::from(mvm_cache_dir());
+    let binaries = mvm_build::run_image::resolve_guest_binaries(&cache_root, None)
+        .context("resolve the mvm-guest-agent binary for the container")?;
+    Ok(binaries.agent)
+}
+
+/// The per-VM shim paths, derived from the state dir in one place so the
+/// spawn path, the lifecycle ops, and tests cannot drift.
+#[derive(Debug, Clone)]
+struct ShimPaths {
+    state_dir: PathBuf,
+    pid_file: PathBuf,
+    spec_file: PathBuf,
+    control_socket: PathBuf,
+    boot_log_dir: PathBuf,
+}
+
+impl ShimPaths {
+    fn for_vm(name: &str) -> Self {
+        let state_dir = vm_state_dir(name);
+        Self {
+            pid_file: state_dir.join(SHIM_PID_FILE),
+            spec_file: state_dir.join(SHIM_SPEC_FILE),
+            control_socket: state_dir.join(SHIM_CONTROL_SOCKET),
+            boot_log_dir: state_dir.join(SHIM_BOOT_LOG_DIR),
+            state_dir,
+        }
+    }
+}
+
+/// Connect to a running VM's shim, if its pid file says one exists. `None`
+/// when nothing was started (a trivially-honest answer follows).
+fn connect_shim(paths: &ShimPaths) -> Option<ShimClient> {
+    if !paths.pid_file.is_file() {
+        return None;
+    }
+    ShimClient::connect(&paths.control_socket, std::time::Duration::from_secs(2)).ok()
+}
+
+/// Write the spec JSON, spawn the shim, and prove it answers.
+fn boot_shim(paths: &ShimPaths, spec: &AppleContainerSpec) -> Result<ShimClient> {
+    let shim_bin = resolve_shim_binary()?;
+    let json = serde_json::to_string_pretty(spec).context("serialize container spec")?;
+    std::fs::write(&paths.spec_file, json)
+        .map_err(|e| anyhow::anyhow!("write {}: {e}", paths.spec_file.display()))?;
+    let mut client = spawn_shim(
+        &shim_bin,
+        &paths.spec_file,
+        &paths.control_socket,
+        &paths.pid_file,
+    )?;
+    client.ping()?;
+    Ok(client)
+}
+
+/// Inject everything the guest needs: the run dir, the static guest-agent
+/// binary (executable), and the serialized activation message every other
+/// backend builds. The shim streams each file whole over the container's
+/// copy channel, so no chunking is needed even for the ~1 MiB agent.
+fn inject_guest_files(
+    client: &mut ShimClient,
+    agent_binary: &Path,
+    activation_json: &[u8],
+) -> Result<(), AppleContainerError> {
+    client.mkdir(GUEST_RUN_DIR, true, 0o700)?;
+    let agent_bytes = std::fs::read(agent_binary).map_err(|e| AppleContainerError::Shim {
+        op: "read guest agent",
+        reason: format!("read {}: {e}", agent_binary.display()),
+    })?;
+    client.write_file(GUEST_AGENT_PATH, &agent_bytes, 0o755)?;
+    client.write_file(GUEST_ACTIVATION_PATH, activation_json, 0o644)?;
+    Ok(())
+}
+
+/// Tear down a just-booted VM when a later step fails closed: ask the shim
+/// to stop its container (which also makes the shim exit), then drop the
+/// shim's pid/spec sidecars so a retry re-boots cleanly.
+fn teardown_shim(client: ShimClient, paths: &ShimPaths) {
+    let mut client = client;
+    let _ = client.stop();
+    let _ = std::fs::remove_file(&paths.pid_file);
+    let _ = std::fs::remove_file(&paths.spec_file);
 }
 
 impl VmBackend for AppleContainerBackend {
@@ -74,10 +255,9 @@ impl VmBackend for AppleContainerBackend {
 
     fn capabilities(&self) -> VmCapabilities {
         VmCapabilities {
-            // Framework VMs will route egress through the same host-mediated
-            // vsock endpoint seam every other backend uses — no routable
-            // guest NIC. Until the boot path lands this is vacuously true:
-            // the skeleton boots nothing, so nothing can reach a network.
+            // Framework VMs route egress through the same host-mediated
+            // endpoint seam every other backend uses — no routable guest
+            // NIC (the shim attaches no network interface).
             no_routable_guest_nic: true,
             snapshot_capability: SnapshotCapability::Unsupported,
             standby_pool: false,
@@ -85,26 +265,76 @@ impl VmBackend for AppleContainerBackend {
         }
     }
 
-    fn start_with_mode(&self, _config: &VmStartConfig, _mode: StartMode) -> Result<VmId> {
+    fn start_with_mode(&self, config: &VmStartConfig, _mode: StartMode) -> Result<VmId> {
+        reject_unsupported_start_config(config)?;
+        let kernel = resolve_kernel(config)?;
+        let initfs = resolve_initfs()?;
+        let agent_binary = resolve_guest_agent_binary()?;
+
+        let paths = ShimPaths::for_vm(&config.name);
+        std::fs::create_dir_all(&paths.state_dir)
+            .map_err(|e| anyhow::anyhow!("create state dir {}: {e}", paths.state_dir.display()))?;
+        std::fs::create_dir_all(&paths.boot_log_dir).map_err(|e| {
+            anyhow::anyhow!("create boot log dir {}: {e}", paths.boot_log_dir.display())
+        })?;
+
+        let spec = build_apple_container_spec(
+            config,
+            &SpecInputs {
+                kernel_path: &kernel,
+                initfs_path: &initfs,
+                control_socket: &paths.control_socket,
+                boot_log_dir: &paths.boot_log_dir,
+                agent_port: crate::vm::vminitd_client::GUEST_AGENT_VSOCK_PORT,
+            },
+        );
+        let activation = crate::microvm::build_activation_environment(config)?;
+        let activation_json =
+            serde_json::to_vec_pretty(&activation).context("serialize activation environment")?;
+
+        let mut client = match boot_shim(&paths, &spec) {
+            Ok(client) => client,
+            Err(e) => {
+                teardown_shim_files_only(&paths);
+                return Err(e);
+            }
+        };
+        if let Err(e) = inject_guest_files(&mut client, &agent_binary, &activation_json) {
+            teardown_shim(client, &paths);
+            return Err(e.into());
+        }
+
+        // Everything the guest needs is in place; what the guest agent
+        // cannot yet do is consume it — it has no activation-file entry
+        // point. Tear the VM down so a half-boot never lingers silently,
+        // then fail closed naming the milestone.
+        teardown_shim(client, &paths);
         Err(AppleContainerError::NotImplemented {
-            operation: "start a container VM",
-            milestone: "the Containerization Swift shim (stage 2)",
+            operation: "launch the guest agent inside the container VM",
+            milestone: "the guest-agent activation-file entry point (stage 4)",
         }
         .into())
     }
 
-    fn wait(&self, _id: &VmId) -> Result<VmExitStatus> {
-        Err(AppleContainerError::NotImplemented {
-            operation: "wait on a container VM",
-            milestone: "the vminitd gRPC transport (stage 3)",
+    fn wait(&self, id: &VmId) -> Result<VmExitStatus> {
+        let paths = ShimPaths::for_vm(&id.0);
+        match connect_shim(&paths) {
+            Some(mut client) => {
+                let code = client.wait()?;
+                Ok(VmExitStatus {
+                    code: i32::try_from(code).ok(),
+                    success: code == 0,
+                })
+            }
+            // Nothing was ever started for this VM.
+            None => Ok(VmExitStatus::UNKNOWN),
         }
-        .into())
     }
 
     fn pause(&self, _id: &VmId) -> Result<()> {
         Err(AppleContainerError::NotImplemented {
             operation: "pause a container VM",
-            milestone: "the Containerization Swift shim (stage 2)",
+            milestone: "a Containerization pause/resume surface (none exists yet)",
         }
         .into())
     }
@@ -112,75 +342,149 @@ impl VmBackend for AppleContainerBackend {
     fn resume(&self, _id: &VmId) -> Result<()> {
         Err(AppleContainerError::NotImplemented {
             operation: "resume a container VM",
-            milestone: "the Containerization Swift shim (stage 2)",
+            milestone: "a Containerization pause/resume surface (none exists yet)",
         }
         .into())
     }
 
-    fn stop(&self, _id: &VmId) -> Result<()> {
-        // Honest trivial answer: `start` cannot succeed yet, so no container
-        // VM this backend owns can be running.
+    fn stop(&self, id: &VmId) -> Result<()> {
+        let paths = ShimPaths::for_vm(&id.0);
+        if let Some(mut client) = connect_shim(&paths) {
+            // Graceful stop first; escalate to a kill if the shim's own
+            // teardown path fails (the container must not outlive the op).
+            if client.stop().is_err() {
+                let _ = client.kill();
+            }
+        } else if let Some(pid) = crate::qemu::read_pid(&paths.pid_file) {
+            // The control socket is gone but the shim may still be up:
+            // signal it; the shim stops its VM on exit.
+            crate::qemu::send_signal(pid, libc::SIGTERM);
+        }
+        let _ = std::fs::remove_file(&paths.pid_file);
+        let _ = std::fs::remove_file(&paths.spec_file);
         Ok(())
     }
 
     fn stop_all(&self) -> Result<()> {
-        Ok(())
+        let mut last_err = None;
+        for name in shim_vm_names() {
+            if let Err(e) = self.stop(&VmId(name.clone())) {
+                tracing::warn!(name, error = %e, "apple-container stop_all: stop failed");
+                last_err = Some(e);
+            }
+        }
+        last_err.map_or(Ok(()), Err)
     }
 
-    fn status(&self, _id: &VmId) -> Result<VmStatus> {
-        // No boot path exists, so every VM is trivially stopped.
-        Ok(VmStatus::Stopped)
+    fn status(&self, id: &VmId) -> Result<VmStatus> {
+        let paths = ShimPaths::for_vm(&id.0);
+        Ok(match crate::qemu::read_pid(&paths.pid_file) {
+            Some(pid) if crate::qemu::pid_alive(pid) => VmStatus::Running,
+            _ => VmStatus::Stopped,
+        })
     }
 
     fn list(&self) -> Result<Vec<VmInfo>> {
-        Ok(Vec::new())
+        let mut vms = Vec::new();
+        for name in shim_vm_names() {
+            let paths = ShimPaths::for_vm(&name);
+            let status = match crate::qemu::read_pid(&paths.pid_file) {
+                Some(pid) if crate::qemu::pid_alive(pid) => VmStatus::Running,
+                _ => VmStatus::Stopped,
+            };
+            vms.push(VmInfo {
+                id: VmId(name.clone()),
+                name,
+                status,
+                guest_ip: None,
+                cpus: 0,
+                memory_mib: 0,
+                profile: None,
+                revision: None,
+                flake_ref: None,
+                ports: Vec::new(),
+            });
+        }
+        Ok(vms)
     }
 
-    fn logs(&self, _id: &VmId, _lines: u32, _hypervisor: bool) -> Result<String> {
-        Err(AppleContainerError::NotImplemented {
-            operation: "read container VM logs",
-            milestone: "the vminitd gRPC transport (stage 3)",
-        }
-        .into())
+    fn logs(&self, id: &VmId, lines: u32, _hypervisor: bool) -> Result<String> {
+        // One boot stream (the framework's serial log), whether the caller
+        // asked for the "hypervisor" log or not.
+        let log = vm_state_dir(&id.0).join(SHIM_BOOT_LOG_DIR).join("boot.log");
+        let body = std::fs::read_to_string(&log).unwrap_or_default();
+        Ok(tail(&body, lines as usize))
     }
 
     fn is_available(&self) -> Result<bool> {
-        // No boot path exists on any host yet; reporting `true` would let a
-        // probe conclude a workload could start here.
-        Ok(false)
+        Ok(cfg!(target_os = "macos") && resolve_shim_binary().is_ok())
     }
 
     fn install(&self) -> Result<()> {
         Err(AppleContainerError::NotImplemented {
             operation: "install the Apple Containerization runtime",
-            milestone: "the Containerization Swift shim (stage 2)",
+            milestone: "run `just apple-container-shim` plus the kernel/initfs artifact fetches (see the ArtifactMissing hints)",
         }
         .into())
     }
 
     fn security_profile(&self) -> BackendSecurityProfile {
-        // Every numbered claim reports `DoesNotHold` until the boot path
-        // lands and can actually enforce them — the skeleton booted nothing,
-        // so nothing here may be claimed. Apple's framework VMs are
-        // hardware-isolated lightweight Linux VMs, which is the Tier 2
-        // shape this backend is being built toward; the tier string says so
-        // honestly rather than rounding the posture up.
+        // Every numbered claim still reports `DoesNotHold`: the boot
+        // machinery is wired through vminitd injection, but no workload has
+        // ever booted to activation, so nothing here may be claimed. The
+        // tier string keeps saying so honestly.
         BackendSecurityProfile {
             claims: [ClaimStatus::DoesNotHold; 7],
             layer_coverage: LayerCoverage::default(),
-            tier: "Tier 2 (Apple Containerization framework; skeleton — no boot path yet)",
+            tier: "Tier 2 (Apple Containerization framework; boot path wired, no agent bring-up yet)",
             notes: &[
                 "Apple Containerization-framework VMs are hardware-isolated lightweight \
                  Linux VMs; the framework owns the kernel boot and `vminitd` as guest PID 1.",
-                "Activation will ride vminitd's gRPC API (vsock port 1024) instead of an \
-                 mvm initramfs; the guest agent, mount logic, uid-901 drop, and RPC gate \
-                 stay shared with every other backend.",
-                "Skeleton: every claim reports DoesNotHold until the boot path lands — \
+                "The container shim boots the framework VM and injects the static guest \
+                 agent plus the serialized activation message through vminitd's API (vsock \
+                 port 1024); the agent's own activation entry point is the remaining gap.",
+                "Every claim reports DoesNotHold until a workload boots to activation — \
                  nothing here may carry an untrusted workload yet.",
                 "Opt-in only; never selected by auto-detect.",
             ],
         }
     }
+}
+
+/// Names of VMs with a shim pid file under `vms_dir()`. Directory scan
+/// keyed on the pid file, mirroring the QEMU backend's list convention.
+fn shim_vm_names() -> Vec<String> {
+    let root = vms_dir();
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut names = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() || !path.join(SHIM_PID_FILE).exists() {
+            continue;
+        }
+        if let Ok(name) = entry.file_name().into_string() {
+            names.push(name);
+        }
+    }
+    names.sort();
+    names
+}
+
+/// Roll back only the on-disk sidecars when the shim never came up (nothing
+/// to stop through the control socket).
+fn teardown_shim_files_only(paths: &ShimPaths) {
+    let _ = std::fs::remove_file(&paths.pid_file);
+    let _ = std::fs::remove_file(&paths.spec_file);
+}
+
+fn tail(s: &str, n: usize) -> String {
+    if n == 0 {
+        return String::new();
+    }
+    let lines: Vec<&str> = s.lines().collect();
+    lines[lines.len().saturating_sub(n)..].join("\n")
 }
 
 #[cfg(test)]
@@ -197,7 +501,7 @@ mod tests {
 
     /// Extract the typed error from the `anyhow` wrapper the trait returns,
     /// so tests assert the exact variant, not a substring.
-    fn not_implemented(err: &anyhow::Error) -> &AppleContainerError {
+    fn typed(err: &anyhow::Error) -> &AppleContainerError {
         err.downcast_ref::<AppleContainerError>()
             .expect("apple-container failures must be the typed error")
     }
@@ -224,147 +528,175 @@ mod tests {
 
     #[test]
     fn auto_select_never_returns_apple_container() {
-        // Opt-in only, same discipline as the wasm tier: `auto_select`'s
-        // ladder constructs Firecracker/Hvf/Libkrun and nothing else, so this
-        // holds on every platform the ladder can resolve to.
         assert_ne!(
             AnyBackend::auto_select().kind(),
             BackendKind::AppleContainer,
-            "auto_select must never fall through to the apple-container skeleton"
+            "auto_select must never fall through to the apple-container tier"
         );
     }
 
     #[test]
-    fn capabilities_are_honest_about_lacking_a_boot_path() {
+    fn capabilities_are_honest() {
         let caps = AppleContainerBackend::new().capabilities();
         assert!(!caps.pause_resume);
         assert!(!caps.snapshots);
         assert_eq!(caps.snapshot_capability, SnapshotCapability::Unsupported);
         assert!(!caps.standby_pool);
-        assert!(!caps.vsock);
         assert!(!caps.tap_networking);
         assert!(!caps.balloon);
-        assert!(!caps.fs_quick_checkpoint);
-        assert!(!caps.host_vsock_proxy);
         assert!(!caps.pty_exec);
         assert!(!caps.production_ssh);
         assert!(caps.no_routable_guest_nic);
     }
 
     #[test]
-    fn security_profile_carries_zero_numbered_claims() {
+    fn security_profile_still_carries_zero_numbered_claims() {
         let profile = AppleContainerBackend::new().security_profile();
         assert!(
             profile
                 .claims
                 .iter()
                 .all(|c| matches!(c, ClaimStatus::DoesNotHold)),
-            "the skeleton must not claim any numbered security guarantee"
+            "nothing may be claimed before a workload boots to activation"
         );
         assert_eq!(profile.dropped_claims(), vec![1, 2, 3, 4, 5, 6, 7]);
-        assert_eq!(profile.layer_coverage, LayerCoverage::default());
-        assert!(
-            profile.tier.starts_with("Tier 2"),
-            "the tier string must agree with the catalog's Tier 2 classification: {}",
-            profile.tier
-        );
+        assert!(profile.tier.starts_with("Tier 2"), "tier: {}", profile.tier);
     }
 
     #[test]
-    fn snapshot_capability_defaults_to_unsupported() {
-        assert_eq!(
-            AppleContainerBackend::new().snapshot_capability(),
-            SnapshotCapability::Unsupported
-        );
-    }
-
-    #[test]
-    fn warm_start_fails_closed() {
-        use mvm_core::vm_backend::{SnapshotCapability, WarmStartError};
+    fn snapshot_and_standby_and_pause_resume_fail_closed() {
+        use mvm_core::vm_backend::WarmStartError;
         let b = AppleContainerBackend::new();
+        assert_eq!(b.snapshot_capability(), SnapshotCapability::Unsupported);
         match b.warm_start(&VmStartConfig::default(), SnapshotCapability::DiskOnly) {
             Err(WarmStartError::Unsupported { .. }) => {}
             other => panic!("expected Unsupported, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn standby_pool_fails_closed() {
-        assert!(!AppleContainerBackend::new().supports_standby_pool());
-    }
-
-    #[test]
-    fn start_fails_closed_with_typed_error_naming_the_milestone() {
-        let b = AppleContainerBackend::new();
-        let err = b.start(&cfg("x")).unwrap_err();
-        assert_eq!(
-            not_implemented(&err),
-            &AppleContainerError::NotImplemented {
-                operation: "start a container VM",
-                milestone: "the Containerization Swift shim (stage 2)",
-            }
-        );
-        assert!(
-            err.to_string().contains("cannot start a container VM yet"),
-            "the display names the refused operation and the milestone: {err}"
-        );
-    }
-
-    #[test]
-    fn pause_resume_wait_logs_fail_closed_with_typed_errors() {
-        let b = AppleContainerBackend::new();
+        assert!(!b.supports_standby_pool());
         let id = VmId("x".to_string());
-        for err in [
-            b.pause(&id).unwrap_err(),
-            b.resume(&id).unwrap_err(),
-            b.wait(&id).unwrap_err(),
-            b.logs(&id, 10, false).unwrap_err(),
-        ] {
-            assert!(
-                matches!(
-                    not_implemented(&err),
-                    AppleContainerError::NotImplemented { .. }
-                ),
-                "expected a typed NotImplemented, got: {err}"
-            );
-        }
-    }
-
-    #[test]
-    fn trivially_true_operations_are_honest() {
-        // `start` cannot succeed, so nothing can be running: stop, status,
-        // and list answer trivially instead of inventing state.
-        let b = AppleContainerBackend::new();
-        let id = VmId("x".to_string());
-        assert!(b.stop(&id).is_ok());
-        assert!(b.stop_all().is_ok());
-        assert_eq!(b.status(&id).unwrap(), VmStatus::Stopped);
-        assert!(b.list().unwrap().is_empty());
-    }
-
-    #[test]
-    fn availability_is_honest_and_install_fails_closed() {
-        let b = AppleContainerBackend::new();
-        assert!(!b.is_available().unwrap(), "no boot path exists yet");
         assert!(matches!(
-            not_implemented(&b.install().unwrap_err()),
+            typed(&b.pause(&id).unwrap_err()),
+            AppleContainerError::NotImplemented { .. }
+        ));
+        assert!(matches!(
+            typed(&b.resume(&id).unwrap_err()),
             AppleContainerError::NotImplemented { .. }
         ));
     }
 
     #[test]
-    fn network_info_and_guest_channel_info_fail_closed_by_default() {
+    fn start_fails_closed_with_typed_error_after_injection_wiring() {
         let b = AppleContainerBackend::new();
-        let id = VmId("x".to_string());
-        assert!(b.network_info(&id).is_err());
-        assert!(b.guest_channel_info(&id).is_err());
+        let err = b.start(&cfg("start-fail-closed-test")).unwrap_err();
+        assert!(
+            matches!(
+                typed(&err),
+                AppleContainerError::ArtifactMissing { .. }
+                    | AppleContainerError::Shim { .. }
+                    | AppleContainerError::NotImplemented { .. }
+            ),
+            "start must fail closed with a typed error (artifact, shim, or milestone): {err}"
+        );
     }
 
     #[test]
-    fn balloon_ops_fail_closed_by_default() {
+    fn stop_status_list_wait_are_honest_for_a_never_started_vm() {
         let b = AppleContainerBackend::new();
-        let id = VmId("x".to_string());
-        assert!(b.balloon_set_target(&id, 64).is_err());
-        assert!(b.balloon_state(&id).is_err());
+        let id = VmId("ac-never-started-test-vm".to_string());
+        assert!(b.stop(&id).is_ok());
+        assert_eq!(b.status(&id).unwrap(), VmStatus::Stopped);
+        assert_eq!(b.wait(&id).unwrap(), VmExitStatus::UNKNOWN);
+        assert!(!b.list().unwrap().iter().any(|v| v.name == id.0));
+    }
+
+    #[test]
+    fn shim_paths_are_derived_from_the_state_dir() {
+        let paths = ShimPaths::for_vm("paths-test");
+        let state = vm_state_dir("paths-test");
+        assert_eq!(paths.pid_file, state.join(SHIM_PID_FILE));
+        assert_eq!(paths.control_socket, state.join(SHIM_CONTROL_SOCKET));
+        assert_eq!(paths.boot_log_dir, state.join(SHIM_BOOT_LOG_DIR));
+    }
+
+    #[test]
+    fn logs_tails_the_boot_log() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", dir.path());
+        let log_dir = vm_state_dir("logs-test").join(SHIM_BOOT_LOG_DIR);
+        std::fs::create_dir_all(&log_dir).unwrap();
+        std::fs::write(log_dir.join("boot.log"), "a\nb\nc\nd\n").unwrap();
+        let b = AppleContainerBackend::new();
+        assert_eq!(b.logs(&VmId("logs-test".into()), 2, false).unwrap(), "c\nd");
+    }
+
+    #[test]
+    fn shim_vm_names_finds_only_dirs_with_a_shim_pid_file() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", dir.path());
+        let with_pid = vm_state_dir("ac-vm-with-pid");
+        std::fs::create_dir_all(&with_pid).unwrap();
+        std::fs::write(with_pid.join(SHIM_PID_FILE), "123").unwrap();
+        std::fs::create_dir_all(vm_state_dir("ac-vm-without-pid")).unwrap();
+        assert_eq!(shim_vm_names(), vec!["ac-vm-with-pid".to_string()]);
+    }
+
+    #[test]
+    fn connect_shim_is_none_without_a_pid_file() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", dir.path());
+        let paths = ShimPaths::for_vm("connect-none-test");
+        assert!(connect_shim(&paths).is_none());
+    }
+
+    /// macOS-only, gated live smoke: requires the shim binary, a framework
+    /// kernel, and an initfs under the cache (see `ArtifactMissing` hints).
+    /// Run with `MVM_AC_E2E=1 cargo test -p mvm-runtime --features
+    /// apple-container ac_e2e -- --ignored`.
+    #[cfg(all(target_os = "macos", feature = "apple-container"))]
+    #[test]
+    #[ignore = "requires shim + kernel + initfs artifacts (MVM_AC_E2E=1 to run)"]
+    fn ac_e2e_boots_a_framework_vm_and_injects_files() {
+        if std::env::var("MVM_AC_E2E").is_err() {
+            return;
+        }
+        // The artifact precondition is the whole gate: without them the
+        // backend fails closed long before this point.
+        let kernel = resolve_kernel(&cfg("ac-e2e")).expect("framework kernel");
+        let initfs = resolve_initfs().expect("framework initfs");
+        let paths = ShimPaths::for_vm("ac-e2e");
+        std::fs::create_dir_all(&paths.state_dir).unwrap();
+        std::fs::create_dir_all(&paths.boot_log_dir).unwrap();
+        let mut config = cfg("ac-e2e");
+        config.rootfs_path = "<an ext4 rootfs>".into();
+        let spec = build_apple_container_spec(
+            &config,
+            &SpecInputs {
+                kernel_path: &kernel,
+                initfs_path: &initfs,
+                control_socket: &paths.control_socket,
+                boot_log_dir: &paths.boot_log_dir,
+                agent_port: crate::vm::vminitd_client::GUEST_AGENT_VSOCK_PORT,
+            },
+        );
+        let mut client = boot_shim(&paths, &spec).expect("shim boots and answers ping");
+        client
+            .mkdir("/run/mvm", true, 0o700)
+            .expect("mkdir via vminitd");
+        client
+            .write_file("/run/mvm/hello", b"hi", 0o644)
+            .expect("file injection via the copy channel");
+        let _ = client.stop();
     }
 }

--- a/crates/mvm-runtime/src/lib.rs
+++ b/crates/mvm-runtime/src/lib.rs
@@ -28,6 +28,7 @@ pub mod vsock_transport;
 
 pub mod vm;
 
+pub mod apple_container;
 pub mod apple_container_backend;
 pub mod artifacts;
 pub mod audit_substrate;

--- a/crates/mvm-runtime/src/microvm/activation.rs
+++ b/crates/mvm-runtime/src/microvm/activation.rs
@@ -71,7 +71,10 @@ pub fn activate_workload(vm: &dyn RunningVm, config: &VmStartConfig) -> Result<(
 /// share by tag instead.  The runtime overlay rides along only when the full
 /// overlay triple is present — it is always verity-sealed.  Custom volumes
 /// are translated to virtio-fs tags when the config carries directory shares.
-fn build_activation_environment(config: &VmStartConfig) -> Result<ActivateEnvironment> {
+///
+/// `pub(crate)` so the Apple Container backend builds the identical message
+/// for its vminitd injection instead of re-rolling it.
+pub(crate) fn build_activation_environment(config: &VmStartConfig) -> Result<ActivateEnvironment> {
     // Verity is keyed off the hash device: `verity_path` set means the
     // backend attached the Merkle sidecar at the hash slot, so the root mounts
     // as dm-verity and must carry a roothash. No sidecar device means a plain

--- a/public/src/content/docs/architecture/boot-flow.md
+++ b/public/src/content/docs/architecture/boot-flow.md
@@ -164,10 +164,13 @@ model in adapted form — or honestly not at all:
   contract rather than sharing this one.
 - **Apple Container** — Apple's `container` framework boots lightweight Linux
   VMs with its own init (`vminitd` as guest PID 1, gRPC on vsock port 1024)
-  and networking/vsock stack. An honest, fail-closed backend skeleton now
-  exists behind `--hypervisor apple-container` (opt-in only, never
-  auto-selected; every operation fails with a typed error naming the
-  milestone that provides it) — see
+  and networking/vsock stack. The `--hypervisor apple-container` backend
+  (opt-in only, never auto-selected) now boots through a per-VM Swift shim
+  (`swift/mvm-container-shim`): it creates and starts the framework VM,
+  drives `vminitd`'s API, and injects the static guest agent plus the
+  serialized `ActivateEnvironment` every other backend builds. The agent's
+  own activation entry point is the remaining gap, so `start` still fails
+  closed with a typed error naming that milestone — see
   `specs/plans/271-apple-container-backend.md` for the staged design. Full
   support means driving the same activation contract through `vminitd`'s
   gRPC API rather than an mvm initramfs: the host writes the serialized

--- a/scripts/build-apple-container-shim.sh
+++ b/scripts/build-apple-container-shim.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Build the Apple Containerization shim and install it (codesigned with the
+# virtualization entitlement) into the mvm cache the backend resolves:
+#   <MVM_HOME>/cache/apple-container/bin/mvm-container-shim
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cache_root="${MVM_HOME:-$HOME/.mvm}/cache/apple-container"
+
+cd "$repo_root/swift/mvm-container-shim"
+swift build -c release --product mvm-container-shim
+
+mkdir -p "$cache_root/bin"
+cp .build/release/mvm-container-shim "$cache_root/bin/mvm-container-shim"
+codesign --entitlements "$repo_root/assets/mvmctl.entitlements" -f -s - \
+  "$cache_root/bin/mvm-container-shim"
+
+echo "apple-container shim installed at $cache_root/bin/mvm-container-shim"

--- a/specs/notes/2026-07-29-universal-initramfs-future-tiers.md
+++ b/specs/notes/2026-07-29-universal-initramfs-future-tiers.md
@@ -36,17 +36,23 @@ backends").
 
 ## Apple Container
 
-- Today: the stage-1 backend skeleton exists — `BackendKind::AppleContainer`
-  and `AnyBackend::AppleContainer` behind `--hypervisor apple-container`
-  (alias `container`), opt-in only and never auto-selected. Every operation
-  fails closed with a typed error naming the milestone that provides it;
-  capabilities and the security profile report honestly (no snapshot, no
-  standby pool, all seven claims `DoesNotHold`). The staged design lives in
-  `specs/plans/271-apple-container-backend.md`. Two doc comments in
-  `crates/mvm-runtime/src/backend.rs` still name Apple Container
-  (`start` example, `for_started_vm` probe) — they describe the real
-  variant's eventual shape (no pid-file marker; the framework tracks VM
-  state out-of-band).
+- Today: stages 1–2 are implemented. Stage 1 registered the honest
+  skeleton (`BackendKind::AppleContainer`, opt-in, never auto-selected,
+  everything fail-closed). Stage 2 wires the real boot machinery: a per-VM
+  Swift shim (`swift/mvm-container-shim`, built + codesigned via `just
+  apple-container-shim`) creates and starts the framework VM from a JSON
+  boot spec (kernel + initfs from the mvm cache, rootfs, vda–vdd blocks,
+  virtio-fs shares, no NIC), drives `vminitd`'s API over vsock port 1024
+  through a newline-JSON + SCM_RIGHTS control protocol, and the backend
+  (`crates/mvm-runtime/src/apple_container/` + `apple_container_backend.rs`)
+  resolves artifacts with typed `ArtifactMissing` errors and injects the
+  static musl guest agent plus the serialized `ActivateEnvironment` — the
+  same message every other backend builds — through the container's
+  streaming copy channel. `stop`/`stop_all`/`status`/`list`/`wait`/`logs`
+  are real (shim ops + pid-file conventions); `start` still fails closed
+  after injection because the agent has no activation-file entry point
+  yet (stage 4). The Rust-side gRPC transport milestone collapsed into the
+  shim (the framework's own `Vminitd` client owns the wire).
 - Future support shape: Apple's Swift-only framework owns the kernel boot
   and `vminitd` as guest PID 1 (gRPC on vsock port 1024), so the universal
   initramfs does not apply verbatim — the **activation contract** rides

--- a/specs/plans/271-apple-container-backend.md
+++ b/specs/plans/271-apple-container-backend.md
@@ -1,6 +1,8 @@
 # Plan 271: Apple Container backend — same boot contract through vminitd
 
-**Status:** Stage 1 (backend skeleton) implemented; stages 2–4 designed below.
+**Status:** Stage 1 (backend skeleton) and stage 2 (Swift shim + Rust
+client + backend wiring through vminitd injection) implemented; stage 3
+collapsed into the shim; stage 4 (agent bring-up) remains.
 **Owner:** mvm core.
 **Depends on:** universal initramfs + `ActivateEnvironment` (PR #1914).
 
@@ -72,47 +74,57 @@ What is honestly different, and must be documented as such:
   `snapshot`/`warm_start` all fail closed with the typed error.
 - Gate: workspace clippy + tests + policy xtasks green.
 
-### Stage 2 — Swift Containerization shim
+### Stage 2 — Swift Containerization shim (implemented)
 
-- New SwiftPM package `swift/container-shim/` vendoring
-  `github.com/apple/containerization` (pin to a tagged release; record the
-  pin and its SHA in the shim's `Package.swift` comment and in
-  `xtask check-forbidden-deps` allowance if the checker scans it).
-- `@_cdecl` exports: `mvm_ac_create(config_json) -> handle`,
-  `mvm_ac_start(handle)`, `mvm_ac_stop(handle)`,
-  `mvm_ac_vsock_fd(handle, port) -> fd`, `mvm_ac_destroy(handle)`.
-  Config JSON carries: kernel path, rootfs block, verity sidecar, overlay
-  pair, virtiofs shares, cpus/mem, vm name.
-- Rust binding crate `crates/mvm-runtime/src/apple_container/sys.rs`
-  (hand-written `extern "C"`, `// SAFETY:` per call) built by `build.rs`
-  invoking `swift build` behind the `apple-container` Cargo feature —
-  off by default so the default build has no SwiftPM dependency (same
-  discipline as `wasm-backend`).
-- Kernel: reuse the mvm workload kernel artifact
-  (`mvmctl kernel build --which workload`) in the framework's kernel slot.
-- Entitlements: add `com.apple.vm.networking` to
-  `assets/mvmctl.entitlements` only if the endpoint path needs vmnet;
-  document the codesign step in the milestone PR.
-- Verification: a macOS-only `#[cfg(all(target_os = "macos",
-  feature = "apple-container"))]` smoke test that creates and destroys a VM
-  running the stock container kernel — gated `MVM_AC_E2E=1`, ignored by
-  default (mirrors `MVM_LIBKRUN_E2E`).
+- SwiftPM package `swift/mvm-container-shim/` (swift-tools-version 6.2,
+  platforms macOS 26, `apple/containerization` from 0.6.0) — one detached
+  executable per VM, mirroring the other per-VM supervisors. It takes
+  `--spec <path>` (JSON boot spec: kernel, initfs, cpus/mem, rootfs,
+  blocks, virtio-fs shares, control socket, agent port, boot-log dir),
+  builds `Kernel` + initfs `Mount` + `VZVirtualMachineManager` +
+  `LinuxContainer` (`useInit = true`, no network interfaces, blocks +
+  shares as mounts), and serves newline-delimited JSON RPC on the control
+  socket: `ping`, `stop`, `kill`, `wait`, `vminitd_write_file`,
+  `vminitd_mkdir`, `vminitd_mount`, `vminitd_create_process`,
+  `vminitd_start_process`, `vminitd_wait_process`, `vminitd_signal`, and
+  `dial_vsock` (fd handoff via SCM_RIGHTS: ok response line, then one
+  sendmsg with a 1-byte payload + the fd).
+- Rust side `crates/mvm-runtime/src/apple_container/`: `spec.rs` (the
+  serde spec + pure `VmStartConfig` → spec mapping with the vda/vdb/vdc/
+  vdd block order and `device_only` marking for verity sidecars) and
+  `shim_client.rs` (detached spawn, newline-JSON client, SCM_RIGHTS
+  receive; framing unit-tested against an in-process mock server).
+- Backend wiring in `apple_container_backend.rs`: artifact resolution from
+  `<mvm_cache>/apple-container/` (shim binary, kernel, initfs) with typed
+  `ArtifactMissing { what, path, hint }` errors naming the exact fetch;
+  `stop`/`stop_all`/`status`/`list`/`wait`/`logs` via the shim and the
+  pid-file conventions the QEMU backend established.
+- File injection rides `LinuxContainer.copyIn` (streaming copy channel),
+  not `Vminitd.writeFile` — `WriteFileFlags` has no public constructor in
+  0.6.0 (internal init), so the unary write is unreachable outside the
+  framework module.
+- Build + sign: `scripts/build-apple-container-shim.sh` (swift build,
+  install to `<MVM_HOME>/cache/apple-container/bin/`, codesign with
+  `assets/mvmctl.entitlements`), wired as `just apple-container-shim`.
+- Entitlements: `com.apple.security.virtualization` covers the boot; no
+  network interfaces are attached, so `com.apple.vm.networking` is not
+  needed.
+- What stage 2 deliberately does NOT do: launch the guest agent. The agent
+  has no activation-file entry point yet, so `start_with_mode` boots,
+  injects, tears the VM down, and returns a typed `NotImplemented` naming
+  stage 4.
+- Verification: spec-mapping and shim-framing unit tests; a macOS-only
+  `MVM_AC_E2E=1` gated smoke (`#[ignore]`) that boots a framework VM and
+  injects files when the artifacts exist.
 
-### Stage 3 — vminitd gRPC-over-vsock transport
+### Stage 3 — collapsed into the shim
 
-- Generate prost types from `crates/mvm-runtime/src/vm/proto/sandbox_context.proto`
-  (`prost-build` in the existing build pipeline; the proto is already
-  vendored).
-- Transport: HTTP/2 gRPC over the shim's vsock fd using `tonic` with a
-  custom connector, or `h2` hand-framed if the `tonic` dependency tree is
-  rejected at audit time — decision recorded in the stage-3 PR after
-  `cargo deny` output.
-- Fill `vm/vminitd_client.rs` (typed interface already exists): `WriteFile`,
-  `CreateProcess`, `StartProcess`, `WaitProcess`, `KillProcess`,
-  `ProxyVsock`, `Mount`.
-- Tests: in-process mock gRPC server over a Unix socket pair asserting the
-  exact request bytes for the activation sequence; no Apple framework
-  required.
+The Rust-side vminitd gRPC-over-vsock transport (prost + tonic/h2 from the
+vendored proto) is **not built**: the Swift shim owns the vminitd gRPC via
+the framework's own `Vminitd` client, and Rust speaks newline-JSON +
+SCM_RIGHTS to the shim. This removes the proto-generation and
+transport-dependency milestones entirely; `crates/mvm-runtime/src/vm/
+vminitd_client.rs` stays the typed interface doc for the port constants.
 
 ### Stage 4 — Activation through vminitd + driver wiring
 

--- a/swift/mvm-container-shim/Package.resolved
+++ b/swift/mvm-container-shim/Package.resolved
@@ -1,0 +1,267 @@
+{
+  "originHash" : "4c1daf8f92cf93424242696aeda8a1dfc359b42e5b63ab19b7bc5276569aa4cc",
+  "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "9544287b9416c0bc71e58b9f3aead8dd14b16103",
+        "version" : "1.36.0"
+      }
+    },
+    {
+      "identity" : "containerization",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/containerization.git",
+      "state" : {
+        "revision" : "7800b4642171561c95b5f55500b19e5dce5acd45",
+        "version" : "0.40.1"
+      }
+    },
+    {
+      "identity" : "grpc-swift-2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-2.git",
+      "state" : {
+        "revision" : "28cdd63ef88583ddc67d7bb179eab46fab465ce9",
+        "version" : "2.4.2"
+      }
+    },
+    {
+      "identity" : "grpc-swift-nio-transport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-nio-transport.git",
+      "state" : {
+        "revision" : "2ca31f06658ed288a2560e23ad649acbb3d6b3a3",
+        "version" : "2.9.0"
+      }
+    },
+    {
+      "identity" : "grpc-swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-protobuf.git",
+      "state" : {
+        "revision" : "176c5a434fd76f6f479848d1a8f7d44967534168",
+        "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "449dbbecd0f31e82b510ada227ca152caa8b5e98",
+        "version" : "1.19.4"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "45bdf670248be5f16ec0340e125dca285536f0fb",
+        "version" : "1.45.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "d930168b86f46ca51a4bc09c5ca45c1833db8067",
+        "version" : "2.37.2"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
+        "version" : "1.38.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "50688cacbd41d547e9eb9f7a213542340b7c442b",
+        "version" : "1.7.5"
+      }
+    },
+    {
+      "identity" : "zstd",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/zstd.git",
+      "state" : {
+        "revision" : "f8745da6ff1ad1e7bab384bd1f9d742439278e99",
+        "version" : "1.5.7"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/swift/mvm-container-shim/Package.swift
+++ b/swift/mvm-container-shim/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+// Dependency pin: apple/containerization 0.6.0. Package.resolved records
+// the exact revision; bump both deliberately and rebuild before relying on
+// a newer upstream API.
+let package = Package(
+    name: "mvm-container-shim",
+    platforms: [.macOS(.v26)],
+    dependencies: [
+        .package(url: "https://github.com/apple/containerization.git", from: "0.6.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "mvm-container-shim",
+            dependencies: [
+                .product(name: "Containerization", package: "containerization")
+            ]
+        )
+    ]
+)

--- a/swift/mvm-container-shim/Sources/mvm-container-shim/FdPassing.swift
+++ b/swift/mvm-container-shim/Sources/mvm-container-shim/FdPassing.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// Raw-fd plumbing the Foundation layer does not cover: Unix-domain socket
+/// listen/accept, line reads, full writes, and the SCM_RIGHTS fd handoff
+/// the `dial_vsock` op needs. Kept small and total — every public function
+/// returns or throws, never traps.
+
+enum SocketError: Error, CustomStringConvertible {
+    case syscall(name: String, errno: Int32)
+
+    var description: String {
+        switch self {
+        case .syscall(let name, let errno):
+            return "\(name) failed: errno \(errno) (\(String(cString: strerror(errno))))"
+        }
+    }
+}
+
+enum UnixFd {
+    /// Bind + listen on a Unix socket at `path` (stale path removed first).
+    static func listen(path: String, backlog: Int32 = 4) throws -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw SocketError.syscall(name: "socket", errno: errno) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(path.utf8CString)
+        let capacity = MemoryLayout.size(ofValue: addr.sun_path)
+        guard pathBytes.count <= capacity else {
+            close(fd)
+            throw SocketError.syscall(name: "bind(path too long)", errno: ENAMETOOLONG)
+        }
+        withUnsafeMutablePointer(to: &addr.sun_path) { sunPath in
+            sunPath.withMemoryRebound(to: CChar.self, capacity: capacity) { dest in
+                pathBytes.withUnsafeBufferPointer { src in
+                    if let base = src.baseAddress {
+                        dest.update(from: base, count: pathBytes.count)
+                    }
+                }
+            }
+        }
+        unlink(path)
+        let bindRc = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                bind(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindRc == 0 else {
+            let e = errno
+            close(fd)
+            throw SocketError.syscall(name: "bind", errno: e)
+        }
+        guard Darwin.listen(fd, backlog) == 0 else {
+            let e = errno
+            close(fd)
+            throw SocketError.syscall(name: "listen", errno: e)
+        }
+        return fd
+    }
+
+    static func accept(_ listenFd: Int32) throws -> Int32 {
+        let fd = Darwin.accept(listenFd, nil, nil)
+        guard fd >= 0 else { throw SocketError.syscall(name: "accept", errno: errno) }
+        return fd
+    }
+
+    /// Read one newline-terminated line (without the newline). Returns nil
+    /// on clean EOF before any byte.
+    static func readLine(_ fd: Int32) throws -> Data? {
+        var out = Data()
+        var byte = [UInt8](repeating: 0, count: 1)
+        while true {
+            let n = read(fd, &byte, 1)
+            if n == 0 {
+                return out.isEmpty ? nil : out
+            }
+            guard n > 0 else {
+                let e = errno
+                if e == EINTR { continue }
+                throw SocketError.syscall(name: "read", errno: e)
+            }
+            if byte[0] == UInt8(ascii: "\n") {
+                return out
+            }
+            out.append(byte[0])
+        }
+    }
+
+    static func writeAll(_ fd: Int32, _ data: Data) throws {
+        try data.withUnsafeBytes { raw in
+            var written = 0
+            while written < raw.count {
+                let n = write(fd, raw.baseAddress!.advanced(by: written), raw.count - written)
+                if n < 0 {
+                    let e = errno
+                    if e == EINTR { continue }
+                    throw SocketError.syscall(name: "write", errno: e)
+                }
+                written += n
+            }
+        }
+    }
+
+    static func writeLine(_ fd: Int32, _ data: Data) throws {
+        var line = data
+        line.append(UInt8(ascii: "\n"))
+        try writeAll(fd, line)
+    }
+}
+
+/// CMSG helpers mirroring CMSG_ALIGN/CMSG_LEN/CMSG_SPACE from <sys/socket.h>.
+enum Cmsg {
+    static func align(_ n: Int) -> Int {
+        (n + MemoryLayout<Int>.size - 1) & ~(MemoryLayout<Int>.size - 1)
+    }
+
+    static func len(_ payloadBytes: Int) -> Int {
+        align(MemoryLayout<cmsghdr>.size) + payloadBytes
+    }
+
+    static func space(_ payloadBytes: Int) -> Int {
+        align(MemoryLayout<cmsghdr>.size) + align(payloadBytes)
+    }
+
+    static func data(_ cmsg: UnsafeMutablePointer<cmsghdr>) -> UnsafeMutableRawPointer {
+        UnsafeMutableRawPointer(cmsg).advanced(by: align(MemoryLayout<cmsghdr>.size))
+    }
+}
+
+enum FdPassing {
+    /// The wire convention for `dial_vsock`: after the JSON response line,
+    /// one sendmsg carries a single dummy byte as payload and the vsock fd
+    /// in an SCM_RIGHTS control message. The Rust side does the symmetric
+    /// recvmsg. A plain byte is required because a message may not consist
+    /// of control data alone.
+    static func sendFd(_ socket: Int32, fd fdToSend: Int32) throws {
+        var dummy: UInt8 = 0
+        try withUnsafeMutableBytes(of: &dummy) { dummyPtr in
+            var iov = iovec(iov_base: dummyPtr.baseAddress, iov_len: dummyPtr.count)
+            try withUnsafeMutablePointer(to: &iov) { iovPtr in
+                let controlBytes = Cmsg.space(MemoryLayout<Int32>.size)
+                let control = UnsafeMutableRawPointer.allocate(
+                    byteCount: controlBytes,
+                    alignment: MemoryLayout<cmsghdr>.alignment
+                )
+                defer { control.deallocate() }
+                control.initializeMemory(as: UInt8.self, repeating: 0, count: controlBytes)
+
+                var msg = msghdr()
+                msg.msg_iov = iovPtr
+                msg.msg_iovlen = 1
+                msg.msg_control = control
+                // macOS requires the ancillary length to be CMSG_LEN (the
+                // exact header+payload), not CMSG_SPACE, or sendmsg fails
+                // EINVAL.
+                msg.msg_controllen = socklen_t(Cmsg.len(MemoryLayout<Int32>.size))
+
+                // Single cmsg at the head of the control buffer —
+                // CMSG_FIRSTHDR is a function-like macro Swift can't
+                // import, but with exactly one header it is simply the
+                // buffer start.
+                let cmsg = control.assumingMemoryBound(to: cmsghdr.self)
+                cmsg.pointee.cmsg_level = SOL_SOCKET
+                cmsg.pointee.cmsg_type = SCM_RIGHTS
+                cmsg.pointee.cmsg_len = socklen_t(Cmsg.len(MemoryLayout<Int32>.size))
+                Cmsg.data(cmsg).withMemoryRebound(to: Int32.self, capacity: 1) { ptr in
+                    ptr.pointee = fdToSend
+                }
+
+                let rc = sendmsg(socket, &msg, 0)
+                guard rc >= 0 else { throw SocketError.syscall(name: "sendmsg", errno: errno) }
+            }
+        }
+    }
+}

--- a/swift/mvm-container-shim/Sources/mvm-container-shim/Rpc.swift
+++ b/swift/mvm-container-shim/Sources/mvm-container-shim/Rpc.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Wire types for the shim's newline-delimited-JSON control protocol and
+/// the `--spec` boot description. One request line in, one response line
+/// out; `dial_vsock` is the only op that also transfers an fd (see
+/// FdPassing.swift).
+
+/// The boot description the backend writes before spawning the shim.
+/// Decoded with `.convertFromSnakeCase`, so the on-disk keys are the
+/// snake_case names the Rust side serializes.
+struct ShimSpec: Codable {
+    struct Rootfs: Codable {
+        var path: String
+        var readOnly: Bool
+    }
+
+    struct Block: Codable {
+        var path: String
+        var readOnly: Bool
+        /// True for blocks that are not mountable filesystems (dm-verity
+        /// hash sidecars): they ride along as virtio-blk devices for the
+        /// guest to assemble, never as OCI runtime mounts.
+        var deviceOnly: Bool
+    }
+
+    struct Share: Codable {
+        /// mvm's virtio-fs tag for the activation contract (uvol{idx}).
+        var tag: String
+        var hostPath: String
+        var guestPath: String
+        var readOnly: Bool
+    }
+
+    var vmName: String
+    var kernelPath: String
+    var initfsPath: String
+    var cpus: Int
+    var memoryMib: UInt64
+    var rootfs: Rootfs
+    var blocks: [Block]
+    var virtiofsShares: [Share]
+    var controlSocket: String
+    var agentPort: UInt32
+    var bootLogDir: String
+}
+
+/// One control request. Heterogeneous params stay a JSON dictionary so the
+/// wire format is explicit in the dispatcher (no schema drift between a
+/// Codable here and the Rust encoder).
+typealias RpcRequest = [String: Any]
+
+enum RpcError: Error, CustomStringConvertible {
+    case malformed(String)
+
+    var description: String {
+        switch self {
+        case .malformed(let message): return message
+        }
+    }
+}
+
+enum Rpc {
+    /// Read the op name and id out of a request dictionary.
+    static func requestMeta(_ req: RpcRequest) throws -> (id: Int, op: String) {
+        guard let id = req["id"] as? Int, let op = req["op"] as? String else {
+            throw RpcError.malformed("request requires numeric `id` and string `op`")
+        }
+        return (id, op)
+    }
+
+    static func int(_ req: RpcRequest, _ key: String) throws -> Int {
+        guard let value = req[key] as? Int else {
+            throw RpcError.malformed("request requires numeric `\(key)`")
+        }
+        return value
+    }
+
+    static func string(_ req: RpcRequest, _ key: String) throws -> String {
+        guard let value = req[key] as? String else {
+            throw RpcError.malformed("request requires string `\(key)`")
+        }
+        return value
+    }
+
+    static func stringArray(_ req: RpcRequest, _ key: String) -> [String] {
+        (req[key] as? [String]) ?? []
+    }
+
+    static func bool(_ req: RpcRequest, _ key: String, default defaultValue: Bool) -> Bool {
+        (req[key] as? Bool) ?? defaultValue
+    }
+
+    /// Decode one newline-terminated request line.
+    static func decodeRequest(_ line: Data) throws -> RpcRequest {
+        let object = try JSONSerialization.jsonObject(with: line)
+        guard let req = object as? RpcRequest else {
+            throw RpcError.malformed("request line is not a JSON object")
+        }
+        return req
+    }
+
+    /// Encode one response line (always ends without a newline; the writer
+    /// appends it).
+    static func encodeResponse(id: Int, result: [String: Any] = [:]) throws -> Data {
+        var body: [String: Any] = ["id": id, "ok": true]
+        body.merge(result) { _, new in new }
+        return try JSONSerialization.data(withJSONObject: body)
+    }
+
+    static func encodeError(id: Int, message: String) throws -> Data {
+        try JSONSerialization.data(withJSONObject: [
+            "id": id,
+            "ok": false,
+            "error": message,
+        ])
+    }
+
+    /// Load and decode the boot spec JSON file.
+    static func loadSpec(path: String) throws -> ShimSpec {
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(ShimSpec.self, from: data)
+    }
+}

--- a/swift/mvm-container-shim/Sources/mvm-container-shim/Shim.swift
+++ b/swift/mvm-container-shim/Sources/mvm-container-shim/Shim.swift
@@ -1,0 +1,288 @@
+import Containerization
+import ContainerizationOCI
+import Foundation
+import NIO
+
+/// The shim's job: own one container VM's lifecycle and translate the
+/// backend's newline-JSON control protocol into Containerization + vminitd
+/// calls. One process per VM, mirroring the other supervisors — the parent
+/// backend never shares a VM's fate with another VM's shim. An actor so
+/// the signal-source shutdown path and the serving loop can both touch
+/// the container without a data race.
+actor Shim {
+    let spec: ShimSpec
+    let group: EventLoopGroup = MultiThreadedEventLoopGroup.singleton
+    private var container: LinuxContainer?
+    private var vminitd: Vminitd?
+
+    init(spec: ShimSpec) {
+        self.spec = spec
+    }
+
+    /// Build the VM from the spec, boot it with vminitd as PID 1, and open
+    /// the vminitd control channel (vsock port 1024).
+    func boot() async throws {
+        let kernel = Kernel(
+            path: URL(fileURLWithPath: spec.kernelPath),
+            platform: .linuxArm,
+            commandline: .init(debug: false, panic: 0)
+        )
+        let initfs = Mount.block(
+            format: "ext4",
+            source: spec.initfsPath,
+            destination: "/",
+            options: ["ro"]
+        )
+        let manager = VZVirtualMachineManager(kernel: kernel, initialFilesystem: initfs)
+
+        var config = LinuxContainer.Configuration()
+        config.cpus = spec.cpus
+        config.memoryInBytes = spec.memoryMib * 1024 * 1024
+        // vminitd boots from the initfs as PID 1; mvm's activation contract
+        // then rides its gRPC API rather than an mvm initramfs.
+        config.useInit = true
+        try FileManager.default.createDirectory(
+            atPath: spec.bootLogDir,
+            withIntermediateDirectories: true
+        )
+        config.bootLog = .file(path: URL(fileURLWithPath: spec.bootLogDir + "/boot.log"))
+
+        var mounts = LinuxContainer.defaultMounts()
+        for (index, block) in spec.blocks.enumerated() {
+            if block.deviceOnly {
+                // Verity sidecars are not filesystems: an OCI runtime mount
+                // would fail the boot. They attach as bare virtio-blk
+                // devices when the stage-4 activation path needs them —
+                // there is deliberately no device-only attach through
+                // Configuration.mounts.
+                FileHandle.standardError.write(
+                    Data("mvm-container-shim: deferring device-only block \(block.path)\n".utf8)
+                )
+                continue
+            }
+            mounts.append(
+                .block(
+                    format: "ext4",
+                    source: block.path,
+                    destination: "/mnt/mvm/blocks/\(index)",
+                    options: block.readOnly ? ["ro"] : []
+                )
+            )
+        }
+        for share in spec.virtiofsShares {
+            mounts.append(
+                .share(
+                    source: share.hostPath,
+                    destination: share.guestPath,
+                    options: share.readOnly ? ["ro"] : []
+                )
+            )
+        }
+        config.mounts = mounts
+
+        let rootfs = Mount.block(
+            format: "ext4",
+            source: spec.rootfs.path,
+            destination: "/",
+            options: spec.rootfs.readOnly ? ["ro"] : []
+        )
+        let container = try LinuxContainer(
+            spec.vmName,
+            rootfs: rootfs,
+            vmm: manager,
+            configuration: config
+        )
+        try await container.create()
+        try await container.start()
+        self.container = container
+
+        let connection = try await container.dialVsock(port: 1024)
+        self.vminitd = try await Vminitd(connection: connection, group: group)
+    }
+
+    /// Stop the container VM if it is up. Idempotent and best-effort — used
+    /// by the shutdown path and the `stop` op alike.
+    func shutdown() async {
+        if let container {
+            try? await container.stop()
+        }
+        self.container = nil
+        self.vminitd = nil
+    }
+
+    /// Serve the control protocol: one client at a time on the control
+    /// Unix socket until the client asks us to stop or goes away.
+    func serve() async throws {
+        let listenFd = try UnixFd.listen(path: spec.controlSocket)
+        defer {
+            close(listenFd)
+            unlink(spec.controlSocket)
+        }
+        while true {
+            let clientFd = try UnixFd.accept(listenFd)
+            let keepServing = try await serveClient(clientFd)
+            close(clientFd)
+            if !keepServing {
+                return
+            }
+        }
+    }
+
+    /// Serve one control connection until EOF or the `stop` op. Returns
+    /// false when the shim should exit (the stop op was handled).
+    private func serveClient(_ clientFd: Int32) async throws -> Bool {
+        while let line = try UnixFd.readLine(clientFd) {
+            if line.isEmpty { continue }
+            let keepServing = try await handle(line: line, clientFd: clientFd)
+            if !keepServing {
+                return false
+            }
+        }
+        return true
+    }
+
+    private func writeOk(_ fd: Int32, id: Int, result: [String: Any] = [:]) throws {
+        try UnixFd.writeLine(fd, Rpc.encodeResponse(id: id, result: result))
+    }
+
+    private func writeErr(_ fd: Int32, id: Int, message: String) throws {
+        try UnixFd.writeLine(fd, Rpc.encodeError(id: id, message: message))
+    }
+
+    /// Dispatch one request. Returns false only for the `stop` op.
+    private func handle(line: Data, clientFd: Int32) async throws -> Bool {
+        let req: RpcRequest
+        let meta: (id: Int, op: String)
+        do {
+            req = try Rpc.decodeRequest(line)
+            meta = try Rpc.requestMeta(req)
+        } catch {
+            try writeErr(clientFd, id: 0, message: "malformed request: \(error)")
+            return true
+        }
+
+        do {
+            switch meta.op {
+            case "ping":
+                try writeOk(clientFd, id: meta.id)
+
+            case "stop":
+                await shutdown()
+                try writeOk(clientFd, id: meta.id)
+                return false
+
+            case "kill":
+                guard let container else { throw RpcError.malformed("container is not running") }
+                try await container.kill(Signal(rawValue: 9))
+                try writeOk(clientFd, id: meta.id)
+
+            case "wait":
+                guard let container else { throw RpcError.malformed("container is not running") }
+                let status = try await container.wait()
+                try writeOk(clientFd, id: meta.id, result: ["exit_code": status.exitCode])
+
+            case "vminitd_write_file":
+                let path = try Rpc.string(req, "path")
+                let b64 = try Rpc.string(req, "data_b64")
+                guard let data = Data(base64Encoded: b64) else {
+                    throw RpcError.malformed("data_b64 is not valid base64")
+                }
+                let mode = UInt32(try Rpc.int(req, "mode"))
+                guard let container else { throw RpcError.malformed("container is not running") }
+                // `WriteFileFlags` is unconstructable outside the
+                // Containerization module (its only initializer is
+                // internal), so injection rides `copyIn`'s streaming
+                // transfer instead: stage the bytes in a temp file and copy
+                // them over the dedicated vsock channel. No unary message
+                // size cap applies, so there is no append/chunk flag.
+                let tmp = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("mvm-shim-\(UUID().uuidString)")
+                try data.write(to: tmp)
+                defer { try? FileManager.default.removeItem(at: tmp) }
+                try await container.copyIn(from: tmp, to: URL(fileURLWithPath: path), mode: mode)
+                try writeOk(clientFd, id: meta.id)
+
+            case "vminitd_mkdir":
+                let path = try Rpc.string(req, "path")
+                let all = Rpc.bool(req, "all", default: false)
+                let perms = UInt32(try Rpc.int(req, "perms"))
+                try await requireVminitd().mkdir(path: path, all: all, perms: perms)
+                try writeOk(clientFd, id: meta.id)
+
+            case "vminitd_mount":
+                let source = try Rpc.string(req, "source")
+                let destination = try Rpc.string(req, "destination")
+                let type = try Rpc.string(req, "type")
+                let options = Rpc.stringArray(req, "options")
+                let mount = ContainerizationOCI.Mount(
+                    type: type,
+                    source: source,
+                    destination: destination,
+                    options: options
+                )
+                try await requireVminitd().mount(mount)
+                try writeOk(clientFd, id: meta.id)
+
+            case "vminitd_create_process":
+                let procId = try Rpc.string(req, "proc_id")
+                let path = try Rpc.string(req, "path")
+                let args = Rpc.stringArray(req, "args")
+                let env = Rpc.stringArray(req, "env")
+                let cwd = (req["cwd"] as? String) ?? "/"
+                var process = ContainerizationOCI.Process()
+                process.args = [path] + args
+                process.env = env
+                process.cwd = cwd
+                let ociSpec = Spec(version: "", process: process)
+                try await requireVminitd().createProcess(
+                    id: procId,
+                    containerID: nil,
+                    stdinPort: nil,
+                    stdoutPort: nil,
+                    stderrPort: nil,
+                    ociRuntimePath: nil,
+                    configuration: ociSpec,
+                    options: nil
+                )
+                try writeOk(clientFd, id: meta.id)
+
+            case "vminitd_start_process":
+                let procId = try Rpc.string(req, "proc_id")
+                let pid = try await requireVminitd().startProcess(id: procId, containerID: nil)
+                try writeOk(clientFd, id: meta.id, result: ["pid": pid])
+
+            case "vminitd_wait_process":
+                let procId = try Rpc.string(req, "proc_id")
+                let status = try await requireVminitd().waitProcess(id: procId, containerID: nil)
+                try writeOk(clientFd, id: meta.id, result: ["exit_code": status.exitCode])
+
+            case "vminitd_signal":
+                let procId = try Rpc.string(req, "proc_id")
+                let sig = Int32(try Rpc.int(req, "signal"))
+                try await requireVminitd().signalProcess(id: procId, containerID: nil, signal: sig)
+                try writeOk(clientFd, id: meta.id)
+
+            case "dial_vsock":
+                guard let container else { throw RpcError.malformed("container is not running") }
+                let port = UInt32(try Rpc.int(req, "port"))
+                let handle = try await container.dialVsock(port: port)
+                // Respond first so the client knows the fd is coming, then
+                // hand the connected socket over SCM_RIGHTS.
+                try writeOk(clientFd, id: meta.id)
+                try FdPassing.sendFd(clientFd, fd: handle.fileDescriptor)
+                handle.closeFile()
+
+            default:
+                try writeErr(clientFd, id: meta.id, message: "unknown op `\(meta.op)`")
+            }
+        } catch {
+            try writeErr(clientFd, id: meta.id, message: "\(error)")
+        }
+        return true
+    }
+
+    private func requireVminitd() throws -> Vminitd {
+        guard let vminitd else { throw RpcError.malformed("vminitd channel is not up") }
+        return vminitd
+    }
+}

--- a/swift/mvm-container-shim/Sources/mvm-container-shim/main.swift
+++ b/swift/mvm-container-shim/Sources/mvm-container-shim/main.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// mvm-container-shim — one container VM per process. Usage:
+///
+///   mvm-container-shim --spec <path>
+///
+/// Reads the boot spec JSON, creates + starts the container VM, and serves
+/// the newline-JSON control protocol on the spec's control socket until
+/// told to stop. On exit (any reason) the container VM is stopped so a
+/// shim death never orphans a running VM.
+
+func writeStderr(_ message: String) {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+}
+
+guard CommandLine.arguments.count == 3, CommandLine.arguments[1] == "--spec" else {
+    writeStderr("usage: mvm-container-shim --spec <path>")
+    exit(2)
+}
+let specPath = CommandLine.arguments[2]
+
+let spec: ShimSpec
+do {
+    spec = try Rpc.loadSpec(path: specPath)
+} catch {
+    writeStderr("mvm-container-shim: failed to load spec \(specPath): \(error)")
+    exit(1)
+}
+
+let shim = Shim(spec: spec)
+
+// SIGTERM/SIGINT → stop the container, then exit. A plain C handler can't
+// await, so the dispatch source hops to a task.
+let termSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .global())
+let intSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .global())
+signal(SIGTERM, SIG_IGN)
+signal(SIGINT, SIG_IGN)
+termSource.setEventHandler {
+    Task {
+        await shim.shutdown()
+        exit(0)
+    }
+}
+intSource.setEventHandler {
+    Task {
+        await shim.shutdown()
+        exit(0)
+    }
+}
+termSource.resume()
+intSource.resume()
+
+let exitCode: Int32 = await {
+    do {
+        try await shim.boot()
+        try await shim.serve()
+        await shim.shutdown()
+        return 0
+    } catch {
+        writeStderr("mvm-container-shim: \(error)")
+        await shim.shutdown()
+        return 1
+    }
+}()
+
+exit(exitCode)


### PR DESCRIPTION
Stage 2 of plan 271 (`specs/plans/271-apple-container-backend.md`): the Swift Containerization shim plus the Rust-side client and boot wiring. Stage 3 (Rust gRPC transport) is collapsed into the shim — the Swift side drives vminitd through the framework's own gRPC client; Rust speaks newline-JSON + SCM_RIGHTS to the shim.

## What changed

- **`swift/mvm-container-shim/`** (new SwiftPM executable, `apple/containerization` 0.6.0): `--spec <json>` supervisor — builds `Kernel` + initfs `Mount` + `VZVirtualMachineManager` + `LinuxContainer` (`useInit`, no network interfaces), creates + starts the VM, then serves newline-delimited JSON RPC over a control Unix socket: `ping`, `stop`, `kill`, `wait`, `vminitd_write_file/mkdir/mount/create_process/start_process/wait_process/signal`, and `dial_vsock` (fd handoff via SCM_RIGHTS; macOS `msg_controllen = CMSG_LEN` + 8-byte alignment fixed and round-trip tested). Codesigned with `assets/mvmctl.entitlements` (verified).
- **`crates/mvm-runtime/src/apple_container/`**: `spec.rs` (boot-spec serde + pure `VmStartConfig`→spec mapping — blocks in attach order rootfs/verity/overlay/overlay-verity with `device_only` marking for verity sidecars, DirShare→`uvol{idx}` shares, Disk/virtiofs-root/initrd/console typed refusals, 7 tests) and `shim_client.rs` (spawn/connect/framing/SCM_RIGHTS-receive, loopback tests).
- **`AppleContainerBackend` real flow**: artifact resolution from `<mvm_cache>/apple-container/` with typed `ArtifactMissing{what,path,hint}`; spec → spawn → ping → `mkdir /run/mvm` → inject the musl `mvm-guest-agent` (via `LinuxContainer.copyIn` — 0.6.0's `WriteFileFlags` has no public init; recon correction) and the same serialized `ActivateEnvironment` every backend builds. Agent bring-up stays a typed `NotImplemented` (no `--activation-file` in the agent yet — stage 4) and `start` rolls the VM back rather than leaving a half-boot. `stop`/`stop_all` (graceful→kill), `status`/`list`, `wait`, `logs`, `is_available` are production-real.
- `just apple-container-shim` / `scripts/build-apple-container-shim.sh`: build + codesign into the cache. Plan doc updated (stage 2 implemented; stage 3 collapsed).

## Validation

- `swift build -c release` ✓; codesign ✓
- mvm-runtime 1181 / mvm-core 1414 / mvm-protocol tests pass (24 apple_container tests incl. SCM_RIGHTS fd round-trip)
- workspace clippy clean; all 9 policy xtasks clean; Linux musl check compiles
- No live container boot (no initfs artifact on this host); the gated `MVM_AC_E2E` hook documents the precondition.