### PR TITLE
Fix orphaned helper process lifecycle

### DIFF
--- a/crates/mvm-cli/src/commands/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/bootstrap.rs
@@ -56,6 +56,14 @@ pub(in crate::commands) fn run_builder_egress_supervisor(
     args: BuilderEgressSupervisorArgs,
     _cfg: &MvmConfig,
 ) -> Result<()> {
+    run_builder_egress_supervisor_inner(&args, mvm_hostd::parent_death::exit_when_orphaned)
+}
+
+fn run_builder_egress_supervisor_inner(
+    args: &BuilderEgressSupervisorArgs,
+    arm_parent_death: impl FnOnce(),
+) -> Result<()> {
+    arm_parent_death();
     let status = Command::new(&args.endpoint)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
@@ -77,4 +85,30 @@ pub(in crate::commands) fn run_builder_egress_supervisor(
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    #[test]
+    fn builder_egress_supervisor_arms_parent_watchdog_before_spawn() {
+        let watchdog_armed = Cell::new(false);
+        let args = BuilderEgressSupervisorArgs {
+            endpoint: PathBuf::from("/definitely/missing/mvm-substitution-endpoint"),
+        };
+
+        let error = run_builder_egress_supervisor_inner(&args, || watchdog_armed.set(true))
+            .expect_err("missing endpoint must fail");
+
+        assert!(watchdog_armed.get(), "parent watchdog must arm first");
+        assert!(
+            error
+                .to_string()
+                .contains("running builder egress endpoint"),
+            "spawn failure should retain endpoint context: {error:#}"
+        );
+    }
 }

--- a/crates/mvm-cli/src/commands/env/builder_vm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm.rs
@@ -82,7 +82,8 @@ use stage0_cache::{
 pub(in crate::commands) use vm_helpers::sweep_orphaned_vm_helpers_on_startup;
 #[cfg(test)]
 use vm_helpers::{
-    BUILDER_SIDECARS, ProcSnapshot, WORKLOAD_SIDECARS, pid_is_alive, reap_orphaned_vm_helpers_at,
+    BUILDER_SIDECARS, ProcSnapshot, WORKLOAD_SIDECARS, pid_is_alive,
+    reap_orphaned_builder_egress_supervisors, reap_orphaned_vm_helpers_at,
     reap_orphaned_vm_helpers_at_with_snapshot,
 };
 

--- a/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
@@ -610,6 +610,75 @@ mod reap_orphans_tests {
         );
         assert!(!vm.exists(), "ephemeral builder dir should be gone");
     }
+
+    #[test]
+    fn startup_reaps_builder_egress_supervisor_from_another_worktree() {
+        let pid = std::process::id() as i32;
+        let command = concat!(
+            "/tmp/other-worktree/target/debug/mvmctl ",
+            "__builder-egress-supervisor --endpoint ",
+            "/tmp/other-worktree/target/debug/mvm-substitution-endpoint"
+        );
+        let snapshot = ProcSnapshot::from_parts(
+            [(pid, 1)].into_iter().collect(),
+            vec![(pid, command.to_string())],
+        );
+
+        assert_eq!(
+            reap_orphaned_builder_egress_supervisors(true, &snapshot),
+            1,
+            "a launchd-parented builder egress wrapper is orphaned regardless of worktree"
+        );
+    }
+
+    #[test]
+    fn startup_spares_owned_or_unrelated_mvmctl_processes() {
+        let pid = std::process::id() as i32;
+        let wrapper = concat!(
+            "/tmp/worktree/target/debug/mvmctl ",
+            "__builder-egress-supervisor --endpoint /tmp/endpoint"
+        );
+        let owned = ProcSnapshot::from_parts(
+            [(pid, 42)].into_iter().collect(),
+            vec![(pid, wrapper.to_string())],
+        );
+        let unrelated = ProcSnapshot::from_parts(
+            [(pid, 1)].into_iter().collect(),
+            vec![(
+                pid,
+                "/tmp/worktree/target/debug/mvmctl machine ls".to_string(),
+            )],
+        );
+        let spoofed_executable = ProcSnapshot::from_parts(
+            [(pid, 1)].into_iter().collect(),
+            vec![(
+                pid,
+                "/tmp/worktree/target/debug/not-mvmctl __builder-egress-supervisor".to_string(),
+            )],
+        );
+        let later_argument = ProcSnapshot::from_parts(
+            [(pid, 1)].into_iter().collect(),
+            vec![(
+                pid,
+                "/tmp/worktree/target/debug/mvmctl machine run __builder-egress-supervisor"
+                    .to_string(),
+            )],
+        );
+
+        assert_eq!(reap_orphaned_builder_egress_supervisors(true, &owned), 0);
+        assert_eq!(
+            reap_orphaned_builder_egress_supervisors(true, &unrelated),
+            0
+        );
+        assert_eq!(
+            reap_orphaned_builder_egress_supervisors(true, &spoofed_executable),
+            0
+        );
+        assert_eq!(
+            reap_orphaned_builder_egress_supervisors(true, &later_argument),
+            0
+        );
+    }
 }
 
 #[cfg(all(test, feature = "builder-vm"))]

