### PR TITLE
fix(vmm): seed the guest CSPRNG at boot — machine run 5.4s to 1.35s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,9 @@ jobs:
       - name: no new builder shell-job dispatch sites
         run: cargo run -p xtask -- check-builder-shell-job-sites
 
+      - name: every VMM boot path seeds the guest CSPRNG
+        run: cargo run -p xtask -- check-guest-entropy-seed
+
       - name: runtime-overlay version pinned to workspace
         run: cargo run -p xtask -- check-runtime-overlay-version
 

--- a/crates/mvm-runtime/src/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/hvf/kernel_boot.rs
@@ -460,12 +460,18 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
     if channels.virtiofs_root.is_some() {
         virtio_nodes.push((FS_MMIO_BASE, FS_IRQ));
     }
+    // Fresh host entropy per boot. Without it the guest — which has no NIC,
+    // no rotating disk, and no virtio-rng — has almost no interrupt jitter to
+    // harvest, so the first userspace `getrandom(2)` blocks for seconds on
+    // CSPRNG init before the workload can start.
+    let rng_seed = fdt::fresh_rng_seed();
     let dtb = fdt::build_dtb(
         &bootargs,
         RAM_BASE,
         ram_size as u64,
         initrd_bounds,
         &virtio_nodes,
+        Some(&rng_seed),
     );
     if dtb.len() > FDT_MAX_SIZE as usize {
         return Err(HvfError::BadKernel);

--- a/crates/mvm-runtime/src/vmm/fdt.rs
+++ b/crates/mvm-runtime/src/vmm/fdt.rs
@@ -79,6 +79,12 @@ impl FdtBuilder {
         self.pad_struct();
     }
 
+    /// Raw byte-blob property. Used for `/chosen/rng-seed`, whose value is
+    /// opaque entropy rather than cells or a string.
+    pub fn prop_bytes(&mut self, name: &str, bytes: &[u8]) {
+        self.prop_raw(name, bytes);
+    }
+
     pub fn prop_empty(&mut self, name: &str) {
         self.prop_raw(name, &[]);
     }
@@ -166,15 +172,44 @@ const IRQ_LEVEL_HI: u32 = 4;
 /// SPI on guest EOI, which only works with edge semantics.
 const IRQ_EDGE_RISING: u32 = 1;
 
+/// Bytes of entropy handed to the guest through `/chosen/rng-seed`. 32 bytes
+/// is what other arm64 VMMs pass and is comfortably above the pool's init
+/// threshold.
+pub const RNG_SEED_LEN: usize = 32;
+
+/// Fresh seed from the host OS CSPRNG. Call once per boot — reusing a seed
+/// across guests would hand them a shared starting state.
+pub fn fresh_rng_seed() -> [u8; RNG_SEED_LEN] {
+    use rand::RngCore;
+    let mut seed = [0u8; RNG_SEED_LEN];
+    rand::rngs::OsRng.fill_bytes(&mut seed);
+    seed
+}
+
 /// Build a device tree for an arm64 Linux guest: one CPU, GICv3, arch timer,
 /// PL011 console (with IRQ + clock), PSCI over HVC, memory, and `/chosen`
 /// bootargs. Enough for the kernel to set up its console and boot.
+///
+/// `rng_seed` seeds the guest CSPRNG through `/chosen/rng-seed`. Pass fresh
+/// host entropy on every boot. Omitting it is what makes a workload sit at
+/// `random: crng init done` for seconds: this guest has no NIC, no rotating
+/// disk, and no virtio-rng, so there is almost no interrupt jitter for the
+/// kernel to harvest, and the first userspace `getrandom(2)` blocks until the
+/// pool initialises.
+///
+/// Linux credits the seed at `early_init_dt_scan_chosen` and zeroes the
+/// property afterwards. No kernel config is needed: the old
+/// `CONFIG_RANDOM_TRUST_BOOTLOADER` gate was removed in 6.2 and trust is now
+/// unconditional, leaving `random.trust_bootloader=0` on the cmdline as the
+/// only way to turn it off — which mvm never sets. This is the same mechanism
+/// other arm64 VMMs use.
 pub fn build_dtb(
     bootargs: &str,
     ram_base: u64,
     ram_size: u64,
     initrd: Option<(u64, u64)>,
     virtio: &[(u64, u32)],
+    rng_seed: Option<&[u8]>,
 ) -> Vec<u8> {
     let reg_pair = |addr: u64, size: u64| {
         [
@@ -210,6 +245,9 @@ pub fn build_dtb(
     f.begin_node("chosen");
     f.prop_str("bootargs", bootargs);
     f.prop_str("stdout-path", &format!("/pl011@{SERIAL_MMIO_BASE:x}"));
+    if let Some(seed) = rng_seed {
+        f.prop_bytes("rng-seed", seed);
+    }
     if let Some((start, end)) = initrd {
         f.prop_cells("linux,initrd-start", &[(start >> 32) as u32, start as u32]);
         f.prop_cells("linux,initrd-end", &[(end >> 32) as u32, end as u32]);
@@ -300,6 +338,7 @@ mod tests {
             0x2000_0000,
             None,
             &[],
+            None,
         );
         assert_eq!(be32(&dtb, 0), FDT_MAGIC);
         assert_eq!(be32(&dtb, 4) as usize, dtb.len(), "totalsize == blob len");
@@ -320,6 +359,7 @@ mod tests {
             0x2000_0000,
             None,
             &[],
+            None,
         );
         let needle = b"earlycon=pl011,mmio32,0x9000000";
         assert!(
@@ -344,7 +384,7 @@ mod tests {
 
     #[test]
     fn initrd_props_present_only_when_supplied() {
-        let without = build_dtb("x", 0x8000_0000, 0x2000_0000, None, &[]);
+        let without = build_dtb("x", 0x8000_0000, 0x2000_0000, None, &[], None);
         assert!(!without.windows(18).any(|w| w == b"linux,initrd-start"));
         let with = build_dtb(
             "x",
@@ -352,6 +392,7 @@ mod tests {
             0x2000_0000,
             Some((0x9000_0000, 0x9000_0600)),
             &[],
+            None,
         );
         assert!(with.windows(18).any(|w| w == b"linux,initrd-start"));
         assert!(with.windows(16).any(|w| w == b"linux,initrd-end"));
@@ -359,8 +400,43 @@ mod tests {
 
     #[test]
     fn struct_block_is_4_byte_aligned() {
-        let dtb = build_dtb("x", 0x4000_0000, 0x1000_0000, None, &[]);
+        let dtb = build_dtb("x", 0x4000_0000, 0x1000_0000, None, &[], None);
         assert!(be32(&dtb, 8).is_multiple_of(4), "off_dt_struct 4-aligned");
         assert!(be32(&dtb, 16).is_multiple_of(8), "off_mem_rsvmap 8-aligned");
+    }
+
+    #[test]
+    fn rng_seed_is_embedded_verbatim_when_supplied() {
+        // Without a seed the guest has no entropy source at all — no NIC, no
+        // rotating disk, no virtio-rng — and userspace blocks for seconds on
+        // CSPRNG init before the workload runs.
+        let seed: Vec<u8> = (0..RNG_SEED_LEN as u8).collect();
+        let with = build_dtb("x", 0x4000_0000, 0x1000_0000, None, &[], Some(&seed));
+        assert!(
+            with.windows(seed.len()).any(|w| w == seed.as_slice()),
+            "the seed bytes must reach the blob verbatim"
+        );
+        assert!(
+            with.windows(8).any(|w| w == b"rng-seed"),
+            "the property must be named rng-seed for Linux to credit it"
+        );
+    }
+
+    #[test]
+    fn no_rng_seed_property_when_none_is_supplied() {
+        let without = build_dtb("x", 0x4000_0000, 0x1000_0000, None, &[], None);
+        assert!(
+            !without.windows(8).any(|w| w == b"rng-seed"),
+            "an absent seed must not leave a stray property name behind"
+        );
+    }
+
+    #[test]
+    fn fresh_rng_seed_differs_between_boots() {
+        // A seed reused across guests would hand them a shared starting state.
+        let a = fresh_rng_seed();
+        let b = fresh_rng_seed();
+        assert_ne!(a, b);
+        assert_ne!(a, [0u8; RNG_SEED_LEN], "seed must not be all zeroes");
     }
 }

--- a/xtask/src/check_guest_entropy_seed.rs
+++ b/xtask/src/check_guest_entropy_seed.rs
@@ -1,0 +1,103 @@
+//! `xtask check-guest-entropy-seed`
+//!
+//! Every guest boots with a device tree the VMM builds, and that tree must
+//! carry `/chosen/rng-seed`.
+//!
+//! A workload guest has no entropy source of its own: no NIC, no rotating
+//! disk, and no virtio-rng device on the host side. There is almost no
+//! interrupt jitter for the kernel to harvest, so without a credited
+//! bootloader seed the CSPRNG takes seconds to initialise — and the guest
+//! agent mints an Ed25519 identity key at startup, so its first
+//! `getrandom(2)` blocks for that entire window before the control plane
+//! comes up. A boot that should take tens of milliseconds took four seconds.
+//!
+//! The seed itself is unit-tested in `mvm_runtime::vmm::fdt`, which compiles
+//! everywhere. The *call site* cannot be: the HVF boot path is
+//! `#[cfg(all(target_os = "macos", target_arch = "aarch64"))]` and CI is
+//! Linux-only, so no test that runs in CI ever links it. This gate covers
+//! that hole by reading the source instead — a file that builds a device tree
+//! must also obtain a seed to put in it.
+//!
+//! Fails on both regressions worth catching: a new VMM boot path that forgets
+//! the seed, and someone deleting the seeding from the existing one.
+
+use anyhow::{Context, Result, bail};
+use std::path::{Path, PathBuf};
+
+/// The FDT builder's own module: it defines `build_dtb` and `fresh_rng_seed`
+/// and exercises both with and without a seed, so it is not a call site.
+const DEFINING_MODULE: &str = "crates/mvm-runtime/src/vmm/fdt.rs";
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let mut rs_files = Vec::new();
+    collect_rs_files(&workspace.join("crates"), &mut rs_files)?;
+
+    let mut unseeded = Vec::new();
+    let mut callers = 0usize;
+    for file in &rs_files {
+        let rel = file
+            .strip_prefix(workspace)
+            .unwrap_or(file)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if rel == DEFINING_MODULE || !rel.contains("/src/") {
+            continue;
+        }
+        let src =
+            std::fs::read_to_string(file).with_context(|| format!("reading {}", file.display()))?;
+        if !src.contains("build_dtb(") {
+            continue;
+        }
+        callers += 1;
+        // The seed has to come from somewhere; requiring the helper keeps
+        // every boot path on one source of per-boot host entropy rather than
+        // letting one grow its own (a fixed or reused seed would hand two
+        // guests the same CSPRNG starting state).
+        if !src.contains("fresh_rng_seed") {
+            unseeded.push(rel);
+        }
+    }
+
+    if !unseeded.is_empty() {
+        bail!(
+            "check-guest-entropy-seed: {} file(s) build a guest device tree without seeding \
+             its CSPRNG: {}.\n\
+             Pass `Some(&fdt::fresh_rng_seed())` as `build_dtb`'s `rng_seed`. Without it the \
+             guest has no entropy source at all and its first `getrandom(2)` blocks for \
+             seconds at boot.",
+            unseeded.len(),
+            unseeded.join(", ")
+        );
+    }
+
+    // A gate that matches nothing passes vacuously forever. If the last caller
+    // is renamed or moved, say so rather than reporting success.
+    if callers == 0 {
+        bail!(
+            "check-guest-entropy-seed: found no `build_dtb(` call sites outside {DEFINING_MODULE}. \
+             The gate is no longer covering anything — update it to match where the device tree \
+             is built now."
+        );
+    }
+
+    println!("check-guest-entropy-seed: {callers} device-tree boot path(s) seed the guest CSPRNG");
+    Ok(())
+}
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
+        let path = entry?.path();
+        if path.is_dir() {
+            if path.file_name().is_some_and(|n| n == "target") {
+                continue;
+            }
+            collect_rs_files(&path, out)?;
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -28,6 +28,7 @@ mod check_forbidden_deps;
 mod check_guest_agent_in_all_images;
 mod check_guest_agent_runtime_free;
 mod check_guest_binary_lists;
+mod check_guest_entropy_seed;
 mod check_guest_images_no_builder_tools;
 mod check_honesty;
 mod check_kernel_config_budget;
@@ -128,6 +129,10 @@ fn main() -> Result<()> {
         Some("check-builder-shell-job-sites") => {
             let workspace = workspace_root();
             check_builder_shell_job_sites::run(&workspace)
+        }
+        Some("check-guest-entropy-seed") => {
+            let workspace = workspace_root();
+            check_guest_entropy_seed::run(&workspace)
         }
         Some("check-closure-budget") => {
             let workspace = workspace_root();
@@ -285,7 +290,7 @@ fn main() -> Result<()> {
             ir_parity::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-conformance, check-trust-gradient, check-vsock-only-egress, check-uniform-vsock-egress, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-conformance, check-trust-gradient, check-vsock-only-egress, check-uniform-vsock-egress, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {
@@ -326,6 +331,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-builder-shell-job-sites           Plan 204 WS-D: freeze the set of files that construct a legacy builder shell-job request"
+            );
+            eprintln!(
+                "  check-guest-entropy-seed                Every VMM boot path must seed the guest CSPRNG via /chosen/rng-seed"
             );
             eprintln!(
                 "  check-closure-budget                    Plan 200: assert mvmctl's default linux closure stays within the crate budget"


### PR DESCRIPTION
A workload guest has no entropy source: no NIC, no rotating disk, and no
virtio-rng device on the host side. There is almost no interrupt jitter for the
kernel to harvest, so the CSPRNG took four seconds to initialise — and the guest
agent mints an Ed25519 identity key at startup, so its first `getrandom(2)`
blocked for that entire window before the control plane came up.

**The agent had been reporting this on every boot the whole time:**

```
mvm-guest-agent: control plane ready (4076ms)
```

And the guest console showed the kernel finishing at 0.044s, then four seconds
of silence, then `random: crng init done` at 4.127s. The kernel was never slow —
it was done in 44ms and waiting.

## Result

Measured on macOS/HVF, `python:3.12`, identical workload:

| | before | after |
|---|---|---|
| `crng init done` | 4.127s | **0.000s** |
| `control plane ready` | 4076ms | **0ms** |
| `machine run` wall | 5.40s | **1.35s** |
| `machine run` CPU | 4.59s | **0.59s** |

The CPU drop is the host vCPU thread that had been spinning while the guest sat
blocked — which is also why this looked CPU-bound and misled me for a while.

Correctness unchanged: `print(2 + 2)` → `4`, exit 0; requested exit codes 0 and
7 both propagate.

## The fix

Pass fresh host entropy in the device tree's `/chosen/rng-seed`, which is what
other arm64 VMMs do. Linux credits it in `early_init_dt_scan_chosen` and zeroes
the property afterwards.

**No kernel config change is needed**, and the first revision of this PR was
wrong to add one. `CONFIG_RANDOM_TRUST_BOOTLOADER` was removed as a Kconfig
symbol in 6.2, when crediting a bootloader seed became unconditional;
`random.trust_bootloader=0` on the cmdline is the only way to disable it, and
mvm never sets that. The kernel build's own guard caught it —

```
ERROR: requested kernel enables were dropped by olddefconfig: RANDOM_TRUST_BOOTLOADER
Each dropped symbol has an unmet Kconfig dependency... Investigate — do not suppress.
```

— and the measurements above corroborate it: they come from a kernel built on
27 Jul, well before any config edit, so the seed was already being credited.
Good gate; it caught a wrong change that would otherwise have shipped as
harmless-looking noise.

## Regression gate

`xtask check-guest-entropy-seed`, wired into the Lint job. The seed is
unit-tested in `vmm::fdt`, which compiles everywhere — but the *call site* can't
be: the HVF path is `#[cfg(all(target_os = "macos", target_arch = "aarch64"))]`
and every CI job is `ubuntu-latest`, so nothing in CI ever links it. The gate
reads the source instead.

Two properties worth noting:

- It fails if it matches **zero** call sites, so it can't go quietly vacuous if
  the boot path moves — that's the failure mode that let the original bug hide.
- It requires `fresh_rng_seed()` specifically, not merely some seed. A hardcoded
  or reused seed would hand two guests identical CSPRNG starting state, which is
  worse than the slow boot it replaces.

I verified it goes red rather than assuming: replacing the seeding with
`[0u8; 32]` fails it, restoring passes.

## Deliberately not done

Making the agent's key generation non-blocking. Deriving an identity key from an
uninitialised CSPRNG is a real weakness, and it'd sit badly beside fifteen
CI-enforced security claims. **The blocking is correct; the absent entropy was
the bug.** Someone will propose that shortcut, so it's worth writing down why
the answer is no.

## Fork safety

Restored children already diverge — `instance_snapshot` reseeds the guest CSPRNG
on VMGenID rotation — so a per-boot seed doesn't give a forked child its
parent's stream.

## Follow-up, not in this PR

virtio-rng (#2060). A boot seed fixes startup; a long-running workload drawing
on the pool wants an ongoing source. The guest kernel already has
`HW_RANDOM_VIRTIO` built in, so that work is purely host-side.

## Depends on

This change is invisible without #2058 — `mvm-cli`'s build script didn't watch
`mvm-runtime/src`, so the per-VM supervisor that builds the device tree was
never rebuilt. It measured as a complete no-op until that was fixed.