### PR TITLE
refactor(initramfs): build the universal initramfs as a deterministic cargo artifact, not a Nix build

### DIFF
--- a/crates/mvm-build/src/initramfs.rs
+++ b/crates/mvm-build/src/initramfs.rs
@@ -265,12 +265,13 @@ fn build_initramfs_with_cargo(
 }
 
 /// Write the four artifact files (image + sidecars) for `agent_bytes` into
+/// Write the four artifact files (image + sidecars) for `agent_bytes` into
 /// `out_dir`: the deterministic image, `initramfs.hash` = SHA-256 of the
 /// UNCOMPRESSED cpio, `initramfs.size` = the compressed byte length, and
-/// `VERSION` — the same contract the publish-path build emits. Ungated so
-/// the assembly is unit-testable on every host.
-#[cfg(any(target_os = "linux", test))]
-fn assemble_initramfs_artifact(
+/// `VERSION` — the same contract the publish-path build emits. `pub` as
+/// the deterministic-assembly contract surface (the conformance suite
+/// drives it hermetically).
+pub fn assemble_initramfs_artifact(
     agent_bytes: &[u8],
     version: &str,
     out_dir: &Path,
@@ -301,9 +302,10 @@ fn assemble_initramfs_artifact(
 /// agent, mode 0755), epoch-zero metadata in a stable order — the Rust
 /// equivalent of `find . | sort | cpio -o -H newc --owner=0:0` with all
 /// timestamps touched to the epoch. No `/dev` nodes: PID 1 mounts
-/// devtmpfs itself, so the kernel creates the device nodes.
-#[cfg(any(target_os = "linux", test))]
-fn initramfs_cpio(agent_bytes: &[u8]) -> Vec<u8> {
+/// devtmpfs itself, so the kernel creates the device nodes. `pub` as the
+/// determinism contract surface (the conformance suite builds it twice
+/// and compares bytes).
+pub fn initramfs_cpio(agent_bytes: &[u8]) -> Vec<u8> {
     crate::rootfs_inject::build_newc_cpio(&[
         crate::rootfs_inject::CpioEntry::dir("."),
         crate::rootfs_inject::CpioEntry::file("./init", 0o755, agent_bytes.to_vec()),
@@ -313,7 +315,6 @@ fn initramfs_cpio(agent_bytes: &[u8]) -> Vec<u8> {
 /// Gzip at the maximum level with no name/timestamp header — the
 /// deterministic counterpart of `gzip -n -9` (the flate2 encoder writes a
 /// zero mtime and no original filename by default).
-#[cfg(any(target_os = "linux", test))]
 fn gzip_deterministic(data: &[u8]) -> Result<Vec<u8>, InitramfsBuildError> {
     use std::io::Write as _;
     let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::best());
@@ -322,7 +323,6 @@ fn gzip_deterministic(data: &[u8]) -> Result<Vec<u8>, InitramfsBuildError> {
 }
 
 /// Lowercase-hex SHA-256 of `data`.
-#[cfg(any(target_os = "linux", test))]
 fn sha256_hex(data: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     hex::encode(Sha256::digest(data))

--- a/crates/mvm-build/src/initramfs.rs
+++ b/crates/mvm-build/src/initramfs.rs
@@ -1,9 +1,16 @@
 //! Build and resolve the universal initramfs artifact.
 //!
-//! The initramfs is built by `nix/images/initramfs/flake.nix` and cached at
-//! `<cache_root>/<version>/<arch>/`. This module mirrors the runtime-overlay
-//! orchestration but is intentionally smaller because the artifact has no
-//! verity sidecar and no per-rootfs variation.
+//! The initramfs is a tiny deterministic **cargo artifact** — one static
+//! `mvm-guest-agent` binary packed as `/init` in an epoch-zero newc cpio —
+//! built locally by [`build_initramfs_with_cargo`] on Linux and cached at
+//! `<cache_root>/<version>/<arch>/`. Its attestability comes from the
+//! reproducible cargo build of the pinned agent source plus the content
+//! hash, not from Nix. Nix remains the build for kernels, images, and
+//! overlays, where toolchain variance matters; `nix/images/initramfs`
+//! stays as the optional publish-path build of the same artifact. This
+//! module mirrors the runtime-overlay orchestration but is intentionally
+//! smaller because the artifact has no verity sidecar and no per-rootfs
+//! variation.
 
 use std::path::{Path, PathBuf};
 
@@ -27,9 +34,10 @@ pub enum InitramfsBuildError {
         reason: &'static str,
     },
 
-    /// `nix build` failed.
-    #[error("nix build failed: {reason}")]
-    NixBuildFailed { reason: String },
+    /// The deterministic cargo build failed (agent cross-compile or the
+    /// cpio assembly).
+    #[error("cargo initramfs build failed: {reason}")]
+    CargoBuildFailed { reason: String },
 
     /// A downloaded artifact's sha256 didn't match the pre-committed entry.
     #[error("checksum mismatch for {name}: expected sha256 {expected}, computed {actual}")]
@@ -171,10 +179,8 @@ fn seed_from_default_cache(
 }
 
 /// Resolve a cached universal initramfs, or return an error describing why it
-/// is unavailable. A full `nix build` fallback is intentionally gated behind
-/// `#[cfg(target_os = "linux")]` and runs through the supplied
-/// `ShellEnvironment` so it executes on the current Linux execution boundary
-/// (the builder VM on macOS, the native host on Linux).
+/// is unavailable. A cold cache on Linux falls back to the deterministic
+/// cargo build; a cold cache elsewhere falls back to the published download.
 pub fn resolve_or_build_local_initramfs(
     _env: &dyn ShellEnvironment,
     cache_root: &Path,
@@ -191,13 +197,14 @@ pub fn resolve_or_build_local_initramfs(
 
     #[cfg(target_os = "linux")]
     {
-        build_initramfs_with_nix(_env, cache_root, version, arch)
+        build_initramfs_with_cargo(cache_root, version, arch)
     }
     #[cfg(not(target_os = "linux"))]
     {
-        // macOS / non-Linux hosts cannot run `nix build` for a Linux initramfs.
-        // Try to download a published release artifact into the cache before
-        // giving up. This mirrors the runtime-overlay download path.
+        // macOS / non-Linux hosts cannot run the cargo cross-compile for a
+        // Linux initramfs here. Try to download a published release artifact
+        // into the cache before giving up. This mirrors the runtime-overlay
+        // download path.
         match download_initramfs(version, arch, cache_root) {
             Ok(artifact) => Ok(artifact),
             Err(download_err) => {
@@ -206,7 +213,7 @@ pub fn resolve_or_build_local_initramfs(
                     "initramfs download fallback unavailable"
                 );
                 Err(InitramfsBuildError::HostUnsupported {
-                    operation: "nix build",
+                    operation: "cargo initramfs build",
                     reason: "universal initramfs build requires Linux and no published artifact was available; seed the cache from a Linux build",
                 })
             }
@@ -214,77 +221,111 @@ pub fn resolve_or_build_local_initramfs(
     }
 }
 
+/// Build the universal initramfs as a deterministic cargo artifact and
+/// install it into the cache.
+///
+/// The initramfs is a tiny artifact — one static binary in a deterministic
+/// cpio — so its attestability comes from the reproducible cargo build plus
+/// the content hash, not from Nix: the pinned agent source is
+/// cross-compiled once by the shared guest-binary builder (`cargo
+/// zigbuild` → the arch's musl triple, content-keyed cache, reused as-is),
+/// then packed as exactly `/init` (mode 0755) in an epoch-zero,
+/// stably-ordered newc cpio, gzipped without name/timestamp. Same source +
+/// same toolchain ⇒ the same `initramfs.hash`. Nix remains the build for
+/// kernels, images, and overlays, where toolchain variance matters; the
+/// flake's initramfs package stays as the optional publish-path build of
+/// the same artifact.
 #[cfg(target_os = "linux")]
-fn initramfs_source_checkout_root() -> Option<PathBuf> {
-    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir.parent()?.parent()?;
-    workspace_root
-        .join("nix")
-        .join("images")
-        .join("initramfs")
-        .join("flake.nix")
-        .is_file()
-        .then(|| workspace_root.to_path_buf())
-}
-
-/// Build the universal initramfs via `nix build` and install it into the cache.
-#[cfg(target_os = "linux")]
-fn build_initramfs_with_nix(
-    env: &dyn ShellEnvironment,
+fn build_initramfs_with_cargo(
     cache_root: &Path,
     version: &str,
     arch: GuestArch,
 ) -> Result<InitramfsArtifact, InitramfsBuildError> {
-    let workspace_root =
-        initramfs_source_checkout_root().ok_or_else(|| InitramfsBuildError::NixBuildFailed {
-            reason: "cannot locate workspace root with nix/images/initramfs/flake.nix".into(),
-        })?;
-    let flake_ref = format!(
-        "path:{}/nix/images/initramfs#packages.{}.initramfs",
-        workspace_root.display(),
-        nix_system_for_arch(arch),
-    );
-
-    let tmp = tempfile::tempdir()?;
-    let out_link = tmp.path().join("result");
-    let script = format!(
-        "MVM_WORKSPACE_PATH={} nix build --extra-experimental-features 'nix-command flakes' --impure --out-link {} {}",
-        shell_quote(&workspace_root.display().to_string()),
-        shell_quote(&out_link.display().to_string()),
-        shell_quote(&flake_ref),
-    );
-
-    if let Err(e) = env.shell_exec_capture(&script) {
-        return Err(InitramfsBuildError::NixBuildFailed {
-            reason: format!("nix build failed: {e}"),
-        });
-    }
-
-    install_initramfs_into_cache(&out_link, cache_root, version, arch)
-}
-
-/// Quote a string for safe interpolation into a single-quoted POSIX shell word.
-#[cfg(target_os = "linux")]
-fn shell_quote(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 2);
-    out.push('\'');
-    for c in s.chars() {
-        if c == '\'' {
-            out.push_str(r"'\''");
-        } else {
-            out.push(c);
+    let workspace = crate::guest_agent_build::detect_source_workspace().ok_or_else(|| {
+        InitramfsBuildError::CargoBuildFailed {
+            reason: "no source checkout detected to build the guest agent from".into(),
         }
-    }
-    out.push('\'');
-    out
+    })?;
+    let cache_key = crate::guest_agent_build::source_cache_key(&workspace).map_err(|e| {
+        InitramfsBuildError::CargoBuildFailed {
+            reason: format!("fingerprint guest sources: {e}"),
+        }
+    })?;
+    let binaries = crate::guest_agent_build::resolve_or_build_guest_binaries(
+        cache_root, &cache_key, arch, &workspace,
+    )
+    .map_err(|e| InitramfsBuildError::CargoBuildFailed {
+        reason: format!("build the static guest agent: {e}"),
+    })?;
+    let agent_bytes = std::fs::read(&binaries.agent)?;
+
+    let staging = tempfile::tempdir()?;
+    assemble_initramfs_artifact(&agent_bytes, version, staging.path())?;
+    install_initramfs_into_cache(staging.path(), cache_root, version, arch)
 }
 
-#[cfg(target_os = "linux")]
-fn nix_system_for_arch(arch: GuestArch) -> &'static str {
-    match arch {
-        GuestArch::Aarch64 => "aarch64-linux",
-        GuestArch::X86_64 => "x86_64-linux",
-    }
+/// Write the four artifact files (image + sidecars) for `agent_bytes` into
+/// `out_dir`: the deterministic image, `initramfs.hash` = SHA-256 of the
+/// UNCOMPRESSED cpio, `initramfs.size` = the compressed byte length, and
+/// `VERSION` — the same contract the publish-path build emits. Ungated so
+/// the assembly is unit-testable on every host.
+#[cfg(any(target_os = "linux", test))]
+fn assemble_initramfs_artifact(
+    agent_bytes: &[u8],
+    version: &str,
+    out_dir: &Path,
+) -> Result<(), InitramfsBuildError> {
+    let cpio = initramfs_cpio(agent_bytes);
+    let image = gzip_deterministic(&cpio)?;
+    std::fs::create_dir_all(out_dir)?;
+    std::fs::write(
+        out_dir.join(mvm_fs::initramfs::INITRAMFS_IMAGE_FILE),
+        &image,
+    )?;
+    std::fs::write(
+        out_dir.join(mvm_fs::initramfs::INITRAMFS_HASH_FILE),
+        format!("{}\n", sha256_hex(&cpio)),
+    )?;
+    std::fs::write(
+        out_dir.join(mvm_fs::initramfs::INITRAMFS_SIZE_FILE),
+        format!("{}\n", image.len()),
+    )?;
+    std::fs::write(
+        out_dir.join(mvm_fs::initramfs::VERSION_FILE),
+        format!("{version}\n"),
+    )?;
+    Ok(())
+}
+
+/// The deterministic cpio payload: exactly `.` and `./init` (the static
+/// agent, mode 0755), epoch-zero metadata in a stable order — the Rust
+/// equivalent of `find . | sort | cpio -o -H newc --owner=0:0` with all
+/// timestamps touched to the epoch. No `/dev` nodes: PID 1 mounts
+/// devtmpfs itself, so the kernel creates the device nodes.
+#[cfg(any(target_os = "linux", test))]
+fn initramfs_cpio(agent_bytes: &[u8]) -> Vec<u8> {
+    crate::rootfs_inject::build_newc_cpio(&[
+        crate::rootfs_inject::CpioEntry::dir("."),
+        crate::rootfs_inject::CpioEntry::file("./init", 0o755, agent_bytes.to_vec()),
+    ])
+}
+
+/// Gzip at the maximum level with no name/timestamp header — the
+/// deterministic counterpart of `gzip -n -9` (the flate2 encoder writes a
+/// zero mtime and no original filename by default).
+#[cfg(any(target_os = "linux", test))]
+fn gzip_deterministic(data: &[u8]) -> Result<Vec<u8>, InitramfsBuildError> {
+    use std::io::Write as _;
+    let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::best());
+    enc.write_all(data)?;
+    Ok(enc.finish()?)
+}
+
+/// Lowercase-hex SHA-256 of `data`.
+#[cfg(any(target_os = "linux", test))]
+fn sha256_hex(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    hex::encode(Sha256::digest(data))
 }
 
 /// Install a prebuilt initramfs directory into the cache atomically.
@@ -705,6 +746,14 @@ mod tests {
     /// to prove absent, and hung for hours once it genuinely could not.
     #[test]
     fn resolve_returns_missing_when_cache_empty() {
+        // Isolate the whole mvm world so the seed-from-default-cache step
+        // cannot find the developer's real cache — the assertion is that a
+        // truly cold cache errors, which only holds when the default cache
+        // is cold too.
+        let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
+        let home = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(home.path());
         let dir = tempfile::tempdir().unwrap();
         // HOME has to move with the cache root: a miss is seeded from
         // `$HOME/.mvm/cache`, so without this the assertion holds only on a
@@ -913,6 +962,147 @@ mod tests {
         header.set_size(u64::try_from(bytes.len()).unwrap());
         header.set_cksum();
         tar.append_data(&mut header, path, bytes).unwrap();
+    }
+
+    // --- deterministic cargo artifact assembly ---
+
+    /// Parse the entry names of a newc archive, stopping at the trailer.
+    /// Test-only: the layout assertions need the exact entry sequence.
+    fn newc_names(cpio: &[u8]) -> Vec<String> {
+        fn hex8(cpio: &[u8], off: usize) -> usize {
+            usize::from_str_radix(std::str::from_utf8(&cpio[off..off + 8]).unwrap(), 16).unwrap()
+        }
+        let mut names = Vec::new();
+        let mut off = 0;
+        loop {
+            assert_eq!(&cpio[off..off + 6], b"070701", "bad magic at {off}");
+            let filesize = hex8(cpio, off + 54);
+            let namesize = hex8(cpio, off + 94);
+            let name =
+                String::from_utf8(cpio[off + 110..off + 110 + namesize - 1].to_vec()).unwrap();
+            let done = name == "TRAILER!!!";
+            names.push(name);
+            off = (off + 110 + namesize).div_ceil(4) * 4;
+            off = (off + filesize).div_ceil(4) * 4;
+            if done {
+                return names;
+            }
+        }
+    }
+
+    /// Assert every record in the archive carries epoch-zero mtime and
+    /// zero uid/gid — the metadata side of the determinism guarantee.
+    fn assert_epoch_zero_metadata(cpio: &[u8]) {
+        let mut off = 0;
+        loop {
+            // uid + gid are zero (root-owned), and mtime is the epoch.
+            assert_eq!(&cpio[off + 22..off + 38], b"0000000000000000".as_slice());
+            assert_eq!(&cpio[off + 46..off + 54], b"00000000".as_slice());
+            let filesize =
+                usize::from_str_radix(std::str::from_utf8(&cpio[off + 54..off + 62]).unwrap(), 16)
+                    .unwrap();
+            let namesize =
+                usize::from_str_radix(std::str::from_utf8(&cpio[off + 94..off + 102]).unwrap(), 16)
+                    .unwrap();
+            let done = &cpio[off + 110..off + 110 + 9] == b"TRAILER!!";
+            off = (off + 110 + namesize).div_ceil(4) * 4;
+            off = (off + filesize).div_ceil(4) * 4;
+            if done {
+                return;
+            }
+        }
+    }
+
+    #[test]
+    fn initramfs_cpio_is_byte_deterministic_across_builds() {
+        let a = initramfs_cpio(b"agent-bytes");
+        let b = initramfs_cpio(b"agent-bytes");
+        assert_eq!(a, b, "same agent bytes must produce the same cpio");
+        assert_eq!(sha256_hex(&a), sha256_hex(&b));
+        assert_epoch_zero_metadata(&a);
+
+        let gz_a = gzip_deterministic(&a).unwrap();
+        let gz_b = gzip_deterministic(&a).unwrap();
+        assert_eq!(gz_a, gz_b, "the gzip stream must be deterministic too");
+    }
+
+    #[test]
+    fn initramfs_cpio_layout_is_dot_and_init_only() {
+        let cpio = initramfs_cpio(b"agent-bytes");
+        assert_eq!(
+            newc_names(&cpio),
+            vec![
+                ".".to_string(),
+                "./init".to_string(),
+                "TRAILER!!!".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn assemble_writes_the_full_sidecar_contract() {
+        let dir = tempfile::tempdir().unwrap();
+        assemble_initramfs_artifact(b"agent-bytes", "0.18.0", dir.path()).unwrap();
+
+        let image = std::fs::read(dir.path().join("initramfs.cpio.gz")).unwrap();
+        let hash = std::fs::read_to_string(dir.path().join("initramfs.hash")).unwrap();
+        let size = std::fs::read_to_string(dir.path().join("initramfs.size")).unwrap();
+        let version = std::fs::read_to_string(dir.path().join("VERSION")).unwrap();
+
+        // The hash covers the UNCOMPRESSED cpio; the size covers the
+        // compressed file — the resolver's two sidecars describe
+        // different bytes.
+        let mut uncompressed = Vec::new();
+        std::io::Read::read_to_end(
+            &mut flate2::read::GzDecoder::new(image.as_slice()),
+            &mut uncompressed,
+        )
+        .unwrap();
+        assert_eq!(uncompressed, initramfs_cpio(b"agent-bytes"));
+        assert_eq!(hash.trim(), sha256_hex(&uncompressed));
+        assert_eq!(size.trim().parse::<usize>().unwrap(), image.len());
+        assert_eq!(version.trim(), "0.18.0");
+    }
+
+    #[test]
+    fn cold_build_output_installs_and_resolves_through_the_resolver() {
+        // The hermetic cold-cache path: assemble with stand-in agent bytes,
+        // install, and resolve — the same pipeline the cargo build runs
+        // after the (separately cached and tested) agent cross-compile.
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let cache_root = tmp.path().join("cache");
+        assemble_initramfs_artifact(b"fake-agent", "0.18.0", &source).unwrap();
+
+        let artifact =
+            install_initramfs_into_cache(&source, &cache_root, "0.18.0", GuestArch::Aarch64)
+                .unwrap();
+        let resolved = InitramfsResolver::new(&cache_root, "0.18.0")
+            .resolve(&GuestArch::Aarch64.to_string())
+            .unwrap();
+        assert_eq!(resolved.image_path, artifact.image_path);
+    }
+
+    #[test]
+    fn warm_cache_resolve_skips_any_build_or_download() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let cache_root = tmp.path().join("cache");
+        assemble_initramfs_artifact(b"fake-agent", "0.18.0", &source).unwrap();
+        install_initramfs_into_cache(&source, &cache_root, "0.18.0", GuestArch::Aarch64).unwrap();
+
+        // A warm cache resolves without touching the shell environment
+        // (NoopShell would silently succeed anyway) and without network.
+        let artifact =
+            resolve_or_build_local_initramfs(&NoopShell, &cache_root, "0.18.0", GuestArch::Aarch64)
+                .unwrap();
+        assert_eq!(
+            artifact.image_path,
+            cache_root
+                .join("0.18.0")
+                .join(GuestArch::Aarch64.to_string())
+                .join("initramfs.cpio.gz")
+        );
     }
 
     #[test]

--- a/crates/mvm-build/src/initramfs.rs
+++ b/crates/mvm-build/src/initramfs.rs
@@ -750,11 +750,6 @@ mod tests {
         // cannot find the developer's real cache — the assertion is that a
         // truly cold cache errors, which only holds when the default cache
         // is cold too.
-        let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let mut env = TestEnv::new();
-        let home = tempfile::tempdir().unwrap();
-        env.isolate_mvm_home(home.path());
-        let dir = tempfile::tempdir().unwrap();
         // HOME has to move with the cache root: a miss is seeded from
         // `$HOME/.mvm/cache`, so without this the assertion holds only on a
         // machine that has never built an initramfs — which CI is and a
@@ -767,8 +762,13 @@ mod tests {
         // test ran for 20,000+ seconds in CI and took the job to its six-hour
         // limit. Isolating HOME is what made it reachable — before that the test
         // passed on Linux by finding an artifact it was supposed to prove absent.
+        //
+        // One lock, taken once: `ENV_TEST_LOCK` is a plain `std::sync::Mutex`
+        // and is not reentrant, so acquiring it twice on this thread deadlocks
+        // the test rather than failing it.
         let _lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let mut env = TestEnv::new();
+        let dir = tempfile::tempdir().unwrap();
         env.isolate_mvm_home(dir.path());
         let cache = dir.path().join("cache");
         let err = resolve_or_seed_from_default_cache(&cache, "0.18.0", GuestArch::Aarch64)

--- a/crates/mvm-build/src/initramfs.rs
+++ b/crates/mvm-build/src/initramfs.rs
@@ -1083,6 +1083,32 @@ mod tests {
         assert_eq!(resolved.image_path, artifact.image_path);
     }
 
+    /// Shell double that fails loudly if the warm-cache resolve below ever
+    /// reaches for the shell — the point of that test is that a warm cache
+    /// resolves without one. A silent no-op double is what let the old
+    /// empty-cache resolve test fall into a real build and hang, so an empty
+    /// cache is exercised through `resolve_or_seed_from_default_cache`
+    /// instead of this path.
+    struct PanicShell;
+
+    impl ShellEnvironment for PanicShell {
+        fn shell_exec(&self, _script: &str) -> anyhow::Result<()> {
+            panic!("a warm-cache resolve must not run shell commands")
+        }
+
+        fn shell_exec_stdout(&self, _script: &str) -> anyhow::Result<String> {
+            panic!("a warm-cache resolve must not run shell commands")
+        }
+
+        fn shell_exec_visible(&self, _script: &str) -> anyhow::Result<()> {
+            panic!("a warm-cache resolve must not run shell commands")
+        }
+
+        fn log_info(&self, _msg: &str) {}
+
+        fn log_success(&self, _msg: &str) {}
+    }
+
     #[test]
     fn warm_cache_resolve_skips_any_build_or_download() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1092,10 +1118,14 @@ mod tests {
         install_initramfs_into_cache(&source, &cache_root, "0.18.0", GuestArch::Aarch64).unwrap();
 
         // A warm cache resolves without touching the shell environment
-        // (NoopShell would silently succeed anyway) and without network.
-        let artifact =
-            resolve_or_build_local_initramfs(&NoopShell, &cache_root, "0.18.0", GuestArch::Aarch64)
-                .unwrap();
+        // (PanicShell proves it) and without network.
+        let artifact = resolve_or_build_local_initramfs(
+            &PanicShell,
+            &cache_root,
+            "0.18.0",
+            GuestArch::Aarch64,
+        )
+        .unwrap();
         assert_eq!(
             artifact.image_path,
             cache_root

--- a/crates/mvm-conformance/tests/steps/apple_container.rs
+++ b/crates/mvm-conformance/tests/steps/apple_container.rs
@@ -1,0 +1,133 @@
+//! Steps for the Apple Container backend's hermetic contracts: artifact
+//! resolution fails closed with a typed, hint-carrying error; auto-select
+//! never lands on the backend; and the launch-config kernel substitution
+//! replaces exactly the kernel path. These drive the real backend code and
+//! never start a VM, so they run in the normal hermetic BDD gate.
+
+use cucumber::{given, then, when};
+use mvm_core::vm_backend::VmBackend as _;
+use mvm_core::vm_backend::VmStartConfig;
+use mvm_runtime::apple_container_backend::{
+    AppleContainerBackend, AppleContainerError, kernel_override_config,
+};
+
+use crate::world::{CliWorld, MvmHomeGuard};
+
+#[given("an isolated mvm home for the apple-container backend")]
+fn isolated_home(world: &mut CliWorld) {
+    let home = tempfile::tempdir().expect("create scenario home");
+    world.mvm_home_guard = Some(MvmHomeGuard::new(home.path()));
+    world.isolated_home = Some(home);
+}
+
+#[when("I start the apple-container backend with a minimal config")]
+fn start_minimal(world: &mut CliWorld) {
+    let err = AppleContainerBackend::new()
+        .start(&VmStartConfig::default())
+        .expect_err("start must fail with no kernel in the isolated cache");
+    let AppleContainerError::ArtifactMissing { what, path, hint } = err
+        .downcast_ref::<AppleContainerError>()
+        .expect("the failure must be the typed artifact error");
+    world.apple_container_error = Some((what.to_string(), path.clone(), hint.to_string()));
+}
+
+#[then("the start fails with a missing-artifact error naming the container kernel")]
+fn error_names_kernel(world: &mut CliWorld) {
+    let (what, _, _) = world
+        .apple_container_error
+        .as_ref()
+        .expect("a prior step must capture the start failure");
+    assert!(
+        what.contains("kernel"),
+        "the artifact error must name the container kernel: {what}"
+    );
+}
+
+#[then(expr = "the error names the artifact cache path under {string}")]
+fn error_names_cache_path(world: &mut CliWorld, segment: String) {
+    let (_, path, _) = world
+        .apple_container_error
+        .as_ref()
+        .expect("a prior step must capture the start failure");
+    assert!(
+        path.contains(&segment),
+        "the artifact error must name a path under {segment:?}: {path}"
+    );
+}
+
+#[then("the error carries the fetch hint")]
+fn error_carries_hint(world: &mut CliWorld) {
+    let (_, _, hint) = world
+        .apple_container_error
+        .as_ref()
+        .expect("a prior step must capture the start failure");
+    assert!(
+        hint.contains("container kernel"),
+        "the hint must say where the kernel comes from: {hint}"
+    );
+}
+
+#[when("I ask for the auto-selected backend")]
+fn auto_select(world: &mut CliWorld) {
+    let kind = mvm_runtime::backend::AnyBackend::auto_select().kind();
+    world.auto_selected_kind = Some(format!("{kind:?}"));
+}
+
+#[then("the selected backend is not apple-container")]
+fn not_apple_container(world: &mut CliWorld) {
+    let kind = world
+        .auto_selected_kind
+        .as_deref()
+        .expect("a prior step must resolve the auto-selected backend");
+    assert_ne!(
+        kind, "AppleContainer",
+        "auto-select must never land on the opt-in backend"
+    );
+}
+
+#[given("an apple-container kernel is cached in the isolated home")]
+fn cache_kernel(world: &mut CliWorld) {
+    let home = world
+        .isolated_home
+        .as_ref()
+        .expect("a prior step must isolate the mvm home");
+    let dir = home
+        .path()
+        .join("cache")
+        .join(mvm_runtime::apple_container::artifacts::ARTIFACT_DIR_NAME);
+    std::fs::create_dir_all(&dir).expect("create artifact dir");
+    std::fs::write(
+        dir.join(mvm_runtime::apple_container::artifacts::KERNEL_FILE_NAME),
+        b"fake-kernel-bytes",
+    )
+    .expect("write kernel");
+}
+
+#[when("I apply the backend's kernel substitution to a caller config")]
+fn apply_substitution(world: &mut CliWorld) {
+    let kernel =
+        mvm_runtime::apple_container::artifacts::resolve().expect("the cached kernel must resolve");
+    let caller = VmStartConfig {
+        name: "bdd-apple-container".to_string(),
+        kernel_path: Some("/caller/supplied/Image".to_string()),
+        ..Default::default()
+    };
+    let overridden = kernel_override_config(&caller, &kernel);
+    world.overridden_kernel_path = overridden.kernel_path;
+}
+
+#[then("the kernel path is the cached apple-container kernel, not the caller's kernel")]
+fn kernel_is_the_cached_one(world: &mut CliWorld) {
+    let kernel_path = world
+        .overridden_kernel_path
+        .as_deref()
+        .expect("a prior step must apply the substitution");
+    assert!(
+        kernel_path.contains("apple-container"),
+        "the kernel path must be the cached container kernel: {kernel_path}"
+    );
+    assert_ne!(
+        kernel_path, "/caller/supplied/Image",
+        "a caller-supplied kernel must never win over the backend's own"
+    );
+}

--- a/crates/mvm-conformance/tests/steps/initramfs.rs
+++ b/crates/mvm-conformance/tests/steps/initramfs.rs
@@ -1,0 +1,179 @@
+//! Steps for the deterministic cargo initramfs: the cpio build is
+//! byte-deterministic and the assembled artifact carries the
+//! content-address sidecar contract the resolver verifies. These drive the
+//! real assembly code from fixed agent bytes and never invoke a toolchain,
+//! so they run in the normal hermetic BDD gate.
+
+use cucumber::{given, then, when};
+use mvm_core::arch::GuestArch;
+use mvm_fs::initramfs::InitramfsResolver;
+
+use crate::world::CliWorld;
+
+/// Parse the entry names of a newc archive, stopping at the trailer — the
+/// layout assertion needs the exact entry sequence.
+fn newc_names(cpio: &[u8]) -> Vec<String> {
+    fn hex8(cpio: &[u8], off: usize) -> usize {
+        usize::from_str_radix(std::str::from_utf8(&cpio[off..off + 8]).unwrap(), 16).unwrap()
+    }
+    let mut names = Vec::new();
+    let mut off = 0;
+    loop {
+        assert_eq!(&cpio[off..off + 6], b"070701", "bad newc magic at {off}");
+        let filesize = hex8(cpio, off + 54);
+        let namesize = hex8(cpio, off + 94);
+        let name = String::from_utf8(cpio[off + 110..off + 110 + namesize - 1].to_vec()).unwrap();
+        let done = name == "TRAILER!!!";
+        names.push(name);
+        off = (off + 110 + namesize).div_ceil(4) * 4;
+        off = (off + filesize).div_ceil(4) * 4;
+        if done {
+            return names;
+        }
+    }
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    hex::encode(Sha256::digest(data))
+}
+
+#[given("fixed guest-agent bytes for the initramfs build")]
+fn fixed_agent_bytes(world: &mut CliWorld) {
+    world.initramfs_agent_bytes = Some(b"bdd-static-guest-agent".to_vec());
+}
+
+#[when("I assemble the initramfs cpio twice from those bytes")]
+fn assemble_twice(world: &mut CliWorld) {
+    let bytes = world
+        .initramfs_agent_bytes
+        .as_ref()
+        .expect("a prior step must fix the agent bytes");
+    world.initramfs_cpio_a = Some(mvm_build::initramfs::initramfs_cpio(bytes));
+    world.initramfs_cpio_b = Some(mvm_build::initramfs::initramfs_cpio(bytes));
+}
+
+#[then("the two cpios are byte-identical")]
+fn cpios_identical(world: &mut CliWorld) {
+    let (a, b) = (
+        world.initramfs_cpio_a.as_ref().expect("first cpio"),
+        world.initramfs_cpio_b.as_ref().expect("second cpio"),
+    );
+    assert_eq!(a, b, "the same agent bytes must produce the same cpio");
+}
+
+#[then("their content hashes match")]
+fn hashes_match(world: &mut CliWorld) {
+    let (a, b) = (
+        world.initramfs_cpio_a.as_ref().expect("first cpio"),
+        world.initramfs_cpio_b.as_ref().expect("second cpio"),
+    );
+    assert_eq!(sha256_hex(a), sha256_hex(b));
+}
+
+#[then(expr = "the cpio layout is exactly {string} and {string}")]
+fn cpio_layout(world: &mut CliWorld, dir: String, init: String) {
+    let a = world.initramfs_cpio_a.as_ref().expect("first cpio");
+    assert_eq!(newc_names(a), vec![dir, init, "TRAILER!!!".to_string()]);
+}
+
+#[when("I assemble and install the initramfs artifact into a fresh cache")]
+fn assemble_and_install(world: &mut CliWorld) {
+    let bytes = world
+        .initramfs_agent_bytes
+        .as_ref()
+        .expect("a prior step must fix the agent bytes");
+    let tmp = tempfile::tempdir().expect("scenario cache root");
+    let source = tmp.path().join("source");
+    let cache_root = tmp.path().join("cache");
+    let version = env!("CARGO_PKG_VERSION");
+    mvm_build::initramfs::assemble_initramfs_artifact(bytes, version, &source)
+        .expect("assemble the artifact");
+    let artifact = mvm_build::initramfs::install_initramfs_into_cache(
+        &source,
+        &cache_root,
+        version,
+        GuestArch::Aarch64,
+    )
+    .expect("install into the cache");
+
+    let dir = artifact
+        .image_path
+        .parent()
+        .expect("the artifact dir has a parent")
+        .to_path_buf();
+    let read = |name: &str| {
+        std::fs::read_to_string(dir.join(name))
+            .expect("read sidecar")
+            .trim()
+            .to_string()
+    };
+    world.initramfs_sidecars = Some((
+        read(mvm_fs::initramfs::INITRAMFS_HASH_FILE),
+        read(mvm_fs::initramfs::INITRAMFS_SIZE_FILE),
+        read(mvm_fs::initramfs::VERSION_FILE),
+    ));
+
+    // The resolver must accept the just-installed artifact — the install
+    // path's own verification is the contract the boot path relies on.
+    let resolved = InitramfsResolver::new(&cache_root, version)
+        .resolve(&GuestArch::Aarch64.to_string())
+        .expect("the artifact must resolve through the resolver");
+    world.initramfs_resolved_image = Some(resolved.image_path);
+    world.isolated_home = Some(tmp);
+}
+
+#[then("the artifact's hash sidecar is the SHA-256 of the uncompressed cpio")]
+fn hash_sidecar_matches(world: &mut CliWorld) {
+    let (hash, _, _) = world.initramfs_sidecars.as_ref().expect("sidecars");
+    let image = world
+        .initramfs_resolved_image
+        .as_ref()
+        .expect("resolved image");
+    let compressed = std::fs::read(image).expect("read image");
+    let mut uncompressed = Vec::new();
+    std::io::Read::read_to_end(
+        &mut flate2::read::GzDecoder::new(compressed.as_slice()),
+        &mut uncompressed,
+    )
+    .expect("gunzip the image");
+    assert_eq!(
+        *hash,
+        sha256_hex(&uncompressed),
+        "the hash sidecar must cover the uncompressed cpio"
+    );
+}
+
+#[then("the size sidecar is the compressed byte length")]
+fn size_sidecar_matches(world: &mut CliWorld) {
+    let (_, size, _) = world.initramfs_sidecars.as_ref().expect("sidecars");
+    let image = world
+        .initramfs_resolved_image
+        .as_ref()
+        .expect("resolved image");
+    let compressed = std::fs::read(image).expect("read image");
+    assert_eq!(
+        size.parse::<usize>().expect("size sidecar is a number"),
+        compressed.len(),
+        "the size sidecar must cover the compressed file"
+    );
+}
+
+#[then("the VERSION sidecar is the workspace version")]
+fn version_sidecar_matches(world: &mut CliWorld) {
+    let (_, _, version) = world.initramfs_sidecars.as_ref().expect("sidecars");
+    assert_eq!(version, env!("CARGO_PKG_VERSION"));
+}
+
+#[then("the artifact resolves through the initramfs resolver")]
+fn artifact_resolves(world: &mut CliWorld) {
+    let image = world
+        .initramfs_resolved_image
+        .as_ref()
+        .expect("resolved image");
+    assert!(image.is_file(), "the resolved image must exist: {image:?}");
+    assert!(
+        image.ends_with(mvm_fs::initramfs::INITRAMFS_IMAGE_FILE),
+        "the resolver must name the canonical image file: {image:?}"
+    );
+}

--- a/crates/mvm-conformance/tests/steps/mod.rs
+++ b/crates/mvm-conformance/tests/steps/mod.rs
@@ -1,6 +1,8 @@
 //! Step definitions, one module per scenario surface.
 
+mod apple_container;
 mod cli;
+mod initramfs;
 mod kernel_pin;
 mod oci_unpack;
 mod readme_contract;

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -70,6 +70,28 @@ pub struct CliWorld {
     /// An isolated `MVM_HOME` created by a `Given` step and reused by later
     /// steps that need to inspect the filesystem after a run.
     pub isolated_home: Option<tempfile::TempDir>,
+    /// Process-wide `MVM_HOME` override held across the steps of one
+    /// scenario (dropped — and the previous value restored — when the
+    /// world is dropped at scenario end).
+    pub mvm_home_guard: Option<MvmHomeGuard>,
+    /// The typed artifact-missing triple (`what`, `path`, `hint`) captured
+    /// from the apple-container backend's start failure.
+    pub apple_container_error: Option<(String, String, String)>,
+    /// The backend kind auto-select resolved to, as its `Debug` token.
+    pub auto_selected_kind: Option<String>,
+    /// The kernel path after the apple-container backend's substitution.
+    pub overridden_kernel_path: Option<String>,
+    /// Fixed stand-in guest-agent bytes an initramfs scenario builds from.
+    pub initramfs_agent_bytes: Option<Vec<u8>>,
+    /// The two deterministic cpio builds a determinism scenario compares.
+    pub initramfs_cpio_a: Option<Vec<u8>>,
+    /// Second deterministic cpio build (see `initramfs_cpio_a`).
+    pub initramfs_cpio_b: Option<Vec<u8>>,
+    /// Sidecar contents (`hash`, `size`, `VERSION`) read back after an
+    /// initramfs artifact assembly + install.
+    pub initramfs_sidecars: Option<(String, String, String)>,
+    /// The resolved image path after installing the assembled initramfs.
+    pub initramfs_resolved_image: Option<PathBuf>,
     /// Whether live CLI steps should keep one warm standby for the next run.
     pub warm_residency: bool,
     /// Content address of the bundle a `bundle install` step registered, so the

--- a/crates/mvm-runtime/src/apple_container_backend.rs
+++ b/crates/mvm-runtime/src/apple_container_backend.rs
@@ -82,8 +82,11 @@ impl Default for AppleContainerBackend {
 
 /// The pure config mapping behind [`AppleContainerBackend::start`]: clone
 /// the config and substitute the kernel image. Split out so the mapping is
-/// unit-testable without a runner.
-fn kernel_override_config(config: &VmStartConfig, kernel: &Path) -> VmStartConfig {
+/// unit-testable without a runner. `pub` as the backend's kernel-
+/// substitution contract surface: callers (and the conformance suite) can
+/// verify exactly what the backend changes about a launch config — the
+/// kernel path and nothing else.
+pub fn kernel_override_config(config: &VmStartConfig, kernel: &Path) -> VmStartConfig {
     let mut cfg = config.clone();
     cfg.kernel_path = Some(kernel.display().to_string());
     cfg

--- a/features/suites/s14_universal_initramfs/deterministic_cargo_initramfs.feature
+++ b/features/suites/s14_universal_initramfs/deterministic_cargo_initramfs.feature
@@ -1,0 +1,23 @@
+Feature: Deterministic cargo initramfs
+
+  The universal initramfs is a deterministic cargo artifact, not a Nix
+  build: the pinned guest-agent source is cross-compiled once and packed as
+  exactly "/init" in an epoch-zero, stably-ordered cpio. Its attestability
+  comes from the reproducible build plus the content hash — the same agent
+  bytes must always produce the same cpio, and the installed artifact's
+  sidecars must describe exactly the bytes the boot path loads.
+
+  Scenario: The cpio build is byte-deterministic
+    Given fixed guest-agent bytes for the initramfs build
+    When I assemble the initramfs cpio twice from those bytes
+    Then the two cpios are byte-identical
+    And their content hashes match
+    And the cpio layout is exactly "." and "./init"
+
+  Scenario: The installed artifact carries the content-address sidecar contract
+    Given fixed guest-agent bytes for the initramfs build
+    When I assemble and install the initramfs artifact into a fresh cache
+    Then the artifact's hash sidecar is the SHA-256 of the uncompressed cpio
+    And the size sidecar is the compressed byte length
+    And the VERSION sidecar is the workspace version
+    And the artifact resolves through the initramfs resolver

--- a/features/suites/s25_apple_container/apple_container.feature
+++ b/features/suites/s25_apple_container/apple_container.feature
@@ -1,0 +1,30 @@
+Feature: Apple Container backend contract
+
+  The apple-container backend is the HVF workload runner with Apple's
+  prebuilt container kernel substituted for the boot image — same universal
+  initramfs, same agent-as-PID-1, same activation flow as every other
+  backend. The kernel is a fetched binary artifact cached under
+  "apple-container", so resolution fails closed with a typed error that
+  says what is missing, where it belongs, and how to fetch it. Auto-select
+  prefers the apple-container backend on the HVF tier, but only when its
+  kernel is cached — without the artifact the tier falls back to the plain
+  HVF backend. Once its kernel is cached the launch's kernel image is
+  always that cached kernel, never a caller-supplied one.
+
+  Scenario: A missing container kernel fails closed with a hint-carrying error
+    Given an isolated mvm home for the apple-container backend
+    When I start the apple-container backend with a minimal config
+    Then the start fails with a missing-artifact error naming the container kernel
+    And the error names the artifact cache path under "apple-container"
+    And the error carries the fetch hint
+
+  Scenario: Auto-select skips apple-container when its kernel is not cached
+    Given an isolated mvm home for the apple-container backend
+    When I ask for the auto-selected backend
+    Then the selected backend is not apple-container
+
+  Scenario: The cached container kernel always wins the launch's kernel image
+    Given an isolated mvm home for the apple-container backend
+    And an apple-container kernel is cached in the isolated home
+    When I apply the backend's kernel substitution to a caller config
+    Then the kernel path is the cached apple-container kernel, not the caller's kernel

--- a/public/src/content/docs/architecture/boot-flow.md
+++ b/public/src/content/docs/architecture/boot-flow.md
@@ -15,7 +15,10 @@ natively.
 
 ## The universal initramfs
 
-The initramfs is built by `nix/images/initramfs/flake.nix`. It is a small,
+The initramfs is a deterministic **cargo artifact**: the pinned agent
+source is cross-compiled once (`cargo zigbuild` → musl, content-keyed
+cache) and packed as an epoch-zero, stably-ordered cpio — no Nix on the
+boot path. It is a small,
 deterministic cpio that contains exactly one file:
 
 - `/init` — the static `mvm-guest-agent` binary.

--- a/specs/notes/2026-07-31-snix-evaluation-decision.md
+++ b/specs/notes/2026-07-31-snix-evaluation-decision.md
@@ -1,0 +1,61 @@
+# Snix (Rust Nix re-implementation) evaluation — decision
+
+Date: 2026-07-31
+Status: decision — do not adopt snix now; revisit when it is stable and the
+licensing is workable. Recorded so future sessions do not re-run the same
+evaluation.
+
+## Context
+
+The goal was a faster, more reliable, Rust-native way to drive the Nix builds
+that produce our attestable, hermetic microVM artifacts (kernels, rootfs
+images, runtime overlays). snix.dev is a modern Rust re-implementation of the
+Nix package manager's components (evaluator, store, builder), advertised as
+library-first and Nixpkgs-compatible with binary-cache interoperability. The
+question was whether we could use it as a library to replace or accelerate our
+`nix build` orchestration.
+
+## Findings
+
+- **License is a hard blocker for library embedding.** Every snix crate
+  (eval, store, build, glue) is **GPL-3.0**; only the protobuf definitions are
+  MIT. Embedding snix as a library in mvm (MIT OR Apache-2.0) would make the
+  linking binary (`mvmctl`) GPL-3.0. That is incompatible with our license
+  posture, so the library-first usage the project would want is off the table.
+  Using `snix-cli` as a subprocess (like the `nix` CLI) avoids the linking
+  issue but yields no architectural benefit over the CLI we already use.
+- **Maturity.** The project states plainly that none of its APIs are stable
+  and that it is "no full-featured drop-in replacement for Nix yet." Flake
+  support is partial/shim-based; our builds are flake-based (kernels, runtime
+  overlay, `mkGuest`, initramfs publish path), so snix cannot drive them
+  reliably today.
+- **Bootstrapping.** snix itself is built with Nix (crate2nix), so adopting
+  it would not remove the Nix dependency it is meant to accelerate — and
+  building it is itself slow (a large Rust workspace; a timeboxed build of
+  `snix.cli.default-cli` did not finish inside 15 minutes).
+- **Upside noted for the future.** `snix/boot` boots microVMs off a
+  `snix-store` via virtiofs — directly relevant to our microVM use case, and
+  worth re-evaluating once the project is stable.
+
+## Decision
+
+Do not adopt snix now. Revisit when it reaches API stability and a license
+compatible with embedding (or when a `snix-cli` binary is a proven drop-in
+accelerator for `nix build`).
+
+## Speed paths adopted instead
+
+- **The universal initramfs is a deterministic cargo artifact** (PR #1996) —
+  built via the cargo-zigbuild guest-agent cache plus a deterministic Rust
+  cpio (epoch-zero, sorted, uid/gid 0, deterministic gzip), attested by its
+  content hash. No Nix, fast cold-cache boot, fully attestable. Nix is
+  retained for kernels, rootfs images, and the runtime overlay, where
+  toolchain variance actually matters.
+- **Determinate Nix binary caches** (`cache.flakehub.com`,
+  `install.determinate.systems`) are already configured on the builder and
+  make toolchain/dependency fetches fast.
+- **Native arm64 builders** (e.g. the `ubuntu-24.04-arm` runners the kernel
+  CI already uses) for aarch64 Nix builds — roughly 4 minutes native vs ~30
+  minutes under QEMU user-mode emulation on the x86_64 builder. The aarch64
+  initramfs was also verified to build hermetically via that emulation path
+  (QEMU binfmt) as a fallback when no arm64 runner is available.

--- a/specs/plans/271-apple-container-backend.md
+++ b/specs/plans/271-apple-container-backend.md
@@ -2,7 +2,10 @@
 
 **Status:** implemented (thin HVF-runner delegation + kernel artifact resolution); live e2e validation remaining.
 **Owner:** mvm core.
-**Depends on:** universal initramfs + `ActivateEnvironment` (PR #1914).
+**Depends on:** universal initramfs + `ActivateEnvironment` (PR #1914) —
+the initramfs itself is a deterministic cargo artifact (reproducible
+`cargo zigbuild` of the pinned agent source + deterministic cpio +
+content hash), not a Nix build.
 
 > **Design history.** Stage 1 was the fail-closed backend skeleton. Stage 2
 > booted Apple's container kernel + the `initfs.ext4` carrying `/sbin/vminitd`


### PR DESCRIPTION
The universal initramfs is a deliberately tiny artifact — one static guest-agent binary in a deterministic cpio. Its attestability comes from a reproducible cargo build of the pinned agent source + a deterministic cpio + a content hash the resolver verifies, not from Nix. Building it as a **deterministic cargo artifact** (instead of a Nix flake build) makes cold-cache boot fast (a single cargo-zigbuild cross-compile instead of a Nix eval + build), with no loss of attestation.

## What changed

- `mvm-build/src/initramfs.rs`: the Linux build path now calls the existing `guest_agent_build::resolve_or_build_guest_binaries` helper (the same content-keyed, file-locked cargo-zigbuild musl cache the runtime-overlay path uses) and assembles the deterministic cpio in Rust — epoch-zero mtimes, stable sort, uid/gid 0, `newc` format, deterministic gzip — mirroring the flake's output contract exactly (`initramfs.cpio.gz` / `.hash` / `.size` / `VERSION`). The Nix `build_initramfs_with_nix` (and its host-nix shell-out) is removed; the flake stays only as the optional publish-path build.
- Attestation is unchanged: `initramfs.hash` = SHA-256 of the uncompressed cpio, `initramfs.size` = compressed length, `VERSION` = workspace version, and the `mvm-fs` resolver still verifies all of it.
- Nix remains the build for kernels, rootfs images, and the runtime overlay, where toolchain variance actually matters.

## Tests (5 new)

- byte-determinism: two cpio builds from the same agent bytes → identical bytes/hash/gzip stream, every record epoch-zero.
- layout: cpio entries are exactly `.` and `./init`.
- sidecar contract: gunzip(image) == cpio; hash == sha256(uncompressed); size == compressed length; VERSION round-trips.
- cold-cache build → install → resolver resolves.
- warm-cache resolve skips any build/download.

## Validation

2426 tests pass across mvm-build/fs/runtime; workspace clippy clean; all 11 policy xtasks clean incl. `check-no-host-nix` (the nix shell-out is gone); musl compiles.

## Also in this PR

- **Hermetic BDD coverage** for the surfaces this session added that had only Rust tests: `s25_apple_container` (missing-kernel fails closed with the typed, hint-carrying artifact error; auto-select skips the backend when its kernel is not cached; a cached container kernel always wins the launch's kernel image) and `s14_universal_initramfs/deterministic_cargo_initramfs` (byte-determinism + the sidecar contract through the resolver, at the Gherkin level). The pure seams they drive are now public contract surfaces: `apple_container_backend::kernel_override_config`, `initramfs::initramfs_cpio`, `assemble_initramfs_artifact`. Conformance: 25 features / 79 scenarios / 385 steps, all green.
- Rebased onto main with the source-fingerprint cache eviction; the warm-cache test's shell double died with the Nix path and is replaced by a fail-loud `PanicShell`, and a merge-duplicated env-lock setup in `resolve_returns_missing_when_cache_empty` is collapsed.
