### PR TITLE
docs: describe run-shaped agent authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Linux + /dev/kvm           →  Firecracker
   workloads and a *runtime* SDK for driving them, both thin wrappers over one
   conformance-pinned surface
 - **Security claims, CI-enforced** — 15+ numbered claims (signed execution
-  plans, chain-signed audit log, dm-verity boot, default-deny egress, sealed
-  prod images that refuse interactive access, secret substitution over vsock)
+  plans, chain-signed audit log, dm-verity boot, default-deny egress, run-shaped
+  agent-verb grants, sealed prod images that refuse interactive access, secret
+  substitution over vsock)
 
 ## Install
 
@@ -160,8 +161,9 @@ first `machine run --image ...`.
 ### 2. From a Nix flake (`mkGuest`)
 
 Reproducible, minimal guests built from a flake — the guest carries only what
-you declare. `mkGuest` has three entrypoint forms; the form decides the security
-posture:
+you declare. `mkGuest` has three entrypoint forms; the form sets the image's
+default accessibility and profile metadata, while the launch profile and run
+shape decide the agent-verb grant:
 
 ```nix
 {
@@ -200,7 +202,11 @@ mvmctl machine run   --flake . -- ./app # build + boot + run
 Builds run `nix build` inside a builder VM — **host Nix is never used or
 required**, so the same `mvmctl` produces byte-identical artifacts on every host.
 Sealed images are dm-verity verified and refuse interactive access — no shell,
-no `do_exec`, no PTY; the dev form keeps a console. See the
+no `do_exec`, no PTY; the dev form keeps a console. At launch, a
+baked-entrypoint run on a non-dev profile gets the restricted ProdSafe
+agent-verb grant, while a PTY or ad-hoc argv run requires DevOnly verbs. This
+grant is chosen from the run shape and profile, not from whether an OCI rootfs
+carries a sealed sidecar bit. See the
 [mkGuest guide](public/src/content/docs/guides/nix-flakes.md) and
 `nix/lib/default.nix` for the full API.
 
@@ -370,9 +376,10 @@ mvmctl run --mode live ./script.py     # boot a real microVM and execute
 ```
 
 Interactive surfaces (`exec`, `commands.start`, `console`) are **dev-tier only**;
-against a sealed prod image they refuse with `SandboxDevOnly` — no silent
-fallback (claim 4). `Machine` is the persistent-handle variant; `Session` drives
-function-entrypoint `invoke`.
+they refuse with `SandboxDevOnly` when the run needs DevOnly verbs but admission
+offers only the restricted ProdSafe grant — no silent fallback (claim 4).
+`Machine` is the persistent-handle variant; `Session` drives function-entrypoint
+`invoke`.
 
 **Rust** — the runtime SDK is the `MvmClient` facade (`crates/mvm-client`), an
 `async` trait with a `LocalBackend` (in-process, drives the host directly) and a
@@ -549,6 +556,9 @@ carries that rewording, plus a `Preview` claim 17 for the input channel with
 the four limits that keep it a preview — including that it has no operator
 surface yet. See
 [Workload input](public/src/content/docs/guides/workload-input.md).
+
+    Separately, the restricted ProdSafe grant is issued only to a baked-entrypoint
+    run on a non-dev profile; PTY and ad-hoc argv paths require DevOnly verbs.
 
 The guest agent runs as an unprivileged uid under `setpriv`; `~/.mvm` and
 `~/.mvm/cache` are mode 0700. **Out of scope** (named in ADR-001): a malicious

--- a/public/src/content/docs/console/attach.md
+++ b/public/src/content/docs/console/attach.md
@@ -29,10 +29,12 @@ mvmctl proc start devbox -- python /work/task.py
 
 ## Attach behavior
 
-Console behavior depends on the active backend and image mode:
+Console behavior depends on the active backend, image mode, and launch policy:
 
-- Development images may expose PTY-backed shell access.
+- Development images and development-profile runs may expose PTY-backed shell access.
 - Sealed images should refuse interactive console access.
