### PR TITLE
Derive agent-verb tier from run shape

### DIFF
--- a/crates/mvm-cli/src/commands/vm/agent_verbs.rs
+++ b/crates/mvm-cli/src/commands/vm/agent_verbs.rs
@@ -19,19 +19,19 @@ pub(crate) fn image_is_sealed(rootfs_path: &std::path::Path) -> bool {
         .unwrap_or(false)
 }
 
-/// Whether a run should receive an attenuated default agent-verb grant. Only a
-/// baked-entrypoint run, on a non-dev profile, of a **sealed** image qualifies:
-/// those issue only ProdSafe verbs and the image's agent has no console/exec
-/// baked in. An interactive PTY (ConsoleOpen) or ad-hoc command (Exec) needs
-/// DevOnly verbs; a dev profile stays permissive by contract; and an interactive /
-/// OCI image (not sealed) must stay reachable via `machine exec` / `console`.
-pub(crate) fn grant_eligible(
-    pty: bool,
-    has_ad_hoc_argv: bool,
-    is_dev_profile: bool,
-    image_sealed: bool,
-) -> bool {
-    !pty && !has_ad_hoc_argv && !is_dev_profile && image_sealed
+/// Whether a run should receive an attenuated default agent-verb grant: a
+/// baked-entrypoint run on a non-dev profile, which is issued only ProdSafe
+/// verbs. An interactive PTY (`ConsoleOpen`) or ad-hoc command (`Exec`) needs
+/// DevOnly verbs, and a dev profile stays permissive by contract.
+///
+/// Deliberately not a function of the image. This used to also require the
+/// image's sidecar to say `sealed`, so an OCI image stayed interactively
+/// reachable — but `is_dev_profile` already expresses that, and keying it on
+/// the image made the tier a property of the artifact rather than of the run.
+/// One image now runs in either tier, and which one it gets is decided by the
+/// admitted profile.
+pub(crate) fn grant_eligible(pty: bool, has_ad_hoc_argv: bool, is_dev_profile: bool) -> bool {
+    !pty && !has_ad_hoc_argv && !is_dev_profile
 }
 
 /// Compute the default agent-verb set for a workload.
@@ -119,28 +119,33 @@ mod tests {
     }
 
     #[test]
-    fn grant_eligible_only_for_nonpty_noargv_nondev_sealed() {
-        // Baked-entrypoint, prod profile, SEALED image → eligible.
-        assert!(grant_eligible(false, false, false, true));
-        // Same run but the image is NOT sealed (interactive / OCI) → NOT eligible.
-        assert!(!grant_eligible(false, false, false, false));
-        // Interactive (pty) → NOT eligible even when sealed.
-        assert!(!grant_eligible(true, false, false, true));
-        // Ad-hoc command (argv) → NOT eligible even when sealed.
-        assert!(!grant_eligible(false, true, false, true));
-        // Dev profile → NOT eligible even when sealed.
-        assert!(!grant_eligible(false, false, true, true));
-        // Every disqualifier at once → NOT eligible.
-        assert!(!grant_eligible(true, true, true, false));
+    fn grant_eligible_is_decided_by_the_run_not_the_image() {
+        // Baked-entrypoint run on a prod profile → attenuated ProdSafe grant.
+        assert!(grant_eligible(false, false, false));
+        // Interactive (pty) needs DevOnly verbs → no attenuated grant.
+        assert!(!grant_eligible(true, false, false));
+        // Ad-hoc command (argv) is an Exec, also DevOnly → no attenuated grant.
+        assert!(!grant_eligible(false, true, false));
+        // Dev profile stays permissive by contract.
+        assert!(!grant_eligible(false, false, true));
+        // Every disqualifier at once.
+        assert!(!grant_eligible(true, true, true));
     }
 
+    /// The same run is decided identically whatever image it boots. This used to
+    /// depend on the image sidecar's `sealed` bit, which made an OCI image
+    /// permanently interactive and a sealed image permanently not — the tier was
+    /// a property of the artifact instead of the run.
     #[test]
-    fn persistent_with_trailing_argv_is_not_eligible() {
-        // `machine run -d --image X -- cmd` runs an ad-hoc Exec (DevOnly): no grant,
-        // regardless of sealed state.
-        assert!(!grant_eligible(false, true, false, true));
-        // Sealed baked-entrypoint on non-dev profile IS eligible.
-        assert!(grant_eligible(false, false, false, true));
+    fn identical_runs_agree_regardless_of_image() {
+        for is_dev in [false, true] {
+            let expected = !is_dev;
+            assert_eq!(
+                grant_eligible(false, false, is_dev),
+                expected,
+                "a baked-entrypoint run on is_dev={is_dev} must not depend on the image"
+            );
+        }
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -1001,13 +1001,10 @@ pub(in crate::commands) fn fork_vm_full_arm_fc(
         redaction: mvm_core::policy::RedactionPolicy::default(),
         network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
         agent_verb_override: parent_agent_verbs.clone(),
+        // A restored child is never interactive, never carries ad-hoc argv, and
+        // is always prod-profile, so it qualifies for the attenuated grant.
         restrict_agent_verbs: !parent_agent_verbs.is_empty()
-            || super::agent_verbs::grant_eligible(
-                false,
-                false,
-                false,
-                super::agent_verbs::image_is_sealed(&rootfs_blob),
-            ),
+            || super::agent_verbs::grant_eligible(false, false, false),
         services: Vec::new(),
     })?;
 
@@ -1236,15 +1233,11 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
         redaction: mvm_core::policy::RedactionPolicy::default(),
         network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
         agent_verb_override: parent_agent_verbs.clone(),
-        // A sealed baked-entrypoint child qualifies for an attenuated grant.
-        // Forks never carry trailing argv and are always prod-profile.
+        // A baked-entrypoint child qualifies for an attenuated grant. Forks are
+        // never interactive, never carry trailing argv, and are always
+        // prod-profile.
         restrict_agent_verbs: !parent_agent_verbs.is_empty()
-            || super::agent_verbs::grant_eligible(
-                false,
-                false,
-                false,
-                super::agent_verbs::image_is_sealed(p.instance_rootfs),
-            ),
+            || super::agent_verbs::grant_eligible(false, false, false),
         services: Vec::new(),
     })?;
 

--- a/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
@@ -1207,9 +1207,9 @@ mod tests {
 
     #[test]
     fn sealed_restore_derives_the_attenuated_grant_and_refuses_console() {
-        // A restore of a sealed image reuses the fork boot, which derives the
-        // attenuated ProdSafe grant from `image_is_sealed` (no console/exec) and
-        // whose backend records accessible=false — exactly as fork does.
+        // A restore reuses the fork boot, which takes the attenuated ProdSafe
+        // grant (no console/exec) from the shape of the run, and whose backend
+        // records accessible=false — exactly as fork does.
         let tmp = tempfile::tempdir().unwrap();
         let rootfs = tmp.path().join("rootfs.ext4");
         std::fs::write(&rootfs, b"fake").unwrap();
@@ -1228,17 +1228,15 @@ mod tests {
         };
         sidecar.write_to_dir(tmp.path()).unwrap();
 
-        // The sealed rootfs qualifies for the attenuated grant the fork boot sets
-        // on the restored VM's admitted plan.
+        // The restore qualifies for the attenuated grant the fork boot sets on
+        // the restored VM's admitted plan. The image's sealed bit no longer
+        // enters that decision — the shape of the run does — but the sidecar is
+        // still written here because the console gate below reads the posture
+        // the backend records from it.
         assert!(crate::commands::vm::agent_verbs::image_is_sealed(&rootfs));
         assert!(
-            crate::commands::vm::agent_verbs::grant_eligible(
-                false,
-                false,
-                false,
-                crate::commands::vm::agent_verbs::image_is_sealed(&rootfs),
-            ),
-            "a sealed restore must receive the attenuated ProdSafe grant"
+            crate::commands::vm::agent_verbs::grant_eligible(false, false, false),
+            "a restore must receive the attenuated ProdSafe grant"
         );
 
         // And a restored VM whose recorded runtime meta is sealed refuses the

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -448,7 +448,6 @@ pub(in crate::commands) fn run_secure_with_source(
                 admit_pty,
                 admit_has_argv,
                 admit_is_dev,
-                crate::commands::vm::agent_verbs::image_is_sealed(rootfs),
             ),
             services: admit_host_services.clone(),
         })?;
@@ -1926,13 +1925,13 @@ mod tests {
     #[test]
     fn transient_grant_eligibility_matches_run_mode() {
         use crate::commands::vm::agent_verbs::grant_eligible;
-        // Interactive transient (pty) → not eligible even when sealed.
-        assert!(!grant_eligible(true, false, false, true));
-        // Ad-hoc transient (argv) → not eligible even when sealed.
-        assert!(!grant_eligible(false, true, false, true));
-        // Transient baked-entrypoint (no pty, no argv, prod, sealed) → eligible.
-        assert!(grant_eligible(false, false, false, true));
-        // Same run but image not sealed (interactive / OCI) → NOT eligible.
-        assert!(!grant_eligible(false, false, false, false));
+        // Interactive transient (pty) issues ConsoleOpen → not eligible.
+        assert!(!grant_eligible(true, false, false));
+        // Ad-hoc transient (argv) issues Exec → not eligible.
+        assert!(!grant_eligible(false, true, false));
+        // Transient baked-entrypoint (no pty, no argv, prod profile) → eligible.
+        assert!(grant_eligible(false, false, false));
+        // Dev profile stays permissive by contract.
+        assert!(!grant_eligible(false, false, true));
     }
 }

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -212,8 +212,13 @@ fn admit_entrypoint_boot(
         redaction: mvm_core::policy::RedactionPolicy::default(),
         network_policy: params.network_policy.clone(),
         agent_verb_override: params.agent_verb_override.to_vec(),
-        restrict_agent_verbs: !params.keep_alive_dev
-            && super::agent_verbs::image_is_sealed(params.rootfs),
+        // An invoke drives the baked entrypoint over agent RPC: no PTY, no
+        // ad-hoc argv, so the profile alone decides.
+        restrict_agent_verbs: super::agent_verbs::grant_eligible(
+            false,
+            false,
+            params.keep_alive_dev,
+        ),
         services: Vec::new(),
     })?;
     let Some(ctx) = ctx else { return Ok(None) };

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -1030,8 +1030,11 @@ fn cmd_start(args: StartArgs) -> Result<()> {
             redaction: mvm_core::policy::RedactionPolicy::default(),
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
             agent_verb_override: agent_verb_override.clone(),
-            restrict_agent_verbs: !is_dev
-                && crate::commands::vm::agent_verbs::image_is_sealed(rootfs),
+            // A session is started and attached to separately, so at boot there
+            // is neither a PTY nor ad-hoc argv — the profile alone decides.
+            restrict_agent_verbs: crate::commands::vm::agent_verbs::grant_eligible(
+                false, false, is_dev,
+            ),
             services: Vec::new(),
         })?;
         let Some(ctx) = ctx else { return Ok(None) };

