### PR TITLE
feat(egress): make a refusal say why

### DIFF
--- a/crates/mvm-hostd/src/supervisor/http_forward.rs
+++ b/crates/mvm-hostd/src/supervisor/http_forward.rs
@@ -65,32 +65,41 @@ where
     let head = match read_http_head(&mut guest).await {
         Ok(head) => head,
         Err(error) => {
-            write_proxy_error_async(&mut guest, ProxyStatus::BadRequest).await?;
+            write_proxy_error_async(&mut guest, ProxyStatus::BadRequest, None).await?;
             return Err(error);
         }
     };
     let request = match parse_forward_request(&head) {
         Ok(request) => request,
         Err(status) => {
-            write_proxy_error_async(&mut guest, status).await?;
+            write_proxy_error_async(&mut guest, status, None).await?;
             return Ok(());
         }
     };
     let (ips, port) = match gate.decide_request(&request.target) {
         EgressVerdict::Allow { ips, port } => (ips, port),
-        EgressVerdict::Deny => {
-            write_proxy_error_async(&mut guest, ProxyStatus::Forbidden).await?;
+        EgressVerdict::Deny(reason) => {
+            // Also host-side: the body reaches anything that reads it, but a
+            // plain `wget` prints only the status line, so the operator would
+            // still be left with three digits.
+            tracing::warn!(target_dest = %request.target, %reason, "egress refused");
+            write_proxy_error_async(
+                &mut guest,
+                ProxyStatus::Forbidden,
+                Some(&reason.to_string()),
+            )
+            .await?;
             return Ok(());
         }
         EgressVerdict::Malformed => {
-            write_proxy_error_async(&mut guest, ProxyStatus::BadRequest).await?;
+            write_proxy_error_async(&mut guest, ProxyStatus::BadRequest, None).await?;
             return Ok(());
         }
     };
     let body = match read_request_body_async(&mut guest, request.content_length).await {
         Ok(body) => body,
         Err(error) => {
-            write_proxy_error_async(&mut guest, ProxyStatus::BadRequest).await?;
+            write_proxy_error_async(&mut guest, ProxyStatus::BadRequest, None).await?;
             return Err(error);
         }
     };
@@ -98,7 +107,7 @@ where
         Ok(response) => response,
         Err(error) => {
             tracing::warn!(error = %error, target = %request.target, "host HTTP forward request failed");
-            write_proxy_error_async(&mut guest, ProxyStatus::BadGateway).await?;
+            write_proxy_error_async(&mut guest, ProxyStatus::BadGateway, None).await?;
             return Ok(());
         }
     };
@@ -118,32 +127,37 @@ where
     let head = match read_http_head_blocking(&mut guest) {
         Ok(head) => head,
         Err(error) => {
-            write_proxy_error_blocking(&mut guest, ProxyStatus::BadRequest)?;
+            write_proxy_error_blocking(&mut guest, ProxyStatus::BadRequest, None)?;
             return Err(error);
         }
     };
     let request = match parse_forward_request(&head) {
         Ok(request) => request,
         Err(status) => {
-            write_proxy_error_blocking(&mut guest, status)?;
+            write_proxy_error_blocking(&mut guest, status, None)?;
             return Ok(());
         }
     };
     let (ips, port) = match gate.decide_request(&request.target) {
         EgressVerdict::Allow { ips, port } => (ips, port),
-        EgressVerdict::Deny => {
-            write_proxy_error_blocking(&mut guest, ProxyStatus::Forbidden)?;
+        EgressVerdict::Deny(reason) => {
+            tracing::warn!(target_dest = %request.target, %reason, "egress refused");
+            write_proxy_error_blocking(
+                &mut guest,
+                ProxyStatus::Forbidden,
+                Some(&reason.to_string()),
+            )?;
             return Ok(());
         }
         EgressVerdict::Malformed => {
-            write_proxy_error_blocking(&mut guest, ProxyStatus::BadRequest)?;
+            write_proxy_error_blocking(&mut guest, ProxyStatus::BadRequest, None)?;
             return Ok(());
         }
     };
     let body = match read_request_body_blocking(&mut guest, request.content_length) {
         Ok(body) => body,
         Err(error) => {
-            write_proxy_error_blocking(&mut guest, ProxyStatus::BadRequest)?;
+            write_proxy_error_blocking(&mut guest, ProxyStatus::BadRequest, None)?;
             return Err(error);
         }
     };
@@ -151,7 +165,7 @@ where
         Ok(response) => response,
         Err(error) => {
             tracing::warn!(error = %error, target = %request.target, "host HTTP forward request failed");
-            write_proxy_error_blocking(&mut guest, ProxyStatus::BadGateway)?;
+            write_proxy_error_blocking(&mut guest, ProxyStatus::BadGateway, None)?;
             return Ok(());
         }
     };
