### PR TITLE
ci: parallelize pull request validation lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   # Keep pull-request validation cheap and predictable. On a pull request this
-  # workflow runs two jobs: lint and test. The merge queue also runs Nix eval.
+  # workflow runs parallel lint/test lanes plus the stable aggregate checks
+  # required by branch protection. The merge queue also runs Nix eval.
   # Expensive platform, live-VM, OCI ratification, security, Windows, and
   # release artifact jobs live in release/manual workflows.
   pull_request:
@@ -27,9 +28,10 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  lint:
-    name: Lint (fmt + clippy + policy)
+  lint-core:
+    name: Lint core (fmt + clippy)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
 
@@ -40,18 +42,6 @@ jobs:
 
       - name: Install system build deps
         run: sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld
-
-      # SDK stub codegen (check-stubs) shells out to `uvx datamodel-codegen`
-      # (Python) + `npx json-schema-to-typescript` (TS). The pinned generator
-      # versions live in xtask, so the host node/python versions don't change
-      # the output (verified byte-identical macOS node22/py3.12 vs Linux
-      # node18/py3.11) — these just provide the runners.
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v8.2.0
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
 
       - uses: ./.github/actions/install-zigbuild
 
@@ -80,6 +70,31 @@ jobs:
       # suite unnoticed and only surface in a release run. Compile it here.
       - name: Clippy (BDD conformance target)
         run: cargo clippy -p mvm-conformance --tests --features bdd -- -D warnings
+
+  lint-policy:
+    name: Lint policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      # Policy checks invoke xtask, and the stub/parity checks invoke the
+      # pinned Python and TypeScript generators. They are independent of the
+      # compiler lint lane, so start them on their own runner.
+      - name: Install system build deps
+        run: sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld shellcheck
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.2.0
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - uses: ./.github/actions/install-zigbuild
 
       - name: ADR coverage (informational)
         continue-on-error: true
@@ -139,10 +154,6 @@ jobs:
       - name: Conformance claim catalog
         run: cargo run -p xtask -- check-claim-catalog
 
-      # Surface pin only — milliseconds, no cargo-mutants needed. Fails when a
-      # claim's witnesses stop resolving to a mutable file, i.e. when a claim
-      # drops out of the nightly mutation lane's scope. The mutation run itself
-      # lives in security.yml because it costs hours.
       - name: Claim mutation surface is pinned
         run: cargo run -p xtask -- check-mutation-witnesses
 
@@ -188,23 +199,9 @@ jobs:
       - name: no new duplicate-major dependencies
         run: cargo run -p xtask -- check-duplicate-majors
 
-      # security.yml runs on tags + cron, so a step pointing at a renamed
-      # crate is invisible on a PR and dead until someone reads a nightly.
-      # This resolves those paths here, where the rename happens.
       - name: workflow paths and fuzz targets still exist
         run: cargo run -p xtask -- check-workflow-paths
 
-      # The cargo-fuzz crates are workspace-excluded (libfuzzer-sys needs
-      # cargo-fuzz's linker flags), so clippy and every other lane skip them.
-      # Nothing compiles these files until the nightly runs them, and that
-      # lane aborts on its first failure — one broken target hides every
-      # target after it, which is how a syntactically invalid harness
-      # survived eleven days.
-      #
-      # Only PRs that touch a fuzz crate pay for this: the per-crate dep
-      # trees do not share artifacts with the workspace build above, and
-      # this lane is deliberately capped. A crate rename — the change that
-      # actually broke them — touches these paths, so it is still covered.
       - name: Detect fuzz-crate changes
         id: fuzz_changed
         env:
@@ -212,7 +209,6 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${BASE_SHA:-}" ]; then
-            # merge_group / dispatch: no PR base to diff against, so check.
             echo "changed=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
           git fetch --no-tags --depth=1 origin "$BASE_SHA" >/dev/null 2>&1 || true
