### PR TITLE
docs(plan291): record attested boot acceptance

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,10 +1,6 @@
 # Refactor status
 
-<<<<<<< HEAD
 Last updated: 2026-08-05
-=======
-Last updated: 2026-08-04
->>>>>>> b1153c154 (fix(hostd): release the withheld tail on writer silence)
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -25,14 +21,17 @@ for detailed scope and acceptance criteria.
         gates and merged into main
   - [~] WS4 tier follows the attestation
     - [x] Agent-verb grant derives from admitted run shape, not image sidecar
-    - [~] Bind the tier to an attested artifact and replace the interactive
-          feature/symbol witnesses with conformance scenarios. Local
+    - [x] Bind the tier to an attested artifact. Local
           `machine run --deployment` verifies and persists the signed record
-          plus exact rootfs binding; remote extraction/boot are merged, and
-          persistent-OCI console listeners now pre-open only for dev profiles
-          (PR #2157). Feature-fork removal, guest-image validation, and the
-          final cross-path acceptance matrix remain. Grant enforcement now
-          proves a complete ProdSafe grant refuses Exec and ConsoleOpen.
+          plus exact rootfs binding; remote extraction/boot are merged, the
+          cross-path acceptance matrix is green, and child issues #2144 and
+          mvmd #208 are closed. Persistent-OCI console listeners now pre-open
+          only for dev profiles (PR #2157). Grant enforcement proves a
+          complete ProdSafe grant refuses both Exec and ConsoleOpen.
+    - [~] Replace the interactive feature/symbol witnesses with conformance
+          scenarios. Mainline workspace tests, Clippy, doctests, and policy
+          xtasks are green; feature-fork removal and full guest-image witness
+          replacement remain open pending the explicit security decision.
 
 - [~] Plan 290 — Sensitive egress redaction
       (`specs/plans/290-sensitive-egress-redaction.md`)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -40,13 +40,14 @@
       compile errors, while `--once` remains fail-fast for automation. PR
       #2109 is merged and its required queue gates passed.
 - [~] Develop → build → deploy an attested workload image — **plan 291**.
-      WS1–WS3 are merged with their queue-gate evidence. WS4 remains open:
-      local `machine run --deployment` now verifies and persists an exact
-      deploy record/rootfs binding, remote record extraction and boot are
-      merged, and persistent-OCI console pre-open is limited to dev profiles
-      (PR #2157). The universal-agent design decision and guest-image
-      conformance remain open. Tracking issues #2144/#208 own the final
-      local/remote boot acceptance matrix.
+      WS1–WS3 are merged with their queue-gate evidence. WS4 exact-artifact
+      authority, local/remote deployment boot, and the acceptance matrix are
+      complete; mvm #2144 and mvmd #208 are closed. Current-main validation
+      passed workspace tests (with the rustup-sensitive host test rerun using
+      the normal rustup home), workspace all-target Clippy with warnings
+      denied, doctests, and the conformance, honesty, deferral, overclaim, and
+      no-spec-reference xtask gates. The universal-agent security decision and
+      the dependent full guest-image witness replacement remain open.
 - [x] `mvmctl deploy` — **plan 291 WS1**. Local deployment now has a durable
       sealed archive and deploy record path, with BLAKE3 as the native artifact
       identity, SHA-256 retained for interoperability, optional environment

--- a/specs/plans/291-develop-build-deploy-attested.md
+++ b/specs/plans/291-develop-build-deploy-attested.md
@@ -1,9 +1,10 @@
 # Develop → build → deploy: one stupidly simple path to an attested workload image
 
 **Status:** In progress. WS1–WS3 are merged and their required queue gates are
-green; WS4 attestation binding and the universal-agent/conformance closure
-remain open. The persistent-OCI console-listener hardening is merged as PR
-#2157.
+green; WS4 exact-artifact authority, local/remote deployment boot, and the
+required conformance/policy gates are complete. The universal-agent security
+decision remains open. The persistent-OCI console-listener hardening is merged
+as PR #2157.
 
 **Goal:** A developer starts from an OCI image or a Nix flake, iterates on a
 machine until the workload actually works — including discovering the
@@ -139,13 +140,13 @@ same sealed, hash-pinned, CVE-scanned volume.
 - [x] Make the agent-verb grant depend on the admitted run shape rather than
       the image sidecar: a baked-entrypoint boot on a non-dev profile receives
       ProdSafe verbs; a PTY or ad-hoc argv receives DevOnly verbs.
-- [~] Make the run tier come from whether the run uses an attested artifact,
+- [x] Make the run tier come from whether the run uses an attested artifact,
       not from a build variant and not from an unattested CLI flag. Local
       `mvmctl machine run --deployment DIR` now verifies the signed deploy
       record and exact `rootfs.ext4`, persists the canonical deployment
       directory, and revalidates it on restart. Remote record extraction and
-      boot are merged; the final cross-path acceptance matrix remains in
-      #2144/#208.
+      boot are merged; the cross-path acceptance matrix is complete and
+      tracked child issues #2144 and mvmd #208 are closed.
 - [x] Keep host-side console listeners aligned with the run profile: persistent
       OCI boots pre-open the console data range only for `dev`, while sealed
       production boots expose no host-side console listeners (PR #2157).
@@ -157,8 +158,10 @@ same sealed, hash-pinned, CVE-scanned volume.
       symbol-grep jobs live in `security.yml`, which does not run on pull
       requests, so a conformance scenario in the PR-gating suite is stronger
       than what it replaces, not weaker. The grant-enforcement unit now proves
-      a complete ProdSafe grant refuses both `Exec` and `ConsoleOpen`; the
-      feature-fork replacement and full guest-image validation remain open.
+      a complete ProdSafe grant refuses both `Exec` and `ConsoleOpen`, and the
+      mainline workspace conformance/policy gates are green; replacing the
+      feature fork and completing full guest-image validation remain tied to
+      the explicit universal-agent decision.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

- record that exact boot-artifact authority and local/remote deployment acceptance are complete
- record the closed mvm #2144 and mvmd #208 child issues
- record the current-main workspace and policy-gate evidence
- keep the universal-agent feature-fork decision explicitly open pending owner approval

## Validation

- `cargo fmt --all -- --check`
- workspace tests: 1,537 passed; the rustup-sensitive host test passed when rerun with the normal rustup home
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --doc`
- xtask: `check-conformance`, `check-honesty`, `check-deferrals`, `check-no-overclaim`, `check-no-spec-refs-in-comments`
