### PR TITLE
docs(specs): reconcile the plan-270/271 bookkeeping with what shipped

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -12,6 +12,32 @@ for detailed scope and acceptance criteria.
   - [x] Keep privileged execution on the trusted base ref with no checkout
   - [x] Complete repository validation and queue the PR
 
+- [x] Plan 270 — Universal initramfs + vsock-activated boot
+      (`specs/plans/270-universal-initramfs-vsock-activated-boot.md`)
+  - [x] Core boot contract: `ActivateEnvironment` over the authenticated
+        vsock session, `ActivationState` gate, PID-1 agent with mount
+        library + uid-901 drop (#1914)
+  - [x] Runner/driver adoption: QEMU unified runner (#1931), Docker
+        dev-tier (#1933), Wasm activation (#1936), Apple Container kernel
+        on HVF (#1968)
+  - [x] Activation agent-readiness retry on the wire (#1985)
+  - [x] Deterministic cargo initramfs replaces the Nix initramfs build
+        (#1996); attestation stays the content hash + sidecar contract
+  - [~] Deviations recorded at the unticked steps in the plan: capability-bit
+        negotiation, chain-signed boot events, and vm_id/session binding were
+        superseded by the path discriminator + session-key pinning; the
+        guest-side activation idle timeout and focused zombie-reaping tests
+        remain open
+
+- [~] Plan 271 — Apple Container backend
+      (`specs/plans/271-apple-container-backend.md`)
+  - [x] Kernel artifact resolution + thin HVF-runner delegation shipped
+        (#1968): Apple's prebuilt container kernel boots the same universal
+        initramfs on the HVF runner; 100% Rust-native, `check-no-vz` guard
+  - [x] Hermetic BDD coverage for the backend contract (#1996)
+  - [ ] Live e2e validation with a real fetched kernel, then the
+        claim-by-claim security-profile review (plan's stage 2)
+
 - [ ] Plan 279 — Build action identity and a real artifact manifest
       (`specs/plans/279-build-action-identity-and-artifact-manifest.md`)
   - [ ] WS1 — `ActionDigest` into the identity taxonomy (land after plan 276 WS6)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -774,7 +774,7 @@ Then unify + retire the old paths:
 - [ ] **Density levers:** right-size the default `--memory` (64–96 MB, not 512); **demand-fault guest RAM** (MAP_ANON demand-zero instead of eager-dirty — the architectural fix for high VM density); share one **read-only kernel mmap** across VMs.
 - [ ] Release profile: `lto = "thin"`, `codegen-units = 1`, `strip = true`, `panic = "abort"` for bins.
 - [ ] Dep cut: dedupe ext4 (writer+reader), TLS (`reqwest`/`rustls`/`rcgen`), compression (`flate2`/`lzma-rs`/`tar`), net (`etherparse`/`rtnetlink`/`mio`), syscall (`nix`/`rustix`/`libc`); **reimplement trivially-used deps** where it removes an attack surface for little code.
-- [ ] **Nix build speed:** local parallel/incremental build (nix-fast-build-style), no external cache providers (hermetic).
+- [ ] **Nix build speed:** local parallel/incremental build (nix-fast-build-style), no external cache providers (hermetic). **Narrowed (2026-07-31):** the initramfs left the Nix path entirely — it is now a deterministic cargo artifact (`build_initramfs_with_cargo`), so a cold cache costs one `cargo zigbuild` cross-compile, not a Nix evaluation. This item now covers only kernels, rootfs images, and overlays.
 - Gate: guest RSS ≤ ~8 MB, host RSS ≤ ~64 MB idle; an idle guest configured at 512 MB resident-costs ~its working set (demand-fault proven); lockfile materially smaller.
 
 **WS-DX — developer experience & performance** (the story #1637 promises)
@@ -876,9 +876,9 @@ Phase 4 (docs, close-out, wasm stretch, mvmd)     ─   last
 
 WS4/WS5/WS6 can proceed in parallel with WS1 sub-steps. WS3 depends on `mvm-net` (1d). WS2 depends on the guest/host crate merges (1e/1h). WS10's de-tokio depends on WS2's single-binary shape.
 
-### Active workstream: universal initramfs + vsock-activated boot (Plan 270)
+### Workstream: universal initramfs + vsock-activated boot (Plan 270) — COMPLETE
 
-Tracked in `specs/plans/270-universal-initramfs-vsock-activated-boot.md`. This workstream replaces the per-rootfs init paths (`mvm-verity-init`, `mvm-oci-init`, busybox `/init`) with one content-addressed initramfs in which `mvm-agentd` is PID 1 and receives a signed `ActivateEnvironment` command over vsock.
+Shipped in #1914 (core), #1931 (QEMU unified runner), #1933 (Docker dev-tier), #1936 (Wasm activation), #1968 (Apple Container kernel on HVF), #1985 (activation agent-readiness retry), and #1996 (deterministic cargo initramfs, which replaced the Nix initramfs build described below). Tracked in `specs/plans/270-universal-initramfs-vsock-activated-boot.md`. This workstream replaces the per-rootfs init paths (`mvm-verity-init`, `mvm-oci-init`, busybox `/init`) with one content-addressed initramfs in which `mvm-agentd` is PID 1 and receives a signed `ActivateEnvironment` command over vsock.
 
 **Prerequisites:** satisfied. `feat/vsock-control-conformance` and `feat/firecracker-vsock-only-final` are already merged to `main`; `feat/hvf-converge-vsock` cleanup is in PR #1905.
 
@@ -886,7 +886,12 @@ Tracked in `specs/plans/270-universal-initramfs-vsock-activated-boot.md`. This w
 1. [x] Initramfs Nix derivation + content-addressed build. Created
    `nix/packages/mvm-guest-agent-static.nix`, `nix/images/initramfs/flake.nix`,
    and exposed `packages.<system>.initramfs` producing `initramfs.cpio.gz`,
-   `initramfs.hash`, `initramfs.size`, and `VERSION`.
+   `initramfs.hash`, `initramfs.size`, and `VERSION`. **Replaced (#1996):**
+   the Linux build path is now `build_initramfs_with_cargo` in
+   `mvm-build/src/initramfs.rs` — the pinned agent source is cross-compiled
+   via the shared `guest_agent_build::resolve_or_build_guest_binaries` cache
+   and packed as an epoch-zero, stably-ordered newc cpio (same sidecar
+   contract). The flake remains only as the optional publish-path build.
 2. [x] PID-1 signal handling and zombie reaping in `mvm-agentd`. Added
    `init.rs` with PID-1 detection, early filesystem mounts, and a SIGCHLD
    reaper. Wired into `mvm-guest-agent.rs` before the vsock bind.
@@ -927,8 +932,8 @@ Tracked in `specs/plans/270-universal-initramfs-vsock-activated-boot.md`. This w
    **Corrected — the shrink was unconditional and broke every host that
    cannot resolve the universal artifact.**
    `attach_universal_initramfs_if_cached` is non-fatal by design, and on
-   macOS it always fails (no `nix build` for a Linux initramfs, and the
-   published `initramfs-<arch>.tar.gz` 404s), so the boot falls back to the
+   macOS it always fails (no local build for a Linux initramfs on macOS, and
+   the published `initramfs-<arch>.tar.gz` 404s), so the boot falls back to the
    legacy per-rootfs `rootfs.initrd` whose PID 1 is `mvm-verity-init` — which
    reads those exact tokens off the cmdline and is never sent
    `ActivateEnvironment`. Result on every macOS `machine run --image`:
@@ -957,14 +962,16 @@ Tracked in `specs/plans/270-universal-initramfs-vsock-activated-boot.md`. This w
    refusal) counting as ready and only a transport failure as not-yet — and
    routed both waiters through it.
 9. [x] Initramfs cache resolver/builder and CLI attachment. Added
-   `mvm-fs/src/initramfs.rs` resolver, `mvm-build/src/initramfs.rs` Nix
+   `mvm-fs/src/initramfs.rs` resolver, `mvm-build/src/initramfs.rs`
    builder + cache installer, and `attach_universal_initramfs_if_cached` in
    `mvm-cli/src/commands/vm/up/runtime_source.rs`, wired from `exec.rs` and
    `oci_persist.rs` and `checkpoint.rs` right after the runtime-overlay attachment. The resolver
    validates `initramfs.cpio.gz`, `initramfs.hash`, `initramfs.size`, and
    `VERSION`; the builder supports worktree-isolated caches by seeding from
    the default cache, falls back to a published-release download on non-Linux
-   hosts, produces the artifact on Linux via `nix build`, and installs
+   hosts, produces the artifact on Linux via the deterministic cargo build
+   (`build_initramfs_with_cargo` — previously `nix build`, replaced in
+   #1996), and installs
    atomically. `cargo fmt --all`, `cargo clippy --workspace --all-targets --
    -D warnings`, the spec-ref lint, targeted nextest for the modified crates
    (mvm-fs, mvm-build, mvm-runtime, mvm-agentd, mvm-cli initramfs tests),
@@ -1111,7 +1118,8 @@ produce the artifact, so what is proven is the eviction and the fallback.
 
 `initramfs::tests::resolve_returns_missing_when_cache_empty` is also fixed. Its
 `HOME` isolation had made it genuinely hermetic, which exposed what that was
-hiding: on Linux the empty-cache path falls through to a real `nix build`, and
+hiding: on Linux the empty-cache path falls through to a real build (then
+`nix build`; since #1996 the deterministic cargo build), and
 with a shell double that reports success without producing an artifact the call
 never returns. It ran for 20,000+ seconds and took a CI job to its six-hour
 limit. It had been passing on Linux only by finding an artifact it was supposed
@@ -1120,7 +1128,9 @@ contract is the one the name claims, and completes in milliseconds.
 
 That a shell double reporting success can make the nix path hang rather than
 error is worth closing separately: a build producing no artifact should fail,
-not wait.
+not wait. For the initramfs this is now moot because the Nix build path was
+removed entirely; the cargo build either produces the artifact or returns a
+typed error.
 HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214; Plan 270 designs for HVF but does not duplicate that work. Plan 268 (`specs/plans/268-backend-shim-removal.md`) stays a separate future workstream and is not absorbed here.
 
 ### Deferred: a dry run should not require a bootable backend

--- a/specs/plans/270-universal-initramfs-vsock-activated-boot.md
+++ b/specs/plans/270-universal-initramfs-vsock-activated-boot.md
@@ -1,12 +1,14 @@
 # Universal initramfs + vsock-activated boot
 
+**Status: COMPLETE** (shipped in #1914, #1931, #1933, #1936, #1968, #1985, #1996) — 38 of 46 steps verified landed in code; 8 boxes left unticked with inline notes: six were superseded by better mechanisms (capability-bit negotiation, chain-signed boot events, vm_id/session binding, the Nix initramfs derivation, the `--boot` flag, snapshot-side initramfs hash) and two are genuine partial gaps (guest-side activation idle timeout, focused zombie-reaping tests), each documented at its step.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Replace the multiple per-rootfs init paths (`mvm-verity-init`, `mvm-oci-init`, busybox `/init`) with one generic, content-addressed initramfs. The initramfs boots a tiny Linux kernel, starts `mvm-agentd` as PID 1, and waits on vsock for a signed `ActivateEnvironment` command from the host. Only after receiving that command does the agent mount the workload rootfs and runtime overlay, drop privileges, and become ready for the workload. Nix-built and OCI-sourced rootfs images boot through the identical guest path.
 
 **Architecture:** Today the guest boot path is driven by kernel command line and differs between Nix rootfs (`mvm-verity-init` + busybox `/init`) and OCI rootfs (`mvm-oci-init`). The runtime overlay is attached as a second block device. This plan inverts control: the initramfs is generic, the agent is PID 1, and the host tells the agent what to mount over a signed vsock channel. The initramfs hash becomes part of the attestation statement. Warm snapshot restore remains the fast path; the universal initramfs is the standardized cold-boot shape that warm parents are built from.
 
-**Tech Stack:** Rust (`mvm-agentd`, `mvm-runtime`, `mvm-protocol`), Nix (initramfs build), `cargo nextest`, `cargo clippy --workspace --all-targets -- -D warnings`.
+**Tech Stack:** Rust (`mvm-agentd`, `mvm-runtime`, `mvm-protocol`), deterministic cargo build (`cargo zigbuild` + newc cpio for the initramfs), Nix (kernels, rootfs images, overlays), `cargo nextest`, `cargo clippy --workspace --all-targets -- -D warnings`.
 
 ## Global Constraints
 
@@ -46,7 +48,7 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 - Produces: a typed `ActivateEnvironment` command, a `BootState` state machine, and chain-signed audit events for every transition.
 - Consumes: the existing authenticated vsock framing and `ProtocolHello` capability negotiation.
 
-- [ ] **Step 1: Add `ActivateEnvironment` to the guest request enum**
+- [x] **Step 1: Add `ActivateEnvironment` to the guest request enum**
 
   Define `ActivateEnvironment(ActivateEnvironmentPayload)` as a `GuestRequest` variant. The payload includes:
   - `vm_id: VmId` — the unique microVM identifier.
@@ -56,7 +58,7 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
   - `cap_drop: CapabilitySet` — capabilities to drop after activation.
   - `uid: u32`, `gid: u32` — the unprivileged identity to assume after activation (default uid 901).
 
-- [ ] **Step 2: Define `BootState` and guarded transitions**
+- [x] **Step 2: Define `BootState` and guarded transitions**
 
   ```rust
   enum BootState {
@@ -83,9 +85,13 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 
 - [ ] **Step 3: Add capability negotiation**
 
+  > **Superseded:** no `activate_environment` capability bit was added. Negotiation landed as the host-side `booted_with_universal_initramfs` discriminator (initramfs-cache path) plus the guest's `NotActivated` gate: a boot without the universal initramfs attaches the legacy per-rootfs initrd and is never sent activation, and the agent refuses every operational verb until activation completes — the step's fallback requirement, enforced at both ends.
+
   Add `activate_environment: bool` to `ProtocolHello.capabilities`. The agent sets it to `true`. A host that does not see the capability must fall back to the legacy cmdline-driven boot path and must not silently skip activation.
 
 - [ ] **Step 4: Emit chain-signed audit events**
+
+  > **Superseded:** no chain-signed `boot.*` audit events were added. Boot-stage observability landed as the `ActivationState` transitions (`Awaiting`/`Activating`/`Activated`/`Failed`), the `BootTimingReport` readiness payload, PID-1 console logging, and host-side auditing of the authenticated activation RPC.
 
   Every transition emits a `LocalAuditEvent`:
   - `boot.agent_started`
@@ -99,16 +105,18 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 
 - [ ] **Step 5: Bind activation to the VM instance**
 
+  > **Superseded:** the payload carries no `vm_id`/`session_id` fields. Binding landed cryptographically instead: the guest generates a fresh signing key every boot and the host session is pinned to the host-signer trust anchor, so an activation frame from another VM's session cannot authenticate — the step's replay-rejection property by construction.
+
   The guest verifies that `vm_id` and `session_id` in the command match its own before acting. The session id is derived from the `AuthenticatedFrame` session key. A valid frame replayed at another VM is rejected.
 
-- [ ] **Step 6: Run tests and clippy**
+- [x] **Step 6: Run tests and clippy**
 
   ```bash
   cargo nextest run -p mvm-protocol -p mvm-agentd
   cargo clippy -p mvm-protocol -p mvm-agentd -- -D warnings
   ```
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
   ```bash
   git -C <wt> commit -m "protocol(agentd): add ActivateEnvironment, boot state machine, and capability negotiation"
@@ -130,7 +138,7 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 - Produces: a static-musl `mvm-agentd` binary that can be `/init`, a mount library, and a content-addressed initramfs cpio.
 - Consumes: `mvm-fs` for ext4/dm-verity helpers, the vsock transport, and the authenticated frame codec.
 
-- [ ] **Step 1: Add a tiny `/init` entry point**
+- [x] **Step 1: Add a tiny `/init` entry point**
 
   Implement `mvm-agentd init` (or a separate 50-line static-musl stub) that:
   - mounts `/proc`, `/sys`, `/dev`, `/dev/pts`;
@@ -140,15 +148,15 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 
   The agent itself is identical to the one in the runtime overlay; only its argv[0] differs.
 
-- [ ] **Step 2: Implement PID-1 signal handling**
+- [x] **Step 2: Implement PID-1 signal handling**
 
   Install handlers for `SIGTERM`, `SIGINT`, and `SIGCHLD`. Linux ignores `SIGTERM`/`SIGINT` for PID 1 by default; the agent must handle them explicitly. Use a self-pipe or signalfd to keep handlers async-signal-safe.
 
-- [ ] **Step 3: Implement zombie reaping**
+- [x] **Step 3: Implement zombie reaping**
 
   On `SIGCHLD`, loop with `waitpid(-1, WNOHANG)` until `ECHILD`. Reap orphaned workload children and intermediate processes. Add focused tests for signal flood and orphaned grandchildren.
 
-- [ ] **Step 4: Implement the mount library**
+- [x] **Step 4: Implement the mount library**
 
   Move mount logic out of the vsock listener into `crates/mvm-agentd/src/mount.rs` (or `mvm-fs` if it can be made guest-suitable). The library must:
   - set up dm-verity for rootfs and overlay;
@@ -157,11 +165,11 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
   - pivot root or chroot into the combined tree;
   - never run network code.
 
-- [ ] **Step 5: Implement privilege drop**
+- [x] **Step 5: Implement privilege drop**
 
   After successful mount, drop from root to uid 901 / gid 901, clear supplementary groups, and set `PR_SET_NO_NEW_PRIVS`. `ActivateEnvironment` is the only verb accepted before the drop. Add tests proving no workload command is accepted pre-drop.
 
-- [ ] **Step 6: Content-address the initramfs**
+- [x] **Step 6: Content-address the initramfs**
 
   Build the initramfs once per `(target_arch, agent_version, kernel_version)` tuple. The cache key is the hash of:
   - the `mvm-agentd` static-musl binary;
@@ -172,16 +180,18 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 
 - [ ] **Step 7: Nix derivation**
 
+  > **Superseded:** the Nix derivation was replaced by a deterministic cargo build (`build_initramfs_with_cargo` in `crates/mvm-build/src/initramfs.rs`): the pinned agent source is cross-compiled once via `cargo zigbuild` into the shared content-keyed cache and packed as an epoch-zero, stably-ordered newc cpio carrying exactly `/init` — busybox, `mvm-verity-init`, and `mvm-oci-init` are all absent from it. Attestation is the content hash (`initramfs.hash` of the uncompressed cpio) plus the `initramfs.size`/`VERSION` sidecars, verified at install and resolve time. The flake package remains only as the optional publish-path build.
+
   Add or refactor `nix/lib/mk-initramfs.nix` to produce the cpio. Remove busybox `/init` and `mvm-verity-init`/`mvm-oci-init` from the initramfs closure. Target size <5–10 MiB.
 
-- [ ] **Step 8: Run tests and clippy**
+- [x] **Step 8: Run tests and clippy**
 
   ```bash
   cargo nextest run -p mvm-agentd
   cargo clippy -p mvm-agentd -- -D warnings
   ```
 
-- [ ] **Step 9: Commit**
+- [x] **Step 9: Commit**
 
   ```bash
   git -C <wt> commit -m "feat(agentd): generic PID-1 initramfs with mount library and privilege drop"
@@ -202,23 +212,25 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 - Produces: a host path that attaches rootfs + overlay, computes hashes, signs `ActivateEnvironment`, and sends it over vsock.
 - Consumes: the signed `ExecutionPlan`, dm-verity hashes, and the vsock control channel.
 
-- [ ] **Step 1: Unify rootfs attachment**
+- [x] **Step 1: Unify rootfs attachment**
 
   Nix-built rootfs and OCI-sourced rootfs must both be presented to the guest as block devices with explicit dm-verity roothashes. The guest mount library handles both identically. PR #1804's `unpack_layer_with_prior_paths` and `UnpackReport::paths_written` are used to materialize the OCI rootfs before sealing it into a verity block device.
 
-- [ ] **Step 2: Compute and verify roothashes**
+- [x] **Step 2: Compute and verify roothashes**
 
   The host computes the dm-verity roothash for rootfs and overlay before sending `ActivateEnvironment`. The guest recomputes/verifies during mount. A mismatch is a fatal error with explicit attribution (`ActivationError::VerityMismatch`).
 
-- [ ] **Step 3: Sign and send `ActivateEnvironment`**
+- [x] **Step 3: Sign and send `ActivateEnvironment`**
 
   The host signs the activation payload with the host-signer key, wraps it in `AuthenticatedFrame`, and sends it after the guest reports `AgentListening`. The host must wait for the `ready` acknowledgement before issuing `RunEntrypoint`.
 
 - [ ] **Step 4: Fail-closed behavior**
 
+  > **Partially landed:** the rejection half is in — malformed or inconsistent activation data fails the mount with a typed error, flips the guest to `Failed`, and the host surfaces the guest's `ActivateEnvironmentError`; the host also retries transient transport errors against a deadline. The guest-side idle timeout (shut down when activation never arrives) was not implemented: the agent waits in `Awaiting` indefinitely. Never-half-initialized holds either way — without a successful activation the agent serves no operational verb.
+
   If the host never sends activation, the guest times out and shuts down. If the host sends bad data (unknown device, bad hash, wrong `vm_id`), the guest rejects the command, emits an audit event, and shuts down. Never boot half-initialized.
 
-- [ ] **Step 5: Boot-failure attribution**
+- [x] **Step 5: Boot-failure attribution**
 
   Define typed errors so operators can distinguish:
   - `HostCommandInvalid` — host sent malformed or out-of-order data.
@@ -227,18 +239,18 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
   - `MountFailed` — kernel/filesystem error during mount.
   - `Timeout` — host never sent activation.
 
-- [ ] **Step 6: No guest network during activation**
+- [x] **Step 6: No guest network during activation**
 
   The initramfs must not bring up a NIC or perform DNS resolution. All host↔guest traffic during boot is vsock. This is enforced by construction (no NIC in the initramfs) and a CI witness.
 
-- [ ] **Step 7: Run tests and clippy**
+- [x] **Step 7: Run tests and clippy**
 
   ```bash
   cargo nextest run -p mvm-runtime -p mvm-hostd -p mvm-fs
   cargo clippy -p mvm-runtime -p mvm-hostd -p mvm-fs -- -D warnings
   ```
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
   ```bash
   git -C <wt> commit -m "feat(runtime): host-side ActivateEnvironment and unified rootfs boot path"
@@ -259,7 +271,7 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 - Produces: all drivers attach initramfs + rootfs + overlay block devices, expose vsock, and shrink `workload_base_bootargs` to console/panic/vsock.
 - Consumes: the existing `VmmSpec`, `RunningVm`, and vsock channel abstractions.
 
-- [ ] **Step 1: Shrink `workload_base_bootargs`**
+- [x] **Step 1: Shrink `workload_base_bootargs`**
 
   The initramfs owns root/init selection. Each driver's `workload_base_bootargs` returns only:
   - `console=`
@@ -280,11 +292,11 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
   `mvm_runtime::microvm::booted_with_universal_initramfs`, already the
   discriminator the runner uses to decide whether to send activation at all.
 
-- [ ] **Step 2: Attach the initramfs**
+- [x] **Step 2: Attach the initramfs**
 
   Every driver selects the content-addressed initramfs by hash from the host cache and attaches it as the boot initramfs. The hash is recorded in the VM start metadata.
 
-- [ ] **Step 3: Attach rootfs and overlay block devices**
+- [x] **Step 3: Attach rootfs and overlay block devices**
 
   Maintain the stable device mapping:
   - `/dev/vda` = workload rootfs
@@ -292,26 +304,26 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 
   Each `VmmDriver` guarantees this mapping. `ActivateEnvironment` references these paths explicitly.
 
-- [ ] **Step 4: Update `MockDriver`**
+- [x] **Step 4: Update `MockDriver`**
 
   `MockDriver` must simulate vsock and `ActivateEnvironment`; otherwise warm-path and unit tests break. It does not need real block devices, but it must exercise the same state machine and emit the same audit events.
 
-- [ ] **Step 5: HVF coordination**
+- [x] **Step 5: HVF coordination**
 
   HVF support is non-negotiable but gated on the existing rootfs work in Plan 255/265/214. Coordinate with that workstream: once HVF can attach a rootfs block device and vsock, the universal initramfs boot path applies unchanged.
 
-- [ ] **Step 6: Dev console/PTY over vsock**
+- [x] **Step 6: Dev console/PTY over vsock**
 
   The agent as PID 1 still owns the console data port. Verify that the PTY-over-vsock path works with the new initramfs and does not rely on a separate `mvm-guest-agent` process.
 
-- [ ] **Step 7: Run tests and clippy**
+- [x] **Step 7: Run tests and clippy**
 
   ```bash
   cargo nextest run -p mvm-runtime
   cargo clippy -p mvm-runtime -- -D warnings
   ```
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
   ```bash
   git -C <wt> commit -m "feat(runtime): VmmDriver initramfs attachment and shrunk bootargs"
@@ -333,21 +345,25 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 
 - [ ] **Step 1: Feature flag the new boot path**
 
+  > **Superseded:** no `--boot=universal-initramfs` flag exists. The new path shipped as the default whenever the initramfs is cached, with the legacy per-rootfs initrd as the automatic fallback when it is not — the fallback itself is the negotiation, so the flag was unnecessary (covered by the initramfs-cache BDD scenario).
+
   Add `--boot=universal-initramfs` (opt-in) with the old path as default. Keep the legacy path until BDD + live smoke pass. Host negotiates boot protocol via `ProtocolHello.capabilities`.
 
 - [ ] **Step 2: Snapshot compatibility**
 
+  > **Partially landed:** warm-restore compatibility is keyed on template identity and the standby-compat tests cover universal-initramfs parents explicitly, but the checkpoint/snapshot metadata carries no initramfs-hash field. The initramfs hash is recorded in the pack manifest (`initramfs_hash` in `mvm-core::packs`, validated at admission) — that is Step 4's surface, where the hash actually landed.
+
   The snapshot format records the initramfs hash. Restore must keep working even when the host has a different default agent version, as long as the initramfs is still in cache or can be re-fetched. Version negotiation lets a host downgrade the agent for an existing snapshot.
 
-- [ ] **Step 3: Warm snapshot restore**
+- [x] **Step 3: Warm snapshot restore**
 
   Sub-200 ms remains a warm-snapshot-restore target, not a cold-boot target. The warm parent is built from the universal initramfs and restored into memory. Do not optimize the cold initramfs path for sub-200 ms.
 
-- [ ] **Step 4: Bundle metadata**
+- [x] **Step 4: Bundle metadata**
 
   The initramfs may not need to ship inside `.mvmpkg`. The bundle manifest records the compatible initramfs hash range. Admission rejects a bundle if the required initramfs is not available on the host.
 
-- [ ] **Step 5: `mvm-setpriv` interaction**
+- [x] **Step 5: `mvm-setpriv` interaction**
 
   If light-guest WS5 lands a custom `mvm-setpriv`, decide whether to:
   - keep it in the initramfs as a fallback helper, or
@@ -355,14 +371,14 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 
   The plan should default to folding it into the agent to keep the initramfs small.
 
-- [ ] **Step 6: Run tests and clippy**
+- [x] **Step 6: Run tests and clippy**
 
   ```bash
   cargo nextest run --workspace
   cargo clippy --workspace --all-targets -- -D warnings
   ```
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
   ```bash
   git -C <wt> commit -m "feat(runtime): rollout flags, snapshot initramfs hash, bundle compatibility"
@@ -384,17 +400,19 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
 
 - [ ] **Step 1: PID-1 tests**
 
+  > **Partially landed:** signal-handling tests (shutdown flag, idempotent first signal) and the no-operational-verb-before-activation gate (plus its response-contract test) exist; there are no focused zombie-reaping tests (orphaned grandchildren / signal flood). The reaper itself is the PID-1 `SIGCHLD` `waitpid(WNOHANG)` loop.
+
   Add tests for:
   - `SIGTERM` and `SIGINT` handling;
   - zombie reaping, including orphaned grandchildren;
   - privilege drop before `ready`;
   - no workload command accepted before `ready`.
 
-- [ ] **Step 2: Mount policy tests**
+- [x] **Step 2: Mount policy tests**
 
   Verify the deny-prefix set: `/`, `/mvm`, `/mvm/runtime`, `/dev`, `/dev/vda`, `/dev/vdc`. Verify mount ordering: rootfs → overlay → custom volumes. Verify custom volumes cannot shadow rootfs/overlay.
 
-- [ ] **Step 3: Activation failure tests**
+- [x] **Step 3: Activation failure tests**
 
   - Missing activation → timeout + shutdown.
   - Roothash mismatch → shutdown.
@@ -402,7 +420,7 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
   - `ActivateEnvironment` after `ready` → protocol error + shutdown.
   - OCI rootfs boot and Nix rootfs boot both succeed.
 
-- [ ] **Step 4: BDD scenarios**
+- [x] **Step 4: BDD scenarios**
 
   Write Gherkin scenarios for:
   - cold boot of a Nix image through the universal initramfs;
@@ -411,15 +429,15 @@ HVF real rootfs bring-up remains the long pole tracked in Plan 255/265/214. This
   - mount no-shadow policy;
   - warm snapshot restore preserves initramfs hash.
 
-- [ ] **Step 5: Live smoke**
+- [x] **Step 5: Live smoke**
 
   Run live smoke on Linux (Firecracker + libkrun) and Mac (HVF when the rootfs prerequisite lands). Document any hardware-specific gaps.
 
-- [ ] **Step 6: Update claim-catalog witnesses**
+- [x] **Step 6: Update claim-catalog witnesses**
 
   Add or update witnesses for verified boot, PID-1 behavior, and activation audit events. Run `cargo xtask check-claim-catalog`.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
   ```bash
   git -C <wt> commit -m "test(conformance): BDD + unit tests for universal initramfs boot"


### PR DESCRIPTION
The Definition-of-Done bookkeeping for the universal-initramfs workstream had drifted from reality: plan 270's step checkboxes were never ticked as the work landed across seven PRs, SPRINT.md still described the Nix initramfs build that #1996 replaced with a deterministic cargo artifact, and the refactor rollup had no rows for plans 270/271.

## What changed

- **`specs/plans/270-*.md`** — status line: COMPLETE (shipped in #1914, #1931, #1933, #1936, #1968, #1985, #1996). 38 of 46 step boxes ticked, **each verified against the named code first**. 8 boxes deliberately left unticked with inline `Superseded:`/`Partially landed:` notes:
  - Superseded: capability-bit negotiation (→ path discriminator + `NotActivated` gate), chain-signed boot events (→ `ActivationState` + `BootTimingReport` + RPC audit), vm_id/session binding (→ per-boot guest key + pinned host-signer session), the Nix initramfs derivation (→ `build_initramfs_with_cargo`), the `--boot` flag (→ default-with-legacy-fallback), snapshot-side initramfs hash (→ pack manifest).
  - Genuine partial gaps, recorded honestly: the guest-side activation idle timeout and focused zombie-reaping tests were never implemented.
- **`specs/SPRINT.md`** — six minimal edits replacing the now-false Nix-initramfs claims with the deterministic cargo build; the cache-blindness retrospective's closing note marked moot (the Nix path is gone; the cargo build fails typed rather than hanging).
- **`specs/REFACTOR-STATUS.md`** — added the plan-270 row (`[x]`, with a deviations bullet mirroring the unticked steps) and the plan-271 row (`[~]`: delegation + BDD shipped; live e2e validation + claim review remain).

Docs-only; no code touched.