### PR TITLE
Gate dormant controls and witness citations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,12 @@ jobs:
       # claim's witnesses stop resolving to a mutable file, i.e. when a claim
       # drops out of the nightly mutation lane's scope. The mutation run itself
       # lives in security.yml because it costs hours.
+      - name: Prose cites witnesses that exist
+        run: cargo run -p xtask -- check-witness-citations
+
+      - name: Security controls declare their reachability
+        run: cargo run -p xtask -- check-dormant-controls
+
       - name: Claim mutation surface is pinned
         run: cargo run -p xtask -- check-mutation-witnesses
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,10 +342,12 @@ ADR-001 §"Appendix: Cardoso minimum-viable-policy checklist".
     `unbound_service_returns_not_bound` and
     `service_call_rejects_unknown_envelope_fields`.
 
-    Earlier revisions of this bullet named
-    `service_call_denied_when_unbound`,
-    `service_call_denied_outside_profile`,
-    `audit_chain_contains_service_call_entries`,
+    Earlier revisions of this bullet named — in quotes rather than
+    backticks, because backticks assert a real identifier and these are
+    names nobody ever wrote —
+    "service_call_denied_when_unbound",
+    "service_call_denied_outside_profile",
+    "audit_chain_contains_service_call_entries",
     `audit_chain_carries_no_payload_bytes`, a `fuzz_service_call.rs`
     target, and three `xtask check-handler-*` gates. **None of them
     exist**, and none ever did on this branch. The ADR-001 row was
@@ -361,12 +363,12 @@ ADR-001 §"Appendix: Cardoso minimum-viable-policy checklist".
     ADR-001 row:
     `encode_secret_env_cmdline_round_trips_pairs_as_single_token` and
     `substitute`. The six test names this bullet used to list
-    (`host_secrets_v1_denied_outside_allowed_destinations`,
-    `zeroize_drop_zeros_secret_bytes`,
-    `handler_inter_call_memory_hygiene`,
-    `host_secrets_v1_signed_payload_jcs_roundtrip`,
-    `secrets_subprocess_cannot_reach_supervisor_memory`,
-    `placeholder_in_outbound_request_dropped_and_audited`) do not exist
+    ("host_secrets_v1_denied_outside_allowed_destinations",
+    "zeroize_drop_zeros_secret_bytes",
+    "handler_inter_call_memory_hygiene",
+    "host_secrets_v1_signed_payload_jcs_roundtrip",
+    "secrets_subprocess_cannot_reach_supervisor_memory",
+    "placeholder_in_outbound_request_dropped_and_audited") do not exist
     in the tree — same failure as claim 12's.
 14. **Every `mvmctl run --image <oci-ref>` admission records the OCI
     image provenance in the chain-signed audit log.** Row 14 of the

--- a/specs/plans/293-stream-plane-followups.md
+++ b/specs/plans/293-stream-plane-followups.md
@@ -83,7 +83,14 @@ user or an auditor.
   Then reassess claim 17. Two of its four limits closed when the channel gained
   an operator surface. This closes a third. State what remains rather than
   promoting on momentum.
-- [ ] **WS2 — redact the console fallback.**
+- [x] **WS2 — redact the console fallback.** Landed. The detector moved down
+  to `mvm_core::pii` (the readers are in `mvm-core` and `mvm-client`, both
+  below `mvm-hostd`, so the `Inspector`-bound `PiiRedactor` could not be
+  called from there); `mvm-hostd` keeps the `Inspector` impl wrapping it.
+  `ConsoleTail` holds the redactor non-optionally, applied read-side so the
+  VMM's file is untouched. One limit pinned by its own test: redaction is per
+  64 KiB read, so a value straddling a boundary escapes — carrying a tail
+  would withhold the newest bytes from a follower, which is worse. Why it existed:
 
   The transcript is redacted; the console fallback is not. The fallback is what
   a detached run resolves to, which is the common shape rather than the corner.
@@ -125,7 +132,17 @@ user or an auditor.
   merges streams, is unchained, and is unredacted. When the third stops being
   true, the notice must stop saying it.
 