+- A baked-entrypoint run on a non-dev profile can receive restricted ProdSafe
+  agent verbs, but requesting a PTY still requires DevOnly verbs.
 - Terminal resize, signal forwarding, and scrollback are backend-specific.
 - Console sessions end when the VM stops.
 

--- a/public/src/content/docs/console/index.md
+++ b/public/src/content/docs/console/index.md
@@ -13,9 +13,12 @@ audit.
 
 ## Security model
 
-Console access is intentionally gated by the image mode. Development images can
-expose a console; sealed production images should refuse interactive shell
-access and rely on declared entrypoints, logs, guest RPC, and audit records.
+Console access is intentionally gated by the image mode and launch policy.
+Development images may expose a console; sealed production images should refuse
+interactive shell access and rely on declared entrypoints, logs, guest RPC, and
+audit records. This console gate is separate from the agent-verb grant: a
+baked-entrypoint run on a non-dev profile can receive restricted ProdSafe verbs,
+while a PTY always requires DevOnly verbs.
 
 That distinction matters because an interactive shell is broad authority inside
 the guest. It is useful for debugging, but it is not the default control plane

--- a/public/src/content/docs/guides/building-microvm-images.md
+++ b/public/src/content/docs/guides/building-microvm-images.md
@@ -80,7 +80,7 @@ That direct Nix command is only for users who intentionally manage their own Nix
 | `packages` | `[pkg]` (optional) | Extra Nix packages added to the rootfs closure. |
 | `hypervisor` | `string` (optional) | Override the default (`firecracker`). |
 | `vcpus`, `memory_mib` | `int` (optional) | Resource defaults; `mvm.toml` overrides at run time. |
-| `dev` | `bool` (optional) | Explicit accessible-vs-sealed override. Inferred from entrypoint by default. |
+| `dev` | `bool` (optional) | Explicit accessible-vs-sealed image default. Inferred from entrypoint by default; the launch profile and run shape still decide agent-verb grants. |
 | `uids` | `attrs` (optional) | `{ agent = 990; entrypoint = 0|1000; }` — privilege model override. See [Rootless workloads](#rootless-workloads) below. |
 | `extraFiles` | `attrs` (optional) | `{ "/abs/path" = { content; mode?; }; }` baked into the rootfs at build time. |
 
@@ -159,7 +159,13 @@ mkGuest { entrypoint.shell = "/bin/bash"; dev = false; ... }
 mkGuest { entrypoint.command = [ "..." ]; dev = true; ... }
 ```
 
-The same flake source is consumed in **both** dev and production builds — there's no separate "dev flake" the user has to maintain. The difference is purely in the resulting image's metadata + the host-side `console` gate.
+The same flake source is consumed in **both** dev and production builds —
+there's no separate "dev flake" the user has to maintain. The image metadata
+continues to describe the guest profile and the host-side console gate, but it
+is not the sole input to agent-verb authority. At launch, a baked-entrypoint
+run on a non-dev profile receives the restricted ProdSafe grant; PTY and
+ad-hoc argv runs require DevOnly verbs. This keeps an OCI image's artifact
+metadata separate from the shape of the run that consumes it.
 
 The `mkGuest` library produces a **busybox-as-PID-1** rootfs (no NixOS, no systemd) and emits an ext4 image directly. The boot path is: kernel → `/init` script → mounts `/proc` `/sys` `/dev` → execs your entrypoint. No service manager between the kernel and your code. mvm's security overlay (per-service uids, seccomp tier, dm-verity, read-only `/etc`) layers on top in Phase 6 without changing this base.
 

--- a/public/src/content/docs/guides/exec.md
+++ b/public/src/content/docs/guides/exec.md
@@ -18,10 +18,11 @@ mvmctl machine run --manifest my-tpl -- /bin/true
 ```
 
 > Overriding the guest's argv (a trailing `-- <cmd>`) is a **dev-tier**
-> capability. A sealed production image refuses it (claim 15) — its entrypoint
-> is fixed and there is no interactive command surface. Use `--image`/`--flake`
-> dev builds for ad-hoc commands; production workloads run their baked
-> entrypoint (`machine run --entrypoint`) or go through `mvmd`.
+> capability. It requires DevOnly verbs regardless of the image's sealed bit;
+> sealed production images also refuse it because their entrypoint is fixed.
+> Use `--image`/`--flake` dev builds and a dev profile for ad-hoc commands;
+> production workloads run their baked entrypoint (`machine run --entrypoint`)
+> or go through `mvmd`.
 
 ## When to use it
 
@@ -204,10 +205,11 @@ highest):
 
 ## Limits
 
