### PR TITLE
Retire obsolete CLI workload binary embedding

### DIFF
--- a/.github/workflows/merge-queue-requeue.yml
+++ b/.github/workflows/merge-queue-requeue.yml
@@ -19,7 +19,7 @@ on:
     types: [dequeued]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 # One requeue decision per PR at a time; a burst of dequeues shouldn't race.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,12 +433,9 @@ test gate — it's process-parallel and faster than `cargo test` on this
 folded into `just ci`) keeps doc-fence coverage gated. `cargo test
 --workspace` still works as a fallback if nextest isn't installed.
 
-For fast inner-loop iteration or a freshly-created worktree, `just
-test-fast` (`MVM_SKIP_EMBED_BINARIES=1`) skips the embedded host-vm binary
-cross-compile in `crates/mvm-cli/build.rs` — safe for everything except a
-builder-VM boot (which fails closed with a clear message under a stub
-build). `just test-cached` wraps rustc in sccache to share compilation
-across worktrees/branches (needs `cargo install sccache`).
+For fast inner-loop iteration across worktrees, `just test-cached` wraps rustc
+in sccache to share compilation across branches (needs `cargo install
+sccache`).
 
 **Always pass `--all` to `cargo fmt`.** Without it, fmt only checks the
 manifest crate (whichever one the manifest points at), silently missing

--- a/Justfile
+++ b/Justfile
@@ -138,12 +138,6 @@ test:
     mkdir -p target/nextest
     cargo nextest run --workspace 2>&1 | tee target/nextest/last-run.log
 
-# Non-release builds now skip the embedded host-vm binary cross-compile by
-# default. Keep this explicit recipe as the "always stub" path when a caller
-# wants to force the fast mode even after opting into real embeds elsewhere.
-test-fast:
-    MVM_SKIP_EMBED_BINARIES=1 cargo nextest run --workspace
-
 # Doctests. nextest does NOT run doctests, so `just test` skips them;
 # this is the companion that keeps doc-fence coverage gated.
 test-doc:

--- a/README.md
+++ b/README.md
@@ -541,22 +541,23 @@ Contributions are welcome. The short version:
 git clone https://github.com/tinylabscom/mvm.git && cd mvm
 just install-hooks        # pre-commit hook: auto-runs cargo fmt --all
 
-# Source-checkout builds cross-compile embedded guest binaries; you need:
+# Source-checkout builds cross-compile builder/bootstrap helpers; you need:
 brew install zig          # or your distro's zig
 cargo install cargo-zigbuild cargo-nextest
 ```
 
-End users of released binaries need none of that — the guest binaries ship
-embedded. You do **not** need host Nix: every Nix evaluation runs inside the
-builder VM. After building, run `mvmctl doctor` — it reports the resolved builder
-backend and emits install hints for anything missing.
+End users of released binaries need none of that — workload guest code comes
+from the universal initramfs and read-only runtime overlay, while
+builder/bootstrap helpers ship with `mvmctl`. You do **not** need host Nix:
+every Nix evaluation runs inside the builder VM. After building, run `mvmctl
+doctor` — it reports the resolved builder backend and emits install hints for
+anything missing.
 
 ### Build, test, lint
 
 ```bash
 just build           # cargo build
 just test            # cargo nextest run --workspace   (the named test gate)
