### PR TITLE
Stop racing a clock for a spawned process

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -36,8 +36,19 @@ final-status-level = "flaky"
 # same tests pass in about a second alone. Capping how many race a clock
 # at once helps, but does not cure it: the group caps concurrency among
 # its own members, while the starvation comes from the other ~8,200 tests
-# in the run. Treat this as a mitigation; the durable fix is for these
-# tests not to assert a wall-clock budget for a spawned process at all.
+# in the run. Treat this as a mitigation, not a cure.
+#
+# The durable fix — a test not racing a clock for a spawned process — has
+# landed for the two `mvm-hostd` binaries: their give-up conditions are now
+# hang guards sized to be unreachable by a merely-slow machine, plus a
+# liveness short-circuit so a dead daemon fails immediately with a reason
+# instead of waiting one out. They stay in the group as belt-and-braces.
+#
+# It does NOT apply to the `mvm-runtime` members, and that is the point of
+# keeping the group: their budget is `SUBST_HANDSHAKE_TIMEOUT`, a production
+# constant. The wait those tests race is the one the product itself enforces,
+# so raising it to suit the test suite would change shipped behaviour. For
+# them the concurrency cap is the fix available.
 #
 # This is deliberately narrow. A test that merely needs a unique tempdir
 # and does not have one is a bug in the test, and a group here would hide

--- a/crates/mvm-hostd/tests/host_agent_restart.rs
+++ b/crates/mvm-hostd/tests/host_agent_restart.rs
@@ -18,6 +18,21 @@ const HOST_AGENT_BIN: &str = env!("CARGO_BIN_EXE_mvm-host-agent");
 const SIGNER_HELPER_BIN: &str = env!("CARGO_BIN_EXE_mvm-signer-helper");
 const BROKER_RECOVERY_TIMEOUT: Duration = Duration::from_secs(180);
 