-- **Dev-mode only.** `mvmctl machine run` requires a guest agent built with the
-  `interactive` Cargo feature, which is the default for the dev images
-  `mvmctl` ships with. Production guest images omit the feature and the
-  Exec handler is physically absent from the binary.
+- **Ad-hoc execution is dev-mode only.** A baked-entrypoint
+  `mvmctl machine run` may use the restricted ProdSafe grant on a non-dev
+  profile. A trailing argv requires the guest agent's `interactive` Cargo
+  feature and DevOnly verbs; production guest images may omit that feature, in
+  which case the Exec handler is physically absent from the binary.
 - **Network access.** The guest gets the same network configuration
   any other transient VM gets -- if your `--manifest` exposes outbound
   internet, so does `mvmctl machine run` from that template.

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -239,10 +239,13 @@ mvmctl machine run -it --image <dev-image> -- /bin/sh   # drops into a shell
 
 The command after `--` is the same command argv as a non-interactive run; `-it`
 only adds a PTY and forwards stdin. Omit the command to use the guest default
-shell. `-it` is refused for a sealed/production image (claim 15: no interactive
-access to a sealed microVM), with no `--force` override. It is also refused when
-stdin is not a terminal — both fail fast with a clear message rather than
-hanging. To keep the machine after the shell exits, add `--name <N>` or `-d`.
+shell. `-it` requires DevOnly agent verbs and is refused for a sealed/production
+image (claim 15: no interactive access to a sealed microVM), with no `--force`
+override. A non-dev baked-entrypoint run may receive the restricted ProdSafe
+grant, but it cannot be upgraded to a PTY by adding `-it`. The command is also
+refused when stdin is not a terminal — both fail fast with a clear message
+rather than hanging. To keep the machine after the shell exits, add `--name <N>`
+or `-d`.
 
 ### `machine run --name X` recreated my machine
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -63,7 +63,7 @@ guest-RPC surface, fleet-shaped workflows).
 | `mvmctl machine run --hypervisor <backend>` | Backend: `firecracker` (Linux/KVM), `hvf` (macOS 26+ default, vsock-only), `libkrun` (macOS 13–25 & Linux), `qemu` (dev/test) |
 | `mvmctl machine run --flake <ref> --flake-profile <variant>` | Flake package variant (e.g. worker, gateway) |
 | `mvmctl machine run --host-service <service>` | Bind a host service the workload may call over the broker channel (repeatable, e.g. `host.audit.v1`). Baked into the signed execution plan: the broker refuses any service absent from the set. Binding an SDK-served service (`host.audit.v1`, `host.cost.v1`, `host.secrets.v1`, `host.time.v1`) also attaches the optional SDK sidecar read-only at `/mvm/sdk`. On an installed `mvmctl` a cold cache downloads the published sidecar for the running version and arch, hash-verifies it, and boots; the launch is refused if the download fails or the artifact is version-mismatched, tampered, or incomplete. From a source checkout the refusal names `nix build ./nix/images/runtime-overlay#sdk-sidecar-image` instead of downloading, because building it needs the builder VM |
