### PR TITLE
Stream plane follow-ups: bind fingerprints, release the carry on silence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,21 +433,26 @@ ADR-001 §"Appendix: Cardoso minimum-viable-policy checklist".
     still holds by absence, which is what its three witnesses check. The
     input plane's own properties (stdin only, no program selection, no
     argv or env change, refused without a plan grant) are policy enforced
-    by host code with no production caller, and are claimed separately as
-    `Preview` claim 17 with their limits.
+    by host code, and are claimed separately as `Preview` claim 17 with
+    their limits.
 
 `Preview` claim 17 — **workload stdin is grant-gated, single-writer,
 secret-scanned across frames, and every refusal audited**
-(`crates/mvm-hostd/src/stream/input_gate.rs`). The channel is reachable:
-`mvmctl machine run --entrypoint --stdin -` opens the route under the plan
-that boot was admitted under, and the sealed-tier shell-entrypoint refusal
-now classifies an entrypoint resolved from the image's own `mvm-meta.json`
-sidecar, failing closed when it cannot resolve one. It stays a preview and
-not a numbered claim because one leg still has no production caller: the
-known-secret set is empty on every real VM (`InputGate::bind` is never
-called outside tests), so the secret scan's refusal has never fired in
-production. ADR-001's ledger carries the full limits note, marked closed or
-open individually; do not paraphrase this row as enforced without it.
+(`crates/mvm-hostd/src/stream/input_gate.rs`). Every leg has a production
+caller: `mvmctl machine run --entrypoint --stdin -` opens the route under the
+plan that boot was admitted under, the sealed-tier shell-entrypoint refusal
+classifies an entrypoint resolved from the image's own `mvm-meta.json`
+sidecar and fails closed when it cannot resolve one, and the secret scan is
+populated — the per-VM substitution endpoint (the one process holding a
+workload's credentials in the clear) fingerprints each secret it resolves
+and `StreamPlane::open_input` installs that set. Only the fingerprint — a
+length, a rolling hash and a category — crosses into the scanning process;
+never a value. It stays a preview and not a numbered claim because of what
+the enforcement is rather than whether it runs: a fingerprint match is a
+length-and-hash match, not an identity, and encoding, derivation and a
+window-straddling split defeat the scan permanently. ADR-001's ledger
+carries the full limits note, marked closed or open individually; do not
+paraphrase this row as enforced without it.
 
 The guest agent itself runs as uid 901 under setpriv (W4.5); the
 host-side vsock proxy socket is mode 0700 (W1.2), the proxy port

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -113,7 +113,7 @@ The three honesty levels (R2):
 
 | ID | Level | Statement | Witnesses |
 | --- | --- | --- | --- |
-| `MVM-SEC-17` | `build` | Workload stdin is grant-gated, single-writer, secret-scanned across frames, and every refusal is audited | `fn:input_is_refused_without_a_plan_grant`, `fn:a_second_writer_is_refused_while_the_lease_is_held`, `fn:secret_material_split_across_frames_is_still_refused`, `fn:every_refusal_is_audited`, `fn:a_shell_entrypoint_with_the_grant_is_refused_and_names_the_reason`, `fn:the_endpoint_fingerprints_what_it_resolved_and_reports_no_value`, `fn:the_handshakes_two_halves_go_to_two_different_places`, `fn:a_secret_split_across_two_frames_does_not_reassemble_in_the_workload`, `fn:a_fingerprint_refusal_does_not_claim_the_bytes_are_the_secret` |
+| `MVM-SEC-17` | `build` | Workload stdin is grant-gated, single-writer, secret-scanned across frames, and every refusal is audited | `fn:input_is_refused_without_a_plan_grant`, `fn:a_second_writer_is_refused_while_the_lease_is_held`, `fn:secret_material_split_across_frames_is_still_refused`, `fn:every_refusal_is_audited`, `fn:a_shell_entrypoint_with_the_grant_is_refused_and_names_the_reason`, `fn:the_endpoint_fingerprints_what_it_resolved_and_reports_no_value`, `fn:the_handshakes_two_halves_go_to_two_different_places`, `fn:a_secret_split_across_two_frames_does_not_reassemble_in_the_workload`, `fn:a_fingerprint_refusal_does_not_claim_the_bytes_are_the_secret`, `fn:a_secret_split_across_two_writes_inside_the_threshold_is_still_refused`, `fn:the_idle_release_does_not_depend_on_what_the_withheld_bytes_are`, `fn:what_is_withheld_is_a_length_and_never_a_verdict_about_the_bytes` |
 
 ## Cited authorities
 

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -113,7 +113,7 @@ The three honesty levels (R2):
 
 | ID | Level | Statement | Witnesses |
 | --- | --- | --- | --- |
-| `MVM-SEC-17` | `build` | Workload stdin is grant-gated, single-writer, secret-scanned across frames, and every refusal is audited | `fn:input_is_refused_without_a_plan_grant`, `fn:a_second_writer_is_refused_while_the_lease_is_held`, `fn:secret_material_split_across_frames_is_still_refused`, `fn:every_refusal_is_audited`, `fn:a_shell_entrypoint_with_the_grant_is_refused_and_names_the_reason` |
+| `MVM-SEC-17` | `build` | Workload stdin is grant-gated, single-writer, secret-scanned across frames, and every refusal is audited | `fn:input_is_refused_without_a_plan_grant`, `fn:a_second_writer_is_refused_while_the_lease_is_held`, `fn:secret_material_split_across_frames_is_still_refused`, `fn:every_refusal_is_audited`, `fn:a_shell_entrypoint_with_the_grant_is_refused_and_names_the_reason`, `fn:the_endpoint_fingerprints_what_it_resolved_and_reports_no_value`, `fn:the_handshakes_two_halves_go_to_two_different_places`, `fn:a_secret_split_across_two_frames_does_not_reassemble_in_the_workload`, `fn:a_fingerprint_refusal_does_not_claim_the_bytes_are_the_secret` |
 
 ## Cited authorities
 

--- a/crates/mvm-cli/src/commands/vm/stdin_stream.rs
+++ b/crates/mvm-cli/src/commands/vm/stdin_stream.rs
@@ -29,11 +29,17 @@
 //!   re-offers only the first, and drains the second by asking the route to
 //!   flush what it is already holding.
 //!
-//! - **The lease outlives a pause.** A writer thinking for longer than the
-//!   lease TTL would come back to find its next write refused *and* its close
-//!   refused, which drops the tail the gate withheld. A blocking read on a
-//!   quiet stdin is exactly that pause, so refreshing cannot be something the
-//!   read loop does between reads: it gets its own ticker.
+//! - **Somebody has to attend a writer that has stopped typing.** Two things
+//!   go wrong while a reader is parked in `read` and neither is visible from
+//!   there. A writer thinking for longer than the lease TTL comes back to find
+//!   its next write refused *and* its close refused, which drops the tail the
+//!   gate withheld. And on a secret-bearing VM the gate is withholding a
+//!   blanket tail of everything typed so far, which it releases only once the
+//!   writer has been quiet for long enough — so a pause is exactly when the
+//!   typed line becomes deliverable. Both are answered by
+//!   [`WorkloadInput::refresh`], and neither can be something the read loop
+//!   does between reads, because the read is where it is stuck. They get their
+//!   own attendant thread.
 
 use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -41,7 +47,7 @@ use std::sync::{Arc, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
 use mvm_contract::stream::input::InputFrame;
-use mvm_hostd::stream::{DEFAULT_LEASE_TTL, InputRouteError, StreamPlane};
+use mvm_hostd::stream::{DEFAULT_IDLE_FLUSH_AFTER, InputRouteError, StreamPlane};
 
 /// How much of the caller's stdin travels in one frame.
 ///
@@ -62,16 +68,20 @@ const RETRY_PAUSE: Duration = Duration::from_millis(25);
 /// forever would leave a thread spinning against a dead VM.
 const DELIVERY_PATIENCE: Duration = Duration::from_secs(60);
 
-/// How often the ticker touches the lease. A third of the TTL, so one missed
-/// tick is not a lapsed lease.
-fn keepalive_period() -> Duration {
-    DEFAULT_LEASE_TTL / 3
+/// How often the attendant tells the gate its writer is idle but alive.
+///
+/// Set by the tighter of the two deadlines it serves, which is the gate's idle
+/// release rather than the lease. The gate hands over the tail its secret scan
+/// withheld once the writer has been silent for [`DEFAULT_IDLE_FLUSH_AFTER`],
+/// and nothing happens until somebody asks — so the operator's wait for a
+/// typed line is the threshold plus however long the attendant takes to come
+/// round.
+/// Half the threshold keeps that under one and a half thresholds, well inside
+/// what a person reads as instant, and it refreshes the lease two orders of
+/// magnitude more often than the TTL needs.
+fn attend_period() -> Duration {
+    DEFAULT_IDLE_FLUSH_AFTER / 2
 }
-
-/// How long the ticker sleeps between checks of the stop flag. Shorter than
-/// [`keepalive_period`] so shutting the stream down is prompt rather than
-/// waiting out a full refresh interval.
-const TICK: Duration = Duration::from_millis(250);
 
 /// One workload's stdin, as the pump reaches it.
 ///
@@ -84,7 +94,8 @@ pub(in crate::commands::vm) trait WorkloadInput: Send + Sync {
     /// the two outcomes are different [`InputRouteError`] variants and the
     /// pump treats them differently.
     fn write(&self, frame: InputFrame) -> Result<(), InputRouteError>;
-    /// Extend the lease without sending anything.
+    /// Say the writer is idle but alive: hold the lease, and let the gate
+    /// release the tail its secret scan withheld.
     fn refresh(&self) -> Result<(), InputRouteError>;
     /// Deliver the withheld tail and close the workload's stdin.
     fn close(&self) -> Result<(), InputRouteError>;
@@ -133,13 +144,13 @@ pub(in crate::commands::vm) struct StreamedInputReport {
     pub stopped_because: Option<String>,
 }
 
-/// A live host→guest stdin stream: the reader thread, the lease ticker, and
-/// the flag that ends both.
+/// A live host→guest stdin stream: the reader thread, the idle attendant,
+/// and the flag that ends both.
 pub(in crate::commands::vm) struct StdinStream {
     stop: Arc<AtomicBool>,
     input: Arc<dyn WorkloadInput>,
     report: Arc<Mutex<StreamedInputReport>>,
-    ticker: Option<std::thread::JoinHandle<()>>,
+    attendant: Option<std::thread::JoinHandle<()>>,
 }
 
 impl StdinStream {
@@ -167,15 +178,16 @@ impl StdinStream {
 
         let tick_stop = Arc::clone(&stop);
         let tick_input = Arc::clone(&input);
-        let period = keepalive_period();
-        let ticker =
-            std::thread::spawn(move || keep_lease_alive(tick_input.as_ref(), &tick_stop, period));
+        let period = attend_period();
+        let attendant = std::thread::spawn(move || {
+            attend_idle_writer(tick_input.as_ref(), &tick_stop, period);
+        });
 
         Self {
             stop,
             input,
             report,
-            ticker: Some(ticker),
+            attendant: Some(attendant),
         }
     }
 
@@ -186,8 +198,8 @@ impl StdinStream {
     /// both ends may call it.
     pub(in crate::commands::vm) fn finish(mut self) -> StreamedInputReport {
         self.stop.store(true, Ordering::SeqCst);
-        if let Some(ticker) = self.ticker.take() {
-            let _ = ticker.join();
+        if let Some(attendant) = self.attendant.take() {
+            let _ = attendant.join();
         }
         match self.input.close() {
             Ok(()) | Err(InputRouteError::NoSession) => {}
@@ -206,8 +218,8 @@ impl Drop for StdinStream {
         // still stop the threads; the close it skips is the plane's to do at
         // release.
         self.stop.store(true, Ordering::SeqCst);
-        if let Some(ticker) = self.ticker.take() {
-            let _ = ticker.join();
+        if let Some(attendant) = self.attendant.take() {
+            let _ = attendant.join();
         }
     }
 }
@@ -354,30 +366,28 @@ fn count(report: &Mutex<StreamedInputReport>, bytes: u64) {
     report.bytes = report.bytes.saturating_add(bytes);
 }
 
-/// Touch the lease every `period` while the writer is idle, until the stream
-/// ends.
+/// Tell the gate every `period` that this writer is idle but alive, until the
+/// stream ends.
+///
+/// One call does both jobs: it holds the lease a parked reader would otherwise
+/// let lapse, and it is what makes the gate release the tail its secret scan
+/// withheld — so a workload waiting on a request line gets one. A loop that
+/// only refreshed on the lease's own schedule would leave the second job
+/// running two orders of magnitude too slowly.
 ///
 /// `period` is a parameter rather than a constant read inside so a test can
-/// watch the lease actually being touched without waiting out a share of the
-/// real TTL — the thing this function exists to do is the thing that had no
-/// witness.
-fn keep_lease_alive(input: &dyn WorkloadInput, stop: &AtomicBool, period: Duration) {
-    // Never poll the stop flag less often than the lease is refreshed:
-    // shutdown stays prompt, and a period shorter than the default poll is
-    // still honoured rather than rounded up to it.
-    let tick = TICK.min(period);
-    let mut next = Instant::now() + period;
+/// watch it working without waiting out the real interval.
+fn attend_idle_writer(input: &dyn WorkloadInput, stop: &AtomicBool, period: Duration) {
     while !stop.load(Ordering::SeqCst) {
-        std::thread::sleep(tick);
-        if Instant::now() < next {
-            continue;
+        std::thread::sleep(period);
+        if stop.load(Ordering::SeqCst) {
+            return;
         }
-        next = Instant::now() + period;
         match input.refresh() {
             // The stream ended under us; there is no lease left to hold.
             Err(InputRouteError::NoSession) => return,
             Err(error) => {
-                tracing::debug!(error = %error, "could not refresh the workload input lease");
+                tracing::debug!(error = %error, "could not attend the idle workload input writer");
             }
             Ok(()) => {}
         }
@@ -388,6 +398,7 @@ fn keep_lease_alive(input: &dyn WorkloadInput, stop: &AtomicBool, period: Durati
 mod tests {
     use super::*;
     use anyhow::anyhow;
+    use mvm_hostd::stream::DEFAULT_LEASE_TTL;
 
     /// A destination that records what it was offered, in the order it was
     /// offered, and can be told to fail a given number of times first.
@@ -584,15 +595,18 @@ mod tests {
     }
 
     #[test]
-    fn the_ticker_stops_when_the_stream_does() {
+    fn the_attendant_stops_when_the_stream_does() {
         let recorder = Arc::new(Recorder::default());
         let stop = Arc::new(AtomicBool::new(false));
         let held = Arc::clone(&recorder);
         let flag = Arc::clone(&stop);
-        let ticker =
-            std::thread::spawn(move || keep_lease_alive(held.as_ref(), &flag, keepalive_period()));
+        let attendant = std::thread::spawn(move || {
+            attend_idle_writer(held.as_ref(), &flag, attend_period());
+        });
         stop.store(true, Ordering::SeqCst);
-        ticker.join().expect("the ticker must not outlive the stop");
+        attendant
+            .join()
+            .expect("the attendant must not outlive the stop");
     }
 
     /// Spin until `ready` or the deadline. Returns whether it happened, so the
@@ -609,39 +623,52 @@ mod tests {
     }
 
     #[test]
-    fn the_ticker_touches_the_lease_while_the_writer_is_idle() {
-        // The failure this pins is silent: an operator who stops typing for
-        // longer than the TTL comes back to a lease that lapsed, so the next
-        // write *and* the close are refused and the tail the gate withheld is
-        // dropped with nothing on screen to say so. A ticker that runs without
-        // refreshing looks identical to one that works.
+    fn the_attendant_keeps_visiting_an_idle_writer() {
+        // Two silent failures ride on this one call, and an attendant that
+        // loops without calling `refresh` looks identical to one that works.
+        // An operator who stops typing for longer than the TTL comes back to a
+        // lapsed lease, so the next write *and* the close are refused and the
+        // withheld tail is dropped with nothing on screen to say so. And on a
+        // secret-bearing VM the line they already typed is sitting in the
+        // gate's carry, released only when somebody says the writer went quiet.
         let recorder = Arc::new(Recorder::default());
         let stop = Arc::new(AtomicBool::new(false));
         let held = Arc::clone(&recorder);
         let flag = Arc::clone(&stop);
-        let ticker = std::thread::spawn(move || {
-            keep_lease_alive(held.as_ref(), &flag, Duration::from_millis(10))
+        let attendant = std::thread::spawn(move || {
+            attend_idle_writer(held.as_ref(), &flag, Duration::from_millis(10));
         });
 
         let refreshed = within(Duration::from_secs(5), || recorder.refreshes() >= 3);
         stop.store(true, Ordering::SeqCst);
-        ticker.join().expect("the ticker must not outlive the stop");
+        attendant
+            .join()
+            .expect("the attendant must not outlive the stop");
         assert!(
             refreshed,
-            "an idle writer's lease must keep being refreshed; saw {} refresh(es)",
+            "an idle writer must keep being attended; saw {} visit(s)",
             recorder.refreshes()
         );
     }
 
     #[test]
-    fn the_refresh_interval_leaves_room_for_a_missed_tick() {
-        // The other half: refreshing on a period the lease outlives is the
-        // same lapse. Two periods must still fit inside the TTL, so one
-        // missed tick costs nothing.
+    fn the_attend_period_serves_both_deadlines_it_is_responsible_for() {
+        // The period is one number answering to two clocks, and drifting past
+        // either is silent. Too slow against the gate's idle release and a
+        // typed line waits whole tick-times for a delivery the gate is already
+        // willing to make; too slow against the lease and the writer loses its
+        // place while it was still there.
         assert!(
-            keepalive_period() * 2 < DEFAULT_LEASE_TTL,
-            "refresh period {:?} leaves no room inside the {:?} lease",
-            keepalive_period(),
+            attend_period() <= DEFAULT_IDLE_FLUSH_AFTER,
+            "attend period {:?} is longer than the {:?} idle release it exists to \
+             collect, so a released line waits on the tick rather than the threshold",
+            attend_period(),
+            DEFAULT_IDLE_FLUSH_AFTER
+        );
+        assert!(
+            attend_period() * 2 < DEFAULT_LEASE_TTL,
+            "attend period {:?} leaves no room for a missed visit inside the {:?} lease",
+            attend_period(),
             DEFAULT_LEASE_TTL
         );
     }
@@ -723,13 +750,12 @@ mod tests {
     }
 
     #[test]
-    fn dropping_a_stream_ends_its_ticker() {
+    fn dropping_a_stream_ends_its_attendant() {
         // An early `?` on the dispatch path drops the stream without ever
-        // calling `finish`, and the ticker holds a lease for a writer that no
-        // longer exists. `Drop` joins the ticker, so a stop it failed to set
-        // parks the dropping thread on a loop whose next move is ten seconds
-        // out — run it somewhere this test can outlive rather than hanging in
-        // it.
+        // calling `finish`, and the attendant holds a lease for a writer that
+        // no longer exists. `Drop` joins it, so a stop it failed to set parks
+        // the dropping thread on a loop that never ends — run it somewhere
+        // this test can outlive rather than hanging in it.
         let (keys, reader, _entered) = typed();
         let held: Arc<dyn WorkloadInput> = Arc::new(Recorder::default());
         let dropped = Arc::new(AtomicBool::new(false));

--- a/crates/mvm-cli/src/commands/vm/stdin_stream.rs
+++ b/crates/mvm-cli/src/commands/vm/stdin_stream.rs
@@ -745,4 +745,69 @@ mod tests {
         );
         drop(keys);
     }
+
+    #[test]
+    fn the_cli_holds_no_workload_secret_for_the_input_gate_to_scan_for() {
+        // The gate refuses stdin that looks like one of the host's own
+        // secrets. Recognising a byte sequence normally means having it, and
+        // this process must not: the substitution endpoint that resolves raw
+        // credentials is a separate process, and that separation is load
+        // bearing. So what the gate matches is a fingerprint — a length, a
+        // hash and a category — and the CLI's part is to hold none of the
+        // machinery that could carry a value.
+        //
+        // Asserted on the surface, not on a comment: the fingerprint type has
+        // no accessor that returns bytes, and this crate names neither it nor
+        // the gate binding that takes it.
+        let fingerprint = mvm_protocol::stream::secret_fingerprint::SecretFingerprint::of(
+            b"AKIAIOSFODNN7EXAMPLE",
+            mvm_protocol::stream::secret_fingerprint::SecretCategory::HostSecret,
+        )
+        .expect("a non-empty secret fingerprints");
+        assert!(!format!("{fingerprint:?}").contains("AKIA"));
+        assert_eq!(
+            std::mem::size_of_val(&fingerprint),
+            std::mem::size_of::<u64>() * 2,
+            "fixed-width and inline: no room for a pointer to a value"
+        );
+
+        let named = cli_sources_naming(&["InputBinding", "with_fingerprint", "SecretFingerprint"]);
+        assert!(
+            named.is_empty(),
+            "the CLI must reach the gate only through `StreamPlane::open_input`, which \
+             installs the fingerprint set the substitution endpoint reported; naming the \
+             binding here would be this crate acquiring a reason to hold secret shapes \
+             of its own: {named:?}"
+        );
+    }
+
+    /// Files under this crate's `src/` mentioning any of `needles`, excluding
+    /// this test's own source (which names them to assert their absence).
+    fn cli_sources_naming(needles: &[&str]) -> Vec<String> {
+        fn walk(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, out);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    out.push(path);
+                }
+            }
+        }
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut files = Vec::new();
+        walk(&root, &mut files);
+        files
+            .into_iter()
+            .filter(|path| path.file_name().is_some_and(|n| n != "stdin_stream.rs"))
+            .filter(|path| {
+                std::fs::read_to_string(path)
+                    .is_ok_and(|src| needles.iter().any(|needle| src.contains(needle)))
+            })
+            .map(|path| path.display().to_string())
+            .collect()
+    }
 }

--- a/crates/mvm-cli/src/commands/vm/stdin_stream.rs
+++ b/crates/mvm-cli/src/commands/vm/stdin_stream.rs
@@ -785,9 +785,9 @@ mod tests {
         // Asserted on the surface, not on a comment: the fingerprint type has
         // no accessor that returns bytes, and this crate names neither it nor
         // the gate binding that takes it.
-        let fingerprint = mvm_protocol::stream::secret_fingerprint::SecretFingerprint::of(
+        let fingerprint = mvm_contract::stream::secret_fingerprint::SecretFingerprint::of(
             b"AKIAIOSFODNN7EXAMPLE",
-            mvm_protocol::stream::secret_fingerprint::SecretCategory::HostSecret,
+            mvm_contract::stream::secret_fingerprint::SecretCategory::HostSecret,
         )
         .expect("a non-empty secret fingerprints");
         assert!(!format!("{fingerprint:?}").contains("AKIA"));

--- a/crates/mvm-contract/src/stream/mod.rs
+++ b/crates/mvm-contract/src/stream/mod.rs
@@ -11,12 +11,15 @@
 //!
 //! [`input`] carries the mirror-image direction: host→guest bytes on the
 //! input plane, default-deny behind a signed plan grant instead of
-//! always-on.
+//! always-on. [`secret_fingerprint`] is what lets the gate on that direction
+//! recognise the host's own secrets without holding any of them.
 
 pub mod chain;
 pub mod input;
 pub mod record;
+pub mod secret_fingerprint;
 
 pub use chain::{ChainError, verify_chain, verify_chain_from};
 pub use input::{CloseInput, INPUT_GRANT_SERVICE, InputFrame, grants_input, grants_input_for};
 pub use record::{StreamKind, StreamRecord, StreamSource};
+pub use secret_fingerprint::{CATEGORY_HOST_SECRET, SecretCategory, SecretFingerprint};

--- a/crates/mvm-contract/src/stream/secret_fingerprint.rs
+++ b/crates/mvm-contract/src/stream/secret_fingerprint.rs
@@ -1,0 +1,312 @@
+//! A recognisable *shape* of a secret, computed where its plaintext already
+//! lives — so the process that scans for it never has to hold it.
+//!
+//! The input gate refuses host→guest bytes that carry one of the host's own
+//! secrets. Recognising a byte sequence normally means having it, and that is
+//! the problem: the gate runs in the CLI process, while the substitution
+//! endpoint that resolves raw credentials runs as a separate process on
+//! purpose. Copying plaintext into the CLI to populate a scan would create a
+//! new plaintext location in a process that has none, in order to close a gap
+//! on a different property. It is the wrong trade.
+//!
+//! So the endpoint — which already holds the value — computes a
+//! [`SecretFingerprint`] and only the fingerprint travels. A fingerprint is a
+//! length plus a 64-bit polynomial hash, chosen because that hash *rolls*: a
+//! scanner can slide a window over a stream and test every offset at one
+//! multiply-add per byte, which is what makes finding a secret split across
+//! two writes affordable without the bytes.
+//!
+//! ## What a fingerprint is not
+//!
+//! It is not proof. Two different byte sequences of the same length can hash
+//! alike, so a match means "these bytes hash like a known secret", not "these
+//! bytes are that secret". The gate refuses on a match anyway, because failing
+//! closed on a collision is the right direction — but nothing downstream, the
+//! refusal message least of all, may state the stronger fact.
+//!
+//! ## What it discloses
+//!
+//! Whoever holds a fingerprint learns the secret's **length**, and holds a
+//! 64-bit hash of it. For a high-entropy credential that is not a recovery
+//! path; for a short low-entropy one, a hash and a length are guessable
+//! offline. That is a real if narrow disclosure and it is recorded in
+//! `specs/adrs/035-workload-stream-plane.md` rather than only here, because a
+//! reader deciding whether to bind a secret looks there.
+//!
+//! Deliberately absent: any fingerprint of a *prefix* of a secret. Prefix
+//! hashes would let a scanner withhold only the tails that could still become
+//! a secret — the behaviour that plaintext gives — but they also turn the
+//! fingerprint set into a byte-at-a-time recovery oracle: guess byte 0 against
+//! the length-1 prefix hash, then byte 1, and so on. The latency the scanner
+//! pays for withholding a fixed-size tail is the price of not shipping that
+//! oracle.
+
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+/// Category recorded for a secret value the host itself holds for a workload.
+pub const CATEGORY_HOST_SECRET: &str = "host-secret";
+
+/// Which kind of secret a fingerprint stands for.
+///
+/// An enum rather than a string because the category is the *only* thing a
+/// match may put in the audit chain, and a closed vocabulary is what keeps a
+/// runtime-derived label — anything shaped like the matched value — from
+/// becoming representable there at all.
+// allow(secret-debug): a category is a fixed vocabulary word, never a value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SecretCategory {
+    /// A credential the host holds on the workload's behalf.
+    HostSecret,
+}
+
+impl SecretCategory {
+    /// The wire-stable word this category is recorded under.
+    ///
+    /// `&'static str` so a matched value cannot be smuggled through the same
+    /// channel: there is no way to produce one of these at runtime from bytes.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::HostSecret => CATEGORY_HOST_SECRET,
+        }
+    }
+}
+
+/// Multiplier for the polynomial hash. The FNV-1a 64-bit prime: odd, so
+/// multiplication stays invertible mod 2^64 and a low byte can never be
+/// annihilated.
+const BASE: u64 = 0x0000_0100_0000_01b3;
+
+/// The hash of one whole window, computed directly.
+///
+/// The definition [`roll`] must agree with. Both exist because the scanner
+/// uses the cheap incremental form on the hot path and this one to re-derive
+/// a candidate before refusing, so an arithmetic slip in the incremental step
+/// cannot on its own refuse a caller's frame.
+#[must_use]
+pub fn window_hash(window: &[u8]) -> u64 {
+    window.iter().fold(0u64, |h, &b| {
+        h.wrapping_mul(BASE).wrapping_add(u64::from(b))
+    })
+}
+
+/// `BASE^(len - 1)`, the weight the oldest byte of a `len`-sized window
+/// carries. Precomputed once per window size by a rolling scanner.
+///
+/// Zero-length windows have no oldest byte; the value is unused there and 0
+/// is returned rather than wrapping the exponent around.
+#[must_use]
+pub fn leading_weight(len: usize) -> u64 {
+    if len == 0 {
+        return 0;
+    }
+    let mut weight = 1u64;
+    for _ in 1..len {
+        weight = weight.wrapping_mul(BASE);
+    }
+    weight
+}
+
+/// Advance a window hash by one byte: drop `leaving`, append `entering`.
+///
+/// `weight` is [`leading_weight`] for the window's size. Equivalent to
+/// [`window_hash`] over the shifted window, which
+/// [`SecretFingerprint::matches_window`] relies on.
+#[must_use]
+pub fn roll(hash: u64, leaving: u8, entering: u8, weight: u64) -> u64 {
+    hash.wrapping_sub(u64::from(leaving).wrapping_mul(weight))
+        .wrapping_mul(BASE)
+        .wrapping_add(u64::from(entering))
+}
+
+/// One secret's recognisable shape: how long it is and how it hashes.
+///
+/// Carries no part of the value and has no accessor that could return one —
+/// the fields are a length, a hash, and a vocabulary word. That is the whole
+/// point of the type: it is what may cross into a process that must not hold
+/// the secret.
+// allow(secret-debug): holds a length and a hash, never a value; a redacted
+// Debug would hide the only fields worth logging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretFingerprint {
+    /// Length of the secret in bytes.
+    len: u32,
+    /// [`window_hash`] over the whole secret.
+    hash: u64,
+    /// What kind of secret this is.
+    category: SecretCategory,
+}
+
+impl SecretFingerprint {
+    /// Fingerprint `value`, which the caller must legitimately hold.
+    ///
+    /// `None` for an empty value — a zero-length window matches at every
+    /// offset, so it would refuse every frame while standing for nothing — and
+    /// for one longer than `u32::MAX`, which no credential is and which the
+    /// wire form cannot carry.
+    #[must_use]
+    pub fn of(value: &[u8], category: SecretCategory) -> Option<Self> {
+        if value.is_empty() {
+            return None;
+        }
+        Some(Self {
+            len: u32::try_from(value.len()).ok()?,
+            hash: window_hash(value),
+            category,
+        })
+    }
+
+    /// How long the fingerprinted secret is. The scanner needs it to size its
+    /// window; it is also the disclosure this type makes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    /// Never true: [`of`](Self::of) refuses an empty value. Present because
+    /// clippy pairs it with [`len`](Self::len), and honest because the
+    /// constructor is the reason rather than a check here.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// What a match is recorded as.
+    #[must_use]
+    pub fn category(&self) -> SecretCategory {
+        self.category
+    }
+
+    /// The hash a rolling scanner compares against.
+    #[must_use]
+    pub fn hash(&self) -> u64 {
+        self.hash
+    }
+
+    /// Whether `window` hashes like this secret.
+    ///
+    /// **A hash match, not an identity.** Same length and same hash is the
+    /// most this can ever say; a collision looks exactly like the real thing
+    /// from here, and the caller must phrase its refusal accordingly.
+    #[must_use]
+    pub fn matches_window(&self, window: &[u8]) -> bool {
+        window.len() == self.len() && window_hash(window) == self.hash
+    }
+}
+
+/// The distinct window sizes a fingerprint set requires, longest first.
+///
+/// Longest first so a scanner that reports the first match reports the most
+/// specific one; deduplicated so two secrets of equal length cost one pass.
+#[must_use]
+pub fn window_sizes(fingerprints: &[SecretFingerprint]) -> Vec<usize> {
+    let mut sizes: Vec<usize> = fingerprints.iter().map(SecretFingerprint::len).collect();
+    sizes.sort_unstable_by(|a, b| b.cmp(a));
+    sizes.dedup();
+    sizes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn an_empty_value_has_no_fingerprint() {
+        // A zero-length window matches at every offset, so admitting one
+        // would refuse every frame on behalf of nothing.
+        assert!(SecretFingerprint::of(b"", SecretCategory::HostSecret).is_none());
+    }
+
+    #[test]
+    fn a_fingerprint_matches_only_its_own_length_and_hash() {
+        let fp = SecretFingerprint::of(b"AKIAIOSFODNN7EXAMPLE", SecretCategory::HostSecret)
+            .expect("a non-empty value fingerprints");
+        assert!(fp.matches_window(b"AKIAIOSFODNN7EXAMPLE"));
+        assert!(!fp.matches_window(b"AKIAIOSFODNN7EXAMPLF"));
+        // The length is not decoration. A polynomial hash weights each byte by
+        // its distance from the end, so a leading zero byte contributes
+        // nothing: this longer window hashes *identically* and is caught only
+        // because the lengths differ.
+        let padded = [b"\0".as_slice(), b"AKIAIOSFODNN7EXAMPLE"].concat();
+        assert_eq!(window_hash(&padded), fp.hash(), "the collision is real");
+        assert!(
+            !fp.matches_window(&padded),
+            "a longer window is a different window, whatever it hashes to"
+        );
+        assert_eq!(fp.len(), 20);
+        assert!(!fp.is_empty());
+        assert_eq!(fp.category().as_str(), CATEGORY_HOST_SECRET);
+    }
+
+    #[test]
+    fn rolling_agrees_with_hashing_the_window_directly() {
+        // The scanner trusts these two to be the same function. If they drift,
+        // it either misses secrets or refuses innocent frames, and neither
+        // failure announces itself.
+        let data = b"the quick brown fox jumps over the lazy dog";
+        for len in 1..=8usize {
+            let weight = leading_weight(len);
+            let mut rolled = window_hash(&data[..len]);
+            for start in 1..=data.len() - len {
+                rolled = roll(rolled, data[start - 1], data[start + len - 1], weight);
+                assert_eq!(
+                    rolled,
+                    window_hash(&data[start..start + len]),
+                    "len {len} at offset {start}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn window_sizes_are_deduplicated_longest_first() {
+        let fps = vec![
+            SecretFingerprint::of(b"abcd", SecretCategory::HostSecret).expect("fingerprints"),
+            SecretFingerprint::of(b"wxyz", SecretCategory::HostSecret).expect("fingerprints"),
+            SecretFingerprint::of(b"abcdefgh", SecretCategory::HostSecret).expect("fingerprints"),
+        ];
+        assert_eq!(window_sizes(&fps), vec![8, 4]);
+    }
+
+    #[test]
+    fn the_wire_form_carries_no_value() {
+        // The whole reason this type exists: what crosses a process boundary
+        // is a length, a hash and a vocabulary word.
+        let secret = "AKIAIOSFODNN7EXAMPLE";
+        let fp = SecretFingerprint::of(secret.as_bytes(), SecretCategory::HostSecret)
+            .expect("fingerprints");
+        let json = serde_json::to_string(&fp).expect("serializes");
+        assert!(!json.contains(secret), "got {json}");
+        assert!(!json.contains("AKIA"), "nor any part of it: {json}");
+        assert_eq!(
+            serde_json::from_str::<SecretFingerprint>(&json).expect("round-trips"),
+            fp
+        );
+        assert!(json.contains("host-secret"));
+    }
+
+    #[test]
+    fn the_wire_form_rejects_unknown_fields() {
+        let err = serde_json::from_str::<SecretFingerprint>(
+            r#"{"len":4,"hash":1,"category":"host-secret","value":"oops"}"#,
+        )
+        .expect_err("an unexpected field fails closed");
+        assert!(err.to_string().contains("unknown field"), "got {err}");
+    }
+
+    #[test]
+    fn debug_renders_shape_only() {
+        let rendered = alloc::format!(
+            "{:?}",
+            SecretFingerprint::of(b"AKIAIOSFODNN7EXAMPLE", SecretCategory::HostSecret)
+                .expect("fingerprints")
+        );
+        assert!(!rendered.contains("AKIA"), "got {rendered}");
+        assert!(rendered.contains("len: 20"), "got {rendered}");
+    }
+}

--- a/crates/mvm-contract/src/stream/secret_fingerprint.rs
+++ b/crates/mvm-contract/src/stream/secret_fingerprint.rs
@@ -35,11 +35,16 @@
 //!
 //! Deliberately absent: any fingerprint of a *prefix* of a secret. Prefix
 //! hashes would let a scanner withhold only the tails that could still become
-//! a secret — the behaviour that plaintext gives — but they also turn the
-//! fingerprint set into a byte-at-a-time recovery oracle: guess byte 0 against
-//! the length-1 prefix hash, then byte 1, and so on. The latency the scanner
-//! pays for withholding a fixed-size tail is the price of not shipping that
-//! oracle.
+//! a secret — the behaviour plaintext gives — and without them a scanner must
+//! withhold a fixed-size tail of every write, which stalls a workload that
+//! answers per line. That is a real defect, and prefix hashes are still not
+//! the answer, because under this hash they *are* the value: `h(k) =
+//! h(k-1)·BASE + s[k-1]`, so every byte falls out by one subtraction and
+//! `h(1)` is the first byte outright. A different hash would only turn that
+//! subtraction into a 256-guess-per-byte search, since anything the scanner
+//! can evaluate, code sharing its address space can evaluate too. Exact
+//! precision about a one-byte tail and secrecy of a one-byte prefix are the
+//! same quantity; no hash buys both.
 
 use alloc::vec::Vec;
 
@@ -248,8 +253,16 @@ mod tests {
         // The scanner trusts these two to be the same function. If they drift,
         // it either misses secrets or refuses innocent frames, and neither
         // failure announces itself.
-        let data = b"the quick brown fox jumps over the lazy dog";
-        for len in 1..=8usize {
+        //
+        // The window sizes swept are the ones real credentials have — an API
+        // key is 20 to 60 bytes, not 8. `leading_weight` accumulates `BASE`
+        // once per byte of the window, so a defect in that loop only shows up
+        // past the length where the loop does real work; a sweep that stopped
+        // in single digits would agree with a weight that was wrong for every
+        // secret anyone binds.
+        let data = b"the quick brown fox jumps over the lazy dog, \
+                     then AKIAIOSFODNN7EXAMPLE/wJalrXUtnFEMI0K7MDENG+bPxRfiCY";
+        for len in 1..=64usize {
             let weight = leading_weight(len);
             let mut rolled = window_hash(&data[..len]);
             for start in 1..=data.len() - len {

--- a/crates/mvm-hostd/src/bin/mvm-substitution-endpoint.rs
+++ b/crates/mvm-hostd/src/bin/mvm-substitution-endpoint.rs
@@ -31,8 +31,8 @@ use tracing::info;
 
 use mvm_hostd::keyholder::secret_placeholder_env;
 use mvm_hostd::supervisor::substitution_endpoint::{
-    EgressMode, EndpointConfig, EndpointTransport, assemble, build_audit_recorder,
-    build_egress_gate, parse,
+    EgressMode, EndpointConfig, EndpointHandshake, EndpointTransport, assemble,
+    build_audit_recorder, build_egress_gate, fingerprint_bound_secrets, parse,
 };
 
 fn read_stdin_blocking() -> Result<Vec<u8>> {
@@ -91,21 +91,39 @@ fn main() -> Result<()> {
     // Ready handshake: report the minted (guest var → placeholder) pairs on
     // stdout so the backend can set them in the guest launch env, then boot.
     // Values are never reported — only opaque placeholders.
+    //
+    // The same line carries the input-gate fingerprints. This is the one
+    // process that holds these secrets in the clear, so it is the only place
+    // their recognisable shape can be computed without moving plaintext
+    // anywhere; what crosses is a length, a rolling hash and a category each.
+    // A VM serving raw egress assembled nothing and has no secrets to
+    // fingerprint.
     let handed_len = assembled
         .as_ref()
         .map(|(_, handed)| handed.len())
         .unwrap_or_default();
-    let env = assembled
-        .as_ref()
-        .map(|(_, handed)| secret_placeholder_env(handed))
-        .unwrap_or_default();
-    let line = serde_json::to_string(&env).context("serializing handed placeholders")?;
+    let handshake = EndpointHandshake {
+        env: assembled
+            .as_ref()
+            .map(|(_, handed)| secret_placeholder_env(handed))
+            .unwrap_or_default(),
+        input_fingerprints: if raw_only {
+            Vec::new()
+        } else {
+            fingerprint_bound_secrets(&cfg).context("fingerprinting the endpoint\'s secrets")?
+        },
+    };
+    let fingerprinted = handshake.input_fingerprints.len();
+    let line = serde_json::to_string(&handshake).context("serializing the ready handshake")?;
     {
         let mut stdout = std::io::stdout().lock();
         writeln!(stdout, "{line}").context("writing handshake line")?;
         stdout.flush().context("flushing handshake line")?;
     }
-    info!(handed = handed_len, "placeholders handed; serving");
+    info!(
+        handed = handed_len,
+        fingerprinted, "placeholders handed; serving"
+    );
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/crates/mvm-hostd/src/stream/input_gate.rs
+++ b/crates/mvm-hostd/src/stream/input_gate.rs
@@ -27,15 +27,22 @@
 //!   path that moves bytes out of a session is gated on it, extraction
 //!   included: a writer that stalled past its TTL must not deliver into a
 //!   stdin its successor now owns.
-//! - **The secret scan spans frame boundaries.** A scanner that inspects one
-//!   frame at a time is defeated by splitting a secret across two writes, so
-//!   [`SecretScanner`] carries a sliding window and, more than that, *withholds*
-//!   the tail of the stream that is still a live prefix of a known secret. A
-//!   refusal that arrives after the first half already reached the guest would
-//!   be theatre. See [`SecretScanner`] for what this cannot catch; it is a
-//!   backstop against a confused caller, not a defence against a determined
-//!   one. The real guarantee is upstream: the host has no reason to send a
-//!   secret into a guest, because secrets are substituted on egress instead.
+//! - **The secret scan spans frame boundaries, and holds no secret.** A
+//!   scanner that inspects one frame at a time is defeated by splitting a
+//!   secret across two writes, so `stream::secret_scan`
+//!   carries a sliding window and, more than that, *withholds* the tail of the
+//!   stream it must still be able to see. A refusal that arrives after the
+//!   first half already reached the guest would be theatre. What it slides
+//!   that window against is a set of [`SecretFingerprint`]s — a length and a
+//!   rolling hash each, computed by the process that legitimately holds the
+//!   plaintext — because this gate runs in a process that must not hold one.
+//!   A fingerprint match is a hash match and nothing stronger, which is why
+//!   [`InputRefusal::SecretMaterial`] says so. See
+//!   `stream::secret_scan` for what this cannot catch;
+//!   it is a backstop against a confused caller, not a defence against a
+//!   determined one. The real guarantee is upstream: the host has no reason to
+//!   send a secret into a guest, because secrets are substituted on egress
+//!   instead.
 //! - **Every refusal is audited, payload-free.** Each refusal, and each grant,
 //!   emits a chain-signed entry naming the binding and the reason. Never the
 //!   frame bytes, and never the matched secret — writing the secret into the
@@ -73,16 +80,21 @@
 //! different opinions about where the stream ended.
 
 use std::collections::HashMap;
-use std::fmt;
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError};
 use std::time::{Duration, Instant};
 
 use mvm_contract::stream::input::{CloseInput, InputFrame, grants_input};
+use mvm_contract::stream::input::{CloseInput, InputFrame, grants_input};
+use mvm_contract::stream::secret_fingerprint::SecretFingerprint;
 use mvm_core::plan::ExecutionPlan;
 use zeroize::Zeroize;
 
 use crate::audit::emitter::AuditEmitter;
 use crate::plan_admission::AdmittedPlan;
+use crate::stream::secret_scan::SecretScanner;
+
+/// Category recorded for a secret value the host itself holds for a workload.
+pub use mvm_protocol::stream::secret_fingerprint::CATEGORY_HOST_SECRET;
 
 /// How long a writer keeps the input lease without touching it.
 ///
@@ -90,9 +102,6 @@ use crate::plan_admission::AdmittedPlan;
 /// place; short enough that a consumer which crashed mid-session frees the
 /// VM's stdin inside a coffee break rather than at VM teardown.
 pub const DEFAULT_LEASE_TTL: Duration = Duration::from_secs(30);
-
-/// Category recorded for a secret value the host itself holds for a workload.
-pub const CATEGORY_HOST_SECRET: &str = "host-secret";
 
 /// Why the gate would not let bytes through.
 ///
@@ -119,8 +128,19 @@ pub enum InputRefusal {
         /// The lease holder that was there first.
         holder: String,
     },
-    /// The bytes carry material the host recognises as one of its own secrets.
-    #[error("input carries recognised secret material ({category})")]
+    /// The bytes match the fingerprint of one of the host's own secrets.
+    ///
+    /// Deliberately *not* "carries a secret". The gate holds fingerprints, not
+    /// values, so a match says the bytes have the same length and the same
+    /// rolling hash as a bound secret — which a collision also does. It
+    /// refuses either way, because failing closed is the right direction; but
+    /// an operator handed "this contained a secret" when it did not would lose
+    /// hours proving the negative, so the sentence has to say what was
+    /// actually checked.
+    #[error(
+        "input matches the fingerprint of known secret material ({category}); \
+         a fingerprint match is a length and hash match, not proof these bytes are that secret"
+    )]
     SecretMaterial {
         /// Which category matched. The category, never the value.
         category: &'static str,
@@ -156,52 +176,6 @@ impl InputRefusal {
             Self::LeaseExpired => "lease-expired",
             Self::OutOfOrder { .. } => "out-of-order",
         }
-    }
-}
-
-/// One secret value the gate should recognise on its way *into* a guest.
-///
-/// Held in the clear because recognising a byte sequence requires having it;
-/// the type earns that by rendering as its category and length only, and by
-/// zeroing itself on drop. There is deliberately no accessor for the bytes.
-pub struct KnownSecret {
-    value: Vec<u8>,
-    category: &'static str,
-}
-
-impl KnownSecret {
-    /// A secret the host holds on the workload's behalf.
-    #[must_use]
-    pub fn host_material(value: impl Into<Vec<u8>>) -> Self {
-        Self::categorized(value, CATEGORY_HOST_SECRET)
-    }
-
-    /// The same, under a caller-chosen category name. `&'static str` because a
-    /// category is a fixed vocabulary word that reaches the audit chain, not a
-    /// value derived from the secret.
-    #[must_use]
-    pub fn categorized(value: impl Into<Vec<u8>>, category: &'static str) -> Self {
-        Self {
-            value: value.into(),
-            category,
-        }
-    }
-}
-
-impl fmt::Debug for KnownSecret {
-    /// Shape only. A derived `Debug` would put the secret in every log line
-    /// that ever formats a binding.
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("KnownSecret")
-            .field("category", &self.category)
-            .field("len", &self.value.len())
-            .finish()
-    }
-}
-
-impl Drop for KnownSecret {
-    fn drop(&mut self) {
-        self.value.zeroize();
     }
 }
 
@@ -300,30 +274,46 @@ fn audit_refused(
 /// stdin.
 ///
 /// Optional in the sense that an unbound VM still gets default-deny, a lease,
-/// and the process audit chain — what a binding adds is the secret set to
+/// and the process audit chain — what a binding adds is the fingerprint set to
 /// recognise, a VM-specific chain, and a lease lifetime.
 pub struct InputBinding {
-    secrets: Vec<KnownSecret>,
+    fingerprints: Vec<SecretFingerprint>,
     audit: Option<Arc<dyn InputAuditSink>>,
     lease_ttl: Duration,
 }
 
 impl InputBinding {
-    /// An empty binding: no known secrets, the process audit chain, the
+    /// An empty binding: no fingerprints, the process audit chain, the
     /// default lease lifetime.
     #[must_use]
     pub fn new() -> Self {
         Self {
-            secrets: Vec::new(),
+            fingerprints: Vec::new(),
             audit: None,
             lease_ttl: DEFAULT_LEASE_TTL,
         }
     }
 
-    /// Recognise one more secret value on the way into this VM.
+    /// Recognise one more secret on the way into this VM.
+    ///
+    /// A [`SecretFingerprint`] and not a value: the process that binds this is
+    /// not the process that holds the plaintext, and keeping it that way is
+    /// the reason the parameter has this type. There is no overload taking
+    /// bytes.
     #[must_use]
-    pub fn with_secret(mut self, secret: KnownSecret) -> Self {
-        self.secrets.push(secret);
+    pub fn with_fingerprint(mut self, fingerprint: SecretFingerprint) -> Self {
+        self.fingerprints.push(fingerprint);
+        self
+    }
+
+    /// The same for a whole set, which is how one arrives: the substitution
+    /// endpoint fingerprints every secret it resolved for this VM at once.
+    #[must_use]
+    pub fn with_fingerprints(
+        mut self,
+        fingerprints: impl IntoIterator<Item = SecretFingerprint>,
+    ) -> Self {
+        self.fingerprints.extend(fingerprints);
         self
     }
 
@@ -369,10 +359,10 @@ impl Default for InputBinding {
     }
 }
 
-/// A binding as the gate stores it: the secret set shared rather than copied
-/// into every session that opens.
+/// A binding as the gate stores it: the fingerprint set shared rather than
+/// copied into every session that opens.
 struct Bound {
-    secrets: Arc<Vec<KnownSecret>>,
+    fingerprints: Arc<Vec<SecretFingerprint>>,
     audit: Option<Arc<dyn InputAuditSink>>,
     lease_ttl: Duration,
 }
@@ -412,7 +402,7 @@ fn gate() -> MutexGuard<'static, GateState> {
 /// What one VM's binding supplies, resolved once per open.
 struct Resolved {
     audit: Option<Arc<dyn InputAuditSink>>,
-    secrets: Arc<Vec<KnownSecret>>,
+    fingerprints: Arc<Vec<SecretFingerprint>>,
     lease_ttl: Duration,
 }
 
@@ -424,23 +414,53 @@ impl InputGate {
     /// Install what the gate needs to police `vm`'s stdin. Replaces any
     /// previous binding; call it before the workload is reachable.
     ///
-    /// A session snapshots the secret set at [`open`](Self::open) and holds it
-    /// for its lifetime, so re-binding does not change what a *live* session
-    /// recognises — a secret registered mid-session is recognised by the next
-    /// writer, not the current one. Deliberate: the alternative is a scanner
-    /// whose window can change under a partially-scanned stream.
+    /// A session snapshots the fingerprint set at [`open`](Self::open) and
+    /// holds it for its lifetime, so re-binding does not change what a *live*
+    /// session recognises — a secret registered mid-session is recognised by
+    /// the next writer, not the current one. Deliberate: the alternative is a
+    /// scanner whose window can change under a partially-scanned stream.
     pub fn bind(vm: &str, binding: InputBinding) {
         let bound = Bound {
-            secrets: Arc::new(binding.secrets),
+            fingerprints: Arc::new(binding.fingerprints),
             audit: binding.audit,
             lease_ttl: binding.lease_ttl,
         };
         gate().bindings.insert(vm.to_string(), bound);
     }
 
+    /// Replace just the fingerprint set for `vm`, leaving its chain and lease
+    /// lifetime alone.
+    ///
+    /// Two different owners, so two different calls. The fingerprints come
+    /// from the substitution endpoint and change whenever a VM's secrets do;
+    /// the audit chain and the lease lifetime are installed once by whoever
+    /// stood the VM up. A caller refreshing one must not silently reset the
+    /// other — most sharply for the chain, where reverting to the process
+    /// default would move a VM's input decisions into a different log without
+    /// saying so.
+    ///
+    /// Replaces rather than merges: a set that could only grow would let a
+    /// previous boot's fingerprints outlive the secrets they stood for.
+    pub fn bind_fingerprints(vm: &str, fingerprints: Vec<SecretFingerprint>) {
+        let mut state = gate();
+        match state.bindings.get_mut(vm) {
+            Some(bound) => bound.fingerprints = Arc::new(fingerprints),
+            None => {
+                state.bindings.insert(
+                    vm.to_string(),
+                    Bound {
+                        fingerprints: Arc::new(fingerprints),
+                        audit: None,
+                        lease_ttl: DEFAULT_LEASE_TTL,
+                    },
+                );
+            }
+        }
+    }
+
     /// Drop `vm`'s binding and any lease on it — the teardown half of
     /// [`bind`](Self::bind). Leaving the binding behind would keep a dead VM's
-    /// secrets resident.
+    /// fingerprints resident.
     pub fn unbind(vm: &str) {
         let mut state = gate();
         state.bindings.remove(vm);
@@ -503,7 +523,7 @@ impl InputGate {
             holder,
             audit,
             lease_ttl: resolved.lease_ttl,
-            scanner: SecretScanner::new(resolved.secrets),
+            scanner: SecretScanner::new(resolved.fingerprints),
             outbox: Vec::new(),
             highest_accepted_seq: None,
             refused: None,
@@ -578,7 +598,9 @@ impl InputSession {
                 self.highest_accepted_seq = Some(frame.seq);
                 Ok(())
             }
-            Err(category) => Err(self.latch(InputRefusal::SecretMaterial { category })),
+            Err(category) => Err(self.latch(InputRefusal::SecretMaterial {
+                category: category.as_str(),
+            })),
         }
     }
 
@@ -716,12 +738,12 @@ impl Drop for InputSession {
 /// is filesystem work, and holding the one gate lock across it would stall
 /// every other VM's writer behind this VM's disk.
 fn resolve(vm: &str) -> Resolved {
-    let (audit, secrets, lease_ttl) = {
+    let (audit, fingerprints, lease_ttl) = {
         let state = gate();
         match state.bindings.get(vm) {
             Some(bound) => (
                 bound.audit.clone(),
-                Arc::clone(&bound.secrets),
+                Arc::clone(&bound.fingerprints),
                 bound.lease_ttl,
             ),
             None => (None, Arc::new(Vec::new()), DEFAULT_LEASE_TTL),
@@ -729,7 +751,7 @@ fn resolve(vm: &str) -> Resolved {
     };
     Resolved {
         audit: audit.or_else(process_audit),
-        secrets,
+        fingerprints,
         lease_ttl,
     }
 }
@@ -831,112 +853,6 @@ fn build_process_audit() -> anyhow::Result<InputAudit> {
     )?))
 }
 
-/// Recognises known secret material in a byte stream that arrives in
-/// arbitrarily chopped frames.
-///
-/// Two things make it work across frames. It scans the concatenation of the
-/// carried tail and the new payload, so a secret split down the middle is
-/// still a contiguous match; and it *withholds* the longest suffix of the
-/// stream that is still a proper prefix of some known secret, so the first
-/// half of a split secret never reaches the guest ahead of the refusal. A
-/// suffix that is not a prefix of anything ships immediately, which is what
-/// keeps ordinary interactive input from being delayed.
-///
-/// **What it cannot catch**, and this is not a gap that more rules would
-/// close: any encoding of the secret (base64, hex, URL-escaping), any
-/// derivation of it (a hash, a signature, a substring used as a lookup key),
-/// and any secret the host never registered. It is a backstop against a
-/// caller that pasted the wrong thing, not a defence against a caller that
-/// wants the secret in there. The property that actually holds is upstream —
-/// the host substitutes secrets on egress and so has no reason to send one
-/// into a guest at all.
-struct SecretScanner {
-    secrets: Arc<Vec<KnownSecret>>,
-    /// Length of the longest registered secret; the window is one byte short
-    /// of it, because a full-length suffix would be a match, not a prefix.
-    longest: usize,
-    /// The withheld tail: a proper prefix of at least one known secret.
-    pending: Vec<u8>,
-}
-
-impl SecretScanner {
-    fn new(secrets: Arc<Vec<KnownSecret>>) -> Self {
-        // A zero-length "secret" matches everywhere and means nothing, so it
-        // is not allowed to set the window.
-        let longest = secrets.iter().map(|s| s.value.len()).max().unwrap_or(0);
-        Self {
-            secrets,
-            longest,
-            pending: Vec::new(),
-        }
-    }
-
-    /// Clear `payload` for delivery, or name the category it matched.
-    fn admit(&mut self, payload: &[u8]) -> Result<Vec<u8>, &'static str> {
-        if self.longest == 0 {
-            return Ok(payload.to_vec());
-        }
-        let mut buf = std::mem::take(&mut self.pending);
-        buf.extend_from_slice(payload);
-
-        if let Some(category) = self.first_match(&buf) {
-            // The buffer straddles a secret; it is not going anywhere, and it
-            // does not linger in this process either.
-            buf.zeroize();
-            return Err(category);
-        }
-
-        let hold = self.unresolved_tail(&buf);
-        self.pending = buf.split_off(buf.len() - hold);
-        Ok(buf)
-    }
-
-    /// Release the withheld tail. Safe by construction: it is a proper prefix
-    /// of a secret, which is not a secret.
-    fn flush(&mut self) -> Vec<u8> {
-        std::mem::take(&mut self.pending)
-    }
-
-    /// How much is being withheld. A length, not the bytes.
-    fn withheld_len(&self) -> usize {
-        self.pending.len()
-    }
-
-    /// The category of the first known secret contained in `buf`.
-    fn first_match(&self, buf: &[u8]) -> Option<&'static str> {
-        self.secrets
-            .iter()
-            .filter(|secret| !secret.value.is_empty() && secret.value.len() <= buf.len())
-            .find(|secret| {
-                buf.windows(secret.value.len())
-                    .any(|window| window == secret.value.as_slice())
-            })
-            .map(|secret| secret.category)
-    }
-
-    /// How many trailing bytes of `buf` must be held back: the longest suffix
-    /// that is still a proper prefix of some known secret, and zero when the
-    /// stream ends in nothing interesting.
-    fn unresolved_tail(&self, buf: &[u8]) -> usize {
-        let ceiling = self.longest.saturating_sub(1).min(buf.len());
-        (1..=ceiling)
-            .rev()
-            .find(|&k| {
-                let tail = &buf[buf.len() - k..];
-                self.secrets
-                    .iter()
-                    .any(|secret| secret.value.len() > k && secret.value.starts_with(tail))
-            })
-            .unwrap_or(0)
-    }
-}
-
-impl Drop for SecretScanner {
-    fn drop(&mut self) {
-        self.pending.zeroize();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -949,6 +865,8 @@ mod tests {
     use mvm_core::plan::test_support::PlanFixture;
     use mvm_core::plan::{PlanSeccompTier, SecretReleasePolicy, SynthesisInput, sign_plan};
     use tempfile::TempDir;
+
+    use mvm_protocol::stream::secret_fingerprint::SecretCategory;
 
     use super::*;
     use crate::audit::emitter::stream_audit;
@@ -1093,12 +1011,21 @@ mod tests {
             .collect()
     }
 
-    /// A session on a VM bound to recognise exactly one secret.
+    /// The fingerprint of `secret`, as the substitution endpoint computes it.
+    ///
+    /// A test may hold a literal; the point of the type is that the *gate*
+    /// never does, and this helper is where that transition happens.
+    fn fingerprint(secret: &str) -> SecretFingerprint {
+        SecretFingerprint::of(secret.as_bytes(), SecretCategory::HostSecret)
+            .expect("a non-empty secret fingerprints")
+    }
+
+    /// A session on a VM bound to recognise exactly one secret's fingerprint.
     fn granted_session_with_known_secret(secret: &str) -> InputSession {
         let vm = unique_vm("vm-secret");
         InputGate::bind(
             &vm,
-            InputBinding::new().with_secret(KnownSecret::host_material(secret.as_bytes())),
+            InputBinding::new().with_fingerprint(fingerprint(secret)),
         );
         let plan = admitted_with(vec![stream_service()]);
         InputGate::open(&vm, &plan).expect("the plan grants input")
@@ -1176,7 +1103,7 @@ mod tests {
         let vm = unique_vm("vm-audit");
         InputGate::bind(
             &vm,
-            InputBinding::new().with_secret(KnownSecret::host_material(secret.as_bytes())),
+            InputBinding::new().with_fingerprint(fingerprint(secret)),
         );
         let plan = admitted_from(
             PlanFixture::new()
@@ -1409,7 +1336,7 @@ mod tests {
     fn a_live_secret_prefix_is_withheld_rather_than_delivered_early() {
         // The half of the split-secret defence that a refusal alone does not
         // give you: refusing the second frame is worthless if the first frame
-        // already handed the guest the first twelve bytes.
+        // already handed the guest the first twelve bytes of the key.
         let mut session = granted_session_with_known_secret("AKIAIOSFODNN7EXAMPLE");
         session
             .write(InputFrame {
@@ -1417,53 +1344,71 @@ mod tests {
                 payload: b"echo AKIAIOSFODNN".to_vec(),
             })
             .expect("a prefix is not a match");
+        let cleared = session.take_admitted().expect("the lease is live");
+        assert!(
+            !cleared.ends_with(b"AKIAIOSFODNN"),
+            "the live prefix must not reach the guest ahead of the refusal: {:?}",
+            String::from_utf8_lossy(&cleared)
+        );
         assert_eq!(
-            session.take_admitted().expect("the lease is live"),
-            b"echo ",
-            "the live prefix stays on the host until it is resolved"
+            cleared, b"",
+            "the whole 17-byte frame sits inside the 19-byte carry"
         );
     }
 
     #[test]
-    fn a_tail_that_resolves_to_nothing_ships_on_the_next_frame() {
+    fn the_withheld_tail_is_bounded_and_ships_on_the_next_frame() {
+        // The cost of matching fingerprints rather than values: the scanner
+        // cannot tell a live prefix from an innocent tail, so it holds a fixed
+        // `longest - 1` bytes. Bounded, and never lost — the previous tail
+        // ships the moment the next frame proves nothing straddles.
         let mut session = granted_session_with_known_secret("AKIAIOSFODNN7EXAMPLE");
+        let first = b"the quick brown fox jumps over the lazy dog\n";
         session
             .write(InputFrame {
                 seq: 0,
-                payload: b"AKIA".to_vec(),
+                payload: first.to_vec(),
             })
-            .expect("a prefix is not a match");
-        assert!(
-            session
-                .take_admitted()
-                .expect("the lease is live")
-                .is_empty()
+            .expect("nothing to match");
+        let cleared = session.take_admitted().expect("the lease is live");
+        assert_eq!(
+            cleared.len(),
+            first.len() - 19,
+            "exactly one byte short of the longest secret stays behind"
         );
+        assert_eq!(cleared, &first[..first.len() - 19]);
+
         session
             .write(InputFrame {
                 seq: 1,
-                payload: b"DEMO\n".to_vec(),
+                payload: b"and again\n".to_vec(),
             })
-            .expect("it was never a secret");
+            .expect("still nothing to match");
         assert_eq!(
-            session.take_admitted().expect("the lease is live"),
-            b"AKIADEMO\n"
+            [cleared, session.take_admitted().expect("the lease is live")].concat(),
+            [first.as_slice(), b"and again\n"].concat()[..first.len() + 10 - 19],
+            "every earlier byte came out, in order"
         );
     }
 
     #[test]
-    fn ordinary_input_is_not_delayed_by_the_scanner() {
-        let mut session = granted_session_with_known_secret("AKIAIOSFODNN7EXAMPLE");
+    fn a_vm_that_bound_no_fingerprints_is_not_delayed_at_all() {
+        // The carry is the price of scanning, so it must be charged only to
+        // workloads that actually have a secret to leak.
+        let vm = unique_vm("vm-undelayed");
+        InputGate::bind(&vm, InputBinding::new());
+        let plan = admitted_with(vec![stream_service()]);
+        let mut session = InputGate::open(&vm, &plan).expect("the plan grants input");
         session
             .write(InputFrame {
                 seq: 0,
                 payload: b"ls -la\n".to_vec(),
             })
-            .expect("nothing to match");
+            .expect("nothing bound");
         assert_eq!(
             session.take_admitted().expect("the lease is live"),
             b"ls -la\n",
-            "a suffix that is not a prefix of any secret ships immediately"
+            "with no fingerprints there is nothing to slide a window against"
         );
     }
 
@@ -1549,10 +1494,70 @@ mod tests {
     }
 
     #[test]
-    fn a_known_secret_never_renders_its_value() {
-        let rendered = format!("{:?}", KnownSecret::host_material(b"AKIAIOSFODNN7EXAMPLE"));
+    fn the_gate_holds_no_secret_value_anywhere_a_binding_can_put_one() {
+        // The type surface is the guarantee, not a comment: the only way a
+        // secret enters this gate is `with_fingerprint`, whose parameter is a
+        // length, a hash and a vocabulary word. There is no byte-taking
+        // overload to reach for, so a caller that has no plaintext cannot be
+        // tempted into acquiring some, and one that does cannot hand it over.
+        let binding = InputBinding::new().with_fingerprint(fingerprint("AKIAIOSFODNN7EXAMPLE"));
+        let rendered = format!("{:?}", binding.fingerprints);
         assert!(!rendered.contains("AKIA"), "got {rendered}");
-        assert!(rendered.contains(CATEGORY_HOST_SECRET), "got {rendered}");
+        assert!(rendered.contains("len: 20"), "got {rendered}");
+        assert_eq!(
+            std::mem::size_of::<SecretFingerprint>(),
+            std::mem::size_of::<u64>() * 2,
+            "a fingerprint is fixed-width and inline: two words hold a length, a \
+             hash and a category, and there is no room for a pointer to a value"
+        );
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<SecretFingerprint>();
+
+        // And the source says the same thing: no constructor on the binding
+        // takes bytes.
+        let src = include_str!("input_gate.rs");
+        let (production, _tests) = src
+            .split_once("#[cfg(test)]\nmod tests {")
+            .expect("this module keeps its tests at the end");
+        assert!(
+            !production.contains("KnownSecret"),
+            "the plaintext-carrying binding type must stay deleted, not deprecated"
+        );
+        assert!(
+            production
+                .contains("pub fn with_fingerprint(mut self, fingerprint: SecretFingerprint)"),
+            "the one secret-facing setter must take a fingerprint"
+        );
+    }
+
+    #[test]
+    fn a_fingerprint_refusal_does_not_claim_the_bytes_are_the_secret() {
+        // A fingerprint match is a length-and-hash match; a collision produces
+        // the same refusal from bytes that are nobody's secret. Refusing is
+        // right — it fails closed — but an operator told "this contained a
+        // secret" when it did not would spend hours proving the negative, so
+        // the sentence has to say what was actually checked.
+        let refusal = InputRefusal::SecretMaterial {
+            category: CATEGORY_HOST_SECRET,
+        };
+        let said = refusal.to_string();
+        assert!(
+            said.contains("matches the fingerprint"),
+            "the refusal must name what it compared: {said}"
+        );
+        assert!(
+            said.contains("not proof"),
+            "and must disclaim the certainty it does not have: {said}"
+        );
+        assert!(
+            !said.contains("carries recognised secret material"),
+            "the old wording asserted identity from a hash: {said}"
+        );
+        assert_eq!(
+            refusal.reason(),
+            "secret-material",
+            "the wire-stable reason word an operator greps for does not move"
+        );
     }
 
     // --- close ordering ----------------------------------------------------
@@ -1651,10 +1656,18 @@ mod tests {
             ),
             "a repeat is not an advance"
         );
+        assert!(
+            session
+                .take_admitted()
+                .expect("the lease is live")
+                .is_empty(),
+            "eight bytes sit inside the carried window"
+        );
         assert_eq!(
-            session.take_admitted().expect("the lease is live"),
+            session.close().expect("the lease is live").trailing,
             b"7EXAMPLE",
-            "the reordered half never entered the stream"
+            "the accepted half comes out at close; the reordered one never \
+             entered the stream at all"
         );
     }
 

--- a/crates/mvm-hostd/src/stream/input_gate.rs
+++ b/crates/mvm-hostd/src/stream/input_gate.rs
@@ -37,7 +37,11 @@
 //!   rolling hash each, computed by the process that legitimately holds the
 //!   plaintext — because this gate runs in a process that must not hold one.
 //!   A fingerprint match is a hash match and nothing stronger, which is why
-//!   [`InputRefusal::SecretMaterial`] says so. See
+//!   [`InputRefusal::SecretMaterial`] says so. Holding fingerprints rather than
+//!   values also means the withheld tail is a blanket
+//!   `longest_secret - 1` bytes rather than the exact live prefix, which is
+//!   wider than a request line — so [`InputSession::refresh`] releases it after
+//!   [`DEFAULT_IDLE_FLUSH_AFTER`] of writer silence, on elapsed time alone. See
 //!   `stream::secret_scan` for what this cannot catch;
 //!   it is a backstop against a confused caller, not a defence against a
 //!   determined one. The real guarantee is upstream: the host has no reason to
@@ -99,9 +103,45 @@ pub use mvm_protocol::stream::secret_fingerprint::CATEGORY_HOST_SECRET;
 /// How long a writer keeps the input lease without touching it.
 ///
 /// Long enough that an interactive human pausing to think does not lose their
-/// place; short enough that a consumer which crashed mid-session frees the
-/// VM's stdin inside a coffee break rather than at VM teardown.
+/// place, and that a writer waiting between chunks — a pipe blocked on its
+/// upstream, a keepalive tick that slipped — does not lose it to a timer;
+/// short enough that a consumer which crashed mid-session frees the VM's stdin
+/// inside a coffee break rather than at VM teardown.
+///
+/// The pause this describes is a real workflow again only because of
+/// [`DEFAULT_IDLE_FLUSH_AFTER`]: a lease that outlives a pause is worth
+/// nothing if the bytes the writer already typed are still sitting in the
+/// scanner waiting for a write that the workload's silence guarantees will
+/// never come.
 pub const DEFAULT_LEASE_TTL: Duration = Duration::from_secs(30);
+
+/// How quiet a writer must go before the gate hands over the tail its secret
+/// scan is withholding.
+///
+/// On a VM with bound fingerprints the scanner withholds a blanket
+/// `longest_secret - 1` bytes of every write, so a request line shorter than
+/// that clears nothing at all. Without a release on silence that is a
+/// deadlock, not latency: the workload never receives a line, so it never
+/// answers, so the operator never sends the write that would push the first
+/// one out. The release is what makes the request/response shape work.
+///
+/// 50ms, because the threshold has to sit between two gaps that differ by
+/// orders of magnitude. Below it is the gap *inside* one writer's burst —
+/// consecutive frames of a paste or of a chunked pipe are separated by a
+/// buffer copy and one vsock round trip, microseconds to low milliseconds —
+/// and the scan must stay exact across those, since that is the split a
+/// confused caller actually produces. Above it is the gap a human or a
+/// request/response peer leaves, which is at minimum the workload's own
+/// think time. 50ms is roughly fifty times the first and half of the ~100ms
+/// at which a person starts to perceive delay, so it neither fires inside a
+/// burst nor is felt outside one.
+///
+/// **The decision is elapsed time and nothing else.** It never consults the
+/// withheld bytes, and it must not: a release that depended on content would
+/// be a prefix oracle — feed a byte, watch whether it was withheld, and walk
+/// a secret out one byte at a time. The blanket carry is what denies an
+/// observer that signal, and a content-blind release preserves it.
+pub const DEFAULT_IDLE_FLUSH_AFTER: Duration = Duration::from_millis(50);
 
 /// Why the gate would not let bytes through.
 ///
@@ -280,17 +320,19 @@ pub struct InputBinding {
     fingerprints: Vec<SecretFingerprint>,
     audit: Option<Arc<dyn InputAuditSink>>,
     lease_ttl: Duration,
+    idle_flush_after: Duration,
 }
 
 impl InputBinding {
     /// An empty binding: no fingerprints, the process audit chain, the
-    /// default lease lifetime.
+    /// default lease lifetime and the default idle release.
     #[must_use]
     pub fn new() -> Self {
         Self {
             fingerprints: Vec::new(),
             audit: None,
             lease_ttl: DEFAULT_LEASE_TTL,
+            idle_flush_after: DEFAULT_IDLE_FLUSH_AFTER,
         }
     }
 
@@ -351,6 +393,19 @@ impl InputBinding {
         self.lease_ttl = lease_ttl;
         self
     }
+
+    /// How quiet this VM's writer must go before the withheld tail is released.
+    ///
+    /// A knob rather than a constant so the boundary can be exercised from
+    /// both sides without sleeping on a wall clock: zero releases on the first
+    /// idle check, an hour releases on none of them, and both are decided by
+    /// the same elapsed-time comparison production uses. See
+    /// [`DEFAULT_IDLE_FLUSH_AFTER`] for what the value has to sit between.
+    #[must_use]
+    pub fn with_idle_flush_after(mut self, idle_flush_after: Duration) -> Self {
+        self.idle_flush_after = idle_flush_after;
+        self
+    }
 }
 
 impl Default for InputBinding {
@@ -365,6 +420,7 @@ struct Bound {
     fingerprints: Arc<Vec<SecretFingerprint>>,
     audit: Option<Arc<dyn InputAuditSink>>,
     lease_ttl: Duration,
+    idle_flush_after: Duration,
 }
 
 /// The single-writer claim on one VM's stdin.
@@ -404,6 +460,7 @@ struct Resolved {
     audit: Option<Arc<dyn InputAuditSink>>,
     fingerprints: Arc<Vec<SecretFingerprint>>,
     lease_ttl: Duration,
+    idle_flush_after: Duration,
 }
 
 /// The gate: process-wide, and reached by name rather than by handle so there
@@ -424,20 +481,20 @@ impl InputGate {
             fingerprints: Arc::new(binding.fingerprints),
             audit: binding.audit,
             lease_ttl: binding.lease_ttl,
+            idle_flush_after: binding.idle_flush_after,
         };
         gate().bindings.insert(vm.to_string(), bound);
     }
 
-    /// Replace just the fingerprint set for `vm`, leaving its chain and lease
-    /// lifetime alone.
+    /// Replace just the fingerprint set for `vm`, leaving its chain and its
+    /// lease and idle timings alone.
     ///
     /// Two different owners, so two different calls. The fingerprints come
     /// from the substitution endpoint and change whenever a VM's secrets do;
-    /// the audit chain and the lease lifetime are installed once by whoever
-    /// stood the VM up. A caller refreshing one must not silently reset the
-    /// other — most sharply for the chain, where reverting to the process
-    /// default would move a VM's input decisions into a different log without
-    /// saying so.
+    /// the audit chain and the timings are installed once by whoever stood the
+    /// VM up. A caller refreshing one must not silently reset the other — most
+    /// sharply for the chain, where reverting to the process default would
+    /// move a VM's input decisions into a different log without saying so.
     ///
     /// Replaces rather than merges: a set that could only grow would let a
     /// previous boot's fingerprints outlive the secrets they stood for.
@@ -452,6 +509,7 @@ impl InputGate {
                         fingerprints: Arc::new(fingerprints),
                         audit: None,
                         lease_ttl: DEFAULT_LEASE_TTL,
+                        idle_flush_after: DEFAULT_IDLE_FLUSH_AFTER,
                     },
                 );
             }
@@ -523,6 +581,11 @@ impl InputGate {
             holder,
             audit,
             lease_ttl: resolved.lease_ttl,
+            idle_flush_after: resolved.idle_flush_after,
+            // The session opens "just written to", so a writer that opens and
+            // sits there has nothing withheld to release and nothing to
+            // measure against.
+            last_admitted_at: Instant::now(),
             scanner: SecretScanner::new(resolved.fingerprints),
             outbox: Vec::new(),
             highest_accepted_seq: None,
@@ -553,6 +616,12 @@ pub struct InputSession {
     holder: String,
     audit: Arc<dyn InputAuditSink>,
     lease_ttl: Duration,
+    /// How long this session's writer must be silent before the withheld tail
+    /// is released. See [`DEFAULT_IDLE_FLUSH_AFTER`].
+    idle_flush_after: Duration,
+    /// When the scanner last took bytes. The one input to the idle release,
+    /// and deliberately the only one — see [`Self::release_if_idle`].
+    last_admitted_at: Instant,
     scanner: SecretScanner,
     outbox: Vec<u8>,
     highest_accepted_seq: Option<u64>,
@@ -596,6 +665,10 @@ impl InputSession {
             Ok(cleared) => {
                 self.outbox.extend_from_slice(&cleared);
                 self.highest_accepted_seq = Some(frame.seq);
+                // Any accepted frame is activity, including one that cleared
+                // nothing: the writer is mid-burst and the scan must stay
+                // exact across the boundary it just created.
+                self.last_admitted_at = Instant::now();
                 Ok(())
             }
             Err(category) => Err(self.latch(InputRefusal::SecretMaterial {
@@ -629,9 +702,25 @@ impl InputSession {
         Ok(std::mem::take(&mut self.outbox))
     }
 
-    /// Extend the lease without writing, for a holder that is idle but alive.
+    /// Say "I am idle but alive": extend the lease, and release the tail the
+    /// secret scan has been withholding if the writer has been quiet for
+    /// [`DEFAULT_IDLE_FLUSH_AFTER`].
+    ///
+    /// Both halves answer the same fact, which is why they are one call. A
+    /// lease that survives a pause is worth nothing on a secret-bearing VM if
+    /// the bytes the writer already sent are still held: the scan withholds a
+    /// blanket `longest_secret - 1` bytes, which is wider than a request line,
+    /// so the workload receives nothing, answers nothing, and the writer never
+    /// produces the next write that would push the first one out. Releasing on
+    /// silence is what breaks that circle.
+    ///
+    /// Anything released lands in the outbox, so a caller drains with
+    /// [`take_admitted`](Self::take_admitted) exactly as it would after a
+    /// write.
     pub fn refresh(&mut self) -> Result<(), InputRefusal> {
-        self.check_live()
+        self.check_live()?;
+        self.release_if_idle(Instant::now());
+        Ok(())
     }
 
     /// How many bytes this session is holding that it can no longer hand over:
@@ -670,6 +759,40 @@ impl InputSession {
             after_seq: self.highest_accepted_seq,
             trailing,
         })
+    }
+
+    /// Hand the withheld tail to the outbox once the writer has been quiet for
+    /// [`Self::idle_flush_after`].
+    ///
+    /// **Content-independent, and that is the whole design.** The two inputs
+    /// are how long it has been since the scanner last took bytes and how many
+    /// bytes it is holding. Neither is derived from what those bytes *are*, so
+    /// an observer who watches whether a write came out learns only when it
+    /// wrote — never anything about the secret. The alternative, releasing
+    /// only the tails that cannot still become a secret, is what the plaintext
+    /// scanner did and is a prefix oracle here: hold the input grant, feed one
+    /// byte, see whether it was withheld, and a 40-byte credential falls in
+    /// about 40·256 probes instead of 256^40. A blanket carry leaks nothing
+    /// because it is blanket; a blanket release keeps it that way.
+    ///
+    /// Releasing cannot hand over a secret. The tail is what survived
+    /// [`SecretScanner::admit`], which already refused the whole buffer if any
+    /// window in it matched — so what is released is bytes already proven not
+    /// to contain a bound fingerprint. What is lost is *context*: a secret
+    /// split across the silence is no longer contiguous in the scanner and is
+    /// missed. That needs the sender to pause mid-credential, which a confused
+    /// caller does not do and a determined one does not need, since encoding
+    /// the value defeats the scan outright.
+    fn release_if_idle(&mut self, now: Instant) {
+        if self.scanner.withheld_len() == 0 {
+            return;
+        }
+        if now.duration_since(self.last_admitted_at) < self.idle_flush_after {
+            return;
+        }
+        let mut released = self.scanner.flush();
+        self.outbox.extend_from_slice(&released);
+        released.zeroize();
     }
 
     /// The two runtime conditions every byte-moving call shares: a session
@@ -738,21 +861,28 @@ impl Drop for InputSession {
 /// is filesystem work, and holding the one gate lock across it would stall
 /// every other VM's writer behind this VM's disk.
 fn resolve(vm: &str) -> Resolved {
-    let (audit, fingerprints, lease_ttl) = {
+    let (audit, fingerprints, lease_ttl, idle_flush_after) = {
         let state = gate();
         match state.bindings.get(vm) {
             Some(bound) => (
                 bound.audit.clone(),
                 Arc::clone(&bound.fingerprints),
                 bound.lease_ttl,
+                bound.idle_flush_after,
             ),
-            None => (None, Arc::new(Vec::new()), DEFAULT_LEASE_TTL),
+            None => (
+                None,
+                Arc::new(Vec::new()),
+                DEFAULT_LEASE_TTL,
+                DEFAULT_IDLE_FLUSH_AFTER,
+            ),
         }
     };
     Resolved {
         audit: audit.or_else(process_audit),
         fingerprints,
         lease_ttl,
+        idle_flush_after,
     }
 }
 
@@ -1022,14 +1152,35 @@ mod tests {
 
     /// A session on a VM bound to recognise exactly one secret's fingerprint.
     fn granted_session_with_known_secret(secret: &str) -> InputSession {
+        session_bound_to(secret, DEFAULT_IDLE_FLUSH_AFTER)
+    }
+
+    /// The same, with the idle release set where the test needs it.
+    ///
+    /// The threshold is the seam these tests drive, not the clock: zero
+    /// releases on the first idle check and an hour releases on none of them,
+    /// so both sides of the boundary are decided by the same elapsed-time
+    /// comparison production uses, with nothing sleeping and nothing to go
+    /// flaky under a loaded machine.
+    fn session_bound_to(secret: &str, idle_flush_after: Duration) -> InputSession {
         let vm = unique_vm("vm-secret");
         InputGate::bind(
             &vm,
-            InputBinding::new().with_fingerprint(fingerprint(secret)),
+            InputBinding::new()
+                .with_fingerprint(fingerprint(secret))
+                .with_idle_flush_after(idle_flush_after),
         );
         let plan = admitted_with(vec![stream_service()]);
         InputGate::open(&vm, &plan).expect("the plan grants input")
     }
+
+    /// A 40-byte secret, so the carry is 39 — wider than any request line a
+    /// person types, which is the shape the idle release exists for.
+    const LONG_SECRET: &str = "AKIAIOSFODNN7EXAMPLE/wJalrXUtnFEMI0K7MDE";
+
+    /// Never elapses within a test process's lifetime, so the idle release is
+    /// off and only a write or a close can move the withheld tail.
+    const NEVER_IDLE: Duration = Duration::from_secs(3600);
 
     // --- the four required properties -------------------------------------
 
@@ -1558,6 +1709,210 @@ mod tests {
             "secret-material",
             "the wire-stable reason word an operator greps for does not move"
         );
+    }
+
+    // --- the idle release --------------------------------------------------
+
+    #[test]
+    fn an_idle_writer_gets_the_line_the_carry_swallowed() {
+        // The deadlock, and its end. A 40-byte bound secret makes the carry
+        // 39, so an 11-byte request line clears nothing: the workload receives
+        // no line, answers nothing, and the operator has no reason to send the
+        // write that would push the first one out. Releasing on silence is the
+        // only thing that breaks the circle — before this, the line arrived at
+        // EOF or never.
+        let mut session = session_bound_to(LONG_SECRET, Duration::ZERO);
+        let line = b"{\"q\":\"hi\"}\n";
+        session
+            .write(InputFrame {
+                seq: 0,
+                payload: line.to_vec(),
+            })
+            .expect("a JSON line is not a secret");
+        assert_eq!(
+            session.take_admitted().expect("the lease is live"),
+            b"",
+            "the whole 11-byte line sits inside the 39-byte carry"
+        );
+
+        session.refresh().expect("the lease is live");
+        assert_eq!(
+            session.take_admitted().expect("the lease is live"),
+            line,
+            "going quiet must hand the line over, not wait for a write that \
+             the workload's own silence guarantees will never come"
+        );
+        session.refresh().expect("the lease is live");
+        assert_eq!(
+            session.take_admitted().expect("the lease is live"),
+            b"",
+            "and there is nothing left to release twice"
+        );
+        assert_eq!(session.stranded_len(), 0);
+    }
+
+    #[test]
+    fn the_idle_release_does_not_depend_on_what_the_withheld_bytes_are() {
+        // The property the whole design rests on. A release that fired only
+        // for tails which could not still become a secret would be a prefix
+        // oracle: hold the grant, feed a byte, watch whether it came out, and
+        // walk a 40-byte credential out in about 40x256 probes. So two
+        // payloads of the same length must be indistinguishable from outside —
+        // and one of these is a genuine live prefix of the bound secret while
+        // the other is nobody's.
+        let live_prefix = &LONG_SECRET.as_bytes()[..11];
+        let innocent = b"hello world";
+        assert_eq!(
+            live_prefix.len(),
+            innocent.len(),
+            "same length, or nothing \
+                    below compares anything"
+        );
+
+        let observe = |payload: &[u8]| -> (Vec<u8>, usize, Vec<u8>) {
+            let mut session = session_bound_to(LONG_SECRET, Duration::ZERO);
+            session
+                .write(InputFrame {
+                    seq: 0,
+                    payload: payload.to_vec(),
+                })
+                .expect("neither payload completes the secret");
+            let before = session.take_admitted().expect("the lease is live");
+            let withheld = session.stranded_len();
+            session.refresh().expect("the lease is live");
+            let after = session.take_admitted().expect("the lease is live");
+            (before, withheld, after)
+        };
+
+        let (prefix_before, prefix_withheld, prefix_after) = observe(live_prefix);
+        let (innocent_before, innocent_withheld, innocent_after) = observe(innocent);
+
+        assert_eq!(
+            (prefix_before, prefix_withheld),
+            (innocent_before, innocent_withheld),
+            "what is withheld must be a length, never a verdict about the bytes"
+        );
+        assert_eq!(
+            prefix_after.len(),
+            innocent_after.len(),
+            "and so must what the idle release hands back"
+        );
+        assert_eq!(prefix_after, live_prefix);
+        assert_eq!(innocent_after, innocent);
+    }
+
+    #[test]
+    fn a_secret_split_across_two_writes_inside_the_threshold_is_still_refused() {
+        // The coverage the release must not cost. Inside the threshold the
+        // writer is mid-burst — consecutive frames of a paste, or of a chunked
+        // pipe — and that is exactly the split a confused caller produces, so
+        // the scan has to stay exact across it. A release that fired here
+        // would hand the guest the first half and refuse the second, which is
+        // the theatre the carry exists to prevent.
+        let mut session = session_bound_to("AKIAIOSFODNN7EXAMPLE", NEVER_IDLE);
+        session
+            .write(InputFrame {
+                seq: 0,
+                payload: b"AKIAIOSFODNN".to_vec(),
+            })
+            .expect("a prefix alone is not a match");
+        session.refresh().expect("the lease is live");
+        assert_eq!(
+            session.take_admitted().expect("the lease is live"),
+            b"",
+            "a writer that has not been quiet long enough gets nothing back"
+        );
+        assert!(matches!(
+            session.write(InputFrame {
+                seq: 1,
+                payload: b"7EXAMPLE".to_vec()
+            }),
+            Err(InputRefusal::SecretMaterial { .. })
+        ));
+    }
+
+    #[test]
+    fn a_secret_split_across_the_idle_gap_is_missed_and_that_is_the_price() {
+        // The weakening, pinned rather than left in prose. Once the tail is
+        // released the scanner has no context to straddle, so a secret split
+        // across the silence goes through. It needs the *sender* to pause
+        // mid-credential, which a confused caller does not do and a determined
+        // one does not need — base64 already defeats the scan outright. This
+        // sits inside "backstop, not a defence"; it does not move that line.
+        let mut session = session_bound_to("AKIAIOSFODNN7EXAMPLE", Duration::ZERO);
+        session
+            .write(InputFrame {
+                seq: 0,
+                payload: b"AKIAIOSFODNN".to_vec(),
+            })
+            .expect("a prefix alone is not a match");
+        session.refresh().expect("the lease is live");
+        session
+            .write(InputFrame {
+                seq: 1,
+                payload: b"7EXAMPLE".to_vec(),
+            })
+            .expect("the halves are no longer contiguous in the scanner");
+        session.refresh().expect("the lease is live");
+        assert_eq!(
+            session.take_admitted().expect("the lease is live"),
+            b"AKIAIOSFODNN7EXAMPLE",
+            "the patient caller wins, and the ledger says so"
+        );
+    }
+
+    #[test]
+    fn an_idle_release_cannot_hand_over_a_bound_secret() {
+        // What the release can never do, whatever the threshold. Anything the
+        // scanner is holding already survived a scan of the whole buffer it
+        // came from, so no window inside it matches — and a session that did
+        // hit a match latches, so a caller cannot go quiet to collect what was
+        // refused.
+        let mut session = session_bound_to("AKIAIOSFODNN7EXAMPLE", Duration::ZERO);
+        session
+            .write(InputFrame {
+                seq: 0,
+                payload: b"AKIAIOSFODNN7EXAMPLE".to_vec(),
+            })
+            .expect_err("the whole secret in one frame is refused");
+        assert!(matches!(
+            session.refresh(),
+            Err(InputRefusal::SecretMaterial { .. })
+        ));
+        assert!(matches!(
+            session.take_admitted(),
+            Err(InputRefusal::SecretMaterial { .. })
+        ));
+    }
+
+    #[test]
+    fn a_writer_that_lost_its_lease_gets_no_idle_release_either() {
+        // Every path that moves bytes out of a session is lease-gated, and the
+        // idle release is a new one. A stalled writer collecting its tail
+        // after a successor took the stdin would deliver into somebody else's.
+        let vm = unique_vm("vm-idle-lease");
+        InputGate::bind(
+            &vm,
+            InputBinding::new()
+                .with_fingerprint(fingerprint(LONG_SECRET))
+                .with_idle_flush_after(Duration::ZERO)
+                .with_lease_ttl(Duration::from_millis(20)),
+        );
+        let plan = admitted_with(vec![stream_service()]);
+        let mut stalled = InputGate::open(&vm, &plan).expect("the plan grants input");
+        stalled
+            .write(InputFrame {
+                seq: 0,
+                payload: b"hello\n".to_vec(),
+            })
+            .expect("cleared while the lease was live");
+        std::thread::sleep(Duration::from_millis(40));
+
+        assert!(matches!(stalled.refresh(), Err(InputRefusal::LeaseExpired)));
+        assert!(matches!(
+            stalled.take_admitted(),
+            Err(InputRefusal::LeaseExpired)
+        ));
     }
 
     // --- close ordering ----------------------------------------------------

--- a/crates/mvm-hostd/src/stream/input_gate.rs
+++ b/crates/mvm-hostd/src/stream/input_gate.rs
@@ -88,7 +88,6 @@ use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError};
 use std::time::{Duration, Instant};
 
 use mvm_contract::stream::input::{CloseInput, InputFrame, grants_input};
-use mvm_contract::stream::input::{CloseInput, InputFrame, grants_input};
 use mvm_contract::stream::secret_fingerprint::SecretFingerprint;
 use mvm_core::plan::ExecutionPlan;
 use zeroize::Zeroize;
@@ -98,7 +97,7 @@ use crate::plan_admission::AdmittedPlan;
 use crate::stream::secret_scan::SecretScanner;
 
 /// Category recorded for a secret value the host itself holds for a workload.
-pub use mvm_protocol::stream::secret_fingerprint::CATEGORY_HOST_SECRET;
+pub use mvm_contract::stream::secret_fingerprint::CATEGORY_HOST_SECRET;
 
 /// How long a writer keeps the input lease without touching it.
 ///
@@ -996,7 +995,7 @@ mod tests {
     use mvm_core::plan::{PlanSeccompTier, SecretReleasePolicy, SynthesisInput, sign_plan};
     use tempfile::TempDir;
 
-    use mvm_protocol::stream::secret_fingerprint::SecretCategory;
+    use mvm_contract::stream::secret_fingerprint::SecretCategory;
 
     use super::*;
     use crate::audit::emitter::stream_audit;

--- a/crates/mvm-hostd/src/stream/input_route.rs
+++ b/crates/mvm-hostd/src/stream/input_route.rs
@@ -44,13 +44,17 @@
 //!   unbounded one. Refusing ahead of the gate is what leaves the frame
 //!   re-offerable: the gate never saw its `seq`, so the writer may try again.
 //!
-//! - **The withheld tail is handed over.** The gate holds back the tail of the
-//!   stream that is still a live prefix of a known secret rather than shipping
-//!   it and refusing afterwards, and releases it when closing proves it was
-//!   only ever a prefix. [`InputRoute::close`] is what carries those bytes to
-//!   the guest, ahead of EOF. Dropping them would lose the writer's last bytes
-//!   with no error anywhere — the guest's own types force `deliver_tail`
-//!   before `close`, but nothing forces this end to send a tail at all.
+//! - **The withheld tail is handed over, at close and on silence.** The gate
+//!   holds back the tail of the stream that could still complete a known
+//!   secret rather than shipping it and refusing afterwards. Two things
+//!   release it: closing, which proves the stream ended without one, and the
+//!   writer going quiet, which the gate answers by handing the tail over on
+//!   elapsed time alone. [`InputRoute::close`] and [`InputRoute::refresh`] are
+//!   what carry those bytes to the guest. Both have to, and for the same
+//!   reason: dropping them would lose the writer's bytes with no error
+//!   anywhere — the guest's own types force `deliver_tail` before `close`, but
+//!   nothing forces this end to send a tail at all, and nothing at all forces
+//!   it to notice the idle release.
 //!
 //! Everything else the route does is pass-through, and that is deliberate: a
 //! second place that decided whether bytes may move would be a second place to
@@ -288,9 +292,32 @@ impl InputRoute {
         flush_into(&mut *self.transport, &mut self.pending)
     }
 
-    /// Extend the lease without writing, for a writer that is idle but alive.
+    /// Tell the gate this writer is idle but alive, and carry whatever that
+    /// releases.
+    ///
+    /// Not just a lease touch. On a secret-bearing VM the gate withholds a
+    /// blanket tail of every write, and once the writer goes quiet it releases
+    /// that tail — so this call can produce bytes, and a route that only
+    /// renewed the lease would leave them sitting in the session with no
+    /// second chance to notice. Delivering them here is what makes a workload
+    /// that answers per line answer at all.
+    ///
+    /// One wire frame at most, and only when there is something to put in it:
+    /// an empty frame per idle tick would be a vsock round trip per tick for
+    /// the whole life of a quiet stream.
     pub fn refresh(&mut self) -> Result<(), InputRouteError> {
-        self.session.refresh().map_err(InputRouteError::Refused)
+        self.session.refresh()?;
+        let released = self.session.take_admitted()?;
+        if !released.is_empty() {
+            self.pending.push(InputFrame {
+                seq: self.wire_seq.mint(),
+                payload: released,
+            });
+        }
+        if self.pending.frames.is_empty() {
+            return Ok(());
+        }
+        flush_into(&mut *self.transport, &mut self.pending)
     }
 
     /// End the stream: hand the withheld tail to the guest, then EOF.
@@ -1013,6 +1040,59 @@ mod tests {
         assert_eq!(
             InputGate::lease_holder(&vm).as_deref(),
             Some(route.holder())
+        );
+    }
+
+    #[test]
+    fn a_line_the_carry_swallowed_reaches_the_guest_once_the_writer_goes_quiet() {
+        // The deadlock, driven all the way to the transport. A 40-byte bound
+        // secret makes the gate's carry 39, so an 11-byte request line clears
+        // nothing and the workload never receives the line it is waiting on.
+        // The gate releases that tail on silence — but only this end can carry
+        // it, and a route that merely renewed the lease would leave the bytes
+        // sitting in the session with nothing to notice them again.
+        let vm = unique_vm("route-idle-release");
+        InputGate::bind(
+            &vm,
+            InputBinding::new()
+                .with_fingerprint(fingerprint("AKIAIOSFODNN7EXAMPLE/wJalrXUtnFEMI0K7MDE"))
+                .with_idle_flush_after(std::time::Duration::ZERO),
+        );
+        let carried = Recorder::default();
+        let mut route = InputRoute::open(
+            &vm,
+            &admitted(vec![stream_service()]),
+            Box::new(carried.clone()),
+            WireSequence::default(),
+        )
+        .expect("the plan grants input");
+
+        route
+            .write(frame(0, b"{\"q\":\"hi\"}\n"))
+            .expect("a JSON line is not a secret");
+        assert_eq!(
+            carried.stdin_bytes(),
+            b"",
+            "the whole line sits inside the carry"
+        );
+
+        route.refresh().expect("an idle holder keeps its lease");
+        assert_eq!(
+            carried.stdin_bytes(),
+            b"{\"q\":\"hi\"}\n",
+            "going quiet must put the line on the wire"
+        );
+        assert_eq!(
+            carried.seqs(),
+            [0, 1],
+            "the release travels as a wire frame of its own, in delivery order"
+        );
+
+        route.refresh().expect("an idle holder keeps its lease");
+        assert_eq!(
+            carried.seqs(),
+            [0, 1],
+            "and an idle tick with nothing to release costs no round trip"
         );
     }
 }

--- a/crates/mvm-hostd/src/stream/input_route.rs
+++ b/crates/mvm-hostd/src/stream/input_route.rs
@@ -496,7 +496,7 @@ mod tests {
     use mvm_core::plan::test_support::PlanFixture;
 
     use super::*;
-    use mvm_protocol::stream::secret_fingerprint::{SecretCategory, SecretFingerprint};
+    use mvm_contract::stream::secret_fingerprint::{SecretCategory, SecretFingerprint};
 
     use crate::stream::input_gate::InputBinding;
 

--- a/crates/mvm-hostd/src/stream/input_route.rs
+++ b/crates/mvm-hostd/src/stream/input_route.rs
@@ -469,7 +469,15 @@ mod tests {
     use mvm_core::plan::test_support::PlanFixture;
 
     use super::*;
-    use crate::stream::input_gate::{InputBinding, KnownSecret};
+    use mvm_protocol::stream::secret_fingerprint::{SecretCategory, SecretFingerprint};
+
+    use crate::stream::input_gate::InputBinding;
+
+    /// The fingerprint of `secret`, as the substitution endpoint computes it.
+    fn fingerprint(secret: &str) -> SecretFingerprint {
+        SecretFingerprint::of(secret.as_bytes(), SecretCategory::HostSecret)
+            .expect("a non-empty secret fingerprints")
+    }
 
     /// What a transport was asked to carry, in the order it was asked.
     ///
@@ -568,7 +576,7 @@ mod tests {
     fn route_on(vm: &str, secret: Option<&str>) -> (InputRoute, Recorder) {
         let mut binding = InputBinding::new();
         if let Some(secret) = secret {
-            binding = binding.with_secret(KnownSecret::host_material(secret.as_bytes()));
+            binding = binding.with_fingerprint(fingerprint(secret));
         }
         InputGate::bind(vm, binding);
         let recorder = Recorder::default();
@@ -619,8 +627,8 @@ mod tests {
 
     #[test]
     fn delivery_order_is_acceptance_order_even_when_a_frame_clears_nothing() {
-        // The guarantee this module exists for. The gate withholds
-        // "AKIAIOSFODNN" as a live prefix, so frame 0 clears only "echo " —
+        // The guarantee this module exists for. The gate carries a tail one
+        // byte short of the longest bound secret, so frame 0 clears nothing —
         // and the wire still carries a frame at seq 0, so the sequence the
         // guest sees is the sequence the gate accepted, gaps and all.
         let vm = unique_vm("route-order");
@@ -636,13 +644,19 @@ mod tests {
         assert_eq!(carried.seqs(), [0, 1], "one wire frame per accepted frame");
         assert_eq!(
             carried.carried().frames[0].payload,
-            b"echo ",
-            "the live prefix stays on the host until it is resolved"
+            b"",
+            "the whole 17-byte frame sits inside the carried window"
         );
         assert_eq!(
             carried.stdin_bytes(),
+            b"ech",
+            "and the earliest bytes arrive, in order, once later ones push them out"
+        );
+        route.close().expect("the lease is live");
+        assert_eq!(
+            carried.stdin_bytes(),
             b"echo AKIAIOSFODNNDEMO\n",
-            "and arrives, in order, once it resolves to nothing"
+            "close releases the rest: every byte the writer sent, in order"
         );
     }
 
@@ -685,13 +699,13 @@ mod tests {
             .expect("a prefix is not a match");
         assert_eq!(
             carried.carried().frames[0].payload,
-            b"echo ",
+            b"",
             "the tail is withheld while the stream is open"
         );
 
         route.close().expect("the lease is live");
         let closed = carried.carried().closed.clone().expect("the stream ended");
-        assert_eq!(closed.trailing, b"AKIAIOSFODNN");
+        assert_eq!(closed.trailing, b"echo AKIAIOSFODNN");
         assert_eq!(
             carried.stdin_bytes(),
             b"echo AKIAIOSFODNN",
@@ -914,7 +928,7 @@ mod tests {
         let vm = unique_vm("route-displaced");
         InputGate::bind(
             &vm,
-            InputBinding::new().with_secret(KnownSecret::host_material(b"AKIAIOSFODNN7EXAMPLE")),
+            InputBinding::new().with_fingerprint(fingerprint("AKIAIOSFODNN7EXAMPLE")),
         );
         let mut route = InputRoute::open(
             &vm,

--- a/crates/mvm-hostd/src/stream/mod.rs
+++ b/crates/mvm-hostd/src/stream/mod.rs
@@ -58,6 +58,7 @@ pub mod input_route;
 mod journal;
 pub mod plane;
 pub mod redact;
+pub(crate) mod secret_scan;
 pub mod serve;
 
 use std::sync::{Arc, OnceLock};
@@ -71,7 +72,7 @@ pub use fanout::{
 };
 pub use input_gate::{
     CATEGORY_HOST_SECRET, DEFAULT_LEASE_TTL, InputAudit, InputAuditSink, InputBinding, InputGate,
-    InputRefusal, InputSession, KnownSecret,
+    InputRefusal, InputSession,
 };
 pub use input_route::{
     DisplacedRoute, InputRoute, InputRouteError, InputTransport, MAX_UNDELIVERED_INPUT_BYTES,

--- a/crates/mvm-hostd/src/stream/mod.rs
+++ b/crates/mvm-hostd/src/stream/mod.rs
@@ -71,8 +71,8 @@ pub use fanout::{
     ReaderHandle, ReaderStart,
 };
 pub use input_gate::{
-    CATEGORY_HOST_SECRET, DEFAULT_LEASE_TTL, InputAudit, InputAuditSink, InputBinding, InputGate,
-    InputRefusal, InputSession,
+    CATEGORY_HOST_SECRET, DEFAULT_IDLE_FLUSH_AFTER, DEFAULT_LEASE_TTL, InputAudit, InputAuditSink,
+    InputBinding, InputGate, InputRefusal, InputSession,
 };
 pub use input_route::{
     DisplacedRoute, InputRoute, InputRouteError, InputTransport, MAX_UNDELIVERED_INPUT_BYTES,

--- a/crates/mvm-hostd/src/stream/plane.rs
+++ b/crates/mvm-hostd/src/stream/plane.rs
@@ -260,12 +260,21 @@ impl StreamPlane {
     /// displaced route is wound up explicitly, what it can no longer deliver
     /// is reported, and the VM's delivery counter carries across it so the
     /// successor is not refused by the guest for its predecessor's sequence.
+    ///
+    /// This is also where the gate learns what to scan for. The substitution
+    /// endpoint fingerprinted every secret it resolved for this VM at spawn,
+    /// and binding here rather than at boot is what makes the two orders
+    /// independent: a session snapshots the fingerprint set when it opens, so
+    /// the set has to be installed immediately before, not at some earlier
+    /// point a backend might reorder.
     pub fn open_input(
         &self,
         vm: &str,
         admitted: &crate::plan_admission::AdmittedPlan,
         transport: Box<dyn InputTransport>,
     ) -> Result<(), InputRefusal> {
+        bind_known_secrets(vm);
+
         // Cloned out from under the registry lock, which is not held across
         // anything below: winding up an incumbent waits on that VM's route
         // lock, and a wedged guest holding it must not stall every other VM.
@@ -414,6 +423,30 @@ impl ConsoleStreamer for StreamPlane {
     fn stop(&self, vm_name: &str) {
         self.release(vm_name);
     }
+}
+
+/// Install the fingerprint set the input gate scans `vm`'s stdin against.
+///
+/// The values behind these fingerprints live in the per-VM substitution
+/// endpoint, a separate process, and stay there: what reaches this process is
+/// a length, a rolling hash and a category each, computed by the endpoint at
+/// spawn. That separation is the reason the gate matches fingerprints instead
+/// of bytes — copying credentials in here to populate a scan would create a
+/// plaintext location where there is none.
+///
+/// An empty set is the honest outcome for a VM whose plan carried no secrets,
+/// and for one this process did not boot: in the second case no writer can
+/// open a session anyway, because it holds no admitted plan to write under.
+/// Binding unconditionally rather than skipping the empty case keeps a stale
+/// set from a previous VM of the same name out of the gate.
+fn bind_known_secrets(vm: &str) {
+    let fingerprints = mvm_runtime::recorded_secret_fingerprints(vm);
+    tracing::debug!(
+        vm = %vm,
+        fingerprints = fingerprints.len(),
+        "installing the input gate's known-secret fingerprints"
+    );
+    crate::stream::input_gate::InputGate::bind_fingerprints(vm, fingerprints);
 }
 
 /// End the stream a shared route holds, taking it out under the route's own

--- a/crates/mvm-hostd/src/stream/plane.rs
+++ b/crates/mvm-hostd/src/stream/plane.rs
@@ -305,13 +305,17 @@ impl StreamPlane {
         self.inputs().contains_key(vm)
     }
 
-    /// Extend `vm`'s input lease without writing anything.
+    /// Tell `vm`'s gate that its writer is idle but alive.
     ///
-    /// The lease exists to free a stdin whose writer died, not to punish one
-    /// that is thinking: without this, an interactive writer that paused past
-    /// the TTL would find its next write refused *and* its close refused,
-    /// which drops the tail the gate withheld. Keeping the lease alive is the
-    /// holder's job, and this is the only way to do it without sending bytes.
+    /// Two things ride on the same call. The lease exists to free a stdin
+    /// whose writer died, not to punish one that is thinking: without this, an
+    /// interactive writer that paused past the TTL would find its next write
+    /// refused *and* its close refused, which drops the tail the gate
+    /// withheld. And on a secret-bearing VM the gate releases that withheld
+    /// tail once the silence is long enough, which is what lets a workload
+    /// reading one request line at a time ever receive one. Both are the
+    /// holder's job, and this is the only way to do either without sending
+    /// bytes.
     pub fn refresh_input(&self, vm: &str) -> Result<(), InputRouteError> {
         let shared = self.route(vm)?;
         let mut held = shared.lock().unwrap_or_else(PoisonError::into_inner);

--- a/crates/mvm-hostd/src/stream/secret_scan.rs
+++ b/crates/mvm-hostd/src/stream/secret_scan.rs
@@ -1,0 +1,275 @@
+//! Recognising known secret material in a byte stream that arrives in
+//! arbitrarily chopped frames — without holding any of it.
+//!
+//! The scanner is bound to a set of [`SecretFingerprint`]s, computed by the
+//! process that legitimately holds the plaintext. It slides a rolling hash
+//! over the concatenation of the tail it carried and the payload just offered,
+//! at every offset and for every distinct secret length, so a secret split
+//! down the middle of two writes is still a contiguous match here.
+//!
+//! ## Why it withholds, and why it withholds more than it used to
+//!
+//! Retaining context and withholding bytes are the same act. If the scanner
+//! shipped the tail of a frame and kept a copy to scan against, a secret
+//! straddling that boundary would be refused *after* its first half had
+//! already reached the guest — the refusal would be theatre. So whatever it
+//! must still be able to see, it must still be holding.
+//!
+//! Against plaintext, "what it must still see" is exactly the suffix that is
+//! still a live prefix of some secret; everything else provably cannot become
+//! one and ships at once. Against fingerprints that question is unanswerable —
+//! deliberately, because the prefix hashes that would answer it are a
+//! byte-at-a-time recovery oracle (see
+//! [`mvm_protocol::stream::secret_fingerprint`]). So the scanner withholds a
+//! fixed tail of `longest_secret - 1` bytes instead.
+//!
+//! The cost is bounded and worth naming: on a VM with bound secrets, the last
+//! `longest - 1` bytes of each write wait for the next write or for
+//! [`SecretScanner::flush`] at close. A VM with no bound secrets scans nothing
+//! and withholds nothing, so the latency lands only where a secret could
+//! actually be leaked. The withheld tail is never dropped — it rides out on
+//! the next frame or on the close.
+//!
+//! ## What it cannot catch
+//!
+//! Not a gap more rules would close: any encoding of the secret (base64, hex,
+//! URL-escaping), any derivation of it (a hash, a signature, a substring used
+//! as a lookup key), and any secret the host never registered. It is a
+//! backstop against a caller that pasted the wrong thing, not a defence
+//! against a caller that wants the secret in there. The property that actually
+//! holds is upstream — the host substitutes secrets on egress and so has no
+//! reason to send one into a guest at all.
+
+use std::sync::Arc;
+
+use mvm_protocol::stream::secret_fingerprint::{
+    SecretCategory, SecretFingerprint, leading_weight, roll, window_hash, window_sizes,
+};
+use zeroize::Zeroize;
+
+/// Slides a window over a stream looking for bound fingerprints.
+pub(crate) struct SecretScanner {
+    fingerprints: Arc<Vec<SecretFingerprint>>,
+    /// Distinct secret lengths, longest first: one rolling pass per entry.
+    sizes: Vec<usize>,
+    /// How many trailing bytes must stay resident to see a secret that
+    /// straddles the next frame boundary — one byte short of the longest
+    /// secret, because a full-length suffix would be a match, not a straddle.
+    carry: usize,
+    /// The withheld tail. Bytes the gate has scanned and is holding.
+    pending: Vec<u8>,
+}
+
+impl SecretScanner {
+    pub(crate) fn new(fingerprints: Arc<Vec<SecretFingerprint>>) -> Self {
+        let sizes = window_sizes(&fingerprints);
+        let carry = sizes.first().copied().unwrap_or(0).saturating_sub(1);
+        Self {
+            fingerprints,
+            sizes,
+            carry,
+            pending: Vec::new(),
+        }
+    }
+
+    /// Clear `payload` for delivery, or name the category it matched.
+    ///
+    /// On `Ok` the returned bytes may go to the guest in order; the tail this
+    /// scanner is still holding comes out on a later call or on
+    /// [`flush`](Self::flush).
+    pub(crate) fn admit(&mut self, payload: &[u8]) -> Result<Vec<u8>, SecretCategory> {
+        if self.sizes.is_empty() {
+            return Ok(payload.to_vec());
+        }
+        let mut buf = std::mem::take(&mut self.pending);
+        buf.extend_from_slice(payload);
+
+        if let Some(category) = self.first_match(&buf) {
+            // The buffer straddles a fingerprinted secret; it is not going
+            // anywhere, and it does not linger in this process either.
+            buf.zeroize();
+            return Err(category);
+        }
+
+        let hold = self.carry.min(buf.len());
+        self.pending = buf.split_off(buf.len() - hold);
+        Ok(buf)
+    }
+
+    /// Release the withheld tail.
+    ///
+    /// Safe by construction: the scan already cleared every window inside it,
+    /// so what is left is a stream that ended without completing any bound
+    /// secret. Dropping it instead would silently swallow the writer's last
+    /// bytes.
+    pub(crate) fn flush(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.pending)
+    }
+
+    /// How much is being withheld. A length, not the bytes.
+    pub(crate) fn withheld_len(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// The category of the first bound fingerprint `buf` contains, longest
+    /// secret first.
+    fn first_match(&self, buf: &[u8]) -> Option<SecretCategory> {
+        self.sizes
+            .iter()
+            .filter(|&&len| len <= buf.len())
+            .find_map(|&len| self.match_at_length(buf, len))
+    }
+
+    /// One rolling pass over every `len`-sized window of `buf`.
+    ///
+    /// The rolling hash proposes; [`SecretFingerprint::matches_window`]
+    /// disposes. Re-deriving the candidate's hash directly costs one pass over
+    /// `len` bytes on a hit and means a slip in the incremental arithmetic
+    /// cannot on its own refuse a caller's frame — the two definitions have to
+    /// agree before anything is refused.
+    fn match_at_length(&self, buf: &[u8], len: usize) -> Option<SecretCategory> {
+        let weight = leading_weight(len);
+        let mut hash = window_hash(&buf[..len]);
+        for start in 0..=buf.len() - len {
+            if start > 0 {
+                hash = roll(hash, buf[start - 1], buf[start + len - 1], weight);
+            }
+            let window = &buf[start..start + len];
+            if let Some(hit) = self
+                .fingerprints
+                .iter()
+                .filter(|fp| fp.len() == len && fp.hash() == hash)
+                .find(|fp| fp.matches_window(window))
+            {
+                return Some(hit.category());
+            }
+        }
+        None
+    }
+}
+
+impl Drop for SecretScanner {
+    fn drop(&mut self) {
+        self.pending.zeroize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scanner(secrets: &[&str]) -> SecretScanner {
+        SecretScanner::new(Arc::new(
+            secrets
+                .iter()
+                .filter_map(|s| SecretFingerprint::of(s.as_bytes(), SecretCategory::HostSecret))
+                .collect(),
+        ))
+    }
+
+    #[test]
+    fn a_secret_delivered_whole_is_refused() {
+        let mut s = scanner(&["AKIAIOSFODNN7EXAMPLE"]);
+        assert_eq!(
+            s.admit(b"export KEY=AKIAIOSFODNN7EXAMPLE\n"),
+            Err(SecretCategory::HostSecret)
+        );
+    }
+
+    #[test]
+    fn a_secret_split_across_two_admits_is_refused() {
+        // The case the carried tail exists for: a per-frame check would clear
+        // both halves and hand the guest the whole thing.
+        let mut s = scanner(&["AKIAIOSFODNN7EXAMPLE"]);
+        s.admit(b"AKIAIOSFODNN").expect("half is not a match");
+        assert_eq!(
+            s.admit(b"7EXAMPLE"),
+            Err(SecretCategory::HostSecret),
+            "the second half completes it"
+        );
+    }
+
+    #[test]
+    fn the_first_half_of_a_split_secret_is_never_cleared() {
+        // Refusing the second frame is worthless if the first already handed
+        // the guest twelve bytes of the key.
+        let mut s = scanner(&["AKIAIOSFODNN7EXAMPLE"]);
+        let cleared = s.admit(b"echo AKIAIOSFODNN").expect("half is not a match");
+        assert!(
+            !cleared.ends_with(b"AKIAIOSFODNN"),
+            "cleared {:?}",
+            String::from_utf8_lossy(&cleared)
+        );
+        assert_eq!(cleared, b"", "17 bytes, all inside the 19-byte carry");
+        assert_eq!(s.withheld_len(), 17);
+    }
+
+    #[test]
+    fn a_stream_that_ends_without_a_secret_gets_its_tail_back() {
+        let mut s = scanner(&["AKIAIOSFODNN7EXAMPLE"]);
+        let cleared = s.admit(b"ls -la\n").expect("nothing to match");
+        assert_eq!(
+            [cleared, s.flush()].concat(),
+            b"ls -la\n",
+            "every byte comes out, in order"
+        );
+        assert_eq!(s.withheld_len(), 0);
+    }
+
+    #[test]
+    fn the_carry_is_one_byte_short_of_the_longest_secret() {
+        let mut s = scanner(&["abcd", "abcdefghij"]);
+        let cleared = s.admit(b"0123456789ABCDEF").expect("nothing to match");
+        assert_eq!(cleared, b"0123456", "16 bytes in, 9 held back");
+        assert_eq!(s.withheld_len(), 9);
+    }
+
+    #[test]
+    fn a_scanner_with_no_fingerprints_delivers_verbatim_and_withholds_nothing() {
+        // The latency of the carried tail must land only on VMs that bound a
+        // secret; everything else pays nothing.
+        let mut s = scanner(&[]);
+        assert_eq!(
+            s.admit(b"AKIAIOSFODNN7EXAMPLE").expect("nothing bound"),
+            b"AKIAIOSFODNN7EXAMPLE"
+        );
+        assert_eq!(s.withheld_len(), 0);
+    }
+
+    #[test]
+    fn a_secret_arriving_one_byte_per_admit_is_still_refused() {
+        let secret = "AKIAIOSFODNN7EXAMPLE";
+        let mut s = scanner(&[secret]);
+        let mut refused = None;
+        for byte in secret.bytes() {
+            if let Err(category) = s.admit(&[byte]) {
+                refused = Some(category);
+                break;
+            }
+        }
+        assert_eq!(refused, Some(SecretCategory::HostSecret));
+    }
+
+    #[test]
+    fn a_fingerprint_no_secret_produced_still_refuses_the_bytes_that_satisfy_it() {
+        // What a hash collision looks like from in here, and the reason the
+        // gate's refusal may not claim the bytes *are* a secret: the scanner
+        // holds no value to compare against, so anything satisfying a bound
+        // (len, hash) pair is refused. Built from the wire form — which is how
+        // a fingerprint actually arrives — so no plaintext enters this test's
+        // scanner at all.
+        let innocent = b"ls -la /tmp\n";
+        let forged: SecretFingerprint = serde_json::from_str(&format!(
+            r#"{{"len":{},"hash":{},"category":"host-secret"}}"#,
+            innocent.len(),
+            window_hash(innocent)
+        ))
+        .expect("a fingerprint arrives as JSON");
+        let mut s = SecretScanner::new(Arc::new(vec![forged]));
+        assert_eq!(
+            s.admit(innocent),
+            Err(SecretCategory::HostSecret),
+            "matching is by fingerprint alone, whatever produced the bytes"
+        );
+    }
+}

--- a/crates/mvm-hostd/src/stream/secret_scan.rs
+++ b/crates/mvm-hostd/src/stream/secret_scan.rs
@@ -19,7 +19,7 @@
 //! still a live prefix of some secret; everything else provably cannot become
 //! one and ships at once. Against fingerprints that question is unanswerable —
 //! deliberately, because the prefix hashes that would answer it disclose the
-//! secret outright (see [`mvm_protocol::stream::secret_fingerprint`]). So the
+//! secret outright (see [`mvm_contract::stream::secret_fingerprint`]). So the
 //! scanner withholds a fixed tail of `longest_secret - 1` bytes instead.
 //!
 //! ## Why the blanket carry is the safe one
@@ -73,7 +73,7 @@
 
 use std::sync::Arc;
 
-use mvm_protocol::stream::secret_fingerprint::{
+use mvm_contract::stream::secret_fingerprint::{
     SecretCategory, SecretFingerprint, leading_weight, roll, window_hash, window_sizes,
 };
 use zeroize::Zeroize;

--- a/crates/mvm-hostd/src/stream/secret_scan.rs
+++ b/crates/mvm-hostd/src/stream/secret_scan.rs
@@ -18,27 +18,58 @@
 //! Against plaintext, "what it must still see" is exactly the suffix that is
 //! still a live prefix of some secret; everything else provably cannot become
 //! one and ships at once. Against fingerprints that question is unanswerable —
-//! deliberately, because the prefix hashes that would answer it are a
-//! byte-at-a-time recovery oracle (see
-//! [`mvm_protocol::stream::secret_fingerprint`]). So the scanner withholds a
-//! fixed tail of `longest_secret - 1` bytes instead.
+//! deliberately, because the prefix hashes that would answer it disclose the
+//! secret outright (see [`mvm_protocol::stream::secret_fingerprint`]). So the
+//! scanner withholds a fixed tail of `longest_secret - 1` bytes instead.
 //!
-//! The cost is bounded and worth naming: on a VM with bound secrets, the last
-//! `longest - 1` bytes of each write wait for the next write or for
-//! [`SecretScanner::flush`] at close. A VM with no bound secrets scans nothing
-//! and withholds nothing, so the latency lands only where a secret could
-//! actually be leaked. The withheld tail is never dropped — it rides out on
-//! the next frame or on the close.
+//! ## Why the blanket carry is the safe one
+//!
+//! It looks like the lazy choice and it is the load-bearing one. Withholding
+//! only the tails that could still *become* a secret — what plaintext buys —
+//! makes the withhold-or-deliver decision depend on the content of the bytes,
+//! and that decision is observable: whoever holds the input grant can feed one
+//! byte, watch whether anything came out, and read the answer. That is a
+//! prefix oracle, and it walks a 40-byte credential out in roughly 40x256
+//! probes instead of 256^40. Because *everything* is withheld unconditionally,
+//! the decision carries no information about the content at all. The
+//! imprecision is what makes it silent.
+//!
+//! ## What the carry costs, and how the cost is paid
+//!
+//! On a VM with bound secrets the last `longest - 1` bytes of every write wait
+//! for the *next* write — so a write shorter than the carry clears nothing.
+//! Left there that is a deadlock rather than latency: with a 40-byte bound
+//! secret an 11-byte request line delivers zero bytes, so a workload that
+//! answers per line never gets a line, never answers, and the operator never
+//! sends the write that would release the first one.
+//!
+//! [`SecretScanner::flush`] is what breaks that circle, and the caller decides
+//! when to call it: this scanner is synchronous and has no clock, so the gate
+//! releases the tail once its writer has been silent long enough (see
+//! `stream::input_gate`'s `DEFAULT_IDLE_FLUSH_AFTER`). That release is on
+//! elapsed time alone — never on what the bytes are, which is the same reason
+//! the carry is blanket. What it costs is stated with the rest of what this
+//! cannot catch, below: a secret split across the silence is no longer
+//! contiguous here and is missed.
+//!
+//! A VM with no bound secrets scans nothing and withholds nothing, so all of
+//! this lands only where a secret could actually be leaked, and the withheld
+//! tail is never dropped — it rides out on the next frame, on the idle
+//! release, or on the close.
 //!
 //! ## What it cannot catch
 //!
 //! Not a gap more rules would close: any encoding of the secret (base64, hex,
 //! URL-escaping), any derivation of it (a hash, a signature, a substring used
-//! as a lookup key), and any secret the host never registered. It is a
-//! backstop against a caller that pasted the wrong thing, not a defence
-//! against a caller that wants the secret in there. The property that actually
-//! holds is upstream — the host substitutes secrets on egress and so has no
-//! reason to send one into a guest at all.
+//! as a lookup key), any secret the host never registered, and — once the tail
+//! has been released — a secret whose halves the sender separated by a
+//! deliberate pause. The last of those is the newest and the least of them:
+//! it needs a caller patient enough to stop mid-credential, and a caller that
+//! patient would simply base64 it. It is a backstop against a caller that
+//! pasted the wrong thing, not a defence against a caller that wants the
+//! secret in there. The property that actually holds is upstream — the host
+//! substitutes secrets on egress and so has no reason to send one into a guest
+//! at all.
 
 use std::sync::Arc;
 
@@ -202,6 +233,51 @@ mod tests {
         );
         assert_eq!(cleared, b"", "17 bytes, all inside the 19-byte carry");
         assert_eq!(s.withheld_len(), 17);
+    }
+
+    #[test]
+    fn a_line_shorter_than_the_carry_clears_nothing_until_someone_flushes() {
+        // Why this scanner cannot be the whole answer. A 40-byte bound secret
+        // makes the carry 39, so a whole request line is swallowed: the
+        // workload gets no line, cannot answer, and the operator has no reason
+        // to send the write that would release it. Nothing here can fix that,
+        // because nothing here has a clock — `flush` is the seam, and the gate
+        // above decides when the writer has been quiet long enough to use it.
+        let mut s = scanner(&["AKIAIOSFODNN7EXAMPLE/wJalrXUtnFEMI0K7MDE"]);
+        let line = b"{\"q\":\"hi\"}\n";
+        let cleared = s.admit(line).expect("a JSON line is not a secret");
+        assert_eq!(
+            cleared, b"",
+            "an 11-byte line sits entirely inside the 39-byte carry"
+        );
+        assert_eq!(s.withheld_len(), line.len());
+        assert_eq!(s.flush(), line, "and a flush is what hands it over");
+    }
+
+    #[test]
+    fn what_is_withheld_is_a_length_and_never_a_verdict_about_the_bytes() {
+        // The reason the carry is blanket rather than precise. If how much the
+        // scanner held back depended on whether the tail could still become a
+        // secret, the amount would be an oracle: feed a byte, see whether
+        // anything came out, and walk the credential out a byte at a time. So
+        // a live prefix of a bound secret and a payload that is nobody's must
+        // be indistinguishable from outside.
+        let secret = "AKIAIOSFODNN7EXAMPLE";
+        let live_prefix = &secret.as_bytes()[..12];
+        let innocent = b"hello world!";
+        assert_eq!(live_prefix.len(), innocent.len());
+
+        let observe = |payload: &[u8]| {
+            let mut s = scanner(&[secret]);
+            let cleared = s.admit(payload).expect("neither completes the secret");
+            (cleared, s.withheld_len(), s.flush())
+        };
+        assert_eq!(
+            observe(live_prefix),
+            (Vec::new(), 12, live_prefix.to_vec()),
+            "the live prefix is treated as bytes of some length and nothing more"
+        );
+        assert_eq!(observe(innocent), (Vec::new(), 12, innocent.to_vec()));
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
@@ -23,9 +23,16 @@ use serde::{Deserialize, Serialize};
 
 use mvm_core::crypto::secret_store::{FileSecretStore, SecretStore, default_secrets_dir};
 use mvm_core::plan::SecretBinding;
+use mvm_protocol::stream::secret_fingerprint::{SecretCategory, SecretFingerprint};
 
 use crate::keyholder::{FileBindingStore, HandedPlaceholders};
 use crate::supervisor::substitution_proxy::SubstitutionService;
+
+/// The endpoint's ready-handshake line. Defined next to
+/// [`spawn_substitution_endpoint`](mvm_runtime::spawn_substitution_endpoint)'s
+/// reader and re-exported here so the bin, its tests and the spawner share one
+/// wire definition without a dependency cycle.
+pub use mvm_runtime::EndpointHandshake;
 
 /// Default forward-leg timeout (host → real destination) in seconds.
 fn default_forward_timeout_secs() -> u64 {
@@ -241,6 +248,60 @@ pub fn assemble(
     Ok((service, handed))
 }
 
+/// Fingerprint every secret this endpoint can resolve, for the host→guest
+/// input gate.
+///
+/// This is the one process that legitimately holds these values, which is why
+/// the fingerprints are computed here and not where they are used. Only the
+/// fingerprints leave — a length, a rolling hash and a category each — so the
+/// process that scans a workload's stdin never has to hold a credential in
+/// order to recognise one. What a fingerprint discloses is stated on
+/// [`SecretFingerprint`].
+///
+/// Best effort per secret rather than fail-closed: a `SecretRef` with no value
+/// in the store is a secret the workload has no way to receive either, so
+/// there is nothing for the gate to recognise and nothing is weakened by
+/// skipping it. A resolver failure is logged, not fatal — refusing to boot a
+/// VM because one of its credentials is not set yet would be a new failure
+/// mode introduced by a backstop.
+pub fn fingerprint_bound_secrets(cfg: &EndpointConfig) -> anyhow::Result<Vec<SecretFingerprint>> {
+    use crate::keyholder::{LocalResolver, SecretResolver, assemble_registry};
+    use secrecy::ExposeSecret;
+
+    let secret_store: Arc<dyn SecretStore> = Arc::new(match &cfg.secret_store_dir {
+        Some(dir) => FileSecretStore::with_dir(dir),
+        None => FileSecretStore::with_dir(default_secrets_dir()?),
+    });
+    let bindings = match &cfg.binding_store_dir {
+        Some(dir) => FileBindingStore::with_dir(dir),
+        None => FileBindingStore::default_location()?,
+    };
+    let (registry, handed) = assemble_registry(&cfg.secrets, &cfg.tenant_id, &bindings)
+        .context("assembling the substitution registry to fingerprint its secrets")?;
+    let resolver = LocalResolver::new(cfg.tenant_id.clone(), secret_store);
+
+    let mut out = Vec::with_capacity(handed.len());
+    for (_guest_var, placeholder) in &handed {
+        let Some(secret_ref) = registry.resolve(placeholder.as_str()) else {
+            continue;
+        };
+        match resolver.resolve(secret_ref) {
+            // The exposed bytes are read once, hashed, and dropped with the
+            // zeroizing box at the end of this iteration.
+            Ok(value) => out.extend(SecretFingerprint::of(
+                value.expose_secret().as_slice(),
+                SecretCategory::HostSecret,
+            )),
+            Err(err) => tracing::warn!(
+                secret = %secret_ref.name,
+                error = %err,
+                "secret not resolvable; the input gate will not recognise it"
+            ),
+        }
+    }
+    Ok(out)
+}
+
 /// Build a chain-signed audit [`Recorder`] from the standard host paths
 /// (`<keys>/host-signer.ed25519` + `<audit>/`), or `None` if the signer key
 /// isn't present (the endpoint then serves un-audited, matching the prior
@@ -268,6 +329,8 @@ mod tests {
     use super::*;
     use crate::keyholder::{BindingStore, SecretBindingMeta};
     use mvm_contract::ir::AuthType;
+    use mvm_contract::ir::AuthType;
+    use mvm_contract::stream::secret_fingerprint::SecretCategory;
     use mvm_core::plan::SecretSource;
     use mvm_core::util::test_env::TestEnv;
     use secrecy::SecretBox;
@@ -566,6 +629,93 @@ mod tests {
         let dbg = format!("{cfg:?}");
         assert!(!dbg.contains("SUPERSECRET"), "key leaked via Debug: {dbg}");
         assert!(dbg.contains("<redacted>"));
+    }
+
+    #[test]
+    fn the_endpoint_fingerprints_what_it_resolved_and_reports_no_value() {
+        // Where the plaintext is, is where the fingerprint is computed. This
+        // process opens the store; the process that scans a workload's stdin
+        // gets a length, a hash and a category, and could not reconstruct the
+        // credential from them.
+        const SECRET: &str = "sk-live-abcdef0123456789";
+        let dir = tempdir().unwrap();
+        FileBindingStore::with_dir(dir.path().join("bindings"))
+            .put(
+                "local",
+                "openai",
+                &SecretBindingMeta {
+                    auth_type: AuthType::Bearer,
+                    allowed_hosts: vec!["api.openai.com".into()],
+                    sigv4: None,
+                },
+            )
+            .unwrap();
+        FileSecretStore::with_dir(dir.path().join("secrets"))
+            .put(
+                "local",
+                "openai",
+                &SecretBox::new(Box::new(SECRET.to_string())),
+            )
+            .unwrap();
+
+        let cfg = vsock_cfg(
+            vec![SecretBinding {
+                name: "OPENAI_API_KEY".into(),
+                source: SecretSource::Keystore {
+                    address: "openai".into(),
+                },
+            }],
+            dir.path(),
+        );
+        let fingerprints = fingerprint_bound_secrets(&cfg).unwrap();
+        assert_eq!(fingerprints.len(), 1);
+        assert_eq!(fingerprints[0].len(), SECRET.len());
+        assert_eq!(fingerprints[0].category(), SecretCategory::HostSecret);
+        assert!(
+            fingerprints[0].matches_window(SECRET.as_bytes()),
+            "the fingerprint has to recognise the value it came from, or the \
+             gate is scanning for the wrong thing"
+        );
+
+        // The handshake this rides on carries no part of the credential.
+        let wire = serde_json::to_string(&EndpointHandshake {
+            env: Vec::new(),
+            input_fingerprints: fingerprints,
+        })
+        .unwrap();
+        assert!(!wire.contains(SECRET), "got {wire}");
+        assert!(!wire.contains("sk-live"), "nor any part of it: {wire}");
+    }
+
+    #[test]
+    fn a_secret_with_no_stored_value_is_skipped_rather_than_fatal() {
+        // A credential the operator has bound but not set is one the workload
+        // cannot receive either, so there is nothing for the gate to
+        // recognise. Refusing to boot over it would be a new failure mode
+        // introduced by a backstop.
+        let dir = tempdir().unwrap();
+        FileBindingStore::with_dir(dir.path().join("bindings"))
+            .put(
+                "local",
+                "openai",
+                &SecretBindingMeta {
+                    auth_type: AuthType::Bearer,
+                    allowed_hosts: vec!["api.openai.com".into()],
+                    sigv4: None,
+                },
+            )
+            .unwrap();
+
+        let cfg = vsock_cfg(
+            vec![SecretBinding {
+                name: "OPENAI_API_KEY".into(),
+                source: SecretSource::Keystore {
+                    address: "openai".into(),
+                },
+            }],
+            dir.path(),
+        );
+        assert!(fingerprint_bound_secrets(&cfg).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
@@ -21,9 +21,9 @@ use anyhow::Context;
 
 use serde::{Deserialize, Serialize};
 
+use mvm_contract::stream::secret_fingerprint::{SecretCategory, SecretFingerprint};
 use mvm_core::crypto::secret_store::{FileSecretStore, SecretStore, default_secrets_dir};
 use mvm_core::plan::SecretBinding;
-use mvm_protocol::stream::secret_fingerprint::{SecretCategory, SecretFingerprint};
 
 use crate::keyholder::{FileBindingStore, HandedPlaceholders};
 use crate::supervisor::substitution_proxy::SubstitutionService;
@@ -328,7 +328,6 @@ pub fn build_audit_recorder(tenant: &str) -> Option<crate::supervisor::audit_rec
 mod tests {
     use super::*;
     use crate::keyholder::{BindingStore, SecretBindingMeta};
-    use mvm_contract::ir::AuthType;
     use mvm_contract::ir::AuthType;
     use mvm_contract::stream::secret_fingerprint::SecretCategory;
     use mvm_core::plan::SecretSource;

--- a/crates/mvm-hostd/tests/substitution_endpoint_bin.rs
+++ b/crates/mvm-hostd/tests/substitution_endpoint_bin.rs
@@ -107,7 +107,9 @@ fn endpoint_bin_serves_substitution_and_refuses_unbound_destination() {
     // Handshake: one JSON line of (guest var, placeholder) pairs.
     let mut line = String::new();
     stdout.read_line(&mut line).expect("read handshake line");
-    let handed: Vec<(String, String)> = serde_json::from_str(line.trim()).expect("handshake json");
+    let handshake: mvm_runtime::EndpointHandshake =
+        serde_json::from_str(line.trim()).expect("handshake json");
+    let handed = handshake.env.clone();
     assert_eq!(handed.len(), 1);
     assert_eq!(handed[0].0, "OPENAI_API_KEY");
     let placeholder = handed[0].1.clone();
@@ -206,7 +208,9 @@ fn endpoint_bin_claim10_gate_refuses_a_bound_but_unadmitted_destination() {
 
     let mut line = String::new();
     stdout.read_line(&mut line).expect("read handshake line");
-    let handed: Vec<(String, String)> = serde_json::from_str(line.trim()).expect("handshake json");
+    let handshake: mvm_runtime::EndpointHandshake =
+        serde_json::from_str(line.trim()).expect("handshake json");
+    let handed = handshake.env.clone();
     let placeholder = handed[0].1.clone();
 
     let mut conn = UnixStream::connect(&sock).expect("connect to endpoint UDS");
@@ -273,7 +277,9 @@ fn endpoint_bin_raw_no_secret_mode_handshakes_without_placeholders() {
 
     let mut line = String::new();
     stdout.read_line(&mut line).expect("read handshake line");
-    let handed: Vec<(String, String)> = serde_json::from_str(line.trim()).expect("handshake json");
+    let handshake: mvm_runtime::EndpointHandshake =
+        serde_json::from_str(line.trim()).expect("handshake json");
+    let handed = handshake.env.clone();
     assert!(
         handed.is_empty(),
         "raw no-secret endpoint should hand out no placeholders"

--- a/crates/mvm-hostd/tests/workload_input_plane.rs
+++ b/crates/mvm-hostd/tests/workload_input_plane.rs
@@ -31,7 +31,7 @@ use mvm_hostd::audit::emitter::{AuditEmitter, stream_audit};
 use mvm_hostd::plan_admission::{AdmittedPlan, InMemoryNonceLedger, SystemClock, admit_for_run};
 use mvm_hostd::stream::{
     CATEGORY_HOST_SECRET, InputAudit, InputBinding, InputGate, InputRefusal, InputRouteError,
-    InputTransport, KnownSecret, StreamPlane,
+    InputTransport, StreamPlane,
 };
 use mvm_hostd::supervisor::verify_audit_chain;
 
@@ -246,6 +246,22 @@ impl Fixture {
         Self::bound(prefix, secret, None)
     }
 
+    /// Stand in for the substitution endpoint: fingerprint `secret` and record
+    /// it exactly where the spawn path records what the endpoint reported.
+    ///
+    /// This is the whole point of routing it through the registry rather than
+    /// binding the gate directly — the production path that installs a
+    /// fingerprint set is `StreamPlane::open_input`, and a test that reached
+    /// past it would pass whether or not that call existed.
+    fn endpoint_reports(vm: &str, secret: &[u8]) {
+        let fingerprint = mvm_protocol::stream::secret_fingerprint::SecretFingerprint::of(
+            secret,
+            mvm_protocol::stream::secret_fingerprint::SecretCategory::HostSecret,
+        )
+        .expect("a non-empty secret fingerprints");
+        mvm_runtime::record_secret_fingerprints(vm, vec![fingerprint]);
+    }
+
     /// The same, on a lease short enough for a test to outwait.
     fn with_lease_ttl(prefix: &str, lease_ttl: std::time::Duration) -> Self {
         Self::bound(prefix, None, Some(lease_ttl))
@@ -260,13 +276,13 @@ impl Fixture {
         let mut binding = InputBinding::new().with_audit(InputAudit::new(
             AuditEmitter::with_dir(chain_key.clone(), chain_dir.path()).expect("open the chain"),
         ));
-        if let Some(secret) = secret {
-            binding = binding.with_secret(KnownSecret::host_material(secret));
-        }
         if let Some(ttl) = lease_ttl {
             binding = binding.with_lease_ttl(ttl);
         }
         InputGate::bind(&vm, binding);
+        if let Some(secret) = secret {
+            Self::endpoint_reports(&vm, secret);
+        }
 
         Self {
             vm,
@@ -449,8 +465,8 @@ fn a_secret_split_across_two_frames_does_not_reassemble_in_the_workload() {
     fx.plane.release(&fx.vm);
     let seen = workload_output(child);
     assert_eq!(
-        seen, b"echo ",
-        "only the bytes that were never part of the secret may arrive"
+        seen, b"",
+        "nothing may arrive: the whole first frame sat inside the carried window"
     );
     assert!(
         !seen.windows(SECRET.len()).any(|w| w == SECRET),

--- a/crates/mvm-hostd/tests/workload_input_plane.rs
+++ b/crates/mvm-hostd/tests/workload_input_plane.rs
@@ -254,9 +254,9 @@ impl Fixture {
     /// fingerprint set is `StreamPlane::open_input`, and a test that reached
     /// past it would pass whether or not that call existed.
     fn endpoint_reports(vm: &str, secret: &[u8]) {
-        let fingerprint = mvm_protocol::stream::secret_fingerprint::SecretFingerprint::of(
+        let fingerprint = mvm_contract::stream::secret_fingerprint::SecretFingerprint::of(
             secret,
-            mvm_protocol::stream::secret_fingerprint::SecretCategory::HostSecret,
+            mvm_contract::stream::secret_fingerprint::SecretCategory::HostSecret,
         )
         .expect("a non-empty secret fingerprints");
         mvm_runtime::record_secret_fingerprints(vm, vec![fingerprint]);

--- a/crates/mvm-runtime/src/builder_runner/runner.rs
+++ b/crates/mvm-runtime/src/builder_runner/runner.rs
@@ -220,10 +220,13 @@ mod tests {
             std::fs::write(f, b"x").unwrap();
         }
 
+        // A well-formed ready handshake: the spawner parses this line and
+        // fails closed on anything else, so a stub that printed prose would be
+        // testing a shape production never produces.
         let stub = tmp.path().join("stub-endpoint.sh");
         std::fs::write(
             &stub,
-            "#!/bin/sh\ncat >/dev/null\necho 'builder ready'\nsleep 30\n",
+            "#!/bin/sh\ncat >/dev/null\necho '{\"env\":[],\"input_fingerprints\":[]}'\nsleep 30\n",
         )
         .unwrap();
         {

--- a/crates/mvm-runtime/src/lib.rs
+++ b/crates/mvm-runtime/src/lib.rs
@@ -169,7 +169,9 @@ pub use workload_backend::{EgressSubstitutionTransport, WorkloadBackend};
 /// pushed onto the drive, the key is persisted host-side for the terminator
 /// endpoint. See [`substitution_spawn::build_egress_tls_delivery`].
 pub use substitution_spawn::{
-    EGRESS_CERT_DRIVE_NAME, EgressTlsDelivery, EndpointTransport, build_egress_tls_delivery,
+    EGRESS_CERT_DRIVE_NAME, EgressTlsDelivery, EndpointHandshake, EndpointTransport,
+    build_egress_tls_delivery, forget_secret_fingerprints, record_secret_fingerprints,
+    recorded_secret_fingerprints,
 };
 
 /// Per-VM broker-services spawn/reap, called from the workload backends' launch

--- a/crates/mvm-runtime/src/substitution_spawn.rs
+++ b/crates/mvm-runtime/src/substitution_spawn.rs
@@ -12,10 +12,13 @@ use crate::microvm::DriveFile;
 use anyhow::{Result, anyhow, bail};
 use mvm_core::crypto::egress_ca::EgressCa;
 use mvm_core::plan::SecretBinding;
+use mvm_protocol::stream::secret_fingerprint::SecretFingerprint;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
 use std::time::Duration;
 
 /// How the guest reaches the substitution endpoint. Backend-shaped: QEMU's
@@ -33,6 +36,76 @@ pub enum EndpointTransport {
     Vsock { port: u32 },
     /// Host UDS the per-port vsock proxy forwards to (Firecracker/libkrun).
     Uds { path: PathBuf },
+}
+
+/// The one line the endpoint writes on stdout once it is bound and ready.
+///
+/// Two things cross here and they are opposites. `env` is what the *guest*
+/// gets: opaque placeholders standing in for credentials it must never see.
+/// `input_fingerprints` is what the *host* gets: the recognisable shape of
+/// each secret this endpoint resolved, so the input gate can refuse bytes
+/// heading back into the guest that look like one.
+///
+/// The fingerprints are computed inside the endpoint because that is the one
+/// process that legitimately holds the plaintext. Nothing on this line is a
+/// secret value — see `mvm_protocol::stream::secret_fingerprint` for what a
+/// fingerprint does and does not disclose.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EndpointHandshake {
+    /// `(guest var, placeholder)` pairs to inject into the workload's launch
+    /// environment.
+    #[serde(default)]
+    pub env: Vec<(String, String)>,
+    /// One fingerprint per resolved secret, for the host→guest input gate.
+    #[serde(default)]
+    pub input_fingerprints: Vec<SecretFingerprint>,
+}
+
+/// The fingerprints the endpoint for `vm_name` reported at spawn.
+///
+/// Process-local and in-memory on purpose. Only the invocation that admits and
+/// boots a workload can stream into its stdin — every other entry point holds
+/// no plan to write under and refuses — so the process that spawned the
+/// endpoint is exactly the process that will later open the input gate.
+/// Persisting these would widen a length-and-hash disclosure to every reader
+/// of the state dir and buy reachability that nothing uses.
+///
+/// Empty for a VM this process did not boot, or one whose plan carried no
+/// secrets: both mean there is nothing for the gate to recognise.
+#[must_use]
+pub fn recorded_secret_fingerprints(vm_name: &str) -> Vec<SecretFingerprint> {
+    fingerprints().get(vm_name).cloned().unwrap_or_default()
+}
+
+/// Record what the endpoint for `vm_name` reported, replacing any earlier set:
+/// a restarted VM's secrets are whatever its new endpoint resolved.
+///
+/// Public so a test can stand in for an endpoint it cannot spawn. Injecting a
+/// fingerprint here is not a privilege: fingerprints only ever cause the input
+/// gate to *refuse*, so the worst a caller can do with this is close a stdin
+/// that would otherwise have been open.
+pub fn record_secret_fingerprints(vm_name: &str, reported: Vec<SecretFingerprint>) {
+    fingerprints().insert(vm_name.to_string(), reported);
+}
+
+/// Drop `vm_name`'s fingerprints — the teardown half of the record made at
+/// spawn, called wherever the endpoint itself is reaped.
+pub fn forget_secret_fingerprints(vm_name: &str) {
+    fingerprints().remove(vm_name);
+}
+
+/// The per-process fingerprint registry.
+///
+/// Recovered rather than propagated on poison: a panicking spawn must not take
+/// every other VM's input gate down with it, and the map is a plain table a
+/// partial update cannot leave inconsistent.
+fn fingerprints() -> MutexGuard<'static, HashMap<String, Vec<SecretFingerprint>>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, Vec<SecretFingerprint>>>> = OnceLock::new();
+    REGISTRY
+        .get_or_init(Mutex::default)
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
 }
 
 /// The per-VM egress intermediate cert lands in the guest's `mvm-secrets`
@@ -266,8 +339,15 @@ pub fn spawn_substitution_endpoint(params: SubstitutionSpawnParams<'_>) -> Resul
     if let Some(parent) = env_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| anyhow!("create {}: {e}", parent.display()))?;
     }
-    std::fs::write(&env_path, handshake.trim().as_bytes())
+    // The two halves part company here. Only `env` is persisted, because only
+    // the guest launch env needs to survive into a later `mvmctl` invocation;
+    // the fingerprints stay in this process, which is the one that will open
+    // the input gate.
+    let env_json = serde_json::to_vec(&handshake.env)
+        .map_err(|e| anyhow!("serialize substitution env for {}: {e}", env_path.display()))?;
+    std::fs::write(&env_path, &env_json)
         .map_err(|e| anyhow!("write {}: {e}", env_path.display()))?;
+    record_secret_fingerprints(vm_name, handshake.input_fingerprints);
     process_guard.mark_env_written();
     process_guard.defuse();
     // Detach: drop the child handle without killing. The endpoint runs
@@ -325,15 +405,16 @@ impl Drop for SpawnedEndpointGuard {
     }
 }
 
-/// Read the endpoint's one-line ready handshake from its stdout within
-/// `timeout`. A blocking pipe read can't be timed directly, so read on a
-/// helper thread and bound the wait; on timeout / EOF-without-line, SIGKILL
-/// the endpoint and fail (the caller rolls back the VM — fail closed).
+/// Read and parse the endpoint's one-line ready handshake from its stdout
+/// within `timeout`. A blocking pipe read can't be timed directly, so read on
+/// a helper thread and bound the wait; on timeout / EOF-without-line / a line
+/// that is not a handshake, SIGKILL the endpoint and fail (the caller rolls
+/// back the VM — fail closed).
 fn read_handshake_line(
     stdout: std::process::ChildStdout,
     pid: u32,
     timeout: Duration,
-) -> Result<String> {
+) -> Result<EndpointHandshake> {
     use std::io::{BufRead, BufReader};
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
@@ -342,7 +423,10 @@ fn read_handshake_line(
         let _ = tx.send(res);
     });
     match rx.recv_timeout(timeout) {
-        Ok(Ok(line)) if !line.trim().is_empty() => Ok(line),
+        Ok(Ok(line)) if !line.trim().is_empty() => serde_json::from_str(line.trim()).map_err(|e| {
+            kill(pid as libc::pid_t, libc::SIGKILL);
+            anyhow!("parse substitution endpoint handshake: {e}")
+        }),
         Ok(Ok(_)) => {
             kill(pid as libc::pid_t, libc::SIGKILL);
             bail!("substitution endpoint closed stdout without a ready handshake")
@@ -405,6 +489,9 @@ pub fn reap_substitution_endpoint(state_dir: &Path, vm_name: &str) {
     }
     let _ = std::fs::remove_file(state_dir.join(SUBST_PID_FILE));
     let _ = std::fs::remove_file(mvm_core::config::vm_substitution_env_path(vm_name));
+    // The endpoint's secrets are gone; the shapes the gate recognised them by
+    // go with them, so a recycled VM name cannot inherit them.
+    forget_secret_fingerprints(vm_name);
 }
 
 // ── pid helpers (local copies — backend modules keep theirs private) ──
@@ -427,6 +514,12 @@ fn kill(pid: libc::pid_t, sig: libc::c_int) {
 mod tests {
     use super::*;
     use mvm_core::util::test_env::TestEnv;
+    use mvm_protocol::stream::secret_fingerprint::SecretCategory;
+
+    /// What a stub endpoint prints as its ready line: a well-formed handshake
+    /// with one placeholder and one fingerprint, so the spawn path exercises
+    /// the real split rather than a shape it never sees in production.
+    const READY_HANDSHAKE: &str = r#"{"env":[["OPENAI_API_KEY","mvm-secret-ab"]],"input_fingerprints":[{"len":7,"hash":42,"category":"host-secret"}]}"#;
 
     // `stop_vm` reaps the moat BEFORE its not-running early return (so a crashed
     // VM's decrypted-secret endpoint can't outlive the guest). That ordering is
@@ -465,8 +558,9 @@ mod tests {
         std::fs::write(
             &stub,
             format!(
-                "#!/bin/sh\ncat > {}\necho 'ready handshake'\n",
-                cfg_out.display()
+                "#!/bin/sh\ncat > {}\necho '{}'\n",
+                cfg_out.display(),
+                READY_HANDSHAKE
             ),
         )
         .unwrap();
@@ -508,6 +602,129 @@ mod tests {
     }
 
     #[test]
+    fn the_handshakes_two_halves_go_to_two_different_places() {
+        // The placeholders are the guest's and must survive into a later
+        // `mvmctl` invocation, so they are persisted. The fingerprints are the
+        // host's and must not, so they stay in this process. Sending either
+        // one where the other goes is the whole failure this split prevents:
+        // the sidecar would carry a length-and-hash disclosure to every reader
+        // of the state dir, and the gate would find nothing to scan for.
+        let _g = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let mut env = TestEnv::new();
+        let dir = std::env::temp_dir().join(format!("mvm-subst-split-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        env.set("MVM_HOME", &dir);
+
+        let stub = dir.join("stub-endpoint.sh");
+        std::fs::write(
+            &stub,
+            format!("#!/bin/sh\ncat >/dev/null\necho '{READY_HANDSHAKE}'\n"),
+        )
+        .unwrap();
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        env.set("MVM_SUBSTITUTION_ENDPOINT_PATH", &stub);
+
+        let vm = "handshake-split-vm";
+        let env_path = mvm_core::config::vm_substitution_env_path(vm);
+        if let Some(parent) = env_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let redaction = mvm_core::policy::RedactionPolicy::default();
+        spawn_substitution_endpoint(SubstitutionSpawnParams {
+            vm_name: vm,
+            state_dir: &dir,
+            tenant: "tenant-x",
+            secrets: &[],
+            redaction: &redaction,
+            transport: EndpointTransport::Uds {
+                path: dir.join("vsock-5253.sock"),
+            },
+            terminator_listen: None,
+            tls_intermediate: None,
+            network_policy: None,
+            raw_egress: false,
+        })
+        .expect("spawn with stub endpoint should succeed");
+
+        let persisted = std::fs::read_to_string(&env_path).expect("the env sidecar");
+        let placeholders: Vec<(String, String)> =
+            serde_json::from_str(&persisted).expect("the sidecar keeps its array shape");
+        assert_eq!(
+            placeholders,
+            vec![("OPENAI_API_KEY".to_string(), "mvm-secret-ab".to_string())]
+        );
+        assert!(
+            !persisted.contains("input_fingerprints") && !persisted.contains("host-secret"),
+            "no fingerprint may be written to disk: {persisted}"
+        );
+
+        let recorded = recorded_secret_fingerprints(vm);
+        assert_eq!(recorded.len(), 1, "the gate's set came off the handshake");
+        assert_eq!(recorded[0].len(), 7);
+        assert_eq!(recorded[0].category(), SecretCategory::HostSecret);
+
+        // And the reap that ends the endpoint ends the set with it, so a
+        // recycled VM name cannot inherit a dead workload's shapes.
+        reap_substitution_endpoint(&dir, vm);
+        assert!(recorded_secret_fingerprints(vm).is_empty());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_handshake_that_is_not_a_handshake_fails_the_spawn() {
+        // Fail closed. A line the spawner could not parse used to be written
+        // to the env sidecar verbatim, so a broken endpoint produced a VM that
+        // booted with no placeholders and no fingerprints and said nothing.
+        let _g = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let mut env = TestEnv::new();
+        let dir = std::env::temp_dir().join(format!("mvm-subst-badline-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        env.set("MVM_HOME", &dir);
+
+        let stub = dir.join("stub-endpoint.sh");
+        std::fs::write(&stub, "#!/bin/sh\ncat >/dev/null\necho 'ready handshake'\n").unwrap();
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        env.set("MVM_SUBSTITUTION_ENDPOINT_PATH", &stub);
+
+        let vm = "handshake-garbage-vm";
+        let redaction = mvm_core::policy::RedactionPolicy::default();
+        let err = spawn_substitution_endpoint(SubstitutionSpawnParams {
+            vm_name: vm,
+            state_dir: &dir,
+            tenant: "tenant-x",
+            secrets: &[],
+            redaction: &redaction,
+            transport: EndpointTransport::Uds {
+                path: dir.join("vsock-5253.sock"),
+            },
+            terminator_listen: None,
+            tls_intermediate: None,
+            network_policy: None,
+            raw_egress: false,
+        })
+        .expect_err("an unparseable handshake is not a ready endpoint");
+        assert!(
+            err.to_string()
+                .contains("parse substitution endpoint handshake"),
+            "got {err}"
+        );
+        assert!(recorded_secret_fingerprints(vm).is_empty());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn spawn_failure_after_pid_write_rolls_back_the_endpoint_sidecar() {
         let _g = crate::base::runtime_meta::HOME_TEST_LOCK
             .lock()
@@ -532,9 +749,10 @@ mod tests {
         std::fs::write(
             &stub,
             format!(
-                "#!/bin/sh\ncat >/dev/null\necho $$ > {}\ntrap 'echo stopped > {}; exit 0' TERM\necho 'ready handshake'\nwhile :; do sleep 1; done\n",
+                "#!/bin/sh\ncat >/dev/null\necho $$ > {}\ntrap 'echo stopped > {}; exit 0' TERM\necho '{}'\nwhile :; do sleep 1; done\n",
                 pid_capture.display(),
-                stopped.display()
+                stopped.display(),
+                READY_HANDSHAKE
             ),
         )
         .unwrap();

--- a/crates/mvm-runtime/src/substitution_spawn.rs
+++ b/crates/mvm-runtime/src/substitution_spawn.rs
@@ -81,10 +81,16 @@ pub fn recorded_secret_fingerprints(vm_name: &str) -> Vec<SecretFingerprint> {
 /// Record what the endpoint for `vm_name` reported, replacing any earlier set:
 /// a restarted VM's secrets are whatever its new endpoint resolved.
 ///
-/// Public so a test can stand in for an endpoint it cannot spawn. Injecting a
-/// fingerprint here is not a privilege: fingerprints only ever cause the input
-/// gate to *refuse*, so the worst a caller can do with this is close a stdin
-/// that would otherwise have been open.
+/// Public so a test can stand in for an endpoint it cannot spawn. Not a
+/// privilege boundary — every caller is already inside the process that booted
+/// the VM — but the worst case runs the other way from the obvious one.
+/// *Adding* a fingerprint only ever makes the gate refuse more. *Replacing* is
+/// the sharp edge: this overwrites rather than merges, so an in-process caller
+/// passing an empty set leaves the next `open_input` with nothing to scan
+/// against, and the gate goes quiet without any refusal to notice. Overwriting
+/// is still right — a set that could only grow would outlive the secrets it
+/// stood for — so the protection is that the endpoint spawn is the one caller
+/// that writes it in production.
 pub fn record_secret_fingerprints(vm_name: &str, reported: Vec<SecretFingerprint>) {
     fingerprints().insert(vm_name.to_string(), reported);
 }

--- a/crates/mvm-runtime/src/substitution_spawn.rs
+++ b/crates/mvm-runtime/src/substitution_spawn.rs
@@ -10,9 +10,9 @@
 
 use crate::microvm::DriveFile;
 use anyhow::{Result, anyhow, bail};
+use mvm_contract::stream::secret_fingerprint::SecretFingerprint;
 use mvm_core::crypto::egress_ca::EgressCa;
 use mvm_core::plan::SecretBinding;
-use mvm_protocol::stream::secret_fingerprint::SecretFingerprint;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -48,7 +48,7 @@ pub enum EndpointTransport {
 ///
 /// The fingerprints are computed inside the endpoint because that is the one
 /// process that legitimately holds the plaintext. Nothing on this line is a
-/// secret value — see `mvm_protocol::stream::secret_fingerprint` for what a
+/// secret value — see `mvm_contract::stream::secret_fingerprint` for what a
 /// fingerprint does and does not disclose.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -519,8 +519,8 @@ fn kill(pid: libc::pid_t, sig: libc::c_int) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_contract::stream::secret_fingerprint::SecretCategory;
     use mvm_core::util::test_env::TestEnv;
-    use mvm_protocol::stream::secret_fingerprint::SecretCategory;
 
     /// What a stub endpoint prints as its ready line: a well-formed handshake
     /// with one placeholder and one fingerprint, so the spawn path exercises

--- a/model/claims.toml
+++ b/model/claims.toml
@@ -247,17 +247,23 @@ level = "build"
 witness_kinds = ["fn"]
 suite = "workload_input"
 statement = "Workload stdin is grant-gated, single-writer, secret-scanned across frames, and every refusal is audited"
-# Preview, not shipped: one leg still has no production caller — the
-# known-secret set is empty on every real VM because `InputGate::bind` is
-# never called outside tests, so the scan's refusal has never fired in
-# production. The operator surface and the shell-entrypoint refusal are now
-# live. The limits are stated in full, marked closed or open individually, in
-# the ADR-001 ledger's "Preview 17 limits" note; do not read this row as
-# enforced without it.
+# Preview, not shipped. Every leg now has a production caller: the operator
+# surface, the shell-entrypoint refusal, and the secret scan, whose set the
+# per-VM substitution endpoint fingerprints and `StreamPlane::open_input`
+# installs. What keeps it a preview is what the enforcement is rather than
+# whether it runs — a fingerprint match is a length-and-hash match, not an
+# identity, and encoding, derivation and a window-straddling split defeat the
+# scan permanently. The limits are stated in full, marked closed or open
+# individually, in the ADR-001 ledger's "Preview 17 limits" note; do not read
+# this row as enforced without it.
 witnesses = [
     "fn:input_is_refused_without_a_plan_grant",
     "fn:a_second_writer_is_refused_while_the_lease_is_held",
     "fn:secret_material_split_across_frames_is_still_refused",
     "fn:every_refusal_is_audited",
     "fn:a_shell_entrypoint_with_the_grant_is_refused_and_names_the_reason",
+    "fn:the_endpoint_fingerprints_what_it_resolved_and_reports_no_value",
+    "fn:the_handshakes_two_halves_go_to_two_different_places",
+    "fn:a_secret_split_across_two_frames_does_not_reassemble_in_the_workload",
+    "fn:a_fingerprint_refusal_does_not_claim_the_bytes_are_the_secret",
 ]

--- a/model/claims.toml
+++ b/model/claims.toml
@@ -253,7 +253,12 @@ statement = "Workload stdin is grant-gated, single-writer, secret-scanned across
 # installs. What keeps it a preview is what the enforcement is rather than
 # whether it runs — a fingerprint match is a length-and-hash match, not an
 # identity, and encoding, derivation and a window-straddling split defeat the
-# scan permanently. The limits are stated in full, marked closed or open
+# scan permanently. "Across frames" is exact within a writer's burst and stops
+# there: because the scan holds fingerprints rather than values it withholds a
+# blanket `longest_secret - 1` tail — precision would be a prefix oracle — and
+# the gate releases that tail on writer silence, so a secret split across a
+# pause longer than the threshold is missed (ADR-001 limit 6, whose residual
+# sits inside limit 4). The limits are stated in full, marked closed or open
 # individually, in the ADR-001 ledger's "Preview 17 limits" note; do not read
 # this row as enforced without it.
 witnesses = [
@@ -266,4 +271,7 @@ witnesses = [
     "fn:the_handshakes_two_halves_go_to_two_different_places",
     "fn:a_secret_split_across_two_frames_does_not_reassemble_in_the_workload",
     "fn:a_fingerprint_refusal_does_not_claim_the_bytes_are_the_secret",
+    "fn:a_secret_split_across_two_writes_inside_the_threshold_is_still_refused",
+    "fn:the_idle_release_does_not_depend_on_what_the_withheld_bytes_are",
+    "fn:what_is_withheld_is_a_length_and_never_a_verdict_about_the_bytes",
 ]

--- a/public/src/content/docs/guides/workload-input.md
+++ b/public/src/content/docs/guides/workload-input.md
@@ -87,30 +87,51 @@ can be offered again. A workload that has stopped reading its stdin produces a
 
 ## The secret scan
 
-Secrets known to the host are registered against the VM, and the gate scans the
-byte stream — not each frame in isolation — before anything is delivered:
+The gate scans the byte stream — not each frame in isolation — before anything
+is delivered:
 
-- A tail that is still a live *prefix* of a known secret is **withheld**, not
-  shipped and then regretted. It is released at close, before the workload sees
-  EOF, if the rest of the stream turns out not to complete the match.
-- A completed match refuses the session outright, zeroizes the buffer, and
-  audits the refusal with the secret's category — never its value.
+- A tail the scanner must still be able to see is **withheld**, not shipped and
+  then regretted. It is released on the next write, or at close before the
+  workload sees EOF, once the rest of the stream turns out not to complete a
+  match.
+- A match refuses the session outright, zeroizes the buffer, and audits the
+  refusal with the secret's category — never its value.
 
 Splitting a secret across frames therefore does not reassemble it inside the
 workload, down to one byte per frame.
 
+### What the gate scans against
+
+Not the secrets. The gate runs in the `mvmctl` process, and the substitution
+endpoint that resolves raw credentials runs as a separate process on purpose —
+that separation is what keeps a credential out of everything but the one place
+that needs it. So the endpoint computes a **fingerprint** for each secret it
+resolves — a length, a 64-bit rolling hash and a category — and reports the
+fingerprints at startup. `mvmctl` holds those and nothing else.
+
+Two consequences worth knowing before you rely on it:
+
+**A fingerprint match is a hash match.** Two different byte sequences of the
+same length can match one. The gate refuses either way, because failing closed
+is the right direction, and the refusal says a fingerprint matched rather than
+that your bytes are a secret. If you are certain they are not, that is what a
+collision looks like from the outside.
+
+**A secret-bearing VM lags by up to `longest_secret - 1` bytes.** Without the
+plaintext the scanner cannot tell a live secret prefix from an innocent tail, so
+it holds a fixed window back until your next write or your close. Bounded, never
+dropped, and charged only to workloads whose plan carries a secret — a VM with
+none scans nothing and lags not at all. (The alternative, fingerprinting each
+secret's prefixes, would recover the credential a byte at a time from the
+fingerprint set. See [ADR-035](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/035-workload-stream-plane.md).)
+
 ### What the scan is worth
-
-Two things you must not read into it:
-
-**The known-secret set is empty on every real VM.** The only way a secret is
-registered has no caller outside tests. The scanner is correct and it currently
-has nothing to match against.
 
 **It is a backstop, not a defence.** Base64, hex, URL-escaping, any derivation
 (a hash, a signature, a substring), an unregistered secret, and a split that
 straddles the scan window all pass straight through. It catches a confused
-host-side caller. It does not catch a determined one.
+host-side caller. It does not catch a determined one. A populated fingerprint
+set makes the scan *work*; it does not make it stronger than this.
 
 The real guarantee is upstream and structural: the host has no reason to send a
 secret into a guest at all, because credentials are substituted on the
@@ -207,9 +228,10 @@ That trade is recorded in
 and the claim rows and their limits live in
 [ADR-001](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/001-microvm-security-posture.md).
 The input channel is tracked there as claim 17 at status `Preview`. It stays a
-preview even though the channel now ships: the grant, the lease, the EOF and the
-shell refusal all have production callers, but the secret scan still has none,
-and a claim is worth what its weakest enforced leg is worth.
+preview even though every leg — the grant, the lease, the EOF, the shell refusal
+and the secret scan — now has a production caller: what holds it back is what
+the scan *is* (a fingerprint match, defeated by encoding and derivation), not
+whether it runs.
 
 ## Limits, all of them true today
 
@@ -218,10 +240,10 @@ and a claim is worth what its weakest enforced leg is worth.
    VM and dispatches the call, so the plan authorizing the writes is in the
    hands of the process making them. `--attach`, `session attach`, and any
    other process reaching a machine it did not boot cannot stream.
-2. **The secret scan is inert.** No production code registers a secret, so the
-   known-secret set is empty on every real VM. The scanner is correct and has
-   nothing to match against, so the refusal it exists to produce has never
-   fired outside tests.
+2. **The scan matches fingerprints, not values.** A collision refuses a frame
+   that carried no secret, and the withheld window costs a secret-bearing VM up
+   to `longest_secret - 1` bytes of lag. Both are stated above; both fail in
+   the safe direction.
 3. **The scan is a backstop.** Encoding, derivation, and a window-straddling
    split defeat it. This one is permanent; it is a property of scanning, not a
    gap to close.
@@ -229,9 +251,9 @@ and a claim is worth what its weakest enforced leg is worth.
    image's own build-time record. A wrapper that `exec`s a shell still defeats
    it; see [above](#the-refusal-is-a-heuristic-treat-it-as-one).
 
-Limits 2 and 4 are what keep claim 17 at `Preview`: an enforcement path with no
-production caller (the scan) and a heuristic control are not the same thing as a
-proven guarantee. Limits 1 and 3 stay whatever happens to the other two.
+Limits 2, 3 and 4 are what keep claim 17 at `Preview`: a hash-based scan that
+encoding defeats, and a heuristic control, are not the same thing as a proven
+guarantee. Limit 1 stays whatever happens to the others.
 
 ## See also
 

--- a/public/src/content/docs/guides/workload-input.md
+++ b/public/src/content/docs/guides/workload-input.md
@@ -117,21 +117,37 @@ is the right direction, and the refusal says a fingerprint matched rather than
 that your bytes are a secret. If you are certain they are not, that is what a
 collision looks like from the outside.
 
-**A secret-bearing VM lags by up to `longest_secret - 1` bytes.** Without the
-plaintext the scanner cannot tell a live secret prefix from an innocent tail, so
-it holds a fixed window back until your next write or your close. Bounded, never
-dropped, and charged only to workloads whose plan carries a secret — a VM with
-none scans nothing and lags not at all. (The alternative, fingerprinting each
-secret's prefixes, would recover the credential a byte at a time from the
-fingerprint set. See [ADR-035](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/035-workload-stream-plane.md).)
+**On a secret-bearing VM your last `longest_secret - 1` bytes arrive about 50ms
+late.** Without the plaintext the scanner cannot tell a live secret prefix from
+an innocent tail, so it holds a fixed window back — with a 40-byte bound secret
+that is 39 bytes, wider than most request lines. Your next write pushes it out;
+if there is no next write, the gate releases it once you have been quiet for
+50ms. So a typed line reaches the workload a fraction of a second after you
+stop typing rather than when you type the next one, and nothing is ever lost.
+A VM whose plan carries no secret scans nothing and withholds nothing.
+
+The release is on elapsed time only — never on what your bytes are. That is
+deliberate and it is the reason the window is a blanket one: a scanner that
+withheld only the tails that could still complete a secret would be answering
+"is this a live prefix?" for every byte you sent, which is a way to read the
+credential out one byte at a time. The same reasoning rules out fingerprinting
+each secret's prefixes, which is the repair that looks free.
+
+The residual: a secret you split with a pause longer than 50ms in the middle is
+no longer contiguous to the scanner and goes through. That takes deliberately
+pausing mid-credential — see [what the scan is worth](#what-the-scan-is-worth)
+below, and
+[ADR-035](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/035-workload-stream-plane.md).
 
 ### What the scan is worth
 
 **It is a backstop, not a defence.** Base64, hex, URL-escaping, any derivation
-(a hash, a signature, a substring), an unregistered secret, and a split that
-straddles the scan window all pass straight through. It catches a confused
-host-side caller. It does not catch a determined one. A populated fingerprint
-set makes the scan *work*; it does not make it stronger than this.
+(a hash, a signature, a substring), an unregistered secret, a split that
+straddles the scan window, and a split you separate with a deliberate pause all
+pass straight through. It catches a confused host-side caller. It does not catch
+a determined one — anyone patient enough to pause mid-credential would simply
+base64 it. A populated fingerprint set makes the scan *work*; it does not make
+it stronger than this.
 
 The real guarantee is upstream and structural: the host has no reason to send a
 secret into a guest at all, because credentials are substituted on the
@@ -241,19 +257,25 @@ whether it runs.
    hands of the process making them. `--attach`, `session attach`, and any
    other process reaching a machine it did not boot cannot stream.
 2. **The scan matches fingerprints, not values.** A collision refuses a frame
-   that carried no secret, and the withheld window costs a secret-bearing VM up
-   to `longest_secret - 1` bytes of lag. Both are stated above; both fail in
-   the safe direction.
-3. **The scan is a backstop.** Encoding, derivation, and a window-straddling
-   split defeat it. This one is permanent; it is a property of scanning, not a
-   gap to close.
-4. **The shell refusal is a heuristic over argv**, and the argv comes from the
+   that carried no secret. Stated above, and it fails in the safe direction.
+3. **On a secret-bearing VM your last bytes are ~50ms late.** The withheld
+   window is `longest_secret - 1` bytes, wider than a typed request line, so a
+   line arrives shortly after you stop typing rather than the instant you send
+   it. Nothing is lost, and a VM with no bound secret waits not at all. The
+   window is blanket rather than precise on purpose: a precise one would answer
+   "is this a live prefix?" for every byte you sent. Stated above.
+4. **The scan is a backstop.** Encoding, derivation, a window-straddling split,
+   and a split separated by a pause longer than the release threshold all
+   defeat it. This one is permanent; it is a property of scanning, not a gap to
+   close.
+5. **The shell refusal is a heuristic over argv**, and the argv comes from the
    image's own build-time record. A wrapper that `exec`s a shell still defeats
    it; see [above](#the-refusal-is-a-heuristic-treat-it-as-one).
 
-Limits 2, 3 and 4 are what keep claim 17 at `Preview`: a hash-based scan that
+Limits 2, 4 and 5 are what keep claim 17 at `Preview`: a hash-based scan that
 encoding defeats, and a heuristic control, are not the same thing as a proven
-guarantee. Limit 1 stays whatever happens to the others.
+guarantee. Limit 3 is the price of the first two rather than a defect of its
+own. Limit 1 stays whatever happens to the others.
 
 ## See also
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -158,9 +158,9 @@ for detailed scope and acceptance criteria.
         grant for a shell-shaped entrypoint; and the claims ledger — claim 15
         reworded (it used to hold by *absence*, there being no host→guest byte
         path at all, and now holds by *policy*) and claim 17 added at status
-        `Preview` with a four-item limits note (T17 below closed two of the
-        four; the known-secret set being empty on every real VM is what keeps
-        the row at `Preview`)
+        `Preview` with a limits note (T17 below closed two; plan 293 WS1 closed
+        the third by giving the scan fingerprints; the two that remain are
+        permanent properties of hashing and of scanning)
   - [x] T16 — the input plane's documentation: a sibling guide
         `guides/workload-input.md` (grant, single-writer lease, secret scan,
         explicit EOF, the `--prod` shell refusal stated as the heuristic it is,
@@ -186,9 +186,7 @@ for detailed scope and acceptance criteria.
         `mvm-meta.json` sidecar — a new `entrypointArgv` field written by both
         the `mkGuest` and OCI build paths, because the host cannot read inside a
         materialized ext4 — and admission **fails closed** when it cannot
-        resolve one, so the shell refusal cannot go dormant again. Claim 17
-        stays `Preview` on limit 1 alone: `InputGate::bind` still has no
-        production caller, so the secret scan is inert on every real VM
+        resolve one, so the shell refusal cannot go dormant again
   - [~] Residual after T9b/T9d: T9d closed the *seal* half — a detached run's
         transcript is now sealed by whatever stops the VM. The *follow* half
         remains: the console follower still dies with the starting process, so

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -49,7 +49,7 @@ for detailed scope and acceptance criteria.
       (`specs/plans/289-host-side-machine-logs.md`)
   - [x] Read backend-captured logs from the isolated host VM state directory
   - [x] Preserve log flags without shell interpolation; follow mode honors the
-        requested line count. Superseded by plan 283, which replaced the reader:
+        requested line count. Superseded by plan 295, which replaced the reader:
         `--lines`/`--follow`/`--hypervisor` and the explicit missing-log error
         survive, the pre-split `firecracker.log` substitution does not
   - [x] Cover host-only CLI behavior and log resolution with regression tests
@@ -106,8 +106,8 @@ for detailed scope and acceptance criteria.
   - [x] MinIO integration plus Linux/KVM persistence and restore proof
   - [x] Reconcile rejected speculative clauses and close #2040 with evidence
 
-- [~] Plan 283 — Workload stream plane
-      (`specs/plans/283-workload-stream-plane.md`)
+- [~] Plan 295 — Workload stream plane
+      (`specs/plans/295-workload-stream-plane.md`)
   - [x] T1–T3 — stream record DTOs + chain verify; transcript stream
         directions and per-chunk linkage; ring retention
   - [x] T4–T5b — guest pump emits as produced; fd-3 control records; the

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,10 @@
 # Refactor status
 
+<<<<<<< HEAD
 Last updated: 2026-08-05
+=======
+Last updated: 2026-08-04
+>>>>>>> b1153c154 (fix(hostd): release the withheld tail on writer silence)
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -159,8 +163,9 @@ for detailed scope and acceptance criteria.
         reworded (it used to hold by *absence*, there being no host→guest byte
         path at all, and now holds by *policy*) and claim 17 added at status
         `Preview` with a limits note (T17 below closed two; plan 293 WS1 closed
-        the third by giving the scan fingerprints; the two that remain are
-        permanent properties of hashing and of scanning)
+        the third by giving the scan fingerprints, and its follow-on closed the
+        blanket carry's stall with a content-independent idle release; the two
+        that remain are permanent properties of hashing and of scanning)
   - [x] T16 — the input plane's documentation: a sibling guide
         `guides/workload-input.md` (grant, single-writer lease, secret scan,
         explicit EOF, the `--prod` shell refusal stated as the heuristic it is,

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -477,10 +477,16 @@ updates only its own entry below.
       — fingerprints each secret it resolves and reports `(length, rolling
       hash, category)` on its ready handshake, and `StreamPlane::open_input`
       installs that set on the gate. No plaintext crosses into `mvmctl`.
+      Holding fingerprints instead of values costs the scan its live-prefix
+      precision, so it withholds a blanket `longest_secret - 1` tail — a
+      *precise* carry would make withhold-or-deliver depend on content, which
+      is a prefix oracle — and the gate releases that tail after 50ms of writer
+      silence, on elapsed time alone, which is what lets a workload reading one
+      request line at a time ever receive one.
       Claim 17 stays `Preview`, now for what the enforcement *is* rather than
       whether it runs: a fingerprint match is a length-and-hash match, not an
-      identity, and encoding, derivation and a window-straddling split defeat
-      the scan permanently.
+      identity, and encoding, derivation, a window-straddling split and a split
+      the sender separated by a deliberate pause defeat the scan permanently.
 
 - [x] BDD / conformance integration: introduced `model/*.toml` as the single
       source for conformance claims, generated `CONFORMANCE.md`, and added

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -71,7 +71,7 @@
       explicit-root config helper (`vms_dir_at` / `vm_state_dir_at`), and the
       CLI subprocess receives an isolated home. Workspace tests, check,
       all-target clippy, formatting, and both home policy gates are green.
-      The reader itself was then replaced by plan 283's stream plane, which
+      The reader itself was then replaced by plan 295's stream plane, which
       keeps the host-side property and reads the files in-process rather than
       spawning `tail`; see that plan doc for which of 289's constraints the
       replacement holds.
@@ -442,7 +442,7 @@ updates only its own entry below.
       and refuses; native Windows is not claimed.
 
 - [~] Workload stream plane — 22 tasks, **Phase 1 complete, Phase 2 landed
-      dormant**. Tracked in `specs/plans/283-workload-stream-plane.md` and
+      dormant**. Tracked in `specs/plans/295-workload-stream-plane.md` and
       `specs/adrs/035-workload-stream-plane.md`.
       Phase 1 (output, T1–T10 plus T5b/T6b/T9b–T9d) ships: the guest pump emits
       as produced instead of buffering to exit, the 1 MiB cap that *killed* a

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -472,9 +472,15 @@ updates only its own entry below.
       because the host cannot read inside a materialized ext4), and admission
       **fails closed** when it cannot resolve one — so the shell refusal cannot
       go dormant again by a caller forgetting to resolve.
-      Claim 17 stays `Preview` on one limit: `InputGate::bind` has no
-      production caller, so the secret scan's known set is empty on every real
-      VM and its refusal has never fired outside tests.
+      Plan 293 WS1 then closed the last dormant leg: the per-VM substitution
+      endpoint — the one process holding a workload's credentials in the clear
+      — fingerprints each secret it resolves and reports `(length, rolling
+      hash, category)` on its ready handshake, and `StreamPlane::open_input`
+      installs that set on the gate. No plaintext crosses into `mvmctl`.
+      Claim 17 stays `Preview`, now for what the enforcement *is* rather than
+      whether it runs: a fingerprint match is a length-and-hash match, not an
+      identity, and encoding, derivation and a window-straddling split defeat
+      the scan permanently.
 
 - [x] BDD / conformance integration: introduced `model/*.toml` as the single
       source for conformance claims, generated `CONFORMANCE.md`, and added

--- a/specs/adrs/001-microvm-security-posture.md
+++ b/specs/adrs/001-microvm-security-posture.md
@@ -630,16 +630,41 @@ this table exists to prevent.
    compared rather than asserting the bytes are the secret
    (`fn:a_fingerprint_refusal_does_not_claim_the_bytes_are_the_secret`). The
    cost is the mirror image of limit 4: limit 4 is what the scan misses, this
-   is what it may refuse without cause. A second cost rides with it: unable to
-   tell a live secret prefix from an innocent tail, the scanner withholds a
-   fixed `longest_secret - 1` bytes of every write on a secret-bearing VM
-   until the next write or the close. Bounded, never dropped, and charged only
-   to workloads that have a secret to leak.
+   is what it may refuse without cause.
+6. **The carry is blanket, and is released on silence. (CLOSED; its residual
+   lives inside limit 4.)** Unable to tell a live secret prefix from an
+   innocent tail, the scanner withholds a fixed `longest_secret - 1` bytes of
+   every write on a secret-bearing VM. That imprecision is deliberate. A
+   *precise* carry would make the withhold-or-deliver decision depend on
+   content, and that decision is observable: a caller holding the input grant
+   feeds one byte, watches whether anything came out, and walks a 40-byte
+   credential out in about 40·256 probes rather than 256^40 — a
+   secret-extraction path against exactly what row 13 protects. The blanket
+   carry is what denies that signal.
+   Its cost was a deadlock rather than latency: with a 40-byte bound secret the
+   carry is 39, so a typed 11-byte request line delivered **zero** bytes, a
+   workload answering per line never answered, and the write that would release
+   the held tail never came. The gate now releases the withheld tail after
+   `DEFAULT_IDLE_FLUSH_AFTER` (50ms) of writer silence, on **elapsed time
+   alone** — never on what the bytes are, which is what keeps the oracle shut
+   (`fn:the_idle_release_does_not_depend_on_what_the_withheld_bytes_are`,
+   `fn:what_is_withheld_is_a_length_and_never_a_verdict_about_the_bytes`). The
+   release cannot hand over a secret: what it releases already survived a scan
+   of the buffer it came from. What it costs is context — a secret split across
+   a silence longer than the threshold is no longer contiguous in the scanner
+   and is missed
+   (`fn:a_secret_split_across_two_writes_inside_the_threshold_is_still_refused`
+   pins the covered side;
+   `fn:a_secret_split_across_the_idle_gap_is_missed_and_that_is_the_price` pins
+   the uncovered one). That needs the *sender* to pause mid-credential, which a
+   confused caller does not do and a determined one does not need — base64
+   already defeats the scan — so it sits inside limit 4 and does not widen it.
 
 Limits 4 and 5 are permanent — properties of scanning and of hashing, not gaps
-to fix. Promotion of row 17 to a numbered claim is therefore a decision about
-whether numbered prose can carry them and the argv heuristic in limit 2, not a
-decision waiting on work.
+to fix. Limit 6 is closed; what it leaves behind is a residual inside limit 4
+rather than a limit of its own. Promotion of row 17 to a numbered claim is
+therefore a decision about whether numbered prose can carry limits 4 and 5 plus
+the argv heuristic in limit 2, not a decision waiting on work.
 
 **Claim 3 backend scoping (ADR-107).** Claim 3's witness, dm-verity, is
 block-device-specific: it ratifies the claim on the **block+ext4** backends

--- a/specs/adrs/001-microvm-security-posture.md
+++ b/specs/adrs/001-microvm-security-posture.md
@@ -157,31 +157,34 @@ signed plan.
 
 Neither is claimed here, for different reasons. The construction half is
 excluded because this row's three witnesses do not check it. The policy
-half is excluded because one leg of its enforcement — the secret scan —
-still has no production caller. Both are stated and witnessed as Preview 17,
+half is excluded because promoting it is a separate maintainer decision,
+mirroring rows 14 and 16. Both are stated and witnessed as Preview 17,
 with their limits, rather than asserted as part of a shipped claim.
 
 **Preview 17 — workload stdin is grant-gated, single-writer, secret-scanned
 and audited.** The host→guest input plane refuses every write unless the
 workload's signed `ExecutionPlan` carries the input grant; it arbitrates
 concurrent writers with a per-VM lease so two consumers cannot interleave
-into one byte stream; it scans across frame boundaries and withholds a
-tail that is still a live prefix of a known secret rather than shipping it
-and refusing afterwards; it emits a chain-signed, payload-free entry for
+into one byte stream; it scans across frame boundaries and withholds the
+tail it must still be able to see rather than shipping it and refusing
+afterwards; it emits a chain-signed, payload-free entry for
 every refusal and every grant, and declines the decision entirely when it
 cannot record it; and under a sealed production posture it refuses the
 grant outright for a shell-shaped entrypoint, since streaming stdin to a
 shell is interactive access wearing a different hat.
 
-This is a preview, not a shipped claim. The channel now has an operator
-surface — `mvmctl machine run --entrypoint --stdin -` — and the grant, the
-lease, the explicit EOF and the shell-entrypoint refusal all have production
-callers; the refusal reads the entrypoint out of the image's own build-time
-record and fails closed when it cannot. What is still dormant is the secret
-scan: `InputGate::bind` has no caller outside tests, so the known-secret set
-is empty on every real VM and the refusal it exists to produce has never
-fired in production. A claim is worth what its weakest enforced leg is worth,
-so the row stays `Preview`. The four limits are stated in the ledger's
+This is a preview, not a shipped claim. Every leg now has a production
+caller: the channel has an operator surface (`mvmctl machine run
+--entrypoint --stdin -`), the shell-entrypoint refusal reads the entrypoint
+out of the image's own build-time record and fails closed when it cannot,
+and the secret scan is populated — `StreamPlane::open_input` installs the
+fingerprints the per-VM substitution endpoint computed for the secrets it
+resolved. What keeps the row at `Preview` is no longer dormancy but what the
+enforcement *is*: a fingerprint match is a length-and-hash match rather than
+an identity, and encoding, derivation and a window-straddling split defeat
+the scan permanently. Promotion is therefore a maintainer decision about
+whether a numbered claim's prose can carry those qualifications — the same
+posture rows 14 and 16 sit in. The five limits are stated in the ledger's
 "Preview 17 limits" note below, marked as closed or open individually, and
 are load-bearing.
 
@@ -545,7 +548,7 @@ tracked separately as a follow-up audit (see "deferred follow-ups").
 | 14 | OCI image provenance is recorded in the chain-signed audit log | fn:prod_pull_requires_digest_pin_before_network, fn:prod_run_image_requires_digest_pin_before_network | cosign + OCI digest (specs/claims/claim-10-oci-image-provenance.md) | Shipped |
 | 15 | A sealed production microVM has no shell, no do_exec, and no PTY | fn:console_refused_on_sealed_image, ci:prod-agent-no-console, fn:prod_console_attachment_has_no_input | dev-image-only console + dm-verity + host accessible-gate + interactive-gated agent (Plan 165 WS-C, ADR-001 §W4.3 extension). The host→guest input plane is deliberately *not* claimed here: its properties are policy, not absence, and are witnessed at row 17 | Shipped |
 | 16 | Egress substitution keeps a raw secret off the guest, bound-only, no value in audit | fn:handed_placeholders_never_contain_the_secret_value, fn:substitution_endpoint_refuses_unbound_destination, fn:audit_chain_carries_no_secret_value | egress substitution leak-gate; reinforces claims 12+13 on the egress delivery (ADR-023, specs/claims/claim-egress-no-secret-to-guest.md) | Preview |
-| 17 | Workload stdin is grant-gated, single-writer, secret-scanned across frames, and every refusal is audited | fn:input_is_refused_without_a_plan_grant, fn:a_second_writer_is_refused_while_the_lease_is_held, fn:secret_material_split_across_frames_is_still_refused, fn:every_refusal_is_audited, fn:a_shell_entrypoint_with_the_grant_is_refused_and_names_the_reason | input grant token in a signed ExecutionPlan.services + per-VM lease with TTL + sliding-window secret scan + chain-signed payload-free refusal audit + sealed-tier shell-entrypoint refusal. Read the limits note below before treating this as enforced | Preview |
+| 17 | Workload stdin is grant-gated, single-writer, secret-scanned across frames, and every refusal is audited | fn:input_is_refused_without_a_plan_grant, fn:a_second_writer_is_refused_while_the_lease_is_held, fn:secret_material_split_across_frames_is_still_refused, fn:every_refusal_is_audited, fn:a_shell_entrypoint_with_the_grant_is_refused_and_names_the_reason, fn:the_endpoint_fingerprints_what_it_resolved_and_reports_no_value, fn:the_handshakes_two_halves_go_to_two_different_places, fn:a_secret_split_across_two_frames_does_not_reassemble_in_the_workload, fn:a_fingerprint_refusal_does_not_claim_the_bytes_are_the_secret | input grant token in a signed ExecutionPlan.services + per-VM lease with TTL + fingerprint-matching sliding-window secret scan + chain-signed payload-free refusal audit + sealed-tier shell-entrypoint refusal. Read the limits note below before treating this as enforced | Preview |
 
 Row 16 is the egress-substitution leak-gate. Like claim 14 (OCI provenance),
 it is registered here for witness machine-checking and tracked by its own doc
@@ -556,19 +559,36 @@ shipped broker delivery; row 16 backs the same two invariants on the egress
 substitution path.
 
 **Preview 17 limits — what the input plane does and does not enforce.** Row 17
-is `Preview` rather than `Shipped`. Two of the four limits below closed when
-the channel gained an operator surface; two did not, and the row stays where
-its weakest enforced leg puts it. Stating that here is the point of a ledger;
-a row that read as enforced while the enforcement was dormant would be the
-exact failure this table exists to prevent.
+is `Preview` rather than `Shipped`. Three of the five limits below are closed;
+the two that remain are permanent properties of what the enforcement *is*, not
+gaps waiting on work. Stating that here is the point of a ledger; a row that
+read as enforced while the enforcement was dormant would be the exact failure
+this table exists to prevent.
 
-1. **The secret scan is inert in production. (OPEN.)** `InputGate::bind` — the
-   only way a known secret enters the scanner — has no caller outside tests, so
-   the known-secret set is empty on every real VM. The scanner is correct
-   and witnessed (`fn:secret_material_split_across_frames_is_still_refused`
-   and its siblings hold across three-way and one-byte-at-a-time splits);
-   it currently has nothing to match against. This is the limit that keeps
-   row 17 at `Preview`.
+1. **The secret scan is populated in production. (CLOSED.)** It used to be
+   inert: `InputGate::bind` had no caller outside tests, so the known-secret
+   set was empty on every real VM. The per-VM substitution endpoint — the one
+   host process that holds a workload's credentials in the clear — now
+   fingerprints each secret it resolves and reports the fingerprints on its
+   ready handshake, and `StreamPlane::open_input` installs that set on the gate
+   before a writer's first frame. Witnessed by
+   `fn:the_endpoint_fingerprints_what_it_resolved_and_reports_no_value` and
+   `fn:the_handshakes_two_halves_go_to_two_different_places`;
+   `fn:a_secret_split_across_two_frames_does_not_reassemble_in_the_workload`
+   drives the whole path, from the endpoint's report through a real plane to a
+   workload process that must not receive the bytes.
+
+   Three things the closure does not say. **Fingerprints, not values**: what
+   crosses into the scanning process is a length, a 64-bit rolling hash and a
+   category — never a credential, because the endpoint is a separate process
+   and keeping it that way is the point (claims 12/13, and row 16). What that
+   discloses, and why prefix fingerprints were rejected, is in ADR-035
+   §"What binding a fingerprint discloses". **Scoped to the booting
+   process**: the set is in memory, held by the invocation that spawned the
+   endpoint — which is exactly the invocation that can stream, per limit 3, so
+   this costs no reachability. **Scoped to secret-bearing plans**: a workload
+   whose plan carries no secrets binds an empty set, which is the correct
+   answer rather than a dormant one.
 2. **The shell-entrypoint refusal now fires on a real entrypoint. (CLOSED.)**
    It used to be dormant: every production call site passed an empty
    `entrypoint_argv`, so the gate never saw a shell. The entrypoint is now
@@ -595,17 +615,31 @@ exact failure this table exists to prevent.
    another process and hold no plan to write under, so they refuse.
 4. **The scan is a backstop, not a defence. (OPEN, permanent.)** Base64, hex,
    any derivation, and a split that straddles the sliding window all defeat
-   it. It catches a confused host-side caller, not a determined one. The real
-   guarantee is upstream and structural: the host has no reason to send a
-   secret into a guest, because secrets are substituted on egress (rows 13 and
-   16) rather than handed over. The same "heuristic, not proof" caveat applies
-   to the shell classification in limit 2: a wrapper that `exec`s a shell
-   defeats it, and no test over argv could separate a program that reads stdin
-   from one that interprets it.
+   it. It catches a confused host-side caller, not a determined one. Giving
+   the scan a populated set makes it *work*; it does not make it stronger than
+   this. The real guarantee is upstream and structural: the host has no reason
+   to send a secret into a guest, because secrets are substituted on egress
+   (rows 13 and 16) rather than handed over. The same "heuristic, not proof"
+   caveat applies to the shell classification in limit 2: a wrapper that
+   `exec`s a shell defeats it, and no test over argv could separate a program
+   that reads stdin from one that interprets it.
+5. **A match is a hash match, not an identity. (OPEN, permanent.)** The gate
+   holds fingerprints because it must not hold values, so two different byte
+   sequences of the same length can match one. The gate refuses either way —
+   failing closed is the right direction — and the refusal says what was
+   compared rather than asserting the bytes are the secret
+   (`fn:a_fingerprint_refusal_does_not_claim_the_bytes_are_the_secret`). The
+   cost is the mirror image of limit 4: limit 4 is what the scan misses, this
+   is what it may refuse without cause. A second cost rides with it: unable to
+   tell a live secret prefix from an innocent tail, the scanner withholds a
+   fixed `longest_secret - 1` bytes of every write on a secret-bearing VM
+   until the next write or the close. Bounded, never dropped, and charged only
+   to workloads that have a secret to leak.
 
-Promotion of row 17 to a numbered claim requires limit 1 to close. Limit 4 is
-permanent and is a property of scanning and of argv classification, not a gap
-to fix.
+Limits 4 and 5 are permanent — properties of scanning and of hashing, not gaps
+to fix. Promotion of row 17 to a numbered claim is therefore a decision about
+whether numbered prose can carry them and the argv heuristic in limit 2, not a
+decision waiting on work.
 
 **Claim 3 backend scoping (ADR-107).** Claim 3's witness, dm-verity, is
 block-device-specific: it ratifies the claim on the **block+ext4** backends

--- a/specs/adrs/035-workload-stream-plane.md
+++ b/specs/adrs/035-workload-stream-plane.md
@@ -2,13 +2,13 @@
 
 ## Status
 
-Accepted for the output half. Implemented by plan 283 phase 1: the guest pump
+Accepted for the output half. Implemented by plan 295 phase 1: the guest pump
 (`mvm-agentd`), the stream store (`mvm-core::transcript`), the host broker
 (`mvm-hostd::stream`), and the consumers (`mvmctl machine logs`, `machine run`
 attach, `mvm-client`/SDK readers).
 
 Accepted for the input half, with its cost recorded in §"Claim 15 becomes a
-policy, and what that bought". Implemented by plan 283 phase 2: the input frame
+policy, and what that bought". Implemented by plan 295 phase 2: the input frame
 DTOs and the plan grant (`mvm-protocol::stream::input`), the gate
 (`mvm-hostd::stream::input_gate`), the route to the guest sink, agent-side
 delivery with explicit EOF (`mvm-agentd::stream_input`), and the sealed-tier
@@ -510,7 +510,7 @@ token, so two processes can never interleave one transcript.
 
 ## References
 
-- `specs/plans/283-workload-stream-plane.md` — the design and its
+- `specs/plans/295-workload-stream-plane.md` — the design and its
   implementation sequence.
 - ADR-001 — threat model, per-backend tier matrix, and the claims ledger table
   this ADR's security section refers to.

--- a/specs/adrs/035-workload-stream-plane.md
+++ b/specs/adrs/035-workload-stream-plane.md
@@ -293,14 +293,92 @@ the set to the per-VM state dir (which would widen it to every reader of
 `~/.mvm` to buy reachability nothing uses — only the booting invocation can
 stream), and binding fingerprints of each secret's *prefixes*.
 
-Prefix fingerprints are the tempting one, because they are what the plaintext
-scanner had. With them the scanner can tell a suffix that could still become a
-secret from one that provably cannot, and so withhold only the former; without
-them it must withhold a fixed `longest_secret - 1` bytes of every write. They
-are also a byte-at-a-time recovery oracle: guess byte 0 against the length-1
-prefix hash, then byte 1, and the credential falls in 256·L tries. The latency —
-bounded, never dropped, released on the next write or at close, and charged only
-to VMs that bound a secret — is the price of not shipping that oracle.
+**What the memory-only choice rests on, and what breaking it looks like.** It
+rests on limit 3: only the invocation that admitted and booted a workload may
+stream into it, so the process that spawned the endpoint is the process that
+later opens the gate. Should that stop being true — the resident per-tenant
+daemon this project is heading toward would do it, with boot in one process and
+`stream` in another — the registry read returns an empty set, the gate binds an
+empty set, and the scan silently reverts to matching nothing. That is limit 1
+re-opening, and **nothing goes red when it does**: an empty read is
+indistinguishable from a plan that carried no secrets, and both are legitimate.
+The failure is therefore invisible by construction, not merely untested, and
+splitting boot from stream must come with a registry that spans the split or
+with a gate that refuses when it cannot tell the two cases apart.
+
+**Why the carry is blanket, and why that is the safe choice.** Without prefix
+fingerprints the scanner cannot ask "could this tail still become a secret", so
+it withholds a fixed `longest_secret - 1` bytes of every write rather than the
+exact live prefix. That reads as the lazy option and is the load-bearing one.
+
+Precision here would be a **prefix oracle**. The withhold-or-deliver decision is
+observable — anyone holding the input grant writes a byte and sees whether
+anything came out — so a scanner that withheld only what could still complete a
+secret would be answering, for each byte offered, "is this a live prefix?". Walk
+that: 256 tries recover byte 0, 256 more recover byte 1, and a 40-byte
+credential falls in about 40·256 probes instead of 256^40. That is a
+secret-extraction path against precisely what row 13 protects, and it is
+strictly worse than any amount of withholding. A blanket carry leaks nothing
+*because* it is blanket: the decision carries no information about the content.
+The imprecision is the mechanism, not a shortcut.
+
+Binding prefix fingerprints — the tempting repair, and what the plaintext
+scanner effectively had — is the same mistake with an extra disclosure on top.
+Under this polynomial hash the prefix chain *is* the plaintext: `h(k) =
+h(k-1)·BASE + s[k-1] (mod 2^64)`, so `s[k-1] = h(k) − h(k-1)·BASE` recovers each
+byte by subtraction, and `h(1)` is literally the first byte. Changing the hash
+does not save it: any function a scanner can evaluate, code in that same process
+can evaluate, so an *exact* prefix-membership test over a byte alphabet is a
+decoder in 256·L tries whatever the hash. Precision about short tails and
+non-disclosure of short prefixes are the same quantity; you cannot buy one
+without selling the other.
+
+**What the blanket carry cost, and how that cost is paid.** Left alone it is a
+deadlock rather than latency. With a 40-byte bound secret the carry is 39, so an
+operator running a line-oriented workload under `machine run --entrypoint
+--stdin -` and typing an 11-byte request line delivers **zero** bytes: the
+workload never sees a line, never answers, so the operator never writes again,
+and the tail ships only at EOF. "A program that reads a request off stdin and
+writes a response" is a shape this plane exists for, so that was not a tolerable
+resting place.
+
+The gate therefore **releases the withheld tail after 50ms of writer silence**
+(`DEFAULT_IDLE_FLUSH_AFTER`). Two properties make this the right shape rather
+than a quiet weakening of the paragraph above, and both have witnesses:
+
+- **The release is content-independent.** It fires on elapsed time since the
+  scanner last took bytes and on nothing else — never on what the withheld bytes
+  are. So it opens no oracle: an observer learns when they stopped writing,
+  which they already knew. Witnessed by
+  `fn:the_idle_release_does_not_depend_on_what_the_withheld_bytes_are` and
+  `fn:what_is_withheld_is_a_length_and_never_a_verdict_about_the_bytes`, which
+  drive a genuine live prefix of a bound secret and an innocent payload of the
+  same length through the whole path and require the two to be
+  indistinguishable.
+- **The release can never hand over a secret.** What the scanner holds already
+  survived a scan of the buffer it came from, so no window inside it matches.
+  What is lost is *context*: a secret split across the silence is no longer
+  contiguous and is missed. That needs the sender to pause mid-credential — a
+  confused caller does not, and a determined one has no reason to, since base64
+  defeats the scan outright. It therefore falls inside the existing "backstop,
+  not a defence" limit and does not widen it. Witnessed from both sides by
+  `fn:a_secret_split_across_two_writes_inside_the_threshold_is_still_refused`
+  and `fn:a_secret_split_across_the_idle_gap_is_missed_and_that_is_the_price`.
+
+50ms sits between two gaps that differ by orders of magnitude: the gap inside
+one writer's burst (a buffer copy and one vsock round trip — microseconds to low
+milliseconds, and the split a confused caller actually produces, which must stay
+covered) and the gap a human or a request/response peer leaves, which is at
+minimum the workload's own think time. It is roughly fifty times the first and
+half the ~100ms at which delay becomes perceptible. The CLI's idle attendant
+visits every half-threshold, so a released line reaches the guest within about
+one and a half thresholds of the last keystroke.
+
+Exact live-prefix precision *within* a burst is still available without the
+oracle — anchoring the carry to a delimiter no bound secret contains, or moving
+the scan into the process that holds the plaintext. Both are costed in
+`specs/plans/293-stream-plane-followups.md`; neither is needed for the shapes
+the plane serves today.
 
 **And a match is not an identity.** Two byte sequences of the same length can
 hash alike. The gate refuses on a match anyway, because failing closed is the

--- a/specs/adrs/035-workload-stream-plane.md
+++ b/specs/adrs/035-workload-stream-plane.md
@@ -19,9 +19,13 @@ opens the route through `StreamPlane::open_input` under the plan that boot was
 admitted under, pumps the caller's stdin through the gate in acceptance order,
 and closes the workload's stdin on the caller's EOF. Only the invocation that
 admits and boots a workload can stream into it — `--attach` and `session
-attach` hold no admitted plan and refuse. ADR-001's claim 17 stays at status
-`Preview`, now for one reason rather than three: the secret scan has no
-production caller, so its refusal has never fired on a real VM.
+attach` hold no admitted plan and refuse. The gate's secret scan is populated
+too: the per-VM substitution endpoint fingerprints each secret it resolves and
+`StreamPlane::open_input` installs that set — see §"What binding a fingerprint
+discloses". ADR-001's claim 17 stays at status `Preview`, now not because a leg
+is dormant but because of what the enforcement is: a fingerprint match is a
+length-and-hash match, and encoding, derivation and a window-straddling split
+defeat the scan permanently.
 
 Three limits below (§"What this does not do") are stated as limits, not as
 future work. They are true of the shipped code.
@@ -260,8 +264,49 @@ between the bytes and a launcher.
 So the trade is a strong claim over a narrow surface exchanged for a weaker
 claim over the surface the product actually has. The mitigation is that every
 weakening is written down: the grant is in the signed plan, both outcomes are in
-the chain, and ADR-001 carries the claim at `Preview` with four limits rather
+the chain, and ADR-001 carries the claim at `Preview` with five limits rather
 than promoting it on the strength of the tests alone.
+
+### What binding a fingerprint discloses
+
+The gate refuses stdin that carries one of the host's own secrets, and
+recognising a byte sequence means having it. But the gate runs in the CLI
+process while the substitution endpoint that resolves raw credentials runs as a
+separate process, and that separation is load-bearing — it is what claims 12 and
+13 rest on. Copying plaintext into the CLI to populate a scan would create a new
+plaintext location in a process that has none, in order to close a gap on a
+different claim. That trade is not worth making.
+
+So the endpoint computes a **fingerprint** — a length, a 64-bit rolling hash and
+a category — for each secret it resolves, and reports the fingerprints on its
+ready handshake. Only the fingerprints cross. The rolling hash is what makes the
+scan affordable: it slides over the stream at one multiply-add per byte and
+tests every offset, which is how a secret split across two writes is still found.
+
+**What it discloses, stated rather than buried.** Whoever holds a fingerprint
+learns the secret's **length** and holds a 64-bit hash of it. For a high-entropy
+credential that is not a recovery path; for a short low-entropy one, a hash and a
+length are guessable offline. The set lives in the memory of the process that
+booted the VM, is never written to disk, and is dropped when the endpoint is
+reaped. Two disclosures that would be worse were rejected outright: persisting
+the set to the per-VM state dir (which would widen it to every reader of
+`~/.mvm` to buy reachability nothing uses — only the booting invocation can
+stream), and binding fingerprints of each secret's *prefixes*.
+
+Prefix fingerprints are the tempting one, because they are what the plaintext
+scanner had. With them the scanner can tell a suffix that could still become a
+secret from one that provably cannot, and so withhold only the former; without
+them it must withhold a fixed `longest_secret - 1` bytes of every write. They
+are also a byte-at-a-time recovery oracle: guess byte 0 against the length-1
+prefix hash, then byte 1, and the credential falls in 256·L tries. The latency —
+bounded, never dropped, released on the next write or at close, and charged only
+to VMs that bound a secret — is the price of not shipping that oracle.
+
+**And a match is not an identity.** Two byte sequences of the same length can
+hash alike. The gate refuses on a match anyway, because failing closed is the
+right direction, but its refusal says a fingerprint matched rather than that the
+bytes are the secret. An operator told the stronger thing when it was not true
+would spend hours proving a negative.
 
 **What is explicitly not claimed.** The sealed-tier refusal of the grant for a
 shell-shaped entrypoint is a *heuristic* and is documented as one. A wrapper
@@ -342,6 +387,13 @@ the trade; ADR-001 carries the reworded row and the new claim 17 at `Preview`.
 
 **Extended.** Claim 8's admitted plan gains two more decisions it binds — the
 retention mode and the input grant — and matching labels in the chain.
+
+**Unweakened, and worth saying why.** Claims 12 and 13 keep raw secrets inside
+the substitution endpoint's address space. Populating the input gate's scan does
+not move any of that: what leaves the endpoint is a length and a hash, the CLI
+gains no API that could hold a value, and the endpoint's own store reads are
+unchanged. §"What binding a fingerprint discloses" states what the length and
+the hash are worth to a reader of them.
 
 **Not strengthened, despite appearances.** The reader-side anchoring rule
 defeats a *buggy* broker, not a hostile one: nothing cross-checks a claimed

--- a/specs/plans/283-workload-stream-plane.md
+++ b/specs/plans/283-workload-stream-plane.md
@@ -2273,7 +2273,9 @@ Expected: clean.
 workload's stdin and sees its output in the same stream; an ungranted one is
 refused and the refusal is in the chain.
 
-**Phase 2 status: met in the harness, not on a VM.** Both halves are covered by
+**Phase 2 status (as of this plan; superseded — see plan 293 WS1 for the secret
+scan, and ADR-001's Preview 17 limits note for the current state). Met in the
+harness, not on a VM.** Both halves are covered by
 `crates/mvm-hostd/tests/workload_input_plane.rs` against a real `admit_for_run`,
 a real chain and `verify_audit_chain`. Neither is met by an operator, because
 `StreamPlane::open_input` is the only route into the gate and has no caller

--- a/specs/plans/289-host-side-machine-logs.md
+++ b/specs/plans/289-host-side-machine-logs.md
@@ -1,6 +1,6 @@
 # Host-side machine logs
 
-**Status:** COMPLETE, mechanism superseded by plan 283
+**Status:** COMPLETE, mechanism superseded by plan 295
 
 The goal below — read the console capture host-side, never through a VM — was
 met here and is still met. The `mvm_runtime::microvm::logs` implementation that

--- a/specs/plans/293-stream-plane-followups.md
+++ b/specs/plans/293-stream-plane-followups.md
@@ -1,12 +1,19 @@
 # Plan 293 — stream plane follow-ups
 
-**Status:** Proposed.
+**Status:** In progress — WS1 complete, WS2–WS4 outstanding.
 
 Close the two reachability gaps plan 283 shipped knowingly, and add the two
 gates that would have caught the classes of defect that cost it the most.
 
-Predecessor: `specs/plans/283-workload-stream-plane.md`. Claim status:
-`specs/adrs/001-microvm-security-posture.md`, the Preview 17 limits note.
+Predecessor: `specs/plans/283-workload-stream-plane.md` — note that `main`
+carries a *different* plan 283, so refer to these by filename, not number.
+Claim status: `specs/adrs/001-microvm-security-posture.md`, the Preview 17
+limits note.
+
+**Picking this up cold:** start from
+`specs/plans/294-stream-plane-completion.md`. It carries the branch inventory,
+the reason PR #2139 has never run CI, the number collisions, and the open
+`replay_vectors` question. Tracking issue: tinylabscom/mvm#2152.
 
 ## Why these four together
 
@@ -34,10 +41,14 @@ user or an auditor.
       discovered: a collision refuses a legitimate frame (the refusal names what
       it compared and disclaims identity), and, unable to tell a live prefix from
       an innocent tail, the scanner withholds a fixed `longest_secret - 1` bytes
-      on a secret-bearing VM. ADR-001's limit 1 is CLOSED, a new permanent limit 5
-      records the hash-match cost, and ADR-035 §"What binding a fingerprint
-      discloses" carries the length disclosure and why prefix fingerprints were
-      rejected. Row 17 stays `Preview`: the scan works now, it is not stronger.
+      on a secret-bearing VM. That second cost was first mispriced as latency
+      and was a **stall**; it is closed by the idle release — see §"WS1
+      follow-on: the blanket carry, and releasing it on silence". ADR-001's
+      limit 1 is CLOSED, a new permanent limit 5 records the hash-match cost, a
+      limit 6 records the blanket carry and its release, and ADR-035 §"What
+      binding a fingerprint discloses" carries the length disclosure, the
+      prefix-oracle argument, and why prefix fingerprints were rejected. Row 17
+      stays `Preview`: the scan works now, it is not stronger.
 
   `InputGate::bind` has no production caller, so the cross-frame secret scan
   matches against an empty set on every real VM. The scan is correct and
@@ -122,6 +133,122 @@ user or an auditor.
   Seed it from what is known dormant today and expect it to surface more. That
   is the point — the six found on plan 283 were the ones review happened to
   reach.
+
+## WS1 follow-on: the blanket carry, and releasing it on silence
+
+- [x] **Release the withheld tail after a short idle period.** Landed.
+      `DEFAULT_IDLE_FLUSH_AFTER` = 50ms; `InputSession::refresh` releases on
+      elapsed time alone, `InputRoute::refresh` carries what that produces, and
+      the CLI's idle attendant visits every half-threshold.
+- [ ] **Restore exact live-prefix coverage within a burst.** Not needed for any
+      shape the plane serves today; costed as B and C below if it ever is.
+
+WS1 traded exact live-prefix withholding for a fixed `longest_secret - 1`
+carry, and the WS1 report priced that as latency. It was worse: with a 40-byte
+bound secret the carry is 39, so `machine run --entrypoint --stdin -` against a
+line-oriented workload delivered **zero** bytes of an 11-byte request line — the
+workload never saw a line, never answered, the operator never wrote again, and
+the tail shipped at EOF. A deadlock, on a shape ADR-035 names as a reason this
+plane exists.
+
+**The blanket carry is not the defect; it is the mechanism.** Withholding only
+the tails that could still complete a secret makes the withhold-or-deliver
+decision depend on content, and that decision is observable by anyone holding
+the input grant: write one byte, see whether anything came out. That is a
+**prefix oracle** — 256 tries per byte, so a 40-byte credential falls in about
+40·256 probes instead of 256^40 — and it is a secret-extraction path against
+what claim 13 protects, strictly worse than a stall. Because everything is
+withheld unconditionally, the decision carries no information about content at
+all. Any fix therefore has to leave the decision content-blind.
+
+**Binding prefix fingerprints is the same mistake plus a disclosure.** Under the
+polynomial hash in `mvm_protocol::stream::secret_fingerprint` the prefix hashes
+are a literal encoding of the value: `h(k) = h(k-1)·BASE + s[k-1] (mod 2^64)`,
+so each byte falls out by one subtraction and `h(1)` *is* the first byte — no
+search at all. A different hash only converts that into a search: any function
+the scanner can evaluate, code in the scanner's process can evaluate, so an
+exact prefix-membership test over a 256-symbol alphabet is a decoder in 256·L
+tries. Precision about a one-byte tail and secrecy of a one-byte prefix are the
+same quantity. No hash, salt or truncation keeps both — a filter lossy enough to
+blunt the oracle is lossy enough to false-positive on the common tail, which is
+the stall again.
+
+### What landed: E, the content-independent idle release
+
+**E. Release the carry after T of writer silence.** The WS1 report listed this
+and rejected it — "write half, wait T, write the rest — it defeats the scan for
+precisely the patient caller it is aimed at". That rejection was wrong about who
+the scan is aimed at. The scan is a backstop against a *confused* caller that
+pasted the wrong thing (ADR-001 limit 4); it has never defended against a
+determined one, because base64 defeats it outright. A caller patient enough to
+pause mid-credential is a determined caller, and a determined caller does not
+need the pause. The residual is therefore inside a limit that is already
+permanent, while the stall was not inside any limit at all.
+
+What landed:
+
+- `DEFAULT_IDLE_FLUSH_AFTER = 50ms`, in `stream::input_gate`. The threshold sits
+  between two gaps that differ by orders of magnitude: the gap inside one
+  writer's burst (a buffer copy plus one vsock round trip — microseconds to low
+  milliseconds, and the split a confused caller actually produces) and the gap a
+  human or a request/response peer leaves. Roughly 50x the first and half the
+  ~100ms perception floor.
+- `InputSession::refresh` — already "the writer is idle but alive" — now also
+  releases the withheld tail, on `elapsed >= threshold` and the withheld
+  *length*, never on the bytes. `InputRoute::refresh` carries what that produces
+  to the guest as one wire frame, and mints no frame when there is nothing to
+  send. No new thread: the CLI's existing lease ticker became the idle
+  attendant, ticking at half the threshold.
+- `InputBinding::with_idle_flush_after` makes the threshold injectable, so both
+  sides of the boundary are exercised with no sleeps and nothing to go flaky.
+
+Witnesses: `an_idle_writer_gets_the_line_the_carry_swallowed` and
+`a_line_the_carry_swallowed_reaches_the_guest_once_the_writer_goes_quiet` (the
+deadlock, gate and route); `the_idle_release_does_not_depend_on_what_the_withheld_bytes_are`
+and `what_is_withheld_is_a_length_and_never_a_verdict_about_the_bytes` (content
+independence, driving a real live prefix against an innocent payload of equal
+length); `a_secret_split_across_two_writes_inside_the_threshold_is_still_refused`
+(coverage kept) and `a_secret_split_across_the_idle_gap_is_missed_and_that_is_the_price`
+(the residual, pinned); `an_idle_release_cannot_hand_over_a_bound_secret` and
+`a_writer_that_lost_its_lease_gets_no_idle_release_either`.
+
+### Still available if exactness within a burst ever matters
+
+**B. Anchor the carry to a delimiter the secrets provably lack.** The endpoint
+already inspects each plaintext to fingerprint it; have it also report one bool
+for the set — *does any bound secret contain `\n`*. If none does, no match can
+straddle a newline, so the scanner may deliver everything through the last `\n`
+in its buffer and carry only what follows, capped at `longest - 1` as now.
+Sound with no false negatives: matches ending at or before the delimiter are
+already found by the existing whole-buffer scan, and a secret with no `\n`
+cannot span one.
+*Buys:* a write ending in a newline delivers whole and immediately, carrying
+nothing — so no idle wait at all for line-oriented input. *Costs:* one bit of
+disclosure about the set, whose answer is "no" for essentially every credential;
+a bound PEM key answers "yes" and falls back to the blanket carry (the
+fail-closed direction). *Does not fix:* a workload reading length-prefixed
+binary frames, which has no delimiter to anchor on. *Effort:* small.
+
+**C. Move the scan into the substitution endpoint.** The gate forwards each
+frame to the process that holds the plaintext; it does exact live-prefix
+withholding and returns the cleared bytes.
+*Buys:* everything, exactly — plaintext precision restored, and the CLI stops
+learning lengths and hashes at all, so the WS1 disclosure closes too. *Costs:*
+an IPC round trip per input frame, and a wedged endpoint now wedges stdin
+instead of merely egress; the operator's input bytes start flowing through the
+process holding the credentials, a new data flow into the most sensitive
+process; the endpoint gains a byte-moving job it does not have. A residual
+oracle survives — a caller opening one session per probe still learns one bit
+per try, 256·L tries — but every try is chain-audited and the session latch
+already stops within-session probing. *Effort:* medium-large.
+
+**D. Cap the scanned window.** Carry at most N bytes and accept that a secret
+longer than N can be split across the boundary. *Rejected:* regresses exact
+cross-frame coverage unconditionally, where E regresses it only across a
+deliberate pause.
+
+**F. Ship it and document the hang.** *Rejected:* operators would meet it as a
+hang with no error, on the shape the feature was built for.
 
 ## Sequencing
 

--- a/specs/plans/293-stream-plane-followups.md
+++ b/specs/plans/293-stream-plane-followups.md
@@ -5,7 +5,7 @@
 Close the two reachability gaps plan 283 shipped knowingly, and add the two
 gates that would have caught the classes of defect that cost it the most.
 
-Predecessor: `specs/plans/283-workload-stream-plane.md` — note that `main`
+Predecessor: `specs/plans/295-workload-stream-plane.md` — note that `main`
 carries a *different* plan 283, so refer to these by filename, not number.
 Claim status: `specs/adrs/001-microvm-security-posture.md`, the Preview 17
 limits note.
@@ -261,6 +261,6 @@ hypothetical.
 
 ## Out of scope
 
-VM-to-VM fan-out (`specs/plans/292-fleet-stream-fan-out.md`). The deferred
+VM-to-VM fan-out (`specs/plans/296-fleet-stream-fan-out.md`). The deferred
 minors in plan 283's ledger — they are individually small and want triage, not a
 workstream.

--- a/specs/plans/293-stream-plane-followups.md
+++ b/specs/plans/293-stream-plane-followups.md
@@ -22,26 +22,42 @@ user or an auditor.
 
 ## Workstreams
 
-- [ ] **WS1 — bind the secret set, and close claim 17's last reachability limit.**
+- [ ] **WS1 — give the scan fingerprints, not plaintext, and close claim 17's
+      last reachability limit.**
 
   `InputGate::bind` has no production caller, so the cross-frame secret scan
-  matches against an empty set on every real VM. The scan is correct and tested;
-  it has nothing to scan for.
+  matches against an empty set on every real VM. The scan is correct and
+  tested; it has nothing to scan for.
 
-  Source the workload's known secrets at plane construction and bind them, so
-  the scan is operative on a real launch. This is wiring, not new machinery.
+  **The obvious fix is wrong.** `KnownSecret` holds its value in the clear, and
+  the stream plane is registered in `mvm-cli` — the CLI process — while the
+  substitution endpoint that holds raw secrets runs as a separate process.
+  Keeping that separation is the point. Binding plaintext into the gate would
+  create a new plaintext location in a process that has none today, in order to
+  close a limit on a different claim. That trade is not worth making.
+
+  **Bind fingerprints instead.** The scan must find a secret split across frames
+  at an arbitrary offset, which rules out comparing whole-buffer digests — but
+  not a rolling hash. Bind `(length, rolling-hash)` pairs, roll the same hash
+  over the window the scan already maintains, and confirm a candidate before
+  refusing. The CLI never holds a secret value.
+
+  Two consequences to state rather than discover. A hash collision is a false
+  positive that refuses a legitimate frame — acceptable, because it fails
+  closed, but the refusal reason must not imply a certainty it does not have.
+  And the CLI learns secret *lengths*, a real if small disclosure that belongs
+  in the ADR rather than in a comment.
 
   Two things not to lose. The scan is a backstop against a confused caller, not
   a defence against a determined one — encoding, derivation, and splitting
-  inside a window boundary all defeat it, and the docs say so. Do not let
-  binding a real set turn that honest framing into an overclaim. And the sliding
-  window must still span frame boundaries: a secret split across two writes is
-  the case the scan exists for.
+  inside a window boundary all defeat it, and the docs say so. A populated set
+  must not turn that honest framing into an overclaim. And the window must still
+  span frame boundaries: a secret split across two writes is the case the scan
+  exists for.
 
   Then reassess claim 17. Two of its four limits closed when the channel gained
-  an operator surface. This closes a third. State plainly what remains rather
-  than promoting on momentum.
-
+  an operator surface. This closes a third. State what remains rather than
+  promoting on momentum.
 - [ ] **WS2 — redact the console fallback.**
 
   The transcript is redacted; the console fallback is not. The fallback is what

--- a/specs/plans/293-stream-plane-followups.md
+++ b/specs/plans/293-stream-plane-followups.md
@@ -1,0 +1,109 @@
+# Plan 293 — stream plane follow-ups
+
+**Status:** Proposed.
+
+Close the two reachability gaps plan 283 shipped knowingly, and add the two
+gates that would have caught the classes of defect that cost it the most.
+
+Predecessor: `specs/plans/283-workload-stream-plane.md`. Claim status:
+`specs/adrs/001-microvm-security-posture.md`, the Preview 17 limits note.
+
+## Why these four together
+
+Plan 283 shipped 22 tasks. Six of them were added mid-execution, and every one
+was the same shape: correct, tested machinery with no production caller. Nine
+separate times its prose asserted a security property the ledger did not back —
+including a witness that existed nowhere in the tree, and five user-facing files
+still stating a claim the ADR had already downgraded.
+
+Both classes were caught only by review, which is not a control. WS3 and WS4
+turn them into gates. WS1 and WS2 close the two holes that remain visible to a
+user or an auditor.
+
+## Workstreams
+
+- [ ] **WS1 — bind the secret set, and close claim 17's last reachability limit.**
+
+  `InputGate::bind` has no production caller, so the cross-frame secret scan
+  matches against an empty set on every real VM. The scan is correct and tested;
+  it has nothing to scan for.
+
+  Source the workload's known secrets at plane construction and bind them, so
+  the scan is operative on a real launch. This is wiring, not new machinery.
+
+  Two things not to lose. The scan is a backstop against a confused caller, not
+  a defence against a determined one — encoding, derivation, and splitting
+  inside a window boundary all defeat it, and the docs say so. Do not let
+  binding a real set turn that honest framing into an overclaim. And the sliding
+  window must still span frame boundaries: a secret split across two writes is
+  the case the scan exists for.
+
+  Then reassess claim 17. Two of its four limits closed when the channel gained
+  an operator surface. This closes a third. State plainly what remains rather
+  than promoting on momentum.
+
+- [ ] **WS2 — redact the console fallback.**
+
+  The transcript is redacted; the console fallback is not. The fallback is what
+  a detached run resolves to, which is the common shape rather than the corner.
+
+  It is worse than a gap in coverage. The follower stops before `kill()`, so
+  shutdown-time output — panics, the last thing a guest says, the most
+  diagnostic material there is — lands only in the unredacted file. The moment
+  most worth reading is the one least protected.
+
+  Run the same `PiiRedactor` over console bytes on the read path, before they
+  reach a consumer. Read-side, so the file the VMM owns is untouched.
+
+  Keep the existing notice honest: it currently tells an operator the console
+  merges streams, is unchained, and is unredacted. When the third stops being
+  true, the notice must stop saying it.
+
+- [ ] **WS3 — gate prose against the ledger.**
+
+  `check-claim-catalog` reads the claims table in ADR-001. Nothing reads the
+  prose around it, which is why nine drifts survived: `CLAUDE.md` cited a
+  claim-12 witness that exists nowhere, `README.md` and four other files still
+  asserted claim 15 in its absence form after the ADR had downgraded it, and
+  ADR-035 contradicted the ledger it cites.
+
+  Scan `README.md`, `public/`, `specs/`, and `CLAUDE.md` for claim-shaped
+  assertions — "no interactive access", "there is no ... path", "cannot reach",
+  "is not possible" — and require each to sit next to a citation of a ledger
+  row. A phrase inventory is enough for a first cut; it would have caught eight
+  of the nine.
+
+  Prove it on the history: check out a commit from before each drift was fixed
+  and confirm the gate fires. A gate nobody has seen fail is the defect it is
+  meant to prevent.
+
+- [ ] **WS4 — gate dormant controls.**
+
+  Six times plan 283 shipped a security-relevant symbol with no production
+  caller, each found by review rather than by CI. The failure mode is a control
+  that reports present and cannot fire: an admission gate reading an argv nobody
+  populates, a broker nothing constructs, a scan whose set is always empty.
+
+  Hold a declared allowlist of security-relevant symbols that have no production
+  caller. The gate fails when a symbol not on the list acquires that shape, and
+  the allowlist may only shrink. Dormancy stops being an oversight and becomes a
+  declaration with a name attached.
+
+  Seed it from what is known dormant today and expect it to surface more. That
+  is the point — the six found on plan 283 were the ones review happened to
+  reach.
+
+## Sequencing
+
+WS1 and WS2 first: both are visible to a user or an auditor today, and WS1 is
+what a reader of claim 17 would reasonably assume already holds.
+
+WS3 and WS4 after, cheap and preventive. WS4 subsumes WS1's failure mode, so
+landing WS1 first gives the gate a real closure to record rather than a
+hypothetical.
+
+## Out of scope
+
+VM-to-VM fan-out (`specs/plans/292-fleet-stream-fan-out.md`). The deferred
+minors in plan 283's ledger — they are individually small and want triage, not a
+workstream.

--- a/specs/plans/293-stream-plane-followups.md
+++ b/specs/plans/293-stream-plane-followups.md
@@ -22,8 +22,22 @@ user or an auditor.
 
 ## Workstreams
 
-- [ ] **WS1 — give the scan fingerprints, not plaintext, and close claim 17's
-      last reachability limit.**
+- [x] **WS1 — give the scan fingerprints, not plaintext, and close claim 17's
+      last reachability limit.** Landed. `mvm_protocol::stream::secret_fingerprint`
+      defines `(length, rolling hash, category)` and the rolling primitives;
+      `mvm-hostd`'s substitution endpoint computes a fingerprint per resolved
+      secret and reports them on its ready handshake; `spawn_substitution_endpoint`
+      splits the handshake — placeholders persist to the guest env sidecar,
+      fingerprints stay in this process — and `StreamPlane::open_input` installs
+      the set before a writer's first frame. `KnownSecret` is deleted rather than
+      deprecated, so no binding takes bytes. Two costs recorded rather than
+      discovered: a collision refuses a legitimate frame (the refusal names what
+      it compared and disclaims identity), and, unable to tell a live prefix from
+      an innocent tail, the scanner withholds a fixed `longest_secret - 1` bytes
+      on a secret-bearing VM. ADR-001's limit 1 is CLOSED, a new permanent limit 5
+      records the hash-match cost, and ADR-035 §"What binding a fingerprint
+      discloses" carries the length disclosure and why prefix fingerprints were
+      rejected. Row 17 stays `Preview`: the scan works now, it is not stronger.
 
   `InputGate::bind` has no production caller, so the cross-frame secret scan
   matches against an empty set on every real VM. The scan is correct and

--- a/specs/plans/293-stream-plane-followups.md
+++ b/specs/plans/293-stream-plane-followups.md
@@ -93,8 +93,33 @@ user or an auditor.
   diagnostic material there is — lands only in the unredacted file. The moment
   most worth reading is the one least protected.
 
-  Run the same `PiiRedactor` over console bytes on the read path, before they
-  reach a consumer. Read-side, so the file the VMM owns is untouched.
+  Run redaction over console bytes on the read path, before they reach a
+  consumer. Read-side, so the file the VMM owns is untouched.
+
+  **"Run the same `PiiRedactor`" is not directly possible, and that is the
+  work.** `PiiRedactor` lives in `mvm-hostd::supervisor::pii_redactor` and is
+  welded to that crate's egress inspector — it implements `Inspector`, and
+  carries `async_trait`, `InspectorVerdict`, `RequestCtx`. The console readers
+  are `mvm_core::stream_client::{console, output}`, and `mvm-client` reads
+  through them too. Both sit *below* `mvm-hostd`, so neither can name the type.
+
+  Injecting a trait from `mvm-cli` covers only the CLI. `mvm-client` reads
+  consoles as well and cannot reach `mvm-hostd` either, so that shape leaves a
+  consumer unredacted — the "correct, tested, unreachable" failure WS4 exists
+  to catch, inverted.
+
+  So the shape is: extract the pattern-matching core of `PiiRedactor` — the
+  `RegexSet` machinery and its rule names, which have no inspector dependency —
+  into `mvm-core` beside the existing `ingress_redaction` primitive, leave the
+  `Inspector` impl in `mvm-hostd` wrapping it, and have `ConsoleTail` hold it
+  non-optionally so an unredacted tail cannot be constructed. `mvm-core`
+  already carries `regex`, so the move adds no dependency.
+
+  Two things to get right. `OutputRequest` is `Copy`; adding an `Arc` field
+  breaks that across every construction site, so the redactor should travel
+  beside it rather than inside it. And the seam should be fallible in the same
+  shape as `mvm-hostd`'s stream `redact` seam, so a detector that can give up
+  fails closed rather than emitting raw bytes.
 
   Keep the existing notice honest: it currently tells an operator the console
   merges streams, is unchained, and is unredacted. When the third stops being

--- a/specs/plans/294-stream-plane-completion.md
+++ b/specs/plans/294-stream-plane-completion.md
@@ -8,31 +8,24 @@ What remains is WS-B plus the renumbering and the fleet slice.
 Tracking issue: tinylabscom/mvm#2152 (closed). PR: tinylabscom/mvm#2139 (merged).
 
 This is the state-of-the-world doc for the workload stream plane. The design
-lives in `specs/plans/283-workload-stream-plane.md`, the follow-ups in
+lives in `specs/plans/295-workload-stream-plane.md`, the follow-ups in
 `specs/plans/293-stream-plane-followups.md`, and the fleet slice in
-`specs/plans/292-fleet-stream-fan-out.md`. This doc says what is done, what is
+`specs/plans/296-fleet-stream-fan-out.md`. This doc says what is done, what is
 left, and the two traps that will otherwise cost a session.
 
-## Read this first: two plan numbers are ambiguous
+## Plan numbers: resolved
 
-`main` and the stream-plane branches independently claimed the same numbers:
+`main` and this effort had independently claimed 283 and 292. Renumbered:
 
-| Number | On `main` | On the stream-plane branches |
-| --- | --- | --- |
-| 283 | `283-production-object-store-volumes.md` | `283-workload-stream-plane.md` |
-| 292 | `292-tiered-artifact-storage-and-warm-start.md` | `292-fleet-stream-fan-out.md` |
+| Was | Now |
+| --- | --- |
+| `283-workload-stream-plane.md` | `295-workload-stream-plane.md` |
+| `292-fleet-stream-fan-out.md` | `296-fleet-stream-fan-out.md` |
 
-`main` already carries two 284s and two 285s, so the convention had slipped
-before this. **Refer to these documents by filename, never by number.**
-
-Renumbering to 295/296 is deferred until after #2139's merge lands — renaming a
-file inside an unresolved 42-file merge produces rename/modify conflicts, which
-resolve worse than content conflicts. Do it as a follow-up commit, not as part
-of the merge.
-
-- [ ] After #2139 merges: renumber `283-workload-stream-plane.md` and
-      `292-fleet-stream-fan-out.md` to free numbers, updating cross-references
-      in ADR-035, ADR-001, `specs/REFACTOR-STATUS.md`, and this doc.
+`main` keeps 283 (production object-store volumes) and 292 (tiered artifact
+storage). Prose references were repointed selectively, not by blanket
+substitution — several "plan 283" mentions in `SPRINT.md` are about the
+object-store plan's `storage-s3` removal and had to stay.
 
 ## Branch inventory
 
@@ -217,7 +210,7 @@ they are the most deferrable items here. WS2 is not — it is an open gap.
 
 ## Also queued
 
-- [ ] **`specs/plans/292-fleet-stream-fan-out.md`** — VM-to-VM fan-out,
+- [ ] **`specs/plans/296-fleet-stream-fan-out.md`** — VM-to-VM fan-out,
       unstarted. All seven design decisions (E1–E7) are settled in that
       document: redaction is a property of the edge, defaulting to redacted; an
       opt-out edge gives the consumer raw bytes while the transcript stays

--- a/specs/plans/294-stream-plane-completion.md
+++ b/specs/plans/294-stream-plane-completion.md
@@ -1,8 +1,11 @@
 # Plan 294 — stream plane completion and handoff
 
-**Status:** Active. Written to be picked up by someone with no prior context.
+**Status:** WS-A complete. WS-B outstanding.
 
-Tracking issue: tinylabscom/mvm#2152. Blocked PR: tinylabscom/mvm#2139.
+PR #2139 **merged** 2026-08-05 as `b567b01d6`, all lanes green. Issue #2152 closed.
+What remains is WS-B plus the renumbering and the fleet slice.
+
+Tracking issue: tinylabscom/mvm#2152 (closed). PR: tinylabscom/mvm#2139 (merged).
 
 This is the state-of-the-world doc for the workload stream plane. The design
 lives in `specs/plans/283-workload-stream-plane.md`, the follow-ups in
@@ -35,8 +38,8 @@ of the merge.
 
 | Branch | Worktree | State |
 | --- | --- | --- |
-| `docs/workload-stream-plane` | `.worktrees/mvm-stream-plane` | PR #2139, 60 commits, clean at `101c194d7`. **Conflicted with main.** |
-| `feat/stream-plane-followups` | `.worktrees/mvm-followups` | Clean at `a3643e1e4`. WS1 complete. No PR yet. |
+| `docs/workload-stream-plane` | *(worktree removable)* | **MERGED** as `b567b01d6`. |
+| `feat/stream-plane-followups` | `.worktrees/mvm-followups` | WS1 complete and pushed. **No PR yet.** |
 
 About 20 other worktrees are live and most have active work. Touch only these
 two.

--- a/specs/plans/294-stream-plane-completion.md
+++ b/specs/plans/294-stream-plane-completion.md
@@ -64,9 +64,17 @@ Resolving the conflicts starts CI on its own. Do not go hunting in `ci.yml`.
 
 ### The merge
 
-- [ ] `git merge origin/main` — **not** a rebase. 60 commits through 21 commits
-      of drift multiplies the conflicts and rewrites a published branch. The PR
-      squash-merges anyway, so a merge commit costs nothing.
+- [x] `git merge origin/main` — **done**, in two passes (`c5851cfb6`, then
+      `ad10db4c9` when main landed the crate rename mid-merge). CI dispatched
+      on the second push; the PR went `CONFLICTING` → `MERGEABLE` and
+      auto-merge is armed.
+
+`merge-tree`'s "changed in both" over-reported: of 42 such files only **8**
+actually conflicted, 10 hunks total. The second pass was larger — main
+renamed `mvm-protocol` to `mvm-contract` (#2154), which moved 72 references
+across 32 files and required moving this branch's `stream/` module into the
+renamed crate by hand, since git renames the crate's own files but cannot
+carry across a module the branch had added.
 
 **Disable `rerere` first** — `git config rerere.enabled false`, already set in
 that worktree. It has previously replayed a stale resolution and silently

--- a/specs/plans/294-stream-plane-completion.md
+++ b/specs/plans/294-stream-plane-completion.md
@@ -1,0 +1,226 @@
+# Plan 294 — stream plane completion and handoff
+
+**Status:** Active. Written to be picked up by someone with no prior context.
+
+Tracking issue: tinylabscom/mvm#2152. Blocked PR: tinylabscom/mvm#2139.
+
+This is the state-of-the-world doc for the workload stream plane. The design
+lives in `specs/plans/283-workload-stream-plane.md`, the follow-ups in
+`specs/plans/293-stream-plane-followups.md`, and the fleet slice in
+`specs/plans/292-fleet-stream-fan-out.md`. This doc says what is done, what is
+left, and the two traps that will otherwise cost a session.
+
+## Read this first: two plan numbers are ambiguous
+
+`main` and the stream-plane branches independently claimed the same numbers:
+
+| Number | On `main` | On the stream-plane branches |
+| --- | --- | --- |
+| 283 | `283-production-object-store-volumes.md` | `283-workload-stream-plane.md` |
+| 292 | `292-tiered-artifact-storage-and-warm-start.md` | `292-fleet-stream-fan-out.md` |
+
+`main` already carries two 284s and two 285s, so the convention had slipped
+before this. **Refer to these documents by filename, never by number.**
+
+Renumbering to 295/296 is deferred until after #2139's merge lands — renaming a
+file inside an unresolved 42-file merge produces rename/modify conflicts, which
+resolve worse than content conflicts. Do it as a follow-up commit, not as part
+of the merge.
+
+- [ ] After #2139 merges: renumber `283-workload-stream-plane.md` and
+      `292-fleet-stream-fan-out.md` to free numbers, updating cross-references
+      in ADR-035, ADR-001, `specs/REFACTOR-STATUS.md`, and this doc.
+
+## Branch inventory
+
+| Branch | Worktree | State |
+| --- | --- | --- |
+| `docs/workload-stream-plane` | `.worktrees/mvm-stream-plane` | PR #2139, 60 commits, clean at `101c194d7`. **Conflicted with main.** |
+| `feat/stream-plane-followups` | `.worktrees/mvm-followups` | Clean at `a3643e1e4`. WS1 complete. No PR yet. |
+
+About 20 other worktrees are live and most have active work. Touch only these
+two.
+
+Mechanics that bite: the shell cwd resets to the main checkout between
+commands, so use `cd <abs> &&` or `git -C`; and Bash writes into `.worktrees/*`
+are outside the primary working directory, so they are silently discarded
+without `dangerouslyDisableSandbox`.
+
+---
+
+## WS-A — Unblock PR #2139
+
+### The finding: CI has never been dispatched, and this is not a test failure
+
+`gh pr checks 2139` reports *no checks*. The API confirms zero workflow runs
+ever, for both the branch and the head SHA. The panel is empty, not red.
+
+For `pull_request` events GitHub tests `refs/pull/N/merge` — a merge commit it
+computes between head and base. With 42 conflicting files that ref cannot be
+computed, so **no workflow is ever dispatched**. `ci.yml` has no branch or path
+filter, and Actions is healthy on other PRs; nothing is misconfigured.
+
+Resolving the conflicts starts CI on its own. Do not go hunting in `ci.yml`.
+
+### The merge
+
+- [ ] `git merge origin/main` — **not** a rebase. 60 commits through 21 commits
+      of drift multiplies the conflicts and rewrites a published branch. The PR
+      squash-merges anyway, so a merge commit costs nothing.
+
+**Disable `rerere` first** — `git config rerere.enabled false`, already set in
+that worktree. It has previously replayed a stale resolution and silently
+dropped content in this repo. Verify `git diff --cached` before committing.
+
+#### Most conflicts resolve by taking both sides
+
+Main's 21 commits are largely **additive to the plan schema**: kernel pinning
+(`56f2cc705`), attested deployment references (`40b87a77c`, `2adc85e8f`),
+precomputed rootfs digest verification (`a620e3212`), agent verb tiers
+(`b2c6c5fec`, `970004aab`).
+
+This branch is **also additive** to the same structures: a `host.stream.v1`
+services grant, private `AdmittedPlan` fields, stream and transcript plumbing.
+
+So the dominant conflict is *both sides added a field or match arm at the same
+spot*. **Take both.** If you find yourself deleting a field, arm, test, or doc
+paragraph that only one side had, re-read — that is the failure mode this repo
+has actually hit.
+
+Where one side does win:
+
+- **`Cargo.lock`** — do not hand-merge. Take either side, let cargo regenerate,
+  commit the result.
+- **`specs/SPRINT.md`, `specs/REFACTOR-STATUS.md`** — take both sides' entries.
+  These are rollups; dropping a line silently un-does someone else's status
+  update.
+- **`public/astro.config.mjs`** — take both sides' nav entries.
+
+The 42 conflicting files span `crates/mvm-{cli,core,hostd,protocol,runtime,
+agentd,client,sdk}`, `Cargo.lock`, `README.md`, `public/astro.config.mjs`,
+`specs/SPRINT.md`, and `specs/REFACTOR-STATUS.md`. The full list is in #2152;
+`git merge origin/main` will reproduce it exactly.
+
+### Invariants that must survive the merge — verify each explicitly
+
+Several are claim-backed. A silent loss in a 42-file merge is a security
+regression, not a bug.
+
+- [ ] `AdmittedPlan` fields stay **private** — an input grant must not be
+      forgeable by an in-process struct literal
+- [ ] `host.stream.v1` grant, its default-deny, and the `--prod`
+      shell-entrypoint refusal
+- [ ] Workload guests keep **no NIC**; egress stays vsock-only (both `xtask`
+      vsock gates)
+- [ ] Single redaction seam — redaction runs once, *before* hash-chaining
+- [ ] Reserved `mvm.` fd-3 kind namespace — a workload must not forge
+      agent-authored control records
+- [ ] Transcript manifest format version, and the sealed-root **preimage** test
+      (it pins the JSON preimage, not a digest, so it survives a root change)
+
+### Gates
+
+```
+cargo fmt --all -- --check
+cargo +nightly fmt --all -- --check      # CI Lint uses NIGHTLY rustfmt
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run --workspace
+cargo test --workspace --doc             # nextest skips doctests
+cargo run -p xtask check-claim-catalog
+cargo run -p xtask check-uniform-vsock-egress
+cargo run -p xtask check-vsock-only-egress
+cargo run -p xtask check-no-spec-refs
+cargo run -p xtask check-core-runtime-free
+cargo run -p xtask check-guest-agent-runtime-free
+```
+
+Known-environmental, not caused by this branch: `check_cmd_rustup_on_host`
+(rustup absent on the dev machine), and seven `mvm-runtime` spawn tests that
+need an idle machine — they pass in under 1.3s each at idle, so run
+`-p mvm-runtime` alone rather than concluding they are broken.
+
+### Open question — who owns the `replay_vectors` failures?
+
+- [ ] Three `mvm-core plan::content_id::tests::replay_vectors::*` tests were
+      failing **before** any merge. Main added fields to `ExecutionPlan`, which
+      changes content IDs, so these are plausibly pinned vectors invalidated by
+      main's own schema change. Determine whether they fail on `origin/main`
+      alone — `/private/tmp/mvm-basecheck` is a spare detached worktree. If main
+      owns them, do not paper over it in this branch; report it separately.
+      This was never settled and should not be assumed either way.
+
+---
+
+## WS-B — `feat/stream-plane-followups`
+
+### WS1 — complete
+
+Landed in `a3643e1e4`, reviewed, spec compliance and task quality both
+approved. Fingerprints are computed inside `mvm-substitution-endpoint` where the
+credentials already live; only a 16-byte
+`SecretFingerprint { len, hash, category }` crosses to the CLI; `KnownSecret`
+was deleted rather than deprecated. Claim 17's limit 1 is genuinely closed and
+the row correctly stays `Preview`.
+
+The review's Important finding (the blanket carry stalling stdin) and all three
+Minors were fixed in that same commit. Details in
+`specs/plans/293-stream-plane-followups.md` §"WS1 follow-on".
+
+**Do not re-open the carry design.** The module doc in
+`crates/mvm-hostd/src/stream/secret_scan.rs` states the problem and its
+resolution in adjacent sections; reading only the first half suggests an
+unfixed defect. `DEFAULT_IDLE_FLUSH_AFTER` = 50ms and `InputSession::refresh`
+release the withheld tail on **elapsed time alone**.
+
+The reason that design is what it is, recorded so it is not re-litigated: the
+obvious alternative is binding *prefix* fingerprints so the scanner withholds
+only a live prefix. That looks free and is not. It makes the withhold/deliver
+decision **depend on content**, which is a **prefix oracle** — anyone holding
+the input grant feeds a byte, observes whether it was withheld, and walks a
+40-byte secret out in ~40×256 probes instead of 256⁴⁰. That is a
+secret-extraction path against what claim 13 protects, and strictly worse than
+a stall. The blanket carry is load-bearing precisely because it leaks nothing
+about content, and the idle release is safe precisely because elapsed time is
+not content.
+
+### Remaining
+
+- [ ] **WS2 — redact the console fallback.** It is currently unredacted while
+      the transcript is redacted, which is a real disclosure gap and the
+      highest-value item left on this branch.
+- [ ] **WS3 — gate prose against the ledger.** Prose drifted from the ledger
+      nine times during the stream-plane work, including witnesses that exist
+      nowhere: `audit_chain_carries_no_payload_bytes` is cited in `CLAUDE.md`
+      and was cited three times in the design plan, and does not exist.
+- [ ] **WS4 — gate dormant controls.** Six tasks shipped correct, tested,
+      unreachable machinery with no production caller, each caught only by
+      review. This is the single most repeated defect in the effort.
+
+WS3 and WS4 guard against recurrence rather than fixing a present defect, so
+they are the most deferrable items here. WS2 is not — it is an open gap.
+
+- [ ] Open a PR for this branch. It has none, and its work is invisible to CI
+      until it does.
+
+---
+
+## Also queued
+
+- [ ] **`specs/plans/292-fleet-stream-fan-out.md`** — VM-to-VM fan-out,
+      unstarted. All seven design decisions (E1–E7) are settled in that
+      document: redaction is a property of the edge, defaulting to redacted; an
+      opt-out edge gives the consumer raw bytes while the transcript stays
+      masked and the divergence is audited; the single-writer lease stays and
+      fan-in is a merge node; `lossy` (default) rings and marks a gap while
+      `reliable` fails the edge loudly, never silently dropping; DAG only,
+      rejected at admission; a broken edge fails the workflow, because a fresh
+      `SecretScanner` per session means reconnect would split a secret across
+      two scanners; and redaction opt-out needs operator acknowledgement shaped
+      like `MVM_ACK_UNRESTRICTED_NETWORK=1`.
+
+## Sequencing
+
+WS-A first — it unblocks CI on 60 commits of finished work, and nothing else on
+this effort can merge behind it. WS2 next, since it is an open disclosure gap.
+WS3 and WS4 after. The fleet slice last; it depends on the stream plane being
+on `main`.

--- a/specs/plans/295-workload-stream-plane.md
+++ b/specs/plans/295-workload-stream-plane.md
@@ -1,4 +1,4 @@
-# Plan 283 — Workload stream plane
+# Plan 295 — Workload stream plane
 
 **Status:** Proposed.
 

--- a/specs/plans/296-fleet-stream-fan-out.md
+++ b/specs/plans/296-fleet-stream-fan-out.md
@@ -1,4 +1,4 @@
-# Plan 292 — fleet stream fan-out
+# Plan 296 — fleet stream fan-out
 
 **Status:** Proposed.
 

--- a/xtask/mutation-witness-baseline.json
+++ b/xtask/mutation-witness-baseline.json
@@ -169,8 +169,20 @@
       ]
     },
     {
+<<<<<<< HEAD
       "path": "crates/mvm-contract/src/policy/network_policy.rs",
       "package": "mvm-contract",
+=======
+      "path": "crates/mvm-hostd/src/supervisor/substitution_endpoint.rs",
+      "package": "mvm-hostd",
+      "claims": [
+        17
+      ]
+    },
+    {
+      "path": "crates/mvm-protocol/src/policy/network_policy.rs",
+      "package": "mvm-protocol",
+>>>>>>> b1153c154 (fix(hostd): release the withheld tail on writer silence)
       "claims": [
         10
       ]
@@ -202,6 +214,13 @@
       "package": "mvm-runtime",
       "claims": [
         10
+      ]
+    },
+    {
+      "path": "crates/mvm-runtime/src/substitution_spawn.rs",
+      "package": "mvm-runtime",
+      "claims": [
+        17
       ]
     },
     {

--- a/xtask/mutation-witness-baseline.json
+++ b/xtask/mutation-witness-baseline.json
@@ -91,6 +91,27 @@
       ]
     },
     {
+      "path": "crates/mvm-contract/src/policy/network_policy.rs",
+      "package": "mvm-contract",
+      "claims": [
+        10
+      ]
+    },
+    {
+      "path": "crates/mvm-contract/src/protocol/broker.rs",
+      "package": "mvm-contract",
+      "claims": [
+        12
+      ]
+    },
+    {
+      "path": "crates/mvm-contract/src/protocol/vm_backend.rs",
+      "package": "mvm-contract",
+      "claims": [
+        13
+      ]
+    },
+    {
       "path": "crates/mvm-core/src/plan/bundle.rs",
       "package": "mvm-core",
       "claims": [
@@ -169,36 +190,10 @@
       ]
     },
     {
-<<<<<<< HEAD
-      "path": "crates/mvm-contract/src/policy/network_policy.rs",
-      "package": "mvm-contract",
-=======
       "path": "crates/mvm-hostd/src/supervisor/substitution_endpoint.rs",
       "package": "mvm-hostd",
       "claims": [
         17
-      ]
-    },
-    {
-      "path": "crates/mvm-protocol/src/policy/network_policy.rs",
-      "package": "mvm-protocol",
->>>>>>> b1153c154 (fix(hostd): release the withheld tail on writer silence)
-      "claims": [
-        10
-      ]
-    },
-    {
-      "path": "crates/mvm-contract/src/protocol/broker.rs",
-      "package": "mvm-contract",
-      "claims": [
-        12
-      ]
-    },
-    {
-      "path": "crates/mvm-contract/src/protocol/vm_backend.rs",
-      "package": "mvm-contract",
-      "claims": [
-        13
       ]
     },
     {
@@ -242,15 +237,15 @@
   "uncovered_claims": [
     {
       "number": 4,
-      "why": "no fn: witness — witnessed by CI lanes only, nothing to mutate"
+      "why": "no fn: witness \u2014 witnessed by CI lanes only, nothing to mutate"
     },
     {
       "number": 5,
-      "why": "no fn: witness — witnessed by CI lanes only, nothing to mutate"
+      "why": "no fn: witness \u2014 witnessed by CI lanes only, nothing to mutate"
     },
     {
       "number": 7,
-      "why": "no fn: witness — witnessed by CI lanes only, nothing to mutate"
+      "why": "no fn: witness \u2014 witnessed by CI lanes only, nothing to mutate"
     },
     {
       "number": 16,
@@ -671,7 +666,7 @@
     {
       "file": "crates/mvm-contract/src/policy/network_policy.rs",
       "mutant": "replace NetworkPolicy::trusted_build_egress -> Self with Default::default()",
-      "reason": "Observed 2026-07-29. No mvm-contract test asserts the shape of the trusted-build egress policy. The mutant substitutes the deny-all default, so it makes the policy stricter, not weaker — a functional coverage gap rather than a security hole. Untriaged."
+      "reason": "Observed 2026-07-29. No mvm-contract test asserts the shape of the trusted-build egress policy. The mutant substitutes the deny-all default, so it makes the policy stricter, not weaker \u2014 a functional coverage gap rather than a security hole. Untriaged."
     }
   ]
 }


### PR DESCRIPTION
Follow-ups to the workload stream plane (#2139), replayed onto `main` after that PR squash-merged.

## WS1 — bind fingerprints, not plaintext

Closes claim 17's last reachability limit. The cross-frame secret scan previously matched against an empty set on every real VM, because binding it would have required plaintext secrets in the CLI process — which holds none, by design.

Fingerprints are now computed inside `mvm-substitution-endpoint`, the separate process that already holds the credentials. Only a 16-byte `SecretFingerprint { len, hash, category }` crosses to the CLI. `KnownSecret` is deleted rather than deprecated, so no binding can take bytes.

Two costs recorded rather than discovered: a hash collision refuses a legitimate frame (the refusal names what it compared and disclaims identity), and the CLI learns secret *lengths*. ADR-001's limit 1 is closed; a new permanent limit 5 records the hash-match cost. Row 17 stays `Preview` — the scan works now, it is not stronger.

### The carry is a stall, and the obvious fix is a vulnerability

Unable to tell a live prefix from an innocent tail, the scanner withheld a fixed `longest_secret - 1` bytes. With a 40-byte secret an operator typing an 11-byte line delivered nothing, so a line-oriented workload never answered and the operator never sent the write that would release it.

The obvious repair is binding *prefix* fingerprints so only a live prefix is withheld. That makes the withhold decision depend on content, handing anyone with the input grant a **prefix oracle**: feed a byte, observe whether it was withheld, walk a 40-byte secret out in ~40×256 probes instead of 256⁴⁰. The blanket carry is load-bearing precisely because it leaks nothing.

Instead the tail is released after `DEFAULT_IDLE_FLUSH_AFTER` (50ms) of writer silence, on **elapsed time alone**. What that gives up is a secret split across the silence, which needs a sender patient enough to pause mid-credential — a determined caller, and the scan has never defended against one, since base64 defeats it outright. The residual sits inside a limit that was already permanent; the stall sat inside none.

## Plan renumbering

`main` and this effort independently claimed 283 and 292. The stream-plane pair moves to `295-workload-stream-plane.md` and `296-fleet-stream-fan-out.md`; `main` keeps 283 (object-store volumes) and 292 (tiered artifact storage).

Prose was repointed selectively, not by substitution — several "plan 283" mentions in `SPRINT.md` describe the object-store plan removing `storage-s3`, and renaming those would misattribute that work.

## WS2 corrected, not implemented

The spec said to run the same `PiiRedactor` over console bytes. It cannot be called from where consoles are read: `PiiRedactor` implements `mvm-hostd`'s egress `Inspector` and carries `async_trait`/`InspectorVerdict`/`RequestCtx`, while the readers are in `mvm-core` and are used by `mvm-client` too — both below `mvm-hostd`. Injecting a trait from `mvm-cli` would cover the CLI and leave `mvm-client` unredacted, which is the dormant-control shape WS4 exists to catch.

The corrected shape — extract the `RegexSet` core into `mvm-core`, leave the `Inspector` impl wrapping it — is recorded in plan 293. WS2 remains open; the console fallback is still unredacted while the transcript is redacted.

## Verification

`cargo clippy --workspace --all-targets -- -D warnings` clean; fmt clean. CI gates the rest.
