### PR TITLE
ci(security): arm the mutation-witnesses lane, sharded per package

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -530,27 +530,22 @@ jobs:
   mutation-witnesses:
     name: Claim witnesses — mutation-tested (ADR-001 claims ledger)
     runs-on: ubuntu-latest
-    # STILL NON-BLOCKING, and now for a smaller and stated reason.
+    # BLOCKING. The whole surface measures -- 1221 mutants -- and every
+    # survivor is either closed by a test or carried in
+    # xtask/mutation-witness-baseline.json with the mechanism that makes
+    # it uncatchable here (a live VMM, a nix build, a feature this run
+    # does not compile, or a provable equivalence).
     #
     # It was non-blocking because accepted_misses had been seeded for one
     # anchor file only. Establishing the rest found that eight of the 26
-    # files could not be measured at all — their packages' suites did not
-    # pass package-scoped, and this lane is always package-scoped — and
-    # that two of those reported themselves clean. All of that is fixed,
-    # and the whole surface now measures: 1221 mutants, 359 surviving.
+    # files could not be measured at all -- their packages' suites did not
+    # pass package-scoped, and this lane is always package-scoped -- and
+    # that two of those reported themselves clean. See
+    # specs/VERIFICATION.md §"Mutation-tested witnesses".
     #
-    # What is left before this can block: the survivors in the
-    # driver-level files (Firecracker snapshot I/O, nix-gated overlay
-    # builds) still need their accepted_misses entries, and the ratchet
-    # compares exact mutant identities, so those entries have to come from
-    # a confirmation run over the changed files rather than be written
-    # from memory. Arming before that would fail the first nightly on
-    # entries that do not match — the same "green result standing in for
-    # evidence" this lane exists to prevent, one level up.
-    #
-    # See specs/VERIFICATION.md §"Mutation-tested witnesses" and plan 272
-    # WS-2.
-    continue-on-error: true
+    # The ratchet tolerates only the exact identities listed, so a NEW
+    # hole anywhere on the surface still fails this job, including inside
+    # the files that carry accepted entries.
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -528,24 +528,40 @@ jobs:
   # checked on every PR by ci.yml; only the mutation run itself is
   # nightly, because it costs hours.
   mutation-witnesses:
-    name: Claim witnesses — mutation-tested (ADR-001 claims ledger)
+    name: Claim witnesses — mutation-tested (${{ matrix.package }})
     runs-on: ubuntu-latest
-    # BLOCKING. The whole surface measures -- 1221 mutants -- and every
-    # survivor is either closed by a test or carried in
-    # xtask/mutation-witness-baseline.json with the mechanism that makes
-    # it uncatchable here (a live VMM, a nix build, a feature this run
-    # does not compile, or a provable equivalence).
+    # BLOCKING, and sharded per package because it has to be.
     #
-    # It was non-blocking because accepted_misses had been seeded for one
-    # anchor file only. Establishing the rest found that eight of the 26
-    # files could not be measured at all -- their packages' suites did not
-    # pass package-scoped, and this lane is always package-scoped -- and
-    # that two of those reported themselves clean. See
-    # specs/VERIFICATION.md §"Mutation-tested witnesses".
+    # The whole surface takes ~6.9h end to end and a GitHub-hosted job is
+    # killed at 6, so one job could not reliably finish: it would go red
+    # nightly for a reason unrelated to any claim and be ignored — the
+    # failure this lane exists to prevent, reached from the other side.
+    # Split per package the slowest shard is ~2.5h.
     #
-    # The ratchet tolerates only the exact identities listed, so a NEW
-    # hole anywhere on the surface still fails this job, including inside
-    # the files that carry accepted entries.
+    # Every survivor is either closed by a test or carried in
+    # xtask/mutation-witness-baseline.json with the mechanism that makes it
+    # uncatchable here (a live VMM, a nix build, a feature this run does not
+    # compile, or a provable equivalence). The ratchet tolerates only those
+    # exact identities, so a NEW hole still fails — including inside the
+    # files that carry accepted entries.
+    #
+    # The matrix is pinned against the baseline by check-mutation-witnesses
+    # on every PR, so a package joining the surface cannot silently go
+    # unmeasured here.
+    #
+    # See specs/VERIFICATION.md §"Mutation-tested witnesses" and plan 272 WS-2.
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - mvm-agentd
+          - mvm-build
+          - mvm-cli
+          - mvm-core
+          - mvm-hostd
+          - mvm-protocol
+          - mvm-runtime
+          - mvm-sdk
     steps:
       - uses: actions/checkout@v6
 
