### PR TITLE
fix(cli): only the dedicated workload kernel may boot a workload

### DIFF
--- a/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
@@ -3,13 +3,11 @@ use super::*;
 use std::io::Write;
 
 #[test]
-fn find_cached_workload_kernel_prefers_dedicated_then_default_images() {
+fn only_the_dedicated_workload_kernel_qualifies() {
     let tmp = tempfile::tempdir().unwrap();
     let cache = tmp.path().to_str().unwrap();
     let arch = "x86_64";
-    // Nothing on disk → None (caller will build/download).
-    assert_eq!(find_cached_workload_kernel(cache, arch, false), None);
-    assert_eq!(find_cached_workload_kernel(cache, arch, true), None);
+    assert_eq!(find_cached_workload_kernel(cache, arch), None);
 
     let mk = |rel: &str| {
         let p = tmp.path().join(rel);
@@ -17,31 +15,24 @@ fn find_cached_workload_kernel_prefers_dedicated_then_default_images() {
         std::fs::write(&p, b"vmlinux").unwrap();
         p.to_str().unwrap().to_string()
     };
-    // The dev default image's kernel is a valid reuse source.
-    let dev = mk("default-microvm/dev/vmlinux");
+
+    // The default-microvm images ship a general-purpose NixOS kernel. It used to
+    // be accepted here as a stand-in, which silently gave workloads a kernel with
+    // CONFIG_USER_NS enabled whenever the real workload kernel was not cached.
+    // Neither variant qualifies now, however convenient the reuse was.
+    mk("default-microvm/prod/vmlinux");
+    mk("default-microvm/dev/vmlinux");
     assert_eq!(
-        find_cached_workload_kernel(cache, arch, false).as_deref(),
-        Some(dev.as_str())
+        find_cached_workload_kernel(cache, arch),
+        None,
+        "a default-microvm kernel must never stand in for the workload kernel"
     );
-    assert_eq!(find_cached_workload_kernel(cache, arch, true), None);
-    // Prod wins over dev (checked first).
-    let prod = mk("default-microvm/prod/vmlinux");
-    assert_eq!(
-        find_cached_workload_kernel(cache, arch, false).as_deref(),
-        Some(prod.as_str())
-    );
-    assert_eq!(
-        find_cached_workload_kernel(cache, arch, true).as_deref(),
-        Some(prod.as_str())
-    );
-    // The dedicated kernel cache wins over everything.
+
+    // Only the dedicated kernel resolves, so a cold cache reaches the
+    // build-or-download path instead of booting on whatever is lying around.
     let dedicated = mk(&format!("builder-vm/{arch}/kernels/workload/vmlinux"));
     assert_eq!(
-        find_cached_workload_kernel(cache, arch, false).as_deref(),
-        Some(dedicated.as_str())
-    );
-    assert_eq!(
-        find_cached_workload_kernel(cache, arch, true).as_deref(),
+        find_cached_workload_kernel(cache, arch).as_deref(),
         Some(dedicated.as_str())
     );
 }
@@ -52,7 +43,7 @@ fn cold_cache_downloads_instead_of_building_locally() {
     let cache = tmp.path().to_str().unwrap();
     let arch = "x86_64";
     assert_eq!(
-        resolve_workload_kernel_bootstrap(cache, arch, true, false),
+        resolve_workload_kernel_bootstrap(cache, arch, false),
         WorkloadKernelBootstrap::Download(format!(
             "{cache}/builder-vm/{arch}/kernels/workload/vmlinux"
         ))
@@ -65,7 +56,7 @@ fn source_checkout_cold_cache_downloads_by_default() {
     let cache = tmp.path().to_str().unwrap();
     let arch = "aarch64";
     assert_eq!(
-        resolve_workload_kernel_bootstrap(cache, arch, false, false),
+        resolve_workload_kernel_bootstrap(cache, arch, false),
         WorkloadKernelBootstrap::Download(format!(
             "{cache}/builder-vm/{arch}/kernels/workload/vmlinux"
         ))
@@ -78,7 +69,7 @@ fn explicit_source_build_request_builds_workload_kernel_locally() {
     let cache = tmp.path().to_str().unwrap();
     let arch = "aarch64";
     assert_eq!(
-        resolve_workload_kernel_bootstrap(cache, arch, false, true),
+        resolve_workload_kernel_bootstrap(cache, arch, true),
         WorkloadKernelBootstrap::BuildLocal(format!(
             "{cache}/builder-vm/{arch}/kernels/workload/vmlinux"
         ))
@@ -98,23 +89,23 @@ fn workload_kernel_never_reuses_the_non_verity_builder_kernel() {
     let dir = tmp.path().join(format!("builder-vm/{arch}"));
     std::fs::create_dir_all(&dir).unwrap();
     std::fs::write(dir.join("vmlinux"), b"vmlinux").unwrap();
-    assert!(find_cached_workload_kernel(cache, arch, false).is_none());
-    assert!(find_cached_workload_kernel(cache, arch, true).is_none());
+    assert!(find_cached_workload_kernel(cache, arch).is_none());
+    assert!(find_cached_workload_kernel(cache, arch).is_none());
 
     // With no workload/default kernel cached, resolution builds it (source
     // checkout) or downloads it (installed) — never the builder kernel, in
     // either dev or prod.
     let dest = format!("{cache}/builder-vm/{arch}/kernels/workload/vmlinux");
     assert_eq!(
-        resolve_workload_kernel_bootstrap(cache, arch, false, true),
+        resolve_workload_kernel_bootstrap(cache, arch, true),
         WorkloadKernelBootstrap::BuildLocal(dest.clone())
     );
     assert_eq!(
-        resolve_workload_kernel_bootstrap(cache, arch, false, false),
+        resolve_workload_kernel_bootstrap(cache, arch, false),
         WorkloadKernelBootstrap::Download(dest.clone())
     );
     assert_eq!(
-        resolve_workload_kernel_bootstrap(cache, arch, true, false),
+        resolve_workload_kernel_bootstrap(cache, arch, false),
         WorkloadKernelBootstrap::Download(dest)
     );
 }

--- a/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
@@ -17,11 +17,10 @@ pub(crate) fn ensure_default_microvm_image(
     }
 }
 
-pub(crate) fn ensure_workload_kernel(prod: bool) -> Result<String> {
+pub(crate) fn ensure_workload_kernel() -> Result<String> {
     let cache = mvm_core::config::mvm_cache_dir();
     let arch = builder_vm_host_arch();
-    let resolved =
-        resolve_workload_kernel_bootstrap(&cache, arch, prod, find_builder_vm_flake().is_ok());
+    let resolved = resolve_workload_kernel_bootstrap(&cache, arch, find_builder_vm_flake().is_ok());
     // Name which kernel variant a run resolved and where it came from. Without
     // this breadcrumb a wrong-kernel boot (e.g. a non-verity kernel under a
     // verity-sealed rootfs) is invisible host-side until the guest panics.
@@ -160,10 +159,9 @@ pub(super) enum WorkloadKernelBootstrap {
 pub(super) fn resolve_workload_kernel_bootstrap(
     cache_dir: &str,
     arch: &str,
-    prod: bool,
     source_checkout: bool,
 ) -> WorkloadKernelBootstrap {
-    if let Some(cached) = find_cached_workload_kernel(cache_dir, arch, prod) {
+    if let Some(cached) = find_cached_workload_kernel(cache_dir, arch) {
         return WorkloadKernelBootstrap::Cached(cached);
     }
     // The workload always boots through the verity initrd (mvm-verity-init opens
@@ -211,21 +209,26 @@ fn download_workload_kernel(arch: &str, dest: &str) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn find_cached_workload_kernel(
-    cache_dir: &str,
-    arch: &str,
-    prod: bool,
-) -> Option<String> {
-    let mut candidates = vec![
-        format!("{cache_dir}/builder-vm/{arch}/kernels/workload/vmlinux"),
-        format!("{cache_dir}/default-microvm/prod/vmlinux"),
-    ];
-    if !prod {
-        candidates.push(format!("{cache_dir}/default-microvm/dev/vmlinux"));
-    }
-    candidates
-        .into_iter()
-        .find(|p| std::path::Path::new(p).is_file())
+/// The dedicated workload kernel, or `None` when it has not been built or
+/// downloaded yet.
+///
+/// Only the dedicated kernel qualifies. The default-microvm images ship a
+/// general-purpose NixOS kernel, and borrowing it used to be allowed here —
+/// which meant that on a host with no workload kernel cached, a workload
+/// silently booted a kernel built for a different job. Those kernels enable
+/// `CONFIG_USER_NS`, which the workload kernel deliberately leaves unset, so
+/// the borrow handed the guest a user-namespace escape hatch the workload
+/// kernel exists to remove. It was invisible: same command, same image, and a
+/// posture that depended on which kernels happened to be in the local cache.
+///
+/// A cold cache is now resolved by building or downloading the real workload
+/// kernel — which is what the caller already does, and what its own comment
+/// already claimed it did.
+pub(super) fn find_cached_workload_kernel(cache_dir: &str, arch: &str) -> Option<String> {
+    let dedicated = format!("{cache_dir}/builder-vm/{arch}/kernels/workload/vmlinux");
+    std::path::Path::new(&dedicated)
+        .is_file()
+        .then_some(dedicated)
 }
 
 fn ensure_default_microvm_prod_image(cache_dir: &str) -> Result<(String, String)> {

--- a/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
@@ -98,33 +98,27 @@ mod default_microvm_tests {
         );
     }
 
+    /// One rule for every workload boot: no default-microvm kernel stands in,
+    /// dev or prod. The previous split ("prod never reuses the dev default, dev
+    /// may") meant a workload's kernel — and therefore whether it could enter a
+    /// user namespace — depended on which images happened to be cached locally.
     #[test]
-    fn prod_workload_kernel_cache_never_reuses_dev_default_kernel() {
-        let tmp = tempfile::tempdir().unwrap();
-        let cache_dir = tmp.path().to_string_lossy().to_string();
-        let dev_kernel = tmp.path().join("default-microvm/dev/vmlinux");
-        std::fs::create_dir_all(dev_kernel.parent().unwrap()).unwrap();
-        std::fs::write(&dev_kernel, b"dev-kernel").unwrap();
+    fn no_default_microvm_kernel_is_ever_reused_as_the_workload_kernel() {
+        for variant in ["dev", "prod"] {
+            let tmp = tempfile::tempdir().unwrap();
+            let cache_dir = tmp.path().to_string_lossy().to_string();
+            let kernel = tmp
+                .path()
+                .join(format!("default-microvm/{variant}/vmlinux"));
+            std::fs::create_dir_all(kernel.parent().unwrap()).unwrap();
+            std::fs::write(&kernel, b"default-kernel").unwrap();
 
-        assert_eq!(
-            find_cached_workload_kernel(&cache_dir, "x86_64", true),
-            None,
-            "prod/workload boots must not silently reuse a dev-tier default kernel"
-        );
-    }
-
-    #[test]
-    fn dev_workload_kernel_cache_may_reuse_dev_default_kernel() {
-        let tmp = tempfile::tempdir().unwrap();
-        let cache_dir = tmp.path().to_string_lossy().to_string();
-        let dev_kernel = tmp.path().join("default-microvm/dev/vmlinux");
-        std::fs::create_dir_all(dev_kernel.parent().unwrap()).unwrap();
-        std::fs::write(&dev_kernel, b"dev-kernel").unwrap();
-
-        assert_eq!(
-            find_cached_workload_kernel(&cache_dir, "x86_64", false),
-            Some(dev_kernel.to_string_lossy().to_string())
-        );
+            assert_eq!(
+                find_cached_workload_kernel(&cache_dir, "x86_64"),
+                None,
+                "the {variant} default-microvm kernel must not stand in for the workload kernel"
+            );
+        }
     }
 
     #[test]
@@ -135,7 +129,7 @@ mod default_microvm_tests {
         std::fs::create_dir_all(dev_kernel.parent().unwrap()).unwrap();
         std::fs::write(&dev_kernel, b"dev-kernel").unwrap();
 
-        let resolved = resolve_workload_kernel_bootstrap(&cache_dir, "x86_64", true, false);
+        let resolved = resolve_workload_kernel_bootstrap(&cache_dir, "x86_64", false);
         assert_eq!(
             resolved,
             WorkloadKernelBootstrap::Download(format!(
@@ -150,7 +144,7 @@ mod default_microvm_tests {
         let tmp = tempfile::tempdir().unwrap();
         let cache_dir = tmp.path().to_string_lossy().to_string();
 
-        let resolved = resolve_workload_kernel_bootstrap(&cache_dir, "x86_64", true, true);
+        let resolved = resolve_workload_kernel_bootstrap(&cache_dir, "x86_64", true);
         assert_eq!(
             resolved,
             WorkloadKernelBootstrap::BuildLocal(format!(

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -797,7 +797,7 @@ fn build_exec_request(
                 // surfacing only after a full pull + rootfs materialization. The
                 // rootfs boots verity-sealed, so the kernel must carry dm-verity;
                 // the builder kernel (which drops it) is never a stand-in.
-                let kernel_path = ensure_workload_kernel(prod)?;
+                let kernel_path = ensure_workload_kernel()?;
                 // Enforce that invariant host-side: a kernel with no dm-verity
                 // support would panic the guest in early init opening
                 // /dev/mapper/control, with no host signal. Fail fast instead.

--- a/crates/mvm-cli/src/commands/vm/up/kernel.rs
+++ b/crates/mvm-cli/src/commands/vm/up/kernel.rs
@@ -131,14 +131,6 @@ pub(in crate::commands) fn resolve_kernel_pin_path(pinned: bool) -> anyhow::Resu
     )?))
 }
 
-pub(super) fn persistent_oci_uses_prod_kernel(
-    profile: &str,
-    runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy,
-) -> bool {
-    profile != "dev"
-        || runtime_source_policy == mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay
-}
-
 #[cfg(test)]
 mod resolve_workload_kernel_tests {
     use super::*;

--- a/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
+++ b/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
@@ -22,7 +22,6 @@ use super::admission::{
     AdmitPlanForBootParams, admit_plan_for_boot, attach_guest_boot_config, emit_failed_if,
     emit_launched_if, enforce_shares_if, guest_profile_for_boot,
 };
-use super::kernel::persistent_oci_uses_prod_kernel;
 use super::policy::shares_from_volume_cfg;
 use super::runtime_source::{
     attach_runtime_overlay_if_cached, attach_universal_initramfs_if_cached,
@@ -214,10 +213,7 @@ pub(in crate::commands) fn start_persistent_oci_machine(
         // Resolve just the workload kernel — same as the transient OCI path
         // (`exec.rs`) — rather than building/downloading a whole default-microvm
         // image whose rootfs we'd discard.
-        ensure_workload_kernel(persistent_oci_uses_prod_kernel(
-            profile,
-            runtime_source_policy,
-        ))?
+        ensure_workload_kernel()?
     };
     let initrd_path = persistent_oci_effective_initrd(rootfs_path, runtime_source_policy)?;
 
@@ -642,30 +638,6 @@ mod runtime_source_policy_for_workload_boot_tests {
             resolved.as_deref(),
             Some(sibling.to_str().expect("utf-8 initrd path"))
         );
-    }
-
-    #[test]
-    fn persistent_oci_required_overlay_forces_prod_kernel_even_on_dev_profile() {
-        assert!(super::super::kernel::persistent_oci_uses_prod_kernel(
-            "dev",
-            RuntimeSourcePolicy::RequiredOverlay
-        ));
-    }
-
-    #[test]
-    fn persistent_oci_prefer_overlay_keeps_dev_kernel_lane_for_dev_profile() {
-        assert!(!super::super::kernel::persistent_oci_uses_prod_kernel(
-            "dev",
-            RuntimeSourcePolicy::PreferOverlay
-        ));
-    }
-
-    #[test]
-    fn persistent_oci_non_dev_profiles_keep_prod_kernel_lane() {
-        assert!(super::super::kernel::persistent_oci_uses_prod_kernel(
-            "prod",
-            RuntimeSourcePolicy::PreferOverlay
-        ));
     }
 }
 


### PR DESCRIPTION
Fixes the root cause behind #2101.

## What was happening

`find_cached_workload_kernel` preferred the dedicated workload kernel but fell back to `default-microvm/prod/vmlinux`, and to `default-microvm/dev/vmlinux` as well on a non-prod run. Those images ship a general-purpose NixOS kernel that enables `CONFIG_USER_NS`, which the workload kernel deliberately leaves unset.

So on any host where the workload kernel had not been built or downloaded, a workload silently booted on a kernel that let it `unshare -r` into a user namespace as uid 0.

## It presented as a backend difference and was not one

I originally filed #2101 as "HVF boots a kernel with NAMESPACES enabled". Both details were wrong, and the issue is corrected in place:

- **The discriminator is `CONFIG_USER_NS`, not `NAMESPACES`.** The built workload kernel has `CONFIG_NAMESPACES=y`, `CONFIG_CGROUPS=y`, and `# CONFIG_USER_NS is not set`.
- **It is host cache state, not a backend property.** The guest console banner from the HVF boot (`6.12.98 (root@(none)) #1-NixOS`) is a byte-exact match for `default-microvm/prod/vmlinux`; the builder kernel is distinguishable by its `(@localhost)` build host. The Linux host had `builder-vm/x86_64/kernels/workload/` cached; the macOS host had no `kernels/` directory at all. A Firecracker host in the same state would behave identically.

## The change

Only the dedicated kernel qualifies. A cold cache now reaches the build-or-download path the caller already had — and whose own comment already claimed it always resolved the real workload kernel.

This also collapses the prod/dev kernel lane, which existed only to pick which default image to borrow from. `persistent_oci_uses_prod_kernel` decided nothing once the borrow was gone, so it and its three tests are removed rather than left as policy with no effect.

## On the behaviour change

A source checkout with no workload kernel built will now fail with the existing actionable error (`mvmctl kernel build --which workload`) instead of booting on a borrowed kernel. That is the intended trade: a loud stop rather than a silent, weaker guest.

## Tests

The prior test asserted the borrow was correct ("the dev default image's kernel is a valid reuse source"), so this reverses a deliberate decision — the security consequence of that decision does not appear to have been evaluated when it was made. Both the borrow test and the prod/dev split test are replaced by a single rule: no default-microvm kernel is ever reused, dev or prod.

`mvm-cli` 1441/1441 green; workspace green apart from three known `mvm-hostd` parallel flakes that pass isolated (`host_agent_restart` ×2, `per_tenant_isolation`), in files this change does not touch.