### PR TITLE
feat(core): carry attested deployment references

### DIFF
--- a/crates/mvm-core/src/domain/agent.rs
+++ b/crates/mvm-core/src/domain/agent.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 use crate::instance::InstanceState;
 use crate::node::{NodeInfo, NodeStats};
 use crate::pool::{
-    DesiredCounts, InstanceResources, RegistryArtifact, Role, RuntimePolicy, SecretScope,
-    SleepPolicyConfig, UpdateStrategy,
+    AttestedDeployment, DesiredCounts, InstanceResources, RegistryArtifact, Role, RuntimePolicy,
+    SecretScope, SleepPolicyConfig, UpdateStrategy,
 };
 use crate::routing::RoutingTable;
 use crate::signing::SignedPayload;
@@ -87,6 +87,11 @@ pub struct DesiredPool {
     /// a local Nix build. Falls back to local build if the pull fails.
     #[serde(default)]
     pub registry_artifact: Option<RegistryArtifact>,
+    /// Attested deployment bundle to fetch from mvmd before this pool boots.
+    /// Unlike `registry_artifact`, a failed fetch is terminal for this
+    /// desired revision and must not fall back to a local build.
+    #[serde(default)]
+    pub attested_deployment: Option<AttestedDeployment>,
     /// Distributed-volume mounts attached to every instance of this pool.
     ///
     /// Schema evolution: `#[serde(default)]` keeps the old-coordinator →
@@ -1231,6 +1236,7 @@ mod tests {
                 health_check_timeout_secs: 90,
             })),
             registry_artifact: None,
+            attested_deployment: None,
             mounts: vec![],
         };
         let json = serde_json::to_string(&pool).unwrap();
@@ -1306,6 +1312,7 @@ mod tests {
         let parsed: DesiredPool = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.pool_id, "gateways");
         assert!(parsed.registry_artifact.is_none());
+        assert!(parsed.attested_deployment.is_none());
     }
 
     #[test]
@@ -1372,6 +1379,7 @@ mod tests {
                 template_id: "hello".to_string(),
                 revision: Some("rev-abc123".to_string()),
             }),
+            attested_deployment: None,
             mounts: vec![],
         };
         let json = serde_json::to_string(&pool).unwrap();
@@ -1444,6 +1452,7 @@ mod tests {
             sleep_policy: None,
             default_update_strategy: None,
             registry_artifact: None,
+            attested_deployment: None,
             mounts: vec![mount.clone()],
         };
         let json = serde_json::to_string(&pool).unwrap();

--- a/crates/mvm-core/src/domain/pool.rs
+++ b/crates/mvm-core/src/domain/pool.rs
@@ -250,6 +250,18 @@ pub struct RegistryArtifact {
     pub revision: Option<String>,
 }
 
+/// Reference to an attested deployment bundle stored by mvmd.
+///
+/// The revision is the bundle's SHA-256 transport identity. The agent must
+/// fetch and verify the deploy record and its embedded boot artifact before it
+/// makes this revision current; it must not substitute a local build.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AttestedDeployment {
+    /// SHA-256 revision returned by the authenticated deploy-artifact upload.
+    pub revision: String,
+}
+
 // ============================================================================
 // Pool spec
 // ============================================================================
@@ -665,6 +677,22 @@ mod tests {
         // revision: None should be omitted or null
         let parsed: RegistryArtifact = serde_json::from_str(&json).unwrap();
         assert!(parsed.revision.is_none());
+    }
+
+    #[test]
+    fn test_attested_deployment_serde_roundtrip() {
+        let deployment = AttestedDeployment {
+            revision: "a".repeat(64),
+        };
+        let json = serde_json::to_string(&deployment).unwrap();
+        let parsed: AttestedDeployment = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, deployment);
+    }
+
+    #[test]
+    fn test_attested_deployment_rejects_unknown_fields() {
+        let json = format!(r#"{{"revision":"{}","tenant_id":"other"}}"#, "a".repeat(64));
+        assert!(serde_json::from_str::<AttestedDeployment>(&json).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- add a strict desired-state reference for an attested mvmd deployment revision\n- keep it distinct from the legacy registry artifact path\n- preserve backward compatibility for older desired-state payloads\n\n## Verification\n- cargo test -p mvm-core (1,495 tests plus doctests)\n- pre-commit workspace cargo clippy --workspace --all-targets -- -D warnings\n- cargo fmt --all -- --check\n\nThis is the shared schema seam for the remote deploy consumer tracked in mvmd#208 and mvm#2144.