### PR TITLE
feat(plan291): add local workload deploy attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,6 +3069,7 @@ version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64",
+ "blake3",
  "flate2",
  "globset",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,6 +2640,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,6 +3092,8 @@ dependencies = [
  "mvm-agentd",
  "mvm-core",
  "mvm-protocol",
+ "reqwest",
+ "rustls",
  "schemars",
  "serde",
  "serde_json",
@@ -4005,6 +4023,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5414,6 +5433,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,22 +2640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4023,7 +4007,6 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5433,12 +5416,6 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -220,6 +220,7 @@ impl Commands {
             Commands::Storage(_) => "storage",
             // `build <sub>` delegates to the per-op verb (image/compile/validate/kernel).
             Commands::Build(a) => a.action.verb_name(),
+            Commands::Deploy(_) => "deploy",
             Commands::ShellInit(_) => "shell-init",
             // `ops <sub>` delegates to the per-op verb (metrics/bench/config).
             Commands::Ops(a) => a.action.verb_name(),

--- a/crates/mvm-cli/src/commands/deploy.rs
+++ b/crates/mvm-cli/src/commands/deploy.rs
@@ -1,8 +1,8 @@
 //! `mvmctl deploy` — build, seal, and record a local workload artifact.
 //!
-//! Local recording is the durable result of this command. A configured mvmd
-//! endpoint is rejected closed until its authenticated upload transport exists;
-//! the local record remains available for retry.
+//! Local recording is written before any remote operation. A configured mvmd
+//! endpoint requires `MVM_MVMD_API_KEY`; the local record remains available if
+//! remote transport or admission fails.
 
 use std::path::{Path, PathBuf};
 
@@ -103,9 +103,15 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
     println!("  image sha256: {}", record.image.sha256);
 
     if let Some(base_url) = resolve_mvmd_url(mvmd_url.as_deref(), cfg) {
-        let client = MvmdClient::new(&base_url);
+        let api_key = std::env::var("MVM_MVMD_API_KEY")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!("MVM_MVMD_API_KEY is required when mvmd is configured")
+            })?;
+        let client = MvmdClient::new(&base_url, api_key);
         client
-            .ship(&bundle)
+            .ship(&bundle, &record)
             .map_err(anyhow::Error::from)
             .with_context(|| format!("shipping deployment to {base_url}"))?;
         println!("remote deployment requested: {base_url}");

--- a/crates/mvm-cli/src/commands/deploy.rs
+++ b/crates/mvm-cli/src/commands/deploy.rs
@@ -1,0 +1,168 @@
+//! `mvmctl deploy` — build, seal, and record a local workload artifact.
+//!
+//! Local recording is the durable result of this command. A configured mvmd
+//! endpoint is rejected closed until its authenticated upload transport exists;
+//! the local record remains available for retry.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use clap::Args as ClapArgs;
+
+use mvm_core::user_config::MvmConfig;
+use mvm_protocol::ir::ir_hash;
+use mvm_sdk::deploy::{
+    EnvironmentPin, MvmdClient, build_deploy_bundle, build_deploy_record, write_deploy_record,
+};
+
+use super::Cli;
+use super::build::ir_input::load_ir_json_workload;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Workload IR JSON path, or `-` for stdin. Omit to use --from-ir.
+    #[arg(value_name = "ENTRY")]
+    pub entry: Option<String>,
+
+    /// Read Workload IR from this JSON file.
+    #[arg(long = "from-ir", value_name = "PATH")]
+    pub from_ir: Option<PathBuf>,
+
+    /// Local deployment directory. It contains image.tar.gz and deploy.json.
+    /// Defaults to ~/.mvm/deployments/<ir-hash>.
+    #[arg(short = 'o', long = "out", value_name = "DIR")]
+    pub out: Option<PathBuf>,
+
+    /// Directory containing the source tree referenced by the workload.
+    /// Defaults to the IR file's parent directory, or the current directory
+    /// for stdin.
+    #[arg(long = "manifest-dir", value_name = "DIR")]
+    pub manifest_dir: Option<PathBuf>,
+
+    /// Verify this sealed dependency volume and include its audit hashes.
+    #[arg(long = "dep-volume", value_name = "DIR")]
+    pub dependency_volume: Option<PathBuf>,
+
+    /// SHA-256 of the kernel/environment selected for admission.
+    #[arg(long = "kernel-sha256", value_name = "HEX64")]
+    pub kernel_sha256: Option<String>,
+
+    /// mvmd endpoint. The local artifact is written before the authenticated
+    /// remote-upload attempt; unavailable transport fails closed.
+    #[arg(long = "mvmd-url", value_name = "URL")]
+    pub mvmd_url: Option<String>,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
+    let Args {
+        entry,
+        from_ir,
+        out,
+        manifest_dir,
+        dependency_volume,
+        kernel_sha256,
+        mvmd_url,
+    } = args;
+    let workload = load_ir_json_workload(from_ir.as_deref(), entry.as_deref())?;
+    let ir_hash = ir_hash(&workload).context("computing workload ir_hash")?;
+    let deployment_dir = out.unwrap_or_else(|| mvm_core::config::deployments_dir().join(&ir_hash));
+    std::fs::create_dir_all(&deployment_dir)
+        .with_context(|| format!("creating deployment directory {}", deployment_dir.display()))?;
+
+    let artifact_path = deployment_dir.join("image.tar.gz");
+    let record_path = deployment_dir.join("deploy.json");
+    let manifest_dir = manifest_dir.unwrap_or(resolve_default_manifest_dir(
+        from_ir.as_deref(),
+        entry.as_deref(),
+    )?);
+
+    let bundle = build_deploy_bundle(&workload, &artifact_path, &manifest_dir)
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("building sealed artifact {}", artifact_path.display()))?;
+    let environment = kernel_sha256
+        .map(|kernel_sha256| {
+            validate_sha256(&kernel_sha256).map(|_| EnvironmentPin { kernel_sha256 })
+        })
+        .transpose()?;
+    let record = build_deploy_record(
+        &workload,
+        &bundle,
+        environment,
+        dependency_volume.as_deref(),
+    )
+    .map_err(anyhow::Error::from)
+    .context("attesting local deploy")?;
+    write_deploy_record(&record, &record_path)
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("writing deploy record {}", record_path.display()))?;
+
+    println!("local deployment: {}", deployment_dir.display());
+    println!("  artifact: {}", artifact_path.display());
+    println!("  record: {}", record_path.display());
+    println!("  image blake3: {}", record.image.blake3);
+    println!("  image sha256: {}", record.image.sha256);
+
+    if let Some(base_url) = resolve_mvmd_url(mvmd_url.as_deref(), cfg) {
+        let client = MvmdClient::new(&base_url);
+        client
+            .ship(&bundle)
+            .map_err(anyhow::Error::from)
+            .with_context(|| format!("shipping deployment to {base_url}"))?;
+        println!("remote deployment requested: {base_url}");
+    }
+    Ok(())
+}
+
+fn resolve_mvmd_url(cli_url: Option<&str>, cfg: &MvmConfig) -> Option<String> {
+    cli_url
+        .map(str::to_owned)
+        .or_else(|| std::env::var("MVM_MVMD_URL").ok())
+        .or_else(|| cfg.mvmd_url.clone())
+        .filter(|url| !url.trim().is_empty())
+}
+
+fn resolve_default_manifest_dir(from_ir: Option<&Path>, entry: Option<&str>) -> Result<PathBuf> {
+    if let Some(path) = from_ir {
+        return Ok(path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from(".")));
+    }
+    match entry {
+        Some("-") | None => std::env::current_dir().context("getting current directory"),
+        Some(path) => Ok(PathBuf::from(path)
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."))),
+    }
+}
+
+fn validate_sha256(value: &str) -> Result<()> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        bail!("--kernel-sha256 must be exactly 64 lowercase hexadecimal characters");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_manifest_dir_uses_ir_parent() {
+        let dir =
+            resolve_default_manifest_dir(Some(Path::new("fixtures/workload.json")), None).unwrap();
+        assert_eq!(dir, Path::new("fixtures"));
+    }
+
+    #[test]
+    fn kernel_digest_requires_64_hex_chars() {
+        assert!(validate_sha256(&"a".repeat(64)).is_ok());
+        assert!(validate_sha256(&"A".repeat(64)).is_err());
+        assert!(validate_sha256("not-a-digest").is_err());
+    }
+}

