### PR TITLE
feat(client): complete persistent and transient launch lifecycle through LocalBackend

### DIFF
--- a/crates/mvm-client/src/inventory.rs
+++ b/crates/mvm-client/src/inventory.rs
@@ -169,9 +169,9 @@ fn persistent_record(
         .created_at(spec.created_at)
         .last_started_at(spec.last_started_at)
         .volumes(volumes)
-        // No secret references are persisted on a machine definition today;
-        // the field exists in the contract so consumers get a count — never
-        // a value — the moment a secret-bearing source is wired in.
+        // The pure join carries no host reach; the local composition
+        // back-fills the real count from the machine's `secret-refs.json`
+        // sidecar via [`apply_secret_ref_counts`] — a count, never a value.
         .secret_ref_count(0);
 
     if let Some(live) = live {
@@ -249,8 +249,31 @@ pub fn apply_registry_readiness(records: &mut [MachineInventoryRecord]) {
     }
 }
 
+/// Count of secret references recorded in `name`'s metadata-only
+/// `secret-refs.json` sidecar under `machines_root`. Tolerant by design: an
+/// absent or unreadable sidecar reads as `0` — the listing must not fail on
+/// one bad sidecar (deletion decisions fail closed at the service seam, not
+/// here).
+pub fn secret_ref_count_of(machines_root: &std::path::Path, name: &str) -> u32 {
+    crate::secret::refs::load_refs(machines_root, name)
+        .ok()
+        .flatten()
+        .map(|record| record.references.len() as u32)
+        .unwrap_or(0)
+}
+
+/// Back-fill each record's `secret_ref_count` from the machine's persisted
+/// secret-reference sidecar — the count only, never a name-to-value reach.
+pub fn apply_secret_ref_counts(records: &mut [MachineInventoryRecord]) {
+    let root = mvm_core::config::machine_state_root();
+    for record in records {
+        record.secret_ref_count = secret_ref_count_of(&root, &record.name);
+    }
+}
+
 /// The full local inventory: every persisted machine definition joined with
-/// every live VM `client` can see, readiness back-filled from the registry.
+/// every live VM `client` can see, readiness back-filled from the registry
+/// and secret-reference counts from the per-machine sidecars.
 /// Read-only — no state dir, registry entry, or audit log is mutated.
 /// Filter with [`InventoryQuery::matches`]; the unfiltered stream includes
 /// stopped and expired machines so callers own visibility policy.
@@ -260,6 +283,7 @@ pub async fn list_local_inventory(client: &dyn MvmClient) -> Result<Vec<MachineI
     })?;
     let mut records = inventory_with_specs(client, specs).await?;
     apply_registry_readiness(&mut records);
+    apply_secret_ref_counts(&mut records);
     Ok(records)
 }
 
@@ -527,6 +551,66 @@ mod tests {
     fn secret_ref_count_is_zero_with_no_secret_source() {
         let records = join_inventory(vec![spec("web")], vec![], stub_posture);
         assert_eq!(records[0].secret_ref_count, 0);
+    }
+
+    /// Record a sidecar fixture for `machine` under `root`.
+    fn record_ref_fixture(root: &std::path::Path, machine: &str) {
+        std::fs::create_dir_all(root.join(machine)).unwrap();
+        std::fs::write(root.join(machine).join("machine.json"), b"{}").unwrap();
+        crate::secret::refs::record_refs(
+            root,
+            machine,
+            &[crate::secret::MachineSecretRef {
+                tenant: "local".into(),
+                name: "openai".into(),
+                placeholder_var: Some("API_KEY".into()),
+                destinations: vec!["api.openai.com".into()],
+            }],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn secret_ref_count_reads_the_recorded_sidecar() {
+        let tmp = tempfile::tempdir().unwrap();
+        record_ref_fixture(tmp.path(), "web");
+        assert_eq!(secret_ref_count_of(tmp.path(), "web"), 1);
+        // Absent sidecar → 0; malformed sidecar degrades to 0 (listing
+        // tolerance — deletion decisions fail closed elsewhere).
+        assert_eq!(secret_ref_count_of(tmp.path(), "other"), 0);
+        std::fs::write(
+            tmp.path()
+                .join("web")
+                .join(crate::secret::refs::MACHINE_SECRET_REFS_FILENAME),
+            b"not-json",
+        )
+        .unwrap();
+        assert_eq!(secret_ref_count_of(tmp.path(), "web"), 0);
+    }
+
+    #[tokio::test]
+    async fn list_local_inventory_reports_recorded_secret_ref_counts() {
+        let _home = IsolatedHome::new();
+        persist::save_machine_spec(&spec("web"), false).expect("save spec");
+        crate::secret::refs::record_refs(
+            &mvm_core::config::machine_state_root(),
+            "web",
+            &[crate::secret::MachineSecretRef {
+                tenant: "local".into(),
+                name: "openai".into(),
+                placeholder_var: Some("API_KEY".into()),
+                destinations: vec!["api.openai.com".into()],
+            }],
+        )
+        .unwrap();
+
+        let mock = MockBackend::default();
+        let records = list_local_inventory(&mock).await.expect("inventory");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].secret_ref_count, 1, "count from the sidecar");
+        // The serialized record carries the count, never the reference names.
+        let json = serde_json::to_string(&records[0]).unwrap();
+        assert!(!json.contains("openai"), "no secret name in record: {json}");
     }
 
     #[test]

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -736,6 +736,10 @@ impl LocalBackend {
                 self.stop_for_recreate(name);
             }
             self.release_session_resources(name)?;
+            // Drop the per-VM runtime dir too: a stale substitution-endpoint
+            // socket left behind blocks the next launch under the same name
+            // (the endpoint dies binding it, before its ready handshake).
+            remove_dir_if_present(&vm_state_dir(name))?;
             // The definition directory carries machine.json plus the
             // secret-refs sidecar (already cleared above) — drop it whole.
             remove_dir_if_present(&machine_state_dir(name))?;

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -650,13 +650,13 @@ impl LocalBackend {
                 expires_at: expires_at_from_ttl(request.ttl_seconds),
                 ..Default::default()
             },
-            plan_id: started.admitted.plan_id.0.clone(),
+            plan_id: started.admitted.plan_id().0.clone(),
             mode: if transient {
                 LifecycleMode::Transient
             } else {
                 LifecycleMode::Persistent
             },
-            plan: started.admitted.plan,
+            plan: started.admitted.plan().clone(),
         }
     }
 }

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -519,13 +519,40 @@ impl LocalBackend {
 
     /// Boot a persistent definition that was just created/reconciled from
     /// `request` (TTL and backend override honored from the request).
+    ///
+    /// The reconciled on-disk definition — not the request — is the boot
+    /// authority: the `Reuse` arm keeps an earlier definition, so the spec
+    /// is re-checked for in-process bootability and the sidecar's recorded
+    /// secret references are re-validated fail-closed even when this
+    /// request carries none.
     async fn boot_persistent(&self, name: &str, request: &LaunchRequest) -> Result<LaunchOutcome> {
         if self.machine_running(name) {
             return Err(MvmError::Conflict {
                 reason: format!("machine {name:?} is already running"),
             });
         }
+        let spec = mp::load_machine_spec(name).map_err(crate::local::backend_err)?;
+        ensure_spec_bootable_in_process(&spec)?;
+        self.validate_sidecar_refs(name)?;
         self.attach_lease_and_boot(name, request, false).await
+    }
+
+    /// Re-validate the secret references recorded in `name`'s sidecar —
+    /// the fail-closed gate every persistent admission passes, whether the
+    /// references arrived with this request or with an earlier create.
+    fn validate_sidecar_refs(&self, name: &str) -> Result<()> {
+        let refs = crate::secret::refs::load_refs(&machine_state_root(), name)
+            .map_err(|e| crate::local::backend_err(format!("loading secret refs: {e:#}")))?
+            .map(|record| record.references)
+            .unwrap_or_default();
+        if refs.is_empty() {
+            return Ok(());
+        }
+        self.secrets()?
+            .validate_for_admission(LOCAL_TENANT, &refs)
+            .map_err(|e| MvmError::Rejected {
+                reason: format!("secret reference admission refused: {e}"),
+            })
     }
 
     /// Shared tail of both launch paths: acquire volume leases, boot through
@@ -664,17 +691,7 @@ impl LocalBackend {
             });
         }
         let image = ensure_spec_bootable_in_process(&spec)?;
-        let refs = crate::secret::refs::load_refs(&machine_state_root(), name)
-            .map_err(|e| crate::local::backend_err(format!("loading secret refs: {e:#}")))?
-            .map(|record| record.references)
-            .unwrap_or_default();
-        if !refs.is_empty() {
-            self.secrets()?
-                .validate_for_admission(LOCAL_TENANT, &refs)
-                .map_err(|e| MvmError::Rejected {
-                    reason: format!("secret reference admission refused: {e}"),
-                })?;
-        }
+        self.validate_sidecar_refs(name)?;
         let memory_mib =
             mvm_core::util::parse_human_size(&spec.memory).map_err(crate::local::backend_err)?;
         let request = LaunchRequest::builder(LifecycleMode::Persistent, image)
