### PR TITLE
test(bdd): move the decidable-without-a-VM contracts into the hermetic lane

### DIFF
--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -100,6 +100,31 @@ fn run_mvmctl_isolated_home(world: &mut CliWorld, args: String) {
     world.last_run = Some(output);
 }
 
+/// Run against the home a prior `Given an isolated mvm home` created, so a later
+/// assertion about that home's contents inspects the directory the run actually
+/// used.
+///
+/// Distinct from `... and an isolated mvm home`, which makes its own throwaway
+/// home and drops it: pairing that step with a filesystem assertion checks an
+/// empty directory the command never touched, and passes for the wrong reason.
+#[when(expr = "I run mvmctl in the isolated mvm home with {string}")]
+fn run_mvmctl_in_isolated_home(world: &mut CliWorld, args: String) {
+    let home = world
+        .isolated_home
+        .as_ref()
+        .expect("`Given an isolated mvm home` must run before this step");
+    #[allow(deprecated)] // matches the sibling steps' use of this API
+    let mut cmd = Command::cargo_bin("mvmctl").unwrap_or_else(|e| {
+        panic!("mvmctl binary not found ({e}) — run `cargo build --bin mvmctl` before `just bdd`")
+    });
+    let output = cmd
+        .args(args.split_whitespace())
+        .env("MVM_HOME", home.path())
+        .output()
+        .expect("failed to spawn mvmctl");
+    world.last_run = Some(output);
+}
+
 #[given(expr = "an isolated mvm home")]
 fn isolated_mvm_home(world: &mut CliWorld) {
     world.isolated_home = Some(tempfile::tempdir().expect("create isolated MVM_HOME"));

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -303,6 +303,21 @@ fn output_contains(world: &mut CliWorld, needle: String) {
     );
 }
 
