### PR TITLE
Add contributor development flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,9 +644,10 @@ workflow. Host Nix remains optional for running `mvmctl`: workload Nix
 evaluation and image builds still run inside the managed builder VM. The
 microVM library and image-building flake lives separately under [`nix/`](nix/).
 
-When opened interactively, the development shell re-enters your configured
-`$SHELL`, so aliases and functions from your normal shell startup files remain
-available. Set `MVM_PRESERVE_PERSONAL_SHELL=0` to keep Nix’s default Bash shell.
+When opened interactively, the development shell replaces Nix’s default Bash
+with login zsh, so aliases and functions from your normal zsh startup files
+remain available. The shell also best-effort installs the
+`wasm32-unknown-unknown` target when `rustup` is available.
 
 After building, run `mvmctl doctor` — it reports the resolved builder backend
 and emits install hints for anything missing.

--- a/README.md
+++ b/README.md
@@ -629,17 +629,23 @@ Contributions are welcome. The short version:
 git clone https://github.com/tinylabscom/mvm.git && cd mvm
 just install-hooks        # pre-commit hook: auto-runs cargo fmt --all
 
-# Source-checkout builds cross-compile builder/bootstrap helpers; you need:
+# Recommended: enter the pinned contributor environment.
+nix develop
+
+# Or install the source-checkout tools manually:
 brew install zig          # or your distro's zig
 cargo install cargo-zigbuild cargo-nextest
 ```
 
-End users of released binaries need none of that — workload guest code comes
-from the universal initramfs and read-only runtime overlay, while
-builder/bootstrap helpers ship with `mvmctl`. You do **not** need host Nix:
-every Nix evaluation runs inside the builder VM. After building, run `mvmctl
-doctor` — it reports the resolved builder backend and emits install hints for
-anything missing.
+The root [`flake.nix`](flake.nix) is a development environment, not a
+workload image. `nix develop` provides the pinned Rust toolchain, Cargo tools,
+formatters, linters, Zig, and documentation tooling used by the contributor
+workflow. Host Nix remains optional for running `mvmctl`: workload Nix
+evaluation and image builds still run inside the managed builder VM. The
+microVM library and image-building flake lives separately under [`nix/`](nix/).
+
+After building, run `mvmctl doctor` — it reports the resolved builder backend
+and emits install hints for anything missing.
 
 ### Build, test, lint
 

--- a/README.md
+++ b/README.md
@@ -644,6 +644,10 @@ workflow. Host Nix remains optional for running `mvmctl`: workload Nix
 evaluation and image builds still run inside the managed builder VM. The
 microVM library and image-building flake lives separately under [`nix/`](nix/).
 
+When opened interactively, the development shell re-enters your configured
+`$SHELL`, so aliases and functions from your normal shell startup files remain
+available. Set `MVM_PRESERVE_PERSONAL_SHELL=0` to keep Nix’s default Bash shell.
+
 After building, run `mvmctl doctor` — it reports the resolved builder backend
 and emits install hints for anything missing.
 

--- a/crates/mvm-runtime/src/host_agent_spawn.rs
+++ b/crates/mvm-runtime/src/host_agent_spawn.rs
@@ -591,16 +591,21 @@ mod tests {
     fn register_vm_retries_across_control_socket_restart() {
         let dir = tempfile::tempdir().unwrap();
         let socket = dir.path().join("control.sock");
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
         let worker = std::thread::spawn({
             let socket = socket.clone();
             let dir = dir.path().to_path_buf();
             move || -> bool {
-                std::thread::sleep(Duration::from_millis(150));
-
                 let Some(listener) = bind_unix_listener(&socket) else {
+                    let _ = ready_tx.send(false);
                     return false;
                 };
-                let (mut stream, _) = listener.accept().unwrap();
+                if ready_tx.send(true).is_err() {
+                    return false;
+                }
+                let Some((mut stream, _)) = accept_with_timeout(&listener) else {
+                    return false;
+                };
                 let signed = read_framed::<SignedControl>(&mut stream).unwrap();
                 match &signed.request {
                     ControlRequest::Register(r) => assert_eq!(r.vm_id, "vm-1"),
@@ -614,7 +619,9 @@ mod tests {
                 let Some(listener) = bind_unix_listener(&socket) else {
                     return false;
                 };
-                let (mut stream, _) = listener.accept().unwrap();
+                let Some((mut stream, _)) = accept_with_timeout(&listener) else {
+                    return false;
+                };
                 let signed = read_framed::<SignedControl>(&mut stream).unwrap();
                 match &signed.request {
                     ControlRequest::Register(r) => {
@@ -631,6 +638,14 @@ mod tests {
             }
         });
 
+        match ready_rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(true) => {}
+            Ok(false) | Err(_) => {
+                assert!(!worker.join().unwrap(), "the control endpoint must bind");
+                return;
+            }
+        }
+
         if let Err(err) = register_vm(&socket, &key(), sample_register(dir.path())) {
             let helper_ready = worker.join().unwrap();
             if !helper_ready {
@@ -643,6 +658,25 @@ mod tests {
             panic!("register retries across daemon restart: {err}");
         }
         assert!(worker.join().unwrap());
+    }
+
+    fn accept_with_timeout(
+        listener: &std::os::unix::net::UnixListener,
+    ) -> Option<(UnixStream, std::os::unix::net::SocketAddr)> {
+        listener.set_nonblocking(true).unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match listener.accept() {
+                Ok(connection) => return Some(connection),
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    if std::time::Instant::now() >= deadline {
+                        return None;
+                    }
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                Err(_) => return None,
+            }
+        }
     }
 
     #[test]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785993740,
+        "narHash": "sha256-naSJ+p7zkIT2hHNSJkhxiPZlmVRgE3UdODinMM7rpD8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3d1b34a12a26be073f7ae67165a6b61229ca6025",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
               shfmt
               treefmt
               zig
+              zsh
             ]) ++ optionalCargoTools;
 
             buildInputs = with pkgs; [
@@ -86,6 +87,22 @@
             PKG_CONFIG_PATH = pkgs.lib.makeSearchPath "lib/pkgconfig" [ pkgs.openssl.dev ];
 
             shellHook = ''
+              case "$-" in
+                *i*)
+                  if [ "''${MVM_PRESERVE_PERSONAL_SHELL:-1}" = 1 ] \
+                    && [ -z "''${MVM_PERSONAL_SHELL_ACTIVE:-}" ]; then
+                    case "''${SHELL##*/}" in
+                      bash|zsh)
+                        if personal_shell="$(command -v "''${SHELL##*/}" 2>/dev/null)"; then
+                          export MVM_PERSONAL_SHELL_ACTIVE=1
+                          exec "$personal_shell" -i
+                        fi
+                        ;;
+                    esac
+                  fi
+                  ;;
+              esac
+
               echo "mvm development shell"
               echo "Rust toolchain: ${rustChannel}"
               echo "Try: just build, just test, or just lint"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,103 @@
+{
+  description = "mvm contributor development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, rust-overlay, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      toolchain = builtins.fromTOML (builtins.readFile ./rust-toolchain.toml);
+      rustChannel = toolchain.toolchain.channel;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ (import rust-overlay) ];
+          };
+
+          rust = pkgs.rust-bin.stable.${rustChannel}.default.override {
+            extensions = [
+              "clippy"
+              "rust-src"
+              "rustfmt"
+            ];
+            targets = [
+              "aarch64-unknown-linux-musl"
+              "x86_64-unknown-linux-musl"
+            ];
+          };
+
+          zig = if pkgs ? zig_0_13 then pkgs.zig_0_13 else pkgs.zig;
+
+          optionalCargoTools =
+            (pkgs.lib.optional (pkgs ? cargo-machete) pkgs.cargo-machete)
+            ++ (pkgs.lib.optional (pkgs ? cargo-zigbuild) pkgs.cargo-zigbuild);
+        in
+        {
+          default = pkgs.mkShell {
+            packages = (with pkgs; [
+              rust
+              rust-analyzer
+              cargo-audit
+              cargo-deny
+              cargo-nextest
+              curl
+              git
+              jq
+              just
+              lld
+              nix
+              nixfmt-rfc-style
+              nodejs_22
+              pkg-config
+              pnpm
+              prettier
+              protobuf
+              python3
+              ripgrep
+              shellcheck
+              shfmt
+              treefmt
+              zig
+            ]) ++ optionalCargoTools;
+
+            buildInputs = with pkgs; [
+              llvmPackages.libclang
+              openssl
+            ];
+
+            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+            PKG_CONFIG_PATH = pkgs.lib.makeSearchPath "lib/pkgconfig" [ pkgs.openssl.dev ];
+
+            shellHook = ''
+              echo "mvm development shell"
+              echo "Rust toolchain: ${rustChannel}"
+              echo "Try: just build, just test, or just lint"
+              echo "Nix workload flake: ./nix"
+            '';
+          };
+        });
+
+      formatter = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        pkgs.nixfmt-rfc-style);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -87,21 +87,17 @@
             PKG_CONFIG_PATH = pkgs.lib.makeSearchPath "lib/pkgconfig" [ pkgs.openssl.dev ];
 
             shellHook = ''
-              case "$-" in
-                *i*)
-                  if [ "''${MVM_PRESERVE_PERSONAL_SHELL:-1}" = 1 ] \
-                    && [ -z "''${MVM_PERSONAL_SHELL_ACTIVE:-}" ]; then
-                    case "''${SHELL##*/}" in
-                      bash|zsh)
-                        if personal_shell="$(command -v "''${SHELL##*/}" 2>/dev/null)"; then
-                          export MVM_PERSONAL_SHELL_ACTIVE=1
-                          exec "$personal_shell" -i
-                        fi
-                        ;;
-                    esac
-                  fi
-                  ;;
-              esac
+              # WASM target for the portable half of the workspace.
+              if command -v rustup >/dev/null 2>&1; then
+                rustup target add wasm32-unknown-unknown \
+                  >/dev/null 2>&1 || true
+              fi
+
+              # nix develop initially starts Bash. Replace only the
+              # interactive shell with the user's configured zsh.
+              if [[ "$-" == *i* ]]; then
+                exec /bin/zsh -il
+              fi
 
               echo "mvm development shell"
               echo "Rust toolchain: ${rustChannel}"


### PR DESCRIPTION
## Summary

- Make the repository root `flake.nix` a contributor development environment.
- Provide the pinned Rust toolchain, Cargo tooling, formatting/linting tools, Zig, and documentation dependencies through `nix develop`.
- Keep the microVM library and workload/image flake under `nix/`.
- Preserve personal shell conveniences by replacing interactive Nix Bash with login zsh.
- Best-effort install the `wasm32-unknown-unknown` target when `rustup` is available.
- Document the distinction in the README.

## Validation

- `nix-instantiate --parse flake.nix`
- `nix flake lock .`
- `cargo fmt --all -- --check`
- Full Linux-builder flake evaluation remains for the builder/CI environment; this macOS host has no Linux builder available.

See [Architecture & ADRs](specs/adrs/).