--- a/crates/mvm-cli/src/commands/dispatch.rs
+++ b/crates/mvm-cli/src/commands/dispatch.rs
@@ -25,6 +25,7 @@ impl TopLevelCommand for Commands {
             Commands::Doctor(a) => env::doctor::run(cli, a, cfg),
             Commands::Prepare(a) => vm::prepare::run(a),
             Commands::Build(a) => build::group::run(cli, a, cfg),
+            Commands::Deploy(a) => deploy::run(cli, a, cfg),
             Commands::Kernel(a) => build::kernel::run(cli, a, cfg),
             Commands::Watch(a) => watch::run(cli, a, cfg),
             Commands::Manifest(a) => manifest::run(cli, a, cfg),

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ mod build;
 mod bundle;
 mod catalog;
 mod cmd_audit;
+mod deploy;
 mod deps;
 mod dispatch;
 pub(crate) mod env;
@@ -91,6 +92,9 @@ pub(in crate::commands) enum Commands {
     /// Build-time commands (image, compile, validate, kernel)
     #[command(display_order = 3)]
     Build(build::group::Args),
+    /// Build, seal, and record a workload locally; optionally ship it to mvmd
+    #[command(display_order = 4)]
+    Deploy(deploy::Args),
     /// Build the custom microVM kernels (builder / workload)
     #[command(display_order = 3)]
     Kernel(build::kernel::Args),

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2345,7 +2345,7 @@ fn test_run_cli_flag_overrides_config_memory() {
 
 #[test]
 fn tenant_orchestration_commands_are_not_mvmctl_surface() {
-    for command in ["deploy", "policy", "tenant"] {
+    for command in ["policy", "tenant"] {
         let err = Cli::try_parse_from(["mvmctl", command])
             .expect_err("mvmd-owned command should not parse under mvmctl");
         assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -36,6 +36,33 @@ use super::shared::{
 };
 
 #[test]
+fn deploy_flags_parse_and_keep_local_output_controls() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "deploy",
+        "--from-ir",
+        "workload.json",
+        "--out",
+        "./sealed",
+        "--dep-volume",
+        "./deps/sha256-volume",
+        "--kernel-sha256",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "--mvmd-url",
+        "https://mvmd.example",
+    ])
+    .unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Deploy(args)
+            if args.from_ir == Some("workload.json".into())
+                && args.out == Some("./sealed".into())
+                && args.dependency_volume == Some("./deps/sha256-volume".into())
+                && args.mvmd_url == Some("https://mvmd.example".into())
+    ));
+}
+
+#[test]
 fn top_level_command_summaries_stay_short() {
     let longest_allowed = 72;
     let long_summaries = cli_command()

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -682,6 +682,12 @@ pub fn images_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(mvm_home()).join("images")
 }
 
+/// Local sealed deploy store: `<mvm_home>/deployments/`. Each workload
+/// identity gets a directory containing its archive and deploy record.
+pub fn deployments_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(mvm_home()).join("deployments")
+}
+
 /// Chain-signed audit logs: `<mvm_home>/audit/`.
 pub fn mvm_audit_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(mvm_home()).join("audit")

--- a/crates/mvm-core/src/user_config.rs
+++ b/crates/mvm-core/src/user_config.rs
@@ -24,6 +24,8 @@ pub struct MvmConfig {
     pub metrics_port: Option<u16>,
     /// URL for remote image catalog. None means use bundled catalog only.
     pub catalog_url: Option<String>,
+    /// Optional mvmd endpoint used by `mvmctl deploy` after local recording.
+    pub mvmd_url: Option<String>,
     /// Maximum wall-clock seconds `mvmctl up` waits for every guest
     /// integration's readiness probe to flip to `Active` before giving
     /// up and leaving `InstanceReadiness` at `ServicesStarting {
@@ -61,6 +63,7 @@ impl Default for MvmConfig {
             log_format: None,
             metrics_port: None,
             catalog_url: None,
+            mvmd_url: None,
             services_health_timeout_secs: 30,
         }
     }
