### PR TITLE
docs(adr-001): say how claim 10 is actually enforced, and drop a dead CI step

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -136,9 +136,6 @@ jobs:
       - name: repr(C) types carry a layout contract (check-abi-layout)
         run: cargo run -p xtask -- check-abi-layout
 
-      - name: SDK crate split guard
-        run: cargo run -p xtask -- check-sdk-split
-
       - name: Gated doc claims (plan 74 W0)
         run: cargo run -p xtask -- check-doc-claims
 

--- a/specs/adrs/001-microvm-security-posture.md
+++ b/specs/adrs/001-microvm-security-posture.md
@@ -213,13 +213,31 @@ except claim 3, which is scoped to the block+ext4 backends. There is no
 Tier 3: a shared-kernel container runtime holds none of the L1–L3
 isolation claims, so mvm ships no container-based backend at any tier.
 
-**Claim-10 coverage.** Claim 10's default-deny egress is enforced at the
-host-side network chokepoint of the two backends that run untrusted
-workloads: Firecracker via nftables default-deny on the TAP, and libkrun
-via the gateway-bridge `PlanFlowPolicy` composed with an always-on
-mandatory deny-egress scan and per-tenant policy/DNS-sinkhole scans. Both
-derive the same posture from the same `NetworkPolicy`. QEMU is
-intentionally excluded, for the reason given in the tier matrix above.
+**Claim-10 coverage.** Claim 10's default-deny egress is enforced at **one**
+seam for every backend that runs an untrusted workload: the per-VM
+substitution endpoint reached over vsock, whose shared `EgressGate` is the
+sole decision point. There is no host-side network chokepoint to enforce at,
+because a workload guest has no network interface at all — Firecracker omits
+`/network-interfaces`, libkrun pins `NetworkingMode::VsockDirect`, and the
+HVF device model has no net device. Egress leaves a guest only over vsock, to
+a host-side endpoint the host itself originates the outbound connection from,
+which is what makes admission, substitution and the audit record possible.
+
+Two gates keep that true rather than aspirational. `xtask
+check-uniform-vsock-egress` pins Firecracker, libkrun and HVF to a single
+spawn site (`RealEndpointSpawner::spawn`), so a driver cannot grow a second
+gate or revert to a raw backend. `xtask check-vsock-only-egress` fails closed
+if `virtio_net`, a tap, or a userspace-gateway token appears on a workload
+path. QEMU is intentionally excluded, for the reason given in the tier matrix
+above.
+
+*Corrected 2026-08-02.* This section previously described enforcement as
+"Firecracker via nftables default-deny on the TAP, and libkrun via the
+gateway-bridge `PlanFlowPolicy`". That predates the vsock-egress convergence
+and had stopped being true: a workload has no TAP to put nftables on. The
+mechanism was sound throughout — the description of it was not, which matters
+because this document is what a reviewer reads to decide whether to trust the
+posture.
 
 **Deny-all control-plane posture (DHCP/ARP).** A networked guest brings
 up its network interface at boot — link-up, then DHCP, then a static


### PR DESCRIPTION
Closes **F2** and **F1** from the claim-reality audit (#2087). With #2089 (F5), that clears every actionable finding from that pass.

## F2 — ADR-001 misdescribed how claim 10 is enforced

The section read:

> Claim 10's default-deny egress is enforced at the host-side network chokepoint … **Firecracker via nftables default-deny on the TAP**, and libkrun via the gateway-bridge `PlanFlowPolicy`

A workload guest has **no network interface** — Firecracker omits `/network-interfaces`, libkrun pins `NetworkingMode::VsockDirect`, and the HVF device model has no net device. There is no TAP to put nftables on. That text predates the vsock-egress convergence and had simply stopped being true.

**The mechanism was sound throughout; the description was not.** That matters more than ordinary doc drift, because this is the document a reviewer reads to decide whether to trust the posture — it is the artifact the claim is made in.

Rewritten to describe the single per-VM substitution endpoint that is the sole decision point, and to name the two gates that keep it that way (`check-uniform-vsock-egress` pinning all three backends to one spawn site, `check-vsock-only-egress` failing closed on any `virtio_net`/tap/gateway token) rather than asking the reader to take it on faith. The correction is dated and states what it replaces, so the change is legible rather than silent.

## F1 — a dead CI step

`ci-full.yml` ran `cargo run -p xtask -- check-sdk-split`, which is not an xtask subcommand:

```
Error: Unknown xtask: "check-sdk-split"
```

History explains it. `d115fcebe` — the 32→16 crate consolidation — deleted `check_sdk_split.rs`, because it guarded the SDK crate split that consolidation **deliberately reversed**. The workflow step was left behind, and survived because that workflow is dispatch-only.

Removed rather than reimplemented: the policy it enforced no longer exists.

## The implication worth keeping

**A gate placed only in `ci-full.yml` is not enforced at all.** That workflow runs on `workflow_dispatch:` and nothing else, so it gates neither pull requests nor the merge queue. This was the only such gate, so exposure was bounded — but the lane's shape invites the mistake, and it is why #2089's new gate went into `ci.yml`.

## Verification

- `ci-full.yml` still parses; jobs intact (`lint`, `test`, `e2e`, `sdk-release-dry-run`, `sealed-prod-allowlist`, `jailer-lite-property`)
- No stray `check-sdk-split` reference anywhere in `.github/` or `xtask/`
- Gates: `check-adr-coverage`, `check-no-overclaim`, `check-claim-catalog`, `check-honesty`, `check-workflow-paths` — clean