@@ -265,17 +261,24 @@ jobs:
       - name: Python and TypeScript IR fixtures match the Rust semantic address
         run: cargo run -p xtask -- check-ir-parity
 
-      # Feature-gated test runs that the default `Test` workspace pass skips.
-      # They live here, not in `Test`, so they run in parallel off the merge
-      # queue's critical path (this job has headroom; `Test` is the long pole).
-      # Clippy above already compiled the workspace `--all-targets`, so the
-      # crate graph is warm for these feature-specific recompiles.
+  lint-features:
+    name: Lint feature coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+
+      - name: Install system build deps
+        run: sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld
+
+      - uses: ./.github/actions/install-zigbuild
+
       - name: Clippy (mvm-client tracing-bridge)
-        # `--all-targets` selects targets, not features: the workspace clippy
-        # above never enables `tracing-bridge`, and nothing else in the tree
-        # does either, so `stream_tracing.rs` and its tests compile in no lane.
-        # A rename in `mvm-core::stream_client` would break it with the merge
-        # queue green.
         run: cargo clippy -p mvm-client --all-targets --features tracing-bridge -- -D warnings
 
       - name: Install cargo-nextest
@@ -284,15 +287,9 @@ jobs:
           tool: nextest
 
       - name: hostd-transport feature tests (mvm-core)
-        # `hostd-transport` is off by default (plan 126 B5), so the default
-        # workspace run skips the protocol transport tests. Cover them here.
         run: cargo nextest run -p mvm-core --features hostd-transport
 
       - name: client facade tests (mvm-core)
-        # The `client` module (MvmClient trait + DTOs + MockBackend + remote
-        # GatewayBackend) is off by default so the runtime-free closure pulls no
-        # async-trait. `client-remote` implies `client`, so this one lane covers
-        # every moved unit test.
         run: cargo nextest run -p mvm-core --features client-remote
 
       - name: Assert auto-detect still picks libkrun off Linux/HVF
@@ -301,15 +298,9 @@ jobs:
             builder_backend_select::tests::auto_detect_default_for_everything_else_picks_libkrun
 
       - name: In-process pure-mkfs materialize tests
-        # `pure-mkfs` is off by default (keeps mvm-ext4 out of the mvmctl default
-        # closure), so the default workspace run skips these. Cover them here.
         run: cargo test -p mvm-build --features pure-mkfs --lib rootfs::tests::pure
 
       - name: test-support feature tests (mock backend)
-        # Only these packages own code gated by `test-support`. Re-running the
-        # whole workspace here repeated more than eight thousand tests from the
-        # Test job to reach a handful of mock-backend cases. Keep the feature's
-        # unit, integration, and required-example surfaces explicit instead.
         run: |
           cargo nextest run -p mvm-runtime --features test-support --lib
           cargo nextest run -p mvm-client --features test-support --lib
@@ -317,22 +308,53 @@ jobs:
           cargo nextest run -p mvmctl --features test-support --test audit_emissions_live
           cargo check -p mvm-cli --features test-support --example verification_loop
 
+  lint:
+    name: Lint (fmt + clippy + policy)
+    if: ${{ always() }}
+    needs: [lint-core, lint-policy, lint-features]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every lint lane to pass
+        env:
+          CORE_RESULT: ${{ needs.lint-core.result }}
+          POLICY_RESULT: ${{ needs.lint-policy.result }}
+          FEATURES_RESULT: ${{ needs.lint-features.result }}
+        run: |
+          set -euo pipefail
+          for result in "$CORE_RESULT" "$POLICY_RESULT" "$FEATURES_RESULT"; do
+            if [ "$result" != success ]; then
+              echo "A lint lane did not pass: $result"
+              exit 1
+            fi
+          done
+
   test:
     name: Test
