### PR TITLE
docs: collapse the duplicate plan-270 rollup entry and correct dead dev-VM prose

### DIFF
--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -91,11 +91,14 @@ fn dev_builds_dir() -> String {
     format!("{}/dev/builds", mvm_core::config::mvm_home())
 }
 
-/// Path the CLI writes when a build notices the host-backed Nix
-/// store has grown past the GC threshold. Lives under the data dir
-/// because the data dir is the only path the dev VM and the host
-/// agree on (via the `datadir` VirtioFS share mounted at the same
-/// absolute path in both).
+/// Path the GC sentinel would live at, under the data dir.
+///
+/// Vestigial, and `cfg(test)` for that reason: the only caller is
+/// [`run_gc_if_requested`], itself reachable only from the `cfg(test)`
+/// [`dev_build_via_shell_env`]. Nothing in a production build writes or reads
+/// this sentinel. The scheme it belonged to shared the data dir between the
+/// host and a long-lived Lima guest at the same absolute path; that runtime is
+/// gone, and today a build reaches its Nix store through the builder VM.
 #[cfg(test)]
 fn gc_sentinel_path() -> String {
     format!("{}/dev/nix-store-needs-gc", mvm_core::config::mvm_home())

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -51,7 +51,7 @@ for detailed scope and acceptance criteria.
   - [x] Keep privileged execution on the trusted base ref with no checkout
   - [x] Complete repository validation and queue the PR
 
- - [x] Plan 270 — Universal initramfs + vsock-activated boot
+- [~] Plan 270 — Universal initramfs + vsock-activated boot
       (`specs/plans/270-universal-initramfs-vsock-activated-boot.md`)
   - [x] Core boot contract: `ActivateEnvironment` over the authenticated
         vsock session, `ActivationState` gate, PID-1 agent with mount
@@ -62,11 +62,18 @@ for detailed scope and acceptance criteria.
   - [x] Activation agent-readiness retry on the wire (#1985)
   - [x] Deterministic cargo initramfs replaces the Nix initramfs build
         (#1996); attestation stays the content hash + sidecar contract
+  - [x] Retire the obsolete CLI workload-guest payload and dead
+        skip-embedding switch; the universal initramfs/runtime overlay owns
+        workload binaries (#2013)
+  - [x] Pin `mvmctl` embedding to the builder/bootstrap host and seed
+        manifests
   - [~] Deviations recorded at the unticked steps in the plan: capability-bit
         negotiation, chain-signed boot events, and vm_id/session binding were
         superseded by the path discriminator + session-key pinning; the
         guest-side activation idle timeout and focused zombie-reaping tests
         remain open
+  - [~] Remaining rollout, snapshot, BDD, and live-smoke work stays in the
+        plan
 
 - [~] Plan 271 — Apple Container backend: Apple's container kernel on HVF
       (`specs/plans/271-apple-container-backend.md`)
@@ -103,12 +110,6 @@ for detailed scope and acceptance criteria.
         allow-list so a docs-only edit stops invalidating every guest binary
         (416 of 1872 files, 22%, stop being cache keys)
 
- - [~] Plan 270 — universal initramfs + vsock-activated boot
- (`specs/plans/270-universal-initramfs-vsock-activated-boot.md`)
-  - [x] Retire the obsolete CLI workload-guest payload and dead skip-embedding
-        switch; the universal initramfs/runtime overlay owns workload binaries
-  - [x] Pin `mvmctl` embedding to the builder/bootstrap host and seed manifests
-  - [~] Remaining rollout, snapshot, BDD, and live-smoke work stays in the plan
 - [x] Plan 284 — CI lint and merge-queue latency
   (`specs/plans/284-ci-lint-latency.md`)
   - [x] Target only the packages that own `test-support` code
@@ -118,7 +119,7 @@ for detailed scope and acceptance criteria.
   - [x] Keep the removed MCP server and smoke lane out of CI
   - [x] Complete workspace and Linux clippy verification; the first live run
         passed and measured a 19–21 minute runner wait
- - [~] Plan 276 — Content-addressing conformance and defense
+- [~] Plan 276 — Content-addressing conformance and defense
       (`specs/plans/276-content-addressing-conformance-and-defense.md`)
   - [x] WS0 — plan + recon note landed (#1964); axis/policy ratification open
   - [ ] WS1 — reconcile the two claim tier vocabularies (`model/claims.toml`


### PR DESCRIPTION
Two small corrections found while landing #2038. Docs + one doc comment; no behaviour change.

## 1. `REFACTOR-STATUS.md` reported plan 270 twice

The rollup carried two separate plan-270 entries — a comprehensive block, and a later smaller one covering the #2013 payload retirement — so the same plan reported **two different states depending on which you read**: `[x]` in one, `[~]` in the other.

Merged into one entry, marked `[~]`. That is the accurate status: the smaller block's "remaining rollout, snapshot, BDD, and live-smoke work stays in the plan" is still true, and the `[x]` on the larger block already contradicted its own `[~]` deviations sub-item.

Also normalised three list items carrying a stray leading space (one of them mine, from a merge resolution in #2038).

## 2. `gc_sentinel_path` described a runtime that no longer exists

Its doc asserted, in the present tense, that the data dir is *"the only path the dev VM and the host agree on (via the `datadir` VirtioFS share mounted at the same absolute path in both)"*.

There is no dev VM — Lima was removed, and a build reaches its Nix store through the builder VM.

Reworded to say what is true, including the part that matters more than the wording: **the sentinel is vestigial.** It is `cfg(test)`; its only caller is `run_gc_if_requested`; and that is reachable only from the `cfg(test)` `dev_build_via_shell_env`. Nothing in a production build writes or reads it.

The two other "dev VM" mentions in that file are left alone — they are past-tense history in `cleanup_old_dev_builds` explaining *why* the indirection was removed, which is still accurate and worth keeping.

## Follow-up worth a decision (not done here)

That `cfg(test)` chain is larger than one sentinel. `dev_build_via_shell_env`, `run_gc_if_requested`, `gc_sentinel_path`, `resolve_dev_build_attribute` and `builder_env_has_nix` are all `cfg(test)`, with roughly ten tests hanging off them — an entire build path that production never takes, still carrying tests that assert how it behaves. Deleting it is a real change with a real judgement call attached, so it is flagged rather than bundled into a docs fix.

## Verification

- `cargo test -p mvm-build --features builder-vm --lib` — **775 passed**, 3 ignored, with `RUSTFLAGS=-D warnings`
- Gates: `check-no-spec-refs-in-comments`, `check-deferrals`, `check-honesty`, `check-no-overclaim`, `check-claim-catalog`, `check-conformance` — all clean