### PR TITLE
Clean mvm cache with just clean

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,6 +2837,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "blake3",
+ "clap",
  "cucumber",
  "ed25519-dalek",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,7 +233,12 @@ thiserror = "2"
 toml = "0.8"
 
 # CLI
-clap = { version = "4", default-features = false, features = ["derive", "help", "std", "usage"] }
+clap = { version = "4", default-features = false, features = [
+    "derive",
+    "help",
+    "std",
+    "usage",
+] }
 clap_mangen = "0.2"
 
 # HTTP client (for CLI upgrade)

--- a/Justfile
+++ b/Justfile
@@ -490,9 +490,10 @@ setup-libkrun:
 
 # ── Utilities ────────────────────────────────────────────────────────────
 
-# Clean build artifacts
+# Clean build artifacts and the regenerable mvm cache
 clean:
     cargo clean
+    cargo run --quiet -- env cleanup --cache --yes
 
 # Reap leaked host-side helper subprocesses (broker/host-agent/signer/etc.)
 # older than N minutes (default 30). Backstop for the in-binary parent-death

--- a/crates/mvm-cli/src/commands/env/cleanup.rs
+++ b/crates/mvm-cli/src/commands/env/cleanup.rs
@@ -215,7 +215,10 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resul
             return Ok(());
         }
 