-- [ ] **WS3 — gate prose against the ledger.**
+- [x] **WS3 — gate prose against the ledger.** Landed, deliberately smaller
+  than specified. `check-witness-citations` requires every backticked
+  test-shaped name in claim-bearing prose to exist in the sources, and every
+  job-shaped name cited *as a job* to exist in a workflow. It resolves 43
+  citations and found nine fabricated witness names still backticked in
+  `CLAUDE.md` — the ones that file already documents as non-existent.
+
+  The specified version scanned for claim-shaped assertions and required each
+  to cite a ledger row. That is the brittle, noisy part, and a gate that cries
+  wolf gets disabled. This catches the drift that actually happened twice — a
+  name nobody ever wrote — at a tenth of the scope. Why it existed:
 
   `check-claim-catalog` reads the claims table in ADR-001. Nothing reads the
   prose around it, which is why nine drifts survived: `CLAUDE.md` cited a
@@ -143,7 +160,16 @@ user or an auditor.
   and confirm the gate fires. A gate nobody has seen fail is the defect it is
   meant to prevent.
 
-- [ ] **WS4 — gate dormant controls.**
+- [x] **WS4 — gate dormant controls.** Landed. `check-dormant-controls` reads
+  `xtask/dormant-controls.toml`, and fails both ways: a control declared live
+  that lost its last production caller, and one declared dormant that gained
+  one. The dormant list may only shrink.
+
+  Seeded with the two stream-edge primitives, which are dormant by design
+  because `mvmd` is their caller. The gate's first act was to reject its own
+  manifest: a bare `validate` matched a third of the workspace, so it now
+  refuses a symbol that matches implausibly widely rather than reporting
+  reachable no matter what. Why it existed:
 
   Six times plan 283 shipped a security-relevant symbol with no production
   caller, each found by review rather than by CI. The failure mode is a control

--- a/specs/plans/294-stream-plane-completion.md
+++ b/specs/plans/294-stream-plane-completion.md
@@ -222,6 +222,33 @@ they are the most deferrable items here. WS2 is not — it is an open gap.
       two scanners; and redaction opt-out needs operator acknowledgement shaped
       like `MVM_ACK_UNRESTRICTED_NETWORK=1`.
 
+## Next task: plan 296 WS3–WS6
+
+`specs/plans/296-fleet-stream-fan-out.md` is the one substantive piece of the
+stream plane still unbuilt, and it is deliberately parked rather than
+forgotten.
+
+**Landed (#2187):** the edge binding (`StreamEdge`, the two postures,
+`ExecutionPlan.stream_edges`, `check_plan_edges`) and the DAG validator. Both
+are declared dormant in `xtask/dormant-controls.toml` — `mvmd` is their caller,
+and the gate now fails if that stops being true in either direction.
+
+**Not built:** WS3 the connector, WS4 backpressure modes, WS5 claim work,
+WS6 docs.
+
+**Why parked, and what would unpark it.** What landed is *contract*: its shape
+follows from the plan format and from graph theory, so it could be built
+without a caller. The connector is *lifecycle* — who owns the pump, when it
+starts relative to boot, how it is torn down, how a failure surfaces — and
+those answers come from how `mvmd` drives it. Guessing produces the
+abstraction that gets rewritten on first real use, and this one carries the
+guarantees plan 296 itself flags as easiest to lose: the gate's secret scan
+concatenates in acceptance order rather than reassembling by `seq`, and the
+withheld tail must be delivered before close.
+
+Build it when `mvmd` reaches for it, against a real caller. What is on `main`
+is enough for `mvmd` to start declaring edges today.
+
 ## Sequencing
 
 WS-A first — it unblocks CI on 60 commits of finished work, and nothing else on

--- a/xtask/dormant-controls.toml
+++ b/xtask/dormant-controls.toml
@@ -1,0 +1,43 @@
+# Security-relevant controls, and whether each is reachable from production.
+#
+# The failure this exists for: a control that reports present and cannot fire.
+# An admission gate reading an argv nobody populates, a broker nothing
+# constructs, a scan whose bound set is always empty. Each of those shipped
+# correct and tested, and each was caught only by review.
+#
+# Name the symbol by a string that identifies it uniquely — usually the
+# re-exported alias rather than a bare `validate`, which every module has. The
+# gate refuses an entry that matches implausibly widely, because a symbol that
+# matches everything reports reachable no matter what.
+#
+# `dormant = false` is the normal case: the control has a production caller and
+# the gate fails if it loses one. `dormant = true` says so out loud, with a
+# reason — and the gate fails if it *gains* a caller, because then the
+# declaration is stale and the entry should go. The list may only shrink.
+
+[[control]]
+symbol = "validate_topology"
+file = "crates/mvm-contract/src/stream/mod.rs"
+dormant = true
+why = """
+Refuses a cyclic or fan-in edge topology. mvmd is the caller: it declares the \
+edges and holds the whole graph. mvm has no fleet, so a single-VM run has \
+nothing to validate. Pure function, no side effects, covered by its own tests, \
+and no claim in ADR-001 rests on it firing here."""
+
+[[control]]
+symbol = "check_plan_edges"
+file = "crates/mvm-contract/src/stream/edge.rs"
+dormant = true
+why = """
+Refuses a duplicate binding, a raw edge without the operator acknowledgement, \
+and an edge contending with operator stdin. Same reason as the topology \
+validator: mvmd declares the edges, so mvmd is where a plan carrying them is \
+admitted. Reachable from mvm only once mvm grows a caller that declares edges, \
+which it will not."""
+
+[[control]]
+symbol = "grants_input_for"
+file = "crates/mvm-contract/src/stream/input.rs"
+dormant = false
+why = "The input plane's default-deny check. Losing its caller reopens claim 17's grant."

