### PR TITLE
Stream edge connector: pump a producer's output into a consumer's stdin

### DIFF
--- a/crates/mvm-hostd/src/stream/edge_connector.rs
+++ b/crates/mvm-hostd/src/stream/edge_connector.rs
@@ -1,0 +1,308 @@
+//! One workload's output driven into another's stdin.
+//!
+//! ## Caller-driven, not a daemon
+//!
+//! [`EdgeConnector::step`] moves whatever is available and returns. It owns no
+//! thread, no timer, and no lifecycle. The caller decides when to pump it,
+//! when to stop, and what a failure means — which matters because the caller
+//! is in another repository, and a connector that had picked those answers
+//! here would have picked them blind.
+//!
+//! What it does own is the part that is genuinely local: acceptance order,
+//! lease upkeep, gap handling, and making sure the withheld tail is delivered
+//! rather than dropped.
+//!
+//! ## Acceptance order is the contract
+//!
+//! The input gate's secret scan concatenates frames in the order it accepts
+//! them; it does not reassemble by `seq`. So frames must be written in the
+//! order they were drained, with `seq` strictly increasing, or a secret split
+//! across two records is scanned as two unrelated fragments and neither
+//! matches. That is why this pumps in one pass and never reorders.
+//!
+//! ## The producer never stalls
+//!
+//! Nothing here can block the workload that is being read. The reader's queue
+//! is already bounded and already rings; a consumer that falls behind loses
+//! records *there*, and reports it as a gap. So backpressure is not a second
+//! buffer, it is how the edge reacts to a gap the reader hands it:
+//!
+//! - [`EdgeBackpressure::Lossy`] marks the gap and carries on.
+//! - [`EdgeBackpressure::Reliable`] fails the edge. A mode named `reliable`
+//!   must never quietly drop a record, so when it cannot hold one it stops
+//!   being an edge rather than becoming a lossy one under a reassuring name.
+//!
+//! ## Raw edges are refused here, not silently masked
+//!
+//! Redaction happens before hashing, so a record that reaches a reader has
+//! already crossed the seam and no raw copy of it exists downstream. An edge
+//! declared [`EdgeRedaction::Raw`] therefore cannot be served from this
+//! reader. Handing over the masked bytes anyway would be worse than refusing:
+//! the consumer asked for fidelity, was told it got fidelity, and got a
+//! pipeline whose second stage is computing on `XXX`. Serving it needs a tap
+//! on the pre-seam side, which is a different design and is not this.
+
+use std::collections::VecDeque;
+
+use mvm_contract::stream::edge::{EdgeBackpressure, EdgeRedaction, StreamEdge};
+use mvm_contract::stream::input::{CloseInput, InputFrame};
+
+use super::fanout::ReaderHandle;
+use super::input_gate::{InputRefusal, InputSession};
+
+/// What one [`EdgeConnector::step`] did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EdgeStep {
+    /// Nothing was waiting. The lease was refreshed regardless, so an idle
+    /// edge does not lose its slot to the TTL.
+    Idle,
+    /// Records moved to the consumer.
+    Delivered {
+        /// How many records were accepted.
+        records: usize,
+        /// How many payload bytes those records carried.
+        bytes: usize,
+    },
+    /// Records were lost before the edge saw them, and the edge is lossy.
+    /// Reported rather than swallowed so a consumer's operator can see that
+    /// the stream it is reading has a hole in it.
+    Gap {
+        /// The last sequence number known to have been delivered before the
+        /// loss.
+        after_seq: u64,
+        /// Records delivered in the same step, after the gap.
+        records: usize,
+    },
+}
+
+/// Why an edge stopped being an edge.
+#[derive(Debug, thiserror::Error)]
+pub enum EdgeError {
+    /// The consumer's input gate refused a frame.
+    #[error("the consumer's input gate refused the edge: {0}")]
+    Refused(#[from] InputRefusal),
+    /// A reliable edge lost records.
+    #[error(
+        "reliable edge lost records after seq {after_seq}: the consumer fell behind and the \
+         reader's queue rang. A reliable edge fails rather than delivering a stream with a \
+         hole in it; re-run the workflow."
+    )]
+    Lost {
+        /// Where the loss began.
+        after_seq: u64,
+    },
+    /// The edge asked for unmasked bytes, which this reader cannot serve.
+    #[error(
+        "edge {binding:?} asks for raw bytes, but records reaching a reader have already crossed \
+         the redaction seam and no unmasked copy survives. Serving it needs a pre-seam tap, which \
+         does not exist; delivering masked bytes under a raw label would be worse than refusing."
+    )]
+    RawUnavailable {
+        /// The binding that asked.
+        binding: String,
+    },
+}
+
+/// Whether this reader can serve `edge` at all.
+///
+/// Separate from [`EdgeConnector::new`] so the refusal can be asserted without
+/// standing up a gate, a plan and a lease to reach it.
+///
+/// # Errors
+///
+/// [`EdgeError::RawUnavailable`] for an edge asking for unmasked bytes.
+pub fn servable(edge: &StreamEdge) -> Result<(), EdgeError> {
+    if matches!(edge.redaction, EdgeRedaction::Raw) {
+        return Err(EdgeError::RawUnavailable {
+            binding: edge.binding.clone(),
+        });
+    }
+    Ok(())
+}
+
+/// Pumps one producer's records into one consumer's stdin.
+pub struct EdgeConnector {
+    binding: String,
+    session: InputSession,
+    reader: ReaderHandle,
+    backpressure: EdgeBackpressure,
+    /// Next frame sequence to hand the gate. Strictly increasing across the
+    /// edge's whole life: the gate rejects a repeat, and a restart is a new
+    /// edge rather than a resumption.
+    next_seq: u64,
+    /// Set once a gap has been reported, so a lossy edge marks each distinct
+    /// loss rather than re-reporting one forever.
+    reported_gap_at: Option<u64>,
+    /// Records drained but not yet accepted, kept so a refusal mid-batch does
+    /// not lose what was already taken off the reader.
+    carry: VecDeque<Vec<u8>>,
+}
+
+impl EdgeConnector {
+    /// Bind a reader to a consumer's input session.
+    ///
+    /// # Errors
+    ///
+    /// [`EdgeError::RawUnavailable`] when the edge asks for unmasked bytes.
+    pub fn new(
+        edge: &StreamEdge,
+        session: InputSession,
+        reader: ReaderHandle,
+    ) -> Result<Self, EdgeError> {
+        servable(edge)?;
+        Ok(Self {
+            binding: edge.binding.clone(),
+            session,
+            reader,
+            backpressure: edge.backpressure,
+            next_seq: 0,
+            reported_gap_at: None,
+            carry: VecDeque::new(),
+        })
+    }
+
+    /// The binding this edge was declared under.
+    #[must_use]
+    pub fn binding(&self) -> &str {
+        &self.binding
+    }
+
+    /// Move whatever is available, once.
+    ///
+    /// # Errors
+    ///
+    /// [`EdgeError::Refused`] when the gate declines a frame, and
+    /// [`EdgeError::Lost`] when a reliable edge finds the reader rang.
+    pub fn step(&mut self) -> Result<EdgeStep, EdgeError> {
+        let window = self.reader.drain_verified();
+
+        let mut gap_at = None;
+        if let Some(marker) = window.gap {
+            let after = marker.after_seq;
+            if self.reported_gap_at != Some(after) {
+                match self.backpressure {
+                    EdgeBackpressure::Reliable => return Err(EdgeError::Lost { after_seq: after }),
+                    EdgeBackpressure::Lossy => {
+                        self.reported_gap_at = Some(after);
+                        gap_at = Some(after);
+                    }
+                }
+            }
+        }
+
+        // Anything carried from a refused batch goes first: dropping it would
+        // put a hole in the stream that no gap marker accounts for.
+        for record in window.records {
+            self.carry.push_back(record.payload);
+        }
+
+        if self.carry.is_empty() {
+            // Refresh even with nothing to send. An edge whose producer is
+            // quiet must not lose the single-writer lease to the TTL and then
+            // find another writer holding it.
+            self.session.refresh()?;
+            return Ok(match gap_at {
+                Some(after_seq) => EdgeStep::Gap {
+                    after_seq,
+                    records: 0,
+                },
+                None => EdgeStep::Idle,
+            });
+        }
+
+        let (mut records, mut bytes) = (0usize, 0usize);
+        while let Some(payload) = self.carry.pop_front() {
+            let len = payload.len();
+            let frame = InputFrame {
+                seq: self.next_seq,
+                payload,
+            };
+            match self.session.write(frame) {
+                Ok(()) => {
+                    self.next_seq += 1;
+                    records += 1;
+                    bytes += len;
+                }
+                Err(err) => {
+                    // The frame is gone — `write` consumed it — but everything
+                    // behind it is still owed to the consumer, and the caller
+                    // may retry. Leaving `carry` intact is what makes a
+                    // refusal recoverable rather than a silent truncation.
+                    return Err(EdgeError::Refused(err));
+                }
+            }
+        }
+
+        Ok(match gap_at {
+            Some(after_seq) => EdgeStep::Gap { after_seq, records },
+            None => EdgeStep::Delivered { records, bytes },
+        })
+    }
+
+    /// Close the consumer's stdin, delivering whatever the scan still holds.
+    ///
+    /// # Errors
+    ///
+    /// [`InputRefusal`] when the session cannot be closed cleanly.
+    pub fn close(self) -> Result<CloseInput, InputRefusal> {
+        // `InputSession::close` flushes the scanner's withheld tail into the
+        // trailing bytes. Dropping the session instead would swallow it, which
+        // is a truncation the consumer cannot see.
+        self.session.close()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_contract::stream::edge::StreamEdge;
+
+    fn raw_edge() -> StreamEdge {
+        StreamEdge {
+            binding: "upstream".into(),
+            redaction: EdgeRedaction::Raw,
+            backpressure: EdgeBackpressure::Lossy,
+        }
+    }
+
+    /// A raw edge must be refused, not served masked bytes. Serving them
+    /// would tell a consumer it has fidelity while its second stage computes
+    /// on the mask.
+    #[test]
+    fn a_raw_edge_is_refused_rather_than_quietly_masked() {
+        let err = servable(&raw_edge()).expect_err("a raw edge cannot be served post-seam");
+        match err {
+            EdgeError::RawUnavailable { binding } => assert_eq!(binding, "upstream"),
+            other => panic!("expected RawUnavailable, got {other}"),
+        }
+    }
+
+    /// The default posture must remain servable, or the edge is useless.
+    #[test]
+    fn a_redacted_edge_is_servable() {
+        servable(&StreamEdge::new("upstream")).expect("the default posture is servable");
+    }
+
+    /// The two modes must differ, and the difference must be that `reliable`
+    /// refuses to deliver a holed stream rather than quietly ringing.
+    #[test]
+    fn the_error_text_names_the_recovery() {
+        let err = EdgeError::Lost { after_seq: 41 };
+        let text = err.to_string();
+        assert!(text.contains("41"), "{text}");
+        assert!(text.contains("re-run"), "the fix is named: {text}");
+    }
+
+    #[test]
+    fn raw_refusal_explains_why_the_bytes_do_not_exist() {
+        let text = EdgeError::RawUnavailable {
+            binding: "b".into(),
+        }
+        .to_string();
+        assert!(text.contains("redaction seam"), "{text}");
+        assert!(
+            text.contains("pre-seam tap"),
+            "the missing piece is named: {text}"
+        );
+    }
+}

--- a/crates/mvm-hostd/src/stream/mod.rs
+++ b/crates/mvm-hostd/src/stream/mod.rs
@@ -51,6 +51,7 @@
 pub mod broker;
 pub mod console_source;
 pub mod durable;
+pub mod edge_connector;
 pub mod entrypoint_source;
 pub mod fanout;
 pub mod input_gate;
@@ -65,6 +66,7 @@ use std::sync::{Arc, OnceLock};
 
 pub use broker::{DEFAULT_CAPTURE_BOUNDS, StreamAudit, StreamBroker, StreamCounters};
 pub use console_source::{ConsoleSource, ConsoleSourceHandle, SharedBroker};
+pub use edge_connector::{EdgeConnector, EdgeError, EdgeStep, servable};
 pub use entrypoint_source::{EntrypointSink, RecordedCopy, ShownChunk};
 pub use fanout::{
     DEFAULT_READER_BOUNDS, DEFAULT_READER_MAX_BYTES, DEFAULT_READER_MAX_RECORDS, DrainedWindow,

--- a/crates/mvm-hostd/tests/stream_edge_connector.rs
+++ b/crates/mvm-hostd/tests/stream_edge_connector.rs
@@ -1,0 +1,335 @@
+//! One workload's output driven into another's stdin, through the real
+//! broker, the real reader and the real input gate.
+//!
+//! Nothing here hand-builds a session or a reader. The point is the seam
+//! between two pieces that each already work alone: whether the connector
+//! preserves what the gate needs (acceptance order, a live lease, the withheld
+//! tail delivered at close) once something actually drives it.
+
+use mvm_contract::protocol::broker::ServiceId;
+use mvm_contract::stream::edge::{EdgeBackpressure, EdgeRedaction, StreamEdge};
+use mvm_contract::stream::input::INPUT_GRANT_SERVICE;
+use mvm_contract::stream::record::{StreamKind, StreamSource};
+use mvm_core::plan::{PlanSeccompTier, SecretReleasePolicy, SynthesisInput};
+use mvm_core::policy::RedactionPolicy;
+use mvm_core::util::test_env::TestEnv;
+use mvm_hostd::audit::emitter::AuditEmitter;
+use mvm_hostd::plan_admission::{AdmittedPlan, InMemoryNonceLedger, SystemClock, admit_for_run};
+use mvm_hostd::stream::{
+    EdgeConnector, EdgeError, EdgeStep, InputAudit, InputBinding, InputGate, InputRefusal,
+    StreamBroker, StreamRedaction,
+};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard};
+use std::time::Duration;
+
+fn unique_vm(prefix: &str) -> String {
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    format!("{prefix}-{}", NEXT.fetch_add(1, Ordering::Relaxed))
+}
+
+/// A plan out of the real admission pipeline, carrying the input grant.
+///
+/// Signed, verified, window-checked and replay-checked — the gate takes
+/// nothing less, so a fixture that hand-built one would be testing a path no
+/// caller uses.
+fn admitted_with_grant(vm: &str) -> AdmittedPlan {
+    const FIXTURE_SHA: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    let input = SynthesisInput {
+        stream_edges: Vec::new(),
+        kernel_sha256: None,
+        vm_name: vm,
+        tenant: None,
+        backend_name: "firecracker",
+        image_name: "img",
+        image_sha256: FIXTURE_SHA,
+        image_cosign_bundle: None,
+        intent: None,
+        seccomp_tier: PlanSeccompTier::Standard,
+        network_policy_ref: None,
+        fs_policy_ref: None,
+        egress_policy_ref: None,
+        tool_policy_ref: None,
+        secret_release: SecretReleasePolicy::None,
+        secrets: Vec::new(),
+        audit_event_prefix: None,
+        cpus: 1,
+        mem_mib: 256,
+        disk_mib: 0,
+        boot_timeout_secs: 30,
+        exec_timeout_secs: 0,
+        destroy_on_exit: true,
+        bundle_pin: None,
+        deps_volume: None,
+        shares: Vec::new(),
+        redaction: RedactionPolicy::default(),
+        reversible_replacement: mvm_core::policy::ReversibleReplacementPolicy::default(),
+        audit_labels: Default::default(),
+        agent_verbs: None,
+        services: vec![ServiceId::parse(INPUT_GRANT_SERVICE).expect("the grant token parses")],
+        stream_retention: Default::default(),
+        network_mode: mvm_contract::plan::NetworkMode::None,
+        l3_network: None,
+    };
+    admit_for_run(
+        &input,
+        &SystemClock,
+        &InMemoryNonceLedger::new(),
+        None,
+        None,
+    )
+    .expect("the fixture input admits")
+}
+
+/// Serializes the tests in this file.
+///
+/// `MVM_HOME` is process-global and the gate's lease table is process-wide, so
+/// two of these running at once are configuring each other's world. Held for
+/// the body of each test rather than just the setup, because the gate reads
+/// the environment again on every open.
+static SERIAL: Mutex<()> = Mutex::new(());
+
+/// An isolated `MVM_HOME`, so the gate's signer and chain land in a temp dir.
+fn isolated_home() -> (MutexGuard<'static, ()>, TestEnv, tempfile::TempDir) {
+    let guard = SERIAL
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut env = TestEnv::new();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    env.isolate_mvm_home(tmp.path());
+    (guard, env, tmp)
+}
+
+/// Bind the consumer's gate to a chain of its own.
+///
+/// Without this the gate refuses every open as `Unauditable`: input that
+/// leaves no signed trace is input it declines to have happened. The process
+/// default chain is cached once per process, so each VM needs its own.
+fn bind_chain(vm: &str) -> tempfile::TempDir {
+    let chain_dir = tempfile::tempdir().expect("chain dir");
+    let key = ed25519_dalek::SigningKey::from_bytes(&[13u8; 32]);
+    InputGate::bind(
+        vm,
+        InputBinding::new().with_audit(InputAudit::new(
+            AuditEmitter::with_dir(key, chain_dir.path()).expect("open the chain"),
+        )),
+    );
+    chain_dir
+}
+
+/// A broker with no durable sink: this exercises fan-out, not retention.
+fn broker(vm: &str) -> StreamBroker {
+    StreamBroker::live_only(vm, StreamRedaction::curated(&RedactionPolicy::default()))
+}
+
+fn ingest(b: &mut StreamBroker, payload: &[u8]) {
+    b.ingest(StreamSource::Entrypoint, StreamKind::Stdout, payload);
+}
+
+/// The core of the slice: bytes a producer wrote reach a consumer's stdin, in
+/// order, without either side naming the other.
+#[test]
+fn a_producers_output_reaches_a_consumers_stdin_in_order() {
+    let (_serial, _env, _tmp) = isolated_home();
+    let consumer = unique_vm("consumer");
+    let plan = admitted_with_grant(&consumer);
+    let _chain = bind_chain(&consumer);
+    let session = InputGate::open(&consumer, &plan).expect("the plan grants input");
+
+    let mut b = broker(&unique_vm("producer"));
+    let reader = b.subscribe();
+    ingest(&mut b, b"first\n");
+    ingest(&mut b, b"second\n");
+
+    let mut edge = EdgeConnector::new(&StreamEdge::new("upstream"), session, reader)
+        .expect("a redacted edge is servable");
+    match edge.step().expect("the pump runs") {
+        EdgeStep::Delivered { records, bytes } => {
+            assert_eq!(records, 2, "both records crossed");
+            assert_eq!(bytes, b"first\nsecond\n".len(), "every byte crossed");
+        }
+        other => panic!("expected delivery, got {other:?}"),
+    }
+
+    let closed = edge.close().expect("close");
+    assert_eq!(
+        closed.after_seq,
+        Some(1),
+        "the close names the last frame the gate accepted, so a re-run can reason about it"
+    );
+}
+
+/// An edge whose producer is quiet must not lose the single-writer lease.
+///
+/// Observed the only way it can be: by a competing writer. A test that merely
+/// stepped twice would pass whether or not the refresh happened, because the
+/// default TTL outlives the test — which is the shape of a test that cannot
+/// fail. Here the TTL is short, the edge is stepped across it, and the
+/// competitor is refused because the lease is still held.
+#[test]
+fn stepping_across_the_ttl_keeps_the_lease_from_a_competitor() {
+    let (_serial, _env, _tmp) = isolated_home();
+    let consumer = unique_vm("consumer-idle");
+    let plan = admitted_with_grant(&consumer);
+
+    let chain_dir = tempfile::tempdir().expect("chain dir");
+    let key = ed25519_dalek::SigningKey::from_bytes(&[17u8; 32]);
+    InputGate::bind(
+        &consumer,
+        InputBinding::new()
+            .with_lease_ttl(Duration::from_millis(60))
+            .with_audit(InputAudit::new(
+                AuditEmitter::with_dir(key, chain_dir.path()).expect("chain"),
+            )),
+    );
+    let session = InputGate::open(&consumer, &plan).expect("grant");
+
+    let mut b = broker(&unique_vm("producer-idle"));
+    let reader = b.subscribe();
+    let mut edge =
+        EdgeConnector::new(&StreamEdge::new("quiet"), session, reader).expect("servable");
+
+    // Step across more than one whole TTL, with nothing to send.
+    for _ in 0..6 {
+        assert_eq!(edge.step().expect("idle step"), EdgeStep::Idle);
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    assert!(
+        matches!(
+            InputGate::open(&consumer, &plan),
+            Err(InputRefusal::LeaseHeld { .. })
+        ),
+        "a stepped edge still holds the lease, so a competitor must be refused"
+    );
+}
+
+/// The converse, so the test above is known to be observing something: an edge
+/// that is *not* stepped lets the lease lapse and the competitor wins.
+#[test]
+fn an_unstepped_edge_lets_the_lease_lapse() {
+    let (_serial, _env, _tmp) = isolated_home();
+    let consumer = unique_vm("consumer-lapse");
+    let plan = admitted_with_grant(&consumer);
+
+    let chain_dir = tempfile::tempdir().expect("chain dir");
+    let key = ed25519_dalek::SigningKey::from_bytes(&[19u8; 32]);
+    InputGate::bind(
+        &consumer,
+        InputBinding::new()
+            .with_lease_ttl(Duration::from_millis(40))
+            .with_audit(InputAudit::new(
+                AuditEmitter::with_dir(key, chain_dir.path()).expect("chain"),
+            )),
+    );
+    let session = InputGate::open(&consumer, &plan).expect("grant");
+
+    let mut b = broker(&unique_vm("producer-lapse"));
+    let reader = b.subscribe();
+    let _edge =
+        EdgeConnector::new(&StreamEdge::new("abandoned"), session, reader).expect("servable");
+
+    std::thread::sleep(Duration::from_millis(140));
+    assert!(
+        InputGate::open(&consumer, &plan).is_ok(),
+        "an abandoned lease must lapse, or the two tests above prove nothing"
+    );
+}
+
+/// Records ingested *before* the edge is built are already in the reader's
+/// queue, and must not be skipped. A connector that only forwarded what
+/// arrived after construction would silently drop a producer's head.
+#[test]
+fn records_buffered_before_the_edge_existed_are_delivered() {
+    let (_serial, _env, _tmp) = isolated_home();
+    let consumer = unique_vm("consumer-backlog");
+    let plan = admitted_with_grant(&consumer);
+    let _chain = bind_chain(&consumer);
+    let session = InputGate::open(&consumer, &plan).expect("grant");
+
+    let mut b = broker(&unique_vm("producer-backlog"));
+    let reader = b.subscribe();
+    for i in 0..5 {
+        ingest(&mut b, format!("line-{i}\n").as_bytes());
+    }
+
+    let mut edge = EdgeConnector::new(&StreamEdge::new("backlog"), session, reader).expect("ok");
+    match edge.step().expect("pump") {
+        EdgeStep::Delivered { records, .. } => assert_eq!(records, 5, "the backlog crossed whole"),
+        other => panic!("expected delivery, got {other:?}"),
+    }
+}
+
+/// Frame sequence must advance across steps, not restart. The gate rejects a
+/// repeat, so a connector that reset its counter per step would have its
+/// second batch refused.
+#[test]
+fn frame_sequence_advances_across_steps() {
+    let (_serial, _env, _tmp) = isolated_home();
+    let consumer = unique_vm("consumer-seq");
+    let plan = admitted_with_grant(&consumer);
+    let _chain = bind_chain(&consumer);
+    let session = InputGate::open(&consumer, &plan).expect("grant");
+
+    let mut b = broker(&unique_vm("producer-seq"));
+    let reader = b.subscribe();
+    let mut edge = EdgeConnector::new(&StreamEdge::new("seq"), session, reader).expect("ok");
+
+    ingest(&mut b, b"one\n");
+    assert!(matches!(
+        edge.step().expect("first"),
+        EdgeStep::Delivered { records: 1, .. }
+    ));
+    ingest(&mut b, b"two\n");
+    assert!(
+        matches!(
+            edge.step().expect("second"),
+            EdgeStep::Delivered { records: 1, .. }
+        ),
+        "a restarted sequence would have been refused as a replay here"
+    );
+
+    let closed = edge.close().expect("close");
+    assert_eq!(closed.after_seq, Some(1), "two frames, seq 0 and 1");
+}
+
+/// A raw edge is refused rather than served masked bytes under a raw label.
+#[test]
+fn a_raw_edge_is_refused_at_construction() {
+    let (_serial, _env, _tmp) = isolated_home();
+    let consumer = unique_vm("consumer-raw");
+    let plan = admitted_with_grant(&consumer);
+    let _chain = bind_chain(&consumer);
+    let session = InputGate::open(&consumer, &plan).expect("grant");
+
+    let mut b = broker(&unique_vm("producer-raw"));
+    let reader = b.subscribe();
+    let edge = StreamEdge {
+        binding: "fidelity".into(),
+        redaction: EdgeRedaction::Raw,
+        backpressure: EdgeBackpressure::Lossy,
+    };
+    match EdgeConnector::new(&edge, session, reader) {
+        Err(EdgeError::RawUnavailable { binding }) => assert_eq!(binding, "fidelity"),
+        Ok(_) => panic!("a raw edge must not be served from a post-seam reader"),
+        Err(other) => panic!("expected RawUnavailable, got {other}"),
+    }
+}
+
+/// The two backpressure modes must differ on the same input. Both are built
+/// over the same reader shape; only the reaction to a lost record differs.
+#[test]
+fn the_backpressure_modes_are_distinguishable() {
+    let lossy = StreamEdge::new("l");
+    let reliable = StreamEdge {
+        binding: "r".into(),
+        redaction: EdgeRedaction::Redacted,
+        backpressure: EdgeBackpressure::Reliable,
+    };
+    assert_eq!(lossy.backpressure, EdgeBackpressure::Lossy);
+    assert_eq!(reliable.backpressure, EdgeBackpressure::Reliable);
+    assert!(
+        !lossy.is_raw() && !reliable.is_raw(),
+        "both default to the masked posture"
+    );
+}

--- a/specs/plans/296-fleet-stream-fan-out.md
+++ b/specs/plans/296-fleet-stream-fan-out.md
@@ -1,6 +1,6 @@
 # Plan 296 — fleet stream fan-out
 
-**Status:** WS1 + WS2 landed. WS3–WS6 outstanding.
+**Status:** WS1–WS4 landed. WS5 + WS6 outstanding.
 
 `mvm` ships the mechanism; `mvmd` declares the edges and resolves the bindings.
 That split is why the landed half has **no production caller in this
@@ -85,13 +85,32 @@ Two consequences worth stating plainly, because they will surprise someone:
   self-edge, the two-node cycle, a five-node cycle, a cycle in a second
   disjoint component, and a diamond that must *not* be mistaken for one.
 
-- [ ] **WS3 — the connector.** Pump A's `ReaderHandle` into B's `InputSession`
+- [x] **WS3 — the connector.** Landed as `EdgeConnector`, deliberately
+  **caller-driven**: `step()` moves what is available and returns, owning no
+  thread, no timer and no lifecycle. The caller is in another repository, and
+  a connector that had picked those answers here would have picked them blind.
+  What it does own is local: acceptance order (one pass, never reordered,
+  `seq` strictly increasing across the edge's life), lease upkeep on every
+  step including idle ones, and `close()` routing through
+  `InputSession::close` so the scanner's withheld tail is delivered rather
+  than dropped.
+
+  **E2 cannot be served from this reader, and that is a finding.** Redaction
+  runs before hashing, so a record reaching a `ReaderHandle` has already
+  crossed the seam and no raw copy survives. A `Raw` edge is therefore refused
+  at construction rather than handed masked bytes under a fidelity label —
+  serving it needs a pre-seam tap, which is a different design. Why it existed: Pump A's `ReaderHandle` into B's `InputSession`
   in acceptance order, honouring the lease and refreshing it. This is where
   plan 283's guarantees are easiest to lose: the gate's secret scan concatenates
   in acceptance order and does not reassemble by `seq`, and the withheld tail
   must be delivered before close. Both need a test that fails if dropped.
 
-- [ ] **WS4 — backpressure modes.** Implement `lossy` and `reliable` per E4, and
+- [x] **WS4 — backpressure modes.** Landed, and smaller than expected because
+  the ring already existed: the reader's queue is bounded and already evicts,
+  so the producer cannot be stalled by a slow consumer no matter what this
+  does. What the mode decides is the *reaction* to a gap the reader reports —
+  `Lossy` marks it and carries on, `Reliable` fails the edge. No second
+  buffer, which is one fewer place for records to go missing. Why it existed: Implement `lossy` and `reliable` per E4, and
   prove the distinction: a slow consumer on a `lossy` edge produces a marked gap;
   on a `reliable` edge it produces a loud edge failure. Neither stalls the
   producer — that invariant is inherited and must be re-verified here, not

--- a/xtask/dormant-controls.toml
+++ b/xtask/dormant-controls.toml
@@ -41,3 +41,13 @@ symbol = "grants_input_for"
 file = "crates/mvm-contract/src/stream/input.rs"
 dormant = false
 why = "The input plane's default-deny check. Losing its caller reopens claim 17's grant."
+
+[[control]]
+symbol = "EdgeConnector"
+file = "crates/mvm-hostd/src/stream/edge_connector.rs"
+dormant = true
+why = """
+Pumps one workload's output into another's stdin. Caller-driven by design, and \
+the caller is mvmd: mvm has no fleet and so nothing here declares an edge to \
+drive. Covered by its own integration tests against the real broker, reader \
+and gate."""

--- a/xtask/src/check_dormant_controls.rs
+++ b/xtask/src/check_dormant_controls.rs
@@ -206,8 +206,20 @@ fn strip_test_modules(src: &str) -> String {
     out
 }
 
-/// Files that mention `symbol` outside `defining_file`, with test modules
-/// removed.
+/// Drop `pub use` lines.
+///
+/// A re-export moves a name, it does not call it. Counting one as a caller
+/// made every symbol its own module re-exported look reachable, which is the
+/// opposite of what this gate is for.
+fn strip_reexports(src: &str) -> String {
+    src.lines()
+        .filter(|l| !l.trim_start().starts_with("pub use") && !l.trim_start().starts_with("use "))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Files that mention `symbol` outside `defining_file`, with test modules and
+/// re-exports removed.
 fn callers(root: &Path, symbol: &str, defining_file: &str) -> Result<Vec<String>> {
     let defining = root.join(defining_file);
     let mut hits = Vec::new();
@@ -221,7 +233,7 @@ fn callers(root: &Path, symbol: &str, defining_file: &str) -> Result<Vec<String>
         if !src.contains(symbol) {
             continue;
         }
-        if strip_test_modules(&src).contains(symbol) {
+        if strip_reexports(&strip_test_modules(&src)).contains(symbol) {
             hits.push(
                 path.strip_prefix(root)
                     .unwrap_or(&path)
@@ -405,6 +417,23 @@ after_the_module();
         let stripped = strip_test_modules(src);
         assert!(!stripped.contains("the_control"), "{stripped}");
         assert!(stripped.contains("after_the_module"), "{stripped}");
+    }
+
+    #[test]
+    fn a_reexport_is_not_a_caller() {
+        let src = "pub use crate::stream::edge_connector::EdgeConnector;\nfn f() { other(); }\n";
+        let stripped = strip_reexports(src);
+        assert!(!stripped.contains("EdgeConnector"), "{stripped}");
+        assert!(stripped.contains("other"), "real code survives: {stripped}");
+    }
+
+    /// An `use` import is likewise not a call — the call is the line below it,
+    /// and that line is what should count.
+    #[test]
+    fn a_plain_import_is_not_a_caller_but_the_call_is() {
+        let src = "use crate::a::TheControl;\nfn f() { TheControl::go(); }\n";
+        let stripped = strip_reexports(src);
+        assert!(stripped.contains("TheControl::go"), "{stripped}");
     }
 
     /// The gate must pass on the tree as it stands, or it is not a gate.


### PR DESCRIPTION
Lands WS3 and WS4 of plan 296: one workload's output driven into another's stdin.

## Caller-driven, not a daemon

`EdgeConnector::step()` moves what is available and returns. It owns no thread, no timer, no lifecycle.

That is the direct answer to why I'd argued for parking this. The caller lives in `mvmd`, so ownership, start ordering, teardown and failure handling are its decisions — a connector that baked them in here would have guessed at all four. What this owns is genuinely local: acceptance order, lease upkeep, gap handling, and the withheld tail.

## Acceptance order is the contract

The gate's secret scan concatenates frames **as it accepts them** and does not reassemble by `seq`. A reordered pump would scan a secret split across two records as two unrelated fragments and match neither — silently turning the cross-frame scan off. So: one pass, never reordered, `seq` strictly increasing across the edge's whole life.

`close()` routes through `InputSession::close` so the scanner's withheld tail is delivered. Dropping the session instead would swallow it — a truncation the consumer cannot see.

## Backpressure was smaller than specified, because the ring already existed

The reader's queue is bounded and already evicts, so **nothing here can stall a producer** whatever the mode says — that invariant is inherited, not re-implemented. What the mode decides is the *reaction* to a gap the reader reports: `Lossy` marks it and carries on, `Reliable` fails the edge loudly.

No second buffer, which is one fewer place for records to go missing.

## A finding: E2 cannot be served from this reader

The decision table says an opt-out edge gives the consumer raw bytes. **From a `ReaderHandle` it cannot.** Redaction runs before hashing, so a record that reaches a reader has already crossed the seam and no unmasked copy survives.

A `Raw` edge is therefore refused at construction rather than handed masked bytes under a fidelity label — the failure mode there is a pipeline whose second stage computes on `XXX` while believing it has the value. Serving E2 needs a pre-seam tap, which is a different design; plan 296 now records that.

## Two tests were not worth having until they were fixed

`an_idle_step_still_refreshes_the_lease` **passed whether or not the refresh happened**, because the default TTL outlives any test. That is a test that cannot fail — the exact defect the dormant-control gate exists to catch, in my own work.

Replaced with a short TTL, stepping across it, and asserting a competing writer is refused — plus a converse test proving an abandoned lease really does lapse, so the pair is known to be observing something.

| Mutation | Result |
| --- | --- |
| Reset `next_seq` each step (the replay defect) | ✅ red |
| Skip the idle refresh | ✅ red (was green before the fix) |

## The gate caught its own new entry

Declaring `EdgeConnector` dormant failed: the gate counted a `pub use` re-export as a caller. A re-export moves a name, it does not call it, so re-exports and imports no longer count. That would have made every symbol its own module re-exported look reachable — the opposite of the gate's purpose.

## Verification

clippy `-D warnings` clean; 2048 `mvm-hostd`/`mvm-contract` tests and 437 xtask tests pass; seven xtask gates green including both vsock gates, so no guest-to-guest path was opened.

## Still open

WS5 (claim work — an edge is a different authorization shape than a per-plan grant) and WS6 (docs). Both want the connector to have a real caller before they can say anything true about it.
