### PR TITLE
Stop sizing worker-pool call timeouts as a multiple of the expected call

### DIFF
--- a/crates/mvm-agentd/tests/worker_pool_warm.rs
+++ b/crates/mvm-agentd/tests/worker_pool_warm.rs
@@ -64,9 +64,24 @@ fn start_pool_with_behavior(cfg: WarmProcessConfig, behavior: Option<&str>) -> A
 }
 
 fn dispatch(pool: &Arc<WorkerPool>, payload: &[u8]) -> DispatchOutcome {
-    pool.dispatch(payload.to_vec(), 30, Vec::new())
+    pool.dispatch(payload.to_vec(), CALL_HANG_GUARD_SECS, Vec::new())
         .expect("dispatch returns outcome")
 }
+
+/// Per-call timeout for dispatches whose test asserts a *result* — ordering,
+/// recycling, which slot served it — rather than a duration.
+///
+/// Not a budget. Sizing it as a small multiple of the expected call is what
+/// made this file flaky: `idle_timeout_skips_busy_workers` gave a `slow_secs=2`
+/// worker a 5s timeout and failed at 5.099s under a loaded run, and
+/// `fifo_queue_serializes_callers` is tighter still by construction — five
+/// calls serialize through a one-slot pool, so the last caller's budget has to
+/// cover the four ahead of it, and each was given the same 5s.
+///
+/// Reached only when a call never returns, which is a hang rather than a slow
+/// host. Never tune it toward "what seems fast enough"; the only test here that
+/// asserts a timeout *occurs* is the readiness-probe one, which sets its own.
+const CALL_HANG_GUARD_SECS: u64 = 120;
 
 /// Block until `cond` holds, or fail the test.
 ///