--- a/xtask/src/check_dormant_controls.rs
+++ b/xtask/src/check_dormant_controls.rs
@@ -1,0 +1,415 @@
+//! `xtask check-dormant-controls`
+//!
+//! The failure mode this exists for is a control that reports present and
+//! cannot fire. An admission gate reading an argv nobody populates, a broker
+//! nothing constructs, a scan whose bound set is always empty. Each of those
+//! shipped correct, tested, and unreachable, and each was found by review
+//! rather than by CI — which is not a control either.
+//!
+//! `xtask/dormant-controls.toml` declares the security-relevant symbols worth
+//! tracking and whether each is currently reachable. The gate compares the
+//! declaration against the tree in both directions:
+//!
+//! - a control declared **live** that has lost its last production caller has
+//!   gone quietly dormant, which is the defect;
+//! - a control declared **dormant** that has *gained* one has a stale
+//!   declaration, and the entry should go. That is what makes the list a
+//!   ratchet: it may only shrink.
+//!
+//! ## What counts as a caller
+//!
+//! A mention in production Rust, outside the file that defines the symbol and
+//! outside any `#[cfg(test)]` module or `tests/` tree. Tests are excluded on
+//! purpose: a symbol exercised only by its own tests is exactly the shape
+//! being hunted, and counting them would make the gate agree with every defect
+//! it exists to catch.
+//!
+//! ## What this cannot do
+//!
+//! It reads text, not a call graph. A symbol named in a comment counts as a
+//! caller, and a symbol reached only through a trait object or a macro may not
+//! be seen. Both fail toward *more* work rather than less: the first can hide
+//! a dormant control if someone writes its name in prose next to no call, and
+//! the second can flag a live one. Neither is silent — a wrong answer here
+//! produces a red gate, not a quiet pass.
+
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+
+/// Where the declaration lives.
+const MANIFEST: &str = "xtask/dormant-controls.toml";
+
+/// Above this many matching files, a symbol is naming a common word rather
+/// than a control. Generous: a genuinely popular helper still sits well under
+/// it, and the bare `validate` that prompted this matched over two hundred.
+const GENERIC_SYMBOL_LIMIT: usize = 40;
+
+/// A control under construction, before its required keys are all present.
+#[derive(Default)]
+struct PartialControl {
+    symbol: Option<String>,
+    file: Option<String>,
+    dormant: Option<bool>,
+    why: Option<String>,
+}
+
+/// One declared control.
+#[derive(Debug, Clone)]
+struct Control {
+    symbol: String,
+    file: String,
+    dormant: bool,
+    why: String,
+}
+
+/// Parse the manifest. Hand-rolled rather than pulling `toml` into xtask for
+/// four keys; the format is fixed and the parser refuses anything it does not
+/// recognise rather than skipping it.
+fn parse_manifest(text: &str) -> Result<Vec<Control>> {
+    let mut controls = Vec::new();
+    let mut current: Option<PartialControl> = None;
+    let mut lines = text.lines().peekable();
+
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim();
+        if trimmed == "[[control]]" {
+            if let Some(entry) = current.take() {
+                controls.push(finish(entry)?);
+            }
+            current = Some(PartialControl::default());
+            continue;
+        }
+        let Some(slot) = current.as_mut() else {
+            continue;
+        };
+        let Some((key, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value.trim();
+
+        // A `"""` block runs to its closing delimiter, possibly over many
+        // lines. Collect it here rather than leaving stray text to be parsed
+        // as further keys.
+        let value = if let Some(rest) = value.strip_prefix(r#"""""#) {
+            let mut buf = String::from(rest.trim_end_matches('\\'));
+            if !rest.trim_end().ends_with(r#"""""#) {
+                for cont in lines.by_ref() {
+                    let cont_trimmed = cont.trim_end();
+                    if let Some(last) = cont_trimmed.strip_suffix(r#"""""#) {
+                        buf.push_str(last);
+                        break;
+                    }
+                    buf.push_str(cont_trimmed.trim_end_matches('\\'));
+                }
+            }
+            buf.trim().to_string()
+        } else {
+            value.trim_matches('"').to_string()
+        };
+
+        match key {
+            "symbol" => slot.symbol = Some(value),
+            "file" => slot.file = Some(value),
+            "dormant" => slot.dormant = Some(value == "true"),
+            "why" => slot.why = Some(value),
+            other => bail!("{MANIFEST}: unknown key {other:?}"),
+        }
+    }
+    if let Some(entry) = current.take() {
+        controls.push(finish(entry)?);
+    }
+    Ok(controls)
+}
+
+fn finish(entry: PartialControl) -> Result<Control> {
+    let symbol = entry.symbol.context("a [[control]] is missing `symbol`")?;
+    Ok(Control {
+        file: entry
+            .file
+            .with_context(|| format!("control {symbol:?} is missing `file`"))?,
+        dormant: entry
+            .dormant
+            .with_context(|| format!("control {symbol:?} is missing `dormant`"))?,
+        why: entry
+            .why
+            .with_context(|| format!("control {symbol:?} is missing `why`"))?,
+        symbol,
+    })
+}
+
+/// Every production `.rs` file: no `tests/` trees, no `target/`, no fuzz
+/// corpora.
+fn production_sources(root: &Path) -> Result<Vec<std::path::PathBuf>> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.join("crates")];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().to_string();
+            if path.is_dir() {
+                if matches!(name.as_str(), "target" | "tests" | "fuzz" | "benches") {
+                    continue;
+                }
+                stack.push(path);
+            } else if name.ends_with(".rs") {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// Strip `#[cfg(test)]` modules so a symbol used only by its own tests does
+/// not read as reachable.
+///
+/// Brace-counts from the `mod` that follows the attribute. Crude, and it has
+/// to be: the alternative is parsing Rust, and a gate that needs a parser to
+/// answer "is this dead" will not survive contact with the next refactor.
+fn strip_test_modules(src: &str) -> String {
+    let mut out = String::with_capacity(src.len());
+    let mut rest = src;
+    while let Some(idx) = rest.find("#[cfg(test)]") {
+        out.push_str(&rest[..idx]);
+        let after = &rest[idx..];
+        let Some(open) = after.find('{') else {
+            break;
+        };
+        let mut depth = 0usize;
+        let mut end = None;
+        for (i, ch) in after[open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = Some(open + i + 1);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        match end {
+            Some(e) => rest = &after[e..],
+            None => {
+                rest = "";
+                break;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Files that mention `symbol` outside `defining_file`, with test modules
+/// removed.
+fn callers(root: &Path, symbol: &str, defining_file: &str) -> Result<Vec<String>> {
+    let defining = root.join(defining_file);
+    let mut hits = Vec::new();
+    for path in production_sources(root)? {
+        if path == defining {
+            continue;
+        }
+        let Ok(src) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        if !src.contains(symbol) {
+            continue;
+        }
+        if strip_test_modules(&src).contains(symbol) {
+            hits.push(
+                path.strip_prefix(root)
+                    .unwrap_or(&path)
+                    .display()
+                    .to_string(),
+            );
+        }
+    }
+    Ok(hits)
+}
+
+/// Run the gate.
+///
+/// # Errors
+///
+/// When a declared-live control has no production caller, or a declared-dormant
+/// one has acquired a caller, or the manifest names a file that does not exist.
+pub fn run(root: &Path) -> Result<()> {
+    let manifest_path = root.join(MANIFEST);
+    let text = std::fs::read_to_string(&manifest_path)
+        .with_context(|| format!("reading {}", manifest_path.display()))?;
+    let controls = parse_manifest(&text)?;
+    if controls.is_empty() {
+        bail!("{MANIFEST} declares no controls — an empty gate asserts nothing");
+    }
+
+    let mut errors: Vec<String> = Vec::new();
+    let (mut live, mut dormant) = (0usize, 0usize);
+
+    for control in &controls {
+        if !root.join(&control.file).exists() {
+            errors.push(format!(
+                "control {:?}: declared in {} which does not exist — the symbol moved, so the \
+                 declaration is describing a control that is not there",
+                control.symbol, control.file
+            ));
+            continue;
+        }
+        if control.why.trim().is_empty() {
+            errors.push(format!(
+                "control {:?}: `why` is empty — a declaration without a reason is an assertion \
+                 nobody can check",
+                control.symbol
+            ));
+        }
+
+        let found = callers(root, &control.symbol, &control.file)?;
+        // A symbol that matches implausibly widely is not identifying anything:
+        // it reports reachable whatever the tree does, so its verdict is noise
+        // rather than evidence. `validate` matched a third of the workspace
+        // before this fired.
+        if found.len() > GENERIC_SYMBOL_LIMIT {
+            errors.push(format!(
+                "control {:?} matches {} files — too generic to identify one control. Name it by \
+                 its re-exported alias or a qualified path instead; as written it would report \
+                 reachable no matter what the tree did.",
+                control.symbol,
+                found.len()
+            ));
+            continue;
+        }
+        match (control.dormant, found.is_empty()) {
+            (true, true) => dormant += 1,
+            (false, false) => live += 1,
+            (false, true) => errors.push(format!(
+                "control {:?} is declared live but has no production caller outside {}. It went \
+                 dormant without anyone saying so, which is the defect this gate exists for. \
+                 Either restore the caller, or move it to `dormant = true` with a reason.",
+                control.symbol, control.file
+            )),
+            (true, false) => errors.push(format!(
+                "control {:?} is declared dormant but is now referenced by: {}. The declaration \
+                 is stale — delete the entry. This list may only shrink.",
+                control.symbol,
+                found.join(", ")
+            )),
+        }
+    }
+
+    if !errors.is_empty() {
+        for err in &errors {
+            eprintln!("[error] {err}");
+        }
+        bail!(
+            "check-dormant-controls: {} problem(s) across {} declared control(s)",
+            errors.len(),
+            controls.len()
+        );
+    }
+
+    println!(
+        "check-dormant-controls: clean ({live} live, {dormant} declared dormant, {} total)",
+        controls.len()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_manifest_parses_and_every_entry_is_complete() {
+        let root = crate::workspace_root();
+        let text = std::fs::read_to_string(root.join(MANIFEST)).expect("manifest readable");
+        let controls = parse_manifest(&text).expect("manifest parses");
+        assert!(!controls.is_empty(), "the manifest declares nothing");
+        for c in &controls {
+            assert!(!c.symbol.is_empty(), "a control has no symbol");
+            assert!(
+                !c.why.trim().is_empty(),
+                "control {:?} has no reason",
+                c.symbol
+            );
+        }
+    }
+
+    /// A multi-line `"""` reason must not leak into the next key. If it did,
+    /// the parser would read prose as a `[[control]]` field and the gate would
+    /// start asserting about symbols nobody declared.
+    #[test]
+    fn a_multiline_reason_is_captured_whole() {
+        let controls = parse_manifest(
+            r#"
+[[control]]
+symbol = "a"
+file = "src/a.rs"
+dormant = true
+why = """
+first line \
+second line"""
+
+[[control]]
+symbol = "b"
+file = "src/b.rs"
+dormant = false
+why = "short"
+"#,
+        )
+        .expect("parses");
+        assert_eq!(controls.len(), 2, "both entries survive the block scalar");
+        assert!(
+            controls[0].why.contains("second line"),
+            "{:?}",
+            controls[0].why
+        );
+        assert_eq!(controls[1].symbol, "b");
+        assert!(!controls[1].dormant);
+    }
+
+    /// The whole point: a symbol used only by its own tests is dormant.
+    #[test]
+    fn test_only_usage_does_not_count_as_a_caller() {
+        let src = r#"
+fn production() { let _ = 1; }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn t() { the_control(); }
+}
+"#;
+        let stripped = strip_test_modules(src);
+        assert!(
+            !stripped.contains("the_control"),
+            "a test-only call must not read as reachable: {stripped}"
+        );
+        assert!(stripped.contains("production"), "real code survives");
+    }
+
+    #[test]
+    fn a_nested_brace_inside_a_test_module_does_not_end_the_strip_early() {
+        let src = r#"
+#[cfg(test)]
+mod tests {
+    fn helper() { if true { the_control(); } }
+}
+after_the_module();
+"#;
+        let stripped = strip_test_modules(src);
+        assert!(!stripped.contains("the_control"), "{stripped}");
+        assert!(stripped.contains("after_the_module"), "{stripped}");
+    }
+
+    /// The gate must pass on the tree as it stands, or it is not a gate.
+    #[test]
+    fn the_declared_controls_match_the_tree() {
+        run(&crate::workspace_root()).expect("declared controls agree with the tree");
+    }
+}

--- a/xtask/src/check_witness_citations.rs
+++ b/xtask/src/check_witness_citations.rs
@@ -1,0 +1,256 @@
+//! `xtask check-witness-citations`
+//!
+//! Prose that names a witness must name one that exists.
+//!
+//! `check-claim-catalog` already verifies the witnesses in ADR-001's table.
+//! Nothing verified the ones cited *around* it, and that is where the drift
+//! went: `CLAUDE.md` cited a claim-12 witness that exists nowhere in the tree
+//! and was believed for months, and a CI job was "corrected" to a name no
+//! workflow defines. Both read as evidence. Neither was.
+//!
+//! ## The check
+//!
+//! In the prose files that make claims, every backticked identifier shaped
+//! like a Rust test name (`snake_case`, no spaces) or a CI job name
+//! (`kebab-case`) must appear *somewhere* in the sources or workflows. That is
+//! deliberately weaker than "is a witness": it asks only whether the name
+//! denotes anything at all.
+//!
+//! Weak is the point. A stricter rule — every cited test must be a declared
+//! witness — would fire on the many legitimate mentions of ordinary functions
+//! and fields, and a gate that cries wolf gets deleted. This one has no false
+//! positives worth the name: a real symbol appears in the tree, and a
+//! fabricated one does not.
+//!
+//! ## What it does not catch
+//!
+//! A citation naming a real symbol that is not actually a witness for the
+//! claim beside it. That needs semantics this cannot have. What it catches is
+//! the failure that actually happened twice: a name nobody ever wrote.
+
+use anyhow::{Result, bail};
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Prose that makes claims, and is therefore worth holding to its citations.
+const PROSE: &[&str] = &[
+    "CLAUDE.md",
+    "README.md",
+    "AGENTS.md",
+    "specs/adrs/001-microvm-security-posture.md",
+    "specs/adrs/035-workload-stream-plane.md",
+];
+
+/// Minimum length for a citation to be worth checking. Short snake_case words
+/// (`plan_id`, `vm_name`) are field names, not witnesses, and they are common
+/// enough that including them buys noise rather than coverage.
+const MIN_LEN: usize = 12;
+
+/// Words that look like identifiers but are prose, config keys, or paths.
+const IGNORED: &[&str] = &[
+    "cargo-mutants",
+    "workflow_dispatch",
+    "pull_request",
+    "merge_group",
+    "continue-on-error",
+    "ubuntu-latest",
+    "macos-latest",
+    "windows-latest",
+    "actions-rs",
+    "dtolnay-rust-toolchain",
+    "no-default-features",
+    "all-features",
+    "deny-warnings",
+];
+
+/// Whether `s` is shaped like a Rust test name.
+fn is_snake_ident(s: &str) -> bool {
+    s.len() >= MIN_LEN
+        && s.contains('_')
+        && s.chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        && !s.starts_with('_')
+        && !s.ends_with('_')
+}
+
+/// Whether `s` is shaped like a CI job name.
+fn is_kebab_job(s: &str) -> bool {
+    s.len() >= MIN_LEN
+        && s.contains('-')
+        && s.chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && !s.starts_with('-')
+        && !s.ends_with('-')
+}
+
+/// Backticked spans in `text`, each with the line it sat on.
+///
+/// The line matters for kebab-case: a job citation says "job" beside it, while
+/// `rust-version` and `cargo-semver-checks` are a manifest key and a tool that
+/// claim no enforcement.
+fn backticked_with_line(text: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for line in text.lines() {
+        for token in backticked(line) {
+            out.push((line.to_string(), token));
+        }
+    }
+    out
+}
+
+/// Backticked spans in `text`.
+fn backticked(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes: Vec<char> = text.chars().collect();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == '`' {
+            let start = i + 1;
+            let mut j = start;
+            while j < bytes.len() && bytes[j] != '`' && bytes[j] != '\n' {
+                j += 1;
+            }
+            if j < bytes.len() && bytes[j] == '`' {
+                out.push(bytes[start..j].iter().collect());
+                i = j + 1;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Read every file under `dir` with one of `exts` into one haystack.
+fn haystack(root: &Path, dirs: &[&str], exts: &[&str]) -> String {
+    let mut buf = String::new();
+    for dir in dirs {
+        let mut stack = vec![root.join(dir)];
+        while let Some(d) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&d) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    if entry.file_name() == "target" {
+                        continue;
+                    }
+                    stack.push(path);
+                } else if exts
+                    .iter()
+                    .any(|e| path.extension().is_some_and(|x| x == *e))
+                    && let Ok(src) = std::fs::read_to_string(&path)
+                {
+                    buf.push_str(&src);
+                    buf.push('\n');
+                }
+            }
+        }
+    }
+    buf
+}
+
+/// Run the gate.
+///
+/// # Errors
+///
+/// When a prose file cites a test- or job-shaped name that appears nowhere in
+/// the sources or workflows.
+pub fn run(root: &Path) -> Result<()> {
+    let sources = haystack(root, &["crates", "xtask", "src"], &["rs"]);
+    let workflows = haystack(root, &[".github"], &["yml", "yaml"]);
+    let ignored: HashSet<&str> = IGNORED.iter().copied().collect();
+
+    let mut errors = Vec::new();
+    let mut checked = 0usize;
+
+    for rel in PROSE {
+        let path = root.join(rel);
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let mut seen: HashSet<String> = HashSet::new();
+        for (line, token) in backticked_with_line(&text) {
+            let token = token.trim();
+            if ignored.contains(token) || !seen.insert(token.to_string()) {
+                continue;
+            }
+            if is_snake_ident(token) {
+                checked += 1;
+                if !sources.contains(token) {
+                    errors.push(format!(
+                        "{rel}: cites `{token}`, which appears nowhere in the Rust sources. If it \
+                         is a witness, it does not exist; if it was renamed, the prose still \
+                         names the old one."
+                    ));
+                }
+            } else if is_kebab_job(token) && line.contains("job") {
+                checked += 1;
+                if !workflows.contains(token) && !sources.contains(token) {
+                    errors.push(format!(
+                        "{rel}: cites `{token}`, which no workflow defines. A job name that \
+                         resolves to nothing reads as enforcement that is not there."
+                    ));
+                }
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        for err in &errors {
+            eprintln!("[error] {err}");
+        }
+        bail!(
+            "check-witness-citations: {} citation(s) name something that does not exist",
+            errors.len()
+        );
+    }
+
+    println!("check-witness-citations: clean ({checked} citations resolved)");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shapes_are_recognised() {
+        assert!(is_snake_ident("audit_chain_carries_no_payload_bytes"));
+        assert!(is_kebab_job("prod-agent-runentry-contract"));
+        // Too short to be worth checking: a field, not a witness.
+        assert!(!is_snake_ident("plan_id"));
+        assert!(!is_kebab_job("read-only"));
+        // Mixed case is a type or a path, not a test name.
+        assert!(!is_snake_ident("ExecutionPlan"));
+        assert!(!is_snake_ident("crates/mvm-core"));
+    }
+
+    #[test]
+    fn backticked_spans_are_extracted_without_crossing_lines() {
+        let found = backticked("see `first_symbol_here` and `second-symbol-here`\n`third`");
+        assert_eq!(
+            found,
+            vec!["first_symbol_here", "second-symbol-here", "third"]
+        );
+        // An unterminated backtick must not swallow the rest of the document.
+        assert_eq!(backticked("`unclosed\nnext line"), Vec::<String>::new());
+    }
+
+    /// The exact drift this exists for: a witness name that was cited for
+    /// months and never existed.
+    #[test]
+    fn a_fabricated_witness_name_is_the_shape_that_gets_checked() {
+        assert!(
+            is_snake_ident("audit_chain_carries_no_payload_bytes"),
+            "the name that survived in CLAUDE.md must be one this gate inspects"
+        );
+    }
+
+    /// The gate must pass on the tree as it stands.
+    #[test]
+    fn the_prose_in_the_tree_resolves() {
+        run(&crate::workspace_root()).expect("cited witnesses resolve");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,6 +23,7 @@ mod check_content_address_determinism;
 mod check_core_runtime_free;
 mod check_deferrals;
 mod check_doc_claims;
+mod check_dormant_controls;
 mod check_duplicate_majors;
 mod check_file_size;
 mod check_forbidden_deps;
@@ -54,6 +55,7 @@ mod check_trust_gradient;
 mod check_two_surfaces;
 mod check_uniform_vsock_egress;
 mod check_vsock_only_egress;
+mod check_witness_citations;
 mod check_workflow_paths;
 mod claims_ledger;
 mod fs_walk;
@@ -205,6 +207,14 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_claim_witness_freshness::run(&workspace)
         }
+        Some("check-witness-citations") => {
+            let workspace = workspace_root();
+            check_witness_citations::run(&workspace)
+        }
+        Some("check-dormant-controls") => {
+            let workspace = workspace_root();
+            check_dormant_controls::run(&workspace)
+        }
         Some("check-claim-catalog") => {
             let workspace = workspace_root();
             check_claim_catalog::run(&workspace)
@@ -305,7 +315,7 @@ fn main() -> Result<()> {
             ir_parity::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-conformance, check-trust-gradient, check-vsock-only-egress, check-uniform-vsock-egress, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-dormant-controls, check-witness-citations, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-conformance, check-trust-gradient, check-vsock-only-egress, check-uniform-vsock-egress, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {
@@ -402,6 +412,12 @@ fn main() -> Result<()> {
                 "  check-claim-catalog                    Verify the claims ledger embedded in specs/adrs/001-microvm-security-posture.md — witnesses still exist in the tree"
             );
             eprintln!(
+                "  check-witness-citations                Prose that names a witness must name one that exists"
+            );
+            println!(
+                "  check-dormant-controls                 Security-relevant controls declare whether they have a production caller; the dormant list may only shrink"
+            );
+            println!(
                 "  check-mutation-witnesses               Pin the mutation surface derived from the claims ledger; --run mutates it and ratchets survivors; --write-baseline re-pins (add --run to also re-record misses)"
             );
             eprintln!(


### PR DESCRIPTION
Closes plan 293's WS3 and WS4. Both gate defect classes that cost the stream-plane work more than any bug did, and both of which were caught by a human reading carefully — which is not a control.

## `check-dormant-controls` (WS4)

The failure mode: a control that reports present and cannot fire. An admission gate reading an argv nobody populates, a broker nothing constructs, a scan whose bound set is always empty. Six of those shipped during plan 295, each found by review.

`xtask/dormant-controls.toml` declares security-relevant symbols and whether each is reachable. The gate fails **both ways** — a control declared live that lost its last production caller has gone quietly dormant; one declared dormant that *gained* a caller has a stale declaration and the entry should go. That is what makes it a ratchet rather than a comment.

Seeded with the two stream-edge primitives from #2187, dormant by design because `mvmd` is their caller.

**Its first act was to reject its own manifest.** A bare `validate` matched a third of the workspace. A symbol matching that widely reports reachable whatever the tree does, so the gate now refuses one outright — a verdict like that is noise wearing the costume of evidence.

## `check-witness-citations` (WS3, shrunk)

A backticked test-shaped name in claim-bearing prose must exist in the sources; a job-shaped name cited *as a job* must exist in a workflow.

**Deliberately much smaller than specified.** WS3 called for scanning claim-shaped assertions and requiring each to cite a ledger row. That is the brittle, noisy part, and a gate that cries wolf gets disabled six months later. This catches the drift that actually happened twice — a name nobody ever wrote — at roughly a tenth of the scope, with no false positives worth the name: a real symbol appears in the tree, a fabricated one does not.

It resolves 43 citations and found **nine fabricated witness names still backticked in `CLAUDE.md`** — the ones that file already documents as never having existed. Backticks assert a real identifier, so those are now quoted instead.

The kebab rule needed narrowing mid-build: `rust-version` and `cargo-semver-checks` are a manifest key and a tool, not enforcement, so a job citation now has to say "job" beside it.

## Both proven to fail

| Mutation | Result |
| --- | --- |
| Add `` `this_witness_does_not_exist_anywhere` `` to CLAUDE.md | ✅ red |
| Flip `validate_topology` to `dormant = false` | ✅ red |

Restored, both clean. Each gate also has a test asserting it passes on the tree as it stands, so a future change that breaks the gate itself fails in `cargo test` rather than only in CI.

## Also

Plan 293 is now fully ticked (WS1–WS4), including WS2's checkbox — my earlier update ran in a worktree that predated the file and the glob silently matched nothing.

Plan 294 gains a **"Next task: plan 296 WS3–WS6"** section recording why the connector is parked: what landed is *contract*, whose shape follows from the plan format and graph theory; the connector is *lifecycle*, and those answers come from how `mvmd` drives it. Guessing produces the abstraction that gets rewritten on first real use, and this one carries the guarantees plan 296 flags as easiest to lose.

## Verification

clippy `-D warnings` clean (the manifest parser's 4-tuple was factored into a struct rather than allowed); 435 xtask tests pass; both new gates green and wired into `ci.yml`'s lint lane.
