### PR TITLE
ci: requeue transient merge-queue ejections safely

### DIFF
--- a/.github/workflows/merge-queue-requeue.yml
+++ b/.github/workflows/merge-queue-requeue.yml
@@ -1,11 +1,9 @@
 name: Merge queue auto-requeue
 
 # A PR ejected from the merge queue stops being worked on and stays that way
-# until a human notices. Measured on this repo: 4 of 8 recent PRs were ejected
-# at least once, and #1997 sat outside the queue for nearly three hours between
-# `removed_from_merge_queue` and someone re-adding it. That gap, not queue
-# throughput, is what "waiting hours to merge" actually is — the queue builds
-# five entries concurrently and a cycle is ~35 minutes.
+# until a human notices. Live queue history shows that these unattended gaps
+# can exceed the validation cycle itself, so bounded automatic recovery is part
+# of keeping queue latency predictable.
 #
 # Most ejections are transient: a flaky test in the queue run, or the entry
 # being invalidated because something ahead of it merged. Those deserve an
@@ -41,8 +39,8 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           # How many times this workflow will retry one PR before leaving it
           # alone. A PR that keeps being ejected is telling us something, and
-          # retrying it forever would burn a ~35-minute queue cycle each time
-          # while hiding the signal.
+          # retrying it forever would burn a validation cycle each time while
+          # hiding the signal.
           MAX_ATTEMPTS: "2"
         run: |
           set -euo pipefail
@@ -79,7 +77,7 @@ jobs:
           if [ "${attempts}" -ge "${MAX_ATTEMPTS}" ]; then
             echo "::warning::PR #${PR} has already been auto-requeued ${attempts} time(s); leaving it for a human."
             gh pr comment "${PR}" --repo "${REPO}" --body \
-              "Ejected from the merge queue again after ${attempts} automatic retries. Not requeuing — this is repeating, so it is worth a look rather than another ~35-minute cycle." \
+              "Ejected from the merge queue again after ${attempts} automatic retries. Not requeuing — this is repeating, so it is worth a look rather than consuming another validation cycle." \
               || true
             exit 0
           fi
@@ -90,7 +88,11 @@ jobs:
           gh label create auto-requeued --repo "${REPO}" \
             --description "Automatically re-added to the merge queue after a transient ejection" \
             --color ededed 2>/dev/null || true
-          gh pr edit "${PR}" --repo "${REPO}" --add-label auto-requeued || true
+          # Toggle the label so every retry produces a distinct labeled event;
+          # leaving it attached would make the persistent attempt count stick
+          # at one forever.
+          gh pr edit "${PR}" --repo "${REPO}" --remove-label auto-requeued 2>/dev/null || true
+          gh pr edit "${PR}" --repo "${REPO}" --add-label auto-requeued
 
           echo "Requeuing PR #${PR} (attempt $((attempts + 1)) of ${MAX_ATTEMPTS})."
           gh pr merge "${PR}" --repo "${REPO}" --auto

