### PR TITLE
chore(mvm-client): reserve service-module seams for the mvm-studio wave

### DIFF
--- a/crates/mvm-client/src/audit.rs
+++ b/crates/mvm-client/src/audit.rs
@@ -1,6 +1,5 @@
 //! Verified, normalized local audit events for UI consumers.
 //!
-//! Issue #2082 extracts chain reading and verification behind a reusable
-//! service returning `VerifiedAuditEvent`s only after signature and chain
-//! integrity checks pass; unverifiable sources yield typed refusals, never
-//! events.
+//! Extracts chain reading and verification behind a reusable service that
+//! returns normalized events only after signature and chain integrity
+//! checks pass; unverifiable sources yield typed refusals, never events.

--- a/crates/mvm-client/src/audit.rs
+++ b/crates/mvm-client/src/audit.rs
@@ -1,0 +1,6 @@
+//! Verified, normalized local audit events for UI consumers.
+//!
+//! Issue #2082 extracts chain reading and verification behind a reusable
+//! service returning `VerifiedAuditEvent`s only after signature and chain
+//! integrity checks pass; unverifiable sources yield typed refusals, never
+//! events.

--- a/crates/mvm-client/src/inventory.rs
+++ b/crates/mvm-client/src/inventory.rs
@@ -1,0 +1,5 @@
+//! Canonical host-wide machine inventory for non-CLI consumers.
+//!
+//! Issue #2078 moves the persisted-spec × live-backend join out of
+//! `mvm-cli::commands::machine::list` so `mvmctl machine ls` and local UI
+//! surfaces such as mvm-studio consume one typed inventory contract.

--- a/crates/mvm-client/src/inventory.rs
+++ b/crates/mvm-client/src/inventory.rs
@@ -1,5 +1,5 @@
 //! Canonical host-wide machine inventory for non-CLI consumers.
 //!
-//! Issue #2078 moves the persisted-spec × live-backend join out of
-//! `mvm-cli::commands::machine::list` so `mvmctl machine ls` and local UI
-//! surfaces such as mvm-studio consume one typed inventory contract.
+//! Home of the persisted-spec × live-backend join so `mvmctl machine ls`
+//! and local UI surfaces such as mvm-studio consume one typed inventory
+//! contract instead of assembling their own.

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -8,11 +8,15 @@
 //! crate and `mvm-sdk` share one trait without a dependency cycle — but callers
 //! depend only on `mvm-client` and never name `mvm-core` directly.
 
+pub mod audit;
 pub mod boot;
 pub mod connect;
+pub mod inventory;
 pub mod local;
 pub mod readiness;
 pub mod registration;
+pub mod secret;
+pub mod volume;
 
 pub use mvm_core::client::dto;
 pub use mvm_core::client::dto::{

--- a/crates/mvm-client/src/secret.rs
+++ b/crates/mvm-client/src/secret.rs
@@ -1,0 +1,6 @@
+//! Write-only local secret lifecycle service.
+//!
+//! Issue #2081 composes `SecretStore`, binding metadata, reference checks,
+//! and audit emission behind one canonical service. The service exposes
+//! metadata only — no reveal path, no serializable type carrying secret
+//! material.

--- a/crates/mvm-client/src/secret.rs
+++ b/crates/mvm-client/src/secret.rs
@@ -1,6 +1,5 @@
 //! Write-only local secret lifecycle service.
 //!
-//! Issue #2081 composes `SecretStore`, binding metadata, reference checks,
-//! and audit emission behind one canonical service. The service exposes
-//! metadata only — no reveal path, no serializable type carrying secret
-//! material.
+//! Composes `SecretStore`, binding metadata, reference checks, and audit
+//! emission behind one canonical service. The service exposes metadata
+//! only — no reveal path, no serializable type carrying secret material.

--- a/crates/mvm-client/src/volume.rs
+++ b/crates/mvm-client/src/volume.rs
@@ -1,5 +1,5 @@
 //! Reusable local encrypted-volume lifecycle service.
 //!
-//! Issue #2080 composes the existing volume backend, encryption, registry,
-//! admission, and attachment primitives behind one object-safe service so
-//! local presentation surfaces never duplicate policy or cleanup logic.
+//! Composes the existing volume backend, encryption, registry, admission,
+//! and attachment primitives behind one object-safe service so local
+//! presentation surfaces never duplicate policy or cleanup logic.

--- a/crates/mvm-client/src/volume.rs
+++ b/crates/mvm-client/src/volume.rs
@@ -1,0 +1,5 @@
+//! Reusable local encrypted-volume lifecycle service.
+//!
+//! Issue #2080 composes the existing volume backend, encryption, registry,
+//! admission, and attachment primitives behind one object-safe service so
+//! local presentation surfaces never duplicate policy or cleanup logic.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,24 @@
 
 ## Current issue delivery
 
+### mvm-studio local-service wave (issues #2078–#2082; #2083 deferred)
+
+Wave 0 scaffolded the `mvm-client` service module seams (`inventory`,
+`volume`, `secret`, `audit`). Each issue lands via its own PR; each PR
+updates only its own entry below.
+
+- [ ] #2078 — canonical unified machine inventory through mvm-client.
+
+- [ ] #2080 — reusable local encrypted-volume lifecycle service.
+
+- [ ] #2081 — reusable write-only local secret lifecycle service.
+
+- [ ] #2082 — normalized verified local audit events for UI consumers.
+
+- [ ] #2079 — persistent + transient launch lifecycle through
+      `LocalBackend` (starts after #2078/#2080/#2081 land the shared
+      inventory/volume/secret types).
+
 - [x] Guest-kernel hardware floor — **plan 286**. Audit the resolved Linux
       6.12.100 configs and remove unsupported physical hardware, radio/input,
       filesystem, power-management, tracing/debug, keyring, task-accounting,


### PR DESCRIPTION
## Summary

Wave 0 prep for the mvm-studio local-service issues (#2078, #2079, #2080, #2081, #2082; #2083 deferred — its server side is in flight in mvm-studio).

- Scaffold empty `inventory` / `volume` / `secret` / `audit` modules in `mvm-client` with doc comments pointing at their issues.
- Add the sprint tracking section for the wave to `specs/SPRINT.md`, one entry per issue.

Purpose: the four service extractions land in parallel PRs; pre-reserving the `lib.rs` module lines and per-issue sprint entries removes the only shared-file merge contention between them.

No behavior change — modules are doc-only until their issue PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)