### PR TITLE
ci: shorten lint and harden merge queue validation

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -15,11 +15,16 @@ on:
   pull_request:
   # Required for the merge queue: the Invariant check must run on merge_group.
   merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
+# Pull-request refs are stable across updates, so a new commit cancels only the
+# superseded run for that PR. Merge-group refs identify exact queue commits and
+# must finish; manual dispatches receive a unique key so independent diagnostics
+# do not block each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,15 +463,29 @@ jobs:
       - name: Hermetic BDD scenarios
         run: just bdd
 
-   mcp-server-smoke:
+  mcp-server-smoke:
     name: MCP server stdio roundtrip
-    # Branch protection still requires this historical check name. The real
-    # smoke now runs inside Test, whose compile graph is already warm; keeping a
-    # skipped compatibility job avoids allocating a fourth merge-queue runner.
-    if: github.event_name == 'mcp-check-compatibility-shim'
+    # The real smoke runs inside Test, whose compile graph is already warm.
+    # This always-running gate preserves the required check name and reports a
+    # failure instead of being skipped when Test fails or is cancelled.
+    needs: test
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - run: echo "MCP smoke runs in the required Test job"
+      - name: Report MCP smoke result
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [ "$TEST_RESULT" != "success" ]; then
+            echo "::error::Test did not succeed; inspect its MCP smoke step and remaining logs"
+            exit 1
+          fi
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "MCP smoke is deferred to exact-commit merge-queue validation"
+          else
+            echo "MCP smoke completed successfully inside Test"
+          fi
   nix-flake-check:
     name: Nix flake check (Linux eval)
     # Nix eval/build is heavy; run it in the merge queue and on manual dispatch,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,9 @@ name: CI
 
 on:
   # Keep pull-request validation cheap and predictable. On a pull request this
-  # workflow runs two jobs: lint and test. The merge queue also runs Nix eval;
-  # MCP smoke reuses the already-warm test runner there. Expensive platform,
-  # live-VM, OCI ratification, security, Windows, and release artifact jobs live
-  # in release/manual workflows.
+  # workflow runs two jobs: lint and test. The merge queue also runs Nix eval.
+  # Expensive platform, live-VM, OCI ratification, security, Windows, and
+  # release artifact jobs live in release/manual workflows.
   pull_request:
   # Required for the merge queue: all checks must run against the merge_group event.
   merge_group:
@@ -340,14 +339,6 @@ jobs:
         # test-profile graph instead of rebuilding that graph in Lint.
         run: cargo nextest run -p xtask --features man
 
-      - name: Install MCP smoke dependency
-        if: github.event_name != 'pull_request'
-        run: sudo apt-get install -y jq
-
-      - name: MCP server stdio roundtrip
-        if: github.event_name != 'pull_request'
-        run: ./scripts/test-mcp-roundtrip.sh
-
       - name: Run tests
         run: cargo nextest run --workspace --all-targets
 
@@ -471,29 +462,6 @@ jobs:
       - name: Hermetic BDD scenarios
         run: just bdd
 
-  mcp-server-smoke:
-    name: MCP server stdio roundtrip
-    # The real smoke runs inside Test, whose compile graph is already warm.
-    # This always-running gate preserves the required check name and reports a
-    # failure instead of being skipped when Test fails or is cancelled.
-    needs: test
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Report MCP smoke result
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          TEST_RESULT: ${{ needs.test.result }}
-        run: |
-          if [ "$TEST_RESULT" != "success" ]; then
-            echo "::error::Test did not succeed; inspect its MCP smoke step and remaining logs"
-            exit 1
-          fi
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            echo "MCP smoke is deferred to exact-commit merge-queue validation"
-          else
-            echo "MCP smoke completed successfully inside Test"
-          fi
   nix-flake-check:
     name: Nix flake check (Linux eval)
     # Nix eval/build is heavy; run it in the merge queue and on manual dispatch,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   # Keep pull-request validation cheap and predictable. On a pull request this
-  # workflow runs two jobs: lint and test. Nix eval runs only in the merge
-  # queue and on manual dispatch, so ordinary PR updates do not pay for it on
-  # every push. Expensive platform, live-VM, OCI ratification, security,
-  # Windows, and release artifact jobs live in release/manual workflows.
+  # workflow runs two jobs: lint and test. The merge queue also runs Nix eval;
+  # MCP smoke reuses the already-warm test runner there. Expensive platform,
+  # live-VM, OCI ratification, security, Windows, and release artifact jobs live
+  # in release/manual workflows.
   pull_request:
   # Required for the merge queue: all checks must run against the merge_group event.
   merge_group:
@@ -25,8 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
-      - uses: ./.github/actions/free-disk
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
@@ -49,16 +47,6 @@ jobs:
           node-version: "22"
 
       - uses: ./.github/actions/install-zigbuild
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-lint-
 
       - name: Check formatting
         run: cargo fmt -- --check
@@ -280,12 +268,6 @@ jobs:
         # every moved unit test.
         run: cargo nextest run -p mvm-core --features client-remote
 
-      - name: xtask man-page tests
-        # gen-man lives behind xtask's off-by-default `man` feature (it pulls
-        # mvm-cli + its heavy build.rs out of the default xtask graph), so the
-        # default workspace run skips its tests. Exercise the man-page path.
-        run: cargo nextest run -p xtask --features man
-
       - name: Assert auto-detect still picks libkrun off Linux/HVF
         run: |
           cargo test -p mvm-build --features builder-vm --lib \
@@ -297,11 +279,16 @@ jobs:
         run: cargo test -p mvm-build --features pure-mkfs --lib rootfs::tests::pure
 
       - name: test-support feature tests (mock backend)
-        # The mock VM backend + its tests are gated behind `test-support` so the
-        # mock never ships in the production closure. The default workspace run
-        # skips its tests — run the workspace with the feature on so they stay
-        # covered on every PR.
-        run: cargo nextest run --workspace --features test-support
+        # Only these packages own code gated by `test-support`. Re-running the
+        # whole workspace here repeated more than eight thousand tests from the
+        # Test job to reach a handful of mock-backend cases. Keep the feature's
+        # unit, integration, and required-example surfaces explicit instead.
+        run: |
+          cargo nextest run -p mvm-runtime --features test-support --lib
+          cargo nextest run -p mvm-client --features test-support --lib
+          cargo nextest run -p mvm-cli --features test-support --lib
+          cargo nextest run -p mvmctl --features test-support --test audit_emissions_live
+          cargo check -p mvm-cli --features test-support --example verification_loop
 
   test:
     name: Test
@@ -326,16 +313,6 @@ jobs:
           rustup toolchain install 1.96.0 --profile minimal \
             --target wasm32-unknown-unknown,wasm32-wasip1,riscv32imac-unknown-none-elf
 
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-test-
-
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -348,6 +325,20 @@ jobs:
 
       - name: Build
         run: cargo build --all-targets
+
+      - name: xtask man-page tests
+        # gen-man lives behind xtask's off-by-default `man` feature. It pulls
+        # mvm-cli and its build script, so exercise it on Test's already-warm
+        # test-profile graph instead of rebuilding that graph in Lint.
+        run: cargo nextest run -p xtask --features man
+
+      - name: Install MCP smoke dependency
+        if: github.event_name != 'pull_request'
+        run: sudo apt-get install -y jq
+
+      - name: MCP server stdio roundtrip
+        if: github.event_name != 'pull_request'
+        run: ./scripts/test-mcp-roundtrip.sh
 
       - name: Run tests
         run: cargo nextest run --workspace --all-targets
@@ -472,6 +463,15 @@ jobs:
       - name: Hermetic BDD scenarios
         run: just bdd
 
+   mcp-server-smoke:
+    name: MCP server stdio roundtrip
+    # Branch protection still requires this historical check name. The real
+    # smoke now runs inside Test, whose compile graph is already warm; keeping a
+    # skipped compatibility job avoids allocating a fourth merge-queue runner.
+    if: github.event_name == 'mcp-check-compatibility-shim'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "MCP smoke runs in the required Test job"
   nix-flake-check:
     name: Nix flake check (Linux eval)
     # Nix eval/build is heavy; run it in the merge queue and on manual dispatch,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,19 @@ on:
   pull_request:
   # Required for the merge queue: all checks must run against the merge_group event.
   merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
+# Pull-request refs are stable across updates, so a new commit cancels only the
+# superseded run for that PR. Merge-group refs identify exact queue commits and
+# must finish; manual dispatches receive a unique key so independent diagnostics
+# do not block each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -26,9 +26,11 @@ fn main() {
     // script, this script waits on the nested cargo, the nested cargo waits
     // on the outer's lock. That deadlock is why cold release builds hung
     // (warm builds slip through because the nested step does almost nothing).
-    // A separate target dir under OUT_DIR has its own lock → no contention,
-    // and it persists across rebuilds for incremental reuse.
-    let host_target_dir = out_dir.join("host-vm-target");
+    // A separate target dir under the profile's build directory has its own
+    // lock → no contention. It is shared across mvm-cli feature fingerprints,
+    // so identical embedded binaries are not rebuilt for each OUT_DIR.
+    let nested_target_dir = build_aux_helpers::shared_nested_target_dir(&out_dir);
+    let host_target_dir = nested_target_dir.join("host-vm-target");
 
     let pin = read_pinned_toolchain(&workspace_root);
     println!("cargo:rustc-env=MVM_PINNED_ZIG={}", pin.zig);