--- a/.github/workflows/merge-queue-requeue.yml
+++ b/.github/workflows/merge-queue-requeue.yml
@@ -1,0 +1,96 @@
+name: Merge queue auto-requeue
+
+# A PR ejected from the merge queue stops being worked on and stays that way
+# until a human notices. Measured on this repo: 4 of 8 recent PRs were ejected
+# at least once, and #1997 sat outside the queue for nearly three hours between
+# `removed_from_merge_queue` and someone re-adding it. That gap, not queue
+# throughput, is what "waiting hours to merge" actually is — the queue builds
+# five entries concurrently and a cycle is ~35 minutes.
+#
+# Most ejections are transient: a flaky test in the queue run, or the entry
+# being invalidated because something ahead of it merged. Those deserve an
+# automatic retry. A genuine merge conflict does not — it needs a human to
+# rebase — so this refuses to requeue one and says so on the PR instead.
+#
+# `pull_request_target` runs with a write token against the BASE ref. This
+# workflow never checks out the PR's code and only makes API calls, so nothing
+# from the head branch is executed with those permissions.
+
+on:
+  pull_request_target:
+    types: [dequeued]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# One requeue decision per PR at a time; a burst of dequeues shouldn't race.
+concurrency:
+  group: merge-queue-requeue-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  requeue:
+    name: Requeue if the ejection was transient
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide, and requeue when it is safe to
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          # How many times this workflow will retry one PR before leaving it
+          # alone. A PR that keeps being ejected is telling us something, and
+          # retrying it forever would burn a ~35-minute queue cycle each time
+          # while hiding the signal.
+          MAX_ATTEMPTS: "2"
+        run: |
+          set -euo pipefail
+
+          state=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.state')
+          merged=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.merged')
+          draft=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.draft')
+          if [ "${state}" != "open" ] || [ "${merged}" = "true" ] || [ "${draft}" = "true" ]; then
+            echo "PR #${PR} is state=${state} merged=${merged} draft=${draft} — nothing to requeue."
+            exit 0
+          fi
+
+          # `mergeable` is computed asynchronously; poll briefly rather than
+          # act on `null`, which would misread a conflict as a transient
+          # ejection and requeue something that cannot merge.
+          for _ in $(seq 1 10); do
+            mergeable=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.mergeable')
+            [ "${mergeable}" != "null" ] && break
+            sleep 6
+          done
+          mergeable_state=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.mergeable_state')
+          echo "PR #${PR}: mergeable=${mergeable} mergeable_state=${mergeable_state}"
+
+          if [ "${mergeable}" = "false" ] || [ "${mergeable_state}" = "dirty" ]; then
+            echo "::notice::PR #${PR} conflicts with the base — a human needs to rebase it."
+            gh pr comment "${PR}" --repo "${REPO}" --body \
+              "Ejected from the merge queue and **not** requeued: this PR conflicts with \`main\`. Rebase it and it will re-enter the queue on its own." \
+              || true
+            exit 0
+          fi
+
+          attempts=$(gh api "repos/${REPO}/issues/${PR}/timeline" --paginate \
+            --jq '[.[] | select(.event == "labeled") | select(.label.name == "auto-requeued")] | length')
+          if [ "${attempts}" -ge "${MAX_ATTEMPTS}" ]; then
+            echo "::warning::PR #${PR} has already been auto-requeued ${attempts} time(s); leaving it for a human."
+            gh pr comment "${PR}" --repo "${REPO}" --body \
+              "Ejected from the merge queue again after ${attempts} automatic retries. Not requeuing — this is repeating, so it is worth a look rather than another ~35-minute cycle." \
+              || true
+            exit 0
+          fi
+
+          # The label is the attempt counter: `labeled` events persist in the
+          # timeline even after the label is removed, so the count survives
+          # someone tidying the PR.
+          gh label create auto-requeued --repo "${REPO}" \
+            --description "Automatically re-added to the merge queue after a transient ejection" \
+            --color ededed 2>/dev/null || true
+          gh pr edit "${PR}" --repo "${REPO}" --add-label auto-requeued || true
+
+          echo "Requeuing PR #${PR} (attempt $((attempts + 1)) of ${MAX_ATTEMPTS})."
+          gh pr merge "${PR}" --repo "${REPO}" --auto

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -6,6 +6,12 @@ This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## In-flight plans
+- [x] Plan 282 — Merge queue auto-requeue
+      (`specs/plans/282-merge-queue-auto-requeue.md`)
+  - [x] Refuse conflicts and bound retry attempts per PR
+  - [x] Keep privileged execution on the trusted base ref with no checkout
+  - [x] Complete repository validation and queue the PR
+
 - [ ] Plan 279 — Build action identity and a real artifact manifest
       (`specs/plans/279-build-action-identity-and-artifact-manifest.md`)
   - [ ] WS1 — `ActionDigest` into the identity taxonomy (land after plan 276 WS6)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,13 @@
 
 ## Current issue delivery
 