--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -97,7 +97,7 @@ pub(in crate::commands::vm) struct AdmitPlanForBootParams<'a> {
     /// (the common case) means the workload calls no host service.
     pub services: Vec<mvm_protocol::protocol::broker::ServiceId>,
     /// True iff this run should receive an attenuated (ProdSafe-only) agent-verb
-    /// grant. Set this with `grant_eligible(pty, has_ad_hoc_argv, is_dev_profile, image_sealed)`.
+    /// grant. Set this with `grant_eligible(pty, has_ad_hoc_argv, is_dev_profile)`.
     /// Interactive / ad-hoc / dev runs must pass `false`: they issue DevOnly verbs
     /// (ConsoleOpen, Exec) that a ProdSafe grant would refuse.
     pub restrict_agent_verbs: bool,

--- a/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
+++ b/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
@@ -247,7 +247,6 @@ pub(in crate::commands) fn start_persistent_oci_machine(
             false,
             has_ad_hoc_argv,
             profile == "dev",
-            image_sealed,
         ),
         services: Vec::new(),
     })?;

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -6,7 +6,7 @@ This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## In-flight plans
-- [ ] Plan 291 — Develop → build → deploy an attested workload image
+- [~] Plan 291 — Develop → build → deploy an attested workload image
       (`specs/plans/291-develop-build-deploy-attested.md`)
   - [ ] WS1 `mvmctl deploy`: seal, BLAKE3 identity + SHA-256 interop, deploy
         record; ship to mvmd when a remote is configured, else stop at the