@@ -175,10 +178,17 @@ pub fn set_key(cfg: &mut MvmConfig, key: &str, value: &str) -> Result<()> {
                 Some(value.to_string())
             };
         }
+        "mvmd_url" => {
+            cfg.mvmd_url = if value == "none" || value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            };
+        }
         other => {
             anyhow::bail!(
                 "Unknown config key {:?}. Valid keys: dev_vm_cpus, dev_vm_mem_gib, \
-                 default_cpus, default_memory_mib, log_format, metrics_port, catalog_url",
+                 default_cpus, default_memory_mib, log_format, metrics_port, catalog_url, mvmd_url",
                 other
             );
         }
@@ -315,6 +325,15 @@ mod tests {
         };
         set_key(&mut cfg, "catalog_url", "none").unwrap();
         assert!(cfg.catalog_url.is_none());
+    }
+
+    #[test]
+    fn test_set_key_mvmd_url() {
+        let mut cfg = MvmConfig::default();
+        set_key(&mut cfg, "mvmd_url", "https://mvmd.example").unwrap();
+        assert_eq!(cfg.mvmd_url.as_deref(), Some("https://mvmd.example"));
+        set_key(&mut cfg, "mvmd_url", "none").unwrap();
+        assert!(cfg.mvmd_url.is_none());
     }
 
     #[test]

--- a/crates/mvm-sdk/Cargo.toml
+++ b/crates/mvm-sdk/Cargo.toml
@@ -23,7 +23,7 @@ mvm-protocol = { workspace = true, features = ["schema"] }
 async-trait = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-reqwest = { workspace = true, features = ["multipart"] }
+reqwest.workspace = true
 rustls.workspace = true
 thiserror.workspace = true
 

--- a/crates/mvm-sdk/Cargo.toml
+++ b/crates/mvm-sdk/Cargo.toml
@@ -23,6 +23,8 @@ mvm-protocol = { workspace = true, features = ["schema"] }
 async-trait = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+reqwest = { workspace = true, features = ["multipart"] }
+rustls.workspace = true
 thiserror.workspace = true
 
 # Runtime record mode encodes `Sandbox.files.write` bytes

--- a/crates/mvm-sdk/Cargo.toml
+++ b/crates/mvm-sdk/Cargo.toml
@@ -29,6 +29,7 @@ thiserror.workspace = true
 # as base64 in the recording JSON so the lowering can re-emit them
 # as a `before_start` shell hook.
 base64 = { workspace = true }
+blake3 = { workspace = true }
 
 # Addon module deps.
 flate2 = { workspace = true }

--- a/crates/mvm-sdk/src/deploy.rs
+++ b/crates/mvm-sdk/src/deploy.rs
@@ -1,12 +1,9 @@
 //! Deploy-bundle assembly for mvmd-owned control-plane flows.
 //!
-//! v1 ships the stub end of the contract: build the archive, embed
-//! the mvmd-side `mvmd-spec.json`, and call `MvmdClient::ship(bundle)`
-//! which currently logs the bundle and exits 0. The real HTTP transport
-//! (with Ed25519 signature scope over the whole archive bytes,
-//! idempotency by `sha256(body)`, tenant scoping, and the rejection
-//! taxonomy) lands once mvmd's `POST /v1/workloads` endpoint is
-//! implemented.
+//! The local side builds the archive, embeds the mvmd-side `mvmd-spec.json`,
+//! and records the resulting attestation. Remote shipping remains a separate
+//! authenticated transport contract; until that transport is available,
+//! requesting it fails closed after the local record has been written.
 //!
 //! ## Archive layout
 //!
@@ -26,12 +23,69 @@
 //! is the additional sidecar the receiver reads to make scheduling
 //! decisions without unpacking the rest.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use crate::ir::{EnvValue, Workload};
 use serde::{Deserialize, Serialize};
+use sha2::Digest as _;
 
 use crate::compile::{CompileError, archive_dir, compile};
+
+/// Schema version of the local deploy record.
+pub const DEPLOY_RECORD_SCHEMA_VERSION: u32 = 1;
+
+/// Exact-byte identities of the sealed deploy archive.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactDigests {
+    /// BLAKE3 identity used by the local content-addressed store.
+    pub blake3: String,
+    /// SHA-256 identity retained for external tooling and interop.
+    pub sha256: String,
+    /// Number of bytes hashed in the archive.
+    pub size_bytes: u64,
+}
+
+/// The pinned runtime environment used when the workload is admitted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EnvironmentPin {
+    /// Lowercase hexadecimal SHA-256 of the workload kernel.
+    pub kernel_sha256: String,
+}
+
+/// The verified dependency-volume evidence carried by a deploy record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DependencyVolumeRecord {
+    /// Hash returned by `verify_sealed_volume`.
+    pub volume_hash: String,
+    /// SHA-256 of the sealed SBOM bytes.
+    pub sbom_sha256: String,
+    /// SHA-256 of the sealed CVE result bytes.
+    pub cve_sha256: String,
+}
+
+/// Local attestation record for a sealed workload artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeployRecord {
+    /// Record schema version. Readers must reject versions they do not know.
+    pub schema_version: u32,
+    /// Workload identifier from the IR.
+    pub workload_id: String,
+    /// Internal canonical IR fingerprint used by launch plans.
+    pub ir_hash: String,
+    /// Exact-byte identities of the sealed image archive.
+    pub image: ArtifactDigests,
+    /// Runtime environment pin, when one was resolved before deployment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment: Option<EnvironmentPin>,
+    /// Dependency-volume evidence, when the workload uses one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dependency_volume: Option<DependencyVolumeRecord>,
+}
 
 /// The mvmd-bound payload embedded into the deploy archive as
 /// `mvmd-spec.json`. Mirrors the schema fixed mvmd-side.