@@ -534,34 +548,46 @@ where
     guest.write_all(b"\r\n")
 }
 
-async fn write_proxy_error_async<W>(guest: &mut W, status: ProxyStatus) -> std::io::Result<()>
+/// A proxy-generated error response. `detail` is the guest-facing explanation —
+/// for a policy refusal it is the [`EgressVerdict::Deny`] reason, which the guest
+/// has no other way to learn: it sees a status code from a proxy it did not
+/// configure, against a policy it cannot read. Without it a port mismatch and a
+/// broken network are the same three digits.
+async fn write_proxy_error_async<W>(
+    guest: &mut W,
+    status: ProxyStatus,
+    detail: Option<&str>,
+) -> std::io::Result<()>
 where
     W: AsyncWrite + Unpin,
 {
-    guest
-        .write_all(
-            format!(
-                "HTTP/1.1 {}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
-                status.line()
-            )
-            .as_bytes(),
-        )
-        .await?;
+    guest.write_all(&proxy_error_bytes(status, detail)).await?;
     guest.flush().await
 }
 
+/// The response bytes for [`write_proxy_error_async`] and its blocking sibling,
+/// so the two paths cannot drift.
+fn proxy_error_bytes(status: ProxyStatus, detail: Option<&str>) -> Vec<u8> {
+    let body = detail.map(|d| format!("{d}\n")).unwrap_or_default();
+    format!(
+        "HTTP/1.1 {}\r\nContent-Length: {}\r\nContent-Type: text/plain\r\n\
+         Connection: close\r\n\r\n{body}",
+        status.line(),
+        body.len()
+    )
+    .into_bytes()
+}
+
 #[cfg(target_os = "linux")]
-fn write_proxy_error_blocking<W>(guest: &mut W, status: ProxyStatus) -> std::io::Result<()>
+fn write_proxy_error_blocking<W>(
+    guest: &mut W,
+    status: ProxyStatus,
+    detail: Option<&str>,
+) -> std::io::Result<()>
 where
     W: Write,
 {
-    guest.write_all(
-        format!(
-            "HTTP/1.1 {}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
-            status.line()
-        )
-        .as_bytes(),
-    )?;
+    guest.write_all(&proxy_error_bytes(status, detail))?;
     guest.flush()
 }
 
@@ -727,6 +753,58 @@ mod tests {
         assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
         assert!(response.contains("Transfer-Encoding: chunked\r\n"));
         assert!(response.ends_with("Connection: close\r\n\r\n"));
+        task.await.unwrap();
+    }
+
+    /// The refusal a caller actually meets: a bare `--allow-host example.com`
+    /// admits `example.com:443`, so an `http://` URL asks for port 80 and is
+    /// correctly denied. The guest cannot read the policy, so unless the 403
+    /// carries the reason the answer is indistinguishable from a broken network
+    /// — which is exactly how it reads today.
+    #[tokio::test]
+    async fn port_mismatch_403_tells_the_guest_which_port_is_admitted() {
+        use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
+        use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+
+        let mut pins = DnsPinRegistry::new();
+        pins.add(DnsPin::at(
+            "example.com",
+            vec!["93.184.216.34".parse().unwrap()],
+            "2025-01-01T00:00:00Z",
+            "2030-01-01T00:00:00Z",
+        ));
+        let policy = NetworkPolicy::allow_list(vec![HostPort {
+            host: "example.com".into(),
+            port: 443,
+        }]);
+        let gate = EgressGate::from_network_policy(&policy, &pins, "2026-01-01T00:00:00Z");
+
+        let (mut client, server) = tokio::io::duplex(1024);
+        let task = tokio::spawn(async move {
+            serve_http_forward(server, &gate, Duration::from_secs(1))
+                .await
+                .unwrap();
+        });
+        client
+            .write_all(b"GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n")
+            .await
+            .unwrap();
+        let mut buf = Vec::new();
+        client.read_to_end(&mut buf).await.unwrap();
+        let response = std::str::from_utf8(&buf).unwrap();
+
+        assert!(
+            response.starts_with("HTTP/1.1 403 Forbidden"),
+            "{response:?}"
+        );
+        assert!(
+            response.contains("example.com:80 is not admitted"),
+            "403 must name the refused destination: {response:?}"
+        );
+        assert!(
+            response.contains("example.com:443"),
+            "403 must name the admitted destination: {response:?}"
+        );
         task.await.unwrap();
     }
 

