### PR TITLE
docs: design note for an `ai` command — deferred draft, no implementation

### DIFF
--- a/specs/notes/2026-07-29-ai-command-design.md
+++ b/specs/notes/2026-07-29-ai-command-design.md
@@ -1,0 +1,366 @@
+# Design: the `ai` command — models run only in profile-matched microVMs
+
+**Date:** 2026-07-29
+**Status:** Design approved; implementation plan pending.
+**Scope:** v1 is one-shot inference. Serving is phase 2, tool-calling is phase 3,
+and both are gated by the boundaries stated in "Deferred, with boundaries".
+
+## Goal
+
+`mvmctl ai run <model> --vm-profile <p>` executes a model inside a microVM that has
+been *proved* to satisfy that model's requirements, from a signed
+`ExecutionPlan` that binds the model bytes, the runtime bytes, and the granted
+resources together. A model whose requirements the profile cannot meet is
+refused at admission, not discovered as an OOM mid-generation.
+
+mvm today is a sandbox for code an LLM writes. This adds the inverse: a sandbox
+for the model itself.
+
+## Decisions
+
+Four load-bearing choices, settled before design:
+
+1. **mvm orchestrates; it does not implement inference.** mvm owns acquisition,
+   provenance, the capability match, the plan, the VM, and the audit trail. A
+   single pinned third-party runtime does the arithmetic.
+2. **One runtime, pinned, digest-bound — `candle`.** Not pluggable.
+3. **Models are OCI artifacts.** Acquisition reuses the existing OCI provenance
+   pipeline rather than growing a second one.
+4. **Requirements are derived host-side at pull and frozen into the signed
+   plan.** The guest never declares its own needs and never negotiates.
+
+### Why one runtime, not a pluggable set
+
+Two properties mvm actually sells break under N runtimes.
+
+*Reproducibility.* The same `mvmctl` is supposed to produce the same result on
+every host. Different runtimes produce different tokens for the same model and
+prompt — different dequantization paths, sampler arithmetic, KV-cache precision.
+Since `ai run` writes provenance to a chain-signed audit log, a pluggable
+runtime makes that record non-reproducible: the log names the model and prompt
+while the output depended on something absent from the plan. Pinning one runtime
+and putting *its* digest in the plan is what makes
+`(model, runtime, seed, prompt) → output` an auditable relation.
+
+*Claim surface.* Each runtime is a fresh untrusted-input parser, CVE stream,
+capability matrix, and egress profile — several runtimes fetch tokenizers at load
+time, which is a separate egress problem each time. The per-backend tier matrix
+is already incomplete (claim-10 egress enforcement is live on two of four VM
+backends). Multiplying the workload-bearing surface again is how that matrix
+stays permanently incomplete.
+
+The seam is defined without the plurality: a narrow guest-side contract
+(declare capabilities, load model, generate) with exactly one implementation
+behind it. A second implementation is a rebuild, not a portability break,
+because mvm controls the guest image end to end — which is why runtime lock-in
+is not the same risk as VMM lock-in.
+
+### Why candle, and what it costs
+
+The runtime's security-relevant job is parsing untrusted binary files — headers,
+tensor layouts, tokenizer data. Doing that in Rust rather than C++ is the
+largest available reduction in this choice, and it keeps C/C++ off the workload
+path.
+
+Being precise: **candle uses `unsafe`** — memory-mapped safetensors access and
+SIMD intrinsics at minimum. This is a meaningful reduction from a C++ runtime,
+not the `forbid(unsafe_code)` guarantee `mvm-protocol` provides. Any claim
+written about this must say "no C/C++ on the workload path", never "memory-safe".
+
+safetensors-first also buys a claim that is otherwise unavailable: safetensors
+has no execution semantics — a JSON header and a flat tensor region. Pickle
+(`.pt`/`.bin`) is arbitrary code execution on load. Supporting exactly one
+format, and that format having no code-execution semantics, is a cheap and
+defensible position.
+
+The cost, stated plainly: candle's quantized/GGUF coverage is weaker than
+llama.cpp's. This design targets provably-isolated auditable inference of
+moderate models, not maximum model size per gigabyte of host RAM. If the latter
+becomes the requirement, this decision must be revisited rather than stretched.
+
+**Footprint risk to measure in week one:** the complete guest footprint budget
+is 50 MB. candle plus a tokenizer may exceed it. This is an engineering
+constraint, not a security one, but it could force decision 2 to be revisited,
+so it must be measured before the runtime is embedded.
+
+## Architecture
+
+**The model is data; the runtime is code.** The candle-based inference binary
+ships inside the signed, dm-verity-sealed guest overlay and is measured like
+every other guest executable. Model weights are a separate read-only volume.
+Swapping models never re-seals the guest; the runtime stays measured
+independently. The plan binds both digests, and neither is taken from the
+guest's word.
+
+**Model storage reuses the sealed-volume mechanism** that backs claim 11.
+Models live at `<mvm_home>/volumes/models/<digest>/` alongside
+`<mvm_home>/volumes/deps`, verified by the same
+`verify_sealed_volume`-shaped path: a directory with a hash-chained manifest,
+checked before launch. SBOM and CVE sidecars do not apply to weights, so the
+manifest carries an explicit `kind: model` and their absence is by design rather
+than a stub — the verifier must not have to guess which sidecars to expect.
+
+**The model volume is dm-verity sealed, not merely hash-checked at admission.**
+Admission-time hashing proves the bytes were correct when checked, not that they
+stayed correct. Verity is continuous and kernel-enforced. A large, read-only,
+long-lived blob reused across many runs is verity's ideal case, and the claim-3
+machinery already exists. This matters because "sealed volume" will otherwise be
+read as verity-strength when it is not.
+
+### Crate placement
+
+Following the existing dependency direction (high → low):
+
+| Crate | Addition | Why here |
+|---|---|---|
+| `mvm-protocol` | `ModelRequirements`, `Generate` request/response DTOs | Already owns the Workload IR and policy DTOs; keeps these `no_std` and wasm-buildable |
+| `mvm-fs` | `mvm_fs::model` — bounded safetensors header reader | Pure parsing beside the ext4 writer and OCI unpacker; keeps mvm-fs a zero-mvm-dep leaf, so the parser is trivially fuzzable |
+| `mvm-core` | `policy/model_requirements.rs` — derivation and `Profile::satisfies`; the `model` section on `ExecutionPlan` | Derivation is policy, not parsing; separating them makes the arithmetic unit-testable with no I/O |
+| `mvm-hostd` | Admission check in `plan_admission.rs` | Where sealed-volume verification and plan admission already live |
+| `mvm-cli` | `commands/ai/{pull,run,ls,profile}.rs` | Clap group = directory, one file per subaction |
+| Guest | candle runtime in the runtime overlay | uid 901 under setpriv, model volume read-only, `Generate` on the existing vsock protocol |
+
+Four subcommands clears the grouping map's bar against single-member and
+semantically-forced groups. `ai` is not folded into `run --image` because a
+model run is a different kind of admission with its own requirement check, and
+that difference should be visible rather than hidden behind a flag.
+
+### Naming: "capability profile", and it extends templates
+
+`--profile` is already taken. In `build image` and `template create` it means a
+*nix image profile* — which software is in the guest. What `ai` needs is a
+declared *resource and capability shape* — vCPUs, memory, available ops. Same
+word, two axes, in adjacent commands. Resolved explicitly:
+
+- The concept is a **capability profile**. Within `ai`'s own namespace the
+  subcommand `ai profile list|show` is unambiguous, because it is a noun under
+  `ai` rather than a flag.
+- The flag is **`--vm-profile`**, never `--profile`. `--profile` is not a global
+  argument, so there is no clap-level conflict, but reusing the word for a
+  second meaning in a neighbouring command is exactly the ambiguity that costs
+  someone an hour later.
+- A capability profile **extends the existing template config rather than
+  forking a parallel resource vocabulary.** Templates already declare a
+  microVM's shape — cpus, memory, role, flake, image profile. Adding a declared
+  capability set to that schema is an extension; inventing a second
+  "profile" type that also carries cpus and memory would be a duplicate source
+  of truth for the same facts, which is this repo's most common bug source.
+
+What remains open is schema mechanics, not direction — see "Open questions".
+
+## Data flow
+
+### `ai pull <oci-ref>`
+
+1. Resolve the reference. Under `--prod`, refuse a mutable reference **before
+   any network fetch**.
+2. Fetch the manifest, verify cosign against the configured registry policy,
+   resolve to a digest.
+3. Stream layers through the allow-listed OCI unpacker to disk. Never buffer a
+   model in host RAM — a 30 B model is a 30 GB allocation.
+4. **Content-sniff** the format. Exactly one is accepted: safetensors. Anything
+   else is refused, naming the detected format. Extension is never consulted.
+5. Parse the safetensors header under bounds (see "Host-side parsing").
+6. Derive `ModelRequirements` from **summed actual tensor shapes** plus dtype
+   and context length — not from a declared parameter count. A model claiming
+   7 B while carrying 70 B of weights would otherwise be granted an undersized
+   VM.
+7. Seal the volume: `content/`, hash-chained `meta.json` (`kind: model`),
+   verity sidecar and roothash.
+8. Emit `model.pulled` to the chain-signed audit log: registry host, repository,
+   supplied reference, resolved manifest digest, layer digest list, trust
+   policy, cosign verdict, derived requirements, verity roothash.
+
+### `ai run <model> --vm-profile <p>`
+
+1. Verify the sealed volume and the verity roothash.
+2. Resolve the named profile. Evaluate `Profile::satisfies(&requirements)`; on
+   failure, refuse with a per-requirement diff naming each unmet dimension.
+3. Apply the host memory-grant ceiling, which is independent of what the model
+   asks for.
+4. Synthesize an `ExecutionPlan` binding model digest, runtime digest, verity
+   roothash, resolved profile, frozen requirements, sampler seed, and prompt
+   digest. Sign under the host signer, verify, enforce the validity window and
+   the nonce replay store.
+5. Admit: re-verify the sealed volume, re-check `satisfies`, confirm the
+   resolved network policy is deny-all absent an explicit opt-in.
+6. Emit `plan.admitted`. Boot a transient microVM — verity rootfs, read-only
+   verity model volume, no network, no console, agent at uid 901.
+7. Deliver the prompt over chunked vsock. Stream tokens back chunked.
+8. Sanitize control sequences on the host before stdout.
+9. Emit `plan.launched`, then `model.generated`: prompt digest, output digest,
+   token counts, seed, duration. **No prompt or output bytes.**
+10. Destroy the VM. Transient is the default lifecycle.
+
+## Security surfaces
+
+### Host-side parsing — the deliberate inversion
+
+Deriving requirements host-side means a hostile model file attacks the **host**
+parser before any microVM exists. This inverts mvm's usual posture and is
+accepted deliberately, under bounds:
+
+- Header length capped at 16 MiB; a larger declared length is refused, not
+  allocated.
+- Every tensor offset and size validated against actual file length.
+- Checked arithmetic on all `offset + size` computations.
+- `forbid(unsafe_code)` in `mvm_fs::model`.
+- Tensor *data* is never read on the host. Only the header.
+- A `cargo-fuzz` target (`fuzz_safetensors_header`) as a claim-5-style witness.
+
+**Documented upgrade path:** derive inside a disposable microVM using the
+existing Stage-0/dev tier, so no untrusted model bytes are parsed on the host at
+all. Strictly stronger. Deferred because it puts a VM boot on the `ai pull` path
+and needs a trusted channel for returning the derived requirements, and because
+a bounded header parse is small enough to prove. If the header parser ever grows
+beyond header parsing, this upgrade becomes mandatory rather than optional.
+
+### Terminal escape injection
+
+Generated tokens reach the user's terminal. Model output can carry ANSI/OSC
+sequences — cursor manipulation, hyperlinks, clipboard writes on some
+terminals. Control sequences are stripped on output by default, with an explicit
+opt-out for raw. This is a real attack on the operator, not the guest.
+
+### Chat templates are an interpreter on untrusted input
+
+Hugging Face models ship Jinja2 chat templates. Template semantics over
+attacker-controlled data is a computation-DoS surface at best. **v1 refuses
+templates outright** and treats the prompt as literal text. If templating ever
+lands, it renders *only* inside the guest, never on the host.
+
+### Framing
+
+`MAX_FRAME_SIZE` is 256 KiB. Long-context prompts and streamed generations
+exceed it, so `Generate` is chunked — and chunking is where framing bugs live.
+The chunked path joins the fuzzed surface alongside `GuestRequest` and
+`AuthenticatedFrame`; it does not sit beside it unfuzzed.
+
+### Prompt confidentiality
+
+Prompts routinely carry secrets.
+
+- Never on a command line. Anything in argv is world-readable via `ps`.
+- Never in an environment variable of a child process.
+- Delivered over vsock or by file descriptor.
+- The plan carries the prompt **digest**, never the prompt.
+- The audit chain carries prompt and output **digests**, never bytes —
+  consistent with the existing no-payload-bytes property of the broker channel.
+
+### Resource arithmetic
+
+A model declaring a 2³¹ context length derives a KV-cache floor in the
+petabytes. Derivation uses checked arithmetic and an absolute ceiling; an absurd
+requirement is a refusal, not a VM spec. Separately, the host enforces a
+memory-grant ceiling independent of the model's ask, so a single `ai run`
+cannot exhaust the machine.
+
+### Format confusion
+
+Format detection is content-based. A file named `.safetensors` whose bytes are a
+pickle is refused. Extension-driven detection is the weak version of this and is
+not used.
+
+### Failure ladder
+
+Fifteen named refusals, each with a test, none silently degrading:
+
+1. Mutable reference under `--prod` — refused before network I/O
+2. cosign verdict failure — refused before cache admission
+3. Unpack path escape, symlink, or device node
+4. Content-sniffed format is not safetensors
+5. Header length over cap
+6. Header length past EOF
+7. Tensor offset or size overflow, or past EOF
+8. Derived requirement over the absolute ceiling
+9. Volume manifest tamper
+10. Verity roothash mismatch
+11. Profile does not satisfy requirements — with a per-requirement diff
+12. Profile ask over the host grant ceiling
+13. Unsigned, expired, or replayed plan
+14. Resolved egress policy is not deny-all without an explicit opt-in
+15. Guest reports a missing capability at load
+
+## Deferred, with boundaries
+
+These are not omissions. Each is a boundary that a later phase must argue past
+rather than drift across.
+
+### Prompt injection — out of scope only while `ai` is one-shot
+
+v1 has no tools, so model output is data that reaches a terminal and nothing
+else. **The moment model output can trigger a tool call, output becomes control
+flow and the threat model changes completely** — an untrusted string starts
+selecting actions. Phase 3 (agentic use) may not be added as an increment to
+this design; it requires its own threat model covering at minimum: which verbs
+model output may select, how those verbs are bound in the plan the way broker
+services already are, and what the audit record of a model-selected action looks
+like. The plan-bound verb enforcement machinery is the obvious foundation, and
+the default must remain that model output selects nothing.
+
+### Warm-pool KV residue — a phase-2 blocker for `ai serve`
+
+Serving means reusing a warm VM across prompts. Prior prompt data persists in
+guest memory, and the agent explicitly does not scrub between calls —
+cross-call state is documented as the caller's responsibility. For a single
+tenant's successive prompts that is a confidentiality question; across tenants
+it is a confidentiality **bug**. `ai serve` therefore cannot ship on the warm
+pool until one of the following holds:
+
+- the guest scrubs KV-cache and prompt buffers between generations, with a test
+  proving residue is absent; or
+- a warm VM is bound to exactly one tenant for its whole life, enforced at
+  claim time rather than by convention; or
+- serving uses cold transient VMs per request, accepting the latency.
+
+This interacts with the standby pool shipping disarmed: the pool's own pre-flip
+blockers must clear before this one is even reachable.
+
+### Timing and resource side channels — out of scope, stated
+
+Inference timing leaks prompt and output length, and shared-CPU cache effects
+are real. Consistent with the existing exclusion of hardware-level attacks from
+the threat model. Recorded so the exclusion is deliberate rather than silent. A
+co-tenant threat model would have to revisit this, and the single-workload-per-
+guest rule is what currently makes it tolerable.
+
+### GPU acceleration — out of scope, and it moves the C/C++ line
+
+candle is Rust end-to-end on the CPU path. Accelerator backends pull in vendor
+toolchains — CUDA kernels, Metal shaders — which moves C/C++ back onto the
+workload path and would weaken the justification for decision 2. microVM guests
+have no GPU passthrough today, so CPU-only is the natural v1 scope. Any GPU work
+must re-argue the runtime choice rather than inherit it.
+
+### Model licensing and use restrictions — not addressed
+
+Weights frequently carry licence terms restricting use. mvm records provenance
+and makes no licence assertion. Out of scope, noted so nobody reads
+`model.pulled` provenance as a licence check.
+
+## Testing
+
+- **Unit** — derivation arithmetic (overflow, ceiling, dtype table); every
+  `Profile::satisfies` dimension independently; content sniffing against each
+  rejected magic; header validation against each malformed case.
+- **Fuzz** — `fuzz_safetensors_header`; the chunked `Generate` framing.
+- **Tamper** — byte-flip in `content/` caught by verity; `meta.json` tamper
+  caught by the volume verifier; digest swap refused.
+- **Claims** — this adds claim-bearing behaviour, so it needs rows in the
+  claims ledger with `fn:` and `ci:` witnesses. Those witnesses enter the
+  mutation surface automatically via the ledger-derived pin, which means a
+  witness that cannot detect its property breaking will be reported.
+- **CI** — an `ai-model-admission` lane exercising pull → run against a tiny
+  fixture model with no network access, plus the refusal ladder.
+
+## Open questions
+
+- Does candle plus a tokenizer fit the 50 MB guest footprint budget? Measure
+  before embedding. A miss forces decision 2 to be revisited.
+- How exactly does a capability profile attach to the template schema — a new
+  optional section, or a separate file keyed by template name? Direction is
+  settled (extend templates, do not fork a resource vocabulary); only the
+  mechanics are open.
+- Does verity on a second, very large volume add measurable boot cost? If it
+  does, the fallback is admission-time hashing with the weaker guarantee stated
+  explicitly rather than silently.