-        let exec = execute_plan(&plan)?;
+        let spinner = ui::spinner("Cleaning mvm cache...");
+        let exec_result = execute_plan(&plan);
+        spinner.finish_and_clear();
+        let exec = exec_result?;
         ui::success(&format!(
             "Cleanup tier {}: removed {} path(s), freed {}",
             t.name(),

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -32,7 +32,8 @@ pub(in crate::commands) use build::ir_input::load_ir_json_workload;
 mod tests;
 
 use anyhow::Result;
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::error::ErrorKind;
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use std::sync::Arc;
 
 use crate::logging::{self, LogFormat};
@@ -41,7 +42,12 @@ use dispatch::TopLevelCommand;
 use shared::{CHILD_PIDS, IN_CONSOLE_MODE, with_hints};
 
 #[derive(Parser, Debug, Clone)]
-#[command(name = "mvmctl", version, about = "Lightweight VM development tool")]
+#[command(
+    name = "mvmctl",
+    version,
+    about = "Lightweight VM development tool",
+    term_width = 80
+)]
 pub(in crate::commands) struct Cli {
     /// Output format
     #[arg(long, global = true)]
@@ -205,12 +211,25 @@ pub(in crate::commands) enum Commands {
 /// Used by the `xtask` crate to generate man pages without duplicating the
 /// command definition.
 pub fn cli_command() -> clap::Command {
-    Cli::command()
+    constrain_help_width(Cli::command())
 }
 
 pub fn run() -> Result<()> {
     let _ = rustls::crypto::ring::default_provider().install_default();
-    let cli = Cli::parse();
+    let cli = match cli_command().try_get_matches_from(std::env::args_os()) {
+        Ok(matches) => Cli::from_arg_matches(&matches)
+            .expect("generated CLI arguments must convert into the typed command"),
+        Err(error)
+            if matches!(
+                error.kind(),
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
+            ) =>
+        {
+            print!("{}", constrain_help_output(&error.to_string()));
+            return Ok(());
+        }
+        Err(error) => error.exit(),
+    };
     apply_startup_env(&cli);
     register_inhouse_builder();
     register_stream_plane();
@@ -237,6 +256,109 @@ pub fn run() -> Result<()> {
     cmd_audit::emit_cmd_outcome(cmd_recorder.as_ref(), verb, &result);
 
     with_hints(result)
+}
+
+fn constrain_help_width(command: clap::Command) -> clap::Command {
+    let mut command = command.term_width(80).max_term_width(80);
+    if let Some(usage) = command
+        .clone()
+        .render_help()
+        .to_string()
+        .lines()
+        .find(|line| line.starts_with("Usage:"))
+        && usage.chars().count() > 80
+    {
+        command = command.override_usage(wrap_usage(usage));
+    }
+    command.mut_subcommands(constrain_help_width)
+}
+
+fn wrap_usage(usage: &str) -> String {
+    let body = usage.strip_prefix("Usage: ").unwrap_or(usage);
+    let continuation_indent = "       ";
+    let line_limit = 80 - continuation_indent.chars().count();
+    let mut wrapped = String::new();
+    let mut line_width = 0;
+
+    for word in body.split_whitespace() {
+        let word_width = word.chars().count();
+        let separator_width = usize::from(line_width > 0);
+        if line_width > 0 && line_width + separator_width + word_width > line_limit {
+            wrapped.push('\n');
+            wrapped.push_str(continuation_indent);
+            line_width = continuation_indent.chars().count();
+        }
+        if line_width > continuation_indent.chars().count() {
+            wrapped.push(' ');
+            line_width += 1;
+        }
+        wrapped.push_str(word);
+        line_width += word_width;
+    }
+    wrapped
+}
+
+fn constrain_help_output(help: &str) -> String {
+    let trailing_newline = help.ends_with('\n');
+    let mut constrained = help
+        .lines()
+        .map(|line| wrap_help_line(line, 80))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if trailing_newline {
+        constrained.push('\n');
+    }
+    constrained
+}
+
+fn wrap_help_line(line: &str, width: usize) -> String {
+    if line.chars().count() <= width {
+        return line.to_owned();
+    }
+
+    let indentation = line
+        .chars()
+        .take_while(|character| character.is_whitespace())
+        .count();
+    let prefix = &line[..line.len() - line.trim_start().len()];
+    let continuation = if line.trim_start().starts_with("Usage:") {
+        "       "
+    } else {
+        prefix
+    };
+    let mut current = String::new();
+    let mut current_limit = width.saturating_sub(indentation);
+    let mut wrapped = Vec::new();
+
+    for word in line.split_whitespace() {
+        let word_width = word.chars().count();
+        if current.is_empty() {
+            current.push_str(word);
+        } else if current.chars().count() + 1 + word_width <= current_limit {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            wrapped.push(current);
+            current = word.to_owned();
+            current_limit = width.saturating_sub(continuation.chars().count());
+        }
+    }
+    if !current.is_empty() {
+        wrapped.push(current);
+    }
+
+    wrapped
+        .into_iter()
+        .enumerate()
+        .map(|(index, text)| {
+            if index == 0 {
+                format!("{prefix}{text}")
+            } else {
+                format!("{continuation}{text}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Set a process-global environment variable from the CLI.

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -6,6 +6,17 @@ use super::*;
 use clap::Parser;
 use std::path::Path;
 
+#[test]
+fn help_output_wraps_long_lines() {
+    let help =
+        "  command  A long description that must wrap before it exceeds the fixed output width";
+    let wrapped = constrain_help_output(help);
+
+    assert!(wrapped.lines().all(|line| line.chars().count() <= 80));
+    assert!(wrapped.lines().count() > 1);
+    assert!(wrapped.contains("\n  "));
+}
+
 // Group module aliases — give tests short names (`cleanup`, `up`, etc.) that
 // follow the dispatcher's naming, regardless of which group they live in.
 use super::build::build;

--- a/crates/mvm-conformance/Cargo.toml
+++ b/crates/mvm-conformance/Cargo.toml
@@ -34,6 +34,9 @@ tokio.workspace = true
 # through a crate rename as long as the produced binary is still named
 # `mvmctl`.
 assert_cmd.workspace = true
+# Inspects the generated command tree so the BDD help-width check covers every
+# visible and hidden subcommand, rather than maintaining a second command list.
+clap.workspace = true
 # Parses the `build address --json` report in the workload-identity steps.
 # Dev-only: `cargo tree -p mvm-conformance -e no-dev` must not gain it.
 serde_json.workspace = true

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -407,3 +407,50 @@ fn help_options_fit_within(world: &mut CliWorld, width: i64) {
         );
     }
 }
+
+#[then(expr = "every mvmctl subcommand help fits within {int} columns")]
+fn every_subcommand_help_fits_within(_world: &mut CliWorld, width: i64) {
+    let mut command_paths = Vec::new();
+    collect_command_paths(&mvm_cli::commands::cli_command(), &[], &mut command_paths);
+
+    for path in command_paths {
+        let mut args = path.clone();
+        args.push("--help".to_string());
+        let output = mvmctl_command()
+            .args(&args)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to run `mvmctl {}`: {e}", args.join(" ")));
+        assert!(
+            output.status.success(),
+            "`mvmctl {}` failed:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let help = String::from_utf8_lossy(&output.stdout);
+        for (line_number, line) in help.lines().enumerate() {
+            let line_width = i64::try_from(line.chars().count()).expect("line width fits in i64");
+            assert!(
+                line_width <= width,
+                "`mvmctl {}` line {} exceeds {width} columns ({}):\n{}",
+                args.join(" "),
+                line_number + 1,
+                line_width,
+                help
+            );
+        }
+    }
+}
+
+fn collect_command_paths(
+    command: &clap::Command,
+    prefix: &[String],
+    command_paths: &mut Vec<Vec<String>>,
+) {
+    for subcommand in command.get_subcommands() {
+        let mut child = prefix.to_vec();
+        child.push(subcommand.get_name().to_string());
+        command_paths.push(child.clone());
+        collect_command_paths(subcommand, &child, command_paths);
+    }
+}

--- a/features/suites/s0_cli/verbs.feature
+++ b/features/suites/s0_cli/verbs.feature
@@ -31,3 +31,6 @@ Feature: mvmctl top-level CLI surface
     And the help output contains "Record check interval in seconds (not yet enforced)"
     But the help output does not contain "Mutually exclusive with"
     And the help output does not contain "production-safe call surface"
+
+  Scenario: every CLI subcommand help fits within 80 columns
+    Then every mvmctl subcommand help fits within 80 columns

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -114,6 +114,7 @@ guest-RPC surface, fleet-shaped workflows).
 | `mvmctl env cleanup --all` | Remove all cached build revisions |
 | `mvmctl env cleanup --keep <N>` | Keep the N newest build revisions |
 | `mvmctl env cleanup --verbose` | Print each cached build path that gets removed |
+| `mvmctl env cleanup --cache` | Remove the regenerable `~/.mvm/cache` |
 
 ## Manifests
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1286,6 +1286,9 @@ Then unify + retire the old paths:
 
 - [ ] Redesign to a small, discoverable verb set; `env` shown in `--help`.
 - [ ] Merge `setup`/`bootstrap` into one first-run `bootstrap`. Add the lifecycle verbs: **`upgrade`** (self-update `mvmctl`); **`uninstall`** (remove everything — the binary, `~/.mvm`, and installed host/guest artifacts); **`env cleanup`** (reclaim `~/.mvm` — caches + transient VM/build state, keeping config + keys); **`env reset`** (wipe `~/.mvm` back to a clean slate). These replace the fragmented `cache prune` / `pack prune` / `storage gc`. `env` becomes a visible top-level subcommand (today `hide = true`).
+- [x] `just clean` now removes build artifacts and the regenerable `~/.mvm/cache`
+      through `mvmctl env cleanup --cache`; cache cleanup shows progress, and
+      BDD coverage verifies every subcommand's help stays within 80 columns.
 - [ ] Replace the 31-arm dispatch `match` with a `Command` trait (`fn run(&self, ctx: &Cli) -> Result<()>`); one module per command; every command calls `mvm-client`.
 - [x] ~~`mvmctl serve` exposes the agent-facing server behind an `AgentProtocol` trait~~ — descoped. The MCP server was removed outright; no agent-protocol server surface remains.
 - [ ] Remove hidden/duplicate/dead verbs.


### PR DESCRIPTION
## Summary

- Make `just clean` run both `cargo clean` and `mvmctl env cleanup --cache --yes`.
- Show a spinner while the cache sweep is running.
- Constrain all subcommand help, including usage lines, to 80 columns.
- Add recursive BDD coverage for every CLI subcommand and document the cache cleanup path.

## Validation

- `cargo fmt --all -- --check`
- Pre-commit `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check -p mvmctl --bin mvmctl`
- `cargo check -p mvm-conformance --test conformance --features bdd`
- `just --dry-run clean`
- `cargo test --workspace` was started but the environment terminated the long-running process before completion.
