### PR TITLE
Bind encrypted transcripts to signed audit roots

### DIFF
--- a/crates/mvm-cli/src/commands/ops/audit.rs
+++ b/crates/mvm-cli/src/commands/ops/audit.rs
@@ -613,7 +613,7 @@ fn run_verify_inclusion(
 
 /// Load a trusted Ed25519 verifying key from a file. Accepts the raw
 /// 32-byte form (`~/.mvm/keys/host-signer.pub`), 64-char hex, or base64.
-fn load_verifying_key(path: &std::path::Path) -> Result<VerifyingKey> {
+pub(super) fn load_verifying_key(path: &std::path::Path) -> Result<VerifyingKey> {
     let raw =
         std::fs::read(path).with_context(|| format!("reading pubkey file {}", path.display()))?;
     // Raw 32-byte key half — the on-disk host-signer.pub shape.

--- a/crates/mvm-cli/src/commands/ops/transcript.rs
+++ b/crates/mvm-cli/src/commands/ops/transcript.rs
@@ -1,4 +1,4 @@
-//! `mvmctl audit transcript` — operator surface for opt-in forensic network
+//! `mvmctl trust audit transcript` — operator surface for opt-in forensic network
 //! transcript captures.
 //!
 //! `arm` provisions a capture (per-capture data key wrapped under the host KEK
@@ -22,6 +22,13 @@ use mvm_core::transcript::{
     self, CaptureBinding, CaptureBounds, TranscriptManifest, TranscriptWriter,
     TranscriptWriterConfig,
 };
+use mvm_hostd::supervisor::audit::{
+    LABEL_CAPTURE_ID, LABEL_CHUNK_COUNT, LABEL_TRANSCRIPT_ROOT, LABEL_VM_NAME,
+    TRANSCRIPT_SEALED_EVENT,
+};
+use mvm_hostd::supervisor::verify_audit_chain_entries;
+
+use super::super::vm::host_signer::PUBLIC_FILENAME;
 
 const MANIFEST_FILE: &str = "manifest.json";
 const KEK_RECIPIENT: &str = "transcript-kek";
@@ -157,15 +164,20 @@ struct CaptureSummary {
 struct TranscriptCtx {
     transcripts_dir: PathBuf,
     keys_dir: PathBuf,
+    audit_dir: PathBuf,
+    verifying_key_path: PathBuf,
     /// Audit-log path override (tests). `None` → the default local audit log.
     audit_path: Option<PathBuf>,
 }
 
 impl TranscriptCtx {
     fn from_config() -> Self {
+        let keys_dir = config::mvm_keys_dir();
         Self {
             transcripts_dir: config::mvm_transcripts_dir(),
-            keys_dir: config::mvm_keys_dir(),
+            verifying_key_path: keys_dir.join(PUBLIC_FILENAME),
+            keys_dir,
+            audit_dir: config::mvm_audit_dir(),
             audit_path: None,
         }
     }
@@ -276,6 +288,7 @@ impl TranscriptCtx {
         let vm = manifest.binding.vm_name.clone();
 
         let recover = || -> Result<Vec<u8>> {
+            self.verify_chain_anchor(tenant, capture_id, &manifest)?;
             let kek = transcript::load_or_init_kek(&self.keys_dir)
                 .context("loading the host transcript KEK")?;
             let data_key = transcript::unwrap_data_key(&kek, &manifest.wrapped_data_key_b64)
@@ -304,6 +317,54 @@ impl TranscriptCtx {
         }
     }
 
+    fn verify_chain_anchor(
+        &self,
+        tenant: &str,
+        capture_id: &str,
+        manifest: &TranscriptManifest,
+    ) -> Result<()> {
+        transcript::verify_sealed_root(manifest).context("verifying transcript manifest root")?;
+        if manifest.capture_id != capture_id || manifest.binding.tenant_id != tenant {
+            anyhow::bail!(
+                "transcript binding does not match requested tenant/capture ({tenant}/{capture_id})"
+            );
+        }
+
+        let verifying_key = super::audit::load_verifying_key(&self.verifying_key_path)
+            .context("loading trusted host audit verifying key")?;
+        let chain_path = self.audit_dir.join(format!("{tenant}.jsonl"));
+        let entries = verify_audit_chain_entries(&chain_path, &verifying_key)
+            .with_context(|| format!("verifying audit chain {}", chain_path.display()))?;
+        let matching: Vec<_> = entries
+            .iter()
+            .filter(|entry| {
+                entry.tenant.0 == tenant
+                    && entry.event == TRANSCRIPT_SEALED_EVENT
+                    && entry
+                        .labels
+                        .get(LABEL_CAPTURE_ID)
+                        .is_some_and(|value| value == capture_id)
+            })
+            .collect();
+        if matching.len() != 1 {
+            anyhow::bail!(
+                "expected exactly one host-signed transcript seal for capture {capture_id}, found {}",
+                matching.len()
+            );
+        }
+        let entry = matching[0];
+        let expected_chunks = manifest.chunks.len().to_string();
+        if entry.labels.get(LABEL_VM_NAME) != Some(&manifest.binding.vm_name)
+            || entry.labels.get(LABEL_TRANSCRIPT_ROOT) != Some(&manifest.sealed_root_hex)
+            || entry.labels.get(LABEL_CHUNK_COUNT) != Some(&expected_chunks)
+        {
+            anyhow::bail!(
+                "host-signed transcript seal does not match capture {capture_id} binding, root, or chunk count"
+            );
+        }
+        Ok(())
+    }
+
     fn audit(&self, kind: LocalAuditKind, vm: &str) -> LocalAuditBuilder {
         let b = event(kind).vm_name(vm);
         match &self.audit_path {
@@ -316,7 +377,8 @@ impl TranscriptCtx {
 fn write_manifest(dir: &Path, manifest: &TranscriptManifest) -> Result<()> {
     let path = dir.join(MANIFEST_FILE);
     let json = serde_json::to_string_pretty(manifest)?;
-    std::fs::write(&path, json).with_context(|| format!("writing {}", path.display()))
+    mvm_core::atomic_io::atomic_write(&path, json.as_bytes())
+        .with_context(|| format!("writing {}", path.display()))
 }
 
 /// Immediate subdirectory names of `dir` (empty if `dir` is missing).
@@ -346,8 +408,43 @@ mod tests {
         TranscriptCtx {
             transcripts_dir: root.join("transcripts"),
             keys_dir: root.join("keys"),
+            audit_dir: root.join("chain-audit"),
+            verifying_key_path: root.join("keys/host-signer.pub"),
             audit_path: Some(root.join("audit.jsonl")),
         }
+    }
+
+    fn trusted_host_key(c: &TranscriptCtx) -> ed25519_dalek::SigningKey {
+        use ed25519_dalek::SigningKey;
+
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        std::fs::create_dir_all(c.verifying_key_path.parent().unwrap()).unwrap();
+        std::fs::write(&c.verifying_key_path, key.verifying_key().to_bytes()).unwrap();
+        key
+    }
+
+    fn anchor(c: &TranscriptCtx, manifest: &TranscriptManifest, root: &str) {
+        use mvm_hostd::audit::emitter::AuditEmitter;
+
+        let key = trusted_host_key(c);
+        let emitter = AuditEmitter::with_dir(key, &c.audit_dir).unwrap();
+        let plan = mvm_core::plan::test_support::PlanFixture::new()
+            .tenant(&manifest.binding.tenant_id)
+            .plan_id("transcript-test-plan")
+            .build();
+        emitter
+            .emit_transcript_sealed(
+                &plan,
+                &manifest.capture_id,
+                &manifest.binding.vm_name,
+                root,
+                manifest.chunks.len(),
+            )
+            .unwrap();
+    }
+
+    fn anchor_manifest(c: &TranscriptCtx, manifest: &TranscriptManifest) {
+        anchor(c, manifest, &manifest.sealed_root_hex);
     }
 
     fn bounds() -> CaptureBounds {
@@ -425,7 +522,9 @@ mod tests {
         );
         w.push(Direction::Egress, b"GET / HTTP/1.1\r\n").unwrap();
         w.push(Direction::Ingress, b"HTTP/1.1 200 OK\r\n").unwrap();
-        write_manifest(&dir, &w.seal()).unwrap();
+        let sealed = w.seal();
+        write_manifest(&dir, &sealed).unwrap();
+        anchor_manifest(&c, &sealed);
 
         let out = c.export("t1", &id).unwrap();
         assert_eq!(out, b"GET / HTTP/1.1\r\nHTTP/1.1 200 OK\r\n");
@@ -453,13 +552,65 @@ mod tests {
             },
         );
         w.push(Direction::Egress, b"secret").unwrap();
-        write_manifest(&dir, &w.seal()).unwrap();
+        let sealed = w.seal();
+        write_manifest(&dir, &sealed).unwrap();
+        anchor_manifest(&c, &sealed);
         // Same-length byte flip → hash mismatch on export.
         let mut ct = std::fs::read(dir.join("0.chunk")).unwrap();
         ct[0] ^= 0xff;
         std::fs::write(dir.join("0.chunk"), &ct).unwrap();
 
         assert!(c.export("t1", &id).is_err());
+        assert!(audit_contains(&c, "transcript_refused"));
+    }
+
+    #[test]
+    fn export_refuses_when_the_host_signed_anchor_is_missing() {
+        let d = tempfile::tempdir().unwrap();
+        let c = ctx(d.path());
+        let id = c.arm("t1", "vm1", None, bounds()).unwrap();
+        trusted_host_key(&c);
+
+        let err = c
+            .export("t1", &id)
+            .expect_err("unanchored evidence is refused");
+        assert!(err.to_string().contains("audit chain"));
+        assert!(audit_contains(&c, "transcript_refused"));
+    }
+
+    #[test]
+    fn export_refuses_when_the_host_signed_root_does_not_match() {
+        let d = tempfile::tempdir().unwrap();
+        let c = ctx(d.path());
+        let id = c.arm("t1", "vm1", None, bounds()).unwrap();
+        let (_dir, manifest) = c.load_manifest("t1", &id).unwrap();
+        anchor(&c, &manifest, &"00".repeat(32));
+
+        let err = c
+            .export("t1", &id)
+            .expect_err("mismatched signed root is refused");
+        assert!(err.to_string().contains("does not match"));
+        assert!(audit_contains(&c, "transcript_refused"));
+    }
+
+    #[test]
+    fn export_refuses_a_tampered_host_audit_chain() {
+        let d = tempfile::tempdir().unwrap();
+        let c = ctx(d.path());
+        let id = c.arm("t1", "vm1", None, bounds()).unwrap();
+        let (_dir, manifest) = c.load_manifest("t1", &id).unwrap();
+        anchor_manifest(&c, &manifest);
+
+        let path = c.audit_dir.join("t1.jsonl");
+        let chain = std::fs::read_to_string(&path).unwrap();
+        std::fs::write(
+            &path,
+            chain.replace("gateway.transcript_sealed", "gateway.forged"),
+        )
+        .unwrap();
+
+        let err = c.export("t1", &id).expect_err("tampered chain is refused");
+        assert!(err.to_string().contains("verifying audit chain"));
         assert!(audit_contains(&c, "transcript_refused"));
     }
 

--- a/crates/mvm-conformance/tests/steps/mod.rs
+++ b/crates/mvm-conformance/tests/steps/mod.rs
@@ -6,6 +6,7 @@ mod oci_unpack;
 mod readme_contract;
 mod sdk_sidecar;
 mod snapshot;
+mod transcript;
 mod verified_boot;
 mod warm_claim;
 mod warm_restore;

--- a/crates/mvm-conformance/tests/steps/transcript.rs
+++ b/crates/mvm-conformance/tests/steps/transcript.rs
@@ -1,0 +1,109 @@
+//! Hermetic operator-path scenarios for authenticated transcript export.
+
+use std::path::Path;
+
+use cucumber::given;
+use mvm_core::crypto::aead;
+use mvm_core::plan::test_support::PlanFixture;
+use mvm_core::transcript::{
+    self, CaptureBinding, CaptureBounds, Direction, TranscriptManifest, TranscriptWriter,
+    TranscriptWriterConfig,
+};
+use mvm_hostd::audit::emitter::AuditEmitter;
+use mvm_hostd::audit::host_keypair;
+
+use crate::world::CliWorld;
+
+const CAPTURE_ID: &str = "bdd-transcript";
+const EVIDENCE: &[u8] = b"authenticated transcript evidence";
+
+fn home(world: &CliWorld) -> &Path {
+    world
+        .isolated_home
+        .as_ref()
+        .expect("an isolated mvm home must be created first")
+        .path()
+}
+
+fn manifest_path(root: &Path) -> std::path::PathBuf {
+    root.join("audit/transcripts/local")
+        .join(CAPTURE_ID)
+        .join("manifest.json")
+}
+
+#[given("a sealed transcript anchored to the host audit chain")]
+async fn sealed_transcript_with_chain_anchor(world: &mut CliWorld) {
+    let root = home(world).to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let capture_dir = root.join("audit/transcripts/local").join(CAPTURE_ID);
+        let keys_dir = root.join("keys");
+        let audit_dir = root.join("audit");
+        std::fs::create_dir_all(&capture_dir).expect("create transcript fixture directory");
+
+        let kek = transcript::load_or_init_kek(&keys_dir).expect("create transcript KEK");
+        let data_key = aead::Key::from_bytes([9u8; 32]);
+        let wrapped_data_key_b64 = transcript::wrap_data_key(&kek, &data_key);
+        let mut writer = TranscriptWriter::new(
+            &capture_dir,
+            data_key,
+            TranscriptWriterConfig {
+                capture_id: CAPTURE_ID.to_string(),
+                binding: CaptureBinding {
+                    tenant_id: "local".to_string(),
+                    vm_name: "bdd-vm".to_string(),
+                    session_id: Some("bdd-session".to_string()),
+                },
+                bounds: CaptureBounds {
+                    max_duration_secs: 60,
+                    max_bytes: 4096,
+                    max_chunks: 4,
+                },
+                created_unix_secs: 1_700_000_000,
+                recipient: "transcript-kek".to_string(),
+                wrapped_data_key_b64,
+            },
+        );
+        writer
+            .push(Direction::Egress, EVIDENCE)
+            .expect("capture transcript fixture");
+        let manifest = writer.seal();
+        mvm_core::atomic_io::atomic_write(
+            &manifest_path(&root),
+            &serde_json::to_vec_pretty(&manifest).expect("serialize transcript manifest"),
+        )
+        .expect("write transcript manifest");
+
+        let signer = host_keypair::load_or_init_at(&keys_dir).expect("create host signer");
+        let emitter =
+            AuditEmitter::with_dir(signer.signing, &audit_dir).expect("open audit emitter");
+        let plan = PlanFixture::new()
+            .tenant("local")
+            .plan_id("bdd-transcript-plan")
+            .build();
+        emitter
+            .emit_transcript_sealed(
+                &plan,
+                &manifest.capture_id,
+                &manifest.binding.vm_name,
+                &manifest.sealed_root_hex,
+                manifest.chunks.len(),
+            )
+            .expect("anchor transcript root in host audit chain");
+    })
+    .await
+    .expect("transcript audit fixture task joins");
+}
+
+#[given("the sealed transcript binding is tampered")]
+fn tamper_transcript_binding(world: &mut CliWorld) {
+    let path = manifest_path(home(world));
+    let mut manifest: TranscriptManifest =
+        serde_json::from_slice(&std::fs::read(&path).expect("read transcript manifest fixture"))
+            .expect("parse transcript manifest fixture");
+    manifest.binding.vm_name = "forged-vm".to_string();
+    std::fs::write(
+        &path,
+        serde_json::to_vec_pretty(&manifest).expect("serialize tampered manifest"),
+    )
+    .expect("write tampered transcript manifest");
+}

--- a/crates/mvm-core/src/transcript.rs
+++ b/crates/mvm-core/src/transcript.rs
@@ -21,7 +21,7 @@ use crate::crypto::aead;
 pub const TRANSCRIPT_KEK_FILENAME: &str = "transcript-kek.bin";
 
 /// Current sealed-transcript manifest format. Unknown versions fail closed.
-pub const TRANSCRIPT_MANIFEST_FORMAT_VERSION: u32 = 1;
+pub const TRANSCRIPT_MANIFEST_FORMAT_VERSION: u32 = 2;
 
 /// Direction of a captured chunk relative to the workload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -84,6 +84,11 @@ pub struct TranscriptManifest {
     /// Recipient binding allowed to decrypt later (e.g. a host key id).
     pub recipient: String,
     pub chunks: Vec<ChunkRecord>,
+    /// RFC-6962 Merkle root over the capture binding, sealed-key metadata,
+    /// bounds, and ordered chunk records. The chunk records contain ciphertext
+    /// digests, never plaintext digests.
+    #[serde(default)]
+    pub sealed_root_hex: String,
 }
 
 /// Why a transcript operation refused. Fail-closed: any variant means the
@@ -113,6 +118,98 @@ pub enum TranscriptError {
     Decrypt { seq: u64, file: String },
     #[error("wrapped transcript key is malformed or cannot be unwrapped")]
     WrappedKeyInvalid,
+    #[error("sealed transcript root is missing")]
+    SealedRootMissing,
+    #[error("sealed transcript root must be 64 lowercase hex characters")]
+    SealedRootMalformed,
+    #[error("sealed transcript root does not match the manifest")]
+    SealedRootMismatch,
+    #[error("sealed transcript root metadata could not be serialized: {0}")]
+    SealedRootSerialization(String),
+}
+
+#[derive(Serialize)]
+struct RootMetadata<'a> {
+    domain: &'static str,
+    format_version: u32,
+    capture_id: &'a str,
+    binding: &'a CaptureBinding,
+    bounds: &'a CaptureBounds,
+    created_unix_secs: u64,
+    wrapped_data_key_b64: &'a str,
+    recipient: &'a str,
+    chunk_count: usize,
+}
+
+#[derive(Serialize)]
+struct RootChunk<'a> {
+    domain: &'static str,
+    chunk: &'a ChunkRecord,
+}
+
+/// Recompute the manifest's content address. Leaves use fixed-field-order JSON
+/// and the shared RFC-6962 tree implementation; the domain strings keep this
+/// tree distinct from audit-log trees and distinguish metadata from chunks.
+pub fn sealed_root_hex(manifest: &TranscriptManifest) -> Result<String, TranscriptError> {
+    validate_format(manifest)?;
+    let metadata = RootMetadata {
+        domain: "mvm.transcript.metadata.v1",
+        format_version: manifest.format_version,
+        capture_id: &manifest.capture_id,
+        binding: &manifest.binding,
+        bounds: &manifest.bounds,
+        created_unix_secs: manifest.created_unix_secs,
+        wrapped_data_key_b64: &manifest.wrapped_data_key_b64,
+        recipient: &manifest.recipient,
+        chunk_count: manifest.chunks.len(),
+    };
+    let mut leaves = Vec::with_capacity(manifest.chunks.len() + 1);
+    leaves.push(
+        serde_json::to_vec(&metadata)
+            .map_err(|e| TranscriptError::SealedRootSerialization(e.to_string()))?,
+    );
+    for chunk in &manifest.chunks {
+        leaves.push(
+            serde_json::to_vec(&RootChunk {
+                domain: "mvm.transcript.chunk.v1",
+                chunk,
+            })
+            .map_err(|e| TranscriptError::SealedRootSerialization(e.to_string()))?,
+        );
+    }
+    Ok(hex::encode(mvm_protocol::merkle::merkle_root(&leaves)))
+}
+
+/// Verify the manifest-stored root against a fresh recomputation. This checks
+/// manifest integrity; callers that need authenticated provenance must also
+/// compare the recomputed root with the host-signed audit-chain label.
+pub fn verify_sealed_root(manifest: &TranscriptManifest) -> Result<(), TranscriptError> {
+    validate_format(manifest)?;
+    if manifest.sealed_root_hex.is_empty() {
+        return Err(TranscriptError::SealedRootMissing);
+    }
+    if manifest.sealed_root_hex.len() != 64
+        || !manifest
+            .sealed_root_hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(TranscriptError::SealedRootMalformed);
+    }
+    if sealed_root_hex(manifest)? != manifest.sealed_root_hex {
+        return Err(TranscriptError::SealedRootMismatch);
+    }
+    Ok(())
+}
+
+fn validate_format(manifest: &TranscriptManifest) -> Result<(), TranscriptError> {
+    if manifest.format_version != TRANSCRIPT_MANIFEST_FORMAT_VERSION {
+        return Err(TranscriptError::UnknownFormatVersion {
+            got: manifest.format_version,
+            expected: TRANSCRIPT_MANIFEST_FORMAT_VERSION,
+        });
+    }
+    Ok(())
 }
 
 /// Accumulates a live capture and fails closed the moment a bound is hit.
@@ -164,12 +261,7 @@ impl CaptureBudget {
 /// closed on an unknown format version, an unsafe filename, or a missing,
 /// oversized, or tampered chunk. Integrity only — does not decrypt.
 pub fn verify_chunks(manifest: &TranscriptManifest, dir: &Path) -> Result<(), TranscriptError> {
-    if manifest.format_version != TRANSCRIPT_MANIFEST_FORMAT_VERSION {
-        return Err(TranscriptError::UnknownFormatVersion {
-            got: manifest.format_version,
-            expected: TRANSCRIPT_MANIFEST_FORMAT_VERSION,
-        });
-    }
+    validate_format(manifest)?;
     for c in &manifest.chunks {
         if c.file.is_empty()
             || c.file.contains('/')
@@ -306,7 +398,7 @@ impl TranscriptWriter {
 
     /// Finalize the manifest for the chunks written so far.
     pub fn seal(self) -> TranscriptManifest {
-        TranscriptManifest {
+        let mut manifest = TranscriptManifest {
             format_version: TRANSCRIPT_MANIFEST_FORMAT_VERSION,
             capture_id: self.capture_id,
             binding: self.binding,
@@ -315,7 +407,11 @@ impl TranscriptWriter {
             wrapped_data_key_b64: self.wrapped_data_key_b64,
             recipient: self.recipient,
             chunks: self.chunks,
-        }
+            sealed_root_hex: String::new(),
+        };
+        manifest.sealed_root_hex =
+            sealed_root_hex(&manifest).expect("fixed transcript root metadata serializes");
+        manifest
     }
 }
 
@@ -327,6 +423,7 @@ pub fn export(
     dir: &Path,
     key: &aead::Key,
 ) -> Result<Vec<u8>, TranscriptError> {
+    verify_sealed_root(manifest)?;
     verify_chunks(manifest, dir)?;
     let mut out = Vec::new();
     for c in &manifest.chunks {
@@ -385,7 +482,7 @@ mod tests {
     }
 
     fn manifest(chunks: Vec<ChunkRecord>) -> TranscriptManifest {
-        TranscriptManifest {
+        let mut manifest = TranscriptManifest {
             format_version: TRANSCRIPT_MANIFEST_FORMAT_VERSION,
             capture_id: "cap-1".to_string(),
             binding: CaptureBinding {
@@ -398,7 +495,10 @@ mod tests {
             wrapped_data_key_b64: String::new(),
             recipient: "host-key-1".to_string(),
             chunks,
-        }
+            sealed_root_hex: String::new(),
+        };
+        manifest.sealed_root_hex = sealed_root_hex(&manifest).unwrap();
+        manifest
     }
 
     fn write_chunk(dir: &Path, name: &str, body: &[u8]) -> ChunkRecord {
@@ -427,6 +527,32 @@ mod tests {
         let json = serde_json::to_string(&m).unwrap();
         let back: TranscriptManifest = serde_json::from_str(&json).unwrap();
         assert_eq!(m, back);
+    }
+
+    #[test]
+    fn sealed_root_vector_is_pinned() {
+        let m = manifest(vec![
+            ChunkRecord {
+                seq: 0,
+                file: "0.chunk".to_string(),
+                sha256_hex: "11".repeat(32),
+                size_bytes: 48,
+                direction: Direction::Egress,
+                dropped: false,
+            },
+            ChunkRecord {
+                seq: 1,
+                file: "1.chunk".to_string(),
+                sha256_hex: "22".repeat(32),
+                size_bytes: 64,
+                direction: Direction::Ingress,
+                dropped: true,
+            },
+        ]);
+        assert_eq!(
+            m.sealed_root_hex,
+            "81cf47b6993c2752d0a50ed0051151d6354986863f5b6265ae723e664c4f6dda"
+        );
     }
 
     #[test]
@@ -535,6 +661,70 @@ mod tests {
             recipient: "host-key-1".to_string(),
             wrapped_data_key_b64: "wrapped".to_string(),
         }
+    }
+
+    #[test]
+    fn sealed_root_binds_capture_metadata_and_ordered_ciphertext_chunks() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = aead::Key::from_bytes([6u8; 32]);
+        let mut writer = TranscriptWriter::new(dir.path(), key, writer_config());
+        writer.push(Direction::Egress, b"request").unwrap();
+        writer
+            .push_dropped(Direction::Ingress, b"response")
+            .unwrap();
+        let manifest = writer.seal();
+
+        assert_eq!(manifest.sealed_root_hex.len(), 64);
+        assert_eq!(
+            sealed_root_hex(&manifest).unwrap(),
+            manifest.sealed_root_hex
+        );
+        verify_sealed_root(&manifest).expect("freshly sealed manifest root verifies");
+
+        let mut changed_binding = manifest.clone();
+        changed_binding.binding.vm_name = "different-vm".into();
+        assert!(matches!(
+            verify_sealed_root(&changed_binding),
+            Err(TranscriptError::SealedRootMismatch)
+        ));
+
+        let mut reordered = manifest.clone();
+        reordered.chunks.reverse();
+        assert!(matches!(
+            verify_sealed_root(&reordered),
+            Err(TranscriptError::SealedRootMismatch)
+        ));
+
+        let mut changed_digest = manifest.clone();
+        changed_digest.chunks[0].sha256_hex = "00".repeat(32);
+        assert!(matches!(
+            verify_sealed_root(&changed_digest),
+            Err(TranscriptError::SealedRootMismatch)
+        ));
+    }
+
+    #[test]
+    fn sealed_root_verification_rejects_an_absent_or_malformed_root() {
+        let mut legacy = manifest(Vec::new());
+        legacy.format_version = 1;
+        legacy.sealed_root_hex.clear();
+        assert!(matches!(
+            verify_sealed_root(&legacy),
+            Err(TranscriptError::UnknownFormatVersion { got: 1, .. })
+        ));
+
+        let mut manifest = manifest(Vec::new());
+        manifest.sealed_root_hex.clear();
+        assert!(matches!(
+            verify_sealed_root(&manifest),
+            Err(TranscriptError::SealedRootMissing)
+        ));
+
+        manifest.sealed_root_hex = "not-a-sha256".into();
+        assert!(matches!(
+            verify_sealed_root(&manifest),
+            Err(TranscriptError::SealedRootMalformed)
+        ));
     }
 
     // `aead::Key` is deliberately not `Clone`; build identical keys from bytes

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -538,6 +538,29 @@ impl AuditEmitter {
         )
     }
 
+    /// Record the authenticated ciphertext-manifest root of a completed
+    /// forensic transcript capture. Payload bytes and plaintext digests stay
+    /// outside the chain; the labels are sufficient to authenticate the
+    /// encrypted evidence before decryption.
+    pub fn emit_transcript_sealed(
+        &self,
+        plan: &ExecutionPlan,
+        capture_id: &str,
+        vm_name: &str,
+        sealed_root_hex: &str,
+        chunk_count: usize,
+    ) -> Result<()> {
+        let entry = AuditEntry::transcript_sealed(
+            plan,
+            None,
+            capture_id,
+            vm_name,
+            sealed_root_hex,
+            chunk_count,
+        );
+        self.emit_entry(&entry)
+    }
+
     /// Emit `plan.exited` — fires after a waited-for workload powers off,
     /// carrying its captured exit code.
     pub fn emit_exited(&self, plan: &ExecutionPlan, exit_code: i32, backend: &str) -> Result<()> {
@@ -635,13 +658,17 @@ impl AuditEmitter {
         E: IntoIterator<Item = (String, String)>,
     {
         let entry = AuditEntry::for_plan(plan, None, event, extras);
+        self.emit_entry(&entry)
+    }
+
+    fn emit_entry(&self, entry: &AuditEntry) -> Result<()> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .context("building tokio runtime for audit emit")?;
         for signer in &self.signers {
-            rt.block_on(signer.sign_and_emit(&entry))
-                .with_context(|| format!("signing-and-emitting audit event {event}"))?;
+            rt.block_on(signer.sign_and_emit(entry))
+                .with_context(|| format!("signing-and-emitting audit event {}", entry.event))?;
         }
         Ok(())
     }
@@ -872,6 +899,44 @@ mod tests {
             verify_audit_chain(&path, &vk).unwrap(),
             1,
             "single-entry chain must verify clean"
+        );
+    }
+
+    #[test]
+    fn transcript_sealed_event_is_chain_signed_with_root_labels() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut seed);
+            SigningKey::from_bytes(&seed)
+        };
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-transcript");
+        let root = "cd".repeat(32);
+
+        emitter
+            .emit_transcript_sealed(&plan, "capture-1", "vm-1", &root, 3)
+            .unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        let entries = crate::supervisor::verify_audit_chain_entries(&path, &vk).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].event,
+            crate::supervisor::audit::TRANSCRIPT_SEALED_EVENT
+        );
+        assert_eq!(
+            entries[0]
+                .labels
+                .get(crate::supervisor::audit::LABEL_TRANSCRIPT_ROOT),
+            Some(&root)
+        );
+        assert_eq!(
+            entries[0]
+                .labels
+                .get(crate::supervisor::audit::LABEL_CHUNK_COUNT),
+            Some(&"3".to_string())
         );
     }
 

--- a/crates/mvm-hostd/src/supervisor/audit.rs
+++ b/crates/mvm-hostd/src/supervisor/audit.rs
@@ -154,6 +154,33 @@ impl AuditEntry {
             ],
         )
     }
+
+    /// Construct the chain entry that authenticates a sealed transcript's
+    /// ciphertext-manifest root without exposing payload bytes or plaintext
+    /// digests to the audit stream.
+    pub fn transcript_sealed(
+        plan: &ExecutionPlan,
+        bundle: Option<&PolicyBundle>,
+        capture_id: &str,
+        vm_name: &str,
+        sealed_root_hex: &str,
+        chunk_count: usize,
+    ) -> Self {
+        Self::for_plan(
+            plan,
+            bundle,
+            TRANSCRIPT_SEALED_EVENT,
+            [
+                (LABEL_CAPTURE_ID.to_string(), capture_id.to_string()),
+                (LABEL_VM_NAME.to_string(), vm_name.to_string()),
+                (
+                    LABEL_TRANSCRIPT_ROOT.to_string(),
+                    sealed_root_hex.to_string(),
+                ),
+                (LABEL_CHUNK_COUNT.to_string(), chunk_count.to_string()),
+            ],
+        )
+    }
 }
 
 /// Canonical `event` string for a `FlowOpened` chain entry. Pinned
