### PR TITLE
feat(cache): verify build-cache artifacts on read instead of trusting the path

### DIFF
--- a/crates/mvm-build/src/pipeline/build_cache.rs
+++ b/crates/mvm-build/src/pipeline/build_cache.rs
@@ -171,7 +171,7 @@ pub fn workload_build_fingerprint(
     Ok(hex::encode(hasher.finalize()))
 }
 
-/// Directory holding `fingerprint -> revision` cache records
+/// Directory holding `fingerprint -> record` cache entries
 /// (`~/.mvm/dev/build-cache/`).
 fn build_cache_dir() -> PathBuf {
     PathBuf::from(mvm_core::config::mvm_home())
@@ -179,45 +179,84 @@ fn build_cache_dir() -> PathBuf {
         .join("build-cache")
 }
 
-/// Look up the nix revision a previous build recorded for `fingerprint`,
-/// or `None` if there is no record (or it is unreadable / malformed).
-/// Never returns a value that can't be a safe build-dir component.
-pub fn read_cached_revision(fingerprint: &str) -> Option<String> {
-    read_cached_revision_in(&build_cache_dir(), fingerprint)
+/// One build-cache record: the nix revision a fingerprint resolved to, plus
+/// the digests of the artifacts that build produced.
+///
+/// The digests are what make a cache hit checkable. Without them the only
+/// question a hit could answer is "does a file exist at the expected path",
+/// which cannot distinguish the artifacts of this build from a corrupted,
+/// truncated, or simply different build's.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CachedBuild {
+    /// Nix store hash, used as the `~/.mvm/dev/builds/<rev>/` component.
+    pub revision: String,
+    /// Artifact name → SHA-256, verified on every read.
+    #[serde(default)]
+    pub digests: mvm_core::cache_verify::ArtifactDigests,
 }
 
-/// Record `fingerprint -> revision` so the next build with the same
-/// inputs can skip the builder VM. Best-effort and atomic (temp +
-/// rename) so a concurrent reader never sees a torn record.
-pub fn write_cached_revision(fingerprint: &str, revision: &str) -> Result<()> {
-    write_cached_revision_in(&build_cache_dir(), fingerprint, revision)
+/// Look up the record a previous build wrote for `fingerprint`, or `None` if
+/// there is none (or it is unreadable, malformed, or names an unsafe
+/// revision). Never returns a value that can't be a safe build-dir component.
+pub fn read_cached_build(fingerprint: &str) -> Option<CachedBuild> {
+    read_cached_build_in(&build_cache_dir(), fingerprint)
 }
 
-fn read_cached_revision_in(dir: &Path, fingerprint: &str) -> Option<String> {
+/// Record `fingerprint -> (revision, digests)` so the next build with the same
+/// inputs can skip the builder VM. Atomic (temp + rename) so a concurrent
+/// reader never sees a torn record.
+pub fn write_cached_build(fingerprint: &str, record: &CachedBuild) -> Result<()> {
+    write_cached_build_in(&build_cache_dir(), fingerprint, record)
+}
+
+/// Drop the record for `fingerprint`. Called when verify-on-read rejects an
+/// entry, so a damaged build is re-derived rather than re-examined on every
+/// subsequent build.
+pub fn evict_cached_build(fingerprint: &str) {
+    evict_cached_build_in(&build_cache_dir(), fingerprint);
+}
+
+fn read_cached_build_in(dir: &Path, fingerprint: &str) -> Option<CachedBuild> {
     if !is_safe_component(fingerprint) {
         return None;
     }
     let raw = std::fs::read_to_string(dir.join(fingerprint)).ok()?;
-    let rev = raw.trim();
+    // Records are JSON. A record that does not parse — including one written
+    // by a build that predates verify-on-read, which stored a bare revision
+    // string — is a miss, never a fallback to trusting the path.
+    let record: CachedBuild = serde_json::from_str(&raw).ok()?;
     // The revision becomes a `~/.mvm/dev/builds/<rev>/` path component;
     // reject anything that isn't a plain store-hash token.
-    is_safe_component(rev).then(|| rev.to_string())
+    is_safe_component(&record.revision).then_some(record)
 }
 
-fn write_cached_revision_in(dir: &Path, fingerprint: &str, revision: &str) -> Result<()> {
+fn write_cached_build_in(dir: &Path, fingerprint: &str, record: &CachedBuild) -> Result<()> {
     anyhow::ensure!(
-        is_safe_component(fingerprint) && is_safe_component(revision),
+        is_safe_component(fingerprint) && is_safe_component(&record.revision),
         "refusing to write build-cache record with unsafe key/value"
+    );
+    anyhow::ensure!(
+        !record.digests.is_empty(),
+        "refusing to write a build-cache record with no artifact digests — an \
+         unverifiable record would be served on trust"
     );
     std::fs::create_dir_all(dir)
         .with_context(|| format!("creating build-cache dir {}", dir.display()))?;
     let final_path = dir.join(fingerprint);
     let tmp = dir.join(format!(".{}.{}.tmp", fingerprint, std::process::id()));
-    std::fs::write(&tmp, format!("{revision}\n"))
+    let body = serde_json::to_string(record).context("serialising build-cache record")?;
+    std::fs::write(&tmp, body)
         .with_context(|| format!("writing build-cache temp {}", tmp.display()))?;
     std::fs::rename(&tmp, &final_path)
         .with_context(|| format!("renaming build-cache record into {}", final_path.display()))?;
     Ok(())
+}
+
+fn evict_cached_build_in(dir: &Path, fingerprint: &str) {
+    if is_safe_component(fingerprint) {
+        let _ = std::fs::remove_file(dir.join(fingerprint));
+    }
 }
 
 /// A token safe to use as a single path component: non-empty, no path
@@ -590,20 +629,30 @@ mod tests {
         );
     }
 
+    /// A record carrying one artifact digest, enough to satisfy the
+    /// "never write an unverifiable record" guard.
+    fn record_with_digest(revision: &str) -> (tempfile::TempDir, CachedBuild) {
+        let build = tempfile::tempdir().unwrap();
+        std::fs::write(build.path().join("rootfs.ext4"), b"root").unwrap();
+        let mut digests = mvm_core::cache_verify::ArtifactDigests::new();
+        digests.record(build.path(), "rootfs.ext4").unwrap();
+        (
+            build,
+            CachedBuild {
+                revision: revision.to_string(),
+                digests,
+            },
+        )
+    }
+
     #[test]
     fn cache_record_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let fp = "a".repeat(64);
-        assert_eq!(
-            read_cached_revision_in(dir.path(), &fp),
-            None,
-            "absent → None"
-        );
-        write_cached_revision_in(dir.path(), &fp, "l6fjg21gfazc98635yr2zjcfxm6ykilk").unwrap();
-        assert_eq!(
-            read_cached_revision_in(dir.path(), &fp).as_deref(),
-            Some("l6fjg21gfazc98635yr2zjcfxm6ykilk")
-        );
+        assert_eq!(read_cached_build_in(dir.path(), &fp), None, "absent → None");
+        let (_build, record) = record_with_digest("l6fjg21gfazc98635yr2zjcfxm6ykilk");
+        write_cached_build_in(dir.path(), &fp, &record).unwrap();
+        assert_eq!(read_cached_build_in(dir.path(), &fp), Some(record));
     }
 
     #[test]
@@ -611,13 +660,62 @@ mod tests {
         // A tampered record must never become a path component.
         let dir = tempfile::tempdir().unwrap();
         let fp = "b".repeat(64);
-        std::fs::write(dir.path().join(&fp), "../../etc/passwd\n").unwrap();
-        assert_eq!(read_cached_revision_in(dir.path(), &fp), None);
+        std::fs::write(
+            dir.path().join(&fp),
+            r#"{"revision":"../../etc/passwd","digests":{"artifacts":{}}}"#,
+        )
+        .unwrap();
+        assert_eq!(read_cached_build_in(dir.path(), &fp), None);
     }
 
     #[test]
     fn cache_record_write_refuses_unsafe_key() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(write_cached_revision_in(dir.path(), "../escape", "rev").is_err());
+        let (_build, mut record) = record_with_digest("rev");
+        assert!(write_cached_build_in(dir.path(), "../escape", &record).is_err());
+        record.revision = "../escape".to_string();
+        assert!(write_cached_build_in(dir.path(), &"c".repeat(64), &record).is_err());
+    }
+
+    #[test]
+    fn cache_record_write_refuses_an_unverifiable_record() {
+        // Fail-closed at the write end too: a record with no digests could only
+        // ever be served on trust, so it must not be writable at all.
+        let dir = tempfile::tempdir().unwrap();
+        let record = CachedBuild {
+            revision: "l6fjg21gfazc98635yr2zjcfxm6ykilk".to_string(),
+            digests: mvm_core::cache_verify::ArtifactDigests::new(),
+        };
+        let err = write_cached_build_in(dir.path(), &"d".repeat(64), &record).unwrap_err();
+        assert!(
+            err.to_string().contains("no artifact digests"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn a_bare_revision_record_is_a_miss_not_a_trusted_hit() {
+        // The pre-verify-on-read record format was a bare revision string. It
+        // carries no digests, so it cannot be checked; reading it must miss and
+        // force a rebuild rather than serving unverified artifacts.
+        let dir = tempfile::tempdir().unwrap();
+        let fp = "e".repeat(64);
+        std::fs::write(dir.path().join(&fp), "l6fjg21gfazc98635yr2zjcfxm6ykilk\n").unwrap();
+        assert_eq!(read_cached_build_in(dir.path(), &fp), None);
+    }
+
+    #[test]
+    fn evict_removes_the_record_and_tolerates_absence() {
+        let dir = tempfile::tempdir().unwrap();
+        let fp = "f".repeat(64);
+        let (_build, record) = record_with_digest("l6fjg21gfazc98635yr2zjcfxm6ykilk");
+        write_cached_build_in(dir.path(), &fp, &record).unwrap();
+        assert!(read_cached_build_in(dir.path(), &fp).is_some());
+
+        evict_cached_build_in(dir.path(), &fp);
+        assert_eq!(read_cached_build_in(dir.path(), &fp), None);
+        // Second eviction is a no-op, not an error.
+        evict_cached_build_in(dir.path(), &fp);
+        evict_cached_build_in(dir.path(), "../escape");
     }
 }

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -483,10 +483,10 @@ fn dev_build_via_builder_vm(
     // image would be byte-identical — see `build_cache`'s soundness note.
     let fingerprint = build_cache_fingerprint(flake_ref, profile, mode);
     if let Some(fp) = fingerprint.as_deref()
-        && let Some(hit) = cached_build_result(fp)
+        && let Some(hit) = cached_build_result(env, fp)
     {
         env.log_success(&format!(
-            "Build cache hit — reusing {} (skipped builder VM + nix eval)",
+            "Build cache hit — reusing {} (verified; skipped builder VM + nix eval)",
             hit.build_dir
         ));
         return Ok(hit);
@@ -494,14 +494,57 @@ fn dev_build_via_builder_vm(
 
     let result = dev_build_via_builder_vm_uncached(env, flake_ref, profile, mode)?;
 
-    // Record the fingerprint → revision mapping so the next identical
-    // build short-circuits. Best-effort: a read-only cache dir just means
-    // the next build re-evaluates.
+    // Record the fingerprint → (revision, artifact digests) mapping so the next
+    // identical build short-circuits — and so that short-circuit is checkable.
+    // Best-effort: a read-only cache dir just means the next build re-evaluates.
     if let Some(fp) = fingerprint.as_deref() {
-        let _ = crate::pipeline::build_cache::write_cached_revision(fp, &result.revision_hash);
+        record_build_in_cache(env, fp, &result);
     }
     Ok(result)
 }
+
+/// Hash the artifacts a build produced and store them alongside the revision.
+///
+/// A failure here costs a redundant rebuild next time and nothing else, so it
+/// warns rather than failing the build that just succeeded. What it must not do
+/// is write a record it could not hash: an unverifiable record would be served
+/// on trust, which is the property this whole path exists to remove.
+#[cfg(feature = "builder-vm")]
+fn record_build_in_cache(env: &dyn ShellEnvironment, fingerprint: &str, result: &DevBuildResult) {
+    let mut digests = mvm_core::cache_verify::ArtifactDigests::new();
+    let build_dir = std::path::Path::new(&result.build_dir);
+    match digests.record_all(build_dir, CACHED_BUILD_ARTIFACTS) {
+        Ok(0) => {
+            tracing::debug!(
+                build_dir = %result.build_dir,
+                "no cacheable artifacts to digest; not recording a build-cache entry"
+            );
+            return;
+        }
+        Ok(_) => {}
+        Err(e) => {
+            env.log_warn(&format!(
+                "Could not digest build artifacts in {} ({e}); not caching this build",
+                result.build_dir
+            ));
+            return;
+        }
+    }
+    let record = crate::pipeline::build_cache::CachedBuild {
+        revision: result.revision_hash.clone(),
+        digests,
+    };
+    if let Err(e) = crate::pipeline::build_cache::write_cached_build(fingerprint, &record) {
+        tracing::debug!(error = %e, "build-cache record not written");
+    }
+}
+
+/// The artifacts a cache hit reuses, and therefore the ones a hit must verify.
+/// `rootfs.ext4` is the one universal output; `vmlinux` and `initrd` are absent
+/// for a kernel-less mkGuest image, and [`mvm_core::cache_verify::ArtifactDigests::record_all`]
+/// skips what a build did not produce.
+#[cfg(any(test, feature = "builder-vm"))]
+const CACHED_BUILD_ARTIFACTS: &[&str] = &["rootfs.ext4", "vmlinux", "initrd"];
 
 /// Compute the host-side build fingerprint for the cache, or `None` when
 /// the cache is disabled (`MVM_NO_BUILD_CACHE`) or the inputs can't be
@@ -531,19 +574,33 @@ fn build_cache_fingerprint(
     }
 }
 
-/// Reconstruct a cache-hit [`DevBuildResult`] from a recorded revision,
-/// or `None` when there is no record or its artifacts are incomplete.
-/// The completeness gate is `rootfs.ext4` — the one universal artifact;
-/// a kernel-less mkGuest image carries no `vmlinux` and relies on the
-/// cached-builder-kernel fallback resolved at boot.
+/// Reconstruct a cache-hit [`DevBuildResult`] from a recorded revision, or
+/// `None` when there is no record or the recorded artifacts do not verify.
+///
+/// Verification re-reads every recorded artifact and compares it to the digest
+/// the producing build stored. The previous completeness gate — "`rootfs.ext4`
+/// exists as a file" — answered a different question: it could not tell this
+/// build's rootfs from a corrupted one, a half-written one, or another build's.
+/// A rejected entry is evicted so the damage is re-derived rather than
+/// re-examined on every subsequent build.
 #[cfg(feature = "builder-vm")]
-fn cached_build_result(fingerprint: &str) -> Option<DevBuildResult> {
-    let revision_hash = crate::pipeline::build_cache::read_cached_revision(fingerprint)?;
+fn cached_build_result(env: &dyn ShellEnvironment, fingerprint: &str) -> Option<DevBuildResult> {
+    let record = crate::pipeline::build_cache::read_cached_build(fingerprint)?;
+    let revision_hash = record.revision;
     let build_dir = dev_build_dir(&revision_hash);
-    let rootfs_path = format!("{build_dir}/rootfs.ext4");
-    if !std::path::Path::new(&rootfs_path).is_file() {
+    let verdict = record.digests.verify(std::path::Path::new(&build_dir));
+    if !verdict.is_verified() {
+        if verdict.should_evict() {
+            env.log_warn(&format!(
+                "Build cache entry {revision_hash} did not verify ({}); discarding it and \
+                 rebuilding",
+                verdict.reason()
+            ));
+            crate::pipeline::build_cache::evict_cached_build(fingerprint);
+        }
         return None;
     }
+    let rootfs_path = format!("{build_dir}/rootfs.ext4");
     let initrd_path = detect_initrd(&build_dir);
     let runner_dir = detect_runner(&build_dir);
     let artifact_sizes = measure_artifact_sizes(&build_dir, initrd_path.is_some());
@@ -1279,6 +1336,144 @@ mod tests {
         fn log_success(&self, msg: &str) {
             self.logs.lock().unwrap().push(format!("SUCCESS: {}", msg));
         }
+
+        fn log_warn(&self, msg: &str) {
+            self.logs.lock().unwrap().push(format!("WARN: {}", msg));
+        }
+    }
+
+    impl TestEnv {
+        fn logged(&self) -> String {
+            self.logs.lock().unwrap().join("\n")
+        }
+    }
+
+    /// Stage a build directory plus its build-cache record inside an isolated
+    /// `MVM_HOME`, the way a successful build would leave them.
+    #[cfg(feature = "builder-vm")]
+    fn stage_cached_build(
+        env: &TestEnv,
+        fingerprint: &str,
+        revision: &str,
+        artifacts: &[(&str, &[u8])],
+    ) -> String {
+        let build_dir = dev_build_dir(revision);
+        std::fs::create_dir_all(&build_dir).unwrap();
+        for (name, bytes) in artifacts {
+            std::fs::write(format!("{build_dir}/{name}"), bytes).unwrap();
+        }
+        let result = DevBuildResult {
+            build_dir: build_dir.clone(),
+            vmlinux_path: format!("{build_dir}/vmlinux"),
+            initrd_path: None,
+            rootfs_path: format!("{build_dir}/rootfs.ext4"),
+            revision_hash: revision.to_string(),
+            cached: false,
+            runner_dir: None,
+            artifact_sizes: Default::default(),
+        };
+        record_build_in_cache(env, fingerprint, &result);
+        build_dir
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn verified_cache_entry_is_reused() {
+        let home = tempfile::tempdir().unwrap();
+        let mut guard = EnvGuard::new();
+        guard.isolate_mvm_home(home.path());
+        let env = TestEnv::new();
+        let fp = "a".repeat(64);
+
+        stage_cached_build(
+            &env,
+            &fp,
+            "l6fjg21gfazc98635yr2zjcfxm6ykilk",
+            &[("rootfs.ext4", b"root bytes"), ("vmlinux", b"kernel bytes")],
+        );
+
+        let hit = cached_build_result(&env, &fp).expect("an untouched entry must verify and hit");
+        assert_eq!(hit.revision_hash, "l6fjg21gfazc98635yr2zjcfxm6ykilk");
+        assert!(hit.cached);
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn tampered_cached_rootfs_is_rejected_and_evicted() {
+        // Substituted content: the entry used to be served whenever
+        // `rootfs.ext4` existed, so a swap went undetected and the provenance
+        // recorder then signed whatever bytes were on disk.
+        let home = tempfile::tempdir().unwrap();
+        let mut guard = EnvGuard::new();
+        guard.isolate_mvm_home(home.path());
+        let env = TestEnv::new();
+        let fp = "b".repeat(64);
+
+        let build_dir = stage_cached_build(
+            &env,
+            &fp,
+            "l6fjg21gfazc98635yr2zjcfxm6ykilk",
+            &[("rootfs.ext4", b"the real rootfs")],
+        );
+        // Same length — a size check would not notice.
+        std::fs::write(format!("{build_dir}/rootfs.ext4"), b"the fake rootfs").unwrap();
+
+        assert!(
+            cached_build_result(&env, &fp).is_none(),
+            "a substituted rootfs must not be served"
+        );
+        assert!(env.logged().contains("did not verify"), "{}", env.logged());
+        assert!(
+            crate::pipeline::build_cache::read_cached_build(&fp).is_none(),
+            "a rejected entry must be evicted, not re-examined every build"
+        );
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn intact_but_skewed_kernel_is_detected() {
+        // Identity discrepancy: both kernels are complete and readable, they
+        // just belong to different builds. Existence checks see nothing wrong,
+        // which is why kernel cache skew currently mimics a real bug.
+        let home = tempfile::tempdir().unwrap();
+        let mut guard = EnvGuard::new();
+        guard.isolate_mvm_home(home.path());
+        let env = TestEnv::new();
+        let fp = "c".repeat(64);
+
+        let build_dir = stage_cached_build(
+            &env,
+            &fp,
+            "l6fjg21gfazc98635yr2zjcfxm6ykilk",
+            &[("rootfs.ext4", b"root"), ("vmlinux", b"kernel for build C")],
+        );
+        std::fs::write(format!("{build_dir}/vmlinux"), b"kernel for build D").unwrap();
+
+        assert!(
+            cached_build_result(&env, &fp).is_none(),
+            "an intact kernel from another build must not be served"
+        );
+        assert!(env.logged().contains("vmlinux"), "{}", env.logged());
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn deleted_cached_artifact_is_a_miss() {
+        let home = tempfile::tempdir().unwrap();
+        let mut guard = EnvGuard::new();
+        guard.isolate_mvm_home(home.path());
+        let env = TestEnv::new();
+        let fp = "d".repeat(64);
+
+        let build_dir = stage_cached_build(
+            &env,
+            &fp,
+            "l6fjg21gfazc98635yr2zjcfxm6ykilk",
+            &[("rootfs.ext4", b"root")],
+        );
+        std::fs::remove_file(format!("{build_dir}/rootfs.ext4")).unwrap();
+
+        assert!(cached_build_result(&env, &fp).is_none());
     }
 
     #[cfg(feature = "builder-vm")]

--- a/crates/mvm-core/src/cache_verify.rs
+++ b/crates/mvm-core/src/cache_verify.rs
@@ -1,0 +1,418 @@
+//! Verify-on-read for path-keyed artifact caches.
+//!
+//! A cache that serves an entry because a file *exists* at the expected path
+//! answers "is something here?" when the question is "are these the bytes we
+//! built?". Those differ in three ways that all show up in practice:
+//!
+//! - **Corruption.** Silent data corruption is measured, not hypothetical, and
+//!   it does not move a file's size or mtime — so a size/mtime-keyed digest
+//!   sidecar (`crypto::image_verify::sha256_file_cached`) cannot see it. That is
+//!   why everything here streams the file through [`sha256_file`] on every read
+//!   rather than consulting that sidecar.
+//! - **Identity discrepancy.** An intact artifact that is the *wrong* artifact —
+//!   the whole file is readable and self-consistent, it just belongs to a
+//!   different build. A path-trusting cache cannot detect this at all, and it is
+//!   the shape of the cache-skew that otherwise mimics a real bug.
+//! - **Partial writes.** An entry whose producer died mid-write leaves a file
+//!   that exists and is short.
+//!
+//! ## What this is not
+//!
+//! This is a cache-trust check, not an admission decision, and not a defence
+//! against a host-level attacker: whoever can rewrite a cached artifact can
+//! usually rewrite the record that describes it. Workload admission stays with
+//! the signed execution plan. The value here is that a cache stops *silently*
+//! serving bytes it never checked.
+//!
+//! ## Fail-closed
+//!
+//! An entry with no recorded digests is [`CacheVerdict::Unrecorded`] and callers
+//! must treat it as a miss. Falling back to "the file is there, serve it" would
+//! reintroduce exactly the path-trust this module exists to remove.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::crypto::image_verify::sha256_file;
+
+/// Recorded digests for one cache entry: artifact name → lowercase SHA-256 hex.
+///
+/// Names are single path components relative to the entry's directory, so a
+/// record can never redirect a read outside the entry it describes.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactDigests {
+    #[serde(default)]
+    artifacts: BTreeMap<String, String>,
+}
+
+/// The outcome of verifying a cache entry against its recorded digests.
+///
+/// Only [`CacheVerdict::Verified`] permits serving the entry. Every other
+/// variant is a miss; [`CacheVerdict::Mismatch`] and [`CacheVerdict::Missing`]
+/// additionally mean the entry should be evicted rather than left to be
+/// re-consulted on the next read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CacheVerdict {
+    /// Every recorded artifact is present and hashes to its recorded digest.
+    Verified,
+    /// The entry carries no recorded digests. Treated as a miss, never trusted.
+    Unrecorded,
+    /// A recorded artifact is absent from the entry directory.
+    Missing { artifact: String },
+    /// A recorded artifact hashes to something other than what was recorded.
+    Mismatch {
+        artifact: String,
+        expected: String,
+        actual: String,
+    },
+    /// A recorded artifact could not be read to be hashed.
+    Unreadable { artifact: String, error: String },
+}
+
+impl CacheVerdict {
+    /// Whether the entry may be served. Only `Verified` qualifies.
+    pub fn is_verified(&self) -> bool {
+        matches!(self, Self::Verified)
+    }
+
+    /// Whether the entry should be evicted. `Unrecorded` is a miss but not
+    /// evidence of damage, so it is not an eviction trigger on its own.
+    pub fn should_evict(&self) -> bool {
+        matches!(
+            self,
+            Self::Missing { .. } | Self::Mismatch { .. } | Self::Unreadable { .. }
+        )
+    }
+
+    /// A one-line operator-facing reason, for the log line that explains why a
+    /// cache hit turned into a rebuild.
+    pub fn reason(&self) -> String {
+        match self {
+            Self::Verified => "verified".to_string(),
+            Self::Unrecorded => "no recorded digests (entry predates verify-on-read)".to_string(),
+            Self::Missing { artifact } => format!("{artifact} is missing"),
+            Self::Mismatch {
+                artifact,
+                expected,
+                actual,
+            } => format!(
+                "{artifact} hashes to {} but {} was recorded",
+                short(actual),
+                short(expected)
+            ),
+            Self::Unreadable { artifact, error } => {
+                format!("{artifact} could not be read: {error}")
+            }
+        }
+    }
+}
+
+/// First 12 hex chars, enough to identify a digest in a log line.
+fn short(hex: &str) -> &str {
+    hex.get(..12).unwrap_or(hex)
+}
+
+impl ArtifactDigests {
+    /// An empty record. Verifying against it yields [`CacheVerdict::Unrecorded`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether anything was recorded.
+    pub fn is_empty(&self) -> bool {
+        self.artifacts.is_empty()
+    }
+
+    /// Recorded artifact names, sorted.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.artifacts.keys().map(String::as_str)
+    }
+
+    /// Look up one recorded digest.
+    pub fn get(&self, artifact: &str) -> Option<&str> {
+        self.artifacts.get(artifact).map(String::as_str)
+    }
+
+    /// Hash `dir/artifact` and record it. A name that is not a single safe path
+    /// component is refused, so a record can never point outside its entry.
+    /// A missing file is skipped — callers record the artifacts a build
+    /// actually produced, and an optional artifact that was not produced must
+    /// not become a permanent `Missing` verdict.
+    pub fn record(&mut self, dir: &Path, artifact: &str) -> std::io::Result<bool> {
+        if !is_safe_artifact_name(artifact) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("unsafe cache artifact name {artifact:?}"),
+            ));
+        }
+        let path = dir.join(artifact);
+        if !path.is_file() {
+            return Ok(false);
+        }
+        let digest = sha256_file(&path)?;
+        self.artifacts.insert(artifact.to_string(), digest);
+        Ok(true)
+    }
+
+    /// Record every name in `artifacts` that exists under `dir`, returning how
+    /// many were recorded.
+    pub fn record_all(&mut self, dir: &Path, artifacts: &[&str]) -> std::io::Result<usize> {
+        let mut n = 0;
+        for artifact in artifacts {
+            if self.record(dir, artifact)? {
+                n += 1;
+            }
+        }
+        Ok(n)
+    }
+
+    /// Re-hash every recorded artifact under `dir` and compare.
+    ///
+    /// Streams each file fresh — deliberately not via the size/mtime digest
+    /// sidecar, which by construction cannot observe a change that leaves both
+    /// unchanged.
+    pub fn verify(&self, dir: &Path) -> CacheVerdict {
+        if self.artifacts.is_empty() {
+            return CacheVerdict::Unrecorded;
+        }
+        for (artifact, expected) in &self.artifacts {
+            if !is_safe_artifact_name(artifact) {
+                return CacheVerdict::Mismatch {
+                    artifact: artifact.clone(),
+                    expected: expected.clone(),
+                    actual: "<unsafe artifact name in record>".to_string(),
+                };
+            }
+            let path = dir.join(artifact);
+            if !path.is_file() {
+                return CacheVerdict::Missing {
+                    artifact: artifact.clone(),
+                };
+            }
+            match sha256_file(&path) {
+                Ok(actual) if actual.eq_ignore_ascii_case(expected) => {}
+                Ok(actual) => {
+                    return CacheVerdict::Mismatch {
+                        artifact: artifact.clone(),
+                        expected: expected.clone(),
+                        actual,
+                    };
+                }
+                Err(e) => {
+                    return CacheVerdict::Unreadable {
+                        artifact: artifact.clone(),
+                        error: e.to_string(),
+                    };
+                }
+            }
+        }
+        CacheVerdict::Verified
+    }
+}
+
+/// A single safe path component: non-empty, no separators, no traversal.
+fn is_safe_artifact_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 255
+        && name != "."
+        && name != ".."
+        && !name.contains('/')
+        && !name.contains('\\')
+        && !name.contains('\0')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, name: &str, contents: &[u8]) {
+        std::fs::write(dir.join(name), contents).unwrap();
+    }
+
+    #[test]
+    fn empty_record_is_unrecorded_not_verified() {
+        // The fail-closed contract: nothing recorded must never read as "fine".
+        let dir = tempfile::tempdir().unwrap();
+        let digests = ArtifactDigests::new();
+        assert_eq!(digests.verify(dir.path()), CacheVerdict::Unrecorded);
+        assert!(!digests.verify(dir.path()).is_verified());
+        assert!(!digests.verify(dir.path()).should_evict());
+    }
+
+    #[test]
+    fn recorded_then_unchanged_verifies() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "rootfs.ext4", b"root filesystem bytes");
+        write(dir.path(), "vmlinux", b"kernel bytes");
+
+        let mut digests = ArtifactDigests::new();
+        let n = digests
+            .record_all(dir.path(), &["rootfs.ext4", "vmlinux"])
+            .unwrap();
+        assert_eq!(n, 2);
+        assert!(digests.verify(dir.path()).is_verified());
+    }
+
+    #[test]
+    fn absent_optional_artifact_is_not_recorded() {
+        // initrd is optional; a build that produced none must not leave a
+        // record that permanently fails as Missing.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "rootfs.ext4", b"root");
+
+        let mut digests = ArtifactDigests::new();
+        let n = digests
+            .record_all(dir.path(), &["rootfs.ext4", "initrd"])
+            .unwrap();
+        assert_eq!(n, 1);
+        assert_eq!(digests.get("initrd"), None);
+        assert!(digests.verify(dir.path()).is_verified());
+    }
+
+    #[test]
+    fn flipped_byte_is_a_mismatch_and_evicts() {
+        // The corruption class. Same length, so a size check would pass.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "rootfs.ext4", b"aaaaaaaa");
+        let mut digests = ArtifactDigests::new();
+        digests.record(dir.path(), "rootfs.ext4").unwrap();
+
+        write(dir.path(), "rootfs.ext4", b"aaaaaaab");
+        let verdict = digests.verify(dir.path());
+        assert!(matches!(verdict, CacheVerdict::Mismatch { .. }));
+        assert!(!verdict.is_verified());
+        assert!(verdict.should_evict());
+    }
+
+    #[test]
+    fn intact_but_wrong_artifact_is_detected() {
+        // The identity-discrepancy class: swap two entries' kernels. Both files
+        // are complete and readable; each is simply the other build's. A
+        // path-trusting cache sees nothing wrong.
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        write(a.path(), "vmlinux", b"kernel from build A");
+        write(b.path(), "vmlinux", b"kernel from build B");
+
+        let mut da = ArtifactDigests::new();
+        da.record(a.path(), "vmlinux").unwrap();
+        let mut db = ArtifactDigests::new();
+        db.record(b.path(), "vmlinux").unwrap();
+
+        // Swap the two intact kernels.
+        let ka = std::fs::read(a.path().join("vmlinux")).unwrap();
+        let kb = std::fs::read(b.path().join("vmlinux")).unwrap();
+        std::fs::write(a.path().join("vmlinux"), &kb).unwrap();
+        std::fs::write(b.path().join("vmlinux"), &ka).unwrap();
+
+        assert!(a.path().join("vmlinux").is_file(), "still intact");
+        assert!(da.verify(a.path()).should_evict());
+        assert!(db.verify(b.path()).should_evict());
+    }
+
+    #[test]
+    fn truncated_artifact_is_a_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "rootfs.ext4", b"the whole thing");
+        let mut digests = ArtifactDigests::new();
+        digests.record(dir.path(), "rootfs.ext4").unwrap();
+
+        write(dir.path(), "rootfs.ext4", b"the whole");
+        assert!(digests.verify(dir.path()).should_evict());
+    }
+
+    #[test]
+    fn deleted_artifact_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "rootfs.ext4", b"root");
+        let mut digests = ArtifactDigests::new();
+        digests.record(dir.path(), "rootfs.ext4").unwrap();
+
+        std::fs::remove_file(dir.path().join("rootfs.ext4")).unwrap();
+        assert_eq!(
+            digests.verify(dir.path()),
+            CacheVerdict::Missing {
+                artifact: "rootfs.ext4".to_string()
+            }
+        );
+        assert!(digests.verify(dir.path()).should_evict());
+    }
+
+    #[test]
+    fn unsafe_artifact_name_is_refused_on_record() {
+        let dir = tempfile::tempdir().unwrap();
+        for name in ["../escape", "a/b", "..", "", "nul\0byte"] {
+            assert!(
+                digests_record(dir.path(), name).is_err(),
+                "{name:?} must be refused"
+            );
+        }
+    }
+
+    fn digests_record(dir: &Path, name: &str) -> std::io::Result<bool> {
+        ArtifactDigests::new().record(dir, name)
+    }
+
+    #[test]
+    fn unsafe_artifact_name_in_a_tampered_record_cannot_escape() {
+        // A record is on-disk data; a hand-edited one must not turn into a read
+        // outside the entry directory.
+        let dir = tempfile::tempdir().unwrap();
+        let json = r#"{"artifacts":{"../../etc/passwd":"00"}}"#;
+        let digests: ArtifactDigests = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            digests.verify(dir.path()),
+            CacheVerdict::Mismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn record_round_trips_through_json() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "rootfs.ext4", b"root");
+        let mut digests = ArtifactDigests::new();
+        digests.record(dir.path(), "rootfs.ext4").unwrap();
+
+        let json = serde_json::to_string(&digests).unwrap();
+        let back: ArtifactDigests = serde_json::from_str(&json).unwrap();
+        assert_eq!(digests, back);
+        assert!(back.verify(dir.path()).is_verified());
+    }
+
+    #[test]
+    fn verify_does_not_consult_the_size_mtime_sidecar() {
+        // Bit-rot leaves size and mtime untouched, so a sidecar-backed digest
+        // would report the stale value. Prove verification reads the bytes: seed
+        // a sidecar that claims the ORIGINAL digest, then change the content and
+        // restore size+mtime. If verify consulted the sidecar it would pass.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rootfs.ext4");
+        std::fs::write(&path, b"original").unwrap();
+        let original_meta = std::fs::metadata(&path).unwrap();
+        let original_mtime = original_meta.modified().unwrap();
+
+        let mut digests = ArtifactDigests::new();
+        digests.record(dir.path(), "rootfs.ext4").unwrap();
+        // Populate the sidecar with the pre-rot digest.
+        let _ = crate::crypto::image_verify::sha256_file_cached(&path).unwrap();
+
+        // Same length, restored mtime — the sidecar still "matches".
+        std::fs::write(&path, b"rottened").unwrap();
+        filetime_set(&path, original_mtime);
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), original_meta.len());
+
+        assert!(
+            digests.verify(dir.path()).should_evict(),
+            "verify must re-read the bytes, not trust size+mtime"
+        );
+    }
+
+    fn filetime_set(path: &Path, mtime: std::time::SystemTime) {
+        let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        f.set_modified(mtime).unwrap();
+        f.sync_all().unwrap();
+    }
+}

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod arch;
 pub mod build_env;