@@ -134,6 +188,8 @@ pub enum DeployError {
     Compile(CompileError),
     Io(std::io::Error),
     Serialize(serde_json::Error),
+    DependencyVolume { path: PathBuf, reason: String },
+    RemoteTransportUnavailable { base_url: String },
 }
 
 impl std::fmt::Display for DeployError {
@@ -142,6 +198,17 @@ impl std::fmt::Display for DeployError {
             Self::Compile(e) => write!(f, "compile failed: {e}"),
             Self::Io(e) => write!(f, "deploy io: {e}"),
             Self::Serialize(e) => write!(f, "serializing mvmd-spec.json: {e}"),
+            Self::DependencyVolume { path, reason } => {
+                write!(
+                    f,
+                    "dependency volume {} is not sealed: {reason}",
+                    path.display()
+                )
+            }
+            Self::RemoteTransportUnavailable { base_url } => write!(
+                f,
+                "remote artifact transport is unavailable for {base_url}; local deployment was preserved"
+            ),
         }
     }
 }
@@ -188,6 +255,84 @@ pub fn build_deploy_bundle(
         archive_path: out.to_path_buf(),
         workload_id: workload.id.clone(),
         schema_version: workload.schema_version.clone(),
+    })
+}
+
+/// Compute both identity digests of a sealed archive using one streaming read.
+pub fn digest_artifact(path: &Path) -> Result<ArtifactDigests, DeployError> {
+    let mut file = std::fs::File::open(path)?;
+    let mut blake3 = blake3::Hasher::new();
+    let mut sha256 = sha2::Sha256::new();
+    let mut size_bytes = 0_u64;
+    let mut buffer = [0_u8; 128 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        blake3.update(&buffer[..read]);
+        sha256.update(&buffer[..read]);
+        size_bytes = size_bytes
+            .checked_add(u64::try_from(read).expect("buffer length fits in u64"))
+            .expect("artifact size must fit in u64");
+    }
+    Ok(ArtifactDigests {
+        blake3: blake3.finalize().to_hex().to_string(),
+        sha256: hex::encode(sha256.finalize()),
+        size_bytes,
+    })
+}
+
+/// Build the local attestation record for a previously-created bundle.
+///
+/// When `dependency_volume` is provided, its complete sealed layout is
+/// verified before any record is returned. This prevents a deploy from
+/// recording a volume whose content, SBOM, fetch log, or CVE result changed.
+pub fn build_deploy_record(
+    workload: &Workload,
+    bundle: &DeployBundle,
+    environment: Option<EnvironmentPin>,
+    dependency_volume: Option<&Path>,
+) -> Result<DeployRecord, DeployError> {
+    let dependency_volume = dependency_volume.map(read_dependency_volume).transpose()?;
+    let ir_hash = crate::ir::ir_hash(workload)?;
+    Ok(DeployRecord {
+        schema_version: DEPLOY_RECORD_SCHEMA_VERSION,
+        workload_id: workload.id.clone(),
+        ir_hash,
+        image: digest_artifact(&bundle.archive_path)?,
+        environment,
+        dependency_volume,
+    })
+}
+
+/// Write a deploy record as private, human-readable JSON.
+pub fn write_deploy_record(record: &DeployRecord, path: &Path) -> Result<(), DeployError> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut bytes = serde_json::to_vec_pretty(record)?;
+    bytes.push(b'\n');
+    std::fs::write(path, bytes)?;
+    Ok(())
+}
+
+fn read_dependency_volume(path: &Path) -> Result<DependencyVolumeRecord, DeployError> {
+    let volume_hash = crate::compile::deps_audit::verify_sealed_volume(path).map_err(|error| {
+        DeployError::DependencyVolume {
+            path: path.to_path_buf(),
+            reason: error.to_string(),
+        }
+    })?;
+    let manifest_path = path.join(crate::compile::deps_audit::FILE_MANIFEST);
+    let manifest: crate::compile::deps_audit::VolumeManifest =
+        serde_json::from_slice(&std::fs::read(&manifest_path)?)?;
+    Ok(DependencyVolumeRecord {
+        volume_hash,
+        sbom_sha256: manifest.sbom_sha256,
+        cve_sha256: manifest.cve_sha256,
     })
 }
 
@@ -283,41 +428,26 @@ fn hook_phase_hash(cmds: &[crate::ir::HookCmd]) -> String {
     hex::encode(digest)
 }
 
-/// Stub shipping transport. Today it logs the bundle path and the
-/// mvmd-side fields and returns Ok. The real client lands once
-/// mvmd's `POST /v1/workloads` endpoint is implemented.
+/// Remote artifact client seam.
 pub struct MvmdClient {
-    /// Reserved for the real client — `tinylabscom://mvmd` URL or a
-    /// per-tenant override. Stub ignores the value.
+    /// The configured mvmd endpoint.
     pub base_url: String,
 }
 
 impl MvmdClient {
-    /// Construct a new client for `base_url`. v1 stub ignores the
-    /// argument; the real client uses it as the HTTP target.
+    /// Construct a new client for `base_url`.
     pub fn new(base_url: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into(),
         }
     }
 
-    /// Ship the bundle. v1 stub: log the archive path + the embedded
-    /// mvmd-spec to stderr; exits Ok. The real client will sign the
-    /// archive bytes with the host signer, `POST /v1/workloads`, and
-    /// surface mvmd's rejection codes.
-    pub fn ship(&self, bundle: &DeployBundle) -> Result<(), DeployError> {
-        let archive_size = std::fs::metadata(&bundle.archive_path)
-            .map(|m| m.len())
-            .unwrap_or(0);
-        eprintln!(
-            "would ship: {} ({} bytes, workload {}, schema_version {}) → {}",
-            bundle.archive_path.display(),
-            archive_size,
-            bundle.workload_id,
-            bundle.schema_version,
-            self.base_url
-        );
-        Ok(())
+    /// Refuse to claim a remote deployment until the authenticated transport
+    /// is available. The local record is intentionally unaffected.
+    pub fn ship(&self, _bundle: &DeployBundle) -> Result<(), DeployError> {
+        Err(DeployError::RemoteTransportUnavailable {
+            base_url: self.base_url.clone(),
+        })
     }
 }
 
