### PR TITLE
fix(agentd): no workload runs as root — OCI init privilege drop + fail-closed gate

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent.rs
@@ -55,9 +55,9 @@ use std::sync::{Arc, Mutex};
 
 use mvm_agentd::vsock::{
     AuthenticatedSession, GuestRequest, GuestResponse, HOST_SIGNER_PUBKEY_PATH, TrafficPlane,
-    TrustDecision, VERB_TRUST_POLICY_PATH, enforce_verb_grant, is_verb_trust_baseline,
+    TrustDecision, VERB_TRUST_POLICY_PATH, current_uid, enforce_verb_grant, is_verb_trust_baseline,
     launch_requires_grant, load_host_signer_verifying_key, load_pinned_verb_grant,
-    load_verb_trust_policy, trust_decision,
+    load_verb_trust_policy, trust_decision, workload_privilege_refusal,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -288,6 +288,15 @@ fn handle_client(
     }
 
     if let Some(resp) = enforce_verb_grant(&req, verb_grant.as_ref()) {
+        send_authenticated_response(&mut file, &mut session, &resp);
+        return;
+    }
+
+    // No workload code runs as root. The privilege drop during activation is
+    // the mechanism; this is the backstop that makes a boot path which never
+    // reached that drop fail closed and name itself, rather than silently
+    // running the workload with uid 0.
+    if let Some(resp) = workload_privilege_refusal(&req, current_uid()) {
         send_authenticated_response(&mut file, &mut session, &resp);
         return;
     }

--- a/crates/mvm-agentd/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-oci-init.rs
@@ -10,6 +10,7 @@ mod linux {
     use mvm_agentd::guest_bootstrap::{
         cmdline, cmdline_has_flag, cmdline_value, cstring_str, ensure_runtime_dirs, hex_decode,
         is_executable, provision_guest_environment, resolve_exec, runtime_source_policy, spawn_one,
+        spawn_one_as,
     };
     use std::ffi::{CString, OsStr};
     use std::fs;
@@ -50,7 +51,14 @@ mod linux {
             );
             std::process::exit(1);
         };
-        spawn_one(&agent, "guest-agent");
+        // Unprivileged from the start: this init has already done every root-only
+        // step above, and the agent serves the verbs that run workload code.
+        spawn_one_as(
+            &agent,
+            "guest-agent",
+            mvm_agentd::guest_mount::WORKLOAD_UID,
+            mvm_agentd::guest_mount::WORKLOAD_GID,
+        );
         idle_forever();
     }
 

--- a/crates/mvm-agentd/src/guest_bootstrap.rs
+++ b/crates/mvm-agentd/src/guest_bootstrap.rs
@@ -424,6 +424,45 @@ pub fn spawn_one(path: &Path, label: &str) {
     }
 }
 
+/// Spawn a helper the way `spawn_one` does, but as an unprivileged user.
+///
+/// The guest agent is started this way because it serves the verbs that run
+/// workload code, and every one of those spawn sites inherits the agent's
+/// identity rather than setting its own. On the pid-1 boot path the agent
+/// drops privilege itself once its mounts are done; on this path the init
+/// owns the mounts, so the agent never needs root and is handed the workload
+/// identity from the start. Both paths converge on the same posture: nothing
+/// that executes workload code runs as uid 0.
+#[cfg(target_os = "linux")]
+pub fn spawn_one_as(path: &Path, label: &str, uid: u32, gid: u32) {
+    use std::os::unix::process::CommandExt;
+
+    if !is_executable(path) {
+        eprintln!(
+            "mvm-guest-init: no executable {label} at {}",
+            path.display()
+        );
+        return;
+    }
+    let mut cmd = Command::new(path);
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    // SAFETY: the hook runs in the forked child before exec. It calls only
+    // async-signal-safe syscalls and allocates nothing, which is what
+    // `drop_privilege_raw` exists to guarantee.
+    unsafe {
+        cmd.pre_exec(move || crate::guest_mount::drop_privilege_raw(uid, gid));
+    }
+    match cmd.spawn() {
+        Ok(child) => eprintln!(
+            "mvm-guest-init: spawned {label} pid={} uid={uid} gid={gid}",
+            child.id()
+        ),
+        Err(e) => eprintln!("mvm-guest-init: spawn {label} at {}: {e}", path.display()),
+    }
+}
+
 pub fn cmdline() -> String {
     fs::read_to_string("/proc/cmdline").unwrap_or_default()
 }