--- a/specs/notes/2026-07-29-ai-command-design.md
+++ b/specs/notes/2026-07-29-ai-command-design.md
@@ -98,9 +98,46 @@ candle's quantized/GGUF coverage is weaker than llama.cpp's. Under a pluggable
 design this is no longer a dead end — it is the specific gap a second runtime
 would fill, and the reason a GGUF-capable runtime is the obvious second entry.
 
-**Footprint risk to measure in week one:** the complete guest footprint budget
-is 50 MB, and it applies *per runtime image*. candle plus a tokenizer may exceed
-it. Measure before embedding.
+candle plus a tokenizer will not fit the default tier's 50 MB guest footprint
+budget. That budget is not relaxed — it is **tiered**; see "Footprint: a second
+tier, not an exemption".
+
+### Footprint: a second tier, not an exemption
+
+The 50 MB guest footprint budget is a *default-tier* number and it does not
+move. An inference runtime does not fit in it and should not be squeezed into
+it; AI guests get their own tier with its own ceiling.
+
+The distinction matters because the existing budgets are not advisory. They are
+pinned constants with tests that pin them (`guest_storage_budget_is_50_mb`,
+`all_budgets_pin_guest_storage_to_constant`), and the closure budget's error
+message tells you to bump the constant "with a one-line justification". The AI
+tier follows that same discipline rather than opting out of it:
+
+- `GUEST_STORAGE_BUDGET` (default tier, 50 MB) is unchanged. Nothing about this
+  work is allowed to move it.
+- A new `AI_GUEST_STORAGE_BUDGET` constant is added beside it, with its own
+  pinning test and its own entry in `all_budgets()`, so `xtask perf budgets`
+  lists both tiers and neither can drift silently.
+- **Initial ceiling: 256 MB.** Roughly five times the default, comfortably above
+  a realistic candle-plus-tokenizer image, and still an order of magnitude below
+  any model it will load.
+- The tier is declared in the runtime registry entry, so conformance check 5
+  asserts a runtime against *its own tier's* budget. A runtime that cannot fit
+  its declared tier is not admissible.
+- Raising the constant requires the same one-line justification the closure
+  budget already demands, visible in review.
+
+256 MB is a **starting** ceiling chosen without measurement, and the first
+implementation task is to measure the real image and *tighten the constant to
+the measured size plus headroom*. Set-generous-and-forget is how a budget stops
+being a budget; the ratchet is supposed to move down.
+
+This is a security number, not only a performance one. Everything inside the
+guest image sits inside the dm-verity boundary and is measured as part of the
+runtime digest, so a larger image is more attack surface within the sealed
+perimeter. That is precisely why the AI tier is a pinned, justified ceiling
+rather than an exemption from the gate.
 
 ### Format policy across runtimes
 
