### PR TITLE
Fix Stage 0 builder sockets in deep worktrees

### DIFF
--- a/crates/mvm-build/src/builderd.rs
+++ b/crates/mvm-build/src/builderd.rs
@@ -628,8 +628,10 @@ pub fn dispatch_with_executor(
 // ============================================================================
 
 /// The **libkrun**-shape control socket for a builder VM rooted at
-/// `vm_state_dir`: `<vm_state_dir>/vsock-<port>.sock`. libkrun binds one
-/// socket per forwarded port directly in the state dir (matching
+/// `vm_state_dir`: normally `<vm_state_dir>/vsock-<port>.sock`. libkrun binds
+/// one socket per forwarded port directly in the resolved socket directory;
+/// deep state paths use the short namespace selected by
+/// `mvm_core::config::vm_socket_dir_at` (matching
 /// `persistent_builder::dispatch_socket_path`).
 ///
 /// HVF nests its per-port sockets one level deeper, under a `vsock/`
@@ -639,17 +641,21 @@ pub fn dispatch_with_executor(
 /// the libkrun-vs-HVF socket-path bug class that has bitten the broker
 /// path before.
 pub fn builderd_control_socket_path(vm_state_dir: &Path) -> PathBuf {
-    vm_state_dir.join(builderd_control_socket_filename())
+    mvm_core::config::vm_vsock_port_socket_at(
+        vm_state_dir,
+        mvm_agentd::builder_agent::BUILDERD_CONTROL_PORT,
+    )
 }
 
 /// The **HVF**-shape control socket for a builder VM rooted at
-/// `vm_state_dir`: `<vm_state_dir>/vsock/vsock-<port>.sock`. The HVF
-/// supervisor nests per-port sockets under a `vsock/` subdir (see
-/// `mvm_core::config::vm_hvf_vsock_dir`).
+/// `vm_state_dir`: normally `<vm_state_dir>/vsock/vsock-<port>.sock`. The HVF
+/// supervisor nests per-port sockets under a `vsock/` subdir of the resolved
+/// socket directory (see `mvm_core::config::vm_hvf_vsock_dir_at`).
 pub fn builderd_hvf_control_socket_path(vm_state_dir: &Path) -> PathBuf {
-    vm_state_dir
-        .join("vsock")
-        .join(builderd_control_socket_filename())
+    mvm_core::config::vm_hvf_vsock_port_socket_at(
+        vm_state_dir,
+        mvm_agentd::builder_agent::BUILDERD_CONTROL_PORT,
+    )
 }
 
 /// Both candidate control-socket paths (libkrun shape, then HVF shape)
@@ -662,12 +668,6 @@ pub fn builderd_control_socket_candidates(vm_state_dir: &Path) -> [PathBuf; 2] {
         builderd_control_socket_path(vm_state_dir),
         builderd_hvf_control_socket_path(vm_state_dir),
     ]
-}
-
-/// `vsock-<BUILDERD_CONTROL_PORT>.sock` — the per-port socket filename
-/// both backends use; they differ only in which directory it lives in.
-fn builderd_control_socket_filename() -> String {
-    mvm_core::config::vsock_socket_filename(mvm_agentd::builder_agent::BUILDERD_CONTROL_PORT)
 }
 
 /// Outcome of a host-side readiness probe against a builder daemon's
@@ -1530,6 +1530,17 @@ mod tests {
                 builderd_hvf_control_socket_path(dir),
             ]
         );
