### PR TITLE
feat(xtask): stop a workload path reaching the unrestricted-egress constructor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
       - name: No positional audit::emit / event-chain calls
         run: cargo run -p xtask -- check-audit-positional
 
+      - name: Broad-egress constructor stays builder-only
+        run: cargo run -p xtask -- check-build-egress-callers
+
       - name: No host-nix invocation (builds route through the builder VM)
         run: cargo run -p xtask -- check-no-host-nix
 

--- a/specs/VERIFICATION.md
+++ b/specs/VERIFICATION.md
@@ -21,6 +21,8 @@ row below records a defect that was planted to prove the gate fires.
 
 | Gate | Planted defect | Reported |
 | --- | --- | --- |
+| `check-build-egress-callers` | Add a `NetworkPolicy::trusted_build_egress()` call to `workload_runner/runner.rs` — the shape of a future workload path reaching the unrestricted-egress constructor and turning off claim 10's default-deny | yes — named the file and line, refused |
+| `check-build-egress-callers` (vacuity) | Point the gate at a tree with no allow-listed call site, i.e. the state it would reach if the constructor were renamed and the gate silently stopped checking anything | yes — refused rather than passing empty |
 | `check-conformance` (R1) | Edit `CONFORMANCE.md` so it disagrees with `model/claims.toml` | yes |
 | `check-honesty` (R2) | Add "MVM-SEC-07 proves cargo deps are audited" to `README.md` | yes |
 | `meta` (R3) | Register `MVM-SEC-99` with no scenario, or remove a scenario's ID tag | yes |

