### PR TITLE
Add sandbox dependency capture command

### DIFF
--- a/crates/mvm-cli/src/commands/deps/audit.rs
+++ b/crates/mvm-cli/src/commands/deps/audit.rs
@@ -433,7 +433,7 @@ fn copy_volume_skeleton(src: &Path, dest: &Path) -> Result<()> {
     Ok(())
 }
 
-fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<()> {
+pub(super) fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<()> {
     std::fs::create_dir_all(dest).with_context(|| format!("creating {}", dest.display()))?;
     for entry in std::fs::read_dir(src).with_context(|| format!("reading {}", src.display()))? {
         let entry = entry?;
@@ -454,7 +454,7 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<()> {
 
 /// Update `<cache_root>/index/<lockfile_hash>` so the orchestrator's
 /// cache hit on the same lockfile picks up the resealed volume.
-fn refresh_index_pointer(
+pub(super) fn refresh_index_pointer(
     cache_root: &Path,
     lockfile_hash: &str,
     new_volume_hash: &str,

--- a/crates/mvm-cli/src/commands/deps/capture.rs
+++ b/crates/mvm-cli/src/commands/deps/capture.rs
@@ -1,0 +1,341 @@
+//! Import a dependency tree discovered in a development sandbox.
+//!
+//! The sandbox install itself remains a dev-only operation. This command owns
+//! the host-side handoff: it copies captured content and fresh audit sidecars
+//! into a scratch volume, reseals them, and atomically publishes the new hash
+//! under the existing lockfile index entry.
+
+use anyhow::{Context, Result, bail};
+use chrono::Utc;
+use clap::Args as ClapArgs;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+use mvm_sdk::compile::deps_audit::{
+    FILE_CONTENT_DIR, FILE_CVE, FILE_FETCH_LOG, FILE_MANIFEST, FILE_SBOM, VolumeManifest,
+    reseal_volume, verify_sealed_volume,
+};
+
+use super::audit::{copy_dir_recursive, refresh_index_pointer};
+
+/// Arguments for importing a dependency tree captured from a development
+/// sandbox. The sidecars must come from the same capture as the content.
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Existing sealed dependency volume to replace.
+    #[arg(value_name = "VOLUME_HASH")]
+    pub volume_hash: String,
+
+    /// Local directory containing the dependency tree captured from the sandbox.
+    #[arg(long, value_name = "DIR")]
+    pub content_dir: PathBuf,
+
+    /// Fresh CycloneDX SBOM generated for the captured dependency tree.
+    #[arg(long, value_name = "PATH")]
+    pub sbom: PathBuf,
+
+    /// Fetch log generated while installing the captured dependency tree.
+    #[arg(long, value_name = "PATH")]
+    pub fetch_log: PathBuf,
+
+    /// Fresh CVE scan result generated for the captured dependency tree.
+    #[arg(long, value_name = "PATH")]
+    pub cve: PathBuf,
+
+    /// Override the sealed dependency-volume cache root.
+    #[arg(long)]
+    pub cache_root: Option<PathBuf>,
+
+    /// Emit a machine-readable JSON result on stdout.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CaptureOutcome {
+    prior_volume_hash: String,
+    volume_hash: String,
+    lockfile_hash: String,
+    volume_dir: PathBuf,
+}
+
+pub(super) fn run(args: Args) -> Result<()> {
+    let cache_root = mvm_build::app_deps::resolve_cache_root(args.cache_root.as_deref());
+    let outcome = capture_volume(
+        &cache_root,
+        &args.volume_hash,
+        &args.content_dir,
+        &args.sbom,
+        &args.fetch_log,
+        &args.cve,
+    )?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&outcome)?);
+    } else {
+        eprintln!(
+            "captured dependency volume {} -> {} (lockfile_hash {})",
+            outcome.prior_volume_hash, outcome.volume_hash, outcome.lockfile_hash
+        );
+    }
+    Ok(())
+}
+
+fn capture_volume(
+    cache_root: &Path,
+    prior_hash: &str,
+    captured_content: &Path,
+    sbom: &Path,
+    fetch_log: &Path,
+    cve: &Path,
+) -> Result<CaptureOutcome> {
+    validate_volume_hash(prior_hash)?;
+    require_directory(captured_content, "captured content")?;
+    require_file(sbom, "SBOM")?;
+    require_file(fetch_log, "fetch log")?;
+    require_file(cve, "CVE result")?;
+
+    let prior_dir = cache_root.join(prior_hash);
+    let computed = verify_sealed_volume(&prior_dir).with_context(|| {
+        format!(
+            "verifying dependency volume {}; capture refuses tampered input",
+            prior_dir.display()
+        )
+    })?;
+    if computed != prior_hash {
+        bail!(
+            "dependency volume directory {} disagrees with its sealed hash {}",
+            prior_hash,
+            computed
+        );
+    }
+    let prior_manifest = read_manifest(&prior_dir)?;
+    let lockfile_hash = prior_manifest
+        .annotations
+        .get("lockfile_hash")
+        .cloned()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "dependency volume {} has no lockfile_hash annotation; captured dependencies must remain pinned",
+                prior_hash
+            )
+        })?;
+    validate_hash(&lockfile_hash, "lockfile")?;
+
+    let scratch = scratch_dir(cache_root, prior_hash)?;
+    let result = (|| {
+        copy_dir_recursive(captured_content, &scratch.join(FILE_CONTENT_DIR))?;
+        for (source, name) in [
+            (sbom, FILE_SBOM),
+            (fetch_log, FILE_FETCH_LOG),
+            (cve, FILE_CVE),
+        ] {
+            std::fs::copy(source, scratch.join(name))
+                .with_context(|| format!("copying captured {} into scratch volume", name))?;
+        }
+
+        let sealed = reseal_volume(
+            &scratch.join(FILE_CONTENT_DIR),
+            &scratch.join(FILE_SBOM),
+            &scratch.join(FILE_FETCH_LOG),
+            &scratch.join(FILE_CVE),
+            prior_manifest.created_at,
+            Utc::now().to_rfc3339(),
+            prior_manifest.annotations,
+        )?;
+        std::fs::write(scratch.join(FILE_MANIFEST), &sealed.manifest_bytes)
+            .context("writing captured dependency volume manifest")?;
+
+        let new_dir = cache_root.join(&sealed.volume_hash);
+        if new_dir.exists() {
+            let existing = verify_sealed_volume(&new_dir).with_context(|| {
+                format!("verifying existing captured volume {}", new_dir.display())
+            })?;
+            if existing != sealed.volume_hash {
+                bail!(
+                    "existing volume directory {} failed its own sealed-hash check",
+                    new_dir.display()
+                );
+            }
+            std::fs::remove_dir_all(&scratch)
+                .with_context(|| format!("removing scratch volume {}", scratch.display()))?;
+        } else {
+            std::fs::rename(&scratch, &new_dir).with_context(|| {
+                format!(
+                    "publishing captured volume {} as {}",
+                    scratch.display(),
+                    new_dir.display()
+                )
+            })?;
+        }
+
+        refresh_index_pointer(cache_root, &lockfile_hash, &sealed.volume_hash)?;
+        if new_dir != prior_dir {
+            std::fs::remove_dir_all(&prior_dir)
+                .with_context(|| format!("removing prior volume {}", prior_dir.display()))?;
+        }
+        Ok(CaptureOutcome {
+            prior_volume_hash: prior_hash.to_string(),
+            volume_hash: sealed.volume_hash,
+            lockfile_hash,
+            volume_dir: new_dir,
+        })
+    })();
+    if result.is_err() && scratch.exists() {
+        let _ = std::fs::remove_dir_all(&scratch);
+    }
+    result
+}
+
+fn read_manifest(volume_dir: &Path) -> Result<VolumeManifest> {
+    let path = volume_dir.join(FILE_MANIFEST);
+    let bytes = std::fs::read(&path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_slice(&bytes).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn scratch_dir(cache_root: &Path, prior_hash: &str) -> Result<PathBuf> {
+    let root = cache_root.join("in-progress");
+    std::fs::create_dir_all(&root).with_context(|| format!("creating {}", root.display()))?;
+    let scratch = root.join(format!("capture-{prior_hash}.{}", std::process::id()));
+    if scratch.exists() {
+        std::fs::remove_dir_all(&scratch)
+            .with_context(|| format!("removing stale scratch {}", scratch.display()))?;
+    }
+    std::fs::create_dir_all(&scratch)
+        .with_context(|| format!("creating scratch {}", scratch.display()))?;
+    Ok(scratch)
+}
+
+fn validate_volume_hash(value: &str) -> Result<()> {
+    validate_hash(value, "volume")
+}
+
+fn validate_hash(value: &str, label: &str) -> Result<()> {
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("{label} hash must be exactly 64 hexadecimal characters");
+    }
+    Ok(())
+}
+
+fn require_directory(path: &Path, label: &str) -> Result<()> {
+    if !path.is_dir() {
+        bail!("{} directory does not exist: {}", label, path.display());
+    }
+    Ok(())
+}
+
+fn require_file(path: &Path, label: &str) -> Result<()> {
+    if !path.is_file() {
+        bail!("{} file does not exist: {}", label, path.display());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_sdk::compile::deps_audit::seal_volume;
+    use std::collections::BTreeMap;
+    use std::fs;
+
+    const LOCKFILE_HASH: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    fn seed_volume(root: &Path, lockfile_hash: Option<&str>) -> String {
+        let volume = root.join("seed");
+        let content = volume.join(FILE_CONTENT_DIR);
+        fs::create_dir_all(&content).unwrap();
+        fs::write(content.join("installed.txt"), b"old").unwrap();
+        let sbom = volume.join(FILE_SBOM);
+        let fetch = volume.join(FILE_FETCH_LOG);
+        let cve = volume.join(FILE_CVE);
+        fs::write(&sbom, b"old sbom").unwrap();
+        fs::write(&fetch, b"old fetch\n").unwrap();
+        fs::write(&cve, b"{\"results\":[]}").unwrap();
+        let annotations = lockfile_hash
+            .map(|hash| BTreeMap::from([("lockfile_hash".to_string(), hash.to_string())]))
+            .unwrap_or_default();
+        let sealed = seal_volume(
+            &content,
+            &sbom,
+            &fetch,
+            &cve,
+            "2026-08-03T00:00:00Z",
+            annotations,
+        )
+        .unwrap();
+        fs::write(volume.join(FILE_MANIFEST), sealed.manifest_bytes).unwrap();
+        let final_dir = root.join(&sealed.volume_hash);
+        fs::rename(volume, &final_dir).unwrap();
+        if let Some(lockfile_hash) = lockfile_hash {
+            fs::create_dir_all(root.join("index")).unwrap();
+            fs::write(root.join("index").join(lockfile_hash), &sealed.volume_hash).unwrap();
+        }
+        sealed.volume_hash
+    }
+
+    #[test]
+    fn capture_reseals_content_and_refreshes_lockfile_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old_hash = seed_volume(tmp.path(), Some(LOCKFILE_HASH));
+        let captured = tmp.path().join("captured");
+        fs::create_dir_all(&captured).unwrap();
+        fs::write(captured.join("installed.txt"), b"new").unwrap();
+        let sbom = tmp.path().join("sbom.json");
+        let fetch = tmp.path().join("fetch.log");
+        let cve = tmp.path().join("cve.json");
+        fs::write(&sbom, b"new sbom").unwrap();
+        fs::write(&fetch, b"new fetch\n").unwrap();
+        fs::write(&cve, b"{\"results\":[]}").unwrap();
+
+        let outcome =
+            capture_volume(tmp.path(), &old_hash, &captured, &sbom, &fetch, &cve).unwrap();
+        assert_ne!(outcome.prior_volume_hash, outcome.volume_hash);
+        assert!(!tmp.path().join(&old_hash).exists());
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("index").join(LOCKFILE_HASH)).unwrap(),
+            outcome.volume_hash
+        );
+        assert_eq!(
+            verify_sealed_volume(&outcome.volume_dir).unwrap(),
+            outcome.volume_hash
+        );
+    }
+
+    #[test]
+    fn capture_refuses_unpinned_volume() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old_hash = seed_volume(tmp.path(), None);
+        let captured = tmp.path().join("captured");
+        fs::create_dir_all(&captured).unwrap();
+        let sbom = tmp.path().join("sbom.json");
+        let fetch = tmp.path().join("fetch.log");
+        let cve = tmp.path().join("cve.json");
+        fs::write(&sbom, b"sbom").unwrap();
+        fs::write(&fetch, b"fetch\n").unwrap();
+        fs::write(&cve, b"{}").unwrap();
+        assert!(capture_volume(tmp.path(), &old_hash, &captured, &sbom, &fetch, &cve).is_err());
+        assert!(tmp.path().join(&old_hash).exists());
+    }
+
+    #[test]
+    fn capture_refuses_tampered_volume() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old_hash = seed_volume(tmp.path(), Some(LOCKFILE_HASH));
+        fs::write(
+            tmp.path()
+                .join(&old_hash)
+                .join(FILE_CONTENT_DIR)
+                .join("installed.txt"),
+            b"tampered",
+        )
+        .unwrap();
+        let captured = tmp.path().join("captured");
+        fs::create_dir_all(&captured).unwrap();
+        let sbom = tmp.path().join("sbom.json");
+        let fetch = tmp.path().join("fetch.log");
+        let cve = tmp.path().join("cve.json");
+        fs::write(&sbom, b"sbom").unwrap();
+        fs::write(&fetch, b"fetch\n").unwrap();
+        fs::write(&cve, b"{}").unwrap();
+        assert!(capture_volume(tmp.path(), &old_hash, &captured, &sbom, &fetch, &cve).is_err());
+    }
+}