+- [x] Merge-queue auto-requeue: bounded recovery for transiently ejected pull
+      requests, with conflict refusal, persistent attempt counting, no checkout
+      of untrusted code, and structural security tests. The label counter now
+      toggles on every retry so its persistent timeline count cannot stick at
+      one. Workflow validation, focused tests, workspace check, clippy, and
+      formatting pass. Tracked in plan 282.
+
 - [x] Build-cache invalidation: narrowed `nix/lib/workspace-filter.nix` from a
       basename deny-list over the whole workspace root to an allow-list of the
       top-level entries cargo can actually read. The filtered tree is `mvmSrc`,

--- a/specs/plans/282-merge-queue-auto-requeue.md
+++ b/specs/plans/282-merge-queue-auto-requeue.md
@@ -1,0 +1,25 @@
+# Merge queue auto-requeue
+
+**Status:** Complete.
+
+**Goal:** Return transiently ejected pull requests to the merge queue without
+executing untrusted code with a privileged token or retrying indefinitely.
+
+## Work
+
+- [x] Handle only the `dequeued` activity type and serialize decisions per PR.
+- [x] Refuse closed, merged, draft, and conflicting pull requests.
+- [x] Bound automatic retries to two persistent attempts per PR.
+- [x] Use a base-ref `pull_request_target` workflow only for GitHub API calls;
+  never check out or execute the pull request's code.
+- [x] Add structural tests for event scope, permissions, checkout absence,
+  conflict handling, persistent retry counting, and auto-merge invocation.
+- [x] Validate workflows, formatting, focused tests, workspace check, and
+  clippy, then record completion in the sprint and refactor rollup.
+
+## Security posture
+
+The workflow has `contents: read` and `pull-requests: write`, receives only the
+repository identifier and numeric PR number from the event, and never checks
+out a ref. Its shell code is loaded from the trusted base branch. A per-PR
+concurrency key prevents two dequeue events from racing the attempt counter.

--- a/tests/merge_queue_requeue_workflow.rs
+++ b/tests/merge_queue_requeue_workflow.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+
+fn workflow() -> String {
+    std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/merge-queue-requeue.yml"),
+    )
+    .expect("merge-queue requeue workflow must be readable")
+}
+
+#[test]
+fn privileged_requeue_workflow_never_executes_pull_request_code() {
+    let source = workflow();
+
+    assert!(source.contains("pull_request_target:\n    types: [dequeued]"));
+    assert!(source.contains("contents: read\n  pull-requests: write"));
+    assert!(!source.contains("actions/checkout"));
+    assert!(!source.contains("github.event.pull_request.head"));
+    assert!(!source.contains("github.head_ref"));
+}
+
+#[test]
+fn retries_are_bounded_counted_and_conflict_aware() {
+    let source = workflow();
+
+    assert!(source.contains("MAX_ATTEMPTS: \"2\""));
+    assert!(source.contains("mergeable_state"));
+    assert!(source.contains("--remove-label auto-requeued"));
+    assert!(source.contains("--add-label auto-requeued"));
+    assert!(source.contains("gh pr merge \"${PR}\" --repo \"${REPO}\" --auto"));
+}


### PR DESCRIPTION
## Outcome

Adds a bounded API-only recovery workflow for pull requests ejected from the merge queue for transient reasons. Genuine merge conflicts remain out of the queue and receive an actionable comment.

## Safety

- Runs only for `pull_request_target: dequeued`.
- Uses `contents: read` and `pull-requests: write`.
- Never checks out or executes pull-request code.
- Waits for GitHub mergeability computation before deciding.
- Retries at most twice, persisted through timeline label events.
- Removes and reapplies the retry label so every attempt is counted; the prior implementation could leave the counter stuck at one.

## Validation

- `actionlint -shellcheck= .github/workflows/*.yml`
- `cargo fmt --all -- --check`
- `cargo test --test merge_queue_requeue_workflow`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

The trigger itself requires a live queue dequeue. Its safe failure mode is unchanged: if the recovery workflow fails, the pull request remains out of the queue for human diagnosis.