--- a/crates/mvm-hostd/src/supervisor/raw_egress.rs
+++ b/crates/mvm-hostd/src/supervisor/raw_egress.rs
@@ -108,8 +108,17 @@ where
         EgressVerdict::Allow { ips, port } => {
             splice(guest, &target, &ips, port, leftover, timeout).await
         }
-        EgressVerdict::Deny | EgressVerdict::Malformed => {
-            eprintln!("raw-egress: refusing target {target}");
+        // A raw tunnel's only reply is a one-byte nack, so the reason cannot
+        // reach the guest here the way it does on the HTTP forward path. Log it
+        // host-side rather than discarding it — otherwise the operator's only
+        // signal is a connection that failed.
+        verdict @ (EgressVerdict::Deny(_) | EgressVerdict::Malformed) => {
+            match verdict {
+                EgressVerdict::Deny(reason) => {
+                    eprintln!("raw-egress: refusing target {target}: {reason}")
+                }
+                _ => eprintln!("raw-egress: refusing malformed target {target}"),
+            }
             // Refused: nack the guest and close without ever opening a host socket.
             write_connect_ack_async(&mut guest, ConnectAck::Fail).await?;
             Ok(())
@@ -324,8 +333,15 @@ fn handle_raw_conn_blocking(
     let (ips, port) =
         match gate.decide_request_with(&target, |host| resolve_hostname_ips_pure(host, timeout)) {
             EgressVerdict::Allow { ips, port } => (ips, port),
-            EgressVerdict::Deny | EgressVerdict::Malformed => {
-                eprintln!("raw-egress: refusing target {target}");
+            // As on the async path: a raw tunnel answers with a one-byte nack,
+            // so the reason is logged host-side rather than discarded.
+            verdict @ (EgressVerdict::Deny(_) | EgressVerdict::Malformed) => {
+                match verdict {
+                    EgressVerdict::Deny(reason) => {
+                        eprintln!("raw-egress: refusing target {target}: {reason}")
+                    }
+                    _ => eprintln!("raw-egress: refusing malformed target {target}"),
+                }
                 write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
                 return Ok(());
             }

--- a/crates/mvm-hostd/src/supervisor/socks5_udp.rs
+++ b/crates/mvm-hostd/src/supervisor/socks5_udp.rs
@@ -46,7 +46,16 @@ async fn relay_async(
         raw_egress::resolve_hostname_ips_pure(host, timeout)
     }) {
         EgressVerdict::Allow { ips, port } => (ips, port),
-        EgressVerdict::Deny | EgressVerdict::Malformed => return Ok(None),
+        // A refused datagram is answered with silence (SOCKS UDP has no error
+        // reply), so the reason is logged host-side rather than dropped.
+        EgressVerdict::Deny(reason) => {
+            tracing::debug!(%target, %reason, "socks5-udp: refusing datagram");
+            return Ok(None);
+        }
+        EgressVerdict::Malformed => {
+            tracing::debug!(%target, "socks5-udp: refusing malformed datagram target");
+            return Ok(None);
+        }
     };
 
     let mut sent = false;
@@ -154,7 +163,14 @@ fn relay_blocking(
         raw_egress::resolve_hostname_ips_pure(host, timeout)
     }) {
         EgressVerdict::Allow { ips, port } => (ips, port),
-        EgressVerdict::Deny | EgressVerdict::Malformed => return Ok(None),
+        EgressVerdict::Deny(reason) => {
+            tracing::debug!(%target, %reason, "socks5-udp: refusing datagram");
+            return Ok(None);
+        }
+        EgressVerdict::Malformed => {
+            tracing::debug!(%target, "socks5-udp: refusing malformed datagram target");
+            return Ok(None);
+        }
     };
     let mut selected = None;
     for ip in &ips {

--- a/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
+++ b/crates/mvm-runtime/src/vsock_egress_bridge/egress_gate.rs
@@ -27,9 +27,119 @@ pub enum EgressVerdict {
     /// may send to each and accept the first valid response.
     Allow { ips: Vec<IpAddr>, port: u16 },
     /// Refused — policy did not admit it (claim-10 default-deny / mandatory-deny).
-    Deny,
+    /// Carries which refusal it was, so a caller can tell the guest.
+    Deny(DenyReason),
     /// The guest's connect request was malformed (not `<ip>:<port>` or `<hostname>:<port>`).
     Malformed,
+}
+
+impl EgressVerdict {
+    /// Whether this verdict refuses the request, whatever the reason. For
+    /// callers (and assertions) that care that the gate said no, not why.
+    pub fn is_deny(&self) -> bool {
+        matches!(self, Self::Deny(_))
+    }
+}
+
+/// Which claim-10 refusal a [`EgressVerdict::Deny`] is.
+///
+/// The decision and its reason are one value because a caller that has to
+/// explain the refusal cannot recompute it: the gate holds the pins and the
+/// canonical rules, and by the time a 403 is being written they are gone. The
+/// distinctions here are the ones a caller acts on differently — a host absent
+/// from the allow-list is a different fix from the same host on an unadmitted
+/// port, which is the pair a bare `--allow-host <host>` (meaning `<host>:443`)
+/// most often lands a caller in.
+///
+/// This is deliberately about *policy shape*, not about the destination: it
+/// names hosts and ports the operator already wrote on the command line, never
+/// anything learned from the network.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DenyReason {
+    /// The workload admits no egress at all (claim-10 default-deny).
+    NoEgressAdmitted,
+    /// The destination host is not in the allow-list — no admission pin exists
+    /// for it. `admitted_hosts` are the names that are pinned.
+    HostNotAdmitted {
+        /// The refused name, as the guest asked for it.
+        host: String,
+        /// Every host name the policy does admit.
+        admitted_hosts: Vec<String>,
+    },
+    /// The host is admitted but not on this port. `admitted_ports` are the
+    /// ports the policy admits for it.
+    PortNotAdmitted {
+        /// The admitted host.
+        host: String,
+        /// The refused port.
+        port: u16,
+        /// Ports the policy admits for `host`.
+        admitted_ports: Vec<u16>,
+    },
+    /// A numeric destination outside every rule, or one under mandatory-deny
+    /// (loopback / private / link-local) or a banned flow.
+    AddressNotAdmitted {
+        /// The refused address.
+        ip: IpAddr,
+        /// The refused port.
+        port: u16,
+    },
+    /// An unrestricted gate could not resolve the name.
+    ResolutionFailed {
+        /// The name that would not resolve.
+        host: String,
+    },
+}
+
+impl std::fmt::Display for DenyReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoEgressAdmitted => {
+                write!(f, "egress is deny-all for this workload")
+            }
+            Self::HostNotAdmitted {
+                host,
+                admitted_hosts,
+            } if admitted_hosts.is_empty() => {
+                write!(f, "{host} is not admitted; no hosts are admitted")
+            }
+            Self::HostNotAdmitted {
+                host,
+                admitted_hosts,
+            } => {
+                write!(
+                    f,
+                    "{host} is not admitted; allowed: {}",
+                    admitted_hosts.join(", ")
+                )
+            }
+            Self::PortNotAdmitted {
+                host,
+                port,
+                admitted_ports,
+            } if admitted_ports.is_empty() => {
+                write!(f, "{host}:{port} is not admitted")
+            }
+            Self::PortNotAdmitted {
+                host,
+                port,
+                admitted_ports,
+            } => {
+                let allowed = admitted_ports
+                    .iter()
+                    .map(|p| format!("{host}:{p}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "{host}:{port} is not admitted; allowed: {allowed}")
+            }
+            Self::AddressNotAdmitted { ip, port } => {
+                write!(f, "{ip}:{port} is not admitted")
+            }
+            Self::ResolutionFailed { host } => {
+                write!(f, "could not resolve {host}")
+            }
+        }
+    }
 }
 
 /// Policy result for a guest DNS question.
@@ -144,9 +254,47 @@ impl EgressGate {
         self.decide_udp_request_with(target, resolve_hostname_ips)
     }
 
+    /// Host names the policy admits, in registry order. The pin registry is the
+    /// admission record — a name is pinned exactly when the allow-list named it —
+    /// so this is what a caller can suggest instead of the refused destination.
+    fn admitted_hosts(&self) -> Vec<String> {
+        self.pins.pins.keys().cloned().collect()
+    }
+
+    /// Ports the policy admits for an already-pinned host, ascending. Derived by
+    /// probing the canonical rules with the host's own pinned addresses, so it
+    /// reports what the gate would actually admit rather than re-parsing the
+    /// operator's input.
+    fn admitted_ports_for(&self, proto: &Proto, ips: &[IpAddr]) -> Vec<u16> {
+        let CanonicalEgress::Rules(rules) = &self.egress else {
+            return Vec::new();
+        };
+        let mut ports: Vec<u16> = rules
+            .iter()
+            .filter(|rule| rule.proto == *proto)
+            .filter(|rule| ips.iter().any(|ip| rule.net.contains(ip)))
+            // A rule is a range; report its endpoints rather than expanding a
+            // range that can span the whole port space.
+            .flat_map(|rule| [rule.port_lo, rule.port_hi])
+            .collect();
+        ports.sort_unstable();
+        ports.dedup();
+        ports
+    }
+
     fn decide_addr_for_proto(&self, proto: Proto, ip: IpAddr, port: u16) -> EgressVerdict {
         if !self.egress.permits(&proto, ip, port) {
-            return EgressVerdict::Deny;
+            // A pinned address on the wrong port is the port-mismatch case even
+            // when the guest dialled it numerically, so name the host it belongs
+            // to rather than reporting a bare address.
+            return match self.pins.pin_containing(&ip) {
+                Some(pin) => EgressVerdict::Deny(DenyReason::PortNotAdmitted {
+                    host: pin.dest.clone(),
+                    port,
+                    admitted_ports: self.admitted_ports_for(&proto, &pin.ips),
+                }),
+                None => EgressVerdict::Deny(DenyReason::AddressNotAdmitted { ip, port }),
+            };
         }
         let ips = match self.pins.pin_containing(&ip) {
             Some(pin) => admitted_ips(&self.egress, &proto, &pin.ips, port),
@@ -188,22 +336,47 @@ impl EgressGate {
     where
         F: Fn(&str) -> std::io::Result<Vec<IpAddr>>,
     {
+        let pinned = self.pins.lookup(host).is_some();
         let candidates = if let Some(pin) = self.pins.lookup(host) {
             pin.ips.clone()
         } else if matches!(self.egress, CanonicalEgress::Unrestricted) {
             match resolve(host) {
                 Ok(ips) => ips,
-                Err(_) => return EgressVerdict::Deny,
+                Err(_) => {
+                    return EgressVerdict::Deny(DenyReason::ResolutionFailed {
+                        host: host.to_string(),
+                    });
+                }
             }
         } else {
-            return EgressVerdict::Deny;
+            return EgressVerdict::Deny(if self.admitted_hosts().is_empty() {
+                DenyReason::NoEgressAdmitted
+            } else {
+                DenyReason::HostNotAdmitted {
+                    host: host.to_string(),
+                    admitted_hosts: self.admitted_hosts(),
+                }
+            });
         };
         let ips = admitted_ips(&self.egress, &proto, &candidates, port);
-        if ips.is_empty() {
-            EgressVerdict::Deny
-        } else {
-            EgressVerdict::Allow { ips, port }
+        if !ips.is_empty() {
+            return EgressVerdict::Allow { ips, port };
         }
+        // Pinned but nothing admitted for this port is the port mismatch; an
+        // unpinned name only reaches here on an unrestricted gate, where the
+        // refusal came from the address filter rather than the allow-list.
+        EgressVerdict::Deny(if pinned {
+            DenyReason::PortNotAdmitted {
+                host: host.to_string(),
+                port,
+                admitted_ports: self.admitted_ports_for(&proto, &candidates),
+            }
+        } else {
+            DenyReason::HostNotAdmitted {
+                host: host.to_string(),
+                admitted_hosts: self.admitted_hosts(),
+            }
+        })
     }
 
     /// Resolve an admitted DNS name through the same policy seam as TCP egress.
@@ -281,11 +454,85 @@ mod tests {
         }
     }
 
+    /// The refusal a caller most often meets, and the one that reads as a
+    /// broken network rather than a policy answer: a bare `--allow-host <host>`
+    /// means `<host>:443`, so an `http://` URL asks for port 80 and is correctly
+    /// denied. The verdict has to carry enough to say which port was asked for
+    /// and which the policy admits, because that difference is the whole answer.
+    #[test]
+    fn wrong_port_on_an_admitted_host_explains_the_port_mismatch() {
+        use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
+        use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+
+        let mut pins = DnsPinRegistry::new();
+        pins.add(DnsPin::at(
+            "example.com",
+            vec!["93.184.216.34".parse().unwrap()],
+            "2025-01-01T00:00:00Z",
+            "2030-01-01T00:00:00Z",
+        ));
+        let policy = NetworkPolicy::allow_list(vec![HostPort {
+            host: "example.com".into(),
+            port: 443,
+        }]);
+        let gate = EgressGate::from_network_policy(&policy, &pins, "2026-01-01T00:00:00Z");
+
+        let verdict = gate.decide_request("example.com:80");
+        let EgressVerdict::Deny(reason) = verdict else {
+            panic!("port 80 must be denied, got {verdict:?}");
+        };
+        assert_eq!(
+            reason,
+            DenyReason::PortNotAdmitted {
+                host: "example.com".to_string(),
+                port: 80,
+                admitted_ports: vec![443],
+            }
+        );
+        let rendered = reason.to_string();
+        assert!(rendered.contains("example.com:80"), "{rendered}");
+        assert!(rendered.contains("example.com:443"), "{rendered}");
+    }
+
+    /// A host absent from the allow-list is a different answer from a wrong
+    /// port, and naming the admitted hosts is what turns it into one.
+    #[test]
+    fn unlisted_host_names_the_hosts_that_are_admitted() {
+        use mvm_core::policy::dns_pin::{DnsPin, DnsPinRegistry};
+        use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
+
+        let mut pins = DnsPinRegistry::new();
+        pins.add(DnsPin::at(
+            "example.com",
+            vec!["93.184.216.34".parse().unwrap()],
+            "2025-01-01T00:00:00Z",
+            "2030-01-01T00:00:00Z",
+        ));
+        let policy = NetworkPolicy::allow_list(vec![HostPort {
+            host: "example.com".into(),
+            port: 443,
+        }]);
+        let gate = EgressGate::from_network_policy(&policy, &pins, "2026-01-01T00:00:00Z");
+
+        let verdict = gate.decide_request("evil.test:443");
+        let EgressVerdict::Deny(reason) = verdict else {
+            panic!("an unlisted host must be denied, got {verdict:?}");
+        };
+        assert_eq!(
+            reason,
+            DenyReason::HostNotAdmitted {
+                host: "evil.test".to_string(),
+                admitted_hosts: vec!["example.com".to_string()],
+            }
+        );
+        assert!(reason.to_string().contains("example.com"));
+    }
+
     #[test]
     fn default_deny_refuses_everything() {
         let gate = EgressGate::default_deny();
-        assert_eq!(gate.decide_request("1.1.1.1:443"), EgressVerdict::Deny);
-        assert_eq!(gate.decide_request("93.184.216.34:80"), EgressVerdict::Deny);
+        assert!(gate.decide_request("1.1.1.1:443").is_deny());
+        assert!(gate.decide_request("93.184.216.34:80").is_deny());
     }
 
     #[test]
@@ -299,15 +546,15 @@ mod tests {
             }
         );
         // Wrong port / wrong host → still denied.
-        assert_eq!(gate.decide_request("1.1.1.1:80"), EgressVerdict::Deny);
-        assert_eq!(gate.decide_request("8.8.8.8:443"), EgressVerdict::Deny);
+        assert!(gate.decide_request("1.1.1.1:80").is_deny());
+        assert!(gate.decide_request("8.8.8.8:443").is_deny());
     }
 
     #[test]
     fn ssh_flow_is_refused_even_when_listed() {
         // A grant that names port 22 must still be refused (claim-10 banned-SSH).
         let gate = EgressGate::new(CanonicalEgress::Rules(vec![allow_rule("1.1.1.1/32", 22)]));
-        assert_eq!(gate.decide_request("1.1.1.1:22"), EgressVerdict::Deny);
+        assert!(gate.decide_request("1.1.1.1:22").is_deny());
     }
 
     #[test]
@@ -344,7 +591,7 @@ mod tests {
                 port: 5353,
             }
         );
-        assert_eq!(gate.decide_request("192.0.2.1:5353"), EgressVerdict::Deny);
+        assert!(gate.decide_request("192.0.2.1:5353").is_deny());
     }
 
     #[test]
@@ -371,7 +618,7 @@ mod tests {
         let verdict = gate.decide_hostname_request(Proto::Tcp, "cache.nixos.org", 443, |_host| {
             Ok(vec!["151.101.1.91".parse().unwrap()])
         });
-        assert_eq!(verdict, EgressVerdict::Deny);
+        assert!(verdict.is_deny());
     }
 
     /// The gate composes with the real `NetworkPolicy` projection — the path the
@@ -386,9 +633,10 @@ mod tests {
         let now = "2026-01-01T00:00:00Z";
 
         let deny = canonicalize_network_policy(&NetworkPolicy::deny_all(), &pins, now).unwrap();
-        assert_eq!(
-            EgressGate::new(deny).decide_request("1.1.1.1:443"),
-            EgressVerdict::Deny
+        assert!(
+            EgressGate::new(deny)
+                .decide_request("1.1.1.1:443")
+                .is_deny()
         );
 
         let open = canonicalize_network_policy(&NetworkPolicy::unrestricted(), &pins, now).unwrap();
@@ -412,7 +660,7 @@ mod tests {
         let now = "2026-01-01T00:00:00Z";
 
         let deny = EgressGate::from_network_policy(&NetworkPolicy::deny_all(), &pins, now);
-        assert_eq!(deny.decide_request("1.1.1.1:443"), EgressVerdict::Deny);
+        assert!(deny.decide_request("1.1.1.1:443").is_deny());
 
         let open = EgressGate::from_network_policy(&NetworkPolicy::unrestricted(), &pins, now);
         assert_eq!(
@@ -430,10 +678,7 @@ mod tests {
             port: 443,
         }]);
         let gate = EgressGate::from_network_policy(&unpinned, &pins, now);
-        assert_eq!(
-            gate.decide_request("93.184.216.34:443"),
-            EgressVerdict::Deny
-        );
+        assert!(gate.decide_request("93.184.216.34:443").is_deny());
     }
 
     /// An IP-host allow-list with the matching pin admits exactly that
@@ -464,8 +709,8 @@ mod tests {
                 port: 19099
             }
         );
-        assert_eq!(gate.decide_request("192.168.4.23:80"), EgressVerdict::Deny);
-        assert_eq!(gate.decide_request("8.8.8.8:19099"), EgressVerdict::Deny);
+        assert!(gate.decide_request("192.168.4.23:80").is_deny());
+        assert!(gate.decide_request("8.8.8.8:19099").is_deny());
     }
 
     /// DNS-over-vsock: a `socks5h` client sends a *hostname*; the gate resolves it
