### PR TITLE
feat(mvm-client): expose the canonical unified machine inventory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2802,6 +2802,7 @@ dependencies = [
  "mvm-fs",
  "mvm-hostd",
  "mvm-runtime",
+ "serde_json",
  "tempfile",
  "tokio",
  "tracing",

--- a/crates/mvm-cli/src/commands/machine/list.rs
+++ b/crates/mvm-cli/src/commands/machine/list.rs
@@ -1,308 +1,95 @@
 //! `mvmctl machine ls` — the single listing of every microVM on the host.
 //!
-//! Three stores describe a microVM and none of them is complete on its own:
-//! the persisted spec registry (a machine the user created by name), the live
-//! backend scan joined with the VM name registry (what is actually booted), and
-//! the per-VM state dirs underneath both. A machine started from a spec, a
-//! transient `machine run`, and a direct-boot VM must all appear here, so this
-//! joins the spec registry against the live listing by name.
+//! The spec×live join, the typed record, and the visibility semantics all
+//! live in the shared inventory service (`mvm_client::inventory`), so this
+//! module is presentation only: it maps the CLI flags onto an
+//! [`InventoryQuery`], fetches the canonical records, and renders them as a
+//! table or as JSON. The JSON output *is* the serialized inventory record —
+//! the same typed shape any other consumer of the service sees.
 
 use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};
 
-use mvm_client::{LocalBackend, MachineFilter, MachineState, MachineStatus, MvmClient};
-use mvm_runtime::machine::persist::MachineSpec;
+use mvm_client::inventory::{InventoryQuery, MachineInventoryRecord, list_local_inventory};
+use mvm_client::{LocalBackend, MachineStatus};
 
