### PR TITLE
Stream-edge primitives: binding, postures, and DAG validation

### DIFF
--- a/crates/mvm-cli/src/bench/probe.rs
+++ b/crates/mvm-cli/src/bench/probe.rs
@@ -56,6 +56,7 @@ pub fn admit_probe_plan(
     let sha = mvm_core::crypto::image_verify::sha256_file(rootfs)
         .with_context(|| format!("hashing probe rootfs {}", rootfs.display()))?;
     let input = SynthesisInput {
+        stream_edges: Vec::new(),
         kernel_sha256: None,
         network_mode: Default::default(),
         l3_network: None,

--- a/crates/mvm-cli/src/commands/build/image_lineage.rs
+++ b/crates/mvm-cli/src/commands/build/image_lineage.rs
@@ -420,6 +420,7 @@ pub(in crate::commands) fn build_event_plan(
     image_sha256: &str,
 ) -> Result<ExecutionPlan> {
     let input = SynthesisInput {
+        stream_edges: Vec::new(),
         kernel_sha256: None,
         network_mode: Default::default(),
         l3_network: None,

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -215,6 +215,7 @@ fn admit_standby_parent_plan(
     mem_mib: u32,
 ) -> Result<AdmittedPlan> {
     let input = SynthesisInput {
+        stream_edges: Vec::new(),
         kernel_sha256: None,
         vm_name: &handle.id,
         tenant: Some(tenant),

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -940,6 +940,7 @@ fn emit_oci_run_admission(
         })?;
     let exec_timeout_secs = u32::try_from(timeout_secs).unwrap_or(u32::MAX);
     let input = SynthesisInput {
+        stream_edges: Vec::new(),
         kernel_sha256: None,
         network_mode,
         l3_network: None,

--- a/crates/mvm-cli/src/commands/vm/policy_resolver.rs
+++ b/crates/mvm-cli/src/commands/vm/policy_resolver.rs
@@ -665,6 +665,7 @@ mod tests {
             shares: Vec::new(),
             agent_verbs: None,
             services: Vec::new(),
+            stream_edges: Vec::new(),
         }
     }
 

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -347,6 +347,7 @@ fn synthesis_input_for_app<'a>(
     let leaked: &'static str = Box::leak(placeholder.into_boxed_str());
 
     Ok(SynthesisInput {
+        stream_edges: Vec::new(),
         kernel_sha256: None,
         network_mode,
         l3_network: None,

--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -323,6 +323,7 @@ pub(in crate::commands::vm) fn admit_plan_for_boot(
         .map(|(policy_ref, _)| policy_ref.as_str());
 
     let input = SynthesisInput {
+        stream_edges: Vec::new(),
         kernel_sha256: None,
         network_mode: Default::default(),
         l3_network: None,

--- a/crates/mvm-cli/src/commands/vm/up/audit.rs
+++ b/crates/mvm-cli/src/commands/vm/up/audit.rs
@@ -143,6 +143,7 @@ chain_signing = true
         let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
         let mut plan = admit_for_run(
             &SynthesisInput {
+                stream_edges: Vec::new(),
                 kernel_sha256: None,
                 network_mode: Default::default(),
                 l3_network: None,
@@ -252,6 +253,7 @@ stream_destinations = ["file://{}"]
         let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
         let mut plan = admit_for_run(
             &SynthesisInput {
+                stream_edges: Vec::new(),
                 kernel_sha256: None,
                 network_mode: Default::default(),
                 l3_network: None,
@@ -360,6 +362,7 @@ chain_signing = false
         let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
         let mut plan = admit_for_run(
             &SynthesisInput {
+                stream_edges: Vec::new(),
                 kernel_sha256: None,
                 network_mode: Default::default(),
                 l3_network: None,
@@ -443,6 +446,7 @@ chain_signing = false
         let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
         let mut plan = admit_for_run(
             &SynthesisInput {
+                stream_edges: Vec::new(),
                 kernel_sha256: None,
                 network_mode: Default::default(),
                 l3_network: None,
@@ -546,6 +550,7 @@ disabled_inspectors = ["ssrf_guarrd"]
         let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
         let mut plan = admit_for_run(
             &SynthesisInput {
+                stream_edges: Vec::new(),
                 kernel_sha256: None,
                 network_mode: Default::default(),
                 l3_network: None,
@@ -655,6 +660,7 @@ port_hi  = 443
         let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
         let mut plan = admit_for_run(
             &SynthesisInput {
+                stream_edges: Vec::new(),
                 kernel_sha256: None,
                 network_mode: Default::default(),
                 l3_network: None,

--- a/crates/mvm-contract/src/plan/execution_plan.rs
+++ b/crates/mvm-contract/src/plan/execution_plan.rs
@@ -232,6 +232,17 @@ pub struct ExecutionPlan {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub services: Vec<ServiceId>,
 
+    /// Inbound stream edges: other workloads whose output feeds this one's
+    /// stdin. Each names a *binding* the host resolves, never a VM — see
+    /// [`crate::stream::edge`] for why a guest never addresses another guest.
+    ///
+    /// Skip-serialized when empty so a plan that declares no edge stays
+    /// byte-identical to one written before the field existed: the field is
+    /// inside the signed payload and inside the content address, so emitting
+    /// `[]` would move every existing plan's identity for nothing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub stream_edges: Vec<crate::stream::StreamEdge>,
+
     /// Whether this workload's captured output is kept after the run.
     ///
     /// Always serialized, unlike the optional pins above: the point of
@@ -321,6 +332,7 @@ pub(crate) fn minimal_plan() -> ExecutionPlan {
         deps_volume: None,
         shares: Vec::new(),
         services: Vec::new(),
+        stream_edges: Vec::new(),
         stream_retention: StreamRetention::Persist,
     }
 }

--- a/crates/mvm-contract/src/stream/edge.rs
+++ b/crates/mvm-contract/src/stream/edge.rs
@@ -1,0 +1,364 @@
+//! Stream edges: one workload's output feeding another's input.
+//!
+//! ## A consumer names a binding, never a VM
+//!
+//! [`StreamEdge::binding`] is a name local to the consumer's own plan. The
+//! host resolves it to a source workload; the guest never learns which one, or
+//! that there was one. That is the whole reason this is not guest networking
+//! by the back door: A and B never share a transport, never learn each other's
+//! identity, and neither gains a NIC. Bytes cross in the host, between two
+//! independent vsock channels, at the one place that was already the single
+//! authorization point.
+//!
+//! A consumer naming a binding it was not granted is refused before boot, and
+//! the refusal reaches the chain-signed log. "Not granted" and "no such
+//! source" are deliberately the same answer: a consumer must not be able to
+//! probe the fleet's shape by trying names.
+//!
+//! ## Two postures, both defaulting to the safe side
+//!
+//! [`EdgeRedaction`] defaults to `Redacted` and [`EdgeBackpressure`] to
+//! `Lossy`. Both defaults are what a plan written before this field existed
+//! deserializes to, so an old plan cannot acquire a raw edge by omission.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+/// Environment variable an operator sets to accept raw, unredacted bytes on an
+/// edge.
+///
+/// Shaped after `MVM_ACK_UNRESTRICTED_NETWORK` on purpose. A plan is signed on
+/// behalf of whoever launched the workload, so a plan signature alone is the
+/// wrong authority for this: it would let a careless or compromised workload
+/// definition export raw PII to another workload with no human in the loop.
+/// Between two workloads those are different trust domains, so the opt-out
+/// needs a second, human-held key. Never set in CI.
+pub const ACK_RAW_EDGE_ENV: &str = "MVM_ACK_RAW_STREAM_EDGE";
+
+/// What a consumer receives on an edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum EdgeRedaction {
+    /// Masked by the same seam every other consumer crosses. The default, and
+    /// the only posture that needs no operator acknowledgement.
+    #[default]
+    Redacted,
+    /// The consumer receives the producer's bytes unmasked.
+    ///
+    /// Exists because always-redact corrupts a pipeline whose second stage
+    /// needs what the first computed — a masked value is not a value. The
+    /// durable transcript still stores the redacted copy, so the artifact that
+    /// outlives the run is unweakened and the divergence is audited. Requires
+    /// [`ACK_RAW_EDGE_ENV`] in addition to the plan signature.
+    Raw,
+}
+
+/// What happens when a consumer cannot keep up.
+///
+/// Neither mode stalls the producer. A workload that blocks because its reader
+/// is slow is a workload whose behaviour depends on who is watching it, which
+/// this plane refuses to allow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum EdgeBackpressure {
+    /// Ring, evict oldest, mark the gap, audit it. The default: a workflow
+    /// that would rather see recent output than none.
+    #[default]
+    Lossy,
+    /// Fail the edge loudly when the buffer fills.
+    ///
+    /// A mode named `reliable` must never quietly drop a record, so when it
+    /// cannot hold one it stops being an edge rather than becoming a lossy one
+    /// under a reassuring name.
+    Reliable,
+}
+
+/// One inbound edge on a consumer's signed plan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StreamEdge {
+    /// The binding name, resolved by the host. Not a VM name — see the module
+    /// docs on why a guest never addresses another guest.
+    pub binding: String,
+    /// Redaction posture. Absent = [`EdgeRedaction::Redacted`].
+    #[serde(default)]
+    pub redaction: EdgeRedaction,
+    /// Backpressure mode. Absent = [`EdgeBackpressure::Lossy`].
+    #[serde(default)]
+    pub backpressure: EdgeBackpressure,
+}
+
+impl StreamEdge {
+    /// An edge with both postures at their defaults.
+    #[must_use]
+    pub fn new(binding: impl Into<String>) -> Self {
+        Self {
+            binding: binding.into(),
+            redaction: EdgeRedaction::Redacted,
+            backpressure: EdgeBackpressure::Lossy,
+        }
+    }
+
+    /// Whether this edge hands the consumer unmasked bytes.
+    #[must_use]
+    pub fn is_raw(&self) -> bool {
+        matches!(self.redaction, EdgeRedaction::Raw)
+    }
+}
+
+/// Whether `edges` contains any edge that would carry unmasked bytes.
+///
+/// The admission check needs this before it can decide whether the operator
+/// acknowledgement is required, and asking it in one place keeps the two from
+/// disagreeing about what "raw" means.
+#[must_use]
+pub fn any_raw_edge(edges: &[StreamEdge]) -> bool {
+    edges.iter().any(StreamEdge::is_raw)
+}
+
+/// Every distinct binding named by `edges`, in declaration order.
+///
+/// Duplicates are a plan defect rather than a topology question — the same
+/// binding twice means two writers for one input slot, which E3 rules out —
+/// so admission rejects them before the graph is built.
+#[must_use]
+pub fn duplicate_binding(edges: &[StreamEdge]) -> Option<&str> {
+    for (i, edge) in edges.iter().enumerate() {
+        if edges[..i].iter().any(|e| e.binding == edge.binding) {
+            return Some(edge.binding.as_str());
+        }
+    }
+    None
+}
+
+/// Bindings named by `edges`, in declaration order.
+#[must_use]
+pub fn binding_names(edges: &[StreamEdge]) -> Vec<&str> {
+    edges.iter().map(|e| e.binding.as_str()).collect()
+}
+
+/// Why a plan's declared edges were refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EdgeRefusal {
+    /// The same binding twice. Two edges into one input slot is fan-in, which
+    /// E3 rules out — caught here on the single plan rather than left for the
+    /// graph, because a plan can be wrong on its own.
+    DuplicateBinding { binding: String },
+    /// A raw edge without the operator acknowledgement.
+    ///
+    /// Deliberately not satisfiable by the plan signature: see
+    /// [`ACK_RAW_EDGE_ENV`] on why a signature is the wrong authority for
+    /// exporting unmasked bytes into a different trust domain.
+    RawEdgeUnacknowledged { binding: String },
+    /// The workload is fed by an edge *and* takes operator stdin.
+    ///
+    /// One input slot, one writer. This is the surprising one, so it is a
+    /// diagnosable admission error rather than a runtime race for the lease.
+    InputSlotContested { binding: String },
+}
+
+impl EdgeRefusal {
+    /// An operator-facing description that names the binding at fault.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            Self::DuplicateBinding { binding } => alloc::format!(
+                "stream edge {binding:?} is declared twice: one input slot takes one writer, so                  declare a merge stage instead"
+            ),
+            Self::RawEdgeUnacknowledged { binding } => alloc::format!(
+                "stream edge {binding:?} asks for unredacted bytes, which needs {ACK_RAW_EDGE_ENV}                  set by an operator — a plan signature is not that authority, because it is made                  on behalf of the workload rather than by a human accepting the export"
+            ),
+            Self::InputSlotContested { binding } => alloc::format!(
+                "stream edge {binding:?} feeds this workload's stdin, so it cannot also be given                  operator input: there is one input slot and one writer"
+            ),
+        }
+    }
+}
+
+/// Check one plan's declared edges, before boot and before the graph.
+///
+/// `raw_acknowledged` is whether the operator set [`ACK_RAW_EDGE_ENV`]; it is
+/// passed in rather than read here so this stays a pure function that a host
+/// can call from wherever it resolves environment. `operator_stdin` is whether
+/// the same launch also hands the workload an operator-driven stdin.
+///
+/// This is the per-plan half. The cross-plan half — resolving bindings to
+/// sources and refusing a cyclic graph — is
+/// [`crate::stream::topology::validate`], and belongs to whoever holds the
+/// whole declaration.
+///
+/// # Errors
+///
+/// One [`EdgeRefusal`] per the first problem found, in the order a reader
+/// would want them: shape, then authority, then slot contention.
+pub fn check_plan_edges(
+    edges: &[StreamEdge],
+    raw_acknowledged: bool,
+    operator_stdin: bool,
+) -> Result<(), EdgeRefusal> {
+    if let Some(binding) = duplicate_binding(edges) {
+        return Err(EdgeRefusal::DuplicateBinding {
+            binding: String::from(binding),
+        });
+    }
+    if !raw_acknowledged && let Some(edge) = edges.iter().find(|e| e.is_raw()) {
+        return Err(EdgeRefusal::RawEdgeUnacknowledged {
+            binding: edge.binding.clone(),
+        });
+    }
+    if operator_stdin && let Some(edge) = edges.first() {
+        return Err(EdgeRefusal::InputSlotContested {
+            binding: edge.binding.clone(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+
+    #[test]
+    fn defaults_are_the_safe_side() {
+        let edge = StreamEdge::new("upstream");
+        assert_eq!(edge.redaction, EdgeRedaction::Redacted);
+        assert_eq!(edge.backpressure, EdgeBackpressure::Lossy);
+        assert!(!edge.is_raw());
+    }
+
+    /// A plan written before this field existed must not acquire a raw edge by
+    /// omission. Serde defaults are what enforce that, so they are pinned.
+    #[test]
+    fn an_edge_missing_both_postures_deserializes_to_the_safe_ones() {
+        let edge: StreamEdge =
+            serde_json::from_str(r#"{"binding":"upstream"}"#).expect("bare binding parses");
+        assert_eq!(edge.redaction, EdgeRedaction::Redacted);
+        assert_eq!(edge.backpressure, EdgeBackpressure::Lossy);
+    }
+
+    #[test]
+    fn unknown_fields_are_refused() {
+        let err = serde_json::from_str::<StreamEdge>(r#"{"binding":"a","mode":"raw"}"#);
+        assert!(err.is_err(), "deny_unknown_fields must reject a typo'd key");
+    }
+
+    /// `raw` is the wire spelling. A rename here silently downgrades every
+    /// existing raw edge to redacted, which fails safe but would be a mystery.
+    #[test]
+    fn postures_roundtrip_through_their_wire_names() {
+        let edge = StreamEdge {
+            binding: "upstream".into(),
+            redaction: EdgeRedaction::Raw,
+            backpressure: EdgeBackpressure::Reliable,
+        };
+        let json = serde_json::to_string(&edge).expect("serialize");
+        assert!(json.contains(r#""redaction":"raw""#), "{json}");
+        assert!(json.contains(r#""backpressure":"reliable""#), "{json}");
+        assert_eq!(
+            serde_json::from_str::<StreamEdge>(&json).expect("roundtrip"),
+            edge
+        );
+    }
+
+    #[test]
+    fn any_raw_edge_finds_one_among_redacted_siblings() {
+        let edges = vec![
+            StreamEdge::new("a"),
+            StreamEdge {
+                binding: "b".into(),
+                redaction: EdgeRedaction::Raw,
+                backpressure: EdgeBackpressure::Lossy,
+            },
+            StreamEdge::new("c"),
+        ];
+        assert!(any_raw_edge(&edges));
+        assert!(!any_raw_edge(&edges[..1]));
+    }
+
+    #[test]
+    fn duplicate_binding_names_the_repeat() {
+        let edges = vec![
+            StreamEdge::new("a"),
+            StreamEdge::new("b"),
+            StreamEdge::new("a"),
+        ];
+        assert_eq!(duplicate_binding(&edges), Some("a"));
+        assert_eq!(duplicate_binding(&edges[..2]), None);
+    }
+
+    #[test]
+    fn binding_names_preserves_declaration_order() {
+        let edges = vec![StreamEdge::new("z"), StreamEdge::new("a")];
+        assert_eq!(binding_names(&edges), vec!["z", "a"]);
+    }
+
+    #[test]
+    fn a_plain_plan_admits() {
+        check_plan_edges(&[StreamEdge::new("a")], false, false).expect("a redacted edge is fine");
+    }
+
+    #[test]
+    fn a_duplicate_binding_is_refused() {
+        let edges = vec![StreamEdge::new("a"), StreamEdge::new("a")];
+        let err = check_plan_edges(&edges, false, false).expect_err("two writers, one slot");
+        assert_eq!(
+            err,
+            EdgeRefusal::DuplicateBinding {
+                binding: "a".into()
+            }
+        );
+        assert!(err.describe().contains("merge stage"), "{}", err.describe());
+    }
+
+    /// The signature is deliberately not enough. If this ever starts passing
+    /// with `false`, a workload definition can export unmasked bytes into
+    /// another trust domain with no human in the loop.
+    #[test]
+    fn a_raw_edge_without_the_acknowledgement_is_refused() {
+        let edges = vec![StreamEdge {
+            binding: "a".into(),
+            redaction: EdgeRedaction::Raw,
+            backpressure: EdgeBackpressure::Lossy,
+        }];
+        let err = check_plan_edges(&edges, false, false).expect_err("needs the operator ack");
+        assert_eq!(
+            err,
+            EdgeRefusal::RawEdgeUnacknowledged {
+                binding: "a".into()
+            }
+        );
+        assert!(
+            err.describe().contains(ACK_RAW_EDGE_ENV),
+            "{}",
+            err.describe()
+        );
+
+        check_plan_edges(&edges, true, false).expect("acknowledged, so admitted");
+    }
+
+    /// The consequence most likely to surprise someone: an edge consumes
+    /// the single input slot, so the workload cannot also take operator stdin.
+    /// A diagnosable refusal, not a runtime race for the lease.
+    #[test]
+    fn an_edge_and_operator_stdin_together_are_refused() {
+        let edges = vec![StreamEdge::new("a")];
+        let err = check_plan_edges(&edges, false, true).expect_err("one slot, one writer");
+        assert_eq!(
+            err,
+            EdgeRefusal::InputSlotContested {
+                binding: "a".into()
+            }
+        );
+    }
+
+    /// Operator stdin with no edge is the ordinary case and must stay allowed —
+    /// a check that refused it would break `machine run --stdin -`.
+    #[test]
+    fn operator_stdin_without_an_edge_admits() {
+        check_plan_edges(&[], false, true).expect("no edge, no contention");
+    }
+}

--- a/crates/mvm-contract/src/stream/mod.rs
+++ b/crates/mvm-contract/src/stream/mod.rs
@@ -15,11 +15,18 @@
 //! recognise the host's own secrets without holding any of them.
 
 pub mod chain;
+pub mod edge;
 pub mod input;
 pub mod record;
 pub mod secret_fingerprint;
+pub mod topology;
 
 pub use chain::{ChainError, verify_chain, verify_chain_from};
+pub use edge::{
+    ACK_RAW_EDGE_ENV, EdgeBackpressure, EdgeRedaction, StreamEdge, any_raw_edge, binding_names,
+    duplicate_binding,
+};
 pub use input::{CloseInput, INPUT_GRANT_SERVICE, InputFrame, grants_input, grants_input_for};
 pub use record::{StreamKind, StreamRecord, StreamSource};
 pub use secret_fingerprint::{CATEGORY_HOST_SECRET, SecretCategory, SecretFingerprint};
+pub use topology::{ResolvedEdge, TopologyError, validate as validate_topology};

--- a/crates/mvm-contract/src/stream/topology.rs
+++ b/crates/mvm-contract/src/stream/topology.rs
@@ -1,0 +1,331 @@
+//! The declared edge graph, validated once before anything boots.
+//!
+//! ## Why a cycle is not merely unsupported
+//!
+//! A cycle breaks EOF propagation: nothing downstream of itself ever sees its
+//! producer close, so it never closes either. With lossy eviction it does not
+//! even deadlock into something obvious — it degrades into a silently churning
+//! loop that looks like a workload doing work. And every edge hash-chains, so
+//! a cycle leaves no order in which to ask what a workload saw.
+//!
+//! The topology is declared rather than discovered, so this is a cheap static
+//! check with nothing to race. It runs before boot and fails closed.
+//!
+//! ## What this module is not
+//!
+//! It does not resolve bindings, authorize them, or know what a fleet is. It
+//! takes edges already resolved to source workloads and answers one question:
+//! is this a DAG. `mvmd` owns the resolution; `mvm` owns the refusal.
+
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::String;
+use alloc::vec::Vec;
+
+/// One resolved edge: bytes flow from `source` into `consumer`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ResolvedEdge {
+    /// The workload whose output feeds the edge.
+    pub source: String,
+    /// The workload whose input the edge writes.
+    pub consumer: String,
+    /// The consumer-local binding name, carried so a refusal can name the
+    /// declaration a human wrote rather than the pair a validator derived.
+    pub binding: String,
+}
+
+impl ResolvedEdge {
+    /// A resolved edge from its three parts.
+    #[must_use]
+    pub fn new(
+        source: impl Into<String>,
+        consumer: impl Into<String>,
+        binding: impl Into<String>,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            consumer: consumer.into(),
+            binding: binding.into(),
+        }
+    }
+}
+
+/// Why a declared topology was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TopologyError {
+    /// The graph contains a cycle. `path` is the cycle in flow order, first
+    /// node repeated at the end, so an operator can read it as a route.
+    Cycle { path: Vec<String> },
+    /// Two edges write the same consumer's input.
+    ///
+    /// E3: one input slot, one writer. Two producers interleaving into one
+    /// stdin produce corrupted records, and stdin carries no framing to
+    /// recover them. A workflow that needs fan-in declares a merge stage,
+    /// which is itself a workload the fleet can express.
+    FanIn {
+        consumer: String,
+        bindings: Vec<String>,
+    },
+}
+
+impl TopologyError {
+    /// An operator-facing description that names the declaration at fault.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Cycle { path } => {
+                alloc::format!(
+                    "stream edges form a cycle: {} — a cycle never propagates EOF, so nothing \
+                     downstream of itself ever closes",
+                    path.join(" -> ")
+                )
+            }
+            Self::FanIn { consumer, bindings } => alloc::format!(
+                "workload {:?} is fed by {} edges ({}) but has one input slot — declare a merge \
+                 stage instead of two writers",
+                consumer,
+                bindings.len(),
+                bindings.join(", ")
+            ),
+        }
+    }
+}
+
+/// Validate a declared topology, refusing before anything boots.
+///
+/// Returns the consumers in a valid start order when the graph is a DAG: a
+/// caller that wants to boot producers before consumers can follow it, and a
+/// caller that does not can ignore it.
+///
+/// # Errors
+///
+/// [`TopologyError::FanIn`] when two edges write one consumer, and
+/// [`TopologyError::Cycle`] when flow returns to a workload it already passed
+/// through — including the self-edge and cycles of any length.
+pub fn validate(edges: &[ResolvedEdge]) -> Result<Vec<String>, TopologyError> {
+    // Fan-in first: it is the cheaper question, and a graph that fails it has
+    // an ambiguous shape the cycle walk would then be reasoning about.
+    let mut writers: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for edge in edges {
+        writers
+            .entry(edge.consumer.as_str())
+            .or_default()
+            .push(edge.binding.as_str());
+    }
+    if let Some((consumer, bindings)) = writers.iter().find(|(_, b)| b.len() > 1) {
+        return Err(TopologyError::FanIn {
+            consumer: String::from(*consumer),
+            bindings: bindings.iter().map(|b| String::from(*b)).collect(),
+        });
+    }
+
+    let mut out: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    let mut nodes: BTreeSet<&str> = BTreeSet::new();
+    for edge in edges {
+        out.entry(edge.source.as_str())
+            .or_default()
+            .push(edge.consumer.as_str());
+        nodes.insert(edge.source.as_str());
+        nodes.insert(edge.consumer.as_str());
+    }
+
+    // Iterative DFS with an explicit on-stack set. Recursion would be simpler
+    // and would blow the stack on a long chain, which a fleet can trivially
+    // declare.
+    let mut done: BTreeSet<&str> = BTreeSet::new();
+    let mut order: Vec<String> = Vec::new();
+    for root in &nodes {
+        if done.contains(root) {
+            continue;
+        }
+        let mut on_path: Vec<&str> = Vec::new();
+        let mut on_path_set: BTreeSet<&str> = BTreeSet::new();
+        // (node, index of the next child to visit)
+        let mut stack: Vec<(&str, usize)> = alloc::vec![(*root, 0)];
+        on_path.push(root);
+        on_path_set.insert(root);
+
+        while let Some((node, child_idx)) = stack.pop() {
+            let children = out.get(node).map(Vec::as_slice).unwrap_or(&[]);
+            if child_idx < children.len() {
+                stack.push((node, child_idx + 1));
+                let child = children[child_idx];
+                if on_path_set.contains(child) {
+                    // Cycle: report it from where it re-enters, so the path
+                    // reads as the loop rather than as the walk that found it.
+                    let start = on_path.iter().position(|n| *n == child).unwrap_or(0);
+                    let mut path: Vec<String> =
+                        on_path[start..].iter().map(|n| String::from(*n)).collect();
+                    path.push(String::from(child));
+                    return Err(TopologyError::Cycle { path });
+                }
+                if !done.contains(child) {
+                    on_path.push(child);
+                    on_path_set.insert(child);
+                    stack.push((child, 0));
+                }
+            } else {
+                done.insert(node);
+                order.push(String::from(node));
+                on_path.pop();
+                on_path_set.remove(node);
+            }
+        }
+    }
+
+    // `order` is post-order, so producers land after the consumers they feed.
+    // Reverse it to get flow order.
+    order.reverse();
+    Ok(order)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+
+    fn edge(source: &str, consumer: &str) -> ResolvedEdge {
+        ResolvedEdge::new(source, consumer, alloc::format!("{source}->{consumer}"))
+    }
+
+    #[test]
+    fn a_chain_is_a_dag_and_comes_back_in_flow_order() {
+        let edges = vec![edge("a", "b"), edge("b", "c")];
+        let order = validate(&edges).expect("a chain is acyclic");
+        let a = order.iter().position(|n| n == "a").expect("a present");
+        let b = order.iter().position(|n| n == "b").expect("b present");
+        let c = order.iter().position(|n| n == "c").expect("c present");
+        assert!(a < b && b < c, "producers precede consumers: {order:?}");
+    }
+
+    #[test]
+    fn a_fan_out_is_a_dag() {
+        // One producer feeding two consumers is fine — it is fan-*in* that E3
+        // rules out, and conflating them would refuse a legal topology.
+        let edges = vec![edge("a", "b"), edge("a", "c")];
+        validate(&edges).expect("one source may feed several consumers");
+    }
+
+    #[test]
+    fn a_self_edge_is_refused() {
+        let err = validate(&[edge("a", "a")]).expect_err("a self-edge is a cycle");
+        match err {
+            TopologyError::Cycle { path } => assert_eq!(path, vec!["a", "a"]),
+            other => panic!("expected a cycle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_two_node_cycle_is_refused() {
+        let err = validate(&[edge("a", "b"), edge("b", "a")]).expect_err("a->b->a is a cycle");
+        assert!(matches!(err, TopologyError::Cycle { .. }), "{err:?}");
+    }
+
+    /// The usual defect is a validator that only catches `A→A`, so the long
+    /// cycle is the one that actually proves the walk works.
+    #[test]
+    fn a_long_cycle_is_refused() {
+        let edges = vec![
+            edge("a", "b"),
+            edge("b", "c"),
+            edge("c", "d"),
+            edge("d", "e"),
+            edge("e", "a"),
+        ];
+        let err = validate(&edges).expect_err("a five-node cycle is a cycle");
+        match err {
+            TopologyError::Cycle { path } => {
+                assert_eq!(path.first(), path.last(), "the path closes: {path:?}");
+                assert!(path.len() >= 5, "the whole loop is reported: {path:?}");
+            }
+            other => panic!("expected a cycle, got {other:?}"),
+        }
+    }
+
+    /// Entering a cycle from outside it is refused — as fan-in, not as a
+    /// cycle, and that is not a weaker answer.
+    ///
+    /// It falls out of E3 rather than being a second rule: one input slot
+    /// means one in-edge, so a node reachable both from a prefix and from
+    /// around a loop already has two writers. The consequence worth writing
+    /// down is that under E3 a cycle can only ever be an isolated loop with no
+    /// way in — which is why the cycle walk is checked against disjoint
+    /// components below rather than against attached ones, and why refusing
+    /// fan-in first is what makes the graph shape simple enough to reason
+    /// about at all.
+    #[test]
+    fn entering_a_cycle_from_outside_it_is_refused_as_fan_in() {
+        let edges = vec![edge("root", "a"), edge("a", "b"), edge("b", "a")];
+        let err = validate(&edges).expect_err("`a` is written by both root and b");
+        match err {
+            TopologyError::FanIn { consumer, .. } => assert_eq!(consumer, "a"),
+            other => panic!("expected fan-in, got {other:?}"),
+        }
+    }
+
+    /// Two disjoint components, one clean and one cyclic. A validator that
+    /// returned on the first clean root would miss this.
+    #[test]
+    fn a_cycle_in_a_second_component_is_refused() {
+        let edges = vec![edge("a", "b"), edge("x", "y"), edge("y", "x")];
+        let err = validate(&edges).expect_err("the second component cycles");
+        assert!(matches!(err, TopologyError::Cycle { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn a_diamond_is_a_dag() {
+        // a feeds b and c; both feed different consumers. Not fan-in, and a
+        // depth-first walk revisits `a`'s descendants — which must not be
+        // mistaken for a cycle.
+        let edges = vec![
+            edge("a", "b"),
+            edge("a", "c"),
+            edge("b", "d"),
+            edge("c", "e"),
+        ];
+        validate(&edges).expect("a diamond of distinct consumers is acyclic");
+    }
+
+    #[test]
+    fn two_writers_for_one_consumer_are_refused() {
+        let edges = vec![
+            ResolvedEdge::new("a", "sink", "from-a"),
+            ResolvedEdge::new("b", "sink", "from-b"),
+        ];
+        let err = validate(&edges).expect_err("one input slot, one writer");
+        match err {
+            TopologyError::FanIn { consumer, bindings } => {
+                assert_eq!(consumer, "sink");
+                assert_eq!(bindings, vec!["from-a", "from-b"]);
+            }
+            other => panic!("expected fan-in, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_empty_topology_is_valid() {
+        assert_eq!(
+            validate(&[]).expect("nothing to refuse"),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn descriptions_name_the_declaration_at_fault() {
+        let cycle = validate(&[edge("a", "b"), edge("b", "a")]).expect_err("cycle");
+        let text = cycle.describe();
+        assert!(
+            text.contains("a -> b -> a") || text.contains("b -> a -> b"),
+            "{text}"
+        );
+
+        let fan_in = validate(&[
+            ResolvedEdge::new("a", "sink", "from-a"),
+            ResolvedEdge::new("b", "sink", "from-b"),
+        ])
+        .expect_err("fan-in");
+        let text = fan_in.describe();
+        assert!(text.contains("from-a") && text.contains("from-b"), "{text}");
+        assert!(text.contains("merge stage"), "the fix is named: {text}");
+    }
+}

--- a/crates/mvm-core/src/plan/signing.rs
+++ b/crates/mvm-core/src/plan/signing.rs
@@ -279,6 +279,7 @@ pub mod test_support {
             deps_volume: None,
             shares: Vec::new(),
             services: Vec::new(),
+            stream_edges: Vec::new(),
         }
     }
 }

--- a/crates/mvm-core/src/plan/synthesis.rs
+++ b/crates/mvm-core/src/plan/synthesis.rs
@@ -186,6 +186,9 @@ pub struct SynthesisInput<'a> {
     /// grant (`mvm_contract::stream::INPUT_GRANT_SERVICE`) — no dedicated field
     /// was needed, since `mvm_contract::stream::grants_input` reads this list.
     pub services: Vec<mvm_contract::protocol::broker::ServiceId>,
+    /// Inbound stream edges this workload is fed by. Empty (the default) means
+    /// no other workload writes its stdin.
+    pub stream_edges: Vec<mvm_contract::stream::StreamEdge>,
     /// Whether this workload's captured output is kept after the run.
     /// [`StreamRetention::Persist`] (the default) writes an encrypted,
     /// hash-chained transcript sealed at exit; `Ephemeral` fans the output out
@@ -345,6 +348,7 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
         deps_volume: input.deps_volume.clone(),
         shares: input.shares.clone(),
         services: input.services.clone(),
+        stream_edges: input.stream_edges.clone(),
         stream_retention: input.stream_retention,
     };
 
@@ -460,6 +464,7 @@ mod tests {
             audit_labels: Default::default(),
             agent_verbs: None,
             services: Vec::new(),
+            stream_edges: Vec::new(),
             stream_retention: Default::default(),
         }
     }

--- a/crates/mvm-core/src/plan/test_support.rs
+++ b/crates/mvm-core/src/plan/test_support.rs
@@ -33,6 +33,7 @@ pub struct PlanFixture {
     valid_from: Option<DateTime<Utc>>,
     valid_until: Option<DateTime<Utc>>,
     services: Vec<ServiceId>,
+    stream_edges: Vec<mvm_contract::stream::StreamEdge>,
     stream_retention: StreamRetention,
     audit_labels: BTreeMap<String, String>,
 }
@@ -49,6 +50,7 @@ impl Default for PlanFixture {
             valid_from: None,
             valid_until: None,
             services: Vec::new(),
+            stream_edges: Vec::new(),
             stream_retention: StreamRetention::default(),
             audit_labels: BTreeMap::new(),
         }
@@ -185,6 +187,7 @@ impl PlanFixture {
             deps_volume: None,
             shares: Vec::new(),
             services: self.services,
+            stream_edges: self.stream_edges.clone(),
             stream_retention: self.stream_retention,
         }
     }

--- a/crates/mvm-core/tests/replay_protection.rs
+++ b/crates/mvm-core/tests/replay_protection.rs
@@ -74,6 +74,7 @@ fn fixture_plan(nonce: [u8; 16]) -> ExecutionPlan {
         deps_volume: None,
         shares: Vec::new(),
         services: Vec::new(),
+        stream_edges: Vec::new(),
     }
 }
 

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -931,6 +931,7 @@ mod tests {
 
     fn fixture_input(vm_name: &str) -> SynthesisInput<'_> {
         SynthesisInput {
+            stream_edges: Vec::new(),
             kernel_sha256: None,
             network_mode: Default::default(),
             l3_network: None,

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -92,6 +92,7 @@ pub fn admit_and_boot_local(
         .transpose()?;
 
     let synthesis = SynthesisInput {
+        stream_edges: Vec::new(),
         kernel_sha256: kernel_sha.as_deref(),
         network_mode: Default::default(),
         l3_network: None,

--- a/crates/mvm-hostd/src/stream/input_gate.rs
+++ b/crates/mvm-hostd/src/stream/input_gate.rs
@@ -1051,6 +1051,7 @@ mod tests {
         const FIXTURE_SHA: &str =
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
         SynthesisInput {
+            stream_edges: Vec::new(),
             kernel_sha256: None,
             vm_name,
             tenant: None,

--- a/crates/mvm-hostd/src/supervisor/aggregate.rs
+++ b/crates/mvm-hostd/src/supervisor/aggregate.rs
@@ -1274,6 +1274,7 @@ mod tests {
             shares: Vec::new(),
             agent_verbs: None,
             services: Vec::new(),
+            stream_edges: Vec::new(),
         };
         plan.plan_id = mvm_core::plan::compute_plan_id(&plan);
         plan

--- a/crates/mvm-hostd/src/supervisor/audit.rs
+++ b/crates/mvm-hostd/src/supervisor/audit.rs
@@ -408,6 +408,7 @@ mod tests {
             shares: Vec::new(),
             agent_verbs: None,
             services: Vec::new(),
+            stream_edges: Vec::new(),
         }
     }
 

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge/signer.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge/signer.rs
@@ -350,6 +350,7 @@ mod tests {
             shares: Vec::new(),
             agent_verbs: None,
             services: Vec::new(),
+            stream_edges: Vec::new(),
         }
     }
 }

--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -984,6 +984,7 @@ mod tests {
             shares: Vec::new(),
             agent_verbs: None,
             services: Vec::new(),
+            stream_edges: Vec::new(),
         }
     }
 

--- a/crates/mvm-hostd/tests/workload_input_plane.rs
+++ b/crates/mvm-hostd/tests/workload_input_plane.rs
@@ -185,6 +185,7 @@ fn unique_vm(prefix: &str) -> String {
 fn synthesis_input(vm_name: &str) -> SynthesisInput<'_> {
     const FIXTURE_SHA: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     SynthesisInput {
+        stream_edges: Vec::new(),
         kernel_sha256: None,
         vm_name,
         tenant: None,

--- a/crates/mvm-runtime/src/hvf_backend.rs
+++ b/crates/mvm-runtime/src/hvf_backend.rs
@@ -875,6 +875,7 @@ mod tests {
         use mvm_core::policy::RedactionPolicy;
 
         let input = SynthesisInput {
+            stream_edges: Vec::new(),
             kernel_sha256: None,
             network_mode: Default::default(),
             l3_network: None,

--- a/specs/plans/296-fleet-stream-fan-out.md
+++ b/specs/plans/296-fleet-stream-fan-out.md
@@ -1,6 +1,11 @@
 # Plan 296 — fleet stream fan-out
 
-**Status:** Proposed.
+**Status:** WS1 + WS2 landed. WS3–WS6 outstanding.
+
+`mvm` ships the mechanism; `mvmd` declares the edges and resolves the bindings.
+That split is why the landed half has **no production caller in this
+repository** — see "Declared dormancy" below. It is a declaration, not an
+oversight.
 
 Connect one workload's output stream to another's input stream, so a fleet can
 run a workflow. `mvmd` declares the edges; `mvm` exposes the primitives and
@@ -46,6 +51,8 @@ reference on a workload path.
 | E3 | The single-writer lease stays; fan-in is a merge node | Two producers interleaving into one stdin produce corrupted records and stdin carries no framing to recover them. A workflow needing fan-in declares a merge stage, which is itself a workload the fleet can express. |
 | E4 | Backpressure never stalls a producer and never silently loses | `lossy` (default) rings, evicts oldest, marks the gap and audits it. `reliable` keeps the producer unstalled but fails the edge loudly when its buffer fills. A mode named `reliable` must never quietly drop records. |
 | E5 | The topology is a DAG, rejected at admission | A cycle breaks EOF propagation, so nothing downstream of itself ever closes. With lossy eviction it does not even deadlock — it degrades into a silently churning loop. And every edge hash-chains, so a cycle leaves no order in which to ask what a workload saw. The topology is declared, so validate the static graph once and refuse before anything boots. |
+| E6 | A broken edge fails the workflow. It does not silently reconnect across a consumer restart | Reconnection is not free: the gate builds a fresh `SecretScanner` per session, so a secret split across the restart boundary would be scanned by two scanners with neither seeing the whole — the same hole this project refused to open at route displacement. Surviving a restart also means buffering on the producer for an unbounded interval, which breaks the bounded-memory invariant. Workflows already have a supervisor; re-running the DAG is the correct recovery, at the correct layer. The edge records its last delivered sequence in the chain-signed log so a re-run is reasoned about rather than guessed. |
+| E7 | The redaction opt-out (E1) requires an explicit operator acknowledgement, distinct from the plan signature | A plan is signed on behalf of whoever launched the workload, so letting a workload's own plan opt its edge out of redaction lets a careless or compromised workload definition export raw PII to another workload with no human in the loop. Between two workloads these are different trust domains. This repository already has the right shape for it: unrestricted egress requires `MVM_ACK_UNRESTRICTED_NETWORK=1`, an operator acknowledgement never set in CI. The redaction opt-out takes the same form and is audited. |
 
 Two consequences worth stating plainly, because they will surprise someone:
 
@@ -57,16 +64,26 @@ Two consequences worth stating plainly, because they will surprise someone:
 
 ## Work
 
-- [ ] **WS1 — the edge binding.** A signed-plan shape by which a consumer names
-  a *binding*, not a VM. The host resolves it. A consumer that names a source it
-  was not granted is refused and the refusal reaches the chain-signed log.
-  Includes the redaction posture (E1) and the backpressure mode (E4) as
-  properties of the binding.
+- [x] **WS1 — the edge binding.** Landed. `mvm_contract::stream::edge` defines
+  `StreamEdge` (binding name, `EdgeRedaction`, `EdgeBackpressure`), the plan
+  carries `ExecutionPlan.stream_edges`, and `check_plan_edges` refuses a
+  duplicate binding, a raw edge without `MVM_ACK_RAW_STREAM_EDGE`, and an edge
+  contending with operator stdin. Both postures default to the safe side and
+  are `#[serde(default)]`, so a plan written before the field existed cannot
+  acquire a raw edge by omission. `stream_edges` is `skip_serializing_if`
+  empty, so no existing plan's content address moved.
 
-- [ ] **WS2 — DAG validation at admission.** Build the declared graph, reject a
-  cycle before any boot, and name the offending edge. Cheap, static, fail-closed.
-  Test the self-edge, the two-node cycle, and a long cycle — a validator that
-  only catches `A→A` is the usual defect.
+- [x] **WS2 — DAG validation at admission.** Landed.
+  `mvm_contract::stream::topology::validate` takes resolved edges and refuses
+  fan-in and cycles, returning flow order on success. Iterative DFS, because a
+  fleet can trivially declare a chain deep enough to blow a recursive one.
+
+  One consequence fell out and is worth keeping: with fan-in refused first
+  (E3), every consumer has at most one in-edge, so a cycle can only ever be an
+  **isolated loop** — entering one from outside necessarily gives the entry
+  node two writers and is refused as fan-in instead. The tests cover the
+  self-edge, the two-node cycle, a five-node cycle, a cycle in a second
+  disjoint component, and a diamond that must *not* be mistaken for one.
 
 - [ ] **WS3 — the connector.** Pump A's `ReaderHandle` into B's `InputSession`
   in acceptance order, honouring the lease and refreshing it. This is where
@@ -89,8 +106,22 @@ Two consequences worth stating plainly, because they will surprise someone:
   flight, why fan-in is a merge node, and what happens when a consumer falls
   behind under each mode.
 
-| E6 | A broken edge fails the workflow. It does not silently reconnect across a consumer restart | Reconnection is not free: the gate builds a fresh `SecretScanner` per session, so a secret split across the restart boundary would be scanned by two scanners with neither seeing the whole — the same hole this project refused to open at route displacement. Surviving a restart also means buffering on the producer for an unbounded interval, which breaks the bounded-memory invariant. Workflows already have a supervisor; re-running the DAG is the correct recovery, at the correct layer. The edge records its last delivered sequence in the chain-signed log so a re-run is reasoned about rather than guessed. |
-| E7 | The redaction opt-out (E1) requires an explicit operator acknowledgement, distinct from the plan signature | A plan is signed on behalf of whoever launched the workload, so letting a workload's own plan opt its edge out of redaction lets a careless or compromised workload definition export raw PII to another workload with no human in the loop. Between two workloads these are different trust domains. This repository already has the right shape for it: unrestricted egress requires `MVM_ACK_UNRESTRICTED_NETWORK=1`, an operator acknowledgement never set in CI. The redaction opt-out takes the same form and is audited. |
+## Declared dormancy
+
+`validate_topology` and `check_plan_edges` have **no caller inside `mvm`**, and
+will not get one: a single-VM `mvmctl` run has no graph to validate, and this
+repository has no fleet. `mvmd` is the caller.
+
+That is the shape plan 293's WS4 exists to catch, so it is written down here
+rather than discovered later. The distinction WS4 draws is between a control
+that is dormant *by declaration* and one that is dormant *by accident* — this
+is the former, and when WS4 lands these two belong in its allowlist with this
+paragraph as the justification.
+
+What keeps it honest meanwhile: both are pure functions with no side effects,
+both are covered by their own tests, and neither claims a guarantee that
+anything in `mvm` relies on. The refusals they implement are real only once
+`mvmd` calls them, and no claim in ADR-001 asserts otherwise.
 
 ## Open questions
 


### PR DESCRIPTION
Lands WS1 and WS2 of plan 296: the stream-edge primitives, so one workload's output can feed another's stdin.

**`mvmd` declares the edges; `mvm` exposes the mechanism and never learns what a fleet is.** This is the mechanism half only.

## A consumer names a binding, never a VM

`StreamEdge.binding` is local to the consumer's own plan. The host resolves it, so the guest never learns which workload feeds it — or that one does.

That is what keeps fleet data-sharing from becoming guest networking by the back door: the two workloads never share a transport, never learn each other's identity, and neither gains a NIC. Bytes cross in the host, between two independent vsock channels, at the place that was already the single authorization point. Both `xtask` vsock gates stay green.

## Defaults, and why no plan re-addresses

`EdgeRedaction` defaults to `Redacted`, `EdgeBackpressure` to `Lossy`, both `#[serde(default)]` — a plan written before this field existed cannot acquire a raw edge by omission, and a test pins that.

`ExecutionPlan.stream_edges` is `skip_serializing_if` empty, so a plan declaring no edge stays byte-identical. **The frozen content-address vectors still pass**, which is the check that would have caught it otherwise — no repeat of the reseed the last schema change needed.

## The refusals

`check_plan_edges` rejects, in the order a reader wants them:

- **Duplicate binding** — two edges into one input slot is fan-in, which E3 rules out.
- **Raw edge without `MVM_ACK_RAW_STREAM_EDGE`** — deliberately *not* satisfiable by the plan signature. A signature is made on behalf of the workload; exporting unmasked bytes into another workload crosses a trust boundary that wants a human. Same shape as `MVM_ACK_UNRESTRICTED_NETWORK`.
- **Edge plus operator stdin** — one slot, one writer. This would otherwise surface at runtime as a race for the lease, so it is a diagnosable admission error instead.

`validate_topology` refuses fan-in and cycles over already-resolved edges and returns flow order. Iterative DFS, because a fleet can declare a chain deep enough to blow a recursive one.

**One property fell out of checking fan-in first:** with at most one in-edge per consumer, a cycle can only ever be an *isolated loop* — entering one from outside necessarily gives the entry node two writers, so it is refused as fan-in. My first draft of that test asserted `Cycle` and failed; the test was wrong, not the validator, and it now pins the real behaviour.

Tests cover the self-edge, a two-node cycle, a five-node cycle, a cycle in a second disjoint component, and a diamond that must **not** be mistaken for one.

## Declared dormancy — please read

Neither `check_plan_edges` nor `validate_topology` has a caller in this repository, and neither will: there is no fleet here to call them. `mvmd` is the caller.

That is exactly the "correct, tested, unreachable" shape plan 293's WS4 exists to catch, so it is **declared in plan 296** rather than left to be discovered — with the reasoning that belongs in WS4's allowlist when it lands. Both are pure functions, both are covered by their own tests, and neither claims a guarantee anything in `mvm` relies on.

## Still open

WS3 (the connector pumping a `ReaderHandle` into an `InputSession`), WS4 (backpressure modes), WS5 (claim work) and WS6 (docs). WS3 is where plan 296 warns the existing guarantees are easiest to lose — the gate's secret scan concatenates in acceptance order and the withheld tail must survive close — so it wants its own slice rather than a rushed tail on this one.

## Verification

clippy `-D warnings` clean. `mvm-contract` 52 stream tests plus 12 edge tests; workspace suites pass. Seven xtask gates green, including both vsock gates, `check-mutation-witnesses` and `check-no-spec-refs-in-comments` — which caught a plan citation in one of my own comments.

Two lease-expiry tests flake under full-suite concurrency and pass 28/28 across three runs at `-j 2`; they are timing-sensitive and untouched by this change, which adds a plan field.
