### PR TITLE
fix(runtime): stop auto-detect selecting the opt-in apple-container tier

### DIFF
--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -374,6 +374,66 @@ impl BackendTier {
     }
 }
 
+/// The three host capabilities the auto-detect ladder branches on,
+/// resolved once so the ladder itself can be a pure function of them.
+///
+/// Probing and deciding are separated because the decision is the part
+/// worth testing and the probe is the part that pins a test to whatever
+/// host runs it. With them fused, "an opt-in tier is never auto-selected"
+/// could only ever be checked for the tier the test machine happened to
+/// be — which is how a macOS-only regression stayed invisible to a Linux
+/// CI runner.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct HostTiers {
+    /// Native Linux with `/dev/kvm` — the Firecracker production tier.
+    native_runner: bool,
+    /// macOS 26+ Apple Silicon, where HVF is the auto-detect default.
+    hvf_default: bool,
+    /// libkrun is installed.
+    libkrun: bool,
+}
+
+impl HostTiers {
+    fn probe() -> Self {
+        let plat = mvm_core::platform::current();
+        Self {
+            native_runner: plat.supports_native_runner(),
+            hvf_default: plat.is_hvf_default_tier(),
+            libkrun: plat.has_libkrun(),
+        }
+    }
+}
+
+/// The auto-detect ladder.
+///
+/// Only production-tier backends appear here. Every other backend —
+/// apple-container, qemu, docker, wasm, mock — is opt-in, reachable only
+/// through an explicit `--hypervisor` / `MVM_BACKEND` selection, and must
+/// never be reachable from this function. Adding a return site for one
+/// silently moves a workload onto a backend the caller did not ask for.
+fn select_kind(tiers: HostTiers) -> catalog::BackendKind {
+    use catalog::BackendKind;
+
+    // 1. Native Linux KVM → the Firecracker workload runner (vsock-only
+    //    egress; fastest — dev & production). WSL2 nested KVM is
+    //    future/experimental and is not auto-selected today.
+    if tiers.native_runner {
+        return BackendKind::Firecracker;
+    }
+    // 2. macOS 26+ Apple Silicon → the HVF VMM.
+    if tiers.hvf_default {
+        return BackendKind::Hvf;
+    }
+    // 3. libkrun installed → the libkrun workload runner (vsock-only egress).
+    if tiers.libkrun {
+        return BackendKind::Libkrun;
+    }
+    // Final default. Reachable when no tier is available; start() then
+    // fails with the production-path error message rather than silently
+    // picking a backend the caller didn't ask for.
+    BackendKind::Firecracker
+}
+
 /// Backend-agnostic dispatch enum.
 ///
 /// Wraps concrete backends so CLI commands don't need to know which
@@ -517,37 +577,7 @@ impl AnyBackend {
     /// which is a clearer failure mode than picking a backend the
     /// caller didn't ask for.
     pub fn auto_select() -> Self {
-        let plat = mvm_core::platform::current();
-
-        // 1. Native Linux KVM → the Firecracker workload runner (vsock-only
-        //    egress; fastest — dev & production). WSL2 nested KVM is
-        //    future/experimental and is not auto-selected today.
-        if plat.supports_native_runner() {
-            return Self::Firecracker(fc_runner());
-        }
-
-        // 2. macOS 26+ Apple Silicon → the HVF VMM. Prefer the Apple
-        //    Container backend when its container kernel is cached: it boots
-        //    Apple's prebuilt container kernel through the same HVF runner,
-        //    so a plain `machine run` uses it without `--hypervisor`. Without
-        //    the artifact, fall back to the workload-kernel hvf runner.
-        if plat.is_hvf_default_tier() {
-            let apple = AppleContainerBackend::new();
-            if apple.is_available().unwrap_or(false) {
-                return Self::AppleContainer(apple);
-            }
-            return Self::Hvf(hvf_runner());
-        }
-
-        // 3. libkrun installed → the libkrun workload runner (vsock-only egress).
-        if plat.has_libkrun() {
-            return Self::Libkrun(libkrun_runner());
-        }
-
-        // Final default. Reachable when no tier is available; start()
-        // then fails with the production-path error message rather than
-        // silently picking a backend the caller didn't ask for.
-        Self::Firecracker(fc_runner())
+        catalog::descriptor(select_kind(HostTiers::probe())).instantiate()
     }
 
     /// Resolve the backend that owns an already-started VM by its per-VM
@@ -1232,18 +1262,72 @@ mod tests {
         );
     }
 
