### PR TITLE
feat(mvm-client): expose normalized verified audit events for UI consumers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2804,6 +2804,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "ed25519-dalek",
  "ext4-view",
  "flate2",
  "hex",

--- a/crates/mvm-cli/src/commands/ops/audit.rs
+++ b/crates/mvm-cli/src/commands/ops/audit.rs
@@ -6,9 +6,9 @@ use clap::{Args as ClapArgs, Subcommand};
 use crate::ui;
 
 use ed25519_dalek::VerifyingKey;
+use mvm_client::audit::{AuditSourceId, AuditSourceKind, LocalAuditReader};
 use mvm_core::user_config::MvmConfig;
-use mvm_hostd::audit_signer::verify::verify_workload_chain;
-use mvm_hostd::supervisor::{SignedEnvelope, verify_audit_chain};
+use mvm_hostd::supervisor::SignedEnvelope;
 use mvm_protocol::merkle::{InclusionProof, SignedAuditRoot, verify_inclusion, verify_signed_root};
 
 use super::super::vm::audit_chain::{AuditEmitter, audit_path_for_tenant, default_audit_dir};
@@ -774,10 +774,19 @@ fn print_chain_line(line: &str) {
 
 fn audit_verify(tenant: &str) -> Result<()> {
     let dir = default_audit_dir()?;
-    let lifecycle_path = audit_path_for_tenant(&dir, tenant);
-    let workload_paths = workload_chain_paths(&dir, tenant)?;
+    // Both chain kinds are signed under the host key; load it once.
+    let signer =
+        host_signer::load_or_init().context("loading host signer to verify audit chain")?;
 
-    if !lifecycle_path.exists() && workload_paths.is_empty() {
+    // The canonical verification seam: the same source discovery +
+    // verification the verified-audit UI reader uses, so the CLI and UI
+    // consumers can never disagree on what verifies.
+    let reader = LocalAuditReader::new(&dir, signer.verifying);
+    let outcome = reader
+        .verify_sources(Some(tenant))
+        .context("enumerating audit sources")?;
+
+    if outcome.sources.is_empty() && outcome.refusals.is_empty() {
         ui::info(&format!(
             "No audit chain found for tenant '{tenant}' under {}. Nothing to verify.",
             dir.display()
@@ -785,65 +794,46 @@ fn audit_verify(tenant: &str) -> Result<()> {
         return Ok(());
     }
 
-    // Both chain kinds are signed under the host key; load it once.
-    let signer =
-        host_signer::load_or_init().context("loading host signer to verify audit chain")?;
-    let vk = signer.verifying;
-
-    // The host-lifecycle chain (`<tenant>.jsonl`, SignedEnvelope format).
-    if lifecycle_path.exists() {
-        match verify_audit_chain(&lifecycle_path, &vk) {
-            Ok(count) => ui::success(&format!(
-                "audit chain '{}' verifies clean: {count} entries",
-                lifecycle_path.display()
-            )),
-            // Print a clear error AND propagate so the process exits
-            // nonzero. `mvmctl audit verify` is meant for scripting.
-            Err(e) => anyhow::bail!("audit chain verify failed: {e}"),
-        }
+    for summary in &outcome.sources {
+        ui::success(&format!(
+            "{} '{}' verifies clean: {} entries",
+            source_kind_label(summary.source.kind),
+            source_path(&dir, &summary.source).display(),
+            summary.entries
+        ));
     }
 
-    // The per-VM workload-emitted chains (`<tenant>.<vm>.workload.jsonl`,
-    // OnDiskEntry/JCS). Each per-VM signer owns its own file (single-writer),
-    // so a tenant can have several; verify every one.
-    for workload_path in &workload_paths {
-        match verify_workload_chain(workload_path, &vk) {
-            Ok(count) => ui::success(&format!(
-                "workload audit chain '{}' verifies clean: {count} entries",
-                workload_path.display()
-            )),
-            Err(e) => anyhow::bail!(
-                "workload audit chain verify failed ({}): {e}",
-                workload_path.display()
-            ),
-        }
+    // Print a clear error AND propagate so the process exits nonzero.
+    // `mvmctl audit verify` is meant for scripting.
+    if let Some(refusal) = outcome.refusals.first() {
+        anyhow::bail!(
+            "{} verify failed ({}): {}",
+            source_kind_label(refusal.source.kind),
+            source_path(&dir, &refusal.source).display(),
+            refusal.detail
+        );
     }
-
     Ok(())
 }
 
-/// Enumerate a tenant's per-VM workload audit chains
-/// (`<tenant>.<vm>.workload.jsonl`) in the audit dir, sorted for stable
-/// output. The naming convention lives in `mvm-core::config` so the writer
-/// (the backend spawn) and this reader can't drift.
-fn workload_chain_paths(dir: &std::path::Path, tenant: &str) -> Result<Vec<std::path::PathBuf>> {
-    let entries = match std::fs::read_dir(dir) {
-        Ok(e) => e,
-        // No audit dir yet ⇒ no workload chains.
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(e) => return Err(e).with_context(|| format!("reading audit dir {}", dir.display())),
-    };
-    let mut paths = Vec::new();
-    for entry in entries {
-        let entry = entry.with_context(|| format!("reading audit dir {}", dir.display()))?;
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else { continue };
-        if mvm_core::config::workload_audit_vm_name(name, tenant).is_some() {
-            paths.push(entry.path());
-        }
+/// Human label for a chain kind in `audit verify` output.
+fn source_kind_label(kind: AuditSourceKind) -> &'static str {
+    match kind {
+        AuditSourceKind::Lifecycle => "audit chain",
+        AuditSourceKind::Workload => "workload audit chain",
     }
-    paths.sort();
-    Ok(paths)
+}
+
+/// On-disk path of a source, for operator-facing display.
+fn source_path(dir: &std::path::Path, source: &AuditSourceId) -> std::path::PathBuf {
+    match (&source.kind, &source.machine) {
+        (AuditSourceKind::Workload, Some(vm)) => dir.join(format!(
+            "{}.{vm}{}",
+            source.tenant,
+            mvm_core::config::WORKLOAD_AUDIT_SUFFIX
+        )),
+        _ => audit_path_for_tenant(dir, &source.tenant),
+    }
 }
 
 fn audit_show(tenant: &str, plan_id: &str, json: bool) -> Result<()> {

--- a/crates/mvm-cli/src/commands/ops/audit.rs
+++ b/crates/mvm-cli/src/commands/ops/audit.rs
@@ -774,6 +774,19 @@ fn print_chain_line(line: &str) {
 
 fn audit_verify(tenant: &str) -> Result<()> {
     let dir = default_audit_dir()?;
+
+    // Nothing to verify ⇒ return before touching the host signer, so a
+    // read-only verify on a pristine host never mints a signing keypair.
+    let discovered = mvm_client::audit::discover_source_ids(&dir, Some(tenant))
+        .context("enumerating audit sources")?;
+    if discovered.is_empty() {
+        ui::info(&format!(
+            "No audit chain found for tenant '{tenant}' under {}. Nothing to verify.",
+            dir.display()
+        ));
+        return Ok(());
+    }
+
     // Both chain kinds are signed under the host key; load it once.
     let signer =
         host_signer::load_or_init().context("loading host signer to verify audit chain")?;
@@ -784,15 +797,7 @@ fn audit_verify(tenant: &str) -> Result<()> {
     let reader = LocalAuditReader::new(&dir, signer.verifying);
     let outcome = reader
         .verify_sources(Some(tenant))
-        .context("enumerating audit sources")?;
-
-    if outcome.sources.is_empty() && outcome.refusals.is_empty() {
-        ui::info(&format!(
-            "No audit chain found for tenant '{tenant}' under {}. Nothing to verify.",
-            dir.display()
-        ));
-        return Ok(());
-    }
+        .context("verifying audit sources")?;
 
     for summary in &outcome.sources {
         ui::success(&format!(

--- a/crates/mvm-client/Cargo.toml
+++ b/crates/mvm-client/Cargo.toml
@@ -48,6 +48,15 @@ flate2 = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 tempfile = { workspace = true }
 async-trait = { workspace = true }
+# Verified audit reader surface: chrono for time filters/ordering,
+# ed25519 for the trusted verifying key in the reader's constructor,
+# serde for the UI-facing event/cursor DTOs. All already in the mvmctl
+# closure via mvm-core/mvm-hostd, so no new crates enter the build.
+chrono = { workspace = true }
+ed25519-dalek = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 # Non-fatal diagnostics on the pause path (fc.paused marker best-effort write).
 # Already in the mvmctl closure via mvm-runtime, so this adds no crates.
 tracing = { workspace = true }
@@ -78,3 +87,6 @@ mvm-core = { workspace = true, features = ["test-support"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
 # Inventory-record wire assertions (round-trips, no-host-path leak checks).
 serde_json = { workspace = true }
+# Seeded property-style loops + fresh Ed25519 test keys for the verified
+# audit reader's fixture chains.
+rand = { workspace = true }

--- a/crates/mvm-client/Cargo.toml
+++ b/crates/mvm-client/Cargo.toml
@@ -49,11 +49,10 @@ tokio = { workspace = true, features = ["rt"] }
 tempfile = { workspace = true }
 async-trait = { workspace = true }
 # Verified audit reader surface: ed25519 for the trusted verifying key in
-# the reader's constructor and thiserror for typed refusals; the shared
-# chrono/serde/serde_json entries below serve its filters and DTOs too.
-# Already in the mvmctl closure via mvm-core/mvm-hostd.
+# the reader's constructor; the shared chrono/serde/serde_json/thiserror
+# entries below serve its filters, DTOs, and typed refusals too. Already
+# in the mvmctl closure via mvm-core/mvm-hostd.
 ed25519-dalek = { workspace = true }
-thiserror = { workspace = true }
 # Non-fatal diagnostics on the pause path (fc.paused marker best-effort write).
 # Already in the mvmctl closure via mvm-runtime, so this adds no crates.
 tracing = { workspace = true }

--- a/crates/mvm-client/Cargo.toml
+++ b/crates/mvm-client/Cargo.toml
@@ -48,14 +48,11 @@ flate2 = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 tempfile = { workspace = true }
 async-trait = { workspace = true }
-# Verified audit reader surface: chrono for time filters/ordering,
-# ed25519 for the trusted verifying key in the reader's constructor,
-# serde for the UI-facing event/cursor DTOs. All already in the mvmctl
-# closure via mvm-core/mvm-hostd, so no new crates enter the build.
-chrono = { workspace = true }
+# Verified audit reader surface: ed25519 for the trusted verifying key in
+# the reader's constructor and thiserror for typed refusals; the shared
+# chrono/serde/serde_json entries below serve its filters and DTOs too.
+# Already in the mvmctl closure via mvm-core/mvm-hostd.
 ed25519-dalek = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
 # Non-fatal diagnostics on the pause path (fc.paused marker best-effort write).
 # Already in the mvmctl closure via mvm-runtime, so this adds no crates.

--- a/crates/mvm-client/src/audit.rs
+++ b/crates/mvm-client/src/audit.rs
@@ -1,5 +1,0 @@
-//! Verified, normalized local audit events for UI consumers.
-//!
-//! Extracts chain reading and verification behind a reusable service that
-//! returns normalized events only after signature and chain integrity
-//! checks pass; unverifiable sources yield typed refusals, never events.

--- a/crates/mvm-client/src/audit/event.rs
+++ b/crates/mvm-client/src/audit/event.rs
@@ -1,0 +1,621 @@
+//! Typed DTOs for the verified local audit read contract.
+//!
+//! Everything a UI consumer receives is defined here: the normalized
+//! [`VerifiedAuditEvent`], its stable [`AuditEventId`] identity, the typed
+//! per-source refusal, and the bounded newest-first read request/response
+//! pair with its typed cursor. Serialization shapes are pinned with
+//! `deny_unknown_fields` so drift fails loudly on both ends.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Which local chain format an event or refusal came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditSourceKind {
+    /// Per-tenant host-lifecycle chain (`<tenant>.jsonl`, signed envelopes).
+    Lifecycle,
+    /// Per-VM workload-emitted chain (`<tenant>.<vm>.workload.jsonl`, JCS).
+    Workload,
+}
+
+/// Identity of one local audit source: a chain kind plus its scope.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuditSourceId {
+    /// Chain format of the source.
+    pub kind: AuditSourceKind,
+    /// Tenant the chain file is scoped to.
+    pub tenant: String,
+    /// VM name for per-VM workload chains; `None` for lifecycle chains.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub machine: Option<String>,
+}
+
+/// Stable identity of one verified event: its source plus the entry's
+/// zero-based position in the verified chain. Chains are append-only and
+/// only verified prefixes are ever exposed, so `(source, seq)` names the
+/// same entry on every read without rewriting the underlying chain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuditEventId {
+    /// The source chain this event was read from.
+    pub source: AuditSourceId,
+    /// Zero-based position in the verified chain order.
+    pub seq: u64,
+}
+
+/// Normalized category of audit activity, mapped from raw event names and
+/// workload categories at the service boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AuditEventKind {
+    /// Plan/bundle/image admission and provenance decisions.
+    Admission,
+    /// A workload being launched or running.
+    Launch,
+    /// Machine/tenant lifecycle transitions (created, exited, destroyed…).
+    Lifecycle,
+    /// Readiness/health signals.
+    Readiness,
+    /// Volume and application-dependency activity.
+    Volume,
+    /// Secret-reference activity (metadata only, never values).
+    SecretReference,
+    /// Policy resolution and network-policy activity.
+    Policy,
+    /// An explicit denial, rejection, or failure.
+    Refusal,
+    /// Anything not covered by a dedicated category.
+    Other,
+}
+
+/// One normalized audit event, returned only after its source chain passed
+/// signature, link, and scope verification. All free text is sanitized and
+/// capped; secret values, credentials, raw payloads, and host paths never
+/// appear in any field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VerifiedAuditEvent {
+    /// Stable identity (source + position in the verified chain).
+    pub id: AuditEventId,
+    /// Normalized activity category.
+    pub kind: AuditEventKind,
+    /// RFC 3339 timestamp carried by the signed entry.
+    pub timestamp: String,
+    /// Tenant the event belongs to (matches the source scope).
+    pub tenant: String,
+    /// Machine/VM the event concerns, when one is identifiable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub machine: Option<String>,
+    /// Sanitized raw event name (lifecycle chains) or category (workload
+    /// chains) for display alongside the normalized kind.
+    pub event: String,
+    /// Plan content-address the event is bound to, when bound.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan_id: Option<String>,
+    /// Sanitized, capped human-readable detail. Sensitive labels are
+    /// dropped and path-like values redacted before rendering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// Why events from a source were withheld. Withheld means withheld: a
+/// refused source contributes zero events, never a partial prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AuditRefusalKind {
+    /// The chain file could not be read.
+    Io,
+    /// A line failed to parse or decode.
+    Malformed,
+    /// A chain link (prev-hash / entry-hash) did not hold.
+    ChainBroken,
+    /// A signature did not verify under the trusted host key.
+    SignatureInvalid,
+    /// A verified entry claimed a scope other than the source's.
+    ScopeMismatch,
+}
+
+/// Typed refusal for one source that failed verification. Returned
+/// alongside (never mixed into) verified events.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuditSourceRefusal {
+    /// The source that was refused.
+    pub source: AuditSourceId,
+    /// Failure category.
+    pub kind: AuditRefusalKind,
+    /// Zero-based line/entry index of the first failure, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u64>,
+    /// Sanitized human-readable reason.
+    pub detail: String,
+}
+
+/// Per-source verification summary for sources that verified clean.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VerifiedSourceSummary {
+    /// The verified source.
+    pub source: AuditSourceId,
+    /// Number of authenticated entries in the chain.
+    pub entries: u64,
+}
+
+/// Typed pagination cursor: the ordering key of the last event of the
+/// previous page. The next page contains strictly older events.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuditCursor {
+    /// RFC 3339 timestamp of the last returned event.
+    pub timestamp: String,
+    /// Source of the last returned event.
+    pub source: AuditSourceId,
+    /// Chain position of the last returned event.
+    pub seq: u64,
+}
+
+impl AuditCursor {
+    /// Cursor pointing at `event`, for requesting the page after it.
+    pub fn after(event: &VerifiedAuditEvent) -> Self {
+        Self {
+            timestamp: event.timestamp.clone(),
+            source: event.id.source.clone(),
+            seq: event.id.seq,
+        }
+    }
+}
+
+/// Default page size when the request does not name one.
+pub const DEFAULT_READ_LIMIT: usize = 100;
+
+/// Hard upper bound on a single page. Requests above it are clamped.
+pub const MAX_READ_LIMIT: usize = 1000;
+
+/// Bounded, filtered read request. Build via [`AuditReadRequest::builder`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AuditReadRequest {
+    pub(crate) tenant: Option<String>,
+    pub(crate) machine: Option<String>,
+    pub(crate) kinds: Vec<AuditEventKind>,
+    pub(crate) since: Option<DateTime<Utc>>,
+    pub(crate) until: Option<DateTime<Utc>>,
+    pub(crate) limit: Option<usize>,
+    pub(crate) cursor: Option<AuditCursor>,
+}
+
+impl AuditReadRequest {
+    /// Start building a request. An empty request reads the newest
+    /// [`DEFAULT_READ_LIMIT`] events across every local source.
+    pub fn builder() -> AuditReadRequestBuilder {
+        AuditReadRequestBuilder::default()
+    }
+
+    /// Effective page size: default when unset, clamped to
+    /// `1..=`[`MAX_READ_LIMIT`].
+    pub(crate) fn effective_limit(&self) -> usize {
+        self.limit
+            .unwrap_or(DEFAULT_READ_LIMIT)
+            .clamp(1, MAX_READ_LIMIT)
+    }
+}
+
+/// Builder for [`AuditReadRequest`].
+#[derive(Debug, Clone, Default)]
+pub struct AuditReadRequestBuilder {
+    request: AuditReadRequest,
+}
+
+impl AuditReadRequestBuilder {
+    /// Only events from this tenant's chains.
+    #[must_use]
+    pub fn tenant(mut self, tenant: impl Into<String>) -> Self {
+        self.request.tenant = Some(tenant.into());
+        self
+    }
+
+    /// Only events whose machine matches.
+    #[must_use]
+    pub fn machine(mut self, machine: impl Into<String>) -> Self {
+        self.request.machine = Some(machine.into());
+        self
+    }
+
+    /// Restrict to one normalized kind (repeatable).
+    #[must_use]
+    pub fn kind(mut self, kind: AuditEventKind) -> Self {
+        self.request.kinds.push(kind);
+        self
+    }
+
+    /// Only events at or after this instant.
+    #[must_use]
+    pub fn since(mut self, since: DateTime<Utc>) -> Self {
+        self.request.since = Some(since);
+        self
+    }
+
+    /// Only events at or before this instant.
+    #[must_use]
+    pub fn until(mut self, until: DateTime<Utc>) -> Self {
+        self.request.until = Some(until);
+        self
+    }
+
+    /// Page size (clamped to `1..=`[`MAX_READ_LIMIT`]).
+    #[must_use]
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.request.limit = Some(limit);
+        self
+    }
+
+    /// Resume strictly after this cursor.
+    #[must_use]
+    pub fn cursor(mut self, cursor: AuditCursor) -> Self {
+        self.request.cursor = Some(cursor);
+        self
+    }
+
+    /// Finish the request.
+    pub fn build(self) -> AuditReadRequest {
+        self.request
+    }
+}
+
+/// Result of a bounded verified read: newest-first events, per-source
+/// summaries, typed refusals, and the continuation cursor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuditReadResponse {
+    /// Verified events, newest first.
+    pub events: Vec<VerifiedAuditEvent>,
+    /// Sources that verified clean (whether or not they contributed
+    /// events to this page).
+    pub sources: Vec<VerifiedSourceSummary>,
+    /// Sources withheld because verification failed.
+    pub refusals: Vec<AuditSourceRefusal>,
+    /// Cursor for the next (older) page; `None` when exhausted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<AuditCursor>,
+}
+
+/// Total ordering key for merged events. Newest-first output sorts by this
+/// key descending: timestamp first, then a deterministic source rank
+/// (kind, tenant, machine) as tie-break, then chain position. The rule is
+/// stable across reads because it depends only on signed entry content and
+/// source identity — never on file mtimes or read order.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct OrderKey {
+    ts_ms: i64,
+    kind: AuditSourceKind,
+    tenant: String,
+    machine: Option<String>,
+    seq: u64,
+}
+
+impl OrderKey {
+    fn new(timestamp: &str, source: &AuditSourceId, seq: u64) -> Self {
+        Self {
+            ts_ms: parse_ts_millis(timestamp),
+            kind: source.kind,
+            tenant: source.tenant.clone(),
+            machine: source.machine.clone(),
+            seq,
+        }
+    }
+
+    pub(crate) fn of_event(event: &VerifiedAuditEvent) -> Self {
+        Self::new(&event.timestamp, &event.id.source, event.id.seq)
+    }
+
+    pub(crate) fn of_cursor(cursor: &AuditCursor) -> Self {
+        Self::new(&cursor.timestamp, &cursor.source, cursor.seq)
+    }
+}
+
+/// Epoch milliseconds of an RFC 3339 timestamp; unparseable timestamps
+/// sort oldest so they can never jump the queue.
+pub(crate) fn parse_ts_millis(timestamp: &str) -> i64 {
+    DateTime::parse_from_rfc3339(timestamp)
+        .map(|t| t.timestamp_millis())
+        .unwrap_or(i64::MIN)
+}
+
+/// Map a lifecycle-chain event name onto the normalized kind.
+pub(crate) fn classify_lifecycle_event(event: &str) -> AuditEventKind {
+    if event == "plan.failed"
+        || event.contains(".rejected")
+        || event.contains(".denied")
+        || event.contains(".refused")
+        || event.ends_with(".grant_required")
+    {
+        return AuditEventKind::Refusal;
+    }
+    match event {
+        "plan.launched" | "plan.running" => AuditEventKind::Launch,
+        "plan.admitted"
+        | "plan.verified"
+        | "plan.boot_posture"
+        | "plan.shares_admitted"
+        | "plan.oci_provenance" => AuditEventKind::Admission,
+        "plan.policy_resolved" => AuditEventKind::Policy,
+        "plan.exited" => AuditEventKind::Lifecycle,
+        _ => classify_lifecycle_prefix(event),
+    }
+}
+
+fn classify_lifecycle_prefix(event: &str) -> AuditEventKind {
+    if event.starts_with("lifecycle.")
+        || event.starts_with("checkpoint.")
+        || event.starts_with("cmd.")
+    {
+        AuditEventKind::Lifecycle
+    } else if event.starts_with("readiness.") || event.contains("readiness") {
+        AuditEventKind::Readiness
+    } else if event.starts_with("volume.") || event.starts_with("deps.") {
+        AuditEventKind::Volume
+    } else if event.starts_with("secret") || event.starts_with("host.secrets") {
+        AuditEventKind::SecretReference
+    } else if event.starts_with("policy.")
+        || event.starts_with("network.")
+        || event.starts_with("service.")
+        || event.starts_with("flow.")
+    {
+        AuditEventKind::Policy
+    } else {
+        AuditEventKind::Other
+    }
+}
+
+/// Map a workload-chain category onto the normalized kind.
+pub(crate) fn classify_workload_category(category: &str) -> AuditEventKind {
+    match category {
+        "plan" => AuditEventKind::Admission,
+        "lifecycle" | "cmd" => AuditEventKind::Lifecycle,
+        "secret" | "key" => AuditEventKind::SecretReference,
+        "policy" | "flow" | "dns" => AuditEventKind::Policy,
+        _ => AuditEventKind::Other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_event() -> VerifiedAuditEvent {
+        VerifiedAuditEvent {
+            id: AuditEventId {
+                source: AuditSourceId {
+                    kind: AuditSourceKind::Lifecycle,
+                    tenant: "local".into(),
+                    machine: None,
+                },
+                seq: 3,
+            },
+            kind: AuditEventKind::Launch,
+            timestamp: "2026-08-01T10:00:00+00:00".into(),
+            tenant: "local".into(),
+            machine: Some("worker".into()),
+            event: "plan.launched".into(),
+            plan_id: Some("sha256:abc".into()),
+            detail: Some("verb=up".into()),
+        }
+    }
+
+    #[test]
+    fn event_serde_roundtrip() {
+        let event = sample_event();
+        let json = serde_json::to_string(&event).unwrap();
+        let back: VerifiedAuditEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+    }
+
+    #[test]
+    fn event_rejects_unknown_fields() {
+        let mut value = serde_json::to_value(sample_event()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("smuggled".into(), serde_json::json!("x"));
+        let err = serde_json::from_value::<VerifiedAuditEvent>(value).unwrap_err();
+        assert!(err.to_string().contains("smuggled"), "{err}");
+    }
+
+    #[test]
+    fn optional_fields_are_omitted_when_absent() {
+        let mut event = sample_event();
+        event.machine = None;
+        event.plan_id = None;
+        event.detail = None;
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(!json.contains("machine"));
+        assert!(!json.contains("plan_id"));
+        assert!(!json.contains("detail"));
+        let back: VerifiedAuditEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+    }
+
+    #[test]
+    fn kind_serde_roundtrip_all_variants() {
+        for kind in [
+            AuditEventKind::Admission,
+            AuditEventKind::Launch,
+            AuditEventKind::Lifecycle,
+            AuditEventKind::Readiness,
+            AuditEventKind::Volume,
+            AuditEventKind::SecretReference,
+            AuditEventKind::Policy,
+            AuditEventKind::Refusal,
+            AuditEventKind::Other,
+        ] {
+            let json = serde_json::to_string(&kind).unwrap();
+            let back: AuditEventKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(kind, back);
+        }
+        assert_eq!(
+            serde_json::to_string(&AuditEventKind::SecretReference).unwrap(),
+            "\"secret_reference\""
+        );
+    }
+
+    #[test]
+    fn refusal_and_response_serde_roundtrip() {
+        let response = AuditReadResponse {
+            events: vec![sample_event()],
+            sources: vec![VerifiedSourceSummary {
+                source: sample_event().id.source,
+                entries: 4,
+            }],
+            refusals: vec![AuditSourceRefusal {
+                source: AuditSourceId {
+                    kind: AuditSourceKind::Workload,
+                    tenant: "local".into(),
+                    machine: Some("vm1".into()),
+                },
+                kind: AuditRefusalKind::SignatureInvalid,
+                line: Some(2),
+                detail: "signature invalid at line 2".into(),
+            }],
+            next_cursor: Some(AuditCursor::after(&sample_event())),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        let back: AuditReadResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(response, back);
+    }
+
+    #[test]
+    fn cursor_rejects_unknown_fields() {
+        let err = serde_json::from_str::<AuditCursor>(
+            r#"{"timestamp":"2026-08-01T10:00:00Z","source":{"kind":"lifecycle","tenant":"local"},"seq":0,"extra":1}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("extra"), "{err}");
+    }
+
+    #[test]
+    fn effective_limit_defaults_and_clamps() {
+        assert_eq!(
+            AuditReadRequest::builder().build().effective_limit(),
+            DEFAULT_READ_LIMIT
+        );
+        assert_eq!(
+            AuditReadRequest::builder()
+                .limit(0)
+                .build()
+                .effective_limit(),
+            1
+        );
+        assert_eq!(
+            AuditReadRequest::builder()
+                .limit(10_000)
+                .build()
+                .effective_limit(),
+            MAX_READ_LIMIT
+        );
+        assert_eq!(
+            AuditReadRequest::builder()
+                .limit(7)
+                .build()
+                .effective_limit(),
+            7
+        );
+    }
+
+    #[test]
+    fn order_key_sorts_by_time_then_source_then_seq() {
+        let lifecycle = AuditSourceId {
+            kind: AuditSourceKind::Lifecycle,
+            tenant: "local".into(),
+            machine: None,
+        };
+        let workload = AuditSourceId {
+            kind: AuditSourceKind::Workload,
+            tenant: "local".into(),
+            machine: Some("vm1".into()),
+        };
+        let older = OrderKey::new("2026-08-01T09:00:00Z", &lifecycle, 5);
+        let newer = OrderKey::new("2026-08-01T10:00:00Z", &lifecycle, 0);
+        assert!(newer > older, "later timestamp wins regardless of seq");
+
+        // Equal timestamps: deterministic source rank breaks the tie.
+        let a = OrderKey::new("2026-08-01T10:00:00Z", &lifecycle, 1);
+        let b = OrderKey::new("2026-08-01T10:00:00Z", &workload, 1);
+        assert!(a < b, "lifecycle ranks before workload at equal instants");
+
+        // Same source, equal timestamps: chain position decides.
+        let s0 = OrderKey::new("2026-08-01T10:00:00Z", &lifecycle, 0);
+        let s1 = OrderKey::new("2026-08-01T10:00:00Z", &lifecycle, 1);
+        assert!(s1 > s0);
+    }
+
+    #[test]
+    fn unparseable_timestamp_sorts_oldest() {
+        let src = AuditSourceId {
+            kind: AuditSourceKind::Lifecycle,
+            tenant: "local".into(),
+            machine: None,
+        };
+        let bad = OrderKey::new("not-a-time", &src, 99);
+        let good = OrderKey::new("1970-01-01T00:00:01Z", &src, 0);
+        assert!(bad < good);
+    }
+
+    #[test]
+    fn lifecycle_event_classification() {
+        use AuditEventKind::*;
+        let cases = [
+            ("plan.launched", Launch),
+            ("plan.running", Launch),
+            ("plan.admitted", Admission),
+            ("plan.verified", Admission),
+            ("plan.oci_provenance", Admission),
+            ("plan.boot_posture", Admission),
+            ("plan.shares_admitted", Admission),
+            ("plan.policy_resolved", Policy),
+            ("plan.failed", Refusal),
+            ("plan.rejected.nonce_replay", Refusal),
+            ("service.call.denied", Refusal),
+            ("plan.grant_required", Refusal),
+            ("plan.exited", Lifecycle),
+            ("lifecycle.tenant.destroyed", Lifecycle),
+            ("checkpoint.forked", Lifecycle),
+            ("cmd.up.completed", Lifecycle),
+            ("readiness.probe", Readiness),
+            ("volume.sealed", Volume),
+            ("deps.installed", Volume),
+            ("secret.put", SecretReference),
+            ("host.secrets.v1", SecretReference),
+            ("policy.resolved", Policy),
+            ("network.flow", Policy),
+            ("service.call", Policy),
+            ("totally.unknown", Other),
+        ];
+        for (name, want) in cases {
+            assert_eq!(classify_lifecycle_event(name), want, "{name}");
+        }
+    }
+
+    #[test]
+    fn workload_category_classification() {
+        use AuditEventKind::*;
+        let cases = [
+            ("plan", Admission),
+            ("lifecycle", Lifecycle),
+            ("cmd", Lifecycle),
+            ("secret", SecretReference),
+            ("key", SecretReference),
+            ("policy", Policy),
+            ("flow", Policy),
+            ("dns", Policy),
+            ("workload_audit", Other),
+            ("host", Other),
+            ("audit", Other),
+        ];
+        for (category, want) in cases {
+            assert_eq!(classify_workload_category(category), want, "{category}");
+        }
+    }
+}

--- a/crates/mvm-client/src/audit/mod.rs
+++ b/crates/mvm-client/src/audit/mod.rs
@@ -19,9 +19,11 @@
 //! capped at this boundary; secret material, environment values, raw
 //! payloads, host paths, and terminal control sequences never leave it.
 //!
-//! The unsigned legacy operator log (`<state_dir>/log/audit.jsonl`) is
-//! deliberately not a source: it carries no authenticity and can never be
-//! presented as trusted activity.
+//! The unsigned operator logs — the legacy `<state_dir>/log/audit.jsonl`
+//! and the `<audit_dir>/secrets.jsonl` the secret CLI writes — are
+//! deliberately not sources: they carry no authenticity and can never be
+//! presented as trusted activity, so they yield neither events nor
+//! refusals.
 
 mod event;
 mod normalize;
@@ -241,11 +243,69 @@ struct SourceFile {
     path: PathBuf,
 }
 
+/// The unsigned plain-JSON operator log `mvmctl secret …` writes into the
+/// audit directory. It is not a chain and carries no authenticity, so it
+/// is never a source — neither events nor a refusal.
+const SECRETS_OPERATOR_LOG: &str = "secrets.jsonl";
+
+/// Enumerate the source identities under `dir` without verifying anything
+/// (and without needing a verifying key). Same discovery rules as a read:
+/// lifecycle chains first, then workload chains, sorted by scope; the
+/// unsigned operator log and non-chain sidecars are never included. A
+/// missing directory is an empty host, not an error.
+pub fn discover_source_ids(
+    dir: &Path,
+    tenant: Option<&str>,
+) -> Result<Vec<AuditSourceId>, AuditReadError> {
+    Ok(discover_sources(dir, tenant)?
+        .into_iter()
+        .map(|s| s.id)
+        .collect())
+}
+
 /// Enumerate the audit sources under `dir`, optionally scoped to one
 /// tenant, in deterministic order: lifecycle chains first, then workload
-/// chains, each sorted by (tenant, machine). A missing directory is an
-/// empty host, not an error.
+/// chains, each sorted by (tenant, machine).
 fn discover_sources(dir: &Path, tenant: Option<&str>) -> Result<Vec<SourceFile>, AuditReadError> {
+    let names = list_dir_names(dir)?;
+    let mut sources: Vec<SourceFile> = match tenant {
+        // Tenant-scoped: anchor parsing on the requested tenant, exactly
+        // like the chain writers name their files — a tenant name may
+        // itself contain dots.
+        Some(tenant) => names
+            .iter()
+            .filter_map(|(name, path)| {
+                classify_for_tenant(name, tenant).map(|id| SourceFile {
+                    id,
+                    path: path.clone(),
+                })
+            })
+            .collect(),
+        // Unscoped: lifecycle stems name the tenants; workload files are
+        // matched against those known tenants first so dotted tenant
+        // names split correctly, falling back to the first dot.
+        None => {
+            let known_tenants: Vec<String> = names
+                .iter()
+                .filter_map(|(name, _)| lifecycle_tenant(name))
+                .collect();
+            names
+                .iter()
+                .filter_map(|(name, path)| {
+                    classify_unscoped(name, &known_tenants).map(|id| SourceFile {
+                        id,
+                        path: path.clone(),
+                    })
+                })
+                .collect()
+        }
+    };
+    sources.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(sources)
+}
+
+/// File names (with paths) in the audit directory. Missing dir ⇒ empty.
+fn list_dir_names(dir: &Path) -> Result<Vec<(String, PathBuf)>, AuditReadError> {
     let entries = match std::fs::read_dir(dir) {
         Ok(entries) => entries,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -256,56 +316,99 @@ fn discover_sources(dir: &Path, tenant: Option<&str>) -> Result<Vec<SourceFile>,
             });
         }
     };
-    let mut sources = Vec::new();
+    let mut names = Vec::new();
     for entry in entries {
         let entry = entry.map_err(|e| AuditReadError::Io {
             dir: dir.to_path_buf(),
             reason: e.to_string(),
         })?;
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else { continue };
-        let Some(id) = classify_file_name(name) else {
-            continue;
-        };
-        if let Some(want) = tenant
-            && id.tenant != want
-        {
-            continue;
+        if let Some(name) = entry.file_name().to_str() {
+            names.push((name.to_string(), entry.path()));
         }
-        sources.push(SourceFile {
-            id,
-            path: entry.path(),
-        });
     }
-    sources.sort_by(|a, b| a.id.cmp(&b.id));
-    Ok(sources)
+    Ok(names)
 }
 
-/// Map a file name in the audit directory onto a source identity.
-/// `<tenant>.<vm>.workload.jsonl` is a workload chain, any other
-/// `*.jsonl` is a per-tenant lifecycle chain; sidecars (`*.root.json`,
-/// transcripts, heads) are not sources.
-fn classify_file_name(name: &str) -> Option<AuditSourceId> {
-    if let Some(stem) = name.strip_suffix(mvm_core::config::WORKLOAD_AUDIT_SUFFIX) {
-        let (tenant, vm) = stem.split_once('.')?;
-        if tenant.is_empty() || vm.is_empty() {
-            return None;
-        }
+/// Tenant named by a lifecycle chain file (`<tenant>.jsonl`), excluding
+/// the unsigned operator log and workload chains.
+fn lifecycle_tenant(name: &str) -> Option<String> {
+    if name == SECRETS_OPERATOR_LOG || name.ends_with(mvm_core::config::WORKLOAD_AUDIT_SUFFIX) {
+        return None;
+    }
+    let tenant = name.strip_suffix(".jsonl")?;
+    if tenant.is_empty() {
+        return None;
+    }
+    Some(tenant.to_string())
+}
+
+/// Tenant-anchored classification: is `name` one of `tenant`'s chains?
+/// Uses the same naming helper the chain writers use, so a tenant name
+/// containing dots parses identically on both sides.
+fn classify_for_tenant(name: &str, tenant: &str) -> Option<AuditSourceId> {
+    if name == SECRETS_OPERATOR_LOG {
+        return None;
+    }
+    if let Some(vm) = mvm_core::config::workload_audit_vm_name(name, tenant) {
         return Some(AuditSourceId {
             kind: AuditSourceKind::Workload,
             tenant: tenant.to_string(),
             machine: Some(vm.to_string()),
         });
     }
-    let tenant = name.strip_suffix(".jsonl")?;
-    if tenant.is_empty() {
+    if lifecycle_tenant(name).is_some_and(|t| t == tenant) {
+        return Some(AuditSourceId {
+            kind: AuditSourceKind::Lifecycle,
+            tenant: tenant.to_string(),
+            machine: None,
+        });
+    }
+    None
+}
+
+/// Unscoped classification of one file name. Workload stems are matched
+/// against the known lifecycle tenants (longest match wins) before the
+/// first-dot fallback, so `<a.b>.<vm>.workload.jsonl` splits correctly
+/// whenever tenant `a.b` has a lifecycle chain alongside.
+fn classify_unscoped(name: &str, known_tenants: &[String]) -> Option<AuditSourceId> {
+    if name == SECRETS_OPERATOR_LOG {
         return None;
     }
-    Some(AuditSourceId {
+    if let Some(stem) = name.strip_suffix(mvm_core::config::WORKLOAD_AUDIT_SUFFIX) {
+        let (tenant, vm) = split_workload_stem(stem, known_tenants)?;
+        return Some(AuditSourceId {
+            kind: AuditSourceKind::Workload,
+            tenant,
+            machine: Some(vm),
+        });
+    }
+    lifecycle_tenant(name).map(|tenant| AuditSourceId {
         kind: AuditSourceKind::Lifecycle,
-        tenant: tenant.to_string(),
+        tenant,
         machine: None,
     })
+}
+
+/// Split a workload-chain stem (`<tenant>.<vm>`) into its parts: longest
+/// known-tenant prefix first, then the first-dot fallback.
+fn split_workload_stem(stem: &str, known_tenants: &[String]) -> Option<(String, String)> {
+    let known = known_tenants
+        .iter()
+        .filter_map(|t| {
+            stem.strip_prefix(t.as_str())
+                .and_then(|rest| rest.strip_prefix('.'))
+                .filter(|vm| !vm.is_empty())
+                .map(|vm| (t.clone(), vm.to_string()))
+        })
+        .max_by_key(|(t, _)| t.len());
+    if known.is_some() {
+        return known;
+    }
+    let (tenant, vm) = stem.split_once('.')?;
+    if tenant.is_empty() || vm.is_empty() {
+        return None;
+    }
+    Some((tenant.to_string(), vm.to_string()))
 }
 
 /// Apply the request's machine, kind, and time-window filters.

--- a/crates/mvm-client/src/audit/mod.rs
+++ b/crates/mvm-client/src/audit/mod.rs
@@ -1,0 +1,342 @@
+//! Verified, normalized local audit events for UI consumers.
+//!
+//! [`LocalAuditReader`] is the one seam through which a local consumer
+//! (mvm-studio, `mvmctl audit verify`) reads mvm's chain-signed audit
+//! sources. It discovers the per-tenant lifecycle chains
+//! (`<audit_dir>/<tenant>.jsonl`) and the per-VM workload chains
+//! (`<audit_dir>/<tenant>.<vm>.workload.jsonl`), verifies each through the
+//! canonical verifiers (`mvm_hostd::supervisor::verify_audit_chain_entries`
+//! and `mvm_hostd::audit_signer::verify::verify_workload_chain_entries`),
+//! and returns normalized [`VerifiedAuditEvent`]s only from sources whose
+//! signatures, chain links, and tenant scope all hold. A source that fails
+//! any check contributes an explicit typed [`AuditSourceRefusal`] and
+//! **zero** events — never a partial prefix, never an unverified line.
+//!
+//! Reads are bounded and newest-first with a typed cursor; ordering is a
+//! pure function of signed entry content and source identity (timestamp,
+//! then source rank, then chain position), so pagination is stable across
+//! reads without rewriting any chain. All free text is sanitized and
+//! capped at this boundary; secret material, environment values, raw
+//! payloads, host paths, and terminal control sequences never leave it.
+//!
+//! The unsigned legacy operator log (`<state_dir>/log/audit.jsonl`) is
+//! deliberately not a source: it carries no authenticity and can never be
+//! presented as trusted activity.
+
+mod event;
+mod normalize;
+mod sanitize;
+
+pub use event::{
+    AuditCursor, AuditEventId, AuditEventKind, AuditReadRequest, AuditReadRequestBuilder,
+    AuditReadResponse, AuditRefusalKind, AuditSourceId, AuditSourceKind, AuditSourceRefusal,
+    DEFAULT_READ_LIMIT, MAX_READ_LIMIT, VerifiedAuditEvent, VerifiedSourceSummary,
+};
+pub use sanitize::{MAX_DETAIL_LEN, MAX_FIELD_LEN, REDACTED_PATH, sanitize_free_text};
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use ed25519_dalek::VerifyingKey;
+use thiserror::Error;
+
+use event::{OrderKey, parse_ts_millis};
+use normalize::{
+    normalize_lifecycle_entry, normalize_workload_entry, refusal_from_lifecycle,
+    refusal_from_workload, scope_mismatch_refusal,
+};
+
+/// Infrastructure failure of a read. Verification failures are **not**
+/// errors — they surface as typed refusals in the response.
+#[derive(Debug, Error)]
+pub enum AuditReadError {
+    /// The audit directory could not be enumerated.
+    #[error("reading audit directory {dir}: {reason}")]
+    Io {
+        /// Directory the reader was pointed at.
+        dir: PathBuf,
+        /// Underlying I/O failure.
+        reason: String,
+    },
+    /// The trusted host verifying key could not be loaded.
+    #[error("loading host signer key: {0}")]
+    Signer(String),
+}
+
+/// Outcome of verifying every discovered source without reading a page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceVerification {
+    /// Sources that verified clean, in deterministic order (lifecycle
+    /// chains first, then workload chains, each sorted by scope).
+    pub sources: Vec<VerifiedSourceSummary>,
+    /// Sources withheld because verification failed.
+    pub refusals: Vec<AuditSourceRefusal>,
+}
+
+/// Verified local audit reader: one audit directory, one trusted key.
+pub struct LocalAuditReader {
+    audit_dir: PathBuf,
+    verifying_key: VerifyingKey,
+}
+
+impl LocalAuditReader {
+    /// Reader over an explicit audit directory and trusted verifying key.
+    pub fn new(audit_dir: impl Into<PathBuf>, verifying_key: VerifyingKey) -> Self {
+        Self {
+            audit_dir: audit_dir.into(),
+            verifying_key,
+        }
+    }
+
+    /// Reader over the host's default audit directory
+    /// (`<mvm_home>/audit/`) and the host signer's verifying key.
+    pub fn open_default() -> Result<Self, AuditReadError> {
+        let dir = mvm_hostd::audit::emitter::default_audit_dir()
+            .map_err(|e| AuditReadError::Signer(e.to_string()))?;
+        let signer = mvm_hostd::audit::host_keypair::load_or_init()
+            .map_err(|e| AuditReadError::Signer(e.to_string()))?;
+        Ok(Self::new(dir, signer.verifying))
+    }
+
+    /// Verify every discovered source (optionally scoped to one tenant)
+    /// and report per-source outcomes without materializing events.
+    pub fn verify_sources(
+        &self,
+        tenant: Option<&str>,
+    ) -> Result<SourceVerification, AuditReadError> {
+        let collected = self.collect(tenant)?;
+        Ok(SourceVerification {
+            sources: collected
+                .verified
+                .iter()
+                .map(|(summary, _)| summary.clone())
+                .collect(),
+            refusals: collected.refusals,
+        })
+    }
+
+    /// Bounded newest-first read of verified events. See the module docs
+    /// for the ordering, identity, and refusal contract.
+    pub fn read(&self, request: &AuditReadRequest) -> Result<AuditReadResponse, AuditReadError> {
+        let collected = self.collect(request.tenant.as_deref())?;
+        let sources: Vec<VerifiedSourceSummary> = collected
+            .verified
+            .iter()
+            .map(|(summary, _)| summary.clone())
+            .collect();
+
+        let mut events: Vec<VerifiedAuditEvent> = collected
+            .verified
+            .into_iter()
+            .flat_map(|(_, events)| events)
+            .filter(|e| event_matches(request, e))
+            .collect();
+        // Newest first: descending by the stable ordering key.
+        events.sort_by(|a, b| OrderKey::of_event(b).cmp(&OrderKey::of_event(a)));
+
+        if let Some(cursor) = &request.cursor {
+            let cursor_key = OrderKey::of_cursor(cursor);
+            events.retain(|e| OrderKey::of_event(e) < cursor_key);
+        }
+
+        let limit = request.effective_limit();
+        let has_more = events.len() > limit;
+        events.truncate(limit);
+        let next_cursor = if has_more {
+            events.last().map(AuditCursor::after)
+        } else {
+            None
+        };
+
+        Ok(AuditReadResponse {
+            events,
+            sources,
+            refusals: collected.refusals,
+            next_cursor,
+        })
+    }
+
+    /// Verify every discovered source, splitting clean sources (with their
+    /// normalized events) from typed refusals. A refused source
+    /// contributes no events at all.
+    fn collect(&self, tenant: Option<&str>) -> Result<Collected, AuditReadError> {
+        let mut verified = Vec::new();
+        let mut refusals = Vec::new();
+        for source_file in discover_sources(&self.audit_dir, tenant)? {
+            match self.verify_one(&source_file) {
+                Ok((summary, events)) => verified.push((summary, events)),
+                Err(refusal) => refusals.push(*refusal),
+            }
+        }
+        Ok(Collected { verified, refusals })
+    }
+
+    /// Verify one source end-to-end: chain verification through the
+    /// canonical seam, then tenant-scope check, then normalization.
+    fn verify_one(
+        &self,
+        source_file: &SourceFile,
+    ) -> Result<(VerifiedSourceSummary, Vec<VerifiedAuditEvent>), Box<AuditSourceRefusal>> {
+        let source = &source_file.id;
+        let events = match source.kind {
+            AuditSourceKind::Lifecycle => {
+                let entries = mvm_hostd::supervisor::verify_audit_chain_entries(
+                    &source_file.path,
+                    &self.verifying_key,
+                )
+                .map_err(|e| Box::new(refusal_from_lifecycle(source, &e)))?;
+                for (i, entry) in entries.iter().enumerate() {
+                    if entry.tenant.0 != source.tenant {
+                        return Err(Box::new(scope_mismatch_refusal(
+                            source,
+                            i as u64,
+                            &entry.tenant.0,
+                        )));
+                    }
+                }
+                entries
+                    .iter()
+                    .enumerate()
+                    .map(|(i, entry)| normalize_lifecycle_entry(source, i as u64, entry))
+                    .collect::<Vec<_>>()
+            }
+            AuditSourceKind::Workload => {
+                let entries = mvm_hostd::audit_signer::verify::verify_workload_chain_entries(
+                    &source_file.path,
+                    &self.verifying_key,
+                )
+                .map_err(|e| Box::new(refusal_from_workload(source, &e)))?;
+                for (i, entry) in entries.iter().enumerate() {
+                    if entry.tenant_id != source.tenant {
+                        return Err(Box::new(scope_mismatch_refusal(
+                            source,
+                            i as u64,
+                            &entry.tenant_id,
+                        )));
+                    }
+                }
+                entries
+                    .iter()
+                    .enumerate()
+                    .map(|(i, entry)| normalize_workload_entry(source, i as u64, entry))
+                    .collect::<Vec<_>>()
+            }
+        };
+        let summary = VerifiedSourceSummary {
+            source: source.clone(),
+            entries: events.len() as u64,
+        };
+        Ok((summary, events))
+    }
+}
+
+struct Collected {
+    verified: Vec<(VerifiedSourceSummary, Vec<VerifiedAuditEvent>)>,
+    refusals: Vec<AuditSourceRefusal>,
+}
+
+/// One discovered chain file.
+struct SourceFile {
+    id: AuditSourceId,
+    path: PathBuf,
+}
+
+/// Enumerate the audit sources under `dir`, optionally scoped to one
+/// tenant, in deterministic order: lifecycle chains first, then workload
+/// chains, each sorted by (tenant, machine). A missing directory is an
+/// empty host, not an error.
+fn discover_sources(dir: &Path, tenant: Option<&str>) -> Result<Vec<SourceFile>, AuditReadError> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(AuditReadError::Io {
+                dir: dir.to_path_buf(),
+                reason: e.to_string(),
+            });
+        }
+    };
+    let mut sources = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|e| AuditReadError::Io {
+            dir: dir.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(id) = classify_file_name(name) else {
+            continue;
+        };
+        if let Some(want) = tenant
+            && id.tenant != want
+        {
+            continue;
+        }
+        sources.push(SourceFile {
+            id,
+            path: entry.path(),
+        });
+    }
+    sources.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(sources)
+}
+
+/// Map a file name in the audit directory onto a source identity.
+/// `<tenant>.<vm>.workload.jsonl` is a workload chain, any other
+/// `*.jsonl` is a per-tenant lifecycle chain; sidecars (`*.root.json`,
+/// transcripts, heads) are not sources.
+fn classify_file_name(name: &str) -> Option<AuditSourceId> {
+    if let Some(stem) = name.strip_suffix(mvm_core::config::WORKLOAD_AUDIT_SUFFIX) {
+        let (tenant, vm) = stem.split_once('.')?;
+        if tenant.is_empty() || vm.is_empty() {
+            return None;
+        }
+        return Some(AuditSourceId {
+            kind: AuditSourceKind::Workload,
+            tenant: tenant.to_string(),
+            machine: Some(vm.to_string()),
+        });
+    }
+    let tenant = name.strip_suffix(".jsonl")?;
+    if tenant.is_empty() {
+        return None;
+    }
+    Some(AuditSourceId {
+        kind: AuditSourceKind::Lifecycle,
+        tenant: tenant.to_string(),
+        machine: None,
+    })
+}
+
+/// Apply the request's machine, kind, and time-window filters.
+fn event_matches(request: &AuditReadRequest, event: &VerifiedAuditEvent) -> bool {
+    if let Some(machine) = &request.machine
+        && event.machine.as_deref() != Some(machine.as_str())
+    {
+        return false;
+    }
+    if !request.kinds.is_empty() && !request.kinds.contains(&event.kind) {
+        return false;
+    }
+    if request.since.is_some() || request.until.is_some() {
+        let ts = parse_ts_millis(&event.timestamp);
+        if let Some(since) = request.since
+            && ts < instant_millis(since)
+        {
+            return false;
+        }
+        if let Some(until) = request.until
+            && ts > instant_millis(until)
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn instant_millis(instant: DateTime<Utc>) -> i64 {
+    instant.timestamp_millis()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/mvm-client/src/audit/normalize.rs
+++ b/crates/mvm-client/src/audit/normalize.rs
@@ -1,0 +1,417 @@
+//! Normalization from verified chain entries to [`VerifiedAuditEvent`]s
+//! and from verifier errors to typed [`AuditSourceRefusal`]s.
+//!
+//! Only already-verified entries reach the normalizers here — the service
+//! never normalizes an entry whose source failed verification. Refusal
+//! mapping keeps the verifier taxonomy (malformed / broken link / bad
+//! signature) without leaking raw error payloads.
+
+use std::collections::BTreeMap;
+
+use mvm_hostd::audit_signer::canonical::CanonicalEntry;
+use mvm_hostd::audit_signer::verify::WorkloadVerifyError;
+use mvm_hostd::supervisor::{
+    AuditEntry, UNBOUND_IMAGE_NAME, UNBOUND_PLAN_ID, VerifyError as LifecycleVerifyError,
+};
+
+use super::event::{
+    AuditEventId, AuditRefusalKind, AuditSourceId, AuditSourceRefusal, VerifiedAuditEvent,
+    classify_lifecycle_event, classify_workload_category,
+};
+use super::sanitize::{
+    MAX_DETAIL_LEN, MAX_FIELD_LEN, is_sensitive_label_key, sanitize_free_text, sanitize_label_value,
+};
+
+/// Label keys inspected (in order) when deriving the machine name of a
+/// lifecycle event.
+const MACHINE_LABEL_KEYS: &[&str] = &["vm", "vm_name", "machine", "workload"];
+
+/// Normalize one verified lifecycle-chain entry.
+pub(crate) fn normalize_lifecycle_entry(
+    source: &AuditSourceId,
+    seq: u64,
+    entry: &AuditEntry,
+) -> VerifiedAuditEvent {
+    VerifiedAuditEvent {
+        id: AuditEventId {
+            source: source.clone(),
+            seq,
+        },
+        kind: classify_lifecycle_event(&entry.event),
+        timestamp: entry.timestamp.to_rfc3339(),
+        tenant: entry.tenant.0.clone(),
+        machine: lifecycle_machine(entry),
+        event: sanitize_free_text(&entry.event, MAX_FIELD_LEN),
+        plan_id: lifecycle_plan_id(entry),
+        detail: render_labels(&entry.labels),
+    }
+}
+
+/// Normalize one verified workload-chain entry. The entry's free-form
+/// `fields` payload is deliberately never rendered — it can carry raw
+/// policy payloads and guest-influenced bytes.
+pub(crate) fn normalize_workload_entry(
+    source: &AuditSourceId,
+    seq: u64,
+    entry: &CanonicalEntry,
+) -> VerifiedAuditEvent {
+    let detail = format!(
+        "correlation_id={} session_id={} workload_id={}",
+        sanitize_free_text(&entry.correlation_id, MAX_FIELD_LEN),
+        sanitize_free_text(&entry.session_id, MAX_FIELD_LEN),
+        sanitize_free_text(&entry.workload_id, MAX_FIELD_LEN),
+    );
+    VerifiedAuditEvent {
+        id: AuditEventId {
+            source: source.clone(),
+            seq,
+        },
+        kind: classify_workload_category(&entry.category),
+        timestamp: sanitize_free_text(&entry.ts, MAX_FIELD_LEN),
+        tenant: entry.tenant_id.clone(),
+        machine: source.machine.clone(),
+        event: sanitize_free_text(&entry.category, MAX_FIELD_LEN),
+        plan_id: None,
+        detail: Some(sanitize_free_text(&detail, MAX_DETAIL_LEN)),
+    }
+}
+
+/// Machine name of a lifecycle event: an explicit machine-ish label wins,
+/// then the image name unless it is the unbound placeholder.
+fn lifecycle_machine(entry: &AuditEntry) -> Option<String> {
+    for key in MACHINE_LABEL_KEYS {
+        if let Some(value) = entry.labels.get(*key) {
+            return Some(sanitize_free_text(value, MAX_FIELD_LEN));
+        }
+    }
+    if entry.image_name == UNBOUND_IMAGE_NAME {
+        None
+    } else {
+        Some(sanitize_free_text(&entry.image_name, MAX_FIELD_LEN))
+    }
+}
+
+/// Plan id unless the entry is the unbound placeholder.
+fn lifecycle_plan_id(entry: &AuditEntry) -> Option<String> {
+    if entry.plan_id.0 == UNBOUND_PLAN_ID {
+        None
+    } else {
+        Some(sanitize_free_text(&entry.plan_id.0, MAX_FIELD_LEN))
+    }
+}
+
+/// Render labels as sorted `k=v` pairs, dropping sensitive keys and
+/// redacting path-like values, capped at the detail limit.
+fn render_labels(labels: &BTreeMap<String, String>) -> Option<String> {
+    let pairs: Vec<String> = labels
+        .iter()
+        .filter(|(key, _)| !is_sensitive_label_key(key))
+        .map(|(key, value)| {
+            format!(
+                "{}={}",
+                sanitize_free_text(key, MAX_FIELD_LEN),
+                sanitize_label_value(value)
+            )
+        })
+        .collect();
+    if pairs.is_empty() {
+        None
+    } else {
+        Some(sanitize_free_text(&pairs.join(" "), MAX_DETAIL_LEN))
+    }
+}
+
+/// Map a lifecycle-chain verification failure to a typed refusal.
+pub(crate) fn refusal_from_lifecycle(
+    source: &AuditSourceId,
+    err: &LifecycleVerifyError,
+) -> AuditSourceRefusal {
+    let (kind, line) = match err {
+        LifecycleVerifyError::Io(_) => (AuditRefusalKind::Io, None),
+        LifecycleVerifyError::Malformed { line, .. } => {
+            (AuditRefusalKind::Malformed, Some(*line as u64))
+        }
+        LifecycleVerifyError::PrevHashMismatch { line } => {
+            (AuditRefusalKind::ChainBroken, Some(*line as u64))
+        }
+        LifecycleVerifyError::SignatureInvalid { line } => {
+            (AuditRefusalKind::SignatureInvalid, Some(*line as u64))
+        }
+    };
+    refusal(source, kind, line, &err.to_string())
+}
+
+/// Map a workload-chain verification failure to a typed refusal.
+pub(crate) fn refusal_from_workload(
+    source: &AuditSourceId,
+    err: &WorkloadVerifyError,
+) -> AuditSourceRefusal {
+    let (kind, line) = match err {
+        WorkloadVerifyError::Io(_) => (AuditRefusalKind::Io, None),
+        WorkloadVerifyError::Malformed { line, .. }
+        | WorkloadVerifyError::NonCanonical { line }
+        | WorkloadVerifyError::DisallowedCategory { line, .. }
+        | WorkloadVerifyError::UnsupportedSigAlg { line, .. } => {
+            (AuditRefusalKind::Malformed, Some(*line as u64))
+        }
+        WorkloadVerifyError::PrevHashMismatch { line }
+        | WorkloadVerifyError::EntryHashMismatch { line } => {
+            (AuditRefusalKind::ChainBroken, Some(*line as u64))
+        }
+        WorkloadVerifyError::SignatureInvalid { line } => {
+            (AuditRefusalKind::SignatureInvalid, Some(*line as u64))
+        }
+    };
+    refusal(source, kind, line, &err.to_string())
+}
+
+/// Typed refusal for a verified entry that claims a scope other than its
+/// source's (e.g. a foreign tenant's entry spliced into this tenant's file
+/// by a signer confusion).
+pub(crate) fn scope_mismatch_refusal(
+    source: &AuditSourceId,
+    line: u64,
+    found_tenant: &str,
+) -> AuditSourceRefusal {
+    refusal(
+        source,
+        AuditRefusalKind::ScopeMismatch,
+        Some(line),
+        &format!(
+            "entry at line {line} claims tenant '{}' but the source is scoped to tenant '{}'",
+            sanitize_free_text(found_tenant, MAX_FIELD_LEN),
+            source.tenant
+        ),
+    )
+}
+
+fn refusal(
+    source: &AuditSourceId,
+    kind: AuditRefusalKind,
+    line: Option<u64>,
+    detail: &str,
+) -> AuditSourceRefusal {
+    AuditSourceRefusal {
+        source: source.clone(),
+        kind,
+        line,
+        detail: sanitize_free_text(detail, MAX_DETAIL_LEN),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::event::AuditEventKind;
+    use super::*;
+    use chrono::Utc;
+    use mvm_core::plan::{PlanId, TenantId};
+
+    fn lifecycle_source() -> AuditSourceId {
+        AuditSourceId {
+            kind: super::super::event::AuditSourceKind::Lifecycle,
+            tenant: "local".into(),
+            machine: None,
+        }
+    }
+
+    fn workload_source() -> AuditSourceId {
+        AuditSourceId {
+            kind: super::super::event::AuditSourceKind::Workload,
+            tenant: "local".into(),
+            machine: Some("vm1".into()),
+        }
+    }
+
+    fn entry(event: &str) -> AuditEntry {
+        AuditEntry {
+            timestamp: Utc::now(),
+            tenant: TenantId("local".into()),
+            plan_id: PlanId("sha256:abc".into()),
+            plan_version: 1,
+            bundle_id: None,
+            bundle_version: None,
+            image_name: "worker-img".into(),
+            image_sha256: "abc123".into(),
+            event: event.into(),
+            labels: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn lifecycle_entry_normalizes_core_fields() {
+        let e = entry("plan.launched");
+        let out = normalize_lifecycle_entry(&lifecycle_source(), 4, &e);
+        assert_eq!(out.kind, AuditEventKind::Launch);
+        assert_eq!(out.tenant, "local");
+        assert_eq!(out.id.seq, 4);
+        assert_eq!(out.event, "plan.launched");
+        assert_eq!(out.plan_id.as_deref(), Some("sha256:abc"));
+        assert_eq!(out.machine.as_deref(), Some("worker-img"));
+        assert!(out.detail.is_none(), "no labels ⇒ no detail");
+    }
+
+    #[test]
+    fn machine_label_outranks_image_name() {
+        let mut e = entry("plan.launched");
+        e.labels.insert("vm".into(), "my-vm".into());
+        let out = normalize_lifecycle_entry(&lifecycle_source(), 0, &e);
+        assert_eq!(out.machine.as_deref(), Some("my-vm"));
+    }
+
+    #[test]
+    fn unbound_placeholders_map_to_none() {
+        let mut e = entry("lifecycle.tenant.destroyed");
+        e.plan_id = PlanId(UNBOUND_PLAN_ID.into());
+        e.image_name = UNBOUND_IMAGE_NAME.into();
+        let out = normalize_lifecycle_entry(&lifecycle_source(), 0, &e);
+        assert!(out.plan_id.is_none());
+        assert!(out.machine.is_none());
+    }
+
+    #[test]
+    fn sensitive_labels_are_dropped_from_detail() {
+        let mut e = entry("plan.admitted");
+        e.labels.insert("verb".into(), "up".into());
+        e.labels.insert("api_token".into(), "sk-live-123".into());
+        e.labels.insert("env_home".into(), "/Users/alice".into());
+        let out = normalize_lifecycle_entry(&lifecycle_source(), 0, &e);
+        let detail = out.detail.unwrap();
+        assert!(detail.contains("verb=up"));
+        assert!(!detail.contains("sk-live-123"), "{detail}");
+        assert!(!detail.contains("alice"), "{detail}");
+    }
+
+    #[test]
+    fn path_values_are_redacted_in_detail() {
+        let mut e = entry("plan.admitted");
+        e.labels.insert(
+            "rootfs".into(),
+            "/Users/alice/.mvm/cache/rootfs.ext4".into(),
+        );
+        let out = normalize_lifecycle_entry(&lifecycle_source(), 0, &e);
+        let detail = out.detail.unwrap();
+        assert!(detail.contains("rootfs=[redacted-path]"), "{detail}");
+        assert!(!detail.contains(".mvm"), "{detail}");
+    }
+
+    #[test]
+    fn control_sequences_are_stripped_from_event_and_detail() {
+        let mut e = entry("plan.\u{1b}[31madmitted");
+        e.labels
+            .insert("note".into(), "line1\nline2\u{1b}]0;t\u{07}".into());
+        let out = normalize_lifecycle_entry(&lifecycle_source(), 0, &e);
+        assert_eq!(out.event, "plan.admitted");
+        let detail = out.detail.unwrap();
+        assert!(!detail.contains('\n'), "{detail:?}");
+        assert!(!detail.contains('\u{1b}'), "{detail:?}");
+    }
+
+    #[test]
+    fn oversized_labels_are_capped() {
+        let mut e = entry("plan.admitted");
+        e.labels.insert("big".into(), "z".repeat(4000));
+        let out = normalize_lifecycle_entry(&lifecycle_source(), 0, &e);
+        let detail = out.detail.unwrap();
+        assert!(detail.chars().count() <= MAX_DETAIL_LEN, "{}", detail.len());
+    }
+
+    #[test]
+    fn workload_entry_normalizes_without_fields_payload() {
+        let e = CanonicalEntry {
+            category: "policy".into(),
+            correlation_id: "corr-1".into(),
+            fields: serde_json::json!({"raw_policy": "SUPER-SENSITIVE"}),
+            prev_hash: "0".repeat(64),
+            session_id: "sess-9".into(),
+            tenant_id: "local".into(),
+            ts: "2026-08-01T10:00:00Z".into(),
+            workload_id: "wl-7".into(),
+        };
+        let out = normalize_workload_entry(&workload_source(), 2, &e);
+        assert_eq!(out.kind, AuditEventKind::Policy);
+        assert_eq!(out.tenant, "local");
+        assert_eq!(out.machine.as_deref(), Some("vm1"));
+        assert_eq!(out.event, "policy");
+        let detail = out.detail.unwrap();
+        assert!(detail.contains("corr-1"));
+        assert!(
+            !detail.contains("SUPER-SENSITIVE"),
+            "raw fields payload must never be rendered: {detail}"
+        );
+    }
+
+    #[test]
+    fn lifecycle_refusals_map_to_typed_kinds() {
+        let src = lifecycle_source();
+        let cases = [
+            (
+                LifecycleVerifyError::Io("nope".into()),
+                AuditRefusalKind::Io,
+                None,
+            ),
+            (
+                LifecycleVerifyError::Malformed {
+                    line: 3,
+                    reason: "bad".into(),
+                },
+                AuditRefusalKind::Malformed,
+                Some(3),
+            ),
+            (
+                LifecycleVerifyError::PrevHashMismatch { line: 1 },
+                AuditRefusalKind::ChainBroken,
+                Some(1),
+            ),
+            (
+                LifecycleVerifyError::SignatureInvalid { line: 0 },
+                AuditRefusalKind::SignatureInvalid,
+                Some(0),
+            ),
+        ];
+        for (err, want_kind, want_line) in cases {
+            let r = refusal_from_lifecycle(&src, &err);
+            assert_eq!(r.kind, want_kind);
+            assert_eq!(r.line, want_line);
+            assert_eq!(r.source, src);
+        }
+    }
+
+    #[test]
+    fn workload_refusals_map_to_typed_kinds() {
+        let src = workload_source();
+        let cases = [
+            (
+                WorkloadVerifyError::NonCanonical { line: 2 },
+                AuditRefusalKind::Malformed,
+            ),
+            (
+                WorkloadVerifyError::EntryHashMismatch { line: 5 },
+                AuditRefusalKind::ChainBroken,
+            ),
+            (
+                WorkloadVerifyError::SignatureInvalid { line: 4 },
+                AuditRefusalKind::SignatureInvalid,
+            ),
+            (
+                WorkloadVerifyError::UnsupportedSigAlg {
+                    line: 0,
+                    sig_alg: 9,
+                },
+                AuditRefusalKind::Malformed,
+            ),
+        ];
+        for (err, want_kind) in cases {
+            assert_eq!(refusal_from_workload(&src, &err).kind, want_kind);
+        }
+    }
+
+    #[test]
+    fn scope_mismatch_refusal_names_both_tenants_sanitized() {
+        let r = scope_mismatch_refusal(&lifecycle_source(), 7, "evil\u{1b}[2Jtenant");
+        assert_eq!(r.kind, AuditRefusalKind::ScopeMismatch);
+        assert_eq!(r.line, Some(7));
+        assert!(r.detail.contains("eviltenant"), "{}", r.detail);
+        assert!(r.detail.contains("local"));
+        assert!(!r.detail.contains('\u{1b}'));
+    }
+}

--- a/crates/mvm-client/src/audit/sanitize.rs
+++ b/crates/mvm-client/src/audit/sanitize.rs
@@ -1,0 +1,255 @@
+//! Free-text sanitization for the verified-audit service boundary.
+//!
+//! Every string that leaves this service and could reach a UI passes
+//! through here first: terminal control sequences are stripped, control
+//! characters dropped, lengths capped, sensitive label keys filtered, and
+//! values that look like host filesystem paths redacted. A signed audit
+//! entry is authentic, but its label values may carry guest-influenced
+//! bytes — authenticity is not display-safety.
+
+use std::borrow::Cow;
+
+/// Maximum characters in a rendered `detail` string.
+pub const MAX_DETAIL_LEN: usize = 512;
+
+/// Maximum characters in a single field (event name, machine, label value).
+pub const MAX_FIELD_LEN: usize = 128;
+
+/// Replacement emitted for values that look like host filesystem paths.
+pub const REDACTED_PATH: &str = "[redacted-path]";
+
+/// Marker appended when a string was truncated at the cap.
+const TRUNCATION_MARK: char = '…';
+
+/// Strip terminal control sequences and control characters, then cap the
+/// result at `max_len` characters (appending a truncation mark when cut).
+pub fn sanitize_free_text(input: &str, max_len: usize) -> String {
+    cap_chars(&strip_control_sequences(input), max_len)
+}
+
+/// Label keys whose values must never be rendered. Substring match on the
+/// lowercased key; over-redaction is acceptable, leakage is not.
+const SENSITIVE_KEY_FRAGMENTS: &[&str] = &[
+    "secret",
+    "token",
+    "password",
+    "passwd",
+    "credential",
+    "private",
+    "env",
+    "key",
+    "auth",
+];
+
+/// True when a label key names material that must not be rendered
+/// (secret values, environment values, credentials, key material).
+pub fn is_sensitive_label_key(key: &str) -> bool {
+    let lower = key.to_ascii_lowercase();
+    SENSITIVE_KEY_FRAGMENTS.iter().any(|f| lower.contains(f))
+}
+
+/// Sanitize one label value for display: host-path-looking values are
+/// replaced wholesale, everything else is control-stripped and capped.
+pub fn sanitize_label_value(value: &str) -> String {
+    match redact_host_path(value) {
+        Cow::Borrowed(v) => sanitize_free_text(v, MAX_FIELD_LEN),
+        Cow::Owned(redacted) => redacted,
+    }
+}
+
+/// Replace values that look like filesystem paths. Any absolute path is
+/// treated as a potential host path — a UI consumer never needs one, and
+/// guessing which absolute paths are "safe" is how leaks happen.
+fn redact_host_path(value: &str) -> Cow<'_, str> {
+    let trimmed = value.trim_start();
+    if trimmed.starts_with('/') || trimmed.starts_with("~/") || value.contains("/.mvm") {
+        Cow::Owned(REDACTED_PATH.to_string())
+    } else {
+        Cow::Borrowed(value)
+    }
+}
+
+/// Parser state for [`strip_control_sequences`].
+enum StripState {
+    /// Plain text.
+    Normal,
+    /// Saw ESC; the next char decides the sequence family.
+    Escape,
+    /// Inside a CSI sequence (`ESC [` … final byte 0x40–0x7e).
+    Csi,
+    /// Inside an OSC sequence (`ESC ]` … BEL or `ESC \`).
+    Osc,
+}
+
+/// Remove ANSI escape sequences (CSI, OSC, and two-char escapes) and all
+/// remaining control characters. The output is single-line printable text.
+fn strip_control_sequences(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut state = StripState::Normal;
+    for c in input.chars() {
+        state = match state {
+            StripState::Normal => match c {
+                '\u{1b}' => StripState::Escape,
+                c if c.is_control() => StripState::Normal, // drop
+                c => {
+                    out.push(c);
+                    StripState::Normal
+                }
+            },
+            StripState::Escape => match c {
+                '[' => StripState::Csi,
+                ']' => StripState::Osc,
+                // Two-character escape (ESC + one byte): swallow it.
+                _ => StripState::Normal,
+            },
+            StripState::Csi => {
+                // Parameter (0x30–0x3f) and intermediate (0x20–0x2f) bytes
+                // continue the sequence; a final byte (0x40–0x7e) ends it.
+                if ('\u{40}'..='\u{7e}').contains(&c) {
+                    StripState::Normal
+                } else {
+                    StripState::Csi
+                }
+            }
+            StripState::Osc => match c {
+                // OSC terminates on BEL or on ESC (which begins ST `ESC \`).
+                '\u{07}' => StripState::Normal,
+                '\u{1b}' => StripState::Escape,
+                _ => StripState::Osc,
+            },
+        };
+    }
+    out
+}
+
+/// Cap `s` at `max` characters, appending a truncation mark when cut.
+fn cap_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let keep = max.saturating_sub(1);
+    let mut out: String = s.chars().take(keep).collect();
+    out.push(TRUNCATION_MARK);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_text_passes_through() {
+        assert_eq!(sanitize_free_text("plan.admitted", 64), "plan.admitted");
+    }
+
+    #[test]
+    fn csi_color_sequence_is_stripped() {
+        assert_eq!(
+            sanitize_free_text("\u{1b}[31mred\u{1b}[0m text", 64),
+            "red text"
+        );
+    }
+
+    #[test]
+    fn osc_title_sequence_is_stripped() {
+        assert_eq!(
+            sanitize_free_text("\u{1b}]0;evil title\u{07}after", 64),
+            "after"
+        );
+        // OSC terminated by ST (ESC \) instead of BEL.
+        assert_eq!(
+            sanitize_free_text("\u{1b}]0;evil\u{1b}\\after", 64),
+            "after"
+        );
+    }
+
+    #[test]
+    fn bare_control_chars_are_dropped() {
+        assert_eq!(sanitize_free_text("a\rb\nc\td\u{7f}e\u{0}f", 64), "abcdef");
+    }
+
+    #[test]
+    fn oversized_input_is_capped_with_mark() {
+        let long = "x".repeat(600);
+        let out = sanitize_free_text(&long, MAX_DETAIL_LEN);
+        assert_eq!(out.chars().count(), MAX_DETAIL_LEN);
+        assert!(out.ends_with(TRUNCATION_MARK));
+    }
+
+    #[test]
+    fn exact_cap_is_not_truncated() {
+        let exact = "y".repeat(MAX_FIELD_LEN);
+        assert_eq!(sanitize_free_text(&exact, MAX_FIELD_LEN), exact);
+    }
+
+    #[test]
+    fn sensitive_keys_are_detected_case_insensitively() {
+        for key in [
+            "secret",
+            "API_TOKEN",
+            "Password",
+            "db_credential",
+            "private_half",
+            "env_vars",
+            "key_id",
+            "authorization",
+        ] {
+            assert!(is_sensitive_label_key(key), "{key} must be sensitive");
+        }
+        for key in ["workload", "cert_fingerprint", "image", "verb", "plan"] {
+            assert!(!is_sensitive_label_key(key), "{key} must be renderable");
+        }
+    }
+
+    #[test]
+    fn absolute_paths_are_redacted() {
+        assert_eq!(
+            sanitize_label_value("/Users/alice/.mvm/keys"),
+            REDACTED_PATH
+        );
+        assert_eq!(sanitize_label_value("/home/bob/thing"), REDACTED_PATH);
+        assert_eq!(sanitize_label_value("~/state"), REDACTED_PATH);
+        assert_eq!(sanitize_label_value("rel/.mvm/audit"), REDACTED_PATH);
+    }
+
+    #[test]
+    fn non_path_values_survive_redaction() {
+        assert_eq!(sanitize_label_value("sha256:abc123"), "sha256:abc123");
+        assert_eq!(sanitize_label_value("worker-vm"), "worker-vm");
+    }
+
+    /// Property: for random inputs the sanitizer output never contains a
+    /// control character and never exceeds the cap. Hand-rolled property
+    /// loop over seeded random bytes, matching the repo's pattern.
+    #[test]
+    fn property_sanitized_output_is_always_display_safe() {
+        use rand::{Rng, SeedableRng, rngs::StdRng};
+        let mut rng = StdRng::seed_from_u64(0x5a17);
+        for _ in 0..200 {
+            let len = rng.gen_range(0..1024);
+            let bytes: Vec<u8> = (0..len).map(|_| rng.r#gen::<u8>()).collect();
+            let input = String::from_utf8_lossy(&bytes);
+            let out = sanitize_free_text(&input, MAX_DETAIL_LEN);
+            assert!(
+                out.chars().all(|c| !c.is_control()),
+                "control char survived sanitization: {out:?}"
+            );
+            assert!(out.chars().count() <= MAX_DETAIL_LEN);
+        }
+    }
+
+    /// Property: sanitization is idempotent — cleaning clean text is a no-op.
+    #[test]
+    fn property_sanitization_is_idempotent() {
+        use rand::{Rng, SeedableRng, rngs::StdRng};
+        let mut rng = StdRng::seed_from_u64(0xf00d);
+        for _ in 0..200 {
+            let len = rng.gen_range(0..600);
+            let bytes: Vec<u8> = (0..len).map(|_| rng.r#gen::<u8>()).collect();
+            let input = String::from_utf8_lossy(&bytes);
+            let once = sanitize_free_text(&input, MAX_DETAIL_LEN);
+            let twice = sanitize_free_text(&once, MAX_DETAIL_LEN);
+            assert_eq!(once, twice);
+        }
+    }
+}

--- a/crates/mvm-client/src/audit/tests.rs
+++ b/crates/mvm-client/src/audit/tests.rs
@@ -1,0 +1,628 @@
+//! Service-level tests: real chains written through the production
+//! signers, then read back through [`LocalAuditReader`]. Covers the full
+//! verification-refusal matrix, scope checks, ordering, pagination,
+//! filters, and untrusted-input robustness.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, TimeZone, Utc};
+use ed25519_dalek::SigningKey;
+use mvm_core::plan::{PlanId, TenantId};
+use mvm_hostd::audit_signer::canonical::CanonicalEntry;
+use mvm_hostd::audit_signer::chain::Chain;
+use mvm_hostd::supervisor::{AuditEntry, AuditSigner, FileAuditSigner};
+
+use super::*;
+
+fn fresh_key() -> SigningKey {
+    let mut seed = [0u8; 32];
+    rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut seed);
+    SigningKey::from_bytes(&seed)
+}
+
+fn ts(hour: u32, minute: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 8, 1, hour, minute, 0).unwrap()
+}
+
+fn lifecycle_entry(tenant: &str, event: &str, at: DateTime<Utc>) -> AuditEntry {
+    AuditEntry {
+        timestamp: at,
+        tenant: TenantId(tenant.to_string()),
+        plan_id: PlanId("sha256:plan".to_string()),
+        plan_version: 1,
+        bundle_id: None,
+        bundle_version: None,
+        image_name: "worker-img".to_string(),
+        image_sha256: "abc123".to_string(),
+        event: event.to_string(),
+        labels: BTreeMap::new(),
+    }
+}
+
+/// Write a lifecycle chain of `entries` under `key` into `audit_dir`.
+fn write_lifecycle_chain(audit_dir: &Path, key: &SigningKey, entries: &[AuditEntry]) {
+    let signer = FileAuditSigner::open(key.clone(), audit_dir).unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    for entry in entries {
+        rt.block_on(signer.sign_and_emit(entry)).unwrap();
+    }
+}
+
+/// Write a workload chain for `tenant`/`vm` signed by `key` into
+/// `audit_dir`. Each `(category, ts, tenant_id)` becomes one entry.
+fn write_workload_chain(
+    audit_dir: &Path,
+    scratch: &Path,
+    key: &SigningKey,
+    tenant: &str,
+    vm: &str,
+    entries: &[(&str, &str, &str)],
+) -> PathBuf {
+    let key_path = scratch.join(format!("{tenant}.{vm}.chain.key"));
+    std::fs::write(&key_path, key.to_bytes()).unwrap();
+    let jsonl = audit_dir.join(format!(
+        "{tenant}.{vm}{}",
+        mvm_core::config::WORKLOAD_AUDIT_SUFFIX
+    ));
+    let head = scratch.join(format!("{tenant}.{vm}.HEAD"));
+    let mut chain = Chain::open(&jsonl, &head, Some(&key_path)).unwrap();
+    for (i, (category, ts, tenant_id)) in entries.iter().enumerate() {
+        let entry = CanonicalEntry {
+            category: (*category).to_string(),
+            correlation_id: format!("corr-{i}"),
+            fields: serde_json::json!({"n": i}),
+            prev_hash: chain.head().to_string(),
+            session_id: "sess-1".to_string(),
+            tenant_id: (*tenant_id).to_string(),
+            ts: (*ts).to_string(),
+            workload_id: format!("wl-{vm}"),
+        };
+        chain.append(entry).unwrap();
+    }
+    jsonl
+}
+
+struct Fixture {
+    _dir: tempfile::TempDir,
+    audit_dir: PathBuf,
+    scratch: PathBuf,
+    key: SigningKey,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let audit_dir = dir.path().join("audit");
+        let scratch = dir.path().join("scratch");
+        std::fs::create_dir_all(&audit_dir).unwrap();
+        std::fs::create_dir_all(&scratch).unwrap();
+        Self {
+            _dir: dir,
+            audit_dir,
+            scratch,
+            key: fresh_key(),
+        }
+    }
+
+    fn reader(&self) -> LocalAuditReader {
+        LocalAuditReader::new(&self.audit_dir, self.key.verifying_key())
+    }
+
+    fn lifecycle_path(&self, tenant: &str) -> PathBuf {
+        self.audit_dir.join(format!("{tenant}.jsonl"))
+    }
+}
+
+fn read_all(reader: &LocalAuditReader) -> AuditReadResponse {
+    reader.read(&AuditReadRequest::builder().build()).unwrap()
+}
+
+// ─── valid chains ────────────────────────────────────────────────────
+
+#[test]
+fn valid_chains_yield_normalized_events_from_both_source_kinds() {
+    let fx = Fixture::new();
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[
+            lifecycle_entry("local", "plan.admitted", ts(9, 0)),
+            lifecycle_entry("local", "plan.launched", ts(9, 5)),
+        ],
+    );
+    write_workload_chain(
+        &fx.audit_dir,
+        &fx.scratch,
+        &fx.key,
+        "local",
+        "vm1",
+        &[("plan", "2026-08-01T09:02:00Z", "local")],
+    );
+
+    let response = read_all(&fx.reader());
+    assert!(response.refusals.is_empty(), "{:?}", response.refusals);
+    assert_eq!(response.sources.len(), 2);
+    assert_eq!(response.events.len(), 3);
+    // Newest first.
+    assert_eq!(response.events[0].event, "plan.launched");
+    assert_eq!(response.events[0].kind, AuditEventKind::Launch);
+    assert_eq!(response.events[1].id.source.kind, AuditSourceKind::Workload);
+    assert_eq!(response.events[1].machine.as_deref(), Some("vm1"));
+    assert_eq!(response.events[2].event, "plan.admitted");
+    assert!(response.next_cursor.is_none());
+}
+
+#[test]
+fn empty_audit_dir_and_missing_dir_read_as_empty() {
+    let fx = Fixture::new();
+    let response = read_all(&fx.reader());
+    assert!(response.events.is_empty());
+    assert!(response.sources.is_empty());
+    assert!(response.refusals.is_empty());
+
+    let missing =
+        LocalAuditReader::new(fx.audit_dir.join("does-not-exist"), fx.key.verifying_key());
+    let response = read_all(&missing);
+    assert!(response.events.is_empty());
+    assert!(response.refusals.is_empty());
+}
+
+// ─── refusal matrix ──────────────────────────────────────────────────
+
+#[test]
+fn tampered_signature_refuses_the_source_and_spares_others() {
+    let fx = Fixture::new();
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[lifecycle_entry("local", "plan.admitted", ts(9, 0))],
+    );
+    // A second, clean tenant chain.
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[lifecycle_entry("acme", "plan.admitted", ts(9, 1))],
+    );
+    // Flip a signed byte in local's chain.
+    let path = fx.lifecycle_path("local");
+    let content = std::fs::read_to_string(&path).unwrap();
+    std::fs::write(&path, content.replacen("plan.admitted", "plan.hijacked", 1)).unwrap();
+
+    let response = read_all(&fx.reader());
+    assert_eq!(response.refusals.len(), 1);
+    let refusal = &response.refusals[0];
+    assert_eq!(refusal.kind, AuditRefusalKind::SignatureInvalid);
+    assert_eq!(refusal.source.tenant, "local");
+    assert_eq!(refusal.line, Some(0));
+    // The tampered source contributed zero events; the clean one is intact.
+    assert!(response.events.iter().all(|e| e.tenant == "acme"));
+    assert_eq!(response.events.len(), 1);
+    assert_eq!(response.sources.len(), 1);
+}
+
+#[test]
+fn deleted_middle_line_is_a_chain_broken_refusal() {
+    let fx = Fixture::new();
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[
+            lifecycle_entry("local", "e-0", ts(9, 0)),
+            lifecycle_entry("local", "e-1", ts(9, 1)),
+            lifecycle_entry("local", "e-2", ts(9, 2)),
+        ],
+    );
+    let path = fx.lifecycle_path("local");
+    let lines: Vec<String> = std::fs::read_to_string(&path)
+        .unwrap()
+        .lines()
+        .map(str::to_string)
+        .collect();
+    std::fs::write(&path, format!("{}\n{}\n", lines[0], lines[2])).unwrap();
+
+    let response = read_all(&fx.reader());
+    assert!(response.events.is_empty(), "no partial prefix may leak");
+    assert_eq!(response.refusals.len(), 1);
+    assert_eq!(response.refusals[0].kind, AuditRefusalKind::ChainBroken);
+    assert_eq!(response.refusals[0].line, Some(1));
+}
+
+#[test]
+fn reordered_entries_are_a_chain_broken_refusal() {
+    let fx = Fixture::new();
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[
+            lifecycle_entry("local", "e-0", ts(9, 0)),
+            lifecycle_entry("local", "e-1", ts(9, 1)),
+        ],
+    );
+    let path = fx.lifecycle_path("local");
+    let lines: Vec<String> = std::fs::read_to_string(&path)
+        .unwrap()
+        .lines()
+        .map(str::to_string)
+        .collect();
+    std::fs::write(&path, format!("{}\n{}\n", lines[1], lines[0])).unwrap();
+
+    let response = read_all(&fx.reader());
+    assert!(response.events.is_empty());
+    assert_eq!(response.refusals[0].kind, AuditRefusalKind::ChainBroken);
+}
+
+#[test]
+fn truncated_tail_refuses_the_whole_source() {
+    // A half-written final line must not demote the source to "the valid
+    // prefix": the reader fails the source closed until the chain is whole.
+    let fx = Fixture::new();
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[
+            lifecycle_entry("local", "e-0", ts(9, 0)),
+            lifecycle_entry("local", "e-1", ts(9, 1)),
+        ],
+    );
+    let path = fx.lifecycle_path("local");
+    let content = std::fs::read_to_string(&path).unwrap();
+    let cut = content.len() - 40;
+    std::fs::write(&path, &content[..cut]).unwrap();
+
+    let response = read_all(&fx.reader());
+    assert!(response.events.is_empty(), "no partial prefix may leak");
+    assert_eq!(response.refusals.len(), 1);
+    assert_eq!(response.refusals[0].kind, AuditRefusalKind::Malformed);
+    assert_eq!(response.refusals[0].line, Some(1));
+}
+
+#[test]
+fn wrong_key_refuses_every_source() {
+    let fx = Fixture::new();
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[lifecycle_entry("local", "plan.admitted", ts(9, 0))],
+    );
+    write_workload_chain(
+        &fx.audit_dir,
+        &fx.scratch,
+        &fx.key,
+        "local",
+        "vm1",
+        &[("plan", "2026-08-01T09:02:00Z", "local")],
+    );
+
+    let stranger = LocalAuditReader::new(&fx.audit_dir, fresh_key().verifying_key());
+    let response = read_all(&stranger);
+    assert!(response.events.is_empty());
+    assert!(response.sources.is_empty());
+    assert_eq!(response.refusals.len(), 2);
+    for refusal in &response.refusals {
+        assert_eq!(refusal.kind, AuditRefusalKind::SignatureInvalid);
+    }
+}
+
+#[test]
+fn cross_scope_lifecycle_entry_refuses_the_source() {
+    // A genuinely-signed entry for another tenant, spliced into this
+    // tenant's file via a fixed-file signer, verifies cryptographically —
+    // only the scope check catches it.
+    let fx = Fixture::new();
+    let path = fx.lifecycle_path("local");
+    let signer = FileAuditSigner::open_file(fx.key.clone(), &path).unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(signer.sign_and_emit(&lifecycle_entry("local", "e-0", ts(9, 0))))
+        .unwrap();
+    rt.block_on(signer.sign_and_emit(&lifecycle_entry("other", "e-1", ts(9, 1))))
+        .unwrap();
+
+    let response = read_all(&fx.reader());
+    assert!(response.events.is_empty(), "no partial prefix may leak");
+    assert_eq!(response.refusals.len(), 1);
+    let refusal = &response.refusals[0];
+    assert_eq!(refusal.kind, AuditRefusalKind::ScopeMismatch);
+    assert_eq!(refusal.line, Some(1));
+    assert!(refusal.detail.contains("other"), "{}", refusal.detail);
+}
+
+#[test]
+fn cross_scope_workload_entry_refuses_the_source() {
+    let fx = Fixture::new();
+    write_workload_chain(
+        &fx.audit_dir,
+        &fx.scratch,
+        &fx.key,
+        "local",
+        "vm1",
+        &[
+            ("plan", "2026-08-01T09:00:00Z", "local"),
+            ("plan", "2026-08-01T09:01:00Z", "other"),
+        ],
+    );
+    let response = read_all(&fx.reader());
+    assert!(response.events.is_empty());
+    assert_eq!(response.refusals.len(), 1);
+    assert_eq!(response.refusals[0].kind, AuditRefusalKind::ScopeMismatch);
+}
+
+#[test]
+fn garbage_file_is_a_malformed_refusal_not_a_panic() {
+    let fx = Fixture::new();
+    std::fs::write(fx.audit_dir.join("evil.jsonl"), "not json at all\n{}\n").unwrap();
+    let response = read_all(&fx.reader());
+    assert!(response.events.is_empty());
+    assert_eq!(response.refusals.len(), 1);
+    assert_eq!(response.refusals[0].kind, AuditRefusalKind::Malformed);
+}
+
+/// Property: arbitrary bytes in either chain position never panic the
+/// reader and never surface as verified events. Hand-rolled seeded loop,
+/// matching the repo's property-test pattern.
+#[test]
+fn property_untrusted_audit_input_never_yields_events() {
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+    let mut rng = StdRng::seed_from_u64(0xa0d17);
+    for i in 0..50 {
+        let fx = Fixture::new();
+        let len = rng.gen_range(1..2048);
+        let bytes: Vec<u8> = (0..len).map(|_| rng.r#gen::<u8>()).collect();
+        let name = if i % 2 == 0 {
+            "local.jsonl".to_string()
+        } else {
+            format!("local.vm{i}{}", mvm_core::config::WORKLOAD_AUDIT_SUFFIX)
+        };
+        std::fs::write(fx.audit_dir.join(name), &bytes).unwrap();
+        let response = read_all(&fx.reader());
+        assert!(
+            response.events.is_empty(),
+            "random bytes must never verify (iteration {i})"
+        );
+        // Anything beyond bare newlines must be an explicit refusal.
+        let has_payload = bytes.iter().any(|b| *b != b'\n' && *b != b'\r');
+        if has_payload {
+            assert!(!response.refusals.is_empty(), "iteration {i}");
+        }
+    }
+}
+
+// ─── ordering, pagination, filters ───────────────────────────────────
+
+#[test]
+fn merged_ordering_is_newest_first_with_stable_tie_breaks() {
+    let fx = Fixture::new();
+    // Lifecycle and workload entries at the same instant plus around it.
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[
+            lifecycle_entry("local", "e-old", ts(8, 0)),
+            lifecycle_entry("local", "e-tie", ts(9, 0)),
+        ],
+    );
+    write_workload_chain(
+        &fx.audit_dir,
+        &fx.scratch,
+        &fx.key,
+        "local",
+        "vm1",
+        &[
+            ("plan", "2026-08-01T09:00:00Z", "local"),
+            ("plan", "2026-08-01T10:00:00Z", "local"),
+        ],
+    );
+
+    let response = read_all(&fx.reader());
+    let order: Vec<(AuditSourceKind, u64)> = response
+        .events
+        .iter()
+        .map(|e| (e.id.source.kind, e.id.seq))
+        .collect();
+    // 10:00 workload, then the 09:00 tie (workload ranks above lifecycle
+    // in the descending ordering), then lifecycle 09:00, then 08:00.
+    assert_eq!(
+        order,
+        vec![
+            (AuditSourceKind::Workload, 1),
+            (AuditSourceKind::Workload, 0),
+            (AuditSourceKind::Lifecycle, 1),
+            (AuditSourceKind::Lifecycle, 0),
+        ]
+    );
+}
+
+#[test]
+fn pagination_walks_the_stream_without_gaps_or_duplicates() {
+    let fx = Fixture::new();
+    let entries: Vec<AuditEntry> = (0..7u32)
+        .map(|i| lifecycle_entry("local", &format!("e-{i}"), ts(9, i)))
+        .collect();
+    write_lifecycle_chain(&fx.audit_dir, &fx.key, &entries);
+    let reader = fx.reader();
+
+    let full = read_all(&reader);
+    assert_eq!(full.events.len(), 7);
+
+    let mut paged: Vec<VerifiedAuditEvent> = Vec::new();
+    let mut cursor: Option<AuditCursor> = None;
+    let mut pages = 0;
+    loop {
+        let mut builder = AuditReadRequest::builder().limit(3);
+        if let Some(c) = cursor.take() {
+            builder = builder.cursor(c);
+        }
+        let page = reader.read(&builder.build()).unwrap();
+        assert!(page.events.len() <= 3);
+        paged.extend(page.events.clone());
+        pages += 1;
+        match page.next_cursor {
+            Some(c) => cursor = Some(c),
+            None => break,
+        }
+        assert!(pages < 10, "cursor walk must terminate");
+    }
+    assert_eq!(pages, 3);
+    assert_eq!(paged, full.events, "paged walk must equal the full read");
+}
+
+#[test]
+fn machine_filter_selects_one_vm() {
+    let fx = Fixture::new();
+    write_workload_chain(
+        &fx.audit_dir,
+        &fx.scratch,
+        &fx.key,
+        "local",
+        "vm1",
+        &[("plan", "2026-08-01T09:00:00Z", "local")],
+    );
+    write_workload_chain(
+        &fx.audit_dir,
+        &fx.scratch,
+        &fx.key,
+        "local",
+        "vm2",
+        &[("plan", "2026-08-01T09:01:00Z", "local")],
+    );
+    let response = fx
+        .reader()
+        .read(&AuditReadRequest::builder().machine("vm2").build())
+        .unwrap();
+    assert_eq!(response.events.len(), 1);
+    assert_eq!(response.events[0].machine.as_deref(), Some("vm2"));
+    // Both sources still verified — filtering is presentation, not trust.
+    assert_eq!(response.sources.len(), 2);
+}
+
+#[test]
+fn tenant_filter_scopes_discovery() {
+    let fx = Fixture::new();
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[lifecycle_entry("acme", "plan.admitted", ts(9, 0))],
+    );
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[lifecycle_entry("beta", "plan.admitted", ts(9, 1))],
+    );
+    let response = fx
+        .reader()
+        .read(&AuditReadRequest::builder().tenant("acme").build())
+        .unwrap();
+    assert_eq!(response.events.len(), 1);
+    assert_eq!(response.events[0].tenant, "acme");
+    assert_eq!(response.sources.len(), 1);
+}
+
+#[test]
+fn kind_filter_selects_normalized_categories() {
+    let fx = Fixture::new();
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[
+            lifecycle_entry("local", "plan.admitted", ts(9, 0)),
+            lifecycle_entry("local", "plan.launched", ts(9, 1)),
+            lifecycle_entry("local", "plan.failed", ts(9, 2)),
+        ],
+    );
+    let response = fx
+        .reader()
+        .read(
+            &AuditReadRequest::builder()
+                .kind(AuditEventKind::Refusal)
+                .kind(AuditEventKind::Launch)
+                .build(),
+        )
+        .unwrap();
+    assert_eq!(response.events.len(), 2);
+    assert_eq!(response.events[0].kind, AuditEventKind::Refusal);
+    assert_eq!(response.events[1].kind, AuditEventKind::Launch);
+}
+
+#[test]
+fn time_window_filter_bounds_the_read() {
+    let fx = Fixture::new();
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[
+            lifecycle_entry("local", "e-0", ts(8, 0)),
+            lifecycle_entry("local", "e-1", ts(9, 0)),
+            lifecycle_entry("local", "e-2", ts(10, 0)),
+        ],
+    );
+    let response = fx
+        .reader()
+        .read(
+            &AuditReadRequest::builder()
+                .since(ts(8, 30))
+                .until(ts(9, 30))
+                .build(),
+        )
+        .unwrap();
+    assert_eq!(response.events.len(), 1);
+    assert_eq!(response.events[0].event, "e-1");
+}
+
+#[test]
+fn verify_sources_reports_summaries_and_refusals() {
+    let fx = Fixture::new();
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[
+            lifecycle_entry("local", "e-0", ts(9, 0)),
+            lifecycle_entry("local", "e-1", ts(9, 1)),
+        ],
+    );
+    let workload_path = write_workload_chain(
+        &fx.audit_dir,
+        &fx.scratch,
+        &fx.key,
+        "local",
+        "vm1",
+        &[("plan", "2026-08-01T09:00:00Z", "local")],
+    );
+
+    let outcome = fx.reader().verify_sources(Some("local")).unwrap();
+    assert!(outcome.refusals.is_empty());
+    assert_eq!(outcome.sources.len(), 2);
+    assert_eq!(outcome.sources[0].source.kind, AuditSourceKind::Lifecycle);
+    assert_eq!(outcome.sources[0].entries, 2);
+    assert_eq!(outcome.sources[1].source.kind, AuditSourceKind::Workload);
+    assert_eq!(outcome.sources[1].entries, 1);
+
+    // Tamper the workload chain: it becomes a refusal, the lifecycle
+    // summary survives.
+    let content = std::fs::read_to_string(&workload_path).unwrap();
+    let tampered = content.replacen('A', "B", 1);
+    assert_ne!(content, tampered, "fixture must actually change a byte");
+    std::fs::write(&workload_path, tampered).unwrap();
+    let outcome = fx.reader().verify_sources(Some("local")).unwrap();
+    assert_eq!(outcome.sources.len(), 1);
+    assert_eq!(outcome.refusals.len(), 1);
+    assert_eq!(outcome.refusals[0].source.kind, AuditSourceKind::Workload);
+}
+
+#[test]
+fn unreadable_audit_dir_is_an_io_error_not_a_refusal() {
+    let fx = Fixture::new();
+    // A file where the directory should be.
+    let bogus = fx.scratch.join("not-a-dir");
+    std::fs::write(&bogus, b"x").unwrap();
+    let reader = LocalAuditReader::new(&bogus, fx.key.verifying_key());
+    let err = reader
+        .read(&AuditReadRequest::builder().build())
+        .unwrap_err();
+    assert!(matches!(err, AuditReadError::Io { .. }), "{err}");
+}

