### PR TITLE
test(worker-pool): replace the warm-pool's fixed sleeps with the conditions they stood for

### DIFF
--- a/crates/mvm-agentd/src/worker_pool.rs
+++ b/crates/mvm-agentd/src/worker_pool.rs
@@ -413,6 +413,18 @@ impl WorkerPool {
         thread::sleep(grace.min(Duration::from_secs(30)));
     }
 
+    /// How many callers are parked waiting for a slot.
+    ///
+    /// The queue cap is enforced against this number, so it is the only
+    /// thing that says whether a caller has actually reached the queue.
+    /// Without it an observer can only infer it from elapsed time, and a
+    /// time guess is either too short (spurious failure on a loaded host)
+    /// or too long (every run pays for the worst case).
+    pub fn queued_waiters(&self) -> usize {
+        let st = self.state.lock().expect("worker pool state mutex poisoned");
+        st.pending_waiters
+    }
+
     /// Snapshot of slot states for observability / tests.
     pub fn snapshot(&self) -> Vec<SlotSnapshot> {
         let st = self.state.lock().expect("worker pool state mutex poisoned");
@@ -689,12 +701,25 @@ impl WorkerPool {
     /// tick. Production callers should let the background recycler
     /// run on its own cadence.
     pub fn sweep_idle(self: &Arc<Self>) {
+        self.sweep_idle_at(Instant::now());
+    }
+
+    /// [`Self::sweep_idle`] against a supplied instant instead of the
+    /// wall clock.
+    ///
+    /// The threshold comparison is the whole behaviour here, and reading
+    /// the clock is the one part of it that cannot be asked a question.
+    /// Taking `now` as an argument lets a caller ask "what would this
+    /// sweep do ten minutes from now" in no time at all, so a test of an
+    /// idle *timeout* does not have to spend the timeout to run — and
+    /// can check the under-threshold side, which sleeping past the
+    /// threshold structurally cannot.
+    pub fn sweep_idle_at(self: &Arc<Self>, now: Instant) {
         let secs = self.idle_timeout_secs.load(Ordering::Acquire);
         if secs == 0 {
             return;
         }
         let max_idle = Duration::from_secs(secs);
-        let now = Instant::now();
 
         let mut to_recycle: Vec<usize> = Vec::new();
         {

--- a/crates/mvm-agentd/tests/worker_pool_warm.rs
+++ b/crates/mvm-agentd/tests/worker_pool_warm.rs
@@ -68,6 +68,33 @@ fn dispatch(pool: &Arc<WorkerPool>, payload: &[u8]) -> DispatchOutcome {
         .expect("dispatch returns outcome")
 }
 
+/// Block until `cond` holds, or fail the test.
+///
+/// A fixed sleep used as a readiness wait is wrong in both directions:
+/// too short and the test fails on a loaded host for no reason, too long
+/// and every run pays the worst case. The deadline here is generous
+/// because it is only ever reached when something is genuinely broken;
+/// the poll interval is what sets the common-case cost.
+fn wait_until(what: &str, mut cond: impl FnMut() -> bool) {
+    const LIMIT: Duration = Duration::from_secs(10);
+    const POLL: Duration = Duration::from_millis(5);
+    let deadline = Instant::now() + LIMIT;
+    while Instant::now() < deadline {
+        if cond() {
+            return;
+        }
+        std::thread::sleep(POLL);
+    }
+    panic!("timed out after {LIMIT:?} waiting for {what}");
+}
+
+/// True once at least one slot is mid-call.
+fn any_slot_busy(pool: &Arc<WorkerPool>) -> bool {
+    pool.snapshot()
+        .iter()
+        .any(|s| matches!(s, SlotSnapshot::Busy))
+}
+
 fn idle_pid(pool: &Arc<WorkerPool>) -> u32 {
     let snap = pool.snapshot();
     snap.iter()
@@ -157,31 +184,44 @@ fn set_idle_timeout_returns_previous_value() {
 
 #[test]
 fn idle_timeout_zero_disables_recycle() {
-    // With timeout=0, even if the worker has been "idle" for a while,
-    // sweep should not touch it. PID remains stable.
+    // With timeout=0 no amount of idleness recycles. Sweeping against an
+    // instant an hour out states that far more strongly than sleeping
+    // 100ms did, and costs nothing.
     let pool = start_pool(cfg(1, 100, 1024));
+    let started = Instant::now();
     let pid_before = idle_pid(&pool);
     assert_eq!(pool.set_idle_timeout(0), 0);
-    std::thread::sleep(Duration::from_millis(100));
-    pool.sweep_idle();
+    pool.sweep_idle_at(started + Duration::from_secs(3600));
     assert_eq!(idle_pid(&pool), pid_before, "no recycle when timeout=0");
 }
 
 #[test]
-fn idle_timeout_recycles_idle_workers_past_threshold() {
-    // 1-second idle timeout. A freshly-spawned worker, given 1.5
-    // seconds of nothing-to-do, should be recycled by an explicit
-    // sweep — `sweep_idle` is the deterministic test hook for what
-    // the background recycler thread does on its 10s tick.
+fn idle_timeout_recycles_idle_workers_only_past_the_threshold() {
+    // 60-second idle timeout, swept against both sides of it.
+    //
+    // The under-threshold half is the half that discriminates: a sweep
+    // that recycled everything unconditionally would pass a
+    // past-threshold-only test. Reaching it by sleeping is not an
+    // option — the wait would have to be shorter than the timeout, so
+    // the timeout would have to be short, and a short timeout is
+    // precisely what makes the other half racy.
     let pool = start_pool(cfg(1, 100, 1024));
+    let started = Instant::now();
     let pid_before = idle_pid(&pool);
-    pool.set_idle_timeout(1);
-    std::thread::sleep(Duration::from_millis(1500));
-    pool.sweep_idle();
-    let pid_after = idle_pid(&pool);
+    pool.set_idle_timeout(60);
+
+    pool.sweep_idle_at(started + Duration::from_secs(59));
+    assert_eq!(
+        idle_pid(&pool),
+        pid_before,
+        "a worker idle for less than the timeout must survive the sweep"
+    );
+
+    pool.sweep_idle_at(started + Duration::from_secs(61));
     assert_ne!(
-        pid_after, pid_before,
-        "expected idle-recycle to replace the worker"
+        idle_pid(&pool),
+        pid_before,
+        "expected idle-recycle to replace the worker past the timeout"
     );
 }
 
@@ -191,6 +231,7 @@ fn idle_timeout_skips_busy_workers() {
     // it — recycling a busy worker would yank the call's pipe and
     // surface as a transport error to the caller.
     let pool = start_pool_with_behavior(cfg(1, 100, 1024), Some("slow_secs=2"));
+    let started = Instant::now();
     pool.set_idle_timeout(1);
 
     // Dispatch a 2s call on a background thread; it'll be Busy
@@ -202,10 +243,14 @@ fn idle_timeout_skips_busy_workers() {
             .expect("dispatch")
     });
 
-    // Give the worker time to enter Busy state (acquire flips the
-    // slot) and pass the 1s idle threshold from spawn.
-    std::thread::sleep(Duration::from_millis(1200));
-    pool.sweep_idle();
+    // Two separate conditions, so two separate mechanisms: wait for the
+    // slot to actually flip to Busy, then sweep against an instant well
+    // past the idle threshold. The old single 1200ms sleep stood in for
+    // both and guaranteed neither.
+    wait_until("the dispatched call to occupy the slot", || {
+        any_slot_busy(&pool)
+    });
+    pool.sweep_idle_at(started + Duration::from_secs(60));
 
     // Slot should still be Busy (the call is in-flight). If the
     // sweep had recycled, the slot would be Idle with a fresh PID.
@@ -335,7 +380,6 @@ fn fifo_queue_serializes_callers() {
     wpc.max_queue_depth = Some(4);
     let pool = start_pool(wpc);
     let pool_clone = Arc::clone(&pool);
-    let start = Instant::now();
     let mut handles = Vec::new();
     for i in 0..5u8 {
         let p = Arc::clone(&pool_clone);
@@ -351,9 +395,16 @@ fn fifo_queue_serializes_callers() {
     for out in &outs {
         assert!(matches!(out.outcome, WorkerOutcome::Exit { code: 0 }));
     }
-    assert!(
-        start.elapsed() < Duration::from_secs(10),
-        "5 quick calls under pool_size=1 finish promptly"
+    // Serialization is the claim, so assert serialization: one slot,
+    // and every one of the five calls went through it. The previous
+    // `start.elapsed() < 10s` asserted nothing about ordering — it was
+    // a wall-clock budget, and the only thing it ever caught was a
+    // loaded CI host.
+    let pid = idle_pid(&pool);
+    assert_eq!(
+        idle_call_count(&pool, pid),
+        5,
+        "all five callers must have queued through the single worker"
     );
 }
 
@@ -388,11 +439,16 @@ fn queue_full_returns_error() {
     let p1 = Arc::clone(&pool);
     let p2 = Arc::clone(&pool);
     let h1 = std::thread::spawn(move || p1.dispatch(b"a".to_vec(), 10, Vec::new()));
-    // Give the first dispatch time to enter the worker (occupy slot).
-    std::thread::sleep(Duration::from_millis(200));
+    // The first caller must hold the only slot before the second can
+    // queue behind it; the second must be parked in the queue before a
+    // third can overflow it. Both are observable, so neither is timed.
+    wait_until("the first caller to occupy the only slot", || {
+        any_slot_busy(&pool)
+    });
     let h2 = std::thread::spawn(move || p2.dispatch(b"b".to_vec(), 10, Vec::new()));
-    // Give the second dispatch time to enter the queue.
-    std::thread::sleep(Duration::from_millis(200));
+    wait_until("the second caller to park in the queue", || {
+        pool.queued_waiters() == 1
+    });
 
     // Third should hit QueueFull.
     let res = pool.dispatch(b"c".to_vec(), 10, Vec::new());
@@ -455,8 +511,11 @@ fn wait_for_ready_succeeds_against_passing_probe() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let probe = write_probe(tmp.path(), "after_start.sh", "#!/bin/sh\nexit 0\n");
     let pool = start_pool_unready(cfg(1, 100, 1024));
+    // Generous bound: this test asserts the probe *succeeds*, so the
+    // timeout is only here to stop a hang. Sizing it tightly turns a
+    // busy host into a red test without telling anyone anything.
     let cfg_probe = ReadinessConfig::new(probe)
-        .with_timeout(Duration::from_secs(2))
+        .with_timeout(Duration::from_secs(60))
         .with_interval(Duration::from_millis(50));
     pool.wait_for_ready(&cfg_probe).expect("ready");
     assert!(pool.is_ready());
@@ -477,8 +536,11 @@ fn wait_for_ready_succeeds_after_initial_failures() {
     );
     let probe = write_probe(tmp.path(), "after_start.sh", &body);
     let pool = start_pool_unready(cfg(1, 100, 1024));
+    // Generous for the same reason as the passing-probe test: three
+    // probe attempts at a 50ms interval, so the subject is the retry,
+    // not the deadline.
     let cfg_probe = ReadinessConfig::new(probe)
-        .with_timeout(Duration::from_secs(3))
+        .with_timeout(Duration::from_secs(60))
         .with_interval(Duration::from_millis(50));
 
     // While warming, dispatch should fail-closed.

--- a/crates/mvm-runtime/src/substitution_spawn.rs
+++ b/crates/mvm-runtime/src/substitution_spawn.rs
@@ -563,25 +563,36 @@ mod tests {
 
         assert!(result.is_err(), "invalid MVM_HOME must fail sidecar setup");
         assert!(!state_dir.join(SUBST_PID_FILE).exists());
-        for _ in 0..100 {
-            if stopped.exists() {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(10));
+
+        // The stub is a shell script: it has to take the SIGTERM, run the
+        // trap body and write the sentinel. One second of budget for that
+        // is not a property of the rollback, it is a bet on how loaded the
+        // host is. The deadline here is only a hang guard, so it is
+        // generous; the poll interval sets the common-case cost.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while !stopped.exists() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(5));
         }
-        if !stopped.exists()
-            && let Ok(pid) = std::fs::read_to_string(&pid_capture)
+        let sentinel_written = stopped.exists();
+
+        // Reap the stub whatever happened, but only after reading the
+        // sentinel. SIGKILL cannot fire a TERM trap, so killing first
+        // turns "the stub was slow" into "the sentinel can never appear"
+        // — the previous order did exactly that, then asserted on the
+        // outcome it had just foreclosed.
+        if let Ok(pid) = std::fs::read_to_string(&pid_capture)
             && let Ok(pid) = pid.trim().parse::<libc::pid_t>()
         {
             unsafe {
                 libc::kill(pid, libc::SIGKILL);
             }
         }
+        std::fs::remove_dir_all(&dir).ok();
+
         assert!(
-            stopped.exists(),
+            sentinel_written,
             "rollback must terminate the endpoint process"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     // Build a minimal params (empty secrets, default redaction, UDS transport,


### PR DESCRIPTION
## What

`crates/mvm-agentd/tests/worker_pool_warm.rs` used a fixed `thread::sleep` as a readiness wait in four places, and a wall-clock budget as a correctness assertion in a fifth. Every one is wrong in both directions: too short and it fails on a loaded host for no reason, too long and each run pays the worst case. Two of them failed during this work on nothing more than a cold `target/` dir.

## Two of the sleeps were not waits

They were **spending an idle timeout in order to test an idle timeout**, so polling cannot remove them — the elapsed time is the subject. `sweep_idle` now delegates to `sweep_idle_at(now: Instant)`, taking the instant rather than reading the clock:

```rust
pub fn sweep_idle(self: &Arc<Self>) { self.sweep_idle_at(Instant::now()) }
pub fn sweep_idle_at(self: &Arc<Self>, now: Instant) { … }
```

A test can then ask what the sweep would do an hour from now, in no time at all.

That also buys a check the old shape structurally could not make. The old test slept past a 1s threshold and asserted a recycle — **a sweep that recycled every idle worker unconditionally would have passed it**. Reaching the under-threshold side by sleeping is not possible: the wait has to be shorter than the timeout, so the timeout has to be short, and a short timeout is exactly what makes the other half racy. Against a 60s timeout swept at 59s and 61s, both halves are checked and neither waits.

Falsified, not assumed: pinning the comparison to `Duration::ZERO` fails the 59s assertion.

```
FAIL idle_timeout_recycles_idle_workers_only_past_the_threshold
  assertion `left == right` failed: a worker idle for less than the timeout must survive the sweep
```

## The three genuine readiness waits now poll

Two of them had nothing to poll, so `WorkerPool` grew `queued_waiters()`. The queue cap is enforced against `pending_waiters`, so that count is the only thing that can say a caller has actually reached the queue — the alternative is inferring it from elapsed time, which is the defect being removed.

## Two more of the same family, found while measuring

- `fifo_queue_serializes_callers` asserted `start.elapsed() < 10s` and **nothing about ordering**, despite its name. It now asserts all five callers ran on the single worker, which is what serialization means and does not care how busy the host is.
- The two `wait_for_ready` tests that assert the probe *succeeds* had 2s and 3s bounds. The deadline is not their subject, it is a hang guard; both are now 60s. The two tests that do have the timeout as their subject keep their short bounds.

## Verification

```
cargo nextest run -p mvm-agentd                      # 522 passed, 0 skipped
cargo clippy -p mvm-agentd --all-targets -- -D warnings
41/41 xtask Lint gates green
```

The two idle-timeout tests drop from 2.7s of pure sleeping to 0.12s.
