### PR TITLE
Wire authenticated remote volume lifecycle

### DIFF
--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-mvm-core.workspace = true
+mvm-core = { workspace = true, features = ["client-remote"] }
 mvm-agentd.workspace = true
 mvm-runtime = { workspace = true, default-features = false }
 mvm-build = { workspace = true, default-features = false }

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -322,12 +322,18 @@ fn volume_create_parses_default_root() {
                     root,
                     host_backed,
                     size,
+                    remote,
+                    bucket,
+                    storage_class,
                 },
         })) => {
             assert_eq!(volume, "work");
             assert_eq!(root, None);
             assert!(!host_backed);
             assert_eq!(size, "1G");
+            assert!(!remote);
+            assert!(bucket.is_none());
+            assert!(storage_class.is_none());
         }
         _ => panic!("Expected volume create command"),
     }
@@ -355,12 +361,18 @@ fn volume_create_host_backed_parses() {
                     root,
                     host_backed,
                     size,
+                    remote,
+                    bucket,
+                    storage_class,
                 },
         })) => {
             assert_eq!(volume, "work");
             assert_eq!(root, None);
             assert!(host_backed);
             assert_eq!(size, "1G");
+            assert!(!remote);
+            assert!(bucket.is_none());
+            assert!(storage_class.is_none());
         }
         _ => panic!("Expected volume create command"),
     }
@@ -402,8 +414,11 @@ fn volume_catalog_json_parses() {
     };
     match mg.action {
         machine::MachineAction::Vm(group::VmCmd::Volume(volume::Args {
-            command: volume::VolumeCmd::Catalog { json },
-        })) => assert!(json),
+            command: volume::VolumeCmd::Catalog { json, remote },
+        })) => {
+            assert!(json);
+            assert!(!remote);
+        }
         _ => panic!("Expected volume catalog command"),
     }
 }
@@ -425,8 +440,8 @@ fn volume_snapshot_parses() {
     assert!(matches!(
         mg.action,
         machine::MachineAction::Vm(group::VmCmd::Volume(volume::Args {
-            command: volume::VolumeCmd::Snapshot { volume, snapshot },
-        })) if volume == "work" && snapshot == "before-upgrade"
+            command: volume::VolumeCmd::Snapshot { volume, snapshot, remote },
+        })) if volume == "work" && snapshot == "before-upgrade" && !remote
     ));
 }
 
@@ -447,8 +462,103 @@ fn volume_restore_parses() {
     assert!(matches!(
         mg.action,
         machine::MachineAction::Vm(group::VmCmd::Volume(volume::Args {
-            command: volume::VolumeCmd::Restore { volume, snapshot },
-        })) if volume == "work" && snapshot == "before-upgrade"
+            command: volume::VolumeCmd::Restore { volume, snapshot, target, remote },
+        })) if volume == "work" && snapshot == "before-upgrade" && target.is_none() && !remote
+    ));
+}
+
+#[test]
+fn remote_volume_lifecycle_flags_parse() {
+    let create = Cli::try_parse_from([
+        "mvmctl",
+        "machine",
+        "volume",
+        "create",
+        "data",
+        "--size",
+        "8G",
+        "--remote",
+        "--bucket",
+        "bucket-1",
+        "--storage-class",
+        "durable",
+    ])
+    .unwrap();
+    let Commands::Machine(group) = create.command else {
+        panic!("expected machine group")
+    };
+    assert!(matches!(
+        group.action,
+        machine::MachineAction::Vm(group::VmCmd::Volume(volume::Args {
+            command: volume::VolumeCmd::Create {
+                volume,
+                size,
+                remote: true,
+                bucket: Some(bucket),
+                storage_class: Some(storage_class),
+                ..
+            },
+        })) if volume == "data" && size == "8G" && bucket == "bucket-1" && storage_class == "durable"
+    ));
+
+    let checkpoint = Cli::try_parse_from([
+        "mvmctl",
+        "machine",
+        "volume",
+        "checkpoint",
+        "vol-1",
+        "snap-1",
+        "--remote",
+    ])
+    .unwrap();
+    let Commands::Machine(group) = checkpoint.command else {
+        panic!("expected machine group")
+    };
+    assert!(matches!(
+        group.action,
+        machine::MachineAction::Vm(group::VmCmd::Volume(volume::Args {
+            command: volume::VolumeCmd::Snapshot {
+                volume,
+                snapshot,
+                remote: true,
+            },
+        })) if volume == "vol-1" && snapshot == "snap-1"
+    ));
+
+    let restore = Cli::try_parse_from([
+        "mvmctl", "machine", "volume", "restore", "vol-1", "snap-1", "--target", "restored",
+        "--remote",
+    ])
+    .unwrap();
+    let Commands::Machine(group) = restore.command else {
+        panic!("expected machine group")
+    };
+    assert!(matches!(
+        group.action,
+        machine::MachineAction::Vm(group::VmCmd::Volume(volume::Args {
+            command: volume::VolumeCmd::Restore {
+                volume,
+                snapshot,
+                target: Some(target),
+                remote: true,
+            },
+        })) if volume == "vol-1" && snapshot == "snap-1" && target == "restored"
+    ));
+
+    let delete =
+        Cli::try_parse_from(["mvmctl", "machine", "volume", "delete", "vol-1", "--remote"])
+            .unwrap();
+    let Commands::Machine(group) = delete.command else {
+        panic!("expected machine group")
+    };
+    assert!(matches!(
+        group.action,
+        machine::MachineAction::Vm(group::VmCmd::Volume(volume::Args {
+            command: volume::VolumeCmd::Delete {
+                volume,
+                remote: true,
+            },
+        })) if volume == "vol-1"
     ));
 }
 

--- a/crates/mvm-cli/src/commands/vm/volume.rs
+++ b/crates/mvm-cli/src/commands/vm/volume.rs
@@ -28,9 +28,6 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use clap::{Args as ClapArgs, Subcommand};
 
-use mvm_core::client::gateway::{
-    GatewayBackend, GatewayConfig, RemoteVolume, RemoteVolumeCreate, RemoteVolumeMount,
-};
 use mvm_core::crypto::key_rotation;
 use mvm_core::crypto::policy::validate_mount_path;
 use mvm_core::crypto::rotation_policy;
@@ -50,6 +47,7 @@ use sha2::{Digest, Sha256};
 use super::Cli;
 use super::shared::clap_vm_name;
 
+mod remote;
 mod snapshot;
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -193,7 +191,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 if root.is_some() || host_backed {
                     bail!("--root and --host-backed are local-only volume options");
                 }
-                return remote_create(&volume, &size, bucket.as_deref(), storage_class.as_deref());
+                return remote::create(&volume, &size, bucket.as_deref(), storage_class.as_deref());
             }
             create(&volume, root.as_deref(), host_backed, &size)
         }
@@ -201,7 +199,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         VolumeCmd::Lock { volume } => lock(&volume),
         VolumeCmd::Catalog { json, remote } => {
             if remote {
-                return remote_catalog(json);
+                return remote::catalog(json);
             }
             catalog(json)
         }
@@ -211,7 +209,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             remote,
         } => {
             if remote {
-                return remote_snapshot(&volume, &snapshot);
+                return remote::snapshot(&volume, &snapshot);
             }
             snapshot::create(&volume, &snapshot)
         }
@@ -223,7 +221,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         } => {
             if remote {
                 let target = target.unwrap_or_else(|| format!("{volume}-restored"));
-                return remote_restore(&volume, &snapshot, &target);
+                return remote::restore(&volume, &snapshot, &target);
             }
             if target.is_some() {
                 bail!("--target is only valid with --remote");
@@ -234,7 +232,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             if !remote {
                 bail!("local volume deletion is not implicit; use --remote for tenant volumes");
             }
-            remote_delete(&volume)
+            remote::delete(&volume)
         }
         VolumeCmd::Mount {
             name,
@@ -248,13 +246,13 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 if host.is_some() {
                     bail!("--host is a local-only volume option");
                 }
-                return remote_mount(&name, &volume, &guest, rw);
+                return remote::mount(&name, &volume, &guest, rw);
             }
             mount(&name, &volume, host.as_deref(), &guest, rw)
         }
         VolumeCmd::Ls { name, json, remote } => {
             if remote {
-                return remote_ls(&name, json);
+                return remote::ls(&name, json);
             }
             ls(&name, json)
         }