--- a/crates/mvm-cli/src/commands/deps/capture.rs
+++ b/crates/mvm-cli/src/commands/deps/capture.rs
@@ -69,6 +69,13 @@ pub(super) fn run(args: Args) -> Result<()> {
         &args.fetch_log,
         &args.cve,
     )?;
+    mvm_core::audit_emit!(
+        DepsAudit,
+        "prior={},new={},lockfile_hash={}",
+        outcome.prior_volume_hash,
+        outcome.volume_hash,
+        outcome.lockfile_hash,
+    );
     if args.json {
         println!("{}", serde_json::to_string_pretty(&outcome)?);
     } else {

--- a/crates/mvm-cli/src/commands/deps/mod.rs
+++ b/crates/mvm-cli/src/commands/deps/mod.rs
@@ -22,6 +22,7 @@
 //! - `mod.rs` — `Args` / `Action` enum, dispatch, shared types.
 //! - `inspect.rs` — pretty-printer for sealed artifacts.
 //! - `audit.rs` — re-audit logic + `AuditRunner` trait for testing.
+//! - `capture.rs` — import a sandbox capture and publish its resealed volume.
 //!
 //! Cache root resolution always routes through
 //! [`mvm_build::app_deps::resolve_cache_root`] so the supervisor's
@@ -39,6 +40,7 @@ use mvm_core::user_config::MvmConfig;
 use super::Cli;
 
 pub(super) mod audit;
+pub(super) mod capture;
 pub(super) mod inspect;
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -94,6 +96,8 @@ pub(in crate::commands) enum DepsAction {
     /// Bring `pip-audit` / `pnpm` if they aren't already on PATH; the
     /// runner surfaces a clear error pointing at install instructions.
     Audit(audit::Args),
+    /// Capture a sandbox-installed dependency tree and reseal the volume.
+    Capture(capture::Args),
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
@@ -104,5 +108,6 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             json,
         } => inspect::run(&volume_hash, cache_root.as_deref(), json),
         DepsAction::Audit(a) => audit::run(a),
+        DepsAction::Capture(a) => capture::run(a),
     }
 }

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -11,6 +11,7 @@ use super::build::build;
 use super::build::compile;
 use super::build::group as build_group;
 use super::catalog;
