### PR TITLE
feat(apple-container): admit the backend into the workload funnel

### DIFF
--- a/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
+++ b/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
@@ -34,13 +34,18 @@ use super::runtime_source::{
 /// off disk to decide whether to stand up its egress endpoint needs the pre-start
 /// persist:
 ///
-/// - **Firecracker / libkrun / hvf**: the runner-backed endpoint reads
-///   `<state_dir>/plan.json` during endpoint setup.
+/// - **Firecracker / libkrun / hvf / apple-container**: the runner-backed
+///   endpoint reads `<state_dir>/plan.json` during endpoint setup. The
+///   apple-container backend holds the same HVF runner, so its `start()` reads
+///   the same file.
 ///
 /// QEMU is excluded: it reads the in-memory config and must not overwrite the
 /// persisted plan.
 pub(crate) fn persists_plan_before_start(hypervisor: &str) -> bool {
-    matches!(hypervisor, "firecracker" | "libkrun" | "hvf")
+    matches!(
+        hypervisor,
+        "firecracker" | "libkrun" | "hvf" | "apple-container"
+    )
 }
 
 pub(in crate::commands::vm) fn load_workload_ir(
@@ -667,9 +672,10 @@ mod persists_plan_before_start_tests {
     fn persists_plan_before_start_covers_the_substitution_backends() {
         // The substitution endpoint reads <state_dir>/plan.json inside start() to
         // decide whether to spawn, so every backend that spawns it must persist the
-        // plan first — including the hvf backend. QEMU must not (it would
+        // plan first — including the hvf backend and the apple-container backend,
+        // which holds the same HVF runner. QEMU must not (it would
         // overwrite the in-memory config).
-        for hv in ["firecracker", "libkrun", "hvf"] {
+        for hv in ["firecracker", "libkrun", "hvf", "apple-container"] {
             assert!(
                 persists_plan_before_start(hv),
                 "{hv} spawns the substitution endpoint and must persist plan.json"

--- a/crates/mvm-conformance/tests/steps/apple_container.rs
+++ b/crates/mvm-conformance/tests/steps/apple_container.rs
@@ -131,3 +131,25 @@ fn kernel_is_the_cached_one(world: &mut CliWorld) {
         "a caller-supplied kernel must never win over the backend's own"
     );
 }
+
+#[when("I ask the admitted workload funnel for the apple-container backend")]
+fn admitted_funnel(world: &mut CliWorld) {
+    // The funnel boundary is pure permission — it matches the backend kind
+    // and never probes the artifact cache, so no isolated home is needed.
+    let backend = mvm_runtime::backend::AnyBackend::from_hypervisor("apple-container");
+    let workload = mvm_runtime::workload_backend::require_workload_backend(&backend)
+        .expect("the admitted funnel must accept the apple-container backend");
+    world.apple_container_workload_kind = Some(format!("{:?}", workload.kind()));
+}
+
+#[then("the funnel accepts it as a workload backend of kind apple-container")]
+fn funnel_accepts(world: &mut CliWorld) {
+    let kind = world
+        .apple_container_workload_kind
+        .as_deref()
+        .expect("a prior step must ask the admitted funnel");
+    assert_eq!(
+        kind, "AppleContainer",
+        "the funnel must return the backend under its own kind"
+    );
+}

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -127,6 +127,9 @@ pub struct CliWorld {
     pub auto_selected_kind: Option<String>,
     /// The kernel path after the apple-container backend's substitution.
     pub overridden_kernel_path: Option<String>,
+    /// The backend kind (`Debug` token) the admitted workload funnel
+    /// returned for the apple-container selector.
+    pub apple_container_workload_kind: Option<String>,
     /// Fixed stand-in guest-agent bytes an initramfs scenario builds from.
     pub initramfs_agent_bytes: Option<Vec<u8>>,
     /// The two deterministic cpio builds a determinism scenario compares.

--- a/crates/mvm-runtime/src/apple_container_backend.rs
+++ b/crates/mvm-runtime/src/apple_container_backend.rs
@@ -34,6 +34,7 @@ use thiserror::Error;
 
 use crate::apple_container::artifacts;
 use crate::backend::HvfRunner;
+use crate::workload_backend::{EgressSubstitutionTransport, WorkloadBackend};
 
 /// Typed, fail-closed errors for requests this backend cannot satisfy.
 /// Every error names what was refused and why, rather than silently falling
@@ -188,6 +189,16 @@ impl VmBackend for AppleContainerBackend {
     }
 }
 
+impl WorkloadBackend for AppleContainerBackend {
+    fn egress_substitution_transport(&self) -> EgressSubstitutionTransport {
+        // The same posture as the HVF runner this backend delegates to:
+        // proxy-aware substitution over the vsock UDS channel, no
+        // transparent :80/:443 terminator. Delegating keeps the two in
+        // lock-step if the runner's transport ever changes.
+        self.runner.egress_substitution_transport()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -328,6 +339,51 @@ mod tests {
         let b = AppleContainerBackend::new();
         // No kernel in the isolated cache: unavailable regardless of platform.
         assert!(!b.is_available().unwrap());
+    }
+
+    #[test]
+    fn workload_transport_mirrors_the_hvf_runner() {
+        let b = AppleContainerBackend::new();
+        let transport = b.egress_substitution_transport();
+        assert_eq!(
+            transport,
+            b.runner.egress_substitution_transport(),
+            "the transport delegates to the runner's own declaration"
+        );
+        assert_eq!(transport, EgressSubstitutionTransport::VsockUdsChannel);
+        assert!(transport.supports_proxy_aware_substitution());
+        assert!(!transport.supports_transparent_terminator());
+    }
+
+    #[test]
+    fn workload_identity_and_capabilities_delegate() {
+        let b = AppleContainerBackend::new();
+        // `&dyn WorkloadBackend` still carries the full VmBackend surface:
+        // identity and capabilities are the backend's own delegations.
+        let workload: &dyn WorkloadBackend = &b;
+        assert_eq!(workload.name(), "apple-container");
+        assert_eq!(workload.kind(), BackendKind::AppleContainer);
+        let (mine, theirs) = (
+            workload.capabilities(),
+            crate::backend::hvf_runner().capabilities(),
+        );
+        assert_eq!(mine.vsock, theirs.vsock);
+        assert_eq!(mine.no_routable_guest_nic, theirs.no_routable_guest_nic);
+        assert_eq!(mine.standby_pool, theirs.standby_pool);
+        assert_eq!(mine.snapshot_capability, theirs.snapshot_capability);
+        assert_eq!(mine.pause_resume, theirs.pause_resume);
+    }
+
+    #[test]
+    fn require_workload_backend_accepts_apple_container() {
+        // The admitted-funnel boundary is pure permission — it matches the
+        // backend kind and never probes the artifact cache, so no isolated
+        // MVM_HOME is needed here (the kernel is resolved at `start`).
+        let backend = AnyBackend::from_hypervisor("apple-container");
+        let workload = crate::workload_backend::require_workload_backend(&backend)
+            .expect("apple-container boots the full admitted stack — it is a workload backend");
+        assert_eq!(workload.name(), "apple-container");
+        assert_eq!(workload.kind(), BackendKind::AppleContainer);
     }
 
     #[test]

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -588,9 +588,9 @@ impl AnyBackend {
     ///
     /// Returns `None` when no marker is present — the VM doesn't exist, or
     /// isn't one of the pid-file backends (Apple Container boots through
-    /// the same HVF supervisor, so its live VMs surface under the HVF
-    /// marker until its own lifecycle lands). Callers fall back to the
-    /// platform default in that case.
+    /// the same HVF supervisor, so its live VMs deliberately surface under
+    /// the HVF marker — same supervisor, same lifecycle). Callers fall back
+    /// to the platform default in that case.
     pub fn for_started_vm(name: &str) -> Option<Self> {
         let dir = mvm_core::config::vm_state_dir(name);
         catalog::started_vm_probe_descriptors()
@@ -724,11 +724,11 @@ impl AnyBackend {
             // egress seam). Barred from the admitted launch funnel until
             // then, the same carve-out as `Qemu`.
             AnyBackend::Wasm(_) => None,
-            // The apple-container skeleton has no boot path at all — it
-            // cannot carry an untrusted workload until the framework shim
-            // and the activation channel land, so it is barred from the
-            // admitted launch funnel the same way `Qemu`/`Wasm` are.
-            AnyBackend::AppleContainer(_) => None,
+            // Apple Container boots the full admitted stack — it IS the HVF
+            // workload runner with only the kernel image substituted, so the
+            // same egress endpoint, broker registration, and activation gate
+            // apply verbatim.
+            AnyBackend::AppleContainer(b) => Some(b),
             // Docker is a shared-kernel container dev tier: namespaces are
             // not a hardware boundary, so it must never carry an untrusted
             // production workload. Barred from the admitted launch funnel
@@ -787,7 +787,9 @@ impl AnyBackend {
             // checkpoint contract while keeping the VM itself in memory.
             #[cfg(feature = "test-support")]
             AnyBackend::Mock(backend) => backend.spawn_standby_captured(ctx, spec),
-            // Not workload-bearing backends — no warm pool, fail closed.
+            // No warm pool on these backends: qemu, wasm, and docker are not
+            // workload-bearing; apple-container is, but the HVF driver has no
+            // standby support — all fail closed.
             AnyBackend::Qemu(_)
             | AnyBackend::Wasm(_)
             | AnyBackend::AppleContainer(_)
@@ -830,7 +832,9 @@ impl AnyBackend {
             // its own in-memory state (the context is a runner detail it ignores).
             #[cfg(feature = "test-support")]
             AnyBackend::Mock(backend) => backend.claim_standby(handle, claim),
-            // Not workload-bearing backends — no warm pool, fail closed.
+            // No warm pool on these backends: qemu, wasm, and docker are not
+            // workload-bearing; apple-container is, but the HVF driver has no
+            // standby support — all fail closed.
             AnyBackend::Qemu(_)
             | AnyBackend::Wasm(_)
             | AnyBackend::AppleContainer(_)
@@ -1857,14 +1861,15 @@ mod tests {
     }
 
     #[test]
-    fn as_workload_backend_none_for_apple_container_skeleton() {
-        // The skeleton has no boot path; it must not carry an untrusted
-        // workload until the framework shim and activation channel land.
+    fn as_workload_backend_some_for_apple_container() {
+        // Apple Container boots the full admitted stack through the shared
+        // HVF runner — only the kernel image differs — so it is a workload
+        // backend under its own kind.
         let backend = AnyBackend::from_hypervisor("apple-container");
-        assert!(
-            backend.as_workload_backend().is_none(),
-            "apple-container: skeleton must not be a workload backend"
-        );
+        let workload = backend
+            .as_workload_backend()
+            .expect("apple-container boots the admitted stack — it is a workload backend");
+        assert_eq!(workload.kind(), BackendKind::AppleContainer);
     }
 
     #[test]

--- a/features/suites/s25_apple_container/apple_container.feature
+++ b/features/suites/s25_apple_container/apple_container.feature
@@ -9,7 +9,10 @@ Feature: Apple Container backend contract
   prefers the apple-container backend on the HVF tier, but only when its
   kernel is cached — without the artifact the tier falls back to the plain
   HVF backend. Once its kernel is cached the launch's kernel image is
-  always that cached kernel, never a caller-supplied one.
+  always that cached kernel, never a caller-supplied one. The backend is
+  admitted to the workload funnel — the egress endpoint, broker
+  registration, and activation gate are the HVF runner's verbatim; only
+  the kernel image differs.
 
   Scenario: A missing container kernel fails closed with a hint-carrying error
     Given an isolated mvm home for the apple-container backend
@@ -28,3 +31,7 @@ Feature: Apple Container backend contract
     And an apple-container kernel is cached in the isolated home
     When I apply the backend's kernel substitution to a caller config
     Then the kernel path is the cached apple-container kernel, not the caller's kernel
+
+  Scenario: The admitted workload funnel accepts the apple-container backend
+    When I ask the admitted workload funnel for the apple-container backend
+    Then the funnel accepts it as a workload backend of kind apple-container

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-07-31
+Last updated: 2026-08-01
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -12,7 +12,7 @@ for detailed scope and acceptance criteria.
   - [x] Keep privileged execution on the trusted base ref with no checkout
   - [x] Complete repository validation and queue the PR
 
-- [x] Plan 270 — Universal initramfs + vsock-activated boot
+ - [x] Plan 270 — Universal initramfs + vsock-activated boot
       (`specs/plans/270-universal-initramfs-vsock-activated-boot.md`)
   - [x] Core boot contract: `ActivateEnvironment` over the authenticated
         vsock session, `ActivationState` gate, PID-1 agent with mount
@@ -29,14 +29,22 @@ for detailed scope and acceptance criteria.
         guest-side activation idle timeout and focused zombie-reaping tests
         remain open
 
-- [~] Plan 271 — Apple Container backend
+- [~] Plan 271 — Apple Container backend: Apple's container kernel on HVF
       (`specs/plans/271-apple-container-backend.md`)
-  - [x] Kernel artifact resolution + thin HVF-runner delegation shipped
-        (#1968): Apple's prebuilt container kernel boots the same universal
-        initramfs on the HVF runner; 100% Rust-native, `check-no-vz` guard
-  - [x] Hermetic BDD coverage for the backend contract (#1996)
-  - [ ] Live e2e validation with a real fetched kernel, then the
-        claim-by-claim security-profile review (plan's stage 2)
+  - [x] Stage 1 — fail-closed skeleton: kernel artifact resolution + thin
+        HVF-runner delegation
+  - [x] Stage 2 — live validation + claim review (2026-08-01): required
+        `vmlinux.sha256` digest sidecar (fail-closed on absence/mismatch),
+        sealed dm-verity boot proven on macOS HVF (gated e2e, 4.27s), CLI
+        smoke via `machine run --hypervisor apple-container`, claims array
+        stays a verbatim HVF-runner mirror (claim 3 stays DoesNotHold for
+        the virtiofs-root path — owner decision)
+  - [x] Admitted workload funnel un-barred (2026-08-01): `WorkloadBackend`
+        implemented with the runner's `VsockUdsChannel` transport,
+        `as_workload_backend` returns the backend, and
+        `require_workload_backend` / `start_prepared` / the admitted
+        persistent-OCI path accept `--hypervisor apple-container`
+  - [ ] Container-mode closure (later stage)
 
 - [ ] Plan 279 — Build action identity and a real artifact manifest
       (`specs/plans/279-build-action-identity-and-artifact-manifest.md`)

--- a/specs/plans/271-apple-container-backend.md
+++ b/specs/plans/271-apple-container-backend.md
@@ -34,6 +34,15 @@ package the containerization project recommends, or any compatible arm64
 Linux `Image`) — no toolchain, no Swift, nothing Apple-built runs on the
 host or as guest PID 1.
 
+The backend is admitted to the workload funnel: it implements
+`WorkloadBackend` (the same `VsockUdsChannel` egress transport as the
+runner), so `require_workload_backend` — the single boundary of the
+admitted launch path — accepts it, and `mvm_client::start_prepared` plus
+the admitted persistent-OCI path boot `--hypervisor apple-container`
+exactly as they boot `--hypervisor hvf`. Egress, broker registration,
+and the admitted funnel are shared verbatim; only the kernel image
+differs.
+
 ## Design
 
 ```text


### PR DESCRIPTION
`AnyBackend::as_workload_backend` returned `None` for apple-container under a stale skeleton-era comment, so `require_workload_backend` — the single boundary of the admitted launch path — refused it, and with it `mvm_client::start_prepared` and the admitted persistent-machine flow. The backend has booted the full admitted stack since stage 1: it **is** the HVF workload runner with only the kernel image substituted, and the sealed boot is live-proven on macOS HVF (dm-verity rootfs + overlay mounts, activation ack, uid-901 drop). The refusal was an artificial boundary, not a tier boundary — AC is Tier2 exactly like HVF (test-pinned), and admission treats it identically.

## Changes

- `impl WorkloadBackend for AppleContainerBackend`, delegating `egress_substitution_transport()` to the inner runner (`VsockUdsChannel` — lock-step by construction); identity/capabilities/profile were already the shared delegations.
- The dispatch arm returns `Some(b)`; the stale skeleton comment is rewritten to the truth.
- `persists_plan_before_start` now covers `apple-container`: the runner-backed substitution endpoint reads `<state_dir>/plan.json` during `start()`, and AC holds the same runner — without the persist, admitted egress on the persistent path would misbehave.
- Comment honesty sweep: the warm-pool grouping mislabelled AC as not workload-bearing (it is — the HVF driver simply has no standby support); the inventory comment predated its lifecycle (AC VMs deliberately surface under the HVF marker — same supervisor, as the live run below shows).
- Caller sweep: no code relied on the `None` arm — the only production consumer is the boundary itself.

## Tests

- Unit: transport mirrors the runner, identity/capabilities delegate, `require_workload_backend` accepts AC (hermetic), the persists-gate test now covers apple-container.
- BDD: new hermetic scenario — `AnyBackend::from_hypervisor("apple-container")` passes `require_workload_backend`. Suite: 84 scenarios / 406 steps, all green.

## Live validation (macOS HVF, 2026-08-01)

The exact flow that refused before:
```
mvmctl machine create --name ac-funnel-smoke --image alpine   # ok
mvmctl machine start ac-funnel-smoke --hypervisor apple-container   # ok — START_EXIT=0
mvmctl machine ls    # ac-funnel-smoke  persistent  hvf  alpine  (HVF marker by design)
mvmctl machine stop / rm --yes   # clean teardown
```
Transient regression check (`machine run --hypervisor apple-container --image alpine`) also still boots.

## Validation

`cargo fmt` · `mvm-runtime` apple_container (15/15), backend (170/170), workload_backend (12/12) · `mvm-cli` persists_plan (1/1) · BDD 84/84 · clippy `mvm-runtime`/`mvm-cli`/`mvm-conformance --all-targets -D warnings` · `xtask check-no-vz` — all clean.