### PR TITLE
feat(xtask): mutate the code the lane was skipping, instead of tolerating it

### DIFF
--- a/xtask/mutation-witness-baseline.json
+++ b/xtask/mutation-witness-baseline.json
@@ -38,6 +38,9 @@
       "package": "mvm-build",
       "claims": [
         6
+      ],
+      "features": [
+        "pure-mkfs"
       ]
     },
     {
@@ -232,21 +235,6 @@
     },
     {
       "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "delete ! in stage_runtime_overlay_binary",
-      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace & with ^ in overlay_mode_of",
-      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace & with | in overlay_mode_of",
-      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
       "mutant": "replace && with || in extract_release_archive",
       "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
     },
@@ -254,21 +242,6 @@
       "file": "crates/mvm-build/src/runtime_overlay.rs",
       "mutant": "replace && with || in local_source_cache_is_fresh",
       "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace build_runtime_overlay_from_guest_binaries -> Result<RuntimeOverlayArtifact, RuntimeOverlayError> with Ok(Default::default())",
-      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace collect_overlay_nodes -> Result<Vec<mvm_fs::ext4::Node>, RuntimeOverlayError> with Ok(vec![Default::default()])",
-      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace collect_overlay_nodes -> Result<Vec<mvm_fs::ext4::Node>, RuntimeOverlayError> with Ok(vec![])",
-      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
     },
     {
       "file": "crates/mvm-build/src/runtime_overlay.rs",
@@ -287,26 +260,6 @@
     },
     {
       "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace overlay_guest_path -> String with \"xyzzy\".into()",
-      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace overlay_guest_path -> String with String::new()",
-      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace overlay_mode_of -> u16 with 0",
-      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace overlay_mode_of -> u16 with 1",
-      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
       "mutant": "replace run_nix_build -> Result<(), RuntimeOverlayError> with Ok(())",
       "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
     },
@@ -319,11 +272,6 @@
       "file": "crates/mvm-build/src/runtime_overlay.rs",
       "mutant": "replace runtime_overlay_source_checkout_root -> Option<PathBuf> with Some(Default::default())",
       "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace stage_runtime_overlay_binary -> Result<(), RuntimeOverlayError> with Ok(())",
-      "reason": "not compiled by the mutation build: these live behind the pure-mkfs feature, which is not a default. cargo-mutants generates mutants by parsing source -- syn does not evaluate cfg -- so the code is mutated, never built, and no test can kill it. Falsifiable: the tests added for overlay_mode_of and all_required_files_present do catch these under --features pure-mkfs."
     },
     {
       "file": "crates/mvm-build/src/runtime_overlay.rs",

--- a/xtask/src/check_mutation_witnesses.rs
+++ b/xtask/src/check_mutation_witnesses.rs
@@ -85,6 +85,16 @@ pub struct SurfaceFile {
     /// Optionally restrict which mutants in this file are in claim scope.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope: Option<SurfaceScope>,
+    /// Cargo features the mutation build must enable for this file.
+    ///
+    /// cargo-mutants generates mutants by parsing source, and `syn` does
+    /// not evaluate `cfg`. A function behind a feature the run does not
+    /// enable is therefore mutated, never compiled, and reported as a
+    /// survivor that no test could ever kill. Naming the feature here is
+    /// the difference between measuring the code and tolerating a mutant
+    /// nothing can reach.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub features: Vec<String>,
 }
 
 /// A narrowing of one file's mutation surface.
@@ -356,6 +366,7 @@ pub fn resolve_surface(workspace: &Path) -> Result<Surface> {
                 // hand to the committed baseline, which is what makes it
                 // a reviewable act rather than a silent one.
                 scope: None,
+                features: Vec::new(),
             })
         })
         .collect();