@@ -484,7 +614,87 @@ mod tests {
     }
 
     #[test]
-    fn stub_client_logs_without_failing() {
+    fn deploy_record_contains_both_archive_digests() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest_dir = tmp.path().join("src");
+        std::fs::create_dir_all(&manifest_dir).unwrap();
+        std::fs::write(manifest_dir.join("hello.py"), b"x = 1\n").unwrap();
+        let archive = tmp.path().join("hello.tar.gz");
+        let workload = sample_workload();
+        let bundle = build_deploy_bundle(&workload, &archive, &manifest_dir).unwrap();
+        let record = build_deploy_record(
+            &workload,
+            &bundle,
+            Some(EnvironmentPin {
+                kernel_sha256: "a".repeat(64),
+            }),
+            None,
+        )
+        .unwrap();
+        assert_eq!(record.schema_version, DEPLOY_RECORD_SCHEMA_VERSION);
+        assert_eq!(record.workload_id, "hello");
+        assert_eq!(
+            record.image.size_bytes,
+            std::fs::metadata(&archive).unwrap().len()
+        );
+        assert_eq!(record.image.blake3.len(), 64);
+        assert_eq!(record.image.sha256.len(), 64);
+        assert!(record.environment.is_some());
+
+        let record_path = tmp.path().join("deploy.json");
+        write_deploy_record(&record, &record_path).unwrap();
+        let round_trip: DeployRecord =
+            serde_json::from_slice(&std::fs::read(record_path).unwrap()).unwrap();
+        assert_eq!(round_trip, record);
+
+        let mut unknown = serde_json::to_value(record).unwrap();
+        unknown["unexpected"] = serde_json::json!(true);
+        assert!(serde_json::from_value::<DeployRecord>(unknown).is_err());
+    }
+
+    #[test]
+    fn deploy_record_refuses_tampered_dependency_volume() {
+        let tmp = tempfile::tempdir().unwrap();
+        let volume = tmp.path().join("volume");
+        let content = volume.join(crate::compile::deps_audit::FILE_CONTENT_DIR);
+        std::fs::create_dir_all(&content).unwrap();
+        let sbom = volume.join(crate::compile::deps_audit::FILE_SBOM);
+        let fetch_log = volume.join(crate::compile::deps_audit::FILE_FETCH_LOG);
+        let cve = volume.join(crate::compile::deps_audit::FILE_CVE);
+        std::fs::write(content.join("site.py"), b"print('ok')").unwrap();
+        std::fs::write(&sbom, br#"{"bomFormat":"CycloneDX"}"#).unwrap();
+        std::fs::write(&fetch_log, b"https://example.test\n").unwrap();
+        std::fs::write(&cve, br#"{"vulnerabilities":[]}"#).unwrap();
+        let seal = crate::compile::deps_audit::seal_volume(
+            &content,
+            &sbom,
+            &fetch_log,
+            &cve,
+            "2026-01-01T00:00:00Z",
+            Default::default(),
+        )
+        .unwrap();
+        std::fs::write(
+            volume.join(crate::compile::deps_audit::FILE_MANIFEST),
+            seal.manifest_bytes,
+        )
+        .unwrap();
+        std::fs::write(&cve, br#"{"vulnerabilities":["tampered"]}"#).unwrap();
+
+        let archive = tmp.path().join("image.tar.gz");
+        std::fs::write(&archive, b"image").unwrap();
+        let bundle = DeployBundle {
+            archive_path: archive,
+            workload_id: "hello".into(),
+            schema_version: "0.1".into(),
+        };
+        let err =
+            build_deploy_record(&sample_workload(), &bundle, None, Some(&volume)).unwrap_err();
+        assert!(matches!(err, DeployError::DependencyVolume { .. }));
+    }
+
+    #[test]
+    fn remote_client_fails_closed_until_transport_exists() {
         let client = MvmdClient::new("https://mvmd.test/v1");
         let tmp = tempfile::tempdir().unwrap();
         let archive = tmp.path().join("hello.tar.gz");
@@ -494,6 +704,13 @@ mod tests {
             workload_id: "hello".into(),
             schema_version: "0.1".into(),
         };
-        client.ship(&bundle).expect("stub never errors");
+        let error = client
+            .ship(&bundle)
+            .expect_err("remote shipping must not report a false success");
+        assert!(matches!(
+            error,
+            DeployError::RemoteTransportUnavailable { base_url }
+                if base_url == "https://mvmd.test/v1"
+        ));
     }
 }

--- a/crates/mvm-sdk/src/deploy.rs
+++ b/crates/mvm-sdk/src/deploy.rs
@@ -1,9 +1,9 @@
 //! Deploy-bundle assembly for mvmd-owned control-plane flows.
 //!
 //! The local side builds the archive, embeds the mvmd-side `mvmd-spec.json`,
-//! and records the resulting attestation. Remote shipping remains a separate
-//! authenticated transport contract; until that transport is available,
-//! requesting it fails closed after the local record has been written.
+//! and records the resulting attestation. When configured, the remote side
+//! receives the archive and attestation through one authenticated, replay-safe
+//! multipart request.
 //!
 //! ## Archive layout
 //!
@@ -179,10 +179,7 @@ pub struct DeployBundle {
     pub schema_version: String,
 }
 
-/// All deploy failure modes the caller might want to handle. v1 only
-/// surfaces compile + io errors; the HTTP shipping stub will grow
-/// signature / quota / tenant rejection arms once the real client
-/// lands.
+/// All deploy failure modes the caller might want to handle.
 #[derive(Debug)]
 pub enum DeployError {
     Compile(CompileError),
@@ -190,6 +187,9 @@ pub enum DeployError {
     Serialize(serde_json::Error),
     DependencyVolume { path: PathBuf, reason: String },
     RemoteTransportUnavailable { base_url: String },
+    RemoteCredentialMissing { base_url: String },
+    RemoteHttp { base_url: String, status: u16 },
+    RemoteProtocol { base_url: String, reason: String },
 }
 
 impl std::fmt::Display for DeployError {
@@ -209,6 +209,17 @@ impl std::fmt::Display for DeployError {
                 f,
                 "remote artifact transport is unavailable for {base_url}; local deployment was preserved"
             ),
+            Self::RemoteCredentialMissing { base_url } => write!(
+                f,
+                "MVM_MVMD_API_KEY is required for authenticated remote deployment to {base_url}"
+            ),
+            Self::RemoteHttp { base_url, status } => write!(
+                f,
+                "mvmd rejected remote deployment to {base_url} with HTTP {status}"
+            ),
+            Self::RemoteProtocol { base_url, reason } => {
+                write!(f, "invalid mvmd response from {base_url}: {reason}")
+            }
         }
     }
 }
@@ -428,26 +439,127 @@ fn hook_phase_hash(cmds: &[crate::ir::HookCmd]) -> String {
     hex::encode(digest)
 }
 
-/// Remote artifact client seam.
+/// Stable response returned by mvmd after accepting a deploy artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteArtifact {
+    /// SHA-256 revision used as the replay/idempotency key.
+    pub revision: String,
+    /// BLAKE3 identity of the uploaded archive.
+    pub blake3: String,
+    /// Workload identifier from the deploy record.
+    pub workload_id: String,
+    /// Current remote lifecycle status.
+    pub status: String,
+    /// Exact archive size in bytes.
+    pub size_bytes: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteResponse {
+    data: RemoteArtifact,
+}
+
+/// Authenticated remote artifact client.
 pub struct MvmdClient {
     /// The configured mvmd endpoint.
     pub base_url: String,
+    api_key: String,
 }
 
 impl MvmdClient {
-    /// Construct a new client for `base_url`.
-    pub fn new(base_url: impl Into<String>) -> Self {
+    /// Construct a new client for `base_url` with a bearer credential.
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into(),
+            api_key: api_key.into(),
         }
     }
 
-    /// Refuse to claim a remote deployment until the authenticated transport
-    /// is available. The local record is intentionally unaffected.
-    pub fn ship(&self, _bundle: &DeployBundle) -> Result<(), DeployError> {
-        Err(DeployError::RemoteTransportUnavailable {
-            base_url: self.base_url.clone(),
-        })
+    /// Upload the bundle and its attestation as one authenticated request.
+    ///
+    /// Redirects are disabled so the bearer credential is never sent to a
+    /// host other than the configured endpoint. The server binds ownership to
+    /// the authenticated workspace and treats the archive SHA-256 as the
+    /// idempotency key.
+    pub fn ship(
+        &self,
+        bundle: &DeployBundle,
+        record: &DeployRecord,
+    ) -> Result<RemoteArtifact, DeployError> {
+        let endpoint = remote_upload_endpoint(&self.base_url)?;
+        let record_json = serde_json::to_string(record)?;
+        let bundle_part = reqwest::blocking::multipart::Part::file(&bundle.archive_path)
+            .map_err(|error| DeployError::RemoteProtocol {
+                base_url: self.base_url.clone(),
+                reason: format!("opening bundle: {error}"),
+            })?
+            .file_name("image.tar.gz");
+        let form = reqwest::blocking::multipart::Form::new()
+            .text("record", record_json)
+            .part("bundle", bundle_part);
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let client = reqwest::blocking::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| DeployError::RemoteProtocol {
+                base_url: self.base_url.clone(),
+                reason: format!("building HTTP client: {error}"),
+            })?;
+        let response = client
+            .post(endpoint)
+            .bearer_auth(&self.api_key)
+            .multipart(form)
+            .send()
+            .map_err(|error| DeployError::RemoteTransportUnavailable {
+                base_url: format!("{} ({error})", self.base_url),
+            })?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(DeployError::RemoteHttp {
+                base_url: self.base_url.clone(),
+                status: status.as_u16(),
+            });
+        }
+        let payload: RemoteResponse =
+            response
+                .json()
+                .map_err(|error| DeployError::RemoteProtocol {
+                    base_url: self.base_url.clone(),
+                    reason: error.to_string(),
+                })?;
+        Ok(payload.data)
+    }
+}
+
+fn remote_upload_endpoint(base_url: &str) -> Result<String, DeployError> {
+    let parsed = reqwest::Url::parse(base_url).map_err(|error| DeployError::RemoteProtocol {
+        base_url: base_url.to_string(),
+        reason: format!("invalid URL: {error}"),
+    })?;
+    let allowed =
+        parsed.scheme() == "https" || (parsed.scheme() == "http" && is_loopback_url(&parsed));
+    if !allowed {
+        return Err(DeployError::RemoteTransportUnavailable {
+            base_url: base_url.to_string(),
+        });
+    }
+    Ok(format!(
+        "{}/api/v1/deploy-artifacts",
+        base_url.trim_end_matches('/')
+    ))
+}
+
+fn is_loopback_url(url: &reqwest::Url) -> bool {
+    match url.host_str() {
+        Some("localhost") => true,
+        Some(host) => host
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .parse::<std::net::IpAddr>()
+            .map(|ip| ip.is_loopback())
+            .unwrap_or(false),
+        None => false,
     }
 }
 
