### PR TITLE
feat(hostd,cli,client): runtime emission of ExecutionReceipts (WS4)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -534,7 +534,7 @@ pub(crate) fn bind_checkpoint_created(name: &str, meta: &mvm_core::checkpoint::C
         }
     };
     let emitter = match super::audit_chain::AuditEmitter::new(signer.signing) {
-        Ok(e) => e,
+        Ok(e) => e.with_receipts(),
         Err(e) => {
             tracing::warn!(error = %e, "audit emitter unavailable; chain entry skipped");
             return;
@@ -1461,6 +1461,7 @@ pub(crate) fn bind_checkpoint_forked(
         }
     };
     let emitter = super::audit_chain::AuditEmitter::new(signer.signing)
+        .map(|e| e.with_receipts())
         .context("refusing an unaudited fork: audit emitter unavailable")?;
     mvm_hostd::audit::bind::bind_checkpoint_forked(&emitter, &plan, parent, child, child_vm_name)
         .context("refusing an unaudited fork")?;

--- a/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
@@ -461,6 +461,7 @@ fn emit_image_revert_audit(node: &ImageNode, via: RevertVia, reference: &str) ->
         }
     };
     let emitter = crate::commands::vm::audit_chain::AuditEmitter::new(signer.signing)
+        .map(|e| e.with_receipts())
         .context("refusing an unaudited image restore: audit emitter unavailable")?;
     // The node's content-address is always a valid 64-hex digest — bind the
     // event plan's image to it so synthesis can never reject a genuine node.
@@ -643,6 +644,7 @@ fn emit_revert_audit(
         }
     };
     let emitter = crate::commands::vm::audit_chain::AuditEmitter::new(signer.signing)
