### PR TITLE
fix(vmm): enforce virtio-vsock transmit credit on HVF egress

### DIFF
--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -635,7 +635,7 @@ fn validate_run_profile(args: &RunArgs) -> Result<()> {
             anyhow::bail!("--profile restrictive does not allow --env");
         }
         if !args.add_dir.is_empty() {
-            anyhow::bail!("--profile restrictive does not allow --add-dir");
+            anyhow::bail!("--profile restrictive does not allow --mount");
         }
     }
 
@@ -643,7 +643,7 @@ fn validate_run_profile(args: &RunArgs) -> Result<()> {
         for spec in &args.add_dir {
             if !crate::exec::AddDir::parse(spec)?.read_only {
                 anyhow::bail!(
-                    "--add-dir '{spec}' requests rw; use --profile dev for writable host shares"
+                    "--mount '{spec}' requests rw; use --profile dev for writable host shares"
                 );
             }
         }
@@ -1725,7 +1725,7 @@ mod tests {
         args.add_dir.push(".:/work".to_string());
 
         let err = validate_run_profile(&args).expect_err("restrictive rejects shares");
-        assert!(err.to_string().contains("does not allow --add-dir"));
+        assert!(err.to_string().contains("does not allow --mount"));
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/phase_timing.rs
+++ b/crates/mvm-cli/src/commands/vm/phase_timing.rs
@@ -19,7 +19,7 @@ pub struct RunPhaseMarks {
     pub start: Instant,
     /// Kernel/rootfs artifacts resolved (template load or prebuilt pair).
     pub image_resolved: Instant,
-    /// `--add-dir` images built and the verity sidecar probed.
+    /// `--mount` images built and the verity sidecar probed.
     pub drives_ready: Instant,
     /// The transient workload's signed plan was admitted (or admission skipped).
     pub admitted: Instant,

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -68,7 +68,7 @@ pub struct LaunchEntrypoint {
     pub env: BTreeMap<String, String>,
 }
 
-/// One `--add-dir host:guest[:mode]` mapping.
+/// One `--mount host:guest[:mode]` mapping.
 ///
 /// The host directory is materialized into a small ext4 image attached as
 /// an extra Firecracker drive, then mounted at `guest_path` by a wrapper
@@ -93,26 +93,26 @@ impl AddDir {
     /// component is unambiguously path-shaped (contains a slash).
     pub fn parse(spec: &str) -> Result<Self> {
         let (host, rest) = spec.split_once(':').ok_or_else(|| {
-            anyhow::anyhow!("--add-dir '{spec}': expected 'host:guest[:mode]', missing ':'")
+            anyhow::anyhow!("--mount '{spec}': expected 'host:guest[:mode]', missing ':'")
         })?;
         if host.is_empty() {
-            anyhow::bail!("--add-dir '{spec}': host path must not be empty");
+            anyhow::bail!("--mount '{spec}': host path must not be empty");
         }
 
         let (guest, read_only) = match rest.rsplit_once(':') {
             Some((path, "ro")) => (path, true),
             Some((path, "rw")) => (path, false),
             Some((_, tail)) if looks_like_mode_typo(tail) => {
-                anyhow::bail!("--add-dir '{spec}': unknown mode '{tail}' (expected 'ro' or 'rw')");
+                anyhow::bail!("--mount '{spec}': unknown mode '{tail}' (expected 'ro' or 'rw')");
             }
             _ => (rest, true),
         };
 
         if guest.is_empty() {
-            anyhow::bail!("--add-dir '{spec}': guest path must not be empty");
+            anyhow::bail!("--mount '{spec}': guest path must not be empty");
         }
         if !guest.starts_with('/') {
-            anyhow::bail!("--add-dir '{spec}': guest path must be absolute (start with '/')");
+            anyhow::bail!("--mount '{spec}': guest path must be absolute (start with '/')");
         }
         Ok(Self {
             host_path: expand_tilde(host),
@@ -732,7 +732,7 @@ pub fn shell_quote(arg: &str) -> String {
 }
 
 /// Build the wrapper script that runs inside the guest:
-///   1. mounts each `--add-dir` ext4 image at the exact VMM-assigned block device
+///   1. mounts each `--mount` ext4 image at the exact VMM-assigned block device
 ///   2. exports launch-plan-derived env vars (when target is LaunchPlan)
 ///   3. exports CLI `--env` vars (CLI overrides launch-plan)
 ///   4. cds into `working_dir` (when target is LaunchPlan and it's set)
@@ -810,10 +810,10 @@ pub fn transient_run_dev_console(pty: bool, image_sealed: bool) -> bool {
 }
 
 /// Remove the transient VM's host state dir (`~/.mvm/vms/<name>`, which also
-/// holds any `--add-dir` extra images) once the VM is stopped. Host-side
+/// holds any `--mount` extra images) once the VM is stopped. Host-side
 /// `std::fs` — never `run_in_vm`, which targets a path *inside* the guest and
 /// (on macOS) would wake a builder VM to `rm` a path that isn't there, leaking
-/// the real host dir. Runs for every transient run, `--add-dir` or not: the
+/// the real host dir. Runs for every transient run, `--mount` or not: the
 /// backend writes `hvf.pid` / `console.log` here regardless, so a plain OCI
 /// launch created the dir and must clean it up too. Best-effort — teardown must
 /// never fail on a cleanup error.
@@ -856,9 +856,9 @@ fn remove_transient_state_dir(staging_dir: &str) {
 /// Decide whether snapshot restore is safe for this request.
 ///
 /// Only enabled for the trivial case: a registered template (so the image
-/// has a snapshot at all), no `--add-dir` extras (so the drive layout
+/// has a snapshot at all), no `--mount` extras (so the drive layout
 /// matches the snapshot's recorded layout), and a backend that advertises
-/// snapshot support. Adding `--add-dir` would change the drive count and
+/// snapshot support. Adding `--mount` would change the drive count and
 /// break the snapshot — that case stays cold-boot for now.
 pub fn snapshot_eligible(
     image: &ImageSource,
@@ -996,6 +996,11 @@ fn run_inner(
     let timing = crate::commands::vm::phase_timing::enabled();
     let t_start = timing.then(std::time::Instant::now);
 
+    // Validate inputs that do not depend on the image before doing any
+    // expensive work (OCI layer pulls, snapshot probes, etc.). A bad --mount
+    // host path should fail fast rather than after downloading a guest image.
+    validate_add_dirs_before_resolve(&req.add_dirs)?;
+
     // Resolve image artifacts: either a named template or a pre-built pair.
     // For templates, also probe for a pre-built snapshot so we can skip the
     // cold-boot cost when the request is snapshot-eligible.
@@ -1003,7 +1008,7 @@ fn run_inner(
 
     let t_image_resolved = timing.then(std::time::Instant::now);
 
-    // Build read-only ext4 images for each --add-dir, staged in a transient
+    // Build read-only ext4 images for each --mount, staged in a transient
     // VMS subdirectory so cleanup is straightforward.
     let AddDirStaging {
         vm_name,
@@ -1209,7 +1214,7 @@ fn resolve_image_artifacts(image: &ImageSource) -> Result<ResolvedImage> {
     }
 }
 
-/// Per-`--add-dir` staging: a small RO ext4 image built for each host
+/// Per-`--mount` staging: a small RO ext4 image built for each host
 /// directory mapping, plus the VM name / staging dir the images live under.
 struct AddDirStaging {
     vm_name: String,
@@ -1217,7 +1222,32 @@ struct AddDirStaging {
     volumes: Vec<mvm_runtime::image::RuntimeVolume>,
 }
 
-/// Build read-only ext4 images for each `--add-dir`, staged in a transient
+/// Fail fast if any `--mount` host path is missing or not a directory.
+///
+/// This runs before image resolution so a typo in a host path does not pay
+/// for an OCI pull only to error out during volume staging.
+fn validate_add_dirs_before_resolve(add_dirs: &[AddDir]) -> Result<()> {
+    for dir in add_dirs {
+        let path = Path::new(&dir.host_path);
+        if !path.exists() {
+            anyhow::bail!(
+                "--mount '{}' -> '{}': host path does not exist",
+                dir.host_path,
+                dir.guest_path
+            );
+        }
+        if !path.is_dir() {
+            anyhow::bail!(
+                "--mount '{}' -> '{}': host path is not a directory",
+                dir.host_path,
+                dir.guest_path
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Build read-only ext4 images for each `--mount`, staged in a transient
 /// VM's `extras` subdirectory so cleanup is straightforward.
 fn stage_add_dir_volumes(req: &ExecRequest) -> Result<AddDirStaging> {
     let vm_name = req.name.clone().unwrap_or_else(transient_vm_name);
@@ -1232,7 +1262,7 @@ fn stage_add_dir_volumes(req: &ExecRequest) -> Result<AddDirStaging> {
         mvm_runtime::image::build_dir_image_ro(&dir.host_path, &label, &image_path).with_context(
             || {
                 format!(
-                    "preparing --add-dir image for '{}' -> '{}'",
+                    "preparing --mount image for '{}' -> '{}'",
                     dir.host_path, dir.guest_path
                 )
             },
@@ -1242,7 +1272,7 @@ fn stage_add_dir_volumes(req: &ExecRequest) -> Result<AddDirStaging> {
             guest: dir.guest_path.clone(),
             size: String::new(),
             read_only: dir.read_only,
-            // `--add-dir` builds an RO ext4 image, so this is a disk.
+            // `--mount` builds an RO ext4 image, so this is a disk.
             ..Default::default()
         });
     }
@@ -1362,7 +1392,7 @@ fn build_start_config(
         memory_mib: req.memory_mib,
         mem_initial_mib: req.mem_initial_mib,
         ports: Vec::new(),
-        // User `--add-dir` volumes first, then the SDK sidecar. The order is
+        // User `--mount` volumes first, then the SDK sidecar. The order is
         // the block-device order every backend assigns, so keeping the
         // host-resolved sidecar last means adding or removing it never
         // renumbers a user volume's device.
@@ -1402,7 +1432,7 @@ struct BootAttempt<'a> {
 /// housekeeping since there is no daemon to do it between invocations.
 ///
 /// Returns the effective VM name — a claimed standby runs under its own
-/// standby id, not `vm_name`. On a cold-boot failure the `--add-dir`
+/// standby id, not `vm_name`. On a cold-boot failure the `--mount`
 /// staging is cleaned up and the error is returned, exactly as the inline
 /// boot sequence this replaces used to do.
 fn boot_transient_vm(
@@ -1499,7 +1529,7 @@ fn install_ctrlc_teardown(
     interrupted
 }
 
-/// Resolve the guest block devices for the transient command's `--add-dir`
+/// Resolve the guest block devices for the transient command's `--mount`
 /// volumes. `build_start_config` places those volumes before any SDK sidecar,
 /// while the runtime mapper resolves their actual slots after rootfs, verity,
 /// and runtime-overlay devices have been accounted for.
@@ -1511,7 +1541,7 @@ fn add_dir_block_devices(config: &VmStartConfig, count: usize) -> Result<Vec<Str
     let devices = mvm_runtime::workload_runner::workload_volume_devices(config);
     if devices.len() < count {
         anyhow::bail!(
-            "expected {count} --add-dir volumes, but the start config carries only {}",
+            "expected {count} --mount volumes, but the start config carries only {}",
             devices.len()
         );
     }
@@ -1523,7 +1553,7 @@ fn add_dir_block_devices(config: &VmStartConfig, count: usize) -> Result<Vec<Str
         .map(|(idx, device)| {
             device.ok_or_else(|| {
                 anyhow::anyhow!(
-                    "--add-dir volume {idx} has no attached block device on the workload runner"
+                    "--mount volume {idx} has no attached block device on the workload runner"
                 )
             })
         })
@@ -1532,7 +1562,7 @@ fn add_dir_block_devices(config: &VmStartConfig, count: usize) -> Result<Vec<Str
 
 /// Tear down the transient VM after the guest command finishes (or fails to
 /// dispatch): stop the backend VM, top up the warm pool toward its target,
-/// sync back any writable `--add-dir` mounts, and remove the host VM state
+/// sync back any writable `--mount` mounts, and remove the host VM state
 /// directory (`~/.mvm/vms/<name>`), which includes the `extras` staging
 /// subdirectory and any backend files such as `hvf.pid` / `console.log`.
 ///
@@ -1559,7 +1589,7 @@ fn teardown_transient_vm(
         tracing::debug!(error = %e, "pool replenish skipped (best-effort)");
     }
 
-    // Writable --add-dir uses rsync-back. With the VM stopped the
+    // Writable --mount uses rsync-back. With the VM stopped the
     // ext4 image is no longer in use, so we mount it host-side and rsync
     // its contents over the host directory before nuking the staging dir.
     // Failures here are warned but do not override the guest exit code.
@@ -1570,7 +1600,7 @@ fn teardown_transient_vm(
         let image_path = format!("{staging_dir}/extra-{idx}.ext4");
         if let Err(e) = mvm_runtime::image::rsync_image_to_host(&image_path, &dir.host_path) {
             ui::warn(&format!(
-                "writable --add-dir sync-back failed for '{}' -> '{}': {e:#}",
+                "writable --mount sync-back failed for '{}' -> '{}': {e:#}",
                 dir.host_path, dir.guest_path,
             ));
         }
@@ -1596,7 +1626,7 @@ fn remove_transient_state_dirs(effective_dir: &Path, requested_dir: &Path) {
 /// Mirrors the snapshot path in `cmd_run`: allocate a slot, build a
 /// `FlakeRunConfig` matching the snapshot's recorded layout, then call
 /// `microvm::restore_from_template_snapshot`. The caller is responsible for
-/// ensuring the request is `snapshot_eligible` first (no `--add-dir`,
+/// ensuring the request is `snapshot_eligible` first (no `--mount`,
 /// template image source).
 fn restore_via_snapshot(
     vm_name: &str,
@@ -1794,7 +1824,7 @@ fn direct_pty_inline_argv(req_argv: &[String], req: &ExecRequest, labels: &[Stri
 //   2. dispatch N  → ExecOutput per call
 //   3. tear down   → on idle / max / close / shutdown
 //
-// They deliberately NOT support `--add-dir` (volumes, rsync-back,
+// They deliberately NOT support `--mount` (volumes, rsync-back,
 // staging dirs) — session VMs are meant for repeated calls against a
 // clean closure, not interactive file mounts.
 
@@ -1809,7 +1839,7 @@ pub struct SessionVm {
 /// Boot a session microVM from a registered template. Snapshot-resume
 /// is taken when the template has one and the backend supports it
 /// (matches the eligibility rule in [`snapshot_eligible`] for the
-/// no-`--add-dir` case), unless an admission hook supplies per-boot
+/// no-`--mount` case), unless an admission hook supplies per-boot
 /// state that must ride the fresh boot path.
 ///
 /// `vm_name_prefix` becomes the human-readable part of the VM name —
@@ -1959,7 +1989,7 @@ pub fn dispatch_in_session(
         anyhow::bail!("guest agent did not become reachable within 30s");
     }
     // Reuse build_guest_wrapper by constructing a minimal ExecRequest
-    // with no add_dirs (sessions don't take --add-dir). The wrapper
+    // with no add_dirs (sessions don't take --mount). The wrapper
     // emits `set -e\n<env exports>\n<argv>\n`.
     let req = ExecRequest {
         name: None,
@@ -2281,6 +2311,43 @@ mod tests {
     }
 
     #[test]
+    fn validate_add_dirs_rejects_missing_host_path() {
+        let dirs = vec![AddDir {
+            host_path: "/definitely/not/a/real/path".into(),
+            guest_path: "/work".into(),
+            read_only: true,
+        }];
+        let err = validate_add_dirs_before_resolve(&dirs).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("does not exist"), "got: {msg}");
+        assert!(msg.contains("/definitely/not/a/real/path"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_add_dirs_rejects_non_directory_host_path() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let dirs = vec![AddDir {
+            host_path: file.path().to_str().unwrap().into(),
+            guest_path: "/work".into(),
+            read_only: true,
+        }];
+        let err = validate_add_dirs_before_resolve(&dirs).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("is not a directory"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_add_dirs_accepts_existing_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let dirs = vec![AddDir {
+            host_path: dir.path().to_str().unwrap().into(),
+            guest_path: "/work".into(),
+            read_only: true,
+        }];
+        validate_add_dirs_before_resolve(&dirs).expect("existing directory should validate");
+    }
+
+    #[test]
     fn shell_quote_basic() {
         assert_eq!(shell_quote("hello"), "'hello'");
         assert_eq!(shell_quote("hello world"), "'hello world'");
@@ -2343,7 +2410,7 @@ mod tests {
             ..Default::default()
         };
         let error = add_dir_block_devices(&config, 1).expect_err("missing volume must fail");
-        assert!(error.to_string().contains("expected 1 --add-dir volumes"));
+        assert!(error.to_string().contains("expected 1 --mount volumes"));
     }
 
     #[test]
@@ -3193,7 +3260,7 @@ mod tests {
 
     #[test]
     fn remove_transient_state_dir_removes_the_host_dir() {
-        // Every transient run (with or without --add-dir) creates its state dir
+        // Every transient run (with or without --mount) creates its state dir
         // when the backend writes hvf.pid / console.log there, so teardown must
         // remove it host-side — not via run_in_vm, which targets the guest.
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/mvm-hostd/src/supervisor/raw_egress.rs
+++ b/crates/mvm-hostd/src/supervisor/raw_egress.rs
@@ -11,6 +11,8 @@
 //! loopback echo server (the gate mandatory-denies loopback, so an admitted-target
 //! splice test cannot route through the real gate).
 
+#[cfg(target_os = "linux")]
+use std::io::Write;
 use std::net::IpAddr;
 #[cfg(target_os = "linux")]
 use std::net::{SocketAddr, UdpSocket};

--- a/crates/mvm-hostd/src/supervisor/raw_egress.rs
+++ b/crates/mvm-hostd/src/supervisor/raw_egress.rs
@@ -186,7 +186,7 @@ where
     let mut upstream = match connect_first_admitted(ips, port, timeout).await {
         Some(stream) => stream,
         None => {
-            eprintln!("raw-egress: no admitted address reachable for {target}");
+            tracing::warn!(target = %target, "raw-egress: no admitted address reachable");
             write_connect_ack_async(&mut guest, ConnectAck::Fail).await?;
             return Ok(());
         }
@@ -195,17 +195,20 @@ where
     if !leftover.is_empty() {
         upstream.write_all(&leftover).await?;
     }
-    eprintln!("raw-egress: connected target {target}");
+    tracing::debug!(target = %target, "raw-egress: connected");
     // EOF on either side ends the copy; a reset surfaces as an error we log so
     // one torn-down connection never crashes the accept loop.
     match tokio::io::copy_bidirectional(&mut guest, &mut upstream).await {
         Ok((guest_to_upstream, upstream_to_guest)) => {
-            eprintln!(
-                "raw-egress: completed target {target} guest_to_upstream_bytes={guest_to_upstream} upstream_to_guest_bytes={upstream_to_guest}"
+            tracing::debug!(
+                target = %target,
+                guest_to_upstream,
+                upstream_to_guest,
+                "raw-egress: completed"
             );
         }
         Err(e) => {
-            eprintln!("raw-egress: splicing target {target} failed: {e}");
+            tracing::warn!(target = %target, error = %e, "raw-egress: splicing failed");
         }
     }
     Ok(())
@@ -374,13 +377,13 @@ fn handle_raw_conn_blocking(
     let upstream = match connect_first_admitted_blocking(&ips, port, timeout) {
         Some(stream) => stream,
         None => {
-            eprintln!("raw-egress: no admitted address reachable for {target}");
+            tracing::warn!(target = %target, "raw-egress: no admitted address reachable");
             write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
             return Ok(());
         }
     };
     write_connect_ack_blocking(&mut guest, ConnectAck::Ok)?;
-    eprintln!("raw-egress: connected target {target}");
+    tracing::debug!(target = %target, "raw-egress: connected");
     let guest_fd = guest.as_raw_fd();
     set_nonblocking(guest_fd)?;
     upstream.set_nonblocking(true)?;
@@ -398,7 +401,6 @@ fn handle_raw_conn_blocking(
 /// Write the host's one-byte connect-result ack on the blocking raw-egress path.
 #[cfg(target_os = "linux")]
 fn write_connect_ack_blocking(guest: &mut std::fs::File, ack: ConnectAck) -> std::io::Result<()> {
-    use std::io::Write;
     guest.write_all(&[ack.as_byte()])?;
     guest.flush()
 }

--- a/crates/mvm-hostd/src/supervisor/raw_egress.rs
+++ b/crates/mvm-hostd/src/supervisor/raw_egress.rs
@@ -196,14 +196,17 @@ where
         upstream.write_all(&leftover).await?;
     }
     eprintln!("raw-egress: connected target {target}");
-    // EOF on either side ends the copy; a reset surfaces as an error we swallow so
+    // EOF on either side ends the copy; a reset surfaces as an error we log so
     // one torn-down connection never crashes the accept loop.
-    if let Ok((guest_to_upstream, upstream_to_guest)) =
-        tokio::io::copy_bidirectional(&mut guest, &mut upstream).await
-    {
-        eprintln!(
-            "raw-egress: completed target {target} guest_to_upstream_bytes={guest_to_upstream} upstream_to_guest_bytes={upstream_to_guest}"
-        );
+    match tokio::io::copy_bidirectional(&mut guest, &mut upstream).await {
+        Ok((guest_to_upstream, upstream_to_guest)) => {
+            eprintln!(
+                "raw-egress: completed target {target} guest_to_upstream_bytes={guest_to_upstream} upstream_to_guest_bytes={upstream_to_guest}"
+            );
+        }
+        Err(e) => {
+            eprintln!("raw-egress: splicing target {target} failed: {e}");
+        }
     }
     Ok(())
 }

--- a/crates/mvm-runtime/src/image.rs
+++ b/crates/mvm-runtime/src/image.rs
@@ -733,13 +733,13 @@ ls -lh "$IMAGES_DIR/{name}.$(uname -m).elf"
 }
 
 // ---------------------------------------------------------------------------
-// Read-only host-directory volume images (used by `mvmctl exec --add-dir`)
+// Read-only host-directory volume images (used by `mvmctl exec --mount`)
 // ---------------------------------------------------------------------------
 
 /// Build a read-only ext4 image populated with the contents of a host
 /// directory.
 ///
-/// Used by `mvmctl exec --add-dir host:guest` to share a host directory
+/// Used by `mvmctl exec --mount host:guest` to share a host directory
 /// into a transient microVM without virtio-fs. The image is built
 /// in-process with the memory-safe `mvm-ext4` writer — no builder/dev VM,
 /// no `mkfs`, no mount/copy/unmount — so `host_dir` is read directly by this
@@ -766,7 +766,7 @@ pub fn build_dir_image_ro(host_dir: &str, label: &str, dest_image_path: &str) ->
     }
 
     if !std::path::Path::new(host_dir).is_dir() {
-        anyhow::bail!("--add-dir host path must be a directory: {host_dir}");
+        anyhow::bail!("--mount host path must be a directory: {host_dir}");
     }
 
     // Reject (rather than skip) unsupported inode kinds: silently dropping a
@@ -799,7 +799,7 @@ pub fn build_dir_image_ro(host_dir: &str, label: &str, dest_image_path: &str) ->
 /// Mount an ext4 image read-only inside the Linux build environment and
 /// rsync its contents over a host directory.
 ///
-/// Used by `mvmctl exec --add-dir HOST:GUEST:rw` to deliver guest-side
+/// Used by `mvmctl exec --mount HOST:GUEST:rw` to deliver guest-side
 /// writes back to the host once the transient microVM has stopped.
 /// Uses `--delete` so the guest's view of the directory is the
 /// source of truth at sync time — added/modified files are copied over,
@@ -812,7 +812,7 @@ pub fn build_dir_image_ro(host_dir: &str, label: &str, dest_image_path: &str) ->
 /// an image still attached to a running Firecracker.
 pub fn rsync_image_to_host(image_path: &str, host_dir: &str) -> Result<()> {
     crate::base::linux_env::require_guest_exec_available(
-        "writing '--add-dir :rw' changes back to the host needs an ext4 reader, which doesn't exist yet",
+        "writing '--mount :rw' changes back to the host needs an ext4 reader, which doesn't exist yet",
     )?;
 
     let script = format!(
@@ -866,6 +866,25 @@ mod tests {
     fn build_dir_image_ro_rejects_empty_label() {
         let err = build_dir_image_ro("/tmp/x", "", "/tmp/x.ext4").unwrap_err();
         assert!(err.to_string().contains("ext4 label"));
+    }
+
+    #[test]
+    fn build_dir_image_ro_rejects_a_non_directory_host_path() {
+        let err = build_dir_image_ro(
+            "/this/path/almost/certainly/does/not/exist",
+            "mvm-extra-0",
+            "/tmp/x.ext4",
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--mount host path must be a directory"),
+            "expected a directory-check error, got: {msg}"
+        );
+        assert!(
+            msg.contains("/this/path/almost/certainly/does/not/exist"),
+            "{msg}"
+        );
     }
 
     /// `build_dir_image_ro` must materialize the ext4 image in-process (no

--- a/crates/mvm-runtime/src/vmm/vsock.rs
+++ b/crates/mvm-runtime/src/vmm/vsock.rs
@@ -13,7 +13,8 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use super::vsock_handlers::{VsockHandlerContext, VsockHandlerRegistry, VsockLifecycleState};
 #[cfg(test)]
 use super::vsock_transport::{
-    GUEST_CID, HOST_BUF_ALLOC, HOST_CID, TYPE_STREAM, VIRTIO_ID_VSOCK, VIRTIO_MAGIC, VIRTIO_VERSION,
+    GUEST_CID, HDR_LEN, HOST_BUF_ALLOC, HOST_CID, OP_SHUTDOWN, TYPE_STREAM, VIRTIO_ID_VSOCK,
+    VIRTIO_MAGIC, VIRTIO_VERSION,
 };
 use super::vsock_transport::{
     OP_CREDIT_UPDATE, OP_REQUEST, OP_RESPONSE, OP_RST, OP_RW, RegisterWrite, VsockHdr,
@@ -115,11 +116,17 @@ impl VsockShared {
             }
         }
         let flushed = self.transport.flush_rx();
+        // A guest TX notification may carry a credit update that unblocks
+        // host→guest data buffered in the handlers. Run host I/O here so the
+        // vCPU thread can make progress even if the dedicated host-I/O thread
+        // is blocked waiting for endpoint readability.
+        let host_io = self.service_host_io();
         let drained = self.transport.interrupt_status & 1 != 0;
-        drained || flushed
+        drained || flushed || host_io
     }
 
     fn handle_packet(&mut self, hdr: VsockHdr, payload: &[u8]) {
+        self.transport.record_tx_credit(&hdr);
         let mut ctx = VsockHandlerContext::new(&mut self.transport, &mut self.lifecycle);
         if self.handlers.dispatch_packet(&mut ctx, hdr, payload) {
             return;
@@ -156,6 +163,10 @@ impl VsockShared {
         self.handlers.cancel();
         self.transport.recv_cnt.clear();
         self.transport.pending_rx.clear();
+    }
+    #[cfg(test)]
+    fn provide_rx_descriptor(&mut self, buf_addr: u64, buf_len: usize) {
+        self.transport.test_provide_rx_descriptor(buf_addr, buf_len);
     }
 
     pub(super) fn poll_fds(&self) -> Vec<std::os::fd::RawFd> {
@@ -518,6 +529,7 @@ mod tests {
             len: raw.len() as u32,
             op: OP_RW,
             typ: TYPE_STREAM,
+            buf_alloc: HOST_BUF_ALLOC,
             ..Default::default()
         };
         d.handle_packet(rw, &raw);
@@ -626,6 +638,7 @@ mod tests {
             len: raw.len() as u32,
             op: OP_RW,
             typ: TYPE_STREAM,
+            buf_alloc: HOST_BUF_ALLOC,
             ..Default::default()
         };
         d.handle_packet(rw, &raw);
@@ -781,6 +794,7 @@ mod tests {
             len: 5,
             op: OP_RW,
             typ: TYPE_STREAM,
+            buf_alloc: HOST_BUF_ALLOC,
             ..Default::default()
         };
         d.handle_packet(rw, b"1.2.3");
@@ -958,5 +972,206 @@ mod tests {
         d.set_console_sockets([]).unwrap();
         assert!(!d.service_host_io());
         assert!(d.transport.pending_rx.is_empty());
+    }
+    #[test]
+    fn egress_port_relays_large_payload_without_loss() {
+        use std::io::{Read, Write};
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("subst.sock");
+
+        let Some(listener) = bind_unix_listener(&sock) else {
+            return;
+        };
+
+        // 10 MiB of deterministic payload.
+        let payload_len: usize = 10 * 1024 * 1024;
+        let payload: Vec<u8> = (0..payload_len).map(|i| (i % 251) as u8).collect();
+        let payload_for_server = payload.clone();
+
+        let server = std::thread::spawn(move || {
+            let (mut c, _) = listener.accept().unwrap();
+            // Read the raw-egress target line the guest sends.
+            let mut target_buf = Vec::new();
+            let mut byte = [0u8; 1];
+            loop {
+                c.read_exact(&mut byte).unwrap();
+                if byte[0] == b'\n' {
+                    break;
+                }
+                target_buf.push(byte[0]);
+            }
+            // Write the large payload.
+            c.write_all(&payload_for_server).unwrap();
+            // Hold the connection open briefly, then close gracefully.
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        });
+
+        let mut d = dev();
+        d.set_substitution_endpoint(&sock);
+
+        // Guest opens the stream with a raw-egress target line.
+        let raw = b"files.pythonhosted.org:443\n".to_vec();
+        let rw = VsockHdr {
+            src_cid: GUEST_CID,
+            dst_cid: HOST_CID,
+            src_port: 1500,
+            dst_port: mvm_agentd::vsock::EGRESS_PORT,
+            len: raw.len() as u32,
+            op: OP_RW,
+            typ: TYPE_STREAM,
+            buf_alloc: (payload_len as u32) + 1024,
+            ..Default::default()
+        };
+        d.handle_packet(rw, &raw);
+
+        // Repeatedly service host I/O and provide fresh RX buffers until the
+        // connection closes and no payload remains queued.
+        let mut received = Vec::new();
+        let mut shutdown_seen = false;
+        let rx_buf_addr = 0x6000_0000u64;
+        for _ in 0..2000 {
+            d.provide_rx_descriptor(rx_buf_addr, HDR_LEN + 65536);
+
+            let _ = d.service_host_io();
+
+            // Collect any OP_RW payloads addressed to our src_port.
+            let mut found = false;
+            let pending: Vec<_> = d.transport.pending_rx.drain(..).collect();
+            for (h, p) in pending {
+                if h.op == OP_RW && h.dst_port == 1500 {
+                    received.extend_from_slice(&p);
+                    found = true;
+                } else if h.op == OP_SHUTDOWN && h.dst_port == 1500 {
+                    shutdown_seen = true;
+                }
+            }
+
+            if shutdown_seen && !found {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        // Wait for the server to finish writing and close.
+        server.join().unwrap();
+
+        assert!(
+            shutdown_seen,
+            "expected graceful SHUTDOWN for the egress stream"
+        );
+        assert_eq!(
+            received.len(),
+            payload_len,
+            "expected {payload_len} bytes, got {}",
+            received.len()
+        );
+        assert_eq!(received, payload, "payload mismatch");
+    }
+
+    #[test]
+    fn host_honors_guest_tx_credit_for_large_endpoint_reply() {
+        use std::io::{Read, Write};
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("credit.sock");
+
+        let Some(listener) = bind_unix_listener(&sock) else {
+            return;
+        };
+
+        let reply_payload = vec![b'x'; 200];
+        let reply_for_server = reply_payload.clone();
+        let server = std::thread::spawn(move || {
+            let (mut c, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 64];
+            let _ = c.read(&mut buf).unwrap();
+            c.write_all(&reply_for_server).unwrap();
+            c.flush().unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        });
+
+        let mut d = dev();
+        d.set_substitution_endpoint(&sock);
+
+        // Guest opens the stream advertising only 64 bytes of receive credit.
+        let raw = b"files.pythonhosted.org:443\n".to_vec();
+        let rw = VsockHdr {
+            src_cid: GUEST_CID,
+            dst_cid: HOST_CID,
+            src_port: 1700,
+            dst_port: mvm_agentd::vsock::EGRESS_PORT,
+            len: raw.len() as u32,
+            op: OP_RW,
+            typ: TYPE_STREAM,
+            buf_alloc: 64,
+            ..Default::default()
+        };
+        d.handle_packet(rw, &raw);
+
+        // Wait for the endpoint to accept and write the reply.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let mut received = Vec::new();
+        let rx_buf_addr = 0x6000_0000u64;
+        for _ in 0..100 {
+            d.provide_rx_descriptor(rx_buf_addr, HDR_LEN + 256);
+            let _ = d.service_host_io();
+            let pending: Vec<_> = d.transport.pending_rx.drain(..).collect();
+            for (h, p) in pending {
+                if h.op == OP_RW && h.dst_port == 1700 {
+                    received.extend_from_slice(&p);
+                }
+            }
+            if !received.is_empty() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        // The host must not send more than the advertised 64 bytes.
+        assert_eq!(
+            received.len(),
+            64,
+            "host sent {} bytes but guest advertised only 64",
+            received.len()
+        );
+
+        // Guest acknowledges the first 64 bytes.
+        let credit = VsockHdr {
+            src_cid: GUEST_CID,
+            dst_cid: HOST_CID,
+            src_port: 1700,
+            dst_port: mvm_agentd::vsock::EGRESS_PORT,
+            len: 0,
+            op: OP_CREDIT_UPDATE,
+            typ: TYPE_STREAM,
+            buf_alloc: 64,
+            fwd_cnt: 64,
+            ..Default::default()
+        };
+        d.handle_packet(credit, &[]);
+
+        for _ in 0..100 {
+            d.provide_rx_descriptor(rx_buf_addr, HDR_LEN + 256);
+            let _ = d.service_host_io();
+            let pending: Vec<_> = d.transport.pending_rx.drain(..).collect();
+            for (h, p) in pending {
+                if h.op == OP_RW && h.dst_port == 1700 {
+                    received.extend_from_slice(&p);
+                }
+            }
+            if received.len() >= 128 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        assert_eq!(
+            received.len(),
+            128,
+            "host did not resume after credit update: got {} bytes",
+            received.len()
+        );
+
+        server.join().unwrap();
     }
 }

--- a/crates/mvm-runtime/src/vmm/vsock_handlers/mod.rs
+++ b/crates/mvm-runtime/src/vmm/vsock_handlers/mod.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::AtomicBool;
 use super::agent_bridge::AgentBridge;
 use super::console_bridge::ConsoleBridge;
 use super::substitution_bridge::{
-    EgressBudget, EndpointRelayAction, GuestEndpointRelay, SubstitutionBridge,
+    EgressBudget, EndpointRelayAction, GuestEndpointRelay, READ_CHUNK, SubstitutionBridge,
 };
 use super::vsock_transport::{
     OP_CREDIT_REQUEST, OP_CREDIT_UPDATE, OP_REQUEST, OP_RESPONSE, OP_RST, OP_RW, OP_SHUTDOWN,
@@ -54,6 +54,15 @@ impl<'a> VsockHandlerContext<'a> {
 
     pub(crate) fn remove_recv(&mut self, host_port: u32, guest_port: u32) {
         self.transport.remove_recv(host_port, guest_port);
+        self.transport.remove_tx_credit(host_port, guest_port);
+    }
+
+    pub(crate) fn tx_credit_available(&self, host_port: u32, guest_port: u32) -> u32 {
+        self.transport.tx_credit_available(host_port, guest_port)
+    }
+
+    pub(crate) fn consume_tx_credit(&mut self, host_port: u32, guest_port: u32, n: u32) {
+        self.transport.consume_tx_credit(host_port, guest_port, n);
     }
 
     pub(crate) fn evict_idle_recv(&mut self) -> Vec<(u32, u32)> {
@@ -353,15 +362,50 @@ impl GuestPortHandler for WorkloadExitHandler {
 }
 
 struct StreamRelayHandler {
+    guest_port: u32,
     bridge: SubstitutionBridge,
     headers: HashMap<u32, VsockHdr>,
+    tx_pending: HashMap<u32, Vec<u8>>,
 }
 
 impl StreamRelayHandler {
-    fn with_budget(_guest_port: u32, budget: EgressBudget) -> Self {
+    fn with_budget(guest_port: u32, budget: EgressBudget) -> Self {
         Self {
+            guest_port,
             bridge: SubstitutionBridge::with_budget(budget),
             headers: HashMap::new(),
+            tx_pending: HashMap::new(),
+        }
+    }
+
+    fn flush_tx_pending(&mut self, ctx: &mut VsockHandlerContext<'_>, conn_id: u32) {
+        if let Some(bytes) = self.tx_pending.remove(&conn_id) {
+            if let Some(hdr) = self.headers.get(&conn_id).copied() {
+                self.queue_up_to_credit(ctx, conn_id, hdr, bytes);
+            } else {
+                // No remembered header yet; keep the bytes buffered.
+                self.tx_pending.insert(conn_id, bytes);
+            }
+        }
+    }
+
+    fn queue_up_to_credit(
+        &mut self,
+        ctx: &mut VsockHandlerContext<'_>,
+        conn_id: u32,
+        hdr: VsockHdr,
+        bytes: Vec<u8>,
+    ) {
+        let avail = ctx.tx_credit_available(self.guest_port, conn_id) as usize;
+        if avail == 0 {
+            self.tx_pending.insert(conn_id, bytes);
+            return;
+        }
+        let send_len = bytes.len().min(avail);
+        ctx.queue_reply(&hdr, OP_RW, &bytes[..send_len]);
+        ctx.consume_tx_credit(self.guest_port, conn_id, send_len as u32);
+        if send_len < bytes.len() {
+            self.tx_pending.insert(conn_id, bytes[send_len..].to_vec());
         }
     }
 }
@@ -396,10 +440,11 @@ impl GuestPortHandler for StreamRelayHandler {
                 }
             }
             OP_CREDIT_REQUEST => ctx.queue_reply(&hdr, OP_CREDIT_UPDATE, &[]),
-            OP_SHUTDOWN => {
+            OP_SHUTDOWN | OP_RST => {
                 if self.headers.remove(&hdr.src_port).is_some() {
                     self.bridge.close_connection(hdr.src_port);
                 }
+                self.tx_pending.remove(&hdr.src_port);
                 ctx.remove_recv(hdr.dst_port, hdr.src_port);
                 ctx.queue_reply(&hdr, OP_RST, &[]);
             }
@@ -408,19 +453,50 @@ impl GuestPortHandler for StreamRelayHandler {
     }
 
     fn drain(&mut self, ctx: &mut VsockHandlerContext<'_>) -> Option<u32> {
-        if !self.bridge.is_active() {
+        if !self.bridge.is_active() && self.tx_pending.is_empty() {
             return None;
         }
-        let drained = self.bridge.drain_endpoint_bytes();
-        for (conn_id, bytes) in drained.ready {
+
+        // First, try to push any buffered egress bytes that previously lacked
+        // guest receive credit. This lets progress resume as soon as the guest
+        // sends a credit update, even if the endpoint has no new data yet.
+        let pending_conn_ids: Vec<u32> = self.tx_pending.keys().copied().collect();
+        for conn_id in pending_conn_ids {
+            self.flush_tx_pending(ctx, conn_id);
+        }
+
+        // Only pull more bytes from the endpoint when we have credit for them.
+        // This keeps the in-memory pending queue bounded and preserves stream
+        // ordering for each connection.
+        let guest_port = self.guest_port;
+        let tx_pending = &self.tx_pending;
+        let mut limit = |conn_id: u32| -> usize {
+            if tx_pending.contains_key(&conn_id) {
+                return 0;
+            }
+            let avail = ctx.tx_credit_available(guest_port, conn_id) as usize;
+            READ_CHUNK.min(avail)
+        };
+        let drained = self.bridge.drain_endpoint_bytes_limited(&mut limit);
+        for (conn_id, mut bytes) in drained.ready {
+            if let Some(pending) = self.tx_pending.remove(&conn_id) {
+                let mut combined = pending;
+                combined.append(&mut bytes);
+                bytes = combined;
+            }
             if let Some(hdr) = self.headers.get(&conn_id).copied() {
-                ctx.queue_reply(&hdr, OP_RW, &bytes);
+                self.queue_up_to_credit(ctx, conn_id, hdr, bytes);
             }
         }
         for conn_id in drained.closed {
+            self.flush_tx_pending(ctx, conn_id);
+            self.tx_pending.remove(&conn_id);
             if let Some(hdr) = self.headers.remove(&conn_id) {
                 ctx.remove_recv(hdr.dst_port, hdr.src_port);
-                ctx.queue_reply(&hdr, OP_RST, &[]);
+                ctx.queue_reply(&hdr, OP_SHUTDOWN, &[]);
+                if let Some((h, _)) = ctx.transport.pending_rx.back_mut() {
+                    h.flags = 3;
+                }
             }
         }
         if ctx.flush_rx() { Some(0) } else { None }

--- a/crates/mvm-runtime/src/vmm/vsock_transport.rs
+++ b/crates/mvm-runtime/src/vmm/vsock_transport.rs
@@ -142,6 +142,7 @@ pub(crate) struct VsockTransportCore {
     pub(crate) interrupt_status: u32,
     pub(crate) recv_cnt: HashMap<VsockConnectionKey, RecvCredit>,
     pub(crate) pending_rx: VecDeque<(VsockHdr, Vec<u8>)>,
+    tx_credit: HashMap<VsockConnectionKey, TxCredit>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -152,6 +153,13 @@ pub(crate) struct VsockConnectionKey {
 
 pub(crate) struct RecvCredit {
     bytes: u32,
+    last_activity: Instant,
+}
+
+pub(crate) struct TxCredit {
+    peer_buf_alloc: u32,
+    peer_fwd_cnt: u32,
+    tx_cnt: u32,
     last_activity: Instant,
 }
 
@@ -169,6 +177,7 @@ impl VsockTransportCore {
             interrupt_status: 0,
             recv_cnt: HashMap::new(),
             pending_rx: VecDeque::new(),
+            tx_credit: HashMap::new(),
         }
     }
 
@@ -328,6 +337,61 @@ impl VsockTransportCore {
         });
     }
 
+    /// Record the peer's advertised receive-buffer credit from an incoming
+    /// packet. The guest updates `buf_alloc` and `fwd_cnt` as it consumes data,
+    /// so the host must refresh its view before sending more.
+    pub(crate) fn record_tx_credit(&mut self, inbound: &VsockHdr) {
+        let key = VsockConnectionKey {
+            host_port: inbound.dst_port,
+            guest_port: inbound.src_port,
+        };
+        if !self.tx_credit.contains_key(&key) && self.tx_credit.len() >= MAX_CONNECTIONS {
+            return;
+        }
+        let now = Instant::now();
+        let entry = self.tx_credit.entry(key).or_insert(TxCredit {
+            peer_buf_alloc: inbound.buf_alloc,
+            peer_fwd_cnt: inbound.fwd_cnt,
+            tx_cnt: 0,
+            last_activity: now,
+        });
+        entry.peer_buf_alloc = inbound.buf_alloc;
+        entry.peer_fwd_cnt = inbound.fwd_cnt;
+        entry.last_activity = now;
+    }
+
+    pub(crate) fn tx_credit_available(&self, host_port: u32, guest_port: u32) -> u32 {
+        self.tx_credit
+            .get(&VsockConnectionKey {
+                host_port,
+                guest_port,
+            })
+            .map(|credit| {
+                credit
+                    .peer_buf_alloc
+                    .saturating_add(credit.peer_fwd_cnt)
+                    .saturating_sub(credit.tx_cnt)
+            })
+            .unwrap_or(HOST_BUF_ALLOC)
+    }
+
+    pub(crate) fn consume_tx_credit(&mut self, host_port: u32, guest_port: u32, n: u32) {
+        if let Some(credit) = self.tx_credit.get_mut(&VsockConnectionKey {
+            host_port,
+            guest_port,
+        }) {
+            credit.tx_cnt = credit.tx_cnt.saturating_add(n);
+            credit.last_activity = Instant::now();
+        }
+    }
+
+    pub(crate) fn remove_tx_credit(&mut self, host_port: u32, guest_port: u32) {
+        self.tx_credit.remove(&VsockConnectionKey {
+            host_port,
+            guest_port,
+        });
+    }
+
     pub(crate) fn queue_host_packet(
         &mut self,
         src_port: u32,
@@ -450,6 +514,25 @@ impl VsockTransportCore {
         self.queues[RX].last_avail = queue.next_avail();
         self.queues[RX].next_used = queue.next_used();
         delivered
+    }
+    #[cfg(test)]
+    pub(crate) fn test_provide_rx_descriptor(&mut self, buf_addr: u64, buf_len: usize) {
+        let base = 0x5000_0000u64;
+        self.queues[RX] = Queue {
+            num: 1,
+            ready: 1,
+            desc: base,
+            avail: base + 0x100,
+            used: base + 0x200,
+            last_avail: 0,
+            next_used: 0,
+        };
+        self.mem.write_bytes(base, &buf_addr.to_le_bytes());
+        self.mem
+            .write_bytes(base + 8, &(buf_len as u32).to_le_bytes());
+        self.mem.wr_u16(base + 12, 2); // DESC_F_WRITE
+        self.mem.wr_u16(base + 0x100 + 2, 1); // avail_idx = 1
+        self.mem.wr_u16(base + 0x100 + 4, 0); // ring[0] = 0
     }
 
     fn cur(&self) -> &Queue {

--- a/crates/mvm-runtime/src/vsock_egress_bridge/substitution_bridge.rs
+++ b/crates/mvm-runtime/src/vsock_egress_bridge/substitution_bridge.rs
@@ -22,7 +22,7 @@ use crate::vmm::vsock_transport::CONNECTION_IDLE_TIMEOUT;
 use crate::vmm::vsock_transport::MAX_CONNECTIONS;
 
 /// Per-drain read budget per endpoint connection.
-const READ_CHUNK: usize = 16 * 1024;
+pub(crate) const READ_CHUNK: usize = 16 * 1024;
 /// Maximum number of active raw/SOCKS5/DNS/substitution streams per workload.
 pub(crate) const MAX_EGRESS_STREAMS: usize = 128;
 /// Sustained egress byte budget shared by all host-mediated workload streams.
@@ -150,7 +150,18 @@ pub(crate) trait GuestEndpointRelay {
     fn relay_guest_bytes(&mut self, conn_id: u32, payload: &[u8]) -> EndpointRelayAction;
 
     /// Drain host→guest endpoint bytes once from every active connection.
+    #[allow(dead_code)]
     fn drain_endpoint_bytes(&mut self) -> EndpointRelayDrain;
+
+    /// Drain endpoint bytes with a per-connection read limit.
+    ///
+    /// `limit(conn_id)` returns the maximum bytes to read for that connection.
+    /// A limit of zero skips the connection, leaving any buffered bytes in the
+    /// socket for a later drain.
+    fn drain_endpoint_bytes_limited(
+        &mut self,
+        limit: &mut dyn FnMut(u32) -> usize,
+    ) -> EndpointRelayDrain;
 
     /// Close the endpoint side of `conn_id`.
     fn close_connection(&mut self, conn_id: u32);
@@ -289,10 +300,24 @@ impl GuestEndpointRelay for SubstitutionBridge {
     }
 
     fn drain_endpoint_bytes(&mut self) -> EndpointRelayDrain {
+        self.drain_endpoint_bytes_limited(&mut |_| READ_CHUNK)
+    }
+
+    fn drain_endpoint_bytes_limited(
+        &mut self,
+        limit: &mut dyn FnMut(u32) -> usize,
+    ) -> EndpointRelayDrain {
         let mut ready = Vec::new();
         let mut closed = self.evict_idle_at(Instant::now());
         for (conn_id, conn) in self.conns.iter_mut() {
-            let allowance = self.budget.reserve_read(READ_CHUNK, Instant::now());
+            let max = limit(*conn_id);
+            if max == 0 {
+                continue;
+            }
+            let allowance = self
+                .budget
+                .reserve_read(max.min(READ_CHUNK), Instant::now());
+
             if allowance == 0 {
                 // The endpoint remains readable while the token bucket refills.
                 // Avoid a hot loop in the host-I/O poller without tearing down a


### PR DESCRIPTION
Fixes #2203.

The in-house HVF virtio-vsock device was ignoring the guest's advertised receive-buffer credit (`buf_alloc + fwd_cnt`). On high-bandwidth host→guest streams the host wrote far ahead of what the guest had consumed, causing the guest driver to drop or RST packets. This surfaced as truncated PyPI wheels and TLS/hash failures.

Changes:
- Added per-connection transmit-credit tracking to `VsockTransportCore`.
- Added `drain_endpoint_bytes_limited` to `SubstitutionBridge` so the egress handler only pulls bytes it has credit to forward.
- `StreamRelayHandler` now buffers unsent egress bytes and flushes them on credit updates.
- The vCPU `on_notify` path calls `service_host_io` after guest TX packets so credit updates unblock buffered egress.
- Converted raw-egress `eprintln!` diagnostics to structured `tracing`.
- Updated/added vsock tests, including a 10 MiB regression test and a focused credit-boundary test.

Verification:
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p mvm-runtime --lib vmm::vsock` pass.
- Live HVF reproduction: direct 10 MB wheel download and `pip install pandas numpy` inside an HVF VM now complete without truncation.
