### PR TITLE
fix(build): rebuild the per-VM supervisors when mvm-runtime changes

### DIFF
--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -157,6 +157,13 @@ fn build_native_aux_helpers(workspace_root: &Path, out_dir: &Path) {
         "cargo:rerun-if-changed={}",
         workspace_root.join("crates/deps/libkrun-sys/src").display()
     );
+    // The per-VM supervisors link `mvm-runtime` — it owns the VMM, the device
+    // model, and the FDT the guest boots on. Without this watch an edit there
+    // rebuilds `mvmctl` but leaves the supervisor binaries stale, so the change
+    // never reaches a running guest and the edit appears to do nothing. Use the
+    // file-by-file walk rather than a directory entry, for the same reason the
+    // `mvm-build` watch does.
+    emit_rerun_for_tree(&workspace_root.join("crates/mvm-runtime/src"));
 
     let libkrun_present = libkrun_header_present();
     for spec in build_aux_helpers::aux_helper_specs(&target_os, &target_arch, libkrun_present) {


### PR DESCRIPTION
`mvm-cli`'s build script compiles the per-VM host helpers —
`mvm-hvf-supervisor`, `mvm-libkrun-supervisor`, `mvm-bridge` — and declares
rerun triggers for `mvm-hostd/src`, `mvm-core/src`, `libkrun-sys/src`, and
`Cargo.lock`.

It never watched **`mvm-runtime/src`**, which is where the VMM, the device
model, the FDT, and the kernel loader live — and which every one of those
helpers links.

So editing the VMM rebuilds `mvmctl` and leaves the supervisors stale. The
guest keeps booting on the old device tree. No error, no warning, no version
skew to notice.

## Why this is worth its own PR

The failure mode is silent by construction. The observable is *"my change did
nothing"*, which reads as a wrong diagnosis rather than a stale artifact.

It cost me most of an afternoon: a one-line device-tree change that removes a
four-second guest boot stall measured as a complete no-op across several
rebuild cycles, because the binary that builds the device tree was never
recompiled. I concluded my diagnosis was wrong, wrote that up, and moved on —
twice — before checking the build script.

With this fix applied, the same change takes `control plane ready` from
**4076ms to 0ms** and end-to-end `machine run` from **5.4s to 1.35s**. Nothing
about that change was different; it just finally reached the guest.

## Implementation

`emit_rerun_for_tree` rather than a directory-level `rerun-if-changed`, for the
reason the neighbouring `mvm-build` watch already documents: cargo does not
reliably detect content edits under a directory entry.

## Verification

Before: supervisor mtime unchanged across an `mvm-runtime` edit + rebuild.
After: supervisor rebuilt at 20:50:30 following a 19:28:29 edit to
`crates/mvm-runtime/src/vmm/fdt.rs`, and the change took effect in the guest.

fmt + clippy clean via the pre-commit hook.