### PR TITLE
feat(plan291): capture dependencies from development sandboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,12 @@ What that looks like today:
 ```bash
 mvmctl build compile app.py --out ./out   # declared deps; lockfiles must be hash-pinned
 mvmctl machine build --flake ./out        # installs deps into a SEALED volume
+mvmctl deps install --lockfile uv.lock --language python  # dev install + seal
+mvmctl deps capture-live HASH --vm dev-vm \
+  --guest-content /mvm/deps/content \
+  --guest-sbom /mvm/deps/sbom.cdx.json \
+  --guest-fetch-log /mvm/deps/fetch.log \
+  --guest-cve /mvm/deps/cve.json              # export + reseal
 mvmctl deps inspect                       # SBOM + CVE + hash-chained meta, no VM needed
 mvmctl machine run --entrypoint --flake ./out
 ```
@@ -261,8 +267,8 @@ verifies that volume before launch and refuses a tampered one, and `--prod`
 fails closed on high/critical findings or a stub SBOM. A lockfile entry with no
 integrity hash is rejected at compile time.
 
-`mvmctl deploy`, `mvmctl watch`, and capturing a dependency you installed inside
-a dev sandbox are **designed but not yet built** — see
+`mvmctl deploy`, `mvmctl watch`, and the remaining attested-image steps are
+**designed but not yet built** — see
 [plan 291](specs/plans/291-develop-build-deploy-attested.md). Until they land,
 the declared route above is the supported way to get a dependency into an
 attested workload.

--- a/crates/mvm-build/src/app_deps.rs
+++ b/crates/mvm-build/src/app_deps.rs
@@ -295,38 +295,75 @@ pub trait InstallDriver {
     ) -> Result<BuilderArtifacts, BuilderVmError>;
 }
 
-/// Blanket impl: any [`BuilderVm`] is also an [`InstallDriver`].
-/// The driver wraps the `BuilderJob::Install` call with the
-/// canonical mount layout (source_root → `/work`, artifact_out
-/// → `/out`). Host-Nix store reuse is intentionally absent for
-/// install jobs — uv / pnpm don't touch `/nix/store`.
-impl<T: BuilderVm> InstallDriver for T {
+/// Adapter that exposes a dynamically selected builder as an install driver.
+///
+/// Builder selection returns a trait object because the backend is chosen at
+/// runtime. Keeping this adapter beside the install contract avoids requiring
+/// callers to know the concrete builder type or to duplicate the canonical
+/// install mount layout.
+pub struct BuilderInstallDriver<'a> {
+    builder: &'a dyn BuilderVm,
+}
+
+impl<'a> BuilderInstallDriver<'a> {
+    /// Wrap a dynamically selected builder for [`install_app_deps`].
+    pub fn new(builder: &'a dyn BuilderVm) -> Self {
+        Self { builder }
+    }
+}
+
+impl InstallDriver for BuilderInstallDriver<'_> {
     fn run_install(
         &self,
         spec_path: &Path,
         source_root: &Path,
         artifact_out: &Path,
     ) -> Result<BuilderArtifacts, BuilderVmError> {
-        let job = BuilderJob::Install {
-            spec_path: spec_path.to_path_buf(),
-        };
-        // Install jobs don't embed host-vm binaries into a rootfs, so
-        // host_bin_dir is unused. Use a private temp dir as a valid
-        // placeholder so validate_mounts passes.
-        let _host_bins_tmp = tempfile::TempDir::new().map_err(|e| {
-            BuilderVmError::ExtractionFailed(format!("creating temp host_bin_dir: {e}"))
-        })?;
-        let mounts = BuilderMounts {
-            flake_src: source_root.to_path_buf(),
-            host_nix_store: None,
-            artifact_out: artifact_out.to_path_buf(),
-            host_bin_dir: _host_bins_tmp.path().to_path_buf(),
-            // App-dep installs stage an install spec, not a user flake; no
-            // mvm override applies.
-            staged_user_flake: None,
-        };
-        self.run_build(&job, &mounts)
+        run_install_with_builder(self.builder, spec_path, source_root, artifact_out)
     }
+}
+
+/// Blanket impl: any [`BuilderVm`] is also an [`InstallDriver`].
+/// The driver wraps the `BuilderJob::Install` call with the
+/// canonical mount layout (source_root → `/work`, artifact_out
+/// → `/out`). Host-Nix store reuse is intentionally absent for
+/// install jobs — uv / pnpm don't touch `/nix/store`.
+impl<T: BuilderVm + ?Sized> InstallDriver for T {
+    fn run_install(
+        &self,
+        spec_path: &Path,
+        source_root: &Path,
+        artifact_out: &Path,
+    ) -> Result<BuilderArtifacts, BuilderVmError> {
+        run_install_with_builder(self, spec_path, source_root, artifact_out)
+    }
+}
+
+fn run_install_with_builder<T: BuilderVm + ?Sized>(
+    builder: &T,
+    spec_path: &Path,
+    source_root: &Path,
+    artifact_out: &Path,
+) -> Result<BuilderArtifacts, BuilderVmError> {
+    let job = BuilderJob::Install {
+        spec_path: spec_path.to_path_buf(),
+    };
+    // Install jobs don't embed host-vm binaries into a rootfs, so
+    // host_bin_dir is unused. Use a private temp dir as a valid
+    // placeholder so validate_mounts passes.
+    let _host_bins_tmp = tempfile::TempDir::new().map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("creating temp host_bin_dir: {e}"))
+    })?;
+    let mounts = BuilderMounts {
+        flake_src: source_root.to_path_buf(),
+        host_nix_store: None,
+        artifact_out: artifact_out.to_path_buf(),
+        host_bin_dir: _host_bins_tmp.path().to_path_buf(),
+        // App-dep installs stage an install spec, not a user flake; no
+        // mvm override applies.
+        staged_user_flake: None,
+    };
+    builder.run_build(&job, &mounts)
 }
 
 /// Resolve a deps install for `spec`. Cache-hit path is pure I/O
@@ -485,6 +522,10 @@ fn run_install_via_driver(
     let mut annotations = BTreeMap::new();
     annotations.insert("language".to_string(), spec.language.token().to_string());
     annotations.insert("gate".to_string(), spec.gate.token().to_string());
+    annotations.insert(
+        "lockfile_relative_path".to_string(),
+        lockfile_relative_path(spec).to_string_lossy().into_owned(),
+    );
     annotations.insert("lockfile_sha256".to_string(), lockfile_sha256.to_string());
     annotations.insert("lockfile_hash".to_string(), lockfile_hash.to_string());
     let created_at = Utc::now().to_rfc3339();
@@ -556,20 +597,21 @@ fn install_spec_json(spec: &InstallSpec) -> String {
         // an absolute lockfile that isn't under source_root we
         // fall back to the bare file name (rare but possible
         // for callers that constructed `spec.lockfile` manually).
-        path = json_string_escape(
-            &spec
-                .lockfile
-                .strip_prefix(&spec.source_root)
-                .map(Path::to_path_buf)
-                .unwrap_or_else(|_| spec
-                    .lockfile
-                    .file_name()
-                    .map(PathBuf::from)
-                    .unwrap_or_default())
-                .to_string_lossy()
-        ),
+        path = json_string_escape(&lockfile_relative_path(spec).to_string_lossy()),
         gate = spec.gate.token(),
     )
+}
+
+fn lockfile_relative_path(spec: &InstallSpec) -> PathBuf {
+    spec.lockfile
+        .strip_prefix(&spec.source_root)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|_| {
+            spec.lockfile
+                .file_name()
+                .map(PathBuf::from)
+                .unwrap_or_default()
+        })
 }
 
 /// JSON-string escaper matching the one in
