### PR TITLE
ci: report a failing Security lane instead of letting it sit red

### DIFF
--- a/.github/workflows/security-lane-watch.yml
+++ b/.github/workflows/security-lane-watch.yml
@@ -1,0 +1,98 @@
+name: Security lane watch
+
+# The Security workflow runs on release tags, a nightly cron, and manual
+# dispatch — never on a pull request. Nothing surfaces a failure, so a red
+# lane is invisible until somebody thinks to read run history. That is not
+# hypothetical: cargo-deny, cargo-audit, the fuzz lane, the flake-lock check
+# and builder-VM reproducibility were all red for six consecutive nights
+# before anyone noticed, and three of those five back numbered security
+# claims (ADR-001). A claim keeps a green ledger entry while its only
+# evidence is failing.
+#
+# This watches Security instead of living inside it. Two reasons:
+#
+#   1. `workflow_run` fires after the whole run completes, so there is no
+#      20-entry `needs:` list to keep in sync with the job graph.
+#   2. It reads each job's real conclusion from the API rather than the
+#      workflow's aggregate status. A job marked `continue-on-error: true`
+#      — the mutation-witness lane is one — never fails the workflow, so an
+#      `if: failure()` guard would not fire for it. The API still reports
+#      that job as failed, and this reports it too.
+#
+# Failure opens or updates one tracking issue; a clean run closes it. The
+# issue is the enforcement surface, not a merge block: these lanes do not
+# run on PRs, so there is nothing to block.
+
+on:
+  workflow_run:
+    workflows: ["Security"]
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write # opens/updates/closes the tracking issue
+  actions: read # reads the watched run's per-job conclusions
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  report:
+    name: Report failing security lanes
+    # Manual dispatch has an operator watching the run; the cron and the
+    # release-tag gate do not.
+    if: >-
+      github.event.workflow_run.event == 'schedule' ||
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Collect failing jobs and open, update, or close the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          TITLE: "Security lane is red"
+        run: |
+          set -euo pipefail
+
+          # Per-job conclusions, not the run's aggregate: a
+          # continue-on-error job leaves the run green while reporting its
+          # own failure here.
+          gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs" \
+            --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out")
+                  | "- \(.name) — [log](\(.html_url))"' > failing.md
+
+          EXISTING=$(gh issue list --repo "$REPO" --state open \
+            --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
+
+          if [ ! -s failing.md ]; then
+            if [ -n "$EXISTING" ]; then
+              printf 'Security run [%s](%s) on `%s` is green again — closing.\n' \
+                "$RUN_ID" "$RUN_URL" "$HEAD_SHA" > body.md
+              gh issue comment "$EXISTING" --repo "$REPO" --body-file body.md
+              gh issue close "$EXISTING" --repo "$REPO"
+            fi
+            echo "Security run $RUN_ID: all jobs green."
+            exit 0
+          fi
+
+          {
+            printf 'The `Security` workflow (%s) failed on `%s`.\n\n' "$RUN_EVENT" "$HEAD_SHA"
+            printf 'Run: %s\n\n' "$RUN_URL"
+            printf 'Failing jobs:\n\n'
+            cat failing.md
+            printf '\nThese lanes do not run on pull requests, so a failure here is\n'
+            printf 'invisible until someone reads run history. Several of them are the\n'
+            printf 'only witness for a numbered claim in `specs/adrs/001-microvm-security-posture.md`\n'
+            printf '— while a lane is red, that claim has no live evidence behind it.\n'
+          } > body.md
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$REPO" --body-file body.md
+          else
+            gh issue create --repo "$REPO" --title "$TITLE" --body-file body.md
+          fi


### PR DESCRIPTION
## Why

The `Security` workflow runs on release tags, a nightly cron, and manual dispatch — **never on a pull request** — and nothing surfaces a failure. A red lane is invisible until somebody thinks to read run history.

Not hypothetical. In the 2026-07-30 nightly, five jobs were failing, and had been for six consecutive nights:

```
Supply chain — cargo-audit          Fuzz — parsers (vsock + OCI)
Supply chain — cargo-deny           Builder-VM image reproducibility
Flake locks — committed + in sync
```

Three of those five are the **only** witness for a numbered claim in ADR-001. Those claims kept green ledger entries the entire time, because `check-claim-catalog` can only establish that a witness *exists* — no static lint can know a job is red.

## Why a watcher rather than a job inside Security

**`workflow_run` fires after the run completes**, so there is no 20-entry `needs:` list to keep in sync with the job graph as jobs come and go.

**It reads each job's own conclusion from the API**, not the run's aggregate status. A job marked `continue-on-error: true` never fails the workflow — the mutation-witness lane added in #1934 is one — so an `if: failure()` guard would not fire for it. The API still reports that job as failed, and so does this.

## Behaviour

Failure opens or updates one tracking issue naming the failing jobs with per-job log links. A clean run comments and closes it. The issue is the enforcement surface rather than a merge block, since these lanes do not run on PRs and there is nothing to block. Manual dispatch is skipped — an operator is already watching that run.

Follows the open/update-a-tracking-issue idiom already in `kernel-cve-watch.yml`.

## Verified against real runs

Not just "the YAML parses". The job query was run against the known-red run and a known-green one:

```
$ gh api repos/.../actions/runs/30516225311/jobs --jq '...'
- Supply chain — cargo-audit (ADR-001 §W5.2) — [log](...)
- Supply chain — cargo-deny (ADR-001 §W5.2) — [log](...)
- Flake locks — committed + in sync (plan 36 §Layer 0) — [log](...)
- Fuzz — parsers (vsock + OCI) — [log](...)
- Builder-VM image reproducibility (Plan 107 A2.5) — [log](...)

$ ... run 27608345191 (green)
(no output)
```

and the whole script body was dry-run on both, confirming it creates an issue on red and stays silent on green.

## What this deliberately is not

I first proposed a claim-scoped *witness liveness* check — resolve each `ci:` witness to its job and fail if that job is red. I dropped it, for a reason worth recording: **only three of the five failing jobs back claims.** `Flake locks` and `Builder-VM image reproducibility` would have stayed exactly as invisible. The incident was "a 20-job workflow was red and nobody looked", not "claim witnesses specifically went red", so scoping the fix to claims would have built the more elaborate thing for a strictly smaller slice of the problem.

Claim attribution is left for later and is cheap to add on top: two of the twelve `ci:` witnesses (`check-abi-layout`, `fuzz-dns-codec`) don't name a job at all, so job→claim mapping needs the ledger tightened first. The job names here are already actionable.

Related: #1958 fixes the fuzz lane this would have reported; #1952 fixed the cargo-deny failure. Found while auditing whether each claim's witness can actually fail (`specs/plans/274-witness-rigor.md`).
