### PR TITLE
Add mvmctl watch for local workload changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,6 +2759,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "base64",
+ "blake3",
  "chrono",
  "clap",
  "ed25519-dalek",

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -30,6 +30,7 @@ mvm-sdk.workspace = true
 # only need the DTOs, not the rest of the SDK's build-time tooling.
 mvm-protocol.workspace = true
 anyhow.workspace = true
+blake3.workspace = true
 # Real ext4 inode lookup for the Stage 0 post-build check (replaces the
 # old raw-byte substring scan over rootfs.ext4).
 ext4-view.workspace = true

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -210,6 +210,7 @@ impl Commands {
             Commands::Doctor(_) => "doctor",
             Commands::Prepare(_) => "prepare",
             Commands::Kernel(_) => "kernel",
+            Commands::Watch(_) => "watch",
             Commands::Manifest(_) => "manifest",
             Commands::Image(_) => "image",
             Commands::Pack(_) => "pack",

--- a/crates/mvm-cli/src/commands/dispatch.rs
+++ b/crates/mvm-cli/src/commands/dispatch.rs
@@ -26,6 +26,7 @@ impl TopLevelCommand for Commands {
             Commands::Prepare(a) => vm::prepare::run(a),
             Commands::Build(a) => build::group::run(cli, a, cfg),
             Commands::Kernel(a) => build::kernel::run(cli, a, cfg),
+            Commands::Watch(a) => watch::run(cli, a, cfg),
             Commands::Manifest(a) => manifest::run(cli, a, cfg),
             Commands::Image(a) => image::run(cli, a, cfg),
             Commands::Pack(a) => pack::run(cli, a, cfg),

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -25,6 +25,8 @@ mod trust;
 pub(crate) mod vm;
 mod watch;
 
+pub(in crate::commands) use build::ir_input::load_ir_json_workload;
+
 #[cfg(test)]
 mod tests;
 

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -23,6 +23,7 @@ mod shared;
 mod storage;
 mod trust;
 pub(crate) mod vm;
+mod watch;
 
 #[cfg(test)]
 mod tests;
@@ -103,8 +104,11 @@ pub(in crate::commands) enum Commands {
     /// Explain a run after the fact from the chain-signed audit log
     #[command(display_order = 7)]
     Explain(vm::explain::Args),
-    /// Manage the versioned pack cache (list/rollback/prune/download/update)
+    /// Rebuild a workload when its local inputs change
     #[command(display_order = 8)]
+    Watch(watch::Args),
+    /// Manage the versioned pack cache (list/rollback/prune/download/update)
+    #[command(display_order = 9)]
     Pack(pack::Args),
     /// SDK transport surface (`run --mode live/plan`). Hidden: the user-facing
     /// transient-run role folded into `machine run`; `run` survives only as the

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -89,6 +89,26 @@ fn deps_capture_parses_seal_inputs() {
 }
 
 #[test]
+fn watch_parses_file_backed_ir_and_defaults_to_one_shot_only_when_requested() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "watch",
+        "--from-ir",
+        "workload.json",
+        "--once",
+        "--interval-ms",
+        "1",
+    ])
+    .unwrap();
+    let Commands::Watch(args) = cli.command else {
+        panic!("expected watch command")
+    };
+    assert_eq!(args.from_ir, Some("workload.json".into()));
+    assert!(args.once);
+    assert_eq!(args.interval_ms, 1);
+}
+
+#[test]
 fn global_option_summaries_stay_short() {
     let longest_allowed = 48;
     let long_summaries = cli_command()

--- a/crates/mvm-cli/src/commands/watch.rs
+++ b/crates/mvm-cli/src/commands/watch.rs
@@ -50,8 +50,22 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     let mut previous = None;
 
     loop {
-        let workload = load_workload(&input)?;
-        let state = input_state(&workload, &manifest_dir, &args.out)?;
+        let workload = match load_workload(&input) {
+            Ok(workload) => workload,
+            Err(error) => {
+                handle_watch_error(error, args.once, "watch input unavailable")?;
+                std::thread::sleep(Duration::from_millis(args.interval_ms));
+                continue;
+            }
+        };
+        let state = match input_state(&workload, &manifest_dir, &args.out) {
+            Ok(state) => state,
+            Err(error) => {
+                handle_watch_error(error, args.once, "watched input unavailable")?;
+                std::thread::sleep(Duration::from_millis(args.interval_ms));
+                continue;
+            }
+        };
         if previous.as_ref() != Some(&state) {
             let change = previous.as_ref().map_or("initial", |old| {
                 match (
@@ -65,14 +79,18 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 }
             });
             let started = Instant::now();
-            compile(&workload, &args.out, &manifest_dir)
+            let compile_result = compile(&workload, &args.out, &manifest_dir)
                 .map_err(anyhow::Error::from)
-                .with_context(|| format!("compiling watched workload to {}", args.out.display()))?;
-            let compile_ms = started.elapsed().as_millis();
-            eprintln!(
-                "rebuilt workload {} (change={change}, ir_hash {}, compile_ms={compile_ms})",
-                workload.id, state.ir_hash,
-            );
+                .with_context(|| format!("compiling watched workload to {}", args.out.display()));
+            if let Err(error) = compile_result {
+                handle_watch_error(error, args.once, "rebuild failed")?;
+            } else {
+                let compile_ms = started.elapsed().as_millis();
+                eprintln!(
+                    "rebuilt workload {} (change={change}, ir_hash {}, compile_ms={compile_ms})",
+                    workload.id, state.ir_hash,
+                );
+            }
             previous = Some(state);
         } else {
             eprintln!(
@@ -86,6 +104,14 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         }
         std::thread::sleep(Duration::from_millis(args.interval_ms));
     }
+}
+
+fn handle_watch_error(error: anyhow::Error, once: bool, context: &str) -> Result<()> {
+    if once {
+        return Err(error);
+    }
+    eprintln!("{context}: {error}; waiting for the next change");
+    Ok(())
 }
 
 fn validate_interval(interval_ms: u64) -> Result<()> {
@@ -367,5 +393,11 @@ mod tests {
     fn zero_poll_interval_is_rejected() {
         assert!(validate_interval(0).is_err());
         assert!(validate_interval(1).is_ok());
+    }
+
+    #[test]
+    fn long_running_watch_recovers_from_transient_errors() {
+        assert!(handle_watch_error(anyhow::anyhow!("broken input"), false, "watch").is_ok());
+        assert!(handle_watch_error(anyhow::anyhow!("broken input"), true, "watch").is_err());
     }
 }

--- a/crates/mvm-cli/src/commands/watch.rs
+++ b/crates/mvm-cli/src/commands/watch.rs
@@ -10,11 +10,11 @@ use anyhow::{Context, Result, bail};
 use blake3::Hasher;
 use clap::Args as ClapArgs;
 use mvm_core::user_config::MvmConfig;
-use mvm_protocol::ir::{App, Entrypoint, Image, Resources, Source, Workload, ir_hash};
+use mvm_protocol::ir::{Source, Workload, ir_hash};
 use mvm_sdk::compile::compile;
 
 use super::Cli;
-use super::ir_input::load_ir_json_workload;
+use super::load_ir_json_workload;
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
@@ -174,7 +174,7 @@ fn hash_inputs(roots: &[PathBuf], excluded: &Path) -> Result<String> {
     for path in files {
         let relative = path.to_string_lossy();
         hasher.update(relative.as_bytes());
-        hasher.update([0]);
+        hasher.update(&[0]);
         let mut file = fs::File::open(&path)
             .with_context(|| format!("opening watched input {}", path.display()))?;
         let mut buffer = [0_u8; 64 * 1024];
@@ -185,7 +185,7 @@ fn hash_inputs(roots: &[PathBuf], excluded: &Path) -> Result<String> {
             }
             hasher.update(&buffer[..read]);
         }
-        hasher.update([0]);
+        hasher.update(&[0]);
     }
     Ok(hasher.finalize().to_hex().to_string())
 }
@@ -230,6 +230,7 @@ mod tests {
     use super::*;
     use crate::commands::Commands;
     use clap::Parser;
+    use mvm_protocol::ir::{App, Entrypoint, Image, Resources};
 
     fn sample_workload() -> Workload {
         Workload {

--- a/crates/mvm-cli/src/commands/watch.rs
+++ b/crates/mvm-cli/src/commands/watch.rs
@@ -1,0 +1,370 @@
+//! `mvmctl watch` — rebuild a Workload IR when its inputs change.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use blake3::Hasher;
+use clap::Args as ClapArgs;
+use mvm_core::user_config::MvmConfig;
+use mvm_protocol::ir::{App, Entrypoint, Image, Resources, Source, Workload, ir_hash};
+use mvm_sdk::compile::compile;
+
+use super::Cli;
+use super::ir_input::load_ir_json_workload;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Workload IR JSON path. `--from-ir` is accepted as an alternative.
+    #[arg(value_name = "ENTRY")]
+    pub entry: Option<String>,
+
+    /// Read Workload IR from this JSON file.
+    #[arg(long = "from-ir", value_name = "PATH")]
+    pub from_ir: Option<PathBuf>,
+
+    /// Output directory for the rebuilt compile artifact.
+    #[arg(short = 'o', long = "out", value_name = "DIR", default_value = "./out")]
+    pub out: PathBuf,
+
+    /// Directory containing local source paths referenced by the workload.
+    #[arg(long = "manifest-dir", value_name = "DIR")]
+    pub manifest_dir: Option<PathBuf>,
+
+    /// Poll interval in milliseconds.
+    #[arg(long, default_value_t = 500, value_name = "MILLISECONDS")]
+    pub interval_ms: u64,
+
+    /// Build once and exit after the initial rebuild.
+    #[arg(long)]
+    pub once: bool,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    validate_interval(args.interval_ms)?;
+    let input = resolve_input(&args)?;
+    let manifest_dir = args.manifest_dir.unwrap_or(resolve_manifest_dir(&input)?);
+    let mut previous = None;
+
+    loop {
+        let workload = load_workload(&input)?;
+        let state = input_state(&workload, &manifest_dir, &args.out)?;
+        if previous.as_ref() != Some(&state) {
+            let change = previous.as_ref().map_or("initial", |old| {
+                match (
+                    old.ir_hash != state.ir_hash,
+                    old.inputs_blake3 != state.inputs_blake3,
+                ) {
+                    (true, true) => "ir+inputs",
+                    (true, false) => "ir",
+                    (false, true) => "inputs",
+                    (false, false) => "unknown",
+                }
+            });
+            let started = Instant::now();
+            compile(&workload, &args.out, &manifest_dir)
+                .map_err(anyhow::Error::from)
+                .with_context(|| format!("compiling watched workload to {}", args.out.display()))?;
+            let compile_ms = started.elapsed().as_millis();
+            eprintln!(
+                "rebuilt workload {} (change={change}, ir_hash {}, compile_ms={compile_ms})",
+                workload.id, state.ir_hash,
+            );
+            previous = Some(state);
+        } else {
+            eprintln!(
+                "unchanged workload {} (ir_hash {})",
+                workload.id, state.ir_hash
+            );
+        }
+
+        if args.once {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(args.interval_ms));
+    }
+}
+
+fn validate_interval(interval_ms: u64) -> Result<()> {
+    if interval_ms == 0 {
+        bail!("--interval-ms must be greater than zero");
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InputState {
+    ir_hash: String,
+    inputs_blake3: String,
+}
+
+enum Input {
+    Path(PathBuf),
+}
+
+fn resolve_input(args: &Args) -> Result<Input> {
+    match (
+        args.from_ir.as_ref(),
+        args.entry
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty()),
+    ) {
+        (Some(_), Some(_)) => bail!("--from-ir and the positional entry are mutually exclusive"),
+        (Some(path), None) => Ok(Input::Path(path.clone())),
+        (None, Some("-")) => {
+            bail!("mvmctl watch requires a file-backed IR; stdin cannot be watched")
+        }
+        (None, Some(path)) => Ok(Input::Path(PathBuf::from(path))),
+        (None, None) => bail!("missing entry: pass an IR JSON path or --from-ir <path>"),
+    }
+}
+
+fn load_workload(input: &Input) -> Result<Workload> {
+    match input {
+        Input::Path(path) => load_ir_json_workload(Some(path), None),
+    }
+}
+
+fn resolve_manifest_dir(input: &Input) -> Result<PathBuf> {
+    match input {
+        Input::Path(path) => Ok(path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."))),
+    }
+}
+
+fn input_state(workload: &Workload, manifest_dir: &Path, output: &Path) -> Result<InputState> {
+    let ir_hash = ir_hash(workload).context("computing watched workload ir_hash")?;
+    let roots = local_source_roots(workload, manifest_dir)?;
+    let excluded = absolute_path(output)?;
+    let inputs_blake3 = hash_inputs(&roots, &excluded)?;
+    Ok(InputState {
+        ir_hash,
+        inputs_blake3,
+    })
+}
+
+fn local_source_roots(workload: &Workload, manifest_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut roots = BTreeSet::new();
+    for app in &workload.apps {
+        if let Source::LocalPath { path, .. } = &app.source {
+            roots.insert(manifest_dir.join(path));
+        } else {
+            bail!(
+                "mvmctl watch requires local_path sources; app {:?} is not file-backed",
+                app.name
+            );
+        }
+    }
+    Ok(roots.into_iter().collect())
+}
+
+fn hash_inputs(roots: &[PathBuf], excluded: &Path) -> Result<String> {
+    let mut hasher = Hasher::new();
+    let mut files = Vec::new();
+    for root in roots {
+        collect_files(root, excluded, &mut files)?;
+    }
+    files.sort();
+    for path in files {
+        let relative = path.to_string_lossy();
+        hasher.update(relative.as_bytes());
+        hasher.update([0]);
+        let mut file = fs::File::open(&path)
+            .with_context(|| format!("opening watched input {}", path.display()))?;
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        hasher.update([0]);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn collect_files(path: &Path, excluded: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    let absolute = absolute_path(path)?;
+    if absolute == excluded || absolute.starts_with(excluded) {
+        return Ok(());
+    }
+    let metadata = fs::symlink_metadata(&absolute)
+        .with_context(|| format!("reading watched input {}", absolute.display()))?;
+    if metadata.is_file() {
+        files.push(absolute);
+        return Ok(());
+    }
+    if !metadata.is_dir() {
+        return Ok(());
+    }
+    let mut children = fs::read_dir(&absolute)
+        .with_context(|| format!("reading watched input directory {}", absolute.display()))?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<std::io::Result<Vec<_>>>()?;
+    children.sort();
+    for child in children {
+        if child.file_name().is_some_and(|name| name == ".git") {
+            continue;
+        }
+        collect_files(&child, excluded, files)?;
+    }
+    Ok(())
+}
+
+fn absolute_path(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    Ok(std::env::current_dir()?.join(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::Commands;
+    use clap::Parser;
+
+    fn sample_workload() -> Workload {
+        Workload {
+            schema_version: "0.1".into(),
+            id: "watch-test".into(),
+            apps: vec![App {
+                name: "app".into(),
+                source: Source::LocalPath {
+                    path: ".".into(),
+                    include: vec!["**".into()],
+                    exclude: vec![],
+                },
+                image: Image::NixPackages { packages: vec![] },
+                entrypoints: vec![Entrypoint::Command {
+                    command: vec!["/bin/true".into()],
+                    working_dir: "/app".into(),
+                    env: Default::default(),
+                }],
+                env: Default::default(),
+                mounts: vec![],
+                network: None,
+                resources: Resources {
+                    cpu_cores: 1,
+                    memory_mb: 256,
+                    rootfs_size_mb: 512,
+                },
+                dependencies: None,
+                threat_tier: Default::default(),
+                addons: vec![],
+                hooks: Default::default(),
+                files: vec![],
+                health_check: None,
+            }],
+            volumes: vec![],
+            extensions: Default::default(),
+        }
+    }
+
+    #[test]
+    fn same_ir_and_inputs_are_a_noop_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("src");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("main.py"), b"print('hello')").unwrap();
+        let mut workload = sample_workload();
+        workload.apps[0].source = Source::LocalPath {
+            path: "src".into(),
+            include: vec!["**".into()],
+            exclude: vec![],
+        };
+        let a = input_state(&workload, tmp.path(), &tmp.path().join("out")).unwrap();
+        let b = input_state(&workload, tmp.path(), &tmp.path().join("out")).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn source_change_changes_input_state_without_changing_ir_hash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("src");
+        fs::create_dir_all(&source).unwrap();
+        let path = source.join("main.py");
+        fs::write(&path, b"print('hello')").unwrap();
+        let mut workload = sample_workload();
+        workload.apps[0].source = Source::LocalPath {
+            path: "src".into(),
+            include: vec!["**".into()],
+            exclude: vec![],
+        };
+        let before = input_state(&workload, tmp.path(), &tmp.path().join("out")).unwrap();
+        fs::write(path, b"print('changed')").unwrap();
+        let after = input_state(&workload, tmp.path(), &tmp.path().join("out")).unwrap();
+        assert_eq!(before.ir_hash, after.ir_hash);
+        assert_ne!(before.inputs_blake3, after.inputs_blake3);
+    }
+
+    #[test]
+    fn non_local_sources_are_rejected_instead_of_being_treated_as_unchanged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut workload = sample_workload();
+        workload.apps[0].source = Source::OciImage {
+            reference: "example/app".into(),
+            digest: "sha256:deadbeef".into(),
+        };
+        assert!(input_state(&workload, tmp.path(), &tmp.path().join("out")).is_err());
+    }
+
+    #[test]
+    fn one_shot_watch_writes_a_compile_artifact() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("src");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("main.py"), b"print('hello')").unwrap();
+        let ir_path = tmp.path().join("workload.json");
+        fs::write(
+            &ir_path,
+            serde_json::to_vec(&sample_workload()).expect("sample workload serializes"),
+        )
+        .unwrap();
+        let output = tmp.path().join("out");
+        let cli = Cli::try_parse_from([
+            "mvmctl",
+            "watch",
+            "--from-ir",
+            ir_path.to_str().expect("temporary path is UTF-8"),
+            "--out",
+            output.to_str().expect("temporary path is UTF-8"),
+            "--manifest-dir",
+            tmp.path().to_str().expect("temporary path is UTF-8"),
+            "--once",
+        ])
+        .expect("watch CLI parses");
+        let Commands::Watch(args) = cli.command.clone() else {
+            panic!("expected watch command")
+        };
+        run(&cli, args, &MvmConfig::default()).expect("one-shot watch compiles");
+        assert!(output.join("launch.json").is_file());
+        assert!(output.join("workload.json").is_file());
+    }
+
+    #[test]
+    fn stdin_is_rejected_because_it_cannot_be_watched() {
+        let args = Args {
+            entry: Some("-".into()),
+            from_ir: None,
+            out: PathBuf::from("out"),
+            manifest_dir: None,
+            interval_ms: 500,
+            once: true,
+        };
+        assert!(resolve_input(&args).is_err());
+    }
+
+    #[test]
+    fn zero_poll_interval_is_rejected() {
+        assert!(validate_interval(0).is_err());
+        assert!(validate_interval(1).is_ok());
+    }
+}

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -11,7 +11,7 @@ for detailed scope and acceptance criteria.
   - [ ] WS1 `mvmctl deploy`: seal, BLAKE3 identity + SHA-256 interop, deploy
         record; ship to mvmd when a remote is configured, else stop at the
         local sealed artifact
-  - [ ] WS2 `mvmctl watch`: rebuild on change, skip no-op rebuilds by address
+  - [~] WS2 `mvmctl watch`: rebuild on change, skip no-op rebuilds by address
   - [~] WS3 capture-from-sandbox via `reseal_volume`, converging on the
         declared-dependency path and keeping the lockfile hash pin
   - [~] WS4 tier follows the attestation

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-03
+Last updated: 2026-08-04
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -11,7 +11,9 @@ for detailed scope and acceptance criteria.
   - [ ] WS1 `mvmctl deploy`: seal, BLAKE3 identity + SHA-256 interop, deploy
         record; ship to mvmd when a remote is configured, else stop at the
         local sealed artifact
-  - [~] WS2 `mvmctl watch`: rebuild on change, skip no-op rebuilds by address
+  - [~] WS2 `mvmctl watch`: rebuild on change, skip no-op rebuilds by address;
+        long-running mode recovers from transient input/compile errors while
+        `--once` remains fail-fast
   - [~] WS3 capture-from-sandbox via `reseal_volume`, converging on the
         declared-dependency path and keeping the lockfile hash pin
   - [~] WS4 tier follows the attestation

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -20,6 +20,9 @@
       longer keys interactive reachability on an image sidecar bit. Deploy
       attestation, the remaining tier binding, and conformance witnesses stay
       open in WS1–WS4.
+- [~] `mvmctl watch` — **plan 291 WS2**. A file-backed Workload IR watcher
+      polls local source inputs, recompiles only when the semantic IR address
+      or source fingerprint changes, and reports rebuild/no-op iterations.
 
 - [~] Sensitive egress redaction — **plan 290**. The first delivery establishes
       a validated byte-span detector contract and supplements the curated

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -13,6 +13,12 @@
 - [~] `mvmctl deps capture` — **plan 291 WS3**. Reseals a sandbox-captured
       dependency tree with fresh audit sidecars, updates the lockfile index,
       and refuses tampered or unpinned source volumes.
+
+- [~] `mvmctl watch` — **plan 291 WS2**. A file-backed Workload IR watcher
+      polls local source inputs, recompiles only when the semantic IR address
+      or source fingerprint changes, and reports rebuild/no-op iterations.
+      Long-running mode now waits for the next change after transient input or
+      compile errors, while `--once` remains fail-fast for automation.
 - [~] Develop → build → deploy an attested workload image — **plan 291**.
       The agent-verb grant now derives from the admitted run shape: baked
       entrypoints on non-dev profiles receive the attenuated ProdSafe grant,

--- a/specs/plans/291-develop-build-deploy-attested.md
+++ b/specs/plans/291-develop-build-deploy-attested.md
@@ -101,7 +101,9 @@ before WS1 starts.
       what their workload actually depends on.
       Each iteration reports whether it rebuilt or found an unchanged state;
       rebuilds identify whether IR or source inputs changed and report compile
-      duration in milliseconds.
+      duration in milliseconds. Long-running watches keep polling after a
+      transient input or compile error and retry when the fingerprint changes;
+      `--once` remains fail-fast for automation.
 
 ### WS3 — capture dependencies from the sandbox
 

--- a/specs/plans/291-develop-build-deploy-attested.md
+++ b/specs/plans/291-develop-build-deploy-attested.md
@@ -92,11 +92,16 @@ before WS1 starts.
 
 ### WS2 — `mvmctl watch`
 
-- [ ] Watch the workload source and rebuild the image on change.
-- [ ] Reuse the existing content addresses to skip no-op rebuilds: if the
+- [~] Watch the workload source and rebuild the image on change.
+      The file-backed IR watcher polls local source inputs and invokes the
+      existing deterministic compiler when the input fingerprint changes.
+- [~] Reuse the existing content addresses to skip no-op rebuilds: if the
       `ir_hash` and inputs are unchanged, do nothing.
-- [ ] Surface what changed and what it cost, so the loop teaches the developer
+- [~] Surface what changed and what it cost, so the loop teaches the developer
       what their workload actually depends on.
+      Each iteration reports whether it rebuilt or found an unchanged state;
+      rebuilds identify whether IR or source inputs changed and report compile
+      duration in milliseconds.
 
 ### WS3 — capture dependencies from the sandbox
 

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -442,6 +442,7 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     ("prepare", AuditPosture::ReadOnly),
     ("shell-init", AuditPosture::InteractiveOrControl),
     ("init", AuditPosture::InteractiveOrControl),
+    ("watch", AuditPosture::InteractiveOrControl),
     // VM lifecycle. `up` and `invoke` are retired (folded into `machine run`'s
     // argv lifecycle + `--entrypoint` action). `run` survives hidden as the SDK
     // Sandbox transport (`run --mode live/plan`); its posture is unchanged.


### PR DESCRIPTION
Adds top-level mvmctl watch for file-backed Workload IR, BLAKE3 source fingerprints, no-op rebuild skipping, change reporting, and Plan 291 WS2 tests. Nightly formatting, metadata, and diff checks passed; Cargo validation stalled behind concurrent workspace builds on this host and remains for CI.