### PR TITLE
test(plan291): prove ProdSafe grants refuse interactive verbs

### DIFF
--- a/crates/mvm-agentd/src/vsock/verb_grant.rs
+++ b/crates/mvm-agentd/src/vsock/verb_grant.rs
@@ -419,6 +419,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn prod_safe_grant_refuses_interactive_requests() {
+        use mvm_core::plan::{Nonce, VerbGrant, VerbId};
+
+        let grant = VerbGrant {
+            session_id: "s".into(),
+            plan_nonce: Nonce::from_bytes([0u8; 16]),
+            not_after: chrono::Utc::now() + chrono::Duration::minutes(1),
+            verbs: GuestRequest::prod_safe_verb_names()
+                .iter()
+                .map(|name| VerbId::new(name).expect("the prod-safe catalog contains valid verbs"))
+                .collect(),
+            sig: vec![],
+        };
+        let requests = [
+            GuestRequest::Exec {
+                command: "id".into(),
+                stdin: None,
+                timeout_secs: Some(1),
+            },
+            GuestRequest::ConsoleOpen {
+                cols: 80,
+                rows: 24,
+                env: vec![],
+                argv: vec![],
+            },
+        ];
+
+        for request in requests {
+            assert_eq!(request.class(), RequestClass::DevOnly);
+            assert!(matches!(
+                enforce_verb_grant(&request, Some(&grant)),
+                Some(GuestResponse::VerbNotAuthorized { .. })
+            ));
+        }
+    }
+
     // ---- load_host_signer_verifying_key ----
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -18,8 +18,10 @@ for detailed scope and acceptance criteria.
         declared-dependency path and keeping the lockfile hash pin
   - [~] WS4 tier follows the attestation
     - [x] Agent-verb grant derives from admitted run shape, not image sidecar
-    - [ ] Bind the tier to an attested artifact and replace the interactive
-          feature/symbol witnesses with conformance scenarios
+    - [~] Bind the tier to an attested artifact and replace the interactive
+          feature/symbol witnesses with conformance scenarios. Grant
+          enforcement now proves a complete ProdSafe grant refuses Exec and
+          ConsoleOpen; feature-fork removal and guest-image validation remain.
 
 - [~] Plan 290 — Sensitive egress redaction
       (`specs/plans/290-sensitive-egress-redaction.md`)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -25,10 +25,9 @@
       while PTY and ad-hoc argv runs remain DevOnly. This prerequisite no
       longer keys interactive reachability on an image sidecar bit. Deploy
       attestation, the remaining tier binding, and conformance witnesses stay
-      open in WS1–WS4.
-- [~] `mvmctl watch` — **plan 291 WS2**. A file-backed Workload IR watcher
-      polls local source inputs, recompiles only when the semantic IR address
-      or source fingerprint changes, and reports rebuild/no-op iterations.
+      open in WS1–WS4. A ProdSafe-grant conformance test now proves both
+      Exec and ConsoleOpen are refused; the interactive feature fork and
+      guest-image validation remain open.
 
 - [~] Sensitive egress redaction — **plan 290**. The first delivery establishes
       a validated byte-span detector contract and supplements the curated

--- a/specs/plans/291-develop-build-deploy-attested.md
+++ b/specs/plans/291-develop-build-deploy-attested.md
@@ -133,11 +133,13 @@ same sealed, hash-pinned, CVE-scanned volume.
 - [ ] Retire the `interactive` Cargo feature fork so one agent binary serves
       both tiers; the existing `RequestClass::{ProdSafe, DevOnly}` gate and the
       signed `VerbGrant` already do the enforcement.
-- [ ] Replace the symbol-absence CI witnesses with conformance scenarios
+- [~] Replace the symbol-absence CI witnesses with conformance scenarios
       asserting an attested run refuses DevOnly verbs. Note that those
       symbol-grep jobs live in `security.yml`, which does not run on pull
       requests, so a conformance scenario in the PR-gating suite is stronger
-      than what it replaces, not weaker.
+      than what it replaces, not weaker. The grant-enforcement unit now proves
+      a complete ProdSafe grant refuses both `Exec` and `ConsoleOpen`; the
+      feature-fork replacement and full guest-image validation remain open.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

- add a complete ProdSafe `VerbGrant` witness
- prove `Exec` and `ConsoleOpen` remain DevOnly
- prove grant enforcement returns `VerbNotAuthorized` for both requests
- synchronize Plan 291 status documents with the partial conformance result

## Validation

- nightly rustfmt check
- `git diff --check`
- focused `mvm-agentd` grant test — passed
- `cargo clippy -p mvm-agentd --lib -- -D warnings` — passed
- pre-commit workspace clippy — passed

This is the safe conformance slice of WS4. The interactive feature-fork retirement and full guest-image validation remain separate acceptance work; this PR does not claim those are complete.

Tracks #2127 and #2123.