@@ -265,7 +302,10 @@ partially-enforced backend matrix.
 4. **Capability honesty** — declared capabilities match observed behaviour. A
    model using a declared-supported op runs; a model needing an undeclared op is
    refused *at admission*, not by failing mid-generation.
-5. **Footprint** — the guest image carrying this runtime stays within budget.
+5. **Footprint** — the guest image carrying this runtime stays within the budget
+   of the tier that runtime declares. A runtime that cannot fit its declared
+   tier is not admissible; declaring a larger tier is a reviewed constant bump,
+   not a per-runtime escape hatch.
 6. **No interactive surface** — the runtime binary links no console or exec
    path, mirroring the claim-15 symbol contract.
 7. **Frame discipline** — chunked `Generate` respects `MAX_FRAME_SIZE` in both
@@ -471,8 +511,9 @@ as a licence check.
 
 ## Open questions
 
-- Does candle plus a tokenizer fit the 50 MB guest footprint budget? Measure
-  before embedding. The budget applies per runtime image.
+- What is the real candle-plus-tokenizer image size? The AI tier ships with a
+  256 MB starting ceiling; measure first and tighten the constant to the
+  measured size plus headroom rather than leaving the initial guess in place.
 - How exactly does a capability profile attach to the template schema — a new
   optional section, or a separate file keyed by template name? Direction is
   settled (extend templates, do not fork a resource vocabulary); only the

--- a/specs/notes/2026-07-29-ai-command-design.md
+++ b/specs/notes/2026-07-29-ai-command-design.md
@@ -1,7 +1,10 @@
 # Design: the `ai` command — models run only in profile-matched microVMs
 
 **Date:** 2026-07-29
-**Status:** Design approved; implementation plan pending.
+**Status:** **Draft — design settled, implementation deferred and unscheduled.**
+No implementation plan exists by choice: a plan written for unscheduled work
+goes stale before anyone reads it. The sequencing sketch at the end is the
+starting point if and when this is picked up.
 **Scope:** v1 is one-shot inference. Serving is phase 2, tool-calling is phase 3,
 and both are gated by the boundaries stated in "Deferred, with boundaries".
 
@@ -119,19 +122,23 @@ tier follows that same discipline rather than opting out of it:
 - A new `AI_GUEST_STORAGE_BUDGET` constant is added beside it, with its own
   pinning test and its own entry in `all_budgets()`, so `xtask perf budgets`
   lists both tiers and neither can drift silently.
