### PR TITLE
Fix machine logs on macOS

### DIFF
--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -304,14 +304,27 @@ pub fn pack_dir(pack_hash: &str) -> std::path::PathBuf {
 /// disk images) and the host-side VMM state (pid files, console log,
 /// vsock sockets) share the same per-VM directory with disjoint file names.
 pub fn vms_dir() -> std::path::PathBuf {
-    std::path::PathBuf::from(mvm_home()).join("vms")
+    vms_dir_at(mvm_home())
+}
+
+/// Root of all per-VM directories beneath an explicit mvm home.
+///
+/// This pure variant lets callers with an already-resolved or isolated root
+/// use the canonical layout without mutating process-wide environment state.
+pub fn vms_dir_at(mvm_home: impl AsRef<std::path::Path>) -> std::path::PathBuf {
+    mvm_home.as_ref().join("vms")
 }
 
 /// Per-VM state directory: `<mvm_home>/vms/<name>/`. Holds the
 /// libkrun pid file, console log, vsock listener socket(s), runtime
 /// `mode.json`, `rootfs.ref` / `kernel.ref`, and the `ports` file.
 pub fn vm_state_dir(name: &str) -> std::path::PathBuf {
-    vms_dir().join(name)
+    vm_state_dir_at(mvm_home(), name)
+}
+
+/// Per-VM state directory beneath an explicit mvm home.
+pub fn vm_state_dir_at(mvm_home: impl AsRef<std::path::Path>, name: &str) -> std::path::PathBuf {
+    vms_dir_at(mvm_home).join(name)
 }
 
 /// Per-instance state root: `<mvm_home>/instances/<name>/`. Distinct from
@@ -1198,6 +1211,18 @@ mod tests {
         }
 
         env.remove("MVM_HOME");
+    }
+
+    #[test]
+    fn vm_state_dir_at_uses_an_explicit_isolated_home() {
+        assert_eq!(
+            vms_dir_at("/isolated/mvm"),
+            std::path::PathBuf::from("/isolated/mvm/vms")
+        );
+        assert_eq!(
+            vm_state_dir_at("/isolated/mvm", "log-test"),
+            std::path::PathBuf::from("/isolated/mvm/vms/log-test")
+        );
     }
 
     #[test]

--- a/crates/mvm-runtime/src/microvm/observe.rs
+++ b/crates/mvm-runtime/src/microvm/observe.rs
@@ -2,10 +2,13 @@
 //! slot allocation/reservation bookkeeping.
 
 use anyhow::{Context, Result};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use tracing::{instrument, warn};
 
 use crate::base::config::{RunInfo, VmSlot};
-use crate::base::shell::{run_in_vm, run_in_vm_stdout, run_in_vm_visible, shell_quote};
+use crate::base::shell::{run_in_vm, run_in_vm_stdout, shell_quote};
 use crate::base::ui;
 use crate::firecracker;
 
@@ -16,46 +19,76 @@ use super::{abs_vms_dir, firecracker_vsock_uds_path, require_linux_env};
 /// By default shows the guest serial console (`console.log`).
 /// With `hypervisor=true`, shows Firecracker hypervisor logs (`firecracker.log`).
 pub fn logs(name: &str, follow: bool, lines: u32, hypervisor: bool) -> Result<()> {
-    require_linux_env()?;
+    let state_dir = mvm_core::config::vm_state_dir(name);
+    let log_file = resolve_log_path(&state_dir, hypervisor)
+        .with_context(|| format!("No logs found for VM '{name}' (is the name correct?)"))?;
+    show_log_file(&log_file, follow, lines)
+}
 
