### PR TITLE
docs(plan-291): the develop → build → deploy path to an attested image

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,35 @@ inside the microVM.
 
 ---
 
+
+### From dev loop to attested image
+
+The three routes above are the *start* of one path: pick a base, iterate until
+the workload actually works, then end with a sealed, hashed, recorded artifact.
+
+What that looks like today:
+
+```bash
+mvmctl build compile app.py --out ./out   # declared deps; lockfiles must be hash-pinned
+mvmctl machine build --flake ./out        # installs deps into a SEALED volume
+mvmctl deps inspect                       # SBOM + CVE + hash-chained meta, no VM needed
+mvmctl machine run --entrypoint --flake ./out
+```
+
+Dependencies land in a sealed volume rather than in the image: hash-locked
+content, an SBOM, a CVE scan, and a hash-chained `meta.json`. The supervisor
+verifies that volume before launch and refuses a tampered one, and `--prod`
+fails closed on high/critical findings or a stub SBOM. A lockfile entry with no
+integrity hash is rejected at compile time.
+
+`mvmctl deploy`, `mvmctl watch`, and capturing a dependency you installed inside
+a dev sandbox are **designed but not yet built** — see
+[plan 291](specs/plans/291-develop-build-deploy-attested.md). Until they land,
+the declared route above is the supported way to get a dependency into an
+attested workload.
+
+Full walkthrough: [From dev loop to attested image](public/src/content/docs/guides/develop-to-attested.md).
+
 ## SDKs
 
 Two SDK families, three languages. Both are deliberately **thin**: they drive

