### PR TITLE
fix(guest): create the early mount points before mounting them

### DIFF
--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -75,9 +75,15 @@ pub fn validate_roothash(roothash: &str, name: &str) -> Result<()> {
 
 /// Basic early-boot filesystems the PID-1 agent needs before it can
 /// receive `ActivateEnvironment` over vsock.
+///
+/// Each target is created before it is mounted. The universal initramfs
+/// carries the init binary and nothing else — no `/proc`, no `/sys`, no
+/// `/dev` — so there is no directory to mount onto unless PID 1 makes one,
+/// and `mount` fails before the agent can report anything useful.
 pub fn mount_early_filesystems() -> Result<()> {
     #[cfg(target_os = "linux")]
     {
+        ensure_dir("/proc")?;
         mount(
             "proc",
             "/proc",
@@ -85,6 +91,7 @@ pub fn mount_early_filesystems() -> Result<()> {
             libc::MS_NOSUID | libc::MS_NOEXEC | libc::MS_NODEV,
             "",
         )?;
+        ensure_dir("/sys")?;
         mount(
             "sysfs",
             "/sys",
@@ -95,6 +102,7 @@ pub fn mount_early_filesystems() -> Result<()> {
         // devtmpfs gives us /dev/console, /dev/null, etc. without a static
         // device table in the initramfs.
         if !Path::new("/dev/console").exists() {
+            ensure_dir("/dev")?;
             mount("devtmpfs", "/dev", "devtmpfs", libc::MS_NOSUID, "")?;
         }
     }
@@ -816,6 +824,47 @@ mod tests {
     use std::io::{Seek, SeekFrom, Write};
 
     const FAKE_HASH: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    /// Every early mount target must be created before it is mounted.
+    ///
+    /// The universal initramfs carries the init binary and nothing else, so
+    /// there is no `/proc`, `/sys` or `/dev` to mount onto unless PID 1 makes
+    /// one. Without that, `mount` fails with ENOENT, init exits, and the kernel
+    /// panics before the agent can report anything — which is what shipped.
+    ///
+    /// Asserted against the source because the real function issues syscalls
+    /// that no unit test can run: it needs PID 1 in a guest, and the host it is
+    /// compiled on may not even be Linux.
+    #[test]
+    fn every_early_mount_target_is_created_before_it_is_mounted() {
+        let src = include_str!("guest_mount.rs");
+        let body = src
+            .split("pub fn mount_early_filesystems")
+            .nth(1)
+            .expect("mount_early_filesystems must exist");
+        let body = body
+            .split("\npub fn ")
+            .next()
+            .expect("function body is delimited by the next item");
+
+        for target in ["/proc", "/sys", "/dev"] {
+            let created = body
+                .find(&format!("ensure_dir(\"{target}\")"))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{target} is mounted but never created; the initramfs has no \
+                     directory to mount onto, so PID 1 dies on ENOENT"
+                    )
+                });
+            let mounted = body
+                .find(&format!("\"{target}\","))
+                .unwrap_or_else(|| panic!("{target} should still be mounted here"));
+            assert!(
+                created < mounted,
+                "{target}: ensure_dir must come before the mount, not after"
+            );
+        }
+    }
 
     #[test]
     fn validate_roothash_accepts_64_lowercase_hex() {


### PR DESCRIPTION
Fixes #1945.

## What was broken

A Firecracker workload could not boot **at all** on `main`. The agent runs as PID 1 out of the universal initramfs, calls `mount(proc -> /proc)`, and the mount fails because nothing has created `/proc`. Init exits and the kernel panics:

```
[    0.364179] Run /init as init process
mvm-guest-agent: running as PID 1, performing early initramfs setup
mvm-guest-agent: FATAL (PID 1): early filesystem mount failed: syscall failed: mount(proc -> /proc, proc)
[    0.569396] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
```

## Why it happened

Two halves that are each reasonable on their own, with nothing in between.

The initramfs carries the init binary and nothing else, deliberately — `nix/images/initramfs/flake.nix` says it "carries exactly one executable" and "contains NO busybox". Unpacking the built artifact confirms there is no `/proc`, `/sys` or `/dev`:

```
$ zcat initramfs.cpio.gz | cpio -idmv && ls -la
-rwxr-xr-x  init      (2544640 bytes)
```

And `mount_early_filesystems` mounts those three paths, which is what PID 1 must do. Neither side creates the mount points, so the first mount dies on ENOENT before the agent can report anything useful.

## The fix

Create `/proc`, `/sys` and `/dev` before mounting them, using the `ensure_dir` helper already in that file (the older `mvm-verity-init` path does the equivalent `create_dir_all`).

## The guard

`every_early_mount_target_is_created_before_it_is_mounted` asserts each target is created *before* it is mounted, and is deliberately a source-level assertion: the real function issues syscalls that need PID 1 inside a guest, and the host it compiles on may not be Linux. Verified red by deleting the `/proc` line — the shipped bug exactly.

## Scope of verification

The mechanism is verified — the initramfs genuinely contains only `init`, and the mount genuinely precedes any `mkdir`. The **boot itself is not yet verified on hardware**: this was found from macOS, which cannot run a Firecracker guest. `/proc` may also be only the first missing piece. The next step is rebuilding on a KVM host and retrying the boot.

Reproduced on a Linux/KVM host with a completely clean cache — workload kernel, initramfs, runtime overlay and OCI rootfs all freshly built by current `main` in an empty `MVM_HOME` — so this is not stale-artifact skew.

## Secondary finding (not fixed here)

The workload kernel has **no staleness detection**, unlike the runtime overlay (which reports "source-built cache is stale; rebuilding") and the initramfs (regenerated per run), and `machine run` refuses to build it implicitly. A cached kernel can therefore skew arbitrarily far behind freshly-built guest artifacts. On the test host an 8-day-old kernel predating the universal initramfs was pairing with a fresh PID-1 initramfs and producing this same panic for a different reason, which made the real defect harder to isolate. Recorded in #1945.
