### PR TITLE
feat(plan): pin the execution environment, starting with the kernel

### DIFF
--- a/crates/mvm-cli/src/bench/probe.rs
+++ b/crates/mvm-cli/src/bench/probe.rs
@@ -56,6 +56,7 @@ pub fn admit_probe_plan(
     let sha = mvm_core::crypto::image_verify::sha256_file(rootfs)
         .with_context(|| format!("hashing probe rootfs {}", rootfs.display()))?;
     let input = SynthesisInput {
+        kernel_sha256: None,
         network_mode: Default::default(),
         l3_network: None,
         vm_name,

--- a/crates/mvm-cli/src/commands/build/image_lineage.rs
+++ b/crates/mvm-cli/src/commands/build/image_lineage.rs
@@ -420,6 +420,7 @@ pub(in crate::commands) fn build_event_plan(
     image_sha256: &str,
 ) -> Result<ExecutionPlan> {
     let input = SynthesisInput {
+        kernel_sha256: None,
         network_mode: Default::default(),
         l3_network: None,
         vm_name: workload,

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -215,6 +215,7 @@ fn admit_standby_parent_plan(
     mem_mib: u32,
 ) -> Result<AdmittedPlan> {
     let input = SynthesisInput {
+        kernel_sha256: None,
         vm_name: &handle.id,
         tenant: Some(tenant),
         backend_name,

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -937,6 +937,7 @@ fn emit_oci_run_admission(
         })?;
     let exec_timeout_secs = u32::try_from(timeout_secs).unwrap_or(u32::MAX);
     let input = SynthesisInput {
+        kernel_sha256: None,
         network_mode,
         l3_network: None,
         vm_name: "run-oci",

--- a/crates/mvm-cli/src/commands/vm/policy_resolver.rs
+++ b/crates/mvm-cli/src/commands/vm/policy_resolver.rs
@@ -604,6 +604,7 @@ mod tests {
     fn fixture_plan() -> ExecutionPlan {
         let now = chrono::Utc::now();
         ExecutionPlan {
+            environment: None,
             build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -347,6 +347,7 @@ fn synthesis_input_for_app<'a>(
     let leaked: &'static str = Box::leak(placeholder.into_boxed_str());
 
     Ok(SynthesisInput {
+        kernel_sha256: None,
         network_mode,
         l3_network: None,
         vm_name: &app.name,

--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -219,6 +219,7 @@ pub(in crate::commands::vm) fn admit_plan_for_boot(
         .map(|(policy_ref, _)| policy_ref.as_str());
 
     let input = SynthesisInput {
+        kernel_sha256: None,
         network_mode: Default::default(),
         l3_network: None,
         vm_name: p.vm_name,

--- a/crates/mvm-cli/src/commands/vm/up/audit.rs
+++ b/crates/mvm-cli/src/commands/vm/up/audit.rs
@@ -143,6 +143,7 @@ chain_signing = true
         let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
         let mut plan = admit_for_run(
             &SynthesisInput {
+                kernel_sha256: None,
                 network_mode: Default::default(),
                 l3_network: None,
                 vm_name: "vm-live",
@@ -249,6 +250,7 @@ stream_destinations = ["file://{}"]
         let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
         let mut plan = admit_for_run(
             &SynthesisInput {
+                kernel_sha256: None,
                 network_mode: Default::default(),
                 l3_network: None,
                 vm_name: "vm-stream",
@@ -354,6 +356,7 @@ chain_signing = false
         let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
         let mut plan = admit_for_run(
             &SynthesisInput {
+                kernel_sha256: None,
                 network_mode: Default::default(),
                 l3_network: None,
                 vm_name: "vm-unsigned-audit",
@@ -434,6 +437,7 @@ chain_signing = false
         let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
         let mut plan = admit_for_run(
             &SynthesisInput {
+                kernel_sha256: None,
                 network_mode: Default::default(),
                 l3_network: None,
                 vm_name: "vm-nope",
@@ -534,6 +538,7 @@ disabled_inspectors = ["ssrf_guarrd"]
         let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
         let mut plan = admit_for_run(
             &SynthesisInput {
+                kernel_sha256: None,
                 network_mode: Default::default(),
                 l3_network: None,
                 vm_name: "vm-typo",
@@ -640,6 +645,7 @@ port_hi  = 443
         let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
         let mut plan = admit_for_run(
             &SynthesisInput {
+                kernel_sha256: None,
                 network_mode: Default::default(),
                 l3_network: None,
                 vm_name: "vm-bad",

--- a/crates/mvm-core/src/plan/mod.rs
+++ b/crates/mvm-core/src/plan/mod.rs
@@ -62,9 +62,9 @@ pub use synthesis::{
 };
 pub use types::{
     AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, AuditLabels,
-    AuditTaxonomy, DepsVolumeBinding, DepsVolumeBindingError, FsPolicyRef, HostShareGrant,
-    KeyRotationSpec, L3IcmpPolicy, L3IngressMapping, L3NetworkSpec, NetworkMode, Nonce,
-    NonceParseError, PlanId, PlanSeccompTier, PlanSeccompTierParseError, PolicyRef,
+    AuditTaxonomy, DepsVolumeBinding, DepsVolumeBindingError, EnvironmentRef, FsPolicyRef,
+    HostShareGrant, KeyRotationSpec, L3IcmpPolicy, L3IngressMapping, L3NetworkSpec, NetworkMode,
+    Nonce, NonceParseError, PlanId, PlanSeccompTier, PlanSeccompTierParseError, PolicyRef,
     PostRunLifecycle, ReleasePin, Resources, RuntimeProfileRef, SecretBinding, SecretReleasePolicy,
     SecretSource, ShareKind, SignedImageRef, TenantId, TimeoutSpec, Variant, WorkloadId,
     WorkloadIntent,

--- a/crates/mvm-core/src/plan/signing.rs
+++ b/crates/mvm-core/src/plan/signing.rs
@@ -218,6 +218,7 @@ pub mod test_support {
     /// Callers override `valid_from`/`valid_until`/`nonce` for their scenario.
     pub fn sample_plan() -> ExecutionPlan {
         ExecutionPlan {
+            environment: None,
             build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),

--- a/crates/mvm-core/src/plan/synthesis.rs
+++ b/crates/mvm-core/src/plan/synthesis.rs
@@ -43,10 +43,10 @@
 
 use crate::plan::{
     AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, AuditLabels,
-    AuditTaxonomy, DepsVolumeBinding, ExecutionPlan, FsPolicyRef, KeyRotationSpec, L3NetworkSpec,
-    NetworkMode, Nonce, PlanId, PlanSeccompTier, PolicyRef, PostRunLifecycle, Resources,
-    RuntimeProfileRef, SCHEMA_VERSION, SecretBinding, SecretReleasePolicy, SignedImageRef,
-    TenantId, TimeoutSpec, WorkloadId, WorkloadIntent,
+    AuditTaxonomy, DepsVolumeBinding, EnvironmentRef, ExecutionPlan, FsPolicyRef, KeyRotationSpec,
+    L3NetworkSpec, NetworkMode, Nonce, PlanId, PlanSeccompTier, PolicyRef, PostRunLifecycle,
+    Resources, RuntimeProfileRef, SCHEMA_VERSION, SecretBinding, SecretReleasePolicy,
+    SignedImageRef, TenantId, TimeoutSpec, WorkloadId, WorkloadIntent,
 };
 use anyhow::Result;
 use chrono::{Duration, Utc};
@@ -94,6 +94,10 @@ pub struct SynthesisInput<'a> {
     /// image_verify::sha256_file` or upstream Nix).
     pub image_name: &'a str,
     pub image_sha256: &'a str,
+    /// Lowercase-hex SHA-256 of the kernel this workload boots, pinning the
+    /// environment into the signed plan. `None` = the caller resolved no kernel
+    /// (a backend that supplies its own bundled one), and the plan pins none.
+    pub kernel_sha256: Option<&'a str>,
     pub image_cosign_bundle: Option<&'a str>,
     /// Purpose this run is admitted for. `None` means
     /// `DEFAULT_INTENT`.
@@ -220,6 +224,14 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
             input.image_sha256.len()
         );
     }
+    if let Some(kernel) = input.kernel_sha256
+        && kernel.len() != 64
+    {
+        anyhow::bail!(
+            "kernel_sha256 must be a 64-character lowercase hex digest, got {} chars",
+            kernel.len()
+        );
+    }
     let intent = input.intent.unwrap_or(DEFAULT_INTENT);
     if intent.is_empty() {
         anyhow::bail!("intent must not be empty");
@@ -264,7 +276,12 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
         entrypoint_present: true,
     };
 
+    let environment = input.kernel_sha256.map(|kernel_sha256| EnvironmentRef {
+        kernel_sha256: kernel_sha256.to_string(),
+    });
+
     let mut plan = ExecutionPlan {
+        environment,
         build_provenance: Default::default(),
         snapshot_at: Default::default(),
         network_mode: input.network_mode,
@@ -401,6 +418,7 @@ mod tests {
 
     fn input(vm_name: &str) -> SynthesisInput<'_> {
         SynthesisInput {
+            kernel_sha256: None,
             network_mode: NetworkMode::default(),
             l3_network: None,
             vm_name,

--- a/crates/mvm-core/src/plan/test_support.rs
+++ b/crates/mvm-core/src/plan/test_support.rs
@@ -103,6 +103,7 @@ impl PlanFixture {
     pub fn build(self) -> ExecutionPlan {
         let now = Utc::now();
         ExecutionPlan {
+            environment: None,
             build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),

--- a/crates/mvm-core/tests/replay_protection.rs
+++ b/crates/mvm-core/tests/replay_protection.rs
@@ -16,6 +16,7 @@ use mvm_core::plan::{ExecutionPlan, SCHEMA_VERSION};
 
 fn fixture_plan(nonce: [u8; 16]) -> ExecutionPlan {
     ExecutionPlan {
+        environment: None,
         build_provenance: Default::default(),
         snapshot_at: Default::default(),
         network_mode: Default::default(),

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -719,8 +719,9 @@ mod admitted_environment_tests {
         .expect("matching kernel must be admitted");
     }
 
-    /// A different kernel than the plan pinned is refused. This is the #2101
-    /// case: same plan, same image, a kernel swapped underneath.
+    /// A different kernel than the plan pinned is refused: same plan, same
+    /// image, a kernel swapped underneath — the substitution that used to be
+    /// invisible because nothing in the plan described the environment.
     #[test]
     fn substituted_kernel_is_refused() {
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -598,6 +598,44 @@ pub struct AdmitAndStartParams<'a> {
     pub policy_bundle: Option<&'a PolicyBundle>,
 }
 
+/// Refuse a boot whose kernel is not the one the plan pinned.
+///
+/// The image digest says what the workload *is*; it says nothing about what
+/// confines it. The same signed image on a kernel built for a different job has
+/// a different security posture — a kernel with `CONFIG_USER_NS` enabled lets
+/// the guest become uid 0 in a user namespace, which the workload kernel is
+/// built to prevent. Before the kernel was pinned, that substitution was
+/// invisible: identical plan, identical image digest, and confinement decided
+/// by whichever kernel the host happened to have cached.
+///
+/// Fail-closed in both directions. A plan that pins a kernel and a launch
+/// config that supplies none is a refusal, not a pass — otherwise dropping the
+/// kernel path would be a way to skip the check.
+fn enforce_admitted_environment(config: &VmStartConfig, plan: &ExecutionPlan) -> Result<()> {
+    let Some(environment) = plan.environment.as_ref() else {
+        // No environment pinned. Plans predating the field, and backends that
+        // boot their own bundled kernel, land here.
+        return Ok(());
+    };
+    let Some(kernel_path) = config.kernel_path.as_deref() else {
+        anyhow::bail!(
+            "plan pins kernel {} but the launch config supplies no kernel path",
+            environment.kernel_sha256
+        );
+    };
+    let actual = mvm_core::crypto::image_verify::sha256_file(std::path::Path::new(kernel_path))
+        .with_context(|| {
+            format!("hashing kernel at {kernel_path} for admitted-environment check")
+        })?;
+    if actual != environment.kernel_sha256 {
+        anyhow::bail!(
+            "admitted-environment mismatch: plan pins kernel {} but {kernel_path} hashes to {actual}",
+            environment.kernel_sha256
+        );
+    }
+    Ok(())
+}
+
 /// Outcome of a successful admitted boot: the backend's VM id plus the
 /// `AdmittedPlan` (for the caller's audit chain / typed result).
 #[derive(Debug)]
@@ -634,12 +672,96 @@ pub fn admit_and_start(
     let mut config = params.config;
     populate_audit_substrate(&mut config, &admitted, params.policy_bundle)?;
     enforce_admitted_shares(&config.volumes, &admitted.plan)?;
+    enforce_admitted_environment(&config, &admitted.plan)?;
     enforce_sdk_sidecar_attachment(&config.volumes, &admitted.plan)?;
 
     let vm_id = backend
         .start(&config)
         .context("backend start after signed-plan admission")?;
     Ok(StartedMachine { vm_id, admitted })
+}
+
+#[cfg(test)]
+mod admitted_environment_tests {
+    use super::*;
+
+    fn plan_pinning(kernel_sha256: Option<&str>) -> ExecutionPlan {
+        let mut plan = mvm_core::plan::test_support::PlanFixture::new().build();
+        plan.environment = kernel_sha256.map(|k| mvm_core::plan::EnvironmentRef {
+            kernel_sha256: k.to_string(),
+        });
+        plan
+    }
+
+    fn config_with_kernel(kernel: Option<&std::path::Path>) -> VmStartConfig {
+        VmStartConfig {
+            kernel_path: kernel.map(|k| k.display().to_string()),
+            ..VmStartConfig::default()
+        }
+    }
+
+    fn write_kernel(dir: &std::path::Path, bytes: &[u8]) -> std::path::PathBuf {
+        let p = dir.join("vmlinux");
+        std::fs::write(&p, bytes).expect("write kernel fixture");
+        p
+    }
+
+    /// The pinned kernel is the one on disk: the boot proceeds.
+    #[test]
+    fn matching_kernel_digest_is_admitted() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let kernel = write_kernel(tmp.path(), b"workload-kernel");
+        let sha = mvm_core::crypto::image_verify::sha256_file(&kernel).expect("hash");
+        enforce_admitted_environment(
+            &config_with_kernel(Some(&kernel)),
+            &plan_pinning(Some(&sha)),
+        )
+        .expect("matching kernel must be admitted");
+    }
+
+    /// A different kernel than the plan pinned is refused. This is the #2101
+    /// case: same plan, same image, a kernel swapped underneath.
+    #[test]
+    fn substituted_kernel_is_refused() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let kernel = write_kernel(tmp.path(), b"workload-kernel");
+        let sha = mvm_core::crypto::image_verify::sha256_file(&kernel).expect("hash");
+        std::fs::write(&kernel, b"a-general-purpose-kernel").expect("swap kernel");
+
+        let err = enforce_admitted_environment(
+            &config_with_kernel(Some(&kernel)),
+            &plan_pinning(Some(&sha)),
+        )
+        .expect_err("a substituted kernel must be refused");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("admitted-environment mismatch"),
+            "error must name the mismatch, got: {msg}"
+        );
+    }
+
+    /// Dropping the kernel path must not be a way around the pin.
+    #[test]
+    fn pinned_plan_with_no_kernel_path_is_refused() {
+        let err = enforce_admitted_environment(
+            &config_with_kernel(None),
+            &plan_pinning(Some(&"a".repeat(64))),
+        )
+        .expect_err("a pinned plan with no kernel path must be refused");
+        assert!(format!("{err:#}").contains("supplies no kernel path"));
+    }
+
+    /// Plans that pin nothing still boot — every plan written before the field
+    /// existed, and backends that carry their own bundled kernel.
+    #[test]
+    fn unpinned_plan_is_unaffected() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let kernel = write_kernel(tmp.path(), b"whatever");
+        enforce_admitted_environment(&config_with_kernel(Some(&kernel)), &plan_pinning(None))
+            .expect("an unpinned plan must be unaffected");
+        enforce_admitted_environment(&config_with_kernel(None), &plan_pinning(None))
+            .expect("an unpinned plan with no kernel must be unaffected");
+    }
 }
 
 #[cfg(test)]
@@ -652,6 +774,7 @@ mod tests {
 
     fn fixture_input(vm_name: &str) -> SynthesisInput<'_> {
         SynthesisInput {
+            kernel_sha256: None,
             network_mode: Default::default(),
             l3_network: None,
             vm_name,

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -79,7 +79,20 @@ pub fn admit_and_boot_local(
     let sha = mvm_core::crypto::image_verify::sha256_file_cached(&req.rootfs_path)
         .with_context(|| format!("hashing rootfs at {}", req.rootfs_path.display()))?;
 
+    // Pin the kernel into the signed plan. Deliberately the uncached digest: a
+    // path+mtime-keyed cache can hand back a stale hash, which for an integrity
+    // pin would defeat the point of having one.
+    let kernel_sha = req
+        .kernel_path
+        .as_ref()
+        .map(|k| {
+            mvm_core::crypto::image_verify::sha256_file(k)
+                .with_context(|| format!("hashing kernel at {}", k.display()))
+        })
+        .transpose()?;
+
     let synthesis = SynthesisInput {
+        kernel_sha256: kernel_sha.as_deref(),
         network_mode: Default::default(),
         l3_network: None,
         vm_name: &req.name,

--- a/crates/mvm-hostd/src/supervisor/aggregate.rs
+++ b/crates/mvm-hostd/src/supervisor/aggregate.rs
@@ -1206,6 +1206,7 @@ mod tests {
 
     fn sample_plan() -> ExecutionPlan {
         let mut plan = ExecutionPlan {
+            environment: None,
             build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),

--- a/crates/mvm-hostd/src/supervisor/audit.rs
+++ b/crates/mvm-hostd/src/supervisor/audit.rs
@@ -346,6 +346,7 @@ mod tests {
 
     fn sample_plan() -> ExecutionPlan {
         ExecutionPlan {
+            environment: None,
             build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge/signer.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge/signer.rs
@@ -289,6 +289,7 @@ mod tests {
             TenantId, TimeoutSpec, WorkloadId,
         };
         ExecutionPlan {
+            environment: None,
             build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),

--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -923,6 +923,7 @@ mod tests {
             TenantId, TimeoutSpec, WorkloadId,
         };
         ExecutionPlan {
+            environment: None,
             build_provenance: Default::default(),
             snapshot_at: Default::default(),
             network_mode: Default::default(),

--- a/crates/mvm-protocol/src/plan/execution_plan.rs
+++ b/crates/mvm-protocol/src/plan/execution_plan.rs
@@ -16,9 +16,9 @@ use crate::lifecycle::SnapshotAt;
 use crate::plan::bundle::PlanArtifact;
 use crate::plan::types::{
     AdmissionProfile, ArtifactPolicy, AttestationRequirement, AuditLabels, BuildProvenance,
-    DepsVolumeBinding, FsPolicyRef, HostShareGrant, KeyRotationSpec, L3NetworkSpec, NetworkMode,
-    Nonce, PlanId, PolicyRef, PostRunLifecycle, ReleasePin, Resources, RuntimeProfileRef,
-    SecretBinding, SignedImageRef, TenantId, WorkloadId,
+    DepsVolumeBinding, EnvironmentRef, FsPolicyRef, HostShareGrant, KeyRotationSpec, L3NetworkSpec,
+    NetworkMode, Nonce, PlanId, PolicyRef, PostRunLifecycle, ReleasePin, Resources,
+    RuntimeProfileRef, SecretBinding, SignedImageRef, TenantId, WorkloadId,
 };
 use crate::plan::verb::VerbId;
 use crate::protocol::broker::ServiceId;
@@ -63,6 +63,16 @@ pub struct ExecutionPlan {
     /// Signed image to boot. SHA-256 + cosign bundle reference;
     /// resolved by `mvm-core::crypto::image_verify`.
     pub image: SignedImageRef,
+
+    /// The environment the image is admitted to boot in — currently the kernel
+    /// digest. `None` (default) = this plan pins no environment, which is every
+    /// plan written before the field existed.
+    ///
+    /// Skip-serialized when absent so those plans stay byte-identical: the field
+    /// is inside the signed payload, so emitting it as `null` would invalidate
+    /// every existing signature and frozen vector.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment: Option<EnvironmentRef>,
 
     pub resources: Resources,
 
@@ -243,6 +253,7 @@ mod tests {
     fn minimal_plan() -> ExecutionPlan {
         let valid_from = Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 0).unwrap();
         ExecutionPlan {
+            environment: None,
             schema_version: SCHEMA_VERSION,
             plan_id: PlanId("fixture-plan".to_string()),
             plan_version: 1,

--- a/crates/mvm-protocol/src/plan/types.rs
+++ b/crates/mvm-protocol/src/plan/types.rs
@@ -239,6 +239,28 @@ pub struct WorkloadId(pub String);
 #[serde(transparent)]
 pub struct RuntimeProfileRef(pub String);
 
+/// The execution environment a workload is admitted to boot *in*, as opposed to
+/// the image it boots. Content-addressed like [`SignedImageRef`].
+///
+/// This exists because the image digest alone does not determine how the
+/// workload is confined. The same signed image, booted on a kernel built for a
+/// different job, gets a different security posture — a kernel with
+/// `CONFIG_USER_NS` enabled lets the guest enter a user namespace as uid 0,
+/// which the workload kernel deliberately prevents. Without the kernel in the
+/// plan, that difference is invisible: identical plan, identical image,
+/// identical digests, and a posture decided by whatever the host had cached.
+///
+/// Pinning it makes the mismatch refusable at admission instead of silent at
+/// boot. The struct (rather than a bare digest) is so the rest of the
+/// environment — initrd, runtime overlay, seccomp tier — can be added without
+/// another plan field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EnvironmentRef {
+    /// Lowercase hex SHA-256 of the kernel image this workload boots.
+    pub kernel_sha256: String,
+}
+
 /// Reference to a signed image. SHA-256 of the rootfs + name. The
 /// `cosign_bundle` field
 /// is the path or URL to the cosign keyless bundle that

--- a/crates/mvm-runtime/src/hvf_backend.rs
+++ b/crates/mvm-runtime/src/hvf_backend.rs
@@ -875,6 +875,7 @@ mod tests {
         use mvm_core::policy::RedactionPolicy;
 
         let input = SynthesisInput {
+            kernel_sha256: None,
             network_mode: Default::default(),
             l3_network: None,
             vm_name: "hvf-secret-vm",


### PR DESCRIPTION
Follows #2102. That PR stops the wrong kernel being *selected*; this one makes the right kernel *provable*.

## Why

An `ExecutionPlan` pinned the image and nothing about what confines it. The image digest says what the workload **is**; the kernel decides what it **can do**. The same signed image on a kernel built for a different job gets a different security posture — a kernel with `CONFIG_USER_NS` enabled lets the guest become uid 0 in a user namespace, which the workload kernel is built to prevent.

That made a real substitution invisible: identical plan, identical image, identical digests, and confinement decided by whichever kernel the host happened to have cached. Pinning the kernel turns it into a refusal at admission instead of a silent difference at boot.

## Shape

`EnvironmentRef` is a struct rather than a bare digest, so the rest of the environment — initrd, runtime overlay, seccomp tier — can follow without another plan field.

The plan field is **skip-serialized when absent**. It lives inside the signed payload, so emitting it as `null` would invalidate every existing signature and every frozen address/audit vector.

`enforce_admitted_environment` runs in `admit_and_start` — the single admitted-boot entrypoint every driver shares — next to the existing share and sidecar gates. It is fail-closed in both directions: a plan that pins a kernel and a launch config that supplies none is **refused**, so dropping the kernel path is not a way around the check.

## Coverage is partial, by design

`mvm-hostd`'s local-boot seam populates the pin. **The CLI synthesis sites still pass `None`**, so plans they build pin nothing and the gate no-ops for them — including `machine run --image`, the path where this was originally observed.

Wiring those needs separating the audit-only synthesis sites from the boot ones (`emit_oci_run_admission` turned out to be provenance emission, not a boot seam). That distinction is worth getting right rather than guessing at it inside an admission path, so it is deliberately left as follow-up rather than half-done here.

## Tests

Four, covering match / substitution / pin-without-kernel / unpinned-is-unaffected. Both failure paths were verified by planting the defect:

- neutering the digest comparison fails `substituted_kernel_is_refused`
- treating a missing kernel path as a pass fails `pinned_plan_with_no_kernel_path_is_refused`

Workspace 9231/9231 green at `-j 4`, doctests green, clippy clean, xtask gates pass. (At `-j 6` the `host_agent_restart` tests time out under contention; they pass isolated and fail identically on branches that do not touch `mvm-hostd`.)