### PR TITLE
test: make two clock-sensitive test failures diagnose themselves

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -119,9 +119,24 @@ sdk-build-typescript:
 
 # ── Testing (nextest) ────────────────────────────────────────────────────
 
-# Run all tests
+# Run all tests, keeping the full output at target/nextest/last-run.log.
+#
+# An intermittent failure in a suite this size is only diagnosable from the
+# panic and captured streams nextest prints beside it, and those survive
+# nowhere by default — a dev who hits one has terminal scrollback at best,
+# and anyone piping this through `grep` has already discarded the part that
+# mattered. `tee` costs nothing and leaves the evidence under target/, which
+# is gitignored and never uploaded, so this says nothing about the CI-artifact
+# question that .config/nextest.toml settles deliberately.
+#
+# `pipefail` is load-bearing: without it the recipe reports `tee`'s status and
+# a failing suite exits 0, which is the exact silent-green this whole change
+# is trying to remove.
 test:
-    cargo nextest run --workspace
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p target/nextest
+    cargo nextest run --workspace 2>&1 | tee target/nextest/last-run.log
 
 # Non-release builds now skip the embedded host-vm binary cross-compile by
 # default. Keep this explicit recipe as the "always stub" path when a caller

--- a/crates/mvm-hostd/src/supervisor/reaper.rs
+++ b/crates/mvm-hostd/src/supervisor/reaper.rs
@@ -531,10 +531,39 @@ mod tests {
         }
     }
 
+    /// The contract that made the ordering above load-bearing: a timestamp
+    /// ahead of `now` is clock skew, and `idle_elapsed` reports `None` rather
+    /// than a negative — so any caller handing it a future timestamp gets
+    /// `None`, which is a panic away for a caller that unwraps.
+    #[test]
+    fn idle_elapsed_reports_none_for_a_future_timestamp() {
+        let mut reg = registry_with_one(None);
+        let now = Utc::now();
+        let ahead = (now + chrono::Duration::seconds(30))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        reg.touch_last_active("vm1", ahead).unwrap();
+
+        assert!(
+            idle_elapsed(reg.lookup("vm1").unwrap(), now).is_none(),
+            "a timestamp ahead of now is clock skew, not negative idleness"
+        );
+    }
+
     #[test]
     fn idle_elapsed_prefers_last_active_then_registered_at() {
-        let now = Utc::now();
         let mut reg = registry_with_one(None);
+        // Sample `now` *after* registering. `registered_at` is stamped inside
+        // the registry and stored truncated to whole seconds, so truncation
+        // only ever moves it earlier — which makes `now >= registered_at` hold
+        // by construction once `now` is taken later in real time.
+        //
+        // Sampling `now` first instead let the two `Utc::now()` calls straddle
+        // a second boundary: `registered_at` then truncated to the *next*
+        // second, `idle_elapsed` saw a future timestamp, returned `None` per
+        // its clock-skew contract, and the unwrap below panicked. Same-second
+        // truncation hid it on almost every run.
+        let now = Utc::now();
         // No last_active → falls back to registered_at (~now) → tiny elapsed.
         let e = idle_elapsed(reg.lookup("vm1").unwrap(), now).unwrap();
         assert!(e < Duration::from_secs(5));

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -309,12 +309,17 @@ fn serve_release_latest_fixture(response_body: String) -> (String, mpsc::Sender<
                     let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(1)));
                     let mut req_bytes = Vec::with_capacity(2048);
                     let mut buf = [0u8; 512];
