### PR TITLE
docs(plan291): record merged workstreams

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -8,17 +8,17 @@ for detailed scope and acceptance criteria.
 ## In-flight plans
 - [~] Plan 291 — Develop → build → deploy an attested workload image
       (`specs/plans/291-develop-build-deploy-attested.md`)
-  - [~] WS1 `mvmctl deploy`: seal, BLAKE3 identity + SHA-256 interop, deploy
+  - [x] WS1 `mvmctl deploy`: seal, BLAKE3 identity + SHA-256 interop, deploy
         record; retain the local sealed artifact and ship it to mvmd through
         the authenticated upload contract when a remote is configured
-  - [~] WS2 `mvmctl watch`: rebuild on change, skip no-op rebuilds by address;
+  - [x] WS2 `mvmctl watch`: rebuild on change, skip no-op rebuilds by address;
         long-running mode recovers from transient input/compile errors while
         `--once` remains fail-fast
-  - [~] WS3 capture-from-sandbox via `reseal_volume`, converging on the
+  - [x] WS3 capture-from-sandbox via `reseal_volume`, converging on the
         declared-dependency path and keeping the lockfile hash pin; capture,
         `deps install`, and bounded `deps capture-live` implementation are
-        present. Focused mvm-cli (33) and mvm-build (21) tests, compile, build,
-        and Clippy gates pass; workspace/Linux-builder gates remain
+        present. PR #2132 passed branch and merge-group Test, Lint, and Nix
+        gates and merged into main
   - [~] WS4 tier follows the attestation
     - [x] Agent-verb grant derives from admitted run shape, not image sidecar
     - [~] Bind the tier to an attested artifact and replace the interactive

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,43 +10,37 @@
 
 ## Current issue delivery
 
-- [~] `mvmctl deps capture` — **plan 291 WS3**. Reseals a sandbox-captured
+- [x] `mvmctl deps capture` — **plan 291 WS3**. Reseals a sandbox-captured
       dependency tree with fresh audit sidecars, updates the lockfile index,
       refuses tampered or unpinned source volumes, and can emit the canonical
       `Dependencies` declaration after verifying the matching lockfile pin;
-      implementation is present. Focused mvm-cli dependency tests (33) and
-      mvm-build app-dependency tests (21) pass; workspace and Linux-builder
-      gates remain.
+      implementation is merged. PR #2132 passed branch and merge-group Test,
+      Lint, and Nix gates.
 
-- [~] `mvmctl watch` — **plan 291 WS2**. A file-backed Workload IR watcher
+- [x] `mvmctl watch` — **plan 291 WS2**. A file-backed Workload IR watcher
       polls local source inputs, recompiles only when the semantic IR address
       or source fingerprint changes, and reports rebuild/no-op iterations.
       Long-running mode now waits for the next change after transient input or
-      compile errors, while `--once` remains fail-fast for automation.
+      compile errors, while `--once` remains fail-fast for automation. PR
+      #2109 is merged and its required queue gates passed.
 - [~] Develop → build → deploy an attested workload image — **plan 291**.
-      The agent-verb grant now derives from the admitted run shape: baked
-      entrypoints on non-dev profiles receive the attenuated ProdSafe grant,
-      while PTY and ad-hoc argv runs remain DevOnly. This prerequisite no
-      longer keys interactive reachability on an image sidecar bit. Deploy
-      attestation, the remaining tier binding, and conformance witnesses stay
-      open in WS1–WS4. A ProdSafe-grant conformance test now proves both
-      Exec and ConsoleOpen are refused; the interactive feature fork and
-      guest-image validation remain open.
-- [~] `mvmctl watch` — **plan 291 WS2**. A file-backed Workload IR watcher
-      polls local source inputs, recompiles only when the semantic IR address
-      or source fingerprint changes, and reports rebuild/no-op iterations.
-- [~] `mvmctl deploy` — **plan 291 WS1**. Local deployment now has a durable
+      WS1–WS3 are merged with their queue-gate evidence. WS4 remains open:
+      the run tier must bind to the deploy record, the universal-agent design
+      needs its security decision, and guest-image conformance must replace
+      symbol-only witnesses.
+- [x] `mvmctl deploy` — **plan 291 WS1**. Local deployment now has a durable
       sealed archive and deploy record path, with BLAKE3 as the native artifact
       identity, SHA-256 retained for interoperability, optional environment
       pinning, and fail-closed verification of an explicitly supplied sealed
       dependency volume. A configured remote now ships the record and bundle
-      through mvmd’s authenticated upload contract. Host compilation and the
-      remaining workspace gates remain pending.
-- [~] `mvmctl deps install` runs the lockfile-pinned development install in the
+      through mvmd’s authenticated upload contract. PR #2131 passed branch and
+      merge-group Test, Lint, and Nix gates and merged into main.
+- [x] `mvmctl deps install` runs the lockfile-pinned development install in the
       builder boundary and publishes its sealed volume. `mvmctl deps
       capture-live` exports bounded guest content and sidecars before handing
       them to the atomic reseal path, and requires a running development VM;
-      implementation is present, with full workspace validation pending.
+      implementation is merged through PR #2132, whose branch and merge-group
+      Test, Lint, and Nix gates passed.
 
 - [~] Sensitive egress redaction — **plan 290**. The first delivery establishes
       a validated byte-span detector contract and supplements the curated