+pub mod cache_verify;
 pub mod catalog;
 pub mod checkpoint;
 // The `MvmClient` machine-driving facade (trait + DTOs + mock + remote gateway).

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -87,11 +87,18 @@ for detailed scope and acceptance criteria.
         drift mechanism, not an address)
   - [ ] WS4 — ≥2 independent verifiers over the WS3 corpus
   - [ ] WS5 — bind each witness to its recorded red-proof
-  - [ ] WS6 — **lead item**: content-address the kernel + build cache, verify on
-        read as well as on write (**blocks plan 279 WS1**; scheduled in
-        `specs/SPRINT.md`). The 2026-08-01 recon revision reverses finding 2 —
-        integrity-on-read is the one attestation property no surveyed system
-        enforces, mvm included — which promotes this from tail to lead
+  - [~] WS6 — **lead item**: content-address the caches, verify on read
+        (**unblocks plan 279 WS1**). The 2026-08-01 recon revision reverses
+        finding 2 — integrity-on-read is the one attestation property no
+        surveyed system enforces, mvm included — which promoted this to lead
+    - [x] Dev-build artifact cache (`~/.mvm/dev/builds/<rev>/`): shared
+          `mvm_core::cache_verify`, digests in the build-cache record, verify
+          on read, fail closed and evict; covers bit-rot, truncation and the
+          intact-but-wrong-artifact class an existence check cannot see
+    - [ ] Workload/builder kernel cache: still path-trusting.
+          `verify_fetched_kernel` exists with **no production caller** — needs
+          the published pin threaded to the fetch and read sites
+    - [ ] Cold-tier background scrub (recon §7.9)
   - [ ] WS7 — σ/κ separation and the transform descriptor: the protocol digest
         over plaintext and the storage address over bytes at rest as disjoint
         types, σ as a set, descriptor as an open enumeration. Free while every

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -45,13 +45,23 @@
       directions are enforced by tests that parse the specific named nix list;
       both were planted against and recorded in `specs/VERIFICATION.md`.
 