@@ -239,7 +254,7 @@ fn idle_timeout_skips_busy_workers() {
     let pool_clone = Arc::clone(&pool);
     let dispatch_handle = std::thread::spawn(move || {
         pool_clone
-            .dispatch(b"x".to_vec(), 5, Vec::new())
+            .dispatch(b"x".to_vec(), CALL_HANG_GUARD_SECS, Vec::new())
             .expect("dispatch")
     });
 
@@ -306,12 +321,12 @@ fn wrapper_crash_returns_error_and_recycles() {
     let first_pid = idle_pid(&pool);
 
     let out1 = pool
-        .dispatch(b"first".to_vec(), 5, Vec::new())
+        .dispatch(b"first".to_vec(), CALL_HANG_GUARD_SECS, Vec::new())
         .expect("dispatch returns outcome");
     assert!(matches!(out1.outcome, WorkerOutcome::Exit { code: 0 }));
 
     let out2 = pool
-        .dispatch(b"second".to_vec(), 5, Vec::new())
+        .dispatch(b"second".to_vec(), CALL_HANG_GUARD_SECS, Vec::new())
         .expect("dispatch returns outcome even on crash");
     assert!(
         matches!(out2.outcome, WorkerOutcome::Error { .. }),
@@ -348,7 +363,11 @@ fn pool_size_4_parallel_dispatches() {
         handles.push(std::thread::spawn(move || {
             let payload = format!("call-{i}");
             let out = p
-                .dispatch(payload.clone().into_bytes(), 30, Vec::new())
+                .dispatch(
+                    payload.clone().into_bytes(),
+                    CALL_HANG_GUARD_SECS,
+                    Vec::new(),
+                )
                 .expect("ok");
             assert_eq!(out.stdout, payload.as_bytes());
             assert!(matches!(out.outcome, WorkerOutcome::Exit { code: 0 }));
@@ -384,7 +403,8 @@ fn fifo_queue_serializes_callers() {
     for i in 0..5u8 {
         let p = Arc::clone(&pool_clone);
         handles.push(std::thread::spawn(move || {
-            p.dispatch(vec![i], 5, Vec::new()).expect("dispatch")
+            p.dispatch(vec![i], CALL_HANG_GUARD_SECS, Vec::new())
+                .expect("dispatch")
         }));
     }
     let outs: Vec<DispatchOutcome> = handles
@@ -438,20 +458,22 @@ fn queue_full_returns_error() {
 
     let p1 = Arc::clone(&pool);
     let p2 = Arc::clone(&pool);
-    let h1 = std::thread::spawn(move || p1.dispatch(b"a".to_vec(), 10, Vec::new()));
+    let h1 =
+        std::thread::spawn(move || p1.dispatch(b"a".to_vec(), CALL_HANG_GUARD_SECS, Vec::new()));
     // The first caller must hold the only slot before the second can
     // queue behind it; the second must be parked in the queue before a
     // third can overflow it. Both are observable, so neither is timed.
     wait_until("the first caller to occupy the only slot", || {
         any_slot_busy(&pool)
     });
-    let h2 = std::thread::spawn(move || p2.dispatch(b"b".to_vec(), 10, Vec::new()));
+    let h2 =
+        std::thread::spawn(move || p2.dispatch(b"b".to_vec(), CALL_HANG_GUARD_SECS, Vec::new()));
     wait_until("the second caller to park in the queue", || {
         pool.queued_waiters() == 1
     });
 
     // Third should hit QueueFull.
-    let res = pool.dispatch(b"c".to_vec(), 10, Vec::new());
+    let res = pool.dispatch(b"c".to_vec(), CALL_HANG_GUARD_SECS, Vec::new());
     assert!(
         res.is_err(),
         "third dispatch must hit queue cap, got {:?}",
@@ -495,13 +517,13 @@ fn start_pool_unready(cfg: WarmProcessConfig) -> Arc<WorkerPool> {
 #[test]
 fn dispatch_refuses_until_readiness_marked() {
     let pool = start_pool_unready(cfg(1, 100, 1024));
-    let res = pool.dispatch(b"hello".to_vec(), 5, Vec::new());
+    let res = pool.dispatch(b"hello".to_vec(), CALL_HANG_GUARD_SECS, Vec::new());
     assert!(matches!(res, Err(DispatchError::NotReady)));
     assert!(!pool.is_ready());
     pool.mark_ready();
     assert!(pool.is_ready());
     let out = pool
-        .dispatch(b"hello".to_vec(), 5, Vec::new())
+        .dispatch(b"hello".to_vec(), CALL_HANG_GUARD_SECS, Vec::new())
         .expect("post-ready dispatch ok");
     assert_eq!(out.stdout, b"hello");
 }
@@ -519,7 +541,7 @@ fn wait_for_ready_succeeds_against_passing_probe() {
         .with_interval(Duration::from_millis(50));
     pool.wait_for_ready(&cfg_probe).expect("ready");
     assert!(pool.is_ready());
-    pool.dispatch(b"ok".to_vec(), 5, Vec::new())
+    pool.dispatch(b"ok".to_vec(), CALL_HANG_GUARD_SECS, Vec::new())
         .expect("dispatch ok after ready");
 }
 
@@ -545,14 +567,14 @@ fn wait_for_ready_succeeds_after_initial_failures() {
 
     // While warming, dispatch should fail-closed.
     assert!(matches!(
-        pool.dispatch(b"early".to_vec(), 5, Vec::new()),
+        pool.dispatch(b"early".to_vec(), CALL_HANG_GUARD_SECS, Vec::new()),
         Err(DispatchError::NotReady)
     ));
 
     pool.wait_for_ready(&cfg_probe).expect("warmed up");
     assert!(pool.is_ready());
     let out = pool
-        .dispatch(b"after-warmup".to_vec(), 5, Vec::new())
+        .dispatch(b"after-warmup".to_vec(), CALL_HANG_GUARD_SECS, Vec::new())
         .expect("dispatch after warmup");
     assert_eq!(out.stdout, b"after-warmup");
 }
@@ -570,7 +592,7 @@ fn wait_for_ready_marks_ready_when_probe_missing() {
     pool.wait_for_ready(&cfg_probe)
         .expect("missing probe is ok");
     assert!(pool.is_ready());
-    pool.dispatch(b"ok".to_vec(), 5, Vec::new())
+    pool.dispatch(b"ok".to_vec(), CALL_HANG_GUARD_SECS, Vec::new())
         .expect("dispatch ok with absent probe");
 }
 
@@ -592,7 +614,7 @@ fn wait_for_ready_timeout_leaves_pool_not_ready() {
     );
     assert!(!pool.is_ready(), "timeout must leave pool NotReady");
     assert!(matches!(
-        pool.dispatch(b"x".to_vec(), 5, Vec::new()),
+        pool.dispatch(b"x".to_vec(), CALL_HANG_GUARD_SECS, Vec::new()),
         Err(DispatchError::NotReady)
     ));
 }


### PR DESCRIPTION
Item 1 of the merge-queue slowness work — and the one with the widest blast radius.

## The failures

`worker_pool_warm` fails **4 out of 522** on clean `main` under `cargo nextest run -p mvm-agentd -j 6`. Every failure is a per-call dispatch timeout sized as a small multiple of how long the call was expected to take — a guess about host load, not a property of the code.

- `idle_timeout_skips_busy_workers` — a `slow_secs=2` worker given a 5s timeout, a 2.5x margin. Observed failure: **5.099s**.
- `fifo_queue_serializes_callers` — tight *by construction*, not just under load: five calls serialize through a one-slot pool, so the last caller's budget must cover the four ahead of it. Each was given the same 5s.

Neither test asserts anything about duration. They assert ordering, recycling, and which slot served a call.

## The file already knew better

Its readiness-probe test says exactly the right thing:

> Generous bound: this test asserts the probe *succeeds*, so the timeout is only here to stop a hang. Sizing it tightly turns a busy host into a red test without telling anyone anything.

The dispatch timeouts had simply never been brought in line with it. All 16 now use one named `CALL_HANG_GUARD_SECS`, documented as not a budget and reached only when a call never returns.

Verified safe to raise: the only test in the file that asserts a timeout *occurs* is the readiness-probe one, which sets its own timeout and is untouched.

## Why this is worth more than it looks

I measured why the merge queue felt slow, and it is not the queue:

```
concurrently RUNNING jobs: 14
jobs WAITING for a runner:  22
plan: free            (GitHub Free caps orgs at 20 concurrent jobs)
```

The queue builds 5 entries concurrently; each entry is ~5 jobs, so the queue alone oversubscribes the 20-slot pool and starves both itself and ordinary PR CI.

Against that, a flake is expensive in a way it would not otherwise be: it does not just redden one lane, it **ejects the entry** — wasting a full ~35-minute cycle of a rationed pool — and the PR then sits outside the queue until a human re-adds it. Measured: **4 of 8 recent PRs were ejected at least once**, and #1997 sat out for nearly three hours.

So removing a flake source removes whole cycles, not just one red check.

## Verification

- **522/522 twice** at `-j 6`, where `main` gives 4 failures at the same parallelism
- 17/17 for the `worker_pool_warm` binary alone
- `cargo clippy -p mvm-agentd --all-targets -- -D warnings` clean, nightly fmt clean

## Related

- #2015 removes a different flake source in the same crate (a genuine drain race in `handle_proc_wait`, not a test bug)
- #2020 requeues an ejected PR instead of leaving it out of the queue
- Lowering `max_entries_to_build` from 5 to 2 is the remaining lever and needs a repo-settings change — it is a ruleset edit I do not have permission to make