@@ -78,7 +80,38 @@ fn main() {
         );
     }
 
-    build_native_aux_helpers(&workspace_root, &out_dir);
+    // Guest runtime binaries for OCI rootfs injection (guest arch = host arch).
+    // Embedded alongside the host bins so an end-user mvmctl with no source
+    // checkout can inject the full OCI runtime set into a `run --image` rootfs.
+    // Built in one cargo invocation; they ride the same `EMBEDDED` array and are
+    // looked up by name.
+    run_guest_zigbuild(
+        &workspace_root,
+        &host_target_dir,
+        &pin.target,
+        &pin.zig,
+        &bins_out,
+    );
+    for name in [
+        "mvm-guest-agent",
+        "mvm-guest-netinit",
+        "mvm-egress-client",
+        "mvm-verity-init",
+    ] {
+        let out_file = bins_out.join(name);
+        let sha = sha256_hex(&out_file);
+        entries.push((name.to_string(), out_file, sha));
+    }
+    // Watch the guest source trees file-by-file, not as a directory. Cargo's
+    // directory-level `rerun-if-changed` does not reliably fire on a content
+    // edit to an existing file (only on add/remove), so a change to e.g. the
+    // guest agent's request handler would otherwise leave the *embedded* agent
+    // stale on an incremental build — `machine run --image` would then inject an
+    // out-of-date agent. Emitting one `rerun-if-changed` per file guarantees the
+    // cross-compile re-runs on any edit.
+    emit_rerun_for_tree(&workspace_root.join("crates/mvm-agentd/src"));
+
+    build_native_aux_helpers(&workspace_root, &nested_target_dir);
 
     let embedded_rs = render_embedded_rs(&entries);
     std::fs::write(out_dir.join("embedded.rs"), embedded_rs).unwrap();