-- [ ] Build cache verify-on-read — schedule **plan 276 WS6**. `~/.mvm/dev/builds/
-      <rev>/` is served on a hit if `rootfs.ext4` merely exists as a file: no
-      digest, no signature, so content substitution is undetected, and the
-      provenance recorder then signs whatever bytes are on disk. The audit log
-      faithfully records a substituted image as legitimate. Plan 276 is written
-      and Proposed; this moves WS6 into the sprint. Prerequisite for plan 279
-      WS1 so the new cache key and the new verification do not land together.
+- [~] Build cache verify-on-read — **plan 276 WS6**. `~/.mvm/dev/builds/<rev>/`
+      was served on a hit if `rootfs.ext4` merely existed as a file: no digest,
+      no signature, so content substitution went undetected and the provenance
+      recorder then signed whatever bytes were on disk — the audit log
+      faithfully recording a substituted image as legitimate.
+  - [x] Closed for the dev-build artifact cache: `mvm_core::cache_verify` is the
+        shared record-and-re-read discipline, the build-cache record carries the
+        artifact digests, a hit is verified on read, and a failure fails closed
+        and evicts. An unverifiable record is refused at write and missed at
+        read, so the previous bare-revision format is never served on trust.
+        Detects bit-rot, truncation, deletion, and the intact-but-wrong-artifact
+        case that an existence check structurally cannot see. This unblocks
+        plan 279 WS1.
+  - [ ] Still open: the workload/builder kernel cache is path-trusting, and
+        `verify_fetched_kernel` has no production caller — neither the fetch nor
+        the read path checks a kernel against its pin. Needs the published
+        per-arch expected hash threaded to both sites.
 
 - [ ] Build action identity + artifact manifest — **plan 279**
       (`specs/plans/279-build-action-identity-and-artifact-manifest.md`).

