### PR TITLE
Kill bounding-set mutation survivor

### DIFF
--- a/crates/mvm-agentd/src/l3/privdrop.rs
+++ b/crates/mvm-agentd/src/l3/privdrop.rs
@@ -181,14 +181,29 @@ mod linux {
             let rc = unsafe { libc::prctl(PR_CAPBSET_DROP, cap, 0, 0, 0) };
             // EINVAL means the capability number does not exist on this
             // kernel, which is not a failure to drop it.
-            if rc != 0 {
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::EINVAL) {
-                    ok = false;
-                }
+            let errno = std::io::Error::last_os_error().raw_os_error();
+            if !bounding_set_drop_succeeded(rc, errno) {
+                ok = false;
             }
         }
         ok
+    }
+
+    fn bounding_set_drop_succeeded(rc: libc::c_int, errno: Option<libc::c_int>) -> bool {
+        rc == 0 || errno == Some(libc::EINVAL)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::bounding_set_drop_succeeded;
+
+        #[test]
+        fn bounding_set_drop_result_classification_is_fail_closed() {
+            assert!(bounding_set_drop_succeeded(0, None));
+            assert!(bounding_set_drop_succeeded(0, Some(libc::EPERM)));
+            assert!(bounding_set_drop_succeeded(-1, Some(libc::EINVAL)));
+            assert!(!bounding_set_drop_succeeded(-1, Some(libc::EPERM)));
+        }
     }
 }
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -32,6 +32,8 @@ for detailed scope and acceptance criteria.
         exposed by #2067's exact security rerun
   - [x] Pin libkrun's L3 refusal and classify its default-equivalent mutation
         exposed by #2067's exact security rerun
+  - [x] Add a fail-closed bounding-set result classifier whose Linux mutation
+        witness kills the final comparison survivor from the corrected-head run
 
 - [x] Plan 283 — Production object-store volumes
       (`specs/plans/283-production-object-store-volumes.md`, issue #2040)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -52,7 +52,11 @@
       adds a PR-time structural regression test, proves in an isolated
       privileged child that `NoNewPrivs` and every capability set are actually
       cleared, and pins the libkrun L3 declaration; its merge closes #2067 and
-      restores the zero-open-issue state.
+      restores the zero-open-issue state. A fresh full-security run on the
+      merged head then exposed one remaining bounding-set result-classification
+      mutant. The follow-up extracts a pure syscall-result classifier with a
+      fail-closed truth-table test; the exact Linux `mvm-agentd` mutation shard
+      is clean with 27 relevant privilege-drop mutants caught.
       Tracked in plan 284.
 
 - [x] Production object-store volumes — **plan 283 / issue #2040**. Standardize

--- a/specs/plans/284-zero-open-issue-reconciliation.md
+++ b/specs/plans/284-zero-open-issue-reconciliation.md
@@ -76,6 +76,11 @@ open GitHub issues.
       libkrun's explicit `l3_vsock: false` falls back to the same derived
       `VmCapabilities` default. Pin the declared L3 refusal in the capability
       tests and the exact equivalent mutation in the ratchet.
+- [x] Close the final post-merge `mvm-agentd` witness gap: classify bounding-set
+      syscall results through a pure fail-closed helper, cover success, stale
+      errno, unsupported-capability, and permission-denied cases, and confirm
+      the exact Linux mutation shard catches every relevant privilege-drop
+      mutant.
 
 Closeout evidence (2026-08-02): the production-volume implementation merged
 across mvm PRs #2044 and #2064 and mvmd PRs #198 through #202. The independent
@@ -87,7 +92,10 @@ older main commit; its two reproducible workflow failures are repaired by the
 follow-up above. Its exact branch rerun additionally exposed the L3
 privilege-drop mutation gap and the equivalent libkrun capability deletion,
 which the same closing PR repairs and classifies before restoring the zero-issue
-state.
+state. The corrected-head security run then found one additional comparison
+mutation in bounding-set result handling; the follow-up truth-table witness
+kills it, and the exact Linux shard is clean at 27 files across 8 packages with
+83 accepted misses.
 
 ## Verified upstream inputs
 


### PR DESCRIPTION
Follow-up to #2067 and #2068. The corrected-head Security run found one remaining mutation survivor in Linux bounding-set result handling.

## Changes
- classify `PR_CAPBSET_DROP` return values through a pure fail-closed helper
- cover successful calls with clean/stale errno, unsupported capability numbers, and permission failures
- record the corrected-head mutation evidence in plan 284, the sprint, and the refactor rollup

## Validation
- `cargo test --workspace -- --test-threads=1`
- Linux `cargo clippy --workspace --all-targets -- -D warnings`
- Linux `cargo run -p xtask -- check-mutation-witnesses --run --package mvm-agentd` (clean: 27 files, 8 packages, 83 accepted misses)
- `cargo fmt --check`
- `cargo run -p xtask -- check-machine-doc-guards`