### PR TITLE
fix(guest): deliver mediated tools on a sealed rootfs via PATH

### DIFF
--- a/crates/mvm-agentd/src/guest_bootstrap.rs
+++ b/crates/mvm-agentd/src/guest_bootstrap.rs
@@ -95,19 +95,53 @@ pub fn ensure_runtime_dirs() {
     }
 }
 
-/// Bind-mount each mediated tool over the image's own copy.
+/// Deliver each mediated tool, by both routes available.
 ///
-/// Skipped silently when either side is absent: an image that ships no
-/// `ping` has nothing to mount over (and the rootfs is read-only under
-/// verity, so one cannot be created), and a launch shape with no runtime
-/// overlay has no replacement to offer. In both cases the image behaves as
-/// it would have without mvm, which is the honest outcome.
+/// A launch shape with no runtime overlay has no replacement to offer, and
+/// that case is skipped silently — the image behaves as it would have without
+/// mvm, which is the honest outcome.
 pub fn mount_mediated_tools() {
     for (source, target) in MEDIATED_TOOLS {
-        if !Path::new(source).is_file() || !Path::new(target).exists() {
+        if !Path::new(source).is_file() {
             continue;
         }
-        bind_mount_file(source, target);
+        // Always reachable by name, even when the image ships no copy to mount
+        // over and even when the rootfs is sealed against the mount.
+        install_mediated_tool(source, target);
+        if Path::new(target).exists() {
+            bind_mount_file(source, target);
+        }
+    }
+}
+
+/// Link a stand-in into the mediated-tool directory so `PATH` finds it.
+///
+/// The bind mount is the stronger delivery — it reaches a caller that runs
+/// `/bin/ping` outright, which no `PATH` order does — but it cannot apply to a
+/// symlink on a read-only rootfs. This route always applies: `/run` is a tmpfs
+/// the init just mounted.
+pub fn install_mediated_tool(source: &str, target: &str) {
+    install_mediated_tool_in(
+        Path::new(mvm_core::guest_netd::MEDIATED_TOOLS_BIN),
+        source,
+        target,
+    );
+}
+
+fn install_mediated_tool_in(dir: &Path, source: &str, target: &str) {
+    let Some(name) = Path::new(target).file_name() else {
+        return;
+    };
+    if let Err(e) = fs::create_dir_all(dir) {
+        eprintln!("mvm-guest-init: mkdir {}: {e}", dir.display());
+        return;
+    }
+    let link = dir.join(name);
+    // Replace rather than fail: activation can retry, and a stale link from a
+    // previous boot would shadow the current overlay.
+    let _ = fs::remove_file(&link);
+    if let Err(e) = std::os::unix::fs::symlink(source, &link) {
+        eprintln!("mvm-guest-init: link {source} to {}: {e}", link.display());
     }
 }
 
@@ -614,5 +648,58 @@ mod tests {
             leftovers.is_empty(),
             "staging file left behind: {leftovers:?}"
         );
+    }
+
+    /// The delivery that still works when the rootfs is sealed: a link in the
+    /// mediated-tool dir, which `PATH` finds even though the bind mount cannot
+    /// apply to a symlink on a read-only filesystem.
+    #[test]
+    fn install_mediated_tool_links_the_stand_in_under_its_target_name() {
+        let root = tempfile::tempdir().unwrap();
+        let bin = root.path().join("bin");
+
+        install_mediated_tool_in(&bin, "/mvm/runtime/ping", "/bin/ping");
+
+        // Named for the tool it stands in for, so `ping` on PATH finds it.
+        let link = bin.join("ping");
+        assert_eq!(
+            fs::read_link(&link).unwrap(),
+            Path::new("/mvm/runtime/ping")
+        );
+    }
+
+    #[test]
+    fn install_mediated_tool_replaces_a_stale_link_from_a_previous_boot() {
+        let root = tempfile::tempdir().unwrap();
+        let bin = root.path().join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        std::os::unix::fs::symlink("/stale/ping", bin.join("ping")).unwrap();
+
+        install_mediated_tool_in(&bin, "/mvm/runtime/ping", "/bin/ping");
+
+        assert_eq!(
+            fs::read_link(bin.join("ping")).unwrap(),
+            Path::new("/mvm/runtime/ping")
+        );
+    }
+
+    #[test]
+    fn mediated_tools_bin_is_an_absolute_guest_path() {
+        assert!(Path::new(mvm_core::guest_netd::MEDIATED_TOOLS_BIN).is_absolute());
+    }
+
+    #[test]
+    fn mediated_tools_name_the_target_binary() {
+        for (source, target) in MEDIATED_TOOLS {
+            assert!(target.starts_with('/'), "{target} must be absolute");
+            assert!(
+                source.starts_with("/mvm/runtime/"),
+                "{source} is an overlay path"
+            );
+            assert!(
+                Path::new(target).file_name().is_some(),
+                "{target} must name a binary for the PATH route"
+            );
+        }
     }
 }

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -763,6 +763,13 @@ pub fn build_guest_wrapper(req: &ExecRequest, add_dir_labels: &[String]) -> Stri
     for (k, v) in &req.env {
         script.push_str(&format!("export {k}={}\n", shell_quote(v)));
     }
