### PR TITLE
Deliver warm-claim grants only to final restored children

### DIFF
--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -28,14 +28,25 @@ use mvm_fs::snapshot_store::FsSnapshotStore;
 use mvm_runtime::backend::AnyBackend;
 use mvm_runtime::checkpoint::CheckpointStore;
 use mvm_runtime::standby_pool::{STANDBY_POOL_TTL, SupervisorStandbyPool, now_unix_secs};
-use mvm_runtime::workload_runner::{ClaimContext, SpawnContext};
+use mvm_runtime::workload_runner::{ChildGrantIssuer, ClaimContext, SpawnContext};
 use sha2::{Digest, Sha256};
 
 use super::Cli;
 use super::env::builder_vm::ensure_default_microvm_image;
 use super::vm::checkpoint::SignedChainAnchor;
 use super::vm::host_signer;
-use mvm_hostd::plan_admission::stash_plan_for_bridge;
+use mvm_hostd::plan_admission::stash_plan_and_mint_verb_grant;
+
+struct HostChildGrantIssuer;
+
+impl ChildGrantIssuer for HostChildGrantIssuer {
+    fn issue(
+        &self,
+        config: &VmStartConfig,
+    ) -> Result<Option<mvm_core::protocol::vm_backend::VerbGrantEnvelope>> {
+        stash_plan_and_mint_verb_grant(config)
+    }
+}
 
 /// Lowercase-hex sha256 of a kernel image — part of the base-compat key.
 pub fn kernel_sha256_hex(kernel: &Path) -> Result<String> {
@@ -363,6 +374,7 @@ where
     let snapshots = FsSnapshotStore::new(mvm_core::config::snapshots_dir())?;
     let anchor = SignedChainAnchor::load()?;
     let registry_path = mvm_runtime::vm::name_registry::registry_path();
+    let grant_issuer = HostChildGrantIssuer;
     let ctx = ClaimContext {
         pool,
         checkpoints: &checkpoints,
@@ -370,6 +382,7 @@ where
         anchor: &anchor,
         parent_checkpoint: &parent_checkpoint,
         registry_path: &registry_path,
+        grant_issuer: Some(&grant_issuer),
     };
     match backend.claim_standby_via_runner(&ctx, &handle, &claim) {
         Ok(vm_id) => {
@@ -507,11 +520,6 @@ pub fn try_warm_claim(
         start_config.plan_json = Some(plan_json.clone());
         start_config.bundle_json = bundle_json.clone();
         start_config.network_policy = cfg.network_policy.clone();
-        if mvm_runtime::catalog::descriptor(backend.kind()).needs_plan_json && !plan_json.is_empty()
-        {
-            stash_plan_for_bridge(&start_config)
-                .with_context(|| format!("stash admitted plan for claimed VM '{}'", handle.id))?;
-        }
         Ok(StandbyClaim {
             start_config: Some(start_config),
             rootfs_path: rootfs.clone(),

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -205,7 +205,10 @@ fn signal_guest_post_restore(name: &str) -> Result<()> {
     );
     signal_post_restore(
         name,
-        &VsockPostRestoreSignal { token },
+        &VsockPostRestoreSignal {
+            token,
+            grant_envelope: None,
+        },
         POST_RESTORE_READY_TIMEOUT,
     )
     .map_err(|e| backend_err(format!("post-restore signal for {name:?}: {e:#}")))?;

--- a/crates/mvm-conformance/tests/steps/warm_claim.rs
+++ b/crates/mvm-conformance/tests/steps/warm_claim.rs
@@ -26,7 +26,8 @@ use mvm_runtime::driver::mock::MockDriver;
 use mvm_runtime::standby_pool::SupervisorStandbyPool;
 use mvm_runtime::workload_runner::claim::parent_rootfs_digest;
 use mvm_runtime::workload_runner::{
-    ClaimContext, EndpointSpawnRequest, EndpointSpawner, RealBrokerRegistrar, WorkloadRunner,
+    ChildGrantIssuer, ClaimContext, EndpointSpawnRequest, EndpointSpawner, RealBrokerRegistrar,
+    WorkloadRunner,
 };
 
 use crate::world::{CliWorld, WarmClaimOutcome, WarmClaimWitness};
@@ -156,6 +157,17 @@ impl EndpointSpawner for WarmClaimSpawner {
     }
 }
 
+struct WarmClaimGrantIssuer;
+
+impl ChildGrantIssuer for WarmClaimGrantIssuer {
+    fn issue(
+        &self,
+        config: &VmStartConfig,
+    ) -> anyhow::Result<Option<mvm_core::protocol::vm_backend::VerbGrantEnvelope>> {
+        mvm_hostd::plan_admission::stash_plan_and_mint_verb_grant(config)
+    }
+}
+
 #[when(expr = "the parent is claimed with an admitted child plan")]
 fn when_claim_parent(world: &mut CliWorld) {
     // `vm_state_dir` / `vm_substitution_endpoint_socket` are `MVM_HOME`-rooted.
@@ -217,6 +229,9 @@ fn when_claim_parent(world: &mut CliWorld) {
         .nonce([9u8; 16])
         .build();
     plan.image.sha256 = parent_digest.clone();
+    plan.agent_verbs = Some(vec![
+        mvm_core::plan::VerbId::new("run-entrypoint").expect("valid verb fixture"),
+    ]);
     let plan_json = serde_json::to_string(&mvm_core::plan::sign_plan(&plan, &key, "host:test"))
         .expect("serialize the signed child plan");
 
@@ -245,6 +260,7 @@ fn when_claim_parent(world: &mut CliWorld) {
     let driver = MockDriver::default();
     let driver_probe = driver.clone();
     let runner = WorkloadRunner::new(driver, WarmClaimSpawner::default(), RealBrokerRegistrar);
+    let grant_issuer = WarmClaimGrantIssuer;
     let ctx = ClaimContext {
         pool,
         checkpoints,
@@ -252,6 +268,7 @@ fn when_claim_parent(world: &mut CliWorld) {
         anchor: &anchor,
         parent_checkpoint: parent_id,
         registry_path: &registry_path,
+        grant_issuer: Some(&grant_issuer),
     };
 
     world.warm_claim_outcome = Some(match runner.claim_standby(&ctx, &handle, &claim) {
@@ -262,6 +279,22 @@ fn when_claim_parent(world: &mut CliWorld) {
                 .iter()
                 .find(|f| f.child_vm_name == child.0)
                 .expect("a successful claim records exactly one fork for its child");
+            let delivered = driver_probe.delivered_child_identities();
+            let grant = delivered
+                .first()
+                .and_then(|identity| identity.grant_envelope.as_ref())
+                .expect("the successful claim delivers its child grant");
+            let host_key_bytes = std::fs::read(
+                mvm_core::config::mvm_keys_dir()
+                    .join(mvm_hostd::audit::host_keypair::PUBLIC_FILENAME),
+            )
+            .expect("read the host signer public key used for the child grant");
+            let host_key = ed25519_dalek::VerifyingKey::from_bytes(
+                &host_key_bytes
+                    .try_into()
+                    .expect("host signer public key is exactly 32 bytes"),
+            )
+            .expect("host signer public key is valid Ed25519");
             WarmClaimOutcome::Claimed(WarmClaimWitness {
                 child_id: child.0.clone(),
                 child_dir_has_sidecar: child_dir
@@ -270,6 +303,17 @@ fn when_claim_parent(world: &mut CliWorld) {
                 child_dir_has_rootfs: child_dir.join("rootfs.ext4").exists(),
                 fork_genid_nonzero: fork.genid.token != [0u8; GENID_BYTES],
                 fork_genid_content_hash_matches_parent: fork.genid.content_hash == parent_digest,
+                post_restore_grant_session_matches_child: grant.grant.session_id == child.0,
+                post_restore_grant_verbs: grant
+                    .grant
+                    .verbs
+                    .iter()
+                    .map(|verb| verb.as_str().to_string())
+                    .collect(),
+                post_restore_grant_verifies_under_host_key: grant
+                    .grant
+                    .verify(&host_key, &child.0, &plan.nonce, plan.valid_from)
+                    .is_ok(),
             })
         }
         Err(e) => WarmClaimOutcome::Refused {
@@ -326,6 +370,24 @@ fn then_fresh_genid(world: &mut CliWorld) {
     assert!(
         witness.fork_genid_content_hash_matches_parent,
         "the fresh token must be bound to the verified parent's content-address"
+    );
+}
+
+#[then(expr = "the child's signed verb grant is delivered with its final identity")]
+fn then_child_grant_matches_final_identity(world: &mut CliWorld) {
+    let witness = claimed_witness(world);
+    assert!(
+        witness.post_restore_grant_session_matches_child,
+        "the post-restore grant must bind the final runner-minted child identity"
+    );
+    assert_eq!(
+        witness.post_restore_grant_verbs,
+        ["run-entrypoint"],
+        "the post-restore grant must carry exactly the admitted verb set"
+    );
+    assert!(
+        witness.post_restore_grant_verifies_under_host_key,
+        "the post-restore grant must verify under the host's trusted signer key"
     );
 }
 

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -201,6 +201,9 @@ pub struct WarmClaimWitness {
     pub child_dir_has_rootfs: bool,
     pub fork_genid_nonzero: bool,
     pub fork_genid_content_hash_matches_parent: bool,
+    pub post_restore_grant_session_matches_child: bool,
+    pub post_restore_grant_verbs: Vec<String>,
+    pub post_restore_grant_verifies_under_host_key: bool,
 }
 
 impl fmt::Debug for CliWorld {

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -350,8 +350,18 @@ pub(crate) fn write_secret_file(path: &std::path::Path, body: &[u8]) -> Result<(
 /// in scope; `microvm` reads it back from disk inside the
 /// `target_os = "linux"` bridge-spawn block.
 pub fn stash_plan_for_bridge(cfg: &mvm_core::vm_backend::VmStartConfig) -> Result<()> {
+    stash_plan_and_mint_verb_grant(cfg).map(|_| ())
+}
+
+/// Persist a VM's admitted plan material and mint its optional signed agent
+/// verb grant, returning the exact envelope written to disk. Warm-restore
+/// callers use the returned value in the post-restore handshake because there
+/// is no new kernel boot at which to consume the sidecar.
+pub fn stash_plan_and_mint_verb_grant(
+    cfg: &mvm_core::vm_backend::VmStartConfig,
+) -> Result<Option<mvm_core::protocol::vm_backend::VerbGrantEnvelope>> {
     let Some(plan_json) = cfg.plan_json.as_deref() else {
-        return Ok(());
+        return Ok(None);
     };
     let state_dir = mvm_core::config::vm_state_dir(&cfg.name);
     std::fs::create_dir_all(&state_dir)
@@ -360,8 +370,7 @@ pub fn stash_plan_for_bridge(cfg: &mvm_core::vm_backend::VmStartConfig) -> Resul
     if let Some(bundle_json) = cfg.bundle_json.as_deref() {
         write_secret_file(&state_dir.join("bundle.json"), bundle_json.as_bytes())?;
     }
-    mint_verb_grant_sidecar(plan_json, &cfg.name, &state_dir)?;
-    Ok(())
+    mint_verb_grant_sidecar(plan_json, &cfg.name, &state_dir)
 }
 
 /// If the plan carries `agent_verbs`, mint a signed `VerbGrantEnvelope` and
@@ -375,7 +384,7 @@ fn mint_verb_grant_sidecar(
     plan_json: &str,
     vm_name: &str,
     state_dir: &std::path::Path,
-) -> Result<()> {
+) -> Result<Option<mvm_core::protocol::vm_backend::VerbGrantEnvelope>> {
     use mvm_core::plan::SignedExecutionPlan;
     use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
 
@@ -396,15 +405,15 @@ fn mint_verb_grant_sidecar(
     // sidecar (grant-less boot), matching the fail-open posture of the
     // other cmdline token producers.
     let Ok(signed) = serde_json::from_str::<SignedExecutionPlan>(plan_json) else {
-        return Ok(());
+        return Ok(None);
     };
     let Ok(plan) = serde_json::from_slice::<ExecutionPlan>(&signed.0.payload) else {
-        return Ok(());
+        return Ok(None);
     };
 
     let Some(verbs) = plan.agent_verbs else {
         // No verb grant requested — grant-less boot, sidecar already removed.
-        return Ok(());
+        return Ok(None);
     };
 
     let keys_dir = mvm_core::config::mvm_keys_dir();
@@ -438,7 +447,7 @@ fn mint_verb_grant_sidecar(
     };
     let envelope_json = serde_json::to_vec(&envelope).context("serialize VerbGrantEnvelope")?;
     write_secret_file(&state_dir.join("verb-grant.json"), &envelope_json)?;
-    Ok(())
+    Ok(Some(envelope))
 }
 
 /// Admission enforcement: every volume about to be attached must be
@@ -1523,7 +1532,9 @@ mod tests {
             ..Default::default()
         };
         populate_audit_substrate(&mut cfg, &admitted, None).expect("populate");
-        stash_plan_for_bridge(&cfg).expect("stash succeeds");
+        let issued = stash_plan_and_mint_verb_grant(&cfg)
+            .expect("stash succeeds")
+            .expect("agent verbs mint a grant");
 
         let grant_path = dir.path().join("vms/vm-verb-grant/verb-grant.json");
         assert!(grant_path.exists(), "verb-grant.json must be written");
@@ -1533,6 +1544,11 @@ mod tests {
         // Parse the envelope and verify the grant under the signer key.
         let raw = std::fs::read(&grant_path).unwrap();
         let envelope: VerbGrantEnvelope = serde_json::from_slice(&raw).unwrap();
+        assert_eq!(
+            serde_json::to_vec(&issued).unwrap(),
+            serde_json::to_vec(&envelope).unwrap(),
+            "the returned envelope is exactly the sidecar payload"
+        );
         assert!(!envelope.pubkey_hex.is_empty(), "pubkey_hex must be set");
         assert_eq!(
             envelope.plan_nonce_hex,

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -1925,6 +1925,7 @@ mod tests {
                     anchor: &self.anchor,
                     parent_checkpoint: &self.parent,
                     registry_path: &self.registry_path,
+                    grant_issuer: None,
                 }
             }
         }

--- a/crates/mvm-runtime/src/driver/mock.rs
+++ b/crates/mvm-runtime/src/driver/mock.rs
@@ -16,6 +16,7 @@ use mvm_core::vm_backend::{
 };
 
 use mvm_core::crypto::vmgenid::{GENID_BYTES, GenerationToken};
+use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
 
 use crate::driver::spec::{VmmSpec, VsockPort};
 use crate::driver::traits::{
@@ -31,8 +32,16 @@ type GuestEnds = Arc<Mutex<HashMap<(String, u32), UnixStream>>>;
 /// transport error takes); `Some` scripts the flags a live agent would report.
 type ScriptedChildIdentity = Option<PostRestoreOutcome>;
 
-/// One `(child_vm_name, token)` pair `deliver_child_identity` was handed.
-type DeliveredIdentity = (String, [u8; GENID_BYTES]);
+/// One post-restore child identity delivery recorded by the mock driver.
+#[derive(Clone, Debug)]
+pub struct DeliveredChildIdentity {
+    /// Final runner-minted identity of the restored child.
+    pub child_vm_name: String,
+    /// Fresh VMGenID token delivered to the child.
+    pub token: [u8; GENID_BYTES],
+    /// Optional signed agent authority delivered in the same handshake.
+    pub grant_envelope: Option<VerbGrantEnvelope>,
+}
 
 /// A clean post-restore answer: the guest acknowledged, rotated its generation
 /// identity off the delivered token, and took the host's wall clock. The
@@ -79,9 +88,9 @@ pub struct MockDriver {
     /// child, so a test can drive the claim's fresh-identity gate — including
     /// the refusal arms — with no live guest.
     child_identity: ScriptedChildIdentity,
-    /// Every `(child, token)` this driver was asked to deliver, so a test can
-    /// prove the claim handed the guest the same token it forked with.
-    delivered_identities: Arc<Mutex<Vec<DeliveredIdentity>>>,
+    /// Every identity and grant this driver was asked to deliver, so a test can
+    /// prove the claim handed the guest the same values it minted.
+    delivered_identities: Arc<Mutex<Vec<DeliveredChildIdentity>>>,
     /// Names of the VMs killed through any handle this driver produced, so a
     /// test can prove a refused claim actually tore its child down instead of
     /// leaving it resumed.
@@ -165,9 +174,8 @@ impl MockDriver {
         self
     }
 
-    /// Every `(child_vm_name, token)` handed to `deliver_child_identity`, in
-    /// order.
-    pub fn delivered_child_identities(&self) -> Vec<DeliveredIdentity> {
+    /// Every identity and grant handed to `deliver_child_identity`, in order.
+    pub fn delivered_child_identities(&self) -> Vec<DeliveredChildIdentity> {
         self.delivered_identities.lock().unwrap().clone()
     }
 
@@ -292,11 +300,16 @@ impl VmmDriver for MockDriver {
         &self,
         child_vm_name: &str,
         token: [u8; GENID_BYTES],
+        grant_envelope: Option<VerbGrantEnvelope>,
     ) -> Result<PostRestoreOutcome> {
         self.delivered_identities
             .lock()
             .unwrap()
-            .push((child_vm_name.to_string(), token));
+            .push(DeliveredChildIdentity {
+                child_vm_name: child_vm_name.to_string(),
+                token,
+                grant_envelope,
+            });
         self.child_identity.clone().ok_or_else(|| {
             anyhow!("mock guest agent for '{child_vm_name}' did not answer the post-restore signal")
         })

--- a/crates/mvm-runtime/src/driver/traits.rs
+++ b/crates/mvm-runtime/src/driver/traits.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use mvm_core::crypto::vmgenid::{GENID_BYTES, GenerationToken};
+use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
 use mvm_core::vm_backend::{
     BackendKind, BackendSecurityProfile, GuestChannelInfo, SnapshotCapability, StandbyError,
     StandbyHandle, StandbySpec, VmCapabilities, VmExitStatus, VmId, VmStatus,
@@ -147,10 +148,11 @@ pub trait VmmDriver: Send + Sync {
         })
     }
 
-    /// Hand a freshly forked child its own generation token and report, verbatim,
-    /// what the guest agent says it did with it — whether it acknowledged the
-    /// signal, rotated its generation identity (reseeding its CSPRNG off the
-    /// parent's cloned state), and resynchronized its wall clock off the host's.
+    /// Hand a freshly forked child its generation token and optional signed verb
+    /// grant, then report verbatim what the guest agent says it did with them —
+    /// whether it acknowledged the signal, rotated its generation identity
+    /// (reseeding its CSPRNG off the parent's cloned state), and resynchronized
+    /// its wall clock off the host's.
     ///
     /// The reported flags are the guest's own claims, not a verdict: judging them
     /// is the role layer's job, so a driver never decides whether a child is
@@ -165,10 +167,14 @@ pub trait VmmDriver: Send + Sync {
         &self,
         child_vm_name: &str,
         token: [u8; GENID_BYTES],
+        grant_envelope: Option<VerbGrantEnvelope>,
     ) -> Result<PostRestoreOutcome> {
         crate::vm::instance_snapshot::signal_post_restore(
             child_vm_name,
-            &crate::vm::instance_snapshot::VsockPostRestoreSignal { token },
+            &crate::vm::instance_snapshot::VsockPostRestoreSignal {
+                token,
+                grant_envelope,
+            },
             crate::vm::instance_snapshot::POST_RESTORE_READY_TIMEOUT,
         )
     }

--- a/crates/mvm-runtime/src/microvm/snapshot.rs
+++ b/crates/mvm-runtime/src/microvm/snapshot.rs
@@ -116,7 +116,10 @@ pub fn warm_restore_instance_from_path(
     // reachable; a zero token's honest outcome is `NotRotated`, not `Rotated`.
     let reseed = match signal_post_restore(
         name,
-        &VsockPostRestoreSignal { token },
+        &VsockPostRestoreSignal {
+            token,
+            grant_envelope: None,
+        },
         POST_RESTORE_READY_TIMEOUT,
     ) {
         Ok(outcome) if outcome.reseeded => mvm_core::vm_backend::ReseedStatus::Rotated,

--- a/crates/mvm-runtime/src/vm/instance_snapshot.rs
+++ b/crates/mvm-runtime/src/vm/instance_snapshot.rs
@@ -558,6 +558,19 @@ pub struct VsockPostRestoreSignal {
     /// it rotates its VMGenID. Random per resume; an all-zero token requests
     /// no rotation (template restore).
     pub token: [u8; mvm_core::crypto::vmgenid::GENID_BYTES],
+    /// Signed capability to pin while the restored guest adopts its fresh
+    /// identity. Ordinary resume paths carry no new grant.
+    pub grant_envelope: Option<mvm_core::protocol::vm_backend::VerbGrantEnvelope>,
+}
+
+impl VsockPostRestoreSignal {
+    fn request(&self, host_epoch_secs: u64) -> mvm_agentd::vsock::GuestRequest {
+        mvm_agentd::vsock::GuestRequest::PostRestore {
+            token: self.token,
+            host_epoch_secs: Some(host_epoch_secs),
+            grant_envelope: self.grant_envelope.clone(),
+        }
+    }
 }
 
 impl PostRestoreSignal for VsockPostRestoreSignal {
@@ -571,7 +584,7 @@ impl PostRestoreSignal for VsockPostRestoreSignal {
     }
 
     fn post_restore(&self, vm_name: &str) -> Result<PostRestoreOutcome> {
-        use mvm_agentd::vsock::{GUEST_AGENT_PORT, GuestRequest, GuestResponse, call_unary};
+        use mvm_agentd::vsock::{GUEST_AGENT_PORT, GuestResponse, call_unary};
         let transport = crate::vsock_transport::for_vm(vm_name)
             .with_context(|| format!("resolving vsock transport for {vm_name}"))?;
         let mut stream = transport
@@ -580,19 +593,11 @@ impl PostRestoreSignal for VsockPostRestoreSignal {
         // `call_unary` enforces PostRestore's response contract — the agent
         // `Error` / off-contract cases surface as a typed `RpcError`, so the
         // only `Ok` variant here is the contracted `PostRestoreAck`.
-        match call_unary(
-            &mut stream,
-            &GuestRequest::PostRestore {
-                token: self.token,
-                host_epoch_secs: Some(
-                    std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .context("reading host wall clock for post-restore")?
-                        .as_secs(),
-                ),
-                grant_envelope: None,
-            },
-        )? {
+        let host_epoch_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .context("reading host wall clock for post-restore")?
+            .as_secs();
+        match call_unary(&mut stream, &self.request(host_epoch_secs))? {
             GuestResponse::PostRestoreAck {
                 success,
                 detail,
@@ -1021,6 +1026,46 @@ mod tests {
     use super::*;
     use mvm_core::util::test_env::TestEnv;
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn post_restore_request_carries_the_child_grant_envelope() {
+        use mvm_core::plan::{Nonce, VerbGrant, VerbId};
+        use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
+
+        let nonce = Nonce::from_bytes([5u8; 16]);
+        let envelope = VerbGrantEnvelope {
+            pubkey_hex: "ab".repeat(32),
+            plan_nonce_hex: nonce.as_hex().to_string(),
+            predecessor_session_id: None,
+            predecessor_plan_nonce_hex: None,
+            grant: VerbGrant {
+                session_id: "child-final".into(),
+                plan_nonce: nonce,
+                not_after: mvm_core::time::parse_iso8601("2099-01-01T00:00:00Z").unwrap(),
+                verbs: vec![VerbId::new("run-entrypoint").unwrap()],
+                sig: vec![7u8; 64],
+            },
+        };
+        let signal = VsockPostRestoreSignal {
+            token: [9u8; mvm_core::crypto::vmgenid::GENID_BYTES],
+            grant_envelope: Some(envelope),
+        };
+
+        let mvm_agentd::vsock::GuestRequest::PostRestore {
+            token,
+            host_epoch_secs,
+            grant_envelope,
+        } = signal.request(42)
+        else {
+            panic!("post-restore signal built the wrong request variant");
+        };
+        assert_eq!(token, [9u8; mvm_core::crypto::vmgenid::GENID_BYTES]);
+        assert_eq!(host_epoch_secs, Some(42));
+        assert_eq!(
+            grant_envelope.expect("grant is carried").grant.session_id,
+            "child-final"
+        );
+    }
 
     /// Run a closure with `MVM_HOME` overridden to a tempdir
     /// so each test gets an isolated `~/.mvm/instances/...` tree.

--- a/crates/mvm-runtime/src/workload_runner/child_grant.rs
+++ b/crates/mvm-runtime/src/workload_runner/child_grant.rs
@@ -1,0 +1,301 @@
+//! Signed child capability issuance at the warm-restore boundary.
+//!
+//! The runner owns the final child identity, while the host admission layer
+//! owns the signing key. This seam lets the runner request a grant only after
+//! it has minted that identity, then validates every plan-derived field before
+//! the envelope crosses into the restored guest.
+
+use anyhow::Result;
+use mvm_core::plan::ExecutionPlan;
+use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
+use mvm_core::vm_backend::VmStartConfig;
+
+/// Host authority that persists the admitted child plan and signs its optional
+/// agent-verb grant.
+pub trait ChildGrantIssuer: Send + Sync {
+    /// Persist the child's admitted launch material and return a signed grant
+    /// when the plan carries an agent-verb allow-list.
+    fn issue(&self, config: &VmStartConfig) -> Result<Option<VerbGrantEnvelope>>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ChildGrantError {
+    #[error("the admitted plan requests agent verbs but no child grant issuer is configured")]
+    IssuerRequired,
+    #[error("child grant issuer failed: {0}")]
+    Issue(#[source] anyhow::Error),
+    #[error("the admitted plan requests agent verbs but the issuer returned no grant")]
+    GrantRequired,
+    #[error("the admitted plan requests no agent verbs but the issuer returned a grant")]
+    UnexpectedGrant,
+    #[error("child grant session id does not match the final child identity")]
+    SessionMismatch,
+    #[error("child grant envelope nonce does not match the admitted plan")]
+    EnvelopeNonceMismatch,
+    #[error("child grant nonce does not match the admitted plan")]
+    GrantNonceMismatch,
+    #[error("child grant expiry does not match the admitted plan")]
+    ExpiryMismatch,
+    #[error("child grant verbs do not match the admitted plan")]
+    VerbsMismatch,
+    #[error("fresh child grant unexpectedly carries predecessor lineage")]
+    UnexpectedPredecessor,
+    #[error("child grant public key is not a 32-byte lowercase hex key")]
+    PublicKeyMalformed,
+    #[error("child grant signature is not 64 bytes")]
+    SignatureMalformed,
+}
+
+/// Issue and structurally bind the optional child grant to the admitted plan
+/// and the runner-minted final identity.
+pub(crate) fn issue_child_grant(
+    plan: &ExecutionPlan,
+    config: &VmStartConfig,
+    issuer: Option<&dyn ChildGrantIssuer>,
+) -> std::result::Result<Option<VerbGrantEnvelope>, ChildGrantError> {
+    let Some(issuer) = issuer else {
+        return if plan.agent_verbs.is_some() {
+            Err(ChildGrantError::IssuerRequired)
+        } else {
+            Ok(None)
+        };
+    };
+    let issued = issuer.issue(config).map_err(ChildGrantError::Issue)?;
+
+    let Some(expected_verbs) = plan.agent_verbs.as_ref() else {
+        return if issued.is_some() {
+            Err(ChildGrantError::UnexpectedGrant)
+        } else {
+            Ok(None)
+        };
+    };
+    let envelope = issued.ok_or(ChildGrantError::GrantRequired)?;
+
+    if envelope.grant.session_id != config.name {
+        return Err(ChildGrantError::SessionMismatch);
+    }
+    if envelope.plan_nonce_hex != plan.nonce.as_hex() {
+        return Err(ChildGrantError::EnvelopeNonceMismatch);
+    }
+    if envelope.grant.plan_nonce != plan.nonce {
+        return Err(ChildGrantError::GrantNonceMismatch);
+    }
+    if envelope.grant.not_after != plan.valid_until {
+        return Err(ChildGrantError::ExpiryMismatch);
+    }
+    if &envelope.grant.verbs != expected_verbs {
+        return Err(ChildGrantError::VerbsMismatch);
+    }
+    if envelope.predecessor_session_id.is_some() || envelope.predecessor_plan_nonce_hex.is_some() {
+        return Err(ChildGrantError::UnexpectedPredecessor);
+    }
+    if envelope.pubkey_hex.len() != 64
+        || !envelope
+            .pubkey_hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(ChildGrantError::PublicKeyMalformed);
+    }
+    if envelope.grant.sig.len() != 64 {
+        return Err(ChildGrantError::SignatureMalformed);
+    }
+
+    Ok(Some(envelope))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use anyhow::Result;
+    use mvm_core::plan::{ExecutionPlan, VerbGrant, VerbId};
+    use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
+    use mvm_core::vm_backend::VmStartConfig;
+
+    use super::{ChildGrantError, ChildGrantIssuer, issue_child_grant};
+
+    struct FixedIssuer {
+        envelope: Option<VerbGrantEnvelope>,
+        seen_names: Mutex<Vec<String>>,
+    }
+
+    impl FixedIssuer {
+        fn returning(envelope: Option<VerbGrantEnvelope>) -> Self {
+            Self {
+                envelope,
+                seen_names: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ChildGrantIssuer for FixedIssuer {
+        fn issue(&self, config: &VmStartConfig) -> Result<Option<VerbGrantEnvelope>> {
+            self.seen_names.lock().unwrap().push(config.name.clone());
+            Ok(self.envelope.clone())
+        }
+    }
+
+    fn plan_with_verbs() -> ExecutionPlan {
+        let mut plan = mvm_core::plan::test_support::PlanFixture::new()
+            .nonce([7u8; 16])
+            .build();
+        plan.agent_verbs = Some(vec![VerbId::new("run-entrypoint").unwrap()]);
+        plan
+    }
+
+    fn matching_envelope(plan: &ExecutionPlan, child: &str) -> VerbGrantEnvelope {
+        VerbGrantEnvelope {
+            pubkey_hex: "ab".repeat(32),
+            plan_nonce_hex: plan.nonce.as_hex().to_string(),
+            predecessor_session_id: None,
+            predecessor_plan_nonce_hex: None,
+            grant: VerbGrant {
+                session_id: child.to_string(),
+                plan_nonce: plan.nonce.clone(),
+                not_after: plan.valid_until,
+                verbs: plan.agent_verbs.clone().unwrap(),
+                sig: vec![3u8; 64],
+            },
+        }
+    }
+
+    #[test]
+    fn matching_grant_is_issued_for_the_final_child_identity() {
+        let plan = plan_with_verbs();
+        let config = VmStartConfig {
+            name: "child-final".into(),
+            ..Default::default()
+        };
+        let issuer = FixedIssuer::returning(Some(matching_envelope(&plan, &config.name)));
+
+        let envelope = issue_child_grant(&plan, &config, Some(&issuer))
+            .expect("matching grant is accepted")
+            .expect("plan requests a grant");
+
+        assert_eq!(envelope.grant.session_id, "child-final");
+        assert_eq!(
+            issuer.seen_names.lock().unwrap().as_slice(),
+            ["child-final"]
+        );
+    }
+
+    #[test]
+    fn grant_bearing_plan_requires_an_issuer_and_an_envelope() {
+        let plan = plan_with_verbs();
+        let config = VmStartConfig {
+            name: "child-final".into(),
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            issue_child_grant(&plan, &config, None),
+            Err(ChildGrantError::IssuerRequired)
+        ));
+        let issuer = FixedIssuer::returning(None);
+        assert!(matches!(
+            issue_child_grant(&plan, &config, Some(&issuer)),
+            Err(ChildGrantError::GrantRequired)
+        ));
+    }
+
+    #[test]
+    fn grant_is_rejected_when_its_child_or_plan_binding_differs() {
+        let plan = plan_with_verbs();
+        let config = VmStartConfig {
+            name: "child-final".into(),
+            ..Default::default()
+        };
+
+        let mut wrong_child = matching_envelope(&plan, "child-other");
+        let issuer = FixedIssuer::returning(Some(wrong_child.clone()));
+        assert!(matches!(
+            issue_child_grant(&plan, &config, Some(&issuer)),
+            Err(ChildGrantError::SessionMismatch)
+        ));
+
+        wrong_child.grant.session_id = config.name.clone();
+        wrong_child.plan_nonce_hex = "00".repeat(16);
+        let issuer = FixedIssuer::returning(Some(wrong_child));
+        assert!(matches!(
+            issue_child_grant(&plan, &config, Some(&issuer)),
+            Err(ChildGrantError::EnvelopeNonceMismatch)
+        ));
+
+        let mut wrong_verbs = matching_envelope(&plan, &config.name);
+        wrong_verbs.grant.verbs = vec![VerbId::new("ping").unwrap()];
+        let issuer = FixedIssuer::returning(Some(wrong_verbs));
+        assert!(matches!(
+            issue_child_grant(&plan, &config, Some(&issuer)),
+            Err(ChildGrantError::VerbsMismatch)
+        ));
+    }
+
+    #[test]
+    fn grant_is_rejected_when_any_signed_security_field_is_malformed() {
+        let plan = plan_with_verbs();
+        let config = VmStartConfig {
+            name: "child-final".into(),
+            ..Default::default()
+        };
+
+        let mut wrong_nonce = matching_envelope(&plan, &config.name);
+        wrong_nonce.grant.plan_nonce = mvm_core::plan::Nonce::from_bytes([8u8; 16]);
+        let issuer = FixedIssuer::returning(Some(wrong_nonce));
+        assert!(matches!(
+            issue_child_grant(&plan, &config, Some(&issuer)),
+            Err(ChildGrantError::GrantNonceMismatch)
+        ));
+
+        let mut wrong_expiry = matching_envelope(&plan, &config.name);
+        wrong_expiry.grant.not_after += chrono::Duration::seconds(1);
+        let issuer = FixedIssuer::returning(Some(wrong_expiry));
+        assert!(matches!(
+            issue_child_grant(&plan, &config, Some(&issuer)),
+            Err(ChildGrantError::ExpiryMismatch)
+        ));
+
+        let mut predecessor = matching_envelope(&plan, &config.name);
+        predecessor.predecessor_session_id = Some("parent".into());
+        let issuer = FixedIssuer::returning(Some(predecessor));
+        assert!(matches!(
+            issue_child_grant(&plan, &config, Some(&issuer)),
+            Err(ChildGrantError::UnexpectedPredecessor)
+        ));
+
+        let mut bad_key = matching_envelope(&plan, &config.name);
+        bad_key.pubkey_hex = "AB".repeat(32);
+        let issuer = FixedIssuer::returning(Some(bad_key));
+        assert!(matches!(
+            issue_child_grant(&plan, &config, Some(&issuer)),
+            Err(ChildGrantError::PublicKeyMalformed)
+        ));
+
+        let mut bad_signature = matching_envelope(&plan, &config.name);
+        bad_signature.grant.sig.pop();
+        let issuer = FixedIssuer::returning(Some(bad_signature));
+        assert!(matches!(
+            issue_child_grant(&plan, &config, Some(&issuer)),
+            Err(ChildGrantError::SignatureMalformed)
+        ));
+    }
+
+    #[test]
+    fn grantless_plan_rejects_an_unexpected_issued_grant() {
+        let plan = mvm_core::plan::test_support::PlanFixture::new().build();
+        let config = VmStartConfig {
+            name: "child-final".into(),
+            ..Default::default()
+        };
+        let mut envelope = matching_envelope(&plan_with_verbs(), &config.name);
+        envelope.grant.plan_nonce = plan.nonce.clone();
+        envelope.plan_nonce_hex = plan.nonce.as_hex().to_string();
+        envelope.grant.not_after = plan.valid_until;
+        let issuer = FixedIssuer::returning(Some(envelope));
+
+        assert!(matches!(
+            issue_child_grant(&plan, &config, Some(&issuer)),
+            Err(ChildGrantError::UnexpectedGrant)
+        ));
+    }
+}

--- a/crates/mvm-runtime/src/workload_runner/mod.rs
+++ b/crates/mvm-runtime/src/workload_runner/mod.rs
@@ -4,12 +4,14 @@
 //! audit. This module holds the pure, driver-independent pieces of that mapping
 //! so they are unit-testable without a hypervisor.
 
+mod child_grant;
 pub mod claim;
 pub(crate) mod cmdline;
 pub mod runner;
 pub mod spec_map;
 pub mod standby_boot;
 
+pub use child_grant::ChildGrantIssuer;
 pub use runner::{
     BrokerGuard, BrokerRegisterRequest, BrokerRegistrar, ClaimContext, EndpointSpawnRequest,
     EndpointSpawner, RealBrokerRegistrar, RealEndpointSpawner, SpawnContext, WorkloadLaunchInputs,

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -13,9 +13,10 @@ use mvm_agentd::vsock::BROKER_PORT;
 use mvm_core::checkpoint::{CheckpointId, CheckpointMeta};
 use mvm_core::config::{vm_state_dir, vm_substitution_endpoint_socket, vms_dir};
 use mvm_core::crypto::vmgenid::fresh_generation_token;
-use mvm_core::plan::SecretBinding;
+use mvm_core::plan::{ExecutionPlan, SecretBinding};
 use mvm_core::policy::RedactionPolicy;
 use mvm_core::policy::network_policy::NetworkPolicy;
+use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
 use mvm_core::vm_backend::{
     BackendKind, BackendSecurityProfile, GuestChannelInfo, StandbyClaim, StandbyError,
     StandbyHandle, StandbySpec, StartMode, VmBackend, VmCapabilities, VmExitStatus, VmId, VmInfo,
@@ -38,6 +39,7 @@ use crate::vm::instance_snapshot::PostRestoreOutcome;
 use crate::vm::name_registry::{VmNameRegistry, acquire_registry_lock, generate_vm_name};
 use crate::warm_snapshot::materialize_child_from_parent;
 use crate::workload_backend::{EgressSubstitutionTransport, WorkloadBackend};
+use crate::workload_runner::child_grant::{ChildGrantIssuer, issue_child_grant};
 use crate::workload_runner::claim::{
     ClaimGuards, ClaimRefusal, EndpointSpawnInputs, bind_plan_to_parent, parent_rootfs_digest,
 };
@@ -275,6 +277,10 @@ pub struct ClaimContext<'a> {
     /// VM name registry file whose sibling lock serializes the parent reserve
     /// and the child-name mint, so two claims never double-claim one parent.
     pub registry_path: &'a Path,
+    /// Host signing authority invoked only after the runner has minted the
+    /// final child identity. Grant-less test contexts may omit it; a plan that
+    /// requests agent verbs fails closed when it is absent.
+    pub grant_issuer: Option<&'a dyn ChildGrantIssuer>,
 }
 
 /// The warm-pool substrate a spawn-and-capture needs beyond the runner's
@@ -422,8 +428,8 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
 
         // (2) + (4) Bind the admitted plan's image digest to the verified parent.
         // A missing plan or a digest mismatch refuses before any child side effect.
-        let plan_image = claim_plan_image_sha256(claim)?;
-        bind_plan_to_parent(&plan_image, &parent).map_err(refuse)?;
+        let plan = claim_plan(claim)?;
+        bind_plan_to_parent(&plan.image.sha256, &parent).map_err(refuse)?;
 
         // (6a) Fresh, registry-unique identity for the child.
         let child = fresh_child_id(ctx)?;
@@ -450,6 +456,9 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
         guards
             .admit_overlay_contract(&child_cfg)
             .map_err(|e| StandbyError::ClaimFailed(format!("overlay contract: {e}")))?;
+
+        let grant_envelope = issue_child_grant(&plan, &child_cfg, ctx.grant_issuer)
+            .map_err(|e| StandbyError::ClaimFailed(format!("issue child verb grant: {e}")))?;
 
         let secrets =
             mvm_core::plan::secrets_from_signed_json(&claim.plan_json).unwrap_or_default();
@@ -513,7 +522,7 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
         // of one parent that skipped this would draw identical randomness, which
         // is the whole reason a warm child needs a fresh identity — so a child
         // that cannot prove it is never admitted.
-        if let Err(refusal) = self.take_fresh_child_identity(&child.0, token) {
+        if let Err(refusal) = self.take_fresh_child_identity(&child.0, token, grant_envelope) {
             // The child is live and still carrying its parent's random state.
             // Unwinding alone would leave running exactly the VM this refusal
             // exists to prevent, so stop it before returning.
@@ -536,10 +545,11 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
         &self,
         child_vm_name: &str,
         token: [u8; mvm_core::crypto::vmgenid::GENID_BYTES],
+        grant_envelope: Option<VerbGrantEnvelope>,
     ) -> std::result::Result<(), StandbyError> {
         let outcome = self
             .driver
-            .deliver_child_identity(child_vm_name, token)
+            .deliver_child_identity(child_vm_name, token, grant_envelope)
             .map_err(|e| {
                 StandbyError::ClaimFailed(format!(
                     "forked child '{child_vm_name}' never answered the post-restore identity \
@@ -843,14 +853,14 @@ fn reserve_and_verify_parent(
     Ok(parent)
 }
 
-/// The admitted plan's bound image digest (`plan.image.sha256`) from the claim.
+/// The admitted plan from the claim.
 /// The runner does not re-verify the signature — the host admitted the plan and
-/// the supervisor re-verifies at attach — it only reads the digest it must bind
-/// to the parent. A claim carrying no parseable plan fails closed.
-fn claim_plan_image_sha256(claim: &StandbyClaim) -> std::result::Result<String, StandbyError> {
-    let plan = mvm_core::plan::plan_from_admitted_json(&claim.plan_json)
-        .map_err(|_| refuse(ClaimRefusal::PlanMissing))?;
-    Ok(plan.image.sha256)
+/// the supervisor re-verifies at attach. The runner reads the image binding and
+/// child-grant fields it must enforce. A claim carrying no parseable plan fails
+/// closed.
+fn claim_plan(claim: &StandbyClaim) -> std::result::Result<ExecutionPlan, StandbyError> {
+    mvm_core::plan::plan_from_admitted_json(&claim.plan_json)
+        .map_err(|_| refuse(ClaimRefusal::PlanMissing))
 }
 
 /// How many times to redraw a fresh child name before giving up. A collision is
@@ -893,6 +903,8 @@ fn child_start_config(claim: &StandbyClaim, child: &VmId, child_dir: &Path) -> V
     cfg.rootfs_path = child_dir.join("rootfs.ext4").to_string_lossy().into_owned();
     cfg.tenant_id = Some(claim.tenant_id.clone());
     cfg.network_policy = claim.network_policy.clone();
+    cfg.plan_json = Some(claim.plan_json.clone());
+    cfg.bundle_json = claim.bundle_json.clone();
     cfg
 }
 
@@ -2776,12 +2788,49 @@ mod tests {
     /// parent's own verified rootfs content-address (claim-8 authority), the way
     /// the CLI mints it before handing the runner the claim.
     fn signed_child_plan_json(image_sha256: &str) -> String {
+        signed_child_plan_json_with_verbs(image_sha256, None)
+    }
+
+    fn signed_child_plan_json_with_verbs(
+        image_sha256: &str,
+        agent_verbs: Option<Vec<VerbId>>,
+    ) -> String {
         let mut plan = mvm_core::plan::test_support::PlanFixture::new()
             .tenant("tenant-x")
             .build();
         plan.image.sha256 = image_sha256.to_string();
+        plan.agent_verbs = agent_verbs;
         let key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
         serde_json::to_string(&mvm_core::plan::sign_plan(&plan, &key, "host:test")).unwrap()
+    }
+
+    #[derive(Default)]
+    struct TestChildGrantIssuer {
+        seen_child: Mutex<Option<String>>,
+    }
+
+    impl ChildGrantIssuer for TestChildGrantIssuer {
+        fn issue(&self, config: &VmStartConfig) -> Result<Option<VerbGrantEnvelope>> {
+            let plan_json = config.plan_json.as_deref().context("child plan missing")?;
+            let plan = mvm_core::plan::plan_from_admitted_json(plan_json)?;
+            let Some(verbs) = plan.agent_verbs else {
+                return Ok(None);
+            };
+            *self.seen_child.lock().unwrap() = Some(config.name.clone());
+            Ok(Some(VerbGrantEnvelope {
+                pubkey_hex: "ab".repeat(32),
+                plan_nonce_hex: plan.nonce.as_hex().to_string(),
+                predecessor_session_id: None,
+                predecessor_plan_nonce_hex: None,
+                grant: mvm_core::plan::VerbGrant {
+                    session_id: config.name.clone(),
+                    plan_nonce: plan.nonce,
+                    not_after: plan.valid_until,
+                    verbs,
+                    sig: vec![3u8; 64],
+                },
+            }))
+        }
     }
 
     fn idle_parent_handle(id: &str, control_socket: &Path) -> StandbyHandle {
@@ -2848,7 +2897,10 @@ mod tests {
 
         let claim = admitted_child_claim(
             &src.path().join("rootfs.ext4"),
-            signed_child_plan_json(&parent_digest),
+            signed_child_plan_json_with_verbs(
+                &parent_digest,
+                Some(vec![VerbId::new("run-entrypoint").unwrap()]),
+            ),
         );
 
         let runner = WorkloadRunner::new(
@@ -2856,6 +2908,7 @@ mod tests {
             KeyingSpawner::default(),
             RecordingBrokerRegistrar::new(),
         );
+        let grant_issuer = TestChildGrantIssuer::default();
         let ctx = ClaimContext {
             pool: &pool,
             checkpoints: &checkpoints,
@@ -2863,6 +2916,7 @@ mod tests {
             anchor: &anchor,
             parent_checkpoint: &parent_id,
             registry_path: &registry_path,
+            grant_issuer: Some(&grant_issuer),
         };
 
         let child = runner.claim_standby(&ctx, &handle, &claim).expect("claim");
@@ -2907,10 +2961,22 @@ mod tests {
         // The fork alone only resumes the child on the parent's saved memory, so
         // the claim also handed that same token to the child's guest agent and
         // committed only once the guest reported it had rotated onto it.
+        let delivered = runner.driver.delivered_child_identities();
+        assert_eq!(delivered.len(), 1);
+        assert_eq!(delivered[0].child_vm_name, child.0);
+        assert_eq!(delivered[0].token, forks[0].genid.token);
+        let delivered_grant = delivered[0]
+            .grant_envelope
+            .as_ref()
+            .expect("the child grant rides the post-restore handshake");
+        assert_eq!(delivered_grant.grant.session_id, child.0);
         assert_eq!(
-            runner.driver.delivered_child_identities(),
-            vec![(child.0.clone(), forks[0].genid.token)],
-            "the claim delivers the forked token to the child's own guest agent, exactly once"
+            delivered_grant.grant.verbs,
+            vec![VerbId::new("run-entrypoint").unwrap()]
+        );
+        assert_eq!(
+            grant_issuer.seen_child.lock().unwrap().as_deref(),
+            Some(child.0.as_str())
         );
 
         // The runner-side overlay-contract gate ran on the materialized child:
@@ -2991,6 +3057,7 @@ mod tests {
             anchor: &anchor,
             parent_checkpoint: &parent_id,
             registry_path: &registry_path,
+            grant_issuer: None,
         };
 
         runner
@@ -3115,6 +3182,7 @@ mod tests {
                     anchor: &anchor,
                     parent_checkpoint: &parent_id,
                     registry_path: &registry_path,
+                    grant_issuer: None,
                 },
                 &handle,
                 &claim,
@@ -3235,6 +3303,14 @@ mod tests {
     /// claim touches (MVM_HOME, stores, pool, registry) is fresh per call, so the
     /// handshake outcomes are independent of each other.
     fn claim_with_scripted_handshake(driver: MockDriver) -> HandshakeClaimOutcome {
+        claim_with_scripted_handshake_and_grant(driver, None, None)
+    }
+
+    fn claim_with_scripted_handshake_and_grant(
+        driver: MockDriver,
+        agent_verbs: Option<Vec<VerbId>>,
+        grant_issuer: Option<&dyn ChildGrantIssuer>,
+    ) -> HandshakeClaimOutcome {
         let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
@@ -3255,7 +3331,7 @@ mod tests {
         let anchor = ClaimTestAnchor::audited(&parent_meta);
         let claim = admitted_child_claim(
             &src.path().join("rootfs.ext4"),
-            signed_child_plan_json(&parent_digest),
+            signed_child_plan_json_with_verbs(&parent_digest, agent_verbs),
         );
 
         let probe = driver.clone();
@@ -3271,6 +3347,7 @@ mod tests {
             anchor: &anchor,
             parent_checkpoint: &parent_id,
             registry_path: &registry_path,
+            grant_issuer,
         };
 
         let result = runner.claim_standby(&ctx, &handle, &claim);
@@ -3280,6 +3357,24 @@ mod tests {
             parent_state: pool.load("warm-parent").unwrap().state,
             orphan_child_dirs: orphan_child_dirs(),
         }
+    }
+
+    #[test]
+    fn claim_refuses_a_grant_bearing_plan_before_fork_when_no_issuer_is_configured() {
+        let out = claim_with_scripted_handshake_and_grant(
+            MockDriver::default(),
+            Some(vec![VerbId::new("run-entrypoint").unwrap()]),
+            None,
+        );
+
+        let err = out.result.expect_err("the missing issuer must fail closed");
+        assert!(err.to_string().contains("no child grant issuer"));
+        assert!(
+            out.driver.forked_children().is_empty(),
+            "grant issuance is checked before a child is resumed"
+        );
+        assert_eq!(out.parent_state, StandbyState::Idle);
+        assert_eq!(out.orphan_child_dirs, 0);
     }
 
     /// A forked child comes back resumed on its parent's saved memory, so until
@@ -3360,9 +3455,9 @@ mod tests {
         let delivered = out.driver.delivered_child_identities();
         let forks = out.driver.forked_children();
         assert_eq!(delivered.len(), 1, "the token is delivered exactly once");
-        assert_eq!(delivered[0].0, forks[0].child_vm_name);
+        assert_eq!(delivered[0].child_vm_name, forks[0].child_vm_name);
         assert_eq!(
-            delivered[0].1, forks[0].genid.token,
+            delivered[0].token, forks[0].genid.token,
             "the delivered token is the one the fork minted"
         );
     }
@@ -3451,6 +3546,7 @@ mod tests {
             anchor: &anchor,
             parent_checkpoint: &parent_id,
             registry_path: &registry_path,
+            grant_issuer: None,
         };
 
         let err = runner
@@ -3520,6 +3616,7 @@ mod tests {
             anchor: &anchor,
             parent_checkpoint: &parent_id,
             registry_path: &registry_path,
+            grant_issuer: None,
         };
 
         let err = runner
@@ -3588,6 +3685,7 @@ mod tests {
             anchor: &anchor,
             parent_checkpoint: &parent_id,
             registry_path: &registry_path,
+            grant_issuer: None,
         };
 
         let err = runner
@@ -3673,6 +3771,7 @@ mod tests {
             anchor: &anchor,
             parent_checkpoint: &parent_id,
             registry_path: &registry_path,
+            grant_issuer: None,
         };
 
         let err = runner
@@ -3750,6 +3849,7 @@ mod tests {
                     anchor: &anchor1,
                     parent_checkpoint: &parent_id,
                     registry_path: &registry_path,
+                    grant_issuer: None,
                 };
                 runner.claim_standby(&ctx, &handle, &claim)
             });
@@ -3761,6 +3861,7 @@ mod tests {
                     anchor: &anchor2,
                     parent_checkpoint: &parent_id,
                     registry_path: &registry_path,
+                    grant_issuer: None,
                 };
                 runner.claim_standby(&ctx, &handle, &claim)
             });

--- a/features/suites/s12_warm_claim/warm_claim_guarded_fork.feature
+++ b/features/suites/s12_warm_claim/warm_claim_guarded_fork.feature
@@ -10,6 +10,7 @@ Feature: Warm-claim guarded fork
     Then the claim yields a fresh child identity distinct from the parent
     And the child's rootfs is materialized from the parent's own content
     And the child is delivered a fresh, non-zero generation token bound to the parent
+    And the child's signed verb grant is delivered with its final identity
     Given a clean warm parent recorded in the pool with no signed audit-chain entry
     When the parent is claimed with an admitted child plan
     Then the claim is refused and no child is forked

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -53,6 +53,8 @@ for detailed scope and acceptance criteria.
   - [x] Template-scoped warm-parent reservation and memory bounds
   - [x] QEMU Stage 0 raw-egress proof on the FC host
   - [x] Linux regression coverage for concurrent raw-egress handlers
+  - [x] Final-child verb grant issuance, validation, persistence, and
+        PostRestore delivery without granting authority to the parent
   - [~] Live warm-launch, fork-isolation, and restore-clock verification
   - [ ] Typed-connector egress-policy enrichment
   - [ ] OCI-image template build path and CLI facade completion

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -723,9 +723,18 @@ Then unify + retire the old paths:
       the CLI no longer reserves a parent the runner is about to reserve (#1922),
       which had made every warm claim refuse with "parent is not in a claimable
       state" so the pool filled and never drained.
+      The post-restore authority gap is also closed in code: after the final
+      child identity is materialized, the host mints and validates the exact
+      admitted `VerbGrant`, persists it only for that child, and delivers it
+      with the generation token over PostRestore. The factory parent retains
+      the boot-pinned host identity but receives no workload grant. A real
+      host-key signature is verified in the hermetic warm-claim BDD, and a
+      missing issuer or mismatched envelope refuses before fork with no orphan.
       `standby_pool` stays **`false`**: the **claim** half has still never
-      executed live, so the post-restore handshake and the child's egress/broker/
-      exit channels remain unproven. The flip is gated on that run.
+      completed live. It now reaches the signed-parent check and refuses because
+      the capture path does not emit `checkpoint.created` (#1962), so the
+      post-restore grant delivery and the child's egress/broker/exit channels
+      remain live-unproven. The flip is gated on that run.
 - [ ] A clean **external API** (`Image` / `Vm` / `Pool` / `ExecBuilder`-style) on `mvm-client`, so library and CLI share one surface.
 - [ ] **Simple, fast install:** a one-line installer + `mvmctl upgrade`.
 - Gate: the timed e2e proves sub-second launch on both hosts; warm-start + snapshot restore measured; the external API is documented and BDD-covered.

--- a/specs/plans/255-live-fc-warm-claim.md
+++ b/specs/plans/255-live-fc-warm-claim.md
@@ -1024,24 +1024,20 @@ connection with `rejecting control connection without a pinned host key`. It
 predates this branch's merge base. Track it separately; expect it to be the next
 blocker once BUG-1 is fixed.
 
-**BLOCKER-3 — a restored child has no host-signer anchor, so it cannot be
-authorized at all.** Found by review of the BUG-1 fix, not by the run, and
-**not** a variant of BUG-2: BUG-2 is a missing sidecar on one code path, this is
-a structural consequence of a shared parent and survives BUG-2's fix. The
-grant cmdline tokens are derived per-VM from `<vm_state_dir>/verb-grant.json`; a
-factory parent holds no plan, so it has no sidecar and boots with no
-`mvm.host_signer_pub=` anchor — correctly, since a parent must hold no workload
-authority. But a child inherits the parent's cmdline out of restored memory
-rather than deriving its own, nothing re-pins an anchor after the restore (the
-production `VsockPostRestoreSignal` hardcodes `grant_envelope: None`), and the
-guest-side `re_pin_verb_grant` verifies a replacement grant against the
-**boot-pinned** anchor — which is absent. So the child refuses the PostRestore
-RPC, `require_fresh_child_identity` refuses the child, and every claim
-cold-boots. Fail-closed, no security hole, but the warm claim is structurally
-unreachable until it is fixed. Suggested shape (recorded, not implemented) in
-the validation note: pin `mvm.host_signer_pub=` on the parent as *host
-identity*, keep withholding `mvm.verb_grant=` / `mvm.require_grant=` as
-*workload authority*, and carry a replacement grant over the PostRestore signal.
+**BLOCKER-3 — resolved in code; live delivery remains gated behind #1962.**
+#1959 established the host-signer public key as boot-pinned *host identity*
+while the factory parent still receives no workload grant. The claim path now
+mints the admitted `VerbGrant` only after the final child identity exists,
+validates that its session, nonce, expiry, verbs, predecessor set, signer key,
+and signature exactly match that child and plan, persists it only in the
+child's state, and carries the envelope with the fresh generation token over
+the PostRestore signal. The guest verifies the replacement grant under the
+boot-pinned host key before accepting it. A grant-bearing claim without an
+issuer, or with any mismatched envelope field, refuses before fork; the parent
+never receives workload authority. Hermetic BDD coverage verifies the real
+host signature against the trusted host public key. The live claim still
+cannot reach this delivery while #1962 refuses the parent for its missing
+`checkpoint.created` audit entry, so this does not justify the capability flip.
 
 **BLOCKER-4 — a claimed child is wired none of the host channels a cold boot
 gets.** Also found by review. `wire_guest_dial_bridges` and
@@ -1211,6 +1207,12 @@ cargo clippy --workspace --all-targets -- -D warnings
 
 - [ ] **Step 5: Re-validate live, then and only then consider the flip**
 
+  - [x] Issue and persist the admitted grant only after the final child
+        identity is materialized, validate it fail-closed, and deliver it with
+        the generation token over PostRestore. The hermetic warm-claim BDD
+        verifies the grant under the trusted host signer; missing-issuer and
+        mismatch tests prove refusal before fork with no orphaned child.
+
 Re-run Task 7 on the KVM host. The capability stays `false` until that run is green. Expect BUG-2 to surface next; if it blocks, record it and stop rather than working around a pre-existing bug inside this slice.
 
 **Partially done.** A live run on the KVM host with the corrected boot shape
@@ -1232,8 +1234,9 @@ error=claim standby: parent has no signed audit entry;
 Correct behaviour meeting a missing emit: nothing on the spawn path writes the
 `checkpoint.created` entry the claim's parent verification requires, so every
 captured parent is unclaimable by construction (issue #1962). BUG-2 and the
-double-reserve no longer block the claim; BLOCKER-3's boot half is fixed by
-#1959; BLOCKER-4 remains open and unexercised.
+double-reserve no longer block the claim; BLOCKER-3 is fixed in code but its
+post-restore delivery cannot be exercised live until #1962 is closed;
+BLOCKER-4 remains open and unexercised.
 
 Cold boot to activation, measured over 10 reps: median 1837.5 ms (min 1766,
 p90 2027, max 2119, spread 353), 10/10 activated. Warm is **not** measurable


### PR DESCRIPTION
## Summary

- mint a child `VerbGrant` only after the warm claim has materialized its final child identity
- validate the issued envelope against the final session, plan nonce/expiry/verbs, empty predecessor set, host signer key, and signature before any fork
- persist the plan and grant only in the child state and deliver the envelope with the fresh generation token over PostRestore
- keep the factory parent authority-free: it may carry the boot-pinned host identity, but never a workload grant
- fail closed before fork when a grant-bearing plan has no issuer or the issuer returns a mismatched envelope
- verify the real hostd-issued signature under the trusted host public key in the hermetic warm-claim BDD

This is the post-restore authority implementation follow-up to the decision record in #1998.

`standby_pool` remains `false`. Live delivery is still unproven because the capture path lacks the signed `checkpoint.created` entry tracked by #1962; this PR does not claim to close that blocker or enable the capability.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- model/conformance/honesty/deferral gates
- 8,401 workspace tests
- workspace doctests
- BDD: 23 features, 74 scenarios, 363 steps
- isolated rerun of the one transient installer fixture, followed by a fully green `just ci` rerun