### PR TITLE
test: close the subprocess half of the MVM_HOME isolation gate

### DIFF
--- a/crates/mvm-cli/tests/artifact_extract_cli.rs
+++ b/crates/mvm-cli/tests/artifact_extract_cli.rs
@@ -24,6 +24,7 @@ fn artifact_extract_round_trips_a_packed_dev_artifact() {
     #[allow(deprecated)]
     let pack = Command::cargo_bin("mvmctl")
         .unwrap()
+        .env("HOME", &data)
         .env("MVM_HOME", &data)
         .args([
             "artifact",
@@ -54,6 +55,7 @@ fn artifact_extract_round_trips_a_packed_dev_artifact() {
     #[allow(deprecated)]
     let extract = Command::cargo_bin("mvmctl")
         .unwrap()
+        .env("HOME", &data)
         .env("MVM_HOME", &data)
         .args([
             "artifact",

--- a/crates/mvm-cli/tests/artifact_model_cli.rs
+++ b/crates/mvm-cli/tests/artifact_model_cli.rs
@@ -167,6 +167,7 @@ fn artifact_model_validate_exits_nonzero_on_failed_check() {
     let out = Command::cargo_bin("mvmctl")
         .expect("locate mvmctl")
         .args(["artifact", "model-validate", artifact_id])
+        .env("HOME", tmp.path().to_str().unwrap())
         .env("MVM_HOME", tmp.path().to_str().unwrap())
         .output()
         .expect("spawn mvmctl");

--- a/crates/mvm-cli/tests/cli.rs
+++ b/crates/mvm-cli/tests/cli.rs
@@ -222,6 +222,7 @@ fn machine_warm_restore_rejects_missing_checkpoint() {
     #[allow(deprecated)]
     let out = Command::cargo_bin("mvmctl")
         .unwrap()
+        .env("HOME", &tmp)
         .env("MVM_HOME", &tmp)
         .args(["machine", "warm-restore", "no-such-checkpoint"])
         .output()
@@ -248,6 +249,7 @@ fn machine_warm_restore_json_flag_parses() {
     #[allow(deprecated)]
     let out = Command::cargo_bin("mvmctl")
         .unwrap()
+        .env("HOME", &tmp)
         .env("MVM_HOME", &tmp)
         .args(["machine", "warm-restore", "no-such-checkpoint", "--json"])
         .output()

--- a/crates/mvm-cli/tests/machine_check_artifact_cli.rs
+++ b/crates/mvm-cli/tests/machine_check_artifact_cli.rs
@@ -25,6 +25,7 @@ fn check_artifact_reports_verified_runnable_and_admission_preview() {
     #[allow(deprecated)]
     let pack = Command::cargo_bin("mvmctl")
         .unwrap()
+        .env("HOME", &data)
         .env("MVM_HOME", &data)
         .args([
             "artifact",
@@ -55,6 +56,7 @@ fn check_artifact_reports_verified_runnable_and_admission_preview() {
     #[allow(deprecated)]
     let check = Command::cargo_bin("mvmctl")
         .unwrap()
+        .env("HOME", &data)
         .env("MVM_HOME", &data)
         .args([
             "machine",

--- a/crates/mvm-cli/tests/reconcile_cli.rs
+++ b/crates/mvm-cli/tests/reconcile_cli.rs
@@ -66,6 +66,7 @@ fn reconcile_dry_run_json_runs_against_isolated_dirs() {
     let out = Command::cargo_bin("mvmctl")
         .expect("locate mvmctl")
         .args(["reconcile", "--dry-run", "--json"])
+        .env("HOME", tmp.path().join("mvm-root"))
         .env("MVM_HOME", tmp.path().join("mvm-root"))
         .output()
         .expect("spawn mvmctl");

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -94,6 +94,7 @@ fn run_mvmctl_isolated_home(world: &mut CliWorld, args: String) {
     });
     let output = cmd
         .args(args.split_whitespace())
+        .env("HOME", home.path())
         .env("MVM_HOME", home.path())
         .output()
         .expect("failed to spawn mvmctl");
@@ -119,6 +120,7 @@ fn run_mvmctl_in_isolated_home(world: &mut CliWorld, args: String) {
     });
     let output = cmd
         .args(args.split_whitespace())
+        .env("HOME", home.path())
         .env("MVM_HOME", home.path())
         .output()
         .expect("failed to spawn mvmctl");
@@ -153,6 +155,7 @@ pub(crate) fn run_mvmctl_isolated_live_home(world: &mut CliWorld, args: String) 
     command
         .current_dir(workspace_root())
         .args(args.split_whitespace())
+        .env("HOME", home.path())
         .env("MVM_HOME", home.path());
     if world.warm_residency {
         command.env("MVM_RESIDENCY", "warm");
@@ -179,6 +182,7 @@ fn install_bundle_fixture(world: &mut CliWorld) {
         .current_dir(workspace_root())
         .args(["bundle", "install"])
         .arg(&fixture)
+        .env("HOME", home.path())
         .env("MVM_HOME", home.path())
         .output()
         .expect("failed to spawn mvmctl");
@@ -220,6 +224,7 @@ fn boot_installed_bundle(world: &mut CliWorld, args: String) {
         .current_dir(workspace_root())
         .args(["machine", "run", "--manifest", &sha])
         .args(args.split_whitespace())
+        .env("HOME", home.path())
         .env("MVM_HOME", home.path())
         .output()
         .expect("failed to spawn mvmctl");

--- a/crates/mvm-conformance/tests/steps/readme_contract.rs
+++ b/crates/mvm-conformance/tests/steps/readme_contract.rs
@@ -43,7 +43,9 @@ fn spawn_mvmctl(args: &str, home: Option<PathBuf>) -> std::process::Output {
     if let Some(home) = home {
         // Reconcile-on-entry converges live-VM state; disable it so a refusal
         // guard runs against a clean slate with no host side effects.
-        cmd.env("MVM_HOME", home).env("MVM_SKIP_RECONCILE", "1");
+        cmd.env("HOME", &home)
+            .env("MVM_HOME", &home)
+            .env("MVM_SKIP_RECONCILE", "1");
     }
     cmd.args(args.split_whitespace())
         .output()

--- a/tests/e2e/audit_emissions.rs
+++ b/tests/e2e/audit_emissions.rs
@@ -29,7 +29,7 @@ impl IsolatedEnv {
 
     fn cmd(&self) -> Command {
         let mut cmd = mvmctl();
-        cmd.env("MVM_HOME", &self.root);
+        cmd.env("HOME", &self.root).env("MVM_HOME", &self.root);
         cmd
     }
 

--- a/tests/oci_image_runner_smoke.rs
+++ b/tests/oci_image_runner_smoke.rs
@@ -131,6 +131,7 @@ impl Drop for SessionCleanup {
             return;
         };
         let _ = mvmctl_with_target_path()
+            .env("HOME", &self.data_dir)
             .env("MVM_HOME", &self.data_dir)
             .args(["session", "kill", session_id])
             .output();
@@ -629,6 +630,7 @@ fn prod_agent_verb_grant_hvf_witness_proves_staging_denial_and_audit() {
     );
 
     let compile = mvmctl_with_target_path()
+        .env("HOME", &data_dir)
         .env("MVM_HOME", &data_dir)
         .args([
             "build",
@@ -649,6 +651,7 @@ fn prod_agent_verb_grant_hvf_witness_proves_staging_denial_and_audit() {
 
     let run = run_with_stdin(
         mvmctl_with_target_path()
+            .env("HOME", &data_dir)
             .env("MVM_HOME", &data_dir)
             .env("MVM_HYPERVISOR", "hvf")
             .args([
@@ -684,6 +687,7 @@ fn prod_agent_verb_grant_hvf_witness_proves_staging_denial_and_audit() {
     cleanup.arm(session_id.clone());
 
     let info = mvmctl_with_target_path()
+        .env("HOME", &data_dir)
         .env("MVM_HOME", &data_dir)
         .args(["session", "info", &session_id])
         .output()
@@ -720,6 +724,7 @@ fn prod_agent_verb_grant_hvf_witness_proves_staging_denial_and_audit() {
     );
 
     let denied = mvmctl_with_target_path()
+        .env("HOME", &data_dir)
         .env("MVM_HOME", &data_dir)
         .env("MVM_HYPERVISOR", "hvf")
         .args(["machine", "set-timeout", &vm_name, "349"])
@@ -738,6 +743,7 @@ fn prod_agent_verb_grant_hvf_witness_proves_staging_denial_and_audit() {
     );
 
     let verify = mvmctl_with_target_path()
+        .env("HOME", &data_dir)
         .env("MVM_HOME", &data_dir)
         .args(["trust", "audit", "verify", "--tenant", "local"])
         .output()
@@ -759,6 +765,7 @@ fn prod_agent_verb_grant_hvf_witness_proves_staging_denial_and_audit() {
     );
 
     let kill = mvmctl_with_target_path()
+        .env("HOME", &data_dir)
         .env("MVM_HOME", &data_dir)
         .args(["session", "kill", &session_id])
         .output()

--- a/xtask/src/check_test_home_isolation.rs
+++ b/xtask/src/check_test_home_isolation.rs
@@ -12,7 +12,7 @@
 //! reads green in CI while the same test is red for everyone else — and a
 //! genuine regression in the code under test is masked either way.
 //!
-//! Two rules keep that class closed:
+//! Three rules keep that class closed:
 //!
 //! 1. `default-cache-caller` — `default_mvm_cache_dir` is the only resolver
 //!    that reads `$HOME` while `MVM_HOME` is set, so it is the only door the
@@ -22,11 +22,15 @@
 //! 2. `test-home-isolation` — in a file that can reach a seed site, a test
 //!    that moves `MVM_HOME` must move `HOME` with it.
 //!    `TestEnv::isolate_mvm_home` does both; an explicit `HOME` set counts.
+//! 3. `subprocess-home-isolation` — in an integration test, a `Command`
+//!    handed `MVM_HOME` must be handed `HOME` too.
 //!
-//! Scope, stated plainly: rule 2 reads `#[test]` bodies, so it covers the
-//! in-process `TestEnv` pattern that the known failures came from. A
-//! subprocess fixture that exports `MVM_HOME` from a shared helper outside
-//! any `#[test]` body is not matched.
+//! Rule 3 deliberately does no reachability analysis, and that is the point:
+//! the child is a whole `mvmctl`, so it reaches *every* seed regardless of
+//! what the spawning test file imports. Rule 2 cannot see these at all — such
+//! a fixture names none of the seed symbols, and it builds its `Command` in a
+//! shared helper rather than inside a `#[test]` body, which is the second
+//! thing rule 2 keys on.
 
 use anyhow::{Result, bail};
 use std::path::Path;
@@ -35,6 +39,7 @@ use std::path::Path;
 enum Rule {
     DefaultCacheCaller,
     TestHomeIsolation,
+    SubprocessHomeIsolation,
 }
 
 impl Rule {
@@ -42,6 +47,7 @@ impl Rule {
         match self {
             Rule::DefaultCacheCaller => "default-cache-caller",
             Rule::TestHomeIsolation => "test-home-isolation",
+            Rule::SubprocessHomeIsolation => "subprocess-home-isolation",
         }
     }
 }
@@ -157,6 +163,25 @@ fn scan_source(rel: &str, src: &str) -> Vec<String> {
         }
     }
 
+    // Rule 3 first: it applies to any integration test, with no dependence on
+    // what the file imports, so the seed-anchor early return below must not
+    // short-circuit it.
+    if is_integration_test(rel) {
+        for block in fn_blocks(src) {
+            if spawns_with_mvm_home(block.body) && !spawns_with_home(block.body) {
+                push(
+                    &mut hits,
+                    block.line,
+                    Rule::SubprocessHomeIsolation,
+                    format!(
+                        "`{}` gives a subprocess MVM_HOME but not HOME, so the child reads the developer's real cache",
+                        block.name
+                    ),
+                );
+            }
+        }
+    }
+
     if ISOLATION_EXEMPT.iter().any(|(path, _)| *path == rel) {
         return hits;
     }
@@ -227,6 +252,40 @@ fn isolates_home(body: &str) -> bool {
         || ["set(\"HOME\"", "set_var(\"HOME\"", "env(\"HOME\""]
             .iter()
             .any(|pattern| body.contains(pattern))
+}
+
+/// Is this an integration test — a file under a `tests/` directory?
+///
+/// Those are where subprocess fixtures live. Unit tests inside `src/` drive
+/// the code in-process and are rule 2's business.
+fn is_integration_test(rel: &str) -> bool {
+    rel.starts_with("tests/") || rel.contains("/tests/")
+}
+
+/// Split `src` into one block per `fn`, so a fixture that builds its
+/// `Command` in a helper is judged as a unit rather than per line.
+fn fn_blocks(src: &str) -> Vec<TestBlock<'_>> {
+    let starts: Vec<usize> = src.match_indices("fn ").map(|(at, _)| at).collect();
+    starts
+        .iter()
+        .enumerate()
+        .map(|(n, &start)| {
+            let end = starts.get(n + 1).copied().unwrap_or(src.len());
+            TestBlock {
+                line: src[..start].lines().count() + 1,
+                name: test_fn_name(&src[start..end]).unwrap_or("<unnamed>"),
+                body: &src[start..end],
+            }
+        })
+        .collect()
+}
+
+fn spawns_with_mvm_home(body: &str) -> bool {
+    body.contains("env(\"MVM_HOME\"")
+}
+
+fn spawns_with_home(body: &str) -> bool {
+    body.contains("env(\"HOME\"") || body.contains("env_clear()")
 }
 
 fn walk(dir: &Path, f: &mut dyn FnMut(&Path)) -> Result<()> {
@@ -327,6 +386,53 @@ mod tests {
              #[test]\nfn ignores_override() {{\n    env.set(\"MVM_HOME\", d);\n}}\n"
         );
         assert!(scan_source("crates/mvm-core/src/config.rs", &src).is_empty());
+    }
+
+    #[test]
+    fn flags_a_subprocess_fixture_that_moves_only_mvm_home() {
+        let src = "fn mvmctl(&self) -> Command {\n    c.env(\"MVM_HOME\", self.root())\n}\n";
+        let hits = scan_source("tests/oci_smoke.rs", src);
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert!(hits[0].contains("subprocess-home-isolation"), "{hits:?}");
+        assert!(hits[0].contains("mvmctl"), "{hits:?}");
+    }
+
+    #[test]
+    fn subprocess_rule_fires_without_any_seed_anchor_in_the_file() {
+        // The whole point of rule 3: the child is a full mvmctl, so the
+        // spawning file naming no seed symbol proves nothing.
+        let src = "fn spawn() {\n    c.env(\"MVM_HOME\", d);\n}\n";
+        assert!(!SEED_ANCHORS.iter().any(|a| src.contains(a)));
+        assert_eq!(scan_source("tests/whatever.rs", src).len(), 1);
+    }
+
+    #[test]
+    fn accepts_a_subprocess_given_both_roots() {
+        let src = "fn mvmctl() -> Command {\n    c.env(\"HOME\", h).env(\"MVM_HOME\", r)\n}\n";
+        assert!(scan_source("tests/oci_smoke.rs", src).is_empty());
+    }
+
+    #[test]
+    fn accepts_a_subprocess_with_a_cleared_environment() {
+        let src = "fn mvmctl() -> Command {\n    c.env_clear().env(\"MVM_HOME\", r)\n}\n";
+        assert!(
+            scan_source("tests/oci_smoke.rs", src).is_empty(),
+            "env_clear drops the inherited HOME, which is stricter than setting it"
+        );
+    }
+
+    #[test]
+    fn subprocess_rule_covers_crate_local_integration_tests() {
+        let src = "fn mvmctl() -> Command {\n    c.env(\"MVM_HOME\", d)\n}\n";
+        assert_eq!(scan_source("crates/mvm-cli/tests/cli.rs", src).len(), 1);
+    }
+
+    #[test]
+    fn subprocess_rule_leaves_in_process_unit_tests_to_rule_two() {
+        // A `src/` file driving code in-process is rule 2's business; applying
+        // rule 3 there would flag every Command-shaped helper in the tree.
+        let src = "fn helper() {\n    c.env(\"MVM_HOME\", d)\n}\n";
+        assert!(scan_source("crates/mvm-runtime/src/vm/name_registry.rs", src).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #1966.

## The gap

The gate added in #1923 keys on two things, and an integration-test fixture that shells out to `mvmctl` satisfies neither:

1. it builds its `Command` in a shared helper — `AuditSandbox::mvmctl()`, `run_mvmctl_isolated_home`, `spawn_mvmctl` — not inside a `#[test]` body
2. it names none of the seed symbols the file-level anchor check looks for, because a test that shells out imports none of them

The child, though, is a whole `mvmctl`. It reaches **every** cross-root seed regardless of what the spawning file imports. So a fixture that sets `MVM_HOME` and lets the child inherit the developer's real `HOME` is the same bug the gate exists to prevent, one process boundary away.

## Rule 3

`subprocess-home-isolation`: in a file under a `tests/` directory, a `fn` handing a `Command` `MVM_HOME` must hand it `HOME` too (`env_clear()` counts, being stricter).

It does **no** reachability analysis, and that is the justification rather than a shortcut — there is nothing to analyse when the callee is the entire binary. That also makes it immune to both things that blinded rule 2.

Scoped to `tests/` deliberately: a `src/` unit test drives the code in-process and is rule 2's business, and applying rule 3 there would flag every `Command`-shaped helper in the tree.

**21 sites across 14 `fn` blocks in 9 files** now pair the two. Heaviest: `mvm-conformance/tests/steps/cli.rs` (4 blocks) and `tests/oci_image_runner_smoke.rs`, which runs real `mvmctl run --image` and so reaches the runtime-overlay seed.

## Not theoretical

`run_mvmctl_isolated_home` documents the property it is trying to establish:

> A fresh, empty `MVM_HOME` makes cache-precondition scenarios hermetic: every cache (workload kernel, OCI, guest runtime) is cold, so the run exercises the missing-prerequisite path without depending on — or mutating — the dev's real `~/.mvm`.

That is exactly the guarantee the missing `HOME` broke. The child's caches are not cold on any machine that has built the artifacts, so a scenario asserting a missing prerequisite could pass for the wrong reason.

## A second shape of the same bug, fixed here

`initramfs::tests::resolve_returns_missing_when_cache_empty` never sets `MVM_HOME` at all. It hands a tempdir straight to `resolve_or_build_local_initramfs` and inherits the real `HOME`, so "empty cache" is only empty on a machine that has never built an initramfs:

| `HOME` | result |
|---|---|
| empty dir | **PASS** |
| the real one | **FAIL** — `called Result::unwrap_err() on an Ok value: InitramfsArtifact { … }` |

Deterministic, 10/10, once `~/.mvm/cache/initramfs/…` exists — which on this machine happened partway through a session, so the same test passed in the morning and failed in the evening.

The rule change that would have caught it — widening rule 2 from "sets `MVM_HOME`" to "or calls a seeding entry point" — flags 13 sites, including false positives from this crate's own unit tests that drive `seed_on_miss` with `Path::new("/same")` and in-memory closures. That needs a judgement pass per site, so it is filed as #1973 with the triage rather than rushed in here. The acute test is fixed because it is actively red on any dev machine with a built initramfs.

## Verification

- **Negative control**: delete one migrated `HOME` line and rule 3 flags `run_mvmctl_isolated_home`; restore and it is clean. Worth stating that my *first* control was a false negative — `cargo fmt` had split the chained `.env()` calls across lines so the pattern matched nothing, and it reported "0 hits" that reads exactly like the guard holding. Re-run by deleting the real line.
- 6 new unit tests on rule 3, including one asserting the fixture file contains no seed anchor yet is still flagged. 17 total on this lint.
- **8350/8350 nextest, 0 failed** on a host with a populated `~/.mvm`.
- clippy `-D warnings`, fmt, `check-single-home`, `check-test-home-isolation`, `check-no-spec-refs-in-comments` clean.