--- a/specs/VERIFICATION.md
+++ b/specs/VERIFICATION.md
@@ -31,6 +31,10 @@ row below records a defect that was planted to prove the gate fires.
 | `check-workflow-paths` | Point a fuzz step's `working-directory` at `crates/mvm-oci` (the pre-consolidation path that made the fuzz lane dead for ten nightlies) | yes |
 | `check-mvm-host-binaries-sync` | Drop `--bin mvm-builderd` from the builder-VM cross-compile step, reproducing the "path does not exist" image-build failure | yes |
 | `check-mutation-witnesses` (shard matrix) | Remove the `mvm-cli` shard from `security.yml`'s mutation matrix, so that package would never be mutated while every shard stayed green | yes — `package mvm-cli is on the mutation surface but has no shard` |
+| `verify_does_not_consult_the_size_mtime_sidecar` | Point `ArtifactDigests::verify` at `sha256_file_cached` instead of `sha256_file`, so a rewrite that preserves size and mtime reads as unchanged | yes |
+| `tampered_cached_rootfs_is_rejected_and_evicted` | Serve a build-cache hit on `rootfs.ext4` existing rather than on its recorded digest | yes |
+| `intact_but_skewed_kernel_is_detected` | Replace a cached `vmlinux` with another build's intact kernel — detected only because the digest is recorded, never by an existence check | yes |
+| `cache_record_write_refuses_an_unverifiable_record` | Allow a build-cache record with no artifact digests, which could only ever be served on trust | yes |
 | `check-claim-witness-freshness` | Change `security.yml`'s cron to hourly so its real last-run age exceeds the allowance; reported `security.yml last ran 14h ago (schedule allows 3h)` naming all 8 claims it backs | yes |
 | `cargo-fuzz crates still compile` | None planted — run against main it independently rediscovered both real defects (`fuzz_authed_path` E0308, `fuzz_build_image` unclosed delimiter) that the nightly took eleven days to surface | yes |
 | `included_top_level_is_a_superset_of_the_nix_filter_allowlist` | Remove `"nix"` from `INCLUDED_TOP_LEVEL` while `workspace-filter.nix` still admits it, so a `nix/` change would go unhashed and boot a stale image | yes |

