### PR TITLE
fix(guest): run the guest environment setup on the universal-initramfs path

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
@@ -112,6 +112,11 @@ pub(crate) fn apply_activation(
     } else {
         guest_mount::pivot_to_root(&new_root)?;
     }
+    // The same post-mount setup the legacy per-rootfs init performs: mediated
+    // tools, egress CA, verb grant, netinit, loopback + resolver, egress client.
+    // It has to land after the pivot (it writes into the workload's root) and
+    // before the privilege drop (mounts and interface changes need root).
+    bootstrap_guest_environment()?;
     guest_mount::drop_privilege(WORKLOAD_UID, WORKLOAD_GID)?;
 
     boot_state.set_activation(ActivationState::Activated);
@@ -130,4 +135,22 @@ fn fatal(message: &str) -> ! {
     );
     std::thread::sleep(std::time::Duration::from_millis(200));
     std::process::exit(1);
+}
+
+/// Run the post-mount setup shared with the legacy per-rootfs init.
+#[cfg(target_os = "linux")]
+fn bootstrap_guest_environment() -> Result<(), guest_mount::MountError> {
+    mvm_agentd::guest_bootstrap::provision_guest_environment().map_err(|_| {
+        guest_mount::MountError::GuestBootstrap(
+            "egress was required but no egress client resolved".to_string(),
+        )
+    })
+}
+
+/// The agent is PID 1 only inside a Linux guest, so there is nothing to set up
+/// on a host build. Spelled out rather than left as a `cfg`-erased call site so
+/// the Linux path cannot quietly disappear.
+#[cfg(not(target_os = "linux"))]
+fn bootstrap_guest_environment() -> Result<(), guest_mount::MountError> {
+    Ok(())
 }