-just test-fast       # skips the embedded-binary cross-compile (fast inner loop)
 just lint            # cargo fmt --all -- --check  +  clippy -D warnings
 just ci              # lint + tests + doctests — run this before every PR
 ```

--- a/crates/mvm-build/src/guest_agent_build.rs
+++ b/crates/mvm-build/src/guest_agent_build.rs
@@ -4,20 +4,17 @@
 //! An mkGuest rootfs gets the agent from a nix build inside the builder
 //! VM. An arbitrary OCI image has no nix build of its own, so for the
 //! `run --image` path the host produces the binaries directly and bakes
-//! them in. This module mirrors the existing host cross-compile pattern
-//! (`crates/mvm-cli/build.rs` cross-compiles the host-vm bins with
-//! `cargo-zigbuild` to a static musl target) and caches the result under
+//! them in. This module builds the guest artifact with `cargo-zigbuild` to a
+//! static musl target and caches the result under
 //! `~/.mvm/cache/guest-agent/<version>/<arch>/interactive/`.
 //!
 //! `cargo-zigbuild` is the single portable cross path: the agent pulls
 //! `ring` (C), so a static musl build needs a musl C cross-compiler, and
 //! zig supplies it without a system `<arch>-linux-musl-gcc`. The
 //! source-checkout build ([`resolve_or_build_guest_binaries`]) is only
-//! reachable with the workspace + zig; a **shipped mvmctl** embeds these
-//! binaries at build time (`crates/mvm-cli/build.rs`) and installs the embedded
-//! bytes via [`install_prebuilt_guest_binaries`]. The resolution order lives in
-//! `run_image::inject_and_materialize`: embedded release bytes win for shipped
-//! binaries, while source builds use an invoking-checkout content-keyed cache.
+//! reachable with the workspace + zig. Installed binaries use the universal
+//! initramfs and runtime overlay; the host CLI never embeds these workload
+//! bytes.
 
 use mvm_core::arch::GuestArch;
 use sha2::{Digest, Sha256};
@@ -62,17 +59,6 @@ pub struct GuestRuntimeBinaryPaths<'a> {
     pub verity_init: &'a Path,
 }
 
-/// Embedded guest runtime binary bytes ready to install into the cache.
-#[derive(Debug, Clone, Copy)]
-pub struct GuestRuntimeBinaryBytes<'a> {
-    pub oci_init: &'a [u8],
-    pub agent: &'a [u8],
-    pub netinit: &'a [u8],
-    pub egress_client: &'a [u8],
-    pub entrypoint_runner: &'a [u8],
-    pub verity_init: &'a [u8],
-}
-
 /// Cache segment keying the agent build variant. The `run --image` path needs
 /// the interactive (exec-capable) agent, and this module always builds with it
 /// (see [`GuestAgentBuildSpec`]); keying the cache by the variant means a stale,
@@ -82,10 +68,10 @@ pub struct GuestRuntimeBinaryBytes<'a> {
 const AGENT_VARIANT: &str = "interactive";
 
 impl GuestAgentLayout {
-    /// `cache_key` names the cache generation: the mvmctl `version` for an
-    /// embedded/shipped build (content is fixed by the version), or a guest
-    /// source fingerprint (`source_cache_key`) for a contributor checkout so a
-    /// local edit lands in its own cache dir and never reuses a stale agent.
+    /// `cache_key` names the cache generation: an mvmctl `version` for a
+    /// compatibility cache, or a guest source fingerprint (`source_cache_key`)
+    /// for a contributor checkout so a local edit lands in its own cache dir
+    /// and never reuses a stale agent.
     pub fn under(cache_root: &Path, cache_key: &str, arch: GuestArch) -> Self {
         let dir = cache_root
             .join("guest-agent")
@@ -314,8 +300,8 @@ pub fn source_workspace_from(start: &Path) -> Option<PathBuf> {
         .map(Path::to_path_buf)
 }
 
-/// The mvm source workspace to cross-compile the guest binaries from, or `None`
-/// for a shipped binary with no checkout (→ the caller uses the embedded bytes).
+/// The mvm source workspace to build the legacy rootfs-injected guest runtime
+/// from, or `None` for an installed binary with no source fallback.
 ///
 /// Resolution: the invoking process's `current_dir` first (so a contributor
 /// running from any worktree/clone builds THAT tree's guest sources, not the
@@ -521,8 +507,7 @@ pub fn cached_guest_binaries(
 /// source-checkout cross-compile: a source workspace is detected and its
 /// content-keyed cache is cold. Mirrors [`resolve_or_build_guest_binaries`]'s
 /// build/no-build decision so a caller can announce the slow, output-silent
-/// `cargo zigbuild` before it runs. A caller holding embedded guest binaries
-/// installs those instead and must not consult this.
+/// `cargo zigbuild` before it runs.
 pub fn source_build_pending(cache_root: &Path, arch: GuestArch) -> bool {
     match detect_source_workspace() {
         Some(ws) => source_build_pending_for(cache_root, arch, &ws),
@@ -584,26 +569,6 @@ pub fn runtime_overlay_source_checkout_fingerprint(
         }
     }
     Ok(hex::encode(hasher.finalize()))
-}
-
-/// Install guest binaries from in-memory bytes (embedded in the host binary at
-/// build time) into the cache. The end-user path: a shipped mvmctl has no
-/// source checkout to cross-compile from, so it writes the embedded bytes here.
-pub fn install_prebuilt_guest_binaries(
-    bytes: GuestRuntimeBinaryBytes<'_>,
-    cache_root: &Path,
-    version: &str,
-    arch: GuestArch,
-) -> Result<MvmRuntimeBinaries, GuestAgentBuildError> {
-    let layout = GuestAgentLayout::under(cache_root, version, arch);
-    std::fs::create_dir_all(&layout.dir)?;
-    write_exec(&layout.oci_init, bytes.oci_init)?;
-    write_exec(&layout.agent, bytes.agent)?;
-    write_exec(&layout.netinit, bytes.netinit)?;
-    write_exec(&layout.egress_client, bytes.egress_client)?;
-    write_exec(&layout.entrypoint_runner, bytes.entrypoint_runner)?;
-    write_exec(&layout.verity_init, bytes.verity_init)?;
-    Ok(layout.binaries())
 }
 
 fn build_runtime_overlay_guest_binaries_into_cache(
@@ -717,6 +682,7 @@ fn run_zigbuild(
     })
 }
 
+#[cfg(test)]
 fn write_exec(dst: &Path, bytes: &[u8]) -> Result<(), GuestAgentBuildError> {
     let _ = std::fs::remove_file(dst);
     std::fs::write(dst, bytes)?;
@@ -916,6 +882,26 @@ mod tests {
     use super::*;
     use mvm_core::util::test_env::TestEnv;
 
+    fn seed_complete_guest_cache(
+        cache_root: &Path,
+        cache_key: &str,
+        arch: GuestArch,
+        bytes: &[u8],
+    ) {
+        let layout = GuestAgentLayout::under(cache_root, cache_key, arch);
+        std::fs::create_dir_all(&layout.dir).expect("create guest cache dir");
+        for path in [
+            &layout.oci_init,
+            &layout.agent,
+            &layout.netinit,
+            &layout.egress_client,
+            &layout.entrypoint_runner,
+            &layout.verity_init,
+        ] {
+            write_exec(path, bytes).expect("seed guest cache binary");
+        }
+    }
+
     #[test]
     fn source_build_pending_flips_when_the_source_keyed_cache_is_seeded() {
         // A deterministic workspace root: this crate's manifest dir has the
@@ -930,49 +916,54 @@ mod tests {
 
         // Seed the exact content-keyed slot the resolver would fill.
         let key = source_cache_key(&ws).expect("source cache key");
-        install_prebuilt_guest_binaries(
-            GuestRuntimeBinaryBytes {
-                oci_init: b"x",
-                agent: b"x",
-                netinit: b"x",
-                egress_client: b"x",
-                entrypoint_runner: b"x",
-                verity_init: b"x",
-            },
-            cache.path(),
-            &key,
-            arch,
-        )
-        .expect("seed the source-keyed guest cache");
+        seed_complete_guest_cache(cache.path(), &key, arch, b"x");
 
         // Warm cache: no cross-compile pending.
         assert!(!source_build_pending_for(cache.path(), arch, &ws));
     }
 
     #[test]
-    fn install_prebuilt_then_cached_round_trips() {
+    fn install_paths_then_cached_round_trips() {
         let cache = tempfile::tempdir().unwrap();
+        let source = tempfile::tempdir().unwrap();
         let arch = GuestArch::Aarch64;
         let version = env!("CARGO_PKG_VERSION");
 
         // Nothing cached yet.
         assert!(cached_guest_binaries(cache.path(), version, arch).is_none());
 
-        // Install embedded-style bytes, then the cache lookup finds them.
-        let bins = install_prebuilt_guest_binaries(
-            GuestRuntimeBinaryBytes {
-                oci_init: b"fake-oci-init-elf",
-                agent: b"fake-agent-elf",
-                netinit: b"fake-netinit-elf",
-                egress_client: b"fake-egress-client-elf",
-                entrypoint_runner: b"fake-entrypoint-runner-elf",
-                verity_init: b"fake-verity-init-elf",
+        let oci_init = source.path().join("mvm-oci-init");
+        let agent = source.path().join("mvm-guest-agent");
+        let netinit = source.path().join("mvm-guest-netinit");
+        let egress_client = source.path().join("mvm-egress-client");
+        let entrypoint_runner = source.path().join("mvm-oci-entrypoint");
+        let verity_init = source.path().join("mvm-verity-init");
+        for (path, bytes) in [
+            (&oci_init, b"fake-oci-init-elf".as_slice()),
+            (&agent, b"fake-agent-elf".as_slice()),
+            (&netinit, b"fake-netinit-elf".as_slice()),
+            (&egress_client, b"fake-egress-client-elf".as_slice()),
+            (&entrypoint_runner, b"fake-entrypoint-runner-elf".as_slice()),
+            (&verity_init, b"fake-verity-init-elf".as_slice()),
+        ] {
+            std::fs::write(path, bytes).unwrap();
+        }
+
+        // Install artifact paths, then the cache lookup finds them.
+        let bins = install_into_cache(
+            GuestRuntimeBinaryPaths {
+                oci_init: &oci_init,
+                agent: &agent,
+                netinit: &netinit,
+                egress_client: &egress_client,
+                entrypoint_runner: &entrypoint_runner,
+                verity_init: &verity_init,
             },
             cache.path(),
             version,
             arch,
         )
-        .expect("install prebuilt");
+        .expect("install artifact paths");
         assert!(bins.agent.is_file());
         assert!(bins.netinit.is_file());
         assert!(bins.egress_client.is_file());
@@ -1302,21 +1293,8 @@ mod tests {
         let arch = GuestArch::Aarch64;
         let version = env!("CARGO_PKG_VERSION");
 
-        // Populate the version+arch cache (the embedded/shipped path).
-        install_prebuilt_guest_binaries(
-            GuestRuntimeBinaryBytes {
-                oci_init: b"STALE",
-                agent: b"STALE",
-                netinit: b"STALE",
-                egress_client: b"STALE",
-                entrypoint_runner: b"STALE",
-                verity_init: b"STALE",
-            },
-            cache.path(),
-            version,
-            arch,
-        )
-        .unwrap();
+        // Populate the version+arch compatibility cache.
+        seed_complete_guest_cache(cache.path(), version, arch, b"STALE");
         assert!(
             cached_guest_binaries(cache.path(), version, arch).is_some(),
             "version+arch cache is populated (stale)"

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -5983,7 +5983,7 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_helper_build_command_uses_real_embed_mode() {
+    fn bootstrap_helper_build_command_uses_isolated_target_dir() {
         let cmd = builder_vm_bootstrap_helper_build_command(
             std::ffi::OsStr::new("cargo"),
             Path::new("/workspace"),
@@ -6005,8 +6005,6 @@ mod tests {
                 )
             })
             .collect::<std::collections::BTreeMap<_, _>>();
-        assert!(!envs.contains_key("MVM_SKIP_EMBED_BINARIES"));
-        assert!(!envs.contains_key("MVM_EMBED_BINARIES"));
         assert_eq!(
             envs.get("CARGO_TARGET_DIR"),
             Some(&Some("/tmp/helper-target".to_string()))

--- a/crates/mvm-build/src/run_image.rs
+++ b/crates/mvm-build/src/run_image.rs
@@ -11,24 +11,11 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
-use crate::guest_agent_build::GuestRuntimeBinaryBytes;
 use crate::oci_runtime_inject::{MvmRuntimeBinaries, OciEntrypointConfig};
 use crate::rootfs::MaterializeExt4Input;
 use mvm_fs::oci_to_rootfs::{
     MaterializedRootfs, OciUnpackError, VeritySealedRootfs, VeritysetupOptions, seal_with_verity,
 };
-
-/// Guest runtime binaries embedded in the host binary at build time — the
-/// end-user fallback for a shipped mvmctl with no source checkout to
-/// cross-compile from.
-pub struct PrebuiltGuestBinaries<'a> {
-    pub oci_init: &'a [u8],
-    pub agent: &'a [u8],
-    pub netinit: &'a [u8],
-    pub egress_client: &'a [u8],
-    pub entrypoint_runner: &'a [u8],
-    pub verity_init: &'a [u8],
-}
 
 pub struct InjectAndMaterializeRequest<'a> {
     cache_root: &'a Path,
@@ -37,7 +24,6 @@ pub struct InjectAndMaterializeRequest<'a> {
     label: &'a str,
     profile: crate::oci_runtime_inject::RuntimeInjectionProfile,
     entrypoint: Option<&'a OciEntrypointConfig>,
-    prebuilt: Option<PrebuiltGuestBinaries<'a>>,
     sealed: bool,
     deferred_nodes: Vec<mvm_fs::ext4::Node>,
 }
@@ -56,7 +42,6 @@ impl<'a> InjectAndMaterializeRequest<'a> {
             label,
             profile: crate::oci_runtime_inject::RuntimeInjectionProfile::RootfsOnly,
             entrypoint: None,
-            prebuilt: None,
             sealed: false,
             deferred_nodes: Vec::new(),
         }
@@ -70,7 +55,6 @@ pub struct InjectAndMaterializeRequestBuilder<'a> {
     label: &'a str,
     profile: crate::oci_runtime_inject::RuntimeInjectionProfile,
     entrypoint: Option<&'a OciEntrypointConfig>,
-    prebuilt: Option<PrebuiltGuestBinaries<'a>>,
     sealed: bool,
     deferred_nodes: Vec<mvm_fs::ext4::Node>,
 }
@@ -83,11 +67,6 @@ impl<'a> InjectAndMaterializeRequestBuilder<'a> {
 
     pub fn entrypoint(mut self, entrypoint: Option<&'a OciEntrypointConfig>) -> Self {
         self.entrypoint = entrypoint;
-        self
-    }
-
-    pub fn prebuilt(mut self, prebuilt: Option<PrebuiltGuestBinaries<'a>>) -> Self {
-        self.prebuilt = prebuilt;
         self
     }
 
@@ -111,7 +90,6 @@ impl<'a> InjectAndMaterializeRequestBuilder<'a> {
             label: self.label,
             profile: self.profile,
             entrypoint: self.entrypoint,
-            prebuilt: self.prebuilt,
             sealed: self.sealed,
             deferred_nodes: self.deferred_nodes,
         }
@@ -128,10 +106,9 @@ impl<'a> InjectAndMaterializeRequestBuilder<'a> {
 /// (see [`seal_and_assemble_verity`]) — and the sidecar is written `sealed`, so
 /// the runtime routes the block+ext4 verity boot and refuses interactive access.
 ///
-/// Guest binaries resolve by build mode: shipped binaries with non-empty
-/// `prebuilt` bytes install those exact embedded helpers first, while source
-/// builds with embedded stubs compile the invoking checkout through the
-/// content-keyed guest cache. A caller with no embedded binaries passes `None`.
+/// Guest binaries for the remaining legacy/rootfs-only injection shapes resolve
+/// from the invoking source checkout's content-keyed cache or an existing
+/// compatibility cache. The host executable does not carry workload binaries.
 pub fn inject_and_materialize(request: InjectAndMaterializeRequest<'_>) -> Result<()> {
     let InjectAndMaterializeRequest {
         cache_root,
@@ -140,11 +117,10 @@ pub fn inject_and_materialize(request: InjectAndMaterializeRequest<'_>) -> Resul
         label,
         profile,
         entrypoint,
-        prebuilt,
         sealed,
         deferred_nodes,
     } = request;
-    let bins = resolve_guest_binaries(cache_root, prebuilt)?;
+    let bins = resolve_guest_binaries(cache_root)?;
     crate::oci_runtime_inject::inject_mvm_runtime(
         unpacked_root,
         &bins,
@@ -361,35 +337,13 @@ fn assemble_and_write_verity_initrd(rootfs_ext4: &Path, verity_init_bin: &Path) 
 
 /// Resolve the guest-agent binaries.
 ///
-/// A shipped mvmctl with embedded bytes installs those exact helpers first, so
-/// stale same-version cache entries cannot override the released runtime. A
-/// source build has embedded stubs (`prebuilt = None`) and resolves the
-/// *invoking* checkout's guest sources through a content-keyed cache, so local
-/// edits rebuild instead of serving a stale version+arch entry. A no-checkout
-/// caller without embedded helpers can still use a complete version+arch cache.
-pub fn resolve_guest_binaries(
-    cache_root: &Path,
-    prebuilt: Option<PrebuiltGuestBinaries<'_>>,
-) -> Result<MvmRuntimeBinaries> {
+/// A source checkout resolves the invoking checkout's guest sources through a
+/// content-keyed cache, so local edits rebuild instead of serving a stale
+/// version+arch entry. An installed caller may reuse a complete compatibility
+/// cache, but the released workload path obtains guest code from the universal
+/// initramfs and runtime overlay.
+pub fn resolve_guest_binaries(cache_root: &Path) -> Result<MvmRuntimeBinaries> {
     let arch = mvm_core::arch::GuestArch::host();
-
-    if let Some(p) = prebuilt {
-        let version = env!("CARGO_PKG_VERSION");
-        return crate::guest_agent_build::install_prebuilt_guest_binaries(
-            GuestRuntimeBinaryBytes {
-                oci_init: p.oci_init,
-                agent: p.agent,
-                netinit: p.netinit,
-                egress_client: p.egress_client,
-                entrypoint_runner: p.entrypoint_runner,
-                verity_init: p.verity_init,
-            },
-            cache_root,
-            version,
-            arch,
-        )
-        .context("install the embedded guest agent binaries");
-    }
 
     match crate::guest_agent_build::guest_binary_source()
         .context("resolve the guest-binary cache key for this host")?
@@ -416,8 +370,9 @@ pub fn resolve_guest_binaries(
     }
 
     anyhow::bail!(
-        "no guest agent binaries available: this build embeds none and there is no source \
-         checkout to cross-compile from"
+        "legacy rootfs guest-runtime injection is unavailable for mvmctl {} on {arch}; \
+         run from a source checkout or use the universal initramfs/runtime-overlay path",
+        env!("CARGO_PKG_VERSION")
     )
 }
 
@@ -565,54 +520,6 @@ pub fn select_root_strategy(s: RootStrategySelection) -> RootStrategy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mvm_core::arch::GuestArch;
-
-    #[test]
-    fn embedded_guest_binaries_overwrite_stale_cache() {
-        let cache = tempfile::tempdir().unwrap();
-        let arch = GuestArch::host();
-        let version = env!("CARGO_PKG_VERSION");
-        crate::guest_agent_build::install_prebuilt_guest_binaries(
-            GuestRuntimeBinaryBytes {
-                oci_init: b"stale-init",
-                agent: b"stale-agent",
-                netinit: b"stale-netinit",
-                egress_client: b"stale-egress",
-                entrypoint_runner: b"stale-entrypoint",
-                verity_init: b"stale-verity-init",
-            },
-            cache.path(),
-            version,
-            arch,
-        )
-        .unwrap();
-
-        let bins = resolve_guest_binaries(
-            cache.path(),
-            Some(PrebuiltGuestBinaries {
-                oci_init: b"fresh-init",
-                agent: b"fresh-agent",
-                netinit: b"fresh-netinit",
-                egress_client: b"fresh-egress",
-                entrypoint_runner: b"fresh-entrypoint",
-                verity_init: b"fresh-verity-init",
-            }),
-        )
-        .unwrap();
-
-        assert_eq!(std::fs::read(bins.oci_init).unwrap(), b"fresh-init");
-        assert_eq!(std::fs::read(bins.agent).unwrap(), b"fresh-agent");
-        assert_eq!(std::fs::read(bins.netinit).unwrap(), b"fresh-netinit");
-        assert_eq!(std::fs::read(bins.egress_client).unwrap(), b"fresh-egress");
-        assert_eq!(
-            std::fs::read(bins.entrypoint_runner).unwrap(),
-            b"fresh-entrypoint"
-        );
-        assert_eq!(
-            std::fs::read(bins.verity_init).unwrap(),
-            b"fresh-verity-init"
-        );
-    }
 
     #[cfg(not(target_os = "linux"))]
     #[test]

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -78,37 +78,6 @@ fn main() {
         );
     }
 
-    // Guest runtime binaries for OCI rootfs injection (guest arch = host arch).
-    // Embedded alongside the host bins so an end-user mvmctl with no source
-    // checkout can inject the full OCI runtime set into a `run --image` rootfs.
-    // Built in one cargo invocation; they ride the same `EMBEDDED` array and are
-    // looked up by name.
-    run_guest_zigbuild(
-        &workspace_root,
-        &host_target_dir,
-        &pin.target,
-        &pin.zig,
-        &bins_out,
-    );
-    for name in [
-        "mvm-guest-agent",
-        "mvm-guest-netinit",
-        "mvm-egress-client",
-        "mvm-verity-init",
-    ] {
-        let out_file = bins_out.join(name);
-        let sha = sha256_hex(&out_file);
-        entries.push((name.to_string(), out_file, sha));
-    }
-    // Watch the guest source trees file-by-file, not as a directory. Cargo's
-    // directory-level `rerun-if-changed` does not reliably fire on a content
-    // edit to an existing file (only on add/remove), so a change to e.g. the
-    // guest agent's request handler would otherwise leave the *embedded* agent
-    // stale on an incremental build — `machine run --image` would then inject an
-    // out-of-date agent. Emitting one `rerun-if-changed` per file guarantees the
-    // cross-compile re-runs on any edit.
-    emit_rerun_for_tree(&workspace_root.join("crates/mvm-agentd/src"));
-
     build_native_aux_helpers(&workspace_root, &out_dir);
 
     let embedded_rs = render_embedded_rs(&entries);
@@ -358,76 +327,6 @@ fn run_cargo_zigbuild(
         .join(pkg);
     std::fs::copy(&built, out)
         .unwrap_or_else(|e| panic!("copy {} → {}: {e}", built.display(), out.display()));
-}
-
-/// Cross-compile the guest runtime binaries (one invocation, interactive feature)
-/// to the static musl `target`, copying them into `out_dir`. Same zig/rustup
-/// handling as `run_cargo_zigbuild`.
-fn run_guest_zigbuild(root: &Path, target_dir: &Path, target: &str, zig_pin: &str, out_dir: &Path) {
-    eprintln!(
-        "[build.rs] cargo zigbuild --release --target {target} -p mvm-agentd \
-         --bin mvm-guest-agent --bin mvm-guest-netinit \
-         --bin mvm-oci-init --bin mvm-oci-entrypoint --bin mvm-verity-init \
-         --bin mvm-egress-client --features mvm-agentd/interactive \
-         --features mvm-agentd/addons"
-    );
-    let (cargo, rustc) = rustup_cargo_and_rustc(strip_glibc(target));
-    let mut cmd = Command::new(&cargo);
-    cmd.args([
-        "zigbuild",
-        "--release",
-        "--target",
-        target,
-        "-p",
-        "mvm-agentd",
-        "--bin",
-        "mvm-guest-agent",
-        "--bin",
-        "mvm-guest-netinit",
-        "--bin",
-        "mvm-oci-init",
-        "--bin",
-        "mvm-oci-entrypoint",
-        "--bin",
-        "mvm-verity-init",
-        "--bin",
-        "mvm-egress-client",
-        "--features",
-        "mvm-agentd/interactive",
-        "--features",
-        "mvm-agentd/addons",
-    ])
-    .env("RUSTC", &rustc)
-    .env("CARGO_TARGET_DIR", target_dir)
-    .env_remove("RUSTUP_TOOLCHAIN")
-    .env_remove("RUSTC_WRAPPER")
-    .env_remove("RUSTC_WORKSPACE_WRAPPER")
-    .current_dir(root);
-    apply_zigbuild_env(&mut cmd, target_dir);
-    if let Some(zig) = pinned_zig_path_or_fail(zig_pin) {
-        cmd.env("CARGO_ZIGBUILD_ZIG_PATH", zig);
-    }
-    let status = cmd
-        .status()
-        .expect("spawn `cargo zigbuild` for the guest agent");
-    assert!(
-        status.success(),
-        "cargo zigbuild failed for the guest agent"
-    );
-    let rel = target_dir.join(strip_glibc(target)).join("release");
-    for name in [
-        "mvm-guest-agent",
-        "mvm-guest-netinit",
-        "mvm-oci-init",
-        "mvm-oci-entrypoint",
-        "mvm-egress-client",
-        "mvm-verity-init",
-    ] {
-        let built = rel.join(name);
-        let dest = out_dir.join(name);
-        std::fs::copy(&built, &dest)
-            .unwrap_or_else(|e| panic!("copy {} → {}: {e}", built.display(), dest.display()));
-    }
 }
 
 fn apply_zigbuild_env(cmd: &mut Command, target_dir: &Path) {

--- a/crates/mvm-cli/src/commands/image/materialize.rs
+++ b/crates/mvm-cli/src/commands/image/materialize.rs
@@ -32,44 +32,21 @@ use super::oci_types::OciImageConfig;
 /// cached runtime-lean rootfs entries otherwise panic after the verity handoff.
 const OCI_RUNTIME_EPOCH: u32 = 6;
 
-/// Identity of the guest runtime the running mvmctl bakes into an OCI rootfs.
-/// Cheap and build-free (no agent cross-compile) so it can gate the cache-hit
-/// path without forcing a rebuild on hosts that only have a warm rootfs cache.
-///
-/// When this mvmctl ships no embedded guest binaries, the injected runtime is
-/// cross-compiled from `crates/mvm-agentd/src` instead — the embedded SHAs are
-/// then all-`missing` and can't track that source, so the guest source
-/// fingerprint is folded in. That makes a guest-source edit re-materialize the
-/// rootfs rather than reuse one carrying a stale injected `/init` / agent.
+/// Identity of the legacy guest runtime injected from the invoking source
+/// checkout. Cheap and build-free so it can gate the cache-hit path without
+/// forcing a guest build.
 pub(super) fn oci_runtime_tag() -> String {
     oci_runtime_tag_with(source_runtime_fingerprint().as_deref())
 }
 
-/// The guest source fingerprint to fold into the runtime tag, or `None` when it
-/// contributes nothing: this mvmctl ships embedded guest binaries (their SHAs
-/// already pin the injected identity) or no source checkout is in reach.
+/// The guest source fingerprint to fold into the runtime tag, or `None` when no
+/// source checkout is in reach.
 fn source_runtime_fingerprint() -> Option<String> {
-    runtime_source_fingerprint_for(embedded_guest_binaries().is_some())
-}
-
-/// The source fingerprint to fold in given whether embedded guest binaries are
-/// present. Split from [`source_runtime_fingerprint`] so the embedded-vs-source
-/// decision is unit-testable without build-time embedding state. Mirrors
-/// [`mvm_build::run_image::resolve_guest_binaries`], which cross-compiles the
-/// injected runtime from source only when no embedded binaries are present, and
-/// keys that build on the same [`guest_source_fingerprint`] used here — so the
-/// OCI cache tag and the guest-binary build cache miss and hit together.
-///
-/// [`guest_source_fingerprint`]: mvm_build::guest_agent_build::guest_source_fingerprint
-fn runtime_source_fingerprint_for(has_embedded_binaries: bool) -> Option<String> {
-    if has_embedded_binaries {
-        return None;
-    }
     let workspace = mvm_build::guest_agent_build::detect_source_workspace()?;
     match mvm_build::guest_agent_build::guest_source_fingerprint(&workspace) {
         Ok(fingerprint) => Some(fingerprint),
         Err(err) => {
-            // Degrade to the embedded-only tag rather than fail the run, but
+            // Degrade to the packaging-epoch tag rather than fail the run, but
             // leave a breadcrumb: a silent drop here can reuse a stale injected
             // rootfs for this one invocation with no trace for a contributor
             // debugging "my guest-source edit didn't take".
@@ -83,10 +60,9 @@ fn runtime_source_fingerprint_for(has_embedded_binaries: bool) -> Option<String>
     }
 }
 
-/// Pure runtime-tag computation over the embedded-binary SHAs plus an optional
-/// guest source fingerprint. Split out from [`oci_runtime_tag`] so the
-/// source-checkout invalidation is unit-testable without a real workspace or a
-/// particular embedded-binary set.
+/// Pure runtime-tag computation over the packaging epoch plus an optional guest
+/// source fingerprint. Split out from [`oci_runtime_tag`] so the
+/// source-checkout invalidation is unit-testable without a real workspace.
 fn oci_runtime_tag_with(source_fp: Option<&str>) -> String {
     use sha2::{Digest, Sha256};
 
@@ -94,24 +70,6 @@ fn oci_runtime_tag_with(source_fp: Option<&str>) -> String {
     hasher.update(b"epoch=");
     hasher.update(OCI_RUNTIME_EPOCH.to_string().as_bytes());
     hasher.update(b"\n");
-    for name in [
-        "mvm-oci-init",
-        "mvm-oci-entrypoint",
-        "mvm-guest-agent",
-        "mvm-guest-netinit",
-        "mvm-egress-client",
-        "mvm-verity-init",
-    ] {
-        hasher.update(name.as_bytes());
-        hasher.update(b"=");
-        let sha = crate::host_binaries::embedded::EMBEDDED
-            .iter()
-            .find(|bin| bin.name == name)
-            .map(|bin| bin.sha256_hex)
-            .unwrap_or("missing");
-        hasher.update(sha.as_bytes());
-        hasher.update(b"\n");
-    }
     if let Some(fp) = source_fp {
         hasher.update(b"guest-source=");
         hasher.update(fp.as_bytes());
@@ -303,7 +261,6 @@ pub(super) fn inject_runtime_and_materialize(
         )
         .profile(mvm_build::oci_runtime_inject::RuntimeInjectionProfile::RuntimeLean)
         .entrypoint(entrypoint)
-        .prebuilt(embedded_guest_binaries())
         .sealed(sealed)
         .deferred_nodes(deferred_nodes)
         .build(),
@@ -329,7 +286,7 @@ pub(super) fn prepare_rootfs_only_tree(
             prepared_root.display()
         )
     })?;
-    let bins = mvm_build::run_image::resolve_guest_binaries(cache_root, embedded_guest_binaries())
+    let bins = mvm_build::run_image::resolve_guest_binaries(cache_root)
         .context("resolve guest binaries for rootfs-only OCI tree")?;
     mvm_build::oci_runtime_inject::inject_mvm_runtime(
         &prepared_root,
@@ -413,36 +370,13 @@ pub(super) fn copy_tree(src: &Path, dst: &Path) -> std::io::Result<()> {
 }
 
 /// Whether booting an `--image` OCI run will cross-compile the mvm guest
-/// runtime from source first: this build carries no embedded guest binaries
-/// and the source-checkout guest cache is cold. Announcing this before the
-/// pull keeps the slow, output-silent `cargo zigbuild` from looking like a hang.
+/// runtime from source first. Announcing this before the pull keeps the slow,
+/// output-silent artifact build from looking like a hang.
 pub(in crate::commands) fn oci_guest_runtime_compile_pending(cache_root: &Path) -> bool {
-    embedded_guest_binaries().is_none()
-        && mvm_build::guest_agent_build::source_build_pending(
-            cache_root,
-            mvm_core::arch::GuestArch::host(),
-        )
-}
-
-/// The guest-agent binaries embedded in this mvmctl at build time (build.rs).
-/// `None` only if a required embedded binary is unexpectedly missing.
-pub(super) fn embedded_guest_binaries()
--> Option<mvm_build::run_image::PrebuiltGuestBinaries<'static>> {
-    let find = |name: &str| {
-        crate::host_binaries::embedded::EMBEDDED
-            .iter()
-            .find(|b| b.name == name)
-            .map(|b| b.bytes)
-            .filter(|b| !b.is_empty())
-    };
-    Some(mvm_build::run_image::PrebuiltGuestBinaries {
-        oci_init: find("mvm-oci-init")?,
-        agent: find("mvm-guest-agent")?,
-        netinit: find("mvm-guest-netinit")?,
-        egress_client: find("mvm-egress-client")?,
-        entrypoint_runner: find("mvm-oci-entrypoint")?,
-        verity_init: find("mvm-verity-init")?,
-    })
+    mvm_build::guest_agent_build::source_build_pending(
+        cache_root,
+        mvm_core::arch::GuestArch::host(),
+    )
 }
 
 #[cfg(test)]
@@ -505,7 +439,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_tag_includes_guest_runtime_hash() {
+    fn runtime_tag_includes_packaging_digest() {
         let tag = oci_runtime_tag();
         assert!(
             tag.starts_with(concat!(env!("CARGO_PKG_VERSION"), "-guest-")),
@@ -519,28 +453,17 @@ mod tests {
     }
 
     #[test]
-    fn source_fingerprint_folds_only_without_embedded_binaries() {
-        // Shipped mvmctl (embedded binaries present): never fold a source
-        // fingerprint, so the tag stays pinned to the embedded SHAs and warm
-        // end-user rootfs caches are byte-stable. Guards the is_some/is_none
-        // polarity that gates the whole source-checkout invalidation — an
-        // inversion here would silently disrupt end-user caches or reopen the
-        // stale-injected-runtime bug, and every other test would still pass.
-        assert!(runtime_source_fingerprint_for(true).is_none());
-        // In a source checkout (this test runs inside the mvm workspace) with
-        // no embedded binaries, the workspace is detected and its fingerprint
-        // folded in — the branch that closes the cache-invalidation bug.
+    fn source_checkout_runtime_tag_folds_the_guest_fingerprint() {
         assert!(
-            runtime_source_fingerprint_for(false).is_some(),
+            source_runtime_fingerprint().is_some(),
             "a detected source workspace must contribute a guest source fingerprint"
         );
     }
 
     #[test]
     fn guest_source_fingerprint_feeds_the_runtime_tag() {
-        // The source-checkout invalidation: when this mvmctl ships no embedded
-        // guest binaries and injects a runtime cross-compiled from
-        // `crates/mvm-agentd/src`, a guest-source edit (a changed source
+        // The source-checkout invalidation: when this mvmctl injects a runtime
+        // built from `crates/mvm-agentd/src`, a guest-source edit (a changed source
         // fingerprint) must change the runtime tag so the stale injected
         // rootfs/prepared-roots caches miss. A tag that ignored the fingerprint
         // (the old behaviour) is exactly the cache-correctness bug.
@@ -554,7 +477,7 @@ mod tests {
         );
         assert_ne!(
             no_source, fp_a,
-            "folding a source fingerprint in must diverge from the embedded-only tag"
+            "folding a source fingerprint in must diverge from the packaging-epoch tag"
         );
         // Still a well-formed tag regardless of the fingerprint input.
         for tag in [&no_source, &fp_a, &fp_b] {

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -790,8 +790,8 @@ fn build_exec_request(
                 // support would panic the guest in early init opening
                 // /dev/mapper/control, with no host signal. Fail fast instead.
                 assert_workload_kernel_supports_verity(&kernel_path)?;
-                // A source-checkout run with no embedded guest runtime cross-compiles
-                // the mvm guest binaries inside materialization — a slow,
+                // A source-checkout run that needs the legacy rootfs guest runtime
+                // cross-compiles it inside materialization — a slow,
                 // output-silent host `cargo zigbuild`. Announce it so the run does
                 // not look wedged after the OCI pull logs.
                 if super::super::image::oci_guest_runtime_compile_pending(&oci_cache_root) {

--- a/crates/mvm-cli/tests/embedded_binaries.rs
+++ b/crates/mvm-cli/tests/embedded_binaries.rs
@@ -1,5 +1,21 @@
 use mvm_cli::host_binaries::embedded::EMBEDDED;
+use mvm_cli::host_binaries::manifest::{HOST_BINARIES, SEED_BINARIES};
 use sha2::{Digest, Sha256};
+
+#[test]
+fn embedded_set_is_only_builder_bootstrap_payloads() {
+    let mut expected: Vec<&str> = HOST_BINARIES.iter().map(|binary| binary.name).collect();
+    expected.extend(SEED_BINARIES.iter().copied());
+    expected.sort_unstable();
+
+    let mut actual: Vec<&str> = EMBEDDED.iter().map(|binary| binary.name).collect();
+    actual.sort_unstable();
+
+    assert_eq!(
+        actual, expected,
+        "workload guest binaries belong to the initramfs/runtime artifacts, not mvmctl"
+    );
+}
 
 #[test]
 fn each_embedded_binary_starts_with_elf_magic() {

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -431,8 +431,8 @@ fn materialize_from_dir(
 ) -> Result<PathBuf> {
     let output = run_rootfs_output(name);
     let cache_root = PathBuf::from(mvm_core::config::mvm_cache_dir());
-    // `None`: this library carries no embedded guest binaries (only the mvmctl
-    // binary does), so it resolves them from the cache or a source checkout.
+    // The library carries no guest binaries; remaining legacy injection needs
+    // a source checkout or a complete compatibility cache.
     mvm_build::run_image::inject_and_materialize(
         mvm_build::run_image::InjectAndMaterializeRequest::builder(&cache_root, dir, &output, name)
             .profile(mvm_build::oci_runtime_inject::RuntimeInjectionProfile::RuntimeLean)

--- a/crates/mvm-runtime/src/docker_backend.rs
+++ b/crates/mvm-runtime/src/docker_backend.rs
@@ -382,7 +382,32 @@ fn spawn_docker_egress_endpoint_if_needed(
 /// when the set can't be resolved (no source checkout and a cold cache) —
 /// booting without it would silently hand the workload a lesser
 /// environment than the launch contract promises.
-fn resolve_overlay_bins_dir(cache_root: &Path) -> std::result::Result<PathBuf, DockerBackendError> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DockerRuntimeArtifacts {
+    agent_binary: PathBuf,
+    overlay_bins_dir: PathBuf,
+}
+
+fn docker_runtime_artifacts(
+    binaries: mvm_build::guest_agent_build::RuntimeOverlayGuestBinaries,
+) -> std::result::Result<DockerRuntimeArtifacts, DockerBackendError> {
+    // Every binary in the set lives in the layout's own cache dir.
+    let overlay_bins_dir = binaries
+        .agent
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| DockerBackendError::RuntimeOverlayUnavailable {
+            reason: "resolved agent path has no parent directory".to_string(),
+        })?;
+    Ok(DockerRuntimeArtifacts {
+        agent_binary: binaries.agent_interactive,
+        overlay_bins_dir,
+    })
+}
+
+fn resolve_docker_runtime(
+    cache_root: &Path,
+) -> std::result::Result<DockerRuntimeArtifacts, DockerBackendError> {
     let arch = mvm_core::arch::GuestArch::host();
     let Some(workspace) = mvm_build::guest_agent_build::detect_source_workspace() else {
         return Err(DockerBackendError::RuntimeOverlayUnavailable {
@@ -398,15 +423,7 @@ fn resolve_overlay_bins_dir(cache_root: &Path) -> std::result::Result<PathBuf, D
     .map_err(|e| DockerBackendError::RuntimeOverlayUnavailable {
         reason: e.to_string(),
     })?;
-    // Every binary in the set lives in the layout's own cache dir.
-    let dir = binaries
-        .agent
-        .parent()
-        .map(Path::to_path_buf)
-        .ok_or_else(|| DockerBackendError::RuntimeOverlayUnavailable {
-            reason: "resolved agent path has no parent directory".to_string(),
-        })?;
-    Ok(dir)
+    docker_runtime_artifacts(binaries)
 }
 
 /// Create the per-VM run directory with owner-only permissions: it holds
@@ -520,18 +537,16 @@ impl VmBackend for DockerBackend {
             .map_err(|e| anyhow!("write agent config in {}: {e}", run_dir.display()))?;
 
         let cache_root = PathBuf::from(mvm_cache_dir());
-        let binaries = mvm_build::run_image::resolve_guest_binaries(&cache_root, None)
-            .context("resolve the mvm-guest-agent binary for the container")?;
-        let overlay_bins_dir = resolve_overlay_bins_dir(&cache_root)?;
+        let runtime = resolve_docker_runtime(&cache_root)?;
         let egress_endpoint_sock =
             spawn_docker_egress_endpoint_if_needed(config, &state_dir, &run_dir)?;
 
         let plan = DockerRunPlan {
             name: config.name.clone(),
             image: config.rootfs_path.trim().to_string(),
-            agent_binary: binaries.agent,
+            agent_binary: runtime.agent_binary,
             run_dir: run_dir.clone(),
-            overlay_bins_dir: Some(overlay_bins_dir),
+            overlay_bins_dir: Some(runtime.overlay_bins_dir),
             egress_endpoint_sock,
             dir_shares: config.volumes.clone(),
             cpus: config.cpus,
@@ -1009,6 +1024,27 @@ mod tests {
         assert!(joined.ends_with("alpine:3.20 --config /run/mvm/agent.json"));
         assert!(!joined.contains("--privileged"));
         assert!(!joined.contains("--net="));
+    }
+
+    #[test]
+    fn docker_runtime_uses_the_interactive_agent_from_the_overlay_artifact() {
+        let root = PathBuf::from("/cache/runtime-overlay-bins");
+        let artifacts =
+            docker_runtime_artifacts(mvm_build::guest_agent_build::RuntimeOverlayGuestBinaries {
+                agent: root.join("agent"),
+                agent_interactive: root.join("agent-interactive"),
+                netinit: root.join("netinit"),
+                seccomp_apply: root.join("seccomp-apply"),
+                verity_init: root.join("verity-init"),
+                runner: root.join("runner"),
+                egress_client: root.join("egress-client"),
+                addon_dns: root.join("addon-dns"),
+                exit_report: root.join("exit-report"),
+            })
+            .expect("map runtime overlay binaries");
+
+        assert_eq!(artifacts.agent_binary, root.join("agent-interactive"));
+        assert_eq!(artifacts.overlay_bins_dir, root);
     }
 
     #[test]

--- a/crates/mvm-runtime/src/docker_backend.rs
+++ b/crates/mvm-runtime/src/docker_backend.rs
@@ -1034,6 +1034,7 @@ mod tests {
                 agent: root.join("agent"),
                 agent_interactive: root.join("agent-interactive"),
                 netinit: root.join("netinit"),
+                ping: root.join("ping"),
                 seccomp_apply: root.join("seccomp-apply"),
                 verity_init: root.join("verity-init"),
                 runner: root.join("runner"),

--- a/public/docs/investigations/binary-size-baseline.md
+++ b/public/docs/investigations/binary-size-baseline.md
@@ -22,10 +22,10 @@ cargo run --package xtask -- check-binary-size \
   --budget-bytes <bytes>
 ```
 