+    }
+
+    #[test]
+    fn control_socket_path_shortens_deep_worktree_state_dirs() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("x".repeat(120));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let socket = builderd_control_socket_path(&dir);
+        assert_ne!(socket.parent(), Some(dir.as_path()));
+        assert!(socket.to_string_lossy().len() <= 103);
     }
 
     #[test]

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -339,7 +339,8 @@ pub(crate) struct BuilderVsockEgressEndpoint {
 
 impl BuilderVsockEgressEndpoint {
     fn spawn(state_dir: &Path) -> Result<Self, BuilderVmError> {
-        let transport_path = state_dir.join(mvm_core::config::vsock_socket_filename(
+        let socket_dir = builder_vsock_socket_dir(state_dir)?;
+        let transport_path = socket_dir.join(mvm_core::config::vsock_socket_filename(
             mvm_agentd::vsock::EGRESS_PORT,
         ));
         Self::spawn_with_transport(
@@ -439,6 +440,17 @@ impl BuilderVsockEgressEndpoint {
     fn reap(&self) {
         reap_builder_vsock_egress_endpoint(&self.state_dir);
     }
+}
+
+fn builder_vsock_socket_dir(state_dir: &Path) -> Result<PathBuf, BuilderVmError> {
+    let socket_dir = mvm_core::config::vm_socket_dir_at(state_dir);
+    std::fs::create_dir_all(&socket_dir).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "creating builder vsock socket dir {}: {e}",
+            socket_dir.display()
+        ))
+    })?;
+    Ok(socket_dir)
 }
 
 impl Drop for BuilderVsockEgressEndpoint {
@@ -940,6 +952,7 @@ impl LibkrunBuilderVm {
             ))
         })?;
         let console_log = vm_state_dir.join("console.log");
+        let socket_dir = builder_vsock_socket_dir(&vm_state_dir)?;
         // The in-guest nix build streams its `--print-build-logs` to this
         // console as it runs (stage0-init echoes each line live). In verbose
         // mode the host forwards that console to stderr, so the build log is
@@ -964,7 +977,7 @@ impl LibkrunBuilderVm {
         let mut krun = krun_context_for_image(&vm_name, &image)?
             .with_resources(self.vcpus, self.memory_mib)
             .with_console_output(path_to_str(&console_log, "console_log")?)
-            .with_vsock_socket_dir(path_to_str(&vm_state_dir, "vm_state_dir")?)
+            .with_vsock_socket_dir(path_to_str(&socket_dir, "vm_socket_dir")?)
             // Persistent /nix store disk — the first block device attached
             // to a RootDir guest, so it enumerates as /dev/vda. `stage0-init`
             // mounts and reuses it when it is ext4, formats it when the seed
@@ -1095,6 +1108,7 @@ impl LibkrunBuilderVm {
             ))
         })?;
         let console_log = vm_state_dir.join("console.log");
+        let socket_dir = builder_vsock_socket_dir(&vm_state_dir)?;
         let runtime_overlay = builder_runtime_overlay_or_bail(&image)?;
         let guest_agent_vsock =
             builder_runtime_overlay_guest_agent_enabled(&image, runtime_overlay.as_deref());