--- a/specs/plans/291-develop-build-deploy-attested.md
+++ b/specs/plans/291-develop-build-deploy-attested.md
@@ -1,8 +1,8 @@
 # Develop → build → deploy: one stupidly simple path to an attested workload image
 
-**Status:** In progress. WS3 capture, install, and live-capture paths are
-implemented; the deploy artifact path is also present, while authenticated
-remote transport and host-wide test gates remain.
+**Status:** In progress. WS1–WS3 are merged and their required queue gates are
+green; WS4 attestation binding and the universal-agent/conformance closure
+remain open.
 
 **Goal:** A developer starts from an OCI image or a Nix flake, iterates on a
 machine until the workload actually works — including discovering the
@@ -74,34 +74,31 @@ bug.
 
 ### WS1 — `mvmctl deploy`
 
-- [~] Seal the built image, compute its BLAKE3 identity, and write a deploy
+- [x] Seal the built image, compute its BLAKE3 identity, and write a deploy
       record: workload address (`ir_hash`), image BLAKE3, image SHA-256, the
       environment pin, sealed dep-volume hash, and the SBOM/CVE verdicts already
       produced by claim 11's pipeline.
-- [~] If a remote is configured, use the authenticated shipping contract. Until
+- [x] If a remote is configured, use the authenticated shipping contract. Until
       mvmd exposes that contract, fail closed after writing the local record;
       without a remote, stop at the local sealed artifact.
-- [~] Refuse to record an artifact whose dep volume fails
+- [x] Refuse to record an artifact whose dep volume fails
       `verify_sealed_volume`, so a deploy cannot launder a tampered volume.
-      The SDK path and tamper regression are green; full CLI/workspace gates
-      remain.
+      The SDK path and tamper regression are covered by the merged PR's branch
+      and merge-group Test, Lint, and Nix gates.
 
-**Open question for the owner.** `CLAUDE.md` states that deploy-to-control-plane
-commands live in mvmd, not mvmctl. Sealing, hashing and recording are artifact
-construction and belong in mvm; pushing to a control plane, tenants and
-placement belong in mvmd. This plan assumes `mvmctl deploy` performs the former
-and delegates the latter. If `mvmctl deploy` is meant to own the control-plane
-conversation directly, that is an architectural change and needs deciding
-before WS1 starts.
+The control-plane split is settled: sealing, hashing, and recording remain
+artifact construction in mvm; authenticated shipping, tenants, and placement
+remain mvmd responsibilities. `mvmctl deploy` performs the former and delegates
+the latter through mvmd's authenticated upload contract.
 
 ### WS2 — `mvmctl watch`
 
-- [~] Watch the workload source and rebuild the image on change.
+- [x] Watch the workload source and rebuild the image on change.
       The file-backed IR watcher polls local source inputs and invokes the
       existing deterministic compiler when the input fingerprint changes.
-- [~] Reuse the existing content addresses to skip no-op rebuilds: if the
+- [x] Reuse the existing content addresses to skip no-op rebuilds: if the
       `ir_hash` and inputs are unchanged, do nothing.
-- [~] Surface what changed and what it cost, so the loop teaches the developer
+- [x] Surface what changed and what it cost, so the loop teaches the developer
       what their workload actually depends on.
       Each iteration reports whether it rebuilt or found an unchanged state;
       rebuilds identify whether IR or source inputs changed and report compile
@@ -111,17 +108,17 @@ before WS1 starts.
 
 ### WS3 — capture dependencies from the sandbox
 
-- [~] `mvmctl deps capture` imports a sandbox-installed dependency tree and
+- [x] `mvmctl deps capture` imports a sandbox-installed dependency tree and
       its fresh SBOM, fetch log, and CVE result, then reseals it atomically
       through the existing volume verifier and lockfile index.
-- [~] Install into a development sandbox, then reseal via `reseal_volume` to
+- [x] Install into a development sandbox, then reseal via `reseal_volume` to
       capture it — new volume hash, refreshed SBOM, fresh CVE scan. The SDK's
       existing development `install_package` helpers perform the install;
       `mvmctl deps capture-live` requires a running development VM, exports
       bounded regular-file content and matching guest sidecars, and hands them
       to the atomic reseal path. `mvmctl deps install` covers the declared
       lockfile route.
-- [~] Emit the captured set back out as the canonical dependency declaration
+- [x] Emit the captured set back out as the canonical dependency declaration
       the developer can commit,
       so an interactively-discovered dependency becomes a declared one. The
       capture path must converge on the declared path, not fork from it. The
@@ -129,7 +126,7 @@ before WS1 starts.
       SHA-256 and emits the same `Dependencies` IR shape used by normal builds.
       It refuses declaration targets that would overwrite the lockfile or
       enter the sealed dependency cache.
-- [~] Keep the lockfile hash-pin requirement intact: a captured dependency is
+- [x] Keep the lockfile hash-pin requirement intact: a captured dependency is
       pinned like a declared one, or the seal refuses.
 
 **The opencv case, end to end:** the developer either declares it (works today)


### PR DESCRIPTION
## Summary

- mark Plan 291 WS1, WS2, and WS3 complete after their merged queue-gate evidence
- keep WS4 and the umbrella plan explicitly open for the remaining attestation and agent work
- synchronize the sprint and refactor rollup with the current GitHub state

## Validation

- `git diff --check`
- PR #2131 and PR #2132 branch and merge-group Test, Lint, and Nix checks passed

This is documentation-only and does not change runtime behavior.