--- a/crates/mvm-cli/src/commands/env/builder_vm/vm_helpers.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/vm_helpers.rs
@@ -30,6 +30,12 @@ pub(in crate::commands) struct ReapOutcome {
 /// leftover-Vz-dir case: a future refactor that narrows the traversal or
 /// renames the sidecar must update that test.
 ///
+/// The persistent builder egress wrapper is the one exception to root-scoped
+/// discovery. Its exact argv identifies an internal process whose owner is
+/// always a live `BuilderVsockEgressEndpoint` guard. A wrapper reparented to
+/// init/launchd is therefore unambiguously orphaned, so the same snapshot also
+/// finds and reaps those wrappers across worktree-specific `MVM_HOME` roots.
+///
 /// A microVM is several processes: the supervisor (the VMM-host that
 /// owns the guest) plus dependent helpers (for example a
 /// `tail -F console.log` reader). The supervisor is the authoritative
@@ -134,7 +140,48 @@ fn reap_orphaned_vm_helpers_both_roots(
     out.killed += workload.killed;
     out.removed_dirs += workload.removed_dirs;
     out.freed_bytes += workload.freed_bytes;
+    out.killed += reap_orphaned_builder_egress_supervisors(dry_run, &snapshot);
     Ok(out)
+}
+
+const BUILDER_EGRESS_SUPERVISOR_SUBCOMMAND: &str = "__builder-egress-supervisor";
+
+fn is_builder_egress_supervisor(command: &str) -> bool {
+    let mut fields = command.split_whitespace();
+    let Some(executable) = fields.next() else {
+        return false;
+    };
+    std::path::Path::new(executable)
+        .file_name()
+        .is_some_and(|name| name == "mvmctl")
+        && fields.next() == Some(BUILDER_EGRESS_SUPERVISOR_SUBCOMMAND)
+}
+
+pub(super) fn reap_orphaned_builder_egress_supervisors(
+    dry_run: bool,
+    snapshot: &ProcSnapshot,
+) -> u64 {
+    let victims: Vec<i32> = snapshot
+        .cmds
+        .iter()
+        .filter(|(pid, command)| {
+            snapshot.parent(*pid) == Some(1) && is_builder_egress_supervisor(command)
+        })
+        .map(|(pid, _)| *pid)
+        .collect();
+
+    if !dry_run {
+        for pid in &victims {
+            // SAFETY: the fresh process snapshot proves this is the exact
+            // init-parented internal wrapper. SIGTERM is the wrapper's normal
+            // shutdown path and lets its endpoint child observe parent death.
+            unsafe {
+                libc::kill(*pid, libc::SIGTERM);
+            }
+        }
+    }
+
+    u64::try_from(victims.len()).expect("process count fits in u64")
 }
 
 #[cfg(test)]

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -360,6 +360,10 @@ pub fn host_agent_root() -> std::path::PathBuf {
     std::path::PathBuf::from(mvm_home()).join("host-agent")
 }
 
+/// Per-VM marker containing the supervisor PID-file path that owns a
+/// host-agent registration.
+pub const HOST_AGENT_OWNER_PID_REF_FILE: &str = "host-agent.owner-pid";
+
 /// Per-tenant host-agent daemon directory: `<mvm_home>/host-agent/<tenant>/`.
 /// Holds the resident daemon's control UDS, pid file, worker pid file, and
 /// spawn lock — one set per tenant, so the daemon is `O(active tenants)` not

--- a/crates/mvm-hostd/src/broker/daemon.rs
+++ b/crates/mvm-hostd/src/broker/daemon.rs
@@ -250,6 +250,33 @@ impl HostAgentDaemon {
         self.vms.len()
     }
 
+    /// Drop registrations whose VM state no longer has a live supervisor.
+    ///
+    /// A crashed CLI can miss the signed deregistration request. Without this
+    /// backstop, the persisted registration keeps the resident daemon and its
+    /// signer helper alive forever. Registrations from older clients without
+    /// an ownership marker fail open while their state directory still exists.
+    pub fn reap_dead_registrations(&mut self) -> Result<usize> {
+        let dead: Vec<String> = self
+            .registrations
+            .iter()
+            .filter(|(_, registration)| registration_owner_is_dead(registration))
+            .map(|(vm_id, _)| vm_id.clone())
+            .collect();
+
+        for vm_id in &dead {
+            self.vms.remove(vm_id);
+            self.registrations.remove(vm_id);
+            if let Err(e) = self.deregister_helper_vm(vm_id) {
+                warn!(vm_id = %vm_id, error = %e, "dead VM signer-helper deregister failed");
+            }
+        }
+        if !dead.is_empty() {
+            self.persist_registrations()?;
+        }
+        Ok(dead.len())
+    }
+
     /// Snapshot of the currently-registered VM ids (bound + serving). The
     /// health watcher reads this each pass to decide which guests to probe.
     pub fn registered_vm_ids(&self) -> Vec<String> {
@@ -519,6 +546,27 @@ impl HostAgentDaemon {
     }
 }
 
+fn registration_owner_is_dead(registration: &RegisterVm) -> bool {
+    let Some(head_path) = registration.workload_chain_head_path.as_deref() else {
+        return false;
+    };
+    let Some(state_dir) = Path::new(head_path).parent() else {
+        return false;
+    };
+    if !state_dir.exists() {
+        return true;
+    }
+    let reference = state_dir.join(mvm_core::config::HOST_AGENT_OWNER_PID_REF_FILE);
+    let Ok(bytes) = std::fs::read(reference) else {
+        return false;
+    };
+    let Ok(pid_path) = serde_json::from_slice::<PathBuf>(&bytes) else {
+        return false;
+    };
+    pid_path.parent() == Some(state_dir)
+        && !mvm_runtime::vm::reconcile::pid_file_has_live_process(&pid_path)
+}
+
 /// Validate a `vm_id` is safe to embed in a filesystem path: a non-empty DNS-
 /// label-shaped token (alphanumeric plus `-`/`_`), no separators, no traversal.
 fn validate_vm_id(vm_id: &str) -> Result<()> {
@@ -712,6 +760,82 @@ mod tests {
         assert!(!d.is_registered("vm-1"));
         // Drop runs synchronously on remove → socket file gone.
         assert!(!sock.exists(), "broker socket unbound");
+    }
+
+    #[tokio::test]
+    async fn dead_registration_is_reaped_and_removed_from_journal() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal_path = dir.path().join("registrations.json");
+        let mut d = daemon("local").with_registration_journal(&journal_path);
+        let reg = register(dir.path(), "dead-vm", "local", None);
+        let owner_pid_path = dir.path().join("hvf.pid");
+        std::fs::write(
+            dir.path()
+                .join(mvm_core::config::HOST_AGENT_OWNER_PID_REF_FILE),
+            serde_json::to_vec(&owner_pid_path).unwrap(),
+        )
+        .unwrap();
+        let sock = PathBuf::from(&reg.broker_listen_socket);
+
+        d.apply(&ControlRequest::Register(reg)).unwrap();
+
+        assert_eq!(d.reap_dead_registrations().unwrap(), 1);
+        assert_eq!(d.registration_count(), 0);
+        assert!(!sock.exists(), "dead registration must unbind its socket");
+        assert!(
+            RegistrationJournal::new(journal_path)
+                .load()
+                .unwrap()
+                .is_empty(),
+            "dead registration must be removed from the restart journal"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_supervisor_pid_spares_registration() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("hvf.pid"), std::process::id().to_string()).unwrap();
+        let mut d = daemon("local");
+        let reg = register(dir.path(), "live-vm", "local", None);
+        let owner_pid_path = dir.path().join("hvf.pid");
+        std::fs::write(
+            dir.path()
+                .join(mvm_core::config::HOST_AGENT_OWNER_PID_REF_FILE),
+            serde_json::to_vec(&owner_pid_path).unwrap(),
+        )
+        .unwrap();
+
+        d.apply(&ControlRequest::Register(reg)).unwrap();
+
+        assert_eq!(d.reap_dead_registrations().unwrap(), 0);
+        assert!(d.is_registered("live-vm"));
+    }
+
+    #[tokio::test]
+    async fn legacy_registration_without_owner_path_fails_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut d = daemon("local");
+        let reg = register(dir.path(), "legacy-vm", "local", None);
+
+        d.apply(&ControlRequest::Register(reg)).unwrap();
+
+        assert_eq!(d.reap_dead_registrations().unwrap(), 0);
+        assert!(d.is_registered("legacy-vm"));
+    }
+
+    #[test]
+    fn registration_with_missing_state_directory_is_dead() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut reg = register(dir.path(), "missing-vm", "local", None);
+        reg.workload_chain_head_path = Some(
+            dir.path()
+                .join("removed-state")
+                .join("audit-signer.head")
+                .to_string_lossy()
+                .into_owned(),
+        );
+
+        assert!(registration_owner_is_dead(&reg));
     }
 
     #[test]

