### PR TITLE
Simplify VMM channel specs and wire L3 vsock

### DIFF
--- a/crates/mvm-conformance/tests/steps/verified_boot.rs
+++ b/crates/mvm-conformance/tests/steps/verified_boot.rs
@@ -107,7 +107,6 @@ fn map_elf_kernel(world: &mut CliWorld) {
         console: ConsoleCapture {
             log_path: state.path().join("console.log"),
         },
-        trusted_builder: false,
     };
     let (mapped_path, format) =
         mvm_runtime::driver::libkrun::map_kernel_for_test(&spec, state.path())

--- a/crates/mvm-net/src/channel.rs
+++ b/crates/mvm-net/src/channel.rs
@@ -39,6 +39,12 @@ pub enum GuestService {
     Broker,
     /// The egress substitution endpoint.
     Substitution,
+    /// One dev-only interactive console data stream.
+    ///
+    /// The guest allocates these ports from its console session range. The
+    /// numeric value remains transport detail; callers still select the
+    /// service by its semantic role.
+    ConsoleData { port: u32 },
 }
 
 impl GuestService {
@@ -55,6 +61,7 @@ impl GuestService {
             Self::NetworkControl => mvm_contract::l3::L3_CONTROL_PORT,
             Self::NetworkData { queue } => mvm_contract::l3::data_port(queue),
             Self::Broker => 5300,
+            Self::ConsoleData { port } => port,
         }
     }
 
@@ -67,6 +74,7 @@ impl GuestService {
             Self::WorkloadExit => "workload-exit",
             Self::Broker => "broker",
             Self::Substitution => "substitution",
+            Self::ConsoleData { .. } => "console-data",
         }
     }
 
@@ -80,6 +88,7 @@ impl fmt::Display for GuestService {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NetworkData { queue } => write!(f, "network-data[{queue}]"),
+            Self::ConsoleData { port } => write!(f, "console-data[{port}]"),
             other => write!(f, "{}", other.as_str()),
         }
     }