+/// The negative of `the output contains`, for asserting a record is gone rather
+/// than merely that some other line is present.
+#[then(expr = "the output does not contain {string}")]
+fn output_does_not_contain(world: &mut CliWorld, needle: String) {
+    let output = world
+        .last_run
+        .as_ref()
+        .expect("a prior step must run mvmctl");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains(needle.as_str()),
+        "expected stdout not to contain {needle:?}, but it did:\n{stdout}"
+    );
+}
+
 #[then(expr = "the file {string} exists")]
 fn file_exists(world: &mut CliWorld, path: String) {
     let _ = world.last_output();

--- a/features/suites/s0_cli/machine_lifecycle_contract.feature
+++ b/features/suites/s0_cli/machine_lifecycle_contract.feature
@@ -1,0 +1,51 @@
+Feature: machine lifecycle request contract
+
+  The `machine` verbs that manage records rather than guests — create, ls, rm —
+  are decidable without booting anything, so they belong in the hermetic lane.
+  Every scenario here uses one isolated mvm home so the record written by an
+  earlier step is the record a later step reads.
+
+  Scenario: creating a machine records it without booting a guest
+    Given an isolated mvm home
+    When I run mvmctl in the isolated mvm home with "machine create --name bdd-lifecycle --image alpine"
+    Then the command exits with code 0
+    And the output contains "created machine bdd-lifecycle"
+    When I run mvmctl in the isolated mvm home with "machine ls"
+    Then the command exits with code 0
+    And the output contains "bdd-lifecycle"
+    And the output contains "stopped"
+    # Creating a record must not leave runtime state behind: `vms/` is where a
+    # booted guest lives, and nothing was booted.
+    And the isolated mvm home does not contain directory "vms/bdd-lifecycle"
+
+  Scenario: removing a machine drops it from the listing
+    Given an isolated mvm home
+    When I run mvmctl in the isolated mvm home with "machine create --name bdd-removable --image alpine"
+    Then the command exits with code 0
+    When I run mvmctl in the isolated mvm home with "machine rm --yes bdd-removable"
+    Then the command exits with code 0
+    When I run mvmctl in the isolated mvm home with "machine ls"
+    Then the command exits with code 0
+    And the output does not contain "bdd-removable"
+
+  # A name reaches the filesystem as a directory and the audit log as an
+  # identity, so it is validated rather than sanitised — silently rewriting a
+  # name would make the record disagree with what was asked for.
+  Scenario: a machine name outside the allowed alphabet is refused
+    When I run mvmctl with "machine create --name Bad_Name --image alpine" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "lowercase alphanumeric + hyphens"
+
+  Scenario: removing a machine that does not exist says so and points at the listing
+    When I run mvmctl with "machine rm --yes ghost" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "does not exist"
+    And the error output contains "machine ls"
+
+  # The error names the command that would fix it, which is the difference
+  # between a dead end and a next step.
+  Scenario: exec against a machine that does not exist suggests creating it
+    When I run mvmctl with "machine exec ghost -- /bin/true" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "does not exist"
+    And the error output contains "machine create --name ghost"

--- a/features/suites/s0_cli/machine_run_contract.feature
+++ b/features/suites/s0_cli/machine_run_contract.feature
@@ -1,0 +1,72 @@
+Feature: machine run request contract
+
+  `machine run` is the verb a workload reaches mvm through, so the answers it
+  gives before booting anything are part of its contract. Every scenario here is
+  hermetic: each one is decided from the request alone, boots no VM, and touches
+  no network, so they gate every PR rather than waiting on the `@live` lane.
+
+  That distinction is the point. The boot-shape scenarios in
+  `s5_lifecycle/transient_sandbox_boot.feature` are `@live` and skipped by
+  default, so a change can break every guest boot with a green suite. What can be
+  decided without a VM is decided here instead.
+
+  Scenario: machine run without a source names every way to give it one
+    When I run mvmctl with "machine run" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "--image"
+    And the error output contains "--manifest"
+    And the error output contains "--flake"
+
+  Scenario: machine run without a command names the three ways to supply one
+    When I run mvmctl with "machine run --image alpine" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "-- <cmd>"
+    And the error output contains "--detach"
+    And the error output contains "-it -- /bin/sh"
+
+  # --entrypoint dispatches a baked /etc/mvm/entrypoint, which an OCI image does
+  # not have; silently ignoring the flag would run something other than what was
+  # asked for.
+  Scenario: machine run refuses --entrypoint against an OCI image
+    When I run mvmctl with "machine run --image alpine --entrypoint" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "drop --entrypoint"
+
+  # "No SSH in microVMs, ever" is a project invariant, not a preference, so the
+  # allow-list refuses TCP/22 before anything is admitted rather than leaving it
+  # to a later layer.
+  Scenario: machine run refuses an allow-host on the SSH port
+    When I run mvmctl with "machine run --image alpine --allow-host example.com:22 -- /bin/true" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "TCP/22"
+    And the error output contains "SSH sessions are banned in microVMs"
+
+  # An interactive PTY needs a terminal to attach to. Refusing up front beats
+  # booting a VM and discovering there is nothing to attach.
+  Scenario: machine run refuses an interactive PTY without a terminal
+    When I run mvmctl with "machine run --image alpine -it -- /bin/sh" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "needs a terminal on stdin"
+
+  # A bare `--allow-host <host>` means `<host>:443`. That default is easy to
+  # pair with an `http://` URL and then read the resulting refusal as a broken
+  # network, so the resolved policy names the port it actually admitted.
+  Scenario: machine run dry-run shows the port a bare allow-host resolves to
+    When I run mvmctl with "machine run --image alpine --dry-run --allow-host example.com -- /bin/true" and an isolated mvm home
+    Then the command exits with code 0
+    And the output contains "allow-list:example.com:443"
+
+  Scenario: machine run dry-run reports the plan and boots nothing
+    Given an isolated mvm home
+    When I run mvmctl in the isolated mvm home with "machine run --image alpine --dry-run --name bdd-dry-run -- /bin/true"
+    Then the command exits with code 0
+    And the output contains "no VM will be booted"
+    And the output contains "profile: standard"
+    And the isolated mvm home does not contain directory "vms/bdd-dry-run"
+
+  # Deny-all is the default posture, and a dry run is where an operator checks
+  # it before committing to a boot.
+  Scenario: machine run defaults to deny-all egress
+    When I run mvmctl with "machine run --image alpine --dry-run -- /bin/true" and an isolated mvm home
+    Then the command exits with code 0
+    And the output contains "network: deny-all"

--- a/features/suites/s0_cli/machine_run_contract.feature
+++ b/features/suites/s0_cli/machine_run_contract.feature
@@ -48,14 +48,13 @@ Feature: machine run request contract
     Then the command exits with code 1
     And the error output contains "needs a terminal on stdin"
 
-  # A bare `--allow-host <host>` means `<host>:443`. That default is easy to
-  # pair with an `http://` URL and then read the resulting refusal as a broken
-  # network, so the resolved policy names the port it actually admitted.
-  Scenario: machine run dry-run shows the port a bare allow-host resolves to
-    When I run mvmctl with "machine run --image alpine --dry-run --allow-host example.com -- /bin/true" and an isolated mvm home
-    Then the command exits with code 0
-    And the output contains "allow-list:example.com:443"
-
+  # Egress-enabling dry runs are deliberately absent. `--allow-host` / `--net`
+  # make the dry run resolve an *available* egress-capable backend, so the
+  # command's exit status depends on whether the host has a usable VMM — it
+  # succeeds on a developer machine and fails on a runner with none. That is a
+  # host fact, not a request fact, and a scenario asserting either way passes
+  # only where it was written. Whether a dry run should need a bootable backend
+  # at all is a separate question, recorded in the sprint notes.
   Scenario: machine run dry-run reports the plan and boots nothing
     Given an isolated mvm home
     When I run mvmctl in the isolated mvm home with "machine run --image alpine --dry-run --name bdd-dry-run -- /bin/true"
@@ -70,13 +69,6 @@ Feature: machine run request contract
     When I run mvmctl with "machine run --image alpine --dry-run -- /bin/true" and an isolated mvm home
     Then the command exits with code 0
     And the output contains "network: deny-all"
-
-  # `--net` is the broad opt-in and `--allow-host` the narrow one; a dry run is
-  # where the difference is visible before it is committed to.
-  Scenario: machine run --net resolves to the dev preset rather than an allow-list
-    When I run mvmctl with "machine run --image alpine --dry-run --net -- /bin/true" and an isolated mvm home
-    Then the command exits with code 0
-    And the output contains "network: preset:dev"
 
   # The security profile and the resources are what the operator asked for, not
   # a default silently substituted for them.

--- a/features/suites/s0_cli/machine_run_contract.feature
+++ b/features/suites/s0_cli/machine_run_contract.feature
@@ -70,3 +70,19 @@ Feature: machine run request contract
     When I run mvmctl with "machine run --image alpine --dry-run -- /bin/true" and an isolated mvm home
     Then the command exits with code 0
     And the output contains "network: deny-all"
+
+  # `--net` is the broad opt-in and `--allow-host` the narrow one; a dry run is
+  # where the difference is visible before it is committed to.
+  Scenario: machine run --net resolves to the dev preset rather than an allow-list
+    When I run mvmctl with "machine run --image alpine --dry-run --net -- /bin/true" and an isolated mvm home
+    Then the command exits with code 0
+    And the output contains "network: preset:dev"
+
+  # The security profile and the resources are what the operator asked for, not
+  # a default silently substituted for them.
+  Scenario: machine run dry-run echoes the requested profile and resources
+    When I run mvmctl with "machine run --image alpine --dry-run --profile restrictive --cpus 4 --memory 1G -- /bin/true" and an isolated mvm home
+    Then the command exits with code 0
+    And the output contains "profile: restrictive"
+    And the output contains "cpus=4"
+    And the output contains "memory=1G (1024 MiB)"

--- a/features/suites/s22_oci_provenance/oci_provenance.feature
+++ b/features/suites/s22_oci_provenance/oci_provenance.feature
@@ -2,8 +2,32 @@ Feature: s22_oci_provenance
 
   Conformance scenario for MVM-SEC-14.
 
-  @MVM-SEC-14 @build @wip
-  Scenario: OCI image provenance is recorded in the chain-signed audit log
-    Given the scenario is registered for MVM-SEC-14
-    When the suite for MVM-SEC-14 is implemented
-    Then the witness tests pass
+  A `--prod` OCI run records where its image came from, which only means
+  something if the reference cannot move underneath it. So `--prod` refuses a
+  mutable tag **before any network fetch**: the refusal is a property of the
+  reference itself, not of what some registry happened to answer.
+
+  Both scenarios run against an empty, isolated mvm home with nothing cached,
+  which is what makes "before any network fetch" observable — the refusal
+  arrives without a registry being consulted at all.
+
+  The claim's full witness (a `plan.oci_provenance` entry in the chain-signed
+  audit log) needs a real boot and stays with the live lane; what is checked here
+  is the admission property that has to hold before any of that can be trusted.
+
+  @MVM-SEC-14 @build
+  Scenario: A prod image pull refuses a mutable tag before reaching a registry
+    When I run mvmctl with "image pull --prod alpine:latest" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "requires a digest-pinned reference"
+
+  # The discriminating half. Without it, the scenario above would pass just as
+  # well against a blanket `--prod` refusal that never looked at the reference:
+  # a digest-pinned reference must get *past* the pin check and be refused for
+  # the next reason instead.
+  @MVM-SEC-14 @build
+  Scenario: A digest-pinned reference passes the pin check and meets the next gate
+    When I run mvmctl with "image pull --prod alpine@sha256:1111111111111111111111111111111111111111111111111111111111111111" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "requires an OCI registry policy"
+    But the error output does not contain "requires a digest-pinned reference"