+    if: ${{ always() }}
+    needs: [test-workspace, test-linux]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every test lane to pass
+        env:
+          WORKSPACE_RESULT: ${{ needs.test-workspace.result }}
+          LINUX_RESULT: ${{ needs.test-linux.result }}
+        run: |
+          set -euo pipefail
+          for result in "$WORKSPACE_RESULT" "$LINUX_RESULT"; do
+            if [ "$result" != success ]; then
+              echo "A test lane did not pass: $result"
+              exit 1
+            fi
+          done
+
+  test-workspace:
+    name: Test workspace
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
-
-      # `just bdd` exercises the generated Python/TypeScript SDK contracts;
-      # keep its generators available in this job as well as the standalone
-      # reusable BDD workflow.
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v8.2.0
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
 
       - uses: ./.github/actions/free-disk
 
@@ -346,20 +368,10 @@ jobs:
 
       - uses: ./.github/actions/install-zigbuild
 
-      - name: Install pinned no_std toolchain and targets
-        run: |
-          rustup toolchain install 1.96.0 --profile minimal \
-            --target wasm32-unknown-unknown,wasm32-wasip1,riscv32imac-unknown-none-elf
-
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
-
-      - name: Install just
-        uses: taiki-e/install-action@v2
-        with:
-          tool: just
 
       - name: Build
         run: cargo build --all-targets
@@ -394,104 +406,45 @@ jobs:
         # nextest does not run doctests; gate them separately.
         run: cargo test --workspace --doc
 
-      - name: Install wasmtime (wasm32-wasip1 test runner)
-        env:
-          # Pinned to match the wasmtime crate version in Cargo.lock.
-          WASMTIME_VERSION: "46.0.1"
+  test-linux:
+    name: Test Linux and conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - uses: ./.github/actions/free-disk
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install system build deps
         run: |
-          set -euo pipefail
-          tmpdir="$(mktemp -d)"
-          trap 'rm -rf "$tmpdir"' EXIT
-          base="wasmtime-v${WASMTIME_VERSION}-x86_64-linux"
-          curl -fsSL "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/${base}.tar.xz" \
-            | tar -xJf - -C "$tmpdir"
-          mkdir -p "$HOME/.wasmtime/bin"
-          mv "$tmpdir/${base}/wasmtime" "$HOME/.wasmtime/bin/wasmtime"
-          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update
+          sudo apt-get install -y attr cryptsetup-bin libcap-ng-dev lld
 
-      - name: mvm-contract builds no_std + alloc on wasm and bare metal
+      - uses: ./.github/actions/install-zigbuild
+
+      - name: Install pinned no_std toolchain and targets
         run: |
-          cargo +1.96.0 build -p mvm-contract --target wasm32-unknown-unknown
-          cargo +1.96.0 build -p mvm-contract --lib \
-            --target riscv32imac-unknown-none-elf
+          rustup toolchain install 1.96.0 --profile minimal \
+            --target wasm32-unknown-unknown,wasm32-wasip1,riscv32imac-unknown-none-elf
 
-      - name: mvm-contract tests run under wasm
-        run: cargo +1.96.0 test -p mvm-contract --target wasm32-wasip1
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
 
