### PR TITLE
fix(deps): collapse the duplicate curve25519-dalek out of the guest agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,21 +1042,6 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "fiat-crypto 0.2.9",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
@@ -1065,7 +1050,7 @@ dependencies = [
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
- "fiat-crypto 0.3.0",
+ "fiat-crypto",
  "rand_core 0.10.1",
  "rustc_version",
  "subtle",
@@ -1297,7 +1282,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
- "curve25519-dalek 5.0.0",
+ "curve25519-dalek",
  "ed25519",
  "rand_core 0.10.1",
  "sha2 0.11.0",
@@ -1405,12 +1390,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiat-crypto"
@@ -6626,13 +6605,12 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
- "curve25519-dalek 4.1.3",
- "rand_core 0.6.4",
- "serde",
+ "curve25519-dalek",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ base64 = "0.22"
 ed25519-dalek = "3"
 hmac = "0.13"
 rand = "0.8"
-x25519-dalek = { version = "2", features = ["static_secrets"] }
+x25519-dalek = { version = "3", features = ["static_secrets"] }
 # Plan 129 Stage 2 (ADR-003): mint the per-VM name-constrained egress CA /
 # intermediate / leaf certs for transparent https substitution. 0.13+ for the
 # `nameConstraints` API. `ring` crypto backend (no cmake/C-toolchain like the

--- a/xtask/src/check_duplicate_majors.rs
+++ b/xtask/src/check_duplicate_majors.rs
@@ -28,12 +28,6 @@ use std::process::Command;
 /// into the build.
 const ALLOWLIST: &[&str] = &[
     "bitflags",
-    // x25519-dalek 2.x still uses curve25519-dalek 4.x while the workspace's
-    // Ed25519 stack uses curve25519-dalek 5.x; the authenticated control path
-    // requires both until the upstream stacks converge.
-    "cpufeatures",
-    "curve25519-dalek",
-    "fiat-crypto",
     "getrandom",
     "hashbrown",
     // nom 8 is pulled only by the cargo-fuzz tooling in the fuzz member crates;


### PR DESCRIPTION
## Why

`cargo-deny` — MVM-SEC-07's witness — has failed on **every scheduled `security.yml` run since at least 2026-07-25**, six consecutive nights:

```
error[duplicate]: found 2 duplicate entries for crate 'cpufeatures'
error[duplicate]: found 2 duplicate entries for crate 'curve25519-dalek'
error[duplicate]: found 2 duplicate entries for crate 'fiat-crypto'
```

## Root cause

One crate depending on two dalek stacks that had diverged:

```
mvm-agentd ├── x25519-dalek 2.0.1  → curve25519-dalek 4.1.3
           └── ed25519-dalek 3.0.0 → curve25519-dalek 5.0.0
```

`cpufeatures` and `fiat-crypto` duplicate as transitive consequences. The effect is two copies of the curve arithmetic compiled into the sealed, size-budgeted guest agent — which `xtask check-binary-size` budgets and the "limit dependencies" principle argues against independently of the gate being red.

## Fix

`x25519-dalek 3.0.0` tracks `curve25519-dalek 5`, so bumping it **converges** the two stacks rather than allowlisting the split:

```
Removing curve25519-dalek v4.1.3
Removing fiat-crypto v0.2.9
Updating x25519-dalek v2.0.1 -> v3.0.0
```

`cargo deny check` now reports *advisories ok, bans ok, licenses ok, sources ok*. The only usage site is `crates/mvm-agentd/src/vsock/framing.rs` (`PublicKey`, `StaticSecret`), whose API is unchanged across the major.

Also drops the three now-stale entries from `check-duplicate-majors`' `ALLOWLIST` — the gate reports them itself once the duplication is gone, and its own comment had recorded this exact case: *"until the upstream stacks converge."* They have.

## Why it stayed red for six nights

`check-duplicate-majors` allowlisted all three and exited clean; `deny.toml` did not skip them and `cargo-deny` failed. **The two gates' allowlists had drifted apart**, so the cheap advisory gate read green while the real supply-chain gate was red — in a lane that only runs on tags and nightly cron and is therefore invisible on PRs.

## Verification

`cargo deny check` clean · `check-duplicate-majors` clean · `cargo clippy --workspace --all-targets -- -D warnings` clean · full workspace suite green apart from failures established as pre-existing and unrelated.

On that last point, in the interest of not hiding it: a full `--no-fail-fast` run showed 13 failures. All were checked rather than assumed. One (`raw_egress splice_sends_fail_ack…`) fails identically on unmodified `main` and is filed as #1950. The other twelve (`mvm-agentd::entrypoint_execute`, `::worker_pool_warm`) pass in isolation and fail only under full parallelism with the signature `Timeout { stdout: [], stderr: [], controls: [] }` at exactly their 5s budget — a spawned wrapper that never started, which is the process-spawn-racing-a-clock class #1943 identified and grouped. An 8-run A/B under CPU load with and without this change gave 1/8 and 0/8, i.e. load noise rather than a signal; the failure mode contains no crypto path. Extending #1943's `process-handshake` test group to cover those two binaries is a follow-up.

Found while auditing whether each claim's witness can actually fail (`specs/plans/274-witness-rigor.md`, WS3). Related: #1951 (MVM-SEC-05's fuzz lane, red the same six nights).