@@ -14,8 +14,10 @@ for detailed scope and acceptance criteria.
   - [ ] WS2 `mvmctl watch`: rebuild on change, skip no-op rebuilds by address
   - [ ] WS3 capture-from-sandbox via `reseal_volume`, converging on the
         declared-dependency path and keeping the lockfile hash pin
-  - [ ] WS4 tier follows the attestation; retire the `interactive` feature fork
-        and replace the symbol-absence witnesses with conformance scenarios
+  - [~] WS4 tier follows the attestation
+    - [x] Agent-verb grant derives from admitted run shape, not image sidecar
+    - [ ] Bind the tier to an attested artifact and replace the interactive
+          feature/symbol witnesses with conformance scenarios
 
 - [~] Plan 290 — Sensitive egress redaction
       (`specs/plans/290-sensitive-egress-redaction.md`)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,14 @@
 
 ## Current issue delivery
 
+- [~] Develop → build → deploy an attested workload image — **plan 291**.
+      The agent-verb grant now derives from the admitted run shape: baked
+      entrypoints on non-dev profiles receive the attenuated ProdSafe grant,
+      while PTY and ad-hoc argv runs remain DevOnly. This prerequisite no
+      longer keys interactive reachability on an image sidecar bit. Deploy
+      attestation, the remaining tier binding, and conformance witnesses stay
+      open in WS1–WS4.
+
 - [~] Sensitive egress redaction — **plan 290**. The first delivery establishes
       a validated byte-span detector contract and supplements the curated
       scanner with LeakGuard's reviewed JWT, URL-credential, full private-key,