--- a/crates/mvm-agentd/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-oci-init.rs
@@ -7,67 +7,26 @@
 
 #[cfg(target_os = "linux")]
 mod linux {
+    use mvm_agentd::guest_bootstrap::{
+        cmdline, cmdline_value, cstring_str, ensure_runtime_dirs, hex_decode, is_executable,
+        provision_guest_environment, runtime_source_policy, spawn_one,
+    };
     use std::ffi::{CString, OsStr};
     use std::fs;
     use std::os::unix::ffi::OsStrExt;
     use std::path::{Path, PathBuf};
-    use std::process::{Command, Stdio};
     use std::time::Duration;
 
     const AGENT_FALLBACK: &str = "/usr/local/bin/mvm-guest-agent";
     const AGENT_OVERLAY: &str = "/mvm/runtime/agent";
     const AGENT_OVERLAY_INTERACTIVE: &str = "/mvm/runtime/agent-interactive";
-    const NETINIT_FALLBACK: &str = "/usr/local/bin/mvm-guest-netinit";
-    const NETINIT_OVERLAY: &str = "/mvm/runtime/netinit";
-    const EGRESS_CLIENT: &str = "/usr/local/bin/mvm-egress-client";
-    const EGRESS_CLIENT_OVERLAY: &str = "/mvm/runtime/egress-client";
-
-    /// Tools the image ships that cannot work in this guest, and the overlay
-    /// binary that stands in for each.
-    ///
-    /// A NIC-less guest has no route and no raw socket, so the image's own
-    /// `ping` fails at `socket()` before a packet exists. The replacement is
-    /// bind-mounted over it rather than written into the image: the rootfs keeps
-    /// exactly the bytes the registry served (which is what the recorded OCI
-    /// provenance refers to), `/proc/mounts` records the substitution for anyone
-    /// who wonders, and the original stays underneath. It also reaches a caller
-    /// that runs `/bin/ping` outright, which no `PATH` order does.
-    const MEDIATED_TOOLS: &[(&str, &str)] = &[("/mvm/runtime/ping", "/bin/ping")];
-
     pub fn main() {
         mount_pseudofs();
         ensure_runtime_dirs();
         mount_user_volumes();
-        mount_mediated_tools();
-        provision_egress_ca();
-        provision_verb_grant();
         provision_host_signer_pub();
-        run_one(resolve_exec([NETINIT_OVERLAY, NETINIT_FALLBACK]), "netinit");
-        if cmdline_has_flag("mvm.vsock_egress=1") {
-            bring_loopback_up();
-            if let Err(error) = mvm_agentd::guest_net::seed_loopback_resolver() {
-                // Non-fatal: a read-only image rootfs may have no writable
-                // /etc/resolv.conf to repoint, but the workload still reaches its
-                // admitted egress through the loopback proxy. Log and continue —
-                // panicking PID 1 here would fail an otherwise-bootable VM.
-                eprintln!(
-                    "mvm-oci-init: could not point resolv.conf at the loopback DNS stub \
-                     (continuing; proxy egress is unaffected): {error}"
-                );
-            }
-            // Egress is required when this flag is set; the client is the only guest
-            // path to the admitted network. Resolve overlay-first (respecting the
-            // runtime-source policy) and fail closed rather than boot a workload that
-            // silently cannot reach its allow-listed egress.
-            let Some(egress_client) = resolve_egress_client() else {
-                eprintln!(
-                    "mvm-oci-init: mvm.vsock_egress=1 but no egress client resolved from \
-                     /mvm/runtime and no baked fallback — refusing to boot a workload that \
-                     cannot reach its admitted egress"
-                );
-                std::process::exit(1);
-            };
-            spawn_one(&egress_client, "egress-client");
+        if provision_guest_environment().is_err() {
+            std::process::exit(1);
         }
         // The guest agent is the mvm vsock control plane — the whole reason this
         // init exists (scratch/distroless/Alpine all get it from the overlay).
@@ -107,24 +66,6 @@ mod linux {
         );
     }
 
-    fn ensure_runtime_dirs() {
-        for path in [
-            "/proc",
-            "/sys",
-            "/dev",
-            "/dev/pts",
-            "/dev/shm",
-            "/run",
-            "/run/mvm",
-            "/tmp",
-            "/mvm/runtime",
-        ] {
-            if let Err(e) = fs::create_dir_all(path) {
-                eprintln!("mvm-oci-init: mkdir {path}: {e}");
-            }
-        }
-    }
-
     fn mount_user_volumes() {
         let Some(encoded) = cmdline_value("mvm.uvols") else {
             return;
@@ -137,7 +78,7 @@ mod linux {
                 eprintln!("mvm-oci-init: malformed user volume token");
                 continue;
             };
-            let Ok(path_bytes) = hex_decode(path_hex) else {
+            let Some(path_bytes) = hex_decode(path_hex) else {
                 eprintln!("mvm-oci-init: malformed user volume path");
                 continue;
             };
@@ -155,101 +96,6 @@ mod linux {
             }
             let flags = if mode == "ro" { libc::MS_RDONLY } else { 0 };
             mount_fs(tag, &upath, "virtiofs", flags, None);
-        }
-    }
-
-    /// Bind-mount each mediated tool over the image's own copy.
-    ///
-    /// Skipped silently when either side is absent: an image that ships no
-    /// `ping` has nothing to mount over (and the rootfs is read-only under
-    /// verity, so one cannot be created), and a launch shape with no runtime
-    /// overlay has no replacement to offer. In both cases the image behaves as
-    /// it would have without mvm, which is the honest outcome.
-    fn mount_mediated_tools() {
-        for (source, target) in MEDIATED_TOOLS {
-            if !Path::new(source).is_file() || !Path::new(target).exists() {
-                continue;
-            }
-            bind_mount_file(source, target);
-        }
-    }
-
-    /// `mount(source, target, NULL, MS_BIND, NULL)` over an existing file.
-    ///
-    /// Distinct from [`mount_fs`], which creates its target as a directory: the
-    /// target here is a file that must already exist, and creating it is exactly
-    /// what we are avoiding.
-    fn bind_mount_file(source: &str, target: &str) {
-        let (Some(source_c), Some(target_c)) = (cstring_str(source), cstring_str(target)) else {
-            return;
-        };
-        // SAFETY: both paths are NUL-terminated and live for the call; MS_BIND
-        // with a null fstype/data is the documented file-bind form.
-        let rc = unsafe {
-            libc::mount(
-                source_c.as_ptr(),
-                target_c.as_ptr(),
-                std::ptr::null(),
-                libc::MS_BIND,
-                std::ptr::null(),
-            )
-        };
-        if rc != 0 {
-            // Non-fatal: the workload keeps the image's own tool, which simply
-            // does not work here. Failing PID 1 over a `ping` would be worse.
-            eprintln!(
-                "mvm-oci-init: bind {source} over {target}: {}",
-                std::io::Error::last_os_error()
-            );
-        }
-    }
-
-    fn provision_egress_ca() {
-        let Some(hex) = cmdline_value("mvm.egress_ca") else {
-            return;
-        };
-        let Ok(cert) = hex_decode(&hex) else {
-            eprintln!("mvm-oci-init: malformed egress CA token");
-            return;
-        };
-        let _ = fs::create_dir_all("/run/mvm");
-        if let Err(e) = fs::write("/run/mvm/egress-ca.crt", &cert) {
-            eprintln!("mvm-oci-init: write egress CA: {e}");
-            return;
-        }
-        let mut bundle = Vec::new();
-        for candidate in [
-            "/etc/ssl/certs/ca-certificates.crt",
-            "/etc/ssl/cert.pem",
-            "/etc/ssl/certs/ca-bundle.crt",
-        ] {
-            if let Ok(bytes) = fs::read(candidate) {
-                bundle.extend_from_slice(&bytes);
-                if !bundle.ends_with(b"\n") {
-                    bundle.push(b'\n');
-                }
-                break;
-            }
-        }
-        bundle.extend_from_slice(&cert);
-        if let Err(e) = fs::write("/run/mvm/ca-bundle.crt", bundle) {
-            eprintln!("mvm-oci-init: write CA bundle: {e}");
-        }
-    }
-
-    fn provision_verb_grant() {
-        let Some(b64) = cmdline_value("mvm.verb_grant") else {
-            return;
-        };
-        // base64, not hex: the envelope is the largest cmdline token and the
-        // kernel silently truncates past COMMAND_LINE_SIZE.
-        let Ok(grant) = base64_decode(&b64) else {
-            eprintln!("mvm-oci-init: malformed verb-grant token");
-            return;
-        };
-        let _ = fs::create_dir_all("/run/mvm");
-        if let Err(e) = fs::write("/run/mvm/verb-grant.json", grant) {
-            eprintln!("mvm-oci-init: write verb grant: {e}");
         }
     }
 
@@ -313,20 +159,6 @@ mod linux {
         }
     }
 
-    fn resolve_exec<const N: usize>(candidates: [&str; N]) -> Option<PathBuf> {
-        candidates
-            .into_iter()
-            .map(PathBuf::from)
-            .find(|p| is_executable(p))
-    }
-
-    fn runtime_source_policy() -> mvm_core::vm_backend::RuntimeSourcePolicy {
-        cmdline_value("mvm.runtime_source_policy")
-            .as_deref()
-            .and_then(mvm_core::vm_backend::RuntimeSourcePolicy::from_cmdline_value)
-            .unwrap_or(mvm_core::vm_backend::RuntimeSourcePolicy::PreferOverlay)
-    }
-
     fn guest_security_profile() -> mvm_core::security::AgentProfile {
         mvm_agentd::builder_agent::load_security_policy()
             .ok()
@@ -381,222 +213,10 @@ mod linux {
             .map(Path::to_path_buf)
     }
 
-    fn resolve_egress_client() -> Option<PathBuf> {
-        resolve_egress_client_for(runtime_source_policy(), is_executable)
-    }
-
-    fn resolve_egress_client_for(
-        runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy,
-        is_exec: impl Fn(&Path) -> bool,
-    ) -> Option<PathBuf> {
-        let candidates: &[&str] = match runtime_source_policy {
-            mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay => &[EGRESS_CLIENT_OVERLAY],
-            mvm_core::vm_backend::RuntimeSourcePolicy::PreferOverlay => {
-                &[EGRESS_CLIENT_OVERLAY, EGRESS_CLIENT]
-            }
-            mvm_core::vm_backend::RuntimeSourcePolicy::RootfsOnly => &[EGRESS_CLIENT],
-        };
-        candidates
-            .iter()
-            .map(Path::new)
-            .find(|path| is_exec(path))
-            .map(Path::to_path_buf)
-    }
-
-    fn is_executable(path: &Path) -> bool {
-        path.is_file()
-            && fs::metadata(path)
-                .map(|m| {
-                    use std::os::unix::fs::PermissionsExt;
-                    m.permissions().mode() & 0o111 != 0
-                })
-                .unwrap_or(false)
-    }
-
-    fn run_one(path: Option<PathBuf>, label: &str) {
-        let Some(path) = path else {
-            return;
-        };
-        match Command::new(&path)
-            .stdin(Stdio::null())
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .status()
-        {
-            Ok(status) if status.success() => {}
-            Ok(status) => eprintln!("mvm-oci-init: {label} exited {status}"),
-            Err(e) => eprintln!("mvm-oci-init: run {label} at {}: {e}", path.display()),
-        }
-    }
-
-    fn spawn_one(path: &Path, label: &str) {
-        if !is_executable(path) {
-            eprintln!("mvm-oci-init: no executable {label} at {}", path.display());
-            return;
-        }
-        match Command::new(path)
-            .stdin(Stdio::null())
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .spawn()
-        {
-            Ok(child) => eprintln!("mvm-oci-init: spawned {label} pid={}", child.id()),
-            Err(e) => eprintln!("mvm-oci-init: spawn {label} at {}: {e}", path.display()),
-        }
-    }
-
-    fn cmdline() -> String {
-        fs::read_to_string("/proc/cmdline").unwrap_or_default()
-    }
-
-    fn cmdline_value(key: &str) -> Option<String> {
-        let prefix = format!("{key}=");
-        cmdline()
-            .split_whitespace()
-            .find_map(|part| part.strip_prefix(&prefix).map(ToOwned::to_owned))
-    }
-
-    fn cmdline_has_flag(flag: &str) -> bool {
-        cmdline().split_whitespace().any(|part| part == flag)
-    }
-
-    fn hex_decode(input: &str) -> Result<Vec<u8>, ()> {
-        let bytes = input.as_bytes();
-        if !bytes.len().is_multiple_of(2) {
-            return Err(());
-        }
-        let mut out = Vec::with_capacity(bytes.len() / 2);
-        for pair in bytes.chunks_exact(2) {
-            let hi = hex_val(pair[0])?;
-            let lo = hex_val(pair[1])?;
-            out.push((hi << 4) | lo);
-        }
-        Ok(out)
-    }
-
-    fn hex_val(b: u8) -> Result<u8, ()> {
-        match b {
-            b'0'..=b'9' => Ok(b - b'0'),
-            b'a'..=b'f' => Ok(b - b'a' + 10),
-            b'A'..=b'F' => Ok(b - b'A' + 10),
-            _ => Err(()),
-        }
-    }
-
-    /// Standard-alphabet base64 decode, hand-rolled to keep this PID 1 free of
-    /// external crates (see the module doc). Rejects a character after padding,
-    /// a trailing partial character, and non-zero padding bits.
-    fn base64_decode(input: &str) -> Result<Vec<u8>, ()> {
-        let mut acc: u32 = 0;
-        let mut nbits: u32 = 0;
-        let mut seen_pad = false;
-        let mut out = Vec::with_capacity(input.len() / 4 * 3);
-        for &b in input.as_bytes() {
-            if b.is_ascii_whitespace() {
-                continue;
-            }
-            if b == b'=' {
-                seen_pad = true;
-                continue;
-            }
-            if seen_pad {
-                return Err(());
-            }
-            acc = (acc << 6) | u32::from(base64_val(b)?);
-            nbits += 6;
-            if nbits >= 8 {
-                nbits -= 8;
-                out.push(((acc >> nbits) & 0xff) as u8);
-            }
-        }
-        // A lone trailing character carries 6 unusable bits, and whatever bits
-        // remain must be the encoder's zero padding.
-        if nbits >= 6 || acc & ((1u32 << nbits) - 1) != 0 {
-            return Err(());
-        }
-        Ok(out)
-    }
-
-    fn base64_val(b: u8) -> Result<u8, ()> {
-        match b {
-            b'A'..=b'Z' => Ok(b - b'A'),
-            b'a'..=b'z' => Ok(b - b'a' + 26),
-            b'0'..=b'9' => Ok(b - b'0' + 52),
-            b'+' => Ok(62),
-            b'/' => Ok(63),
-            _ => Err(()),
-        }
-    }
-
-    fn bring_loopback_up() {
-        if let Err(e) = mvm_agentd::guest_net::bring_iface_up("lo") {
-            eprintln!("mvm-oci-init: bring loopback up: {e}");
-        }
-        if loopback_is_up() {
-            return;
-        }
-        if bring_loopback_up_with_busybox() {
-            if loopback_is_up() {
-                return;
-            }
-            eprintln!("mvm-oci-init: busybox loopback fallback ran, but lo is still down");
-            return;
-        }
-        eprintln!("mvm-oci-init: loopback remains down (no working busybox ip/ifconfig fallback)");
-    }
-
-    fn loopback_is_up() -> bool {
-        let Ok(flags) = fs::read_to_string("/sys/class/net/lo/flags") else {
-            return false;
-        };
-        loopback_flags_indicate_up(&flags)
-    }
-
-    fn loopback_flags_indicate_up(flags: &str) -> bool {
-        let Some(hex) = flags.trim().strip_prefix("0x") else {
-            return false;
-        };
-        u32::from_str_radix(hex, 16)
-            .map(|bits| bits & (libc::IFF_UP as u32) != 0)
-            .unwrap_or(false)
-    }
-
-    fn bring_loopback_up_with_busybox() -> bool {
-        let busybox = Path::new("/bin/busybox");
-        if !is_executable(busybox) {
-            return false;
-        }
-        let ip_ok = Command::new(busybox)
-            .args(["ip", "link", "set", "lo", "up"])
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .map(|status| status.success())
-            .unwrap_or(false);
-        if ip_ok {
-            return true;
-        }
-        Command::new(busybox)
-            .args(["ifconfig", "lo", "up"])
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .map(|status| status.success())
-            .unwrap_or(false)
-    }
-
     fn idle_forever() -> ! {
         loop {
             std::thread::sleep(Duration::from_secs(2_147_483_647));
         }
-    }
-
-    fn cstring_str(s: &str) -> Option<CString> {
-        CString::new(s)
-            .map_err(|_| eprintln!("mvm-oci-init: string contains NUL"))
-            .ok()
     }
 
     fn cstring_os(s: &OsStr) -> Option<CString> {
@@ -608,41 +228,6 @@ mod linux {
     #[cfg(test)]
     mod tests {
         use super::*;
-
-        #[test]
-        fn hex_decode_accepts_lower_upper_and_rejects_bad_input() {
-            assert_eq!(hex_decode("2f62696e").unwrap(), b"/bin");
-            assert_eq!(hex_decode("2F").unwrap(), b"/");
-            assert!(hex_decode("0").is_err());
-            assert!(hex_decode("zz").is_err());
-        }
-
-        #[test]
-        fn base64_decode_round_trips_each_padding_length() {
-            // 0, 1 and 2 bytes of padding respectively.
-            assert_eq!(base64_decode("Zm9vYmFy").unwrap(), b"foobar");
-            assert_eq!(base64_decode("Zm9vYmE=").unwrap(), b"fooba");
-            assert_eq!(base64_decode("Zm9vYg==").unwrap(), b"foob");
-            assert_eq!(base64_decode("").unwrap(), b"");
-            // Both non-alphanumeric alphabet characters.
-            assert_eq!(base64_decode("+/8=").unwrap(), [0xfb, 0xff]);
-        }
-
-        #[test]
-        fn base64_decode_rejects_malformed_input() {
-            assert!(base64_decode("Zm9v!mFy").is_err(), "invalid character");
-            assert!(base64_decode("Zm9vYmFyZ").is_err(), "trailing partial char");
-            assert!(base64_decode("Zm9v=YmFy").is_err(), "data after padding");
-            // Non-zero bits under the padding.
-            assert!(base64_decode("Zm9vYh==").is_err(), "dirty padding bits");
-        }
-
-        #[test]
-        fn loopback_flags_indicate_up_reads_hex_flags() {
-            assert!(!loopback_flags_indicate_up("0x8\n"));
-            assert!(loopback_flags_indicate_up("0x9\n"));
-            assert!(!loopback_flags_indicate_up("garbage"));
-        }
 
         // The anchor writer moved to `mvm_agentd::vsock::write_host_signer_anchor`
         // so both inits share one implementation; its byte layout, 0644 mode and
@@ -685,74 +270,6 @@ mod linux {
             let got = resolve_guest_agent_for(
                 mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
                 mvm_core::security::AgentProfile::SealedProd,
-                |_path| false,
-            );
-            assert_eq!(got, None);
-        }
-
-        #[test]
-        fn resolve_egress_client_for_required_overlay_resolves_overlay() {
-            let got = resolve_egress_client_for(
-                mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
-                |path| path == Path::new(EGRESS_CLIENT_OVERLAY),
-            );
-            assert_eq!(got, Some(PathBuf::from(EGRESS_CLIENT_OVERLAY)));
-        }
-
-        #[test]
-        fn resolve_egress_client_for_required_overlay_returns_none_when_nothing_executable() {
-            // No executable candidate -> None, which main() treats as fatal
-            // (fail closed) rather than booting a workload with no egress path.
-            let got = resolve_egress_client_for(
-                mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
-                |_path| false,
-            );
-            assert_eq!(got, None);
-        }
-
-        #[test]
-        fn resolve_egress_client_for_required_overlay_does_not_fall_back_to_baked() {
-            // Only the baked path is executable; required-overlay must not accept it.
-            let got = resolve_egress_client_for(
-                mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
-                |path| path == Path::new(EGRESS_CLIENT),
-            );
-            assert_eq!(got, None);
-        }
-
-        #[test]
-        fn resolve_egress_client_for_prefer_overlay_prefers_overlay_when_both_present() {
-            let got = resolve_egress_client_for(
-                mvm_core::vm_backend::RuntimeSourcePolicy::PreferOverlay,
-                |_path| true,
-            );
-            assert_eq!(got, Some(PathBuf::from(EGRESS_CLIENT_OVERLAY)));
-        }
-
-        #[test]
-        fn resolve_egress_client_for_prefer_overlay_falls_back_to_baked() {
-            let got = resolve_egress_client_for(
-                mvm_core::vm_backend::RuntimeSourcePolicy::PreferOverlay,
-                |path| path == Path::new(EGRESS_CLIENT),
-            );
-            assert_eq!(got, Some(PathBuf::from(EGRESS_CLIENT)));
-        }
-
-        #[test]
-        fn resolve_egress_client_for_rootfs_only_ignores_overlay_and_uses_baked() {
-            // Overlay executable but policy is rootfs-only -> only the baked
-            // candidate is considered, so it wins.
-            let got = resolve_egress_client_for(
-                mvm_core::vm_backend::RuntimeSourcePolicy::RootfsOnly,
-                |path| path == Path::new(EGRESS_CLIENT_OVERLAY) || path == Path::new(EGRESS_CLIENT),
-            );
-            assert_eq!(got, Some(PathBuf::from(EGRESS_CLIENT)));
-        }
-
-        #[test]
-        fn resolve_egress_client_for_rootfs_only_returns_none_when_baked_missing() {
-            let got = resolve_egress_client_for(
-                mvm_core::vm_backend::RuntimeSourcePolicy::RootfsOnly,
                 |_path| false,
             );
             assert_eq!(got, None);

--- a/crates/mvm-agentd/src/guest_bootstrap.rs
+++ b/crates/mvm-agentd/src/guest_bootstrap.rs
@@ -1,0 +1,618 @@
+//! Guest environment setup shared by the two guest inits.
+//!
+//! Both entry points reach the same workload environment: `mvm-oci-init` as PID 1
+//! on the legacy per-rootfs initrd, and the guest agent's activation path when the
+//! universal initramfs boots it as PID 1. Keeping the steps here means neither can
+//! quietly acquire — or lose — one of them.
+
+use std::ffi::CString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// The egress client could not be resolved while egress was required.
+///
+/// Fail-closed: a workload that boots without it silently cannot reach the
+/// network its plan admitted, which reads as a policy denial rather than a
+/// missing binary.
+#[derive(Debug, PartialEq, Eq)]
+pub struct EgressClientMissing;
+
+/// Run every post-mount setup step the workload environment depends on.
+///
+/// Callers must invoke this after the rootfs is in place and while still
+/// privileged: the mounts, `/run/mvm` writes and interface changes all need root.
+pub fn provision_guest_environment() -> Result<(), EgressClientMissing> {
+    ensure_runtime_dirs();
+    mount_mediated_tools();
+    provision_egress_ca();
+    provision_verb_grant();
+    run_one(resolve_exec([NETINIT_OVERLAY, NETINIT_FALLBACK]), "netinit");
+    if cmdline_has_flag("mvm.vsock_egress=1") {
+        start_vsock_egress()?;
+    }
+    Ok(())
+}
+
+fn start_vsock_egress() -> Result<(), EgressClientMissing> {
+    bring_loopback_up();
+    if let Err(error) = crate::guest_net::seed_loopback_resolver() {
+        // Non-fatal: a read-only image rootfs may have no writable
+        // /etc/resolv.conf to repoint, but the workload still reaches its
+        // admitted egress through the loopback proxy.
+        eprintln!(
+            "mvm-guest-init: could not point resolv.conf at the loopback DNS stub \
+             (continuing; proxy egress is unaffected): {error}"
+        );
+    }
+    let Some(egress_client) = resolve_egress_client() else {
+        eprintln!(
+            "mvm-guest-init: mvm.vsock_egress=1 but no egress client resolved from \
+             /mvm/runtime and no baked fallback — refusing to boot a workload that \
+             cannot reach its admitted egress"
+        );
+        return Err(EgressClientMissing);
+    };
+    spawn_one(&egress_client, "egress-client");
+    Ok(())
+}
+
+pub const NETINIT_FALLBACK: &str = "/usr/local/bin/mvm-guest-netinit";
+
+pub const NETINIT_OVERLAY: &str = "/mvm/runtime/netinit";
+
+pub const EGRESS_CLIENT: &str = "/usr/local/bin/mvm-egress-client";
+
+pub const EGRESS_CLIENT_OVERLAY: &str = "/mvm/runtime/egress-client";
+
+/// Tools the image ships that cannot work in this guest, and the overlay
+/// binary that stands in for each.
+///
+/// A NIC-less guest has no route and no raw socket, so the image's own
+/// `ping` fails at `socket()` before a packet exists. The replacement is
+/// bind-mounted over it rather than written into the image: the rootfs keeps
+/// exactly the bytes the registry served (which is what the recorded OCI
+/// provenance refers to), `/proc/mounts` records the substitution for anyone
+/// who wonders, and the original stays underneath. It also reaches a caller
+/// that runs `/bin/ping` outright, which no `PATH` order does.
+pub const MEDIATED_TOOLS: &[(&str, &str)] = &[("/mvm/runtime/ping", "/bin/ping")];
+
+pub fn ensure_runtime_dirs() {
+    for path in [
+        "/proc",
+        "/sys",
+        "/dev",
+        "/dev/pts",
+        "/dev/shm",
+        "/run",
+        "/run/mvm",
+        "/tmp",
+        "/mvm/runtime",
+    ] {
+        if let Err(e) = fs::create_dir_all(path) {
+            eprintln!("mvm-guest-init: mkdir {path}: {e}");
+        }
+    }
+}
+
+/// Bind-mount each mediated tool over the image's own copy.
+///
+/// Skipped silently when either side is absent: an image that ships no
+/// `ping` has nothing to mount over (and the rootfs is read-only under
+/// verity, so one cannot be created), and a launch shape with no runtime
+/// overlay has no replacement to offer. In both cases the image behaves as
+/// it would have without mvm, which is the honest outcome.
+pub fn mount_mediated_tools() {
+    for (source, target) in MEDIATED_TOOLS {
+        if !Path::new(source).is_file() || !Path::new(target).exists() {
+            continue;
+        }
+        bind_mount_file(source, target);
+    }
+}
+
+/// Convert to a NUL-terminated C string for the raw mount syscalls.
+pub fn cstring_str(s: &str) -> Option<CString> {
+    CString::new(s)
+        .map_err(|_| eprintln!("mvm-guest-init: string contains NUL"))
+        .ok()
+}
+
+/// Make `target` a plain file so a later bind mount lands on it and nothing else.
+///
+/// `MS_BIND` resolves the target path, so mounting onto a symlink lands on
+/// whatever it points at. Busybox images link every applet at one binary —
+/// `/bin/ping` and `/bin/sh` both point at `/bin/busybox` — so mounting over the
+/// link would replace the shell along with the tool. Swap the link for an empty
+/// regular file first, staging then renaming so a failure leaves the image as it was.
+pub fn replace_symlink_target(target: &Path) -> Result<(), String> {
+    match fs::symlink_metadata(target) {
+        Ok(meta) if meta.file_type().is_symlink() => {}
+        // A regular file is already an exclusive path: a bind mount over one
+        // hardlink does not disturb its siblings.
+        Ok(_) => return Ok(()),
+        Err(e) => return Err(format!("stat {}: {e}", target.display())),
+    }
+    let staged = target.with_extension("mvm-mediated");
+    fs::File::create(&staged).map_err(|e| format!("create {}: {e}", staged.display()))?;
+    fs::rename(&staged, target).map_err(|e| {
+        let _ = fs::remove_file(&staged);
+        format!("replace symlink {}: {e}", target.display())
+    })
+}
+
+/// `mount(source, target, NULL, MS_BIND, NULL)` over an existing file.
+///
+/// The target must already exist as a file; creating one is exactly what this
+/// avoids, so the image keeps the bytes the registry served.
+pub fn bind_mount_file(source: &str, target: &str) {
+    if let Err(e) = replace_symlink_target(Path::new(target)) {
+        // Non-fatal, and deliberately before the mount: leaving the image's own
+        // tool in place is far better than mounting through a link.
+        eprintln!("mvm-guest-init: not substituting {target}: {e}");
+        return;
+    }
+    let (Some(source_c), Some(target_c)) = (cstring_str(source), cstring_str(target)) else {
+        return;
+    };
+    // SAFETY: both paths are NUL-terminated and live for the call; MS_BIND
+    // with a null fstype/data is the documented file-bind form.
+    let rc = unsafe {
+        libc::mount(
+            source_c.as_ptr(),
+            target_c.as_ptr(),
+            std::ptr::null(),
+            libc::MS_BIND,
+            std::ptr::null(),
+        )
+    };
+    if rc != 0 {
+        // Non-fatal: the workload keeps the image's own tool, which simply
+        // does not work here. Failing PID 1 over a `ping` would be worse.
+        eprintln!(
+            "mvm-guest-init: bind {source} over {target}: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+}
+
+pub fn provision_egress_ca() {
+    let Some(hex) = cmdline_value("mvm.egress_ca") else {
+        return;
+    };
+    let Some(cert) = hex_decode(&hex) else {
+        eprintln!("mvm-guest-init: malformed egress CA token");
+        return;
+    };
+    let _ = fs::create_dir_all("/run/mvm");
+    if let Err(e) = fs::write("/run/mvm/egress-ca.crt", &cert) {
+        eprintln!("mvm-guest-init: write egress CA: {e}");
+        return;
+    }
+    let mut bundle = Vec::new();
+    for candidate in [
+        "/etc/ssl/certs/ca-certificates.crt",
+        "/etc/ssl/cert.pem",
+        "/etc/ssl/certs/ca-bundle.crt",
+    ] {
+        if let Ok(bytes) = fs::read(candidate) {
+            bundle.extend_from_slice(&bytes);
+            if !bundle.ends_with(b"\n") {
+                bundle.push(b'\n');
+            }
+            break;
+        }
+    }
+    bundle.extend_from_slice(&cert);
+    if let Err(e) = fs::write("/run/mvm/ca-bundle.crt", bundle) {
+        eprintln!("mvm-guest-init: write CA bundle: {e}");
+    }
+}
+
+pub fn provision_verb_grant() {
+    let Some(b64) = cmdline_value("mvm.verb_grant") else {
+        return;
+    };
+    // base64, not hex: the envelope is the largest cmdline token and the
+    // kernel silently truncates past COMMAND_LINE_SIZE.
+    let Some(grant) = base64_decode(&b64) else {
+        eprintln!("mvm-guest-init: malformed verb-grant token");
+        return;
+    };
+    let _ = fs::create_dir_all("/run/mvm");
+    if let Err(e) = fs::write("/run/mvm/verb-grant.json", grant) {
+        eprintln!("mvm-guest-init: write verb grant: {e}");
+    }
+}
+
+pub fn resolve_exec<const N: usize>(candidates: [&str; N]) -> Option<PathBuf> {
+    candidates
+        .into_iter()
+        .map(PathBuf::from)
+        .find(|p| is_executable(p))
+}
+
+pub fn runtime_source_policy() -> mvm_core::vm_backend::RuntimeSourcePolicy {
+    cmdline_value("mvm.runtime_source_policy")
+        .as_deref()
+        .and_then(mvm_core::vm_backend::RuntimeSourcePolicy::from_cmdline_value)
+        .unwrap_or(mvm_core::vm_backend::RuntimeSourcePolicy::PreferOverlay)
+}
+
+pub fn resolve_egress_client() -> Option<PathBuf> {
+    resolve_egress_client_for(runtime_source_policy(), is_executable)
+}
+
+pub fn resolve_egress_client_for(
+    runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy,
+    is_exec: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    let candidates: &[&str] = match runtime_source_policy {
+        mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay => &[EGRESS_CLIENT_OVERLAY],
+        mvm_core::vm_backend::RuntimeSourcePolicy::PreferOverlay => {
+            &[EGRESS_CLIENT_OVERLAY, EGRESS_CLIENT]
+        }
+        mvm_core::vm_backend::RuntimeSourcePolicy::RootfsOnly => &[EGRESS_CLIENT],
+    };
+    candidates
+        .iter()
+        .map(Path::new)
+        .find(|path| is_exec(path))
+        .map(Path::to_path_buf)
+}
+
+pub fn is_executable(path: &Path) -> bool {
+    path.is_file()
+        && fs::metadata(path)
+            .map(|m| {
+                use std::os::unix::fs::PermissionsExt;
+                m.permissions().mode() & 0o111 != 0
+            })
+            .unwrap_or(false)
+}
+
+pub fn run_one(path: Option<PathBuf>, label: &str) {
+    let Some(path) = path else {
+        return;
+    };
+    match Command::new(&path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+    {
+        Ok(status) if status.success() => {}
+        Ok(status) => eprintln!("mvm-guest-init: {label} exited {status}"),
+        Err(e) => eprintln!("mvm-guest-init: run {label} at {}: {e}", path.display()),
+    }
+}
+
+pub fn spawn_one(path: &Path, label: &str) {
+    if !is_executable(path) {
+        eprintln!(
+            "mvm-guest-init: no executable {label} at {}",
+            path.display()
+        );
+        return;
+    }
+    match Command::new(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+    {
+        Ok(child) => eprintln!("mvm-guest-init: spawned {label} pid={}", child.id()),
+        Err(e) => eprintln!("mvm-guest-init: spawn {label} at {}: {e}", path.display()),
+    }
+}
+
+pub fn cmdline() -> String {
+    fs::read_to_string("/proc/cmdline").unwrap_or_default()
+}
+
+pub fn cmdline_value(key: &str) -> Option<String> {
+    let prefix = format!("{key}=");
+    cmdline()
+        .split_whitespace()
+        .find_map(|part| part.strip_prefix(&prefix).map(ToOwned::to_owned))
+}
+
+pub fn cmdline_has_flag(flag: &str) -> bool {
+    cmdline().split_whitespace().any(|part| part == flag)
+}
+
+pub fn hex_decode(input: &str) -> Option<Vec<u8>> {
+    let bytes = input.as_bytes();
+    if !bytes.len().is_multiple_of(2) {
+        return None;
+    }
+    let mut out = Vec::with_capacity(bytes.len() / 2);
+    for pair in bytes.chunks_exact(2) {
+        let hi = hex_val(pair[0])?;
+        let lo = hex_val(pair[1])?;
+        out.push((hi << 4) | lo);
+    }
+    Some(out)
+}
+
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Standard-alphabet base64 decode, hand-rolled to keep this PID 1 free of
+/// external crates (see the module doc). Rejects a character after padding,
+/// a trailing partial character, and non-zero padding bits.
+fn base64_decode(input: &str) -> Option<Vec<u8>> {
+    let mut acc: u32 = 0;
+    let mut nbits: u32 = 0;
+    let mut seen_pad = false;
+    let mut out = Vec::with_capacity(input.len() / 4 * 3);
+    for &b in input.as_bytes() {
+        if b.is_ascii_whitespace() {
+            continue;
+        }
+        if b == b'=' {
+            seen_pad = true;
+            continue;
+        }
+        if seen_pad {
+            return None;
+        }
+        acc = (acc << 6) | u32::from(base64_val(b)?);
+        nbits += 6;
+        if nbits >= 8 {
+            nbits -= 8;
+            out.push(((acc >> nbits) & 0xff) as u8);
+        }
+    }
+    // A lone trailing character carries 6 unusable bits, and whatever bits
+    // remain must be the encoder's zero padding.
+    if nbits >= 6 || acc & ((1u32 << nbits) - 1) != 0 {
+        return None;
+    }
+    Some(out)
+}
+
+fn base64_val(b: u8) -> Option<u8> {
+    match b {
+        b'A'..=b'Z' => Some(b - b'A'),
+        b'a'..=b'z' => Some(b - b'a' + 26),
+        b'0'..=b'9' => Some(b - b'0' + 52),
+        b'+' => Some(62),
+        b'/' => Some(63),
+        _ => None,
+    }
+}
+
+pub fn bring_loopback_up() {
+    if let Err(e) = crate::guest_net::bring_iface_up("lo") {
+        eprintln!("mvm-guest-init: bring loopback up: {e}");
+    }
+    if loopback_is_up() {
+        return;
+    }
+    if bring_loopback_up_with_busybox() {
+        if loopback_is_up() {
+            return;
+        }
+        eprintln!("mvm-guest-init: busybox loopback fallback ran, but lo is still down");
+        return;
+    }
+    eprintln!("mvm-guest-init: loopback remains down (no working busybox ip/ifconfig fallback)");
+}
+
+pub fn loopback_is_up() -> bool {
+    let Ok(flags) = fs::read_to_string("/sys/class/net/lo/flags") else {
+        return false;
+    };
+    loopback_flags_indicate_up(&flags)
+}
+
+pub fn loopback_flags_indicate_up(flags: &str) -> bool {
+    let Some(hex) = flags.trim().strip_prefix("0x") else {
+        return false;
+    };
+    u32::from_str_radix(hex, 16)
+        .map(|bits| bits & (libc::IFF_UP as u32) != 0)
+        .unwrap_or(false)
+}
+
+pub fn bring_loopback_up_with_busybox() -> bool {
+    let busybox = Path::new("/bin/busybox");
+    if !is_executable(busybox) {
+        return false;
+    }
+    let ip_ok = Command::new(busybox)
+        .args(["ip", "link", "set", "lo", "up"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false);
+    if ip_ok {
+        return true;
+    }
+    Command::new(busybox)
+        .args(["ifconfig", "lo", "up"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_decode_accepts_lower_upper_and_rejects_bad_input() {
+        assert_eq!(hex_decode("2f62696e").unwrap(), b"/bin");
+        assert_eq!(hex_decode("2F").unwrap(), b"/");
+        assert!(hex_decode("0").is_none());
+        assert!(hex_decode("zz").is_none());
+    }
+
+    #[test]
+    fn base64_decode_round_trips_each_padding_length() {
+        // 0, 1 and 2 bytes of padding respectively.
+        assert_eq!(base64_decode("Zm9vYmFy").unwrap(), b"foobar");
+        assert_eq!(base64_decode("Zm9vYmE=").unwrap(), b"fooba");
+        assert_eq!(base64_decode("Zm9vYg==").unwrap(), b"foob");
+        assert_eq!(base64_decode("").unwrap(), b"");
+        // Both non-alphanumeric alphabet characters.
+        assert_eq!(base64_decode("+/8=").unwrap(), [0xfb, 0xff]);
+    }
+
+    #[test]
+    fn base64_decode_rejects_malformed_input() {
+        assert!(base64_decode("Zm9v!mFy").is_none(), "invalid character");
+        assert!(
+            base64_decode("Zm9vYmFyZ").is_none(),
+            "trailing partial char"
+        );
+        assert!(base64_decode("Zm9v=YmFy").is_none(), "data after padding");
+        // Non-zero bits under the padding.
+        assert!(base64_decode("Zm9vYh==").is_none(), "dirty padding bits");
+    }
+
+    #[test]
+    fn loopback_flags_indicate_up_reads_hex_flags() {
+        assert!(!loopback_flags_indicate_up("0x8\n"));
+        assert!(loopback_flags_indicate_up("0x9\n"));
+        assert!(!loopback_flags_indicate_up("garbage"));
+    }
+
+    #[test]
+    fn resolve_egress_client_for_required_overlay_resolves_overlay() {
+        let got = resolve_egress_client_for(
+            mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
+            |path| path == Path::new(EGRESS_CLIENT_OVERLAY),
+        );
+        assert_eq!(got, Some(PathBuf::from(EGRESS_CLIENT_OVERLAY)));
+    }
+
+    #[test]
+    fn resolve_egress_client_for_required_overlay_returns_none_when_nothing_executable() {
+        // No executable candidate -> None, which main() treats as fatal
+        // (fail closed) rather than booting a workload with no egress path.
+        let got = resolve_egress_client_for(
+            mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
+            |_path| false,
+        );
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn resolve_egress_client_for_required_overlay_does_not_fall_back_to_baked() {
+        // Only the baked path is executable; required-overlay must not accept it.
+        let got = resolve_egress_client_for(
+            mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
+            |path| path == Path::new(EGRESS_CLIENT),
+        );
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn resolve_egress_client_for_prefer_overlay_prefers_overlay_when_both_present() {
+        let got = resolve_egress_client_for(
+            mvm_core::vm_backend::RuntimeSourcePolicy::PreferOverlay,
+            |_path| true,
+        );
+        assert_eq!(got, Some(PathBuf::from(EGRESS_CLIENT_OVERLAY)));
+    }
+
+    #[test]
+    fn resolve_egress_client_for_prefer_overlay_falls_back_to_baked() {
+        let got = resolve_egress_client_for(
+            mvm_core::vm_backend::RuntimeSourcePolicy::PreferOverlay,
+            |path| path == Path::new(EGRESS_CLIENT),
+        );
+        assert_eq!(got, Some(PathBuf::from(EGRESS_CLIENT)));
+    }
+
+    #[test]
+    fn resolve_egress_client_for_rootfs_only_ignores_overlay_and_uses_baked() {
+        // Overlay executable but policy is rootfs-only -> only the baked
+        // candidate is considered, so it wins.
+        let got = resolve_egress_client_for(
+            mvm_core::vm_backend::RuntimeSourcePolicy::RootfsOnly,
+            |path| path == Path::new(EGRESS_CLIENT_OVERLAY) || path == Path::new(EGRESS_CLIENT),
+        );
+        assert_eq!(got, Some(PathBuf::from(EGRESS_CLIENT)));
+    }
+
+    #[test]
+    fn resolve_egress_client_for_rootfs_only_returns_none_when_baked_missing() {
+        let got = resolve_egress_client_for(
+            mvm_core::vm_backend::RuntimeSourcePolicy::RootfsOnly,
+            |_path| false,
+        );
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn replace_symlink_target_swaps_a_symlink_for_a_regular_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let busybox = dir.path().join("busybox");
+        fs::write(&busybox, b"multi-call binary").unwrap();
+        let ping = dir.path().join("ping");
+        std::os::unix::fs::symlink(&busybox, &ping).unwrap();
+
+        replace_symlink_target(&ping).unwrap();
+
+        // The link is gone, so a bind mount here cannot reach busybox...
+        assert!(
+            !fs::symlink_metadata(&ping)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        // ...and busybox itself is untouched, which is what keeps `sh` working.
+        assert_eq!(fs::read(&busybox).unwrap(), b"multi-call binary");
+    }
+
+    #[test]
+    fn replace_symlink_target_leaves_a_regular_file_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let ping = dir.path().join("ping");
+        fs::write(&ping, b"real ping").unwrap();
+
+        replace_symlink_target(&ping).unwrap();
+
+        assert_eq!(fs::read(&ping).unwrap(), b"real ping");
+    }
+
+    #[test]
+    fn replace_symlink_target_reports_a_missing_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = replace_symlink_target(&dir.path().join("absent")).unwrap_err();
+        assert!(err.contains("stat"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn replace_symlink_target_leaves_no_staging_file_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("ping");
+        std::os::unix::fs::symlink(dir.path().join("busybox"), &target).unwrap();
+
+        replace_symlink_target(&target).unwrap();
+
+        let leftovers: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .filter(|n| n.to_string_lossy().contains("mvm-mediated"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "staging file left behind: {leftovers:?}"
+        );
+    }
+}

--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -37,6 +37,13 @@ pub enum MountError {
     /// The activation message itself is contradictory or malformed.
     #[error("invalid activation config: {0}")]
     InvalidConfig(String),
+    /// Post-mount guest setup failed, so the workload environment is incomplete.
+    ///
+    /// Fail closed: booting on would hand the workload an environment missing
+    /// the egress path its plan admitted, which the workload cannot tell apart
+    /// from a policy denial.
+    #[error("guest bootstrap failed: {0}")]
+    GuestBootstrap(String),
 }
 
 impl MountError {

--- a/crates/mvm-agentd/src/lib.rs
+++ b/crates/mvm-agentd/src/lib.rs
@@ -43,6 +43,10 @@ pub mod fs_rpc;
 /// normal wake) the guest reseeds its CSPRNG so two clones don't generate
 /// identical key material.
 pub mod genid;
+/// Post-mount guest environment setup shared by the two guest inits, so the
+/// legacy per-rootfs initrd and the universal-initramfs agent cannot drift.
+#[cfg(target_os = "linux")]
+pub mod guest_bootstrap;
 pub mod guest_mount;
 /// Shared in-guest network bring-up (eth0 up + DHCP + static fallback), used by
 /// both the builder VM init and the workload guest netinit.

--- a/specs/plans/270-universal-initramfs-vsock-activated-boot.md
+++ b/specs/plans/270-universal-initramfs-vsock-activated-boot.md
@@ -466,6 +466,51 @@ though that switch no longer controlled `build.rs`.
 
 ---
 
+## Task 8: Carry the non-mount guest setup onto the universal path
+
+The plan replaces `mvm-oci-init`, but its steps were only ever enumerated as
+mounting. `mvm-oci-init` also provisioned the workload environment, and the
+universal path silently shipped without any of it: on the default boot the
+workload got no `/etc/resolv.conf`, `lo` down, and nothing listening on the
+loopback proxy port, so every egress attempt failed while the proxy environment
+variables were still exported. The host-signer anchor was the one step ported,
+because it alone blocked boot loudly.
+
+- [x] **Step 1: Extract the shared steps**
+  `crates/mvm-agentd/src/guest_bootstrap.rs` owns the post-mount setup —
+  mediated tools, egress CA, verb grant, netinit, loopback + resolver, egress
+  client — as one `provision_guest_environment()`. Both inits call it, so
+  neither can acquire or lose a step alone.
+- [x] **Step 2: Invoke it from the agent's activation**
+  `apply_activation` runs it after the pivot (it writes into the workload root)
+  and before the privilege drop (mounts and interface changes need root).
+- [x] **Step 3: Fail closed**
+  A required-but-unresolvable egress client aborts activation via
+  `MountError::GuestBootstrap` rather than booting a workload that cannot
+  reach its admitted egress.
+- [x] **Step 4: Stop the mediated-tool mount from following symlinks**
+  `MS_BIND` resolves its target, so mounting over `/bin/ping` on a busybox image
+  landed on `/bin/busybox` and replaced every applet — `sh` included. The step
+  had never run on the universal path, so this stayed latent until Step 2 wired
+  it up. `replace_symlink_target` swaps the link for a plain file first and
+  declines the substitution when it cannot, leaving the image's own tool alone.
+- [ ] **Step 5: Deliver mediated tools on a read-only rootfs**
+  A verity-sealed rootfs cannot be written, so the symlink cannot be replaced
+  and `/bin/ping` stays busybox — which fails at `socket()` in a NIC-less guest.
+  `/mvm/runtime/ping` works when invoked directly. Prepending the runtime
+  overlay to the workload `PATH` would cover unqualified `ping`; an absolute
+  `/bin/ping` needs something else.
+- [ ] **Step 6: Regression witness**
+  A live or BDD scenario asserting the workload environment is complete on the
+  universal path, so this cannot regress silently a second time.
+
+Live verification on macOS/HVF, `machine run --image alpine`:
+`wget https://example.com` returns the page (`Network unreachable` before),
+`lo` is up, `/run/mvm` carries the signer anchor and resolver, and
+`/mvm/runtime/ping -c 2 google.com` reports 0% packet loss.
+
+---
+
 ## Acceptance gate
 
 - `cargo nextest run --workspace` green.


### PR DESCRIPTION
## What

The universal initramfs made the agent PID 1 and replaced `mvm-oci-init`, but only `mvm-oci-init`'s **mounting** was carried over. Everything else it did was silently dropped from the default boot path:

| step | consequence on `main` |
| --- | --- |
| `bring_loopback_up` | `lo` down → `Network unreachable` |
| `seed_loopback_resolver` | no `/etc/resolv.conf` |
| spawn `egress-client` | nothing on `127.0.0.1:1080` → **all egress dead** |
| `provision_egress_ca` | HTTPS substitution has no CA |
| `provision_verb_grant` | plan-bound verb enforcement unprovisioned |
| `mount_mediated_tools` | tool substitution never applied |
| `netinit` | not run |

The host-signer anchor was the one step ported, because it alone failed the boot loudly. The result was a workload that booted fine and could reach nothing — while still receiving all eight proxy environment variables pointing at a dead port, so failures read as `Network unreachable` rather than as policy denials.

## How

Extract the steps into `mvm-agentd`'s `guest_bootstrap` so both inits share one copy — two inits drifting is how the steps went missing in the first place. `apply_activation` runs them after the pivot (they write into the workload root) and before the privilege drop (they need root). `mvm-oci-init` goes 771 → 296 lines.

Fail-closed is preserved: a required-but-unresolvable egress client aborts activation via `MountError::GuestBootstrap` rather than booting a workload that cannot reach its admitted egress.

## A bug this exposed

Wiring the substitution up surfaced a defect in it. `MS_BIND` resolves its target, and `/bin/ping` on a busybox image is a symlink to `/bin/busybox` — so the mount replaced **every applet, `sh` included**. The first live run failed with `mvm-ping: -c value "...export HTTP_PROXY..." is not a number`: the shell wrapper had been executed by the ping binary. It had never run on this path, so it had never been reached.

`replace_symlink_target` swaps the link for a plain file first and declines the substitution when it cannot, leaving the image's own tool alone.

## Known limitation

On a verity-sealed read-only rootfs the symlink cannot be replaced, so `/bin/ping` stays busybox and fails at `socket()` in a NIC-less guest. `/mvm/runtime/ping` works when invoked directly. Tracked as an unticked step in plan 270 rather than claimed done.

## Verification

Live on macOS/HVF, `machine run --image alpine`:

| check | before | after |
| --- | --- | --- |
| `wget https://example.com` | `Network unreachable` | returns the page |
| `lo` | down | `<LOOPBACK,UP,LOWER_UP>` |
| `/run/mvm` | absent | signer anchor + resolver |
| `/mvm/runtime/ping -c 2 google.com` | n/a | 0% packet loss |

`cargo nextest run --workspace` 8603/8603 green, `cargo clippy --workspace --all-targets` clean, nightly `cargo fmt --all --check` clean, and `check-no-spec-refs-in-comments` / `check-guest-binary-lists` / `check-test-home-isolation` / `check-vsock-only-egress` / `check-uniform-vsock-egress` / `check-single-home` all pass. Four new tests cover the symlink guard.