### PR TITLE
fix(agentd): give UID 901 a writable HOME

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
@@ -112,6 +112,13 @@ pub(crate) fn apply_activation(
     // It has to land after the pivot (it writes into the workload's root) and
     // before the privilege drop (mounts and interface changes need root).
     bootstrap_guest_environment()?;
+    if let Err(error) = guest_mount::ensure_workload_home() {
+        eprintln!(
+            "mvm-guest-agent: failed to create workload home ({}): {error}; falling back to {}",
+            guest_mount::WORKLOAD_HOME,
+            guest_mount::WORKLOAD_HOME_FALLBACK
+        );
+    }
     guest_mount::drop_privilege(guest_mount::WORKLOAD_UID, guest_mount::WORKLOAD_GID)?;
 
     boot_state.set_activation(ActivationState::Activated);

--- a/crates/mvm-agentd/src/bin/mvm-oci-entrypoint.rs
+++ b/crates/mvm-agentd/src/bin/mvm-oci-entrypoint.rs
@@ -37,6 +37,7 @@ mod linux {
         let mut command = Command::new(&config.argv[0]);
         command.args(&config.argv[1..]);
         command.env_clear();
+        command.env("HOME", mvm_agentd::guest_mount::workload_home());
         let mut has_path = false;
         for item in &config.env {
             if let Some((key, value)) = item.split_once('=') {

--- a/crates/mvm-agentd/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-oci-init.rs
@@ -38,6 +38,13 @@ mod linux {
         if provision_guest_environment().is_err() {
             std::process::exit(1);
         }
+        if let Err(error) = mvm_agentd::guest_mount::ensure_workload_home() {
+            eprintln!(
+                "mvm-oci-init: failed to create workload home ({}): {error}; falling back to {}",
+                mvm_agentd::guest_mount::WORKLOAD_HOME,
+                mvm_agentd::guest_mount::WORKLOAD_HOME_FALLBACK
+            );
+        }
         if cmdline_has_flag(mvm_contract::l3::GUEST_CMDLINE_FLAG) {
             start_l3_tunnel();
         }

--- a/crates/mvm-agentd/src/console.rs
+++ b/crates/mvm-agentd/src/console.rs
@@ -672,7 +672,8 @@ where
             env.push(c);
         }
     }
-    env.push(std::ffi::CString::new("HOME=/root").expect("no interior NUL"));
+    let home = format!("HOME={}", crate::guest_mount::workload_home());
+    env.push(std::ffi::CString::new(home).expect("no interior NUL"));
     env.push(std::ffi::CString::new("TERM=xterm-256color").expect("no interior NUL"));
     env
 }
@@ -727,7 +728,8 @@ mod tests {
         );
         assert_eq!(strs.iter().filter(|s| s.starts_with("HOME=")).count(), 1);
         assert_eq!(strs.iter().filter(|s| s.starts_with("TERM=")).count(), 1);
-        assert!(strs.contains(&"HOME=/root"), "{strs:?}");
+        let expected_home = format!("HOME={}", crate::guest_mount::workload_home());
+        assert!(strs.contains(&expected_home.as_str()), "{strs:?}");
         assert!(strs.contains(&"TERM=xterm-256color"), "{strs:?}");
         assert!(!strs.contains(&"HOME=/somewhere/else"));
     }
@@ -741,7 +743,8 @@ mod tests {
         let out = build_shell_env_from([(oss("WEIRD"), bad)], &[]);
         let strs: Vec<&str> = out.iter().filter_map(|c| c.to_str().ok()).collect();
         assert!(!strs.iter().any(|s| s.starts_with("WEIRD=")), "{strs:?}");
-        assert!(strs.contains(&"HOME=/root"));
+        let expected_home = format!("HOME={}", crate::guest_mount::workload_home());
+        assert!(strs.contains(&expected_home.as_str()));
         assert!(strs.contains(&"TERM=xterm-256color"));
     }
 

--- a/crates/mvm-agentd/src/exec_stream.rs
+++ b/crates/mvm-agentd/src/exec_stream.rs
@@ -103,6 +103,7 @@ pub fn stream_exec<F: FnMut(ExecEvent)>(
     builder
         .arg("-c")
         .arg(command)
+        .env("HOME", crate::guest_mount::workload_home())
         .stdin(if stdin_data.is_some() {
             Stdio::piped()
         } else {
@@ -317,5 +318,23 @@ mod tests {
         let mut events = Vec::new();
         let term = stream_exec("printf done", None, None, |e| events.push(e));
         assert!(matches!(term, ExecEvent::Exit { code: 0 }), "got {term:?}");
+    }
+
+    #[test]
+    fn sets_home_to_workload_home() {
+        let mut events = Vec::new();
+        let term = stream_exec("printf '%s' \"$HOME\"", None, None, |e| events.push(e));
+        assert!(matches!(term, ExecEvent::Exit { code: 0 }), "got {term:?}");
+        let out: Vec<u8> = events
+            .iter()
+            .filter_map(|e| match e {
+                ExecEvent::Stdout { chunk } => Some(chunk.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        let home = std::str::from_utf8(&out).expect("utf-8 home");
+        assert_eq!(home, crate::guest_mount::workload_home());
+        assert!(!home.is_empty());
     }
 }

--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -20,6 +20,17 @@ pub const WORKLOAD_UID: u32 = 901;
 /// Fixed group used by the guest agent and workload command runner.
 pub const WORKLOAD_GID: u32 = 901;
 
+/// Home directory for the workload identity.
+///
+/// Tools like pip default to `$HOME/.cache`. Without a writable home, UID 901
+/// falls back to `/` (root-owned) and emits spurious sudo warnings. The PID-1
+/// boot paths create this directory and chown it to [`WORKLOAD_UID`] before
+/// dropping privilege.
+pub const WORKLOAD_HOME: &str = "/home/mvm-worker";
+
+/// Fallback home when the rootfs is read-only (e.g. dm-verity prod boots).
+pub const WORKLOAD_HOME_FALLBACK: &str = "/tmp";
+
 /// Boot-time mount error.  Every failure path is terminal: PID 1 has no
 /// init to fall back to, so the agent logs and exits non-zero.
 #[derive(Debug, thiserror::Error)]
@@ -455,6 +466,36 @@ pub fn drop_privilege_raw(uid: u32, gid: u32) -> std::io::Result<()> {
         return Err(std::io::Error::from_raw_os_error(libc::EPERM));
     }
     Ok(())
+}
+
+/// Return the workload home directory, creating it if necessary and possible.
+///
+/// This is intended to be called from PID-1 paths while still root, before the
+/// agent drops privilege or is spawned as UID 901. On a read-only rootfs the
+/// directory creation will fail; callers should log the failure and continue,
+/// because `workload_home()` will fall back to [`WORKLOAD_HOME_FALLBACK`] at
+/// exec time.
+#[cfg(target_os = "linux")]
+pub fn ensure_workload_home() -> Result<()> {
+    ensure_dir(WORKLOAD_HOME)?;
+    chown(WORKLOAD_HOME, WORKLOAD_UID, WORKLOAD_GID)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn ensure_workload_home() -> Result<()> {
+    Ok(())
+}
+
+/// Resolve the directory to use as `$HOME` for workload processes.
+///
+/// Prefer [`WORKLOAD_HOME`] when it was successfully prepared at boot; fall
+/// back to [`WORKLOAD_HOME_FALLBACK`] (always writable) otherwise.
+pub fn workload_home() -> &'static str {
+    if std::path::Path::new(WORKLOAD_HOME).is_dir() {
+        WORKLOAD_HOME
+    } else {
+        WORKLOAD_HOME_FALLBACK
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1371,5 +1412,22 @@ mod tests {
         let err = probe_ext4_block_size(image.path().to_str().expect("temp path"))
             .expect_err("bad magic must fail");
         assert!(err.to_string().contains("magic mismatch"), "{err}");
+    }
+
+    #[test]
+    fn workload_home_falls_back_when_prepared_directory_missing() {
+        // In normal CI this path does not exist, so the function must return
+        // the fallback rather than a non-existent directory.
+        if !std::path::Path::new(WORKLOAD_HOME).is_dir() {
+            assert_eq!(workload_home(), WORKLOAD_HOME_FALLBACK);
+        }
+        let home = workload_home();
+        assert!(home == WORKLOAD_HOME || home == WORKLOAD_HOME_FALLBACK);
+    }
+
+    #[test]
+    fn workload_home_constants_are_non_empty() {
+        assert!(!WORKLOAD_HOME.is_empty());
+        assert!(!WORKLOAD_HOME_FALLBACK.is_empty());
     }
 }


### PR DESCRIPTION
 runs the workload as UID 901 with no `HOME` set. When /bin/sh cannot resolve a passwd entry for UID 901 it defaults `HOME` to `/`, so pip resolves its cache to `/.cache/pip` (root-owned) and emits a spurious sudo warning even though nothing runs as root.

## Changes
- Create `/home/mvm-worker` and `chown` it to UID 901 from the PID-1 boot paths (`mvm-oci-init` and `mvm-guest-agent` init) while still root.
- Set `HOME` to that directory in the streaming exec, console, and OCI entrypoint spawn sites.
- Fall back to `/tmp` if the rootfs is read-only (e.g. dm-verity prod), so the workload always has a writable home directory.

## Verification
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p mvm-agentd` (611 tests)
- `cargo fmt --check`