### PR TITLE
test(guest): gate guest-init parity and cover the egress path in BDD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,9 @@ jobs:
       - name: uniform vsock egress (Firecracker + libkrun + HVF use the WorkloadRunner seam)
         run: cargo run -p xtask -- check-uniform-vsock-egress
 
+      - name: guest init parity (both inits share one post-mount bootstrap)
+        run: cargo run -p xtask -- check-guest-init-parity
+
       - name: require-grant token confined to allowlist (guards mvmd no-brick invariant)
         run: cargo run -p xtask -- check-require-grant-token-allowlist
 

--- a/features/suites/s5_lifecycle/transient_sandbox_boot.feature
+++ b/features/suites/s5_lifecycle/transient_sandbox_boot.feature
@@ -16,12 +16,33 @@ Feature: Transient sandbox boot
     When I run mvmctl in an isolated live home with "machine run --name bdd-nix-boot --flake examples/exit_code --timeout 120"
     Then the command exits with code 7
 
-  # This scenario does not pass today and is not expected to: a NIC-less guest
-  # has no raw socket, so busybox `ping` fails at `socket()` before a packet
-  # exists, and `--allow-host` admits TCP to :443 rather than ICMP. Host-mediated
-  # echo over vsock is what will make it true. Two details have to line up when
-  # it does: the invocation is `/bin/ping` by absolute path, so a PATH-order shim
-  # will not satisfy it, and `-c 1` must produce busybox's "1 received" wording.
+  # The universal initramfs made the agent PID 1 and, for a while, carried over
+  # only the mounting half of the older init. A workload booted with `lo` down
+  # and nothing listening on the loopback proxy port, so every egress attempt
+  # failed as `Network unreachable` — while the proxy environment variables were
+  # still exported, which made it read as a broken network rather than as a
+  # policy denial. This is that regression, as a scenario.
+  @live
+  Scenario: a workload reaches an admitted host over the mediated egress path
+    When I run mvmctl in an isolated live home with "machine run --name bdd-egress-https --image alpine --allow-host example.com --timeout 180 -- wget -q -O- https://example.com"
+    Then the command exits with code 0
+    And the output contains "Example Domain"
+
+  # Unqualified, so the mediated stand-in on PATH satisfies it. A NIC-less guest
+  # has no raw socket, so the image's own ping fails at `socket()`; the host
+  # performs the echo over vsock on the guest's behalf.
+  @live
+  Scenario: machine run reaches an admitted host with an unqualified ping
+    When I run mvmctl in an isolated live home with "machine run --name bdd-egress-ping-path --image alpine --allow-host google.com --timeout 180 -- ping -c 1 google.com"
+    Then the command exits with code 0
+    And the output contains "1 received"
+
+  # Still open, and for one specific reason: `/bin/ping` by absolute path is not
+  # satisfied by a PATH-order stand-in, and the bind mount that would satisfy it
+  # cannot apply here. `/bin/ping` on a busybox image is a symlink to the
+  # multi-call binary, replacing that link needs a write, and the rootfs is
+  # read-only under verity. The unqualified scenario above is the same egress
+  # path within reach today.
   @live @wip
   Scenario: machine run reaches an admitted host with ping
     When I run mvmctl in an isolated live home with "machine run --name bdd-egress-ping --image alpine --allow-host google.com --timeout 120 -- /bin/ping -c 1 google.com"

--- a/specs/plans/270-universal-initramfs-vsock-activated-boot.md
+++ b/specs/plans/270-universal-initramfs-vsock-activated-boot.md
@@ -502,9 +502,14 @@ because it alone blocked boot loudly.
   guest wrapper prepends that to `PATH`. The two routes are complementary: the
   mount still wins for an absolute `/bin/ping` where it can apply, the link
   covers the sealed case.
-- [ ] **Step 6: Regression witness**
-  A live or BDD scenario asserting the workload environment is complete on the
-  universal path, so this cannot regress silently a second time.
+- [x] **Step 6: Regression witness**
+  `xtask check-guest-init-parity`, gated in CI's Lint job. A live scenario was
+  the obvious shape and the wrong one: this regression was a missing call site,
+  and a live boot only catches it on the lanes that boot a guest. The gate
+  asserts the three properties whose absence caused it — both inits reach the
+  shared bootstrap, the bootstrap still performs every step, and the agent runs
+  it before dropping privilege — and each assertion was confirmed to fail when
+  its regression is reintroduced.
 
 Live verification on macOS/HVF, `machine run --image alpine`:
 `wget https://example.com` returns the page (`Network unreachable` before),