--- a/specs/plans/276-content-addressing-conformance-and-defense.md
+++ b/specs/plans/276-content-addressing-conformance-and-defense.md
@@ -144,13 +144,24 @@ Narrower than first written: the mutation surface, the freshness gate and the 36
 
 **Why this is first.** Per the revised recon §7.1, integrity-on-read is the one attestation property no surveyed system enforces — not a coverage nicety. **Downstream dependency: plan 279 WS1 (`ActionDigest`) is blocked on this landing** — plan 279 states the closure explicitly ("`~/.mvm/dev/builds/<rev>/` is served on a hit if `rootfs.ext4` merely exists as a file … Closing this is plan 276 WS6, not this plan"). `specs/SPRINT.md` already carries the same note.
 
-- [ ] Identify the workload/builder kernel cache read path (the one with no staleness check) and the `mvm-build` artifact cache read paths, including `~/.mvm/dev/builds/<rev>/`.
-- [ ] Add a content-address (SHA-256) to each cached artifact's key and verify **on read** on every hit (recompute, compare, fail closed per S3; evict on mismatch). `mvm_core::pack_cache` already implements exactly this discipline for packs — reuse it rather than writing a second cache.
-- [ ] Verify on read *as well as* on write. Recon §7.1 measured `kappa-registry` at 4 of 13 write paths verified and **no** read path; a write-only check is the failure mode to avoid, not the target.
-- [ ] Size the check to the object (recon §7.9): rehash small artifacts before serving; carry a running hash across frames for streamed artifacts and deliver the verdict in a trailer; add a background scrub over the reachability walk for cold artifacts — on-access verification never visits the blocks that are quietly rotting, and the measured corruption pattern has high spatial and temporal locality.
-- [ ] Cover the **identity-discrepancy** class explicitly, not just bit-rot: an intact artifact that is the *wrong* artifact. This is the workload-kernel cache-skew that currently mimics real bugs, and a path-trusting cache cannot see it at all.
-- [ ] Keep caching within the per-tenant/trust boundary (S2); dm-verity roothash chain unchanged (S4).
-- [ ] Tests: cache-hit-verifies, tampered-cache-entry-rejected, skewed-kernel-detected, wrong-but-intact-artifact-detected. `VERIFICATION.md` row (planted: flip a byte in a cached kernel → verify-on-read rejects; swap two intact cached kernels → identity discrepancy fires).
+**Read paths, and their status.** There are two, and they fail differently.
+
+- [x] **The dev-build artifact cache (`~/.mvm/dev/builds/<rev>/`)** — the one plan 279 WS1 waits on. Served a hit whenever `rootfs.ext4` existed as a file; now content-addressed and verified on read.
+- [ ] **The workload/builder kernel cache (`~/.mvm/cache/builder-vm/<arch>/kernels/<label>/vmlinux`)** — still path-trusting. See "The kernel cache" below; it needs the published pin threaded to the read site and is deliberately not bundled into the same change.
+
+Landed:
+
+- [x] `mvm_core::cache_verify` — the shared discipline: `ArtifactDigests` records artifact→SHA-256, `verify` re-reads and compares, `CacheVerdict` separates *serve* from *miss* from *evict*. Streams via `crypto::image_verify::sha256_file`, deliberately **not** `sha256_file_cached`, whose size+mtime sidecar by construction cannot observe a change that leaves both unchanged.
+- [x] The build-cache record carries the digests, not just the revision. A record with no digests is refused at write (it could only ever be served on trust) and is a miss at read — including the previous bare-revision record format, which is unverifiable and so is not honoured.
+- [x] Verify on read on every hit; fail closed per S3 and evict the record on mismatch, so damage is re-derived rather than re-examined on every subsequent build.
+- [x] Covers the **identity-discrepancy** class, not just bit-rot: an intact artifact that is the *wrong* artifact. `intact_but_skewed_kernel_is_detected` swaps one build's `vmlinux` for another's — both complete and readable, which is exactly what a path-trusting cache cannot see, and exactly the kernel cache skew that mimics real bugs.
+- [x] Per-tenant/trust boundary unchanged (S2 — the dev build cache is already per-`MVM_HOME`); dm-verity roothash chain untouched (S4).
+- [x] Tests + four `specs/VERIFICATION.md` falsifiability rows, each with its planted defect recorded. The sidecar row was proved by pointing `verify` at `sha256_file_cached` and confirming only that test went red.
+
+Remaining in WS6:
+
+- [ ] **The kernel cache.** `mvm_build::kernel_fetch::resolve_kernel` returns `Cached(path)` on `path.exists()`, and `resolve_pinned_kernel_with` maps that arm straight to a path with no check. `verify_fetched_kernel` — which hashes against `KernelArtifactId::artifact_hash` and deletes on mismatch — **exists and has no production caller at all**: not on the fetch path, not on the read path. Its own doc comment says installed builds "should still verify it against the pin before boot", and nothing does. Wiring it needs the published per-arch/variant expected hash threaded to both sites (the release checksum manifest, as `download_dev_image` already does), which is why it is its own change rather than an appendix to this one.
+- [ ] **Size the check to the object** (recon §7.9). Today every recorded artifact is rehashed in full on each hit; that is correct and bounded (a cache hit replaces a builder-VM boot), but the cold tier is unaddressed. A background scrub over the reachability walk is the only tier that catches the measured corruption locality — on-access verification never visits the blocks that are quietly rotting.
 
 ### WS7 — σ/κ separation and the transform descriptor (recon §7.8)
 


