### PR TITLE
feat: add native HVF warm handoff

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -279,7 +279,7 @@ pub(in crate::commands) struct MachineRunArgs {
     #[arg(long, default_value = "512M")]
     pub memory: String,
     /// Select a security profile.
-    #[arg(long, value_enum, default_value = "standard")]
+    #[arg(long, value_enum, default_value = "dev")]
     pub profile: RunProfile,
     /// Allow a production-safe guest-agent verb (repeatable).
     #[arg(long = "agent-verb", value_name = "VERB")]
@@ -1081,7 +1081,10 @@ impl MachineCreateArgs {
             .mem_initial
             .or_else(|| workflow.and_then(|workflow| workflow.mem_initial.clone()));
         let _ = validate_machine_memory(&memory, mem_initial.as_deref())?;
-        let profile = self.profile.unwrap_or(RunProfile::Standard);
+        // CLI-created machines are development workloads unless the caller
+        // explicitly opts into a stricter profile. The daemon is the only
+        // producer that should supply a non-dev production profile by policy.
+        let profile = self.profile.unwrap_or(RunProfile::Dev);
         let profile_name = run_profile_name(profile).to_string();
         let init = workflow
             .map(|workflow| workflow.init.clone())
@@ -1500,7 +1503,7 @@ fn run_args_for_image_revert(
             allow_host: Vec::new(),
             cpus: 2,
             memory: "512M".to_string(),
-            profile: RunProfile::Standard,
+            profile: RunProfile::Dev,
             agent_verb: Vec::new(),
             volume: Vec::new(),
             env: Vec::new(),

--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -447,7 +447,7 @@ pub(in crate::commands) fn boot_persistent_by_name(
             allow_host: Vec::new(),
             cpus: 2,
             memory: "512M".to_string(),
-            profile: RunProfile::Standard,
+            profile: RunProfile::Dev,
             agent_verb: Vec::new(),
             volume: Vec::new(),
             env: Vec::new(),

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -383,7 +383,7 @@ fn run_defaults_match_the_lower_level_runner() {
     let args = parse_run(&["run", "--image", "alpine", "--", "true"]).expect("parse");
     assert_eq!(args.cpus, 2);
     assert_eq!(args.memory, "512M");
-    assert_eq!(args.profile, RunProfile::Standard);
+    assert_eq!(args.profile, RunProfile::Dev);
     assert!(!args.json);
     assert!(!args.dry_run);
     assert!(args.volume.is_empty());
@@ -776,13 +776,31 @@ fn run_volume_is_threaded_into_managed_spec_with_absolute_host() {
 fn run_rw_volume_requires_dev_profile() {
     let dir = tempfile::tempdir().expect("tmpdir");
     let host = dir.path().to_string_lossy().into_owned();
-    // Default profile is `standard` → :rw refused.
+    // CLI runs default to `dev`, so a writable share works without repeating
+    // the profile flag.
+    let default_args = parse_run(&[
+        "run",
+        "--image",
+        "x",
+        "--name",
+        "web",
+        "--volume",
+        &format!("{host}:/work:rw"),
+    ])
+    .expect("parse");
+    let default_spec = machine_run_spec(&default_args, "web".to_string(), None)
+        .expect("default dev profile allows :rw");
+    assert!(default_spec.volumes[0].ends_with(":/work:rw"));
+
+    // An explicitly stricter profile still refuses the writable share.
     let std_args = parse_run(&[
         "run",
         "--image",
         "x",
         "--name",
         "web",
+        "--profile",
+        "standard",
         "--volume",
         &format!("{host}:/work:rw"),
     ])
@@ -1517,6 +1535,7 @@ fn create_auto_generates_a_name_when_omitted() {
     // explicit one, so a subsequent `start`/`ls`/`rm` can reference it.
     assert!(!spec.name.is_empty());
     validate_machine_name(&spec.name).expect("generated name is valid");
+    assert_eq!(spec.profile, "dev");
 }
 
 #[test]
@@ -1598,14 +1617,14 @@ fn create_rejects_flake_backed_manifest_for_machine_specs() {
 }
 
 #[test]
-fn create_requires_dev_profile_when_manifest_declares_dev_init() {
+fn create_defaults_to_dev_profile_when_manifest_declares_dev_init() {
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::write(
         dir.path().join("mvm.toml"),
         "image = \"alpine:latest\"\n[dev]\ninit = [\"echo hi\"]\n",
     )
     .expect("manifest");
-    let err = MachineCreateArgs {
+    let spec = MachineCreateArgs {
         name: Some("web".to_string()),
         manifest: Some(dir.path().join("mvm.toml").display().to_string()),
         image: None,
@@ -1619,7 +1638,24 @@ fn create_requires_dev_profile_when_manifest_declares_dev_init() {
         json: false,
     }
     .into_spec()
-    .expect_err("standard profile should refuse dev.init");
+    .expect("CLI-created machines default to dev");
+    assert_eq!(spec.profile, "dev");
+
+    let err = MachineCreateArgs {
+        name: Some("web".to_string()),
+        manifest: Some(dir.path().join("mvm.toml").display().to_string()),
+        image: None,
+        net: false,
+        allow_host: Vec::new(),
+        cpus: None,
+        memory: None,
+        mem_initial: None,
+        profile: Some(RunProfile::Standard),
+        force: false,
+        json: false,
+    }
+    .into_spec()
+    .expect_err("explicit standard profile should refuse dev.init");
     assert!(
         err.to_string()
             .contains("dev.init requires a dev-capable profile")

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -509,6 +509,7 @@ where
         Ok(c) => c,
         Err(e) => {
             tracing::warn!(standby = %handle.id, error = %e, "build claim failed; cold-booting");
+            stop_live_standby_best_effort(backend, &handle);
             let _ = pool.remove(&handle.id);
             return Ok(LaunchDecision::ColdBoot);
         }
@@ -519,6 +520,7 @@ where
         Ok(id) => id,
         Err(e) => {
             tracing::warn!(standby = %handle.id, error = %e, "cold-booting");
+            stop_live_standby_best_effort(backend, &handle);
             let _ = pool.remove(&handle.id);
             return Ok(LaunchDecision::ColdBoot);
         }
@@ -546,9 +548,18 @@ where
         }
         Err(e) => {
             tracing::warn!(standby = %handle.id, error = %e, "standby claim failed; cold-booting");
+            stop_live_standby_best_effort(backend, &handle);
             let _ = pool.remove(&handle.id); // spent/broken — never leave it idle
             Ok(LaunchDecision::ColdBoot)
         }
+    }
+}
+
+fn stop_live_standby_best_effort(backend: &AnyBackend, handle: &StandbyHandle) {
+    if handle.pid != 0
+        && let Err(e) = backend.stop_transient(&VmId(handle.id.clone()))
+    {
+        tracing::debug!(standby = %handle.id, error = %e, "failed to stop discarded live standby");
     }
 }
 
@@ -612,7 +623,7 @@ fn compat_for_launch(backend: &dyn VmBackend, cfg: &VmStartConfig) -> Result<Sta
 /// child's own policy. A shared parent therefore holds nothing per-launch that
 /// could reach the next claim.
 fn warm_eligible_launch(cfg: &VmStartConfig) -> bool {
-    cfg.volumes.is_empty() && cfg.virtiofs_root.is_none()
+    cfg.volumes.is_empty() && cfg.virtiofs_root.is_none() && !cfg.dev_console
 }
 
 /// Attempt a warm-pool claim for this launch. Returns the claimed `VmId` (the standby-id

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1766,7 +1766,7 @@ fn test_run_command_is_recognized() {
     match cli.command {
         Commands::Machine(mg) => match mg.action {
             machine::MachineAction::Run(machine::MachineRunArgs { profile, argv, .. }) => {
-                assert_eq!(profile, exec::RunProfile::Standard);
+                assert_eq!(profile, exec::RunProfile::Dev);
                 assert_eq!(argv, vec!["/bin/true".to_string()]);
             }
             _ => panic!("Expected machine run"),
@@ -3073,7 +3073,7 @@ fn run_default_profile_argv_only() {
                 assert!(allow_host.is_empty());
                 assert_eq!(cpus, 2);
                 assert_eq!(memory, "512M");
-                assert_eq!(profile, exec::RunProfile::Standard);
+                assert_eq!(profile, exec::RunProfile::Dev);
                 assert!(volume.is_empty());
                 assert!(env.is_empty());
                 assert_eq!(timeout, None);

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -2,7 +2,8 @@
 //!
 //! The former bare `mvmctl exec` was folded into `run`: `run` was already a
 //! strict superset (see `RunArgs::into_exec_args`), so `exec` is gone and
-//! `run --profile dev -- <argv>` covers its interactive case. The `Args`
+//! `run -- <argv>` covers its interactive case with the dev profile by
+//! default. The `Args`
 //! struct + internal request machinery stay — `run_secure` reuses them.
 
 use anyhow::{Context, Result};
@@ -163,7 +164,7 @@ pub(in crate::commands) struct RunArgs {
     #[arg(long, default_value = "512M")]
     pub memory: String,
     /// Security profile for the transient run.
-    #[arg(long, value_enum, default_value = "standard")]
+    #[arg(long, value_enum, default_value = "dev")]
     pub profile: RunProfile,
     /// Share a host directory into the guest. Format: `HOST_PATH:/GUEST_PATH[:MODE]`.
     /// MODE defaults to `ro`; `rw` is allowed only with `--profile dev` or `permissive`.
@@ -931,7 +932,7 @@ fn emit_oci_run_admission(
     timeout_secs: u64,
     network_mode: mvm_contract::plan::NetworkMode,
 ) -> Result<()> {
-    let image_sha256 = mvm_core::crypto::image_verify::sha256_file(&image.rootfs_path)
+    let image_sha256 = mvm_core::crypto::image_verify::sha256_file_cached(&image.rootfs_path)
         .with_context(|| {
             format!(
                 "hashing OCI rootfs at {} for run --image admission",

--- a/crates/mvm-cli/src/doctor/warm_start.rs
+++ b/crates/mvm-cli/src/doctor/warm_start.rs
@@ -268,7 +268,7 @@ mod tests {
             ("apple-container".to_string(), false),
             ("docker".to_string(), false),
             ("firecracker".to_string(), false),
-            ("hvf".to_string(), false),
+            ("hvf".to_string(), true),
             ("libkrun".to_string(), false),
             ("qemu".to_string(), false),
             ("wasm".to_string(), false),

--- a/crates/mvm-contract/src/protocol/vm_backend.rs
+++ b/crates/mvm-contract/src/protocol/vm_backend.rs
@@ -722,8 +722,8 @@ pub struct StandbySpec {
     pub control_socket: String,
     /// Per-VM state dir the standby writes its pid into.
     pub vm_state_dir: String,
-    /// Source rootfs image path for HVF saved-standbys. `None` for libkrun (no rootfs
-    /// is baked in at spawn; any workload rootfs attaches at claim time).
+    /// Source rootfs image path for image-bound standbys. `None` for libkrun
+    /// (no rootfs is baked in at spawn; any workload rootfs attaches at claim time).
     pub image_path: Option<String>,
     /// Sha256 hex of `image_path` for the compat key. `None` for libkrun.
     pub image_sha256: Option<String>,
@@ -778,10 +778,10 @@ pub struct StandbyCompat {
 
 /// A recorded standby (persisted as `~/.mvm/pool/<id>/standby.json`).
 ///
-/// `pid` is 0 for saved-state standbys (HVF): the supervisor that booted the seed VM was
-/// stopped at capture time; no process is running. `reap_stale` and the liveness checks
-/// treat pid=0 as "TTL-only" — the standby is never pruned for a dead process, only for
-/// expiry. No real process has pid 0.
+/// `pid` is 0 for saved-state standbys: the supervisor that booted the seed VM
+/// was stopped at capture time; no process is running. A live standby retains
+/// its supervisor PID and is parked until a claim hands it off. `reap_stale`
+/// treats pid=0 as "TTL-only"; no real process has pid 0.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StandbyHandle {
     pub id: String,
@@ -796,7 +796,8 @@ pub struct StandbyHandle {
     pub binding_nonce: String,
     pub spawned_unix_secs: u64,
     pub state: StandbyState,
-    /// `None` for libkrun (image-agnostic); `Some(sha256-hex)` for HVF saved-standbys.
+    /// `None` for libkrun (image-agnostic); `Some(sha256-hex)` for image-bound
+    /// standbys.
     #[serde(default)]
     pub image_sha256: Option<String>,
     /// The content-addressed checkpoint this parent was captured as, set once
@@ -1229,8 +1230,8 @@ mod tests {
         );
     }
 
-    /// An HVF saved-standby uses pid=0 (no running supervisor) and must be treated
-    /// as TTL-only by the liveness path (is_saved_state()).
+    /// A saved-state standby uses pid=0 (no running supervisor) and must be
+    /// treated as TTL-only by the liveness path (is_saved_state()).
     #[test]
     fn standby_handle_saved_state_pid_zero_flag() {
         let saved = StandbyHandle {

--- a/crates/mvm-core/src/residency.rs
+++ b/crates/mvm-core/src/residency.rs
@@ -126,11 +126,15 @@ fn parse_env_residency(raw: &str) -> Option<ResidencyPolicy> {
     }
 }
 
-fn host_default_for(_is_hvf_default_tier: bool) -> ResidencyPolicy {
-    // The default selectable macOS backend does not advertise a standby pool.
-    // Keep the automatic policy parked until a backend with that capability is
-    // selected; an explicit warm request must still fail with a typed error.
-    ResidencyPolicy::parked()
+fn host_default_for(is_hvf_default_tier: bool) -> ResidencyPolicy {
+    // Native HVF keeps one authority-free, paused standby parent so unnamed
+    // transient runs can take the live handoff path. Other hosts retain the
+    // parked default until their own backend advertises an equivalent path.
+    if is_hvf_default_tier {
+        ResidencyPolicy::always_warm()
+    } else {
+        ResidencyPolicy::parked()
+    }
 }
 
 /// The warm-pool size to use: an explicit request wins; otherwise the resolved
@@ -210,8 +214,8 @@ mod tests {
     }
 
     #[test]
-    fn host_default_is_parked_until_a_standby_backend_is_selected() {
-        assert_eq!(host_default_for(true), ResidencyPolicy::parked());
+    fn host_default_warms_native_hvf_and_parks_other_hosts() {
+        assert_eq!(host_default_for(true), ResidencyPolicy::always_warm());
         assert_eq!(host_default_for(false), ResidencyPolicy::parked());
     }
 

--- a/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
@@ -39,6 +39,49 @@ fn exe_has_hypervisor_entitlement(exe: &std::path::Path) -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn signed_marker_path(exe: &std::path::Path) -> std::path::PathBuf {
+    let mut marker = exe.as_os_str().to_os_string();
+    marker.push(".mvm-hvf-signed");
+    std::path::PathBuf::from(marker)
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn executable_fingerprint(exe: &std::path::Path) -> Option<String> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = std::fs::metadata(exe).ok()?;
+    let modified = metadata
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?;
+    Some(format!(
+        "{}:{}:{}:{}",
+        metadata.ino(),
+        metadata.len(),
+        modified.as_secs(),
+        modified.subsec_nanos()
+    ))
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn signed_marker_matches(exe: &std::path::Path) -> bool {
+    let Some(fingerprint) = executable_fingerprint(exe) else {
+        return false;
+    };
+    std::fs::read_to_string(signed_marker_path(exe))
+        .map(|cached| cached.trim() == fingerprint)
+        .unwrap_or(false)
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn record_signed_marker(exe: &std::path::Path) {
+    if let Some(fingerprint) = executable_fingerprint(exe) {
+        let _ = std::fs::write(signed_marker_path(exe), fingerprint);
+    }
+}
+
 /// Self-sign ad-hoc with the hypervisor entitlement, then re-exec. We ship the
 /// bin unsigned and HVF rejects it otherwise. `MVM_HVF_SIGNED` breaks the exec
 /// loop; `exec()` preserves the pid + the stdin config pipe. A file lock
@@ -56,7 +99,15 @@ fn ensure_self_signed() {
     let Ok(exe) = std::env::current_exe() else {
         return;
     };
+    // The helper is stable between builds. Avoid spawning `codesign` for every
+    // short-lived workload by caching only metadata observed after a successful
+    // entitlement check or signing operation. Hypervisor.framework remains the
+    // final authority and still rejects an unsigned helper.
+    if signed_marker_matches(&exe) {
+        return;
+    }
     if exe_has_hypervisor_entitlement(&exe) {
+        record_signed_marker(&exe);
         return;
     }
 
@@ -95,6 +146,7 @@ fn ensure_self_signed() {
             }
             return;
         }
+        record_signed_marker(&exe);
     }
     drop(lock);
 
@@ -104,6 +156,29 @@ fn ensure_self_signed() {
         .exec();
     eprintln!("mvm-hvf-supervisor: re-exec after signing failed: {err}");
     std::process::exit(1);
+}
+
+#[cfg(all(test, target_os = "macos", target_arch = "aarch64"))]
+mod tests {
+    use super::{record_signed_marker, signed_marker_matches};
+    use std::io::Write;
+
+    #[test]
+    fn signed_marker_is_bound_to_the_executable_metadata() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let exe = dir.path().join("mvm-hvf-supervisor");
+        let mut file = std::fs::File::create(&exe).expect("create executable");
+        file.write_all(b"signed helper").expect("write executable");
+        file.flush().expect("flush executable");
+
+        assert!(!signed_marker_matches(&exe));
+        record_signed_marker(&exe);
+        assert!(signed_marker_matches(&exe));
+
+        std::fs::write(&exe, b"replacement helper with different size")
+            .expect("replace executable");
+        assert!(!signed_marker_matches(&exe));
+    }
 }
 
 /// Set by the SIGTERM/SIGINT handler; `boot_kernel_until`'s watchdog polls it and

--- a/crates/mvm-runtime/src/apple_container_backend.rs
+++ b/crates/mvm-runtime/src/apple_container_backend.rs
@@ -117,7 +117,12 @@ impl VmBackend for AppleContainerBackend {
     }
 
     fn capabilities(&self) -> VmCapabilities {
-        self.runner.capabilities()
+        let mut capabilities = self.runner.capabilities();
+        // Apple Container is a separate opt-in wrapper; it does not route the
+        // context-aware standby claim seam, so it must not inherit HVF's live
+        // handoff capability accidentally.
+        capabilities.standby_pool = false;
+        capabilities
     }
 
     fn start(&self, config: &VmStartConfig) -> Result<VmId> {
@@ -334,7 +339,8 @@ mod tests {
         let (mine, theirs) = (b.capabilities(), runner.capabilities());
         assert_eq!(mine.vsock, theirs.vsock);
         assert_eq!(mine.no_routable_guest_nic, theirs.no_routable_guest_nic);
-        assert_eq!(mine.standby_pool, theirs.standby_pool);
+        assert!(!mine.standby_pool);
+        assert!(theirs.standby_pool);
         assert_eq!(mine.snapshot_capability, theirs.snapshot_capability);
         assert_eq!(mine.pause_resume, theirs.pause_resume);
 
@@ -469,7 +475,8 @@ mod tests {
         );
         assert_eq!(mine.vsock, theirs.vsock);
         assert_eq!(mine.no_routable_guest_nic, theirs.no_routable_guest_nic);
-        assert_eq!(mine.standby_pool, theirs.standby_pool);
+        assert!(!mine.standby_pool);
+        assert!(theirs.standby_pool);
         assert_eq!(mine.snapshot_capability, theirs.snapshot_capability);
         assert_eq!(mine.pause_resume, theirs.pause_resume);
     }

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -1682,7 +1682,7 @@ mod tests {
             ("apple-container", SnapshotCapability::Unsupported, false),
             ("docker", SnapshotCapability::Unsupported, false),
             ("firecracker", SnapshotCapability::Unsupported, false),
-            ("hvf", SnapshotCapability::Unsupported, false),
+            ("hvf", SnapshotCapability::Unsupported, true),
             ("libkrun", SnapshotCapability::Unsupported, false),
             ("qemu", SnapshotCapability::Unsupported, false),
             ("wasm", SnapshotCapability::Unsupported, false),

--- a/crates/mvm-runtime/src/driver/fc.rs
+++ b/crates/mvm-runtime/src/driver/fc.rs
@@ -1123,14 +1123,14 @@ mod tests {
     /// `MockBackend` opts into it explicitly via `with_standby()` for the
     /// hermetic claim tests; the `MockDriver` seam here does not.)
     #[test]
-    fn no_selectable_driver_advertises_the_standby_pool() {
+    fn only_hvf_advertises_the_live_standby_pool() {
         use crate::driver::{HvfDriver, LibkrunDriver, MockDriver};
         use crate::qemu::QemuBackend;
         use crate::wasm_backend::WasmBackend;
 
         assert!(!FcDriver::new().capabilities().standby_pool);
         assert!(!LibkrunDriver::new().capabilities().standby_pool);
-        assert!(!HvfDriver::new().capabilities().standby_pool);
+        assert!(HvfDriver::new().capabilities().standby_pool);
         assert!(!MockDriver::default().capabilities().standby_pool);
         assert!(!QemuBackend.capabilities().standby_pool);
         assert!(!WasmBackend::new().capabilities().standby_pool);
@@ -1952,6 +1952,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let missing = tmp.path().join("never-materialized");
         let req = ChildForkRequest {
+            parent_vm_name: "parent-vm",
             child_vm_name: "child-vm-1",
             child_dir: &missing,
             genid: sample_generation_token(),
@@ -1975,6 +1976,7 @@ mod tests {
         std::fs::create_dir_all(&child_dir).unwrap();
         std::fs::write(child_dir.join("rootfs.ext4"), b"rootfs").unwrap();
         let req = ChildForkRequest {
+            parent_vm_name: "parent-vm",
             child_vm_name: "child-vm-2",
             child_dir: &child_dir,
             genid: sample_generation_token(),
@@ -2008,6 +2010,7 @@ mod tests {
 
         let channels = workload_channels();
         let req = ChildForkRequest {
+            parent_vm_name: "parent-vm",
             child_vm_name: "child-vm-3",
             child_dir: &child_dir,
             genid: sample_generation_token(),

--- a/crates/mvm-runtime/src/driver/hvf.rs
+++ b/crates/mvm-runtime/src/driver/hvf.rs
@@ -264,9 +264,9 @@ impl VmmDriver for HvfDriver {
                 &req.child_dir.join("console.log"),
             )?;
 
-            let child_egress = channel_path(req, EGRESS_PORT)?;
+            let child_egress = channel_path(req, GuestService::Substitution)?;
             link_path(&child_egress, &parent_dir.join("standby-egress.sock"))?;
-            if let Some(child_broker) = channel_path_optional(req, BROKER_PORT) {
+            if let Some(child_broker) = channel_path_optional(req, GuestService::Broker) {
                 link_path(&child_broker, &parent_dir.join("standby-broker.sock"))?;
             }
             std::fs::write(req.child_dir.join("hvf-live-parent"), req.parent_vm_name)
@@ -411,17 +411,20 @@ fn wait_for_socket(path: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
-fn channel_path(req: &ChildForkRequest<'_>, guest_port: u32) -> Result<PathBuf> {
-    channel_path_optional(req, guest_port).ok_or_else(|| {
-        anyhow!("live HVF child is missing its required guest-dialed channel {guest_port}")
+fn channel_path(req: &ChildForkRequest<'_>, service: GuestService) -> Result<PathBuf> {
+    channel_path_optional(req, service).ok_or_else(|| {
+        anyhow!(
+            "live HVF child is missing its required guest-dialed channel {}",
+            service.port()
+        )
     })
 }
 
-fn channel_path_optional(req: &ChildForkRequest<'_>, guest_port: u32) -> Option<PathBuf> {
+fn channel_path_optional(req: &ChildForkRequest<'_>, service: GuestService) -> Option<PathBuf> {
     req.channels
         .iter()
         .find(|channel| {
-            channel.guest_port == guest_port && channel.direction == VsockDirection::GuestDials
+            channel.service == service && channel.direction == VsockDirection::GuestDials
         })
         .map(|channel| channel.host_uds.clone())
 }
@@ -616,7 +619,7 @@ mod tests {
     #[test]
     fn live_handoff_only_accepts_guest_dialed_channels() {
         let channels = vec![VsockPort {
-            guest_port: EGRESS_PORT,
+            service: GuestService::Substitution,
             host_uds: "/run/egress.sock".into(),
             direction: VsockDirection::HostDials,
         }];
@@ -632,7 +635,7 @@ mod tests {
             channels: &channels,
         };
 
-        assert!(channel_path_optional(&req, EGRESS_PORT).is_none());
+        assert!(channel_path_optional(&req, GuestService::Substitution).is_none());
     }
 
     #[test]

--- a/crates/mvm-runtime/src/driver/hvf.rs
+++ b/crates/mvm-runtime/src/driver/hvf.rs
@@ -17,15 +17,19 @@ use mvm_agentd::vsock::{CONSOLE_PORT_BASE, GUEST_AGENT_PORT, dev_console_data_po
 use mvm_build::hvf_supervisor::{ConsoleDataSocket, HvfDisk, HvfSupervisorConfig};
 use mvm_core::config::{vm_hvf_vsock_port_socket_at, vm_state_dir};
 use mvm_core::vm_backend::{
-    BackendKind, BackendSecurityProfile, GuestChannelInfo, VmBackend, VmCapabilities, VmExitStatus,
-    VmId, VmStatus,
+    BackendKind, BackendSecurityProfile, GuestChannelInfo, StandbyError, StandbyHandle,
+    StandbyState, VmBackend, VmCapabilities, VmExitStatus, VmId, VmStatus,
 };
 use mvm_net::channel::GuestService;
 
 use crate::driver::spec::KernelImage;
-use crate::driver::{DuplexStream, RunningVm, VmmDriver, VmmSpec};
+use crate::driver::{
+    ChildForkRequest, DuplexStream, RunningVm, StandbyParentSpawn, VmmDriver, VmmSpec,
+    VsockDirection,
+};
 use crate::hvf_backend::{
-    self, HvfBackend, PID_FILE_NAME, PID_FILE_TIMEOUT, resolve_supervisor_path,
+    self, HvfBackend, PID_FILE_NAME, PID_FILE_POLL_INTERVAL, PID_FILE_TIMEOUT,
+    resolve_supervisor_path,
 };
 
 /// The first-party VMM driver: pure VMM mechanics, no policy and no admission.
@@ -176,11 +180,109 @@ impl VmmDriver for HvfDriver {
     }
 
     fn capabilities(&self) -> VmCapabilities {
-        self.backend.capabilities()
+        let mut capabilities = self.backend.capabilities();
+        // HVF uses a paused resident-parent handoff rather than advertising a
+        // serialized fresh-VMM restore that the native API cannot provide.
+        capabilities.pause_resume = true;
+        capabilities.standby_pool = true;
+        capabilities
     }
 
     fn security_profile(&self) -> BackendSecurityProfile {
         self.backend.security_profile()
+    }
+
+    fn standby_parent_is_live(&self) -> bool {
+        true
+    }
+
+    fn spawn_standby_parent(
+        &self,
+        req: &StandbyParentSpawn<'_>,
+    ) -> std::result::Result<StandbyHandle, StandbyError> {
+        let vm = self
+            .boot(req.boot)
+            .map_err(|e| StandbyError::SpawnFailed(format!("boot HVF standby parent: {e}")))?;
+        let state_dir = vm_state_dir(&req.spec.id);
+        let agent = hvf_agent_socket(&state_dir);
+        wait_for_socket(&agent).map_err(|e| {
+            let _ = vm.kill();
+            StandbyError::SpawnFailed(format!("wait for HVF standby agent: {e}"))
+        })?;
+        vm.pause().map_err(|e| {
+            let _ = vm.kill();
+            StandbyError::SpawnFailed(format!("pause HVF standby parent: {e}"))
+        })?;
+        let pid = hvf_backend::read_pid(&state_dir.join(PID_FILE_NAME)).ok_or_else(|| {
+            StandbyError::SpawnFailed("HVF standby parent lost its PID marker".to_string())
+        })?;
+        let pid = u32::try_from(pid).map_err(|_| {
+            StandbyError::SpawnFailed("HVF standby parent PID marker is invalid".to_string())
+        })?;
+        Ok(StandbyHandle {
+            id: req.spec.id.clone(),
+            template_id: req.spec.template_id.clone(),
+            control_socket: req.spec.control_socket.clone(),
+            pid,
+            kernel_sha256: req.spec.kernel_sha256.clone(),
+            vcpus: req.spec.vcpus,
+            mem_mib: req.spec.mem_mib,
+            binding_nonce: req.spec.binding_nonce.clone(),
+            spawned_unix_secs: crate::standby_pool::now_unix_secs(),
+            state: StandbyState::Idle,
+            image_sha256: req.spec.image_sha256.clone(),
+            vsock_egress: req.spec.vsock_egress,
+            parent_checkpoint: None,
+        })
+    }
+
+    fn fork_standby_child(
+        &self,
+        req: &ChildForkRequest<'_>,
+    ) -> std::result::Result<(), StandbyError> {
+        let parent_dir = vm_state_dir(req.parent_vm_name);
+        let parent_pid = parent_dir.join(PID_FILE_NAME);
+        if hvf_backend::read_pid(&parent_pid).is_none() {
+            return Err(StandbyError::ClaimFailed(format!(
+                "live HVF standby parent '{}' is no longer running",
+                req.parent_vm_name
+            )));
+        }
+
+        let result = (|| {
+            link_path(
+                &hvf_agent_socket(&parent_dir),
+                &hvf_agent_socket(req.child_dir),
+            )?;
+            link_path(&parent_pid, &req.child_dir.join(PID_FILE_NAME))?;
+            link_path(
+                &parent_dir.join("workload.exit"),
+                &req.child_dir.join("workload.exit"),
+            )?;
+            link_path(
+                &parent_dir.join("console.log"),
+                &req.child_dir.join("console.log"),
+            )?;
+
+            let child_egress = channel_path(req, EGRESS_PORT)?;
+            link_path(&child_egress, &parent_dir.join("standby-egress.sock"))?;
+            if let Some(child_broker) = channel_path_optional(req, BROKER_PORT) {
+                link_path(&child_broker, &parent_dir.join("standby-broker.sock"))?;
+            }
+            std::fs::write(req.child_dir.join("hvf-live-parent"), req.parent_vm_name)
+                .map_err(|e| anyhow!("record live HVF parent: {e}"))?;
+
+            self.attach(&VmId(req.parent_vm_name.to_string()))?
+                .resume()
+                .map_err(|e| anyhow!("resume live HVF child handoff: {e}"))
+        })();
+
+        result.map_err(|e| {
+            let _ = self
+                .attach(&VmId(req.parent_vm_name.to_string()))
+                .and_then(|vm| vm.kill());
+            StandbyError::ClaimFailed(format!("wire live HVF standby child: {e}"))
+        })
     }
 
     fn boot(&self, spec: &VmmSpec) -> Result<Box<dyn RunningVm>> {
@@ -241,7 +343,7 @@ impl VmmDriver for HvfDriver {
                     paths.console_log.display()
                 );
             }
-            std::thread::sleep(std::time::Duration::from_millis(50));
+            std::thread::sleep(PID_FILE_POLL_INTERVAL);
         }
 
         // Detach: dropping the `Child` does not kill it, so the supervisor
@@ -294,6 +396,60 @@ fn hvf_agent_socket(state_dir: &std::path::Path) -> PathBuf {
     mvm_core::config::vm_hvf_agent_socket_at(state_dir)
 }
 
+fn wait_for_socket(path: &std::path::Path) -> Result<()> {
+    let timeout = PID_FILE_TIMEOUT;
+    let deadline = Instant::now() + timeout;
+    while !path.exists() {
+        if Instant::now() >= deadline {
+            bail!(
+                "HVF supervisor did not bind {} within {timeout:?}",
+                path.display()
+            );
+        }
+        std::thread::sleep(PID_FILE_POLL_INTERVAL);
+    }
+    Ok(())
+}
+
+fn channel_path(req: &ChildForkRequest<'_>, guest_port: u32) -> Result<PathBuf> {
+    channel_path_optional(req, guest_port).ok_or_else(|| {
+        anyhow!("live HVF child is missing its required guest-dialed channel {guest_port}")
+    })
+}
+
+fn channel_path_optional(req: &ChildForkRequest<'_>, guest_port: u32) -> Option<PathBuf> {
+    req.channels
+        .iter()
+        .find(|channel| {
+            channel.guest_port == guest_port && channel.direction == VsockDirection::GuestDials
+        })
+        .map(|channel| channel.host_uds.clone())
+}
+
+fn link_path(target: &std::path::Path, link: &std::path::Path) -> Result<()> {
+    if link.exists() || std::fs::symlink_metadata(link).is_ok() {
+        bail!(
+            "refusing to replace existing live-HVF handoff path {}",
+            link.display()
+        );
+    }
+    std::os::unix::fs::symlink(target, link)
+        .with_context(|| format!("link {} -> {}", link.display(), target.display()))
+}
+
+fn signal_vm(pid_file: &std::path::Path, signal: libc::c_int) -> Result<()> {
+    let pid = hvf_backend::read_pid(pid_file)
+        .ok_or_else(|| anyhow!("HVF VM has no live PID marker at {}", pid_file.display()))?;
+    // SAFETY: the PID comes from the backend-owned marker created for this VM;
+    // the signal is limited to pause/resume/termination for that process.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, signal) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("send signal {signal} to HVF supervisor pid {pid}"));
+    }
+    Ok(())
+}
+
 /// Resolve the host UDS for a console data port via the shared HVF-style socket
 /// helper. Returns `None` when the port is outside `dev_console_data_ports()`.
 fn console_socket_for_port(state_dir: &std::path::Path, guest_port: u32) -> Option<PathBuf> {
@@ -330,15 +486,22 @@ impl RunningVm for HvfRunningVm {
             hvf_backend::terminate_pid(pid);
         }
         let _ = std::fs::remove_file(&self.pid_file);
+        if let Ok(parent_name) = std::fs::read_to_string(self.state_dir.join("hvf-live-parent")) {
+            let parent_name = parent_name.trim();
+            if !parent_name.is_empty() {
+                let parent_state = vm_state_dir(parent_name);
+                let _ = std::fs::remove_dir_all(parent_state);
+            }
+        }
         Ok(())
     }
 
     fn pause(&self) -> Result<()> {
-        bail!("hvf pause/resume is not yet implemented")
+        signal_vm(&self.pid_file, libc::SIGUSR1)
     }
 
     fn resume(&self) -> Result<()> {
-        bail!("hvf pause/resume is not yet implemented")
+        signal_vm(&self.pid_file, libc::SIGUSR2)
     }
 
     fn status(&self) -> Result<VmStatus> {
@@ -427,11 +590,49 @@ mod tests {
         assert_eq!(d.name(), "hvf");
         assert_eq!(d.kind(), BackendKind::Hvf);
         assert!(d.capabilities().vsock);
+        assert!(d.capabilities().pause_resume);
+        assert!(d.capabilities().standby_pool);
         assert_eq!(d.snapshot_capability(), SnapshotCapability::Unsupported);
         assert_eq!(
             d.security_profile().tier,
             HvfBackend.security_profile().tier
         );
+    }
+
+    #[test]
+    fn live_handoff_refuses_to_replace_an_existing_socket_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target.sock");
+        let link = tmp.path().join("link.sock");
+        std::fs::write(&target, b"target").unwrap();
+        std::fs::write(&link, b"existing").unwrap();
+
+        let err = link_path(&target, &link).unwrap_err();
+
+        assert!(err.to_string().contains("refusing to replace"));
+        assert_eq!(std::fs::read(&link).unwrap(), b"existing");
+    }
+
+    #[test]
+    fn live_handoff_only_accepts_guest_dialed_channels() {
+        let channels = vec![VsockPort {
+            guest_port: EGRESS_PORT,
+            host_uds: "/run/egress.sock".into(),
+            direction: VsockDirection::HostDials,
+        }];
+        let child_dir = PathBuf::from("/tmp/child-vm");
+        let req = ChildForkRequest {
+            parent_vm_name: "parent-vm",
+            child_vm_name: "child-vm",
+            child_dir: &child_dir,
+            genid: mvm_core::crypto::vmgenid::GenerationToken {
+                token: [0; mvm_core::crypto::vmgenid::GENID_BYTES],
+                content_hash: "content".into(),
+            },
+            channels: &channels,
+        };
+
+        assert!(channel_path_optional(&req, EGRESS_PORT).is_none());
     }
 
     #[test]

--- a/crates/mvm-runtime/src/driver/traits.rs
+++ b/crates/mvm-runtime/src/driver/traits.rs
@@ -20,6 +20,10 @@ use crate::vm::instance_snapshot::PostRestoreOutcome;
 /// What a driver needs to fork a materialized standby parent into a fresh child
 /// VMM. Grouped so the seam takes one value instead of a positional list.
 pub struct ChildForkRequest<'a> {
+    /// The verified standby parent that is being handed off to this child.
+    /// Saved-state drivers use the checkpoint in `child_dir`; live standby
+    /// drivers use this name to transfer their paused resident VM.
+    pub parent_vm_name: &'a str,
     /// The child's fresh, registry-unique name (its `~/.mvm/vms/<name>` key).
     pub child_vm_name: &'a str,
     /// The child's state dir, already holding the copy-on-write clone of the
@@ -188,6 +192,15 @@ pub trait VmmDriver: Send + Sync {
     fn vm_full_control(&self, vm_name: &str) -> Option<Box<dyn crate::checkpoint::VmFullControl>> {
         let _ = vm_name;
         None
+    }
+
+    /// Whether a standby parent stays resident and is handed off in place.
+    ///
+    /// This is distinct from a saved-state snapshot: a live handoff must
+    /// rewire every host channel while the parent is paused and must never be
+    /// selected by a driver that has not implemented that protocol.
+    fn standby_parent_is_live(&self) -> bool {
+        false
     }
 
     /// The VMM-specific base kernel bootargs (console, earlycon, root/init

--- a/crates/mvm-runtime/src/host_agent_spawn.rs
+++ b/crates/mvm-runtime/src/host_agent_spawn.rs
@@ -38,6 +38,9 @@ const SPAWN_LOCK: &str = "spawn.lock";
 const DAEMON_READY_TIMEOUT: Duration = Duration::from_secs(10);
 /// Control-frame cap (replies are tiny).
 const CONTROL_MAX_FRAME_BYTES: usize = 64 * 1024;
+/// Bound a single control exchange so a daemon that dies after accepting a
+/// request cannot hold the VM launch path indefinitely.
+const CONTROL_IO_TIMEOUT: Duration = Duration::from_secs(1);
 /// Control reconnect attempts when the worker is restarting under the wrapper.
 const CONTROL_RETRIES: u32 = 4;
 /// Base delay for exponential control reconnect backoff.
@@ -381,6 +384,12 @@ fn send_control(
                     control_socket.display()
                 )
             })?;
+            stream
+                .set_read_timeout(Some(CONTROL_IO_TIMEOUT))
+                .context("set host-agent control read timeout")?;
+            stream
+                .set_write_timeout(Some(CONTROL_IO_TIMEOUT))
+                .context("set host-agent control write timeout")?;
             write_framed(&mut stream, &signed)?;
             match read_framed::<ControlResponse>(&mut stream)? {
                 ControlResponse::Ok => Ok(()),

--- a/crates/mvm-runtime/src/hvf_backend.rs
+++ b/crates/mvm-runtime/src/hvf_backend.rs
@@ -36,6 +36,10 @@ pub(crate) const PID_FILE_NAME: &str = "hvf.pid";
 /// How long `start` waits for the supervisor to confirm boot (PID file). Shared
 /// with the hvf driver, which spawns the same supervisor binary.
 pub(crate) const PID_FILE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Readiness is signalled by a file written by the detached supervisor. Keep
+/// the poll interval below the launch latency budget; the file check is cheap,
+/// and a coarse interval otherwise adds visible tail latency to every run.
+pub(crate) const PID_FILE_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
 /// Raw HVF (`Hypervisor.framework`) backend. macOS / Apple-silicon only.
 pub struct HvfBackend;
@@ -540,7 +544,7 @@ impl VmBackend for HvfBackend {
                     console_log.display()
                 );
             }
-            std::thread::sleep(Duration::from_millis(50));
+            std::thread::sleep(PID_FILE_POLL_INTERVAL);
         }
 
         // Boot confirmed: the supervisor's device is wired to the endpoint, so it

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -29,8 +29,8 @@ use mvm_fs::snapshot_store::FsSnapshotStore;
 use mvm_net::channel::GuestService;
 
 use crate::checkpoint::{
-    CaptureVmFullParams, CheckpointChainAnchor, CheckpointStore, capture_vm_full, verify_content,
-    verify_lineage,
+    CaptureVmFullParams, CheckpointChainAnchor, CheckpointStore, capture_fs_quick, capture_vm_full,
+    verify_content, verify_lineage,
 };
 use crate::driver::{ChildForkRequest, RunningVm, StandbyParentSpawn, VmmDriver};
 use crate::egress_shared::{decode_plan_secrets_from_state, plan_stream_retention};
@@ -52,7 +52,9 @@ use crate::workload_runner::spec_map::{
     WorkloadSockets, WorkloadSpecInputs, console_data_sockets, ensure_no_dir_share_volumes,
     workload_spec, workload_vsock_ports,
 };
-use crate::workload_runner::standby_boot::{factory_parent_config, factory_parent_spec};
+use crate::workload_runner::standby_boot::{
+    factory_parent_config, factory_parent_spec, factory_parent_spec_live,
+};
 
 /// What the workload runner needs to stand up the per-VM gating endpoint.
 pub struct EndpointSpawnRequest<'a> {
@@ -629,6 +631,7 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
         let genid = fresh_generation_token(content_hash);
         let token = genid.token;
         self.driver.fork_standby_child(&ChildForkRequest {
+            parent_vm_name: &handle.id,
             child_vm_name: &child.0,
             child_dir: &child_dir,
             genid,
@@ -668,6 +671,22 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
             self.force_stop(&child.0, "refused forked standby child");
             self.console_streamer.stop(&child.0);
             return Err(refusal);
+        }
+
+        // A universal initramfs keeps the factory parent behind its activation
+        // gate. A live HVF handoff has no boot callback in which to perform the
+        // cold path's activation, so do it after the child identity proof and
+        // before the claim commits. The endpoint and broker are already armed,
+        // which preserves the same host-service ordering as cold boot.
+        if let Some(config) = claim.start_config.as_ref()
+            && crate::microvm::booted_with_universal_initramfs(config)
+        {
+            let vm = self
+                .driver
+                .attach(&child)
+                .map_err(|e| StandbyError::ClaimFailed(format!("attach claimed child: {e}")))?;
+            crate::microvm::activate_workload(&*vm, config)
+                .map_err(|e| StandbyError::ClaimFailed(format!("activate claimed child: {e}")))?;
         }
 
         // The child booted and proved a fresh identity: disarm the endpoint and
@@ -750,9 +769,15 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
             ))
         })?;
 
-        let boot = factory_parent_spec(&parent_config, &state_dir, |virtiofs_root, has_disk| {
-            self.driver.workload_base_bootargs(virtiofs_root, has_disk)
-        });
+        let boot = if self.driver.standby_parent_is_live() {
+            factory_parent_spec_live(&parent_config, &state_dir, |virtiofs_root, has_disk| {
+                self.driver.workload_base_bootargs(virtiofs_root, has_disk)
+            })
+        } else {
+            factory_parent_spec(&parent_config, &state_dir, |virtiofs_root, has_disk| {
+                self.driver.workload_base_bootargs(virtiofs_root, has_disk)
+            })
+        };
         // The same truncation refusal a workload boot gets, for the same reason
         // and then some: a child inherits its parent's cmdline out of restored
         // memory rather than deriving its own, so a parent whose trailing tokens
@@ -767,41 +792,63 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
             .driver
             .spawn_standby_parent(&StandbyParentSpawn { spec, boot: &boot })?;
 
-        let control = self.driver.vm_full_control(&spec.id).ok_or_else(|| {
-            StandbyError::SpawnFailed(format!(
-                "backend cannot capture a warm parent's memory for standby '{}'",
-                spec.id
-            ))
-        })?;
+        let meta = if self.driver.standby_parent_is_live() {
+            // Native HVF cannot restore a fresh VMM from serialized device
+            // state yet. It therefore uses an explicit live handoff: the
+            // parent was paused by the driver, its rootfs is still sealed and
+            // captured for the same content/lineage gates, and the driver keeps
+            // the resident VM paused until a claim rewires its channels.
+            let captured = capture_fs_quick(
+                ctx.checkpoints,
+                crate::checkpoint::CaptureFsQuickParams {
+                    id: CheckpointId::new(format!("standby-{}", spec.id)),
+                    vm_name: spec.id.clone(),
+                    rootfs: PathBuf::from(parent_config.rootfs_path.clone()),
+                    supervisor_config_digest: String::new(),
+                    runtime_source_policy: None,
+                    runtime_overlay_version: None,
+                    tag: None,
+                    created_unix: crate::standby_pool::now_unix_secs(),
+                    quiesced: true,
+                },
+            );
+            captured.map_err(|e| {
+                self.force_stop(&spec.id, "failed live standby capture");
+                StandbyError::SpawnFailed(format!("capture live standby parent: {e}"))
+            })?
+        } else {
+            let control = self.driver.vm_full_control(&spec.id).ok_or_else(|| {
+                StandbyError::SpawnFailed(format!(
+                    "backend cannot capture a warm parent's memory for standby '{}'",
+                    spec.id
+                ))
+            })?;
 
-        let captured = capture_vm_full(
-            ctx.checkpoints,
-            CaptureVmFullParams {
-                id: CheckpointId::new(format!("standby-{}", spec.id)),
-                vm_name: spec.id.clone(),
-                supervisor_config_digest: String::new(),
-                runtime_source_policy: None,
-                runtime_overlay_version: None,
-                // Firecracker keeps no supervisor-config blob; its presence is
-                // what marks a checkpoint as originating from a backend that does.
-                supervisor_config_src: None,
-                tag: None,
-                created_unix: crate::standby_pool::now_unix_secs(),
-            },
-            control.as_ref(),
-        );
+            let captured = capture_vm_full(
+                ctx.checkpoints,
+                CaptureVmFullParams {
+                    id: CheckpointId::new(format!("standby-{}", spec.id)),
+                    vm_name: spec.id.clone(),
+                    supervisor_config_digest: String::new(),
+                    runtime_source_policy: None,
+                    runtime_overlay_version: None,
+                    // Firecracker keeps no supervisor-config blob; its presence is
+                    // what marks a checkpoint as originating from a backend that does.
+                    supervisor_config_src: None,
+                    tag: None,
+                    created_unix: crate::standby_pool::now_unix_secs(),
+                },
+                control.as_ref(),
+            );
 
-        // Release either way: the checkpoint carries the parent's full state, so
-        // a pool slot costs disk rather than a resident VM, and a failed capture
-        // must not strand the guest.
-        self.force_stop(&spec.id, "captured standby parent");
+            // Release either way: the checkpoint carries the parent's full state, so
+            // a pool slot costs disk rather than a resident VM, and a failed capture
+            // must not strand the guest.
+            self.force_stop(&spec.id, "captured standby parent");
+            captured
+                .map_err(|e| StandbyError::SpawnFailed(format!("capture standby parent: {e}")))?
+        };
 
-        let meta = captured
-            .map_err(|e| StandbyError::SpawnFailed(format!("capture standby parent: {e}")))?;
-
-        // No live process backs the captured parent — zero is the sentinel
-        // `is_saved_state()` keys off, and it is now true.
-        handle.pid = 0;
         handle.parent_checkpoint = Some(meta.id.as_str().to_string());
         Ok(handle)
     }

--- a/crates/mvm-runtime/src/workload_runner/standby_boot.rs
+++ b/crates/mvm-runtime/src/workload_runner/standby_boot.rs
@@ -30,6 +30,7 @@ use mvm_core::vm_backend::{RuntimeSourcePolicy, StandbyError, StandbySpec, VmSta
 use crate::driver::VmmSpec;
 use crate::workload_runner::cmdline;
 use crate::workload_runner::spec_map::workload_device_spec;
+use crate::workload_runner::spec_map::{WorkloadSockets, workload_vsock_ports};
 
 /// Refuse a factory parent whose boot inputs describe a guest that cannot reach
 /// an agent, naming the missing piece.
@@ -196,13 +197,11 @@ pub fn factory_parent_config(
 /// boot uses, so a drive or cmdline token added to the workload's boot reaches
 /// the parent's too.
 ///
-/// One divergence is deliberate and covered by the tests below: the vsock
-/// channel list, which [`workload_device_spec`] leaves empty. A workload wires
-/// its agent, egress, exit and (when admitted) broker channels to host sockets;
-/// a parent wires none because it has no endpoint and no broker to wire them
-/// to. The guest's vsock *device* is identical either way — the driver
-/// configures it unconditionally — so this costs the parent no device-model
-/// divergence.
+/// Saved-state parents deliberately carry no host channels. The live-HVF
+/// variant below adds authority-free stable agent, egress, broker, and exit
+/// paths so a paused resident parent can be handed off without changing its
+/// device model; those paths are connected to child-owned endpoints only at
+/// claim time.
 ///
 /// A second divergence is **not** covered, and no test here can cover it: the
 /// per-VM grant tokens. [`cmdline::workload_cmdline`] appends whatever
@@ -228,8 +227,44 @@ pub fn factory_parent_spec(
     state_dir: &Path,
     base_bootargs: impl Fn(bool, bool) -> String,
 ) -> VmmSpec {
+    factory_parent_spec_inner(config, state_dir, base_bootargs, false)
+}
+
+/// Build the factory parent shape for the native HVF live handoff. The stable
+/// paths are inert until a claim links them to the child's own host channels.
+pub fn factory_parent_spec_live(
+    config: &VmStartConfig,
+    state_dir: &Path,
+    base_bootargs: impl Fn(bool, bool) -> String,
+) -> VmmSpec {
+    factory_parent_spec_inner(config, state_dir, base_bootargs, true)
+}
+
+fn factory_parent_spec_inner(
+    config: &VmStartConfig,
+    state_dir: &Path,
+    base_bootargs: impl Fn(bool, bool) -> String,
+    live_handoff: bool,
+) -> VmmSpec {
     let cmdline = cmdline::runner_cmdline(config, state_dir, base_bootargs);
-    workload_device_spec(config, &cmdline, &state_dir.join("console.log"))
+    if !live_handoff {
+        return workload_device_spec(config, &cmdline, &state_dir.join("console.log"));
+    }
+    let agent = mvm_core::config::vm_hvf_agent_socket_at(state_dir);
+    let egress = state_dir.join("standby-egress.sock");
+    let exit = state_dir.join("workload.exit");
+    let broker = state_dir.join("standby-broker.sock");
+    let sockets = WorkloadSockets {
+        agent: &agent,
+        egress_gateway: &egress,
+        exit: &exit,
+        broker: Some(&broker),
+        console_data: Vec::new(),
+    };
+    VmmSpec {
+        vsock: workload_vsock_ports(&sockets),
+        ..workload_device_spec(config, &cmdline, &state_dir.join("console.log"))
+    }
 }
 
 #[cfg(test)]
@@ -658,11 +693,15 @@ mod tests {
 
         let parent = factory_parent_spec(&parent_cfg, Path::new(&spec.vm_state_dir), fc_base);
         // The enablement the guest boots with is all the parent takes from the
-        // launch's policy, and it buys the parent no reach: a parent wires no
-        // egress channel at all, so the guest's client has nothing to dial.
+        // launch's policy. Its channels are stable, authority-free handoff
+        // paths; no child endpoint or broker is attached until claim time.
         assert!(
-            parent.vsock.is_empty(),
-            "a factory parent wires no host channels: no egress, no broker"
+            parent.vsock.iter().all(|port| {
+                port.host_uds.to_string_lossy().contains("standby")
+                    || port.guest_port == mvm_agentd::vsock::GUEST_AGENT_PORT
+                    || port.guest_port == mvm_agentd::vsock::WORKLOAD_EXIT_PORT
+            }),
+            "a factory parent may only wire stable standby paths"
         );
         assert_eq!(
             parent.blocks.len(),
@@ -673,6 +712,42 @@ mod tests {
             !parent.cmdline.contains("mvm.uvols="),
             "parent cmdline leaked a user-volume manifest: {}",
             parent.cmdline
+        );
+    }
+
+    #[test]
+    fn live_parent_uses_stable_handoff_channels_without_workload_endpoints() {
+        let _home = isolated_home();
+        let tmp = tempfile::tempdir().unwrap();
+        let launch = sealed_launch(tmp.path());
+        let spec = standby_spec_for(&launch, tmp.path());
+        let parent_cfg = factory_parent_config(&launch, &spec).unwrap();
+        let parent = factory_parent_spec_live(&parent_cfg, Path::new(&spec.vm_state_dir), fc_base);
+
+        let ports: std::collections::HashMap<_, _> = parent
+            .vsock
+            .iter()
+            .map(|port| (port.guest_port, port.host_uds.clone()))
+            .collect();
+        assert!(
+            ports[&mvm_agentd::vsock::GUEST_AGENT_PORT]
+                .to_string_lossy()
+                .contains("hvf-agent.sock")
+        );
+        assert!(
+            ports[&mvm_agentd::vsock::EGRESS_PORT]
+                .to_string_lossy()
+                .ends_with("standby-egress.sock")
+        );
+        assert!(
+            ports[&mvm_agentd::vsock::BROKER_PORT]
+                .to_string_lossy()
+                .ends_with("standby-broker.sock")
+        );
+        assert!(
+            ports[&mvm_agentd::vsock::WORKLOAD_EXIT_PORT]
+                .to_string_lossy()
+                .ends_with("workload.exit")
         );
     }
 

--- a/crates/mvm-runtime/src/workload_runner/standby_boot.rs
+++ b/crates/mvm-runtime/src/workload_runner/standby_boot.rs
@@ -259,6 +259,8 @@ fn factory_parent_spec_inner(
         egress_gateway: &egress,
         exit: &exit,
         broker: Some(&broker),
+        network_control: None,
+        network_data: None,
         console_data: Vec::new(),
     };
     VmmSpec {
@@ -276,6 +278,7 @@ mod tests {
 
     use mvm_core::util::test_env::TestEnv;
     use mvm_core::vm_backend::{RuntimeSourcePolicy, VmVolume, VmVolumeKind};
+    use mvm_net::channel::GuestService;
 
     use crate::workload_runner::spec_map::{WorkloadSockets, WorkloadSpecInputs, workload_spec};
 
@@ -698,8 +701,8 @@ mod tests {
         assert!(
             parent.vsock.iter().all(|port| {
                 port.host_uds.to_string_lossy().contains("standby")
-                    || port.guest_port == mvm_agentd::vsock::GUEST_AGENT_PORT
-                    || port.guest_port == mvm_agentd::vsock::WORKLOAD_EXIT_PORT
+                    || port.service == GuestService::MachineControl
+                    || port.service == GuestService::WorkloadExit
             }),
             "a factory parent may only wire stable standby paths"
         );
@@ -727,25 +730,25 @@ mod tests {
         let ports: std::collections::HashMap<_, _> = parent
             .vsock
             .iter()
-            .map(|port| (port.guest_port, port.host_uds.clone()))
+            .map(|port| (port.service, port.host_uds.clone()))
             .collect();
         assert!(
-            ports[&mvm_agentd::vsock::GUEST_AGENT_PORT]
+            ports[&GuestService::MachineControl]
                 .to_string_lossy()
                 .contains("hvf-agent.sock")
         );
         assert!(
-            ports[&mvm_agentd::vsock::EGRESS_PORT]
+            ports[&GuestService::Substitution]
                 .to_string_lossy()
                 .ends_with("standby-egress.sock")
         );
         assert!(
-            ports[&mvm_agentd::vsock::BROKER_PORT]
+            ports[&GuestService::Broker]
                 .to_string_lossy()
                 .ends_with("standby-broker.sock")
         );
         assert!(
-            ports[&mvm_agentd::vsock::WORKLOAD_EXIT_PORT]
+            ports[&GuestService::WorkloadExit]
                 .to_string_lossy()
                 .ends_with("workload.exit")
         );

--- a/crates/mvm-runtime/tests/fc_warm_pool_live.rs
+++ b/crates/mvm-runtime/tests/fc_warm_pool_live.rs
@@ -197,6 +197,7 @@ fn fc_warm_pool_spawn_and_claim() {
 
     let t_claim = Instant::now();
     let fork_result = driver.fork_standby_child(&ChildForkRequest {
+        parent_vm_name: "standby-parent",
         child_vm_name: &child_id,
         child_dir: &child_dir,
         genid: GenerationToken {

--- a/features/suites/s0_cli/machine_run_contract.feature
+++ b/features/suites/s0_cli/machine_run_contract.feature
@@ -60,7 +60,7 @@ Feature: machine run request contract
     When I run mvmctl in the isolated mvm home with "machine run --image alpine --dry-run --name bdd-dry-run -- /bin/true"
     Then the command exits with code 0
     And the output contains "no VM will be booted"
-    And the output contains "profile: standard"
+    And the output contains "profile: dev"
     And the isolated mvm home does not contain directory "vms/bdd-dry-run"
 
   # Deny-all is the default posture, and a dry run is where an operator checks

--- a/features/suites/s5_lifecycle/restore_reapplies_confinement.feature
+++ b/features/suites/s5_lifecycle/restore_reapplies_confinement.feature
@@ -3,9 +3,9 @@ Feature: Restore reapplies confinement
   Confinement parameters are part of the launch contract and must remain
   effective across warm restore.
 
-  Scenario: a dry-run workload advertises its standard confinement profile
+  Scenario: a dry-run workload advertises its dev confinement profile
     When I run mvmctl with "machine run --image alpine --dry-run -- echo hi"
     Then the command exits with code 0
-    And the output contains "profile: standard"
+    And the output contains "profile: dev"
     And the output contains "network: deny-all"
     And the output contains "enforced: flow-drop"

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -409,7 +409,9 @@ for detailed scope and acceptance criteria.
   - [x] Persistent-machine Firecracker stop fails closed and preserves state
         until process exit is verified (#2007; live KVM recheck passed)
   - [~] Live warm-launch, fork-isolation, and restore-clock verification
-        — parent audit anchoring is fixed and live-proven (#1962); the claim
-        now restores a child and stops at post-restore identity/grant re-pin
+        — parent audit anchoring is fixed and live-proven (#1962); native HVF
+        now has a paused-parent handoff with child-owned channel wiring and
+        post-restore identity/grant re-pin (#2174). Serialized fresh-VMM
+        restore and live Apple Silicon witnesses remain open.
   - [ ] Typed-connector egress-policy enrichment
   - [ ] OCI-image template build path and CLI facade completion

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1404,11 +1404,13 @@ Then unify + retire the old paths:
       the boot-pinned host identity but receives no workload grant. A real
       host-key signature is verified in the hermetic warm-claim BDD, and a
       missing issuer or mismatched envelope refuses before fork with no orphan.
-      `standby_pool` stays **`false`**: the **claim** half has still never
-      completed live. It now reaches the signed-parent check and refuses because
-      the capture path does not emit `checkpoint.created` (#1962), so the
-      post-restore grant delivery and the child's egress/broker/exit channels
-      remain live-unproven. The flip is gated on that run.
+      The native macOS fast-start follow-up (#2174) now gives HVF an explicit
+      paused-parent live handoff: the parent is content/lineage anchored, the
+      claim materializes a child rootfs, wires child-owned egress and broker
+      endpoints before resume, and requires the fresh identity handshake before
+      activation. HVF advertises the standby capability only through that
+      driver path; serialized fresh-VMM restore remains unsupported. Live Apple
+      Silicon timing and security witnesses are still the merge gate.
   - [x] Ordinary persistent-machine Firecracker teardown now fails closed
         (#2007): non-interactive or declined confirmation exits non-zero, state
         is retained unless process exit is verified, and a restart cannot


### PR DESCRIPTION
## Summary
- default direct machine runs to the dev profile
- add native macOS HVF paused-parent warm handoff with fresh child identity, content/lineage checks, child-owned endpoints, and fail-closed cleanup
- keep serialized fresh-VMM restore unsupported and Apple Container standby capability disabled
- reduce HVF readiness polling and avoid repeated supervisor signing work

## Validation
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p mvm-runtime --lib
- cargo test -p mvm-cli --lib
- cargo fmt --all -- --check
- full workspace test reached existing shared-state UDS/health-probe failures and was stopped after the volume suite; changed-package and focused suites pass

Closes #2174