### PR TITLE
Record mvmd-only production launch authority

### DIFF
--- a/specs/01-project.md
+++ b/specs/01-project.md
@@ -347,6 +347,12 @@ aren't even built into it, it runs only from a signed and admitted execution
 plan, and dependency, egress, and provenance gates are all enforced. There is no
 interactive way in, by construction.
 
+There is exactly one production launch authority: an authenticated launch
+kicked off by `mvmd`. Every other launch — including local `mvmctl`, SDK,
+library, test, benchmark, and host-daemon launches — is development mode. A
+production-shaped artifact or `--prod`-style preparation flag does not change
+that launch classification. See [ADR-037](adrs/037-mvmd-only-production-launch.md).
+
 The boundary is one-directional: development conveniences never carry over into
 a production workload, and a sealed production microVM can't be dropped back into
 an interactive dev session. Choosing production isn't a flag that loosens under

--- a/specs/adrs/037-mvmd-only-production-launch.md
+++ b/specs/adrs/037-mvmd-only-production-launch.md
@@ -1,0 +1,44 @@
+# ADR-037 — `mvmd` is the only production launch authority
+
+**Status: Accepted**
+**Date: 2026-08-04**
+
+## Context
+
+`mvm` has both development and production security postures. A production
+workload is sealed, admitted, and launched under the fleet control plane;
+development workloads retain the local iteration and interactive surfaces.
+Without an explicit launch-authority rule, a local CLI, SDK, test harness, or
+future embedding could accidentally be treated as a production launcher merely
+because it supplied a production-looking artifact or flag.
+
+## Decision
+
+The **only** path that may launch a workload in production is a launch kicked
+off by the authenticated `mvmd` control plane. `mvmd` owns production
+placement, admission, and launch authority; `mvm` executes the resulting
+admitted request.
+
+Every launch that is not initiated by `mvmd` is **development mode**, without
+exception. This includes local `mvmctl` and SDK launches, direct library or
+host-daemon invocations, test and benchmark harnesses, and developer tooling.
+Those paths must use the development posture and must never be inferred to be
+production from an artifact profile, environment variable, or operator flag.
+
+This decision governs **launch**, not artifact preparation. Local tooling may
+still build, inspect, or validate a sealed/production-shaped artifact for
+development and deployment preparation; that activity does not itself launch
+production.
+
+## Consequences
+
+- Production launch authority is identified by authenticated `mvmd` origin,
+  not by caller convention or a local boolean.
+- Local execution is always a dev-tier operation, even when it exercises the
+  same runtime code used by the fleet.
+- The `mvm`/`mvmd` boundary must preserve the origin and admission evidence
+  needed for `mvm` to reject any attempt to use the production posture outside
+  the `mvmd`-initiated path.
+- Documentation and APIs must describe local `--prod`-shaped operations as
+  artifact preparation or validation unless they are part of an `mvmd`
+  launch.

--- a/specs/refactor/02-architecture.md
+++ b/specs/refactor/02-architecture.md
@@ -66,6 +66,16 @@ Kill: `~/.cache/mvm`, `~/.config/mvm`, `~/.local/{state,share}/mvm`, `$XDG_RUNTI
 
 ## Backend & egress model
 
+### Launch authority
+
+Production launch is an `mvmd`-only capability. An authenticated `mvmd`
+request supplies the production launch authority and admitted execution
+context; `mvm` does not promote a local caller into production. All launches
+from `mvmctl`, the SDK, direct libraries, tests, benchmarks, or host-daemon
+development tooling are dev-mode launches, even when they consume a sealed or
+production-shaped artifact. This is a launch-origin invariant, not an
+operator-selected mode flag; see [ADR-037](../adrs/037-mvmd-only-production-launch.md).
+
 - Backends: **libkrun** (macOS 13–25 + Linux), **HVF** (macOS 26+), **Firecracker** (Linux workload), and **wasm** (a WASI wasm-container — a core goal, see [§Wasm-container backend & `no_std` core](#wasm-container-backend--no_std-core-core-goal) below). **QEMU kept** as an opt-in Tier-2 Linux dev/test substrate (never workload-bearing; the drop was ratified against — see [07-progress-and-decisions.md](07-progress-and-decisions.md)). `mock` behind `test-support`.
 - Selected via the existing `BackendKind` enum + `backend_catalog!` registry — **never string-matched**. The ~6 remaining `backend.name() == "…"` sites in `mvm-cli` and the dead `"vz"` arms are removed.
 - **One host-mediated, default-deny, audited egress boundary for every backend**, transport-abstracted via the runner seam: vsock for microVM workloads and WASI host-calls for the wasm backend. Firecracker, libkrun, and HVF all use `WorkloadRunner` with `RealEndpointSpawner`; any backend that cannot mediate egress through the host fails closed on `--network-allow`. There is no guest NIC, raw packet tunnel, or smoltcp L3 fallback in the production workload path.


### PR DESCRIPTION
## Summary

- Add ADR-037 establishing `mvmd` as the only production launch authority.
- Classify every non-`mvmd` launch as development mode.
- Clarify the rule in the project overview and target architecture.

## Scope

This records launch authority, not artifact preparation: local tooling may still build or validate production-shaped artifacts, but only an authenticated `mvmd`-initiated launch is production.

## Validation

- `git diff --check`
- Documentation-only change; no code tests required.