-      - name: Write a sample ext4 image
-        run: cargo run -p mvm-fs --example write_sample -- /tmp/sample.ext4 | tee /tmp/sample.out
-
-      - name: Loop-mount read-only and verify the ext4 tree
-        run: |
-          set -euo pipefail
-          mnt=$(mktemp -d)
-          sudo mount -o ro,loop /tmp/sample.ext4 "$mnt"
-          trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
-          [ "$(cat "$mnt/etc/hosts")" = "127.0.0.1 localhost" ]
-          diff <(printf 'hi from pure-rust ext4\n') "$mnt/hello"
-          [ "$(readlink "$mnt/etc/localhost")" = "hosts" ]
-          [ -d "$mnt/bin" ] && [ -d "$mnt/etc" ]
-          [ "$(stat -c '%a' "$mnt/hello")" = "755" ]
-          [ "$(stat -c '%a' "$mnt/etc/hosts")" = "644" ]
-          [ "$(stat -c '%s' "$mnt/big")" = "716800" ]
-          cap=$(sudo getfattr --absolute-names -n security.capability -e hex "$mnt/bin/ping" \
-            | grep '^security.capability=' | cut -d= -f2)
-          echo "security.capability=$cap"
-          [ "$cap" = "0x0000000200300000000000000000000000000000" ]
-
-      - name: Match dm-verity output against veritysetup
-        run: |
-          set -euo pipefail
-          ours=$(grep '^ROOTHASH ' /tmp/sample.out | awk '{print $2}')
-          theirs=$(veritysetup format --no-superblock \
-              --data-block-size=4096 --hash-block-size=4096 \
-              --salt=0000000000000000000000000000000000000000000000000000000000000000 \
-              /tmp/sample.ext4 /tmp/vs.verity \
-            | awk '/^Root hash:/ {print $3}')
-          echo "ours=$ours theirs=$theirs"
-          [ -n "$ours" ] && [ "$ours" = "$theirs" ]
-          if ! cmp -s /tmp/sample.ext4.verity /tmp/vs.verity; then
-            echo "::error::hash tree differs from veritysetup"
-            ls -l /tmp/sample.ext4.verity /tmp/vs.verity
-            cmp -l /tmp/sample.ext4.verity /tmp/vs.verity | head -20 || true
-            exit 1
-          fi
-
-      - name: Loop-mount a multi-block-group ext4 image
-        run: |
-          set -euo pipefail
-          cargo run -p mvm-fs --example write_multigroup -- /tmp/multigroup.ext4
-          [ "$(stat -c '%s' /tmp/multigroup.ext4)" -gt 134217728 ]
-          mnt=$(mktemp -d)
-          sudo mount -o ro,loop /tmp/multigroup.ext4 "$mnt"
-          trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
-          [ "$(cat "$mnt/etc/marker")" = "multi-group marker" ]
-          [ "$(stat -c '%s' "$mnt/big")" = "136314880" ]
-          off=134000000
-          got=$(dd if="$mnt/big" bs=1 skip=$off count=1 2>/dev/null | od -An -tu1 | tr -d ' ')
-          [ "$got" = "$((off % 251))" ]
-
-      - name: Loop-mount a depth-1 extent-tree ext4 image
-        run: |
-          set -euo pipefail
-          cargo run -p mvm-fs --example write_extent_tree -- /tmp/extent_tree.ext4
-          [ "$(stat -c '%s' /tmp/extent_tree.ext4)" -gt 536870912 ]
-          mnt=$(mktemp -d)
-          sudo mount -o ro,loop /tmp/extent_tree.ext4 "$mnt"
-          trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
-          [ "$(cat "$mnt/etc/marker")" = "extent-tree marker" ]
-          [ "$(stat -c '%s' "$mnt/huge")" = "545259520" ]
-          off=537000000
-          got=$(dd if="$mnt/huge" bs=1 skip=$off count=1 2>/dev/null | od -An -tu1 | tr -d ' ')
-          [ "$got" = "$((off % 251))" ]
-
-      # Hermetic BDD: live microVM and bundle scenarios remain opt-in. The
-      # meta-gate validates the claim register against scenarios and witnesses.
-      - name: Conformance meta-gate
-        run: cargo test -p mvm-conformance --test meta
-
-      - name: Hermetic BDD scenarios
-        run: just bdd
+      - name: Run Linux, no_std, filesystem, and conformance coverage
+        run: bash scripts/ci-linux-coverage.sh
 
   nix-flake-check:
     name: Nix flake check (Linux eval)