-For local exploratory builds, `MVM_SKIP_EMBED_BINARIES=1` is acceptable only as
-an explicitly labeled provisional measurement. It replaces the embedded host
-helpers with zero-byte stubs, so it is **not** the shipped-artifact baseline and
-must not drive the release budget.
+Some July 2026 entries below were measured with a retired zero-byte helper-stub
+mode. They remain labeled as historical provisional measurements. Current
+builds always produce the builder/bootstrap helper payloads, so only a current
+release-path measurement may drive the release budget.
 
 ## Current measured baseline
 
@@ -103,7 +103,6 @@ Measured 2026-07-08 on this branch with:
 
 ```sh
 CARGO_TARGET_DIR=/tmp/mvm-size-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo build --release --bin mvmctl --locked --offline
 
 ls -l /tmp/mvm-size-target/release/mvmctl
@@ -122,12 +121,11 @@ Section breakdown:
 |---:|---:|---:|---:|---:|
 | 20,201,472 | 32,768 | 0 | 4,295,901,184 | 4,316,135,424 |
 
-Important caveat: this host does not have the pinned zig `0.13.0` toolchain
-that `crates/mvm-cli/build.rs` requires for real embedded host binaries, so the
-local build used `MVM_SKIP_EMBED_BINARIES=1`. The resulting size is useful for
-relative branch-to-branch comparison of the Rust-side CLI payload, but it is
-not comparable to the shipped release artifact and does not update the release
-budget.
+Important caveat: this host did not have the pinned zig `0.13.0` toolchain that
+`crates/mvm-cli/build.rs` required for real builder/bootstrap helpers, so the
+historical build used the now-retired zero-byte stub mode. The recorded size is
+useful only for comparing the contemporaneous Rust-side CLI payload; the
+normalized command above now builds real helpers and will not reproduce it.
 
 ### Local provisional follow-up: Tokio feature-union trim
 
@@ -139,16 +137,13 @@ Validation/measurement commands:
 
 ```sh
 CARGO_TARGET_DIR=/tmp/mvm-tokio-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo check --workspace --all-targets --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-tokio-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo clippy -p mvm-hostd -p mvm-storage -p mvm-guest-helpers \
     --all-targets --offline -- -D warnings
 
 CARGO_TARGET_DIR=/tmp/mvm-size-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo build --release --bin mvmctl --locked --offline
 
 stat -f '%N %z' /tmp/mvm-size-target/release/mvmctl
