### PR TITLE
perf: in-memory builds and streamed OCI layer unpack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,7 +143,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -148,7 +154,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -457,6 +463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +515,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -921,6 +960,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +1048,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1401,7 +1484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1780,6 +1863,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +1904,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2252,10 +2352,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2930,6 +3050,7 @@ dependencies = [
  "am-fs-ext4",
  "async-trait",
  "base64",
+ "criterion",
  "ext4-view",
  "flate2",
  "hex",
@@ -3254,7 +3375,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3407,6 +3528,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3528,6 +3655,34 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polyval"
@@ -3760,7 +3915,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4090,7 +4245,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4158,7 +4313,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4717,7 +4872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4892,7 +5047,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4911,7 +5066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5019,6 +5174,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -6239,7 +6404,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,6 +2737,7 @@ dependencies = [
  "mvm-sdk",
  "nix 0.29.0",
  "rand 0.8.6",
+ "rayon",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,6 +2933,7 @@ dependencies = [
  "hex",
  "libc",
  "mvm-contract",
+ "rayon",
  "reqwest",
  "rustix",
  "rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,6 +2931,7 @@ dependencies = [
  "async-trait",
  "base64",
  "ext4-view",
+ "flate2",
  "hex",
  "libc",
  "mvm-contract",

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -66,6 +66,7 @@ lzma-rs = "0.3"
 
 mvm-core.workspace = true
 mvm-fs.workspace = true
+rayon = "1"
 mvm-agentd.workspace = true
 # `LibkrunNetworkProvider` impls the `NetworkProvider`
 # seam. mvm-net deps only mvm-core + mvm-sdk, so this edge is acyclic.

--- a/crates/mvm-build/src/initramfs.rs
+++ b/crates/mvm-build/src/initramfs.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use mvm_core::arch::GuestArch;
 use mvm_core::build_env::ShellEnvironment;
 use mvm_fs::initramfs::{InitramfsArtifact, InitramfsResolver};
+use rayon::prelude::*;
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -358,15 +359,17 @@ pub fn install_initramfs_into_cache(
     crate::cache_install::reap_stale_staging(parent, &arch_dir);
     std::fs::create_dir(&staging)?;
 
-    for file in [
+    let files = [
         mvm_fs::initramfs::INITRAMFS_IMAGE_FILE,
         mvm_fs::initramfs::INITRAMFS_HASH_FILE,
         mvm_fs::initramfs::INITRAMFS_SIZE_FILE,
         mvm_fs::initramfs::VERSION_FILE,
-    ] {
+    ];
+    files.into_par_iter().try_for_each(|file| {
         std::fs::copy(source_dir.join(file), staging.join(file))?;
         set_cache_perms(&staging.join(file))?;
-    }
+        Ok::<(), InitramfsBuildError>(())
+    })?;
 
     // Verify before the rename, so a corrupt artifact never becomes visible
     // to a resolver.

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -469,13 +469,30 @@ pub fn materialize_ext4_pure(
     if let Some(label) = &input.volume_label {
         options = options.with_volume_label(label.as_bytes());
     }
-    let materialized =
-        mvm_fs::rootfs::materialize_ext4_pure(&input.unpacked_root, &input.output, &options)?;
-    let verity_root_hash = maybe_emit_verity_sidecars(input)?;
+    // Build the whole image in memory so we can compute dm-verity before any
+    // disk write, avoiding a full read-back of the just-written rootfs.
+    let (image, size_bytes) = mvm_fs::rootfs::build_ext4_pure(&input.unpacked_root, &options)?;
+
+    if let Some(parent) = input.output.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| RootfsError::WriteOutput {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    std::fs::write(&input.output, &image).map_err(|source| RootfsError::WriteOutput {
+        path: input.output.clone(),
+        source,
+    })?;
+
+    let verity_root_hash = if input.emit_verity {
+        Some(emit_verity_sidecars_for_image(&input.output, &image)?)
+    } else {
+        None
+    };
 
     Ok(MaterializedExt4 {
-        path: materialized.path,
-        size_bytes: materialized.size_bytes,
+        path: input.output.clone(),
+        size_bytes,
         verity_root_hash,
     })
 }

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -505,7 +505,7 @@ fn write_sidecar(path: &std::path::Path, body: &[u8]) -> Result<(), RootfsError>
     })
 }
 
-#[cfg(feature = "pure-mkfs")]
+#[cfg(all(feature = "pure-mkfs", feature = "builder-vm"))]
 fn maybe_emit_verity_sidecars(input: &MaterializeExt4Input) -> Result<Option<String>, RootfsError> {
     if !input.emit_verity {
         return Ok(None);

--- a/crates/mvm-build/src/runtime_overlay.rs
+++ b/crates/mvm-build/src/runtime_overlay.rs
@@ -23,6 +23,7 @@
 //! instead of rebuilding or re-downloading it.
 
 use mvm_core::arch::GuestArch;
+use rayon::prelude::*;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -197,14 +198,19 @@ pub fn build_runtime_overlay_from_guest_binaries(
     let root = staging.path().join("overlay-root");
     std::fs::create_dir_all(&root)?;
 
-    stage_runtime_overlay_binary(&bins.agent, &root.join("agent"))?;
-    stage_runtime_overlay_binary(&bins.netinit, &root.join("netinit"))?;
-    stage_runtime_overlay_binary(&bins.ping, &root.join("ping"))?;
-    stage_runtime_overlay_binary(&bins.seccomp_apply, &root.join("seccomp-apply"))?;
-    stage_runtime_overlay_binary(&bins.runner, &root.join("runner"))?;
-    stage_runtime_overlay_binary(&bins.egress_client, &root.join("egress-client"))?;
-    stage_runtime_overlay_binary(&bins.addon_dns, &root.join("addon-dns"))?;
-    stage_runtime_overlay_binary(&bins.exit_report, &root.join("exit-report"))?;
+    let binaries = [
+        (&bins.agent, root.join("agent")),
+        (&bins.netinit, root.join("netinit")),
+        (&bins.ping, root.join("ping")),
+        (&bins.seccomp_apply, root.join("seccomp-apply")),
+        (&bins.runner, root.join("runner")),
+        (&bins.egress_client, root.join("egress-client")),
+        (&bins.addon_dns, root.join("addon-dns")),
+        (&bins.exit_report, root.join("exit-report")),
+    ];
+    binaries
+        .into_par_iter()
+        .try_for_each(|(src, dst)| stage_runtime_overlay_binary(src, &dst))?;
     std::fs::write(root.join("VERSION"), format!("{version}\n"))?;
 
     let image = mvm_fs::ext4::build_image(&collect_overlay_nodes(&root)?).map_err(|e| {
@@ -222,13 +228,17 @@ pub fn build_runtime_overlay_from_guest_binaries(
 
     let artifact_dir = staging.path().join("artifact");
     std::fs::create_dir_all(&artifact_dir)?;
-    std::fs::write(artifact_dir.join("overlay.ext4"), &image)?;
-    std::fs::write(artifact_dir.join("overlay.verity"), &verity.hash_tree)?;
-    std::fs::write(
-        artifact_dir.join("overlay.roothash"),
-        format!("{roothash}\n"),
-    )?;
-    std::fs::write(artifact_dir.join("VERSION"), format!("{version}\n"))?;
+    let roothash_body = format!("{roothash}\n");
+    let version_body = format!("{version}\n");
+    let artifact_writes = [
+        ("overlay.ext4", image.as_slice()),
+        ("overlay.verity", verity.hash_tree.as_slice()),
+        ("overlay.roothash", roothash_body.as_bytes()),
+        ("VERSION", version_body.as_bytes()),
+    ];
+    artifact_writes
+        .into_par_iter()
+        .try_for_each(|(name, bytes)| std::fs::write(artifact_dir.join(name), bytes))?;
 
     let built = read_overlay_artifact_from_dir(&artifact_dir, &arch.to_string())?;
     install_overlay_into_cache(&built, cache_root, &InstallOptions { overwrite: true })?;
@@ -763,10 +773,15 @@ pub fn install_overlay_into_cache(
     crate::cache_install::reap_stale_staging(parent, &source.arch);
     std::fs::create_dir(&staging)?;
 
-    install_file_with_perms(&source.overlay_ext4, &staging.join("overlay.ext4"))?;
-    install_file_with_perms(&source.sidecar, &staging.join("overlay.verity"))?;
-    install_file_with_perms(&source.roothash_file, &staging.join("overlay.roothash"))?;
-    install_file_with_perms(&source_version_file, &staging.join("VERSION"))?;
+    let cache_copies = [
+        (&source.overlay_ext4, staging.join("overlay.ext4")),
+        (&source.sidecar, staging.join("overlay.verity")),
+        (&source.roothash_file, staging.join("overlay.roothash")),
+        (&source_version_file, staging.join("VERSION")),
+    ];
+    cache_copies
+        .into_par_iter()
+        .try_for_each(|(src, dst)| install_file_with_perms(src, &dst))?;
     write_checksum_manifest(&staging)?;
     std::fs::write(
         staging.join(LOCAL_BUILD_EPOCH_FILE),

--- a/crates/mvm-cli/src/commands/image/ingest.rs
+++ b/crates/mvm-cli/src/commands/image/ingest.rs
@@ -4,13 +4,17 @@
 
 use std::fs;
 use std::io::{BufReader, Read};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+use flate2::read::GzDecoder;
 
 use mvm_build::rootfs::MaterializeExt4Input;
 use mvm_core::domain::manifest::canonical_key_for_path;
-use mvm_fs::oci::{LinuxPlatform, read_oci_archive};
+use mvm_fs::oci::{
+    LinuxPlatform, UnpackOptions, read_oci_archive, stream_oci_archive,
+    unpack_layer_with_prior_paths,
+};
 
 use super::cache::sha256_hex;
 use super::materialize::{
@@ -41,7 +45,7 @@ pub(super) fn ingest_local_archive(
     }
     let file = fs::File::open(archive_path)
         .with_context(|| format!("open OCI archive {}", archive_path.display()))?;
-    ingest_archive_from_reader(
+    ingest_archive_streamed(
         cache_root,
         BufReader::new(file),
         supplied_reference,
@@ -72,6 +76,120 @@ pub(super) fn ingest_stdin_archive(
         "stdin_archive",
         "OCI archive on stdin",
     )
+}
+
+/// True for OCI layer media types that are gzip-compressed tarballs.
+fn is_gzip_layer(media_type: &str) -> bool {
+    media_type.ends_with("+gzip")
+        || media_type.ends_with(".gzip")
+        || media_type.contains("tar.gzip")
+}
+
+/// Stream a seekable local OCI archive straight to unpacked layers without
+/// buffering every blob in memory. This mirrors [`ingest_archive_from_reader`]
+/// but uses [`stream_oci_archive`], which builds an entry offset map and then
+/// hands each layer blob to the hardened unpacker as a sized stream.
+fn ingest_archive_streamed<R: Read + std::io::Seek>(
+    cache_root: &Path,
+    reader: R,
+    supplied_reference: &str,
+    source_label: &str,
+    source_descr: &str,
+) -> Result<ResolvedOciRunImage> {
+    let platform = LinuxPlatform::for_current_arch();
+    let unpacked_parent = cache_root.join("unpacked");
+    fs::create_dir_all(&unpacked_parent)
+        .with_context(|| format!("create {}", unpacked_parent.display()))?;
+    let tmp_unpack = tempfile::Builder::new()
+        .prefix("streaming-")
+        .tempdir_in(&unpacked_parent)
+        .with_context(|| "create temporary unpack directory")?;
+    let tmp_path = tmp_unpack.path().to_path_buf();
+
+    let mut prior_layer_paths = std::collections::HashSet::<PathBuf>::new();
+    let mut deferred_nodes = Vec::new();
+    let metadata = stream_oci_archive(reader, &platform, |descriptor, raw| {
+        let report = if is_gzip_layer(&descriptor.media_type) {
+            unpack_layer_with_prior_paths(
+                GzDecoder::new(raw),
+                &tmp_path,
+                &UnpackOptions::default(),
+                &prior_layer_paths,
+            )
+        } else {
+            unpack_layer_with_prior_paths(
+                raw,
+                &tmp_path,
+                &UnpackOptions::default(),
+                &prior_layer_paths,
+            )
+        }
+        .map_err(|e| mvm_fs::oci::OciError::Registry(e.to_string()))?;
+        if !report.refused.is_empty() {
+            return Err(mvm_fs::oci::OciError::Registry(format!(
+                "layer {} refused entries: {:?}",
+                descriptor.digest, report.refused
+            )));
+        }
+        prior_layer_paths.extend(report.paths_written);
+        deferred_nodes.extend(report.deferred_nodes);
+        Ok(())
+    })
+    .with_context(|| format!("stream {source_descr}"))?;
+
+    let manifest_hex = sha256_hex(&metadata.manifest_digest)?;
+    let unpacked_root = unpacked_parent.join(&manifest_hex);
+    if unpacked_root.exists() {
+        fs::remove_dir_all(&unpacked_root)
+            .with_context(|| format!("remove stale unpacked root {}", unpacked_root.display()))?;
+    }
+    fs::rename(&tmp_path, &unpacked_root).with_context(|| {
+        format!(
+            "rename unpack directory {} to {}",
+            tmp_path.display(),
+            unpacked_root.display()
+        )
+    })?;
+
+    let rootfs_rel = format!("rootfs/{manifest_hex}-{}/rootfs.ext4", oci_runtime_tag());
+    let rootfs_abs = cache_root.join(&rootfs_rel);
+    let rootfs_only_tree =
+        prepare_rootfs_only_tree(cache_root, &unpacked_root, &metadata.manifest_digest)?;
+    super::cache::write_deferred_nodes(cache_root, &metadata.manifest_digest, &deferred_nodes)?;
+    materialize_overlay_lean_rootfs(
+        cache_root,
+        &unpacked_root,
+        &rootfs_abs,
+        &metadata.manifest_digest,
+        deferred_nodes,
+    )?;
+
+    let provenance = OciProvenance {
+        schema_version: 1,
+        source: source_label.to_string(),
+        supplied_reference: supplied_reference.to_string(),
+        canonical_reference: metadata.manifest_digest.clone(),
+        registry: String::new(),
+        repository: String::new(),
+        tag: None,
+        resolved_digest: metadata.manifest_digest.clone(),
+        layer_digests: metadata
+            .layer_descriptors
+            .iter()
+            .map(|d| d.digest.clone())
+            .collect(),
+        trust_policy: "local-archive-digest-verified".to_string(),
+        verification_status: "content-digest-verified (dev)".to_string(),
+    };
+    Ok(ResolvedOciRunImage {
+        reference: metadata.manifest_digest.clone(),
+        resolved_digest: metadata.manifest_digest,
+        rootfs_path: rootfs_abs,
+        unpacked_root: Some(rootfs_only_tree),
+        pulled: true,
+        provenance,
+        auth_source: None,
+    })
 }
 
 /// Shared archive-ingest core: digest-verify the archive from `reader`, unpack
@@ -438,6 +556,28 @@ mod tests {
             "OCI archive with traversal layer",
         )
         .expect_err("local archive ingest must reject traversal entries");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("refused") || msg.contains("traversal"),
+            "got {msg}"
+        );
+    }
+
+    #[test]
+    fn local_archive_streaming_layer_traversal_is_rejected() {
+        // The seekable file path now uses stream_oci_archive, which must still
+        // reject traversal entries via the same hardened unpack_layer.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let archive_path = tmp.path().join("traversal.tar");
+        let archive = oci_archive_with_layer(&traversal_layer_gzip());
+        std::fs::write(&archive_path, archive).unwrap();
+        let err = ingest_local_archive(
+            tmp.path(),
+            &archive_path,
+            "oci-archive:traversal.tar",
+            false,
+        )
+        .expect_err("streaming local archive ingest must reject traversal entries");
         let msg = format!("{err:#}");
         assert!(
             msg.contains("refused") || msg.contains("traversal"),

--- a/crates/mvm-cli/src/commands/image/ingest.rs
+++ b/crates/mvm-cli/src/commands/image/ingest.rs
@@ -45,13 +45,29 @@ pub(super) fn ingest_local_archive(
     }
     let file = fs::File::open(archive_path)
         .with_context(|| format!("open OCI archive {}", archive_path.display()))?;
-    ingest_archive_streamed(
-        cache_root,
-        BufReader::new(file),
-        supplied_reference,
-        "local_archive",
-        &format!("OCI archive {}", archive_path.display()),
-    )
+    let source_descr = format!("OCI archive {}", archive_path.display());
+    // Stream regular files (seekable) to avoid buffering every blob; fall back
+    // to the buffered reader for pipes, stdin-style special files, etc.
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("stat OCI archive {}", archive_path.display()))?;
+    if metadata.file_type().is_file() {
+        ingest_archive_streamed(
+            cache_root,
+            BufReader::new(file),
+            supplied_reference,
+            "local_archive",
+            &source_descr,
+        )
+    } else {
+        ingest_archive_from_reader(
+            cache_root,
+            BufReader::new(file),
+            supplied_reference,
+            "local_archive",
+            &source_descr,
+        )
+    }
 }
 
 /// Ingest an OCI image-layout archive streamed on stdin (`run --image -`). Same

--- a/crates/mvm-cli/src/commands/image/pull_core.rs
+++ b/crates/mvm-cli/src/commands/image/pull_core.rs
@@ -419,12 +419,25 @@ fn fetch_or_unpack_layer(
     prior_layer_paths: &HashSet<PathBuf>,
 ) -> Result<UnpackReport> {
     let path = layer_blob_path(&layer.digest)?;
-    if let Some(bytes) = read_verified_cache_file(cache_root, &path, &layer.digest)? {
-        return unpack_layer_bytes(layer, &bytes, unpacked_root, prior_layer_paths)
-            .with_context(|| format!("unpack cached layer {}", layer.digest));
+    let cache_abs = safe_cache_path(cache_root, &path)?;
+
+    if cache_abs.exists() {
+        match runtime.block_on(mvm_fs::oci::layer::verify_and_unpack_layer_file(
+            layer,
+            &cache_abs,
+            unpacked_root,
+            &UnpackOptions::default(),
+            prior_layer_paths,
+        )) {
+            Ok(report) => return Ok(report),
+            Err(mvm_fs::oci::OciError::DigestMismatch { .. }) => {
+                // Corrupt cache: evict it and fall through to a fresh fetch.
+                let _ = std::fs::remove_file(&cache_abs);
+            }
+            Err(e) => return Err(e.into()),
+        }
     }
 
-    let cache_abs = safe_cache_path(cache_root, &path)?;
     runtime
         .block_on(fetcher.fetch_and_unpack_layer(
             image_ref,

--- a/crates/mvm-cli/src/commands/image/pull_core.rs
+++ b/crates/mvm-cli/src/commands/image/pull_core.rs
@@ -268,11 +268,16 @@ fn pull_image_ref(
     let mut prior_layer_paths = std::collections::HashSet::new();
     let mut deferred_nodes = Vec::new();
     for layer in &layers {
-        let compressed =
-            fetch_or_read_layer(cache_root, &runtime, &layer_fetcher, &image_ref, layer)
-                .with_context(|| format!("fetch layer {}", layer.digest))?;
-        let report = unpack_layer_bytes(layer, &compressed, &unpacked_root, &prior_layer_paths)
-            .with_context(|| format!("unpack layer {}", layer.digest))?;
+        let report = fetch_or_unpack_layer(
+            cache_root,
+            &runtime,
+            &layer_fetcher,
+            &image_ref,
+            layer,
+            &unpacked_root,
+            &prior_layer_paths,
+        )
+        .with_context(|| format!("layer {}", layer.digest))?;
         prior_layer_paths.extend(report.paths_written);
         deferred_nodes.extend(report.deferred_nodes);
         cached_layers.push(CachedOciLayer {
@@ -404,21 +409,32 @@ fn manifest_config_descriptor(manifest_bytes: &[u8]) -> Result<Option<LayerDescr
     }))
 }
 
-fn fetch_or_read_layer(
+fn fetch_or_unpack_layer(
     cache_root: &Path,
     runtime: &tokio::runtime::Runtime,
     fetcher: &OciLayerFetcher,
     image_ref: &ImageReference,
     layer: &LayerDescriptor,
-) -> Result<Vec<u8>> {
+    unpacked_root: &Path,
+    prior_layer_paths: &HashSet<PathBuf>,
+) -> Result<UnpackReport> {
     let path = layer_blob_path(&layer.digest)?;
     if let Some(bytes) = read_verified_cache_file(cache_root, &path, &layer.digest)? {
-        return Ok(bytes);
+        return unpack_layer_bytes(layer, &bytes, unpacked_root, prior_layer_paths)
+            .with_context(|| format!("unpack cached layer {}", layer.digest));
     }
-    let mut bytes = Vec::new();
-    runtime.block_on(fetcher.fetch_layer(image_ref, layer, &mut bytes))?;
-    super::cache::write_cache_file(cache_root, &path, &bytes)?;
-    Ok(bytes)
+
+    let cache_abs = safe_cache_path(cache_root, &path)?;
+    runtime
+        .block_on(fetcher.fetch_and_unpack_layer(
+            image_ref,
+            layer,
+            &cache_abs,
+            unpacked_root,
+            &UnpackOptions::default(),
+            prior_layer_paths,
+        ))
+        .with_context(|| format!("fetch and unpack layer {}", layer.digest))
 }
 
 pub(super) fn unpack_layer_bytes(

--- a/crates/mvm-fs/Cargo.toml
+++ b/crates/mvm-fs/Cargo.toml
@@ -12,6 +12,7 @@ description = "Image → mountable rootfs for mvm: OCI distribution client (regi
 [dependencies]
 async-trait = "0.1"
 ext4-view.workspace = true
+flate2.workspace = true
 hex.workspace = true
 libc = { workspace = true }
 mvm-contract.workspace = true

--- a/crates/mvm-fs/Cargo.toml
+++ b/crates/mvm-fs/Cargo.toml
@@ -33,8 +33,13 @@ xattr = { workspace = true }
 [dev-dependencies]
 am-fs-ext4 = "0.4"
 base64.workspace = true
+criterion = { version = "0.5", features = ["async_tokio"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "macros", "rt", "rt-multi-thread", "test-util", "time"] }
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "in_memory_build"
+harness = false

--- a/crates/mvm-fs/Cargo.toml
+++ b/crates/mvm-fs/Cargo.toml
@@ -15,6 +15,7 @@ ext4-view.workspace = true
 hex.workspace = true
 libc = { workspace = true }
 mvm-contract.workspace = true
+rayon = "1"
 reqwest.workspace = true
 rustls.workspace = true
 rustix = { version = "1.1", features = ["fs"] }

--- a/crates/mvm-fs/benches/in_memory_build.rs
+++ b/crates/mvm-fs/benches/in_memory_build.rs
@@ -1,0 +1,92 @@
+//! Criterion benchmarks for the in-memory / streamed build paths.
+
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::Path;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use mvm_fs::oci::layer::verify_and_unpack_layer_file;
+use mvm_fs::oci::{LayerDescriptor, UnpackOptions};
+use mvm_fs::rootfs::{MaterializeOptions, build_ext4_pure};
+use sha2::Digest;
+
+fn make_fixture_tree(root: &Path, files: usize, file_size: usize) {
+    for d in 0..10 {
+        std::fs::create_dir_all(root.join(format!("dir{d:02}"))).unwrap();
+    }
+    let payload = vec![0xabu8; file_size];
+    for i in 0..files {
+        let dir = format!("dir{:02}", i % 10);
+        std::fs::write(root.join(&dir).join(format!("file{i:04}.bin")), &payload).unwrap();
+    }
+}
+
+fn bench_build_ext4_pure(c: &mut Criterion) {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("rootfs");
+    make_fixture_tree(&root, 100, 64 * 1024);
+    let options = MaterializeOptions::default();
+
+    c.bench_function("build_ext4_pure_100_files_64k", |b| {
+        b.iter(|| build_ext4_pure(&root, &options).unwrap())
+    });
+}
+
+fn gzip_tar_layer(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+    for (name, bytes) in entries {
+        let mut header = tar::Header::new_gnu();
+        header.set_path(*name).unwrap();
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, *bytes).unwrap();
+    }
+    let raw = builder.into_inner().unwrap();
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(&raw).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn bench_verify_and_unpack_layer_file(c: &mut Criterion) {
+    let layer_bytes = gzip_tar_layer(&[("bench.txt", &[0xabu8; 256 * 1024])]);
+    let digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(&layer_bytes)));
+    let layer = LayerDescriptor {
+        digest,
+        size: layer_bytes.len() as u64,
+        media_type: "application/vnd.oci.image.layer.v1.tar+gzip".to_string(),
+    };
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    c.bench_function("verify_and_unpack_layer_file_256k", |b| {
+        b.iter_batched(
+            || {
+                let tmp = tempfile::tempdir().unwrap();
+                let cache = tmp.path().join("layer.tar.gz");
+                let unpacked = tmp.path().join("unpacked");
+                std::fs::create_dir_all(&unpacked).unwrap();
+                std::fs::write(&cache, &layer_bytes).unwrap();
+                (tmp, cache, unpacked)
+            },
+            |(_tmp, cache, unpacked)| {
+                rt.block_on(verify_and_unpack_layer_file(
+                    &layer,
+                    &cache,
+                    &unpacked,
+                    &UnpackOptions::default(),
+                    &HashSet::new(),
+                ))
+                .unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_build_ext4_pure,
+    bench_verify_and_unpack_layer_file
+);
+criterion_main!(benches);

--- a/crates/mvm-fs/src/ext4/mod.rs
+++ b/crates/mvm-fs/src/ext4/mod.rs
@@ -38,6 +38,9 @@ pub mod mkfs;
 pub mod verity;
 
 use std::collections::BTreeMap;
+
+use rayon::prelude::*;
+
 pub const BLOCK_SIZE: u32 = 4096;
 const BLOCK_SIZE_USIZE: usize = BLOCK_SIZE as usize;
 const INODE_SIZE: u16 = 256;
@@ -346,6 +349,12 @@ impl Image {
     }
     fn total_bytes(&self) -> u64 {
         self.total_blocks as u64 * BLOCK_SIZE as u64
+    }
+    /// Merge all blocks from `other` into this image. The caller must ensure
+    /// the two images have disjoint block sets; overlapping blocks are taken
+    /// from `other`.
+    fn merge_from(&mut self, other: Self) {
+        self.blocks.extend(other.blocks);
     }
     fn block_mut(&mut self, block: u32) -> &mut [u8; BLOCK_SIZE_USIZE] {
         self.blocks
@@ -785,20 +794,34 @@ where
     write_bitmaps(&mut img, &layout);
     write_backups(&mut img, &layout);
 
+    // Inode writes stay sequential: multiple inodes share a 4 KiB inode-table
+    // block, so parallel writers would race on the same block.
     for p in &planned {
         write_inode(&mut img, &layout, p);
-        match p.kind {
-            Kind::Dir => write_dir_blocks(&mut img, p),
-            Kind::File => {}
-            Kind::Symlink => {
-                if let Some(ext) = p.extents.first() {
-                    // Long symlink: target in a data block.
-                    let off = img.block_off(ext.phys);
+    }
+
+    // Directory and long-symlink data blocks are at disjoint physical extents,
+    // so emit them in parallel and merge back into the shared image.
+    let data_images: Vec<Image> = planned
+        .par_iter()
+        .filter(|p| p.kind == Kind::Dir || (p.kind == Kind::Symlink && !p.extents.is_empty()))
+        .map(|p| {
+            let mut local = Image::new(0);
+            match p.kind {
+                Kind::Dir => write_dir_blocks(&mut local, p),
+                Kind::Symlink => {
+                    let ext = p.extents.first().expect("filtered above");
+                    let off = local.block_off(ext.phys);
                     let t = p.symlink_target.clone().unwrap_or_default();
-                    img.put_bytes(off, t.as_bytes());
+                    local.put_bytes(off, t.as_bytes());
                 }
+                Kind::File => unreachable!(),
             }
-        }
+            local
+        })
+        .collect();
+    for local in data_images {
+        img.merge_from(local);
     }
 
     img.emit_chunks(&mut emit).map_err(EmitImageError::Emit)?;

--- a/crates/mvm-fs/src/ext4/verity.rs
+++ b/crates/mvm-fs/src/ext4/verity.rs
@@ -15,6 +15,7 @@
 //! hashed to form the level above, until one block remains — the root hash is
 //! that final block's digest.
 
+use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 
 const DIGEST_SIZE: usize = 32;
@@ -32,6 +33,7 @@ pub fn root_hash(
     // Level 0 (leaves): digest of each data block.
     let n_data_blocks = data.len().div_ceil(data_block_size).max(1);
     let mut level: Vec<[u8; DIGEST_SIZE]> = (0..n_data_blocks)
+        .into_par_iter()
         .map(|i| {
             let start = i * data_block_size;
             let end = (start + data_block_size).min(data.len());
@@ -52,6 +54,7 @@ pub fn root_hash(
         }
         // Otherwise, hash each packed block to form the level above.
         level = (0..n_blocks)
+            .into_par_iter()
             .map(|b| hash_block(salt, &pack(&level, b * hashes_per_block, hash_block_size)))
             .collect();
     }
@@ -81,6 +84,7 @@ pub fn format(
     // Level 0 (leaves): one digest per data block.
     let n_data_blocks = data.len().div_ceil(data_block_size).max(1);
     let mut cur: Vec<[u8; DIGEST_SIZE]> = (0..n_data_blocks)
+        .into_par_iter()
         .map(|i| {
             let start = i * data_block_size;
             let end = (start + data_block_size).min(data.len());
@@ -110,6 +114,7 @@ pub fn format(
         // Next level up: hash each block of this level.
         let this = levels.last().expect("just pushed");
         cur = (0..n_blocks)
+            .into_par_iter()
             .map(|b| hash_block(salt, &this[b * hash_block_size..(b + 1) * hash_block_size]))
             .collect();
     }

--- a/crates/mvm-fs/src/oci/archive.rs
+++ b/crates/mvm-fs/src/oci/archive.rs
@@ -12,14 +12,13 @@
 //! hostile archive entry name can never escape onto the host here.
 
 use std::collections::BTreeMap;
-use std::io::Read;
+use std::io::{Read, Seek, SeekFrom};
 
-use serde::Deserialize;
-
-use crate::oci::layer::LayerDescriptor;
+use crate::oci::layer::{HashingReader, LayerDescriptor};
 use crate::oci::manifest::{LinuxPlatform, matches_linux_platform};
 use crate::oci::manifest_types::OciManifest;
 use crate::oci::{OciError, verify_sha256_digest};
+use serde::Deserialize;
 
 /// Hard cap on the total bytes buffered from one archive. Blobs are
 /// content-addressed, so resolving index → manifest → layers means buffering;
@@ -58,6 +57,26 @@ pub struct OciArchiveImage {
 pub struct OciArchiveLayer {
     pub descriptor: LayerDescriptor,
     pub bytes: Vec<u8>,
+}
+
+/// Metadata for an OCI image read out of a seekable local layout archive.
+/// Unlike [`OciArchiveImage`], this does not buffer layer blobs; the caller
+/// supplies a callback to [`stream_oci_archive`] that consumes each layer
+/// stream as it is read.
+#[derive(Debug, Clone)]
+pub struct OciArchiveMetadata {
+    /// `sha256:<hex>` of the selected image manifest.
+    pub manifest_digest: String,
+    /// `sha256:<hex>` of the image config blob.
+    pub config_digest: String,
+    /// Digest-verified image config JSON blob.
+    pub config_bytes: Vec<u8>,
+    /// `architecture` from the image config.
+    pub architecture: String,
+    /// `os` from the image config.
+    pub os: String,
+    /// Layer descriptors in manifest order.
+    pub layer_descriptors: Vec<LayerDescriptor>,
 }
 
 #[derive(Deserialize)]
@@ -162,6 +181,116 @@ pub fn read_oci_archive<R: Read>(
     })
 }
 
+/// Stream a seekable OCI image-layout archive, verifying metadata blobs
+/// immediately and passing each layer blob to `on_layer` as a sized stream.
+///
+/// This is the seekable/seekable-reader counterpart to
+/// [`read_oci_archive`]: it does not buffer layer blobs into memory. The
+/// caller's callback receives the raw layer bytes and is responsible for
+/// hashing/decompressing/unpacking. After the callback returns, this function
+/// finalizes the SHA-256 digest over the streamed bytes and fails closed on
+/// mismatch.
+///
+/// `reader` must implement both [`Read`] and [`Seek`] so the implementation
+/// can build an entry offset map in one pass and then jump to each needed
+/// blob. Use [`read_oci_archive`] for non-seekable readers such as stdin.
+pub fn stream_oci_archive<R, F>(
+    mut reader: R,
+    platform: &LinuxPlatform,
+    mut on_layer: F,
+) -> Result<OciArchiveMetadata, OciError>
+where
+    R: Read + Seek,
+    F: FnMut(&LayerDescriptor, &mut dyn Read) -> Result<(), OciError>,
+{
+    let offsets = index_tar_entries(&mut reader)?;
+
+    let layout = read_blob_at(&mut reader, &offsets, OCI_LAYOUT_FILE)?;
+    let marker: OciLayoutMarker = serde_json::from_slice(&layout)
+        .map_err(|e| OciError::Registry(format!("parse oci-layout: {e}")))?;
+    if marker.image_layout_version != SUPPORTED_LAYOUT_VERSION {
+        return Err(OciError::Registry(format!(
+            "unsupported OCI image layout version {:?} (want {SUPPORTED_LAYOUT_VERSION})",
+            marker.image_layout_version
+        )));
+    }
+
+    let index_bytes = read_blob_at(&mut reader, &offsets, INDEX_FILE)?;
+    let manifest_digest = select_manifest_digest(&index_bytes, platform)?;
+
+    let manifest_path = blob_path(&manifest_digest)?;
+    let manifest_bytes = read_blob_at(&mut reader, &offsets, &manifest_path)?;
+    verify_sha256_digest(&manifest_bytes, &manifest_digest)?;
+    let OciManifest::Image(image) = serde_json::from_slice(&manifest_bytes)
+        .map_err(|e| OciError::Registry(format!("parse image manifest: {e}")))?
+    else {
+        return Err(OciError::Registry(
+            "selected manifest is an image index, not an image manifest".into(),
+        ));
+    };
+    if image.layers.is_empty() {
+        return Err(OciError::Registry(
+            "OCI image manifest has no layers".into(),
+        ));
+    }
+
+    let config_digest = image.config.digest.clone();
+    let config_path = blob_path(&config_digest)?;
+    let config_bytes = read_blob_at(&mut reader, &offsets, &config_path)?;
+    verify_sha256_digest(&config_bytes, &config_digest)?;
+    let config: ImageConfigPlatform = serde_json::from_slice(&config_bytes)
+        .map_err(|e| OciError::Registry(format!("parse image config: {e}")))?;
+    if config.os != "linux" {
+        return Err(OciError::Registry(format!(
+            "OCI image targets os {:?}, not linux",
+            config.os
+        )));
+    }
+    if config.architecture != platform.architecture {
+        return Err(OciError::Registry(format!(
+            "OCI image architecture {:?} does not match host {:?}",
+            config.architecture, platform.architecture
+        )));
+    }
+
+    let mut layer_descriptors = Vec::with_capacity(image.layers.len());
+    for entry in &image.layers {
+        let path = blob_path(&entry.digest)?;
+        let (offset, size) = offsets.get(&path).copied().ok_or_else(|| {
+            OciError::Registry(format!("OCI archive missing blob {}", entry.digest))
+        })?;
+        let descriptor = LayerDescriptor {
+            digest: entry.digest.clone(),
+            size: entry.size as u64,
+            media_type: entry.media_type.clone(),
+        };
+
+        reader
+            .seek(SeekFrom::Start(offset))
+            .map_err(|e| OciError::Registry(format!("seek to layer {}: {e}", entry.digest)))?;
+        let mut limited = (&mut reader).take(size);
+        let mut hasher = HashingReader::new(&mut limited);
+        on_layer(&descriptor, &mut hasher)?;
+        let computed = format!("sha256:{}", hex::encode(hasher.finalize()));
+        if computed != entry.digest {
+            return Err(OciError::DigestMismatch {
+                expected: entry.digest.clone(),
+                computed,
+            });
+        }
+        layer_descriptors.push(descriptor);
+    }
+
+    Ok(OciArchiveMetadata {
+        manifest_digest,
+        config_digest,
+        config_bytes,
+        architecture: config.architecture,
+        os: config.os,
+        layer_descriptors,
+    })
+}
+
 /// Slurp every tar entry into a `path -> bytes` map, normalizing a leading
 /// `./`. Only entries we resolve by exact key (`oci-layout`, `index.json`,
 /// `blobs/sha256/<hex>`) are ever read back, so a hostile entry *name* cannot
@@ -199,6 +328,63 @@ fn read_tar_entries<R: Read>(reader: R) -> Result<BTreeMap<String, Vec<u8>>, Oci
         out.insert(path, bytes);
     }
     Ok(out)
+}
+
+/// Build a `path -> (data_offset, size)` map for every regular file in a
+/// seekable tar archive, normalizing a leading `./`. This is the first pass
+/// of [`stream_oci_archive`]; no blob bytes are buffered.
+fn index_tar_entries<R: Read + Seek>(reader: R) -> Result<BTreeMap<String, (u64, u64)>, OciError> {
+    let mut archive = tar::Archive::new(reader);
+    let mut out: BTreeMap<String, (u64, u64)> = BTreeMap::new();
+    let tar_entries = archive
+        .entries()
+        .map_err(|e| OciError::Registry(format!("read OCI archive tar: {e}")))?;
+    for entry in tar_entries {
+        let entry = entry.map_err(|e| OciError::Registry(format!("OCI archive entry: {e}")))?;
+        if entry.header().entry_type() != tar::EntryType::Regular {
+            continue;
+        }
+        let path = entry
+            .path()
+            .map_err(|e| OciError::Registry(format!("OCI archive entry path: {e}")))?
+            .to_string_lossy()
+            .trim_start_matches("./")
+            .to_string();
+        let size = entry.header().size().unwrap_or(0);
+        let offset = entry.raw_file_position();
+        out.insert(path, (offset, size));
+    }
+    Ok(out)
+}
+
+/// Read a small blob by its tar path, using the offset map built by
+/// [`index_tar_entries`].
+fn read_blob_at<R: Read + Seek>(
+    reader: &mut R,
+    offsets: &BTreeMap<String, (u64, u64)>,
+    path: &str,
+) -> Result<Vec<u8>, OciError> {
+    let (offset, size) = offsets
+        .get(path)
+        .copied()
+        .ok_or_else(|| OciError::Registry(format!("OCI archive missing blob {path}")))?;
+    reader
+        .seek(SeekFrom::Start(offset))
+        .map_err(|e| OciError::Registry(format!("seek to {path}: {e}")))?;
+    let mut bytes = Vec::with_capacity(size as usize);
+    reader
+        .take(size)
+        .read_to_end(&mut bytes)
+        .map_err(|e| OciError::Registry(format!("read {path}: {e}")))?;
+    Ok(bytes)
+}
+
+/// Translate a `sha256:<hex>` digest into the archive blob path.
+fn blob_path(digest: &str) -> Result<String, OciError> {
+    let hex = digest
+        .strip_prefix("sha256:")
+        .ok_or_else(|| OciError::Registry(format!("blob digest is not sha256: {digest}")))?;
+    Ok(format!("{BLOBS_PREFIX}{hex}"))
 }
 
 /// Look up a `sha256:<hex>` blob by its content address.
@@ -261,6 +447,7 @@ fn select_manifest_digest(
 mod tests {
     use super::*;
     use sha2::{Digest, Sha256};
+    use std::io::Cursor;
 
     fn digest_of(bytes: &[u8]) -> String {
         format!("sha256:{}", hex::encode(Sha256::digest(bytes)))
@@ -527,5 +714,145 @@ mod tests {
         let full = ArchiveFixture::default().build();
         let err = read(&full[..full.len() / 2]).unwrap_err().to_string();
         assert!(!err.is_empty());
+    }
+
+    fn stream(bytes: &[u8]) -> Result<(OciArchiveMetadata, Vec<Vec<u8>>), OciError> {
+        let mut layers: Vec<Vec<u8>> = Vec::new();
+        let metadata = stream_oci_archive(
+            Cursor::new(bytes.to_vec()),
+            &LinuxPlatform::for_current_arch(),
+            |descriptor, raw| {
+                assert_eq!(
+                    descriptor.media_type,
+                    "application/vnd.oci.image.layer.v1.tar+gzip"
+                );
+                let mut buf = Vec::new();
+                raw.read_to_end(&mut buf)
+                    .map_err(|e| OciError::Registry(format!("read layer: {e}")))?;
+                layers.push(buf);
+                Ok(())
+            },
+        )?;
+        Ok((metadata, layers))
+    }
+
+    #[test]
+    fn streaming_reads_a_valid_single_arch_archive() {
+        let bytes = ArchiveFixture::default().build();
+        let (metadata, layers) = stream(&bytes).expect("stream valid archive parses");
+        assert_eq!(metadata.os, "linux");
+        assert_eq!(
+            metadata.architecture,
+            LinuxPlatform::for_current_arch().architecture
+        );
+        assert_eq!(layers.len(), 1);
+        assert_eq!(layers[0], b"layer-bytes-pretend-tar-gz");
+        assert!(metadata.manifest_digest.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn streaming_digest_mismatch_is_rejected() {
+        let f = ArchiveFixture {
+            corrupt_layer_digest: true,
+            ..Default::default()
+        };
+        let err = stream(&f.build()).unwrap_err().to_string();
+        assert!(
+            err.contains("mismatch") || err.contains("missing blob"),
+            "got {err}"
+        );
+    }
+
+    #[test]
+    fn streaming_unexpected_extra_entries_are_ignored() {
+        let f = ArchiveFixture {
+            extra_entries: vec![
+                (
+                    "blobs/sha256/unreferenced-blob".to_string(),
+                    b"junk".to_vec(),
+                ),
+                ("a-stray-top-level-file".to_string(), b"junk".to_vec()),
+            ],
+            ..Default::default()
+        };
+        let (metadata, layers) = stream(&f.build()).expect("stream archive with extras parses");
+        assert_eq!(metadata.layer_descriptors.len(), 1);
+        assert_eq!(layers.len(), 1);
+        assert_eq!(layers[0], b"layer-bytes-pretend-tar-gz");
+    }
+
+    #[test]
+    fn streaming_handles_reordered_entries() {
+        // Build an archive where the layer blob appears before the index and
+        // manifest. The offset map lets stream_oci_archive still find every
+        // blob by digest, so order is irrelevant.
+        let layer = b"layer-bytes-pretend-tar-gz".to_vec();
+        let layer_digest = digest_of(&layer);
+        let config = format!(
+            r#"{{"architecture":"{}","os":"linux","rootfs":{{"type":"layers","diff_ids":["{}"]}}}}"#,
+            LinuxPlatform::for_current_arch().architecture, layer_digest
+        )
+        .into_bytes();
+        let config_digest = digest_of(&config);
+        let manifest = format!(
+            r#"{{"schemaVersion":2,"mediaType":"{IMAGE_MANIFEST_MEDIA}","config":{{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"{config_digest}","size":{cfg_sz}}},"layers":[{{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":"{layer_digest}","size":{lyr_sz}}}]}}"#,
+            cfg_sz = config.len(),
+            lyr_sz = layer.len(),
+        )
+        .into_bytes();
+        let manifest_digest = digest_of(&manifest);
+        let index = format!(
+            r#"{{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{{"mediaType":"{IMAGE_MANIFEST_MEDIA}","digest":"{manifest_digest}","size":{mf_sz},"platform":{{"architecture":"{arch}","os":"linux"}}}}]}}"#,
+            mf_sz = manifest.len(),
+            arch = LinuxPlatform::for_current_arch().architecture,
+        )
+        .into_bytes();
+
+        let add = |b: &mut tar::Builder<Vec<u8>>, name: &str, data: &[u8]| {
+            let mut h = tar::Header::new_gnu();
+            h.set_size(data.len() as u64);
+            h.set_entry_type(tar::EntryType::Regular);
+            h.set_mode(0o644);
+            h.set_cksum();
+            b.append_data(&mut h, name, data).unwrap();
+        };
+        let mut builder = tar::Builder::new(Vec::new());
+        // Layer first, then config, then manifest, then index, then layout.
+        add(
+            &mut builder,
+            &format!(
+                "{BLOBS_PREFIX}{}",
+                layer_digest.strip_prefix("sha256:").unwrap()
+            ),
+            &layer,
+        );
+        add(
+            &mut builder,
+            &format!(
+                "{BLOBS_PREFIX}{}",
+                config_digest.strip_prefix("sha256:").unwrap()
+            ),
+            &config,
+        );
+        add(
+            &mut builder,
+            &format!(
+                "{BLOBS_PREFIX}{}",
+                manifest_digest.strip_prefix("sha256:").unwrap()
+            ),
+            &manifest,
+        );
+        add(&mut builder, INDEX_FILE, &index);
+        add(
+            &mut builder,
+            OCI_LAYOUT_FILE,
+            format!(r#"{{"imageLayoutVersion":"{SUPPORTED_LAYOUT_VERSION}"}}"#).as_bytes(),
+        );
+        let bytes = builder.into_inner().unwrap();
+
+        let (metadata, layers) = stream(&bytes).expect("reordered archive streams");
+        assert_eq!(metadata.layer_descriptors.len(), 1);
+        assert_eq!(layers.len(), 1);
+        assert_eq!(layers[0], b"layer-bytes-pretend-tar-gz");
     }
 }

--- a/crates/mvm-fs/src/oci/error.rs
+++ b/crates/mvm-fs/src/oci/error.rs
@@ -50,4 +50,9 @@ pub enum OciError {
     /// the value configured on `LayerFetchOptions::max_size`.
     #[error("layer size {declared} bytes exceeds cap of {cap} bytes")]
     LayerTooLarge { declared: u64, cap: u64 },
+
+    /// The layer tarball could not be unpacked to the caller-supplied
+    /// output root. The wrapped string is the underlying unpack error.
+    #[error("layer unpack failed: {0}")]
+    Unpack(String),
 }

--- a/crates/mvm-fs/src/oci/layer.rs
+++ b/crates/mvm-fs/src/oci/layer.rs
@@ -28,9 +28,15 @@ use crate::oci::manifest::OciManifestFetcher;
 use crate::oci::reference::ImageReference;
 use crate::oci::registry::{ClientConfig, RegistryAuthConfig, RegistryClient};
 use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
+
+use crate::oci::unpack::{UnpackOptions, UnpackReport, unpack_layer_with_prior_paths};
+use flate2::read::GzDecoder;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 /// Marker substring stored in the `io::Error` we return from the
@@ -255,6 +261,76 @@ impl OciLayerFetcher {
         }
     }
 
+    /// Stream `layer` from `reference`'s registry, persisting the raw
+    /// compressed bytes to `cache_path` while concurrently decompressing
+    /// and unpacking the tar stream into `unpacked_root`.
+    ///
+    /// This avoids the fetch-to-disk-then-read-back round trip: the gzip
+    /// decoder is fed directly from the network stream, and the cache file
+    /// is written by the same reader. The layer digest is verified over the
+    /// streamed bytes after the unpack completes, so a tampered blob leaves
+    /// a partial tree but never a verified cache entry.
+    ///
+    /// Returns the [`UnpackReport`] for the layer. Callers applying multiple
+    /// layers should accumulate `report.paths_written` and pass it as
+    /// `prior_layer_paths` for the next layer.
+    pub async fn fetch_and_unpack_layer(
+        &self,
+        reference: &ImageReference,
+        layer: &LayerDescriptor,
+        cache_path: &Path,
+        unpacked_root: &Path,
+        options: &UnpackOptions,
+        prior_layer_paths: &HashSet<PathBuf>,
+    ) -> Result<UnpackReport, OciError> {
+        if layer.size > self.options.max_size {
+            return Err(OciError::LayerTooLarge {
+                declared: layer.size,
+                cap: self.options.max_size,
+            });
+        }
+        validate_layer_digest(&layer.digest)?;
+
+        let count = Arc::new(AtomicU64::new(0));
+        let cap_hit = Arc::new(AtomicBool::new(false));
+
+        let mut attempt: u32 = 0;
+        let mut delay = self.options.initial_backoff;
+        loop {
+            let attempt_started_at = count.load(Ordering::SeqCst);
+            let ctx = UnpackAttemptCtx {
+                reference,
+                layer,
+                cache_path,
+                unpacked_root,
+                options,
+                prior_layer_paths,
+            };
+            let res = self
+                .fetch_and_unpack_layer_once(ctx, Arc::clone(&count), Arc::clone(&cap_hit))
+                .await;
+            match res {
+                Ok(report) => return Ok(report),
+                Err(_) if cap_hit.load(Ordering::SeqCst) => {
+                    return Err(OciError::LayerTooLarge {
+                        declared: layer.size,
+                        cap: self.options.max_size,
+                    });
+                }
+                Err(e)
+                    if is_transient(&e)
+                        && attempt < self.options.max_retries
+                        && attempt_started_at == 0 =>
+                {
+                    attempt += 1;
+                    tokio::time::sleep(delay).await;
+                    delay = delay.saturating_mul(2);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
     async fn fetch_layer_once(
         &self,
         reference: &ImageReference,
@@ -371,6 +447,238 @@ where
     }
 }
 
+/// Context captured for a single fetch-and-unpack attempt. Grouping these
+/// values keeps the attempt function under the argument-count lint and makes
+/// the retry loop readable.
+struct UnpackAttemptCtx<'a> {
+    reference: &'a ImageReference,
+    layer: &'a LayerDescriptor,
+    cache_path: &'a Path,
+    unpacked_root: &'a Path,
+    options: &'a UnpackOptions,
+    prior_layer_paths: &'a HashSet<PathBuf>,
+}
+
+impl OciLayerFetcher {
+    async fn fetch_and_unpack_layer_once(
+        &self,
+        ctx: UnpackAttemptCtx<'_>,
+        count: Arc<AtomicU64>,
+        cap_hit: Arc<AtomicBool>,
+    ) -> Result<UnpackReport, OciError> {
+        let cap = self.options.max_size;
+        let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let gzip = is_gzip_layer(&ctx.layer.media_type);
+
+        let cache_path = ctx.cache_path.to_path_buf();
+        let unpacked_root = ctx.unpacked_root.to_path_buf();
+        let options = ctx.options.clone();
+        let prior_layer_paths = ctx.prior_layer_paths.clone();
+
+        let mut unpack_task = tokio::task::spawn_blocking(move || {
+            let reader = CacheWriterReader::new(rx, &cache_path, cap)
+                .map_err(|e| OciError::Registry(format!("open cache blob: {e}")))?;
+            let mut decoder: LayerDecoder<CacheWriterReader> = if gzip {
+                LayerDecoder::Gzip(GzDecoder::new(reader))
+            } else {
+                LayerDecoder::Plain(reader)
+            };
+
+            let report = unpack_layer_with_prior_paths(
+                &mut decoder,
+                &unpacked_root,
+                &options,
+                &prior_layer_paths,
+            )
+            .map_err(|e| OciError::Unpack(e.to_string()))?;
+
+            let reader = decoder.into_inner();
+            let (total, digest) = reader.finalize();
+            Ok::<(UnpackReport, u64, String), OciError>((
+                report,
+                total,
+                format!("sha256:{}", hex::encode(digest)),
+            ))
+        });
+
+        let cache_path_for_cleanup = ctx.cache_path.to_path_buf();
+        let layer_digest_for_check = ctx.layer.digest.clone();
+        let fetch_result: Result<(), OciError> = async {
+            let expected_digest = layer_digest_for_check.clone();
+            let mut response = self
+                .client
+                .get_blob(ctx.reference, ctx.layer.digest.as_str())
+                .await?;
+            loop {
+                tokio::select! {
+                    chunk = response.response.chunk() => {
+                        let chunk = chunk
+                            .map_err(|e| OciError::Registry(format!("read blob response chunk: {e}")))?;
+                        match chunk {
+                            Some(bytes) => {
+                                let len = bytes.len() as u64;
+                                let current = count.load(Ordering::SeqCst);
+                                if current.saturating_add(len) > cap {
+                                    cap_hit.store(true, Ordering::SeqCst);
+                                    return Err(OciError::LayerTooLarge {
+                                        declared: ctx.layer.size,
+                                        cap,
+                                    });
+                                }
+                                if tx.send(bytes.to_vec()).await.is_err() {
+                                    // The unpack task stopped reading; stop
+                                    // fetching and let the await on it surface
+                                    // the real error.
+                                    return Ok(());
+                                }
+                                count.fetch_add(len, Ordering::SeqCst);
+                            }
+                            None => return Ok(()),
+                        }
+                    }
+                    res = &mut unpack_task => {
+                        let (report, _total, computed) = res
+                            .map_err(|e| OciError::Registry(format!("unpack task join: {e}")))??;
+                        if computed != expected_digest {
+                            return Err(OciError::DigestMismatch {
+                                expected: expected_digest,
+                                computed,
+                            });
+                        }
+                        // A successful unpack cannot finish before the tar
+                        // stream EOF, so reaching here is unexpected but not
+                        // fatal: return the report.
+                        let _ = report;
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        .await;
+
+        // Close the channel so the blocking reader reaches EOF.
+        drop(tx);
+
+        let task_result = unpack_task
+            .await
+            .map_err(|e| OciError::Registry(format!("unpack task join: {e}")))?;
+
+        if fetch_result.is_err() {
+            let _ = std::fs::remove_file(&cache_path_for_cleanup);
+        }
+        fetch_result?;
+
+        let (report, _total, computed) = task_result?;
+        if computed != layer_digest_for_check {
+            let _ = std::fs::remove_file(&cache_path_for_cleanup);
+            return Err(OciError::DigestMismatch {
+                expected: layer_digest_for_check,
+                computed,
+            });
+        }
+        Ok(report)
+    }
+}
+
+/// Reads compressed layer chunks from an async channel, writes each chunk
+/// to the cache file, hashes the bytes, and exposes the stream as a sync
+/// `Read` so the `tar` crate can consume it in a blocking thread.
+struct CacheWriterReader {
+    rx: tokio::sync::mpsc::Receiver<Vec<u8>>,
+    buf: Vec<u8>,
+    pos: usize,
+    file: std::fs::File,
+    hasher: Sha256,
+    total: u64,
+    cap: u64,
+}
+
+impl CacheWriterReader {
+    fn new(
+        rx: tokio::sync::mpsc::Receiver<Vec<u8>>,
+        path: &Path,
+        cap: u64,
+    ) -> std::io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = std::fs::File::create(path)?;
+        Ok(Self {
+            rx,
+            buf: Vec::new(),
+            pos: 0,
+            file,
+            hasher: Sha256::new(),
+            total: 0,
+            cap,
+        })
+    }
+
+    fn finalize(self) -> (u64, [u8; 32]) {
+        let digest = self.hasher.finalize();
+        let arr: [u8; 32] = digest.into();
+        (self.total, arr)
+    }
+}
+
+impl Read for CacheWriterReader {
+    fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+        if self.pos >= self.buf.len() {
+            match self.rx.blocking_recv() {
+                Some(chunk) => {
+                    if self.total.saturating_add(chunk.len() as u64) > self.cap {
+                        return Err(std::io::Error::other(CAP_EXCEEDED_MSG));
+                    }
+                    self.file.write_all(&chunk)?;
+                    self.hasher.update(&chunk);
+                    self.total += chunk.len() as u64;
+                    self.buf = chunk;
+                    self.pos = 0;
+                }
+                None => return Ok(0),
+            }
+        }
+        let remaining = self.buf.len() - self.pos;
+        let n = remaining.min(out.len());
+        out[..n].copy_from_slice(&self.buf[self.pos..self.pos + n]);
+        self.pos += n;
+        Ok(n)
+    }
+}
+
+/// Either a plain tar stream or a gzip-wrapped tar stream. Keeps the
+/// underlying [`CacheWriterReader`] accessible so we can finalize the
+/// digest after `unpack_layer_with_prior_paths` returns.
+enum LayerDecoder<R: Read> {
+    Plain(R),
+    Gzip(GzDecoder<R>),
+}
+
+impl<R: Read> Read for LayerDecoder<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Plain(r) => r.read(buf),
+            Self::Gzip(d) => d.read(buf),
+        }
+    }
+}
+
+impl<R: Read> LayerDecoder<R> {
+    fn into_inner(self) -> R {
+        match self {
+            Self::Plain(r) => r,
+            Self::Gzip(d) => d.into_inner(),
+        }
+    }
+}
+
+/// True for media types that carry a gzip-wrapped tar stream.
+fn is_gzip_layer(media_type: &str) -> bool {
+    media_type.ends_with("+gzip")
+        || media_type.ends_with(".gzip")
+        || media_type.contains("tar.gzip")
+}
+
 fn validate_layer_digest(d: &str) -> Result<(), OciError> {
     let (alg, hex_part) = d
         .split_once(':')
@@ -407,7 +715,8 @@ fn is_transient(e: &OciError) -> bool {
         | OciError::InvalidReference(_)
         | OciError::MalformedDigest(_)
         | OciError::UnsupportedDigestAlgorithm(_)
-        | OciError::LayerTooLarge { .. } => false,
+        | OciError::LayerTooLarge { .. }
+        | OciError::Unpack(_) => false,
     }
 }
 

--- a/crates/mvm-fs/src/oci/layer.rs
+++ b/crates/mvm-fs/src/oci/layer.rs
@@ -681,20 +681,20 @@ impl CacheWriterReader {
 /// Wraps a sync reader and computes a running SHA-256 over every byte
 /// that passes through. Used to verify a cached layer without loading it
 /// into memory first.
-struct HashingReader<R: Read> {
+pub(crate) struct HashingReader<R: Read> {
     inner: R,
     hasher: Sha256,
 }
 
 impl<R: Read> HashingReader<R> {
-    fn new(inner: R) -> Self {
+    pub(crate) fn new(inner: R) -> Self {
         Self {
             inner,
             hasher: Sha256::new(),
         }
     }
 
-    fn finalize(self) -> [u8; 32] {
+    pub(crate) fn finalize(self) -> [u8; 32] {
         let digest = self.hasher.finalize();
         digest.into()
     }

--- a/crates/mvm-fs/src/oci/layer.rs
+++ b/crates/mvm-fs/src/oci/layer.rs
@@ -475,7 +475,7 @@ impl OciLayerFetcher {
         let options = ctx.options.clone();
         let prior_layer_paths = ctx.prior_layer_paths.clone();
 
-        let mut unpack_task = tokio::task::spawn_blocking(move || {
+        let unpack_task = tokio::task::spawn_blocking(move || {
             let reader = CacheWriterReader::new(rx, &cache_path, cap)
                 .map_err(|e| OciError::Registry(format!("open cache blob: {e}")))?;
             let mut decoder: LayerDecoder<CacheWriterReader> = if gzip {
@@ -504,53 +504,34 @@ impl OciLayerFetcher {
         let cache_path_for_cleanup = ctx.cache_path.to_path_buf();
         let layer_digest_for_check = ctx.layer.digest.clone();
         let fetch_result: Result<(), OciError> = async {
-            let expected_digest = layer_digest_for_check.clone();
             let mut response = self
                 .client
                 .get_blob(ctx.reference, ctx.layer.digest.as_str())
                 .await?;
             loop {
-                tokio::select! {
-                    chunk = response.response.chunk() => {
-                        let chunk = chunk
-                            .map_err(|e| OciError::Registry(format!("read blob response chunk: {e}")))?;
-                        match chunk {
-                            Some(bytes) => {
-                                let len = bytes.len() as u64;
-                                let current = count.load(Ordering::SeqCst);
-                                if current.saturating_add(len) > cap {
-                                    cap_hit.store(true, Ordering::SeqCst);
-                                    return Err(OciError::LayerTooLarge {
-                                        declared: ctx.layer.size,
-                                        cap,
-                                    });
-                                }
-                                if tx.send(bytes.to_vec()).await.is_err() {
-                                    // The unpack task stopped reading; stop
-                                    // fetching and let the await on it surface
-                                    // the real error.
-                                    return Ok(());
-                                }
-                                count.fetch_add(len, Ordering::SeqCst);
-                            }
-                            None => return Ok(()),
-                        }
-                    }
-                    res = &mut unpack_task => {
-                        let (report, _total, computed) = res
-                            .map_err(|e| OciError::Registry(format!("unpack task join: {e}")))??;
-                        if computed != expected_digest {
-                            return Err(OciError::DigestMismatch {
-                                expected: expected_digest,
-                                computed,
+                let chunk =
+                    response.response.chunk().await.map_err(|e| {
+                        OciError::Registry(format!("read blob response chunk: {e}"))
+                    })?;
+                match chunk {
+                    Some(bytes) => {
+                        let len = bytes.len() as u64;
+                        let current = count.load(Ordering::SeqCst);
+                        if current.saturating_add(len) > cap {
+                            cap_hit.store(true, Ordering::SeqCst);
+                            return Err(OciError::LayerTooLarge {
+                                declared: ctx.layer.size,
+                                cap,
                             });
                         }
-                        // A successful unpack cannot finish before the tar
-                        // stream EOF, so reaching here is unexpected but not
-                        // fatal: return the report.
-                        let _ = report;
-                        return Ok(());
+                        if tx.send(bytes.to_vec()).await.is_err() {
+                            // The unpack task stopped reading; stop fetching
+                            // and let the await on it surface the real error.
+                            return Ok(());
+                        }
+                        count.fetch_add(len, Ordering::SeqCst);
                     }
+                    None => return Ok(()),
                 }
             }
         }
@@ -563,10 +544,10 @@ impl OciLayerFetcher {
             .await
             .map_err(|e| OciError::Registry(format!("unpack task join: {e}")))?;
 
-        if fetch_result.is_err() {
+        if let Err(e) = fetch_result {
             let _ = std::fs::remove_file(&cache_path_for_cleanup);
+            return Err(e);
         }
-        fetch_result?;
 
         let (report, _total, computed) = task_result?;
         if computed != layer_digest_for_check {

--- a/crates/mvm-fs/src/oci/layer.rs
+++ b/crates/mvm-fs/src/oci/layer.rs
@@ -580,6 +580,63 @@ impl OciLayerFetcher {
     }
 }
 
+/// Stream-verify and unpack a layer that already lives on disk at
+/// `cache_path`. The file is read once, hashed incrementally, and fed to
+/// the same hardened unpack path used for network layers. On digest
+/// mismatch the cache file is left in place for the caller to decide
+/// whether to retry or reap; this function only reports the mismatch.
+///
+/// This is the cache-hit counterpart to
+/// [`OciLayerFetcher::fetch_and_unpack_layer`]: it avoids loading the
+/// entire compressed blob into memory just to verify and unpack it.
+pub async fn verify_and_unpack_layer_file(
+    layer: &LayerDescriptor,
+    cache_path: &Path,
+    unpacked_root: &Path,
+    options: &UnpackOptions,
+    prior_layer_paths: &HashSet<PathBuf>,
+) -> Result<UnpackReport, OciError> {
+    validate_layer_digest(&layer.digest)?;
+
+    let layer = layer.clone();
+    let cache_path = cache_path.to_path_buf();
+    let unpacked_root = unpacked_root.to_path_buf();
+    let options = options.clone();
+    let prior_layer_paths = prior_layer_paths.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::File::open(&cache_path)
+            .map_err(|e| OciError::Registry(format!("open cached layer: {e}")))?;
+        let reader = HashingReader::new(file);
+        let gzip = is_gzip_layer(&layer.media_type);
+        let mut decoder: LayerDecoder<HashingReader<std::fs::File>> = if gzip {
+            LayerDecoder::Gzip(GzDecoder::new(reader))
+        } else {
+            LayerDecoder::Plain(reader)
+        };
+
+        let report = unpack_layer_with_prior_paths(
+            &mut decoder,
+            &unpacked_root,
+            &options,
+            &prior_layer_paths,
+        )
+        .map_err(|e| OciError::Unpack(e.to_string()))?;
+
+        let reader = decoder.into_inner();
+        let computed = format!("sha256:{}", hex::encode(reader.finalize()));
+        if computed != layer.digest {
+            return Err(OciError::DigestMismatch {
+                expected: layer.digest,
+                computed,
+            });
+        }
+        Ok(report)
+    })
+    .await
+    .map_err(|e| OciError::Registry(format!("unpack task join: {e}")))?
+}
+
 /// Reads compressed layer chunks from an async channel, writes each chunk
 /// to the cache file, hashes the bytes, and exposes the stream as a sync
 /// `Read` so the `tar` crate can consume it in a blocking thread.
@@ -618,6 +675,36 @@ impl CacheWriterReader {
         let digest = self.hasher.finalize();
         let arr: [u8; 32] = digest.into();
         (self.total, arr)
+    }
+}
+
+/// Wraps a sync reader and computes a running SHA-256 over every byte
+/// that passes through. Used to verify a cached layer without loading it
+/// into memory first.
+struct HashingReader<R: Read> {
+    inner: R,
+    hasher: Sha256,
+}
+
+impl<R: Read> HashingReader<R> {
+    fn new(inner: R) -> Self {
+        Self {
+            inner,
+            hasher: Sha256::new(),
+        }
+    }
+
+    fn finalize(self) -> [u8; 32] {
+        let digest = self.hasher.finalize();
+        digest.into()
+    }
+}
+
+impl<R: Read> Read for HashingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.hasher.update(&buf[..n]);
+        Ok(n)
     }
 }
 

--- a/crates/mvm-fs/src/oci/mod.rs
+++ b/crates/mvm-fs/src/oci/mod.rs
@@ -58,7 +58,9 @@ mod registry;
 // drive the unpack and to surface refusals in audit-chain entries.
 pub mod unpack;
 
-pub use archive::{OciArchiveImage, OciArchiveLayer, read_oci_archive};
+pub use archive::{
+    OciArchiveImage, OciArchiveLayer, OciArchiveMetadata, read_oci_archive, stream_oci_archive,
+};
 pub use error::OciError;
 pub use layer::{LayerDescriptor, LayerFetchOptions, OciLayerFetcher};
 pub use manifest::{

--- a/crates/mvm-fs/src/rootfs.rs
+++ b/crates/mvm-fs/src/rootfs.rs
@@ -18,6 +18,8 @@ use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
+use rayon::prelude::*;
+
 use crate::ext4::{BuildOptions, EmitImageError, Ext4Error, Node, Xattr};
 
 /// How [`collect_nodes`] handles a host inode kind the ext4 [`Node`] enum has
@@ -157,13 +159,26 @@ impl SizeHeuristic {
     }
 }
 
+/// A single entry discovered by the sequential directory walk, before its
+/// file contents or xattrs are read in parallel.
+struct WalkEntry {
+    path: PathBuf,
+    guest_path: String,
+    file_type: std::fs::FileType,
+}
+
 /// Walk `root` into a flat [`Node`] list (guest-absolute paths), symlink-aware
 /// (never follows). Directories and their descendants, regular files (contents
 /// read in), and symlinks are captured; other inode types (fifo/socket/device)
 /// are handled per `options.on_unsupported`, since the [`Node`] enum has no
 /// way to represent them. Extended-attribute capture follows `options.xattrs`.
+///
+/// The tree structure is walked sequentially so directory traversal stays
+/// predictable, but regular-file reads and xattr captures happen in parallel
+/// via rayon. The returned nodes are sorted by guest path so the output is
+/// deterministic regardless of filesystem read_dir order.
 pub fn collect_nodes(root: &Path, options: WalkOptions) -> Result<Vec<Node>, MaterializeError> {
-    let mut out = Vec::new();
+    let mut entries = Vec::new();
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
         let read = std::fs::read_dir(&dir).map_err(|source| MaterializeError::Walk {
@@ -181,48 +196,68 @@ pub fn collect_nodes(root: &Path, options: WalkOptions) -> Result<Vec<Node>, Mat
                 path: path.clone(),
                 source,
             })?;
-            if ft.is_symlink() {
+            if ft.is_dir() {
+                stack.push(path.clone());
+            } else if !(ft.is_symlink() || ft.is_file()) {
+                match options.on_unsupported {
+                    UnsupportedNodePolicy::Skip => continue,
+                    UnsupportedNodePolicy::Reject => {
+                        return Err(MaterializeError::UnsupportedNodeType(path));
+                    }
+                }
+            }
+            entries.push(WalkEntry {
+                path,
+                guest_path,
+                file_type: ft,
+            });
+        }
+    }
+
+    let mut nodes: Vec<Node> = entries
+        .into_par_iter()
+        .map(|entry| -> Result<Node, MaterializeError> {
+            let WalkEntry {
+                path,
+                guest_path,
+                file_type,
+            } = entry;
+            if file_type.is_symlink() {
                 let target =
                     std::fs::read_link(&path).map_err(|source| MaterializeError::Walk {
                         path: path.clone(),
                         source,
                     })?;
-                out.push(Node::Symlink {
+                Ok(Node::Symlink {
                     path: guest_path,
                     target: target.to_string_lossy().into_owned(),
-                });
-            } else if ft.is_dir() {
+                })
+            } else if file_type.is_dir() {
                 let xattrs = node_xattrs(options.xattrs, &path);
-                out.push(Node::Dir {
+                Ok(Node::Dir {
                     path: guest_path,
                     mode: mode_of(&path, 0o755),
                     xattrs,
-                });
-                stack.push(path);
-            } else if ft.is_file() {
+                })
+            } else {
                 let data =
                     read_file_for_guest_image(&path).map_err(|source| MaterializeError::Walk {
                         path: path.clone(),
                         source,
                     })?;
                 let xattrs = node_xattrs(options.xattrs, &path);
-                out.push(Node::File {
+                Ok(Node::File {
                     path: guest_path,
                     mode: mode_of(&path, 0o644),
                     data,
                     xattrs,
-                });
-            } else {
-                match options.on_unsupported {
-                    UnsupportedNodePolicy::Skip => {}
-                    UnsupportedNodePolicy::Reject => {
-                        return Err(MaterializeError::UnsupportedNodeType(path));
-                    }
-                }
+                })
             }
-        }
-    }
-    Ok(out)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    nodes.sort_by(|a, b| a.path().cmp(b.path()));
+    Ok(nodes)
 }
 
 /// Descriptor returned by [`materialize_ext4_pure`].

--- a/crates/mvm-fs/src/rootfs.rs
+++ b/crates/mvm-fs/src/rootfs.rs
@@ -302,6 +302,24 @@ fn merge_extra_nodes(mut walked: Vec<Node>, extra: Vec<Node>) -> Vec<Node> {
     walked
 }
 
+/// Build the directory tree at `root` into an in-memory ext4 image.
+///
+/// Returns the raw image bytes and the final image size. The whole tree and the
+/// assembled image are held in memory, so callers can compute content-addressed
+/// sidecars (e.g. dm-verity) from `image` before writing anything to disk.
+pub fn build_ext4_pure(
+    root: &Path,
+    options: &MaterializeOptions,
+) -> Result<(Vec<u8>, u64), MaterializeError> {
+    let nodes = merge_extra_nodes(
+        collect_nodes(root, options.walk)?,
+        options.extra_nodes.clone(),
+    );
+    let image = crate::ext4::build_image_with_options(&nodes, &options.build)?;
+    let size_bytes = image.len() as u64;
+    Ok((image, size_bytes))
+}
+
 /// Materialize the directory tree at `root` into an ext4 image at `output`,
 /// in-process: walk, build, stream-emit, truncate to the final size. Creates
 /// `output`'s parent directory if missing. A `root` that is not a readable
@@ -311,6 +329,10 @@ fn merge_extra_nodes(mut walked: Vec<Node>, extra: Vec<Node>) -> Vec<Node> {
 /// which is fine for small/medium rootfs; a tree past the writer's structural
 /// limits surfaces as [`MaterializeError::Build`] with a capacity-limit
 /// classification callers can use to route to an out-of-process fallback.
+///
+/// Callers that need to compute sidecars from the image bytes before any disk
+/// write should use [`build_ext4_pure`] instead and handle the write
+/// themselves.
 pub fn materialize_ext4_pure(
     root: &Path,
     output: &Path,
@@ -654,6 +676,26 @@ mod tests {
 
         assert_eq!(std::fs::read(&out_path).unwrap(), dense);
         assert_eq!(materialized.size_bytes, dense.len() as u64);
+    }
+
+    #[test]
+    fn build_ext4_pure_returns_bytes_before_any_disk_write() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(src.path().join("etc")).unwrap();
+        std::fs::write(src.path().join("etc/hosts"), b"127.0.0.1 localhost\n").unwrap();
+        std::fs::write(src.path().join("hello"), b"hi\n").unwrap();
+
+        let options = MaterializeOptions::default();
+        let (built, size_bytes) = build_ext4_pure(src.path(), &options).expect("build in memory");
+        assert!(size_bytes > 0);
+        assert_eq!(built.len() as u64, size_bytes);
+
+        // The in-memory result must be byte-identical to the file-written result,
+        // so callers can compute content-addressed sidecars from the buffer.
+        let out = tempfile::tempdir().unwrap();
+        let out_path = out.path().join("rootfs.ext4");
+        materialize_ext4_pure(src.path(), &out_path, &options).expect("materialize");
+        assert_eq!(std::fs::read(&out_path).unwrap(), built);
     }
 
     #[test]

--- a/crates/mvm-fs/tests/hermetic_registry.rs
+++ b/crates/mvm-fs/tests/hermetic_registry.rs
@@ -8,6 +8,7 @@
 mod common;
 
 use common::{HermeticRegistry, client_config_for, minimal_image_manifest};
+use mvm_fs::oci::layer::verify_and_unpack_layer_file;
 use mvm_fs::oci::{
     LayerDescriptor, LayerFetchOptions, LinuxPlatform, ManifestFetcher, OciError, OciLayerFetcher,
     OciManifestFetcher, RegistryAuthConfig, UnpackOptions, verify_sha256_digest,
@@ -712,6 +713,78 @@ async fn fetch_and_unpack_layer_streams_and_caches_blob() {
 
     // The raw compressed blob was persisted concurrently.
     assert_eq!(std::fs::read(&cache).expect("read cache"), layer_bytes);
+}
+
+#[tokio::test]
+async fn verify_and_unpack_layer_file_streams_cache_hit() {
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes = gzip_tar_layer(&[("cached.txt", b"from-cache")]);
+    let layer_digest = reg
+        .register_blob("library/test", LAYER_MEDIA, &layer_bytes)
+        .await;
+
+    let layer = LayerDescriptor {
+        digest: layer_digest,
+        size: layer_bytes.len() as u64,
+        media_type: LAYER_MEDIA.to_string(),
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let unpacked = tmp.path().join("unpacked");
+    std::fs::create_dir_all(&unpacked).expect("create unpacked root");
+    let cache = tmp.path().join("layer.tar.gz");
+    std::fs::write(&cache, &layer_bytes).expect("write cached blob");
+
+    let report = verify_and_unpack_layer_file(
+        &layer,
+        &cache,
+        &unpacked,
+        &UnpackOptions::default(),
+        &std::collections::HashSet::new(),
+    )
+    .await
+    .expect("verify and unpack cached layer");
+
+    assert_eq!(report.files_written, 1);
+    assert!(report.refused.is_empty());
+    assert_eq!(
+        std::fs::read(unpacked.join("cached.txt")).expect("read"),
+        b"from-cache"
+    );
+}
+
+#[tokio::test]
+async fn verify_and_unpack_layer_file_rejects_corrupt_cache() {
+    let intended = gzip_tar_layer(&[("x.txt", b"x")]);
+    let tampered = gzip_tar_layer(&[("x.txt", b"y")]);
+    let claimed_digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(&intended)));
+
+    let layer = LayerDescriptor {
+        digest: claimed_digest,
+        size: intended.len() as u64,
+        media_type: LAYER_MEDIA.to_string(),
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let unpacked = tmp.path().join("unpacked");
+    std::fs::create_dir_all(&unpacked).expect("create unpacked root");
+    let cache = tmp.path().join("layer.tar.gz");
+    std::fs::write(&cache, &tampered).expect("write tampered cached blob");
+
+    let err = verify_and_unpack_layer_file(
+        &layer,
+        &cache,
+        &unpacked,
+        &UnpackOptions::default(),
+        &std::collections::HashSet::new(),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(
+        matches!(err, OciError::DigestMismatch { .. }),
+        "expected DigestMismatch, got {err:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/mvm-fs/tests/hermetic_registry.rs
+++ b/crates/mvm-fs/tests/hermetic_registry.rs
@@ -10,9 +10,10 @@ mod common;
 use common::{HermeticRegistry, client_config_for, minimal_image_manifest};
 use mvm_fs::oci::{
     LayerDescriptor, LayerFetchOptions, LinuxPlatform, ManifestFetcher, OciError, OciLayerFetcher,
-    OciManifestFetcher, RegistryAuthConfig, verify_sha256_digest,
+    OciManifestFetcher, RegistryAuthConfig, UnpackOptions, verify_sha256_digest,
 };
 use sha2::Digest;
+use std::io::Write;
 use std::time::Duration;
 
 const LAYER_MEDIA: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
@@ -652,6 +653,160 @@ async fn layer_fetch_reuses_manifest_fetcher_bearer_auth() {
         .expect("authenticated layer fetch");
     assert_eq!(n, layer_bytes.len() as u64);
     assert_eq!(sink, layer_bytes);
+}
+
+fn gzip_tar_layer(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+    for (name, bytes) in entries {
+        let mut header = tar::Header::new_gnu();
+        header.set_path(*name).expect("valid tar path");
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, *bytes).expect("append tar entry");
+    }
+    let raw = builder.into_inner().expect("finish tar");
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(&raw).expect("gzip input");
+    encoder.finish().expect("finish gzip")
+}
+
+#[tokio::test]
+async fn fetch_and_unpack_layer_streams_and_caches_blob() {
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes = gzip_tar_layer(&[("hello.txt", b"world")]);
+    let layer_digest = reg
+        .register_blob("library/test", LAYER_MEDIA, &layer_bytes)
+        .await;
+
+    let layer = LayerDescriptor {
+        digest: layer_digest.clone(),
+        size: layer_bytes.len() as u64,
+        media_type: LAYER_MEDIA.to_string(),
+    };
+    let fetcher =
+        OciLayerFetcher::with_config(client_config_for(&reg), LayerFetchOptions::default());
+    let image = reg.image_ref("library/test", "v1");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let unpacked = tmp.path().join("unpacked");
+    std::fs::create_dir_all(&unpacked).expect("create unpacked root");
+    let cache = tmp.path().join("layer.tar.gz");
+
+    let report = fetcher
+        .fetch_and_unpack_layer(
+            &image,
+            &layer,
+            &cache,
+            &unpacked,
+            &UnpackOptions::default(),
+            &std::collections::HashSet::new(),
+        )
+        .await
+        .expect("fetch and unpack");
+
+    assert_eq!(report.files_written, 1);
+    assert!(report.refused.is_empty());
+    let out = unpacked.join("hello.txt");
+    assert_eq!(std::fs::read(&out).expect("read unpacked file"), b"world");
+
+    // The raw compressed blob was persisted concurrently.
+    assert_eq!(std::fs::read(&cache).expect("read cache"), layer_bytes);
+}
+
+#[tokio::test]
+async fn fetch_and_unpack_layer_rejects_tampered_blob_and_drops_cache() {
+    let reg = HermeticRegistry::start().await;
+    let intended = gzip_tar_layer(&[("hello.txt", b"world")]);
+    let tampered = gzip_tar_layer(&[("hello.txt", b"evil")]);
+    let claimed_digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(&intended)));
+    reg.register_tampered_blob("library/test", &claimed_digest, &tampered)
+        .await;
+
+    let layer = LayerDescriptor {
+        digest: claimed_digest.clone(),
+        size: intended.len() as u64,
+        media_type: LAYER_MEDIA.to_string(),
+    };
+    let fetcher =
+        OciLayerFetcher::with_config(client_config_for(&reg), LayerFetchOptions::default());
+    let image = reg.image_ref("library/test", "v1");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let unpacked = tmp.path().join("unpacked");
+    std::fs::create_dir_all(&unpacked).expect("create unpacked root");
+    let cache = tmp.path().join("layer.tar.gz");
+
+    let err = fetcher
+        .fetch_and_unpack_layer(
+            &image,
+            &layer,
+            &cache,
+            &unpacked,
+            &UnpackOptions::default(),
+            &std::collections::HashSet::new(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, OciError::DigestMismatch { .. }),
+        "expected DigestMismatch, got {err:?}"
+    );
+    assert!(
+        !cache.exists(),
+        "partial cache blob must be removed on digest mismatch"
+    );
+}
+
+#[tokio::test]
+async fn fetch_and_unpack_layer_handles_plain_tar_media_type() {
+    let reg = HermeticRegistry::start().await;
+    let mut builder = tar::Builder::new(Vec::new());
+    let mut header = tar::Header::new_gnu();
+    header.set_path("plain.txt").expect("valid tar path");
+    header.set_size(5);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder.append(&header, &b"howdy"[..]).expect("append");
+    let layer_bytes = builder.into_inner().expect("finish tar");
+    let media_type = "application/vnd.oci.image.layer.v1.tar";
+    let layer_digest = reg
+        .register_blob("library/test", media_type, &layer_bytes)
+        .await;
+
+    let layer = LayerDescriptor {
+        digest: layer_digest,
+        size: layer_bytes.len() as u64,
+        media_type: media_type.to_string(),
+    };
+    let fetcher =
+        OciLayerFetcher::with_config(client_config_for(&reg), LayerFetchOptions::default());
+    let image = reg.image_ref("library/test", "v1");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let unpacked = tmp.path().join("unpacked");
+    std::fs::create_dir_all(&unpacked).expect("create unpacked root");
+    let cache = tmp.path().join("layer.tar");
+
+    let report = fetcher
+        .fetch_and_unpack_layer(
+            &image,
+            &layer,
+            &cache,
+            &unpacked,
+            &UnpackOptions::default(),
+            &std::collections::HashSet::new(),
+        )
+        .await
+        .expect("fetch and unpack plain tar");
+
+    assert_eq!(report.files_written, 1);
+    assert_eq!(
+        std::fs::read(unpacked.join("plain.txt")).expect("read"),
+        b"howdy"
+    );
+    assert_eq!(std::fs::read(&cache).expect("read cache"), layer_bytes);
 }
 
 #[tokio::test]

--- a/xtask/src/check_closure_budget.rs
+++ b/xtask/src/check_closure_budget.rs
@@ -71,7 +71,12 @@ const BUDGET_TARGET: &str = "x86_64-unknown-linux-gnu";
 /// 274 (was 275): consolidating the protocol and volume contracts into the
 /// feature-gated `mvm-contract` package removes one package from the default
 /// closure while preserving the protocol-only default feature set.
-const CLOSURE_BUDGET: usize = 274;
+///
+/// 279 (was 274): adopting `rayon` for parallel file walks, copies, ext4
+/// directory/symlink block emission, and dm-verity hash-tree computation;
+/// measured delta +5 crates (rayon, rayon-core, crossbeam-deque,
+/// crossbeam-epoch, crossbeam-utils).
+const CLOSURE_BUDGET: usize = 279;
 
 pub fn run(workspace: &Path) -> Result<()> {
     let count = default_closure_crate_count(workspace)?;

--- a/xtask/src/check_duplicate_majors.rs
+++ b/xtask/src/check_duplicate_majors.rs
@@ -28,6 +28,11 @@ use std::process::Command;
 /// into the build.
 const ALLOWLIST: &[&str] = &[
     "bitflags",
+    // `criterion` (the mvm-fs benchmark harness) pulls itertools 0.10, while
+    // cucumber / derive-more / indexmap / zerotrie already resolve itertools
+    // 0.14. Both majors are dev-only/test paths; criterion has no 0.14-compatible
+    // release.
+    "itertools",
     "getrandom",
     "hashbrown",
     // nom 8 is pulled only by the cargo-fuzz tooling in the fuzz member crates;


### PR DESCRIPTION
Build boot artifacts in memory and stream OCI layer fetch/unpack to avoid disk round-trips.

- `mvm_fs::rootfs::build_ext4_pure` returns raw image bytes before any disk write; verity sidecars are computed from the in-memory buffer.
- Parallelize dm-verity hashing, file-tree reads, cache-install copies, and ext4 directory/long-symlink data-block emission with `rayon`.
- Add `OciLayerFetcher::fetch_and_unpack_layer` to stream registry layers directly through a gzip decoder into the tar unpacker while tee-ing the raw compressed bytes to cache.
- Add `verify_and_unpack_layer_file` for cache hits so cached layers are verified and unpacked without loading the whole blob into memory.
- Remove the old `fetch_or_read_layer` fetch-to-Vec/write-disk/read-back path.

Closes the performance item at `specs/scratch.md#L141-144`.