@@ -264,7 +262,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             remote,
         } => {
             if remote {
-                return remote_unmount(&name, &guest_path);
+                return remote::unmount(&name, &guest_path);
             }
             unmount(&name, &guest_path)
         }
@@ -644,229 +642,6 @@ fn ensure_private_dir(path: &Path) -> Result<()> {
     fs::create_dir_all(path).with_context(|| format!("creating {}", path.display()))?;
     fs::set_permissions(path, fs::Permissions::from_mode(0o700))
         .with_context(|| format!("chmod 0700 {}", path.display()))?;
-    Ok(())
-}
-
-struct RemoteContext {
-    client: GatewayBackend,
-    tenant_id: String,
-}
-
-fn required_remote_env(name: &str) -> Result<String> {
-    let value = std::env::var(name)
-        .with_context(|| format!("{name} is required for --remote volume operations"))?;
-    if value.trim().is_empty() {
-        bail!("{name} must not be empty for --remote volume operations");
-    }
-    Ok(value)
-}
-
-fn remote_context() -> Result<RemoteContext> {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-    let base_url = required_remote_env("MVM_GATEWAY_URL")?;
-    let token = required_remote_env("MVM_GATEWAY_TOKEN")?;
-    let tenant_id = required_remote_env("MVM_TENANT_ID")?;
-    let client =
-        GatewayBackend::new(GatewayConfig { base_url, token }).map_err(anyhow::Error::from)?;
-    Ok(RemoteContext { client, tenant_id })
-}
-
-fn remote_runtime() -> Result<tokio::runtime::Runtime> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("building remote volume client runtime")
-}
-
-fn remote_size_gib(size: &str) -> Result<u32> {
-    let size_mib = mvm_core::util::parse_human_size(size)
-        .with_context(|| format!("invalid remote volume size {size:?}"))?;
-    if size_mib == 0 {
-        bail!("remote volume size must be at least 1 MiB");
-    }
-    Ok(size_mib.div_ceil(1024))
-}
-
-fn remote_create(
-    volume_name: &str,
-    size: &str,
-    bucket: Option<&str>,
-    storage_class: Option<&str>,
-) -> Result<()> {
-    let context = remote_context()?;
-    let mut builder = RemoteVolumeCreate::builder(volume_name, remote_size_gib(size)?);
-    if let Some(bucket) = bucket {
-        builder = builder.bucket(bucket);
-    }
-    if let Some(storage_class) = storage_class {
-        builder = builder.storage_class(storage_class);
-    }
-    let request = builder.build().map_err(anyhow::Error::from)?;
-    let volume = remote_runtime()?
-        .block_on(
-            context
-                .client
-                .create_remote_volume(&context.tenant_id, &request),
-        )
-        .map_err(anyhow::Error::from)?;
-    println!("{}", serde_json::to_string_pretty(&volume)?);
-    Ok(())
-}
-
-fn remote_catalog(json: bool) -> Result<()> {
-    let context = remote_context()?;
-    let volumes = remote_runtime()?
-        .block_on(context.client.list_remote_volumes(&context.tenant_id))
-        .map_err(anyhow::Error::from)?;
-    print_remote_volumes(&volumes, json)
-}
-
-fn print_remote_volumes(volumes: &[RemoteVolume], json: bool) -> Result<()> {
-    if json {
-        println!("{}", serde_json::to_string_pretty(volumes)?);
-        return Ok(());
-    }
-    for volume in volumes {
-        let attached = volume.attached_instance_id.as_deref().unwrap_or("-");
-        println!(
-            "{}\t{}\t{} GiB\tattached={attached}",
-            volume.volume_id, volume.name, volume.size_gib
-        );
-    }
-    Ok(())
-}
-
-fn remote_snapshot(volume_id: &str, snapshot_name: &str) -> Result<()> {
-    let context = remote_context()?;
-    let snapshot = remote_runtime()?
-        .block_on(context.client.create_remote_volume_snapshot(
-            &context.tenant_id,
-            volume_id,
-            snapshot_name,
-        ))
-        .map_err(anyhow::Error::from)?;
-    println!("{}", serde_json::to_string_pretty(&snapshot)?);
-    Ok(())
-}
-
-fn remote_restore(source_volume_id: &str, snapshot_id: &str, target_name: &str) -> Result<()> {
-    let context = remote_context()?;
-    let volume = remote_runtime()?
-        .block_on(context.client.restore_remote_volume(
-            &context.tenant_id,
-            source_volume_id,
-            snapshot_id,
-            target_name,
-        ))
-        .map_err(anyhow::Error::from)?;
-    println!("{}", serde_json::to_string_pretty(&volume)?);
-    Ok(())
-}
-
-fn remote_delete(volume_id: &str) -> Result<()> {
-    let context = remote_context()?;
-    remote_runtime()?
-        .block_on(
-            context
-                .client
-                .delete_remote_volume(&context.tenant_id, volume_id),
-        )
-        .map_err(anyhow::Error::from)?;
-    println!("Deleted remote volume {volume_id}");
-    Ok(())
-}
-
-fn remote_mount(
-    instance_id: &str,
-    volume_id: &str,
-    guest_path: &str,
-    writable: bool,
-) -> Result<()> {
-    validate_mount_path(guest_path).context("invalid remote guest mount path")?;
-    let context = remote_context()?;
-    let request = RemoteVolumeMount::new(volume_id, instance_id, guest_path).writable(writable);
-    let attachment = remote_runtime()?
-        .block_on(
-            context
-                .client
-                .attach_remote_volume(&context.tenant_id, &request),
-        )
-        .map_err(anyhow::Error::from)?;
-    println!("{}", serde_json::to_string_pretty(&attachment)?);
-    Ok(())
-}
-
-fn remote_ls(instance_id: &str, json: bool) -> Result<()> {
-    let context = remote_context()?;
-    let runtime = remote_runtime()?;
-    let attachments = runtime.block_on(async {
-        let volumes = context
-            .client
-            .list_remote_volumes(&context.tenant_id)
-            .await?;
-        let mut attachments = Vec::new();
-        for volume in volumes
-            .into_iter()
-            .filter(|volume| volume.attached_instance_id.as_deref() == Some(instance_id))
-        {
-            attachments.push(
-                context
-                    .client
-                    .remote_volume_attachment(&context.tenant_id, &volume.volume_id)
-                    .await?,
-            );
-        }
-        Ok::<_, mvm_core::client::MvmError>(attachments)
-    })?;
-    if json {
-        println!("{}", serde_json::to_string_pretty(&attachments)?);
-    } else {
-        for attachment in attachments {
-            println!(
-                "{}\t{}\tread_only={}\tfencing_token={}",
-                attachment.volume_id,
-                attachment.device_path,
-                attachment.read_only,
-                attachment.fencing_token
-            );
-        }
-    }
-    Ok(())
-}
-
-fn remote_unmount(instance_id: &str, guest_path: &str) -> Result<()> {
-    let context = remote_context()?;
-    let runtime = remote_runtime()?;
-    let volume_id = runtime.block_on(async {
-        let volumes = context
-            .client
-            .list_remote_volumes(&context.tenant_id)
-            .await?;
-        for volume in volumes
-            .into_iter()
-            .filter(|volume| volume.attached_instance_id.as_deref() == Some(instance_id))
-        {
-            let attachment = context
-                .client
-                .remote_volume_attachment(&context.tenant_id, &volume.volume_id)
-                .await?;
-            if attachment.device_path == guest_path {
-                return Ok::<_, mvm_core::client::MvmError>(Some(volume.volume_id));
-            }
-        }
-        Ok(None)
-    })?;
-    let volume_id = volume_id.with_context(|| {
-        format!("no remote volume is mounted at {guest_path:?} on instance {instance_id:?}")
-    })?;
-    runtime
-        .block_on(
-            context
-                .client
-                .detach_remote_volume(&context.tenant_id, &volume_id),
-        )
-        .map_err(anyhow::Error::from)?;
-    println!("Detached remote volume {volume_id}");
     Ok(())
 }
 

--- a/crates/mvm-cli/src/commands/vm/volume.rs
+++ b/crates/mvm-cli/src/commands/vm/volume.rs
@@ -15,11 +15,10 @@
 //!
 //! ## `--remote` mode (mvmd proxy)
 //!