### PR DESCRIPTION
Plan 276 WS6, first half. **Stacked on #2038** (`docs/plan-276-recon-crossover`) because it ticks the plan text that lives there; GitHub will retarget to `main` once that merges.

## The gap

`cached_build_result` returned a cache hit whenever `rootfs.ext4` passed `is_file()`. No digest, no comparison. That answers "is something here?" when the question is "are these the bytes we built?" — so a substituted, corrupted, truncated, or simply *different* build's artifacts were indistinguishable from the real ones. The provenance recorder then signed whatever was on disk, which is how the audit log ends up faithfully recording a substituted image as legitimate.

This is the closure plan 279 WS1 is waiting on, by name.

## What landed

`mvm_core::cache_verify` — the shared discipline. `ArtifactDigests` records artifact→SHA-256 when a build produces them; `verify` re-reads and compares; `CacheVerdict` separates *serve* from *miss* from *evict*. The build-cache record carries those digests alongside the revision, a hit is verified on read, and a failure fails closed and evicts so damage is re-derived rather than re-examined on every subsequent build.

**Fail-closed at both ends.** A record with no digests is refused at write — it could only ever be served on trust — and is a miss at read. That includes the previous bare-revision record format, which is unverifiable and so is never honoured. Absence of a hash must not degrade into trusting the path.