+    // After the caller's exports, and composed against `$PATH` in the guest, so
+    // the mediated tools win whatever the image or the caller sets. A NIC-less
+    // guest's `ping` is one of these: the image's own copy fails at `socket()`.
+    script.push_str(&format!(
+        "export PATH={}:\"$PATH\"\n",
+        shell_quote(mvm_core::guest_netd::MEDIATED_TOOLS_BIN),
+    ));
     if let ExecTarget::LaunchPlan { entrypoint } = &req.target
         && let Some(wd) = &entrypoint.working_dir
     {
@@ -2283,7 +2290,47 @@ mod tests {
         assert!(script.starts_with("set -e\n"));
         assert!(script.contains("exec 'true'"));
         assert!(!script.contains("mount"));
-        assert!(!script.contains("export"));
+        // The mediated-tool PATH is always emitted; no caller export joins it.
+        assert_eq!(script.matches("export ").count(), 1);
+        assert!(script.contains(mvm_core::guest_netd::MEDIATED_TOOLS_BIN));
+    }
+
+    /// The image's own `ping` fails at `socket()` in a NIC-less guest, so the
+    /// mediated stand-in has to win even when the caller sets `PATH` itself.
+    #[test]
+    fn build_guest_wrapper_mediated_path_outranks_a_caller_supplied_path() {
+        let req = ExecRequest {
+            name: None,
+            warm_pool_size: 0,
+            image: ImageSource::Template("t".into()),
+            cpus: 1,
+            memory_mib: 256,
+            mem_initial_mib: None,
+            add_dirs: Vec::new(),
+            env: vec![("PATH".into(), "/usr/bin".into())],
+            target: ExecTarget::Inline {
+                argv: vec!["true".into()],
+            },
+            timeout_secs: Some(30),
+            pty: false,
+            network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
+            stdin: Vec::new(),
+            healthcheck: None,
+            hypervisor: None,
+            sdk_sidecar: None,
+        };
+        let script = build_guest_wrapper(&req, &[]);
+        let caller = script.find("export PATH='/usr/bin'").expect("caller PATH");
+        let mediated = script
+            .find(mvm_core::guest_netd::MEDIATED_TOOLS_BIN)
+            .expect("mediated PATH");
+        assert!(
+            mediated > caller,
+            "mediated PATH must come last to win; got:\n{script}"
+        );
+        // Composed against $PATH rather than replacing it, so the caller's
+        // entry survives behind ours.
+        assert!(script.contains(":\"$PATH\""), "got:\n{script}");
     }
 
     #[test]
@@ -2753,7 +2800,8 @@ mod tests {
         };
         let script = build_guest_wrapper(&req, &[]);
         assert!(!script.contains("cd "));
-        assert!(!script.contains("export "));
+        assert_eq!(script.matches("export ").count(), 1);
+        assert!(script.contains(mvm_core::guest_netd::MEDIATED_TOOLS_BIN));
         assert!(script.contains("exec 'true'"));
     }
 

--- a/crates/mvm-core/src/guest_netd.rs
+++ b/crates/mvm-core/src/guest_netd.rs
@@ -66,6 +66,16 @@ impl ConnectAck {
     }
 }
 
+/// Directory the guest init installs mediated tool replacements into.
+///
+/// Part of the same contract as [`proxy_env_vars`]: a NIC-less guest reaches
+/// the network through host-mediated stand-ins, and some of those are programs
+/// rather than environment variables. It lives on the `/run` tmpfs because the
+/// workload rootfs is read-only under verity — the stand-in cannot be written
+/// into the image, and on a busybox image `/bin/ping` is a symlink to the
+/// multi-call binary, so it cannot be mounted over either.
+pub const MEDIATED_TOOLS_BIN: &str = "/run/mvm/bin";
+
 /// Build the standard proxy environment for a cooperative app, pointing it at
 /// the in-guest loopback proxy at `proxy_addr` (e.g. `127.0.0.1:3128`). Both
 /// upper- and lower-case variants are emitted because tooling is inconsistent