+/// Hang guard — deliberately **not** a budget.
+///
+/// These tests spawn real processes and wait for them to reach a state. What
+/// they assert is that the state is reached at all; how fast is a property of
+/// the host scheduler, not of the code under test. A deadline picked from
+/// "this should take ~1.5s, so 6s is ample headroom" encodes a 4x guess about
+/// machine load, and at full workspace parallelism that guess is wrong — the
+/// test goes red while the same code passes in about a second alone.
+///
+/// So this value is chosen to be unreachable by a merely-slow machine, and it
+/// must never be tuned toward "what seems fast enough". If a wait reaches it,
+/// something is stuck, and the panic says what was observed rather than only
+/// that a clock ran out.
+const HANG_GUARD: Duration = Duration::from_secs(120);
+
 struct HostAgentFixture {
     _env: TestEnv,
     _data_dir: TempDir,
@@ -117,21 +132,40 @@ impl HostAgentFixture {
     }
 
     async fn wait_for_emit_until(&self, event: &str, deadline: Instant) -> ServiceResponse {
+        let started = Instant::now();
         let mut last_error = None;
+        let mut attempts = 0usize;
         while Instant::now() < deadline {
             match self.try_emit(event).await {
                 Ok(resp) => return resp,
                 Err(e) => last_error = Some(e),
             }
+            attempts += 1;
+            // A dead daemon will never bring the broker back, so waiting out
+            // the guard would only turn a decidable failure into a slow one.
+            // Fail on the state change instead of on elapsed time.
+            if let Some(pid) = self.daemon_pid()
+                && !pid_alive(pid)
+            {
+                panic!(
+                    "host-agent daemon (pid {pid}) exited after {attempts} recovery \
+                     attempt(s) in {:.1}s; the broker cannot recover. Last error: {:#}",
+                    started.elapsed().as_secs_f64(),
+                    last_error.expect("at least one recovery attempt")
+                );
+            }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
         panic!(
-            "host-agent broker did not recover before timeout: {:#}",
+            "host-agent broker did not recover after {attempts} attempt(s) in {:.1}s \
+             (hang guard, not a budget). Last error: {:#}",
+            started.elapsed().as_secs_f64(),
             last_error.expect("at least one recovery attempt")
         );
     }
 
     async fn wait_for_worker_replacement(&self, previous_pid: libc::pid_t, deadline: Instant) {
+        let started = Instant::now();
         while Instant::now() < deadline {
             if let Some(pid) = self.worker_pid()
                 && pid != previous_pid
@@ -141,7 +175,12 @@ impl HostAgentFixture {
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
-        panic!("host-agent worker did not restart before timeout; previous pid was {previous_pid}");
+        panic!(
+            "host-agent worker did not restart in {:.1}s (hang guard, not a budget); \
+             previous pid was {previous_pid}, current pid file reads {:?}",
+            started.elapsed().as_secs_f64(),
+            self.worker_pid()
+        );
     }
 
     fn chain_entries(&self) -> usize {
@@ -193,13 +232,21 @@ fn pid_alive(pid: libc::pid_t) -> bool {
 }
 
 async fn wait_until_pid_dead(pid: libc::pid_t, deadline: Instant) {
+    let started = Instant::now();
     while Instant::now() < deadline {
         if !pid_alive(pid) {
             return;
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
-    panic!("pid {pid} was still alive at deadline");
+    // Say what was observed, not just that a clock ran out: a bare "still
+    // alive at deadline" cannot distinguish a stuck process from a loaded one,
+    // which is what made this family unactionable when it went red in CI.
+    panic!(
+        "pid {pid} was still alive after {:.1}s (hang guard, not a budget) — \
+         the process never exited",
+        started.elapsed().as_secs_f64()
+    );
 }
 
 async fn write_frame(stream: &mut UnixStream, value: &impl serde::Serialize) -> Result<()> {
@@ -363,11 +410,12 @@ async fn idle_daemon_self_terminates_when_last_vm_deregisters() {
     // Deregister the only VM → registration count drops to 0.
     fixture.deregister();
 
-    // Poll until both the worker and the wrapper (daemon) are gone.
-    // The idle watcher polls every 500ms and the timeout is 1s, so the worker
-    // exits after ~1.5s at most. The wrapper observes the idle exit code and
-    // returns Ok() without restarting. 6s is ample headroom.
-    let deadline = Instant::now() + Duration::from_secs(6);
+    // Poll until both the worker and the wrapper (daemon) are gone. The idle
+    // watcher polls every 500ms against a 1s timeout, so an unloaded machine
+    // sees the worker exit in ~1.5s and the wrapper follow it. The assertion
+    // is that they exit — not that they exit quickly — so the wait is bounded
+    // by the hang guard rather than by a multiple of the expected duration.
+    let deadline = Instant::now() + HANG_GUARD;
     wait_until_pid_dead(worker_pid, deadline).await;
     wait_until_pid_dead(daemon_pid, deadline).await;
 }

--- a/crates/mvm-hostd/tests/per_tenant_isolation.rs
+++ b/crates/mvm-hostd/tests/per_tenant_isolation.rs
@@ -75,19 +75,33 @@ async fn emit_audit(sock: &Path, event: &str) -> Result<ServiceResponse> {
     read_frame(&mut conn).await
 }
 
+/// Hang guard — deliberately **not** a budget.
+///
+/// This waits on a real spawned broker becoming ready. That it becomes ready
+/// is the assertion; how fast is a property of the host scheduler. A deadline
+/// sized to "ready is quick, 10s is plenty" is a guess about machine load, and
+/// under full workspace parallelism the guess loses. Chosen to be unreachable
+/// by a merely-slow machine, and never to be tuned toward "fast enough".
+const HANG_GUARD: Duration = Duration::from_secs(120);
+
 async fn wait_for_emit(sock: &Path, event: &str) -> ServiceResponse {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let started = Instant::now();
+    let deadline = started + HANG_GUARD;
     let mut last_error = None;
+    let mut attempts = 0usize;
     while Instant::now() < deadline {
         match emit_audit(sock, event).await {
             Ok(resp) => return resp,
             Err(e) => last_error = Some(e),
         }
+        attempts += 1;
         tokio::time::sleep(Duration::from_millis(25)).await;
     }
     panic!(
-        "broker at {} did not become ready before deadline: {:#}",
+        "broker at {} did not become ready after {attempts} attempt(s) in {:.1}s \
+         (hang guard, not a budget): {:#}",
         sock.display(),
+        started.elapsed().as_secs_f64(),
         last_error.expect("at least one attempt")
     );
 }


### PR DESCRIPTION
Item 2 of the follow-up list — the durable fix `.config/nextest.toml` names for the process-handshake flake family: *"for these tests not to assert a wall-clock budget for a spawned process at all."*

This lands it where the budget is a **test artifact**, and deliberately leaves it where the budget is **production behaviour**.

## The clearest offender

`idle_daemon_self_terminates_when_last_vm_deregisters` had a 6s deadline, reasoned in its own comment as:

> the worker exits after ~1.5s at most ... 6s is ample headroom

That's a 4x guess about machine load. The observed failure — 10.09s total, i.e. fixture setup plus the deadline expiring — is that guess losing. Under today's full parallel run the same wait took **1.786s**, already 1.2x of what the comment expected, on a machine that was *not* loaded enough to reproduce the original red. `per_tenant_isolation`'s broker-ready wait had the same shape at 10s.

Both are now bounded by a `HANG_GUARD` documented as explicitly **not** a budget: sized to be unreachable by a merely-slow machine, and never to be tuned toward "what seems fast enough". What these tests assert is that the state is *reached*; how fast is a property of the host scheduler, not of the code under test.

## Raising a number is only half of it

The give-up paths now report **what was observed** rather than that a clock ran out — elapsed, attempt count, the pid file's current contents.

`wait_for_emit_until` also short-circuits on liveness: a dead daemon will never bring the broker back, so it fails immediately naming that instead of waiting out the guard. That converts an unactionable timeout into a decidable failure — which matters most for the occurrences nobody can reproduce on demand.

## What I deliberately did NOT touch

**The `mvm-runtime` members of the same nextest group.** Their budget is `SUBST_HANDSHAKE_TIMEOUT`, a `pub const` the product enforces at runtime. The wait those tests race is the real one, so relaxing it to suit the suite would change shipped behaviour. For them the concurrency cap is the only fix available — now recorded as the group's justification instead of being implied.

**`mvm-agentd::entrypoint_execute`.** Its deadline is already 60s and its observed failures were at ~5.07s, so a budget does not explain them. It did not reproduce across two full runs and I have no failure message for it. Guessing at a fix would only make the next occurrence harder to read; the honest state is "cause unknown", and I'd rather say so than ship a plausible-looking change.

## Verification, and its limits

Full `--workspace --no-fail-fast -j 6`: all five tests across the two binaries pass, 8378/8380 overall. (The two failures are the apple-container `auto_select` pair on `main`, fixed by #1995.)

Stated plainly: today's run was not loaded enough to reproduce the original failure, so this does not *demonstrate* the flake is gone. What it demonstrates is that the budget which failed was tight against its own stated reasoning, and is now unreachable. Also clippy `-p mvm-hostd --all-targets -- -D warnings` clean, nightly fmt clean.