### PR TITLE
fix(oci): make `machine run --image` work on a case-insensitive host

### DIFF
--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -54,6 +54,12 @@ pub struct MaterializeExt4Input {
     /// Only consulted by [`materialize_ext4_pure`] — the builder-VM path
     /// (`materialize_ext4`) doesn't stamp a label.
     pub volume_label: Option<String>,
+    /// Nodes the OCI unpacker could not place on the host tree because
+    /// the host filesystem folds case, carried here so the image still
+    /// gets them. See
+    /// [`mvm_fs::oci::unpack::UnpackReport::deferred_nodes`]. Empty on
+    /// Linux and on any case-sensitive volume.
+    pub deferred_nodes: Vec<mvm_fs::ext4::Node>,
 }
 
 impl MaterializeExt4Input {
@@ -64,7 +70,14 @@ impl MaterializeExt4Input {
             uncompressed_size_bytes,
             emit_verity: false,
             volume_label: None,
+            deferred_nodes: Vec::new(),
         }
+    }
+
+    /// Carry the unpacker's deferred nodes into the image.
+    pub fn with_deferred_nodes(mut self, deferred_nodes: Vec<mvm_fs::ext4::Node>) -> Self {
+        self.deferred_nodes = deferred_nodes;
+        self
     }
 
     /// Opt into dm-verity sidecar emission on the pure path.
@@ -139,6 +152,13 @@ pub enum RootfsError {
 
     #[error("dm-verity sidecar emission requires the `pure-mkfs` feature")]
     VerityFeatureDisabled,
+
+    #[error(
+        "the builder-VM materializer copies the host tree, so it cannot supply the {0} \
+         path(s) the host filesystem could not hold; use the in-process materializer \
+         (unset MVM_MATERIALIZE_BUILDER_VM) for this image"
+    )]
+    DeferredNodesUnsupported(usize),
 
     #[cfg(feature = "builder-vm")]
     #[error("builder VM ext4 materialization failed: {0}")]
@@ -307,6 +327,15 @@ fn materialize_ext4_in_builder_vm(
     use crate::libkrun_builder::{BuilderExtraDisk, BuilderShellJob, LibkrunBuilderVm};
     use crate::qemu_builder::QemuBuilderVm;
 
+    // This path copies `/work` (the host tree) into the mounted ext4, so
+    // it has no way to place a node the host tree never held. Fail closed
+    // rather than emit an image that is quietly missing paths.
+    if !input.deferred_nodes.is_empty() {
+        return Err(RootfsError::DeferredNodesUnsupported(
+            input.deferred_nodes.len(),
+        ));
+    }
+
     let artifact_out = input
         .output
         .parent()
@@ -435,7 +464,8 @@ pub fn materialize_ext4_pure(
     }
     // Stage-0 /work is mounted by label; every other caller leaves
     // volume_label None and gets the unchanged default-options image.
-    let mut options = mvm_fs::rootfs::MaterializeOptions::default();
+    let mut options = mvm_fs::rootfs::MaterializeOptions::default()
+        .with_extra_nodes(input.deferred_nodes.clone());
     if let Some(label) = &input.volume_label {
         options = options.with_volume_label(label.as_bytes());
     }

--- a/crates/mvm-build/src/run_image.rs
+++ b/crates/mvm-build/src/run_image.rs
@@ -39,6 +39,7 @@ pub struct InjectAndMaterializeRequest<'a> {
     entrypoint: Option<&'a OciEntrypointConfig>,
     prebuilt: Option<PrebuiltGuestBinaries<'a>>,
     sealed: bool,
+    deferred_nodes: Vec<mvm_fs::ext4::Node>,
 }
 
 impl<'a> InjectAndMaterializeRequest<'a> {
@@ -57,6 +58,7 @@ impl<'a> InjectAndMaterializeRequest<'a> {
             entrypoint: None,
             prebuilt: None,
             sealed: false,
+            deferred_nodes: Vec::new(),
         }
     }
 }
@@ -70,6 +72,7 @@ pub struct InjectAndMaterializeRequestBuilder<'a> {
     entrypoint: Option<&'a OciEntrypointConfig>,
     prebuilt: Option<PrebuiltGuestBinaries<'a>>,
     sealed: bool,
+    deferred_nodes: Vec<mvm_fs::ext4::Node>,
 }
 
 impl<'a> InjectAndMaterializeRequestBuilder<'a> {
@@ -93,6 +96,13 @@ impl<'a> InjectAndMaterializeRequestBuilder<'a> {
         self
     }
 
+    /// Carry the OCI unpacker's deferred nodes — entries a case-folding
+    /// host filesystem could not hold — into the materialized image.
+    pub fn deferred_nodes(mut self, deferred_nodes: Vec<mvm_fs::ext4::Node>) -> Self {
+        self.deferred_nodes = deferred_nodes;
+        self
+    }
+
     pub fn build(self) -> InjectAndMaterializeRequest<'a> {
         InjectAndMaterializeRequest {
             cache_root: self.cache_root,
@@ -103,6 +113,7 @@ impl<'a> InjectAndMaterializeRequestBuilder<'a> {
             entrypoint: self.entrypoint,
             prebuilt: self.prebuilt,
             sealed: self.sealed,
+            deferred_nodes: self.deferred_nodes,
         }
     }
 }
@@ -131,6 +142,7 @@ pub fn inject_and_materialize(request: InjectAndMaterializeRequest<'_>) -> Resul
         entrypoint,
         prebuilt,
         sealed,
+        deferred_nodes,
     } = request;
     let bins = resolve_guest_binaries(cache_root, prebuilt)?;
     crate::oci_runtime_inject::inject_mvm_runtime(
@@ -145,11 +157,10 @@ pub fn inject_and_materialize(request: InjectAndMaterializeRequest<'_>) -> Resul
     // Measure AFTER injection so the ext4 sizing covers the baked agent/netinit.
     let tree_size = unpacked_tree_size(unpacked_root)
         .with_context(|| format!("measure unpacked root {}", unpacked_root.display()))?;
-    materialize_run_rootfs(&MaterializeExt4Input::new(
-        unpacked_root.to_path_buf(),
-        output.to_path_buf(),
-        tree_size,
-    ))?;
+    materialize_run_rootfs(
+        &MaterializeExt4Input::new(unpacked_root.to_path_buf(), output.to_path_buf(), tree_size)
+            .with_deferred_nodes(deferred_nodes),
+    )?;
 
     // `--prod`: seal the rootfs and stand up its verity initramfs together,
     // before the sidecar is written. If this fails we surface it and never

--- a/crates/mvm-cli/src/commands/image/cache.rs
+++ b/crates/mvm-cli/src/commands/image/cache.rs
@@ -162,6 +162,53 @@ pub(super) fn unpacked_dir_if_present(cache_root: &Path, resolved_digest: &str) 
     dir.is_dir().then_some(dir)
 }
 
+/// Sidecar holding the nodes the layer unpack could not place on the
+/// host tree. It sits *beside* the unpacked root, never inside it, so it
+/// can never be walked into the image as a file of its own.
+fn deferred_nodes_sidecar(cache_root: &Path, resolved_digest: &str) -> Result<PathBuf> {
+    let hex = sha256_hex(resolved_digest)?;
+    Ok(cache_root
+        .join("unpacked")
+        .join(format!("{hex}.deferred-nodes.json")))
+}
+
+/// Persist the unpack's deferred nodes next to the unpacked tree.
+///
+/// Without this, the cache self-heal path — which re-materializes an
+/// ext4 from a surviving unpacked tree, with no layer tarballs in hand —
+/// would emit an image quietly missing every path a case-folding host
+/// could not hold. Writing nothing for the (overwhelmingly common) empty
+/// case keeps the cache layout unchanged on a case-sensitive host.
+pub(super) fn write_deferred_nodes(
+    cache_root: &Path,
+    resolved_digest: &str,
+    nodes: &[mvm_fs::ext4::Node],
+) -> Result<()> {
+    let path = deferred_nodes_sidecar(cache_root, resolved_digest)?;
+    if nodes.is_empty() {
+        let _ = fs::remove_file(&path);
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let body = serde_json::to_vec_pretty(nodes).context("serialize deferred unpack nodes")?;
+    fs::write(&path, body).with_context(|| format!("write {}", path.display()))
+}
+
+/// Read back what [`write_deferred_nodes`] stored. A missing sidecar is
+/// the normal case (nothing was deferred) and reads as empty.
+pub(super) fn read_deferred_nodes(
+    cache_root: &Path,
+    resolved_digest: &str,
+) -> Result<Vec<mvm_fs::ext4::Node>> {
+    let path = deferred_nodes_sidecar(cache_root, resolved_digest)?;
+    let Ok(body) = fs::read(&path) else {
+        return Ok(Vec::new());
+    };
+    serde_json::from_slice(&body).with_context(|| format!("parse {}", path.display()))
+}
+
 pub(super) fn sha256_hex(digest: &str) -> Result<String> {
     let Some(hex) = digest.strip_prefix("sha256:") else {
         bail!("unsupported digest algorithm in {digest:?}");
@@ -626,5 +673,76 @@ mod tests {
         let index = load_index(tmp.path()).expect("load index");
         assert_eq!(index.images.len(), 1);
         assert_eq!(index.images[0].reference, "docker.io/library/busybox:1");
+    }
+
+    const SAMPLE_DIGEST: &str =
+        "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+    #[test]
+    fn deferred_nodes_roundtrip_through_the_sidecar() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let nodes = vec![
+            mvm_fs::ext4::Node::Symlink {
+                path: "/usr/share/man/man7/pam.7.gz".to_string(),
+                target: "PAM.7.gz".to_string(),
+            },
+            mvm_fs::ext4::Node::File {
+                path: "/opt/run".to_string(),
+                mode: 0o755,
+                data: b"body".to_vec(),
+                xattrs: Vec::new(),
+            },
+        ];
+        write_deferred_nodes(tmp.path(), SAMPLE_DIGEST, &nodes).expect("write");
+        assert_eq!(
+            read_deferred_nodes(tmp.path(), SAMPLE_DIGEST).expect("read"),
+            nodes
+        );
+    }
+
+    #[test]
+    fn absent_sidecar_reads_as_nothing_deferred() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(
+            read_deferred_nodes(tmp.path(), SAMPLE_DIGEST)
+                .expect("read")
+                .is_empty(),
+            "a case-sensitive host writes no sidecar, and that is not an error"
+        );
+    }
+
+    #[test]
+    fn writing_an_empty_set_clears_a_stale_sidecar() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let nodes = vec![mvm_fs::ext4::Node::Symlink {
+            path: "/a".to_string(),
+            target: "b".to_string(),
+        }];
+        write_deferred_nodes(tmp.path(), SAMPLE_DIGEST, &nodes).expect("write");
+        write_deferred_nodes(tmp.path(), SAMPLE_DIGEST, &[]).expect("clear");
+        assert!(
+            read_deferred_nodes(tmp.path(), SAMPLE_DIGEST)
+                .expect("read")
+                .is_empty(),
+            "a re-pull that defers nothing must not inherit the old sidecar"
+        );
+    }
+
+    #[test]
+    fn the_sidecar_sits_beside_the_unpacked_tree_not_inside_it() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let nodes = vec![mvm_fs::ext4::Node::Symlink {
+            path: "/a".to_string(),
+            target: "b".to_string(),
+        }];
+        write_deferred_nodes(tmp.path(), SAMPLE_DIGEST, &nodes).expect("write");
+
+        let hex = sha256_hex(SAMPLE_DIGEST).unwrap();
+        let unpacked_root = tmp.path().join("unpacked").join(&hex);
+        std::fs::create_dir_all(&unpacked_root).unwrap();
+        assert!(
+            std::fs::read_dir(&unpacked_root).unwrap().next().is_none(),
+            "the sidecar must never be walked into the image as a file of its own"
+        );
     }
 }