@@ -1120,7 +1134,7 @@ impl LibkrunBuilderVm {
         let mut krun = krun_context_for_image(&vm_name, &image)?
             .with_resources(self.vcpus, self.memory_mib)
             .with_console_output(path_to_str(&console_log, "console_log")?)
-            .with_vsock_socket_dir(path_to_str(&vm_state_dir, "vm_state_dir")?)
+            .with_vsock_socket_dir(path_to_str(&socket_dir, "vm_socket_dir")?)
             .add_disk(
                 "nix-store",
                 path_to_str(nix_store_lock.path(), "nix_store_img")?,
@@ -1463,10 +1477,11 @@ struct BuilderShellKrunContextParams<'a> {
 fn builder_shell_krun_context(
     params: &BuilderShellKrunContextParams<'_>,
 ) -> Result<KrunContext, BuilderVmError> {
+    let socket_dir = mvm_core::config::vm_socket_dir_at(params.vm_state_dir);
     let mut krun = krun_context_for_image(params.vm_name, params.image)?
         .with_resources(params.vcpus, params.memory_mib)
         .with_console_output(path_to_str(params.console_log, "console_log")?)
-        .with_vsock_socket_dir(path_to_str(params.vm_state_dir, "vm_state_dir")?)
+        .with_vsock_socket_dir(path_to_str(&socket_dir, "vm_socket_dir")?)
         .add_disk(
             "nix-store",
             path_to_str(params.nix_store_img, "nix_store_img")?,
@@ -1604,6 +1619,7 @@ impl BuilderVm for LibkrunBuilderVm {
         // hvc0 output silently and "supervisor running, then exits 1"
         // is the only observable signal.
         let console_log = vm_state_dir.join("console.log");
+        let socket_dir = builder_vsock_socket_dir(&vm_state_dir)?;
         let runtime_overlay = builder_runtime_overlay_or_bail(&image)?;
         let guest_agent_vsock =
             builder_runtime_overlay_guest_agent_enabled(&image, runtime_overlay.as_deref());
@@ -1634,7 +1650,7 @@ impl BuilderVm for LibkrunBuilderVm {
         let mut krun = krun_context_for_image(&vm_name, &image)?
             .with_resources(self.vcpus, self.memory_mib)
             .with_console_output(path_to_str(&console_log, "console_log")?)
-            .with_vsock_socket_dir(path_to_str(&vm_state_dir, "vm_state_dir")?)
+            .with_vsock_socket_dir(path_to_str(&socket_dir, "vm_socket_dir")?)
             .add_disk(
                 "nix-store",
                 path_to_str(nix_store_lock.path(), "nix_store_img")?,
@@ -1877,6 +1893,7 @@ impl VmBackendForBuilder for LibkrunBuilderBackend {
         })?;
 
         let console_log = self.console_log_path(&config.vm_state_dir);
+        let socket_dir = builder_vsock_socket_dir(&config.vm_state_dir)?;
 
         // KrunContext construction — same shape as run_build's
         // step 7, but parameterised on the trait's hypervisor-
@@ -1886,7 +1903,7 @@ impl VmBackendForBuilder for LibkrunBuilderBackend {
         let mut krun = krun_context_for_image(&config.name, &self.image)?
             .with_resources(config.vcpus, config.memory_mib)
             .with_console_output(path_to_str(&console_log, "console_log")?)
-            .with_vsock_socket_dir(path_to_str(&config.vm_state_dir, "vm_state_dir")?);
+            .with_vsock_socket_dir(path_to_str(&socket_dir, "vm_socket_dir")?);
         for disk in extra_disks {
             krun = krun.add_disk(
                 disk.id.clone(),
@@ -3507,7 +3524,7 @@ fn wait_for_vsock_socket(
     timeout: Duration,
     label: &str,
 ) -> Result<(), BuilderVmError> {
-    let socket_path = vm_state_dir.join(mvm_core::config::vsock_socket_filename(port));
+    let socket_path = mvm_core::config::vm_vsock_port_socket_at(vm_state_dir, port);
     wait_for_path(child, &socket_path, timeout, label)
 }
 
@@ -3692,9 +3709,10 @@ pub fn spawn_vsock_response_listener(
     use crate::builder_protocol::{HostVmResponseRead, read_host_vm_response};
 
     let (tx, rx) = mpsc::channel();
-    let socket_path = vm_state_dir.join(mvm_core::config::vsock_socket_filename(
+    let socket_path = mvm_core::config::vm_vsock_port_socket_at(
+        vm_state_dir,
         mvm_agentd::builder_agent::BUILDER_DISPATCH_PORT,
-    ));
+    );
 
     std::thread::Builder::new()
         .name("vsock-builder-response".to_string())
@@ -3741,7 +3759,7 @@ fn spawn_vsock_socket_observer(
     use std::sync::mpsc;
 
     let (tx, rx) = mpsc::channel();
-    let socket_path = vm_state_dir.join(mvm_core::config::vsock_socket_filename(port));
+    let socket_path = mvm_core::config::vm_vsock_port_socket_at(vm_state_dir, port);
     std::thread::Builder::new()
         .name(format!("vsock-socket-observer-{port}"))
         .spawn(move || {
@@ -4392,6 +4410,7 @@ impl LibkrunPersistentHostVm {
             ))
         })?;
         let console_log = vm_state_dir.join("console.log");
+        let socket_dir = builder_vsock_socket_dir(&vm_state_dir)?;
         let runtime_overlay = builder_runtime_overlay_or_bail(&image)?;
         let guest_agent_vsock =
             builder_runtime_overlay_guest_agent_enabled(&image, runtime_overlay.as_deref());
@@ -4410,7 +4429,7 @@ impl LibkrunPersistentHostVm {
         let mut krun = krun_context_for_image(&vm_name, &image)?
             .with_resources(self.vcpus, self.memory_mib)
             .with_console_output(path_to_str(&console_log, "console_log")?)
-            .with_vsock_socket_dir(path_to_str(&vm_state_dir, "vm_state_dir")?)
+            .with_vsock_socket_dir(path_to_str(&socket_dir, "vm_socket_dir")?)
             .add_disk(
                 "nix-store",
                 path_to_str(nix_store_lock.path(), "nix_store_img")?,
@@ -4579,10 +4598,10 @@ impl PersistentVmHandle {
     /// inside the guest. `PersistentBuilderSupervisor::new` takes
     /// this directly.
     pub fn dispatch_socket_path(&self) -> PathBuf {
-        self.vm_state_dir
-            .join(mvm_core::config::vsock_socket_filename(
-                mvm_agentd::builder_agent::BUILDER_DISPATCH_PORT,
-            ))
+        mvm_core::config::vm_vsock_port_socket_at(
+            &self.vm_state_dir,
+            mvm_agentd::builder_agent::BUILDER_DISPATCH_PORT,
+        )
     }
 
     /// Per-VM job directory bound at `/job` inside the guest.
@@ -4811,6 +4830,23 @@ mod tests {
             "Stage 0 builder boots must use the explicit vsock device, not TSI"
         );
         assert_eq!(ctx.host_listen_ports, vec![mvm_agentd::vsock::EGRESS_PORT]);
+    }
+
+    #[test]
+    fn builder_vsock_socket_dir_handles_deep_worktree_paths() {
+        let root = TempDir::new().unwrap();
+        let state_dir = root.path().join("x".repeat(120));
+        std::fs::create_dir_all(&state_dir).unwrap();
+
+        let socket_dir = builder_vsock_socket_dir(&state_dir).unwrap();
+        assert_ne!(socket_dir, state_dir);
+        assert_eq!(socket_dir, mvm_core::config::vm_socket_dir_at(&state_dir));
+        assert!(socket_dir.exists());
+        let socket_path =
+            mvm_core::config::vm_vsock_port_socket_at(&state_dir, mvm_agentd::vsock::EGRESS_PORT);
+        assert!(socket_path.to_string_lossy().len() <= 103);
+
+        std::fs::remove_dir_all(socket_dir).unwrap();
     }
 
     fn ok_mounts(scratch: &TempDir) -> BuilderMounts {

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -626,9 +626,10 @@ fn read_next_response(
 /// `libkrun_sys::KrunContext` uses when
 /// `add_vsock_port(BUILDER_DISPATCH_PORT)` is configured.
 pub fn dispatch_socket_path(vm_state_dir: &Path) -> PathBuf {
-    vm_state_dir.join(mvm_core::config::vsock_socket_filename(
+    mvm_core::config::vm_vsock_port_socket_at(
+        vm_state_dir,
         mvm_agentd::builder_agent::BUILDER_DISPATCH_PORT,
-    ))
+    )
 }
 
 // ============================================================

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -106,7 +106,10 @@
       instead of failing with an opaque source-fetch error. `MVM_KERNEL_SOURCE`
       provides a persistent compile/download/auto choice, with explicit CLI
       flags taking precedence. Covered by manifest, policy, and end-to-end
-      builder-kernel validation.
+      builder-kernel validation. Builder libkrun now routes every Stage 0 vsock
+      path through the short-socket resolver, including builderd readiness probes,
+      so the same command also works from deep worktree paths on macOS; the
+      isolated-worktree kernel build was verified end to end on aarch64.
 - [x] One-command local microVM UX. A cold source checkout now builds the
       dedicated dm-verity workload kernel automatically during the first
       `machine run --image`, reports the first-run cost, and caches the result;


### PR DESCRIPTION
## Summary

Source checkouts can place `MVM_HOME` under a deep worktree path. On macOS, libkrun's Unix-domain socket path limit then caused Stage 0 builder startup to fail before the kernel build could run.

This change routes builder launch, response, persistent dispatch, egress, and builderd readiness paths through the existing short socket-directory resolver. Deep worktree paths now use the hashed short socket namespace automatically.

## Validation

- `just kernel-workload` completed end to end from the deep dedicated worktree on aarch64.
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo test -p mvm-build --features builder-vm --lib` — 765 passed
