### PR TITLE
Cosign-verify the downloaded runtime overlay and SDK sidecar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -730,14 +730,40 @@ jobs:
       - name: Sign release tarballs and SBOM
         shell: bash
         run: |
-          # Sign each tarball — keyless OIDC, no secret key needed.
-          # Produces a .bundle file per tarball containing signature + certificate chain.
+          set -euo pipefail
+          shopt -s nullglob
+
+          # Two bundle formats, because two different verifiers consume them.
+          #
+          # The mvmctl binary tarballs and the SBOM are verified by the cosign
+          # CLI (install.sh, and `mvmctl update`, which shells out to
+          # `cosign verify-blob`). That reads both shapes, so they stay on the
+          # legacy `--bundle` format they have always shipped.
+          #
+          # The image tarballs are verified IN-BINARY by the Rust sigstore
+          # stack (mvm_build::release_signature -> image_verify), which parses
+          # only the newer Sigstore bundle carrying verificationMaterial. A
+          # legacy bundle here would fail to parse on every download, so these
+          # must be signed with --new-bundle-format — same as every other
+          # artifact that stack verifies (image manifests, packs, revocations).
           for tarball in artifacts/*.tar.gz; do
+            case "$(basename "${tarball}")" in
+              runtime-overlay-*|sdk-sidecar-*) continue ;;
+            esac
             cosign sign-blob \
               --yes \
               --bundle "${tarball}.bundle" \
               "${tarball}"
-            echo "Signed: ${tarball}"
+            echo "Signed (legacy bundle, cosign-CLI consumers): ${tarball}"
+          done
+
+          for tarball in artifacts/runtime-overlay-*.tar.gz artifacts/sdk-sidecar-*.tar.gz; do
+            cosign sign-blob \
+              --yes \
+              --new-bundle-format \
+              --bundle "${tarball}.bundle" \
+              "${tarball}"
+            echo "Signed (new bundle format, in-binary verifier): ${tarball}"
           done
 
           # Sign the SBOM
@@ -807,6 +833,8 @@ jobs:
             artifacts/runtime-overlay-*.tar.gz.sha256
             artifacts/sdk-sidecar-*.tar.gz
             artifacts/sdk-sidecar-*.tar.gz.sha256
+            artifacts/runtime-overlay-*.tar.gz.bundle
+            artifacts/sdk-sidecar-*.tar.gz.bundle
             artifacts/default-microvm-vmlinux-*
             artifacts/default-microvm-rootfs-*
             artifacts/default-microvm-meta-*

--- a/crates/mvm-build/src/initramfs.rs
+++ b/crates/mvm-build/src/initramfs.rs
@@ -569,8 +569,16 @@ mod tests {
     #[test]
     fn resolve_returns_missing_when_cache_empty() {
         let dir = tempfile::tempdir().unwrap();
+        // HOME has to move with the cache root: a miss is seeded from
+        // `$HOME/.mvm/cache`, so without this the assertion holds only on a
+        // machine that has never built an initramfs — which CI is and a
+        // contributor's laptop is not.
+        let _lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(dir.path());
+        let cache = dir.path().join("cache");
         let err =
-            resolve_or_build_local_initramfs(&NoopShell, dir.path(), "0.18.0", GuestArch::Aarch64)
+            resolve_or_build_local_initramfs(&NoopShell, &cache, "0.18.0", GuestArch::Aarch64)
                 .unwrap_err();
         assert!(!format!("{err}").is_empty());
     }

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -120,6 +120,10 @@ pub mod pipeline;
 /// Host-side resolver for the mvm runtime overlay disk. Picks the right
 /// ext4 + verity sidecar + roothash for the running mvmctl version and
 /// host arch from `~/.mvm/cache/runtime-overlay/<version>/<arch>/`.
+/// Cosign-verify a downloaded release archive against the release workflow's
+/// keyless signing identity before anything reads it. Shared by every
+/// release-artifact downloader.
+pub mod release_signature;
 pub mod runtime_overlay;
 /// Acquire the published SDK-sidecar disk for hosts that cannot build one.
 /// Fetches the per-arch release tarball, proves it against the release's

--- a/crates/mvm-build/src/release_signature.rs
+++ b/crates/mvm-build/src/release_signature.rs
@@ -1,0 +1,283 @@
+//! Cosign-verify a downloaded release archive before anything reads it.
+//!
+//! The digest an installed binary checks an archive against comes from a
+//! `.sha256` fetched over the same channel as the archive itself. That
+//! authenticates the transport, not the publisher: whoever controls what the
+//! base URL serves serves a matching pair. Since the archive becomes the
+//! guest's runtime overlay or its SDK cdylib, "whoever controls that URL"
+//! otherwise gets arbitrary code inside the sandbox.
+//!
+//! So every downloaded release archive is verified against the release
+//! workflow's cosign-keyless signing identity before it is extracted. The
+//! verification primitive is [`mvm_core::crypto::image_verify::verify_signed_payload`]
+//! — an offline check against an embedded Sigstore trust root — and the trust
+//! root is [`mvm_core::release_trust`], the same one a stock binary already uses
+//! for its own release packs. Nothing new is trusted and no dependency is added.
+//!
+//! Fails closed: a missing bundle, an unparseable bundle, a signature from an
+//! identity outside the release set, or a build that cannot verify at all each
+//! refuse the install.
+
+use std::path::Path;
+
+use crate::runtime_overlay::RuntimeOverlayError;
+
+/// Documented emergency-rotation escape: skip the signature rung when a
+/// signing outage would otherwise strand every download. Never set in CI.
+/// Sibling of `MVM_SKIP_HASH_VERIFY`, and deliberately a *separate* switch —
+/// bypassing the publisher check is a strictly bigger concession than
+/// bypassing the digest check, so one does not imply the other.
+pub const SKIP_COSIGN_VERIFY_ENV: &str = "MVM_SKIP_COSIGN_VERIFY";
+
+/// Suffix the release attaches beside each signed archive.
+const BUNDLE_SUFFIX: &str = ".bundle";
+
+/// Name of the signature bundle published beside `asset`.
+///
+/// One definition, so the release workflow's asset list and the downloader's
+/// request cannot drift — a mismatch would be invisible until a real download
+/// 404s. `tests/release_assets.rs` asserts the workflow publishes exactly this.
+#[must_use]
+pub fn bundle_asset_name(asset: &str) -> String {
+    format!("{asset}{BUNDLE_SUFFIX}")
+}
+
+/// One archive to check, and where its signature lives.
+///
+/// A params struct rather than four positional arguments because three of them
+/// are strings and transposing any two would silently verify the wrong thing.
+#[derive(Debug, Clone, Copy)]
+pub struct ReleaseSignatureRequest<'a> {
+    /// Per-version release base URL the archive was fetched from.
+    pub base_url: &'a str,
+    /// The archive's published asset name, e.g. `runtime-overlay-aarch64.tar.gz`.
+    pub asset: &'a str,
+    /// Where the already-downloaded archive sits on disk.
+    pub archive_path: &'a Path,
+    /// Version whose signing identity is accepted. The release identity is
+    /// tag-bound, so this pins *which* release may have signed the archive.
+    pub version: &'a str,
+}
+
+/// Verify `request`'s archive against the release workflow's keyless signing
+/// identity, fetching the Sigstore bundle published beside it.
+///
+/// Accepts if any identity in [`mvm_core::release_trust::accepted_release_identities`]
+/// verifies the archive bytes under the release OIDC issuer. Refuses on a
+/// missing bundle, an unparseable bundle, a signature from an identity outside
+/// that set, or a build compiled without the verifier — there is no downgrade
+/// to the digest-only posture this rung exists to replace.
+///
+/// Errors name the asset and never echo bundle or archive bytes, so the message
+/// is safe to surface to an operator verbatim.
+pub fn verify_release_archive_signature(
+    request: &ReleaseSignatureRequest<'_>,
+) -> Result<(), RuntimeOverlayError> {
+    if std::env::var_os(SKIP_COSIGN_VERIFY_ENV).is_some() {
+        tracing::warn!(
+            asset = request.asset,
+            "{SKIP_COSIGN_VERIFY_ENV} set — skipping release signature verification. \
+             This is an emergency-rotation escape hatch; never set it in CI."
+        );
+        return Ok(());
+    }
+
+    let bundle = fetch_bundle(request)?;
+    let archive = std::fs::read(request.archive_path)?;
+    verify_against_release_identities(&archive, &bundle, request)
+}
+
+/// Download the archive's signature bundle. A release that published an archive
+/// without one is refused here rather than treated as unsigned.
+fn fetch_bundle(request: &ReleaseSignatureRequest<'_>) -> Result<Vec<u8>, RuntimeOverlayError> {
+    let url = format!("{}/{}", request.base_url, bundle_asset_name(request.asset));
+    let tmp = tempfile::NamedTempFile::new()?;
+    crate::runtime_overlay::curl_download(&url, tmp.path()).map_err(|_| {
+        RuntimeOverlayError::SignatureMissing {
+            asset: request.asset.to_string(),
+            bundle_url: url.clone(),
+        }
+    })?;
+    Ok(std::fs::read(tmp.path())?)
+}
+
+/// Try every accepted release identity, accepting on the first that verifies.
+///
+/// The identity set is a list rather than a single value because the release
+/// trust root allows more than one template; a rotation that adds one must not
+/// require a code change here.
+fn verify_against_release_identities(
+    archive: &[u8],
+    bundle: &[u8],
+    request: &ReleaseSignatureRequest<'_>,
+) -> Result<(), RuntimeOverlayError> {
+    let identities = mvm_core::release_trust::accepted_release_identities(request.version);
+    let issuer = mvm_core::release_trust::RELEASE_OIDC_ISSUER;
+    let mut last_failure: Option<String> = None;
+
+    for identity in &identities {
+        match mvm_core::crypto::image_verify::verify_signed_payload(
+            archive, bundle, identity, issuer,
+        ) {
+            Ok(()) => {
+                tracing::debug!(
+                    asset = request.asset,
+                    identity = identity.as_str(),
+                    "release archive signature verified"
+                );
+                return Ok(());
+            }
+            Err(error) => last_failure = Some(error.to_string()),
+        }
+    }
+
+    Err(RuntimeOverlayError::SignatureInvalid {
+        asset: request.asset.to_string(),
+        reason: last_failure.unwrap_or_else(|| {
+            "no release signing identity is configured for this version".to_string()
+        }),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::util::test_env::TestEnv;
+
+    const FIXTURE_VERSION: &str = "9.9.9";
+    const ASSET: &str = "runtime-overlay-aarch64.tar.gz";
+
+    /// Stage a release directory holding `archive`, optionally beside a bundle.
+    /// Returns the tempdir plus the `file://` base URL pointing at it.
+    fn stage(archive: &[u8], bundle: Option<&[u8]>) -> (tempfile::TempDir, String) {
+        let root = tempfile::tempdir().expect("release fixture root");
+        let dir = root.path().join(format!("v{FIXTURE_VERSION}"));
+        std::fs::create_dir_all(&dir).expect("create the release dir");
+        std::fs::write(dir.join(ASSET), archive).expect("write the archive");
+        if let Some(bytes) = bundle {
+            std::fs::write(dir.join(format!("{ASSET}.bundle")), bytes).expect("write the bundle");
+        }
+        let base = format!("file://{}/v{FIXTURE_VERSION}", root.path().display());
+        (root, base)
+    }
+
+    /// Write the archive where the downloader would have put it, then run the
+    /// signature rung against the staged release.
+    fn verify(base: &str, archive: &[u8]) -> Result<(), String> {
+        let local = tempfile::tempdir().expect("local dir");
+        let path = local.path().join(ASSET);
+        std::fs::write(&path, archive).expect("write the local archive");
+        verify_release_archive_signature(&ReleaseSignatureRequest {
+            base_url: base,
+            asset: ASSET,
+            archive_path: &path,
+            version: FIXTURE_VERSION,
+        })
+        .map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn a_missing_bundle_refuses_and_names_the_asset() {
+        let mut env = TestEnv::new();
+        env.remove("MVM_SKIP_COSIGN_VERIFY");
+        let archive = b"archive-bytes";
+        let (_root, base) = stage(archive, None);
+
+        let err = verify(&base, archive).expect_err("an unsigned archive must be refused");
+
+        assert!(
+            err.contains(ASSET),
+            "the refusal must name the asset: {err}"
+        );
+        assert!(
+            err.contains("signature") || err.contains("bundle"),
+            "the refusal must say what was missing: {err}"
+        );
+    }
+
+    /// The documented emergency-rotation escape, and the only way an archive
+    /// with no verifiable signature is ever admitted.
+    #[test]
+    fn the_documented_escape_hatch_admits() {
+        let mut env = TestEnv::new();
+        env.set("MVM_SKIP_COSIGN_VERIFY", "1");
+        let archive = b"archive-bytes";
+        let (_root, base) = stage(archive, None);
+
+        verify(&base, archive).expect("the escape hatch must admit without a bundle");
+    }
+
+    /// A bundle that is present but not a Sigstore bundle must be refused, not
+    /// treated as absent. Only meaningful when the verifier is actually
+    /// compiled in — without `manifest-verify` every bundle fails identically,
+    /// so the assertion could not tell a bad signature from a disabled
+    /// verifier and would not be a witness.
+    #[cfg(feature = "manifest-verify")]
+    #[test]
+    fn a_malformed_bundle_is_refused() {
+        let mut env = TestEnv::new();
+        env.remove("MVM_SKIP_COSIGN_VERIFY");
+        let archive = b"archive-bytes";
+        let (_root, base) = stage(archive, Some(b"{\"not\":\"a sigstore bundle\"}"));
+
+        let err = verify(&base, archive).expect_err("a malformed bundle must be refused");
+
+        assert!(err.contains(ASSET), "{err}");
+    }
+
+    /// A build that cannot verify must refuse rather than silently downgrade to
+    /// the sha256-only posture this rung exists to replace.
+    #[cfg(not(feature = "manifest-verify"))]
+    #[test]
+    fn a_build_that_cannot_verify_refuses_and_names_both_remedies() {
+        let mut env = TestEnv::new();
+        env.remove("MVM_SKIP_COSIGN_VERIFY");
+        let archive = b"archive-bytes";
+        let (_root, base) = stage(archive, Some(b"{\"not\":\"a sigstore bundle\"}"));
+
+        let err = verify(&base, archive).expect_err("a non-verifying build must refuse");
+
+        assert!(
+            err.contains("manifest-verify"),
+            "the refusal must name the feature that would fix it: {err}"
+        );
+        assert!(
+            err.contains(SKIP_COSIGN_VERIFY_ENV),
+            "the refusal must name the documented escape: {err}"
+        );
+    }
+
+    #[test]
+    fn the_refusal_carries_no_bundle_bytes() {
+        let mut env = TestEnv::new();
+        env.remove("MVM_SKIP_COSIGN_VERIFY");
+        let archive = b"archive-bytes";
+        let secret_looking = b"{\"canary\":\"SHOULD-NOT-APPEAR-IN-AN-ERROR\"}";
+        let (_root, base) = stage(archive, Some(secret_looking));
+
+        let err = verify(&base, archive).expect_err("a bogus bundle must be refused");
+
+        assert!(
+            !err.contains("SHOULD-NOT-APPEAR-IN-AN-ERROR"),
+            "an error must not echo bundle contents: {err}"
+        );
+    }
+
+    /// The identities the verifier accepts are the release workflow's, bound to
+    /// the running version — not a wildcard and not a different workflow.
+    #[test]
+    fn accepted_identities_are_the_versioned_release_workflow() {
+        let identities = mvm_core::release_trust::accepted_release_identities(FIXTURE_VERSION);
+        assert!(!identities.is_empty(), "there must be a release identity");
+        for identity in &identities {
+            assert!(
+                identity.contains("release.yml"),
+                "only the release workflow signs release archives: {identity}"
+            );
+            assert!(
+                identity.ends_with(&format!("refs/tags/v{FIXTURE_VERSION}")),
+                "the identity must be pinned to this version's tag: {identity}"
+            );
+        }
+    }
+}

--- a/crates/mvm-build/src/runtime_overlay.rs
+++ b/crates/mvm-build/src/runtime_overlay.rs
@@ -94,6 +94,31 @@ pub enum RuntimeOverlayError {
     #[error("checksum manifest at {checksums_url} did not list an entry for {name}")]
     ChecksumMissing { name: String, checksums_url: String },
 
+    /// The release published an archive with no signature bundle beside it.
+    /// Refused rather than treated as unsigned: a digest fetched over the same
+    /// channel as the archive authenticates the transport, not the publisher.
+    #[error(
+        "release archive {asset} has no signature bundle at {bundle_url} — \
+         refusing to install an unsigned artifact"
+    )]
+    SignatureMissing {
+        /// Published asset name that could not be authenticated.
+        asset: String,
+        /// Where the bundle was expected.
+        bundle_url: String,
+    },
+
+    /// The archive did not verify under any accepted release signing identity.
+    /// The reason is the verifier's own message; neither archive nor bundle
+    /// bytes are echoed, so this is safe to surface verbatim.
+    #[error("release archive {asset} failed signature verification: {reason}")]
+    SignatureInvalid {
+        /// Published asset name whose signature was rejected.
+        asset: String,
+        /// Verifier's description of the failure.
+        reason: String,
+    },
+
     /// A downloaded release tarball was malformed or unsafe to extract.
     /// Always fail closed — tar extraction is an attack surface.
     #[error("release archive invalid at {archive_path:?}: {reason}")]
@@ -873,15 +898,24 @@ pub fn download_runtime_overlay(
     // spend bandwidth on the payload.
     let expected = fetch_expected_hashes(&archive_checksum_url, &[&names.archive])?;
 
-    // Step 2: download the tarball into a temp dir, verify the tarball's
-    // checksum, then safely extract it into canonical filenames so
-    // `install_overlay_into_cache` can consume the extracted directory
-    // directly.
+    // Step 2: download the tarball into a temp dir, prove it against both the
+    // digest and the release signing identity, then safely extract it into
+    // canonical filenames so `install_overlay_into_cache` can consume the
+    // extracted directory directly. The signature rung sits before extraction
+    // so an unauthenticated tar is never parsed.
     let tmp = tempfile::tempdir()?;
     let stage = tmp.path();
     let archive_local = stage.join(&names.archive);
     curl_download(&format!("{base}/{}", names.archive), &archive_local)?;
     verify_file_sha256(&archive_local, &names.archive, expected.get(&names.archive))?;
+    crate::release_signature::verify_release_archive_signature(
+        &crate::release_signature::ReleaseSignatureRequest {
+            base_url: &base,
+            asset: &names.archive,
+            archive_path: &archive_local,
+            version,
+        },
+    )?;
     extract_release_archive(&archive_local, stage, &OVERLAY_ARCHIVE_MEMBERS)?;
     verify_overlay_dir_integrity(stage)?;
 
@@ -1769,6 +1803,10 @@ mod tests {
 
         let base_url = format!("file://{}", upstream.path().display());
         env.set("MVM_OVERLAY_BASE_URL", &base_url);
+        // A valid Sigstore signature cannot be minted offline, and this test is
+        // about the digest, extraction, and install rungs. The signature rung
+        // has its own witnesses in `crate::release_signature` and below.
+        env.set(crate::release_signature::SKIP_COSIGN_VERIFY_ENV, "1");
 
         let cache = TempDir::new().unwrap();
         let result = download_runtime_overlay("9.9.9", GuestArch::Aarch64, cache.path());
@@ -1794,6 +1832,53 @@ mod tests {
         assert_eq!(
             std::fs::read(cache_dir.join("overlay.ext4")).unwrap(),
             ext4_bytes
+        );
+    }
+
+    /// The overlay carries the same signature rung the sidecar does: a release
+    /// that publishes an archive with no signature beside it is refused, and
+    /// nothing lands in the cache — even though its digest matches.
+    #[test]
+    fn download_runtime_overlay_refuses_an_unsigned_archive() {
+        let mut env = TestEnv::new();
+        let upstream = TempDir::new().unwrap();
+        let release_dir = upstream.path().join("v9.9.9");
+        std::fs::create_dir_all(&release_dir).unwrap();
+
+        let archive_bytes = b"not-even-a-real-archive".to_vec();
+        write_fixture(
+            &release_dir,
+            "runtime-overlay-aarch64.tar.gz",
+            &archive_bytes,
+        );
+        write_fixture(
+            &release_dir,
+            "runtime-overlay-aarch64.tar.gz.sha256",
+            format!(
+                "{}  runtime-overlay-aarch64.tar.gz\n",
+                sha256_hex(&archive_bytes)
+            )
+            .as_bytes(),
+        );
+
+        env.set(
+            "MVM_OVERLAY_BASE_URL",
+            format!("file://{}", upstream.path().display()),
+        );
+        env.remove(crate::release_signature::SKIP_COSIGN_VERIFY_ENV);
+
+        let cache = TempDir::new().unwrap();
+        let err = download_runtime_overlay("9.9.9", GuestArch::Aarch64, cache.path())
+            .expect_err("an unsigned overlay archive must not install");
+
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("signature") || rendered.contains("bundle"),
+            "the refusal must be about the signature: {rendered}"
+        );
+        assert!(
+            !cache.path().join("runtime-overlay/9.9.9/aarch64").exists(),
+            "a refused download must cache nothing"
         );
     }
 

--- a/crates/mvm-build/src/sdk_sidecar.rs
+++ b/crates/mvm-build/src/sdk_sidecar.rs
@@ -100,20 +100,25 @@ pub enum SdkSidecarBuildError {
 ///    fetched *before* the payload, so an artifact whose hash cannot be pinned
 ///    costs no bandwidth and reaches no disk.
 /// 2. The downloaded archive must hash to that digest.
-/// 3. Every archive member must be one of the three canonical files, named by a
+/// 3. The archive must verify against the release workflow's cosign-keyless
+///    signing identity — the digest alone authenticates the transport, not the
+///    publisher. Checked before extraction, so an unauthenticated tar is never
+///    parsed.
+/// 4. Every archive member must be one of the three canonical files, named by a
 ///    single unprefixed path component (no traversal, no absolute, no nesting),
 ///    and all three must be present.
-/// 4. The archive's own `checksums-sha256.txt` must agree with the bytes it
+/// 5. The archive's own `checksums-sha256.txt` must agree with the bytes it
 ///    carried.
-/// 5. The *installed* entry must satisfy [`SdkSidecarResolver::resolve`] — the
+/// 6. The *installed* entry must satisfy [`SdkSidecarResolver::resolve`] — the
 ///    same check the launch path runs — so a transport bug cannot produce a
 ///    cache entry that only fails later at boot.
 ///
-/// `MVM_SKIP_HASH_VERIFY=1` bypasses rung 2 only, and is the documented
-/// emergency-rotation escape shared with every other mvm downloader. Never set
-/// it in CI. The release base URL is the runtime overlay's
-/// (`MVM_OVERLAY_BASE_URL` overrides it for a private mirror or a test fixture)
-/// because both artifacts ship in the same release.
+/// `MVM_SKIP_HASH_VERIFY=1` bypasses rung 2 and `MVM_SKIP_COSIGN_VERIFY=1`
+/// bypasses rung 3; both are documented emergency-rotation escapes shared with
+/// every other mvm downloader, and neither is ever set in CI. The release base
+/// URL is the runtime overlay's (`MVM_OVERLAY_BASE_URL` overrides it for a
+/// private mirror or a test fixture) because both artifacts ship in the same
+/// release.
 pub fn download_sdk_sidecar(
     version: &str,
     arch: GuestArch,
@@ -135,6 +140,15 @@ pub fn download_sdk_sidecar(
         &archive_local,
         &names.archive,
         expected.get(&names.archive),
+    )?;
+    // Before extraction: an unauthenticated tar is never parsed.
+    crate::release_signature::verify_release_archive_signature(
+        &crate::release_signature::ReleaseSignatureRequest {
+            base_url: &base,
+            asset: &names.archive,
+            archive_path: &archive_local,
+            version,
+        },
     )?;
 
     let extracted = tmp.path().join("extracted");
@@ -416,12 +430,30 @@ mod tests {
     /// Point the downloader at a staged release directory and give it a cold
     /// cache root. The caller owns the `TestEnv` so its process-wide env lock
     /// spans the whole test, not just the download call.
+    ///
+    /// The signature rung is skipped here via its documented escape hatch: a
+    /// valid Sigstore signature cannot be minted offline, and these tests are
+    /// about the digest, extraction, and install rungs. The signature rung has
+    /// its own witnesses below and in [`crate::release_signature`].
     fn download_from(
         env: &mut TestEnv,
         fixture: &ReleaseFixture,
         cache: &Path,
     ) -> Result<SdkSidecarArtifact, String> {
         env.set("MVM_OVERLAY_BASE_URL", fixture.base_url());
+        env.set(crate::release_signature::SKIP_COSIGN_VERIFY_ENV, "1");
+        download_sdk_sidecar(FIXTURE_VERSION, GuestArch::host(), cache).map_err(|e| format!("{e}"))
+    }
+
+    /// Same, but with the signature rung live — so a test can prove the
+    /// download refuses an archive the release never signed.
+    fn download_with_signature_check(
+        env: &mut TestEnv,
+        fixture: &ReleaseFixture,
+        cache: &Path,
+    ) -> Result<SdkSidecarArtifact, String> {
+        env.set("MVM_OVERLAY_BASE_URL", fixture.base_url());
+        env.remove(crate::release_signature::SKIP_COSIGN_VERIFY_ENV);
         download_sdk_sidecar(FIXTURE_VERSION, GuestArch::host(), cache).map_err(|e| format!("{e}"))
     }
 
@@ -444,6 +476,53 @@ mod tests {
                 .is_err(),
             "a refused download must leave nothing the resolver accepts"
         );
+    }
+
+    /// The rung that matters most for an end user: a release that publishes an
+    /// archive with no signature beside it is refused, and nothing is cached —
+    /// even though the archive's digest matches what the release pinned.
+    #[test]
+    fn an_unsigned_release_archive_is_refused_and_caches_nothing() {
+        let mut env = TestEnv::new();
+        let cache = tempfile::tempdir().unwrap();
+        let fixture = ReleaseFixture::sound();
+
+        let err = download_with_signature_check(&mut env, &fixture, cache.path())
+            .expect_err("an unsigned archive must not install");
+
+        assert!(
+            err.contains("signature") || err.contains("bundle"),
+            "the refusal must be about the signature: {err}"
+        );
+        assert!(err.contains(&fixture.names.archive), "{err}");
+        assert_cache_holds_no_artifact(cache.path());
+    }
+
+    /// Ordering witness: the signature is checked before any tar member is
+    /// read. An archive that is both unsigned *and* full of hostile members
+    /// must fail on the signature — proving extraction never ran.
+    #[test]
+    fn the_signature_is_checked_before_the_archive_is_extracted() {
+        let mut env = TestEnv::new();
+        let cache = tempfile::tempdir().unwrap();
+        let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut tar = tar::Builder::new(encoder);
+        append_raw_named(&mut tar, "../escaped", b"payload");
+        let archive = tar.into_inner().unwrap().finish().unwrap();
+        let fixture = ReleaseFixture::stage(&archive, Some(&archive));
+
+        let err = download_with_signature_check(&mut env, &fixture, cache.path())
+            .expect_err("an unsigned archive must not be extracted at all");
+
+        assert!(
+            err.contains("signature") || err.contains("bundle"),
+            "extraction ran before the signature check: {err}"
+        );
+        assert!(
+            !err.contains("unsafe or unexpected path"),
+            "the tar was parsed before its signature was checked: {err}"
+        );
+        assert_cache_holds_no_artifact(cache.path());
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -566,6 +566,9 @@ mod sdk_sidecar_host_resolution_tests {
             "MVM_OVERLAY_BASE_URL",
             format!("file://{}", release_root.path().display()),
         );
+        // See the overlay test above: the signature rung is witnessed in
+        // `mvm_build::release_signature`, not here.
+        env.set(mvm_build::release_signature::SKIP_COSIGN_VERIFY_ENV, "1");
 
         let attached = resolve_sdk_sidecar_attachment_for_host(&[svc("host.audit.v1")])
             .expect("a published sidecar must satisfy the binding")
@@ -1036,6 +1039,10 @@ mod runtime_overlay_attach_tests {
         env.set("HOME", home.path());
         env.set("MVM_HOME", cache.path());
         env.set(RUNTIME_OVERLAY_ACQUIRE_MODE_ENV, "download");
+        // A valid Sigstore signature cannot be minted offline; this test is
+        // about the acquire ladder's cache/install rungs. The signature rung
+        // has its own witnesses in `mvm_build::release_signature`.
+        env.set(mvm_build::release_signature::SKIP_COSIGN_VERIFY_ENV, "1");
 
         let release_root = tempfile::tempdir().unwrap();
         let version = env!("CARGO_PKG_VERSION");

--- a/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
+++ b/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
@@ -175,6 +175,10 @@ fn acquire_sidecar_from_release(world: &mut CliWorld) {
     // download and cannot stall a concurrently-running scenario.
     let mut env = mvm_core::util::test_env::TestEnv::new();
     env.set("MVM_OVERLAY_BASE_URL", format!("file://{}", base.display()));
+    // The scenario is the acquire-and-boot workflow; a valid Sigstore
+    // signature cannot be minted offline, so the signature rung is exercised
+    // by `mvm_build::release_signature`'s own witnesses instead.
+    env.set(mvm_build::release_signature::SKIP_COSIGN_VERIFY_ENV, "1");
 
     world.sdk_sidecar_result = Some(
         mvm_build::sdk_sidecar::download_sdk_sidecar(FIXTURE_VERSION, GuestArch::host(), &cache)

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -867,7 +867,7 @@ All commands accept these global options:
 | `MVM_MCP_MAX_INFLIGHT` | Max concurrent in-flight `tools/call run` invocations | `8` |
 | `MVM_MCP_MEM_CEILING_MIB` | Per-call memory ceiling enforced before dispatching to a microVM | `8192` |
 | `MVM_TENANT_KEY_<ID>` | Compatibility hook for tenant-scoped key material consumed by shared policy/keystore primitives. Fleet operators should configure tenant keys through `mvmd`. | None |
-| `MVM_SKIP_COSIGN_VERIFY` | Set to `1` to bypass cosign signature verification on prebuilt-image downloads. Documented escape hatch only; never set in CI or production. | Unset |
+| `MVM_SKIP_COSIGN_VERIFY` | Set to `1` to bypass cosign signature verification on prebuilt-image downloads and on the runtime-overlay / SDK-sidecar release archives. Documented emergency-rotation escape only; never set in CI or production. | Unset |
 | `MVM_SKIP_HASH_VERIFY` | Set to `1` to bypass SHA-256 verification on prebuilt-image downloads. Documented escape hatch only; never set in CI or production. | Unset |
 | `MVM_OVERLAY_BASE_URL` | Release base URL the runtime overlay **and** the SDK sidecar are fetched from (both ship in the same release). Point it at a private mirror; `/v<version>` is appended for you. | GitHub Releases |
 | `MVM_RUNTIME_OVERLAY_ACQUIRE_MODE` | `build` or `download` — force how a cold cache is populated for the runtime overlay and the SDK sidecar alike, instead of auto-detecting from whether this is a source checkout. | Auto-detect |

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-07-30
+Last updated: 2026-07-31
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -25,6 +25,16 @@ for detailed scope and acceptance criteria.
         archive-entry validator
   - [x] Reach it from the launch path on the download-mode acquire path; a
         source checkout keeps the fail-closed refusal
+
+- [x] Plan 277 — release-artifact signature verification
+  (`specs/plans/277-release-artifact-signature-verification.md`)
+  - [x] Sign the image tarballs with `--new-bundle-format`, the only shape the
+        in-binary Rust verifier parses; binary tarballs stay legacy for the
+        cosign-CLI consumers (`install.sh`, `mvmctl update`)
+  - [x] `mvm_build::release_signature` — fetch the bundle, verify against the
+        versioned release identity, fail closed with no digest-only downgrade
+  - [x] Wire the rung into both download paths, before extraction
+  - [x] Docs + rollup; closes plan 273's one deferred gap
 
 - [x] Plan 266 — lightweight microVM guest
   (`specs/plans/266-lightweight-microvm-guest.md`)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -213,6 +213,23 @@
       constructor that requests them. 10 downloader unit tests, 5 launch-path
       tests, 4 release-asset gates, and 2 BDD scenarios (acquire-and-boot,
       checksum-drift refusal), taking the BDD suite to 57 scenarios / 279 steps.
+- [x] Plan 277 — cosign-verify the downloaded runtime overlay and SDK sidecar.
+      Closes plan 273's one deferred gap. Both archives are now verified against
+      the release workflow's cosign-keyless signing identity before extraction,
+      through `mvm_core::crypto::image_verify` and the existing
+      `release_trust` root — no new dependency. Two findings shaped it: the
+      published `*.tar.gz.bundle` files are in the legacy cosign format the
+      in-binary Rust verifier *rejects*, so `release.yml`'s signing step is
+      split (binary tarballs keep legacy for the cosign-CLI consumers,
+      image tarballs move to `--new-bundle-format`); and no released version has
+      ever shipped a runtime-overlay tarball, so mandatory verification costs
+      zero compatibility. Fails closed: a build without `manifest-verify`
+      refuses the download rather than downgrading to digest-only, and
+      `MVM_SKIP_COSIGN_VERIFY` — documented but until now never read by any
+      code — is the emergency escape. Drive-by: made
+      `initramfs::resolve_returns_missing_when_cache_empty` hermetic; it read
+      the developer's real `$HOME` cache and failed on any machine that had
+      built an initramfs.
 - [x] Lightweight guest WS-2: replace the static util-linux privilege-drop
       binary with the dedicated static-musl `mvm-setpriv` helper, including
       UID/GID, group, no-new-privileges, and optional loopback capability paths.

--- a/specs/adrs/018-mvm-runtime-overlay-disk.md
+++ b/specs/adrs/018-mvm-runtime-overlay-disk.md
@@ -92,9 +92,14 @@ roothash reaches the guest, and a malicious host is out of scope by ADR-001.
 A source checkout builds it (`nix build
 ./nix/images/runtime-overlay#sdk-sidecar-image`); a downloaded `mvmctl` fetches
 the per-arch `sdk-sidecar-<arch>.tar.gz` published beside the overlay's tarball
-in the same release, verifies it against the release's `.sha256` sidecar and
-then against the archive's own `checksums-sha256.txt`, and installs it
-stage-then-rename so a crash can never leave a half-written cache entry. The
+in the same release, verifies it against the release's `.sha256` sidecar, then
+against the release workflow's cosign-keyless signing identity, then against the
+archive's own `checksums-sha256.txt`, and installs it stage-then-rename so a
+crash can never leave a half-written cache entry. The signature rung is what
+authenticates the *publisher* rather than the transport — a digest fetched over
+the same channel as the archive is served by whoever serves the archive — and it
+is checked before extraction, so an unauthenticated tar is never parsed. Both
+artifacts carry it, since both become code inside the guest. The
 build-vs-download choice is the overlay's — one resolver, so a contributor whose
 overlay is source-built never silently downloads a sidecar. The download ends
 with a `SdkSidecarResolver::resolve` against the *installed* entry, which is the

--- a/specs/plans/273-sdk-sidecar-release-acquisition.md
+++ b/specs/plans/273-sdk-sidecar-release-acquisition.md
@@ -118,7 +118,7 @@ Add a scenario to `features/suites/s21_host_services/sdk_sidecar_attachment.feat
 
 ## Deferred follow-ups (not built in this plan)
 
-- **Cosign-verified sidecar.** The overlay's artifacts are sha256-pinned but not signature-verified at fetch. Extending the `manifest-verify` cosign path to both the overlay and the sidecar is one workstream covering both, and should not be bolted onto the sidecar alone.
+- **Cosign-verified sidecar.** ~~The overlay's artifacts are sha256-pinned but not signature-verified at fetch.~~ **Closed by `specs/plans/277-release-artifact-signature-verification.md`** — the overlay and the sidecar are both verified against the release workflow's keyless signing identity before extraction, as one workstream covering both.
 - **Sidecar closure minimization.** The 8 MiB allocation is a fixed cap, not a measured floor; the loader + `libc.so.6` + `libgcc_s.so.1` + the cdylib have not been closure-audited the way the base rootfs was. Worth a measurement pass before the cap is treated as tight.
 
 ## Self-review

--- a/specs/plans/277-release-artifact-signature-verification.md
+++ b/specs/plans/277-release-artifact-signature-verification.md
@@ -1,0 +1,123 @@
+# Plan 277 — Cosign-verify the downloaded runtime overlay and SDK sidecar
+
+**Status: COMPLETE**
+
+Follow-on to plan 273. That plan closed the *acquisition* gap — an installed
+`mvmctl` can now fetch a published SDK sidecar instead of refusing — and left
+one gap open explicitly: the fetched archive is sha256-pinned but not
+signature-verified. This plan closes it, for the runtime overlay and the SDK
+sidecar together, because they share one transport and have the identical hole.
+
+## Why sha256 alone is not enough
+
+The digest an installed binary checks against comes from
+`<asset>.tar.gz.sha256`, fetched over HTTPS from the same base URL as the
+archive. That authenticates the *transport*, not the *publisher*. Anyone who
+controls what that base URL serves — a private mirror set through
+`MVM_OVERLAY_BASE_URL`, a compromised release, a hijacked CDN edge — serves a
+matching pair and the check passes. The archive then becomes the guest's
+`/mvm/runtime` (every workload) or `/mvm/sdk` cdylib (any workload bound to an
+SDK-served host service), which is arbitrary code inside the sandbox.
+
+The project already has the primitive that closes this: the release workflow
+cosign-keyless-signs its blobs, and `mvm_core::crypto::image_verify::
+verify_signed_payload` verifies a Sigstore bundle against an embedded trust
+root, offline, with no new dependency. It simply was never pointed at these two
+artifacts.
+
+## Two findings that shape the work
+
+**1. The published bundles are in the wrong format.** `release.yml` signs
+`artifacts/*.tar.gz` with plain `--bundle` (the legacy shape). The workflow's
+own comments record that the in-binary Rust verifier *rejects* that shape and
+requires `--new-bundle-format`; every artifact that stack already verifies (dev
+image manifests, packs, revocation lists) is signed that way. Pointing the
+verifier at today's `runtime-overlay-<arch>.tar.gz.bundle` would fail to parse
+100% of the time.
+
+The legacy bundles cannot simply be switched wholesale: `mvmctl-*.tar.gz.bundle`
+is consumed by the **cosign CLI** (`install.sh`, and `mvmctl update`, which
+shells out to `cosign verify-blob`), which reads both shapes. So the binary
+tarballs keep the legacy format and the image tarballs move to the new one.
+
+**2. Nothing is at risk of breaking.** The latest release (v0.17.0) publishes
+the runtime overlay as *loose files* (`.ext4`/`.verity`/`.roothash`/`.VERSION`),
+not as a tarball at all — the tarball transport post-dates it, and no published
+release has ever carried a `runtime-overlay-*.tar.gz` or a `sdk-sidecar-*.tar.gz`.
+There is therefore no working download to regress, and mandatory verification
+costs zero compatibility if it lands before the first release that ships the
+tarballs. That is now.
+
+## Decision: fail closed, both artifacts, no degraded acquire
+
+An archive whose signature cannot be verified is not installed. This matches the
+posture the rest of the project already takes (`Users opt out of security, never
+opt in`) and the discipline plan 273 established for the sidecar.
+
+Concretely that means a build without `mvm-core/manifest-verify` refuses to
+*download* an overlay or sidecar. Released binaries are built
+`--features host,user,...` and `user` enables `manifest-verify`, so every binary
+an end user actually downloads can verify. A default-feature contributor build
+resolves these artifacts by *building* them, not downloading; a contributor who
+deliberately forces the download path (`MVM_RUNTIME_OVERLAY_ACQUIRE_MODE=download`)
+gets a refusal naming both fixes. `MVM_SKIP_COSIGN_VERIFY=1` remains the
+documented emergency-rotation escape, never set in CI.
+
+Note the escape hatch is currently documented but not read anywhere in code —
+this plan is what makes it real, mirroring how `MVM_SKIP_HASH_VERIFY` is
+honored by `verify_file_sha256`.
+
+## Where the rung sits in the ladder
+
+Plan 273's ladder gains one rung, placed after the digest check and **before any
+extraction**, so an unauthenticated tar is never parsed:
+
+1. Archive checksum sidecar pre-commits the digest (fetched before the payload)
+2. Archive hashes to that digest
+3. **Archive verifies against the release-signing identity** ← new
+4. Every archive member is allow-listed and present
+5. The archive's own manifest agrees with the extracted bytes
+6. The installed entry satisfies the resolver
+
+## Tasks
+
+- [x] **Task 1 — Sign the image tarballs in the format the verifier parses.**
+  Split `release.yml`'s signing step: binary tarballs keep legacy `--bundle`
+  (cosign-CLI consumers), image tarballs get `--new-bundle-format`. Attach
+  `runtime-overlay-*.tar.gz.bundle` / `sdk-sidecar-*.tar.gz.bundle` to the
+  release. Extend `tests/release_assets.rs` to pin the bundle asset names and
+  assert the image tarballs are signed in the new format — the failure mode is
+  invisible until a real download, so it needs a static witness.
+
+- [x] **Task 2 — `mvm_build::release_signature`.** One helper both downloaders
+  call: fetch `<asset>.bundle`, verify the local archive bytes against every
+  `release_trust::accepted_release_identities(version)` candidate under
+  `RELEASE_OIDC_ISSUER`, honor `MVM_SKIP_COSIGN_VERIFY`. Reuses `curl_download`
+  and the existing `verify_signed_payload` primitive — no new dependency, no
+  second downloader. Typed refusals that name the asset and never echo bundle
+  bytes.
+
+- [x] **Task 3 — Wire it into both download paths** at rung 3, before
+  extraction, so a refusal leaves nothing in the cache.
+
+- [x] **Task 4 — Docs + rollup.** ADR-018's acquisition paragraph, the
+  `MVM_SKIP_COSIGN_VERIFY` env-var row (scope it to what now honors it), plan
+  273's deferred-gap note, `specs/SPRINT.md`, `specs/REFACTOR-STATUS.md`.
+
+## Test contract
+
+- A missing `.bundle` refuses **before** extraction and caches nothing.
+- A malformed/garbage bundle refuses (discriminating only under
+  `manifest-verify`, so that case runs feature-gated — a test that cannot tell a
+  bad signature from a disabled verifier is not a witness).
+- The refusal names the asset and carries no bundle bytes.
+- `MVM_SKIP_COSIGN_VERIFY=1` admits, and logs that it did.
+- A build without `manifest-verify` refuses the download with a message naming
+  both remedies.
+- The ordering witness: signature is checked before any tar member is read.
+
+Offline tests cannot mint a *valid* Sigstore signature — that needs Fulcio and
+Rekor — so the positive path is exercised with the documented skip hatch and the
+real signature check is witnessed in the rejecting direction plus the existing
+`pack-signing-smoke.yml` lane, which already round-trips a genuine keyless
+signature through this same verifier.

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -80,6 +80,70 @@ fn the_release_job_attaches_the_sdk_sidecar_assets() {
     }
 }
 
+/// The downloader fetches `<asset>.bundle`; the release has to attach it under
+/// exactly that name or every download refuses as unsigned.
+#[test]
+fn release_attaches_the_signature_bundle_the_verifier_fetches() {
+    let workflow = release_workflow();
+    let sidecar = mvmctl::build::sdk_sidecar::SdkSidecarArtifactNames::for_arch("*");
+    let overlay = mvmctl::build::runtime_overlay::RuntimeOverlayArtifactNames::for_arch("*");
+    for asset in [sidecar.archive, overlay.archive] {
+        let bundle = mvmctl::build::release_signature::bundle_asset_name(&asset);
+        assert!(
+            workflow.contains(&format!("artifacts/{bundle}")),
+            "the release job's asset list must attach {bundle:?}"
+        );
+    }
+}
+
+/// The image tarballs must be signed with `--new-bundle-format`. The in-binary
+/// Rust verifier parses only that shape; a legacy `--bundle` here fails to
+/// parse on every download, and nothing would catch it until a real release
+/// shipped. The binary tarballs must NOT move — those are read by the cosign
+/// CLI (`install.sh`, `mvmctl update`), which wants the legacy shape.
+#[test]
+fn image_tarballs_are_signed_in_the_format_the_in_binary_verifier_parses() {
+    let workflow = release_workflow();
+    let step = workflow
+        .split("- name: Sign release tarballs and SBOM")
+        .nth(1)
+        .expect("release.yml must define the tarball signing step");
+    let step = step
+        .split("\n      - name:")
+        .next()
+        .expect("the signing step is non-empty");
+
+    let image_sign = step
+        .split("for tarball in artifacts/runtime-overlay-*.tar.gz artifacts/sdk-sidecar-*.tar.gz")
+        .nth(1)
+        .expect("the image tarballs must be signed by their own loop")
+        .split("done")
+        .next()
+        .expect("the image signing loop is non-empty");
+    assert!(
+        image_sign.contains("--new-bundle-format"),
+        "image tarballs must be signed with --new-bundle-format: {image_sign}"
+    );
+
+    // The generic loop produces the cosign-CLI-consumed bundles, so it must
+    // skip the image tarballs rather than double-signing them legacy.
+    let generic_sign = step
+        .split("for tarball in artifacts/*.tar.gz")
+        .nth(1)
+        .expect("the binary tarballs keep their own loop")
+        .split("done")
+        .next()
+        .expect("the generic signing loop is non-empty");
+    assert!(
+        generic_sign.contains("runtime-overlay-*|sdk-sidecar-*"),
+        "the legacy-format loop must skip the image tarballs: {generic_sign}"
+    );
+    assert!(
+        !generic_sign.contains("--new-bundle-format"),
+        "the cosign-CLI-consumed bundles must stay on the legacy format"
+    );
+}
+
 /// Both published architectures must be built, or a whole platform's users get
 /// the fail-closed refusal this artifact exists to prevent.
 #[test]


### PR DESCRIPTION
Closes the one gap #1954 left open. Plan: `specs/plans/277-release-artifact-signature-verification.md`.

## The gap

A fetched overlay/sidecar archive was sha256-pinned but not signature-verified. The digest comes from a `.sha256` fetched over the same channel as the archive, so it authenticates the **transport, not the publisher** — whoever controls what the base URL serves serves a matching pair. Since these archives become the guest's `/mvm/runtime` (every workload) and its `/mvm/sdk` cdylib (any workload bound to an SDK-served host service), that is arbitrary code inside the sandbox.

New `mvm_build::release_signature` verifies every downloaded release archive against the release workflow's cosign-keyless signing identity, reusing `mvm_core::crypto::image_verify::verify_signed_payload` and the existing `release_trust` root. **No new dependency** — the sigstore stack was already in the graph behind `manifest-verify`; it just was never pointed at these two artifacts.

## Two findings worth reviewing carefully

**The published bundles were in the wrong format.** `release.yml` signed `artifacts/*.tar.gz` with legacy `--bundle`. The workflow's own comments record that the in-binary Rust verifier *rejects* that shape and requires `--new-bundle-format` — every artifact that stack already verifies (image manifests, packs, revocation lists) is signed that way. Pointing the verifier at today's bundles would have failed to parse on **every** download.

They can't be switched wholesale: `mvmctl-*.tar.gz.bundle` is consumed by the **cosign CLI** (`install.sh`, and `mvmctl update`, which shells out to `cosign verify-blob`), which reads both shapes. So the signing step is split — binary tarballs keep legacy, image tarballs move to the new format. `tests/release_assets.rs` pins the split in both directions, because this failure mode is invisible until a real release ships.

**Nothing is at risk of breaking.** v0.17.0 publishes the overlay as *loose files* (`.ext4`/`.verity`/`.roothash`/`.VERSION`) — no published release has ever carried a `runtime-overlay-*.tar.gz` or a `sdk-sidecar-*.tar.gz`. There is no working download to regress, so mandatory verification costs zero compatibility if it lands before the first release that ships the tarballs. That is now.

## Decision: fail closed

A missing bundle, an unparseable bundle, a signature outside the accepted identity set, or a build compiled without `manifest-verify` all refuse the install. There is no downgrade to the digest-only posture this rung replaces.

Released binaries build `--features host,user,...` and `user` enables `manifest-verify`, so every binary that actually downloads can verify. A default-feature contributor build resolves these artifacts by *building* them; a contributor who forces `MVM_RUNTIME_OVERLAY_ACQUIRE_MODE=download` gets a refusal naming both remedies. `MVM_SKIP_COSIGN_VERIFY` — documented in the CLI reference but until now **read by no code** — becomes the real emergency-rotation escape.

## The ladder, one rung longer

| # | Rung | Fires in |
|---|---|---|
| 1 | `.sha256` pre-commits the digest, fetched before the payload | `fetch_expected_hashes` |
| 2 | Archive hashes to that digest | `verify_file_sha256` |
| 3 | **Archive verifies against the release signing identity** | `verify_release_archive_signature` ← new |
| 4 | Every member allow-listed and present | `extract_release_archive` |
| 5 | Archive's own manifest agrees with extracted bytes | `verify_*_dir_integrity` |
| 6 | Installed entry satisfies the resolver | end of each downloader |

Rung 3 sits **before extraction**, so an unauthenticated tar is never parsed.

## Tests

- **5 signature-rung units.** Two are feature-split on purpose: the "malformed bundle is refused" case only runs under `manifest-verify`, because without it every bundle fails identically and the assertion couldn't tell a bad signature from a disabled verifier — that isn't a witness. The complementary case asserts a non-verifying build refuses and names both remedies.
- **Ordering witness.** Feeds the download an unsigned archive full of traversal entries and asserts it fails on the *signature*, not on the tar — proving extraction never ran.
- **Unsigned-archive refusals** on both the sidecar and overlay download paths, each asserting nothing lands in the cache.
- **2 release-asset gates** pinning the bundle asset name to `bundle_asset_name()` and the new-format split.

Offline tests can't mint a *valid* Sigstore signature (that needs Fulcio + Rekor), so the positive path uses the documented skip hatch and the real check is witnessed in the rejecting direction. A genuine keyless signature already round-trips through this same verifier in the existing `pack-signing-smoke.yml` lane.

## Drive-by, flagged

`initramfs::resolve_returns_missing_when_cache_empty` was not hermetic: it asserted an empty cache while the resolver seeded from the real `$HOME/.mvm/cache`, so it passed in CI's fresh `$HOME` and failed on any machine that had built an initramfs. Verified pre-existing on clean `main` before touching it. Now uses `TestEnv::isolate_mvm_home`. It's outside the stated scope but it blocked running this crate's suite locally.

## Gates run locally

- nightly `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`, default **and** `--all-features`, plus the BDD conformance target
- `cargo nextest run --workspace --no-fail-fast -j 6` — 8365/8372. The 7 failures are known parallelism flakes (`entrypoint_execute` ×5, `host_agent_restart` ×2, all uniform ~5s/~10s timings) in crates this doesn't touch; all pass in isolation.
- `cargo test --workspace --doc`
- BDD: 59 scenarios / 293 steps, all passing
- All **40** xtask gates in ci.yml's Lint job, plus the `verify-release-assets` pack-gate (11 passed)

Nix correctness remains CI-only here (the runtime-overlay flake's workspace path sits outside its flake root, so `pkgs.closureInfo` can't be instantiated under a pure local `nix flake check`). I have not observed a local green for the flake and am not claiming one.