+        .map(|e| e.with_receipts())
         .context("refusing an unaudited restore: audit emitter unavailable")?;
     mvm_hostd::audit::bind::bind_checkpoint_restored(
         &emitter,

--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -448,7 +448,7 @@ pub(in crate::commands::vm) fn admit_plan_for_boot(
         p.audit_dir,
         resolved.audit.as_ref(),
     ) {
-        Ok(emitter) => emitter,
+        Ok(emitter) => emitter.with_receipts(),
         Err(err) => {
             let err = err.context("opening audit chain emitter");
             match build_default_audit_emitter(signer.signing, p.audit_dir) {

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -96,7 +96,7 @@ fn build_audit_emitter() -> Option<AuditEmitter> {
         }
     };
     match AuditEmitter::new(signer.signing) {
-        Ok(emitter) => Some(emitter),
+        Ok(emitter) => Some(emitter.with_receipts()),
         Err(e) => {
             tracing::warn!(error = %e, "audit emitter unavailable; skipping chain audit emission");
             None

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -38,6 +38,8 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::audit::receipt_export::audit_entry_to_receipt;
+use crate::audit::receipt_store::ReceiptStore;
 use crate::supervisor::{AuditEntry, AuditSigner, FileAuditSigner};
 use anyhow::{Context, Result};
 use base64::Engine;
@@ -45,6 +47,8 @@ use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use ed25519_dalek::{Signer, SigningKey};
 use mvm_contract::merkle::{SignedAuditRoot, root_signing_bytes};
 use mvm_core::plan::ExecutionPlan;
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 /// Wire-stable event names and label keys for the checkpoint audit entries.
 /// Shared so the emitter (writer) and the lineage chain-anchor (reader) can't
@@ -314,6 +318,8 @@ pub struct AuditEmitter {
     signers: Vec<FileAuditSigner>,
     signing_key: SigningKey,
     audit_dir: PathBuf,
+    receipts_enabled: bool,
+    receipt_stores: Mutex<HashMap<String, ReceiptStore>>,
 }
 
 impl AuditEmitter {
@@ -350,6 +356,8 @@ impl AuditEmitter {
             signers: vec![signer],
             signing_key,
             audit_dir: audit_dir.to_path_buf(),
+            receipts_enabled: false,
+            receipt_stores: Mutex::new(HashMap::new()),
         })
     }
 
@@ -389,6 +397,14 @@ impl AuditEmitter {
             emitter.signers.push(signer);
         }
         Ok(emitter)
+    }
+
+    /// Enable runtime emission of signed [`ExecutionReceipt`]s alongside
+    /// audit events. Receipts are stored under
+    /// `<audit_dir>/receipts/<tenant>/` and chained via `prev_receipt_id`.
+    pub fn with_receipts(mut self) -> Self {
+        self.receipts_enabled = true;
+        self
     }
 
     /// Emit `plan.admitted` — fires immediately after `admit_for_run`
@@ -873,7 +889,82 @@ impl AuditEmitter {
             rt.block_on(signer.sign_and_emit(entry))
                 .with_context(|| format!("signing-and-emitting audit event {}", entry.event))?;
         }
+        self.emit_receipt_for_entry(entry);
         Ok(())
+    }
+
+    /// Best-effort emission of a signed [`ExecutionReceipt`] for an audit
+    /// entry. Errors are logged and swallowed: receipts are a derived cache
+    /// and must never block the primary audit emit.
+    fn emit_receipt_for_entry(&self, entry: &AuditEntry) {
+        if !self.receipts_enabled {
+            return;
+        }
+        let tenant = entry.tenant.0.clone();
+        let store = match self.receipt_store_for_tenant(&tenant) {
+            Some(s) => s,
+            None => return,
+        };
+        let host_did =
+            mvm_core::did_key::DidKey::from_verifying_key(self.signing_key.verifying_key())
+                .to_did_key();
+        let mut receipt = match audit_entry_to_receipt(entry, &host_did) {
+            Some(r) => r,
+            None => return,
+        };
+        let head = match store.head() {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::warn!(event = entry.event, error = %e, "failed to read receipt store head");
+                return;
+            }
+        };
+        receipt.prev_receipt_id = head.last_receipt_id;
+        receipt.receipt_id = match receipt.compute_id() {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::warn!(event = entry.event, error = %e, "failed to compute receipt id");
+                return;
+            }
+        };
+        let signed_at = chrono::Utc::now().to_rfc3339();
+        let signed = match mvm_core::receipt::SignedExecutionReceipt::sign(
+            receipt,
+            &self.signing_key,
+            signed_at,
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(event = entry.event, error = %e, "failed to sign execution receipt");
+                return;
+            }
+        };
+        if let Err(e) = store.append(&signed) {
+            tracing::warn!(event = entry.event, error = %e, "failed to append execution receipt");
+        }
+    }
+
+    /// Return the cached receipt store for `tenant`, creating it on first
+    /// use. Returns `None` if the store cannot be opened.
+    fn receipt_store_for_tenant(&self, tenant: &str) -> Option<ReceiptStore> {
+        {
+            let stores = self.receipt_stores.lock().ok()?;
+            if let Some(store) = stores.get(tenant) {
+                return Some(store.clone());
+            }
+        }
+        let store = match ReceiptStore::open(&self.audit_dir, tenant) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(tenant, error = %e, "failed to open receipt store");
+                return None;
+            }
+        };
+        {
+            let mut stores = self.receipt_stores.lock().ok()?;
+            stores.insert(tenant.to_string(), store.clone());
+        }
+        Some(store)
     }
 }
 