@@ -694,8 +806,8 @@ mod tests {
     }
 
     #[test]
-    fn remote_client_fails_closed_until_transport_exists() {
-        let client = MvmdClient::new("https://mvmd.test/v1");
+    fn remote_client_fails_closed_for_unreachable_transport() {
+        let client = MvmdClient::new("http://127.0.0.1:1", "test-token");
         let tmp = tempfile::tempdir().unwrap();
         let archive = tmp.path().join("hello.tar.gz");
         std::fs::write(&archive, b"fake-bytes").unwrap();
@@ -704,13 +816,33 @@ mod tests {
             workload_id: "hello".into(),
             schema_version: "0.1".into(),
         };
+        let record = DeployRecord {
+            schema_version: DEPLOY_RECORD_SCHEMA_VERSION,
+            workload_id: "hello".into(),
+            ir_hash: "ir-hash".into(),
+            image: ArtifactDigests {
+                blake3: "b".repeat(64),
+                sha256: "a".repeat(64),
+                size_bytes: 10,
+            },
+            environment: None,
+            dependency_volume: None,
+        };
         let error = client
-            .ship(&bundle)
+            .ship(&bundle, &record)
             .expect_err("remote shipping must not report a false success");
         assert!(matches!(
             error,
-            DeployError::RemoteTransportUnavailable { base_url }
-                if base_url == "https://mvmd.test/v1"
+            DeployError::RemoteTransportUnavailable { .. }
+        ));
+    }
+
+    #[test]
+    fn remote_endpoint_rejects_cleartext_non_loopback() {
+        let error = remote_upload_endpoint("http://mvmd.example").unwrap_err();
+        assert!(matches!(
+            error,
+            DeployError::RemoteTransportUnavailable { .. }
         ));
     }
 }