@@ -501,15 +746,9 @@ mod tests {
             }
         );
         // right host, disallowed port → deny.
-        assert_eq!(
-            gate.decide_request("api.example.test:80"),
-            EgressVerdict::Deny
-        );
+        assert!(gate.decide_request("api.example.test:80").is_deny());
         // unknown host (no pin) → deny, not malformed.
-        assert_eq!(
-            gate.decide_request("evil.example.test:443"),
-            EgressVerdict::Deny
-        );
+        assert!(gate.decide_request("evil.example.test:443").is_deny());
         // unparseable → malformed.
         assert_eq!(
             gate.decide_request("not-a-target"),
@@ -566,9 +805,9 @@ mod tests {
                 assert_eq!(ips, vec![v4, v6]);
                 assert_eq!(port, 443);
             }
-            EgressVerdict::Deny | EgressVerdict::Malformed => panic!("expected allow"),
+            EgressVerdict::Deny(_) | EgressVerdict::Malformed => panic!("expected allow"),
         }
-        assert_eq!(gate.decide_request("example.com:80"), EgressVerdict::Deny);
+        assert!(gate.decide_request("example.com:80").is_deny());
     }
 
     /// A guest that resolved a dual-stack pinned host locally (macOS getaddrinfo
@@ -606,7 +845,7 @@ mod tests {
                     "numeric IPv6 connect must offer the pinned IPv4 sibling first"
                 );
             }