@@ -808,12 +825,11 @@ impl LocalBackend {
     pub fn report_exit(&self, outcome: &LaunchOutcome) -> Result<ExitReport> {
         let name = outcome.machine.name.as_str();
         let exit_code = mvm_core::exit_capture::read_captured(&vm_state_dir(name));
+        // Capture fidelity: a missing capture is recorded as uncaptured,
+        // never attested as exit 0.
         if let Some(emitter) = build_audit_emitter()
-            && let Err(e) = emitter.emit_exited(
-                &outcome.plan,
-                exit_code.unwrap_or(0),
-                &outcome.machine.backend,
-            )
+            && let Err(e) =
+                emitter.emit_exited_with_capture(&outcome.plan, exit_code, &outcome.machine.backend)
         {
             tracing::warn!(error = %e, machine = name, "audit emit_exited failed (non-fatal)");
         }

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -237,6 +237,13 @@ impl LocalBackend {
     /// created.
     pub(crate) async fn boot_admitted(&self, params: BootParams) -> Result<StartedMachine> {
         let backend = self.launch_backend(params.backend_override.as_deref())?;
+        // Crash/unclean-stop leftovers in the per-VM runtime dir (notably a
+        // stale substitution-endpoint socket) make the fresh endpoint die
+        // binding it before its ready handshake; a non-running machine owns
+        // no live state there, so recover by starting from an empty dir.
+        if !self.machine_running(&params.name) {
+            remove_dir_if_present(&vm_state_dir(&params.name))?;
+        }
         let rootfs = crate::local::resolve_local_rootfs(&params.image, &params.name).await?;
         let (verity_path, roothash) = crate::local::host_verity_sidecars(&rootfs);
         let kernel_path = Self::resolve_workload_kernel(&backend)?;

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -190,20 +190,44 @@ impl LocalBackend {
     /// backend carries its own.
     pub(crate) fn resolve_workload_kernel(backend: &AnyBackend) -> Result<Option<PathBuf>> {
         use mvm_core::protocol::vm_backend::BackendKind;
-        if backend.kind() != BackendKind::Hvf {
-            return Ok(None);
-        }
         let cache = PathBuf::from(mvm_core::config::mvm_cache_dir());
         let arch = mvm_core::arch::GuestArch::host().to_string();
-        match mvm_build::kernel_fetch::resolve_kernel(&cache, &arch, "workload", false) {
-            mvm_build::kernel_fetch::KernelResolution::Cached(verified) => {
-                Ok(Some(verified.path().to_path_buf()))
+        match backend.kind() {
+            // Bundled-kernel backends: libkrun boots the libkrunfw kernel and
+            // the hermetic mock boots nothing — no host kernel path needed.
+            BackendKind::Mock | BackendKind::Libkrun => Ok(None),
+            BackendKind::Hvf => {
+                match mvm_build::kernel_fetch::resolve_kernel(&cache, &arch, "workload", false) {
+                    mvm_build::kernel_fetch::KernelResolution::Cached(verified) => {
+                        Ok(Some(verified.path().to_path_buf()))
+                    }
+                    _ => Err(crate::local::backend_err(format!(
+                        "hvf needs a verified workload kernel at {} — run a `mvmctl machine run` \
+                         once (or `mvmctl build kernel build`) to populate the cache",
+                        mvm_build::kernel_fetch::cached_kernel_path(&cache, &arch, "workload")
+                            .display()
+                    ))),
+                }
             }
-            _ => Err(crate::local::backend_err(format!(
-                "hvf needs a verified workload kernel at {} — run a `mvmctl machine run` \
-                 once (or `mvmctl build kernel build`) to populate the cache",
-                mvm_build::kernel_fetch::cached_kernel_path(&cache, &arch, "workload").display()
-            ))),
+            // Firecracker (and every other explicit-kernel backend, e.g. the
+            // qemu dev tier) hard-refuses a bundled-kernel spec, so resolve the
+            // same cached workload kernel the CLI's machine-run boot path
+            // supplies: `<cache>/builder-vm/<arch>/kernels/workload/vmlinux`
+            // by presence (the driver derives its own FC-loadable sibling from
+            // it). Cache-hit-or-error; populating the cache is a CLI concern.
+            _ => {
+                let path = mvm_build::kernel_fetch::cached_kernel_path(&cache, &arch, "workload");
+                if path.is_file() {
+                    Ok(Some(path))
+                } else {
+                    Err(crate::local::backend_err(format!(
+                        "{} needs the cached workload kernel at {} — create it once with \
+                         `mvmctl kernel build --which workload`, then retry",
+                        backend.name(),
+                        path.display()
+                    )))
+                }
+            }
         }
     }
 

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -1,0 +1,873 @@
+//! Persistent + transient launch lifecycle through [`LocalBackend`].
+//!
+//! Both modes route through the one canonical admitted-boot seam
+//! (`mvm_hostd::run::admit_and_boot_local`): the plan is synthesized, signed,
+//! verified, window-checked, replay-checked, and chain-audited before the
+//! backend sees a byte of launch config. Volume attachments resolve through
+//! the local volume service (exclusive leases, RAII rollback on a failed
+//! boot) and typed secret references are validated fail-closed and recorded
+//! as metadata-only sidecars before any boot.
+
+mod request;
+#[cfg(test)]
+mod tests;
+
+pub use request::{
+    AccessMode, LaunchNetworkPolicy, LaunchRequest, LaunchRequestBuilder, LaunchVolumeSpec,
+    LifecycleMode, MachineSecretRef,
+};
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use mvm_core::client::dto::{MachineId, MachineState, MachineStatus};
+use mvm_core::client::{MvmError, Result};
+use mvm_core::config::{machine_spec_path, machine_state_dir, machine_state_root, vm_state_dir};
+use mvm_core::domain::instance::InstanceReadiness;
+use mvm_core::plan::ExecutionPlan;
+use mvm_core::protocol::vm_backend::{VmId, VmStatus};
+use mvm_hostd::audit::emitter::AuditEmitter;
+use mvm_hostd::plan_admission::{InMemoryNonceLedger, StartedMachine, SystemClock};
+use mvm_hostd::run::{LocalRunContext, LocalRunRequest, admit_and_boot_local};
+use mvm_runtime::AnyBackend;
+use mvm_runtime::machine::persist as mp;
+
+use crate::local::LocalBackend;
+use crate::registration::{MachineRegistration, register_machine};
+use crate::secret::SecretService;
+use crate::volume::{
+    AdmittedProfile, AttachmentRequest, LaunchLeaseRequest, LocalVolumeService, UnlockPolicy,
+    VolumeService,
+};
+
+/// The tenant every locally-launched machine is admitted and scoped under —
+/// mirrors the admission seam's fixed local tenant label.
+const LOCAL_TENANT: &str = "local";
+
+/// The result of a successful launch: the machine's observed state plus the
+/// admitted plan identity (for correlation with the chain-signed audit log).
+#[derive(Debug)]
+pub struct LaunchOutcome {
+    pub machine: MachineState,
+    /// Content-addressed id of the admitted plan.
+    pub plan_id: String,
+    pub(crate) mode: LifecycleMode,
+    pub(crate) plan: ExecutionPlan,
+}
+
+/// Exit report for a waited-on transient machine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExitReport {
+    /// Captured workload exit code, when the guest reported one before
+    /// shutdown; `None` when no capture exists (e.g. the hermetic mock).
+    pub exit_code: Option<i32>,
+}
+
+/// Options for [`LocalBackend::remove_machine_with`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RemoveOptions {
+    /// Explicitly requested force flow: stop a RUNNING persistent machine
+    /// before removal. Without it, removing a running persistent machine is
+    /// refused.
+    pub force: bool,
+}
+
+/// Generate a name for a nameless transient launch.
+fn generated_transient_name() -> String {
+    let n: u64 = rand::random();
+    format!("transient-{:012x}", n & 0xffff_ffff_ffff)
+}
+
+/// RFC 3339 expiry timestamp `ttl_seconds` from now, or `None`.
+fn expires_at_from_ttl(ttl_seconds: Option<u64>) -> Option<String> {
+    ttl_seconds
+        .map(|secs| (chrono::Utc::now() + chrono::Duration::seconds(secs as i64)).to_rfc3339())
+}
+
+/// Best-effort chain-signed emitter under the host signer. Audit emission is
+/// tamper-evidence, not part of the admission decision: a construction
+/// failure warns and the boot proceeds unaudited-on-chain (CLI parity).
+fn build_audit_emitter() -> Option<AuditEmitter> {
+    let signer = match mvm_hostd::audit::host_keypair::load_or_init() {
+        Ok(signer) => signer,
+        Err(e) => {
+            tracing::warn!(error = %e, "host signer unavailable; skipping chain audit emission");
+            return None;
+        }
+    };
+    match AuditEmitter::new(signer.signing) {
+        Ok(emitter) => Some(emitter),
+        Err(e) => {
+            tracing::warn!(error = %e, "audit emitter unavailable; skipping chain audit emission");
+            None
+        }
+    }
+}
+
+impl LocalBackend {
+    /// The secret lifecycle service to validate/record references through:
+    /// the injected one, else the production-wired local service.
+    fn secrets(&self) -> Result<Arc<SecretService>> {
+        if let Some(service) = &self.secret_service {
+            return Ok(service.clone());
+        }
+        SecretService::local()
+            .map(Arc::new)
+            .map_err(|e| crate::local::backend_err(format!("secret service: {e}")))
+    }
+
+    /// Clear a machine's secret-reference sidecar through the same seam
+    /// [`SecretService::clear_machine_references`] wraps. Idempotent.
+    fn clear_secret_refs(&self, name: &str) -> Result<()> {
+        match &self.secret_service {
+            Some(service) => service
+                .clear_machine_references(name)
+                .map_err(|e| crate::local::backend_err(format!("clearing secret refs: {e}"))),
+            None => crate::secret::refs::clear_refs(&machine_state_root(), name)
+                .map_err(|e| crate::local::backend_err(format!("clearing secret refs: {e:#}"))),
+        }
+    }
+
+    /// Whether `name` is running: prefer the VMM that owns the started VM
+    /// (state-dir marker), falling back to this client's backend so the
+    /// hermetic mock stays observable.
+    fn machine_running(&self, name: &str) -> bool {
+        let status = match AnyBackend::for_started_vm(name) {
+            Some(owner) => owner.status(&VmId(name.to_string())),
+            None => self.backend.status(&VmId(name.to_string())),
+        };
+        matches!(status, Ok(VmStatus::Running))
+    }
+
+    /// Resolve the backend handle for a launch: the request override when it
+    /// names a different hypervisor (validated selectable), else this
+    /// client's own backend.
+    fn launch_backend(&self, override_name: Option<&str>) -> Result<BackendHandle<'_>> {
+        match override_name {
+            Some(name) if name != self.backend.name() => {
+                crate::boot::require_hypervisor_selectable(name)?;
+                Ok(BackendHandle::Owned(AnyBackend::from_hypervisor(name)))
+            }
+            _ => Ok(BackendHandle::Borrowed(&self.backend)),
+        }
+    }
+}
+
+/// A borrowed-or-owned backend handle (`AnyBackend` is not `Clone`, so `Cow`
+/// can't carry it). Borrowing the client's own backend keeps the hermetic
+/// in-memory mock observable across the launch verbs.
+enum BackendHandle<'a> {
+    Borrowed(&'a AnyBackend),
+    Owned(AnyBackend),
+}
+
+impl std::ops::Deref for BackendHandle<'_> {
+    type Target = AnyBackend;
+
+    fn deref(&self) -> &AnyBackend {
+        match self {
+            BackendHandle::Borrowed(backend) => backend,
+            BackendHandle::Owned(backend) => backend,
+        }
+    }
+}
+
+/// The resolved inputs for one admitted boot — the shared core both
+/// lifecycle modes (and the trait's `run_machine`) reach.
+pub(crate) struct BootParams {
+    pub(crate) name: String,
+    pub(crate) image: String,
+    pub(crate) cpus: u32,
+    pub(crate) memory_mib: u32,
+    pub(crate) backend_override: Option<String>,
+    pub(crate) volumes: Vec<mvm_core::vm_backend::VmVolume>,
+    pub(crate) transient: bool,
+}
+
+impl LocalBackend {
+    /// Resolve the per-backend workload kernel: HVF boots an explicit
+    /// verified arm64 kernel from the CLI-populated cache; every other
+    /// backend carries its own.
+    pub(crate) fn resolve_workload_kernel(backend: &AnyBackend) -> Result<Option<PathBuf>> {
+        use mvm_core::protocol::vm_backend::BackendKind;
+        if backend.kind() != BackendKind::Hvf {
+            return Ok(None);
+        }
+        let cache = PathBuf::from(mvm_core::config::mvm_cache_dir());
+        let arch = mvm_core::arch::GuestArch::host().to_string();
+        match mvm_build::kernel_fetch::resolve_kernel(&cache, &arch, "workload", false) {
+            mvm_build::kernel_fetch::KernelResolution::Cached(verified) => {
+                Ok(Some(verified.path().to_path_buf()))
+            }
+            _ => Err(crate::local::backend_err(format!(
+                "hvf needs a verified workload kernel at {} — run a `mvmctl machine run` \
+                 once (or `mvmctl build kernel build`) to populate the cache",
+                mvm_build::kernel_fetch::cached_kernel_path(&cache, &arch, "workload").display()
+            ))),
+        }
+    }
+
+    /// Boot one machine through the canonical signed-plan admission seam.
+    /// The chain-signed `plan.admitted`/`plan.launched`/`plan.failed`
+    /// entries are emitted inside the seam; any failure returns with no VM
+    /// created.
+    pub(crate) async fn boot_admitted(&self, params: BootParams) -> Result<StartedMachine> {
+        let backend = self.launch_backend(params.backend_override.as_deref())?;
+        let rootfs = crate::local::resolve_local_rootfs(&params.image, &params.name).await?;
+        let (verity_path, roothash) = crate::local::host_verity_sidecars(&rootfs);
+        let kernel_path = Self::resolve_workload_kernel(&backend)?;
+
+        let req = LocalRunRequest {
+            name: params.name.clone(),
+            rootfs_path: rootfs,
+            kernel_path,
+            verity_path: verity_path.map(PathBuf::from),
+            roothash,
+            cpus: params.cpus,
+            mem_mib: params.memory_mib,
+            backend_name: backend.name().to_string(),
+            volumes: params.volumes,
+            destroy_on_exit: params.transient,
+        };
+
+        // A fresh per-launch ledger: local launches are one-shot from this
+        // process, so replay protection spans this admission (the CLI uses
+        // the same per-invocation shape). Keys dir `None` → the host signer
+        // at the configured keys dir.
+        let ledger = InMemoryNonceLedger::new();
+        let clock = SystemClock;
+        let emitter = build_audit_emitter();
+        admit_and_boot_local(
+            &backend,
+            &req,
+            LocalRunContext {
+                clock: &clock,
+                ledger: &ledger,
+                host_signer_keys_dir: None,
+                emitter: emitter.as_ref(),
+            },
+        )
+        .map_err(|e| crate::local::backend_err(format!("{e:#}")))
+    }
+
+    /// Fail-closed admission validation of typed secret references, then
+    /// persist the metadata-only sidecar. Runs on every admission that
+    /// declares references; a machine with any invalid reference must not
+    /// boot (and nothing is recorded for it).
+    fn validate_and_record_secret_refs(&self, name: &str, refs: &[MachineSecretRef]) -> Result<()> {
+        if refs.is_empty() {
+            return Ok(());
+        }
+        let service = self.secrets()?;
+        service
+            .validate_for_admission(LOCAL_TENANT, refs)
+            .map_err(|e| MvmError::Rejected {
+                reason: format!("secret reference admission refused: {e}"),
+            })?;
+        service
+            .record_machine_references(name, refs)
+            .map_err(|e| crate::local::backend_err(format!("recording secret refs: {e}")))
+    }
+
+    /// Register the request's typed volume attachments for `name`. An
+    /// identical existing registration is reused; a guest path already
+    /// claimed by a different volume/access is a conflict.
+    fn register_volume_attachments(
+        &self,
+        name: &str,
+        volumes: &[LaunchVolumeSpec],
+        profile: AdmittedProfile,
+    ) -> Result<()> {
+        if volumes.is_empty() {
+            return Ok(());
+        }
+        let service = LocalVolumeService::new();
+        let existing = service
+            .list_attachments(name)
+            .map_err(|e| crate::local::backend_err(format!("listing attachments: {e:#}")))?;
+        for spec in volumes {
+            let identical = existing.iter().any(|a| {
+                a.guest_path == spec.guest_path
+                    && a.volume == spec.volume
+                    && a.access == spec.access
+            });
+            if identical {
+                continue;
+            }
+            if existing.iter().any(|a| a.guest_path == spec.guest_path) {
+                return Err(MvmError::Conflict {
+                    reason: format!(
+                        "guest path {:?} is already attached with a different volume or \
+                         access mode; detach it first",
+                        spec.guest_path
+                    ),
+                });
+            }
+            let request = AttachmentRequest::builder(name, &spec.volume)
+                .and_then(|b| {
+                    b.guest_path(&spec.guest_path)
+                        .access(spec.access)
+                        .profile(profile)
+                        .build()
+                })
+                .map_err(|e| MvmError::InvalidSpec {
+                    reason: format!("volume attachment {:?}: {e:#}", spec.volume),
+                })?;
+            service.prepare_attachment(&request).map_err(|e| {
+                crate::local::backend_err(format!("attaching {:?}: {e:#}", spec.volume))
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Resolve `name`'s registered attachments and take exclusive leases for
+    /// this launch (locked managed volumes unlock just in time and re-seal
+    /// on release).
+    fn acquire_leases(
+        &self,
+        name: &str,
+        profile: AdmittedProfile,
+    ) -> Result<crate::volume::LaunchPreparation> {
+        let request = LaunchLeaseRequest::builder(name)
+            .map_err(|e| MvmError::InvalidSpec {
+                reason: format!("{e:#}"),
+            })?
+            .profile(profile)
+            .unlock(UnlockPolicy::JustInTime)
+            .build();
+        LocalVolumeService::new()
+            .acquire_launch_lease(&request)
+            .map_err(|e| crate::local::backend_err(format!("volume leases for {name:?}: {e:#}")))
+    }
+}
+
+/// Build the persisted declarative spec a persistent launch writes.
+fn persisted_spec_from_request(request: &LaunchRequest, name: &str) -> mp::MachineSpec {
+    mp::MachineSpec {
+        schema_version: mp::MACHINE_SPEC_SCHEMA_VERSION,
+        name: name.to_string(),
+        image: Some(request.image.clone()),
+        manifest: None,
+        deployment: None,
+        resolved_digest: None,
+        runtime_pack: false,
+        net: false,
+        allow_host: vec![],
+        cpus: request.cpus,
+        memory: format!("{}M", request.memory_mib),
+        mem_initial: None,
+        profile: request.profile.clone(),
+        volumes: vec![],
+        init: vec![],
+        agent_verb: vec![],
+        created_at: Some(mvm_core::util::time::utc_now()),
+        last_started_at: None,
+        health_check: None,
+    }
+}
+
+impl LocalBackend {
+    /// Refuse a transient launch whose name is already claimed — by a
+    /// persisted definition (that name is managed via the persistent verbs)
+    /// or by a live VM.
+    fn ensure_transient_name_free(&self, name: &str) -> Result<()> {
+        if machine_spec_path(name).exists() {
+            return Err(MvmError::Conflict {
+                reason: format!(
+                    "a persistent machine named {name:?} exists; use the persistent \
+                     lifecycle verbs (or another name)"
+                ),
+            });
+        }
+        if self.machine_running(name) {
+            return Err(MvmError::Conflict {
+                reason: format!("a machine named {name:?} is already running"),
+            });
+        }
+        Ok(())
+    }
+
+    /// Reconcile + persist the declarative definition for a persistent
+    /// launch. A same-config definition is reused; a different config is
+    /// refused without `force` and recreated (stopping any old instance)
+    /// with it. Never boots.
+    fn persist_definition(&self, request: &LaunchRequest, name: &str) -> Result<mp::MachineSpec> {
+        let desired = persisted_spec_from_request(request, name);
+        let existing = if machine_spec_path(name).exists() {
+            Some(mp::load_machine_spec(name).map_err(crate::local::backend_err)?)
+        } else {
+            None
+        };
+        let reconcile = mp::reconcile_machine_spec(existing.as_ref(), &desired, request.force)
+            .map_err(|e| MvmError::Conflict {
+                reason: format!("{e:#}"),
+            })?;
+        match reconcile {
+            mp::SpecReconcile::Create => {
+                mp::save_machine_spec(&desired, false).map_err(crate::local::backend_err)?;
+                mvm_core::audit_emit!(ConfigChange, vm: name, "action=machine.create mode=persistent");
+                Ok(desired)
+            }
+            mp::SpecReconcile::Reuse => Ok(existing.expect("reuse implies an existing spec")),
+            mp::SpecReconcile::Recreate { changed } => {
+                if self.machine_running(name) {
+                    self.stop_for_recreate(name);
+                }
+                mp::overwrite_machine_spec(&desired).map_err(crate::local::backend_err)?;
+                mvm_core::audit_emit!(
+                    ConfigChange,
+                    vm: name,
+                    "action=machine.recreate changed={changed}"
+                );
+                Ok(desired)
+            }
+        }
+    }
+
+    /// Stop the old instance ahead of a forced recreate. Best-effort: the
+    /// overwrite proceeds either way and the boot surfaces any leftover.
+    fn stop_for_recreate(&self, name: &str) {
+        let vid = VmId(name.to_string());
+        let result = match AnyBackend::for_started_vm(name) {
+            Some(owner) => owner.stop(&vid),
+            None => self.backend.stop(&vid),
+        };
+        if let Err(e) = result {
+            tracing::warn!(error = %e, machine = name, "stopping old instance before recreate failed");
+        }
+    }
+
+    /// Launch a machine from a fully-validated typed request. Transient
+    /// requests boot immediately and are cleaned up on exit/TTL; persistent
+    /// requests persist their definition first, then boot from it — both
+    /// through the one canonical signed-admission seam.
+    pub async fn launch(&self, request: LaunchRequest) -> Result<LaunchOutcome> {
+        match request.mode {
+            LifecycleMode::Transient => self.launch_transient(request).await,
+            LifecycleMode::Persistent => {
+                let name = request
+                    .name
+                    .clone()
+                    .expect("validated: persistent requests carry a name");
+                self.create_definition(&request, &name)?;
+                self.boot_persistent(&name, &request).await
+            }
+        }
+    }
+
+    /// Persist a machine definition (spec + secret-reference sidecar +
+    /// typed volume attachments) without booting. Persistent mode only.
+    pub fn create_from_request(&self, request: &LaunchRequest) -> Result<MachineState> {
+        if request.mode != LifecycleMode::Persistent {
+            return Err(MvmError::InvalidSpec {
+                reason: "create (persist without boot) requires a persistent request".into(),
+            });
+        }
+        let name = request
+            .name
+            .clone()
+            .expect("validated: persistent requests carry a name");
+        let spec = self.create_definition(request, &name)?;
+        Ok(MachineState {
+            id: MachineId(name.clone()),
+            name,
+            status: MachineStatus::Stopped,
+            cpus: spec.cpus,
+            memory_mib: request.memory_mib,
+            profile: Some(spec.profile),
+            ..Default::default()
+        })
+    }
+
+    /// The persistent create path: reconcile + persist the spec, validate +
+    /// record secret references, register typed volume attachments.
+    fn create_definition(&self, request: &LaunchRequest, name: &str) -> Result<mp::MachineSpec> {
+        let spec = self.persist_definition(request, name)?;
+        self.validate_and_record_secret_refs(name, &request.secret_refs)?;
+        self.register_volume_attachments(
+            name,
+            &request.volumes,
+            AdmittedProfile::from_profile_name(&request.profile),
+        )?;
+        Ok(spec)
+    }
+
+    /// The transient launch path: collision check, secret-ref validation +
+    /// recording, attachment registration, lease acquisition, admitted boot,
+    /// registration. Any failure after recording rolls the session-owned
+    /// state back (leases via RAII, secret refs + attachments explicitly).
+    async fn launch_transient(&self, request: LaunchRequest) -> Result<LaunchOutcome> {
+        let name = request
+            .name
+            .clone()
+            .unwrap_or_else(generated_transient_name);
+        self.ensure_transient_name_free(&name)?;
+        self.validate_and_record_secret_refs(&name, &request.secret_refs)?;
+
+        let result = self.attach_lease_and_boot(&name, &request, true).await;
+        match result {
+            Ok(outcome) => Ok(outcome),
+            Err(e) => {
+                // Idempotent rollback of everything this session recorded.
+                if let Err(cleanup) = self.cleanup_transient(&name) {
+                    tracing::warn!(error = %cleanup, machine = %name, "transient cleanup after failed launch");
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Boot a persistent definition that was just created/reconciled from
+    /// `request` (TTL and backend override honored from the request).
+    async fn boot_persistent(&self, name: &str, request: &LaunchRequest) -> Result<LaunchOutcome> {
+        if self.machine_running(name) {
+            return Err(MvmError::Conflict {
+                reason: format!("machine {name:?} is already running"),
+            });
+        }
+        self.attach_lease_and_boot(name, request, false).await
+    }
+
+    /// Shared tail of both launch paths: acquire volume leases, boot through
+    /// admission, commit leases, register + track readiness.
+    async fn attach_lease_and_boot(
+        &self,
+        name: &str,
+        request: &LaunchRequest,
+        transient: bool,
+    ) -> Result<LaunchOutcome> {
+        let profile = AdmittedProfile::from_profile_name(&request.profile);
+        let mut preparation = self.acquire_leases(name, profile)?;
+        let volumes: Vec<mvm_core::vm_backend::VmVolume> =
+            preparation.volumes.iter().map(Into::into).collect();
+
+        let started = self
+            .boot_admitted(BootParams {
+                name: name.to_string(),
+                image: request.image.clone(),
+                cpus: request.cpus,
+                memory_mib: request.memory_mib,
+                backend_override: request.backend.clone(),
+                volumes,
+                transient,
+            })
+            .await?;
+        preparation.commit();
+
+        self.register_started(name, request, transient);
+        Ok(self.launch_outcome(name, request, started, transient))
+    }
+
+    /// Post-boot bookkeeping: name-registry registration (with TTL),
+    /// host-observed readiness, and — for a persistent machine — the
+    /// last-started stamp on its spec. All best-effort: the machine is up.
+    fn register_started(&self, name: &str, request: &LaunchRequest, transient: bool) {
+        register_machine(&MachineRegistration {
+            expires_at: expires_at_from_ttl(request.ttl_seconds),
+            vm_dir: vm_state_dir(name).to_string_lossy().into_owned(),
+            ..MachineRegistration::minimal(name, "none")
+        });
+        crate::record_readiness(name, InstanceReadiness::LaunchAccepted);
+        if !transient && let Ok(mut spec) = mp::load_machine_spec(name) {
+            spec.last_started_at = Some(mvm_core::util::time::utc_now());
+            if let Err(e) = mp::overwrite_machine_spec(&spec) {
+                tracing::warn!(error = %e, machine = name, "stamping last_started_at failed (non-fatal)");
+            }
+        }
+    }
+
+    /// Assemble the outcome for a successful admitted boot.
+    fn launch_outcome(
+        &self,
+        name: &str,
+        request: &LaunchRequest,
+        started: StartedMachine,
+        transient: bool,
+    ) -> LaunchOutcome {
+        LaunchOutcome {
+            machine: MachineState {
+                id: MachineId(started.vm_id.0.clone()),
+                name: name.to_string(),
+                status: MachineStatus::Running,
+                backend: self
+                    .launch_backend(request.backend.as_deref())
+                    .map(|b| b.name().to_string())
+                    .unwrap_or_default(),
+                cpus: request.cpus,
+                memory_mib: request.memory_mib,
+                profile: Some(request.profile.clone()),
+                expires_at: expires_at_from_ttl(request.ttl_seconds),
+                ..Default::default()
+            },
+            plan_id: started.admitted.plan_id.0.clone(),
+            mode: if transient {
+                LifecycleMode::Transient
+            } else {
+                LifecycleMode::Persistent
+            },
+            plan: started.admitted.plan,
+        }
+    }
+}
+
+/// Refusals for persisted-spec shapes the in-process backend cannot honor
+/// (fail closed, never silently ignore a persisted field).
+fn ensure_spec_bootable_in_process(spec: &mp::MachineSpec) -> Result<String> {
+    let unsupported = |what: &str| MvmError::InvalidSpec {
+        reason: format!(
+            "machine {:?} declares {what}, which the in-process local backend cannot \
+             honor; use the CLI's `machine start`",
+            spec.name
+        ),
+    };
+    if spec.manifest.is_some() {
+        return Err(unsupported("a manifest-backed source"));
+    }
+    if spec.deployment.is_some() {
+        return Err(unsupported("an attested-deployment source"));
+    }
+    if spec.runtime_pack {
+        return Err(unsupported("a runtime-pack source"));
+    }
+    if spec.net || !spec.allow_host.is_empty() {
+        return Err(unsupported("a network policy other than deny-all"));
+    }
+    if !spec.volumes.is_empty() {
+        return Err(unsupported(
+            "CLI-grammar volume strings (use typed attachments)",
+        ));
+    }
+    if !spec.init.is_empty() {
+        return Err(unsupported("init commands"));
+    }
+    spec.image.clone().ok_or_else(|| MvmError::InvalidSpec {
+        reason: format!("machine {:?} has no image source", spec.name),
+    })
+}
+
+impl LocalBackend {
+    /// Start a stopped persistent machine from its persisted definition:
+    /// sidecar secret references re-validated fail-closed, registered
+    /// attachments re-resolved and leased, then the canonical admitted boot.
+    /// Starting a machine that is already running returns its state.
+    pub async fn start_persistent(&self, name: &str) -> Result<MachineState> {
+        let spec = mp::load_machine_spec(name).map_err(|e| MvmError::NotFound {
+            id: format!("{name}: {e}"),
+        })?;
+        if self.machine_running(name) {
+            return Ok(MachineState {
+                id: MachineId(name.to_string()),
+                name: name.to_string(),
+                status: MachineStatus::Running,
+                cpus: spec.cpus,
+                ..Default::default()
+            });
+        }
+        let image = ensure_spec_bootable_in_process(&spec)?;
+        let refs = crate::secret::refs::load_refs(&machine_state_root(), name)
+            .map_err(|e| crate::local::backend_err(format!("loading secret refs: {e:#}")))?
+            .map(|record| record.references)
+            .unwrap_or_default();
+        if !refs.is_empty() {
+            self.secrets()?
+                .validate_for_admission(LOCAL_TENANT, &refs)
+                .map_err(|e| MvmError::Rejected {
+                    reason: format!("secret reference admission refused: {e}"),
+                })?;
+        }
+        let memory_mib =
+            mvm_core::util::parse_human_size(&spec.memory).map_err(crate::local::backend_err)?;
+        let request = LaunchRequest::builder(LifecycleMode::Persistent, image)
+            .name(name)
+            .cpus(spec.cpus)
+            .memory_mib(memory_mib)
+            .profile(spec.profile.clone())
+            .build()?;
+        let outcome = self.attach_lease_and_boot(name, &request, false).await?;
+        Ok(outcome.machine)
+    }
+
+    /// Restart a persistent machine: stop it when running (spec kept), then
+    /// start it again from its persisted definition.
+    pub async fn restart_persistent(&self, name: &str) -> Result<MachineState> {
+        if self.machine_running(name) {
+            use mvm_core::client::MvmClient as _;
+            self.stop_machine(&MachineId(name.to_string())).await?;
+        }
+        self.start_persistent(name).await
+    }
+
+    /// Remove a machine. For a persistent definition this is the separate
+    /// confirmed action that deletes the spec: a RUNNING persistent machine
+    /// is refused unless `options.force` explicitly requests the reviewed
+    /// force flow (stop, then remove). A spec-less name gets transient
+    /// semantics: stop + idempotent session cleanup. Removing an absent
+    /// machine is `Ok`.
+    pub async fn remove_machine_with(&self, id: &MachineId, options: RemoveOptions) -> Result<()> {
+        let name = id.0.as_str();
+        let has_spec = machine_spec_path(name).exists();
+        if has_spec {
+            if self.machine_running(name) {
+                if !options.force {
+                    return Err(MvmError::Conflict {
+                        reason: format!(
+                            "machine {name:?} is running; stop it first, or explicitly \
+                             request the force removal flow"
+                        ),
+                    });
+                }
+                self.stop_for_recreate(name);
+            }
+            self.release_session_resources(name)?;
+            // The definition directory carries machine.json plus the
+            // secret-refs sidecar (already cleared above) — drop it whole.
+            remove_dir_if_present(&machine_state_dir(name))?;
+            mvm_core::audit_emit!(
+                ConfigChange,
+                vm: name,
+                "action=machine.remove mode=persistent force={force}",
+                force = options.force,
+            );
+            return Ok(());
+        }
+        // Transient semantics: stop whatever is live, then idempotent cleanup.
+        self.cleanup_transient(name)
+    }
+
+    /// Release every session-owned resource `name` holds: registered volume
+    /// attachments, attachment leases (re-sealing just-in-time unlocks),
+    /// secret-reference sidecar, name-registry entry. Idempotent.
+    fn release_session_resources(&self, name: &str) -> Result<()> {
+        let service = LocalVolumeService::new();
+        match service.list_attachments(name) {
+            Ok(attachments) => {
+                for attachment in attachments {
+                    if let Err(e) = service.detach(name, &attachment.guest_path) {
+                        tracing::warn!(error = %e, machine = name, guest = %attachment.guest_path, "detach during cleanup failed");
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, machine = name, "listing attachments during cleanup failed");
+            }
+        }
+        service
+            .release_owner_leases(name)
+            .map_err(|e| crate::local::backend_err(format!("releasing volume leases: {e:#}")))?;
+        self.clear_secret_refs(name)?;
+        crate::local::deregister_from_name_registry(name);
+        Ok(())
+    }
+
+    /// Idempotent transient cleanup: stop the VM when live, release every
+    /// session-owned resource, and drop the per-VM state dirs. Safe to call
+    /// repeatedly and on names that never launched.
+    pub fn cleanup_transient(&self, name: &str) -> Result<()> {
+        if self.machine_running(name) {
+            self.stop_for_recreate(name);
+        }
+        self.release_session_resources(name)?;
+        remove_dir_if_present(&vm_state_dir(name))?;
+        // The state dir under machines/ only carries session sidecars for a
+        // transient (no machine.json); never touch a persistent definition.
+        if !machine_spec_path(name).exists() {
+            remove_dir_if_present(&machine_state_dir(name))?;
+        }
+        Ok(())
+    }
+}
+
+impl LocalBackend {
+    /// Wait for a transient launch to run to completion, report its captured
+    /// exit code, and clean up its session-owned resources. Polls the owning
+    /// backend; fails with a timeout error if the machine is still running
+    /// after `timeout`. The `plan.exited` chain entry carries the exit code.
+    pub fn wait_for_exit(
+        &self,
+        outcome: &LaunchOutcome,
+        poll: std::time::Duration,
+        timeout: std::time::Duration,
+    ) -> Result<ExitReport> {
+        let name = outcome.machine.name.clone();
+        let deadline = std::time::Instant::now() + timeout;
+        while self.machine_running(&name) {
+            if std::time::Instant::now() >= deadline {
+                return Err(crate::local::backend_err(format!(
+                    "machine {name:?} still running after {}s",
+                    timeout.as_secs()
+                )));
+            }
+            std::thread::sleep(poll);
+        }
+        self.report_exit(outcome)
+    }
+
+    /// Report an already-exited machine's captured exit code, emit the
+    /// chain-signed `plan.exited` entry, and (for a transient) run the
+    /// idempotent cleanup.
+    pub fn report_exit(&self, outcome: &LaunchOutcome) -> Result<ExitReport> {
+        let name = outcome.machine.name.as_str();
+        let exit_code = mvm_core::exit_capture::read_captured(&vm_state_dir(name));
+        if let Some(emitter) = build_audit_emitter()
+            && let Err(e) = emitter.emit_exited(
+                &outcome.plan,
+                exit_code.unwrap_or(0),
+                &outcome.machine.backend,
+            )
+        {
+            tracing::warn!(error = %e, machine = name, "audit emit_exited failed (non-fatal)");
+        }
+        if outcome.mode == LifecycleMode::Transient {
+            self.cleanup_transient(name)?;
+        }
+        Ok(ExitReport { exit_code })
+    }
+
+    /// Stop and clean every transient machine whose registry TTL has lapsed
+    /// at `now` (RFC 3339). Persistent definitions are never touched — their
+    /// TTL semantics stay with the idle reaper. Returns the reaped names.
+    pub fn reap_expired_transients(&self, now_rfc3339: &str) -> Result<Vec<String>> {
+        let Some(now) = mvm_core::util::time::parse_iso8601(now_rfc3339) else {
+            return Err(MvmError::InvalidSpec {
+                reason: format!("invalid RFC 3339 timestamp {now_rfc3339:?}"),
+            });
+        };
+        let registry = mvm_runtime::vm::name_registry::VmNameRegistry::load(
+            &mvm_runtime::vm::name_registry::registry_path(),
+        )
+        .unwrap_or_default();
+        let expired: Vec<String> = registry
+            .vms
+            .iter()
+            .filter(|(name, reg)| {
+                !machine_spec_path(name).exists()
+                    && matches!(
+                        reg.expires_at
+                            .as_deref()
+                            .and_then(mvm_core::util::time::parse_iso8601),
+                        Some(exp) if exp < now
+                    )
+            })
+            .map(|(name, _)| name.clone())
+            .collect();
+        let mut reaped = Vec::with_capacity(expired.len());
+        for name in expired {
+            self.cleanup_transient(&name)?;
+            reaped.push(name);
+        }
+        reaped.sort();
+        Ok(reaped)
+    }
+}
+
+/// Remove a directory tree, treating "already absent" as success.
+fn remove_dir_if_present(dir: &std::path::Path) -> Result<()> {
+    match std::fs::remove_dir_all(dir) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(crate::local::backend_err(format!(
+            "removing {}: {e}",
+            dir.display()
+        ))),
+    }
+}

--- a/crates/mvm-client/src/launch/request.rs
+++ b/crates/mvm-client/src/launch/request.rs
@@ -1,0 +1,430 @@
+//! The typed launch request for the in-process local lifecycle.
+//!
+//! One request shape drives both lifecycle modes: a [`LifecycleMode::Transient`]
+//! machine boots without a persisted definition and is cleaned up when it
+//! exits (or its TTL lapses); a [`LifecycleMode::Persistent`] machine persists
+//! a declarative spec first and is managed by name across starts and stops.
+//!
+//! Every field is validated at the client boundary, in
+//! [`LaunchRequestBuilder::build`]. Fields the in-process backend cannot
+//! honor are **refused**, never silently dropped: a command/entrypoint
+//! override, guest environment variables, and any network policy other than
+//! deny-all all fail the build with an error naming the CLI path that does
+//! support them.
+
+use mvm_core::client::{MvmError, Result};
+
+pub use crate::secret::MachineSecretRef;
+pub use crate::volume::AccessMode;
+
+/// Whether the launched machine outlives this client's session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifecycleMode {
+    /// No persisted definition: the machine exists only while running and its
+    /// session-owned resources are released by the cleanup path.
+    Transient,
+    /// A declarative spec is persisted under the machine's name before any
+    /// boot; stopping never deletes it, and removal is a separate confirmed
+    /// caller action.
+    Persistent,
+}
+
+/// Guest network policy for the launch. The in-process backend enforces
+/// claim-10 default-deny at the shared substitution seam; it has no path
+/// that could honor an allow-list, so anything but deny-all is refused at
+/// validation rather than persisted-but-not-enforced.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum LaunchNetworkPolicy {
+    /// Deny all egress (the only policy the in-process backend admits).
+    #[default]
+    DenyAll,
+    /// Named host allow-list — refused by [`LaunchRequestBuilder::build`];
+    /// use the CLI verbs, whose boot path enforces the resolved policy.
+    AllowHosts(Vec<String>),
+}
+
+/// One typed volume attachment: a managed volume from the local encrypted
+/// volume catalog, mounted at `guest_path`. Resolved through
+/// [`crate::volume::VolumeService`] at launch, which owns the mount-root
+/// policy, the read-write profile gate, and the exclusive lease.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchVolumeSpec {
+    /// Managed volume name in the local catalog.
+    pub volume: String,
+    /// Absolute guest mount point (validated against the mount allow-roots).
+    pub guest_path: String,
+    /// Requested access mode; read-write requires a dev-tier profile.
+    pub access: AccessMode,
+}
+
+/// A fully-validated launch request. Construct via [`LaunchRequest::builder`].
+#[derive(Debug, Clone)]
+pub struct LaunchRequest {
+    pub(crate) name: Option<String>,
+    pub(crate) mode: LifecycleMode,
+    pub(crate) image: String,
+    pub(crate) cpus: u32,
+    pub(crate) memory_mib: u32,
+    pub(crate) backend: Option<String>,
+    pub(crate) profile: String,
+    pub(crate) ttl_seconds: Option<u64>,
+    pub(crate) volumes: Vec<LaunchVolumeSpec>,
+    pub(crate) secret_refs: Vec<MachineSecretRef>,
+    pub(crate) force: bool,
+}
+
+impl LaunchRequest {
+    /// Start building a request for `mode` from OCI image source `image`
+    /// (a registry reference, an unpacked rootfs directory, or a
+    /// pre-materialized `rootfs.ext4` path).
+    pub fn builder(mode: LifecycleMode, image: impl Into<String>) -> LaunchRequestBuilder {
+        LaunchRequestBuilder {
+            mode,
+            image: image.into(),
+            name: None,
+            command: Vec::new(),
+            env: Vec::new(),
+            cpus: 1,
+            memory_mib: 512,
+            backend: None,
+            profile: "standard".to_string(),
+            ttl_seconds: None,
+            network: LaunchNetworkPolicy::DenyAll,
+            volumes: Vec::new(),
+            secret_refs: Vec::new(),
+            force: false,
+        }
+    }
+
+    /// The machine name, when the caller supplied one. Transient launches
+    /// without a name get a generated one at launch time.
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    pub fn mode(&self) -> LifecycleMode {
+        self.mode
+    }
+}
+
+/// Builder for [`LaunchRequest`]. `build` validates every field and refuses
+/// unsupported ones — see the module docs.
+#[derive(Debug, Clone)]
+pub struct LaunchRequestBuilder {
+    mode: LifecycleMode,
+    image: String,
+    name: Option<String>,
+    command: Vec<String>,
+    env: Vec<(String, String)>,
+    cpus: u32,
+    memory_mib: u32,
+    backend: Option<String>,
+    profile: String,
+    ttl_seconds: Option<u64>,
+    network: LaunchNetworkPolicy,
+    volumes: Vec<LaunchVolumeSpec>,
+    secret_refs: Vec<MachineSecretRef>,
+    force: bool,
+}
+
+impl LaunchRequestBuilder {
+    /// Machine name. Required for a persistent launch (the definition must be
+    /// addressable later); optional for a transient one (generated if absent).
+    #[must_use]
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Command/entrypoint override. Represented so a caller's intent is
+    /// visible, but the in-process backend refuses a non-empty override at
+    /// `build` — the image's baked entrypoint is the only thing that runs.
+    #[must_use]
+    pub fn command(mut self, argv: impl IntoIterator<Item = String>) -> Self {
+        self.command.extend(argv);
+        self
+    }
+
+    /// Guest environment variables. Refused when non-empty: the in-process
+    /// boot path has no env delivery seam, and silently dropping values a
+    /// caller believes were set is worse than a refusal.
+    #[must_use]
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.push((key.into(), value.into()));
+        self
+    }
+
+    /// vCPU count (default 1, must be >= 1).
+    #[must_use]
+    pub fn cpus(mut self, cpus: u32) -> Self {
+        self.cpus = cpus;
+        self
+    }
+
+    /// Guest memory in MiB (default 512, must be >= 1).
+    #[must_use]
+    pub fn memory_mib(mut self, memory_mib: u32) -> Self {
+        self.memory_mib = memory_mib;
+        self
+    }
+
+    /// Hypervisor backend name override (`firecracker`, `libkrun`, `hvf`,
+    /// `mock`, …). Checked for selectability at launch time; default is the
+    /// client's own backend.
+    #[must_use]
+    pub fn backend(mut self, backend: impl Into<String>) -> Self {
+        self.backend = Some(backend.into());
+        self
+    }
+
+    /// Machine profile (default `standard`). Only `dev` / `permissive`
+    /// profiles may take writable volume attachments.
+    #[must_use]
+    pub fn profile(mut self, profile: impl Into<String>) -> Self {
+        self.profile = profile.into();
+        self
+    }
+
+    /// Time-to-live in seconds. Recorded as the registry `expires_at`; the
+    /// transient reaper stops and cleans an expired machine.
+    #[must_use]
+    pub fn ttl_seconds(mut self, ttl_seconds: u64) -> Self {
+        self.ttl_seconds = Some(ttl_seconds);
+        self
+    }
+
+    /// Guest network policy (default deny-all — the only admitted value).
+    #[must_use]
+    pub fn network(mut self, network: LaunchNetworkPolicy) -> Self {
+        self.network = network;
+        self
+    }
+
+    /// Attach a managed volume at `guest_path`.
+    #[must_use]
+    pub fn volume(mut self, spec: LaunchVolumeSpec) -> Self {
+        self.volumes.push(spec);
+        self
+    }
+
+    /// Declare a typed secret reference (metadata only — never a value).
+    /// Validated fail-closed at admission and recorded in the machine's
+    /// `secret-refs.json` sidecar.
+    #[must_use]
+    pub fn secret_ref(mut self, secret_ref: MachineSecretRef) -> Self {
+        self.secret_refs.push(secret_ref);
+        self
+    }
+
+    /// Persistent mode only: allow recreating an existing same-name
+    /// definition whose config differs (the reviewed recreate flow).
+    #[must_use]
+    pub fn force(mut self, force: bool) -> Self {
+        self.force = force;
+        self
+    }
+
+    /// Validate every field and build the request. Unsupported fields are
+    /// refused with an error naming the supported path, never ignored.
+    pub fn build(self) -> Result<LaunchRequest> {
+        let invalid = |reason: String| MvmError::InvalidSpec { reason };
+
+        if self.image.trim().is_empty() {
+            return Err(invalid("image source must not be empty".into()));
+        }
+        if let Some(name) = self.name.as_deref() {
+            mvm_core::naming::validate_vm_name(name)
+                .map_err(|e| invalid(format!("invalid machine name {name:?}: {e}")))?;
+        } else if self.mode == LifecycleMode::Persistent {
+            return Err(invalid(
+                "a persistent machine requires a name (its definition is managed by name)".into(),
+            ));
+        }
+        if self.cpus == 0 {
+            return Err(invalid("cpus must be >= 1".into()));
+        }
+        if self.memory_mib == 0 {
+            return Err(invalid("memory_mib must be >= 1".into()));
+        }
+        if !self.command.is_empty() {
+            return Err(invalid(
+                "a command/entrypoint override is not supported by the in-process local \
+                 backend (the image's baked entrypoint runs); use `mvmctl machine run` \
+                 for ad-hoc commands"
+                    .into(),
+            ));
+        }
+        if !self.env.is_empty() {
+            return Err(invalid(
+                "guest environment variables are not supported by the in-process local \
+                 backend (no delivery seam; values would be silently dropped); use the \
+                 CLI run path"
+                    .into(),
+            ));
+        }
+        if self.network != LaunchNetworkPolicy::DenyAll {
+            return Err(invalid(
+                "the in-process local backend admits only the deny-all network policy; \
+                 an egress allow-list needs the CLI boot path, which enforces the \
+                 resolved policy"
+                    .into(),
+            ));
+        }
+        if self.profile.trim().is_empty() {
+            return Err(invalid("profile must not be empty".into()));
+        }
+        if self.ttl_seconds == Some(0) {
+            return Err(invalid("ttl_seconds must be > 0 when set".into()));
+        }
+        for volume in &self.volumes {
+            if volume.volume.trim().is_empty() {
+                return Err(invalid("volume name must not be empty".into()));
+            }
+            if volume.guest_path.trim().is_empty() {
+                return Err(invalid(format!(
+                    "volume {:?} guest path must not be empty",
+                    volume.volume
+                )));
+            }
+        }
+        Ok(LaunchRequest {
+            name: self.name,
+            mode: self.mode,
+            image: self.image,
+            cpus: self.cpus,
+            memory_mib: self.memory_mib,
+            backend: self.backend,
+            profile: self.profile,
+            ttl_seconds: self.ttl_seconds,
+            volumes: self.volumes,
+            secret_refs: self.secret_refs,
+            force: self.force,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base(mode: LifecycleMode) -> LaunchRequestBuilder {
+        LaunchRequest::builder(mode, "alpine:3.20").name("web")
+    }
+
+    #[test]
+    fn minimal_transient_request_builds_with_defaults() {
+        let req = LaunchRequest::builder(LifecycleMode::Transient, "alpine:3.20")
+            .build()
+            .expect("minimal transient request");
+        assert_eq!(req.mode(), LifecycleMode::Transient);
+        assert!(req.name().is_none(), "name is generated at launch time");
+        assert_eq!((req.cpus, req.memory_mib), (1, 512));
+        assert_eq!(req.profile, "standard");
+        assert!(req.volumes.is_empty() && req.secret_refs.is_empty());
+        assert!(!req.force);
+    }
+
+    #[test]
+    fn persistent_request_requires_a_name() {
+        let err = LaunchRequest::builder(LifecycleMode::Persistent, "alpine:3.20")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("requires a name"), "got: {err}");
+        base(LifecycleMode::Persistent)
+            .build()
+            .expect("named persistent request");
+    }
+
+    #[test]
+    fn empty_image_and_invalid_name_are_refused() {
+        let err = LaunchRequest::builder(LifecycleMode::Transient, "  ")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("image source"), "got: {err}");
+
+        let err = LaunchRequest::builder(LifecycleMode::Transient, "img")
+            .name("Bad Name!")
+            .build()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid machine name"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn zero_resources_are_refused() {
+        let err = base(LifecycleMode::Transient).cpus(0).build().unwrap_err();
+        assert!(err.to_string().contains("cpus"), "got: {err}");
+        let err = base(LifecycleMode::Transient)
+            .memory_mib(0)
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("memory_mib"), "got: {err}");
+    }
+
+    #[test]
+    fn command_override_is_refused_not_ignored() {
+        let err = base(LifecycleMode::Transient)
+            .command(["/bin/sh".to_string(), "-c".to_string(), "id".to_string()])
+            .build()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("command/entrypoint override"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn env_vars_are_refused_not_ignored() {
+        let err = base(LifecycleMode::Transient)
+            .env("API_KEY", "value")
+            .build()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("environment variables"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn network_policy_defaults_deny_all_and_allow_list_is_refused() {
+        assert_eq!(LaunchNetworkPolicy::default(), LaunchNetworkPolicy::DenyAll);
+        let err = base(LifecycleMode::Transient)
+            .network(LaunchNetworkPolicy::AllowHosts(vec![
+                "api.example.com".into(),
+            ]))
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("deny-all"), "got: {err}");
+    }
+
+    #[test]
+    fn zero_ttl_and_malformed_volumes_are_refused() {
+        let err = base(LifecycleMode::Transient)
+            .ttl_seconds(0)
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("ttl_seconds"), "got: {err}");
+
+        let err = base(LifecycleMode::Transient)
+            .volume(LaunchVolumeSpec {
+                volume: "".into(),
+                guest_path: "/data/work".into(),
+                access: AccessMode::ReadOnly,
+            })
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("volume name"), "got: {err}");
+
+        let err = base(LifecycleMode::Transient)
+            .volume(LaunchVolumeSpec {
+                volume: "work".into(),
+                guest_path: " ".into(),
+                access: AccessMode::ReadOnly,
+            })
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("guest path"), "got: {err}");
+    }
+}

--- a/crates/mvm-client/src/launch/tests.rs
+++ b/crates/mvm-client/src/launch/tests.rs
@@ -681,6 +681,48 @@ async fn launch_over_a_deployment_backed_spec_refuses_a_silent_image_boot() {
     );
 }
 
+// ── Per-backend workload-kernel resolution ──────────────────────────
+
+#[test]
+fn firecracker_admitted_boot_receives_a_concrete_kernel_path() {
+    let home = Isolated::new();
+    let fc = mvm_runtime::AnyBackend::from_hypervisor("firecracker");
+
+    // Cold cache: the Firecracker arm fails with the CLI's build hint —
+    // never `Ok(None)`, which the FC driver would hard-refuse as a
+    // bundled-kernel spec at boot time.
+    let err = LocalBackend::resolve_workload_kernel(&fc).unwrap_err();
+    assert!(
+        err.to_string().contains("mvmctl kernel build"),
+        "got: {err}"
+    );
+
+    // Seed the exact cache location the CLI's machine-run boot path reads:
+    // `<cache>/builder-vm/<arch>/kernels/workload/vmlinux`.
+    let cache = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir());
+    let arch = mvm_core::arch::GuestArch::host().to_string();
+    let cached = mvm_build::kernel_fetch::cached_kernel_path(&cache, &arch, "workload");
+    std::fs::create_dir_all(cached.parent().unwrap()).unwrap();
+    std::fs::write(&cached, b"kernel-bytes").unwrap();
+
+    let resolved = LocalBackend::resolve_workload_kernel(&fc)
+        .expect("cached kernel resolves")
+        .expect("firecracker must receive a concrete kernel path");
+    assert_eq!(resolved, cached);
+
+    // Bundled-kernel backends need no host kernel path: libkrun boots the
+    // libkrunfw kernel, the hermetic mock boots nothing.
+    let libkrun = mvm_runtime::AnyBackend::from_hypervisor("libkrun");
+    assert_eq!(
+        LocalBackend::resolve_workload_kernel(&libkrun).unwrap(),
+        None
+    );
+    let mock = mvm_runtime::AnyBackend::from_hypervisor("mock");
+    assert_eq!(LocalBackend::resolve_workload_kernel(&mock).unwrap(), None);
+
+    drop(home);
+}
+
 // ── Typed volume attachments ────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/mvm-client/src/launch/tests.rs
+++ b/crates/mvm-client/src/launch/tests.rs
@@ -10,11 +10,11 @@
 use std::sync::Arc;
 
 use super::*;
+use crate::secret::AuthType;
 use crate::secret::{SecretService, SecretValueInput};
 use mvm_core::client::MvmClient;
 use mvm_core::util::test_env::TestEnv;
 use mvm_hostd::keyholder::{FileBindingStore, SecretBindingMeta};
-use mvm_protocol::ir::AuthType;
 
 /// Isolated `MVM_HOME` for every test in this module. `TestEnv` serializes
 /// process-wide env mutation behind its global lock.

--- a/crates/mvm-client/src/launch/tests.rs
+++ b/crates/mvm-client/src/launch/tests.rs
@@ -374,8 +374,26 @@ async fn persistent_create_start_stop_restart_remove_roundtrip() {
     client.remove_machine(&id).await.expect("remove stopped");
     assert!(!machine_spec_path("p-web").exists());
     assert!(!machine_state_dir("p-web").exists());
+    assert!(
+        !mvm_core::config::vm_state_dir("p-web").exists(),
+        "remove drops the per-VM runtime dir; a stale endpoint socket there \
+         blocks the next launch under the same name"
+    );
     // Idempotent: removing again is Ok.
     client.remove_machine(&id).await.expect("re-remove");
+
+    // The name is immediately reusable: a fresh definition launches clean.
+    let request = persistent_request(&home.rootfs(), "p-web").build().unwrap();
+    let outcome = client.launch(request).await.expect("recreate same name");
+    assert_eq!(
+        outcome.machine.status,
+        mvm_core::client::dto::MachineStatus::Running
+    );
+    client.stop_machine(&id).await.expect("stop recreated");
+    client
+        .remove_machine_with(&id, RemoveOptions { force: false })
+        .await
+        .expect("remove recreated");
 }
 
 #[tokio::test]

--- a/crates/mvm-client/src/launch/tests.rs
+++ b/crates/mvm-client/src/launch/tests.rs
@@ -144,6 +144,38 @@ async fn transient_launch_boots_admitted_and_audited() {
 }
 
 #[tokio::test]
+async fn launch_recovers_from_stale_runtime_dir_leftovers() {
+    let home = Isolated::new();
+    let client = mock_client();
+
+    // A crashed prior run leaves runtime residue (e.g. a dead endpoint
+    // socket) under the per-VM dir; the machine is not running, so a fresh
+    // launch must clear it rather than trip over it.
+    let stale = vm_state_dir("t-stale");
+    std::fs::create_dir_all(&stale).unwrap();
+    std::fs::write(stale.join("substitution-endpoint.sock"), b"").unwrap();
+
+    let request = transient_request(&home.rootfs())
+        .name("t-stale")
+        .build()
+        .expect("request");
+    let outcome = client.launch(request).await.expect("launch over residue");
+    assert_eq!(
+        outcome.machine.status,
+        mvm_core::client::dto::MachineStatus::Running
+    );
+    assert!(
+        !stale.join("substitution-endpoint.sock").exists(),
+        "stale residue cleared before boot"
+    );
+    client
+        .stop_machine(&outcome.machine.id)
+        .await
+        .expect("stop");
+    client.cleanup_transient("t-stale").expect("cleanup");
+}
+
+#[tokio::test]
 async fn transient_launch_without_a_name_generates_one() {
     let home = Isolated::new();
     let client = mock_client();

--- a/crates/mvm-client/src/launch/tests.rs
+++ b/crates/mvm-client/src/launch/tests.rs
@@ -580,6 +580,89 @@ async fn launch_refuses_cross_scope_secret_reference() {
     assert!(err.to_string().contains("cross-scope"), "got: {err}");
 }
 
+#[tokio::test]
+async fn persistent_relaunch_revalidates_sidecar_refs_recorded_earlier() {
+    let home = Isolated::new();
+    let service = fixture_secret_service(&home);
+    let secret_ref = seeded_secret_ref(&service);
+    let client = mock_client().with_secret_service(service.clone());
+    let rootfs = home.rootfs();
+
+    // Create the definition WITH a secret reference, then stop the machine.
+    let with_refs = persistent_request(&rootfs, "p-refs")
+        .secret_ref(secret_ref)
+        .build()
+        .unwrap();
+    let outcome = client.launch(with_refs).await.expect("first launch");
+    client
+        .stop_machine(&outcome.machine.id)
+        .await
+        .expect("stop");
+
+    // Revoke the binding out from under the recorded sidecar.
+    service.unbind("local", "openai").expect("revoke binding");
+
+    // An identical-config launch carrying NO refs hits the Reuse arm — the
+    // sidecar's recorded references must still be re-validated fail-closed.
+    let without_refs = persistent_request(&rootfs, "p-refs").build().unwrap();
+    let err = client.launch(without_refs).await.unwrap_err();
+    assert!(
+        matches!(err, mvm_core::client::MvmError::Rejected { .. }),
+        "got: {err}"
+    );
+    assert!(err.to_string().contains("no egress binding"), "got: {err}");
+    assert!(
+        !listed_names(&client).await.contains(&"p-refs".to_string()),
+        "nothing boots on a refused relaunch"
+    );
+}
+
+#[tokio::test]
+async fn launch_over_a_deployment_backed_spec_refuses_a_silent_image_boot() {
+    let home = Isolated::new();
+    let client = mock_client();
+    let rootfs = home.rootfs();
+
+    // A definition carrying an attested-deployment source (created by the
+    // CLI's deployment flow, which this backend cannot honor).
+    let spec = mvm_runtime::machine::persist::MachineSpec {
+        deployment: Some("/deployments/web".into()),
+        ..super::persisted_spec_from_request(
+            &persistent_request(&rootfs, "p-deploy").build().unwrap(),
+            "p-deploy",
+        )
+    };
+    mvm_runtime::machine::persist::save_machine_spec(&spec, false).unwrap();
+
+    // The bootability gate refuses the source outright …
+    let err = super::ensure_spec_bootable_in_process(&spec).unwrap_err();
+    assert!(
+        err.to_string().contains("attested-deployment"),
+        "got: {err}"
+    );
+
+    // … and a same-image launch never silently boots it as a plain image:
+    // the deployment field is part of the launch config, so the reconcile
+    // refuses without the explicit force flow.
+    let request = persistent_request(&rootfs, "p-deploy").build().unwrap();
+    let err = client.launch(request).await.unwrap_err();
+    assert!(
+        matches!(err, mvm_core::client::MvmError::Conflict { .. }),
+        "got: {err}"
+    );
+    assert!(err.to_string().contains("different config"), "got: {err}");
+
+    // `start` refuses the same source fail-closed.
+    let err = client
+        .start_machine(&mvm_core::client::dto::MachineId("p-deploy".into()))
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("attested-deployment"),
+        "got: {err}"
+    );
+}
+
 // ── Typed volume attachments ────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/mvm-client/src/launch/tests.rs
+++ b/crates/mvm-client/src/launch/tests.rs
@@ -1,0 +1,704 @@
+//! Mock-backed lifecycle tests for the launch module.
+//!
+//! Everything here drives the hermetic in-memory mock backend under an
+//! isolated `MVM_HOME`, so the full admitted-boot path (signing, admission,
+//! chain audit, leases, sidecars, registry) runs against real on-disk state
+//! with no hypervisor.
+
+#![cfg(feature = "test-support")]
+
+use std::sync::Arc;
+
+use super::*;
+use crate::secret::{SecretService, SecretValueInput};
+use mvm_core::client::MvmClient;
+use mvm_core::util::test_env::TestEnv;
+use mvm_hostd::keyholder::{FileBindingStore, SecretBindingMeta};
+use mvm_protocol::ir::AuthType;
+
+/// Isolated `MVM_HOME` for every test in this module. `TestEnv` serializes
+/// process-wide env mutation behind its global lock.
+struct Isolated {
+    _env: TestEnv,
+    dir: tempfile::TempDir,
+}
+
+impl Isolated {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(dir.path());
+        Self { _env: env, dir }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        self.dir.path()
+    }
+
+    /// A minimal hashable rootfs file the mock backend boots.
+    fn rootfs(&self) -> String {
+        let path = self.path().join("rootfs.ext4");
+        std::fs::write(&path, b"hashable-rootfs-bytes\n").expect("write rootfs");
+        path.to_string_lossy().into_owned()
+    }
+
+    /// The tenant audit chain the admitted boot writes.
+    fn audit_text(&self) -> String {
+        let audit = std::path::PathBuf::from(mvm_core::config::mvm_home())
+            .join("audit")
+            .join("local.jsonl");
+        std::fs::read_to_string(audit).unwrap_or_default()
+    }
+}
+
+fn mock_client() -> LocalBackend {
+    LocalBackend::with_hypervisor("mock")
+}
+
+/// A file-store-backed secret service rooted inside the isolated home whose
+/// machines root matches the launch path's sidecar location.
+fn fixture_secret_service(home: &Isolated) -> Arc<SecretService> {
+    let service = SecretService::builder()
+        .store(Arc::new(
+            mvm_core::crypto::secret_store::FileSecretStore::with_dir(home.path().join("secrets")),
+        ))
+        .bindings(Arc::new(FileBindingStore::with_dir(
+            home.path().join("bindings"),
+        )))
+        .machines_root(machine_state_root())
+        .build()
+        .expect("fixture secret service");
+    Arc::new(service)
+}
+
+/// Store + bind one secret and return its typed reference.
+fn seeded_secret_ref(service: &SecretService) -> MachineSecretRef {
+    service
+        .put(
+            "local",
+            "openai",
+            SecretValueInput::new("sk-live-zzz".into()),
+        )
+        .expect("store secret");
+    service
+        .bind(
+            "local",
+            "openai",
+            SecretBindingMeta {
+                auth_type: AuthType::Bearer,
+                allowed_hosts: vec!["api.openai.com".into()],
+                sigv4: None,
+            },
+        )
+        .expect("bind secret");
+    MachineSecretRef {
+        tenant: "local".into(),
+        name: "openai".into(),
+        placeholder_var: Some("API_KEY".into()),
+        destinations: vec!["api.openai.com".into()],
+    }
+}
+
+fn transient_request(image: &str) -> LaunchRequestBuilder {
+    LaunchRequest::builder(LifecycleMode::Transient, image)
+}
+
+fn persistent_request(image: &str, name: &str) -> LaunchRequestBuilder {
+    LaunchRequest::builder(LifecycleMode::Persistent, image).name(name)
+}
+
+async fn listed_names(client: &LocalBackend) -> Vec<String> {
+    client
+        .list_machines(mvm_core::client::dto::MachineFilter::all())
+        .await
+        .expect("list")
+        .into_iter()
+        .map(|m| m.name)
+        .collect()
+}
+
+// ── Transient lifecycle ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn transient_launch_boots_admitted_and_audited() {
+    let home = Isolated::new();
+    let client = mock_client();
+    let request = transient_request(&home.rootfs())
+        .name("t-happy")
+        .build()
+        .expect("request");
+
+    let outcome = client.launch(request).await.expect("launch");
+    assert_eq!(
+        outcome.machine.status,
+        mvm_core::client::dto::MachineStatus::Running
+    );
+    assert_eq!(outcome.machine.name, "t-happy");
+    assert!(outcome.plan_id.starts_with("sha256:"), "content-addressed");
+    assert!(listed_names(&client).await.contains(&"t-happy".to_string()));
+
+    // The canonical admission emitted the chain-signed pair.
+    let audit = home.audit_text();
+    assert!(audit.contains("plan.admitted"), "got: {audit}");
+    assert!(audit.contains("plan.launched"), "got: {audit}");
+}
+
+#[tokio::test]
+async fn transient_launch_without_a_name_generates_one() {
+    let home = Isolated::new();
+    let client = mock_client();
+    let request = transient_request(&home.rootfs()).build().expect("request");
+    let outcome = client.launch(request).await.expect("launch");
+    assert!(
+        outcome.machine.name.starts_with("transient-"),
+        "generated name: {}",
+        outcome.machine.name
+    );
+}
+
+#[tokio::test]
+async fn transient_exit_reports_code_and_cleanup_is_idempotent() {
+    let home = Isolated::new();
+    let client = mock_client();
+    let service = fixture_secret_service(&home);
+    let secret_ref = seeded_secret_ref(&service);
+    let client = client.with_secret_service(service);
+
+    let request = transient_request(&home.rootfs())
+        .name("t-exit")
+        .secret_ref(secret_ref)
+        .build()
+        .expect("request");
+    let outcome = client.launch(request).await.expect("launch");
+
+    // The sidecar was recorded before boot.
+    assert!(
+        machine_state_dir("t-exit")
+            .join(crate::secret::refs::MACHINE_SECRET_REFS_FILENAME)
+            .exists()
+    );
+
+    // Simulate run-to-completion: the guest reports exit 7, then powers off.
+    let state_dir = vm_state_dir("t-exit");
+    std::fs::create_dir_all(&state_dir).unwrap();
+    std::fs::write(mvm_core::exit_capture::exit_file_path(&state_dir), b"7\n").unwrap();
+    client
+        .stop_machine(&outcome.machine.id)
+        .await
+        .expect("stop");
+
+    let report = client
+        .wait_for_exit(
+            &outcome,
+            std::time::Duration::from_millis(10),
+            std::time::Duration::from_secs(2),
+        )
+        .expect("wait for exit");
+    assert_eq!(report.exit_code, Some(7));
+
+    // Everything session-owned is gone …
+    assert!(!machine_state_dir("t-exit").exists(), "sidecar dir removed");
+    assert!(!listed_names(&client).await.contains(&"t-exit".to_string()));
+    // … the exit landed in the chain …
+    assert!(home.audit_text().contains("plan.exited"));
+    // … and cleanup is idempotent.
+    client.cleanup_transient("t-exit").expect("re-clean");
+    client
+        .cleanup_transient("never-launched")
+        .expect("absent ok");
+}
+
+#[tokio::test]
+async fn transient_failed_launch_rolls_back_session_state() {
+    let home = Isolated::new();
+    let service = fixture_secret_service(&home);
+    let secret_ref = seeded_secret_ref(&service);
+    let client = mock_client().with_secret_service(service);
+
+    // An unparseable image reference fails resolution after the secret
+    // refs were validated + recorded, before any boot.
+    let request = transient_request("not a valid ref!!")
+        .name("t-fail")
+        .secret_ref(secret_ref)
+        .build()
+        .expect("request");
+    let err = client.launch(request).await.unwrap_err();
+    assert!(
+        err.to_string().contains("parse image reference"),
+        "got: {err}"
+    );
+
+    // Nothing session-owned leaks: no sidecar, no machine dir, no listing.
+    assert!(!machine_state_dir("t-fail").exists());
+    assert!(!listed_names(&client).await.contains(&"t-fail".to_string()));
+}
+
+#[tokio::test]
+async fn transient_name_collisions_are_refused() {
+    let home = Isolated::new();
+    let client = mock_client();
+    let rootfs = home.rootfs();
+
+    // Collides with a running machine of the same name.
+    let first = transient_request(&rootfs).name("t-dup").build().unwrap();
+    client.launch(first).await.expect("first launch");
+    let second = transient_request(&rootfs).name("t-dup").build().unwrap();
+    let err = client.launch(second).await.unwrap_err();
+    assert!(
+        matches!(err, mvm_core::client::MvmError::Conflict { .. }),
+        "got: {err}"
+    );
+
+    // Collides with a persisted definition of the same name.
+    client
+        .create_from_request(&persistent_request(&rootfs, "p-claimed").build().unwrap())
+        .expect("create definition");
+    let third = transient_request(&rootfs)
+        .name("p-claimed")
+        .build()
+        .unwrap();
+    let err = client.launch(third).await.unwrap_err();
+    assert!(err.to_string().contains("persistent machine"), "got: {err}");
+}
+
+#[tokio::test]
+async fn ttl_reaper_stops_and_cleans_expired_transients_only() {
+    let home = Isolated::new();
+    let client = mock_client();
+    let rootfs = home.rootfs();
+
+    let short = transient_request(&rootfs)
+        .name("t-ttl")
+        .ttl_seconds(1)
+        .build()
+        .unwrap();
+    client.launch(short).await.expect("launch with ttl");
+
+    // A persistent machine with an elapsed registry TTL must never be reaped
+    // by the transient reaper.
+    client
+        .create_from_request(&persistent_request(&rootfs, "p-keep").build().unwrap())
+        .expect("create persistent");
+
+    // Before expiry nothing is reaped.
+    let now = chrono::Utc::now().to_rfc3339();
+    assert!(
+        client
+            .reap_expired_transients(&now)
+            .expect("reap")
+            .is_empty()
+    );
+
+    // Past expiry the transient is stopped + cleaned; the definition stays.
+    let later = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+    let reaped = client.reap_expired_transients(&later).expect("reap");
+    assert_eq!(reaped, vec!["t-ttl".to_string()]);
+    assert!(!listed_names(&client).await.contains(&"t-ttl".to_string()));
+    assert!(machine_spec_path("p-keep").exists(), "definition survives");
+
+    // Idempotent: a second reap finds nothing.
+    assert!(
+        client
+            .reap_expired_transients(&later)
+            .expect("reap")
+            .is_empty()
+    );
+}
+
+// ── Persistent lifecycle ────────────────────────────────────────────
+
+#[tokio::test]
+async fn persistent_create_start_stop_restart_remove_roundtrip() {
+    let home = Isolated::new();
+    let service = fixture_secret_service(&home);
+    let secret_ref = seeded_secret_ref(&service);
+    let client = mock_client().with_secret_service(service);
+    let rootfs = home.rootfs();
+
+    // Create (persist without boot): definition + secret-ref sidecar land.
+    let request = persistent_request(&rootfs, "p-web")
+        .cpus(2)
+        .memory_mib(256)
+        .secret_ref(secret_ref)
+        .build()
+        .unwrap();
+    let created = client.create_from_request(&request).expect("create");
+    assert_eq!(
+        created.status,
+        mvm_core::client::dto::MachineStatus::Stopped
+    );
+    assert!(machine_spec_path("p-web").exists(), "definition persisted");
+    assert!(
+        machine_state_dir("p-web")
+            .join(crate::secret::refs::MACHINE_SECRET_REFS_FILENAME)
+            .exists(),
+        "secret refs recorded at create"
+    );
+
+    // Start boots from the persisted definition through admission.
+    let id = mvm_core::client::dto::MachineId("p-web".into());
+    let started = client.start_machine(&id).await.expect("start");
+    assert_eq!(
+        started.status,
+        mvm_core::client::dto::MachineStatus::Running
+    );
+    assert!(home.audit_text().contains("plan.launched"));
+    // Starting again is a no-op reporting the running state.
+    let again = client.start_machine(&id).await.expect("re-start");
+    assert_eq!(again.status, mvm_core::client::dto::MachineStatus::Running);
+    // The start stamped last_started_at on the spec.
+    let spec = mvm_runtime::machine::persist::load_machine_spec("p-web").unwrap();
+    assert!(spec.last_started_at.is_some());
+
+    // Stop never deletes the definition; the machine stays in inventory.
+    client.stop_machine(&id).await.expect("stop");
+    assert!(machine_spec_path("p-web").exists(), "stop keeps the spec");
+    let records = crate::inventory::list_local_inventory(&client)
+        .await
+        .expect("inventory");
+    let record = records.iter().find(|r| r.name == "p-web").expect("listed");
+    assert_eq!(record.kind, crate::inventory::MachineKind::Persistent);
+    assert_eq!(record.status, mvm_core::client::dto::MachineStatus::Stopped);
+    assert_eq!(record.secret_ref_count, 1, "sidecar count surfaces");
+
+    // Restart = start from the stopped definition.
+    let restarted = client.restart_persistent("p-web").await.expect("restart");
+    assert_eq!(
+        restarted.status,
+        mvm_core::client::dto::MachineStatus::Running
+    );
+    client.stop_machine(&id).await.expect("stop again");
+
+    // Remove is the separate confirmed action that deletes the definition
+    // and clears the secret-reference sidecar.
+    client.remove_machine(&id).await.expect("remove stopped");
+    assert!(!machine_spec_path("p-web").exists());
+    assert!(!machine_state_dir("p-web").exists());
+    // Idempotent: removing again is Ok.
+    client.remove_machine(&id).await.expect("re-remove");
+}
+
+#[tokio::test]
+async fn persistent_launch_boots_and_reuses_same_config() {
+    let home = Isolated::new();
+    let client = mock_client();
+    let rootfs = home.rootfs();
+
+    let request = persistent_request(&rootfs, "p-run").build().unwrap();
+    let outcome = client.launch(request).await.expect("launch persistent");
+    assert_eq!(
+        outcome.machine.status,
+        mvm_core::client::dto::MachineStatus::Running
+    );
+    assert!(machine_spec_path("p-run").exists());
+
+    // Launching again while running: same config reuses the definition but
+    // refuses the double boot.
+    let request = persistent_request(&rootfs, "p-run").build().unwrap();
+    let err = client.launch(request).await.unwrap_err();
+    assert!(
+        matches!(err, mvm_core::client::MvmError::Conflict { .. }),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn persistent_name_collision_needs_force_to_recreate() {
+    let home = Isolated::new();
+    let client = mock_client();
+    let rootfs = home.rootfs();
+
+    client
+        .create_from_request(
+            &persistent_request(&rootfs, "p-dup")
+                .cpus(1)
+                .build()
+                .unwrap(),
+        )
+        .expect("create");
+
+    // A different config without force is refused …
+    let changed = persistent_request(&rootfs, "p-dup")
+        .cpus(4)
+        .build()
+        .unwrap();
+    let err = client.create_from_request(&changed).unwrap_err();
+    assert!(
+        matches!(err, mvm_core::client::MvmError::Conflict { .. }),
+        "got: {err}"
+    );
+    assert!(err.to_string().contains("different config"), "got: {err}");
+
+    // … and recreates with the explicit force flow.
+    let forced = persistent_request(&rootfs, "p-dup")
+        .cpus(4)
+        .force(true)
+        .build()
+        .unwrap();
+    client
+        .create_from_request(&forced)
+        .expect("forced recreate");
+    let spec = mvm_runtime::machine::persist::load_machine_spec("p-dup").unwrap();
+    assert_eq!(spec.cpus, 4);
+}
+
+#[tokio::test]
+async fn removing_a_running_persistent_machine_needs_the_force_flow() {
+    let home = Isolated::new();
+    let client = mock_client();
+    let request = persistent_request(&home.rootfs(), "p-live")
+        .build()
+        .unwrap();
+    client.launch(request).await.expect("launch");
+
+    let id = mvm_core::client::dto::MachineId("p-live".into());
+    let err = client.remove_machine(&id).await.unwrap_err();
+    assert!(
+        matches!(err, mvm_core::client::MvmError::Conflict { .. }),
+        "got: {err}"
+    );
+    assert!(
+        machine_spec_path("p-live").exists(),
+        "refusal keeps the spec"
+    );
+
+    client
+        .remove_machine_with(&id, RemoveOptions { force: true })
+        .await
+        .expect("force remove");
+    assert!(!machine_spec_path("p-live").exists());
+    assert!(!listed_names(&client).await.contains(&"p-live".to_string()));
+}
+
+#[tokio::test]
+async fn start_refuses_spec_shapes_the_in_process_backend_cannot_honor() {
+    let _home = Isolated::new();
+    let client = mock_client();
+    let mut spec = mvm_runtime::machine::persist::MachineSpec {
+        schema_version: mvm_runtime::machine::persist::MACHINE_SPEC_SCHEMA_VERSION,
+        name: "p-net".into(),
+        image: Some("alpine:latest".into()),
+        manifest: None,
+        deployment: None,
+        resolved_digest: None,
+        runtime_pack: false,
+        net: true,
+        allow_host: vec![],
+        cpus: 1,
+        memory: "128M".into(),
+        mem_initial: None,
+        profile: "standard".into(),
+        volumes: vec![],
+        init: vec![],
+        agent_verb: vec![],
+        created_at: None,
+        last_started_at: None,
+        health_check: None,
+    };
+    mvm_runtime::machine::persist::save_machine_spec(&spec, false).unwrap();
+    let err = client
+        .start_machine(&mvm_core::client::dto::MachineId("p-net".into()))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("deny-all"), "got: {err}");
+
+    spec.name = "p-vol".into();
+    spec.net = false;
+    spec.volumes = vec!["/h:/data".into()];
+    mvm_runtime::machine::persist::save_machine_spec(&spec, false).unwrap();
+    let err = client
+        .start_machine(&mvm_core::client::dto::MachineId("p-vol".into()))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("volume"), "got: {err}");
+
+    // A machine that was never created is NotFound.
+    let err = client
+        .start_machine(&mvm_core::client::dto::MachineId("p-ghost".into()))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, mvm_core::client::MvmError::NotFound { .. }),
+        "got: {err}"
+    );
+}
+
+// ── Admission refusals ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn launch_refuses_secret_ref_without_binding_and_boots_nothing() {
+    let home = Isolated::new();
+    let service = fixture_secret_service(&home);
+    // Stored value but no egress binding → admission must fail closed.
+    service
+        .put("local", "unbound", SecretValueInput::new("sk-x".into()))
+        .unwrap();
+    let client = mock_client().with_secret_service(service);
+
+    let request = transient_request(&home.rootfs())
+        .name("t-refused")
+        .secret_ref(MachineSecretRef {
+            tenant: "local".into(),
+            name: "unbound".into(),
+            placeholder_var: None,
+            destinations: vec![],
+        })
+        .build()
+        .unwrap();
+    let err = client.launch(request).await.unwrap_err();
+    assert!(
+        matches!(err, mvm_core::client::MvmError::Rejected { .. }),
+        "got: {err}"
+    );
+    assert!(err.to_string().contains("no egress binding"), "got: {err}");
+
+    // Refused before boot: nothing listed, no chain launch entry.
+    assert!(
+        !listed_names(&client)
+            .await
+            .contains(&"t-refused".to_string())
+    );
+    assert!(!home.audit_text().contains("plan.launched"));
+}
+
+#[tokio::test]
+async fn launch_refuses_cross_scope_secret_reference() {
+    let home = Isolated::new();
+    let service = fixture_secret_service(&home);
+    let client = mock_client().with_secret_service(service);
+    let request = transient_request(&home.rootfs())
+        .name("t-cross")
+        .secret_ref(MachineSecretRef {
+            tenant: "acme".into(),
+            name: "openai".into(),
+            placeholder_var: None,
+            destinations: vec![],
+        })
+        .build()
+        .unwrap();
+    let err = client.launch(request).await.unwrap_err();
+    assert!(err.to_string().contains("cross-scope"), "got: {err}");
+}
+
+// ── Typed volume attachments ────────────────────────────────────────
+
+#[tokio::test]
+async fn launch_with_managed_volume_takes_and_releases_the_lease() {
+    use crate::volume::{CreateBlockVolumeRequest, VolumeService as _};
+
+    let home = Isolated::new();
+    let client = mock_client();
+    let rootfs = home.rootfs();
+
+    // A managed encrypted block volume, unlocked so it can be attached.
+    let volumes = crate::volume::LocalVolumeService::new();
+    volumes
+        .create_block_volume(
+            &CreateBlockVolumeRequest::builder("work")
+                .unwrap()
+                .capacity_mib(16)
+                .build()
+                .unwrap(),
+        )
+        .expect("create volume");
+    volumes.unlock_volume("work").expect("unlock");
+
+    let request = persistent_request(&rootfs, "p-vols")
+        .volume(LaunchVolumeSpec {
+            volume: "work".into(),
+            guest_path: "/data/work".into(),
+            access: AccessMode::ReadOnly,
+        })
+        .build()
+        .unwrap();
+    let outcome = client.launch(request).await.expect("launch with volume");
+    assert_eq!(
+        outcome.machine.status,
+        mvm_core::client::dto::MachineStatus::Running
+    );
+
+    // The lease is held by the running machine …
+    let record = volumes.describe_volume("work").expect("describe");
+    assert_eq!(record.attached_to.as_deref(), Some("p-vols"));
+
+    // … a second launch attaching the same artifact is refused …
+    let rival = persistent_request(&rootfs, "p-rival")
+        .volume(LaunchVolumeSpec {
+            volume: "work".into(),
+            guest_path: "/data/work".into(),
+            access: AccessMode::ReadOnly,
+        })
+        .build()
+        .unwrap();
+    let err = client.launch(rival).await.unwrap_err();
+    assert!(err.to_string().contains("already attached"), "got: {err}");
+
+    // … and the stop path releases it.
+    client
+        .stop_machine(&mvm_core::client::dto::MachineId("p-vols".into()))
+        .await
+        .expect("stop");
+    let record = volumes.describe_volume("work").expect("describe");
+    assert_eq!(record.attached_to, None, "lease released on stop");
+}
+
+// ── Audit hygiene ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn lifecycle_audit_carries_no_secret_values_or_env() {
+    let home = Isolated::new();
+    let service = fixture_secret_service(&home);
+    let secret_ref = seeded_secret_ref(&service);
+    let client = mock_client().with_secret_service(service);
+
+    let request = transient_request(&home.rootfs())
+        .name("t-hygiene")
+        .secret_ref(secret_ref)
+        .build()
+        .unwrap();
+    let outcome = client.launch(request).await.expect("launch");
+    client
+        .stop_machine(&outcome.machine.id)
+        .await
+        .expect("stop");
+    client.report_exit(&outcome).expect("exit report");
+
+    // Walk every file the lifecycle wrote under the audit dir plus the
+    // machine dirs: the stored secret value must appear nowhere, and no
+    // environment-shaped assignment leaks either.
+    let audit = home.audit_text();
+    assert!(audit.contains("plan.admitted") && audit.contains("plan.exited"));
+    assert!(
+        !audit.contains("sk-live-zzz"),
+        "secret value in audit: {audit}"
+    );
+    assert!(
+        !audit.contains("API_KEY="),
+        "env assignment in audit: {audit}"
+    );
+
+    let mut stack = vec![std::path::PathBuf::from(mvm_core::config::mvm_home())];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                // The encrypted secret store itself is allowed to hold the
+                // (encrypted) value; everything else must not.
+                if path.ends_with("secrets") {
+                    continue;
+                }
+                stack.push(path);
+            } else if let Ok(bytes) = std::fs::read(&path) {
+                let text = String::from_utf8_lossy(&bytes);
+                assert!(
+                    !text.contains("sk-live-zzz"),
+                    "secret value leaked into {}",
+                    path.display()
+                );
+            }
+        }
+    }
+}

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -17,6 +17,7 @@ pub mod audit;
 pub mod boot;
 pub mod connect;
 pub mod inventory;