@@ -1804,5 +1895,135 @@ mod tests {
         assert!(emitter.publish_root("local").is_err());
         // And no partial sidecar was left behind.
         assert!(!dir.path().join("local.root.json").exists());
+    }
+
+    #[test]
+    fn receipts_disabled_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-no-receipts");
+        emitter.emit_admitted(&plan, "host:test").unwrap();
+
+        assert!(!dir.path().join("receipts").exists());
+    }
+
+    #[test]
+    fn receipts_emitted_when_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let emitter = AuditEmitter::with_dir(key, dir.path())
+            .unwrap()
+            .with_receipts();
+        let plan = fixture_plan("local", "plan-with-receipts");
+        emitter.emit_admitted(&plan, "host:test").unwrap();
+        emitter.emit_launched(&plan, "firecracker").unwrap();
+
+        let receipt_dir = dir.path().join("receipts").join("local");
+        assert!(receipt_dir.exists());
+        let entries: Vec<_> = std::fs::read_dir(&receipt_dir)
+            .unwrap()
+            .filter_map(|e| {
+                let e = e.ok()?;
+                let name = e.file_name().into_string().ok()?;
+                if name.ends_with(".json") && !name.starts_with("head") {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(entries.len(), 2, "two receipt files expected: {entries:?}");
+
+        let head_path = receipt_dir.join("head.json");
+        assert!(head_path.exists());
+    }
+
+    #[test]
+    fn receipt_chain_continuity_across_emits() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let emitter = AuditEmitter::with_dir(key, dir.path())
+            .unwrap()
+            .with_receipts();
+        let plan = fixture_plan("local", "plan-chain");
+        emitter.emit_admitted(&plan, "host:test").unwrap();
+        emitter.emit_launched(&plan, "firecracker").unwrap();
+
+        let receipt_dir = dir.path().join("receipts").join("local");
+        let mut files: Vec<_> = std::fs::read_dir(&receipt_dir)
+            .unwrap()
+            .filter_map(|e| {
+                let e = e.ok()?;
+                let name = e.file_name().into_string().ok()?;
+                if name.ends_with(".json") && !name.starts_with("head") {
+                    Some((name, e.path()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        files.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(files.len(), 2);
+
+        let first: mvm_core::receipt::SignedExecutionReceipt =
+            serde_json::from_slice(&std::fs::read(&files[0].1).unwrap()).unwrap();
+        let second: mvm_core::receipt::SignedExecutionReceipt =
+            serde_json::from_slice(&std::fs::read(&files[1].1).unwrap()).unwrap();
+
+        first.verify().expect("first receipt verifies");
+        second.verify().expect("second receipt verifies");
+        assert_eq!(
+            second.payload.prev_receipt_id,
+            Some(first.payload.receipt_id.clone()),
+            "second receipt must link to first"
+        );
+    }
+
+    #[test]
+    fn checkpoint_receipts_emitted_when_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let emitter = AuditEmitter::with_dir(key, dir.path())
+            .unwrap()
+            .with_receipts();
+        let plan = fixture_plan("local", "plan-chk");
+        emitter
+            .emit_checkpoint_created(&plan, "chk-1", "vm_full", "sha256:abc123", "vm-1")
+            .unwrap();
+
+        let receipt_dir = dir.path().join("receipts").join("local");
+        let files: Vec<_> = std::fs::read_dir(&receipt_dir)
+            .unwrap()
+            .filter_map(|e| {
+                let e = e.ok()?;
+                let name = e.file_name().into_string().ok()?;
+                if name.ends_with(".json") && name.contains("checkpoint.created") {
+                    Some(e.path())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(files.len(), 1);
+        let signed: mvm_core::receipt::SignedExecutionReceipt =
+            serde_json::from_slice(&std::fs::read(&files[0]).unwrap()).unwrap();
+        signed.verify().expect("checkpoint receipt verifies");
     }
 }

--- a/crates/mvm-hostd/src/audit/mod.rs
+++ b/crates/mvm-hostd/src/audit/mod.rs
@@ -12,3 +12,5 @@ pub mod plan_persist;
 /// Read-only exporter from chain-signed audit entries to signed
 /// ExecutionReceipts.
 pub mod receipt_export;
+/// Persistent store for runtime-emitted signed ExecutionReceipts.
+pub mod receipt_store;

--- a/crates/mvm-hostd/src/audit/receipt_store.rs
+++ b/crates/mvm-hostd/src/audit/receipt_store.rs
@@ -1,0 +1,274 @@
+//! Persistent store for runtime-emitted execution receipts.
+//!
+//! Receipts are a derived, content-addressed cache alongside the chain-signed
+//! audit log. The audit log remains the source of truth; this store only
+//! holds already-signed [`ExecutionReceipt`]s so they can be re-exported or
+//! verified offline without recomputing them from the audit chain.
+//!
+//! Layout under the audit directory:
+//!
+//! ```text
+//! <audit_dir>/receipts/<tenant>/
+//!   head.json          { "last_receipt_id": "sha256:...", "sequence": N }
+//!   <seq>-<type>.json  one signed receipt per file
+//! ```
+//!
+//! Each receipt's `prev_receipt_id` points at the previous receipt emitted
+//! for the same tenant, forming a host-signer chain. Updates to `head.json`
+//! and receipt files are made under a per-tenant file lock so concurrent
+//! emitters cannot interleave sequences or lose the chain head.
+
+use std::fs::OpenOptions;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use mvm_core::receipt::SignedExecutionReceipt;
+use serde::{Deserialize, Serialize};
+
+/// Head file content: the chain tip for one tenant's receipt store.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct Head {
+    /// `receipt_id` of the most recently stored receipt, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_receipt_id: Option<String>,
+    /// Monotonic sequence number assigned to the most recent receipt.
+    #[serde(default)]
+    sequence: u64,
+}
+
+/// File-backed receipt store for one tenant.
+#[derive(Debug, Clone)]
+pub struct ReceiptStore {
+    tenant_dir: PathBuf,
+    lock_path: PathBuf,
+    head_path: PathBuf,
+}
+
+impl ReceiptStore {
+    /// Open (and create if missing) the receipt store for `tenant` under
+    /// `audit_dir`.
+    pub fn open(audit_dir: &Path, tenant: &str) -> Result<Self> {
+        let tenant_dir = audit_dir.join("receipts").join(tenant);
+        std::fs::create_dir_all(&tenant_dir)
+            .with_context(|| format!("creating receipt dir {}", tenant_dir.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o700);
+            std::fs::set_permissions(&tenant_dir, perms)
+                .with_context(|| format!("setting 0700 on {}", tenant_dir.display()))?;
+        }
+        let lock_path = tenant_dir.join(".lock");
+        let head_path = tenant_dir.join("head.json");
+        Ok(Self {
+            tenant_dir,
+            lock_path,
+            head_path,
+        })
+    }
+
+    /// Append a signed receipt to the store, returning the assigned sequence
+    /// number. The caller is responsible for setting the receipt's
+    /// `prev_receipt_id` to the value returned by [`Self::head`] before
+    /// calling this method; this method only persists the receipt and bumps
+    /// the head.
+    ///
+    /// The write is atomic: the receipt is written to a temp file and
+    /// renamed, and the head is rewritten atomically under the tenant lock.
+    pub fn append(&self, receipt: &SignedExecutionReceipt) -> Result<u64> {
+        let _guard = self.lock()?;
+        let mut head = self.read_head();
+        head.sequence += 1;
+        let seq = head.sequence;
+        let receipt_path = self.receipt_path(seq, &receipt.payload.receipt_type);
+
+        // Write receipt atomically.
+        let tmp_path = receipt_path.with_extension("tmp");
+        let bytes =
+            serde_json::to_vec_pretty(receipt).context("serializing signed execution receipt")?;
+        std::fs::write(&tmp_path, bytes)
+            .with_context(|| format!("writing receipt temp file {}", tmp_path.display()))?;
+        std::fs::rename(&tmp_path, &receipt_path).with_context(|| {
+            format!(
+                "renaming receipt file {} -> {}",
+                tmp_path.display(),
+                receipt_path.display()
+            )
+        })?;
+
+        // Update head atomically.
+        head.last_receipt_id = Some(receipt.payload.receipt_id.clone());
+        self.write_head(&head)?;
+
+        Ok(seq)
+    }
+
+    /// Return the current chain head for this tenant.
+    pub fn head(&self) -> Result<ReceiptHead> {
+        let _guard = self.lock()?;
+        let head = self.read_head();
+        Ok(ReceiptHead {
+            last_receipt_id: head.last_receipt_id,
+            sequence: head.sequence,
+        })
+    }
+
+    /// Return the path that would be used for sequence `seq` and receipt
+    /// type `receipt_type`.
+    pub fn receipt_path(&self, seq: u64, receipt_type: &str) -> PathBuf {
+        self.tenant_dir
+            .join(format!("{seq:0>8}-{receipt_type}.json"))
+    }
+
+    fn read_head(&self) -> Head {
+        if !self.head_path.exists() {
+            return Head::default();
+        }
+        std::fs::read_to_string(&self.head_path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<Head>(&s).ok())
+            .unwrap_or_default()
+    }
+
+    fn write_head(&self, head: &Head) -> Result<()> {
+        let tmp_path = self.head_path.with_extension("tmp");
+        let bytes = serde_json::to_vec_pretty(head).context("serializing receipt head")?;
+        std::fs::write(&tmp_path, bytes)
+            .with_context(|| format!("writing head temp file {}", tmp_path.display()))?;
+        std::fs::rename(&tmp_path, &self.head_path).with_context(|| {
+            format!(
+                "renaming head file {} -> {}",
+                tmp_path.display(),
+                self.head_path.display()
+            )
+        })?;
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn lock(&self) -> Result<LockGuard> {
+        use std::os::fd::AsRawFd;
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&self.lock_path)
+            .with_context(|| format!("opening lock file {}", self.lock_path.display()))?;
+        let fd = file.as_raw_fd();
+        // SAFETY: fcntl flock is safe when fd is valid and we hold the file
+        // object for the lifetime of the guard.
+        unsafe {
+            let mut flock: libc::flock = std::mem::zeroed();
+            flock.l_type = libc::F_WRLCK as _;
+            flock.l_whence = libc::SEEK_SET as _;
+            if libc::fcntl(fd, libc::F_SETLKW, &flock) != 0 {
+                anyhow::bail!("failed to acquire receipt store lock");
+            }
+        }
+        Ok(LockGuard { _file: file })
+    }
+
+    #[cfg(not(unix))]
+    fn lock(&self) -> Result<LockGuard> {
+        // Non-Unix platforms get a best-effort guard with no locking.
+        Ok(LockGuard)
+    }
+}
+
+/// Snapshot of a receipt store's chain head.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReceiptHead {
+    /// `receipt_id` of the most recently stored receipt, if any.
+    pub last_receipt_id: Option<String>,
+    /// Sequence number of the most recently stored receipt.
+    pub sequence: u64,
+}
+
+#[cfg(unix)]
+struct LockGuard {
+    _file: std::fs::File,
+}
+
+#[cfg(not(unix))]
+struct LockGuard;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use mvm_core::did_key::DidKey;
+    use mvm_core::receipt::{
+        ExecutionReceipt, ReceiptAction, ReceiptOutcome, SignedExecutionReceipt, receipt_type,
+    };
+    use std::collections::BTreeMap;
+
+    fn sample_receipt(prev: Option<String>, seq: u64) -> SignedExecutionReceipt {
+        let signing_key = SigningKey::from_bytes(&[seq as u8; 32]);
+        let host_did = DidKey::from_verifying_key(signing_key.verifying_key()).to_did_key();
+        let mut receipt = ExecutionReceipt {
+            schema_version: 1,
+            receipt_id: String::new(),
+            receipt_type: receipt_type::PLAN_ADMITTED.into(),
+            plan_id: format!("sha256:{seq:064x}"),
+            image_node_digest: None,
+            agent_id: None,
+            principal_did: None,
+            host_did,
+            action: ReceiptAction {
+                verb: "run".into(),
+                resource: format!("sha256:{seq:064x}"),
+                params: BTreeMap::new(),
+            },
+            outcome: ReceiptOutcome::Authorized,
+            granted_by: None,
+            prev_receipt_id: prev,
+            issued_at: "2026-08-06T00:00:00+00:00".into(),
+            extensions: BTreeMap::new(),
+        };
+        receipt.receipt_id = receipt.compute_id().unwrap();
+        SignedExecutionReceipt::sign(receipt, &signing_key, "2026-08-06T00:00:00+00:00").unwrap()
+    }
+
+    #[test]
+    fn append_bumps_sequence_and_head() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(dir.path(), "local").unwrap();
+
+        let r1 = sample_receipt(None, 1);
+        let seq1 = store.append(&r1).unwrap();
+        assert_eq!(seq1, 1);
+
+        let head = store.head().unwrap();
+        assert_eq!(head.sequence, 1);
+        assert_eq!(head.last_receipt_id, Some(r1.payload.receipt_id.clone()));
+
+        let r2 = sample_receipt(Some(r1.payload.receipt_id.clone()), 2);
+        let seq2 = store.append(&r2).unwrap();
+        assert_eq!(seq2, 2);
+
+        let head = store.head().unwrap();
+        assert_eq!(head.sequence, 2);
+        assert_eq!(head.last_receipt_id, Some(r2.payload.receipt_id.clone()));
+    }
+
+    #[test]
+    fn receipt_files_are_written_atomically() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(dir.path(), "local").unwrap();
+        let receipt = sample_receipt(None, 3);
+        store.append(&receipt).unwrap();
+
+        let path = store.receipt_path(1, receipt_type::PLAN_ADMITTED);
+        assert!(path.exists());
+        let bytes = std::fs::read(&path).unwrap();
+        let loaded: SignedExecutionReceipt = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(loaded.payload.receipt_id, receipt.payload.receipt_id);
+        assert!(
+            !store
+                .tenant_dir
+                .join("00000001-plan.admitted.json.tmp")
+                .exists()
+        );
+    }
+}

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -306,7 +306,9 @@ for detailed scope and acceptance criteria.
   - [x] WS3 Read-only receipt exporter: `mvmctl trust audit receipts export`
         derives signed `ExecutionReceipt`s from verified chain-signed
         `AuditEntry` events; unit + integration tests pass
-  - [ ] WS4 Runtime emission of receipts
+  - [x] WS4 Runtime emission of receipts: `AuditEmitter::with_receipts()`
+        persists signed `ExecutionReceipt`s alongside chain-signed audit
+        events; per-tenant receipt store with `prev_receipt_id` continuity
   - [ ] WS5 Conformance badge generator
   - [ ] WS6 Documentation and registry conventions
 >>>>>>> 9e46d0c4e (docs: RFC for NANDA-style execution receipts and conformance badges)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -144,12 +144,14 @@
 
 - [~] NANDA-style execution receipts and conformance badges — **plan 298**
       (`specs/plans/298-nanda-receipts-and-conformance-badges.md`). WS1 RFC
-      approved, WS2 core types landed in `mvm-core`, and WS3 read-only receipt
-      exporter landed: `mvmctl trust audit receipts export` converts verified
-      chain-signed `AuditEntry` events into signed `ExecutionReceipt`s. All
-      `mvm-core` / `mvm-hostd` unit tests and integration tests pass; workspace
-      `cargo check` / `cargo clippy` are clean. WS4–WS6 (runtime emission,
-      badge generator, docs) are next.
+      approved, WS2 core types landed in `mvm-core`, WS3 read-only receipt
+      exporter landed, and WS4 runtime emission landed: `AuditEmitter` now
+      optionally persists signed `ExecutionReceipt`s under
+      `<audit_dir>/receipts/<tenant>/` with `prev_receipt_id` chain continuity
+      for `plan.admitted` / `plan.launched` / `plan.exited` and checkpoint
+      events. All `mvm-core` / `mvm-hostd` / `mvm-cli` / `mvm-client` unit
+      tests and integration tests pass; workspace `cargo check` / `cargo clippy`
+      are clean. WS5–WS6 (conformance badge generator, docs) are next.
 
 ### mvm-studio local-service wave (issues #2078–#2082; #2083 deferred)
 

--- a/specs/plans/298-nanda-receipts-and-conformance-badges.md
+++ b/specs/plans/298-nanda-receipts-and-conformance-badges.md
@@ -1,6 +1,6 @@
 # NANDA-style execution receipts and conformance badges
 
-**Status:** In progress. WS1–WS3 complete. WS4–WS6 pending.
+**Status:** In progress. WS1–WS4 complete. WS5–WS6 pending.
 
 **Date:** 2026-08-06
 **Owner:** mvm
@@ -288,17 +288,21 @@ entries into signed `ExecutionReceipt`s.
 **Goal:** Emit `ExecutionReceipt`s alongside `AuditEmitter` for
 admission/launch/exit/checkpoint events.
 
-- [ ] Extend `AuditEmitter` to optionally emit receipts.
-- [ ] Wire receipt emission into `plan.admitted`, `plan.launched`, `plan.exited`,
+- [x] Extend `AuditEmitter` to optionally emit receipts.
+- [x] Wire receipt emission into `plan.admitted`, `plan.launched`, `plan.exited`,
       and checkpoint events.
-- [ ] Ensure existing audit tests still pass.
-- [ ] Add receipt chain continuity tests.
+- [x] Ensure existing audit tests still pass.
+- [x] Add receipt chain continuity tests.
 
-**Files likely touched:**
+**Files touched:**
 
+- `crates/mvm-hostd/src/audit/receipt_store.rs` (new)
+- `crates/mvm-hostd/src/audit/mod.rs`
 - `crates/mvm-hostd/src/audit/emitter.rs`
-- `crates/mvm-runtime/src/workload_runner/runner.rs`
-- `crates/mvm-cli/src/commands/machine/runtime.rs`
+- `crates/mvm-cli/src/commands/vm/up/admission.rs`
+- `crates/mvm-cli/src/commands/vm/checkpoint.rs`
+- `crates/mvm-cli/src/commands/vm/checkpoint/revert.rs`
+- `crates/mvm-client/src/launch/mod.rs`
 
 ### WS5 — Conformance badge generator
 


### PR DESCRIPTION
Runtime emission of signed ExecutionReceipts alongside chain-signed audit entries. Receipts are derived from the same audit events, stored per-tenant, and chained via prev_receipt_id. Emission is best-effort and does not block audit writes. Follows the receipt types and did:key codec landed in #2227.