-            EgressVerdict::Deny | EgressVerdict::Malformed => {
+            EgressVerdict::Deny(_) | EgressVerdict::Malformed => {
                 panic!("expected Allow with fallover candidates")
             }
         }

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -760,13 +760,34 @@ with `wget http://example.com`, and bare `--allow-host example.com` with
 `wget https://example.com`, both return the real page body from inside the
 guest.
 
-One diagnosability note worth a follow-up. A bare `--allow-host <host>` means
+One diagnosability note, now closed. A bare `--allow-host <host>` means
 `<host>:443` (`parse_allow_host` defaults to the https port), so pairing it with
 an `http://` URL is a port mismatch and the gate denies — correctly. What the
-guest sees is `HTTP/1.1 403 Forbidden` with `Content-Length: 0` from
-`http_forward::write_proxy_error_*`, carrying no reason, which reads as "egress
-is broken" rather than "port 80 was not admitted". The host knows exactly which
-`EgressVerdict::Deny` it took; none of it reaches the caller.
+guest saw was `HTTP/1.1 403 Forbidden` with `Content-Length: 0` and no reason,
+which reads as "egress is broken" rather than "port 80 was not admitted"; the
+host knew exactly which `EgressVerdict::Deny` it took and discarded it. That cost
+three rounds of misdiagnosis in this very session, including two wrong
+attributions of the refusing component.
+
+`EgressVerdict::Deny` now carries a typed `DenyReason` (no-egress / host not
+admitted / port not admitted / address not admitted / resolution failed), so a
+deny site cannot fail to say why — the compiler asks at each one.
+`http_forward` renders it into the 403 body and logs it host-side; the raw-TCP
+and SOCKS-UDP paths, whose wire formats have no room for a reason, log it rather
+than dropping it. Live: `--allow-host example.com` with `http://example.com`
+answers
+
+```
+HTTP/1.1 403 Forbidden
+Content-Type: text/plain
+
+example.com:80 is not admitted; allowed: example.com:443
+```
+
+Remaining gap, deliberately not chased here: busybox `wget` prints only the
+status line and discards the body, so a wget user still needs the host log
+(`/tmp/mvm-substitution-endpoint-<vm>.log`). Surfacing a failed run's egress
+denials through `mvmctl` itself is the follow-up.
 
 HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214; Plan 270 designs for HVF but does not duplicate that work. Plan 268 (`specs/plans/268-backend-shim-removal.md`) stays a separate future workstream and is not absorbed here.
 