--- a/scripts/ci-linux-coverage.sh
+++ b/scripts/ci-linux-coverage.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep Linux-only compile, filesystem, and conformance coverage in one reusable
+# lane so it can run beside the workspace test lane without duplicating the
+# coverage in a second workflow definition.
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+wasmtime_version="46.0.1"
+wasmtime_base="wasmtime-v${wasmtime_version}-x86_64-linux"
+curl -fsSL "https://github.com/bytecodealliance/wasmtime/releases/download/v${wasmtime_version}/${wasmtime_base}.tar.xz" \
+  | tar -xJf - -C "$tmpdir"
+mkdir -p "$HOME/.wasmtime/bin"
+mv "$tmpdir/${wasmtime_base}/wasmtime" "$HOME/.wasmtime/bin/wasmtime"
+rm -rf "$tmpdir"
+export PATH="$HOME/.wasmtime/bin:$PATH"
+
+cargo +1.96.0 build -p mvm-contract --target wasm32-unknown-unknown
+cargo +1.96.0 build -p mvm-contract --lib \
+  --target riscv32imac-unknown-none-elf
+cargo +1.96.0 test -p mvm-contract --target wasm32-wasip1
+
+cargo run -p mvm-fs --example write_sample -- /tmp/sample.ext4 \
+  | tee /tmp/sample.out
+
+mnt=$(mktemp -d)
+sudo mount -o ro,loop /tmp/sample.ext4 "$mnt"
+trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
+[ "$(cat "$mnt/etc/hosts")" = "127.0.0.1 localhost" ]
+diff <(printf 'hi from pure-rust ext4\n') "$mnt/hello"
+[ "$(readlink "$mnt/etc/localhost")" = "hosts" ]
+[ -d "$mnt/bin" ] && [ -d "$mnt/etc" ]
+[ "$(stat -c '%a' "$mnt/hello")" = "755" ]
+[ "$(stat -c '%a' "$mnt/etc/hosts")" = "644" ]
+[ "$(stat -c '%s' "$mnt/big")" = "716800" ]
+cap=$(sudo getfattr --absolute-names -n security.capability -e hex "$mnt/bin/ping" \
+  | grep '^security.capability=' | cut -d= -f2)
+echo "security.capability=$cap"
+[ "$cap" = "0x0000000200300000000000000000000000000000" ]
+sudo umount "$mnt"
+rmdir "$mnt"
+
+cargo run -p mvm-fs --example write_multigroup -- /tmp/multigroup.ext4
+[ "$(stat -c '%s' /tmp/multigroup.ext4)" -gt 134217728 ]
+mnt=$(mktemp -d)
+sudo mount -o ro,loop /tmp/multigroup.ext4 "$mnt"
+trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
+[ "$(cat "$mnt/etc/marker")" = "multi-group marker" ]
+[ "$(stat -c '%s' "$mnt/big")" = "136314880" ]
+off=134000000
+got=$(dd if="$mnt/big" bs=1 skip="$off" count=1 2>/dev/null | od -An -tu1 | tr -d ' ')
+[ "$got" = "$((off % 251))" ]
+sudo umount "$mnt"
+rmdir "$mnt"
+
+cargo run -p mvm-fs --example write_extent_tree -- /tmp/extent_tree.ext4
+[ "$(stat -c '%s' /tmp/extent_tree.ext4)" -gt 536870912 ]
+mnt=$(mktemp -d)
+sudo mount -o ro,loop /tmp/extent_tree.ext4 "$mnt"
+trap 'sudo umount "$mnt" || true; rmdir "$mnt" || true' EXIT
+[ "$(cat "$mnt/etc/marker")" = "extent-tree marker" ]
+[ "$(stat -c '%s' "$mnt/huge")" = "545259520" ]
+off=537000000
+got=$(dd if="$mnt/huge" bs=1 skip="$off" count=1 2>/dev/null | od -An -tu1 | tr -d ' ')
+[ "$got" = "$((off % 251))" ]
+sudo umount "$mnt"
+rmdir "$mnt"
+
+ours=$(grep '^ROOTHASH ' /tmp/sample.out | awk '{print $2}')
+theirs=$(veritysetup format --no-superblock \
+    --data-block-size=4096 --hash-block-size=4096 \
+    --salt=0000000000000000000000000000000000000000000000000000000000000000 \
+    /tmp/sample.ext4 /tmp/vs.verity \
+  | awk '/^Root hash:/ {print $3}')
+echo "ours=$ours theirs=$theirs"
+[ -n "$ours" ] && [ "$ours" = "$theirs" ]
+if ! cmp -s /tmp/sample.ext4.verity /tmp/vs.verity; then
+  echo "::error::hash tree differs from veritysetup"
+  ls -l /tmp/sample.ext4.verity /tmp/vs.verity
+  cmp -l /tmp/sample.ext4.verity /tmp/vs.verity | head -20 || true
+  exit 1
+fi
+
+cargo test -p mvm-conformance --test meta
+just bdd

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -276,6 +276,13 @@ for detailed scope and acceptance criteria.
   - [x] Keep the removed MCP server and smoke lane out of CI
   - [x] Complete workspace and Linux clippy verification; the first live run
         passed and measured a 19–21 minute runner wait
