### PR TITLE
Sign every release blob with one bundle format, drop the legacy shape

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -733,45 +733,24 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
 
-          # Two bundle formats, because two different verifiers consume them.
+          # One bundle format for every signed blob in this release:
+          # --new-bundle-format, the Sigstore bundle carrying
+          # verificationMaterial. Both consumers read it — the in-binary Rust
+          # sigstore stack (mvm_build::release_signature -> image_verify) parses
+          # ONLY this shape, and `cosign verify-blob --bundle` documents it as
+          # the preferred input, so install.sh / `mvmctl update` /
+          # verify-release-assets.sh keep working unchanged.
           #
-          # The mvmctl binary tarballs and the SBOM are verified by the cosign
-          # CLI (install.sh, and `mvmctl update`, which shells out to
-          # `cosign verify-blob`). That reads both shapes, so they stay on the
-          # legacy `--bundle` format they have always shipped.
-          #
-          # The image tarballs are verified IN-BINARY by the Rust sigstore
-          # stack (mvm_build::release_signature -> image_verify), which parses
-          # only the newer Sigstore bundle carrying verificationMaterial. A
-          # legacy bundle here would fail to parse on every download, so these
-          # must be signed with --new-bundle-format — same as every other
-          # artifact that stack verifies (image manifests, packs, revocations).
-          for tarball in artifacts/*.tar.gz; do
-            case "$(basename "${tarball}")" in
-              runtime-overlay-*|sdk-sidecar-*) continue ;;
-            esac
-            cosign sign-blob \
-              --yes \
-              --bundle "${tarball}.bundle" \
-              "${tarball}"
-            echo "Signed (legacy bundle, cosign-CLI consumers): ${tarball}"
-          done
-
-          for tarball in artifacts/runtime-overlay-*.tar.gz artifacts/sdk-sidecar-*.tar.gz; do
+          # Requires cosign >= v2.4 on any host that verifies by hand; that is
+          # the floor this project targets and there is no legacy fallback.
+          for blob in artifacts/*.tar.gz sbom.cdx.json; do
             cosign sign-blob \
               --yes \
               --new-bundle-format \
-              --bundle "${tarball}.bundle" \
-              "${tarball}"
-            echo "Signed (new bundle format, in-binary verifier): ${tarball}"
+              --bundle "${blob}.bundle" \
+              "${blob}"
+            echo "Signed: ${blob}"
           done
-
-          # Sign the SBOM
-          cosign sign-blob \
-            --yes \
-            --bundle sbom.cdx.json.bundle \
-            sbom.cdx.json
-          echo "Signed: sbom.cdx.json"
 
       # Plan 36 / ADR 005: cosign-keyless-sign each per-(arch, variant)
       # SignedManifest JSON. The bundle (.bundle) carries the signature,

--- a/public/src/content/docs/guides/verify-release.md
+++ b/public/src/content/docs/guides/verify-release.md
@@ -19,12 +19,23 @@ Each release includes, alongside the `.tar.gz` archives:
 | `mvmctl-<target>.tar.gz.bundle` | Cosign signature bundle for each platform archive |
 | `sbom.cdx.json` | Software Bill of Materials (CycloneDX JSON) |
 | `sbom.cdx.json.bundle` | Cosign signature bundle for the SBOM |
+| `runtime-overlay-<arch>.tar.gz.bundle` | Cosign signature bundle for the runtime overlay (verified in-binary before install) |
+| `sdk-sidecar-<arch>.tar.gz.bundle` | Cosign signature bundle for the SDK sidecar (verified in-binary before install) |
+
+Every bundle is a [Sigstore bundle](https://docs.sigstore.dev/about/bundle/)
+(`--new-bundle-format`). There is one format across the whole release — the
+in-binary verifier `mvmctl` uses for the overlay and sidecar reads only this
+shape, and `cosign verify-blob --bundle` takes it directly.
 
 ---
 
 ## Prerequisites
 
 Install cosign:
+
+**cosign v2.4 or newer** is required — that is when Sigstore-bundle support
+landed in `verify-blob`. Older cosign cannot read this release's bundles and
+there is no legacy fallback.
 
 ```bash
 # macOS

--- a/specs/plans/277-release-artifact-signature-verification.md
+++ b/specs/plans/277-release-artifact-signature-verification.md
@@ -35,10 +35,10 @@ image manifests, packs, revocation lists) is signed that way. Pointing the
 verifier at today's `runtime-overlay-<arch>.tar.gz.bundle` would fail to parse
 100% of the time.
 
-The legacy bundles cannot simply be switched wholesale: `mvmctl-*.tar.gz.bundle`
-is consumed by the **cosign CLI** (`install.sh`, and `mvmctl update`, which
-shells out to `cosign verify-blob`), which reads both shapes. So the binary
-tarballs keep the legacy format and the image tarballs move to the new one.
+The legacy bundles were initially kept for `mvmctl-*.tar.gz.bundle`, which is
+consumed by the **cosign CLI** (`install.sh`, and `mvmctl update`, which shells
+out to `cosign verify-blob`). That split was then collapsed — see the amendment
+below.
 
 **2. Nothing is at risk of breaking.** The latest release (v0.17.0) publishes
 the runtime overlay as *loose files* (`.ext4`/`.verity`/`.roothash`/`.VERSION`),
@@ -82,8 +82,8 @@ extraction**, so an unauthenticated tar is never parsed:
 ## Tasks
 
 - [x] **Task 1 — Sign the image tarballs in the format the verifier parses.**
-  Split `release.yml`'s signing step: binary tarballs keep legacy `--bundle`
-  (cosign-CLI consumers), image tarballs get `--new-bundle-format`. Attach
+  (Amended — see below: the split this task introduced was collapsed to a single
+  format.) Attach
   `runtime-overlay-*.tar.gz.bundle` / `sdk-sidecar-*.tar.gz.bundle` to the
   release. Extend `tests/release_assets.rs` to pin the bundle asset names and
   assert the image tarballs are signed in the new format — the failure mode is
@@ -121,3 +121,29 @@ Rekor — so the positive path is exercised with the documented skip hatch and t
 real signature check is witnessed in the rejecting direction plus the existing
 `pack-signing-smoke.yml` lane, which already round-trips a genuine keyless
 signature through this same verifier.
+
+## Amendment (2026-07-31) — one bundle format, no legacy
+
+The two-format split above was deliberate but unnecessary, and this project does
+not carry backwards compatibility. It is collapsed: **every** `cosign sign-blob`
+in `release.yml` now passes `--new-bundle-format`, including the mvmctl binary
+tarballs and the SBOM.
+
+The split rested on an assumption that was never tested — that the cosign CLI
+consumers needed the legacy shape. They do not. `cosign verify-blob --bundle`
+documents the Sigstore bundle as its *preferred* input, and a keypair round-trip
+against cosign v3.1.1 confirms it: signing with `--new-bundle-format` and
+verifying with a plain `cosign verify-blob --bundle` reports `Verified OK`. So
+`install.sh`, `mvmctl update`, and `verify-release-assets.sh` all keep working
+unchanged, against one format instead of two.
+
+What this buys: no per-artifact branching in the signing step, no way to sign an
+artifact with the shape its verifier cannot read, and one invariant to gate
+instead of a two-sided split. `tests/release_assets.rs::
+every_signed_release_blob_uses_the_one_bundle_format` asserts every signing
+invocation carries the flag; it was confirmed to go red when a bare `--bundle`
+is reintroduced and green when restored.
+
+The cost, stated plainly: a host verifying by hand needs cosign >= v2.4 (when
+`--new-bundle-format` landed). There is no legacy fallback and that is
+intentional.

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -96,51 +96,35 @@ fn release_attaches_the_signature_bundle_the_verifier_fetches() {
     }
 }
 
-/// The image tarballs must be signed with `--new-bundle-format`. The in-binary
-/// Rust verifier parses only that shape; a legacy `--bundle` here fails to
-/// parse on every download, and nothing would catch it until a real release
-/// shipped. The binary tarballs must NOT move — those are read by the cosign
-/// CLI (`install.sh`, `mvmctl update`), which wants the legacy shape.
+/// Every signed blob in the release uses the one bundle format this project
+/// ships: `--new-bundle-format`.
+///
+/// The in-binary Rust sigstore stack parses only that shape, and
+/// `cosign verify-blob --bundle` documents it as the preferred input — so a
+/// single format serves both consumers and there is no legacy fallback to keep
+/// in step. A bare `--bundle` left behind would sign an artifact the in-binary
+/// verifier cannot read, and nothing surfaces that until a real release ships.
 #[test]
-fn image_tarballs_are_signed_in_the_format_the_in_binary_verifier_parses() {
+fn every_signed_release_blob_uses_the_one_bundle_format() {
     let workflow = release_workflow();
-    let step = workflow
-        .split("- name: Sign release tarballs and SBOM")
-        .nth(1)
-        .expect("release.yml must define the tarball signing step");
-    let step = step
-        .split("\n      - name:")
-        .next()
-        .expect("the signing step is non-empty");
-
-    let image_sign = step
-        .split("for tarball in artifacts/runtime-overlay-*.tar.gz artifacts/sdk-sidecar-*.tar.gz")
-        .nth(1)
-        .expect("the image tarballs must be signed by their own loop")
-        .split("done")
-        .next()
-        .expect("the image signing loop is non-empty");
+    let mut checked = 0usize;
+    for (offset, _) in workflow.match_indices("cosign sign-blob") {
+        // The invocation is a line-continued shell command; its flags run up to
+        // the first line that is not a continuation.
+        let invocation: String = workflow[offset..]
+            .lines()
+            .take_while(|line| line.trim_end().ends_with('\\'))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            invocation.contains("--new-bundle-format"),
+            "every `cosign sign-blob` must use --new-bundle-format; found one without it:\n{invocation}"
+        );
+        checked += 1;
+    }
     assert!(
-        image_sign.contains("--new-bundle-format"),
-        "image tarballs must be signed with --new-bundle-format: {image_sign}"
-    );
-
-    // The generic loop produces the cosign-CLI-consumed bundles, so it must
-    // skip the image tarballs rather than double-signing them legacy.
-    let generic_sign = step
-        .split("for tarball in artifacts/*.tar.gz")
-        .nth(1)
-        .expect("the binary tarballs keep their own loop")
-        .split("done")
-        .next()
-        .expect("the generic signing loop is non-empty");
-    assert!(
-        generic_sign.contains("runtime-overlay-*|sdk-sidecar-*"),
-        "the legacy-format loop must skip the image tarballs: {generic_sign}"
-    );
-    assert!(
-        !generic_sign.contains("--new-bundle-format"),
-        "the cosign-CLI-consumed bundles must stay on the legacy format"
+        checked >= 4,
+        "expected to find the release's signing invocations, found {checked}"
     );
 }
 


### PR DESCRIPTION
Follow-up to #1975, which introduced a two-format split in `release.yml`:

- image tarballs → `--new-bundle-format` (the in-binary Rust verifier parses only this)
- binary tarballs + SBOM → legacy `--bundle` (for the cosign-CLI consumers)

## The split was unnecessary

It rested on an assumption I carried over rather than tested: that `install.sh`, `mvmctl update`, and `verify-release-assets.sh` needed the legacy shape because they shell out to `cosign verify-blob`. They don't.

`cosign verify-blob --help` documents the Sigstore bundle as its **preferred** input, and a keypair round-trip against cosign v3.1.1 confirms it end to end:

```
$ cosign sign-blob --key cosign.key --new-bundle-format --bundle new.bundle blob.txt
$ head -c 60 new.bundle
{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json",...
$ cosign verify-blob --key cosign.pub --bundle new.bundle blob.txt
Verified OK
```

So one format serves both consumers, and this project carries no backwards compatibility.

## What changed

`release.yml`'s signing step collapses from two loops plus a `case` exclusion to one loop over `artifacts/*.tar.gz sbom.cdx.json`, all `--new-bundle-format`. That removes per-artifact branching and, more usefully, removes any way to sign an artifact with a shape its verifier cannot read.

The gate moves with it. `image_tarballs_are_signed_in_the_format_the_in_binary_verifier_parses` pinned the split from both sides; it's replaced by `every_signed_release_blob_uses_the_one_bundle_format`, which walks every `cosign sign-blob` invocation in the workflow and asserts the flag. Stronger invariant, less to keep in step.

I verified the new gate actually discriminates rather than trivially passing: reintroducing a bare `--bundle` turns it red, restoring it turns it green.

## The cost, stated plainly

Verifying by hand now requires **cosign >= v2.4** (when `--new-bundle-format` landed). There is no legacy fallback, deliberately. `verify-release.md` documents that floor, and also gains the `runtime-overlay-*` / `sdk-sidecar-*` bundle rows it was missing after #1975.

## Verification

- nightly `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `tests/release_assets.rs` — 6/6, including the red/green discrimination check above
- root package suite — 134/134
- the doc-sensitive Lint gates (`check-doc-claims`, `check-no-overclaim`, `check-honesty`, `check-machine-doc-guards`, `check-two-surfaces`, `check-conformance`, `check-deferrals`, `check-no-spec-refs-in-comments`, `check-stubs`, `check-file-size`)
- `verify-release-assets.test.sh` — 11 passed

Plan 277 carries an amendment recording the collapse and why the original split was wrong.