--- a/crates/mvm-cli/src/commands/image/ingest.rs
+++ b/crates/mvm-cli/src/commands/image/ingest.rs
@@ -98,6 +98,7 @@ pub(super) fn ingest_archive_from_reader<R: Read>(
     fs::create_dir_all(&unpacked_root)
         .with_context(|| format!("create {}", unpacked_root.display()))?;
     let mut prior_layer_paths = std::collections::HashSet::new();
+    let mut deferred_nodes = Vec::new();
     for layer in &image.layers {
         let report = unpack_layer_bytes(
             &layer.descriptor,
@@ -107,17 +108,20 @@ pub(super) fn ingest_archive_from_reader<R: Read>(
         )
         .with_context(|| format!("unpack layer {}", layer.descriptor.digest))?;
         prior_layer_paths.extend(report.paths_written);
+        deferred_nodes.extend(report.deferred_nodes);
     }
 
     let rootfs_rel = format!("rootfs/{manifest_hex}-{}/rootfs.ext4", oci_runtime_tag());
     let rootfs_abs = cache_root.join(&rootfs_rel);
     let rootfs_only_tree =
         prepare_rootfs_only_tree(cache_root, &unpacked_root, &image.manifest_digest)?;
+    super::cache::write_deferred_nodes(cache_root, &image.manifest_digest, &deferred_nodes)?;
     materialize_overlay_lean_rootfs(
         cache_root,
         &unpacked_root,
         &rootfs_abs,
         &image.manifest_digest,
+        deferred_nodes,
     )?;
 
     let provenance = OciProvenance {

--- a/crates/mvm-cli/src/commands/image/materialize.rs
+++ b/crates/mvm-cli/src/commands/image/materialize.rs
@@ -206,8 +206,15 @@ pub(super) fn ensure_rootfs_verity_sidecars(
 /// Callback signature used to inject the mvm guest runtime and seal a rootfs.
 /// A type alias rather than a bare fn pointer everywhere it's threaded, and
 /// swappable in tests for a fake that skips the real Nix/ext4 machinery.
-pub(super) type RuntimeMaterializer =
-    fn(&Path, &Path, &Path, &str, Option<&OciEntrypointConfig>, bool) -> Result<()>;
+pub(super) type RuntimeMaterializer = fn(
+    &Path,
+    &Path,
+    &Path,
+    &str,
+    Option<&OciEntrypointConfig>,
+    bool,
+    Vec<mvm_fs::ext4::Node>,
+) -> Result<()>;
 
 pub(super) fn rematerialize_cached_image(
     cache_root: &Path,
@@ -240,6 +247,7 @@ pub(super) fn rematerialize_cached_image(
             &image.reference,
             oci_entrypoint_from_cache_path(cache_root, image.config_path.as_deref())?.as_ref(),
             prod,
+            super::cache::read_deferred_nodes(cache_root, &image.resolved_digest)?,
         )
         .with_context(|| {
             format!(
@@ -284,6 +292,7 @@ pub(super) fn inject_runtime_and_materialize(
     image_label: &str,
     entrypoint: Option<&OciEntrypointConfig>,
     sealed: bool,
+    deferred_nodes: Vec<mvm_fs::ext4::Node>,
 ) -> Result<()> {
     mvm_build::run_image::inject_and_materialize(
         mvm_build::run_image::InjectAndMaterializeRequest::builder(
@@ -296,6 +305,7 @@ pub(super) fn inject_runtime_and_materialize(
         .entrypoint(entrypoint)
         .prebuilt(embedded_guest_binaries())
         .sealed(sealed)
+        .deferred_nodes(deferred_nodes)
         .build(),
     )
 }
@@ -342,6 +352,7 @@ pub(super) fn materialize_overlay_lean_rootfs(
     raw_unpacked_root: &Path,
     rootfs_abs: &Path,
     image_label: &str,
+    deferred_nodes: Vec<mvm_fs::ext4::Node>,
 ) -> Result<()> {
     let staging_root = rootfs_abs.with_extension("staging");
     if staging_root.exists() {
@@ -362,6 +373,7 @@ pub(super) fn materialize_overlay_lean_rootfs(
         image_label,
         None,
         false,
+        deferred_nodes,
     );
     let cleanup = fs::remove_dir_all(&staging_root);
     if let Err(err) = cleanup

--- a/crates/mvm-cli/src/commands/image/pull_core.rs
+++ b/crates/mvm-cli/src/commands/image/pull_core.rs
@@ -143,6 +143,7 @@ pub(super) fn resolve_or_pull_run_image_with(
                     oci_entrypoint_from_cache_path(cache_root, image.config_path.as_deref())?
                         .as_ref(),
                     prod,
+                    super::cache::read_deferred_nodes(cache_root, &image.resolved_digest)?,
                 )
                 .with_context(|| {
                     format!(
@@ -265,6 +266,7 @@ fn pull_image_ref(
 
     let mut cached_layers = Vec::with_capacity(layers.len());
     let mut prior_layer_paths = std::collections::HashSet::new();
+    let mut deferred_nodes = Vec::new();
     for layer in &layers {
         let compressed =
             fetch_or_read_layer(cache_root, &runtime, &layer_fetcher, &image_ref, layer)
@@ -272,6 +274,7 @@ fn pull_image_ref(
         let report = unpack_layer_bytes(layer, &compressed, &unpacked_root, &prior_layer_paths)
             .with_context(|| format!("unpack layer {}", layer.digest))?;
         prior_layer_paths.extend(report.paths_written);
+        deferred_nodes.extend(report.deferred_nodes);
         cached_layers.push(CachedOciLayer {
             digest: layer.digest.clone(),
             size_bytes: layer.size,
@@ -282,6 +285,7 @@ fn pull_image_ref(
     let runtime_tag = oci_runtime_tag();
     let rootfs_path = format!("rootfs/{manifest_hex}-{runtime_tag}/rootfs.ext4");
     let rootfs_abs = cache_root.join(&rootfs_path);
+    super::cache::write_deferred_nodes(cache_root, &manifest.digest, &deferred_nodes)?;
     inject_runtime_and_materialize(
         cache_root,
         &unpacked_root,
@@ -289,6 +293,7 @@ fn pull_image_ref(
         &image_ref.canonical(),
         None,
         false,
+        deferred_nodes,
     )?;
 
     let provenance = super::oci_types::OciProvenance {
@@ -530,6 +535,7 @@ mod tests {
         image_label: &str,
         _entrypoint: Option<&OciEntrypointConfig>,
         _sealed: bool,
+        deferred_nodes: Vec<mvm_fs::ext4::Node>,
     ) -> Result<()> {
         assert!(unpacked_root.is_dir(), "unpacked root must exist");
         let parent = rootfs_abs.parent().expect("rootfs has parent");
@@ -537,6 +543,12 @@ mod tests {
         fs::write(rootfs_abs, format!("materialized:{image_label}"))?;
         fs::write(parent.join("rootfs.verity"), b"fake-verity")?;
         fs::write(parent.join("rootfs.roothash"), b"abc\n")?;
+        // A fn pointer can't capture, so the deferred set the materializer
+        // was handed is recorded on disk for the caller to assert on.
+        fs::write(
+            parent.join("deferred-seen.json"),
+            serde_json::to_vec(&deferred_nodes)?,
+        )?;
         Ok(())
     }
 
@@ -683,6 +695,58 @@ mod tests {
             fs::read_to_string(&resolved.rootfs_path).expect("read repaired rootfs"),
             "materialized:docker.io/library/alpine:3.20"
         );
+    }
+
+    #[test]
+    fn self_heal_restores_the_deferred_nodes_the_pull_recorded() {
+        // The self-heal path rebuilds an ext4 from a surviving unpacked
+        // tree with no layer tarballs in hand. On a case-folding host that
+        // tree is missing every path the host could not hold, so the
+        // rebuild has to read them back from the sidecar — otherwise the
+        // repaired image is quietly less complete than the one it replaced.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let digest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let mut image = sample_image("docker.io/library/alpine:3.20", digest, "blobs/a");
+        image.rootfs_path = Some("rootfs/alpine-deferred/rootfs.ext4".to_string());
+        image.runtime_tag = Some(oci_runtime_tag());
+        write_index(
+            tmp.path(),
+            &OciCacheIndex {
+                schema_version: 1,
+                images: vec![image],
+            },
+        );
+        write_minimal_config(tmp.path());
+        create_unpacked_root(tmp.path(), digest);
+        seed_guest_runtime_cache(tmp.path());
+
+        let deferred = vec![mvm_fs::ext4::Node::Symlink {
+            path: "/usr/share/man/man7/pam.7.gz".to_string(),
+            target: "PAM.7.gz".to_string(),
+        }];
+        crate::commands::image::cache::write_deferred_nodes(tmp.path(), digest, &deferred)
+            .expect("record deferred nodes");
+
+        let resolved = resolve_or_pull_run_image_with(
+            tmp.path(),
+            "docker.io/library/alpine:3.20",
+            false,
+            fake_runtime_materialize,
+        )
+        .expect("repair from unpacked layers");
+
+        let seen: Vec<mvm_fs::ext4::Node> = serde_json::from_slice(
+            &fs::read(
+                resolved
+                    .rootfs_path
+                    .parent()
+                    .expect("rootfs has parent")
+                    .join("deferred-seen.json"),
+            )
+            .expect("materializer recorded what it was handed"),
+        )
+        .expect("parse recorded deferred nodes");
+        assert_eq!(seen, deferred);
     }
 
     #[test]

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -396,11 +396,13 @@ fn classify_image(image: &str) -> ImageSource {
 async fn resolve_local_rootfs(image: &str, name: &str) -> Result<PathBuf> {
     match classify_image(image) {
         ImageSource::Materialized(path) => Ok(path),
-        ImageSource::UnpackedDir(dir) => materialize_from_dir(&dir, name),
+        // An already-unpacked tree carries no unpack report, so there is
+        // nothing the host filesystem deferred to merge back in.
+        ImageSource::UnpackedDir(dir) => materialize_from_dir(&dir, name, Vec::new()),
         ImageSource::Registry(reference) => {
             let staging = tempfile::tempdir().map_err(backend_err)?;
-            pull_image_to_dir(&reference, staging.path()).await?;
-            materialize_from_dir(staging.path(), name)
+            let deferred_nodes = pull_image_to_dir(&reference, staging.path()).await?;
+            materialize_from_dir(staging.path(), name, deferred_nodes)
         }
     }
 }
@@ -419,7 +421,11 @@ fn run_rootfs_output(name: &str) -> PathBuf {
 
 /// Inject the mvm runtime into an unpacked tree and materialize it into the
 /// run-rootfs cache, reusing the CLI's shared `run_image` orchestration.
-fn materialize_from_dir(dir: &Path, name: &str) -> Result<PathBuf> {
+fn materialize_from_dir(
+    dir: &Path,
+    name: &str,
+    deferred_nodes: Vec<mvm_fs::ext4::Node>,
+) -> Result<PathBuf> {
     let output = run_rootfs_output(name);
     let cache_root = PathBuf::from(mvm_core::config::mvm_cache_dir());
     // `None`: this library carries no embedded guest binaries (only the mvmctl
@@ -428,6 +434,7 @@ fn materialize_from_dir(dir: &Path, name: &str) -> Result<PathBuf> {
         mvm_build::run_image::InjectAndMaterializeRequest::builder(&cache_root, dir, &output, name)
             .profile(mvm_build::oci_runtime_inject::RuntimeInjectionProfile::RuntimeLean)
             .sealed(false)
+            .deferred_nodes(deferred_nodes)
             .build(),
     )
     .map_err(|e| backend_err(format!("{e:#}")))?;
@@ -437,7 +444,7 @@ fn materialize_from_dir(dir: &Path, name: &str) -> Result<PathBuf> {
 /// Pull a public OCI registry reference and unpack every layer into `dest`,
 /// reusing mvm-oci's fetch + hardened unpacker (gzip is decoded here, at the
 /// crate boundary, keeping mvm-oci decompressor-free by design).
-async fn pull_image_to_dir(reference: &str, dest: &Path) -> Result<()> {
+async fn pull_image_to_dir(reference: &str, dest: &Path) -> Result<Vec<mvm_fs::ext4::Node>> {
     let image_ref: ImageReference = reference
         .parse()
         .map_err(|e| backend_err(format!("parse image reference {reference:?}: {e}")))?;
@@ -455,6 +462,7 @@ async fn pull_image_to_dir(reference: &str, dest: &Path) -> Result<()> {
     let layer_fetcher =
         OciLayerFetcher::from_manifest_fetcher(&manifest_fetcher, LayerFetchOptions::default());
     let mut prior_layer_paths = std::collections::HashSet::new();
+    let mut deferred_nodes = Vec::new();
     for layer in &layers {
         let mut bytes = Vec::new();
         layer_fetcher
@@ -463,8 +471,9 @@ async fn pull_image_to_dir(reference: &str, dest: &Path) -> Result<()> {
             .map_err(|e| backend_err(format!("fetch layer {}: {e}", layer.digest)))?;
         let report = unpack_one_layer(layer, &bytes, dest, &prior_layer_paths)?;
         prior_layer_paths.extend(report.paths_written);
+        deferred_nodes.extend(report.deferred_nodes);
     }
-    Ok(())
+    Ok(deferred_nodes)
 }
 
 /// Unpack one layer's bytes into `dest`, decompressing gzip layers first.

--- a/crates/mvm-fs/src/ext4/mod.rs
+++ b/crates/mvm-fs/src/ext4/mod.rs
@@ -177,7 +177,7 @@ impl<E> From<Ext4Error> for EmitImageError<E> {
 
 /// A filesystem node to place in the image. Paths are absolute (`/`-rooted);
 /// `/` (the root) is implicit and always present.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Node {
     Dir {
         path: String,
@@ -199,7 +199,7 @@ pub enum Node {
 /// An extended attribute (name + raw value) to store in an inode's inline xattr
 /// area. `name` is fully-qualified (e.g. `security.capability`, `user.foo`);
 /// `value` is preserved verbatim.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Xattr {
     pub name: String,
     pub value: Vec<u8>,
@@ -226,7 +226,9 @@ impl BuildOptions {
 }
 
 impl Node {
-    fn path(&self) -> &str {
+    /// The node's guest-absolute path — the identity callers merge and
+    /// deduplicate node lists on.
+    pub fn path(&self) -> &str {
         match self {
             Node::Dir { path, .. } | Node::File { path, .. } | Node::Symlink { path, .. } => path,
         }

--- a/crates/mvm-fs/src/oci/unpack/case_fold.rs
+++ b/crates/mvm-fs/src/oci/unpack/case_fold.rs
@@ -1,0 +1,237 @@
+//! Host case-folding detection and the deferral index that keeps a
+//! Linux rootfs faithful on a case-insensitive host filesystem.
+//!
+//! An OCI layer routinely carries two entries whose paths differ only
+//! by case — `usr/share/man/man7/PAM.7.gz` (the page) and
+//! `usr/share/man/man7/pam.7.gz` (a symlink to it) ship in Debian's
+//! `libpam-runtime`, so every Debian-derived image has the pair. On
+//! Linux both land as distinct files. On a default macOS APFS volume
+//! they name the same file, so the second write hits `EEXIST`.
+//!
+//! Overwriting on `EEXIST` would be corruption, not a fix: it destroys
+//! the regular file and leaves a dangling self-referential symlink. So
+//! the second entry is instead **deferred** — kept out of the host tree
+//! and carried in [`super::UnpackReport::deferred_nodes`] as an ext4
+//! [`Node`], for the image writer to merge. The host tree stays the
+//! host's best effort; the ext4 image, which is what actually boots,
+//! holds both paths.
+//!
+//! Deferral is gated on two conditions, both required:
+//!
+//! 1. The filesystem backing `output_root` actually folds case
+//!    ([`probe_host_case_folding`]). On a case-sensitive host the
+//!    index is never consulted and behavior is bit-identical to before.
+//! 2. The colliding path was written **by this same unpack**. That
+//!    discriminator is what keeps the `O_EXCL` guarantee intact: a
+//!    pre-existing or externally-planted file at the target still
+//!    refuses, because it is not in the index.
+//!
+//! Only ASCII case folding is modelled. A host that also folds Unicode
+//! case or normalizes NFD/NFC (HFS+) can still collide in ways this
+//! index does not predict; those entries refuse with
+//! [`super::RefusalReason::HostPathCollision`] rather than being
+//! silently lost.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+/// Whether the filesystem backing an unpack root distinguishes two
+/// paths that differ only by ASCII case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum HostCaseFolding {
+    /// Case-distinct paths are distinct files — Linux ext4/tmpfs/overlayfs,
+    /// and APFS volumes formatted case-sensitive.
+    Sensitive,
+    /// Case-distinct paths name the same file — the macOS APFS default,
+    /// and HFS+.
+    Insensitive,
+}
+
+/// Filename used to probe the host's case behavior. Written into the
+/// unpack root and removed before the first tar entry is read, so it
+/// never reaches the assembled tree.
+const PROBE_NAME: &str = ".mvm-case-probe";
+
+/// Detect whether `output_root`'s filesystem folds case, by creating a
+/// lowercase probe file and asking for it back under an uppercase name.
+///
+/// Answers [`HostCaseFolding::Sensitive`] when the probe cannot be
+/// created at all. That is the conservative direction: it leaves the
+/// pre-existing refuse-on-`EEXIST` behavior in place rather than
+/// enabling deferral on a host we failed to characterize.
+pub(super) fn probe_host_case_folding(output_root: &Path) -> HostCaseFolding {
+    let probe = output_root.join(PROBE_NAME);
+    // `create_new` so a leftover probe from an interrupted run can't be
+    // mistaken for a successful write.
+    let _ = std::fs::remove_file(&probe);
+    if std::fs::File::create(&probe).is_err() {
+        return HostCaseFolding::Sensitive;
+    }
+    let folded = output_root.join(PROBE_NAME.to_ascii_uppercase());
+    let answer = match std::fs::symlink_metadata(&folded) {
+        Ok(_) => HostCaseFolding::Insensitive,
+        Err(_) => HostCaseFolding::Sensitive,
+    };
+    let _ = std::fs::remove_file(&probe);
+    answer
+}
+
+/// Index of the paths an unpack has materialized, keyed by their
+/// ASCII-case-folded form, so a later entry can ask "does the host
+/// already hold a file at a path that folds equal to mine, and did
+/// *I* put it there?".
+pub(super) struct CaseFoldIndex {
+    folding: HostCaseFolding,
+    /// Fold-key → the exact path that occupies the host name. Only
+    /// populated when `folding` is [`HostCaseFolding::Insensitive`];
+    /// on a case-sensitive host the map stays empty and every lookup
+    /// short-circuits.
+    occupied: HashMap<String, PathBuf>,
+}
+
+impl CaseFoldIndex {
+    /// Build the index over the paths earlier layers already wrote.
+    pub(super) fn new(folding: HostCaseFolding, prior_layer_paths: &HashSet<PathBuf>) -> Self {
+        let mut index = Self {
+            folding,
+            occupied: HashMap::new(),
+        };
+        if folding == HostCaseFolding::Insensitive {
+            for path in prior_layer_paths {
+                index.record(path);
+            }
+        }
+        index
+    }
+
+    /// Note that `rel` now occupies its host name.
+    pub(super) fn record(&mut self, rel: &Path) {
+        if self.folding == HostCaseFolding::Sensitive {
+            return;
+        }
+        self.occupied.insert(fold_key(rel), rel.to_path_buf());
+    }
+
+    /// `true` when writing `rel` would land on a host name this unpack
+    /// already filled with a *differently spelled* path — the entry is
+    /// unrepresentable on this host tree and must be deferred.
+    ///
+    /// Byte-equal paths are not collisions: an OCI layer replacing an
+    /// earlier layer's file at the identical path is ordinary
+    /// last-layer-wins behavior, handled by the prior-layer removal.
+    pub(super) fn collides(&self, rel: &Path) -> bool {
+        if self.folding == HostCaseFolding::Sensitive {
+            return false;
+        }
+        match self.occupied.get(&fold_key(rel)) {
+            Some(occupant) => occupant != rel,
+            None => false,
+        }
+    }
+}
+
+/// ASCII-case-folded lookup key for a relative path. Lossy UTF-8 is
+/// fine here: the key only has to collide for paths the host would
+/// collide, and any byte sequence that survives lossy decoding
+/// identically still compares equal.
+fn fold_key(rel: &Path) -> String {
+    rel.to_string_lossy().to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn rel(p: &str) -> PathBuf {
+        PathBuf::from(p)
+    }
+
+    #[test]
+    fn probe_answers_sensitive_when_the_root_is_not_writable() {
+        // A path that does not exist can't take the probe file.
+        let missing = Path::new("/definitely/not/a/real/unpack/root");
+        assert_eq!(
+            probe_host_case_folding(missing),
+            HostCaseFolding::Sensitive,
+            "an uncharacterizable host must keep the refuse-on-EEXIST default"
+        );
+    }
+
+    #[test]
+    fn probe_leaves_no_trace_in_the_unpack_root() {
+        let tmp = TempDir::new().unwrap();
+        let _ = probe_host_case_folding(tmp.path());
+        let leftovers: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "probe must not contribute an entry to the assembled tree, found {leftovers:?}"
+        );
+    }
+
+    #[test]
+    fn probe_matches_what_the_host_filesystem_actually_does() {
+        let tmp = TempDir::new().unwrap();
+        let probed = probe_host_case_folding(tmp.path());
+
+        // Ground truth, measured the same way the unpacker would hit it.
+        std::fs::write(tmp.path().join("Aa"), b"x").unwrap();
+        let actual = if tmp.path().join("aA").exists() {
+            HostCaseFolding::Insensitive
+        } else {
+            HostCaseFolding::Sensitive
+        };
+        assert_eq!(probed, actual);
+    }
+
+    #[test]
+    fn case_sensitive_host_never_reports_a_collision() {
+        let mut index = CaseFoldIndex::new(HostCaseFolding::Sensitive, &HashSet::new());
+        index.record(&rel("usr/PAM.7.gz"));
+        assert!(!index.collides(&rel("usr/pam.7.gz")));
+    }
+
+    #[test]
+    fn case_insensitive_host_reports_a_differently_spelled_collision() {
+        let mut index = CaseFoldIndex::new(HostCaseFolding::Insensitive, &HashSet::new());
+        index.record(&rel("usr/share/man/man7/PAM.7.gz"));
+        assert!(index.collides(&rel("usr/share/man/man7/pam.7.gz")));
+    }
+
+    #[test]
+    fn identical_path_is_a_layer_replacement_not_a_collision() {
+        let mut index = CaseFoldIndex::new(HostCaseFolding::Insensitive, &HashSet::new());
+        index.record(&rel("etc/passwd"));
+        assert!(
+            !index.collides(&rel("etc/passwd")),
+            "a later layer rewriting the same path must keep the replacement path"
+        );
+    }
+
+    #[test]
+    fn unwritten_path_is_not_a_collision() {
+        let index = CaseFoldIndex::new(HostCaseFolding::Insensitive, &HashSet::new());
+        assert!(
+            !index.collides(&rel("etc/passwd")),
+            "a path this unpack never wrote must fall through to the O_EXCL guard"
+        );
+    }
+
+    #[test]
+    fn prior_layer_paths_seed_the_index() {
+        let prior: HashSet<PathBuf> = [rel("usr/share/man/man7/PAM.7.gz")].into_iter().collect();
+        let index = CaseFoldIndex::new(HostCaseFolding::Insensitive, &prior);
+        assert!(index.collides(&rel("usr/share/man/man7/pam.7.gz")));
+    }
+
+    #[test]
+    fn distinct_paths_do_not_collide() {
+        let mut index = CaseFoldIndex::new(HostCaseFolding::Insensitive, &HashSet::new());
+        index.record(&rel("usr/bin/python3"));
+        assert!(!index.collides(&rel("usr/bin/python3.12")));
+        assert!(!index.collides(&rel("usr/bin/perl")));
+    }
+}

--- a/crates/mvm-fs/src/oci/unpack/entries.rs
+++ b/crates/mvm-fs/src/oci/unpack/entries.rs
@@ -8,10 +8,13 @@ use std::io::Read;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
+use crate::ext4::Node;
+
 use super::device_nodes::DeviceNodeAction;
 use super::fs_ops::{HardlinkAction, Rooted};
+use super::regular_file::{classify_regular_file_mode, record_setid_entry};
 use super::whiteout::{WhiteoutKind, classify_whiteout};
-use super::xattr::{PendingXattr, apply_collected_xattrs};
+use super::xattr::{PendingXattr, apply_collected_xattrs, into_ext4_xattrs};
 use super::{RefusalReason, RefusedEntry, UnpackOptions, UnpackReport};
 
 /// Per-entry inputs threaded from `unpack_layer`'s tar-iteration loop
@@ -27,6 +30,101 @@ pub(super) struct EntryCtx<'a> {
     pub(super) raw_path: &'a [u8],
     pub(super) target: &'a Path,
     pub(super) prior_layer_paths: &'a HashSet<PathBuf>,
+}
+
+/// Carry an entry the host tree cannot hold into the image instead of
+/// writing it.
+///
+/// Reached when the entry's path collides, under the host filesystem's
+/// case folding, with a path this same unpack already materialized —
+/// `usr/share/man/man7/pam.7.gz` arriving after
+/// `usr/share/man/man7/PAM.7.gz` on a default macOS APFS volume. Writing
+/// it would clobber the occupant, so the entry is captured as an ext4
+/// [`Node`] in [`UnpackReport::deferred_nodes`] and merged by the image
+/// writer, leaving both paths present in the rootfs that actually boots.
+///
+/// Only the kinds the [`Node`] enum can express are deferrable. A
+/// colliding hardlink or device node refuses with
+/// [`RefusalReason::HostPathCollision`] — an honest refusal beats an
+/// image that silently lost an inode alias.
+pub(super) fn defer_colliding_entry<R: Read>(
+    entry: &mut tar::Entry<R>,
+    entry_type: tar::EntryType,
+    ctx: &EntryCtx,
+    entry_xattrs: Vec<PendingXattr>,
+    options: &UnpackOptions,
+    report: &mut UnpackReport,
+) {
+    let path = guest_path_of(ctx.rel_path);
+    let node = match entry_type {
+        tar::EntryType::Regular | tar::EntryType::Continuous => {
+            let mode =
+                match classify_regular_file_mode(entry.header().mode().unwrap_or(0o644), options) {
+                    Ok(mode) => mode,
+                    Err(refuse) => {
+                        report.refused.push(RefusedEntry {
+                            raw_path: ctx.raw_path.to_vec(),
+                            reason: refuse,
+                        });
+                        return;
+                    }
+                };
+            let mut data = Vec::new();
+            if entry.read_to_end(&mut data).is_err() {
+                report.refused.push(RefusedEntry {
+                    raw_path: ctx.raw_path.to_vec(),
+                    reason: RefusalReason::MalformedHeader,
+                });
+                return;
+            }
+            record_setid_entry(report, ctx.raw_path, mode, options.setid_policy);
+            Node::File {
+                path,
+                mode: mode as u16,
+                data,
+                xattrs: into_ext4_xattrs(entry_xattrs),
+            }
+        }
+        tar::EntryType::Symlink => {
+            let target = match entry.link_name_bytes() {
+                Some(bytes) if !bytes.is_empty() && !bytes.contains(&0) => {
+                    String::from_utf8_lossy(&bytes).into_owned()
+                }
+                _ => {
+                    report.refused.push(RefusedEntry {
+                        raw_path: ctx.raw_path.to_vec(),
+                        reason: RefusalReason::MalformedHeader,
+                    });
+                    return;
+                }
+            };
+            Node::Symlink { path, target }
+        }
+        // Directories are created 0o755 regardless of header mode on the
+        // host path too, so the deferred node matches what the tree would
+        // otherwise have held.
+        tar::EntryType::Directory => Node::Dir {
+            path,
+            mode: 0o755,
+            xattrs: into_ext4_xattrs(entry_xattrs),
+        },
+        _ => {
+            report.refused.push(RefusedEntry {
+                raw_path: ctx.raw_path.to_vec(),
+                reason: RefusalReason::HostPathCollision,
+            });
+            return;
+        }
+    };
+
+    report.deferred_nodes.push(node);
+}
+
+/// Guest-absolute path string for the ext4 [`Node`] list, matching the
+/// shape [`crate::rootfs::collect_nodes`] produces when it walks the
+/// host tree, so deferred nodes and walked nodes are interchangeable.
+fn guest_path_of(rel: &Path) -> String {
+    format!("/{}", rel.to_string_lossy())
 }
 
 /// Materialize a `Regular`/`Continuous` tar entry: either write the

--- a/crates/mvm-fs/src/oci/unpack/fs_ops.rs
+++ b/crates/mvm-fs/src/oci/unpack/fs_ops.rs
@@ -406,10 +406,26 @@ impl<'a> Rooted<'a> {
         rel: &Path,
         prior_layer_paths: &HashSet<PathBuf>,
     ) -> Result<bool, RefusalReason> {
+        let target = self.root.join(rel);
         if prior_layer_paths.contains(rel) {
-            remove_prior_layer_path(self.root, rel)?;
+            // Only a prior-layer *non-directory* occupying this path is
+            // removed. A prior-layer directory is coalesced with, never
+            // cleared: every OCI layer re-lists the parent chain of
+            // everything it touches, so `usr/` arrives again in layer
+            // after layer, and treating that as a replacement would
+            // recursively delete everything the earlier layers put
+            // there. Clearing a directory is what the opaque whiteout
+            // marker means, and that has its own handler. Mirrors the
+            // Linux arm, which reaches the same outcome via an
+            // `unlinkat` that tolerates EISDIR plus an EEXIST coalesce.
+            let occupant_is_dir = std::fs::symlink_metadata(&target)
+                .map(|meta| meta.file_type().is_dir())
+                .unwrap_or(false);
+            if !occupant_is_dir {
+                remove_prior_layer_path(self.root, rel)?;
+            }
         }
-        create_directory(&self.root.join(rel))
+        create_directory(&target)
     }
 
     pub(super) fn write_symlink(

--- a/crates/mvm-fs/src/oci/unpack/mod.rs
+++ b/crates/mvm-fs/src/oci/unpack/mod.rs
@@ -121,7 +121,21 @@
 //! 3. **Leaf opens use `O_NOFOLLOW` + `O_EXCL`** so a symlink or a
 //!    pre-existing file planted *at the leaf* is refused (`ELOOP` /
 //!    `EEXIST`) rather than followed or overwritten.
-//! 4. **Timestamps zeroed by default.** OCI layer tarballs are
+//! 4. **A case-folding host cannot silently lose an entry.** An OCI
+//!    layer routinely carries two paths that differ only by case —
+//!    Debian's `libpam-runtime` ships `usr/share/man/man7/PAM.7.gz`
+//!    plus a `pam.7.gz` symlink to it, so every Debian-derived image
+//!    has the pair. A default macOS APFS volume names the same file for
+//!    both. The second entry is therefore **deferred**: kept out of the
+//!    host tree and carried in [`UnpackReport::deferred_nodes`] for the
+//!    ext4 writer to merge, so the image that boots holds both paths
+//!    even though the host tree cannot. Overwriting on `EEXIST` would
+//!    be corruption, not a fix — it destroys the regular file and
+//!    leaves a dangling self-referential symlink. Deferral requires the
+//!    colliding path to have been written **by this same unpack**, so
+//!    the `O_EXCL` refusal stays in force for an externally planted
+//!    file. See [`case_fold`].
+//! 5. **Timestamps zeroed by default.** OCI layer tarballs are
 //!    notoriously timestamp-dependent; the same image pulled twice
 //!    can produce non-byte-identical rootfs trees if mtime is
 //!    preserved. [`UnpackOptions::strip_timestamps`] (default `true`)
@@ -146,8 +160,11 @@
 //! writer plus directory/symlink/hardlink primitives; [`regular_file`],
 //! [`device_nodes`], and [`whiteout`] each add their own `impl Rooted`
 //! fragment and free-standing helpers for their entry kind; [`xattr`]
-//! collects and applies pax extended attributes.
+//! collects and applies pax extended attributes; [`case_fold`] detects
+//! a case-folding host and decides which entries the host tree cannot
+//! hold.
 
+mod case_fold;
 mod device_nodes;
 mod entries;
 mod fs_ops;
@@ -161,11 +178,15 @@ use std::io::Read;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
+use crate::ext4::Node;
+
+use case_fold::{CaseFoldIndex, HostCaseFolding, probe_host_case_folding};
 use entries::{
-    EntryCtx, unpack_device_entry, unpack_directory_entry, unpack_hardlink_entry,
-    unpack_regular_entry, unpack_symlink_entry,
+    EntryCtx, defer_colliding_entry, unpack_device_entry, unpack_directory_entry,
+    unpack_hardlink_entry, unpack_regular_entry, unpack_symlink_entry,
 };
 use fs_ops::{Rooted, parent_chain_has_symlink};
+use whiteout::{WhiteoutKind, classify_whiteout};
 use xattr::{XattrWarningReason, collect_entry_xattrs};
 
 /// How [`unpack_layer`] handles xattrs carried in pax headers.
@@ -307,6 +328,21 @@ pub struct UnpackReport {
     /// the stream. Each carries a [`RefusalReason`] so a downstream
     /// audit / debugging surface can render them.
     pub refused: Vec<RefusedEntry>,
+    /// Entries the host filesystem could not hold, expressed as ext4
+    /// nodes for the image writer to merge on top of the walked tree.
+    ///
+    /// Non-empty only on a case-folding host (macOS APFS by default),
+    /// where a layer carrying two paths that differ only by case —
+    /// Debian ships `usr/share/man/man7/PAM.7.gz` alongside a
+    /// `pam.7.gz` symlink to it — can materialize only the first on
+    /// disk. The rest ride here so the ext4 image stays faithful even
+    /// though the host tree cannot be. Always empty on Linux.
+    ///
+    /// Callers that materialize an image from the unpacked tree **must**
+    /// merge these; callers that consume the host tree directly (a
+    /// virtiofs share, say) cannot, and are lossy on such a host by
+    /// construction.
+    pub deferred_nodes: Vec<Node>,
 }
 
 /// One regular file whose setuid or setgid mode bit was preserved.
@@ -339,7 +375,7 @@ pub struct XattrWarning {
 /// a `String`) because the tar header can carry non-UTF-8 paths and
 /// we don't want to mask that with lossy decoding before the audit
 /// gets a chance to see it.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RefusedEntry {
     /// Path bytes from the tar header, verbatim. Render via
     /// `String::from_utf8_lossy` for human-readable output;
@@ -347,6 +383,18 @@ pub struct RefusedEntry {
     pub raw_path: Vec<u8>,
     /// Which policy rejected the entry.
     pub reason: RefusalReason,
+}
+
+/// Hand-written so the refusal an operator sees names the path. The
+/// derived form renders `raw_path` as a byte array, which turns the
+/// one fact that identifies the entry into a wall of integers.
+impl std::fmt::Debug for RefusedEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RefusedEntry")
+            .field("path", &String::from_utf8_lossy(&self.raw_path))
+            .field("reason", &self.reason)
+            .finish()
+    }
 }
 
 /// Why a tar entry was rejected. Each variant maps to one of the
@@ -390,6 +438,13 @@ pub enum RefusalReason {
     /// was enforcing production-without-cosign policy. Equivalent
     /// operator-facing error code: `E_OCI_SETUID_UNSIGNED`.
     SetuidUnsigned,
+    /// The entry's path collides, under the host filesystem's case
+    /// folding, with a path this unpack already wrote, and the entry
+    /// is of a kind the image node list cannot express (a hardlink or
+    /// a device node). Deferrable kinds — files, directories, symlinks
+    /// — never reach this variant; they land in
+    /// [`UnpackReport::deferred_nodes`] instead.
+    HostPathCollision,
     /// Tar header was malformed (unreadable path bytes, etc.). We
     /// refuse the entry rather than failing the whole unpack — a
     /// single bad entry shouldn't poison a multi-thousand-entry
@@ -412,6 +467,7 @@ impl RefusalReason {
             Self::HardlinkTargetMissing => "hardlink_target_missing",
             Self::DeviceNodeRefused => "device_node_refused",
             Self::SetuidUnsigned => "E_OCI_SETUID_UNSIGNED",
+            Self::HostPathCollision => "host_path_collision",
             Self::MalformedHeader => "malformed_header",
         }
     }
@@ -485,7 +541,7 @@ pub fn unpack_layer<R: Read>(
 /// first-creation safety for paths that are genuinely new. Same-layer
 /// duplicates remain refused.
 pub fn unpack_layer_with_prior_paths<R: Read>(
-    mut layer_tar: R,
+    layer_tar: R,
     output_root: &Path,
     options: &UnpackOptions,
     prior_layer_paths: &HashSet<PathBuf>,
@@ -499,6 +555,21 @@ pub fn unpack_layer_with_prior_paths<R: Read>(
         return Err(UnpackError::OutputRootNotADir(output_root.to_path_buf()));
     }
 
+    let folding = probe_host_case_folding(output_root);
+    unpack_layer_inner(layer_tar, output_root, options, prior_layer_paths, folding)
+}
+
+/// The unpack loop, with the host's case behavior supplied rather than
+/// probed, so tests can exercise the case-folding path on a
+/// case-sensitive host (Linux CI) and the case-sensitive path on a
+/// case-folding one (a developer's Mac).
+fn unpack_layer_inner<R: Read>(
+    mut layer_tar: R,
+    output_root: &Path,
+    options: &UnpackOptions,
+    prior_layer_paths: &HashSet<PathBuf>,
+    folding: HostCaseFolding,
+) -> Result<UnpackReport, UnpackError> {
     // Open the root once. On Linux every materialization resolves and
     // writes through this handle via `openat2(RESOLVE_IN_ROOT |
     // RESOLVE_NO_SYMLINKS)`, so the resolve-then-write is atomic
@@ -517,6 +588,7 @@ pub fn unpack_layer_with_prior_paths<R: Read>(
 
     let mut report = UnpackReport::default();
     let mut current_layer_paths = HashSet::new();
+    let mut case_fold_index = CaseFoldIndex::new(folding, prior_layer_paths);
 
     for entry_result in archive.entries()? {
         let mut entry = match entry_result {
@@ -631,6 +703,29 @@ pub fn unpack_layer_with_prior_paths<R: Read>(
             target: &target,
             prior_layer_paths,
         };
+
+        // Safety check 6 — the host name this entry wants is already
+        // held by a differently-spelled path *this unpack wrote*. The
+        // host filesystem folds case (macOS APFS) and cannot represent
+        // both, so carry the entry into the image instead of letting
+        // the write clobber the occupant. A path we did not write is
+        // deliberately not covered: that keeps the `O_EXCL` refusal in
+        // place for a planted file. Whiteout markers are exempt — they
+        // remove a sibling rather than occupy a name of their own.
+        if case_fold_index.collides(&rel_path)
+            && matches!(classify_whiteout(&raw_path), WhiteoutKind::None)
+        {
+            defer_colliding_entry(
+                &mut entry,
+                entry_type,
+                &ctx,
+                entry_xattrs,
+                options,
+                &mut report,
+            );
+            continue;
+        }
+
         match entry_type {
             tar::EntryType::Regular | tar::EntryType::Continuous => unpack_regular_entry(
                 &mut entry,
@@ -671,6 +766,13 @@ pub fn unpack_layer_with_prior_paths<R: Read>(
                     reason: RefusalReason::UnsupportedEntryType,
                 });
             }
+        }
+
+        // The handlers insert into `current_layer_paths` only on a
+        // successful materialization, so this mirrors exactly the host
+        // names that are now occupied.
+        if current_layer_paths.contains(&rel_path) {
+            case_fold_index.record(&rel_path);
         }
     }
 
@@ -857,6 +959,254 @@ mod tests {
     use super::*;
     use std::io::Cursor;
     use tempfile::TempDir;
+
+    /// The `PAM.7.gz` / `pam.7.gz` pair that Debian's `libpam-runtime`
+    /// puts in every Debian-derived image, including the `python:*`
+    /// family. This is the exact shape that broke
+    /// `machine run --image python:3.12` on macOS.
+    fn debian_pam_manpage_layer() -> Vec<u8> {
+        build_tar(|b| {
+            add_dir(b, "usr/share/man/man7");
+            add_file(b, "usr/share/man/man7/PAM.7.gz", b"the real page");
+            add_symlink(b, "usr/share/man/man7/pam.7.gz", "PAM.7.gz");
+        })
+    }
+
+    fn unpack_forcing(
+        tar_bytes: Vec<u8>,
+        root: &Path,
+        folding: HostCaseFolding,
+    ) -> Result<UnpackReport, UnpackError> {
+        unpack_layer_inner(
+            Cursor::new(tar_bytes),
+            root,
+            &UnpackOptions::default(),
+            &HashSet::new(),
+            folding,
+        )
+    }
+
+    #[test]
+    fn case_folding_host_defers_the_colliding_entry_into_the_image() {
+        let tmp = TempDir::new().unwrap();
+        let report = unpack_forcing(
+            debian_pam_manpage_layer(),
+            tmp.path(),
+            HostCaseFolding::Insensitive,
+        )
+        .expect("unpack ok");
+
+        assert!(
+            report.refused.is_empty(),
+            "a case collision must not fail the layer: {:?}",
+            report.refused
+        );
+        assert_eq!(report.files_written, 1);
+        assert_eq!(
+            report.symlinks_written, 0,
+            "the symlink cannot occupy the folded host name"
+        );
+        assert_eq!(
+            report.deferred_nodes,
+            vec![Node::Symlink {
+                path: "/usr/share/man/man7/pam.7.gz".to_string(),
+                target: "PAM.7.gz".to_string(),
+            }],
+            "the symlink must survive as an image node with its exact path"
+        );
+        // The occupant is intact — not clobbered by the colliding write.
+        assert_eq!(
+            std::fs::read(tmp.path().join("usr/share/man/man7/PAM.7.gz")).unwrap(),
+            b"the real page"
+        );
+    }
+
+    #[test]
+    fn both_case_variants_reach_the_image_on_any_host() {
+        // The property that has to hold everywhere, through the real
+        // probing entry point: after unpacking Debian's man-page pair,
+        // both spellings are present in what the image writer will see
+        // — on disk where the host can hold them, deferred where it
+        // cannot. This is the regression that broke
+        // `machine run --image python:3.12` on macOS.
+        let tmp = TempDir::new().unwrap();
+        let report = unpack_layer(
+            Cursor::new(debian_pam_manpage_layer()),
+            tmp.path(),
+            &UnpackOptions::default(),
+        )
+        .expect("unpack ok");
+
+        assert!(report.refused.is_empty(), "{:?}", report.refused);
+        for spelling in ["PAM.7.gz", "pam.7.gz"] {
+            let rel = format!("usr/share/man/man7/{spelling}");
+            let on_disk = report.paths_written.contains(&PathBuf::from(&rel));
+            let deferred = report
+                .deferred_nodes
+                .iter()
+                .any(|node| node.path() == format!("/{rel}"));
+            assert!(
+                on_disk || deferred,
+                "{rel} reached neither the host tree nor the deferred node list"
+            );
+        }
+    }
+
+    #[test]
+    fn a_later_layer_redeclaring_a_directory_keeps_the_earlier_layer_contents() {
+        // Every OCI layer re-lists the parent chain of everything it
+        // touches, so `usr/` and `usr/lib/` appear in layer after layer.
+        // A re-declaration carries the directory's metadata; it does NOT
+        // mean "clear this directory" — only an explicit `.wh..wh..opq`
+        // marker does. Treating it as a replacement recursively deletes
+        // everything the earlier layers put there, which empties a
+        // multi-layer image down to whatever its last layer happened to
+        // list.
+        let tmp = TempDir::new().unwrap();
+        let opts = UnpackOptions::default();
+
+        let layer1 = build_tar(|b| {
+            add_dir(b, "usr");
+            add_dir(b, "usr/lib");
+            add_file(b, "usr/lib/libc.so", b"from layer 1");
+        });
+        let first = unpack_layer(Cursor::new(layer1), tmp.path(), &opts).expect("layer 1 unpacks");
+        assert!(first.refused.is_empty(), "{:?}", first.refused);
+
+        let layer2 = build_tar(|b| {
+            add_dir(b, "usr");
+            add_dir(b, "usr/lib");
+            add_file(b, "usr/lib/libm.so", b"from layer 2");
+        });
+        let second = unpack_layer_with_prior_paths(
+            Cursor::new(layer2),
+            tmp.path(),
+            &opts,
+            &first.paths_written,
+        )
+        .expect("layer 2 unpacks");
+        assert!(second.refused.is_empty(), "{:?}", second.refused);
+
+        assert_eq!(
+            std::fs::read(tmp.path().join("usr/lib/libc.so")).ok(),
+            Some(b"from layer 1".to_vec()),
+            "re-declaring usr/lib must not delete what an earlier layer put in it"
+        );
+        assert_eq!(
+            std::fs::read(tmp.path().join("usr/lib/libm.so")).ok(),
+            Some(b"from layer 2".to_vec())
+        );
+    }
+
+    #[test]
+    fn a_later_layer_replacing_a_file_with_a_directory_still_replaces_it() {
+        // The other side of the same rule: a genuine *type* change from a
+        // prior layer must still remove the occupant, or the directory
+        // could never be created.
+        let tmp = TempDir::new().unwrap();
+        let opts = UnpackOptions::default();
+
+        let layer1 = build_tar(|b| add_file(b, "opt/thing", b"i am a file"));
+        let first = unpack_layer(Cursor::new(layer1), tmp.path(), &opts).expect("layer 1 unpacks");
+
+        let layer2 = build_tar(|b| {
+            add_dir(b, "opt/thing");
+            add_file(b, "opt/thing/inner", b"now a directory");
+        });
+        let second = unpack_layer_with_prior_paths(
+            Cursor::new(layer2),
+            tmp.path(),
+            &opts,
+            &first.paths_written,
+        )
+        .expect("layer 2 unpacks");
+        assert!(second.refused.is_empty(), "{:?}", second.refused);
+
+        assert!(tmp.path().join("opt/thing").is_dir());
+        assert_eq!(
+            std::fs::read(tmp.path().join("opt/thing/inner")).ok(),
+            Some(b"now a directory".to_vec())
+        );
+    }
+
+    #[test]
+    fn deferral_does_not_excuse_a_path_this_unpack_never_wrote() {
+        // A file planted at the target out-of-band is exactly what the
+        // O_EXCL guard exists for. It is not in the fold index, so the
+        // entry must not be deferred past the guard — on a folding host
+        // it refuses, and on either host the plant is left alone.
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("usr")).unwrap();
+        std::fs::write(tmp.path().join("usr/Planted"), b"pre-existing").unwrap();
+
+        let tar_bytes = build_tar(|b| add_file(b, "usr/planted", b"layer content"));
+        let report =
+            unpack_forcing(tar_bytes, tmp.path(), HostCaseFolding::Insensitive).expect("unpack ok");
+
+        assert!(
+            report.deferred_nodes.is_empty(),
+            "an unwritten path must not be treated as our own collision"
+        );
+        assert_eq!(
+            std::fs::read(tmp.path().join("usr/Planted")).unwrap(),
+            b"pre-existing",
+            "the planted file must survive untouched"
+        );
+    }
+
+    #[test]
+    fn colliding_hardlink_refuses_rather_than_silently_dropping_the_alias() {
+        let tmp = TempDir::new().unwrap();
+        let tar_bytes = build_tar(|b| {
+            add_file(b, "bin/Tool", b"payload");
+            add_hardlink(b, "bin/tool", "bin/Tool");
+        });
+        let report =
+            unpack_forcing(tar_bytes, tmp.path(), HostCaseFolding::Insensitive).expect("unpack ok");
+
+        assert!(report.deferred_nodes.is_empty());
+        assert_eq!(report.refused.len(), 1, "{:?}", report.refused);
+        assert_eq!(
+            report.refused[0].reason,
+            RefusalReason::HostPathCollision,
+            "a hardlink has no image-node form, so it must refuse loudly"
+        );
+    }
+
+    #[test]
+    fn deferred_file_carries_its_bytes_and_mode() {
+        let tmp = TempDir::new().unwrap();
+        let tar_bytes = build_tar(|b| {
+            add_file_with_mode(b, "opt/Run", b"first", 0o644);
+            add_file_with_mode(b, "opt/run", b"second", 0o755);
+        });
+        let report =
+            unpack_forcing(tar_bytes, tmp.path(), HostCaseFolding::Insensitive).expect("unpack ok");
+
+        assert!(report.refused.is_empty(), "{:?}", report.refused);
+        assert_eq!(
+            report.deferred_nodes,
+            vec![Node::File {
+                path: "/opt/run".to_string(),
+                mode: 0o755,
+                data: b"second".to_vec(),
+                xattrs: Vec::new(),
+            }]
+        );
+    }
+
+    #[test]
+    fn refused_entry_debug_names_the_path() {
+        let refused = RefusedEntry {
+            raw_path: b"usr/share/man/man7/pam.7.gz".to_vec(),
+            reason: RefusalReason::HostPathCollision,
+        };
+        let rendered = format!("{refused:?}");
+        assert!(
+            rendered.contains("usr/share/man/man7/pam.7.gz"),
+            "a refusal must name the path, got {rendered}"
+        );
+    }
 
     #[test]
     fn happy_path_writes_files_dirs_symlinks() {

--- a/crates/mvm-fs/src/oci/unpack/regular_file.rs
+++ b/crates/mvm-fs/src/oci/unpack/regular_file.rs
@@ -182,7 +182,7 @@ fn write_regular_file<R: Read>(
     Ok(())
 }
 
-fn classify_regular_file_mode(
+pub(super) fn classify_regular_file_mode(
     raw_mode: u32,
     options: &UnpackOptions,
 ) -> Result<u32, RefusalReason> {
@@ -198,7 +198,12 @@ fn classify_regular_file_mode(
     }
 }
 
-fn record_setid_entry(report: &mut UnpackReport, raw_path: &[u8], mode: u32, policy: SetidPolicy) {
+pub(super) fn record_setid_entry(
+    report: &mut UnpackReport,
+    raw_path: &[u8],
+    mode: u32,
+    policy: SetidPolicy,
+) {
     if mode & SETID_MODE_BITS == 0 {
         return;
     }

--- a/crates/mvm-fs/src/oci/unpack/xattr.rs
+++ b/crates/mvm-fs/src/oci/unpack/xattr.rs
@@ -21,6 +21,21 @@ pub(super) struct PendingXattr {
     value: Vec<u8>,
 }
 
+/// Convert collected pax xattrs into the ext4 writer's representation,
+/// for an entry that is being carried into the image as a
+/// [`crate::ext4::Node`] rather than written to the host tree. Names
+/// have already passed [`classify_xattr_name`]'s allow-list, so this is
+/// a pure shape change.
+pub(super) fn into_ext4_xattrs(attrs: Vec<PendingXattr>) -> Vec<crate::ext4::Xattr> {
+    attrs
+        .into_iter()
+        .map(|attr| crate::ext4::Xattr {
+            name: String::from_utf8_lossy(&attr.name).into_owned(),
+            value: attr.value,
+        })
+        .collect()
+}
+
 /// Why an xattr was dropped.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum XattrWarningReason {

--- a/crates/mvm-fs/src/rootfs.rs
+++ b/crates/mvm-fs/src/rootfs.rs
@@ -241,6 +241,12 @@ pub struct MaterializeOptions {
     pub walk: WalkOptions,
     /// Superblock metadata (UUID, volume label) stamped on the image.
     pub build: BuildOptions,
+    /// Nodes to place in the image that the walk cannot find on the host
+    /// tree. This is how an OCI unpack carries the entries a case-folding
+    /// host filesystem refused to hold — see
+    /// [`crate::oci::unpack::UnpackReport::deferred_nodes`]. A node here
+    /// wins over a walked node at the same path.
+    pub extra_nodes: Vec<Node>,
 }
 
 impl MaterializeOptions {
@@ -269,6 +275,31 @@ impl MaterializeOptions {
         self.build = build;
         self
     }
+
+    /// Add nodes the host tree cannot supply, merged over the walk.
+    pub fn with_extra_nodes(mut self, extra_nodes: Vec<Node>) -> Self {
+        self.extra_nodes = extra_nodes;
+        self
+    }
+}
+
+/// Merge `extra` over `walked`, last-wins by path.
+///
+/// The two lists are disjoint in practice — an unpack defers a node
+/// precisely because the host tree could not hold it, so the walk cannot
+/// have found it. The dedup is a guard against emitting two directory
+/// entries with the same name if a caller ever passes an overlapping
+/// node, which would produce a structurally invalid image rather than a
+/// loud error.
+fn merge_extra_nodes(mut walked: Vec<Node>, extra: Vec<Node>) -> Vec<Node> {
+    if extra.is_empty() {
+        return walked;
+    }
+    let overridden: std::collections::HashSet<&str> =
+        extra.iter().map(|node| node.path()).collect();
+    walked.retain(|node| !overridden.contains(node.path()));
+    walked.extend(extra);
+    walked
 }
 
 /// Materialize the directory tree at `root` into an ext4 image at `output`,
@@ -285,7 +316,10 @@ pub fn materialize_ext4_pure(
     output: &Path,
     options: &MaterializeOptions,
 ) -> Result<MaterializedImage, MaterializeError> {
-    let nodes = collect_nodes(root, options.walk)?;
+    let nodes = merge_extra_nodes(
+        collect_nodes(root, options.walk)?,
+        options.extra_nodes.clone(),
+    );
     if let Some(parent) = output.parent() {
         std::fs::create_dir_all(parent).map_err(|source| MaterializeError::Write {
             path: parent.to_path_buf(),
@@ -728,5 +762,70 @@ mod tests {
             ..SizeHeuristic::default()
         };
         assert_eq!(heuristic.estimate(1), Err(InvalidSizeMultiplier));
+    }
+
+    #[test]
+    fn extra_nodes_reach_the_image_alongside_the_walked_tree() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().join("tree");
+        std::fs::create_dir_all(root.join("usr/share/man/man7")).unwrap();
+        std::fs::write(root.join("usr/share/man/man7/PAM.7.gz"), b"page").unwrap();
+
+        let deferred = Node::Symlink {
+            path: "/usr/share/man/man7/pam.7.gz".to_string(),
+            target: "PAM.7.gz".to_string(),
+        };
+        let options = MaterializeOptions::default().with_extra_nodes(vec![deferred.clone()]);
+
+        let walked = collect_nodes(&root, options.walk).unwrap();
+        assert!(
+            !walked.iter().any(|n| n.path() == deferred.path()),
+            "the walk cannot see a path the host tree does not hold"
+        );
+
+        let merged = merge_extra_nodes(walked, options.extra_nodes.clone());
+        assert!(merged.contains(&deferred));
+        assert!(
+            merged
+                .iter()
+                .any(|n| n.path() == "/usr/share/man/man7/PAM.7.gz"),
+            "merging must not displace the walked occupant"
+        );
+
+        // And the whole thing emits a real image.
+        let image = tmp.path().join("rootfs.ext4");
+        let out = materialize_ext4_pure(&root, &image, &options).expect("materialize");
+        assert!(out.size_bytes > 0);
+    }
+
+    #[test]
+    fn an_extra_node_overrides_a_walked_node_at_the_same_path() {
+        let walked = vec![Node::File {
+            path: "/etc/motd".to_string(),
+            mode: 0o644,
+            data: b"walked".to_vec(),
+            xattrs: Vec::new(),
+        }];
+        let extra = vec![Node::File {
+            path: "/etc/motd".to_string(),
+            mode: 0o600,
+            data: b"extra".to_vec(),
+            xattrs: Vec::new(),
+        }];
+
+        let merged = merge_extra_nodes(walked, extra.clone());
+        assert_eq!(
+            merged, extra,
+            "a duplicate path must resolve to one node, not two directory entries"
+        );
+    }
+
+    #[test]
+    fn empty_extra_nodes_leave_the_walk_untouched() {
+        let walked = vec![Node::Symlink {
+            path: "/bin/sh".to_string(),
+            target: "bash".to_string(),
+        }];
+        assert_eq!(merge_extra_nodes(walked.clone(), Vec::new()), walked);
     }
 }


### PR DESCRIPTION
`mvmctl machine run --image python:3.12` — the README's headline OCI example —
fails on macOS. Two independent defects on that path, both macOS-only.

Closes #2028, closes #2029.

## 1. A case-folding host cannot hold two paths that differ only by case

```
Error: unpack layer sha256:6b89e501…
Caused by:
    layer unpack refused entries: [RefusedEntry { raw_path: [117, 115, …],
      reason: MalformedHeader }]
```

`raw_path` is `usr/share/man/man7/pam.7.gz`. Debian's `libpam-runtime` ships
`PAM.7.gz` alongside a `pam.7.gz` symlink to it, so every Debian-derived image
carries the pair. On a default APFS volume the second write hits `EEXIST`,
`write_symlink` mapped every error to `MalformedHeader`, and any refusal fails
the whole pull.

Overwriting on `EEXIST` would be corruption, not a fix — it destroys the
regular file and leaves a dangling self-referential symlink. So the entry is
**deferred**: kept out of the host tree and carried in
`UnpackReport::deferred_nodes` as an ext4 node the image writer merges. The host
tree stays the host's best effort; the image that boots holds both paths.

Guardrails:

- Deferral requires the colliding path to have been written **by the same
  unpack**, so `O_EXCL` still refuses an externally planted file.
- Gated on a probe of the actual filesystem — a case-sensitive host is
  bit-identical to before, and the new `case_fold` module is the only place
  that decides.
- A colliding hardlink or device node has no node form and refuses loudly as
  `HostPathCollision` rather than vanishing.
- The deferred set is persisted beside the unpacked tree: the cache self-heal
  path rebuilds an ext4 from a surviving tree with no layer tarballs in hand,
  and would otherwise emit a quietly less complete image than the one it
  replaced.
- The builder-VM materializer copies the host tree and cannot supply these
  nodes, so it fails closed instead of emitting a lossy image.

## 2. Multi-layer unpack deleted earlier layers on non-Linux hosts

Exposed once the first fix let the loop reach layer 2. `create_directory`
removes a prior-layer occupant before creating the directory. The Linux arm
deliberately tolerates `EISDIR` and coalesces on `mkdirat`'s `EEXIST`; the
non-Linux fallback called `remove_dir_all`. Since every OCI layer re-lists the
parent chain of everything it touches, `usr/` arriving again recursively deleted
everything earlier layers had put there.

Measured on `python:3.12` before the fix — 26,235 files reported written, **0
refused**, 31 entries surviving on disk. Nothing refuses, so no caller can
detect the loss.

The fallback now matches the Linux contract: a prior-layer *directory* is
coalesced with, never cleared (clearing is what an opaque whiteout means, and
that has its own handler). A genuine file→directory type change still replaces.
Both directions are pinned by tests that run on every platform so the two
implementations cannot drift again.

Refusals also now render their path as a path rather than a byte array.

## Verification

End to end on macOS (case-insensitive APFS):

```
$ mvmctl machine run --image python:3.12 -- python -c "print(2 + 2)"
4

$ mvmctl machine run --image python:3.12 -- ls -la /usr/share/man/man7/PAM.7.gz /usr/share/man/man7/pam.7.gz
-rw-r--r-- 1 root root 2323 Jan  1 00:00 /usr/share/man/man7/PAM.7.gz
lrwxrwxrwx 1 root root    8 Jan  1 00:00 /usr/share/man/man7/pam.7.gz -> PAM.7.gz
```

Unpacked tree: 33,070 entries (was 31). Both case variants present in the booted
guest, and the symlink resolves.

Gates: `cargo +nightly fmt --all --check`, `cargo clippy --workspace
--all-targets -D warnings`, `cargo nextest run --workspace` (8529 passed),
`cargo test --workspace --doc`, and the `check-no-spec-refs-in-comments` /
`check-honesty` / `check-no-overclaim` / `check-claim-catalog` /
`check-vsock-only-egress` / `check-uniform-vsock-egress` /
`check-forbidden-deps` / `check-core-runtime-free` / `check-single-home` /
`check-test-home-isolation` / `check-duplicate-majors` /
`check-content-address-determinism` / `check-deferrals` /
`check-no-network-literals` xtask gates.

## Not covered

`prepare_rootfs_only_tree` hands the raw host tree to the virtiofs/rootfs-only
path, which stays lossy on a case-folding host — documented on
`deferred_nodes`. The structural fix is to stop using the host filesystem as the
OCI intermediate at all; that is tracked as follow-up in #2028, not attempted
here.