### PR TITLE
docs(ci): correct claim witness workflow references

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,12 +2,14 @@ name: Security
 
 # ADR-001 §W6.3 — single workflow that hosts every CI-side security
 # gate. Lanes correspond to the microVM hardening workstreams and the
-# seven claims in CLAUDE.md::Security model. Failure on any lane
-# blocks merge.
+# seven claims in CLAUDE.md::Security model. These lanes provide release,
+# nightly, and manually requested security evidence; they are not PR checks
+# and do not block merge directly.
 #
-# Triggers: PRs against main, release-tag pushes (final pre-publish
-# gate), plus a nightly cron so advisory-DB additions get caught even
-# on quiet branches. `push: branches: [main]` was dropped in the
+# Triggers: release-tag pushes (final pre-publish gate), a nightly cron,
+# and manual dispatch. There is no `pull_request` trigger here; day-to-day
+# PR checks live in ci.yml. The nightly cron catches advisory-DB additions
+# even on quiet branches. `push: branches: [main]` was dropped in the
 # ecosystem-wide CI cost reduction — the nightly cron covers the
 # post-merge "did a new advisory land overnight" case at zero
 # per-merge cost, so the duplicate post-merge run was pure waste.
@@ -857,7 +859,6 @@ jobs:
   # single-build hash on every PR for diff-grade visibility.
   builder-vm-image-reproducibility:
     name: Builder-VM image reproducibility (Plan 107 A2.5)
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -953,7 +954,6 @@ jobs:
   # discovery step, not interpolated from any PR-controlled value.
   pack-reproducibility-builder:
     name: Published builder-pack reproducibility (${{ matrix.arch }})
-    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -1126,7 +1126,6 @@ jobs:
   # step below always uses `--keyless` regardless.
   pack-reproducibility-runtime:
     name: Published runtime-pack reproducibility (${{ matrix.arch }})
-    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,7 @@ the source gap analysis is at
    tamper regression confirms the kernel panics before userspace
    on a flipped data block.
 4. **The guest agent does not contain `do_exec` in production
-   builds.** `prod-agent-no-exec` job in `.github/workflows/ci.yml`
+   builds.** `prod-agent-no-exec` job in `.github/workflows/security.yml`
    builds the agent without `interactive` and asserts the
    `mvm_guest_agent::do_exec` symbol is absent (W4.3).
 5. **Vsock framing + supervisor-config JSON are fuzzed.** `cargo-fuzz`
@@ -303,8 +303,9 @@ the source gap analysis is at
    closed on high/critical CVE findings or stub SBOM/CVE
    (`mvm_build::app_deps_gate::apply_install_gate`); `mvmctl deps
    inspect` / `mvmctl deps audit` surface the sealed sidecars without
-   a VM spawn. The `app-deps-audit` job in `.github/workflows/ci.yml`
-   (Followup D) gates every PR: it exercises `mvmctl build compile` on
+   a VM spawn. The `app-deps-audit` job in `.github/workflows/ci-full.yml`
+   (Followup D) runs in the manually dispatched full-matrix workflow: it
+   exercises `mvmctl build compile` on
    `examples/python/hello-app-with-deps/`, seals a clean + a high-CVE
    fixture via `mvm-build`'s `mvm-app-deps-fixture-tool` example,
    asserts `mvmctl deps inspect --json` reports a well-formed report,

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,11 @@
 
 ## Current issue delivery
 
+- [x] Claim-witness CI documentation — **issue #2104**. Corrected the
+      `security.yml` trigger and merge-blocking claims, removed three
+      unreachable pull-request guards, and aligned the claim descriptions with
+      the workflows that actually run them.
+
 - [x] `mvmctl deps capture` — **plan 291 WS3**. Reseals a sandbox-captured
       dependency tree with fresh audit sidecars, updates the lockfile index,
       refuses tampered or unpinned source volumes, and can emit the canonical


### PR DESCRIPTION
## Summary

- Correct the security workflow documentation to match its actual release, nightly, and manual triggers.
- Remove three unreachable pull-request guards from the security workflow.
- Correct claim documentation to point at `.github/workflows/security.yml` and `.github/workflows/ci-full.yml`.
- Record the completed issue work in `specs/SPRINT.md`.

## Why

The previous wording implied that security lanes ran on every pull request and directly blocked merges, and two claims named workflows that did not contain the referenced jobs. This made the repository's coverage appear stronger than the actual workflow configuration.

## Validation

- `actionlint .github/workflows/security.yml .github/workflows/ci.yml .github/workflows/ci-full.yml`
- Ruby YAML parsing for all three workflows
- Stale-reference checks
- `cargo run -p xtask -- check-claim-catalog`

Closes #2104
