### PR TITLE
fix(ci): point the fuzz lane at the crates it was renamed to, and isolate the mutation lane

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -315,7 +315,7 @@ jobs:
           fi
 
       - name: Fuzz GuestRequest
-        working-directory: crates/mvm-guest
+        working-directory: crates/mvm-agentd
         env:
           DURATION: ${{ steps.duration.outputs.secs }}
           # `cargo fuzz` requires nightly (-Z sanitizer flags). The
@@ -326,7 +326,7 @@ jobs:
         run: cargo fuzz run fuzz_guest_request -- -max_total_time="$DURATION"
 
       - name: Fuzz AuthenticatedFrame
-        working-directory: crates/mvm-guest
+        working-directory: crates/mvm-agentd
         env:
           DURATION: ${{ steps.duration.outputs.secs }}
           RUSTUP_TOOLCHAIN: nightly-2026-06-11
@@ -340,7 +340,7 @@ jobs:
         run: cargo fuzz run fuzz_dns_codec -- -max_total_time="$DURATION"
 
       - name: Fuzz authed path (signed-side)
-        working-directory: crates/mvm-guest
+        working-directory: crates/mvm-agentd
         env:
           DURATION: ${{ steps.duration.outputs.secs }}
           RUSTUP_TOOLCHAIN: nightly-2026-06-11
@@ -376,7 +376,7 @@ jobs:
         run: cargo fuzz run fuzz_attach_message -- -max_total_time="$DURATION"
 
       - name: Fuzz OCI unpack_layer
-        working-directory: crates/mvm-oci
+        working-directory: crates/mvm-fs
         env:
           DURATION: ${{ steps.duration.outputs.secs }}
           RUSTUP_TOOLCHAIN: nightly-2026-06-11
@@ -388,10 +388,10 @@ jobs:
         # here from ci.yml's per-PR lane (commit 304b5c9c+) so the
         # 30-min budget only burns on release-tag pushes and the
         # nightly cron, not on every mvm-oci PR.
-        run: cargo fuzz run unpack_layer -- -max_total_time="$DURATION"
+        run: cargo fuzz run --fuzz-dir fuzz-oci unpack_layer -- -max_total_time="$DURATION"
 
       - name: Fuzz mvm-bridge — BridgeConfigJson (host-side)
-        working-directory: crates/mvm-vm-host
+        working-directory: crates/mvm-hostd
         env:
           DURATION: ${{ steps.duration.outputs.secs }}
           RUSTUP_TOOLCHAIN: nightly-2026-06-11
@@ -407,10 +407,10 @@ jobs:
         # `BridgeConfigJson` (Task 12 — `crates/mvm-hostd/
         # src/parse.rs`) means unknown keys fail-closed inside
         # deserialization.
-        run: cargo fuzz run fuzz_bridge_config_json -- -max_total_time="$DURATION"
+        run: cargo fuzz run --fuzz-dir fuzz-vmhost fuzz_bridge_config_json -- -max_total_time="$DURATION"
 
       - name: Fuzz mvm-bridge — passt-hashes TOML
-        working-directory: crates/mvm-vm-host
+        working-directory: crates/mvm-hostd
         env:
           DURATION: ${{ steps.duration.outputs.secs }}
           RUSTUP_TOOLCHAIN: nightly-2026-06-11
@@ -422,7 +422,7 @@ jobs:
         # pipeline is up; this fuzz target asserts the no-panic
         # complement of the `verify_passt_hash_rejects_*` unit-test
         # suite.
-        run: cargo fuzz run fuzz_passt_hashes_toml -- -max_total_time="$DURATION"
+        run: cargo fuzz run --fuzz-dir fuzz-vmhost fuzz_passt_hashes_toml -- -max_total_time="$DURATION"
 
       - name: Fuzz gateway packet parse + rebuild (host-side)
         working-directory: crates/mvm-hostd
@@ -454,7 +454,7 @@ jobs:
         run: cargo fuzz run fuzz_runtime_recording -- -max_total_time="$DURATION"
 
       - name: Fuzz ext4 build_image (rootfs writer)
-        working-directory: crates/mvm-ext4
+        working-directory: crates/mvm-fs
         env:
           DURATION: ${{ steps.duration.outputs.secs }}
           RUSTUP_TOOLCHAIN: nightly-2026-06-11
