### PR TITLE
test(bundle): make claim 9's witnesses discriminate on path safety and signature bytes

### DIFF
--- a/crates/mvm-core/src/plan/bundle.rs
+++ b/crates/mvm-core/src/plan/bundle.rs
@@ -1369,6 +1369,95 @@ mod tests {
         }
     }
 
+    /// The signature blob read back is the exact one written.
+    ///
+    /// Nothing asserted the *contents* of what this returns, so
+    /// `read_signature_from_archive -> Ok(vec![])` survived mutation:
+    /// the install path would have copied an empty signature into the
+    /// extracted directory and no test noticed. Matching the filename is
+    /// also load-bearing — inverting that comparison picks up the
+    /// manifest instead.
+    #[test]
+    fn read_signature_from_archive_returns_the_signature_verbatim() {
+        let sk = fresh_key();
+        let key_id = key_id_from_pubkey(&sk.verifying_key());
+        let manifest = make_manifest(key_id, vec![]);
+        let manifest_bytes = canonical_manifest_bytes(&manifest).unwrap();
+        let sig = sk.sign(&manifest_bytes).to_bytes().to_vec();
+
+        let mut buf = Cursor::new(Vec::<u8>::new());
+        {
+            let mut tar = tar::Builder::new(&mut buf);
+            append_bytes(&mut tar, MANIFEST_FILENAME, &manifest_bytes).unwrap();
+            append_bytes(&mut tar, SIGNATURE_FILENAME, &sig).unwrap();
+            tar.finish().unwrap();
+        }
+
+        let got = read_signature_from_archive(&buf.into_inner()).expect("signature present");
+        assert_eq!(got, sig, "must return the signature bytes verbatim");
+        assert_eq!(got.len(), 64, "an ed25519 signature is 64 bytes");
+        assert_ne!(got, manifest_bytes, "must not return the manifest");
+    }
+
+    /// A signature-less archive is an error, not an empty signature.
+    #[test]
+    fn read_signature_from_archive_errors_when_absent() {
+        let sk = fresh_key();
+        let key_id = key_id_from_pubkey(&sk.verifying_key());
+        let manifest_bytes = canonical_manifest_bytes(&make_manifest(key_id, vec![])).unwrap();
+
+        let mut buf = Cursor::new(Vec::<u8>::new());
+        {
+            let mut tar = tar::Builder::new(&mut buf);
+            append_bytes(&mut tar, MANIFEST_FILENAME, &manifest_bytes).unwrap();
+            tar.finish().unwrap();
+        }
+        assert!(read_signature_from_archive(&buf.into_inner()).is_err());
+    }
+
+    /// Each unsafe shape rejected on its own.
+    ///
+    /// `unsafe_path_rejected_in_manifest` below accepts either
+    /// `UnsafePath` *or* `ArtifactMissing`, because the `../` entry never
+    /// makes it into the tar. That acceptance is wider than the property,
+    /// so deleting the guard entirely still satisfies it — mutation
+    /// testing caught `ensure_safe_path -> Ok(())` surviving. This
+    /// exercises the function directly, one clause per case, so each
+    /// disjunct in the condition is independently load-bearing.
+    #[test]
+    fn ensure_safe_path_rejects_each_unsafe_shape() {
+        for bad in [
+            "",                   // empty
+            "/etc/passwd",        // absolute
+            "a\\b",               // backslash separator
+            "../etc/passwd",      // leading traversal
+            "a/../../etc/passwd", // interior traversal
+            "./a",                // leading single-dot segment
+            "a/./b",              // interior single-dot segment
+        ] {
+            assert!(
+                matches!(
+                    ensure_safe_path(bad),
+                    Err(BundleVerifyError::UnsafePath { .. })
+                ),
+                "expected {bad:?} to be rejected as an unsafe archive path"
+            );
+        }
+    }
+
+    /// The positive half: an ordinary relative path is admitted. Without
+    /// this, a guard that rejected everything would also pass the case
+    /// above.
+    #[test]
+    fn ensure_safe_path_admits_ordinary_relative_paths() {
+        for good in ["kernel.bin", "artifacts/kernel.bin", "a/b/c.img"] {
+            assert!(
+                ensure_safe_path(good).is_ok(),
+                "expected {good:?} to be admitted"
+            );
+        }
+    }
+
     #[test]
     fn unsafe_path_rejected_in_manifest() {
         // The path validator runs both at write time and at read


### PR DESCRIPTION
First real triage pass of the claim mutation surface #1934 landed — WS3 Task 9 in `specs/plans/274-witness-rigor.md`.

## How it was run

Hermetically, per #1946: both mvm roots redirected to a throwaway dir with a keystore pre-flight, and `CARGO_HOME`/`RUSTUP_HOME` resolved from the real home first so the toolchain survives the redirect. (Setting that up locally is what surfaced the job-level-`env` problem fixed in #1958.)

Seven surface files, the same per-file invocation `check-mutation-witnesses --run` uses:

| Claim | File | Mutants | Survived |
| --- | --- | --- | --- |
| 9 | `plan/bundle.rs` | 85 | **14** |
| 8 | `supervisor/audit_file.rs` | 17 | 1 |
| 12 | `protocol/broker.rs` | 19 | 4 |
| 11 | `app_deps_gate.rs` | 37 | 4 |
| 8 | `plan/synthesis.rs` | 15 | **0** |
| 10 | `policy/dns_guard.rs` | 17 | **0** |
| 10 | `microvm/snapshot.rs` | — | not measurable |

## What this fixes

**`ensure_safe_path` — the bundle archive path-traversal guard — was not witnessed.** Replacing its entire body with `Ok(())` survived, as did turning each disjunct of its condition into a conjunction.

The reason is visible in the existing test. `unsafe_path_rejected_in_manifest` accepts either `UnsafePath` **or** `ArtifactMissing`, because the `../` entry never makes it into the tar. That acceptance is wider than the property, so deleting the guard entirely still satisfies it. This is the exact failure mode the workstream was looking for: a witness that names the right thing, passes forever, and never had the power to fail.

CLAUDE.md lists "unsafe path" in claim 9's rejection ladder as exercised on every PR. It now is.

**`read_signature_from_archive` could return `Ok(vec![])` undetected.** Nothing asserted the *contents* of what it returns, so the install path would have copied an empty signature into the extracted directory. Inverting the filename comparison also survived — that picks up the manifest instead.

Each of the five mutants was planted by hand and confirmed to fail the new tests, then reverted.

## What is deliberately not fixed here

Left for `accepted_misses` with stated reasons rather than silently: the `NotFound` match guards in `FsBundleResolver::resolve` and `BundleRegistry::{remove,list}` (registry housekeeping, not enforcement), the `Display` impls and `CorrelationId::as_str` in `broker.rs`, and `warn_outcome_dev` plus the JSON key-shape heuristics in `app_deps_gate.rs`. `check_accepted_reasons` already refuses an unexplained entry, so those need a written justification when they go in.

## Two things the run established rather than refuted

**Claim 11's severity gate is sound.** I initially misread a surviving `==` mutant as the high/critical threshold. It is not — it is JSON key-shape matching (`k == "advisories"`). The actual gate, `matches!(normalized, "high" | "critical")`, **was caught**. The prod CVE refusal is discriminated; claim 11's survivors are peripheral.

**Claim 10's `snapshot.rs` could not be measured at all.** cargo-mutants reports *"cargo test failed in an unmutated tree, so no mutants were tested"* — `mvm-runtime`'s suite is red on macOS for reasons unrelated to mutation (see #1950 for a sibling case). A surface file that cannot establish a baseline is not covered, and silently reports nothing rather than failing. Worth a follow-up on #1934's tooling: an unmutated-baseline failure should be distinguishable from a clean file in the summary.

## Verification

`cargo nextest run -p mvm-core` 1445/1445 · `cargo clippy -p mvm-core --all-targets -- -D warnings` clean · `check-mutation-witnesses` surface pin still clean (26 files, 8 packages) · fmt clean.
