### PR TITLE
fix(guest-agent): stop PID-1 reaping from destroying workload exit codes

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/health.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/health.rs
@@ -35,17 +35,18 @@ pub(crate) fn run_shell_with_timeout(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
+    let _owned = mvm_agentd::child_wait::OwnedChild::new(child.id());
 
     // Poll until the child exits or the timeout fires.
     let start = Instant::now();
     let status = loop {
-        match child.try_wait()? {
+        match mvm_agentd::child_wait::try_wait(&mut child)? {
             Some(status) => break status,
             None if start.elapsed() >= timeout => {
                 if let Err(e) = child.kill() {
                     eprintln!("failed to kill child process: {e}");
                 }
-                if let Err(e) = child.wait() {
+                if let Err(e) = mvm_agentd::child_wait::wait(&mut child) {
                     eprintln!("failed to wait child process: {e}");
                 }
                 return Ok(std::process::Output {

--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
@@ -4,8 +4,11 @@
 //! this harness before entering the normal vsock control plane:
 //!
 //!   1. Mount `/proc`, `/sys`, and `/dev`.
-//!   2. Install a SIGCHLD handler so orphaned descendants become zombies
-//!      that PID 1 reaps immediately.
+//!   2. Start the orphan reaper so descendants re-parented to PID 1 are
+//!      collected instead of accumulating as zombies. It is a thread, not
+//!      a SIGCHLD handler, so it can publish the statuses of children the
+//!      agent owns rather than destroying them — see
+//!      [`mvm_agentd::child_wait`].
 //!   3. Hand control back to `main`; the normal vsock accept loop serves
 //!      `ActivateEnvironment` as the only allowed verb.
 //!   4. `apply_activation` mounts the rootfs, runtime overlay, and volumes,
@@ -13,9 +16,6 @@
 //!
 //! Linux-only.  On non-Linux targets the functions are no-ops so the
 //! workspace still compiles on macOS.
-
-#[cfg(target_os = "linux")]
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use mvm_agentd::guest_mount;
 use mvm_agentd::vsock::ActivateEnvironment;
@@ -47,7 +47,7 @@ pub(crate) fn early_setup() {
             // /sys, and /dev for the namespace and drops CAP_SYS_ADMIN, so
             // the initramfs early mounts would fail with EPERM. The agent
             // is still PID 1 of the container's PID namespace, so the
-            // SIGCHLD reaper is still required.
+            // orphan reaper is still required.
             eprintln!(
                 "mvm-guest-agent: unix transport — container runtime provides early filesystems"
             );
@@ -55,7 +55,7 @@ pub(crate) fn early_setup() {
             fatal(&format!("early filesystem mount failed: {e}"));
         }
         provision_host_signer_anchor();
-        install_sigchld_handler();
+        mvm_agentd::child_wait::install_orphan_reaper();
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -130,54 +130,4 @@ fn fatal(message: &str) -> ! {
     );
     std::thread::sleep(std::time::Duration::from_millis(200));
     std::process::exit(1);
-}
-
-// ============================================================================
-// SIGCHLD handling (Linux only)
-// ============================================================================
-
-#[cfg(target_os = "linux")]
-static SIGCHLD_INSTALLED: AtomicBool = AtomicBool::new(false);
-
-#[cfg(target_os = "linux")]
-fn install_sigchld_handler() {
-    if SIGCHLD_INSTALLED
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .is_err()
-    {
-        return;
-    }
-
-    // SAFETY: `on_sigchld` is async-signal-safe: it only calls `waitpid`
-    // in a loop with `WNOHANG` and writes to `STDERR_FILENO` on failure.
-    // The handler is installed once from the main thread before any child
-    // processes exist.
-    unsafe {
-        let mut action: libc::sigaction = std::mem::zeroed();
-        action.sa_sigaction = on_sigchld as *const () as usize;
-        action.sa_flags = libc::SA_NOCLDSTOP | libc::SA_RESTART;
-        let rc = libc::sigaction(libc::SIGCHLD, &action, std::ptr::null_mut());
-        if rc != 0 {
-            fatal(&format!(
-                "sigaction(SIGCHLD) failed: {}",
-                std::io::Error::last_os_error()
-            ));
-        }
-    }
-}
-
-/// SIGCHLD handler.  Reap any zombie children without blocking.  The
-/// loop is required because multiple children may exit while the signal
-/// is masked and Linux collapses concurrent SIGCHLD deliveries.
-#[cfg(target_os = "linux")]
-unsafe extern "C" fn on_sigchld(_sig: libc::c_int) {
-    loop {
-        let mut status = 0;
-        // SAFETY: `waitpid(-1, WNOHANG)` is async-signal-safe and does not
-        // block.  The status pointer is owned on this signal-handler stack.
-        let pid = unsafe { libc::waitpid(-1, &mut status, libc::WNOHANG) };
-        if pid <= 0 {
-            break;
-        }
-    }
 }

--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/interactive.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/interactive.rs
@@ -165,6 +165,7 @@ fn do_run_detached_with(
         }
     };
     let pid = child.id() as i32;
+    let owned = mvm_agentd::child_wait::OwnedChild::new(child.id());
 
     // Reaper: wait for the detached workload, then report its exit code
     // to the host so the VM powers off (best-effort). Never touches the
@@ -172,7 +173,8 @@ fn do_run_detached_with(
     let exit_report_bin = exit_report_bin.to_path_buf();
     std::thread::spawn(move || {
         let mut child = child;
-        let code = match child.wait() {
+        let _owned = owned;
+        let code = match mvm_agentd::child_wait::wait(&mut child) {
             Ok(status) => status.code().unwrap_or(-1),
             Err(_) => -1,
         };

--- a/crates/mvm-agentd/src/child_wait.rs
+++ b/crates/mvm-agentd/src/child_wait.rs
@@ -1,0 +1,420 @@
+//! One waiter for every child process in the guest.
+//!
+//! When the agent is PID 1 it must reap orphans re-parented to it, or the
+//! guest accumulates zombies. But `waitpid(-1, …)` reaps *any* child,
+//! including one that some other part of the agent spawned and is polling
+//! with [`std::process::Child::try_wait`]. Whichever waiter gets there
+//! first consumes the status; the loser sees `ECHILD` and has no way to
+//! learn what the process actually did.
+//!
+//! That is not hypothetical. With a `SIGCHLD` handler reaping in the
+//! background, `stream_exec` lost every workload exit status: a command
+//! that exited 0, one that exited 3, and one that exited 7 all surfaced
+//! as `-1`, and the host reported 255 for all three. Unit tests could not
+//! see it, because a test process is never PID 1 and so never installed
+//! the reaper.
+//!
+//! So there is exactly one waiter here, and it publishes.
+//!
+//! - Code that spawns a child registers it with [`OwnedChild`], an RAII
+//!   token that deregisters on drop.
+//! - [`install_orphan_reaper`] starts a polling thread. It reaps
+//!   everything, records the status of *registered* pids in a table, and
+//!   discards the rest — those are the orphans it exists to clean up.
+//! - Owners call [`try_wait`] / [`wait`] instead of the inherent `Child`
+//!   methods. Those consult the table when the kernel says `ECHILD`.
+//!
+//! The reaper's `waitpid` + publish, and an owner's `try_wait` + lookup,
+//! each run under the same mutex. So an owner either wins the race and
+//! reads the status from the kernel, or loses it and finds the status
+//! already in the table — there is no interleaving where the status is
+//! observable by neither, and therefore no retry loop. The lock is held
+//! only across non-blocking calls, so a long-lived child never blocks
+//! orphan reaping.
+//!
+//! Everything degrades to the plain `Child` methods when no reaper is
+//! installed, which is every unit test and every non-PID-1 process.
+
+use std::collections::{HashMap, HashSet};
+use std::io;
+use std::process::{Child, ExitStatus};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+/// How often the orphan reaper sweeps. Zombie orphans are harmless while
+/// they wait — they hold a pid table slot and nothing else — so this
+/// trades a little latency for not needing an async-signal-safe handler.
+const REAP_INTERVAL: Duration = Duration::from_millis(200);
+
+/// First poll gap for [`wait`] once a reaper is running and the kernel may
+/// not be the one to hand us the status. Short so a quick command returns
+/// promptly.
+const WAIT_POLL_MIN: Duration = Duration::from_millis(1);
+
+/// Ceiling the [`wait`] poll gap backs off to. A workload can run for
+/// hours; polling it at the initial cadence the whole time would burn a
+/// core for nothing.
+const WAIT_POLL_MAX: Duration = Duration::from_millis(50);
+
+/// Set once [`install_orphan_reaper`] has started the sweeper. Until then
+/// every entry point here delegates straight to the inherent `Child`
+/// methods, so nothing changes for a process that is not PID 1.
+static REAPER_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// Pids some part of the agent owns and intends to wait on, plus the exit
+/// statuses the reaper collected on their behalf.
+///
+/// One mutex covers both so that "is this pid owned?" and "record its
+/// status" are a single atomic step against an owner's own wait.
+#[derive(Default)]
+struct Registry {
+    owned: HashSet<i32>,
+    reaped: HashMap<i32, i32>,
+}
+
+fn registry() -> &'static Mutex<Registry> {
+    static REGISTRY: OnceLock<Mutex<Registry>> = OnceLock::new();
+    REGISTRY.get_or_init(Mutex::default)
+}
+
+/// Registration token for a child this process spawned and will wait on.
+///
+/// Hold it from just after spawn until the last [`try_wait`] / [`wait`]
+/// call for that child. While it is alive the reaper records the child's
+/// status instead of discarding it; on drop the pid and any unread status
+/// are forgotten, so the table cannot grow without bound.
+pub struct OwnedChild {
+    pid: i32,
+}
+
+impl OwnedChild {
+    /// Register `pid` as owned. Cheap and safe to call when no reaper is
+    /// running — the registry simply goes unread.
+    pub fn new(pid: u32) -> Self {
+        let pid = pid as i32;
+        register_in(registry(), pid);
+        Self { pid }
+    }
+}
+
+impl Drop for OwnedChild {
+    fn drop(&mut self) {
+        deregister_in(registry(), self.pid);
+    }
+}
+
+/// Non-blocking wait, safe against a concurrently running orphan reaper.
+///
+/// Same contract as [`Child::try_wait`]: `Ok(None)` means still running.
+/// The difference is that a status already collected by the reaper is
+/// returned here rather than lost to `ECHILD`.
+pub fn try_wait(child: &mut Child) -> io::Result<Option<ExitStatus>> {
+    if !REAPER_RUNNING.load(Ordering::Acquire) {
+        return child.try_wait();
+    }
+    try_wait_in(registry(), child)
+}
+
+/// Blocking wait, safe against a concurrently running orphan reaper.
+///
+/// With a reaper installed this polls [`try_wait`] rather than blocking in
+/// the kernel, because the reaper may be the one that actually collects
+/// the status. Without a reaper it is a straight [`Child::wait`].
+pub fn wait(child: &mut Child) -> io::Result<ExitStatus> {
+    if !REAPER_RUNNING.load(Ordering::Acquire) {
+        return child.wait();
+    }
+    let mut gap = WAIT_POLL_MIN;
+    loop {
+        match try_wait_in(registry(), child)? {
+            Some(status) => return Ok(status),
+            None => {
+                std::thread::sleep(gap);
+                gap = (gap * 2).min(WAIT_POLL_MAX);
+            }
+        }
+    }
+}
+
+/// Start the orphan reaper. Call once, from PID 1, before anything spawns
+/// a child.
+///
+/// Replaces the `SIGCHLD` handler this agent used to install: a handler
+/// must be async-signal-safe, so it could not take a lock, so it could not
+/// publish what it reaped — which is precisely how it destroyed owned
+/// children's exit statuses. A plain thread can lock, so it can publish.
+pub fn install_orphan_reaper() {
+    if REAPER_RUNNING.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    std::thread::Builder::new()
+        .name("mvm-orphan-reaper".to_string())
+        .spawn(|| {
+            loop {
+                reap_in(registry(), waitpid_any);
+                std::thread::sleep(REAP_INTERVAL);
+            }
+        })
+        .expect("spawn orphan reaper thread");
+}
+
+// ---------------------------------------------------------------------------
+// Registry operations, parameterised over the registry and the reap syscall
+// so they can be exercised without touching process-global state or the real
+// `waitpid(-1)` — which in a threaded test binary would steal other tests'
+// children.
+// ---------------------------------------------------------------------------
+
+fn register_in(reg: &Mutex<Registry>, pid: i32) {
+    if let Ok(mut reg) = reg.lock() {
+        reg.owned.insert(pid);
+    }
+}
+
+fn deregister_in(reg: &Mutex<Registry>, pid: i32) {
+    if let Ok(mut reg) = reg.lock() {
+        reg.owned.remove(&pid);
+        reg.reaped.remove(&pid);
+    }
+}
+
+fn try_wait_in(reg: &Mutex<Registry>, child: &mut Child) -> io::Result<Option<ExitStatus>> {
+    let pid = child.id() as i32;
+    let Ok(mut reg) = reg.lock() else {
+        return child.try_wait();
+    };
+    // A status the reaper already collected settles it — the kernel has
+    // nothing left to tell us about this pid.
+    if let Some(raw) = reg.reaped.remove(&pid) {
+        return Ok(Some(exit_status_from_raw(raw)));
+    }
+    match child.try_wait() {
+        Err(e) if e.raw_os_error() == Some(libc::ECHILD) => {
+            // The reaper cannot have published between the lookup above and
+            // here — it takes this same lock to publish. So ECHILD means the
+            // status was consumed by something that never recorded it, and
+            // there is genuinely nothing left to report.
+            Ok(reg.reaped.remove(&pid).map(exit_status_from_raw))
+        }
+        other => other,
+    }
+}
+
+/// Drain every exited child through `waitpid`, recording the ones an
+/// [`OwnedChild`] claims and discarding the rest.
+///
+/// `waitpid` writes the raw status through its out-param and returns the
+/// reaped pid, `0` when children exist but none have exited, or a negative
+/// value when there are none at all — i.e. `waitpid(-1, …, WNOHANG)`.
+fn reap_in(reg: &Mutex<Registry>, mut waitpid: impl FnMut(&mut i32) -> i32) {
+    let Ok(mut reg) = reg.lock() else {
+        return;
+    };
+    loop {
+        let mut raw = 0;
+        let pid = waitpid(&mut raw);
+        if pid <= 0 {
+            return;
+        }
+        if reg.owned.contains(&pid) {
+            reg.reaped.insert(pid, raw);
+        }
+    }
+}
+
+fn waitpid_any(raw: &mut i32) -> i32 {
+    // SAFETY: `waitpid` writes only through `raw`, a live caller-owned
+    // `i32`. `WNOHANG` means it never blocks, so the registry lock the
+    // caller holds is held for a bounded, non-blocking span.
+    unsafe { libc::waitpid(-1, raw, libc::WNOHANG) }
+}
+
+fn exit_status_from_raw(raw: i32) -> ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    ExitStatus::from_raw(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+
+    /// A private registry per test. The process-global one is deliberately
+    /// untouched here: these tests run as threads under `cargo test`, and
+    /// mutating shared reaper state would make them race each other.
+    fn fresh_registry() -> Mutex<Registry> {
+        Mutex::default()
+    }
+
+    fn spawn_exiting_with(code: i32) -> Child {
+        Command::new("/bin/sh")
+            .arg("-c")
+            .arg(format!("exit {code}"))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn")
+    }
+
+    /// Play the sweeper against one specific pid until it collects the
+    /// status, so the test never touches `waitpid(-1)` — which in this
+    /// threaded test binary would steal other tests' children.
+    ///
+    /// A zombie is still a live pid as far as `kill(pid, 0)` is concerned,
+    /// so polling for the process to "disappear" would hang forever; the
+    /// reap itself is the only thing that reports exit.
+    fn reap_until_collected(reg: &Mutex<Registry>, pid: i32) {
+        for _ in 0..500 {
+            reap_in(reg, |raw| {
+                // SAFETY: writes only through `raw`; targeted at our own child.
+                unsafe { libc::waitpid(pid, raw, libc::WNOHANG) }
+            });
+            if reg.lock().unwrap().reaped.contains_key(&pid) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("child {pid} was never collected");
+    }
+
+    #[test]
+    fn the_global_entry_points_are_plain_child_waits_until_a_reaper_runs() {
+        assert!(
+            !REAPER_RUNNING.load(Ordering::Acquire),
+            "a unit test is never PID 1, so it must never install the reaper"
+        );
+        let mut child = spawn_exiting_with(3);
+        assert_eq!(wait(&mut child).expect("wait").code(), Some(3));
+    }
+
+    #[test]
+    fn an_owner_recovers_the_exit_code_the_reaper_collected() {
+        // The exact loss this module exists to prevent, against the real
+        // kernel: the reaper gets to the child first, so the owner's
+        // `try_wait` sees ECHILD — and must still report the true code.
+        let reg = fresh_registry();
+        let mut child = spawn_exiting_with(7);
+        let pid = child.id() as i32;
+        register_in(&reg, pid);
+        reap_until_collected(&reg, pid);
+
+        assert!(
+            child.try_wait().is_err(),
+            "precondition: the kernel must now answer ECHILD for this pid"
+        );
+        let status = try_wait_in(&reg, &mut child).expect("try_wait after reap");
+        assert_eq!(
+            status.and_then(|s| s.code()),
+            Some(7),
+            "the owner must recover the exit code the reaper collected"
+        );
+    }
+
+    #[test]
+    fn a_recovered_status_is_handed_out_once() {
+        // The table is drained on read, so a second poll cannot resurrect a
+        // stale status and report the same exit twice.
+        let reg = fresh_registry();
+        let mut child = spawn_exiting_with(4);
+        let pid = child.id() as i32;
+        register_in(&reg, pid);
+        reap_until_collected(&reg, pid);
+
+        assert_eq!(
+            try_wait_in(&reg, &mut child)
+                .unwrap()
+                .and_then(|s| s.code()),
+            Some(4)
+        );
+        assert_eq!(
+            try_wait_in(&reg, &mut child).unwrap(),
+            None,
+            "a drained status must not be replayed"
+        );
+    }
+
+    #[test]
+    fn an_unowned_pid_is_discarded_rather_than_accumulated() {
+        // Orphans are what the reaper exists for, but nobody will ever ask
+        // for their status, so keeping it would leak the table.
+        let reg = fresh_registry();
+        let mut scripted = vec![(4242, 0), (4243, 1 << 8)].into_iter();
+        reap_in(&reg, |raw| match scripted.next() {
+            Some((pid, status)) => {
+                *raw = status;
+                pid
+            }
+            None => 0,
+        });
+        assert!(reg.lock().unwrap().reaped.is_empty());
+    }
+
+    #[test]
+    fn reaping_stops_at_the_first_non_positive_answer() {
+        // `0` means "children exist, none exited". Treating it as anything
+        // but a stop condition would spin the reaper thread hot.
+        let reg = fresh_registry();
+        register_in(&reg, 4242);
+        let mut calls = 0;
+        let mut scripted = vec![4242, 0, 4243].into_iter();
+        reap_in(&reg, |raw| {
+            calls += 1;
+            *raw = 0;
+            scripted.next().unwrap_or(-1)
+        });
+        assert_eq!(calls, 2, "must stop at the 0, not keep draining");
+        let reg = reg.lock().unwrap();
+        assert!(reg.reaped.contains_key(&4242));
+        assert!(!reg.reaped.contains_key(&4243));
+    }
+
+    #[test]
+    fn only_owned_pids_are_recorded() {
+        let reg = fresh_registry();
+        register_in(&reg, 4242);
+        let mut scripted = vec![(4242, 3 << 8), (9999, 5 << 8)].into_iter();
+        reap_in(&reg, |raw| match scripted.next() {
+            Some((pid, status)) => {
+                *raw = status;
+                pid
+            }
+            None => 0,
+        });
+        let reg = reg.lock().unwrap();
+        assert_eq!(reg.reaped.get(&4242), Some(&(3 << 8)));
+        assert!(!reg.reaped.contains_key(&9999));
+    }
+
+    #[test]
+    fn deregistering_forgets_the_pid_and_any_unread_status() {
+        let reg = fresh_registry();
+        register_in(&reg, 4242);
+        reg.lock().unwrap().reaped.insert(4242, 0);
+        deregister_in(&reg, 4242);
+        let reg = reg.lock().unwrap();
+        assert!(!reg.owned.contains(&4242));
+        assert!(
+            !reg.reaped.contains_key(&4242),
+            "an unread status must not outlive its owner, or the table grows forever"
+        );
+    }
+
+    #[test]
+    fn the_owned_token_registers_and_deregisters_in_the_global_registry() {
+        // The RAII wiring itself, on a pid no real child can hold.
+        let pid = 0x7f00_0001u32;
+        {
+            let _owned = OwnedChild::new(pid);
+            assert!(registry().lock().unwrap().owned.contains(&(pid as i32)));
+        }
+        assert!(!registry().lock().unwrap().owned.contains(&(pid as i32)));
+    }
+
+    #[test]
+    fn raw_status_decoding_matches_the_kernel_encoding() {
+        // wait(2) packs a normal exit as `code << 8`.
+        assert_eq!(exit_status_from_raw(3 << 8).code(), Some(3));
+        assert_eq!(exit_status_from_raw(0).code(), Some(0));
+    }
+}

--- a/crates/mvm-agentd/src/entrypoint.rs
+++ b/crates/mvm-agentd/src/entrypoint.rs
@@ -578,6 +578,11 @@ pub fn execute(
         }
     };
 
+    // Claim the child before it can exit, so PID 1's orphan reaper records
+    // its status for us rather than discarding it. Held until this call
+    // returns, by which point the child has been waited on.
+    let _owned = crate::child_wait::OwnedChild::new(child.id());
+
     // Drop the parent's copy of the write end so the child is the
     // only writer. Without this, reading the read end blocks
     // forever because the kernel sees a writer (us) still has it
@@ -831,7 +836,7 @@ fn poll_for_exit(
             kill_and_reap(child, caps.kill_grace_period);
             return ChildOutcome::PayloadCap;
         }
-        match child.try_wait() {
+        match crate::child_wait::try_wait(child) {
             Ok(Some(status)) => return ChildOutcome::Exited(status),
             Ok(None) => {
                 if Instant::now() >= deadline {
@@ -862,7 +867,7 @@ pub(crate) fn kill_and_reap(child: &mut Child, grace: Duration) {
     }
     let escalate_at = Instant::now() + grace;
     while Instant::now() < escalate_at {
-        if let Ok(Some(_)) = child.try_wait() {
+        if let Ok(Some(_)) = crate::child_wait::try_wait(child) {
             return;
         }
         std::thread::sleep(Duration::from_millis(50));
@@ -872,7 +877,7 @@ pub(crate) fn kill_and_reap(child: &mut Child, grace: Duration) {
     unsafe {
         libc::kill(-pgid, libc::SIGKILL);
     }
-    let _ = child.wait();
+    let _ = crate::child_wait::wait(child);
 }
 
 #[cfg(unix)]

--- a/crates/mvm-agentd/src/exec_stream.rs
+++ b/crates/mvm-agentd/src/exec_stream.rs
@@ -124,6 +124,10 @@ pub fn stream_exec<F: FnMut(ExecEvent)>(
         }
     };
 
+    // Claim the child before it can exit, so the orphan reaper records its
+    // status for us instead of discarding it.
+    let _owned = crate::child_wait::OwnedChild::new(child.id());
+
     if let Some(data) = stdin_data
         && let Some(ref mut pipe) = child.stdin
         && let Err(e) = pipe.write_all(data.as_bytes())
@@ -146,7 +150,7 @@ pub fn stream_exec<F: FnMut(ExecEvent)>(
             | drain_into(&err_buf, &mut sent_err, false, &mut emit);
         if capped {
             kill_pgroup(&child);
-            let _ = child.wait();
+            let _ = crate::child_wait::wait(&mut child);
             emit(ExecEvent::Stderr {
                 chunk: b"\n... (truncated)".to_vec(),
             });
@@ -154,7 +158,7 @@ pub fn stream_exec<F: FnMut(ExecEvent)>(
         }
         if deadline.is_some_and(|d| Instant::now() >= d) {
             kill_pgroup(&child);
-            let _ = child.wait();
+            let _ = crate::child_wait::wait(&mut child);
             // Same no-tail-loss discipline as the normal exit path: join the
             // drain threads so all buffered bytes are appended, then flush.
             if let Some(h) = out_handle.take() {
@@ -167,7 +171,7 @@ pub fn stream_exec<F: FnMut(ExecEvent)>(
             let _ = drain_into(&err_buf, &mut sent_err, false, &mut emit);
             return ExecEvent::TimedOut;
         }
-        match child.try_wait() {
+        match crate::child_wait::try_wait(&mut child) {
             Ok(Some(status)) => {
                 // Child exited: join the drain threads so every buffered
                 // byte has been appended (a happens-before edge — the

--- a/crates/mvm-agentd/src/lib.rs
+++ b/crates/mvm-agentd/src/lib.rs
@@ -19,6 +19,10 @@ pub mod builder_build;
 pub mod builder_session;
 /// Builder-VM file transfer over vsock (the hvf VMM has no virtio-fs).
 pub mod builder_transfer;
+/// The single waiter for child processes: an orphan reaper that publishes
+/// what it collects, so PID-1 reaping cannot destroy an owned child's exit
+/// status.
+pub mod child_wait;
 /// PTY-over-vsock interactive console — the single dev-only interactive path
 /// into a guest. Gated behind `interactive` so the relay symbols are absent from
 /// a sealed production agent (claim 15: no interactive access to a sealed prod

--- a/crates/mvm-agentd/src/lifecycle_hooks.rs
+++ b/crates/mvm-agentd/src/lifecycle_hooks.rs
@@ -87,23 +87,34 @@ impl HookRunner for RealHookRunner {
     }
 
     fn spawn(&self, script_path: &Path) -> io::Result<Self::Child> {
-        Command::new(script_path).spawn().map(RealHookChild)
+        Command::new(script_path)
+            .spawn()
+            .map(|child| RealHookChild {
+                _owned: crate::child_wait::OwnedChild::new(child.id()),
+                child,
+            })
     }
 }
 
-struct RealHookChild(Child);
+/// The hook's child plus the token that keeps PID 1's orphan reaper
+/// publishing its exit status rather than discarding it. The token is
+/// never read — dropping it alongside the child is the whole contract.
+struct RealHookChild {
+    child: Child,
+    _owned: crate::child_wait::OwnedChild,
+}
 
 impl HookChild for RealHookChild {
     fn try_wait(&mut self) -> io::Result<Option<HookExit>> {
-        self.0.try_wait().map(|status| status.map(HookExit::from))
+        crate::child_wait::try_wait(&mut self.child).map(|status| status.map(HookExit::from))
     }
 
     fn kill(&mut self) -> io::Result<()> {
-        self.0.kill()
+        self.child.kill()
     }
 
     fn wait(&mut self) -> io::Result<HookExit> {
-        self.0.wait().map(HookExit::from)
+        crate::child_wait::wait(&mut self.child).map(HookExit::from)
     }
 }
 

--- a/crates/mvm-agentd/src/process_rpc.rs
+++ b/crates/mvm-agentd/src/process_rpc.rs
@@ -156,6 +156,10 @@ struct ProcessRecord {
     started_at: String,
     /// Child handle, or `None` once we've called `wait()`.
     child: Mutex<Option<Child>>,
+    /// Keeps PID 1's orphan reaper publishing this child's exit status
+    /// instead of discarding it. Lives as long as the record. `None`
+    /// mirrors a record with no live child, the same way `child` does.
+    _owned: Option<crate::child_wait::OwnedChild>,
     /// Stdin pipe held by the agent until ProcSendInput drops it.
     stdin: Mutex<Option<ChildStdin>>,
     /// Captured stdout. Background drain thread (holding an `Arc`
@@ -447,6 +451,7 @@ pub fn handle_proc_start(
     let record = Arc::new(ProcessRecord {
         argv0,
         started_at,
+        _owned: Some(crate::child_wait::OwnedChild::new(child.id())),
         child: Mutex::new(Some(child)),
         stdin: Mutex::new(stdin),
         stdout_buf,
@@ -658,7 +663,7 @@ fn try_reap(record: &ProcessRecord, reap_grace: Duration) -> Option<TerminalStat
             .as_ref()
             .copied();
     };
-    match child.try_wait() {
+    match crate::child_wait::try_wait(child) {
         Ok(Some(status)) => {
             let terminal = if let Some(code) = status.code() {
                 TerminalState::Exited(code)
@@ -1058,6 +1063,7 @@ mod tests {
         ProcessRecord {
             argv0: "/bin/test".to_string(),
             started_at: "2025-01-01T00:00:00Z".to_string(),
+            _owned: None,
             child: Mutex::new(None),
             stdin: Mutex::new(None),
             stdout_buf: Arc::new(Mutex::new(vec![0u8; stdout_bytes])),
@@ -1116,6 +1122,7 @@ mod tests {
         let record = Arc::new(ProcessRecord {
             argv0: "/bin/echo".to_string(),
             started_at: "2025-01-01T00:00:00Z".to_string(),
+            _owned: None,
             child: Mutex::new(None),
             stdin: Mutex::new(None),
             stdout_buf,


### PR DESCRIPTION
Closes #2039.

Every `mvmctl machine run --image` reported 255 — success, `exit 3`, and `exit 7`
were indistinguishable — plus a stray `wait failed: No child process (os error 10)`
in the workload's stderr.

```
$ mvmctl machine run --image python:3.12 -- python -c "print(2 + 2)"
4
wait failed: No child process (os error 10)
$ echo $?
255
```

## Root cause

Two waiters raced for the same child. As PID 1 the agent installed a `SIGCHLD`
handler looping `waitpid(-1, WNOHANG)` to reap orphans, while `exec_stream`
polled its own child with `Child::try_wait()`. The handler usually won, so
`try_wait()` returned `ECHILD`, and its error arm emitted `wait failed: {e}` as a
workload stderr chunk and returned `Exit { code: -1 }` — 255 at the host.

The handler could not fix this by publishing what it reaped: a signal handler
must be async-signal-safe, so it can neither lock nor allocate.

The same race sat at **every** explicit wait site, not just `exec_stream`:
`entrypoint.rs` (the workload exit path), `interactive.rs` (the detached
workload's exit report, which is what powers the VM off), `process_rpc.rs`,
`lifecycle_hooks.rs`, `health.rs`.

## Fix

One waiter, and it publishes.

- New `child_wait` module owns a registry: pids the agent owns, plus the exit
  statuses collected for them.
- The `SIGCHLD` handler becomes a reaper **thread**. A thread can lock, so it
  records a registered pid's status instead of destroying it, and discards the
  unregistered ones it exists to clean up.
- Spawn sites hold an RAII `OwnedChild`; wait sites call
  `child_wait::try_wait` / `wait`, which consult the table on `ECHILD`.
- Reaper-publish and owner-lookup take the same mutex, so a status is always
  observable by exactly one of them — no retry window. The lock is only ever
  held across non-blocking calls, so a long-running child never blocks orphan
  reaping. `wait` backs off 1ms→50ms rather than spinning for a workload's
  lifetime.
- With no reaper installed (every test, every non-PID-1 process) the entry
  points delegate to the inherent `Child` methods, so behaviour is unchanged.

Also drops an `unsafe extern "C"` signal handler from the guest agent.

## Why this survived

The handler installs only when the process is PID 1, which a test process never
is. `exec_stream`'s existing tests assert `Exit { code: 3 }` and pass — against a
path production cannot reach. The new tests drive the reaper-wins ordering
explicitly, with the registry and the reap syscall injected so they neither touch
process-global state nor call `waitpid(-1)` (which in a threaded test binary
would steal other tests' children).

I verified the two recovery tests actually go red: neutering only one of the two
lookup paths still passed, so they were not pinning what they appeared to until
both were neutered.

## Verification

macOS, rebuilt agent baked into the rootfs:

```
requested=0   got=0   stderr=[]
requested=3   got=3   stderr=[]
requested=7   got=7   stderr=[]
requested=42  got=42  stderr=[]
```

Every one of those was 255 before.

`cargo nextest run -p mvm-agentd --all-features` — 640 passed. fmt + clippy clean
via the pre-commit hook. The full workspace suite is left to CI: this host is
running several concurrent agent sessions (load average 137) and local full-suite
runs flake on unrelated crates under that contention — `mvm-hostd`'s
`pii_redactor` / `policy_tool_gate` failures I saw locally all pass in isolation.