--- a/crates/mvm-hostd/src/host_agent_idle.rs
+++ b/crates/mvm-hostd/src/host_agent_idle.rs
@@ -89,7 +89,13 @@ pub async fn run_idle_watcher(daemon: Arc<Mutex<HostAgentDaemon>>, timeout: Opti
     const PROBE: Duration = Duration::from_millis(500);
     let mut zero_since: Option<Instant> = None;
     loop {
-        let count = daemon.lock().await.registration_count();
+        let count = {
+            let mut daemon = daemon.lock().await;
+            if let Err(error) = daemon.reap_dead_registrations() {
+                tracing::warn!(%error, "dead host-agent registration reap failed");
+            }
+            daemon.registration_count()
+        };
         if count > 0 {
             zero_since = None;
         } else if zero_since.is_none() {

--- a/crates/mvm-runtime/src/host_agent_spawn.rs
+++ b/crates/mvm-runtime/src/host_agent_spawn.rs
@@ -222,6 +222,7 @@ pub fn register_host_agent_services_if_admitted(
 
     let control_socket = ensure_host_agent_daemon(tenant)?;
     let key = load_host_signing_key()?;
+    write_host_agent_owner_ref(state_dir)?;
     register_vm(
         &control_socket,
         &key,
@@ -260,6 +261,18 @@ pub fn reap_host_agent_services(state_dir: &Path, tenant: &str, vm_name: &str) {
     }
     crate::broker_services_spawn::reap_audit_signer(state_dir);
     let _ = std::fs::remove_file(state_dir.join(HOST_AGENT_TENANT_REF));
+    let _ = std::fs::remove_file(state_dir.join(mvm_core::config::HOST_AGENT_OWNER_PID_REF_FILE));
+}
+
+fn write_host_agent_owner_ref(state_dir: &Path) -> Result<()> {
+    let reference = state_dir.join(mvm_core::config::HOST_AGENT_OWNER_PID_REF_FILE);
+    let Some(owner_pid_path) = crate::vm::reconcile::live_process_pid_file(state_dir) else {
+        let _ = std::fs::remove_file(reference);
+        return Ok(());
+    };
+    let bytes = serde_json::to_vec(&owner_pid_path).context("encode host-agent owner PID path")?;
+    std::fs::write(&reference, bytes)
+        .with_context(|| format!("write host-agent owner ref {}", reference.display()))
 }
 
 /// The `stop()`-side reap: if this VM registered with a daemon (the tenant-ref
@@ -637,6 +650,35 @@ mod tests {
         drop(guard); // defused Drop reaps nothing
         // No tenant-ref written, no audit-signer pid.
         assert!(!dir.path().join(HOST_AGENT_TENANT_REF).exists());
+    }
+
+    #[test]
+    fn owner_ref_records_the_live_supervisor_pid_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_path = dir.path().join("hvf.pid");
+        std::fs::write(&pid_path, std::process::id().to_string()).unwrap();
+
+        write_host_agent_owner_ref(dir.path()).unwrap();
+
+        let bytes = std::fs::read(
+            dir.path()
+                .join(mvm_core::config::HOST_AGENT_OWNER_PID_REF_FILE),
+        )
+        .unwrap();
+        assert_eq!(serde_json::from_slice::<PathBuf>(&bytes).unwrap(), pid_path);
+    }
+
+    #[test]
+    fn owner_ref_removes_stale_marker_without_a_live_supervisor() {
+        let dir = tempfile::tempdir().unwrap();
+        let reference = dir
+            .path()
+            .join(mvm_core::config::HOST_AGENT_OWNER_PID_REF_FILE);
+        std::fs::write(&reference, b"stale").unwrap();
+
+        write_host_agent_owner_ref(dir.path()).unwrap();
+
+        assert!(!reference.exists());
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vm/reconcile.rs
+++ b/crates/mvm-runtime/src/vm/reconcile.rs
@@ -212,11 +212,18 @@ pub fn sweep(
 
 /// Supervisor pid-file names a per-VM state dir may carry. `pid` is the
 /// Apple-Container dev-VM owner file; `libkrun.pid` / `vz.pid` / `hvf.pid` /
-/// `fc.pid` are the workload-supervisor files (one per backend). The first one
+/// `fc.pid` / `qemu.pid` are the workload-supervisor files (one per backend). The first one
 /// that exists and points at a live process marks the dir as having a live
 /// owner. Every pid-file backend must be listed here or convergence can reap a
 /// running machine's state dir before its lifecycle command attaches.
-const PID_FILE_NAMES: &[&str] = &["libkrun.pid", "vz.pid", "hvf.pid", "fc.pid", "pid"];
+const PID_FILE_NAMES: &[&str] = &[
+    "libkrun.pid",
+    "vz.pid",
+    "hvf.pid",
+    "fc.pid",
+    "qemu.pid",
+    "pid",
+];
 
 /// `kill(pid, 0)` existence probe — delivers no signal, just checks the
 /// process is alive. The cheap half of the live-vs-orphan discrimination
@@ -236,12 +243,27 @@ fn read_pid_file(path: &Path) -> Option<i32> {
         .filter(|&p| p > 1)
 }
 
-/// Does `dir` carry a supervisor pid file pointing at a live process?
-fn dir_has_live_process(dir: &Path) -> bool {
+/// Whether one supervisor PID file identifies a live process.
+pub fn pid_file_has_live_process(path: &Path) -> bool {
+    read_pid_file(path).is_some_and(pid_is_alive)
+}
+
+/// Resolve the first known supervisor PID file in `dir` that points at a live
+/// process.
+pub fn live_process_pid_file(dir: &Path) -> Option<PathBuf> {
     PID_FILE_NAMES
         .iter()
-        .filter_map(|f| read_pid_file(&dir.join(f)))
-        .any(pid_is_alive)
+        .map(|file| dir.join(file))
+        .find(|path| pid_file_has_live_process(path))
+}
+
+/// Whether a VM state directory carries a supervisor PID file pointing at a
+/// live process.
+///
+/// Runtime reconciliation and host-agent registration cleanup share this
+/// ownership rule so neither can reap state or services for a live backend.
+pub fn state_dir_has_live_process(dir: &Path) -> bool {
+    live_process_pid_file(dir).is_some()
 }
 
 /// Best-effort recursive removal of a state dir. The dead-process
@@ -275,7 +297,7 @@ impl RuntimeView for FsRuntimeView {
         Path::new(&reg.vm_dir).is_dir()
     }
     fn process_alive(&self, reg: &VmRegistration) -> bool {
-        dir_has_live_process(Path::new(&reg.vm_dir))
+        state_dir_has_live_process(Path::new(&reg.vm_dir))
     }
     fn orphan_dirs(&self, known: &BTreeSet<String>) -> Vec<String> {
         let Ok(entries) = std::fs::read_dir(&self.vms_root) else {
@@ -293,7 +315,7 @@ impl RuntimeView for FsRuntimeView {
             // Canonical layout is `vms/<name>`, so the dir basename is the
             // registry key. A dir with a live owner is an in-flight or
             // specially-managed VM (e.g. the dev VM) — never an orphan.
-            if known.contains(name) || dir_has_live_process(&path) {
+            if known.contains(name) || state_dir_has_live_process(&path) {
                 continue;
             }
             out.push(name.to_string());
@@ -830,6 +852,17 @@ mod tests {
         assert!(
             view.orphan_dirs(&BTreeSet::new()).is_empty(),
             "a dir owned by live Firecracker must not be reaped as an orphan"
+        );
+    }
+
+    #[test]
+    fn shared_liveness_rule_recognizes_qemu_pid() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("qemu.pid"), std::process::id().to_string()).unwrap();
+
+        assert_eq!(
+            live_process_pid_file(tmp.path()),
+            Some(tmp.path().join("qemu.pid"))
         );
     }
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-01
+Last updated: 2026-08-02
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -10,10 +10,12 @@ for detailed scope and acceptance criteria.
       (`specs/plans/284-zero-open-issue-reconciliation.md`)
   - [x] Classify and reconcile the original 19 open issues
   - [x] Land the queued fixes for #2007, #2028, and #2029
-  - [ ] Land the security, kernel-pin, installer-fixture, and cold-cache-test
+  - [x] Land the security, kernel-pin, installer-fixture, and cold-cache-test
         fixes for #1983, #1937, #1972, and #2035
-  - [ ] Repair newly filed #2039 and #2042, and execute the refiled volume
-        epic #2040
+  - [x] Repair newly filed #2039
+  - [x] Repair newly filed #2042
+  - [ ] Repair newly filed #2048
+  - [ ] Execute the refiled volume epic #2040
 
 - [x] Plan 282 — Merge queue auto-requeue
       (`specs/plans/282-merge-queue-auto-requeue.md`)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -20,7 +20,10 @@
       Full-suite validation also made the plan-mode integration test override
       the worktree's `MVM_HOME`, preventing it from reusing another test's
       mutable host-signing key.
-      Newly filed #2039, #2040, and #2042 remain explicit follow-up work.
+      The remaining delivery merged in #2045, closing #1937, #1972, #1983,
+      and #2035; #2039 merged separately in #2041. The #2042 helper-lifecycle
+      repair is implemented and validated; #2040 and #2048 remain explicit
+      follow-up work.
       Tracked in plan 284.
 
 - [x] Merge-queue auto-requeue: bounded recovery for transiently ejected pull

--- a/specs/plans/284-zero-open-issue-reconciliation.md
+++ b/specs/plans/284-zero-open-issue-reconciliation.md
@@ -2,7 +2,7 @@
 
 Issues: #1819, #1821, #1822, #1823, #1825, #1826, #1849, #1851, #1937,
 #1972, #1973, #1977, #1983, #2006, #2007, #2021, #2028, #2029, #2033,
-#2035, #2036, #2039, #2040, #2042
+#2035, #2036, #2039, #2040, #2042, #2048
 
 Status: IN PROGRESS
 
@@ -28,13 +28,16 @@ open GitHub issues.
 - [x] Transfer #2036 to `tinylabscom/mvmd#196`, whose fleet-orchestrator
       ownership covers the epic's production object-store, encryption,
       reconciliation, quota, RBAC, and durability acceptance gates.
-- [ ] Repair #2039 by replacing the PID-1 `SIGCHLD` handler race with one
+- [x] Repair #2039 by replacing the PID-1 `SIGCHLD` handler race with one
       ownership-aware child waiter and proving reaper-first exit-status
-      delivery.
+      delivery; merged in #2041.
 - [ ] Execute the refiled cross-repository volume epic #2040 through its
       dedicated production-object-store plan.
-- [ ] Repair #2042 so per-VM helper processes exit with their owning run and
+- [x] Repair #2042 so per-VM helper processes exit with their owning run and
       stale helpers remain discoverable across worktree boundaries.
+- [ ] Repair #2048 by negative-caching confirmed missing default-origin
+      initramfs release artifacts without caching transient failures or
+      suppressing configured mirrors.
 - [x] Repair #1983 by updating the vulnerable Wasmtime 46.0.1 lock to 46.0.2
       and confirming the queued mutation-baseline fix clears the other failing
       security job.


### PR DESCRIPTION
Closes #2042

Ensure per-run helper processes cannot outlive their owners and safely reap stale helpers across worktree boundaries. Builder egress helpers arm parent-death handling, startup reaping is limited to orphaned builder supervisors, and host-agent registrations carry a host-only owner marker tied to the live VMM process.

Validation:
- cargo test --workspace -- --test-threads=1
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings (Linux KVM host)
- focused lifecycle and reconciliation tests