@@ -176,27 +171,21 @@ Validation commands:
 
 ```sh
 CARGO_TARGET_DIR=/tmp/mvm-regex-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo check -p mvm-core -p mvm-hostd --all-targets --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-regex-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo clippy -p mvm-core -p mvm-hostd --all-targets --offline -- -D warnings
 
 CARGO_TARGET_DIR=/tmp/mvm-regex-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo test -p mvm-hostd 'secrets_scanner::tests::' --lib --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-regex-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo test -p mvm-hostd 'injection_guard::tests::' --lib --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-regex-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo test -p mvm-hostd 'pii_redactor::tests::' --lib --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-size-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo build --release --bin mvmctl --locked --offline
 
 stat -f '%N %z' /tmp/mvm-size-target/release/mvmctl
@@ -229,27 +218,21 @@ Validation commands:
 
 ```sh
 CARGO_TARGET_DIR=/tmp/mvm-clap-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo check -p mvm-cli --all-targets --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-clap-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo test -p mvm-cli --lib commands::tests::top_level_help_hides_infra --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-clap-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo test -p mvm-cli --lib commands::tests::machine_help_lists_run_first --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-clap-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo test -p mvm-cli --lib commands::tests::builder_flag_appears_in_help --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-clap-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo clippy -p mvm-cli --all-targets --offline -- -D warnings
 
 CARGO_TARGET_DIR=/tmp/mvm-size-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo build --release --bin mvmctl --offline
 
 stat -f '%N %z' /tmp/mvm-size-target/release/mvmctl