-- **Initial ceiling: 256 MB.** Roughly five times the default, comfortably above
-  a realistic candle-plus-tokenizer image, and still an order of magnitude below
-  any model it will load.
+- **The ceiling is measured, never guessed.** No number is committed before a
+  measurement exists. The constant is set from the first real
+  runtime-plus-tokenizer image: measured size rounded up to the next 32 MB
+  boundary, with the measured figure recorded in the commit that introduces the
+  constant. The gate therefore lands in the same change as the evidence for its
+  value.
 - The tier is declared in the runtime registry entry, so conformance check 5
   asserts a runtime against *its own tier's* budget. A runtime that cannot fit
   its declared tier is not admissible.
 - Raising the constant requires the same one-line justification the closure
   budget already demands, visible in review.
 
-256 MB is a **starting** ceiling chosen without measurement, and the first
-implementation task is to measure the real image and *tighten the constant to
-the measured size plus headroom*. Set-generous-and-forget is how a budget stops
-being a budget; the ratchet is supposed to move down.
+An earlier draft of this design carried a 256 MB "initial ceiling" picked
+without measuring anything. That is precisely the set-generous-and-forget
+pattern this section exists to prevent, and it was removed rather than kept as a
+convenient default. The AI tier's number is an AI-specific measured fact, not a
+multiple of the default tier's.
 
 This is a security number, not only a performance one. Everything inside the
 guest image sits inside the dm-verity boundary and is measured as part of the
@@ -509,11 +516,37 @@ as a licence check.
   fixture model with no network access, plus the refusal ladder and the
   conformance suite.
 
+## Sequencing sketch
+
+Not a plan — a starting order if this is picked up. Pure and unit-testable work
+first, anything needing a booted VM last.
+
+- **WS-0 — measure the footprint.** Build the candle-plus-tokenizer guest image
+  and measure it; set `AI_GUEST_STORAGE_BUDGET` from that measurement. First
+  because it is the only result that can invalidate the runtime choice, and
+  everything downstream is wasted if it lands somewhere absurd.
+- **WS-1** — `mvm-protocol` DTOs; the bounded safetensors header reader in
+  `mvm-fs` plus its fuzz target. Pure, no VM.
+- **WS-2** — requirement derivation, `Profile::satisfies`, the runtime registry,
+  the three-party match. Pure, no I/O.
+- **WS-3** — the conformance suite, written *before* any runtime exists to pass
+  it. The design's claim that the suite is not shaped by its first
+  implementation only holds if it is written first.
+- **WS-4** — `ai pull`: OCI reuse, content sniffing, volume sealing with verity,
+  the `model.pulled` provenance entry.
+- **WS-5** — plan and admission: the `model` and `runtime` plan sections, the
+  conformance gate in `plan_admission`.
+- **WS-6** — the guest candle runtime, the `Generate` verb, chunked framing and
+  its fuzz target.
+- **WS-7** — the mock runtime, the `ai-model-admission` CI lane, and claims
+  ledger rows with `fn:`/`ci:` witnesses, which then enter the mutation surface
+  via the ledger-derived pin.
+
 ## Open questions
 
-- What is the real candle-plus-tokenizer image size? The AI tier ships with a
-  256 MB starting ceiling; measure first and tighten the constant to the
-  measured size plus headroom rather than leaving the initial guess in place.
+- What is the real candle-plus-tokenizer image size? This sets
+  `AI_GUEST_STORAGE_BUDGET` and is the first task if this is picked up, because
+  it is the one measurement that can invalidate the runtime choice.
 - How exactly does a capability profile attach to the template schema — a new
   optional section, or a separate file keyed by template name? Direction is
   settled (extend templates, do not fork a resource vocabulary); only the

--- a/specs/notes/2026-07-29-ai-command-design.md
+++ b/specs/notes/2026-07-29-ai-command-design.md
@@ -7,11 +7,11 @@ and both are gated by the boundaries stated in "Deferred, with boundaries".
 
 ## Goal
 
-`mvmctl ai run <model> --vm-profile <p>` executes a model inside a microVM that has
-been *proved* to satisfy that model's requirements, from a signed
+`mvmctl ai run <model> --vm-profile <p>` executes a model inside a microVM that
+has been *proved* to satisfy that model's requirements, from a signed
 `ExecutionPlan` that binds the model bytes, the runtime bytes, and the granted
-resources together. A model whose requirements the profile cannot meet is
-refused at admission, not discovered as an OOM mid-generation.
+resources together. A model whose requirements cannot be met is refused at
+admission, not discovered as an OOM mid-generation.
 
 mvm today is a sandbox for code an LLM writes. This adds the inverse: a sandbox
 for the model itself.
@@ -22,83 +22,121 @@ Four load-bearing choices, settled before design:
 
 1. **mvm orchestrates; it does not implement inference.** mvm owns acquisition,
    provenance, the capability match, the plan, the VM, and the audit trail. A
-   single pinned third-party runtime does the arithmetic.
-2. **One runtime, pinned, digest-bound — `candle`.** Not pluggable.
+   third-party runtime does the arithmetic.
+2. **Runtimes are pluggable behind a conformance-gated seam.** More than one
+   inference runtime is supported. A runtime becomes admissible only by passing
+   the conformance suite; the plan binds which runtime ran and its digest.
 3. **Models are OCI artifacts.** Acquisition reuses the existing OCI provenance
    pipeline rather than growing a second one.
 4. **Requirements are derived host-side at pull and frozen into the signed
    plan.** The guest never declares its own needs and never negotiates.
 
-### Why one runtime, not a pluggable set
+### Why pluggable, and what it actually costs
 
-Two properties mvm actually sells break under N runtimes.
+Pluggability avoids betting mvm's workload path on one third party's roadmap —
+the same instinct that keeps VMM specifics behind `VmBackend` rather than
+hardcoding one hypervisor. No single runtime covers every model, format, and
+accelerator, and the format landscape (safetensors, GGUF) is not converging.
 
-*Reproducibility.* The same `mvmctl` is supposed to produce the same result on
-every host. Different runtimes produce different tokens for the same model and
-prompt — different dequantization paths, sampler arithmetic, KV-cache precision.
-Since `ai run` writes provenance to a chain-signed audit log, a pluggable
-runtime makes that record non-reproducible: the log names the model and prompt
-while the output depended on something absent from the plan. Pinning one runtime
-and putting *its* digest in the plan is what makes
-`(model, runtime, seed, prompt) → output` an auditable relation.
+Two objections were raised against pluggability. One dissolves; one is real.
 
-*Claim surface.* Each runtime is a fresh untrusted-input parser, CVE stream,
-capability matrix, and egress profile — several runtimes fetch tokenizers at load
-time, which is a separate egress problem each time. The per-backend tier matrix
-is already incomplete (claim-10 egress enforcement is live on two of four VM
-backends). Multiplying the workload-bearing surface again is how that matrix
-stays permanently incomplete.
+*Reproducibility — dissolves.* The concern was that different runtimes produce
+different tokens for the same model and prompt (different dequantization paths,
+sampler arithmetic, KV-cache precision), making the audit record
+non-reproducible. But the plan already binds the runtime identity **and its
+digest** alongside the model digest. `(model, runtime, runtime_digest, seed,
+prompt) → output` remains an auditable relation; reproducibility is scoped
+per-runtime, which is the honest guarantee and is sufficient. This objection was
+overstated.
 
-The seam is defined without the plurality: a narrow guest-side contract
-(declare capabilities, load model, generate) with exactly one implementation
-behind it. A second implementation is a rebuild, not a portability break,
-because mvm controls the guest image end to end — which is why runtime lock-in
-is not the same risk as VMM lock-in.
+*Claim surface — real, and mitigated mechanically.* Each runtime is a fresh
+untrusted-input parser, CVE stream, capability matrix, egress profile, guest
+image, and footprint. The failure mode is not hypothetical: claim-10 egress
+enforcement is currently live on two of four VM backends, because per-backend
+enforcement was left to discipline. Pluggable runtimes go the same way unless a
+runtime is **inadmissible until it proves itself**.
 