--- a/specs/plans/270-universal-initramfs-vsock-activated-boot.md
+++ b/specs/plans/270-universal-initramfs-vsock-activated-boot.md
@@ -494,20 +494,23 @@ because it alone blocked boot loudly.
   had never run on the universal path, so this stayed latent until Step 2 wired
   it up. `replace_symlink_target` swaps the link for a plain file first and
   declines the substitution when it cannot, leaving the image's own tool alone.
-- [ ] **Step 5: Deliver mediated tools on a read-only rootfs**
+- [x] **Step 5: Deliver mediated tools on a read-only rootfs**
   A verity-sealed rootfs cannot be written, so the symlink cannot be replaced
-  and `/bin/ping` stays busybox — which fails at `socket()` in a NIC-less guest.
-  `/mvm/runtime/ping` works when invoked directly. Prepending the runtime
-  overlay to the workload `PATH` would cover unqualified `ping`; an absolute
-  `/bin/ping` needs something else.
+  and the bind mount cannot apply — the common case, since busybox links every
+  applet at one binary. The init now also links each stand-in into
+  `/run/mvm/bin` (on the tmpfs it just mounted, so always writable) and the
+  guest wrapper prepends that to `PATH`. The two routes are complementary: the
+  mount still wins for an absolute `/bin/ping` where it can apply, the link
+  covers the sealed case.
 - [ ] **Step 6: Regression witness**
   A live or BDD scenario asserting the workload environment is complete on the
   universal path, so this cannot regress silently a second time.
 
 Live verification on macOS/HVF, `machine run --image alpine`:
 `wget https://example.com` returns the page (`Network unreachable` before),
-`lo` is up, `/run/mvm` carries the signer anchor and resolver, and
-`/mvm/runtime/ping -c 2 google.com` reports 0% packet loss.
+`lo` is up, `/run/mvm` carries the signer anchor and resolver, and on a
+`ro` dm-verity root `which ping` resolves to `/run/mvm/bin/ping` with
+`ping -c 2 google.com` reporting 0% packet loss.
 
 ---
 


### PR DESCRIPTION
## What

Follow-up to #2050, which wired the mediated-tool substitution onto the universal-initramfs path and left one gap open.

The bind mount reaches a caller that runs `/bin/ping` outright, which no `PATH` order does — but it cannot apply at all when the target is a symlink on a read-only rootfs, because replacing the link needs a write the verity-sealed image cannot take. That is the *common* case: a busybox image links every applet at one binary. So on a sealed guest the substitution silently did nothing and the image's own `ping` failed at `socket()`, which is exactly what a NIC-less guest cannot do.

## How

Add the second delivery route, complementary to the first:

- The init links each stand-in into `/run/mvm/bin` — on the tmpfs it just mounted, so always writable regardless of how the rootfs is sealed.
- The guest wrapper prepends that directory to `PATH`.

The mount still wins where it can apply; the link covers the sealed case.

The `PATH` export is emitted **after** the caller's own exports and composed against `$PATH` in the guest, so the mediated tool wins whatever the image or the caller sets, while their entries survive behind it. `MEDIATED_TOOLS_BIN` lives in `mvm-core::guest_netd` next to `proxy_env_vars`: it is the same contract — a NIC-less guest reaching the network through host-mediated stand-ins — where some stand-ins are programs rather than environment variables.

## Verification

Live on macOS/HVF, `machine run --image alpine --allow-host google.com`, on a `ro` dm-verity root:

```
--- rootfs:     /dev/dm-0 / ext4 ro,relatime
--- which ping: /run/mvm/bin/ping
--- PATH:       /run/mvm/bin:/sbin:/usr/sbin:/bin:/usr/b...
--- ping:       2 sent, 2 received, 0% packet loss
```

Before this change `ping` on that guest resolved to busybox and failed at `socket()`.

`cargo nextest run --workspace` 8615/8615 green, `cargo clippy --workspace --all-targets` clean on both the host and `aarch64-unknown-linux-musl`, nightly `cargo fmt --all --check` clean.

New tests: the install links the stand-in under its target name, replaces a stale link from a previous boot, and the wrapper's mediated `PATH` outranks a caller-supplied `PATH` while still composing against it. Two existing wrapper tests asserted a minimal script contains no `export` at all; their intent — no caller env means no caller exports — is preserved by counting caller exports rather than forbidding the line.

Closes the last open step of Task 8 in plan 270.