+pub mod launch;
 pub mod local;
 pub mod readiness;
 pub mod registration;
@@ -41,6 +42,10 @@ pub use boot::{
     backend_is_running, backend_stop_by_name, require_hypervisor_selectable, start_prepared,
 };
 pub use connect::{Target, connect};
+pub use launch::{
+    ExitReport, LaunchNetworkPolicy, LaunchOutcome, LaunchRequest, LaunchRequestBuilder,
+    LaunchVolumeSpec, LifecycleMode, RemoveOptions,
+};
 pub use local::LocalBackend;
 pub use readiness::{readiness_of, record_readiness, touch_activity};
 pub use registration::{

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -25,8 +25,6 @@ use mvm_fs::oci::{
     ImageReference, LayerDescriptor, LayerFetchOptions, LinuxPlatform, OciLayerFetcher,
     OciManifestFetcher, UnpackOptions, UnpackReport, unpack_layer_with_prior_paths,
 };
-use mvm_hostd::plan_admission::{InMemoryNonceLedger, SystemClock};
-use mvm_hostd::run::{LocalRunContext, LocalRunRequest, admit_and_boot_local};
 use mvm_runtime::AnyBackend;
 
 use mvm_core::client::dto::{
@@ -48,20 +46,38 @@ use mvm_runtime::vm::name_registry::{VmNameRegistry, VmRegistration};
 /// Drives the host's VM backend directly. Construct with [`LocalBackend::new`]
 /// (auto-selected backend) or [`LocalBackend::with_hypervisor`].
 pub struct LocalBackend {
-    backend: AnyBackend,
+    pub(crate) backend: AnyBackend,
+    /// Injected secret lifecycle service for launch-time reference
+    /// validation/recording. `None` builds the production-wired
+    /// [`crate::secret::SecretService::local`] on first use.
+    pub(crate) secret_service: Option<std::sync::Arc<crate::secret::SecretService>>,
 }
 
 impl LocalBackend {
     pub fn new() -> Self {
         Self {
             backend: AnyBackend::auto_select(),
+            secret_service: None,
         }
     }
 
     pub fn with_hypervisor(name: &str) -> Self {
         Self {
             backend: AnyBackend::from_hypervisor(name),
+            secret_service: None,
         }
+    }
+
+    /// Replace the secret lifecycle service this client validates and
+    /// records machine secret references through (tests inject a fixture
+    /// store; production uses the default).
+    #[must_use]
+    pub fn with_secret_service(
+        mut self,
+        service: std::sync::Arc<crate::secret::SecretService>,
+    ) -> Self {
+        self.secret_service = Some(service);
+        self
     }
 
     /// The backend-observed VMs on this host — every VMM's live listing plus this
@@ -275,7 +291,7 @@ impl Default for LocalBackend {
     }
 }
 
-fn map_status(s: &VmStatus) -> MachineStatus {
+pub(crate) fn map_status(s: &VmStatus) -> MachineStatus {
     match s {
         VmStatus::Running => MachineStatus::Running,
         VmStatus::Starting => MachineStatus::Starting,
@@ -322,7 +338,7 @@ fn load_name_registry() -> VmNameRegistry {
 /// after a successful stop, so it stops showing as registered. A load or save
 /// failure is ignored — a direct-boot VM carries no registry entry, and the
 /// stop this follows already succeeded regardless.
-fn deregister_from_name_registry(name: &str) {
+pub(crate) fn deregister_from_name_registry(name: &str) {
     let path = mvm_runtime::vm::name_registry::registry_path();
     if let Ok(mut registry) = VmNameRegistry::load(&path) {
         registry.deregister(name);
@@ -362,7 +378,7 @@ fn to_state(info: VmInfo, reg: Option<&VmRegistration>) -> MachineState {
     }
 }
 
-fn backend_err(e: impl std::fmt::Display) -> MvmError {
+pub(crate) fn backend_err(e: impl std::fmt::Display) -> MvmError {
     MvmError::Backend {
         reason: e.to_string(),
     }
@@ -396,7 +412,7 @@ fn classify_image(image: &str) -> ImageSource {
 /// Resolve `spec.image` to a host `rootfs.ext4` path, materializing in-process
 /// as needed (no subprocess, no CLI). Registry pulls are async; the dir +
 /// pre-materialized cases are synchronous.
-async fn resolve_local_rootfs(image: &str, name: &str) -> Result<PathBuf> {
+pub(crate) async fn resolve_local_rootfs(image: &str, name: &str) -> Result<PathBuf> {
     match classify_image(image) {
         ImageSource::Materialized(path) => Ok(path),
         // An already-unpacked tree carries no unpack report, so there is
@@ -517,7 +533,7 @@ fn unpack_one_layer(
 /// `(verity_path, roothash)` when both are present and the hash is well-formed
 /// (64-hex); `(None, None)` for an unverified image. A `&Path` adapter over
 /// `mvm_runtime::microvm::probe_verity_sidecar`, which does the host-side read.
-fn host_verity_sidecars(rootfs: &Path) -> (Option<String>, Option<String>) {
+pub(crate) fn host_verity_sidecars(rootfs: &Path) -> (Option<String>, Option<String>) {
     mvm_runtime::microvm::probe_verity_sidecar(&rootfs.to_string_lossy())
 }
 
@@ -585,101 +601,49 @@ impl MvmClient for LocalBackend {
             .ok_or_else(|| MvmError::NotFound { id: id.0.clone() })
     }
 
-    async fn create_machine(&self, _spec: MachineSpec) -> Result<MachineState> {
-        // Create-without-boot needs the machine registry (spec persistence),
-        // which is a CLI-side path not wired into the in-process backend.
-        Err(MvmError::Backend {
-            reason: "local create (persist without boot) is not wired in the in-process backend; \
-                     use run_machine, or the CLI's `machine create`"
-                .into(),
-        })
+    async fn create_machine(&self, spec: MachineSpec) -> Result<MachineState> {
+        if !spec.env.is_empty() {
+            return Err(MvmError::InvalidSpec {
+                reason: "the persisted machine definition carries no environment variables; \
+                         refusing to silently drop them (use the CLI run path)"
+                    .into(),
+            });
+        }
+        let request = crate::launch::LaunchRequest::builder(
+            crate::launch::LifecycleMode::Persistent,
+            spec.image,
+        )
+        .name(spec.name)
+        .cpus(spec.cpus)
+        .memory_mib(spec.memory_mib)
+        .build()?;
+        self.create_from_request(&request)
     }
 
     async fn run_machine(&self, spec: MachineSpec) -> Result<MachineState> {
-        let rootfs = resolve_local_rootfs(&spec.image, &spec.name).await?;
-        let (verity_path, roothash) = host_verity_sidecars(&rootfs);
-
-        // libkrun/mock carry their own kernel; HVF boots an explicit
-        // arm64 kernel Image. Resolve it from the per-arch workload-kernel
-        // cache the CLI's run path populates — the facade stays
-        // cache-hit-or-error; the heavier build/fetch flows are CLI concerns.
-        let kernel_path = if self.backend.kind() == BackendKind::Hvf {
-            let cache = PathBuf::from(mvm_core::config::mvm_cache_dir());
-            let arch = mvm_core::arch::GuestArch::host().to_string();
-            // Through the resolver rather than a bare existence check, so a
-            // cache hit here is verified against its recorded digest like
-            // every other read. `source_checkout: false` only shapes which
-            // non-hit variant comes back; this facade treats any of them the
-            // same way.
-            let path = match mvm_build::kernel_fetch::resolve_kernel(
-                &cache, &arch, "workload", false,
-            ) {
-                mvm_build::kernel_fetch::KernelResolution::Cached(verified) => {
-                    verified.path().to_path_buf()
-                }
-                _ => {
-                    return Err(backend_err(format!(
-                        "hvf needs a verified workload kernel at {} — run a `mvmctl machine run` \
-                         once (or `mvmctl build kernel build`) to populate the cache",
-                        mvm_build::kernel_fetch::cached_kernel_path(&cache, &arch, "workload")
-                            .display()
-                    )));
-                }
-            };
-            Some(path)
-        } else {
-            None
-        };
-
-        let req = LocalRunRequest {
-            name: spec.name.clone(),
-            rootfs_path: rootfs,
-            kernel_path,
-            verity_path: verity_path.map(PathBuf::from),
-            roothash,
-            cpus: spec.cpus,
-            mem_mib: spec.memory_mib,
-            backend_name: self.backend.name().to_string(),
-        };
-
-        // A fresh per-run ledger: local runs are one-shot from this process, so
-        // replay protection spans this admission (the CLI uses the same
-        // per-invocation shape). Keys dir `None` → the host signer at
-        // `~/.mvm/keys/`.
-        let ledger = InMemoryNonceLedger::new();
-        let clock = SystemClock;
-        // `{:#}` keeps the anyhow context chain — "backend start after
-        // signed-plan admission" alone hides the actionable root cause.
-        let started = admit_and_boot_local(
-            &self.backend,
-            &req,
-            LocalRunContext {
-                clock: &clock,
-                ledger: &ledger,
-                host_signer_keys_dir: None,
-            },
+        // Env vars have no delivery seam on the in-process boot path; refuse
+        // rather than silently drop values the caller believes were set.
+        if !spec.env.is_empty() {
+            return Err(MvmError::InvalidSpec {
+                reason: "guest environment variables are not supported by the in-process \
+                         local backend (no delivery seam); use the CLI run path"
+                    .into(),
+            });
+        }
+        let request = crate::launch::LaunchRequest::builder(
+            crate::launch::LifecycleMode::Transient,
+            spec.image,
         )
-        .map_err(|e| backend_err(format!("{e:#}")))?;
-
-        Ok(MachineState {
-            id: MachineId(started.vm_id.0),
-            name: spec.name,
-            status: MachineStatus::Running,
-            backend: self.backend.name().to_string(),
-            cpus: spec.cpus,
-            memory_mib: spec.memory_mib,
-            ..Default::default()
-        })
+        .name(spec.name)
+        .cpus(spec.cpus)
+        .memory_mib(spec.memory_mib)
+        .build()?;
+        let outcome = self.launch(request).await?;
+        Ok(outcome.machine)
     }
 
-    async fn start_machine(&self, _id: &MachineId) -> Result<MachineState> {
-        // Starting a created/stopped machine needs the machine registry (spec
-        // persistence) to know what to boot — a CLI-side path not wired here.
-        Err(MvmError::Backend {
-            reason: "local start of a created machine is not wired in the in-process backend; \
-                     use run_machine, or the CLI's `machine start`"
-                .into(),
-        })
+    async fn start_machine(&self, id: &MachineId) -> Result<MachineState> {
+        self.start_persistent(&id.0).await
     }
 
     async fn stop_machine(&self, id: &MachineId) -> Result<()> {
@@ -696,9 +660,17 @@ impl MvmClient for LocalBackend {
         };
         // Deregister from the name registry only on a successful stop; on
         // failure the entry (and any readiness the caller recorded) stays so
-        // the user can see what happened.
+        // the user can see what happened. A persistent machine's spec is
+        // never touched by stop — only remove deletes a definition.
         if result.is_ok() {
             deregister_from_name_registry(&id.0);
+            // Release the stopped owner's volume-attachment leases (re-sealing
+            // any just-in-time unlocked volume). Best-effort: the stop itself
+            // already succeeded.
+            use crate::volume::VolumeService as _;
+            if let Err(e) = crate::volume::LocalVolumeService::new().release_owner_leases(&id.0) {
+                tracing::warn!(error = %e, machine = %id.0, "releasing volume leases after stop failed");
+            }
         }
         result.map_err(backend_err)
     }
@@ -766,27 +738,12 @@ impl MvmClient for LocalBackend {
     }
 
     async fn remove_machine(&self, id: &MachineId) -> Result<()> {
-        let vid = VmId(id.0.clone());
-        // Idempotent: removing an absent machine is `Ok` (trait contract).
-        // `list` is the source of truth for what this backend can see, so an
-        // id it doesn't know is already "removed".
-        let present = self
-            .backend
-            .list()
-            .map_err(backend_err)?
-            .iter()
-            .any(|v| v.id == vid);
-        if !present {
-            return Ok(());
-        }
-        // This backend is registry-less — it drives live VMs the VMM tracks,
-        // with no persisted spec to delete (which is why `create`/`start`
-        // fail closed above). For that model `stop` *is* the removal: it tears
-        // the VM down and clears the run-state marker the VMM lists on, so the
-        // machine drops out of `list`. Idempotent on an already-stopped VM.
-        // (The CLI's `machine rm` additionally deletes a persisted machine
-        // record — a spec store this in-process backend doesn't own.)
-        self.backend.stop(&vid).map_err(backend_err)
+        // The non-forced flow: a RUNNING persistent machine is refused (the
+        // reviewed force flow is `remove_machine_with`); a stopped persistent
+        // definition is deleted; a spec-less name gets idempotent transient
+        // cleanup. Removing an absent machine is `Ok` (trait contract).
+        self.remove_machine_with(id, crate::launch::RemoveOptions::default())
+            .await
     }
 
     async fn machine_logs(&self, id: &MachineId, opts: LogOpts) -> Result<Vec<u8>> {
@@ -871,21 +828,9 @@ impl MvmClient for LocalBackend {
         let was_running = matches!(self.backend.status(&vid), Ok(VmStatus::Running));
         if was_running {
             self.backend.stop(&vid).map_err(backend_err)?;
-            // LocalBackend's run path requires an image reference.
-            let image = desired.image.clone().ok_or_else(|| MvmError::InvalidSpec {
-                reason: "the local backend cannot relaunch a manifest-backed machine \
-                         (no image reference); use the CLI verb"
-                    .into(),
-            })?;
-            let spec = MachineSpec {
-                name: desired.name.clone(),
-                image,
-                cpus: desired.cpus,
-                memory_mib: mvm_core::util::parse_human_size(&desired.memory)
-                    .map_err(backend_err)?,
-                env: vec![],
-            };
-            return self.run_machine(spec).await;
+            // Relaunch the persisted definition through the persistent start
+            // path — the same admitted boot every lifecycle verb uses.
+            return self.start_persistent(&desired.name).await;
         }
 
         Ok(MachineState {

--- a/crates/mvm-client/tests/launch_lifecycle_live.rs
+++ b/crates/mvm-client/tests/launch_lifecycle_live.rs
@@ -28,12 +28,30 @@ fn live_env() -> Option<(String, String)> {
     Some((kernel, rootfs))
 }
 
+/// Make the lane self-contained: seed the supplied workload kernel into the
+/// exact cache location the launch path resolves
+/// (`<cache>/builder-vm/<arch>/kernels/workload/vmlinux`) when the cache is
+/// cold. An already-populated cache is left untouched — the operator's own
+/// verified kernel wins.
+fn seed_workload_kernel_cache(kernel: &str) {
+    let cache = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir());
+    let arch = mvm_core::arch::GuestArch::host().to_string();
+    let dest = mvm_build::kernel_fetch::cached_kernel_path(&cache, &arch, "workload");
+    if dest.is_file() {
+        return;
+    }
+    std::fs::create_dir_all(dest.parent().expect("kernel cache dir has a parent"))
+        .expect("create workload kernel cache dir");
+    std::fs::copy(kernel, &dest).expect("seed MVM_E2E_KERNEL into the workload kernel cache");
+}
+
 #[tokio::test]
 #[ignore = "live KVM E2E: needs /dev/kvm + firecracker + MVM_E2E_KERNEL/MVM_E2E_ROOTFS; run with -- --ignored"]
 async fn transient_and_persistent_lifecycle_over_firecracker() {
-    let Some((_kernel, rootfs)) = live_env() else {
+    let Some((kernel, rootfs)) = live_env() else {
         return;
     };
+    seed_workload_kernel_cache(&kernel);
     let client = LocalBackend::with_hypervisor("firecracker");
 
     // Transient: boots through the signed admission path, then cleans up.

--- a/crates/mvm-client/tests/launch_lifecycle_live.rs
+++ b/crates/mvm-client/tests/launch_lifecycle_live.rs
@@ -1,0 +1,74 @@
+//! Live KVM E2E for the in-process launch lifecycle.
+//!
+//! Proves both lifecycle modes reach the real admitted boot path on a Linux
+//! host with `/dev/kvm` and a `firecracker` binary — no `mvmctl` subprocess.
+//! Ignored by default (same pattern as the jailer-lite property lanes): a CI
+//! lane or an operator drives it with `-- --ignored` after exporting
+//! `MVM_E2E_KERNEL` (an uncompressed workload kernel) and `MVM_E2E_ROOTFS`
+//! (a bootable ext4 workload rootfs). Without those, or without KVM, the
+//! test skips cleanly so the suite stays green everywhere else.
+
+#![cfg(target_os = "linux")]
+
+use mvm_client::{LaunchRequest, LifecycleMode, LocalBackend, MvmClient, RemoveOptions};
+use mvm_core::client::dto::{MachineId, MachineStatus};
+
+/// Resolve the live-lane prerequisites, or explain the clean skip.
+fn live_env() -> Option<(String, String)> {
+    if !std::path::Path::new("/dev/kvm").exists() {
+        eprintln!("skipping: /dev/kvm not present");
+        return None;
+    }
+    let kernel = std::env::var("MVM_E2E_KERNEL").ok()?;
+    let rootfs = std::env::var("MVM_E2E_ROOTFS").ok()?;
+    if !std::path::Path::new(&kernel).exists() || !std::path::Path::new(&rootfs).exists() {
+        eprintln!("skipping: MVM_E2E_KERNEL / MVM_E2E_ROOTFS do not name existing files");
+        return None;
+    }
+    Some((kernel, rootfs))
+}
+
+#[tokio::test]
+#[ignore = "live KVM E2E: needs /dev/kvm + firecracker + MVM_E2E_KERNEL/MVM_E2E_ROOTFS; run with -- --ignored"]
+async fn transient_and_persistent_lifecycle_over_firecracker() {
+    let Some((_kernel, rootfs)) = live_env() else {
+        return;
+    };
+    let client = LocalBackend::with_hypervisor("firecracker");
+
+    // Transient: boots through the signed admission path, then cleans up.
+    let transient = LaunchRequest::builder(LifecycleMode::Transient, rootfs.clone())
+        .name("e2e-transient")
+        .build()
+        .expect("transient request");
+    let outcome = client.launch(transient).await.expect("transient launch");
+    assert_eq!(outcome.machine.status, MachineStatus::Running);
+    assert!(outcome.plan_id.starts_with("sha256:"), "admitted plan id");
+    client
+        .stop_machine(&outcome.machine.id)
+        .await
+        .expect("stop transient");
+    client
+        .cleanup_transient("e2e-transient")
+        .expect("idempotent cleanup");
+
+    // Persistent: create + start + stop keeps the spec; remove deletes it.
+    let persistent = LaunchRequest::builder(LifecycleMode::Persistent, rootfs)
+        .name("e2e-persistent")
+        .build()
+        .expect("persistent request");
+    let outcome = client.launch(persistent).await.expect("persistent launch");
+    assert_eq!(outcome.machine.status, MachineStatus::Running);
+
+    let id = MachineId("e2e-persistent".into());
+    client.stop_machine(&id).await.expect("stop persistent");
+    assert!(
+        mvm_core::config::machine_spec_path("e2e-persistent").exists(),
+        "stop keeps the persisted definition"
+    );
+    client
+        .remove_machine_with(&id, RemoveOptions { force: false })
+        .await
+        .expect("remove stopped persistent");
+    assert!(!mvm_core::config::machine_spec_path("e2e-persistent").exists());
+}

--- a/crates/mvm-client/tests/launch_lifecycle_live_hvf.rs
+++ b/crates/mvm-client/tests/launch_lifecycle_live_hvf.rs
@@ -1,0 +1,85 @@
+//! Live HVF E2E for the in-process launch lifecycle.
+//!
+//! macOS twin of `launch_lifecycle_live`: proves both lifecycle modes reach
+//! the real admitted boot path on an Apple Silicon host through the HVF
+//! backend — no `mvmctl` subprocess. Ignored by default: an operator or CI
+//! lane drives it with `-- --ignored` after exporting `MVM_E2E_KERNEL` (a
+//! verified arm64 workload kernel, present in the kernel cache) and
+//! `MVM_E2E_ROOTFS` (a bootable ext4 workload rootfs), with
+//! `mvm-hvf-supervisor` built in the workspace target dir or named via
+//! `MVM_HVF_SUPERVISOR_PATH`. Without those the test skips cleanly so the
+//! suite stays green everywhere else.
+
+#![cfg(all(target_os = "macos", target_arch = "aarch64"))]
+
+use mvm_client::{LaunchRequest, LifecycleMode, LocalBackend, MvmClient, RemoveOptions};
+use mvm_core::client::dto::{MachineId, MachineStatus};
+
+/// Resolve the live-lane prerequisites, or explain the clean skip.
+fn live_env() -> Option<(String, String)> {
+    let kernel = std::env::var("MVM_E2E_KERNEL").ok()?;
+    let rootfs = std::env::var("MVM_E2E_ROOTFS").ok()?;
+    if !std::path::Path::new(&kernel).exists() || !std::path::Path::new(&rootfs).exists() {
+        eprintln!("skipping: MVM_E2E_KERNEL / MVM_E2E_ROOTFS do not name existing files");
+        return None;
+    }
+    Some((kernel, rootfs))
+}
+
+/// Optional dwell between launch and stop (`MVM_E2E_LINGER_SECS`), so an
+/// operator can let the guest reach userspace and inspect its console log.
+fn linger() {
+    if let Some(secs) = std::env::var("MVM_E2E_LINGER_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+    {
+        std::thread::sleep(std::time::Duration::from_secs(secs));
+    }
+}
+
+#[tokio::test]
+#[ignore = "live HVF E2E: needs Apple Silicon + mvm-hvf-supervisor + MVM_E2E_KERNEL/MVM_E2E_ROOTFS; run with -- --ignored"]
+async fn transient_and_persistent_lifecycle_over_hvf() {
+    let Some((_kernel, rootfs)) = live_env() else {
+        return;
+    };
+    let client = LocalBackend::with_hypervisor("hvf");
+
+    // Transient: boots through the signed admission path, then cleans up.
+    let transient = LaunchRequest::builder(LifecycleMode::Transient, rootfs.clone())
+        .name("e2e-hvf-transient")
+        .build()
+        .expect("transient request");
+    let outcome = client.launch(transient).await.expect("transient launch");
+    assert_eq!(outcome.machine.status, MachineStatus::Running);
+    assert!(outcome.plan_id.starts_with("sha256:"), "admitted plan id");
+    linger();
+    client
+        .stop_machine(&outcome.machine.id)
+        .await
+        .expect("stop transient");
+    client
+        .cleanup_transient("e2e-hvf-transient")
+        .expect("idempotent cleanup");
+
+    // Persistent: create + start + stop keeps the spec; remove deletes it.
+    let persistent = LaunchRequest::builder(LifecycleMode::Persistent, rootfs)
+        .name("e2e-hvf-persistent")
+        .build()
+        .expect("persistent request");
+    let outcome = client.launch(persistent).await.expect("persistent launch");
+    assert_eq!(outcome.machine.status, MachineStatus::Running);
+    linger();
+
+    let id = MachineId("e2e-hvf-persistent".into());
+    client.stop_machine(&id).await.expect("stop persistent");
+    assert!(
+        mvm_core::config::machine_spec_path("e2e-hvf-persistent").exists(),
+        "stop keeps the persisted definition"
+    );
+    client
+        .remove_machine_with(&id, RemoveOptions { force: false })
+        .await
+        .expect("remove stopped persistent");
+    assert!(!mvm_core::config::machine_spec_path("e2e-hvf-persistent").exists());
+}

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -830,6 +830,24 @@ impl AuditEmitter {
     }
 
     fn emit_entry(&self, entry: &AuditEntry) -> Result<()> {
+        // Callers may be synchronous (the CLI) or already inside an async
+        // runtime (an in-process `MvmClient` consumer). Building + blocking
+        // on a runtime from an async worker thread panics, so when a runtime
+        // context is present the emit runs on a short-lived scoped thread —
+        // emission is rare (a handful of entries per boot), so the thread
+        // cost is negligible.
+        if tokio::runtime::Handle::try_current().is_ok() {
+            return std::thread::scope(|scope| {
+                scope
+                    .spawn(|| self.emit_entry_blocking(entry))
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("audit emit thread panicked"))?
+            });
+        }
+        self.emit_entry_blocking(entry)
+    }
+
+    fn emit_entry_blocking(&self, entry: &AuditEntry) -> Result<()> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -732,11 +732,28 @@ impl AuditEmitter {
     /// Emit `plan.exited` — fires after a waited-for workload powers off,
     /// carrying its captured exit code.
     pub fn emit_exited(&self, plan: &ExecutionPlan, exit_code: i32, backend: &str) -> Result<()> {
+        self.emit_exited_with_capture(plan, Some(exit_code), backend)
+    }
+
+    /// Emit `plan.exited` with capture fidelity: a missing exit capture is
+    /// recorded as `exit_code=none` + `captured=false` rather than being
+    /// attested as a successful exit 0 the guest never reported.
+    pub fn emit_exited_with_capture(
+        &self,
+        plan: &ExecutionPlan,
+        exit_code: Option<i32>,
+        backend: &str,
+    ) -> Result<()> {
+        let (code, captured) = match exit_code {
+            Some(code) => (code.to_string(), "true"),
+            None => ("none".to_string(), "false"),
+        };
         self.emit(
             plan,
             "plan.exited",
             [
-                ("exit_code".to_string(), exit_code.to_string()),
+                ("exit_code".to_string(), code),
+                ("captured".to_string(), captured.to_string()),
                 ("backend".to_string(), backend.to_string()),
             ],
         )
@@ -1324,6 +1341,42 @@ mod tests {
         // And the single-entry chain still verifies.
         let count = verify_audit_chain(&dir.path().join("local.jsonl"), &vk).unwrap();
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn emit_exited_records_capture_fidelity() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-CAP");
+
+        // A captured exit records the code and captured=true.
+        emitter
+            .emit_exited_with_capture(&plan, Some(0), "mock")
+            .unwrap();
+        // A missing capture must never be attested as exit 0.
+        emitter
+            .emit_exited_with_capture(&plan, None, "mock")
+            .unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("\"true\""), "got: {}", lines[0]);
+        assert!(lines[0].contains("\"0\""), "got: {}", lines[0]);
+        assert!(lines[1].contains("\"false\""), "got: {}", lines[1]);
+        assert!(lines[1].contains("\"none\""), "got: {}", lines[1]);
+        assert!(
+            !lines[1].contains("\"0\""),
+            "uncaptured must not read as exit 0"
+        );
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 2);
     }
 
     #[test]

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -724,6 +724,30 @@ pub struct StartedMachine {
 /// The caller resolves the image to a `config.rootfs_path` beforehand; this
 /// function is backend-agnostic (it drives whatever `AnyBackend` it is handed,
 /// including the in-memory mock in tests).
+/// The four post-admission gates between `plan.admitted` and the backend
+/// start, run in order. On refusal the failing stage's wire label is
+/// returned alongside the error so the caller can emit a terminal
+/// `plan.failed` entry naming the gate.
+fn run_post_admission_gates(
+    mut config: VmStartConfig,
+    admitted: &AdmittedPlan,
+    policy_bundle: Option<&PolicyBundle>,
+) -> std::result::Result<VmStartConfig, (&'static str, anyhow::Error)> {
+    if let Err(e) = populate_audit_substrate(&mut config, admitted, policy_bundle) {
+        return Err(("audit-substrate", e));
+    }
+    if let Err(e) = enforce_admitted_shares(&config.volumes, admitted.plan()) {
+        return Err(("admitted-shares", e));
+    }
+    if let Err(e) = enforce_admitted_environment(&config, admitted.plan()) {
+        return Err(("admitted-environment", e));
+    }
+    if let Err(e) = enforce_sdk_sidecar_attachment(&config.volumes, admitted.plan()) {
+        return Err(("sdk-sidecar", e));
+    }
+    Ok(config)
+}
+
 pub fn admit_and_start(
     backend: &AnyBackend,
     params: AdmitAndStartParams<'_>,
@@ -736,16 +760,25 @@ pub fn admit_and_start(
         params.bundle_ctx,
     )?;
     if let Some(emitter) = params.emitter
-        && let Err(e) = emitter.emit_admitted(&admitted.plan, &admitted.signer_id)
+        && let Err(e) = emitter.emit_admitted(admitted.plan(), admitted.signer_id())
     {
         tracing::warn!(error = %e, "audit emit_admitted failed (non-fatal)");
     }
 
-    let mut config = params.config;
-    populate_audit_substrate(&mut config, &admitted, params.policy_bundle)?;
-    enforce_admitted_shares(&config.volumes, admitted.plan())?;
-    enforce_admitted_environment(&config, admitted.plan())?;
-    enforce_sdk_sidecar_attachment(&config.volumes, admitted.plan())?;
+    // A refusal in any post-admission gate must still terminate the chain:
+    // `plan.admitted` already fired, so a gate refusal emits `plan.failed`
+    // carrying the refusing stage rather than leaving a dangling admission.
+    let config = match run_post_admission_gates(params.config, &admitted, params.policy_bundle) {
+        Ok(config) => config,
+        Err((stage, err)) => {
+            if let Some(emitter) = params.emitter
+                && let Err(e) = emitter.emit_failed(admitted.plan(), stage, &format!("{err:#}"))
+            {
+                tracing::warn!(error = %e, "audit emit_failed failed (non-fatal)");
+            }
+            return Err(err.context(format!("admission gate refused ({stage})")));
+        }
+    };
 
     let backend_name = backend.name().to_string();
     match backend
@@ -754,7 +787,7 @@ pub fn admit_and_start(
     {
         Ok(vm_id) => {
             if let Some(emitter) = params.emitter
-                && let Err(e) = emitter.emit_launched(&admitted.plan, &backend_name)
+                && let Err(e) = emitter.emit_launched(admitted.plan(), &backend_name)
             {
                 tracing::warn!(error = %e, "audit emit_launched failed (non-fatal)");
             }
@@ -763,7 +796,7 @@ pub fn admit_and_start(
         Err(err) => {
             if let Some(emitter) = params.emitter
                 && let Err(e) =
-                    emitter.emit_failed(&admitted.plan, "backend-start", &format!("{err:#}"))
+                    emitter.emit_failed(admitted.plan(), "backend-start", &format!("{err:#}"))
             {
                 tracing::warn!(error = %e, "audit emit_failed failed (non-fatal)");
             }

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -657,6 +657,12 @@ pub struct AdmitAndStartParams<'a> {
     pub host_signer_keys_dir: Option<&'a std::path::Path>,
     pub bundle_ctx: Option<&'a BundleAdmissionContext<'a>>,
     pub policy_bundle: Option<&'a PolicyBundle>,
+    /// Optional chain-signed emitter: `plan.admitted` fires after admission
+    /// succeeds, then `plan.launched` on a successful backend start or
+    /// `plan.failed` on a start failure — the same event ordering the CLI's
+    /// up path wires by hand. Emission failures warn and never block a boot
+    /// (the chain is tamper-evidence, not part of the admission decision).
+    pub emitter: Option<&'a crate::audit::emitter::AuditEmitter>,
 }
 
 /// Refuse a boot whose kernel is not the one the plan pinned.
@@ -729,6 +735,11 @@ pub fn admit_and_start(
         params.host_signer_keys_dir,
         params.bundle_ctx,
     )?;
+    if let Some(emitter) = params.emitter
+        && let Err(e) = emitter.emit_admitted(&admitted.plan, &admitted.signer_id)
+    {
+        tracing::warn!(error = %e, "audit emit_admitted failed (non-fatal)");
+    }
 
     let mut config = params.config;
     populate_audit_substrate(&mut config, &admitted, params.policy_bundle)?;
@@ -736,10 +747,29 @@ pub fn admit_and_start(
     enforce_admitted_environment(&config, admitted.plan())?;
     enforce_sdk_sidecar_attachment(&config.volumes, admitted.plan())?;
 
-    let vm_id = backend
+    let backend_name = backend.name().to_string();
+    match backend
         .start(&config)
-        .context("backend start after signed-plan admission")?;
-    Ok(StartedMachine { vm_id, admitted })
+        .context("backend start after signed-plan admission")
+    {
+        Ok(vm_id) => {
+            if let Some(emitter) = params.emitter
+                && let Err(e) = emitter.emit_launched(&admitted.plan, &backend_name)
+            {
+                tracing::warn!(error = %e, "audit emit_launched failed (non-fatal)");
+            }
+            Ok(StartedMachine { vm_id, admitted })
+        }
+        Err(err) => {
+            if let Some(emitter) = params.emitter
+                && let Err(e) =
+                    emitter.emit_failed(&admitted.plan, "backend-start", &format!("{err:#}"))
+            {
+                tracing::warn!(error = %e, "audit emit_failed failed (non-fatal)");
+            }
+            Err(err)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1977,6 +2007,7 @@ mod tests {
                 host_signer_keys_dir: Some(dir.path()),
                 bundle_ctx: None,
                 policy_bundle: None,
+                emitter: None,
             },
         )
         .expect("admit + boot");
@@ -2022,6 +2053,7 @@ mod tests {
                 host_signer_keys_dir: Some(dir.path()),
                 bundle_ctx: None,
                 policy_bundle: None,
+                emitter: None,
             },
         )
         .expect_err("unadmitted volume must refuse");

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -102,6 +102,46 @@ pub fn shares_from_vm_volumes(volumes: &[VmVolume]) -> Vec<mvm_core::plan::HostS
         .collect()
 }
 
+/// Attach the verity-sealed runtime overlay (the guest-binary disk carrying
+/// the agent) from the version-keyed cache, through the same resolver the
+/// CLI's boot paths consume (`RuntimeOverlayResolver` +
+/// `resolve_or_seed_from_default_cache` — a pure cache probe: no build, no
+/// download, no nix). Without the overlay a runtime-lean OCI rootfs has no
+/// guest agent to exec and panics init, so this runs on every in-process
+/// boot exactly as it does on the CLI path. Non-fatal on a cold cache under
+/// `PreferOverlay` (the guest falls back to a baked agent when it has one);
+/// fails closed when the policy is `RequiredOverlay`.
+fn attach_runtime_overlay_from_cache(config: &mut VmStartConfig, backend_name: &str) -> Result<()> {
+    use mvm_build::runtime_overlay::{RuntimeOverlayResolver, resolve_or_seed_from_default_cache};
+    if !matches!(backend_name, "firecracker" | "hvf" | "qemu" | "libkrun") {
+        return Ok(());
+    }
+    let cache_root = PathBuf::from(mvm_core::config::mvm_cache_dir());
+    let resolver = RuntimeOverlayResolver::new(cache_root, env!("CARGO_PKG_VERSION").to_string());
+    match resolve_or_seed_from_default_cache(&resolver, mvm_core::arch::GuestArch::host()) {
+        Ok(artifact) => {
+            config.runtime_overlay_path = Some(artifact.overlay_ext4.display().to_string());
+            config.runtime_overlay_verity_path = Some(artifact.sidecar.display().to_string());
+            config.runtime_overlay_roothash = Some(artifact.roothash);
+            config.runtime_overlay_version = Some(artifact.version);
+            Ok(())
+        }
+        Err(e)
+            if config.runtime_source_policy
+                == mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay =>
+        {
+            Err(anyhow::anyhow!(
+                "runtime overlay required for {backend_name} boot but unavailable: {e}"
+            ))
+        }
+        Err(e) => {
+            // Cold cache / dev rootfs / version drift — boot legacy, don't fail.
+            tracing::debug!(backend = backend_name, error = %e, "runtime overlay not attached");
+            Ok(())
+        }
+    }
+}
+
 /// Admit `req` through the signed-plan gate and boot it on `backend`.
 ///
 /// On success the plan was signed under the host key, verified, inside its
@@ -166,7 +206,7 @@ pub fn admit_and_boot_local(
     };
 
     let path_string = |p: &Path| p.to_string_lossy().into_owned();
-    let config = VmStartConfig {
+    let mut config = VmStartConfig {
         name: req.name.clone(),
         rootfs_path: path_string(&req.rootfs_path),
         kernel_path: req.kernel_path.as_deref().map(path_string),
@@ -187,6 +227,7 @@ pub fn admit_and_boot_local(
         // network_policy defaults to deny-all via VmStartConfig's Default.
         ..Default::default()
     };
+    attach_runtime_overlay_from_cache(&mut config, &req.backend_name)?;
 
     admit_and_start(
         backend,
@@ -215,7 +256,7 @@ mod tests {
     fn admit_and_boot_local_over_mock_boots_admitted_plan() {
         let data = tempfile::tempdir().unwrap();
         let mut env = TestEnv::new();
-        env.set("MVM_HOME", data.path());
+        env.isolate_mvm_home(data.path());
         let keys = tempfile::tempdir().unwrap();
 
         let rootfs = data.path().join("rootfs.ext4");
@@ -302,7 +343,7 @@ mod tests {
         use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
         let data = tempfile::tempdir().unwrap();
         let mut env = TestEnv::new();
-        env.set("MVM_HOME", data.path());
+        env.isolate_mvm_home(data.path());
         let keys = tempfile::tempdir().unwrap();
         let audit = tempfile::tempdir().unwrap();
 
@@ -366,7 +407,7 @@ mod tests {
         use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
         let data = tempfile::tempdir().unwrap();
         let mut env = TestEnv::new();
-        env.set("MVM_HOME", data.path());
+        env.isolate_mvm_home(data.path());
         let keys = tempfile::tempdir().unwrap();
         let audit = tempfile::tempdir().unwrap();
 
@@ -424,6 +465,44 @@ mod tests {
         assert!(
             !chain.contains("plan.launched"),
             "a refused launch must not read as launched: {chain}"
+        );
+    }
+
+    /// The overlay attachment mirrors the CLI's matrix: workload VMM
+    /// backends probe the version-keyed cache (cold cache falls back to a
+    /// legacy boot under `PreferOverlay`, fails closed under
+    /// `RequiredOverlay`); non-VMM backends (the mock) skip entirely.
+    #[test]
+    fn runtime_overlay_attachment_matches_the_cli_matrix() {
+        let data = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(data.path());
+
+        // Mock backend: never probed, fields untouched.
+        let mut config = VmStartConfig::default();
+        attach_runtime_overlay_from_cache(&mut config, "mock").expect("mock skips");
+        assert!(config.runtime_overlay_path.is_none());
+
+        // Firecracker + cold cache + PreferOverlay: legacy boot, no fields.
+        let mut config = VmStartConfig {
+            runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy::PreferOverlay,
+            ..Default::default()
+        };
+        attach_runtime_overlay_from_cache(&mut config, "firecracker")
+            .expect("cold cache under PreferOverlay boots legacy");
+        assert!(config.runtime_overlay_path.is_none());
+        assert!(config.runtime_overlay_roothash.is_none());
+
+        // Firecracker + cold cache + RequiredOverlay: fail closed.
+        let mut config = VmStartConfig {
+            runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
+            ..Default::default()
+        };
+        let err = attach_runtime_overlay_from_cache(&mut config, "firecracker")
+            .expect_err("required overlay + cold cache must refuse");
+        assert!(
+            err.to_string().contains("runtime overlay required"),
+            "got: {err:#}"
         );
     }
 

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -19,9 +19,10 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use mvm_core::plan::{PlanSeccompTier, SecretReleasePolicy, SynthesisInput};
-use mvm_core::vm_backend::VmStartConfig;
+use mvm_core::vm_backend::{VmStartConfig, VmVolume};
 use mvm_runtime::AnyBackend;
 
+use crate::audit::emitter::AuditEmitter;
 use crate::plan_admission::{
     AdmitAndStartParams, Clock, InMemoryNonceLedger, StartedMachine, admit_and_start,
 };
@@ -55,6 +56,15 @@ pub struct LocalRunRequest {
     /// Backend name recorded in the signed plan (`firecracker`, `libkrun`,
     /// `mock`, …) — must match the backend the caller starts.
     pub backend_name: String,
+    /// Volumes to attach. Every entry is baked into the signed plan's
+    /// `shares` (same order, `uvol{idx}` tags) and onto the launch config, so
+    /// the claim-1 admitted-shares gate passes exactly when the two agree —
+    /// no host-fs grant reaches the guest outside the signed plan.
+    pub volumes: Vec<VmVolume>,
+    /// Recorded plan intent: `true` for a transient run-to-completion
+    /// workload, `false` for a persistent machine that outlives the
+    /// admitting call.
+    pub destroy_on_exit: bool,
 }
 
 /// Admission substrate for a local run: the clock and replay ledger that drive
@@ -64,6 +74,32 @@ pub struct LocalRunContext<'a> {
     pub clock: &'a dyn Clock,
     pub ledger: &'a InMemoryNonceLedger,
     pub host_signer_keys_dir: Option<&'a Path>,
+    /// Chain-signed audit emitter for `plan.admitted` / `plan.launched` /
+    /// `plan.failed` entries around this admission. `None` skips emission
+    /// (the caller owns its own audit wiring, e.g. the CLI's up path).
+    pub emitter: Option<&'a AuditEmitter>,
+}
+
+/// Build the signed-plan host-fs grant list from the launch volume set. The
+/// `uvol{idx}` tag matches the id the backend assigns when it attaches each
+/// volume (same `VmStartConfig.volumes` order), so the admitted grants line
+/// up 1:1 with what actually gets attached — the claim-1 check compares them.
+pub fn shares_from_vm_volumes(volumes: &[VmVolume]) -> Vec<mvm_core::plan::HostShareGrant> {
+    volumes
+        .iter()
+        .enumerate()
+        .map(|(idx, v)| mvm_core::plan::HostShareGrant {
+            tag: format!("uvol{idx}"),
+            host_path: v.host.clone(),
+            guest_path: v.guest.clone(),
+            kind: match v.kind {
+                mvm_core::vm_backend::VmVolumeKind::Disk => mvm_core::plan::ShareKind::Disk,
+                mvm_core::vm_backend::VmVolumeKind::DirShare => mvm_core::plan::ShareKind::DirShare,
+            },
+            read_only: v.read_only,
+            encrypted: v.encrypted,
+        })
+        .collect()
 }
 
 /// Admit `req` through the signed-plan gate and boot it on `backend`.
@@ -115,12 +151,12 @@ pub fn admit_and_boot_local(
         disk_mib: 0,
         boot_timeout_secs: 60,
         exec_timeout_secs: 0,
-        // A persistent local machine outlives the admitting call, so it must
-        // not be torn down when this function returns.
-        destroy_on_exit: false,
+        // A persistent local machine outlives the admitting call; a transient
+        // run-to-completion workload records the teardown intent.
+        destroy_on_exit: req.destroy_on_exit,
         bundle_pin: None,
         deps_volume: None,
-        shares: Vec::new(),
+        shares: shares_from_vm_volumes(&req.volumes),
         redaction: Default::default(),
         reversible_replacement: Default::default(),
         audit_labels: Default::default(),
@@ -138,6 +174,7 @@ pub fn admit_and_boot_local(
         roothash: req.roothash.clone(),
         cpus: req.cpus,
         memory_mib: req.mem_mib,
+        volumes: req.volumes.clone(),
         tenant_id: Some(LOCAL_TENANT.to_string()),
         runtime_source_policy: mvm_core::vm_backend::select_runtime_source_policy(
             mvm_core::vm_backend::RuntimeSourcePolicySelection {
@@ -161,6 +198,7 @@ pub fn admit_and_boot_local(
             host_signer_keys_dir: ctx.host_signer_keys_dir,
             bundle_ctx: None,
             policy_bundle: None,
+            emitter: ctx.emitter,
         },
     )
 }
@@ -195,6 +233,8 @@ mod tests {
             cpus: 1,
             mem_mib: 128,
             backend_name: "mock".into(),
+            volumes: Vec::new(),
+            destroy_on_exit: false,
         };
 
         let started = admit_and_boot_local(
@@ -204,6 +244,7 @@ mod tests {
                 clock: &clock,
                 ledger: &ledger,
                 host_signer_keys_dir: Some(keys.path()),
+                emitter: None,
             },
         )
         .expect("admit + boot over mock");
@@ -216,6 +257,104 @@ mod tests {
         assert!(!started.admitted.signer_id().is_empty());
         assert_eq!(started.admitted.plan().image.sha256.len(), 64);
         assert_eq!(started.admitted.plan().runtime_profile.0, "mock");
+    }
+
+    /// The launch volume set is baked into the signed plan's shares in the
+    /// same order and with matching tags/kinds, so the claim-1 gate passes
+    /// exactly when the attached volumes are the admitted ones.
+    #[test]
+    fn shares_mirror_the_launch_volume_set() {
+        use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
+        let volumes = vec![
+            VmVolume {
+                host: "/h/work.ext4".into(),
+                guest: "/data/work".into(),
+                size: "16M".into(),
+                read_only: true,
+                kind: VmVolumeKind::Disk,
+                encrypted: false,
+            },
+            VmVolume {
+                host: "/h/src".into(),
+                guest: "/data/src".into(),
+                size: String::new(),
+                read_only: false,
+                kind: VmVolumeKind::DirShare,
+                encrypted: false,
+            },
+        ];
+        let shares = shares_from_vm_volumes(&volumes);
+        assert_eq!(shares.len(), 2);
+        assert_eq!(shares[0].tag, "uvol0");
+        assert_eq!(shares[0].kind, mvm_core::plan::ShareKind::Disk);
+        assert!(shares[0].read_only);
+        assert_eq!(shares[1].tag, "uvol1");
+        assert_eq!(shares[1].kind, mvm_core::plan::ShareKind::DirShare);
+        assert_eq!(shares[1].guest_path, "/data/src");
+        assert!(shares_from_vm_volumes(&[]).is_empty());
+    }
+
+    /// A boot with a volume passes the claim-1 admitted-shares gate (the
+    /// plan's shares and the config's volumes come from one source), and the
+    /// wired emitter records the admitted → launched pair.
+    #[test]
+    fn admit_and_boot_local_admits_volumes_and_emits_chain_entries() {
+        use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
+        let data = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", data.path());
+        let keys = tempfile::tempdir().unwrap();
+        let audit = tempfile::tempdir().unwrap();
+
+        let rootfs = data.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"hashable\n").unwrap();
+        let volume = data.path().join("work.ext4");
+        std::fs::write(&volume, b"volume-bytes\n").unwrap();
+
+        let signer = crate::audit::host_keypair::load_or_init_at(keys.path()).unwrap();
+        let emitter =
+            crate::audit::emitter::AuditEmitter::with_dir(signer.signing, audit.path()).unwrap();
+
+        let backend = AnyBackend::from_hypervisor("mock");
+        let ledger = InMemoryNonceLedger::new();
+        let clock = SystemClock;
+        let req = LocalRunRequest {
+            name: "local-run-volumes".into(),
+            rootfs_path: rootfs,
+            kernel_path: None,
+            verity_path: None,
+            roothash: None,
+            cpus: 1,
+            mem_mib: 128,
+            backend_name: "mock".into(),
+            volumes: vec![VmVolume {
+                host: volume.to_string_lossy().into_owned(),
+                guest: "/data/work".into(),
+                size: String::new(),
+                read_only: true,
+                kind: VmVolumeKind::Disk,
+                encrypted: false,
+            }],
+            destroy_on_exit: true,
+        };
+        let started = admit_and_boot_local(
+            &backend,
+            &req,
+            LocalRunContext {
+                clock: &clock,
+                ledger: &ledger,
+                host_signer_keys_dir: Some(keys.path()),
+                emitter: Some(&emitter),
+            },
+        )
+        .expect("admitted boot with a volume");
+        assert_eq!(started.admitted.plan.shares.len(), 1);
+        assert_eq!(started.admitted.plan.shares[0].guest_path, "/data/work");
+        assert!(started.admitted.plan.post_run.destroy_on_exit);
+
+        let chain = std::fs::read_to_string(audit.path().join("local.jsonl")).unwrap();
+        assert!(chain.contains("plan.admitted"), "got: {chain}");
+        assert!(chain.contains("plan.launched"), "got: {chain}");
     }
 
     /// A missing rootfs fails at the hash step, before any admission or boot.
@@ -234,6 +373,8 @@ mod tests {
             cpus: 1,
             mem_mib: 128,
             backend_name: "mock".into(),
+            volumes: Vec::new(),
+            destroy_on_exit: false,
         };
         let err = admit_and_boot_local(
             &backend,
@@ -242,6 +383,7 @@ mod tests {
                 clock: &clock,
                 ledger: &ledger,
                 host_signer_keys_dir: Some(keys.path()),
+                emitter: None,
             },
         )
         .unwrap_err();

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -389,9 +389,9 @@ mod tests {
             },
         )
         .expect("admitted boot with a volume");
-        assert_eq!(started.admitted.plan.shares.len(), 1);
-        assert_eq!(started.admitted.plan.shares[0].guest_path, "/data/work");
-        assert!(started.admitted.plan.post_run.destroy_on_exit);
+        assert_eq!(started.admitted.plan().shares.len(), 1);
+        assert_eq!(started.admitted.plan().shares[0].guest_path, "/data/work");
+        assert!(started.admitted.plan().post_run.destroy_on_exit);
 
         let chain = std::fs::read_to_string(audit.path().join("local.jsonl")).unwrap();
         assert!(chain.contains("plan.admitted"), "got: {chain}");

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -357,6 +357,76 @@ mod tests {
         assert!(chain.contains("plan.launched"), "got: {chain}");
     }
 
+    /// A refusal in a post-admission gate (here the SDK-sidecar gate: a
+    /// volume at the sidecar mount point with no SDK service binding) still
+    /// terminates the chain — `plan.admitted` is followed by a `plan.failed`
+    /// naming the refusing stage, never left dangling.
+    #[test]
+    fn gate_refusal_after_admission_emits_plan_failed() {
+        use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
+        let data = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", data.path());
+        let keys = tempfile::tempdir().unwrap();
+        let audit = tempfile::tempdir().unwrap();
+
+        let rootfs = data.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"hashable\n").unwrap();
+        let sidecar = data.path().join("sdk.ext4");
+        std::fs::write(&sidecar, b"sidecar-bytes\n").unwrap();
+
+        let signer = crate::audit::host_keypair::load_or_init_at(keys.path()).unwrap();
+        let emitter =
+            crate::audit::emitter::AuditEmitter::with_dir(signer.signing, audit.path()).unwrap();
+
+        let backend = AnyBackend::from_hypervisor("mock");
+        let ledger = InMemoryNonceLedger::new();
+        let clock = SystemClock;
+        let req = LocalRunRequest {
+            name: "local-run-gate-refusal".into(),
+            rootfs_path: rootfs,
+            kernel_path: None,
+            verity_path: None,
+            roothash: None,
+            cpus: 1,
+            mem_mib: 128,
+            backend_name: "mock".into(),
+            volumes: vec![VmVolume {
+                host: sidecar.to_string_lossy().into_owned(),
+                guest: mvm_core::plan::SDK_SIDECAR_GUEST_PATH.into(),
+                size: String::new(),
+                read_only: true,
+                kind: VmVolumeKind::Disk,
+                encrypted: false,
+            }],
+            destroy_on_exit: true,
+        };
+        let err = admit_and_boot_local(
+            &backend,
+            &req,
+            LocalRunContext {
+                clock: &clock,
+                ledger: &ledger,
+                host_signer_keys_dir: Some(keys.path()),
+                emitter: Some(&emitter),
+            },
+        )
+        .expect_err("the SDK-sidecar gate must refuse");
+        assert!(
+            format!("{err:#}").contains("binds no SDK host service"),
+            "got: {err:#}"
+        );
+
+        let chain = std::fs::read_to_string(audit.path().join("local.jsonl")).unwrap();
+        assert!(chain.contains("plan.admitted"), "got: {chain}");
+        assert!(chain.contains("plan.failed"), "got: {chain}");
+        assert!(chain.contains("sdk-sidecar"), "got: {chain}");
+        assert!(
+            !chain.contains("plan.launched"),
+            "a refused launch must not read as launched: {chain}"
+        );
+    }
+
     /// A missing rootfs fails at the hash step, before any admission or boot.
     #[test]
     fn admit_and_boot_local_missing_rootfs_fails_before_boot() {

--- a/crates/mvm-runtime/src/driver/fc.rs
+++ b/crates/mvm-runtime/src/driver/fc.rs
@@ -84,7 +84,12 @@ fn fc_base_bootargs(virtiofs_root: bool, has_disk: bool) -> String {
     if virtiofs_root {
         format!("{console} rootfstype=virtiofs root=mvmroot rw init=/init")
     } else if has_disk {
-        format!("{console} root=/dev/vda rw rootwait init=/init")
+        // No `root=` declaration here: Firecracker itself appends the
+        // authoritative `root=/dev/vda ro|rw` to the boot args from the root
+        // drive's `is_root_device`/`is_read_only` flags, so emitting our own
+        // would put two contradictory root declarations on the cmdline and
+        // leave the winner to kernel parsing order.
+        format!("{console} rootwait init=/init")
     } else {
         // Verity / initramfs boot: the initramfs PID 1 owns root/init selection,
         // so only the serial-console base is emitted here.
@@ -1136,7 +1141,12 @@ mod tests {
         let d = FcDriver::new();
         let disk = d.workload_base_bootargs(false, true);
         assert!(disk.contains("console=ttyS0"), "got: {disk}");
-        assert!(disk.contains("root=/dev/vda"), "got: {disk}");
+        // The disk base carries rootwait+init but NO `root=` declaration:
+        // Firecracker appends the authoritative `root=/dev/vda ro|rw` from the
+        // root drive's flags, and a second declaration here would contradict
+        // it (exactly one root declaration reaches the guest).
+        assert!(disk.contains("rootwait init=/init"), "got: {disk}");
+        assert!(!disk.contains("root="), "got: {disk}");
         // No NIC tokens, and not another VMM's console.
         assert!(!disk.contains("mvm.ip="), "got: {disk}");
         assert!(!disk.contains("mvm.gw="), "got: {disk}");

--- a/crates/mvm-runtime/src/image.rs
+++ b/crates/mvm-runtime/src/image.rs
@@ -162,6 +162,19 @@ impl From<&mvm_core::vm_backend::VmVolume> for RuntimeVolume {
     }
 }
 
+impl From<&RuntimeVolume> for mvm_core::vm_backend::VmVolume {
+    fn from(v: &RuntimeVolume) -> Self {
+        mvm_core::vm_backend::VmVolume {
+            host: v.host.clone(),
+            guest: v.guest.clone(),
+            size: v.size.clone(),
+            read_only: v.read_only,
+            kind: v.kind,
+            encrypted: v.encrypted,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Config discovery and parsing
 // ---------------------------------------------------------------------------

--- a/crates/mvm-runtime/src/workload_runner/standby_boot.rs
+++ b/crates/mvm-runtime/src/workload_runner/standby_boot.rs
@@ -264,11 +264,13 @@ mod tests {
     }
 
     /// The Firecracker base: a verity boot (`has_disk == false`) carries only
-    /// the console, and the disk shape adds root/init.
+    /// the console, and the disk shape adds rootwait/init (never a `root=`
+    /// declaration — Firecracker appends the authoritative one from the root
+    /// drive's flags).
     fn fc_base(_virtiofs_root: bool, has_disk: bool) -> String {
         let console = "console=ttyS0 reboot=k panic=1 net.ifnames=0";
         if has_disk {
-            format!("{console} root=/dev/vda rw rootwait init=/init")
+            format!("{console} rootwait init=/init")
         } else {
             console.to_string()
         }

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -163,9 +163,37 @@ updates only its own entry below.
       pagination walk, serde/unknown-field pins, and seeded property loops
       over untrusted audit input.
 
-- [ ] #2079 — persistent + transient launch lifecycle through
-      `LocalBackend` (starts after #2078/#2080/#2081 land the shared
-      inventory/volume/secret types).
+- [x] #2079 — persistent + transient launch lifecycle through
+      `LocalBackend`. `mvm_client::launch` adds the typed `LaunchRequest`
+      (builder-validated at the client boundary: explicit
+      `Transient`/`Persistent` mode, image source, optional name —
+      required for persistent, generated for transient — cpu/memory,
+      backend override, profile, TTL, deny-all-only network policy,
+      typed volume attachments, typed secret references; command
+      overrides, env vars, and egress allow-lists are refused, never
+      dropped). Both modes route through the one admitted-boot seam:
+      `mvm_hostd::run::admit_and_boot_local` grew launch volumes (baked
+      into the signed plan's `shares`, claim-1 checked), a
+      `destroy_on_exit` intent, and optional chain emission
+      (`plan.admitted`/`launched`/`failed` now fire inside
+      `admit_and_start`). `LocalBackend` implements persistent
+      create/start/stop/restart/inspect/remove over the reused
+      `mvm-runtime::machine::persist` spec store (reconcile + force
+      recreate; stop never deletes the spec; removing a RUNNING
+      persistent machine is refused without the explicit force flow) and
+      transient run-to-completion (`wait_for_exit` + captured exit code +
+      `plan.exited`), TTL reaping, and idempotent cleanup
+      (`release_owner_leases`, `clear_machine_references`, registry
+      entries, state dirs). Closes both deferred hooks:
+      `SecretService::record_machine_references` at create/launch +
+      `validate_for_admission` on every admission with references +
+      `clear_machine_references` at remove, and inventory
+      `secret_ref_count` now reads the real `secret-refs.json` sidecar.
+      36 new tests (23 mock-backed lifecycle + 10 request-validation in
+      mvm-client, 2 seam tests in mvm-hostd, plus inventory count
+      coverage); the Linux/KVM Firecracker E2E for both modes ships
+      `#[ignore]`-gated in `crates/mvm-client/tests/launch_lifecycle_live.rs`
+      (jailer-lite lane pattern; CI wiring deferred).
 
 - [x] #2091 — no workload runs as root. `mvm-oci-init` is pid 1 and spawned
       the agent as a root child, so `is_pid1()` was false, `apply_activation`

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -189,9 +189,11 @@ updates only its own entry below.
       `validate_for_admission` on every admission with references +
       `clear_machine_references` at remove, and inventory
       `secret_ref_count` now reads the real `secret-refs.json` sidecar.
-      36 new tests (23 mock-backed lifecycle + 10 request-validation in
-      mvm-client, 2 seam tests in mvm-hostd, plus inventory count
-      coverage); the Linux/KVM Firecracker E2E for both modes ships
+      43 new tests (26 mock-backed lifecycle + 10 request-validation in
+      mvm-client, 4 seam/emitter tests in mvm-hostd — incl. sidecar-ref
+      re-validation on relaunch, deployment-source refusal, post-admission
+      gate refusals emitting terminal plan.failed, and plan.exited capture
+      fidelity — plus inventory count coverage); the Linux/KVM Firecracker E2E for both modes ships
       `#[ignore]`-gated in `crates/mvm-client/tests/launch_lifecycle_live.rs`
       (jailer-lite lane pattern; CI wiring deferred).
 


### PR DESCRIPTION
## Summary

An in-process consumer (e.g. mvm-studio) can now launch and manage **both transient and persistent** local machines through the canonical signed admission path, with no `mvmctl` subprocess. Final issue of the five-issue local-service wave; builds on the merged `inventory` (#2078), `volume` (#2080), `secret` (#2081), and `audit` (#2082) services and closes the two hooks those issues deferred here.

## Design

**Typed launch request** (`mvm_client::launch::LaunchRequest`, builder-validated at the client boundary): explicit `LifecycleMode::{Transient, Persistent}`, image source, optional name (required for persistent, generated for transient), cpu/memory, backend override, profile, TTL, deny-by-default network policy, typed volume attachments, and typed `MachineSecretRef`s. Fields the in-process backend cannot honor are **refused, never ignored**: command/entrypoint overrides, guest env vars, and any network policy other than deny-all fail the build naming the CLI path that supports them.

**One admission seam for both modes.** `mvm_hostd::run::admit_and_boot_local` (the existing in-process admitted-boot seam) was extended downward rather than copied:
- launch volumes are baked into the signed plan's `shares` (`uvol{idx}` tags) *and* the launch config from one source, so the claim-1 admitted-shares gate compares like with like;
- a `destroy_on_exit` intent distinguishes transient runs in the signed plan;
- `admit_and_start` now takes an optional chain-signed `AuditEmitter` and emits `plan.admitted` / `plan.launched` / `plan.failed` at the same points the CLI's up path does (`AuditEmitter` is now safe to call from inside an async runtime).

**Persistent lifecycle** reuses `mvm-runtime::machine::persist` verbatim (`reconcile_machine_spec`, `save/overwrite/load/list`): create persists the definition (collision → `Conflict`; a different config recreates only via the explicit `force` flow), start boots from the persisted spec with sidecar secret refs re-validated fail-closed and registered attachments re-leased, **stop never deletes the spec**, and remove is the separate confirmed action — refused on a RUNNING machine unless the caller passes `RemoveOptions { force: true }` (`remove_machine_with`). Persisted spec shapes the in-process backend can't honor (manifest/deployment/runtime-pack sources, net/allow-host, CLI-grammar volumes, init commands) are refused, not silently dropped. The `MvmClient` trait impls (`create_machine`/`start_machine`/`remove_machine`) now delegate to these paths instead of failing closed.

**Transient lifecycle**: run-to-completion via `wait_for_exit` (captured workload exit code via `mvm_core::exit_capture`, `plan.exited` chain entry), TTL expiry via `reap_expired_transients` (persistent definitions are never reaped), and `cleanup_transient` — idempotent release of volume leases (`release_owner_leases`), secret refs (`clear_machine_references` seam), name-registry entries, and state dirs. A failed launch rolls all session state back (leases via the RAII `LaunchLease`, refs/attachments explicitly).

**Deferred hooks closed**:
1. `SecretService::record_machine_references` fires at persistent create and transient launch; `validate_for_admission` runs on **every** admission that declares typed secret references (missing secret / missing binding / unauthorized destination / cross-scope all refuse before boot); `clear_machine_references` fires at remove and transient cleanup.
2. `mvm_client::inventory` now back-fills `secret_ref_count` from the real `secret-refs.json` sidecar (`apply_secret_ref_counts` in `list_local_inventory`; count only, never a name or value).

## Test evidence

- 39 new tests: 10 request-validation (invalid resources, unsupported command/env/network, malformed volumes, persistent-needs-name), 24 mock-backed lifecycle in `mvm-client` (transient success + audit chain, failure rollback, exit reporting + idempotent cleanup, TTL reaping, name collisions both directions, persistent create/start/stop/restart/remove roundtrip, force-recreate, running-remove refusal + force flow, unsupported spec shapes, secret-ref admission refusals incl. cross-scope, managed-volume lease take/refuse/release, audit-hygiene walk asserting no secret value or env assignment anywhere under the isolated `MVM_HOME`), 2 seam tests in `mvm-hostd` (shares mirror the volume set; admitted boot with a volume emits the chain pair), 3 inventory count tests.
- Full local gates green: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (9413 passed), `cargo test --workspace --doc`, `check-no-spec-refs-in-comments`, `check-single-home`, `check-claim-catalog`, plus the broader Lint-job sweep (`check-audit-positional`, `check-test-home-isolation`, `check-file-size`, `check-vsock-only-egress`, …).

## Deferred to CI / follow-up

- The **Linux builder-VM/KVM E2E** proving both modes over real Firecracker ships in `crates/mvm-client/tests/launch_lifecycle_live.rs`, `#[cfg(target_os = "linux")]` + `#[ignore]`-gated with clean skips (the jailer-lite property-lane pattern). It cannot run on this macOS host; driving it needs a KVM runner exporting `MVM_E2E_KERNEL`/`MVM_E2E_ROOTFS` and `-- --ignored`. Adding the dedicated CI lane invocation is deferred to a workflow follow-up.
- Guest env delivery and command overrides remain CLI-only until an in-process delivery seam exists; the request represents and refuses them so the contract is explicit.


## Review fixes (d9b40fb01)

Independent review verdict: merge-with-nits. The three consistency gaps + audit-fidelity nit are fixed in the follow-up commit:

1. `launch(Persistent)` now re-validates the **sidecar's** recorded secret references on every relaunch (the `Reuse` arm previously skipped `validate_for_admission` when the request carried no refs) — test: create-with-refs → revoke binding → identical-config relaunch is `Rejected`.
2. The launch path runs `ensure_spec_bootable_in_process` on the reconciled on-disk definition (deployment/manifest/net/etc. sources can never silently boot as a plain image) — test: deployment-backed spec refuses via both the reconcile and the bootability gate.
3. A refusal in any post-admission gate (`audit-substrate`, `admitted-shares`, `admitted-environment`, `sdk-sidecar`) emits a terminal `plan.failed` naming the stage, so `plan.admitted` is never left dangling — test: SDK-sidecar gate refusal asserts the admitted→failed chain pair.
4. `plan.exited` now carries capture fidelity (`captured=true/false`, `exit_code=none` when uncaptured) instead of attesting exit 0 on a missing capture.

**Accepted follow-ups (out of scope for this PR, per review):** dedupe the env-refusal message between `run_machine`/`create_machine` and the request builder; remove the `vm_state_dir` leftover on persistent remove; rename/guard `cleanup_transient` against accidental use on persistent names; a non-blocking `wait_for_exit` variant; the registry-read TOCTOU between collision check and boot; and keeping `LocalBackend` constructor fields non-`pub(crate)`-dependent for out-of-repo constructors.


## Live verification (45a1c2af2 + 198ad7077)

Verified on a real Firecracker/KVM host and on macOS/HVF; two gaps found live are fixed in-branch:

- **FC workload kernel (BLOCKING, fixed):** the in-process seam returned no kernel for non-HVF backends while the FC driver hard-refuses a bundled-kernel spec. `resolve_workload_kernel` now resolves the same cached workload kernel the CLI's machine-run path supplies (`<cache>/builder-vm/<arch>/kernels/workload/vmlinux`; the driver derives its FC-loadable sibling), the Linux live lane seeds that cache from `MVM_E2E_KERNEL`, and a mock-level test pins the per-backend matrix.
- **Runtime overlay (REQUIRED, fixed):** `admit_and_boot_local` never attached the runtime overlay, panicking init on runtime-lean OCI rootfs. The seam now runs the same cache-probe resolver the CLI consumes (`RuntimeOverlayResolver` + `resolve_or_seed_from_default_cache`): legacy fallback under `PreferOverlay`, fail-closed under `RequiredOverlay`, matrix pinned by a test.
- **Root-arg dedupe (SHOULD, fixed):** the FC driver's disk base no longer emits its own `root=/dev/vda rw` next to the authoritative `root=/dev/vda ro|rw` Firecracker appends from the root drive's flags — exactly one consistent root declaration reaches the guest.

**Verification status:** Firecracker live (KVM): PASS with these fixes — kernel boots to userspace, guest agent up on vsock, signed admissions verified in the chain, both lifecycle modes exercised. HVF live (macOS): lifecycle verbs + kernel boot verified; full-userspace boot is blocked on the pre-existing HVF root-declaration gap tracked as #2165 (not addressed here beyond the FC-side dedupe). A stale-socket fix on persistent remove and the macOS/HVF live-lane twin (`launch_lifecycle_live_hvf.rs`) also landed in-branch.

Closes #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)