-### Why candle, and what it costs
+The answer is the conformance suite below. It is a precondition for admission,
+enforced at plan synthesis, not a checklist someone is trusted to have run.
 
-The runtime's security-relevant job is parsing untrusted binary files — headers,
-tensor layouts, tokenizer data. Doing that in Rust rather than C++ is the
-largest available reduction in this choice, and it keeps C/C++ off the workload
-path.
+There is a genuine upside to being forced into this: with a single runtime, the
+security properties would have been *implicitly* true of whichever runtime was
+chosen and never stated. Pluggability forces them to be explicit and tested.
+
+### The runtime seam
+
+A runtime is described host-side by a registry entry and implemented guest-side
+by a binary honouring the guest contract.
+
+Host-side descriptor:
+
+| Field | Meaning |
+|---|---|
+| `id` | Stable runtime identifier |
+| `digest` | Digest of the guest binary/overlay carrying it |
+| `formats` | Model formats this runtime accepts (never includes pickle) |
+| `capabilities` | Ops, dtypes, quantizations it can execute |
+| `overhead` | Resource overhead added to the model's own requirements |
+| `conformance` | Attestation that this `(id, digest)` passed the suite |
+
+Guest-side contract: declare capabilities, load a model from the read-only
+volume, generate over chunked vsock. Three verbs, no more — the seam stays
+narrow enough that a new runtime is a bounded amount of work.
+
+### Reference runtime: candle
+
+candle is the first runtime and the reference implementation of the seam. It is
+Rust, safetensors-native, HF-backed, and builds static for a small guest.
 
 Being precise: **candle uses `unsafe`** — memory-mapped safetensors access and
 SIMD intrinsics at minimum. This is a meaningful reduction from a C++ runtime,
 not the `forbid(unsafe_code)` guarantee `mvm-protocol` provides. Any claim
-written about this must say "no C/C++ on the workload path", never "memory-safe".
+written about a runtime must say "no C/C++ on the workload path" only where that
+is true of *that* runtime, never as a global property of `ai`.
 
-safetensors-first also buys a claim that is otherwise unavailable: safetensors
-has no execution semantics — a JSON header and a flat tensor region. Pickle
-(`.pt`/`.bin`) is arbitrary code execution on load. Supporting exactly one
-format, and that format having no code-execution semantics, is a cheap and
-defensible position.
-
-The cost, stated plainly: candle's quantized/GGUF coverage is weaker than
-llama.cpp's. This design targets provably-isolated auditable inference of
-moderate models, not maximum model size per gigabyte of host RAM. If the latter
-becomes the requirement, this decision must be revisited rather than stretched.
+candle's quantized/GGUF coverage is weaker than llama.cpp's. Under a pluggable
+design this is no longer a dead end — it is the specific gap a second runtime
+would fill, and the reason a GGUF-capable runtime is the obvious second entry.
 
 **Footprint risk to measure in week one:** the complete guest footprint budget
-is 50 MB. candle plus a tokenizer may exceed it. This is an engineering
-constraint, not a security one, but it could force decision 2 to be revisited,
-so it must be measured before the runtime is embedded.
+is 50 MB, and it applies *per runtime image*. candle plus a tokenizer may exceed
+it. Measure before embedding.
+
+### Format policy across runtimes
+
+Formats are per-runtime — candle accepts safetensors, a GGUF runtime accepts
+GGUF. Two invariants hold **globally**, independent of runtime:
+
+- **Pickle is never accepted by any runtime.** `.pt`/`.bin` pickle is arbitrary
+  code execution on load. No registry entry may list it, and the loader refuses
+  it before any runtime sees it.
+- **Format detection is content-sniffed, never extension-based.** A file named
+  `.safetensors` whose bytes are a pickle is refused. A model is dispatched to a
+  runtime only after its true format is established.
+
+Note what pluggability costs here: with a single safetensors-only runtime, "the
+one format we accept has no code-execution semantics" would have been a claim.
+It is now a weaker, per-runtime statement, and GGUF's richer metadata parser is
+a larger attack surface than safetensors'. That is a real reduction in the
+strength of the claim available, and the conformance suite's refusal ladder is
+what keeps it from being a reduction in actual safety.
 
 ## Architecture
 
-**The model is data; the runtime is code.** The candle-based inference binary
-ships inside the signed, dm-verity-sealed guest overlay and is measured like
-every other guest executable. Model weights are a separate read-only volume.
-Swapping models never re-seals the guest; the runtime stays measured
-independently. The plan binds both digests, and neither is taken from the
+**The model is data; the runtime is code.** A runtime binary ships inside a
+signed, dm-verity-sealed guest overlay and is measured like every other guest
+executable. Model weights are a separate read-only volume. Swapping models never
+re-seals the guest; swapping runtimes means selecting a different sealed
+overlay, and the plan records which one. Neither digest is taken from the
 guest's word.
 
 **Model storage reuses the sealed-volume mechanism** that backs claim 11.
 Models live at `<mvm_home>/volumes/models/<digest>/` alongside
-`<mvm_home>/volumes/deps`, verified by the same
-`verify_sealed_volume`-shaped path: a directory with a hash-chained manifest,
-checked before launch. SBOM and CVE sidecars do not apply to weights, so the
-manifest carries an explicit `kind: model` and their absence is by design rather
-than a stub — the verifier must not have to guess which sidecars to expect.
+`<mvm_home>/volumes/deps`, verified by the same `verify_sealed_volume`-shaped
+path: a directory with a hash-chained manifest, checked before launch. SBOM and
+CVE sidecars do not apply to weights, so the manifest carries an explicit
+`kind: model` and their absence is by design rather than a stub — the verifier
+must not have to guess which sidecars to expect.
 
 **The model volume is dm-verity sealed, not merely hash-checked at admission.**
 Admission-time hashing proves the bytes were correct when checked, not that they
@@ -113,17 +151,19 @@ Following the existing dependency direction (high → low):
 
 | Crate | Addition | Why here |
 |---|---|---|
-| `mvm-protocol` | `ModelRequirements`, `Generate` request/response DTOs | Already owns the Workload IR and policy DTOs; keeps these `no_std` and wasm-buildable |
-| `mvm-fs` | `mvm_fs::model` — bounded safetensors header reader | Pure parsing beside the ext4 writer and OCI unpacker; keeps mvm-fs a zero-mvm-dep leaf, so the parser is trivially fuzzable |
-| `mvm-core` | `policy/model_requirements.rs` — derivation and `Profile::satisfies`; the `model` section on `ExecutionPlan` | Derivation is policy, not parsing; separating them makes the arithmetic unit-testable with no I/O |
-| `mvm-hostd` | Admission check in `plan_admission.rs` | Where sealed-volume verification and plan admission already live |
-| `mvm-cli` | `commands/ai/{pull,run,ls,profile}.rs` | Clap group = directory, one file per subaction |
-| Guest | candle runtime in the runtime overlay | uid 901 under setpriv, model volume read-only, `Generate` on the existing vsock protocol |
+| `mvm-protocol` | `ModelRequirements`, `RuntimeCapabilities`, `Generate` DTOs | Already owns the Workload IR and policy DTOs; keeps these `no_std` and wasm-buildable |
+| `mvm-fs` | `mvm_fs::model` — bounded format readers, one per accepted format | Pure parsing beside the ext4 writer and OCI unpacker; keeps mvm-fs a zero-mvm-dep leaf, so parsers are trivially fuzzable |
+| `mvm-core` | `policy/model_requirements.rs` — derivation, `Profile::satisfies`, runtime registry and the three-party match; the `model` and `runtime` sections on `ExecutionPlan` | Derivation and matching are policy, not parsing; separating them makes the arithmetic unit-testable with no I/O |
+| `mvm-hostd` | Admission check in `plan_admission.rs`, including the conformance gate | Where sealed-volume verification and plan admission already live |
+| `mvm-cli` | `commands/ai/{pull,run,ls,profile,runtime}.rs` | Clap group = directory, one file per subaction |
+| Guest | One runtime binary per runtime overlay | uid 901 under setpriv, model volume read-only, `Generate` on the existing vsock protocol |
 