-//! `--remote` routes operations through mvmd's REST API rather than
-//! executing locally. v1 stub only — the actual `mvmctl::mvmd_client`
-//! module ships in a follow-up once the mvmd-side bucket
-//! reconciliation lands. Today `--remote` returns a clear "not yet
-//! implemented" error.
+//! `--remote` routes operations through mvmd's authenticated REST API rather
+//! than executing locally. Configuration is read from `MVM_GATEWAY_URL`,
+//! `MVM_GATEWAY_TOKEN`, and `MVM_TENANT_ID`; the bearer token is retained only
+//! in memory and is redacted from debug output.
 
 use std::collections::BTreeMap;
 use std::fs::{self, File};
@@ -29,6 +28,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use clap::{Args as ClapArgs, Subcommand};
 
+use mvm_core::client::gateway::{
+    GatewayBackend, GatewayConfig, RemoteVolume, RemoteVolumeCreate, RemoteVolumeMount,
+};
 use mvm_core::crypto::key_rotation;
 use mvm_core::crypto::policy::validate_mount_path;
 use mvm_core::crypto::rotation_policy;
@@ -74,6 +76,15 @@ pub(in crate::commands) enum VolumeCmd {
         /// Capacity of a new portable ext4 block volume.
         #[arg(long, default_value = "1G")]
         size: String,
+        /// Create through the authenticated mvmd tenant API.
+        #[arg(long)]
+        remote: bool,
+        /// Durable StorageBucket ID used for encrypted checkpoints.
+        #[arg(long, requires = "remote")]
+        bucket: Option<String>,
+        /// Remote storage-class policy name.
+        #[arg(long, requires = "remote")]
+        storage_class: Option<String>,
     },
     /// Decrypt a managed volume into its private local attachment artifact.
     Unlock { volume: String },
@@ -83,11 +94,34 @@ pub(in crate::commands) enum VolumeCmd {
     Catalog {
         #[arg(long)]
         json: bool,
+        /// List volumes through the authenticated mvmd tenant API.
+        #[arg(long)]
+        remote: bool,
     },
     /// Create an immutable encrypted snapshot of a locked managed volume.
-    Snapshot { volume: String, snapshot: String },
+    #[command(visible_alias = "checkpoint")]
+    Snapshot {
+        volume: String,
+        snapshot: String,
+        #[arg(long)]
+        remote: bool,
+    },
     /// Restore a locked managed volume from an immutable local snapshot.
-    Restore { volume: String, snapshot: String },
+    Restore {
+        volume: String,
+        snapshot: String,
+        /// Name of the new remote volume created from the checkpoint.
+        #[arg(long, requires = "remote")]
+        target: Option<String>,
+        #[arg(long)]
+        remote: bool,
+    },
+    /// Delete a detached remote volume.
+    Delete {
+        volume: String,
+        #[arg(long)]
+        remote: bool,
+    },
     /// Mount a virtio-fs volume into a VM.
     ///
     /// Operations against provider-backed (S3 / Hetzner / R2 / GCS /
@@ -116,7 +150,7 @@ pub(in crate::commands) enum VolumeCmd {
         #[arg(long)]
         rw: bool,
         /// Route through mvmd REST instead of writing the local
-        /// registry. Stub in v1.
+        /// registry.
         #[arg(long)]
         remote: bool,
     },
@@ -127,7 +161,7 @@ pub(in crate::commands) enum VolumeCmd {
         #[arg(long)]
         json: bool,
         /// Route through mvmd REST instead of reading the local
-        /// registry. Stub in v1.
+        /// registry.
         #[arg(long)]
         remote: bool,
     },
@@ -138,7 +172,7 @@ pub(in crate::commands) enum VolumeCmd {
         /// Guest mount path to detach.
         guest_path: String,
         /// Route through mvmd REST instead of editing the local
-        /// registry. Stub in v1.
+        /// registry.
         #[arg(long)]
         remote: bool,
     },
@@ -151,12 +185,57 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             root,
             host_backed,
             size,
-        } => create(&volume, root.as_deref(), host_backed, &size),
+            remote,
+            bucket,
+            storage_class,
+        } => {
+            if remote {
+                if root.is_some() || host_backed {
+                    bail!("--root and --host-backed are local-only volume options");
+                }
+                return remote_create(&volume, &size, bucket.as_deref(), storage_class.as_deref());
+            }
+            create(&volume, root.as_deref(), host_backed, &size)
+        }
         VolumeCmd::Unlock { volume } => unlock(&volume),
         VolumeCmd::Lock { volume } => lock(&volume),
-        VolumeCmd::Catalog { json } => catalog(json),
-        VolumeCmd::Snapshot { volume, snapshot } => snapshot::create(&volume, &snapshot),
-        VolumeCmd::Restore { volume, snapshot } => snapshot::restore(&volume, &snapshot),
+        VolumeCmd::Catalog { json, remote } => {
+            if remote {
+                return remote_catalog(json);
+            }
+            catalog(json)
+        }
+        VolumeCmd::Snapshot {
+            volume,
+            snapshot,
+            remote,
+        } => {
+            if remote {
+                return remote_snapshot(&volume, &snapshot);
+            }
+            snapshot::create(&volume, &snapshot)
+        }
+        VolumeCmd::Restore {
+            volume,
+            snapshot,
+            target,
+            remote,
+        } => {
+            if remote {
+                let target = target.unwrap_or_else(|| format!("{volume}-restored"));
+                return remote_restore(&volume, &snapshot, &target);
+            }
+            if target.is_some() {
+                bail!("--target is only valid with --remote");
+            }
+            snapshot::restore(&volume, &snapshot)
+        }
+        VolumeCmd::Delete { volume, remote } => {
+            if !remote {
+                bail!("local volume deletion is not implicit; use --remote for tenant volumes");
+            }
+            remote_delete(&volume)
+        }
         VolumeCmd::Mount {
             name,
             volume,
@@ -166,13 +245,16 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             remote,
         } => {
             if remote {
-                return remote_stub("volume mount");
+                if host.is_some() {
+                    bail!("--host is a local-only volume option");
+                }
+                return remote_mount(&name, &volume, &guest, rw);
             }
             mount(&name, &volume, host.as_deref(), &guest, rw)
         }
         VolumeCmd::Ls { name, json, remote } => {
             if remote {
-                return remote_stub("volume ls");
+                return remote_ls(&name, json);
             }
             ls(&name, json)
         }
@@ -182,7 +264,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             remote,
         } => {
             if remote {
-                return remote_stub("volume unmount");
+                return remote_unmount(&name, &guest_path);
             }
             unmount(&name, &guest_path)
         }
