### PR TITLE
feat(core): DesiredMount schema + MountVolume/UnmountVolume hostd verbs (mvmd plan 59 stage 0)

### DIFF
--- a/crates/mvm-core/src/domain/agent.rs
+++ b/crates/mvm-core/src/domain/agent.rs
@@ -87,6 +87,17 @@ pub struct DesiredPool {
     /// a local Nix build. Falls back to local build if the pull fails.
     #[serde(default)]
     pub registry_artifact: Option<RegistryArtifact>,
+    /// Distributed-volume mounts attached to every instance of this pool
+    /// (Plan 59 Stage 0).
+    ///
+    /// Schema evolution: `#[serde(default)]` keeps the old-coordinator →
+    /// new-agent direction parsing (missing field ⇒ no mounts). The
+    /// reverse direction (new coordinator sending `mounts` to an old
+    /// agent) fails closed on `deny_unknown_fields`; rolling that out is
+    /// governed by `DesiredState::schema_version`, matching how prior
+    /// `DesiredPool` field additions were sequenced.
+    #[serde(default)]
+    pub mounts: Vec<DesiredMount>,
 }
 
 fn default_seccomp() -> String {
@@ -95,6 +106,81 @@ fn default_seccomp() -> String {
 
 fn default_compression() -> String {
     "none".to_string()
+}
+
+/// A distributed-volume mount (S3/NFS/FUSE-backed bucket) attached to
+/// every instance of a pool.
+///
+/// Part of the signed desired state (Plan 59 Stage 0 contract freeze).
+/// The coordinator resolves a tenant bucket into this shape; agents
+/// reconcile it via the hostd `MountVolume` / `UnmountVolume` verbs.
+///
+/// This is deliberately a separate type from the IR `Mount`
+/// (`mvm-protocol::ir::workload`) — the IR describes a single workload's
+/// authored intent, while this describes coordinator-resolved fleet
+/// state pushed to agents.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DesiredMount {
+    /// Coordinator-scoped bucket identifier this mount materializes.
+    pub bucket_id: String,
+    /// Backing provider (e.g. "s3", "nfs", "local-virtiofs").
+    ///
+    /// Deliberately an open string rather than an enum, mirroring the
+    /// `MountSource::External { provider, .. }` precedent in the IR:
+    /// new providers plug in without a core-schema edit. An unknown
+    /// provider is rejected at mount time, never silently defaulted.
+    pub provider: String,
+    /// Provider-schema-owned configuration. The desired-state layer
+    /// does not interpret it; the provider validates it at mount time.
+    pub config: serde_json::Value,
+    /// Absolute guest path the volume is mounted at.
+    pub target: String,
+    /// Read-only vs read-write attachment for each instance.
+    pub mode: DesiredMountMode,
+    /// Monotonic mount-config generation. The coordinator bumps it on
+    /// any change to this mount (config, mode, access_mode, …); agents
+    /// remount when their applied generation is behind.
+    pub generation: u64,
+    /// Concurrency contract across instances (see [`MountAccessMode`]).
+    ///
+    /// Defaults to [`MountAccessMode::Rox`]: read-only-many is the only
+    /// mode that is safe on every provider without write coordination,
+    /// so writers must opt in explicitly.
+    #[serde(default)]
+    pub access_mode: MountAccessMode,
+}
+
+/// Read-only vs read-write for a [`DesiredMount`].
+///
+/// Mirrors (rather than reuses) the IR `MountMode`
+/// (`mvm-protocol::ir::workload`) so the signed desired-state schema
+/// stays self-contained; the wire values (`"ro"` / `"rw"`) are
+/// identical by construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DesiredMountMode {
+    /// Read-only attachment.
+    Ro,
+    /// Read-write attachment.
+    Rw,
+}
+
+/// Concurrency/access contract for a [`DesiredMount`] across the
+/// instances of a pool (Kubernetes PV-style semantics).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MountAccessMode {
+    /// Read-write by at most one instance at a time.
+    Rwo,
+    /// Read-only by many instances. The default: the only mode that is
+    /// safe on every provider without write coordination — writers must
+    /// opt in explicitly via `Rwo`/`Rwx`.
+    #[default]
+    Rox,
+    /// Read-write by many instances (requires a provider that
+    /// coordinates concurrent writers, e.g. NFS).
+    Rwx,
 }
 
 // ============================================================================