@@ -689,6 +731,18 @@ mod tests {
     //! exercise the public API.
     use super::*;
 
+    struct FailingBuilder;
+
+    impl BuilderVm for FailingBuilder {
+        fn run_build(
+            &self,
+            _job: &BuilderJob,
+            _mounts: &BuilderMounts,
+        ) -> Result<BuilderArtifacts, BuilderVmError> {
+            Err(BuilderVmError::NotYetImplemented)
+        }
+    }
+
     #[test]
     fn lockfile_hash_differs_across_languages() {
         let h_py = derive_lockfile_hash("aa", Language::Python, GateLevel::Dev);
@@ -714,5 +768,19 @@ mod tests {
     fn resolve_cache_root_prefers_override() {
         let p = PathBuf::from("/tmp/forced");
         assert_eq!(resolve_cache_root(Some(&p)), p);
+    }
+
+    #[test]
+    fn dynamic_builder_install_adapter_delegates_to_builder() {
+        let builder = FailingBuilder;
+        let adapter = BuilderInstallDriver::new(&builder);
+        let error = adapter
+            .run_install(
+                Path::new("spec.json"),
+                Path::new("source"),
+                Path::new("out"),
+            )
+            .expect_err("the fixture builder must be called");
+        assert!(matches!(error, BuilderVmError::NotYetImplemented));
     }
 }

--- a/crates/mvm-cli/src/commands/deps/capture.rs
+++ b/crates/mvm-cli/src/commands/deps/capture.rs
@@ -69,7 +69,7 @@ pub(super) fn run(args: Args) -> Result<()> {
         &args.fetch_log,
         &args.cve,
     )?;
-    mvm_core::audit_emit!(
+ mvm_core::audit_emit!(
         DepsAudit,
         "prior={},new={},lockfile_hash={}",
         outcome.prior_volume_hash,

--- a/crates/mvm-cli/src/commands/deps/capture.rs
+++ b/crates/mvm-cli/src/commands/deps/capture.rs
@@ -3,18 +3,23 @@
 //! The sandbox install itself remains a dev-only operation. This command owns
 //! the host-side handoff: it copies captured content and fresh audit sidecars
 //! into a scratch volume, reseals them, and atomically publishes the new hash
-//! under the existing lockfile index entry.
+//! under the existing lockfile index entry. When the original lockfile is
+//! supplied, it can also emit the same dependency declaration shape consumed
+//! by the workload IR.
 
 use anyhow::{Context, Result, bail};
 use chrono::Utc;
 use clap::Args as ClapArgs;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
+use mvm_build::app_deps::{GateLevel, Language, derive_lockfile_hash};
 use mvm_sdk::compile::deps_audit::{
     FILE_CONTENT_DIR, FILE_CVE, FILE_FETCH_LOG, FILE_MANIFEST, FILE_SBOM, VolumeManifest,
     reseal_volume, verify_sealed_volume,
 };
+use mvm_sdk::ir::{Dependencies, NodeTool, PythonTool};
 
 use super::audit::{copy_dir_recursive, refresh_index_pointer};
 
@@ -49,26 +54,148 @@ pub(in crate::commands) struct Args {
     /// Emit a machine-readable JSON result on stdout.
     #[arg(long)]
     pub json: bool,
+
+    /// Write the captured dependency declaration as the canonical SDK/IR
+    /// dependency object. The file is safe to commit alongside the workload.
+    #[arg(long, value_name = "PATH", requires = "lockfile")]
+    pub declaration: Option<PathBuf>,
+
+    /// Lockfile whose bytes must match the sealed volume's recorded SHA-256.
+    #[arg(long, value_name = "PATH", requires = "declaration")]
+    pub lockfile: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct CaptureOutcome {
-    prior_volume_hash: String,
-    volume_hash: String,
-    lockfile_hash: String,
-    volume_dir: PathBuf,
+pub(in crate::commands::deps) struct CaptureOutcome {
+    pub prior_volume_hash: String,
+    pub volume_hash: String,
+    pub lockfile_hash: String,
+    pub volume_dir: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub declaration: Option<PathBuf>,
+}
+
+/// Inputs for one atomic dependency-volume capture.
+#[derive(Debug)]
+pub(in crate::commands::deps) struct CaptureRequest<'a> {
+    cache_root: &'a Path,
+    prior_hash: &'a str,
+    captured_content: &'a Path,
+    sbom: &'a Path,
+    fetch_log: &'a Path,
+    cve: &'a Path,
+    declaration_path: Option<&'a Path>,
+    lockfile_path: Option<&'a Path>,
+}
+
+/// Builder for [`CaptureRequest`].
+pub(in crate::commands::deps) struct CaptureRequestBuilder<'a> {
+    cache_root: Option<&'a Path>,
+    prior_hash: Option<&'a str>,
+    captured_content: Option<&'a Path>,
+    sbom: Option<&'a Path>,
+    fetch_log: Option<&'a Path>,
+    cve: Option<&'a Path>,
+    declaration_path: Option<&'a Path>,
+    lockfile_path: Option<&'a Path>,
+}
+
+impl<'a> CaptureRequest<'a> {
+    /// Start building a capture request.
+    pub(in crate::commands::deps) fn builder() -> CaptureRequestBuilder<'a> {
+        CaptureRequestBuilder {
+            cache_root: None,
+            prior_hash: None,
+            captured_content: None,
+            sbom: None,
+            fetch_log: None,
+            cve: None,
+            declaration_path: None,
+            lockfile_path: None,
+        }
+    }
+}
+
+impl<'a> CaptureRequestBuilder<'a> {
+    pub(in crate::commands::deps) fn cache_root(mut self, value: &'a Path) -> Self {
+        self.cache_root = Some(value);
+        self
+    }
+
+    pub(in crate::commands::deps) fn prior_hash(mut self, value: &'a str) -> Self {
+        self.prior_hash = Some(value);
+        self
+    }
+
+    pub(in crate::commands::deps) fn captured_content(mut self, value: &'a Path) -> Self {
+        self.captured_content = Some(value);
+        self
+    }
+
+    pub(in crate::commands::deps) fn sbom(mut self, value: &'a Path) -> Self {
+        self.sbom = Some(value);
+        self
+    }
+
+    pub(in crate::commands::deps) fn fetch_log(mut self, value: &'a Path) -> Self {
+        self.fetch_log = Some(value);
+        self
+    }
+
+    pub(in crate::commands::deps) fn cve(mut self, value: &'a Path) -> Self {
+        self.cve = Some(value);
+        self
+    }
+
+    pub(in crate::commands::deps) fn declaration_path(mut self, value: Option<&'a Path>) -> Self {
+        self.declaration_path = value;
+        self
+    }
+
+    pub(in crate::commands::deps) fn lockfile_path(mut self, value: Option<&'a Path>) -> Self {
+        self.lockfile_path = value;
+        self
+    }
+
+    pub(in crate::commands::deps) fn build(self) -> Result<CaptureRequest<'a>> {
+        Ok(CaptureRequest {
+            cache_root: self
+                .cache_root
+                .ok_or_else(|| anyhow::anyhow!("capture cache root is required"))?,
+            prior_hash: self
+                .prior_hash
+                .ok_or_else(|| anyhow::anyhow!("capture prior volume hash is required"))?,
+            captured_content: self
+                .captured_content
+                .ok_or_else(|| anyhow::anyhow!("captured content directory is required"))?,
+            sbom: self
+                .sbom
+                .ok_or_else(|| anyhow::anyhow!("capture SBOM path is required"))?,
+            fetch_log: self
+                .fetch_log
+                .ok_or_else(|| anyhow::anyhow!("capture fetch log path is required"))?,
+            cve: self
+                .cve
+                .ok_or_else(|| anyhow::anyhow!("capture CVE path is required"))?,
+            declaration_path: self.declaration_path,
+            lockfile_path: self.lockfile_path,
+        })
+    }
 }
 
 pub(super) fn run(args: Args) -> Result<()> {
     let cache_root = mvm_build::app_deps::resolve_cache_root(args.cache_root.as_deref());
-    let outcome = capture_volume(
-        &cache_root,
-        &args.volume_hash,
-        &args.content_dir,
-        &args.sbom,
-        &args.fetch_log,
-        &args.cve,
-    )?;
+    let request = CaptureRequest::builder()
+        .cache_root(&cache_root)
+        .prior_hash(&args.volume_hash)
+        .captured_content(&args.content_dir)
+        .sbom(&args.sbom)
+        .fetch_log(&args.fetch_log)
+        .cve(&args.cve)
+        .declaration_path(args.declaration.as_deref())
+        .lockfile_path(args.lockfile.as_deref())
+        .build()?;
+    let outcome = capture_volume(request)?;
     mvm_core::audit_emit!(
         DepsAudit,
         "prior={},new={},lockfile_hash={}",
@@ -87,14 +214,19 @@ pub(super) fn run(args: Args) -> Result<()> {
     Ok(())
 }
 
-fn capture_volume(
-    cache_root: &Path,
-    prior_hash: &str,
-    captured_content: &Path,
-    sbom: &Path,
-    fetch_log: &Path,
-    cve: &Path,
+pub(in crate::commands::deps) fn capture_volume(
+    request: CaptureRequest<'_>,
 ) -> Result<CaptureOutcome> {
+    let CaptureRequest {
+        cache_root,
+        prior_hash,
+        captured_content,
+        sbom,
+        fetch_log,
+        cve,
+        declaration_path,
+        lockfile_path,
+    } = request;
     validate_volume_hash(prior_hash)?;
     require_directory(captured_content, "captured content")?;
     require_file(sbom, "SBOM")?;
@@ -127,6 +259,14 @@ fn capture_volume(
             )
         })?;
     validate_hash(&lockfile_hash, "lockfile")?;
+    let declaration = match (declaration_path, lockfile_path) {
+        (Some(path), Some(lockfile)) => {
+            validate_declaration_target(path, lockfile, cache_root)?;
+            Some((path, build_declaration(&prior_manifest, lockfile)?))
+        }
+        (None, None) => None,
+        _ => bail!("--declaration and --lockfile must be supplied together"),
+    };
 
     let scratch = scratch_dir(cache_root, prior_hash)?;
     let result = (|| {
@@ -180,17 +320,189 @@ fn capture_volume(
             std::fs::remove_dir_all(&prior_dir)
                 .with_context(|| format!("removing prior volume {}", prior_dir.display()))?;
         }
+        if let Some((path, declaration)) = declaration {
+            write_declaration(path, &declaration)?;
+        }
         Ok(CaptureOutcome {
             prior_volume_hash: prior_hash.to_string(),
             volume_hash: sealed.volume_hash,
             lockfile_hash,
             volume_dir: new_dir,
+            declaration: declaration_path.map(Path::to_path_buf),
         })
     })();
     if result.is_err() && scratch.exists() {
         let _ = std::fs::remove_dir_all(&scratch);
     }
     result
+}
+
+fn validate_declaration_target(
+    declaration: &Path,
+    lockfile: &Path,
+    cache_root: &Path,
+) -> Result<()> {
+    let declaration_target = canonical_target(declaration)?;
+    let lockfile_target = std::fs::canonicalize(lockfile)
+        .with_context(|| format!("resolving lockfile {}", lockfile.display()))?;
+    if declaration_target == lockfile_target {
+        bail!(
+            "declaration path {} must not overwrite the lockfile {}",
+            declaration.display(),
+            lockfile.display()
+        );
+    }
+
+    let cache_target = std::fs::canonicalize(cache_root)
+        .with_context(|| format!("resolving dependency cache {}", cache_root.display()))?;
+    if declaration_target.starts_with(&cache_target) {
+        bail!(
+            "declaration path {} must be outside the dependency cache {}",
+            declaration.display(),
+            cache_root.display()
+        );
+    }
+    Ok(())
+}
+
+fn canonical_target(path: &Path) -> Result<std::path::PathBuf> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let name = path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("declaration path must name a file"))?;
+    Ok(std::fs::canonicalize(parent)
+        .with_context(|| format!("resolving declaration parent {}", parent.display()))?
+        .join(name))
+}
+
+fn build_declaration(manifest: &VolumeManifest, lockfile: &Path) -> Result<Dependencies> {
+    require_file(lockfile, "lockfile")?;
+    let expected_sha256 = annotation(&manifest.annotations, "lockfile_sha256")?;
+    validate_hash(expected_sha256, "lockfile SHA-256")?;
+    let actual_sha256 = sha256_file(lockfile)?;
+    if actual_sha256 != expected_sha256 {
+        bail!(
+            "lockfile {} does not match sealed SHA-256: expected {}, got {}",
+            lockfile.display(),
+            expected_sha256,
+            actual_sha256
+        );
+    }
+
+    let language = parse_language(annotation(&manifest.annotations, "language")?)?;
+    let gate = parse_gate(annotation(&manifest.annotations, "gate")?)?;
+    let expected_lockfile_hash = derive_lockfile_hash(&actual_sha256, language, gate);
+    let recorded_lockfile_hash = annotation(&manifest.annotations, "lockfile_hash")?;
+    if expected_lockfile_hash != recorded_lockfile_hash {
+        bail!(
+            "lockfile {} does not match sealed lockfile hash: expected {}, got {}",
+            lockfile.display(),
+            recorded_lockfile_hash,
+            expected_lockfile_hash
+        );
+    }
+
+    let relative_path = annotation(&manifest.annotations, "lockfile_relative_path")?;
+    let relative = Path::new(relative_path);
+    if relative.as_os_str().is_empty()
+        || relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        bail!("sealed lockfile_relative_path must be relative and must not contain `..`");
+    }
+
+    match language {
+        Language::Python => Ok(Dependencies::Python {
+            lockfile: relative_path.to_string(),
+            tool: python_tool(relative),
+        }),
+        Language::Node => Ok(Dependencies::Node {
+            lockfile: relative_path.to_string(),
+            tool: node_tool(relative),
+        }),
+    }
+}
+
+fn annotation<'a>(
+    annotations: &'a std::collections::BTreeMap<String, String>,
+    key: &str,
+) -> Result<&'a str> {
+    annotations
+        .get(key)
+        .map(String::as_str)
+        .ok_or_else(|| anyhow::anyhow!("sealed volume has no {key} annotation"))
+}
+
+fn parse_language(value: &str) -> Result<Language> {
+    match value {
+        "python" => Ok(Language::Python),
+        "node" => Ok(Language::Node),
+        other => bail!("unsupported dependency language annotation `{other}`"),
+    }
+}
+
+fn parse_gate(value: &str) -> Result<GateLevel> {
+    match value {
+        "dev" => Ok(GateLevel::Dev),
+        "prod" => Ok(GateLevel::Prod),
+        other => bail!("unsupported dependency gate annotation `{other}`"),
+    }
+}
+
+fn python_tool(path: &Path) -> PythonTool {
+    match path.file_name().and_then(|name| name.to_str()) {
+        Some("requirements.txt") => PythonTool::PipTools,
+        _ => PythonTool::Uv,
+    }
+}
+
+fn node_tool(path: &Path) -> NodeTool {
+    match path.file_name().and_then(|name| name.to_str()) {
+        Some("package-lock.json") => NodeTool::Npm,
+        Some("yarn.lock") => NodeTool::Yarn,
+        _ => NodeTool::Pnpm,
+    }
+}
+
+fn write_declaration(path: &Path, declaration: &Dependencies) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    if !parent.is_dir() {
+        bail!(
+            "declaration parent directory does not exist: {}",
+            parent.display()
+        );
+    }
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("declaration path must name a file"))?
+        .to_string_lossy();
+    let temporary = parent.join(format!(".{file_name}.tmp-{}", std::process::id()));
+    if temporary.exists() {
+        bail!(
+            "temporary declaration path already exists: {}",
+            temporary.display()
+        );
+    }
+    let result = (|| {
+        let mut bytes = serde_json::to_vec_pretty(declaration)?;
+        bytes.push(b'\n');
+        std::fs::write(&temporary, bytes)
+            .with_context(|| format!("writing temporary declaration {}", temporary.display()))?;
+        std::fs::rename(&temporary, path)
+            .with_context(|| format!("publishing dependency declaration {}", path.display()))?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    Ok(hex::encode(Sha256::digest(bytes)))
 }
 
 fn read_manifest(volume_dir: &Path) -> Result<VolumeManifest> {
@@ -247,6 +559,13 @@ mod tests {
     const LOCKFILE_HASH: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
     fn seed_volume(root: &Path, lockfile_hash: Option<&str>) -> String {
+        let annotations = lockfile_hash
+            .map(|hash| BTreeMap::from([("lockfile_hash".to_string(), hash.to_string())]))
+            .unwrap_or_default();
+        seed_volume_with_annotations(root, annotations)
+    }
+
+    fn seed_volume_with_annotations(root: &Path, annotations: BTreeMap<String, String>) -> String {
         let volume = root.join("seed");
         let content = volume.join(FILE_CONTENT_DIR);
         fs::create_dir_all(&content).unwrap();
@@ -257,9 +576,7 @@ mod tests {
         fs::write(&sbom, b"old sbom").unwrap();
         fs::write(&fetch, b"old fetch\n").unwrap();
         fs::write(&cve, b"{\"results\":[]}").unwrap();
-        let annotations = lockfile_hash
-            .map(|hash| BTreeMap::from([("lockfile_hash".to_string(), hash.to_string())]))
-            .unwrap_or_default();
+        let index_hash = annotations.get("lockfile_hash").cloned();
         let sealed = seal_volume(
             &content,
             &sbom,
@@ -272,11 +589,19 @@ mod tests {
         fs::write(volume.join(FILE_MANIFEST), sealed.manifest_bytes).unwrap();
         let final_dir = root.join(&sealed.volume_hash);
         fs::rename(volume, &final_dir).unwrap();
-        if let Some(lockfile_hash) = lockfile_hash {
+        if let Some(lockfile_hash) = index_hash {
             fs::create_dir_all(root.join("index")).unwrap();
             fs::write(root.join("index").join(lockfile_hash), &sealed.volume_hash).unwrap();
         }
         sealed.volume_hash
+    }
+
+    #[test]
+    fn capture_request_builder_requires_core_inputs() {
+        let error = CaptureRequest::builder()
+            .build()
+            .expect_err("an incomplete capture request must be rejected");
+        assert!(error.to_string().contains("capture cache root is required"));
     }
 
     #[test]
@@ -293,8 +618,16 @@ mod tests {
         fs::write(&fetch, b"new fetch\n").unwrap();
         fs::write(&cve, b"{\"results\":[]}").unwrap();
 
-        let outcome =
-            capture_volume(tmp.path(), &old_hash, &captured, &sbom, &fetch, &cve).unwrap();
+        let request = CaptureRequest::builder()
+            .cache_root(tmp.path())
+            .prior_hash(&old_hash)
+            .captured_content(&captured)
+            .sbom(&sbom)
+            .fetch_log(&fetch)
+            .cve(&cve)
+            .build()
+            .unwrap();
+        let outcome = capture_volume(request).unwrap();
         assert_ne!(outcome.prior_volume_hash, outcome.volume_hash);
         assert!(!tmp.path().join(&old_hash).exists());
         assert_eq!(
@@ -319,7 +652,16 @@ mod tests {
         fs::write(&sbom, b"sbom").unwrap();
         fs::write(&fetch, b"fetch\n").unwrap();
         fs::write(&cve, b"{}").unwrap();
-        assert!(capture_volume(tmp.path(), &old_hash, &captured, &sbom, &fetch, &cve).is_err());
+        let request = CaptureRequest::builder()
+            .cache_root(tmp.path())
+            .prior_hash(&old_hash)
+            .captured_content(&captured)
+            .sbom(&sbom)
+            .fetch_log(&fetch)
+            .cve(&cve)
+            .build()
+            .unwrap();
+        assert!(capture_volume(request).is_err());
         assert!(tmp.path().join(&old_hash).exists());
     }
 
@@ -343,6 +685,130 @@ mod tests {
         fs::write(&sbom, b"sbom").unwrap();
         fs::write(&fetch, b"fetch\n").unwrap();
         fs::write(&cve, b"{}").unwrap();
-        assert!(capture_volume(tmp.path(), &old_hash, &captured, &sbom, &fetch, &cve).is_err());
+        let request = CaptureRequest::builder()
+            .cache_root(tmp.path())
+            .prior_hash(&old_hash)
+            .captured_content(&captured)
+            .sbom(&sbom)
+            .fetch_log(&fetch)
+            .cve(&cve)
+            .build()
+            .unwrap();
+        assert!(capture_volume(request).is_err());
+    }
+
+    #[test]
+    fn capture_emits_the_declared_dependency_shape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lockfile = tmp.path().join("uv.lock");
+        fs::write(&lockfile, "version = 1\n").unwrap();
+        let lockfile_sha256 = sha256_file(&lockfile).unwrap();
+        let lockfile_hash =
+            derive_lockfile_hash(&lockfile_sha256, Language::Python, GateLevel::Dev);
+        let old_hash = seed_volume_with_annotations(
+            tmp.path(),
+            BTreeMap::from([
+                ("lockfile_hash".to_string(), lockfile_hash),
+                ("lockfile_sha256".to_string(), lockfile_sha256),
+                ("lockfile_relative_path".to_string(), "uv.lock".to_string()),
+                ("language".to_string(), "python".to_string()),
+                ("gate".to_string(), "dev".to_string()),
+            ]),
+        );
+        let captured = tmp.path().join("captured");
+        fs::create_dir_all(&captured).unwrap();
+        fs::write(captured.join("installed.txt"), b"new").unwrap();
+        let sbom = tmp.path().join("sbom.json");
+        let fetch = tmp.path().join("fetch.log");
+        let cve = tmp.path().join("cve.json");
+        fs::write(&sbom, b"sbom").unwrap();
+        fs::write(&fetch, b"fetch\n").unwrap();
+        fs::write(&cve, b"{}").unwrap();
+        let declaration_dir = tempfile::tempdir().unwrap();
+        let declaration = declaration_dir.path().join("dependencies.json");
+
+        let request = CaptureRequest::builder()
+            .cache_root(tmp.path())
+            .prior_hash(&old_hash)
+            .captured_content(&captured)
+            .sbom(&sbom)
+            .fetch_log(&fetch)
+            .cve(&cve)
+            .declaration_path(Some(&declaration))
+            .lockfile_path(Some(&lockfile))
+            .build()
+            .unwrap();
+        let outcome = capture_volume(request).unwrap();
+
+        assert_eq!(outcome.declaration, Some(declaration.clone()));
+        let parsed: Dependencies = serde_json::from_slice(&fs::read(declaration).unwrap()).unwrap();
+        assert_eq!(
+            parsed,
+            Dependencies::Python {
+                lockfile: "uv.lock".to_string(),
+                tool: PythonTool::Uv,
+            }
+        );
+    }
+
+    #[test]
+    fn capture_refuses_a_lockfile_that_does_not_match_the_seal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lockfile = tmp.path().join("uv.lock");
+        fs::write(&lockfile, "version = 1\n").unwrap();
+        let lockfile_sha256 = sha256_file(&lockfile).unwrap();
+        let lockfile_hash =
+            derive_lockfile_hash(&lockfile_sha256, Language::Python, GateLevel::Dev);
+        let old_hash = seed_volume_with_annotations(
+            tmp.path(),
+            BTreeMap::from([
+                ("lockfile_hash".to_string(), lockfile_hash),
+                ("lockfile_sha256".to_string(), lockfile_sha256),
+                ("lockfile_relative_path".to_string(), "uv.lock".to_string()),
+                ("language".to_string(), "python".to_string()),
+                ("gate".to_string(), "dev".to_string()),
+            ]),
+        );
+        fs::write(&lockfile, "tampered = true\n").unwrap();
+        let captured = tmp.path().join("captured");
+        fs::create_dir_all(&captured).unwrap();
+        let sbom = tmp.path().join("sbom.json");
+        let fetch = tmp.path().join("fetch.log");
+        let cve = tmp.path().join("cve.json");
+        fs::write(&sbom, b"sbom").unwrap();
+        fs::write(&fetch, b"fetch\n").unwrap();
+        fs::write(&cve, b"{}").unwrap();
+        let declaration_dir = tempfile::tempdir().unwrap();
+        let declaration = declaration_dir.path().join("dependencies.json");
+
+        let request = CaptureRequest::builder()
+            .cache_root(tmp.path())
+            .prior_hash(&old_hash)
+            .captured_content(&captured)
+            .sbom(&sbom)
+            .fetch_log(&fetch)
+            .cve(&cve)
+            .declaration_path(Some(&declaration))
+            .lockfile_path(Some(&lockfile))
+            .build()
+            .unwrap();
+        let error = capture_volume(request)
+            .expect_err("capture must refuse an unmatching declaration lockfile");
+        assert!(error.to_string().contains("does not match sealed SHA-256"));
+        assert!(tmp.path().join(&old_hash).exists());
+    }
+
+    #[test]
+    fn capture_refuses_declaration_inside_dependency_cache() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lockfile = tmp.path().join("uv.lock");
+        fs::write(&lockfile, "version = 1\n").unwrap();
+        let cache_root = tmp.path().join("cache");
+        fs::create_dir_all(&cache_root).unwrap();
+        let declaration = cache_root.join("dependencies.json");
+
+        let error = validate_declaration_target(&declaration, &lockfile, &cache_root)
+            .expect_err("declarations must not be written into the dependency cache");
+        assert!(error.to_string().contains("outside the dependency cache"));
     }
 }

--- a/crates/mvm-cli/src/commands/deps/capture.rs
+++ b/crates/mvm-cli/src/commands/deps/capture.rs
@@ -69,7 +69,7 @@ pub(super) fn run(args: Args) -> Result<()> {
         &args.fetch_log,
         &args.cve,
     )?;
- mvm_core::audit_emit!(
+    mvm_core::audit_emit!(
         DepsAudit,
         "prior={},new={},lockfile_hash={}",
         outcome.prior_volume_hash,

--- a/crates/mvm-cli/src/commands/deps/install.rs
+++ b/crates/mvm-cli/src/commands/deps/install.rs
@@ -1,0 +1,169 @@
+//! Install a declared dependency set in the isolated builder environment.
+//!
+//! The command is the development entry point for producing a sealed
+//! dependency volume from a lockfile. Cache misses run the existing builder
+//! install pipeline; cache hits only verify and reuse the already sealed
+//! volume. Production admission still consumes only the resulting sealed
+//! volume and never performs a live package install.
+
+use anyhow::{Context, Result, bail};
+use clap::{Args as ClapArgs, ValueEnum};
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use mvm_build::app_deps::{GateLevel, InstallSpec, Language};
+
+/// Arguments for `mvmctl deps install`.
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Lockfile to install. The bytes are hashed and pinned in the sealed
+    /// volume manifest.
+    #[arg(long, value_name = "PATH")]
+    pub lockfile: PathBuf,
+
+    /// Project directory containing the lockfile and its installer inputs.
+    #[arg(long, value_name = "DIR", default_value = ".")]
+    pub source_root: PathBuf,
+
+    /// Dependency ecosystem used to interpret the project inputs.
+    #[arg(long, value_enum)]
+    pub language: LanguageArg,
+
+    /// Override the sealed dependency-volume cache root.
+    #[arg(long)]
+    pub cache_root: Option<PathBuf>,
+
+    /// Emit a machine-readable JSON result on stdout.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub(in crate::commands) enum LanguageArg {
+    Python,
+    Node,
+}
+
+impl From<LanguageArg> for Language {
+    fn from(value: LanguageArg) -> Self {
+        match value {
+            LanguageArg::Python => Self::Python,
+            LanguageArg::Node => Self::Node,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct InstallOutcome {
+    volume_hash: String,
+    manifest_sha256: String,
+    lockfile_sha256: String,
+    volume_dir: PathBuf,
+    cache_hit: bool,
+    gate: GateLevel,
+    language: Language,
+}
+
+pub(super) fn run(args: Args) -> Result<()> {
+    let lockfile = existing_path(&args.lockfile, "lockfile")?;
+    let source_root = existing_directory(&args.source_root, "source root")?;
+    if !lockfile.starts_with(&source_root) {
+        bail!(
+            "lockfile `{}` must be inside source root `{}`",
+            lockfile.display(),
+            source_root.display()
+        );
+    }
+    let cache_root = args
+        .cache_root
+        .as_deref()
+        .map(Path::to_path_buf)
+        .or_else(|| Some(mvm_build::app_deps::resolve_cache_root(None)));
+    let language = Language::from(args.language);
+    let spec = InstallSpec {
+        lockfile,
+        source_root,
+        language,
+        gate: GateLevel::Dev,
+        cache_root_override: cache_root,
+    };
+
+    #[cfg(feature = "builder-vm")]
+    let result: mvm_build::app_deps::InstallResult = {
+        let driver = mvm_build::builder_backend_select::resolve_builder_backend();
+        let install_driver = mvm_build::app_deps::BuilderInstallDriver::new(driver.as_ref());
+        mvm_build::app_deps::install_app_deps(&spec, Some(&install_driver))
+            .context("installing declared dependencies in the builder environment")?
+    };
+    #[cfg(not(feature = "builder-vm"))]
+    let result: mvm_build::app_deps::InstallResult = {
+        let _ = spec;
+        bail!("mvmctl deps install requires the builder-vm feature")
+    };
+
+    let outcome = InstallOutcome {
+        volume_hash: result.volume_hash,
+        manifest_sha256: result.manifest_sha256,
+        lockfile_sha256: result.lockfile_sha256,
+        volume_dir: result.volume_dir,
+        cache_hit: result.cache_hit,
+        gate: GateLevel::Dev,
+        language,
+    };
+    mvm_core::audit_emit!(
+        DepsAudit,
+        "operation=install,volume_hash={},cache_hit={},language={},gate=dev",
+        outcome.volume_hash,
+        outcome.cache_hit,
+        outcome.language.token(),
+    );
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&outcome)?);
+    } else {
+        let action = if outcome.cache_hit {
+            "reused"
+        } else {
+            "installed"
+        };
+        eprintln!(
+            "{action} development dependency volume {} at {}",
+            outcome.volume_hash,
+            outcome.volume_dir.display()
+        );
+    }
+    Ok(())
+}
+
+fn existing_path(path: &Path, label: &str) -> Result<PathBuf> {
+    fs::canonicalize(path).with_context(|| format!("resolving {label} `{}`", path.display()))
+}
+
+fn existing_directory(path: &Path, label: &str) -> Result<PathBuf> {
+    let resolved = existing_path(path, label)?;
+    if !resolved.is_dir() {
+        bail!("{label} `{}` is not a directory", path.display());
+    }
+    Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn language_arg_maps_to_install_language() {
+        assert_eq!(Language::from(LanguageArg::Python), Language::Python);
+        assert_eq!(Language::from(LanguageArg::Node), Language::Node);
+    }
+
+    #[test]
+    fn existing_directory_rejects_a_file() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("not-a-directory");
+        fs::write(&file, b"data").unwrap();
+        let error = existing_directory(&file, "source root").unwrap_err();
+        assert!(error.to_string().contains("not a directory"));
+    }
+}

--- a/crates/mvm-cli/src/commands/deps/install.rs
+++ b/crates/mvm-cli/src/commands/deps/install.rs
@@ -89,18 +89,7 @@ pub(super) fn run(args: Args) -> Result<()> {
         cache_root_override: cache_root,
     };
 
-    #[cfg(feature = "builder-vm")]
-    let result: mvm_build::app_deps::InstallResult = {
-        let driver = mvm_build::builder_backend_select::resolve_builder_backend();
-        let install_driver = mvm_build::app_deps::BuilderInstallDriver::new(driver.as_ref());
-        mvm_build::app_deps::install_app_deps(&spec, Some(&install_driver))
-            .context("installing declared dependencies in the builder environment")?
-    };
-    #[cfg(not(feature = "builder-vm"))]
-    let result: mvm_build::app_deps::InstallResult = {
-        let _ = spec;
-        bail!("mvmctl deps install requires the builder-vm feature")
-    };
+    let result = install_in_builder(&spec)?;
 
     let outcome = InstallOutcome {
         volume_hash: result.volume_hash,
@@ -135,6 +124,19 @@ pub(super) fn run(args: Args) -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "builder-vm")]
+fn install_in_builder(spec: &InstallSpec) -> Result<mvm_build::app_deps::InstallResult> {
+    let driver = mvm_build::builder_backend_select::resolve_builder_backend();
+    let install_driver = mvm_build::app_deps::BuilderInstallDriver::new(driver.as_ref());
+    mvm_build::app_deps::install_app_deps(spec, Some(&install_driver))
+        .context("installing declared dependencies in the builder environment")
+}
+
+#[cfg(not(feature = "builder-vm"))]
+fn install_in_builder(_spec: &InstallSpec) -> Result<mvm_build::app_deps::InstallResult> {
+    bail!("mvmctl deps install requires the builder-vm feature")
+}
+
 fn existing_path(path: &Path, label: &str) -> Result<PathBuf> {
     fs::canonicalize(path).with_context(|| format!("resolving {label} `{}`", path.display()))
 }
@@ -165,5 +167,23 @@ mod tests {
         fs::write(&file, b"data").unwrap();
         let error = existing_directory(&file, "source root").unwrap_err();
         assert!(error.to_string().contains("not a directory"));
+    }
+
+    #[cfg(not(feature = "builder-vm"))]
+    #[test]
+    fn install_reports_missing_builder_feature() {
+        let spec = InstallSpec {
+            lockfile: PathBuf::from("Cargo.lock"),
+            source_root: PathBuf::from("."),
+            language: Language::Python,
+            gate: GateLevel::Dev,
+            cache_root_override: None,
+        };
+        let error = install_in_builder(&spec).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("requires the builder-vm feature")
+        );
     }
 }

--- a/crates/mvm-cli/src/commands/deps/live_capture.rs
+++ b/crates/mvm-cli/src/commands/deps/live_capture.rs
@@ -1,0 +1,449 @@
+//! Capture dependency artifacts from a running development VM.
+//!
+//! The guest is read through the agent filesystem RPC rather than through a
+//! host share or a guest shell. The export is bounded, rejects symlinks and
+//! special files, and is staged under a temporary host directory before the
+//! existing capture path verifies and reseals it.
+
+use anyhow::{Context, Result, bail};
+use clap::Args as ClapArgs;
+use serde::Serialize;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use mvm_agentd::vsock::{FsEntryKind, FsResult, GuestRequest};
+use mvm_client::LocalBackend;
+use mvm_client::inventory::{WorkloadPosture, list_local_inventory};
+use mvm_core::client::dto::MachineStatus;
+
+use super::capture::{CaptureOutcome, CaptureRequest, capture_volume};
+
+const DEFAULT_MAX_BYTES: u64 = 512 * 1024 * 1024;
+const DEFAULT_MAX_FILES: u64 = 100_000;
+const MAX_DIRECTORY_DEPTH: usize = 256;
+
+/// Arguments for importing dependency artifacts from a running development VM.
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Existing sealed dependency volume to replace.
+    #[arg(value_name = "VOLUME_HASH")]
+    pub volume_hash: String,
+
+    /// Running development VM containing the installed dependency tree.
+    #[arg(long, value_name = "VM")]
+    pub vm: String,
+
+    /// Absolute guest directory containing the installed dependency tree.
+    #[arg(long, value_name = "PATH")]
+    pub guest_content: String,
+
+    /// Absolute guest path to the fresh CycloneDX SBOM.
+    #[arg(long, value_name = "PATH")]
+    pub guest_sbom: String,
+
+    /// Absolute guest path to the install fetch log.
+    #[arg(long, value_name = "PATH")]
+    pub guest_fetch_log: String,
+
+    /// Absolute guest path to the fresh CVE result.
+    #[arg(long, value_name = "PATH")]
+    pub guest_cve: String,
+
+    /// Override the sealed dependency-volume cache root.
+    #[arg(long)]
+    pub cache_root: Option<PathBuf>,
+
+    /// Emit a machine-readable JSON result on stdout.
+    #[arg(long)]
+    pub json: bool,
+
+    /// Write the captured dependency declaration as the canonical SDK/IR
+    /// dependency object.
+    #[arg(long, value_name = "PATH", requires = "lockfile")]
+    pub declaration: Option<PathBuf>,
+
+    /// Local lockfile whose bytes must match the sealed volume pin.
+    #[arg(long, value_name = "PATH", requires = "declaration")]
+    pub lockfile: Option<PathBuf>,
+
+    /// Maximum combined bytes exported from the guest.
+    #[arg(long, default_value_t = DEFAULT_MAX_BYTES)]
+    pub max_bytes: u64,
+
+    /// Maximum number of regular files exported from the guest.
+    #[arg(long, default_value_t = DEFAULT_MAX_FILES)]
+    pub max_files: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct LiveCaptureOutcome {
+    #[serde(flatten)]
+    capture: CaptureOutcome,
+    vm: String,
+    guest_content: String,
+    files_exported: u64,
+    bytes_exported: u64,
+}
+
+#[derive(Debug)]
+struct ExportState {
+    files: u64,
+    bytes: u64,
+    max_files: u64,
+    max_bytes: u64,
+}
+
+pub(super) fn run(args: Args) -> Result<()> {
+    ensure_dev_vm(&args.vm)?;
+    validate_guest_path(&args.guest_content, "guest content")?;
+    validate_guest_path(&args.guest_sbom, "guest SBOM")?;
+    validate_guest_path(&args.guest_fetch_log, "guest fetch log")?;
+    validate_guest_path(&args.guest_cve, "guest CVE")?;
+    if args.max_bytes == 0 || args.max_files == 0 {
+        bail!("--max-bytes and --max-files must be greater than zero");
+    }
+
+    let staging = tempfile::tempdir().context("creating live dependency capture staging")?;
+    let content = staging.path().join("content");
+    fs::create_dir_all(&content).context("creating live capture content directory")?;
+    let mut state = ExportState {
+        files: 0,
+        bytes: 0,
+        max_files: args.max_files,
+        max_bytes: args.max_bytes,
+    };
+    export_tree(&args.vm, &args.guest_content, &content, &mut state, 0)?;
+    let sbom = export_file(
+        &args.vm,
+        &args.guest_sbom,
+        &staging.path().join("sbom.cdx.json"),
+        &mut state,
+    )?;
+    let fetch_log = export_file(
+        &args.vm,
+        &args.guest_fetch_log,
+        &staging.path().join("fetch.log"),
+        &mut state,
+    )?;
+    let cve = export_file(
+        &args.vm,
+        &args.guest_cve,
+        &staging.path().join("cve.json"),
+        &mut state,
+    )?;
+
+    let cache_root = mvm_build::app_deps::resolve_cache_root(args.cache_root.as_deref());
+    let request = CaptureRequest::builder()
+        .cache_root(&cache_root)
+        .prior_hash(&args.volume_hash)
+        .captured_content(&content)
+        .sbom(&sbom)
+        .fetch_log(&fetch_log)
+        .cve(&cve)
+        .declaration_path(args.declaration.as_deref())
+        .lockfile_path(args.lockfile.as_deref())
+        .build()?;
+    let capture = capture_volume(request)?;
+    let outcome = LiveCaptureOutcome {
+        capture,
+        vm: args.vm,
+        guest_content: args.guest_content,
+        files_exported: state.files,
+        bytes_exported: state.bytes,
+    };
+    mvm_core::audit_emit!(
+        DepsAudit,
+        "operation=capture-live,prior={},new={},files={},bytes={}",
+        outcome.capture.prior_volume_hash,
+        outcome.capture.volume_hash,
+        outcome.files_exported,
+        outcome.bytes_exported,
+    );
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&outcome)?);
+    } else {
+        eprintln!(
+            "captured dependency volume {} -> {} from {} ({} files, {} bytes)",
+            outcome.capture.prior_volume_hash,
+            outcome.capture.volume_hash,
+            outcome.vm,
+            outcome.files_exported,
+            outcome.bytes_exported,
+        );
+    }
+    Ok(())
+}
+
+fn ensure_dev_vm(vm: &str) -> Result<()> {
+    let client = LocalBackend::new();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building runtime for live capture posture check")?;
+    let records = runtime
+        .block_on(list_local_inventory(&client))
+        .map_err(|error| anyhow::anyhow!(error.to_string()))
+        .context("listing machines for live capture")?;
+    let record = records
+        .into_iter()
+        .find(|record| record.name == vm)
+        .ok_or_else(|| anyhow::anyhow!("no machine named `{vm}` is present"))?;
+    require_running_dev_posture(record.status, record.build_mode)
+}
+
+fn require_dev_posture(posture: WorkloadPosture) -> Result<()> {
+    if !posture.is_dev() {
+        bail!("live dependency capture requires a development VM; production posture refused");
+    }
+    Ok(())
+}
+
+fn require_running_dev_posture(status: MachineStatus, posture: WorkloadPosture) -> Result<()> {
+    if status != MachineStatus::Running {
+        bail!(
+            "live dependency capture requires a running development VM; current status is {}",
+            status.wire_label()
+        );
+    }
+    require_dev_posture(posture)
+}
+
+fn export_tree(
+    vm: &str,
+    guest_path: &str,
+    host_path: &Path,
+    state: &mut ExportState,
+    depth: usize,
+) -> Result<()> {
+    ensure_directory_depth(depth, guest_path)?;
+    let stat = stat_guest(vm, guest_path)?;
+    if stat.kind != FsEntryKind::Dir {
+        bail!("guest dependency root `{guest_path}` is not a directory");
+    }
+    let entries = list_guest(vm, guest_path)?;
+    fs::create_dir_all(host_path)
+        .with_context(|| format!("creating exported directory {}", host_path.display()))?;
+    let mut names = HashSet::with_capacity(entries.len());
+    for entry in entries {
+        validate_entry_name(&entry.name)?;
+        if !names.insert(entry.name.clone()) {
+            bail!(
+                "guest directory returned duplicate entry `{guest_path}/{}`",
+                entry.name
+            );
+        }
+        let guest_child = join_guest_path(guest_path, &entry.name);
+        let host_child = host_path.join(&entry.name);
+        match entry.kind {
+            FsEntryKind::Dir => export_tree(vm, &guest_child, &host_child, state, depth + 1)?,
+            FsEntryKind::File => {
+                export_file(vm, &guest_child, &host_child, state)?;
+            }
+            FsEntryKind::Symlink | FsEntryKind::Other => {
+                bail!("live dependency capture refuses non-regular guest entry `{guest_child}`")
+            }
+        }
+    }
+    Ok(())
+}
+
+fn export_file(
+    vm: &str,
+    guest_path: &str,
+    host_path: &Path,
+    state: &mut ExportState,
+) -> Result<PathBuf> {
+    let stat = stat_guest(vm, guest_path)?;
+    if stat.kind != FsEntryKind::File {
+        bail!("live dependency capture source `{guest_path}` is not a regular file");
+    }
+    reserve(state, stat.size, guest_path)?;
+    let bytes = crate::commands::vm::fs::read_guest_chunks_with_symlink_policy(
+        vm, guest_path, 0, stat.size, false,
+    )?;
+    let actual = u64::try_from(bytes.len()).expect("host buffer length fits u64");
+    if actual != stat.size {
+        bail!(
+            "guest file `{guest_path}` changed during capture: expected {}, read {}",
+            stat.size,
+            actual
+        );
+    }
+    let after = stat_guest(vm, guest_path)?;
+    if after != stat {
+        bail!("guest file `{guest_path}` changed during capture");
+    }
+    if let Some(parent) = host_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating export parent {}", parent.display()))?;
+    }
+    fs::write(host_path, bytes)
+        .with_context(|| format!("writing exported file {}", host_path.display()))?;
+    Ok(host_path.to_path_buf())
+}
+
+fn reserve(state: &mut ExportState, bytes: u64, guest_path: &str) -> Result<()> {
+    let next_files = state
+        .files
+        .checked_add(1)
+        .ok_or_else(|| anyhow::anyhow!("captured file count overflow"))?;
+    if next_files > state.max_files {
+        bail!(
+            "live dependency capture exceeded --max-files {} at `{guest_path}`",
+            state.max_files
+        );
+    }
+    let next_bytes = state
+        .bytes
+        .checked_add(bytes)
+        .ok_or_else(|| anyhow::anyhow!("captured byte count overflow"))?;
+    if next_bytes > state.max_bytes {
+        bail!(
+            "live dependency capture exceeded --max-bytes {} at `{guest_path}`",
+            state.max_bytes
+        );
+    }
+    state.files = next_files;
+    state.bytes = next_bytes;
+    Ok(())
+}
+
+fn ensure_directory_depth(depth: usize, guest_path: &str) -> Result<()> {
+    if depth > MAX_DIRECTORY_DEPTH {
+        bail!(
+            "guest dependency tree exceeded the directory depth limit of {} at `{guest_path}`",
+            MAX_DIRECTORY_DEPTH
+        );
+    }
+    Ok(())
+}
+
+fn list_guest(vm: &str, path: &str) -> Result<Vec<mvm_agentd::vsock::FsEntry>> {
+    let request = GuestRequest::FsList {
+        path: path.to_string(),
+        follow_symlinks: false,
+    };
+    crate::commands::shared::emit_vsock_rpc_audit(vm, &request);
+    match crate::commands::vm::fs::fs_request(vm, request)? {
+        FsResult::List { entries, truncated } if !truncated => Ok(entries),
+        FsResult::List {
+            truncated: true, ..
+        } => {
+            bail!("guest directory `{path}` exceeded the agent listing cap")
+        }
+        FsResult::Error { kind, message } => {
+            bail!("guest FS list failed for `{path}` ({kind:?}): {message}")
+        }
+        other => bail!("unexpected guest FS list result for `{path}`: {other:?}"),
+    }
+}
+
+fn stat_guest(vm: &str, path: &str) -> Result<mvm_agentd::vsock::FsStat> {
+    let request = GuestRequest::FsStat {
+        path: path.to_string(),
+        follow_symlinks: false,
+    };
+    crate::commands::shared::emit_vsock_rpc_audit(vm, &request);
+    match crate::commands::vm::fs::fs_request(vm, request)? {
+        FsResult::Stat(stat) => Ok(stat),
+        FsResult::Error { kind, message } => {
+            bail!("guest FS stat failed for `{path}` ({kind:?}): {message}")
+        }
+        other => bail!("unexpected guest FS stat result for `{path}`: {other:?}"),
+    }
+}
+
+fn validate_guest_path(path: &str, label: &str) -> Result<()> {
+    let parsed = Path::new(path);
+    if !parsed.is_absolute()
+        || parsed
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        bail!("{label} path must be absolute and must not contain `..`: `{path}`");
+    }
+    Ok(())
+}
+
+fn validate_entry_name(name: &str) -> Result<()> {
+    let path = Path::new(name);
+    if name.is_empty()
+        || name.contains('/')
+        || name.contains('\\')
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        bail!("guest directory returned an unsafe entry name: `{name}`");
+    }
+    Ok(())
+}
+
+fn join_guest_path(parent: &str, name: &str) -> String {
+    format!("{}/{}", parent.trim_end_matches('/'), name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guest_paths_must_be_absolute_without_parent_components() {
+        assert!(validate_guest_path("/app/deps", "content").is_ok());
+        assert!(validate_guest_path("app/deps", "content").is_err());
+        assert!(validate_guest_path("/app/../etc", "content").is_err());
+    }
+
+    #[test]
+    fn entry_names_cannot_escape_the_export_root() {
+        assert!(validate_entry_name("package.py").is_ok());
+        assert!(validate_entry_name("../package.py").is_err());
+        assert!(validate_entry_name("nested/package.py").is_err());
+        assert!(validate_entry_name("/package.py").is_err());
+    }
+
+    #[test]
+    fn export_limits_are_accounted_before_reading() {
+        let mut state = ExportState {
+            files: 0,
+            bytes: 0,
+            max_files: 1,
+            max_bytes: 4,
+        };
+        reserve(&mut state, 4, "/deps/a").unwrap();
+        assert_eq!(state.files, 1);
+        assert_eq!(state.bytes, 4);
+        assert!(reserve(&mut state, 0, "/deps/b").is_err());
+        assert!(reserve(&mut state, 1, "/deps/c").is_err());
+    }
+
+    #[test]
+    fn directory_depth_is_bounded() {
+        assert!(ensure_directory_depth(MAX_DIRECTORY_DEPTH, "/deps").is_ok());
+        assert!(ensure_directory_depth(MAX_DIRECTORY_DEPTH + 1, "/deps/deep").is_err());
+    }
+
+    #[test]
+    fn guest_path_join_does_not_duplicate_root_separator() {
+        assert_eq!(join_guest_path("/", "deps"), "/deps");
+        assert_eq!(join_guest_path("/app/", "deps"), "/app/deps");
+    }
+
+    #[test]
+    fn production_posture_is_refused() {
+        assert!(require_dev_posture(WorkloadPosture::Prod).is_err());
+        assert!(require_dev_posture(WorkloadPosture::Dev).is_ok());
+    }
+
+    #[test]
+    fn non_running_development_vm_is_refused() {
+        assert!(require_running_dev_posture(MachineStatus::Stopped, WorkloadPosture::Dev).is_err());
+        assert!(require_running_dev_posture(MachineStatus::Paused, WorkloadPosture::Dev).is_err());
+        assert!(
+            require_running_dev_posture(MachineStatus::Running, WorkloadPosture::Prod).is_err()
+        );
+        assert!(require_running_dev_posture(MachineStatus::Running, WorkloadPosture::Dev).is_ok());
+    }
+}

--- a/crates/mvm-cli/src/commands/deps/mod.rs
+++ b/crates/mvm-cli/src/commands/deps/mod.rs
@@ -22,7 +22,12 @@
 //! - `mod.rs` — `Args` / `Action` enum, dispatch, shared types.
 //! - `inspect.rs` — pretty-printer for sealed artifacts.
 //! - `audit.rs` — re-audit logic + `AuditRunner` trait for testing.
-//! - `capture.rs` — import a sandbox capture and publish its resealed volume.
+//! - `capture.rs` — import a sandbox capture, publish its resealed volume, and
+//!   optionally emit the matching workload dependency declaration.
+//! - `install.rs` — run the declared development install in the builder
+//!   environment and publish its sealed volume.
+//! - `live_capture.rs` — export bounded artifacts from a running development
+//!   VM and pass them through the same reseal path.
 //!
 //! Cache root resolution always routes through
 //! [`mvm_build::app_deps::resolve_cache_root`] so the supervisor's
@@ -42,6 +47,8 @@ use super::Cli;
 pub(super) mod audit;
 pub(super) mod capture;
 pub(super) mod inspect;
+pub(super) mod install;
+pub(super) mod live_capture;
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
@@ -98,6 +105,12 @@ pub(in crate::commands) enum DepsAction {
     Audit(audit::Args),
     /// Capture a sandbox-installed dependency tree and reseal the volume.
     Capture(capture::Args),
+    /// Install a lockfile-pinned dependency set in the development builder
+    /// environment and seal the resulting volume.
+    Install(install::Args),
+    /// Export dependency artifacts from a running development VM and reseal
+    /// the existing volume atomically.
+    CaptureLive(live_capture::Args),
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
@@ -109,5 +122,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         } => inspect::run(&volume_hash, cache_root.as_deref(), json),
         DepsAction::Audit(a) => audit::run(a),
         DepsAction::Capture(a) => capture::run(a),
+        DepsAction::Install(a) => install::run(a),
+        DepsAction::CaptureLive(a) => live_capture::run(a),
     }
 }

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -4,6 +4,7 @@
 
 use super::*;
 use clap::Parser;