### PR DESCRIPTION
> Stacked on #1942 — base is `fix/legacy-initramfs-verity-cmdline`, which this
> needs to boot a guest at all. Retarget to `main` once #1942 lands.

A denied request reached the guest as `403 Forbidden`, `Content-Length: 0`, and
nothing else. The gate knew precisely which refusal it was — it holds the pins
and the canonical rules — and discarded that one stack frame before the response
was written.

The refusal this costs most is the ordinary one. A bare `--allow-host <host>`
means `<host>:443`, so pairing it with an `http://` URL asks for port 80 and is
correctly denied; what the caller sees is indistinguishable from a broken
network. In this repo's own session that misread burned three rounds and two
wrong attributions of which component was even refusing.

## Shape

`EgressVerdict::Deny` carries a typed `DenyReason` instead of being a unit
variant, so the decision and its explanation are one value and no deny site can
fail to supply one — the compiler asks at each. The variants are the
distinctions a caller acts on differently:

| variant | the caller's next move |
|---|---|
| `NoEgressAdmitted` | pass `--allow-host` at all |
| `HostNotAdmitted { host, admitted_hosts }` | add the host, or use one of the listed ones |
| `PortNotAdmitted { host, port, admitted_ports }` | `--allow-host host:port` |
| `AddressNotAdmitted { ip, port }` | the address is refused outright (mandatory-deny / outside every rule) |
| `ResolutionFailed { host }` | the name does not resolve |

