### PR TITLE
feat(build-cache): content-addressed dev build cache with verify-on-read (plan 276 WS6)

### DIFF
--- a/crates/mvm-build/src/pipeline/build_cache.rs
+++ b/crates/mvm-build/src/pipeline/build_cache.rs
@@ -175,8 +175,10 @@ pub fn workload_build_fingerprint(
 }
 
 /// Directory holding `fingerprint -> ActionCacheRecord` cache records
-/// (`~/.mvm/dev/build-cache/`).
-fn build_cache_dir() -> PathBuf {
+/// (`~/.mvm/dev/build-cache/`). `pub(crate)` so sibling-module tests can
+/// assert directly against the on-disk record path rather than
+/// reconstructing it.
+pub(crate) fn build_cache_dir() -> PathBuf {
     PathBuf::from(mvm_core::config::mvm_home())
         .join("dev")
         .join("build-cache")

--- a/crates/mvm-build/src/pipeline/build_cache.rs
+++ b/crates/mvm-build/src/pipeline/build_cache.rs
@@ -9,9 +9,11 @@
 //!
 //! This module computes a **host-side input fingerprint** so an
 //! unchanged build can be short-circuited before the builder VM is ever
-//! booted: map `fingerprint -> revision_hash`, and on the next `up`
-//! resolve the fingerprint host-side and reuse the already-materialised
-//! `~/.mvm/dev/builds/<revision>/` artifacts.
+//! booted: map `fingerprint -> ActionCacheRecord` (the revision plus
+//! every artifact's sha256 + size), and on the next `up` resolve the
+//! fingerprint host-side, verify the record against what is actually on
+//! disk, and reuse the already-materialised `~/.mvm/dev/builds/<revision>/`
+//! artifacts only when it checks out.
 //!
 //! ## Soundness (the stale-image footgun)
 //!
@@ -51,6 +53,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use mvm_core::action::ActionCacheRecord;
 use sha2::{Digest, Sha256};
 
 use super::BuildMode;
@@ -171,7 +174,7 @@ pub fn workload_build_fingerprint(
     Ok(hex::encode(hasher.finalize()))
 }
 
-/// Directory holding `fingerprint -> revision` cache records
+/// Directory holding `fingerprint -> ActionCacheRecord` cache records
 /// (`~/.mvm/dev/build-cache/`).
 fn build_cache_dir() -> PathBuf {
     PathBuf::from(mvm_core::config::mvm_home())
@@ -179,45 +182,74 @@ fn build_cache_dir() -> PathBuf {
         .join("build-cache")
 }
 
-/// Look up the nix revision a previous build recorded for `fingerprint`,
-/// or `None` if there is no record (or it is unreadable / malformed).
-/// Never returns a value that can't be a safe build-dir component.
-pub fn read_cached_revision(fingerprint: &str) -> Option<String> {
-    read_cached_revision_in(&build_cache_dir(), fingerprint)
+/// Look up the typed cache record a previous build wrote for
+/// `fingerprint`, or `None` if there is no record, it is unreadable,
+/// it fails to JSON-parse (including a legacy plaintext `<revision>\n`
+/// record from before this cache carried typed records), or its
+/// `revision` can't be trusted as a build-dir path component. Never
+/// returns a record whose `action_digest` doesn't match the key it was
+/// looked up under. This lookup alone does not verify the record's
+/// artifacts against disk — callers do that via
+/// `mvm_core::action::verify_artifacts_on_disk`.
+pub fn read_cache_record(fingerprint: &str) -> Option<ActionCacheRecord> {
+    read_cache_record_in(&build_cache_dir(), fingerprint)
 }
 
-/// Record `fingerprint -> revision` so the next build with the same
+/// Record `fingerprint -> record` so the next build with the same
 /// inputs can skip the builder VM. Best-effort and atomic (temp +
 /// rename) so a concurrent reader never sees a torn record.
-pub fn write_cached_revision(fingerprint: &str, revision: &str) -> Result<()> {
-    write_cached_revision_in(&build_cache_dir(), fingerprint, revision)
+pub fn write_cache_record(fingerprint: &str, record: &ActionCacheRecord) -> Result<()> {
+    write_cache_record_in(&build_cache_dir(), fingerprint, record)
 }
 
-fn read_cached_revision_in(dir: &Path, fingerprint: &str) -> Option<String> {
+/// Delete a stale cache record after verification against disk failed.
+/// Best-effort: an unwritable cache dir just means the entry keeps
+/// failing verification (and getting evicted again) on every future
+/// lookup, never that a bad entry is served.
+pub fn evict_cache_record(fingerprint: &str) {
+    evict_cache_record_in(&build_cache_dir(), fingerprint);
+}
+
+fn read_cache_record_in(dir: &Path, fingerprint: &str) -> Option<ActionCacheRecord> {
     if !is_safe_component(fingerprint) {
         return None;
     }
     let raw = std::fs::read_to_string(dir.join(fingerprint)).ok()?;
-    let rev = raw.trim();
+    let record: ActionCacheRecord = serde_json::from_str(&raw).ok()?;
+    if record.action_digest.as_str() != fingerprint {
+        return None;
+    }
     // The revision becomes a `~/.mvm/dev/builds/<rev>/` path component;
     // reject anything that isn't a plain store-hash token.
-    is_safe_component(rev).then(|| rev.to_string())
+    is_safe_component(&record.revision).then_some(record)
 }
 
-fn write_cached_revision_in(dir: &Path, fingerprint: &str, revision: &str) -> Result<()> {
+fn write_cache_record_in(dir: &Path, fingerprint: &str, record: &ActionCacheRecord) -> Result<()> {
     anyhow::ensure!(
-        is_safe_component(fingerprint) && is_safe_component(revision),
-        "refusing to write build-cache record with unsafe key/value"
+        is_safe_component(fingerprint) && is_safe_component(&record.revision),
+        "refusing to write build-cache record with unsafe key/revision"
+    );
+    anyhow::ensure!(
+        record.action_digest.as_str() == fingerprint,
+        "refusing to write build-cache record whose action_digest doesn't match its key"
     );
     std::fs::create_dir_all(dir)
         .with_context(|| format!("creating build-cache dir {}", dir.display()))?;
     let final_path = dir.join(fingerprint);
     let tmp = dir.join(format!(".{}.{}.tmp", fingerprint, std::process::id()));
-    std::fs::write(&tmp, format!("{revision}\n"))
+    let json = serde_json::to_string(record).with_context(|| "serializing build-cache record")?;
+    std::fs::write(&tmp, json)
         .with_context(|| format!("writing build-cache temp {}", tmp.display()))?;
     std::fs::rename(&tmp, &final_path)
         .with_context(|| format!("renaming build-cache record into {}", final_path.display()))?;
     Ok(())
+}
+
+fn evict_cache_record_in(dir: &Path, fingerprint: &str) {
+    if !is_safe_component(fingerprint) {
+        return;
+    }
+    let _ = std::fs::remove_file(dir.join(fingerprint));
 }
 
 /// A token safe to use as a single path component: non-empty, no path
@@ -590,34 +622,102 @@ mod tests {
         );
     }
 
+    fn sample_cache_record(fingerprint: &str, revision: &str) -> ActionCacheRecord {
+        ActionCacheRecord {
+            action_digest: mvm_core::action::ActionDigest::from_fingerprint_hex(fingerprint)
+                .expect("test fingerprint must be valid 64-hex"),
+            revision: revision.to_string(),
+            artifacts: vec![mvm_core::action::ArtifactDigest {
+                path: "rootfs.ext4".to_string(),
+                sha256: mvm_core::packs::Sha256Hex::from_bytes(b"rootfs bytes"),
+                size_bytes: 12,
+            }],
+        }
+    }
+
     #[test]
     fn cache_record_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let fp = "a".repeat(64);
-        assert_eq!(
-            read_cached_revision_in(dir.path(), &fp),
-            None,
-            "absent → None"
-        );
-        write_cached_revision_in(dir.path(), &fp, "l6fjg21gfazc98635yr2zjcfxm6ykilk").unwrap();
-        assert_eq!(
-            read_cached_revision_in(dir.path(), &fp).as_deref(),
-            Some("l6fjg21gfazc98635yr2zjcfxm6ykilk")
-        );
+        assert_eq!(read_cache_record_in(dir.path(), &fp), None, "absent → None");
+        let record = sample_cache_record(&fp, "l6fjg21gfazc98635yr2zjcfxm6ykilk");
+        write_cache_record_in(dir.path(), &fp, &record).unwrap();
+        assert_eq!(read_cache_record_in(dir.path(), &fp), Some(record));
     }
 
     #[test]
     fn cache_record_rejects_unsafe_revision_on_read() {
-        // A tampered record must never become a path component.
+        // A tampered record must never become a path component, even
+        // though the JSON parses fine.
         let dir = tempfile::tempdir().unwrap();
         let fp = "b".repeat(64);
-        std::fs::write(dir.path().join(&fp), "../../etc/passwd\n").unwrap();
-        assert_eq!(read_cached_revision_in(dir.path(), &fp), None);
+        let mut record = sample_cache_record(&fp, "placeholder");
+        record.revision = "../../etc/passwd".to_string();
+        let json = serde_json::to_string(&record).unwrap();
+        std::fs::write(dir.path().join(&fp), json).unwrap();
+        assert_eq!(read_cache_record_in(dir.path(), &fp), None);
+    }
+
+    #[test]
+    fn cache_record_rejects_mismatched_action_digest_on_read() {
+        // A record filed under one fingerprint but carrying another
+        // action_digest is a sign of a corrupted or spoofed cache dir;
+        // the key must match the recorded digest.
+        let dir = tempfile::tempdir().unwrap();
+        let fp = "c".repeat(64);
+        let other_digest = "d".repeat(64);
+        let record = sample_cache_record(&other_digest, "rev-1");
+        let json = serde_json::to_string(&record).unwrap();
+        std::fs::write(dir.path().join(&fp), json).unwrap();
+        assert_eq!(read_cache_record_in(dir.path(), &fp), None);
+    }
+
+    #[test]
+    fn legacy_plaintext_record_fails_to_parse_on_read() {
+        // Pre-typed-record cache entries were a bare `<revision>\n`
+        // marker; that is not valid JSON, so it must read back as a
+        // cold miss rather than a partially-trusted value.
+        let dir = tempfile::tempdir().unwrap();
+        let fp = "e".repeat(64);
+        std::fs::write(dir.path().join(&fp), "l6fjg21gfazc98635yr2zjcfxm6ykilk\n").unwrap();
+        assert_eq!(read_cache_record_in(dir.path(), &fp), None);
     }
 
     #[test]
     fn cache_record_write_refuses_unsafe_key() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(write_cached_revision_in(dir.path(), "../escape", "rev").is_err());
+        let fp = "f".repeat(64);
+        let record = sample_cache_record(&fp, "rev");
+        assert!(write_cache_record_in(dir.path(), "../escape", &record).is_err());
+    }
+
+    #[test]
+    fn cache_record_write_refuses_mismatched_action_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let fp = "1".repeat(64);
+        let other_digest = "2".repeat(64);
+        let record = sample_cache_record(&other_digest, "rev");
+        assert!(write_cache_record_in(dir.path(), &fp, &record).is_err());
+    }
+
+    #[test]
+    fn evict_removes_an_existing_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let fp = "3".repeat(64);
+        let record = sample_cache_record(&fp, "rev-1");
+        write_cache_record_in(dir.path(), &fp, &record).unwrap();
+        assert!(read_cache_record_in(dir.path(), &fp).is_some());
+
+        evict_cache_record_in(dir.path(), &fp);
+        assert!(read_cache_record_in(dir.path(), &fp).is_none());
+        assert!(!dir.path().join(&fp).exists());
+    }
+
+    #[test]
+    fn evict_is_a_no_op_when_no_record_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let fp = "4".repeat(64);
+        // Must not panic or error when there is nothing to evict.
+        evict_cache_record_in(dir.path(), &fp);
     }
 }

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -583,11 +583,11 @@ fn build_cache_fingerprint(
 /// record, it fails to parse, or verification against the artifacts
 /// actually on disk fails.
 ///
-/// Verification runs unconditionally on every hit; a missing/unparseable
-/// record or any mismatch is a miss+evict, never a path-trust fallback. A
-/// verification failure **evicts** the stale record (deletes it) before
-/// returning `None`, so a tampered or partially-collected cache entry is
-/// never served twice and a fresh build runs unconditionally.
+/// A missing or unparseable record is a plain miss: there is nothing to
+/// evict, since nothing was trusted. A record that parses but fails
+/// on-disk verification is a miss *and* evicts the stale entry (both the
+/// record and the build dir it named), so a tampered or partially-collected
+/// cache entry is never served twice and a fresh build runs unconditionally.
 #[cfg(feature = "builder-vm")]
 fn cached_build_result(fingerprint: &str) -> Option<DevBuildResult> {
     let record = crate::pipeline::build_cache::read_cache_record(fingerprint)?;
@@ -595,6 +595,17 @@ fn cached_build_result(fingerprint: &str) -> Option<DevBuildResult> {
     if let Err(e) = mvm_core::action::verify_artifacts_on_disk(Path::new(&build_dir), &record) {
         tracing::debug!(error = %e, "build-cache entry failed verification; evicting");
         crate::pipeline::build_cache::evict_cache_record(fingerprint);
+        // The build dir must go too, not just the record: the next build's
+        // `dev_build_with_builder_vm` promotes fresh artifacts into
+        // `dev_build_dir(revision)` only when that path is *absent* — it
+        // trusts an existing directory by revision name alone, with no hash
+        // check. Leaving the poisoned dir in place would make the next
+        // build discard its own freshly-built good output, re-adopt the
+        // poisoned bytes because the name matched, and let
+        // `write_cache_record_for_result` bless them again — one detected
+        // tamper would otherwise recur forever instead of self-healing on
+        // the very next build.
+        let _ = std::fs::remove_dir_all(&build_dir);
         return None;
     }
 
@@ -1935,6 +1946,10 @@ mod tests {
             cache_dir.join(&fingerprint).exists(),
             "sanity: the record file must exist before eviction"
         );
+        assert!(
+            build_dir_path.exists(),
+            "sanity: the poisoned build dir must exist before eviction"
+        );
 
         assert!(
             cached_build_result(&fingerprint).is_none(),
@@ -1947,6 +1962,17 @@ mod tests {
         assert!(
             crate::pipeline::build_cache::read_cache_record(&fingerprint).is_none(),
             "a failed verification must evict the stale record, not merely refuse it"
+        );
+        // The build dir must be gone too, not just the record: the next
+        // `dev_build_with_builder_vm` run promotes fresh artifacts into
+        // `dev_build_dir(revision)` only when that path doesn't already
+        // exist (it trusts an existing dir by revision name, no hash
+        // check). If eviction only deleted the record, the poisoned dir
+        // would survive and get silently re-adopted (and re-blessed with a
+        // fresh record) on the very next build.
+        assert!(
+            !build_dir_path.exists(),
+            "eviction must remove the poisoned build dir so a rebuild can't re-adopt it by name"
         );
     }
 

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -516,8 +516,9 @@ fn dev_build_via_builder_vm(
 /// `rootfs.ext4` is the one universal artifact; every other candidate
 /// (`vmlinux`, `initrd`, `bin/microvm-run`, `image.tar.gz`) is recorded only
 /// when it actually exists in the revision dir. When `rootfs.ext4` is
-/// absent, no record is written at all — an absent record reads back as a
-/// cold miss, never as a false hit (S3).
+/// absent, no record is written at all: an absent record reads back as a
+/// cold miss, so we never serve a cache hit we cannot re-verify (fail
+/// closed: never trust the path over a verified digest).
 #[cfg(feature = "builder-vm")]
 fn write_cache_record_for_result(fingerprint: &str, result: &DevBuildResult) -> Result<()> {
     let build_dir = Path::new(&result.build_dir);
@@ -582,10 +583,11 @@ fn build_cache_fingerprint(
 /// record, it fails to parse, or verification against the artifacts
 /// actually on disk fails.
 ///
-/// A verification failure **evicts** the stale record (deletes it) before
+/// Verification runs unconditionally on every hit; a missing/unparseable
+/// record or any mismatch is a miss+evict, never a path-trust fallback. A
+/// verification failure **evicts** the stale record (deletes it) before
 /// returning `None`, so a tampered or partially-collected cache entry is
-/// never served twice and a fresh build runs unconditionally (S3: fail
-/// closed, never trust the path).
+/// never served twice and a fresh build runs unconditionally.
 #[cfg(feature = "builder-vm")]
 fn cached_build_result(fingerprint: &str) -> Option<DevBuildResult> {
     let record = crate::pipeline::build_cache::read_cache_record(fingerprint)?;
@@ -1928,9 +1930,19 @@ mod tests {
         bytes[0] ^= 0xFF;
         std::fs::write(build_dir_path.join("rootfs.ext4"), bytes).expect("rewrite rootfs");
 
+        let cache_dir = crate::pipeline::build_cache::build_cache_dir();
+        assert!(
+            cache_dir.join(&fingerprint).exists(),
+            "sanity: the record file must exist before eviction"
+        );
+
         assert!(
             cached_build_result(&fingerprint).is_none(),
             "a tampered artifact must never be served"
+        );
+        assert!(
+            !cache_dir.join(&fingerprint).exists(),
+            "a failed verification must delete the stale record file, not merely refuse it"
         );
         assert!(
             crate::pipeline::build_cache::read_cache_record(&fingerprint).is_none(),
@@ -1969,9 +1981,7 @@ mod tests {
         std::fs::write(build_dir_path.join("rootfs.ext4"), b"bytes").expect("write rootfs.ext4");
 
         // Pre-typed-record cache entries were a bare `<revision>\n` marker.
-        let cache_dir = std::path::PathBuf::from(mvm_core::config::mvm_home())
-            .join("dev")
-            .join("build-cache");
+        let cache_dir = crate::pipeline::build_cache::build_cache_dir();
         std::fs::create_dir_all(&cache_dir).expect("create build-cache dir");
         std::fs::write(cache_dir.join(&fingerprint), format!("{revision}\n"))
             .expect("write legacy record");

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "builder-vm")]
+use std::path::Path;
+
 use anyhow::{Context, Result};
 use tracing::instrument;
 
@@ -494,13 +497,56 @@ fn dev_build_via_builder_vm(
 
     let result = dev_build_via_builder_vm_uncached(env, flake_ref, profile, mode)?;
 
-    // Record the fingerprint → revision mapping so the next identical
-    // build short-circuits. Best-effort: a read-only cache dir just means
-    // the next build re-evaluates.
-    if let Some(fp) = fingerprint.as_deref() {
-        let _ = crate::pipeline::build_cache::write_cached_revision(fp, &result.revision_hash);
+    // Record the fingerprint → typed cache record mapping so the next
+    // identical build short-circuits (and can verify what it finds rather
+    // than trusting the path). Best-effort: a read-only cache dir, or an
+    // artifact set the record can't describe, just means the next build
+    // re-evaluates.
+    if let Some(fp) = fingerprint.as_deref()
+        && let Err(e) = write_cache_record_for_result(fp, &result)
+    {
+        tracing::debug!(error = %e, "failed to write build-cache record");
     }
     Ok(result)
+}
+
+/// Build and persist an [`mvm_core::action::ActionCacheRecord`] for a
+/// freshly built `result`, keyed by the input `fingerprint`.
+///
+/// `rootfs.ext4` is the one universal artifact; every other candidate
+/// (`vmlinux`, `initrd`, `bin/microvm-run`, `image.tar.gz`) is recorded only
+/// when it actually exists in the revision dir. When `rootfs.ext4` is
+/// absent, no record is written at all — an absent record reads back as a
+/// cold miss, never as a false hit (S3).
+#[cfg(feature = "builder-vm")]
+fn write_cache_record_for_result(fingerprint: &str, result: &DevBuildResult) -> Result<()> {
+    let build_dir = Path::new(&result.build_dir);
+    if !build_dir.join("rootfs.ext4").is_file() {
+        return Ok(());
+    }
+    let mut rel_paths: Vec<&str> = vec!["rootfs.ext4"];
+    if build_dir.join("vmlinux").is_file() {
+        rel_paths.push("vmlinux");
+    }
+    if build_dir.join("initrd").is_file() {
+        rel_paths.push("initrd");
+    }
+    if build_dir.join("bin").join("microvm-run").is_file() {
+        rel_paths.push("bin/microvm-run");
+    }
+    if build_dir.join("image.tar.gz").is_file() {
+        rel_paths.push("image.tar.gz");
+    }
+
+    let action_digest = mvm_core::action::ActionDigest::from_fingerprint_hex(fingerprint)
+        .map_err(|e| anyhow::anyhow!("invalid build-cache fingerprint {fingerprint:?}: {e}"))?;
+    let record = mvm_core::action::build_record(
+        action_digest,
+        result.revision_hash.clone(),
+        build_dir,
+        &rel_paths,
+    )?;
+    crate::pipeline::build_cache::write_cache_record(fingerprint, &record)
 }
 
 /// Compute the host-side build fingerprint for the cache, or `None` when
@@ -531,19 +577,27 @@ fn build_cache_fingerprint(
     }
 }
 
-/// Reconstruct a cache-hit [`DevBuildResult`] from a recorded revision,
-/// or `None` when there is no record or its artifacts are incomplete.
-/// The completeness gate is `rootfs.ext4` — the one universal artifact;
-/// a kernel-less mkGuest image carries no `vmlinux` and relies on the
-/// cached-builder-kernel fallback resolved at boot.
+/// Reconstruct a cache-hit [`DevBuildResult`] from a recorded
+/// [`mvm_core::action::ActionCacheRecord`], or `None` when there is no
+/// record, it fails to parse, or verification against the artifacts
+/// actually on disk fails.
+///
+/// A verification failure **evicts** the stale record (deletes it) before
+/// returning `None`, so a tampered or partially-collected cache entry is
+/// never served twice and a fresh build runs unconditionally (S3: fail
+/// closed, never trust the path).
 #[cfg(feature = "builder-vm")]
 fn cached_build_result(fingerprint: &str) -> Option<DevBuildResult> {
-    let revision_hash = crate::pipeline::build_cache::read_cached_revision(fingerprint)?;
-    let build_dir = dev_build_dir(&revision_hash);
-    let rootfs_path = format!("{build_dir}/rootfs.ext4");
-    if !std::path::Path::new(&rootfs_path).is_file() {
+    let record = crate::pipeline::build_cache::read_cache_record(fingerprint)?;
+    let build_dir = dev_build_dir(&record.revision);
+    if let Err(e) = mvm_core::action::verify_artifacts_on_disk(Path::new(&build_dir), &record) {
+        tracing::debug!(error = %e, "build-cache entry failed verification; evicting");
+        crate::pipeline::build_cache::evict_cache_record(fingerprint);
         return None;
     }
+
+    let revision_hash = record.revision;
+    let rootfs_path = format!("{build_dir}/rootfs.ext4");
     let initrd_path = detect_initrd(&build_dir);
     let runner_dir = detect_runner(&build_dir);
     let artifact_sizes = measure_artifact_sizes(&build_dir, initrd_path.is_some());
@@ -741,6 +795,11 @@ fn dev_build_with_builder_vm<B: crate::builder_vm::BuilderVm + ?Sized>(
     };
     let staging = unique_dev_staging_dir();
     std::fs::create_dir_all(&staging).with_context(|| format!("creating staging dir {staging}"))?;
+    // Armed the moment the dir exists, so every early return below (the
+    // builder error, the install-volume bail) cleans it up on drop. Only
+    // `disarm()`ed once the artifacts have actually left `staging` behind
+    // (renamed, copied-then-removed, or discarded on a cache hit).
+    let mut staging_guard = StagingDirGuard::new(std::path::PathBuf::from(&staging));
 
     // dev_build_with_builder_vm is called for
     // user-flake builds (mvmctl build against the user's flake).
@@ -782,6 +841,9 @@ fn dev_build_with_builder_vm<B: crate::builder_vm::BuilderVm + ?Sized>(
         let _ = std::fs::remove_dir_all(&staging);
         tracing::debug!(error = %e, "rename failed; fell back to copy");
     }
+    // The staging dir is gone one way or another by this point (renamed
+    // away, or removed above) — disarm so Drop doesn't redundantly try.
+    staging_guard.disarm();
 
     let build_dir = final_dir;
     let vmlinux_path = format!("{build_dir}/vmlinux");
@@ -1064,6 +1126,44 @@ fn unique_dev_staging_dir() -> String {
         std::process::id(),
         nanos
     )
+}
+
+/// Removes a staging directory on drop unless [`Self::disarm`] was called
+/// first.
+///
+/// `dev_build_with_builder_vm` used to leak `.staging-*` dirs under
+/// `dev_builds_dir()` on a mid-build failure: the cleanup was only reached
+/// on the success path, so a builder error or an unexpected artifact shape
+/// (`InstallVolume` for a flake build) returned early and left the staged
+/// files behind forever. Tying removal to `Drop` makes every exit path —
+/// present and future — clean up structurally instead of needing a matching
+/// `remove_dir_all` at each `return`/`?`/`bail!`.
+#[cfg(feature = "builder-vm")]
+struct StagingDirGuard {
+    path: std::path::PathBuf,
+    armed: bool,
+}
+
+#[cfg(feature = "builder-vm")]
+impl StagingDirGuard {
+    fn new(path: std::path::PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Call once the staging dir has already been consumed (renamed away)
+    /// or removed, so `Drop` doesn't attempt a redundant no-op removal.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+#[cfg(feature = "builder-vm")]
+impl Drop for StagingDirGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1714,6 +1814,169 @@ mod tests {
             exec_log.iter().all(|entry| !entry.contains("nix ")),
             "builder failure path must not fall back to host-side Nix: {exec_log:?}"
         );
+
+        // The regression this guards: a builder error used to return before
+        // the staging dir (created just before `run_build` is invoked) was
+        // ever cleaned up, leaking a `.staging-*` dir under the builds dir
+        // on every failed build.
+        let leaked_staging = std::fs::read_dir(dev_builds_dir())
+            .map(|entries| {
+                entries
+                    .flatten()
+                    .any(|entry| entry.file_name().to_string_lossy().starts_with(".staging-"))
+            })
+            .unwrap_or(false);
+        assert!(
+            !leaked_staging,
+            "a builder failure must not leave a .staging-* dir behind"
+        );
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn staging_dir_guard_removes_dir_on_drop_without_disarm() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staging = tmp.path().join("staging-guard-armed");
+        std::fs::create_dir_all(&staging).expect("create staging dir");
+        {
+            let _guard = StagingDirGuard::new(staging.clone());
+            assert!(staging.exists());
+        }
+        assert!(
+            !staging.exists(),
+            "an armed guard must remove the dir on drop"
+        );
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn staging_dir_guard_leaves_dir_when_disarmed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staging = tmp.path().join("staging-guard-disarmed");
+        std::fs::create_dir_all(&staging).expect("create staging dir");
+        {
+            let mut guard = StagingDirGuard::new(staging.clone());
+            guard.disarm();
+        }
+        assert!(
+            staging.exists(),
+            "a disarmed guard must leave the dir alone on drop"
+        );
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn cache_hit_verifies_and_serves() {
+        let temp = tempfile::tempdir().expect("create temp MVM_HOME");
+        let mut env_guard = mvm_core::util::test_env::TestEnv::new();
+        env_guard.isolate_mvm_home(temp.path());
+
+        let fingerprint = "a".repeat(64);
+        let revision = "rev-cache-hit";
+        let build_dir_path = std::path::PathBuf::from(dev_build_dir(revision));
+        std::fs::create_dir_all(&build_dir_path).expect("create revision dir");
+        std::fs::write(build_dir_path.join("rootfs.ext4"), b"rootfs contents")
+            .expect("write rootfs.ext4");
+
+        let action_digest = mvm_core::action::ActionDigest::from_fingerprint_hex(&fingerprint)
+            .expect("valid fingerprint");
+        let record = mvm_core::action::build_record(
+            action_digest,
+            revision.to_string(),
+            &build_dir_path,
+            &["rootfs.ext4"],
+        )
+        .expect("build_record over real artifacts");
+        crate::pipeline::build_cache::write_cache_record(&fingerprint, &record)
+            .expect("write cache record");
+
+        let result = cached_build_result(&fingerprint).expect("verified cache entry should hit");
+        assert!(result.cached);
+        assert_eq!(result.revision_hash, revision);
+        assert_eq!(result.build_dir, build_dir_path.to_str().unwrap());
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn tampered_cache_entry_is_evicted() {
+        let temp = tempfile::tempdir().expect("create temp MVM_HOME");
+        let mut env_guard = mvm_core::util::test_env::TestEnv::new();
+        env_guard.isolate_mvm_home(temp.path());
+
+        let fingerprint = "b".repeat(64);
+        let revision = "rev-tampered";
+        let build_dir_path = std::path::PathBuf::from(dev_build_dir(revision));
+        std::fs::create_dir_all(&build_dir_path).expect("create revision dir");
+        std::fs::write(build_dir_path.join("rootfs.ext4"), b"original bytes")
+            .expect("write rootfs.ext4");
+
+        let action_digest = mvm_core::action::ActionDigest::from_fingerprint_hex(&fingerprint)
+            .expect("valid fingerprint");
+        let record = mvm_core::action::build_record(
+            action_digest,
+            revision.to_string(),
+            &build_dir_path,
+            &["rootfs.ext4"],
+        )
+        .expect("build_record over real artifacts");
+        crate::pipeline::build_cache::write_cache_record(&fingerprint, &record)
+            .expect("write cache record");
+
+        // Flip a byte after the record was written — the recorded digest no
+        // longer matches what's on disk.
+        let mut bytes = std::fs::read(build_dir_path.join("rootfs.ext4")).expect("read rootfs");
+        bytes[0] ^= 0xFF;
+        std::fs::write(build_dir_path.join("rootfs.ext4"), bytes).expect("rewrite rootfs");
+
+        assert!(
+            cached_build_result(&fingerprint).is_none(),
+            "a tampered artifact must never be served"
+        );
+        assert!(
+            crate::pipeline::build_cache::read_cache_record(&fingerprint).is_none(),
+            "a failed verification must evict the stale record, not merely refuse it"
+        );
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn missing_record_is_cold_miss() {
+        let temp = tempfile::tempdir().expect("create temp MVM_HOME");
+        let mut env_guard = mvm_core::util::test_env::TestEnv::new();
+        env_guard.isolate_mvm_home(temp.path());
+
+        let fingerprint = "c".repeat(64);
+        let revision = "rev-no-record";
+        let build_dir_path = std::path::PathBuf::from(dev_build_dir(revision));
+        std::fs::create_dir_all(&build_dir_path).expect("create revision dir");
+        std::fs::write(build_dir_path.join("rootfs.ext4"), b"bytes").expect("write rootfs.ext4");
+        // Deliberately no cache record written for `fingerprint`.
+
+        assert!(cached_build_result(&fingerprint).is_none());
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn legacy_plaintext_record_is_cold_miss() {
+        let temp = tempfile::tempdir().expect("create temp MVM_HOME");
+        let mut env_guard = mvm_core::util::test_env::TestEnv::new();
+        env_guard.isolate_mvm_home(temp.path());
+
+        let fingerprint = "d".repeat(64);
+        let revision = "rev-legacy";
+        let build_dir_path = std::path::PathBuf::from(dev_build_dir(revision));
+        std::fs::create_dir_all(&build_dir_path).expect("create revision dir");
+        std::fs::write(build_dir_path.join("rootfs.ext4"), b"bytes").expect("write rootfs.ext4");
+
+        // Pre-typed-record cache entries were a bare `<revision>\n` marker.
+        let cache_dir = std::path::PathBuf::from(mvm_core::config::mvm_home())
+            .join("dev")
+            .join("build-cache");
+        std::fs::create_dir_all(&cache_dir).expect("create build-cache dir");
+        std::fs::write(cache_dir.join(&fingerprint), format!("{revision}\n"))
+            .expect("write legacy record");
+
+        assert!(cached_build_result(&fingerprint).is_none());
     }
 
     #[test]

--- a/crates/mvm-core/src/action/mod.rs
+++ b/crates/mvm-core/src/action/mod.rs
@@ -147,9 +147,15 @@ pub fn build_record(
 }
 
 /// True when `path` cannot escape the directory it will be joined onto:
-/// relative, and every component a plain path segment (no `..`, no root, no
-/// Windows-style prefix).
+/// non-empty, relative, and every component a plain path segment (no `..`,
+/// no root, no Windows-style prefix). An empty path's `Component` iterator
+/// is also empty, so the "every component is `Normal`" check holds
+/// vacuously for it; without an explicit check it would join onto `dir`
+/// itself instead of naming a real artifact, so it's rejected up front.
 fn artifact_path_is_safe(path: &str) -> bool {
+    if path.is_empty() {
+        return false;
+    }
     let path = Path::new(path);
     !path.is_absolute()
         && path
@@ -391,6 +397,16 @@ mod tests {
         let error = verify_artifacts_on_disk(dir.path(), &escaping).unwrap_err();
         match error {
             VerifyError::UnsafePath { path } => assert_eq!(path, "../escape"),
+            other => panic!("expected UnsafePath, got {other:?}"),
+        }
+
+        // An empty path's `Component` iterator is itself empty, so without
+        // an explicit check it would vacuously pass the "every component is
+        // Normal" test and join onto `dir` itself instead of naming a file.
+        let empty = unsafe_record("");
+        let error = verify_artifacts_on_disk(dir.path(), &empty).unwrap_err();
+        match error {
+            VerifyError::UnsafePath { path } => assert_eq!(path, ""),
             other => panic!("expected UnsafePath, got {other:?}"),
         }
     }

--- a/crates/mvm-core/src/action/mod.rs
+++ b/crates/mvm-core/src/action/mod.rs
@@ -107,6 +107,45 @@ pub fn verify_artifacts_on_disk(dir: &Path, record: &ActionCacheRecord) -> Resul
     Ok(())
 }
 
+/// Build an [`ActionCacheRecord`] for a freshly produced action output set:
+/// stream each of `rel_paths` under `dir` through the same sha256 primitive
+/// [`verify_artifacts_on_disk`] re-checks against later, and pack the
+/// results into the typed record. Reuses [`hash_file_streaming`] so the
+/// write side and the verify side can never disagree about how a digest is
+/// computed.
+///
+/// Errors identically to [`verify_artifacts_on_disk`]'s per-artifact
+/// failures (`UnsafePath`, `Missing`, `Io`) — a path that couldn't be
+/// hashed on the way in could never have verified on the way out either.
+pub fn build_record(
+    action_digest: ActionDigest,
+    revision: String,
+    dir: &Path,
+    rel_paths: &[&str],
+) -> Result<ActionCacheRecord, VerifyError> {
+    let mut artifacts = Vec::with_capacity(rel_paths.len());
+    for rel_path in rel_paths {
+        if !artifact_path_is_safe(rel_path) {
+            return Err(VerifyError::UnsafePath {
+                path: (*rel_path).to_string(),
+            });
+        }
+        let path = dir.join(rel_path);
+        let (sha256_hex, size_bytes) = hash_file_streaming(&path, rel_path)?;
+        artifacts.push(ArtifactDigest {
+            path: (*rel_path).to_string(),
+            sha256: Sha256Hex::new(sha256_hex)
+                .expect("stream_sha256 always returns a valid 64-hex digest"),
+            size_bytes,
+        });
+    }
+    Ok(ActionCacheRecord {
+        action_digest,
+        revision,
+        artifacts,
+    })
+}
+
 /// True when `path` cannot escape the directory it will be joined onto:
 /// relative, and every component a plain path segment (no `..`, no root, no
 /// Windows-style prefix).
@@ -350,6 +389,51 @@ mod tests {
 
         let escaping = unsafe_record("../escape");
         let error = verify_artifacts_on_disk(dir.path(), &escaping).unwrap_err();
+        match error {
+            VerifyError::UnsafePath { path } => assert_eq!(path, "../escape"),
+            other => panic!("expected UnsafePath, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_record_produces_a_record_verify_accepts() {
+        let dir = TempDir::new().expect("tempdir");
+        let matching = write_matching_fixture(dir.path());
+        let digest = ActionDigest::from_fingerprint_hex(&valid_hex()).expect("valid fingerprint");
+
+        let built = build_record(
+            digest,
+            "rev-1".to_string(),
+            dir.path(),
+            &["vmlinux", "rootfs.ext4"],
+        )
+        .expect("build_record should succeed on real files");
+
+        // Same digests/sizes the fixture recorded by hand.
+        assert_eq!(built.artifacts, matching.artifacts);
+        verify_artifacts_on_disk(dir.path(), &built).expect("built record should verify");
+    }
+
+    #[test]
+    fn build_record_fails_on_missing_artifact() {
+        let dir = TempDir::new().expect("tempdir");
+        let digest = ActionDigest::from_fingerprint_hex(&valid_hex()).expect("valid fingerprint");
+
+        let error =
+            build_record(digest, "rev-1".to_string(), dir.path(), &["rootfs.ext4"]).unwrap_err();
+        match error {
+            VerifyError::Missing { path } => assert_eq!(path, "rootfs.ext4"),
+            other => panic!("expected Missing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_record_rejects_unsafe_rel_path() {
+        let dir = TempDir::new().expect("tempdir");
+        let digest = ActionDigest::from_fingerprint_hex(&valid_hex()).expect("valid fingerprint");
+
+        let error =
+            build_record(digest, "rev-1".to_string(), dir.path(), &["../escape"]).unwrap_err();
         match error {
             VerifyError::UnsafePath { path } => assert_eq!(path, "../escape"),
             other => panic!("expected UnsafePath, got {other:?}"),

--- a/crates/mvm-core/src/action/mod.rs
+++ b/crates/mvm-core/src/action/mod.rs
@@ -6,15 +6,12 @@
 //! recorded digest + size of every artifact it produced, so a cache hit can be
 //! verified against the actual bytes on disk before reuse rather than assumed.
 
-use std::fs::File;
-use std::io::Read;
-use std::path::Path;
+use std::path::{Component, Path};
 
 use serde::{Deserialize, Deserializer, Serialize};
-use sha2::{Digest, Sha256};
 use thiserror::Error;
 
-use crate::packs::{Sha256Hex, is_sha256_hex};
+use crate::packs::{Sha256Hex, is_sha256_hex, stream_sha256};
 
 /// Identifies a build action by its fingerprint (sha256 over the action's
 /// inputs — flake ref, profile, role, and so on). Bare 64-hex, no prefix: the
@@ -75,12 +72,21 @@ pub struct ActionCacheRecord {
 /// Each file is streamed through a fixed buffer rather than read whole into
 /// memory — a cached `rootfs.ext4` runs to hundreds of megabytes. An empty
 /// `artifacts` list is refused rather than treated as vacuously verified: the
-/// absence of recorded digests must never read back as "verified."
+/// absence of recorded digests must never read back as "verified." Every
+/// `artifact.path` is checked for an escape (absolute, or carrying a `..`,
+/// root, or prefix component) before it is joined onto `dir`, so a record
+/// naming a path outside the revision directory is refused before any file
+/// is touched.
 pub fn verify_artifacts_on_disk(dir: &Path, record: &ActionCacheRecord) -> Result<(), VerifyError> {
     if record.artifacts.is_empty() {
         return Err(VerifyError::EmptyRecord);
     }
     for artifact in &record.artifacts {
+        if !artifact_path_is_safe(&artifact.path) {
+            return Err(VerifyError::UnsafePath {
+                path: artifact.path.clone(),
+            });
+        }
         let path = dir.join(&artifact.path);
         let (got_hash, got_size) = hash_file_streaming(&path, &artifact.path)?;
         if got_size != artifact.size_bytes {
@@ -101,12 +107,23 @@ pub fn verify_artifacts_on_disk(dir: &Path, record: &ActionCacheRecord) -> Resul
     Ok(())
 }
 
-/// Stream `path` through a `Sha256` hasher in fixed-size chunks, returning
-/// its hex digest and byte count. `record_path` is the artifact's recorded
-/// relative path, used for error reporting instead of the joined absolute
-/// path.
+/// True when `path` cannot escape the directory it will be joined onto:
+/// relative, and every component a plain path segment (no `..`, no root, no
+/// Windows-style prefix).
+fn artifact_path_is_safe(path: &str) -> bool {
+    let path = Path::new(path);
+    !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+}
+
+/// Hash `path` on disk via [`stream_sha256`], mapping the raw `io::Error`
+/// onto `VerifyError::Missing` or `VerifyError::Io`. `record_path` is the
+/// artifact's recorded relative path, used for error reporting instead of
+/// the joined absolute path.
 fn hash_file_streaming(path: &Path, record_path: &str) -> Result<(String, u64), VerifyError> {
-    let mut file = File::open(path).map_err(|source| {
+    stream_sha256(path).map_err(|source| {
         if source.kind() == std::io::ErrorKind::NotFound {
             VerifyError::Missing {
                 path: record_path.to_string(),
@@ -117,22 +134,7 @@ fn hash_file_streaming(path: &Path, record_path: &str) -> Result<(String, u64), 
                 source,
             }
         }
-    })?;
-    let mut hasher = Sha256::new();
-    let mut total = 0u64;
-    let mut buffer = [0u8; 8192];
-    loop {
-        let read = file.read(&mut buffer).map_err(|source| VerifyError::Io {
-            path: record_path.to_string(),
-            source,
-        })?;
-        if read == 0 {
-            break;
-        }
-        total += read as u64;
-        hasher.update(&buffer[..read]);
-    }
-    Ok((hex::encode(hasher.finalize()), total))
+    })
 }
 
 #[derive(Debug, Error)]
@@ -157,6 +159,8 @@ pub enum VerifyError {
     },
     #[error("artifact {path} is missing on disk")]
     Missing { path: String },
+    #[error("artifact path {path:?} is unsafe: must be relative with no parent-dir component")]
+    UnsafePath { path: String },
     #[error("artifact {path} could not be read: {source}")]
     Io {
         path: String,
@@ -320,6 +324,35 @@ mod tests {
         match error {
             VerifyError::SizeMismatch { path, .. } => assert_eq!(path, "vmlinux"),
             other => panic!("expected SizeMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_fails_on_unsafe_path() {
+        let dir = TempDir::new().expect("tempdir");
+        let unsafe_record = |path: &str| ActionCacheRecord {
+            action_digest: ActionDigest::from_fingerprint_hex(&valid_hex())
+                .expect("valid fingerprint"),
+            revision: "rev-1".to_string(),
+            artifacts: vec![ArtifactDigest {
+                path: path.to_string(),
+                sha256: Sha256Hex::from_bytes(b"irrelevant"),
+                size_bytes: 0,
+            }],
+        };
+
+        let absolute = unsafe_record("/etc/passwd");
+        let error = verify_artifacts_on_disk(dir.path(), &absolute).unwrap_err();
+        match error {
+            VerifyError::UnsafePath { path } => assert_eq!(path, "/etc/passwd"),
+            other => panic!("expected UnsafePath, got {other:?}"),
+        }
+
+        let escaping = unsafe_record("../escape");
+        let error = verify_artifacts_on_disk(dir.path(), &escaping).unwrap_err();
+        match error {
+            VerifyError::UnsafePath { path } => assert_eq!(path, "../escape"),
+            other => panic!("expected UnsafePath, got {other:?}"),
         }
     }
 

--- a/crates/mvm-core/src/action/mod.rs
+++ b/crates/mvm-core/src/action/mod.rs
@@ -1,0 +1,339 @@
+//! Content-addressed build-action cache records.
+//!
+//! A dev build cache entry used to be a bare `<revision>` marker: its presence
+//! meant "trust whatever is on disk under this name." `ActionCacheRecord`
+//! replaces that with a typed record naming the action's fingerprint and the
+//! recorded digest + size of every artifact it produced, so a cache hit can be
+//! verified against the actual bytes on disk before reuse rather than assumed.
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use serde::{Deserialize, Deserializer, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use crate::packs::{Sha256Hex, is_sha256_hex};
+
+/// Identifies a build action by its fingerprint (sha256 over the action's
+/// inputs — flake ref, profile, role, and so on). Bare 64-hex, no prefix: the
+/// same shape as [`Sha256Hex`], but kept as a distinct type since an action
+/// fingerprint and an artifact's content hash are never interchangeable.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct ActionDigest(String);
+
+impl ActionDigest {
+    pub fn from_fingerprint_hex(value: &str) -> Result<Self, ActionError> {
+        if is_sha256_hex(value) {
+            Ok(Self(value.to_string()))
+        } else {
+            Err(ActionError::InvalidFingerprint(value.to_string()))
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for ActionDigest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        ActionDigest::from_fingerprint_hex(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// One cached artifact's recorded identity: its path relative to the
+/// revision directory (e.g. `rootfs.ext4`, `vmlinux`), content hash, and byte
+/// size.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactDigest {
+    pub path: String,
+    pub sha256: Sha256Hex,
+    pub size_bytes: u64,
+}
+
+/// The typed record for one build action's output set — what a cache entry
+/// stores in place of the old plaintext `<revision>` marker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActionCacheRecord {
+    pub action_digest: ActionDigest,
+    pub revision: String,
+    pub artifacts: Vec<ArtifactDigest>,
+}
+
+/// Recompute each recorded artifact's on-disk digest and size and compare
+/// against `record`, returning the first mismatch encountered.
+///
+/// Each file is streamed through a fixed buffer rather than read whole into
+/// memory — a cached `rootfs.ext4` runs to hundreds of megabytes. An empty
+/// `artifacts` list is refused rather than treated as vacuously verified: the
+/// absence of recorded digests must never read back as "verified."
+pub fn verify_artifacts_on_disk(dir: &Path, record: &ActionCacheRecord) -> Result<(), VerifyError> {
+    if record.artifacts.is_empty() {
+        return Err(VerifyError::EmptyRecord);
+    }
+    for artifact in &record.artifacts {
+        let path = dir.join(&artifact.path);
+        let (got_hash, got_size) = hash_file_streaming(&path, &artifact.path)?;
+        if got_size != artifact.size_bytes {
+            return Err(VerifyError::SizeMismatch {
+                path: artifact.path.clone(),
+                expected: artifact.size_bytes,
+                got: got_size,
+            });
+        }
+        if got_hash != artifact.sha256.as_str() {
+            return Err(VerifyError::Mismatch {
+                path: artifact.path.clone(),
+                expected: artifact.sha256.as_str().to_string(),
+                got: got_hash,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Stream `path` through a `Sha256` hasher in fixed-size chunks, returning
+/// its hex digest and byte count. `record_path` is the artifact's recorded
+/// relative path, used for error reporting instead of the joined absolute
+/// path.
+fn hash_file_streaming(path: &Path, record_path: &str) -> Result<(String, u64), VerifyError> {
+    let mut file = File::open(path).map_err(|source| {
+        if source.kind() == std::io::ErrorKind::NotFound {
+            VerifyError::Missing {
+                path: record_path.to_string(),
+            }
+        } else {
+            VerifyError::Io {
+                path: record_path.to_string(),
+                source,
+            }
+        }
+    })?;
+    let mut hasher = Sha256::new();
+    let mut total = 0u64;
+    let mut buffer = [0u8; 8192];
+    loop {
+        let read = file.read(&mut buffer).map_err(|source| VerifyError::Io {
+            path: record_path.to_string(),
+            source,
+        })?;
+        if read == 0 {
+            break;
+        }
+        total += read as u64;
+        hasher.update(&buffer[..read]);
+    }
+    Ok((hex::encode(hasher.finalize()), total))
+}
+
+#[derive(Debug, Error)]
+pub enum ActionError {
+    #[error("invalid action fingerprint {0:?}: expected 64 lowercase hex characters")]
+    InvalidFingerprint(String),
+}
+
+#[derive(Debug, Error)]
+pub enum VerifyError {
+    #[error("artifact {path} content mismatch: expected {expected}, got {got}")]
+    Mismatch {
+        path: String,
+        expected: String,
+        got: String,
+    },
+    #[error("artifact {path} size mismatch: expected {expected}, got {got}")]
+    SizeMismatch {
+        path: String,
+        expected: u64,
+        got: u64,
+    },
+    #[error("artifact {path} is missing on disk")]
+    Missing { path: String },
+    #[error("artifact {path} could not be read: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("action cache record has no recorded artifacts")]
+    EmptyRecord,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn valid_hex() -> String {
+        "a".repeat(64)
+    }
+
+    #[test]
+    fn action_digest_accepts_64_lower_hex() {
+        let digest = ActionDigest::from_fingerprint_hex(&valid_hex()).expect("valid fingerprint");
+        assert_eq!(digest.as_str(), valid_hex());
+    }
+
+    #[test]
+    fn action_digest_rejects_non_hex() {
+        let value = "g".repeat(64);
+        let error = ActionDigest::from_fingerprint_hex(&value).unwrap_err();
+        assert!(matches!(error, ActionError::InvalidFingerprint(v) if v == value));
+    }
+
+    #[test]
+    fn action_digest_rejects_wrong_length() {
+        let value = "a".repeat(63);
+        let error = ActionDigest::from_fingerprint_hex(&value).unwrap_err();
+        assert!(matches!(error, ActionError::InvalidFingerprint(v) if v == value));
+    }
+
+    #[test]
+    fn action_digest_serde_roundtrip() {
+        let digest = ActionDigest::from_fingerprint_hex(&valid_hex()).expect("valid fingerprint");
+        let json = serde_json::to_string(&digest).expect("serialize");
+        assert_eq!(json, format!("\"{}\"", valid_hex()));
+        let back: ActionDigest = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, digest);
+    }
+
+    #[test]
+    fn action_digest_deserialize_rejects_bad_shape() {
+        let bad = serde_json::to_string("not-a-digest").expect("serialize string");
+        let result: Result<ActionDigest, _> = serde_json::from_str(&bad);
+        assert!(result.is_err());
+    }
+
+    fn sample_record() -> ActionCacheRecord {
+        ActionCacheRecord {
+            action_digest: ActionDigest::from_fingerprint_hex(&valid_hex())
+                .expect("valid fingerprint"),
+            revision: "rev-1".to_string(),
+            artifacts: vec![ArtifactDigest {
+                path: "rootfs.ext4".to_string(),
+                sha256: Sha256Hex::from_bytes(b"rootfs bytes"),
+                size_bytes: 12,
+            }],
+        }
+    }
+
+    #[test]
+    fn record_serde_roundtrip() {
+        let record = sample_record();
+        let json = serde_json::to_string(&record).expect("serialize");
+        let back: ActionCacheRecord = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, record);
+    }
+
+    #[test]
+    fn record_rejects_unknown_field() {
+        let record = sample_record();
+        let mut value = serde_json::to_value(&record).expect("to_value");
+        value
+            .as_object_mut()
+            .expect("object")
+            .insert("unexpected".to_string(), serde_json::json!("surprise"));
+        let result: Result<ActionCacheRecord, _> = serde_json::from_value(value);
+        assert!(result.is_err());
+    }
+
+    /// Write two temp files under `dir`, returning an `ActionCacheRecord`
+    /// whose `artifacts` carry their real on-disk digests and sizes.
+    fn write_matching_fixture(dir: &Path) -> ActionCacheRecord {
+        let first = b"kernel image bytes".to_vec();
+        let second = b"rootfs image bytes, somewhat longer".to_vec();
+        fs::write(dir.join("vmlinux"), &first).expect("write vmlinux");
+        fs::write(dir.join("rootfs.ext4"), &second).expect("write rootfs.ext4");
+        ActionCacheRecord {
+            action_digest: ActionDigest::from_fingerprint_hex(&valid_hex())
+                .expect("valid fingerprint"),
+            revision: "rev-1".to_string(),
+            artifacts: vec![
+                ArtifactDigest {
+                    path: "vmlinux".to_string(),
+                    sha256: Sha256Hex::from_bytes(&first),
+                    size_bytes: first.len() as u64,
+                },
+                ArtifactDigest {
+                    path: "rootfs.ext4".to_string(),
+                    sha256: Sha256Hex::from_bytes(&second),
+                    size_bytes: second.len() as u64,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn verify_passes_on_matching_artifacts() {
+        let dir = TempDir::new().expect("tempdir");
+        let record = write_matching_fixture(dir.path());
+        verify_artifacts_on_disk(dir.path(), &record).expect("verification should pass");
+    }
+
+    #[test]
+    fn verify_fails_on_tampered_artifact() {
+        let dir = TempDir::new().expect("tempdir");
+        let record = write_matching_fixture(dir.path());
+        let path = dir.path().join("rootfs.ext4");
+        let mut bytes = fs::read(&path).expect("read rootfs.ext4");
+        bytes[0] ^= 0xFF;
+        fs::write(&path, &bytes).expect("rewrite rootfs.ext4");
+
+        let error = verify_artifacts_on_disk(dir.path(), &record).unwrap_err();
+        match error {
+            VerifyError::Mismatch { path, .. } => assert_eq!(path, "rootfs.ext4"),
+            other => panic!("expected Mismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_fails_on_missing_artifact() {
+        let dir = TempDir::new().expect("tempdir");
+        let record = write_matching_fixture(dir.path());
+        fs::remove_file(dir.path().join("vmlinux")).expect("remove vmlinux");
+
+        let error = verify_artifacts_on_disk(dir.path(), &record).unwrap_err();
+        match error {
+            VerifyError::Missing { path } => assert_eq!(path, "vmlinux"),
+            other => panic!("expected Missing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_fails_on_size_mismatch() {
+        let dir = TempDir::new().expect("tempdir");
+        let mut record = write_matching_fixture(dir.path());
+        record.artifacts[0].size_bytes += 1;
+
+        let error = verify_artifacts_on_disk(dir.path(), &record).unwrap_err();
+        match error {
+            VerifyError::SizeMismatch { path, .. } => assert_eq!(path, "vmlinux"),
+            other => panic!("expected SizeMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_fails_on_empty_record() {
+        let dir = TempDir::new().expect("tempdir");
+        let record = ActionCacheRecord {
+            action_digest: ActionDigest::from_fingerprint_hex(&valid_hex())
+                .expect("valid fingerprint"),
+            revision: "rev-1".to_string(),
+            artifacts: Vec::new(),
+        };
+
+        let error = verify_artifacts_on_disk(dir.path(), &record).unwrap_err();
+        assert!(matches!(error, VerifyError::EmptyRecord));
+    }
+}

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -4,6 +4,10 @@
 // `deny` (not `forbid`) so `util::test_env` can carry the one narrow
 // unsafe carve-out for process-wide env mutation in tests.
 
+/// Content-addressed build-action cache records: a typed identity for one
+/// cached action's output artifacts, and a verify-on-read helper that
+/// recomputes each artifact's digest before a cache entry is trusted.
+pub mod action;
 pub mod arch;
 pub mod build_env;
 pub mod catalog;

--- a/crates/mvm-core/src/packs.rs
+++ b/crates/mvm-core/src/packs.rs
@@ -786,20 +786,29 @@ fn decode_signature(encoded: &str) -> Result<[u8; 64], PackVerifyError> {
     })
 }
 
-fn hash_file(path: &Path) -> Result<(Sha256Hex, u64), String> {
-    let mut file = File::open(path).map_err(|error| error.to_string())?;
+/// Stream `path` through a `Sha256` hasher in fixed-size chunks (never reads
+/// the whole file into memory) and return its lowercase-hex digest and byte
+/// length. Shared with `action::hash_file_streaming`, which needs the raw
+/// `io::Error` to tell a missing file apart from any other read failure.
+pub(crate) fn stream_sha256(path: &Path) -> std::io::Result<(String, u64)> {
+    let mut file = File::open(path)?;
     let mut hasher = Sha256::new();
     let mut total = 0u64;
     let mut buffer = [0u8; 8192];
     loop {
-        let read = file.read(&mut buffer).map_err(|error| error.to_string())?;
+        let read = file.read(&mut buffer)?;
         if read == 0 {
             break;
         }
         total = total.saturating_add(read as u64);
         hasher.update(&buffer[..read]);
     }
-    Ok((Sha256Hex(hex::encode(hasher.finalize())), total))
+    Ok((hex::encode(hasher.finalize()), total))
+}
+
+fn hash_file(path: &Path) -> Result<(Sha256Hex, u64), String> {
+    let (hex, size) = stream_sha256(path).map_err(|error| error.to_string())?;
+    Ok((Sha256Hex(hex), size))
 }
 
 pub(crate) fn is_sha256_hex(value: &str) -> bool {

--- a/crates/mvm-core/src/packs.rs
+++ b/crates/mvm-core/src/packs.rs
@@ -802,7 +802,7 @@ fn hash_file(path: &Path) -> Result<(Sha256Hex, u64), String> {
     Ok((Sha256Hex(hex::encode(hasher.finalize())), total))
 }
 
-fn is_sha256_hex(value: &str) -> bool {
+pub(crate) fn is_sha256_hex(value: &str) -> bool {
     value.len() == 64
         && value
             .bytes()


### PR DESCRIPTION
Closes **plan 276 WS6** / **plan 279 Milestone A**, and unblocks plan 279 WS1 (`ActionDigest`).

## Problem

The dev build cache (`~/.mvm/dev/builds/<rev>/`) was served on a hit if `rootfs.ext4` merely *existed as a file* — no digest recompute, no content verification. Cache skew or on-disk corruption of a cached rootfs/kernel was served silently (the exact footgun where "cache skew mimics real bugs"). Verify-on-read is content-addressing's founding property; the cache lacked it.

## What

**`mvm-core::action` (new module):**
- `ActionDigest` (bare-64-hex newtype mirroring `Sha256Hex`), `ArtifactDigest { path, sha256, size_bytes }`, `ActionCacheRecord { action_digest, revision, artifacts }`.
- `verify_artifacts_on_disk(dir, &record)` — streams each artifact's SHA-256, compares sha256 **and** size, **fails closed**: empty record, unsafe/absolute/`..`/empty path, missing, hash mismatch, size mismatch each return a distinct typed error before or during the read.
- `build_record(...)` write-side helper, and a shared `packs::stream_sha256` primitive that both `packs::hash_file` and the action module route through (dedupes the old streaming loop — reuse-first; `hash_file` behavior is byte-identical).

**`mvm-build` dev cache (behind the `builder-vm` feature):**
- Write path records a typed `ActionCacheRecord` (JSON, keyed by input fingerprint) with every present artifact's digest, via temp+atomic-rename.
- Read path (`cached_build_result`) parses the record and calls `verify_artifacts_on_disk`: serve on Ok; on any Err **evict and return None** (cache miss → fresh build). A missing/unparseable/legacy-plaintext record is a plain cold miss (never a path-trust fallback). The old "`rootfs.ext4` exists" gate is gone.
- **Durable eviction:** on a verify failure it removes the poisoned `~/.mvm/dev/builds/<rev>/` too — otherwise the rebuild's pre-existing "`final_dir` exists → trust by name" shortcut would re-adopt the poisoned dir and re-bless it. (Caught by the whole-branch review.)
- A RAII staging-dir guard removes the `.staging-*` dir on all exit paths (disarmed only after the successful rename), fixing a mid-build leak.

## Invariants

Integrity only, never an authorization/admission decision (the signed plan + bundle remain the sole authority); caching stays within the per-`MVM_HOME` boundary (no cross-tenant dedup); verify-on-read fails closed; dm-verity roothash chain untouched.

**Deliberately out of scope (deferred to the fleet tier):** signing the cache record and emitting a chain-signed audit entry — `mvm-build` cannot reach the host audit emitter, and local signing is forgeable (host signer key co-located with the cache), so the real local value here is corruption/skew detection, not supply-chain proof.

## Tests

`mvm-core` 1500/1500; `mvm-build --features builder-vm` 769/769; clippy (both feature configs) + nightly fmt + doctests + pre-commit full-workspace clippy clean. Security tests verify real behavior: hit-verifies-and-serves, tampered-entry evicts (record **and** build dir gone), missing/legacy record = cold miss, unsafe/empty path rejected, staging guard arm/disarm.

## Follow-up (separate PR)

`check-no-spec-refs-in-comments`'s regex matches `W\d+.` but not bare `S\d`, a lint blind spot — worth a one-line hardening. No `S\d` tokens remain in this branch's code.