--- a/xtask/src/check_build_egress_callers.rs
+++ b/xtask/src/check_build_egress_callers.rs
@@ -1,0 +1,178 @@
+//! `xtask check-build-egress-callers`
+//!
+//! `NetworkPolicy::trusted_build_egress()` returns unrestricted egress. It
+//! exists because the Stage-0 builder VM and dev shells fetch from arbitrary
+//! Nix substituters and forges, so no tight allow-list is possible there yet.
+//! Cloud-metadata and link-local stay blocked by the always-on mandatory deny,
+//! and the constructor is deliberately one named, greppable symbol so every
+//! broad-egress grant is auditable.
+//!
+//! Its doc says: **never use it for a workload** (`mvmctl run`/`up`/`invoke`),
+//! which default to `deny_all`. That sentence is the whole of claim 10 for this
+//! constructor — and until this gate, nothing enforced it. A future workload
+//! path could call it and turn off default-deny egress with every test green,
+//! because a doc comment is not a control.
+//!
+//! This is the third instance of one shape in this tree: a correct mechanism
+//! that nothing wires shut. `verify_fetched_kernel` hashed a kernel against its
+//! pin and had no caller; `resolve_kernel` handed back a bare path so nothing
+//! signalled a skipped check. Both were real, both were invisible, and both
+//! were "obviously fine" by inspection.
+//!
+//! The gate is an allow-list of call sites rather than a type. A type would be
+//! stronger, but `NetworkPolicy` flows through most of the tree and threading a
+//! builder-only variant through it would be a large change to prevent a
+//! mistake nobody has made yet. An allow-list keeps the cost proportionate and
+//! makes adding a call site a reviewable, explicit act — which is the property
+//! that was missing.
+
+use anyhow::{Result, bail};
+use std::path::Path;
+
+/// The symbol whose call sites are restricted.
+const SYMBOL: &str = "trusted_build_egress";
+
+/// Files permitted to call it, relative to the workspace root.
+///
+/// Every entry must be builder or dev infrastructure. A workload launch path
+/// must never appear here: adding one silently disables default-deny egress
+/// for the workloads it launches, which is exactly what claim 10 asserts does
+/// not happen.
+const ALLOWED_CALLERS: &[&str] = &[
+    // The builder VM's own launch policy.
+    "crates/mvm-runtime/src/builder_runner/runner.rs",
+    // The libkrun builder's supervisor config.
+    "crates/mvm-build/src/libkrun_builder.rs",
+];
+
+/// The file that defines the constructor, plus its own tests. Not a "caller"
+/// in the sense this gate polices.
+const DEFINING_FILE: &str = "crates/mvm-protocol/src/policy/network_policy.rs";
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let mut offenders: Vec<String> = Vec::new();
+    let mut allowed_hits = 0usize;
+
+    let mut files: Vec<(String, String)> = Vec::new();
+    crate::fs_walk::for_each_file(&workspace.join("crates"), Some("rs"), &mut |path, text| {
+        if text.contains(SYMBOL) {
+            let rel = path
+                .strip_prefix(workspace)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            files.push((rel, text.to_string()));
+        }
+    })?;
+
+    for (rel, text) in files {
+        if rel == DEFINING_FILE {
+            continue;
+        }
+        if ALLOWED_CALLERS.contains(&rel.as_str()) {
+            allowed_hits += 1;
+            continue;
+        }
+
+        for (i, line) in text.lines().enumerate() {
+            if line.contains(SYMBOL) {
+                offenders.push(format!("{rel}:{}: {}", i + 1, line.trim()));
+            }
+        }
+    }
+
+    if !offenders.is_empty() {
+        for o in &offenders {
+            eprintln!("[error] {o}");
+        }
+        bail!(
+            "check-build-egress-callers: {} call site(s) of `{SYMBOL}` outside the builder/dev \
+             allow-list. That constructor returns unrestricted egress; a workload reaching it \
+             turns off claim 10's default-deny for everything it launches. If the new site is \
+             genuinely builder or dev infrastructure, add it to ALLOWED_CALLERS — deliberately, \
+             and say why in the commit.",
+            offenders.len()
+        );
+    }
+
+    // A silently-empty allow-list would make this gate vacuous: it would pass
+    // just as happily if the constructor were deleted or renamed, and nobody
+    // would notice it had stopped checking anything.
+    if allowed_hits == 0 {
+        bail!(
+            "check-build-egress-callers: found no calls to `{SYMBOL}` at any allow-listed site. \
+             Either the constructor was renamed — in which case update this gate — or the \
+             builder no longer grants broad egress, in which case delete the allow-list entries \
+             so the gate cannot pass vacuously."
+        );
+    }
+
+    eprintln!(
+        "check-build-egress-callers: clean ({allowed_hits} builder/dev call site(s); no workload \
+         path reaches unrestricted egress)"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace_with(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        for (rel, body) in files {
+            let p = tmp.path().join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(p, body).unwrap();
+        }
+        tmp
+    }
+
+    /// The real allow-listed caller, so the vacuity check is satisfied.
+    fn allowed_caller() -> (&'static str, &'static str) {
+        (
+            "crates/mvm-runtime/src/builder_runner/runner.rs",
+            "fn x() { let p = NetworkPolicy::trusted_build_egress(); }",
+        )
+    }
+
+    #[test]
+    fn an_allow_listed_builder_caller_passes() {
+        let tmp = workspace_with(&[allowed_caller()]);
+        assert!(run(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn a_workload_path_calling_it_is_refused() {
+        let tmp = workspace_with(&[
+            allowed_caller(),
+            (
+                "crates/mvm-runtime/src/workload_runner/runner.rs",
+                "fn boot() { let p = NetworkPolicy::trusted_build_egress(); }",
+            ),
+        ]);
+        let err = run(tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("outside the builder/dev allow-list"), "{err}");
+    }
+
+    #[test]
+    fn the_defining_file_is_not_treated_as_a_caller() {
+        let tmp = workspace_with(&[
+            allowed_caller(),
+            (
+                "crates/mvm-protocol/src/policy/network_policy.rs",
+                "pub fn trusted_build_egress() -> Self { Self::unrestricted() }",
+            ),
+        ]);
+        assert!(run(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn an_empty_allow_list_hit_is_refused_rather_than_passing_vacuously() {
+        // The failure mode this gate is meant to avoid being an instance of:
+        // passing because it found nothing to check.
+        let tmp = workspace_with(&[("crates/mvm-core/src/lib.rs", "fn unrelated() {}")]);
+        let err = run(tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("no calls to"), "{err}");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,7 @@ mod check_abi_layout;
 mod check_adr_coverage;
 mod check_audit_positional;
 mod check_binary_size;
+mod check_build_egress_callers;
 mod check_builder_shell_job_sites;
 mod check_claim_catalog;
 mod check_claim_witness_freshness;
@@ -90,6 +91,10 @@ fn main() -> Result<()> {
         Some("check-audit-positional") => {
             let workspace = workspace_root();
             check_audit_positional::run(&workspace)
+        }
+        Some("check-build-egress-callers") => {
+            let workspace = workspace_root();
+            check_build_egress_callers::run(&workspace)
         }
         Some("check-no-host-nix") => {
             let workspace = workspace_root();


### PR DESCRIPTION
Closes **F5** from the claim-reality audit (#2087) — the highest-severity finding, and the cheapest to close.

## The hole

`NetworkPolicy::trusted_build_egress()` returns `unrestricted()`. That is deliberate and otherwise well-handled: the Stage-0 builder and dev shells fetch from arbitrary substituters and forges, cloud-metadata and link-local stay blocked by the always-on mandatory deny, a test pins that it is not the default, and it is one named greppable symbol so every broad grant is auditable.

Its doc says: **"Never use it for a workload (`mvmctl run`/`up`/`invoke`): those default to `deny_all`."**

**Nothing enforced that sentence.** Its two callers are correctly builder-only today, but a future workload path could have called it and turned off claim 10's default-deny for everything it launches — with every test green, because a doc comment is not a control.

## Why now

Third instance of one shape found this week:

- `verify_fetched_kernel` hashed a kernel against its pin and had **no production caller at all**
- `resolve_kernel` returned a bare `PathBuf` on a cache hit, so nothing signalled a skipped check
- and now a security boundary held by prose

Each was invisible, and each looked fine by inspection. That is the argument for a gate over a review habit.

## Design

An allow-list of call sites, not a type. A builder-only `NetworkPolicy` variant would be stronger, but that type flows through most of the tree, so threading one through is a large change to prevent a mistake nobody has made yet. The allow-list makes adding a call site an explicit, reviewable act — the property that was missing — at proportionate cost. The reasoning is recorded in the module doc so the next person can revisit it rather than rediscover it.

**The gate refuses to pass on an empty allow-list.** Without that it would go green if the constructor were renamed — the same vacuous-pass failure a compile-fail doctest hit earlier this week, where the test held even with the bridge it was meant to forbid. Both directions are tested.

## Verification

- **Planted against the real tree:** added a `trusted_build_egress()` call to `workload_runner/runner.rs`. Gate named the file and line and refused.
- **Planted the vacuity case:** a tree with no allow-listed site. Refused rather than passing empty.
- 4 unit tests over the gate; `cargo test -p xtask` — 406 passed
- Wired into `ci.yml`, which runs on `pull_request` **and** `merge_group` — deliberately not `ci-full.yml`, which is `workflow_dispatch:` only and therefore enforces nothing (finding F1 of the same audit)
- Two `specs/VERIFICATION.md` rows, both planted defects recorded
- Gates: `check-build-egress-callers`, `check-no-overclaim`, `check-deferrals`, `check-honesty`, `check-workflow-paths` — clean