### PR TITLE
docs(warm-pool): record audited parent live validation

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -110,5 +110,7 @@ for detailed scope and acceptance criteria.
   - [x] Persistent-machine Firecracker stop fails closed and preserves state
         until process exit is verified (#2007; live KVM recheck passed)
   - [~] Live warm-launch, fork-isolation, and restore-clock verification
+        — parent audit anchoring is fixed and live-proven (#1962); the claim
+        now restores a child and stops at post-restore identity/grant re-pin
   - [ ] Typed-connector egress-policy enrichment
   - [ ] OCI-image template build path and CLI facade completion

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -883,6 +883,13 @@ Then unify + retire the old paths:
         marker ownership, exact-PID teardown, cleanup ordering, and
         reconciliation. The analogous warm-pool claim-refusal cleanup remains
         a separate open gate.
+      Factory parents now receive an authority-free admitted plan and a signed
+      `checkpoint.created` anchor before entering the pool (#1962). Live KVM
+      validation proves a production-replenished parent is anchored and the
+      next claim passes the former `ParentUnaudited` gate, restores a child, and
+      reaches post-restore signaling. It then fails closed because the child's
+      identity/grant re-pin does not complete; that handshake remains the hard
+      blocker, with egress/broker/exit channel parity still behind it.
 - [ ] A clean **external API** (`Image` / `Vm` / `Pool` / `ExecBuilder`-style) on `mvm-client`, so library and CLI share one surface.
 - [ ] **Simple, fast install:** a one-line installer + `mvmctl upgrade`.
 - Gate: the timed e2e proves sub-second launch on both hosts; warm-start + snapshot restore measured; the external API is documented and BDD-covered.

--- a/specs/notes/2026-07-28-plan-255-live-fc-warm-claim-validation.md
+++ b/specs/notes/2026-07-28-plan-255-live-fc-warm-claim-validation.md
@@ -1039,3 +1039,66 @@ as a claim latency.
 
 `standby_pool` stays `false`. The flip was not proposed: the claim is refused,
 not green.
+
+---
+
+## Sixth live run (2026-08-01 UTC) — audited parent accepted; post-restore re-pin is next
+
+Host: the same Linux 6.8.0-124 / Firecracker v1.14.1 KVM machine. Source:
+`fix/audit-standby-parent-at-spawn` at `965cdacb0`, with the Firecracker
+`standby_pool` capability enabled only in the host's validation checkout. The
+committed capability remains `false`.
+
+The new spawn path admits an authority-free plan for the factory parent and
+emits `checkpoint.created` before recording it as claimable. Two live checks
+established the boundary:
+
+1. An existing unaudited `vm_full` parent changed from
+   `recorded_creation_digest == None` to its exact signed checkpoint digest
+   after the new audit function ran.
+2. A parent replenished through the production path was immediately recorded
+   `idle`, `pid=0`, with a 512 MiB checkpoint and its creation digest already
+   resolvable from the signed chain. No repair step was needed.
+
+The next unnamed transient run found that compatible parent and crossed the
+lineage gate. The refusal is no longer `ParentUnaudited`:
+
+```text
+DEBUG machine run warm-pool eligibility mode=Transient warm_pool_size=1
+WARN  standby claim failed; cold-booting
+      standby=standby-83b9ed2a22fec8a2
+      error=claim standby: forked child 'vm-aa06291e' never answered the
+            post-restore identity handshake: signaling post-restore to vm-aa06291e
+```
+
+The runner restored a real child and reached post-restore signaling, then
+failed closed at the previously identified re-pin half of BLOCKER-3 and
+cold-booted. The failed child and cold-booted workload left no process or state
+directory behind. Replenishment produced a fresh idle parent whose creation
+digest was also present in the signed chain, proving the fix survives the
+normal claim-refusal/replenish cycle.
+
+The command later failed because this checkout's universal initramfs selected
+the sealed agent, which refuses the dev-only `Exec` verb even with
+`--profile dev`. That is independent of parent lineage and occurred after the
+warm claim had already reached the post-restore handshake.
+
+### Gate list — updated after the sixth run
+
+1. **BUG-1** — fixed and live-proven.
+2. **BUG-2** — no longer blocks claim selection.
+3. **BLOCKER-3** — now the hard blocker: the forked child is live, but its
+   post-restore identity/grant re-pin does not complete.
+4. **BLOCKER-4** — still open: parity for egress, broker, and exit channels
+   remains unproven until BLOCKER-3 clears.
+5. **Issue #1962 / BLOCKER-5** — fixed and live-proven. Parents created by the
+   production replenish path carry a signed creation anchor, and the claim
+   passes the former `ParentUnaudited` gate.
+6. **Deferred failed-stop sharp edge** — no failure reproduced in this run;
+   cleanup left no orphan, but the fail-closed implementation work remains a
+   prerequisite to arming the capability.
+7. Only then: complete the Task 7 success-path timings and consider flipping
+   `standby_pool`.
+
+`standby_pool` stays `false`: lineage is now correct, but a warm child is not
+usable until the post-restore identity handshake succeeds.

--- a/specs/plans/255-live-fc-warm-claim.md
+++ b/specs/plans/255-live-fc-warm-claim.md
@@ -1243,6 +1243,21 @@ p90 2027, max 2119, spread 353), 10/10 activated. Warm is **not** measurable
 through the claim path while #1962 stands — the ~60 ms figure is the driver-seam
 restore, not a claim latency.
 
+**Updated by the sixth live run (2026-08-01 UTC).** Issue #1962 is fixed and
+live-proven. A parent replenished through the production path carried a signed
+`checkpoint.created` anchor before it was recorded idle, and the next claim
+passed parent-lineage verification, restored a child, and reached post-restore
+signaling. It then failed closed because the child never completed the
+post-restore identity/grant re-pin. BLOCKER-3 is therefore the next hard gate;
+BLOCKER-4 remains behind it. The failed child and cold-boot fallback left no
+orphan process or state directory. `standby_pool` remains `false`, and no warm
+success latency is claimed.
+
+- [x] Parent audit sub-gate: production-replenished parents carry a signed
+      creation anchor and pass the former `ParentUnaudited` refusal.
+- [ ] Post-restore identity/grant re-pin: make the restored child complete the
+      freshness handshake before the capability can be armed.
+
 The ordered gate list — the one to work from — is "What must happen before
 `standby_pool` can flip to `true`" in
 `specs/notes/2026-07-28-plan-255-live-fc-warm-claim-validation.md`.

--- a/specs/plans/255-vsock-first-snapshot-egress-adoption.md
+++ b/specs/plans/255-vsock-first-snapshot-egress-adoption.md
@@ -4,6 +4,12 @@
 
 **Status:** Active.
 
+Current live status: Firecracker factory parents are now admitted without
+workload authority and anchored by a signed `checkpoint.created` event before
+pooling. KVM validation passes the former `ParentUnaudited` refusal and restores
+a child; post-restore identity/grant re-pin is the next fail-closed gate, so the
+Firecracker `standby_pool` capability remains disabled.
+
 > Backend sequencing, the concrete warm-start/density SLOs, the new
 > restore-path security witnesses, and the competitive-positioning
 > deliverables live in Plan 265, which depends on this plan's substrate


### PR DESCRIPTION
Follow-up to #2014.

## What changed

- Record the sixth Firecracker/KVM live validation run.
- Mark the parent-audit sub-gate fixed and live-proven.
- Update Plan 255, the sprint status, and the refactor rollup.
- Keep `standby_pool` disabled and identify post-restore identity/grant re-pin as the next hard blocker.

## Live result

A production-replenished parent carried a signed `checkpoint.created` anchor. The next claim passed the former `ParentUnaudited` refusal, restored a child, and reached post-restore signaling. It then failed closed at the already identified identity/grant re-pin gate. Cleanup left no orphan process or state directory.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p mvm-cli auditing_a_captured_parent_makes_the_claim_anchor_resolve_it`
- Live Firecracker/KVM validation on Linux 6.8.0-124 with Firecracker v1.14.1
- `git diff --check`