+use std::path::Path;
 
 // Group module aliases — give tests short names (`cleanup`, `up`, etc.) that
 // follow the dispatcher's naming, regardless of which group they live in.
@@ -102,6 +103,10 @@ fn deps_capture_parses_seal_inputs() {
         "fetch.log",
         "--cve",
         "cve.json",
+        "--declaration",
+        "dependencies.json",
+        "--lockfile",
+        "uv.lock",
         "--json",
     ])
     .unwrap();
@@ -113,6 +118,81 @@ fn deps_capture_parses_seal_inputs() {
     };
     assert_eq!(capture.volume_hash.len(), 64);
     assert!(capture.json);
+    assert_eq!(
+        capture.declaration.as_deref(),
+        Some(Path::new("dependencies.json"))
+    );
+    assert_eq!(capture.lockfile.as_deref(), Some(Path::new("uv.lock")));
+}
+
+#[test]
+fn deps_install_parses_development_install_inputs() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "deps",
+        "install",
+        "--lockfile",
+        "uv.lock",
+        "--source-root",
+        "project",
+        "--language",
+        "python",
+        "--cache-root",
+        "cache",
+        "--json",
+    ])
+    .unwrap();
+    let Commands::Deps(args) = cli.command else {
+        panic!("expected deps command")
+    };
+    let deps::DepsAction::Install(install) = args.action else {
+        panic!("expected deps install command")
+    };
+    assert_eq!(install.lockfile, Path::new("uv.lock"));
+    assert_eq!(install.source_root, Path::new("project"));
+    assert!(matches!(
+        install.language,
+        deps::install::LanguageArg::Python
+    ));
+    assert_eq!(install.cache_root.as_deref(), Some(Path::new("cache")));
+    assert!(install.json);
+}
+
+#[test]
+fn deps_capture_live_parses_guest_artifact_inputs() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "deps",
+        "capture-live",
+        "a".repeat(64).as_str(),
+        "--vm",
+        "dev-vm",
+        "--guest-content",
+        "/mvm/deps/content",
+        "--guest-sbom",
+        "/mvm/deps/sbom.cdx.json",
+        "--guest-fetch-log",
+        "/mvm/deps/fetch.log",
+        "--guest-cve",
+        "/mvm/deps/cve.json",
+        "--declaration",
+        "dependencies.json",
+        "--lockfile",
+        "uv.lock",
+        "--max-files",
+        "10",
+    ])
+    .unwrap();
+    let Commands::Deps(args) = cli.command else {
+        panic!("expected deps command")
+    };
+    let deps::DepsAction::CaptureLive(capture) = args.action else {
+        panic!("expected deps capture-live command")
+    };
+    assert_eq!(capture.vm, "dev-vm");
+    assert_eq!(capture.guest_content, "/mvm/deps/content");
+    assert_eq!(capture.max_files, 10);
+    assert_eq!(capture.lockfile.as_deref(), Some(Path::new("uv.lock")));
 }
 
 #[test]