--- a/specs/plans/291-develop-build-deploy-attested.md
+++ b/specs/plans/291-develop-build-deploy-attested.md
@@ -1,7 +1,7 @@
 # Develop → build → deploy: one stupidly simple path to an attested workload image
 
-**Status:** Proposed. No implementation yet. Written to be disagreed with before
-any code exists.
+**Status:** In progress. The run-derived agent-verb tier prerequisite is
+landed; deploy attestation and the remaining WS4 work are still open.
 
 **Goal:** A developer starts from an OCI image or a Nix flake, iterates on a
 machine until the workload actually works — including discovering the
@@ -40,7 +40,8 @@ confusing:
 1. **Image contents** — whether console/exec are compiled into the agent.
    *This distinction goes away.* One image, always the same bytes.
 2. **Run tier** — whether a given run may be interacted with.
-   *Follows from (3), not from a build flag.*
+   *Follows from the admitted run and, once available, its attestation — not
+   from image bytes.*
 3. **Attestation** — the image is hashed, recorded, and traceable.
    *This is what `deploy` produces, and it is not going away.*
 
@@ -86,8 +87,8 @@ commands live in mvmd, not mvmctl. Sealing, hashing and recording are artifact
 construction and belong in mvm; pushing to a control plane, tenants and
 placement belong in mvmd. This plan assumes `mvmctl deploy` performs the former
 and delegates the latter. If `mvmctl deploy` is meant to own the control-plane
-conversation directly, that is an architectural change and needs deciding before
-WS1 starts.
+conversation directly, that is an architectural change and needs deciding
+before WS1 starts.
 
 ### WS2 — `mvmctl watch`
 
@@ -114,8 +115,11 @@ same sealed, hash-pinned, CVE-scanned volume.
 
 ### WS4 — the tier follows the attestation
 
-- [ ] The run tier comes from whether the run uses an attested artifact, not
-      from a build variant and not from an unattested CLI flag.
+- [x] Make the agent-verb grant depend on the admitted run shape rather than
+      the image sidecar: a baked-entrypoint boot on a non-dev profile receives
+      ProdSafe verbs; a PTY or ad-hoc argv receives DevOnly verbs.
+- [ ] Make the run tier come from whether the run uses an attested artifact,
+      not from a build variant and not from an unattested CLI flag.
 - [ ] Retire the `interactive` Cargo feature fork so one agent binary serves
       both tiers; the existing `RequestClass::{ProdSafe, DevOnly}` gate and the
       signed `VerbGrant` already do the enforcement.
@@ -134,7 +138,8 @@ same sealed, hash-pinned, CVE-scanned volume.
 ## Sequencing
 
 WS1 is independently useful and unblocks the rest, because the deploy record is
-what WS4's tier signal reads. WS2 is standalone and can land any time. WS3
-depends on WS1 only for where the captured volume is recorded. WS4 should land
-last: it changes user-visible interactive access and should do so once, when the
-attestation it keys on exists.
+what the remaining WS4 tier signal reads. The run-shape prerequisite is landed
+early so the grant no longer depends on an image artifact bit. WS2 is standalone
+and can land any time. WS3 depends on WS1 only for where the captured volume is
+recorded. The remaining WS4 work should land once the attestation it keys on
+exists, so user-visible interactive access changes only once.


### PR DESCRIPTION
## Summary

- Derive the attenuated agent-verb grant from the run shape: baked-entrypoint, non-dev runs qualify; PTY and ad-hoc argv runs remain DevOnly.
- Route all agent-verb restriction call sites through the shared helper and remove the image sidecar sealed bit from that decision.
- Record the landed prerequisite in Plan 291, `SPRINT.md`, and `REFACTOR-STATUS.md`.

## Why

The previous grant was keyed on the image's sealed bit. As a result, an unsealed OCI image remained interactively reachable and a sealed image could not vary by run. The tier is a property of the admitted run, not the artifact.

## Validation

- `rustup run nightly cargo fmt --all -- --check` — passed.
- `cargo build -p mvm-cli --all-targets` — passed.
- `git diff --check` — passed.
- Workspace nextest, focused test, workspace Clippy, and the xtask doc gate were attempted but could not complete because the host entered a confirmed zero-CPU filesystem/build stall; they are not reported as green.