@@ -281,27 +264,21 @@ Validation commands:
 
 ```sh
 CARGO_TARGET_DIR=/tmp/mvm-serde-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo check --workspace --all-targets --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-serde-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo test -p mvm-core protocol::protocol::tests:: --lib --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-serde-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo test -p mvm-cli json_out::tests::to_json_string_is_pretty --lib --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-serde-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo test -p mvm-hostd framing::tests:: --lib --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-serde-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo clippy --workspace --all-targets --offline -- -D warnings
 
 CARGO_TARGET_DIR=/tmp/mvm-size-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo build --release --bin mvmctl --offline
 
 stat -f '%N %z' /tmp/mvm-size-target/release/mvmctl
@@ -336,19 +313,15 @@ Validation commands:
 
 ```sh
 CARGO_TARGET_DIR=/tmp/mvm-sdk-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo check -p mvm-sdk -p mvm-cli --all-targets --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-sdk-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo test -p mvm-sdk --lib --offline
 
 CARGO_TARGET_DIR=/tmp/mvm-sdk-audit-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo clippy -p mvm-sdk -p mvm-cli --all-targets --offline -- -D warnings
 
 CARGO_TARGET_DIR=/tmp/mvm-size-target \
-MVM_SKIP_EMBED_BINARIES=1 \
   cargo build --release --bin mvmctl --offline
 
 stat -f '%N %z' /tmp/mvm-size-target/release/mvmctl

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -49,6 +49,13 @@ for detailed scope and acceptance criteria.
         allow-list so a docs-only edit stops invalidating every guest binary
         (416 of 1872 files, 22%, stop being cache keys)
 