--- a/crates/mvm-runtime/examples/hvf-relay-egress.rs
+++ b/crates/mvm-runtime/examples/hvf-relay-egress.rs
@@ -59,10 +59,10 @@ fn main() {
     use std::process::{Child, Command, Stdio};
     use std::time::{Duration, Instant};
 
-    use mvm_agentd::vsock::EGRESS_PORT;
     use mvm_core::config::vm_state_dir;
     use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
     use mvm_core::vm_backend::VmStatus;
+    use mvm_net::channel::GuestService;
     use mvm_runtime::driver::{
         ConsoleCapture, HvfDriver, KernelImage, VmmDriver, VmmSpec, VsockDirection, VsockPort,
     };
@@ -171,14 +171,13 @@ fn main() {
             // The one channel off the box: the guest dials EGRESS_PORT, the host
             // relays it to the gating endpoint's UDS.
             vsock: vec![VsockPort {
-                guest_port: EGRESS_PORT,
+                service: GuestService::Substitution,
                 host_uds: uds.clone(),
                 direction: VsockDirection::GuestDials,
             }],
             console: ConsoleCapture {
                 log_path: state_dir.join("console.log"),
             },
-            trusted_builder: false,
         };
 
         let driver = HvfDriver::new();

--- a/crates/mvm-runtime/src/builder_runner/runner.rs
+++ b/crates/mvm-runtime/src/builder_runner/runner.rs
@@ -276,10 +276,9 @@ mod tests {
             .expect("build orchestrates against the mock driver");
 
         assert!(outcome.stopped);
-        // A single builder spec was booted: 4 disks, trusted, builder cmdline.
+        // A single builder spec was booted: 4 disks and the builder cmdline.
         let specs = runner.driver.booted_specs();
         assert_eq!(specs.len(), 1);
-        assert!(specs[0].trusted_builder);
         assert_eq!(specs[0].blocks.len(), 4);
         assert!(specs[0].cmdline.contains("init=/sbin/mvm-host-vm-init"));
         // The input disk was packed and the output extracted (empty tar from the

--- a/crates/mvm-runtime/src/builder_runner/spec.rs
+++ b/crates/mvm-runtime/src/builder_runner/spec.rs
@@ -5,9 +5,8 @@
 
 use std::path::{Path, PathBuf};
 
-use mvm_agentd::vsock::{EGRESS_PORT, GUEST_AGENT_PORT};
-
 use crate::driver::{BlockDev, ConsoleCapture, KernelImage, VmmSpec, VsockDirection, VsockPort};
+use mvm_net::channel::GuestService;
 
 /// Kernel cmdline for the disk-transport builder on the HVF VMM. Mirrors
 /// the console args the workload default uses (PL011 earlycon + `ttyAMA0`), but
@@ -67,13 +66,13 @@ pub fn builder_spec(inputs: &BuilderSpecInputs<'_>) -> VmmSpec {
     let mut vsock = Vec::new();
     if let Some(sock) = &inputs.agent_socket {
         vsock.push(VsockPort {
-            guest_port: GUEST_AGENT_PORT,
+            service: GuestService::MachineControl,
             host_uds: sock.clone(),
             direction: VsockDirection::HostDials,
         });
     }
     vsock.push(VsockPort {
-        guest_port: EGRESS_PORT,
+        service: GuestService::Substitution,
         host_uds: inputs.egress_socket.clone(),
         direction: VsockDirection::HostDials,
     });
@@ -116,7 +115,6 @@ pub fn builder_spec(inputs: &BuilderSpecInputs<'_>) -> VmmSpec {
         console: ConsoleCapture {
             log_path: inputs.console_log.clone(),
         },
-        trusted_builder: true,
     }
 }
 
@@ -164,10 +162,13 @@ mod tests {
     }
 
     #[test]
-    fn builder_spec_is_trusted_with_no_egress_port_and_the_builder_cmdline() {
+    fn builder_spec_carries_the_substitution_channel_and_the_builder_cmdline() {
         let spec = builder_spec(&inputs());
-        assert!(spec.trusted_builder);
-        assert!(spec.vsock.iter().any(|p| p.guest_port == EGRESS_PORT));
+        assert!(
+            spec.vsock
+                .iter()
+                .any(|p| p.service == GuestService::Substitution)
+        );
         // Boots the builder PID 1 over the disk transport, rootfs read-only.
         assert!(spec.cmdline.contains("init=/sbin/mvm-host-vm-init"));
         assert!(spec.cmdline.contains("mvm.builder_transport=disk"));
@@ -183,7 +184,7 @@ mod tests {
         i.agent_socket = None;
         let spec = builder_spec(&i);
         assert_eq!(spec.vsock.len(), 1);
-        assert_eq!(spec.vsock[0].guest_port, EGRESS_PORT);
+        assert_eq!(spec.vsock[0].service, GuestService::Substitution);
     }
 
     #[test]

--- a/crates/mvm-runtime/src/driver/fc.rs
+++ b/crates/mvm-runtime/src/driver/fc.rs
@@ -24,6 +24,7 @@ use mvm_core::vm_backend::{
     BackendKind, BackendSecurityProfile, GuestChannelInfo, SnapshotCapability, StandbyError,
     StandbyHandle, StandbyState, VmBackend, VmCapabilities, VmExitStatus, VmId, VmStatus,
 };
+use mvm_net::channel::GuestService;
 
 use crate::backend::FirecrackerBackend;
 use crate::driver::spec::KernelImage;
@@ -240,10 +241,10 @@ fn wire_guest_dial_bridges(
         // The workload-exit port has no runner-bound listener — its `host_uds`
         // is the captured-code output file, not a socket. The driver binds and
         // captures it directly (see `spawn_workload_exit_capture`).
-        if port.guest_port == WORKLOAD_EXIT_PORT {
+        if port.service == GuestService::WorkloadExit {
             continue;
         }
-        let link = fc_guest_dial_socket(runtime_dir, port.guest_port);
+        let link = fc_guest_dial_socket(runtime_dir, port.port());
         // Clear any stale link/socket from a prior run so the symlink lands.
         let _ = std::fs::remove_file(&link);
         std::os::unix::fs::symlink(&port.host_uds, &link).with_context(|| {
@@ -963,17 +964,17 @@ mod tests {
     use crate::driver::ConsoleCapture;
     use mvm_agentd::vsock::{BROKER_PORT, EGRESS_PORT};
 
-    fn host_dials(guest_port: u32, uds: &str) -> VsockPort {
+    fn host_dials(service: GuestService, uds: &str) -> VsockPort {
         VsockPort {
-            guest_port,
+            service,
             host_uds: uds.into(),
             direction: VsockDirection::HostDials,
         }
     }
 
-    fn guest_dials(guest_port: u32, uds: &str) -> VsockPort {
+    fn guest_dials(service: GuestService, uds: &str) -> VsockPort {
         VsockPort {
-            guest_port,
+            service,
             host_uds: uds.into(),
             direction: VsockDirection::GuestDials,
         }
@@ -983,10 +984,10 @@ mod tests {
     /// dials, and the egress, broker and exit ports the guest dials.
     fn workload_channels() -> Vec<VsockPort> {
         vec![
-            host_dials(GUEST_AGENT_PORT, "/run/agent.sock"),
-            guest_dials(EGRESS_PORT, "/run/egress.sock"),
-            guest_dials(BROKER_PORT, "/run/broker.sock"),
-            guest_dials(WORKLOAD_EXIT_PORT, "/state/w/workload.exit"),
+            host_dials(GuestService::MachineControl, "/run/agent.sock"),
+            guest_dials(GuestService::Substitution, "/run/egress.sock"),
+            guest_dials(GuestService::Broker, "/run/broker.sock"),
+            guest_dials(GuestService::WorkloadExit, "/state/w/workload.exit"),
         ]
     }
 
@@ -1004,7 +1005,6 @@ mod tests {
             console: ConsoleCapture {
                 log_path: "/tmp/console.log".into(),
             },
-            trusted_builder: false,
         }
     }
 
@@ -1218,7 +1218,7 @@ mod tests {
     fn config_threads_cmdline_verbatim_and_configures_no_nic() {
         let mut spec = spec_with(
             KernelImage::Path("/img/vmlinux".into()),
-            vec![guest_dials(EGRESS_PORT, "/run/egress.sock")],
+            vec![guest_dials(GuestService::Substitution, "/run/egress.sock")],
             vec![ro_block("/img/rootfs.ext4", 0)],
         );
         spec.cmdline = "  console=ttyS0 root=/dev/vda mvm.roothash=abc mvm.vsock_egress=1  ".into();

--- a/crates/mvm-runtime/src/driver/hvf.rs
+++ b/crates/mvm-runtime/src/driver/hvf.rs
@@ -13,15 +13,14 @@ use std::process::{Command, Stdio};
 use std::time::Instant;
 
 use anyhow::{Context, Result, anyhow, bail};
-use mvm_agentd::vsock::{
-    BROKER_PORT, CONSOLE_PORT_BASE, EGRESS_PORT, GUEST_AGENT_PORT, dev_console_data_ports,
-};
+use mvm_agentd::vsock::{CONSOLE_PORT_BASE, GUEST_AGENT_PORT, dev_console_data_ports};
 use mvm_build::hvf_supervisor::{ConsoleDataSocket, HvfDisk, HvfSupervisorConfig};
 use mvm_core::config::{vm_hvf_vsock_port_socket_at, vm_state_dir};
 use mvm_core::vm_backend::{
     BackendKind, BackendSecurityProfile, GuestChannelInfo, VmBackend, VmCapabilities, VmExitStatus,
     VmId, VmStatus,
 };
+use mvm_net::channel::GuestService;
 
 use crate::driver::spec::KernelImage;
 use crate::driver::{DuplexStream, RunningVm, VmmDriver, VmmSpec};
@@ -108,18 +107,11 @@ fn relay_supervisor_config(spec: &VmmSpec, paths: &SupervisorPaths) -> Result<Hv
         })
         .collect();
 
-    // Guests that need host egress carry an explicit EGRESS_PORT relay socket in
-    // the spec. Workloads must provide one; trusted builders now provide the same
-    // vsock relay so every backend uses one egress path.
-    let egress_relay_socket = match spec.host_socket_for_port(EGRESS_PORT) {
-        Some(socket) => Some(socket),
-        None if spec.trusted_builder => None,
-        None => {
-            return Err(anyhow!(
-                "hvf workload spec is missing the EGRESS_PORT vsock relay socket"
-            ));
-        }
-    };
+    // Every boot carries the substitution channel, including builder boots.
+    // Requiring it here keeps a malformed spec from creating an ungated path.
+    let egress_relay_socket = spec
+        .host_socket_for_service(GuestService::Substitution)
+        .ok_or_else(|| anyhow!("hvf spec is missing the EGRESS_PORT vsock relay socket"))?;
 
     // An empty spec cmdline means "use the supervisor's workload default"
     // (`init=/init`); a non-empty one (e.g. the builder rootfs's
@@ -135,9 +127,9 @@ fn relay_supervisor_config(spec: &VmmSpec, paths: &SupervisorPaths) -> Result<Hv
     let console_data_sockets = spec
         .vsock
         .iter()
-        .filter(|p| dev_console_data_ports().any(|cp| cp == p.guest_port))
+        .filter(|p| matches!(p.service, GuestService::ConsoleData { .. }))
         .map(|p| ConsoleDataSocket {
-            guest_port: p.guest_port,
+            guest_port: p.port(),
             host_socket: p.host_uds.clone(),
         })
         .collect();
@@ -160,12 +152,12 @@ fn relay_supervisor_config(spec: &VmmSpec, paths: &SupervisorPaths) -> Result<Hv
         // `hvf-agent.sock`, so binder and resolver can't drift.
         agent_socket: Some(hvf_agent_socket(&paths.state_dir)),
         substitution_socket: None,
-        egress_relay_socket,
+        egress_relay_socket: Some(egress_relay_socket),
         // An admitted workload carries a BROKER_PORT relay socket; the supervisor
         // splices the guest's BROKER_PORT dial to it so host.audit.v1 /
         // host.secrets.v1 reach the per-VM broker (or the per-tenant host-agent
         // daemon). Absent for a builder/dev VM, which runs no admitted workload.
-        broker_socket: spec.host_socket_for_port(BROKER_PORT),
+        broker_socket: spec.host_socket_for_service(GuestService::Broker),
         console_data_sockets,
     })
 }
@@ -386,7 +378,7 @@ mod tests {
 
     fn egress_port(uds: &str) -> VsockPort {
         VsockPort {
-            guest_port: EGRESS_PORT,
+            service: GuestService::Substitution,
             host_uds: uds.into(),
             direction: VsockDirection::GuestDials,
         }
@@ -394,7 +386,7 @@ mod tests {
 
     fn agent_port(uds: &str) -> VsockPort {
         VsockPort {
-            guest_port: GUEST_AGENT_PORT,
+            service: GuestService::MachineControl,
             host_uds: uds.into(),
             direction: VsockDirection::HostDials,
         }
@@ -402,7 +394,7 @@ mod tests {
 
     fn broker_port(uds: &str) -> VsockPort {
         VsockPort {
-            guest_port: BROKER_PORT,
+            service: GuestService::Broker,
             host_uds: uds.into(),
             direction: VsockDirection::GuestDials,
         }
@@ -422,7 +414,6 @@ mod tests {
             console: ConsoleCapture {
                 log_path: "/tmp/console.log".into(),
             },
-            trusted_builder: false,
         }
     }
 
@@ -633,8 +624,8 @@ mod tests {
     }
 
     #[test]
-    fn relay_config_trusted_builder_uses_the_same_egress_relay() {
-        let mut spec = spec_with(
+    fn relay_config_requires_the_same_egress_relay_for_builder_boots() {
+        let spec = spec_with(
             KernelImage::Path("/img/Image".into()),
             vec![
                 agent_port("/run/agent.sock"),
@@ -642,7 +633,6 @@ mod tests {
             ],
             vec![],
         );
-        spec.trusted_builder = true;
         let cfg = relay_supervisor_config(&spec, &sample_paths()).unwrap();
         assert_eq!(
             cfg.egress_relay_socket,
@@ -787,7 +777,7 @@ mod tests {
 
     fn console_vsock_port(port: u32, uds: &str) -> VsockPort {
         VsockPort {
-            guest_port: port,
+            service: GuestService::ConsoleData { port },
             host_uds: uds.into(),
             direction: VsockDirection::HostDials,
         }

--- a/crates/mvm-runtime/src/driver/libkrun.rs
+++ b/crates/mvm-runtime/src/driver/libkrun.rs
@@ -14,12 +14,13 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
 use libkrun_sys::{BridgeRestartPolicy, KrunContext, SupervisorConfig};
-use mvm_agentd::vsock::{CONSOLE_PORT_BASE, EGRESS_PORT, GUEST_AGENT_PORT, dev_console_data_ports};
+use mvm_agentd::vsock::{CONSOLE_PORT_BASE, GUEST_AGENT_PORT, dev_console_data_ports};
 use mvm_core::config::{vm_libkrun_pid, vm_state_dir, vm_vsock_port_socket_at};
 use mvm_core::vm_backend::{
     BackendKind, BackendSecurityProfile, GuestChannelInfo, SnapshotCapability, VmBackend,
     VmCapabilities, VmExitStatus, VmId, VmStatus,
 };
+use mvm_net::channel::GuestService;
 
 use crate::driver::spec::KernelImage;
 use crate::driver::{BlockDev, DuplexStream, RunningVm, VmmDriver, VmmSpec, VsockDirection};
@@ -155,8 +156,8 @@ fn relay_libkrun_supervisor_config(spec: &VmmSpec, state_dir: &Path) -> Result<S
     // re-bound here.
     for port in &spec.vsock {
         krun = match port.direction {
-            VsockDirection::HostDials => krun.add_vsock_port(port.guest_port),
-            VsockDirection::GuestDials => krun.add_host_listen_port(port.guest_port),
+            VsockDirection::HostDials => krun.add_vsock_port(port.port()),
+            VsockDirection::GuestDials => krun.add_host_listen_port(port.port()),
         };
     }
 
@@ -184,7 +185,7 @@ fn relay_libkrun_supervisor_config(spec: &VmmSpec, state_dir: &Path) -> Result<S
         // there. A spec without an EGRESS_PORT channel (none of the workload
         // paths) leaves this unset and the derived socket unchanged.
         transparent_terminator_port: None,
-        egress_relay_socket: spec.host_socket_for_port(EGRESS_PORT),
+        egress_relay_socket: spec.host_socket_for_service(GuestService::Substitution),
     })
 }
 
@@ -447,20 +448,20 @@ impl RunningVm for LibkrunRunningVm {
 mod tests {
     use super::*;
     use crate::driver::{ConsoleCapture, VsockPort};
-    use mvm_agentd::vsock::{BROKER_PORT, WORKLOAD_EXIT_PORT};
+    use mvm_agentd::vsock::{BROKER_PORT, EGRESS_PORT, WORKLOAD_EXIT_PORT};
     use mvm_core::vm_backend::SnapshotCapability;
 
-    fn host_dials(guest_port: u32, uds: &str) -> VsockPort {
+    fn host_dials(service: GuestService, uds: &str) -> VsockPort {
         VsockPort {
-            guest_port,
+            service,
             host_uds: uds.into(),
             direction: VsockDirection::HostDials,
         }
     }
 
-    fn guest_dials(guest_port: u32, uds: &str) -> VsockPort {
+    fn guest_dials(service: GuestService, uds: &str) -> VsockPort {
         VsockPort {
-            guest_port,
+            service,
             host_uds: uds.into(),
             direction: VsockDirection::GuestDials,
         }
@@ -480,7 +481,6 @@ mod tests {
             console: ConsoleCapture {
                 log_path: "/tmp/console.log".into(),
             },
-            trusted_builder: false,
         }
     }
 
@@ -542,8 +542,8 @@ mod tests {
         let spec = spec_with(
             KernelImage::Path("/img/Image".into()),
             vec![
-                host_dials(GUEST_AGENT_PORT, "/run/agent.sock"),
-                guest_dials(EGRESS_PORT, "/run/egress.sock"),
+                host_dials(GuestService::MachineControl, "/run/agent.sock"),
+                guest_dials(GuestService::Substitution, "/run/egress.sock"),
             ],
             vec![],
         );
@@ -664,11 +664,16 @@ mod tests {
         let spec = spec_with(
             KernelImage::Path("/img/Image".into()),
             vec![
-                host_dials(GUEST_AGENT_PORT, "/run/agent.sock"),
-                guest_dials(EGRESS_PORT, "/run/egress.sock"),
-                guest_dials(WORKLOAD_EXIT_PORT, "/run/exit.sock"),
-                guest_dials(BROKER_PORT, "/run/broker.sock"),
-                host_dials(CONSOLE_PORT_BASE + 1, "/run/console.sock"),
+                host_dials(GuestService::MachineControl, "/run/agent.sock"),
+                guest_dials(GuestService::Substitution, "/run/egress.sock"),
+                guest_dials(GuestService::WorkloadExit, "/run/exit.sock"),
+                guest_dials(GuestService::Broker, "/run/broker.sock"),
+                host_dials(
+                    GuestService::ConsoleData {
+                        port: CONSOLE_PORT_BASE + 1,
+                    },
+                    "/run/console.sock",
+                ),
             ],
             vec![],
         );

--- a/crates/mvm-runtime/src/driver/mock.rs
+++ b/crates/mvm-runtime/src/driver/mock.rs
@@ -502,7 +502,6 @@ mod tests {
             console: ConsoleCapture {
                 log_path: "/tmp/console.log".into(),
             },
-            trusted_builder: false,
         }
     }
 

--- a/crates/mvm-runtime/src/driver/qemu.rs
+++ b/crates/mvm-runtime/src/driver/qemu.rs
@@ -20,14 +20,13 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
-use mvm_agentd::vsock::{
-    CONSOLE_PORT_BASE, GUEST_AGENT_PORT, WORKLOAD_EXIT_PORT, dev_console_data_ports,
-};
+use mvm_agentd::vsock::{CONSOLE_PORT_BASE, GUEST_AGENT_PORT, dev_console_data_ports};
 use mvm_core::config::{vm_state_dir, vm_vsock_port_socket_at};
 use mvm_core::vm_backend::{
     BackendKind, BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, VmBackend,
     VmCapabilities, VmExitStatus, VmId, VmStatus,
 };
+use mvm_net::channel::GuestService;
 
 use crate::base::ui;
 use crate::driver::spec::KernelImage;
@@ -183,22 +182,22 @@ fn bridge_spec_for_vsock(cid: u32, state_dir: &Path, channels: &[VsockPort]) -> 
     for port in channels {
         match port.direction {
             VsockDirection::HostDials => host_dials.push(QemuBridgeHostDial {
-                guest_port: port.guest_port,
+                guest_port: port.port(),
                 // Re-derived from the state dir (the flat `vsock-<port>.sock`
                 // convention the host-side resolver probes), never the spec's
                 // backend-neutral hint — the same discipline the hvf, libkrun,
                 // and Firecracker drivers apply to the agent socket, so binder
                 // and resolver can't drift.
-                listen_uds: vm_vsock_port_socket_at(state_dir, port.guest_port),
+                listen_uds: vm_vsock_port_socket_at(state_dir, port.port()),
             }),
             // The workload-exit port has no runner-bound listener — its
             // `host_uds` is the captured-code output file, not a socket. The
             // bridge accepts the report and persists it (see qemu.rs).
-            VsockDirection::GuestDials if port.guest_port == WORKLOAD_EXIT_PORT => {
+            VsockDirection::GuestDials if port.service == GuestService::WorkloadExit => {
                 exit_capture_state_dir = Some(state_dir.to_path_buf());
             }
             VsockDirection::GuestDials => guest_dials.push(QemuBridgeGuestDial {
-                guest_port: port.guest_port,
+                guest_port: port.port(),
                 target_uds: port.host_uds.clone(),
             }),
         }
@@ -481,17 +480,17 @@ mod tests {
     use mvm_agentd::vsock::{BROKER_PORT, EGRESS_PORT};
     use mvm_core::vm_backend::SnapshotCapability;
 
-    fn host_dials(guest_port: u32, uds: &str) -> VsockPort {
+    fn host_dials(service: GuestService, uds: &str) -> VsockPort {
         VsockPort {
-            guest_port,
+            service,
             host_uds: uds.into(),
             direction: VsockDirection::HostDials,
         }
     }
 
-    fn guest_dials(guest_port: u32, uds: &str) -> VsockPort {
+    fn guest_dials(service: GuestService, uds: &str) -> VsockPort {
         VsockPort {
-            guest_port,
+            service,
             host_uds: uds.into(),
             direction: VsockDirection::GuestDials,
         }
@@ -511,7 +510,6 @@ mod tests {
             console: ConsoleCapture {
                 log_path: "/state/w/console.log".into(),
             },
-            trusted_builder: false,
         }
     }
 
@@ -709,11 +707,16 @@ mod tests {
     fn bridge_spec_maps_channels_by_direction_and_re_derives_host_sockets() {
         let state_dir = Path::new("/state/w");
         let channels = vec![
-            host_dials(GUEST_AGENT_PORT, "/run/agent-hint.sock"),
-            guest_dials(EGRESS_PORT, "/run/egress.sock"),
-            guest_dials(WORKLOAD_EXIT_PORT, "/state/w/workload.exit"),
-            guest_dials(BROKER_PORT, "/run/broker.sock"),
-            host_dials(CONSOLE_PORT_BASE + 1, "/run/console-hint.sock"),
+            host_dials(GuestService::MachineControl, "/run/agent-hint.sock"),
+            guest_dials(GuestService::Substitution, "/run/egress.sock"),
+            guest_dials(GuestService::WorkloadExit, "/state/w/workload.exit"),
+            guest_dials(GuestService::Broker, "/run/broker.sock"),
+            host_dials(
+                GuestService::ConsoleData {
+                    port: CONSOLE_PORT_BASE + 1,
+                },
+                "/run/console-hint.sock",
+            ),
         ];
         let spec = bridge_spec_for_vsock(9, state_dir, &channels);
 
@@ -757,7 +760,7 @@ mod tests {
         let spec = bridge_spec_for_vsock(
             3,
             Path::new("/state/w"),
-            &[host_dials(GUEST_AGENT_PORT, "/run/agent.sock")],
+            &[host_dials(GuestService::MachineControl, "/run/agent.sock")],
         );
         assert_eq!(spec.exit_capture_state_dir, None);
         assert!(spec.guest_dials.is_empty());

--- a/crates/mvm-runtime/src/driver/spec.rs
+++ b/crates/mvm-runtime/src/driver/spec.rs
@@ -8,6 +8,8 @@
 
 use std::path::PathBuf;
 
+use mvm_net::channel::GuestService;
+
 /// Where a VM's kernel comes from.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KernelImage {
@@ -50,12 +52,19 @@ pub enum VsockDirection {
     GuestDials,
 }
 
-/// One vsock port mapping between a guest port and a host unix socket.
+/// One typed guest service mapping to a host unix socket.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VsockPort {
-    pub guest_port: u32,
+    pub service: GuestService,
     pub host_uds: PathBuf,
     pub direction: VsockDirection,
+}
+
+impl VsockPort {
+    /// The numeric vsock port used at the VMM boundary.
+    pub fn port(&self) -> u32 {
+        self.service.port()
+    }
 }
 
 /// Write-only host capture of the guest console. There is no input fd — the
@@ -84,22 +93,16 @@ pub struct VmmSpec {
     pub blocks: Vec<BlockDev>,
     pub vsock: Vec<VsockPort>,
     pub console: ConsoleCapture,
-    /// Trusted-builder VM: it carries no untrusted workload, so it boots WITHOUT
-    /// the claim-10 egress gate (no `EGRESS_PORT` relay required). A workload
-    /// leaves this `false` so a missing egress relay fails closed rather than
-    /// booting ungated.
-    pub trusted_builder: bool,
 }
 
 impl VmmSpec {
-    /// The host unix socket a standing vsock port binds to, found by its
-    /// guest-port number. `None` when the spec carries no channel for that
-    /// port. Both drivers resolve the egress/agent/broker sockets through this
-    /// one lookup instead of each re-scanning `vsock`.
-    pub fn host_socket_for_port(&self, guest_port: u32) -> Option<PathBuf> {
+    /// The host unix socket a standing guest service binds to.
+    /// `None` when the spec carries no channel for that service. Drivers use
+    /// this lookup instead of each re-scanning the raw channel list.
+    pub fn host_socket_for_service(&self, service: GuestService) -> Option<PathBuf> {
         self.vsock
             .iter()
-            .find(|p| p.guest_port == guest_port)
+            .find(|p| p.service == service)
             .map(|p| p.host_uds.clone())
     }
 }
@@ -119,5 +122,18 @@ mod tests {
         assert_eq!(mk(0).device_node(), "/dev/vda");
         assert_eq!(mk(1).device_node(), "/dev/vdb");
         assert_eq!(mk(25).device_node(), "/dev/vdz");
+    }
+
+    #[test]
+    fn typed_vsock_service_resolves_its_transport_port() {
+        let channel = VsockPort {
+            service: GuestService::NetworkData { queue: 0 },
+            host_uds: "/run/network-data.sock".into(),
+            direction: VsockDirection::GuestDials,
+        };
+        assert_eq!(
+            channel.port(),
+            GuestService::NetworkData { queue: 0 }.port()
+        );
     }
 }

--- a/crates/mvm-runtime/src/libkrun.rs
+++ b/crates/mvm-runtime/src/libkrun.rs
@@ -893,7 +893,11 @@ impl VmBackend for LibkrunBackend {
         // The L3 gateway is orthogonal to the substitution endpoint: a
         // launch may need one, the other, or neither. It goes first because
         // it must be listening before the guest boots and dials it.
-        crate::netd_spawn::spawn_netd_if_needed(config, &state_dir)?;
+        crate::netd_spawn::spawn_netd_if_needed(
+            config,
+            &state_dir,
+            mvm_core::vm_backend::BackendKind::Libkrun,
+        )?;
         let mut endpoint_guard = spawn_libkrun_egress_endpoint_if_needed(
             &config.name,
             &state_dir,

--- a/crates/mvm-runtime/src/netd_spawn.rs
+++ b/crates/mvm-runtime/src/netd_spawn.rs
@@ -17,6 +17,7 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow};
+use mvm_core::vm_backend::BackendKind;
 
 /// Per-VM pid file, under the VM state directory.
 pub const NETD_PID_FILE: &str = "netd.pid";
@@ -222,11 +223,12 @@ impl Drop for NetdGuard {
 pub fn spawn_netd_if_needed(
     config: &mvm_core::vm_backend::VmStartConfig,
     state_dir: &Path,
+    backend_kind: BackendKind,
 ) -> Result<()> {
     if crate::egress_shared::l3_cmdline_token(config).is_none() {
         return Ok(());
     }
-    let netd_config = build_netd_config(config)?;
+    let netd_config = build_netd_config(config, backend_kind)?;
     spawn_netd(NetdSpawnParams {
         state_dir,
         config_json: &netd_config,
@@ -239,7 +241,10 @@ pub fn spawn_netd_if_needed(
 /// Everything here comes from the plan the supervisor admitted; nothing is
 /// re-derived from host state, so the gateway enforces the contract that
 /// was signed rather than one assembled at launch time.
-fn build_netd_config(config: &mvm_core::vm_backend::VmStartConfig) -> Result<String> {
+fn build_netd_config(
+    config: &mvm_core::vm_backend::VmStartConfig,
+    backend_kind: BackendKind,
+) -> Result<String> {
     use mvm_net::l3::config::{
         DEFAULT_DNS_QPS, DEFAULT_QUEUE_DEPTH, NetdConfig, NetdEgress, NetdRule, NetdUdsLayout,
     };
@@ -296,7 +301,10 @@ fn build_netd_config(config: &mvm_core::vm_backend::VmStartConfig) -> Result<Str
         // of the same machine never share an identity.
         boot_id: plan.plan_id.0.clone(),
         plan_digest: plan.plan_id.0.clone(),
-        uds_layout: NetdUdsLayout::PerVmDir,
+        uds_layout: match backend_kind {
+            BackendKind::Hvf => NetdUdsLayout::HvfVsockDir,
+            _ => NetdUdsLayout::PerVmDir,
+        },
         gateway_ipv4: lease.gateway,
         guest_ipv4: lease.guest,
         mtu: spec.mtu,
@@ -392,7 +400,7 @@ mod wiring_tests {
         // no `mvm-netd` on a test host, so a spawn attempt would error.
         let dir = tempfile::tempdir().expect("temp dir");
         for mode in [NetworkMode::None, NetworkMode::HostVsockProxy] {
-            spawn_netd_if_needed(&config_for(mode), dir.path())
+            spawn_netd_if_needed(&config_for(mode), dir.path(), BackendKind::Firecracker)
                 .unwrap_or_else(|e| panic!("{mode:?} must be a no-op, got {e}"));
         }
         spawn_netd_if_needed(
@@ -401,6 +409,7 @@ mod wiring_tests {
                 ..VmStartConfig::default()
             },
             dir.path(),
+            BackendKind::Firecracker,
         )
         .expect("a launch with no admitted plan is not on the tunnel");
         assert!(!dir.path().join(NETD_PID_FILE).exists());
@@ -409,10 +418,11 @@ mod wiring_tests {
     #[test]
     fn the_gateway_config_comes_from_the_admitted_plan() {
         let config = config_for(NetworkMode::L3Vsock);
-        let json = build_netd_config(&config).expect("an l3 plan lowers");
+        let json = build_netd_config(&config, BackendKind::Firecracker).expect("an l3 plan lowers");
         let lowered: serde_json::Value = serde_json::from_str(&json).expect("valid json");
         let spec = L3NetworkSpec::v1();
         assert_eq!(lowered["vm_id"], "wiring");
+        assert_eq!(lowered["uds_layout"], "per_vm_dir");
         assert_eq!(lowered["mtu"], spec.mtu);
         assert_eq!(lowered["policy_epoch"], spec.policy_epoch);
         assert_eq!(lowered["max_flows"], spec.max_flows);
@@ -430,6 +440,10 @@ mod wiring_tests {
             .parse()
             .expect("parses");
         assert_ne!(guest, gateway);
+
+        let hvf_json = build_netd_config(&config, BackendKind::Hvf).expect("an l3 plan lowers");
+        let hvf_lowered: serde_json::Value = serde_json::from_str(&hvf_json).expect("valid json");
+        assert_eq!(hvf_lowered["uds_layout"], "hvf_vsock_dir");
     }
 
     #[test]
@@ -443,7 +457,7 @@ mod wiring_tests {
             plan_json: Some(serde_json::to_string(&plan).expect("serializes")),
             ..VmStartConfig::default()
         };
-        let err = build_netd_config(&config).expect_err("must refuse");
+        let err = build_netd_config(&config, BackendKind::Firecracker).expect_err("must refuse");
         assert!(err.to_string().contains("no l3 network spec"), "{err}");
     }
 
@@ -453,7 +467,7 @@ mod wiring_tests {
         // everything, `Unrestricted` allows everything.
         let mut config = config_for(NetworkMode::L3Vsock);
         config.network_policy = mvm_core::network_policy::NetworkPolicy::deny_all();
-        let json = build_netd_config(&config).expect("lowers");
+        let json = build_netd_config(&config, BackendKind::Firecracker).expect("lowers");
         let lowered: serde_json::Value = serde_json::from_str(&json).expect("valid json");
         assert!(
             lowered["egress"]

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -10,9 +10,11 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 
-use mvm_agentd::vsock::BROKER_PORT;
 use mvm_core::checkpoint::{CheckpointId, CheckpointMeta};
-use mvm_core::config::{vm_state_dir, vm_substitution_endpoint_socket, vms_dir};
+use mvm_core::config::{
+    vm_hvf_vsock_port_socket_at, vm_state_dir, vm_substitution_endpoint_socket,
+    vm_vsock_port_socket_at, vms_dir,
+};
 use mvm_core::crypto::vmgenid::fresh_generation_token;
 use mvm_core::plan::{ExecutionPlan, SecretBinding, StreamRetention};
 use mvm_core::policy::RedactionPolicy;
@@ -24,6 +26,7 @@ use mvm_core::vm_backend::{
     VmStartConfig, VmStatus,
 };
 use mvm_fs::snapshot_store::FsSnapshotStore;
+use mvm_net::channel::GuestService;
 
 use crate::checkpoint::{
     CaptureVmFullParams, CheckpointChainAnchor, CheckpointStore, capture_vm_full, verify_content,
@@ -282,6 +285,8 @@ struct StandingSockets {
     /// broker channel at all. The one path threaded into both the spec and the
     /// `BrokerRegistrar::register` call so the relay target and bind path match.
     broker: Option<PathBuf>,
+    network_control: Option<PathBuf>,
+    network_data: Option<PathBuf>,
     console_log: PathBuf,
     /// Per-port UDS for the interactive console data range. Non-empty only when
     /// `VmStartConfig.dev_console` is true; empty for all sealed prod boots.
@@ -304,12 +309,23 @@ impl StandingSockets {
             egress_gateway: egress_uds,
             exit: &self.exit,
             broker: self.broker.as_deref(),
+            network_control: self.network_control.as_deref(),
+            network_data: self.network_data.as_deref(),
             console_data: self.console_data.clone(),
         }
     }
 }
 
-fn standing_sockets(state_dir: &Path, config: &VmStartConfig) -> StandingSockets {
+fn standing_sockets(
+    state_dir: &Path,
+    config: &VmStartConfig,
+    backend_kind: BackendKind,
+) -> StandingSockets {
+    let l3_channels = crate::egress_shared::l3_cmdline_token(config).is_some();
+    let l3_socket = |service: GuestService| match backend_kind {
+        BackendKind::Hvf => vm_hvf_vsock_port_socket_at(state_dir, service.port()),
+        _ => vm_vsock_port_socket_at(state_dir, service.port()),
+    };
     StandingSockets {
         // Single source of truth shared with the host-side resolver so the
         // guest agent bridge can't drift out of the host's reach.
@@ -320,7 +336,9 @@ fn standing_sockets(state_dir: &Path, config: &VmStartConfig) -> StandingSockets
         broker: config
             .tenant_id
             .is_some()
-            .then(|| mvm_core::config::vm_vsock_port_socket_at(state_dir, BROKER_PORT)),
+            .then(|| vm_vsock_port_socket_at(state_dir, GuestService::Broker.port())),
+        network_control: l3_channels.then(|| l3_socket(GuestService::NetworkControl)),
+        network_data: l3_channels.then(|| l3_socket(GuestService::NetworkData { queue: 0 })),
         console_log: state_dir.join("console.log"),
         console_data: console_data_sockets(state_dir, config.dev_console),
     }
@@ -433,7 +451,7 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
             },
         )?;
 
-        let socks = standing_sockets(&state_dir, inputs.config);
+        let socks = standing_sockets(&state_dir, inputs.config, self.driver.kind());
         let spec = workload_spec(&WorkloadSpecInputs {
             config: inputs.config,
             sockets: socks.with_egress(endpoint.egress_uds()),
@@ -582,7 +600,7 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
         // mapped through the one mapper a cold boot's set comes from. The fork
         // wires these before it resumes the child; a restored guest is already
         // booted, so it dials the instant its vCPUs run.
-        let socks = standing_sockets(&child_dir, &child_cfg);
+        let socks = standing_sockets(&child_dir, &child_cfg, self.driver.kind());
         let channels = workload_vsock_ports(&socks.with_egress(endpoint.egress_uds()));
 
         // Register the child's host-services broker (host.audit.v1 /
@@ -1093,7 +1111,7 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 
         // it: there is no retry and no fallback, so a guest that finds no
         // listener has no network at all. A no-op for every plan that did
         // not select the tunnel.
-        crate::netd_spawn::spawn_netd_if_needed(config, &state_dir)?;
+        crate::netd_spawn::spawn_netd_if_needed(config, &state_dir, self.driver.kind())?;
 
         // Owned decode + defaults must outlive the `WorkloadLaunchInputs` borrows
         // below, so bind them here rather than inline.
@@ -1276,7 +1294,7 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Mutex;
 
-    use mvm_agentd::vsock::{EGRESS_PORT, GUEST_AGENT_PORT};
+    use mvm_agentd::vsock::{BROKER_PORT, EGRESS_PORT, GUEST_AGENT_PORT};
     use mvm_core::plan::{Nonce, SecretBinding, SecretSource, VerbGrant, VerbId};
     use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
     use mvm_core::util::test_env::TestEnv;
@@ -1432,7 +1450,7 @@ mod tests {
     fn egress_host_uds(spec: &crate::driver::VmmSpec) -> &Path {
         spec.vsock
             .iter()
-            .find(|p| p.guest_port == EGRESS_PORT)
+            .find(|p| p.service == GuestService::Substitution)
             .map(|p| p.host_uds.as_path())
             .expect("spec carries an EGRESS_PORT vsock channel")
     }
@@ -1739,7 +1757,7 @@ mod tests {
         let broker = specs[0]
             .vsock
             .iter()
-            .find(|p| p.guest_port == BROKER_PORT)
+            .find(|p| p.service == GuestService::Broker)
             .expect("admitted spec carries a BROKER_PORT channel");
         assert_eq!(broker.direction, crate::driver::VsockDirection::GuestDials);
         assert_eq!(broker.host_uds, expected_socket);
@@ -1778,7 +1796,10 @@ mod tests {
         // BROKER_PORT stays ECONNREFUSED (fail-closed).
         let specs = runner.driver.booted_specs();
         assert!(
-            specs[0].vsock.iter().all(|p| p.guest_port != BROKER_PORT),
+            specs[0]
+                .vsock
+                .iter()
+                .all(|p| p.service != GuestService::Broker),
             "unadmitted VM must carry no broker port"
         );
     }
@@ -2466,7 +2487,6 @@ mod tests {
 
     #[test]
     fn start_workload_with_dev_console_threads_128_console_ports_into_spec() {
-        use mvm_agentd::vsock::CONSOLE_PORT_BASE;
         let policy = NetworkPolicy::deny_all();
         let redaction = RedactionPolicy::default();
         let runner = WorkloadRunner::new(
@@ -2500,7 +2520,7 @@ mod tests {
         let console: Vec<_> = spec
             .vsock
             .iter()
-            .filter(|p| p.guest_port > CONSOLE_PORT_BASE)
+            .filter(|p| matches!(p.service, GuestService::ConsoleData { .. }))
             .collect();
         assert_eq!(console.len(), 128);
         assert!(
@@ -2722,7 +2742,7 @@ mod tests {
             booted[0]
                 .vsock
                 .iter()
-                .map(|p| p.guest_port)
+                .map(crate::driver::VsockPort::port)
                 .collect::<Vec<_>>()
         );
 
@@ -3025,7 +3045,6 @@ mod tests {
             parent.vsock.is_empty(),
             "an egress-enabled parent still wires no egress channel to dial"
         );
-        assert!(!parent.trusted_builder);
     }
 
     // ── Warm claim: the guarded fork of a clean parent into a fresh child ──────
@@ -3450,7 +3469,7 @@ mod tests {
                             .map(|rest| format!("<vm>/{}", rest.display()))
                     })
                     .unwrap_or_else(|| p.host_uds.display().to_string());
-                (p.guest_port, p.direction, where_)
+                (p.port(), p.direction, where_)
             })
             .collect()
     }
@@ -3565,7 +3584,7 @@ mod tests {
         // Non-vacuity: the fixture must actually exercise all four standing
         // channels, or "the two match" would say nothing. These are the three
         // the fork used to drop, plus the agent RPC.
-        let ports: Vec<u32> = cold.iter().map(|p| p.guest_port).collect();
+        let ports: Vec<u32> = cold.iter().map(crate::driver::VsockPort::port).collect();
         for (port, what) in [
             (EGRESS_PORT, "the gated egress endpoint"),
             (BROKER_PORT, "host.audit.v1 / host.secrets.v1"),
@@ -3608,7 +3627,7 @@ mod tests {
         let wired = run.driver.forked_children()[0]
             .channels
             .iter()
-            .find(|p| p.guest_port == BROKER_PORT)
+            .find(|p| p.service == GuestService::Broker)
             .map(|p| p.host_uds.clone())
             .expect("the child carries a broker channel");
         assert_eq!(

--- a/crates/mvm-runtime/src/workload_runner/spec_map.rs
+++ b/crates/mvm-runtime/src/workload_runner/spec_map.rs
@@ -5,11 +5,10 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, bail};
-use mvm_agentd::vsock::{
-    BROKER_PORT, EGRESS_PORT, GUEST_AGENT_PORT, WORKLOAD_EXIT_PORT, dev_console_data_ports,
-};
+use mvm_agentd::vsock::dev_console_data_ports;
 use mvm_core::config::vm_hvf_vsock_port_socket_at;
 use mvm_core::vm_backend::{VmStartConfig, VmVolumeKind};
+use mvm_net::channel::GuestService;
 
 use crate::driver::{BlockDev, ConsoleCapture, KernelImage, VmmSpec, VsockDirection, VsockPort};
 
@@ -172,6 +171,12 @@ pub struct WorkloadSockets<'a> {
     /// unadmitted VM carries no broker port, so a stray guest dial stays
     /// `ECONNREFUSED` (fail-closed).
     pub broker: Option<&'a Path>,
+    /// L3 tunnel control: the guest dials `NetworkControl` when the admitted
+    /// plan selects `l3-vsock`; absent for every other network mode.
+    pub network_control: Option<&'a Path>,
+    /// L3 tunnel packet queue zero: the guest dials `NetworkData` when the
+    /// admitted plan selects `l3-vsock`; absent for every other network mode.
+    pub network_data: Option<&'a Path>,
     /// Dev-only interactive console data ports: one host UDS per port in
     /// `dev_console_data_ports()`, pre-opened so a PTY can attach. Empty for
     /// sealed prod boots (`dev_console = false` in `VmStartConfig`).
@@ -185,17 +190,17 @@ pub struct WorkloadSockets<'a> {
 pub fn workload_vsock_ports(socks: &WorkloadSockets) -> Vec<VsockPort> {
     let mut ports = vec![
         VsockPort {
-            guest_port: GUEST_AGENT_PORT,
+            service: GuestService::MachineControl,
             host_uds: socks.agent.into(),
             direction: VsockDirection::HostDials,
         },
         VsockPort {
-            guest_port: EGRESS_PORT,
+            service: GuestService::Substitution,
             host_uds: socks.egress_gateway.into(),
             direction: VsockDirection::GuestDials,
         },
         VsockPort {
-            guest_port: WORKLOAD_EXIT_PORT,
+            service: GuestService::WorkloadExit,
             host_uds: socks.exit.into(),
             direction: VsockDirection::GuestDials,
         },
@@ -204,8 +209,22 @@ pub fn workload_vsock_ports(socks: &WorkloadSockets) -> Vec<VsockPort> {
     // gets none, so a stray guest dial to BROKER_PORT stays ECONNREFUSED.
     if let Some(broker) = socks.broker {
         ports.push(VsockPort {
-            guest_port: BROKER_PORT,
+            service: GuestService::Broker,
             host_uds: broker.into(),
+            direction: VsockDirection::GuestDials,
+        });
+    }
+    if let Some(network_control) = socks.network_control {
+        ports.push(VsockPort {
+            service: GuestService::NetworkControl,
+            host_uds: network_control.into(),
+            direction: VsockDirection::GuestDials,
+        });
+    }
+    if let Some(network_data) = socks.network_data {
+        ports.push(VsockPort {
+            service: GuestService::NetworkData { queue: 0 },
+            host_uds: network_data.into(),
             direction: VsockDirection::GuestDials,
         });
     }
@@ -214,7 +233,7 @@ pub fn workload_vsock_ports(socks: &WorkloadSockets) -> Vec<VsockPort> {
     // when `dev_console` is true — a sealed prod boot carries none (claim 15).
     for (port, path) in &socks.console_data {
         ports.push(VsockPort {
-            guest_port: *port,
+            service: GuestService::ConsoleData { port: *port },
             host_uds: path.clone(),
             direction: VsockDirection::HostDials,
         });
@@ -281,8 +300,6 @@ pub fn workload_device_spec(config: &VmStartConfig, cmdline: &str, console_log: 
         console: ConsoleCapture {
             log_path: console_log.to_path_buf(),
         },
-        // A workload is untrusted: it must route egress through the gated endpoint.
-        trusted_builder: false,
     }
 }
 
@@ -301,6 +318,7 @@ pub fn workload_spec(inputs: &WorkloadSpecInputs) -> VmmSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_agentd::vsock::{EGRESS_PORT, GUEST_AGENT_PORT, WORKLOAD_EXIT_PORT};
     use std::path::PathBuf;
 
     fn base() -> VmStartConfig {
@@ -610,13 +628,15 @@ mod tests {
             egress_gateway: Path::new("/run/egress.sock"),
             exit: Path::new("/run/workload.exit"),
             broker: None,
+            network_control: None,
+            network_data: None,
             console_data: Vec::new(),
         };
         let ports = workload_vsock_ports(&socks);
 
         // Agent: host dials the guest; egress + exit: the guest dials the host.
         let by_port: std::collections::HashMap<u32, &VsockPort> =
-            ports.iter().map(|p| (p.guest_port, p)).collect();
+            ports.iter().map(|p| (p.port(), p)).collect();
 
         let agent = by_port[&GUEST_AGENT_PORT];
         assert_eq!(agent.direction, VsockDirection::HostDials);
@@ -631,12 +651,42 @@ mod tests {
         assert_eq!(exit.host_uds, PathBuf::from("/run/workload.exit"));
     }
 
+    #[test]
+    fn workload_vsock_ports_wire_l3_control_and_data_channels_when_present() {
+        let socks = WorkloadSockets {
+            agent: Path::new("/run/agent.sock"),
+            egress_gateway: Path::new("/run/egress.sock"),
+            exit: Path::new("/run/workload.exit"),
+            broker: None,
+            network_control: Some(Path::new("/run/network-control.sock")),
+            network_data: Some(Path::new("/run/network-data-0.sock")),
+            console_data: Vec::new(),
+        };
+        let ports = workload_vsock_ports(&socks);
+
+        let control = ports
+            .iter()
+            .find(|port| port.service == GuestService::NetworkControl)
+            .expect("l3 control channel is present");
+        assert_eq!(control.direction, VsockDirection::GuestDials);
+        assert_eq!(control.host_uds, PathBuf::from("/run/network-control.sock"));
+
+        let data = ports
+            .iter()
+            .find(|port| port.service == (GuestService::NetworkData { queue: 0 }))
+            .expect("l3 data channel is present");
+        assert_eq!(data.direction, VsockDirection::GuestDials);
+        assert_eq!(data.host_uds, PathBuf::from("/run/network-data-0.sock"));
+    }
+
     fn sample_sockets() -> WorkloadSockets<'static> {
         WorkloadSockets {
             agent: Path::new("/run/agent.sock"),
             egress_gateway: Path::new("/run/egress.sock"),
             exit: Path::new("/run/workload.exit"),
             broker: None,
+            network_control: None,
+            network_data: None,
             console_data: Vec::new(),
         }
     }
@@ -649,11 +699,13 @@ mod tests {
             egress_gateway: Path::new("/run/egress.sock"),
             exit: Path::new("/run/workload.exit"),
             broker: Some(Path::new("/run/broker.sock")),
+            network_control: None,
+            network_data: None,
             console_data: Vec::new(),
         };
         let broker = workload_vsock_ports(&admitted)
             .into_iter()
-            .find(|p| p.guest_port == BROKER_PORT)
+            .find(|p| p.service == GuestService::Broker)
             .expect("admitted VM carries the broker channel");
         assert_eq!(broker.direction, VsockDirection::GuestDials);
         assert_eq!(broker.host_uds, PathBuf::from("/run/broker.sock"));
@@ -667,7 +719,7 @@ mod tests {
         assert!(
             workload_vsock_ports(&unadmitted)
                 .iter()
-                .all(|p| p.guest_port != BROKER_PORT),
+                .all(|p| p.service != GuestService::Broker),
             "unadmitted VM must carry no broker port"
         );
     }
@@ -780,7 +832,6 @@ mod tests {
 
     #[test]
     fn workload_vsock_ports_with_dev_console_carries_128_console_ports() {
-        use mvm_agentd::vsock::CONSOLE_PORT_BASE;
         let state_dir = Path::new("/state/w");
         let console_data = console_data_sockets(state_dir, true);
         let socks = WorkloadSockets {
@@ -788,6 +839,8 @@ mod tests {
             egress_gateway: Path::new("/run/egress.sock"),
             exit: Path::new("/run/workload.exit"),
             broker: None,
+            network_control: None,
+            network_data: None,
             console_data,
         };
         let ports = workload_vsock_ports(&socks);
@@ -798,7 +851,7 @@ mod tests {
         // All console ports are HostDials and land in the expected range.
         let console_ports: Vec<_> = ports
             .iter()
-            .filter(|p| p.guest_port > CONSOLE_PORT_BASE)
+            .filter(|p| matches!(p.service, GuestService::ConsoleData { .. }))
             .collect();
         assert_eq!(console_ports.len(), 128);
         assert!(
@@ -816,6 +869,8 @@ mod tests {
             egress_gateway: Path::new("/run/egress.sock"),
             exit: Path::new("/run/workload.exit"),
             broker: None,
+            network_control: None,
+            network_data: None,
             console_data: Vec::new(),
         };
         let ports = workload_vsock_ports(&socks);
@@ -837,6 +892,8 @@ mod tests {
                 egress_gateway: Path::new("/run/egress.sock"),
                 exit: Path::new("/run/workload.exit"),
                 broker: None,
+                network_control: None,
+                network_data: None,
                 console_data,
             },
             cmdline: String::new(),

--- a/crates/mvm-runtime/src/workload_runner/standby_boot.rs
+++ b/crates/mvm-runtime/src/workload_runner/standby_boot.rs
@@ -332,6 +332,8 @@ mod tests {
                 egress_gateway: Path::new("/run/egress.sock"),
                 exit: Path::new("/run/workload.exit"),
                 broker: None,
+                network_control: None,
+                network_data: None,
                 console_data: Vec::new(),
             },
             cmdline: cmdline::runner_cmdline(launch, state_dir, fc_base),
@@ -373,7 +375,6 @@ mod tests {
         assert_eq!(parent.vcpus, workload.vcpus);
         assert_eq!(parent.memory_mib, workload.memory_mib);
         assert_eq!(parent.mem_initial_mib, workload.mem_initial_mib);
-        assert!(!parent.trusted_builder);
     }
 
     /// An egress-allowing launch: the parent must boot the *identical* cmdline

--- a/crates/mvm-runtime/tests/fc_warm_pool_live.rs
+++ b/crates/mvm-runtime/tests/fc_warm_pool_live.rs
@@ -84,7 +84,6 @@ fn parent_boot_spec(name: &str, images: &LiveImages, state_dir: &Path) -> VmmSpe
         console: ConsoleCapture {
             log_path: state_dir.join("console.log"),
         },
-        trusted_builder: false,
     }
 }
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -335,6 +335,12 @@ for detailed scope and acceptance criteria.
   - [x] Privileged Linux lane executed on a Linux/KVM host: real host TUN,
         real nftables, live forwarding witness, verified-clean teardown
   - [x] BDD suite `s25_l3_vsock` (23 hermetic scenarios)
+  - [x] Workload `VmmSpec` mapping carries the typed L3 control/data channels;
+        netd socket layout follows the selected backend
+  - [x] `VmmSpec::vsock` uses `GuestService` identities for standing channels;
+        numeric ports are derived only at the VMM boundary
+  - [x] Removed builder-role policy from `VmmSpec`; all boots require the
+        typed substitution channel and HVF fails closed when it is absent
   - [ ] macOS forwarding backend — capability-declared and refusing; the
         userspace socket gateway is not implemented
   - [ ] WSL2 validation on a real runner; node-to-node transport; mvmd

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -478,7 +478,13 @@ updates only its own entry below.
       the guest boots, and every stop path reaps it. Privileged Linux lane
       run on a KVM host (6/6, live forwarding witness, clean teardown); 23
       hermetic BDD scenarios in `s25_l3_vsock`. macOS is capability-declared
-      and refuses; native Windows is not claimed.
+      and refuses; native Windows is not claimed. Follow-up issue #2186 now
+      closes the remaining launch-shape seam: every standing channel in
+      `VmmSpec` is identified by `GuestService`, the workload mapper emits the
+      typed L3 control/data channels, and `mvm-netd` receives the
+      backend-specific socket layout instead of assuming one convention.
+      The physical spec is also role-neutral: builder boots use the same typed
+      substitution channel and no longer carry a `trusted_builder` flag.
 
 - [~] Workload stream plane — 22 tasks, **Phase 1 complete, Phase 2 landed
       dormant**. Tracked in `specs/plans/295-workload-stream-plane.md` and

--- a/specs/notes/2026-07-28-plan-255-live-fc-spike-findings.md
+++ b/specs/notes/2026-07-28-plan-255-live-fc-spike-findings.md
@@ -65,10 +65,10 @@ this result.
 
 The live test boots a generic rootfs with no mvm guest agent, so it says nothing
 about whether a factory parent — no workload, therefore no egress relay wired,
-`trusted_builder: false` — survives the guest's egress gate. That risk is
+the typed substitution channel — survives the guest's egress gate. That risk is
 unchanged and cannot be spiked cheaply, because booting a real mvm parent *is*
 Task 2. The mitigation stands: if the gate refuses, wire the parent a minimal
-vsock egress port; never flip `trusted_builder`, which would disable the egress
+vsock egress port; do not reintroduce a role flag that could disable the egress
 gate on workload-bearing content.
 
 ## 4. The CLI exposes no checkpoint / pool / trust verbs

--- a/specs/plans/255-live-fc-warm-claim.md
+++ b/specs/plans/255-live-fc-warm-claim.md
@@ -34,7 +34,9 @@ Every task's requirements implicitly include this section.
 
 - **Reuse the existing restore machinery.** `capture_vm_full`, `FcForkRestorer::restore_fork`, and `guarded_load_resume` already work and are guarded. Call them. Do not write a second capture or restore path, and do not call the two still-refused entry points named above.
 - **No guest NIC, ever.** vsock is the sole boundary. `VmmSpec` has no NIC field — keep it that way. The no-NIC guard runs inside `guarded_load_resume`; never bypass it or restore without it.
-- **Never set `trusted_builder: true` on a workload-bearing VM.** It disables the claim-10 egress gate; it exists for the builder VM only.
+- **Do not encode builder or workload role in `VmmSpec`.** Every boot carries
+  the typed substitution channel; the builder runner owns its endpoint and a
+  workload runner owns its admitted relay.
 - **No competitor proper nouns** anywhere — code, comments, tests, commit messages, PR text, branch names.
 - **No spec references in code comments.** `Plan`, `ADR`, `#NNNN`, `W#`, `Phase N` are CI-gated by `xtask check-no-spec-refs`. Explain *why* in prose instead. (Files under `specs/` are exempt.)
 - **`#[allow(clippy::...)]` is banned outright**, including `too_many_arguments`. Use a params struct (the repo already uses `CaptureVmFullParams`, `ForkParams`, `WarmParams`, `ClaimContext` for exactly this).
@@ -214,7 +216,11 @@ git commit -m "feat(standby): carry the captured parent checkpoint on the standb
 **Two things the implementer must not miss:**
 
 1. **Do not kill the parent here.** `capture_vm_full` pauses, saves memory, and resumes a *live* VM. `FcDriver::boot` calls `firecracker_guard.defuse()`, so Firecracker keeps running after the returned `RunningVm` is dropped — that is intended. Task 4 releases the parent after capture.
-2. **A factory parent carries no workload, so it has no egress relay wired.** `trusted_builder` must stay `false`. If the guest's egress gate refuses to boot without a relay, wire the parent a minimal vsock egress port — do **not** flip `trusted_builder` to paper over it. Report which you needed.
+2. **A factory parent carries no workload, so it has no workload relay wired.**
+   It still carries the typed substitution channel required by every boot. If
+   the guest's egress gate refuses to boot without a relay, wire the parent a
+   minimal vsock egress port rather than weakening the gate. Report which you
+   needed.
 
 **Files:**
 - Modify: `crates/mvm-runtime/src/driver/traits.rs` (add `vm_full_control` with a fail-closed default)
@@ -245,7 +251,7 @@ pub struct VmmSpec {
     pub name: String, pub kernel: KernelImage, pub initramfs: Option<PathBuf>,
     pub cmdline: String, pub vcpus: u32, pub memory_mib: u32,
     pub mem_initial_mib: Option<u32>, pub blocks: Vec<BlockDev>,
-    pub vsock: Vec<VsockPort>, pub console: ConsoleCapture, pub trusted_builder: bool,
+    pub vsock: Vec<VsockPort>, pub console: ConsoleCapture,
 }
 ```
 
@@ -324,7 +330,6 @@ Add `vm_full_control` to `VmmDriver` in `driver/traits.rs` with the `None` defau
             console: ConsoleCapture {
                 log_path: PathBuf::from(&spec.vm_state_dir).join("console.log"),
             },
-            trusted_builder: false,
         };
 
         // `boot` returns only once the guest agent answered over vsock, so the
@@ -1159,7 +1164,10 @@ The parent must boot **identically to a workload**: same drives, same verity and
 
 Where the seam lands is your judgment; state your choice and reasoning in your report. Two shapes worth weighing: populate the standby spec CLI-side from a real `VmStartConfig` that has been through the overlay pipeline, or hoist the parent spawn itself to the CLI layer so it reuses that pipeline directly. Whichever you pick, a future change to the workload's boot shape must not silently diverge the parent's — say in your report how your choice achieves that.
 
-Keep the existing guarantees intact: no guest NIC, `trusted_builder: false`, `template_id` propagated, the parent left running for capture, and no plan/endpoint/broker on a factory parent (that is the structural never-promote property).
+Keep the existing guarantees intact: no guest NIC, a typed substitution
+channel, `template_id` propagated, the parent left running for capture, and no
+plan/endpoint/broker on a factory parent (that is the structural never-promote
+property).
 
 **Seam as landed.** The parent's boot inputs are derived in the role layer, from
 the launch config the CLI already ran through `attach_runtime_overlay_if_cached`:

--- a/specs/plans/285-l3-tun-over-vsock.md
+++ b/specs/plans/285-l3-tun-over-vsock.md
@@ -203,6 +203,17 @@ Read ADR-036 first; this plan is the sequencing and the checkbox ledger.
       any backend that does not advertise both `l3_vsock` and
       `no_routable_guest_nic`
 - [x] launch-path audit recorded in ADR-036 §"Launch-path convergence"
+- [x] workload launch mapping carries `GuestService::NetworkControl` and
+      `GuestService::NetworkData { queue: 0 }` into the backend-neutral
+      `VmmSpec`; `mvm-netd` selects the matching Firecracker/libkrun or HVF
+      socket-directory layout from the selected backend
+- [x] `VmmSpec::vsock` identifies every standing channel by `GuestService`;
+      numeric vsock ports are derived only at the VMM transport boundary,
+      including the dynamic dev-console data channels
+- [x] `VmmSpec` no longer carries builder-role policy; every boot, including
+      builder boots, requires the typed `GuestService::Substitution` channel,
+      while the builder endpoint remains owned by the builder runner above the
+      VMM driver seam
 - [x] macOS: `MacosUserspaceGateway` declares its intended capabilities and
       refuses until implemented
 - [x] platform matrix (Linux / macOS / WSL2 / native Windows) documented


### PR DESCRIPTION
## Summary

- Replace numeric/stringly VMM channel construction with typed `GuestService` bindings.
- Wire L3 control/data channels through workload specs and backend-specific netd socket layouts.
- Remove the role-bearing `trusted_builder` field from `VmmSpec`; every boot now requires the typed substitution channel and HVF fails closed when it is absent.
- Keep builder endpoint startup and netd policy above the VMM driver seam.

## Validation

- `cargo test -p mvm-runtime --lib -- --test-threads=1`
- `cargo test -p mvm-conformance -- --test-threads=1`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --quiet -- --test-threads=1`

All passed; live/KVM-gated tests remain ignored as designed.

Closes #2186