@@ -559,13 +575,13 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: cargo-mutation-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-mutation-
+          key: cargo-mutation-${{ matrix.package }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-mutation-${{ matrix.package }}-
 
       - name: Install cargo-mutants and nextest
         run: cargo install --locked cargo-mutants cargo-nextest
 
-      - name: Mutate the claim surface and ratchet survivors
+      - name: Mutate this package's claim surface and ratchet survivors
         # `--run` mutates the claim-enforcement surface and runs the suite
         # against each mutant — plan verification that no longer verifies, a
         # seccomp filter that no longer filters, the host signer. That is
@@ -593,7 +609,7 @@ jobs:
             echo "::error::refusing to mutate against a reachable keystore at $HOME/.mvm/keys" >&2
             exit 1
           fi
-          cargo run -p xtask -- check-mutation-witnesses --run
+          cargo run -p xtask -- check-mutation-witnesses --run --package '${{ matrix.package }}'
 
   # ── Lane 5: Hash-verify regression ─────────────────────────────────
   # ADR-001 §W5.1 — the unit tests that exercise the

--- a/specs/VERIFICATION.md
+++ b/specs/VERIFICATION.md
@@ -30,6 +30,7 @@ row below records a defect that was planted to prove the gate fires.
 | `check-claim-catalog` | Name a witness in the ADR-001 ledger that `model/claims.toml` does not list | yes |
 | `check-workflow-paths` | Point a fuzz step's `working-directory` at `crates/mvm-oci` (the pre-consolidation path that made the fuzz lane dead for ten nightlies) | yes |
 | `check-mvm-host-binaries-sync` | Drop `--bin mvm-builderd` from the builder-VM cross-compile step, reproducing the "path does not exist" image-build failure | yes |
+| `check-mutation-witnesses` (shard matrix) | Remove the `mvm-cli` shard from `security.yml`'s mutation matrix, so that package would never be mutated while every shard stayed green | yes — `package mvm-cli is on the mutation surface but has no shard` |
 | `check-claim-witness-freshness` | Change `security.yml`'s cron to hourly so its real last-run age exceeds the allowance; reported `security.yml last ran 14h ago (schedule allows 3h)` naming all 8 claims it backs | yes |
 | `cargo-fuzz crates still compile` | None planted — run against main it independently rediscovered both real defects (`fuzz_authed_path` E0308, `fuzz_build_image` unclosed delimiter) that the nightly took eleven days to surface | yes |
 | `included_top_level_is_a_superset_of_the_nix_filter_allowlist` | Remove `"nix"` from `INCLUDED_TOP_LEVEL` while `workspace-filter.nix` still admits it, so a `nix/` change would go unhashed and boot a stale image | yes |
@@ -127,6 +128,15 @@ writes `outcomes.json` incrementally and a run 39 of 50 through reports
 | equivalent: the field's value equals the derived `Default` | 5 |
 | needs a live VM state dir plus a controlled pid | 3 |
 | singletons (binary entrypoint, fail-closed constant, two provable equivalences, two untestable inputs) | 6 |
+
+The lane is **sharded per package**, because it has to be: the whole
+surface takes ~6.9 hours end to end and a GitHub-hosted job is killed at
+six. One job could not reliably finish, so it would go red nightly for a
+reason unrelated to any claim and be ignored — the same failure this lane
+exists to prevent, arrived at from the other side. Split per package the
+slowest shard is ~2.5 hours. That makes the matrix a second place the
+surface is written down, so `check-mutation-witnesses` pins it against the
+baseline on every PR; the row above records the planted defect.
 
 These are **accepted rather than scoped out** on purpose. Scoping would
 stop the lane measuring those files at all; accepting keeps the ratchet

--- a/specs/VERIFICATION.md
+++ b/specs/VERIFICATION.md
@@ -98,18 +98,42 @@ vacuously true. Both pass today.
 ### Mutation-tested witnesses: what the first full run found
 
 `check-mutation-witnesses --run` breaks each claim-surface file on purpose
-and asks whether any witness notices. Its nightly lane runs
-`continue-on-error` until a baseline covers the whole surface. Producing
+and asks whether any witness notices. Its nightly lane ran
+`continue-on-error` until a baseline covered the whole surface. Producing
 that baseline is recorded here, because most of what it found was not
 surviving mutants.
 
-The whole surface now measures — **1221 mutants, 359 surviving** — which
-it had never done before. The lane is not yet armed: the driver-level
-survivors still need `accepted_misses` entries, and since the ratchet
-compares exact mutant identities those entries must come from a
-confirmation run rather than be written from memory. Arming first would
-fail the first nightly on entries that do not match, which is the same
-unearned-green failure one level up.
+The whole surface now measures — **1221 mutants** — which it had never
+done before, and **the lane is armed**: `continue-on-error` is gone, so a
+witness that stops detecting its own property fails the nightly.
+
+Every survivor is either closed by a test or carried in
+`xtask/mutation-witness-baseline.json` with the mechanism that makes it
+uncatchable here. Ninety-one entries, and none of them says "not yet
+triaged": the generator that wrote them leaves anything without a stated
+mechanism *out*, so an untriaged survivor fails the gate rather than being
+suppressed by omission. Each entry comes from the newest **completed** run
+of that file — completion checked on `end_time`, because cargo-mutants
+writes `outcomes.json` incrementally and a run 39 of 50 through reports
+`missed: 0` and looks clean.
+
+| Mechanism | Entries |
+| --- | --- |
+| libkrun VM lifecycle over a live supervisor process | 31 |
+| Firecracker snapshot driver I/O + vsock readiness probes | 17 |
+| witnessed only by a nix-gated integration test the lane does not run | 12 |
+| not compiled by the lane's feature set (`pure-mkfs`) | 11 |
+| OCI registry / blob-cache I/O | 6 |
+| equivalent: the field's value equals the derived `Default` | 5 |
+| needs a live VM state dir plus a controlled pid | 3 |
+| singletons (binary entrypoint, fail-closed constant, two provable equivalences, two untestable inputs) | 6 |
+
+These are **accepted rather than scoped out** on purpose. Scoping would
+stop the lane measuring those files at all; accepting keeps the ratchet
+live, so a *new* hole in any of them still fails the nightly. Scoping is
+reserved for the case where the non-claim noise would drown the ledger —
+164 and 78 entries would, 40 and 14 do not. The residual coverage debt is
+tracked in #2033.
 
 **Four of eight packages could not be measured at all.** The lane runs
 `cargo mutants -p <package> --file <path>` in a fresh copy of the tree, so

--- a/specs/plans/272-mutation-tested-claim-witnesses.md
+++ b/specs/plans/272-mutation-tested-claim-witnesses.md
@@ -161,7 +161,9 @@ within a day", not "within a PR".
       left the local recipe — the sharper of the two, since a developer's
       real `~/.mvm` is not a discarded VM — running unprotected.
 - [x] Populate `accepted_misses` for the remaining 25 surface files, then
-      drop `continue-on-error` so a new hole fails the lane. **Triage
+      drop `continue-on-error` so a new hole fails the lane. **Done: 91
+      entries, every one naming the mechanism that makes its mutant
+      uncatchable, and the lane is armed.** **Triage
       rule:** a **real hole** gets the test that catches it; an
       **equivalent mutant** gets an `accepted_misses` entry with a stated
       reason. `check_accepted_reasons` already refuses an unexplained

--- a/xtask/mutation-witness-baseline.json
+++ b/xtask/mutation-witness-baseline.json
@@ -216,24 +216,459 @@
   ],
   "accepted_misses": [
     {
-      "file": "crates/mvm-protocol/src/policy/network_policy.rs",
-      "mutant": "replace is_banned_ssh_port -> bool with false",
-      "reason": "Observed 2026-07-29. mvm-protocol's own tests only assert the negative direction (a non-22 port is not banned), so pinning the predicate to false survives while flipping its == does not. The SSH ban has production callers in mvm-core and mvm-cli; the owning crate should assert port 22 IS banned. Untriaged."
+      "file": "crates/mvm-agentd/src/bin/mvm-seccomp-apply.rs",
+      "mutant": "replace main with ()",
+      "reason": "replaces the binary's entrypoint with a no-op. The only witness would be executing the built binary, which this package's own test suite does not do; the claim-2 witness it calls, set_no_new_privs, is asserted directly."
     },
     {
-      "file": "crates/mvm-protocol/src/policy/network_policy.rs",
-      "mutant": "replace NetworkPreset::is_deny_all -> bool with false",
-      "reason": "Observed 2026-07-29. NetworkPreset::is_deny_all has no production caller anywhere in the tree; its only use is an assertion inside mvm-core's security_profile tests. Nothing in mvm-protocol calls it, so the constant survives. Untriaged: either give the predicate a caller or drop it."
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "delete ! in extract_release_archive",
+      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-protocol/src/policy/network_policy.rs",
-      "mutant": "replace NetworkPreset::is_deny_all -> bool with true",
-      "reason": "Observed 2026-07-29. Same uncalled predicate as the `with false` entry; neither constant is detectable from the owning crate. Untriaged."
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "delete ! in run_nix_build",
+      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-protocol/src/policy/network_policy.rs",
-      "mutant": "replace NetworkPolicy::trusted_build_egress -> Self with Default::default()",
-      "reason": "Observed 2026-07-29. No mvm-protocol test asserts the shape of the trusted-build egress policy. The mutant substitutes the deny-all default, so it makes the policy stricter, not weaker \u2014 a functional coverage gap rather than a security hole. Untriaged."
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "delete ! in stage_runtime_overlay_binary",
+      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace & with ^ in overlay_mode_of",
+      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace & with | in overlay_mode_of",
+      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace && with || in extract_release_archive",
+      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace && with || in local_source_cache_is_fresh",
+      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace build_runtime_overlay_from_guest_binaries -> Result<RuntimeOverlayArtifact, RuntimeOverlayError> with Ok(Default::default())",
+      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace collect_overlay_nodes -> Result<Vec<mvm_fs::ext4::Node>, RuntimeOverlayError> with Ok(vec![Default::default()])",
+      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace collect_overlay_nodes -> Result<Vec<mvm_fs::ext4::Node>, RuntimeOverlayError> with Ok(vec![])",
+      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace match guard local_source_cache_is_fresh( &resolver.layout(&arch.to_string()), &expected_fingerprint, )? with false in resolve_or_build_local_runtime_overlay",
+      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace match guard local_source_cache_is_fresh( &resolver.layout(&arch.to_string()), &expected_fingerprint, )? with true in resolve_or_build_local_runtime_overlay",
+      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace match guard out.status.success() with true in curl_download",
+      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace overlay_guest_path -> String with \"xyzzy\".into()",
+      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace overlay_guest_path -> String with String::new()",
+      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace overlay_mode_of -> u16 with 0",
+      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace overlay_mode_of -> u16 with 1",
+      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace run_nix_build -> Result<(), RuntimeOverlayError> with Ok(())",
+      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace runtime_overlay_source_checkout_root -> Option<PathBuf> with None",
+      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace runtime_overlay_source_checkout_root -> Option<PathBuf> with Some(Default::default())",
+      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace stage_runtime_overlay_binary -> Result<(), RuntimeOverlayError> with Ok(())",
+      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace write_local_build_epoch -> Result<(), RuntimeOverlayError> with Ok(())",
+      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-build/src/runtime_overlay.rs",
+      "mutant": "replace write_local_source_fingerprint -> Result<(), RuntimeOverlayError> with Ok(())",
+      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-cli/src/commands/image/pull_core.rs",
+      "mutant": "replace && with || in pull_image_with_trust",
+      "reason": "widens the prod digest-pin refusal to fire on any unpinned reference rather than only under --prod, so it refuses strictly more than the real gate. Fail-closed: claim 14 asks that --prod refuses a mutable tag, which it still does. Catching it needs a dev-mode pull asserted not to bail, which reaches the network."
+    },
+    {
+      "file": "crates/mvm-cli/src/commands/image/pull_core.rs",
+      "mutant": "replace fetch_or_read_layer -> Result<Vec<u8>> with Ok(vec![0])",
+      "reason": "OCI registry and blob-cache I/O: fetching a layer or writing a config blob needs a registry double the crate does not have. The claim-14 witnesses in this file (both prod digest-pin refusals, asserted before any network call) are caught. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-cli/src/commands/image/pull_core.rs",
+      "mutant": "replace fetch_or_read_layer -> Result<Vec<u8>> with Ok(vec![1])",
+      "reason": "OCI registry and blob-cache I/O: fetching a layer or writing a config blob needs a registry double the crate does not have. The claim-14 witnesses in this file (both prod digest-pin refusals, asserted before any network call) are caught. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-cli/src/commands/image/pull_core.rs",
+      "mutant": "replace fetch_or_read_layer -> Result<Vec<u8>> with Ok(vec![])",
+      "reason": "OCI registry and blob-cache I/O: fetching a layer or writing a config blob needs a registry double the crate does not have. The claim-14 witnesses in this file (both prod digest-pin refusals, asserted before any network call) are caught. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-cli/src/commands/image/pull_core.rs",
+      "mutant": "replace write_config_blob -> Result<Option<String>> with Ok(None)",
+      "reason": "OCI registry and blob-cache I/O: fetching a layer or writing a config blob needs a registry double the crate does not have. The claim-14 witnesses in this file (both prod digest-pin refusals, asserted before any network call) are caught. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-cli/src/commands/image/pull_core.rs",
+      "mutant": "replace write_config_blob -> Result<Option<String>> with Ok(Some(\"xyzzy\".into()))",
+      "reason": "OCI registry and blob-cache I/O: fetching a layer or writing a config blob needs a registry double the crate does not have. The claim-14 witnesses in this file (both prod digest-pin refusals, asserted before any network call) are caught. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-cli/src/commands/image/pull_core.rs",
+      "mutant": "replace write_config_blob -> Result<Option<String>> with Ok(Some(String::new()))",
+      "reason": "OCI registry and blob-cache I/O: fetching a layer or writing a config blob needs a registry double the crate does not have. The claim-14 witnesses in this file (both prod digest-pin refusals, asserted before any network call) are caught. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-cli/src/commands/shared/resolve.rs",
+      "mutant": "delete ! in resolve_running_vm",
+      "reason": "resolves a VM state dir and then checks a live pid: needs a running VM, or a state dir plus a process the test controls for the whole call. The claim-10 witness in this file (the deny-all network default) is caught. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-cli/src/commands/shared/resolve.rs",
+      "mutant": "replace resolve_running_vm -> Result<String> with Ok(\"xyzzy\".into())",
+      "reason": "resolves a VM state dir and then checks a live pid: needs a running VM, or a state dir plus a process the test controls for the whole call. The claim-10 witness in this file (the deny-all network default) is caught. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-cli/src/commands/shared/resolve.rs",
+      "mutant": "replace resolve_running_vm -> Result<String> with Ok(String::new())",
+      "reason": "resolves a VM state dir and then checks a live pid: needs a running VM, or a state dir plus a process the test controls for the whole call. The claim-10 witness in this file (the deny-all network default) is caught. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-cli/src/commands/shared/resolve.rs",
+      "mutant": "replace || with && in resolve_manifest_arg",
+      "reason": "the discriminating input is a bare relative name that exists as a file or directory in the process's current directory. A test cannot create one without writing into the repo working tree or mutating process-global CWD shared by parallel tests under the documented cargo test fallback."
+    },
+    {
+      "file": "crates/mvm-hostd/src/plan_admission.rs",
+      "mutant": "replace * with +",
+      "reason": "shrinks BUNDLE_JSON_MAX_BYTES from 4 MiB to about 1 MiB, so the cap refuses strictly more than before -- fail-closed. Catching it needs a PolicyBundle fixture serialising between the two sizes; asserting the constant instead would only assert the code equals itself, which is the tautology this suite exists to avoid. The cap's direction is covered by the boundary test on enforce_size_cap."
+    },
+    {
+      "file": "crates/mvm-hostd/src/supervisor/network/stages.rs",
+      "mutant": "replace < with <= in dns_query_qname",
+      "reason": "equivalent: the guard rejects a payload shorter than the 12-byte DNS header, and the label walk that follows indexes through payload.get(i)?, which returns None rather than panicking. A 12-byte payload therefore yields None down both the mutated and unmutated paths."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "delete ! in <impl VmBackend for LibkrunBackend>::list",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "delete ! in <impl VmBackend for LibkrunBackend>::start",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "delete ! in <impl VmBackend for LibkrunBackend>::stop",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "delete ! in <impl VmBackend for LibkrunBackend>::warm_start",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "delete field balloon from struct VmCapabilities expression in <impl VmBackend for LibkrunBackend>::capabilities",
+      "reason": "equivalent: VmCapabilities derives Default, and each of these fields is declared with the value Default already yields (false), so deleting it from the literal is a semantic no-op that no test can distinguish. The two fields whose declared value differs from Default -- standby_pool: true and snapshot_capability: DiskOnly -- are caught by libkrun_capabilities_declare_the_vsock_only_shape."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "delete field fs_quick_checkpoint from struct VmCapabilities expression in <impl VmBackend for LibkrunBackend>::capabilities",
+      "reason": "equivalent: VmCapabilities derives Default, and each of these fields is declared with the value Default already yields (false), so deleting it from the literal is a semantic no-op that no test can distinguish. The two fields whose declared value differs from Default -- standby_pool: true and snapshot_capability: DiskOnly -- are caught by libkrun_capabilities_declare_the_vsock_only_shape."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "delete field pause_resume from struct VmCapabilities expression in <impl VmBackend for LibkrunBackend>::capabilities",
+      "reason": "equivalent: VmCapabilities derives Default, and each of these fields is declared with the value Default already yields (false), so deleting it from the literal is a semantic no-op that no test can distinguish. The two fields whose declared value differs from Default -- standby_pool: true and snapshot_capability: DiskOnly -- are caught by libkrun_capabilities_declare_the_vsock_only_shape."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "delete field snapshots from struct VmCapabilities expression in <impl VmBackend for LibkrunBackend>::capabilities",
+      "reason": "equivalent: VmCapabilities derives Default, and each of these fields is declared with the value Default already yields (false), so deleting it from the literal is a semantic no-op that no test can distinguish. The two fields whose declared value differs from Default -- standby_pool: true and snapshot_capability: DiskOnly -- are caught by libkrun_capabilities_declare_the_vsock_only_shape."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "delete field tap_networking from struct VmCapabilities expression in <impl VmBackend for LibkrunBackend>::capabilities",
+      "reason": "equivalent: VmCapabilities derives Default, and each of these fields is declared with the value Default already yields (false), so deleting it from the literal is a semantic no-op that no test can distinguish. The two fields whose declared value differs from Default -- standby_pool: true and snapshot_capability: DiskOnly -- are caught by libkrun_capabilities_declare_the_vsock_only_shape."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace && with || in diagnose_vsock_sockets",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace && with || in spawn_libkrun_egress_endpoint_if_needed",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace + with - in <impl VmBackend for LibkrunBackend>::start",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace + with - in <impl VmBackend for LibkrunBackend>::stop",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace < with <= in <impl VmBackend for LibkrunBackend>::stop",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace < with == in <impl VmBackend for LibkrunBackend>::stop",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace < with > in <impl VmBackend for LibkrunBackend>::stop",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace <impl VmBackend for LibkrunBackend>::install -> Result<()> with Ok(())",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace <impl VmBackend for LibkrunBackend>::is_available -> Result<bool> with Ok(false)",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace <impl VmBackend for LibkrunBackend>::is_available -> Result<bool> with Ok(true)",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace <impl VmBackend for LibkrunBackend>::list -> Result<Vec<VmInfo>> with Ok(vec![])",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace <impl VmBackend for LibkrunBackend>::logs -> Result<String> with Ok(\"xyzzy\".into())",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace <impl VmBackend for LibkrunBackend>::logs -> Result<String> with Ok(String::new())",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace <impl VmBackend for LibkrunBackend>::pause -> Result<()> with Ok(())",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace <impl VmBackend for LibkrunBackend>::resume -> Result<()> with Ok(())",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace <impl VmBackend for LibkrunBackend>::stop -> Result<()> with Ok(())",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace <impl VmBackend for LibkrunBackend>::stop_all -> Result<()> with Ok(())",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace <impl VmBackend for LibkrunBackend>::supports_standby_pool -> bool with false",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace == with != in <impl VmBackend for LibkrunBackend>::list",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace >= with < in <impl VmBackend for LibkrunBackend>::start",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace match guard e.kind() == std::io::ErrorKind::NotFound with false in <impl VmBackend for LibkrunBackend>::list",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace match guard e.kind() == std::io::ErrorKind::NotFound with true in <impl VmBackend for LibkrunBackend>::list",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace match guard pid_alive(pid) with false in <impl VmBackend for LibkrunBackend>::status",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace match guard pid_alive(pid) with true in <impl VmBackend for LibkrunBackend>::status",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace read_pid -> Option<libc::pid_t> with None",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace send_signal with ()",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "replace || with && in ensure_libkrun_runtime_source_supported",
+      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/microvm/snapshot.rs",
+      "mutant": "replace create_snapshot_files -> Result<()> with Ok(())",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/microvm/snapshot.rs",
+      "mutant": "replace match guard outcome.reseeded with false in warm_restore_instance_from_path",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/microvm/snapshot.rs",
+      "mutant": "replace restore_from_template_snapshot -> Result<()> with Ok(())",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "delete ! in <impl SnapshotIO for FirecrackerIO>::teardown_paused",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "delete ! in FirecrackerIO::ensure_socket",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "replace <impl PostRestoreSignal for VsockPostRestoreSignal>::probe_ready -> bool with false",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "replace <impl PostRestoreSignal for VsockPostRestoreSignal>::probe_ready -> bool with true",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "replace <impl SnapshotIO for FirecrackerIO>::create_snapshot -> Result<()> with Ok(())",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "replace <impl SnapshotIO for FirecrackerIO>::load_snapshot_for_fork_paused -> Result<()> with Ok(())",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "replace <impl SnapshotIO for FirecrackerIO>::load_snapshot_paused -> Result<()> with Ok(())",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "replace <impl SnapshotIO for FirecrackerIO>::resume -> Result<()> with Ok(())",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "replace <impl SnapshotIO for FirecrackerIO>::teardown_paused -> Result<()> with Ok(())",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "replace FirecrackerIO::ensure_socket -> Result<()> with Ok(())",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "replace FirecrackerIO::load_snapshot_inner -> Result<()> with Ok(())",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "replace VsockPrimedSignalSource::probe_once -> bool with false",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "replace VsockPrimedSignalSource::probe_once -> bool with true",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",
+      "mutant": "replace instance_dir -> PathBuf with Default::default()",
+      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
+    },
+    {
+      "file": "crates/mvm-sdk/src/compile/deps_audit.rs",
+      "mutant": "replace * with + in hash_file_raw",
+      "reason": "equivalent: the mutated expression is the read-buffer size (64 * 1024 versus 64 + 1024). It changes how many bytes are read per iteration and nothing else; the resulting SHA-256 is identical, so no assertion on behaviour can separate them."
     }
   ]
 }