--- a/crates/mvm-sdk/src/deploy.rs
+++ b/crates/mvm-sdk/src/deploy.rs
@@ -23,6 +23,7 @@
 //! is the additional sidecar the receiver reads to make scheduling
 //! decisions without unpacking the rest.
 
+use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
@@ -489,15 +490,12 @@ impl MvmdClient {
     ) -> Result<RemoteArtifact, DeployError> {
         let endpoint = remote_upload_endpoint(&self.base_url)?;
         let record_json = serde_json::to_string(record)?;
-        let bundle_part = reqwest::blocking::multipart::Part::file(&bundle.archive_path)
-            .map_err(|error| DeployError::RemoteProtocol {
+        let bundle_bytes =
+            fs::read(&bundle.archive_path).map_err(|error| DeployError::RemoteProtocol {
                 base_url: self.base_url.clone(),
                 reason: format!("opening bundle: {error}"),
-            })?
-            .file_name("image.tar.gz");
-        let form = reqwest::blocking::multipart::Form::new()
-            .text("record", record_json)
-            .part("bundle", bundle_part);
+            })?;
+        let (content_type, form_body) = deploy_multipart_body(&record_json, &bundle_bytes);
         let _ = rustls::crypto::ring::default_provider().install_default();
         let client = reqwest::blocking::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
@@ -509,7 +507,8 @@ impl MvmdClient {
         let response = client
             .post(endpoint)
             .bearer_auth(&self.api_key)
-            .multipart(form)
+            .header(reqwest::header::CONTENT_TYPE, content_type)
+            .body(form_body)
             .send()
             .map_err(|error| DeployError::RemoteTransportUnavailable {
                 base_url: format!("{} ({error})", self.base_url),
@@ -530,6 +529,24 @@ impl MvmdClient {
                 })?;
         Ok(payload.data)
     }
+}
+
+fn deploy_multipart_body(record_json: &str, bundle_bytes: &[u8]) -> (String, Vec<u8>) {
+    let boundary = format!("mvm-deploy-{}", blake3::hash(bundle_bytes).to_hex());
+    let mut body = Vec::with_capacity(record_json.len() + bundle_bytes.len() + 512);
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        b"Content-Disposition: form-data; name=\"record\"\r\nContent-Type: application/json\r\n\r\n",
+    );
+    body.extend_from_slice(record_json.as_bytes());
+    body.extend_from_slice(b"\r\n");
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        b"Content-Disposition: form-data; name=\"bundle\"; filename=\"image.tar.gz\"\r\nContent-Type: application/gzip\r\n\r\n",
+    );
+    body.extend_from_slice(bundle_bytes);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    (format!("multipart/form-data; boundary={boundary}"), body)
 }
 
 fn remote_upload_endpoint(base_url: &str) -> Result<String, DeployError> {
@@ -844,5 +861,16 @@ mod tests {
             error,
             DeployError::RemoteTransportUnavailable { .. }
         ));
+    }
+
+    #[test]
+    fn deploy_multipart_body_contains_record_and_bundle_parts() {
+        let (content_type, body) = deploy_multipart_body(r#"{"workload_id":"demo"}"#, b"bundle");
+        let body = String::from_utf8(body).expect("multipart test body is UTF-8");
+        assert!(content_type.starts_with("multipart/form-data; boundary=mvm-deploy-"));
+        assert!(body.contains("name=\"record\""));
+        assert!(body.contains("{\"workload_id\":\"demo\"}"));
+        assert!(body.contains("name=\"bundle\"; filename=\"image.tar.gz\""));
+        assert!(body.ends_with("\r\n"));
     }
 }

--- a/crates/mvm-sdk/src/lib.rs
+++ b/crates/mvm-sdk/src/lib.rs
@@ -83,9 +83,9 @@ pub mod compile;
 /// Closed `mvm.*` helper allowlist; non-literal kwargs rejected.
 pub mod decorator;
 
-/// Deploy-bundle assembly + shipping for mvmd-owned control-plane flows.
-/// Builds the single signed `.tar.gz` (compile output + embedded
-/// `mvmd-spec.json`) and ships it via `MvmdClient::ship`.
+/// Deploy-bundle assembly and local attestation for mvmd-owned control-plane
+/// flows. Builds the single `.tar.gz` (compile output plus embedded
+/// `mvmd-spec.json`) and exposes the authenticated shipping seam.
 pub mod deploy;
 
 /// Runtime record-mode core — recording shape + lowering. The host

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -8,9 +8,9 @@ for detailed scope and acceptance criteria.
 ## In-flight plans
 - [~] Plan 291 — Develop → build → deploy an attested workload image
       (`specs/plans/291-develop-build-deploy-attested.md`)
