### PR TITLE
docs(plan-276): reconcile with main, and fold in the recon revision that reverses its premise

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -99,13 +99,21 @@ for detailed scope and acceptance criteria.
         `level` vs ADR claim-frontmatter `status`) so a mistier cannot
         silently disengage `check-no-overclaim`
   - [x] WS2 — prose over-claim meta-gate, shipped as `xtask check-no-overclaim`
-  - [ ] WS3 — replay golden-vector corpus across every content-address surface
-        (no corpus in tree; `check-content-address-determinism` pins the
-        `serde_json preserve_order` drift mechanism, not an address)
+  - [ ] WS3 — replay golden-vector corpus across every content-address surface,
+        recording σ and κ where a transform is in play (no corpus in tree;
+        `check-content-address-determinism` pins the `serde_json preserve_order`
+        drift mechanism, not an address)
   - [ ] WS4 — ≥2 independent verifiers over the WS3 corpus
   - [ ] WS5 — bind each witness to its recorded red-proof
-  - [ ] WS6 — content-address the kernel + build cache, verify-on-read
-        (**blocks plan 279 WS1**; scheduled in `specs/SPRINT.md`)
+  - [ ] WS6 — **lead item**: content-address the kernel + build cache, verify on
+        read as well as on write (**blocks plan 279 WS1**; scheduled in
+        `specs/SPRINT.md`). The 2026-08-01 recon revision reverses finding 2 —
+        integrity-on-read is the one attestation property no surveyed system
+        enforces, mvm included — which promotes this from tail to lead
+  - [ ] WS7 — σ/κ separation and the transform descriptor: the protocol digest
+        over plaintext and the storage address over bytes at rest as disjoint
+        types, σ as a set, descriptor as an open enumeration. Free while every
+        surface is `Identity`; a format migration per transform family later
   - [x] Discharged elsewhere: sealed transcript root anchored into the audit
         chain (recon §7.6 → plan 280, #2017); post-restore child verb grant
         (recon §7.7 → #2019)

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -105,11 +105,19 @@ for detailed scope and acceptance criteria.
         drift mechanism, not an address)
   - [ ] WS4 — ≥2 independent verifiers over the WS3 corpus
   - [ ] WS5 — bind each witness to its recorded red-proof
-  - [ ] WS6 — **lead item**: content-address the kernel + build cache, verify on
-        read as well as on write (**blocks plan 279 WS1**; scheduled in
-        `specs/SPRINT.md`). The 2026-08-01 recon revision reverses finding 2 —
-        integrity-on-read is the one attestation property no surveyed system
-        enforces, mvm included — which promotes this from tail to lead
+  - [~] WS6 — **lead item**: content-address the caches, verify on read. The
+        2026-08-01 recon revision reverses finding 2 — integrity-on-read is the
+        one attestation property no surveyed system enforces, mvm included —
+        which promoted this from tail to lead
+    - [x] Dev-build artifact cache, shipped in #2053: `mvm_core::action` +
+          `verify_artifacts_on_disk`, verify on read, fail closed to a cold
+          miss, and eviction of **both** the record and the build directory —
+          a record-only eviction would leave the poisoned tree under a name a
+          later build re-adopts. Unblocks plan 279 WS1
+    - [ ] Workload/builder kernel cache: still path-trusting.
+          `verify_fetched_kernel` exists with **no production caller** —
+          neither the fetch nor the read path checks a kernel against its pin
+    - [ ] Cold-tier background scrub (recon §7.9)
   - [ ] WS7 — σ/κ separation and the transform descriptor: the protocol digest
         over plaintext and the storage address over bytes at rest as disjoint
         types, σ as a set, descriptor as an open enumeration. Free while every

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -92,6 +92,23 @@ for detailed scope and acceptance criteria.
   - [x] Keep the removed MCP server and smoke lane out of CI
   - [x] Complete workspace and Linux clippy verification; the first live run
         passed and measured a 19–21 minute runner wait
+ - [~] Plan 276 — Content-addressing conformance and defense
+      (`specs/plans/276-content-addressing-conformance-and-defense.md`)
+  - [x] WS0 — plan + recon note landed (#1964); axis/policy ratification open
+  - [ ] WS1 — reconcile the two claim tier vocabularies (`model/claims.toml`
+        `level` vs ADR claim-frontmatter `status`) so a mistier cannot
+        silently disengage `check-no-overclaim`
+  - [x] WS2 — prose over-claim meta-gate, shipped as `xtask check-no-overclaim`
+  - [ ] WS3 — replay golden-vector corpus across every content-address surface
+        (no corpus in tree; `check-content-address-determinism` pins the
+        `serde_json preserve_order` drift mechanism, not an address)
+  - [ ] WS4 — ≥2 independent verifiers over the WS3 corpus
+  - [ ] WS5 — bind each witness to its recorded red-proof
+  - [ ] WS6 — content-address the kernel + build cache, verify-on-read
+        (**blocks plan 279 WS1**; scheduled in `specs/SPRINT.md`)
+  - [x] Discharged elsewhere: sealed transcript root anchored into the audit
+        chain (recon §7.6 → plan 280, #2017); post-restore child verb grant
+        (recon §7.7 → #2019)
 
 - [~] Plan 265 — Fast-start SLO, backend sequencing & competitive positioning
   (`specs/plans/265-fast-start-slo-sequencing-positioning.md`)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -60,12 +60,19 @@
       both were planted against and recorded in `specs/VERIFICATION.md`.
 
 - [ ] Build cache verify-on-read — schedule **plan 276 WS6**. `~/.mvm/dev/builds/
-      <rev>/` is served on a hit if `rootfs.ext4` merely exists as a file: no
-      digest, no signature, so content substitution is undetected, and the
-      provenance recorder then signs whatever bytes are on disk. The audit log
-      faithfully records a substituted image as legitimate. Plan 276 is written
-      and Proposed; this moves WS6 into the sprint. Prerequisite for plan 279
-      WS1 so the new cache key and the new verification do not land together.
+      <rev>/` was served on a hit if `rootfs.ext4` merely existed as a file: no
+      digest, no signature, so content substitution went undetected and the
+      provenance recorder then signed whatever bytes were on disk — the audit
+      log faithfully recording a substituted image as legitimate.
+  - [x] Dev-build artifact cache closed in #2053: `mvm_core::action` +
+        `verify_artifacts_on_disk`, verified on read, failing closed to a cold
+        miss, and evicting both the record and the build directory. Evicting
+        only the record would leave the poisoned tree under a name a later
+        build can re-adopt. Also closed a mid-build leak of `dev_builds_dir()`
+        on failure paths. This unblocks plan 279 WS1.
+  - [ ] Kernel cache still open: `resolve_kernel` returns `Cached` on
+        `path.exists()`, and `verify_fetched_kernel` has no production caller,
+        so neither the fetch nor the read path checks a kernel against its pin.
 
 - [ ] Build action identity + artifact manifest — **plan 279**
       (`specs/plans/279-build-action-identity-and-artifact-manifest.md`).

--- a/specs/plans/276-content-addressing-conformance-and-defense.md
+++ b/specs/plans/276-content-addressing-conformance-and-defense.md
@@ -2,38 +2,61 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Status:** Proposed — Phase 0/1 of the UOR × Hologram cross-project recon (`specs/research/uor-hologram-cross-project-recon.md`). Not yet scheduled into `specs/SPRINT.md`; do not start a workstream until an owner moves it into the active sprint.
+**Status:** Proposed, reconciled against `main` on 2026-08-01. Phase 0/1 of the UOR × Hologram cross-project recon (`specs/research/uor-hologram-cross-project-recon.md`). WS0 and WS2 are **already satisfied by shipped work** (see "Landed since this plan was written"); WS1 and WS5 are narrower than first written because the substrate they proposed to invent already exists. WS3, WS4 and WS6 are the real remaining scope. Not yet scheduled into `specs/SPRINT.md`; do not start a workstream until an owner moves it into the active sprint.
 
-**Goal:** Harden mvm's claim→witness program and broaden content-addressing coverage, taking **zero** UOR/Hologram code dependency. Two convergent outcomes: (1) the claim ledger gains evidence tiers, a prose over-claim gate, a replay-vector lane, and an explicit two-verifier oracle bar; (2) the build/runtime cache — the kernel first — becomes content-addressed with verify-on-read, closing a live cache-skew/poisoning class. Both fall out of the same canonicalization-rigor effort; see recon §6 (methodology) and §7 (defense).
+**Goal:** Harden mvm's claim→witness program and broaden content-addressing coverage, taking **zero** UOR/Hologram code dependency. Two convergent outcomes: (1) the claim ledger gains a single reconciled evidence tier, a replay-vector lane, and an explicit two-verifier oracle bar; (2) the build/runtime cache — the kernel first — becomes content-addressed with verify-on-read, closing a live cache-skew/poisoning class. Both fall out of the same canonicalization-rigor effort; see recon §6 (methodology) and §7 (defense).
 
 **Architecture:** Six workstreams, each its own PR, sharing no code:
 
-- **WS0** Decide & scope (Phase 0): ratify "conform, don't consume" as policy; pin SHA-256 as the canonical content-address axis; land this plan + the recon note.
-- **WS1** Claim evidence tiers (recon U1).
-- **WS2** Prose over-claim meta-gate (recon U2).
-- **WS3** Replay golden-vector lane (recon U4).
+- **WS0** Decide & scope (Phase 0) — **done**, except the axis ratification line.
+- **WS1** Claim evidence tiers (recon U1) — **reconcile two tier vocabularies that already exist**, not invent one.
+- **WS2** Prose over-claim meta-gate (recon U2) — **shipped** as `xtask check-no-overclaim`.
+- **WS3** Replay golden-vector lane (recon U4) — **open**, and the highest-value remaining item.
 - **WS4** Two-verifier oracle bar (recon U5) — extend existing host/no_std parity.
-- **WS5** Falsifiability binding (recon U3) — extend `specs/VERIFICATION.md` + the mutation-witness gate.
-- **WS6** Content-address kernel + build cache, verify-on-read (recon §7.2 defensive coverage).
+- **WS5** Falsifiability binding (recon U3) — bind red-proofs to witnesses; the gates and the `VERIFICATION.md` rows already exist.
+- **WS6** Content-address kernel + build cache, verify-on-read (recon §7.2 defensive coverage) — **open, and blocking plan 279 WS1**.
 
-**Tech Stack:** Rust, `xtask` (gates), `specs/claims/catalog.md` + `specs/adrs/001-microvm-security-posture.md` (the ledger), `specs/VERIFICATION.md` (falsifiability), `cargo-nextest`, `mvm-conformance` (cucumber), GitHub Actions (`ci.yml` + `ci-full.yml` Lint jobs, `security.yml`). SHA-256 + `serde_jcs` + `ed25519-dalek` (existing; **no new crypto, no new runtime dependency**).
+**Tech Stack:** Rust, `xtask` (gates), the claims ledger — the `<!-- claims-catalog:begin -->` / `<!-- claims-catalog:end -->` table embedded in `specs/adrs/001-microvm-security-posture.md` (parsed by `xtask/src/claims_ledger.rs`) plus the `model/claims.toml` conformance ID register — `specs/VERIFICATION.md` (falsifiability), `cargo-nextest`, `mvm-conformance` (cucumber), GitHub Actions (`ci.yml` + `ci-full.yml` Lint jobs, `security.yml`). SHA-256 + `serde_jcs` + `ed25519-dalek` (existing; **no new crypto, no new runtime dependency**).
 
-**What mvm already has (extend, do not rebuild):** `xtask check-claim-catalog` (witness existence + contiguity); the mutation-witness gate (`check-mutation-witnesses`, #1934); `specs/VERIFICATION.md` §Falsifiability rows; host↔no_std audit-verifier parity (`mvm_verify_matches_supervisor_chain`); and `SemanticAddress` = `sha256(JCS(NFC(IR)))` pinned to published UOR-ADDR fixtures. This plan builds on those; it does not duplicate them.
+> **Path correction.** Earlier revisions of this plan referenced `specs/claims/catalog.md`. That file does not exist and this plan must not recreate it. There are two ledger surfaces and they are both authoritative for different things: `model/claims.toml` is the ID register (`id`, `level`, `suite`, `statement`, typed `fn:`/`ci:` witnesses; `CONFORMANCE.md` is generated from it), and the ADR-001 marker-delimited table is what `check-claim-catalog` walks for witness existence and contiguity.
+
+**What mvm already has (extend, do not rebuild):**
+
+- `xtask check-claim-catalog` — witness existence + contiguity over the ADR-001 ledger table.
+- `xtask check-no-overclaim` — the U2 gate, already shipped and stronger than U2 specified.
+- `xtask check-honesty`, `check-doc-claims`, `check-conformance`, `check-adr-coverage` — the surrounding prose/claim gate family.
+- `xtask check-mutation-witnesses` (#1934) and `check-claim-witness-freshness` (#2000, which notices a claim-bearing lane that stops *running*, not only one that fails).
+- `model/claims.toml` — already carries `level = some-true | build | open`, i.e. the `template/model/ids.toml` honesty axis recon U1 named as its source pattern.
+- `specs/VERIFICATION.md` §Falsifiability — 36 recorded planted-defect rows.
+- Host↔no_std audit-verifier parity (`mvm_verify_matches_supervisor_chain`, `crates/mvm-hostd/src/supervisor/audit_file.rs`).
+- `SemanticAddress` = `sha256(JCS(NFC(IR)))`, pinned to published UOR-ADDR fixtures by `matches_published_uor_addr_json_fixtures`.
+
+This plan builds on those; it does not duplicate them.
 
 ## Provenance
 
 Sourced from a code-level read of UOR-Foundation + Hologram-Technologies (`specs/research/uor-hologram-cross-project-recon.md`). The disposition is **conform, don't consume**: adopt the ecosystem's conformance/honesty discipline as patterns; take no `uor-addr`/`uor-prism`/`uor-foundation` dependency. Recon Phases 2 (interop alignment) and 3 (runtime/fleet/AI) are trigger-gated and out of scope here.
 
+The recon gained §7.6 (data-plane provability at the vsock chokepoint) and §7.7 (identity and permissions in the packet — signed capability vs hashed claim) on 2026-07-31, **after** the first draft of this plan. Both have since been discharged by shipped work rather than by a workstream here; see below. Their durable output for this plan is a set of non-goals, not new scope.
+
+## Landed since this plan was written
+
+Recorded so no workstream re-proposes them.
+
+- [x] **Prose over-claim meta-gate (WS2 / recon U2)** — `xtask check-no-overclaim` (`xtask/src/check_no_overclaim.rs`). It is broader than U2 asked for: rather than a curated assertive-verb list, it builds a `phrase → (claim, status, exempt_paths)` index from claim frontmatter embedded in `specs/adrs/**/*.md` and refuses any gated phrase on user-facing surface (`.md` **and** `.rs`) unless the owning claim is `Shipped`. Status vocabulary is `Planned | Preview | Shipped | Not-claimed`, with `Not-claimed` treated as `Planned`.
+- [x] **Sealed data-plane transcript root anchored into the audit chain (recon §7.6)** — plan 280 (`specs/plans/280-transcript-root-audit-binding.md`, **Complete**), shipped in #2017. Manifest format v2 carries an RFC-6962 Merkle root over the capture binding, bounds, wrapped-key metadata and ordered ciphertext chunk records; the host chain-signs that address and `mvmctl trust audit transcript export` requires an exact anchor in a valid tenant chain. Plaintext and plaintext digests never enter the root — the §7.4 confirmation-oracle rule holds. v1 manifests fail closed on export. Recon §11 listed this as Phase-1 work and this plan never carried it as a workstream; it is closed either way.
+- [x] **Post-restore child verb grant (recon §7.7)** — #2019 delivers a freshly host-signed grant bound to the restored child's newly admitted plan/session (`crates/mvm-runtime/src/workload_runner/child_grant.rs`). §7.7's conclusion was that this needed the existing grant path completed, not a new capability system; that is what shipped.
+
 ## Global Constraints
 
-- Work in the dedicated worktree `../.worktrees/mvm-uor-hologram` on branch `docs/uor-hologram-recon` (this plan + the recon note land there first); each later workstream gets its own worktree/branch/PR. git via `git -C <wt-abs>`.
+- Each workstream gets its own worktree/branch/PR; git via `git -C <wt-abs>`. (The original recon worktree `../.worktrees/mvm-uor-hologram` on `docs/uor-hologram-recon` merged in #1964 and is gone — do not look for it.)
 - No `Plan N` / `ADR-\d+` / `#NNNN` / `W\d.` tokens in code or code comments (CI `check-no-spec-refs-in-comments`); spec docs may reference them.
 - Rust: never `#[allow]` a clippy lint; `rustup run nightly cargo fmt --all` before push (CI Lint uses nightly rustfmt); `cargo nextest run --workspace` + `cargo test --workspace --doc` green before any task is marked done.
 - No `Co-Authored-By: Claude` trailer and no AI-tool attribution in commits or PR body.
 - Scratch files under `/tmp/`, never in the working tree.
 - Every new `xtask` gate is added to **both** `.github/workflows/ci.yml` and `.github/workflows/ci-full.yml` Lint jobs — the gate list is duplicated and a gate in only one silently does not run.
 - Every new gate gets a row in `specs/VERIFICATION.md` §Falsifiability recording the planted defect that proved it fires.
-- Tick this plan's checkboxes and update `specs/SPRINT.md` in the same commit as the work.
+- Tick this plan's checkboxes and update `specs/SPRINT.md` + `specs/REFACTOR-STATUS.md` in the same commit as the work.
 
 ## Non-goals (do not re-propose)
 
@@ -41,6 +64,9 @@ Sourced from a code-level read of UOR-Foundation + Hologram-Technologies (`specs
 - **No hash-only trust.** Content-addressing stays an integrity layer *under* the signed, plan-bound authorization — never the hash as permission (see S1).
 - **No BLAKE3 re-axis.** SHA-256 stays the canonical axis (WS0); a second axis is a Phase-2 interop decision, not this plan.
 - **No runtime/fleet/AI interop** (holospace object model, hologram-ai, distributed transport) — recon Phase 3, trigger-gated.
+- **No third claims-ledger file.** `specs/claims/catalog.md` is gone and stays gone; extend `model/claims.toml` and the ADR-001 table.
+- **No new capability system, and no custom Ed25519 + hash-chain delegation scheme** (recon §7.7). A content-addressed permission is not authority — κ certifies that a packet *contains* a permission string, never that it was *granted*. mvm's signed, validity/nonce-bound `ExecutionPlan` (claim 8), broker `services` binding (claim 12) and destination-bound signed credentials (claim 13) are already the working form. An established attenuatable format (Macaroons, Biscuit) is evaluated **only** when a concrete offline or multi-hop delegation requirement appears, and then against a written bearer/replay/revocation threat model.
+- **No per-packet signing on the hot vsock path** (recon §7.7). Authenticate and bind authority at session/connection admission; carry only the already-bound flow/session identity afterwards. Every chain-signed `AuditEntry` already records the governing `plan_id`, so a second capability digest per flow would duplicate an existing binding.
 
 ## Security considerations — settle before writing code
 
@@ -49,54 +75,82 @@ Sourced from a code-level read of UOR-Foundation + Hologram-Technologies (`specs
 - **S3 — verify-on-read must fail closed.** A cache hit whose recomputed address ≠ the key is a tamper/skew signal: reject + evict, never serve. Absence of a hash must not fall back to trusting the path.
 - **S4 — do not weaken dm-verity.** Content-addressing the kernel is additive provenance; the workload rootfs dm-verity roothash chain (claim 3) is unchanged and remains authoritative for the sealed rootfs.
 - **S5 — NFC decision.** `SemanticAddress` NFC-normalizes; `ir_hash`/`plan_id` do not. WS3 pins the *current* behavior as a replay vector first (freeze what ships), then WS1/owner decides whether to converge on NFC — never silently change an address.
+- **S6 — one tier vocabulary, or the gates disagree.** Two independent honesty axes are live: `model/claims.toml` `level` (`some-true` | `build` | `open`) and the ADR claim-frontmatter `status` (`Planned` | `Preview` | `Shipped` | `Not-claimed`) that `check-no-overclaim` enforces. Nothing currently checks them against each other, so a claim can read `open` in the register and `Shipped` in its frontmatter — which would silently disengage the over-claim gate on a property that was only ever measured. WS1 exists to close that, and must not introduce a third vocabulary.
 
 ## Workstreams
 
 ### WS0 — Decide & scope (Phase 0)
+- [x] Land this plan + `specs/research/uor-hologram-cross-project-recon.md` (#1964).
 - [ ] Owner ratifies "conform, don't consume" as recorded policy (a line in ADR-001, or a short ADR referencing the recon).
 - [ ] Pin SHA-256 as the canonical content-address axis (documented; BLAKE3 deferred to Phase 2).
-- [ ] Land this plan + `specs/research/uor-hologram-cross-project-recon.md` (this PR).
-- [ ] Owner moves WS1–WS6 into `specs/SPRINT.md` when scheduling; until then they stay Proposed.
+- [ ] Owner moves WS1 + WS3–WS6 into `specs/SPRINT.md` when scheduling; until then they stay Proposed.
 
-### WS1 — Claim evidence tiers (U1)
-- [ ] Add a `tier:` field per claim in `specs/claims/catalog.md`: `shipped` | `preview` | `open`.
-- [ ] Extend `xtask check-claim-catalog`: `shipped` requires a live `fn:` AND `ci:` witness; `open` must not appear in the ADR-001 numbered prose table; `preview` requires ≥1 witness.
-- [ ] Backfill tiers for claims 1–15 (`shipped`), claim 16 (`preview`), and any `open` measured-not-asserted properties.
-- [ ] Gate wired into `ci.yml` + `ci-full.yml` Lint; falsifiability row in `VERIFICATION.md` (planted: mistier an `open` claim as `shipped` → gate fires).
+### WS1 — Reconcile the claim evidence tiers (U1)
 
-### WS2 — Prose over-claim meta-gate (U2)
-- [ ] New `xtask` lint (or extend `check-claim-catalog`) scanning `preview`/`open` claim prose in ADR-001 / claim docs; fail on assertive verbs ("proves", "guarantees", "verified", "ensures", "cannot", "impossible") absent a `shipped` witness.
-- [ ] Curate the verb list + an allow-mechanism for quoted/negated legitimate uses.
-- [ ] Gate wired into both Lint lanes; `VERIFICATION.md` row (planted: add "this proves" to a preview claim → gate fires).
+Scope changed: the tier fields exist, unreconciled (S6). Do not add a `tier:` column.
+
+- [ ] Define the mapping between `model/claims.toml` `level` and ADR claim-frontmatter `status`, and record it in ADR-001 next to the ledger table (the exhaustive pairs, including which combinations are illegal).
+- [ ] Extend `xtask check-claim-catalog` to fail on a claim whose `level` and `status` disagree — specifically, `level = "open"` with `status = "Shipped"`, which would disengage `check-no-overclaim` on a measured-not-asserted property.
+- [ ] Enforce the witness bar per status: `Shipped` requires a live `fn:` **and** `ci:` witness; `Preview` requires ≥1; `open` must not appear in the ADR-001 numbered prose table.
+- [ ] Backfill any claim whose two fields currently disagree; claim 16 (egress-substitution leak-gate) and the OCI-provenance claim are the known promotion-pending cases.
+- [ ] Gate wired into `ci.yml` + `ci-full.yml` Lint; falsifiability row in `VERIFICATION.md` (planted: flip an `open` claim's frontmatter to `Shipped` → gate fires).
+
+### WS2 — Prose over-claim meta-gate (U2) — shipped
+- [x] `xtask check-no-overclaim` scans user-facing `.md` and `.rs` for phrases gated by a claim whose `status` is not `Shipped`, honouring per-claim `exempt_paths`.
+- [x] Wired into the Lint lanes; `VERIFICATION.md` carries its falsifiability row.
+
+No residual work. WS1's cross-field check is what makes this gate trustworthy — a claim mistiered to `Shipped` disengages it, which is why S6 is a security consideration and not a tidiness one.
 
 ### WS3 — Replay golden-vector lane (U4)
-- [ ] Create a frozen `(input → expected address)` corpus for **every** surface: `SemanticAddress`, `ir_hash`, `plan_id`, `bundle_sha256`/manifest, audit `prev_hash` spine, RFC-6962 Merkle root.
+
+The remaining high-value item, and untouched. `xtask check-content-address-determinism` is **not** this lane — it only asserts the non-build `serde_json` unit reachable from `mvm-core`/`mvm-protocol` does not carry `preserve_order`. That pins one drift mechanism; it pins no address. There is no vector corpus in the tree.
+
+- [ ] Create a frozen `(input → expected address)` corpus for **every** surface: `SemanticAddress`, `ir_hash`, `plan_id`, `bundle_sha256`/manifest, the audit `prev_hash` spine, the RFC-6962 Merkle root, and the plan-280 transcript manifest root (new since the first draft — it is a content address on the signed chain and must not drift either).
 - [ ] A test recomputes each and asserts byte-equality; fails on any canonicalization drift (`serde_jcs` bump, field reorder, NFC change).
 - [ ] Seed with current shipped behavior (freezes S5's NFC status quo). Include astral-plane-key + Unicode-normalization edge vectors.
 - [ ] Run in nextest (workspace); `VERIFICATION.md` row (planted: reorder a JCS key emitter → vector mismatch fires).
 
 ### WS4 — Two-verifier oracle bar (U5)
-- [ ] Make the WS3 replay corpus the shared vector set the existing host↔no_std audit-verifiers both consume.
+- [ ] Make the WS3 replay corpus the shared vector set the existing host↔no_std audit-verifiers both consume (`mvm_verify_matches_supervisor_chain` pins the equivalence today over ad-hoc input, not a frozen corpus).
 - [ ] Add the riscv32/ESP32 verifier (edge tier) as the third independent oracle over the same corpus where it builds.
-- [ ] Record in `specs/claims/catalog.md` which claims are backed by ≥2 independent verifiers.
+- [ ] Record in `model/claims.toml` which claims are backed by ≥2 independent verifiers.
 - [ ] `VERIFICATION.md` row (planted: diverge one verifier's canonicalizer → parity test fires).
 
 ### WS5 — Falsifiability binding (U3)
-- [ ] Add a `falsified_by:` reference per witness in `specs/claims/catalog.md` pointing at the mutation/negative-test that goes red when the witness breaks (reuse the mutation-witness surface #1934 + existing `VERIFICATION.md` rows).
-- [ ] Extend `check-claim-catalog` (or the mutation-witness gate) to fail if a claim witness has no recorded red-proof.
+
+Narrower than first written: the mutation surface, the freshness gate and the 36 `VERIFICATION.md` rows all exist. What is missing is the *binding* from a witness to its red-proof.
+
+- [ ] Add a `falsified_by:` field per witness in `model/claims.toml` pointing at the mutation/negative-test that goes red when the witness breaks.
+- [ ] Extend `check-claim-catalog` (or `check-mutation-witnesses`) to fail if a witness has no recorded red-proof.
 - [ ] Backfill red-proof references; note the CI-only witnesses that mutation testing structurally cannot reach (mirror plan 274 WS3).
 - [ ] `VERIFICATION.md` row (planted: strip a witness's red-proof → gate fires).
 
 ### WS6 — Content-address the kernel + build cache, verify-on-read (defense)
-- [ ] Identify the workload/builder kernel cache read path (the one with no staleness check) and the `mvm-build` artifact cache read paths.
-- [ ] Add a content-address (SHA-256) to each cached artifact's key and verify-on-read on every hit (recompute, compare, fail closed per S3; evict on mismatch).
+
+**Downstream dependency: plan 279 WS1 (`ActionDigest`) is blocked on this landing** — plan 279 states the closure explicitly ("`~/.mvm/dev/builds/<rev>/` is served on a hit if `rootfs.ext4` merely exists as a file … Closing this is plan 276 WS6, not this plan"). `specs/SPRINT.md` already carries the same note. Schedule WS6 accordingly; it is no longer the independent tail of this plan.
+
+- [ ] Identify the workload/builder kernel cache read path (the one with no staleness check) and the `mvm-build` artifact cache read paths, including `~/.mvm/dev/builds/<rev>/`.
+- [ ] Add a content-address (SHA-256) to each cached artifact's key and verify-on-read on every hit (recompute, compare, fail closed per S3; evict on mismatch). `mvm_core::pack_cache` already implements exactly this discipline for packs — reuse it rather than writing a second cache.
 - [ ] Keep caching within the per-tenant/trust boundary (S2); dm-verity roothash chain unchanged (S4).
 - [ ] Tests: cache-hit-verifies, tampered-cache-entry-rejected, skewed-kernel-detected. `VERIFICATION.md` row (planted: flip a byte in a cached kernel → verify-on-read rejects).
 
 ## Sequencing
 
-WS0 first (this PR). Then WS1 + WS3 (foundational, lowest risk; WS3 freezes address behavior before anything else touches it). WS2 and WS5 build on WS1's `tier:` field. WS4 consumes WS3's corpus. WS6 is independent and can run in parallel once WS0 lands. Each workstream is its own PR; none blocks another except the stated dependencies.
+WS0's two open ratification items are paperwork and gate nothing. **WS3 first** — it freezes address behavior before anything else touches it, and it is the only remaining item with no substrate already in place. WS1 next (it makes `check-no-overclaim` trustworthy per S6). WS4 consumes WS3's corpus, so it follows. WS5 is independent. **WS6 should be scheduled early despite being last in the list**, because plan 279 WS1 waits on it. Each workstream is its own PR.
+
+## Relationship to the build/CAS thread
+
+`specs/research/fast-attestable-content-addressed-builds-and-lean4.md` (#2011) and plan 279 cover the same content-addressing question from the build side. The seam is WS6 and it is deliberately owned here — 279 defers to it by name. Two consequences:
+
+- Do not re-derive a CAS in WS6. `mvm_core::pack_cache` is a content-addressed cache with verify-on-read, quarantine staging and atomic-rename publish; `mvm_core::packs::PackManifest` is already a SLSA-shaped provenance manifest.
+- The Lean 4 endpoint of recon §6 U5 (a machine-checked reference spec as the third oracle, recon §9) is scoped in the build/CAS research doc, not here. This plan stops at the ≥2-implementation bar.
+
+## Open — needs the revised recon
+
+A later revision of the recon exists as a published artifact (`a4642b38-55a7-4516-83d4-827aeeb8cb7c`, dated 2026-08-01, method "source-level read · 24 repos · upstream crate source · primary literature"). Its Finding 02 is reframed from "mvm is ahead on every security-critical primitive" to **"attestation coverage across the ecosystem is asymmetric, and integrity is the shared gap"**, and Finding 03 to "conform, don't consume — and the conformance discipline is the asset". That is a posture change, not a wording change: this plan's premise is that mvm is strictly ahead and only needs coverage breadth.
+
+- [ ] Fold the revised findings into the recon note and re-check this plan's premise against them — in particular whether "integrity is the shared gap" changes WS6's priority relative to WS3.
 
 ## Deferred to later recon phases (out of scope)
 
-Recon Phase 2 (interop alignment — axis / wire-form / in-toto canonicalization, reading `uor-foundation`, evaluating `uor-addr-1`) and Phase 3 (holospace object model into mvmd, `hologram-ai` interop for the `ai` command, distributed transport) are trigger-gated per recon §11 and are not part of this plan.
+Recon Phase 2 (interop alignment — axis / wire-form / in-toto canonicalization, reading `uor-foundation`, evaluating `uor-addr-1`) and Phase 3 (holospace object model into mvmd, `hologram-ai` interop for the `ai` command, distributed transport, and an attenuatable-capability format only on a concrete delegation trigger) are trigger-gated per recon §11 and are not part of this plan.

--- a/specs/plans/276-content-addressing-conformance-and-defense.md
+++ b/specs/plans/276-content-addressing-conformance-and-defense.md
@@ -2,19 +2,30 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Status:** Proposed, reconciled against `main` on 2026-08-01. Phase 0/1 of the UOR × Hologram cross-project recon (`specs/research/uor-hologram-cross-project-recon.md`). WS0 and WS2 are **already satisfied by shipped work** (see "Landed since this plan was written"); WS1 and WS5 are narrower than first written because the substrate they proposed to invent already exists. WS3, WS4 and WS6 are the real remaining scope. Not yet scheduled into `specs/SPRINT.md`; do not start a workstream until an owner moves it into the active sprint.
+**Status:** Proposed, reconciled against `main` **and against the 2026-08-01 recon revision**. Phase 0/1 of the UOR × Hologram cross-project recon (`specs/research/uor-hologram-cross-project-recon.md`). WS0 and WS2 are **already satisfied by shipped work** (see "Landed since this plan was written"); WS1 and WS5 are narrower than first written because the substrate they proposed to invent already exists. **WS6 is now the lead workstream, not the tail** — see "The premise changed" below. Not yet scheduled into `specs/SPRINT.md`; do not start a workstream until an owner moves it into the active sprint.
 
-**Goal:** Harden mvm's claim→witness program and broaden content-addressing coverage, taking **zero** UOR/Hologram code dependency. Two convergent outcomes: (1) the claim ledger gains a single reconciled evidence tier, a replay-vector lane, and an explicit two-verifier oracle bar; (2) the build/runtime cache — the kernel first — becomes content-addressed with verify-on-read, closing a live cache-skew/poisoning class. Both fall out of the same canonicalization-rigor effort; see recon §6 (methodology) and §7 (defense).
+**Goal:** Close the integrity-on-read gap and harden mvm's claim→witness program, taking **zero** UOR/Hologram code dependency. Two outcomes: (1) the build/runtime cache — the kernel first — becomes content-addressed and **verified on read**, closing a live cache-skew/poisoning class and the identity-discrepancy class with it; (2) the claim ledger gains a single reconciled evidence tier, a replay-vector lane, and an explicit two-verifier oracle bar. Both fall out of the same canonicalization-rigor effort; see recon §6 (methodology) and §7 (defense).
 
-**Architecture:** Six workstreams, each its own PR, sharing no code:
+## The premise changed
 
-- **WS0** Decide & scope (Phase 0) — **done**, except the axis ratification line.
+The first draft of this plan rested on recon finding 2 as originally written — *"mvm is ahead on every security-critical primitive; the ecosystem stops at integrity."* The 2026-08-01 recon revision **reverses that finding**, and the reversal is load-bearing here:
+
+- `kappa-registry` does enforce authenticity, freshness and ordering (closed-constructor anchors held by a compile-fail test, hybrid-logical-clock watermarks, an Ed25519-signed seven-leaf domain-separated backward-linked epoch root). The ecosystem does not "stop at integrity."
+- What **no** surveyed system enforces is **integrity on read**. `kappa-registry` verifies at 4 of 13 write paths and no read path; mvm's workload kernel and build cache are trusted-by-path. That is the one property a content address exists to supply.
+- Verification on retrieval is the *founding definition* of content-addressing, not an enhancement: the original archival design specified that on retrieval both sides recompute the fingerprint and compare. A signed chain over addresses that were never checked attests to pointers, not to content.
+
+Two consequences for this plan. **WS6 moves from tail to lead** — it is no longer "broader coverage", it is the unenforced property. And **WS0's axis decision inverts**: "pin SHA-256 as the canonical axis" is superseded by the σ-set contract (recon §7.8), because pinning one axis forecloses the dual-hash transition that makes axis fragmentation survivable.
+
+**Architecture:** Seven workstreams, each its own PR, sharing no code:
+
+- **WS0** Decide & scope (Phase 0) — **done**, except the policy + σ-set ratification lines.
 - **WS1** Claim evidence tiers (recon U1) — **reconcile two tier vocabularies that already exist**, not invent one.
 - **WS2** Prose over-claim meta-gate (recon U2) — **shipped** as `xtask check-no-overclaim`.
-- **WS3** Replay golden-vector lane (recon U4) — **open**, and the highest-value remaining item.
+- **WS3** Replay golden-vector lane (recon U4) — open; now records σ **and** κ wherever a transform is in play.
 - **WS4** Two-verifier oracle bar (recon U5) — extend existing host/no_std parity.
 - **WS5** Falsifiability binding (recon U3) — bind red-proofs to witnesses; the gates and the `VERIFICATION.md` rows already exist.
-- **WS6** Content-address kernel + build cache, verify-on-read (recon §7.2 defensive coverage) — **open, and blocking plan 279 WS1**.
+- **WS6** Content-address kernel + build cache, **verify on read** (recon §7.1/§7.9) — **the lead item, and blocking plan 279 WS1**.
+- **WS7** σ/κ separation and the transform descriptor (recon §7.8) — new; cheap now, a per-transform-family format migration later.
 
 **Tech Stack:** Rust, `xtask` (gates), the claims ledger — the `<!-- claims-catalog:begin -->` / `<!-- claims-catalog:end -->` table embedded in `specs/adrs/001-microvm-security-posture.md` (parsed by `xtask/src/claims_ledger.rs`) plus the `model/claims.toml` conformance ID register — `specs/VERIFICATION.md` (falsifiability), `cargo-nextest`, `mvm-conformance` (cucumber), GitHub Actions (`ci.yml` + `ci-full.yml` Lint jobs, `security.yml`). SHA-256 + `serde_jcs` + `ed25519-dalek` (existing; **no new crypto, no new runtime dependency**).
 
@@ -62,7 +73,7 @@ Recorded so no workstream re-proposes them.
 
 - **No `uor-addr`/`uor-prism`/`uor-foundation` dependency.** It drags the prism substrate (~156 transitive crates incl. FHE/tensor) and duplicates existing `sha2`/`serde_jcs`/`ed25519-dalek`. Conform to the wire label; do not consume the crate.
 - **No hash-only trust.** Content-addressing stays an integrity layer *under* the signed, plan-bound authorization — never the hash as permission (see S1).
-- **No BLAKE3 re-axis.** SHA-256 stays the canonical axis (WS0); a second axis is a Phase-2 interop decision, not this plan.
+- **No BLAKE3 *migration*.** SHA-256 stays the axis mvm mints on, and nothing in this plan re-addresses an existing artifact. But do **not** re-propose "pin SHA-256 as the canonical axis" as a policy: the 2026-08-01 recon supersedes it with the σ-set contract (WS7), under which one storage address is reachable by more than one protocol digest. Pinning forecloses the dual-hash transition; minting on SHA-256 does not.
 - **No runtime/fleet/AI interop** (holospace object model, hologram-ai, distributed transport) — recon Phase 3, trigger-gated.
 - **No third claims-ledger file.** `specs/claims/catalog.md` is gone and stays gone; extend `model/claims.toml` and the ADR-001 table.
 - **No new capability system, and no custom Ed25519 + hash-chain delegation scheme** (recon §7.7). A content-addressed permission is not authority — κ certifies that a packet *contains* a permission string, never that it was *granted*. mvm's signed, validity/nonce-bound `ExecutionPlan` (claim 8), broker `services` binding (claim 12) and destination-bound signed credentials (claim 13) are already the working form. An established attenuatable format (Macaroons, Biscuit) is evaluated **only** when a concrete offline or multi-hop delegation requirement appears, and then against a written bearer/replay/revocation threat model.
@@ -71,10 +82,13 @@ Recorded so no workstream re-proposes them.
 ## Security considerations — settle before writing code
 
 - **S1 — address ≠ authorization (invariant).** Every new content-address check verifies integrity only. It must never become an admission decision; the signed `ExecutionPlan` + `key_id`-pinned bundle remain the sole authority. WS6's verify-on-read gates *cache trust*, not *workload admission*.
-- **S2 — cross-tenant dedup is a leak.** WS6's content-addressed cache must not dedup across a tenant/trust boundary (a shared address confirms two tenants hold identical content; an address fingerprints known content). Key the cache within the existing per-tenant boundary.
+- **S2 — cross-tenant dedup is an oracle, not merely a leak.** A truthful existence response across a trust boundary yields one bit per probe, and a target drawn from an enumerable set is recoverable in proportion to its entropy. Key WS6's cache within the existing per-tenant boundary. Two notes from recon §7.10: refusing a cross-namespace mount is *fully conformant* under the distribution spec (same request count, same client path, no unhandled error), so the safe default costs bandwidth rather than correctness; and under per-namespace key derivation the oracle cannot form **arithmetically** — identical plaintext yields different ciphertext, a different address and a different path — which is strictly better than preventing it by policy.
 - **S3 — verify-on-read must fail closed.** A cache hit whose recomputed address ≠ the key is a tamper/skew signal: reject + evict, never serve. Absence of a hash must not fall back to trusting the path.
 - **S4 — do not weaken dm-verity.** Content-addressing the kernel is additive provenance; the workload rootfs dm-verity roothash chain (claim 3) is unchanged and remains authoritative for the sealed rootfs.
 - **S5 — NFC decision.** `SemanticAddress` NFC-normalizes; `ir_hash`/`plan_id` do not. WS3 pins the *current* behavior as a replay vector first (freeze what ships), then WS1/owner decides whether to converge on NFC — never silently change an address.
+- **S7 — an address digest must be collision-resistant; an attestation digest need not be.** MD5, CRC32C and CRC64 are legitimate *attestations* and disqualified as *addresses*. Enforce the distinction with disjoint types and a compile-fail test, not with review — the same posture `mvm_core::semantic_address` already takes by having no conversions between identity families.
+- **S8 — never sign state that cannot be substantiated.** The order is content → index → root → signature → publication. A crash before signing is recoverable; the reverse order forks the chain with no recovery path. This binds WS3's transcript-root vector and any future signed root.
+- **S9 — a reconciliation root is not a commitment.** If distributed transport is ever revisited (recon Phase 3), the fingerprint must be multiset-homomorphic — an XOR aggregation lets a peer withhold arbitrary data by claiming absence, with no collision-finding and no functional-test signal — and an MST page/root digest from a non-cryptographic hash must never be signed. Out of scope here; recorded so it is not rediscovered late.
 - **S6 — one tier vocabulary, or the gates disagree.** Two independent honesty axes are live: `model/claims.toml` `level` (`some-true` | `build` | `open`) and the ADR claim-frontmatter `status` (`Planned` | `Preview` | `Shipped` | `Not-claimed`) that `check-no-overclaim` enforces. Nothing currently checks them against each other, so a claim can read `open` in the register and `Shipped` in its frontmatter — which would silently disengage the over-claim gate on a property that was only ever measured. WS1 exists to close that, and must not introduce a third vocabulary.
 
 ## Workstreams
@@ -82,8 +96,8 @@ Recorded so no workstream re-proposes them.
 ### WS0 — Decide & scope (Phase 0)
 - [x] Land this plan + `specs/research/uor-hologram-cross-project-recon.md` (#1964).
 - [ ] Owner ratifies "conform, don't consume" as recorded policy (a line in ADR-001, or a short ADR referencing the recon).
-- [ ] Pin SHA-256 as the canonical content-address axis (documented; BLAKE3 deferred to Phase 2).
-- [ ] Owner moves WS1 + WS3–WS6 into `specs/SPRINT.md` when scheduling; until then they stay Proposed.
+- [ ] Record the **σ-set contract** as the address-identity policy (one storage address reachable by ≥1 protocol digest), superseding the earlier "pin SHA-256 as the canonical axis" line. SHA-256 remains what mvm mints on.
+- [ ] Owner moves WS1 + WS3–WS7 into `specs/SPRINT.md` when scheduling; until then they stay Proposed.
 
 ### WS1 — Reconcile the claim evidence tiers (U1)
 
@@ -108,6 +122,7 @@ The remaining high-value item, and untouched. `xtask check-content-address-deter
 - [ ] Create a frozen `(input → expected address)` corpus for **every** surface: `SemanticAddress`, `ir_hash`, `plan_id`, `bundle_sha256`/manifest, the audit `prev_hash` spine, the RFC-6962 Merkle root, and the plan-280 transcript manifest root (new since the first draft — it is a content address on the signed chain and must not drift either).
 - [ ] A test recomputes each and asserts byte-equality; fails on any canonicalization drift (`serde_jcs` bump, field reorder, NFC change).
 - [ ] Seed with current shipped behavior (freezes S5's NFC status quo). Include astral-plane-key + Unicode-normalization edge vectors.
+- [ ] Where a transform is in play, record **both σ and κ** — only the pair pins the encoding (WS7 / recon §7.8). Every surface in mvm is `Identity` today, so today the two are equal; the vector must still carry both so the day one of them stops being `Identity` is a vector diff and not a silent re-address.
 - [ ] Run in nextest (workspace); `VERIFICATION.md` row (planted: reorder a JCS key emitter → vector mismatch fires).
 
 ### WS4 — Two-verifier oracle bar (U5)
@@ -125,18 +140,31 @@ Narrower than first written: the mutation surface, the freshness gate and the 36
 - [ ] Backfill red-proof references; note the CI-only witnesses that mutation testing structurally cannot reach (mirror plan 274 WS3).
 - [ ] `VERIFICATION.md` row (planted: strip a witness's red-proof → gate fires).
 
-### WS6 — Content-address the kernel + build cache, verify-on-read (defense)
+### WS6 — Content-address the kernel + build cache, verify on read (lead item)
 
-**Downstream dependency: plan 279 WS1 (`ActionDigest`) is blocked on this landing** — plan 279 states the closure explicitly ("`~/.mvm/dev/builds/<rev>/` is served on a hit if `rootfs.ext4` merely exists as a file … Closing this is plan 276 WS6, not this plan"). `specs/SPRINT.md` already carries the same note. Schedule WS6 accordingly; it is no longer the independent tail of this plan.
+**Why this is first.** Per the revised recon §7.1, integrity-on-read is the one attestation property no surveyed system enforces — not a coverage nicety. **Downstream dependency: plan 279 WS1 (`ActionDigest`) is blocked on this landing** — plan 279 states the closure explicitly ("`~/.mvm/dev/builds/<rev>/` is served on a hit if `rootfs.ext4` merely exists as a file … Closing this is plan 276 WS6, not this plan"). `specs/SPRINT.md` already carries the same note.
 
 - [ ] Identify the workload/builder kernel cache read path (the one with no staleness check) and the `mvm-build` artifact cache read paths, including `~/.mvm/dev/builds/<rev>/`.
-- [ ] Add a content-address (SHA-256) to each cached artifact's key and verify-on-read on every hit (recompute, compare, fail closed per S3; evict on mismatch). `mvm_core::pack_cache` already implements exactly this discipline for packs — reuse it rather than writing a second cache.
+- [ ] Add a content-address (SHA-256) to each cached artifact's key and verify **on read** on every hit (recompute, compare, fail closed per S3; evict on mismatch). `mvm_core::pack_cache` already implements exactly this discipline for packs — reuse it rather than writing a second cache.
+- [ ] Verify on read *as well as* on write. Recon §7.1 measured `kappa-registry` at 4 of 13 write paths verified and **no** read path; a write-only check is the failure mode to avoid, not the target.
+- [ ] Size the check to the object (recon §7.9): rehash small artifacts before serving; carry a running hash across frames for streamed artifacts and deliver the verdict in a trailer; add a background scrub over the reachability walk for cold artifacts — on-access verification never visits the blocks that are quietly rotting, and the measured corruption pattern has high spatial and temporal locality.
+- [ ] Cover the **identity-discrepancy** class explicitly, not just bit-rot: an intact artifact that is the *wrong* artifact. This is the workload-kernel cache-skew that currently mimics real bugs, and a path-trusting cache cannot see it at all.
 - [ ] Keep caching within the per-tenant/trust boundary (S2); dm-verity roothash chain unchanged (S4).
-- [ ] Tests: cache-hit-verifies, tampered-cache-entry-rejected, skewed-kernel-detected. `VERIFICATION.md` row (planted: flip a byte in a cached kernel → verify-on-read rejects).
+- [ ] Tests: cache-hit-verifies, tampered-cache-entry-rejected, skewed-kernel-detected, wrong-but-intact-artifact-detected. `VERIFICATION.md` row (planted: flip a byte in a cached kernel → verify-on-read rejects; swap two intact cached kernels → identity discrepancy fires).
+
+### WS7 — σ/κ separation and the transform descriptor (recon §7.8)
+
+New scope from the 2026-08-01 revision. Every mvm content-address surface is `Identity`-transform today, so σ and κ are numerically equal everywhere and this is a type separation with no migration. The moment any surface compresses, encrypts, deltas or erasure-codes at rest, modelling this as one label — or as an "encrypted" boolean — costs a format migration per transform family. Precedent is unanimous: git object IDs never hash the bytes on disk (loose objects deflated, packed objects delta-encoded), and ZFS compresses and encrypts beneath a checksum carried in the parent block pointer.
+
+- [ ] Introduce the pair as disjoint types with no conversion: **σ** the protocol digest over plaintext, **κ** the storage address over bytes at rest (path derivation, verification target, unit of transfer). Extend `mvm_core::semantic_address`'s identity taxonomy rather than starting a new one.
+- [ ] Model σ as a **set** — one κ reachable by ≥1 σ — which is what a dual-hash transition and multi-axis registration need, and what WS0's σ-set contract records as policy.
+- [ ] Represent the descriptor as an open enumeration, not a boolean: `framing: Whole | Fixed{frame_size} | Chunked{manifest}`, `per_frame: [Identity | Aead | Deflate | Delta{base} | Erasure{k,m}]`, `seek_map: Implicit | Explicit{cumulative} | None`. Framing is the outer layer; transforms apply per frame, which is what keeps ranged reads possible — whole-object sealing turns a ten-byte range request against a large object into a whole-object operation, removing the operation rather than slowing it.
+- [ ] Enforce S7 at the type level: an address family that admits MD5/CRC32C/CRC64 must not compile. Compile-fail test, not review.
+- [ ] `VERIFICATION.md` row (planted: add a σ→κ conversion → compile-fail test fires).
 
 ## Sequencing
 
-WS0's two open ratification items are paperwork and gate nothing. **WS3 first** — it freezes address behavior before anything else touches it, and it is the only remaining item with no substrate already in place. WS1 next (it makes `check-no-overclaim` trustworthy per S6). WS4 consumes WS3's corpus, so it follows. WS5 is independent. **WS6 should be scheduled early despite being last in the list**, because plan 279 WS1 waits on it. Each workstream is its own PR.
+Reordered by the 2026-08-01 revision. **WS6 first** — integrity-on-read is the unenforced property, and plan 279 WS1 is blocked behind it. **WS3 second**, freezing address behavior before anything else touches it. **WS7 alongside WS3** — the σ/κ types are what WS3's vectors record, and doing it while every transform is still `Identity` is the whole reason it is cheap. Then WS1 (it makes `check-no-overclaim` trustworthy per S6), then WS4 (consumes WS3's corpus). WS5 is independent throughout. WS0's remaining ratification items are paperwork and gate nothing. Each workstream is its own PR.
 
 ## Relationship to the build/CAS thread
 
@@ -145,12 +173,8 @@ WS0's two open ratification items are paperwork and gate nothing. **WS3 first** 
 - Do not re-derive a CAS in WS6. `mvm_core::pack_cache` is a content-addressed cache with verify-on-read, quarantine staging and atomic-rename publish; `mvm_core::packs::PackManifest` is already a SLSA-shaped provenance manifest.
 - The Lean 4 endpoint of recon §6 U5 (a machine-checked reference spec as the third oracle, recon §9) is scoped in the build/CAS research doc, not here. This plan stops at the ≥2-implementation bar.
 
-## Open — needs the revised recon
-
-A later revision of the recon exists as a published artifact (`a4642b38-55a7-4516-83d4-827aeeb8cb7c`, dated 2026-08-01, method "source-level read · 24 repos · upstream crate source · primary literature"). Its Finding 02 is reframed from "mvm is ahead on every security-critical primitive" to **"attestation coverage across the ecosystem is asymmetric, and integrity is the shared gap"**, and Finding 03 to "conform, don't consume — and the conformance discipline is the asset". That is a posture change, not a wording change: this plan's premise is that mvm is strictly ahead and only needs coverage breadth.
-
-- [ ] Fold the revised findings into the recon note and re-check this plan's premise against them — in particular whether "integrity is the shared gap" changes WS6's priority relative to WS3.
-
 ## Deferred to later recon phases (out of scope)
 
-Recon Phase 2 (interop alignment — axis / wire-form / in-toto canonicalization, reading `uor-foundation`, evaluating `uor-addr-1`) and Phase 3 (holospace object model into mvmd, `hologram-ai` interop for the `ai` command, distributed transport, and an attenuatable-capability format only on a concrete delegation trigger) are trigger-gated per recon §11 and are not part of this plan.
+Recon Phase 2 (interop alignment — the σ-set contract, canonical wire form and the transform descriptor agreed with the sibling projects **before either side ships a non-identity transform**; in-toto/SLSA canonicalization; reading `uor-foundation`; evaluating `uor-addr-1`) and Phase 3 (holospace object model into mvmd, `hologram-ai` interop for the `ai` command, distributed transport, and an attenuatable-capability format only on a concrete delegation trigger) are trigger-gated per recon §11 and are not part of this plan.
+
+Phase 3's distributed-transport item carries two prerequisites recorded in S9 and recon §7.11 — a multiset-homomorphic fingerprint, and never signing a reconciliation root. They are noted here so they are not rediscovered after an implementation exists.

--- a/specs/plans/276-content-addressing-conformance-and-defense.md
+++ b/specs/plans/276-content-addressing-conformance-and-defense.md
@@ -140,17 +140,25 @@ Narrower than first written: the mutation surface, the freshness gate and the 36
 - [ ] Backfill red-proof references; note the CI-only witnesses that mutation testing structurally cannot reach (mirror plan 274 WS3).
 - [ ] `VERIFICATION.md` row (planted: strip a witness's red-proof → gate fires).
 
-### WS6 — Content-address the kernel + build cache, verify on read (lead item)
+### WS6 — Content-address the caches, verify on read (lead item; dev-build half shipped)
 
-**Why this is first.** Per the revised recon §7.1, integrity-on-read is the one attestation property no surveyed system enforces — not a coverage nicety. **Downstream dependency: plan 279 WS1 (`ActionDigest`) is blocked on this landing** — plan 279 states the closure explicitly ("`~/.mvm/dev/builds/<rev>/` is served on a hit if `rootfs.ext4` merely exists as a file … Closing this is plan 276 WS6, not this plan"). `specs/SPRINT.md` already carries the same note.
+**Why this is first.** Per the revised recon §7.1, integrity-on-read is the one attestation property no surveyed system enforces — not a coverage nicety. **Downstream dependency: plan 279 WS1 (`ActionDigest`) was blocked on this** — plan 279 states the closure explicitly ("`~/.mvm/dev/builds/<rev>/` is served on a hit if `rootfs.ext4` merely exists as a file … Closing this is plan 276 WS6, not this plan").
 
-- [ ] Identify the workload/builder kernel cache read path (the one with no staleness check) and the `mvm-build` artifact cache read paths, including `~/.mvm/dev/builds/<rev>/`.
-- [ ] Add a content-address (SHA-256) to each cached artifact's key and verify **on read** on every hit (recompute, compare, fail closed per S3; evict on mismatch). `mvm_core::pack_cache` already implements exactly this discipline for packs — reuse it rather than writing a second cache.
-- [ ] Verify on read *as well as* on write. Recon §7.1 measured `kappa-registry` at 4 of 13 write paths verified and **no** read path; a write-only check is the failure mode to avoid, not the target.
-- [ ] Size the check to the object (recon §7.9): rehash small artifacts before serving; carry a running hash across frames for streamed artifacts and deliver the verdict in a trailer; add a background scrub over the reachability walk for cold artifacts — on-access verification never visits the blocks that are quietly rotting, and the measured corruption pattern has high spatial and temporal locality.
-- [ ] Cover the **identity-discrepancy** class explicitly, not just bit-rot: an intact artifact that is the *wrong* artifact. This is the workload-kernel cache-skew that currently mimics real bugs, and a path-trusting cache cannot see it at all.
-- [ ] Keep caching within the per-tenant/trust boundary (S2); dm-verity roothash chain unchanged (S4).
-- [ ] Tests: cache-hit-verifies, tampered-cache-entry-rejected, skewed-kernel-detected, wrong-but-intact-artifact-detected. `VERIFICATION.md` row (planted: flip a byte in a cached kernel → verify-on-read rejects; swap two intact cached kernels → identity discrepancy fires).
+There are two read paths and they fail differently. The dev-build artifact cache is closed; the kernel cache is not.
+
+**Shipped in #2053 — the dev-build artifact cache (`~/.mvm/dev/builds/<rev>/`):**
+
+- [x] `mvm_core::action` carries the canonical action/artifact types and `verify_artifacts_on_disk`; the build-cache record content-addresses the artifacts rather than naming a directory.
+- [x] Verify on read on every hit, failing closed per S3: an absent record, an unparseable record, or one that fails verification is a **cold miss**, so a hit that cannot be re-verified is never served.
+- [x] Eviction removes **both the record and the build directory**. Evicting only the record leaves the poisoned tree in place under a name a later build can re-adopt — trust-by-name through the back door. (This is the sharper half of the fix and the reason a record-only eviction is not sufficient.)
+- [x] Also closed a mid-build leak: a failure between materialisation and completion left `dev_builds_dir()` populated, because cleanup was only reached on the success path.
+- [x] Keeps caching within the per-tenant/trust boundary (S2 — the dev build cache is already per-`MVM_HOME`); dm-verity roothash chain untouched (S4). Per S1 this gates *cache trust*, never workload admission.
+
+**Still open — the workload/builder kernel cache (`~/.mvm/cache/builder-vm/<arch>/kernels/<label>/vmlinux`):**
+
+- [ ] It remains path-trusting: `mvm_build::kernel_fetch::resolve_kernel` returns `Cached(path)` on `path.exists()`, and `resolve_pinned_kernel_with` maps that arm straight to a path with no check. Worse than the plan first assumed — `verify_fetched_kernel`, which hashes against `KernelArtifactId::artifact_hash` and deletes on mismatch, **has no production caller at all**: not on the fetch path, not on the read path, despite its own doc saying installed builds should verify against the pin before boot. Wiring it needs the published per-arch expected hash threaded to both sites (the release checksum manifest, as `download_dev_image` already does).
+- [ ] Cover the **identity-discrepancy** class here too: an intact kernel that is the *wrong* kernel is exactly the cache skew that mimics real bugs, and an existence check cannot see it.
+- [ ] Size the check to the object (recon §7.9). Full rehash on every hit is correct and bounded where a hit replaces a builder-VM boot, but the cold tier is unaddressed: a background scrub over the reachability walk is the only tier that catches the measured corruption locality, since on-access verification never visits the blocks that are quietly rotting.
 
 ### WS7 — σ/κ separation and the transform descriptor (recon §7.8)
 

--- a/specs/research/uor-hologram-cross-project-recon.md
+++ b/specs/research/uor-hologram-cross-project-recon.md
@@ -6,6 +6,7 @@
 **Source:** [UOR-Foundation](https://github.com/UOR-Foundation) and [Hologram-Technologies](https://github.com/Hologram-Technologies) GitHub orgs, deep-read at code level (43 repos surveyed, 24 read in depth)
 **Related:** [`uor-addr-integration-assessment.md`](./uor-addr-integration-assessment.md), [`uor-framework-integration-exploration.md`](./uor-framework-integration-exploration.md)
 **Updated:** 2026-07-31 — added §7.6 (data-plane provability at the vsock chokepoint, from a code-grounded read of the sealed-transcript ↔ audit-chain binding), §7.7 (identity & permissions in the packet — signed capability vs hashed claim), and a §9 note on a machine-checked Lean-4 reference spec as the third verifier.
+**Updated:** 2026-08-01 — a second, deeper pass (upstream crate source + primary literature, not just repo-level reads) **reverses finding 2** and adds four sections: §7.8 (σ/κ separation and the transform descriptor), §7.9 (verify-on-read as the founding definition, with the measured corruption rates behind it), §7.10 (deduplication scope as a side-channel decision), and §7.11 (reconciliation prerequisites among mutually distrusting peers). The original finding 2 — "mvm is ahead on every security-critical primitive" — was drawn from a survey that missed `kappa-registry`'s enforcement surface; see §7.1.
 
 ## TL;DR
 
@@ -19,15 +20,20 @@ Three findings reframe the collaboration question:
    conventional canonicalize-then-hash core. It buys nothing over `sha256 +
    serde_jcs`. Confirmed independently by four separate deep reads.
 
-2. **mvm is ahead on every security-critical primitive.** The entire ecosystem
-   trusts content-hash-only ("the name is the hash", verify-by-re-derivation).
-   There is **no per-bundle signing, no signed ExecutionPlan, no hash-linked
-   signed audit chain, and no temporal/nonce admission** anywhere in it — Ed25519
-   appears only in `hologram-network`'s wire layer and as unimplemented trait
-   seams. mvm's `key_id`-pinned signed bundles, validity-window/nonce plans, and
-   RFC-6962 Merkle audit chain are strictly stronger. Adopt their content-identity
-   and dedup ideas as a **complement layered under** mvm's authenticity, never as
-   a replacement for it.
+2. **Attestation coverage across the ecosystem is asymmetric, and integrity is
+   the shared gap.** *(Revised 2026-08-01 — this replaces "mvm is ahead on every
+   security-critical primitive", which the first pass got wrong.)* `kappa-registry`
+   does enforce authenticity, freshness and ordering: closed-constructor asserter
+   anchors held by a compile-fail test, hybrid-logical-clock watermarks giving
+   O(1) bulk invalidation before a timestamp, and an Ed25519-signed epoch chain
+   over a seven-leaf, domain-separated, backward-linked Merkle root with per-leaf
+   selective disclosure. What **no** surveyed system enforces is **integrity on
+   read**: `kappa-registry` verifies at four of thirteen write paths and at no read
+   path, and mvm's workload kernel and build cache are trusted-by-path for the same
+   reason. That is the one property a content address exists to supply, and it is
+   unenforced everywhere. mvm's `key_id`-pinned signed bundles, validity-window/nonce
+   plans and RFC-6962 Merkle audit chain remain strong and stay the authority layer —
+   but "mvm is ahead" was the wrong conclusion, and the gap is shared, not theirs.
 
 3. **The prior disposition holds and extends.** The two existing UOR research
    notes already concluded "conform to UOR-ADDR JSON, take no crate dependency,
@@ -238,22 +244,36 @@ Follow-up analysis on three questions: is content-addressable data useful for mv
 hash/attestation features; can a Hologram `holospace` run inside a microVM; and can
 content-addressing defend against attacks.
 
-### 7.1 Content-addressing supplies integrity — one of attestation's four properties
+### 7.1 Attestation needs four properties — and integrity is the one nobody enforces
 
-Attestation needs four properties; content-addressing supplies exactly one.
+*Revised 2026-08-01. The first pass recorded this table as "content-addressing
+supplies integrity; mvm already has the other three; the ecosystem stops at
+integrity." A deeper read of `kappa-registry` shows both halves of that were wrong:
+they have the other three too, and **neither side enforces integrity on read**.*
 
-| Property | Question | Mechanism | mvm status |
+| Property | Question | Mechanism | Coverage |
 | --- | --- | --- | --- |
-| Integrity | *what* are the bytes | content-address (the hash **is** the tamper check) | shipped everywhere |
-| Authenticity | *who* authorized them | Ed25519 `key_id` pinning | shipped |
-| Freshness | *when* / is it stale | validity window + nonce replay store | shipped |
-| Ordering | *in what sequence* | hash-linked signed audit chain + RFC-6962 Merkle | shipped |
+| **Integrity** | *what* are the bytes | content address, **recomputed and compared** | The property content-addressing exists to supply. `kappa-registry`: verified on 4 of 13 write paths, on **no** read path. mvm: trusted-by-path for the workload kernel and build cache. **The shared gap.** |
+| Authenticity | *who* authorized them | Ed25519 key pinning · closed-constructor anchors | Shipped in mvm. Shipped in `kappa-registry` — an asserter anchor has no public constructor and a compile-fail test holds the boundary. |
+| Freshness | *when* / is it stale | validity window · nonce replay store · watermarks | Shipped in mvm. Shipped in `kappa-registry` as O(1) bulk invalidation before a timestamp over a hybrid logical clock. |
+| Ordering | *in what sequence* | hash-linked signed chain · Merkle root | Shipped in mvm. Shipped in `kappa-registry` as a seven-leaf domain-separated Ed25519-signed epoch root, backward-linked, with per-leaf selective disclosure. |
 
-The whole UOR/Hologram ecosystem stops at **integrity** (content-hash-only,
-verify-by-re-derivation). mvm already layers the other three on top, so
-content-addressing does not *complete* mvm's attestation — mvm completed it already.
-UOR's additive value is narrow: semantic identity (already realized in
-`SemanticAddress`), canonicalization rigor (§6 U4/U5), and coverage breadth (§7.2).
+**`kappa-registry` maturity, corrected.** Eleven crates, 30,742 lines, store format
+v5. It passes 1032/1032 OCI distribution-spec v1.1 conformance and 187/187 kappa
+conformance across five levels with zero warnings. It ships encryption at rest
+across blob content, storage paths and every index table; Veilid-transported
+federation with Merkle-search-tree reconciliation; auditable key-directory absence
+proofs; and the signed epoch chain above. The earlier "real, single-node, auth-stub"
+characterisation understated it materially. It is not a prototype — it is a
+conformant substrate that does not yet enforce the property its addressing scheme
+implies.
+
+**The asymmetry, stated directly.** Authenticity, freshness and ordering are well
+covered on both sides. Integrity — the property a content address is supposed to
+deliver for free — is the one no surveyed system enforces on read. *A signed chain
+over addresses that were never checked attests to pointers, not to content.* That
+reframes §7.2 from "a coverage gain" to "the one unenforced property", and it is why
+verify-on-read is now the lead item rather than the tail.
 
 ### 7.2 The coverage gap: content-address the kernel + cache, verify on read
 
@@ -467,17 +487,175 @@ new work is the §7.6 sealed-transcript-root audit binding plus completion of Pl
 post-restore grant delivery. A general attenuatable capability remains deferred until an actual
 delegation requirement appears.
 
+### 7.8 σ/κ separation and the transform descriptor
+
+*Added 2026-08-01. New material; ranked as an **adopt** alongside the methodology
+upgrade.*
+
+Every transform applied at rest separates the digest a protocol names content by
+from the digest of the bytes actually stored. This is the general case, not an
+encryption special case, and the precedents are unanimous: git object IDs have never
+hashed the bytes on disk in any implementation (loose objects are deflated, packed
+objects are delta-encoded against a base); ZFS compresses and encrypts beneath a
+checksum carried in the parent block pointer; deduplicating backup systems address
+chunks while files are manifests; columnar table formats address manifests which
+address encoded files.
+
+- **σ** is the protocol digest, computed over plaintext — the ETag, the content-digest
+  header, the object identifier.
+- **κ** is the storage address, computed over the bytes at rest — it derives the path,
+  it is the verification target, and it is the unit of federated transfer.
+
+Under the identity transform the two are numerically equal and remain **distinct
+quantities**. The type separation is what stops the property regressing silently.
+
+Two consequences:
+
+1. **σ is a set.** One storage address is reachable by two or more protocol digests.
+   That is exactly what a dual-hash transition requires and what multi-axis
+   registration provides — and it is the real answer to the SHA-256-vs-BLAKE3
+   question in §8, which "pin one axis" would foreclose.
+2. **The descriptor is an open enumeration, not a boolean.**
+
+   ```
+   framing  : Whole | Fixed{frame_size} | Chunked{manifest}
+   per_frame: [ Identity | Aead | Deflate | Delta{base} | Erasure{k,m} ]
+   seek_map : Implicit | Explicit{cumulative} | None
+   ```
+
+   Framing is the outer layer and transforms apply per frame. That is what makes
+   ranged reads into transformed content possible: whole-object sealing means a
+   ten-byte range request against a ten-gigabyte object must process the whole
+   object, which removes the operation rather than slowing it.
+
+**Why now, while mvm is still all-identity-transform.** Modelling this as a single
+label — or as an optional "encrypted" flag — costs one format migration per transform
+family, forever. Modelling the axis once, while every transform in the tree is still
+`Identity`, costs a newtype pair and no migration.
+
+### 7.9 Verify-on-read is the founding definition, not an enhancement
+
+*Added 2026-08-01.*
+
+The archival system that established content-addressing as a systems primitive
+specified that **on retrieval, both client and server compute the fingerprint and
+compare it to the one requested**. The claim content-addressing makes is not "the
+name is a hash"; it is "a block cannot be modified without changing its address" —
+and that claim is cashable only if something recomputes. §7.1's finding is that
+nobody does.
+
+The corruption rate is measured, not hypothetical. A field study of 1.53 million
+drives over 41 months recorded more than 400,000 checksum mismatches. Nearline drives
+develop them an order of magnitude more often than enterprise drives. Mismatches
+within a disk are **not independent** — they show high spatial and temporal locality —
+and mismatches across disks in the same system are not independent either. A
+follow-on study found 8% were discovered during RAID reconstruction, i.e. correlated
+with the moment redundancy is already degraded.
+
+The second corruption class in that taxonomy is the one that matters most here:
+**identity discrepancies** — an intact block that is the *wrong* block. Content-addressing
+detects it for free; a path-trusting store cannot see it at all. This is precisely the
+workload-kernel cache-skew class that currently mimics real bugs in mvm.
+
+Practical form, by object size:
+
+- **Small objects** — rehash before responding.
+- **Streamed objects** — carry a running hash across frames, deliver the verdict in a
+  trailer.
+- **Cold objects** — background scrub over the reachability walk. This is the only tier
+  that catches the locality pattern above; on-access verification never visits the
+  blocks that are quietly rotting.
+
+### 7.10 Deduplication scope is a side-channel decision, and the conformant answer is free
+
+*Added 2026-08-01. Sharpens the cross-tenant dedup rule already stated in §7.4.*
+
+Cross-user deduplication with a truthful existence response **is** an oracle: one bit
+per probe, and a target drawn from an enumerable set is recoverable in proportion to
+its entropy. The foundational study concluded cross-user dedup should be disabled by
+default, and that public storage should provide unlinkability of users and data even
+when data is encrypted before upload.
+
+Two facts make the fix cheap in registry terms:
+
+- The distribution specification once required a cross-repository mount to name a
+  source the client has read access to — an authorizable check. **Version 1.1 made
+  that source optional**, so a mount may be attempted with no source to authorize
+  against.
+- The same specification states a registry unable or unwilling to mount should return
+  202 and begin the upload session, and that a push with or without an attempted mount
+  takes **the same number of API requests**.
+
+**Consequence: declining a cross-namespace mount is fully conformant.** Same request
+count, same client code path, no error a client does not already handle.
+Namespace-scoped dedup by default — with cross-namespace mounts honoured only where
+the caller is authorized on the source — costs bandwidth, not correctness, and is
+stronger than any probabilistic scheme because nothing has to be misreported.
+
+Under per-namespace key derivation the property is stronger still: identical plaintext
+yields different ciphertext, a different address and a different path, so the
+cross-tenant oracle **cannot form arithmetically** rather than being prevented by
+policy.
+
+No CVE, advisory or published threat model was located for cross-tenant
+blob-existence side channels in container registries. The attack has been in the
+literature since 2010 and appears unexamined in this industry as a named class.
+
+### 7.11 Reconciliation prerequisites among mutually distrusting peers
+
+*Added 2026-08-01. Gates the §8 "distributed content-addressed transport" item.*
+
+Range-based set reconciliation and Merkle-search-tree page diffing remain the right
+references, with two prerequisites that must be settled **before** either is used
+among peers that do not trust each other.
+
+- **The fingerprint must be multiset-homomorphic.** Where it is not — an XOR
+  aggregation being the common case — a peer withholds arbitrary data by claiming
+  absence. This requires no collision-finding and is invisible to functional testing,
+  because reconciliation converges cleanly with data missing. All commonly cited
+  candidates except non-commutative Cayley hashes are usable.
+- **A search-tree root is not necessarily a cryptographic commitment.** The widely used
+  MST implementation derives page and root digests from a non-cryptographic 128-bit
+  hash under a fixed key, independent of the user-supplied hasher — which governs key
+  and value digests only. That is appropriate for detecting accidental divergence and
+  inadequate for a signed root. **A reconciliation root and an attested root are
+  different structures with different requirements**; do not sign the former.
+
+### 7.12 The nine axes, and where content-addressing breaks
+
+*Added 2026-08-01.*
+
+Across roughly three hundred systems surveyed — block, file, object, content-addressed,
+package distribution, backup, table format, log, key-value, vector, graph and
+domain-specific families — nine axes cover the design space: naming, mutability,
+granularity, access, verification, consistency, transport, topology, and **transform**.
+
+**Transform (D9) is the axis that silently invalidates naive content-addressing**, is
+present in every mature storage system, and is what motivates §7.8. Nine patterns
+recur across every family — name/content separation, Merkle structure over content,
+transform at rest with an identity case, chunk-and-reassemble, append-only log with a
+signed or ordered root, anti-entropy reconciliation, tiering and lifecycle,
+multi-tenancy with isolation, attestation with provenance. Every surveyed system is a
+combination of these; none introduces a tenth.
+
 ## 8. Interop hazards and alignment points
 
 Concrete cross-project mechanics that decide whether mvm and the UOR/Hologram
 addresses can ever line up:
 
-- **Hash-axis fragmentation — decide before any κ interop.** mvm standardizes on
-  SHA-256; `uor-addr` defaults SHA-256 but `uor-r4`/`hologram` mint on the BLAKE3
-  axis. A κ-label is `<axis>:<hex>`, so the *same bytes* get *different addresses* on
-  different axes — mixing axes across a fleet fragments identity. Interop must pin one
-  axis (SHA-256 keeps mvm unchanged; BLAKE3 buys speed + agility but re-addresses
-  everything).
+- **Hash-axis handling — a σ set, not a pinned axis.** *(Revised 2026-08-01.)* mvm
+  standardizes on SHA-256; `uor-addr` defaults SHA-256 but `uor-r4`/`hologram` mint on
+  the BLAKE3 axis. A κ-label is `<axis>:<hex>`, so the *same bytes* get *different
+  addresses* on different axes. The first pass concluded "interop must pin one axis";
+  §7.8 supersedes that. The resolution is a **σ set** — one storage address reachable
+  by more than one protocol digest. Pinning a single axis would foreclose exactly the
+  dual-hash transition and multi-axis registration that make the fragmentation
+  survivable.
+- **Transform agreement — settle it before either side ships a non-identity transform.**
+  Addresses stop meaning the same thing across projects the moment either side
+  compresses, encrypts, deltas or erasure-codes at rest (§7.8). Agreeing the descriptor
+  while everything is still `Identity` is free; agreeing it afterwards is a format
+  migration on both sides.
 - **Canonical wire-form divergence.** Three address strings are in play: mvm's
   `sha256:<hex>`, UOR-Foundation's kappa `<axis>:<hex>`, and `uor:sha256:<hex>`
   (uor-registry). mvm's `sha256:<hex>` equals the kappa SHA-256 form byte-for-byte;
@@ -569,10 +747,10 @@ should we consider this" is: Phase 1 now, the rest when its trigger fires.
 
 | Phase | Timing | Work | Gate / trigger |
 | --- | --- | --- | --- |
-| **0 — Decide & scope** | Now (days) | Adopt "conform, don't consume" as explicit policy; pin SHA-256 as the canonical axis; turn §6 U1–U5 + §7.5 defensive coverage into a `specs/plans/` doc. | None. |
-| **1 — Methodology + defensive coverage** | Next 1–2 sprints | U1 tiers · U4 replay-vector lane · U2 prose over-claim gate · U3 falsifiability table · U5 ≥2-verifier oracle bar; content-address kernel + build cache with verify-on-read; anchor the sealed data-plane transcript root into the audit chain (§7.6). All in-house, no dependency. | Phase 0 plan approved. |
-| **2 — Interop alignment** | Mid-term, triggered | Agree axis + wire-form + in-toto/SLSA canonicalization with the sibling projects; read `uor-foundation` (the real κ engine); evaluate `uor-addr-1` (lighter crate). | A real second consumer of the addresses **and** a UOR/Hologram-side conversation. |
-| **3 — Runtime / fleet / AI** | Long-term, opportunistic | holospace object model (migrate-by-κ-closure) into mvmd; content-addressed inter-VM routing (mvmd only — no east-west path in mvm, §7.6); evaluate an established attenuatable-capability format only if offline/multi-hop delegation becomes a concrete requirement (§7.7); `hologram-ai` interop for the deferred `ai` command; distributed transport (RBSR / iroh-blobs). | A concrete mvmd migration/scale requirement, a concrete offline/multi-hop delegation requirement, or the `ai` command leaving deferred status. |
+| **0 — Decide & scope** | Now (days) | Adopt "conform, don't consume" as explicit policy; establish the **σ-set contract** for addresses (§7.8 — *not* "pin one axis", which the first pass proposed); turn §6 U1–U5 + §7.5 defensive coverage into a `specs/plans/` doc. | None. |
+| **1 — Methodology + defensive coverage** | Next 1–2 sprints | Content-address the workload kernel + build cache with **verification on read as well as on write** (§7.9 — now the lead item, per the revised §7.1); U4 replay-vector lane (recording σ **and** κ wherever a transform is in play); U1 tiers · U2 prose over-claim gate · U3 falsifiability table · U5 ≥2-verifier oracle bar. All in-house, no dependency. *(The §7.6 sealed-transcript root anchoring listed here originally shipped separately — see plan 280.)* | Phase 0 plan approved. |
+| **2 — Interop alignment** | Mid-term, triggered | Agree the **σ-set contract, canonical wire form and transform descriptor** with the sibling projects **before either side ships a non-identity transform** (§7.8); agree in-toto/SLSA canonicalization; read `uor-foundation` (the real κ engine); evaluate `uor-addr-1` (lighter crate). | A real second consumer of the addresses **and** a UOR/Hologram-side conversation. |
+| **3 — Runtime / fleet / AI** | Long-term, opportunistic | holospace object model (migrate-by-κ-closure) into mvmd; content-addressed inter-VM routing (mvmd only — no east-west path in mvm, §7.6); evaluate an established attenuatable-capability format only if offline/multi-hop delegation becomes a concrete requirement (§7.7); `hologram-ai` interop for the deferred `ai` command; distributed transport (RBSR / iroh-blobs) **with §7.11's multiset-homomorphic-fingerprint and attested-root prerequisites settled first**. | A concrete mvmd migration/scale requirement, a concrete offline/multi-hop delegation requirement, or the `ai` command leaving deferred status. |
 
 **Bottom line:** consider **Phase 1 now** — it is the highest-ROI, lowest-risk, fully
 in-house work, and it doubles as security hardening (the two defensive pursuits). Hold
@@ -591,6 +769,15 @@ Phases 2–3 until their trigger appears; revisit this doc when it does.
   shared address reveals two tenants hold identical content, and an address
   fingerprints known content (a cross-tenant confirmation oracle). Dedup within a
   boundary; never across it.
+- **Never derive an address from a non-collision-resistant digest.** MD5, CRC32C
+  and CRC64 are required as *attestations* and disqualified as *addresses*. Enforce
+  with disjoint types and a compile-fail test, not with review.
+- **Never sign state that cannot be substantiated.** The order is content → index →
+  root → signature → publication. A crash before signing is recoverable; the reverse
+  order forks the chain and has no recovery path.
+- **Never sign a reconciliation root.** An MST page/root digest from a
+  non-cryptographic hash detects accidental divergence and is not a commitment
+  (§7.11).
 - **Licensing gap:** `uor-vv`/`uor-conformance`/`uor-nanda`/`arch-map` ship no
   LICENSE. Even as sibling projects, reusable text/scripts need a license before
   verbatim reuse.


### PR DESCRIPTION
Two commits. The first reconciles plan 276 with `main`; the second folds in the 2026-08-01 recon revision, which reverses the finding the plan was built on. Docs-only.

## 1 — Reconcile with main

**The ledger path does not exist.** The plan targets `specs/claims/catalog.md` in its Tech Stack and in four workstreams. There is no such file. The ledger is the `<!-- claims-catalog:begin -->` table inside `specs/adrs/001-microvm-security-posture.md` (walked by `xtask/src/claims_ledger.rs`) plus the `model/claims.toml` ID register.

**WS2 already shipped** as `xtask check-no-overclaim`, and broader than WS2 specified: a `phrase → (claim, status, exempt_paths)` index built from claim frontmatter in `specs/adrs/**/*.md`, refusing gated phrases across `.md` **and** `.rs`, rather than matching a curated verb list.

**WS1 shrinks and gains a security rationale.** Both tier vocabularies already exist and nothing checks them against each other — `model/claims.toml` carries `level = some-true | build | open` (the `template/model/ids.toml` pattern U1 named as its source), and ADR claim frontmatter carries `status = Planned | Preview | Shipped | Not-claimed`. A claim reading `open` in the register while its frontmatter says `Shipped` would silently disengage `check-no-overclaim`. That is now **S6**.

**WS5 shrinks** — `check-mutation-witnesses`, `check-claim-witness-freshness` and 36 `VERIFICATION.md` rows exist; only the witness → red-proof binding is missing.

**Recon §7.6 and §7.7 are discharged, not scheduled** — §7.6 shipped as plan 280 (#2017), §7.7's post-restore child grant as #2019. Both were added to the recon after this plan's first draft.

## 2 — The premise reversed

The plan rested on recon finding 2 as first written: *"mvm is ahead on every security-critical primitive; the ecosystem stops at integrity."* A second recon pass — upstream crate source and primary literature rather than repo-level reads — overturns both halves.

`kappa-registry` **does** enforce authenticity, freshness and ordering: closed-constructor asserter anchors held by a compile-fail test, hybrid-logical-clock watermarks giving O(1) bulk invalidation before a timestamp, and an Ed25519-signed seven-leaf domain-separated backward-linked epoch root with per-leaf selective disclosure. Eleven crates, 30,742 lines, store format v5, 1032/1032 OCI distribution-spec v1.1 conformance — not the single-node auth-stub the first pass recorded.

What **no** surveyed system enforces is **integrity on read**. `kappa-registry` verifies at four of thirteen write paths and no read path; our workload kernel and build cache are trusted-by-path. Verification on retrieval is the founding definition of content addressing rather than an enhancement — a signed chain over addresses nobody checked attests to pointers, not content.

### What that changes

**WS6 moves from tail to lead**, and gains the shape the evidence implies: verify on read *as well as* on write; sized to the object (rehash small artifacts, running hash with a trailer for streams, background scrub over the reachability walk for cold ones, since on-access verification never visits the blocks that are quietly rotting); and covering **identity discrepancies** — an intact artifact that is the wrong artifact — which is exactly the workload-kernel cache skew that currently mimics real bugs. Backed by the measured rate: 1.53M drives over 41 months, >400,000 checksum mismatches, not independent within a disk, 8% found during RAID reconstruction.

**WS0's axis line inverts.** "Pin SHA-256 as the canonical axis" forecloses the dual-hash transition and is superseded by the **σ-set contract** — one storage address reachable by more than one protocol digest. SHA-256 remains what mvm mints on. The `No BLAKE3 re-axis` non-goal is reworded accordingly.

**WS7 is new — σ/κ separation and the transform descriptor.** σ is the protocol digest over plaintext; κ is the storage address over the bytes at rest. Disjoint types, no conversion. The descriptor is an open enumeration (`framing` × `per_frame` × `seek_map`), not an "encrypted" boolean. Every mvm surface is `Identity` today, so this is a type separation with no migration; after the first non-identity transform it is one format migration per transform family. Precedent is unanimous — git object IDs have never hashed the bytes on disk, ZFS compresses and encrypts beneath a checksum in the parent block pointer.

**Three new guardrails / security considerations:** never derive an address from a non-collision-resistant digest (MD5, CRC32C, CRC64 are attestations, disqualified as addresses — enforce with disjoint types and a compile-fail test); never sign state that cannot be substantiated (content → index → root → signature → publication); never sign a reconciliation root, and require a multiset-homomorphic fingerprint before RBSR among mutually distrusting peers — an XOR aggregation lets a peer withhold data by claiming absence, invisibly to functional testing.

**S2 sharpens.** Cross-tenant dedup is an oracle, not merely a leak. Refusing a cross-namespace mount is fully conformant under the distribution spec (v1.1 made the mount source optional; an unwilling registry returns 202, same request count), so the safe default costs bandwidth rather than correctness — and under per-namespace key derivation the oracle cannot form arithmetically.

The recon note carries the reversal plus four new sections: §7.8 σ/κ, §7.9 verify-on-read and the corruption evidence, §7.10 deduplication scope, §7.11 reconciliation prerequisites, §7.12 the nine axes.

## Gates

`check-no-overclaim`, `check-doc-claims`, `check-honesty`, `check-claim-catalog`, `check-deferrals`, `check-adr-coverage` — all clean.