@@ -565,8 +647,227 @@ fn ensure_private_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn remote_stub(op: &str) -> Result<()> {
-    bail!("{op} --remote not yet implemented. Use the local volume registry for now.")
+struct RemoteContext {
+    client: GatewayBackend,
+    tenant_id: String,
+}
+
+fn required_remote_env(name: &str) -> Result<String> {
+    let value = std::env::var(name)
+        .with_context(|| format!("{name} is required for --remote volume operations"))?;
+    if value.trim().is_empty() {
+        bail!("{name} must not be empty for --remote volume operations");
+    }
+    Ok(value)
+}
+
+fn remote_context() -> Result<RemoteContext> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let base_url = required_remote_env("MVM_GATEWAY_URL")?;
+    let token = required_remote_env("MVM_GATEWAY_TOKEN")?;
+    let tenant_id = required_remote_env("MVM_TENANT_ID")?;
+    let client =
+        GatewayBackend::new(GatewayConfig { base_url, token }).map_err(anyhow::Error::from)?;
+    Ok(RemoteContext { client, tenant_id })
+}
+
+fn remote_runtime() -> Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building remote volume client runtime")
+}
+
+fn remote_size_gib(size: &str) -> Result<u32> {
+    let size_mib = mvm_core::util::parse_human_size(size)
+        .with_context(|| format!("invalid remote volume size {size:?}"))?;
+    if size_mib == 0 {
+        bail!("remote volume size must be at least 1 MiB");
+    }
+    Ok(size_mib.div_ceil(1024))
+}
+
+fn remote_create(
+    volume_name: &str,
+    size: &str,
+    bucket: Option<&str>,
+    storage_class: Option<&str>,
+) -> Result<()> {
+    let context = remote_context()?;
+    let mut builder = RemoteVolumeCreate::builder(volume_name, remote_size_gib(size)?);
+    if let Some(bucket) = bucket {
+        builder = builder.bucket(bucket);
+    }
+    if let Some(storage_class) = storage_class {
+        builder = builder.storage_class(storage_class);
+    }
+    let request = builder.build().map_err(anyhow::Error::from)?;
+    let volume = remote_runtime()?
+        .block_on(
+            context
+                .client
+                .create_remote_volume(&context.tenant_id, &request),
+        )
+        .map_err(anyhow::Error::from)?;
+    println!("{}", serde_json::to_string_pretty(&volume)?);
+    Ok(())
+}
+
+fn remote_catalog(json: bool) -> Result<()> {
+    let context = remote_context()?;
+    let volumes = remote_runtime()?
+        .block_on(context.client.list_remote_volumes(&context.tenant_id))
+        .map_err(anyhow::Error::from)?;
+    print_remote_volumes(&volumes, json)
+}
+
+fn print_remote_volumes(volumes: &[RemoteVolume], json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(volumes)?);
+        return Ok(());
+    }
+    for volume in volumes {
+        let attached = volume.attached_instance_id.as_deref().unwrap_or("-");
+        println!(
+            "{}\t{}\t{} GiB\tattached={attached}",
+            volume.volume_id, volume.name, volume.size_gib
+        );
+    }
+    Ok(())
+}
+
+fn remote_snapshot(volume_id: &str, snapshot_name: &str) -> Result<()> {
+    let context = remote_context()?;
+    let snapshot = remote_runtime()?
+        .block_on(context.client.create_remote_volume_snapshot(
+            &context.tenant_id,
+            volume_id,
+            snapshot_name,
+        ))
+        .map_err(anyhow::Error::from)?;
+    println!("{}", serde_json::to_string_pretty(&snapshot)?);
+    Ok(())
+}
+
+fn remote_restore(source_volume_id: &str, snapshot_id: &str, target_name: &str) -> Result<()> {
+    let context = remote_context()?;
+    let volume = remote_runtime()?
+        .block_on(context.client.restore_remote_volume(
+            &context.tenant_id,
+            source_volume_id,
+            snapshot_id,
+            target_name,
+        ))
+        .map_err(anyhow::Error::from)?;
+    println!("{}", serde_json::to_string_pretty(&volume)?);
+    Ok(())
+}
+
+fn remote_delete(volume_id: &str) -> Result<()> {
+    let context = remote_context()?;
+    remote_runtime()?
+        .block_on(
+            context
+                .client
+                .delete_remote_volume(&context.tenant_id, volume_id),
+        )
+        .map_err(anyhow::Error::from)?;
+    println!("Deleted remote volume {volume_id}");
+    Ok(())
+}
+
+fn remote_mount(
+    instance_id: &str,
+    volume_id: &str,
+    guest_path: &str,
+    writable: bool,
+) -> Result<()> {
+    validate_mount_path(guest_path).context("invalid remote guest mount path")?;
+    let context = remote_context()?;
+    let request = RemoteVolumeMount::new(volume_id, instance_id, guest_path).writable(writable);
+    let attachment = remote_runtime()?
+        .block_on(
+            context
+                .client
+                .attach_remote_volume(&context.tenant_id, &request),
+        )
+        .map_err(anyhow::Error::from)?;
+    println!("{}", serde_json::to_string_pretty(&attachment)?);
+    Ok(())
+}
+
+fn remote_ls(instance_id: &str, json: bool) -> Result<()> {
+    let context = remote_context()?;
+    let runtime = remote_runtime()?;
+    let attachments = runtime.block_on(async {
+        let volumes = context
+            .client
+            .list_remote_volumes(&context.tenant_id)
+            .await?;
+        let mut attachments = Vec::new();
+        for volume in volumes
+            .into_iter()
+            .filter(|volume| volume.attached_instance_id.as_deref() == Some(instance_id))
+        {
+            attachments.push(
+                context
+                    .client
+                    .remote_volume_attachment(&context.tenant_id, &volume.volume_id)
+                    .await?,
+            );
+        }
+        Ok::<_, mvm_core::client::MvmError>(attachments)
+    })?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&attachments)?);
+    } else {
+        for attachment in attachments {
+            println!(
+                "{}\t{}\tread_only={}\tfencing_token={}",
+                attachment.volume_id,
+                attachment.device_path,
+                attachment.read_only,
+                attachment.fencing_token
+            );
+        }
+    }
+    Ok(())
+}
+
+fn remote_unmount(instance_id: &str, guest_path: &str) -> Result<()> {
+    let context = remote_context()?;
+    let runtime = remote_runtime()?;
+    let volume_id = runtime.block_on(async {
+        let volumes = context
+            .client
+            .list_remote_volumes(&context.tenant_id)
+            .await?;
+        for volume in volumes
+            .into_iter()
+            .filter(|volume| volume.attached_instance_id.as_deref() == Some(instance_id))
+        {
+            let attachment = context
+                .client
+                .remote_volume_attachment(&context.tenant_id, &volume.volume_id)
+                .await?;
+            if attachment.device_path == guest_path {
+                return Ok::<_, mvm_core::client::MvmError>(Some(volume.volume_id));
+            }
+        }
+        Ok(None)
+    })?;
+    let volume_id = volume_id.with_context(|| {
+        format!("no remote volume is mounted at {guest_path:?} on instance {instance_id:?}")
+    })?;
+    runtime
+        .block_on(
+            context
+                .client
+                .detach_remote_volume(&context.tenant_id, &volume_id),
+        )
+        .map_err(anyhow::Error::from)?;
+    println!("Detached remote volume {volume_id}");
+    Ok(())
 }
 
 fn validate_volume_name(name: &str) -> Result<()> {

--- a/crates/mvm-cli/src/commands/vm/volume/remote.rs
+++ b/crates/mvm-cli/src/commands/vm/volume/remote.rs
@@ -1,0 +1,230 @@
+//! Authenticated mvmd-backed volume lifecycle commands.
+
+use anyhow::{Context, Result, bail};
+use mvm_core::client::gateway::{
+    GatewayBackend, GatewayConfig, RemoteVolume, RemoteVolumeCreate, RemoteVolumeMount,
+};
+use mvm_core::crypto::policy::validate_mount_path;
+
+struct RemoteContext {
+    client: GatewayBackend,
+    tenant_id: String,
+}
+
+fn required_env(name: &str) -> Result<String> {
+    let value = std::env::var(name)
+        .with_context(|| format!("{name} is required for --remote volume operations"))?;
+    if value.trim().is_empty() {
+        bail!("{name} must not be empty for --remote volume operations");
+    }
+    Ok(value)
+}
+
+fn context() -> Result<RemoteContext> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let base_url = required_env("MVM_GATEWAY_URL")?;
+    let token = required_env("MVM_GATEWAY_TOKEN")?;
+    let tenant_id = required_env("MVM_TENANT_ID")?;
+    let client =
+        GatewayBackend::new(GatewayConfig { base_url, token }).map_err(anyhow::Error::from)?;
+    Ok(RemoteContext { client, tenant_id })
+}
+
+fn runtime() -> Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building remote volume client runtime")
+}
+
+fn size_gib(size: &str) -> Result<u32> {
+    let size_mib = mvm_core::util::parse_human_size(size)
+        .with_context(|| format!("invalid remote volume size {size:?}"))?;
+    if size_mib == 0 {
+        bail!("remote volume size must be at least 1 MiB");
+    }
+    Ok(size_mib.div_ceil(1024))
+}
+
+pub(super) fn create(
+    volume_name: &str,
+    size: &str,
+    bucket: Option<&str>,
+    storage_class: Option<&str>,
+) -> Result<()> {
+    let context = context()?;
+    let mut builder = RemoteVolumeCreate::builder(volume_name, size_gib(size)?);
+    if let Some(bucket) = bucket {
+        builder = builder.bucket(bucket);
+    }
+    if let Some(storage_class) = storage_class {
+        builder = builder.storage_class(storage_class);
+    }
+    let request = builder.build().map_err(anyhow::Error::from)?;
+    let volume = runtime()?
+        .block_on(
+            context
+                .client
+                .create_remote_volume(&context.tenant_id, &request),
+        )
+        .map_err(anyhow::Error::from)?;
+    println!("{}", serde_json::to_string_pretty(&volume)?);
+    Ok(())
+}
+
+pub(super) fn catalog(json: bool) -> Result<()> {
+    let context = context()?;
+    let volumes = runtime()?
+        .block_on(context.client.list_remote_volumes(&context.tenant_id))
+        .map_err(anyhow::Error::from)?;
+    print_volumes(&volumes, json)
+}
+
+fn print_volumes(volumes: &[RemoteVolume], json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(volumes)?);
+        return Ok(());
+    }
+    for volume in volumes {
+        let attached = volume.attached_instance_id.as_deref().unwrap_or("-");
+        println!(
+            "{}\t{}\t{} GiB\tattached={attached}",
+            volume.volume_id, volume.name, volume.size_gib
+        );
+    }
+    Ok(())
+}
+
+pub(super) fn snapshot(volume_id: &str, snapshot_name: &str) -> Result<()> {
+    let context = context()?;
+    let snapshot = runtime()?
+        .block_on(context.client.create_remote_volume_snapshot(
+            &context.tenant_id,
+            volume_id,
+            snapshot_name,
+        ))
+        .map_err(anyhow::Error::from)?;
+    println!("{}", serde_json::to_string_pretty(&snapshot)?);
+    Ok(())
+}
+
+pub(super) fn restore(source_volume_id: &str, snapshot_id: &str, target_name: &str) -> Result<()> {
+    let context = context()?;
+    let volume = runtime()?
+        .block_on(context.client.restore_remote_volume(
+            &context.tenant_id,
+            source_volume_id,
+            snapshot_id,
+            target_name,
+        ))
+        .map_err(anyhow::Error::from)?;
+    println!("{}", serde_json::to_string_pretty(&volume)?);
+    Ok(())
+}
+
+pub(super) fn delete(volume_id: &str) -> Result<()> {
+    let context = context()?;
+    runtime()?
+        .block_on(
+            context
+                .client
+                .delete_remote_volume(&context.tenant_id, volume_id),
+        )
+        .map_err(anyhow::Error::from)?;
+    println!("Deleted remote volume {volume_id}");
+    Ok(())
+}
+
+pub(super) fn mount(
+    instance_id: &str,
+    volume_id: &str,
+    guest_path: &str,
+    writable: bool,
+) -> Result<()> {
+    validate_mount_path(guest_path).context("invalid remote guest mount path")?;
+    let context = context()?;
+    let request = RemoteVolumeMount::new(volume_id, instance_id, guest_path).writable(writable);
+    let attachment = runtime()?
+        .block_on(
+            context
+                .client
+                .attach_remote_volume(&context.tenant_id, &request),
+        )
+        .map_err(anyhow::Error::from)?;
+    println!("{}", serde_json::to_string_pretty(&attachment)?);
+    Ok(())
+}
+
+pub(super) fn ls(instance_id: &str, json: bool) -> Result<()> {
+    let context = context()?;
+    let runtime = runtime()?;
+    let attachments = runtime.block_on(async {
+        let volumes = context
+            .client
+            .list_remote_volumes(&context.tenant_id)
+            .await?;
+        let mut attachments = Vec::new();
+        for volume in volumes
+            .into_iter()
+            .filter(|volume| volume.attached_instance_id.as_deref() == Some(instance_id))
+        {
+            attachments.push(
+                context
+                    .client
+                    .remote_volume_attachment(&context.tenant_id, &volume.volume_id)
+                    .await?,
+            );
+        }
+        Ok::<_, mvm_core::client::MvmError>(attachments)
+    })?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&attachments)?);
+    } else {
+        for attachment in attachments {
+            println!(
+                "{}\t{}\tread_only={}\tfencing_token={}",
+                attachment.volume_id,
+                attachment.device_path,
+                attachment.read_only,
+                attachment.fencing_token
+            );
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn unmount(instance_id: &str, guest_path: &str) -> Result<()> {
+    let context = context()?;
+    let runtime = runtime()?;
+    let volume_id = runtime.block_on(async {
+        let volumes = context
+            .client
+            .list_remote_volumes(&context.tenant_id)
+            .await?;
+        for volume in volumes
+            .into_iter()
+            .filter(|volume| volume.attached_instance_id.as_deref() == Some(instance_id))
+        {
+            let attachment = context
+                .client
+                .remote_volume_attachment(&context.tenant_id, &volume.volume_id)
+                .await?;
+            if attachment.device_path == guest_path {
+                return Ok::<_, mvm_core::client::MvmError>(Some(volume.volume_id));
+            }
+        }
+        Ok(None)
+    })?;
+    let volume_id = volume_id.with_context(|| {
+        format!("no remote volume is mounted at {guest_path:?} on instance {instance_id:?}")
+    })?;
+    runtime
+        .block_on(
+            context
+                .client
+                .detach_remote_volume(&context.tenant_id, &volume_id),
+        )
+        .map_err(anyhow::Error::from)?;
+    println!("Detached remote volume {volume_id}");
+    Ok(())
+}

--- a/crates/mvm-conformance/tests/steps/volume.rs
+++ b/crates/mvm-conformance/tests/steps/volume.rs
@@ -228,6 +228,19 @@ fn unsupported_block_volume_is_refused(world: &mut CliWorld) {
     );
 }
 
+#[when("I run remote volume catalog without gateway configuration")]
+fn remote_volume_catalog_without_configuration(world: &mut CliWorld) {
+    let output = mvmctl_command()
+        .current_dir(workspace_root())
+        .args(["machine", "volume", "catalog", "--remote"])
+        .env_remove("MVM_GATEWAY_URL")
+        .env_remove("MVM_GATEWAY_TOKEN")
+        .env_remove("MVM_TENANT_ID")
+        .output()
+        .expect("run remote volume catalog without gateway configuration");
+    world.last_run = Some(output);
+}
+
 #[when(expr = "I execute shell command {string} in machine {string}")]
 fn execute_machine_shell(world: &mut CliWorld, script: String, machine: String) {
     let home = isolated_home(world);

--- a/crates/mvm-core/src/client/error.rs
+++ b/crates/mvm-core/src/client/error.rs
@@ -16,6 +16,12 @@ pub enum MvmError {
     Backend { reason: String },
     #[error("unauthorized: {reason}")]
     Unauthorized { reason: String },
+    #[error("conflict: {reason}")]
+    Conflict { reason: String },
+    #[error("request rejected: {reason}")]
+    Rejected { reason: String },
+    #[error("service unavailable: {reason}")]
+    Unavailable { reason: String },
 }
 
 #[cfg(test)]

--- a/crates/mvm-core/src/client/gateway.rs
+++ b/crates/mvm-core/src/client/gateway.rs
@@ -97,6 +97,24 @@ impl GatewayBackend {
         Ok(url)
     }
 
+    /// Build an API endpoint from path components so tenant and resource IDs
+    /// are percent-encoded rather than interpolated into a URL string.
+    fn endpoint_components(&self, components: &[&str]) -> Result<Url> {
+        let mut url = self.base.clone();
+        url.set_path("/");
+        url.set_query(None);
+        url.set_fragment(None);
+        {
+            let mut segments = url.path_segments_mut().map_err(|()| MvmError::Backend {
+                reason: "gateway base URL cannot carry API path segments".into(),
+            })?;
+            segments.pop_if_empty();
+            segments.extend(components);
+        }
+        endpoint_guard(&url)?;
+        Ok(url)
+    }
+
     /// Attach the bearer credential. Endpoint-bound: only ever sent to `base`.
     fn authed(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         req.bearer_auth(&self.token)
@@ -113,6 +131,15 @@ fn status_error(status: StatusCode, id: &str) -> Option<MvmError> {
             reason: format!("gateway rejected credential ({status})"),
         },
         StatusCode::NOT_FOUND => MvmError::NotFound { id: id.to_string() },
+        StatusCode::CONFLICT => MvmError::Conflict {
+            reason: format!("gateway rejected conflicting state for {id}"),
+        },
+        StatusCode::UNPROCESSABLE_ENTITY | StatusCode::BAD_REQUEST => MvmError::Rejected {
+            reason: format!("gateway rejected the request for {id} ({status})"),
+        },
+        StatusCode::SERVICE_UNAVAILABLE | StatusCode::GATEWAY_TIMEOUT => MvmError::Unavailable {
+            reason: format!("gateway could not serve {id} ({status})"),
+        },
         other => MvmError::Backend {
             reason: format!("gateway returned {other}"),
         },
@@ -163,6 +190,394 @@ struct ReconfigureBody {
     cpus: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     memory_mib: Option<u32>,
+}
+
+/// A tenant block volume returned by mvmd.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct RemoteVolume {
+    pub volume_id: String,
+    pub tenant_id: String,
+    pub name: String,
+    pub size_gib: u32,
+    #[serde(default)]
+    pub storage_class: String,
+    #[serde(default)]
+    pub from_snapshot_id: Option<String>,
+    #[serde(default)]
+    pub bucket_id: Option<String>,
+    #[serde(default)]
+    pub current_checkpoint_id: Option<String>,
+    #[serde(default)]
+    pub attached_instance_id: Option<String>,
+}
+
+/// One immutable remote volume checkpoint returned by mvmd.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct RemoteVolumeSnapshot {
+    pub snapshot_id: String,
+    pub volume_id: String,
+    pub name: String,
+    pub size_gib: u32,
+    pub status: String,
+    #[serde(default)]
+    pub bucket_id: Option<String>,
+    #[serde(default)]
+    pub checkpoint_id: String,
+}
+
+/// One exclusive remote volume attachment returned by mvmd.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct RemoteVolumeAttachment {
+    pub volume_id: String,
+    pub tenant_id: String,
+    pub instance_id: String,
+    #[serde(default)]
+    pub device_path: String,
+    #[serde(default)]
+    pub read_only: bool,
+    #[serde(default)]
+    pub fencing_token: u64,
+}
+
+/// Validated request for creating or restoring a remote volume.
+pub struct RemoteVolumeCreate {
+    name: String,
+    size_gib: u32,
+    storage_class: Option<String>,
+    from_snapshot_id: Option<String>,
+    bucket_id: Option<String>,
+}
+
+impl RemoteVolumeCreate {
+    /// Begin constructing a remote volume request.
+    #[must_use]
+    pub fn builder(name: impl Into<String>, size_gib: u32) -> RemoteVolumeCreateBuilder {
+        RemoteVolumeCreateBuilder {
+            name: name.into(),
+            size_gib,
+            storage_class: None,
+            from_snapshot_id: None,
+            bucket_id: None,
+        }
+    }
+}
+
+/// Builder for [`RemoteVolumeCreate`].
+pub struct RemoteVolumeCreateBuilder {
+    name: String,
+    size_gib: u32,
+    storage_class: Option<String>,
+    from_snapshot_id: Option<String>,
+    bucket_id: Option<String>,
+}
+
+/// Request for attaching a remote volume to one instance.
+pub struct RemoteVolumeMount {
+    volume_id: String,
+    instance_id: String,
+    device_path: String,
+    read_only: bool,
+}
+
+impl RemoteVolumeMount {
+    /// Construct a mount request; callers may opt into writable access.
+    #[must_use]
+    pub fn new(
+        volume_id: impl Into<String>,
+        instance_id: impl Into<String>,
+        device_path: impl Into<String>,
+    ) -> Self {
+        Self {
+            volume_id: volume_id.into(),
+            instance_id: instance_id.into(),
+            device_path: device_path.into(),
+            read_only: true,
+        }
+    }
+
+    #[must_use]
+    pub fn writable(mut self, writable: bool) -> Self {
+        self.read_only = !writable;
+        self
+    }
+}
+
+impl RemoteVolumeCreateBuilder {
+    #[must_use]
+    pub fn storage_class(mut self, value: impl Into<String>) -> Self {
+        self.storage_class = Some(value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn from_snapshot(mut self, value: impl Into<String>) -> Self {
+        self.from_snapshot_id = Some(value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn bucket(mut self, value: impl Into<String>) -> Self {
+        self.bucket_id = Some(value.into());
+        self
+    }
+
+    pub fn build(self) -> Result<RemoteVolumeCreate> {
+        if self.name.trim().is_empty() {
+            return Err(MvmError::InvalidSpec {
+                reason: "remote volume name must not be empty".into(),
+            });
+        }
+        if self.size_gib == 0 {
+            return Err(MvmError::InvalidSpec {
+                reason: "remote volume size must be at least 1 GiB".into(),
+            });
+        }
+        Ok(RemoteVolumeCreate {
+            name: self.name,
+            size_gib: self.size_gib,
+            storage_class: self.storage_class,
+            from_snapshot_id: self.from_snapshot_id,
+            bucket_id: self.bucket_id,
+        })
+    }
+}
+
+#[derive(serde::Serialize)]
+struct CreateRemoteVolumeBody<'a> {
+    name: &'a str,
+    size_gib: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    storage_class: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    from_snapshot_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bucket_id: Option<&'a str>,
+}
+
+#[derive(serde::Serialize)]
+struct CreateRemoteSnapshotBody<'a> {
+    name: &'a str,
+}
+
+#[derive(serde::Serialize)]
+struct AttachRemoteVolumeBody<'a> {
+    instance_id: &'a str,
+    device_path: &'a str,
+    read_only: bool,
+}
+
+impl GatewayBackend {
+    async fn decode_json<T: serde::de::DeserializeOwned>(
+        response: reqwest::Response,
+        id: &str,
+        operation: &str,
+    ) -> Result<T> {
+        if let Some(error) = status_error(response.status(), id) {
+            return Err(error);
+        }
+        response.json().await.map_err(|error| MvmError::Backend {
+            reason: format!("parsing {operation} response: {error}"),
+        })
+    }
+
+    /// Create a remote tenant volume.
+    pub async fn create_remote_volume(
+        &self,
+        tenant_id: &str,
+        request: &RemoteVolumeCreate,
+    ) -> Result<RemoteVolume> {
+        let url = self.endpoint_components(&["api", "v1", "tenants", tenant_id, "volumes"])?;
+        let body = CreateRemoteVolumeBody {
+            name: &request.name,
+            size_gib: request.size_gib,
+            storage_class: request.storage_class.as_deref(),
+            from_snapshot_id: request.from_snapshot_id.as_deref(),
+            bucket_id: request.bucket_id.as_deref(),
+        };
+        let response = self
+            .authed(self.http.post(url))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| MvmError::Unavailable {
+                reason: format!("remote volume create failed: {error}"),
+            })?;
+        Self::decode_json(response, &request.name, "remote volume create").await
+    }
+
+    /// List all remote volumes visible in a tenant.
+    pub async fn list_remote_volumes(&self, tenant_id: &str) -> Result<Vec<RemoteVolume>> {
+        let url = self.endpoint_components(&["api", "v1", "tenants", tenant_id, "volumes"])?;
+        let response = self
+            .authed(self.http.get(url))
+            .send()
+            .await
+            .map_err(|error| MvmError::Unavailable {
+                reason: format!("remote volume list failed: {error}"),
+            })?;
+        Self::decode_json(response, tenant_id, "remote volume list").await
+    }
+
+    /// Delete a detached remote volume.
+    pub async fn delete_remote_volume(&self, tenant_id: &str, volume_id: &str) -> Result<()> {
+        let url =
+            self.endpoint_components(&["api", "v1", "tenants", tenant_id, "volumes", volume_id])?;
+        let response = self
+            .authed(self.http.delete(url))
+            .send()
+            .await
+            .map_err(|error| MvmError::Unavailable {
+                reason: format!("remote volume delete failed: {error}"),
+            })?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+        match status_error(response.status(), volume_id) {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    /// Attach a remote volume through mvmd's exclusive-writer boundary.
+    pub async fn attach_remote_volume(
+        &self,
+        tenant_id: &str,
+        request: &RemoteVolumeMount,
+    ) -> Result<RemoteVolumeAttachment> {
+        let url = self.endpoint_components(&[
+            "api",
+            "v1",
+            "tenants",
+            tenant_id,
+            "volumes",
+            &request.volume_id,
+            "attach",
+        ])?;
+        let body = AttachRemoteVolumeBody {
+            instance_id: &request.instance_id,
+            device_path: &request.device_path,
+            read_only: request.read_only,
+        };
+        let response = self
+            .authed(self.http.post(url))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| MvmError::Unavailable {
+                reason: format!("remote volume attach failed: {error}"),
+            })?;
+        Self::decode_json(response, &request.volume_id, "remote volume attach").await
+    }
+
+    /// Return one remote volume's current attachment.
+    pub async fn remote_volume_attachment(
+        &self,
+        tenant_id: &str,
+        volume_id: &str,
+    ) -> Result<RemoteVolumeAttachment> {
+        let url = self.endpoint_components(&[
+            "api", "v1", "tenants", tenant_id, "volumes", volume_id, "attach",
+        ])?;
+        let response = self
+            .authed(self.http.get(url))
+            .send()
+            .await
+            .map_err(|error| MvmError::Unavailable {
+                reason: format!("remote attachment read failed: {error}"),
+            })?;
+        Self::decode_json(response, volume_id, "remote attachment read").await
+    }
+
+    /// Detach one remote volume idempotently.
+    pub async fn detach_remote_volume(&self, tenant_id: &str, volume_id: &str) -> Result<()> {
+        let url = self.endpoint_components(&[
+            "api", "v1", "tenants", tenant_id, "volumes", volume_id, "attach",
+        ])?;
+        let response = self
+            .authed(self.http.delete(url))
+            .send()
+            .await
+            .map_err(|error| MvmError::Unavailable {
+                reason: format!("remote volume detach failed: {error}"),
+            })?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+        match status_error(response.status(), volume_id) {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    /// Create an immutable checkpoint for a remote volume.
+    pub async fn create_remote_volume_snapshot(
+        &self,
+        tenant_id: &str,
+        volume_id: &str,
+        snapshot_name: &str,
+    ) -> Result<RemoteVolumeSnapshot> {
+        let url = self.endpoint_components(&[
+            "api",
+            "v1",
+            "tenants",
+            tenant_id,
+            "volumes",
+            volume_id,
+            "snapshots",
+        ])?;
+        let response = self
+            .authed(self.http.post(url))
+            .json(&CreateRemoteSnapshotBody {
+                name: snapshot_name,
+            })
+            .send()
+            .await
+            .map_err(|error| MvmError::Unavailable {
+                reason: format!("remote checkpoint failed: {error}"),
+            })?;
+        Self::decode_json(response, volume_id, "remote checkpoint").await
+    }
+
+    /// Restore a pinned checkpoint into a new remote volume.
+    pub async fn restore_remote_volume(
+        &self,
+        tenant_id: &str,
+        source_volume_id: &str,
+        snapshot_id: &str,
+        target_name: &str,
+    ) -> Result<RemoteVolume> {
+        let url = self.endpoint_components(&[
+            "api",
+            "v1",
+            "tenants",
+            tenant_id,
+            "volumes",
+            source_volume_id,
+            "snapshots",
+            snapshot_id,
+        ])?;
+        let response = self
+            .authed(self.http.get(url))
+            .send()
+            .await
+            .map_err(|error| MvmError::Unavailable {
+                reason: format!("remote checkpoint lookup failed: {error}"),
+            })?;
+        let snapshot: RemoteVolumeSnapshot =
+            Self::decode_json(response, snapshot_id, "remote checkpoint lookup").await?;
+        if snapshot.status != "ready" || snapshot.checkpoint_id.is_empty() {
+            return Err(MvmError::Conflict {
+                reason: "remote checkpoint is not ready for restore".into(),
+            });
+        }
+        let mut builder = RemoteVolumeCreate::builder(target_name, snapshot.size_gib)
+            .from_snapshot(snapshot.snapshot_id);
+        if let Some(bucket_id) = snapshot.bucket_id {
+            builder = builder.bucket(bucket_id);
+        }
+        self.create_remote_volume(tenant_id, &builder.build()?)
+            .await
+    }
 }
 
 /// Map the gateway's status string onto the facade status. Unknown values fail
@@ -405,7 +820,10 @@ impl MvmClient for GatewayBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Once;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Once, mpsc};
+    use std::time::Duration;
 
     fn install_rustls_provider() {
         static INSTALL: Once = Once::new();
@@ -447,6 +865,54 @@ mod tests {
             base_url: base.into(),
             token: "mvmd_org_deadbeef".into(),
         }
+    }
+
+    fn serve_one_json(
+        response_body: &'static str,
+    ) -> (String, mpsc::Receiver<String>, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (sender, receiver) = mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0u8; 4096];
+            loop {
+                let count = stream.read(&mut buffer).unwrap();
+                if count == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..count]);
+                let Some(header_end) = request.windows(4).position(|part| part == b"\r\n\r\n")
+                else {
+                    continue;
+                };
+                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        line.to_ascii_lowercase()
+                            .strip_prefix("content-length: ")
+                            .and_then(|value| value.parse::<usize>().ok())
+                    })
+                    .unwrap_or_default();
+                if request.len() >= header_end + 4 + content_length {
+                    break;
+                }
+            }
+            sender.send(String::from_utf8(request).unwrap()).unwrap();
+            write!(
+                stream,
+                "HTTP/1.1 201 Created\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            )
+            .unwrap();
+        });
+        (format!("http://{address}"), receiver, handle)
     }
 
     #[test]
