### PR TITLE
Close production object-store volume plan

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-02
+Last updated: 2026-08-03
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -65,7 +65,7 @@ for detailed scope and acceptance criteria.
   - [x] Add a fail-closed bounding-set result classifier whose Linux mutation
         witness kills the final comparison survivor from the corrected-head run
 
-- [ ] Plan 283 — Production object-store volumes
+- [x] Plan 283 — Production object-store volumes
       (`specs/plans/283-production-object-store-volumes.md`, issue #2040)
   - [x] Canonical mvm contract and dead S3-path removal
   - [x] Live local/block attachment through the admitted VM launch path
@@ -74,7 +74,7 @@ for detailed scope and acceptance criteria.
   - [x] Canonical worker handoff, Linux/KVM composition proof, and follow-up PR
         matrices are green
   - [x] MinIO integration plus Linux/KVM persistence and restore proof
-  - [ ] Reconcile rejected speculative clauses and close #2040 with evidence
+  - [x] Reconcile rejected speculative clauses and close #2040 with evidence
 
 - [x] Plan 282 — Merge queue auto-requeue
       (`specs/plans/282-merge-queue-auto-requeue.md`)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -157,7 +157,7 @@ updates only its own entry below.
       is clean with 27 relevant privilege-drop mutants caught.
       Tracked in plan 284.
 
-- [ ] Production object-store volumes — **plan 283 / issue #2040**. Standardize
+- [x] Production object-store volumes — **plan 283 / issue #2040**. Standardize
       remote volume I/O on Apache Arrow `object_store` while preserving the
       accepted mvm↔mvmd ownership boundary and mvmd's distinction between
       multi-attach `StorageBucket` and exclusive block `VolumeRecord`. Completion
@@ -165,9 +165,9 @@ updates only its own entry below.
       local/block attachment, encrypted durable checkpoints and cross-worker
       restore, working remote CLI/API policy, MinIO integration, and Linux/KVM
       persistence/restore proof. Registry-only, compile-only, and mocked-only
-      paths do not satisfy the issue. Follow-up verification is open because
-      the original cross-worker claim covered gateway-local directories rather
-      than the gateway→agent→hostd worker data plane.
+      paths do not satisfy the issue. Follow-up verification closed the original
+      gateway-local proof gap with the canonical gateway→agent→hostd worker data
+      plane; mvm PR #2100 and mvmd PR #203 are merged with green final matrices.
   - [x] WS1: external implementations can run the canonical trait-object
         contract; the unregistered member-only S3 mount provider is removed;
         template-registry S3 remains independently gated; the two-surface gate
@@ -218,7 +218,7 @@ updates only its own entry below.
         Twenty-one gateway client tests, including one real loopback HTTP request, nine CLI
         lifecycle parser tests, touched-crate checks, all-target Clippy, and the
         complete 115-scenario / 523-step BDD suite pass.
-  - [ ] WS4/WS5 policy/WS6/WS7: mvmd PRs #199, #201, and #202 deliver durable
+  - [x] WS4/WS5 policy/WS6/WS7: mvmd PRs #199, #201, and #202 deliver durable
         manifests and encrypted checkpoints, gateway-local restore, fencing,
         retention/GC, API policy, metrics, signed lifecycle/refusal audits, and
         operator documentation. The real MinIO lane proves encrypted multipart
@@ -232,8 +232,10 @@ updates only its own entry below.
         The composed Linux/KVM proof is now green: two isolated production
         workers preserve boot counts 1→2 across a source restart, transfer the
         encrypted image through gateway→agent→hostd, and observe boot count 3
-        after destination restore. Both follow-up PR matrices are green; this
-        item and issue #2040 remain open until both changes land.
+        after destination restore. Both follow-up PR matrices are green, mvm
+        PR #2100 passed its full merge-group matrix including the Nix 50 MB
+        guest-artifact footprint gate, and mvmd PR #203 passed all 11 final-head
+        checks before both changes landed.
 
 - [x] Merge-queue auto-requeue: bounded recovery for transiently ejected pull
       requests, with conflict refusal, persistent attempt counting, no checkout

--- a/specs/plans/283-production-object-store-volumes.md
+++ b/specs/plans/283-production-object-store-volumes.md
@@ -1,6 +1,6 @@
 # Production object-store volumes
 
-**Status:** In progress — canonical cross-worker handoff and required PR matrices are green; landing and issue closeout remain (2026-08-02).
+**Status:** Complete — canonical cross-worker handoff, live KVM proof, required PR and merge-queue matrices, and cross-repository landing are complete (2026-08-03).
 
 **Issue:** [#2040](https://github.com/tinylabscom/mvm/issues/2040)
 
@@ -350,7 +350,7 @@ restore, and clean detach. The follow-up PR matrix required by WS7 is green.
       repositories, including all BDD and live lanes.
 - [x] Update both sprint specs, the owning plan checkboxes, and refactor/status
       rollups with final test counts and evidence.
-- [ ] Link the implementing PRs and evidence from this plan and close #2040 with
+- [x] Link the implementing PRs and evidence from this plan and close #2040 with
       an explicit shipped-versus-rejected scope ledger after the required live
       and CI evidence is green.
 
@@ -365,6 +365,10 @@ restore, and clean detach. The follow-up PR matrix required by WS7 is green.
 - Provider ETags are preserved as metadata where available, but the canonical
   manifest digest is the portable integrity identity because ETags are not
   uniformly content digests.
+- Remote object I/O remains in the host and worker userspace planes. Guests see
+  only the admitted block device; no object-store, S3, network-filesystem, or
+  FUSE support was added to the guest kernel. The mvm merge-group Nix lane
+  passed its static-musl, glibc-free, and 50 MB guest-artifact footprint gates.
 - Online master/data-key rotation is not implemented or advertised. The
   operator documentation describes safe export/import recovery under fresh
   keys and warns against swapping the master secret, so no nonexistent rotation
@@ -372,21 +376,22 @@ restore, and clean detach. The follow-up PR matrix required by WS7 is green.
 - The platform fsyncs checkpoint source images. Freezing an arbitrary guest
   database safely requires an application-specific operator/workload contract.
 
-Merged implementation PRs so far: mvm
+Merged implementation PRs: mvm
 [`#2044`](https://github.com/tinylabscom/mvm/pull/2044) and
-[`#2064`](https://github.com/tinylabscom/mvm/pull/2064); mvmd
+[`#2064`](https://github.com/tinylabscom/mvm/pull/2064), followed by the
+canonical hostd v3 worker-transfer protocol in
+[`#2100`](https://github.com/tinylabscom/mvm/pull/2100); mvmd
 [`#198`](https://github.com/tinylabscom/mvmd/pull/198),
 [`#199`](https://github.com/tinylabscom/mvmd/pull/199),
 [`#200`](https://github.com/tinylabscom/mvmd/pull/200),
 [`#201`](https://github.com/tinylabscom/mvmd/pull/201), and
-[`#202`](https://github.com/tinylabscom/mvmd/pull/202). Issue #2040 was closed
-prematurely on 2026-08-02; the worker-handoff follow-up and its evidence must
-land before the shipped ledger is final.
-
-Follow-up review: mvm
-[`#2100`](https://github.com/tinylabscom/mvm/pull/2100) and mvmd
-[`#203`](https://github.com/tinylabscom/mvmd/pull/203). Both required matrices
-are green. Issue #2040 remains open until both changes land.
+[`#202`](https://github.com/tinylabscom/mvmd/pull/202), followed by the exact
+gateway→agent→hostd worker data plane in
+[`#203`](https://github.com/tinylabscom/mvmd/pull/203). The final PR matrices
+and mvm merge-group matrix are green. The composed KVM witness preserves boot
+counts 1→2 across source restart, transfers only detached ciphertext, and
+observes boot count 3 after verified destination restore. The closeout corrects
+the premature 2026-08-02 issue closure with the now-landed canonical proof.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

- mark Plan 283 and its sprint/refactor rollups complete after mvm #2100 and mvmd #203 landed
- record the final PR, merge-queue, MinIO, and cross-worker KVM evidence
- retain the rejected-scope ledger and document that object-store logic stays out of the slim guest kernel

## Validation

- `git diff --check`
- docs-only pre-commit hook traced and passed
- implementation merge-group matrix passed tests, lint/policy, Nix static-musl/glibc-free checks, and the 50 MB guest-artifact footprint gate