-Four subcommands clears the grouping map's bar against single-member and
-semantically-forced groups. `ai` is not folded into `run --image` because a
-model run is a different kind of admission with its own requirement check, and
-that difference should be visible rather than hidden behind a flag.
+`ai runtime list|show` exposes the registry — which runtimes exist, what each
+accepts, and whether its conformance attestation is current.
+
+`ai` is not folded into `run --image` because a model run is a different kind of
+admission with its own requirement check, and that difference should be visible
+rather than hidden behind a flag.
 
 ### Naming: "capability profile", and it extends templates
 
@@ -142,9 +182,9 @@ word, two axes, in adjacent commands. Resolved explicitly:
 - A capability profile **extends the existing template config rather than
   forking a parallel resource vocabulary.** Templates already declare a
   microVM's shape — cpus, memory, role, flake, image profile. Adding a declared
-  capability set to that schema is an extension; inventing a second
-  "profile" type that also carries cpus and memory would be a duplicate source
-  of truth for the same facts, which is this repo's most common bug source.
+  capability set to that schema is an extension; inventing a second "profile"
+  type that also carries cpus and memory would be a duplicate source of truth
+  for the same facts, which is this repo's most common bug source.
 
 What remains open is schema mechanics, not direction — see "Open questions".
 
@@ -158,9 +198,10 @@ What remains open is schema mechanics, not direction — see "Open questions".
    resolve to a digest.
 3. Stream layers through the allow-listed OCI unpacker to disk. Never buffer a
    model in host RAM — a 30 B model is a 30 GB allocation.
-4. **Content-sniff** the format. Exactly one is accepted: safetensors. Anything
-   else is refused, naming the detected format. Extension is never consulted.
-5. Parse the safetensors header under bounds (see "Host-side parsing").
+4. **Content-sniff** the format. Pickle is refused outright. A format no
+   registered runtime accepts is refused, naming the format and listing what is
+   accepted. Extension is never consulted.
+5. Parse the format header under bounds (see "Host-side parsing").
 6. Derive `ModelRequirements` from **summed actual tensor shapes** plus dtype
    and context length — not from a declared parameter count. A model claiming
    7 B while carrying 70 B of weights would otherwise be granted an undersized
@@ -169,28 +210,69 @@ What remains open is schema mechanics, not direction — see "Open questions".
    verity sidecar and roothash.
 8. Emit `model.pulled` to the chain-signed audit log: registry host, repository,
    supplied reference, resolved manifest digest, layer digest list, trust
-   policy, cosign verdict, derived requirements, verity roothash.
+   policy, cosign verdict, detected format, derived requirements, verity
+   roothash.
 
-### `ai run <model> --vm-profile <p>`
+### `ai run <model> --vm-profile <p> [--runtime <id>]`
 
 1. Verify the sealed volume and the verity roothash.
-2. Resolve the named profile. Evaluate `Profile::satisfies(&requirements)`; on
-   failure, refuse with a per-requirement diff naming each unmet dimension.
-3. Apply the host memory-grant ceiling, which is independent of what the model
-   asks for.
-4. Synthesize an `ExecutionPlan` binding model digest, runtime digest, verity
-   roothash, resolved profile, frozen requirements, sampler seed, and prompt
-   digest. Sign under the host signer, verify, enforce the validity window and
-   the nonce replay store.
-5. Admit: re-verify the sealed volume, re-check `satisfies`, confirm the
-   resolved network policy is deny-all absent an explicit opt-in.
-6. Emit `plan.admitted`. Boot a transient microVM — verity rootfs, read-only
+2. **Select the runtime.** Explicit `--runtime` if given; otherwise the single
+   registered runtime accepting this model's format. Ambiguity is a refusal
+   naming the candidates — never an implicit pick, because which runtime ran is
+   a security-relevant fact and guessing it silently is how a model ends up
+   somewhere unintended.
+3. **Three-party match.** The runtime must accept the model's format and
+   capabilities; the profile must satisfy the model's requirements *plus* the
+   runtime's declared overhead. Failure is refused with a per-dimension diff
+   naming what was unmet and by which party.
+4. **Conformance gate.** The selected `(runtime_id, digest)` must carry a
+   current conformance attestation. An unattested runtime is refused here, with
+   no override flag.
+5. Apply the host memory-grant ceiling, independent of what the model asks for.
+6. Synthesize an `ExecutionPlan` binding model digest, runtime id, runtime
+   digest, conformance attestation, verity roothash, resolved profile, frozen
+   requirements, sampler seed, and prompt digest. Sign under the host signer,
+   verify, enforce the validity window and the nonce replay store.
+7. Admit: re-verify the sealed volume, re-check the three-party match and the
+   conformance gate, confirm the resolved network policy is deny-all absent an
+   explicit opt-in.
+8. Emit `plan.admitted`. Boot a transient microVM — verity rootfs, read-only
    verity model volume, no network, no console, agent at uid 901.
-7. Deliver the prompt over chunked vsock. Stream tokens back chunked.
-8. Sanitize control sequences on the host before stdout.
-9. Emit `plan.launched`, then `model.generated`: prompt digest, output digest,
-   token counts, seed, duration. **No prompt or output bytes.**
-10. Destroy the VM. Transient is the default lifecycle.
+9. Deliver the prompt over chunked vsock. Stream tokens back chunked.
+10. Sanitize control sequences on the host before stdout.
+11. Emit `plan.launched`, then `model.generated`: runtime id and digest, prompt
+    digest, output digest, token counts, seed, duration. **No prompt or output
+    bytes.**
+12. Destroy the VM. Transient is the default lifecycle.
+
+## Runtime conformance suite
+
+A runtime is inadmissible until `(id, digest)` passes every check. The
+attestation is recorded in the registry and verified at plan synthesis and again
+at admission. This is the mechanism that keeps pluggability from reproducing the
+partially-enforced backend matrix.
+
+1. **Refusal ladder** — presented with a pickle payload, a truncated header, an
+   offset past EOF, and a declared-huge header, the runtime refuses each with a
+   named error rather than crashing, hanging, or loading. Formats differ between
+   runtimes; refusal behaviour does not.
+2. **No egress at load** — loads a model with deny-all egress and no network
+   device, and succeeds. Catches runtimes that fetch tokenizers or configs at
+   load time.
+3. **Determinism** — fixed model, prompt and seed produce byte-identical output
+   across two runs of the same `(id, digest)`. Scoped per-runtime by design;
+   cross-runtime agreement is explicitly not claimed.
+4. **Capability honesty** — declared capabilities match observed behaviour. A
+   model using a declared-supported op runs; a model needing an undeclared op is
+   refused *at admission*, not by failing mid-generation.
+5. **Footprint** — the guest image carrying this runtime stays within budget.
+6. **No interactive surface** — the runtime binary links no console or exec
+   path, mirroring the claim-15 symbol contract.
+7. **Frame discipline** — chunked `Generate` respects `MAX_FRAME_SIZE` in both
+   directions and refuses oversize frames.
+
+Adding a runtime means passing this suite. Failing any check means the runtime
+cannot be selected, with no flag to override.
 
 ## Security surfaces
 
@@ -200,41 +282,47 @@ Deriving requirements host-side means a hostile model file attacks the **host**
 parser before any microVM exists. This inverts mvm's usual posture and is
 accepted deliberately, under bounds:
 
-- Header length capped at 16 MiB; a larger declared length is refused, not
-  allocated.
+- Header length capped; a larger declared length is refused, not allocated.
 - Every tensor offset and size validated against actual file length.
 - Checked arithmetic on all `offset + size` computations.
 - `forbid(unsafe_code)` in `mvm_fs::model`.
 - Tensor *data* is never read on the host. Only the header.