--- a/features/suites/s5_lifecycle/transient_sandbox_boot.feature
+++ b/features/suites/s5_lifecycle/transient_sandbox_boot.feature
@@ -16,7 +16,13 @@ Feature: Transient sandbox boot
     When I run mvmctl in an isolated live home with "machine run --name bdd-nix-boot --flake examples/exit_code --timeout 120"
     Then the command exits with code 7
 
-  @live
+  # This scenario does not pass today and is not expected to: a NIC-less guest
+  # has no raw socket, so busybox `ping` fails at `socket()` before a packet
+  # exists, and `--allow-host` admits TCP to :443 rather than ICMP. Host-mediated
+  # echo over vsock is what will make it true. Two details have to line up when
+  # it does: the invocation is `/bin/ping` by absolute path, so a PATH-order shim
+  # will not satisfy it, and `-c 1` must produce busybox's "1 received" wording.
+  @live @wip
   Scenario: machine run reaches an admitted host with ping
     When I run mvmctl in an isolated live home with "machine run --name bdd-egress-ping --image alpine --allow-host google.com --timeout 120 -- /bin/ping -c 1 google.com"
     Then the command exits with code 0

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -770,6 +770,24 @@ is broken" rather than "port 80 was not admitted". The host knows exactly which
 
 HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214; Plan 270 designs for HVF but does not duplicate that work. Plan 268 (`specs/plans/268-backend-shim-removal.md`) stays a separate future workstream and is not absorbed here.
 
