### PR TITLE
fix(guest): give PID 1 the host-signer anchor it refuses to serve without

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
@@ -54,6 +54,7 @@ pub(crate) fn early_setup() {
         } else if let Err(e) = guest_mount::mount_early_filesystems() {
             fatal(&format!("early filesystem mount failed: {e}"));
         }
+        provision_host_signer_anchor();
         install_sigchld_handler();
     }
 
@@ -61,6 +62,29 @@ pub(crate) fn early_setup() {
     {
         // Should never be PID 1 on non-Linux, but keep the compile path
         // quiet.
+    }
+}
+
+/// Copy the host-signer anchor off the kernel cmdline into the filesystem the
+/// control listener reads it from.
+///
+/// A block-backed guest gets this from `mvm-oci-init`, which copies the key off
+/// the config drive. The universal initramfs has no config drive and no second
+/// init — the agent itself is `/init` — so without this the anchor never lands,
+/// every control connection is refused for want of a pinned key, and the run
+/// dies at `ActivateEnvironment`, its very first RPC.
+///
+/// Absent or malformed tokens are logged, not fatal: the guest simply stays
+/// anchorless and keeps refusing control connections, which is the same
+/// fail-closed posture as before.
+#[cfg(target_os = "linux")]
+fn provision_host_signer_anchor() {
+    match mvm_agentd::vsock::provision_host_signer_anchor_from_cmdline() {
+        Ok(true) => eprintln!("mvm-guest-agent: host-signer anchor provisioned from cmdline"),
+        Ok(false) => {
+            eprintln!("mvm-guest-agent: no host-signer anchor on cmdline; control stays closed")
+        }
+        Err(e) => eprintln!("mvm-guest-agent: host-signer anchor not provisioned: {e}"),
     }
 }
 

--- a/crates/mvm-agentd/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-oci-init.rs
@@ -585,31 +585,9 @@ mod linux {
             assert!(!loopback_flags_indicate_up("garbage"));
         }
 
