### PR TITLE
fix(cache): let the universal-initramfs cache see guest source changes

### DIFF
--- a/crates/mvm-build/src/initramfs.rs
+++ b/crates/mvm-build/src/initramfs.rs
@@ -64,6 +64,69 @@ pub enum InitramfsBuildError {
 /// the default cache's artifact and retry once. A default-cache miss surfaces
 /// the original resolve error unchanged. This is still a pure cache operation —
 /// no build, no download.
+/// Name of the source-fingerprint file recorded beside a cached initramfs.
+///
+/// The cache key is otherwise `(version, arch)`, and the version only moves on a
+/// release. That makes a locally built artifact outlive every change to the guest
+/// sources it was built from: a fix lands, the cache still serves the binary from
+/// before it, and the fix looks like it did not work. The runtime overlay and the
+/// verity initramfs both record a fingerprint for exactly this reason; this one
+/// did not, which is how an agent built before its own trust-anchor fix kept
+/// being booted afterwards.
+pub const LOCAL_SOURCE_FINGERPRINT_FILE: &str = "SOURCE_FINGERPRINT";
+
+/// Whether a cached artifact was built from `fingerprint`.
+///
+/// A cache with no fingerprint recorded is *not* fresh for a source checkout:
+/// it predates this check and there is no way to tell what built it.
+fn cached_artifact_matches_source(
+    cache_root: &Path,
+    version: &str,
+    arch: GuestArch,
+    fingerprint: &str,
+) -> bool {
+    let recorded = cache_root
+        .join(version)
+        .join(arch.to_string())
+        .join(LOCAL_SOURCE_FINGERPRINT_FILE);
+    std::fs::read_to_string(recorded)
+        .map(|found| found.trim() == fingerprint.trim())
+        .unwrap_or(false)
+}
+
+/// Record the fingerprint an artifact was built from.
+pub fn record_source_fingerprint(
+    cache_root: &Path,
+    version: &str,
+    arch: GuestArch,
+    fingerprint: &str,
+) -> std::io::Result<()> {
+    let dir = cache_root.join(version).join(arch.to_string());
+    std::fs::create_dir_all(&dir)?;
+    std::fs::write(dir.join(LOCAL_SOURCE_FINGERPRINT_FILE), fingerprint)
+}
+
+/// Discard a cached artifact that a source checkout did not build.
+///
+/// Removing rather than ignoring it, so the next resolve takes the build or
+/// download path instead of finding the same stale bytes again.
+pub fn evict_if_source_changed(
+    cache_root: &Path,
+    version: &str,
+    arch: GuestArch,
+    fingerprint: &str,
+) -> std::io::Result<bool> {
+    if cached_artifact_matches_source(cache_root, version, arch, fingerprint) {
+        return Ok(false);
+    }
+    let dir = cache_root.join(version).join(arch.to_string());
+    if !dir.exists() {
+        return Ok(false);
+    }
+    std::fs::remove_dir_all(&dir)?;
+    Ok(true)
+}
+
 pub fn resolve_or_seed_from_default_cache(
     cache_root: &Path,
     version: &str,
@@ -566,6 +629,80 @@ mod tests {
 
     static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    /// The defect this closes: the cache key is `(version, arch)` and the
+    /// version only moves on a release, so an artifact built from older guest
+    /// sources outlives every change to them. A guest-side fix lands, the cache
+    /// still serves the binary from before it, and the fix looks inert — which
+    /// is exactly how an agent built before its own trust-anchor fix kept being
+    /// booted afterwards.
+    #[test]
+    fn a_cached_artifact_from_other_sources_is_evicted() {
+        let cache = tempfile::tempdir().unwrap();
+        let dir = cache.path().join("0.18.0").join("aarch64");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("initramfs.cpio.gz"), b"stale").unwrap();
+        record_source_fingerprint(cache.path(), "0.18.0", GuestArch::Aarch64, "old-sources")
+            .unwrap();
+
+        let evicted =
+            evict_if_source_changed(cache.path(), "0.18.0", GuestArch::Aarch64, "new-sources")
+                .unwrap();
+        assert!(
+            evicted,
+            "a mismatched fingerprint must discard the artifact"
+        );
+        assert!(
+            !dir.exists(),
+            "the stale artifact must be gone, not merely ignored"
+        );
+    }
+
+    /// The matching case must not churn: rebuilding a correct artifact on every
+    /// boot would be its own bug.
+    #[test]
+    fn a_cached_artifact_from_the_same_sources_is_kept() {
+        let cache = tempfile::tempdir().unwrap();
+        let dir = cache.path().join("0.18.0").join("aarch64");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("initramfs.cpio.gz"), b"fresh").unwrap();
+        record_source_fingerprint(cache.path(), "0.18.0", GuestArch::Aarch64, "same").unwrap();
+
+        let evicted =
+            evict_if_source_changed(cache.path(), "0.18.0", GuestArch::Aarch64, "same").unwrap();
+        assert!(!evicted);
+        assert!(dir.join("initramfs.cpio.gz").is_file());
+    }
+
+    /// An artifact with no fingerprint recorded predates this check, so nothing
+    /// can vouch for what built it. Treating it as fresh is what let the stale
+    /// one survive in the first place.
+    #[test]
+    fn an_unfingerprinted_artifact_is_not_trusted() {
+        let cache = tempfile::tempdir().unwrap();
+        let dir = cache.path().join("0.18.0").join("aarch64");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("initramfs.cpio.gz"), b"unknown provenance").unwrap();
+
+        let evicted =
+            evict_if_source_changed(cache.path(), "0.18.0", GuestArch::Aarch64, "any").unwrap();
+        assert!(
+            evicted,
+            "an artifact of unknown provenance must not be reused"
+        );
+    }
+
+    /// Resolution reports "missing" when the cache is genuinely empty.
+    ///
+    /// Two isolations are load-bearing. `HOME` moves because the resolver falls
+    /// back to `default_mvm_cache_dir`, the one resolver that reads `$HOME` even
+    /// when `MVM_HOME` is set, and would otherwise seed this tempdir from the
+    /// developer's real cache — asserting "empty" against a machine-dependent
+    /// fact. And this exercises the *resolver*, not
+    /// `resolve_or_build_local_initramfs`, whose empty-cache path on Linux falls
+    /// through to a real `nix build`: with a no-op shell that build reports
+    /// success without producing anything and the call never returns. Left that
+    /// way the test passed on Linux only by finding an artifact it was supposed
+    /// to prove absent, and hung for hours once it genuinely could not.
     #[test]
     fn resolve_returns_missing_when_cache_empty() {
         let dir = tempfile::tempdir().unwrap();
@@ -573,34 +710,27 @@ mod tests {
         // `$HOME/.mvm/cache`, so without this the assertion holds only on a
         // machine that has never built an initramfs — which CI is and a
         // contributor's laptop is not.
+        //
+        // And this exercises the *resolver* rather than
+        // `resolve_or_build_local_initramfs`, whose empty-cache path on Linux
+        // falls through to a real `nix build`. With a shell double that reports
+        // success without producing an artifact, that call never returns: the
+        // test ran for 20,000+ seconds in CI and took the job to its six-hour
+        // limit. Isolating HOME is what made it reachable — before that the test
+        // passed on Linux by finding an artifact it was supposed to prove absent.
         let _lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let mut env = TestEnv::new();
         env.isolate_mvm_home(dir.path());
         let cache = dir.path().join("cache");
-        let err =
-            resolve_or_build_local_initramfs(&NoopShell, &cache, "0.18.0", GuestArch::Aarch64)
-                .unwrap_err();
-        assert!(!format!("{err}").is_empty());
-    }
-
-    struct NoopShell;
-
-    impl ShellEnvironment for NoopShell {
-        fn shell_exec(&self, _script: &str) -> anyhow::Result<()> {
-            Ok(())
-        }
-
-        fn shell_exec_stdout(&self, _script: &str) -> anyhow::Result<String> {
-            Ok(String::new())
-        }
-
-        fn shell_exec_visible(&self, _script: &str) -> anyhow::Result<()> {
-            Ok(())
-        }
-
-        fn log_info(&self, _msg: &str) {}
-
-        fn log_success(&self, _msg: &str) {}
+        let err = resolve_or_seed_from_default_cache(&cache, "0.18.0", GuestArch::Aarch64)
+            .expect_err("an empty cache with nothing to seed from must resolve as missing");
+        assert!(
+            matches!(
+                err,
+                InitramfsBuildError::Resolve(mvm_fs::initramfs::InitramfsError::Missing(_))
+            ),
+            "expected a Missing resolution, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -296,8 +296,41 @@ pub(crate) fn attach_universal_initramfs_if_cached(
     let cache_root = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("initramfs");
     let arch = mvm_core::arch::GuestArch::host();
     let env = HostShellEnvironment;
+    // A source checkout rebuilds its guest binaries when they change, but the
+    // initramfs cache is keyed only on `(version, arch)` — so without this it
+    // keeps serving the artifact built before the change, and a guest-side fix
+    // appears not to have worked. Evicting on a fingerprint mismatch is what
+    // makes the next resolve rebuild rather than re-find the stale bytes.
+    if let Some(workspace_root) =
+        crate::commands::runtime_overlay::runtime_overlay_source_checkout_root()
+        && let Ok(fingerprint) =
+            mvm_build::guest_agent_build::runtime_overlay_source_checkout_fingerprint(
+                &workspace_root,
+            )
+        && let Ok(true) =
+            mvm_build::initramfs::evict_if_source_changed(&cache_root, version, arch, &fingerprint)
+    {
+        tracing::info!(
+            initramfs_version = version,
+            "guest sources changed since the cached universal initramfs was built; discarded it"
+        );
+    }
     match mvm_build::initramfs::resolve_or_build_local_initramfs(&env, &cache_root, version, arch) {
         Ok(artifact) => {
+            if let Some(workspace_root) =
+                crate::commands::runtime_overlay::runtime_overlay_source_checkout_root()
+                && let Ok(fingerprint) =
+                    mvm_build::guest_agent_build::runtime_overlay_source_checkout_fingerprint(
+                        &workspace_root,
+                    )
+            {
+                let _ = mvm_build::initramfs::record_source_fingerprint(
+                    &cache_root,
+                    version,
+                    arch,
+                    &fingerprint,
+                );
+            }
             start_config.initrd_path = Some(artifact.image_path.display().to_string());
             tracing::info!(
                 initramfs_version = version,
@@ -1355,6 +1388,25 @@ mod universal_initramfs_attach_tests {
         let cache_root = dir.path().join("cache").join("initramfs");
         mvm_build::initramfs::install_initramfs_into_cache(&source, &cache_root, version, arch)
             .unwrap();
+        // A warm cache in a source checkout has to say what built it. Without a
+        // fingerprint the artifact is of unknown provenance and is discarded —
+        // which is the whole point of the eviction, and would make this fixture
+        // describe a cache the attach path is right to refuse.
+        if let Some(workspace_root) =
+            crate::commands::runtime_overlay::runtime_overlay_source_checkout_root()
+            && let Ok(fingerprint) =
+                mvm_build::guest_agent_build::runtime_overlay_source_checkout_fingerprint(
+                    &workspace_root,
+                )
+        {
+            mvm_build::initramfs::record_source_fingerprint(
+                &cache_root,
+                version,
+                arch,
+                &fingerprint,
+            )
+            .unwrap();
+        }
 
         let mut sc = VmStartConfig::default();
         attach_universal_initramfs_if_cached(&mut sc).unwrap();

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -840,6 +840,46 @@ status line and discards the body, so a wget user still needs the host log
 (`/tmp/mvm-substitution-endpoint-<vm>.log`). Surfacing a failed run's egress
 denials through `mvmctl` itself is the follow-up.
 
+### The universal-initramfs cache could not see source fixes
+
+A boot that attached the universal initramfs died at its first RPC with
+`send ActivateEnvironment to guest: Failed to read frame length`, and the guest
+console said `rejecting control connection without a pinned host key` — the
+symptom #1959 had already fixed.
+
+It kept happening because the cache could not see that fix.
+`<cache>/initramfs/<version>/<arch>/` is keyed on a version that only moves at
+release, so an artifact built from older guest sources outlives every change to
+them: the fix lands, the cache still serves the binary from before it, and the
+fix looks inert. The runtime overlay and the verity initramfs both record a
+`SOURCE_FINGERPRINT` for this reason; this one did not. It does now — a mismatch
+**evicts** rather than ignores, so the next resolve rebuilds instead of
+re-finding the same bytes, and an artifact with no fingerprint is treated as
+unknown provenance rather than assumed fresh. Trusting those is what let the
+stale one survive.
+
+The activation race underneath — `activate_workload` sending before the agent
+had bound its port — was fixed independently on main by #1985 while this was in
+review, so only the cache work remains here.
+
+Live on macOS: the stale artifact is discarded, the host falls back to the legacy
+initramfs (macOS cannot build the universal one), and the workload runs. A
+working universal-initramfs boot is **not** verified here — this host cannot
+produce the artifact, so what is proven is the eviction and the fallback.
+
+`initramfs::tests::resolve_returns_missing_when_cache_empty` is also fixed. Its
+`HOME` isolation had made it genuinely hermetic, which exposed what that was
+hiding: on Linux the empty-cache path falls through to a real `nix build`, and
+with a shell double that reports success without producing an artifact the call
+never returns. It ran for 20,000+ seconds and took a CI job to its six-hour
+limit. It had been passing on Linux only by finding an artifact it was supposed
+to prove absent. It now exercises `resolve_or_seed_from_default_cache`, whose
+contract is the one the name claims, and completes in milliseconds.
+
+That a shell double reporting success can make the nix path hang rather than
+error is worth closing separately: a build producing no artifact should fail,
+not wait.
+
 HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214; Plan 270 designs for HVF but does not duplicate that work. Plan 268 (`specs/plans/268-backend-shim-removal.md`) stays a separate future workstream and is not absorbed here.
 
 ### Deferred: a dry run should not require a bootable backend


### PR DESCRIPTION
Main gained the activation-readiness retry in #1985 while this was in review, so
this PR is now just the cache defect underneath it — and one CI landmine.

## The cache could not see a fix that had already landed

A boot attaching the universal initramfs died at its first RPC, with the guest
console saying `rejecting control connection without a pinned host key` — the
symptom #1959 already fixed.

`<cache>/initramfs/<version>/<arch>/` is keyed on a version that only moves at
release, so an artifact built from older guest sources outlives every change to
them. A fix lands, the cache still serves the binary from before it, and the fix
looks inert. Here an artifact built *minutes* before #1959 kept being booted for
hours afterwards.

The runtime overlay and the verity initramfs both record a `SOURCE_FINGERPRINT`
for exactly this reason. This cache now does too: a mismatch **evicts** rather
than ignores, so the next resolve rebuilds instead of re-finding the same bytes,
and an artifact with **no** fingerprint is treated as unknown provenance rather
than assumed fresh. Trusting those is what let the stale one survive.

## A six-hour CI landmine, currently on main

`initramfs::tests::resolve_returns_missing_when_cache_empty` gained `HOME`
isolation, which made it genuinely hermetic — and exposed what that was hiding.
On Linux the empty-cache path falls through to a real `nix build`, and with a
shell double that reports success without producing an artifact, the call never
returns. It ran for **20,000+ seconds** and took a CI job to its six-hour limit.

It had been passing on Linux only by finding an artifact it was supposed to
prove absent, so the hermeticity fix did not cause the hang — it revealed that
the assertion had never been tested there at all.

It now exercises `resolve_or_seed_from_default_cache`, whose contract is the one
the test's name claims, and completes in milliseconds. Removing the `HOME`
isolation makes it fail against a populated host cache, so the isolation is
load-bearing rather than decorative.

## Verification

fmt, clippy (0 warnings), the touched crates' suites (2349 tests), 34 xtask
policy gates.

Live on macOS 26.5.2 / arm64:

```
guest sources changed since the cached universal initramfs was built; discarded it
universal initramfs not attached (macOS cannot nix build it; the release tarball 404s)
BOOT-OK
```

## Not verified here

A working universal-initramfs boot end to end. This host cannot produce the
artifact, so what is proven is the eviction and the fallback. Confirming the
universal path boots needs a Linux host, or an artifact seeded from current
sources.

## Note on two unrelated red tests

`auto_select_never_returns_apple_container` and
`test_auto_select_returns_valid_backend` fail on macOS against **clean main**
(verified in a detached worktree at `origin/main`) — `auto_select` returns the
apple-container backend there. Pre-existing and not touched by this PR.