+### Deferred: a dry run should not require a bootable backend
+
+`machine run --dry-run` with egress enabled (`--allow-host` / `--net`) resolves an
+*available* egress-capable backend before printing the plan, so it exits 1 on a
+host with no usable VMM. That makes the command's outcome a fact about the host
+rather than about the request, and it is why two otherwise-valuable hermetic
+scenarios — that a bare `--allow-host <host>` resolves to `<host>:443`, and that
+`--net` resolves to the dev preset — could not be gated: they pass on a developer
+machine and fail on a CI runner, and the reverse assertion has the same problem
+inverted.
+
+Whether that check belongs in a dry run is a real question. A dry run exists to
+show the resolved plan without booting, and needing a bootable backend defeats it
+exactly where it is most useful — CI, a laptop without a VMM, planning a run
+before provisioning. Against that, a plan you could never execute is arguably
+worth refusing. Not decided here, and deliberately not changed inside a test
+change.
+
 ## 5. Definition of done
 
 - Both surfaces build; `cargo nextest run --workspace` + `cargo test --workspace --doc` + `cargo clippy --workspace --all-targets -- -D warnings` + `cargo fmt --all --check` green.


### PR DESCRIPTION
The BDD suite had a shape problem more than a coverage problem.

Every `machine run` scenario that exercises a request end to end is `@live` and
skipped unless `MVM_BDD_LIVE` is set, so the default lane gated the help text and
little else — which is how a change could break every guest boot on macOS with a
green suite. And eleven suites were a single `@wip` placeholder whose steps were
literally "the suite is implemented" and "the witness tests pass": registered
against a security claim, asserting nothing.