@@ -1087,6 +1173,7 @@ mod tests {
                 health_check_timeout_secs: 90,
             })),
             registry_artifact: None,
+            mounts: vec![],
         };
         let json = serde_json::to_string(&pool).unwrap();
         let parsed: DesiredPool = serde_json::from_str(&json).unwrap();
@@ -1227,12 +1314,164 @@ mod tests {
                 template_id: "hello".to_string(),
                 revision: Some("rev-abc123".to_string()),
             }),
+            mounts: vec![],
         };
         let json = serde_json::to_string(&pool).unwrap();
         let parsed: DesiredPool = serde_json::from_str(&json).unwrap();
         let ra = parsed.registry_artifact.unwrap();
         assert_eq!(ra.template_id, "hello");
         assert_eq!(ra.revision.as_deref(), Some("rev-abc123"));
+    }
+
+    // ========================================================================
+    // Tests for distributed-volume mounts (Plan 59 Stage 0)
+    // ========================================================================
+
+    /// Old coordinator → new agent: a `DesiredPool` payload that predates
+    /// the `mounts` field must still parse (`#[serde(default)]` ⇒ empty).
+    ///
+    /// The reverse direction (new coordinator sending `mounts` to an old
+    /// agent) fails closed on that agent's `deny_unknown_fields` — that
+    /// rollout is governed by `DesiredState::schema_version`, matching how
+    /// prior `DesiredPool` field additions were sequenced.
+    #[test]
+    fn test_desired_pool_backward_compat_no_mounts() {
+        let json = r#"{
+            "pool_id": "gateways",
+            "flake_ref": "github:org/repo",
+            "profile": "minimal",
+            "instance_resources": {"vcpus": 2, "mem_mib": 1024},
+            "desired_counts": {"running": 3, "warm": 1, "sleeping": 0}
+        }"#;
+        let parsed: DesiredPool = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.pool_id, "gateways");
+        assert!(parsed.mounts.is_empty());
+    }
+
+    #[test]
+    fn test_desired_pool_mounts_roundtrip() {
+        let mount = DesiredMount {
+            bucket_id: "bkt-artifacts".to_string(),
+            provider: "s3".to_string(),
+            config: serde_json::json!({
+                "endpoint": "https://s3.example.com",
+                "bucket": "acme-artifacts",
+                "region": "us-east-1"
+            }),
+            target: "/mnt/artifacts".to_string(),
+            mode: DesiredMountMode::Rw,
+            generation: 7,
+            access_mode: MountAccessMode::Rwx,
+        };
+        let pool = DesiredPool {
+            pool_id: "workers".to_string(),
+            flake_ref: ".".to_string(),
+            profile: "minimal".to_string(),
+            role: Role::Worker,
+            instance_resources: InstanceResources {
+                vcpus: 1,
+                mem_mib: 512,
+                data_disk_mib: 0,
+            },
+            desired_counts: DesiredCounts {
+                running: 1,
+                warm: 0,
+                sleeping: 0,
+            },
+            runtime_policy: RuntimePolicy::default(),
+            seccomp_policy: "baseline".to_string(),
+            snapshot_compression: "none".to_string(),
+            routing_table: None,
+            secret_scopes: vec![],
+            sleep_policy: None,
+            default_update_strategy: None,
+            registry_artifact: None,
+            mounts: vec![mount.clone()],
+        };
+        let json = serde_json::to_string(&pool).unwrap();
+        let parsed: DesiredPool = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.mounts.len(), 1);
+        assert_eq!(parsed.mounts[0], mount);
+    }
+
+    #[test]
+    fn test_desired_mount_parses_from_json() {
+        let json = r#"{
+            "bucket_id": "bkt-shared",
+            "provider": "nfs",
+            "config": {"server": "10.240.0.9", "export": "/exports/shared"},
+            "target": "/mnt/shared",
+            "mode": "ro",
+            "generation": 1
+        }"#;
+        let parsed: DesiredMount = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.bucket_id, "bkt-shared");
+        assert_eq!(parsed.provider, "nfs");
+        assert_eq!(parsed.target, "/mnt/shared");
+        assert_eq!(parsed.mode, DesiredMountMode::Ro);
+        assert_eq!(parsed.generation, 1);
+        // access_mode omitted ⇒ defaults to read-only-many.
+        assert_eq!(parsed.access_mode, MountAccessMode::Rox);
+    }
+
+    #[test]
+    fn test_desired_mount_rejects_unknown_fields() {
+        let bad = serde_json::json!({
+            "bucket_id": "bkt-shared",
+            "provider": "s3",
+            "config": {},
+            "target": "/mnt/shared",
+            "mode": "ro",
+            "generation": 1,
+            "unexpected": true
+        });
+        let err = serde_json::from_value::<DesiredMount>(bad).unwrap_err();
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn test_mount_access_mode_default_is_rox() {
+        assert_eq!(MountAccessMode::default(), MountAccessMode::Rox);
+    }
+
+    #[test]
+    fn test_mount_enums_wire_values() {
+        // Pin the wire values: mode mirrors the IR MountMode ("ro"/"rw");
+        // access_mode is snake_case of the K8s-style variants.
+        assert_eq!(
+            serde_json::to_string(&DesiredMountMode::Ro).unwrap(),
+            "\"ro\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DesiredMountMode::Rw).unwrap(),
+            "\"rw\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MountAccessMode::Rwo).unwrap(),
+            "\"rwo\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MountAccessMode::Rox).unwrap(),
+            "\"rox\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MountAccessMode::Rwx).unwrap(),
+            "\"rwx\""
+        );
+        for mode in [DesiredMountMode::Ro, DesiredMountMode::Rw] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: DesiredMountMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+        for access in [
+            MountAccessMode::Rwo,
+            MountAccessMode::Rox,
+            MountAccessMode::Rwx,
+        ] {
+            let json = serde_json::to_string(&access).unwrap();
+            let parsed: MountAccessMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, access);
+        }
     }
 
     // ========================================================================

