### PR TITLE
Close plan 296: stream-edge posture and guide

### DIFF
--- a/public/astro.config.mjs
+++ b/public/astro.config.mjs
@@ -142,6 +142,7 @@ export default defineConfig({
             { label: "Audit and Receipts", slug: "guides/audit-and-receipts" },
             { label: "Workload Output Streaming", slug: "guides/workload-output-streaming" },
             { label: "Workload Input", slug: "guides/workload-input" },
+            { label: "Fleet Stream Edges", slug: "guides/fleet-stream-edges" },
             { label: "Observability and Results", slug: "guides/observability-and-results" },
             { label: "Manifests", slug: "guides/manifests" },
             { label: "Networking", slug: "guides/networking" },

--- a/public/src/content/docs/guides/fleet-stream-edges.md
+++ b/public/src/content/docs/guides/fleet-stream-edges.md
@@ -1,0 +1,179 @@
+---
+title: Stream edges between workloads
+description: How one workload's output feeds another's stdin, what redaction does to data in flight, and what happens when a consumer falls behind.
+---
+
+A **stream edge** connects one workload's output to another's stdin, so a fleet
+can run a workflow. `mvm` provides the mechanism; `mvmd` declares the edges and
+resolves them. A single-VM `mvmctl` run has no edges.
+
+:::caution[Mechanism only, today]
+The pieces below are on `main` and tested, but nothing in `mvm` declares an
+edge — `mvmd` is the caller. Until it does, this page describes a surface you
+can build against rather than a feature you can drive from the CLI.
+:::
+
+## A consumer names a binding, never a VM
+
+An edge appears on the **consumer's** signed plan, and it names a *binding*:
+
+```json
+{
+  "stream_edges": [
+    { "binding": "upstream", "redaction": "redacted", "backpressure": "lossy" }
+  ]
+}
+```
+
+The host resolves `upstream` to a producer. The guest never learns which
+workload that is, or that there was one at all.
+
+That indirection is the whole point. The two workloads never share a
+transport, never learn each other's identity, and neither gains a network
+interface — bytes cross inside the host, between two independent vsock
+channels, at the same place that was already the single authorization point.
+An edge adds no new path out of a guest.
+
+A consumer naming a binding it was not granted is refused before boot, and the
+refusal reaches the chain-signed audit log. "Not granted" and "no such source"
+are deliberately the same answer, so a workload cannot map the fleet by trying
+names.
+
+## Redaction in flight
+
+`redaction` defaults to `redacted`: the consumer sees what every other consumer
+sees, masked by the one seam all output crosses.
+
+`raw` exists because always-masking corrupts a pipeline whose second stage
+needs what the first computed — a masked value is not a value. It requires an
+operator acknowledgement **in addition to** the plan signature:
+
+```sh
+MVM_ACK_RAW_STREAM_EDGE=1
+```
+
+A plan is signed on behalf of whoever launched the workload. Letting a plan
+alone opt out would let a careless or compromised workload definition export
+raw PII into another workload with no human involved, and between two workloads
+those are different trust domains. Same shape as
+`MVM_ACK_UNRESTRICTED_NETWORK`, and likewise never set in CI.
+
+:::note[`raw` is not servable yet]
+Redaction runs *before* hashing, so a record that reaches a reader has already
+crossed the seam and no unmasked copy survives. A `raw` edge is therefore
+refused at connect time rather than handed masked bytes under a fidelity
+label — being told you have the value while computing on `XXX` is worse than
+being told no. Serving it needs a tap on the pre-seam side, which does not
+exist.
+:::
+
+## One input slot, one writer
+
+A workload has a single stdin, so it can be fed by **one** edge.
+
+Two edges into one consumer is fan-in, and it is rejected when the topology is
+validated. Two producers interleaving into one stdin produce corrupted records,
+and stdin carries no framing to recover them — there is no way to tell whose
+half-line you are holding.
+
+A workflow that needs fan-in declares a **merge stage**: a workload that reads
+several inputs and emits one stream. That is itself a workload the fleet can
+express, so nothing is lost except the illusion that stdin could carry it.
+
+Two consequences worth knowing before you hit them:
+
+- An edge consumes the input slot, so a workload fed by an edge **cannot also
+  take operator stdin**. That is an admission error you can read, not a runtime
+  race for the lease.
+- **Iteration is not expressible.** A workflow needing a loop re-invokes the
+  graph from outside, which keeps termination and provenance intact.
+
+## The topology is a DAG
+
+Cycles are rejected before anything boots.
+
+A cycle breaks EOF propagation: nothing downstream of itself ever sees its
+producer close, so it never closes either. With lossy eviction it does not even
+deadlock into something obvious — it degrades into a silently churning loop
+that looks like work. And every edge hash-chains, so a cycle leaves no order in
+which to ask what a workload saw.
+
+Because fan-in is refused first, every consumer has at most one inbound edge —
+which means a cycle can only ever be an isolated loop. Entering one from
+outside gives the entry node two writers, and is reported as fan-in.
+
+## When a consumer falls behind
+
+**The producer never stalls.** A workload whose behaviour changes because
+someone is reading it slowly is a workload you cannot reason about, so that is
+not allowed to happen. The reader's queue is bounded and evicts on its own; the
+mode decides how the edge *reacts* to that loss.
+
+| Mode | On loss |
+| --- | --- |
+| `lossy` (default) | Marks the gap and carries on. The consumer's operator can see the stream has a hole. |
+| `reliable` | Fails the edge, loudly. |
+
+`reliable` does not mean "buffers more". A mode with that name must never
+quietly drop a record, so when it cannot hold one it stops being an edge rather
+than becoming a lossy one under a reassuring name. Recovery is to re-run the
+workflow.
+
+## A broken edge fails the workflow
+
+An edge does not silently reconnect across a consumer restart.
+
+Reconnection is not free. The gate builds a fresh secret scanner per session,
+so a secret split across the restart boundary would be scanned by two scanners
+with neither seeing the whole — the exact hole this project has refused to open
+elsewhere. Surviving a restart also means buffering on the producer for an
+unbounded interval, which breaks the bounded-memory guarantee that keeps the
+producer unstalled in the first place.
+
+Workflows already have a supervisor; re-running the graph is the right recovery
+at the right layer. The edge records its last delivered sequence in the
+chain-signed log, so a re-run is something you reason about rather than guess
+at.
+
+## What an edge does not give you
+
+- **Not a channel.** Bytes flow one way, into stdin. There is no reply path.
+- **Not ordered across sources.** One edge is one producer; ordering between
+  two different producers is not something the transport can offer.
+- **Not exactly-once.** `lossy` marks gaps and `reliable` fails; neither
+  replays.
+- **Not a claim.** See below.
+
+## Security posture
+
+An edge is a different authorization shape from a per-plan grant, and it is
+**not** covered by a numbered security claim today.
+
+What holds by construction, and is tested:
+
+- A guest cannot address another guest. It names a binding; the host resolves
+  it.
+- Neither workload gains a network interface, and no workload path grows a tap
+  or a gateway. Both vsock gates cover this.
+- A raw edge is refused rather than served masked bytes.
+- Duplicate bindings, fan-in and cycles are refused before boot.
+- Defaults are the safe ones, and a plan written before edges existed cannot
+  acquire a raw edge by omission.
+
+What is **not** claimed:
+
+- That the refusals fire in production. They have no caller in `mvm`; `mvmd`
+  is expected to call them, and until it does they are declared dormant in
+  `xtask/dormant-controls.toml` so CI notices if that changes.
+- Anything about a consumer's handling of what it receives. An edge delivers
+  bytes to stdin; what the workload does with them is the workload's business.
+
+Claim 17 (the workload input plane) stays at `Preview`. An edge would be its
+second production caller, and reassessing that is deferred until one exists —
+promoting a claim on the strength of a caller that has not been written is the
+drift this project's gates exist to prevent.
+
+## See also
+
+- [Workload output streaming](/guides/workload-output-streaming/)
+- [Workload input](/guides/workload-input/)

--- a/specs/adrs/035-workload-stream-plane.md
+++ b/specs/adrs/035-workload-stream-plane.md
@@ -487,6 +487,54 @@ increasing loss markers keeps re-anchor control. That is fine and in scope —
 ADR-001 puts a malicious host outside the threat model — but it should not be
 read as a defence it is not.
 
+## Stream edges: what they guarantee, and what they do not
+
+An edge connects one workload's output to another's stdin. It is a different
+authorization shape from the per-plan input grant, so it is deliberately **not
+claim 17 with more rows**, and it carries no numbered claim of its own.
+
+### Holds by construction, and is tested
+
+- **A guest never addresses another guest.** The consumer's plan names a
+  binding; the host resolves it. Neither workload learns the other's identity,
+  and neither can enumerate the fleet by guessing names — an ungranted binding
+  and a nonexistent one give the same refusal.
+- **No new path out of a guest.** Bytes cross inside the host between two
+  independent vsock channels. No workload path gains a NIC, a tap or a gateway,
+  and both `xtask` vsock gates cover the code that would.
+- **Refused before boot:** a duplicate binding, fan-in, a cycle of any length,
+  and an edge on a workload that also takes operator stdin.
+- **A raw edge is refused, not downgraded.** Redaction runs before hashing, so
+  no unmasked copy survives to a reader. Serving masked bytes under a fidelity
+  label would leave a consumer computing on the mask while believing it had the
+  value.
+- **Defaults are safe and cannot be lost by omission.** Both postures are
+  serde-defaulted, so a plan written before the field existed deserializes to
+  redacted and lossy.
+- **The producer cannot be stalled by a consumer.** Inherited from the reader's
+  bounded queue rather than re-implemented, and re-verified at the edge.
+
+### Not claimed
+
+- **That any of it fires in production.** None of these refusals has a caller
+  in this repository, and will not: `mvmd` declares the edges. They are
+  declared dormant in `xtask/dormant-controls.toml`, and the gate fails if that
+  stops being true in either direction. A refusal with no caller is a refusal
+  that has never refused anything.
+- **Anything about what a consumer does with the bytes.** An edge delivers to
+  stdin. Downstream handling is the consumer workload's business and is covered
+  by whatever claims apply to that workload.
+- **Exactly-once delivery.** `lossy` marks gaps, `reliable` fails the edge;
+  neither replays.
+
+### Claim 17 stays at `Preview`
+
+An edge would be the input plane's second production caller, and the question
+of whether that is enough to promote claim 17 is deferred until one exists.
+Promoting on the strength of a caller nobody has written is exactly the drift
+the ledger gates exist to catch — the claim would be true of code, and false of
+the system.
+
 ## Alternatives rejected
 
 **Route stdio through `tracing`.** Rejected: framing, and inventing metadata

--- a/specs/plans/296-fleet-stream-fan-out.md
+++ b/specs/plans/296-fleet-stream-fan-out.md
@@ -1,6 +1,6 @@
 # Plan 296 — fleet stream fan-out
 
-**Status:** WS1–WS4 landed. WS5 + WS6 outstanding.
+**Status:** Complete. WS1–WS6 landed.
 
 `mvm` ships the mechanism; `mvmd` declares the edges and resolves the bindings.
 That split is why the landed half has **no production caller in this
@@ -116,12 +116,30 @@ Two consequences worth stating plainly, because they will surprise someone:
   producer — that invariant is inherited and must be re-verified here, not
   assumed.
 
-- [ ] **WS5 — claim work.** An edge is a different authorization shape than a
+- [x] **WS5 — claim work.** Landed. ADR-035 gains a section stating what an
+  edge guarantees by construction (no guest addresses another, no new path out
+  of a guest, the four pre-boot refusals, raw refused rather than downgraded,
+  safe defaults that cannot be lost by omission, producer never stalled) and
+  what it does not — chiefly that **none of those refusals has fired in
+  production**, because none has a caller here. They are dormant by
+  declaration, and the gate now enforces that in both directions.
+
+  Claim 17 stays `Preview`. An edge would be the input plane's second
+  production caller and the promotion question is deferred until one exists;
+  promoting on a caller nobody has written would make the claim true of code
+  and false of the system. Why it existed: An edge is a different authorization shape than a
   per-plan grant, so this is not claim 17 with more rows. State what an edge
   guarantees, what it does not, and witness it. Reassess whether the input plane
   can leave `Preview` once it has a second production caller.
 
-- [ ] **WS6 — docs.** How a fleet declares edges, what redaction does to data in
+- [x] **WS6 — docs.** Landed as `guides/fleet-stream-edges`, wired into the
+  sidebar: how a consumer names a binding rather than a VM, what the two
+  redaction postures mean and why `raw` needs an operator acknowledgement it
+  cannot get from a plan signature, why fan-in is a merge stage, why the
+  topology is a DAG, what each backpressure mode does when a consumer falls
+  behind, and why a broken edge fails the workflow instead of reconnecting. It
+  opens by saying the surface has no CLI driver yet, so a reader is not left
+  hunting for a command that does not exist. Why it existed: How a fleet declares edges, what redaction does to data in
   flight, why fan-in is a merge node, and what happens when a consumer falls
   behind under each mode.
 


### PR DESCRIPTION
Closes plan 296 (WS5 + WS6). Docs and posture only — no code changes.

## WS5 — what an edge guarantees, and what it does not

ADR-035 gains a section for stream edges. It is deliberately **not claim 17 with more rows**: an edge is a different authorization shape from a per-plan grant, and it carries no numbered claim of its own.

**Holds by construction, and is tested:** a guest never addresses another guest (it names a binding, the host resolves it, and an ungranted binding is indistinguishable from a nonexistent one); no workload path gains a NIC, tap or gateway; four refusals land before boot (duplicate binding, fan-in, cycles of any length, edge-plus-operator-stdin); a raw edge is refused rather than downgraded to masked bytes under a fidelity label; both postures are serde-defaulted so a pre-edge plan cannot acquire a raw edge by omission; the producer cannot be stalled by a slow consumer.

**Not claimed — the part worth reading:** none of those refusals has fired in production, because none has a caller in this repository. `mvmd` declares the edges. They are dormant by declaration in `xtask/dormant-controls.toml`, and the gate enforces that in both directions. A refusal with no caller has never refused anything, and a posture section implying otherwise is exactly the drift the ledger gates exist to catch.

**Claim 17 stays `Preview`.** An edge would be the input plane's second production caller, and the promotion question is deferred until one exists. Promoting on the strength of a caller nobody has written would make the claim true of code and false of the system.

## WS6 — the guide

`guides/fleet-stream-edges`, wired into the sidebar. Covers what a fleet author hits in practice: binding names rather than VM names and why that indirection is what keeps this from being guest networking; the two redaction postures and why `raw` needs `MVM_ACK_RAW_STREAM_EDGE` that a plan signature cannot supply; why fan-in is a merge stage rather than a limitation; why a cycle can only ever be an isolated loop once fan-in is refused first; what `lossy` and `reliable` each do when a consumer falls behind, and why `reliable` fails rather than buffering; and why a broken edge fails the workflow instead of silently reconnecting across a fresh secret scanner.

It opens by saying no CLI drives this yet, so a reader is not left hunting for a command that does not exist.

## Verification

Eight xtask gates green, including `check-no-overclaim`, `check-doc-claims`, `check-witness-citations`, `check-claim-catalog` and `check-adr-coverage` — the ones that would fire on claim prose asserting more than the tree supports.