+use super::deps;
 use super::dispatch::TopLevelCommand;
 use super::env::group as env_group;
 use super::env::{cleanup, init, uninstall};
@@ -57,6 +58,34 @@ fn top_level_command_summaries_stay_short() {
         "top-level command summaries must be {longest_allowed} chars or shorter:\n{}",
         long_summaries.join("\n")
     );
+}
+
+#[test]
+fn deps_capture_parses_seal_inputs() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "deps",
+        "capture",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "--content-dir",
+        "captured",
+        "--sbom",
+        "sbom.json",
+        "--fetch-log",
+        "fetch.log",
+        "--cve",
+        "cve.json",
+        "--json",
+    ])
+    .unwrap();
+    let Commands::Deps(args) = cli.command else {
+        panic!("expected deps command")
+    };
+    let deps::DepsAction::Capture(capture) = args.action else {
+        panic!("expected deps capture command")
+    };
+    assert_eq!(capture.volume_hash.len(), 64);
+    assert!(capture.json);
 }
 
 #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -6,13 +6,13 @@ This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## In-flight plans
-- [ ] Plan 291 — Develop → build → deploy an attested workload image
+- [~] Plan 291 — Develop → build → deploy an attested workload image
       (`specs/plans/291-develop-build-deploy-attested.md`)
   - [ ] WS1 `mvmctl deploy`: seal, BLAKE3 identity + SHA-256 interop, deploy
         record; ship to mvmd when a remote is configured, else stop at the
         local sealed artifact
   - [ ] WS2 `mvmctl watch`: rebuild on change, skip no-op rebuilds by address