--- a/crates/mvm-cli/src/commands/vm/fs.rs
+++ b/crates/mvm-cli/src/commands/vm/fs.rs
@@ -171,7 +171,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
 /// the in-memory mock backend. Gated behind `test-support` along with the
 /// mock backend itself — a production build never has a mock VM dir to
 /// find, so it goes straight to the real probe.
-pub(super) fn fs_request(name: &str, req: GuestRequest) -> Result<FsResult> {
+pub(in crate::commands) fn fs_request(name: &str, req: GuestRequest) -> Result<FsResult> {
     validate_vm_name(name).with_context(|| format!("Invalid VM name: {:?}", name))?;
     #[cfg(feature = "test-support")]
     {
@@ -221,11 +221,21 @@ fn cmd_write(
     Ok(())
 }
 
-pub(super) fn read_guest_chunks(
+pub(in crate::commands) fn read_guest_chunks(
     name: &str,
     path: &str,
     start_offset: u64,
     length: u64,
+) -> Result<Vec<u8>> {
+    read_guest_chunks_with_symlink_policy(name, path, start_offset, length, true)
+}
+
+pub(in crate::commands) fn read_guest_chunks_with_symlink_policy(
+    name: &str,
+    path: &str,
+    start_offset: u64,
+    length: u64,
+    follow_symlinks: bool,
 ) -> Result<Vec<u8>> {
     let chunk_cap =
         u64::try_from(mvm_agentd::vsock::MAX_DATA_CHUNK_SIZE).expect("wire chunk size fits u64");
@@ -235,12 +245,7 @@ pub(super) fn read_guest_chunks(
     let mut remaining = length;
     while remaining > 0 {
         let requested = remaining.min(chunk_cap);
-        let req = GuestRequest::FsRead {
-            path: path.to_string(),
-            offset: Some(offset),
-            length: requested,
-            follow_symlinks: true,
-        };
+        let req = fs_read_request(path, offset, requested, follow_symlinks);
         super::shared::emit_vsock_rpc_audit(name, &req);
         match unwrap_fs(fs_request(name, req)?)? {
             FsResult::Read {
@@ -264,6 +269,15 @@ pub(super) fn read_guest_chunks(
         }
     }
     Ok(content)
+}
+
+fn fs_read_request(path: &str, offset: u64, length: u64, follow_symlinks: bool) -> GuestRequest {
+    GuestRequest::FsRead {
+        path: path.to_string(),
+        offset: Some(offset),
+        length,
+        follow_symlinks,
+    }
 }
 
 pub(super) fn write_guest_chunks(
@@ -427,5 +441,24 @@ fn cmd_mv(name: &str, from: &str, to: &str) -> Result<()> {
             Ok(())
         }
         other => bail!("Unexpected FsResult variant for Move: {:?}", other),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_request_preserves_symlink_policy() {
+        let request = fs_read_request("/deps/site.py", 8, 16, false);
+        assert!(matches!(
+            request,
+            GuestRequest::FsRead {
+                path,
+                offset: Some(8),
+                length: 16,
+                follow_symlinks: false,
+            } if path == "/deps/site.py"
+        ));
     }
 }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -15,7 +15,10 @@ for detailed scope and acceptance criteria.
         long-running mode recovers from transient input/compile errors while
         `--once` remains fail-fast
   - [~] WS3 capture-from-sandbox via `reseal_volume`, converging on the
-        declared-dependency path and keeping the lockfile hash pin
+        declared-dependency path and keeping the lockfile hash pin; capture,
+        `deps install`, and bounded `deps capture-live` implementation are
+        present. Focused mvm-cli (33) and mvm-build (21) tests, compile, build,
+        and Clippy gates pass; workspace/Linux-builder gates remain
   - [~] WS4 tier follows the attestation
     - [x] Agent-verb grant derives from admitted run shape, not image sidecar
     - [~] Bind the tier to an attested artifact and replace the interactive

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -12,7 +12,11 @@
 
 - [~] `mvmctl deps capture` — **plan 291 WS3**. Reseals a sandbox-captured
       dependency tree with fresh audit sidecars, updates the lockfile index,
-      and refuses tampered or unpinned source volumes.
+      refuses tampered or unpinned source volumes, and can emit the canonical
+      `Dependencies` declaration after verifying the matching lockfile pin;
+      implementation is present. Focused mvm-cli dependency tests (33) and
+      mvm-build app-dependency tests (21) pass; workspace and Linux-builder
+      gates remain.
 
 - [~] `mvmctl watch` — **plan 291 WS2**. A file-backed Workload IR watcher
       polls local source inputs, recompiles only when the semantic IR address
@@ -38,6 +42,11 @@
       dependency volume. A configured remote now ships the record and bundle
       through mvmd’s authenticated upload contract. Host compilation and the
       remaining workspace gates remain pending.
+- [~] `mvmctl deps install` runs the lockfile-pinned development install in the
+      builder boundary and publishes its sealed volume. `mvmctl deps
+      capture-live` exports bounded guest content and sidecars before handing
+      them to the atomic reseal path, and requires a running development VM;
+      implementation is present, with full workspace validation pending.
 
 - [~] Sensitive egress redaction — **plan 290**. The first delivery establishes
       a validated byte-span detector contract and supplements the curated

--- a/specs/plans/291-develop-build-deploy-attested.md
+++ b/specs/plans/291-develop-build-deploy-attested.md
@@ -1,14 +1,16 @@
 # Develop → build → deploy: one stupidly simple path to an attested workload image
 
-**Status:** In progress. The run-derived agent-verb tier prerequisite is
-landed; deploy attestation and the remaining WS4 work are still open.
+**Status:** In progress. WS3 capture, install, and live-capture paths are
+implemented; the deploy artifact path is also present, while authenticated
+remote transport and host-wide test gates remain.
 
 **Goal:** A developer starts from an OCI image or a Nix flake, iterates on a
 machine until the workload actually works — including discovering the
 dependencies it needs — and then runs one command that seals, hashes, and
-records the result as an attested image. If a remote (`mvmd`) is configured that
-same command ships it; if not, the developer still ends up holding a sealed,
-recorded artifact.
+records the result as an attested image. If a remote (`mvmd`) is configured,
+authenticated transport is required before it can be shipped; until that
+contract exists, the developer still ends up holding a sealed, recorded
+artifact locally.
 
 ## Why this plan exists
 
@@ -112,13 +114,22 @@ before WS1 starts.
 - [~] `mvmctl deps capture` imports a sandbox-installed dependency tree and
       its fresh SBOM, fetch log, and CVE result, then reseals it atomically
       through the existing volume verifier and lockfile index.
-- [ ] `install`-into-sandbox during development, then reseal via
-      `reseal_volume` to capture it — new volume hash, refreshed SBOM, fresh CVE
-      scan.
-- [ ] Emit the captured set back out as a declaration the developer can commit,
+- [~] Install into a development sandbox, then reseal via `reseal_volume` to
+      capture it — new volume hash, refreshed SBOM, fresh CVE scan. The SDK's
+      existing development `install_package` helpers perform the install;
+      `mvmctl deps capture-live` requires a running development VM, exports
+      bounded regular-file content and matching guest sidecars, and hands them
+      to the atomic reseal path. `mvmctl deps install` covers the declared
+      lockfile route.
+- [~] Emit the captured set back out as the canonical dependency declaration
+      the developer can commit,
       so an interactively-discovered dependency becomes a declared one. The
-      capture path must converge on the declared path, not fork from it.
-- [ ] Keep the lockfile hash-pin requirement intact: a captured dependency is
+      capture path must converge on the declared path, not fork from it. The
+      capture command verifies the supplied lockfile bytes against the sealed
+      SHA-256 and emits the same `Dependencies` IR shape used by normal builds.
+      It refuses declaration targets that would overwrite the lockfile or
+      enter the sealed dependency cache.
+- [~] Keep the lockfile hash-pin requirement intact: a captured dependency is
       pinned like a declared one, or the seal refuses.
 
 **The opencv case, end to end:** the developer either declares it (works today)

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -422,6 +422,8 @@ const DEPS_SUB: &[(&str, AuditPosture)] = &[
     ("inspect", AuditPosture::ReadOnly),
     ("audit", AuditPosture::Emits("DepsAudit")),
     ("capture", AuditPosture::Emits("DepsAudit")),
+    ("install", AuditPosture::Emits("DepsAudit")),
+    ("capture-live", AuditPosture::Emits("DepsAudit")),
 ];
 
 /// Every top-level `mvmctl` subcommand keyed by its clap name.


### PR DESCRIPTION
## Summary

- add lockfile-pinned development `mvmctl deps install`
- add bounded `mvmctl deps capture-live` through agent filesystem RPC only
- reject production or non-running VMs, unsafe guest paths, symlinks, special files, listing truncation, races, and byte/file-limit exhaustion
- reseal atomically through the existing sealed-volume contract
- verify lockfile SHA-256 and derived lockfile hash before emitting canonical `Dependencies`
- keep cache/index and declaration publication fail-closed

## Security and behavior

- no guest shell or host share is used for live capture
- guest files are stat/read/stat checked and read with symlink following disabled
- live capture requires positive development posture and `Running` machine status
- declaration output cannot overwrite the lockfile or land inside the dependency cache
- existing volume and sidecars are verified before capture mutation

## Validation

- nightly rustfmt check
- `git diff --check`
- `cargo test -p mvm-cli --lib commands::deps --no-fail-fast` — 33 passed
- `cargo test -p mvm-build app_deps --lib --no-fail-fast` — 21 passed
- `cargo clippy -p mvm-cli --lib -- -D warnings` — passed
- `cargo build -p mvm-cli --all-targets` — passed
- pre-commit workspace clippy — passed

Live capture still requires a running development VM for an end-to-end witness; full workspace/Linux-builder/supply-chain gates remain required before closure.

Tracks #2126 and #2123.