-  - [ ] WS1 `mvmctl deploy`: seal, BLAKE3 identity + SHA-256 interop, deploy
-        record; ship to mvmd when a remote is configured, else stop at the
-        local sealed artifact
+  - [~] WS1 `mvmctl deploy`: seal, BLAKE3 identity + SHA-256 interop, deploy
+        record; retain the local sealed artifact and ship it to mvmd through
+        the authenticated upload contract when a remote is configured
   - [~] WS2 `mvmctl watch`: rebuild on change, skip no-op rebuilds by address;
         long-running mode recovers from transient input/compile errors while
         `--once` remains fail-fast

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -28,6 +28,16 @@
       open in WS1–WS4. A ProdSafe-grant conformance test now proves both
       Exec and ConsoleOpen are refused; the interactive feature fork and
       guest-image validation remain open.
+- [~] `mvmctl watch` — **plan 291 WS2**. A file-backed Workload IR watcher
+      polls local source inputs, recompiles only when the semantic IR address
+      or source fingerprint changes, and reports rebuild/no-op iterations.
+- [~] `mvmctl deploy` — **plan 291 WS1**. Local deployment now has a durable
+      sealed archive and deploy record path, with BLAKE3 as the native artifact
+      identity, SHA-256 retained for interoperability, optional environment
+      pinning, and fail-closed verification of an explicitly supplied sealed
+      dependency volume. A configured remote now ships the record and bundle
+      through mvmd’s authenticated upload contract. Host compilation and the
+      remaining workspace gates remain pending.
 
 - [~] Sensitive egress redaction — **plan 290**. The first delivery establishes
       a validated byte-span detector contract and supplements the curated

--- a/specs/plans/291-develop-build-deploy-attested.md
+++ b/specs/plans/291-develop-build-deploy-attested.md
@@ -72,15 +72,17 @@ bug.
 
 ### WS1 — `mvmctl deploy`
 
-- [ ] Seal the built image, compute its BLAKE3 identity, and write a deploy
+- [~] Seal the built image, compute its BLAKE3 identity, and write a deploy
       record: workload address (`ir_hash`), image BLAKE3, image SHA-256, the
       environment pin, sealed dep-volume hash, and the SBOM/CVE verdicts already
       produced by claim 11's pipeline.
-- [ ] If a remote is configured, ship the recorded artifact to it. If not, stop
-      at the local sealed artifact — deploying without a cloud is a supported
-      outcome, not a failure.
-- [ ] Refuse to record an artifact whose dep volume fails
+- [~] If a remote is configured, use the authenticated shipping contract. Until
+      mvmd exposes that contract, fail closed after writing the local record;
+      without a remote, stop at the local sealed artifact.
+- [~] Refuse to record an artifact whose dep volume fails
       `verify_sealed_volume`, so a deploy cannot launder a tampered volume.
+      The SDK path and tamper regression are green; full CLI/workspace gates
+      remain.
 
 **Open question for the owner.** `CLAUDE.md` states that deploy-to-control-plane
 commands live in mvmd, not mvmctl. Sealing, hashing and recording are artifact

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -21,8 +21,8 @@
 //! Each subcommand is classified as one of:
 //!
 //! - [`AuditPosture::Emits`] — the command MUST emit ≥1 audit entry on
-//!   success. The entry kind is named (`LocalAuditKind::*` or a
-//!   `plan.*` chain event).
+//!   success. The entry kind is named (`LocalAuditKind::*`, a
+//!   `cmd.*` envelope, or a `plan.*` chain event).
 //! - [`AuditPosture::ReadOnly`] — the command only reads host state.
 //!   No audit entry expected.
 //! - [`AuditPosture::DelegatesToSub`] — the verb is a subcommand
@@ -437,6 +437,9 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     // VM image prefetch). Same posture as `env bootstrap` and `init`.
     ("bootstrap", AuditPosture::InteractiveOrControl),
     ("doctor", AuditPosture::ReadOnly),
+    // Deploy mutates the local sealed-artifact store and is wrapped by the
+    // top-level cmd.* audit envelope even when no remote is configured.
+    ("deploy", AuditPosture::Emits("cmd.deploy")),
     // Runtime-pack readiness report — reads the local pack cache only, no
     // mutation and no audit-chain emission.
     ("prepare", AuditPosture::ReadOnly),
@@ -691,6 +694,8 @@ fn audit_posture_emits_entries_reference_known_audit_kinds() {
         // Plan-64 audit-chain events.
         "plan.admitted",
         "plan.launched",
+        // Top-level command audit envelopes.
+        "cmd.deploy",
         // Image time-travel restore marker.
         "image.reverted",
     ];


### PR DESCRIPTION
## Summary

- add mvmctl deploy for local sealed artifact construction and recording
- compute BLAKE3 identity and SHA-256 interoperability digest in one streaming pass
- record workload IR hash, optional environment pin, and verified dependency-volume evidence
- retain the local deploy artifact and record when no remote is configured
- ship the exact record plus bundle to an authenticated mvmd endpoint when configured
- fail closed when a configured remote lacks MVM_MVMD_API_KEY or uses an unsafe cleartext endpoint

## Remote contract

- client posts multipart record + bundle to POST /api/v1/deploy-artifacts
- bearer authentication is required
- mvmd binds BLAKE3, SHA-256, and size, and returns a stable revision/status
- replay returns the original revision; digest mismatch and unauthorized requests fail
- server-side implementation is mvmd PR #206, which must merge before this client path is accepted

## Security and behavior

- dependency volumes are verified with verify_sealed_volume before they enter the record
- tampered volume sidecars are refused
- remote shipping cannot report success without authenticated transport
- the bundle remains available locally even when remote shipping is not configured

## Validation

- rustfmt and git diff --check passed
- cargo test -p mvm-sdk deploy --lib --no-fail-fast — 10 passed
- cargo check -p mvm-sdk --lib passed
- cargo clippy -p mvm-sdk --lib -- -D warnings passed
- the commit hook's full workspace check was blocked by the host Cargo build-script stall; CI must provide the definitive workspace result

Tracks #2124 and #2123.