### PR TITLE
Consume the published release artifacts through the real download path

### DIFF
--- a/.github/workflows/pack-signing-smoke.yml
+++ b/.github/workflows/pack-signing-smoke.yml
@@ -159,3 +159,61 @@ jobs:
           cargo run --release -p mvm-core --example verify-pack-revocation-list --features manifest-verify -- \
             --list smoke/pack-revocations.json --bundle smoke/pack-revocations.json.bundle \
             --identity "${IDENTITY}" --issuer "https://token.actions.githubusercontent.com"
+
+      - name: Round-trip a release archive through the downloader's verifier
+        # The runtime overlay and SDK sidecar are cosign-verified before an
+        # installed mvmctl will extract them, and the verifier parses ONLY the
+        # Sigstore bundle shape. Offline fixtures cannot cover that contract —
+        # a valid signature needs Fulcio and Rekor — so without this step a
+        # bundle-format regression in release.yml stays invisible until a real
+        # release strands every download, fail-closed, for every user.
+        #
+        # Scope, stated plainly: this proves the SIGNATURE FORMAT round-trip
+        # against a real bundle. Extraction, manifest re-check, atomic install,
+        # and resolve are covered by the offline suite; release.yml runs the
+        # full ladder over its own artifacts before publishing them.
+        run: |
+          set -euo pipefail
+          # A tarball shaped like the one the release publishes. Contents are
+          # irrelevant to a signature check, but keeping the real member set
+          # means this fails the same way a real artifact would.
+          mkdir -p smoke/sidecar
+          printf 'dummy-ext4'   > smoke/sidecar/sdk.ext4
+          printf '0.0.0-smoke'  > smoke/sidecar/VERSION
+          ( cd smoke/sidecar && sha256sum sdk.ext4 VERSION > checksums-sha256.txt )
+          tar -C smoke/sidecar -czf smoke/sdk-sidecar-x86_64.tar.gz \
+            sdk.ext4 VERSION checksums-sha256.txt
+
+          # The exact invocation release.yml signs release archives with.
+          cosign sign-blob \
+            --yes \
+            --new-bundle-format \
+            --bundle smoke/sdk-sidecar-x86_64.tar.gz.bundle \
+            smoke/sdk-sidecar-x86_64.tar.gz
+
+          cargo run --release -p mvm-build --example verify-release-archive-signature \
+            --features manifest-verify -- \
+            --archive smoke/sdk-sidecar-x86_64.tar.gz \
+            --bundle smoke/sdk-sidecar-x86_64.tar.gz.bundle \
+            --identity "${IDENTITY}" --issuer "https://token.actions.githubusercontent.com"
+
+      - name: A legacy-format bundle must be refused
+        # The failure this lane exists to catch, asserted directly: signing
+        # without --new-bundle-format must NOT verify. Without this, the step
+        # above would still pass if the verifier ever silently accepted both
+        # shapes, and the gate would be measuring nothing.
+        run: |
+          set -euo pipefail
+          cosign sign-blob \
+            --yes \
+            --bundle smoke/legacy.bundle \
+            smoke/sdk-sidecar-x86_64.tar.gz
+          if cargo run --release -p mvm-build --example verify-release-archive-signature \
+            --features manifest-verify -- \
+            --archive smoke/sdk-sidecar-x86_64.tar.gz \
+            --bundle smoke/legacy.bundle \
+            --identity "${IDENTITY}" --issuer "https://token.actions.githubusercontent.com"; then
+            echo "::error::a legacy-format bundle verified — the format gate is not discriminating" >&2
+            exit 1
+          fi
+          echo "ok: legacy-format bundle refused, as the release contract requires"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -752,6 +752,67 @@ jobs:
             echo "Signed: ${blob}"
           done
 