@@ -576,9 +587,18 @@ pub fn carry_scopes_forward(
         .iter()
         .filter_map(|s| s.scope.as_ref().map(|sc| (s.path.as_str(), sc)))
         .collect();
+    let features: BTreeMap<&str, &Vec<String>> = previous
+        .surface
+        .iter()
+        .filter(|s| !s.features.is_empty())
+        .map(|s| (s.path.as_str(), &s.features))
+        .collect();
     for file in &mut resolved {
         if let Some(scope) = scopes.get(file.path.as_str()) {
             file.scope = Some((*scope).clone());
+        }
+        if let Some(f) = features.get(file.path.as_str()) {
+            file.features = (*f).clone();
         }
     }
     resolved
@@ -846,6 +866,11 @@ fn run_mutants_for_file(
         ])
         .arg("--output")
         .arg(out_dir);
+    if !file.features.is_empty() {
+        let joined = file.features.join(",");
+        eprintln!("      features {joined}");
+        cmd.args(["--features", &joined]);
+    }
     if let Some(scope) = &file.scope {
         eprintln!(
             "      scoped to /{}/ — {}",
@@ -1160,6 +1185,7 @@ a.rs:5:1: replace x with y
             package: package_for(path).unwrap_or_else(|| "unknown".into()),
             claims,
             scope: None,
+            features: Vec::new(),
         }
     }
 
@@ -1200,6 +1226,7 @@ a.rs:5:1: replace x with y
             path: path.into(),
             package: package_for(path).unwrap_or_else(|| "unknown".into()),
             claims: vec![2],
+            features: Vec::new(),
             scope: Some(SurfaceScope {
                 examine_re: examine_re.into(),
                 why: why.into(),


### PR DESCRIPTION
Part of #2033.

## What

Lets a surface entry name the cargo features the mutation build must enable, and uses it to make `crates/mvm-build/src/runtime_overlay.rs` measurable under `pure-mkfs`.

## Why these mutants were never killable

cargo-mutants generates mutants by parsing source, and `syn` does not evaluate `cfg`. A function behind a feature the run does not enable is therefore **mutated, never compiled, and reported as a survivor** — indistinguishable from a real hole, and unkillable by any test that could ever be written.

Measured both ways on `overlay_mode_of`, which copies a staged file's permission bits into the runtime overlay:

| Build | `& 0o7777` → `| 0o7777` |
| --- | --- |
| default features — what the lane ran | survives, against 720 passing tests |
| `--features pure-mkfs` | caught |

That mutant is not cosmetic: it makes every file in the overlay world-writable and setuid. The test that catches it already existed and passed; the lane simply never built the code.

## The change

`SurfaceFile` gains `features: Vec<String>`, handed to cargo-mutants as `--features`. Same discipline as `scope`:

- resolution never invents one, so it can only arrive by hand in the committed baseline, as a reviewable diff;
- a re-pin carries it forward, so routine maintenance cannot silently drop it and quietly return those mutants to "accepted".

`accepted_misses` drops 91 → 80: the eleven entries whose stated mechanism was "not compiled by the mutation build" are now measured rather than tolerated.

## Verification

`runtime_overlay.rs` mutated on Linux with the feature on:

```
total 80  missed 13  caught 52  unviable 15      (with --features pure-mkfs)
total 80  missed 24  caught 43  unviable 13      (before, default features)
```

**Zero** of the previously-uncompiled functions survive. `overlay_mode_of`, `overlay_guest_path`, `collect_overlay_nodes`, `stage_runtime_overlay_binary` and `build_runtime_overlay_from_guest_binaries` are all now caught — several by tests that already existed and had never been compiled, let alone run.

The observed survivors match the committed baseline exactly:

```
observed survivors : 12
baseline accepted  : 12
NEW misses (would FAIL the lane): 0
now-caught (stale entries)      : 0
```

(13 mutants collapse to 12 identities: two `delete !` in `extract_release_archive` share a description at different columns, which is `mutant_identity` stripping position as designed.)

All twelve are the nix-gated group — `run_nix_build`, `curl_download`, `extract_release_archive`, `local_source_cache_is_fresh` and friends — whose stated mechanism is unchanged.

The remaining #2033 mechanisms are untouched and stay accepted: the libkrun supervisor (31) and Firecracker snapshot I/O (17) need protocol doubles, which is real work and worth doing properly rather than approximating.
