### PR TITLE
Fail closed when stopping Firecracker machines

### DIFF
--- a/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
@@ -395,6 +395,55 @@ mod reap_orphans_tests {
     }
 
     #[test]
+    fn reap_spares_live_firecracker_workload_under_launchd() {
+        let mut supervisor = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn stand-in Firecracker supervisor");
+        let supervisor_pid = supervisor.id() as i32;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let vms_root = dir.path().join("vms");
+        let vm = vms_root.join("mvm-workload-livetest-fc-running");
+        std::fs::create_dir_all(&vm).expect("mkdir");
+        let helper_cmd = format!("sleep 30 # {}", vm.file_name().unwrap().to_string_lossy());
+        let mut helper = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(&helper_cmd)
+            .spawn()
+            .expect("spawn stand-in helper");
+        let helper_pid = helper.id() as i32;
+        let snapshot = ProcSnapshot::from_parts(
+            [(supervisor_pid, 1), (helper_pid, 1)].into_iter().collect(),
+            vec![(helper_pid, helper_cmd)],
+        );
+        std::fs::write(vm.join("fc.pid"), format!("{supervisor_pid}\n")).expect("write pid");
+
+        let out = reap_orphaned_vm_helpers_at_with_snapshot(
+            &vms_root,
+            WORKLOAD_SIDECARS,
+            false,
+            true,
+            false,
+            &snapshot,
+        )
+        .expect("reap");
+
+        assert_eq!(
+            out.killed, 0,
+            "a live Firecracker supervisor must protect its helper"
+        );
+        assert!(
+            pid_is_alive(helper_pid),
+            "helper of live Firecracker was wrongly killed"
+        );
+
+        let _ = supervisor.kill();
+        let _ = supervisor.wait();
+        let _ = helper.kill();
+        let _ = helper.wait();
+    }
+
+    #[test]
     fn reap_still_kills_orphaned_ephemeral_builder_under_launchd() {
         let (mut child, pid, snapshot) = alive_child_under_launchd();
 

--- a/crates/mvm-cli/src/commands/env/builder_vm/vm_helpers.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/vm_helpers.rs
@@ -98,9 +98,10 @@ pub(super) const BUILDER_SIDECARS: &[&str] = &["builder.pid", "stage0.pid"];
 
 /// Sidecar PID file names a workload VM dir under `~/.mvm/vms/<name>/`.
 /// `vz.pid` stays recognised so a leftover from the removed Vz backend still
-/// gets reaped; live HVF supervisors write `hvf.pid` (mvm-runtime's
-/// `vm::reconcile::PID_FILE_NAMES` recognises the same pair).
-pub(super) const WORKLOAD_SIDECARS: &[&str] = &["libkrun.pid", "vz.pid", "hvf.pid"];
+/// gets reaped. Keep this aligned with the workload supervisor markers in
+/// mvm-runtime's reconciliation pass so every live backend protects its
+/// associated helper processes.
+pub(super) const WORKLOAD_SIDECARS: &[&str] = &["libkrun.pid", "vz.pid", "hvf.pid", "fc.pid"];
 
 /// Dir-name prefix of the persistent dev builder VM.
 const PERSISTENT_BUILDER_DIR_PREFIX: &str = "mvm-persistent-builder-";
@@ -286,7 +287,7 @@ fn reap_or_track(
 fn is_supervisor_sidecar(name: &str) -> bool {
     matches!(
         name,
-        "builder.pid" | "stage0.pid" | "vz.pid" | "libkrun.pid" | "hvf.pid"
+        "builder.pid" | "stage0.pid" | "vz.pid" | "libkrun.pid" | "hvf.pid" | "fc.pid"
     )
 }
 

--- a/crates/mvm-cli/src/commands/machine/lifecycle.rs
+++ b/crates/mvm-cli/src/commands/machine/lifecycle.rs
@@ -245,8 +245,9 @@ pub(super) fn shell_machine(cli: &Cli, args: MachineShellArgs, cfg: &MvmConfig) 
 }
 
 pub(super) fn stop_machine(cli: &Cli, args: MachineStopArgs, cfg: &MvmConfig) -> Result<()> {
-    if !args.yes {
-        use std::io::IsTerminal as _;
+    use std::io::IsTerminal as _;
+
+    confirm_stop(args.yes, std::io::stdin().is_terminal(), || {
         let prompt = if args.all {
             "Stop all running machines?".to_string()
         } else if args.names.len() == 1 {
@@ -258,12 +259,8 @@ pub(super) fn stop_machine(cli: &Cli, args: MachineStopArgs, cfg: &MvmConfig) ->
                 args.names.join(", ")
             )
         };
-        let confirmed = std::io::stdin().is_terminal() && crate::ui::confirm(&prompt);
-        if !confirmed {
-            println!("aborted");
-            return Ok(());
-        }
-    }
+        crate::ui::confirm(&prompt)
+    })?;
     if args.all {
         return down::run(cli, down::Args { name: None }, cfg);
     }
@@ -282,6 +279,23 @@ pub(super) fn stop_machine(cli: &Cli, args: MachineStopArgs, cfg: &MvmConfig) ->
     }
     if had_err {
         anyhow::bail!("one or more machines failed to stop");
+    }
+    Ok(())
+}
+
+pub(super) fn confirm_stop(
+    yes: bool,
+    stdin_is_terminal: bool,
+    prompt: impl FnOnce() -> bool,
+) -> Result<()> {
+    if yes {
+        return Ok(());
+    }
+    if !stdin_is_terminal {
+        anyhow::bail!("refusing to stop without confirmation; pass --yes");
+    }
+    if !prompt() {
+        anyhow::bail!("stop aborted");
     }
     Ok(())
 }

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -2023,6 +2023,38 @@ fn machine_stop_yes_skips_confirmation() {
 }
 
 #[test]