-        #[test]
-        fn write_host_signer_pub_writes_bytes_mode_0644() {
-            use std::os::unix::fs::PermissionsExt;
-            let dir = tempfile::tempdir().unwrap();
-            let pubkey = [0xABu8; 32];
-            let hex: String = pubkey.iter().map(|b| format!("{b:02x}")).collect();
-
-            write_host_signer_pub(dir.path(), &hex).unwrap();
-
-            let path = dir.path().join("run/mvm/host-signer.pub");
-            let written = fs::read(&path).unwrap();
-            assert_eq!(written, pubkey.to_vec(), "raw key bytes must round-trip");
-            let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-            assert_eq!(mode, 0o644, "host-signer.pub must be mode 0644");
-        }
-
-        #[test]
-        fn write_host_signer_pub_rejects_malformed_hex() {
-            let dir = tempfile::tempdir().unwrap();
-            assert!(write_host_signer_pub(dir.path(), "zz").is_err());
-            assert!(
-                !dir.path().join("run/mvm/host-signer.pub").exists(),
-                "no file written on malformed input"
-            );
-        }
+        // The anchor writer moved to `mvm_agentd::vsock::write_host_signer_anchor`
+        // so both inits share one implementation; its byte layout, 0644 mode and
+        // malformed-token refusal are covered there rather than duplicated here.
 
         #[test]
         fn resolve_guest_agent_for_dev_required_overlay_prefers_interactive_overlay() {

--- a/crates/mvm-agentd/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-oci-init.rs
@@ -199,28 +199,13 @@ mod linux {
     /// guest has no config drive, so the launcher rides the 32-byte public key on
     /// `mvm.host_signer_pub=<hex>` and the agent verifies the grant against it.
     fn provision_host_signer_pub() {
-        let Some(hex) = cmdline_value("mvm.host_signer_pub") else {
+        let cmdline = cmdline();
+        let Some(hex) = mvm_agentd::vsock::host_signer_pub_token(&cmdline) else {
             return;
         };
-        if let Err(e) = write_host_signer_pub(Path::new("/"), &hex) {
-            eprintln!("mvm-oci-init: {e}");
+        if let Err(e) = mvm_agentd::vsock::write_host_signer_anchor(Path::new("/"), hex) {
+            eprintln!("mvm-oci-init: host-signer anchor not provisioned: {e}");
         }
-    }
-
-    /// Decode the hex host-signer pubkey token and write the raw key bytes to
-    /// `<root>/run/mvm/host-signer.pub` with mode 0644. `root` is a seam for
-    /// tests; production passes `/`.
-    fn write_host_signer_pub(root: &Path, hex: &str) -> Result<(), String> {
-        use std::os::unix::fs::PermissionsExt;
-        let bytes =
-            hex_decode(hex).map_err(|()| "malformed host-signer pubkey token".to_string())?;
-        let dir = root.join("run/mvm");
-        fs::create_dir_all(&dir).map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
-        let path = dir.join("host-signer.pub");
-        fs::write(&path, &bytes).map_err(|e| format!("write {}: {e}", path.display()))?;
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o644))
-            .map_err(|e| format!("chmod {}: {e}", path.display()))?;
-        Ok(())
     }
 
     fn mount_fs(

--- a/crates/mvm-agentd/src/vsock/mod.rs
+++ b/crates/mvm-agentd/src/vsock/mod.rs
@@ -63,10 +63,11 @@ pub use rpc::{
     send_run_code_streaming, send_run_detached, send_run_entrypoint,
 };
 pub use verb_grant::{
-    HOST_SIGNER_PUBKEY_PATH, TrustDecision, VERB_TRUST_POLICY_PATH, enforce_verb_grant,
-    is_verb_trust_baseline, launch_requires_grant, load_host_signer_verifying_key,
-    load_pinned_verb_grant, load_verb_trust_policy, parse_require_grant_cmdline, pin_verb_grant,
-    re_pin_verb_grant, trust_decision, verifying_key_from_hex,
+    HOST_SIGNER_PUB_CMDLINE_KEY, HOST_SIGNER_PUBKEY_PATH, TrustDecision, VERB_TRUST_POLICY_PATH,
+    enforce_verb_grant, host_signer_pub_token, is_verb_trust_baseline, launch_requires_grant,
+    load_host_signer_verifying_key, load_pinned_verb_grant, load_verb_trust_policy,
+    parse_require_grant_cmdline, pin_verb_grant, provision_host_signer_anchor_from_cmdline,
+    re_pin_verb_grant, trust_decision, verifying_key_from_hex, write_host_signer_anchor,
 };
 
 /// Default vsock guest CID (Firecracker convention).

--- a/crates/mvm-agentd/src/vsock/verb_grant.rs
+++ b/crates/mvm-agentd/src/vsock/verb_grant.rs
@@ -85,6 +85,60 @@ pub fn load_host_signer_verifying_key(
     verifying_key_from_hex(raw.trim_ascii()).map(Some)
 }
 
+/// Kernel-cmdline token carrying the host-signer's Ed25519 public key as hex.
+///
+/// A vsock-only guest has no config drive to copy the key off, so the launcher
+/// rides it here instead.
+pub const HOST_SIGNER_PUB_CMDLINE_KEY: &str = "mvm.host_signer_pub";
+
+/// The `mvm.host_signer_pub=<hex>` value in a kernel cmdline, if present.
+pub fn host_signer_pub_token(cmdline: &str) -> Option<&str> {
+    let prefix = format!("{HOST_SIGNER_PUB_CMDLINE_KEY}=");
+    cmdline
+        .split_whitespace()
+        .find_map(|part| part.strip_prefix(prefix.as_str()))
+}
+
+/// Write the host-signer anchor to [`HOST_SIGNER_PUBKEY_PATH`] under `root`.
+///
+/// The token is decoded and validated as an Ed25519 key *before* anything is
+/// written, so a file that exists is always a usable anchor and a malformed
+/// token leaves the guest anchorless — refusing control connections — rather
+/// than holding a key that fails to parse later.
+///
+/// `root` is a test seam; production passes `/`.
+pub fn write_host_signer_anchor(root: &std::path::Path, hex: &str) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let key = verifying_key_from_hex(hex)?;
+    // Derive from the constant so the writer and the reader can never drift.
+    let path = root.join(HOST_SIGNER_PUBKEY_PATH.trim_start_matches('/'));
+    let dir = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("host-signer anchor path has no parent directory"))?;
+    std::fs::create_dir_all(dir).map_err(|e| anyhow::anyhow!("mkdir {}: {e}", dir.display()))?;
+    std::fs::write(&path, key.to_bytes())
+        .map_err(|e| anyhow::anyhow!("write {}: {e}", path.display()))?;
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+        .map_err(|e| anyhow::anyhow!("chmod {}: {e}", path.display()))?;
+    Ok(())
+}
+
+/// Provision the anchor from `/proc/cmdline` into the live root.
+///
+/// Returns `Ok(false)` when the cmdline carries no token — a launch that ships
+/// no anchor is a valid (if unreachable) boot, not an error. Requires `/proc`
+/// to be mounted, so PID 1 must call this after its early mounts.
+pub fn provision_host_signer_anchor_from_cmdline() -> anyhow::Result<bool> {
+    let cmdline = std::fs::read_to_string("/proc/cmdline")
+        .map_err(|e| anyhow::anyhow!("read /proc/cmdline: {e}"))?;
+    let Some(hex) = host_signer_pub_token(&cmdline) else {
+        return Ok(false);
+    };
+    write_host_signer_anchor(std::path::Path::new("/"), hex)?;
+    Ok(true)
+}
+
 /// Decode a single ASCII hex nibble ('0'-'9', 'a'-'f') to its value.
 /// Returns `None` for any other character (including uppercase).
 fn hex_nibble(b: u8) -> Option<u8> {
@@ -704,9 +758,9 @@ mod tests {
         );
     }
 
-    /// The shipped anchor form: `mvm-oci-init` writes `host-signer.pub` as the
-    /// RAW 32 pubkey bytes, not hex. Exercise that byte layout end-to-end
-    /// through the reader into `load_pinned_verb_grant`.
+    /// The shipped anchor form: [`write_host_signer_anchor`] writes
+    /// `host-signer.pub` as the RAW 32 pubkey bytes, not hex. Exercise that byte
+    /// layout end-to-end through the reader into `load_pinned_verb_grant`.
     #[test]
     fn load_pinned_verb_grant_accepts_raw_32_byte_pubkey() {
         let dir = tempfile::tempdir().unwrap();
@@ -723,6 +777,117 @@ mod tests {
             "raw 32-byte host-signer pubkey must pin the grant (not the anchor-absent None path)"
         );
         assert_eq!(result.unwrap().session_id, "sess-raw");
+    }
+
+    /// A real Firecracker cmdline carries the anchor among a dozen other
+    /// tokens, and the value must be lifted out of exactly the right one.
+    #[test]
+    fn host_signer_pub_token_is_lifted_out_of_a_full_cmdline() {
+        let hex = "c5".repeat(32);
+        let cmdline = format!(
+            "console=ttyS0 reboot=k panic=1 root=/dev/vda rw \
+             {HOST_SIGNER_PUB_CMDLINE_KEY}={hex} mvm.require_grant=1 init=/init"
+        );
+        assert_eq!(host_signer_pub_token(&cmdline), Some(hex.as_str()));
+        assert_eq!(
+            host_signer_pub_token("console=ttyS0 root=/dev/vda rw"),
+            None,
+            "a launch that ships no anchor must not be mistaken for one that does"
+        );
+        // A token that merely *contains* the key name is not the key.
+        assert_eq!(
+            host_signer_pub_token(&format!("not.{HOST_SIGNER_PUB_CMDLINE_KEY}=deadbeef")),
+            None
+        );
+    }
+
+    /// The writer must land the anchor at exactly the path the reader opens,
+    /// in the raw byte form the reader accepts.
+    #[test]
+    fn write_host_signer_anchor_round_trips_through_the_reader() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let signer = ed25519_dalek::SigningKey::from_bytes(&[41u8; 32]);
+        let hex: String = signer
+            .verifying_key()
+            .to_bytes()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+
+        write_host_signer_anchor(dir.path(), &hex).unwrap();
+
+        let path = dir
+            .path()
+            .join(HOST_SIGNER_PUBKEY_PATH.trim_start_matches('/'));
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            signer.verifying_key().to_bytes(),
+            "the anchor is written as raw key bytes"
+        );
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+        assert_eq!(
+            load_host_signer_verifying_key(&path).unwrap(),
+            Some(signer.verifying_key()),
+            "the reader must accept exactly what the writer produced"
+        );
+    }
+
+    /// Fail closed: a malformed token leaves no file behind, so the guest stays
+    /// anchorless and keeps refusing control rather than holding a key that
+    /// cannot be parsed at the point it is needed.
+    #[test]
+    fn write_host_signer_anchor_refuses_a_malformed_token_and_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir
+            .path()
+            .join(HOST_SIGNER_PUBKEY_PATH.trim_start_matches('/'));
+
+        for bad in ["", "zz", &"ab".repeat(31), &"ab".repeat(33)] {
+            assert!(
+                write_host_signer_anchor(dir.path(), bad).is_err(),
+                "{bad:?} must be refused"
+            );
+            assert!(
+                !path.exists(),
+                "a refused token must never leave an anchor behind ({bad:?})"
+            );
+        }
+    }
+
+    /// The universal initramfs makes the agent itself PID 1, so no
+    /// `mvm-oci-init` runs to copy the anchor off a config drive. If PID-1
+    /// early setup does not provision it, `host_signer_key()` stays `None`,
+    /// every control connection is refused, and the run dies at
+    /// `ActivateEnvironment` — its first RPC. That shipped.
+    ///
+    /// Asserted against the source because the real path needs to be PID 1
+    /// inside a guest, which no unit test can be.
+    #[test]
+    fn pid1_early_setup_provisions_the_host_signer_anchor() {
+        let src = include_str!("../bin/mvm-guest-agent/init.rs");
+        let body = src
+            .split("pub(crate) fn early_setup")
+            .nth(1)
+            .expect("early_setup must exist")
+            .split("\nfn ")
+            .next()
+            .expect("function body is delimited by the next item");
+
+        let mounted = body
+            .find("mount_early_filesystems")
+            .expect("early setup must mount /proc");
+        let provisioned = body
+            .find("provision_host_signer_anchor")
+            .expect("PID-1 early setup must provision the host-signer anchor from the cmdline");
+        assert!(
+            mounted < provisioned,
+            "the anchor is read off /proc/cmdline, so /proc must be mounted first"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1957.

## What happens today

With #1948 merged, a Firecracker workload boots — PID 1 survives its early mounts and reaches `control plane ready (0ms)`. It then dies at its first RPC:

```
Error: backend error: activate workload after boot: send ActivateEnvironment to guest:
       Failed to read frame length: failed to fill whole buffer
```

while the guest repeats:

```
mvm-guest-agent: rejecting control connection without a pinned host key
```

## Why

The host ships its Ed25519 public key on the kernel cmdline as `mvm.host_signer_pub=<hex>` (`microvm/egress_bridge.rs`) — a vsock-only guest has no config drive to copy it off. Confirmed present on the live boot:

```
mvm.host_signer_pub=c55282c1520fa40b5e3d1868e36c711168ed3ecc4c41bab0cf85cc5af9a3f937
```

The agent reads the anchor from a **file**, `HOST_SIGNER_PUBKEY_PATH = /run/mvm/host-signer.pub`. The only code that turned the token into that file was `provision_host_signer_pub()` in `mvm-oci-init`.

Under the universal initramfs there is no `mvm-oci-init` — the initramfs carries exactly one executable and it is `mvm-guest-agent`, installed as `/init`. That binary parsed no cmdline tokens at all. So the token arrived on every boot and nothing wrote it down, `host_signer_key()` stayed `None`, and every control connection was refused.

Both halves were individually correct; nothing carried the token across the seam. `verb_grant.rs` even documented the now-false assumption: *"the shipped anchor form: `mvm-oci-init` writes `host-signer.pub`"*.

## The change

- PID-1 `early_setup()` provisions the anchor itself, **after** the early mounts — the token comes from `/proc/cmdline`, which only exists once #1948's mounts have run.
- The parse/validate/write logic moves into `vsock::verb_grant`, beside `HOST_SIGNER_PUBKEY_PATH` and its reader, and the write path derives from that constant so writer and reader cannot drift.
- `mvm-oci-init` now calls the shared helper instead of carrying a second copy (it already links the agent library).
- The key is validated as Ed25519 **before** anything is written, so an anchor file that exists is always usable. A malformed or absent token leaves the guest anchorless and still refusing control — the same fail-closed posture as before, which is why this does not widen the trust surface.

## Verification

Live on a Linux/KVM host, `mvmctl` at `main`, fully unshared `MVM_HOME`, freshly nix-built initramfs: the guest reaches `control plane ready` and no longer refuses the control connection.

Tests:
- `host_signer_pub_token_is_lifted_out_of_a_full_cmdline` — parses against a realistic boot cmdline; rejects a token that merely *contains* the key name.
- `write_host_signer_anchor_round_trips_through_the_reader` — raw-32-byte layout, mode 0644, read back through `load_host_signer_verifying_key`.
- `write_host_signer_anchor_refuses_a_malformed_token_and_writes_nothing` — fail-closed, no partial anchor.
- `pid1_early_setup_provisions_the_host_signer_anchor` — source-level guard that early setup provisions after mounting `/proc`. Verified to fail when the call is removed. Asserted against the source because the real path requires being PID 1 inside a guest.

Gates run locally: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo nextest run --workspace` (8315 passed), `cargo test --workspace --doc`, `cargo test --no-run --workspace --features test-support`, and the xtask policy gates (`check-trust-gradient`, `check-vsock-only-egress`, `check-require-grant-token-allowlist`, `check-guest-binary-lists`, `check-claim-catalog`, `check-conformance`, and the rest of the registry).