### PR TITLE
fix(virtio-fs): stop a guest-chosen read size from sizing a host allocation

### DIFF
--- a/crates/mvm-runtime/fuzz-backend/Cargo.lock
+++ b/crates/mvm-runtime/fuzz-backend/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -294,15 +294,6 @@ checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -365,30 +356,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "fiat-crypto 0.2.9",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
- "fiat-crypto 0.3.0",
+ "fiat-crypto",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -475,7 +451,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
- "curve25519-dalek 5.0.0",
+ "curve25519-dalek",
  "ed25519",
  "sha2",
  "subtle",
@@ -528,12 +504,6 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "fiat-crypto"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
@@ -563,6 +533,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -675,6 +651,25 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -960,6 +955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,7 +1055,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b13baf7bdfda2e10bcb109fcb099ef40cff82374eb6b7cdcf4695bdec4e522c"
 dependencies = [
- "vmm-sys-util",
+ "vmm-sys-util 0.12.1",
 ]
 
 [[package]]
@@ -1063,7 +1067,7 @@ dependencies = [
  "bitflags 2.13.0",
  "kvm-bindings",
  "libc",
- "vmm-sys-util",
+ "vmm-sys-util 0.12.1",
 ]
 
 [[package]]
@@ -1283,6 +1287,7 @@ dependencies = [
  "ext4-view",
  "hex",
  "libc",
+ "mvm-protocol",
  "reqwest",
  "rustix",
  "rustls",
@@ -1331,7 +1336,9 @@ dependencies = [
  "ed25519-dalek",
  "ext4-view",
  "fs2",
+ "h2",
  "hex",
+ "http",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
@@ -1343,6 +1350,8 @@ dependencies = [
  "mvm-fs",
  "mvm-protocol",
  "nix",
+ "prost",
+ "prost-types",
  "rand",
  "secrecy",
  "serde",
@@ -1354,6 +1363,9 @@ dependencies = [
  "toml",
  "tracing",
  "uuid",
+ "virtio-queue",
+ "virtio-vsock",
+ "vm-memory",
  "which",
  "zeroize",
 ]
@@ -1509,7 +1521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "universal-hash",
 ]
 
@@ -1544,6 +1556,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1981,7 +2025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest",
 ]
 
@@ -2260,6 +2304,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2563,10 +2621,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "virtio-bindings"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091f1f09cfbf2a78563b562e7a949465cce1aef63b6065645188d995162f8868"
+
+[[package]]
+name = "virtio-queue"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f631bfd09362a9b17f0cfd5ca3b0a1b179d153fa276f9ce86919d560891e61d6"
+dependencies = [
+ "libc",
+ "log",
+ "virtio-bindings",
+ "vm-memory",
+ "vmm-sys-util 0.15.0",
+]
+
+[[package]]
+name = "virtio-vsock"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79123315dc0bad0a2923891c0cdf76269cc64f553548e7b090c2676776ea6baf"
+dependencies = [
+ "virtio-bindings",
+ "virtio-queue",
+ "vm-memory",
+]
+
+[[package]]
+name = "vm-memory"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b55e753c7725603745cb32b2287ef7ef3da05c03c7702cda3fa8abe25ae0465"
+dependencies = [
+ "libc",
+ "thiserror 2.0.18",
+ "winapi",
+]
+
+[[package]]
 name = "vmm-sys-util"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1435039746e20da4f8d507a72ee1b916f7b4b05af7a91c093d2c6561934ede"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -2878,13 +2987,12 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
- "curve25519-dalek 4.1.3",
- "rand_core 0.6.4",
- "serde",
+ "curve25519-dalek",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 

--- a/crates/mvm-runtime/src/vmm/virtio_fs.rs
+++ b/crates/mvm-runtime/src/vmm/virtio_fs.rs
@@ -27,6 +27,17 @@ const FUSE_KERNEL_VERSION: u32 = 7;
 // init-struct growth, keeping `fuse_init_out` at its classic 64-byte size.
 const FUSE_KERNEL_MINOR_VERSION: u32 = 31;
 
+/// Largest buffer a single request may make this server allocate.
+///
+/// `fuse_read_in.size` is a guest-controlled `u32`, so using it directly as an
+/// allocation length hands an untrusted guest a ~4 GiB `malloc` in the host
+/// VMM for the cost of one request — a denial of service that needs no
+/// privilege and touches no file. FUSE allows a short read reply and the
+/// kernel reissues for the remainder, so a cap costs an extra round trip and
+/// nothing else. This is also the `max_write` advertised at INIT: one bound
+/// for both directions means they cannot drift apart.
+const MAX_IO_LEN: usize = 1 << 20;
+
 // Opcodes we handle (others → ENOSYS/EROFS).
 const FUSE_LOOKUP: u32 = 1;
 const FUSE_FORGET: u32 = 2;
@@ -223,7 +234,7 @@ impl FuseServer {
         put_u32(&mut b, 0); // flags (negotiate nothing extra)
         b.extend_from_slice(&0u16.to_le_bytes()); // max_background
         b.extend_from_slice(&0u16.to_le_bytes()); // congestion_threshold
-        put_u32(&mut b, 1 << 20); // max_write (1 MiB)
+        put_u32(&mut b, MAX_IO_LEN as u32); // max_write
         put_u32(&mut b, 1); // time_gran (1 ns)
         b.extend_from_slice(&0u16.to_le_bytes()); // max_pages
         b.extend_from_slice(&0u16.to_le_bytes()); // map_alignment
@@ -421,7 +432,10 @@ fn read_range(path: &Path, offset: u64, size: usize) -> Result<Vec<u8>, i32> {
         .open(path)
         .map_err(|_| ENOENT)?;
     f.seek(SeekFrom::Start(offset)).map_err(|_| ENOENT)?;
-    let mut buf = vec![0u8; size];
+    // `size` reaches here straight off the wire, so it is clamped before it
+    // becomes an allocation length. A guest asking for more than the
+    // advertised maximum gets a short reply, which the protocol permits.
+    let mut buf = vec![0u8; size.min(MAX_IO_LEN)];
     let n = f.read(&mut buf).map_err(|_| ENOENT)?;
     buf.truncate(n);
     Ok(buf)
@@ -712,5 +726,61 @@ mod tests {
             !data.windows(4).any(|w| w == b"SECR"),
             "host file bytes must never leak"
         );
+    }
+
+    /// A guest-chosen `fuse_read_in.size` must not become the allocation
+    /// length. The fuzz harness found `size = 0xD6FF08FF` driving a single
+    /// 3.6 GB `malloc` in the host VMM — one request, from an untrusted
+    /// guest, before a byte of the file is touched.
+    #[test]
+    fn read_allocation_is_bounded_regardless_of_requested_size() {
+        let d = tree();
+        let path = d.path().join("hello");
+        // Far above the cap but cheap to allocate, so this test fails on the
+        // unbounded version by observing the capacity rather than by trying
+        // to reserve 4 GiB.
+        let huge = 64 * 1024 * 1024;
+        let got = read_range(&path, 0, huge).unwrap();
+        assert!(
+            got.capacity() <= MAX_IO_LEN,
+            "read allocated {} bytes for a {}-byte file; cap is {MAX_IO_LEN}",
+            got.capacity(),
+            got.len()
+        );
+        // Clamping must not corrupt the answer for a file under the cap.
+        assert_eq!(got, b"hi from virtiofs\n");
+    }
+
+    /// The clamp is on the allocation, not on correctness: a read asking for
+    /// more than the cap still returns every byte the file has.
+    #[test]
+    fn oversized_read_request_still_returns_the_whole_small_file() {
+        let d = tree();
+        let mut fs = FuseServer::new(d.path());
+        let (_, ent) = parse_reply(&fs.dispatch(&request(FUSE_LOOKUP, 1, ROOT_INO, b"hello\0")));
+        let ino = rd_u64(&ent, 0);
+
+        let mut read_in = Vec::new();
+        put_u64(&mut read_in, 0); // fh
+        put_u64(&mut read_in, 0); // offset
+        put_u32(&mut read_in, u32::MAX); // size — the hostile field
+        put_u32(&mut read_in, 0); // read_flags
+        put_u64(&mut read_in, 0); // lock_owner
+        put_u32(&mut read_in, 0); // flags
+        put_u32(&mut read_in, 0); // padding
+        let (err, data) = parse_reply(&fs.dispatch(&request(FUSE_READ, 4, ino, &read_in)));
+        assert_eq!(err, 0);
+        assert_eq!(data, b"hi from virtiofs\n");
+    }
+
+    /// A read at the cap boundary allocates the cap and no more.
+    #[test]
+    fn read_at_the_cap_boundary_allocates_exactly_the_cap() {
+        let d = tree();
+        let path = d.path().join("hello");
+        for requested in [MAX_IO_LEN - 1, MAX_IO_LEN, MAX_IO_LEN + 1] {
+            let got = read_range(&path, 0, requested).unwrap();
+            assert!(got.capacity() <= MAX_IO_LEN, "requested {requested}");
+        }
     }
 }


### PR DESCRIPTION
## What

`fuse_read_in.size` is a guest-controlled `u32` that reached `vec![0u8; size]` in `read_range` unmodified. One `FUSE_READ` request could ask the host VMM for close to 4 GiB, and the allocation happened *before* the file was opened for reading — so neither the file's length nor its existence bounded it. An untrusted guest gets a host denial of service for the cost of one request.

## How it was found

The `fuzz_dispatch` harness found it in **1.7 seconds**, on the first nightly where that lane executed anything. The fuzz lane had pointed at `crates/mvm-guest` — deleted by the crate consolidation — since 2026-07-20, so it failed to *start* and ran zero targets for ten nights (restored in #1956).

Decoding the reproducer: opcode `0x0f` = `FUSE_READ`, and the trailing bytes `ff 08 ff d6` little-endian are `0xD6FF08FF` = 3607038207 — exactly the reported `malloc(3607038207)`.

## Fix

Clamp the allocation to the maximum this server already advertises. FUSE permits a short read reply and the kernel reissues for the remainder, so a capped read returns the same bytes in at most one extra round trip.

The cap is the value `op_init` publishes as `max_write`, now a named `MAX_IO_LEN` used by both, so the advertised bound and the enforced one cannot drift.

**Deliberately not bounded by file length instead:** `st_size` is 0 for procfs-like files that nonetheless read, so that would turn a DoS fix into a correctness regression.

## Verification

- Three new tests, all **red before the fix**: `read allocated 67108864 bytes for a 17-byte file; cap is 1048576`.
- `oversized_read_request_still_returns_the_whole_small_file` asserts a `size = u32::MAX` request still returns every byte — the clamp bounds the allocation, not the answer.
- The actual CI reproducer replayed against the fix: `Done 101 runs in 0 second(s)`, RSS 85 MB, no OOM — plus a multi-minute unbounded soak from that seed with no crash.
- `cargo nextest run -p mvm-runtime`: 1239 passed, 9 skipped.
- clippy clean, nightly fmt clean.

Scope is one allocation site: `op_readdir`'s `size` is only a loop stop condition, and `FUSE_WRITE` has no dispatch arm (read-only server).