--- a/crates/mvm-core/src/domain/agent.rs
+++ b/crates/mvm-core/src/domain/agent.rs
@@ -87,8 +87,7 @@ pub struct DesiredPool {
     /// a local Nix build. Falls back to local build if the pull fails.
     #[serde(default)]
     pub registry_artifact: Option<RegistryArtifact>,
-    /// Distributed-volume mounts attached to every instance of this pool
-    /// (Plan 59 Stage 0).
+    /// Distributed-volume mounts attached to every instance of this pool.
     ///
     /// Schema evolution: `#[serde(default)]` keeps the old-coordinator →
     /// new-agent direction parsing (missing field ⇒ no mounts). The
@@ -111,9 +110,9 @@ fn default_compression() -> String {
 /// A distributed-volume mount (S3/NFS/FUSE-backed bucket) attached to
 /// every instance of a pool.
 ///
-/// Part of the signed desired state (Plan 59 Stage 0 contract freeze).
-/// The coordinator resolves a tenant bucket into this shape; agents
-/// reconcile it via the hostd `MountVolume` / `UnmountVolume` verbs.
+/// Part of the signed desired-state contract. The coordinator resolves a
+/// tenant bucket into this shape; agents reconcile it via the hostd
+/// `MountVolume` / `UnmountVolume` verbs.
 ///
 /// This is deliberately a separate type from the IR `Mount`
 /// (`mvm-protocol::ir::workload`) — the IR describes a single workload's
@@ -1324,7 +1323,7 @@ mod tests {
     }
 
     // ========================================================================
-    // Tests for distributed-volume mounts (Plan 59 Stage 0)
+    // Tests for distributed-volume mounts
     // ========================================================================
 
     /// Old coordinator → new agent: a `DesiredPool` payload that predates

--- a/crates/mvm-core/src/protocol/protocol.rs
+++ b/crates/mvm-core/src/protocol/protocol.rs
@@ -52,6 +52,13 @@ const MAX_FRAME_SIZE: usize = 1024 * 1024;
 ///   `#[serde(default)]` so old payloads still deserialize; the bump
 ///   forces mvmd-side fixture refresh because byte output changes
 ///   when defaults are present (JSON keys appear with default values).
+/// - `2` (unchanged): `MountVolume` / `UnmountVolume` added
+///   variant-additively (Plan 59 Stage 0 — distributed-volume mount
+///   contract). No existing-variant bytes change, so mvmd's frozen
+///   fixtures stay valid. An older hostd refuses the new frames at
+///   deserialization (unknown variant), which the agent surfaces as a
+///   clean error; the coordinator gates sending these verbs on node
+///   capability, so no bump was taken.
 pub const PROTOCOL_VERSION: u32 = 2;
 
 // ============================================================================
@@ -124,6 +131,44 @@ pub enum HostdRequest {
     SetupNetwork { tenant_id: String, net: TenantNet },
     /// Tear down per-tenant bridge and NAT rules.
     TeardownNetwork { tenant_id: String, net: TenantNet },
+    /// Mount a distributed volume (S3/NFS/FUSE-backed bucket) at a
+    /// host-side mountpoint (Plan 59 Stage 0 — **contract only**).
+    ///
+    /// On success hostd replies `HostdResponse::Ok`. Until the mount
+    /// executor lands, hostd implementations MUST refuse this verb
+    /// with `HostdResponse::Error` (fail-closed stub) — no mount(2)
+    /// logic is implied by the variant's existence.
+    MountVolume {
+        tenant_id: String,
+        /// Coordinator-scoped bucket identifier (matches the desired
+        /// state's `DesiredMount::bucket_id`).
+        bucket_id: String,
+        /// Backing source kind (e.g. "s3", "nfs", "local-virtiofs").
+        /// Open string, matching `DesiredMount::provider` — unknown
+        /// kinds are refused at mount time, never silently defaulted.
+        source_kind: String,
+        /// Source-schema-owned configuration; hostd passes it to the
+        /// mount executor uninterpreted.
+        source_config: serde_json::Value,
+        /// Host-side path the volume is materialized at before being
+        /// exposed to guests.
+        host_mountpoint: String,
+    },
+    /// Unmount a previously mounted distributed volume (Plan 59
+    /// Stage 0 — **contract only**; refused with
+    /// `HostdResponse::Error` until the mount executor lands).
+    ///
+    /// Carries the same source identity as `MountVolume` so
+    /// provider-specific teardown (e.g. FUSE unmount options) needs no
+    /// host-side state lookup. On success hostd replies
+    /// `HostdResponse::Ok`.
+    UnmountVolume {
+        tenant_id: String,
+        bucket_id: String,
+        source_kind: String,
+        source_config: serde_json::Value,
+        host_mountpoint: String,
+    },
     /// Health check.
     Ping,
 }
@@ -524,6 +569,86 @@ mod tests {
     }
 
     #[test]
+    fn test_hostd_request_mount_volume_roundtrip() {
+        let req = HostdRequest::MountVolume {
+            tenant_id: "acme".to_string(),
+            bucket_id: "bkt-artifacts".to_string(),
+            source_kind: "s3".to_string(),
+            source_config: serde_json::json!({
+                "endpoint": "https://s3.example.com",
+                "bucket": "acme-artifacts"
+            }),
+            host_mountpoint: "/var/lib/mvm/mounts/acme/bkt-artifacts".to_string(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: HostdRequest = serde_json::from_str(&json).unwrap();
+        match parsed {
+            HostdRequest::MountVolume {
+                tenant_id,
+                bucket_id,
+                source_kind,
+                source_config,
+                host_mountpoint,
+            } => {
+                assert_eq!(tenant_id, "acme");
+                assert_eq!(bucket_id, "bkt-artifacts");
+                assert_eq!(source_kind, "s3");
+                assert_eq!(
+                    source_config.get("bucket").and_then(|b| b.as_str()),
+                    Some("acme-artifacts")
+                );
+                assert_eq!(host_mountpoint, "/var/lib/mvm/mounts/acme/bkt-artifacts");
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_hostd_request_unmount_volume_roundtrip() {
+        let req = HostdRequest::UnmountVolume {
+            tenant_id: "acme".to_string(),
+            bucket_id: "bkt-artifacts".to_string(),
+            source_kind: "nfs".to_string(),
+            source_config: serde_json::json!({"server": "10.240.0.9"}),
+            host_mountpoint: "/var/lib/mvm/mounts/acme/bkt-artifacts".to_string(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: HostdRequest = serde_json::from_str(&json).unwrap();
+        match parsed {
+            HostdRequest::UnmountVolume {
+                tenant_id,
+                bucket_id,
+                source_kind,
+                source_config,
+                host_mountpoint,
+            } => {
+                assert_eq!(tenant_id, "acme");
+                assert_eq!(bucket_id, "bkt-artifacts");
+                assert_eq!(source_kind, "nfs");
+                assert_eq!(
+                    source_config.get("server").and_then(|s| s.as_str()),
+                    Some("10.240.0.9")
+                );
+                assert_eq!(host_mountpoint, "/var/lib/mvm/mounts/acme/bkt-artifacts");
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    /// An mvm-hostd at PROTOCOL_VERSION 2 built before Plan 59 refuses
+    /// the new mount verbs at deserialization (serde unknown-variant),
+    /// which `recv_request` surfaces as a clean error — the fail-closed
+    /// behavior the variant-additive (no-bump) rollout relies on. This
+    /// test pins that an unknown verb is indeed a refusal, not a silent
+    /// fallback.
+    #[test]
+    fn test_hostd_request_unknown_variant_refused() {
+        let future_json = r#"{"FrobnicateVolume":{"tenant_id":"acme"}}"#;
+        let err = serde_json::from_str::<HostdRequest>(future_json).unwrap_err();
+        assert!(err.to_string().contains("unknown variant"));
+    }
+
+    #[test]
     fn test_hostd_request_ping_roundtrip() {
         let req = HostdRequest::Ping;
         let json = serde_json::to_string(&req).unwrap();
@@ -605,6 +730,20 @@ mod tests {
             HostdRequest::TeardownNetwork {
                 tenant_id: "t".to_string(),
                 net,
+            },
+            HostdRequest::MountVolume {
+                tenant_id: "t".to_string(),
+                bucket_id: "b".to_string(),
+                source_kind: "s3".to_string(),
+                source_config: serde_json::json!({}),
+                host_mountpoint: "/mnt/b".to_string(),
+            },
+            HostdRequest::UnmountVolume {
+                tenant_id: "t".to_string(),
+                bucket_id: "b".to_string(),
+                source_kind: "s3".to_string(),
+                source_config: serde_json::json!({}),
+                host_mountpoint: "/mnt/b".to_string(),
             },
             HostdRequest::Ping,
         ];

--- a/crates/mvm-core/src/protocol/protocol.rs
+++ b/crates/mvm-core/src/protocol/protocol.rs
@@ -53,8 +53,8 @@ const MAX_FRAME_SIZE: usize = 1024 * 1024;
 ///   forces mvmd-side fixture refresh because byte output changes
 ///   when defaults are present (JSON keys appear with default values).
 /// - `2` (unchanged): `MountVolume` / `UnmountVolume` added
-///   variant-additively (Plan 59 Stage 0 — distributed-volume mount
-///   contract). No existing-variant bytes change, so mvmd's frozen
+///   variant-additively for the distributed-volume mount contract. No
+///   existing-variant bytes change, so mvmd's frozen
 ///   fixtures stay valid. An older hostd refuses the new frames at
 ///   deserialization (unknown variant), which the agent surfaces as a
 ///   clean error; the coordinator gates sending these verbs on node
@@ -132,7 +132,7 @@ pub enum HostdRequest {
     /// Tear down per-tenant bridge and NAT rules.
     TeardownNetwork { tenant_id: String, net: TenantNet },
     /// Mount a distributed volume (S3/NFS/FUSE-backed bucket) at a
-    /// host-side mountpoint (Plan 59 Stage 0 — **contract only**).
+    /// host-side mountpoint (**contract only**).
     ///
     /// On success hostd replies `HostdResponse::Ok`. Until the mount
     /// executor lands, hostd implementations MUST refuse this verb
@@ -154,8 +154,8 @@ pub enum HostdRequest {
         /// exposed to guests.
         host_mountpoint: String,
     },
-    /// Unmount a previously mounted distributed volume (Plan 59
-    /// Stage 0 — **contract only**; refused with
+    /// Unmount a previously mounted distributed volume (**contract
+    /// only**; refused with
     /// `HostdResponse::Error` until the mount executor lands).
     ///
     /// Carries the same source identity as `MountVolume` so
@@ -635,8 +635,8 @@ mod tests {
         }
     }
 
-    /// An mvm-hostd at PROTOCOL_VERSION 2 built before Plan 59 refuses
-    /// the new mount verbs at deserialization (serde unknown-variant),
+    /// An mvm-hostd at PROTOCOL_VERSION 2 built before the mount verbs
+    /// were added refuses them at deserialization (serde unknown-variant),
     /// which `recv_request` surfaces as a clean error — the fail-closed
     /// behavior the variant-additive (no-bump) rollout relies on. This
     /// test pins that an unknown verb is indeed a refusal, not a silent


### PR DESCRIPTION
Contract-freeze PR for mvmd Plan 59 Stage 0 (tinylabscom/mvmd#180): the mount schema for signed desired state, plus stub hostd verbs for volume mounting.

**`domain/agent.rs`:**
- `DesiredPool.mounts: Vec<DesiredMount>` with `#[serde(default)]` — old coordinator payloads without mounts parse unchanged (pinned by test).
- `DesiredMount` (`deny_unknown_fields`): `bucket_id`, `provider` (open string per the `MountSource::External` precedent), `config` (provider-schema-owned JSON), `target`, `mode` (`ro`/`rw`, **required** — a mount must state its writability), `generation` (**required**, the sole change signal), `access_mode` (`rwo`/`rox`/`rwx`, the only defaulted field — defaults to `rox`, the sole mode safe on every provider without write coordination; writers opt in).
- `DesiredMountMode` mirrors (not reuses) IR `MountMode` — identical wire values, but signed desired state stays self-contained.

**`protocol/protocol.rs`:**
- `HostdRequest::MountVolume` / `UnmountVolume` `{ tenant_id, bucket_id, source_kind, source_config, host_mountpoint }`. Stubs only — no mount(2) logic. `UnmountVolume` carries full source identity so provider-specific teardown needs no host-side state lookup.
- **No `PROTOCOL_VERSION` bump** (stays 2): variants are purely additive, existing-variant bytes unchanged (frozen fixtures stay green), and an older hostd fails closed on unknown variants (pinned by test). Flagged in the version-history doc for a deliberate call when the real executor lands.
- Note: the mvm repo has no `HostdRequest` dispatch sites — dispatch lives in mvmd's `hostd/server.rs`, which must add "unsupported" arms when its mvm pin bumps (tracked as Plan 59 conductor follow-up).

Tests: `cargo test -p mvm-core` 1455 passed; clippy `-D warnings` clean across mvm-core, mvm-hostd, mvm-agentd, mvm-runtime, mvm-protocol, mvm-build, mvm-sdk, mvm-client, mvm-net, mvm-fs; fmt clean.

Sibling contract PRs: volume-bridge wire protocol (#2004), mvmd mounts seam (tinylabscom/mvmd#195). No file overlap with #2004 (disjoint files in mvm-core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)