### PR TITLE
Restore scheduled security witnesses

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -589,6 +589,10 @@ jobs:
       - name: Install cargo-mutants and nextest
         run: cargo install --locked cargo-mutants cargo-nextest
 
+      - name: Install mvm-cli embedded-host toolchain
+        if: matrix.package == 'mvm-cli'
+        uses: ./.github/actions/install-zigbuild
+
       - name: Mutate this package's claim surface and ratchet survivors
         # `--run` mutates the claim-enforcement surface and runs the suite
         # against each mutant — plan verification that no longer verifies, a

--- a/crates/mvm-agentd/src/l3/privdrop.rs
+++ b/crates/mvm-agentd/src/l3/privdrop.rs
@@ -196,6 +196,9 @@ mod linux {
 mod tests {
     use super::*;
 
+    #[cfg(target_os = "linux")]
+    const PRIVILEGED_CHILD: &str = "MVM_PRIVDROP_TEST_CHILD";
+
     #[test]
     fn a_complete_report_has_no_shortfall() {
         let report = DropReport {
@@ -218,10 +221,93 @@ mod tests {
         assert_eq!(report.shortfall(), vec!["no_new_privs", "bounding_set"]);
     }
 
-    /// Running the real drop inside the test process would disarm the test
-    /// runner, so this only asserts the non-Linux shape. The Linux path is
-    /// covered by the privileged integration lane, which runs it in a child
-    /// process and then checks `/proc/self/status`.
+    #[test]
+    fn a_report_is_complete_only_when_every_step_succeeded() {
+        for no_new_privs in [false, true] {
+            for capabilities_cleared in [false, true] {
+                for bounding_set_cleared in [false, true] {
+                    let report = DropReport {
+                        no_new_privs,
+                        capabilities_cleared,
+                        bounding_set_cleared,
+                    };
+                    assert_eq!(
+                        report.is_complete(),
+                        no_new_privs && capabilities_cleared && bounding_set_cleared
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn recording_dropper_counts_each_request() {
+        let mut dropper = RecordingPrivilegeDropper::default();
+
+        assert!(dropper.drop_privileges().is_complete());
+        assert_eq!(dropper.calls, 1);
+        assert!(dropper.drop_privileges().is_complete());
+        assert_eq!(dropper.calls, 2);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn real_privilege_drop_matches_kernel_state() {
+        if std::env::var_os(PRIVILEGED_CHILD).is_some() {
+            let report = drop_privileges();
+            assert!(
+                report.is_complete(),
+                "kernel privilege drop was incomplete: {:?}",
+                report.shortfall()
+            );
+
+            let status = std::fs::read_to_string("/proc/thread-self/status")
+                .expect("read the privileged test child's process status");
+            assert_eq!(
+                status_field(&status, "NoNewPrivs"),
+                "1",
+                "NoNewPrivs was not set after privilege drop"
+            );
+            for field in ["CapInh", "CapPrm", "CapEff", "CapBnd", "CapAmb"] {
+                let value = u64::from_str_radix(status_field(&status, field), 16)
+                    .expect("capability status fields must contain hexadecimal integers");
+                assert_eq!(value, 0, "{field} remained set after privilege drop");
+            }
+            return;
+        }
+
+        let test_binary = std::env::current_exe().expect("resolve the current test binary");
+        let output = std::process::Command::new("sudo")
+            .args(["-n", "/usr/bin/env"])
+            .arg(format!("{PRIVILEGED_CHILD}=1"))
+            .arg(test_binary)
+            .args(["real_privilege_drop_matches_kernel_state", "--nocapture"])
+            .output()
+            .expect("run the privilege-drop witness in an isolated root child");
+
+        assert!(
+            output.status.success(),
+            "privilege-drop child failed: status={:?}\nstdout={}\nstderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    fn status_field<'a>(status: &'a str, name: &str) -> &'a str {
+        status
+            .lines()
+            .find_map(|line| {
+                line.split_once(':')
+                    .filter(|(field, _)| *field == name)
+                    .map(|(_, value)| value.trim())
+            })
+            .expect("required field must exist in /proc/thread-self/status")
+    }
+
+    /// Linux runs the real drop in an isolated privileged child above. This
+    /// test locks the shared caller's no-op contract on other platforms.
     #[cfg(not(target_os = "linux"))]
     #[test]
     fn non_linux_builds_report_a_complete_drop() {

--- a/crates/mvm-runtime/src/libkrun.rs
+++ b/crates/mvm-runtime/src/libkrun.rs
@@ -2343,7 +2343,7 @@ mod tests {
         assert!(caps.host_vsock_proxy);
         assert!(
             !caps.l3_vsock,
-            "libkrun's virtio-net device violates the L3 tunnel precondition"
+            "libkrun does not meet the stricter L3 tunnel precondition"
         );
 
         // The rest of the table, each pinned so its deletion is visible.

--- a/crates/mvm-runtime/src/libkrun.rs
+++ b/crates/mvm-runtime/src/libkrun.rs
@@ -1545,6 +1545,7 @@ mod tests {
         assert!(!caps.snapshots);
         assert!(!caps.pause_resume);
         assert!(!caps.tap_networking);
+        assert!(!caps.l3_vsock);
     }
 
     #[test]
@@ -2340,6 +2341,10 @@ mod tests {
         );
         assert!(caps.vsock, "vsock is the only transport into the guest");
         assert!(caps.host_vsock_proxy);
+        assert!(
+            !caps.l3_vsock,
+            "libkrun's virtio-net device violates the L3 tunnel precondition"
+        );
 
         // The rest of the table, each pinned so its deletion is visible.
         assert!(

--- a/scripts/check-no-ssh.sh
+++ b/scripts/check-no-ssh.sh
@@ -32,6 +32,9 @@ ALLOWED_FILES=(
   # `.ssh/id_rsa` access and `ssh-keygen` invocation as guest threats.
   "crates/mvm-core/src/crypto/command_gate.rs"
   "crates/mvm-core/src/crypto/threat_classifier.rs"
+  # Host-share parser test: proves the user's SSH credential directory and a
+  # private-key-shaped child path are refused as guest mount sources.
+  "crates/mvm-cli/src/commands/shared/parse.rs"
   # Secrets scanner: a one-line comment naming "OpenSSH" as one of the PEM
   # private-key formats its generic BEGIN-block regex redacts.
   "crates/mvm-hostd/src/supervisor/secrets_scanner.rs"

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -28,6 +28,10 @@ for detailed scope and acceptance criteria.
   - [x] Verify the repository has zero open GitHub issues
   - [x] Repair the subsequent scheduled-security alert #2067 and retain a
         PR-time regression witness for its mutation-shard toolchain
+  - [x] Add executable Linux mutation witnesses for the L3 privilege-drop path
+        exposed by #2067's exact security rerun
+  - [x] Pin libkrun's L3 refusal and classify its default-equivalent mutation
+        exposed by #2067's exact security rerun
 
 - [x] Plan 283 — Production object-store volumes
       (`specs/plans/283-production-object-store-volumes.md`, issue #2040)

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -26,6 +26,8 @@ for detailed scope and acceptance criteria.
   - [x] Revalidate and close newly filed #2054 on current main
   - [x] Execute the refiled volume epic #2040
   - [x] Verify the repository has zero open GitHub issues
+  - [x] Repair the subsequent scheduled-security alert #2067 and retain a
+        PR-time regression witness for its mutation-shard toolchain
 
 - [x] Plan 283 — Production object-store volumes
       (`specs/plans/283-production-object-store-volumes.md`, issue #2040)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -41,6 +41,13 @@
       failures remain retryable. The production-volume epic #2040 and the
       subsequently filed entropy issue #2060 are also closed with merged
       evidence. The final GitHub open-issue query returned zero results.
+      A scheduled run on an older commit subsequently filed #2067: the no-SSH
+      scanner had not classified a protected-credential-path refusal test as
+      deny-only, and the `mvm-cli` mutation shard lacked the pinned Zig
+      toolchain required by its build script. The follow-up audits that exact
+      deny test, installs Zig only for the affected shard, and adds a PR-time
+      structural regression test; its merge closes #2067 and restores the
+      zero-open-issue state.
       Tracked in plan 284.
 
 - [x] Production object-store volumes — **plan 283 / issue #2040**. Standardize

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -44,10 +44,15 @@
       A scheduled run on an older commit subsequently filed #2067: the no-SSH
       scanner had not classified a protected-credential-path refusal test as
       deny-only, and the `mvm-cli` mutation shard lacked the pinned Zig
-      toolchain required by its build script. The follow-up audits that exact
-      deny test, installs Zig only for the affected shard, and adds a PR-time
-      structural regression test; its merge closes #2067 and restores the
-      zero-open-issue state.
+      toolchain required by its build script. The exact rerun also exposed
+      missing mutation witnesses for the new L3 privilege-drop path and an
+      unclassified, semantically equivalent deletion of libkrun's explicit
+      `l3_vsock: false` capability (whose derived default is also `false`). The
+      follow-up audits that deny test, installs Zig only for the affected shard,
+      adds a PR-time structural regression test, proves in an isolated
+      privileged child that `NoNewPrivs` and every capability set are actually
+      cleared, and pins the libkrun L3 declaration; its merge closes #2067 and
+      restores the zero-open-issue state.
       Tracked in plan 284.
 
 - [x] Production object-store volumes — **plan 283 / issue #2040**. Standardize

--- a/specs/plans/284-zero-open-issue-reconciliation.md
+++ b/specs/plans/284-zero-open-issue-reconciliation.md
@@ -67,6 +67,15 @@ open GitHub issues.
       the no-SSH scanner, install the pinned embedded-host Zig toolchain only in
       the `mvm-cli` mutation shard, and add PR-time regression coverage for that
       toolchain dependency.
+- [x] Repair the additional `mvm-agentd` mutation-witness gap exposed by the
+      exact security rerun: cover every `DropReport` state, prove recording
+      calls cannot disappear, and run the real Linux privilege drop in an
+      isolated root child that checks
+      `/proc/thread-self/status` for `NoNewPrivs=1` and zero capability sets.
+- [x] Classify the rerun's `mvm-runtime` survivor as equivalent: deleting
+      libkrun's explicit `l3_vsock: false` falls back to the same derived
+      `VmCapabilities` default. Pin the declared L3 refusal in the capability
+      tests and the exact equivalent mutation in the ratchet.
 
 Closeout evidence (2026-08-02): the production-volume implementation merged
 across mvm PRs #2044 and #2064 and mvmd PRs #198 through #202. The independent
@@ -75,7 +84,10 @@ reconciliation. Issue #2040 was closed with an explicit shipped-versus-rejected
 scope ledger, #2060 closed from its merge, and `gh issue list --state open`
 returned an empty JSON array. A later scheduled-run alert opened #2067 from an
 older main commit; its two reproducible workflow failures are repaired by the
-follow-up above, and its closing PR restores the zero-issue state.
+follow-up above. Its exact branch rerun additionally exposed the L3
+privilege-drop mutation gap and the equivalent libkrun capability deletion,
+which the same closing PR repairs and classifies before restoring the zero-issue
+state.
 
 ## Verified upstream inputs
 

--- a/specs/plans/284-zero-open-issue-reconciliation.md
+++ b/specs/plans/284-zero-open-issue-reconciliation.md
@@ -2,8 +2,8 @@
 
 Issues: #1819, #1821, #1822, #1823, #1825, #1826, #1849, #1851, #1937,
 #1972, #1973, #1977, #1983, #2006, #2007, #2021, #2028, #2029, #2033,
-#2035, #2036, #2039, #2040, #2042, #2048, #2052, #2054, plus #2060 filed
-during execution
+#2035, #2036, #2039, #2040, #2042, #2048, #2052, #2054, plus #2060 and
+#2067 filed during execution
 
 Status: COMPLETE (2026-08-02)
 
@@ -62,13 +62,20 @@ open GitHub issues.
 - [x] Publish the implementation, enter the merge queue, and verify that all
       closing pull requests merge.
 - [x] Confirm the GitHub open-issue count is zero.
+- [x] Repair #2067 after the scheduled security workflow reported two real CI
+      wiring defects: audit the protected-credential-path test as deny-only in
+      the no-SSH scanner, install the pinned embedded-host Zig toolchain only in
+      the `mvm-cli` mutation shard, and add PR-time regression coverage for that
+      toolchain dependency.
 
 Closeout evidence (2026-08-02): the production-volume implementation merged
 across mvm PRs #2044 and #2064 and mvmd PRs #198 through #202. The independent
 HVF entropy issue #2060 merged through mvm PR #2065 after appearing during the
 reconciliation. Issue #2040 was closed with an explicit shipped-versus-rejected
 scope ledger, #2060 closed from its merge, and `gh issue list --state open`
-returned an empty JSON array.
+returned an empty JSON array. A later scheduled-run alert opened #2067 from an
+older main commit; its two reproducible workflow failures are repaired by the
+follow-up above, and its closing PR restores the zero-issue state.
 
 ## Verified upstream inputs
 

--- a/xtask/mutation-witness-baseline.json
+++ b/xtask/mutation-witness-baseline.json
@@ -231,6 +231,11 @@
       "reason": "replaces the binary's entrypoint with a no-op. The only witness would be executing the built binary, which this package's own test suite does not do; the claim-2 witness it calls, set_no_new_privs, is asserted directly."
     },
     {
+      "file": "crates/mvm-agentd/src/l3/privdrop.rs",
+      "mutant": "replace drop_privileges -> DropReport with Default::default()",
+      "reason": "mutates only the cfg(not(target_os = \"linux\")) no-op implementation while the security mutation shard runs on Linux, so that body is not compiled. Non-Linux unit coverage asserts the complete no-op report, while the Linux shard executes the real drop in an isolated privileged child and verifies the thread's kernel privilege state."
+    },
+    {
       "file": "crates/mvm-build/src/runtime_overlay.rs",
       "mutant": "delete ! in extract_release_archive",
       "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
@@ -383,6 +388,11 @@
     {
       "file": "crates/mvm-runtime/src/libkrun.rs",
       "mutant": "delete field fs_quick_checkpoint from struct VmCapabilities expression in <impl VmBackend for LibkrunBackend>::capabilities",
+      "reason": "equivalent: VmCapabilities derives Default, and each of these fields is declared with the value Default already yields (false), so deleting it from the literal is a semantic no-op that no test can distinguish. The two fields whose declared value differs from Default -- standby_pool: true and snapshot_capability: DiskOnly -- are caught by libkrun_capabilities_declare_the_vsock_only_shape."
+    },
+    {
+      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "mutant": "delete field l3_vsock from struct VmCapabilities expression in <impl VmBackend for LibkrunBackend>::capabilities",
       "reason": "equivalent: VmCapabilities derives Default, and each of these fields is declared with the value Default already yields (false), so deleting it from the literal is a semantic no-op that no test can distinguish. The two fields whose declared value differs from Default -- standby_pool: true and snapshot_capability: DiskOnly -- are caught by libkrun_capabilities_declare_the_vsock_only_shape."
     },
     {

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -220,11 +220,11 @@ mod tests {
         .unwrap_or_else(|error| panic!("{name} must be readable: {error}"))
     }
 
-    fn ci_job_block<'a>(workflow: &'a str, job: &str) -> &'a str {
+    fn job_block<'a>(workflow: &'a str, job: &str) -> &'a str {
         let marker = format!("  {job}:\n");
         let start = workflow
             .find(&marker)
-            .unwrap_or_else(|| panic!("CI workflow is missing the {job} job"));
+            .unwrap_or_else(|| panic!("workflow is missing the {job} job"));
         let rest_start = start + marker.len();
         let rest = &workflow[rest_start..];
         let end = rest
@@ -296,7 +296,7 @@ mod tests {
     #[test]
     fn pull_request_ci_does_not_repeat_the_workspace_or_upload_target_caches() {
         let workflow = ci_workflow();
-        let lint = ci_job_block(&workflow, "lint");
+        let lint = job_block(&workflow, "lint");
         for unexpected in [
             "cargo nextest run --workspace --features test-support",
             "cargo nextest run -p xtask --features man",
@@ -322,9 +322,28 @@ mod tests {
             );
         }
 
-        let test = ci_job_block(&workflow, "test");
+        let test = job_block(&workflow, "test");
         assert!(!test.contains("uses: actions/cache@v5"));
         assert!(test.contains("cargo nextest run -p xtask --features man"));
+    }
+
+    #[test]
+    fn mutation_cli_shard_installs_its_embedded_host_toolchain() {
+        let workflow = workflow("security.yml");
+        let mutation = job_block(&workflow, "mutation-witnesses");
+        let install = concat!(
+            "      - name: Install mvm-cli embedded-host toolchain\n",
+            "        if: matrix.package == 'mvm-cli'\n",
+            "        uses: ./.github/actions/install-zigbuild",
+        );
+        assert!(
+            mutation.contains(install),
+            "the mvm-cli mutation shard must install the pinned Zig toolchain"
+        );
+        assert!(
+            mutation.find(install) < mutation.find("Mutate this package's claim surface"),
+            "the embedded-host toolchain must be installed before cargo-mutants builds mvm-cli"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- classify the protected SSH credential-path test as deny-only in the no-SSH scanner
- install the pinned embedded-host Zig toolchain only for the `mvm-cli` mutation shard
- add a PR-time regression test that keeps that action before cargo-mutants
- mutation-test every L3 privilege-drop report and execute the real Linux drop in an isolated root child
- pin libkrun's L3 refusal and classify its default-equivalent capability-field deletion
- record the complete #2067 follow-up in the reconciliation status

## Validation
- `./scripts/check-no-ssh.sh`
- `cargo test --workspace -- --test-threads=1`
- Linux/KVM `cargo test -p mvm-agentd l3::privdrop`
- `cargo test -p mvm-runtime libkrun_capabilities`
- `cargo test -p xtask` (402 passed)
- `cargo run -p xtask -- check-workflow-paths`
- `cargo run -p xtask -- check-mutation-witnesses`
- Linux `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- pre-commit workspace all-target Clippy

Closes #2067