@@ -168,6 +195,17 @@ pub const FLOW_CLOSED_EVENT: &str = "gateway.flow_closed";
 /// emitted when a host-allowlisted observer's `Modify`/`Drop` forced a
 /// fail-closed flow kill.
 pub const FLOW_OBSERVER_FAULT_EVENT: &str = "gateway.flow_observer_fault";
+
+/// Canonical chain event and labels for a sealed transcript content address.
+pub const TRANSCRIPT_SEALED_EVENT: &str = "gateway.transcript_sealed";
+/// Label containing the transcript capture identifier.
+pub const LABEL_CAPTURE_ID: &str = "capture_id";
+/// Label containing the VM identity bound into the transcript root.
+pub const LABEL_VM_NAME: &str = "vm_name";
+/// Label containing the authenticated ciphertext-manifest root.
+pub const LABEL_TRANSCRIPT_ROOT: &str = "transcript_root";
+/// Label containing the number of ordered ciphertext chunks.
+pub const LABEL_CHUNK_COUNT: &str = "chunk_count";
 
 /// Per-direction flow label for [`AuditEntry::flow_opened`] /
 /// [`AuditEntry::flow_closed`]. Egress = guest → internet,
@@ -526,6 +564,24 @@ mod tests {
         assert_eq!(entry.labels.get("flow_id"), Some(&"f00ba4".to_string()));
         assert_eq!(entry.labels.get("direction"), Some(&"egress".to_string()));
         // Plan binding still in place — same shape as for_plan().
+        assert_eq!(entry.plan_id, plan.plan_id);
+        assert_eq!(entry.tenant, plan.tenant);
+    }
+
+    #[test]
+    fn transcript_sealed_helper_carries_only_ciphertext_root_metadata() {
+        let plan = sample_plan();
+        let root = "ab".repeat(32);
+        let entry = AuditEntry::transcript_sealed(&plan, None, "capture-1", "vm-1", &root, 7);
+
+        assert_eq!(entry.event, TRANSCRIPT_SEALED_EVENT);
+        assert_eq!(
+            entry.labels.get(LABEL_CAPTURE_ID),
+            Some(&"capture-1".to_string())
+        );
+        assert_eq!(entry.labels.get(LABEL_VM_NAME), Some(&"vm-1".to_string()));
+        assert_eq!(entry.labels.get(LABEL_TRANSCRIPT_ROOT), Some(&root));
+        assert_eq!(entry.labels.get(LABEL_CHUNK_COUNT), Some(&"7".to_string()));
         assert_eq!(entry.plan_id, plan.plan_id);
         assert_eq!(entry.tenant, plan.tenant);
     }