-  - [ ] WS3 capture-from-sandbox via `reseal_volume`, converging on the
+  - [~] WS3 capture-from-sandbox via `reseal_volume`, converging on the
         declared-dependency path and keeping the lockfile hash pin
   - [ ] WS4 tier follows the attestation; retire the `interactive` feature fork
         and replace the symbol-absence witnesses with conformance scenarios

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,10 @@
 
 ## Current issue delivery
 
+- [~] `mvmctl deps capture` — **plan 291 WS3**. Reseals a sandbox-captured
+      dependency tree with fresh audit sidecars, updates the lockfile index,
+      and refuses tampered or unpinned source volumes.
+
 - [~] Sensitive egress redaction — **plan 290**. The first delivery establishes
       a validated byte-span detector contract and supplements the curated
       scanner with LeakGuard's reviewed JWT, URL-credential, full private-key,

--- a/specs/plans/291-develop-build-deploy-attested.md
+++ b/specs/plans/291-develop-build-deploy-attested.md
@@ -99,6 +99,9 @@ WS1 starts.
 
 ### WS3 — capture dependencies from the sandbox
 
+- [~] `mvmctl deps capture` imports a sandbox-installed dependency tree and
+      its fresh SBOM, fetch log, and CVE result, then reseals it atomically
+      through the existing volume verifier and lockfile index.
 - [ ] `install`-into-sandbox during development, then reseal via
       `reseal_volume` to capture it — new volume hash, refreshed SBOM, fresh CVE
       scan.

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -421,6 +421,7 @@ const TRUST_SUB: &[(&str, AuditPosture)] = &[
 const DEPS_SUB: &[(&str, AuditPosture)] = &[
     ("inspect", AuditPosture::ReadOnly),
     ("audit", AuditPosture::Emits("DepsAudit")),
+    ("capture", AuditPosture::Emits("DepsAudit")),
 ];
 
 /// Every top-level `mvmctl` subcommand keyed by its clap name.


### PR DESCRIPTION
## What changed

Add `mvmctl deps capture` to import a dependency tree captured from a development sandbox and publish it as a sealed dependency volume.

The command:

- verifies the existing source volume and requires its 64-hex `lockfile_hash` pin
- copies captured content and fresh SBOM, fetch log, and CVE sidecars into a scratch volume
- reseals the capture with the existing SDK primitive
- publishes the new content-addressed volume and refreshes the lockfile index
- refuses tampered or unpinned source volumes
- includes CLI parsing and focused transaction/security tests

This is the host-side handoff for the sandbox capture; the sandbox install remains dev-only.

## Why

Interactive dependency discovery needs to converge on the same sealed, lockfile-pinned path as declared dependencies. This keeps captured content auditable and prevents an unverified or unpinned volume from entering the cache.

## Validation

- `rustup run nightly cargo fmt --all`
- `rustup run nightly cargo fmt --all -- --check`
- `cargo metadata --no-deps --offline --format-version 1`
- `git diff --check`
- Targeted Cargo compilation was attempted but stalled during dependency compilation because other workspace jobs are contending for the host Cargo/rustc state; no compile or test pass is being claimed.
