### PR TITLE
feat(core): ExecutionReceipt, ConformanceBadge, and did:key codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3116,6 +3125,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "bs58",
  "chrono",
  "ed25519-dalek",
  "fs2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,6 +3353,7 @@ dependencies = [
  "mvm-cli",
  "mvm-core",
  "mvm-fs",
+ "mvm-hostd",
  "mvm-runtime",
  "objc2-foundation",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -460,6 +460,9 @@ toml.workspace = true
 # Plan 73 Followup H — `tests/run_plan_mode.rs` resolves python3 from
 # PATH to drive the SDK record-mode auto-exec end-to-end.
 which.workspace = true
+# `tests/audit_receipt_export.rs` builds a synthetic chain-signed audit log
+# directly with the same primitives the host uses.
+mvm-hostd = { workspace = true, default-features = false }
 
 [features]
 # ── The two product surfaces — the only two things this project ships ─────────

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,7 @@ leakguard = { version = "=0.8.0", default-features = false }
 # Crypto
 aes-gcm = "0.11"
 base64 = "0.22"
+bs58 = "0.5"
 ed25519-dalek = "3"
 hmac = "0.13"
 rand = "0.8"

--- a/crates/mvm-cli/src/commands/ops/audit.rs
+++ b/crates/mvm-cli/src/commands/ops/audit.rs
@@ -165,11 +165,35 @@ pub(in crate::commands) enum AuditAction {
         #[arg(long, default_value = "local")]
         tenant: String,
     },
+    /// Export chain-signed audit entries as offline-verifiable
+    /// ExecutionReceipts. Read-only: does not emit new audit events.
+    Receipts {
+        #[command(subcommand)]
+        action: ReceiptsAction,
+    },
     /// Opt-in forensic network transcript capture: arm / disarm / list /
     /// export. Off by default; separate from the metadata-only flow audit.
     Transcript {
         #[command(subcommand)]
         action: super::transcript::TranscriptAction,
+    },
+}
+
+/// Subcommands under `mvmctl trust audit receipts`.
+#[derive(Subcommand, Debug, Clone)]
+pub(in crate::commands) enum ReceiptsAction {
+    /// Export signed ExecutionReceipts from the chain-signed audit log.
+    Export {
+        /// Tenant whose chain to read. Defaults to `"local"`.
+        #[arg(long, default_value = "local")]
+        tenant: String,
+        /// Optional plan_id (`sha256:<hex>`) filter; only entries for this
+        /// plan are exported.
+        #[arg(long)]
+        plan_id: Option<String>,
+        /// Emit receipts as a JSON array to stdout.
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -194,6 +218,13 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             json,
         } => audit_show(&tenant, &plan_id, json),
         AuditAction::Posture { json } => super::audit_posture::run(json),
+        AuditAction::Receipts { action } => match action {
+            ReceiptsAction::Export {
+                tenant,
+                plan_id,
+                json,
+            } => audit_receipts_export(&tenant, plan_id.as_deref(), json),
+        },
         AuditAction::Transcript { action } => super::transcript::run(action),
         AuditAction::VerifyCert {
             cert,
@@ -214,6 +245,50 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             tenant,
         } => audit_verify_inclusion(&proof, root.as_deref(), pubkey.as_deref(), &tenant),
     }