--- a/crates/mvm-hostd/src/supervisor/audit_file.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_file.rs
@@ -211,9 +211,19 @@ pub enum VerifyError {
 /// against `verifying_key`. Returns the number of valid entries on
 /// success. Stops at the first failure and reports its line index.
 pub fn verify_audit_chain(path: &Path, verifying_key: &VerifyingKey) -> Result<usize, VerifyError> {
+    verify_audit_chain_entries(path, verifying_key).map(|entries| entries.len())
+}
+
+/// Verify a chain-signed audit file and return its authenticated entries in
+/// chain order. Consumers use this when a decision depends on signed labels,
+/// rather than parsing an already-verified file a second time.
+pub fn verify_audit_chain_entries(
+    path: &Path,
+    verifying_key: &VerifyingKey,
+) -> Result<Vec<AuditEntry>, VerifyError> {
     let content = std::fs::read_to_string(path).map_err(|e| VerifyError::Io(e.to_string()))?;
     let mut prev_hash = [0u8; 32];
-    let mut count = 0usize;
+    let mut entries = Vec::new();
     for (idx, line) in content.lines().enumerate() {
         if line.is_empty() {
             continue;
@@ -260,9 +270,9 @@ pub fn verify_audit_chain(path: &Path, verifying_key: &VerifyingKey) -> Result<u
             .verify(&to_verify, &signature)
             .map_err(|_| VerifyError::SignatureInvalid { line: idx })?;
         prev_hash = hash_line(line.as_bytes());
-        count += 1;
+        entries.push(envelope.entry);
     }
-    Ok(count)
+    Ok(entries)
 }
 
 fn hash_line(bytes: &[u8]) -> [u8; 32] {
@@ -356,6 +366,10 @@ mod tests {
         }
         let count = verify_audit_chain(&signer.tenant_path("tenant-a"), &vk).unwrap();
         assert_eq!(count, 5);
+        let entries = verify_audit_chain_entries(&signer.tenant_path("tenant-a"), &vk).unwrap();
+        assert_eq!(entries.len(), 5);
+        assert_eq!(entries[0].event, "event-0");
+        assert_eq!(entries[4].event, "event-4");
     }
 
     // Pin the wasm-clean `mvm_protocol::verify` re-implementation to the

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge/events.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge/events.rs
@@ -6,6 +6,8 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use tokio::sync::mpsc;
+
 use crate::supervisor::audit::{FlowCloseReason, FlowDirection};
 use crate::supervisor::network::Observer;
 use crate::supervisor::network::latency::ObserverLatency;
@@ -39,6 +41,71 @@ pub enum FlowEventKind {
         observer: String,
         reason: String,
     },
+}
+
+/// A sealed transcript's authenticated content address, sent through the same
+/// ordered signer queue as flow lifecycle entries.
+#[derive(Debug, Clone)]
+pub(crate) struct TranscriptSealedEvent {
+    pub capture_id: String,
+    pub vm_name: String,
+    pub sealed_root_hex: String,
+    pub chunk_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum GatewayAuditEvent {
+    Flow(FlowEvent),
+    TranscriptSealed(TranscriptSealedEvent),
+}
+
+impl GatewayAuditEvent {
+    #[cfg(test)]
+    pub(crate) fn into_flow(self) -> Option<FlowEvent> {
+        match self {
+            Self::Flow(event) => Some(event),
+            Self::TranscriptSealed(_) => None,
+        }
+    }
+}
+
+/// Typed sender that keeps existing flow producers narrow while allowing the
+/// bridge teardown to enqueue a transcript seal on the same ordered channel.
+#[derive(Clone)]
+pub(crate) struct GatewayAuditEventSender {
+    inner: mpsc::Sender<GatewayAuditEvent>,
+}
+
+impl GatewayAuditEventSender {
+    pub async fn send(
+        &self,
+        event: FlowEvent,
+    ) -> Result<(), mpsc::error::SendError<GatewayAuditEvent>> {
+        self.inner.send(GatewayAuditEvent::Flow(event)).await
+    }
+
+    pub fn blocking_send(
+        &self,
+        event: FlowEvent,
+    ) -> Result<(), mpsc::error::SendError<GatewayAuditEvent>> {
+        self.inner.blocking_send(GatewayAuditEvent::Flow(event))
+    }
+
+    pub async fn send_transcript_sealed(
+        &self,
+        event: TranscriptSealedEvent,
+    ) -> Result<(), mpsc::error::SendError<GatewayAuditEvent>> {
+        self.inner
+            .send(GatewayAuditEvent::TranscriptSealed(event))
+            .await
+    }
+}
+
+pub(crate) fn audit_event_channel(
+    capacity: usize,
+) -> (GatewayAuditEventSender, mpsc::Receiver<GatewayAuditEvent>) {
+    let (tx, rx) = mpsc::channel(capacity);
+    (GatewayAuditEventSender { inner: tx }, rx)
 }
 
 /// Bounded mpsc capacity. The bridge `send().await`s — overflow

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge/mod.rs
@@ -15,7 +15,7 @@
 //!   bridge binds an outer listener libkrun connects to, shuffles
 //!   datagrams both ways. SOCK_DGRAM preserves packet boundaries.
 //!
-//! Both feed one `mpsc::Sender<FlowEvent>` into a per-VM
+//! Both feed one ordered audit-event channel into a per-VM
 //! `signer_task` that is the **sole** caller of
 //! `AuditSigner::sign_and_emit` — combined with the
 //! `FileAuditSigner` flock precursor (commit 2), this guarantees

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge/native_gateway.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge/native_gateway.rs
@@ -6,14 +6,12 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use tokio::sync::mpsc;
-
 use crate::supervisor::audit::{FlowCloseReason, FlowDirection};
 use crate::supervisor::network::PacketCtx;
 use crate::supervisor::network::packet::{self, FlowKey};
 use crate::supervisor::network::pipeline::{PacketDecision, run_packet_pipeline};
 
-use super::events::{FlowEvent, FlowEventKind, ObserverWiring};
+use super::events::{FlowEvent, FlowEventKind, GatewayAuditEventSender, ObserverWiring};
 use super::flow_policy::{FlowAction, FlowDecisionCtx, FlowPolicy};
 
 /// True if `raw` parses to a flow already in `killed`. Cheap:
@@ -42,7 +40,7 @@ pub(super) async fn run_libkrun_native_gateway_bridge(
     vm_name: String,
     tenant: String,
     policy: Arc<dyn FlowPolicy>,
-    event_tx: mpsc::Sender<FlowEvent>,
+    event_tx: GatewayAuditEventSender,
     wiring: ObserverWiring,
 ) {
     use tokio::net::UnixDatagram;
@@ -348,7 +346,7 @@ pub(super) fn libkrun_reply_path(supervisor_listen_path: &std::path::Path) -> Pa
 
 #[cfg(test)]
 mod tests {
-    use super::super::events::BRIDGE_MTU;
+    use super::super::events::{BRIDGE_MTU, audit_event_channel};
     use super::super::flow_policy::{PlanFlowPolicy, bare_network_policy_egress};
     use super::super::test_support::*;
     use super::*;
@@ -433,7 +431,7 @@ mod tests {
         let sup_listen = dir.path().join("sup.sock");
         let gateway = tokio::net::UnixDatagram::bind(&gateway_path).unwrap();
 
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, _rx) = audit_event_channel(64);
         let policy = unrestricted_flow_policy();
         let bridge = tokio::spawn(run_libkrun_native_gateway_bridge(
             gateway_path.clone(),
@@ -476,7 +474,7 @@ mod tests {
         let sup_listen = dir.path().join("sup.sock");
         let gateway = tokio::net::UnixDatagram::bind(&gateway_path).unwrap();
 
-        let (tx, mut rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, mut rx) = audit_event_channel(64);
         let policy = unrestricted_flow_policy();
         let bridge = tokio::spawn(run_libkrun_native_gateway_bridge(
             gateway_path.clone(),
@@ -505,6 +503,7 @@ mod tests {
         for _ in 0..4 {
             match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await {
                 Ok(Some(ev)) => {
+                    let ev = ev.into_flow().expect("bridge emits a flow event");
                     if let FlowEventKind::ObserverFault { observer, reason } = ev.kind {
                         assert_eq!(observer, "test-drop");
                         assert_eq!(reason, "drop");
@@ -588,7 +587,7 @@ mod tests {
         let sup_listen = dir.path().join("sup.sock");
         let gateway = tokio::net::UnixDatagram::bind(&gateway_path).unwrap();
 
-        let (tx, mut rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, mut rx) = audit_event_channel(64);
         let policy = unrestricted_flow_policy();
         // deny_all egress → the egress frame to 93.184.216.34:443 has no
         // matching rule → L4PolicyScan drops it at the chokepoint.
@@ -622,6 +621,7 @@ mod tests {
         for _ in 0..4 {
             match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await {
                 Ok(Some(ev)) => {
+                    let ev = ev.into_flow().expect("bridge emits a flow event");
                     if let FlowEventKind::ObserverFault { observer, reason } = ev.kind {
                         assert_eq!(observer, "l4-policy");
                         assert_eq!(reason, "drop");
@@ -646,7 +646,7 @@ mod tests {
         let sup_listen = dir.path().join("sup.sock");
         let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
 
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, _rx) = audit_event_channel(64);
         let policy = unrestricted_flow_policy();
         // Allow tcp to exactly 93.184.216.34:443 — the frame's destination.
         let allow = canonicalize_l4(&[L4RuleSpec {
@@ -688,7 +688,7 @@ mod tests {
         let sup_listen = dir.path().join("sup.sock");
         let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
 
-        let (tx, mut rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, mut rx) = audit_event_channel(64);
         let policy = unrestricted_flow_policy();
         // Egress allow-list = {example.com} → a UDP/53 query for a host outside
         // it is sink-holed at the chokepoint.
@@ -724,6 +724,7 @@ mod tests {
         for _ in 0..4 {
             match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await {
                 Ok(Some(ev)) => {
+                    let ev = ev.into_flow().expect("bridge emits a flow event");
                     if let FlowEventKind::ObserverFault { observer, reason } = ev.kind {
                         assert_eq!(observer, "dns-sinkhole");
                         assert_eq!(reason, "drop");
@@ -748,7 +749,7 @@ mod tests {
         let sup_listen = dir.path().join("sup.sock");
         let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
 
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, _rx) = audit_event_channel(64);
         let policy = unrestricted_flow_policy();
         let bridge = tokio::spawn(run_libkrun_native_gateway_bridge(
             gvproxy_path.clone(),
@@ -793,7 +794,7 @@ mod tests {
         let sup_listen = dir.path().join("sup.sock");
         let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
 
-        let (tx, mut rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, mut rx) = audit_event_channel(64);
         // Deny-all resolved policy → PlanFlowPolicy drops the egress flow at
         // open, before any packet scan runs. NoopScan wiring proves the drop is
         // the FlowPolicy's, not the packet layer's.
@@ -830,6 +831,7 @@ mod tests {
         for _ in 0..4 {
             match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await {
                 Ok(Some(ev)) => {
+                    let ev = ev.into_flow().expect("bridge emits a flow event");
                     if let FlowEventKind::Closed { reason } = ev.kind {
                         assert!(matches!(reason, FlowCloseReason::PolicyDropped));
                         assert_eq!(ev.direction, FlowDirection::Egress);
@@ -854,7 +856,7 @@ mod tests {
         let sup_listen = dir.path().join("sup.sock");
         let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
 
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, _rx) = audit_event_channel(64);
         // `open` egress mode → the flow opens; with NoopScan the frame is
         // forwarded to the gateway.
         let eff = mvm_core::policy::EffectivePolicy {
@@ -910,7 +912,7 @@ mod tests {
         let gvproxy_path = dir.path().join("gvproxy.sock");
         let sup_listen = dir.path().join("sup.sock");
         let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
-        let (tx, mut rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, mut rx) = audit_event_channel(64);
         let bridge = tokio::spawn(run_libkrun_native_gateway_bridge(
             gvproxy_path.clone(),
             sup_listen.clone(),
@@ -937,6 +939,7 @@ mod tests {
         for _ in 0..4 {
             match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await {
                 Ok(Some(ev)) => {
+                    let ev = ev.into_flow().expect("bridge emits a flow event");
                     if matches!(
                         ev.kind,
                         FlowEventKind::Closed {
@@ -975,7 +978,7 @@ mod tests {
         let gateway_path = dir.path().join("native-gateway.sock");
         let sup_listen = dir.path().join("sup.sock");
         let gateway = tokio::net::UnixDatagram::bind(&gateway_path).unwrap();
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, _rx) = audit_event_channel(64);
         let bridge = tokio::spawn(run_libkrun_native_gateway_bridge(
             gateway_path.clone(),
             sup_listen.clone(),
@@ -1022,7 +1025,7 @@ mod tests {
         let gateway_path = dir.path().join("native-gateway.sock");
         let sup_listen = dir.path().join("sup.sock");
         let gateway = tokio::net::UnixDatagram::bind(&gateway_path).unwrap();
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, _rx) = audit_event_channel(64);
         let bridge = tokio::spawn(run_libkrun_native_gateway_bridge(
             gateway_path.clone(),
             sup_listen.clone(),
@@ -1100,7 +1103,7 @@ mod tests {
         let gvproxy_path = dir.path().join("gvproxy.sock");
         let sup_listen = dir.path().join("sup.sock");
         let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, _rx) = audit_event_channel(64);
         let bridge = tokio::spawn(run_libkrun_native_gateway_bridge(
             gvproxy_path.clone(),
             sup_listen.clone(),
@@ -1141,7 +1144,7 @@ mod tests {
         let gvproxy_path = dir.path().join("gvproxy.sock");
         let sup_listen = dir.path().join("sup.sock");
         let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, _rx) = audit_event_channel(64);
         let bridge = tokio::spawn(run_libkrun_native_gateway_bridge(
             gvproxy_path.clone(),
             sup_listen.clone(),
@@ -1179,7 +1182,7 @@ mod tests {
         let gvproxy_path = dir.path().join("gvproxy.sock");
         let sup_listen = dir.path().join("sup.sock");
         let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, _rx) = audit_event_channel(64);
         let bridge = tokio::spawn(run_libkrun_native_gateway_bridge(
             gvproxy_path.clone(),
             sup_listen.clone(),
@@ -1225,7 +1228,7 @@ mod tests {
         let gvproxy_path = dir.path().join("gvproxy.sock");
         let sup_listen = dir.path().join("sup.sock");
         let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, _rx) = audit_event_channel(64);
         let bridge = tokio::spawn(run_libkrun_native_gateway_bridge(
             gvproxy_path.clone(),
             sup_listen.clone(),
@@ -1265,7 +1268,7 @@ mod tests {
         let gvproxy_path = dir.path().join("gvproxy.sock");
         let sup_listen = dir.path().join("sup.sock");
         let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, _rx) = audit_event_channel(64);
         let bridge = tokio::spawn(run_libkrun_native_gateway_bridge(
             gvproxy_path.clone(),
             sup_listen.clone(),
@@ -1309,7 +1312,7 @@ mod tests {
         let gvproxy_path = dir.path().join("gvproxy.sock");
         let sup_listen = dir.path().join("sup.sock");
         let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, _rx) = audit_event_channel(64);
         let bridge = tokio::spawn(run_libkrun_native_gateway_bridge(
             gvproxy_path.clone(),
             sup_listen.clone(),

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge/native_gateway_live.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge/native_gateway_live.rs
@@ -4,9 +4,7 @@
 //! both files a manageable size; every test here is opt-in (env-gated)
 //! and soft-skips when the gateway binary is absent.
 
-use tokio::sync::mpsc;
-
-use super::events::{FlowEvent, FlowEventKind};
+use super::events::{FlowEventKind, audit_event_channel};
 use super::native_gateway::{libkrun_reply_path, run_libkrun_native_gateway_bridge};
 use super::test_support::{unrestricted_flow_policy, wiring_with};
 
@@ -148,7 +146,7 @@ async fn native_gateway_dhcp_offer_roundtrips_through_bridge() {
     // Bridge: gateway-facing = the gateway's socket; libkrun-facing =
     // a listener the harness connects to.
     let sup_listen = tmp.path().join("sup.sock");
-    let (tx, mut rx) = mpsc::channel::<FlowEvent>(64);
+    let (tx, mut rx) = audit_event_channel(64);
     let policy = unrestricted_flow_policy();
     let bridge = tokio::spawn(run_libkrun_native_gateway_bridge(
         gw_sock.clone(),
@@ -204,6 +202,7 @@ async fn native_gateway_dhcp_offer_roundtrips_through_bridge() {
     // the real-gateway path).
     let mut saw_open = false;
     while let Ok(ev) = rx.try_recv() {
+        let ev = ev.into_flow().expect("bridge emits a flow event");
         if matches!(ev.kind, FlowEventKind::Opened) {
             saw_open = true;
         }

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge/passt.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge/passt.rs
@@ -6,13 +6,14 @@
 use std::os::fd::OwnedFd;
 use std::sync::Arc;
 
-use tokio::sync::mpsc;
-
 use crate::supervisor::audit::{FlowCloseReason, FlowDirection};
 use crate::supervisor::network::PacketCtx;
 use crate::supervisor::network::pipeline::{PacketDecision, run_packet_pipeline};
 
-use super::events::{FlowEvent, FlowEventKind, ObserverWiring, TranscriptCaptureRoots};
+use super::events::{
+    FlowEvent, FlowEventKind, GatewayAuditEventSender, ObserverWiring, TranscriptCaptureRoots,
+    TranscriptSealedEvent,
+};
 use super::flow_policy::{FlowAction, FlowDecisionCtx, FlowPolicy};
 use super::native_gateway::flow_is_killed;
 
@@ -22,7 +23,7 @@ pub(super) async fn run_passt_bridge(
     vm_name: String,
     tenant: String,
     policy: Arc<dyn FlowPolicy>,
-    event_tx: mpsc::Sender<FlowEvent>,
+    event_tx: GatewayAuditEventSender,
     wiring: ObserverWiring,
 ) {
     let gateway_std = std::os::unix::net::UnixStream::from(gateway_fd);
@@ -124,7 +125,7 @@ async fn bridge_copy_bidirectional(
     vm_name: String,
     tenant: String,
     policy: Arc<dyn FlowPolicy>,
-    event_tx: mpsc::Sender<FlowEvent>,
+    event_tx: GatewayAuditEventSender,
     wiring: ObserverWiring,
 ) -> std::io::Result<()> {
     let (mut a_rd, mut a_wr) = a.into_split();
@@ -369,13 +370,31 @@ async fn bridge_copy_bidirectional(
         && let Some(sink) = cap.lock().await.take()
     {
         match sink.seal() {
-            Ok(manifest) => mvm_core::audit_emit!(
-                TranscriptSealed,
-                vm: &vm_name,
-                "tenant={tenant} vm={vm_name} capture={} chunks={}",
-                manifest.capture_id,
-                manifest.chunks.len()
-            ),
+            Ok(manifest) => {
+                if let Err(error) = event_tx
+                    .send_transcript_sealed(TranscriptSealedEvent {
+                        capture_id: manifest.capture_id.clone(),
+                        vm_name: vm_name.clone(),
+                        sealed_root_hex: manifest.sealed_root_hex.clone(),
+                        chunk_count: manifest.chunks.len(),
+                    })
+                    .await
+                {
+                    tracing::warn!(
+                        capture_id = %manifest.capture_id,
+                        %error,
+                        "transcript seal could not reach the audit signer"
+                    );
+                }
+                mvm_core::audit_emit!(
+                    TranscriptSealed,
+                    vm: &vm_name,
+                    "tenant={tenant} vm={vm_name} capture={} chunks={} root={}",
+                    manifest.capture_id,
+                    manifest.chunks.len(),
+                    manifest.sealed_root_hex
+                );
+            }
             Err(e) => {
                 tracing::warn!(vm = %vm_name, error = %e, "transcript capture seal failed")
             }
@@ -415,6 +434,7 @@ async fn bridge_copy_bidirectional(
 
 #[cfg(test)]
 mod tests {
+    use super::super::events::{GatewayAuditEvent, audit_event_channel};
     use super::super::test_support::*;
     use super::*;
 
@@ -450,7 +470,7 @@ mod tests {
         let mut passt = tokio::net::UnixStream::from_std(gateway_b).unwrap();
         let mut libkrun = tokio::net::UnixStream::from_std(guest_b).unwrap();
 
-        let (tx, mut rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, mut rx) = audit_event_channel(64);
         let policy = unrestricted_flow_policy();
         let bridge_task = tokio::spawn(bridge_copy_bidirectional(
             supervisor_gateway,
@@ -470,7 +490,9 @@ mod tests {
         let ev1 = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
             .await
             .expect("open in time")
-            .expect("event");
+            .expect("event")
+            .into_flow()
+            .expect("bridge emits a flow event");
         assert!(matches!(ev1.kind, FlowEventKind::Opened));
         assert_eq!(ev1.direction, FlowDirection::Ingress);
 
@@ -482,7 +504,9 @@ mod tests {
         let ev2 = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
             .await
             .expect("second open in time")
-            .expect("event");
+            .expect("event")
+            .into_flow()
+            .expect("bridge emits a flow event");
         assert!(matches!(ev2.kind, FlowEventKind::Opened));
         assert_ne!(ev1.direction, ev2.direction);
 
@@ -491,11 +515,15 @@ mod tests {
         let c1 = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
             .await
             .expect("close")
-            .expect("event");
+            .expect("event")
+            .into_flow()
+            .expect("bridge emits a flow event");
         let c2 = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
             .await
             .expect("second close")
-            .expect("event");
+            .expect("event")
+            .into_flow()
+            .expect("bridge emits a flow event");
         assert!(matches!(c1.kind, FlowEventKind::Closed { .. }));
         assert!(matches!(c2.kind, FlowEventKind::Closed { .. }));
         bridge_task
@@ -554,7 +582,7 @@ mod tests {
         let mut passt = tokio::net::UnixStream::from_std(gateway_b).unwrap();
         let mut libkrun = tokio::net::UnixStream::from_std(guest_b).unwrap();
 
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, mut rx) = audit_event_channel(64);
         let bridge_task = tokio::spawn(bridge_copy_bidirectional(
             supervisor_gateway,
             supervisor_guest,
@@ -593,6 +621,16 @@ mod tests {
             mvm_core::transcript::unwrap_data_key(&kek, &manifest.wrapped_data_key_b64).unwrap();
         let out = mvm_core::transcript::export(&manifest, &cap_dir, &data_key).unwrap();
         assert_eq!(out, frame, "export round-trips the captured frame bytes");
+
+        let sealed = std::iter::from_fn(|| rx.try_recv().ok()).find_map(|event| match event {
+            GatewayAuditEvent::TranscriptSealed(sealed) => Some(sealed),
+            GatewayAuditEvent::Flow(_) => None,
+        });
+        let sealed = sealed.expect("bridge queues the transcript seal for chain signing");
+        assert_eq!(sealed.capture_id, manifest.capture_id);
+        assert_eq!(sealed.vm_name, manifest.binding.vm_name);
+        assert_eq!(sealed.sealed_root_hex, manifest.sealed_root_hex);
+        assert_eq!(sealed.chunk_count, manifest.chunks.len());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -609,7 +647,7 @@ mod tests {
         let mut passt = tokio::net::UnixStream::from_std(gateway_b).unwrap();
         let mut libkrun = tokio::net::UnixStream::from_std(guest_b).unwrap();
 
-        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let (tx, _rx) = audit_event_channel(64);
         let policy = unrestricted_flow_policy();
         let bridge_task = tokio::spawn(bridge_copy_bidirectional(
             supervisor_gateway,

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge/run.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge/run.rs
@@ -8,14 +8,13 @@ use std::sync::Arc;
 use std::thread::JoinHandle;
 
 use mvm_core::policy::EmergencyDeny;
-use tokio::sync::mpsc;
 
 use crate::supervisor::gateway_audit::GatewayAuditSink;
 use crate::supervisor::network::latency::ObserverLatency;
 use crate::supervisor::network::stages::{RedactingSubstitution, build_egress_scan};
 
 use super::config::{BridgeConfig, BridgeEndpoints};
-use super::events::{BRIDGE_MTU, EVENT_CHANNEL_CAPACITY, ObserverWiring};
+use super::events::{BRIDGE_MTU, EVENT_CHANNEL_CAPACITY, ObserverWiring, audit_event_channel};
 use super::flow_policy::{
     FlowPolicy, PlanFlowPolicy, bare_network_policy_egress, resolve_bare_dns_pins,
 };
@@ -117,7 +116,7 @@ fn run_native_audit_inner(cfg: BridgeConfig) {
         };
         let broadcast_tx = sink.sender();
 
-        let (event_tx, event_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
+        let (event_tx, event_rx) = audit_event_channel(EVENT_CHANNEL_CAPACITY);
         let signer_handle = tokio::task::spawn_local(signer_task(
             event_rx,
             cfg.plan.clone(),
@@ -187,7 +186,7 @@ fn run_bridge_inner(endpoints: BridgeEndpoints, cfg: BridgeConfig) {
         };
         let broadcast_tx = sink.sender();
 
-        let (event_tx, event_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
+        let (event_tx, event_rx) = audit_event_channel(EVENT_CHANNEL_CAPACITY);
 
         // Signer task — sole writer of sign_and_emit per VM. Observers
         // fan out BEFORE chain signing inside the task body; the
@@ -314,10 +313,9 @@ fn run_bridge_inner(endpoints: BridgeEndpoints, cfg: BridgeConfig) {
             }
         }
 
-        // Bridge ended (guest shut down, listener died, etc.).
-        // Drop the signer/sink handles — they'll exit naturally
-        // when the runtime tears down.
-        signer_handle.abort();
+        // The bridge owns the last sender. Once it returns, drain every queued
+        // flow close and transcript seal before ending the signer task.
+        let _ = signer_handle.await;
         sink_handle.abort();
     }));
 }

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge/signer.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge/signer.rs
@@ -1,6 +1,7 @@
 //! Signer task — the sole per-VM caller of `AuditSigner::sign_and_emit`.
-//! Drains the bridge's event mpsc, fans each event out to host-allowlisted
-//! observers, then chain-signs it.
+//! Drains the bridge's ordered event queue. Flow events fan out to
+//! host-allowlisted observers before chain signing; transcript seals go
+//! directly to the same chain signer without entering the flow interface.
 
 use std::sync::Arc;
 
@@ -10,21 +11,21 @@ use tokio::sync::{broadcast, mpsc};
 
 use crate::supervisor::audit::{AuditEntry, AuditSigner};
 
-use super::events::{FlowEvent, FlowEventKind, FlowEventWire};
+#[cfg(test)]
+use super::events::audit_event_channel;
+use super::events::{FlowEventKind, FlowEventWire, GatewayAuditEvent};
 
-/// Drains the per-VM event channel, fans each `FlowEvent` out to the
-/// host-allowlisted observers, then converts it
-/// to a chained `AuditEntry` and signs it. Sole caller of
-/// `signer.sign_and_emit` per VM.
+/// Drains the per-VM event channel, converts each item to a chained
+/// `AuditEntry`, and signs it. Flow events first fan out to host-allowlisted
+/// observers; transcript seals share ordering but remain outside that
+/// flow-specific interface. Sole caller of `signer.sign_and_emit` per VM.
 ///
-/// **Ordering invariant:** observer fan-out runs **before** chain
-/// signing, so observers see every event the chain will record. Chain
-/// signing is structural — it always runs after the fan-out loop and
-/// cannot be displaced by tenant policy. A panicking observer is
-/// caught via `catch_unwind` and logged via `tracing::warn`; sibling
-/// observers and the chain-signing call continue.
+/// **Ordering invariant:** flow-observer fan-out runs **before** that flow's
+/// chain signing. Chain signing is structural and cannot be displaced by
+/// tenant policy. A panicking observer is caught via `catch_unwind` and logged
+/// via `tracing::warn`; sibling observers and the chain-signing call continue.
 pub(crate) async fn signer_task(
-    mut rx: mpsc::Receiver<FlowEvent>,
+    mut rx: mpsc::Receiver<GatewayAuditEvent>,
     plan: Arc<ExecutionPlan>,
     bundle: Option<Arc<PolicyBundle>>,
     signer: Arc<dyn AuditSigner>,
@@ -32,6 +33,27 @@ pub(crate) async fn signer_task(
     observers: Vec<Arc<dyn crate::supervisor::network::Observer>>,
 ) {
     while let Some(event) = rx.recv().await {
+        let event = match event {
+            GatewayAuditEvent::Flow(event) => event,
+            GatewayAuditEvent::TranscriptSealed(sealed) => {
+                let entry = AuditEntry::transcript_sealed(
+                    plan.as_ref(),
+                    bundle.as_deref(),
+                    &sealed.capture_id,
+                    &sealed.vm_name,
+                    &sealed.sealed_root_hex,
+                    sealed.chunk_count,
+                );
+                if let Err(e) = signer.sign_and_emit(&entry).await {
+                    tracing::warn!(
+                        error = ?e,
+                        capture_id = sealed.capture_id,
+                        "transcript seal signer emit failed"
+                    );
+                }
+                continue;
+            }
+        };
         // Publish on the live-tail broadcast first (informational,
         // never blocks the signer; failure here is "no subscribers"
         // which is fine).
@@ -104,6 +126,7 @@ pub(crate) async fn signer_task(
 mod tests {
     use super::*;
     use crate::supervisor::audit::{FlowCloseReason, FlowDirection};
+    use crate::supervisor::gateway_bridge::events::{FlowEvent, TranscriptSealedEvent};
 
     /// Proves the structural ordering invariant: observers run BEFORE
     /// chain signing under `catch_unwind`. A
@@ -155,7 +178,7 @@ mod tests {
         let local = LocalSet::new();
         local
             .run_until(async {
-                let (tx, rx) = mpsc::channel::<FlowEvent>(8);
+                let (tx, rx) = audit_event_channel(8);
                 let (broadcast_tx, _broadcast_rx) = broadcast::channel::<String>(8);
 
                 let count_before = Arc::new(CountObs(AtomicU32::new(0)));
@@ -200,6 +223,14 @@ mod tests {
                 })
                 .await
                 .unwrap();
+                tx.send_transcript_sealed(TranscriptSealedEvent {
+                    capture_id: "capture-1".to_string(),
+                    vm_name: "vm-1".to_string(),
+                    sealed_root_hex: "ef".repeat(32),
+                    chunk_count: 2,
+                })
+                .await
+                .unwrap();
                 drop(tx);
                 task.await.unwrap();
 
@@ -223,13 +254,24 @@ mod tests {
                     "after-panic observer must see both events \
                      (proves panic isolation across siblings)"
                 );
-                // CapturingAuditSigner also recorded both entries —
-                // chain integrity preserved across observer panics.
+                // CapturingAuditSigner recorded both flow entries plus the
+                // ordered transcript seal; transcript metadata is not fanned
+                // out through the flow-observer interface.
                 let entries = signer.entries();
                 assert_eq!(
                     entries.len(),
-                    2,
+                    3,
                     "chain signing fires AFTER fan-out regardless of observer panics"
+                );
+                assert_eq!(
+                    entries[2].event,
+                    crate::supervisor::audit::TRANSCRIPT_SEALED_EVENT
+                );
+                assert_eq!(
+                    entries[2]
+                        .labels
+                        .get(crate::supervisor::audit::LABEL_TRANSCRIPT_ROOT),
+                    Some(&"ef".repeat(32))
                 );
             })
             .await;

--- a/crates/mvm-hostd/src/supervisor/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/mod.rs
@@ -125,7 +125,9 @@ pub use artifact::{
 };
 pub use audit::{AuditEntry, AuditError, AuditSigner, CapturingAuditSigner, NoopAuditSigner};
 pub use audit_dedup::{Decision, DedupKey, RetryStormSummary, RetryStormSuppressor};
-pub use audit_file::{FileAuditSigner, SignedEnvelope, VerifyError, verify_audit_chain};
+pub use audit_file::{
+    FileAuditSigner, SignedEnvelope, VerifyError, verify_audit_chain, verify_audit_chain_entries,
+};
 pub use audit_recorder::{
     EventCategory, Recorder, RecorderError, UNBOUND_IMAGE_NAME, UNBOUND_IMAGE_SHA256,
     UNBOUND_PLAN_ID,

--- a/crates/mvm-hostd/src/supervisor/transcript_sink.rs
+++ b/crates/mvm-hostd/src/supervisor/transcript_sink.rs
@@ -58,6 +58,7 @@ impl TranscriptCaptureSink {
             if manifest.binding.vm_name != vm || !manifest.chunks.is_empty() {
                 continue; // wrong VM, or already captured (not armed)
             }
+            transcript::verify_sealed_root(&manifest)?;
             // Armed match — unwrap the per-capture data key under the host KEK.
             let kek = transcript::load_or_init_kek(keys_dir).map_err(|e| io_err("kek", &e))?;
             let data_key = transcript::unwrap_data_key(&kek, &manifest.wrapped_data_key_b64)?;
@@ -108,7 +109,7 @@ impl TranscriptCaptureSink {
         let manifest = self.writer.seal();
         let json =
             serde_json::to_vec_pretty(&manifest).map_err(|e| io_err("serialize manifest", &e))?;
-        std::fs::write(self.dir.join(MANIFEST_FILE), &json)
+        mvm_core::atomic_io::atomic_write(&self.dir.join(MANIFEST_FILE), &json)
             .map_err(|e| io_err(MANIFEST_FILE, &e))?;
         Ok(manifest)
     }
@@ -235,5 +236,24 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
+    }
+
+    #[test]
+    fn open_for_vm_refuses_a_tampered_armed_manifest() {
+        let t = tempfile::tempdir().unwrap();
+        let transcripts = t.path().join("transcripts");
+        let keys = t.path().join("keys");
+        arm(&transcripts, &keys, "t1", "vm1", "cap-1");
+
+        let path = transcripts.join("t1/cap-1").join(MANIFEST_FILE);
+        let mut manifest: TranscriptManifest =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        manifest.bounds.max_bytes += 1;
+        std::fs::write(&path, serde_json::to_vec_pretty(&manifest).unwrap()).unwrap();
+
+        let err = TranscriptCaptureSink::open_for_vm(&transcripts, &keys, "t1", "vm1")
+            .err()
+            .expect("tampered armed manifest is refused");
+        assert_eq!(err, TranscriptError::SealedRootMismatch);
     }
 }

--- a/features/suites/s6_admission_audit/transcript_root_audit.feature
+++ b/features/suites/s6_admission_audit/transcript_root_audit.feature
@@ -1,0 +1,20 @@
+Feature: Transcript evidence is authenticated before decryption
+
+  A sealed transcript carries a content address over its capture binding and
+  ordered ciphertext chunk records. Export succeeds only when that exact root
+  is present in the verified host audit chain.
+
+  Scenario: a host-anchored sealed transcript exports successfully
+    Given an isolated mvm home
+    And a sealed transcript anchored to the host audit chain
+    When I run mvmctl in the isolated mvm home with "trust audit transcript export bdd-transcript --tenant local"
+    Then the command exits with code 0
+    And the output contains "authenticated transcript evidence"
+
+  Scenario: a manifest binding change is refused before export
+    Given an isolated mvm home
+    And a sealed transcript anchored to the host audit chain
+    And the sealed transcript binding is tampered
+    When I run mvmctl in the isolated mvm home with "trust audit transcript export bdd-transcript --tenant local"
+    Then the command exits with code 1
+    And the error output contains "verifying transcript manifest root"

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -58,6 +58,15 @@ for detailed scope and acceptance criteria.
         the unified footprint ledger against the literal 50,000,000-byte contract
         with the optional SDK sidecar reported separately
 
+- [x] Plan 280 — transcript root audit binding
+  (`specs/plans/280-transcript-root-audit-binding.md`)
+  - [x] Version-2 manifest root over fixed metadata and ordered ciphertext
+        chunk records, with deterministic and mutation coverage
+  - [x] Ordered `gateway.transcript_sealed` emission after atomic manifest
+        persistence, chain-signed through the existing per-VM signer
+  - [x] Exact tenant audit-chain anchor required before transcript key unwrap
+        and decryption, with hermetic operator-path BDD coverage
+
 - [~] Plan 255 — vsock-first snapshot, egress, and warm-start adoption
   (`specs/plans/255-vsock-first-snapshot-egress-adoption.md`)
   - [x] Snapshot storage and lineage-protected clone primitives

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -38,6 +38,19 @@
       missing is a typed action identity and a tree manifest that can see a
       permission bit.
 
+- [x] Transcript evidence is now authenticated as one ordered ciphertext
+      evidence set before decryption. Version-2 manifests carry an RFC-6962
+      Merkle root over capture bindings, bounds, wrapped-key metadata, and
+      ordered ciphertext chunk records; the gateway persists the sealed
+      manifest atomically before emitting a chain-signed
+      `gateway.transcript_sealed` entry. Export requires exactly one matching
+      tenant audit-chain anchor before KEK unwrap and fails closed for legacy
+      version-1 manifests or any root, binding, chunk, or chain drift. The real
+      `mvmctl trust audit transcript export` path is covered by success and
+      tamper-refusal scenarios; 8,403 workspace tests, doctests, clippy/model
+      gates, and all 76 BDD scenarios pass. Tracked in
+      `specs/plans/280-transcript-root-audit-binding.md`.
+
 - [x] BDD / conformance integration: introduced `model/*.toml` as the single
       source for conformance claims, generated `CONFORMANCE.md`, and added
       `xtask` gates for R1 (`check-conformance`), R2 (`check-honesty`), and R4

--- a/specs/plans/280-transcript-root-audit-binding.md
+++ b/specs/plans/280-transcript-root-audit-binding.md
@@ -1,0 +1,43 @@
+# Plan 280 — Transcript root audit binding
+
+**Status:** Complete.
+
+## Goal
+
+Make an encrypted forensic transcript authenticatable as one ordered evidence
+set before any payload is decrypted. The sealed manifest gets a deterministic
+content address over its capture binding, bounds, wrapped-key metadata, and
+ordered ciphertext chunk records. The host chain-signs that address, and
+`mvmctl trust audit transcript export` requires an exact anchor in a valid tenant
+audit chain.
+
+Plaintext and plaintext digests never enter the manifest root or audit chain.
+Existing version-1 manifests have no trustworthy aggregate root and therefore
+fail closed on export rather than being silently treated as authenticated.
+
+## Work
+
+- [x] Add manifest format version 2 with an RFC-6962 Merkle root over fixed,
+      domain-separated metadata and ordered chunk-record leaves; verify the
+      root before chunk reads or decryption, with a pinned deterministic vector
+      and mutation/error coverage.
+- [x] Queue `gateway.transcript_sealed` on the bridge's ordered audit channel
+      after the sealed manifest reaches disk, carrying capture id, VM name,
+      ciphertext-manifest root, and chunk count; chain-sign it through the
+      existing per-VM signer.
+- [x] Expose authenticated audit entries from the existing chain verifier and
+      require exactly one tenant/capture anchor whose VM, root, and chunk count
+      match the manifest before transcript export unwraps its data key.
+- [x] Cover the operator path with hermetic BDD scenarios for successful
+      anchored export and fail-closed manifest tampering; pass formatting,
+      workspace tests, documentation tests, check, and clippy.
+
+## Security acceptance
+
+- The aggregate root commits to ciphertext digests, ordering, capture identity,
+  tenant/VM/session binding, bounds, recipient, and wrapped data key.
+- Changing a binding, reordering chunks, changing a chunk record, removing the
+  root, corrupting the chain, omitting the anchor, or signing a different root
+  refuses export.
+- Transcript payload bytes and plaintext digests remain absent from the signed
+  audit entry.


### PR DESCRIPTION
## Summary

- add version-2 transcript manifests with a deterministic RFC-6962 Merkle root over capture bindings, bounds, wrapped-key metadata, and ordered ciphertext chunk records
- persist the sealed manifest atomically before emitting a signed `gateway.transcript_sealed` audit entry
- require exactly one matching entry in the verified tenant audit chain before transcript key unwrap or decryption
- fail closed for version-1 manifests and for root, binding, chunk, anchor, or chain drift
- cover the real `mvmctl trust audit transcript export` path with hermetic success and tamper-refusal scenarios

Plaintext and plaintext digests remain outside both the manifest root and the audit entry.

This is the transcript-root implementation follow-up to the decision record in #1998.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- model/conformance/honesty/deferral gates
- 8,403 workspace tests
- workspace doctests
- BDD: 24 features, 76 scenarios, 373 steps