### PR TITLE
feat(test): give nextest the ci profile the Justfile has always named

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -210,7 +210,19 @@ jobs:
         run: cargo build --all-targets
 
       - name: Run tests
-        run: cargo nextest run --workspace --all-targets
+        run: cargo nextest run --workspace --all-targets --profile ci
+
+      # Structure only — the `ci` profile stores no captured test output, so
+      # this artifact carries pass/fail per test and nothing a failing test
+      # happened to print. Read failures in the job log.
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: nextest-junit
+          path: target/nextest/ci/junit.xml
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: xtask man-page tests
         # gen-man lives behind xtask's off-by-default `man` feature (it pulls

--- a/Justfile
+++ b/Justfile
@@ -152,7 +152,9 @@ test-crate CRATE:
 test-filter FILTER:
     cargo nextest run --workspace -E 'test({{FILTER}})'
 
-# Run tests with CI profile (retries, JUnit output)
+# Run tests under the `ci` profile: no retries, slow-test warnings, and a
+# JUnit report at target/nextest/ci/junit.xml carrying pass/fail structure
+# only (no captured test output — see .config/nextest.toml).
 test-ci:
     cargo nextest run --workspace --profile ci
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -58,11 +58,17 @@
       Reachability was measured empirically by running the suite against an
       empty vs. a populated fixture `$HOME` rather than inferred from the call
       graph. 8021/8021 nextest on a host with a populated `~/.mvm`.
-      **Deferred:** `mvmctl::audit_emissions_live
-      update_check_does_not_emit_audit_entry` fails intermittently under full
-      workspace concurrency and is *not* in this class — its `AuditSandbox`
-      already isolates both roots, and the test binary passed 47/47 across four
-      consecutive runs. Needs separate triage as a concurrency flake.
+      **Deferred → closed.** `mvmctl::audit_emissions_live
+      update_check_does_not_emit_audit_entry` failed intermittently under full
+      workspace concurrency and was correctly ruled out of the `$HOME` class.
+      Triaged in the nextest-profile work: not a concurrency flake but a bug in
+      the shared `serve_release_latest_fixture` helper it and its sibling use.
+      The fixture's listener is non-blocking, and on macOS the accepted socket
+      inherits `O_NONBLOCK` (proven against both platforms — Linux does not
+      inherit), so its read returned `WouldBlock` before the request landed and
+      the loop treated that as "request complete". The fixture then answered an
+      empty request with a 404 and half-closed, which the client saw as that
+      404 or as a reset mid-send. macOS-only, which is why CI never saw it.
 
 - [x] Cross-root cache-seed hardening (#1925, #1926, #1927, #1928). The three
       opportunistic seeds that populate an isolated cache root from the host's

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -291,6 +291,21 @@ fn serve_release_latest_fixture(response_body: String) -> (String, mpsc::Sender<
             }
             match listener.accept() {
                 Ok((mut stream, _)) => {
+                    // The listener is non-blocking so the accept loop can poll
+                    // the stop channel. On macOS the accepted socket inherits
+                    // O_NONBLOCK from it, which makes the read below return
+                    // WouldBlock the instant the request bytes have not landed
+                    // yet — and the loop treats WouldBlock as "request
+                    // complete". The fixture then answers an empty request:
+                    // `path` falls back to "/", so it writes a 404 and
+                    // half-closes while the client may still be sending, which
+                    // the client sees as either that 404 or a reset mid-send.
+                    // Under no load the bytes are almost always already there,
+                    // which is what made this look like a load flake.
+                    //
+                    // Clearing the flag puts the read back under the timeout
+                    // below, which is what was meant to bound it all along.
+                    let _ = stream.set_nonblocking(false);
                     let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(1)));
                     let mut req_bytes = Vec::with_capacity(2048);
                     let mut buf = [0u8; 512];


### PR DESCRIPTION
`Justfile` has always defined:

```
test-ci:
    cargo nextest run --workspace --profile ci
```

There was no `.config/nextest.toml` in the repo, so that recipe failed before running a single test:

```
$ cargo nextest show-config test-groups --profile ci
error: profile `ci` not found (known profiles: default, default-miri)
```

**`just test-ci` has never run.** This adds the profile it names.

## Two deliberate choices

**The JUnit report stores no test output.** Captured stdout/stderr from a failing test in this suite can carry key paths, grant tokens, or raw buffers, and the report is uploaded as a downloadable CI artifact with its own retention. `check-no-display-on-secret-types` protects types *named* like secrets; it says nothing about a byte buffer a debug assertion happened to print. Verified against a forced failure — the emitted XML carries the `<failure>` element and **zero** `system-out`/`system-err` sections. Failures are read in the job log.

**`slow-timeout` warns rather than kills.** The slowest test in the suite runs ~170s, so a `terminate-after` set by feel would eventually kill a legitimately slow test and turn a passing lane red. Adding a kill threshold is a separate change that should arrive with a number behind it.

## What `fail-fast = false` surfaced

The run no longer stops at the first failure, which exposed two things early exit had been hiding.

### A real defect, not contention

`serve_release_latest_fixture` sets its listener non-blocking so the accept loop can poll a stop channel. **On macOS the accepted socket inherits `O_NONBLOCK`**, so its `read()` returned `WouldBlock` before the request bytes landed — and the loop treated `WouldBlock` as *request complete*. The fixture then answered an empty request (`path` falls back to `"/"`) with a 404 and half-closed while the client might still be sending, which the client saw as either that 404 or a reset mid-send.

Proven by direct experiment rather than inferred:

| Platform | Listener `O_NONBLOCK` | Accepted socket |
| --- | --- | --- |
| macOS (arm64) | yes | **YES — inherited** |
| Linux 6.8 | yes | no |

That is why CI never saw this and only developers did. Clearing the flag puts the read back under the 1s timeout that was meant to bound it. 25 runs under CPU load: **1 failure before, 0 after**.

That fixture is shared with `update_check_does_not_emit_audit_entry` — the test `specs/SPRINT.md` deferred as *"needs separate triage as a concurrency flake"*. Same root cause. **The deferral is closed**, and it was not a concurrency flake.

### Genuine contention

Several tests spawn a real helper process and then wait on a fixed 10s handshake-or-bind budget (`mvm-hostd` `host_agent_restart` / `per_tenant_isolation`, `mvm-runtime` `substitution_spawn` / `broker_services_spawn`). At full workspace parallelism those budgets are missed; the same tests pass in ~1s alone. They get a `max-threads = 4` test group.

The group is deliberately narrow. A test that merely needs a unique tempdir and does not have one is a bug in the test, and a group would hide it — as the fixture above shows, "looks like contention" is not the same as "is contention".

## Verification

Three consecutive full workspace passes green (8187/8187) under both the `ci` and `default` profiles · fmt clean · `cargo clippy --workspace --all-targets -- -D warnings` clean · `cargo nextest show-config test-groups --workspace` confirms the group binds to exactly the intended tests and nothing else.

CI wiring: the `ci-full.yml` workspace test step gains `--profile ci` plus a SHA-pinned artifact upload with 14-day retention.
