### PR TITLE
feat(machine): boot local attested deployments

### DIFF
--- a/crates/mvm-cli/src/commands/machine/lifecycle.rs
+++ b/crates/mvm-cli/src/commands/machine/lifecycle.rs
@@ -102,7 +102,15 @@ pub(super) fn start_machine(args: MachineStartArgs) -> Result<()> {
             "direct-boot".to_string(),
         )
     } else {
-        let (label, rootfs, digest) = if let Some(slot_hash) = &spec.manifest {
+        let (label, rootfs, digest) = if let Some(deployment_path) = &spec.deployment {
+            let deployment =
+                super::resolve_local_deployment(std::path::Path::new(deployment_path))?;
+            (
+                format!("deployment:{}", deployment.directory.display()),
+                deployment.rootfs,
+                deployment.boot_artifact_sha256,
+            )
+        } else if let Some(slot_hash) = &spec.manifest {
             let (_, _vmlinux, _initrd, rootfs, rev) =
                 mvm_runtime::vm::template::lifecycle::template_artifacts_for_slot(slot_hash)
                     .with_context(|| {
@@ -136,7 +144,7 @@ pub(super) fn start_machine(args: MachineStartArgs) -> Result<()> {
             )
         } else {
             anyhow::bail!(
-                "machine {name:?} spec has neither image nor manifest — use `machine rm` to remove and recreate it",
+                "machine {name:?} spec has neither deployment, image, nor manifest — use `machine rm` to remove and recreate it",
                 name = spec.name
             );
         };

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -45,7 +45,7 @@ use mvm_runtime::machine::persist::{
 
 use super::Cli;
 use super::build::build;
-use super::vm::exec::{RunArgs, RunProfile, run_secure, run_secure_with_source};
+use super::vm::exec::{RunArgs, RunProfile, run_secure_with_source};
 use super::vm::group::VmCmd;
 #[cfg(test)]
 use super::vm::host_signer::PUBLIC_FILENAME;
@@ -249,17 +249,20 @@ pub(in crate::commands) fn preflight_network(
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct MachineRunArgs {
     /// Boot an OCI image.
-    #[arg(long, value_name = "REF", conflicts_with_all = ["manifest", "flake", "runtime_pack"])]
+    #[arg(long, value_name = "REF", conflicts_with_all = ["manifest", "flake", "runtime_pack", "deployment"])]
     pub image: Option<String>,
     /// Boot a pre-built manifest.
-    #[arg(long, value_name = "PATH", conflicts_with_all = ["image", "flake", "runtime_pack"])]
+    #[arg(long, value_name = "PATH", conflicts_with_all = ["image", "flake", "runtime_pack", "deployment"])]
     pub manifest: Option<String>,
     /// Build and boot a Nix flake.
-    #[arg(long, value_name = "PATH", conflicts_with_all = ["image", "manifest", "runtime_pack"])]
+    #[arg(long, value_name = "PATH", conflicts_with_all = ["image", "manifest", "runtime_pack", "deployment"])]
     pub flake: Option<String>,
     /// Boot a verified runtime pack.
-    #[arg(long, conflicts_with_all = ["image", "manifest", "flake"])]
+    #[arg(long, conflicts_with_all = ["image", "manifest", "flake", "deployment"])]
     pub runtime_pack: bool,
+    /// Boot a local attested deployment (deploy.json plus rootfs.ext4).
+    #[arg(long, value_name = "DIR", conflicts_with_all = ["image", "manifest", "flake", "runtime_pack"])]
+    pub deployment: Option<PathBuf>,
     /// Select a flake package.
     #[arg(long, value_name = "PROFILE", requires = "flake")]
     pub flake_profile: Option<String>,
@@ -355,7 +358,7 @@ pub(in crate::commands) struct MachineRunArgs {
     pub kernel_pin: Option<String>,
     // ── Action axis: --entrypoint dispatches the image's baked entrypoint ──
     /// Run the image's baked entrypoint.
-    #[arg(long, conflicts_with_all = ["argv", "tty", "interactive"])]
+    #[arg(long, conflicts_with_all = ["argv", "tty", "interactive", "deployment"])]
     pub entrypoint: bool,
     /// Boot a fresh VM for the entrypoint.
     #[arg(long, requires = "entrypoint", conflicts_with = "reset")]
@@ -370,7 +373,7 @@ pub(in crate::commands) struct MachineRunArgs {
     #[arg(
         long,
         requires_all = ["entrypoint", "name"],
-        conflicts_with_all = ["image", "manifest", "flake", "fresh", "reset", "detach"]
+        conflicts_with_all = ["image", "manifest", "flake", "deployment", "fresh", "reset", "detach"]
     )]
     pub attach: bool,
     /// Command and arguments to run in the guest.
@@ -488,15 +491,65 @@ impl MachineRunArgs {
         if self.image.is_none()
             && self.manifest.is_none()
             && self.flake.is_none()
+            && self.deployment.is_none()
             && !self.runtime_pack
         {
             bail!(
-                "machine run needs `--image <ref>`, `--manifest <path>`, `--flake <path>`, or \
+                "machine run needs `--image <ref>`, `--manifest <path>`, `--flake <path>`, `--deployment <dir>`, or \
                  `--runtime-pack` to boot a new machine"
             );
         }
         Ok(())
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LocalDeployment {
+    pub directory: PathBuf,
+    pub rootfs: PathBuf,
+    pub boot_artifact_sha256: String,
+}
+
+/// Validate and resolve a local deployment before it can influence boot.
+/// Both the record schema and the exact selected rootfs bytes are checked.
+pub(super) fn resolve_local_deployment(path: &Path) -> Result<LocalDeployment> {
+    let directory = fs::canonicalize(path)
+        .with_context(|| format!("resolving deployment directory {}", path.display()))?;
+    if !directory.is_dir() {
+        bail!(
+            "deployment path is not a directory: {}",
+            directory.display()
+        );
+    }
+    let record_path = directory.join("deploy.json");
+    let rootfs = directory.join("rootfs.ext4");
+    let record = mvm_sdk::deploy::read_deploy_record(&record_path)
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("reading deployment record {}", record_path.display()))?;
+    mvm_sdk::deploy::verify_boot_artifact(&rootfs, &record.boot_artifact)
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("verifying deployment boot artifact {}", rootfs.display()))?;
+    Ok(LocalDeployment {
+        directory,
+        rootfs,
+        boot_artifact_sha256: record.boot_artifact.sha256,
+    })
+}
+
+/// Turn a validated deployment into the common transient-run image source.
+pub(super) fn local_deployment_image_source(
+    deployment: &LocalDeployment,
+) -> Result<crate::exec::ImageSource> {
+    let kernel_path = super::env::builder_vm::ensure_workload_kernel()
+        .context("resolving workload kernel for local deployment")?;
+    super::env::builder_vm::assert_workload_kernel_supports_verity(&kernel_path)?;
+    Ok(crate::exec::ImageSource::Prebuilt {
+        kernel_path,
+        rootfs_path: deployment.rootfs.display().to_string(),
+        initrd_path: None,
+        label: format!("deployment:{}", deployment.directory.display()),
+        virtiofs_oci_root: None,
+    })
 }
 
 /// The lifecycle `machine run` resolves to, computed purely from the parsed
@@ -611,26 +664,29 @@ fn machine_run_spec(
     resolved_manifest_slot: Option<&str>,
 ) -> Result<MachineSpec> {
     validate_machine_name(&name)?;
-    let (image, manifest) = if let Some(slot) = resolved_manifest_slot {
+    let (image, manifest, deployment) = if let Some(path) = &args.deployment {
+        let deployment = resolve_local_deployment(path)?;
+        (None, None, Some(deployment.directory.display().to_string()))
+    } else if let Some(slot) = resolved_manifest_slot {
         // Flake was pre-built; store the slot hash as the manifest source.
-        (None, Some(slot.to_string()))
+        (None, Some(slot.to_string()), None)
     } else if let Some(m) = &args.manifest {
         // Manifest-backed: store the manifest ref.
-        (None, Some(m.clone()))
+        (None, Some(m.clone()), None)
     } else if let Some(img) = &args.image {
         // Image-backed: store the OCI ref.
-        (Some(img.clone()), None)
+        (Some(img.clone()), None, None)
     } else if args.runtime_pack {
         // The verified runtime pack is its own source; recorded via
         // `runtime_pack: true` below, not `image`/`manifest`.
-        (None, None)
+        (None, None, None)
     } else if std::env::var("MVM_DIRECT_BOOT").as_deref() == Ok("1") {
         // Test escape: kernel + rootfs from env vars; no persistent source.
-        (None, None)
+        (None, None, None)
     } else {
         bail!(
-            "machine run needs `--image <ref>`, `--manifest <path>`, `--flake <path>`, or \
-             `--runtime-pack` to create machine {name:?}"
+            "machine run needs `--image <ref>`, `--manifest <path>`, `--flake <path>`, `--deployment <dir>`, or \
+                 `--runtime-pack` to create machine {name:?}"
         );
     };
     super::shared::resolve_run_network_policy(args.net, &args.allow_host)?;
@@ -641,6 +697,7 @@ fn machine_run_spec(
         name,
         image,
         manifest,
+        deployment,
         resolved_digest: None,
         runtime_pack: args.runtime_pack,
         net: args.net,
@@ -1039,6 +1096,7 @@ impl MachineCreateArgs {
             name,
             image: Some(image),
             manifest: None,
+            deployment: None,
             resolved_digest: None,
             runtime_pack: false,
             net,
@@ -1424,6 +1482,7 @@ fn run_args_for_image_revert(
             json: run.json,
             name: None,
             manifest,
+            deployment: None,
             runtime_pack: false,
             flake_profile: None,
             net: false,

--- a/crates/mvm-cli/src/commands/machine/receipt.rs
+++ b/crates/mvm-cli/src/commands/machine/receipt.rs
@@ -11,6 +11,8 @@ pub(super) struct MachineStartReceiptInput {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) manifest: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) deployment: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) resolved_digest: Option<String>,
     pub(super) cpus: u32,
     pub(super) memory: String,
@@ -184,6 +186,7 @@ pub(super) fn machine_start_receipt_input(
         machine_name: spec.name.clone(),
         image: spec.image.clone(),
         manifest: spec.manifest.clone(),
+        deployment: spec.deployment.clone(),
         resolved_digest: spec.resolved_digest.clone(),
         cpus: spec.cpus,
         memory: spec.memory.clone(),

--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -12,13 +12,14 @@ pub(super) fn resolve_persistent_spec(
     let direct_boot = std::env::var("MVM_DIRECT_BOOT").as_deref() == Ok("1");
     let has_source = args.image.is_some()
         || args.manifest.is_some()
+        || args.deployment.is_some()
         || resolved_manifest_slot.is_some()
         || direct_boot;
     if !has_source {
         return match existing {
             Some(spec) => Ok((spec, SpecReconcile::Reuse)),
             None => anyhow::bail!(
-                "machine {name:?} does not exist; pass --image, --manifest, or --flake to create it"
+                "machine {name:?} does not exist; pass --image, --manifest, --deployment, or --flake to create it"
             ),
         };
     }
@@ -194,6 +195,11 @@ pub(super) fn resolve_machine_build_mode(manifest: Option<&str>, name: &str) -> 
 }
 
 fn run_entrypoint_action(args: MachineRunArgs, resolved_flake_slot: Option<String>) -> Result<()> {
+    if args.deployment.is_some() {
+        anyhow::bail!(
+            "machine run --entrypoint does not accept --deployment; use a manifest or flake source"
+        );
+    }
     if args.image.is_some() {
         anyhow::bail!(
             "machine run --entrypoint dispatches a manifest/flake image's baked \
@@ -262,6 +268,11 @@ pub(super) fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig)
     } else {
         None
     };
+    let local_deployment = args
+        .deployment
+        .as_deref()
+        .map(super::resolve_local_deployment)
+        .transpose()?;
 
     // Settle the networking configuration before any build or boot work.
     // There is no mode to choose: the derivation picks the strongest
@@ -292,7 +303,11 @@ pub(super) fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig)
             run_args.warm_pool_size = warm_pool_size;
             use std::io::IsTerminal as _;
             run_args.stdin = invoke::read_auto_stdin(std::io::stdin().is_terminal())?;
-            run_secure(cli, run_args, cfg)
+            let source = local_deployment
+                .as_ref()
+                .map(super::local_deployment_image_source)
+                .transpose()?;
+            run_secure_with_source(cli, run_args, cfg, source)
         }
         MachineRunMode::Persistent => {
             run_persistent(cli, args, cfg, resolved_flake_slot.as_deref())
@@ -307,7 +322,11 @@ pub(super) fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig)
             run_args.pty = true;
             run_args.warm_pool_size = warm_pool_size;
             run_args.stdin = invoke::read_auto_stdin(std::io::stdin().is_terminal())?;
-            run_secure(cli, run_args, cfg)
+            let source = local_deployment
+                .as_ref()
+                .map(super::local_deployment_image_source)
+                .transpose()?;
+            run_secure_with_source(cli, run_args, cfg, source)
         }
     }
 }
@@ -330,6 +349,7 @@ pub(in crate::commands) fn boot_persistent_by_name(
             detach: true,
             image: None,
             manifest: None,
+            deployment: None,
             runtime_pack: false,
             flake_profile: None,
             net: false,

--- a/crates/mvm-cli/src/commands/machine/spec_ops.rs
+++ b/crates/mvm-cli/src/commands/machine/spec_ops.rs
@@ -30,6 +30,9 @@ pub(super) fn inspect_machine(args: MachineInspectArgs) -> Result<()> {
         if let Some(manifest) = spec.manifest.as_deref() {
             println!("manifest: {}", manifest);
         }
+        if let Some(deployment) = spec.deployment.as_deref() {
+            println!("deployment: {}", deployment);
+        }
         if let Some(resolved_digest) = spec.resolved_digest.as_deref() {
             println!("resolved-digest: {resolved_digest}");
         }

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -305,6 +305,25 @@ fn run_runtime_pack_conflicts_with_image_manifest_and_flake() {
 }
 
 #[test]
+fn run_parses_deployment_source_and_conflicts_with_other_sources() {
+    let args = parse_run(&["run", "--deployment", "/tmp/deployment", "--", "true"])
+        .expect("deployment source parses");
+    assert_eq!(args.deployment, Some(PathBuf::from("/tmp/deployment")));
+
+    let err = parse_run(&[
+        "run",
+        "--deployment",
+        "/tmp/deployment",
+        "--image",
+        "alpine",
+        "--",
+        "true",
+    ])
+    .expect_err("deployment and image must be mutually exclusive");
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
 fn run_parses_and_forwards_net_flags() {
     let args = parse_run(&[
         "run",
@@ -575,6 +594,7 @@ fn spec_fixture(name: &str) -> MachineSpec {
         name: name.to_string(),
         image: Some("alpine:latest".to_string()),
         manifest: None,
+        deployment: None,
         resolved_digest: None,
         runtime_pack: false,
         net: false,
@@ -624,6 +644,58 @@ fn run_spec_maps_run_args_into_a_machine_spec() {
     assert!(spec.init.is_empty());
     // No --agent-verb: spec stores an empty list (computed default applies at start).
     assert!(spec.agent_verb.is_empty());
+}
+
+#[test]
+fn deployment_source_is_verified_and_persisted_as_canonical_directory() {
+    let dir = tempfile::tempdir().expect("deployment dir");
+    let rootfs = dir.path().join("rootfs.ext4");
+    std::fs::write(&rootfs, b"rootfs bytes").expect("rootfs");
+    let boot_artifact = mvm_sdk::deploy::digest_boot_artifact(&rootfs).expect("digest");
+    let record = mvm_sdk::deploy::DeployRecord {
+        schema_version: mvm_sdk::deploy::DEPLOY_RECORD_SCHEMA_VERSION,
+        workload_id: "demo".to_string(),
+        ir_hash: "ir".to_string(),
+        image: mvm_sdk::deploy::ArtifactDigests {
+            blake3: "0".repeat(64),
+            sha256: "0".repeat(64),
+            size_bytes: 0,
+        },
+        boot_artifact,
+        environment: None,
+        dependency_volume: None,
+    };
+    mvm_sdk::deploy::write_deploy_record(&record, &dir.path().join("deploy.json")).expect("record");
+
+    let args = parse_run(&[
+        "run",
+        "--deployment",
+        dir.path().to_str().expect("utf8 path"),
+        "--name",
+        "web",
+        "-d",
+    ])
+    .expect("parse");
+    let spec = machine_run_spec(&args, "web".to_string(), None).expect("spec");
+    assert_eq!(
+        spec.deployment.as_deref(),
+        Some(
+            dir.path()
+                .canonicalize()
+                .expect("canonical")
+                .to_str()
+                .expect("utf8")
+        )
+    );
+    assert!(spec.image.is_none());
+    assert!(spec.manifest.is_none());
+
+    std::fs::write(&rootfs, b"tampered").expect("tamper");
+    let err = resolve_local_deployment(dir.path()).expect_err("tampered rootfs refused");
+    assert!(
+        err.to_string()
+            .contains("verifying deployment boot artifact")
+    );
 }
 
 #[test]
@@ -1374,6 +1446,7 @@ fn mark_machine_started_sets_digest_and_timestamp() {
         name: "web".to_string(),
         image: Some("alpine:latest".to_string()),
         manifest: None,
+        deployment: None,
         resolved_digest: None,
         runtime_pack: false,
         net: false,
@@ -1560,6 +1633,7 @@ fn machine_start_receipt_input_redacts_host_paths_and_surfaces_policy() {
         name: "web".to_string(),
         image: Some("ghcr.io/acme/web:latest".to_string()),
         manifest: None,
+        deployment: None,
         resolved_digest: Some("sha256:abc".to_string()),
         runtime_pack: false,
         net: false,
@@ -1606,6 +1680,7 @@ fn machine_start_receipt_is_signed_and_verifiable() {
         machine_name: "web".to_string(),
         image: Some("ghcr.io/acme/web:latest".to_string()),
         manifest: None,
+        deployment: None,
         resolved_digest: Some("sha256:abc".to_string()),
         cpus: 2,
         memory: "512M".to_string(),
@@ -1645,6 +1720,7 @@ fn machine_start_preflight_reports_uniform_l4_enforcement_for_oci_allow_host() {
         name: "web".to_string(),
         image: Some("ghcr.io/acme/web:latest".to_string()),
         manifest: None,
+        deployment: None,
         resolved_digest: None,
         runtime_pack: false,
         net: false,
@@ -1700,6 +1776,7 @@ fn create_refuses_overwrite_without_force() {
         name: "web".to_string(),
         image: Some("alpine:latest".to_string()),
         manifest: None,
+        deployment: None,
         resolved_digest: None,
         runtime_pack: false,
         net: false,
@@ -1729,6 +1806,7 @@ fn remove_machine_spec_requires_confirmation_and_deletes_dir() {
         name: "web".to_string(),
         image: Some("alpine:latest".to_string()),
         manifest: None,
+        deployment: None,
         resolved_digest: None,
         runtime_pack: false,
         net: false,
@@ -1760,6 +1838,7 @@ fn seed_machine_spec(name: &str) {
         name: name.to_string(),
         image: Some(format!("example/{name}:latest")),
         manifest: None,
+        deployment: None,
         resolved_digest: None,
         runtime_pack: false,
         net: false,
@@ -2197,6 +2276,7 @@ fn reconfigure_spec_fixture() -> MachineSpec {
         name: "web".into(),
         image: Some("img:1".into()),
         manifest: None,
+        deployment: None,
         resolved_digest: None,
         runtime_pack: false,
         net: false,

--- a/crates/mvm-client/src/inventory.rs
+++ b/crates/mvm-client/src/inventory.rs
@@ -302,6 +302,7 @@ mod tests {
             name: name.to_string(),
             image: Some("alpine:latest".to_string()),
             manifest: None,
+            deployment: None,
             resolved_digest: None,
             runtime_pack: false,
             net: false,

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -1328,6 +1328,7 @@ mod tests {
             created_at: None,
             last_started_at: None,
             health_check: None,
+            deployment: None,
         };
         save_machine_spec(&spec, false).expect("persist_test_spec: save failed");
     }

--- a/crates/mvm-hostd/src/health_probe.rs
+++ b/crates/mvm-hostd/src/health_probe.rs
@@ -511,6 +511,7 @@ mod tests {
             name: name.to_string(),
             image: Some("alpine:latest".to_string()),
             manifest: None,
+            deployment: None,
             runtime_pack: false,
             resolved_digest: None,
             net: false,

--- a/crates/mvm-runtime/src/machine/persist.rs
+++ b/crates/mvm-runtime/src/machine/persist.rs
@@ -39,6 +39,10 @@ pub struct MachineSpec {
     /// image-backed machines.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub manifest: Option<String>,
+    /// Local attested deployment directory containing `deploy.json` and
+    /// `rootfs.ext4`. Present for machines created with `--deployment`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployment: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_digest: Option<String>,
     /// Boot from the verified downloadable runtime pack instead of an OCI
@@ -163,6 +167,7 @@ pub fn list_machine_specs() -> Result<Vec<MachineSpec>> {
 pub fn machine_config_matches(a: &MachineSpec, b: &MachineSpec) -> bool {
     a.image == b.image
         && a.manifest == b.manifest
+        && a.deployment == b.deployment
         && a.runtime_pack == b.runtime_pack
         && a.net == b.net
         && a.allow_host == b.allow_host
@@ -184,6 +189,7 @@ pub fn machine_config_diff(current: &MachineSpec, desired: &MachineSpec) -> Stri
     // without this a manifest-only swap recreates with an empty `changed` list.
     if current.image != desired.image
         || current.manifest != desired.manifest
+        || current.deployment != desired.deployment
         || current.runtime_pack != desired.runtime_pack
     {
         changed.push("source");
@@ -343,6 +349,7 @@ mod tests {
             name: name.to_string(),
             image: Some("alpine:latest".to_string()),
             manifest: None,
+            deployment: None,
             resolved_digest: None,
             runtime_pack: false,
             net: false,
@@ -409,6 +416,7 @@ mod tests {
             spec.agent_verb.is_empty(),
             "agent_verb should default empty"
         );
+        assert!(spec.deployment.is_none());
         assert!(spec.volumes.is_empty(), "volumes should default empty");
         assert!(spec.init.is_empty(), "init should default empty");
         assert!(spec.created_at.is_none());
@@ -517,6 +525,7 @@ mod tests {
             name: "web".into(),
             image: Some("img:1".into()),
             manifest: None,
+            deployment: None,
             resolved_digest: None,
             runtime_pack: false,
             net: false,
@@ -593,6 +602,17 @@ mod tests {
         desired.manifest = Some("slot-bbbb".to_string());
         let changed = machine_config_diff(&current, &desired);
         assert!(changed.contains("source"), "changed: {changed}");
+    }
+
+    #[test]
+    fn config_diff_reports_deployment_source_change() {
+        let current = spec_fixture("web");
+        let mut desired = spec_fixture("web");
+        desired.image = None;
+        desired.deployment = Some("/tmp/deployment".to_string());
+        let changed = machine_config_diff(&current, &desired);
+        assert!(changed.contains("source"), "changed: {changed}");
+        assert!(!machine_config_matches(&current, &desired));
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -22,9 +22,11 @@ for detailed scope and acceptance criteria.
   - [~] WS4 tier follows the attestation
     - [x] Agent-verb grant derives from admitted run shape, not image sidecar
     - [~] Bind the tier to an attested artifact and replace the interactive
-          feature/symbol witnesses with conformance scenarios. Grant
-          enforcement now proves a complete ProdSafe grant refuses Exec and
-          ConsoleOpen; feature-fork removal and guest-image validation remain.
+          feature/symbol witnesses with conformance scenarios. Local
+          `machine run --deployment` verifies and persists the signed record
+          plus exact rootfs binding; remote extraction/boot, feature-fork
+          removal, and guest-image validation remain. Grant enforcement now
+          proves a complete ProdSafe grant refuses Exec and ConsoleOpen.
 
 - [~] Plan 290 — Sensitive egress redaction
       (`specs/plans/290-sensitive-egress-redaction.md`)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -25,9 +25,10 @@
       #2109 is merged and its required queue gates passed.
 - [~] Develop → build → deploy an attested workload image — **plan 291**.
       WS1–WS3 are merged with their queue-gate evidence. WS4 remains open:
-      the run tier must bind to the deploy record, the universal-agent design
-      needs its security decision, and guest-image conformance must replace
-      symbol-only witnesses.
+      local `machine run --deployment` now verifies and persists an exact
+      deploy record/rootfs binding, while remote record extraction and boot,
+      the universal-agent design decision, and guest-image conformance remain
+      open. Tracking issue #2144 owns the local/remote boot acceptance matrix.
 - [x] `mvmctl deploy` — **plan 291 WS1**. Local deployment now has a durable
       sealed archive and deploy record path, with BLAKE3 as the native artifact
       identity, SHA-256 retained for interoperability, optional environment

--- a/specs/plans/291-develop-build-deploy-attested.md
+++ b/specs/plans/291-develop-build-deploy-attested.md
@@ -138,8 +138,12 @@ same sealed, hash-pinned, CVE-scanned volume.
 - [x] Make the agent-verb grant depend on the admitted run shape rather than
       the image sidecar: a baked-entrypoint boot on a non-dev profile receives
       ProdSafe verbs; a PTY or ad-hoc argv receives DevOnly verbs.
-- [ ] Make the run tier come from whether the run uses an attested artifact,
-      not from a build variant and not from an unattested CLI flag.
+- [~] Make the run tier come from whether the run uses an attested artifact,
+      not from a build variant and not from an unattested CLI flag. Local
+      `mvmctl machine run --deployment DIR` now verifies the signed deploy
+      record and exact `rootfs.ext4`, persists the canonical deployment
+      directory, and revalidates it on restart. Remote record extraction and
+      boot remain in follow-up issue #2144.
 - [ ] Retire the `interactive` Cargo feature fork so one agent binary serves
       both tiers; the existing `RequestClass::{ProdSafe, DevOnly}` gate and the
       signed `VerbGrant` already do the enforcement.


### PR DESCRIPTION
## Summary

- Add mvmctl machine run --deployment DIR for local deploy records.
- Verify the signed deploy.json and exact rootfs.ext4 before boot.
- Persist the canonical deployment directory and revalidate it on restart.
- Carry the verified boot-artifact identity into the start receipt and inspect output.
- Keep the existing OCI, manifest, flake, and runtime-pack source paths unchanged.

## Verification

- cargo fmt --all -- --check
- cargo build -p mvm-cli --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --doc
- Feature-gated conformance: 115 scenarios, 523 steps passed.
- Direct xtask policy and security gates passed.
- Focused deployment, persistence, and socket tests passed.

The broad host cargo test --workspace rerun was stopped after an unrelated host-side Unix-socket test stalled for more than seven minutes; that test passes serially. Merge-group CI is the required full-suite gate.

## Scope

This PR delivers the local half of the deploy-record boot contract. Remote extraction and boot, interactive feature-fork retirement, and guest-image conformance remain tracked in #2144 and are intentionally not closed here.

Related: #2144, #2141, #2127, #2123