--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -418,27 +418,42 @@ pub fn pivot_to_root(new_root: &Path) -> Result<()> {
 pub fn drop_privilege(uid: u32, gid: u32) -> Result<()> {
     #[cfg(target_os = "linux")]
     {
-        // Drop any supplementary groups first while still root.
-        // SAFETY: setgroups(0, NULL) is the documented Linux way to clear all supplementary groups.
-        if unsafe { libc::setgroups(0, std::ptr::null::<libc::gid_t>()) } != 0 {
-            return Err(MountError::syscall(
-                "setgroups",
-                std::io::Error::last_os_error(),
-            ));
-        }
-        // Order matters: setgid before setuid so the saved gid stays usable.
-        setgid(gid)?;
-        setuid(uid)?;
-        // Paranoia: confirm we cannot regain root.
-        // SAFETY: getuid() has no precondition and cannot fail.
-        if unsafe { libc::getuid() } == 0 {
-            return Err(MountError::Syscall {
-                context: "privilege drop failed: still uid 0".to_string(),
-                source: std::io::Error::from_raw_os_error(libc::EPERM),
-            });
-        }
+        drop_privilege_raw(uid, gid)
+            .map_err(|source| MountError::syscall("privilege drop", source))?;
     }
     let _ = (uid, gid);
+    Ok(())
+}
+
+/// The privilege drop as bare syscalls, allocating nothing on any path.
+///
+/// This is the single implementation; `drop_privilege` is the wrapper that
+/// adds a typed error for the pid-1 path. It exists separately because the
+/// other caller runs inside a `pre_exec` hook — that is, in a forked child
+/// before `exec` — where allocating can deadlock if another thread held the
+/// allocator lock at fork time. Bare syscalls plus `last_os_error` (which
+/// only wraps errno) keep that path allocation-free.
+#[cfg(target_os = "linux")]
+pub fn drop_privilege_raw(uid: u32, gid: u32) -> std::io::Result<()> {
+    // Drop any supplementary groups first while still root.
+    // SAFETY: setgroups(0, NULL) is the documented Linux way to clear all supplementary groups.
+    if unsafe { libc::setgroups(0, std::ptr::null::<libc::gid_t>()) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // Order matters: setgid before setuid so the saved gid stays usable.
+    // SAFETY: both receive a plain id value; no pointer contract.
+    if unsafe { libc::setgid(gid) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: as above.
+    if unsafe { libc::setuid(uid) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // Paranoia: confirm we cannot regain root.
+    // SAFETY: getuid() has no precondition and cannot fail.
+    if unsafe { libc::getuid() } == 0 {
+        return Err(std::io::Error::from_raw_os_error(libc::EPERM));
+    }
     Ok(())
 }
 
@@ -651,32 +666,6 @@ fn ensure_dir(path: &str) -> Result<()> {
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
         Err(e) => Err(MountError::syscall(format!("mkdir {path}"), e)),
     }
-}
-
-#[cfg(target_os = "linux")]
-fn setuid(uid: u32) -> Result<()> {
-    // SAFETY: setuid receives a plain uid_t value; no pointer contract.
-    let rc = unsafe { libc::setuid(uid) };
-    if rc != 0 {
-        return Err(MountError::syscall(
-            format!("setuid({uid})"),
-            std::io::Error::last_os_error(),
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "linux")]
-fn setgid(gid: u32) -> Result<()> {
-    // SAFETY: setgid receives a plain gid_t value; no pointer contract.
-    let rc = unsafe { libc::setgid(gid) };
-    if rc != 0 {
-        return Err(MountError::syscall(
-            format!("setgid({gid})"),
-            std::io::Error::last_os_error(),
-        ));
-    }
-    Ok(())
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/mvm-agentd/src/vsock/mod.rs
+++ b/crates/mvm-agentd/src/vsock/mod.rs
@@ -25,6 +25,7 @@ mod rpc;
 /// an empty module elsewhere. Public so the one-shot guest bins can reach it.
 pub mod sys;
 mod verb_grant;
+mod workload_privilege;
 
 pub use activation::{
     ActivateEnvironment, RootfsConfig, RuntimeOverlayConfig, VolumeConfig, VolumeConfigKind,
@@ -71,6 +72,7 @@ pub use verb_grant::{
     parse_require_grant_cmdline, pin_verb_grant, provision_host_signer_anchor_from_cmdline,
     re_pin_verb_grant, trust_decision, verifying_key_from_hex, write_host_signer_anchor,
 };
+pub use workload_privilege::{current_uid, workload_privilege_refusal};
 
 /// Default vsock guest CID (Firecracker convention).
 pub const GUEST_CID: u32 = 3;

--- a/crates/mvm-agentd/src/vsock/response.rs
+++ b/crates/mvm-agentd/src/vsock/response.rs
@@ -197,6 +197,10 @@ pub enum GuestResponse {
     /// The pinned verb grant does not authorize this verb for the
     /// workload. Wire-stable. Universal — may answer any request.
     VerbNotAuthorized { verb: String },
+    /// The agent refused to spawn workload code because it is still running as
+    /// uid 0. Carries the offending verb and the live uid so the refusal is
+    /// self-diagnosing rather than needing a console-log hunt.
+    WorkloadPrivilegeRefused { verb: String, uid: u32 },
     /// Per-integration status report.
     IntegrationStatusReport {
         integrations: Vec<crate::integrations::IntegrationStateReport>,
@@ -357,7 +361,7 @@ name_enum! {
     pub enum ResponseVariant {
         ActivateEnvironmentAck, ActivateEnvironmentError, NotActivated,
         ProtocolHelloAck, ProtocolMismatch, WorkerStatus, SleepPrepAck, WakeAck,
-        Pong, ResourceUsageReport, Error, UnsupportedInProfile, VerbNotAuthorized, IntegrationStatusReport,
+        Pong, ResourceUsageReport, Error, UnsupportedInProfile, VerbNotAuthorized, WorkloadPrivilegeRefused, IntegrationStatusReport,
         CheckpointResult, ProbeStatusReport, PrimedStatusReport, EntrypointEvent, ExecEvent,
         ExecBatchResult, DetachedStarted,
         PostRestoreAck, FsDiffResult, PortForwardStarted,
@@ -379,6 +383,7 @@ impl ResponseVariant {
             ResponseVariant::Error
                 | ResponseVariant::UnsupportedInProfile
                 | ResponseVariant::VerbNotAuthorized
+                | ResponseVariant::WorkloadPrivilegeRefused
         )
     }
 }
@@ -460,6 +465,71 @@ impl Verb {
             | Self::MountVolume
             | Self::UnmountVolume
             | Self::UpdateIdleTimeout => Control,
+        }
+    }
+
+    /// Whether serving this verb creates a process running workload code.
+    ///
+    /// Exhaustive on purpose: a new verb cannot be added without someone
+    /// deciding which side of this line it falls on, the same discipline
+    /// `traffic_plane` and `RequestClass::class` already impose.
+    ///
+    /// This exists because the agent has five distinct workload-spawn sites
+    /// (`entrypoint.rs`, `exec_stream.rs`, `console.rs`, `lifecycle_hooks.rs`,
+    /// `worker_pool.rs`) and **none of them sets a uid** — every one inherits
+    /// the agent's identity. Guarding each site would therefore be guarding the
+    /// symptom. The property that matters is that the agent is not root when it
+    /// serves one of these, which is a single check over this classification.
+    pub fn spawns_workload_process(self) -> bool {
+        match self {
+            // Each of these ends in a process executing image or user code.
+            Self::Exec
+            | Self::ExecBatch
+            | Self::RunEntrypoint
+            | Self::RunDetached
+            | Self::RunCode
+            | Self::ProcStart
+            | Self::ConsoleOpen => true,
+
+            // Agent-internal: these answer from agent state, mutate mounts or
+            // forwarding, or manage a process the verbs above already created.
+            // `ActivateEnvironment` is the important one — it runs the mounts
+            // and the pivot, so it legitimately executes while still root and
+            // must never be caught by this gate.
+            Self::ActivateEnvironment
+            | Self::ProtocolHello
+            | Self::WorkerStatus
+            | Self::SleepPrep
+            | Self::Wake
+            | Self::Ping
+            | Self::ResourceUsage
+            | Self::IntegrationStatus
+            | Self::CheckpointIntegrations
+            | Self::ProbeStatus
+            | Self::PrimedStatus
+            | Self::PostRestore
+            | Self::FsDiff
+            | Self::StartPortForward
+            | Self::StartUnixSocketForward
+            | Self::ConsoleClose
+            | Self::ConsoleResize
+            | Self::EntrypointStatus
+            | Self::ReadinessStatus
+            | Self::FsRead
+            | Self::FsWrite
+            | Self::FsList
+            | Self::FsStat
+            | Self::FsMkdir
+            | Self::FsRemove
+            | Self::FsMove
+            | Self::ProcList
+            | Self::ProcSignal
+            | Self::ProcSendInput
+            | Self::ProcWait
+            | Self::ProcKill
+            | Self::MountVolume
+            | Self::UnmountVolume
+            | Self::UpdateIdleTimeout => false,
         }
     }
 
@@ -546,6 +616,9 @@ impl GuestResponse {
             GuestResponse::Error { .. } => ResponseVariant::Error,
             GuestResponse::UnsupportedInProfile { .. } => ResponseVariant::UnsupportedInProfile,
             GuestResponse::VerbNotAuthorized { .. } => ResponseVariant::VerbNotAuthorized,
+            GuestResponse::WorkloadPrivilegeRefused { .. } => {
+                ResponseVariant::WorkloadPrivilegeRefused
+            }
             GuestResponse::IntegrationStatusReport { .. } => {
                 ResponseVariant::IntegrationStatusReport
             }

--- a/crates/mvm-agentd/src/vsock/rpc.rs
+++ b/crates/mvm-agentd/src/vsock/rpc.rs
@@ -33,6 +33,19 @@ pub enum RpcError {
         /// `kind_name()` (kebab-case) of the rejected request.
         verb: String,
     },
+    /// The agent refused to spawn workload code because it is still uid 0.
+    /// Indicates a boot path that never reached the privilege drop, not a
+    /// policy decision about this particular caller.
+    #[error(
+        "guest agent refused {verb}: it is still running as uid {uid}, so the workload \
+         would have run as root. The agent never reached its privilege drop."
+    )]
+    WorkloadPrivilegeRefused {
+        /// `kind_name()` (kebab-case) of the refused request.
+        verb: String,
+        /// The uid the agent was serving under.
+        uid: u32,
+    },
     /// The agent returned a response variant not in the verb's
     /// `response_contract()` — a protocol violation.
     #[error("guest agent returned {got:?} for {verb}, not in its contract {expected:?}")]
@@ -146,6 +159,9 @@ pub fn check_response(req: &GuestRequest, resp: GuestResponse) -> Result<GuestRe
             Err(RpcError::UnsupportedInProfile { profile, verb })
         }
         GuestResponse::VerbNotAuthorized { verb } => Err(RpcError::VerbNotAuthorized { verb }),
+        GuestResponse::WorkloadPrivilegeRefused { verb, uid } => {
+            Err(RpcError::WorkloadPrivilegeRefused { verb, uid })
+        }
         other => {
             let got = other.variant();
             let contract = req.response_contract();
@@ -348,6 +364,9 @@ where
         let event = match resp {
             GuestResponse::EntrypointEvent(e) => e,
             GuestResponse::Error { message } => bail!("guest agent error: {message}"),
+            GuestResponse::WorkloadPrivilegeRefused { verb, uid } => {
+                return Err(RpcError::WorkloadPrivilegeRefused { verb, uid }.into());
+            }
             other => bail!("expected EntrypointEvent during RunEntrypoint stream, got {other:?}"),
         };
         if event.is_terminal() {
@@ -428,6 +447,9 @@ pub fn send_run_detached(
         GuestResponse::VerbNotAuthorized { verb } => {
             Err(RpcError::VerbNotAuthorized { verb }.into())
         }
+        GuestResponse::WorkloadPrivilegeRefused { verb, uid } => {
+            Err(RpcError::WorkloadPrivilegeRefused { verb, uid }.into())
+        }
         other => bail!("expected DetachedStarted for RunDetached, got {other:?}"),
     }
 }
@@ -461,6 +483,9 @@ where
             // "unexpected variant") so the host can audit it as `verb_denied`.
             GuestResponse::VerbNotAuthorized { verb } => {
                 return Err(RpcError::VerbNotAuthorized { verb }.into());
+            }
+            GuestResponse::WorkloadPrivilegeRefused { verb, uid } => {
+                return Err(RpcError::WorkloadPrivilegeRefused { verb, uid }.into());
             }
             other => bail!("expected ExecEvent during exec stream, got {other:?}"),
         };
@@ -987,6 +1012,35 @@ mod tests {
         assert_eq!(got.len(), 1);
         assert!(matches!(got[0], ExecEvent::Stderr { ref chunk } if chunk == b"e"));
         assert!(matches!(term, ExecEvent::Exit { code: 2 }));
+    }
+
+    #[test]
+    fn read_exec_stream_surfaces_root_refusal_as_typed_rpc_error() {
+        // The no-root gate's refusal must reach the host as a typed, downcastable
+        // error naming the uid — the operator's whole diagnosis is "the agent
+        // never reached its privilege drop", which a stringified "unexpected
+        // variant" would bury.
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        let guest_handle = std::thread::spawn(move || {
+            write_frame(
+                &mut guest,
+                &GuestResponse::WorkloadPrivilegeRefused {
+                    verb: "exec".to_string(),
+                    uid: 0,
+                },
+            )
+            .unwrap();
+        });
+        let err = read_exec_stream(&mut host, |_| {}).unwrap_err();
+        guest_handle.join().unwrap();
+        match err.downcast_ref::<RpcError>() {
+            Some(RpcError::WorkloadPrivilegeRefused { verb, uid }) => {
+                assert_eq!(verb, "exec");
+                assert_eq!(*uid, 0);
+            }
+            other => panic!("expected typed RpcError::WorkloadPrivilegeRefused, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/mvm-agentd/src/vsock/workload_privilege.rs
+++ b/crates/mvm-agentd/src/vsock/workload_privilege.rs
@@ -1,0 +1,134 @@
+//! The no-root-workload gate: the agent refuses to spawn workload code while
+//! it is still uid 0.
+//!
+//! The agent has five distinct workload-spawn sites — the entrypoint runner,
+//! the exec stream, the console, the lifecycle hooks, and the worker pool —
+//! and none of them sets a uid. Every one inherits whatever identity the agent
+//! is serving under. Guarding each site individually would therefore guard the
+//! symptom five times over and still miss the sixth site someone adds later.
+//!
+//! The property that actually matters is a single one: **the agent is not root
+//! at the moment it serves a request that runs workload code**. That is one
+//! check over `Verb::spawns_workload_process`, placed on the one path every
+//! request already traverses.
+//!
+//! This gate is a backstop, not the mechanism. The mechanism is the privilege
+//! drop during activation; the gate exists so a boot path that never reaches
+//! that drop fails closed and names the verb it refused, instead of silently
+//! running the workload as root.
+
+use super::*;
+
+/// The live real uid, or `None` where the host has no such notion. A non-Linux
+/// build has nothing for this gate to assert and says so, rather than
+/// fabricating a uid that would make the check vacuously pass.
+#[must_use]
+pub fn current_uid() -> Option<u32> {
+    #[cfg(target_os = "linux")]
+    {
+        // SAFETY: getuid() has no precondition and cannot fail.
+        Some(unsafe { libc::getuid() })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+/// The refusal a request earns given the live uid, or `None` to proceed.
+/// Pure over its inputs so the policy is testable without a guest.
+#[must_use]
+pub fn workload_privilege_refusal(req: &GuestRequest, uid: Option<u32>) -> Option<GuestResponse> {
+    let uid = uid?;
+    if uid != 0 || !req.verb().spawns_workload_process() {
+        return None;
+    }
+    Some(GuestResponse::WorkloadPrivilegeRefused {
+        verb: req.kind_name().to_string(),
+        uid,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exec() -> GuestRequest {
+        GuestRequest::Exec {
+            command: String::new(),
+            stdin: None,
+            timeout_secs: None,
+        }
+    }
+
+    /// The gate fires for a workload-spawning verb served as root, and names
+    /// both the verb and the uid so the refusal diagnoses itself.
+    #[test]
+    fn root_exec_is_refused_and_self_describing() {
+        let resp = workload_privilege_refusal(&exec(), Some(0));
+        let Some(GuestResponse::WorkloadPrivilegeRefused { verb, uid }) = resp else {
+            panic!("root exec was not refused: {resp:?}");
+        };
+        assert_eq!(verb, "exec");
+        assert_eq!(uid, 0);
+    }
+
+    /// A dropped agent serves the same verb normally — the gate is inert once
+    /// the privilege drop has happened, which is the overwhelmingly common case.
+    #[test]
+    fn workload_uid_passes() {
+        assert!(
+            workload_privilege_refusal(&exec(), Some(crate::guest_mount::WORKLOAD_UID)).is_none()
+        );
+    }
+
+    /// A verb that spawns nothing is unaffected even at root, so a root agent
+    /// can still answer liveness and status probes — which is what makes the
+    /// refusal observable from the host instead of looking like a hang.
+    #[test]
+    fn non_spawning_verb_passes_at_root() {
+        assert!(workload_privilege_refusal(&GuestRequest::Ping, Some(0)).is_none());
+    }
+
+    /// Absent a uid (non-Linux build) the gate asserts nothing rather than
+    /// guessing. Stated as a test so the vacuous branch is deliberate.
+    #[test]
+    fn no_uid_means_no_opinion() {
+        assert!(workload_privilege_refusal(&exec(), None).is_none());
+    }
+
+    /// `ActivateEnvironment` runs the mounts and the pivot, so it legitimately
+    /// executes while still root. If the gate ever caught it, no guest could
+    /// reach the privilege drop at all and every backend would hard-fail —
+    /// this is the one classification that must not drift.
+    #[test]
+    fn activation_is_never_refused_at_root() {
+        assert!(!Verb::ActivateEnvironment.spawns_workload_process());
+    }
+
+    /// Every verb classified as workload-spawning is refused at root, and every
+    /// verb not so classified is not. Iterating `Verb::ALL` means a verb added
+    /// later is covered without anyone remembering to extend this test.
+    #[test]
+    fn classification_is_total_over_every_verb() {
+        let spawning: Vec<_> = Verb::ALL
+            .iter()
+            .filter(|v| v.spawns_workload_process())
+            .map(|v| v.name())
+            .collect();
+        assert_eq!(
+            spawning,
+            vec![
+                "Exec",
+                "ExecBatch",
+                "RunEntrypoint",
+                "RunDetached",
+                "ConsoleOpen",
+                "ProcStart",
+                "RunCode",
+            ],
+            "the set of workload-spawning verbs changed: confirm the new set is \
+             correct, then update this list"
+        );
+    }
+}

--- a/crates/mvm-sdk/sdks/python/mvm/_protocol/protocol.py
+++ b/crates/mvm-sdk/sdks/python/mvm/_protocol/protocol.py
@@ -792,6 +792,17 @@ class GuestResponse13:
 
 
 @dataclass
+class WorkloadPrivilegeRefused:
+    uid: int
+    verb: str
+
+
+@dataclass
+class GuestResponse14:
+    WorkloadPrivilegeRefused: WorkloadPrivilegeRefused
+
+
+@dataclass
 class CheckpointResult:
     failed: List[str]
     success: bool
@@ -799,7 +810,7 @@ class CheckpointResult:
 
 
 @dataclass
-class GuestResponse15:
+class GuestResponse16:
     CheckpointResult: CheckpointResult
 
 
@@ -809,12 +820,12 @@ class PrimedStatusReport:
 
 
 @dataclass
-class GuestResponse17:
+class GuestResponse18:
     PrimedStatusReport: PrimedStatusReport
 
 
 @dataclass
-class GuestResponse19:
+class GuestResponse20:
     ExecEvent: ExecEvent
 
 
@@ -824,7 +835,7 @@ class ExecBatchResult:
 
 
 @dataclass
-class GuestResponse20:
+class GuestResponse21:
     ExecBatchResult: ExecBatchResult
 
 
@@ -834,7 +845,7 @@ class DetachedStarted:
 
 
 @dataclass
-class GuestResponse21:
+class GuestResponse22:
     DetachedStarted: DetachedStarted
 
 
@@ -847,7 +858,7 @@ class PostRestoreAck:
 
 
 @dataclass
-class GuestResponse22:
+class GuestResponse23:
     PostRestoreAck: PostRestoreAck
 
 
@@ -858,7 +869,7 @@ class PortForwardStarted:
 
 
 @dataclass
-class GuestResponse24:
+class GuestResponse25:
     PortForwardStarted: PortForwardStarted
 
 
@@ -869,7 +880,7 @@ class UnixSocketForwardStarted:
 
 
 @dataclass
-class GuestResponse25:
+class GuestResponse26:
     UnixSocketForwardStarted: UnixSocketForwardStarted
 
 
@@ -880,7 +891,7 @@ class ConsoleOpened:
 
 
 @dataclass
-class GuestResponse26:
+class GuestResponse27:
     ConsoleOpened: ConsoleOpened
 
 
@@ -891,7 +902,7 @@ class ConsoleExited:
 
 
 @dataclass
-class GuestResponse27:
+class GuestResponse28:
     ConsoleExited: ConsoleExited
 
 
@@ -901,7 +912,7 @@ class ConsoleResized:
 
 
 @dataclass
-class GuestResponse28:
+class GuestResponse29:
     ConsoleResized: ConsoleResized
 
 
@@ -913,7 +924,7 @@ class EntrypointStatusReport:
 
 
 @dataclass
-class GuestResponse29:
+class GuestResponse30:
     EntrypointStatusReport: EntrypointStatusReport
 
 
@@ -924,7 +935,7 @@ class UpdateIdleTimeoutAck:
 
 
 @dataclass
-class GuestResponse35:
+class GuestResponse36:
     UpdateIdleTimeoutAck: UpdateIdleTimeoutAck
 
 
@@ -1401,12 +1412,12 @@ class ProbeStatusReport:
 
 
 @dataclass
-class GuestResponse16:
+class GuestResponse17:
     ProbeStatusReport: ProbeStatusReport
 
 
 @dataclass
-class GuestResponse18:
+class GuestResponse19:
     EntrypointEvent: EntrypointEvent
 
 
@@ -1416,27 +1427,27 @@ class FsDiffResult:
 
 
 @dataclass
-class GuestResponse23:
+class GuestResponse24:
     FsDiffResult: FsDiffResult
 
 
 @dataclass
-class GuestResponse30:
+class GuestResponse31:
     ReadinessStatusReport: ReadinessReport
 
 
 @dataclass
-class GuestResponse31:
+class GuestResponse32:
     FsResult: FsResult
 
 
 @dataclass
-class GuestResponse33:
+class GuestResponse34:
     ProcWaitEvent: ProcWaitEvent
 
 
 @dataclass
-class GuestResponse34:
+class GuestResponse35:
     VolumeMountResult: VolumeMountResult
 
 
@@ -1577,12 +1588,12 @@ class IntegrationStatusReport:
 
 
 @dataclass
-class GuestResponse14:
+class GuestResponse15:
     IntegrationStatusReport: IntegrationStatusReport
 
 
 @dataclass
-class GuestResponse32:
+class GuestResponse33:
     ProcResult: ProcResult
 
 
@@ -1622,6 +1633,7 @@ GuestResponse = Union[
     GuestResponse33,
     GuestResponse34,
     GuestResponse35,
+    GuestResponse36,
 ]
 
 

--- a/crates/mvm-sdk/sdks/typescript/src/protocol/protocol.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/protocol/protocol.ts
@@ -318,6 +318,11 @@ VerbNotAuthorized: {
 verb: string
 }
 } | {
+WorkloadPrivilegeRefused: {
+uid: number
+verb: string
+}
+} | {
 IntegrationStatusReport: {
 integrations: IntegrationStateReport[]
 }

--- a/schema/protocol-v0.json
+++ b/schema/protocol-v0.json
@@ -2379,6 +2379,34 @@
           "additionalProperties": false
         },
         {
+          "description": "The agent refused to spawn workload code because it is still running as uid 0. Carries the offending verb and the live uid so the refusal is self-diagnosing rather than needing a console-log hunt.",
+          "type": "object",
+          "required": [
+            "WorkloadPrivilegeRefused"
+          ],
+          "properties": {
+            "WorkloadPrivilegeRefused": {
+              "type": "object",
+              "required": [
+                "uid",
+                "verb"
+              ],
+              "properties": {
+                "uid": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "verb": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
           "description": "Per-integration status report.",
           "type": "object",
           "required": [

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -28,6 +28,21 @@ updates only its own entry below.
       `LocalBackend` (starts after #2078/#2080/#2081 land the shared
       inventory/volume/secret types).
 
+- [x] #2091 — no workload runs as root. `mvm-oci-init` is pid 1 and spawned
+      the agent as a root child, so `is_pid1()` was false, `apply_activation`
+      returned before `drop_privilege`, and the agent kept uid 0 — and since
+      none of its five workload-spawn sites sets a uid, every workload launched
+      through it ran as root. Firecracker boots the agent as pid 1 and so
+      already dropped to 901; the variable was the init, not the backend. The
+      OCI init now spawns the agent with the workload identity, and
+      `Verb::spawns_workload_process` plus one check on the shared request path
+      refuse any workload-spawning verb served at uid 0, so a boot path that
+      never reaches the drop fails closed instead of silently running as root.
+      Live: HVF moves from `uid=0(root)` to `uid=901`, Firecracker stays at
+      `uid=901`; reverting the mechanism makes the gate refuse with a
+      self-describing error. Evidence in
+      `specs/research/no-root-workload-live-witness.md`.
+
 - [x] Guest-kernel hardware floor — **plan 286**. Audit the resolved Linux
       6.12.100 configs and remove unsupported physical hardware, radio/input,
       filesystem, power-management, tracing/debug, keyring, task-accounting,

--- a/specs/research/no-root-workload-live-witness.md
+++ b/specs/research/no-root-workload-live-witness.md
@@ -1,0 +1,93 @@
+# No workload runs as root — cause, fix, and live witness
+
+**Status:** Evidence record. Every result below was produced by running the command shown on the host shown.
+**Scope:** #2091 — HVF ran the OCI entrypoint as root while Firecracker dropped to uid 901, for the same command and image.
+**Owner ruling:** a workload entrypoint is the workload's main process and must never run as root.
+
+## The cause
+
+Not a backend difference, despite presenting as one.
+
+`mvm-oci-init` is pid 1 on the OCI path. It performs the mounts and provisioning as root, then calls
+`spawn_one(&agent, "guest-agent")` — a plain `Command::spawn` that sets no uid. The agent is therefore a
+*child*, so `init::is_pid1()` is false, so `apply_activation` returns before reaching
+`guest_mount::drop_privilege`. The agent keeps uid 0.
+
+That matters because the agent has five distinct workload-spawn sites — the entrypoint runner, the exec
+stream, the console, the lifecycle hooks, and the worker pool — and **none of them sets a uid**. Each
+inherits the agent's identity. A root agent means a root workload, at every one of them.
+
+Firecracker boots the agent *as* pid 1, so it reaches the drop and lands on 901. Same command, two inits,
+two postures. HVF was not the variable; the init was. Any backend on the OCI path had the same defect.
+
+## The fix
+
+Two independent changes, deliberately kept separate.
+
+**1. The mechanism.** `mvm-oci-init` now spawns the agent with the workload identity from the start. The
+agent needs no privilege on this path — the init has already done every root-only step by the time it
+spawns. This converges the OCI path on the posture Firecracker already had rather than inventing a
+second one.
+
+`drop_privilege_raw` is now the single drop implementation, allocating on no path, because the new caller
+runs in a `pre_exec` hook — in the forked child before `exec` — where allocating can deadlock if another
+thread held the allocator lock at fork time.
+
+`/run/mvm` deliberately stays root-owned. It holds the host-signer anchor, so making it workload-writable
+would let a compromised workload replace that anchor and undermine verb-grant trust. The agent only reads it.
+
+**2. The backstop.** `Verb::spawns_workload_process()` classifies every wire verb exhaustively, and one
+check on the shared request path refuses when the agent is uid 0. `ActivateEnvironment` is classified as
+non-spawning on purpose: it performs the mounts and the pivot and so legitimately runs while still root.
+If the gate caught it, no guest could reach the privilege drop at all.
+
+Guarding the five spawn sites individually was considered and rejected — it guards the symptom five times
+and still misses the sixth site someone adds later. The property is single: the agent is not root when it
+serves a request that runs workload code.
+
+The gate is what protects the fix. Reverting the mechanism does not silently restore root; it makes every
+workload run fail loudly, on every boot.
+
+## Live results
+
+Command: `mvmctl machine run --image alpine [--hypervisor hvf] -- /bin/sh -c 'echo MVM_BOOT_OK; id'`
+
+| | Before | After |
+|---|---|---|
+| Firecracker (Linux/KVM, Hetzner) | `uid=901 gid=901` | `uid=901 gid=901` |
+| HVF (macOS 26.5.2 arm64) | **`uid=0(root) gid=0(root)`** | **`uid=901 gid=901`** |
+
+## The gate, witnessed live
+
+Reverting only the mechanism and re-running on HVF — a planted defect, not a hypothetical:
+
+```
+Error: guest agent refused exec: it is still running as uid 0, so the workload
+would have run as root. The agent never reached its privilege drop.
+```
+
+The refusal names the verb and the uid, so the diagnosis is in the error rather than in a console-log hunt.
+Restoring the mechanism returns the run to `uid=901`.
+
+Unit-level, the same discipline: moving `Exec` to the non-spawning side turns two tests red; deleting the
+`uid != 0` condition turns another red; removing the host-side handling turns the typed-error test red.
+
+## An obstacle worth recording
+
+The first two HVF attempts failed — one on a substitution-endpoint handshake timeout, one hanging outright —
+and the console showed `spawned guest-agent pid=46` with no `uid=` suffix, i.e. the *old* binary. An
+orphaned `mvm-hvf-supervisor` from an earlier run, 2.5 hours old, was still holding the previous
+`overlay.ext4` open and serving a stale VM. The runs were never exercising the new code.
+
+Worth knowing generally: **a stale supervisor makes a fixed build look broken.** Check for orphaned
+supervisor processes before believing a live result. The tell was the console line's missing field, not
+the error message.
+
+## Not witnessed here
+
+- **Claim 15** (no interactive access to a sealed production microVM) — needs a sealed prod image; the
+  alpine image used here is neither sealed nor prod.
+- **Claims 1 and 2 proper** — witnessing these needs a guest that *attempts* host-fs access and *attempts*
+  elevation, not a report of its starting uid.
+- The `forward proxy failed to start: binding forward proxy on 127.0.0.1:18080` line in the guest console
+  is the known NIC-less loopback gap, pre-existing and untouched by this work.

--- a/specs/research/no-root-workload-live-witness.md
+++ b/specs/research/no-root-workload-live-witness.md
@@ -88,11 +88,47 @@ Worth knowing generally: **a stale supervisor makes a fixed build look broken.**
 supervisor processes before believing a live result. The tell was the console line's missing field, not
 the error message.
 
+## Claims 1 and 2, witnessed adversarially
+
+A second probe ran a guest that *attempts* host-fs access and *attempts* elevation, rather than one
+reporting its starting uid. Same command shape, both backends.
+
+| Probe | HVF | Firecracker |
+|---|---|---|
+| `id` | `uid=901 gid=901` | `uid=901 gid=901` |
+| `CapEff` | `0` | `0` |
+| `CapBnd` | full (`000001ffffffffff`) | full (`000001ffffffffff`) |
+| `NoNewPrivs` | `0` | `0` |
+| `su` / `sudo` / setuid binaries | fails / absent / **0 present** | fails / absent / **0 present** |
+| write `/etc/passwd` | read-only fs | read-only fs |
+| `chown 0:0 /tmp` | operation not permitted | read-only fs |
+| **`unshare -r id`** | **`uid=0(root)`** | `unshare: Invalid argument` |
+| `mount -t proc` | permission denied | denied |
+| virtiofs / 9p / nfs mounts | **none** | **none** |
+| `/proc/1/root` | permission denied | permission denied |
+
+**Claim 1 holds on both.** No host-fs transport is mounted at all — the count of virtiofs/9p/nfs mounts is
+zero, so there is nothing to escape from. `/proc/1/root` is refused.
+
+**Claim 2's outcome holds on both, but for weaker reasons than the claim names.** Nothing escalates: no
+setuid binaries exist, the rootfs is read-only, and `CapEff` is empty. But `NoNewPrivs` is `0` and the
+capability bounding set is *full*, so the mechanism ADR-001 names for claims 1/2 —
+`setpriv --bounding-set=-all --no-new-privs` (W2.3) — is not applied to the OCI workload process. It is
+wired from the nix-built guest path, not this one. The outcome currently rests on the image shipping zero
+setuid binaries rather than on the named control.
+
+**One genuine per-backend divergence.** `unshare -r` yields uid 0 in a user namespace on HVF and is
+rejected on Firecracker. `nix/images/kernel/workload.nix` lists `NAMESPACES` and `CGROUPS` under
+`requiredExtraDisables` precisely "so Kconfig cannot silently select them back on", noting they stay
+enabled only in `builder.nix` for the Nix sandbox. Firecracker matches that intent; HVF boots a kernel
+that does not. Filed as #2101, together with the `no_new_privs` gap.
+
+Both are the same family as #2091 and were found the same way: per-claim CI is green in every case, and
+only running both backends shows the difference.
+
 ## Not witnessed here
 
 - **Claim 15** (no interactive access to a sealed production microVM) — needs a sealed prod image; the
   alpine image used here is neither sealed nor prod.
-- **Claims 1 and 2 proper** — witnessing these needs a guest that *attempts* host-fs access and *attempts*
-  elevation, not a report of its starting uid.
 - The `forward proxy failed to start: binding forward proxy on 127.0.0.1:18080` line in the guest console
   is the known NIC-less loopback gap, pre-existing and untouched by this work.

--- a/specs/research/no-root-workload-live-witness.md
+++ b/specs/research/no-root-workload-live-witness.md
@@ -57,6 +57,11 @@ Command: `mvmctl machine run --image alpine [--hypervisor hvf] -- /bin/sh -c 'ec
 | Firecracker (Linux/KVM, Hetzner) | `uid=901 gid=901` | `uid=901 gid=901` |
 | HVF (macOS 26.5.2 arm64) | **`uid=0(root) gid=0(root)`** | **`uid=901 gid=901`** |
 
+Both "after" figures are runs of a binary built from this branch, with the guest
+binaries recompiled on each host — not a carry-over of the earlier result. The
+Firecracker column is the regression check: the fix changes the OCI init, and
+Firecracker had to be shown still landing on 901 rather than assumed to.
+
 ## The gate, witnessed live
 
 Reverting only the mechanism and re-running on HVF — a planted defect, not a hypothetical:


### PR DESCRIPTION
Closes #2091.

## The cause

Not a backend difference, despite presenting as one.

`mvm-oci-init` is pid 1 on the OCI path. It does the mounts and provisioning as root, then calls `spawn_one(&agent, "guest-agent")` — a plain `Command::spawn` that sets no uid. The agent is therefore a *child*, so `is_pid1()` is false, so `apply_activation` returns before reaching `drop_privilege`. The agent keeps uid 0.

That matters because the agent has five workload-spawn sites — the entrypoint runner, the exec stream, the console, the lifecycle hooks, the worker pool — and **none sets a uid**. Each inherits the agent's identity. A root agent means a root workload at every one of them.

Firecracker boots the agent *as* pid 1, so it reaches the drop and lands on 901. Same command, two inits, two postures. HVF was not the variable; the init was.

## The fix

**Mechanism.** The OCI init now spawns the agent with the workload identity. It needs no privilege on that path — the init has already done every root-only step by the time it spawns. This converges on the posture Firecracker already had rather than inventing a second one.

`drop_privilege_raw` is now the single drop implementation, allocating on no path, because the new caller runs in a `pre_exec` hook — the forked child before `exec` — where allocating can deadlock if another thread held the allocator lock at fork time.

`/run/mvm` deliberately stays root-owned: it holds the host-signer anchor, so making it workload-writable would let a compromised workload replace that anchor and undermine verb-grant trust. The agent only reads it.

**Backstop.** `Verb::spawns_workload_process()` classifies every wire verb exhaustively, and one check on the shared request path refuses when the agent is uid 0. `ActivateEnvironment` is non-spawning on purpose — it performs the mounts and the pivot and legitimately runs while still root; if the gate caught it, no guest could reach the drop at all.

Guarding the five spawn sites individually was considered and rejected: it guards the symptom five times and still misses the sixth site added later. The property is single — the agent is not root when it serves a request that runs workload code.

**The gate protects the fix.** Reverting the mechanism does not silently restore root; it makes every workload run fail loudly, on every boot.

## Live witness

`mvmctl machine run --image alpine [--hypervisor hvf] -- /bin/sh -c 'echo MVM_BOOT_OK; id'`

| | Before | After |
|---|---|---|
| Firecracker (Linux/KVM) | `uid=901 gid=901` | `uid=901 gid=901` |
| HVF (macOS 26.5.2 arm64) | **`uid=0(root) gid=0(root)`** | **`uid=901 gid=901`** |

Reverting only the mechanism and re-running on HVF — a planted defect, not a hypothetical:

```
Error: guest agent refused exec: it is still running as uid 0, so the workload
would have run as root. The agent never reached its privilege drop.
```

Unit-level, the same discipline: moving `Exec` to the non-spawning side turns two tests red; deleting the `uid != 0` condition turns another red; removing the host-side handling turns the typed-error test red.

## Notes

- The refusal is a typed, downcastable `RpcError`, handled at the same four sites as the sibling `VerbNotAuthorized`, so the operator gets the diagnosis rather than "expected ExecEvent, got …".
- Evidence record: `specs/research/no-root-workload-live-witness.md`, including the stale-supervisor trap that made two already-fixed builds look broken.