+    /// Every host tier the ladder can see, enumerated. `auto_select` on
+    /// its own can only ever exercise the one tier the test machine
+    /// happens to be, so a return site added under a `macOS 26+` branch
+    /// is unreachable — and therefore untested — on a Linux CI runner.
+    fn every_host_tier() -> Vec<HostTiers> {
+        let mut all = Vec::new();
+        for native_runner in [false, true] {
+            for hvf_default in [false, true] {
+                for libkrun in [false, true] {
+                    all.push(HostTiers {
+                        native_runner,
+                        hvf_default,
+                        libkrun,
+                    });
+                }
+            }
+        }
+        all
+    }
+
+    /// The ladder resolves to a production tier and nothing else, on
+    /// every host it can see — not just this one.
+    ///
+    /// apple-container, qemu, docker, wasm, and mock are opt-in tiers
+    /// reachable only through an explicit `--hypervisor`. A branch
+    /// returning one of them moves a workload onto a backend nobody asked
+    /// for, which is exactly the shape of defect this enumerates against.
     #[test]
-    fn auto_select_skips_apple_container_without_its_kernel_artifact() {
-        // With an isolated, empty cache there is no container kernel, so
-        // auto_select must not pick the apple-container backend on any
-        // platform — on the HVF tier it falls back to the plain hvf runner.
-        let dir = tempfile::tempdir().expect("tempdir");
-        let mut env = mvm_core::util::test_env::TestEnv::new();
-        env.isolate_mvm_home(dir.path());
-        assert_ne!(
-            AnyBackend::auto_select().kind(),
-            mvm_core::vm_backend::BackendKind::AppleContainer,
-            "without the container kernel artifact, auto_select must not select apple-container"
+    fn the_ladder_never_yields_an_opt_in_tier_on_any_host() {
+        use mvm_core::vm_backend::BackendKind;
+        for tiers in every_host_tier() {
+            let kind = select_kind(tiers);
+            assert!(
+                matches!(
+                    kind,
+                    BackendKind::Firecracker | BackendKind::Hvf | BackendKind::Libkrun
+                ),
+                "auto-detect on {tiers:?} yielded the opt-in backend {kind:?}"
+            );
+        }
+    }
+
+    /// The ladder's priority order, pinned per tier. Without this the
+    /// test above passes for any permutation of the three production
+    /// backends, including one that would pick libkrun over KVM.
+    #[test]
+    fn the_ladder_prefers_kvm_then_hvf_then_libkrun() {
+        use mvm_core::vm_backend::BackendKind;
+        let tiers = |native_runner, hvf_default, libkrun| HostTiers {
+            native_runner,
+            hvf_default,
+            libkrun,
+        };
+        // Native KVM wins even when every other tier is also present.
+        assert_eq!(
+            select_kind(tiers(true, true, true)),
+            BackendKind::Firecracker
+        );
+        // HVF outranks libkrun on the macOS 26+ tier where both exist.
+        assert_eq!(select_kind(tiers(false, true, true)), BackendKind::Hvf);
+        assert_eq!(select_kind(tiers(false, false, true)), BackendKind::Libkrun);
+        // Nothing available: Firecracker, so start() fails pointing at the
+        // production path rather than at a backend nobody selected.
+        assert_eq!(
+            select_kind(tiers(false, false, false)),
+            BackendKind::Firecracker
         );
     }
 

--- a/crates/mvm-runtime/src/builder_runner/runner.rs
+++ b/crates/mvm-runtime/src/builder_runner/runner.rs
@@ -180,16 +180,30 @@ mod tests {
     use crate::driver::mock::MockDriver;
     use mvm_core::util::test_env::TestEnv;
 
-    #[test]
-    fn build_packs_inputs_boots_the_builder_spec_and_extracts_the_output() {
-        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let mut env = TestEnv::new();
+    /// The on-disk inputs a builder run reads, materialized under one
+    /// tempdir.
+    struct BuilderFixture {
+        tmp: tempfile::TempDir,
+        job: PathBuf,
+        work: PathBuf,
+        bins: PathBuf,
+        kernel: PathBuf,
+        rootfs: PathBuf,
+        nix_store: PathBuf,
+    }
+
+    /// Materialize those inputs and point the substitution endpoint at a
+    /// shell stub.
+    ///
+    /// The stub is not a convenience: without it the run spawns the real
+    /// `mvm-substitution-endpoint`, which is an `mvm-hostd` binary. A
+    /// package-scoped `cargo nextest run -p mvm-runtime` never builds it,
+    /// so a test that omits the stub passes only when something else in
+    /// the same target dir happened to build another package's binary.
+    fn builder_fixture(env: &mut TestEnv) -> BuilderFixture {
         let tmp = tempfile::tempdir().unwrap();
         env.set("MVM_HOME", tmp.path());
 
-        // Real input trees + placeholder image files on disk.
         let job = tmp.path().join("job");
         let work = tmp.path().join("work");
         let bins = tmp.path().join("bins");
@@ -205,6 +219,7 @@ mod tests {
         for f in [&kernel, &rootfs, &nix_store] {
             std::fs::write(f, b"x").unwrap();
         }
+
         let stub = tmp.path().join("stub-endpoint.sh");
         std::fs::write(
             &stub,
@@ -217,18 +232,38 @@ mod tests {
         }
         env.set("MVM_SUBSTITUTION_ENDPOINT_PATH", &stub);
 
+        BuilderFixture {
+            tmp,
+            job,
+            work,
+            bins,
+            kernel,
+            rootfs,
+            nix_store,
+        }
+    }
+
+    #[test]
+    fn build_packs_inputs_boots_the_builder_spec_and_extracts_the_output() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut env = TestEnv::new();
+        let fx = builder_fixture(&mut env);
+        let tmp = &fx.tmp;
+
         // A run-to-completion builder: the mock VM reports Stopped so the
         // poll-until-off loop returns at once.
         let runner = BuilderRunner::new(MockDriver::default().reporting_status(VmStatus::Stopped));
         let outcome = runner
             .build(&BuilderBuild {
                 name: "bld-unit",
-                kernel: &kernel,
-                rootfs: &rootfs,
-                nix_store: &nix_store,
-                job_dir: &job,
-                work_src: &work,
-                host_bin_dir: &bins,
+                kernel: &fx.kernel,
+                rootfs: &fx.rootfs,
+                nix_store: &fx.nix_store,
+                job_dir: &fx.job,
+                work_src: &fx.work,
+                host_bin_dir: &fx.bins,
                 runtime_overlay: None,
                 closure_nar: None,
                 output_size: 1 << 20,
@@ -259,24 +294,8 @@ mod tests {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut env = TestEnv::new();
-        let tmp = tempfile::tempdir().unwrap();
-        env.set("MVM_HOME", tmp.path());
-
-        let job = tmp.path().join("job");
-        let work = tmp.path().join("work");
-        let bins = tmp.path().join("bins");
-        for d in [&job, &work, &bins] {
-            std::fs::create_dir_all(d).unwrap();
-        }
-        std::fs::write(job.join("cmd.sh"), b"#!/bin/sh\nnix build\n").unwrap();
-        std::fs::write(work.join("flake.nix"), b"{}").unwrap();
-        std::fs::write(bins.join("mvm-host-vm-init"), b"ELF").unwrap();
-        let kernel = tmp.path().join("Image");
-        let rootfs = tmp.path().join("rootfs.ext4");
-        let nix_store = tmp.path().join("nix-store.img");
-        for f in [&kernel, &rootfs, &nix_store] {
-            std::fs::write(f, b"x").unwrap();
-        }
+        let fx = builder_fixture(&mut env);
+        let tmp = &fx.tmp;
         let closure = tmp.path().join("nix-closure.nar");
         std::fs::write(&closure, b"pretend-nar-bytes").unwrap();
 
@@ -284,12 +303,12 @@ mod tests {
         let outcome = runner
             .build(&BuilderBuild {
                 name: "bld-closure",
-                kernel: &kernel,
-                rootfs: &rootfs,
-                nix_store: &nix_store,
-                job_dir: &job,
-                work_src: &work,
-                host_bin_dir: &bins,
+                kernel: &fx.kernel,
+                rootfs: &fx.rootfs,
+                nix_store: &fx.nix_store,
+                job_dir: &fx.job,
+                work_src: &fx.work,
+                host_bin_dir: &fx.bins,
                 runtime_overlay: None,
                 closure_nar: Some(&closure),
                 output_size: 1 << 20,


### PR DESCRIPTION
## What

Two fixes that together take `mvm-runtime`'s package-scoped suite from 2 failing to 1219/1219. Both block the mutation-witness lane, which measures each claim-surface file with `cargo mutants -p <pkg> --file <path>` and refuses to read an unmutated tree that fails its own tests as "clean".

### 1. `auto_select` no longer returns the opt-in apple-container tier — closes #1986

`auto_select` gained a return site for `apple-container` when its container kernel is cached. Plan 271 states the opposite twice:

> Opt-in only; `auto_select` never returns this backend.

> Auto-select never returns this backend (opt-in only) until it carries a production tier, same discipline as QEMU.

and the PR that added the branch (#1968) says "Never auto-selected" in its own description. `apple-container` is Tier 2, so a developer's Mac with a cached artifact silently moved workloads onto a VMM nobody selected. **The code is wrong, not the tests.**

Two tests already asserted the invariant (`auto_select_never_returns_apple_container`, `test_auto_select_returns_valid_backend`) and had been red on macOS since. Neither could go red anywhere else: the branch sat under a macOS-26 guard a Linux CI runner never reaches.

So rather than just deleting the branch, the ladder is now a pure function of the three host capabilities it branches on, with probing split out:

```rust
fn select_kind(tiers: HostTiers) -> BackendKind
```

`the_ladder_never_yields_an_opt_in_tier_on_any_host` enumerates all eight host tiers, so "an opt-in tier is never auto-selected" becomes checkable on any runner instead of only on the tier the test machine happens to be. `the_ladder_prefers_kvm_then_hvf_then_libkrun` pins the priority order, which the enumeration alone would not.

Falsified, not assumed: planting the removed branch back (`if tiers.hvf_default { return BackendKind::AppleContainer }`) fails the enumeration test on macOS **and** would on Linux — the blind spot the issue names.

### 2. The builder-runner closure-NAR test spawned a real `mvm-hostd` binary

`build_rides_the_closure_nar_on_the_same_input_disk_when_present` did not stub `MVM_SUBSTITUTION_ENDPOINT_PATH`, so it spawned the real `mvm-substitution-endpoint` — an **`mvm-hostd`** binary. `cargo nextest run -p mvm-runtime` never builds it, so the test passed only when some other package's build had populated the shared `target/`. Deleting `target/debug/mvm-substitution-endpoint` reproduces the failure on a clean tree.

Both tests in that module now share one `builder_fixture` helper (they duplicated ~25 lines of setup), and the stub is part of it.

This, not #1986, is why `crates/mvm-runtime/src/microvm/snapshot.rs` could not establish a mutation baseline: cargo-mutants runs package-scoped in a fresh copied tree where no other package's binary exists.

## Verification

```
cargo nextest run -p mvm-runtime     # 1219 passed, 9 skipped (was 2 failed)
cargo clippy --workspace --all-targets -- -D warnings
```