+      # Consume what we are about to publish, before publishing it.
+      #
+      # The runtime overlay and SDK sidecar are acquired by an installed mvmctl
+      # through a fail-closed ladder: checksum, cosign signature, safe-extract,
+      # inner-manifest re-check, atomic install, resolve. Every rung refuses
+      # rather than degrades, so an artifact this pipeline builds slightly wrong
+      # does not degrade the user experience — it strands every download.
+      #
+      # This runs that exact production path over the staged artifacts via a
+      # file:// URL. It is the only place the identity genuinely is this tagged
+      # release workflow's, so it needs no trust override and proves the whole
+      # chain rather than one rung. A missing artifact is skipped (image jobs
+      # are best-effort and the release gates only on the binary build); a
+      # PRESENT artifact that cannot be consumed fails the release here.
+      - name: Verify the published artifacts survive the consumer path
+        shell: bash
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          VERSION="${TAG_NAME#v}"
+          STAGE="consumer-check/v${VERSION}"
+          mkdir -p "${STAGE}"
+
+          checked=0
+          for kind in runtime-overlay sdk-sidecar; do
+            for arch in aarch64 x86_64; do
+              archive="artifacts/${kind}-${arch}.tar.gz"
+              [ -f "${archive}" ] || continue
+              for suffix in "" ".sha256" ".bundle"; do
+                src="${archive}${suffix}"
+                if [ ! -f "${src}" ]; then
+                  echo "::error::${src} is missing — a published archive without its checksum and signature cannot be acquired" >&2
+                  exit 1
+                fi
+                cp "${src}" "${STAGE}/"
+              done
+
+              case "${kind}" in
+                runtime-overlay) example_kind=overlay ;;
+                sdk-sidecar)     example_kind=sidecar ;;
+              esac
+              echo "Consuming ${kind}-${arch} through the production download path..."
+              cargo run --release -p mvm-build --example download-release-artifact \
+                --features manifest-verify -- \
+                --kind "${example_kind}" \
+                --base-url "file://$(pwd)/consumer-check" \
+                --version "${VERSION}" \
+                --arch "${arch}" \
+                --cache "$(mktemp -d)"
+              checked=$((checked + 1))
+            done
+          done
+
+          if [ "${checked}" -eq 0 ]; then
+            echo "::warning::no runtime-overlay or sdk-sidecar archives present — image jobs likely failed; publishing without them" >&2
+          else
+            echo "ok: ${checked} artifact(s) verified through the end-user acquisition path."
+          fi
+
       # Plan 36 / ADR 005: cosign-keyless-sign each per-(arch, variant)
       # SignedManifest JSON. The bundle (.bundle) carries the signature,
       # the Fulcio short-lived cert, and the Rekor inclusion proof —

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -130,6 +130,21 @@ nix = { version = "0.29", features = ["mount", "reboot", "signal", "ioctl"] }
 name = "mvm-builder-pack-tool"
 path = "examples/mvm-builder-pack-tool.rs"
 
+# Round-trips a REAL cosign bundle through the downloader's verifier under an
+# explicit identity, so `pack-signing-smoke.yml` can prove the release's bundle
+# format is one this stack parses. Needs the verifier compiled in.
+[[example]]
+name = "verify-release-archive-signature"
+path = "examples/verify-release-archive-signature.rs"
+required-features = ["manifest-verify"]
+
+# Drives the production download ladder against a staged release. `release.yml`
+# runs it over its own artifacts before publishing them.
+[[example]]
+name = "download-release-artifact"
+path = "examples/download-release-artifact.rs"
+required-features = ["manifest-verify"]
+
 [dev-dependencies]
 mvm-core = { workspace = true, features = ["test-support"] }
 # Test-only: `PackTrustConfig` (the operator trust config the producer's output