@@ -564,6 +1030,18 @@ mod tests {
             Some(MvmError::NotFound { id }) if id == "m1"
         ));
         assert!(matches!(
+            status_error(StatusCode::CONFLICT, "m1"),
+            Some(MvmError::Conflict { .. })
+        ));
+        assert!(matches!(
+            status_error(StatusCode::UNPROCESSABLE_ENTITY, "m1"),
+            Some(MvmError::Rejected { .. })
+        ));
+        assert!(matches!(
+            status_error(StatusCode::SERVICE_UNAVAILABLE, "m1"),
+            Some(MvmError::Unavailable { .. })
+        ));
+        assert!(matches!(
             status_error(StatusCode::INTERNAL_SERVER_ERROR, "m1"),
             Some(MvmError::Backend { .. })
         ));
@@ -610,5 +1088,75 @@ mod tests {
         };
         let json = serde_json::to_string(&body).unwrap();
         assert_eq!(json, r#"{"net":true,"cpus":2}"#);
+    }
+
+    #[test]
+    fn remote_volume_path_components_are_encoded() {
+        install_rustls_provider();
+        let backend = GatewayBackend::new(cfg("https://fleet.example.com")).unwrap();
+        let url = backend
+            .endpoint_components(&["api", "v1", "tenants", "tenant/escape", "volumes"])
+            .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://fleet.example.com/api/v1/tenants/tenant%2Fescape/volumes"
+        );
+    }
+
+    #[test]
+    fn remote_volume_create_builder_validates_and_omits_absent_fields() {
+        assert!(RemoteVolumeCreate::builder("data", 0).build().is_err());
+        let request = RemoteVolumeCreate::builder("data", 4).build().unwrap();
+        let body = CreateRemoteVolumeBody {
+            name: &request.name,
+            size_gib: request.size_gib,
+            storage_class: request.storage_class.as_deref(),
+            from_snapshot_id: request.from_snapshot_id.as_deref(),
+            bucket_id: request.bucket_id.as_deref(),
+        };
+        assert_eq!(
+            serde_json::to_string(&body).unwrap(),
+            r#"{"name":"data","size_gib":4}"#
+        );
+    }
+
+    #[test]
+    fn remote_volume_response_is_backward_compatible() {
+        let volume: RemoteVolume = serde_json::from_str(
+            r#"{"volume_id":"vol-1","tenant_id":"tenant-1","name":"data","size_gib":8}"#,
+        )
+        .unwrap();
+        assert_eq!(volume.volume_id, "vol-1");
+        assert!(volume.bucket_id.is_none());
+        assert!(volume.attached_instance_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn remote_volume_create_sends_authenticated_tenant_request() {
+        install_rustls_provider();
+        let response = r#"{"volume_id":"vol-1","tenant_id":"tenant-a","name":"data","size_gib":8,"bucket_id":"bucket-1"}"#;
+        let (base_url, request_receiver, server) = serve_one_json(response);
+        let backend = GatewayBackend::new(GatewayConfig {
+            base_url,
+            token: "secret-bearer".into(),
+        })
+        .unwrap();
+        let request = RemoteVolumeCreate::builder("data", 8)
+            .bucket("bucket-1")
+            .build()
+            .unwrap();
+
+        let volume = backend
+            .create_remote_volume("tenant-a", &request)
+            .await
+            .unwrap();
+        assert_eq!(volume.volume_id, "vol-1");
+        let raw_request = request_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap();
+        assert!(raw_request.starts_with("POST /api/v1/tenants/tenant-a/volumes HTTP/1.1"));
+        assert!(raw_request.contains("authorization: Bearer secret-bearer"));
+        assert!(raw_request.contains(r#""bucket_id":"bucket-1""#));
+        server.join().unwrap();
     }
 }

--- a/features/suites/s26_volumes/volume_lifecycle.feature
+++ b/features/suites/s26_volumes/volume_lifecycle.feature
@@ -52,6 +52,11 @@ Feature: Encrypted block volume lifecycle and attachment
     When I ask the Docker backend to attach a block volume
     Then the backend refuses the unsupported block volume before boot
 
+  Scenario: remote volume operations require explicit authenticated configuration
+    When I run remote volume catalog without gateway configuration
+    Then the command exits with code 1
+    And the error output contains "MVM_GATEWAY_URL is required"
+
   @live
   Scenario: a failed persistent start releases its volume attachment lease
     Given an isolated mvm home

--- a/public/src/content/docs/guides/persistent-workspaces.md
+++ b/public/src/content/docs/guides/persistent-workspaces.md
@@ -66,6 +66,47 @@ Security rules:
 - do not mount the same writable volume into unrelated sandboxes unless sharing
   state is the intent.
 
+## Durable tenant volumes through mvmd
+
+Use remote mode when mvmd owns the tenant, storage provider, encryption keys,
+quota, and attachment policy. Configure the authenticated client without
+putting the bearer token on the command line:
+
+```sh
+export MVM_GATEWAY_URL=https://mvmd.example.com
+export MVM_TENANT_ID=tenant-acme
+read -rsp "mvmd bearer token: " MVM_GATEWAY_TOKEN
+export MVM_GATEWAY_TOKEN
+```
+
+The client refuses cleartext HTTP except for a loopback sidecar. Provider
+credentials never enter `mvmctl`; mvmd resolves them from the registered
+`StorageBucket`.
+
+Create and list durable volumes:
+
+```sh
+mvmctl volume create database --size 20G --remote --bucket bucket-primary
+mvmctl volume catalog --remote --json
+```
+
+The API allocates whole GiB, so smaller human-readable sizes round up to one
+GiB. Use the returned volume ID for attachment and checkpoint operations:
+
+```sh
+mvmctl volume mount worker-1 --volume vol-123 --guest /data --rw --remote
+mvmctl volume checkpoint vol-123 before-upgrade --remote
+mvmctl volume restore vol-123 snap-456 --target database-recovered --remote
+mvmctl volume unmount worker-1 /data --remote
+mvmctl volume delete vol-123 --remote
+```
+
+Remote restore always creates a new volume from a pinned, ready checkpoint; it
+does not overwrite the source volume. Delete is refused while a volume remains
+attached or retains checkpoints. Attachment conflicts, quota failures,
+authorization failures, provider outages, and integrity refusals are returned
+as errors rather than falling back to the local registry.
+
 ## Host-backed mounts
 
 Ad-hoc host-backed mounts are useful when an existing encrypted host directory

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -24,7 +24,8 @@ for detailed scope and acceptance criteria.
   - [x] Canonical mvm contract and dead S3-path removal
   - [x] Live local/block attachment through the admitted VM launch path
   - [x] mvmd OpenDAL → `object_store` migration with mandatory encryption
-  - [ ] Durable encrypted checkpoints, cross-worker restore, and remote CLI
+  - [x] Authenticated remote volume CLI/client lifecycle with typed failures
+  - [ ] Durable encrypted checkpoint/API policy and cross-worker restore closeout
   - [ ] MinIO integration plus Linux/KVM persistence and restore proof
 
 - [x] Plan 282 — Merge queue auto-requeue

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -79,8 +79,18 @@
         mvmd PR #198 carries the implementation; 1,497 gateway library tests,
         1,632 integration tests, the remaining workspace tests/doctests, check,
         all-target clippy, formatting, focused docs, audit, and deny pass.
-  - [ ] WS4–WS7: durable checkpoint/restore, remote operations, live provider
-        and cross-worker KVM proof, documentation, and closeout remain open.
+  - [x] WS5 client increment: the remote stub is gone. The authenticated,
+        HTTPS-or-loopback `GatewayBackend` now carries tenant volume create,
+        list, attach, detach, checkpoint, restore, and delete operations with
+        typed failures and percent-encoded resource IDs. `mvmctl volume
+        --remote` reads its URL, in-memory-only bearer token, and tenant from
+        dedicated environment variables while local behavior stays unchanged.
+        Twenty-one gateway client tests, including one real loopback HTTP request, nine CLI
+        lifecycle parser tests, touched-crate checks, all-target Clippy, and the
+        complete 115-scenario / 523-step BDD suite pass.
+  - [ ] WS4/WS5 policy/WS6/WS7: durable checkpoint closeout, the full API
+        refusal matrix, live provider and cross-worker KVM proof, remaining
+        documentation, and closeout remain open.
 
 - [x] Merge-queue auto-requeue: bounded recovery for transiently ejected pull
       requests, with conflict refusal, persistent attempt counting, no checkout

--- a/specs/plans/283-production-object-store-volumes.md
+++ b/specs/plans/283-production-object-store-volumes.md
@@ -243,9 +243,9 @@ repository's documented transitive exceptions, and cargo-deny.
 
 ## WS5 — Remote CLI, API, policy, and observability
 
-- [ ] Replace mvmctl's `--remote` volume stub with the authenticated mvmd client
+- [x] Replace mvmctl's `--remote` volume stub with the authenticated mvmd client
       for create/list/mount/unmount/checkpoint/snapshot/restore/delete.
-- [ ] Keep CLI business logic in the library/client seam, return typed errors,
+- [x] Keep CLI business logic in the library/client seam, return typed errors,
       and preserve local-mode behavior without provider credentials on the dev
       machine.
 - [ ] Enforce tenant/workspace scope, RBAC, quotas, mount policy, attachment
@@ -260,6 +260,19 @@ repository's documented transitive exceptions, and cargo-deny.
 - [ ] Add API/CLI BDD coverage for success, authorization refusal, quota refusal,
       conflict, retry, provider outage, integrity refusal, and backward-compatible
       payloads.
+
+WS5 client evidence (2026-08-02): `GatewayBackend` now owns the authenticated
+tenant-volume request/response seam, percent-encodes authority/resource path
+components, refuses cleartext non-loopback endpoints, maps authorization,
+conflict, validation, and availability failures to typed facade errors, and
+redacts the bearer token. `mvmctl volume --remote` covers create, catalog,
+mount, list, unmount, checkpoint/snapshot, restore-to-new-volume, and delete
+using `MVM_GATEWAY_URL`, `MVM_GATEWAY_TOKEN`, and `MVM_TENANT_ID`; provider
+credentials remain fleet-only. Twenty-one gateway client tests, including the authenticated
+loopback HTTP round trip, nine local/remote CLI parse tests, touched-crate
+checks, all-target Clippy with warnings denied, and the complete 115-scenario /
+523-step BDD suite pass. The remaining WS5 boxes are mvmd boundary
+policy/audit/metrics plus the full remote API refusal matrix.
 
 ## WS6 — Live provider and microVM proof
 

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -264,6 +264,9 @@ const VOLUME_SUB: &[(&str, AuditPosture)] = &[
     ("lock", AuditPosture::Emits("VolumeLock")),
     ("snapshot", AuditPosture::Emits("VolumeSnapshot")),
     ("restore", AuditPosture::Emits("VolumeRestore")),
+    // Remote-only control-plane mutation. The authenticated gateway records
+    // the signed deletion audit after enforcing tenant authority.
+    ("delete", AuditPosture::InteractiveOrControl),
     ("catalog", AuditPosture::ReadOnly),
     ("mount", AuditPosture::Emits("VmVolumeAdd")),
     ("ls", AuditPosture::ReadOnly),


### PR DESCRIPTION
Closes the remote CLI/client portion of #2040.

- replace every shipped `volume --remote` stub with authenticated mvmd tenant-volume operations
- add typed client errors, HTTPS-or-loopback transport enforcement, encoded resource paths, and token redaction
- cover create/list/attach/detach/checkpoint/restore/delete while preserving local mode
- document remote configuration and synchronize Plan 283, sprint, and refactor status

Validation:
- 21 `mvm-core` gateway client tests, including a real authenticated loopback HTTP request
- 9 local/remote volume CLI parser tests
- 115 BDD scenarios / 523 steps
- `cargo check -p mvm-core --features client-remote`
- `cargo check -p mvm-cli`
- full workspace pre-commit clippy with warnings denied