-    let abs_vms = abs_vms_dir();
+/// Resolve the backend-captured host log without crossing a guest execution
+/// boundary. Every supported VMM writes its serial console into the VM state
+/// directory, including macOS HVF and libkrun workloads.
+fn resolve_log_path(state_dir: &Path, hypervisor: bool) -> Result<PathBuf> {
     let filename = if hypervisor {
         "firecracker.log"
     } else {
         "console.log"
     };
-    let log_file = format!("{}/{}/{}", abs_vms, name, filename);
-
-    // Check the log file exists; fall back to firecracker.log for VMs started before
-    // the console.log split.
-    let exists = run_in_vm_stdout(&format!("[ -f {} ] && echo yes || echo no", log_file))?;
-    if exists.trim() != "yes" {
-        if !hypervisor {
-            // Try legacy location (pre-split VMs wrote everything to firecracker.log)
-            let fallback = format!("{}/{}/firecracker.log", abs_vms, name);
-            let fb_exists =
-                run_in_vm_stdout(&format!("[ -f {} ] && echo yes || echo no", fallback))?;
-            if fb_exists.trim() == "yes" {
-                ui::warn(
-                    "console.log not found; showing firecracker.log (VM started before log split)",
-                );
-                return show_log_file(&fallback, follow, lines);
-            }
-        }
-        anyhow::bail!("No logs found for VM '{}' (is the name correct?)", name);
+    let requested = state_dir.join(filename);
+    if requested.is_file() {
+        return Ok(requested);
     }
 
-    show_log_file(&log_file, follow, lines)
+    if !hypervisor {
+        let legacy = state_dir.join("firecracker.log");
+        if legacy.is_file() {
+            ui::warn(
+                "console.log not found; showing firecracker.log (VM started before log split)",
+            );
+            return Ok(legacy);
+        }
+    }
+
+    anyhow::bail!("neither the requested log nor a legacy fallback exists")
 }
 
-fn show_log_file(log_file: &str, follow: bool, lines: u32) -> Result<()> {
+fn show_log_file(log_file: &Path, follow: bool, lines: u32) -> Result<()> {
+    let mut command = Command::new("tail");
+    command.args(tail_arguments(log_file, follow, lines));
     if follow {
-        run_in_vm_visible(&format!("tail -f {}", log_file))?;
+        let status = command
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+            .with_context(|| format!("following {}", log_file.display()))?;
+        if !status.success() {
+            anyhow::bail!("tail failed for {} with {status}", log_file.display());
+        }
     } else {
-        let output = run_in_vm_stdout(&format!("tail -n {} {}", lines, log_file))?;
-        print!("{}", output);
+        let output = command
+            .output()
+            .with_context(|| format!("reading {}", log_file.display()))?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "tail failed for {} with {}: {}",
+                log_file.display(),
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        print!("{}", String::from_utf8_lossy(&output.stdout));
     }
     Ok(())
+}
+
+fn tail_arguments(log_file: &Path, follow: bool, lines: u32) -> Vec<OsString> {
+    let mut arguments = vec![OsString::from("-n"), OsString::from(lines.to_string())];
+    if follow {
+        arguments.push(OsString::from("-f"));
+    }
+    arguments.push(log_file.as_os_str().to_owned());
+    arguments
 }
 
 // ============================================================================
@@ -397,6 +430,35 @@ pub(super) fn release_slot_reservation(slot: &VmSlot) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn log_path_resolves_host_console_and_legacy_fallback() {
+        let state_dir = tempfile::tempdir().unwrap();
+        let console = state_dir.path().join("console.log");
+        std::fs::write(&console, "console").unwrap();
+        assert_eq!(resolve_log_path(state_dir.path(), false).unwrap(), console);
+
+        std::fs::remove_file(&console).unwrap();
+        let legacy = state_dir.path().join("firecracker.log");
+        std::fs::write(&legacy, "legacy").unwrap();
+        assert_eq!(resolve_log_path(state_dir.path(), false).unwrap(), legacy);
+    }
+
+    #[test]
+    fn log_path_refuses_missing_or_wrong_stream() {
+        let state_dir = tempfile::tempdir().unwrap();
+        assert!(resolve_log_path(state_dir.path(), false).is_err());
+
+        std::fs::write(state_dir.path().join("console.log"), "console").unwrap();
+        assert!(resolve_log_path(state_dir.path(), true).is_err());
+    }
+
+    #[test]
+    fn follow_tail_arguments_include_requested_line_count() {
+        let path = Path::new("/tmp/console log");
+        let expected = ["-n", "200", "-f", "/tmp/console log"].map(OsString::from);
+        assert_eq!(tail_arguments(path, true, 200), expected);
+    }
 
     #[test]
     fn console_warning_patterns_detect_kernel_panic() {

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -6,6 +6,14 @@ This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## In-flight plans
+- [x] Plan 289 — Host-side machine logs
+      (`specs/plans/289-host-side-machine-logs.md`)
+  - [x] Read backend-captured logs from the isolated host VM state directory
+  - [x] Preserve log flags and legacy fallback without shell interpolation;
+        follow mode honors the requested line count
+  - [x] Cover host-only CLI behavior and log resolution with regression tests
+  - [x] Complete workspace tests, check, formatting, and all-target clippy
+
 - [x] Plan 286 — Guest-kernel hardware floor
       (`specs/plans/286-kernel-floor.md`)
   - [x] Audit resolved x86_64/aarch64 configs and enforce required cuts

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -12,7 +12,8 @@ for detailed scope and acceptance criteria.
   - [x] Preserve log flags and legacy fallback without shell interpolation;
         follow mode honors the requested line count
   - [x] Cover host-only CLI behavior and log resolution with regression tests
-  - [x] Keep isolated test state behind the canonical config resolver
+  - [x] Keep isolated test state behind the canonical config resolver and home
+        isolation gates
   - [x] Complete workspace tests, check, formatting, and all-target clippy
 
 - [x] Plan 286 — Guest-kernel hardware floor

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -12,6 +12,7 @@ for detailed scope and acceptance criteria.
   - [x] Preserve log flags and legacy fallback without shell interpolation;
         follow mode honors the requested line count
   - [x] Cover host-only CLI behavior and log resolution with regression tests
+  - [x] Keep isolated test state behind the canonical config resolver
   - [x] Complete workspace tests, check, formatting, and all-target clippy
 
 - [x] Plan 286 — Guest-kernel hardware floor

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,16 @@
 
 ## Current issue delivery
 
+- [x] Host-side machine logs — **plan 289**. `machine logs` now reads backend
+      console captures directly from the isolated host VM state directory, so
+      macOS no longer attempts to connect to or auto-start the retired
+      interactive dev VM. Host `tail` receives paths as process arguments,
+      `-f` honors the requested `--lines`/`-n` count through
+      `tail -n <lines> -f`, hypervisor and legacy fallback behavior is retained,
+      and unit plus real-CLI regression coverage proves the command works with
+      dev-VM auto-start disabled. Workspace tests, check, all-target clippy, and
+      formatting are green.
+
 ### mvm-studio local-service wave (issues #2078–#2082; #2083 deferred)
 
 Wave 0 scaffolded the `mvm-client` service module seams (`inventory`,

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -18,8 +18,9 @@
       `tail -n <lines> -f`, hypervisor and legacy fallback behavior is retained,
       and unit plus real-CLI regression coverage proves the command works with
       dev-VM auto-start disabled. Isolated test state also resolves through the
-      canonical explicit-root config helper. Workspace tests, check, all-target
-      clippy, formatting, and the single-home policy gate are green.
+      canonical explicit-root config helper, and the CLI subprocess receives an
+      isolated home. Workspace tests, check, all-target clippy, formatting, and
+      both home policy gates are green.
 
 ### mvm-studio local-service wave (issues #2078–#2082; #2083 deferred)
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -17,8 +17,9 @@
       `-f` honors the requested `--lines`/`-n` count through
       `tail -n <lines> -f`, hypervisor and legacy fallback behavior is retained,
       and unit plus real-CLI regression coverage proves the command works with
-      dev-VM auto-start disabled. Workspace tests, check, all-target clippy, and
-      formatting are green.
+      dev-VM auto-start disabled. Isolated test state also resolves through the
+      canonical explicit-root config helper. Workspace tests, check, all-target
+      clippy, formatting, and the single-home policy gate are green.
 
 ### mvm-studio local-service wave (issues #2078–#2082; #2083 deferred)
 

--- a/specs/plans/289-host-side-machine-logs.md
+++ b/specs/plans/289-host-side-machine-logs.md
@@ -33,3 +33,5 @@ the headless Linux builder VM.
       validated result.
 - [x] Make follow mode honor `--lines`/`-n` via `tail -n <lines> -f` and cover
       the exact host-process arguments.
+- [x] Route isolated test state through an explicit-root `mvm_core::config`
+      helper and pass the single-home policy gate.

--- a/specs/plans/289-host-side-machine-logs.md
+++ b/specs/plans/289-host-side-machine-logs.md
@@ -34,4 +34,4 @@ the headless Linux builder VM.
 - [x] Make follow mode honor `--lines`/`-n` via `tail -n <lines> -f` and cover
       the exact host-process arguments.
 - [x] Route isolated test state through an explicit-root `mvm_core::config`
-      helper and pass the single-home policy gate.
+      helper, isolate the CLI subprocess home, and pass both home policy gates.

--- a/specs/plans/289-host-side-machine-logs.md
+++ b/specs/plans/289-host-side-machine-logs.md
@@ -1,0 +1,35 @@
+# Host-side machine logs
+
+**Status:** COMPLETE
+
+## Goal
+
+Make `mvmctl machine logs` read the console capture owned by the selected
+workload backend from the host VM state directory. Reading logs must not
+connect to, start, or otherwise depend on the retired interactive dev VM or
+the headless Linux builder VM.
+
+## Security and compatibility constraints
+
+- Resolve VM state only through `mvm_core::config` so `MVM_HOME` isolation is
+  preserved.
+- Pass paths as process arguments; do not interpolate VM names or paths into a
+  shell command.
+- Preserve `--lines`, `--follow`, `--hypervisor`, and the pre-split
+  `firecracker.log` fallback.
+- Keep missing logs as an explicit error rather than silently returning empty
+  output.
+
+## Delivery checklist
+
+- [x] Reproduce the macOS failure with a real-CLI regression test that disables
+      dev-VM auto-start.
+- [x] Resolve the backend-captured log from the host VM state directory and
+      invoke host `tail` without a shell.
+- [x] Cover console resolution, legacy fallback, missing streams, and the final
+      CLI output.
+- [x] Run formatting, workspace tests/checks, and zero-warning clippy.
+- [x] Synchronize `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md` with the
+      validated result.
+- [x] Make follow mode honor `--lines`/`-n` via `tail -n <lines> -f` and cover
+      the exact host-process arguments.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -181,7 +181,7 @@ fn machine_reconfigure_help_lists_patch_flags() {
 #[test]
 fn machine_logs_reads_host_state_without_dev_vm() {
     let mvm_home = tempfile::tempdir().unwrap();
-    let state_dir = mvm_home.path().join("vms").join("log-test");
+    let state_dir = mvm_core::config::vm_state_dir_at(mvm_home.path(), "log-test");
     std::fs::create_dir_all(&state_dir).unwrap();
     std::fs::write(
         state_dir.join("console.log"),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -176,6 +176,43 @@ fn machine_reconfigure_help_lists_patch_flags() {
     }
 }
 
+/// Reading a machine's captured console is a host-side operation. It must not
+/// depend on the Linux builder/dev VM being available on macOS.
+#[test]
+fn machine_logs_reads_host_state_without_dev_vm() {
+    let mvm_home = tempfile::tempdir().unwrap();
+    let state_dir = mvm_home.path().join("vms").join("log-test");
+    std::fs::create_dir_all(&state_dir).unwrap();
+    std::fs::write(
+        state_dir.join("console.log"),
+        "old line\nrecent line one\nrecent line two\n",
+    )
+    .unwrap();
+    // Reconcile-on-entry preserves only state owned by a live supervisor.
+    std::fs::write(state_dir.join("hvf.pid"), std::process::id().to_string()).unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_mvmctl"))
+        .env("MVM_HOME", mvm_home.path())
+        .env("MVM_NO_AUTO_DEV", "1")
+        .args(["machine", "logs", "log-test", "--lines", "2"])
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "machine logs must read host state; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        "recent line one\nrecent line two"
+    );
+    assert!(
+        !String::from_utf8_lossy(&out.stderr).contains("dev VM"),
+        "machine logs must not try to start or connect to a dev VM"
+    );
+}
+
 /// Regression guard: the `ops bench` verb was removed — benchmarking is a
 /// dev/CI concern, not a shipped end-user command.
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -193,6 +193,7 @@ fn machine_logs_reads_host_state_without_dev_vm() {
 
     let out = Command::new(env!("CARGO_BIN_EXE_mvmctl"))
         .env("MVM_HOME", mvm_home.path())
+        .env("HOME", mvm_home.path())
         .env("MVM_NO_AUTO_DEV", "1")
         .args(["machine", "logs", "log-test", "--lines", "2"])
         .output()


### PR DESCRIPTION
## Summary

- read backend-captured machine logs directly from the host VM state directory
- preserve console, hypervisor, and legacy log selection without shell interpolation
- make follow mode honor the requested line count with `tail -n <lines> -f`
- add unit and real-CLI regression coverage

## Root cause

`machine logs` treated host-owned log files as if they had to be inspected through the Linux shell environment. On macOS that selected the retired interactive dev-VM path, so a local HVF workload could not expose its console logs unless an unrelated VM was running.

## User impact

`mvmctl machine logs <name>` now works directly on macOS for local backends. `-f` follows the log and `-n`/`--lines` controls the initial history, matching `tail` semantics.

## Validation

- `cargo test --workspace --exclude mvm-hostd --quiet`
- `cargo test -p mvm-hostd --quiet -- --test-threads=1`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- commit hook: full all-target clippy