+                    // Did the client's headers actually arrive? The read below
+                    // is bounded by a timeout, so "no bytes" and "unknown path"
+                    // are different failures that must not look alike.
+                    let mut headers_complete = false;
                     loop {
                         match stream.read(&mut buf) {
                             Ok(0) => break,
                             Ok(n) => {
                                 req_bytes.extend_from_slice(&buf[..n]);
                                 if req_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                                    headers_complete = true;
                                     break;
                                 }
                             }
@@ -335,6 +340,28 @@ fn serve_release_latest_fixture(response_body: String) -> (String, mpsc::Sender<
                         .next()
                         .and_then(|line| line.split_whitespace().nth(1))
                         .unwrap_or("/");
+                    // A truncated request is a fixture-side timeout, not a
+                    // routing decision. Answering the 404 below would make a
+                    // slow client indistinguishable from a request for an
+                    // unknown path — which is exactly what made an earlier
+                    // flake in this file unreadable after the fact.
+                    if !headers_complete {
+                        let detail = format!(
+                            "loopback fixture read {} byte(s) before the 1s timeout and never saw \
+                             end-of-headers; the client was too slow or the socket was truncated",
+                            req_bytes.len()
+                        );
+                        let _ = stream.write_all(
+                            format!(
+                                "HTTP/1.1 503 Service Unavailable\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{detail}",
+                                detail.len()
+                            )
+                            .as_bytes(),
+                        );
+                        let _ = stream.flush();
+                        let _ = stream.shutdown(std::net::Shutdown::Write);
+                        continue;
+                    }
                     let body = if path.contains("/releases/latest") {
                         Some(response_body.as_bytes())
                     } else {
@@ -367,6 +394,46 @@ fn serve_release_latest_fixture(response_body: String) -> (String, mpsc::Sender<
         }
     });
     (format!("http://{addr}"), tx)
+}
+
+/// The loopback fixture must not answer a slow client with a 404.
+///
+/// An earlier intermittent failure in this file was unreadable precisely
+/// because a truncated read produced the same 404 as a genuinely unknown
+/// path, so the recorded symptom said nothing about the cause. This pins the
+/// two apart.
+#[test]
+fn loopback_fixture_reports_a_truncated_request_rather_than_a_404() {
+    use std::io::Write as _;
+
+    let (base_url, _stop) = serve_release_latest_fixture(r#"{"tag_name":"v0.0.0"}"#.to_string());
+    let addr = base_url
+        .strip_prefix("http://")
+        .expect("fixture url is http")
+        .to_string();
+
+    let mut stream = std::net::TcpStream::connect(&addr).expect("connect to loopback fixture");
+    // A path the fixture *does* serve, but no end-of-headers — so if the
+    // fixture answered anything routing-shaped it would be a 200, and a 404
+    // would mean it fell back to the unknown-path arm on an empty request.
+    stream
+        .write_all(b"GET /repos/tinylabscom/mvm/releases/latest HTTP/1.1\r\nHost: localhost\r\n")
+        .expect("send truncated request");
+    stream.flush().expect("flush truncated request");
+
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .expect("read fixture response");
+
+    assert!(
+        response.starts_with("HTTP/1.1 503"),
+        "a truncated request must be reported, not routed; got:\n{response}"
+    );
+    assert!(
+        response.contains("never saw end-of-headers"),
+        "the 503 must say why, so a future failure needs no archaeology; got:\n{response}"
+    );
 }
 
 #[test]
@@ -1586,9 +1653,16 @@ fn update_check_does_not_emit_audit_entry() {
         .args(["env", "update", "--check"])
         .output()
         .expect("spawn mvmctl update --check");
+    // This assertion is a precondition, not the property under test. Carry
+    // enough to tell a fixture problem (503 from the loopback server, a
+    // truncated read) apart from a real regression in `update --check`,
+    // without needing to reproduce an intermittent failure to find out.
     assert!(
         output.status.success(),
-        "mvmctl update --check failed: stderr={}",
+        "mvmctl update --check failed before the audit assertion could run.\n\
+         exit={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
 


### PR DESCRIPTION
Two intermittent failures in this suite each cost an afternoon, for the same reason: the recorded symptom said nothing about the cause. One turns out to be a real defect.

## The reaper race is a genuine bug, not noise

`supervisor::reaper::tests::idle_elapsed_prefers_last_active_then_registered_at` sampled `now` **before** building the registry, so `registered_at` was always strictly later:

```rust
let now = Utc::now();                   // sampled first
let mut reg = registry_with_one(None);  // registered_at = Utc::now(), later
idle_elapsed(..., now).unwrap()         // future timestamp → None → panic
```

`idle_elapsed` returns `None` for a future timestamp — its own doc comment says so ("or the timestamp is in the future (clock skew)"). Timestamps are stored truncated to whole seconds, which hides the inversion whenever both calls land in the same second. When they straddle a boundary, `registered_at` truncates to the *next* second and the unwrap panics.

Sampling `now` after registering makes `now >= registered_at` hold **by construction**, because truncation only ever moves the stored value earlier.

**Deterministic proof.** Forcing the boundary crossing (sleep to just past the next second before registering):

| ordering | result |
|---|---|
| old, boundary forced | **FAIL** — `called Option::unwrap() on a None value` at the original line |
| fixed | **PASS** |

That is the same error and line as the observed failure, so this is the bug rather than a plausible-looking neighbour. A companion test pins the clock-skew contract that made the ordering load-bearing.

## The loopback fixture no longer answers a slow client with a 404

A truncated read fell through to the unknown-path arm, so a fixture-side timeout and a genuine routing miss produced identical responses — nothing in the recorded failure could tell them apart. It now returns **503** naming the byte count and the reason.

To be clear about credit: the *trigger* — the accepted socket inheriting `O_NONBLOCK` from the non-blocking listener — was diagnosed and fixed separately in #1943. This closes the residual case where a real 1s timeout still masquerades as a routing decision.

The precondition assertion in `update_check_does_not_emit_audit_entry` now carries the exit code and both streams, and states it fired *before* the audit assertion — so a future failure distinguishes "fixture broke" from "`update --check` regressed" without re-deriving it.

## Verification

- Negative control on the 503: removing the arm turns the new truncated-request test **RED**; restoring it **GREEN**.
- Negative control on the reaper fix: deterministic, as above.
- **8346/8346 nextest, 0 failed**, on a host with a populated `~/.mvm`.
- clippy `-D warnings`, fmt, `check-single-home`, `check-test-home-isolation`, `check-no-spec-refs-in-comments` all clean.

## One attribution, recorded so nobody re-does it

A full-suite run also flagged `install_sh_downloads_verifies_and_installs`, which passes in isolation. Since the new fixture test deliberately holds a socket for a second, that coupling was plausible enough to check rather than assume:

| tree | run A | run B |
|---|---|---|
| clean main | 8344/8344 | 1 failed (the reaper race) |
| with this change | 8345/8345 | 8345/8345 |

It never recurred, and clean main flaked while this branch did not. Pre-existing intermittent, not introduced here — now filed as #1972 with the ruled-out list, so nobody repeats this.


## `just test` keeps its output

None of the above would have cost an afternoon if the failure had survived the run. nextest prints the panic and captured streams beside a failure and they persist nowhere; a dev who hits an intermittent has scrollback at best, and anyone piping through `grep` — as I did, twice — has already discarded the part that mattered.

`just test` now tees to `target/nextest/last-run.log`. That is gitignored and never uploaded, so it says nothing about the CI-artifact question `.config/nextest.toml` settles deliberately (captured output can carry key paths and grant tokens; the job log stays the place to read a CI failure).

`pipefail` is load-bearing there and is tested: without it the recipe reports `tee`'s status and a failing suite exits 0. Verified both directions — a failing command exits nonzero through the pipe, a passing one exits 0.