+
+- [x] Plan 297 — Parallel pull-request CI lanes
+      (`specs/plans/297-ci-parallel-lanes.md`)
+  - [x] Split independent lint and Linux-only test coverage into concurrent
+        jobs without changing required check names
+  - [x] Keep targeted feature coverage and Linux conformance coverage intact
+  - [x] Complete workflow and repository verification
 - [~] Plan 276 — Content-addressing conformance and defense
       (`specs/plans/276-content-addressing-conformance-and-defense.md`)
   - [x] WS0 — plan + recon note landed (#1964); axis/policy ratification open

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -552,6 +552,13 @@ updates only its own entry below.
       execution did not beat the 36-minute cold-run baseline because the
       remaining `mvm-cli` and live audit tests dominate the lane.
 
+- [x] Plan 297 parallel pull-request CI lanes: run compiler lint, policy,
+      feature-gated coverage, workspace tests, and Linux/no-std/filesystem/
+      conformance coverage concurrently while keeping the existing `Lint` and
+      `Test` required check names as fail-closed aggregates. The moved Linux
+      coverage has one reusable script and the PR workflow still has no
+      branch-scoped Cargo target cache.
+
 - [x] #1840 faithful flake-image revert: boot the recorded slot revision,
       reconcile signed artifact hashes, and preserve the admitted restore path.
       Implementation, focused tests, workspace tests, check, and clippy pass;

--- a/specs/adrs/012-ci-execution-policy.md
+++ b/specs/adrs/012-ci-execution-policy.md
@@ -21,7 +21,7 @@ day-to-day development for no proportional benefit.
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `ci.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | two runner jobs on PR (`lint` and `test`); three in merge queue / manual dispatch (the same jobs plus Nix) |
+| `ci.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | parallel compiler/policy/feature and workspace/Linux lanes with stable `lint` and `test` aggregate checks; Nix is added in the merge queue / manual dispatch |
 | `architecture.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | structural/architectural invariants; skips the actual work on docs-only PRs, always runs in merge queue |
 | `ci-full.yml` | `workflow_dispatch` only | the full platform + live-VM + OCI-ratification matrix; operator-triggered, never automatic |
 | `security.yml` | `push: tags: v*` + nightly cron + `workflow_dispatch` | dependency audit / advisory scan; release-time backstop plus nightly catch for new advisories |
@@ -33,24 +33,28 @@ day-to-day development for no proportional benefit.
 `lint` (fmt, clippy, and the full battery of `xtask` architectural
 checks — see ADR-010) and `test` (the workspace nextest run, doctests,
 hermetic BDD, no-std target checks, man-page feature tests, and real-kernel
-ext4 checks) run on every pull request. `nix-flake-check` runs only in the merge
-queue and on manual dispatch, so ordinary PR updates pay for the lighter
-compile/test signal and the heavier eval work runs once before merge. The SDK publication
-dry-run is part of the manual full matrix rather than the development lane.
+ext4 checks) remain the required pull-request signals. Their independent
+compiler/policy/feature and workspace/Linux lanes run concurrently; the
+aggregate jobs retain the exact check names branch protection expects.
+`nix-flake-check` runs only in the merge queue and on manual dispatch, so
+ordinary PR updates pay for the lighter compile/test signal and the heavier
+eval work runs once before merge. The SDK publication dry-run is part of the
+manual full matrix rather than the development lane.
 Nothing platform-specific
 (macOS, live KVM, Windows) or slow (OCI ratification, dependency audit,
 the full builder-VM image build) runs on every pull request — those live
 in `ci-full.yml`, run only by explicit `workflow_dispatch`.
 
-Checks that need the same Linux and Rust environment are steps in the Lint,
-Test, or Nix jobs, not standalone build jobs. This shares checkout, toolchain, and
-dependency installation while retaining the same behavioral coverage. The PR
+The compiler, policy, feature, workspace, and Linux-only groups each have a
+dedicated runner so independent work can progress concurrently. The stable
+`lint` and `test` jobs only inspect their lane results and fail closed when any
+lane fails. The PR
 workflow does not upload `target/`: GitHub scopes caches from pull-request and
 merge-queue refs so sibling runs cannot restore them, making the former 4+ GB
 archives pure upload/storage cost except on a rerun of the same generated ref.
-Within a lint runner, `mvm-cli`'s nested Cargo builds use one target per outer
-profile rather than one per feature-specific build-script `OUT_DIR`; clippy,
-feature tests, and examples therefore reuse the same embedded-binary graph.
+The feature lanes retain the existing targeted package coverage, and the
+Linux-only filesystem/no-std/BDD commands live in one script rather than being
+duplicated between workflows.
 
 ### The merge queue's required checks
 
@@ -90,11 +94,12 @@ evaluation on the hosted Linux runner.
 ## Consequences
 
 A pull-request update gets fast, complete feedback from the checks that
-matter for almost every change — two Linux-only jobs (`lint` and `test`)
-plus the architecture-invariant lane, with the heavier `nix-flake-check` work
-deferred to the merge queue. The merge queue runs the full set of four required
-check names against the final merge group using four allocated runners: lint,
-Test, Nix, and the architecture invariant.
+matter for almost every change — parallel Linux-only lanes behind the stable
+`lint` and `test` aggregates plus the architecture-invariant lane, with the
+heavier `nix-flake-check` work deferred to the merge queue. The merge queue
+runs the full set of four required check names against the final merge group;
+the aggregate names remain `Lint (fmt + clippy + policy)`, `Test`, `Nix flake
+check (Linux eval)`, and `Invariant`.
 Development branches without a pull request consume no hosted runners
 unless an operator dispatches CI manually. Landing that already-checked
 commit on `main` does not run them a third time. An operator opts into the expensive platform, live-VM,

--- a/specs/plans/297-ci-parallel-lanes.md
+++ b/specs/plans/297-ci-parallel-lanes.md
@@ -1,0 +1,33 @@
+# Plan 297 — Parallel pull-request CI lanes
+
+**Status:** Complete
+
+## Goal
+
+Reduce pull-request and merge-queue critical-path time by running independent
+lint and Linux-only test coverage concurrently, while preserving the existing
+required check names and every required coverage surface.
+
+## Work
+
+- [x] Split compiler lint, policy checks, and feature-gated coverage into
+      independent Linux jobs.
+- [x] Split the workspace test lane from no-std, filesystem, and conformance
+      coverage.
+- [x] Preserve `Lint (fmt + clippy + policy)` and `Test` as conclusive
+      aggregate checks for branch protection and merge-queue admission.
+- [x] Keep the PR workflow free of branch-scoped Cargo target caches and avoid
+      repeating the workspace-wide `test-support` suite.
+- [x] Put Linux-only coverage in one reusable script so the moved checks have
+      one source of truth.
+- [x] Validate workflow syntax, structural guards, focused tests, and the
+      workspace compile/test gates.
+
+## Guardrails
+
+- No required check is renamed, skipped, or replaced by an unconditional green
+  compatibility job.
+- The Nix merge-queue check remains required and continues to run only on
+  `merge_group` and manual dispatch.
+- The parallel lanes do not share mutable Cargo target directories or upload
+  large branch-scoped build caches.

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -297,11 +297,13 @@ mod tests {
     fn pull_request_ci_does_not_repeat_the_workspace_or_upload_target_caches() {
         let workflow = ci_workflow();
         let lint = job_block(&workflow, "lint");
+        assert!(lint.contains("name: Lint (fmt + clippy + policy)"));
+        assert!(lint.contains("needs: [lint-core, lint-policy, lint-features]"));
+
         for unexpected in [
             "cargo nextest run --workspace --features test-support",
             "cargo nextest run -p xtask --features man",
             "uses: actions/cache@v5",
-            "uses: ./.github/actions/free-disk",
         ] {
             assert!(
                 !lint.contains(unexpected),
@@ -309,6 +311,11 @@ mod tests {
             );
         }
 
+        let lint_core = job_block(&workflow, "lint-core");
+        assert!(lint_core.contains("cargo clippy --all-targets -- -D warnings"));
+        let lint_policy = job_block(&workflow, "lint-policy");
+        assert!(lint_policy.contains("cargo run -p xtask -- check-conformance"));
+        let lint_features = job_block(&workflow, "lint-features");
         for expected in [
             "cargo nextest run -p mvm-runtime --features test-support --lib",
             "cargo nextest run -p mvm-client --features test-support --lib",
@@ -317,14 +324,37 @@ mod tests {
             "cargo check -p mvm-cli --features test-support --example verification_loop",
         ] {
             assert!(
-                lint.contains(expected),
-                "CI lint job must contain {expected:?}"
+                lint_features.contains(expected),
+                "CI feature lane must contain {expected:?}"
             );
         }
 
         let test = job_block(&workflow, "test");
-        assert!(!test.contains("uses: actions/cache@v5"));
-        assert!(test.contains("cargo nextest run -p xtask --features man"));
+        assert!(test.contains("name: Test"));
+        assert!(test.contains("needs: [test-workspace, test-linux]"));
+        let test_workspace = job_block(&workflow, "test-workspace");
+        assert!(!test_workspace.contains("uses: actions/cache@v5"));
+        assert!(test_workspace.contains("cargo nextest run -p xtask --features man"));
+        let test_linux = job_block(&workflow, "test-linux");
+        assert!(test_linux.contains("bash scripts/ci-linux-coverage.sh"));
+        assert!(!test_workspace.contains("ci-linux-coverage.sh"));
+
+        let linux_coverage = std::fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join("scripts/ci-linux-coverage.sh"),
+        )
+        .expect("Linux coverage script must be readable");
+        for expected in [
+            "cargo +1.96.0 build -p mvm-contract --target wasm32-unknown-unknown",
+            "cargo test -p mvm-conformance --test meta",
+            "just bdd",
+        ] {
+            assert!(
+                linux_coverage.contains(expected),
+                "Linux coverage script must contain {expected:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Split pull-request linting into independent compiler, policy, and feature-coverage lanes.
- Split testing into workspace and Linux/no_std/filesystem/conformance lanes.
- Preserve the existing required `Lint (fmt + clippy + policy)` and `Test` check names as fail-closed aggregate jobs.
- Move Linux-only coverage into `scripts/ci-linux-coverage.sh` and keep PR validation free of branch-scoped Cargo target caches and duplicate workspace `test-support` runs.

## Why

Independent checks can now progress concurrently, reducing the serial critical path before a pull request can enter the merge queue while keeping all existing required coverage and branch-protection contexts intact.

## Validation

- `actionlint .github/workflows/ci.yml`
- `shellcheck scripts/ci-linux-coverage.sh`
- `bash -n scripts/ci-linux-coverage.sh`
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p xtask check_workflow_paths`