--- a/xtask/src/check_mutation_witnesses.rs
+++ b/xtask/src/check_mutation_witnesses.rs
@@ -162,7 +162,18 @@ pub struct Miss {
     pub mutant: String,
 }
 
-pub fn run(workspace: &Path, mode: Mode) -> Result<()> {
+/// Restrict a `--run` to one cargo package.
+///
+/// The whole surface takes about six hours end to end, and a
+/// GitHub-hosted job is killed at six. Split per package the slowest is
+/// well under two and a half, so the lane is one job per package rather
+/// than one job that cannot reliably finish.
+///
+/// Only the mutation step narrows. The surface pin and the uncovered-claim
+/// diff still run over the *whole* ledger in every job, so a claim
+/// dropping out of coverage fails every shard rather than only the one
+/// that happens to own it.
+pub fn run(workspace: &Path, mode: Mode, package: Option<&str>) -> Result<()> {
     let Surface {
         files: resolved,
         uncovered,
@@ -183,7 +194,10 @@ pub fn run(workspace: &Path, mode: Mode) -> Result<()> {
         let previous = read_baseline(&baseline_path).ok();
         let accepted_misses = if mode == Mode::RewriteBaseline {
             let scoped = carry_scopes_forward(resolved.clone(), previous.as_ref());
-            seed_accepted(&run_mutants_over(workspace, &scoped)?)
+            seed_accepted(&run_mutants_over(
+                workspace,
+                &for_package(&scoped, package),
+            )?)
         } else {
             previous
                 .as_ref()
@@ -212,6 +226,7 @@ pub fn run(workspace: &Path, mode: Mode) -> Result<()> {
     let baseline = read_baseline(&baseline_path)?;
     let mut errors = check_accepted_reasons(&baseline.accepted_misses);
     errors.extend(check_scope_reasons(&baseline.surface));
+    errors.extend(check_shard_matrix(workspace, &baseline.surface));
     errors.extend(diff_surface(&baseline.surface, &resolved));
     errors.extend(diff_uncovered(&baseline.uncovered_claims, &uncovered));
 
@@ -226,8 +241,33 @@ pub fn run(workspace: &Path, mode: Mode) -> Result<()> {
         // The committed surface, not the freshly resolved one: resolution
         // cannot know about scopes, and running the unscoped surface would
         // report every out-of-claim mutant as a new miss.
-        let observed = run_mutants_over(workspace, &baseline.surface)?;
-        let verdict = ratchet(&baseline.accepted_misses, &observed);
+        let surface = for_package(&baseline.surface, package);
+        if surface.is_empty() {
+            bail!(
+                "check-mutation-witnesses: --package {} matches no surface file. A shard that \
+                 measures nothing must fail rather than pass silently.",
+                package.unwrap_or("<none>")
+            );
+        }
+        if let Some(pkg) = package {
+            eprintln!(
+                "check-mutation-witnesses: shard for package {pkg} ({} of {} surface files)",
+                surface.len(),
+                baseline.surface.len()
+            );
+        }
+        let observed = run_mutants_over(workspace, &surface)?;
+        // The accepted set narrows with the surface, or every other
+        // package's entries would be reported as "now caught" by a shard
+        // that never looked at them.
+        let paths: BTreeSet<&str> = surface.iter().map(|s| s.path.as_str()).collect();
+        let accepted: Vec<AcceptedMiss> = baseline
+            .accepted_misses
+            .iter()
+            .filter(|a| paths.contains(a.file.as_str()))
+            .cloned()
+            .collect();
+        let verdict = ratchet(&accepted, &observed);
         for m in &verdict.new_misses {
             errors.push(format!(
                 "new surviving mutant in {}: {} — a claim witness does not detect this change",
@@ -425,6 +465,99 @@ pub fn diff_uncovered(committed: &[UncoveredClaim], resolved: &[UncoveredClaim])
         ));
     }
     errors
+}
+
+/// Where the nightly lane declares its per-package shards.
+const SECURITY_WORKFLOW_REL: &str = ".github/workflows/security.yml";
+
+/// The lane's shard matrix must name exactly the packages on the surface.
+///
+/// The shards exist because the whole surface cannot finish inside a
+/// GitHub job's six-hour cap. That makes the matrix a second place the
+/// surface is written down, and a package that joins the ledger but not
+/// the matrix is simply never mutated — while every shard stays green.
+/// That is the same silent-loss failure the committed surface pin exists
+/// to prevent, one level out, so it is checked the same way.
+pub fn check_shard_matrix(workspace: &Path, surface: &[SurfaceFile]) -> Vec<String> {
+    let path = workspace.join(SECURITY_WORKFLOW_REL);
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return vec![format!(
+            "cannot read {SECURITY_WORKFLOW_REL} to verify the mutation shard matrix"
+        )];
+    };
+    let declared = shard_packages(&text);
+    if declared.is_empty() {
+        return vec![format!(
+            "{SECURITY_WORKFLOW_REL} declares no mutation shard matrix; the nightly lane would \
+             measure nothing"
+        )];
+    }
+    let wanted: BTreeSet<&str> = surface.iter().map(|s| s.package.as_str()).collect();
+    let mut errors = Vec::new();
+    for pkg in &wanted {
+        if !declared.contains(*pkg) {
+            errors.push(format!(
+                "package {pkg} is on the mutation surface but has no shard in \
+                 {SECURITY_WORKFLOW_REL}, so nothing ever mutates it"
+            ));
+        }
+    }
+    for pkg in &declared {
+        if !wanted.contains(pkg.as_str()) {
+            errors.push(format!(
+                "{SECURITY_WORKFLOW_REL} declares a mutation shard for {pkg}, which owns no \
+                 surface file; the shard would fail on an empty surface"
+            ));
+        }
+    }
+    errors
+}
+
+/// The `package:` list under the mutation job's matrix.
+///
+/// Text-scanned rather than YAML-parsed, matching the sibling gates and
+/// the workspace's deliberate dependency floor.
+pub fn shard_packages(workflow: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let mut in_job = false;
+    let mut in_list = false;
+    for line in workflow.lines() {
+        if line.starts_with("  mutation-witnesses:") {
+            in_job = true;
+            continue;
+        }
+        if in_job && line.starts_with("  ") && !line.starts_with("   ") && line.ends_with(':') {
+            break; // next job at the same indent
+        }
+        if !in_job {
+            continue;
+        }
+        let t = line.trim();
+        if t == "package:" {
+            in_list = true;
+            continue;
+        }
+        if in_list {
+            if let Some(name) = t.strip_prefix("- ") {
+                out.insert(name.trim().to_string());
+            } else if !t.is_empty() {
+                in_list = false;
+            }
+        }
+    }
+    out
+}
+
+/// The surface files owned by `package`, or all of them when unfiltered.
+pub fn for_package(surface: &[SurfaceFile], package: Option<&str>) -> Vec<SurfaceFile> {
+    match package {
+        None => surface.to_vec(),
+        Some(pkg) => surface
+            .iter()
+            .filter(|s| s.package == pkg)
+            .cloned()
+            .collect(),
+    }
 }
 
 /// Copy each committed file's `scope` onto the freshly resolved surface.
@@ -1142,6 +1275,120 @@ a.rs:5:1: replace x with y
             Some(&previous),
         );
         assert!(carried[0].scope.is_none());
+    }
+
+    const SHARD_WORKFLOW: &str = "\
+jobs:
+  other-job:
+    name: not this one
+    strategy:
+      matrix:
+        package:
+          - not-a-real-package
+  mutation-witnesses:
+    name: Claim witnesses
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - mvm-cli
+          - mvm-hostd
+    steps:
+      - run: true
+  later-job:
+    name: after
+";
+
+    #[test]
+    fn shard_packages_reads_only_the_mutation_jobs_matrix() {
+        let got = shard_packages(SHARD_WORKFLOW);
+        assert_eq!(
+            got,
+            ["mvm-cli", "mvm-hostd"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<BTreeSet<_>>(),
+            "a sibling job's matrix must not leak into the mutation shard list"
+        );
+    }
+
+    #[test]
+    fn a_surface_package_with_no_shard_is_reported() {
+        let declared = shard_packages(SHARD_WORKFLOW);
+        // mvm-core is on the surface but absent from the matrix above.
+        let surface = [
+            surface("crates/mvm-cli/src/a.rs", vec![1]),
+            surface("crates/mvm-core/src/b.rs", vec![2]),
+        ];
+        let missing: Vec<&str> = surface
+            .iter()
+            .map(|s| s.package.as_str())
+            .filter(|p| !declared.contains(*p))
+            .collect();
+        assert_eq!(
+            missing,
+            vec!["mvm-core"],
+            "a package on the surface with no shard must be visible"
+        );
+    }
+
+    #[test]
+    fn a_shard_for_a_package_with_no_surface_file_is_reported() {
+        let declared = shard_packages(SHARD_WORKFLOW);
+        let surface = [surface("crates/mvm-cli/src/a.rs", vec![1])];
+        let wanted: BTreeSet<&str> = surface.iter().map(|s| s.package.as_str()).collect();
+        let extra: Vec<&String> = declared
+            .iter()
+            .filter(|p| !wanted.contains(p.as_str()))
+            .collect();
+        assert_eq!(
+            extra.len(),
+            1,
+            "a shard whose package owns no surface file must be visible"
+        );
+    }
+
+    #[test]
+    fn a_package_shard_selects_only_that_packages_files() {
+        let surface = [
+            surface("crates/mvm-cli/src/a.rs", vec![1]),
+            surface("crates/mvm-cli/src/b.rs", vec![2]),
+            surface("crates/mvm-hostd/src/c.rs", vec![3]),
+        ];
+        let cli = for_package(&surface, Some("mvm-cli"));
+        assert_eq!(cli.len(), 2);
+        assert!(cli.iter().all(|s| s.package == "mvm-cli"));
+
+        assert_eq!(for_package(&surface, Some("mvm-hostd")).len(), 1);
+        // Unfiltered is the whole surface, so a non-sharded run is
+        // unchanged.
+        assert_eq!(for_package(&surface, None).len(), 3);
+        // A package with no surface files yields nothing, which the caller
+        // turns into a failure rather than a silent pass.
+        assert!(for_package(&surface, Some("mvm-sdk")).is_empty());
+    }
+
+    /// Every shard together must cover the surface exactly once. A package
+    /// dropped from the matrix would otherwise go unmeasured while every
+    /// job stayed green.
+    #[test]
+    fn the_shards_partition_the_surface() {
+        let surface = [
+            surface("crates/mvm-cli/src/a.rs", vec![1]),
+            surface("crates/mvm-hostd/src/c.rs", vec![3]),
+            surface("crates/mvm-core/src/d.rs", vec![4]),
+        ];
+        let packages: BTreeSet<&str> = surface.iter().map(|s| s.package.as_str()).collect();
+        let mut seen: Vec<String> = Vec::new();
+        for p in &packages {
+            for f in for_package(&surface, Some(p)) {
+                seen.push(f.path);
+            }
+        }
+        seen.sort();
+        let mut all: Vec<String> = surface.iter().map(|s| s.path.clone()).collect();
+        all.sort();
+        assert_eq!(seen, all, "the shards must cover every file exactly once");
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -210,7 +210,15 @@ fn main() -> Result<()> {
                 (false, true) => check_mutation_witnesses::Mode::Run,
                 (false, false) => check_mutation_witnesses::Mode::PinOnly,
             };
-            check_mutation_witnesses::run(&workspace, mode)
+            // `--package <name>` shards a `--run` by cargo package so each
+            // CI job finishes inside the six-hour job cap; unset means the
+            // whole surface.
+            let package = args
+                .iter()
+                .position(|a| a == "--package")
+                .and_then(|i| args.get(i + 1))
+                .map(String::as_str);
+            check_mutation_witnesses::run(&workspace, mode, package)
         }
         Some("check-conformance") => {
             let workspace = workspace_root();


### PR DESCRIPTION
## What

Arms the `mutation-witnesses` nightly lane: drops `continue-on-error` and lands the `accepted_misses` the ratchet needs to make that meaningful.

Follow-up to #2023, which made the claim surface measurable for the first time and closed every in-claim hole it found. That PR deliberately left the lane non-blocking, because arming it needs `accepted_misses` written from a real run rather than from memory — the ratchet compares exact mutant identities, so entries that do not match would fail the first nightly and teach everyone to ignore the lane.

## The baseline

Every entry comes from the newest **completed** run of that file's surface, and every entry states the mechanism that makes the mutant uncatchable. Nothing without a stated mechanism is included: an untriaged survivor stays a failing miss rather than a silent suppression.

| Mechanism | Entries |
| --- | --- |
| libkrun VM lifecycle over a live supervisor process | 31 |
| Firecracker snapshot driver I/O + vsock readiness probes | 17 |
| witnessed only by a nix-gated integration test the lane does not run | 12 |
| not compiled by the lane's feature set (`pure-mkfs`) | 11 |
| OCI registry / blob-cache I/O | 6 |
| equivalent: field value equals the derived `Default` | 5 |
| needs a live VM state dir plus a controlled pid | 3 |
| the remaining singletons (binary entrypoint, fail-closed constant, two provable equivalences, two untestable-input cases) | 6 |

Four of those deserve their reasoning stated rather than asserted:

- **`VmCapabilities` field deletions.** The struct is `#[derive(Default)]`, so deleting `tap_networking: false` from the literal falls back to a `Default` that is *also* `false` — a semantic no-op. Confirmed by planting all seven: exactly the two whose declared value differs from `Default` (`standby_pool: true`, `snapshot_capability: DiskOnly`) are caught.
- **`dns_query_qname`'s `< 12` → `<= 12`.** The label walk indexes through `payload.get(i)?`, so a 12-byte payload returns `None` down both paths. Verified by simulating both guards over 8000 payloads across lengths 0..19: zero behavioural differences.
- **`hash_file_raw`'s `64 * 1024` → `64 + 1024`.** Read-buffer size only; the SHA-256 is identical.
- **`BUNDLE_JSON_MAX_BYTES`'s `*` → `+`.** Shrinks the cap, so it refuses strictly more — fail-closed. Catching it needs a multi-megabyte `PolicyBundle` fixture, and asserting the constant instead would only assert that the code equals itself.

The residual coverage debt behind the first three mechanisms is tracked in #2033, with the per-file breakdown and three concrete ways in.

## Why this is safe to arm

The ratchet only tolerates the exact identities listed. A **new** hole anywhere on the surface — including inside the files carrying accepted entries — still fails the lane. That is why these are accepted rather than scoped out: scoping would stop measuring those files entirely.


## Why this also shards the lane

Arming a job that cannot finish is not arming it. The full `--run` takes **~6.9 hours** end to end; a GitHub-hosted job is killed at **6**. One job would go red nightly for a reason unrelated to any claim, and a lane that is red every morning is a lane nobody reads — the failure this whole change removes, reached from the other side. I had armed it before measuring how long it runs.

Per package the slowest shard is ~2.5h:

| package | files | hours |
| --- | --- | --- |
| mvm-cli | 4 | 2.5 |
| mvm-hostd | 7 | 1.9 |
| mvm-runtime | 3 | 0.6 |
| mvm-core | 3 | 0.4 |
| mvm-build | 3 | 0.3 |
| mvm-protocol | 3 | 0.2 |
| mvm-agentd | 2 | 0.1 |
| mvm-sdk | 1 | 0.1 |

`--package` narrows only the mutation step: the surface pin and the uncovered-claim diff still run over the whole ledger in every shard, so a claim dropping out of coverage fails all eight rather than only the shard that owns it. The accepted set narrows with the surface, or each shard would report the other seven packages' entries as "now caught" having never looked at them. A `--package` matching no surface file is an error, not an empty pass.

Sharding makes the matrix a second place the surface is written down, so `check-mutation-witnesses` now pins it against the baseline in both directions — a package joining the ledger but not the matrix would otherwise never be mutated while every shard stayed green. Planted against by deleting the `mvm-cli` shard; it reported `package mvm-cli is on the mutation surface but has no shard`.

`mvm-cli`'s 2.5h is dominated by #2035 (a 128s test that does a real initramfs build). Fixing that brings the slowest shard well under an hour, but the lane no longer depends on it.

## Verification

```
cargo run -p xtask -- check-mutation-witnesses    # surface pinned and clean
42/42 xtask Lint gates green
cargo nextest run --workspace
```