-- A `cargo-fuzz` target (`fuzz_safetensors_header`) as a claim-5-style witness.
+- A `cargo-fuzz` target per accepted format, as claim-5-style witnesses.
+
+Pluggability raises the stakes here: each accepted format adds a host-side
+parser, and GGUF's metadata parser is substantially richer than safetensors'.
+The per-format fuzz target is therefore a requirement for accepting a format,
+not a follow-up.
 
 **Documented upgrade path:** derive inside a disposable microVM using the
 existing Stage-0/dev tier, so no untrusted model bytes are parsed on the host at
 all. Strictly stronger. Deferred because it puts a VM boot on the `ai pull` path
-and needs a trusted channel for returning the derived requirements, and because
-a bounded header parse is small enough to prove. If the header parser ever grows
-beyond header parsing, this upgrade becomes mandatory rather than optional.
+and needs a trusted channel for returning derived requirements. **If a second
+format lands and the host-side parser surface grows, this upgrade becomes
+mandatory rather than optional.**
 
 ### Terminal escape injection
 
 Generated tokens reach the user's terminal. Model output can carry ANSI/OSC
 sequences — cursor manipulation, hyperlinks, clipboard writes on some
 terminals. Control sequences are stripped on output by default, with an explicit
-opt-out for raw. This is a real attack on the operator, not the guest.
+opt-out for raw. This is an attack on the operator, not the guest.
 
 ### Chat templates are an interpreter on untrusted input
 
 Hugging Face models ship Jinja2 chat templates. Template semantics over
 attacker-controlled data is a computation-DoS surface at best. **v1 refuses
 templates outright** and treats the prompt as literal text. If templating ever
-lands, it renders *only* inside the guest, never on the host.
+lands, it renders *only* inside the guest, never on the host, and template
+handling joins the conformance suite.
 
 ### Framing
 
 `MAX_FRAME_SIZE` is 256 KiB. Long-context prompts and streamed generations
 exceed it, so `Generate` is chunked — and chunking is where framing bugs live.
 The chunked path joins the fuzzed surface alongside `GuestRequest` and
-`AuthenticatedFrame`; it does not sit beside it unfuzzed.
+`AuthenticatedFrame`, and frame discipline is a conformance check so a new
+runtime cannot quietly get it wrong.
 
 ### Prompt confidentiality
 
@@ -244,47 +332,43 @@ Prompts routinely carry secrets.
 - Never in an environment variable of a child process.
 - Delivered over vsock or by file descriptor.
 - The plan carries the prompt **digest**, never the prompt.
-- The audit chain carries prompt and output **digests**, never bytes —
-  consistent with the existing no-payload-bytes property of the broker channel.
+- The audit chain carries prompt and output **digests**, never bytes.
 
 ### Resource arithmetic
 
 A model declaring a 2³¹ context length derives a KV-cache floor in the
 petabytes. Derivation uses checked arithmetic and an absolute ceiling; an absurd
-requirement is a refusal, not a VM spec. Separately, the host enforces a
-memory-grant ceiling independent of the model's ask, so a single `ai run`
-cannot exhaust the machine.
-
-### Format confusion
-
-Format detection is content-based. A file named `.safetensors` whose bytes are a
-pickle is refused. Extension-driven detection is the weak version of this and is
-not used.
+requirement is a refusal, not a VM spec. Runtime overhead is added with the same
+checked arithmetic. Separately, the host enforces a memory-grant ceiling
+independent of the model's ask, so a single `ai run` cannot exhaust the machine.
 
 ### Failure ladder
 
-Fifteen named refusals, each with a test, none silently degrading:
+Eighteen named refusals, each with a test, none silently degrading:
 
 1. Mutable reference under `--prod` — refused before network I/O
 2. cosign verdict failure — refused before cache admission
 3. Unpack path escape, symlink, or device node
-4. Content-sniffed format is not safetensors
-5. Header length over cap
-6. Header length past EOF
-7. Tensor offset or size overflow, or past EOF
-8. Derived requirement over the absolute ceiling
-9. Volume manifest tamper
-10. Verity roothash mismatch
-11. Profile does not satisfy requirements — with a per-requirement diff
-12. Profile ask over the host grant ceiling
-13. Unsigned, expired, or replayed plan
-14. Resolved egress policy is not deny-all without an explicit opt-in
-15. Guest reports a missing capability at load
+4. Content-sniffed format is pickle — refused globally
+5. Content-sniffed format accepted by no registered runtime
+6. Header length over cap
+7. Header length past EOF
+8. Tensor offset or size overflow, or past EOF
+9. Derived requirement over the absolute ceiling
+10. Volume manifest tamper
+11. Verity roothash mismatch
+12. Runtime selection ambiguous — refused naming the candidates
+13. Selected runtime does not accept the model's format or capabilities
+14. Profile does not satisfy requirements plus runtime overhead — per-dimension diff
+15. Profile ask over the host grant ceiling
+16. Runtime lacks a current conformance attestation — no override
+17. Unsigned, expired, or replayed plan
+18. Resolved egress policy is not deny-all without an explicit opt-in
 
 ## Deferred, with boundaries
 
-These are not omissions. Each is a boundary that a later phase must argue past
-rather than drift across.
+These are not omissions. Each is a boundary a later phase must argue past rather
+than drift across.
 
 ### Prompt injection — out of scope only while `ai` is one-shot
 
@@ -304,59 +388,74 @@ Serving means reusing a warm VM across prompts. Prior prompt data persists in
 guest memory, and the agent explicitly does not scrub between calls —
 cross-call state is documented as the caller's responsibility. For a single
 tenant's successive prompts that is a confidentiality question; across tenants
-it is a confidentiality **bug**. `ai serve` therefore cannot ship on the warm
-pool until one of the following holds:
+it is a confidentiality **bug**. `ai serve` cannot ship on the warm pool until
+one of these holds:
 
 - the guest scrubs KV-cache and prompt buffers between generations, with a test
   proving residue is absent; or
-- a warm VM is bound to exactly one tenant for its whole life, enforced at
-  claim time rather than by convention; or
+- a warm VM is bound to exactly one tenant for its whole life, enforced at claim
+  time rather than by convention; or
 - serving uses cold transient VMs per request, accepting the latency.
 
-This interacts with the standby pool shipping disarmed: the pool's own pre-flip
-blockers must clear before this one is even reachable.
+Under pluggability this becomes a **per-runtime** obligation and therefore joins
+the conformance suite when serving lands — one runtime scrubbing correctly says
+nothing about another.
+
+This also queues behind the standby pool's own pre-flip blockers.
 
 ### Timing and resource side channels — out of scope, stated
 
 Inference timing leaks prompt and output length, and shared-CPU cache effects
 are real. Consistent with the existing exclusion of hardware-level attacks from
 the threat model. Recorded so the exclusion is deliberate rather than silent. A
-co-tenant threat model would have to revisit this, and the single-workload-per-
-guest rule is what currently makes it tolerable.
+co-tenant threat model would have to revisit this; the single-workload-per-guest
+rule is what currently makes it tolerable.
 
 ### GPU acceleration — out of scope, and it moves the C/C++ line
 
-candle is Rust end-to-end on the CPU path. Accelerator backends pull in vendor
-toolchains — CUDA kernels, Metal shaders — which moves C/C++ back onto the
-workload path and would weaken the justification for decision 2. microVM guests
-have no GPU passthrough today, so CPU-only is the natural v1 scope. Any GPU work
-must re-argue the runtime choice rather than inherit it.
+Accelerator backends pull in vendor toolchains — CUDA kernels, Metal shaders —
+which moves C/C++ onto the workload path. microVM guests have no GPU passthrough
+today, so CPU-only is the natural v1 scope. Under pluggability this is cleaner
+than it would have been: a GPU-capable runtime is a *separate registry entry*
+with its own conformance run and its own honest description of what it pulls in,
+rather than a compile-time flag quietly changing the properties of the one
+runtime.
 
 ### Model licensing and use restrictions — not addressed
 
 Weights frequently carry licence terms restricting use. mvm records provenance