--- a/crates/mvm-client/src/audit/tests.rs
+++ b/crates/mvm-client/src/audit/tests.rs
@@ -615,6 +615,106 @@ fn verify_sources_reports_summaries_and_refusals() {
 }
 
 #[test]
+fn unsigned_secrets_operator_log_is_neither_a_source_nor_a_refusal() {
+    // `mvmctl secret …` writes an UNSIGNED plain-JSON operator log at
+    // `<audit_dir>/secrets.jsonl`. It is not a chain: it must never
+    // surface as events, and its presence must not poison reads or
+    // verifies with a permanent refusal.
+    let fx = Fixture::new();
+    std::fs::write(
+        fx.audit_dir.join("secrets.jsonl"),
+        r#"{"ts":"2026-08-01T09:00:00Z","action":"put","name":"db"}"#,
+    )
+    .unwrap();
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[lifecycle_entry("local", "plan.admitted", ts(9, 0))],
+    );
+
+    let response = read_all(&fx.reader());
+    assert!(response.refusals.is_empty(), "{:?}", response.refusals);
+    assert_eq!(response.sources.len(), 1);
+    assert_eq!(response.events.len(), 1);
+
+    // Even a tenant literally named "secrets" cannot claim the operator
+    // log as its lifecycle chain.
+    let outcome = fx.reader().verify_sources(Some("secrets")).unwrap();
+    assert!(outcome.sources.is_empty());
+    assert!(outcome.refusals.is_empty());
+}
+
+#[test]
+fn dotted_tenant_round_trips_scoped_and_unscoped() {
+    // A tenant name may contain dots. Tenant-scoped classification must
+    // anchor on the tenant (like the chain writers do) instead of
+    // splitting at the first dot, and the unscoped path must recover the
+    // same split via the tenant's lifecycle chain.
+    let fx = Fixture::new();
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[lifecycle_entry("a.b", "plan.admitted", ts(9, 0))],
+    );
+    write_workload_chain(
+        &fx.audit_dir,
+        &fx.scratch,
+        &fx.key,
+        "a.b",
+        "vm1",
+        &[("plan", "2026-08-01T09:01:00Z", "a.b")],
+    );
+
+    // Scoped verify sees BOTH chains (the old tenant-anchored semantics).
+    let outcome = fx.reader().verify_sources(Some("a.b")).unwrap();
+    assert!(outcome.refusals.is_empty(), "{:?}", outcome.refusals);
+    assert_eq!(outcome.sources.len(), 2, "{:?}", outcome.sources);
+    let workload = &outcome.sources[1];
+    assert_eq!(workload.source.kind, AuditSourceKind::Workload);
+    assert_eq!(workload.source.tenant, "a.b");
+    assert_eq!(workload.source.machine.as_deref(), Some("vm1"));
+
+    // Scoped read returns both events under the right identities.
+    let scoped = fx
+        .reader()
+        .read(&AuditReadRequest::builder().tenant("a.b").build())
+        .unwrap();
+    assert_eq!(scoped.events.len(), 2);
+    assert!(scoped.events.iter().all(|e| e.tenant == "a.b"));
+
+    // Unscoped read parses the workload stem via the known tenant, so
+    // the scope check passes instead of mis-splitting into tenant "a".
+    let unscoped = read_all(&fx.reader());
+    assert!(unscoped.refusals.is_empty(), "{:?}", unscoped.refusals);
+    assert_eq!(unscoped.events.len(), 2);
+    assert!(unscoped.events.iter().all(|e| e.tenant == "a.b"));
+}
+
+#[test]
+fn discover_source_ids_lists_without_a_key_and_skips_non_chains() {
+    let fx = Fixture::new();
+    assert!(
+        discover_source_ids(&fx.audit_dir, Some("local"))
+            .unwrap()
+            .is_empty()
+    );
+    std::fs::write(fx.audit_dir.join("secrets.jsonl"), "{}\n").unwrap();
+    assert!(
+        discover_source_ids(&fx.audit_dir, None).unwrap().is_empty(),
+        "the unsigned operator log must never count as a source"
+    );
+    write_lifecycle_chain(
+        &fx.audit_dir,
+        &fx.key,
+        &[lifecycle_entry("local", "plan.admitted", ts(9, 0))],
+    );
+    let ids = discover_source_ids(&fx.audit_dir, Some("local")).unwrap();
+    assert_eq!(ids.len(), 1);
+    assert_eq!(ids[0].kind, AuditSourceKind::Lifecycle);
+    assert_eq!(ids[0].tenant, "local");
+}
+
+#[test]
 fn unreadable_audit_dir_is_an_io_error_not_a_refusal() {
     let fx = Fixture::new();
     // A file where the directory should be.

--- a/crates/mvm-hostd/src/audit_signer/verify.rs
+++ b/crates/mvm-hostd/src/audit_signer/verify.rs
@@ -52,10 +52,22 @@ pub fn verify_workload_chain(
     path: &Path,
     verifying_key: &VerifyingKey,
 ) -> Result<usize, WorkloadVerifyError> {
+    verify_workload_chain_entries(path, verifying_key).map(|entries| entries.len())
+}
+
+/// Verify the workload audit chain at `path` and return its authenticated
+/// entries in chain order. Consumers use this when a decision or a display
+/// depends on the entry contents, rather than re-parsing an
+/// already-verified file a second time. Same rejection ladder as
+/// [`verify_workload_chain`].
+pub fn verify_workload_chain_entries(
+    path: &Path,
+    verifying_key: &VerifyingKey,
+) -> Result<Vec<CanonicalEntry>, WorkloadVerifyError> {
     let content =
         std::fs::read_to_string(path).map_err(|e| WorkloadVerifyError::Io(e.to_string()))?;
     let mut prev_hash = CanonicalEntry::genesis_prev_hash();
-    let mut count = 0usize;
+    let mut entries = Vec::new();
     for (idx, line) in content.lines().enumerate() {
         if line.trim().is_empty() {
             continue;
@@ -134,9 +146,9 @@ pub fn verify_workload_chain(
             .map_err(|_| WorkloadVerifyError::SignatureInvalid { line: idx })?;
 
         prev_hash = on_disk.entry_hash;
-        count += 1;
+        entries.push(entry);
     }
-    Ok(count)
+    Ok(entries)
 }
 
 // ============================================================================
@@ -218,6 +230,21 @@ mod tests {
         let (path, sk) = build(&dir, 3);
         let count = verify_workload_chain(&path, &vk(&sk)).expect("clean chain must verify");
         assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn entries_variant_returns_authenticated_entries_in_chain_order() {
+        let dir = tempdir().unwrap();
+        let (path, sk) = build(&dir, 3);
+        let entries = verify_workload_chain_entries(&path, &vk(&sk))
+            .expect("clean chain must yield its entries");
+        assert_eq!(entries.len(), 3);
+        for e in &entries {
+            assert_eq!(e.category, "workload_audit");
+            assert_eq!(e.tenant_id, "t-1");
+        }
+        // Chain order: each entry's prev_hash links to the previous head.
+        assert_eq!(entries[0].prev_hash, CanonicalEntry::genesis_prev_hash());
     }
 
     #[test]

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -113,7 +113,26 @@ updates only its own entry below.
       responses, serialization, Debug, errors, audit records, and
       persisted sidecars.
 
-- [ ] #2082 — normalized verified local audit events for UI consumers.
+- [x] #2082 — normalized verified local audit events for UI consumers.
+      Delivered `mvm_client::audit::LocalAuditReader`: discovers the
+      per-tenant lifecycle chains and per-VM workload chains under
+      `<mvm_home>/audit/`, verifies each through the canonical seams
+      (`mvm_hostd::supervisor::verify_audit_chain_entries` and the new
+      `mvm_hostd::audit_signer::verify::verify_workload_chain_entries`,
+      extracted from the existing count-only verifier), enforces a
+      per-source tenant-scope check, and returns normalized
+      `VerifiedAuditEvent`s (stable `(source, seq)` identity; newest-first
+      ordering by signed timestamp → source rank → chain position) with
+      typed per-source `AuditSourceRefusal`s — a failed source yields zero
+      events, never a partial prefix. Bounded reads with typed cursor plus
+      machine/tenant/kind/time filters; all free text sanitized (ANSI/OSC
+      strip, control-char drop, length caps, sensitive-label exclusion,
+      host-path redaction) at the service boundary; workload `fields`
+      payloads are never rendered. `mvmctl audit verify` now runs through
+      the same `verify_sources` seam. 53 new tests including the
+      refusal matrix (tamper, reorder, truncation, wrong key, cross-scope),
+      pagination walk, serde/unknown-field pins, and seeded property loops
+      over untrusted audit input.
 
 - [ ] #2079 — persistent + transient launch lifecycle through
       `LocalBackend` (starts after #2078/#2080/#2081 land the shared

--- a/xtask/src/check_single_home.rs
+++ b/xtask/src/check_single_home.rs
@@ -107,6 +107,19 @@ const EXEMPTIONS: &[(&str, &[Rule], &str)] = &[
         &[Rule::HomeRead, Rule::HomeLiteral],
         "manual smoke example in the FFI crate, which sits below mvm-core and cannot call the resolver",
     ),
+    (
+        "crates/mvm-client/src/audit/sanitize.rs",
+        &[Rule::HomeLiteral],
+        "the path-redaction detector: matches the .mvm literal inside untrusted audit text to \
+         scrub it before UI exposure, and its tests feed .mvm-shaped fixtures to prove the scrub; \
+         it derives no mvm path",
+    ),
+    (
+        "crates/mvm-client/src/audit/normalize.rs",
+        &[Rule::HomeLiteral],
+        ".mvm-shaped test fixtures asserting host paths are redacted from normalized event detail; \
+         it derives no mvm path",
+    ),
 ];
 
 pub fn run(workspace: &Path) -> Result<()> {


### PR DESCRIPTION
## Summary

Adds `mvm_client::audit::LocalAuditReader` — the verified read contract for mvm's local audit sources, per #2082. A UI consumer (mvm-studio) gets bounded, typed, newest-first reads of normalized audit events, returned **only** after the source chain passes signature, chain-link, and tenant-scope verification. Live HTTP/SSE transport stays in mvm-studio; this PR owns only the read contract and normalization.

### Design

- **Sources.** The per-tenant lifecycle chains (`<mvm_home>/audit/<tenant>.jsonl`) and the per-VM workload chains (`<tenant>.<vm>.workload.jsonl`), discovered via the `mvm-core::config` naming convention. The unsigned legacy operator log is deliberately **not** a source — it carries no authenticity.
- **One verification seam, reused.** No second verifier was written. Lifecycle chains go through `mvm_hostd::supervisor::verify_audit_chain_entries`; workload chains go through a new `mvm_hostd::audit_signer::verify::verify_workload_chain_entries`, extracted from the existing count-only `verify_workload_chain` (which now delegates to it) — mirroring the supervisor's existing count/entries pair. `mvmctl audit verify` is rewired through the same `LocalAuditReader::verify_sources` seam, so CLI and UI consumers cannot disagree on what verifies.
- **DTOs.** `VerifiedAuditEvent { id, kind, timestamp, tenant, machine, event, plan_id, detail }` with a normalized `AuditEventKind` (admission, launch, lifecycle, readiness, volume, secret_reference, policy, refusal, other). All serde shapes pinned with `deny_unknown_fields`.
- **Identity + ordering.** Event identity is `(source, seq)` — the entry's zero-based position in its verified chain; chains are append-only and only verified prefixes are exposed, so identity is stable with no chain rewrite. Newest-first ordering is a total order over (signed timestamp, source rank, chain position) — a pure function of signed content and source identity, so pagination is stable across reads. The typed `AuditCursor` carries that ordering key; pages are strictly-older continuations. Limits: default 100, hard cap 1000.
- **Refusals.** A source failing any check yields a typed `AuditSourceRefusal` (`io | malformed | chain_broken | signature_invalid | scope_mismatch`, with line and sanitized detail) and **zero events — never a partial prefix**. A verified-but-foreign-tenant entry (validly signed, spliced into another tenant's file) is refused via the scope check.
- **Sanitization at the boundary.** ANSI CSI/OSC sequences and control chars stripped, all fields capped, sensitive label keys (secret/token/password/credential/private/env/key/auth) dropped, path-like values redacted, and workload `fields` payloads (raw policy material) never rendered.

## Test evidence

53 new tests (52 in `mvm-client`, 1 in `mvm-hostd`); full suite `cargo nextest run --workspace`: **9196 passed, 0 failed**.

**Verification refusal matrix** (each asserts zero events from the refused source):

| Scenario | Result |
|---|---|
| Valid lifecycle + workload chains | events from both, no refusals |
| Tampered signed byte | `signature_invalid`, sibling tenant chain unaffected |
| Deleted middle line | `chain_broken` at line 1 |
| Reordered entries | `chain_broken` |
| Truncated tail (half-written last line) | `malformed` — whole source withheld, no valid-prefix leak |
| Wrong verifying key | `signature_invalid` on every source |
| Cross-scope entry (lifecycle + workload) | `scope_mismatch` naming both tenants |
| Garbage bytes | `malformed`, no panic |

**Sanitization:** CSI/OSC/ST stripping, bare control chars, cap-with-mark truncation, sensitive-key detection, absolute/`~`/`.mvm` path redaction, raw workload `fields` never rendered, refusal details sanitized.

**Property tests** (hand-rolled seeded loops with `rand`, matching the repo's existing pattern — noted in lieu of a cargo-fuzz target since fuzz targets aren't built in normal CI): 200×2 sanitizer invariants (no control chars survive, caps hold, idempotence) and 50 random-byte chain files through the full reader (never panics, never yields events, refuses non-empty garbage).

**Contract pins:** serde roundtrips for event/refusal/response/cursor, unknown-field rejection, optional-field omission, limit default/clamp, ordering tie-breaks, unparseable-timestamp demotion, pagination walk (no gaps, no duplicates, equals the unpaged read), machine/tenant/kind/time filters, `verify_sources` summaries, kind classification tables.

Closes #2082



## Review follow-up (cb3c5184b)

Addresses the independent review's findings:

- **Operator-log exclusion:** the unsigned `<audit_dir>/secrets.jsonl` operator log is a known non-chain and is excluded from discovery — neither events nor a permanent `malformed` refusal, even for a tenant literally named `secrets`.
- **Dotted tenant names:** tenant-scoped classification now anchors on the requested tenant via `mvm_core::config::workload_audit_vm_name` (the writer's own helper), restoring the old tenant-anchored verify coverage; unscoped classification matches workload stems against known lifecycle tenants (longest match) before the first-dot fallback.
- **No key mint on empty verify:** `mvmctl audit verify` early-returns through the new key-free `discover_source_ids` before loading the host signer, so a read-only verify on a pristine host no longer creates `~/.mvm/keys/host-signer.ed25519`.

Accepted as fast-follows (out of scope here, per review): deepening machine-label path redaction, and redacting path fragments appearing mid-string in label values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