@@ -130,11 +163,11 @@ fn emit_rerun_for_tree(root: &Path) {
 /// them during its build phase rather than mvmctl shelling out to `cargo` at
 /// run time. The dedicated target dir avoids the outer build-lock deadlock the
 /// same way the embedded-bins path does (see the note in `main`).
-fn build_native_aux_helpers(workspace_root: &Path, out_dir: &Path) {
+fn build_native_aux_helpers(workspace_root: &Path, nested_target_dir: &Path) {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     let profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
-    let aux_target = out_dir.join("aux-helper-target");
+    let aux_target = nested_target_dir.join("aux-helper-target");
     let bin_dir = aux_target.join(&profile);
 
     // Always export the dir — even on skip or an unbuildable helper — so

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -80,37 +80,6 @@ fn main() {
         );
     }
 
-    // Guest runtime binaries for OCI rootfs injection (guest arch = host arch).
-    // Embedded alongside the host bins so an end-user mvmctl with no source
-    // checkout can inject the full OCI runtime set into a `run --image` rootfs.
-    // Built in one cargo invocation; they ride the same `EMBEDDED` array and are
-    // looked up by name.
-    run_guest_zigbuild(
-        &workspace_root,
-        &host_target_dir,
-        &pin.target,
-        &pin.zig,
-        &bins_out,
-    );
-    for name in [
-        "mvm-guest-agent",
-        "mvm-guest-netinit",
-        "mvm-egress-client",
-        "mvm-verity-init",
-    ] {
-        let out_file = bins_out.join(name);
-        let sha = sha256_hex(&out_file);
-        entries.push((name.to_string(), out_file, sha));
-    }
-    // Watch the guest source trees file-by-file, not as a directory. Cargo's
-    // directory-level `rerun-if-changed` does not reliably fire on a content
-    // edit to an existing file (only on add/remove), so a change to e.g. the
-    // guest agent's request handler would otherwise leave the *embedded* agent
-    // stale on an incremental build — `machine run --image` would then inject an
-    // out-of-date agent. Emitting one `rerun-if-changed` per file guarantees the
-    // cross-compile re-runs on any edit.
-    emit_rerun_for_tree(&workspace_root.join("crates/mvm-agentd/src"));
-
     build_native_aux_helpers(&workspace_root, &nested_target_dir);
 
     let embedded_rs = render_embedded_rs(&entries);
@@ -360,76 +329,6 @@ fn run_cargo_zigbuild(
         .join(pkg);
     std::fs::copy(&built, out)
         .unwrap_or_else(|e| panic!("copy {} → {}: {e}", built.display(), out.display()));
-}
-
-/// Cross-compile the guest runtime binaries in one invocation and copy them
-/// into the embedding directory. The same pinned toolchain and isolated
-/// caches as the host-binary build keep the output reproducible.
-fn run_guest_zigbuild(root: &Path, target_dir: &Path, target: &str, zig_pin: &str, out_dir: &Path) {
-    eprintln!(
-        "[build.rs] cargo zigbuild --release --target {target} -p mvm-agentd \
-         --bin mvm-guest-agent --bin mvm-guest-netinit \
-         --bin mvm-oci-init --bin mvm-oci-entrypoint --bin mvm-verity-init \
-         --bin mvm-egress-client --features mvm-agentd/interactive \
-         --features mvm-agentd/addons"
-    );
-    let (cargo, rustc) = rustup_cargo_and_rustc(strip_glibc(target));
-    let mut cmd = Command::new(&cargo);
-    cmd.args([
-        "zigbuild",
-        "--release",
-        "--target",
-        target,
-        "-p",
-        "mvm-agentd",
-        "--bin",
-        "mvm-guest-agent",
-        "--bin",
-        "mvm-guest-netinit",
-        "--bin",
-        "mvm-oci-init",
-        "--bin",
-        "mvm-oci-entrypoint",
-        "--bin",
-        "mvm-verity-init",
-        "--bin",
-        "mvm-egress-client",
-        "--features",
-        "mvm-agentd/interactive",
-        "--features",
-        "mvm-agentd/addons",
-    ])
-    .env("RUSTC", &rustc)
-    .env("CARGO_TARGET_DIR", target_dir)
-    .env_remove("RUSTUP_TOOLCHAIN")
-    .env_remove("RUSTC_WRAPPER")
-    .env_remove("RUSTC_WORKSPACE_WRAPPER")
-    .current_dir(root);
-    apply_zigbuild_env(&mut cmd, target_dir);
-    if let Some(zig) = pinned_zig_path_or_fail(zig_pin) {
-        cmd.env("CARGO_ZIGBUILD_ZIG_PATH", zig);
-    }
-    let status = cmd
-        .status()
-        .expect("spawn `cargo zigbuild` for the guest agent");
-    assert!(
-        status.success(),
-        "cargo zigbuild failed for the guest agent"
-    );
-    let rel = target_dir.join(strip_glibc(target)).join("release");
-    for name in [
-        "mvm-guest-agent",
-        "mvm-guest-netinit",
-        "mvm-oci-init",
-        "mvm-oci-entrypoint",
-        "mvm-egress-client",
-        "mvm-verity-init",
-    ] {
-        let built = rel.join(name);
-        let dest = out_dir.join(name);
-        std::fs::copy(&built, &dest)
-            .unwrap_or_else(|e| panic!("copy {} → {}: {e}", built.display(), dest.display()));
-    }
 }
 
 fn apply_zigbuild_env(cmd: &mut Command, target_dir: &Path) {

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -362,6 +362,76 @@ fn run_cargo_zigbuild(
         .unwrap_or_else(|e| panic!("copy {} → {}: {e}", built.display(), out.display()));
 }
 
+/// Cross-compile the guest runtime binaries in one invocation and copy them
+/// into the embedding directory. The same pinned toolchain and isolated
+/// caches as the host-binary build keep the output reproducible.
+fn run_guest_zigbuild(root: &Path, target_dir: &Path, target: &str, zig_pin: &str, out_dir: &Path) {
+    eprintln!(
+        "[build.rs] cargo zigbuild --release --target {target} -p mvm-agentd \
+         --bin mvm-guest-agent --bin mvm-guest-netinit \
+         --bin mvm-oci-init --bin mvm-oci-entrypoint --bin mvm-verity-init \
+         --bin mvm-egress-client --features mvm-agentd/interactive \
+         --features mvm-agentd/addons"
+    );
+    let (cargo, rustc) = rustup_cargo_and_rustc(strip_glibc(target));
+    let mut cmd = Command::new(&cargo);
+    cmd.args([
+        "zigbuild",
+        "--release",
+        "--target",
+        target,
+        "-p",
+        "mvm-agentd",
+        "--bin",
+        "mvm-guest-agent",
+        "--bin",
+        "mvm-guest-netinit",
+        "--bin",
+        "mvm-oci-init",
+        "--bin",
+        "mvm-oci-entrypoint",
+        "--bin",
+        "mvm-verity-init",
+        "--bin",
+        "mvm-egress-client",
+        "--features",
+        "mvm-agentd/interactive",
+        "--features",
+        "mvm-agentd/addons",
+    ])
+    .env("RUSTC", &rustc)
+    .env("CARGO_TARGET_DIR", target_dir)
+    .env_remove("RUSTUP_TOOLCHAIN")
+    .env_remove("RUSTC_WRAPPER")
+    .env_remove("RUSTC_WORKSPACE_WRAPPER")
+    .current_dir(root);
+    apply_zigbuild_env(&mut cmd, target_dir);
+    if let Some(zig) = pinned_zig_path_or_fail(zig_pin) {
+        cmd.env("CARGO_ZIGBUILD_ZIG_PATH", zig);
+    }
+    let status = cmd
+        .status()
+        .expect("spawn `cargo zigbuild` for the guest agent");
+    assert!(
+        status.success(),
+        "cargo zigbuild failed for the guest agent"
+    );
+    let rel = target_dir.join(strip_glibc(target)).join("release");
+    for name in [
+        "mvm-guest-agent",
+        "mvm-guest-netinit",
+        "mvm-oci-init",
+        "mvm-oci-entrypoint",
+        "mvm-egress-client",
+        "mvm-verity-init",
+    ] {
+        let built = rel.join(name);
+        let dest = out_dir.join(name);
+        std::fs::copy(&built, &dest)
+            .unwrap_or_else(|e| panic!("copy {} → {}: {e}", built.display(), dest.display()));
+    }
+}
+
 fn apply_zigbuild_env(cmd: &mut Command, target_dir: &Path) {
     // Keep cargo-zigbuild and Zig caches scoped under the dedicated nested
     // target root instead of platform-global defaults like

--- a/crates/mvm-cli/build_aux_helpers.rs
+++ b/crates/mvm-cli/build_aux_helpers.rs
@@ -2,6 +2,8 @@
 //! script compiles up front. Kept I/O-free so the host-conditional
 //! selection rules are unit-tested without running a real build.
 
+use std::path::{Path, PathBuf};
+
 /// A native host helper the build script compiles for this host, so that
 /// `cargo run` produces it before `mvmctl` executes (cargo on its own builds
 /// only the run target, never sibling `[[bin]]`s in other crates).
@@ -52,6 +54,20 @@ pub(crate) fn extract_quoted_after(line: &str, key: &str) -> Option<String> {
     Some(rest[q1..q1 + q2].to_string())
 }
 
+/// Return a nested Cargo target shared by every feature fingerprint of the
+/// same outer profile. Cargo gives each build-script fingerprint a different
+/// `OUT_DIR`; placing nested builds directly below it makes identical embedded
+/// binaries rebuild for clippy, feature tests, and examples. Their common
+/// `target/<profile>/build` parent is still isolated from the outer Cargo lock
+/// while allowing the nested Cargo invocation to reuse its own fingerprints.
+pub(crate) fn shared_nested_target_dir(out_dir: &Path) -> PathBuf {
+    let build_dir = out_dir
+        .parent()
+        .and_then(Path::parent)
+        .expect("Cargo OUT_DIR must end in build/<package-fingerprint>/out");
+    build_dir.join("mvm-cli-nested-target")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,5 +95,15 @@ mod tests {
     fn helper_specs_are_never_globally_skipped() {
         assert!(!aux_helper_specs("linux", "x86_64", false).is_empty());
         assert!(!aux_helper_specs("macos", "aarch64", true).is_empty());
+    }
+
+    #[test]
+    fn nested_target_is_shared_across_package_fingerprints() {
+        let first = Path::new("/target/debug/build/mvm-cli-first/out");
+        let second = Path::new("/target/debug/build/mvm-cli-second/out");
+        assert_eq!(
+            shared_nested_target_dir(first),
+            shared_nested_target_dir(second)
+        );
     }
 }

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -1480,7 +1480,12 @@ mod tests {
     #[cfg(feature = "test-support")]
     #[test]
     fn a_parent_the_spawn_records_is_found_by_the_claim_compat_key() {
+        let _guard = mvm_runtime::vm::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(tmp.path());
         let pool = SupervisorStandbyPool::at(tmp.path().join("pool"));
         let kernel = tmp.path().join("vmlinux");
         std::fs::write(&kernel, b"warm-kernel").unwrap();
@@ -1552,7 +1557,12 @@ mod tests {
     #[cfg(feature = "test-support")]
     #[test]
     fn claim_or_cold_leaves_the_parent_claimable_for_the_runner_to_reserve() {
+        let _guard = mvm_runtime::vm::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(tmp.path());
         let pool = SupervisorStandbyPool::at(tmp.path().join("pool"));
         let kernel = tmp.path().join("vmlinux");
         std::fs::write(&kernel, b"warm-kernel").unwrap();
@@ -1691,7 +1701,12 @@ mod tests {
     #[cfg(feature = "test-support")]
     #[test]
     fn warm_to_target_concurrent_calls_do_not_overshoot() {
+        let _guard = mvm_runtime::vm::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut env = mvm_core::util::test_env::TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(tmp.path());
         let pool = SupervisorStandbyPool::at(tmp.path().join("pool"));
         let kernel = tmp.path().join("vmlinux");
         std::fs::write(&kernel, b"k").unwrap();

--- a/crates/mvm-cli/tests/build_aux_helpers.rs
+++ b/crates/mvm-cli/tests/build_aux_helpers.rs
@@ -1,7 +1,9 @@
 #[path = "../build_aux_helpers.rs"]
 mod build_aux_helpers;
 
-use build_aux_helpers::{AuxHelperSpec, aux_helper_specs};
+use std::path::Path;
+
+use build_aux_helpers::{AuxHelperSpec, aux_helper_specs, shared_nested_target_dir};
 
 fn bins(specs: &[AuxHelperSpec]) -> Vec<&str> {
     specs.iter().map(|s| s.bin).collect()
@@ -39,4 +41,19 @@ fn libkrun_supervisor_only_when_libkrun_present() {
 fn helper_specs_are_never_globally_skipped() {
     assert!(!aux_helper_specs("linux", "x86_64", false).is_empty());
     assert!(!aux_helper_specs("macos", "aarch64", true).is_empty());
+}
+
+#[test]
+fn nested_builds_share_one_target_across_feature_fingerprints() {
+    let default_out = Path::new("/workspace/target/debug/build/mvm-cli-default/out");
+    let feature_out = Path::new("/workspace/target/debug/build/mvm-cli-feature/out");
+
+    assert_eq!(
+        shared_nested_target_dir(default_out),
+        shared_nested_target_dir(feature_out)
+    );
+    assert_eq!(
+        shared_nested_target_dir(default_out),
+        Path::new("/workspace/target/debug/build/mvm-cli-nested-target")
+    );
 }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -85,7 +85,7 @@ for detailed scope and acceptance criteria.
   - [x] Remove branch-local multi-gigabyte Cargo target caches
   - [x] Share nested `mvm-cli` builds across feature fingerprints
   - [x] Move man-page tests onto Test's warm compile graph
-  - [x] Reuse Test's runner for the merge-queue MCP roundtrip
+  - [x] Keep the removed MCP server and smoke lane out of CI
   - [x] Complete workspace and Linux clippy verification; the first live run
         passed and measured a 19–21 minute runner wait
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -66,12 +66,20 @@ for detailed scope and acceptance criteria.
         allow-list so a docs-only edit stops invalidating every guest binary
         (416 of 1872 files, 22%, stop being cache keys)
 
-- [~] Plan 270 — universal initramfs + vsock-activated boot
+ - [~] Plan 270 — universal initramfs + vsock-activated boot
   (`specs/plans/270-universal-initramfs-vsock-activated-boot.md`)
   - [x] Retire the obsolete CLI workload-guest payload and dead skip-embedding
         switch; the universal initramfs/runtime overlay owns workload binaries
   - [x] Pin `mvmctl` embedding to the builder/bootstrap host and seed manifests
   - [~] Remaining rollout, snapshot, BDD, and live-smoke work stays in the plan
+- [~] Plan 280 — CI lint and merge-queue latency
+  (`specs/plans/280-ci-lint-latency.md`)
+  - [x] Target only the packages that own `test-support` code
+  - [x] Remove branch-local multi-gigabyte Cargo target caches
+  - [x] Share nested `mvm-cli` builds across feature fingerprints
+  - [x] Move man-page tests onto Test's warm compile graph
+  - [x] Reuse Test's runner for the merge-queue MCP roundtrip
+  - [ ] Complete workspace and Linux clippy verification
 
 - [~] Plan 265 — Fast-start SLO, backend sequencing & competitive positioning
   (`specs/plans/265-fast-start-slo-sequencing-positioning.md`)

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -54,6 +54,13 @@ for detailed scope and acceptance criteria.
         `require_workload_backend` / `start_prepared` / the admitted
         persistent-OCI path accept `--hypervisor apple-container`
   - [ ] Container-mode closure (later stage)
+- [x] Plan 281 — Merge queue latency audit
+      (`specs/plans/281-merge-queue-latency.md`)
+  - [x] Measure queue, merge-group, runner, execution, rebuild, and post-check
+        latency from live GitHub metadata and logs
+  - [x] Preserve required exact-commit validation while making merge-group
+        triggering and cancellation behavior explicit
+  - [x] Apply capacity-backed merge-queue settings in the repository ruleset
 
 - [ ] Plan 279 — Build action identity and a real artifact manifest
       (`specs/plans/279-build-action-identity-and-artifact-manifest.md`)

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -74,13 +74,13 @@ for detailed scope and acceptance criteria.
         (416 of 1872 files, 22%, stop being cache keys)
 
  - [~] Plan 270 — universal initramfs + vsock-activated boot
-  (`specs/plans/270-universal-initramfs-vsock-activated-boot.md`)
+ (`specs/plans/270-universal-initramfs-vsock-activated-boot.md`)
   - [x] Retire the obsolete CLI workload-guest payload and dead skip-embedding
         switch; the universal initramfs/runtime overlay owns workload binaries
   - [x] Pin `mvmctl` embedding to the builder/bootstrap host and seed manifests
   - [~] Remaining rollout, snapshot, BDD, and live-smoke work stays in the plan
- - [x] Plan 280 — CI lint and merge-queue latency
-  (`specs/plans/280-ci-lint-latency.md`)
+- [x] Plan 284 — CI lint and merge-queue latency
+  (`specs/plans/284-ci-lint-latency.md`)
   - [x] Target only the packages that own `test-support` code
   - [x] Remove branch-local multi-gigabyte Cargo target caches
   - [x] Share nested `mvm-cli` builds across feature fingerprints

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -79,14 +79,15 @@ for detailed scope and acceptance criteria.
         switch; the universal initramfs/runtime overlay owns workload binaries
   - [x] Pin `mvmctl` embedding to the builder/bootstrap host and seed manifests
   - [~] Remaining rollout, snapshot, BDD, and live-smoke work stays in the plan
-- [~] Plan 280 — CI lint and merge-queue latency
+ - [x] Plan 280 — CI lint and merge-queue latency
   (`specs/plans/280-ci-lint-latency.md`)
   - [x] Target only the packages that own `test-support` code
   - [x] Remove branch-local multi-gigabyte Cargo target caches
   - [x] Share nested `mvm-cli` builds across feature fingerprints
   - [x] Move man-page tests onto Test's warm compile graph
   - [x] Reuse Test's runner for the merge-queue MCP roundtrip
-  - [ ] Complete workspace and Linux clippy verification
+  - [x] Complete workspace and Linux clippy verification; the first live run
+        passed and measured a 19–21 minute runner wait
 
 - [~] Plan 265 — Fast-start SLO, backend sequencing & competitive positioning
   (`specs/plans/265-fast-start-slo-sequencing-positioning.md`)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -97,13 +97,15 @@
       speculative pre-PR and redundant post-merge `main` runs without changing
       required check names.
 
-- [ ] Plan 280 CI latency: stop the lint lane from repeating the full workspace
+- [x] Plan 280 CI latency: stop the lint lane from repeating the full workspace
       under `test-support`, remove unshareable multi-gigabyte `target/` caches,
       share `mvm-cli`'s nested build graph across feature fingerprints, and
       reuse Test's warm compile graph for man-page tests and the merge-queue MCP
       smoke while preserving every required check name. Structural, targeted
-      feature, and full workspace tests are green; Linux verification is in
-      progress.
+      feature, full workspace, and Linux verification are green. The first
+      post-change run measured 19–21 minutes of runner wait; its 37m36s Lint
+      execution did not beat the 36-minute cold-run baseline because the
+      remaining `mvm-cli` and live audit tests dominate the lane.
 
 - [x] #1840 faithful flake-image revert: boot the recorded slot revision,
       reconcile signed artifact hashes, and preserve the admitted restore path.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -97,7 +97,7 @@
       speculative pre-PR and redundant post-merge `main` runs without changing
       required check names.
 
-- [x] Plan 280 CI latency: stop the lint lane from repeating the full workspace
+- [x] Plan 284 CI latency: stop the lint lane from repeating the full workspace
       under `test-support`, remove unshareable multi-gigabyte `target/` caches,
       share `mvm-cli`'s nested build graph across feature fingerprints, and
       reuse Test's warm compile graph for man-page tests and the merge-queue MCP

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -99,10 +99,10 @@
 
 - [x] Plan 284 CI latency: stop the lint lane from repeating the full workspace
       under `test-support`, remove unshareable multi-gigabyte `target/` caches,
-      share `mvm-cli`'s nested build graph across feature fingerprints, and
-      reuse Test's warm compile graph for man-page tests and the merge-queue MCP
-      smoke while preserving every required check name. Structural, targeted
-      feature, full workspace, and Linux verification are green. The first
+      share `mvm-cli`'s nested build graph across feature fingerprints, move
+      man-page tests onto Test's warm compile graph, and keep the removed MCP
+      server and smoke lane out of CI. Structural, targeted feature, full
+      workspace, and Linux verification are green. The first
       post-change run measured 19–21 minutes of runner wait; its 37m36s Lint
       execution did not beat the 36-minute cold-run baseline because the
       remaining `mvm-cli` and live audit tests dominate the lane.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -86,6 +86,14 @@
       speculative pre-PR and redundant post-merge `main` runs without changing
       required check names.
 
+- [ ] Plan 280 CI latency: stop the lint lane from repeating the full workspace
+      under `test-support`, remove unshareable multi-gigabyte `target/` caches,
+      share `mvm-cli`'s nested build graph across feature fingerprints, and
+      reuse Test's warm compile graph for man-page tests and the merge-queue MCP
+      smoke while preserving every required check name. Structural, targeted
+      feature, and full workspace tests are green; Linux verification is in
+      progress.
+
 - [x] #1840 faithful flake-image revert: boot the recorded slot revision,
       reconcile signed artifact hashes, and preserve the admitted restore path.
       Implementation, focused tests, workspace tests, check, and clippy pass;

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -30,6 +30,17 @@
       one. Workflow validation, focused tests, workspace check, clippy, and
       formatting pass. Tracked in plan 282.
 
+- [x] Merge-queue latency audit and workflow hardening: measured 50 recent
+      queued merges and 101 merge-group jobs, confirmed runner admission and
+      long required-job execution as the dominant critical path, and found
+      regenerated speculative groups adding up to 2h04m of rebuild delay. The
+      two required workflows now declare `checks_requested` explicitly, cancel
+      only superseded pull-request runs, never cancel merge-group validation,
+      and give manual runs unique concurrency keys. All five required check
+      names and exact-merge-commit validation remain intact. Plan 281 records
+      the measured 38m26s p50 / 2h14m03s p95 queue latency. The live ruleset is
+      now set to build concurrency 3, group wait 0, and timeout 90 minutes.
+
 - [x] Build-cache invalidation: narrowed `nix/lib/workspace-filter.nix` from a
       basename deny-list over the whole workspace root to an allow-list of the
       top-level entries cargo can actually read. The filtered tree is `mvmSrc`,

--- a/specs/adrs/012-ci-execution-policy.md
+++ b/specs/adrs/012-ci-execution-policy.md
@@ -62,6 +62,14 @@ feature tests, and examples therefore reuse the same embedded-binary graph.
 merges. `ci-full.yml`, `security.yml`, and `windows.yml` are not part of
 the merge-queue gate.
 
+Both required workflows listen explicitly for `checks_requested`. Their
+concurrency keys include the workflow, event type, and event ref, so unrelated
+pull requests and merge-group commits do not serialize. A new commit cancels a
+superseded `pull_request` run for the same PR; `merge_group` runs are never
+cancelled by workflow concurrency, because cancelling validation of the exact
+queue commit can eject the entry or leave its required checks unresolved.
+Manual dispatches use the run ID and therefore remain independent.
+
 ### Pre-commit hook (`.githooks/pre-commit`)
 
 Activated via `git config core.hooksPath .githooks`, it runs on every

--- a/specs/adrs/012-ci-execution-policy.md
+++ b/specs/adrs/012-ci-execution-policy.md
@@ -21,23 +21,22 @@ day-to-day development for no proportional benefit.
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `ci.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | two runner jobs on PR (`lint` + `test`); three in merge queue / manual dispatch (`lint`, `test` including MCP, and Nix) |
+| `ci.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | three runner jobs on PR (`lint`, `test`, and the short MCP aggregate gate); four in merge queue / manual dispatch (the same jobs plus Nix, with MCP executed inside Test) |
 | `architecture.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | structural/architectural invariants; skips the actual work on docs-only PRs, always runs in merge queue |
 | `ci-full.yml` | `workflow_dispatch` only | the full platform + live-VM + OCI-ratification matrix; operator-triggered, never automatic |
 | `security.yml` | `push: tags: v*` + nightly cron + `workflow_dispatch` | dependency audit / advisory scan; release-time backstop plus nightly catch for new advisories |
 | `windows.yml` | `push: tags: v*` + `workflow_dispatch` | non-blocking informational Windows build check; never a required check |
 | `release.yml` | `push: tags: v*` | builds and publishes release artifacts |
 
-### `ci.yml` is capped at three runner jobs in the merge queue, two on pull requests
+### `ci.yml` shares expensive work and keeps required results conclusive
 
 `lint` (fmt, clippy, and the full battery of `xtask` architectural
 checks — see ADR-010) and `test` (the workspace nextest run, doctests,
 hermetic BDD, no-std target checks, man-page feature tests, and real-kernel
 ext4 checks) run on every pull request. The MCP stdio roundtrip runs inside
 the already-warm Test runner in the merge queue and on manual
-`workflow_dispatch`; its historical
-required-check job remains as a skipped compatibility shim until the branch
-rule is updated. `nix-flake-check` also runs only in the merge queue and on
+`workflow_dispatch`; its historical required-check job is an always-running
+aggregate gate that fails unless Test succeeds. `nix-flake-check` also runs only in the merge queue and on
 manual dispatch, so ordinary PR updates pay for the lighter compile/test signal
 and the heavier smoke/eval work runs once before merge. The SDK publication
 dry-run is part of the manual full matrix rather than the development lane.
@@ -46,8 +45,8 @@ Nothing platform-specific
 the full builder-VM image build) runs on every pull request — those live
 in `ci-full.yml`, run only by explicit `workflow_dispatch`.
 
-Checks that need the same Linux and Rust environment are steps in one of these
-three runner jobs, not standalone jobs. This shares checkout, toolchain, and
+Checks that need the same Linux and Rust environment are steps in the Lint,
+Test, or Nix jobs, not standalone build jobs. This shares checkout, toolchain, and
 dependency installation while retaining the same behavioral coverage. The PR
 workflow does not upload `target/`: GitHub scopes caches from pull-request and
 merge-queue refs so sibling runs cannot restore them, making the former 4+ GB

--- a/specs/adrs/012-ci-execution-policy.md
+++ b/specs/adrs/012-ci-execution-policy.md
@@ -21,7 +21,7 @@ day-to-day development for no proportional benefit.
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `ci.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | three runner jobs on PR (`lint`, `test`, and the short MCP aggregate gate); four in merge queue / manual dispatch (the same jobs plus Nix, with MCP executed inside Test) |
+| `ci.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | two runner jobs on PR (`lint` and `test`); three in merge queue / manual dispatch (the same jobs plus Nix) |
 | `architecture.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | structural/architectural invariants; skips the actual work on docs-only PRs, always runs in merge queue |
 | `ci-full.yml` | `workflow_dispatch` only | the full platform + live-VM + OCI-ratification matrix; operator-triggered, never automatic |
 | `security.yml` | `push: tags: v*` + nightly cron + `workflow_dispatch` | dependency audit / advisory scan; release-time backstop plus nightly catch for new advisories |
@@ -33,12 +33,9 @@ day-to-day development for no proportional benefit.
 `lint` (fmt, clippy, and the full battery of `xtask` architectural
 checks — see ADR-010) and `test` (the workspace nextest run, doctests,
 hermetic BDD, no-std target checks, man-page feature tests, and real-kernel
-ext4 checks) run on every pull request. The MCP stdio roundtrip runs inside
-the already-warm Test runner in the merge queue and on manual
-`workflow_dispatch`; its historical required-check job is an always-running
-aggregate gate that fails unless Test succeeds. `nix-flake-check` also runs only in the merge queue and on
-manual dispatch, so ordinary PR updates pay for the lighter compile/test signal
-and the heavier smoke/eval work runs once before merge. The SDK publication
+ext4 checks) run on every pull request. `nix-flake-check` runs only in the merge
+queue and on manual dispatch, so ordinary PR updates pay for the lighter
+compile/test signal and the heavier eval work runs once before merge. The SDK publication
 dry-run is part of the manual full matrix rather than the development lane.
 Nothing platform-specific
 (macOS, live KVM, Windows) or slow (OCI ratification, dependency audit,
@@ -94,11 +91,10 @@ evaluation on the hosted Linux runner.
 
 A pull-request update gets fast, complete feedback from the checks that
 matter for almost every change — two Linux-only jobs (`lint` and `test`)
-plus the architecture-invariant lane, with the heavier MCP smoke and
-`nix-flake-check` work deferred to the merge queue. The merge queue runs the
-full set of five required check names against the final merge group using four
-allocated runners: lint, Test with MCP, Nix, and the architecture invariant.
-The MCP compatibility check is skipped without allocating a runner.
+plus the architecture-invariant lane, with the heavier `nix-flake-check` work
+deferred to the merge queue. The merge queue runs the full set of four required
+check names against the final merge group using four allocated runners: lint,
+Test, Nix, and the architecture invariant.
 Development branches without a pull request consume no hosted runners
 unless an operator dispatches CI manually. Landing that already-checked
 commit on `main` does not run them a third time. An operator opts into the expensive platform, live-VM,

--- a/specs/adrs/012-ci-execution-policy.md
+++ b/specs/adrs/012-ci-execution-policy.md
@@ -21,31 +21,40 @@ day-to-day development for no proportional benefit.
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `ci.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | two jobs on PR (`lint` + `test`); all three jobs in merge queue / manual dispatch |
+| `ci.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | two runner jobs on PR (`lint` + `test`); three in merge queue / manual dispatch (`lint`, `test` including MCP, and Nix) |
 | `architecture.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | structural/architectural invariants; skips the actual work on docs-only PRs, always runs in merge queue |
 | `ci-full.yml` | `workflow_dispatch` only | the full platform + live-VM + OCI-ratification matrix; operator-triggered, never automatic |
 | `security.yml` | `push: tags: v*` + nightly cron + `workflow_dispatch` | dependency audit / advisory scan; release-time backstop plus nightly catch for new advisories |
 | `windows.yml` | `push: tags: v*` + `workflow_dispatch` | non-blocking informational Windows build check; never a required check |
 | `release.yml` | `push: tags: v*` | builds and publishes release artifacts |
 
-### `ci.yml` is capped at three jobs in the merge queue, two on pull requests
+### `ci.yml` is capped at three runner jobs in the merge queue, two on pull requests
 
 `lint` (fmt, clippy, and the full battery of `xtask` architectural
 checks — see ADR-010) and `test` (the workspace nextest run, doctests,
-hermetic BDD, no-std target checks, and real-kernel ext4 checks) run on
-every pull request. `nix-flake-check` runs only in the merge queue and
-on manual `workflow_dispatch`, so ordinary PR updates pay for the
-lighter compile/test signal and the heavier eval lane runs once before
-merge. The SDK publication dry-run is part of the manual full matrix
-rather than the development lane. Nothing platform-specific (macOS,
-live KVM, Windows) or slow (OCI ratification, dependency audit, the
-full builder-VM image build) runs on every pull request — those live in
-`ci-full.yml`, run only by explicit `workflow_dispatch`.
+hermetic BDD, no-std target checks, man-page feature tests, and real-kernel
+ext4 checks) run on every pull request. The MCP stdio roundtrip runs inside
+the already-warm Test runner in the merge queue and on manual
+`workflow_dispatch`; its historical
+required-check job remains as a skipped compatibility shim until the branch
+rule is updated. `nix-flake-check` also runs only in the merge queue and on
+manual dispatch, so ordinary PR updates pay for the lighter compile/test signal
+and the heavier smoke/eval work runs once before merge. The SDK publication
+dry-run is part of the manual full matrix rather than the development lane.
+Nothing platform-specific
+(macOS, live KVM, Windows) or slow (OCI ratification, dependency audit,
+the full builder-VM image build) runs on every pull request — those live
+in `ci-full.yml`, run only by explicit `workflow_dispatch`.
 
-Checks that need the same Linux and Rust environment are steps in one of
-these three jobs, not standalone jobs. This shares checkout, toolchain,
-dependency installation, and cache overhead while retaining the same
-behavioral coverage.
+Checks that need the same Linux and Rust environment are steps in one of these
+three runner jobs, not standalone jobs. This shares checkout, toolchain, and
+dependency installation while retaining the same behavioral coverage. The PR
+workflow does not upload `target/`: GitHub scopes caches from pull-request and
+merge-queue refs so sibling runs cannot restore them, making the former 4+ GB
+archives pure upload/storage cost except on a rerun of the same generated ref.
+Within a lint runner, `mvm-cli`'s nested Cargo builds use one target per outer
+profile rather than one per feature-specific build-script `OUT_DIR`; clippy,
+feature tests, and examples therefore reuse the same embedded-binary graph.
 
 ### The merge queue's required checks
 
@@ -78,9 +87,11 @@ evaluation on the hosted Linux runner.
 
 A pull-request update gets fast, complete feedback from the checks that
 matter for almost every change — two Linux-only jobs (`lint` and `test`)
-plus the architecture-invariant lane, with the heavier `nix-flake-check`
-lane deferred to the merge queue. The merge queue runs the full set of
-required checks against the final merge group.
+plus the architecture-invariant lane, with the heavier MCP smoke and
+`nix-flake-check` work deferred to the merge queue. The merge queue runs the
+full set of five required check names against the final merge group using four
+allocated runners: lint, Test with MCP, Nix, and the architecture invariant.
+The MCP compatibility check is skipped without allocating a runner.
 Development branches without a pull request consume no hosted runners
 unless an operator dispatches CI manually. Landing that already-checked
 commit on `main` does not run them a third time. An operator opts into the expensive platform, live-VM,

--- a/specs/plans/280-ci-lint-latency.md
+++ b/specs/plans/280-ci-lint-latency.md
@@ -33,9 +33,9 @@ binaries for clippy, `test-support`, and example feature fingerprints.
 - [x] Move the `xtask` man-page feature tests from Lint to the required Test
       job, where the test-profile `mvm-cli` graph is already warm.
 - [x] Run the MCP stdio roundtrip inside the already-warm Test job for merge-
-      queue and manual runs. Retain the historical required-check name as a
-      skipped compatibility job so the branch rule does not need an unsafe
-      transition window.
+      queue and manual runs. Retain the historical required-check name as an
+      always-running aggregate gate that fails unless Test succeeds, so no
+      required result is ever satisfied by a skipped job.
 - [x] Measure the targeted feature lane locally: 2,718 tests plus the required
       example check completed in 7m27s, versus 13m38s and 8,610 tests for the
       sampled workspace-wide command.
@@ -55,8 +55,8 @@ binaries for clippy, `test-support`, and example feature fingerprints.
   nested target, so later feature variants reuse the embedded-binary graph.
 - Man-page feature coverage remains required but does not rebuild the
   test-profile CLI graph on Lint's critical path.
-- MCP still executes before a merge, but no separate runner is allocated for
-  its compatibility check.
+- MCP still executes before a merge. Its historical required check always
+  concludes and uses only a short aggregate runner after Test completes.
 - `cargo test --workspace`, `cargo check --workspace`, and Linux
   `cargo clippy --workspace --all-targets -- -D warnings` pass.
 

--- a/specs/plans/280-ci-lint-latency.md
+++ b/specs/plans/280-ci-lint-latency.md
@@ -1,0 +1,70 @@
+# Plan 280 — CI lint and merge-queue latency
+
+**Status: In progress**
+
+## Goal
+
+Reduce pull-request and merge-queue latency without weakening the required
+Rust, policy, feature-gated, MCP, or Nix coverage.
+
+The baseline is GitHub Actions run `30664687885`: `Lint (fmt + clippy +
+policy)` occupied a runner for 36 minutes. Clippy and policy finished after
+roughly 13 minutes; the remaining time was dominated by feature-test rebuilds.
+The final `test-support` command repeated 8,610 tests after the Test job had
+already run 8,595. The same lint job then uploaded a 4.44 GB `target/` cache.
+GitHub scopes pull-request and merge-queue caches to their generated refs, so
+sibling runs cannot restore those archives; the repository has no default-
+branch cache for them to inherit. In addition, `mvm-cli` placed nested Cargo
+targets below its feature-specific `OUT_DIR`, rebuilding the same embedded
+binaries for clippy, `test-support`, and example feature fingerprints.
+
+## Tasks
+
+- [x] Add a structural regression test that pins the optimized CI shape.
+- [x] Replace the workspace-wide `test-support` rerun with the library tests
+      for `mvm-runtime`, `mvm-client`, and `mvm-cli`, the root
+      `audit_emissions_live` integration test, and an explicit compile check
+      for the required `verification_loop` example.
+- [x] Remove the branch-scoped `target/` caches from the PR workflow and remove
+      the lint-only disk purge they required.
+- [x] Share `mvm-cli`'s nested embedded-binary and auxiliary-helper target
+      across feature fingerprints while keeping it isolated from the outer
+      Cargo target lock.
+- [x] Move the `xtask` man-page feature tests from Lint to the required Test
+      job, where the test-profile `mvm-cli` graph is already warm.
+- [x] Run the MCP stdio roundtrip inside the already-warm Test job for merge-
+      queue and manual runs. Retain the historical required-check name as a
+      skipped compatibility job so the branch rule does not need an unsafe
+      transition window.
+- [x] Measure the targeted feature lane locally: 2,718 tests plus the required
+      example check completed in 7m27s, versus 13m38s and 8,610 tests for the
+      sampled workspace-wide command.
+- [ ] Validate workflow syntax, the full xtask suite, formatting, workspace
+      tests/check, and Linux all-target clippy.
+- [ ] Record the first post-change Actions timings and decide separately
+      whether cross-branch sccache storage or larger runners are justified.
+
+## Acceptance gates
+
+- The CI workflow parses under `actionlint`.
+- `xtask`'s CI-shape regression is green.
+- The default workspace test lane remains unchanged.
+- Every source location gated by `feature = "test-support"` is owned by one of
+  the explicitly tested packages, and the feature-gated example is compiled.
+- Two `mvm-cli` build-script `OUT_DIR`s in the same profile resolve to one
+  nested target, so later feature variants reuse the embedded-binary graph.
+- Man-page feature coverage remains required but does not rebuild the
+  test-profile CLI graph on Lint's critical path.
+- MCP still executes before a merge, but no separate runner is allocated for
+  its compatibility check.
+- `cargo test --workspace`, `cargo check --workspace`, and Linux
+  `cargo clippy --workspace --all-targets -- -D warnings` pass.
+
+## Security posture
+
+No required behavioral gate is removed. The mock backend remains test-only,
+MCP continues to exercise its real JSON-RPC subprocess boundary, and Nix
+closure checks remain required in the merge queue. Removing branch-local build
+archives also reduces the cache-poisoning and stale-artifact surface; a future
+shared compiler cache must be written only from a trusted default-branch or
+external cache boundary.

--- a/specs/plans/280-ci-lint-latency.md
+++ b/specs/plans/280-ci-lint-latency.md
@@ -1,6 +1,6 @@
 # Plan 280 — CI lint and merge-queue latency
 
-**Status: In progress**
+**Status: Complete**
 
 ## Goal
 
@@ -39,10 +39,25 @@ binaries for clippy, `test-support`, and example feature fingerprints.
 - [x] Measure the targeted feature lane locally: 2,718 tests plus the required
       example check completed in 7m27s, versus 13m38s and 8,610 tests for the
       sampled workspace-wide command.
-- [ ] Validate workflow syntax, the full xtask suite, formatting, workspace
+- [x] Validate workflow syntax, the full xtask suite, formatting, workspace
       tests/check, and Linux all-target clippy.
-- [ ] Record the first post-change Actions timings and decide separately
+- [x] Record the first post-change Actions timings and decide separately
       whether cross-branch sccache storage or larger runners are justified.
+
+## First GitHub Actions result
+
+Pull-request run `30682895396` passed on the exact branch commit. Test waited
+19m07s for a runner and executed for 27m31s. Lint waited 21m10s and executed
+for 37m36s; its targeted `test-support` step took 23m23s. The reduced test set
+removed duplicate work, but the cold-run critical path did not improve over the
+36-minute baseline because a small number of `mvm-cli` and live audit tests
+still dominate that lane. The stable MCP aggregate appeared after Test and
+passed in two seconds.
+
+Do not add a cross-branch compiler cache without a trusted write boundary.
+Faster or additional hosted-runner capacity is justified by the observed
+19–21 minute runner waits; repository-scoped credentials cannot inspect or
+change that organization-level allocation.
 
 ## Acceptance gates
 

--- a/specs/plans/281-merge-queue-latency.md
+++ b/specs/plans/281-merge-queue-latency.md
@@ -1,0 +1,68 @@
+# Merge queue latency audit
+
+**Status:** Complete.
+
+**Goal:** Keep exact-merge-commit validation intact while removing avoidable
+merge-queue cancellation and measuring the capacity settings that control
+queue latency.
+
+## Evidence snapshot
+
+The snapshot was taken on 2026-08-01 UTC from the repository ruleset, classic
+branch protection, pull-request timelines, merge-queue entries, Actions runs,
+jobs, and one failed run's logs.
+
+- The queue ruleset built five speculative entries. Each entry emitted five
+  required GitHub Actions checks, so one full generation created 25 required
+  jobs. The repository had no repository-scoped self-hosted runners.
+- Across 50 recently merged queue entries, queue-entry-to-merge latency was
+  38m26s p50 and 2h14m03s p95. Initial merge-group creation was normally fast
+  (18s p50, 3m56s p95), but regenerated groups added as much as 2h04m21s.
+- Across 101 jobs from 44 recent completed merge-group workflow runs, runner
+  wait was 7m59s p50 and 34m16s p95; job execution was 26m42s p50 and 40m00s
+  p95. The sample reached 19 simultaneously running merge-group jobs before
+  counting ordinary pull-request work.
+- Required CI workflow duration, including runner admission, was 52m07s p50
+  and 1h19m05s p95 across 19 completed merge-group CI runs. At the time of the
+  measurement, the ruleset's status-check timeout was 60 minutes.
+- The required contexts were `Lint (fmt + clippy + policy)`, `Test`,
+  `MCP server stdio roundtrip`, `Nix flake check (Linux eval)`, and `Invariant`.
+  A successful merge-group commit emitted all five under the GitHub Actions app.
+  No third-party check or deployment was required.
+
+## Work
+
+- [x] Make the two required workflows listen explicitly for
+  `merge_group: checks_requested`.
+- [x] Keep pull-request supersession cancellation while preventing
+  merge-group cancellation and manual-run serialization.
+- [x] Make the CI workflow's read-only token posture explicit.
+- [x] Validate all workflows with `actionlint` and add structural tests for
+  required-check names, merge-group triggers, concurrency, and permissions.
+- [x] Run repository formatting, check, test, and clippy gates. The host
+  workspace suite passed serially; an initial parallel run exposed an existing
+  process-environment/socket isolation race in `mvm-runtime`, and the focused
+  serial rerun passed all 1,219 active library tests.
+- [x] Apply the measured GitHub settings and read them back from the ruleset.
+- [x] Record the completed work in `specs/SPRINT.md` and
+  `specs/REFACTOR-STATUS.md`.
+
+## Applied GitHub settings
+
+The repository ruleset now keeps squash merging, `ALLGREEN`, minimum group
+size 1, maximum group size 5, all five required checks, no bypass actors, and
+no required deployments. On 2026-08-01 it changed speculative build
+concurrency from 5 to 3, minimum-group wait from 5 minutes to 0, and the check
+response timeout from 60 to 90 minutes. Three speculative entries create at
+most 15 required jobs with the measured five-check shape, leaving capacity for
+ordinary pull-request feedback. The 90-minute timeout is the smallest round
+value above the measured 79-minute successful p95 while runner and critical-
+path changes roll out.
+
+## Non-goals
+
+- Do not drop, rename, or replace a required check with a skipped compatibility
+  job.
+- Do not reuse pull-request artifacts as proof for a different merge-group SHA.
+- Do not add privileged secrets, `pull_request_target`, or broader workflow
+  permissions to the required workflows.

--- a/specs/plans/281-merge-queue-latency.md
+++ b/specs/plans/281-merge-queue-latency.md
@@ -25,10 +25,11 @@ jobs, and one failed run's logs.
 - Required CI workflow duration, including runner admission, was 52m07s p50
   and 1h19m05s p95 across 19 completed merge-group CI runs. At the time of the
   measurement, the ruleset's status-check timeout was 60 minutes.
-- The required contexts were `Lint (fmt + clippy + policy)`, `Test`,
-  `MCP server stdio roundtrip`, `Nix flake check (Linux eval)`, and `Invariant`.
-  A successful merge-group commit emitted all five under the GitHub Actions app.
-  No third-party check or deployment was required.
+- At measurement time the required contexts were `Lint (fmt + clippy + policy)`,
+  `Test`, `MCP server stdio roundtrip`, `Nix flake check (Linux eval)`, and
+  `Invariant`. The MCP server and its check were subsequently removed; the
+  current queue requires the remaining four contexts. No third-party check or
+  deployment was required.
 
 ## Work
 
@@ -49,10 +50,11 @@ jobs, and one failed run's logs.
 
 ## Applied GitHub settings
 
-The repository ruleset now keeps squash merging, `ALLGREEN`, minimum group
-size 1, maximum group size 5, all five required checks, no bypass actors, and
-no required deployments. On 2026-08-01 it changed speculative build
-concurrency from 5 to 3, minimum-group wait from 5 minutes to 0, and the check
+The repository ruleset keeps squash merging, `ALLGREEN`, minimum group size 1,
+maximum group size 5, no bypass actors, and no required deployments. The MCP
+context was removed when its server was deleted, leaving four required checks.
+On 2026-08-01 the ruleset changed speculative build concurrency from 5 to 3,
+minimum-group wait from 5 minutes to 0, and the check
 response timeout from 60 to 90 minutes. Three speculative entries create at
 most 15 required jobs with the measured five-check shape, leaving capacity for
 ordinary pull-request feedback. The 90-minute timeout is the smallest round

--- a/specs/plans/284-ci-lint-latency.md
+++ b/specs/plans/284-ci-lint-latency.md
@@ -5,7 +5,7 @@
 ## Goal
 
 Reduce pull-request and merge-queue latency without weakening the required
-Rust, policy, feature-gated, MCP, or Nix coverage.
+Rust, policy, feature-gated, or Nix coverage.
 
 The baseline is GitHub Actions run `30664687885`: `Lint (fmt + clippy +
 policy)` occupied a runner for 36 minutes. Clippy and policy finished after
@@ -32,10 +32,8 @@ binaries for clippy, `test-support`, and example feature fingerprints.
       Cargo target lock.
 - [x] Move the `xtask` man-page feature tests from Lint to the required Test
       job, where the test-profile `mvm-cli` graph is already warm.
-- [x] Run the MCP stdio roundtrip inside the already-warm Test job for merge-
-      queue and manual runs. Retain the historical required-check name as an
-      always-running aggregate gate that fails unless Test succeeds, so no
-      required result is ever satisfied by a skipped job.
+- [x] Keep the removed MCP server and its smoke lane out of CI while optimizing
+      the remaining required jobs.
 - [x] Measure the targeted feature lane locally: 2,718 tests plus the required
       example check completed in 7m27s, versus 13m38s and 8,610 tests for the
       sampled workspace-wide command.
@@ -51,8 +49,7 @@ Pull-request run `30682895396` passed on the exact branch commit. Test waited
 for 37m36s; its targeted `test-support` step took 23m23s. The reduced test set
 removed duplicate work, but the cold-run critical path did not improve over the
 36-minute baseline because a small number of `mvm-cli` and live audit tests
-still dominate that lane. The stable MCP aggregate appeared after Test and
-passed in two seconds.
+still dominate that lane.
 
 Do not add a cross-branch compiler cache without a trusted write boundary.
 Faster or additional hosted-runner capacity is justified by the observed
@@ -70,16 +67,14 @@ change that organization-level allocation.
   nested target, so later feature variants reuse the embedded-binary graph.
 - Man-page feature coverage remains required but does not rebuild the
   test-profile CLI graph on Lint's critical path.
-- MCP still executes before a merge. Its historical required check always
-  concludes and uses only a short aggregate runner after Test completes.
+- The removed MCP server and its former required-check lane remain absent.
 - `cargo test --workspace`, `cargo check --workspace`, and Linux
   `cargo clippy --workspace --all-targets -- -D warnings` pass.
 
 ## Security posture
 
-No required behavioral gate is removed. The mock backend remains test-only,
-MCP continues to exercise its real JSON-RPC subprocess boundary, and Nix
-closure checks remain required in the merge queue. Removing branch-local build
-archives also reduces the cache-poisoning and stale-artifact surface; a future
-shared compiler cache must be written only from a trusted default-branch or
-external cache boundary.
+No active required behavioral gate is removed. The mock backend remains
+test-only, and Nix closure checks remain required in the merge queue. Removing
+branch-local build archives also reduces the cache-poisoning and stale-artifact
+surface; a future shared compiler cache must be written only from a trusted
+default-branch or external cache boundary.

--- a/specs/plans/284-ci-lint-latency.md
+++ b/specs/plans/284-ci-lint-latency.md
@@ -1,4 +1,4 @@
-# Plan 280 — CI lint and merge-queue latency
+# Plan 284 — CI lint and merge-queue latency
 
 **Status: Complete**
 

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -207,12 +207,17 @@ mod tests {
     use super::*;
 
     fn ci_workflow() -> String {
+        workflow("ci.yml")
+    }
+
+    fn workflow(name: &str) -> String {
         std::fs::read_to_string(
             Path::new(env!("CARGO_MANIFEST_DIR"))
                 .join("..")
-                .join(".github/workflows/ci.yml"),
+                .join(".github/workflows")
+                .join(name),
         )
-        .expect("CI workflow must be readable")
+        .unwrap_or_else(|error| panic!("{name} must be readable: {error}"))
     }
 
     fn ci_job_block<'a>(workflow: &'a str, job: &str) -> &'a str {
@@ -339,6 +344,43 @@ mod tests {
         assert!(gate.contains("if [ \"$TEST_RESULT\" != \"success\" ]"));
         assert!(!gate.contains("mcp-check-compatibility-shim"));
         assert!(!gate.contains("./scripts/test-mcp-roundtrip.sh"));
+    }
+
+    #[test]
+    fn required_workflows_keep_merge_group_runs_independent_and_conclusive() {
+        let expected_group = "group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}";
+        let expected_cancel = "cancel-in-progress: ${{ github.event_name == 'pull_request' }}";
+
+        for name in ["ci.yml", "architecture.yml"] {
+            let source = workflow(name);
+            assert!(
+                source.contains("merge_group:\n    types: [checks_requested]"),
+                "{name} must handle merge-queue check requests explicitly"
+            );
+            assert!(
+                source.contains(expected_group),
+                "{name} concurrency key drifted"
+            );
+            assert!(
+                source.contains(expected_cancel),
+                "{name} must cancel only superseded pull-request runs"
+            );
+            assert!(!source.contains("cancel-in-progress: true"));
+        }
+
+        let ci = ci_workflow();
+        assert!(ci.contains("permissions:\n  contents: read"));
+        for required_name in [
+            "name: Lint (fmt + clippy + policy)",
+            "name: Test",
+            "name: MCP server stdio roundtrip",
+            "name: Nix flake check (Linux eval)",
+        ] {
+            assert!(ci.contains(required_name), "required check name drifted");
+        }
+
+        let architecture = workflow("architecture.yml");
+        assert!(architecture.contains("name: Invariant #1"));
     }
 
     #[test]

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -206,6 +206,32 @@ fn parse_fuzz_args(args: &str, crate_dir: &str) -> Option<FuzzInvocation> {
 mod tests {
     use super::*;
 
+    fn ci_workflow() -> String {
+        std::fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join(".github/workflows/ci.yml"),
+        )
+        .expect("CI workflow must be readable")
+    }
+
+    fn ci_job_block<'a>(workflow: &'a str, job: &str) -> &'a str {
+        let marker = format!("  {job}:\n");
+        let start = workflow
+            .find(&marker)
+            .unwrap_or_else(|| panic!("CI workflow is missing the {job} job"));
+        let rest_start = start + marker.len();
+        let rest = &workflow[rest_start..];
+        let end = rest
+            .match_indices("\n  ")
+            .find_map(|(offset, _)| {
+                let line = rest[offset + 1..].lines().next()?;
+                (!line.starts_with("    ") && line.ends_with(':')).then_some(rest_start + offset)
+            })
+            .unwrap_or(workflow.len());
+        &workflow[start..end]
+    }
+
     #[test]
     fn working_directories_are_unquoted() {
         let src = "    working-directory: crates/mvm-agentd\n  working-directory: \"crates/x\"\n";
@@ -259,6 +285,87 @@ mod tests {
                 fuzz_dir: "fuzz".to_string(),
                 target: "fuzz_runtime_recording".to_string(),
             }]
+        );
+    }
+
+    #[test]
+    fn pull_request_ci_does_not_repeat_the_workspace_or_upload_target_caches() {
+        let workflow = ci_workflow();
+        let lint = ci_job_block(&workflow, "lint");
+        for unexpected in [
+            "cargo nextest run --workspace --features test-support",
+            "cargo nextest run -p xtask --features man",
+            "uses: actions/cache@v5",
+            "uses: ./.github/actions/free-disk",
+        ] {
+            assert!(
+                !lint.contains(unexpected),
+                "CI lint job must not contain {unexpected:?}"
+            );
+        }
+
+        for expected in [
+            "cargo nextest run -p mvm-runtime --features test-support --lib",
+            "cargo nextest run -p mvm-client --features test-support --lib",
+            "cargo nextest run -p mvm-cli --features test-support --lib",
+            "cargo nextest run -p mvmctl --features test-support --test audit_emissions_live",
+            "cargo check -p mvm-cli --features test-support --example verification_loop",
+        ] {
+            assert!(
+                lint.contains(expected),
+                "CI lint job must contain {expected:?}"
+            );
+        }
+
+        let test = ci_job_block(&workflow, "test");
+        assert!(!test.contains("uses: actions/cache@v5"));
+        assert!(test.contains("cargo nextest run -p xtask --features man"));
+    }
+
+    #[test]
+    fn mcp_smoke_reuses_the_test_runner_without_dropping_the_required_check_name() {
+        let workflow = ci_workflow();
+        let test = ci_job_block(&workflow, "test");
+        assert!(test.contains("sudo apt-get install -y attr cryptsetup-bin libcap-ng-dev lld"));
+        assert!(test.contains("- name: Install MCP smoke dependency"));
+        assert!(test.contains("run: sudo apt-get install -y jq"));
+        assert!(test.contains("run: ./scripts/test-mcp-roundtrip.sh"));
+
+        let compatibility = ci_job_block(&workflow, "mcp-server-smoke");
+        assert!(compatibility.contains("name: MCP server stdio roundtrip"));
+        assert!(compatibility.contains("if: github.event_name == 'mcp-check-compatibility-shim'"));
+        assert!(!compatibility.contains("./scripts/test-mcp-roundtrip.sh"));
+    }
+
+    #[test]
+    fn test_support_source_owners_match_the_targeted_ci_lane() {
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        let mut unexpected = Vec::new();
+        crate::fs_walk::for_each_file(&workspace, Some("rs"), &mut |path, contents| {
+            if !contents.contains("feature = \"test-support\"") {
+                return;
+            }
+            let relative = path
+                .strip_prefix(&workspace)
+                .expect("workspace-relative path");
+            let owned = [
+                "crates/mvm-cli/",
+                "crates/mvm-client/",
+                "crates/mvm-core/",
+                "crates/mvm-runtime/",
+                "tests/audit_emissions_live.rs",
+            ]
+            .iter()
+            .any(|prefix| relative.to_string_lossy().starts_with(*prefix));
+            if !owned {
+                unexpected.push(relative.display().to_string());
+            }
+        })
+        .expect("test-support source scan must succeed");
+
+        assert!(
+            unexpected.is_empty(),
+            "new test-support source owners need an explicit targeted CI command: {unexpected:?}"
         );
     }
 }

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -328,22 +328,19 @@ mod tests {
     }
 
     #[test]
-    fn mcp_smoke_reuses_the_test_runner_without_dropping_the_required_check_name() {
+    fn removed_mcp_server_stays_out_of_ci() {
         let workflow = ci_workflow();
-        let test = ci_job_block(&workflow, "test");
-        assert!(test.contains("sudo apt-get install -y attr cryptsetup-bin libcap-ng-dev lld"));
-        assert!(test.contains("- name: Install MCP smoke dependency"));
-        assert!(test.contains("run: sudo apt-get install -y jq"));
-        assert!(test.contains("run: ./scripts/test-mcp-roundtrip.sh"));
-
-        let gate = ci_job_block(&workflow, "mcp-server-smoke");
-        assert!(gate.contains("name: MCP server stdio roundtrip"));
-        assert!(gate.contains("needs: test"));
-        assert!(gate.contains("if: ${{ always() }}"));
-        assert!(gate.contains("TEST_RESULT: ${{ needs.test.result }}"));
-        assert!(gate.contains("if [ \"$TEST_RESULT\" != \"success\" ]"));
-        assert!(!gate.contains("mcp-check-compatibility-shim"));
-        assert!(!gate.contains("./scripts/test-mcp-roundtrip.sh"));
+        for removed in [
+            "MCP server stdio roundtrip",
+            "mcp-server-smoke",
+            "test-mcp-roundtrip.sh",
+            "Install MCP smoke dependency",
+        ] {
+            assert!(
+                !workflow.contains(removed),
+                "removed MCP server CI surface returned: {removed}"
+            );
+        }
     }
 
     #[test]
@@ -373,7 +370,6 @@ mod tests {
         for required_name in [
             "name: Lint (fmt + clippy + policy)",
             "name: Test",
-            "name: MCP server stdio roundtrip",
             "name: Nix flake check (Linux eval)",
         ] {
             assert!(ci.contains(required_name), "required check name drifted");

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -331,10 +331,14 @@ mod tests {
         assert!(test.contains("run: sudo apt-get install -y jq"));
         assert!(test.contains("run: ./scripts/test-mcp-roundtrip.sh"));
 
-        let compatibility = ci_job_block(&workflow, "mcp-server-smoke");
-        assert!(compatibility.contains("name: MCP server stdio roundtrip"));
-        assert!(compatibility.contains("if: github.event_name == 'mcp-check-compatibility-shim'"));
-        assert!(!compatibility.contains("./scripts/test-mcp-roundtrip.sh"));
+        let gate = ci_job_block(&workflow, "mcp-server-smoke");
+        assert!(gate.contains("name: MCP server stdio roundtrip"));
+        assert!(gate.contains("needs: test"));
+        assert!(gate.contains("if: ${{ always() }}"));
+        assert!(gate.contains("TEST_RESULT: ${{ needs.test.result }}"));
+        assert!(gate.contains("if [ \"$TEST_RESULT\" != \"success\" ]"));
+        assert!(!gate.contains("mcp-check-compatibility-shim"));
+        assert!(!gate.contains("./scripts/test-mcp-roundtrip.sh"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace the workspace-wide `test-support` rerun with targeted package, integration, and example coverage
- move man-page tests onto the already-warm Test runner
- keep the removed MCP server and smoke lane out of CI
- share `mvm-cli` nested Cargo targets across feature fingerprints
- remove branch-scoped multi-gigabyte Cargo target caches and the disk purge they required
- trigger required workflows explicitly on `merge_group: checks_requested`
- cancel only superseded pull-request runs, never exact-commit merge-group validation
- keep manual dispatches independent and make CI's `contents: read` permission explicit
- add structural regression tests for the optimized and merge-queue-safe workflow shape

## Why

GitHub Actions run `30664687885` spent 36 minutes in `Lint (fmt + clippy + policy)`. The tail repeated 8,610 workspace tests under `test-support`, rebuilt embedded binaries for multiple feature-specific `OUT_DIR` values, ran the man-page feature suite on Lint's separate test graph, and uploaded a 4.44 GB target cache that sibling PR and merge-queue refs cannot restore.

A live audit of 50 recently merged queue entries measured 38m26s p50 and 2h14m03s p95 queue latency. Across 101 merge-group jobs, runner wait was 7m59s p50 and 34m16s p95. Regenerated speculative groups added as much as 2h04m21s while obsolete jobs continued consuming hosted-runner capacity.



## Impact

The targeted feature lane covers 2,718 tests plus the required example check and completed locally in 7m27s, down from 13m38s for the sampled workspace-wide command. The 6m26s man-page feature suite no longer sits on Lint's critical path. The removed MCP server and smoke lane remain absent. Required feature, policy, Rust, Nix, and exact-merge-commit coverage remain in place.

The repository merge-queue ruleset was updated separately from build concurrency 5 to 3, minimum-group wait 5 to 0 minutes, and check timeout 60 to 90 minutes. Squash, ALLGREEN, group sizes, bypass policy, required checks, and deployment requirements were unchanged.

## Validation

- `actionlint -shellcheck= .github/workflows/*.yml`
- `cargo fmt --all -- --check`
- all 10 `xtask` workflow-shape regression tests
- `cargo check --workspace`
- `cargo test --workspace -- --test-threads=1` with isolated `MVM_HOME`
- `cargo test -p xtask --features man`
- `cargo clippy --workspace --all-targets -- -D warnings`
- targeted `test-support` CI command sequence
- build-helper and CI-shape regression tests

## Stack

The prerequisite PR #2012 is merged. This branch is rebased and targets `main`.
