### PR TITLE
fix(cli): skip the legacy verity-initrd resolution when the universal initramfs is warm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,6 +2790,7 @@ dependencies = [
  "flate2",
  "hex",
  "mvm-build",
+ "mvm-cli",
  "mvm-core",
  "mvm-fs",
  "mvm-hostd",

--- a/crates/mvm-cli/src/commands/vm/up/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/up/mod.rs
@@ -11,7 +11,9 @@ use super::shared::{clap_flake_ref, clap_port_spec, clap_vm_name, clap_volume_sp
 mod admission;
 mod audit;
 mod kernel;
-mod oci_persist;
+// `pub(crate)` so the crate-root boot-policy facade can re-export the
+// effective-initrd decision; nothing else in the module is `pub`.
+pub(crate) mod oci_persist;
 mod policy;
 mod runtime_source;
 

--- a/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
+++ b/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
@@ -99,21 +99,48 @@ fn persistent_oci_rootfs_requires_overlay_policy(rootfs_path: &std::path::Path) 
     runtime_lean && verity_path.is_some() && roothash.is_some()
 }
 
-pub(crate) fn persistent_oci_effective_initrd(
+/// The legacy per-rootfs verity initrd that ships next to the rootfs image,
+/// when present.
+fn sibling_rootfs_initrd(rootfs_path: &std::path::Path) -> Option<String> {
+    rootfs_path
+        .parent()
+        .map(|dir| dir.join("rootfs.initrd"))
+        .filter(|path| path.is_file())
+        .map(|path| path.display().to_string())
+}
+
+/// Resolve the initrd a persistent OCI boot should carry: the on-disk
+/// sibling when the universal initramfs is warm in the cache (it replaces the
+/// initrd later in the boot), otherwise the legacy per-rootfs verity initrd
+/// ladder (sibling, then cached/embedded/built verity initrd, failing the
+/// boot when none is available).
+///
+/// This is the boot-policy contract surface the dev-only conformance harness
+/// drives directly; it is re-exported at `mvm_cli::boot_policy` for that
+/// harness and is not a general-purpose API.
+pub fn persistent_oci_effective_initrd(
     rootfs_path: &std::path::Path,
     runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy,
 ) -> Result<Option<String>> {
+    // When the universal initramfs is warm in the cache, the attach step later
+    // in the boot overwrites `initrd_path` with it, so resolving the legacy
+    // verity initrd here is dead work — and the resolution can cross-compile
+    // every guest binary or hard-fail a boot the universal initramfs would
+    // have carried. Skip it and hand back only what is already on disk. On a
+    // cold universal cache the legacy initrd becomes the real PID 1, so the
+    // full resolution below must run.
+    if runtime_source_policy == mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay
+        && super::runtime_source::universal_initramfs_available()
+    {
+        return Ok(sibling_rootfs_initrd(rootfs_path));
+    }
     if runtime_source_policy == mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay
         && runtime_overlay_acquire_mode() == RuntimeOverlayAcquireMode::BuildFromSourceCheckout
         && crate::commands::env::builder_vm::find_builder_vm_flake_is_source_checkout()
     {
         return Ok(Some(ensure_workload_verity_initrd()?));
     }
-    let sibling = rootfs_path
-        .parent()
-        .map(|dir| dir.join("rootfs.initrd"))
-        .filter(|path| path.is_file())
-        .map(|path| path.display().to_string());
+    let sibling = sibling_rootfs_initrd(rootfs_path);
     if sibling.is_some() {
         return Ok(sibling);
     }
@@ -491,6 +518,119 @@ mod runtime_source_policy_for_workload_boot_tests {
                     .to_str()
                     .expect("utf-8 cached initrd path")
             )
+        );
+    }
+
+    /// Install a fixture universal initramfs into `<mvm_home>/cache/initramfs`
+    /// exactly the way the real build/install path lays it out.
+    fn seed_warm_universal_initramfs(mvm_home: &std::path::Path) {
+        let version = env!("CARGO_PKG_VERSION");
+        let arch = mvm_core::arch::GuestArch::host();
+        let source = mvm_home.join("source");
+        std::fs::create_dir_all(&source).unwrap();
+        // The installer verifies the image against its hash sidecar, so the
+        // fixture has to match what the build emits: a real gzip stream, the
+        // SHA-256 of the uncompressed payload, and the compressed length.
+        let payload = b"cpio-payload";
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        std::io::Write::write_all(&mut encoder, payload).unwrap();
+        let image = encoder.finish().unwrap();
+        std::fs::write(source.join("initramfs.cpio.gz"), &image).unwrap();
+        std::fs::write(
+            source.join("initramfs.hash"),
+            format!(
+                "{}\n",
+                hex::encode(<sha2::Sha256 as sha2::Digest>::digest(payload))
+            ),
+        )
+        .unwrap();
+        std::fs::write(source.join("initramfs.size"), format!("{}\n", image.len())).unwrap();
+        std::fs::write(source.join("VERSION"), version).unwrap();
+
+        let cache_root = mvm_home.join("cache").join("initramfs");
+        mvm_build::initramfs::install_initramfs_into_cache(&source, &cache_root, version, arch)
+            .unwrap();
+        // A warm cache in a source checkout has to say what built it, or the
+        // fingerprint eviction treats it as stale and discards it.
+        if let Some(workspace_root) =
+            crate::commands::runtime_overlay::runtime_overlay_source_checkout_root()
+            && let Ok(fingerprint) =
+                mvm_build::guest_agent_build::runtime_overlay_source_checkout_fingerprint(
+                    &workspace_root,
+                )
+        {
+            mvm_build::initramfs::record_source_fingerprint(
+                &cache_root,
+                version,
+                arch,
+                &fingerprint,
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn persistent_oci_warm_universal_initramfs_skips_legacy_resolution_without_sibling() {
+        let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"rootfs").unwrap();
+
+        let cache = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(cache.path());
+        env.set(
+            crate::commands::runtime_overlay::RUNTIME_OVERLAY_ACQUIRE_MODE_ENV,
+            "download",
+        );
+        seed_warm_universal_initramfs(cache.path());
+
+        let resolved =
+            super::persistent_oci_effective_initrd(&rootfs, RuntimeSourcePolicy::RequiredOverlay)
+                .unwrap();
+
+        // No sibling and no verity-initrd cache: the legacy ladder would fail
+        // the boot here, so reaching Ok(None) proves the legacy resolution
+        // never ran — the universal attach later in the boot supplies the
+        // initramfs instead.
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn persistent_oci_warm_universal_initramfs_skips_source_checkout_verity_build() {
+        let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(_workspace_root) =
+            crate::commands::runtime_overlay::runtime_overlay_source_checkout_root()
+        else {
+            // The source-checkout branch only exists in a source checkout.
+            return;
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        let sibling = dir.path().join("rootfs.initrd");
+        std::fs::write(&rootfs, b"rootfs").unwrap();
+        std::fs::write(&sibling, b"initrd").unwrap();
+
+        let cache = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(cache.path());
+        env.set(
+            crate::commands::runtime_overlay::RUNTIME_OVERLAY_ACQUIRE_MODE_ENV,
+            "build",
+        );
+        seed_warm_universal_initramfs(cache.path());
+
+        let resolved =
+            super::persistent_oci_effective_initrd(&rootfs, RuntimeSourcePolicy::RequiredOverlay)
+                .unwrap();
+
+        // Source-checkout mode would normally rebuild/refresh the verity
+        // initrd and ignore the sibling; with a warm universal initramfs the
+        // sibling is returned as-is and no build runs.
+        assert_eq!(
+            resolved.as_deref(),
+            Some(sibling.to_str().expect("utf-8 initrd path"))
         );
     }
 

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -289,6 +289,46 @@ impl mvm_core::build_env::ShellEnvironment for HostShellEnvironment {
 /// seeded on every supported host, workloads that have a rootfs continue to
 /// boot with their legacy `/init`. Once attached, `WorkloadRunner::start_workload`
 /// will send `ActivateEnvironment` over vsock after boot.
+/// Discard a cached universal initramfs whose recorded source fingerprint no
+/// longer matches the checkout it would be attached from. Returns true when a
+/// stale artifact was evicted.
+///
+/// A source checkout rebuilds its guest binaries when they change, but the
+/// initramfs cache is keyed only on `(version, arch)` — so without this it
+/// keeps serving the artifact built before the change, and a guest-side fix
+/// appears not to have worked. Evicting on a fingerprint mismatch is what
+/// makes the next resolve rebuild rather than re-find the stale bytes.
+fn evict_stale_universal_initramfs(
+    cache_root: &std::path::Path,
+    version: &str,
+    arch: mvm_core::arch::GuestArch,
+) -> bool {
+    let Some(workspace_root) = runtime_overlay_source_checkout_root() else {
+        return false;
+    };
+    let Ok(fingerprint) =
+        mvm_build::guest_agent_build::runtime_overlay_source_checkout_fingerprint(&workspace_root)
+    else {
+        return false;
+    };
+    matches!(
+        mvm_build::initramfs::evict_if_source_changed(cache_root, version, arch, &fingerprint),
+        Ok(true)
+    )
+}
+
+/// Pure-read probe: would the universal initramfs attach from the cache
+/// without building or downloading anything? Applies the same
+/// source-fingerprint eviction as the attach path first, so a stale artifact
+/// never counts as available.
+pub(crate) fn universal_initramfs_available() -> bool {
+    let version = env!("CARGO_PKG_VERSION");
+    let cache_root = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("initramfs");
+    let arch = mvm_core::arch::GuestArch::host();
+    evict_stale_universal_initramfs(&cache_root, version, arch);
+    mvm_build::initramfs::resolve_or_seed_from_default_cache(&cache_root, version, arch).is_ok()
+}
+
 pub(crate) fn attach_universal_initramfs_if_cached(
     start_config: &mut mvm_core::vm_backend::VmStartConfig,
 ) -> Result<()> {
@@ -296,20 +336,7 @@ pub(crate) fn attach_universal_initramfs_if_cached(
     let cache_root = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("initramfs");
     let arch = mvm_core::arch::GuestArch::host();
     let env = HostShellEnvironment;
-    // A source checkout rebuilds its guest binaries when they change, but the
-    // initramfs cache is keyed only on `(version, arch)` — so without this it
-    // keeps serving the artifact built before the change, and a guest-side fix
-    // appears not to have worked. Evicting on a fingerprint mismatch is what
-    // makes the next resolve rebuild rather than re-find the stale bytes.
-    if let Some(workspace_root) =
-        crate::commands::runtime_overlay::runtime_overlay_source_checkout_root()
-        && let Ok(fingerprint) =
-            mvm_build::guest_agent_build::runtime_overlay_source_checkout_fingerprint(
-                &workspace_root,
-            )
-        && let Ok(true) =
-            mvm_build::initramfs::evict_if_source_changed(&cache_root, version, arch, &fingerprint)
-    {
+    if evict_stale_universal_initramfs(&cache_root, version, arch) {
         tracing::info!(
             initramfs_version = version,
             "guest sources changed since the cached universal initramfs was built; discarded it"
@@ -1342,29 +1369,12 @@ mod universal_initramfs_attach_tests {
     use mvm_core::util::test_env::TestEnv;
     use mvm_core::vm_backend::VmStartConfig;
 
-    #[test]
-    fn attach_universal_initramfs_if_cached_cold_cache_is_non_fatal() {
-        let mut env = TestEnv::new();
-        let dir = tempfile::tempdir().unwrap();
-        // HOME moves with MVM_HOME or the cache under test is not cold: the
-        // initramfs resolver seeds a miss from `$HOME/.mvm/cache`.
-        env.isolate_mvm_home(dir.path());
-
-        let mut sc = VmStartConfig::default();
-        // Must never return an error: a cold cache falls back to legacy boot
-        // (or is warmed automatically on hosts that can build/fetch it).
-        attach_universal_initramfs_if_cached(&mut sc).unwrap();
-    }
-
-    #[test]
-    fn attach_universal_initramfs_if_cached_attaches_from_cache() {
-        let mut env = TestEnv::new();
-        let dir = tempfile::tempdir().unwrap();
-        env.isolate_mvm_home(dir.path());
-
+    /// Install a fixture universal initramfs into `<mvm_home>/cache/initramfs`
+    /// exactly the way the real build/install path lays it out.
+    fn seed_warm_universal_initramfs(mvm_home: &std::path::Path) {
         let version = env!("CARGO_PKG_VERSION");
         let arch = GuestArch::host();
-        let source = dir.path().join("source");
+        let source = mvm_home.join("source");
         std::fs::create_dir_all(&source).unwrap();
         // The installer verifies the image against its hash sidecar, so the
         // fixture has to match what the build emits: a real gzip stream, the
@@ -1385,15 +1395,14 @@ mod universal_initramfs_attach_tests {
         std::fs::write(source.join("initramfs.size"), format!("{}\n", image.len())).unwrap();
         std::fs::write(source.join("VERSION"), version).unwrap();
 
-        let cache_root = dir.path().join("cache").join("initramfs");
+        let cache_root = mvm_home.join("cache").join("initramfs");
         mvm_build::initramfs::install_initramfs_into_cache(&source, &cache_root, version, arch)
             .unwrap();
         // A warm cache in a source checkout has to say what built it. Without a
         // fingerprint the artifact is of unknown provenance and is discarded —
         // which is the whole point of the eviction, and would make this fixture
         // describe a cache the attach path is right to refuse.
-        if let Some(workspace_root) =
-            crate::commands::runtime_overlay::runtime_overlay_source_checkout_root()
+        if let Some(workspace_root) = runtime_overlay_source_checkout_root()
             && let Ok(fingerprint) =
                 mvm_build::guest_agent_build::runtime_overlay_source_checkout_fingerprint(
                     &workspace_root,
@@ -1407,6 +1416,28 @@ mod universal_initramfs_attach_tests {
             )
             .unwrap();
         }
+    }
+
+    #[test]
+    fn attach_universal_initramfs_if_cached_cold_cache_is_non_fatal() {
+        let mut env = TestEnv::new();
+        let dir = tempfile::tempdir().unwrap();
+        // HOME moves with MVM_HOME or the cache under test is not cold: the
+        // initramfs resolver seeds a miss from `$HOME/.mvm/cache`.
+        env.isolate_mvm_home(dir.path());
+
+        let mut sc = VmStartConfig::default();
+        // Must never return an error: a cold cache falls back to legacy boot
+        // (or is warmed automatically on hosts that can build/fetch it).
+        attach_universal_initramfs_if_cached(&mut sc).unwrap();
+    }
+
+    #[test]
+    fn attach_universal_initramfs_if_cached_attaches_from_cache() {
+        let mut env = TestEnv::new();
+        let dir = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(dir.path());
+        seed_warm_universal_initramfs(dir.path());
 
         let mut sc = VmStartConfig::default();
         attach_universal_initramfs_if_cached(&mut sc).unwrap();
@@ -1422,5 +1453,54 @@ mod universal_initramfs_attach_tests {
                 .contains("initramfs.cpio.gz"),
             "attached path should point at the cpio.gz image"
         );
+    }
+
+    #[test]
+    fn universal_initramfs_available_true_on_warm_cache() {
+        let mut env = TestEnv::new();
+        let dir = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(dir.path());
+        seed_warm_universal_initramfs(dir.path());
+
+        assert!(universal_initramfs_available());
+    }
+
+    #[test]
+    fn universal_initramfs_available_false_on_cold_cache() {
+        let mut env = TestEnv::new();
+        let dir = tempfile::tempdir().unwrap();
+        // HOME moves with MVM_HOME or the cache under test is not cold: the
+        // initramfs resolver seeds a miss from `$HOME/.mvm/cache`.
+        env.isolate_mvm_home(dir.path());
+
+        assert!(!universal_initramfs_available());
+    }
+
+    #[test]
+    fn universal_initramfs_available_false_when_source_fingerprint_is_stale() {
+        let Some(_workspace_root) = runtime_overlay_source_checkout_root() else {
+            // Fingerprint eviction only applies to a source checkout.
+            return;
+        };
+        let mut env = TestEnv::new();
+        let dir = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(dir.path());
+        seed_warm_universal_initramfs(dir.path());
+
+        let version = env!("CARGO_PKG_VERSION");
+        let arch = GuestArch::host();
+        let cache_root = dir.path().join("cache").join("initramfs");
+        mvm_build::initramfs::record_source_fingerprint(
+            &cache_root,
+            version,
+            arch,
+            "stale-fingerprint",
+        )
+        .unwrap();
+
+        assert!(!universal_initramfs_available());
+        // The probe evicts the stale artifact rather than merely ignoring it,
+        // so the attach path never re-finds the same stale bytes.
+        assert!(!cache_root.join(version).join(arch.to_string()).exists());
     }
 }

--- a/crates/mvm-cli/src/lib.rs
+++ b/crates/mvm-cli/src/lib.rs
@@ -24,6 +24,14 @@ pub mod watch;
 
 pub use commands::run;
 
+/// Boot-policy contract surface for the dev-only conformance harness, which
+/// drives the real effective-initrd decision instead of re-stating it in
+/// Gherkin steps. Not a general-purpose API; other consumers must not take a
+/// dependency on it.
+pub mod boot_policy {
+    pub use crate::commands::vm::up::oci_persist::persistent_oci_effective_initrd;
+}
+
 /// Plan synthesis for library consumers — building an
 /// [`mvm_core::plan::ExecutionPlan`] from typed inputs.
 ///

--- a/crates/mvm-conformance/Cargo.toml
+++ b/crates/mvm-conformance/Cargo.toml
@@ -73,6 +73,11 @@ hex.workspace = true
 # `sdk-sidecar-image` job publishes, so the download path runs against staged
 # local bytes instead of the network.
 flate2.workspace = true
+# The sealed-OCI initrd scenarios drive the real boot-policy decision
+# (`mvm_cli::boot_policy`) in-process rather than re-stating it. Same feature
+# set the `mvmctl` binary builds with, so this adds no new closure. Dev-only:
+# `cargo tree -p mvm-conformance -e no-dev` must not gain it.
+mvm-cli = { workspace = true, features = ["builder-vm", "pure-mkfs"] }
 
 [lints]
 workspace = true

--- a/crates/mvm-conformance/tests/steps/initramfs.rs
+++ b/crates/mvm-conformance/tests/steps/initramfs.rs
@@ -6,9 +6,12 @@
 
 use cucumber::{given, then, when};
 use mvm_core::arch::GuestArch;
+use mvm_core::vm_backend::RuntimeSourcePolicy;
 use mvm_fs::initramfs::InitramfsResolver;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
 
-use crate::world::CliWorld;
+use crate::world::{CliWorld, ScenarioEnvGuard};
 
 /// Parse the entry names of a newc archive, stopping at the trailer — the
 /// layout assertion needs the exact entry sequence.
@@ -36,6 +39,147 @@ fn newc_names(cpio: &[u8]) -> Vec<String> {
 fn sha256_hex(data: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     hex::encode(Sha256::digest(data))
+}
+
+/// Env selector pinning the overlay/initrd acquisition ladder to the
+/// published-artifact mode, so a scenario running inside a source checkout
+/// never takes the cross-compile branch. Kept in sync with the CLI's
+/// `MVM_RUNTIME_OVERLAY_ACQUIRE_MODE`.
+const ACQUIRE_MODE_ENV: &str = "MVM_RUNTIME_OVERLAY_ACQUIRE_MODE";
+
+/// Isolate the whole mvm world for an in-process boot-policy scenario:
+/// `MVM_HOME` *and* `HOME` move to `home` (a cold-cache scenario must not be
+/// warmed by the developer's real default cache), and the acquisition mode
+/// is pinned so no branch reaches for a toolchain.
+fn isolated_boot_env(home: &Path) -> ScenarioEnvGuard {
+    ScenarioEnvGuard::new(&[
+        ("MVM_HOME", home.as_os_str()),
+        ("HOME", home.as_os_str()),
+        (ACQUIRE_MODE_ENV, OsStr::new("download")),
+    ])
+}
+
+/// The workspace root the boot path's source-fingerprint freshness check
+/// sees from this checkout, keyed on the same marker file it uses.
+fn source_checkout_root() -> Option<PathBuf> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).parent()?.parent()?;
+    root.join("nix")
+        .join("images")
+        .join("runtime-overlay")
+        .join("flake.nix")
+        .is_file()
+        .then(|| root.to_path_buf())
+}
+
+/// Install a universal initramfs into `<mvm_home>/cache/initramfs` exactly
+/// the way the real build/install path lays it out, including the source
+/// fingerprint a source checkout records — without it the freshness check
+/// would treat the artifact as stale and discard it.
+fn seed_warm_universal_initramfs(mvm_home: &Path) {
+    let version = env!("CARGO_PKG_VERSION");
+    let arch = GuestArch::host();
+    let source = mvm_home.join("universal-initramfs-source");
+    let cache_root = mvm_home.join("cache").join("initramfs");
+    mvm_build::initramfs::assemble_initramfs_artifact(b"bdd-static-guest-agent", version, &source)
+        .expect("assemble the initramfs artifact");
+    mvm_build::initramfs::install_initramfs_into_cache(&source, &cache_root, version, arch)
+        .expect("install the initramfs into the cache");
+    if let Some(root) = source_checkout_root() {
+        let fingerprint =
+            mvm_build::guest_agent_build::runtime_overlay_source_checkout_fingerprint(&root)
+                .expect("fingerprint the source checkout");
+        mvm_build::initramfs::record_source_fingerprint(&cache_root, version, arch, &fingerprint)
+            .expect("record the initramfs source fingerprint");
+    }
+}
+
+/// The scenario's sealed rootfs lives at a fixed spot inside its isolated
+/// home so the Given that writes it and the When that boots it agree.
+fn scenario_rootfs(mvm_home: &Path) -> PathBuf {
+    mvm_home.join("vm").join("rootfs.ext4")
+}
+
+#[given("an isolated mvm home with a warm universal initramfs cache")]
+fn isolated_home_warm_universal_initramfs(world: &mut CliWorld) {
+    let tmp = tempfile::tempdir().expect("scenario mvm home");
+    world.initramfs_boot_env = Some(isolated_boot_env(tmp.path()));
+    seed_warm_universal_initramfs(tmp.path());
+    world.isolated_home = Some(tmp);
+}
+
+#[given("an isolated mvm home with a cold universal cache but a cached legacy verity initrd")]
+fn isolated_home_cold_universal_cached_verity_initrd(world: &mut CliWorld) {
+    let tmp = tempfile::tempdir().expect("scenario mvm home");
+    world.initramfs_boot_env = Some(isolated_boot_env(tmp.path()));
+    let layout = mvm_build::verity_initrd::VerityInitrdLayout::under(
+        &tmp.path().join("cache"),
+        env!("CARGO_PKG_VERSION"),
+        GuestArch::host(),
+    );
+    std::fs::create_dir_all(&layout.dir).expect("create the verity-initrd cache dir");
+    std::fs::write(&layout.initrd, b"legacy-verity-initrd").expect("seed the legacy verity initrd");
+    world.isolated_home = Some(tmp);
+}
+
+#[given("a sealed OCI rootfs with no sibling initrd")]
+fn sealed_oci_rootfs_without_sibling_initrd(world: &mut CliWorld) {
+    let home = world
+        .isolated_home
+        .as_ref()
+        .expect("a prior step must isolate the mvm home");
+    let rootfs = scenario_rootfs(home.path());
+    std::fs::create_dir_all(rootfs.parent().expect("the rootfs has a parent dir"))
+        .expect("create the rootfs dir");
+    std::fs::write(&rootfs, b"rootfs").expect("write the rootfs");
+}
+
+#[when("the persistent OCI effective initrd is resolved for a required-overlay boot")]
+fn resolve_persistent_oci_effective_initrd(world: &mut CliWorld) {
+    let home = world
+        .isolated_home
+        .as_ref()
+        .expect("a prior step must isolate the mvm home");
+    let outcome = mvm_cli::boot_policy::persistent_oci_effective_initrd(
+        &scenario_rootfs(home.path()),
+        RuntimeSourcePolicy::RequiredOverlay,
+    )
+    .map_err(|e| format!("{e:#}"));
+    world.initramfs_boot_initrd = Some(outcome);
+}
+
+#[then("the effective initrd is empty")]
+fn effective_initrd_is_empty(world: &mut CliWorld) {
+    let outcome = world
+        .initramfs_boot_initrd
+        .as_ref()
+        .expect("a prior step must resolve the effective initrd");
+    assert_eq!(
+        outcome.as_ref().map(Option::as_deref),
+        Ok(None),
+        "a warm universal initramfs must skip the legacy initrd entirely: {outcome:?}"
+    );
+}
+
+#[then("the effective initrd is the cached legacy verity initrd")]
+fn effective_initrd_is_cached_legacy_verity_initrd(world: &mut CliWorld) {
+    let home = world
+        .isolated_home
+        .as_ref()
+        .expect("a prior step must isolate the mvm home");
+    let layout = mvm_build::verity_initrd::VerityInitrdLayout::under(
+        &home.path().join("cache"),
+        env!("CARGO_PKG_VERSION"),
+        GuestArch::host(),
+    );
+    let outcome = world
+        .initramfs_boot_initrd
+        .as_ref()
+        .expect("a prior step must resolve the effective initrd");
+    assert_eq!(
+        outcome.as_ref().map(Option::as_deref),
+        Ok(Some(layout.initrd.to_str().expect("utf-8 initrd path"))),
+        "a cold universal cache must still run the legacy verity-initrd ladder: {outcome:?}"
+    );
 }
 
 #[given("fixed guest-agent bytes for the initramfs build")]

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -51,6 +51,52 @@ impl Drop for MvmHomeGuard {
     }
 }
 
+/// Overrides a fixed set of process environment variables for the duration
+/// of one scenario and restores each previous value when the guard drops.
+///
+/// This is the process-wide counterpart of the per-command `.env(...)` the
+/// CLI steps use, for steps that drive in-process boot-policy code reading
+/// the environment (`MVM_HOME`, `HOME`, acquire-mode selectors). The BDD
+/// runner executes scenarios sequentially, so the process-global mutation is
+/// safe.
+pub struct ScenarioEnvGuard {
+    previous: Vec<(std::ffi::OsString, Option<std::ffi::OsString>)>,
+}
+
+impl ScenarioEnvGuard {
+    pub fn new(overrides: &[(&str, &std::ffi::OsStr)]) -> Self {
+        let previous = overrides
+            .iter()
+            .map(|(key, value)| {
+                let previous = std::env::var_os(key);
+                // SAFETY: the BDD runner executes scenarios sequentially, so
+                // no other thread observes the process environment while this
+                // guard is alive.
+                unsafe { std::env::set_var(key, value) };
+                (std::ffi::OsString::from(key), previous)
+            })
+            .collect();
+        Self { previous }
+    }
+}
+
+impl Drop for ScenarioEnvGuard {
+    fn drop(&mut self) {
+        for (key, previous) in &self.previous {
+            match previous {
+                Some(prev) => {
+                    // SAFETY: serial scenario execution; see `ScenarioEnvGuard::new`.
+                    unsafe { std::env::set_var(key, prev) };
+                }
+                None => {
+                    // SAFETY: serial scenario execution; see `ScenarioEnvGuard::new`.
+                    unsafe { std::env::remove_var(key) };
+                }
+            }
+        }
+    }
+}
+
 /// Constructed fresh for every scenario. Holds the result of the most
 /// recent CLI invocation so later `Then` steps can assert on it, plus the
 /// workload identities parsed from successful `build address` runs, keyed by
@@ -92,6 +138,15 @@ pub struct CliWorld {
     pub initramfs_sidecars: Option<(String, String, String)>,
     /// The resolved image path after installing the assembled initramfs.
     pub initramfs_resolved_image: Option<PathBuf>,
+    /// Process-wide env overrides held across the steps of a sealed-OCI
+    /// initrd scenario (dropped — and the previous values restored — when
+    /// the world is dropped at scenario end).
+    pub initramfs_boot_env: Option<ScenarioEnvGuard>,
+    /// Outcome of the most recent persistent-OCI effective-initrd
+    /// resolution: `Ok(Some(path))` for a resolved initrd, `Ok(None)` for
+    /// "no initrd", `Err(rendered)` for the legacy ladder's terminal
+    /// failure.
+    pub initramfs_boot_initrd: Option<Result<Option<String>, String>>,
     /// Whether live CLI steps should keep one warm standby for the next run.
     pub warm_residency: bool,
     /// Content address of the bundle a `bundle install` step registered, so the

--- a/features/suites/s14_universal_initramfs/legacy_initrd_skip.feature
+++ b/features/suites/s14_universal_initramfs/legacy_initrd_skip.feature
@@ -1,0 +1,22 @@
+Feature: Sealed OCI boots skip the legacy initrd when the universal initramfs is cached
+
+  A sealed OCI boot requires the runtime overlay, and its boot path
+  historically resolved the legacy per-rootfs verity initrd up front — a
+  resolution that can cross-compile every guest binary or fail the boot
+  outright.  When the universal initramfs is already warm in the cache it
+  replaces that initrd later in the boot, so resolving it is dead work: the
+  effective initrd is whatever already sits on disk next to the rootfs, and
+  the legacy build-or-fail ladder must not run.  On a cold universal cache
+  the legacy initrd is the real guest init, so the ladder must still run.
+
+  Scenario: A warm universal initramfs skips the legacy initrd resolution
+    Given an isolated mvm home with a warm universal initramfs cache
+    And a sealed OCI rootfs with no sibling initrd
+    When the persistent OCI effective initrd is resolved for a required-overlay boot
+    Then the effective initrd is empty
+
+  Scenario: A cold universal cache still resolves the legacy verity initrd
+    Given an isolated mvm home with a cold universal cache but a cached legacy verity initrd
+    And a sealed OCI rootfs with no sibling initrd
+    When the persistent OCI effective initrd is resolved for a required-overlay boot
+    Then the effective initrd is the cached legacy verity initrd


### PR DESCRIPTION
The sealed-OCI boot paths (persistent machine and transient `machine run`) resolved the legacy per-rootfs verity initrd **unconditionally** — up to a full `cargo zigbuild` cross-compile of every guest binary in source-checkout mode, or a hard `bail!` when no verity initrd was available. Moments later `attach_universal_initramfs_if_cached` **overwrites** `initrd_path` with the universal initramfs whenever it resolves. So on a warm universal cache the legacy resolution was dead work at best, and a boot failure the universal initramfs would have avoided at worst.

## Fix

`persistent_oci_effective_initrd` now probes the universal initramfs cache first:

- The probe is **read-only** — the same `resolve_or_seed_from_default_cache` the attach step tries first. No build, no download (never `resolve_or_build_local_initramfs`).
- It honors the **source-fingerprint eviction** exactly as the attach path does — that logic is factored into `evict_stale_universal_initramfs`, shared by both call sites, so a stale artifact never counts as available.
- **Warm cache** ⇒ return the on-disk sibling `rootfs.initrd` or `None`; the legacy ladder (cache → embedded → cross-compile → bail) never runs.
- **Cold cache** ⇒ byte-for-byte the old behavior, because the legacy initrd becomes the real guest init when the universal attach can't fire.
- Probe is gated on `RequiredOverlay`, so `PreferOverlay`/`RootfsOnly` boots never pay for it. No changes to exec.rs, checkpoint, warm-pool, or snapshot paths.

## Tests

- `runtime_source.rs`: `universal_initramfs_available` — warm ⇒ true, cold ⇒ false, stale-fingerprint ⇒ false (and evicted, not ignored); existing attach tests unchanged and green.
- `oci_persist.rs`: warm-cache skips legacy resolution (no sibling ⇒ `Ok(None)`, which pre-fix hit the failing end of the ladder) and skips the source-checkout verity build (sibling returned instead); all pre-existing cold-cache tests pass unchanged.
- **BDD**: two new hermetic scenarios in `s14_universal_initramfs/legacy_initrd_skip.feature` (warm skips; cold still resolves the legacy path) driving the real decision via a deliberately narrow `mvm_cli::boot_policy` facade (conformance-only re-export, flagged in the facade docs). Suite: 108 scenarios, all green; meta-gate passes.

## Validation

`cargo fmt --check`, `cargo clippy -p mvm-cli --all-targets -- -D warnings`, `cargo clippy -p mvm-conformance --tests --features bdd -- -D warnings`, targeted `mvm-cli` tests (14/14 oci_persist, 49/49 runtime_source), full BDD suite — all clean.