### PR TITLE
fix(boot): give the legacy initramfs its cmdline back, and prove agent readiness

### DIFF
--- a/crates/mvm-agentd/src/vsock/mod.rs
+++ b/crates/mvm-agentd/src/vsock/mod.rs
@@ -59,8 +59,8 @@ pub use response_payloads::{
 };
 pub use rpc::{
     ControlSession, RpcError, call_streaming, call_unary, check_response, negotiate_protocol,
-    read_exec_stream, require_capabilities, send_exec_streaming, send_run_code_streaming,
-    send_run_detached, send_run_entrypoint,
+    probe_agent_ready, read_exec_stream, require_capabilities, send_exec_streaming,
+    send_run_code_streaming, send_run_detached, send_run_entrypoint,
 };
 pub use verb_grant::{
     HOST_SIGNER_PUBKEY_PATH, TrustDecision, VERB_TRUST_POLICY_PATH, enforce_verb_grant,

--- a/crates/mvm-agentd/src/vsock/rpc.rs
+++ b/crates/mvm-agentd/src/vsock/rpc.rs
@@ -182,6 +182,31 @@ pub fn call_streaming(
     let mut session = ControlSession::open(stream)?;
     session.call_streaming(stream, req, on_event)
 }
+/// Prove that a guest agent is serving RPCs on `stream`.
+///
+/// A bound socket is not a live agent. The host-side VMM binds the agent port
+/// before the guest kernel starts, so `connect()` keeps succeeding for the whole
+/// of the guest's boot — and succeeds just as well for a guest that panicked
+/// before userspace. Readiness therefore has to be settled on the wire, which is
+/// what this does: the authenticated session handshake plus one `Ping`, both real
+/// I/O against the guest.
+///
+/// Any answer means ready. A refusal (`Error`, an unsupported profile, a verb the
+/// session's grant withholds) still came from an agent that parsed, verified and
+/// replied to an authenticated frame, so the caller's next RPC reaches it too.
+/// Only a transport failure — EOF, timeout, a frame that won't decode — means
+/// "not yet"; callers poll on `Err`.
+///
+/// Unlike [`negotiate_protocol`], this is never satisfied by a host-local check:
+/// a probe that answers without touching the stream cannot tell a booting guest
+/// from a serving one.
+pub fn probe_agent_ready(stream: &mut UnixStream) -> Result<()> {
+    let mut session = connection::open_authenticated_session(stream)?;
+    session.write(stream, &GuestRequest::Ping)?;
+    let _: GuestResponse = session.read(stream)?;
+    Ok(())
+}
+
 /// Validate guest-agent protocol version and capabilities on an
 /// already-connected control stream.
 ///
@@ -987,6 +1012,92 @@ mod tests {
             other => panic!("expected typed RpcError::VerbNotAuthorized, got {other:?}"),
         }
     }
+    // ---- probe_agent_ready: readiness settled on the wire ----
+
+    use ed25519_dalek::SigningKey;
+
+    /// Seed a host signer key so `probe_agent_ready` can open its session, and
+    /// return it for the guest side of the fixture to pin as its trust anchor.
+    fn seeded_host_signer(home: &std::path::Path) -> SigningKey {
+        let mut seed = [0u8; 32];
+        rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut seed);
+        let keys = mvm_core::config::mvm_keys_dir();
+        assert!(
+            keys.starts_with(home),
+            "test must isolate MVM_HOME before seeding the host signer key"
+        );
+        std::fs::create_dir_all(&keys).unwrap();
+        std::fs::write(keys.join("host-signer.ed25519"), seed).unwrap();
+        SigningKey::from_bytes(&seed)
+    }
+
+    /// The regression this guards: a probe that reports "ready" without touching
+    /// the stream cannot tell a serving agent from a socket the VMM bound before
+    /// the guest kernel even started. A peer that accepts and closes must read as
+    /// not-ready, so the caller keeps polling instead of issuing an RPC that dies
+    /// on EOF.
+    #[test]
+    fn probe_agent_ready_rejects_a_peer_that_answers_nothing() {
+        let home = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", home.path());
+        let _signer = seeded_host_signer(home.path());
+
+        let (mut host, guest) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        // Nothing is serving: the peer end is gone. That is what the host sees
+        // from a socket the VMM bound for a guest still booting, or one that
+        // panicked before its agent ever ran.
+        drop(guest);
+
+        // Which transport error surfaces is an OS-timing detail — the handshake
+        // write may complete and the read then hit EOF, or the closed peer may
+        // fail the write with EPIPE first. Both mean "no agent answered", which
+        // is the whole property: the caller polls again instead of proceeding to
+        // an RPC. Pinning either one passes on macOS and fails on Linux.
+        let err = probe_agent_ready(&mut host).expect_err("a silent peer is not ready");
+        assert!(
+            !err.to_string().is_empty(),
+            "a refusal must carry a diagnosable transport error: {err:#}"
+        );
+    }
+
+    /// The positive case, against the real counterparty: a guest running the
+    /// production `AuthenticatedSession` reads as ready.
+    #[test]
+    fn probe_agent_ready_accepts_a_guest_serving_the_authenticated_session() {
+        let home = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", home.path());
+        let host_key = seeded_host_signer(home.path());
+        let anchor = host_key.verifying_key();
+
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        guest
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+
+        let guest_thread = std::thread::spawn(move || {
+            let mut guest_key_seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut guest_key_seed);
+            let mut session = AuthenticatedSession::guest(
+                &mut guest,
+                SigningKey::from_bytes(&guest_key_seed),
+                &anchor,
+            )
+            .expect("guest handshake");
+            let req: GuestRequest = session.read(&mut guest).expect("read probe request");
+            assert!(matches!(req, GuestRequest::Ping), "got {req:?}");
+            session
+                .write(&mut guest, &GuestResponse::Pong)
+                .expect("write pong");
+        });
+
+        probe_agent_ready(&mut host).expect("a serving agent must read as ready");
+        guest_thread.join().unwrap();
+    }
+
     // ---- check_response: the pure contract enforcer ----
 
     #[test]

