### PR TITLE
docs(claude.md): trim the --help-derivable command dump from Build and Run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,40 +463,13 @@ Never write scratch, temporary, or intermediate files anywhere inside the repo w
 
 ```bash
 cargo build
-cargo run -- --help
-
-# Bootstrap the builder VM (optional; builds auto-bootstrap it on first use)
-cargo run -- bootstrap
-
-# Build from Nix flake (Plan 178: build-time verbs live under `build`)
-cargo run -- build image --flake . --profile minimal --role worker
-cargo run -- run --flake . --profile minimal --cpus 2 --memory 1024
-
-# Templates
-cargo run -- template create base --flake . --profile minimal --role worker --cpus 2 --mem 1024
-cargo run -- template build base
-cargo run -- template list
-
-# Image catalog
-cargo run -- image list              # browse bundled catalog
-cargo run -- image search http       # search by name/tag
-cargo run -- image fetch minimal     # build from catalog entry
-
-# Networks
-cargo run -- network create isolated # create named network
-cargo run -- network list            # list all networks
-cargo run -- network remove isolated # remove a network
-
-# Console (interactive PTY, dev-mode only)
-cargo run -- console myvm            # interactive shell
-cargo run -- console myvm --command "uname -a"  # one-shot exec
-
-# Setup & diagnostics
-cargo run -- init                    # first-time setup wizard
-cargo run -- security status         # security posture evaluation
-cargo run -- cache info              # cache directory info
-cargo run -- cache prune             # clean stale temp files
+cargo run -- --help   # full verb surface: build/run/template/image/network/console/init/cache/doctor/…
 ```
+
+Every subcommand is self-documenting via `--help`; the complete reference is
+`public/src/content/docs/reference/cli-commands.md`. Build-time verbs
+(`image`/`run`/`template`) live under `build`; `console` is an interactive PTY,
+dev-mode only.
 
 ## Dev Network Layout
 


### PR DESCRIPTION
From a `/doctor` checkup: the root `CLAUDE.md` (always loaded into every session's context) had grown past the ~40k-char large-memory-file warning. The "Build and Run" section was a 36-line dump of `cargo run -- …` examples — all derivable from `cargo run -- --help` and the CLI reference doc.

Replaces it with a lean pointer, keeping the two non-obvious notes (build-time verbs live under `build`; `console` is dev-mode-only) and the Dev Network diagram. Saves ~974 chars (~243 est tokens) off every session's resident context.

No behavior change — docs only.