-| `mvmctl machine session start <template> --agent-verb <verb>` | Boot a prod session with an explicit ProdSafe agent-verb allow-list instead of the computed sealed-image default. Repeatable; refused with `--dev` |
+| `mvmctl machine session start <template> --agent-verb <verb>` | Boot a prod session with an explicit ProdSafe agent-verb allow-list instead of the computed baked-entrypoint/non-dev default. Repeatable; refused with `--dev` |
 | `mvmctl machine build --flake <ref> --watch` | Watch the flake and rebuild on change |
 | `mvmctl machine stop [name...]` | Stop one or more VMs by name, or `--all` |
 | `mvmctl machine ls` | List every microVM: persistent machines and running transients (alias: `ps`) |
@@ -298,7 +298,10 @@ with a Firecracker microVM as the sandbox. Plan 178 merged the former bare
 security `--profile`, OCI `--image`, signed `--receipt`, `--json`/`--dry-run`,
 and the SDK `--mode`/`--dev`/`--prod` transport. Arbitrary command dispatch
 requires a dev-feature guest agent (the `do_exec` handler is `interactive`-gated,
-claim 4); production guests run their baked entrypoint via `mvmctl machine run --entrypoint` (no shell).
+claim 4). A baked-entrypoint run on a non-dev profile receives the restricted
+ProdSafe grant; PTY and ad-hoc argv runs require DevOnly verbs. Production
+guests run their baked entrypoint via `mvmctl machine run --entrypoint` (no
+shell).
 
 | Command | Description |
 |---------|-------------|
@@ -351,7 +354,8 @@ flag:
 - **Foreground interactive** (`-t`/`--tty`, with `-i` accepted so `-it`
   parses): boot a fresh transient VM, run the requested argv attached to a PTY,
   return that command's exit code, then tear the VM down. **Dev-only** —
-  refused for a sealed image (claim 15) and when stdin is not a terminal.
+  requires DevOnly verbs, is refused for a sealed image (claim 15), and is
+  refused when stdin is not a terminal.
 - **Persistent** (`machine create` + `machine start`, or `machine run -d`):
   boot a machine that survives after the command returns and is reconnectable by
   name through `machine shell`/`exec`/`stop`. Bare `-d` auto-generates a name and
@@ -562,8 +566,9 @@ mvmctl machine stop  blue-fox-3f2a --yes      # tear it down when done
 `-d --name <N>` does the same with a name you choose.
 
 **Interactive is dev-only.** `-t`/`--tty` attaches the foreground command to a
-PTY and is refused for a sealed/production image (claim 15 — no interactive
-access to a sealed microVM) and when stdin is not a terminal. `machine run -it`
+PTY and requires DevOnly verbs; it is refused for a sealed/production image
+(claim 15 — no interactive access to a sealed microVM) and when stdin is not a
+terminal. `machine run -it`
 requires an argv after `--`; use `machine shell <name>` (or `machine exec
 <name>` with no argv) for the default shell on an already-running machine.
 

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -173,6 +173,17 @@ gate keeps the handler symbols *absent* from production binaries; the
 profile gate keeps the dispatcher *reachable but refusing* for dev
 verbs in sealed-prod. Both checks run on every request.
 
+### Run-shaped agent grants
+
+The image profile remains an artifact property, but the host's attenuated
+ProdSafe grant is a property of the launch. A baked-entrypoint run on a
+non-dev profile is eligible for that restricted grant; a PTY (`ConsoleOpen`) or
+an ad-hoc argv (`Exec`) run is not, because those paths require DevOnly verbs.
+The decision does not depend on an OCI rootfs being marked sealed. Console
+attachment is a separate host-side gate and remains unavailable for sealed
+production images; a restricted grant never widens the guest profile or adds
+interactive handlers.
+
 ## Readiness model
 
 Plan 76 Phase 2 binds the vsock control port **before** entrypoint


### PR DESCRIPTION
## Summary

- update the README to describe run-shaped ProdSafe grants and DevOnly PTY/argv paths
- align website guidance for guest-agent profiles, console access, image builds, exec, troubleshooting, and CLI reference
- preserve the separate sealed-image console gate and compile-time interactive-agent boundary

## Validation

- `git diff --check`
- Astro build not run locally because `public/node_modules` is not installed; website CI should provide the build gate

Related: #2127