--- a/xtask/src/check_guest_init_parity.rs
+++ b/xtask/src/check_guest_init_parity.rs
@@ -1,0 +1,218 @@
+//! `xtask check-guest-init-parity`
+//!
+//! Guest init parity: a workload guest is brought up by one of two inits —
+//! `mvm-oci-init` as PID 1 on the legacy per-rootfs initrd, and the guest agent's
+//! activation path when the universal initramfs boots it as PID 1. Both must run
+//! the same post-mount setup, and they do it by calling one shared
+//! `provision_guest_environment`.
+//!
+//! This gate exists because that parity was silently lost once. The universal
+//! initramfs replaced `mvm-oci-init` but carried over only its mounting: the
+//! workload booted with `lo` down, no resolver, and nothing listening on the
+//! loopback proxy port, while still being handed the proxy environment
+//! variables. Every egress attempt failed as `Network unreachable` rather than
+//! as a policy denial, and nothing in CI noticed — the guest booted, so the only
+//! signal was a workload that could not reach anything.
+//!
+//! Three assertions:
+//!
+//! - **A — both inits call the shared bootstrap.** Neither may open-code the
+//!   steps or skip them. A third init added later trips this too, because the
+//!   entry-point list is the ledger.
+//! - **B — the shared bootstrap still performs every step.** Each required step
+//!   is named in `provision_guest_environment`, so deleting one is a gate
+//!   failure rather than a silent capability loss in the guest.
+//! - **C — the agent runs it before dropping privilege.** The steps mount, write
+//!   into the workload root, and change interface state; all of that needs root.
+//!   Ordering it after the drop would fail at runtime, in the guest, where it is
+//!   expensive to see.
+
+use anyhow::{Result, bail};
+use std::path::Path;
+
+/// The shared entry point both inits must call.
+const SHARED_BOOTSTRAP: &str = "provision_guest_environment";
+
+/// Where the shared steps live.
+const BOOTSTRAP_RS: &str = "crates/mvm-agentd/src/guest_bootstrap.rs";
+
+/// The agent's PID-1 activation path, which also carries the ordering rule.
+const AGENT_INIT_RS: &str = "crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs";
+
+/// Every guest init entry point. Adding an init means adding it here — the list
+/// is what makes "both inits" checkable rather than aspirational.
+const GUEST_INITS: &[&str] = &["crates/mvm-agentd/src/bin/mvm-oci-init.rs", AGENT_INIT_RS];
+
+/// Steps `provision_guest_environment` must still perform.
+///
+/// Each was skipped by the universal path at some point, and each failure is
+/// quiet: the guest boots either way. Naming them here turns a deletion into a
+/// build failure.
+const REQUIRED_STEPS: &[(&str, &str)] = &[
+    (
+        "ensure_runtime_dirs",
+        "the runtime dirs the rest writes into",
+    ),
+    (
+        "mount_mediated_tools",
+        "stand-ins for tools a NIC-less guest cannot run",
+    ),
+    (
+        "provision_egress_ca",
+        "the CA the egress substitution presents",
+    ),
+    ("provision_verb_grant", "the plan-bound verb grant"),
+    ("netinit", "the guest network defense install"),
+    (
+        "start_vsock_egress",
+        "loopback, resolver, and the egress client",
+    ),
+];
+
+/// The privilege drop the bootstrap must precede.
+const PRIVILEGE_DROP: &str = "drop_privilege";
+
+/// The agent reaches the shared bootstrap through a small `cfg`-split wrapper,
+/// so the Linux-only call site is written down rather than erased on other
+/// targets. Assertion C follows that one hop.
+const AGENT_WRAPPER: &str = "bootstrap_guest_environment";
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let mut checked = 0usize;
+
+    // A — both inits reach the shared bootstrap.
+    for init in GUEST_INITS {
+        let path = workspace.join(init);
+        let src = std::fs::read_to_string(&path)
+            .map_err(|e| anyhow::anyhow!("read {}: {e}", path.display()))?;
+        if !src.contains(SHARED_BOOTSTRAP) {
+            bail!(
+                "check-guest-init-parity: {init} does not call `{SHARED_BOOTSTRAP}`.\n\
+                 Every guest init runs the same post-mount setup through that one\n\
+                 function. An init that skips it boots a workload with no egress\n\
+                 path, no resolver, and no verb grant — which looks like a healthy\n\
+                 boot and fails later as `Network unreachable`."
+            );
+        }
+        checked += 1;
+    }
+
+    // B — the shared bootstrap still does the work.
+    let bootstrap_path = workspace.join(BOOTSTRAP_RS);
+    let bootstrap = std::fs::read_to_string(&bootstrap_path)
+        .map_err(|e| anyhow::anyhow!("read {}: {e}", bootstrap_path.display()))?;
+    let body = fn_body(&bootstrap, SHARED_BOOTSTRAP).ok_or_else(|| {
+        anyhow::anyhow!("check-guest-init-parity: no `fn {SHARED_BOOTSTRAP}` in {BOOTSTRAP_RS}")
+    })?;
+    for (step, why) in REQUIRED_STEPS {
+        if !body.contains(step) {
+            bail!(
+                "check-guest-init-parity: `{SHARED_BOOTSTRAP}` no longer performs `{step}`\n\
+                 ({why}). If the step moved, point this gate at its new home; if it\n\
+                 was dropped, the guest loses that capability silently."
+            );
+        }
+    }
+
+    // C — the agent bootstraps while it is still root.
+    let agent_path = workspace.join(AGENT_INIT_RS);
+    let agent = std::fs::read_to_string(&agent_path)
+        .map_err(|e| anyhow::anyhow!("read {}: {e}", agent_path.display()))?;
+    let activation = fn_body(&agent, "apply_activation").ok_or_else(|| {
+        anyhow::anyhow!("check-guest-init-parity: no `fn apply_activation` in {AGENT_INIT_RS}")
+    })?;
+    match (
+        activation.find(AGENT_WRAPPER),
+        activation.find(PRIVILEGE_DROP),
+    ) {
+        (Some(bootstrap_at), Some(drop_at)) if bootstrap_at > drop_at => bail!(
+            "check-guest-init-parity: `apply_activation` bootstraps the guest after\n\
+             `{PRIVILEGE_DROP}`. The steps mount, write into the workload root, and\n\
+             bring up an interface — all of which need root."
+        ),
+        (None, _) => bail!(
+            "check-guest-init-parity: `apply_activation` does not reach `{AGENT_WRAPPER}`.\n\
+             Activation is the agent's only pre-workload hook; setup skipped here is\n\
+             skipped entirely."
+        ),
+        _ => {}
+    }
+    // ...and the wrapper must actually reach the shared bootstrap, so the hop
+    // cannot become a no-op on the target that matters.
+    let wrapper = fn_body(&agent, AGENT_WRAPPER).ok_or_else(|| {
+        anyhow::anyhow!("check-guest-init-parity: no `fn {AGENT_WRAPPER}` in {AGENT_INIT_RS}")
+    })?;
+    if !wrapper.contains(SHARED_BOOTSTRAP) {
+        bail!(
+            "check-guest-init-parity: `{AGENT_WRAPPER}` no longer calls `{SHARED_BOOTSTRAP}`.\n\
+             The wrapper exists only to carry the Linux-only call; an empty one\n\
+             silently restores the regression this gate guards."
+        );
+    }
+
+    println!(
+        "check-guest-init-parity: clean ({checked} guest inits share one bootstrap; \
+         {} steps intact; agent bootstraps before the privilege drop)",
+        REQUIRED_STEPS.len()
+    );
+    Ok(())
+}
+
+/// Return the brace-matched body of `fn <name>`, so a token found elsewhere in
+/// the file (a doc comment, an unrelated helper) cannot satisfy an assertion.
+fn fn_body<'a>(src: &'a str, name: &str) -> Option<&'a str> {
+    let needle = format!("fn {name}");
+    let start = src.find(&needle)?;
+    let open = src[start..].find('{')? + start;
+    let mut depth = 0usize;
+    for (offset, ch) in src[open..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&src[open..=open + offset]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fn_body_returns_only_the_named_function() {
+        let src = "fn a() { alpha(); }\nfn b() { beta(); }\n";
+        let body = fn_body(src, "b").unwrap();
+        assert!(body.contains("beta"));
+        assert!(!body.contains("alpha"));
+    }
+
+    #[test]
+    fn fn_body_matches_nested_braces() {
+        let src = "fn a() { if x { inner(); } tail(); }\n";
+        let body = fn_body(src, "a").unwrap();
+        assert!(body.contains("inner"));
+        assert!(body.trim_end().ends_with('}'));
+        assert!(body.contains("tail"));
+    }
+
+    #[test]
+    fn fn_body_is_none_for_an_absent_function() {
+        assert!(fn_body("fn a() {}", "missing").is_none());
+    }
+
+    /// The gate has to hold on the tree it ships with, or it is decoration.
+    #[test]
+    fn gate_passes_on_this_workspace() {
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("workspace root")
+            .to_path_buf();
+        run(&workspace).expect("guest init parity holds on this tree");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -30,6 +30,7 @@ mod check_guest_agent_runtime_free;
 mod check_guest_binary_lists;
 mod check_guest_entropy_seed;
 mod check_guest_images_no_builder_tools;
+mod check_guest_init_parity;
 mod check_honesty;
 mod check_kernel_config_budget;
 mod check_kernel_pin_freshness;
@@ -238,6 +239,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_vsock_only_egress::run(&workspace)
         }
+        Some("check-guest-init-parity") => {
+            let workspace = workspace_root();
+            check_guest_init_parity::run(&workspace)
+        }
         Some("check-uniform-vsock-egress") => {
             let workspace = workspace_root();
             check_uniform_vsock_egress::run(&workspace)
@@ -290,7 +295,7 @@ fn main() -> Result<()> {
             ir_parity::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-conformance, check-trust-gradient, check-vsock-only-egress, check-uniform-vsock-egress, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-conformance, check-trust-gradient, check-vsock-only-egress, check-uniform-vsock-egress, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {


### PR DESCRIPTION
## What

Closes the last open step of Task 8 in plan 270 — the regression witness for the guest-setup gap fixed in #2050 and #2055.

The universal initramfs replaced `mvm-oci-init` but carried over only its mounting, so a workload booted with `lo` down, no resolver, and nothing listening on the loopback proxy port. Nothing caught it: the guest booted fine, and the proxy environment variables were still exported, so the failure read as a broken network rather than as a policy denial.

## Why a gate rather than only a live scenario

The plan originally called for a live/BDD scenario. That is the wrong primary shape here: the regression was a **missing call site**, and a live scenario only catches that on lanes that actually boot a guest — which is exactly why the original slipped through. A policy gate runs on every PR, and this repo already uses that shape for lockstep invariants (`check-uniform-vsock-egress`).

`xtask check-guest-init-parity` asserts three properties, each the executable form of something whose absence caused the bug:

- **A** — both guest inits reach the shared `provision_guest_environment`. A third init added later trips it too; the entry-point list is the ledger.
- **B** — that function still performs every step, so deleting one is a build failure rather than a silent capability loss in the guest.
- **C** — the agent runs it *before* `drop_privilege`. The steps mount, write into the workload root, and bring up an interface, all of which need root; ordering it after the drop only fails at runtime, inside a guest.

Each assertion was confirmed to **fail** when its regression is reintroduced, then pass again when restored:

```
A: `apply_activation` does not reach `bootstrap_guest_environment`
B: `provision_guest_environment` no longer performs `mount_mediated_tools`
C: `apply_activation` bootstraps the guest after `drop_privilege`
```

The gate follows one deliberate hop: `apply_activation` calls a small `cfg`-split wrapper rather than the shared function directly, so the Linux-only call site is written down instead of erased on other targets. The gate checks the wrapper is reached *and* that it still calls the shared bootstrap, so emptying it also trips.

## BDD

Two live scenarios cover the behaviour end to end — a workload reaching an admitted host over https, and an unqualified `ping` served by the host-mediated stand-in on `PATH`. Both were run live in the exact argv form the feature uses (`1 received` / `Example Domain`, exit 0), not merely parsed.

The absolute-path `ping` scenario stays `@wip`, with its stated reason corrected: it is no longer blocked on host-mediated echo — that exists now — but on `/bin/ping` being a symlink to the busybox multi-call binary, where replacing the link needs a write and the rootfs is read-only under verity.

## Verification

`cargo nextest run --workspace` 8670/8670 green, `cargo clippy --workspace --all-targets` clean, nightly `cargo fmt --all --check` clean, BDD harness 85/85 scenarios, and `check-conformance` / `check-workflow-paths` / `check-no-spec-refs-in-comments` pass.