+fn machine_stop_without_tty_refuses_with_an_error() {
+    let err = super::lifecycle::confirm_stop(false, false, || {
+        panic!("a non-interactive stop must not try to prompt")
+    })
+    .expect_err("non-interactive stop without --yes must fail");
+
+    assert!(
+        err.to_string().contains("pass --yes"),
+        "error must tell automation how to proceed: {err:#}"
+    );
+}
+
+#[test]
+fn machine_stop_yes_bypasses_confirmation_without_a_tty() {
+    super::lifecycle::confirm_stop(true, false, || {
+        panic!("--yes must bypass the confirmation prompt")
+    })
+    .expect("--yes must permit a non-interactive stop");
+}
+
+#[test]
+fn machine_stop_declined_at_tty_refuses_with_an_error() {
+    let err = super::lifecycle::confirm_stop(false, true, || false)
+        .expect_err("declining a stop must not report success");
+
+    assert!(
+        err.to_string().contains("aborted"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
 fn machine_stop_requires_target() {
     let err = parse(&["stop"]).expect_err("no name and no --all must be rejected");
     assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);

--- a/crates/mvm-runtime/src/driver/fc.rs
+++ b/crates/mvm-runtime/src/driver/fc.rs
@@ -323,25 +323,26 @@ enum KillOutcome {
     StillRunning,
 }
 
-/// Deliver `signal` to the sudo-launched Firecracker process recorded in
-/// `pid_file`. Firecracker is started under `sudo` and runs as **root**, so a
+/// Deliver `signal` to an already-captured, identity-checked Firecracker PID.
+/// Firecracker is started under `sudo` and runs as **root**, so a
 /// non-root `mvmctl` cannot signal it directly — a plain `libc::kill` returns
 /// `EPERM` and silently no-ops. The signal therefore goes through `sudo kill`,
 /// the same mechanism the raw stop path uses. Best-effort: a delivery failure
 /// is logged, and the caller's liveness probe is the authority on whether the
 /// process actually stopped (so a lost race with a self-exiting process is not
 /// mistaken for a failure).
-fn fc_sudo_signal(pid_file: &str, signal: FcStopSignal) {
+fn fc_sudo_signal(pid: u32, signal: FcStopSignal) {
     let flag = match signal {
         FcStopSignal::Terminate => "",
         FcStopSignal::ForceKill => " -9",
     };
-    let q_pid = crate::base::shell::shell_quote(pid_file);
-    let script = format!(r#"[ -f {q_pid} ] && sudo kill{flag} "$(cat {q_pid})""#);
+    let script = format!(
+        r#"[ -f "/proc/{pid}/comm" ] && [ "$(cat /proc/{pid}/comm)" = "firecracker" ] && sudo kill{flag} {pid}"#
+    );
     match crate::base::shell::run_in_vm(&script) {
         Ok(out) if out.status.success() => {}
         Ok(_) | Err(_) => tracing::warn!(
-            "Firecracker stop signal {signal:?} to pid in {pid_file} did not report success \
+            "Firecracker stop signal {signal:?} to pid {pid} did not report success \
              (the process may have already exited)"
         ),
     }
@@ -375,6 +376,26 @@ fn resolve_standby_parent_pid(
     })
 }
 
+/// Clear a dead process's stale marker before a new launch. A live marker is
+/// retained and the launch is refused: replacing it would make the existing
+/// Firecracker invisible to every normal list, stop, and orphan-reap path.
+fn clear_stale_pid_marker_for_start(
+    pid_file: &Path,
+    is_running: impl FnOnce() -> Result<bool>,
+) -> Result<()> {
+    if !pid_file.exists() {
+        return Ok(());
+    }
+    if is_running()? {
+        bail!(
+            "Firecracker recorded by {} is already running; refusing to replace its pid marker",
+            pid_file.display()
+        );
+    }
+    std::fs::remove_file(pid_file)
+        .with_context(|| format!("remove stale Firecracker pid marker {}", pid_file.display()))
+}
+
 /// SIGTERM → grace → SIGKILL escalation against a Firecracker process, mirroring
 /// the raw stop path's shutdown escalation. The liveness probe, signal
 /// delivery, clock, and sleep are injected so the decision — "did the process
@@ -405,6 +426,49 @@ fn escalate_kill(
         Ok(KillOutcome::StillRunning)
     } else {
         Ok(KillOutcome::Stopped)
+    }
+}
+
+fn remove_pid_marker_if_matches(pid_file: &Path, pid: u32) {
+    let marker_matches = std::fs::read_to_string(pid_file)
+        .map(|recorded| recorded.trim() == pid.to_string())
+        .unwrap_or(false);
+    if marker_matches {
+        let _ = std::fs::remove_file(pid_file);
+    }
+}
+
+/// Terminate one already-captured Firecracker process and remove its marker
+/// only after that exact PID is proven gone. The caller must capture `pid`
+/// while `pid_file` is still trusted; this function never rereads the marker
+/// for liveness or signal delivery.
+pub(crate) fn terminate_firecracker_pid(name: &str, pid: u32, pid_file: &Path) -> Result<()> {
+    let outcome = escalate_kill(
+        crate::libkrun::STOP_TIMEOUT,
+        Duration::from_millis(100),
+        || crate::firecracker::is_firecracker_pid_running(pid),
+        |signal| fc_sudo_signal(pid, signal),
+        Instant::now,
+        std::thread::sleep,
+    )?;
+    finish_firecracker_kill(name, pid, pid_file, outcome)
+}
+
+fn finish_firecracker_kill(
+    name: &str,
+    pid: u32,
+    pid_file: &Path,
+    outcome: KillOutcome,
+) -> Result<()> {
+    match outcome {
+        KillOutcome::AlreadyStopped | KillOutcome::Stopped => {
+            remove_pid_marker_if_matches(pid_file, pid);
+            Ok(())
+        }
+        KillOutcome::StillRunning => bail!(
+            "Firecracker VM '{name}' is still running after SIGTERM and SIGKILL; \
+             the stop signal could not be delivered"
+        ),
     }
 }
 
@@ -589,17 +653,20 @@ impl VmmDriver for FcDriver {
         let state_dir = vm_state_dir(&spec.name);
         std::fs::create_dir_all(&state_dir)
             .map_err(|e| anyhow!("create state dir {}: {e}", state_dir.display()))?;
+        let pid_file = fc_pid_path(&spec.name)
+            .ok_or_else(|| anyhow!("resolve Firecracker pid path for '{}'", spec.name))?;
+        // Clear only a marker proven stale. Removing a live process's marker
+        // would orphan that Firecracker as soon as this launch overwrote the
+        // rest of its state directory.
+        let pid_file_str = pid_file.to_string_lossy().into_owned();
+        clear_stale_pid_marker_for_start(&pid_file, || {
+            crate::firecracker::is_vm_running(&pid_file_str)
+        })?;
+
         let runtime_dir = state_dir.join("runtime");
         std::fs::create_dir_all(&runtime_dir)
             .map_err(|e| anyhow!("create runtime dir {}: {e}", runtime_dir.display()))?;
-
         let abs_dir = state_dir.to_string_lossy().into_owned();
-        let pid_file = fc_pid_path(&spec.name)
-            .ok_or_else(|| anyhow!("resolve Firecracker pid path for '{}'", spec.name))?;
-        // Clear the stale pid marker so the readiness poll observes only this
-        // launch's process (the captured exit code is cleared with the rest of
-        // the host channel set, in `arm_host_channels`).
-        let _ = std::fs::remove_file(&pid_file);
 
         // Convert the workload kernel to an FC-loadable image (x86_64 bzImage →
         // extracted ELF; aarch64 Image passthrough), reusing the same helper the
@@ -642,7 +709,6 @@ impl VmmDriver for FcDriver {
         // Confirm the guest is up: a successful agent CONNECT over the vsock mux
         // means userspace booted and the agent is listening. Bounded so a guest
         // that never comes up fails closed rather than hanging forever.
-        let pid_file_str = pid_file.to_string_lossy().into_owned();
         let deadline = Instant::now() + AGENT_READY_TIMEOUT;
         loop {
             // Fail fast if Firecracker itself died on boot (kernel panic,
@@ -672,6 +738,9 @@ impl VmmDriver for FcDriver {
             id: VmId(spec.name.clone()),
             state_dir,
             pid_file,
+            pid: Some(read_firecracker_pid(&abs_dir).with_context(|| {
+                format!("capture Firecracker pid for '{}' after boot", spec.name)
+            })?),
             vsock_uds,
         });
         firecracker_guard.defuse();
@@ -686,8 +755,18 @@ impl VmmDriver for FcDriver {
         let vsock_uds = firecracker_vsock_uds_path(&state_dir.to_string_lossy());
         let pid_file = fc_pid_path(&id.0)
             .ok_or_else(|| anyhow!("resolve Firecracker pid path for '{}'", id.0))?;
+        let pid = if pid_file.exists() {
+            Some(
+                read_firecracker_pid(&state_dir.to_string_lossy()).with_context(|| {
+                    format!("capture Firecracker pid for '{}' while attaching", id.0)
+                })?,
+            )
+        } else {
+            None
+        };
         Ok(Box::new(FcRunningVm {
             pid_file,
+            pid,
             state_dir,
             vsock_uds,
             id: id.clone(),
@@ -706,39 +785,12 @@ struct FcRunningVm {
     id: VmId,
     state_dir: PathBuf,
     pid_file: PathBuf,
+    /// Process identity captured while attaching, before any sidecar teardown
+    /// can remove the recovery marker. `None` represents an already-stopped VM.
+    pid: Option<u32>,
     /// The single host-side vsock mux UDS (`<state_dir>/runtime/v.sock`); the
     /// host dials guest ports through the CONNECT handshake on this socket.
     vsock_uds: String,
-}
-
-impl FcRunningVm {
-    /// The kill escalation with the grace timeout, liveness probe, signal
-    /// delivery, and clock injected, so the fail-closed pid-retention decision
-    /// is unit-testable without a live VM or a wall-clock grace wait. `kill`
-    /// wires the real FC `/proc` probe + sudo signal here.
-    fn kill_with(
-        &self,
-        grace: Duration,
-        poll: Duration,
-        is_running: impl FnMut() -> Result<bool>,
-        signal: impl FnMut(FcStopSignal),
-        now: impl FnMut() -> Instant,
-        sleep: impl FnMut(Duration),
-    ) -> Result<()> {
-        match escalate_kill(grace, poll, is_running, signal, now, sleep)? {
-            KillOutcome::AlreadyStopped | KillOutcome::Stopped => {
-                let _ = std::fs::remove_file(&self.pid_file);
-                Ok(())
-            }
-            // Fail closed: do NOT remove the pid file or report success when the
-            // signal never landed — that would orphan a live root VM silently.
-            KillOutcome::StillRunning => bail!(
-                "Firecracker VM '{}' is still running after SIGTERM and SIGKILL; \
-                 the stop signal could not be delivered",
-                self.id.0
-            ),
-        }
-    }
 }
 
 impl RunningVm for FcRunningVm {
@@ -759,15 +811,10 @@ impl RunningVm for FcRunningVm {
         // through sudo (reaching the root process) and probe liveness
         // ownership-independently via /proc/<pid>/comm; the escalation is
         // SIGTERM → grace → SIGKILL, mirroring the raw stop path.
-        let pid_file = self.pid_file.to_string_lossy().into_owned();
-        self.kill_with(
-            crate::libkrun::STOP_TIMEOUT,
-            Duration::from_millis(100),
-            || crate::firecracker::is_vm_running(&pid_file),
-            |signal| fc_sudo_signal(&pid_file, signal),
-            Instant::now,
-            std::thread::sleep,
-        )
+        let Some(pid) = self.pid else {
+            return Ok(());
+        };
+        terminate_firecracker_pid(&self.id.0, pid, &self.pid_file)
     }
 
     fn pause(&self) -> Result<()> {
@@ -785,7 +832,9 @@ impl RunningVm for FcRunningVm {
         // running-VM's `libc::kill(pid, 0)` probe returns EPERM from a non-root
         // mvmctl and would misreport a live VM as Stopped. Probe ownership-
         // independently via /proc/<pid>/comm, reusing FC's own liveness helper.
-        if crate::firecracker::is_vm_running(&self.pid_file.to_string_lossy())? {
+        if let Some(pid) = self.pid
+            && crate::firecracker::is_firecracker_pid_running(pid)?
+        {
             Ok(VmStatus::Running)
         } else {
             Ok(VmStatus::Stopped)
@@ -1192,6 +1241,7 @@ mod tests {
             id: VmId("root-vm".into()),
             state_dir: PathBuf::from("/state/root-vm"),
             pid_file: PathBuf::from("/state/root-vm/fc.pid"),
+            pid: Some(4242),
             vsock_uds: "/state/root-vm/runtime/v.sock".into(),
         };
         let running = crate::base::shell_mock::install_handler(|_| {
@@ -1218,13 +1268,90 @@ mod tests {
             id: VmId("gone-vm".into()),
             state_dir: dir.path().to_path_buf(),
             pid_file: pid_file.clone(),
+            pid: Some(4242),
             vsock_uds: "/state/gone-vm/runtime/v.sock".into(),
         };
-        let _guard = crate::base::shell_mock::install_handler(|_| {
-            crate::base::shell_mock::MockResponse::ok("no")
+        let _guard = crate::base::shell_mock::install_handler(|script| {
+            if script.starts_with("cat ") {
+                crate::base::shell_mock::MockResponse::ok("4242")
+            } else {
+                crate::base::shell_mock::MockResponse::ok("no")
+            }
         });
         vm.kill().unwrap();
         assert!(!pid_file.exists(), "pid marker must be removed on kill");
+    }
+
+    #[test]
+    fn kill_tracks_the_captured_pid_after_the_marker_disappears() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("fc.pid");
+        std::fs::write(&pid_file, "4242").unwrap();
+        let vm = FcRunningVm {
+            id: VmId("marker-race-vm".into()),
+            state_dir: dir.path().to_path_buf(),
+            pid_file: pid_file.clone(),
+            pid: Some(4242),
+            vsock_uds: "/state/marker-race-vm/runtime/v.sock".into(),
+        };
+        let probes = Arc::new(AtomicUsize::new(0));
+        let handler_probes = Arc::clone(&probes);
+        let marker = pid_file.clone();
+        let _guard = crate::base::shell_mock::install_handler(move |script| {
+            if script.starts_with("cat ") {
+                return crate::base::shell_mock::MockResponse::ok("4242");
+            }
+            if script.contains("sudo kill") {
+                std::fs::remove_file(&marker).unwrap();
+                assert!(script.contains("sudo kill 4242"));
+                assert!(!script.contains("fc.pid"));
+                return crate::base::shell_mock::MockResponse::ok("");
+            }
+            assert!(script.contains("/proc/4242/comm"));
+            let probe = handler_probes.fetch_add(1, Ordering::SeqCst);
+            crate::base::shell_mock::MockResponse::ok(if probe == 0 { "yes" } else { "no" })
+        });
+
+        vm.kill()
+            .expect("marker loss must not lose the captured process identity");
+
+        assert_eq!(probes.load(Ordering::SeqCst), 2);
+        assert!(!pid_file.exists());
+    }
+
+    #[test]
+    fn start_refuses_to_replace_the_pid_marker_of_a_live_firecracker() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("fc.pid");
+        std::fs::write(&pid_file, "4242").unwrap();
+
+        let err = clear_stale_pid_marker_for_start(&pid_file, || Ok(true))
+            .expect_err("a second start must refuse a live Firecracker");
+
+        assert!(
+            err.to_string().contains("already running"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&pid_file).unwrap(),
+            "4242",
+            "the only handle to the live process must remain intact"
+        );
+    }
+
+    #[test]
+    fn start_removes_a_stale_pid_marker_after_proving_the_process_is_gone() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("fc.pid");
+        std::fs::write(&pid_file, "4242").unwrap();
+
+        clear_stale_pid_marker_for_start(&pid_file, || Ok(false))
+            .expect("a dead process leaves a removable stale marker");
+
+        assert!(!pid_file.exists());
     }
 
     #[test]
@@ -1312,28 +1439,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let pid_file = dir.path().join("fc.pid");
         std::fs::write(&pid_file, "4242").unwrap();
-        let vm = FcRunningVm {
-            id: VmId("wedged-vm".into()),
-            state_dir: dir.path().to_path_buf(),
-            pid_file: pid_file.clone(),
-            vsock_uds: "/state/wedged-vm/runtime/v.sock".into(),
-        };
-        let base = Instant::now();
-        let tick = std::cell::Cell::new(0u64);
-        let now = || {
-            let n = tick.get();
-            tick.set(n + 1);
-            base + Duration::from_millis(n)
-        };
-        let err = vm
-            .kill_with(
-                Duration::from_millis(1),
-                Duration::from_millis(10),
-                || Ok(true),
-                |_| {},
-                now,
-                |_| {},
-            )
+        let err = finish_firecracker_kill("wedged-vm", 4242, &pid_file, KillOutcome::StillRunning)
             .expect_err("kill must fail closed when the signal can't land");
         assert!(
             err.to_string().contains("still running"),
@@ -1356,14 +1462,16 @@ mod tests {
             sink.lock().unwrap().push(s.to_string());
             crate::base::shell_mock::MockResponse::empty()
         });
-        fc_sudo_signal("/state/vm/fc.pid", FcStopSignal::Terminate);
-        fc_sudo_signal("/state/vm/fc.pid", FcStopSignal::ForceKill);
+        fc_sudo_signal(4242, FcStopSignal::Terminate);
+        fc_sudo_signal(4242, FcStopSignal::ForceKill);
         let captured = scripts.lock().unwrap();
         assert!(
             captured[0].contains("sudo kill "),
             "SIGTERM: {}",
             captured[0]
         );
+        assert!(captured[0].contains("/proc/4242/comm"));
+        assert!(captured[0].ends_with("sudo kill 4242"));
         assert!(
             !captured[0].contains("kill -9"),
             "SIGTERM must not force: {}",
@@ -1374,6 +1482,7 @@ mod tests {
             "ForceKill: {}",
             captured[1]
         );
+        assert!(captured[1].ends_with("sudo kill -9 4242"));
     }
 
     #[test]
@@ -1410,6 +1519,7 @@ mod tests {
             id: VmId("agent-vm".into()),
             state_dir: dir.path().to_path_buf(),
             pid_file: dir.path().join("fc.pid"),
+            pid: None,
             vsock_uds: vsock.to_string_lossy().into_owned(),
         };
 
@@ -1436,6 +1546,7 @@ mod tests {
             id: VmId("console-vm".into()),
             state_dir: PathBuf::from("/state/console-vm"),
             pid_file: PathBuf::from("/state/console-vm/fc.pid"),
+            pid: None,
             vsock_uds: "/nonexistent/runtime/v.sock".into(),
         };
         // In range but no listener ⇒ a connect error (not an allow-list refusal).

--- a/crates/mvm-runtime/src/firecracker.rs
+++ b/crates/mvm-runtime/src/firecracker.rs
@@ -283,6 +283,19 @@ pub fn is_vm_running(pid_file: &str) -> Result<bool> {
     Ok(result.trim() == "yes")
 }
 
+/// Check whether one already-captured PID still names a Firecracker process.
+///
+/// Unlike [`is_vm_running`], this probe does not depend on the PID marker still
+/// existing. Teardown captures the marker once, then uses this identity until
+/// the process is proven gone so a concurrently removed marker cannot turn a
+/// live process into a false "stopped" result.
+pub fn is_firecracker_pid_running(pid: u32) -> Result<bool> {
+    let result = run_in_vm_stdout(&format!(
+        r#"[ -f "/proc/{pid}/comm" ] && [ "$(cat /proc/{pid}/comm)" = "firecracker" ] && echo yes || echo no"#,
+    ))?;
+    Ok(result.trim() == "yes")
+}
+
 /// Name of the Firecracker VM-state file produced by `PUT /snapshot/create`.
 pub const FC_VMSTATE_FILENAME: &str = "vmstate.bin";
 

--- a/crates/mvm-runtime/src/microvm/control.rs
+++ b/crates/mvm-runtime/src/microvm/control.rs
@@ -8,7 +8,7 @@ use crate::base::ui;
 use crate::firecracker;
 
 use super::observe::list_vms;
-use super::{abs_vms_dir, require_linux_env};
+use super::{abs_vms_dir, read_firecracker_pid, require_linux_env};
 
 /// Pause the vCPUs of a running Firecracker VM.
 ///
@@ -170,6 +170,22 @@ fn await_graceful_exit(
     Ok(false)
 }
 
+/// Remove per-VM runtime state only after the Firecracker process is proven
+/// gone. Keeping the directory on failure preserves the pid marker, API socket,
+/// logs, and other evidence needed to retry or diagnose the stop.
+fn cleanup_stopped_vm_state(
+    name: &str,
+    is_running: impl FnOnce() -> Result<bool>,
+    cleanup: impl FnOnce() -> Result<()>,
+) -> Result<()> {
+    if is_running()? {
+        anyhow::bail!(
+            "Firecracker VM '{name}' is still running; retaining its state for retry and recovery"
+        );
+    }
+    cleanup()
+}
+
 pub fn stop_vm(name: &str) -> Result<()> {
     require_linux_env()?;
 
@@ -194,6 +210,12 @@ pub fn stop_vm(name: &str) -> Result<()> {
         ui::info(&format!("VM '{}' is not running.", name));
         return Ok(());
     }
+    // Capture the process identity while the marker is known-good. From this
+    // point onward, marker presence is recovery metadata only: every liveness
+    // decision uses the captured PID so losing `fc.pid` cannot make a live
+    // Firecracker look stopped.
+    let pid = read_firecracker_pid(&abs_dir)
+        .with_context(|| format!("read Firecracker pid for VM '{name}' before stop"))?;
 
     ui::info(&format!("Stopping VM '{}'...", name));
 
@@ -214,32 +236,28 @@ pub fn stop_vm(name: &str) -> Result<()> {
     let exited_gracefully = await_graceful_exit(
         std::time::Duration::from_millis(250),
         std::time::Duration::from_millis(25),
-        || firecracker::is_vm_running(&pid_file),
+        || firecracker::is_firecracker_pid_running(pid),
         std::time::Instant::now,
         std::thread::sleep,
     )?;
 
-    // Clean up the API socket either way; only fall back to a hard kill when
-    // the guest ignored the ACPI request within the graceful window.
-    if exited_gracefully {
-        run_in_vm(&format!("sudo rm -f {socket}", socket = socket))?;
-    } else {
-        run_in_vm(&format!(
-            r#"
-            if [ -f {pid} ]; then
-                sudo kill $(cat {pid}) 2>/dev/null || true
-            fi
-            sudo rm -f {socket}
-            "#,
-            pid = pid_file,
-            socket = socket,
-        ))?;
+    // The driver owns the verified SIGTERM → SIGKILL escalation. It reports an
+    // error and retains the pid marker if the process survives both signals.
+    if !exited_gracefully {
+        crate::driver::fc::terminate_firecracker_pid(name, pid, std::path::Path::new(&pid_file))
+            .with_context(|| format!("terminate Firecracker VM '{name}'"))?;
     }
 
-    // Remove the VM directory
-    if let Err(e) = run_in_vm(&format!("rm -rf {}", abs_dir)) {
-        warn!("failed to remove VM directory: {e}");
-    }
+    let q_abs_dir = shell_quote(&abs_dir);
+    cleanup_stopped_vm_state(
+        name,
+        || firecracker::is_firecracker_pid_running(pid),
+        || {
+            run_in_vm(&format!("rm -rf {q_abs_dir}"))
+                .map(|_| ())
+                .with_context(|| format!("remove stopped VM state {abs_dir}"))
+        },
+    )?;
 
     ui::success(&format!("VM '{}' stopped.", name));
     Ok(())
@@ -357,5 +375,44 @@ mod tests {
             result.is_err(),
             "a failing liveness probe must surface, not be swallowed"
         );
+    }
+
+    #[test]
+    fn cleanup_refuses_to_remove_state_while_firecracker_is_alive() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("fc.pid"), "4242").unwrap();
+        let cleanup_called = Cell::new(false);
+
+        let err = cleanup_stopped_vm_state(
+            "wedged-vm",
+            || Ok(true),
+            || {
+                cleanup_called.set(true);
+                std::fs::remove_dir_all(dir.path()).map_err(Into::into)
+            },
+        )
+        .expect_err("live Firecracker state must be retained");
+
+        assert!(
+            err.to_string().contains("still running"),
+            "unexpected error: {err:#}"
+        );
+        assert!(!cleanup_called.get());
+        assert!(dir.path().join("fc.pid").exists());
+    }
+
+    #[test]
+    fn cleanup_removes_state_after_firecracker_exit_is_verified() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("fc.pid"), "4242").unwrap();
+
+        cleanup_stopped_vm_state(
+            "stopped-vm",
+            || Ok(false),
+            || std::fs::remove_dir_all(dir.path()).map_err(Into::into),
+        )
+        .expect("verified-stopped state can be removed");
+
+        assert!(!dir.path().exists());
     }
 }

--- a/crates/mvm-runtime/src/vm/reconcile.rs
+++ b/crates/mvm-runtime/src/vm/reconcile.rs
@@ -211,11 +211,12 @@ pub fn sweep(
 }
 
 /// Supervisor pid-file names a per-VM state dir may carry. `pid` is the
-/// Apple-Container dev-VM owner file; `libkrun.pid` / `vz.pid` / `hvf.pid` are
-/// the workload-supervisor files (one per backend). The first one that exists
-/// and points at a live process marks the dir as having a live owner. HVF must
-/// be listed here or convergence reaps every running HVF machine's state dir.
-const PID_FILE_NAMES: &[&str] = &["libkrun.pid", "vz.pid", "hvf.pid", "pid"];
+/// Apple-Container dev-VM owner file; `libkrun.pid` / `vz.pid` / `hvf.pid` /
+/// `fc.pid` are the workload-supervisor files (one per backend). The first one
+/// that exists and points at a live process marks the dir as having a live
+/// owner. Every pid-file backend must be listed here or convergence can reap a
+/// running machine's state dir before its lifecycle command attaches.
+const PID_FILE_NAMES: &[&str] = &["libkrun.pid", "vz.pid", "hvf.pid", "fc.pid", "pid"];
 
 /// `kill(pid, 0)` existence probe — delivers no signal, just checks the
 /// process is alive. The cheap half of the live-vs-orphan discrimination
@@ -806,6 +807,29 @@ mod tests {
         assert!(
             view.orphan_dirs(&BTreeSet::new()).is_empty(),
             "a dir owned by a live hvf supervisor must not be reaped as an orphan"
+        );
+    }
+
+    #[test]
+    fn fs_view_recognizes_live_firecracker_pid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let dir = root.join("firecracker-vm");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("fc.pid"), std::process::id().to_string()).unwrap();
+
+        let view = FsRuntimeView::new(root);
+        let dir_str = dir.to_string_lossy().into_owned();
+        let reg = RegisterParams::minimal("firecracker-vm", &dir_str, "default");
+        let mut registry = VmNameRegistry::default();
+        registry.register_with_metadata(reg).unwrap();
+        assert!(
+            view.process_alive(registry.lookup("firecracker-vm").unwrap()),
+            "a live fc.pid must count as a live Firecracker owner"
+        );
+        assert!(
+            view.orphan_dirs(&BTreeSet::new()).is_empty(),
+            "a dir owned by live Firecracker must not be reaped as an orphan"
         );
     }
 

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -1008,6 +1008,11 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 
     }
 
     fn stop(&self, id: &VmId) -> Result<()> {
+        // Capture the VMM's disk-backed process identity before reaping any
+        // sidecars. A teardown helper may remove marker files as part of its own
+        // cleanup; the live handle must already own everything needed to stop
+        // and verify the VMM independently of those mutable markers.
+        let vm = self.driver.attach(id)?;
         // Reap the per-VM secrets endpoint first, so a crashed VM's
         // decrypted-secret process can't outlive the guest. Idempotent + a no-op
         // when the VM spawned none.
@@ -1018,7 +1023,7 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 
         // that registered none.
         crate::broker_services_spawn::reap_broker_services(&vm_state_dir(&id.0));
         crate::host_agent_spawn::reap_host_agent_services_from_state(&vm_state_dir(&id.0), &id.0);
-        self.driver.attach(id)?.kill()
+        vm.kill()
     }
 
     fn stop_all(&self) -> Result<()> {

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -81,6 +81,8 @@ for detailed scope and acceptance criteria.
   - [x] Linux regression coverage for concurrent raw-egress handlers
   - [x] Final-child verb grant issuance, validation, persistence, and
         PostRestore delivery without granting authority to the parent
+  - [x] Persistent-machine Firecracker stop fails closed and preserves state
+        until process exit is verified (#2007; live KVM recheck passed)
   - [~] Live warm-launch, fork-isolation, and restore-clock verification
   - [ ] Typed-connector egress-policy enrichment
   - [ ] OCI-image template build path and CLI facade completion

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -820,6 +820,17 @@ Then unify + retire the old paths:
       the capture path does not emit `checkpoint.created` (#1962), so the
       post-restore grant delivery and the child's egress/broker/exit channels
       remain live-unproven. The flip is gated on that run.
+  - [x] Ordinary persistent-machine Firecracker teardown now fails closed
+        (#2007): non-interactive or declined confirmation exits non-zero, state
+        is retained unless process exit is verified, and a restart cannot
+        overwrite the PID marker of a still-live process. Reconcile-on-entry
+        also recognizes `fc.pid`, so it cannot delete a live Firecracker's
+        state before the stop path attaches. The 2026-07-31 KVM recheck passed:
+        refusal retained PID 4124113 and the exact process, then `--yes`
+        removed the marker and process. Eleven regressions cover confirmation,
+        marker ownership, exact-PID teardown, cleanup ordering, and
+        reconciliation. The analogous warm-pool claim-refusal cleanup remains
+        a separate open gate.
 - [ ] A clean **external API** (`Image` / `Vm` / `Pool` / `ExecBuilder`-style) on `mvm-client`, so library and CLI share one surface.
 - [ ] **Simple, fast install:** a one-line installer + `mvmctl upgrade`.
 - Gate: the timed e2e proves sub-second launch on both hosts; warm-start + snapshot restore measured; the external API is documented and BDD-covered.

--- a/specs/notes/2026-07-28-plan-255-live-fc-warm-claim-validation.md
+++ b/specs/notes/2026-07-28-plan-255-live-fc-warm-claim-validation.md
@@ -429,6 +429,19 @@ timing reps (`pgrep -af firecracker` showed seven live
 `--api-sock /root/mvm-t7-home/vms/t7cold/fc.socket` processes at the end).
 The next launch's orphan reaper collects them one at a time.
 
+**Follow-up (2026-07-31, #2007): fixed and live-proven for the ordinary
+persistent-machine path.** The immediate failure was reconcile-on-entry
+omitting `fc.pid` from its live-owner table, which let every state-touching CLI
+command recursively remove a live Firecracker's state before stop attached.
+Reconciliation and orphan-helper cleanup now recognize the marker.
+Confirmation refusal exits non-zero, teardown captures and verifies the exact
+Firecracker PID before state is removed, and start refuses to replace a PID
+marker that still names a live process. Hermetic regressions cover these
+boundaries. On the KVM host, non-TTY refusal retained PID 4124113, its marker,
+and the matching Firecracker command line; the following `machine stop
+stop2007 --yes` removed the marker and the exact process. The warm-pool
+claim-refusal cleanup described in the gate list below remains separate.
+
 ## Gate list as written after run 1
 
 *(Superseded by "What must happen before `standby_pool` can flip to `true`" at
@@ -1018,8 +1031,10 @@ as a claim latency.
    Fix options in the issue; option 1 (admit a plan for the factory parent and
    emit `checkpoint.created` under it) is the one consistent with claim 8.
    Relaxing the claim-side check is not an option.
-6. **Deferred, known-sharp** — failed-stop leaves an invisible live VM
-   (unchanged).
+6. **Deferred, known-sharp** — failed-stop leaves an invisible live VM on the
+   warm-pool claim-refusal cleanup path. The ordinary `machine stop`
+   manifestation is fixed and live-proven by #2007, but `force_stop` plus
+   `ClaimCleanup` remains a separate owner and is unchanged.
 7. Only then: re-run the Task 7 priorities and flip the capability if green.
 
 `standby_pool` stays `false`. The flip was not proposed: the claim is refused,

--- a/specs/plans/255-live-fc-warm-claim.md
+++ b/specs/plans/255-live-fc-warm-claim.md
@@ -1247,6 +1247,16 @@ The ordered gate list — the one to work from — is "What must happen before
 `standby_pool` can flip to `true`" in
 `specs/notes/2026-07-28-plan-255-live-fc-warm-claim-validation.md`.
 
+- [x] Close the ordinary persistent-machine stop leak found during live
+  validation (#2007). A non-interactive or declined confirmation now fails
+  non-zero, reconcile-on-entry recognizes `fc.pid`, both Firecracker stop paths
+  retain a captured process identity through teardown, and a new start refuses
+  to replace the PID marker of a process still alive. Hermetic regressions cover
+  those boundaries. The 2026-07-31 KVM recheck retained the exact process and
+  marker after non-TTY refusal, then removed both after `--yes`. The warm-pool
+  claim-refusal cleanup remains a separate open gate because it owns and
+  removes child state through `ClaimCleanup`, not this ordinary stop path.
+
 ## Done when
 
 - All eight tasks' boxes are ticked.

--- a/tests/machine_stop_confirmation.rs
+++ b/tests/machine_stop_confirmation.rs
@@ -1,0 +1,25 @@
+use assert_cmd::cargo::CommandCargoExt;
+use std::process::{Command, Stdio};
+
+/// Destructive machine stops fail closed when no TTY is available and
+/// automation has not supplied explicit confirmation.
+#[test]
+fn machine_stop_without_tty_requires_yes() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .expect("mvmctl binary")
+        .env("HOME", tmp.path())
+        .env("MVM_HOME", tmp.path())
+        .stdin(Stdio::null())
+        .args(["machine", "stop", "ghost"])
+        .output()
+        .expect("run mvmctl machine stop");
+
+    assert!(!out.status.success(), "unconfirmed stop must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("pass --yes"),
+        "failure must explain explicit confirmation: {stderr}"
+    );
+}


### PR DESCRIPTION
Closes #2007

## Summary

- require explicit confirmation for destructive machine stops and fail closed without a TTY unless `--yes` is supplied
- capture and verify the exact Firecracker PID before tearing down sidecars, then use bounded SIGTERM-to-SIGKILL escalation
- retain PID and machine state whenever process exit cannot be proven, and refuse to overwrite a live `fc.pid` during startup
- teach reconciliation and orphan cleanup to recognize Firecracker PID markers
- update the active plan, sprint status, and refactor rollup with the live KVM witness

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace -- --test-threads=1`
- `cargo test -p mvm-runtime --lib` (1,232 passed; 6 ignored)
- `cargo test -p mvm-cli machine_stop --tests`
- `cargo test --test machine_stop_confirmation`
- Linux/KVM: `cargo clippy --workspace --all-targets -- -D warnings`
- live KVM: refusal preserved the recorded Firecracker PID/process; `--yes` removed both process and state