--- a/crates/mvm-build/examples/download-release-artifact.rs
+++ b/crates/mvm-build/examples/download-release-artifact.rs
@@ -1,0 +1,124 @@
+//! Drive the real end-user acquisition path against a staged release.
+//!
+//! Runs the production `download_runtime_overlay` / `download_sdk_sidecar`
+//! unchanged — the whole ladder: fetch the checksum, fetch the archive, verify
+//! its digest, verify its cosign signature against the tagged release identity,
+//! safe-extract, re-check the archive's own manifest, install atomically, and
+//! re-resolve the installed entry.
+//!
+//! `release.yml` points this at its own about-to-be-published artifacts over a
+//! `file://` URL before `gh release create` runs. That is the one context where
+//! the signing identity genuinely is the tagged release workflow's, so no trust
+//! override is needed or offered — a release that cannot be consumed by the
+//! consumer path fails here instead of stranding every download after publish.
+//!
+//! ```text
+//! download-release-artifact --kind sidecar --base-url file:///abs/staging \
+//!   --version 0.18.0 --arch x86_64 --cache /tmp/verify-cache
+//! ```
+//!
+//! Exits 0 only when the artifact installs *and* resolves.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use mvm_core::arch::GuestArch;
+
+enum Kind {
+    Overlay,
+    Sidecar,
+}
+
+struct Args {
+    kind: Kind,
+    base_url: String,
+    version: String,
+    arch: GuestArch,
+    cache: PathBuf,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let (mut kind, mut base_url, mut version, mut arch, mut cache) = (None, None, None, None, None);
+    let mut argv = std::env::args().skip(1);
+    while let Some(flag) = argv.next() {
+        let mut value = || {
+            argv.next()
+                .ok_or_else(|| format!("{flag} requires a value"))
+        };
+        match flag.as_str() {
+            "--kind" => {
+                kind = Some(match value()?.as_str() {
+                    "overlay" => Kind::Overlay,
+                    "sidecar" => Kind::Sidecar,
+                    other => return Err(format!("--kind must be overlay|sidecar, got {other}")),
+                })
+            }
+            "--base-url" => base_url = Some(value()?),
+            "--version" => version = Some(value()?),
+            "--arch" => {
+                let raw = value()?;
+                arch = Some(match raw.as_str() {
+                    "aarch64" => GuestArch::Aarch64,
+                    "x86_64" => GuestArch::X86_64,
+                    other => return Err(format!("--arch must be aarch64|x86_64, got {other}")),
+                })
+            }
+            "--cache" => cache = Some(PathBuf::from(value()?)),
+            other => return Err(format!("unknown argument {other}")),
+        }
+    }
+    Ok(Args {
+        kind: kind.ok_or("--kind is required")?,
+        base_url: base_url.ok_or("--base-url is required")?,
+        version: version.ok_or("--version is required")?,
+        arch: arch.ok_or("--arch is required")?,
+        cache: cache.ok_or("--cache is required")?,
+    })
+}
+
+fn main() -> ExitCode {
+    let args = match parse_args() {
+        Ok(args) => args,
+        Err(reason) => {
+            eprintln!("error: {reason}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // `release_base_url` appends `/v<version>` itself, so the caller supplies
+    // the prefix — exactly as an operator pointing at a private mirror would.
+    // SAFETY: single-threaded example, set before any download runs.
+    unsafe { std::env::set_var("MVM_OVERLAY_BASE_URL", &args.base_url) };
+
+    // The two downloaders return different error types. Render each at its own
+    // call site rather than coercing one into the other — a wrong-variant
+    // coercion would print a reason that misnames what actually failed.
+    let outcome: Result<String, String> = match args.kind {
+        Kind::Overlay => mvm_build::runtime_overlay::download_runtime_overlay(
+            &args.version,
+            args.arch,
+            &args.cache,
+        )
+        .map(|a| format!("runtime overlay {} roothash {}", a.version, a.roothash))
+        .map_err(|e| e.to_string()),
+        Kind::Sidecar => {
+            mvm_build::sdk_sidecar::download_sdk_sidecar(&args.version, args.arch, &args.cache)
+                .map(|a| format!("sdk sidecar {} sha256 {}", a.version, a.image_sha256))
+                .map_err(|e| e.to_string())
+        }
+    };
+
+    match outcome {
+        Ok(summary) => {
+            println!("ok: installed and resolved {summary} ({})", args.arch);
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!(
+                "error: {} {} did not survive the consumer path: {e}",
+                args.arch, args.version
+            );
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/mvm-build/examples/verify-release-archive-signature.rs
+++ b/crates/mvm-build/examples/verify-release-archive-signature.rs
@@ -1,0 +1,104 @@
+//! Verify a release archive against a real cosign bundle, under an explicit
+//! signing identity.
+//!
+//! Exists so a CI lane can prove the *format* contract end to end: sign a real
+//! tarball with the exact `cosign sign-blob` invocation `release.yml` uses, then
+//! feed the resulting bundle through the same primitive the downloader calls.
+//! Offline unit fixtures cannot cover this — a valid Sigstore signature needs
+//! Fulcio and Rekor — so a bundle-format regression in the release workflow
+//! would otherwise stay invisible until a real release stranded every download.
+//!
+//! Identity is a parameter because the smoke lane signs under its own workflow's
+//! OIDC identity, not the tagged release workflow's.
+//!
+//! ```text
+//! verify-release-archive-signature \
+//!   --archive sdk-sidecar-x86_64.tar.gz \
+//!   --bundle  sdk-sidecar-x86_64.tar.gz.bundle \
+//!   --identity "https://github.com/<repo>/.github/workflows/<wf>@<ref>" \
+//!   --issuer   "https://token.actions.githubusercontent.com"
+//! ```
+//!
+//! Exits 0 when the signature verifies, nonzero with a reason otherwise.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+struct Args {
+    archive: PathBuf,
+    bundle: PathBuf,
+    identity: String,
+    issuer: String,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let (mut archive, mut bundle, mut identity, mut issuer) = (None, None, None, None);
+    let mut argv = std::env::args().skip(1);
+    while let Some(flag) = argv.next() {
+        let mut value = || {
+            argv.next()
+                .ok_or_else(|| format!("{flag} requires a value"))
+        };
+        match flag.as_str() {
+            "--archive" => archive = Some(PathBuf::from(value()?)),
+            "--bundle" => bundle = Some(PathBuf::from(value()?)),
+            "--identity" => identity = Some(value()?),
+            "--issuer" => issuer = Some(value()?),
+            other => return Err(format!("unknown argument {other}")),
+        }
+    }
+    Ok(Args {
+        archive: archive.ok_or("--archive is required")?,
+        bundle: bundle.ok_or("--bundle is required")?,
+        identity: identity.ok_or("--identity is required")?,
+        issuer: issuer.ok_or("--issuer is required")?,
+    })
+}
+
+fn main() -> ExitCode {
+    let args = match parse_args() {
+        Ok(args) => args,
+        Err(reason) => {
+            eprintln!("error: {reason}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let archive = match std::fs::read(&args.archive) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            eprintln!("error: read {}: {e}", args.archive.display());
+            return ExitCode::FAILURE;
+        }
+    };
+    let bundle = match std::fs::read(&args.bundle) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            eprintln!("error: read {}: {e}", args.bundle.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let asset = args
+        .archive
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| args.archive.display().to_string());
+
+    match mvm_build::release_signature::verify_release_archive_bytes(
+        &archive,
+        &bundle,
+        &asset,
+        std::slice::from_ref(&args.identity),
+        &args.issuer,
+    ) {
+        Ok(()) => {
+            println!("ok: {asset} verified under {}", args.identity);
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/mvm-build/src/release_signature.rs
+++ b/crates/mvm-build/src/release_signature.rs
@@ -101,27 +101,51 @@ fn fetch_bundle(request: &ReleaseSignatureRequest<'_>) -> Result<Vec<u8>, Runtim
     Ok(std::fs::read(tmp.path())?)
 }
 
-/// Try every accepted release identity, accepting on the first that verifies.
-///
-/// The identity set is a list rather than a single value because the release
-/// trust root allows more than one template; a rotation that adds one must not
-/// require a code change here.
 fn verify_against_release_identities(
     archive: &[u8],
     bundle: &[u8],
     request: &ReleaseSignatureRequest<'_>,
 ) -> Result<(), RuntimeOverlayError> {
-    let identities = mvm_core::release_trust::accepted_release_identities(request.version);
-    let issuer = mvm_core::release_trust::RELEASE_OIDC_ISSUER;
+    verify_release_archive_bytes(
+        archive,
+        bundle,
+        request.asset,
+        &mvm_core::release_trust::accepted_release_identities(request.version),
+        mvm_core::release_trust::RELEASE_OIDC_ISSUER,
+    )
+}
+
+/// Verify `archive` against `bundle` under any of `identities`, accepting on
+/// the first that verifies.
+///
+/// The trust root is a parameter rather than baked in — the same shape
+/// `mvm_core::packs::verify` takes a `KeylessTrust` — so a signer other than
+/// the tagged release workflow can be checked without a second implementation.
+/// Production always passes [`mvm_core::release_trust`]'s set; the
+/// `verify-release-archive-signature` example passes an explicit identity so a
+/// CI lane can round-trip a *real* cosign bundle signed under that lane's own
+/// OIDC identity. That is the only way to prove the format the release
+/// publishes is one this verifier can actually parse — offline fixtures cannot,
+/// because a valid Sigstore signature needs Fulcio and Rekor.
+///
+/// The identity set is a list because the release trust root allows more than
+/// one template; a rotation that adds one must not require a code change here.
+pub fn verify_release_archive_bytes(
+    archive: &[u8],
+    bundle: &[u8],
+    asset: &str,
+    identities: &[String],
+    issuer: &str,
+) -> Result<(), RuntimeOverlayError> {
     let mut last_failure: Option<String> = None;
 
-    for identity in &identities {
+    for identity in identities {
         match mvm_core::crypto::image_verify::verify_signed_payload(
             archive, bundle, identity, issuer,
         ) {
             Ok(()) => {
                 tracing::debug!(
-                    asset = request.asset,
+                    asset,
                     identity = identity.as_str(),
                     "release archive signature verified"
                 );
@@ -132,7 +156,7 @@ fn verify_against_release_identities(
     }
 
     Err(RuntimeOverlayError::SignatureInvalid {
-        asset: request.asset.to_string(),
+        asset: asset.to_string(),
         reason: last_failure.unwrap_or_else(|| {
             "no release signing identity is configured for this version".to_string()
         }),

--- a/specs/plans/277-release-artifact-signature-verification.md
+++ b/specs/plans/277-release-artifact-signature-verification.md
@@ -147,3 +147,38 @@ is reintroduced and green when restored.
 The cost, stated plainly: a host verifying by hand needs cosign >= v2.4 (when
 `--new-bundle-format` landed). There is no legacy fallback and that is
 intentional.
+
+## Amendment (2026-07-31, second) — close the loop before a release, not after
+
+Everything above is proven against staged fixtures and static workflow
+assertions. Nothing had ever exercised the real chain — Nix build → tarball →
+`--new-bundle-format` sign → attach → fetch → sha256 → signature → extract →
+install → resolve — because no published release has ever carried these
+tarballs. The first real run would have been a `v*` tag push, and because the
+ladder is fail-closed, a mistake there strands every download rather than
+degrading.
+
+Two lanes now cover it, at different costs and different times:
+
+- **`pack-signing-smoke.yml`** (dispatch) signs a release-shaped tarball with the
+  exact `cosign sign-blob --new-bundle-format` invocation `release.yml` uses and
+  feeds the real bundle through the downloader's verifier via the
+  `verify-release-archive-signature` example. A companion step asserts a
+  *legacy* bundle is **refused** — without it the gate would still pass if the
+  verifier ever silently accepted both shapes, and would be measuring nothing.
+  Scope: the signature-format contract, against a real bundle. Extraction,
+  manifest re-check, install, and resolve stay fixture-covered.
+
+- **`release.yml`** runs the whole ladder over its own artifacts, after signing
+  and before `gh release create`, via the `download-release-artifact` example
+  over a `file://` URL. That is the one context where the signing identity
+  genuinely is the tagged release workflow's, so it needs no trust override.
+  A missing artifact is skipped — image jobs are best-effort — but an artifact
+  that is present and cannot be consumed fails the release before publish.
+
+`verify_release_archive_bytes` is the seam that makes the first lane possible:
+the identity set is a parameter, the same shape `mvm_core::packs::verify` takes
+a `KeylessTrust`. Production always passes `release_trust`'s set.
+
+`tests/release_assets.rs::the_release_consumes_its_own_artifacts_before_publishing_them`
+pins the ordering so the self-check cannot drift after signing or before publish.

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -128,6 +128,35 @@ fn every_signed_release_blob_uses_the_one_bundle_format() {
     );
 }
 
+/// The release must consume its own artifacts through the production download
+/// ladder *before* publishing them.
+///
+/// That ladder is fail-closed at every rung, so an artifact this pipeline builds
+/// slightly wrong does not degrade — it strands every download. The self-check
+/// is the only thing that turns that into a failed release instead of a shipped
+/// one, and it has to run after signing and before `gh release create`.
+#[test]
+fn the_release_consumes_its_own_artifacts_before_publishing_them() {
+    let workflow = release_workflow();
+    let verify = workflow
+        .find("- name: Verify the published artifacts survive the consumer path")
+        .expect("release.yml must consume its artifacts before publishing them");
+    let sign = workflow
+        .find("- name: Sign release tarballs and SBOM")
+        .expect("release.yml must sign the tarballs");
+    let publish = workflow
+        .find("- name: Create GitHub Release")
+        .expect("release.yml must create the release");
+    assert!(
+        sign < verify && verify < publish,
+        "the consumer check must run after signing and before publishing"
+    );
+    assert!(
+        workflow.contains("--example download-release-artifact"),
+        "the check must drive the real downloader, not a restatement of it"
+    );
+}
+
 /// Both published architectures must be built, or a whole platform's users get
 /// the fail-closed refusal this artifact exists to prevent.
 #[test]


### PR DESCRIPTION
Item 1 of the follow-up list. Plans 273 + 277 shipped the end-user acquisition path for the runtime overlay and SDK sidecar, fail-closed at every rung — and **none of it has ever run against a real release.**

No published version has ever carried a `runtime-overlay-*.tar.gz` or `sdk-sidecar-*.tar.gz` (v0.17.0 ships the overlay as loose files). So the first real exercise of

```
Nix build → tarball → --new-bundle-format sign → attach
          → fetch → sha256 → signature → extract → install → resolve
```

would have been a `v*` tag push. And because I made the ladder refuse rather than degrade, a mistake there doesn't produce a worse experience — it strands every download for every user. `dry_run=true` doesn't help either; it skips the image jobs entirely.

## Two lanes, different times and costs

**`pack-signing-smoke.yml`** (dispatch) signs a release-shaped tarball with the *exact* `cosign sign-blob --new-bundle-format` invocation `release.yml` uses, then feeds the real bundle through the downloader's own verifier.

A companion step asserts a **legacy bundle is refused**. Without it the first step would still pass if the verifier ever silently accepted both shapes — the gate would be measuring nothing. This is the same discrimination check I ran by hand on #1984, now permanent.

This covers the signature-format contract against a real Fulcio/Rekor-backed bundle, which offline fixtures structurally cannot produce.

**`release.yml`** runs the *whole* ladder over its own artifacts — after signing, before `gh release create` — via a `file://` URL. That's the one context where the signing identity genuinely is the tagged release workflow's, so it needs no trust override and proves the full chain rather than one rung.

A missing artifact is skipped (image jobs are best-effort and the release gates only on the binary build). An artifact that is **present and cannot be consumed fails the release before publish** rather than after.

## The seam

`verify_release_archive_bytes` makes the smoke lane possible: the accepted-identity set becomes a parameter, the same shape `mvm_core::packs::verify` already takes a `KeylessTrust`. Production always passes `release_trust`'s set — the trust root is unchanged, and no override reaches a user-facing path or env var.

Two examples drive the lanes, both `required-features = ["manifest-verify"]` so a default build doesn't pull sigstore:

- `verify-release-archive-signature` — format check under an explicit identity
- `download-release-artifact` — full ladder against a staged release

## Verification

I exercised both examples' failure paths locally. The second is worth showing, because it's exactly the regression this lane catches:

```
$ verify-release-archive-signature --bundle <legacy-shaped> ...
error: release archive ... failed signature verification:
       cosign bundle parse failed: missing field `verificationMaterial`
exit=1
```

- nightly `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `tests/release_assets.rs` — 7/7, including a new ordering gate that pins the self-check between signing and publishing so it can't drift
- `mvm-build` + root suites — 1049/1049
- Ten Lint-job xtask gates including `check-closure-budget` (the new examples add no closure — they're dev-only)
- Both workflows parse as YAML; release-job step ordering asserted programmatically

## Also

Removed two stale worktree branches whose PRs had already merged (`feat/firecracker-vsock-only-final`, `feat/vsock-control-conformance`) — item 4 from the list.

Items 2 (recurring parallelism flakes) and 3 (non-hermetic test sweep) are next, as separate PRs.