-use super::{MachineListArgs, health_cell, humanize_age, list_machine_specs, machine_status_label};
-
-/// Where a listed microVM's definition lives.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
-#[serde(rename_all = "snake_case")]
-pub(super) enum MachineKind {
-    /// Backed by a persisted spec: survives a stop, restartable by name.
-    Persistent,
-    /// Live only. A `machine run` or a direct-boot VM; it leaves nothing
-    /// behind once it exits.
-    Transient,
-}
-
-impl MachineKind {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Persistent => "persistent",
-            Self::Transient => "transient",
-        }
-    }
-}
-
-/// One microVM, from whichever stores know about it. A persistent machine that
-/// is not booted has `live: None`; a transient one always has `live: Some`.
-pub(super) struct ListedMachine {
-    kind: MachineKind,
-    name: String,
-    live: Option<MachineState>,
-    spec: Option<MachineSpec>,
-}
-
-impl ListedMachine {
-    /// Status label, lowercase. SDK facades parse this field out of
-    /// `--json` (`running` / `starting` / `failed`, anything else read as
-    /// stopped), so it stays the snake_case `MachineStatus` wire form. A
-    /// machine with no live row falls back to the pid-file probe.
-    fn status(&self) -> String {
-        let Some(live) = &self.live else {
-            return machine_status_label(&self.name).to_string();
-        };
-        let label = status_label(live.status);
-        // `MachineStatus::Failed` is a unit variant, so the reason rides
-        // alongside it; keep it visible rather than dropping it.
-        match (&live.status, &live.status_detail) {
-            (MachineStatus::Failed, Some(reason)) => format!("{label} ({reason})"),
-            _ => label,
-        }
-    }
-
-    /// `"dev"` / `"prod"`, resolved the same way as the boot-time SDK
-    /// envelope. Read by `Sandbox.connect(id)` to inherit the dev-only exec
-    /// guard when attaching to a running machine from a fresh process, so a
-    /// transient machine resolves it too — fail-closed to `prod`.
-    fn build_mode(&self) -> &'static str {
-        super::runtime::resolve_machine_build_mode(
-            self.spec.as_ref().and_then(|s| s.manifest.as_deref()),
-            &self.name,
-        )
-    }
-
-    /// What the machine was made from: the spec's image/manifest for a
-    /// persistent machine, and whatever the backend knows for a transient one.
-    fn source(&self) -> String {
-        let from_spec = self
-            .spec
-            .as_ref()
-            .and_then(|spec| spec.image.as_deref().or(spec.manifest.as_deref()));
-        if let Some(source) = from_spec {
-            return source.to_string();
-        }
-        self.live
-            .as_ref()
-            .and_then(|live| live.flake_ref.as_deref().or(live.profile.as_deref()))
-            .unwrap_or("-")
-            .to_string()
-    }
-
-    fn backend(&self) -> &str {
-        self.live
-            .as_ref()
-            .map(|live| live.backend.as_str())
-            .unwrap_or("-")
-    }
-
-    fn ports(&self) -> String {
-        let Some(live) = &self.live else {
-            return "-".to_string();
-        };
-        if live.ports.is_empty() {
-            return "-".to_string();
-        }
-        live.ports
-            .iter()
-            .map(|p| format!("{}→{}", p.host, p.guest))
-            .collect::<Vec<_>>()
-            .join(", ")
-    }
-
-    fn health(&self) -> &'static str {
-        let readiness = self
-            .live
-            .as_ref()
-            .and_then(|live| live.readiness.clone())
-            .or_else(|| mvm_client::readiness_of(&self.name));
-        health_cell(readiness.as_ref())
-    }
-
-    /// Age from the spec's creation time. A transient machine was never
-    /// created as a spec, so it has none.
-    fn age(&self, now: chrono::DateTime<chrono::Utc>) -> String {
-        humanize_age(
-            self.spec.as_ref().and_then(|s| s.created_at.as_deref()),
-            now,
-        )
-    }
-}
+use super::{MachineListArgs, health_cell, humanize_age};
 
 pub(super) fn list_machines(args: MachineListArgs) -> Result<()> {
-    let tag_filter = parse_tag_filter(&args.tags)?;
-    let specs = list_machine_specs()?;
-    let live = live_machines()?;
+    let query = query_from_args(&args)?;
+    let records = fetch_local_inventory()?;
     let now = chrono::Utc::now();
 
-    let machines: Vec<ListedMachine> = join_by_name(specs, live)
+    let visible: Vec<MachineInventoryRecord> = records
         .into_iter()
-        .filter(|m| passes_filters(m, args.all, &tag_filter, args.show_expired, now))
+        .filter(|record| query.matches(record, now))
         .collect();
 
     if args.json {
-        return emit_json(&machines, now);
+        // The listing's JSON is the canonical inventory record, verbatim —
+        // SDK facades parse `name` / `status` / `build_mode` / `kind` out of
+        // it, and those keys are pinned by the record's wire contract.
+        crate::json_out::emit_json(&visible)?;
+        return Ok(());
     }
-    if machines.is_empty() {
+    if visible.is_empty() {
         println!("no machines");
         return Ok(());
     }
-    println!("{}", format_table(&machines, now));
+    println!("{}", format_table(&visible, now));
     Ok(())
 }
 
-/// Every VM a backend currently knows about, joined with the VM name registry.
-fn live_machines() -> Result<Vec<MachineState>> {
+/// The canonical unfiltered inventory, via the shared service.
+fn fetch_local_inventory() -> Result<Vec<MachineInventoryRecord>> {
     let client = LocalBackend::new();
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .context("build runtime for machine listing")?;
     runtime
-        .block_on(client.list_machines(MachineFilter::all()))
+        .block_on(list_local_inventory(&client))
         .map_err(|e| anyhow::anyhow!("{e}"))
         .context("listing machines")
 }
 
-/// Join the two stores by name: every spec becomes a persistent row (carrying
-/// its live state when booted), and every live VM left over is transient.
-/// Persistent rows come first, each block name-sorted, so the listing is
-/// stable and the two kinds read as groups.
-pub(super) fn join_by_name(specs: Vec<MachineSpec>, live: Vec<MachineState>) -> Vec<ListedMachine> {
-    let mut by_name: BTreeMap<String, MachineState> = live
-        .into_iter()
-        .map(|state| (state.name.clone(), state))
-        .collect();
-
-    let mut persistent: Vec<ListedMachine> = specs
-        .into_iter()
-        .map(|spec| ListedMachine {
-            kind: MachineKind::Persistent,
-            live: by_name.remove(&spec.name),
-            name: spec.name.clone(),
-            spec: Some(spec),
-        })
-        .collect();
-    persistent.sort_by(|a, b| a.name.cmp(&b.name));
-
-    // Whatever the spec registry did not claim is running without a spec.
-    let transient = by_name.into_values().map(|state| ListedMachine {
-        kind: MachineKind::Transient,
-        name: state.name.clone(),
-        live: Some(state),
-        spec: None,
-    });
-
-    persistent.into_iter().chain(transient).collect()
-}
-
-fn parse_tag_filter(raw_tags: &[String]) -> Result<BTreeMap<String, String>> {
-    let mut filter = BTreeMap::new();
-    for raw in raw_tags {
+/// Map the CLI flags onto the shared visibility query: `--all` includes
+/// stopped transients, `--show-expired` includes elapsed-TTL machines, and
+/// each `--tag KEY=VALUE` adds a must-match constraint.
+pub(super) fn query_from_args(args: &MachineListArgs) -> Result<InventoryQuery> {
+    let mut tags = BTreeMap::new();
+    for raw in &args.tags {
         let (k, v) = mvm_core::crypto::policy::InputValidator::parse_tag_arg(raw)
             .with_context(|| format!("Invalid --tag value: {:?}", raw))?;
-        filter.insert(k, v);
+        tags.insert(k, v);
     }
-    Ok(filter)
+    Ok(InventoryQuery {
+        include_stopped_transient: args.all,
+        include_expired: args.show_expired,
+        tags,
+    })
 }
 
-/// Visibility policy. A persistent machine always lists — it exists whether or
-/// not it is booted, and hiding it would lose the only record of it. A
-/// transient machine exists only while it runs, so a stopped one is leftover
-/// state and stays hidden unless asked for.
-pub(super) fn passes_filters(
-    m: &ListedMachine,
-    all: bool,
-    tag_filter: &BTreeMap<String, String>,
-    show_expired: bool,
-    now: chrono::DateTime<chrono::Utc>,
-) -> bool {
-    let stopped = m
-        .live
-        .as_ref()
-        .map(|live| live.status == MachineStatus::Stopped)
-        .unwrap_or(true);
-    if !all && m.kind == MachineKind::Transient && stopped {
-        return false;
-    }
-    if !tag_filter.is_empty() {
-        let tags = m.live.as_ref().map(|live| &live.tags);
-        let matches = tags.is_some_and(|tags| {
-            tag_filter
-                .iter()
-                .all(|(k, v)| tags.get(k).map(String::as_str) == Some(v.as_str()))
-        });
-        if !matches {
-            return false;
-        }
-    }
-    if !show_expired && expired(m, now) {
-        return false;
-    }
-    true
-}
-
-/// Whether a machine's TTL has elapsed. A missing or unparseable `expires_at`
-/// is treated as "no TTL" (never expired).
-fn expired(m: &ListedMachine, now: chrono::DateTime<chrono::Utc>) -> bool {
-    m.live
-        .as_ref()
-        .and_then(|live| live.expires_at.as_deref())
-        .and_then(mvm_core::util::time::parse_iso8601)
-        .map(|t| t < now)
-        .unwrap_or(false)
-}
-
-/// The snake_case wire label for a status, as SDK facades parse it.
-fn status_label(status: MachineStatus) -> String {
-    match serde_json::to_value(status) {
-        Ok(serde_json::Value::String(label)) => label,
-        _ => "stopped".to_string(),
+/// STATUS cell: the typed wire label, with a failure reason kept visible
+/// beside it rather than dropped.
+pub(super) fn status_cell(record: &MachineInventoryRecord) -> String {
+    match (&record.status, &record.status_detail) {
+        (MachineStatus::Failed, Some(reason)) => format!("failed ({reason})"),
+        (status, _) => status.wire_label().to_string(),
     }
 }
 
-/// Serialize one row. The persisted spec is flattened at the top level and
-/// `status` / `build_mode` sit beside it — the shape SDK facades already
-/// parse. A transient machine has no spec to flatten, so it carries the
-/// common fields alone. Built as a map rather than a struct because
-/// `#[serde(flatten)]` over an optional spec would emit `name` twice.
-fn json_row(m: &ListedMachine, now: chrono::DateTime<chrono::Utc>) -> Result<serde_json::Value> {
-    let mut obj = match &m.spec {
-        Some(spec) => match serde_json::to_value(spec)? {
-            serde_json::Value::Object(map) => map,
-            other => anyhow::bail!("machine spec must serialize to a JSON object, got {other}"),
-        },
-        None => serde_json::Map::new(),
-    };
-
-    let mut set = |key: &str, value: serde_json::Value| {
-        obj.insert(key.to_string(), value);
-    };
-    set("name", m.name.clone().into());
-    set("kind", serde_json::to_value(m.kind)?);
-    set("status", m.status().into());
-    set("build_mode", m.build_mode().into());
-    set("health", m.health().into());
-    set("backend", m.backend().into());
-    set("source", m.source().into());
-    set("age", m.age(now).into());
-    set("expired", expired(m, now).into());
-    if let Some(live) = &m.live {
-        set("live", serde_json::to_value(live)?);
+fn ports_cell(record: &MachineInventoryRecord) -> String {
+    if record.ports.is_empty() {
+        return "-".to_string();
     }
-
-    Ok(serde_json::Value::Object(obj))
-}
-
-fn emit_json(machines: &[ListedMachine], now: chrono::DateTime<chrono::Utc>) -> Result<()> {
-    let rows = machines
+    record
+        .ports
         .iter()
-        .map(|m| json_row(m, now))
-        .collect::<Result<Vec<_>>>()?;
-    crate::json_out::emit_json(&rows)?;
-    Ok(())
+        .map(|p| format!("{}→{}", p.host, p.guest))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// One rendered row, already stringified for display.
@@ -330,27 +117,31 @@ impl Cells {
             age: "AGE".into(),
         }
     }
+
+    fn from_record(record: &MachineInventoryRecord, now: chrono::DateTime<chrono::Utc>) -> Self {
+        Self {
+            name: record.name.clone(),
+            kind: record.kind.label().to_string(),
+            status: status_cell(record),
+            health: health_cell(record.readiness.as_ref()).to_string(),
+            backend: record.backend.clone().unwrap_or_else(|| "-".to_string()),
+            ports: ports_cell(record),
+            source: record.source.clone().unwrap_or_else(|| "-".to_string()),
+            age: humanize_age(record.created_at.as_deref(), now),
+        }
+    }
 }
 
 /// Render the table: a header plus left-aligned columns padded to their widest
 /// cell, so a column nothing populates collapses to its header width. Pure so
 /// the alignment is unit-testable.
 pub(super) fn format_table(
-    machines: &[ListedMachine],
+    records: &[MachineInventoryRecord],
     now: chrono::DateTime<chrono::Utc>,
 ) -> String {
-    let rows: Vec<Cells> = machines
+    let rows: Vec<Cells> = records
         .iter()
-        .map(|m| Cells {
-            name: m.name.clone(),
-            kind: m.kind.label().to_string(),
-            status: m.status(),
-            health: m.health().to_string(),
-            backend: m.backend().to_string(),
-            ports: m.ports(),
-            source: m.source(),
-            age: m.age(now),
-        })
+        .map(|record| Cells::from_record(record, now))
         .collect();
 
     let header = Cells::header();

--- a/crates/mvm-cli/src/commands/machine/list/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/list/tests.rs
@@ -1,40 +1,13 @@
-use std::collections::BTreeMap;
+use mvm_client::inventory::{InventoryQuery, MachineInventoryRecord, MachineKind, WorkloadPosture};
+use mvm_client::{MachineStatus, PortMapping};
 
-use mvm_client::{MachineId, MachineState, MachineStatus};
-use mvm_runtime::machine::persist::{MACHINE_SPEC_SCHEMA_VERSION, MachineSpec};
-
+use super::super::MachineListArgs;
 use super::*;
 
-fn spec(name: &str) -> MachineSpec {
-    MachineSpec {
-        schema_version: MACHINE_SPEC_SCHEMA_VERSION,
-        name: name.to_string(),
-        image: Some("alpine:latest".to_string()),
-        manifest: None,
-        resolved_digest: None,
-        runtime_pack: false,
-        net: false,
-        allow_host: vec![],
-        cpus: 2,
-        memory: "512M".to_string(),
-        mem_initial: None,
-        profile: "standard".to_string(),
-        volumes: vec![],
-        init: vec![],
-        agent_verb: vec![],
-        created_at: None,
-        last_started_at: None,
-        health_check: None,
-    }
-}
-
-fn live(name: &str, status: MachineStatus) -> MachineState {
-    MachineState {
-        id: MachineId(name.to_string()),
-        name: name.to_string(),
-        status,
-        ..Default::default()
-    }
+fn record(name: &str, kind: MachineKind, status: MachineStatus) -> MachineInventoryRecord {
+    MachineInventoryRecord::builder(name, kind)
+        .status(status)
+        .build()
 }
 
 fn now() -> chrono::DateTime<chrono::Utc> {
@@ -43,190 +16,132 @@ fn now() -> chrono::DateTime<chrono::Utc> {
         .with_timezone(&chrono::Utc)
 }
 
-/// The whole point of the unified listing: a persistent machine and a
-/// transient VM are two stores, and both must appear.
-#[test]
-fn join_lists_persistent_specs_and_leftover_live_vms() {
-    let listed = join_by_name(
-        vec![spec("web")],
-        vec![
-            live("web", MachineStatus::Running),
-            live("adhoc", MachineStatus::Running),
-        ],
-    );
-
-    let kinds: Vec<_> = listed.iter().map(|m| (m.name.as_str(), m.kind)).collect();
-    assert_eq!(
-        kinds,
-        vec![
-            ("web", MachineKind::Persistent),
-            ("adhoc", MachineKind::Transient)
-        ]
-    );
+fn args() -> MachineListArgs {
+    MachineListArgs {
+        json: false,
+        all: false,
+        tags: vec![],
+        show_expired: false,
+    }
 }
 
-/// A spec joins to its live row, so a booted persistent machine reports the
-/// backend's status rather than defaulting to stopped.
+/// The CLI flags map one-to-one onto the shared visibility query, so `machine
+/// ls` and a non-CLI consumer filtering the same inventory agree exactly.
 #[test]
-fn a_booted_spec_carries_its_live_state() {
-    let listed = join_by_name(vec![spec("web")], vec![live("web", MachineStatus::Running)]);
+fn flags_map_onto_the_shared_query() {
+    let query = query_from_args(&args()).expect("default query");
+    assert_eq!(query, InventoryQuery::active());
 
-    assert_eq!(listed.len(), 1, "the spec and its live row are one machine");
-    assert_eq!(listed[0].status(), "running");
-}
-
-/// A persistent machine exists whether or not it is booted; hiding it would
-/// lose the only record of it.
-#[test]
-fn a_stopped_persistent_machine_is_listed_by_default() {
-    let listed = join_by_name(vec![spec("web")], vec![]);
-
-    assert!(passes_filters(
-        &listed[0],
-        false,
-        &BTreeMap::new(),
-        false,
-        now()
-    ));
-}
-
-/// A transient machine exists only while it runs, so a stopped one is
-/// leftover state — hidden unless `--all`.
-#[test]
-fn a_stopped_transient_machine_is_hidden_without_all() {
-    let listed = join_by_name(vec![], vec![live("adhoc", MachineStatus::Stopped)]);
-
-    assert!(!passes_filters(
-        &listed[0],
-        false,
-        &BTreeMap::new(),
-        false,
-        now()
-    ));
-    assert!(
-        passes_filters(&listed[0], true, &BTreeMap::new(), false, now()),
-        "--all reveals it"
-    );
+    let mut all = args();
+    all.all = true;
+    all.show_expired = true;
+    all.tags = vec!["env=prod".to_string()];
+    let query = query_from_args(&all).expect("query with flags");
+    assert!(query.include_stopped_transient);
+    assert!(query.include_expired);
+    assert_eq!(query.tags.get("env").map(String::as_str), Some("prod"));
 }
 
 #[test]
-fn a_running_transient_machine_is_listed_by_default() {
-    let listed = join_by_name(vec![], vec![live("adhoc", MachineStatus::Running)]);
-
-    assert!(passes_filters(
-        &listed[0],
-        false,
-        &BTreeMap::new(),
-        false,
-        now()
-    ));
-}
-
-#[test]
-fn tag_filter_drops_a_machine_without_the_tag() {
-    let mut tagged = live("adhoc", MachineStatus::Running);
-    tagged.tags.insert("env".into(), "prod".into());
-    let listed = join_by_name(vec![], vec![tagged]);
-
-    let mut want = BTreeMap::new();
-    want.insert("env".to_string(), "prod".to_string());
-    assert!(passes_filters(&listed[0], false, &want, false, now()));
-
-    want.insert("env".to_string(), "dev".to_string());
-    assert!(!passes_filters(&listed[0], false, &want, false, now()));
-}
-
-#[test]
-fn an_expired_machine_is_hidden_unless_asked_for() {
-    let mut expiring = live("adhoc", MachineStatus::Running);
-    expiring.expires_at = Some("2026-07-31T11:00:00Z".to_string());
-    let listed = join_by_name(vec![], vec![expiring]);
-
-    assert!(!passes_filters(
-        &listed[0],
-        false,
-        &BTreeMap::new(),
-        false,
-        now()
-    ));
-    assert!(passes_filters(
-        &listed[0],
-        false,
-        &BTreeMap::new(),
-        true,
-        now()
-    ));
+fn a_malformed_tag_flag_is_rejected() {
+    let mut bad = args();
+    // Spaces are outside the validated tag-key charset.
+    bad.tags = vec!["bad key=1".to_string()];
+    let err = query_from_args(&bad).expect_err("invalid tag");
+    assert!(err.to_string().contains("Invalid --tag"), "{err}");
 }
 
 /// SDK facades parse `machine ls --json`: the Rust `SubprocessBackend` reads
 /// `name` + `status`, and `Sandbox.connect(id)` reads `build_mode` to inherit
-/// the dev-only exec guard. The persisted spec stays flattened at the top
-/// level. Breaking any of that breaks attach across all three SDKs.
+/// the dev-only exec guard. Those keys ride on the shared inventory record,
+/// so the CLI JSON and the mvm-client inventory are one shape.
 #[test]
-fn json_row_keeps_the_shape_the_sdks_parse() {
-    let listed = join_by_name(vec![spec("web")], vec![live("web", MachineStatus::Running)]);
-    let row = json_row(&listed[0], now()).expect("serialize");
-    let obj = row.as_object().expect("row is an object");
+fn json_rows_keep_the_keys_the_sdks_parse() {
+    let r = record("web", MachineKind::Persistent, MachineStatus::Running);
+    let obj = serde_json::to_value(&r).expect("serialize");
 
     assert_eq!(obj["name"], "web");
     assert_eq!(
         obj["status"], "running",
         "status is the snake_case wire form"
     );
-    assert!(
-        obj["build_mode"] == "dev" || obj["build_mode"] == "prod",
-        "build_mode gates the dev-only exec path, got {:?}",
-        obj["build_mode"]
+    assert_eq!(
+        obj["build_mode"], "prod",
+        "posture is fail-closed prod unless explicitly dev"
     );
-    // Spec fields are flattened, not nested under a `spec` key.
-    assert_eq!(obj["image"], "alpine:latest");
-    assert_eq!(obj["schema_version"], MACHINE_SPEC_SCHEMA_VERSION);
-    assert!(!obj.contains_key("spec"));
     assert_eq!(obj["kind"], "persistent");
 }
 
-/// A transient machine has no spec to flatten, but must still carry the
-/// fields the SDKs read — including a fail-closed `build_mode`.
+/// A transient machine carries the same fields — including the fail-closed
+/// `build_mode` — with no spec-derived extras.
 #[test]
-fn json_row_for_a_transient_machine_carries_the_common_fields() {
-    let listed = join_by_name(vec![], vec![live("adhoc", MachineStatus::Running)]);
-    let row = json_row(&listed[0], now()).expect("serialize");
-    let obj = row.as_object().expect("row is an object");
+fn json_row_for_a_transient_machine_is_fail_closed() {
+    let r = record("adhoc", MachineKind::Transient, MachineStatus::Running);
+    let obj = serde_json::to_value(&r).expect("serialize");
 
     assert_eq!(obj["name"], "adhoc");
-    assert_eq!(obj["status"], "running");
     assert_eq!(
         obj["build_mode"], "prod",
         "no runtime meta means no dev exec"
     );
     assert_eq!(obj["kind"], "transient");
-    assert!(!obj.contains_key("image"), "there is no spec to flatten");
+    assert!(
+        obj["created_at"].is_null(),
+        "no definition, no creation time"
+    );
+}
+
+/// The status cell keeps a failure's reason visible instead of dropping it,
+/// while `--json` consumers get the typed `status` + `status_detail` pair.
+#[test]
+fn status_cell_appends_the_failure_reason() {
+    let mut failed = record("adhoc", MachineKind::Transient, MachineStatus::Failed);
+    failed.status_detail = Some("boot wedged".to_string());
+    assert_eq!(status_cell(&failed), "failed (boot wedged)");
+
+    let paused = record("web", MachineKind::Persistent, MachineStatus::Paused);
+    assert_eq!(status_cell(&paused), "paused");
+
+    // A failed machine with no recorded reason renders the bare label.
+    let bare = record("adhoc", MachineKind::Transient, MachineStatus::Failed);
+    assert_eq!(status_cell(&bare), "failed");
 }
 
 #[test]
 fn table_renders_a_header_and_one_row_per_machine() {
-    let listed = join_by_name(
-        vec![spec("web")],
-        vec![
-            live("web", MachineStatus::Running),
-            live("adhoc", MachineStatus::Running),
-        ],
-    );
-    let table = format_table(&listed, now());
+    let dev = MachineInventoryRecord::builder("web", MachineKind::Persistent)
+        .status(MachineStatus::Running)
+        .build_mode(WorkloadPosture::Dev)
+        .source(Some("alpine:latest".to_string()))
+        .backend(Some("firecracker".to_string()))
+        .ports(vec![PortMapping {
+            host: 8080,
+            guest: 80,
+        }])
+        .build();
+    let adhoc = record("adhoc", MachineKind::Transient, MachineStatus::Running);
+    let table = format_table(&[dev, adhoc], now());
     let lines: Vec<&str> = table.lines().collect();
 
     assert_eq!(lines.len(), 3, "header + two machines");
     assert!(lines[0].starts_with("NAME"));
     assert!(lines[0].contains("KIND"));
     assert!(lines[1].contains("web") && lines[1].contains("persistent"));
+    assert!(lines[1].contains("8080→80") && lines[1].contains("alpine:latest"));
     assert!(lines[2].contains("adhoc") && lines[2].contains("transient"));
+    assert!(lines[2].contains(" - "), "unbooted fields render as dashes");
 }
 
 /// Columns pad to their widest cell, so a long name does not ragged the rest.
 #[test]
 fn table_columns_align_across_rows() {
-    let listed = join_by_name(vec![spec("a-very-long-machine-name"), spec("b")], vec![]);
-    let table = format_table(&listed, now());
+    let a = record(
+        "a-very-long-machine-name",
+        MachineKind::Persistent,
+        MachineStatus::Stopped,
+    );
+    let b = record("b", MachineKind::Persistent, MachineStatus::Stopped);
+    let table = format_table(&[a, b], now());
     let lines: Vec<&str> = table.lines().collect();
 
     let kind_col = |line: &str| line.find("persistent").expect("kind cell");

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -1178,15 +1178,6 @@ fn remove_machine_spec(name: &str, yes: bool) -> Result<MachineRemoveSummary> {
     })
 }
 
-/// Live status label for a persisted machine, resolved through the backend.
-fn machine_status_label(name: &str) -> &'static str {
-    if lifecycle::machine_is_running(name) {
-        "running"
-    } else {
-        "stopped"
-    }
-}
-
 /// Health label for a machine's readiness, as shown in `machine ls`'s HEALTH
 /// column and `machine inspect`'s `health:` line. `None` covers both a
 /// registry entry with no readiness signal yet and a machine absent from the

--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -184,32 +184,13 @@ fn resolve_build_mode_for_envelope(args: &MachineRunArgs, name: &str) -> &'stati
     resolve_machine_build_mode(args.manifest.as_deref(), name)
 }
 
-/// Resolve a machine's `build_mode` (`"dev"` / `"prod"`) from its manifest
-/// slot's template revision, falling back to the runtime accessibility flag.
-/// Shared by the boot-time SDK envelope and the `machine ls --json` listing so
-/// an attach-from-a-fresh-process client reads the same value the boot path
-/// stamps. Fails closed on `"prod"` — only an explicitly dev-built template or
-/// an accessible (dev) runtime resolves to `"dev"`.
+/// Resolve a machine's `build_mode` (`"dev"` / `"prod"`) for the boot-time
+/// SDK envelope. Delegates to the shared inventory service's fail-closed
+/// posture resolution so this envelope, `machine ls --json`, and every other
+/// inventory consumer read the same value — only an explicitly dev-built
+/// template or an accessible (dev) runtime resolves to `"dev"`.
 pub(super) fn resolve_machine_build_mode(manifest: Option<&str>, name: &str) -> &'static str {
-    if let Some(manifest) = manifest {
-        let slot_name = manifest
-            .trim_end_matches('/')
-            .split('/')
-            .next_back()
-            .unwrap_or(manifest);
-        if let Ok(Some(revision)) =
-            mvm_runtime::vm::template::lifecycle::template_load_current_revision(slot_name)
-        {
-            return match revision.build_mode.as_deref() {
-                Some("dev") => "dev",
-                _ => "prod",
-            };
-        }
-    }
-    match mvm_runtime::vm::runtime_meta::read(name) {
-        Ok(Some(meta)) if meta.accessible => "dev",
-        _ => "prod",
-    }
+    mvm_client::inventory::resolve_workload_posture(manifest, name).label()
 }
 
 fn run_entrypoint_action(args: MachineRunArgs, resolved_flake_slot: Option<String>) -> Result<()> {

--- a/crates/mvm-client/Cargo.toml
+++ b/crates/mvm-client/Cargo.toml
@@ -55,3 +55,5 @@ tracing = { workspace = true }
 [dev-dependencies]
 mvm-core = { workspace = true, features = ["test-support"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
+# Inventory-record wire assertions (round-trips, no-host-path leak checks).
+serde_json = { workspace = true }

--- a/crates/mvm-client/src/inventory.rs
+++ b/crates/mvm-client/src/inventory.rs
@@ -1,5 +1,592 @@
-//! Canonical host-wide machine inventory for non-CLI consumers.
+//! Canonical host-wide machine inventory for CLI and non-CLI consumers.
 //!
-//! Home of the persisted-spec × live-backend join so `mvmctl machine ls`
-//! and local UI surfaces such as mvm-studio consume one typed inventory
-//! contract instead of assembling their own.
+//! Home of the persisted-spec × live-backend join: three stores describe a
+//! microVM and none of them is complete on its own — the persisted spec
+//! registry (a machine the user created by name), the live backend scan
+//! joined with the VM name registry (what is actually booted), and the
+//! per-VM state dirs underneath both. This module joins them into one typed
+//! [`MachineInventoryRecord`] stream so `mvmctl machine ls` and local UI
+//! surfaces such as mvm-studio consume identical semantics instead of
+//! assembling their own.
+//!
+//! The record contract and visibility semantics live in the client DTO layer
+//! ([`mvm_core::client::inventory`], re-exported here); this module adds the
+//! join, the fail-closed posture resolution, and the local collection that
+//! composes any [`MvmClient`] with the on-disk spec registry.
+
+use std::collections::BTreeMap;
+use std::collections::btree_map::Entry;
+
+use mvm_core::client::dto::{MachineFilter, MachineId, MachineState, MachineStatus};
+use mvm_core::client::{MvmClient, MvmError, Result};
+use mvm_runtime::machine::persist::{self, MachineSpec as PersistedMachineSpec};
+
+pub use mvm_core::client::inventory::{
+    InventoryQuery, MachineInventoryRecord, MachineInventoryRecordBuilder, MachineKind,
+    VolumeAttachment, VolumeAttachmentKind, WorkloadPosture,
+};
+
+/// Resolve a machine's dev/prod posture the same way the boot-time SDK
+/// envelope does, fail-closed: a manifest-backed machine reads its template
+/// revision's recorded build mode; otherwise the per-VM runtime metadata's
+/// `accessible` flag is the only thing that can open dev. Anything missing,
+/// unreadable, or unknown is production.
+pub fn resolve_workload_posture(manifest: Option<&str>, name: &str) -> WorkloadPosture {
+    if let Some(manifest) = manifest {
+        let slot_name = manifest
+            .trim_end_matches('/')
+            .split('/')
+            .next_back()
+            .unwrap_or(manifest);
+        if let Ok(Some(revision)) =
+            mvm_runtime::vm::template::lifecycle::template_load_current_revision(slot_name)
+        {
+            return WorkloadPosture::from_label(revision.build_mode.as_deref().unwrap_or("prod"));
+        }
+    }
+    match mvm_runtime::vm::runtime_meta::read(name) {
+        Ok(Some(meta)) if meta.accessible => WorkloadPosture::Dev,
+        _ => WorkloadPosture::Prod,
+    }
+}
+
+/// Summarize one persisted volume spec (`host:guest[:ro|rw]` dir share or
+/// `host:guest:SIZE[:ro|rw][:enc]` disk) for the inventory record. The host
+/// path is deliberately dropped — the record never carries host filesystem
+/// locations. Tolerant by design: a malformed spec degrades to an empty
+/// guest mount rather than failing the listing; strict validation stays at
+/// the admission choke point that materializes volumes.
+pub fn summarize_volume_spec(raw: &str) -> VolumeAttachment {
+    let mut parts = raw.split(':');
+    let _host = parts.next();
+    let guest_mount = parts.next().unwrap_or("").to_string();
+    let mut read_only = false;
+    let mut encrypted = false;
+    let mut kind = VolumeAttachmentKind::DirShare;
+    for token in parts {
+        match token.to_ascii_lowercase().as_str() {
+            "ro" => read_only = true,
+            "rw" => read_only = false,
+            "enc" => encrypted = true,
+            "" => {}
+            // Any other token is the size slot, which only disks carry.
+            _ => kind = VolumeAttachmentKind::Disk,
+        }
+    }
+    VolumeAttachment {
+        guest_mount,
+        kind,
+        read_only,
+        encrypted,
+    }
+}
+
+/// Join the two stores by name: every persisted spec becomes a persistent
+/// record (carrying its live state when booted), and every live VM left over
+/// is transient. Persistent records come first, each block name-sorted, so
+/// the listing is stable and the two kinds read as groups. `posture`
+/// resolves the dev/prod posture per record — pass
+/// [`resolve_workload_posture`] on a live host, or a stub in tests.
+pub fn join_inventory(
+    specs: Vec<PersistedMachineSpec>,
+    live: Vec<MachineState>,
+    posture: impl Fn(Option<&str>, &str) -> WorkloadPosture,
+) -> Vec<MachineInventoryRecord> {
+    let mut by_name = dedup_live_by_name(live);
+
+    let mut persistent: Vec<MachineInventoryRecord> = specs
+        .into_iter()
+        .map(|spec| {
+            let live = by_name.remove(&spec.name);
+            let posture = posture(spec.manifest.as_deref(), &spec.name);
+            persistent_record(spec, live, posture)
+        })
+        .collect();
+    persistent.sort_by(|a, b| a.name.cmp(&b.name));
+
+    // Whatever the spec registry did not claim is running without a spec.
+    let transient = by_name.into_values().map(|state| {
+        let posture = posture(None, &state.name);
+        transient_record(state, posture)
+    });
+
+    persistent.into_iter().chain(transient).collect()
+}
+
+/// Collapse duplicate live rows onto one entry per name. A non-stopped row
+/// wins over a stopped duplicate (a stale stopped registry row must never
+/// mask the actually-running VM); among rows of equal liveness the
+/// later-listed one wins, so the fold is deterministic.
+fn dedup_live_by_name(live: Vec<MachineState>) -> BTreeMap<String, MachineState> {
+    let mut by_name: BTreeMap<String, MachineState> = BTreeMap::new();
+    for state in live {
+        match by_name.entry(state.name.clone()) {
+            Entry::Vacant(slot) => {
+                slot.insert(state);
+            }
+            Entry::Occupied(mut slot) => {
+                let keep_existing = slot.get().status != MachineStatus::Stopped
+                    && state.status == MachineStatus::Stopped;
+                if !keep_existing {
+                    slot.insert(state);
+                }
+            }
+        }
+    }
+    by_name
+}
+
+/// Guest memory in MiB declared by the spec; `0` when unparseable (the
+/// listing must not fail on a hand-edited spec file).
+fn spec_memory_mib(spec: &PersistedMachineSpec) -> u32 {
+    mvm_core::util::parse_human_size(&spec.memory).unwrap_or(0)
+}
+
+/// Build the record for a persisted definition, folding in its live state
+/// when booted. Declared resources back-fill anything the live row does not
+/// know (a stopped machine reports `0` from the backend).
+fn persistent_record(
+    spec: PersistedMachineSpec,
+    live: Option<MachineState>,
+    posture: WorkloadPosture,
+) -> MachineInventoryRecord {
+    let source = spec
+        .image
+        .clone()
+        .or_else(|| spec.manifest.clone())
+        .or_else(|| live.as_ref().and_then(live_source));
+    let volumes = spec
+        .volumes
+        .iter()
+        .map(|raw| summarize_volume_spec(raw))
+        .collect();
+
+    let mut builder = MachineInventoryRecord::builder(&spec.name, MachineKind::Persistent)
+        .build_mode(posture)
+        .source(source)
+        .cpus(spec.cpus)
+        .memory_mib(spec_memory_mib(&spec))
+        .created_at(spec.created_at)
+        .last_started_at(spec.last_started_at)
+        .volumes(volumes)
+        // No secret references are persisted on a machine definition today;
+        // the field exists in the contract so consumers get a count — never
+        // a value — the moment a secret-bearing source is wired in.
+        .secret_ref_count(0);
+
+    if let Some(live) = live {
+        builder = builder
+            .id(MachineId(live.id.0))
+            .status(live.status)
+            .backend(non_empty(live.backend))
+            .readiness(live.readiness)
+            .ports(live.ports)
+            .tags(live.tags)
+            .expires_at(live.expires_at);
+        if let Some(detail) = live.status_detail {
+            builder = builder.status_detail(detail);
+        }
+        if live.cpus > 0 {
+            builder = builder.cpus(live.cpus);
+        }
+        if live.memory_mib > 0 {
+            builder = builder.memory_mib(live.memory_mib);
+        }
+    }
+    builder.build()
+}
+
+/// Build the record for a live VM with no persisted definition.
+fn transient_record(live: MachineState, posture: WorkloadPosture) -> MachineInventoryRecord {
+    let source = live_source(&live);
+    let mut builder = MachineInventoryRecord::builder(&live.name, MachineKind::Transient)
+        .id(MachineId(live.id.0))
+        .status(live.status)
+        .build_mode(posture)
+        .source(source)
+        .backend(non_empty(live.backend))
+        .cpus(live.cpus)
+        .memory_mib(live.memory_mib)
+        .readiness(live.readiness)
+        .ports(live.ports)
+        .tags(live.tags)
+        .expires_at(live.expires_at);
+    if let Some(detail) = live.status_detail {
+        builder = builder.status_detail(detail);
+    }
+    builder.build()
+}
+
+/// What a spec-less machine was made from: whatever the backend knows.
+fn live_source(live: &MachineState) -> Option<String> {
+    live.flake_ref.clone().or_else(|| live.profile.clone())
+}
+
+fn non_empty(value: String) -> Option<String> {
+    if value.is_empty() { None } else { Some(value) }
+}
+
+/// Join the given persisted specs against `client`'s live listing, resolving
+/// posture from host state. The testable core of [`list_local_inventory`];
+/// also the entry point for a caller that already holds the specs (or wants
+/// a spec-less inventory over a mock backend).
+pub async fn inventory_with_specs(
+    client: &dyn MvmClient,
+    specs: Vec<PersistedMachineSpec>,
+) -> Result<Vec<MachineInventoryRecord>> {
+    let live = client.list_machines(MachineFilter::all()).await?;
+    Ok(join_inventory(specs, live, resolve_workload_posture))
+}
+
+/// Back-fill readiness from the local VM name registry for records the live
+/// listing left blank, so a freshly-attached consumer sees the same health a
+/// long-poll would.
+pub fn apply_registry_readiness(records: &mut [MachineInventoryRecord]) {
+    for record in records {
+        if record.readiness.is_none() {
+            record.readiness = crate::readiness_of(&record.name);
+        }
+    }
+}
+
+/// The full local inventory: every persisted machine definition joined with
+/// every live VM `client` can see, readiness back-filled from the registry.
+/// Read-only — no state dir, registry entry, or audit log is mutated.
+/// Filter with [`InventoryQuery::matches`]; the unfiltered stream includes
+/// stopped and expired machines so callers own visibility policy.
+pub async fn list_local_inventory(client: &dyn MvmClient) -> Result<Vec<MachineInventoryRecord>> {
+    let specs = persist::list_machine_specs().map_err(|e| MvmError::Backend {
+        reason: format!("listing machine specs: {e:#}"),
+    })?;
+    let mut records = inventory_with_specs(client, specs).await?;
+    apply_registry_readiness(&mut records);
+    Ok(records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::client::mock::MockBackend;
+    use mvm_core::util::test_env::TestEnv;
+    use mvm_runtime::machine::persist::MACHINE_SPEC_SCHEMA_VERSION;
+
+    /// Serializes the tests that redirect `MVM_HOME` (env vars are
+    /// process-global under plain `cargo test`).
+    static MVM_HOME_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct IsolatedHome {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        _env: TestEnv,
+        _tmp: tempfile::TempDir,
+    }
+
+    impl IsolatedHome {
+        fn new() -> Self {
+            let lock = MVM_HOME_TEST_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let mut env = TestEnv::new();
+            env.set("MVM_HOME", tmp.path());
+            Self {
+                _lock: lock,
+                _env: env,
+                _tmp: tmp,
+            }
+        }
+    }
+
+    fn spec(name: &str) -> PersistedMachineSpec {
+        PersistedMachineSpec {
+            schema_version: MACHINE_SPEC_SCHEMA_VERSION,
+            name: name.to_string(),
+            image: Some("alpine:latest".to_string()),
+            manifest: None,
+            resolved_digest: None,
+            runtime_pack: false,
+            net: false,
+            allow_host: vec![],
+            cpus: 2,
+            memory: "512M".to_string(),
+            mem_initial: None,
+            profile: "standard".to_string(),
+            volumes: vec![],
+            init: vec![],
+            agent_verb: vec![],
+            created_at: Some("2026-07-01T00:00:00Z".to_string()),
+            last_started_at: None,
+            health_check: None,
+        }
+    }
+
+    fn live(name: &str, status: MachineStatus) -> MachineState {
+        MachineState {
+            id: MachineId(format!("vm-{name}")),
+            name: name.to_string(),
+            status,
+            ..Default::default()
+        }
+    }
+
+    /// A posture stub for pure join tests — every machine named `dev-*`
+    /// resolves dev, the rest prod.
+    fn stub_posture(_manifest: Option<&str>, name: &str) -> WorkloadPosture {
+        if name.starts_with("dev-") {
+            WorkloadPosture::Dev
+        } else {
+            WorkloadPosture::Prod
+        }
+    }
+
+    #[test]
+    fn persistent_only_spec_lists_as_stopped_definition() {
+        let records = join_inventory(vec![spec("web")], vec![], stub_posture);
+        assert_eq!(records.len(), 1);
+        let r = &records[0];
+        assert_eq!(r.kind, MachineKind::Persistent);
+        assert_eq!(r.status, MachineStatus::Stopped);
+        assert_eq!(r.id, MachineId("web".into()), "identity falls back to name");
+        assert_eq!(r.source.as_deref(), Some("alpine:latest"));
+        assert_eq!(r.cpus, 2);
+        assert_eq!(r.memory_mib, 512, "declared memory parses to MiB");
+        assert!(r.backend.is_none());
+        assert_eq!(r.created_at.as_deref(), Some("2026-07-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn transient_only_live_vm_lists_as_transient() {
+        let mut vm = live("adhoc", MachineStatus::Running);
+        vm.backend = "firecracker".into();
+        vm.cpus = 1;
+        vm.memory_mib = 256;
+        let records = join_inventory(vec![], vec![vm], stub_posture);
+        assert_eq!(records.len(), 1);
+        let r = &records[0];
+        assert_eq!(r.kind, MachineKind::Transient);
+        assert_eq!(r.status, MachineStatus::Running);
+        assert_eq!(r.id, MachineId("vm-adhoc".into()));
+        assert_eq!(r.backend.as_deref(), Some("firecracker"));
+        assert_eq!((r.cpus, r.memory_mib), (1, 256));
+        assert!(r.created_at.is_none(), "no definition, no creation time");
+    }
+
+    #[test]
+    fn joined_running_persistent_machine_carries_live_state_over_spec_defaults() {
+        let mut vm = live("web", MachineStatus::Running);
+        vm.backend = "hvf".into();
+        vm.cpus = 4;
+        vm.tags.insert("env".into(), "prod".into());
+        vm.expires_at = Some("2099-01-01T00:00:00Z".into());
+
+        let records = join_inventory(vec![spec("web")], vec![vm], stub_posture);
+        assert_eq!(
+            records.len(),
+            1,
+            "the spec and its live row are one machine"
+        );
+        let r = &records[0];
+        assert_eq!(r.kind, MachineKind::Persistent);
+        assert_eq!(r.status, MachineStatus::Running);
+        assert_eq!(r.id, MachineId("vm-web".into()), "live id wins");
+        assert_eq!(r.cpus, 4, "live cpus win over the declared value");
+        assert_eq!(r.memory_mib, 512, "zero live memory falls back to the spec");
+        assert_eq!(r.backend.as_deref(), Some("hvf"));
+        assert_eq!(r.tags.get("env").map(String::as_str), Some("prod"));
+        assert_eq!(r.expires_at.as_deref(), Some("2099-01-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn persistent_records_sort_first_then_transients() {
+        let records = join_inventory(
+            vec![spec("zeta"), spec("alpha")],
+            vec![
+                live("beta-adhoc", MachineStatus::Running),
+                live("alpha", MachineStatus::Running),
+            ],
+            stub_posture,
+        );
+        let names: Vec<(&str, MachineKind)> =
+            records.iter().map(|r| (r.name.as_str(), r.kind)).collect();
+        assert_eq!(
+            names,
+            vec![
+                ("alpha", MachineKind::Persistent),
+                ("zeta", MachineKind::Persistent),
+                ("beta-adhoc", MachineKind::Transient),
+            ]
+        );
+    }
+
+    #[test]
+    fn paused_machine_keeps_its_paused_status() {
+        let records = join_inventory(
+            vec![spec("web")],
+            vec![live("web", MachineStatus::Paused)],
+            stub_posture,
+        );
+        assert_eq!(records[0].status, MachineStatus::Paused);
+        // And a paused machine stays visible in the default inventory.
+        let now = mvm_core::util::time::parse_iso8601("2026-07-31T12:00:00Z").unwrap();
+        assert!(InventoryQuery::active().matches(&records[0], now));
+    }
+
+    #[test]
+    fn failed_machine_carries_its_reason_in_status_detail() {
+        let mut failed = live("adhoc", MachineStatus::Failed);
+        failed.status_detail = Some("boot wedged".into());
+        let records = join_inventory(vec![], vec![failed], stub_posture);
+        assert_eq!(records[0].status, MachineStatus::Failed);
+        assert_eq!(records[0].status_detail.as_deref(), Some("boot wedged"));
+    }
+
+    #[test]
+    fn duplicate_live_names_collapse_to_the_live_row() {
+        // A stale stopped row must never mask the running VM, in either order.
+        let stopped = live("web", MachineStatus::Stopped);
+        let mut running = live("web", MachineStatus::Running);
+        running.id = MachineId("vm-web-2".into());
+
+        for order in [
+            vec![stopped.clone(), running.clone()],
+            vec![running.clone(), stopped.clone()],
+        ] {
+            let records = join_inventory(vec![], order, stub_posture);
+            assert_eq!(records.len(), 1, "duplicates collapse to one record");
+            assert_eq!(records[0].status, MachineStatus::Running);
+            assert_eq!(records[0].id, MachineId("vm-web-2".into()));
+        }
+    }
+
+    #[test]
+    fn unknown_posture_resolution_is_prod_never_dev() {
+        // The stub resolves unknown names to prod — assert the join threads
+        // that through instead of inferring dev from anything else.
+        let records = join_inventory(
+            vec![spec("web")],
+            vec![live("mystery", MachineStatus::Running)],
+            |_, _| WorkloadPosture::from_label("unrecognized"),
+        );
+        for r in &records {
+            assert_eq!(r.build_mode, WorkloadPosture::Prod, "{}", r.name);
+        }
+    }
+
+    #[test]
+    fn dev_posture_is_only_ever_explicit() {
+        let records = join_inventory(vec![spec("dev-box"), spec("web")], vec![], stub_posture);
+        assert_eq!(records[0].build_mode, WorkloadPosture::Dev); // dev-box
+        assert_eq!(records[1].build_mode, WorkloadPosture::Prod); // web
+    }
+
+    #[test]
+    fn volume_summaries_drop_the_host_path() {
+        let mut with_volumes = spec("web");
+        with_volumes.volumes = vec![
+            "/home/user/data:/data:ro".to_string(),
+            "/home/user/scratch:/scratch:2G:rw:enc".to_string(),
+        ];
+        let records = join_inventory(vec![with_volumes], vec![], stub_posture);
+        let volumes = &records[0].volumes;
+        assert_eq!(
+            volumes,
+            &vec![
+                VolumeAttachment {
+                    guest_mount: "/data".into(),
+                    kind: VolumeAttachmentKind::DirShare,
+                    read_only: true,
+                    encrypted: false,
+                },
+                VolumeAttachment {
+                    guest_mount: "/scratch".into(),
+                    kind: VolumeAttachmentKind::Disk,
+                    read_only: false,
+                    encrypted: true,
+                },
+            ]
+        );
+        let json = serde_json::to_string(&records[0]).unwrap();
+        assert!(
+            !json.contains("/home/user"),
+            "no host path may reach the serialized record: {json}"
+        );
+    }
+
+    #[test]
+    fn summarize_volume_spec_degrades_gracefully_on_malformed_input() {
+        let attachment = summarize_volume_spec("just-a-host-path");
+        assert_eq!(attachment.guest_mount, "");
+        assert_eq!(attachment.kind, VolumeAttachmentKind::DirShare);
+        assert!(!attachment.read_only && !attachment.encrypted);
+        // A bare dir share defaults to read-write, matching the run grammar.
+        let rw = summarize_volume_spec("/h:/g");
+        assert!(!rw.read_only);
+    }
+
+    #[test]
+    fn secret_ref_count_is_zero_with_no_secret_source() {
+        let records = join_inventory(vec![spec("web")], vec![], stub_posture);
+        assert_eq!(records[0].secret_ref_count, 0);
+    }
+
+    #[test]
+    fn unparseable_spec_memory_degrades_to_zero() {
+        let mut bad = spec("web");
+        bad.memory = "not-a-size".to_string();
+        let records = join_inventory(vec![bad], vec![], stub_posture);
+        assert_eq!(records[0].memory_mib, 0);
+    }
+
+    #[tokio::test]
+    async fn mock_backend_inventory_lists_its_machines_as_transients() {
+        let _home = IsolatedHome::new();
+        let mock = MockBackend::default();
+        let spec = mvm_core::client::dto::MachineSpec::builder("adhoc", "img").build();
+        mock.run_machine(spec).await.unwrap();
+
+        let records = inventory_with_specs(&mock, vec![]).await.unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].kind, MachineKind::Transient);
+        assert_eq!(records[0].status, MachineStatus::Running);
+        assert_eq!(
+            records[0].build_mode,
+            WorkloadPosture::Prod,
+            "no runtime meta means no dev posture"
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_backend_inventory_joins_persisted_specs() {
+        let _home = IsolatedHome::new();
+        let mock = MockBackend::default();
+        let boot = mvm_core::client::dto::MachineSpec::builder("web", "img").build();
+        mock.run_machine(boot).await.unwrap();
+
+        let records = inventory_with_specs(&mock, vec![spec("web"), spec("db")])
+            .await
+            .unwrap();
+        let shape: Vec<(&str, MachineKind, MachineStatus)> = records
+            .iter()
+            .map(|r| (r.name.as_str(), r.kind, r.status))
+            .collect();
+        assert_eq!(
+            shape,
+            vec![
+                ("db", MachineKind::Persistent, MachineStatus::Stopped),
+                ("web", MachineKind::Persistent, MachineStatus::Running),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn list_local_inventory_reads_the_isolated_spec_registry() {
+        let _home = IsolatedHome::new();
+        persist::save_machine_spec(&spec("web"), false).expect("save spec");
+
+        let mock = MockBackend::default();
+        let records = list_local_inventory(&mock).await.expect("inventory");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].name, "web");
+        assert_eq!(records[0].kind, MachineKind::Persistent);
+        assert_eq!(records[0].status, MachineStatus::Stopped);
+    }
+}

--- a/crates/mvm-client/src/inventory.rs
+++ b/crates/mvm-client/src/inventory.rs
@@ -115,8 +115,8 @@ pub fn join_inventory(
 
 /// Collapse duplicate live rows onto one entry per name. A non-stopped row
 /// wins over a stopped duplicate (a stale stopped registry row must never
-/// mask the actually-running VM); among rows of equal liveness the
-/// later-listed one wins, so the fold is deterministic.
+/// mask the actually-running VM); otherwise the later-listed row wins, so
+/// the fold is deterministic.
 fn dedup_live_by_name(live: Vec<MachineState>) -> BTreeMap<String, MachineState> {
     let mut by_name: BTreeMap<String, MachineState> = BTreeMap::new();
     for state in live {

--- a/crates/mvm-core/src/client/dto.rs
+++ b/crates/mvm-core/src/client/dto.rs
@@ -22,6 +22,20 @@ pub enum MachineStatus {
     Failed,
 }
 
+impl MachineStatus {
+    /// The snake_case wire label — the exact string the serde form emits,
+    /// which SDK facades parse out of machine listings.
+    pub fn wire_label(self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::Stopped => "stopped",
+            Self::Paused => "paused",
+            Self::Failed => "failed",
+        }
+    }
+}
+
 /// What to run — intent only. No host paths, no signing material.
 ///
 /// Build one fluently with [`MachineSpec::builder`]:
@@ -431,6 +445,20 @@ mod tests {
             serde_json::to_string(&MachineStatus::Paused).unwrap(),
             "\"paused\""
         );
+    }
+
+    #[test]
+    fn wire_label_matches_the_serde_form_for_every_variant() {
+        for status in [
+            MachineStatus::Starting,
+            MachineStatus::Running,
+            MachineStatus::Stopped,
+            MachineStatus::Paused,
+            MachineStatus::Failed,
+        ] {
+            let serde_form = serde_json::to_value(status).unwrap();
+            assert_eq!(serde_form, status.wire_label(), "{status:?}");
+        }
     }
 
     #[test]

--- a/crates/mvm-core/src/client/inventory.rs
+++ b/crates/mvm-core/src/client/inventory.rs
@@ -1,0 +1,647 @@
+//! The canonical host-wide machine inventory contract.
+//!
+//! One typed record unifies the two stores that describe a microVM — the
+//! persisted machine-spec registry and the live backend listing — so the CLI
+//! and non-CLI consumers (local UIs, SDK facades) read identical semantics
+//! instead of each assembling their own join. Like the rest of the client
+//! DTOs, the record is REST-satisfiable plain data and carries **no host key
+//! material, no secret values, and no host filesystem paths**: volume
+//! attachments are summarized by guest mount only, and secrets appear only as
+//! a count of references.
+//!
+//! The join itself needs the runtime's persisted spec type, so it lives one
+//! crate up in `mvm-client`'s `inventory` module; this module owns the wire
+//! shape and the visibility semantics both sides share.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::dto::{MachineId, MachineStatus, PortMapping};
+use crate::domain::instance::InstanceReadiness;
+
+/// Where a listed microVM's definition lives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MachineKind {
+    /// Backed by a persisted spec: survives a stop, restartable by name.
+    Persistent,
+    /// Live only. It leaves nothing behind once it exits.
+    Transient,
+}
+
+impl MachineKind {
+    /// The snake_case wire/display label.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Persistent => "persistent",
+            Self::Transient => "transient",
+        }
+    }
+}
+
+/// Fail-closed dev/prod workload posture.
+///
+/// Only an explicit `"dev"` is ever dev; a missing, unknown, or malformed
+/// posture is production, so a stale or hostile record can never *open* a
+/// dev-only path — it can only keep it shut. Deserialization enforces the
+/// same rule: any string other than `"dev"` becomes [`WorkloadPosture::Prod`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkloadPosture {
+    Dev,
+    #[default]
+    Prod,
+}
+
+impl WorkloadPosture {
+    /// Resolve a posture label fail-closed: exactly `"dev"` is dev,
+    /// everything else — including unknown labels — is prod.
+    pub fn from_label(label: &str) -> Self {
+        if label == "dev" {
+            Self::Dev
+        } else {
+            Self::Prod
+        }
+    }
+
+    /// The snake_case wire/display label.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Dev => "dev",
+            Self::Prod => "prod",
+        }
+    }
+
+    /// Whether dev-only paths (interactive exec, console) may open.
+    pub fn is_dev(self) -> bool {
+        matches!(self, Self::Dev)
+    }
+}
+
+impl<'de> Deserialize<'de> for WorkloadPosture {
+    // Hand-rolled so an unknown posture value deserializes fail-closed to
+    // `Prod` instead of failing the whole record or — worse — being mapped
+    // to dev by a permissive consumer.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let label = String::deserialize(deserializer)?;
+        Ok(Self::from_label(&label))
+    }
+}
+
+/// How a summarized volume is attached to the guest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VolumeAttachmentKind {
+    /// Live host-directory share (virtio-fs).
+    DirShare,
+    /// Persistent disk image (virtio-blk).
+    Disk,
+}
+
+/// A machine's volume attachment, summarized for listing. Deliberately omits
+/// the host-side path — the inventory record never carries host filesystem
+/// locations; `machine inspect` remains the place to see the full spec.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VolumeAttachment {
+    /// Guest mount point (or attach target) of the volume.
+    pub guest_mount: String,
+    pub kind: VolumeAttachmentKind,
+    pub read_only: bool,
+    /// Whether the disk volume is routed through in-guest encryption.
+    #[serde(default)]
+    pub encrypted: bool,
+}
+
+/// One machine in the unified host inventory: the typed join of a persisted
+/// spec (when one exists) and the live backend state (when booted).
+///
+/// Field notes:
+/// - `build_mode` keeps that wire name (not "posture") because SDK facades
+///   already parse `build_mode` out of the machine listing to gate the
+///   dev-only exec path; it deserializes fail-closed (see
+///   [`WorkloadPosture`]) and defaults to prod when absent.
+/// - `secret_ref_count` is a count of secret *references* only. Secret
+///   values, key material, and host paths never ride in this record.
+/// - Optional fields default so an older serialized record still loads;
+///   unknown fields fail closed like every other client DTO.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MachineInventoryRecord {
+    /// Stable identity: the live backend id when booted, else the machine
+    /// name (which is the registry identity of a non-booted definition).
+    pub id: MachineId,
+    pub name: String,
+    pub kind: MachineKind,
+    pub status: MachineStatus,
+    /// Free-text detail behind a non-happy `status` (e.g. a failure reason).
+    #[serde(default)]
+    pub status_detail: Option<String>,
+    /// Fail-closed dev/prod posture; wire name kept for SDK compatibility.
+    #[serde(default)]
+    pub build_mode: WorkloadPosture,
+    /// What the machine was made from: the spec's image/manifest reference
+    /// for a persistent machine, the backend's flake ref/profile otherwise.
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Backend that owns the live VM (e.g. `"firecracker"`). `None` when
+    /// not booted.
+    #[serde(default)]
+    pub backend: Option<String>,
+    /// vCPU count. `0` when unknown.
+    #[serde(default)]
+    pub cpus: u32,
+    /// Guest memory in MiB. `0` when unknown.
+    #[serde(default)]
+    pub memory_mib: u32,
+    /// Finer-grained host-observed readiness, when tracked.
+    #[serde(default)]
+    pub readiness: Option<InstanceReadiness>,
+    /// Active host:guest port forwardings.
+    #[serde(default)]
+    pub ports: Vec<PortMapping>,
+    /// Caller-supplied metadata tags.
+    #[serde(default)]
+    pub tags: BTreeMap<String, String>,
+    /// RFC 3339 TTL expiry, when set.
+    #[serde(default)]
+    pub expires_at: Option<String>,
+    /// RFC 3339 creation time of the persistent definition, when recorded.
+    #[serde(default)]
+    pub created_at: Option<String>,
+    /// RFC 3339 time of the last lifecycle start, when recorded.
+    #[serde(default)]
+    pub last_started_at: Option<String>,
+    /// Volume attachments, summarized without host paths.
+    #[serde(default)]
+    pub volumes: Vec<VolumeAttachment>,
+    /// Number of secret references bound to this machine. A count only —
+    /// never names-with-values, never the values themselves.
+    #[serde(default)]
+    pub secret_ref_count: u32,
+}
+
+impl MachineInventoryRecord {
+    /// Start building a record. `name` and `kind` are required; everything
+    /// else defaults to the fail-closed empty shape (stopped, prod posture,
+    /// no live detail) and is overridable on the returned builder.
+    pub fn builder(name: impl Into<String>, kind: MachineKind) -> MachineInventoryRecordBuilder {
+        let name = name.into();
+        MachineInventoryRecordBuilder {
+            record: MachineInventoryRecord {
+                id: MachineId(name.clone()),
+                name,
+                kind,
+                status: MachineStatus::Stopped,
+                status_detail: None,
+                build_mode: WorkloadPosture::Prod,
+                source: None,
+                backend: None,
+                cpus: 0,
+                memory_mib: 0,
+                readiness: None,
+                ports: Vec::new(),
+                tags: BTreeMap::new(),
+                expires_at: None,
+                created_at: None,
+                last_started_at: None,
+                volumes: Vec::new(),
+                secret_ref_count: 0,
+            },
+        }
+    }
+
+    /// Whether the machine's TTL has elapsed at `now`. A missing or
+    /// unparseable `expires_at` is "no TTL" (never expired).
+    pub fn is_expired(&self, now: chrono::DateTime<chrono::Utc>) -> bool {
+        self.expires_at
+            .as_deref()
+            .and_then(crate::util::time::parse_iso8601)
+            .map(|t| t < now)
+            .unwrap_or(false)
+    }
+}
+
+/// Fluent builder for [`MachineInventoryRecord`]; obtain one from
+/// [`MachineInventoryRecord::builder`]. `build` is infallible — the required
+/// identity fields were supplied up front and every other field has a safe
+/// fail-closed default.
+#[derive(Debug, Clone)]
+pub struct MachineInventoryRecordBuilder {
+    record: MachineInventoryRecord,
+}
+
+impl MachineInventoryRecordBuilder {
+    /// Override the stable id (defaults to the machine name).
+    #[must_use]
+    pub fn id(mut self, id: MachineId) -> Self {
+        self.record.id = id;
+        self
+    }
+
+    #[must_use]
+    pub fn status(mut self, status: MachineStatus) -> Self {
+        self.record.status = status;
+        self
+    }
+
+    #[must_use]
+    pub fn status_detail(mut self, detail: impl Into<String>) -> Self {
+        self.record.status_detail = Some(detail.into());
+        self
+    }
+
+    #[must_use]
+    pub fn build_mode(mut self, posture: WorkloadPosture) -> Self {
+        self.record.build_mode = posture;
+        self
+    }
+
+    #[must_use]
+    pub fn source(mut self, source: Option<String>) -> Self {
+        self.record.source = source;
+        self
+    }
+
+    #[must_use]
+    pub fn backend(mut self, backend: Option<String>) -> Self {
+        self.record.backend = backend;
+        self
+    }
+
+    #[must_use]
+    pub fn cpus(mut self, cpus: u32) -> Self {
+        self.record.cpus = cpus;
+        self
+    }
+
+    #[must_use]
+    pub fn memory_mib(mut self, memory_mib: u32) -> Self {
+        self.record.memory_mib = memory_mib;
+        self
+    }
+
+    #[must_use]
+    pub fn readiness(mut self, readiness: Option<InstanceReadiness>) -> Self {
+        self.record.readiness = readiness;
+        self
+    }
+
+    #[must_use]
+    pub fn ports(mut self, ports: Vec<PortMapping>) -> Self {
+        self.record.ports = ports;
+        self
+    }
+
+    #[must_use]
+    pub fn tags(mut self, tags: BTreeMap<String, String>) -> Self {
+        self.record.tags = tags;
+        self
+    }
+
+    #[must_use]
+    pub fn expires_at(mut self, expires_at: Option<String>) -> Self {
+        self.record.expires_at = expires_at;
+        self
+    }
+
+    #[must_use]
+    pub fn created_at(mut self, created_at: Option<String>) -> Self {
+        self.record.created_at = created_at;
+        self
+    }
+
+    #[must_use]
+    pub fn last_started_at(mut self, last_started_at: Option<String>) -> Self {
+        self.record.last_started_at = last_started_at;
+        self
+    }
+
+    #[must_use]
+    pub fn volumes(mut self, volumes: Vec<VolumeAttachment>) -> Self {
+        self.record.volumes = volumes;
+        self
+    }
+
+    #[must_use]
+    pub fn secret_ref_count(mut self, count: u32) -> Self {
+        self.record.secret_ref_count = count;
+        self
+    }
+
+    /// Finish building. Infallible — identity was required up front.
+    #[must_use]
+    pub fn build(self) -> MachineInventoryRecord {
+        self.record
+    }
+}
+
+/// Visibility query over the inventory. The default is the *active*
+/// inventory: a persistent definition always lists (stopped or not — it
+/// exists whether or not it is booted, and hiding it would lose the only
+/// record of it), while a stopped transient machine is leftover state and
+/// stays hidden unless explicitly included. Expired machines are hidden
+/// until asked for; tag constraints must all match.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InventoryQuery {
+    /// Include transient machines that are no longer running.
+    #[serde(default)]
+    pub include_stopped_transient: bool,
+    /// Include machines whose TTL has elapsed but that are not yet reaped.
+    #[serde(default)]
+    pub include_expired: bool,
+    /// Tag constraints; every `key=value` pair must match the record's tags.
+    #[serde(default)]
+    pub tags: BTreeMap<String, String>,
+}
+
+impl InventoryQuery {
+    /// The default active inventory (stopped transients and expired hidden).
+    pub fn active() -> Self {
+        Self::default()
+    }
+
+    /// Everything, including stopped transients and expired machines.
+    pub fn all() -> Self {
+        Self {
+            include_stopped_transient: true,
+            include_expired: true,
+            tags: BTreeMap::new(),
+        }
+    }
+
+    /// Whether `record` is visible under this query at `now`.
+    ///
+    /// Only [`MachineStatus::Stopped`] counts as "no longer running" — a
+    /// paused or failed machine stays visible by default so its state is
+    /// observable rather than silently folding away.
+    pub fn matches(
+        &self,
+        record: &MachineInventoryRecord,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> bool {
+        let stopped = record.status == MachineStatus::Stopped;
+        if !self.include_stopped_transient && record.kind == MachineKind::Transient && stopped {
+            return false;
+        }
+        let tags_match = self
+            .tags
+            .iter()
+            .all(|(k, v)| record.tags.get(k).map(String::as_str) == Some(v.as_str()));
+        if !tags_match {
+            return false;
+        }
+        if !self.include_expired && record.is_expired(now) {
+            return false;
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> chrono::DateTime<chrono::Utc> {
+        crate::util::time::parse_iso8601("2026-07-31T12:00:00Z").unwrap()
+    }
+
+    fn full_record() -> MachineInventoryRecord {
+        MachineInventoryRecord::builder("web", MachineKind::Persistent)
+            .id(MachineId("m1".into()))
+            .status(MachineStatus::Failed)
+            .status_detail("boom")
+            .build_mode(WorkloadPosture::Dev)
+            .source(Some("alpine:latest".into()))
+            .backend(Some("firecracker".into()))
+            .cpus(2)
+            .memory_mib(512)
+            .readiness(Some(InstanceReadiness::AgentReady))
+            .ports(vec![PortMapping {
+                host: 8080,
+                guest: 80,
+            }])
+            .tags(BTreeMap::from([("env".to_string(), "prod".to_string())]))
+            .expires_at(Some("2099-01-01T00:00:00Z".into()))
+            .created_at(Some("2026-07-01T00:00:00Z".into()))
+            .last_started_at(Some("2026-07-02T00:00:00Z".into()))
+            .volumes(vec![VolumeAttachment {
+                guest_mount: "/data".into(),
+                kind: VolumeAttachmentKind::Disk,
+                read_only: false,
+                encrypted: true,
+            }])
+            .secret_ref_count(3)
+            .build()
+    }
+
+    #[test]
+    fn record_serde_round_trips_with_all_fields() {
+        let record = full_record();
+        let json = serde_json::to_string(&record).unwrap();
+        let back: MachineInventoryRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(record, back);
+    }
+
+    #[test]
+    fn minimal_record_deserializes_with_fail_closed_defaults() {
+        // Only the identity fields present: every added field must fall back
+        // to its default — and the posture default must be prod, never dev.
+        let json = r#"{"id":"m1","name":"web","kind":"transient","status":"running"}"#;
+        let record: MachineInventoryRecord = serde_json::from_str(json).unwrap();
+        assert_eq!(record.kind, MachineKind::Transient);
+        assert_eq!(record.build_mode, WorkloadPosture::Prod);
+        assert!(record.status_detail.is_none());
+        assert!(record.volumes.is_empty());
+        assert_eq!(record.secret_ref_count, 0);
+        assert!(record.tags.is_empty());
+    }
+
+    #[test]
+    fn record_rejects_unknown_field_fail_closed() {
+        let json = r#"{"id":"m1","name":"web","kind":"transient","status":"running","rogue":1}"#;
+        assert!(serde_json::from_str::<MachineInventoryRecord>(json).is_err());
+    }
+
+    #[test]
+    fn record_never_carries_secret_or_host_path_shaped_fields() {
+        // The wire shape must not grow value-bearing or host-path fields;
+        // pin the serialized key set so an accidental addition is loud.
+        let value = serde_json::to_value(full_record()).unwrap();
+        let keys: Vec<&str> = value
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        for forbidden in ["secret", "secrets", "host_path", "rootfs", "key"] {
+            assert!(
+                !keys.contains(&forbidden),
+                "forbidden key {forbidden:?} in {keys:?}"
+            );
+        }
+        // The volume summary carries the guest mount only.
+        let volume = &value["volumes"][0];
+        assert!(volume.get("host").is_none() && volume.get("host_path").is_none());
+    }
+
+    #[test]
+    fn posture_deserializes_fail_closed() {
+        // Explicit dev stays dev; prod stays prod.
+        assert_eq!(
+            serde_json::from_str::<WorkloadPosture>("\"dev\"").unwrap(),
+            WorkloadPosture::Dev
+        );
+        assert_eq!(
+            serde_json::from_str::<WorkloadPosture>("\"prod\"").unwrap(),
+            WorkloadPosture::Prod
+        );
+        // Unknown / malformed labels are production, never dev.
+        for unknown in ["\"debug\"", "\"DEV\"", "\"\"", "\"development\""] {
+            assert_eq!(
+                serde_json::from_str::<WorkloadPosture>(unknown).unwrap(),
+                WorkloadPosture::Prod,
+                "label {unknown} must fail closed to prod"
+            );
+        }
+    }
+
+    #[test]
+    fn posture_labels_round_trip_and_default_is_prod() {
+        assert_eq!(WorkloadPosture::default(), WorkloadPosture::Prod);
+        assert_eq!(WorkloadPosture::from_label("dev"), WorkloadPosture::Dev);
+        assert_eq!(WorkloadPosture::from_label("weird"), WorkloadPosture::Prod);
+        assert_eq!(WorkloadPosture::Dev.label(), "dev");
+        assert_eq!(WorkloadPosture::Prod.label(), "prod");
+        assert!(WorkloadPosture::Dev.is_dev());
+        assert!(!WorkloadPosture::Prod.is_dev());
+        // Serialized form matches the label, so round-trips are stable.
+        assert_eq!(
+            serde_json::to_string(&WorkloadPosture::Dev).unwrap(),
+            "\"dev\""
+        );
+    }
+
+    #[test]
+    fn kind_serde_is_snake_case_and_labels_match() {
+        assert_eq!(
+            serde_json::to_string(&MachineKind::Persistent).unwrap(),
+            "\"persistent\""
+        );
+        assert_eq!(MachineKind::Persistent.label(), "persistent");
+        assert_eq!(MachineKind::Transient.label(), "transient");
+    }
+
+    #[test]
+    fn volume_attachment_serde_round_trips_and_rejects_unknown_fields() {
+        let attachment = VolumeAttachment {
+            guest_mount: "/data".into(),
+            kind: VolumeAttachmentKind::DirShare,
+            read_only: true,
+            encrypted: false,
+        };
+        let json = serde_json::to_string(&attachment).unwrap();
+        assert_eq!(
+            serde_json::from_str::<VolumeAttachment>(&json).unwrap(),
+            attachment
+        );
+        assert!(
+            serde_json::from_str::<VolumeAttachment>(
+                r#"{"guest_mount":"/d","kind":"disk","read_only":false,"host":"/tmp"}"#
+            )
+            .is_err(),
+            "a host-path-shaped field must be rejected"
+        );
+    }
+
+    #[test]
+    fn query_serde_round_trips_defaults_and_rejects_unknown_fields() {
+        let query: InventoryQuery = serde_json::from_str("{}").unwrap();
+        assert_eq!(query, InventoryQuery::active());
+        let all = InventoryQuery::all();
+        let json = serde_json::to_string(&all).unwrap();
+        assert_eq!(serde_json::from_str::<InventoryQuery>(&json).unwrap(), all);
+        assert!(serde_json::from_str::<InventoryQuery>(r#"{"rogue":true}"#).is_err());
+    }
+
+    fn record(kind: MachineKind, status: MachineStatus) -> MachineInventoryRecord {
+        MachineInventoryRecord::builder("m", kind)
+            .status(status)
+            .build()
+    }
+
+    #[test]
+    fn stopped_persistent_definition_stays_visible_by_default() {
+        let stopped = record(MachineKind::Persistent, MachineStatus::Stopped);
+        assert!(InventoryQuery::active().matches(&stopped, now()));
+    }
+
+    #[test]
+    fn stopped_transient_is_hidden_unless_included() {
+        let stopped = record(MachineKind::Transient, MachineStatus::Stopped);
+        assert!(!InventoryQuery::active().matches(&stopped, now()));
+        assert!(InventoryQuery::all().matches(&stopped, now()));
+    }
+
+    #[test]
+    fn paused_failed_and_running_transients_stay_visible_by_default() {
+        for status in [
+            MachineStatus::Paused,
+            MachineStatus::Failed,
+            MachineStatus::Running,
+            MachineStatus::Starting,
+        ] {
+            let r = record(MachineKind::Transient, status);
+            assert!(
+                InventoryQuery::active().matches(&r, now()),
+                "{status:?} must stay visible"
+            );
+        }
+    }
+
+    #[test]
+    fn expired_machine_is_hidden_unless_included() {
+        let expired = MachineInventoryRecord::builder("m", MachineKind::Transient)
+            .status(MachineStatus::Running)
+            .expires_at(Some("2026-07-31T11:00:00Z".into()))
+            .build();
+        assert!(!InventoryQuery::active().matches(&expired, now()));
+        let show = InventoryQuery {
+            include_expired: true,
+            ..InventoryQuery::active()
+        };
+        assert!(show.matches(&expired, now()));
+    }
+
+    #[test]
+    fn unparseable_expiry_is_never_expired() {
+        let r = MachineInventoryRecord::builder("m", MachineKind::Transient)
+            .status(MachineStatus::Running)
+            .expires_at(Some("not-a-date".into()))
+            .build();
+        assert!(!r.is_expired(now()));
+        assert!(InventoryQuery::active().matches(&r, now()));
+    }
+
+    #[test]
+    fn tag_constraints_must_all_match() {
+        let mut r = record(MachineKind::Transient, MachineStatus::Running);
+        r.tags.insert("env".into(), "prod".into());
+
+        let mut query = InventoryQuery::active();
+        query.tags.insert("env".into(), "prod".into());
+        assert!(query.matches(&r, now()));
+
+        query.tags.insert("team".into(), "core".into());
+        assert!(!query.matches(&r, now()), "a missing tag drops the record");
+
+        let mut wrong = InventoryQuery::active();
+        wrong.tags.insert("env".into(), "dev".into());
+        assert!(!wrong.matches(&r, now()), "a mismatched value drops it");
+    }
+}

--- a/crates/mvm-core/src/client/mod.rs
+++ b/crates/mvm-core/src/client/mod.rs
@@ -16,6 +16,7 @@ pub mod dto;
 pub mod error;
 #[cfg(feature = "client-remote")]
 pub mod gateway;
+pub mod inventory;
 pub mod mock;
 
 pub use error::{MvmError, Result};

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -16,7 +16,27 @@ Wave 0 scaffolded the `mvm-client` service module seams (`inventory`,
 `volume`, `secret`, `audit`). Each issue lands via its own PR; each PR
 updates only its own entry below.
 
-- [ ] #2078 — canonical unified machine inventory through mvm-client.
+- [x] #2078 — canonical unified machine inventory through mvm-client.
+      `mvm_core::client::inventory` adds the typed `MachineInventoryRecord`
+      contract (identity/name, persistent-vs-transient kind, status +
+      detail incl. paused, fail-closed `build_mode` posture where any
+      unknown label deserializes to prod, source/backend, cpu/memory,
+      readiness, TTL, created/last-started, tags, host-path-free volume
+      attachment summaries, secret-reference count only) plus the shared
+      `InventoryQuery` visibility semantics (stopped persistent
+      definitions stay visible; stopped transients hide unless included;
+      expired hide unless included). `mvm_client::inventory` hosts the
+      spec×live join (duplicate live names collapse with the live row
+      winning), the fail-closed posture resolver the SDK envelope now
+      delegates to, and the read-only `list_local_inventory` composition
+      over any `MvmClient` — mock backend included; the `MvmClient` trait
+      and gateway are unchanged. `mvmctl machine ls` now renders the
+      shared records and its `--json` is the serialized record verbatim
+      (SDK-parsed `name`/`status`/`build_mode`/`kind` keys pinned by
+      tests). 41 new/updated unit tests across the three crates cover the
+      persistent-only/transient-only/joined/paused/failed/stopped/expired/
+      duplicate-name/unknown-posture matrix, serde round-trips,
+      unknown-field rejection, and the no-secret/no-host-path guarantees.
 
 - [ ] #2080 — reusable local encrypted-volume lifecycle service.
 


### PR DESCRIPTION
## Summary

Exposes the canonical unified local machine inventory through `mvm-client`, so `mvmctl machine ls` and non-CLI consumers (mvm-studio) share one typed contract instead of the CLI-private spec×live join.

- **`mvm_core::client::inventory` (new)** — the wire contract: `MachineInventoryRecord` with typed identity/name, `MachineKind` (persistent/transient), `MachineStatus` + `status_detail` (paused stays distinct and visible), fail-closed `WorkloadPosture` (serialized under the SDK-compatible `build_mode` key; **any unknown or missing posture deserializes to prod, never dev**), source, backend, cpus/memory MiB, readiness, ports, tags, TTL `expires_at`, created/last-started timestamps, host-path-free `VolumeAttachment` summaries (guest mount + kind + ro/enc only), and `secret_ref_count` (a count, never values). Plus the shared `InventoryQuery` visibility semantics: stopped persistent definitions always list; stopped transients hide unless included; expired machines hide unless included; tag constraints must all match. Records are `deny_unknown_fields` fail-closed like the sibling DTOs, with `#[serde(default)]` optional fields for forward compatibility.
- **`mvm_client::inventory`** — the reusable service: `join_inventory` (spec registry × live listing by name; persistent block first, then transients, name-sorted; duplicate live names collapse with the non-stopped row winning), `resolve_workload_posture` (moved out of mvm-cli; the boot-time SDK envelope now delegates to it so `machine ls --json` and the envelope can never drift), `summarize_volume_spec` (drops host paths), and the read-only `list_local_inventory(&dyn MvmClient)` composition that works over `LocalBackend` and `MockBackend` alike. No audit mutation anywhere on the path.
- **`mvmctl machine ls`** is now presentation-only: flags map onto `InventoryQuery`, the table renders the shared records, and `--json` emits the serialized inventory records verbatim — the SDK-parsed `name` / `status` / `build_mode` / `kind` keys are pinned by tests. Host volume paths no longer leak into the listing JSON (`machine inspect` remains the full-spec view).
- **`MvmClient` trait unchanged** — remote/gateway compatibility preserved with no new endpoint; the DTO round-trips over the wire.

## Test evidence

41 new/updated unit tests across the three crates (workspace suite green, clippy `-D warnings` clean, fmt clean, `check-no-spec-refs-in-comments` clean, doctests pass):

- Join matrix (`mvm-client`): persistent-only, transient-only, joined running persistent, paused, failed (reason in `status_detail`), stopped, duplicate-name (both orders; live row wins), sort order, mock-backend inventory (transients + joined specs), isolated-registry `list_local_inventory`.
- Fail-closed negatives: unknown posture label → prod (resolver, serde, and join threading); missing `build_mode` → prod; unparseable spec memory → 0; malformed volume spec degrades instead of failing the listing; malformed `--tag` rejected.
- Wire contract (`mvm-core`): full-record serde round-trip, legacy minimal record defaults, unknown-field rejection (record, query, volume attachment incl. a host-path-shaped field), forbidden-key pinning (no `secret`/`host_path`/`key` keys, volume summaries carry no host path), `MachineStatus::wire_label` ↔ serde parity.
- Visibility: stopped persistent visible by default, stopped transient hidden unless included, paused/failed/starting stay visible, expired hidden unless included, unparseable expiry never expires, tag conjunction semantics.
- CLI presentation: flag→query mapping, SDK JSON key pinning for persistent and transient rows, failed-status cell keeps the reason, table header/rows/alignment.

Closes #2078

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Behavioral note

The old per-machine pid-probe status fallback (`machine_status_label` -> `backend_is_running`) is replaced by `LocalBackend::list_machines`, which sweeps every backend's listing. If a backend listing errors, the machine now renders as stopped rather than being pid-probed; coverage is broader (all backends, not just the effective hypervisor) but the probe fallback is gone.
