### PR TITLE
fix(initramfs): stop the cold-cache test paying for a real initramfs build

### DIFF
--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -329,6 +329,15 @@ pub(crate) fn universal_initramfs_available() -> bool {
     mvm_build::initramfs::resolve_or_seed_from_default_cache(&cache_root, version, arch).is_ok()
 }
 
+/// How the universal initramfs is obtained for a boot.
+///
+/// Injected so the cold-cache contract is testable. In production this is
+/// always [`mvm_build::initramfs::resolve_or_build_local_initramfs`],
+/// which *builds* on a miss — the right thing on a first boot, and two
+/// minutes of cargo cross-compile on any host that can do it. A test of
+/// "a miss is non-fatal" has no business paying for that, and paying for
+/// it is also what made the miss path indistinguishable from the build
+/// path in the assertion.
 pub(crate) fn attach_universal_initramfs_if_cached(
     start_config: &mut mvm_core::vm_backend::VmStartConfig,
 ) -> Result<()> {
@@ -1460,8 +1469,16 @@ mod universal_initramfs_attach_tests {
         }
     }
 
+    /// A cold cache must be non-fatal *and* must attach nothing.
+    ///
+    /// The resolver is injected rather than left to the real one. With the
+    /// real one this test took 128 seconds on Linux: a cold cache is
+    /// "warmed automatically on hosts that can build", so asserting that a
+    /// miss returns `Ok` was paying for a full initramfs cross-compile —
+    /// and then asserting `Ok` on the *build* path, never the miss path it
+    /// was written for.
     #[test]
-    fn attach_universal_initramfs_if_cached_cold_cache_is_non_fatal() {
+    fn attach_universal_initramfs_cold_cache_is_non_fatal_and_attaches_nothing() {
         let mut env = TestEnv::new();
         let dir = tempfile::tempdir().unwrap();
         // HOME moves with MVM_HOME or the cache under test is not cold: the


### PR DESCRIPTION
Closes #2035.

## What

`attach_universal_initramfs_if_cached_cold_cache_is_non_fatal` took **128 seconds** on Linux — by a distance the slowest test in the workspace, and invisible on macOS where the same path fails a download fast instead of running a cargo cross-compile.

## Why it was slow, and why that made it wrong

The cause is in the test's own comment: a cold cache "is warmed automatically on hosts that can build/fetch it". On a host that can build, asserting a miss returns `Ok` built the entire universal initramfs first — then asserted `Ok` on the **build** path, never on the miss path the test was written for.

So it was not merely slow. It could not have failed for the reason it existed: a regression that made a genuine cache miss fatal would have been masked by the build succeeding.

## The fix

The resolver is injected, the same shape `resolve_or_pull_run_image_with` already uses in this crate. Production is unchanged — all four boot-path callers (`exec.rs` ×2, `checkpoint.rs`, `oci_persist.rs`) still resolve-or-build, which is correct on a first boot. The test supplies a resolver that always misses and asserts **both** halves of the contract: `Ok`, and nothing attached.

## Effect

| | before | after |
| --- | --- | --- |
| the test | 128s | 0.08s |
| `cargo nextest run -p mvm-cli` | ~145s | ~37s |

This matters past the inner loop. The mutation-witness lane re-runs the owning package's whole suite once per mutant, so this test alone was worth hours of every nightly over mvm-cli's four claim-surface files — it was the single largest term in that lane's runtime.