+}
+
+// ─────────────────────────────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────────
+
+/// Export signed [`ExecutionReceipt`]s from the tenant's chain-signed
+/// audit log and render them.
+///
+/// This is a read-only operation: it verifies the existing chain under
+/// the host signer's public key, converts each mappable `AuditEntry`
+/// into a receipt payload, signs it with the same host key, and prints
+/// the result. No new audit entries are written.
+fn audit_receipts_export(tenant: &str, plan_id: Option<&str>, json: bool) -> Result<()> {
+    let signer = host_signer::load_or_init().context("loading host signer to export receipts")?;
+    let dir = default_audit_dir().context("resolving audit directory")?;
+    let receipts =
+        mvm_hostd::audit::receipt_export::export_receipts(&dir, tenant, plan_id, &signer.signing)
+            .with_context(|| format!("exporting receipts for tenant '{tenant}'"))?;
+
+    if json {
+        crate::json_out::emit_json(&receipts)?;
+    } else {
+        if receipts.is_empty() {
+            ui::info(&format!(
+                "No exportable receipts found for tenant '{tenant}'."
+            ));
+        } else {
+            ui::success(&format!(
+                "exported {n} receipt(s) for tenant '{tenant}'",
+                n = receipts.len()
+            ));
+            for signed in &receipts {
+                eprintln!(
+                    "  {type} {outcome} {id}",
+                    type = signed.payload.receipt_type,
+                    outcome = serde_json::to_string(&signed.payload.outcome)
+                        .unwrap_or_default()
+                        .trim_matches('"'),
+                    id = signed.payload.receipt_id,
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 // ─────────────────────────────────────────────────────────────────

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2276,6 +2276,35 @@ fn test_audit_verify_inclusion_defaults_optional_paths() {
 }
 
 #[test]
+fn test_audit_receipts_export_parses() {
+    let cli = Cli::try_parse_from([
+        "mvmctl", "trust", "audit", "receipts", "export", "--tenant", "acme", "--json",
+    ])
+    .unwrap();
+    let Commands::Trust(tg) = cli.command else {
+        panic!("expected trust group")
+    };
+    match tg.action {
+        trust::TrustAction::Audit(audit::Args {
+            action:
+                AuditAction::Receipts {
+                    action:
+                        audit::ReceiptsAction::Export {
+                            tenant,
+                            plan_id,
+                            json,
+                        },
+                },
+        }) => {
+            assert_eq!(tenant, "acme");
+            assert_eq!(plan_id, None);
+            assert!(json);
+        }
+        _ => panic!("Expected Audit::Receipts::Export"),
+    }
+}
+
+#[test]
 fn test_audit_tail_no_log_prints_message() {
     // When no audit log exists, the command should succeed with a
     // helpful message rather than an error.

--- a/crates/mvm-core/Cargo.toml
+++ b/crates/mvm-core/Cargo.toml
@@ -12,6 +12,7 @@ authors.workspace = true
 mvm-contract = { workspace = true, default-features = false, features = ["protocol", "volume"] }
 anyhow.workspace = true
 base64.workspace = true
+bs58.workspace = true
 serde_jcs = "0.1"
 unicode-normalization = "0.1"
 chrono.workspace = true

--- a/crates/mvm-core/src/conformance_badge.rs
+++ b/crates/mvm-core/src/conformance_badge.rs
@@ -457,16 +457,20 @@ mod tests {
     #[test]
     fn suite_digest_mismatch_rejected() {
         let signed = signed_sample();
-        let mut admission = BadgeAdmission::default();
-        admission.expected_suite_digest = Some("sha256:deadbeef".into());
+        let admission = BadgeAdmission {
+            expected_suite_digest: Some("sha256:deadbeef".into()),
+            ..Default::default()
+        };
         assert!(signed.verify_with_admission(&admission).is_err());
     }
 
     #[test]
     fn build_mismatch_rejected() {
         let signed = signed_sample();
-        let mut admission = BadgeAdmission::default();
-        admission.expected_build = Some("wrong".into());
+        let admission = BadgeAdmission {
+            expected_build: Some("wrong".into()),
+            ..Default::default()
+        };
         assert!(signed.verify_with_admission(&admission).is_err());
     }
 
@@ -479,8 +483,10 @@ mod tests {
         badge.skipped_vectors.insert("hard-vector".into());
         let signed =
             SignedConformanceBadge::sign(badge, &signing_key, "2026-08-06T00:00:00+00:00").unwrap();
-        let mut admission = BadgeAdmission::default();
-        admission.forbid_skip.insert("hard-vector".into());
+        let admission = BadgeAdmission {
+            forbid_skip: ["hard-vector".into()].into_iter().collect(),
+            ..Default::default()
+        };
         assert!(signed.verify_with_admission(&admission).is_err());
     }
 

--- a/crates/mvm-core/src/conformance_badge.rs
+++ b/crates/mvm-core/src/conformance_badge.rs
@@ -1,0 +1,529 @@
+//! Signed, offline-verifiable conformance badges for MVM-SEC claims.
+//!
+//! A [`ConformanceBadge`] is a signed export of the existing claim/witness
+//! program (`model/claims.toml` + test corpus). It lets a runtime or SDK prove
+//! which MVM-SEC claims it satisfies without requiring a live CI query.
+//!
+//! The wire format is influenced by Project NANDA's `sm-conformance`, but
+//! re-implemented on mvm's existing Ed25519/JCS/SHA-256 stack.
+//!
+//! # Important
+//!
+//! A badge is **not** the source of truth for conformance. The source of truth
+//! remains `model/claims.toml`, the actual tests, and the `xtask` gates. A badge
+//! is a portable, signed snapshot of a passing run.
+
+use crate::did_key::DidKey;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use ed25519_dalek::{Signer, SigningKey, Verifier};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+/// The signed payload of a conformance badge.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConformanceBadge {
+    /// Wire schema version. Const `1` for this version.
+    #[serde(default = "schema_version_default")]
+    pub schema_version: u32,
+    /// Runtime or SDK name, e.g. `mvmctl`.
+    pub runtime: String,
+    /// Protocol versions covered, e.g. `["0.1"]`.
+    pub protocol_versions: Vec<String>,
+    /// `sha256:<hex>` over the conformance vector corpus.
+    pub suite_digest: String,
+    /// RFC 3339 UTC timestamp of when the suite completed.
+    pub completed_at: String,
+    /// Exit status of the suite runner.
+    pub exit_status: i64,
+    /// Counts from the suite run.
+    pub passed: u64,
+    pub failed: u64,
+    pub skipped: u64,
+    pub xfailed: u64,
+    pub xpassed: u64,
+    pub errored: u64,
+    /// Optional total vector count (self-attested).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_vectors: Option<u64>,
+    /// Identities of any skipped vectors.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub skipped_vectors: BTreeSet<String>,
+    /// MVM-SEC claim IDs covered by this badge.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub claims: BTreeSet<String>,
+    /// Kinds of evidence each claim rests on, derived from `model/claims.toml`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub witness_kinds: BTreeMap<String, Vec<String>>,
+    /// Namespace-prefixed extensions.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extensions: BTreeMap<String, Value>,
+}
+
+fn schema_version_default() -> u32 {
+    1
+}
+
+/// A signed conformance badge envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedConformanceBadge {
+    /// The signed payload.
+    pub payload: ConformanceBadge,
+    /// `did:key` of the signer.
+    pub signed_by: String,
+    /// RFC 3339 UTC timestamp of signing. **Not signed** — forgeable.
+    pub signed_at: String,
+    /// Base64 Ed25519 signature over `canonical_json(payload)`.
+    pub signature: String,
+}
+
+/// Admission / verification policy for a conformance badge.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BadgeAdmission {
+    /// If true, verify only the signature and schema; do not gate the run
+    /// result. Use with care — a verified badge with `failed: 99` is still
+    /// cryptographically valid.
+    pub signature_only: bool,
+    /// Expected `suite_digest`. A badge pinning a different corpus is rejected.
+    pub expected_suite_digest: Option<String>,
+    /// Expected total vector count. Catches an honest partial run.
+    pub expected_total_vectors: Option<u64>,
+    /// Maximum allowed skipped vectors.
+    pub max_skipped: Option<u64>,
+    /// Skipped vector IDs that are forbidden.
+    pub forbid_skip: BTreeSet<String>,
+    /// Require `skipped_vectors` to be present when `skipped > 0`.
+    pub require_skip_ids: bool,
+    /// Expected `extensions.mvm.build` value.
+    pub expected_build: Option<String>,
+    /// Maximum age in days of the signed `completed_at`.
+    pub max_age_days: Option<u64>,
+}
+
+/// Error type for badge operations.
+#[derive(Debug, thiserror::Error)]
+pub enum BadgeError {
+    /// The payload value space was violated.
+    #[error("payload contains a value outside the signed value space: {0}")]
+    InvalidValueSpace(String),
+    /// JSON serialization or deserialization failed.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    /// Signing or verification failed.
+    #[error("signature error: {0}")]
+    Signature(#[from] ed25519_dalek::SignatureError),
+    /// The `signed_by` field did not match the signature's public key.
+    #[error("signed_by did:key does not match the signature key")]
+    SignerMismatch,
+    /// The badge recorded failures or errors.
+    #[error(
+        "badge records failed={failed}, errored={errored}, exit_status={exit_status}, xfailed={xfailed}"
+    )]
+    NonPassing {
+        failed: u64,
+        errored: u64,
+        exit_status: i64,
+        xfailed: u64,
+    },
+    /// The `suite_digest` did not match the expected value.
+    #[error("suite_digest mismatch: expected {expected}, got {actual}")]
+    SuiteDigestMismatch { expected: String, actual: String },
+    /// The `total_vectors` count did not match the expected value.
+    #[error("total_vectors mismatch: expected {expected}, got {actual}")]
+    TotalVectorsMismatch { expected: u64, actual: u64 },
+    /// Too many vectors were skipped.
+    #[error("too many skipped vectors: {actual} > {max}")]
+    TooManySkipped { max: u64, actual: u64 },
+    /// A forbidden vector was skipped.
+    #[error("skipped vector {0} is forbidden")]
+    ForbiddenSkip(String),
+    /// `skipped_vectors` was required but missing or incomplete.
+    #[error("skipped vector IDs are required but missing or incomplete")]
+    MissingSkipIds,
+    /// The `extensions.mvm.build` value did not match.
+    #[error("build mismatch: expected {expected}, got {actual}")]
+    BuildMismatch { expected: String, actual: String },
+    /// The badge was too old.
+    #[error("badge is older than {max_age_days} days")]
+    TooOld { max_age_days: u64 },
+    /// The badge timestamp was too far in the future.
+    #[error("badge timestamp is in the future")]
+    FutureTimestamp,
+    /// The `did:key` could not be parsed.
+    #[error("did:key parse error: {0}")]
+    DidKey(#[from] crate::did_key::DidKeyError),
+    /// An I/O error occurred while computing a corpus digest.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl ConformanceBadge {
+    /// Prefix for corpus digests.
+    pub const DIGEST_PREFIX: &'static str = "sha256:";
+
+    /// Compute the `suite_digest` over a corpus directory.
+    ///
+    /// The digest is over all `*.json` files, sorted by POSIX-relative path,
+    /// with NUL-delimited path bytes and raw file bytes. This matches the
+    /// stability rules from `sm-conformance` so the same corpus produces the
+    /// same digest across platforms.
+    pub fn compute_suite_digest(corpus_dir: impl AsRef<Path>) -> Result<String, BadgeError> {
+        let corpus_dir = corpus_dir.as_ref();
+        let mut entries: Vec<(PathBuf, Vec<u8>)> = Vec::new();
+        Self::collect_json_files(corpus_dir, corpus_dir, &mut entries)?;
+        entries.sort_by(|(a, _), (b, _)| a.as_os_str().cmp(b.as_os_str()));
+
+        let mut hasher = Sha256::new();
+        for (path, bytes) in entries {
+            hasher.update(path.as_os_str().as_encoded_bytes());
+            hasher.update([0u8]);
+            hasher.update(&bytes);
+        }
+        Ok(format!(
+            "{}{}",
+            Self::DIGEST_PREFIX,
+            hex::encode(hasher.finalize())
+        ))
+    }
+
+    fn collect_json_files(
+        root: &Path,
+        current: &Path,
+        out: &mut Vec<(PathBuf, Vec<u8>)>,
+    ) -> Result<(), BadgeError> {
+        for entry in std::fs::read_dir(current)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                Self::collect_json_files(root, &path, out)?;
+            } else if path.extension().map(|ext| ext == "json").unwrap_or(false) {
+                let relative = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
+                let bytes = std::fs::read(&path)?;
+                out.push((relative, bytes));
+            }
+        }
+        Ok(())
+    }
+
+    /// Return the `extensions.mvm.build` value, if present.
+    pub fn build(&self) -> Option<&str> {
+        self.extensions.get("mvm.build").and_then(|v| v.as_str())
+    }
+
+    /// Verify the self-attested accounting, independent of signature.
+    ///
+    /// Checks that `passed + failed + skipped + xfailed + xpassed + errored`
+    /// equals `total_vectors` when `total_vectors` is present.
+    pub fn verify_accounting(&self) -> Result<(), BadgeError> {
+        if let Some(total) = self.total_vectors {
+            let sum = self
+                .passed
+                .saturating_add(self.failed)
+                .saturating_add(self.skipped)
+                .saturating_add(self.xfailed)
+                .saturating_add(self.xpassed)
+                .saturating_add(self.errored);
+            if sum != total {
+                return Err(BadgeError::TotalVectorsMismatch {
+                    expected: total,
+                    actual: sum,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+impl SignedConformanceBadge {
+    /// Sign a conformance badge payload.
+    pub fn sign(
+        payload: ConformanceBadge,
+        signing_key: &SigningKey,
+        signed_at: impl Into<String>,
+    ) -> Result<Self, BadgeError> {
+        payload.verify_accounting()?;
+        let did = DidKey::from_verifying_key(signing_key.verifying_key());
+        let canonical = canonical_json(&payload)?;
+        let signature = signing_key.sign(&canonical);
+        Ok(Self {
+            payload,
+            signed_by: did.to_did_key(),
+            signed_at: signed_at.into(),
+            signature: BASE64_STANDARD.encode(signature.to_bytes()),
+        })
+    }
+
+    /// Verify the badge signature and reject non-passing runs.
+    ///
+    /// A badge recording any failures, errors, or a non-zero exit status is
+    /// rejected. Use [`Self::verify_with_admission`] with
+    /// `signature_only: true` to verify only the signature.
+    pub fn verify(&self) -> Result<(), BadgeError> {
+        self.verify_with_admission(&BadgeAdmission::default())
+    }
+
+    /// Verify with an explicit admission policy.
+    pub fn verify_with_admission(&self, admission: &BadgeAdmission) -> Result<(), BadgeError> {
+        self.payload.verify_accounting()?;
+
+        let did = DidKey::parse(&self.signed_by)?;
+        let vk = did.verifying_key();
+        let canonical = canonical_json(&self.payload)?;
+        let sig_bytes = BASE64_STANDARD
+            .decode(&self.signature)
+            .map_err(|e| BadgeError::InvalidValueSpace(format!("base64: {e}")))?;
+        let sig = ed25519_dalek::Signature::from_slice(&sig_bytes)?;
+        vk.verify(&canonical, &sig)?;
+        if *vk != *DidKey::parse(&self.signed_by)?.verifying_key() {
+            return Err(BadgeError::SignerMismatch);
+        }
+
+        if !admission.signature_only
+            && (self.payload.failed != 0
+                || self.payload.errored != 0
+                || self.payload.exit_status != 0
+                || self.payload.xfailed != 0)
+        {
+            return Err(BadgeError::NonPassing {
+                failed: self.payload.failed,
+                errored: self.payload.errored,
+                exit_status: self.payload.exit_status,
+                xfailed: self.payload.xfailed,
+            });
+        }
+
+        if let Some(expected) = &admission.expected_suite_digest
+            && expected != &self.payload.suite_digest
+        {
+            return Err(BadgeError::SuiteDigestMismatch {
+                expected: expected.clone(),
+                actual: self.payload.suite_digest.clone(),
+            });
+        }
+
+        if let Some(expected) = admission.expected_total_vectors {
+            let actual = self.payload.total_vectors.unwrap_or(0);
+            if expected != actual {
+                return Err(BadgeError::TotalVectorsMismatch { expected, actual });
+            }
+        }
+
+        if let Some(max) = admission.max_skipped
+            && self.payload.skipped > max
+        {
+            return Err(BadgeError::TooManySkipped {
+                max,
+                actual: self.payload.skipped,
+            });
+        }
+
+        if admission.require_skip_ids
+            && self.payload.skipped > 0
+            && self.payload.skipped_vectors.len() as u64 != self.payload.skipped
+        {
+            return Err(BadgeError::MissingSkipIds);
+        }
+
+        for forbidden in &admission.forbid_skip {
+            if self.payload.skipped_vectors.contains(forbidden) {
+                return Err(BadgeError::ForbiddenSkip(forbidden.clone()));
+            }
+        }
+
+        if let Some(expected) = &admission.expected_build {
+            let actual = self.payload.build().unwrap_or("");
+            if expected != actual {
+                return Err(BadgeError::BuildMismatch {
+                    expected: expected.clone(),
+                    actual: actual.to_string(),
+                });
+            }
+        }
+
+        if let Some(max_age_days) = admission.max_age_days {
+            let completed = chrono::DateTime::parse_from_rfc3339(&self.payload.completed_at)
+                .map_err(|e| BadgeError::InvalidValueSpace(format!("completed_at: {e}")))?;
+            let now = chrono::Utc::now();
+            if completed > now + chrono::TimeDelta::minutes(5) {
+                return Err(BadgeError::FutureTimestamp);
+            }
+            let age = now - completed.to_utc();
+            if age > chrono::TimeDelta::days(max_age_days as i64) {
+                return Err(BadgeError::TooOld { max_age_days });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn canonical_json<T: Serialize>(value: &T) -> Result<Vec<u8>, BadgeError> {
+    let json_value = serde_json::to_value(value)?;
+    validate_value_space(&json_value)?;
+    Ok(serde_jcs::to_vec(&json_value)?)
+}
+
+fn validate_value_space(value: &Value) -> Result<(), BadgeError> {
+    match value {
+        Value::Null | Value::Bool(_) => Ok(()),
+        Value::Number(n) if n.is_i64() || n.is_u64() => Ok(()),
+        Value::Number(n) => Err(BadgeError::InvalidValueSpace(format!(
+            "float or non-integer number: {n}"
+        ))),
+        Value::String(s) => {
+            if s.is_ascii() {
+                Ok(())
+            } else {
+                Err(BadgeError::InvalidValueSpace(format!(
+                    "non-ASCII string: {s:?}"
+                )))
+            }
+        }
+        Value::Array(values) => {
+            for v in values {
+                validate_value_space(v)?;
+            }
+            Ok(())
+        }
+        Value::Object(entries) => {
+            for (k, v) in entries {
+                if !k.is_ascii() {
+                    return Err(BadgeError::InvalidValueSpace(format!(
+                        "non-ASCII object key: {k:?}"
+                    )));
+                }
+                validate_value_space(v)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Write;
+
+    fn sample_badge() -> ConformanceBadge {
+        ConformanceBadge {
+            schema_version: 1,
+            runtime: "mvmctl".into(),
+            protocol_versions: vec!["0.1".into()],
+            suite_digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                .into(),
+            completed_at: "2026-08-06T00:00:00+00:00".into(),
+            exit_status: 0,
+            passed: 42,
+            failed: 0,
+            skipped: 0,
+            xfailed: 0,
+            xpassed: 0,
+            errored: 0,
+            total_vectors: Some(42),
+            skipped_vectors: BTreeSet::new(),
+            claims: BTreeSet::from(["MVM-SEC-08".into(), "MVM-SEC-09".into()]),
+            witness_kinds: BTreeMap::new(),
+            extensions: BTreeMap::from([("mvm.build".into(), serde_json::json!("abc123"))]),
+        }
+    }
+
+    fn signed_sample() -> SignedConformanceBadge {
+        let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+        SignedConformanceBadge::sign(sample_badge(), &signing_key, "2026-08-06T00:00:00+00:00")
+            .unwrap()
+    }
+
+    #[test]
+    fn sign_and_verify_roundtrip() {
+        let signed = signed_sample();
+        signed.verify().expect("verify own badge");
+    }
+
+    #[test]
+    fn failing_badge_rejected() {
+        let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+        let mut badge = sample_badge();
+        badge.failed = 1;
+        badge.total_vectors = Some(43);
+        let signed =
+            SignedConformanceBadge::sign(badge, &signing_key, "2026-08-06T00:00:00+00:00").unwrap();
+        assert!(signed.verify().is_err());
+    }
+
+    #[test]
+    fn suite_digest_mismatch_rejected() {
+        let signed = signed_sample();
+        let mut admission = BadgeAdmission::default();
+        admission.expected_suite_digest = Some("sha256:deadbeef".into());
+        assert!(signed.verify_with_admission(&admission).is_err());
+    }
+
+    #[test]
+    fn build_mismatch_rejected() {
+        let signed = signed_sample();
+        let mut admission = BadgeAdmission::default();
+        admission.expected_build = Some("wrong".into());
+        assert!(signed.verify_with_admission(&admission).is_err());
+    }
+
+    #[test]
+    fn forbidden_skip_rejected() {
+        let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+        let mut badge = sample_badge();
+        badge.skipped = 1;
+        badge.total_vectors = Some(43);
+        badge.skipped_vectors.insert("hard-vector".into());
+        let signed =
+            SignedConformanceBadge::sign(badge, &signing_key, "2026-08-06T00:00:00+00:00").unwrap();
+        let mut admission = BadgeAdmission::default();
+        admission.forbid_skip.insert("hard-vector".into());
+        assert!(signed.verify_with_admission(&admission).is_err());
+    }
+
+    #[test]
+    fn corpus_digest_is_stable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("corpus");
+        std::fs::create_dir(&dir).unwrap();
+        let mut a = std::fs::File::create(dir.join("a.json")).unwrap();
+        a.write_all(b"{\"x\":1}").unwrap();
+        let mut b = std::fs::File::create(dir.join("b.json")).unwrap();
+        b.write_all(b"{\"y\":2}").unwrap();
+
+        let d1 = ConformanceBadge::compute_suite_digest(&dir).unwrap();
+        let d2 = ConformanceBadge::compute_suite_digest(&dir).unwrap();
+        assert_eq!(d1, d2);
+        assert!(d1.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn corpus_digest_changes_on_content_change() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("corpus");
+        std::fs::create_dir(&dir).unwrap();
+        let mut a = std::fs::File::create(dir.join("a.json")).unwrap();
+        a.write_all(b"{\"x\":1}").unwrap();
+
+        let d1 = ConformanceBadge::compute_suite_digest(&dir).unwrap();
+        let mut a = std::fs::File::create(dir.join("a.json")).unwrap();
+        a.write_all(b"{\"x\":2}").unwrap();
+        let d2 = ConformanceBadge::compute_suite_digest(&dir).unwrap();
+        assert_ne!(d1, d2);
+    }
+
+    #[test]
+    fn non_ascii_extension_rejected() {
+        let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+        let mut badge = sample_badge();
+        badge
+            .extensions
+            .insert("mvm.label".into(), serde_json::json!("Müller"));
+        assert!(
+            SignedConformanceBadge::sign(badge, &signing_key, "2026-08-06T00:00:00+00:00").is_err()
+        );
+    }
+}

--- a/crates/mvm-core/src/did_key.rs
+++ b/crates/mvm-core/src/did_key.rs
@@ -1,0 +1,215 @@
+//! `did:key` derivation and parsing for Ed25519 public keys.
+//!
+//! This module implements the W3C `did:key` method for Ed25519 keys, used by
+//! [`crate::receipt::ExecutionReceipt`] and [`crate::conformance_badge::ConformanceBadge`]
+//! as the portable signer identity format.
+//!
+//! An Ed25519 `did:key` value is:
+//!
+//! ```text
+//! did:key:z<base58btc(0xed01 || pubkey32)>
+//! ```
+//!
+//! where `0xed01` is the multicodec prefix for Ed25519 public keys and `z` is
+//! the multibase base58btc prefix.
+
+use ed25519_dalek::VerifyingKey;
+
+/// A parsed Ed25519 `did:key` identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DidKey {
+    verifying_key: VerifyingKey,
+}
+
+impl DidKey {
+    /// The multibase base58btc prefix character.
+    pub const MULTIBASE_PREFIX: char = 'z';
+    /// The multicodec prefix for an Ed25519 public key: `0xed01`.
+    pub const MULTICODEC_PREFIX: [u8; 2] = [0xed, 0x01];
+    /// The string prefix every `did:key` carries.
+    pub const DID_KEY_PREFIX: &'static str = "did:key:";
+
+    /// Derive a `did:key` from an Ed25519 verifying key.
+    pub fn from_verifying_key(key: VerifyingKey) -> Self {
+        Self { verifying_key: key }
+    }
+
+    /// Parse a `did:key` string into a verifying key.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the string is not a well-formed Ed25519 `did:key`,
+    /// including wrong prefix, unknown multicodec, bad base58 encoding, or
+    /// wrong public-key length.
+    pub fn parse(did: impl AsRef<str>) -> Result<Self, DidKeyError> {
+        let did = did.as_ref();
+        let rest = did
+            .strip_prefix(Self::DID_KEY_PREFIX)
+            .ok_or(DidKeyError::MissingPrefix)?;
+        if rest.is_empty() {
+            return Err(DidKeyError::EmptyKey);
+        }
+        let mut chars = rest.chars();
+        let multibase = chars.next().ok_or(DidKeyError::EmptyKey)?;
+        if multibase != Self::MULTIBASE_PREFIX {
+            return Err(DidKeyError::UnsupportedMultibase(multibase));
+        }
+        let encoded = chars.as_str();
+        let decoded = bs58::decode(encoded)
+            .into_vec()
+            .map_err(DidKeyError::Base58)?;
+        if decoded.len() != Self::MULTICODEC_PREFIX.len() + 32 {
+            return Err(DidKeyError::WrongLength(decoded.len()));
+        }
+        if decoded[..Self::MULTICODEC_PREFIX.len()] != Self::MULTICODEC_PREFIX {
+            return Err(DidKeyError::UnsupportedMulticodec(
+                decoded[..Self::MULTICODEC_PREFIX.len()].to_vec(),
+            ));
+        }
+        let key_bytes: [u8; 32] = decoded[Self::MULTICODEC_PREFIX.len()..]
+            .try_into()
+            .map_err(|_| DidKeyError::WrongLength(decoded.len()))?;
+        let verifying_key =
+            VerifyingKey::from_bytes(&key_bytes).map_err(DidKeyError::InvalidPublicKey)?;
+        Ok(Self { verifying_key })
+    }
+
+    /// The underlying Ed25519 verifying key.
+    pub fn verifying_key(&self) -> &VerifyingKey {
+        &self.verifying_key
+    }
+
+    /// Serialize this identifier as a `did:key` string.
+    pub fn to_did_key(&self) -> String {
+        let mut bytes = Vec::with_capacity(Self::MULTICODEC_PREFIX.len() + 32);
+        bytes.extend_from_slice(&Self::MULTICODEC_PREFIX);
+        bytes.extend_from_slice(self.verifying_key.as_bytes());
+        format!(
+            "{}{}{}",
+            Self::DID_KEY_PREFIX,
+            Self::MULTIBASE_PREFIX,
+            bs58::encode(bytes).into_string()
+        )
+    }
+}
+
+impl core::fmt::Display for DidKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.to_did_key())
+    }
+}
+
+/// [`DidKey::parse`] failure.
+#[derive(Debug, thiserror::Error)]
+pub enum DidKeyError {
+    /// The value did not start with `did:key:`.
+    #[error("did:key must start with \"did:key:\"")]
+    MissingPrefix,
+    /// The key material was empty.
+    #[error("did:key has no key material")]
+    EmptyKey,
+    /// The multibase prefix was not `z` (base58btc).
+    #[error("did:key uses unsupported multibase prefix {0:?}")]
+    UnsupportedMultibase(char),
+    /// The base58 decoding failed.
+    #[error("did:key base58 decode failed: {0}")]
+    Base58(bs58::decode::Error),
+    /// The decoded byte length was wrong.
+    #[error("did:key decoded length {0} is not 34 bytes (multicodec + 32-byte pubkey)")]
+    WrongLength(usize),
+    /// The multicodec prefix was not Ed25519 (`0xed01`).
+    #[error("did:key uses unsupported multicodec prefix {0:?}")]
+    UnsupportedMulticodec(Vec<u8>),
+    /// The public key bytes were not a valid Ed25519 point.
+    #[error("did:key public key is invalid: {0}")]
+    InvalidPublicKey(ed25519_dalek::SignatureError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    #[test]
+    fn roundtrip() {
+        let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+        let did = DidKey::from_verifying_key(signing_key.verifying_key());
+        let did_string = did.to_did_key();
+        assert!(did_string.starts_with("did:key:z"));
+        let parsed = DidKey::parse(&did_string).expect("roundtrip parse");
+        assert_eq!(
+            parsed.verifying_key().as_bytes(),
+            signing_key.verifying_key().as_bytes()
+        );
+        assert_eq!(parsed, did);
+    }
+
+    #[test]
+    fn parse_known_vector() {
+        // A well-known Ed25519 test key:
+        // secret: 0x9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60
+        // public: 0xd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a
+        let pubkey_hex = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+        let pubkey_bytes = hex::decode(pubkey_hex).unwrap();
+        let vk = VerifyingKey::from_bytes(&pubkey_bytes.try_into().unwrap()).unwrap();
+        let did = DidKey::from_verifying_key(vk);
+        assert_eq!(
+            did.to_did_key(),
+            "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+        );
+        let parsed = DidKey::parse(did.to_did_key()).unwrap();
+        assert_eq!(parsed.verifying_key().as_bytes(), vk.as_bytes());
+    }
+
+    #[test]
+    fn parse_missing_prefix() {
+        assert!(matches!(
+            DidKey::parse("z6MkhaXgZAgMVMFG8oYF1ADbc94YHQ6D98F4BAtRzGWsqd71"),
+            Err(DidKeyError::MissingPrefix)
+        ));
+    }
+
+    #[test]
+    fn parse_bad_multibase() {
+        assert!(matches!(
+            DidKey::parse("did:key:b6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"),
+            Err(DidKeyError::UnsupportedMultibase('b'))
+        ));
+    }
+
+    #[test]
+    fn parse_wrong_length() {
+        // Valid prefix + base58 of 33 bytes instead of 34.
+        let bytes: Vec<u8> = [0xed, 0x01]
+            .iter()
+            .copied()
+            .chain([0u8; 31].iter().copied())
+            .collect();
+        let short = bs58::encode(bytes).into_string();
+        assert!(
+            matches!(
+                DidKey::parse(format!("did:key:z{short}")),
+                Err(DidKeyError::WrongLength(33))
+            ),
+            "expected WrongLength(33)"
+        );
+    }
+
+    #[test]
+    fn parse_wrong_multicodec() {
+        // Valid length but multicodec prefix changed to 0xed02.
+        let bytes: Vec<u8> = [0xed, 0x02]
+            .iter()
+            .copied()
+            .chain([0u8; 32].iter().copied())
+            .collect();
+        let encoded = bs58::encode(bytes).into_string();
+        assert!(
+            matches!(
+                DidKey::parse(format!("did:key:z{encoded}")),
+                Err(DidKeyError::UnsupportedMulticodec(_))
+            ),
+            "expected UnsupportedMulticodec"
+        );
+    }
+}

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -21,7 +21,9 @@ pub mod checkpoint;
 #[cfg(feature = "client")]
 pub mod client;
 pub mod config;
+pub mod conformance_badge;
 pub mod dev_network;
+pub mod did_key;
 /// The single `sha256:<64 lowercase hex>` shape check every prefixed
 /// content-address newtype in this crate shares (crate-private).
 pub(crate) mod digest_shape;
@@ -109,6 +111,7 @@ pub mod platform;
 pub mod policy;
 pub mod protocol;
 pub mod rate_limit;
+pub mod receipt;
 pub mod residency;
 /// Hardened snapshot frame v0: cap-bounded, fail-closed parsing of the
 /// snapshot container mvm controls (eager-CoW / raw-hypervisor path).

--- a/crates/mvm-core/src/receipt.rs
+++ b/crates/mvm-core/src/receipt.rs
@@ -1,0 +1,440 @@
+//! Signed, chainable execution receipts for mvm workloads.
+//!
+//! An [`ExecutionReceipt`] is a portable, offline-verifiable proof that a
+//! specific workload ran under a specific authority at a specific time. It is
+//! intentionally a *derived* artifact over the chain-signed audit log, not a
+//! new runtime authority.
+//!
+//! The wire format is influenced by Project NANDA's Agency Receipt Protocol
+//! (`sm-arp`) and Attested Action Envelope (`sm-aae`), but re-implemented on
+//! mvm's existing Ed25519/JCS/SHA-256 stack without taking an external
+//! dependency.
+//!
+//! # Envelope
+//!
+//! ```json
+//! {
+//!   "payload": { ... },
+//!   "signed_by": "did:key:z6Mk...",
+//!   "signed_at": "<rfc3339-utc>",
+//!   "signature": "<base64-ed25519>"
+//! }
+//! ```
+//!
+//! The signature covers the RFC 8785 (JCS) canonicalization of `payload`. The
+//! payload's value space is constrained to ASCII strings, integers, booleans,
+//! null, and nested objects/arrays of the same — no floats, no non-ASCII
+//! strings, no raw bytes. This makes the canonical form unambiguous across
+//! implementations.
+
+use crate::did_key::DidKey;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+/// Wire-stable receipt types.
+pub mod receipt_type {
+    /// Emitted when a plan is admitted by the host.
+    pub const PLAN_ADMITTED: &str = "plan.admitted";
+    /// Emitted when a workload launches.
+    pub const PLAN_LAUNCHED: &str = "plan.launched";
+    /// Emitted when a workload exits.
+    pub const PLAN_EXITED: &str = "plan.exited";
+    /// Emitted when a checkpoint is created.
+    pub const CHECKPOINT_CREATED: &str = "checkpoint.created";
+    /// Emitted when a checkpoint is restored.
+    pub const CHECKPOINT_RESTORED: &str = "checkpoint.restored";
+    /// Emitted when a checkpoint is forked.
+    pub const CHECKPOINT_FORKED: &str = "checkpoint.forked";
+    /// Emitted when a workload input request is refused.
+    pub const INPUT_REFUSED: &str = "stream.input_refused";
+}
+
+/// Outcome of the action described by a receipt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReceiptOutcome {
+    /// The action was authorized but not yet executed.
+    Authorized,
+    /// The workload is running.
+    Running,
+    /// The workload completed successfully.
+    Succeeded,
+    /// The workload failed.
+    Failed,
+    /// The action was refused by policy.
+    Refused,
+}
+
+/// The action described by a receipt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceiptAction {
+    /// The verb, e.g. `run`, `exec`, `checkpoint`.
+    pub verb: String,
+    /// The resource the verb acts on, typically a `plan_id`.
+    pub resource: String,
+    /// Optional named parameters.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub params: BTreeMap<String, Value>,
+}
+
+/// The signed payload of an execution receipt.
+///
+/// Every field is part of the signed material. Keep secrets out: this payload
+/// may be published to auditors or registries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionReceipt {
+    /// Wire schema version. Const `1` for this version.
+    #[serde(default = "schema_version_default")]
+    pub schema_version: u32,
+    /// Content-address of this receipt: `sha256(JCS(payload))`.
+    pub receipt_id: String,
+    /// Wire-stable receipt type, e.g. `plan.admitted`.
+    pub receipt_type: String,
+    /// Content-address of the admitted `ExecutionPlan`.
+    pub plan_id: String,
+    /// Optional content-address of the image lineage node.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_node_digest: Option<String>,
+    /// Optional identifier for the acting agent/workload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    /// Optional `did:key` of the principal the agent acts for.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub principal_did: Option<String>,
+    /// `did:key` of the host signer.
+    pub host_did: String,
+    /// What action this receipt records.
+    pub action: ReceiptAction,
+    /// Outcome of the action.
+    pub outcome: ReceiptOutcome,
+    /// Optional citation to a grant or oversight approval receipt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub granted_by: Option<String>,
+    /// Optional hash link to the previous receipt in this chain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prev_receipt_id: Option<String>,
+    /// RFC 3339 UTC timestamp of when the action occurred.
+    pub issued_at: String,
+    /// Namespace-prefixed extensions. Unknown keys are preserved by verifiers.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extensions: BTreeMap<String, Value>,
+}
+
+fn schema_version_default() -> u32 {
+    1
+}
+
+/// A signed execution receipt envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedExecutionReceipt {
+    /// The signed payload.
+    pub payload: ExecutionReceipt,
+    /// `did:key` of the signer.
+    pub signed_by: String,
+    /// RFC 3339 UTC timestamp of signing. **Not signed** — forgeable.
+    pub signed_at: String,
+    /// Base64 Ed25519 signature over `canonical_json(payload)`.
+    pub signature: String,
+}
+
+/// Error type for receipt operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ReceiptError {
+    /// The payload value space was violated.
+    #[error("payload contains a value outside the signed value space: {0}")]
+    InvalidValueSpace(String),
+    /// JSON serialization or deserialization failed.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    /// Signing or verification failed.
+    #[error("signature error: {0}")]
+    Signature(#[from] ed25519_dalek::SignatureError),
+    /// The `signed_by` field did not match the signature's public key.
+    #[error("signed_by did:key does not match the signature key")]
+    SignerMismatch,
+    /// The `receipt_id` did not match the recomputed content address.
+    #[error("receipt_id does not match recomputed content address")]
+    ReceiptIdMismatch,
+    /// The `did:key` could not be parsed.
+    #[error("did:key parse error: {0}")]
+    DidKey(#[from] crate::did_key::DidKeyError),
+}
+
+impl ExecutionReceipt {
+    /// Prefix for content-addressed receipt IDs.
+    pub const ID_PREFIX: &'static str = "sha256:";
+
+    /// Recompute the content-address of this receipt.
+    ///
+    /// The ID is `sha256:<hex>` over the JCS-canonical form of the payload
+    /// with `receipt_id` temporarily cleared. This prevents a self-reference
+    /// cycle: the id is part of the payload, but it cannot be part of its own
+    /// input.
+    pub fn compute_id(&self) -> Result<String, ReceiptError> {
+        let mut canonical_self = self.clone();
+        canonical_self.receipt_id.clear();
+        let canonical = canonical_json(&canonical_self)?;
+        let digest = Sha256::digest(&canonical);
+        Ok(format!("{}{}", Self::ID_PREFIX, hex::encode(digest)))
+    }
+
+    /// Verify that `receipt_id` matches the recomputed content address.
+    pub fn verify_id(&self) -> Result<(), ReceiptError> {
+        let expected = self.compute_id()?;
+        if expected == self.receipt_id {
+            Ok(())
+        } else {
+            Err(ReceiptError::ReceiptIdMismatch)
+        }
+    }
+}
+
+impl SignedExecutionReceipt {
+    /// Sign a receipt payload with an Ed25519 signing key.
+    ///
+    /// The `signed_at` timestamp is captured from the caller; it is not part of
+    /// the signed material. The `issued_at` field inside the payload is signed.
+    pub fn sign(
+        payload: ExecutionReceipt,
+        signing_key: &SigningKey,
+        signed_at: impl Into<String>,
+    ) -> Result<Self, ReceiptError> {
+        payload.verify_id()?;
+        let did = DidKey::from_verifying_key(signing_key.verifying_key());
+        let canonical = canonical_json(&payload)?;
+        let signature = signing_key.sign(&canonical);
+        Ok(Self {
+            payload,
+            signed_by: did.to_did_key(),
+            signed_at: signed_at.into(),
+            signature: BASE64_STANDARD.encode(signature.to_bytes()),
+        })
+    }
+
+    /// Verify the signature and structural integrity of this receipt.
+    ///
+    /// Checks, in order:
+    /// 1. `receipt_id` matches the recomputed content address.
+    /// 2. `signed_by` is a valid `did:key`.
+    /// 3. The signature is valid over the canonical payload.
+    /// 4. The signing key matches `signed_by`.
+    pub fn verify(&self) -> Result<(), ReceiptError> {
+        self.payload.verify_id()?;
+        let did = DidKey::parse(&self.signed_by)?;
+        let vk = did.verifying_key();
+        let canonical = canonical_json(&self.payload)?;
+        let sig_bytes = BASE64_STANDARD
+            .decode(&self.signature)
+            .map_err(|e| ReceiptError::InvalidValueSpace(format!("base64: {e}")))?;
+        let sig = ed25519_dalek::Signature::from_slice(&sig_bytes)?;
+        vk.verify(&canonical, &sig)?;
+        if *vk != self.resolve_signer()? {
+            return Err(ReceiptError::SignerMismatch);
+        }
+        Ok(())
+    }
+
+    /// Recover the signer's verifying key from `signed_by`.
+    fn resolve_signer(&self) -> Result<VerifyingKey, ReceiptError> {
+        Ok(*DidKey::parse(&self.signed_by)?.verifying_key())
+    }
+}
+
+/// Canonicalize a value into the constrained JCS form used for signing.
+///
+/// Returns an error if the value contains a float, a non-ASCII string, or any
+/// other value outside the admissible space.
+pub fn canonical_json<T: Serialize>(value: &T) -> Result<Vec<u8>, ReceiptError> {
+    let json_value = serde_json::to_value(value)?;
+    validate_value_space(&json_value)?;
+    Ok(serde_jcs::to_vec(&json_value)?)
+}
+
+fn validate_value_space(value: &Value) -> Result<(), ReceiptError> {
+    match value {
+        Value::Null | Value::Bool(_) => Ok(()),
+        Value::Number(n) if n.is_i64() || n.is_u64() => Ok(()),
+        Value::Number(n) => Err(ReceiptError::InvalidValueSpace(format!(
+            "float or non-integer number: {n}"
+        ))),
+        Value::String(s) => {
+            if s.is_ascii() {
+                Ok(())
+            } else {
+                Err(ReceiptError::InvalidValueSpace(format!(
+                    "non-ASCII string: {s:?}"
+                )))
+            }
+        }
+        Value::Array(values) => {
+            for v in values {
+                validate_value_space(v)?;
+            }
+            Ok(())
+        }
+        Value::Object(entries) => {
+            for (k, v) in entries {
+                if !k.is_ascii() {
+                    return Err(ReceiptError::InvalidValueSpace(format!(
+                        "non-ASCII object key: {k:?}"
+                    )));
+                }
+                validate_value_space(v)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Verify the continuity of a receipt chain.
+///
+/// For each receipt after the first, checks that its `prev_receipt_id` equals
+/// the previous receipt's `receipt_id`. Does not verify signatures; call
+/// [`SignedExecutionReceipt::verify`] on each receipt first.
+pub fn verify_receipt_chain(receipts: &[ExecutionReceipt]) -> Result<(), ReceiptError> {
+    for window in receipts.windows(2) {
+        let prev = &window[0];
+        let curr = &window[1];
+        let expected = curr
+            .prev_receipt_id
+            .as_deref()
+            .ok_or_else(|| ReceiptError::InvalidValueSpace("missing prev_receipt_id".into()))?;
+        if expected != prev.receipt_id {
+            return Err(ReceiptError::InvalidValueSpace(
+                "receipt chain broken".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_receipt() -> ExecutionReceipt {
+        ExecutionReceipt {
+            schema_version: 1,
+            receipt_id: String::new(), // filled in by sign
+            receipt_type: receipt_type::PLAN_ADMITTED.into(),
+            plan_id: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                .into(),
+            image_node_digest: None,
+            agent_id: Some("agent-1".into()),
+            principal_did: Some("did:key:z6MkhaXgZAgMVMFG8oYF1ADbc94YHQ6D98F4BAtRzGWsqd71".into()),
+            host_did: String::new(), // filled in by sign
+            action: ReceiptAction {
+                verb: "run".into(),
+                resource: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                    .into(),
+                params: BTreeMap::new(),
+            },
+            outcome: ReceiptOutcome::Authorized,
+            granted_by: None,
+            prev_receipt_id: None,
+            issued_at: "2026-08-06T00:00:00+00:00".into(),
+            extensions: BTreeMap::new(),
+        }
+    }
+
+    fn signed_sample() -> SignedExecutionReceipt {
+        let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+        let mut receipt = sample_receipt();
+        receipt.host_did = DidKey::from_verifying_key(signing_key.verifying_key()).to_did_key();
+        receipt.receipt_id = receipt.compute_id().unwrap();
+        SignedExecutionReceipt::sign(receipt, &signing_key, "2026-08-06T00:00:00+00:00").unwrap()
+    }
+
+    #[test]
+    fn sign_and_verify_roundtrip() {
+        let signed = signed_sample();
+        signed.verify().expect("verify own signature");
+    }
+
+    #[test]
+    fn tampered_signature_fails() {
+        let mut signed = signed_sample();
+        signed.signature = BASE64_STANDARD.encode([0u8; 64]);
+        assert!(signed.verify().is_err());
+    }
+
+    #[test]
+    fn tampered_payload_fails() {
+        let mut signed = signed_sample();
+        signed.payload.outcome = ReceiptOutcome::Failed;
+        assert!(signed.verify().is_err());
+    }
+
+    #[test]
+    fn non_ascii_string_rejected() {
+        let mut receipt = sample_receipt();
+        receipt.agent_id = Some("Müller".into());
+        assert!(matches!(
+            receipt.compute_id(),
+            Err(ReceiptError::InvalidValueSpace(_))
+        ));
+    }
+
+    #[test]
+    fn float_rejected() {
+        let mut receipt = sample_receipt();
+        receipt
+            .action
+            .params
+            .insert("ratio".into(), serde_json::json!(1.5));
+        assert!(matches!(
+            receipt.compute_id(),
+            Err(ReceiptError::InvalidValueSpace(_))
+        ));
+    }
+
+    #[test]
+    fn receipt_id_is_deterministic() {
+        let signed1 = signed_sample();
+        let signed2 = signed_sample();
+        assert_eq!(signed1.payload.receipt_id, signed2.payload.receipt_id);
+    }
+
+    #[test]
+    fn chain_continuity_ok() {
+        let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+        let mut r1 = sample_receipt();
+        r1.host_did = DidKey::from_verifying_key(signing_key.verifying_key()).to_did_key();
+        r1.receipt_id = r1.compute_id().unwrap();
+
+        let signed1 =
+            SignedExecutionReceipt::sign(r1.clone(), &signing_key, "2026-08-06T00:00:00+00:00")
+                .unwrap();
+
+        let mut r2 = sample_receipt();
+        r2.receipt_type = receipt_type::PLAN_LAUNCHED.into();
+        r2.outcome = ReceiptOutcome::Running;
+        r2.prev_receipt_id = Some(signed1.payload.receipt_id.clone());
+        r2.host_did = signed1.payload.host_did.clone();
+        r2.receipt_id = r2.compute_id().unwrap();
+
+        verify_receipt_chain(&[signed1.payload, r2]).expect("chain valid");
+    }
+
+    #[test]
+    fn broken_chain_fails() {
+        let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+        let mut r1 = sample_receipt();
+        r1.host_did = DidKey::from_verifying_key(signing_key.verifying_key()).to_did_key();
+        r1.receipt_id = r1.compute_id().unwrap();
+
+        let mut r2 = sample_receipt();
+        r2.receipt_type = receipt_type::PLAN_LAUNCHED.into();
+        r2.outcome = ReceiptOutcome::Running;
+        r2.prev_receipt_id = Some("sha256:deadbeef".into());
+        r2.host_did = r1.host_did.clone();
+        r2.receipt_id = r2.compute_id().unwrap();
+
+        assert!(verify_receipt_chain(&[r1, r2]).is_err());
+    }
+}

--- a/crates/mvm-hostd/src/audit/mod.rs
+++ b/crates/mvm-hostd/src/audit/mod.rs
@@ -9,3 +9,6 @@ pub mod host_keypair;
 /// tenant's chain-signed audit log.
 pub mod merkle;
 pub mod plan_persist;
+/// Read-only exporter from chain-signed audit entries to signed
+/// ExecutionReceipts.
+pub mod receipt_export;

--- a/crates/mvm-hostd/src/audit/receipt_export.rs
+++ b/crates/mvm-hostd/src/audit/receipt_export.rs
@@ -1,0 +1,391 @@
+//! Read-only exporter from chain-signed audit entries to signed
+//! [`mvm_core::receipt::ExecutionReceipt`]s.
+//!
+//! Converts the existing host-side chain-signed audit log into portable,
+//! offline-verifiable receipts without adding new runtime instrumentation.
+//!
+//! The exporter is deliberately conservative: it only emits receipts for
+//! audit events whose semantics are unambiguously mappable to a receipt
+//! type and outcome. Unknown events are skipped so a future audit-entry
+//! extension cannot silently change the meaning of an exported receipt.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use ed25519_dalek::SigningKey;
+use mvm_core::did_key::DidKey;
+use mvm_core::receipt::{
+    ExecutionReceipt, ReceiptAction, ReceiptOutcome, SignedExecutionReceipt, receipt_type,
+};
+use serde_json::Value;
+
+use crate::supervisor::audit::AuditEntry;
+use crate::supervisor::audit_file::verify_audit_chain_entries;
+
+/// Export signed execution receipts from a tenant's chain-signed audit log.
+///
+/// The chain is verified under `signing_key.verifying_key()` before any
+/// entry is converted. Each authenticated `AuditEntry` that maps to a known
+/// receipt type is converted, signed, and returned in chain order.
+///
+/// If `plan_id_filter` is `Some`, only entries whose `plan_id` matches are
+/// exported.
+pub fn export_receipts(
+    audit_dir: &std::path::Path,
+    tenant: &str,
+    plan_id_filter: Option<&str>,
+    signing_key: &SigningKey,
+) -> Result<Vec<SignedExecutionReceipt>> {
+    let path = crate::audit::emitter::audit_path_for_tenant(audit_dir, tenant);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let entries = verify_audit_chain_entries(&path, &signing_key.verifying_key())
+        .with_context(|| format!("verifying audit chain for tenant '{tenant}'"))?;
+    let host_did = DidKey::from_verifying_key(signing_key.verifying_key()).to_did_key();
+    let signed_at = chrono::Utc::now().to_rfc3339();
+    let mut receipts = Vec::with_capacity(entries.len());
+    for entry in entries {
+        if let Some(filter) = plan_id_filter
+            && entry.plan_id.0 != filter
+        {
+            continue;
+        }
+        let receipt = match audit_entry_to_receipt(&entry, &host_did) {
+            Some(r) => r,
+            None => continue,
+        };
+        let signed = SignedExecutionReceipt::sign(receipt, signing_key, signed_at.clone())
+            .context("signing execution receipt")?;
+        receipts.push(signed);
+    }
+    Ok(receipts)
+}
+
+/// Convert one verified audit entry into an execution-receipt payload.
+///
+/// Returns `None` for events that have no defined receipt mapping.
+/// The receipt's `receipt_id` is computed from the canonical payload so
+/// callers can verify content addressing offline.
+pub fn audit_entry_to_receipt(entry: &AuditEntry, host_did: &str) -> Option<ExecutionReceipt> {
+    let (receipt_type, outcome) = map_event_to_receipt_type(&entry.event)?;
+    let action = build_action(entry, receipt_type);
+    let extensions = build_extensions(entry);
+
+    let image_node_digest = entry.labels.get("image_node_digest").cloned();
+    let agent_id = entry.labels.get("agent_id").cloned();
+    let principal_did = entry.labels.get("principal_did").cloned();
+    let granted_by = entry.labels.get("granted_by").cloned();
+    let prev_receipt_id = entry.labels.get("prev_receipt_id").cloned();
+
+    let mut receipt = ExecutionReceipt {
+        schema_version: 1,
+        receipt_id: String::new(),
+        receipt_type: receipt_type.to_string(),
+        plan_id: entry.plan_id.0.clone(),
+        image_node_digest,
+        agent_id,
+        principal_did,
+        host_did: host_did.to_string(),
+        action,
+        outcome,
+        granted_by,
+        prev_receipt_id,
+        issued_at: entry.timestamp.to_rfc3339(),
+        extensions,
+    };
+    receipt.receipt_id = receipt.compute_id().ok()?;
+    Some(receipt)
+}
+
+/// Map an audit `event` name to a receipt type and outcome.
+///
+/// Unknown events return `None`.
+fn map_event_to_receipt_type(event: &str) -> Option<(&'static str, ReceiptOutcome)> {
+    let pair = match event {
+        "plan.admitted" => (receipt_type::PLAN_ADMITTED, ReceiptOutcome::Authorized),
+        "plan.launched" => (receipt_type::PLAN_LAUNCHED, ReceiptOutcome::Running),
+        "plan.exited" => (receipt_type::PLAN_EXITED, ReceiptOutcome::Succeeded),
+        "plan.failed" => (receipt_type::PLAN_EXITED, ReceiptOutcome::Failed),
+        "checkpoint.created" => (receipt_type::CHECKPOINT_CREATED, ReceiptOutcome::Succeeded),
+        "checkpoint.restored" => (receipt_type::CHECKPOINT_RESTORED, ReceiptOutcome::Succeeded),
+        "checkpoint.forked" => (receipt_type::CHECKPOINT_FORKED, ReceiptOutcome::Succeeded),
+        "stream.input_refused" => (receipt_type::INPUT_REFUSED, ReceiptOutcome::Refused),
+        _ => return None,
+    };
+    Some(pair)
+}
+
+/// Build the [`ReceiptAction`] for an audit entry.
+///
+/// The verb/resource are derived from the receipt type. All labels except
+/// those consumed as top-level receipt fields become `params`.
+fn build_action(entry: &AuditEntry, receipt_type: &str) -> ReceiptAction {
+    let mut params: BTreeMap<String, Value> = BTreeMap::new();
+    for (k, v) in &entry.labels {
+        if is_top_level_label(k) {
+            continue;
+        }
+        params.insert(k.clone(), Value::String(v.clone()));
+    }
+
+    let (verb, resource) = match receipt_type {
+        receipt_type::PLAN_ADMITTED
+        | receipt_type::PLAN_LAUNCHED
+        | receipt_type::PLAN_EXITED
+        | receipt_type::INPUT_REFUSED => ("run", entry.plan_id.0.clone()),
+        receipt_type::CHECKPOINT_CREATED
+        | receipt_type::CHECKPOINT_RESTORED
+        | receipt_type::CHECKPOINT_FORKED => {
+            let resource = entry
+                .labels
+                .get("checkpoint_id")
+                .cloned()
+                .unwrap_or_else(|| entry.plan_id.0.clone());
+            ("checkpoint", resource)
+        }
+        _ => ("run", entry.plan_id.0.clone()),
+    };
+
+    ReceiptAction {
+        verb: verb.to_string(),
+        resource,
+        params,
+    }
+}
+
+/// Labels that are hoisted to top-level receipt fields rather than being
+/// treated as generic action parameters.
+fn is_top_level_label(key: &str) -> bool {
+    matches!(
+        key,
+        "agent_id" | "principal_did" | "granted_by" | "prev_receipt_id" | "image_node_digest"
+    )
+}
+
+/// Build namespace-prefixed extensions that preserve audit-entry metadata
+/// not otherwise represented in the receipt payload.
+fn build_extensions(entry: &AuditEntry) -> BTreeMap<String, Value> {
+    let mut ext = BTreeMap::new();
+    ext.insert(
+        "mvm.tenant".to_string(),
+        Value::String(entry.tenant.0.clone()),
+    );
+    ext.insert(
+        "mvm.image_name".to_string(),
+        Value::String(entry.image_name.clone()),
+    );
+    ext.insert(
+        "mvm.image_sha256".to_string(),
+        Value::String(entry.image_sha256.clone()),
+    );
+    if let Some(bundle_id) = &entry.bundle_id {
+        ext.insert(
+            "mvm.bundle_id".to_string(),
+            Value::String(bundle_id.0.clone()),
+        );
+    }
+    if let Some(bundle_version) = entry.bundle_version {
+        ext.insert(
+            "mvm.bundle_version".to_string(),
+            Value::Number(bundle_version.into()),
+        );
+    }
+    ext
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    use chrono::{TimeZone, Utc};
+    use ed25519_dalek::SigningKey;
+    use mvm_core::plan::{PlanId, TenantId};
+    use mvm_core::receipt::ReceiptOutcome;
+
+    use crate::supervisor::AuditSigner;
+    use crate::supervisor::audit::AuditEntry;
+    use crate::supervisor::audit_file::FileAuditSigner;
+
+    fn sample_plan_id() -> PlanId {
+        PlanId("sha256:0000000000000000000000000000000000000000000000000000000000000001".into())
+    }
+
+    fn sample_audit_entry(event: &str, labels: BTreeMap<String, String>) -> AuditEntry {
+        AuditEntry {
+            timestamp: Utc.with_ymd_and_hms(2026, 8, 6, 0, 0, 0).unwrap(),
+            tenant: TenantId("local".into()),
+            plan_id: sample_plan_id(),
+            plan_version: 1,
+            bundle_id: None,
+            bundle_version: None,
+            image_name: "test-image".into(),
+            image_sha256: "sha256:0000000000000000000000000000000000000000000000000000000000000002"
+                .into(),
+            event: event.into(),
+            labels,
+        }
+    }
+
+    #[test]
+    fn admitted_entry_maps_to_authorized_receipt() {
+        let entry = sample_audit_entry("plan.admitted", BTreeMap::new());
+        let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+        let host_did = DidKey::from_verifying_key(signing_key.verifying_key()).to_did_key();
+
+        let receipt = audit_entry_to_receipt(&entry, &host_did).unwrap();
+
+        assert_eq!(receipt.receipt_type, receipt_type::PLAN_ADMITTED);
+        assert_eq!(receipt.outcome, ReceiptOutcome::Authorized);
+        assert_eq!(receipt.plan_id, sample_plan_id().0);
+        assert_eq!(receipt.host_did, host_did);
+        assert_eq!(receipt.action.verb, "run");
+        assert_eq!(receipt.action.resource, sample_plan_id().0);
+        assert!(!receipt.receipt_id.is_empty());
+        receipt.verify_id().unwrap();
+    }
+
+    #[test]
+    fn launched_entry_includes_backend_param() {
+        let mut labels = BTreeMap::new();
+        labels.insert("backend".into(), "firecracker".into());
+        let entry = sample_audit_entry("plan.launched", labels);
+        let host_did =
+            DidKey::from_verifying_key(SigningKey::from_bytes(&[2u8; 32]).verifying_key())
+                .to_did_key();
+
+        let receipt = audit_entry_to_receipt(&entry, &host_did).unwrap();
+
+        assert_eq!(receipt.receipt_type, receipt_type::PLAN_LAUNCHED);
+        assert_eq!(receipt.outcome, ReceiptOutcome::Running);
+        assert_eq!(
+            receipt.action.params.get("backend"),
+            Some(&Value::String("firecracker".into()))
+        );
+    }
+
+    #[test]
+    fn failed_entry_maps_to_failed_outcome() {
+        let mut labels = BTreeMap::new();
+        labels.insert("class".into(), "boot".into());
+        labels.insert("message".into(), "kernel panic".into());
+        let entry = sample_audit_entry("plan.failed", labels);
+        let host_did =
+            DidKey::from_verifying_key(SigningKey::from_bytes(&[3u8; 32]).verifying_key())
+                .to_did_key();
+
+        let receipt = audit_entry_to_receipt(&entry, &host_did).unwrap();
+
+        assert_eq!(receipt.receipt_type, receipt_type::PLAN_EXITED);
+        assert_eq!(receipt.outcome, ReceiptOutcome::Failed);
+    }
+
+    #[test]
+    fn checkpoint_entry_uses_checkpoint_id_as_resource() {
+        let mut labels = BTreeMap::new();
+        labels.insert("checkpoint_id".into(), "chk-123".into());
+        labels.insert("class".into(), "full".into());
+        labels.insert("vm_name".into(), "my-vm".into());
+        let entry = sample_audit_entry("checkpoint.created", labels);
+        let host_did =
+            DidKey::from_verifying_key(SigningKey::from_bytes(&[4u8; 32]).verifying_key())
+                .to_did_key();
+
+        let receipt = audit_entry_to_receipt(&entry, &host_did).unwrap();
+
+        assert_eq!(receipt.receipt_type, receipt_type::CHECKPOINT_CREATED);
+        assert_eq!(receipt.action.verb, "checkpoint");
+        assert_eq!(receipt.action.resource, "chk-123");
+    }
+
+    #[test]
+    fn unknown_event_is_skipped_by_export() {
+        let entry = sample_audit_entry("plan.boot_posture", BTreeMap::new());
+        let host_did =
+            DidKey::from_verifying_key(SigningKey::from_bytes(&[5u8; 32]).verifying_key())
+                .to_did_key();
+
+        let result = audit_entry_to_receipt(&entry, &host_did);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn exported_receipts_verify_and_form_chain() {
+        let dir = tempfile::tempdir().unwrap();
+        let signing_key = SigningKey::from_bytes(&[6u8; 32]);
+        let signer = FileAuditSigner::open(signing_key.clone(), dir.path()).unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let _plan_id = sample_plan_id();
+        let entries = vec![
+            sample_audit_entry("plan.admitted", BTreeMap::new()),
+            {
+                let mut labels = BTreeMap::new();
+                labels.insert("backend".into(), "firecracker".into());
+                sample_audit_entry("plan.launched", labels)
+            },
+            {
+                let mut labels = BTreeMap::new();
+                labels.insert("backend".into(), "firecracker".into());
+                labels.insert("exit_code".into(), "0".into());
+                sample_audit_entry("plan.exited", labels)
+            },
+        ];
+
+        for entry in &entries {
+            rt.block_on(signer.sign_and_emit(entry)).unwrap();
+        }
+
+        let receipts = export_receipts(dir.path(), "local", None, &signing_key).unwrap();
+        assert_eq!(receipts.len(), 3);
+
+        for signed in &receipts {
+            signed.verify().unwrap();
+        }
+
+        for signed in &receipts {
+            assert!(signed.payload.prev_receipt_id.is_none());
+        }
+    }
+
+    #[test]
+    fn plan_id_filter_limits_exported_receipts() {
+        let dir = tempfile::tempdir().unwrap();
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let signer = FileAuditSigner::open(signing_key.clone(), dir.path()).unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let plan_a = sample_plan_id();
+        let plan_b = PlanId(
+            "sha256:0000000000000000000000000000000000000000000000000000000000000002".into(),
+        );
+
+        let mut entry_a = sample_audit_entry("plan.admitted", BTreeMap::new());
+        entry_a.plan_id = plan_a.clone();
+        let mut entry_b = sample_audit_entry("plan.admitted", BTreeMap::new());
+        entry_b.plan_id = plan_b.clone();
+
+        rt.block_on(signer.sign_and_emit(&entry_a)).unwrap();
+        rt.block_on(signer.sign_and_emit(&entry_b)).unwrap();
+
+        let receipts = export_receipts(dir.path(), "local", Some(&plan_a.0), &signing_key).unwrap();
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(receipts[0].payload.plan_id, plan_a.0);
+    }
+
+    #[test]
+    fn missing_chain_returns_empty_receipts() {
+        let dir = tempfile::tempdir().unwrap();
+        let signing_key = SigningKey::from_bytes(&[8u8; 32]);
+
+        let receipts = export_receipts(dir.path(), "local", None, &signing_key).unwrap();
+        assert!(receipts.is_empty());
+    }
+}

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -6,6 +6,7 @@ This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## In-flight plans
+<<<<<<< HEAD
 - [~] eBPF vsock egress telemetry spike — **issue #2211**, branch
       `feat/ebpf-vsock-egress-telemetry`
   - [x] Remove the standalone `mvm-ebpf-egress` crate; fold the Aya loader
@@ -293,6 +294,19 @@ for detailed scope and acceptance criteria.
         stay refused at admission on the userspace backend, honestly and
         for a stated reason. ADR-039 status Rejected; reopening requires a
         workload with a demonstrated need
+=======
+
+- [ ] Plan 298 — NANDA-style execution receipts and conformance badges
+      (`specs/plans/298-nanda-receipts-and-conformance-badges.md`)
+  - [x] WS1 RFC approved: `ExecutionReceipt` and `ConformanceBadge` envelopes,
+        JCS canonicalization, Ed25519/`did:key` signing, chain semantics, and
+        mapping to existing `AuditEntry` events defined
+  - [ ] WS2 Core types and canonicalization
+  - [ ] WS3 Read-only receipt exporter
+  - [ ] WS4 Runtime emission of receipts
+  - [ ] WS5 Conformance badge generator
+  - [ ] WS6 Documentation and registry conventions
+>>>>>>> 9e46d0c4e (docs: RFC for NANDA-style execution receipts and conformance badges)
 
 - [x] Plan 291 — Develop → build → deploy an attested workload image
       (`specs/plans/291-develop-build-deploy-attested.md`)
@@ -318,12 +332,12 @@ for detailed scope and acceptance criteria.
           and signed grant enforcement reject the complete DevOnly request set.
 
 - [~] Plan 290 — Sensitive egress redaction
-      (`specs/plans/290-sensitive-egress-redaction.md`)
+  (`specs/plans/290-sensitive-egress-redaction.md`)
   - [x] Validated byte detector and pinned, no-default-feature LeakGuard adapter
   - [x] Shared supplemental coverage for masking and reversible replacement
   - [x] Default secret/PII policy arms compressed and over-cap fail-closed gates
   - [~] Host workspace tests/check, workspace all-target Clippy and supply-chain
-        gates pass; Linux builder-VM workspace all-target Clippy remains
+    gates pass; Linux builder-VM workspace all-target Clippy remains
   - [ ] Structured/streaming body coverage and split-boundary witnesses
   - [ ] Signed CLI policy lowering and admission posture reporting
   - [ ] Build-level claim promotion and adversarial backend witnesses
@@ -390,7 +404,7 @@ for detailed scope and acceptance criteria.
   - [x] Reconcile rejected speculative clauses and close #2040 with evidence
 
 - [~] Plan 295 — Workload stream plane
-      (`specs/plans/295-workload-stream-plane.md`)
+  (`specs/plans/295-workload-stream-plane.md`)
   - [x] T1–T3 — stream record DTOs + chain verify; transcript stream
         directions and per-chunk linkage; ring retention
   - [x] T4–T5b — guest pump emits as produced; fd-3 control records; the
@@ -443,8 +457,8 @@ for detailed scope and acceptance criteria.
         the grant/lease/secret-scan gate; agent-side delivery and EOF; the
         route from gate to guest sink; the sealed-tier refusal of the input
         grant for a shell-shaped entrypoint; and the claims ledger — claim 15
-        reworded (it used to hold by *absence*, there being no host→guest byte
-        path at all, and now holds by *policy*) and claim 17 added at status
+        reworded (it used to hold by _absence_, there being no host→guest byte
+        path at all, and now holds by _policy_) and claim 17 added at status
         `Preview` with a limits note (T17 below closed two; plan 293 WS1 closed
         the third by giving the scan fingerprints, and its follow-on closed the
         blanket carry's stall with a content-independent idle release; the two
@@ -460,12 +474,12 @@ for detailed scope and acceptance criteria.
         `reference/guest-agent.md`, which had drifted from the `ProdSafe`
         classification of `StreamInput`/`CloseStreamInput`. ADR-001's limit 3
         sharpened: `StreamPlane::open_input` is the only route into the gate and
-        has no caller outside `tests/workload_input_plane.rs`, so *neither* half
+        has no caller outside `tests/workload_input_plane.rs`, so _neither_ half
         of the input plane has run on a real VM — "proven end to end" described
         test fidelity, not liveness
   - [x] T17 — the operator surface, landed with a live entrypoint resolver in
         the same change as the plan required. `machine run --entrypoint --stdin
-        -` opens the route under the plan that boot was admitted under, pumps
+    -` opens the route under the plan that boot was admitted under, pumps
         the caller's stdin through the gate in acceptance order on its own
         thread, refreshes the lease on a ticker while the writer is idle, and
         closes the workload's stdin on the caller's EOF. The grant is
@@ -475,16 +489,16 @@ for detailed scope and acceptance criteria.
         the `mkGuest` and OCI build paths, because the host cannot read inside a
         materialized ext4 — and admission **fails closed** when it cannot
         resolve one, so the shell refusal cannot go dormant again
-  - [~] Residual after T9b/T9d: T9d closed the *seal* half — a detached run's
-        transcript is now sealed by whatever stops the VM. The *follow* half
-        remains: the console follower still dies with the starting process, so
-        output a detached VM produces after that point reaches no capture at
-        all until a resident host process owns the plane
+  - [~] Residual after T9b/T9d: T9d closed the _seal_ half — a detached run's
+    transcript is now sealed by whatever stops the VM. The _follow_ half
+    remains: the console follower still dies with the starting process, so
+    output a detached VM produces after that point reaches no capture at
+    all until a resident host process owns the plane
   - [ ] Deferred to the broker task: state a follower's start sequence in the
         first batch, so the reader can close the accept-window gap between the
         transcript snapshot and the live subscription
   - [ ] Deferred to the broker task: re-seal the stream transcript periodically,
-        so durable history exists for a *running* VM and survives a kill
+        so durable history exists for a _running_ VM and survives a kill
 - [x] Plan 282 — Merge queue auto-requeue
       (`specs/plans/282-merge-queue-auto-requeue.md`)
   - [x] Refuse conflicts and bound retry attempts per PR
@@ -492,7 +506,7 @@ for detailed scope and acceptance criteria.
   - [x] Complete repository validation and queue the PR
 
 - [~] Plan 270 — Universal initramfs + vsock-activated boot
-      (`specs/plans/270-universal-initramfs-vsock-activated-boot.md`)
+  (`specs/plans/270-universal-initramfs-vsock-activated-boot.md`)
   - [x] Core boot contract: `ActivateEnvironment` over the authenticated
         vsock session, `ActivationState` gate, PID-1 agent with mount
         library + uid-901 drop (#1914)
@@ -508,15 +522,15 @@ for detailed scope and acceptance criteria.
   - [x] Pin `mvmctl` embedding to the builder/bootstrap host and seed
         manifests
   - [~] Deviations recorded at the unticked steps in the plan: capability-bit
-        negotiation, chain-signed boot events, and vm_id/session binding were
-        superseded by the path discriminator + session-key pinning; the
-        guest-side activation idle timeout and focused zombie-reaping tests
-        remain open
+    negotiation, chain-signed boot events, and vm_id/session binding were
+    superseded by the path discriminator + session-key pinning; the
+    guest-side activation idle timeout and focused zombie-reaping tests
+    remain open
   - [~] Remaining rollout, snapshot, BDD, and live-smoke work stays in the
-        plan
+    plan
 
 - [~] Plan 271 — Apple Container backend: Apple's container kernel on HVF
-      (`specs/plans/271-apple-container-backend.md`)
+  (`specs/plans/271-apple-container-backend.md`)
   - [x] Stage 1 — fail-closed skeleton: kernel artifact resolution + thin
         HVF-runner delegation
   - [x] Stage 2 — live validation + claim review (2026-08-01): required
@@ -551,7 +565,7 @@ for detailed scope and acceptance criteria.
         (416 of 1872 files, 22%, stop being cache keys)
 
 - [x] Plan 284 — CI lint and merge-queue latency
-  (`specs/plans/284-ci-lint-latency.md`)
+      (`specs/plans/284-ci-lint-latency.md`)
   - [x] Target only the packages that own `test-support` code
   - [x] Remove branch-local multi-gigabyte Cargo target caches
   - [x] Share nested `mvm-cli` builds across feature fingerprints
@@ -567,7 +581,7 @@ for detailed scope and acceptance criteria.
   - [x] Keep targeted feature coverage and Linux conformance coverage intact
   - [x] Complete workflow and repository verification
 - [~] Plan 276 — Content-addressing conformance and defense
-      (`specs/plans/276-content-addressing-conformance-and-defense.md`)
+  (`specs/plans/276-content-addressing-conformance-and-defense.md`)
   - [x] WS0 — plan + recon note landed (#1964); axis/policy ratification open
   - [x] WS1 — pin the evidence each claim rests on: `witness_kinds` per claim
         in `model/claims.toml`, gated by `check-claim-catalog`. The original
@@ -576,11 +590,11 @@ for detailed scope and acceptance criteria.
         delisted from a whole kind of witness with every gate green
   - [x] WS2 — prose over-claim meta-gate, shipped as `xtask check-no-overclaim`
   - [~] WS3 — replay golden-vector corpus. `ir_hash`, `leaf_hash`,
-        `interior_hash`, `merkle_root`, `compute_plan_id` and `bundle_sha256`
-        now carry frozen addresses. The existing `ir_hash` tests were all
-        *relational*, so a canonicalization change moving every address
-        consistently passed all four — planted and confirmed. The audit `prev_hash`
-        spine is closed by WS4's frozen signed corpus
+    `interior_hash`, `merkle_root`, `compute_plan_id` and `bundle_sha256`
+    now carry frozen addresses. The existing `ir_hash` tests were all
+    _relational_, so a canonicalization change moving every address
+    consistently passed all four — planted and confirmed. The audit `prev_hash`
+    spine is closed by WS4's frozen signed corpus
   - [x] WS4 — one frozen signed audit chain both verifiers read. The existing
         parity test compared them over a randomly-keyed chain generated per
         run, which no verifier outside that process could ever see. riscv32 is
@@ -588,9 +602,9 @@ for detailed scope and acceptance criteria.
         verifier and the no_std mirror, with wasm executing the mirror
   - [ ] WS5 — bind each witness to its recorded red-proof
   - [~] WS6 — **lead item**: content-address the caches, verify on read. The
-        2026-08-01 recon revision reverses finding 2 — integrity-on-read is the
-        one attestation property no surveyed system enforces, mvm included —
-        which promoted this from tail to lead
+    2026-08-01 recon revision reverses finding 2 — integrity-on-read is the
+    one attestation property no surveyed system enforces, mvm included —
+    which promoted this from tail to lead
     - [x] Dev-build artifact cache, shipped in #2053: `mvm_core::action` +
           `verify_artifacts_on_disk`, verify on read, fail closed to a cold
           miss, and eviction of **both** the record and the build directory —
@@ -603,11 +617,11 @@ for detailed scope and acceptance criteria.
           (`specs/plans/288-kernel-cache-verify-on-read.md`)
     - [ ] Cold-tier background scrub (recon §7.9)
   - [~] WS7 — σ/κ separation: `mvm_core::at_rest` gives the protocol digest
-        over plaintext and the storage address over bytes at rest as disjoint
-        types, σ as a set, and the transform descriptor as an open enumeration.
-        The plan's "everything is Identity today" premise was wrong — OCI
-        layers are tar+gzip and transcripts store ciphertext — which
-        strengthens the case. Remaining: adopt the types at those two sites
+    over plaintext and the storage address over bytes at rest as disjoint
+    types, σ as a set, and the transform descriptor as an open enumeration.
+    The plan's "everything is Identity today" premise was wrong — OCI
+    layers are tar+gzip and transcripts store ciphertext — which
+    strengthens the case. Remaining: adopt the types at those two sites
   - [x] Discharged elsewhere: sealed transcript root anchored into the audit
         chain (recon §7.6 → plan 280, #2017); post-restore child verb grant
         (recon §7.7 → #2019)
@@ -652,7 +666,7 @@ for detailed scope and acceptance criteria.
         ~5–6 ms gap is Firecracker process startup + snapshot resume.
 
 - [x] Plan 273 — SDK sidecar release acquisition
-  (`specs/plans/273-sdk-sidecar-release-acquisition.md`)
+      (`specs/plans/273-sdk-sidecar-release-acquisition.md`)
   - [x] Publish `sdk-sidecar-<arch>.tar.gz` per-arch release assets, with
         `tests/release_assets.rs` pinning the workflow's names to the Rust
         constructor that requests them
@@ -663,7 +677,7 @@ for detailed scope and acceptance criteria.
         source checkout keeps the fail-closed refusal
 
 - [x] Plan 277 — release-artifact signature verification
-  (`specs/plans/277-release-artifact-signature-verification.md`)
+      (`specs/plans/277-release-artifact-signature-verification.md`)
   - [x] Sign the image tarballs with `--new-bundle-format`, the only shape the
         in-binary Rust verifier parses; binary tarballs stay legacy for the
         cosign-CLI consumers (`install.sh`, `mvmctl update`)
@@ -673,7 +687,7 @@ for detailed scope and acceptance criteria.
   - [x] Docs + rollup; closes plan 273's one deferred gap
 
 - [x] Plan 266 — lightweight microVM guest
-  (`specs/plans/266-lightweight-microvm-guest.md`)
+      (`specs/plans/266-lightweight-microvm-guest.md`)
   - [x] WS-1/WS-2: static-musl privilege drop via the in-house `mvm-setpriv`
   - [x] WS-3: static-musl runtime overlay with the glibc SDK FFI split out
   - [x] WS-3 follow-up: plan-driven automatic SDK-sidecar attachment, gated
@@ -684,7 +698,7 @@ for detailed scope and acceptance criteria.
         with the optional SDK sidecar reported separately
 
 - [x] Plan 280 — transcript root audit binding
-  (`specs/plans/280-transcript-root-audit-binding.md`)
+      (`specs/plans/280-transcript-root-audit-binding.md`)
   - [x] Version-2 manifest root over fixed metadata and ordered ciphertext
         chunk records, with deterministic and mutation coverage
   - [x] Ordered `gateway.transcript_sealed` emission after atomic manifest
@@ -703,9 +717,9 @@ for detailed scope and acceptance criteria.
   - [x] Persistent-machine Firecracker stop fails closed and preserves state
         until process exit is verified (#2007; live KVM recheck passed)
   - [~] Live warm-launch, fork-isolation, and restore-clock verification
-        — parent audit anchoring is fixed and live-proven (#1962); native HVF
-        now has a paused-parent handoff with child-owned channel wiring and
-        post-restore identity/grant re-pin (#2174). Serialized fresh-VMM
-        restore and live Apple Silicon witnesses remain open.
+    — parent audit anchoring is fixed and live-proven (#1962); native HVF
+    now has a paused-parent handoff with child-owned channel wiring and
+    post-restore identity/grant re-pin (#2174). Serialized fresh-VMM
+    restore and live Apple Silicon witnesses remain open.
   - [ ] Typed-connector egress-policy enrichment
   - [ ] OCI-image template build path and CLI facade completion

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -303,7 +303,9 @@ for detailed scope and acceptance criteria.
         mapping to existing `AuditEntry` events defined
   - [x] WS2 Core types and canonicalization: `receipt.rs`,
         `conformance_badge.rs`, `did_key.rs`, unit tests, workspace clippy clean
-  - [ ] WS3 Read-only receipt exporter
+  - [x] WS3 Read-only receipt exporter: `mvmctl trust audit receipts export`
+        derives signed `ExecutionReceipt`s from verified chain-signed
+        `AuditEntry` events; unit + integration tests pass
   - [ ] WS4 Runtime emission of receipts
   - [ ] WS5 Conformance badge generator
   - [ ] WS6 Documentation and registry conventions

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -301,7 +301,8 @@ for detailed scope and acceptance criteria.
   - [x] WS1 RFC approved: `ExecutionReceipt` and `ConformanceBadge` envelopes,
         JCS canonicalization, Ed25519/`did:key` signing, chain semantics, and
         mapping to existing `AuditEntry` events defined
-  - [ ] WS2 Core types and canonicalization
+  - [x] WS2 Core types and canonicalization: `receipt.rs`,
+        `conformance_badge.rs`, `did_key.rs`, unit tests, workspace clippy clean
   - [ ] WS3 Read-only receipt exporter
   - [ ] WS4 Runtime emission of receipts
   - [ ] WS5 Conformance badge generator

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -142,6 +142,15 @@
       short reads, EOF, and nonblocking errors refund unused reservations.
       Regression coverage proves an exhausted budget keeps the stream alive.
 
+- [~] NANDA-style execution receipts and conformance badges — **plan 298**
+      (`specs/plans/298-nanda-receipts-and-conformance-badges.md`). WS1 RFC
+      approved: defines `ExecutionReceipt` (signed, chainable proof of what ran,
+      by whom, under what authority) and `ConformanceBadge` (signed, corpus-pinned
+      export of the MVM-SEC claim/witness program), both built on existing
+      Ed25519/JCS/SHA-256 primitives with no new authority or external dependency.
+      WS2–WS6 (core types, read-only exporter, runtime emission, badge generator,
+      docs) are scheduled next.
+
 ### mvm-studio local-service wave (issues #2078–#2082; #2083 deferred)
 
 Wave 0 scaffolded the `mvm-client` service module seams (`inventory`,

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -144,12 +144,12 @@
 
 - [~] NANDA-style execution receipts and conformance badges — **plan 298**
       (`specs/plans/298-nanda-receipts-and-conformance-badges.md`). WS1 RFC
-      approved and WS2 core types landed in `mvm-core`: `ExecutionReceipt` and
-      `ConformanceBadge` structs, JCS canonicalization with a constrained value
-      space, Ed25519 signing/verification, and a `did:key` codec. All
-      `mvm-core` unit tests and workspace `cargo check` / `cargo clippy` pass.
-      WS3–WS6 (read-only exporter, runtime emission, badge generator, docs) are
-      next.
+      approved, WS2 core types landed in `mvm-core`, and WS3 read-only receipt
+      exporter landed: `mvmctl trust audit receipts export` converts verified
+      chain-signed `AuditEntry` events into signed `ExecutionReceipt`s. All
+      `mvm-core` / `mvm-hostd` unit tests and integration tests pass; workspace
+      `cargo check` / `cargo clippy` are clean. WS4–WS6 (runtime emission,
+      badge generator, docs) are next.
 
 ### mvm-studio local-service wave (issues #2078–#2082; #2083 deferred)
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -144,12 +144,12 @@
 
 - [~] NANDA-style execution receipts and conformance badges — **plan 298**
       (`specs/plans/298-nanda-receipts-and-conformance-badges.md`). WS1 RFC
-      approved: defines `ExecutionReceipt` (signed, chainable proof of what ran,
-      by whom, under what authority) and `ConformanceBadge` (signed, corpus-pinned
-      export of the MVM-SEC claim/witness program), both built on existing
-      Ed25519/JCS/SHA-256 primitives with no new authority or external dependency.
-      WS2–WS6 (core types, read-only exporter, runtime emission, badge generator,
-      docs) are scheduled next.
+      approved and WS2 core types landed in `mvm-core`: `ExecutionReceipt` and
+      `ConformanceBadge` structs, JCS canonicalization with a constrained value
+      space, Ed25519 signing/verification, and a `did:key` codec. All
+      `mvm-core` unit tests and workspace `cargo check` / `cargo clippy` pass.
+      WS3–WS6 (read-only exporter, runtime emission, badge generator, docs) are
+      next.
 
 ### mvm-studio local-service wave (issues #2078–#2082; #2083 deferred)
 

--- a/specs/plans/298-nanda-receipts-and-conformance-badges.md
+++ b/specs/plans/298-nanda-receipts-and-conformance-badges.md
@@ -1,8 +1,6 @@
 # NANDA-style execution receipts and conformance badges
 
-**Status:** RFC approved. Phase 0 / WS1 complete. WS2–WS6 are gated on
-scheduling into `specs/SPRINT.md` and creating a dedicated worktree per
-workstream.
+**Status:** In progress. WS1 (RFC) and WS2 (core types) complete. WS3–WS6 pending.
 
 **Date:** 2026-08-06
 **Owner:** mvm
@@ -249,14 +247,14 @@ and wire formats. This workstream gates all others.
 **Goal:** Implement the receipt and badge types in `mvm-core` with JCS
 canonicalization and Ed25519 signing/verification.
 
-- [ ] Add `ExecutionReceipt` and `ConformanceBadge` types in `mvm-core`.
-- [ ] Implement JCS canonicalization helpers constrained to the admissible value
-      space.
-- [ ] Implement Ed25519 signing/verification with `did:key` derivation and
-      parsing.
-- [ ] Add unit tests for canonicalization determinism, signature roundtrip,
-      tamper detection, and invalid value-space rejection.
-- [ ] Add golden vectors for both envelopes.
+- [x] Add `ExecutionReceipt` and `ConformanceBadge` types in `mvm-core`.
+- [x] Implement JCS canonicalization helpers constrained to the admissible value
+      space (ASCII strings, integers, booleans, null, nested objects/arrays).
+- [x] Implement Ed25519 signing/verification with `did:key` derivation and
+      parsing (new `did_key` module).
+- [x] Add unit tests for canonicalization determinism, signature roundtrip,
+      tamper detection, invalid value-space rejection, and chain continuity.
+- [ ] Add frozen golden-vector files for both envelopes (deferred to WS3/WS5).
 
 **Files likely touched:**
 

--- a/specs/plans/298-nanda-receipts-and-conformance-badges.md
+++ b/specs/plans/298-nanda-receipts-and-conformance-badges.md
@@ -1,6 +1,6 @@
 # NANDA-style execution receipts and conformance badges
 
-**Status:** In progress. WS1 (RFC) and WS2 (core types) complete. WS3–WS6 pending.
+**Status:** In progress. WS1–WS3 complete. WS4–WS6 pending.
 
 **Date:** 2026-08-06
 **Owner:** mvm
@@ -268,16 +268,20 @@ canonicalization and Ed25519 signing/verification.
 **Goal:** Add a tool/CLI command that converts existing chain-signed audit
 entries into signed `ExecutionReceipt`s.
 
-- [ ] Add `mvmctl trust audit receipts export` (or similar) command.
-- [ ] Implement derivation from `AuditEntry` to `ExecutionReceipt`.
-- [ ] Ensure exported receipts verify offline end-to-end.
-- [ ] Add integration tests using the frozen audit corpus.
+- [x] Add `mvmctl trust audit receipts export` (or similar) command.
+- [x] Implement derivation from `AuditEntry` to `ExecutionReceipt`.
+- [x] Ensure exported receipts verify offline end-to-end.
+- [x] Add integration tests using the frozen audit corpus.
 
-**Files likely touched:**
+**Files touched:**
 
-- `crates/mvm-cli/src/commands/cmd_audit.rs`
-- `crates/mvm-hostd/src/audit/emitter.rs` (read path)
+- `crates/mvm-hostd/src/audit/receipt_export.rs` (new)
+- `crates/mvm-hostd/src/audit/mod.rs`
+- `crates/mvm-cli/src/commands/ops/audit.rs`
+- `crates/mvm-cli/src/commands/tests.rs`
 - `tests/audit_total_coverage.rs`
+- `tests/audit_receipt_export.rs` (new)
+- `Cargo.toml` (dev-dependency for integration test)
 
 ### WS4 — Runtime emission of receipts
 

--- a/tests/audit_receipt_export.rs
+++ b/tests/audit_receipt_export.rs
@@ -1,0 +1,247 @@
+//! End-to-end test of the read-only receipt exporter.
+//!
+//! Builds a synthetic chain-signed audit log directly, then drives the
+//! real `mvmctl trust audit receipts export` binary and asserts the
+//! exported receipts verify offline.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use ed25519_dalek::SigningKey;
+use mvm_core::plan::{PlanId, TenantId};
+use mvm_core::receipt::{ReceiptOutcome, receipt_type};
+use mvm_hostd::supervisor::audit::AuditEntry;
+use mvm_hostd::supervisor::{AuditSigner, FileAuditSigner};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use tempfile::TempDir;
+
+struct ExportSandbox {
+    home: TempDir,
+}
+
+impl ExportSandbox {
+    fn new() -> Self {
+        Self {
+            home: tempfile::tempdir().expect("tempdir"),
+        }
+    }
+
+    fn home_path(&self) -> &std::path::Path {
+        self.home.path()
+    }
+
+    fn mvm_root(&self) -> PathBuf {
+        self.home_path().join("mvm-home")
+    }
+
+    fn audit_dir(&self) -> PathBuf {
+        self.mvm_root().join("audit")
+    }
+
+    fn keys_dir(&self) -> PathBuf {
+        self.mvm_root().join("keys")
+    }
+
+    fn mvmctl(&self) -> Command {
+        let mut c = Command::cargo_bin("mvmctl").expect("cargo_bin mvmctl");
+        c.env("HOME", self.home_path())
+            .env("MVM_HOME", self.mvm_root());
+        c
+    }
+}
+
+fn sample_plan_id() -> PlanId {
+    PlanId("sha256:0000000000000000000000000000000000000000000000000000000000000001".into())
+}
+
+fn sample_audit_entry(event: &str, labels: BTreeMap<String, String>) -> AuditEntry {
+    AuditEntry {
+        timestamp: chrono::Utc::now(),
+        tenant: TenantId("local".into()),
+        plan_id: sample_plan_id(),
+        plan_version: 1,
+        bundle_id: None,
+        bundle_version: None,
+        image_name: "test-image".into(),
+        image_sha256: "sha256:0000000000000000000000000000000000000000000000000000000000000002"
+            .into(),
+        event: event.into(),
+        labels,
+    }
+}
+
+fn set_secret_permissions(path: &std::path::Path) {
+    #[cfg(unix)]
+    {
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o600);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+}
+
+fn write_test_chain(sandbox: &ExportSandbox) -> SigningKey {
+    let keys_dir = sandbox.keys_dir();
+    std::fs::create_dir_all(&keys_dir).unwrap();
+    let audit_dir = sandbox.audit_dir();
+    std::fs::create_dir_all(&audit_dir).unwrap();
+
+    let signing_key = SigningKey::from_bytes(&[9u8; 32]);
+    let signer = FileAuditSigner::open(signing_key.clone(), &audit_dir).unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let entries = vec![
+        sample_audit_entry("plan.admitted", BTreeMap::new()),
+        {
+            let mut labels = BTreeMap::new();
+            labels.insert("backend".into(), "mock".into());
+            sample_audit_entry("plan.launched", labels)
+        },
+        {
+            let mut labels = BTreeMap::new();
+            labels.insert("backend".into(), "mock".into());
+            labels.insert("exit_code".into(), "0".into());
+            sample_audit_entry("plan.exited", labels)
+        },
+    ];
+
+    for entry in &entries {
+        rt.block_on(signer.sign_and_emit(entry)).unwrap();
+    }
+
+    // Copy the signer pubkey to where `mvmctl` expects it.
+    std::fs::write(
+        keys_dir.join("host-signer.pub"),
+        signing_key.verifying_key().to_bytes(),
+    )
+    .unwrap();
+    std::fs::write(keys_dir.join("host-signer.ed25519"), signing_key.to_bytes()).unwrap();
+    set_secret_permissions(&keys_dir.join("host-signer.ed25519"));
+
+    signing_key
+}
+
+#[test]
+fn receipts_export_json_verifies_offline() {
+    let sandbox = ExportSandbox::new();
+    let signing_key = write_test_chain(&sandbox);
+
+    let mut cmd = sandbox.mvmctl();
+    cmd.args([
+        "trust", "audit", "receipts", "export", "--tenant", "local", "--json",
+    ]);
+    let output = cmd.assert().success();
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+
+    let receipts: Vec<mvm_core::receipt::SignedExecutionReceipt> =
+        serde_json::from_str(&stdout).expect("parsing exported receipts");
+    assert_eq!(receipts.len(), 3);
+
+    let expected_types = [
+        receipt_type::PLAN_ADMITTED,
+        receipt_type::PLAN_LAUNCHED,
+        receipt_type::PLAN_EXITED,
+    ];
+    for (i, signed) in receipts.iter().enumerate() {
+        signed
+            .verify()
+            .expect("exported receipt signature must verify");
+        assert_eq!(signed.payload.receipt_type, expected_types[i]);
+        assert_eq!(
+            signed.payload.host_did,
+            mvm_core::did_key::DidKey::from_verifying_key(signing_key.verifying_key()).to_did_key()
+        );
+    }
+    assert_eq!(receipts[0].payload.outcome, ReceiptOutcome::Authorized);
+    assert_eq!(receipts[1].payload.outcome, ReceiptOutcome::Running);
+    assert_eq!(receipts[2].payload.outcome, ReceiptOutcome::Succeeded);
+}
+
+#[test]
+fn receipts_export_with_plan_id_filter() {
+    let sandbox = ExportSandbox::new();
+    let keys_dir = sandbox.keys_dir();
+    std::fs::create_dir_all(&keys_dir).unwrap();
+    let audit_dir = sandbox.audit_dir();
+    std::fs::create_dir_all(&audit_dir).unwrap();
+
+    let signing_key = SigningKey::from_bytes(&[10u8; 32]);
+    let signer = FileAuditSigner::open(signing_key.clone(), &audit_dir).unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let plan_a = sample_plan_id();
+    let plan_b =
+        PlanId("sha256:0000000000000000000000000000000000000000000000000000000000000002".into());
+
+    let mut entry_a = sample_audit_entry("plan.admitted", BTreeMap::new());
+    entry_a.plan_id = plan_a.clone();
+    let mut entry_b = sample_audit_entry("plan.admitted", BTreeMap::new());
+    entry_b.plan_id = plan_b.clone();
+
+    rt.block_on(signer.sign_and_emit(&entry_a)).unwrap();
+    rt.block_on(signer.sign_and_emit(&entry_b)).unwrap();
+
+    std::fs::write(
+        keys_dir.join("host-signer.pub"),
+        signing_key.verifying_key().to_bytes(),
+    )
+    .unwrap();
+    std::fs::write(keys_dir.join("host-signer.ed25519"), signing_key.to_bytes()).unwrap();
+    set_secret_permissions(&keys_dir.join("host-signer.ed25519"));
+
+    let mut cmd = sandbox.mvmctl();
+    cmd.args([
+        "trust",
+        "audit",
+        "receipts",
+        "export",
+        "--tenant",
+        "local",
+        "--plan-id",
+        &plan_a.0,
+        "--json",
+    ]);
+    let output = cmd.assert().success();
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+
+    let receipts: Vec<mvm_core::receipt::SignedExecutionReceipt> =
+        serde_json::from_str(&stdout).expect("parsing filtered receipts");
+    assert_eq!(receipts.len(), 1);
+    assert_eq!(receipts[0].payload.plan_id, plan_a.0);
+}
+
+#[test]
+fn receipts_export_empty_chain_reports_no_receipts() {
+    let sandbox = ExportSandbox::new();
+    let keys_dir = sandbox.keys_dir();
+    std::fs::create_dir_all(&keys_dir).unwrap();
+    let audit_dir = sandbox.audit_dir();
+    std::fs::create_dir_all(&audit_dir).unwrap();
+
+    let signing_key = SigningKey::from_bytes(&[11u8; 32]);
+    std::fs::write(
+        keys_dir.join("host-signer.pub"),
+        signing_key.verifying_key().to_bytes(),
+    )
+    .unwrap();
+    std::fs::write(keys_dir.join("host-signer.ed25519"), signing_key.to_bytes()).unwrap();
+    set_secret_permissions(&keys_dir.join("host-signer.ed25519"));
+
+    let mut cmd = sandbox.mvmctl();
+    cmd.args([
+        "trust", "audit", "receipts", "export", "--tenant", "local", "--json",
+    ]);
+    let output = cmd.assert().success();
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+
+    let receipts: Vec<mvm_core::receipt::SignedExecutionReceipt> =
+        serde_json::from_str(&stdout).expect("parsing empty receipt array");
+    assert!(receipts.is_empty());
+}

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -390,6 +390,8 @@ const TRANSCRIPT_SUB: &[(&str, AuditPosture)] = &[
 // their own: `publish-root` writes a signed-root sidecar derived from the chain
 // (not a new chain event), and `prove` / `verify-inclusion` are pure reads —
 // the same audit posture as `verify-cert`.
+const RECEIPTS_SUB: &[(&str, AuditPosture)] = &[("export", AuditPosture::ReadOnly)];
+
 const AUDIT_SUB: &[(&str, AuditPosture)] = &[
     ("tail", AuditPosture::ReadOnly),
     ("verify", AuditPosture::ReadOnly),
@@ -399,6 +401,7 @@ const AUDIT_SUB: &[(&str, AuditPosture)] = &[
     ("publish-root", AuditPosture::ReadOnly),
     ("prove", AuditPosture::ReadOnly),
     ("verify-inclusion", AuditPosture::ReadOnly),
+    ("receipts", AuditPosture::DelegatesToSub(RECEIPTS_SUB)),
     ("transcript", AuditPosture::DelegatesToSub(TRANSCRIPT_SUB)),
 ];
 

--- a/xtask/src/check_closure_budget.rs
+++ b/xtask/src/check_closure_budget.rs
@@ -94,7 +94,11 @@ const BUDGET_TARGET: &str = "x86_64-unknown-linux-gnu";
 /// 283 (was 279): making the userspace socket datapath's host-side polling,
 /// socket, and smoltcp protocol dependencies explicit in the shipping binary;
 /// measured delta +4 crates for the complete fallback forwarding backend.
-const CLOSURE_BUDGET: usize = 283;
+///
+/// 284 (was 283): the `did:key` codec for receipt/conformance identity uses
+/// the audited `bs58` crate; it is zero-dependency and the only new crate in
+/// the default closure.
+const CLOSURE_BUDGET: usize = 284;
 
 pub fn run(workspace: &Path) -> Result<()> {
     let count = default_closure_crate_count(workspace)?;


### PR DESCRIPTION
Implements Plan 298 WS2.

- Adds `receipt::ExecutionReceipt` + `SignedExecutionReceipt`: signed, chainable proof of what ran, with content-addressed `receipt_id` over JCS-canonical payload.
- Adds `conformance_badge::ConformanceBadge` + `SignedConformanceBadge`: corpus-pinned conformance export with admission gates.
- Adds `did_key::DidKey` codec for Ed25519 `did:key` derivation and parsing.
- Constrained JCS canonicalization rejects floats, non-ASCII strings/keys, and raw bytes.
- Unit tests for signing roundtrip, tamper detection, value-space rejection, chain continuity, and corpus digest stability.
- Updates Plan 298, SPRINT.md, and REFACTOR-STATUS.md to mark WS2 complete.