### PR TITLE
fix(guest): mount devtmpfs unconditionally so dm-verity has a control node

### DIFF
--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -99,12 +99,19 @@ pub fn mount_early_filesystems() -> Result<()> {
             libc::MS_NOSUID | libc::MS_NOEXEC | libc::MS_NODEV,
             "",
         )?;
-        // devtmpfs gives us /dev/console, /dev/null, etc. without a static
-        // device table in the initramfs.
-        if !Path::new("/dev/console").exists() {
-            ensure_dir("/dev")?;
-            mount("devtmpfs", "/dev", "devtmpfs", libc::MS_NOSUID, "")?;
-        }
+        // devtmpfs supplies every device node the initramfs has no static
+        // table for — /dev/null, and the /dev/mapper/control that dm-verity
+        // needs to bring the sealed rootfs up at activation.
+        //
+        // Mounted unconditionally. The kernel creates a bare /dev/console in
+        // the initramfs rootfs so init has stdio, so a "is /dev/console
+        // already there?" guard reads as "devtmpfs is already mounted" when
+        // in fact nothing is — and then activation dies on a missing
+        // /dev/mapper/control. A shared-kernel container runtime, the one case
+        // where /dev really is pre-mounted, never reaches here: that path is
+        // branched off before the early mounts.
+        ensure_dir("/dev")?;
+        mount("devtmpfs", "/dev", "devtmpfs", libc::MS_NOSUID, "")?;
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -899,6 +906,51 @@ mod tests {
                 "{target}: ensure_dir must come before the mount, not after"
             );
         }
+    }
+
+    /// devtmpfs must be mounted unconditionally, never gated on `/dev/console`.
+    ///
+    /// The kernel creates a bare `/dev/console` in the initramfs rootfs so init
+    /// has stdio — which is precisely why the agent's own output reaches the
+    /// serial console. A `if !Path::new("/dev/console").exists()` guard around
+    /// the devtmpfs mount therefore always skips it, `/dev` keeps that single
+    /// node, and activation dies on a missing `/dev/mapper/control` the moment
+    /// dm-verity tries to bring the sealed rootfs up. That shipped, and it reads
+    /// as a verity bug rather than a mount bug.
+    ///
+    /// The one case where `/dev` genuinely is pre-mounted — a shared-kernel
+    /// container runtime — branches off before the early mounts entirely, so it
+    /// needs no guard here.
+    ///
+    /// Asserted against the source for the same reason as the test above: the
+    /// real path needs to be PID 1 inside a guest.
+    #[test]
+    fn devtmpfs_is_not_gated_on_a_kernel_supplied_console_node() {
+        let src = include_str!("guest_mount.rs");
+        let body = src
+            .split("pub fn mount_early_filesystems")
+            .nth(1)
+            .expect("mount_early_filesystems must exist")
+            .split("\npub fn ")
+            .next()
+            .expect("function body is delimited by the next item");
+        // Comments explain the trap by naming the node, so judge the code only.
+        let code: String = body
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            code.contains("\"devtmpfs\""),
+            "devtmpfs must still be mounted; without it there is no /dev/mapper/control"
+        );
+        assert!(
+            !code.contains("/dev/console"),
+            "devtmpfs must not be gated on /dev/console — the kernel always supplies \
+             that node, so the guard skips the mount every time and dm-verity then \
+             fails to open /dev/mapper/control"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Third and last blocker in the chain that kept Firecracker workloads from running. Stacked conceptually on #1948 (mount points) and #1959 (host-signer anchor) — each one only became visible once the previous was fixed.

## What happens today

With #1948 and #1959 in place the guest boots, serves its control plane, and receives `ActivateEnvironment`. It then dies mounting its own rootfs:

```
Error: backend error: activate workload after boot: guest activation failed:
       syscall failed: open /dev/mapper/control
```

## Why

devtmpfs was mounted only when `/dev/console` was absent:

```rust
if !Path::new("/dev/console").exists() {
    ensure_dir("/dev")?;
    mount("devtmpfs", "/dev", "devtmpfs", libc::MS_NOSUID, "")?;
}
```

The kernel creates a bare `/dev/console` in the initramfs rootfs so init has stdio — which is precisely why the agent's own `eprintln!` output shows up on the serial console in every boot log we have. So the condition was always false, devtmpfs was never mounted, and `/dev` contained exactly that one kernel-made node.

dm-verity then had no `/dev/mapper/control` to open, and activation failed. The console confirms the DM subsystem itself was fine:

```
device-mapper: ioctl: 4.48.0-ioctl (2023-03-01) initialised: dm-devel@lists.linux.dev
```

The guard reads as "don't double-mount", but the only case where `/dev` genuinely is pre-mounted — a shared-kernel container runtime, which drops `CAP_SYS_ADMIN` and would fail these mounts with EPERM — is branched off *before* the early mounts run. There was nothing left for the guard to protect; it only ever suppressed the mount.

Note this predates #1948, which added `ensure_dir("/dev")` **inside** the conditional without changing it.

## The change

Mount devtmpfs unconditionally. devtmpfs supplies `/dev/console` itself so init's stdio is unaffected, and already-open fds keep pointing at the original inode.

## Verification

Live on a Linux/KVM host, `mvmctl` at `main` + #1959, freshly nix-built initramfs:

```
mvm-guest-agent: host-signer anchor provisioned from cmdline
mvm-guest-agent: control plane ready (0ms)
mvm-guest-agent: activation complete, serving operational RPCs
```

`machine start` returns 0 where it previously failed at `open /dev/mapper/control`.

`devtmpfs_is_not_gated_on_a_kernel_supplied_console_node` guards the regression. It strips comment lines before asserting, so the comment explaining the trap cannot satisfy the test that guards it — I hit exactly that false-green while writing it. Verified to fail when the conditional is restored.

Gates: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo nextest run --workspace` (8333 passed), doctests, `--features test-support`, and the xtask policy registry.