@@ -464,7 +464,7 @@ jobs:
         # set panics build_image (a run-path DoS), and every image it emits is
         # block-aligned and carries the ext4 superblock magic. Impossible trees
         # must return Err, never abort.
-        run: cargo fuzz run fuzz_build_image -- -max_total_time="$DURATION"
+        run: cargo fuzz run --fuzz-dir fuzz-ext4 fuzz_build_image -- -max_total_time="$DURATION"
 
       - name: Fuzz FUSE dispatch (virtio-fs request parser)
         working-directory: crates/mvm-runtime
@@ -530,6 +530,18 @@ jobs:
     # not-yet-triaged files. Flip this off once the baseline covers the
     # whole surface — tracked in specs/plans/272.
     continue-on-error: true
+    # `--run` mutates the claim-enforcement surface and then runs the suite
+    # against each mutant — plan verification that no longer verifies, a
+    # seccomp filter that no longer filters, the host signer. That is
+    # security code with the check removed, so it must not reach a real
+    # mvm state root: it could mint a key at the wrong path or mode (the
+    # mutation may be *in* the path/mode logic) or leave firewall rules
+    # behind. MVM_HOME alone is not enough — `default_mvm_cache_dir`
+    # deliberately reads $HOME to seed from the shared cache, which is the
+    # leak `check-test-home-isolation` exists to catch.
+    env:
+      MVM_HOME: ${{ runner.temp }}/mutants-mvm-home
+      HOME: ${{ runner.temp }}/mutants-mvm-home
     steps:
       - uses: actions/checkout@v6
 
@@ -545,6 +557,14 @@ jobs:
             target
           key: cargo-mutation-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-mutation-
+
+      - name: Fail closed if a real mvm state root is reachable
+        run: |
+          mkdir -p "$MVM_HOME"
+          if [ -e "$HOME/.mvm/keys" ]; then
+            echo "::error::refusing to mutate against a reachable keystore at $HOME/.mvm/keys" >&2
+            exit 1
+          fi
 
       - name: Install cargo-mutants and nextest
         run: cargo install --locked cargo-mutants cargo-nextest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -530,18 +530,6 @@ jobs:
     # not-yet-triaged files. Flip this off once the baseline covers the
     # whole surface — tracked in specs/plans/272.
     continue-on-error: true
-    # `--run` mutates the claim-enforcement surface and then runs the suite
-    # against each mutant — plan verification that no longer verifies, a
-    # seccomp filter that no longer filters, the host signer. That is
-    # security code with the check removed, so it must not reach a real
-    # mvm state root: it could mint a key at the wrong path or mode (the
-    # mutation may be *in* the path/mode logic) or leave firewall rules
-    # behind. MVM_HOME alone is not enough — `default_mvm_cache_dir`
-    # deliberately reads $HOME to seed from the shared cache, which is the
-    # leak `check-test-home-isolation` exists to catch.
-    env:
-      MVM_HOME: ${{ runner.temp }}/mutants-mvm-home
-      HOME: ${{ runner.temp }}/mutants-mvm-home
     steps:
       - uses: actions/checkout@v6
 
@@ -558,19 +546,38 @@ jobs:
           key: cargo-mutation-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-mutation-
 
-      - name: Fail closed if a real mvm state root is reachable
-        run: |
-          mkdir -p "$MVM_HOME"
-          if [ -e "$HOME/.mvm/keys" ]; then
-            echo "::error::refusing to mutate against a reachable keystore at $HOME/.mvm/keys" >&2
-            exit 1
-          fi
-
       - name: Install cargo-mutants and nextest
         run: cargo install --locked cargo-mutants cargo-nextest
 
       - name: Mutate the claim surface and ratchet survivors
