### PR TITLE
ci(security): stop the shard comment arguing from a stale measurement

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -530,13 +530,21 @@ jobs:
   mutation-witnesses:
     name: Claim witnesses — mutation-tested (${{ matrix.package }})
     runs-on: ubuntu-latest
-    # BLOCKING, and sharded per package because it has to be.
+    # BLOCKING, and sharded per package.
     #
-    # The whole surface takes ~6.9h end to end and a GitHub-hosted job is
-    # killed at 6, so one job could not reliably finish: it would go red
-    # nightly for a reason unrelated to any claim and be ignored — the
-    # failure this lane exists to prevent, reached from the other side.
-    # Split per package the slowest shard is ~2.5h.
+    # Sharding is structural, not a response to a particular runtime: a
+    # GitHub-hosted job is killed at six hours, the surface only grows,
+    # and a failure should name the package that owns it rather than
+    # arrive as one opaque red job. A lane that cannot reliably finish
+    # goes red for reasons unrelated to any claim and stops being read —
+    # the failure this lane exists to prevent, reached from the other
+    # side.
+    #
+    # Deliberately no duration quoted here. The first version of this
+    # comment cited hours measured before the slowest tests in the tree
+    # were fixed, and was wrong by roughly an order of magnitude within a
+    # week. `specs/VERIFICATION.md` carries dated, measured per-shard
+    # times instead; re-measure rather than re-quote.
     #
     # Every survivor is either closed by a test or carried in
     # xtask/mutation-witness-baseline.json with the mechanism that makes it


### PR DESCRIPTION
## What

The `mutation-witnesses` job comment justified sharding with "~6.9h end to end" and "slowest shard ~2.5h". Both numbers are wrong, and were wrong within about a week of being written.

## Why they were wrong

They were measured before the slowest tests in the tree were fixed. `mvm-cli`'s package suite went from **~145s to 4.5s** once #2045 landed — and the mutation lane re-runs the owning package's whole suite once per mutant, so that one change moved the lane's cost by an order of magnitude. I never re-derived the estimate.

Measured since, running the real lane command shard by shard on a Linux host:

| shard | measured |
| --- | --- |
| mvm-sdk | 299s |
| mvm-agentd | 235s |
| mvm-protocol | 687s |
| mvm-build | 1294s |
| mvm-core | 1483s |

Sequential, and in CI the eight shards run in parallel — so the lane's wall clock is the slowest single shard, not the sum.

## The actual fix

The number was never the reason. Sharding is right because a GitHub-hosted job is killed at six hours, the surface only grows, and a failure should name the package that owns it rather than arrive as one opaque red job. None of that depends on today's runtime.

So the comment states the structural reason and quotes **no duration at all**, pointing at `specs/VERIFICATION.md` for dated, measured times instead.

That is the generalisable bit: a volatile measurement embedded in an argument decays invisibly, because nothing about a code comment goes stale in a way anyone can see. The same measurement in a dated table announces its own age.

## Follow-up

A full eight-shard run is in progress; the remaining three (`mvm-runtime`, `mvm-hostd`, `mvm-cli`) will be added to `specs/VERIFICATION.md` as a dated table. This PR stands alone without it — it removes a false claim rather than adding a true one.