### PR TITLE
docs: mark eBPF live Linux validation complete

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -24,10 +24,10 @@ for detailed scope and acceptance criteria.
   - [x] Full workspace test run on the host (cargo nextest: 10134 passed,
         18 skipped; cargo test previously flaked on one netd test that
         passes in isolation)
-  - [ ] Full workspace test run in CI / Linux builder VM
+  - [x] Full workspace test run in CI / Linux builder VM (PR #2214)
   - [x] Implement Linux Aya load/attach/ring-buffer read path
         (cross-compiles for x86_64-unknown-linux-gnu via cargo-zigbuild)
-  - [ ] Validate load/attach on a live Linux host
+  - [x] Validate load/attach on a live Linux host (PR #2221)
 
 - [~] Plan 287 — Userspace socket datapath
       (`specs/plans/287-userspace-socket-datapath.md`, ADR-037)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -115,8 +115,8 @@
       `just build-ebpf` (nightly + `bpf-linker`), added an attach→detach
       integration test that reads the sidecar, implemented the Linux Aya
       load/attach/ring-buffer read path, and ran the full workspace nextest
-      suite (10134 passed, 18 skipped). Validating load/attach on a live
-      Linux host remains for the builder VM.
+      suite (10134 passed, 18 skipped). Live Linux load/attach validation
+      merged in #2221.
 
 - [x] Source-checkout kernel bootstrap reliability. `just kernel-workload` and
       `mvmctl kernel build --which workload` now embed the Stage 0 egress client


### PR DESCRIPTION
Update SPRINT.md and REFACTOR-STATUS.md now that #2221 validated eBPF telemetry load/attach on a live Linux runner.