### PR TITLE
Fix multi-machine nftables isolation

### DIFF
--- a/crates/mvm-hostd/src/netd/linux.rs
+++ b/crates/mvm-hostd/src/netd/linux.rs
@@ -898,7 +898,11 @@ mod tests {
             jump_handles(listing, "mvmn_f_a", "mvmna").expect("handles"),
             vec![11, 13]
         );
-        assert!(jump_handles(listing, "mvmn_f_a", "mvmnb").is_empty());
+        assert!(
+            jump_handles(listing, "mvmn_f_a", "mvmnb")
+                .expect("matching interface has no malformed handles")
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/mvm-hostd/src/netd/linux.rs
+++ b/crates/mvm-hostd/src/netd/linux.rs
@@ -15,6 +15,7 @@
 use std::io::{Read, Write};
 use std::net::Ipv4Addr;
 use std::os::fd::AsRawFd;
+use std::path::Path;
 use std::process::{Command, Stdio};
 
 use mvm_net::l3::AdmittedPacket;
@@ -50,6 +51,9 @@ const fn ioctl_request_max() -> u64 {
 /// Prefix for every device and table this datapath creates, so a sweep can
 /// find them all and nothing unrelated is ever touched.
 const RESOURCE_PREFIX: &str = "mvmn";
+const NFT_TABLE: &str = "mvmn";
+const NFT_FORWARD_CHAIN: &str = "forward";
+const NFT_POSTROUTING_CHAIN: &str = "postrouting";
 
 #[repr(C, align(8))]
 struct IfReqFlags {
@@ -211,7 +215,11 @@ impl LinuxHandle {
             return Ok(());
         }
         set_point_to_point(&self.iface, req.gateway, req.guest, req.mtu)?;
-        apply_nft(&nft_ruleset(&self.table, &self.iface, req.guest))?;
+        let _lock = nft_lock()?;
+        if let Err(error) = install_nft(&self.table, &self.iface, &self.machine_id, req.guest) {
+            let _ = remove_shared_table_if_empty(&self.table);
+            return Err(error);
+        }
         self.nft_applied = true;
         Ok(())
     }
@@ -258,8 +266,8 @@ impl DatapathHandle for LinuxHandle {
         if self.closed {
             return Ok(());
         }
-        self.closed = true;
         if self.dry_run {
+            self.closed = true;
             self.file = None;
             return Ok(());
         }
@@ -268,14 +276,27 @@ impl DatapathHandle for LinuxHandle {
         // addresses and routes with it — so the descriptor has to go here
         // rather than whenever the handle happens to be dropped.
         //
-        // Each step is best-effort because this also runs on the
-        // failed-setup path, where some of it was never created.
-        if self.nft_applied {
-            let _ = delete_nft_table(&self.table);
-            self.nft_applied = false;
-        }
+        // Cleanup also runs on the failed-setup path, where some of the
+        // resources were never created. Surface a lock or nft failure to an
+        // explicit close caller; Drop still makes a best-effort attempt.
+        let result = if self.nft_applied {
+            match nft_lock() {
+                Ok(lock) => {
+                    let result = delete_machine_nft(&self.table, &self.iface, &self.machine_id);
+                    drop(lock);
+                    result
+                }
+                Err(error) => Err(error),
+            }
+        } else {
+            Ok(())
+        };
         self.file = None;
-        Ok(())
+        if result.is_ok() {
+            self.nft_applied = false;
+            self.closed = true;
+        }
+        result
     }
 
     fn description(&self) -> String {
@@ -309,9 +330,19 @@ pub fn device_name(machine_id: &str) -> String {
     format!("{RESOURCE_PREFIX}{}", slug(machine_id, budget))
 }
 
-/// nftables table name for a machine.
-pub fn table_name(machine_id: &str) -> String {
-    format!("{RESOURCE_PREFIX}_{}", slug(machine_id, 32))
+/// nftables table shared by all machine-scoped chains.
+pub fn table_name(_machine_id: &str) -> String {
+    NFT_TABLE.to_string()
+}
+
+/// Filter chain for one machine inside the shared nftables table.
+pub fn forward_chain_name(machine_id: &str) -> String {
+    format!("{RESOURCE_PREFIX}_f_{}", slug(machine_id, 32))
+}
+
+/// NAT chain for one machine inside the shared nftables table.
+pub fn nat_chain_name(machine_id: &str) -> String {
+    format!("{RESOURCE_PREFIX}_n_{}", slug(machine_id, 32))
 }
 
 /// Reduce an identifier to `[a-z0-9]`, truncated to `budget` characters.
@@ -334,27 +365,105 @@ fn slug(input: &str, budget: usize) -> String {
     out
 }
 
-/// The nftables ruleset for one machine.
+/// A complete shared-table ruleset containing the first machine's chains.
 ///
-/// Two layers, neither load-bearing on its own: masquerade so replies come
-/// back, and a filter that drops anything whose source is not the address
-/// this machine was assigned. Userspace admission has already made that
-/// decision; this is what still holds if a rule elsewhere is wrong.
+/// The shared forward base chain owns the host-wide default drop. Each
+/// machine gets regular chains reached only by interface-scoped jumps, so a
+/// machine's rules cannot drop packets belonging to another machine.
 fn nft_ruleset(table: &str, iface: &str, guest: Ipv4Addr) -> String {
+    let forward_chain = forward_chain_name(iface);
+    let nat_chain = nat_chain_name(iface);
     format!(
-        "table inet {table} {{\n\
-         \x20 chain postrouting {{\n\
-         \x20   type nat hook postrouting priority srcnat; policy accept;\n\
-         \x20   ip saddr {guest}/32 masquerade\n\
-         \x20 }}\n\
-         \x20 chain forward {{\n\
-         \x20   type filter hook forward priority filter; policy drop;\n\
-         \x20   iifname \"{iface}\" ip saddr {guest}/32 accept\n\
-         \x20   oifname \"{iface}\" ip daddr {guest}/32 ct state established,related accept\n\
-         \x20   iifname \"{iface}\" drop\n\
-         \x20 }}\n\
-         }}\n"
+        "add table inet {table}\n\
+         add chain inet {table} {NFT_POSTROUTING_CHAIN} {{ type nat hook postrouting priority srcnat; policy accept; }}\n\
+         add chain inet {table} {NFT_FORWARD_CHAIN} {{ type filter hook forward priority filter; policy drop; }}\n\
+         {machine_rules}",
+        machine_rules = machine_ruleset(table, iface, guest, &forward_chain, &nat_chain,)
     )
+}
+
+fn shared_table_ruleset(table: &str) -> String {
+    format!(
+        "add table inet {table}\n\
+         add chain inet {table} {NFT_POSTROUTING_CHAIN} {{ type nat hook postrouting priority srcnat; policy accept; }}\n\
+         add chain inet {table} {NFT_FORWARD_CHAIN} {{ type filter hook forward priority filter; policy drop; }}\n"
+    )
+}
+
+fn machine_ruleset(
+    table: &str,
+    iface: &str,
+    guest: Ipv4Addr,
+    forward_chain: &str,
+    nat_chain: &str,
+) -> String {
+    format!(
+        "add chain inet {table} {forward_chain}\n\
+         add chain inet {table} {nat_chain}\n\
+         add rule inet {table} {NFT_FORWARD_CHAIN} iifname \"{iface}\" jump {forward_chain}\n\
+         add rule inet {table} {NFT_FORWARD_CHAIN} oifname \"{iface}\" jump {forward_chain}\n\
+         add rule inet {table} {NFT_POSTROUTING_CHAIN} iifname \"{iface}\" jump {nat_chain}\n\
+         add rule inet {table} {forward_chain} iifname \"{iface}\" ip saddr {guest}/32 counter accept\n\
+         add rule inet {table} {forward_chain} iifname \"{iface}\" drop\n\
+         add rule inet {table} {forward_chain} oifname \"{iface}\" ip daddr {guest}/32 ct state established,related counter accept\n\
+         add rule inet {table} {forward_chain} oifname \"{iface}\" drop\n\
+         add rule inet {table} {nat_chain} iifname \"{iface}\" ip saddr {guest}/32 masquerade\n"
+    )
+}
+
+fn install_nft(
+    table: &str,
+    iface: &str,
+    machine_id: &str,
+    guest: Ipv4Addr,
+) -> Result<(), DatapathError> {
+    ensure_shared_table(table)?;
+    let forward_chain = forward_chain_name(machine_id);
+    let nat_chain = nat_chain_name(machine_id);
+    apply_nft(&machine_ruleset(
+        table,
+        iface,
+        guest,
+        &forward_chain,
+        &nat_chain,
+    ))
+}
+
+fn ensure_shared_table(table: &str) -> Result<(), DatapathError> {
+    if !nft_table_exists_for_runtime(table)? {
+        apply_nft(&shared_table_ruleset(table))?;
+    }
+    let forward = list_nft_chain(table, NFT_FORWARD_CHAIN)?;
+    if !forward.contains("type filter hook forward") || !forward.contains("policy drop") {
+        return Err(DatapathError::PrivilegeRequired {
+            operation: "validating the shared nftables forward policy",
+            detail: "the mvm-owned forward chain is missing its default drop policy".to_string(),
+        });
+    }
+    let postrouting = list_nft_chain(table, NFT_POSTROUTING_CHAIN)?;
+    if !postrouting.contains("type nat hook postrouting") || !postrouting.contains("policy accept")
+    {
+        return Err(DatapathError::PrivilegeRequired {
+            operation: "validating the shared nftables NAT policy",
+            detail: "the mvm-owned postrouting chain is missing its accept policy".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn nft_lock() -> Result<mvm_core::util::atomic_io::FileLock, DatapathError> {
+    let runtime =
+        mvm_core::config::ensure_runtime_dir().map_err(|source| DatapathError::SetupFailed {
+            what: "nftables lock directory",
+            machine_id: String::new(),
+            source,
+        })?;
+    mvm_core::util::atomic_io::FileLock::acquire(&Path::new(&runtime).join("netd-nftables"))
+        .map_err(|error| DatapathError::SetupFailed {
+            what: "nftables lock",
+            machine_id: String::new(),
+            source: std::io::Error::other(error.to_string()),
+        })
 }
 
 /// Load a ruleset through `nft -f -`.
@@ -391,18 +500,116 @@ fn apply_nft(rules: &str) -> Result<(), DatapathError> {
     Ok(())
 }
 
-fn delete_nft_table(table: &str) -> Result<(), DatapathError> {
-    let status = Command::new("nft")
-        .args(["delete", "table", "inet", table])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()?;
-    if status.success() {
-        Ok(())
-    } else {
-        // A table that is already gone is the desired state, not a failure.
-        Ok(())
+fn nft_table_exists_for_runtime(table: &str) -> Result<bool, DatapathError> {
+    let output = Command::new("nft")
+        .args(["list", "table", "inet", table])
+        .output()
+        .map_err(|source| DatapathError::SetupFailed {
+            what: "nft",
+            machine_id: String::new(),
+            source,
+        })?;
+    Ok(output.status.success())
+}
+
+fn list_nft_chain(table: &str, chain: &str) -> Result<String, DatapathError> {
+    let output = Command::new("nft")
+        .args(["-a", "list", "chain", "inet", table, chain])
+        .output()
+        .map_err(|source| DatapathError::SetupFailed {
+            what: "nft",
+            machine_id: String::new(),
+            source,
+        })?;
+    if !output.status.success() {
+        return Err(DatapathError::PrivilegeRequired {
+            operation: "listing nftables rules",
+            detail: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
     }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn delete_machine_nft(table: &str, iface: &str, machine_id: &str) -> Result<(), DatapathError> {
+    if !nft_table_exists_for_runtime(table)? {
+        return Ok(());
+    }
+    let forward_chain = forward_chain_name(machine_id);
+    let nat_chain = nat_chain_name(machine_id);
+    let forward = list_nft_chain(table, NFT_FORWARD_CHAIN)?;
+    let postrouting = list_nft_chain(table, NFT_POSTROUTING_CHAIN)?;
+    let mut rules = String::new();
+    for handle in jump_handles(&forward, &forward_chain, iface)? {
+        rules.push_str(&format!(
+            "delete rule inet {table} {NFT_FORWARD_CHAIN} handle {handle}\n"
+        ));
+    }
+    for handle in jump_handles(&postrouting, &nat_chain, iface)? {
+        rules.push_str(&format!(
+            "delete rule inet {table} {NFT_POSTROUTING_CHAIN} handle {handle}\n"
+        ));
+    }
+    rules.push_str(&format!(
+        "delete chain inet {table} {forward_chain}\n\
+         delete chain inet {table} {nat_chain}\n"
+    ));
+    apply_nft(&rules)?;
+    remove_shared_table_if_empty(table)
+}
+
+fn jump_handles(
+    chain_listing: &str,
+    target_chain: &str,
+    iface: &str,
+) -> Result<Vec<u64>, DatapathError> {
+    let target = format!("jump {target_chain}");
+    let interface = format!("\"{iface}\"");
+    let mut handles = Vec::new();
+    for line in chain_listing.lines() {
+        if !line.contains(&target) || !line.contains(&interface) {
+            continue;
+        }
+        let handle = line
+            .split("# handle ")
+            .nth(1)
+            .and_then(|value| value.split_whitespace().next())
+            .and_then(|value| value.parse::<u64>().ok())
+            .ok_or_else(|| DatapathError::PrivilegeRequired {
+                operation: "identifying nftables teardown rules",
+                detail: format!("rule for {iface} has no nft handle"),
+            })?;
+        handles.push(handle);
+    }
+    Ok(handles)
+}
+
+fn remove_shared_table_if_empty(table: &str) -> Result<(), DatapathError> {
+    if !nft_table_exists_for_runtime(table)? {
+        return Ok(());
+    }
+    let listing = {
+        let output = Command::new("nft")
+            .args(["list", "table", "inet", table])
+            .output()
+            .map_err(|source| DatapathError::SetupFailed {
+                what: "nft",
+                machine_id: String::new(),
+                source,
+            })?;
+        if !output.status.success() {
+            return Ok(());
+        }
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    };
+    let has_machine_chain = listing.lines().any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with("chain mvmn_f_") || trimmed.starts_with("chain mvmn_n_")
+    });
+    if !has_machine_chain {
+        let rules = format!("delete table inet {table}\n");
+        apply_nft(&rules)?;
+    }
+    Ok(())
 }
 
 /// Assign the host address, set the MTU, and bring the interface up.
@@ -587,15 +794,18 @@ mod tests {
     #[test]
     fn distinct_machines_get_distinct_devices() {
         assert_ne!(device_name("vm-a"), device_name("vm-b"));
-        assert_ne!(table_name("vm-a"), table_name("vm-b"));
+        assert_eq!(table_name("vm-a"), table_name("vm-b"));
+        assert_ne!(forward_chain_name("vm-a"), forward_chain_name("vm-b"));
+        assert_ne!(nat_chain_name("vm-a"), nat_chain_name("vm-b"));
     }
 
     #[test]
     fn a_hostile_machine_id_cannot_smuggle_shell_or_nft_syntax() {
         let hostile = "a; nft flush ruleset; echo \"$(id)\" `whoami` -- --";
-        let table = table_name(hostile);
         let device = device_name(hostile);
-        for name in [&table, &device] {
+        let forward = forward_chain_name(hostile);
+        let nat = nat_chain_name(hostile);
+        for name in [&forward, &nat, &device] {
             assert!(
                 name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'),
                 "{name} carries characters that are not [a-z0-9_]"
@@ -607,7 +817,7 @@ mod tests {
         // and injection is what would *add* statements, so compare the
         // counts against a benign id instead.
         let guest = Ipv4Addr::new(10, 201, 0, 6);
-        let hostile_rules = nft_ruleset(&table, &device, guest);
+        let hostile_rules = nft_ruleset(&table_name(hostile), &device, guest);
         let benign_rules = nft_ruleset(&table_name("vm-a"), &device_name("vm-a"), guest);
         for syntax in [';', '{', '}', '\n'] {
             assert_eq!(
@@ -638,21 +848,31 @@ mod tests {
     }
 
     #[test]
-    fn the_ruleset_defaults_to_drop_and_pins_the_guest_source() {
+    fn the_ruleset_keeps_one_shared_default_drop_and_pins_the_guest_source() {
         let rules = nft_ruleset("mvmn_vma", "mvmnvma", Ipv4Addr::new(10, 201, 0, 6));
         assert!(rules.contains("policy drop"), "{rules}");
-        assert!(rules.contains("ip saddr 10.201.0.6/32 accept"), "{rules}");
+        assert!(
+            rules.contains("ip saddr 10.201.0.6/32 counter accept"),
+            "{rules}"
+        );
         assert!(
             rules.contains("ip saddr 10.201.0.6/32 masquerade"),
             "{rules}"
         );
         assert!(
-            rules.contains("ct state established,related accept"),
+            rules.contains("ct state established,related counter accept"),
             "return traffic must be stateful: {rules}"
         );
         assert!(
             rules.contains("iifname \"mvmnvma\" drop"),
             "a final fail-closed rule must follow the accepts: {rules}"
+        );
+        assert!(rules.contains("jump mvmn_f_mvmnvma"), "{rules}");
+        assert!(rules.contains("jump mvmn_n_mvmnvma"), "{rules}");
+        assert_eq!(
+            rules.matches("type filter hook forward").count(),
+            1,
+            "the shared table must own exactly one forward base chain: {rules}"
         );
     }
 
@@ -665,6 +885,26 @@ mod tests {
                 "the L3 path must not reference {forbidden}: {rules}"
             );
         }
+    }
+
+    #[test]
+    fn jump_handles_only_select_the_named_machine_interface() {
+        let listing = r#"
+            iifname "mvmna" jump mvmn_f_a # handle 11
+            iifname "mvmnb" jump mvmn_f_b # handle 12
+            oifname "mvmna" jump mvmn_f_a # handle 13
+        "#;
+        assert_eq!(
+            jump_handles(listing, "mvmn_f_a", "mvmna").expect("handles"),
+            vec![11, 13]
+        );
+        assert!(jump_handles(listing, "mvmn_f_a", "mvmnb").is_empty());
+    }
+
+    #[test]
+    fn jump_handles_reject_a_matching_rule_without_a_kernel_handle() {
+        let listing = r#"iifname "mvmna" jump mvmn_f_a"#;
+        assert!(jump_handles(listing, "mvmn_f_a", "mvmna").is_err());
     }
 
     #[test]

--- a/crates/mvm-hostd/tests/l3_linux_privileged.rs
+++ b/crates/mvm-hostd/tests/l3_linux_privileged.rs
@@ -12,7 +12,14 @@
 
 use std::net::Ipv4Addr;
 
-use mvm_hostd::netd::{DatapathRequest, ForwardingCapabilities, L3Datapath, linux::LinuxDatapath};
+use mvm_core::policy::projection::{CanonicalEgress, CanonicalRule, Proto};
+use mvm_hostd::netd::{
+    DatapathHandle, DatapathRequest, ForwardingCapabilities, L3Datapath, linux::LinuxDatapath,
+};
+use mvm_net::l3::{
+    AddressLease, DnsBindingStore, FlowTable, IngressTable, L3Admitter, L3PolicyConfig,
+    OutboundVerdict,
+};
 
 /// Whether the privileged lane is enabled. Absent, every test here reports
 /// success without asserting anything — the alternative is a suite that is
@@ -29,6 +36,77 @@ fn request(machine_id: &str, third_octet: u8) -> DatapathRequest {
         prefix_len: 30,
         mtu: 1500,
     }
+}
+
+fn udp_packet(src: Ipv4Addr, dst: Ipv4Addr, dst_port: u16) -> Vec<u8> {
+    let payload = b"live-witness";
+    let total = 20 + 8 + payload.len();
+    let mut packet = vec![0u8; 20];
+    packet[0] = 0x45;
+    packet[2..4].copy_from_slice(&(total as u16).to_be_bytes());
+    packet[8] = 64;
+    packet[9] = 17;
+    packet[12..16].copy_from_slice(&src.octets());
+    packet[16..20].copy_from_slice(&dst.octets());
+    let mut udp = vec![0u8; 8];
+    udp[0..2].copy_from_slice(&40000u16.to_be_bytes());
+    udp[2..4].copy_from_slice(&dst_port.to_be_bytes());
+    udp[4..6].copy_from_slice(&((8 + payload.len()) as u16).to_be_bytes());
+    packet.extend_from_slice(&udp);
+    packet.extend_from_slice(payload);
+    packet
+}
+
+fn admitting_policy(req: &DatapathRequest) -> L3Admitter {
+    let policy = L3PolicyConfig {
+        egress: CanonicalEgress::Rules(vec![CanonicalRule {
+            proto: Proto::Udp,
+            net: "93.184.216.0/24".parse().expect("test CIDR is valid"),
+            port_lo: 9999,
+            port_hi: 9999,
+        }]),
+        ..L3PolicyConfig::default()
+    };
+    let mut admitter = L3Admitter::new(
+        AddressLease::for_test(req.gateway, req.guest),
+        policy,
+        FlowTable::with_defaults(),
+        DnsBindingStore::with_defaults(),
+        IngressTable::with_defaults(),
+    );
+    admitter.set_ready(true);
+    admitter
+}
+
+fn send_admitted_packet(
+    handle: &mut dyn DatapathHandle,
+    admitter: &mut L3Admitter,
+    packet: &[u8],
+    tick: u64,
+) {
+    match admitter.admit_outbound(packet, tick) {
+        OutboundVerdict::Forward(packet) => handle.send_to_network(&packet).expect("write packet"),
+        other => panic!("the packet must be admitted, got {other:?}"),
+    }
+}
+
+fn nft_chain_listing(table: &str, chain: &str) -> String {
+    let output = std::process::Command::new("nft")
+        .args(["-a", "list", "chain", "inet", table, chain])
+        .output()
+        .expect("nft list chain");
+    assert!(output.status.success(), "nft list chain failed: {output:?}");
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn counter_packets(listing: &str, rule_fragment: &str) -> u64 {
+    listing
+        .lines()
+        .find(|line| line.contains(rule_fragment))
+        .and_then(|line| line.split("counter packets ").nth(1))
+        .and_then(|value| value.split_whitespace().next())
+        .and_then(|value| value.parse().ok())
+        .unwrap_or_else(|| panic!("missing packet counter for {rule_fragment}: {listing}"))
 }
 
 /// Read the interface list straight from the kernel rather than shelling
@@ -187,13 +265,127 @@ fn the_host_tun_is_not_something_a_guest_can_address() {
         .output()
         .expect("nft list");
     let rules = String::from_utf8_lossy(&listing.stdout);
-    assert!(rules.contains("policy drop"), "{rules}");
     assert!(
         rules.contains(&req.guest.to_string()),
         "the ruleset must pin the assigned guest address: {rules}"
     );
+    assert!(
+        rules.contains("policy drop"),
+        "the shared forward chain must default-deny: {rules}"
+    );
+    assert!(
+        rules.contains(&format!("iifname \"{iface}\" drop")),
+        "spoofed packets from this machine must be dropped: {rules}"
+    );
+    assert!(
+        rules.contains(&format!("oifname \"{iface}\" drop")),
+        "unsolicited packets to this machine must be dropped: {rules}"
+    );
 
     handle.close().expect("close");
+}
+
+/// Two machines must be able to coexist under one host-wide default-drop
+/// chain. A machine-specific chain may only be reached by jumps scoped to its
+/// own interface, so it cannot drop the other machine's traffic.
+#[test]
+fn two_open_machines_keep_each_others_forwarding_rules_active() {
+    if !enabled() {
+        eprintln!("skipping: set MVM_L3_PRIVILEGED_TESTS=1");
+        return;
+    }
+    let dp = LinuxDatapath::new();
+    let a = request("privtest-forward-a", 70);
+    let b = request("privtest-forward-b", 71);
+    let table = mvm_hostd::netd::linux::table_name(&a.machine_id);
+    let a_iface = mvm_hostd::netd::linux::device_name(&a.machine_id);
+    let b_iface = mvm_hostd::netd::linux::device_name(&b.machine_id);
+
+    let mut ha = dp.open(&a).expect("open machine a");
+    let mut hb = dp.open(&b).expect("open machine b");
+    assert!(nft_table_exists(&table));
+
+    let listing = std::process::Command::new("nft")
+        .args(["list", "table", "inet", &table])
+        .output()
+        .expect("nft list shared table");
+    let rules = String::from_utf8_lossy(&listing.stdout);
+    assert!(rules.contains("policy drop"), "{rules}");
+    for iface in [&a_iface, &b_iface] {
+        assert!(
+            rules.contains(&format!("iifname \"{iface}\" drop")),
+            "{iface} must retain source anti-spoofing: {rules}"
+        );
+        assert!(
+            rules.contains(&format!("oifname \"{iface}\" drop")),
+            "{iface} must retain destination default-deny: {rules}"
+        );
+    }
+
+    // Removing one machine must not remove the shared table or the other
+    // machine's chains.
+    ha.close().expect("close machine a");
+    assert!(nft_table_exists(&table));
+    let remaining = std::process::Command::new("nft")
+        .args(["list", "table", "inet", &table])
+        .output()
+        .expect("nft list remaining table");
+    let remaining_rules = String::from_utf8_lossy(&remaining.stdout);
+    assert!(
+        remaining_rules.contains(&format!("iifname \"{b_iface}\" drop")),
+        "machine b's source anti-spoofing must survive machine a teardown: {remaining_rules}"
+    );
+
+    hb.close().expect("close machine b");
+    assert!(!nft_table_exists(&table));
+}
+
+/// The shared forward hook must actually admit traffic for both machines,
+/// not merely retain both sets of rules in the table listing.
+#[test]
+fn two_machines_forward_admitted_packets_through_the_shared_hook() {
+    if !enabled() {
+        eprintln!("skipping: set MVM_L3_PRIVILEGED_TESTS=1");
+        return;
+    }
+    let dp = LinuxDatapath::new();
+    let a = request("privtest-packet-a", 72);
+    let b = request("privtest-packet-b", 73);
+    let table = mvm_hostd::netd::linux::table_name(&a.machine_id);
+    let a_chain = mvm_hostd::netd::linux::forward_chain_name(&a.machine_id);
+    let b_chain = mvm_hostd::netd::linux::forward_chain_name(&b.machine_id);
+    let mut ha = dp.open(&a).expect("open machine a");
+    let mut hb = dp.open(&b).expect("open machine b");
+    let mut aa = admitting_policy(&a);
+    let mut ab = admitting_policy(&b);
+
+    send_admitted_packet(
+        ha.as_mut(),
+        &mut aa,
+        &udp_packet(a.guest, Ipv4Addr::new(93, 184, 216, 5), 9999),
+        1,
+    );
+    send_admitted_packet(
+        hb.as_mut(),
+        &mut ab,
+        &udp_packet(b.guest, Ipv4Addr::new(93, 184, 216, 6), 9999),
+        1,
+    );
+
+    let a_listing = nft_chain_listing(&table, &a_chain);
+    let b_listing = nft_chain_listing(&table, &b_chain);
+    assert!(
+        counter_packets(&a_listing, &format!("ip saddr {}/32", a.guest)) > 0,
+        "machine a's admitted packet must traverse its forward chain: {a_listing}"
+    );
+    assert!(
+        counter_packets(&b_listing, &format!("ip saddr {}/32", b.guest)) > 0,
+        "machine b's admitted packet must traverse its forward chain: {b_listing}"
+    );
+
+    ha.close().expect("close machine a");
+    hb.close().expect("close machine b");
+    assert!(!nft_table_exists(&table));
 }
 
 /// Read an interface's RX packet counter. This is the kernel's own view of
@@ -220,12 +412,6 @@ fn an_admitted_packet_reaches_the_host_stack_and_a_denied_one_does_not() {
         eprintln!("skipping: set MVM_L3_PRIVILEGED_TESTS=1");
         return;
     }
-    use mvm_core::policy::projection::{CanonicalEgress, CanonicalRule, Proto};
-    use mvm_net::l3::{
-        AddressLease, DnsBindingStore, FlowTable, IngressTable, L3Admitter, L3PolicyConfig,
-        OutboundVerdict,
-    };
-
     let dp = LinuxDatapath::new();
     let req = request("privtest-fwd", 50);
     let iface = mvm_hostd::netd::linux::device_name(&req.machine_id);
@@ -233,46 +419,7 @@ fn an_admitted_packet_reaches_the_host_stack_and_a_denied_one_does_not() {
 
     // A lease matching the datapath's addressing, and a policy admitting
     // exactly one destination and port.
-    let lease = AddressLease::for_test(req.gateway, req.guest);
-    let policy = L3PolicyConfig {
-        egress: CanonicalEgress::Rules(vec![CanonicalRule {
-            proto: Proto::Udp,
-            // A routable public range. Documentation and benchmarking
-            // ranges are refused by the address-class check before the
-            // allow-list is reached, which would test the wrong thing.
-            net: "93.184.216.0/24".parse().unwrap(),
-            port_lo: 9999,
-            port_hi: 9999,
-        }]),
-        ..L3PolicyConfig::default()
-    };
-    let mut admitter = L3Admitter::new(
-        lease,
-        policy,
-        FlowTable::with_defaults(),
-        DnsBindingStore::with_defaults(),
-        IngressTable::with_defaults(),
-    );
-    admitter.set_ready(true);
-
-    fn udp_packet(src: Ipv4Addr, dst: Ipv4Addr, dst_port: u16) -> Vec<u8> {
-        let payload = b"live-witness";
-        let total = 20 + 8 + payload.len();
-        let mut p = vec![0u8; 20];
-        p[0] = 0x45;
-        p[2..4].copy_from_slice(&(total as u16).to_be_bytes());
-        p[8] = 64;
-        p[9] = 17;
-        p[12..16].copy_from_slice(&src.octets());
-        p[16..20].copy_from_slice(&dst.octets());
-        let mut u = vec![0u8; 8];
-        u[0..2].copy_from_slice(&40000u16.to_be_bytes());
-        u[2..4].copy_from_slice(&dst_port.to_be_bytes());
-        u[4..6].copy_from_slice(&((8 + payload.len()) as u16).to_be_bytes());
-        p.extend_from_slice(&u);
-        p.extend_from_slice(payload);
-        p
-    }
+    let mut admitter = admitting_policy(&req);
 
     // A destination the policy refuses: nothing may reach the device.
     let before_denied = rx_packets(&iface);

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -335,7 +335,9 @@ for detailed scope and acceptance criteria.
         with a local standalone authority, capability-gated forwarding
         backends, and the launch-specification no-guest-NIC guard
   - [x] Privileged Linux lane executed on a Linux/KVM host: real host TUN,
-        real nftables, live forwarding witness, verified-clean teardown
+        real nftables, one shared default-drop forward hook with isolated
+        per-machine chains, live forwarding witnesses for two machines,
+        verified-clean teardown (nine privileged tests)
   - [x] BDD suite `s25_l3_vsock` (23 hermetic scenarios)
   - [x] Workload `VmmSpec` mapping carries the typed L3 control/data channels;
         netd socket layout follows the selected backend

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -484,11 +484,15 @@ updates only its own entry below.
       ingress), guest `mvm-net-agent`, machine-scoped host gateway, Linux
       host-TUN/nftables datapath, `CONFIG_TUN` in the workload kernel, and
       the amendment's backend-neutral guest channel, per-boot VM identity,
-      signed network lease, and capability-gated forwarding. Wired through
+      signed network lease, and capability-gated forwarding. The Linux
+      nftables datapath now uses one shared default-drop forward hook with
+      interface-scoped per-machine chains, so concurrent machines do not
+      drop each other's admitted traffic. Wired through
       the launch path: synthesis derives the L3 spec from the admitted mode,
       the workload runner starts the gateway and waits for it to bind before
       the guest boots, and every stop path reaps it. Privileged Linux lane
-      run on a KVM host (6/6, live forwarding witness, clean teardown); 23
+      run on a KVM host (nine tests, two-machine live forwarding witnesses,
+      clean teardown); 23
       hermetic BDD scenarios in `s25_l3_vsock`. macOS is capability-declared
       and refuses; native Windows is not claimed. Follow-up issue #2186 now
       closes the remaining launch-shape seam: every standing channel in

--- a/specs/plans/285-l3-tun-over-vsock.md
+++ b/specs/plans/285-l3-tun-over-vsock.md
@@ -88,6 +88,10 @@ Read ADR-036 first; this plan is the sequencing and the checkbox ledger.
 - [x] Linux datapath: host TUN + per-machine netns + narrow routes +
       nftables via the existing `NftApplier` seam; no bridge, no TAP,
       no Firecracker net device
+- [x] nftables isolation: all machines share one `inet mvmn` table and one
+      `forward` base chain with a host-wide default drop; each machine owns
+      interface-scoped jump chains for filtering and NAT, and serialized
+      updates/teardown remove only that machine's rules
 - [x] macOS datapath: fails closed with a named error; admission
       refuses `l3-vsock` on macOS
 - [x] deterministic cleanup on stop and on failed startup
@@ -147,9 +151,10 @@ Read ADR-036 first; this plan is the sequencing and the checkbox ledger.
       protocol, real policy, real gateway, mock datapath — covers
       scenarios 1–8 of the brief
 - [x] privileged Linux end-to-end with real TUN/nftables, gated behind
-      `MVM_L3_PRIVILEGED_TESTS=1`; executed on a Linux/KVM host — 6/6 green,
-      including a live forwarding witness that reads the kernel's own RX
-      counter, and a verified-clean teardown
+      `MVM_L3_PRIVILEGED_TESTS=1`; the lane now contains nine tests,
+      including live forwarding witnesses for two concurrent machines,
+      kernel counters, and verified-clean teardown; Linux/KVM execution is
+      the acceptance gate
 - [x] BDD suite `s25_l3_vsock` (23 scenarios)
 - [x] `UdsGuestChannelProvider` — the concrete per-port Unix-socket
       transport behind the backend-neutral abstraction, covering


### PR DESCRIPTION
## Summary

Fix multi-machine Linux L3 forwarding isolation by moving nftables ownership to one shared `inet mvmn` table with one host-wide `forward` base chain. Each machine now gets interface-scoped filter and NAT chains reached through per-machine jumps.

## Root cause

Each machine previously installed its own `forward` base chain with `policy drop`. Since nftables base chains all see the same host forwarding path, one machine's default drop could reject another machine's already-admitted traffic.

## Changes

- Preserve one shared default-drop `forward` hook and shared `postrouting` hook.
- Add per-machine filter/NAT chains and interface-scoped jumps.
- Serialize nftables install and teardown across netd processes.
- Remove only the closing machine's jump rules and chains; remove the shared table only when empty.
- Add multi-machine privileged witnesses, nft counter checks, cleanup checks, and teardown-handle parser tests.
- Update the L3 plan, sprint ledger, and refactor rollup.

## Validation

- `cargo fmt --all -- --check`
- Repository pre-commit workspace clippy passed.
- Host `mvm-hostd` check passed.
- Linux privileged integration target cross-compiled successfully.
- Real `MVM_L3_PRIVILEGED_TESTS=1` execution remains required on the builder/KVM host.

Closes #2184.
