### PR TITLE
feat(mvm-client): add the write-only secret lifecycle service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2811,6 +2811,7 @@ dependencies = [
  "mvm-core",
  "mvm-fs",
  "mvm-hostd",
+ "mvm-protocol",
  "mvm-runtime",
  "rand 0.8.6",
  "secrecy",
@@ -2820,6 +2821,7 @@ dependencies = [
  "sha2 0.11.0",
  "tar",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]

--- a/crates/mvm-cli/src/commands/ops/secret.rs
+++ b/crates/mvm-cli/src/commands/ops/secret.rs
@@ -1,56 +1,50 @@
 //! `mvmctl secret put/set/get/ls/rm` CLI surface.
 //!
-//! Local CRUD for secret namespaces. Values never appear in
-//! logs, error chains, or process listings — `put`/`set` accept the
-//! value via an interactive hidden prompt, stdin, flag, or file;
-//! `get` verifies that a secret exists but never prints the stored
-//! value.
+//! Thin flag layer over the canonical write-only secret lifecycle service
+//! ([`mvm_client::secret::SecretService`]) — the same orchestration local UI
+//! surfaces consume. Values never appear in logs, error chains, or process
+//! listings — `put`/`set` accept the value via an interactive hidden prompt,
+//! stdin, flag, or file; `get` verifies that a secret exists but never
+//! prints the stored value; the service has no reveal path at all.
 //!
-//! `set` is `put` plus an egress binding: it
-//! records, in a parallel [`mvm_hostd::keyholder::FileBindingStore`], the
-//! auth-type and destination allow-list for a secret whose value the host
-//! egress proxy substitutes toward bound destinations only (never the
-//! guest). `ls` surfaces that binding (type + hosts) but never the value.
+//! `set` is `put` plus an egress binding: it records the auth-type and
+//! destination allow-list for a secret whose value the host egress proxy
+//! substitutes toward bound destinations only (never the guest). `ls`
+//! surfaces that binding (type + hosts) but never the value. `rm` refuses
+//! while a persistent machine still references the secret.
 //!
 //! ## Audit
 //!
-//! Every put/get/delete/list emits one JSON line to
-//! `~/.mvm/audit/secrets.jsonl` carrying
-//! `(timestamp, action, namespace, name, outcome, pid,
-//! secret_visibility, storage_security, error?)`. Values are never
-//! logged. When the chain recorder is available, the same posture
-//! labels are emitted on the chain-signed `secret.*` event.
+//! The service emits one JSON line per action to
+//! `~/.mvm/audit/secrets.jsonl` (`create`/`replace`/`bind`/`unbind`/
+//! `remove`/`remove_refused`/`get`/`list`) carrying
+//! `(timestamp, action, tenant, name, outcome, pid, secret_visibility,
+//! storage_security, error?)`. Values are never logged. When the chain
+//! recorder is available, the same posture labels ride the chain-signed
+//! `secret.*` event.
 //!
 //! ## Backend choice
 //!
-//! Goes through [`secret_store::default_secret_store`]:
+//! [`SecretService::local`] goes through the default store selection:
 //! - Auto store when the OS keystore is reachable: writes prefer
-//!   `KeyringSecretStore`, while reads/lists/deletes keep
-//!   file-backed secrets visible.
+//!   `KeyringSecretStore`, while reads/lists/deletes keep file-backed
+//!   secrets visible.
 //! - `FileSecretStore` everywhere else (CI Linux, headless hosts).
 //!
-//! Tests inject `FileSecretStore::with_dir` + `FileBindingStore::with_dir`
-//! via [`run_with_stores`].
+//! Tests inject temp-dir stores via [`SecretService::builder`] and
+//! [`run_with_service`].
 
-use std::io::{IsTerminal, Read, Write};
+use std::io::{IsTerminal, Read};
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use chrono::Utc;
 use clap::{Args as ClapArgs, Subcommand, ValueEnum};
-use mvm_core::crypto::secret_store::{self, SecretStore};
-use mvm_core::plan::TenantId;
-use mvm_hostd::keyholder::{BindingStore, FileBindingStore, SecretBindingMeta};
-use mvm_hostd::supervisor::{EventCategory, FileAuditSigner, Recorder};
+use mvm_client::secret::{PutOutcome, SecretBindingMeta, SecretService, SecretValueInput};
 use mvm_protocol::ir::{AuthType, Sigv4Params};
-use secrecy::SecretBox;
 
 use mvm_core::user_config::MvmConfig;
 
 use super::Cli;
-use crate::commands::vm::audit_chain::default_audit_dir;
-use crate::commands::vm::host_signer;
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
@@ -101,7 +95,7 @@ pub(in crate::commands) enum SecretAction {
         /// Local namespace. Fleet tenant secrets are managed by mvmd.
         #[arg(long, default_value = "local")]
         tenant: String,
-        /// Destination the credential may reach (claim 12). Repeatable;
+        /// Destination the credential may reach. Repeatable;
         /// at least one required. `*.` subdomain wildcards supported.
         #[arg(long = "host", required = true)]
         hosts: Vec<String>,
@@ -138,7 +132,8 @@ pub(in crate::commands) enum SecretAction {
         tenant: String,
     },
 
-    /// Remove a tenant secret.
+    /// Remove a tenant secret. Refused while a persistent machine still
+    /// references it.
     Rm {
         name: String,
         #[arg(long, default_value = "local")]
@@ -168,26 +163,20 @@ impl From<AuthTypeArg> for AuthType {
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
-    let store = secret_store::default_secret_store();
-    let bindings = FileBindingStore::default_location()?;
-    run_with_stores(store.as_ref(), &bindings, args)
+    let service = SecretService::local()?;
+    run_with_service(&service, args)
 }
 
-/// Same dispatch as [`run`] but takes injected stores. Test seam for
-/// `FileSecretStore::with_dir(<tempdir>)` + `FileBindingStore::with_dir`.
-pub(in crate::commands) fn run_with_stores(
-    store: &dyn SecretStore,
-    bindings: &dyn BindingStore,
-    args: Args,
-) -> Result<()> {
-    let audit = AuditLog::default()?.with_optional_recorder();
+/// Same dispatch as [`run`] but takes an injected service. Test seam for a
+/// `SecretService` built over temp-dir stores.
+pub(in crate::commands) fn run_with_service(service: &SecretService, args: Args) -> Result<()> {
     match args.action {
         SecretAction::Put {
             name,
             tenant,
             value,
             value_file,
-        } => cmd_put(store, &audit, tenant, name, value, value_file),
+        } => cmd_put(service, tenant, name, value, value_file),
         SecretAction::Set {
             name,
             tenant,
@@ -195,13 +184,11 @@ pub(in crate::commands) fn run_with_stores(
             auth_type,
             aws_access_key_id,
             region,
-            service,
+            service: aws_service,
             value,
             value_file,
         } => cmd_set(
-            store,
-            bindings,
-            &audit,
+            service,
             SetArgs {
                 tenant,
                 name,
@@ -209,14 +196,14 @@ pub(in crate::commands) fn run_with_stores(
                 auth_type: auth_type.into(),
                 aws_access_key_id,
                 region,
-                service,
+                service: aws_service,
                 value,
                 value_file,
             },
         ),
-        SecretAction::Get { name, tenant } => cmd_get(store, &audit, tenant, name),
-        SecretAction::Ls { tenant } => cmd_ls(store, bindings, &audit, tenant),
-        SecretAction::Rm { name, tenant } => cmd_rm(store, bindings, &audit, tenant, name),
+        SecretAction::Get { name, tenant } => cmd_get(service, tenant, name),
+        SecretAction::Ls { tenant } => cmd_ls(service, tenant),
+        SecretAction::Rm { name, tenant } => cmd_rm(service, tenant, name),
     }
 }
 
@@ -225,21 +212,18 @@ pub(in crate::commands) fn run_with_stores(
 // ============================================================================
 
 fn cmd_put(
-    store: &dyn SecretStore,
-    audit: &AuditLog,
+    service: &SecretService,
     tenant: String,
     name: String,
     value: Option<String>,
     value_file: Option<PathBuf>,
 ) -> Result<()> {
-    let result = (|| {
-        let raw = resolve_value(value, value_file, &name)?;
-        let secret = SecretBox::new(Box::new(raw));
-        store.put(&tenant, &name, &secret)
-    })();
-    audit.record("put", &tenant, &name, &result)?;
-    result?;
-    eprintln!("Stored secret '{name}' for tenant '{tenant}'.");
+    let raw = resolve_value(value, value_file, &name)?;
+    let outcome = service.put(&tenant, &name, SecretValueInput::new(raw))?;
+    match outcome {
+        PutOutcome::Created => eprintln!("Stored secret '{name}' for tenant '{tenant}'."),
+        PutOutcome::Replaced => eprintln!("Replaced secret '{name}' for tenant '{tenant}'."),
+    }
     Ok(())
 }
 
@@ -257,12 +241,7 @@ struct SetArgs {
     value_file: Option<PathBuf>,
 }
 
-fn cmd_set(
-    store: &dyn SecretStore,
-    bindings: &dyn BindingStore,
-    audit: &AuditLog,
-    set: SetArgs,
-) -> Result<()> {
+fn cmd_set(service: &SecretService, set: SetArgs) -> Result<()> {
     let SetArgs {
         tenant,
         name,
@@ -270,32 +249,27 @@ fn cmd_set(
         auth_type,
         aws_access_key_id,
         region,
-        service,
+        service: aws_service,
         value,
         value_file,
     } = set;
-    let result = (|| -> Result<()> {
-        // Validate the SigV4 scope params against the auth-type BEFORE touching
-        // the store: `--type sigv4` requires all three; any of them is rejected
-        // for a non-sigv4 type (they'd be silently dropped otherwise).
-        let sigv4 = resolve_sigv4_params(auth_type, aws_access_key_id, region, service)?;
-        let raw = resolve_value(value, value_file, &name)?;
-        let secret = SecretBox::new(Box::new(raw));
-        store.put(&tenant, &name, &secret)?;
-        // Binding after value: if the value write fails we never record a
-        // binding for a secret that isn't there.
-        bindings.put(
-            &tenant,
-            &name,
-            &SecretBindingMeta {
-                auth_type,
-                allowed_hosts: hosts,
-                sigv4,
-            },
-        )
-    })();
-    audit.record("set", &tenant, &name, &result)?;
-    result?;
+    // Validate the SigV4 scope params against the auth-type BEFORE touching
+    // the store: `--type sigv4` requires all three; any of them is rejected
+    // for a non-sigv4 type (they'd be silently dropped otherwise).
+    let sigv4 = resolve_sigv4_params(auth_type, aws_access_key_id, region, aws_service)?;
+    let raw = resolve_value(value, value_file, &name)?;
+    service.put(&tenant, &name, SecretValueInput::new(raw))?;
+    // Binding after value: the service refuses to bind a secret with no
+    // stored value, so a failed value write never leaves a dangling binding.
+    service.bind(
+        &tenant,
+        &name,
+        SecretBindingMeta {
+            auth_type,
+            allowed_hosts: hosts,
+            sigv4,
+        },
+    )?;
     eprintln!("Defined secret '{name}' for tenant '{tenant}'.");
     Ok(())
 }
@@ -339,33 +313,29 @@ fn resolve_sigv4_params(
     }
 }
 
-fn cmd_get(store: &dyn SecretStore, audit: &AuditLog, tenant: String, name: String) -> Result<()> {
-    let result = store.get(&tenant, &name);
-    audit.record("get", &tenant, &name, &result.as_ref().map(|_| ()))?;
-    result?;
-    println!("Secret '{name}' is set for tenant '{tenant}'.");
-    Ok(())
+fn cmd_get(service: &SecretService, tenant: String, name: String) -> Result<()> {
+    // Presence check only — the service has no reveal path, so the value is
+    // never decrypted, let alone printed.
+    match service.metadata(&tenant, &name)? {
+        Some(_) => {
+            println!("Secret '{name}' is set for tenant '{tenant}'.");
+            Ok(())
+        }
+        None => anyhow::bail!("secret '{name}' is not set for tenant '{tenant}'"),
+    }
 }
 
-fn cmd_ls(
-    store: &dyn SecretStore,
-    bindings: &dyn BindingStore,
-    audit: &AuditLog,
-    tenant: String,
-) -> Result<()> {
-    let result = store.list(&tenant);
-    audit.record("list", &tenant, "*", &result.as_ref().map(|_| ()))?;
-    let names = result?;
-    if names.is_empty() {
+fn cmd_ls(service: &SecretService, tenant: String) -> Result<()> {
+    let rows = service.list(&tenant)?;
+    if rows.is_empty() {
         eprintln!("No secrets stored for tenant '{tenant}'.");
         return Ok(());
     }
-    for name in &names {
+    for row in &rows {
         // Name + (for bound secrets) auth-type and destination
         // allow-list. Never the value, and never anything value-derived:
         // the binding is operator-declared metadata.
-        let binding = bindings.get(&tenant, name)?;
-        println!("{}", ls_line(name, binding.as_ref()));
+        println!("{}", ls_line(&row.name, row.binding.as_ref()));
     }
     Ok(())
 }
@@ -405,19 +375,11 @@ fn auth_type_label(t: AuthType) -> &'static str {
     }
 }
 
-fn cmd_rm(
-    store: &dyn SecretStore,
-    bindings: &dyn BindingStore,
-    audit: &AuditLog,
-    tenant: String,
-    name: String,
-) -> Result<()> {
-    let result = store.delete(&tenant, &name);
-    audit.record("delete", &tenant, &name, &result)?;
-    result?;
-    // Drop the binding too so a re-`put` of the same name can't inherit a
-    // stale allow-list. Idempotent — absent binding is fine.
-    bindings.delete(&tenant, &name)?;
+fn cmd_rm(service: &SecretService, tenant: String, name: String) -> Result<()> {
+    // The service refuses while a persistent machine references the secret
+    // (fail closed; no force path) and drops the binding alongside the value
+    // so a re-`put` of the same name can't inherit a stale allow-list.
+    service.remove(&tenant, &name)?;
     eprintln!("Removed secret '{name}' for tenant '{tenant}'.");
     Ok(())
 }
@@ -470,268 +432,71 @@ fn read_secret_from_stdin() -> Result<String> {
     Ok(buf)
 }
 
-// ============================================================================
-// Audit log — minimal per-action JSONL stream
-// ============================================================================
-
-const AUDIT_FILENAME: &str = "secrets.jsonl";
-const SECRET_VISIBILITY_AUDIT_VALUE: &str = "write_only";
-const STORAGE_SECURITY_AUDIT_VALUE: &str = "encrypted_at_rest";
-
-/// Resolve `~/.mvm/audit/secrets.jsonl`. Falls back to a no-op log
-/// when `$HOME` is unset (CI sandboxes, daemons without a home dir)
-/// rather than failing the whole command — secret CRUD should keep
-/// working even when the audit destination is unreachable.
-///
-/// Dual-emit: when a [`Recorder`] is wired (via
-/// [`AuditLog::with_optional_recorder`]), every successful action
-/// also emits a chain-signed `secret.<verb>` entry through the
-/// chain-signed audit stream. The original JSONL stream stays — operators
-/// reading `~/.mvm/audit/secrets.jsonl` see the same shape; the Recorder
-/// is purely additive.
-pub(crate) struct AuditLog {
-    path: Option<PathBuf>,
-    recorder: Option<Recorder>,
-}
-
-impl AuditLog {
-    pub(crate) fn default() -> Result<Self> {
-        // No resolvable home root → no-op log (CI sandboxes, daemons
-        // without a home dir).
-        if mvm_core::config::mvm_home_strict().is_err() {
-            return Ok(Self {
-                path: None,
-                recorder: None,
-            });
-        }
-        let dir = mvm_core::config::mvm_audit_dir();
-        std::fs::create_dir_all(&dir)
-            .with_context(|| format!("creating audit dir {}", dir.display()))?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).ok();
-        }
-        Ok(Self {
-            path: Some(dir.join(AUDIT_FILENAME)),
-            recorder: None,
-        })
-    }
-
-    /// Best-effort: attach a Recorder backed by the host signer's
-    /// chain-signed audit stream. Failures (no `$HOME`, host signer
-    /// not initialized, loose perms) leave the recorder unset and
-    /// log a `tracing::warn` — secret CRUD continues to work; the
-    /// extra chain-signed entry just doesn't land.
-    pub(crate) fn with_optional_recorder(mut self) -> Self {
-        match build_secret_recorder() {
-            Ok(rec) => self.recorder = Some(rec),
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "plan 60 Phase 4 secret recorder not wired; \
-                     falling back to JSONL-only audit"
-                );
-            }
-        }
-        self
-    }
-
-    /// Test seam — write to an injected path.
-    #[cfg(test)]
-    pub(crate) fn with_path(path: PathBuf) -> Self {
-        Self {
-            path: Some(path),
-            recorder: None,
-        }
-    }
-
-    /// Test seam — inject both a path and a pre-built Recorder for
-    /// dual-emit testing.
-    #[cfg(test)]
-    pub(crate) fn with_path_and_recorder(path: PathBuf, recorder: Recorder) -> Self {
-        Self {
-            path: Some(path),
-            recorder: Some(recorder),
-        }
-    }
-
-    pub(crate) fn record<T, E>(
-        &self,
-        action: &str,
-        tenant: &str,
-        name: &str,
-        outcome: &std::result::Result<T, E>,
-    ) -> Result<()>
-    where
-        E: std::fmt::Display,
-    {
-        let (outcome_str, error) = match outcome {
-            Ok(_) => ("ok", None),
-            Err(e) => ("err", Some(e.to_string())),
-        };
-        if let Some(ref path) = self.path {
-            let entry = serde_json::json!({
-                "timestamp": Utc::now().to_rfc3339(),
-                "action": action,
-                "tenant": tenant,
-                "name": name,
-                "outcome": outcome_str,
-                "pid": std::process::id(),
-                "secret_visibility": SECRET_VISIBILITY_AUDIT_VALUE,
-                "storage_security": STORAGE_SECURITY_AUDIT_VALUE,
-                "error": error,
-            });
-            let mut line = serde_json::to_vec(&entry).context("serialize audit entry")?;
-            line.push(b'\n');
-            let mut f = std::fs::OpenOptions::new()
-                .append(true)
-                .create(true)
-                .open(path)
-                .with_context(|| format!("opening audit log {}", path.display()))?;
-            f.write_all(&line)
-                .with_context(|| format!("writing audit entry to {}", path.display()))?;
-        }
-        // Dual-emit through Recorder. Audit-side failures are
-        // surfaced as warnings, not propagated — operator-secret CRUD
-        // must not fail because the chain-signed stream is unreachable
-        // (matches `audit_chain::AuditEmitter`'s posture).
-        if let Some(ref rec) = self.recorder {
-            emit_through_recorder(rec, action, tenant, name, outcome_str, error.as_deref());
-        }
-        Ok(())
-    }
-}
-
-/// Build a Recorder backed by `FileAuditSigner` rooted at
-/// `~/.mvm/audit/`. The host signing key is read via
-/// `host_signer::load_or_init`; the default tenant the recorder uses
-/// for the unbound entry's required `tenant` field is `"local"` (matches
-/// the secret command's default tenant). The per-action tenant is
-/// captured in the entry's labels.
-fn build_secret_recorder() -> Result<Recorder> {
-    let signer = host_signer::load_or_init().context("loading host signer for secret recorder")?;
-    let audit_dir = default_audit_dir()?;
-    let file_signer = FileAuditSigner::open(signer.signing, &audit_dir)
-        .with_context(|| format!("opening FileAuditSigner at {}", audit_dir.display()))?;
-    Ok(Recorder::new(
-        Arc::new(file_signer),
-        TenantId("local".to_string()),
-    ))
-}
-
-fn emit_through_recorder(
-    recorder: &Recorder,
-    action: &str,
-    tenant: &str,
-    name: &str,
-    outcome: &str,
-    error: Option<&str>,
-) {
-    let event = format!("secret.{action}");
-    let mut extras: Vec<(String, String)> = vec![
-        ("tenant".to_string(), tenant.to_string()),
-        ("name".to_string(), name.to_string()),
-        ("outcome".to_string(), outcome.to_string()),
-        ("pid".to_string(), std::process::id().to_string()),
-        (
-            "secret_visibility".to_string(),
-            SECRET_VISIBILITY_AUDIT_VALUE.to_string(),
-        ),
-        (
-            "storage_security".to_string(),
-            STORAGE_SECURITY_AUDIT_VALUE.to_string(),
-        ),
-    ];
-    if let Some(err) = error {
-        extras.push(("error".to_string(), err.to_string()));
-    }
-    let rt = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(e) => {
-            tracing::warn!(error = %e, "building tokio runtime for secret audit emit");
-            return;
-        }
-    };
-    if let Err(e) = rt.block_on(recorder.record_unbound(EventCategory::Secret, event, extras)) {
-        tracing::warn!(
-            error = %e,
-            action = action,
-            "Recorder dual-emit failed for secret event"
-        );
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_client::secret::{MachineSecretRef, SecretAudit};
     use mvm_core::crypto::secret_store::FileSecretStore;
+    use mvm_hostd::keyholder::FileBindingStore;
+    use std::sync::Arc;
+    use tempfile::TempDir;
 
-    fn temp_audit() -> (tempfile::TempDir, AuditLog) {
+    struct Fixture {
+        _tmp: TempDir,
+        service: SecretService,
+        audit_path: PathBuf,
+        bindings_dir: PathBuf,
+        machines_root: PathBuf,
+    }
+
+    fn fixture() -> Fixture {
         let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("secrets.jsonl");
-        (tmp, AuditLog::with_path(path))
+        let bindings_dir = tmp.path().join("bindings");
+        let machines_root = tmp.path().join("machines");
+        let audit_path = tmp.path().join("secrets.jsonl");
+        let service = SecretService::builder()
+            .store(Arc::new(FileSecretStore::with_dir(
+                tmp.path().join("secrets"),
+            )))
+            .bindings(Arc::new(FileBindingStore::with_dir(&bindings_dir)))
+            .machines_root(machines_root.clone())
+            .audit(SecretAudit::with_path(audit_path.clone()))
+            .build()
+            .unwrap();
+        Fixture {
+            _tmp: tmp,
+            service,
+            audit_path,
+            bindings_dir,
+            machines_root,
+        }
     }
 
-    fn temp_bindings() -> (tempfile::TempDir, FileBindingStore) {
-        let tmp = tempfile::tempdir().unwrap();
-        let store = FileBindingStore::with_dir(tmp.path());
-        (tmp, store)
+    fn audit_text(f: &Fixture) -> String {
+        std::fs::read_to_string(&f.audit_path).unwrap_or_default()
     }
 
-    fn read_audit(audit: &AuditLog) -> String {
-        let path = audit.path.as_ref().expect("audit has path");
-        std::fs::read_to_string(path).unwrap_or_default()
-    }
-
-    // ──────────────────────────────────────────────────────────────
-    // Audit invariants
-    // ──────────────────────────────────────────────────────────────
-
-    #[test]
-    fn audit_log_records_put_action_with_tenant_and_name() {
-        let (_dir, audit) = temp_audit();
-        let res: Result<()> = Ok(());
-        audit.record("put", "acme", "api_token", &res).unwrap();
-        let log = read_audit(&audit);
-        assert!(log.contains("\"action\":\"put\""), "got: {log}");
-        assert!(log.contains("\"tenant\":\"acme\""));
-        assert!(log.contains("\"name\":\"api_token\""));
-        assert!(log.contains("\"outcome\":\"ok\""));
-        assert!(log.contains("\"secret_visibility\":\"write_only\""));
-        assert!(log.contains("\"storage_security\":\"encrypted_at_rest\""));
-    }
-
-    #[test]
-    fn audit_log_never_carries_value_field() {
-        // The audit entry shape must not include any field named
-        // `value` or similar — even on failure. If a future
-        // refactor accidentally adds the value to the entry, this
-        // test catches it.
-        let (_dir, audit) = temp_audit();
-        let res: Result<()> = Err(anyhow::anyhow!("boom"));
-        audit.record("put", "acme", "tok", &res).unwrap();
-        let log = read_audit(&audit);
-        assert!(!log.contains("\"value\""));
-        assert!(!log.contains("\"plaintext\""));
-        assert!(log.contains("\"outcome\":\"err\""));
-        assert!(log.contains("\"error\":\"boom\""));
-        assert!(log.contains("\"secret_visibility\":\"write_only\""));
-        assert!(log.contains("\"storage_security\":\"encrypted_at_rest\""));
-    }
-
-    #[test]
-    fn audit_log_includes_pid() {
-        let (_dir, audit) = temp_audit();
-        let res: Result<()> = Ok(());
-        audit.record("get", "acme", "tok", &res).unwrap();
-        let log = read_audit(&audit);
-        // pid is process id at time of record; just assert the
-        // field exists with a numeric value.
-        assert!(log.contains("\"pid\":"));
+    fn set(
+        f: &Fixture,
+        name: &str,
+        hosts: &[&str],
+        auth_type: AuthType,
+        value: &str,
+    ) -> Result<()> {
+        cmd_set(
+            &f.service,
+            SetArgs {
+                tenant: "local".into(),
+                name: name.into(),
+                hosts: hosts.iter().map(|h| h.to_string()).collect(),
+                auth_type,
+                aws_access_key_id: None,
+                region: None,
+                service: None,
+                value: Some(value.into()),
+                value_file: None,
+            },
+        )
     }
 
     // ──────────────────────────────────────────────────────────────
@@ -769,125 +534,49 @@ mod tests {
     }
 
     // ──────────────────────────────────────────────────────────────
-    // Subcommand handlers — happy paths
+    // Subcommand handlers over the service
     //
     // `cmd_get` is intentionally a presence check only: it verifies
-    // the entry exists but never exposes the raw value.
+    // the entry exists but never exposes the raw value (the service
+    // has no reveal path to call).
     // ──────────────────────────────────────────────────────────────
 
     #[test]
     fn cmd_put_then_ls_shows_name() {
-        let tmp_store = tempfile::tempdir().unwrap();
-        let store = FileSecretStore::with_dir(tmp_store.path());
-        let (_audit_dir, audit) = temp_audit();
+        let f = fixture();
         cmd_put(
-            &store,
-            &audit,
+            &f.service,
             "acme".into(),
             "api_token".into(),
             Some("secret-xyz".into()),
             None,
         )
         .unwrap();
-        let names = store.list("acme").unwrap();
-        assert_eq!(names, vec!["api_token"]);
+        let rows = f.service.list("acme").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "api_token");
     }
 
     #[test]
     fn cmd_rm_after_put_clears_name() {
-        let tmp_store = tempfile::tempdir().unwrap();
-        let store = FileSecretStore::with_dir(tmp_store.path());
-        let (_bind_dir, bindings) = temp_bindings();
-        let (_audit_dir, audit) = temp_audit();
+        let f = fixture();
         cmd_put(
-            &store,
-            &audit,
+            &f.service,
             "acme".into(),
             "k".into(),
             Some("v".into()),
             None,
         )
         .unwrap();
-        cmd_rm(&store, &bindings, &audit, "acme".into(), "k".into()).unwrap();
-        assert!(store.list("acme").unwrap().is_empty());
-    }
-
-    // ──────────────────────────────────────────────────────────────
-    // `secret set` (value + egress binding) and `ls`
-    // ──────────────────────────────────────────────────────────────
-
-    fn set(
-        store: &dyn SecretStore,
-        bindings: &dyn BindingStore,
-        audit: &AuditLog,
-        name: &str,
-        hosts: &[&str],
-        auth_type: AuthType,
-        value: &str,
-    ) -> Result<()> {
-        cmd_set(
-            store,
-            bindings,
-            audit,
-            SetArgs {
-                tenant: "local".into(),
-                name: name.into(),
-                hosts: hosts.iter().map(|h| h.to_string()).collect(),
-                auth_type,
-                aws_access_key_id: None,
-                region: None,
-                service: None,
-                value: Some(value.into()),
-                value_file: None,
-            },
-        )
-    }
-
-    /// The injected stores + audit log a `set` test threads through — grouped
-    /// so the SigV4 helper stays under the argument-count lint.
-    struct SetCtx<'a> {
-        store: &'a dyn SecretStore,
-        bindings: &'a dyn BindingStore,
-        audit: &'a AuditLog,
-    }
-
-    /// Like [`set`] but for a SigV4 secret: passes the scope params through.
-    fn set_sigv4(
-        ctx: SetCtx<'_>,
-        name: &str,
-        hosts: &[&str],
-        params: Sigv4Params,
-        value: &str,
-    ) -> Result<()> {
-        cmd_set(
-            ctx.store,
-            ctx.bindings,
-            ctx.audit,
-            SetArgs {
-                tenant: "local".into(),
-                name: name.into(),
-                hosts: hosts.iter().map(|h| h.to_string()).collect(),
-                auth_type: AuthType::Sigv4,
-                aws_access_key_id: Some(params.access_key_id),
-                region: Some(params.region),
-                service: Some(params.service),
-                value: Some(value.into()),
-                value_file: None,
-            },
-        )
+        cmd_rm(&f.service, "acme".into(), "k".into()).unwrap();
+        assert!(f.service.list("acme").unwrap().is_empty());
     }
 
     #[test]
     fn cmd_set_stores_value_and_binding_without_leaking_value() {
-        let tmp_store = tempfile::tempdir().unwrap();
-        let store = FileSecretStore::with_dir(tmp_store.path());
-        let (bind_dir, bindings) = temp_bindings();
-        let (_audit_dir, audit) = temp_audit();
-
+        let f = fixture();
         set(
-            &store,
-            &bindings,
-            &audit,
+            &f,
             "openai",
             &["api.openai.com"],
             AuthType::Bearer,
@@ -895,57 +584,53 @@ mod tests {
         )
         .unwrap();
 
-        // Value landed in the value store.
-        assert_eq!(store.list("local").unwrap(), vec!["openai"]);
-        // Binding landed with type + hosts.
-        let b = bindings.get("local", "openai").unwrap().unwrap();
-        assert_eq!(b.auth_type, AuthType::Bearer);
-        assert_eq!(b.allowed_hosts, vec!["api.openai.com"]);
+        // Value + binding both landed.
+        let rows = f.service.list("local").unwrap();
+        assert_eq!(rows.len(), 1);
+        let binding = rows[0].binding.as_ref().expect("binding recorded");
+        assert_eq!(binding.auth_type, AuthType::Bearer);
+        assert_eq!(binding.allowed_hosts, vec!["api.openai.com"]);
         // The binding sidecar carries metadata only — never the value.
         let sidecar =
-            std::fs::read_to_string(bind_dir.path().join("local").join("openai.json")).unwrap();
+            std::fs::read_to_string(f.bindings_dir.join("local").join("openai.json")).unwrap();
         assert!(
             !sidecar.contains("sk-live-zzz"),
             "binding sidecar must not contain the secret value: {sidecar}"
         );
+        // Neither does the audit stream.
+        assert!(!audit_text(&f).contains("sk-live-zzz"));
     }
 
     #[test]
     fn cmd_set_sigv4_stores_params_in_binding_not_value_in_sidecar() {
-        let tmp_store = tempfile::tempdir().unwrap();
-        let store = FileSecretStore::with_dir(tmp_store.path());
-        let (bind_dir, bindings) = temp_bindings();
-        let (_audit_dir, audit) = temp_audit();
-
-        set_sigv4(
-            SetCtx {
-                store: &store,
-                bindings: &bindings,
-                audit: &audit,
+        let f = fixture();
+        cmd_set(
+            &f.service,
+            SetArgs {
+                tenant: "local".into(),
+                name: "aws".into(),
+                hosts: vec!["s3.us-east-1.amazonaws.com".into()],
+                auth_type: AuthType::Sigv4,
+                aws_access_key_id: Some("AKIAIOSFODNN7EXAMPLE".into()),
+                region: Some("us-east-1".into()),
+                service: Some("s3".into()),
+                // The secret-access-key is the stored value.
+                value: Some("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into()),
+                value_file: None,
             },
-            "aws",
-            &["s3.us-east-1.amazonaws.com"],
-            Sigv4Params {
-                access_key_id: "AKIAIOSFODNN7EXAMPLE".into(),
-                region: "us-east-1".into(),
-                service: "s3".into(),
-            },
-            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", // the secret-access-key
         )
         .unwrap();
 
-        // The value (secret-access-key) landed in the value store.
-        assert_eq!(store.list("local").unwrap(), vec!["aws"]);
-        // The binding carries the non-secret scope params.
-        let b = bindings.get("local", "aws").unwrap().unwrap();
-        assert_eq!(b.auth_type, AuthType::Sigv4);
-        let params = b.sigv4.expect("sigv4 params stored");
+        let rows = f.service.list("local").unwrap();
+        let binding = rows[0].binding.as_ref().expect("binding recorded");
+        assert_eq!(binding.auth_type, AuthType::Sigv4);
+        let params = binding.sigv4.as_ref().expect("sigv4 params stored");
         assert_eq!(params.access_key_id, "AKIAIOSFODNN7EXAMPLE");
         assert_eq!(params.region, "us-east-1");
         assert_eq!(params.service, "s3");
         // The secret-access-key (the signing key) never lands in the sidecar.
         let sidecar =
-            std::fs::read_to_string(bind_dir.path().join("local").join("aws.json")).unwrap();
+            std::fs::read_to_string(f.bindings_dir.join("local").join("aws.json")).unwrap();
         assert!(
             !sidecar.contains("wJalrXUtnFEMI"),
             "binding sidecar must not carry the secret-access-key: {sidecar}"
@@ -1039,40 +724,68 @@ mod tests {
 
     #[test]
     fn cmd_rm_removes_binding_too() {
-        let tmp_store = tempfile::tempdir().unwrap();
-        let store = FileSecretStore::with_dir(tmp_store.path());
-        let (_bind_dir, bindings) = temp_bindings();
-        let (_audit_dir, audit) = temp_audit();
+        let f = fixture();
         set(
-            &store,
-            &bindings,
-            &audit,
+            &f,
             "openai",
             &["api.openai.com"],
             AuthType::Bearer,
             "sk-live-zzz",
         )
         .unwrap();
-        cmd_rm(&store, &bindings, &audit, "local".into(), "openai".into()).unwrap();
-        assert!(bindings.get("local", "openai").unwrap().is_none());
+        cmd_rm(&f.service, "local".into(), "openai".into()).unwrap();
+        assert!(f.service.metadata("local", "openai").unwrap().is_none());
+    }
+
+    #[test]
+    fn cmd_rm_refused_while_a_machine_references_the_secret() {
+        let f = fixture();
+        cmd_put(
+            &f.service,
+            "local".into(),
+            "openai".into(),
+            Some("sk-live-zzz".into()),
+            None,
+        )
+        .unwrap();
+        // A persistent machine (spec on disk) declares a reference.
+        let machine_dir = f.machines_root.join("web");
+        std::fs::create_dir_all(&machine_dir).unwrap();
+        std::fs::write(machine_dir.join("machine.json"), b"{}").unwrap();
+        f.service
+            .record_machine_references(
+                "web",
+                &[MachineSecretRef {
+                    tenant: "local".into(),
+                    name: "openai".into(),
+                    placeholder_var: Some("OPENAI_API_KEY".into()),
+                    destinations: vec!["api.openai.com".into()],
+                }],
+            )
+            .unwrap();
+
+        let err = cmd_rm(&f.service, "local".into(), "openai".into()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("web"), "refusal names the machine: {msg}");
+        assert!(!msg.contains("sk-live-zzz"), "refusal must not leak: {msg}");
+        // Value survives; refusal is audited.
+        assert_eq!(f.service.list("local").unwrap().len(), 1);
+        assert!(audit_text(&f).contains("\"action\":\"remove_refused\""));
     }
 
     #[test]
     fn cmd_get_checks_presence_without_returning_secret() {
-        let tmp_store = tempfile::tempdir().unwrap();
-        let store = FileSecretStore::with_dir(tmp_store.path());
-        let (_audit_dir, audit) = temp_audit();
+        let f = fixture();
         cmd_put(
-            &store,
-            &audit,
+            &f.service,
             "acme".into(),
             "api_token".into(),
             Some("secret-xyz".into()),
             None,
         )
         .unwrap();
-        cmd_get(&store, &audit, "acme".into(), "api_token".into()).unwrap();
-        let log = read_audit(&audit);
+        cmd_get(&f.service, "acme".into(), "api_token".into()).unwrap();
+        let log = audit_text(&f);
         assert!(log.contains("\"action\":\"get\""), "got: {log}");
         assert!(
             !log.contains("secret-xyz"),
@@ -1081,16 +794,20 @@ mod tests {
     }
 
     #[test]
+    fn cmd_get_missing_secret_is_an_error() {
+        let f = fixture();
+        let err = cmd_get(&f.service, "acme".into(), "absent".into()).unwrap_err();
+        assert!(err.to_string().contains("not set"), "got: {err}");
+    }
+
+    #[test]
     fn cmd_put_with_unsafe_tenant_id_records_audit_failure() {
         // `mvmctl secret put --tenant ../etc` must be rejected by
         // validate_shell_id before the secret hits disk, AND the
         // audit log must capture the rejection.
-        let tmp_store = tempfile::tempdir().unwrap();
-        let store = FileSecretStore::with_dir(tmp_store.path());
-        let (_audit_dir, audit) = temp_audit();
+        let f = fixture();
         let err = cmd_put(
-            &store,
-            &audit,
+            &f.service,
             "../etc".into(),
             "k".into(),
             Some("v".into()),
@@ -1101,133 +818,8 @@ mod tests {
             err.to_string().contains("Invalid tenant_id")
                 || err.to_string().contains("alphanumeric")
         );
-        let log = read_audit(&audit);
+        let log = audit_text(&f);
         assert!(log.contains("\"outcome\":\"err\""));
         assert!(log.contains("\"tenant\":\"../etc\""));
-    }
-
-    // ──────────────────────────────────────────────────────────────
-    // Recorder dual-emit
-    //
-    // When a Recorder is wired, AuditLog::record additionally emits
-    // a chain-signed `secret.<verb>` entry through the unified
-    // EventCategory::Secret stream. Existing JSONL contract is
-    // unchanged.
-    // ──────────────────────────────────────────────────────────────
-
-    use mvm_hostd::supervisor::CapturingAuditSigner;
-
-    fn temp_audit_with_recorder() -> (
-        tempfile::TempDir,
-        AuditLog,
-        std::sync::Arc<CapturingAuditSigner>,
-    ) {
-        let tmp = tempfile::tempdir().unwrap();
-        let jsonl_path = tmp.path().join("secrets.jsonl");
-        let signer = std::sync::Arc::new(CapturingAuditSigner::new());
-        let recorder = Recorder::new(signer.clone(), TenantId("local".to_string()));
-        (
-            tmp,
-            AuditLog::with_path_and_recorder(jsonl_path, recorder),
-            signer,
-        )
-    }
-
-    #[test]
-    fn record_with_recorder_dual_emits_to_jsonl_and_chain() {
-        // Both sinks fire on a single record() call: the original
-        // JSONL stream keeps its shape, and the Recorder's
-        // chain-signed envelope carries the secret.<verb> event.
-        let (_dir, audit, signer) = temp_audit_with_recorder();
-        let res: Result<()> = Ok(());
-        audit.record("put", "acme", "api_token", &res).unwrap();
-
-        // JSONL stream — preserved verbatim.
-        let log = read_audit(&audit);
-        assert!(log.contains("\"action\":\"put\""), "got: {log}");
-        assert!(log.contains("\"tenant\":\"acme\""));
-        assert!(log.contains("\"secret_visibility\":\"write_only\""));
-        assert!(log.contains("\"storage_security\":\"encrypted_at_rest\""));
-
-        // Recorder stream — entry carries the
-        // canonical `secret.put` event name and per-action tenant
-        // in labels (the entry's `tenant` field is the recorder's
-        // default).
-        let entries = signer.entries();
-        assert_eq!(entries.len(), 1, "expected one Recorder entry");
-        assert_eq!(entries[0].event, "secret.put");
-        assert_eq!(entries[0].labels.get("tenant"), Some(&"acme".to_string()));
-        assert_eq!(
-            entries[0].labels.get("name"),
-            Some(&"api_token".to_string())
-        );
-        assert_eq!(entries[0].labels.get("outcome"), Some(&"ok".to_string()));
-        assert_eq!(
-            entries[0].labels.get("secret_visibility"),
-            Some(&"write_only".to_string())
-        );
-        assert_eq!(
-            entries[0].labels.get("storage_security"),
-            Some(&"encrypted_at_rest".to_string())
-        );
-        // category label is injected by the Recorder substrate.
-        assert_eq!(
-            entries[0].labels.get("category"),
-            Some(&"secret".to_string())
-        );
-        // No value leaks into the chain entry — same posture as
-        // the JSONL stream.
-        assert!(!entries[0].labels.values().any(|v| v.contains("plaintext")));
-    }
-
-    #[test]
-    fn record_with_recorder_carries_error_label_on_failure() {
-        let (_dir, audit, signer) = temp_audit_with_recorder();
-        let res: Result<()> = Err(anyhow::anyhow!("boom"));
-        audit.record("get", "acme", "tok", &res).unwrap();
-
-        let entries = signer.entries();
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].event, "secret.get");
-        assert_eq!(entries[0].labels.get("outcome"), Some(&"err".to_string()));
-        assert_eq!(entries[0].labels.get("error"), Some(&"boom".to_string()));
-        assert_eq!(
-            entries[0].labels.get("secret_visibility"),
-            Some(&"write_only".to_string())
-        );
-        assert_eq!(
-            entries[0].labels.get("storage_security"),
-            Some(&"encrypted_at_rest".to_string())
-        );
-    }
-
-    #[test]
-    fn record_without_recorder_only_writes_jsonl() {
-        // Default `temp_audit()` path leaves recorder=None. The
-        // chain stream must NOT be touched.
-        let (_dir, audit) = temp_audit();
-        let res: Result<()> = Ok(());
-        audit.record("put", "acme", "k", &res).unwrap();
-        // Sanity: the JSONL still has the entry.
-        assert!(read_audit(&audit).contains("\"action\":\"put\""));
-        // No way to inspect a chain we never wired — the absence is
-        // the contract. The signer field on AuditLog is None.
-        assert!(audit.recorder.is_none());
-    }
-
-    #[test]
-    fn record_with_recorder_emits_all_four_verbs() {
-        let (_dir, audit, signer) = temp_audit_with_recorder();
-        let ok: Result<()> = Ok(());
-        audit.record("put", "acme", "k", &ok).unwrap();
-        audit.record("get", "acme", "k", &ok).unwrap();
-        audit.record("list", "acme", "*", &ok).unwrap();
-        audit.record("delete", "acme", "k", &ok).unwrap();
-
-        let events: Vec<String> = signer.entries().iter().map(|e| e.event.clone()).collect();
-        assert_eq!(
-            events,
-            vec!["secret.put", "secret.get", "secret.list", "secret.delete"]
-        );
     }
 }

--- a/crates/mvm-client/Cargo.toml
+++ b/crates/mvm-client/Cargo.toml
@@ -67,6 +67,11 @@ hex = { workspace = true }
 tar = { workspace = true }
 chrono = { workspace = true }
 ext4-view = { workspace = true }
+# The write-only secret lifecycle service (`secret` module): typed refusals
+# (thiserror) and the `host_matches` destination check (mvm-protocol); the
+# shared serde/secrecy/chrono entries above serve it too.
+mvm-protocol = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 mvm-core = { workspace = true, features = ["test-support"] }

--- a/crates/mvm-client/src/secret.rs
+++ b/crates/mvm-client/src/secret.rs
@@ -230,18 +230,32 @@ impl SecretService {
     }
 
     /// Non-secret metadata for one secret, or `None` when it doesn't exist.
+    ///
+    /// Audit fidelity: a present secret records outcome `ok`, an absent one
+    /// records `miss`, and a store/row failure records `err` — so probes for
+    /// absent secrets are distinguishable from hits and from storage faults.
     pub fn metadata(
         &self,
         tenant: &str,
         name: &str,
     ) -> Result<Option<SecretMetadata>, SecretServiceError> {
-        let exists = self.secret_exists(tenant, name);
-        self.audit
-            .record("get", tenant, name, &Ok::<(), anyhow::Error>(()))?;
-        if !exists {
-            return Ok(None);
+        let result = (|| -> Result<Option<SecretMetadata>, SecretServiceError> {
+            if !self.secret_exists(tenant, name)? {
+                return Ok(None);
+            }
+            self.metadata_row(tenant, name).map(Some)
+        })();
+        match &result {
+            Ok(Some(_)) => self.audit.record_outcome("get", tenant, name, "ok", None)?,
+            Ok(None) => self
+                .audit
+                .record_outcome("get", tenant, name, "miss", None)?,
+            Err(e) => {
+                self.audit
+                    .record_outcome("get", tenant, name, "err", Some(&e.to_string()))?
+            }
         }
-        self.metadata_row(tenant, name).map(Some)
+        result
     }
 
     fn metadata_row(&self, tenant: &str, name: &str) -> Result<SecretMetadata, SecretServiceError> {
@@ -266,7 +280,17 @@ impl SecretService {
         name: &str,
         value: SecretValueInput,
     ) -> Result<PutOutcome, SecretServiceError> {
-        let existed = self.secret_exists(tenant, name);
+        // A store failure here must surface, not silently mislabel a replace
+        // as a create; the failed attempt is still audited (labeled `create`,
+        // since the prior state is unknowable when the store can't be read).
+        let existed = match self.secret_exists(tenant, name) {
+            Ok(existed) => existed,
+            Err(e) => {
+                self.audit
+                    .record("create", tenant, name, &Err::<(), _>(&e))?;
+                return Err(e);
+            }
+        };
         let action = if existed { "replace" } else { "create" };
         let result = self.store.put(tenant, name, value.storage_value());
         // Consume the input now: the plaintext is zeroized here, immediately
@@ -318,7 +342,7 @@ impl SecretService {
         meta: SecretBindingMeta,
     ) -> Result<(), SecretServiceError> {
         let result = (|| -> Result<(), SecretServiceError> {
-            if !self.secret_exists(tenant, name) {
+            if !self.secret_exists(tenant, name)? {
                 return Err(SecretServiceError::MissingSecret {
                     tenant: tenant.to_string(),
                     name: name.to_string(),
@@ -386,7 +410,7 @@ impl SecretService {
                     name: r.name.clone(),
                 });
             }
-            if !self.secret_exists(&r.tenant, &r.name) {
+            if !self.secret_exists(&r.tenant, &r.name)? {
                 return Err(SecretServiceError::MissingSecret {
                     tenant: r.tenant.clone(),
                     name: r.name.clone(),
@@ -419,11 +443,12 @@ impl SecretService {
     // ── Internals ─────────────────────────────────────────────────────
 
     /// Presence check via enumeration — never decrypts or touches a value.
-    fn secret_exists(&self, tenant: &str, name: &str) -> bool {
-        self.store
-            .list(tenant)
-            .map(|names| names.iter().any(|n| n == name))
-            .unwrap_or(false)
+    /// A store failure propagates rather than reading as "absent": treating
+    /// an IO error as `false` would let `get` claim a stored secret is not
+    /// set and let `put` mislabel a replace as a create.
+    fn secret_exists(&self, tenant: &str, name: &str) -> Result<bool, SecretServiceError> {
+        let names = self.store.list(tenant)?;
+        Ok(names.iter().any(|n| n == name))
     }
 }
 
@@ -753,9 +778,119 @@ mod tests {
     }
 
     #[test]
-    fn metadata_for_missing_secret_is_none() {
+    fn metadata_for_missing_secret_is_none_and_audited_as_miss() {
         let f = fixture();
         assert!(f.service.metadata("local", "absent").unwrap().is_none());
+        // A probe for an absent secret is distinguishable in the audit
+        // stream: outcome `miss`, not `ok`.
+        let log = audit_text(&f);
+        assert!(log.contains("\"action\":\"get\""), "got: {log}");
+        assert!(log.contains("\"outcome\":\"miss\""), "got: {log}");
+        assert!(!log.contains("\"outcome\":\"ok\""), "got: {log}");
+    }
+
+    #[test]
+    fn metadata_hit_is_audited_as_ok() {
+        let f = fixture();
+        f.service
+            .put("local", "openai", SecretValueInput::new("sk".into()))
+            .unwrap();
+        f.service.metadata("local", "openai").unwrap().unwrap();
+        let last = audit_text(&f).lines().last().unwrap().to_string();
+        assert!(last.contains("\"action\":\"get\""), "got: {last}");
+        assert!(last.contains("\"outcome\":\"ok\""), "got: {last}");
+    }
+
+    // ── Store-failure propagation ─────────────────────────────────────
+
+    /// A value store whose every operation fails, standing in for an
+    /// unreachable keyring or unreadable secrets dir.
+    struct FailingStore;
+
+    impl SecretStore for FailingStore {
+        fn put(
+            &self,
+            _tenant: &str,
+            _name: &str,
+            _value: &secrecy::SecretBox<String>,
+        ) -> anyhow::Result<()> {
+            anyhow::bail!("store offline")
+        }
+        fn get(&self, _tenant: &str, _name: &str) -> anyhow::Result<secrecy::SecretBox<String>> {
+            anyhow::bail!("store offline")
+        }
+        fn delete(&self, _tenant: &str, _name: &str) -> anyhow::Result<()> {
+            anyhow::bail!("store offline")
+        }
+        fn list(&self, _tenant: &str) -> anyhow::Result<Vec<String>> {
+            anyhow::bail!("store offline")
+        }
+    }
+
+    fn failing_fixture() -> Fixture {
+        let tmp = tempfile::tempdir().unwrap();
+        let bindings_dir = tmp.path().join("bindings");
+        let machines_root = tmp.path().join("machines");
+        let audit_path = tmp.path().join("secrets.jsonl");
+        let service = SecretService::builder()
+            .store(Arc::new(FailingStore))
+            .bindings(Arc::new(FileBindingStore::with_dir(&bindings_dir)))
+            .machines_root(machines_root.clone())
+            .audit(SecretAudit::with_path(audit_path.clone()))
+            .build()
+            .unwrap();
+        Fixture {
+            _tmp: tmp,
+            service,
+            audit_path,
+            bindings_dir,
+            machines_root,
+        }
+    }
+
+    #[test]
+    fn metadata_store_error_propagates_instead_of_reading_as_absent() {
+        // An IO failure must not make a probe claim "not set".
+        let f = failing_fixture();
+        let err = f.service.metadata("local", "openai").unwrap_err();
+        assert!(err.to_string().contains("store offline"), "got: {err}");
+        let log = audit_text(&f);
+        assert!(log.contains("\"action\":\"get\""), "got: {log}");
+        assert!(log.contains("\"outcome\":\"err\""), "got: {log}");
+        assert!(!log.contains("\"outcome\":\"miss\""), "got: {log}");
+    }
+
+    #[test]
+    fn put_store_error_on_existence_check_propagates_and_is_audited() {
+        // The prior state is unknowable when the store can't be read, so the
+        // attempt fails (never a silently mislabeled create/replace) and the
+        // failure lands in the audit stream.
+        let f = failing_fixture();
+        let err = f
+            .service
+            .put("local", "openai", SecretValueInput::new("sk".into()))
+            .unwrap_err();
+        assert!(err.to_string().contains("store offline"), "got: {err}");
+        let log = audit_text(&f);
+        assert!(log.contains("\"action\":\"create\""), "got: {log}");
+        assert!(log.contains("\"outcome\":\"err\""), "got: {log}");
+        assert!(!log.contains("\"sk\""), "no value in audit: {log}");
+    }
+
+    #[test]
+    fn bind_store_error_fails_closed() {
+        // A store failure during the existence check refuses the binding
+        // rather than admitting or misreporting a missing secret.
+        let f = failing_fixture();
+        let err = f
+            .service
+            .bind("local", "openai", bearer_binding(&["api.openai.com"]))
+            .unwrap_err();
+        assert!(matches!(err, SecretServiceError::Storage(_)), "got: {err}");
+        assert!(
+            !f.bindings_dir.join("local").join("openai.json").exists(),
+            "no binding may land when the store is unreadable"
+        );
     }
 
     // ── Admission validation ──────────────────────────────────────────

--- a/crates/mvm-client/src/secret.rs
+++ b/crates/mvm-client/src/secret.rs
@@ -3,3 +3,924 @@
 //! Composes `SecretStore`, binding metadata, reference checks, and audit
 //! emission behind one canonical service. The service exposes metadata
 //! only — no reveal path, no serializable type carrying secret material.
+//!
+//! ## Write-only contract
+//!
+//! Values go in as [`SecretValueInput`] (redacted `Debug`, zeroize-on-drop,
+//! no accessor outside this crate) and never come back out: there is no
+//! method that returns, prints, serializes, or logs a stored value. Every
+//! read-shaped operation ([`SecretService::list`],
+//! [`SecretService::metadata`], [`SecretService::references`]) returns
+//! names, auth types, destination allow-lists, reference metadata, and
+//! timestamps only. Guests receive opaque placeholders; the host-side
+//! egress substitution path is the only place a value is resolved.
+//!
+//! ## Composition
+//!
+//! - Values: [`mvm_core::crypto::secret_store::SecretStore`] (OS keyring
+//!   preferred, encrypted file store everywhere else — the existing
+//!   backend selection and migration behavior is reused verbatim).
+//! - Bindings: [`mvm_hostd::keyholder::BindingStore`] — the auth-type +
+//!   destination allow-list the egress proxy enforces.
+//! - References: [`refs`] — per-machine sidecars naming which secrets a
+//!   persistent machine uses (metadata only, never values).
+//! - Audit: [`SecretAudit`] — JSONL + best-effort chain-signed entries for
+//!   create, replace, bind, unbind, remove, and refusals.
+//!
+//! ## Fail-closed posture
+//!
+//! [`SecretService::remove`] refuses while any existing persistent machine
+//! references the secret. [`SecretService::validate_for_admission`] fails
+//! closed on missing secrets, missing or malformed bindings, destinations
+//! outside the binding allow-list, and cross-scope references.
+
+pub mod audit;
+pub mod input;
+pub mod refs;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Context;
+use mvm_core::crypto::secret_store::{self, SecretStore};
+use mvm_hostd::keyholder::{BindingStore, FileBindingStore};
+use mvm_protocol::ir::host_matches;
+use serde::Serialize;
+
+pub use audit::SecretAudit;
+pub use input::SecretValueInput;
+pub use mvm_hostd::keyholder::SecretBindingMeta;
+pub use mvm_protocol::ir::{AuthType, Sigv4Params};
+pub use refs::{MachineSecretRef, MachineSecretRefSet};
+
+/// Typed refusals and failures for secret lifecycle operations. Never
+/// carries secret material — every variant names scopes, names, hosts,
+/// and machines only.
+#[derive(Debug, thiserror::Error)]
+pub enum SecretServiceError {
+    #[error("secret '{name}' does not exist in scope '{tenant}'")]
+    MissingSecret { tenant: String, name: String },
+    #[error(
+        "secret '{name}' in scope '{tenant}' has no egress binding; \
+         bind it to a destination and auth type first"
+    )]
+    MissingBinding { tenant: String, name: String },
+    #[error("invalid binding for secret '{name}' in scope '{tenant}': {reason}")]
+    InvalidBinding {
+        tenant: String,
+        name: String,
+        reason: String,
+    },
+    #[error(
+        "destination '{destination}' is not in the allow-list bound to \
+         secret '{name}' in scope '{tenant}'"
+    )]
+    UnauthorizedDestination {
+        tenant: String,
+        name: String,
+        destination: String,
+    },
+    #[error(
+        "machine scope '{machine_tenant}' cannot reference secret '{name}' \
+         in scope '{secret_tenant}' (cross-scope references are refused)"
+    )]
+    CrossScope {
+        machine_tenant: String,
+        secret_tenant: String,
+        name: String,
+    },
+    #[error(
+        "refusing to remove secret '{name}' in scope '{tenant}': still \
+         referenced by persistent machine(s) {machines:?}; remove or update \
+         those machines first"
+    )]
+    ReferencedByMachines {
+        tenant: String,
+        name: String,
+        machines: Vec<String>,
+    },
+    #[error(transparent)]
+    Storage(#[from] anyhow::Error),
+}
+
+/// Whether a [`SecretService::put`] created a new secret or replaced an
+/// existing value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PutOutcome {
+    Created,
+    Replaced,
+}
+
+/// Non-secret description of one stored secret: name, scope, egress binding
+/// (auth type + destination allow-list + SigV4 scope), and the persistent
+/// machines that reference it. Serializable for UI consumption because it is
+/// structurally incapable of carrying a value.
+// allow(secret-debug): metadata only — name, scope, binding policy, and
+// referencing machine names. The value lives in `SecretStore` and no field
+// here can hold it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SecretMetadata {
+    pub tenant: String,
+    pub name: String,
+    /// Egress binding, when one is recorded. `None` for value-only secrets.
+    pub binding: Option<SecretBindingMeta>,
+    /// Names of existing persistent machines referencing this secret.
+    pub referenced_by: Vec<String>,
+}
+
+/// Builder for [`SecretService`]. Unset seams fall back to the production
+/// defaults (default store selection, `~/.mvm/secret-bindings/`,
+/// `~/.mvm/machines/`, no audit sink).
+#[derive(Default)]
+pub struct SecretServiceBuilder {
+    store: Option<Arc<dyn SecretStore>>,
+    bindings: Option<Arc<dyn BindingStore>>,
+    machines_root: Option<PathBuf>,
+    audit: Option<SecretAudit>,
+}
+
+impl SecretServiceBuilder {
+    pub fn store(mut self, store: Arc<dyn SecretStore>) -> Self {
+        self.store = Some(store);
+        self
+    }
+
+    pub fn bindings(mut self, bindings: Arc<dyn BindingStore>) -> Self {
+        self.bindings = Some(bindings);
+        self
+    }
+
+    pub fn machines_root(mut self, root: PathBuf) -> Self {
+        self.machines_root = Some(root);
+        self
+    }
+
+    pub fn audit(mut self, audit: SecretAudit) -> Self {
+        self.audit = Some(audit);
+        self
+    }
+
+    /// Finish the build, filling unset seams with production defaults.
+    /// The default audit sink is disabled — use [`SecretService::local`]
+    /// for the fully wired local service.
+    pub fn build(self) -> Result<SecretService, SecretServiceError> {
+        let store = match self.store {
+            Some(s) => s,
+            None => Arc::from(secret_store::default_secret_store()),
+        };
+        let bindings: Arc<dyn BindingStore> = match self.bindings {
+            Some(b) => b,
+            None => Arc::new(
+                FileBindingStore::default_location().context("resolving binding store location")?,
+            ),
+        };
+        let machines_root = self
+            .machines_root
+            .unwrap_or_else(mvm_core::config::machine_state_root);
+        let audit = self.audit.unwrap_or_else(SecretAudit::disabled);
+        Ok(SecretService {
+            store,
+            bindings,
+            machines_root,
+            audit,
+        })
+    }
+}
+
+/// The canonical local secret lifecycle service. One instance fronts value
+/// storage, egress bindings, machine references, and audit for every local
+/// consumer (CLI, studio, SDKs).
+pub struct SecretService {
+    store: Arc<dyn SecretStore>,
+    bindings: Arc<dyn BindingStore>,
+    machines_root: PathBuf,
+    audit: SecretAudit,
+}
+
+impl SecretService {
+    /// The fully wired local service: default stores (honoring `MVM_HOME`
+    /// and the keyring/file selection), JSONL audit at
+    /// `~/.mvm/audit/secrets.jsonl`, and a best-effort chain recorder.
+    pub fn local() -> Result<Self, SecretServiceError> {
+        Self::builder()
+            .audit(
+                SecretAudit::default_local()
+                    .context("resolving secret audit sink")?
+                    .with_recorder_best_effort(),
+            )
+            .build()
+    }
+
+    pub fn builder() -> SecretServiceBuilder {
+        SecretServiceBuilder::default()
+    }
+
+    // ── Metadata reads ────────────────────────────────────────────────
+
+    /// Non-secret metadata for every secret in `tenant`, sorted by name.
+    pub fn list(&self, tenant: &str) -> Result<Vec<SecretMetadata>, SecretServiceError> {
+        let result = self.store.list(tenant);
+        self.audit.record("list", tenant, "*", &result)?;
+        let mut names = result?;
+        names.sort();
+        names
+            .into_iter()
+            .map(|name| self.metadata_row(tenant, &name))
+            .collect()
+    }
+
+    /// Non-secret metadata for one secret, or `None` when it doesn't exist.
+    pub fn metadata(
+        &self,
+        tenant: &str,
+        name: &str,
+    ) -> Result<Option<SecretMetadata>, SecretServiceError> {
+        let exists = self.secret_exists(tenant, name);
+        self.audit
+            .record("get", tenant, name, &Ok::<(), anyhow::Error>(()))?;
+        if !exists {
+            return Ok(None);
+        }
+        self.metadata_row(tenant, name).map(Some)
+    }
+
+    fn metadata_row(&self, tenant: &str, name: &str) -> Result<SecretMetadata, SecretServiceError> {
+        let binding = self.bindings.get(tenant, name)?;
+        let referenced_by = refs::machines_referencing(&self.machines_root, tenant, name)?;
+        Ok(SecretMetadata {
+            tenant: tenant.to_string(),
+            name: name.to_string(),
+            binding,
+            referenced_by,
+        })
+    }
+
+    // ── Value lifecycle ───────────────────────────────────────────────
+
+    /// Create or replace the value stored at `(tenant, name)`. The input is
+    /// consumed and its plaintext buffer zeroized as soon as the encrypted
+    /// store write returns. Emits `secret.create` or `secret.replace`.
+    pub fn put(
+        &self,
+        tenant: &str,
+        name: &str,
+        value: SecretValueInput,
+    ) -> Result<PutOutcome, SecretServiceError> {
+        let existed = self.secret_exists(tenant, name);
+        let action = if existed { "replace" } else { "create" };
+        let result = self.store.put(tenant, name, value.storage_value());
+        // Consume the input now: the plaintext is zeroized here, immediately
+        // after storage, regardless of the write's outcome.
+        drop(value);
+        self.audit.record(action, tenant, name, &result)?;
+        result?;
+        Ok(if existed {
+            PutOutcome::Replaced
+        } else {
+            PutOutcome::Created
+        })
+    }
+
+    /// Remove `(tenant, name)` — value and binding. Refuses (and audits the
+    /// refusal) while any existing persistent machine references the secret;
+    /// there is deliberately no force path.
+    pub fn remove(&self, tenant: &str, name: &str) -> Result<(), SecretServiceError> {
+        let referencing = refs::machines_referencing(&self.machines_root, tenant, name)?;
+        if !referencing.is_empty() {
+            let err = SecretServiceError::ReferencedByMachines {
+                tenant: tenant.to_string(),
+                name: name.to_string(),
+                machines: referencing,
+            };
+            self.audit
+                .record("remove_refused", tenant, name, &Err::<(), _>(&err))?;
+            return Err(err);
+        }
+        let result = self.store.delete(tenant, name);
+        self.audit.record("remove", tenant, name, &result)?;
+        result?;
+        // Drop the binding too so a later re-create of the same name can't
+        // inherit a stale allow-list. Idempotent — absent binding is fine.
+        self.bindings.delete(tenant, name)?;
+        Ok(())
+    }
+
+    // ── Binding lifecycle ─────────────────────────────────────────────
+
+    /// Record the egress binding for an existing secret: how it
+    /// authenticates and which destinations the substituted credential may
+    /// reach. Fails closed when the secret has no stored value (a binding
+    /// without a value would admit nothing and mask an operator mistake).
+    pub fn bind(
+        &self,
+        tenant: &str,
+        name: &str,
+        meta: SecretBindingMeta,
+    ) -> Result<(), SecretServiceError> {
+        let result = (|| -> Result<(), SecretServiceError> {
+            if !self.secret_exists(tenant, name) {
+                return Err(SecretServiceError::MissingSecret {
+                    tenant: tenant.to_string(),
+                    name: name.to_string(),
+                });
+            }
+            validate_binding_meta(tenant, name, &meta)?;
+            self.bindings.put(tenant, name, &meta)?;
+            Ok(())
+        })();
+        self.audit.record("bind", tenant, name, &result)?;
+        result
+    }
+
+    /// Remove the egress binding, keeping the value. Idempotent.
+    pub fn unbind(&self, tenant: &str, name: &str) -> Result<(), SecretServiceError> {
+        let result = self.bindings.delete(tenant, name);
+        self.audit.record("unbind", tenant, name, &result)?;
+        result?;
+        Ok(())
+    }
+
+    // ── Persistent-machine references ─────────────────────────────────
+
+    /// Names of existing persistent machines that reference `(tenant, name)`.
+    pub fn references(&self, tenant: &str, name: &str) -> Result<Vec<String>, SecretServiceError> {
+        Ok(refs::machines_referencing(
+            &self.machines_root,
+            tenant,
+            name,
+        )?)
+    }
+
+    /// Persist `machine`'s full secret-reference set (metadata only — the
+    /// record cannot carry values). Replaces any previous record.
+    pub fn record_machine_references(
+        &self,
+        machine: &str,
+        references: &[MachineSecretRef],
+    ) -> Result<(), SecretServiceError> {
+        Ok(refs::record_refs(&self.machines_root, machine, references)?)
+    }
+
+    /// Drop `machine`'s secret-reference record. Idempotent.
+    pub fn clear_machine_references(&self, machine: &str) -> Result<(), SecretServiceError> {
+        Ok(refs::clear_refs(&self.machines_root, machine)?)
+    }
+
+    /// Fail-closed admission validation for a machine's secret references.
+    ///
+    /// For each reference: the machine's scope must match the secret's
+    /// scope, the secret must exist, an egress binding must be recorded and
+    /// well-formed, and every destination the reference names must be
+    /// admitted by the binding's allow-list. The first violation is
+    /// returned; a machine with any invalid reference must not boot.
+    pub fn validate_for_admission(
+        &self,
+        machine_tenant: &str,
+        references: &[MachineSecretRef],
+    ) -> Result<(), SecretServiceError> {
+        for r in references {
+            if r.tenant != machine_tenant {
+                return Err(SecretServiceError::CrossScope {
+                    machine_tenant: machine_tenant.to_string(),
+                    secret_tenant: r.tenant.clone(),
+                    name: r.name.clone(),
+                });
+            }
+            if !self.secret_exists(&r.tenant, &r.name) {
+                return Err(SecretServiceError::MissingSecret {
+                    tenant: r.tenant.clone(),
+                    name: r.name.clone(),
+                });
+            }
+            let Some(meta) = self.bindings.get(&r.tenant, &r.name)? else {
+                return Err(SecretServiceError::MissingBinding {
+                    tenant: r.tenant.clone(),
+                    name: r.name.clone(),
+                });
+            };
+            validate_binding_meta(&r.tenant, &r.name, &meta)?;
+            for destination in &r.destinations {
+                if !meta
+                    .allowed_hosts
+                    .iter()
+                    .any(|p| host_matches(p, destination))
+                {
+                    return Err(SecretServiceError::UnauthorizedDestination {
+                        tenant: r.tenant.clone(),
+                        name: r.name.clone(),
+                        destination: destination.clone(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // ── Internals ─────────────────────────────────────────────────────
+
+    /// Presence check via enumeration — never decrypts or touches a value.
+    fn secret_exists(&self, tenant: &str, name: &str) -> bool {
+        self.store
+            .list(tenant)
+            .map(|names| names.iter().any(|n| n == name))
+            .unwrap_or(false)
+    }
+}
+
+/// Structural validation for an egress binding: at least one non-empty
+/// destination, and the SigV4 scope present exactly when the auth type is
+/// SigV4 (present otherwise it would be silently ignored; absent for SigV4
+/// the signer could not name the credential scope).
+pub fn validate_binding_meta(
+    tenant: &str,
+    name: &str,
+    meta: &SecretBindingMeta,
+) -> Result<(), SecretServiceError> {
+    let invalid = |reason: &str| SecretServiceError::InvalidBinding {
+        tenant: tenant.to_string(),
+        name: name.to_string(),
+        reason: reason.to_string(),
+    };
+    if meta.allowed_hosts.is_empty() {
+        return Err(invalid("destination allow-list is empty"));
+    }
+    if meta.allowed_hosts.iter().any(|h| h.trim().is_empty()) {
+        return Err(invalid("destination allow-list contains an empty host"));
+    }
+    match (meta.auth_type, &meta.sigv4) {
+        (AuthType::Sigv4, None) => Err(invalid("sigv4 auth type requires sigv4 scope params")),
+        (AuthType::Sigv4, Some(p))
+            if p.access_key_id.is_empty() || p.region.is_empty() || p.service.is_empty() =>
+        {
+            Err(invalid("sigv4 scope params must be non-empty"))
+        }
+        (AuthType::Sigv4, Some(_)) => Ok(()),
+        (_, Some(_)) => Err(invalid("sigv4 scope params are only valid for sigv4 auth")),
+        (_, None) => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::crypto::secret_store::FileSecretStore;
+    use mvm_hostd::keyholder::FileBindingStore;
+    use tempfile::TempDir;
+
+    struct Fixture {
+        _tmp: TempDir,
+        service: SecretService,
+        audit_path: PathBuf,
+        bindings_dir: PathBuf,
+        machines_root: PathBuf,
+    }
+
+    fn fixture() -> Fixture {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_dir = tmp.path().join("secrets");
+        let bindings_dir = tmp.path().join("bindings");
+        let machines_root = tmp.path().join("machines");
+        let audit_path = tmp.path().join("secrets.jsonl");
+        let service = SecretService::builder()
+            .store(Arc::new(FileSecretStore::with_dir(&store_dir)))
+            .bindings(Arc::new(FileBindingStore::with_dir(&bindings_dir)))
+            .machines_root(machines_root.clone())
+            .audit(SecretAudit::with_path(audit_path.clone()))
+            .build()
+            .unwrap();
+        Fixture {
+            _tmp: tmp,
+            service,
+            audit_path,
+            bindings_dir,
+            machines_root,
+        }
+    }
+
+    fn audit_text(f: &Fixture) -> String {
+        std::fs::read_to_string(&f.audit_path).unwrap_or_default()
+    }
+
+    fn bearer_binding(hosts: &[&str]) -> SecretBindingMeta {
+        SecretBindingMeta {
+            auth_type: AuthType::Bearer,
+            allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: None,
+        }
+    }
+
+    fn machine_with_ref(f: &Fixture, machine: &str, tenant: &str, name: &str) {
+        let dir = f.machines_root.join(machine);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("machine.json"), b"{}").unwrap();
+        f.service
+            .record_machine_references(
+                machine,
+                &[MachineSecretRef {
+                    tenant: tenant.into(),
+                    name: name.into(),
+                    placeholder_var: Some("API_KEY".into()),
+                    destinations: vec!["api.openai.com".into()],
+                }],
+            )
+            .unwrap();
+    }
+
+    // ── Value lifecycle ───────────────────────────────────────────────
+
+    #[test]
+    fn put_creates_then_replaces_with_distinct_audit_actions() {
+        let f = fixture();
+        let first = f
+            .service
+            .put("local", "openai", SecretValueInput::new("sk-one".into()))
+            .unwrap();
+        assert_eq!(first, PutOutcome::Created);
+        let second = f
+            .service
+            .put("local", "openai", SecretValueInput::new("sk-two".into()))
+            .unwrap();
+        assert_eq!(second, PutOutcome::Replaced);
+
+        let log = audit_text(&f);
+        assert!(log.contains("\"action\":\"create\""), "got: {log}");
+        assert!(log.contains("\"action\":\"replace\""), "got: {log}");
+        // Neither plaintext value ever reaches the audit stream.
+        assert!(!log.contains("sk-one"));
+        assert!(!log.contains("sk-two"));
+    }
+
+    #[test]
+    fn put_with_unsafe_tenant_fails_and_audits_the_error() {
+        let f = fixture();
+        let err = f
+            .service
+            .put("../etc", "k", SecretValueInput::new("v".into()))
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Invalid tenant_id") || msg.contains("alphanumeric"),
+            "got: {msg}"
+        );
+        let log = audit_text(&f);
+        assert!(log.contains("\"outcome\":\"err\""));
+        assert!(log.contains("\"tenant\":\"../etc\""));
+        assert!(!log.contains("\"v\""));
+    }
+
+    #[test]
+    fn remove_deletes_value_and_binding() {
+        let f = fixture();
+        f.service
+            .put("local", "openai", SecretValueInput::new("sk".into()))
+            .unwrap();
+        f.service
+            .bind("local", "openai", bearer_binding(&["api.openai.com"]))
+            .unwrap();
+        f.service.remove("local", "openai").unwrap();
+        assert!(f.service.list("local").unwrap().is_empty());
+        assert!(f.service.metadata("local", "openai").unwrap().is_none());
+        let log = audit_text(&f);
+        assert!(log.contains("\"action\":\"remove\""));
+    }
+
+    #[test]
+    fn remove_missing_secret_is_an_error() {
+        let f = fixture();
+        assert!(f.service.remove("local", "absent").is_err());
+    }
+
+    // ── Referenced-delete refusal ─────────────────────────────────────
+
+    #[test]
+    fn remove_refused_while_a_persistent_machine_references_the_secret() {
+        let f = fixture();
+        f.service
+            .put("local", "openai", SecretValueInput::new("sk".into()))
+            .unwrap();
+        machine_with_ref(&f, "web", "local", "openai");
+
+        let err = f.service.remove("local", "openai").unwrap_err();
+        match &err {
+            SecretServiceError::ReferencedByMachines { machines, .. } => {
+                assert_eq!(machines, &vec!["web".to_string()]);
+            }
+            other => panic!("expected ReferencedByMachines, got {other:?}"),
+        }
+        // Value survives the refusal.
+        assert_eq!(f.service.list("local").unwrap().len(), 1);
+        // Refusal is audited, without the value.
+        let log = audit_text(&f);
+        assert!(log.contains("\"action\":\"remove_refused\""), "got: {log}");
+        assert!(log.contains("\"outcome\":\"err\""));
+        assert!(!log.contains("\"sk\""));
+    }
+
+    #[test]
+    fn remove_succeeds_after_references_are_cleared() {
+        let f = fixture();
+        f.service
+            .put("local", "openai", SecretValueInput::new("sk".into()))
+            .unwrap();
+        machine_with_ref(&f, "web", "local", "openai");
+        assert!(f.service.remove("local", "openai").is_err());
+        f.service.clear_machine_references("web").unwrap();
+        f.service.remove("local", "openai").unwrap();
+    }
+
+    // ── Binding lifecycle ─────────────────────────────────────────────
+
+    #[test]
+    fn bind_records_metadata_and_never_the_value() {
+        let f = fixture();
+        f.service
+            .put(
+                "local",
+                "openai",
+                SecretValueInput::new("sk-live-zzz".into()),
+            )
+            .unwrap();
+        f.service
+            .bind("local", "openai", bearer_binding(&["api.openai.com"]))
+            .unwrap();
+
+        let meta = f.service.metadata("local", "openai").unwrap().unwrap();
+        let binding = meta.binding.expect("binding recorded");
+        assert_eq!(binding.auth_type, AuthType::Bearer);
+        assert_eq!(binding.allowed_hosts, vec!["api.openai.com"]);
+
+        // The binding sidecar on disk carries metadata only.
+        let sidecar =
+            std::fs::read_to_string(f.bindings_dir.join("local").join("openai.json")).unwrap();
+        assert!(
+            !sidecar.contains("sk-live-zzz"),
+            "binding sidecar must not contain the value: {sidecar}"
+        );
+        let log = audit_text(&f);
+        assert!(log.contains("\"action\":\"bind\""));
+        assert!(!log.contains("sk-live-zzz"));
+    }
+
+    #[test]
+    fn bind_refuses_a_secret_without_a_stored_value() {
+        let f = fixture();
+        let err = f
+            .service
+            .bind("local", "ghost", bearer_binding(&["api.example.com"]))
+            .unwrap_err();
+        assert!(matches!(err, SecretServiceError::MissingSecret { .. }));
+        // The refusal is audited.
+        assert!(audit_text(&f).contains("\"action\":\"bind\""));
+        assert!(audit_text(&f).contains("\"outcome\":\"err\""));
+    }
+
+    #[test]
+    fn bind_refuses_empty_destination_list() {
+        let f = fixture();
+        f.service
+            .put("local", "k", SecretValueInput::new("v".into()))
+            .unwrap();
+        let err = f
+            .service
+            .bind("local", "k", bearer_binding(&[]))
+            .unwrap_err();
+        assert!(matches!(err, SecretServiceError::InvalidBinding { .. }));
+    }
+
+    #[test]
+    fn unbind_keeps_the_value_and_is_idempotent() {
+        let f = fixture();
+        f.service
+            .put("local", "openai", SecretValueInput::new("sk".into()))
+            .unwrap();
+        f.service
+            .bind("local", "openai", bearer_binding(&["api.openai.com"]))
+            .unwrap();
+        f.service.unbind("local", "openai").unwrap();
+        let meta = f.service.metadata("local", "openai").unwrap().unwrap();
+        assert!(meta.binding.is_none());
+        assert_eq!(f.service.list("local").unwrap().len(), 1);
+        f.service.unbind("local", "openai").unwrap(); // second: no error
+        assert!(audit_text(&f).contains("\"action\":\"unbind\""));
+    }
+
+    // ── Metadata reads ────────────────────────────────────────────────
+
+    #[test]
+    fn list_returns_metadata_rows_without_values() {
+        let f = fixture();
+        f.service
+            .put(
+                "local",
+                "openai",
+                SecretValueInput::new("sk-live-zzz".into()),
+            )
+            .unwrap();
+        f.service
+            .bind("local", "openai", bearer_binding(&["api.openai.com"]))
+            .unwrap();
+        f.service
+            .put("local", "plain", SecretValueInput::new("p-val".into()))
+            .unwrap();
+
+        let rows = f.service.list("local").unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].name, "openai");
+        assert!(rows[0].binding.is_some());
+        assert_eq!(rows[1].name, "plain");
+        assert!(rows[1].binding.is_none());
+
+        // Serialized metadata carries no value under any field name.
+        let json = serde_json::to_string(&rows).unwrap();
+        assert!(!json.contains("sk-live-zzz"), "got: {json}");
+        assert!(!json.contains("p-val"), "got: {json}");
+        assert!(!json.contains("\"value\""), "got: {json}");
+        // Debug output carries no value either.
+        let debug = format!("{rows:?}");
+        assert!(!debug.contains("sk-live-zzz"));
+        assert!(!debug.contains("p-val"));
+    }
+
+    #[test]
+    fn metadata_reports_referencing_machines() {
+        let f = fixture();
+        f.service
+            .put("local", "openai", SecretValueInput::new("sk".into()))
+            .unwrap();
+        machine_with_ref(&f, "web", "local", "openai");
+        let meta = f.service.metadata("local", "openai").unwrap().unwrap();
+        assert_eq!(meta.referenced_by, vec!["web"]);
+    }
+
+    #[test]
+    fn metadata_for_missing_secret_is_none() {
+        let f = fixture();
+        assert!(f.service.metadata("local", "absent").unwrap().is_none());
+    }
+
+    // ── Admission validation ──────────────────────────────────────────
+
+    fn admission_ref(tenant: &str, name: &str, destinations: &[&str]) -> MachineSecretRef {
+        MachineSecretRef {
+            tenant: tenant.into(),
+            name: name.into(),
+            placeholder_var: Some("API_KEY".into()),
+            destinations: destinations.iter().map(|d| d.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn admission_accepts_a_valid_bound_reference() {
+        let f = fixture();
+        f.service
+            .put("local", "openai", SecretValueInput::new("sk".into()))
+            .unwrap();
+        f.service
+            .bind(
+                "local",
+                "openai",
+                bearer_binding(&["api.openai.com", "*.openai.com"]),
+            )
+            .unwrap();
+        f.service
+            .validate_for_admission(
+                "local",
+                &[admission_ref("local", "openai", &["api.openai.com"])],
+            )
+            .unwrap();
+        // Wildcard subdomain admitted too.
+        f.service
+            .validate_for_admission(
+                "local",
+                &[admission_ref("local", "openai", &["eu.openai.com"])],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn admission_fails_closed_on_missing_secret() {
+        let f = fixture();
+        let err = f
+            .service
+            .validate_for_admission("local", &[admission_ref("local", "ghost", &[])])
+            .unwrap_err();
+        assert!(matches!(err, SecretServiceError::MissingSecret { .. }));
+    }
+
+    #[test]
+    fn admission_fails_closed_on_missing_binding() {
+        let f = fixture();
+        f.service
+            .put("local", "openai", SecretValueInput::new("sk".into()))
+            .unwrap();
+        let err = f
+            .service
+            .validate_for_admission("local", &[admission_ref("local", "openai", &[])])
+            .unwrap_err();
+        assert!(matches!(err, SecretServiceError::MissingBinding { .. }));
+    }
+
+    #[test]
+    fn admission_refuses_unauthorized_destination() {
+        let f = fixture();
+        f.service
+            .put("local", "openai", SecretValueInput::new("sk".into()))
+            .unwrap();
+        f.service
+            .bind("local", "openai", bearer_binding(&["api.openai.com"]))
+            .unwrap();
+        let err = f
+            .service
+            .validate_for_admission(
+                "local",
+                &[admission_ref("local", "openai", &["evil.example.com"])],
+            )
+            .unwrap_err();
+        match &err {
+            SecretServiceError::UnauthorizedDestination { destination, .. } => {
+                assert_eq!(destination, "evil.example.com");
+            }
+            other => panic!("expected UnauthorizedDestination, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn admission_refuses_cross_scope_references() {
+        let f = fixture();
+        f.service
+            .put("acme", "openai", SecretValueInput::new("sk".into()))
+            .unwrap();
+        f.service
+            .bind("acme", "openai", bearer_binding(&["api.openai.com"]))
+            .unwrap();
+        let err = f
+            .service
+            .validate_for_admission(
+                "local",
+                &[admission_ref("acme", "openai", &["api.openai.com"])],
+            )
+            .unwrap_err();
+        assert!(matches!(err, SecretServiceError::CrossScope { .. }));
+    }
+
+    // ── Binding validation ────────────────────────────────────────────
+
+    #[test]
+    fn binding_meta_requires_sigv4_scope_exactly_for_sigv4() {
+        let sigv4 = Sigv4Params {
+            access_key_id: "AKIA".into(),
+            region: "us-east-1".into(),
+            service: "s3".into(),
+        };
+        // SigV4 without scope → refused.
+        let missing = SecretBindingMeta {
+            auth_type: AuthType::Sigv4,
+            allowed_hosts: vec!["s3.amazonaws.com".into()],
+            sigv4: None,
+        };
+        assert!(validate_binding_meta("local", "aws", &missing).is_err());
+        // SigV4 with scope → accepted.
+        let good = SecretBindingMeta {
+            auth_type: AuthType::Sigv4,
+            allowed_hosts: vec!["s3.amazonaws.com".into()],
+            sigv4: Some(sigv4.clone()),
+        };
+        validate_binding_meta("local", "aws", &good).unwrap();
+        // Non-SigV4 carrying scope → refused (would be silently ignored).
+        let stray = SecretBindingMeta {
+            auth_type: AuthType::Bearer,
+            allowed_hosts: vec!["api.example.com".into()],
+            sigv4: Some(sigv4),
+        };
+        assert!(validate_binding_meta("local", "k", &stray).is_err());
+    }
+
+    // ── No-leak invariants across error surfaces ──────────────────────
+
+    #[test]
+    fn error_display_and_debug_never_carry_values() {
+        let f = fixture();
+        f.service
+            .put(
+                "local",
+                "openai",
+                SecretValueInput::new("sk-live-zzz".into()),
+            )
+            .unwrap();
+        machine_with_ref(&f, "web", "local", "openai");
+        let err = f.service.remove("local", "openai").unwrap_err();
+        let display = err.to_string();
+        let debug = format!("{err:?}");
+        assert!(!display.contains("sk-live-zzz"), "got: {display}");
+        assert!(!debug.contains("sk-live-zzz"), "got: {debug}");
+
+        // The persisted machine sidecar never carries the value either.
+        let sidecar = std::fs::read_to_string(
+            f.machines_root
+                .join("web")
+                .join(refs::MACHINE_SECRET_REFS_FILENAME),
+        )
+        .unwrap();
+        assert!(!sidecar.contains("sk-live-zzz"), "got: {sidecar}");
+    }
+}

--- a/crates/mvm-client/src/secret/audit.rs
+++ b/crates/mvm-client/src/secret/audit.rs
@@ -1,0 +1,357 @@
+//! Non-sensitive audit emission for secret lifecycle operations.
+//!
+//! Every service operation emits one JSON line to
+//! `~/.mvm/audit/secrets.jsonl` carrying
+//! `(timestamp, action, tenant, name, outcome, pid, secret_visibility,
+//! storage_security, error?)`. Values are never logged — the entry shape has
+//! no field that could carry secret material.
+//!
+//! Dual-emit: when a chain [`Recorder`] is wired (via
+//! [`SecretAudit::with_recorder_best_effort`]), every recorded action also
+//! lands as a chain-signed `secret.<action>` entry in the unified audit
+//! stream, signed by the host keypair. The JSONL stream stays authoritative
+//! for operators tailing the file; the Recorder is purely additive.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use mvm_core::plan::TenantId;
+use mvm_hostd::supervisor::{EventCategory, FileAuditSigner, Recorder};
+
+const AUDIT_FILENAME: &str = "secrets.jsonl";
+const SECRET_VISIBILITY_AUDIT_VALUE: &str = "write_only";
+const STORAGE_SECURITY_AUDIT_VALUE: &str = "encrypted_at_rest";
+
+/// Append-only audit sink for secret lifecycle actions.
+///
+/// Falls back to a no-op sink when no home root resolves (CI sandboxes,
+/// daemons without a home dir) rather than failing the operation — secret
+/// CRUD keeps working even when the audit destination is unreachable.
+pub struct SecretAudit {
+    path: Option<PathBuf>,
+    recorder: Option<Recorder>,
+}
+
+impl SecretAudit {
+    /// Resolve `~/.mvm/audit/secrets.jsonl` (honors `MVM_HOME`). No-op sink
+    /// when no home root resolves.
+    pub fn default_local() -> Result<Self> {
+        if mvm_core::config::mvm_home_strict().is_err() {
+            return Ok(Self::disabled());
+        }
+        let dir = mvm_core::config::mvm_audit_dir();
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("creating audit dir {}", dir.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).ok();
+        }
+        Ok(Self {
+            path: Some(dir.join(AUDIT_FILENAME)),
+            recorder: None,
+        })
+    }
+
+    /// A sink that records nothing. Used when no home root resolves.
+    pub fn disabled() -> Self {
+        Self {
+            path: None,
+            recorder: None,
+        }
+    }
+
+    /// Injection seam: write JSONL to an explicit path, no recorder.
+    pub fn with_path(path: PathBuf) -> Self {
+        Self {
+            path: Some(path),
+            recorder: None,
+        }
+    }
+
+    /// Injection seam: explicit path plus a pre-built chain [`Recorder`].
+    pub fn with_path_and_recorder(path: PathBuf, recorder: Recorder) -> Self {
+        Self {
+            path: Some(path),
+            recorder: Some(recorder),
+        }
+    }
+
+    /// Best-effort: attach a Recorder backed by the host signer's
+    /// chain-signed audit stream. Failures (no home dir, host signer
+    /// unavailable, loose perms) leave the recorder unset and log a
+    /// `tracing::warn` — the operation continues; the extra chain-signed
+    /// entry just doesn't land.
+    pub fn with_recorder_best_effort(mut self) -> Self {
+        match build_secret_recorder() {
+            Ok(rec) => self.recorder = Some(rec),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "secret audit recorder not wired; falling back to JSONL-only audit"
+                );
+            }
+        }
+        self
+    }
+
+    /// The JSONL destination, if any. Test/diagnostic accessor.
+    pub fn jsonl_path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
+
+    /// Whether a chain recorder is attached.
+    pub fn has_recorder(&self) -> bool {
+        self.recorder.is_some()
+    }
+
+    /// Record one action outcome. Only the error's `Display` text is
+    /// captured — never any payload — so the entry is structurally incapable
+    /// of carrying secret material.
+    pub fn record<T, E>(
+        &self,
+        action: &str,
+        tenant: &str,
+        name: &str,
+        outcome: &std::result::Result<T, E>,
+    ) -> Result<()>
+    where
+        E: std::fmt::Display,
+    {
+        let (outcome_str, error) = match outcome {
+            Ok(_) => ("ok", None),
+            Err(e) => ("err", Some(e.to_string())),
+        };
+        if let Some(ref path) = self.path {
+            let entry = serde_json::json!({
+                "timestamp": Utc::now().to_rfc3339(),
+                "action": action,
+                "tenant": tenant,
+                "name": name,
+                "outcome": outcome_str,
+                "pid": std::process::id(),
+                "secret_visibility": SECRET_VISIBILITY_AUDIT_VALUE,
+                "storage_security": STORAGE_SECURITY_AUDIT_VALUE,
+                "error": error,
+            });
+            let mut line = serde_json::to_vec(&entry).context("serialize audit entry")?;
+            line.push(b'\n');
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(path)
+                .with_context(|| format!("opening audit log {}", path.display()))?;
+            f.write_all(&line)
+                .with_context(|| format!("writing audit entry to {}", path.display()))?;
+        }
+        // Chain-recorder failures are surfaced as warnings, not propagated —
+        // operator secret CRUD must not fail because the chain-signed stream
+        // is unreachable.
+        if let Some(ref rec) = self.recorder {
+            emit_through_recorder(rec, action, tenant, name, outcome_str, error.as_deref());
+        }
+        Ok(())
+    }
+}
+
+/// Build a Recorder backed by `FileAuditSigner` rooted at the default audit
+/// dir. The host signing key is loaded (or initialized) from the default
+/// keys dir; the recorder's default tenant for the unbound entry's required
+/// `tenant` field is `"local"` — the per-action tenant rides in the labels.
+fn build_secret_recorder() -> Result<Recorder> {
+    let signer = mvm_hostd::audit::host_keypair::load_or_init()
+        .context("loading host signer for secret recorder")?;
+    let audit_dir = mvm_hostd::audit::emitter::default_audit_dir()?;
+    let file_signer = FileAuditSigner::open(signer.signing, &audit_dir)
+        .with_context(|| format!("opening FileAuditSigner at {}", audit_dir.display()))?;
+    Ok(Recorder::new(
+        Arc::new(file_signer),
+        TenantId("local".to_string()),
+    ))
+}
+
+fn emit_through_recorder(
+    recorder: &Recorder,
+    action: &str,
+    tenant: &str,
+    name: &str,
+    outcome: &str,
+    error: Option<&str>,
+) {
+    let event = format!("secret.{action}");
+    let mut extras: Vec<(String, String)> = vec![
+        ("tenant".to_string(), tenant.to_string()),
+        ("name".to_string(), name.to_string()),
+        ("outcome".to_string(), outcome.to_string()),
+        ("pid".to_string(), std::process::id().to_string()),
+        (
+            "secret_visibility".to_string(),
+            SECRET_VISIBILITY_AUDIT_VALUE.to_string(),
+        ),
+        (
+            "storage_security".to_string(),
+            STORAGE_SECURITY_AUDIT_VALUE.to_string(),
+        ),
+    ];
+    if let Some(err) = error {
+        extras.push(("error".to_string(), err.to_string()));
+    }
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            tracing::warn!(error = %e, "building tokio runtime for secret audit emit");
+            return;
+        }
+    };
+    if let Err(e) = rt.block_on(recorder.record_unbound(EventCategory::Secret, event, extras)) {
+        tracing::warn!(
+            error = %e,
+            action = action,
+            "Recorder dual-emit failed for secret event"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_hostd::supervisor::CapturingAuditSigner;
+
+    fn temp_audit() -> (tempfile::TempDir, SecretAudit) {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("secrets.jsonl");
+        (tmp, SecretAudit::with_path(path))
+    }
+
+    fn read_audit(audit: &SecretAudit) -> String {
+        let path = audit.jsonl_path().expect("audit has path");
+        std::fs::read_to_string(path).unwrap_or_default()
+    }
+
+    fn temp_audit_with_recorder() -> (tempfile::TempDir, SecretAudit, Arc<CapturingAuditSigner>) {
+        let tmp = tempfile::tempdir().unwrap();
+        let jsonl_path = tmp.path().join("secrets.jsonl");
+        let signer = Arc::new(CapturingAuditSigner::new());
+        let recorder = Recorder::new(signer.clone(), TenantId("local".to_string()));
+        (
+            tmp,
+            SecretAudit::with_path_and_recorder(jsonl_path, recorder),
+            signer,
+        )
+    }
+
+    #[test]
+    fn records_action_with_tenant_name_and_posture_labels() {
+        let (_dir, audit) = temp_audit();
+        let res: Result<()> = Ok(());
+        audit.record("create", "acme", "api_token", &res).unwrap();
+        let log = read_audit(&audit);
+        assert!(log.contains("\"action\":\"create\""), "got: {log}");
+        assert!(log.contains("\"tenant\":\"acme\""));
+        assert!(log.contains("\"name\":\"api_token\""));
+        assert!(log.contains("\"outcome\":\"ok\""));
+        assert!(log.contains("\"pid\":"));
+        assert!(log.contains("\"secret_visibility\":\"write_only\""));
+        assert!(log.contains("\"storage_security\":\"encrypted_at_rest\""));
+    }
+
+    #[test]
+    fn entry_shape_has_no_value_field_even_on_failure() {
+        let (_dir, audit) = temp_audit();
+        let res: Result<()> = Err(anyhow::anyhow!("boom"));
+        audit.record("create", "acme", "tok", &res).unwrap();
+        let log = read_audit(&audit);
+        assert!(!log.contains("\"value\""));
+        assert!(!log.contains("\"plaintext\""));
+        assert!(log.contains("\"outcome\":\"err\""));
+        assert!(log.contains("\"error\":\"boom\""));
+    }
+
+    #[test]
+    fn disabled_sink_records_nothing_and_succeeds() {
+        let audit = SecretAudit::disabled();
+        let res: Result<()> = Ok(());
+        audit.record("create", "acme", "k", &res).unwrap();
+        assert!(audit.jsonl_path().is_none());
+        assert!(!audit.has_recorder());
+    }
+
+    #[test]
+    fn recorder_dual_emits_chain_entry_with_labels() {
+        let (_dir, audit, signer) = temp_audit_with_recorder();
+        let res: Result<()> = Ok(());
+        audit.record("replace", "acme", "api_token", &res).unwrap();
+
+        // JSONL stream keeps its shape.
+        let log = read_audit(&audit);
+        assert!(log.contains("\"action\":\"replace\""), "got: {log}");
+
+        // Chain entry carries the canonical event name + labels.
+        let entries = signer.entries();
+        assert_eq!(entries.len(), 1, "expected one Recorder entry");
+        assert_eq!(entries[0].event, "secret.replace");
+        assert_eq!(entries[0].labels.get("tenant"), Some(&"acme".to_string()));
+        assert_eq!(
+            entries[0].labels.get("name"),
+            Some(&"api_token".to_string())
+        );
+        assert_eq!(entries[0].labels.get("outcome"), Some(&"ok".to_string()));
+        assert_eq!(
+            entries[0].labels.get("secret_visibility"),
+            Some(&"write_only".to_string())
+        );
+        assert_eq!(
+            entries[0].labels.get("storage_security"),
+            Some(&"encrypted_at_rest".to_string())
+        );
+        assert_eq!(
+            entries[0].labels.get("category"),
+            Some(&"secret".to_string())
+        );
+    }
+
+    #[test]
+    fn recorder_carries_error_label_on_failure() {
+        let (_dir, audit, signer) = temp_audit_with_recorder();
+        let res: Result<()> = Err(anyhow::anyhow!("boom"));
+        audit.record("bind", "acme", "tok", &res).unwrap();
+
+        let entries = signer.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].event, "secret.bind");
+        assert_eq!(entries[0].labels.get("outcome"), Some(&"err".to_string()));
+        assert_eq!(entries[0].labels.get("error"), Some(&"boom".to_string()));
+    }
+
+    #[test]
+    fn recorder_emits_every_lifecycle_action() {
+        let (_dir, audit, signer) = temp_audit_with_recorder();
+        let ok: Result<()> = Ok(());
+        for action in ["create", "replace", "bind", "unbind", "remove"] {
+            audit.record(action, "acme", "k", &ok).unwrap();
+        }
+        let refusal: Result<()> = Err(anyhow::anyhow!("referenced"));
+        audit
+            .record("remove_refused", "acme", "k", &refusal)
+            .unwrap();
+
+        let events: Vec<String> = signer.entries().iter().map(|e| e.event.clone()).collect();
+        assert_eq!(
+            events,
+            vec![
+                "secret.create",
+                "secret.replace",
+                "secret.bind",
+                "secret.unbind",
+                "secret.remove",
+                "secret.remove_refused",
+            ]
+        );
+    }
+}

--- a/crates/mvm-client/src/secret/audit.rs
+++ b/crates/mvm-client/src/secret/audit.rs
@@ -121,10 +121,24 @@ impl SecretAudit {
     where
         E: std::fmt::Display,
     {
-        let (outcome_str, error) = match outcome {
-            Ok(_) => ("ok", None),
-            Err(e) => ("err", Some(e.to_string())),
-        };
+        match outcome {
+            Ok(_) => self.record_outcome(action, tenant, name, "ok", None),
+            Err(e) => self.record_outcome(action, tenant, name, "err", Some(&e.to_string())),
+        }
+    }
+
+    /// Record with an explicit outcome label. The `ok`/`err` pair covers most
+    /// actions; probe-shaped reads additionally use `miss` so an absent
+    /// secret is distinguishable from a present one — and from a storage
+    /// failure — in the audit stream.
+    pub fn record_outcome(
+        &self,
+        action: &str,
+        tenant: &str,
+        name: &str,
+        outcome_str: &str,
+        error: Option<&str>,
+    ) -> Result<()> {
         if let Some(ref path) = self.path {
             let entry = serde_json::json!({
                 "timestamp": Utc::now().to_rfc3339(),
@@ -151,7 +165,7 @@ impl SecretAudit {
         // operator secret CRUD must not fail because the chain-signed stream
         // is unreachable.
         if let Some(ref rec) = self.recorder {
-            emit_through_recorder(rec, action, tenant, name, outcome_str, error.as_deref());
+            emit_through_recorder(rec, action, tenant, name, outcome_str, error);
         }
         Ok(())
     }

--- a/crates/mvm-client/src/secret/input.rs
+++ b/crates/mvm-client/src/secret/input.rs
@@ -1,0 +1,70 @@
+//! Redacted, zeroizing wrapper for a secret value on its way into storage.
+//!
+//! [`SecretValueInput`] is the only shape secret material takes inside the
+//! secret service, and it is strictly write-only: the wrapped value can be
+//! handed to a [`mvm_core::crypto::secret_store::SecretStore`] for encrypted
+//! persistence, but there is no public accessor, no `Display`, no serde, and
+//! `Debug` prints a fixed redaction marker. The inner buffer is zeroized on
+//! drop (via `secrecy`), so the plaintext lives exactly as long as the store
+//! call that consumes it.
+
+use secrecy::SecretBox;
+
+/// A secret value accepted by the service for storage.
+///
+/// Construction moves the caller's `String` into a zeroize-on-drop container;
+/// no copy of the plaintext remains under the caller's control. The service
+/// consumes the input by value, so it is dropped — and its buffer zeroized —
+/// immediately after the store write returns.
+pub struct SecretValueInput {
+    value: SecretBox<String>,
+}
+
+impl SecretValueInput {
+    /// Wrap a plaintext value. The `String` is moved, not copied.
+    pub fn new(value: String) -> Self {
+        Self {
+            value: SecretBox::new(Box::new(value)),
+        }
+    }
+
+    /// Hand the wrapped value to the encrypted store. Crate-private on
+    /// purpose: external callers can put a value in but never get one out.
+    pub(crate) fn storage_value(&self) -> &SecretBox<String> {
+        &self.value
+    }
+}
+
+impl From<String> for SecretValueInput {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl std::fmt::Debug for SecretValueInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SecretValueInput(REDACTED)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::ExposeSecret;
+
+    #[test]
+    fn debug_output_is_redacted_and_never_contains_the_value() {
+        let input = SecretValueInput::new("sk-live-topsecret".into());
+        let rendered = format!("{input:?}");
+        assert_eq!(rendered, "SecretValueInput(REDACTED)");
+        assert!(!rendered.contains("topsecret"));
+    }
+
+    #[test]
+    fn from_string_wraps_the_value_for_storage() {
+        let input = SecretValueInput::from(String::from("v-123"));
+        // In-crate storage handoff still carries the exact value; this is
+        // the sole path out and it terminates inside the store.
+        assert_eq!(input.storage_value().expose_secret(), "v-123");
+    }
+}

--- a/crates/mvm-client/src/secret/refs.rs
+++ b/crates/mvm-client/src/secret/refs.rs
@@ -1,0 +1,293 @@
+//! Persistent-machine secret references.
+//!
+//! A persistent machine that consumes a secret records a *reference* — the
+//! secret's scope + name plus placeholder/usage metadata — in a sidecar next
+//! to its `machine.json`. The sidecar carries no secret bytes, ever: the
+//! value stays in the encrypted store and only the host-side substitution
+//! path resolves it at egress. The reference record is what lets the service
+//! (a) refuse deleting a secret a machine still depends on, and (b) validate
+//! every reference at admission time before the machine boots.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use mvm_core::atomic_io::atomic_write;
+use mvm_core::crypto::keystore::validate_shell_id;
+use serde::{Deserialize, Serialize};
+
+/// Sidecar filename inside a machine's state dir, next to `machine.json`.
+pub const MACHINE_SECRET_REFS_FILENAME: &str = "secret-refs.json";
+
+/// Schema version stamped into every sidecar.
+pub const MACHINE_SECRET_REFS_SCHEMA_VERSION: u32 = 1;
+
+/// One machine → secret reference: scope + name plus non-secret usage
+/// metadata (the guest-facing placeholder variable and the destinations the
+/// workload intends to reach). Never carries a value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MachineSecretRef {
+    /// Scope (tenant namespace) the secret lives in.
+    pub tenant: String,
+    /// Secret name inside that scope.
+    pub name: String,
+    /// Guest-facing env var that receives the opaque placeholder at boot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placeholder_var: Option<String>,
+    /// Destinations the workload intends to reach with the substituted
+    /// credential. Validated against the binding allow-list at admission.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub destinations: Vec<String>,
+}
+
+/// The persisted sidecar: every secret reference one machine declares.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MachineSecretRefSet {
+    pub schema_version: u32,
+    /// Machine name the record belongs to (mirrors the directory name).
+    pub machine: String,
+    /// RFC 3339 timestamp of the last write.
+    pub recorded_at: String,
+    #[serde(default)]
+    pub references: Vec<MachineSecretRef>,
+}
+
+fn sidecar_path(machines_root: &Path, machine: &str) -> Result<PathBuf> {
+    mvm_core::naming::validate_id(machine, "machine name")?;
+    Ok(machines_root
+        .join(machine)
+        .join(MACHINE_SECRET_REFS_FILENAME))
+}
+
+fn machine_spec_exists(machines_root: &Path, machine: &str) -> bool {
+    machines_root.join(machine).join("machine.json").exists()
+}
+
+/// Persist the full reference set for `machine`, replacing any previous
+/// record. Each reference's scope and name are validated up front so a
+/// malformed record never lands on disk.
+pub fn record_refs(machines_root: &Path, machine: &str, refs: &[MachineSecretRef]) -> Result<()> {
+    for r in refs {
+        validate_shell_id(&r.tenant)
+            .with_context(|| format!("invalid secret scope in reference: {:?}", r.tenant))?;
+        validate_shell_id(&r.name)
+            .with_context(|| format!("invalid secret name in reference: {:?}", r.name))?;
+    }
+    let path = sidecar_path(machines_root, machine)?;
+    let record = MachineSecretRefSet {
+        schema_version: MACHINE_SECRET_REFS_SCHEMA_VERSION,
+        machine: machine.to_string(),
+        recorded_at: chrono::Utc::now().to_rfc3339(),
+        references: refs.to_vec(),
+    };
+    let bytes = serde_json::to_vec_pretty(&record).context("serializing secret references")?;
+    atomic_write(&path, &bytes)
+        .with_context(|| format!("writing secret references {}", path.display()))
+}
+
+/// Remove `machine`'s reference record. Idempotent — an absent sidecar is
+/// not an error.
+pub fn clear_refs(machines_root: &Path, machine: &str) -> Result<()> {
+    let path = sidecar_path(machines_root, machine)?;
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(anyhow::Error::from(e).context(format!("removing {}", path.display()))),
+    }
+}
+
+/// Load `machine`'s reference record, if one exists.
+pub fn load_refs(machines_root: &Path, machine: &str) -> Result<Option<MachineSecretRefSet>> {
+    let path = sidecar_path(machines_root, machine)?;
+    match std::fs::read(&path) {
+        Ok(bytes) => {
+            let record = serde_json::from_slice(&bytes)
+                .with_context(|| format!("parsing secret references {}", path.display()))?;
+            Ok(Some(record))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(anyhow::Error::from(e).context(format!("reading {}", path.display()))),
+    }
+}
+
+/// Every existing persistent machine (one with a `machine.json`) whose
+/// reference record names `(tenant, name)`. A malformed sidecar propagates
+/// as an error — deletion decisions must fail closed on records we cannot
+/// read, never silently skip them.
+pub fn machines_referencing(machines_root: &Path, tenant: &str, name: &str) -> Result<Vec<String>> {
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(machines_root) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(e) => {
+            return Err(anyhow::Error::from(e)
+                .context(format!("reading machines root {}", machines_root.display())));
+        }
+    };
+    for entry in entries {
+        let entry = entry.context("reading machines root entry")?;
+        if !entry.path().is_dir() {
+            continue;
+        }
+        let Some(machine) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        // Only machines that still exist can reference a secret; a leftover
+        // sidecar without a spec belongs to a removed machine.
+        if !machine_spec_exists(machines_root, &machine) {
+            continue;
+        }
+        let Some(record) = load_refs(machines_root, &machine)? else {
+            continue;
+        };
+        if record
+            .references
+            .iter()
+            .any(|r| r.tenant == tenant && r.name == name)
+        {
+            out.push(machine);
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn oref(tenant: &str, name: &str) -> MachineSecretRef {
+        MachineSecretRef {
+            tenant: tenant.into(),
+            name: name.into(),
+            placeholder_var: Some("OPENAI_API_KEY".into()),
+            destinations: vec!["api.openai.com".into()],
+        }
+    }
+
+    fn create_machine(root: &Path, machine: &str) {
+        let dir = root.join(machine);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("machine.json"), b"{}").unwrap();
+    }
+
+    #[test]
+    fn record_then_load_roundtrips_metadata() {
+        let tmp = tempdir().unwrap();
+        create_machine(tmp.path(), "web");
+        record_refs(tmp.path(), "web", &[oref("local", "openai")]).unwrap();
+        let record = load_refs(tmp.path(), "web").unwrap().unwrap();
+        assert_eq!(record.machine, "web");
+        assert_eq!(record.schema_version, MACHINE_SECRET_REFS_SCHEMA_VERSION);
+        assert_eq!(record.references, vec![oref("local", "openai")]);
+        assert!(!record.recorded_at.is_empty());
+    }
+
+    #[test]
+    fn sidecar_carries_reference_metadata_never_values() {
+        let tmp = tempdir().unwrap();
+        create_machine(tmp.path(), "web");
+        record_refs(tmp.path(), "web", &[oref("local", "openai")]).unwrap();
+        let raw =
+            std::fs::read_to_string(tmp.path().join("web").join(MACHINE_SECRET_REFS_FILENAME))
+                .unwrap();
+        // Names + usage metadata only; the record shape has no value slot.
+        assert!(raw.contains("\"openai\""));
+        assert!(raw.contains("\"placeholder_var\""));
+        assert!(
+            !raw.contains("\"value\""),
+            "sidecar must not carry a value field: {raw}"
+        );
+    }
+
+    #[test]
+    fn machines_referencing_finds_only_matching_machines() {
+        let tmp = tempdir().unwrap();
+        create_machine(tmp.path(), "web");
+        create_machine(tmp.path(), "worker");
+        record_refs(tmp.path(), "web", &[oref("local", "openai")]).unwrap();
+        record_refs(tmp.path(), "worker", &[oref("local", "aws")]).unwrap();
+
+        let hits = machines_referencing(tmp.path(), "local", "openai").unwrap();
+        assert_eq!(hits, vec!["web"]);
+        assert!(
+            machines_referencing(tmp.path(), "local", "absent")
+                .unwrap()
+                .is_empty()
+        );
+        // Same name in a different scope is a different secret.
+        assert!(
+            machines_referencing(tmp.path(), "acme", "openai")
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn sidecar_without_machine_spec_does_not_count() {
+        let tmp = tempdir().unwrap();
+        // Sidecar present but the machine.json is gone: the machine no
+        // longer exists, so its stale record must not pin the secret.
+        std::fs::create_dir_all(tmp.path().join("gone")).unwrap();
+        let record = MachineSecretRefSet {
+            schema_version: MACHINE_SECRET_REFS_SCHEMA_VERSION,
+            machine: "gone".into(),
+            recorded_at: chrono::Utc::now().to_rfc3339(),
+            references: vec![oref("local", "openai")],
+        };
+        std::fs::write(
+            tmp.path().join("gone").join(MACHINE_SECRET_REFS_FILENAME),
+            serde_json::to_vec(&record).unwrap(),
+        )
+        .unwrap();
+        assert!(
+            machines_referencing(tmp.path(), "local", "openai")
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn malformed_sidecar_fails_closed() {
+        let tmp = tempdir().unwrap();
+        create_machine(tmp.path(), "web");
+        std::fs::write(
+            tmp.path().join("web").join(MACHINE_SECRET_REFS_FILENAME),
+            b"not-json",
+        )
+        .unwrap();
+        assert!(machines_referencing(tmp.path(), "local", "openai").is_err());
+    }
+
+    #[test]
+    fn clear_refs_is_idempotent() {
+        let tmp = tempdir().unwrap();
+        create_machine(tmp.path(), "web");
+        record_refs(tmp.path(), "web", &[oref("local", "openai")]).unwrap();
+        clear_refs(tmp.path(), "web").unwrap();
+        assert!(load_refs(tmp.path(), "web").unwrap().is_none());
+        clear_refs(tmp.path(), "web").unwrap(); // second clear: no error
+    }
+
+    #[test]
+    fn record_refs_rejects_unsafe_scope_or_name() {
+        let tmp = tempdir().unwrap();
+        create_machine(tmp.path(), "web");
+        assert!(record_refs(tmp.path(), "web", &[oref("../etc", "k")]).is_err());
+        assert!(record_refs(tmp.path(), "web", &[oref("local", "../escape")]).is_err());
+        assert!(record_refs(tmp.path(), "../web", &[oref("local", "k")]).is_err());
+    }
+
+    #[test]
+    fn empty_root_yields_no_references() {
+        let tmp = tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        assert!(
+            machines_referencing(&missing, "local", "openai")
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -83,7 +83,24 @@ updates only its own entry below.
       prove relock after the final release; guest write/read + restart remain
       covered by the existing `s26_volumes` firecracker scenarios.
 
-- [ ] #2081 — reusable write-only local secret lifecycle service.
+- [x] #2081 — reusable write-only local secret lifecycle service.
+      Delivered `mvm_client::secret::SecretService`: one canonical service
+      composing `SecretStore` (unchanged keyring/file selection),
+      `BindingStore` egress bindings, a new per-machine secret-reference
+      sidecar (`secret-refs.json`, metadata only), and JSONL +
+      chain-signed audit (`secret.create/replace/bind/unbind/remove/
+      remove_refused`). Inputs are `SecretValueInput` (zeroize-on-drop,
+      redacted Debug, crate-private accessor); no reveal method or
+      value-carrying response type exists. `remove` refuses while an
+      existing persistent machine references the secret (no force path);
+      `validate_for_admission` fails closed on missing secrets,
+      missing/malformed bindings, unauthorized destinations (via
+      `host_matches`), and cross-scope references. `mvmctl secret
+      put/set/get/ls/rm` now consumes the service (`get` is a pure
+      presence check — no decryption). 53 new/ported tests (36 in
+      mvm-client, 17 in mvm-cli) including no-leak assertions across
+      responses, serialization, Debug, errors, audit records, and
+      persisted sidecars.
 
 - [ ] #2082 — normalized verified local audit events for UI consumers.
 

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -2108,10 +2108,11 @@ fn put_a_secret(sandbox: &AuditSandbox, tenant: &str, name: &str, value: &str) {
 }
 
 #[test]
-fn secret_put_emits_put_action_in_secret_audit_log() {
+fn secret_put_emits_create_action_in_secret_audit_log() {
     // The `mvmctl secret` command writes per-action JSONL to a
     // separate audit file (`~/.mvm/audit/secrets.jsonl`); the
-    // shape is `{"action":"put","tenant":...,"name":...,"outcome":"ok",...}`.
+    // shape is `{"action":"create","tenant":...,"name":...,"outcome":"ok",...}`
+    // (a `put` over an existing name records `"replace"` instead).
     // This pins the entry shape so a regression that flips
     // "action" → "verb" or relocates the file gets caught.
     let sandbox = AuditSandbox::new();
@@ -2137,8 +2138,8 @@ fn secret_put_emits_put_action_in_secret_audit_log() {
 
     let log = std::fs::read_to_string(sandbox.secret_audit_log_path()).unwrap_or_default();
     assert!(
-        log.contains("\"action\":\"put\""),
-        "expected an 'action':'put' entry in secrets audit log. Full log:\n{log}"
+        log.contains("\"action\":\"create\""),
+        "expected an 'action':'create' entry in secrets audit log. Full log:\n{log}"
     );
     assert!(
         log.contains("\"tenant\":\"test-tenant\""),
@@ -2213,9 +2214,9 @@ fn secret_ls_emits_list_action_in_secret_audit_log() {
 }
 
 #[test]
-fn secret_rm_emits_delete_action_in_secret_audit_log() {
+fn secret_rm_emits_remove_action_in_secret_audit_log() {
     // Same op-name vs CLI-verb decoupling as `ls` above: clap
-    // surface is `rm`, audit action is `"delete"`.
+    // surface is `rm`, audit action is `"remove"`.
     let sandbox = AuditSandbox::new();
     put_a_secret(&sandbox, "test-tenant", "api-key", "deadbeef");
 
@@ -2232,8 +2233,8 @@ fn secret_rm_emits_delete_action_in_secret_audit_log() {
 
     let log = std::fs::read_to_string(sandbox.secret_audit_log_path()).unwrap_or_default();
     assert!(
-        log.contains("\"action\":\"delete\""),
-        "expected an 'action':'delete' entry in secrets audit log. Full log:\n{log}"
+        log.contains("\"action\":\"remove\""),
+        "expected an 'action':'remove' entry in secrets audit log. Full log:\n{log}"
     );
 }
 


### PR DESCRIPTION
## Summary

Extracts one reusable, write-only local secret lifecycle service — `mvm_client::secret::SecretService` — and rewires `mvmctl secret put/set/get/ls/rm` to consume it, so local UI surfaces (mvm-studio) and the CLI share a single canonical orchestration for secrets.

### The service (`crates/mvm-client/src/secret.rs` + `secret/{input,audit,refs}.rs`)

- **Composition, all reuse-first**: values through the existing `mvm_core::crypto::secret_store::SecretStore` (unchanged keyring/file selection + migration behavior), egress bindings through `mvm_hostd::keyholder::{BindingStore, SecretBindingMeta}`, destination matching through `mvm_protocol::ir::host_matches`, audit through `mvm_hostd::supervisor::{FileAuditSigner, Recorder}` imported directly (not via the CLI shims).
- **Write-only inputs**: `SecretValueInput` wraps `secrecy::SecretBox<String>` — zeroized on drop immediately after the encrypted store write, redacted manual `Debug`, no `Display`, no serde, and its only accessor is `pub(crate)`. The service has **no reveal method** and no serializable response type that can carry a value.
- **Operations**: `list`/`metadata` (names, auth type, allowed destinations, binding + reference metadata only), `put` (create-or-replace, `PutOutcome` distinguishes the two), `bind`/`unbind` (typed bindings, validated: non-empty destination list, SigV4 scope present exactly when auth is SigV4, binding refused for a secret with no stored value), `remove`, `references`, `record_machine_references`/`clear_machine_references`, `validate_for_admission`.
- **Persistent-machine references**: a per-machine `secret-refs.json` sidecar next to `machine.json` (via `mvm_core::config::machine_state_root()`, so `MVM_HOME` isolation holds) carrying scope, name, placeholder var, and intended destinations — metadata only, never values. `remove` refuses (and audits `secret.remove_refused`) while any existing machine references the secret; force-delete is intentionally not implemented. A malformed sidecar fails closed; a sidecar whose `machine.json` is gone does not pin the secret.
- **Admission validation**: `validate_for_admission` fails closed on missing secrets, missing/malformed bindings, destinations outside the binding allow-list (wildcards via `host_matches`), and cross-scope references. This complements the existing host-side substitution path (`mvm_hostd::keyholder::assemble_registry`), which remains the runtime enforcement seam — guests still receive placeholders, never credentials.
- **Audit**: every action emits the established JSONL shape to `~/.mvm/audit/secrets.jsonl` plus a best-effort chain-signed `secret.<action>` entry (`create`, `replace`, `bind`, `unbind`, `remove`, `remove_refused`, `get`, `list`) with the `write_only` / `encrypted_at_rest` posture labels. No entry field can carry a value.

### CLI (`crates/mvm-cli/src/commands/ops/secret.rs`)

Now a thin flag layer over the service. Notable behavior changes:

- `secret get` was already presence-only in output, but previously **decrypted** the value via `store.get()` before discarding it. It is now a pure metadata presence check — the value is never decrypted for a `get`.
- `secret rm` now refuses while a persistent machine references the secret, naming the machines.
- Audit actions renamed to the lifecycle taxonomy (`create`/`replace` instead of `put`, `remove` instead of `delete`; `set` emits `create|replace` + `bind`).

The in-file `AuditLog`/recorder plumbing moved into the service (`mvm_client::secret::SecretAudit`) unchanged in shape. The two live audit-emission tests pinning the old `put`/`delete` action names (`tests/audit_emissions_live.rs`) were updated to pin `create`/`remove`.

## Test evidence

53 tests (36 in mvm-client, 17 in mvm-cli), including the no-leak matrix:

- value absent from list/metadata responses, their `serde_json` serialization, and their `Debug` output (`list_returns_metadata_rows_without_values`)
- value absent from audit JSONL and chain-recorder labels on success and failure (`put_creates_then_replaces_with_distinct_audit_actions`, `entry_shape_has_no_value_field_even_on_failure`, `recorder_dual_emits_chain_entry_with_labels`)
- value absent from error `Display`/`Debug` and from persisted machine sidecars (`error_display_and_debug_never_carry_values`, `sidecar_carries_reference_metadata_never_values`)
- value absent from binding sidecars incl. the SigV4 secret-access-key (`bind_records_metadata_and_never_the_value`, `cmd_set_sigv4_stores_params_in_binding_not_value_in_sidecar`)
- `SecretValueInput` `Debug` is a fixed redaction marker (`debug_output_is_redacted_and_never_contains_the_value`)
- refusal ladder: create/replace, bind-without-value, empty destination list, missing secret, missing binding, unauthorized destination, cross-scope, referenced-delete refusal, unsafe tenant/name ids, malformed sidecar fail-closed

Gates run locally: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo test --workspace --doc`, `xtask check-no-spec-refs-in-comments`, `xtask check-no-display-on-secret-types` — all green.

## Notes

- Zeroization relies on `secrecy`'s zeroize-on-drop (mvm-client is `#![forbid(unsafe_code)]`, so there is deliberately no unsafe memory-peek test).
- Wiring `machine create/run` to call `record_machine_references` is left to the launch-lifecycle work; this PR lands the canonical seam + persistence format (machine command files are owned by a parallel workstream).
- Reference timestamps are recorded (`recorded_at` in the sidecar); store-level timestamps are not surfaced because the `SecretStore` trait does not expose them.

Closes #2081

🤖 Generated with [Claude Code](https://claude.com/claude-code)