--- a/public/astro.config.mjs
+++ b/public/astro.config.mjs
@@ -126,6 +126,7 @@ export default defineConfig({
             { label: "Overview", slug: "guides" },
             { label: "Writing Nix Flakes", slug: "guides/nix-flakes" },
             { label: "Nix and OCI", slug: "guides/nix-and-oci" },
+            { label: "From dev loop to attested image", slug: "guides/develop-to-attested" },
             { label: "From Workload IR to MicroVM Image", slug: "guides/ir-to-image" },
             { label: "Building MicroVM Images", slug: "guides/building-microvm-images" },
             { label: "Building from Source", slug: "guides/building-from-source" },

--- a/public/src/content/docs/guides/develop-to-attested.md
+++ b/public/src/content/docs/guides/develop-to-attested.md
@@ -1,0 +1,118 @@
+---
+title: From dev loop to attested image
+description: Start from an OCI image or a Nix flake, capture what your workload actually needs, and end with a sealed, hashed, recorded artifact.
+---
+
+The path from "does this even run?" to "this is an attested artifact" is meant to
+be one line of travel: pick a base, iterate until it works, then seal and record
+the result.
+
+This page documents that path **as it works today**, and is explicit about the
+parts that are designed but not yet built.
+
+## 1. Pick a base — OCI or Nix, both are first class
+
+```bash
+# OCI: fastest start, no flake and no host Nix
+mvmctl machine run --image python:3.12 -- python -c "print(2 + 2)"
+
+# Nix flake: reproducible, minimal, carries only what you declare
+mvmctl machine run --flake . -- ./app
+```
+
+Both compile to the same thing — a signed image plus a launch plan — and boot
+identically on every backend. They do not carry the same provenance story;
+see [Nix and OCI](/guides/nix-and-oci/) for the difference.
+
+## 2. Declare what the workload needs
+
+Dependencies are declared alongside the workload, and **the lockfile must be
+hash-pinned**. An entry without an integrity hash is rejected at compile time
+rather than resolved at build time:
+
+```python
+# app.py
+import mvm
+
+@mvm.app(
+    image=mvm.python_image(python="3.12"),
+    dependencies=mvm.python_deps(lockfile="uv.lock", tool="uv"),
+)
+def detect(path: str) -> int:
+    import cv2                     # opencv, resolved from the pinned lockfile
+    return len(cv2.imread(path))
+```
+
+```bash
+mvmctl build compile app.py --out ./out
+mvmctl machine build --flake ./out
+```
+
+`uv.lock`, `yarn.lock` and the other supported formats are each checked for
+per-entry integrity hashes. This is what makes the resulting dependency set
+reproducible rather than merely recorded.
+
+## 3. What you get: a sealed dependency volume
+
+Building installs the declared dependencies into a **sealed volume**, not into
+the image. That volume carries:
+
+- the installed content, hash-locked
+- an SBOM (`sbom.cdx.json`)
+- a CVE scan (`cve.json`)
+- a fetch log
+- a hash-chained `meta.json` binding all of the above together
+
+```bash
+mvmctl deps inspect     # read the sidecars without booting a VM
+mvmctl deps audit
+```
+
+The supervisor verifies this volume before launch and refuses a tampered one, so
+the dependency set is part of the workload's admitted identity — not a
+convention. `--prod` additionally fails closed on high or critical CVE findings,
+and on a stub SBOM or CVE report.
+
+## 4. Run it
+
+```bash
+mvmctl machine run --entrypoint --flake ./out
+```
+
+The image, the environment it boots in, and the sealed dependency volume are all
+pinned into the signed execution plan, and every admission is recorded in the
+chain-signed audit log.
+
+## Designed, not yet built
+
+The following are specified in `specs/plans/291-develop-build-deploy-attested.md`
+and **do not exist yet**. They are listed here so the intended shape is legible,
+not because they can be run:
+
+- **`mvmctl deploy`** — seal, compute the artifact's BLAKE3 identity alongside
+  its SHA-256 interop digest, and write a deploy record. If a remote (`mvmd`) is
+  configured it ships the recorded artifact; if not, you still end up holding a
+  sealed, recorded artifact locally.
+- **`mvmctl watch`** — rebuild on source change during development, skipping
+  no-op rebuilds by content address.
+- **Capture from the sandbox** — install a dependency inside a dev sandbox and
+  capture it into the sealed volume, then emit it back out as a declaration you
+  can commit. The capture path is designed to converge on the declared path
+  above, keeping the same hash-pin requirement, rather than becoming a second
+  way to specify dependencies.
+
+Until those land, the declared route in step 2 is the supported way to get a
+dependency into an attested workload.
+
+## Why two digests
+
+Deployed artifacts are designed to carry both BLAKE3 and SHA-256, and the
+distinction is deliberate:
+
+- **BLAKE3 is identity.** It is a tree hash, so a large rootfs can be verified
+  incrementally and in part rather than read end to end.
+- **SHA-256 is interop.** OCI registry digests, cosign signatures, and in-kernel
+  dm-verity all specify SHA-256, and dm-verity has no BLAKE3 support at all — so
+  verified boot keeps its SHA-256 roothash.
+
+Anything that pins a digest states which of the two it means.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -6,6 +6,17 @@ This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## In-flight plans
+- [ ] Plan 291 — Develop → build → deploy an attested workload image
+      (`specs/plans/291-develop-build-deploy-attested.md`)
+  - [ ] WS1 `mvmctl deploy`: seal, BLAKE3 identity + SHA-256 interop, deploy
+        record; ship to mvmd when a remote is configured, else stop at the
+        local sealed artifact
+  - [ ] WS2 `mvmctl watch`: rebuild on change, skip no-op rebuilds by address
+  - [ ] WS3 capture-from-sandbox via `reseal_volume`, converging on the
+        declared-dependency path and keeping the lockfile hash pin
+  - [ ] WS4 tier follows the attestation; retire the `interactive` feature fork
+        and replace the symbol-absence witnesses with conformance scenarios
+
 - [~] Plan 290 — Sensitive egress redaction
       (`specs/plans/290-sensitive-egress-redaction.md`)
   - [x] Validated byte detector and pinned, no-default-feature LeakGuard adapter

--- a/specs/plans/291-develop-build-deploy-attested.md
+++ b/specs/plans/291-develop-build-deploy-attested.md
@@ -1,0 +1,140 @@
+# Develop → build → deploy: one stupidly simple path to an attested workload image
+
+**Status:** Proposed. No implementation yet. Written to be disagreed with before
+any code exists.
+
+**Goal:** A developer starts from an OCI image or a Nix flake, iterates on a
+machine until the workload actually works — including discovering the
+dependencies it needs — and then runs one command that seals, hashes, and
+records the result as an attested image. If a remote (`mvmd`) is configured that
+same command ships it; if not, the developer still ends up holding a sealed,
+recorded artifact.
+
+## Why this plan exists
+
+The pieces are mostly built and hard to see. The risk is not that this is
+difficult — it is that someone rebuilds machinery that already ships, or that
+"sealed" keeps meaning three different things.
+
+## What already exists (do not rebuild)
+
+| Capability | Where |
+|---|---|
+| OCI **and** Nix flake as workload bases | the existing build pipeline; both already unify |
+| Declared dependencies, with **hash-pinned lockfiles enforced** | `mvm_sdk::compile::deps::validate_lockfiles` — `uv.lock`, `yarn.lock`, and friends; any entry lacking an integrity hash is rejected |
+| Sealed dependency volume: SBOM, CVE scan, hash-chained `meta.json` | `mvm_sdk::compile::deps_audit::{seal_volume, reseal_volume, verify_sealed_volume, derive_volume_hash}` (claim 11) |
+| Admission-time refusal of a tampered dep volume | supervisor admission verifier |
+| Workload content address | `mvmctl build address` (semantic address + `ir_hash`) |
+| Image + environment pinned into the signed plan | `SignedImageRef`, `EnvironmentRef` |
+
+**`reseal_volume` is the capture primitive.** Installing a package inside a dev
+sandbox and then resealing produces a new volume hash, a refreshed SBOM, and a
+fresh CVE scan for free. The security-sensitive half of "capture what I
+installed" is already written; what is missing is the loop around it.
+
+## What "sealed" means, stated once
+
+The word currently carries three jobs. They must be separated or this stays
+confusing:
+
+1. **Image contents** — whether console/exec are compiled into the agent.
+   *This distinction goes away.* One image, always the same bytes.
+2. **Run tier** — whether a given run may be interacted with.
+   *Follows from (3), not from a build flag.*
+3. **Attestation** — the image is hashed, recorded, and traceable.
+   *This is what `deploy` produces, and it is not going away.*
+
+So sealing is **not** removed and **not** a build variant. It becomes an
+attestation over a fixed image: same bytes, now hashed and recorded.
+
+## Addressing: BLAKE3 for identity, SHA-256 for interop
+
+`blake3` is already a workspace dependency, so this adds nothing new to the
+tree.
+
+- **BLAKE3 is the mvm-native artifact address.** It is a tree hash, so it
+  supports verified streaming and incremental verification — a large rootfs can
+  be verified in part without reading all of it. That directly serves
+  verify-on-read and content-addressed reuse. SHA-256 cannot do this.
+- **SHA-256 stays wherever the outside world specifies it**, and cannot be
+  replaced: OCI registry digests (`sha256:…`), cosign signatures, and in-kernel
+  dm-verity, which has no BLAKE3 support and therefore keeps claim 3's roothash
+  on SHA-256.
+
+A deployed artifact therefore carries **both**. This is the σ/κ distinction plan
+276 already formalised, not a new concept. The rule, stated once: **BLAKE3 is
+identity, SHA-256 is interop, and anything that pins a digest says which it
+means.** A single unlabelled "hash" field anywhere in the deploy record is a
+bug.
+
+## Workstreams
+
+### WS1 — `mvmctl deploy`
+
+- [ ] Seal the built image, compute its BLAKE3 identity, and write a deploy
+      record: workload address (`ir_hash`), image BLAKE3, image SHA-256, the
+      environment pin, sealed dep-volume hash, and the SBOM/CVE verdicts already
+      produced by claim 11's pipeline.
+- [ ] If a remote is configured, ship the recorded artifact to it. If not, stop
+      at the local sealed artifact — deploying without a cloud is a supported
+      outcome, not a failure.
+- [ ] Refuse to record an artifact whose dep volume fails
+      `verify_sealed_volume`, so a deploy cannot launder a tampered volume.
+
+**Open question for the owner.** `CLAUDE.md` states that deploy-to-control-plane
+commands live in mvmd, not mvmctl. Sealing, hashing and recording are artifact
+construction and belong in mvm; pushing to a control plane, tenants and
+placement belong in mvmd. This plan assumes `mvmctl deploy` performs the former
+and delegates the latter. If `mvmctl deploy` is meant to own the control-plane
+conversation directly, that is an architectural change and needs deciding before
+WS1 starts.
+
+### WS2 — `mvmctl watch`
+
+- [ ] Watch the workload source and rebuild the image on change.
+- [ ] Reuse the existing content addresses to skip no-op rebuilds: if the
+      `ir_hash` and inputs are unchanged, do nothing.
+- [ ] Surface what changed and what it cost, so the loop teaches the developer
+      what their workload actually depends on.
+
+### WS3 — capture dependencies from the sandbox
+
+- [ ] `install`-into-sandbox during development, then reseal via
+      `reseal_volume` to capture it — new volume hash, refreshed SBOM, fresh CVE
+      scan.
+- [ ] Emit the captured set back out as a declaration the developer can commit,
+      so an interactively-discovered dependency becomes a declared one. The
+      capture path must converge on the declared path, not fork from it.
+- [ ] Keep the lockfile hash-pin requirement intact: a captured dependency is
+      pinned like a declared one, or the seal refuses.
+
+**The opencv case, end to end:** the developer either declares it (works today)
+or installs it in the sandbox and lets WS3 capture it. Both routes end at the
+same sealed, hash-pinned, CVE-scanned volume.
+
+### WS4 — the tier follows the attestation
+
+- [ ] The run tier comes from whether the run uses an attested artifact, not
+      from a build variant and not from an unattested CLI flag.
+- [ ] Retire the `interactive` Cargo feature fork so one agent binary serves
+      both tiers; the existing `RequestClass::{ProdSafe, DevOnly}` gate and the
+      signed `VerbGrant` already do the enforcement.
+- [ ] Replace the symbol-absence CI witnesses with conformance scenarios
+      asserting an attested run refuses DevOnly verbs. Note that those
+      symbol-grep jobs live in `security.yml`, which does not run on pull
+      requests, so a conformance scenario in the PR-gating suite is stronger
+      than what it replaces, not weaker.
+
+## Non-goals
+
+- Changing what claim 11 already guarantees about dependency volumes.
+- Replacing SHA-256 where OCI, cosign, or dm-verity specify it.
+- Moving tenant lifecycle or placement out of mvmd.
+
+## Sequencing
+
+WS1 is independently useful and unblocks the rest, because the deploy record is
+what WS4's tier signal reads. WS2 is standalone and can land any time. WS3
+depends on WS1 only for where the captured volume is recorded. WS4 should land
+last: it changes user-visible interactive access and should do so once, when the
+attestation it keys on exists.


### PR DESCRIPTION
Plan only — no implementation. Written to be disagreed with cheaply, before any code exists.

## The goal

A developer starts from an OCI image or a Nix flake, iterates until the workload actually works — including discovering what it depends on — then runs one command that seals, hashes, and records the result. If a remote (`mvmd`) is configured that command ships it; if not, they still end up holding a sealed, recorded artifact.

## The main thing this plan does

**It marks what already exists**, because the real risk here is rebuilding shipped machinery:

- Both OCI and Nix bases are already first class
- Dependencies are already declarable, and **hash-pinned lockfiles are already enforced at compile time** — a `uv.lock`/`yarn.lock` entry without an integrity hash is rejected, not resolved
- The sealed dependency volume (SBOM, CVE scan, hash-chained `meta.json`, admission-time refusal of a tampered volume) already ships as claim 11
- `mvmctl build address` already gives a workload a content address

So "declare opencv and get a sealed, hash-pinned, CVE-scanned volume" **works today**.

Only three things are genuinely missing: `mvmctl deploy`, `mvmctl watch`, and capture-from-sandbox. And `reseal_volume` already exists — that is the capture primitive, so the security-sensitive half of "capture what I installed" is written; only the loop around it is missing.

## Stating what "sealed" means, once

The word currently does three jobs, which is why this keeps tangling:

1. **Image contents** — whether console/exec are compiled in. *This distinction goes away:* one image, same bytes.
2. **Run tier** — whether a run may be interacted with. *Follows from (3)*, not from a build flag.
3. **Attestation** — hashed, recorded, traceable. *This is what deploy produces, and it does not go away.*

Sealing is therefore neither removed nor a build variant. It becomes an attestation over fixed bytes.

## Addressing

BLAKE3 for identity, SHA-256 for interop. `blake3` is already a workspace dependency, so this adds nothing to the tree.

BLAKE3 is a tree hash, so a large rootfs can be verified incrementally rather than read end to end. It **cannot** replace SHA-256 where OCI registry digests, cosign, or in-kernel dm-verity specify it — dm-verity has no BLAKE3 support at all, so verified boot keeps its SHA-256 roothash. Artifacts carry both, and anything that pins says which it means. This is the σ/κ split plan 276 already formalised, not a new concept.

## Docs

README section and a web guide (`guides/develop-to-attested`, registered in the sidebar) document the path **as it works today**. The three unbuilt verbs are explicitly marked as designed-not-built with a pointer here, so the docs do not describe commands that do not exist. All doc gates pass (`check-doc-claims`, `check-no-overclaim`, `check-honesty`, `check-deferrals`, `check-machine-doc-guards`, `check-two-surfaces`).

## Open question for the owner

`CLAUDE.md` states that deploy-to-control-plane commands live in mvmd, not mvmctl. This plan assumes `mvmctl deploy` performs seal + hash + record (artifact construction, which mvm already owns) and delegates control-plane conversation, tenants and placement to mvmd. If `mvmctl deploy` is meant to own the control-plane side directly, that is an architectural change and should be decided before WS1 starts.