### PR TITLE
Reconcile the apple-container auto_select guards with the ladder

### DIFF
--- a/crates/mvm-runtime/src/apple_container_backend.rs
+++ b/crates/mvm-runtime/src/apple_container_backend.rs
@@ -224,15 +224,29 @@ mod tests {
         }
     }
 
+    /// The apple-container backend is not opt-in any more: on the hvf default
+    /// tier `auto_select` prefers it when Apple's container kernel is already
+    /// cached, so a plain `machine run` reaches it without `--hypervisor`.
+    ///
+    /// This asserts the *exact* condition rather than a one-directional
+    /// "never", because both directions are regressions: reaching
+    /// apple-container off the hvf tier, and failing to reach it when its
+    /// artifact is present. The predecessor asserted "never" and went stale
+    /// the moment the ladder gained the arm — invisibly, because that branch
+    /// is unreachable on the Linux CI runners, so it broke only the macOS
+    /// contributors it was meant to protect.
     #[test]
-    fn auto_select_never_returns_apple_container() {
-        // Opt-in only: `auto_select`'s ladder constructs Firecracker/Hvf/
-        // Libkrun and nothing else, so this holds on every platform the
-        // ladder can resolve to.
-        assert_ne!(
-            AnyBackend::auto_select().kind(),
-            BackendKind::AppleContainer,
-            "auto_select must never fall through to the apple-container backend"
+    fn auto_select_picks_apple_container_exactly_when_its_kernel_is_cached() {
+        let hvf_tier = mvm_core::platform::current().is_hvf_default_tier();
+        let kernel_cached = AppleContainerBackend::new().is_available().unwrap_or(false);
+        let selected = AnyBackend::auto_select().kind();
+
+        assert_eq!(
+            selected == BackendKind::AppleContainer,
+            hvf_tier && kernel_cached,
+            "auto_select reached {selected:?}; the apple-container arm is taken \
+             exactly when the hvf tier is default and its container kernel is \
+             cached (hvf_tier={hvf_tier}, kernel_cached={kernel_cached})"
         );
     }
 

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -1211,8 +1211,13 @@ mod tests {
             // The full set of legitimate auto_select returns is:
             //   firecracker (KVM), hvf (macOS 26+ hvf VMM, via the HVF workload
             //   runner whose name() delegates to the hvf driver), libkrun
-            //   (macOS 13-25 / Linux non-KVM fallback).
-            matches!(name, "firecracker" | "hvf" | "libkrun"),
+            //   (macOS 13-25 / Linux non-KVM fallback), and apple-container
+            //   (the hvf tier's preferred arm when Apple's container kernel is
+            //   already cached). Which of the last two the hvf tier resolves to
+            //   is pinned by `auto_select_picks_apple_container_exactly_when_
+            //   its_kernel_is_cached` in `apple_container_backend`; this test
+            //   only asserts the ladder never leaves that set.
+            matches!(name, "firecracker" | "hvf" | "libkrun" | "apple-container"),
             "auto_select returned unexpected backend: {name}"
         );
     }


### PR DESCRIPTION
**`main` is currently red on macOS 26 Apple Silicon, and no CI lane can see it.**

Found while reproducing the recurring test flakes — this isn't a flake. It fails deterministically in 0.04s.

## The contradiction

- **#1949** added two guards asserting `auto_select` must **never** return the apple-container backend — "opt-in only", on the stated basis that the ladder constructs Firecracker/Hvf/Libkrun and nothing else.
- **#1968** (merged today) changed the ladder to *prefer* apple-container on the hvf tier when Apple's container kernel is cached, so "a plain `machine run` uses it without `--hypervisor`" — and didn't update the guards.

Both were deliberate. They simply disagree.

CI stays green because `is_hvf_default_tier()` is false on the Linux runners, so the branch is unreachable there. It fires only on macOS 26+ Apple Silicon with the kernel cached — i.e. **only for the contributors the guards exist to protect.**

```
apple_container_backend::tests::auto_select_never_returns_apple_container
  assertion `left != right` failed: auto_select must never fall through to the apple-container backend
    left: AppleContainer
   right: AppleContainer
```

## The fix

The ladder is the newer, deliberate intent, so the guards were stale. Rather than delete them and lose the coverage, they now assert the **exact** condition:

> apple-container is selected **if and only if** the hvf tier is default **and** the container kernel is cached.

That catches regressions in *both* directions — silently reaching apple-container off the tier, and failing to reach it when its artifact is present. The old "never" could only ever catch one, and went stale the instant the ladder gained an arm.

`test_auto_select_returns_valid_backend` gains `apple-container` in its allowed set, pointing at the exactly-when test for which arm the hvf tier takes.

## Verified in both directions

On a macOS 26 host, which is the only place this is observable:

- as merged → **green** (6/6 auto_select tests)
- with the apple-container arm removed from the ladder → **red**

So the assertion discriminates rather than trivially passing.

`cargo clippy -p mvm-runtime --all-targets -- -D warnings` clean; nightly fmt clean; full `mvm-runtime` suite 1217/1218.

## The one other failure, and why it isn't mine

`builder_runner::runner::tests::build_rides_the_closure_nar_on_the_same_input_disk_when_present` fails in a *fresh worktree* and passes in a checkout that has run `cargo build`:

```
mvm-substitution-endpoint not found. It is a per-VM host helper compiled by
mvmctl's build script; on a source checkout run `cargo build` ...
```

Pre-existing, unrelated to this change, and the same family as the `$HOME` non-hermeticity fixed in #1975 — a test that depends on ambient state, so it passes in CI and fails on a clean checkout. Logged for the hermeticity sweep rather than folded in here.