It reports policy shape only — hosts and ports the operator already wrote on the
command line — never anything learned from the network.

## Where it surfaces

`http_forward` renders it into the 403 body **and** logs it host-side, because
busybox `wget` prints the status line and discards the body. The raw-TCP tunnel
and SOCKS-UDP paths have no room for a reason on the wire (a one-byte nack, and
silence) so they log rather than drop it.

Live, on the exact invocation that caused the confusion:

```
$ mvmctl machine run --image alpine --allow-host example.com -- \
    /bin/sh -c "printf 'GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n' | nc 127.0.0.1 1080"
HTTP/1.1 403 Forbidden
Content-Length: 57
Content-Type: text/plain

example.com:80 is not admitted; allowed: example.com:443
```

## Verification

New tests: the gate's port-mismatch and unlisted-host reasons, and an
`http_forward` test that reads the 403 off a real duplex stream and asserts the
body names both the refused and the admitted destination. Existing gate tests
that only cared *that* it denied now use `EgressVerdict::is_deny()`.

fmt (nightly), clippy, 8194 workspace tests, doctests, 52 BDD scenarios, 34
xtask policy gates.

## Not covered

Busybox `wget` still shows only the status line, so a wget user needs the host
log at `/tmp/mvm-substitution-endpoint-<vm>.log`. Surfacing a run's egress
denials through `mvmctl` itself is the follow-up.