**It streams the file rather than consulting the size+mtime digest sidecar**, and that distinction is the point. Silent corruption moves neither size nor mtime, so `sha256_file_cached` would report the pre-rot digest indefinitely. `verify_does_not_consult_the_size_mtime_sidecar` pins it; pointing `verify` at the cached variant turns exactly that test red and nothing else.

**Three failure classes, and the third is why this matters.** Corruption and truncation are the obvious ones. **Identity discrepancy** — an intact artifact that is the *wrong* artifact — is invisible to an existence check by construction. `intact_but_skewed_kernel_is_detected` swaps two builds' kernels; both stay complete and readable. That is precisely the kernel cache skew that has been mimicking real bugs.

S2 (per-tenant boundary) is unchanged — the dev build cache is already per-`MVM_HOME`. S4 (dm-verity roothash chain) is untouched. Per S1 this gates *cache trust*, not workload admission; the signed execution plan remains the sole authority, and the module says so rather than implying a stronger property.

## Not addressed here, and worse than the plan assumed

The **workload/builder kernel cache is still path-trusting**. `resolve_kernel` returns `Cached(path)` on `path.exists()` and `resolve_pinned_kernel_with` maps that arm straight to a path.

`verify_fetched_kernel` — which hashes against `KernelArtifactId::artifact_hash` and deletes on mismatch — **has no production caller at all.** Not on the fetch path, not on the read path. Its own doc comment says installed builds "should still verify it against the pin before boot", and nothing ever has.

Wiring it needs the published per-arch expected hash threaded to both sites (the release checksum manifest, as `download_dev_image` already does), which touches the release surface — so it stays its own change rather than an appendix to this one. Recorded in plan 276, `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md` as the remaining WS6 work, along with the cold-tier background scrub.

## Verification

- `cargo nextest run --workspace -j 6` — **8603 passed**, 17 skipped
- `cargo test --workspace --doc` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- nightly `cargo fmt --all`
- Gates: `check-no-spec-refs-in-comments`, `check-no-overclaim`, `check-deferrals`, `check-honesty`, `check-single-home`, `check-test-home-isolation`, `check-file-size`, `check-core-runtime-free` — all clean
- Four new `specs/VERIFICATION.md` falsifiability rows, each with its planted defect recorded