### PR TITLE
Fix remaining security and reliability issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1375,7 +1375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3184,7 +3184,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3693,7 +3693,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4023,7 +4023,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4091,7 +4091,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4650,7 +4650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4825,7 +4825,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4844,7 +4844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6172,7 +6172,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -705,27 +705,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06aeba2c965fc446d13c56a6ccb2631b78445d7544543dd9a25289977630914"
+checksum = "47ca6361f42d0c945fadc1103501e1c07438e034fd5a86896a3074eff3e860bd"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2d2dde4ec1352715595b5cfa6fe2e5b8ebb9da3457b3ee8db0aa2808c069aa"
+checksum = "2c1dbc96db7cebf747bd5722d482338a5acff91d6be43b6bec145f9471327ffa"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4982ef9fa54ec9eee841e891e7ddc5434be1250e88de31572e000c888f30b"
+checksum = "353b309eef494e4adb4c6cca76f30ef27daa907534db7d05b5986500f51aa4e1"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529143118c4eeb58c39ecb02319557d512be6c61348486422974ab8e3906b8a8"
+checksum = "e3cafe127a4c5d9765b1df54052245d2cbaca7238782805bb5ac94986ccdb591"
 dependencies = [
  "serde",
  "serde_derive",
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7780677247ad3577e3a6a3ebf43f39b325a11d6393db72b2c9968a910d4d13d"
+checksum = "3964f31c6dc9d21e926ef884d3eec2f1ca83266a233521da4a737143262ceb84"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -775,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9645250416cbf92454fe61160e17e026e0ce405906a54500b114f923ddffc9"
+checksum = "b2f8b35746603b792e4ae34499a39251f310a06c98d4bc2ca02cf4bd29ce3c84"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -788,24 +788,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ee8d222ff0fd3681791979afbf88586ac9f49010d3db96b3cbe4c96759aee3"
+checksum = "584bd91987927dfe35e79c5d6dd52a117cb64c4fce26df881d02dcc17bd59a8f"
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591abe6f5312bd2c4220f1b3bead56c2ad00257c52668015ba013b85dcf2a17a"
+checksum = "af277352af76db01bb42fa4978b672a44406715798edb693cc02e363e12dc505"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5300c49cf940526fe771517b3b3eabd5d0ff164ee61698579cf403fe8d3af3c"
+checksum = "42ad4f0c556d3d57580d07477be9e665f4d2a826971a5ab4642ead20a19df443"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4adbf760207fdbbe130f1191cce01cdef66831a9f648b1f39ff2800d126d45"
+checksum = "29d69a6b7d8412c716e8599c7330dfbd122c1bc145f3bda05a9e237fba20419d"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -828,15 +828,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8315b21ff018226a42a60a4702c2dd75f6447cac26e9bca622e14c22088c2ff5"
+checksum = "52fcdcd4a5c7fa8bfea35e72c0979ad5a699c836364870f0a84169d02a085a88"
 
 [[package]]
 name = "cranelift-native"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d506ef23a60715bde451b06620b14402166ded3b648454fccbf04f3e46a4aa70"
+checksum = "0fee933cf8ec90e58e68163a02bdb0e4d29f2260a7592b3f09cbba52fcd34d12"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ed47e602652e3410f9387fc0db70fefadcee4d78a78881421aabcab4e26b89"
+checksum = "6bd75e1e2719808c80af27ebe168d2220ec10e519e1d5a52bdbed9bd5cac1a32"
 
 [[package]]
 name = "crc"
@@ -1375,7 +1375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3184,7 +3184,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3608,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b92604caae1a1899b6a5b54967289dd538177c626004c91accf9d0ec7e4a12"
+checksum = "3683e69168d2e2374cea51a79fce2e9870e7c622366b8bf7af87fb5c2428a2a9"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -3620,9 +3620,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7ac85c0bb3fb351f10d531230aaa5e366b46d7c4e5328e5f02801d6dac1165"
+checksum = "8ebbd6dada1e3df36ea4a4b8feca2ed230aa92d59e55bf5714eb4286cdd632b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3693,7 +3693,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4023,7 +4023,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4091,7 +4091,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4650,7 +4650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4825,7 +4825,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4844,7 +4844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5752,9 +5752,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4213d2f019a5e44aa8a61d8826dd33a505bff79f749b14a8bafd67321cb9351"
+checksum = "ed27b4a4a5271d2608406a99c8d1cf8aea1e894fe4ec361d470063bcf342f1d7"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -5805,9 +5805,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45863de41977ec6453e859cf843d456fa3fcb45a659b66d16e794f90ec4f5b7"
+checksum = "7712f99b0920d4638023405eb9723ef200efd6d39bfc7466c92e926ca5d130f0"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -5836,9 +5836,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438bc7dc45fb75297d75f79a9a0ce852345d13ebc6a6863f6f688f013836a9dd"
+checksum = "bb07d96412d6958817749712969cfd6416cbce11639c3f3431dc659816d84ace"
 dependencies = [
  "base64",
  "directories-next",
@@ -5856,9 +5856,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e48f8d4966d62a10b6d70722bc432c1e163890be2801d3b5784589ad36ffc3"
+checksum = "f60f3492a55dbd4eb2e4f1f33ed0626d141f5f4cf4c0194168a4c5006f6601b0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -5871,15 +5871,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819ad5abd5822a22dbf4014475cdfd1fe790707761cd732d74aaa3ba4d5ba489"
+checksum = "c777c83bb4c3414b23fe84fecd47a46016a0a0b0a39aa786cad0a701fe3cbc7f"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc28372e36eaf8cf70faa83b5779137f7e99c8d18569a125d1580e735cc9e4d"
+checksum = "ffb54b5de8723a9acf2c0bc531df8e773462796a5f87e8f49a3d5ea5c3b32ef7"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -5889,9 +5889,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a433efc6e35112a5457e1dc8bc4d8d39820ac7722267e89bc04e5df641f32124"
+checksum = "9c60bb70116a88791ccceef605b31010c4888a7305e450f01dc7d4f430ad25f0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5916,9 +5916,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a1d3a39d0d210f6b8574ee96a4315e0a14c67f3a1fc3cd5372cb10d2fb4422"
+checksum = "24bdf54907e0bad31ad6676d03ed1008fa21489725635136f9c38979c39a98ed"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5931,9 +5931,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f667288cb4dfa68a4639ffac4d5628535dda64ebdc2b990526efb12b30ba803"
+checksum = "ef4edaf07e20511f3ca070a4a0f026c407969f09e536075729872f548ca6f8d4"
 dependencies = [
  "cc",
  "object",
@@ -5943,9 +5943,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba651d44ab0faad4c58106b3adb45068189fb65ef50f0c404b6d9e3bf81a357"
+checksum = "f96a6d7eb246d1306b7db8915a169cd8628a9e6b8299d1d1f8ab109801ef0a66"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5955,9 +5955,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ecc52563b0558af2a7487eb710de07cc4532564b55528876129238e83118cb1"
+checksum = "39472572ea3eb11b7cc7fe7bd6df0005cef87b580eb06a3378d103ac99d45bc3"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5968,9 +5968,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747f4a074699ba1b4e4d841fb263f9b7df5bd1555181c4752bf5990d21ba676"
+checksum = "7bf2eff1c108b01566a7c8870de34821e7bda7d327e86e12a548c026e1e3677d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5979,9 +5979,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80009f46991622814196d96fac6fc0a938f46b5cba737a8f4e21e24e5a03856f"
+checksum = "d1d9d3ffd05d6e864adc35cff702f56307c454caec3b1d2d89dd6c843219b663"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -5992,9 +5992,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f65ef30a2c5478873cdb619085a7a649d3ce41cc3eaf298a7ce3dee96a8e11"
+checksum = "b88f243a21e600902fd03bd970df7e4671d760d724c9fad202166fd98c842548"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -6021,9 +6021,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee57d5fef4976b1ab542615f4cef2c43278eb549d8078939668ea0f13d5c696"
+checksum = "0373c9dc92c9373aa9cee05963ea438bc318bf07bb284bede77a9ce24b39f682"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6112,9 +6112,9 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "wiggle"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03df88bf1a6068b02851aa3ef9427d285118f5c1c153b068a8995c69dd9562a"
+checksum = "9914a7e8ac8cb37be90753103e2aa96959e9e5d2f549a2d081bcfeb8fa97e08d"
 dependencies = [
  "bitflags 2.13.0",
  "thiserror 2.0.18",
@@ -6126,9 +6126,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e014aec8661b613154377e4b49dbbb0dfc4f424efcee749782054576c00537d9"
+checksum = "789b4c6d82c1ae0f5003eb6c5b9d3c9fb80112c4be50ad2690eb7347f0edd852"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6140,9 +6140,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67310a8ae5190b7f3dcacf8697f2890701a3a8427b3e77ed91d3632dcedaceb"
+checksum = "c5be72b12200c1270ee5cc9c6c30450e9ba5abdcb5fe8d09d08b516b7bd974d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6172,7 +6172,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -332,6 +332,23 @@ pub(crate) fn universal_initramfs_available() -> bool {
 pub(crate) fn attach_universal_initramfs_if_cached(
     start_config: &mut mvm_core::vm_backend::VmStartConfig,
 ) -> Result<()> {
+    attach_universal_initramfs_with_resolver(start_config, |env, cache_root, version, arch| {
+        mvm_build::initramfs::resolve_or_build_local_initramfs(env, cache_root, version, arch)
+    })
+}
+
+fn attach_universal_initramfs_with_resolver(
+    start_config: &mut mvm_core::vm_backend::VmStartConfig,
+    resolve: impl FnOnce(
+        &HostShellEnvironment,
+        &std::path::Path,
+        &str,
+        mvm_core::arch::GuestArch,
+    ) -> Result<
+        mvm_fs::initramfs::InitramfsArtifact,
+        mvm_build::initramfs::InitramfsBuildError,
+    >,
+) -> Result<()> {
     let version = env!("CARGO_PKG_VERSION");
     let cache_root = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("initramfs");
     let arch = mvm_core::arch::GuestArch::host();
@@ -342,7 +359,7 @@ pub(crate) fn attach_universal_initramfs_if_cached(
             "guest sources changed since the cached universal initramfs was built; discarded it"
         );
     }
-    match mvm_build::initramfs::resolve_or_build_local_initramfs(&env, &cache_root, version, arch) {
+    match resolve(&env, &cache_root, version, arch) {
         Ok(artifact) => {
             if let Some(workspace_root) =
                 crate::commands::runtime_overlay::runtime_overlay_source_checkout_root()
@@ -1452,9 +1469,24 @@ mod universal_initramfs_attach_tests {
         env.isolate_mvm_home(dir.path());
 
         let mut sc = VmStartConfig::default();
-        // Must never return an error: a cold cache falls back to legacy boot
-        // (or is warmed automatically on hosts that can build/fetch it).
-        attach_universal_initramfs_if_cached(&mut sc).unwrap();
+        let resolver_called = std::cell::Cell::new(false);
+        attach_universal_initramfs_with_resolver(&mut sc, |_, _, _, _| {
+            resolver_called.set(true);
+            Err(mvm_build::initramfs::InitramfsBuildError::HostUnsupported {
+                operation: "test cache miss",
+                reason: "automatic warming is disabled in this test",
+            })
+        })
+        .unwrap();
+
+        assert!(
+            resolver_called.get(),
+            "the cold-cache resolver must be called"
+        );
+        assert!(
+            sc.initrd_path.is_none(),
+            "a cold-cache resolution failure must preserve legacy boot"
+        );
     }
 
     #[test]

--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -49,10 +49,10 @@ let
   # kernel — lets both of mvm's kernels track the latest point release exactly
   # and keeps the two pins from drifting apart. Bump `kernelVersion` + `hash`
   # together (the tarball's own sha256, e.g. via `nix store prefetch-file`).
-  kernelVersion = "6.12.98";
+  kernelVersion = "6.12.100";
   kernelSrc = pkgs.fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${kernelVersion}.tar.xz";
-    hash = "sha256-pitqLSB/9yUQ5fRxVrcHjh5xeXNXQSQRuOT/+X/I9Mc=";
+    hash = "sha256-Z/lzUzQGSS6Gd0usvO+uUNUNXDTL9wPEfsUmpe/c7pA=";
   };
   # The builder's overlay filesystem triggers a GNU tar directory-metadata
   # race while unpacking this archive. Materialize the source with bsdtar once

--- a/nix/packages/libkrunfw.nix
+++ b/nix/packages/libkrunfw.nix
@@ -20,8 +20,8 @@ assert lib.elem variant [
 
 let
   kernelSrc = fetchurl {
-    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.98.tar.xz";
-    hash = "sha256-pitqLSB/9yUQ5fRxVrcHjh5xeXNXQSQRuOT/+X/I9Mc=";
+    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.100.tar.xz";
+    hash = "sha256-Z/lzUzQGSS6Gd0usvO+uUNUNXDTL9wPEfsUmpe/c7pA=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -37,7 +37,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace Makefile \
+      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.100' \
       --replace-fail 'curl $(KERNEL_REMOTE) -o $(KERNEL_TARBALL)' 'ln -s ${kernelSrc} $(KERNEL_TARBALL)'
+    substituteInPlace patches/0008-virtio-vsock-support-dgrams.patch \
+      --replace-fail 'virtio_transport_alloc_skb(&info, dgram_len, false,' \
+        'virtio_transport_alloc_skb(&info, dgram_len, false, NULL,'
   '';
 
   nativeBuildInputs = [

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,11 +1,20 @@
 # Refactor status
 
-Last updated: 2026-07-31
+Last updated: 2026-08-01
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## In-flight plans
+- [ ] Plan 284 — Zero-open-issue reconciliation
+      (`specs/plans/284-zero-open-issue-reconciliation.md`)
+  - [x] Classify and reconcile the original 19 open issues
+  - [x] Land the queued fixes for #2007, #2028, and #2029
+  - [ ] Land the security, kernel-pin, installer-fixture, and cold-cache-test
+        fixes for #1983, #1937, #1972, and #2035
+  - [ ] Repair newly filed #2039 and #2042, and execute the refiled volume
+        epic #2040
+
 - [x] Plan 282 — Merge queue auto-requeue
       (`specs/plans/282-merge-queue-auto-requeue.md`)
   - [x] Refuse conflicts and bound retry attempts per PR

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,19 @@
 
 ## Current issue delivery
 
+- [x] Zero-open-issue reconciliation tranche: the original 19-issue queue is fully
+      classified, with completed, superseded, duplicate, and intentionally
+      unplanned items closed with evidence. Queued fixes for #2007, #2028, and
+      #2029 have merged. The remaining delivery updates Wasmtime to the patched
+      46.0.2 family, synchronizes and actually builds both Linux 6.12.100
+      kernel consumers, hardens the installer HTTP fixture, and removes the
+      Linux-only 128-second initramfs build from the cold-cache unit test.
+      Full-suite validation also made the plan-mode integration test override
+      the worktree's `MVM_HOME`, preventing it from reusing another test's
+      mutable host-signing key.
+      Newly filed #2039, #2040, and #2042 remain explicit follow-up work.
+      Tracked in plan 284.
+
 - [x] Merge-queue auto-requeue: bounded recovery for transiently ejected pull
       requests, with conflict refusal, persistent attempt counting, no checkout
       of untrusted code, and structural security tests. The label counter now

--- a/specs/plans/284-zero-open-issue-reconciliation.md
+++ b/specs/plans/284-zero-open-issue-reconciliation.md
@@ -1,0 +1,63 @@
+# Zero-open-issue reconciliation
+
+Issues: #1819, #1821, #1822, #1823, #1825, #1826, #1849, #1851, #1937,
+#1972, #1973, #1977, #1983, #2006, #2007, #2021, #2028, #2029, #2033,
+#2035, #2036, #2039, #2040, #2042
+
+Status: IN PROGRESS
+
+## Goal
+
+Reconcile every open GitHub issue against the current architecture and code,
+close completed, superseded, or unplanned work with an explicit reason, and
+deliver every remaining relevant fix. Completion means the repository has no
+open GitHub issues.
+
+## Reconciliation checklist
+
+- [x] Close roadmap proposals superseded by repository plans or rejected by
+      accepted architecture: #1819, #1821, #1822, #1823, #1825, #1826, #1849,
+      and #1851.
+- [x] Close #1973 as completed by the merged seed-caller isolation gate.
+- [x] Close #1977 as completed by the merged observable-condition and hang-guard
+      fix for `worker_pool_warm`.
+- [x] Close unbounded mutation-coverage proposals #2006, #2021, and #2033 after
+      confirming the security witnesses are caught and the exact-identity
+      baseline ratchets against new misses.
+- [x] Land the queued fixes for #2007, #2028, and #2029.
+- [x] Transfer #2036 to `tinylabscom/mvmd#196`, whose fleet-orchestrator
+      ownership covers the epic's production object-store, encryption,
+      reconciliation, quota, RBAC, and durability acceptance gates.
+- [ ] Repair #2039 by replacing the PID-1 `SIGCHLD` handler race with one
+      ownership-aware child waiter and proving reaper-first exit-status
+      delivery.
+- [ ] Execute the refiled cross-repository volume epic #2040 through its
+      dedicated production-object-store plan.
+- [ ] Repair #2042 so per-VM helper processes exit with their owning run and
+      stale helpers remain discoverable across worktree boundaries.
+- [x] Repair #1983 by updating the vulnerable Wasmtime 46.0.1 lock to 46.0.2
+      and confirming the queued mutation-baseline fix clears the other failing
+      security job.
+- [x] Repair #1937 by synchronizing both Linux pins on 6.12.100 and its verified
+      upstream tarball hash, including the compatibility adjustment required
+      by the libkrunfw datagram patch set.
+- [x] Repair #1972 by making the installer fixture read a complete, bounded
+      HTTP header instead of treating one socket read as one request.
+- [x] Repair #2035 by injecting the cold-cache resolution failure into the
+      non-fatal attachment test so Linux never performs a real initramfs build.
+- [x] Keep plan-mode integration coverage hermetic when the worktree exports
+      `MVM_HOME`, so it cannot consume mutable signing keys from another test.
+- [x] Run focused tests, workspace tests, workspace check, Linux all-targets
+      clippy, Nix evaluation/build checks, and `cargo audit`.
+- [ ] Publish the implementation, enter the merge queue, and verify that all
+      closing pull requests merge.
+- [ ] Confirm the GitHub open-issue count is zero.
+
+## Verified upstream inputs
+
+- Linux 6.12.100 is the latest upstream 6.12 point release on 2026-08-01.
+- `nix store prefetch-file` returned
+  `sha256-Z/lzUzQGSS6Gd0usvO+uUNUNXDTL9wPEfsUmpe/c7pA=` for the official
+  `linux-6.12.100.tar.xz` archive.
+- RustSec advisories RUSTSEC-2026-0222 and RUSTSEC-2026-0223 require Wasmtime
+  46.0.2 or later within the 46.x release line.

--- a/tests/install_sh.rs
+++ b/tests/install_sh.rs
@@ -2,12 +2,52 @@
 //! assets over a loopback HTTP server and drives the script with its
 //! documented env overrides.
 
+use std::collections::VecDeque;
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::mpsc;
 use std::thread;
+
+const MAX_REQUEST_HEADER_BYTES: usize = 8 * 1024;
+
+fn read_request_path(reader: &mut impl Read) -> std::io::Result<Option<String>> {
+    let mut request = Vec::with_capacity(512);
+    let mut chunk = [0u8; 512];
+
+    loop {
+        let read = reader.read(&mut chunk)?;
+        if read == 0 {
+            break;
+        }
+        if request.len().saturating_add(read) > MAX_REQUEST_HEADER_BYTES {
+            return Ok(None);
+        }
+        request.extend_from_slice(&chunk[..read]);
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    if !request.windows(4).any(|window| window == b"\r\n\r\n") {
+        return Ok(None);
+    }
+
+    let request = String::from_utf8_lossy(&request);
+    let mut fields = request
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .split_whitespace();
+    let method = fields.next();
+    let path = fields.next();
+    let version = fields.next();
+    if method != Some("GET") || version.is_none() || fields.next().is_some() {
+        return Ok(None);
+    }
+    Ok(path.map(str::to_owned))
+}
 
 fn host_target() -> &'static str {
     if cfg!(all(target_arch = "aarch64", target_os = "macos")) {
@@ -76,17 +116,17 @@ fn serve(routes: Vec<(String, Vec<u8>)>) -> (String, mpsc::Sender<()>) {
             }
             match listener.accept() {
                 Ok((mut stream, _)) => {
-                    let mut buf = [0u8; 2048];
-                    let n = stream.read(&mut buf).unwrap_or(0);
-                    let req = String::from_utf8_lossy(&buf[..n]);
-                    let path = req
-                        .lines()
-                        .next()
-                        .and_then(|l| l.split_whitespace().nth(1))
-                        .unwrap_or("/");
+                    // The listener is non-blocking so the stop channel can be
+                    // observed. Accepted sockets are request/response streams:
+                    // make that contract explicit on every platform, then read
+                    // through the header terminator instead of assuming one
+                    // `read` contains the entire request line.
+                    let _ = stream.set_nonblocking(false);
+                    let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(5)));
+                    let path = read_request_path(&mut stream).ok().flatten();
                     let body = routes
                         .iter()
-                        .find(|(p, _)| p == path)
+                        .find(|(candidate, _)| Some(candidate.as_str()) == path.as_deref())
                         .map(|(_, b)| b.clone());
                     match body {
                         Some(b) => {
@@ -107,6 +147,44 @@ fn serve(routes: Vec<(String, Vec<u8>)>) -> (String, mpsc::Sender<()>) {
         }
     });
     (format!("http://{addr}"), tx)
+}
+
+#[test]
+fn request_reader_collects_fragmented_headers() {
+    struct FragmentedReader<'a> {
+        fragments: VecDeque<&'a [u8]>,
+    }
+
+    impl Read for FragmentedReader<'_> {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let Some(fragment) = self.fragments.pop_front() else {
+                return Ok(0);
+            };
+            assert!(fragment.len() <= buf.len());
+            buf[..fragment.len()].copy_from_slice(fragment);
+            Ok(fragment.len())
+        }
+    }
+
+    let mut reader = FragmentedReader {
+        fragments: VecDeque::from([
+            b"G".as_slice(),
+            b"ET /artifact HTTP/1.1\r\nHo".as_slice(),
+            b"st: 127.0.0.1\r\nConnection: close\r\n\r\n".as_slice(),
+        ]),
+    };
+
+    assert_eq!(
+        read_request_path(&mut reader).unwrap().as_deref(),
+        Some("/artifact")
+    );
+}
+
+#[test]
+fn request_reader_rejects_incomplete_headers() {
+    let mut reader = b"GET /artifact HTTP/1.1\r\nHost: localhost\r\n".as_slice();
+
+    assert_eq!(read_request_path(&mut reader).unwrap(), None);
 }
 
 fn repo_root() -> PathBuf {

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -240,14 +240,18 @@ fn native_vmm_recipes_are_source_built_and_pinned() {
         );
     }
 
-    const KERNEL_VERSION: &str = "6.12.98";
-    const KERNEL_HASH: &str = "sha256-pitqLSB/9yUQ5fRxVrcHjh5xeXNXQSQRuOT/+X/I9Mc=";
+    const KERNEL_VERSION: &str = "6.12.100";
+    const KERNEL_HASH: &str = "sha256-Z/lzUzQGSS6Gd0usvO+uUNUNXDTL9wPEfsUmpe/c7pA=";
     assert!(
         libkrunfw.contains(&format!("linux-{KERNEL_VERSION}.tar.xz"))
             && libkrunfw.contains(&format!("hash = \"{KERNEL_HASH}\""))
             && libkrunfw.contains("KERNEL_REMOTE")
-            && libkrunfw.contains("ln -s ${kernelSrc} $(KERNEL_TARBALL)"),
-        "libkrunfw must pin and substitute the kernel source instead of downloading it during build"
+            && libkrunfw.contains(&format!(
+                "'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-{KERNEL_VERSION}'"
+            ))
+            && libkrunfw.contains("ln -s ${kernelSrc} $(KERNEL_TARBALL)")
+            && libkrunfw.contains("'virtio_transport_alloc_skb(&info, dgram_len, false, NULL,'"),
+        "libkrunfw must pin the kernel version, substitute the source, and keep its datagram patch compatible with that kernel"
     );
     assert!(
         kernel_base.contains(&format!("kernelVersion = \"{KERNEL_VERSION}\""))

--- a/tests/run_plan_mode.rs
+++ b/tests/run_plan_mode.rs
@@ -67,6 +67,7 @@ fn mvmctl_run_plan_cmd(home_dir: &std::path::Path) -> Command {
     #[allow(deprecated)]
     let mut cmd = Command::cargo_bin("mvmctl").expect("locate mvmctl binary");
     cmd.env("HOME", home_dir);
+    cmd.env("MVM_HOME", home_dir.join(".mvm"));
     cmd.env_remove("MVM_SDK_MODE");
     cmd
 }

--- a/tests/run_plan_mode.rs
+++ b/tests/run_plan_mode.rs
@@ -67,7 +67,7 @@ fn mvmctl_run_plan_cmd(home_dir: &std::path::Path) -> Command {
     #[allow(deprecated)]
     let mut cmd = Command::cargo_bin("mvmctl").expect("locate mvmctl binary");
     cmd.env("HOME", home_dir);
-    cmd.env("MVM_HOME", home_dir.join(".mvm"));
+    cmd.env("MVM_HOME", home_dir.join("mvm-state"));
     cmd.env_remove("MVM_SDK_MODE");
     cmd
 }


### PR DESCRIPTION
## Summary

- update the Wasmtime 46.x lockfile family to 46.0.2, clearing RUSTSEC-2026-0222 and RUSTSEC-2026-0223
- synchronize the workload and libkrunfw kernel pins on Linux 6.12.100, including the upstream Makefile and datagram-patch compatibility fixes needed for a real libkrunfw build
- make the installer loopback fixture read complete bounded HTTP headers instead of assuming one socket read contains the request
- keep the cold-cache initramfs unit test fast by injecting the expected non-fatal resolver failure
- isolate the plan-mode integration test's `MVM_HOME` so it cannot reuse mutable signing state from another worktree

## Validation

- `cargo test --workspace -- --test-threads=1`
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- Linux `cargo clippy --workspace --all-targets -- -D warnings`
- focused installer, kernel-structure, cold-cache, and plan-mode regressions
- real x86_64 Linux builds of `libkrunfw` and `workload-vmlinux`
- `cargo audit`
- `cargo deny check`

Closes #1983
Closes #1937
Closes #1972
Closes #2035
