### PR TITLE
ci(hostd): validate eBPF telemetry load/attach on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,6 +448,42 @@ jobs:
       - name: Run Linux, no_std, filesystem, and conformance coverage
         run: bash scripts/ci-linux-coverage.sh
 
+  test-ebpf-telemetry:
+    name: Test eBPF telemetry load/attach
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/free-disk
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install nightly Rust toolchain for eBPF build
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+
+      - name: Install system build deps
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update
+          sudo apt-get install -y libcap-ng-dev lld
+
+      - name: Install bpf-linker
+        run: cargo +nightly install --locked bpf-linker
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Build the eBPF object
+        run: just build-ebpf
+
+      - name: Run mvm-hostd eBPF telemetry load/attach test
+        run: cargo test -p mvm-hostd --features ebpf-telemetry --lib
+
   nix-flake-check:
     name: Nix flake check (Linux eval)
     # Nix eval/build is heavy; run it in the merge queue and on manual dispatch,

--- a/crates/mvm-hostd/src/supervisor/ebpf_telemetry/loader.rs
+++ b/crates/mvm-hostd/src/supervisor/ebpf_telemetry/loader.rs
@@ -293,3 +293,34 @@ mod tests {
         assert!(telemetry.attach(target).is_ok());
     }
 }
+
+#[cfg(all(target_os = "linux", feature = "ebpf-telemetry"))]
+#[test]
+fn telemetry_probe_loads_and_attaches_real_ebpf_object() {
+    let path = default_ebpf_object_path();
+    let Some(path) = path else {
+        eprintln!("skipping: no default eBPF object path");
+        return;
+    };
+    if !path.exists() {
+        eprintln!("skipping: eBPF object not built at {}", path.display());
+        return;
+    }
+
+    let telemetry = EgressTelemetry::new(ProbeConfig {
+        ebpf_object_path: Some(path),
+        enable_procfs_fallback: false,
+    });
+    let target =
+        ObservabilityTarget::new("ebpf-live-test").with_substitution_pid(std::process::id());
+
+    let handle = telemetry
+        .attach(target)
+        .expect("eBPF object should load and tcp_connect kprobe should attach");
+
+    // Give the kprobe a moment to settle; we do not require an actual
+    // TCP connect event to fire in this test.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    telemetry.detach(handle);
+}


### PR DESCRIPTION
Adds a Linux-only unit test that loads the real eBPF object and attaches the tcp_connect kprobe, plus a CI job that builds the object and runs the test.

This closes the open 'validate load/attach on a live Linux host' follow-up from #2214. Destination address/port parsing from struct sock is still a placeholder and will be handled separately.

Refs: #2211