### PR TITLE
docs(verification): record the planted defects for the three CI-lane witnesses

### DIFF
--- a/specs/VERIFICATION.md
+++ b/specs/VERIFICATION.md
@@ -43,6 +43,48 @@ it changes no types, so nothing but an offset assertion sees it.
 | `SockaddrVm` | Revert to the pre-6.0 `svm_zero: [u8; 4]` shape | yes |
 | `DmTargetSpec` | Swap the `sector_start` and `length` `u64` fields | yes |
 
+### CI-lane witnesses
+
+Three claims are witnessed only by a CI lane — a symbol grep, a fuzz run,
+a dependency audit. Mutation testing cannot reach them: there is no Rust
+function body whose mutation exercises a workflow job. They were planted
+against by hand instead.
+
+| Claim | Witness | Planted defect | Fired |
+| --- | --- | --- | --- |
+| MVM-SEC-05 | `ci:fuzz` | Unchecked `s[..8]` slice behind a `deserialize_with` on `GuestRequest::FsRead::path` | yes — libFuzzer `deadly signal` inside a 90s budget |
+| MVM-SEC-07 | `ci:cargo-deny` | Remove `MIT` from `deny.toml`'s licence allow-list | yes — `rejected: license is not explicitly allowed` |
+| MVM-SEC-04 | `ci:prod-agent-runentry-contract` | Ungate `do_exec_streaming` so it compiles into a production build | no — see below |
+
+**MVM-SEC-05.** The lane could not have fired at all until its
+`working-directory` values were corrected — they pointed at crates the
+consolidation renamed, so it died on a missing directory rather than on
+anything it was meant to detect. With the paths fixed, a planted parser
+panic is found inside the per-run budget. The seed corpus is what makes that fast — the
+fuzzer starts from valid `GuestRequest` JSON rather than random bytes.
+
+**MVM-SEC-07.** Removing an allowed licence is a deterministic stand-in
+for a dependency arriving with a disallowed one; it exercises the same
+rejection path without depending on a particular crate's licensing. Note
+the lane also fired on a *real* defect during this work — duplicate
+`curve25519-dalek` — which is stronger evidence than any plant.
+
+**MVM-SEC-04 — the plant did not fire, and that is the correct
+behaviour.** Ungating `do_exec_streaming` leaves it with no caller in a
+production build, so it is dead-code-eliminated and no symbol appears.
+The check measures *reachability*, not source presence. An unreachable
+function is not a leak, so this is the property worth having; a faithful
+plant needs a production-reachable call site.
+
+What makes this witness trustworthy is not a hand-planted defect at all:
+`scripts/check-prod-agent-no-exec.sh` carries **its own positive
+control** — it builds a second time with `interactive` enabled and fails
+if `do_exec` is *not* detectable there. That proves the detector works,
+so the absence assertion cannot rot into a no-op against a renamed
+symbol. It also carries a canary (`handle_run_entrypoint` must be
+present) so a stripped symbol table cannot make the absence check
+vacuously true. Both pass today.
+
 ### Does device-mapper layout drift fail open?
 
 Asked because `DmIoctl`/`DmTargetSpec` build the dm-verity table, and a


### PR DESCRIPTION
Completes WS3 Task 8 in `specs/plans/274-witness-rigor.md`. Depends on #1958 for the MVM-SEC-05 result to be reproducible.

Three claims are witnessed **only** by a CI lane — a symbol grep, a fuzz run, a dependency audit. `check-mutation-witnesses` structurally cannot reach them: there is no Rust function body whose mutation exercises a workflow job, and it correctly reports them as touching no mutable file. So they were planted against by hand.

The results are not uniform, which is the interesting part.

| Claim | Witness | Planted defect | Fired |
| --- | --- | --- | --- |
| MVM-SEC-05 | `ci:fuzz` | Unchecked `s[..8]` behind a `deserialize_with` on `GuestRequest::FsRead::path` | **yes** — libFuzzer `deadly signal` inside a 90s budget |
| MVM-SEC-07 | `ci:cargo-deny` | Remove `MIT` from `deny.toml`'s allow-list | **yes** — `rejected: license is not explicitly allowed` |
| MVM-SEC-04 | `ci:prod-agent-runentry-contract` | Ungate `do_exec_streaming` into a production build | **no** — and that is correct |

## MVM-SEC-05

The lane could not have fired at all until #1958 corrected its paths — it was dying on a missing directory, not on anything it was meant to detect. With that fixed, a planted parser panic is found well inside the per-run budget. The seed corpus is what makes it fast: the fuzzer starts from valid `GuestRequest` JSON rather than random bytes.

## MVM-SEC-07

Removing an allowed licence is a deterministic stand-in for a dependency arriving with a disallowed one — same rejection path, no dependence on a particular crate's licensing or a network fetch. Worth noting the lane also fired on a **real** defect during this work (the duplicate `curve25519-dalek`, #1952), which is stronger evidence than any plant.

## MVM-SEC-04 — the negative result

Ungating `do_exec_streaming` leaves it with no caller in a production build, so it is dead-code-eliminated and no symbol appears. The check measures **reachability, not source presence**. An unreachable function is not a leak, so this is the property worth having — but it means a faithful plant needs a production-reachable call site, and I did not manufacture one.

What actually makes this witness trustworthy is not a hand-planted defect. `scripts/check-prod-agent-no-exec.sh` carries **its own positive control**: it builds a second time with `interactive` enabled and fails if `do_exec` is *not* detectable there, so the absence assertion cannot rot into a no-op against a renamed symbol. It also canaries `handle_run_entrypoint` so a stripped symbol table cannot make the absence check vacuously true. Both pass today. This is the best-constructed witness in the ledger and needed nothing from me.

## Hygiene

Every planted defect was reverted. The fuzz run re-resolved the frozen `crates/mvm-agentd/fuzz/Cargo.lock` (I used plain `nightly`, not the pinned `nightly-2026-06-11`) and dropped a libFuzzer crash artifact — both cleaned up before commit. Docs-only diff.