-        run: cargo run -p xtask -- check-mutation-witnesses --run
+        # `--run` mutates the claim-enforcement surface and runs the suite
+        # against each mutant — plan verification that no longer verifies, a
+        # seccomp filter that no longer filters, the host signer. That is
+        # security code with its check removed, so it must not reach a real
+        # mvm state root: it could mint a key at the wrong path or mode (the
+        # mutation may be *in* the path/mode logic) or leave firewall rules
+        # behind.
+        #
+        # MVM_HOME alone is not enough — `default_mvm_cache_dir` deliberately
+        # reads the home directory to seed from the shared cache, which is the
+        # leak `check-test-home-isolation` exists to catch. So both roots move.
+        #
+        # CARGO_HOME/RUSTUP_HOME are pinned to the real home *before* the
+        # redirect: `~` follows HOME, so without this the toolchain the earlier
+        # steps installed would vanish mid-job and the cache step above would
+        # be keyed on a path that only exists here.
+        run: |
+          set -euo pipefail
+          export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+          export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
+          export MVM_HOME="$RUNNER_TEMP/mutants-mvm-home"
+          export HOME="$MVM_HOME"
+          mkdir -p "$HOME"
+          if [ -e "$HOME/.mvm/keys" ]; then
+            echo "::error::refusing to mutate against a reachable keystore at $HOME/.mvm/keys" >&2
+            exit 1
+          fi
+          cargo run -p xtask -- check-mutation-witnesses --run
 
   # ── Lane 5: Hash-verify regression ─────────────────────────────────
   # ADR-001 §W5.1 — the unit tests that exercise the


### PR DESCRIPTION
Closes #1946. Fixes the fuzz half of #1951.

## The fuzz lane has been dead since the crate consolidation

MVM-SEC-05's only witness is `security.yml`'s `fuzz` job. It has failed on **every scheduled run since at least 2026-07-25**. Seven of its fourteen `working-directory` values name crates the v1 consolidation renamed:

| Stale | Actual |
| --- | --- |
| `crates/mvm-guest` (×3) | `crates/mvm-agentd` |
| `crates/mvm-oci` | `crates/mvm-fs/fuzz-oci` |
| `crates/mvm-vm-host` (×2) | `crates/mvm-hostd/fuzz-vmhost` |
| `crates/mvm-ext4` | `crates/mvm-fs/fuzz-ext4` |

**Every target still exists.** The consolidation moved the harnesses and updated `workspace.exclude` to the new paths — it just never updated the CI steps. So the lane died on a missing directory rather than on anything it was meant to detect. No fuzz coverage was lost; only its invocation broke.

Where the fuzz directory is no longer named `fuzz`, the invocation gains `--fuzz-dir`, matching the pattern the already-working `mvm-runtime/fuzz-backend` steps use.

### Verified rather than assumed

All fourteen `(working-directory, --fuzz-dir, target)` triples now resolve to a harness on disk, checked programmatically. And one is confirmed to actually build:

```
$ cd crates/mvm-fs && cargo fuzz build --fuzz-dir fuzz-oci unpack_layer
   Compiling mvm-fs-oci-fuzz v0.0.0 (.../crates/mvm-fs/fuzz-oci)
    Finished `release` profile [optimized + debuginfo] target(s) in 29.50s
```

That is the target ADR-001 claim 14 names, so its documented coverage is real again rather than merely promised.

## The mutation lane ran against the real home directory

`check-mutation-witnesses --run` mutates the claim-enforcement surface and runs the suite against each mutant — plan verification that no longer verifies, a seccomp filter that no longer filters, the host signer. It did that with the runner's default `$HOME`.

Both roots are now redirected, with a pre-flight that **fails closed** if a keystore is reachable. `MVM_HOME` alone would not do: `default_mvm_cache_dir` deliberately reads the home directory to seed from the shared cache, which is the leak `check-test-home-isolation` exists to catch.

The same exposure via `just mutation-witnesses` on a developer machine is left to #1946's follow-up — the durable fix there is for `--run` itself to refuse to start, not for each caller to remember.

## Why neither was noticed

`check-claim-catalog` resolves a `ci:` witness by asserting the literal string appears somewhere in `.github/workflows/*`. `ci:fuzz` matched the job key for the whole time the job could not run. Combine that with `security.yml` running only on tags, nightly cron, and manual dispatch — invisible on PRs — and a claim keeps a green ledger entry while its only evidence is red.

Resolving a `ci:` witness to a job *key* rather than any string match would have caught this on the PR that renamed the crates. Left as a follow-up on #1951 rather than folded in here.

## Note

The frozen per-crate fuzz `Cargo.lock` files are untouched. The local `cargo fuzz build` above re-resolved one (I used plain `nightly` rather than the pinned `nightly-2026-06-11`); that was reverted before commit.

Found while auditing whether each claim's witness can actually fail (`specs/plans/274-witness-rigor.md`, WS3).
