### PR TITLE
Add fenced block-volume worker transfer protocol

### DIFF
--- a/crates/mvm-core/src/client/gateway.rs
+++ b/crates/mvm-core/src/client/gateway.rs
@@ -346,6 +346,7 @@ impl RemoteVolumeCreateBuilder {
 struct CreateRemoteVolumeBody<'a> {
     name: &'a str,
     size_gib: u32,
+    encrypted: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     storage_class: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -390,6 +391,7 @@ impl GatewayBackend {
         let body = CreateRemoteVolumeBody {
             name: &request.name,
             size_gib: request.size_gib,
+            encrypted: true,
             storage_class: request.storage_class.as_deref(),
             from_snapshot_id: request.from_snapshot_id.as_deref(),
             bucket_id: request.bucket_id.as_deref(),
@@ -1110,13 +1112,14 @@ mod tests {
         let body = CreateRemoteVolumeBody {
             name: &request.name,
             size_gib: request.size_gib,
+            encrypted: true,
             storage_class: request.storage_class.as_deref(),
             from_snapshot_id: request.from_snapshot_id.as_deref(),
             bucket_id: request.bucket_id.as_deref(),
         };
         assert_eq!(
             serde_json::to_string(&body).unwrap(),
-            r#"{"name":"data","size_gib":4}"#
+            r#"{"name":"data","size_gib":4,"encrypted":true}"#
         );
     }
 

--- a/crates/mvm-core/src/domain/agent.rs
+++ b/crates/mvm-core/src/domain/agent.rs
@@ -479,6 +479,15 @@ pub enum AgentRequest {
         instance_id: String,
         action: InstanceAction,
     },
+    /// Start an instance with fleet-resolved encrypted block volumes.
+    StartInstanceWithBlockVolumes {
+        tenant_id: String,
+        pool_id: String,
+        instance_id: String,
+        #[serde(default)]
+        workspace_id: Option<String>,
+        volumes: Vec<crate::instance::BlockVolumeAttach>,
+    },
     /// Forward a sandbox operation (filesystem, exec, logs) to the guest agent.
     SandboxAction {
         tenant_id: String,
@@ -2087,6 +2096,22 @@ mod tests {
                 pool_id: "p1".to_string(),
                 instance_id: "i1".to_string(),
                 action: InstanceAction::Start,
+            },
+            AgentRequest::StartInstanceWithBlockVolumes {
+                tenant_id: "t1".to_string(),
+                pool_id: "p1".to_string(),
+                instance_id: "i1".to_string(),
+                workspace_id: Some("ws1".to_string()),
+                volumes: vec![crate::instance::BlockVolumeAttach {
+                    org_id: "org1".to_string(),
+                    workspace_id: "ws1".to_string(),
+                    volume_id: "vol1".to_string(),
+                    guest_path: "/data".to_string(),
+                    read_only: false,
+                    encrypted: true,
+                    fencing_token: 1,
+                    data_key_version: 1,
+                }],
             },
             AgentRequest::SandboxAction {
                 tenant_id: "t1".to_string(),

--- a/crates/mvm-core/src/domain/agent.rs
+++ b/crates/mvm-core/src/domain/agent.rs
@@ -488,6 +488,13 @@ pub enum AgentRequest {
         workspace_id: Option<String>,
         volumes: Vec<crate::instance::BlockVolumeAttach>,
     },
+    /// Refresh the same fenced leases before their UTC expiry.
+    RenewBlockVolumeLeases {
+        tenant_id: String,
+        pool_id: String,
+        instance_id: String,
+        volumes: Vec<crate::instance::BlockVolumeAttach>,
+    },
     /// Forward a sandbox operation (filesystem, exec, logs) to the guest agent.
     SandboxAction {
         tenant_id: String,
@@ -2110,6 +2117,23 @@ mod tests {
                     read_only: false,
                     encrypted: true,
                     fencing_token: 1,
+                    lease_expires_at: "2026-08-02T12:00:00Z".to_string(),
+                    data_key_version: 1,
+                }],
+            },
+            AgentRequest::RenewBlockVolumeLeases {
+                tenant_id: "t1".to_string(),
+                pool_id: "p1".to_string(),
+                instance_id: "i1".to_string(),
+                volumes: vec![crate::instance::BlockVolumeAttach {
+                    org_id: "org1".to_string(),
+                    workspace_id: "ws1".to_string(),
+                    volume_id: "vol1".to_string(),
+                    guest_path: "/data".to_string(),
+                    read_only: false,
+                    encrypted: true,
+                    fencing_token: 1,
+                    lease_expires_at: "2026-08-02T12:01:00Z".to_string(),
                     data_key_version: 1,
                 }],
             },

--- a/crates/mvm-core/src/domain/agent.rs
+++ b/crates/mvm-core/src/domain/agent.rs
@@ -495,6 +495,39 @@ pub enum AgentRequest {
         instance_id: String,
         volumes: Vec<crate::instance::BlockVolumeAttach>,
     },
+    /// Read one bounded ciphertext chunk from a fenced, detached volume image.
+    ReadBlockVolumeChunk {
+        tenant_id: String,
+        pool_id: String,
+        volume: crate::instance::BlockVolumeTransfer,
+        offset: u64,
+        max_bytes: u32,
+    },
+    /// Create private restore staging for an exact encrypted image.
+    BeginBlockVolumeRestore {
+        tenant_id: String,
+        pool_id: String,
+        restore: crate::instance::BlockVolumeRestore,
+    },
+    /// Append one verified ciphertext chunk to restore staging.
+    WriteBlockVolumeRestoreChunk {
+        tenant_id: String,
+        pool_id: String,
+        transfer_id: String,
+        chunk: crate::instance::BlockVolumeChunk,
+    },
+    /// Verify, fsync, and atomically publish a staged encrypted image.
+    CommitBlockVolumeRestore {
+        tenant_id: String,
+        pool_id: String,
+        transfer_id: String,
+    },
+    /// Idempotently discard private restore staging.
+    AbortBlockVolumeRestore {
+        tenant_id: String,
+        pool_id: String,
+        transfer_id: String,
+    },
     /// Forward a sandbox operation (filesystem, exec, logs) to the guest agent.
     SandboxAction {
         tenant_id: String,
@@ -637,6 +670,16 @@ pub enum AgentResponse {
     InstanceActionResult {
         success: bool,
         new_status: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+    /// A bounded encrypted-image chunk returned to the gateway.
+    BlockVolumeChunk(crate::instance::BlockVolumeChunk),
+    /// Progress or completion of a worker-side image restore.
+    BlockVolumeTransferResult {
+        success: bool,
+        next_offset: u64,
+        complete: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         error: Option<String>,
     },
@@ -2116,6 +2159,8 @@ mod tests {
                     guest_path: "/data".to_string(),
                     read_only: false,
                     encrypted: true,
+                    size_mib: 1024,
+                    initialize_if_missing: false,
                     fencing_token: 1,
                     lease_expires_at: "2026-08-02T12:00:00Z".to_string(),
                     data_key_version: 1,
@@ -2132,10 +2177,63 @@ mod tests {
                     guest_path: "/data".to_string(),
                     read_only: false,
                     encrypted: true,
+                    size_mib: 1024,
+                    initialize_if_missing: false,
                     fencing_token: 1,
                     lease_expires_at: "2026-08-02T12:01:00Z".to_string(),
                     data_key_version: 1,
                 }],
+            },
+            AgentRequest::ReadBlockVolumeChunk {
+                tenant_id: "t1".into(),
+                pool_id: "p1".into(),
+                volume: crate::instance::BlockVolumeTransfer {
+                    org_id: "org1".into(),
+                    workspace_id: "ws1".into(),
+                    volume_id: "vol1".into(),
+                    fencing_token: 2,
+                    data_key_version: 1,
+                },
+                offset: 0,
+                max_bytes: 1024,
+            },
+            AgentRequest::BeginBlockVolumeRestore {
+                tenant_id: "t1".into(),
+                pool_id: "p1".into(),
+                restore: crate::instance::BlockVolumeRestore {
+                    transfer_id: "restore1".into(),
+                    volume: crate::instance::BlockVolumeTransfer {
+                        org_id: "org1".into(),
+                        workspace_id: "ws1".into(),
+                        volume_id: "vol1".into(),
+                        fencing_token: 3,
+                        data_key_version: 1,
+                    },
+                    expected_size: 2,
+                    expected_sha256: "ab".repeat(32),
+                },
+            },
+            AgentRequest::WriteBlockVolumeRestoreChunk {
+                tenant_id: "t1".into(),
+                pool_id: "p1".into(),
+                transfer_id: "restore1".into(),
+                chunk: crate::instance::BlockVolumeChunk {
+                    offset: 0,
+                    total_size: 2,
+                    sha256: "ab".repeat(32),
+                    data_hex: "00ff".into(),
+                    eof: true,
+                },
+            },
+            AgentRequest::CommitBlockVolumeRestore {
+                tenant_id: "t1".into(),
+                pool_id: "p1".into(),
+                transfer_id: "restore1".into(),
+            },
+            AgentRequest::AbortBlockVolumeRestore {
+                tenant_id: "t1".into(),
+                pool_id: "p1".into(),
+                transfer_id: "restore1".into(),
             },
             AgentRequest::SandboxAction {
                 tenant_id: "t1".to_string(),
@@ -2293,6 +2391,19 @@ mod tests {
             AgentResponse::InstanceActionResult {
                 success: true,
                 new_status: "running".to_string(),
+                error: None,
+            },
+            AgentResponse::BlockVolumeChunk(crate::instance::BlockVolumeChunk {
+                offset: 0,
+                total_size: 1,
+                sha256: "ab".repeat(32),
+                data_hex: "00".into(),
+                eof: true,
+            }),
+            AgentResponse::BlockVolumeTransferResult {
+                success: true,
+                next_offset: 1,
+                complete: true,
                 error: None,
             },
             AgentResponse::SandboxResult {

--- a/crates/mvm-core/src/domain/instance.rs
+++ b/crates/mvm-core/src/domain/instance.rs
@@ -6,6 +6,10 @@ use serde::{Deserialize, Serialize};
 use crate::idle_metrics::IdleMetrics;
 use crate::pool::Role;
 
+/// Maximum ciphertext bytes carried in one block-volume transfer frame.
+pub const MAX_BLOCK_VOLUME_TRANSFER_CHUNK_BYTES: usize = 384 * 1024;
+const SHA256_HEX_LEN: usize = 64;
+
 // ============================================================================
 // Workspace volume attach + workload classification (cross-repo with mvmd)
 // ============================================================================
@@ -58,6 +62,12 @@ pub struct BlockVolumeAttach {
     pub read_only: bool,
     #[serde(default)]
     pub encrypted: bool,
+    /// Allocated image capacity used only when the control plane explicitly
+    /// authorizes first materialization on an empty worker.
+    pub size_mib: u32,
+    /// Whether this attachment may create a fresh encrypted image if absent.
+    #[serde(default)]
+    pub initialize_if_missing: bool,
     /// Exclusive-writer epoch admitted by the fleet control plane.
     pub fencing_token: u64,
     /// UTC expiry for the writer lease. The worker must stop the workload
@@ -70,24 +80,14 @@ pub struct BlockVolumeAttach {
 impl BlockVolumeAttach {
     /// Reject malformed or unsafe identity and mount intent before dispatch.
     pub fn validate(&self) -> Result<()> {
-        for (label, value) in [
-            ("org_id", self.org_id.as_str()),
-            ("workspace_id", self.workspace_id.as_str()),
-            ("volume_id", self.volume_id.as_str()),
-        ] {
-            if value.is_empty()
-                || value.len() > 128
-                || !value
-                    .chars()
-                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-            {
-                bail!("{label} is not a valid volume identity");
-            }
-        }
+        validate_volume_identity(&self.org_id, &self.workspace_id, &self.volume_id)?;
         crate::crypto::policy::validate_mount_path(&self.guest_path)
             .map_err(|error| anyhow::anyhow!(error))?;
         if self.fencing_token == 0 {
             bail!("fencing_token must be non-zero");
+        }
+        if self.size_mib == 0 {
+            bail!("size_mib must be non-zero");
         }
         let lease_expiry = chrono::DateTime::parse_from_rfc3339(&self.lease_expires_at)
             .map_err(|_| anyhow::anyhow!("lease_expires_at must be RFC 3339 UTC time"))?;
@@ -99,6 +99,148 @@ impl BlockVolumeAttach {
         }
         Ok(())
     }
+}
+
+/// Fenced identity used to transfer an encrypted block image without exposing
+/// provider configuration, keys, object names, or host paths.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BlockVolumeTransfer {
+    /// Organization owning the volume.
+    pub org_id: String,
+    /// Workspace owning the volume.
+    pub workspace_id: String,
+    /// Canonical persistent-volume identifier.
+    pub volume_id: String,
+    /// Current control-plane mutation epoch.
+    pub fencing_token: u64,
+    /// Version of the locally derived LUKS data key.
+    pub data_key_version: u32,
+}
+
+impl BlockVolumeTransfer {
+    /// Reject malformed identity or an unfenced transfer.
+    pub fn validate(&self) -> Result<()> {
+        validate_volume_identity(&self.org_id, &self.workspace_id, &self.volume_id)?;
+        if self.fencing_token == 0 {
+            bail!("fencing_token must be non-zero");
+        }
+        if self.data_key_version == 0 {
+            bail!("data_key_version must be non-zero");
+        }
+        Ok(())
+    }
+}
+
+/// One bounded, content-addressed ciphertext chunk read from a worker.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BlockVolumeChunk {
+    /// Byte offset in the encrypted image.
+    pub offset: u64,
+    /// Total encrypted image length observed by the worker.
+    pub total_size: u64,
+    /// SHA-256 digest of the decoded chunk bytes.
+    pub sha256: String,
+    /// Hex-encoded ciphertext bytes. Hex keeps JSON framing deterministic.
+    pub data_hex: String,
+    /// Whether this chunk reaches the observed end of the image.
+    pub eof: bool,
+}
+
+impl BlockVolumeChunk {
+    /// Validate framing bounds, digest shape, and end-of-image arithmetic.
+    pub fn validate(&self) -> Result<()> {
+        if !valid_sha256(&self.sha256) {
+            bail!("block-volume chunk digest must be lowercase SHA-256");
+        }
+        if self.data_hex.len() > MAX_BLOCK_VOLUME_TRANSFER_CHUNK_BYTES * 2
+            || !self.data_hex.len().is_multiple_of(2)
+            || !self
+                .data_hex
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            bail!("block-volume chunk data is malformed or exceeds the frame bound");
+        }
+        let decoded_len = u64::try_from(self.data_hex.len() / 2)
+            .map_err(|_| anyhow::anyhow!("block-volume chunk length is unsupported"))?;
+        let end = self
+            .offset
+            .checked_add(decoded_len)
+            .ok_or_else(|| anyhow::anyhow!("block-volume chunk offset overflow"))?;
+        if end > self.total_size || self.eof != (end == self.total_size) {
+            bail!("block-volume chunk does not match the image length");
+        }
+        Ok(())
+    }
+}
+
+/// Expected immutable image used to begin a private worker-side restore.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BlockVolumeRestore {
+    /// Unpredictable identifier for this bounded staging attempt.
+    pub transfer_id: String,
+    /// Fenced destination identity.
+    pub volume: BlockVolumeTransfer,
+    /// Exact encrypted image byte length.
+    pub expected_size: u64,
+    /// SHA-256 digest of the complete encrypted image.
+    pub expected_sha256: String,
+}
+
+impl BlockVolumeRestore {
+    /// Validate restore identity and exact expected content metadata.
+    pub fn validate(&self) -> Result<()> {
+        self.volume.validate()?;
+        validate_block_volume_transfer_id(&self.transfer_id)?;
+        if self.expected_size == 0 {
+            bail!("block-volume restore size must be non-zero");
+        }
+        if !valid_sha256(&self.expected_sha256) {
+            bail!("block-volume restore digest must be lowercase SHA-256");
+        }
+        Ok(())
+    }
+}
+
+fn validate_volume_identity(org_id: &str, workspace_id: &str, volume_id: &str) -> Result<()> {
+    for (label, value) in [
+        ("org_id", org_id),
+        ("workspace_id", workspace_id),
+        ("volume_id", volume_id),
+    ] {
+        if value.is_empty()
+            || value.len() > 128
+            || !value
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            bail!("{label} is not a valid volume identity");
+        }
+    }
+    Ok(())
+}
+
+/// Validate an opaque restore transfer identifier at every wire boundary.
+pub fn validate_block_volume_transfer_id(value: &str) -> Result<()> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        bail!("transfer_id is not valid");
+    }
+    Ok(())
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == SHA256_HEX_LEN
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
 /// Workload class — drives sleep policy, auto-provision rules, and
@@ -437,6 +579,7 @@ pub fn validate_transition(from: InstanceStatus, to: InstanceStatus) -> Result<(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::Digest;
 
     #[test]
     fn test_valid_transitions() {
@@ -895,6 +1038,8 @@ mod tests {
             guest_path: "/data".into(),
             read_only: false,
             encrypted: true,
+            size_mib: 1024,
+            initialize_if_missing: false,
             fencing_token: 4,
             lease_expires_at: "2026-08-02T12:00:00Z".into(),
             data_key_version: 1,
@@ -919,6 +1064,8 @@ mod tests {
             guest_path: "/data".into(),
             read_only: true,
             encrypted: true,
+            size_mib: 1024,
+            initialize_if_missing: false,
             fencing_token: 1,
             lease_expires_at: "2026-08-02T12:00:00Z".into(),
             data_key_version: 1,
@@ -933,6 +1080,47 @@ mod tests {
         attach.fencing_token = 1;
         attach.lease_expires_at = "not-a-time".into();
         assert!(attach.validate().is_err());
+    }
+
+    #[test]
+    fn block_volume_transfer_chunks_enforce_bounds_and_image_arithmetic() {
+        let data = b"ciphertext";
+        let mut chunk = BlockVolumeChunk {
+            offset: 0,
+            total_size: u64::try_from(data.len()).unwrap(),
+            sha256: hex::encode(sha2::Sha256::digest(data)),
+            data_hex: hex::encode(data),
+            eof: true,
+        };
+        chunk.validate().unwrap();
+
+        chunk.eof = false;
+        assert!(chunk.validate().is_err());
+        chunk.eof = true;
+        chunk.data_hex = "z0".into();
+        assert!(chunk.validate().is_err());
+    }
+
+    #[test]
+    fn block_volume_restore_validates_fenced_identity_and_digest() {
+        let mut restore = BlockVolumeRestore {
+            transfer_id: "restore-1".into(),
+            volume: BlockVolumeTransfer {
+                org_id: "org-1".into(),
+                workspace_id: "workspace-1".into(),
+                volume_id: "volume-1".into(),
+                fencing_token: 9,
+                data_key_version: 2,
+            },
+            expected_size: 4096,
+            expected_sha256: "ab".repeat(32),
+        };
+        restore.validate().unwrap();
+        restore.volume.fencing_token = 0;
+        assert!(restore.validate().is_err());
+        restore.volume.fencing_token = 9;
+        restore.expected_sha256 = "not-a-digest".into();
+        assert!(restore.validate().is_err());
     }
 
     // ------------- DesiredInstance -------------

--- a/crates/mvm-core/src/domain/instance.rs
+++ b/crates/mvm-core/src/domain/instance.rs
@@ -165,6 +165,9 @@ impl BlockVolumeChunk {
         }
         let decoded_len = u64::try_from(self.data_hex.len() / 2)
             .map_err(|_| anyhow::anyhow!("block-volume chunk length is unsupported"))?;
+        if self.total_size == 0 || decoded_len == 0 {
+            bail!("block-volume chunk must make progress within a non-empty image");
+        }
         let end = self
             .offset
             .checked_add(decoded_len)
@@ -1098,6 +1101,9 @@ mod tests {
         assert!(chunk.validate().is_err());
         chunk.eof = true;
         chunk.data_hex = "z0".into();
+        assert!(chunk.validate().is_err());
+        chunk.data_hex.clear();
+        chunk.sha256 = hex::encode(sha2::Sha256::digest([]));
         assert!(chunk.validate().is_err());
     }
 

--- a/crates/mvm-core/src/domain/instance.rs
+++ b/crates/mvm-core/src/domain/instance.rs
@@ -60,6 +60,9 @@ pub struct BlockVolumeAttach {
     pub encrypted: bool,
     /// Exclusive-writer epoch admitted by the fleet control plane.
     pub fencing_token: u64,
+    /// UTC expiry for the writer lease. The worker must stop the workload
+    /// before allowing this lease to lapse.
+    pub lease_expires_at: String,
     /// Version of the resource data-key derivation used by this image.
     pub data_key_version: u32,
 }
@@ -85,6 +88,11 @@ impl BlockVolumeAttach {
             .map_err(|error| anyhow::anyhow!(error))?;
         if self.fencing_token == 0 {
             bail!("fencing_token must be non-zero");
+        }
+        let lease_expiry = chrono::DateTime::parse_from_rfc3339(&self.lease_expires_at)
+            .map_err(|_| anyhow::anyhow!("lease_expires_at must be RFC 3339 UTC time"))?;
+        if lease_expiry.offset().local_minus_utc() != 0 {
+            bail!("lease_expires_at must use UTC");
         }
         if self.data_key_version == 0 {
             bail!("data_key_version must be non-zero");
@@ -888,6 +896,7 @@ mod tests {
             read_only: false,
             encrypted: true,
             fencing_token: 4,
+            lease_expires_at: "2026-08-02T12:00:00Z".into(),
             data_key_version: 1,
         };
         attach.validate().unwrap();
@@ -911,6 +920,7 @@ mod tests {
             read_only: true,
             encrypted: true,
             fencing_token: 1,
+            lease_expires_at: "2026-08-02T12:00:00Z".into(),
             data_key_version: 1,
         };
         assert!(attach.validate().is_err());
@@ -919,6 +929,9 @@ mod tests {
         assert!(attach.validate().is_err());
         attach.guest_path = "/data".into();
         attach.fencing_token = 0;
+        assert!(attach.validate().is_err());
+        attach.fencing_token = 1;
+        attach.lease_expires_at = "not-a-time".into();
         assert!(attach.validate().is_err());
     }
 

--- a/crates/mvm-core/src/domain/instance.rs
+++ b/crates/mvm-core/src/domain/instance.rs
@@ -42,6 +42,57 @@ pub struct VolumeAttach {
     pub mode: VolumeMode,
 }
 
+/// Fleet-resolved block volume attached to an instance at boot.
+///
+/// This carries only identity and admitted mount intent. Provider credentials,
+/// encryption keys, object names, and host paths are deliberately absent; the
+/// mvmd worker resolves its local encrypted image from these identifiers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BlockVolumeAttach {
+    pub org_id: String,
+    pub workspace_id: String,
+    pub volume_id: String,
+    pub guest_path: String,
+    #[serde(default)]
+    pub read_only: bool,
+    #[serde(default)]
+    pub encrypted: bool,
+    /// Exclusive-writer epoch admitted by the fleet control plane.
+    pub fencing_token: u64,
+    /// Version of the resource data-key derivation used by this image.
+    pub data_key_version: u32,
+}
+
+impl BlockVolumeAttach {
+    /// Reject malformed or unsafe identity and mount intent before dispatch.
+    pub fn validate(&self) -> Result<()> {
+        for (label, value) in [
+            ("org_id", self.org_id.as_str()),
+            ("workspace_id", self.workspace_id.as_str()),
+            ("volume_id", self.volume_id.as_str()),
+        ] {
+            if value.is_empty()
+                || value.len() > 128
+                || !value
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+            {
+                bail!("{label} is not a valid volume identity");
+            }
+        }
+        crate::crypto::policy::validate_mount_path(&self.guest_path)
+            .map_err(|error| anyhow::anyhow!(error))?;
+        if self.fencing_token == 0 {
+            bail!("fencing_token must be non-zero");
+        }
+        if self.data_key_version == 0 {
+            bail!("data_key_version must be non-zero");
+        }
+        Ok(())
+    }
+}
+
 /// Workload class — drives sleep policy, auto-provision rules, and
 /// resource defaults. Sandbox is the user-controlled ephemeral default;
 /// Service is workspace-owned, auto-provisioned, long-running (e.g. the
@@ -825,6 +876,50 @@ mod tests {
         let json = serde_json::to_string(&attach).unwrap();
         let parsed: VolumeAttach = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, attach);
+    }
+
+    #[test]
+    fn block_volume_attach_validates_and_carries_no_secrets_or_paths() {
+        let attach = BlockVolumeAttach {
+            org_id: "org-1".into(),
+            workspace_id: "ws-1".into(),
+            volume_id: "vol-1".into(),
+            guest_path: "/data".into(),
+            read_only: false,
+            encrypted: true,
+            fencing_token: 4,
+            data_key_version: 1,
+        };
+        attach.validate().unwrap();
+        let json = serde_json::to_string(&attach).unwrap();
+        assert!(!json.contains("credential"));
+        assert!(!json.contains("encryption_key"));
+        assert!(!json.contains("host_path"));
+        assert_eq!(
+            serde_json::from_str::<BlockVolumeAttach>(&json).unwrap(),
+            attach
+        );
+    }
+
+    #[test]
+    fn block_volume_attach_rejects_bad_identity_path_and_epoch() {
+        let mut attach = BlockVolumeAttach {
+            org_id: "org-1".into(),
+            workspace_id: "ws-1".into(),
+            volume_id: "../vol".into(),
+            guest_path: "/data".into(),
+            read_only: true,
+            encrypted: true,
+            fencing_token: 1,
+            data_key_version: 1,
+        };
+        assert!(attach.validate().is_err());
+        attach.volume_id = "vol-1".into();
+        attach.guest_path = "/etc".into();
+        assert!(attach.validate().is_err());
+        attach.guest_path = "/data".into();
+        attach.fencing_token = 0;
+        assert!(attach.validate().is_err());
     }
 
     // ------------- DesiredInstance -------------

--- a/crates/mvm-core/src/protocol/protocol.rs
+++ b/crates/mvm-core/src/protocol/protocol.rs
@@ -103,6 +103,39 @@ pub enum HostdRequest {
         instance_id: String,
         volumes: Vec<crate::instance::BlockVolumeAttach>,
     },
+    /// Read one bounded ciphertext chunk from a fenced local volume.
+    ReadBlockVolumeChunk {
+        tenant_id: String,
+        pool_id: String,
+        volume: crate::instance::BlockVolumeTransfer,
+        offset: u64,
+        max_bytes: u32,
+    },
+    /// Begin a private encrypted-image restore.
+    BeginBlockVolumeRestore {
+        tenant_id: String,
+        pool_id: String,
+        restore: crate::instance::BlockVolumeRestore,
+    },
+    /// Append one verified restore chunk.
+    WriteBlockVolumeRestoreChunk {
+        tenant_id: String,
+        pool_id: String,
+        transfer_id: String,
+        chunk: crate::instance::BlockVolumeChunk,
+    },
+    /// Atomically publish a completely verified restore.
+    CommitBlockVolumeRestore {
+        tenant_id: String,
+        pool_id: String,
+        transfer_id: String,
+    },
+    /// Remove restore staging if it exists.
+    AbortBlockVolumeRestore {
+        tenant_id: String,
+        pool_id: String,
+        transfer_id: String,
+    },
     /// Stop a running instance (kill FC, teardown cgroup, TAP).
     StopInstance {
         tenant_id: String,
@@ -198,6 +231,15 @@ pub enum HostdResponse {
     Error { message: String },
     /// Pong response to Ping.
     Pong,
+    /// A bounded encrypted-image chunk.
+    BlockVolumeChunk(crate::instance::BlockVolumeChunk),
+    /// Worker-side restore progress.
+    BlockVolumeTransferResult {
+        success: bool,
+        next_offset: u64,
+        complete: bool,
+        error: Option<String>,
+    },
 }
 
 // ============================================================================
@@ -399,6 +441,8 @@ mod tests {
                 guest_path: "/data".into(),
                 read_only: false,
                 encrypted: true,
+                size_mib: 1024,
+                initialize_if_missing: false,
                 fencing_token: 8,
                 lease_expires_at: "2026-08-02T12:00:00Z".into(),
                 data_key_version: 1,
@@ -429,6 +473,8 @@ mod tests {
                 guest_path: "/data".into(),
                 read_only: false,
                 encrypted: true,
+                size_mib: 1024,
+                initialize_if_missing: false,
                 fencing_token: 8,
                 lease_expires_at: "2026-08-02T12:01:00Z".into(),
                 data_key_version: 1,
@@ -442,6 +488,35 @@ mod tests {
             serde_json::from_str::<HostdRequest>(&json).unwrap(),
             HostdRequest::RenewBlockVolumeLeases { volumes, .. }
                 if volumes[0].lease_expires_at.ends_with('Z')
+        ));
+    }
+
+    #[test]
+    fn hostd_block_volume_restore_roundtrip_is_bounded_and_has_no_secrets() {
+        let request = HostdRequest::BeginBlockVolumeRestore {
+            tenant_id: "tenant-1".into(),
+            pool_id: "pool-1".into(),
+            restore: crate::instance::BlockVolumeRestore {
+                transfer_id: "restore-1".into(),
+                volume: crate::instance::BlockVolumeTransfer {
+                    org_id: "org-1".into(),
+                    workspace_id: "ws-1".into(),
+                    volume_id: "vol-1".into(),
+                    fencing_token: 9,
+                    data_key_version: 2,
+                },
+                expected_size: 4096,
+                expected_sha256: "ab".repeat(32),
+            },
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        for forbidden in ["credential", "encryption_key", "host_path", "object_key"] {
+            assert!(!json.contains(forbidden));
+        }
+        assert!(matches!(
+            serde_json::from_str::<HostdRequest>(&json).unwrap(),
+            HostdRequest::BeginBlockVolumeRestore { restore, .. }
+                if restore.volume.fencing_token == 9
         ));
     }
 

--- a/crates/mvm-core/src/protocol/protocol.rs
+++ b/crates/mvm-core/src/protocol/protocol.rs
@@ -96,6 +96,13 @@ pub enum HostdRequest {
         workspace_id: Option<String>,
         volumes: Vec<crate::instance::BlockVolumeAttach>,
     },
+    /// Refresh already-admitted block-volume leases without reopening drives.
+    RenewBlockVolumeLeases {
+        tenant_id: String,
+        pool_id: String,
+        instance_id: String,
+        volumes: Vec<crate::instance::BlockVolumeAttach>,
+    },
     /// Stop a running instance (kill FC, teardown cgroup, TAP).
     StopInstance {
         tenant_id: String,
@@ -393,6 +400,7 @@ mod tests {
                 read_only: false,
                 encrypted: true,
                 fencing_token: 8,
+                lease_expires_at: "2026-08-02T12:00:00Z".into(),
                 data_key_version: 1,
             }],
         };
@@ -405,6 +413,35 @@ mod tests {
             parsed,
             HostdRequest::StartInstanceWithBlockVolumes { volumes, .. }
                 if volumes.len() == 1 && volumes[0].fencing_token == 8
+        ));
+    }
+
+    #[test]
+    fn hostd_block_volume_renewal_roundtrip_has_no_secret_material() {
+        let request = HostdRequest::RenewBlockVolumeLeases {
+            tenant_id: "tenant-1".into(),
+            pool_id: "pool-1".into(),
+            instance_id: "inst-1".into(),
+            volumes: vec![crate::instance::BlockVolumeAttach {
+                org_id: "org-1".into(),
+                workspace_id: "ws-1".into(),
+                volume_id: "vol-1".into(),
+                guest_path: "/data".into(),
+                read_only: false,
+                encrypted: true,
+                fencing_token: 8,
+                lease_expires_at: "2026-08-02T12:01:00Z".into(),
+                data_key_version: 1,
+            }],
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(!json.contains("credential"));
+        assert!(!json.contains("encryption_key"));
+        assert!(!json.contains("host_path"));
+        assert!(matches!(
+            serde_json::from_str::<HostdRequest>(&json).unwrap(),
+            HostdRequest::RenewBlockVolumeLeases { volumes, .. }
+                if volumes[0].lease_expires_at.ends_with('Z')
         ));
     }
 

--- a/crates/mvm-core/src/protocol/protocol.rs
+++ b/crates/mvm-core/src/protocol/protocol.rs
@@ -59,7 +59,10 @@ const MAX_FRAME_SIZE: usize = 1024 * 1024;
 ///   deserialization (unknown variant), which the agent surfaces as a
 ///   clean error; the coordinator gates sending these verbs on node
 ///   capability, so no bump was taken.
-pub const PROTOCOL_VERSION: u32 = 2;
+/// - `3`: fenced block-volume start, lease renewal, ciphertext transfer,
+///   and atomic restore request/response variants. These operations are
+///   coordinated across agent and hostd and have no safe legacy fallback.
+pub const PROTOCOL_VERSION: u32 = 3;
 
 // ============================================================================
 // Request/Response types
@@ -351,9 +354,8 @@ mod tests {
     /// here means a PR can't silently bump the const without also
     /// updating this test (and prompting the fixture re-gen).
     #[test]
-    fn protocol_version_is_two() {
-        // Bumped from 1 to 2 in the workspace-volume attach change.
-        assert_eq!(PROTOCOL_VERSION, 2);
+    fn protocol_version_is_three() {
+        assert_eq!(PROTOCOL_VERSION, 3);
     }
 
     #[test]

--- a/crates/mvm-core/src/protocol/protocol.rs
+++ b/crates/mvm-core/src/protocol/protocol.rs
@@ -87,6 +87,15 @@ pub enum HostdRequest {
         #[serde(default)]
         volumes: Vec<VolumeAttach>,
     },
+    /// Start with exclusive fleet block volumes already materialized locally.
+    StartInstanceWithBlockVolumes {
+        tenant_id: String,
+        pool_id: String,
+        instance_id: String,
+        #[serde(default)]
+        workspace_id: Option<String>,
+        volumes: Vec<crate::instance::BlockVolumeAttach>,
+    },
     /// Stop a running instance (kill FC, teardown cgroup, TAP).
     StopInstance {
         tenant_id: String,
@@ -367,6 +376,36 @@ mod tests {
             }
             _ => panic!("Wrong variant"),
         }
+    }
+
+    #[test]
+    fn hostd_block_volume_start_roundtrip_has_no_secret_material() {
+        let request = HostdRequest::StartInstanceWithBlockVolumes {
+            tenant_id: "tenant-1".into(),
+            pool_id: "pool-1".into(),
+            instance_id: "inst-1".into(),
+            workspace_id: Some("ws-1".into()),
+            volumes: vec![crate::instance::BlockVolumeAttach {
+                org_id: "org-1".into(),
+                workspace_id: "ws-1".into(),
+                volume_id: "vol-1".into(),
+                guest_path: "/data".into(),
+                read_only: false,
+                encrypted: true,
+                fencing_token: 8,
+                data_key_version: 1,
+            }],
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(!json.contains("credential"));
+        assert!(!json.contains("encryption_key"));
+        assert!(!json.contains("host_path"));
+        let parsed: HostdRequest = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            parsed,
+            HostdRequest::StartInstanceWithBlockVolumes { volumes, .. }
+                if volumes.len() == 1 && volumes[0].fencing_token == 8
+        ));
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -50,8 +50,8 @@ for detailed scope and acceptance criteria.
   - [x] Live local/block attachment through the admitted VM launch path
   - [x] mvmd OpenDAL → `object_store` migration with mandatory encryption
   - [x] Authenticated remote volume CLI/client lifecycle with typed failures
-  - [ ] Canonical worker handoff and Linux/KVM composition proof are green;
-        final follow-up PR-matrix closeout remains
+  - [x] Canonical worker handoff, Linux/KVM composition proof, and follow-up PR
+        matrices are green
   - [x] MinIO integration plus Linux/KVM persistence and restore proof
   - [ ] Reconcile rejected speculative clauses and close #2040 with evidence
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -44,15 +44,16 @@ for detailed scope and acceptance criteria.
   - [x] Add a fail-closed bounding-set result classifier whose Linux mutation
         witness kills the final comparison survivor from the corrected-head run
 
-- [x] Plan 283 — Production object-store volumes
+- [ ] Plan 283 — Production object-store volumes
       (`specs/plans/283-production-object-store-volumes.md`, issue #2040)
   - [x] Canonical mvm contract and dead S3-path removal
   - [x] Live local/block attachment through the admitted VM launch path
   - [x] mvmd OpenDAL → `object_store` migration with mandatory encryption
   - [x] Authenticated remote volume CLI/client lifecycle with typed failures
-  - [x] Durable encrypted checkpoint/API policy and cross-worker restore closeout
+  - [ ] Canonical worker handoff and Linux/KVM composition proof are green;
+        final follow-up PR-matrix closeout remains
   - [x] MinIO integration plus Linux/KVM persistence and restore proof
-  - [x] Reconcile rejected speculative clauses and close #2040 with evidence
+  - [ ] Reconcile rejected speculative clauses and close #2040 with evidence
 
 - [x] Plan 282 — Merge queue auto-requeue
       (`specs/plans/282-merge-queue-auto-requeue.md`)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -72,9 +72,12 @@ updates only its own entry below.
       defect reported as #2052, and the exact Apple-container E2E now passes on
       current main, closing #2054. #2048 now caches confirmed default-release
       404s per version and architecture for 24 hours while mirrors and transient
-      failures remain retryable. The production-volume epic #2040 and the
-      subsequently filed entropy issue #2060 are also closed with merged
-      evidence. The final GitHub open-issue query returned zero results.
+      failures remain retryable. The production-volume epic #2040 was closed
+      with the then-available evidence, but was subsequently reopened after the
+      claimed cross-worker proof was found to cover gateway-local directories
+      rather than the gateway→agent→hostd data plane. The subsequently filed
+      entropy issue #2060 is closed with merged evidence. The historical
+      open-issue query at that point returned zero results.
       A scheduled run on an older commit subsequently filed #2067: the no-SSH
       scanner had not classified a protected-credential-path refusal test as
       deny-only, and the `mvm-cli` mutation shard lacked the pinned Zig
@@ -93,7 +96,7 @@ updates only its own entry below.
       is clean with 27 relevant privilege-drop mutants caught.
       Tracked in plan 284.
 
-- [x] Production object-store volumes — **plan 283 / issue #2040**. Standardize
+- [ ] Production object-store volumes — **plan 283 / issue #2040**. Standardize
       remote volume I/O on Apache Arrow `object_store` while preserving the
       accepted mvm↔mvmd ownership boundary and mvmd's distinction between
       multi-attach `StorageBucket` and exclusive block `VolumeRecord`. Completion
@@ -101,7 +104,9 @@ updates only its own entry below.
       local/block attachment, encrypted durable checkpoints and cross-worker
       restore, working remote CLI/API policy, MinIO integration, and Linux/KVM
       persistence/restore proof. Registry-only, compile-only, and mocked-only
-      paths do not satisfy the issue.
+      paths do not satisfy the issue. Follow-up verification is open because
+      the original cross-worker claim covered gateway-local directories rather
+      than the gateway→agent→hostd worker data plane.
   - [x] WS1: external implementations can run the canonical trait-object
         contract; the unregistered member-only S3 mount provider is removed;
         template-registry S3 remains independently gated; the two-surface gate
@@ -152,16 +157,22 @@ updates only its own entry below.
         Twenty-one gateway client tests, including one real loopback HTTP request, nine CLI
         lifecycle parser tests, touched-crate checks, all-target Clippy, and the
         complete 115-scenario / 523-step BDD suite pass.
-  - [x] WS4/WS5 policy/WS6/WS7: mvmd PRs #199, #201, and #202 deliver durable
-        manifests and encrypted checkpoints, fresh-worker restore, fencing,
+  - [ ] WS4/WS5 policy/WS6/WS7: mvmd PRs #199, #201, and #202 deliver durable
+        manifests and encrypted checkpoints, gateway-local restore, fencing,
         retention/GC, API policy, metrics, signed lifecycle/refusal audits, and
         operator documentation. The real MinIO lane proves encrypted multipart
         I/O, conditional conflict handling, pagination beyond 1,000 objects,
         and cleanup. A live Firecracker/KVM run proves encrypted attach, restart
         persistence, checkpoint, mutation, restore into fresh state, digest
         recovery, and clean teardown. mvm PR #2064 supplies the authenticated
-        remote CLI. Issue #2040 records the rejected speculative clauses that
-        conflict with the shipped resource and artifact contracts.
+        remote CLI. The follow-up now supplies the missing canonical
+        `VolumeRecord` gateway→agent→hostd transfer, exact-node placement,
+        worker-local LUKS derivation, lease renewal/watchdog, and protocol v3.
+        The composed Linux/KVM proof is now green: two isolated production
+        workers preserve boot counts 1→2 across a source restart, transfer the
+        encrypted image through gateway→agent→hostd, and observe boot count 3
+        after destination restore. This item remains open for the follow-up PR
+        matrix; issue #2040 must not close before it is green.
 
 - [x] Merge-queue auto-requeue: bounded recovery for transiently ejected pull
       requests, with conflict refusal, persistent attempt counting, no checkout

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -171,8 +171,8 @@ updates only its own entry below.
         The composed Linux/KVM proof is now green: two isolated production
         workers preserve boot counts 1→2 across a source restart, transfer the
         encrypted image through gateway→agent→hostd, and observe boot count 3
-        after destination restore. This item remains open for the follow-up PR
-        matrix; issue #2040 must not close before it is green.
+        after destination restore. Both follow-up PR matrices are green; this
+        item and issue #2040 remain open until both changes land.
 
 - [x] Merge-queue auto-requeue: bounded recovery for transiently ejected pull
       requests, with conflict refusal, persistent attempt counting, no checkout

--- a/specs/plans/283-production-object-store-volumes.md
+++ b/specs/plans/283-production-object-store-volumes.md
@@ -384,6 +384,11 @@ Merged implementation PRs so far: mvm
 prematurely on 2026-08-02; the worker-handoff follow-up and its evidence must
 land before the shipped ledger is final.
 
+Follow-up review: mvm
+[`#2100`](https://github.com/tinylabscom/mvm/pull/2100) and mvmd
+[`#203`](https://github.com/tinylabscom/mvmd/pull/203). Both remain draft and
+issue #2040 remains open until their required matrices are green and they land.
+
 ## Out of scope
 
 - A direct general-purpose object-store FUSE filesystem.

--- a/specs/plans/283-production-object-store-volumes.md
+++ b/specs/plans/283-production-object-store-volumes.md
@@ -1,6 +1,6 @@
 # Production object-store volumes
 
-**Status:** Complete after relevance reconciliation (2026-08-02).
+**Status:** In progress — canonical cross-worker handoff is implemented and live-proven; the follow-up PR matrix remains open (2026-08-02).
 
 **Issue:** [#2040](https://github.com/tinylabscom/mvm/issues/2040)
 
@@ -230,7 +230,7 @@ repository's documented transitive exceptions, and cargo-deny.
       publish the manifest last with a conditional write, and make retry resume
       or converge without accepting partial chunks. Application-aware quiescing
       remains an explicit workload/operator responsibility.
-- [x] Restore onto a different worker by fetching the pinned manifest/chunks,
+- [ ] Restore onto a different worker by fetching the pinned manifest/chunks,
       enforcing scope and lineage, verifying integrity before decryption,
       atomically materializing the local encrypted image, and only then making it
       eligible for mvm attachment.
@@ -246,12 +246,22 @@ repository's documented transitive exceptions, and cargo-deny.
       manifest/ciphertext, wrong-key, bounded-resource refusal, retry, retention,
       and cross-worker restore tests.
 
-WS4 evidence (2026-08-02): mvmd PR
+WS4 evidence correction (2026-08-02): mvmd PR
 [`#199`](https://github.com/tinylabscom/mvmd/pull/199) supplies the immutable
 manifest/checkpoint state machine, bounded encrypted chunks, retry convergence,
-fresh-worker restore, fencing, retention/GC, API reconciliation, metrics, and
-positive and negative integrity coverage. Its required CI matrix passed before
-merge.
+gateway-local restore, fencing metadata, retention/GC, API reconciliation,
+metrics, and positive and negative integrity coverage. Its two-directory test
+did not transport ciphertext through the gateway/agent/hostd seam to a worker,
+so it was not evidence of cross-worker restore. The follow-up branches add the
+missing hostd v3 protocol, exact-node bounded pull/push, LUKS materialization,
+lease renewal/watchdog enforcement, and crash-safe canonical `VolumeRecord`
+placement. A dedicated Linux/KVM run now boots the encrypted volume on worker
+one, observes guest boot counters 1 and 2 across a real Firecracker restart,
+pulls the detached ciphertext through gateway → agent → hostd, restores it
+through a distinct authenticated worker, and observes counter 3 in that guest.
+The exact ignored test passes in 103.33 seconds with 1,532 other gateway tests
+filtered. This checkbox remains open only until the cross-repository PR matrix
+is green.
 
 ## WS5 — Remote CLI, API, policy, and observability
 
@@ -298,7 +308,7 @@ final required matrices passed.
 - [x] Run Linux/KVM tests for LUKS/ext4 lifecycle, checkpoint/restore, and
       attachment preparation; no Nix, Firecracker, mvmctl runtime, or Linux-only
       syscall runs on the macOS host.
-- [x] Add KVM E2E proving create → attach → guest write → restart → guest read →
+- [ ] Add KVM E2E proving create → attach → guest write → restart → guest read →
       checkpoint → restore on fresh host state → guest read → clean detach.
 - [x] Reconcile the proposed immutable read-only block-volume multi-attach as
       outside the `VolumeRecord` contract. The existing guest/device read-only
@@ -310,13 +320,20 @@ final required matrices passed.
       test GCS/Azure builders without requiring external tenant credentials in
       normal CI.
 
-WS6 evidence (2026-08-02): the required MinIO job passed with explicit
+WS6 evidence correction (2026-08-02): the required MinIO job passed with explicit
 credentials and wrong-credential redaction, encrypted raw provider bytes, an
 8 MiB multipart round trip, conditional rename/conflict behavior, pagination
 across 1,005 objects, and cleanup. A live Firecracker/KVM run mounted a 128 MiB
 encrypted ext4 volume, preserved a guest-written digest across restart,
 checkpointed it, mutated it, restored the checkpoint into fresh local state,
-recovered the original digest, and tore down cleanly.
+recovered the original digest, and tore down cleanly. That KVM run proved the
+mvm-local block lifecycle but did not include the mvmd gateway→agent→hostd
+worker handoff. The follow-up composed run now supplies that missing proof with
+two mount/PID-isolated production workers, distinct hostd and agent processes,
+exact node identities, worker-derived LUKS2 keys, real Firecracker/jailer
+launches, restart persistence, bounded ciphertext transfer, destination
+restore, and clean detach. The end-to-end checkbox remains open only for the
+follow-up PR matrix required by WS7.
 
 ## WS7 — Composition, documentation, and closeout
 
@@ -330,11 +347,11 @@ recovered the original digest, and tore down cleanly.
 - [x] Update operator runbooks and public docs with provider configuration,
       credential handling, durability/RPO semantics, restore, key recovery, quotas,
       limits, unsupported operations, and incident recovery.
-- [x] Run the complete required quality/security/supply-chain matrix in both
+- [ ] Run the complete required quality/security/supply-chain matrix in both
       repositories, including all BDD and live lanes.
 - [x] Update both sprint specs, the owning plan checkboxes, and refactor/status
       rollups with final test counts and evidence.
-- [x] Link the implementing PRs and evidence from this plan and close #2040 with
+- [ ] Link the implementing PRs and evidence from this plan and close #2040 with
       an explicit shipped-versus-rejected scope ledger after the required live
       and CI evidence is green.
 
@@ -356,7 +373,7 @@ recovered the original digest, and tore down cleanly.
 - The platform fsyncs checkpoint source images. Freezing an arbitrary guest
   database safely requires an application-specific operator/workload contract.
 
-Implementation PRs: mvm
+Merged implementation PRs so far: mvm
 [`#2044`](https://github.com/tinylabscom/mvm/pull/2044) and
 [`#2064`](https://github.com/tinylabscom/mvm/pull/2064); mvmd
 [`#198`](https://github.com/tinylabscom/mvmd/pull/198),
@@ -364,7 +381,8 @@ Implementation PRs: mvm
 [`#200`](https://github.com/tinylabscom/mvmd/pull/200),
 [`#201`](https://github.com/tinylabscom/mvmd/pull/201), and
 [`#202`](https://github.com/tinylabscom/mvmd/pull/202). Issue #2040 was closed
-on 2026-08-02 after the final dependency merged.
+prematurely on 2026-08-02; the worker-handoff follow-up and its evidence must
+land before the shipped ledger is final.
 
 ## Out of scope
 

--- a/specs/plans/283-production-object-store-volumes.md
+++ b/specs/plans/283-production-object-store-volumes.md
@@ -1,6 +1,6 @@
 # Production object-store volumes
 
-**Status:** In progress — canonical cross-worker handoff is implemented and live-proven; the follow-up PR matrix remains open (2026-08-02).
+**Status:** In progress — canonical cross-worker handoff and required PR matrices are green; landing and issue closeout remain (2026-08-02).
 
 **Issue:** [#2040](https://github.com/tinylabscom/mvm/issues/2040)
 
@@ -230,7 +230,7 @@ repository's documented transitive exceptions, and cargo-deny.
       publish the manifest last with a conditional write, and make retry resume
       or converge without accepting partial chunks. Application-aware quiescing
       remains an explicit workload/operator responsibility.
-- [ ] Restore onto a different worker by fetching the pinned manifest/chunks,
+- [x] Restore onto a different worker by fetching the pinned manifest/chunks,
       enforcing scope and lineage, verifying integrity before decryption,
       atomically materializing the local encrypted image, and only then making it
       eligible for mvm attachment.
@@ -260,8 +260,8 @@ one, observes guest boot counters 1 and 2 across a real Firecracker restart,
 pulls the detached ciphertext through gateway → agent → hostd, restores it
 through a distinct authenticated worker, and observes counter 3 in that guest.
 The exact ignored test passes in 103.33 seconds with 1,532 other gateway tests
-filtered. This checkbox remains open only until the cross-repository PR matrix
-is green.
+filtered. Both cross-repository PR matrices are green, satisfying this
+cross-worker restore requirement.
 
 ## WS5 — Remote CLI, API, policy, and observability
 
@@ -308,7 +308,7 @@ final required matrices passed.
 - [x] Run Linux/KVM tests for LUKS/ext4 lifecycle, checkpoint/restore, and
       attachment preparation; no Nix, Firecracker, mvmctl runtime, or Linux-only
       syscall runs on the macOS host.
-- [ ] Add KVM E2E proving create → attach → guest write → restart → guest read →
+- [x] Add KVM E2E proving create → attach → guest write → restart → guest read →
       checkpoint → restore on fresh host state → guest read → clean detach.
 - [x] Reconcile the proposed immutable read-only block-volume multi-attach as
       outside the `VolumeRecord` contract. The existing guest/device read-only
@@ -332,8 +332,7 @@ worker handoff. The follow-up composed run now supplies that missing proof with
 two mount/PID-isolated production workers, distinct hostd and agent processes,
 exact node identities, worker-derived LUKS2 keys, real Firecracker/jailer
 launches, restart persistence, bounded ciphertext transfer, destination
-restore, and clean detach. The end-to-end checkbox remains open only for the
-follow-up PR matrix required by WS7.
+restore, and clean detach. The follow-up PR matrix required by WS7 is green.
 
 ## WS7 — Composition, documentation, and closeout
 
@@ -347,7 +346,7 @@ follow-up PR matrix required by WS7.
 - [x] Update operator runbooks and public docs with provider configuration,
       credential handling, durability/RPO semantics, restore, key recovery, quotas,
       limits, unsupported operations, and incident recovery.
-- [ ] Run the complete required quality/security/supply-chain matrix in both
+- [x] Run the complete required quality/security/supply-chain matrix in both
       repositories, including all BDD and live lanes.
 - [x] Update both sprint specs, the owning plan checkboxes, and refactor/status
       rollups with final test counts and evidence.
@@ -386,8 +385,8 @@ land before the shipped ledger is final.
 
 Follow-up review: mvm
 [`#2100`](https://github.com/tinylabscom/mvm/pull/2100) and mvmd
-[`#203`](https://github.com/tinylabscom/mvmd/pull/203). Both remain draft and
-issue #2040 remains open until their required matrices are green and they land.
+[`#203`](https://github.com/tinylabscom/mvmd/pull/203). Both required matrices
+are green. Issue #2040 remains open until both changes land.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

- add hostd protocol v3 requests for encrypted block-volume start, lease renewal, bounded ciphertext reads, and verified restore
- reject zero-progress transfer chunks and require encrypted remote volume creation
- keep Plan 283 open until the paired mvmd PR and required matrices are green

Paired with tinylabscom/mvmd#203.
Tracks #2040.

## Validation

- `cargo test --workspace --no-fail-fast -- --test-threads=1`: 9,190 passed, 0 failed, 25 ignored
- `cargo clippy --workspace --all-targets -- -D warnings`
- paired two-worker Firecracker witness: 1 passed, 0 failed, 1,532 filtered, 103.33s