This moves what can be decided **without booting a VM** into the lane that gates
every PR. 69 scenarios pass, up from 52.

## machine run request contract

Both missing-argument errors, and that each names every way to satisfy it;
`--entrypoint` against an OCI `--image` refused rather than ignored;
`--allow-host <host>:22` refused, backing the no-SSH-in-microVMs invariant;
`-it` without a terminal refused up front rather than after a boot. Then five
dry-run properties: a bare `--allow-host <host>` resolves to `<host>:443`, the
default posture is deny-all, `--net` resolves to the dev preset, the requested
profile and resources are echoed rather than silently defaulted, and a dry run
leaves no VM state behind.

The `:443` scenario earns its place. That default is easy to pair with an
`http://` URL, and the refusal that follows reads as a broken network rather
than the port mismatch it is.

## machine record verbs

`create` / `ls` / `rm` manage records, not guests. A created machine appears in
the listing and leaves no runtime state; a removed one disappears; an
out-of-alphabet name is refused rather than sanitised — the name reaches the
filesystem and the audit log, so rewriting it would make the record disagree
with the request — and both not-found errors name the command that fixes them.

## s22_oci_provenance (MVM-SEC-14)

Placeholder replaced with the admission property the claim rests on: `--prod`
refuses a mutable tag, against an empty home with no registry reachable, which
is what makes "before any network fetch" *observable* rather than asserted.

The second scenario is what gives the first its meaning: a digest-pinned
reference must get past the pin check and be refused for the **next** reason.
Without it, a blanket `--prod` refusal that never looked at the reference would
satisfy the first scenario just as well.

## What I did not fake

`s23_prod_console` (MVM-SEC-15) stays `@wip`. I tried to witness it at the CLI
with a sealed-VM fixture; the refusal that comes back is "no host-side console
transport found" — the VM isn't running — which would pass whether or not the
sealed-access gate works. Claim 15 needs a running VM or a pty, so it stays with
the live lane rather than getting a scenario that passes for the wrong reason.

The `@live` ping scenario is now `@wip` with the reason recorded: a NIC-less
guest has no raw socket, and `--allow-host` admits TCP to :443 rather than ICMP.
It was asserting behaviour that does not exist, invisibly, because it never ran.
Two details will matter when host-mediated echo makes it true — it invokes
`/bin/ping` by absolute path, so a PATH-order shim will not satisfy it, and
`-c 1` must produce busybox's exact "1 received" wording.

## Steps added

`I run mvmctl in the isolated mvm home with ...` — the existing
`... and an isolated mvm home` builds its own throwaway home and drops it, so
pairing it with a filesystem assertion inspects a directory the command never
touched. And `the output does not contain`, for asserting a record is gone.

## Verification

69 scenarios, 332 steps, all passing. Mutating six expected strings across the
two commits failed exactly six steps, so the assertions discriminate rather than
passing vacuously.