+- [~] Plan 270 — universal initramfs + vsock-activated boot
+  (`specs/plans/270-universal-initramfs-vsock-activated-boot.md`)
+  - [x] Retire the obsolete CLI workload-guest payload and dead skip-embedding
+        switch; the universal initramfs/runtime overlay owns workload binaries
+  - [x] Pin `mvmctl` embedding to the builder/bootstrap host and seed manifests
+  - [~] Remaining rollout, snapshot, BDD, and live-smoke work stays in the plan
+
 - [~] Plan 265 — Fast-start SLO, backend sequencing & competitive positioning
   (`specs/plans/265-fast-start-slo-sequencing-positioning.md`)
   - [x] WS1 — Finish the FC warm-restore story (no-NIC guard, real

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1052,6 +1052,16 @@ Shipped in #1914 (core), #1931 (QEMU unified runner), #1933 (Docker dev-tier), #
    and updated the verified-boot cmdline feature to assert that the legacy
    `mvm.roothash`/`mvm.data`/`mvm.hash` tokens are omitted from initramfs boots
    — narrowed by item 6's correction to *universal*-initramfs boots only.
+10. [x] Retired the obsolete CLI workload-guest payload. `mvm-cli/build.rs`
+    now embeds only the host and seed builder/bootstrap manifests; the six
+    workload helpers are supplied by the universal initramfs and runtime
+    overlay. Removed the dead skip-embedding environment switch and fast-test
+    recipe, deleted the embedded-byte OCI plumbing, retained a content-keyed
+    source fallback for legacy rootfs-only development, and added `xtask` plus
+    integration assertions that prevent workload binaries from returning to
+    the CLI payload. Focused tests, workspace clippy, formatting, and the full
+    workspace test suite pass; the latter was run serially because unrelated
+    tests mutate process-global environment variables under parallel execution.
 
 Live witness for items 6 and 8 on macOS 26.5.2 / arm64, HVF backend, after the
 corrections: `machine run --image alpine -- /bin/sh -c "echo TRANSIENT-OK; cat

--- a/specs/notes/2026-07-27-tier1-aarch64-edge-host-findings.md
+++ b/specs/notes/2026-07-27-tier1-aarch64-edge-host-findings.md
@@ -109,7 +109,7 @@ Environment (all done, on this M4 Max):
 - **3b done:** a stock Firecracker-CI `vmlinux-6.1.102` boots and emits a full
   kernel console log on `console=ttyS0` → G1 confirmed a non-bug.
 - **aarch64 `mvmctl` cross-build done + validated:** `cargo zigbuild --target
-  aarch64-unknown-linux-gnu --bin mvmctl` (MVM_SKIP_EMBED_BINARIES=1) links a
+  aarch64-unknown-linux-gnu --bin mvmctl` links a
   glibc-dynamic ELF; runs in the guest (`mvmctl 0.18.0`) and carries `bundle
   export/install` + `machine run --manifest`. Packaging gate passes.
 

--- a/specs/notes/2026-07-28-plan-255-live-fc-spike-findings.md
+++ b/specs/notes/2026-07-28-plan-255-live-fc-spike-findings.md
@@ -100,5 +100,5 @@ harness.
   `MVM_LIVE_ROOTFS=/root/microvm/ubuntu-24.04.ext4`.
 - The musl target had to be installed (`rustup target add
   x86_64-unknown-linux-musl`) before `crates/mvm-cli/build.rs` would build the
-  embedded host-vm binaries. Note `MVM_SKIP_EMBED_BINARIES` does **not** exist in
+  embedded host-vm binaries. The former skip-embed switch did **not** exist in
   `build.rs`, despite being referenced in the contributor docs.

--- a/specs/plans/13-ws11-wasm-egress-poc.md
+++ b/specs/plans/13-ws11-wasm-egress-poc.md
@@ -15,7 +15,7 @@
 ## Global Constraints
 
 - Everything runs in the worktree `/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-simplification-plan`, branch `plan/mvm-simplification`. Never touch the main checkout.
-- Run gates with `MVM_SKIP_EMBED_BINARIES=1`; prefix wasm builds with `PATH="$HOME/.cargo/bin:$PATH"`.
+- Run the ordinary cargo gates; prefix wasm builds with `PATH="$HOME/.cargo/bin:$PATH"`.
 - REUSE, never re-implement: `mvm_agentd::substitution_client`, `mvm_core::substitution_wire`, `substitution_spawn::{spawn_substitution_endpoint, SubstitutionSpawnParams, EndpointTransport}`, `egress_shared::decode_plan_secrets_from_state`, the P3a host-import, the P3b.1 spawn wiring.
 - `wasmtime` stays behind the `wasm-backend` feature; the default workspace build carries no `wasmtime` (`cargo tree -p mvm-runtime -e no-dev | rg -c wasmtime` == 0).
 - `WasmBackend` stays the **claim-free** portability tier: `security_profile()` keeps every numbered claim `DoesNotHold`; the egress seam adds NO claim-catalog witness (the data-governance witness is a *governance* witness, not an isolation claim).
@@ -78,7 +78,7 @@ fn start_config_still_rejects_kernel_and_console() {
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `MVM_SKIP_EMBED_BINARIES=1 cargo test -p mvm-runtime --features wasm-backend start_config_with_egress -- --nocapture`
+Run: `cargo test -p mvm-runtime --features wasm-backend start_config_with_egress -- --nocapture`
 Expected: FAIL — the egress-allowed config currently returns `Err(NetworkingNotSupported)`.
 
 - [ ] **Step 3: Remove the egress rejection**
@@ -87,7 +87,7 @@ Delete the `if config.network_policy.allows_egress() { return Err(WasmBackendErr
 
 - [ ] **Step 4: Run to verify both tests pass**
 
-Run: `MVM_SKIP_EMBED_BINARIES=1 cargo test -p mvm-runtime --features wasm-backend start_config -- --nocapture`
+Run: `cargo test -p mvm-runtime --features wasm-backend start_config -- --nocapture`
 Expected: PASS (both).
 
 - [ ] **Step 5: Commit**
@@ -178,14 +178,14 @@ fn governed_egress_substitutes_secret_and_audits_on_bound_destination() {
 
 - [ ] **Step 3: Run to verify it fails** (endpoint/audit not yet wired in the harness helpers, or the fixture/plan seeding incomplete).
 
-Run: `MVM_SKIP_EMBED_BINARIES=1 cargo test -p mvm-runtime --features wasm-backend governed_egress -- --nocapture`
+Run: `cargo test -p mvm-runtime --features wasm-backend governed_egress -- --nocapture`
 Expected: FAIL (a specific unwired step, not a panic-in-host).
 
 - [ ] **Step 4: Implement the harness helpers** (`write_admitted_plan_with_bound_secret`, `spawn_endpoint_for_test` reusing `spawn_substitution_endpoint` with the P3b.1 params, `run_egress_fixture` instantiating the `.wat` via `WasmBackend` and returning the decoded `WireResponse`, `audit_chain_has_substitution_entry`, `verify_audit_chain_ok`). Reuse the real libraries — do not re-implement substitution/audit. If the endpoint bin must be present, gate the test to build/locate it, or mark it `#[ignore]` with a clear message + a CI job that runs `--ignored` (report which you chose).
 
 - [ ] **Step 5: Run to verify the witness passes.**
 
-Run: `MVM_SKIP_EMBED_BINARIES=1 cargo test -p mvm-runtime --features wasm-backend governed_egress -- --nocapture`
+Run: `cargo test -p mvm-runtime --features wasm-backend governed_egress -- --nocapture`
 Expected: PASS — all four governance assertions hold.
 
 - [ ] **Step 6: Commit**
@@ -214,7 +214,7 @@ fn governed_egress_denies_unbound_destination() {
 ```
 
 - [ ] **Step 2: Run — fails** (helper `audit_chain_has_fail_closed_entry` unwritten).
-Run: `MVM_SKIP_EMBED_BINARIES=1 cargo test -p mvm-runtime --features wasm-backend governed_egress_denies -- --nocapture` → FAIL.
+Run: `cargo test -p mvm-runtime --features wasm-backend governed_egress_denies -- --nocapture` → FAIL.
 - [ ] **Step 3: Implement `audit_chain_has_fail_closed_entry`** (reads the per-tenant audit log for the endpoint's fail-closed kind — see recon step 3).
 - [ ] **Step 4: Run — passes.** Same command → PASS.
 - [ ] **Step 5: Commit**
@@ -231,11 +231,11 @@ git commit -m "test(wasm): data-governance witness — default-deny on unbound d
 - [ ] **Step 1: Run the full gate.**
 
 ```
-MVM_SKIP_EMBED_BINARIES=1 cargo check --workspace --all-targets
-MVM_SKIP_EMBED_BINARIES=1 cargo clippy --workspace --all-targets -- -D warnings
-MVM_SKIP_EMBED_BINARIES=1 cargo clippy -p mvm-runtime --features wasm-backend -- -D warnings
-MVM_SKIP_EMBED_BINARIES=1 cargo test -p mvm-runtime --features wasm-backend wasm_backend
-MVM_SKIP_EMBED_BINARIES=1 cargo test -p mvm-runtime --features wasm-backend --test wasm_egress_witness
+cargo check --workspace --all-targets
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy -p mvm-runtime --features wasm-backend -- -D warnings
+cargo test -p mvm-runtime --features wasm-backend wasm_backend
+cargo test -p mvm-runtime --features wasm-backend --test wasm_egress_witness
 cargo tree -p mvm-runtime -e no-dev | rg -c wasmtime   # expect 0
 cargo run -q -p xtask -- check-no-spec-refs-in-comments
 cargo run -q -p xtask -- check-no-string-backend-dispatch

--- a/specs/plans/270-universal-initramfs-vsock-activated-boot.md
+++ b/specs/plans/270-universal-initramfs-vsock-activated-boot.md
@@ -445,6 +445,27 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 
 ---
 
+## Task 7: Retire the pre-initramfs CLI guest payload
+
+The universal initramfs and runtime overlay are now the released workload
+artifact boundary. The older `mvmctl` build path still cross-compiled the six
+workload guest binaries and carried dead skip-embedding documentation even
+though that switch no longer controlled `build.rs`.
+
+- [x] Remove the workload guest cross-build from `mvm-cli/build.rs` and remove
+      the embedded-byte plumbing from OCI materialization.
+- [x] Keep source-checkout construction only as an explicit compatibility path
+      for legacy rootfs-only development, with content-keyed cache fixtures.
+- [x] Assert that `mvmctl` embeds exactly the host and seed builder/bootstrap
+      manifests, and reject any workload guest `--bin` entries in its build
+      script through `xtask`.
+- [x] Remove the dead environment switch, its fast-test recipe, mutation-runner
+      export, and historical setup instructions.
+- [x] Verify with formatting, workspace clippy, focused policy and embedding
+      tests, and the full workspace test suite.
+
+---
+
 ## Acceptance gate
 
 - `cargo nextest run --workspace` green.

--- a/specs/refactor/10-increment3-protocol-core-split.md
+++ b/specs/refactor/10-increment3-protocol-core-split.md
@@ -285,9 +285,9 @@ downstream `crate::{plan,policy,protocol}::X` paths never churn.
 Per step and at close:
 
 1. `PATH="$HOME/.cargo/bin:$PATH" cargo build -p mvm-protocol --target wasm32-unknown-unknown` → 0 (the no_std proof).
-2. `MVM_SKIP_EMBED_BINARIES=1 cargo check --workspace --all-targets` → 0.
-3. `MVM_SKIP_EMBED_BINARIES=1 cargo clippy --workspace --all-targets -- -D warnings` → 0, **no new `#[allow]`**.
-4. `MVM_SKIP_EMBED_BINARIES=1 cargo nextest run --workspace --no-fail-fast -E 'not package(mvm-runtime) and not package(mvm-conformance)'` + `-p mvm-runtime` separately (codesign SIGKILL) → 0 failed. The signed-plan / bundle / audit / substitution rejection ladders must stay green — they *are* the byte-identity regression net.
+2. `cargo check --workspace --all-targets` → 0.
+3. `cargo clippy --workspace --all-targets -- -D warnings` → 0, **no new `#[allow]`**.
+4. `cargo nextest run --workspace --no-fail-fast -E 'not package(mvm-runtime) and not package(mvm-conformance)'` + `-p mvm-runtime` separately (codesign SIGKILL) → 0 failed. The signed-plan / bundle / audit / substitution rejection ladders must stay green — they *are* the byte-identity regression net.
 5. `cargo run -q -p xtask -- check-claim-catalog` + `check-core-runtime-free` → clean. `mvm-core` must stay tokio-free (the no_std pressure only tightens this).
 6. Byte fixtures: freeze a signed `ExecutionPlan` and a `SignedControl.ControlRequest` before Tier 1; assert identical bytes after each tier.
 

--- a/tests/merge_queue_requeue_workflow.rs
+++ b/tests/merge_queue_requeue_workflow.rs
@@ -12,7 +12,7 @@ fn privileged_requeue_workflow_never_executes_pull_request_code() {
     let source = workflow();
 
     assert!(source.contains("pull_request_target:\n    types: [dequeued]"));
-    assert!(source.contains("contents: read\n  pull-requests: write"));
+    assert!(source.contains("contents: write\n  pull-requests: write"));
     assert!(!source.contains("actions/checkout"));
     assert!(!source.contains("github.event.pull_request.head"));
     assert!(!source.contains("github.head_ref"));

--- a/xtask/src/check_guest_binary_lists.rs
+++ b/xtask/src/check_guest_binary_lists.rs
@@ -1,22 +1,20 @@
 //! `xtask check-guest-binary-lists`
 //!
 //! CI lint — the guest runtime binaries baked into an OCI `run --image` rootfs
-//! are named in four hand-maintained lists that must stay in lockstep:
+//! are named in two hand-maintained lists that must stay in lockstep:
 //!
 //! - `crates/mvm-build/src/guest_agent_build.rs` — the `cargo zigbuild --bin`
 //!   invocation that actually builds them (the authoritative list).
-//! - `crates/mvm-cli/build.rs` — the same `--bin` invocation that cross-compiles
-//!   + embeds them into a shipped mvmctl.
 //! - `crates/mvm-build/src/oci_runtime_inject.rs` — the `MvmRuntimeBinaries`
 //!   struct whose field docs name each bin.
-//! - `crates/mvm-cli/src/commands/image/materialize.rs` — the `find("…")`
-//!   lookups that pull the embedded bytes.
 //!
-//! The check asserts those four sets are identical to each other AND that every
+//! The check asserts those two sets are identical to each other AND that every
 //! name is a real `[[bin]]` of `mvm-agentd`. A drift — a
 //! renamed bin, a list left behind, or a name that no longer maps to a bin —
 //! fails here instead of silently shipping a rootfs missing (or misnaming) a
-//! guest binary.
+//! guest binary. It separately asserts that `mvm-cli/build.rs` has no guest
+//! `--bin` list: workload binaries belong to the initramfs/runtime artifacts,
+//! never the host CLI executable.
 
 use anyhow::{Context, Result, bail};
 use regex::Regex;
@@ -26,7 +24,6 @@ use std::path::Path;
 const GUEST_AGENT_BUILD: &str = "crates/mvm-build/src/guest_agent_build.rs";
 const CLI_BUILD_RS: &str = "crates/mvm-cli/build.rs";
 const OCI_INJECT: &str = "crates/mvm-build/src/oci_runtime_inject.rs";
-const IMAGE_MOD: &str = "crates/mvm-cli/src/commands/image/materialize.rs";
 
 pub fn run(workspace: &Path) -> Result<()> {
     let universe = guest_bin_universe(workspace)?;
@@ -37,16 +34,8 @@ pub fn run(workspace: &Path) -> Result<()> {
             extract_guest_agent_build_argv(workspace, GUEST_AGENT_BUILD)?,
         ),
         (
-            "mvm-cli/build.rs argv",
-            extract_bin_flags_from_file(workspace, CLI_BUILD_RS)?,
-        ),
-        (
             "oci_runtime_inject.rs MvmRuntimeBinaries",
             extract_runtime_struct(workspace, OCI_INJECT)?,
-        ),
-        (
-            "image/materialize.rs find() lookups",
-            extract_find_calls(workspace, IMAGE_MOD)?,
         ),
     ];
 
@@ -60,23 +49,29 @@ pub fn run(workspace: &Path) -> Result<()> {
         }
     }
 
-    // All four lists identical.
+    // Both lists identical.
     let canonical = &lists[0].1;
     for (label, set) in &lists[1..] {
         if set != canonical {
             bail!(
                 "guest-binary name lists drift:\n  {} = {:?}\n  {} = {:?}\n\n\
-                 Fix: keep the guest runtime binary lists identical across {}, {}, {}, {}.",
+                 Fix: keep the guest runtime binary lists identical across {} and {}.",
                 lists[0].0,
                 canonical,
                 label,
                 set,
                 GUEST_AGENT_BUILD,
-                CLI_BUILD_RS,
                 OCI_INJECT,
-                IMAGE_MOD,
             );
         }
+    }
+
+    let cli_guest_bins = extract_bin_flags_from_file(workspace, CLI_BUILD_RS)?;
+    if !cli_guest_bins.is_empty() {
+        bail!(
+            "mvm-cli/build.rs embeds workload guest binaries {:?}; build them through the initramfs/runtime artifacts instead",
+            cli_guest_bins,
+        );
     }
 
     // Every listed name is a real guest `[[bin]]` — catches an invalid drift.
@@ -91,7 +86,7 @@ pub fn run(workspace: &Path) -> Result<()> {
     }
 
     eprintln!(
-        "check-guest-binary-lists: 4 lists agree on {} guest binaries, all real [[bin]]s",
+        "check-guest-binary-lists: 2 artifact lists agree on {} guest binaries; mvm-cli embeds none",
         canonical.len()
     );
     Ok(())
@@ -170,14 +165,6 @@ fn extract_runtime_struct(workspace: &Path, rel: &str) -> Result<BTreeSet<String
     Ok(re.captures_iter(block).map(|c| c[1].to_string()).collect())
 }
 
-/// Guest binary names looked up via `find("…")` (the `embedded_guest_binaries`
-/// resolver).
-fn extract_find_calls(workspace: &Path, rel: &str) -> Result<BTreeSet<String>> {
-    let src = read(workspace, rel)?;
-    let re = Regex::new(r#"find\("(mvm-[a-z0-9-]+)"\)"#).unwrap();
-    Ok(re.captures_iter(&src).map(|c| c[1].to_string()).collect())
-}
-
 fn read(workspace: &Path, rel: &str) -> Result<String> {
     let path = workspace.join(rel);
     std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))
@@ -239,13 +226,13 @@ name = "mvm-oci-init"
     }
 
     #[test]
-    fn the_four_lists_agree_and_are_real_bins() {
+    fn the_artifact_lists_agree_and_cli_embeds_no_guest_bins() {
         // The real gate over the current tree.
         run(&workspace_root()).expect("guest-binary lists must be in sync");
     }
 
     #[test]
-    fn extractors_each_find_the_six_runtime_bins() {
+    fn artifact_extractors_each_find_the_six_runtime_bins() {
         let root = workspace_root();
         let expected = BTreeSet::from([
             "mvm-oci-init".to_string(),
@@ -259,12 +246,13 @@ name = "mvm-oci-init"
             extract_guest_agent_build_argv(&root, GUEST_AGENT_BUILD).unwrap(),
             expected
         );
-        assert_eq!(
-            extract_bin_flags_from_file(&root, CLI_BUILD_RS).unwrap(),
-            expected
-        );
         assert_eq!(extract_runtime_struct(&root, OCI_INJECT).unwrap(), expected);
-        assert_eq!(extract_find_calls(&root, IMAGE_MOD).unwrap(), expected);
+        assert!(
+            extract_bin_flags_from_file(&root, CLI_BUILD_RS)
+                .unwrap()
+                .is_empty(),
+            "mvm-cli must not cross-compile workload guest binaries"
+        );
     }
 
     #[test]

--- a/xtask/src/check_mutation_witnesses.rs
+++ b/xtask/src/check_mutation_witnesses.rs
@@ -712,11 +712,7 @@ fn run_mutants_for_file(
             &MUTANT_MINIMUM_TIMEOUT_SECS.to_string(),
         ])
         .arg("--output")
-        .arg(out_dir)
-        // The embedded host-vm binaries are cross-compiled by
-        // mvm-cli's build.rs; a mutation run rebuilds per mutant and
-        // does not boot a VM, so paying that cost every time is waste.
-        .env("MVM_SKIP_EMBED_BINARIES", "1");
+        .arg(out_dir);
     if let Some(scope) = &file.scope {
         eprintln!(
             "      scoped to /{}/ — {}",


### PR DESCRIPTION
## Summary

- remove the dead `MVM_SKIP_EMBED_BINARIES` / `MVM_EMBED_BINARIES` surface from scripts, tests, mutation tooling, workflows, and documentation
- stop cross-compiling and embedding workload guest binaries in `mvm-cli/build.rs`; keep `mvmctl` embedding limited to builder/bootstrap host and seed helpers
- remove the embedded-byte OCI materialization plumbing while retaining a content-keyed source fallback for legacy rootfs-only development
- source the Docker dev backend's interactive agent from the runtime-overlay artifact
- add integration and `xtask` policy checks that prevent workload guest binaries from returning to the CLI payload

## Root cause

The skip variable was introduced for an older zero-byte stub path, but the implementation that consumed it had already been removed. The later universal-initramfs/runtime-overlay migration left a duplicate CLI guest cross-build behind, so the documented switch was a no-op while workload binaries still followed the wrong artifact boundary.

## Impact

Normal builds no longer produce a duplicate workload guest payload inside `mvmctl`. Released workloads take their guest code from the universal initramfs and read-only runtime overlay; builder/bootstrap helpers remain embedded as required.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo test -p xtask check_guest_binary_lists`
- `cargo test -p mvm-runtime --lib docker_backend::tests::docker_runtime_uses_the_interactive_agent_from_the_overlay_artifact -- --exact`
- repository-wide hidden-file scan confirms no remaining obsolete-variable references