-and makes no licence assertion. Out of scope, noted so nobody reads
-`model.pulled` provenance as a licence check.
+and makes no licence assertion. Noted so nobody reads `model.pulled` provenance
+as a licence check.
 
 ## Testing
 
 - **Unit** — derivation arithmetic (overflow, ceiling, dtype table); every
-  `Profile::satisfies` dimension independently; content sniffing against each
-  rejected magic; header validation against each malformed case.
-- **Fuzz** — `fuzz_safetensors_header`; the chunked `Generate` framing.
+  `Profile::satisfies` dimension independently; runtime selection including the
+  ambiguity refusal; content sniffing against each rejected magic; header
+  validation against each malformed case.
+- **Conformance** — the seven-check suite, run per runtime, gating admission.
+  It is written **before** the second runtime exists, so the seam is validated
+  by the suite rather than shaped by one implementation's accidents.
+- **Fuzz** — one target per accepted format header; the chunked `Generate`
+  framing.
 - **Tamper** — byte-flip in `content/` caught by verity; `meta.json` tamper
-  caught by the volume verifier; digest swap refused.
-- **Claims** — this adds claim-bearing behaviour, so it needs rows in the
-  claims ledger with `fn:` and `ci:` witnesses. Those witnesses enter the
-  mutation surface automatically via the ledger-derived pin, which means a
-  witness that cannot detect its property breaking will be reported.
+  caught by the volume verifier; digest swap refused; a forged or stale
+  conformance attestation refused.
+- **Claims** — this adds claim-bearing behaviour, so it needs rows in the claims
+  ledger with `fn:` and `ci:` witnesses. Those witnesses enter the mutation
+  surface automatically via the ledger-derived pin, so a witness that cannot
+  detect its property breaking will be reported.
 - **CI** — an `ai-model-admission` lane exercising pull → run against a tiny
-  fixture model with no network access, plus the refusal ladder.
+  fixture model with no network access, plus the refusal ladder and the
+  conformance suite.
 
 ## Open questions
 
+- How many runtimes ship in v1 — candle alone with the seam and suite proven by
+  a mock, or candle plus a GGUF runtime so the seam is validated against a
+  genuinely different format and language? See the note below.
 - Does candle plus a tokenizer fit the 50 MB guest footprint budget? Measure
-  before embedding. A miss forces decision 2 to be revisited.
+  before embedding. The budget applies per runtime image.
 - How exactly does a capability profile attach to the template schema — a new
   optional section, or a separate file keyed by template name? Direction is
   settled (extend templates, do not fork a resource vocabulary); only the

--- a/specs/notes/2026-07-29-ai-command-design.md
+++ b/specs/notes/2026-07-29-ai-command-design.md
@@ -274,6 +274,26 @@ partially-enforced backend matrix.
 Adding a runtime means passing this suite. Failing any check means the runtime
 cannot be selected, with no flag to override.
 
+### v1 ships candle plus a mock runtime
+
+candle is the only *admitted* runtime in v1. A second, test-only mock runtime
+exists to exercise the seam and the full suite in CI: it declares a different
+format and a different capability set, so registry lookup, runtime selection,
+the ambiguity refusal, and the three-party match are all exercised against more
+than one entry.
+
+The suite is therefore written **before** any second real runtime exists, which
+is the point — a seam validated only by its first implementation tends to fit
+exactly that implementation. The mock is the cheap way to keep the seam honest
+without paying for a second guest image, a second host-side format parser and
+its fuzz target, and C/C++ on the workload path in v1.
+
+Stated limitation: a mock cannot prove the seam survives a genuinely different
+runtime. It proves the seam is *used* by more than one entry, not that it is
+sufficient. The first real second runtime — most likely GGUF-capable, to fill
+candle's quantization gap — remains the real test, and finding the seam wrong at
+that point is an accepted risk of this choice.
+
 ## Security surfaces
 
 ### Host-side parsing — the deliberate inversion
@@ -451,9 +471,6 @@ as a licence check.
 
 ## Open questions
 
-- How many runtimes ship in v1 — candle alone with the seam and suite proven by
-  a mock, or candle plus a GGUF runtime so the seam is validated against a
-  genuinely different format and language? See the note below.
 - Does candle plus a tokenizer fit the 50 MB guest footprint budget? Measure
   before embedding. The budget applies per runtime image.
 - How exactly does a capability profile attach to the template schema — a new


### PR DESCRIPTION
Design note only — no code, no implementation plan, nothing scheduled.

## What this is

A settled design for an `ai` command: models acquired with provenance, and run
only inside a microVM *proved* to satisfy that model's requirements, from a
signed `ExecutionPlan` binding the model bytes, the runtime bytes, and the
granted resources together. mvm today is a sandbox for code an LLM writes; this
is the inverse — a sandbox for the model itself.

**Status is Draft / deferred.** No `specs/plans/` document accompanies it,
deliberately: an implementation plan for unscheduled work goes stale before
anyone reads it. The workstream ordering lives inside the note as a sketch.

## Settled decisions

1. **mvm orchestrates; it does not implement inference.** mvm owns acquisition,
   provenance, the capability match, the plan, the VM and the audit trail.
2. **Runtimes are pluggable behind a conformance-gated seam.** candle is the
   reference runtime; a test-only mock exercises the seam in v1.
3. **Models are OCI artifacts**, so acquisition reuses the existing provenance
   pipeline (digest pinning, cosign, mutable-ref refusal under `--prod`,
   audit-chain provenance) rather than growing a second one.
4. **Requirements are derived host-side at pull and frozen into the signed
   plan.** The guest never declares its own needs and never negotiates.

## The part worth reviewing

Pluggability's real cost is claim surface — every runtime is a fresh untrusted
parser, capability matrix and egress profile. The precedent is uncomfortable:
claim-10 egress enforcement is live on two of four VM backends because
per-backend work was left to discipline.

So a runtime is **inadmissible until `(id, digest)` passes a seven-check
conformance suite** — refusal ladder, no-egress-at-load, determinism, capability
honesty, footprint, no interactive surface, frame discipline — verified at plan
synthesis and again at admission, with no override flag.

The footprint budget becomes **tiered, not loosened**: the 50 MB default-tier
constant does not move, and `AI_GUEST_STORAGE_BUDGET` sits beside it with its own
pinning test, set from a measurement rather than a guess.

## What it records honestly

- Deriving requirements host-side **inverts mvm's usual posture** — a hostile
  model attacks the host parser first. Accepted under explicit bounds, with
  disposable-VM derivation documented as the upgrade path and made *mandatory*
  if the parser surface grows.
- Pluggability **weakens an available claim**: "the one format we accept has no
  code-execution semantics" is no longer sayable. Pickle stays globally refused
  and detection stays content-sniffed.
- **candle uses `unsafe`** (mmap, SIMD), so the claim is "no C/C++ on the
  workload path", never "memory-safe".
- Terminal escape injection, chat templates as an interpreter over untrusted
  input, prompts never reaching argv, and prompt/output digests rather than
  bytes in the audit chain.
- An 18-step failure ladder, every step a named refusal with a test.

## Deferred items are boundaries, not omissions

- **Prompt injection** is out of scope only while `ai` is one-shot. Tool-calling
  turns model output into control flow and needs its own threat model.
- **Warm-pool KV residue** blocks `ai serve` until scrubbing, tenant-pinning, or
  cold-per-request holds — and becomes a per-runtime conformance obligation.
- **Timing side channels** and **GPU** are excluded deliberately, the latter
  because accelerator backends move C/C++ back onto the workload path.
- **Model licensing** is not asserted, so provenance is not read as a licence
  check.