--- a/crates/mvm-cli/src/commands/shared/vsock.rs
+++ b/crates/mvm-cli/src/commands/shared/vsock.rs
@@ -8,12 +8,15 @@
 
 use mvm_runtime::vsock_transport;
 
-/// Wait for the guest agent to complete the protocol hello over
-/// vsock. Returns true once the agent has
-/// answered `ProtocolHelloAck` (with at least the `Ping` capability)
-/// within `timeout_secs`. A `ProtocolMismatch` answer, a transport
-/// error, or an unexpected response counts as "not ready yet" and the
-/// probe keeps polling until the deadline.
+/// Wait for the guest agent to answer an authenticated RPC over vsock. Returns
+/// true once a handshake-and-ping round trip completes within `timeout_secs`; a
+/// transport error (EOF from a guest that is still booting, a timeout, an
+/// undecodable frame) counts as "not ready yet" and the probe keeps polling
+/// until the deadline.
+///
+/// The round trip is the point. The VMM binds the agent port before the guest
+/// kernel starts, so a `connect()` that succeeds says nothing about whether an
+/// agent exists behind it.
 pub fn wait_for_guest_agent(vm_id: &str, timeout_secs: u64) -> bool {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
 
@@ -22,10 +25,7 @@ pub fn wait_for_guest_agent(vm_id: &str, timeout_secs: u64) -> bool {
     // full 500 ms before the next probe noticed; the backoff starts at
     // 20 ms and grows to the same 500 ms cap, so the common fast-boot
     // case is detected far sooner while a slow guest still polls at the
-    // old steady cadence. This is a timing change only — the
-    // connect→`negotiate_protocol` ordering (and the
-    // ProtocolHello/Ack contract) is untouched; no RPC is issued before
-    // negotiation succeeds.
+    // old steady cadence.
     //
     // Resolve the transport each iteration via `for_vm`: it selects the
     // live backend by connecting to the agent port, so a still-booting
@@ -34,11 +34,12 @@ pub fn wait_for_guest_agent(vm_id: &str, timeout_secs: u64) -> bool {
     while std::time::Instant::now() < deadline {
         if let Ok(transport) = vsock_transport::for_vm(vm_id)
             && let Ok(mut s) = transport.connect(mvm_agentd::vsock::GUEST_AGENT_PORT)
-            && mvm_agentd::vsock::negotiate_protocol(
-                &mut s,
-                vec![mvm_agentd::vsock::GuestCapability::Ping],
-            )
-            .is_ok()
+            && {
+                // Bound the probe so a bound-but-silent socket can't park the
+                // loop past its deadline.
+                let _ = s.set_read_timeout(Some(std::time::Duration::from_secs(3)));
+                mvm_agentd::vsock::probe_agent_ready(&mut s).is_ok()
+            }
         {
             return true;
         }

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1984,30 +1984,26 @@ pub fn wait_for_agent(vm_name: &str, timeout_secs: u64) -> bool {
         // Re-pick the transport on each iteration: a Firecracker VM
         // that's still booting may not show up in
         // resolve_running_vm_dir until the daemon registers it.
-        // "agent reachable" means it speaks the protocol, not just that
-        // the socket is open. We require a
-        // successful hello (with at least the `Ping` capability) before
-        // reporting ready, since under hard cutover a pre-hello agent
-        // would only answer `ProtocolMismatch` to the next request and
-        // that is *not* "reachable" from the caller's perspective.
+        // "agent reachable" means it answered on the wire, not just that the
+        // socket is open — the VMM binds the agent port before the guest kernel
+        // starts, so a connect alone also succeeds against a guest that is still
+        // booting or that panicked before userspace. `probe_agent_ready`
+        // handshakes and pings, so returning true here means the caller's next
+        // RPC reaches a live agent instead of reading EOF.
         if let Ok(transport) = vsock_transport::for_vm(vm_name)
             && let Ok(mut stream) = transport.connect(mvm_agentd::vsock::GUEST_AGENT_PORT)
             && {
                 // Bound each probe: a transport whose socket is bound but whose
                 // guest agent hasn't replied yet (e.g. still booting, or an
                 // hvf VMM whose relay isn't answering) must not block the
-                // whole hello read forever — otherwise this loop never gets back
-                // to the deadline check and hangs instead of timing out. A short
-                // per-attempt read timeout lets `negotiate_protocol` fail fast so
+                // whole handshake read forever — otherwise this loop never gets
+                // back to the deadline check and hangs instead of timing out. A
+                // short per-attempt read timeout lets the probe fail fast so
                 // the outer loop retries and ultimately honours `timeout_secs`.
                 // The stream is a throwaway probe (dropped below), so the timeout
                 // never touches a real agent-RPC data stream.
                 let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(3)));
-                mvm_agentd::vsock::negotiate_protocol(
-                    &mut stream,
-                    vec![mvm_agentd::vsock::GuestCapability::Ping],
-                )
-                .is_ok()
+                mvm_agentd::vsock::probe_agent_ready(&mut stream).is_ok()
             }
         {
             return true;

--- a/crates/mvm-conformance/tests/steps/verified_boot.rs
+++ b/crates/mvm-conformance/tests/steps/verified_boot.rs
@@ -9,17 +9,42 @@ use mvm_runtime::driver::{
     ConsoleCapture, HvfDriver, KernelImage, LibkrunDriver, VmmDriver, VmmSpec,
 };
 
-use crate::world::CliWorld;
+use crate::world::{CliWorld, MvmHomeGuard};
 
-#[when(expr = "I assemble a sealed workload cmdline for {string}")]
-fn assemble_sealed_cmdline(world: &mut CliWorld, backend: String) {
+/// Materialize the initramfs this sealed boot attaches, and return its path.
+///
+/// The path is the discriminant between the two boot protocols, so the fixture
+/// has to produce a real one. `universal` lands in the shared initramfs cache —
+/// that PID 1 is handed its roothashes and device slots over vsock. `legacy` is
+/// a per-rootfs `rootfs.initrd` sibling, whose PID 1 can only read them off the
+/// kernel cmdline.
+fn sealed_initramfs_path(flavor: &str) -> String {
+    match flavor {
+        "universal" => {
+            let dir = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("initramfs");
+            std::fs::create_dir_all(&dir).expect("create initramfs cache dir");
+            let image = dir.join("initramfs.cpio.gz");
+            std::fs::write(&image, b"initramfs").expect("write initramfs");
+            image.display().to_string()
+        }
+        "legacy" => "/image/rootfs.initrd".to_string(),
+        other => panic!("unsupported sealed initramfs flavor {other:?}"),
+    }
+}
+
+#[when(expr = "I assemble a sealed workload cmdline for {string} booting the {string} initramfs")]
+fn assemble_sealed_cmdline(world: &mut CliWorld, backend: String, flavor: String) {
     let state = tempfile::tempdir().expect("create cmdline state dir");
+    let home = tempfile::tempdir().expect("create scenario home");
+    // The universal flavor is recognized by its path under the cache root, and
+    // the grant tokens read this home too, so both need it pointed at a tempdir.
+    let _home_guard = MvmHomeGuard::new(home.path());
     let config = VmStartConfig {
         name: format!("bdd-{backend}-sealed-boot"),
         rootfs_path: "/image/rootfs.ext4".to_string(),
         verity_path: Some("/image/rootfs.verity".to_string()),
         roothash: Some("a".repeat(64)),
-        initrd_path: Some("/image/rootfs.initrd".to_string()),
+        initrd_path: Some(sealed_initramfs_path(&flavor)),
         runtime_overlay_path: Some("/image/runtime.ext4".to_string()),
         runtime_overlay_verity_path: Some("/image/runtime.verity".to_string()),
         runtime_overlay_roothash: Some("b".repeat(64)),

--- a/crates/mvm-runtime/src/workload_runner/cmdline.rs
+++ b/crates/mvm-runtime/src/workload_runner/cmdline.rs
@@ -129,10 +129,23 @@ pub(crate) fn workload_cmdline(
     } else {
         base_bootargs(virtiofs_root, has_disk)
     };
-    // Legacy per-rootfs initramfs boot: removed. The universal initramfs passes the rootfs
-    // and runtime-overlay roothashes/device paths via vsock `ActivateEnvironment`
-    // after boot, so the kernel cmdline no longer carries `mvm.roothash`,
-    // `mvm.data`, `mvm.hash`, or the runtime overlay equivalents.
+    // The universal initramfs receives the rootfs and runtime-overlay
+    // roothashes/device paths over vsock via `ActivateEnvironment` after boot, so
+    // its cmdline carries none of them. A legacy per-rootfs verity initramfs
+    // (`mvm-verity-init` as PID 1) is never sent that verb — the cmdline is its
+    // only channel, and without these tokens it aborts before userspace and the
+    // kernel panics on a dead PID 1. Hosts that cannot yet resolve the universal
+    // artifact still boot the legacy initramfs, so both shapes stay live.
+    if verity_is_enabled
+        && !crate::microvm::booted_with_universal_initramfs(config)
+        && let Some(verity_args) = crate::microvm::build_verity_cmdline_args(
+            config.roothash.as_deref(),
+            runtime_overlay(config).map(|(_, _, roothash)| roothash),
+        )
+    {
+        cmdline.push(' ');
+        cmdline.push_str(&verity_args);
+    }
     // Non-verity boots carry the runtime overlay as a plain read-only
     // `/dev/vdb` (attached by the backend's disk layout); emit the token its
     // `/init` mounts from. Verity boots already emitted the dm-verity variant
@@ -187,6 +200,24 @@ pub(crate) fn runner_cmdline(
             format!("{} {uvols}", base_bootargs(virtiofs_root, has_disk))
         }
     }
+}
+
+/// Materialize an initramfs inside the shared initramfs cache that
+/// [`crate::microvm::booted_with_universal_initramfs`] recognizes, and return its
+/// path. `home` must already be the active `MVM_HOME`. Shared by the boot-shape
+/// tests here and in [`crate::workload_runner::standby_boot`], which both need a
+/// launch config that resolves as a universal-initramfs boot.
+#[cfg(test)]
+pub(crate) fn seed_universal_initramfs(home: &Path) -> String {
+    let dir = PathBuf::from(mvm_core::config::mvm_cache_dir()).join("initramfs");
+    assert!(
+        dir.starts_with(home),
+        "test must isolate MVM_HOME before seeding the initramfs cache"
+    );
+    std::fs::create_dir_all(&dir).expect("create initramfs cache dir");
+    let image = dir.join("initramfs.cpio.gz");
+    std::fs::write(&image, b"initramfs").expect("write initramfs");
+    image.display().to_string()
 }
 
 #[cfg(test)]
@@ -252,20 +283,27 @@ mod tests {
         assert!(cmdline.contains("mvm.vsock_egress=1"));
     }
 
+    /// A verity boot whose initramfs is the *universal* one (resolved out of the
+    /// shared initramfs cache) gets its roothashes and device paths over vsock
+    /// via `ActivateEnvironment`, so the kernel cmdline must not carry them.
     #[test]
-    fn workload_cmdline_for_verity_boot_emits_console_and_policy_only() {
+    fn workload_cmdline_for_universal_initramfs_verity_boot_emits_console_and_policy_only() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", dir.path());
         let rootfs = dir.path().join("rootfs.ext4");
         let verity = dir.path().join("rootfs.verity");
-        let initrd = dir.path().join("rootfs.initrd");
         std::fs::write(&rootfs, b"rootfs").unwrap();
         std::fs::write(&verity, b"verity").unwrap();
-        std::fs::write(&initrd, b"initrd").unwrap();
 
         let config = VmStartConfig {
             rootfs_path: rootfs.display().to_string(),
             verity_path: Some(verity.display().to_string()),
             roothash: Some("a".repeat(64)),
+            initrd_path: Some(seed_universal_initramfs(dir.path())),
             runtime_overlay_path: Some("/tmp/runtime.ext4".into()),
             runtime_overlay_verity_path: Some("/tmp/runtime.verity".into()),
             runtime_overlay_roothash: Some("b".repeat(64)),
@@ -274,8 +312,10 @@ mod tests {
         };
         let cmdline = workload_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs)
             .expect("cmdline");
-        // The initramfs PID-1 receives roothashes and device paths
-        // over vsock, so the kernel cmdline must not carry them.
+        assert!(
+            crate::microvm::booted_with_universal_initramfs(&config),
+            "fixture must resolve as a universal-initramfs boot"
+        );
         assert!(!cmdline.contains("root=/dev/vda"));
         assert!(!cmdline.contains("init=/init"));
         assert!(!cmdline.contains("mvm.roothash="));
@@ -284,6 +324,60 @@ mod tests {
         assert!(!cmdline.contains("mvm.runtime_roothash="));
         assert!(!cmdline.contains("mvm.runtime_data=/dev/vdc"));
         assert!(!cmdline.contains("mvm.runtime_hash=/dev/vdd"));
+        assert!(cmdline.contains("mvm.runtime_source_policy=required_overlay"));
+    }
+
+    /// The counterpart: a legacy per-rootfs verity initramfs (`mvm-verity-init`
+    /// as PID 1) is never sent `ActivateEnvironment`, so the kernel cmdline is
+    /// its only channel for the roothashes and device paths. Dropping those
+    /// tokens makes `mvm-verity-init` fatal ("no mvm.roothash= on kernel
+    /// cmdline") and panics the guest before userspace.
+    #[test]
+    fn workload_cmdline_for_legacy_verity_initramfs_boot_carries_the_roothash_tokens() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", dir.path());
+        let rootfs = dir.path().join("rootfs.ext4");
+        let verity = dir.path().join("rootfs.verity");
+        let initrd = dir.path().join("rootfs.initrd");
+        std::fs::write(&rootfs, b"rootfs").unwrap();
+        std::fs::write(&verity, b"verity").unwrap();
+        std::fs::write(&initrd, b"initrd").unwrap();
+
+        let rootfs_hash = "a".repeat(64);
+        let overlay_hash = "b".repeat(64);
+        let config = VmStartConfig {
+            rootfs_path: rootfs.display().to_string(),
+            verity_path: Some(verity.display().to_string()),
+            roothash: Some(rootfs_hash.clone()),
+            runtime_overlay_path: Some("/tmp/runtime.ext4".into()),
+            runtime_overlay_verity_path: Some("/tmp/runtime.verity".into()),
+            runtime_overlay_roothash: Some(overlay_hash.clone()),
+            runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
+            ..Default::default()
+        };
+        assert!(
+            !crate::microvm::booted_with_universal_initramfs(&config),
+            "fixture must resolve as a legacy-initramfs boot"
+        );
+        let cmdline = workload_cmdline(&config, dir.path(), crate::hvf_bootargs::workload_bootargs)
+            .expect("cmdline");
+        for token in [
+            format!("mvm.roothash={rootfs_hash}"),
+            "mvm.data=/dev/vda".to_string(),
+            "mvm.hash=/dev/vdb".to_string(),
+            format!("mvm.runtime_roothash={overlay_hash}"),
+            "mvm.runtime_data=/dev/vdc".to_string(),
+            "mvm.runtime_hash=/dev/vdd".to_string(),
+        ] {
+            assert!(
+                cmdline.contains(&token),
+                "legacy verity cmdline missing {token}: {cmdline}"
+            );
+        }
         assert!(cmdline.contains("mvm.runtime_source_policy=required_overlay"));
     }
 

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -975,6 +975,7 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 
         if let Some(problem) = cmdline::cmdline_overflow(&cmdline) {
             anyhow::bail!("refusing to start VM {}: {problem}", config.name);
         }
+        tracing::debug!(vm = %config.name, %cmdline, "assembled workload kernel cmdline");
 
         let inputs = WorkloadLaunchInputs {
             config,

--- a/crates/mvm-runtime/src/workload_runner/standby_boot.rs
+++ b/crates/mvm-runtime/src/workload_runner/standby_boot.rs
@@ -536,6 +536,11 @@ mod tests {
     /// The same guard, stated against the concrete symptoms the live run
     /// recorded, so a failure names what the guest will miss rather than only
     /// that two values differ.
+    ///
+    /// `sealed_launch` is the legacy sibling-initramfs shape, whose PID 1 reads
+    /// the roothashes and device paths off the kernel cmdline — it is never sent
+    /// `ActivateEnvironment`. A parent booted without those tokens aborts in PID
+    /// 1 and panics the kernel, so there is nothing left to capture.
     #[test]
     fn parent_carries_the_overlay_drives_and_runtime_tokens_the_guest_agent_needs() {
         let _home = isolated_home();
@@ -560,6 +565,40 @@ mod tests {
             "parent cmdline missing runtime-source policy: {}",
             parent.cmdline
         );
+        for token in [
+            "mvm.roothash=",
+            "mvm.data=/dev/vda",
+            "mvm.hash=/dev/vdb",
+            "mvm.runtime_roothash=",
+            "mvm.runtime_data=/dev/vdc",
+            "mvm.runtime_hash=/dev/vdd",
+        ] {
+            assert!(
+                parent.cmdline.contains(token),
+                "parent cmdline missing {token} its legacy PID 1 needs: {}",
+                parent.cmdline
+            );
+        }
+    }
+
+    /// The universal-initramfs counterpart: that PID 1 is handed the same
+    /// roothashes and device paths over vsock, so carrying them on the cmdline
+    /// would leak the boot secrets of a sealed image into a kernel argument the
+    /// guest can read from `/proc/cmdline`.
+    #[test]
+    fn parent_on_the_universal_initramfs_carries_no_roothash_tokens() {
+        let (_env, home, _lock) = isolated_home();
+        let tmp = tempfile::tempdir().unwrap();
+        let mut launch = sealed_launch(tmp.path());
+        launch.initrd_path = Some(cmdline::seed_universal_initramfs(home.path()));
+        let spec = standby_spec_for(&launch, tmp.path());
+        let parent_cfg = factory_parent_config(&launch, &spec).unwrap();
+        let parent = factory_parent_spec(&parent_cfg, Path::new(&spec.vm_state_dir), fc_base);
+
+        assert!(
+            crate::microvm::booted_with_universal_initramfs(&parent_cfg),
+            "fixture must resolve as a universal-initramfs boot"
+        );
         for legacy in [
             "mvm.roothash=",
             "mvm.data=/dev/vda",
@@ -574,6 +613,13 @@ mod tests {
                 parent.cmdline
             );
         }
+        assert!(
+            parent
+                .cmdline
+                .contains("mvm.runtime_source_policy=required_overlay"),
+            "parent cmdline missing runtime-source policy: {}",
+            parent.cmdline
+        );
     }
 
     #[test]

--- a/features/suites/s4_verified_boot/tampered_rootfs_fails_boot.feature
+++ b/features/suites/s4_verified_boot/tampered_rootfs_fails_boot.feature
@@ -6,13 +6,15 @@ Feature: Verified boot rejects a tampered rootfs
   kernel format it can actually boot, without changing the shared verity
   device contract.
 
-  With the universal initramfs, roothashes and block-device slots travel over
-  vsock from the host to PID 1, so the sealed workload cmdline must no longer
-  carry the legacy `mvm.roothash`, `mvm.data`, `mvm.hash`, or runtime-overlay
-  equivalents.
+  Which channel carries the roothashes depends on which initramfs is PID 1.
+  Under the universal initramfs they travel over vsock, so the sealed cmdline
+  must not carry the legacy `mvm.roothash`, `mvm.data`, `mvm.hash`, or
+  runtime-overlay equivalents. A legacy per-rootfs initramfs is never sent that
+  vsock command, so for it the cmdline is the only channel and those same tokens
+  are mandatory — without them PID 1 aborts and the kernel panics on a dead init.
 
-  Scenario: A sealed libkrun workload uses its virtio console
-    When I assemble a sealed workload cmdline for "libkrun"
+  Scenario: A sealed libkrun workload on the universal initramfs uses its virtio console
+    When I assemble a sealed workload cmdline for "libkrun" booting the "universal" initramfs
     Then the sealed workload cmdline contains "console=hvc0"
     And the sealed workload cmdline contains "mvm.runtime_source_policy=required_overlay"
     And the sealed workload cmdline omits "mvm.roothash="
@@ -24,13 +26,31 @@ Feature: Verified boot rejects a tampered rootfs
     But the sealed workload cmdline omits "console=ttyAMA0"
     And the sealed workload cmdline omits "earlycon=pl011"
 
-  Scenario: A sealed HVF workload keeps its pl011 console
-    When I assemble a sealed workload cmdline for "hvf"
+  Scenario: A sealed HVF workload on the universal initramfs keeps its pl011 console
+    When I assemble a sealed workload cmdline for "hvf" booting the "universal" initramfs
     Then the sealed workload cmdline contains "console=ttyAMA0"
     And the sealed workload cmdline contains "earlycon=pl011"
     And the sealed workload cmdline contains "mvm.runtime_source_policy=required_overlay"
     And the sealed workload cmdline omits "mvm.roothash="
     But the sealed workload cmdline omits "console=hvc0"
+
+  Scenario: A sealed libkrun workload on the legacy initramfs carries its verity tokens
+    When I assemble a sealed workload cmdline for "libkrun" booting the "legacy" initramfs
+    Then the sealed workload cmdline contains "console=hvc0"
+    And the sealed workload cmdline contains "mvm.runtime_source_policy=required_overlay"
+    And the sealed workload cmdline contains "mvm.roothash="
+    And the sealed workload cmdline contains "mvm.data=/dev/vda"
+    And the sealed workload cmdline contains "mvm.hash=/dev/vdb"
+    And the sealed workload cmdline contains "mvm.runtime_roothash="
+    And the sealed workload cmdline contains "mvm.runtime_data=/dev/vdc"
+    And the sealed workload cmdline contains "mvm.runtime_hash=/dev/vdd"
+
+  Scenario: A sealed HVF workload on the legacy initramfs carries its verity tokens
+    When I assemble a sealed workload cmdline for "hvf" booting the "legacy" initramfs
+    Then the sealed workload cmdline contains "console=ttyAMA0"
+    And the sealed workload cmdline contains "mvm.roothash="
+    And the sealed workload cmdline contains "mvm.data=/dev/vda"
+    And the sealed workload cmdline contains "mvm.hash=/dev/vdb"
 
   Scenario: Libkrun maps the workload kernel to its host-loadable format
     When I map an existing ELF workload kernel through the libkrun driver

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -616,7 +616,39 @@ Tracked in `specs/plans/270-universal-initramfs-vsock-activated-boot.md`. This w
    change. Updated `workload_runner::cmdline` and runner tests to assert
    the new token-free cmdline shape. `cargo nextest run -p mvm-runtime`
    (1091 passed) and `cargo nextest run -p mvm-agentd` (498 passed).
-7. [x] Initramfs cache resolver/builder and CLI attachment. Added
+   **Corrected — the shrink was unconditional and broke every host that
+   cannot resolve the universal artifact.**
+   `attach_universal_initramfs_if_cached` is non-fatal by design, and on
+   macOS it always fails (no `nix build` for a Linux initramfs, and the
+   published `initramfs-<arch>.tar.gz` 404s), so the boot falls back to the
+   legacy per-rootfs `rootfs.initrd` whose PID 1 is `mvm-verity-init` — which
+   reads those exact tokens off the cmdline and is never sent
+   `ActivateEnvironment`. Result on every macOS `machine run --image`:
+   `mvm-verity-init: FATAL: no mvm.roothash= on kernel cmdline` → `Kernel
+   panic - Attempted to kill init!` before userspace, no guest agent, and a
+   host-side `Failed to read frame length` out of the first RPC.
+   `workload_cmdline` now emits the tokens whenever
+   `microvm::booted_with_universal_initramfs(config)` is false, so each boot
+   protocol gets the channel its PID 1 actually reads. The unit tests and the
+   `s4_verified_boot` feature that asserted the tokens were absent were
+   themselves keyed to a legacy `rootfs.initrd` fixture, so they encoded the
+   panic; each now carries a universal-flavour case (tokens absent) and a
+   legacy-flavour case (tokens present).
+8. [x] Guest-agent readiness proven on the wire. `wait_for_agent` /
+   `wait_for_guest_agent` both documented "reachable means it speaks the
+   protocol, not just that the socket is open", but reached that verdict
+   through `negotiate_protocol`, which in a non-test build takes the
+   `negotiate_protocol_authenticated` arm and never touches the stream — so
+   in every shipped binary the probe degenerated to "did `connect()` succeed".
+   The VMM binds the agent port before the guest kernel starts, so that
+   succeeds throughout the guest's boot and equally for a guest that panicked
+   before userspace; both callers then issued their real RPC into a dead
+   socket and surfaced `Failed to read frame length` from the framing layer.
+   Added `mvm_agentd::vsock::probe_agent_ready` — authenticated handshake plus
+   one `Ping`, real I/O with no cfg-gated shortcut, any answer (including a
+   refusal) counting as ready and only a transport failure as not-yet — and
+   routed both waiters through it.
+9. [x] Initramfs cache resolver/builder and CLI attachment. Added
    `mvm-fs/src/initramfs.rs` resolver, `mvm-build/src/initramfs.rs` Nix
    builder + cache installer, and `attach_universal_initramfs_if_cached` in
    `mvm-cli/src/commands/vm/up/runtime_source.rs`, wired from `exec.rs` and
@@ -640,7 +672,30 @@ Tracked in `specs/plans/270-universal-initramfs-vsock-activated-boot.md`. This w
    fallback can warm the cache automatically.  Added a BDD scenario for the
    cold-cache non-fatal fallback under `features/suites/s14_universal_initramfs`,
    and updated the verified-boot cmdline feature to assert that the legacy
-   `mvm.roothash`/`mvm.data`/`mvm.hash` tokens are omitted from initramfs boots.
+   `mvm.roothash`/`mvm.data`/`mvm.hash` tokens are omitted from initramfs boots
+   — narrowed by item 6's correction to *universal*-initramfs boots only.
+
+Live witness for items 6 and 8 on macOS 26.5.2 / arm64, HVF backend, after the
+corrections: `machine run --image alpine -- /bin/sh -c "echo TRANSIENT-OK; cat
+/etc/alpine-release"` prints `TRANSIENT-OK` + `3.24.1` in 5.8s, and
+`machine run --image alpine -it --allow-host google.com -- /bin/sh -c "ping -c 3
+google.com"` attaches its PTY, resolves `google.com` to a real address, and runs
+the command inside the guest. `ping` then fails with `can't create raw socket:
+Address family not supported by protocol` — the vsock-only data plane offers no
+raw IP by design, so ICMP is unreachable and a TCP client is the right probe.
+
+TCP egress over vsock is live on the same path: `--allow-host example.com:80`
+with `wget http://example.com`, and bare `--allow-host example.com` with
+`wget https://example.com`, both return the real page body from inside the
+guest.
+
+One diagnosability note worth a follow-up. A bare `--allow-host <host>` means
+`<host>:443` (`parse_allow_host` defaults to the https port), so pairing it with
+an `http://` URL is a port mismatch and the gate denies — correctly. What the
+guest sees is `HTTP/1.1 403 Forbidden` with `Content-Length: 0` from
+`http_forward::write_proxy_error_*`, carrying no reason, which reads as "egress
+is broken" rather than "port 80 was not admitted". The host knows exactly which
+`EgressVerdict::Deny` it took; none of it reaches the caller.
 
 HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214; Plan 270 designs for HVF but does not duplicate that work. Plan 268 (`specs/plans/268-backend-shim-removal.md`) stays a separate future workstream and is not absorbed here.
 

--- a/specs/plans/270-universal-initramfs-vsock-activated-boot.md
+++ b/specs/plans/270-universal-initramfs-vsock-activated-boot.md
@@ -268,6 +268,18 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 
   Remove rootfs/overlay/roothash parameters from the kernel command line.
 
+  **Only for boots that actually attach the universal initramfs.** Attachment is
+  best-effort: a host that cannot resolve the artifact (macOS cannot `nix build`
+  a Linux initramfs, and no published release tarball exists yet) falls back to
+  the legacy per-rootfs `rootfs.initrd`, whose PID 1 is `mvm-verity-init` and is
+  never sent `ActivateEnvironment`. For that PID 1 the cmdline is the only
+  channel, so removing the tokens unconditionally panics it before userspace.
+  This is Task 3 Step 4's requirement — "a host that does not see the capability
+  must fall back to the legacy cmdline-driven boot path" — restated at the
+  cmdline layer: gate the removal on
+  `mvm_runtime::microvm::booted_with_universal_initramfs`, already the
+  discriminator the runner uses to decide whether to send activation at all.
+
 - [ ] **Step 2: Attach the initramfs**
 
   Every driver selects the content-addressed initramfs by hash from the host cache and attaches it as the boot initramfs. The hash is recorded in the VM start metadata.


### PR DESCRIPTION
`mvmctl machine run --image <ref>` panicked every guest before userspace on any
host that cannot resolve the universal initramfs — which is every macOS host —
and reported it as `guest agent transport error: Failed to read frame length`.
Two defects, one masking the other.

## The boot

The universal-initramfs cmdline shrink was unconditional. That PID 1 receives
its roothashes and device slots over vsock via `ActivateEnvironment`, so its
cmdline carries none of them. But attaching it is best-effort and on macOS
always fails — there is no `nix build` for a Linux initramfs, and the published
`initramfs-<arch>.tar.gz` 404s. The boot then falls back to the legacy
per-rootfs `rootfs.initrd`, whose PID 1 is `mvm-verity-init`: never sent
activation, and reads those tokens off the cmdline. From `console.log`:

```
mvm-verity-init: FATAL: no mvm.roothash= on kernel cmdline
Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
```

`workload_cmdline` now emits the tokens whenever
`microvm::booted_with_universal_initramfs(config)` is false — already the
discriminator the runner uses to decide whether to send activation at all — so
each protocol gets the channel its PID 1 actually reads. This is the plan's own
requirement ("a host that does not see the capability must fall back to the
legacy cmdline-driven boot path") restated at the cmdline layer.

The unit tests and the `s4_verified_boot` feature that asserted those tokens
were absent were all keyed to a legacy `rootfs.initrd` fixture, so they encoded
the panic rather than catching it. Each now carries both flavours: universal
(tokens absent) and legacy (tokens present).

## Why the symptom named the wrong layer

`wait_for_agent` and `wait_for_guest_agent` both document "reachable means it
speaks the protocol, not just that the socket is open", but reached that verdict
through `negotiate_protocol`, whose non-test arm never touches the stream. In
every shipped binary the probe was therefore just `connect()` — which succeeds
throughout a guest's boot, and equally for a guest that panicked, because the
VMM binds the agent port before the kernel starts. Both waiters then drove their
real RPC into a dead socket, and the framing layer got the blame.

`mvm_agentd::vsock::probe_agent_ready` settles it on the wire: authenticated
handshake plus one `Ping`, real I/O with no cfg-gated shortcut. Any answer
counts as ready — a refusal still came from an agent that parsed, verified and
replied — and only a transport failure means not-yet. Its positive test runs
against the real `AuthenticatedSession` guest rather than a double.

## Verification

Live on macOS 26.5.2 / arm64 / HVF: `machine run --image alpine -- /bin/sh -c
"cat /etc/alpine-release"` returns `3.24.1` in 5.8s; `-it` attaches its PTY and
resolves DNS from inside the guest.

Gates: nightly `cargo fmt --all --check`, `cargo clippy --workspace
--all-targets`, 8191 workspace tests, doctests, 52 BDD scenarios, 34 xtask
policy gates, `just check-linux`.

## Egress

TCP egress over vsock is live on the same path: `--allow-host example.com:80`
with `wget http://example.com`, and bare `--allow-host example.com` with
`wget https://example.com`, both return the real page body from inside the
guest.

One diagnosability follow-up, not fixed here: a bare `--allow-host <host>` means
`<host>:443` (`parse_allow_host` defaults to the https port), so pairing it with
an `http://` URL is a port mismatch and the gate denies — correctly. What the
guest sees is `HTTP/1.1 403 Forbidden` with `Content-Length: 0` from
`http_forward::write_proxy_error_*`, carrying no reason, which reads as "egress
is broken" rather than "port 80 was not admitted". The host knows which
`EgressVerdict::Deny` it took; none of it reaches the caller.
