### PR TITLE
ci: run fewer jobs on ordinary pull requests

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -117,11 +117,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect Rust-related path changes
+        id: changed
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          if git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -qE '^(crates/|src/|tests/|Cargo\.|\.cargo/|rust-toolchain|\.github/workflows/architecture\.yml)'; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rust=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install ripgrep
+        if: steps.changed.outputs.rust == 'true'
         run: sudo apt-get install -y ripgrep
 
       - name: Grep mvm crates for server-binding patterns outside substrate allowlist
+        if: steps.changed.outputs.rust == 'true'
         run: |
           set -e
 
@@ -245,3 +264,7 @@ jobs:
           fi
 
           echo "No orchestration servers in mvm — invariant #1 holds."
+
+      - name: Skip message for docs-only changes
+        if: steps.changed.outputs.rust == 'false'
+        run: echo "No Rust paths changed; architecture invariant check skipped."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 name: CI
 
 on:
-  # Keep pull-request validation cheap and predictable. This workflow is
-  # intentionally capped at four runner jobs:
-  # lint, test, MCP smoke, and Nix eval. Expensive platform, live-VM,
-  # OCI ratification, security, Windows, and release artifact jobs live
-  # in release/manual workflows.
+  # Keep pull-request validation cheap and predictable. On a pull request this
+  # workflow runs two jobs: lint and test. MCP smoke and Nix eval run only in
+  # the merge queue and on manual dispatch, so ordinary PR updates do not pay
+  # for them on every push. Expensive platform, live-VM, OCI ratification,
+  # security, Windows, and release artifact jobs live in release/manual workflows.
   pull_request:
-  # Required for the merge queue: checks must run against the merge_group event.
+  # Required for the merge queue: all checks must run against the merge_group event.
   merge_group:
   workflow_dispatch:
 
@@ -433,6 +433,8 @@ jobs:
 
   mcp-server-smoke:
     name: MCP server stdio roundtrip
+    # Not needed on every PR push; the merge queue exercises it once before merge.
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -462,6 +464,9 @@ jobs:
 
   nix-flake-check:
     name: Nix flake check (Linux eval)
+    # Nix eval/build is heavy; run it in the merge queue and on manual dispatch,
+    # not on every PR update.
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/specs/adrs/012-ci-execution-policy.md
+++ b/specs/adrs/012-ci-execution-policy.md
@@ -21,24 +21,26 @@ day-to-day development for no proportional benefit.
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `ci.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | day-to-day pull-request signal; a required merge-queue check |
-| `architecture.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | structural/architectural invariants; a required merge-queue check |
+| `ci.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | two jobs on PR (`lint` + `test`); all four jobs in merge queue / manual dispatch |
+| `architecture.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | structural/architectural invariants; skips the actual work on docs-only PRs, always runs in merge queue |
 | `ci-full.yml` | `workflow_dispatch` only | the full platform + live-VM + OCI-ratification matrix; operator-triggered, never automatic |
 | `security.yml` | `push: tags: v*` + nightly cron + `workflow_dispatch` | dependency audit / advisory scan; release-time backstop plus nightly catch for new advisories |
 | `windows.yml` | `push: tags: v*` + `workflow_dispatch` | non-blocking informational Windows build check; never a required check |
 | `release.yml` | `push: tags: v*` | builds and publishes release artifacts |
 
-### `ci.yml` is capped at four jobs
+### `ci.yml` is capped at four jobs in the merge queue, two on pull requests
 
 `lint` (fmt, clippy, and the full battery of `xtask` architectural
-checks — see ADR-010), `test` (the workspace nextest run, doctests,
-hermetic BDD, no-std target checks, and real-kernel ext4 checks),
-`mcp-server-smoke`, and `nix-flake-check`. The SDK publication dry-run
-is part of the manual full matrix rather than the development lane.
-Nothing platform-specific (macOS, live KVM, Windows) or slow (OCI
-ratification, dependency audit, the full builder-VM image build) runs on
-every pull request — those live in `ci-full.yml`, run only by explicit
-`workflow_dispatch`.
+checks — see ADR-010) and `test` (the workspace nextest run, doctests,
+hermetic BDD, no-std target checks, and real-kernel ext4 checks) run on
+every pull request. `mcp-server-smoke` and `nix-flake-check` run only in
+the merge queue and on manual `workflow_dispatch`, so ordinary PR updates
+pay for the lighter compile/test signal and the heavier smoke/eval lanes
+run once before merge. The SDK publication dry-run is part of the manual
+full matrix rather than the development lane. Nothing platform-specific
+(macOS, live KVM, Windows) or slow (OCI ratification, dependency audit,
+the full builder-VM image build) runs on every pull request — those live
+in `ci-full.yml`, run only by explicit `workflow_dispatch`.
 
 Checks that need the same Linux and Rust environment are steps in one of
 these four jobs, not standalone jobs. This shares checkout, toolchain,
@@ -75,12 +77,13 @@ evaluation on the hosted Linux runner.
 ## Consequences
 
 A pull-request update gets fast, complete feedback from the checks that
-matter for almost every change — four Linux-only jobs plus the
-architecture-invariant lane. Development branches without a pull request
-consume no hosted runners unless an operator dispatches CI manually. The
-merge queue runs the same five required checks against the final merge
-group. Landing that already-checked commit on `main` does not run them a
-third time. An operator opts into the expensive platform, live-VM,
+matter for almost every change — two Linux-only jobs (`lint` and `test`)
+plus the architecture-invariant lane, with the heavier `mcp-server-smoke`
+and `nix-flake-check` lanes deferred to the merge queue. The merge queue
+runs the full set of five required checks against the final merge group.
+Development branches without a pull request consume no hosted runners
+unless an operator dispatches CI manually. Landing that already-checked
+commit on `main` does not run them a third time. An operator opts into the expensive platform, live-VM,
 SDK-publication dry-run, and OCI-ratification matrix deliberately through
 `ci-full.yml`, rather than paying for it on every update.
 


### PR DESCRIPTION
Move the heavier MCP smoke and Nix flake-check jobs from ci.yml to merge_group / workflow_dispatch only, so ordinary PR updates run just lint + test. Keep architecture.yml fast by skipping the actual grep work on docs-only PRs while still reporting a successful check.

Update ADR-012 to record the new PR/merge-queue split.