### PR TITLE
feat(secrets): mvm-side primitives for the tenant-secrets egress broker (RemoteResolver + pluggable backend)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -415,6 +415,12 @@ mvm-runtime = { workspace = true, default-features = false }
 mvm-build = { workspace = true, default-features = false }
 mvm-agentd.workspace = true
 mvm-cli = { workspace = true, default-features = false }
+# mvmd's tenant-secrets vault (Phase 1 egress broker, plan 202-remote-resolver)
+# needs `EndpointConfig`/`assemble`/`FileBindingStore` to spawn a per-VM
+# substitution endpoint. `default = []` already on mvm-hostd, so this is a
+# no-op feature-wise; it's already in the graph transitively via mvm-cli
+# (`mvmctl secret set`), this just names it at the facade root too.
+mvm-hostd.workspace = true
 anyhow.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/mvm-backends/src/legacy/hvf.rs
+++ b/crates/mvm-backends/src/legacy/hvf.rs
@@ -234,6 +234,8 @@ fn spawn_hvf_gating_endpoint_if_needed(
         tls_intermediate: None,
         network_policy: Some(network_policy),
         raw_egress: secrets.is_empty(),
+        resolver_remote: None,
+        binding_store_dir: None,
     })?;
     Ok((EndpointGuard::new(vm_name), Some(socket)))
 }

--- a/crates/mvm-backends/src/legacy/libkrun.rs
+++ b/crates/mvm-backends/src/legacy/libkrun.rs
@@ -94,6 +94,8 @@ fn spawn_libkrun_egress_endpoint_if_needed(
         tls_intermediate: None,
         network_policy: Some(network_policy),
         raw_egress: secrets.is_empty(),
+        resolver_remote: None,
+        binding_store_dir: None,
     })?;
     Ok(EndpointGuard::new(vm_name))
 }

--- a/crates/mvm-core/src/substitution_wire.rs
+++ b/crates/mvm-core/src/substitution_wire.rs
@@ -47,6 +47,31 @@ pub enum WireResponse {
     },
 }
 
+/// A `SecretResolver` request over the fleet secret-resolution socket
+/// (mvmd's tenant vault, or the standalone `mvm-substitution-endpoint`'s
+/// local fallback): resolve `name` to its raw credential value, bound to
+/// `allowed_hosts` for this workload. `auth_type` is the snake_case
+/// `AuthType` label (kept as a bare string here so `mvm-core` doesn't need
+/// to depend on `mvm-sdk`'s IR).
+///
+/// `deny_unknown_fields` fails closed on an unexpected field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResolveWireRequest {
+    pub name: String,
+    pub allowed_hosts: Vec<String>,
+    pub auth_type: String,
+}
+
+/// The resolver's reply: the resolved value (base64) or a refusal. A
+/// refusal never carries a secret.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum ResolveWireResponse {
+    Ok { value_b64: String },
+    Refused { message: String },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -96,6 +121,53 @@ mod tests {
     #[test]
     fn wire_response_refused_uses_snake_case_tag() {
         let json = serde_json::to_string(&WireResponse::Refused {
+            message: "x".into(),
+        })
+        .unwrap();
+        assert!(json.contains(r#""result":"refused""#), "got: {json}");
+    }
+
+    #[test]
+    fn resolve_wire_request_roundtrips() {
+        let req = ResolveWireRequest {
+            name: "openai".into(),
+            allowed_hosts: vec!["api.openai.com".into()],
+            auth_type: "bearer".into(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ResolveWireRequest>(&json).unwrap(),
+            req
+        );
+    }
+
+    #[test]
+    fn resolve_wire_request_rejects_unknown_fields() {
+        let bad = r#"{"name":"openai","allowed_hosts":[],"auth_type":"bearer","evil":1}"#;
+        assert!(serde_json::from_str::<ResolveWireRequest>(bad).is_err());
+    }
+
+    #[test]
+    fn resolve_wire_response_tagged_roundtrip() {
+        for resp in [
+            ResolveWireResponse::Ok {
+                value_b64: "c2stbGl2ZS14eHg=".into(),
+            },
+            ResolveWireResponse::Refused {
+                message: "secret not bound".into(),
+            },
+        ] {
+            let json = serde_json::to_string(&resp).unwrap();
+            assert_eq!(
+                serde_json::from_str::<ResolveWireResponse>(&json).unwrap(),
+                resp
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_wire_response_refused_uses_snake_case_tag() {
+        let json = serde_json::to_string(&ResolveWireResponse::Refused {
             message: "x".into(),
         })
         .unwrap();

--- a/crates/mvm-core/src/substitution_wire.rs
+++ b/crates/mvm-core/src/substitution_wire.rs
@@ -12,6 +12,8 @@
 //! `body_b64` is base64 so the JSON stays compact and binary-safe; callers
 //! encode/decode at the edges.
 
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 
 /// A request the guest routed to the substitution endpoint. A header value may
@@ -65,11 +67,30 @@ pub struct ResolveWireRequest {
 
 /// The resolver's reply: the resolved value (base64) or a refusal. A
 /// refusal never carries a secret.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// `Debug` is hand-written (not derived): the `Ok` variant's `value_b64` is
+/// the raw credential, base64-encoded but otherwise unprotected, so a
+/// derived `Debug` would print it verbatim into any log or panic message
+/// that formats this type. See [`fmt::Debug for ResolveWireResponse`].
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "result", rename_all = "snake_case")]
 pub enum ResolveWireResponse {
     Ok { value_b64: String },
     Refused { message: String },
+}
+
+impl fmt::Debug for ResolveWireResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ResolveWireResponse::Ok { .. } => f
+                .debug_struct("Ok")
+                .field("value_b64", &"<redacted>")
+                .finish(),
+            ResolveWireResponse::Refused { message } => {
+                f.debug_struct("Refused").field("message", message).finish()
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -172,5 +193,24 @@ mod tests {
         })
         .unwrap();
         assert!(json.contains(r#""result":"refused""#), "got: {json}");
+    }
+
+    #[test]
+    fn resolve_wire_response_ok_debug_redacts_the_value() {
+        let resp = ResolveWireResponse::Ok {
+            value_b64: "c2stbGl2ZS14eHg=".into(),
+        };
+        let debug = format!("{resp:?}");
+        assert!(!debug.contains("c2stbGl2ZS14eHg="), "leaked value: {debug}");
+        assert!(debug.contains("<redacted>"), "got: {debug}");
+    }
+
+    #[test]
+    fn resolve_wire_response_refused_debug_shows_the_message() {
+        let resp = ResolveWireResponse::Refused {
+            message: "secret not bound".into(),
+        };
+        let debug = format!("{resp:?}");
+        assert!(debug.contains("secret not bound"), "got: {debug}");
     }
 }

--- a/crates/mvm-hostd/src/bin/mvm-substitution-endpoint.rs
+++ b/crates/mvm-hostd/src/bin/mvm-substitution-endpoint.rs
@@ -31,7 +31,7 @@ use tracing::info;
 
 use mvm_hostd::keyholder::secret_placeholder_env;
 use mvm_hostd::supervisor::substitution_endpoint::{
-    EgressMode, EndpointConfig, EndpointHandshake, EndpointTransport, assemble,
+    EgressMode, EndpointConfig, EndpointHandshake, EndpointTransport, ResolverBackend, assemble,
     build_audit_recorder, build_egress_gate, fingerprint_bound_secrets, parse,
 };
 
@@ -167,6 +167,20 @@ fn raw_egress_gate(cfg: &EndpointConfig) -> mvm_runtime::vmm::egress_gate::Egres
     }
 }
 
+/// The one extra Landlock/seccomp grant `Remote` needs beyond `Local`: the
+/// fleet-secrets daemon's UDS path, or `None` when resolving locally. Kept as
+/// a standalone, non-platform-gated function (rather than inlined into
+/// `confine_endpoint`, whose real body is Linux-only) so the `Remote ⇒
+/// Some(uds)` decision is unit-testable on every contributor host, not just
+/// Linux CI — see `ConfinementSpec::substitution_endpoint`'s doc for what this
+/// grants once it reaches the confinement builder.
+fn resolver_uds_path(cfg: &EndpointConfig) -> Option<&std::path::Path> {
+    match &cfg.resolver {
+        ResolverBackend::Local => None,
+        ResolverBackend::Remote { uds_path, .. } => Some(uds_path.as_path()),
+    }
+}
+
 /// Apply mvm's self-confinement (Landlock FS + seccomp-BPF) to the endpoint.
 ///
 /// Linux-only effect; on macOS/Windows the jailer's `confine_self` stub errors,
@@ -184,12 +198,15 @@ fn confine_endpoint(cfg: &EndpointConfig) -> Result<()> {
         resolve_store_dirs(cfg).context("resolve substitution-endpoint store dirs")?;
     // The audit recorder (when the host signer key is present) reads the key
     // and appends to the per-tenant audit log; grant both so the confined
-    // endpoint can chain-sign substitution events.
+    // endpoint can chain-sign substitution events. `resolver_uds_path` widens
+    // the grant with the ONE resolver socket when (and only when) `cfg.resolver`
+    // is `Remote` — `Local` leaves the confinement unchanged.
     let spec = ConfinementSpec::substitution_endpoint(
         secret_dir,
         binding_dir,
         mvm_core::config::mvm_audit_dir(),
         mvm_core::config::mvm_keys_dir(),
+        resolver_uds_path(cfg),
     );
     confine_self(&spec).context("confine substitution endpoint")?;
     info!("substitution endpoint self-confined (landlock + seccomp)");
@@ -199,9 +216,12 @@ fn confine_endpoint(cfg: &EndpointConfig) -> Result<()> {
 /// macOS/Windows: no kernel LSM. The jailer stub errors rather than run
 /// unconfined, so callers on those hosts must not reach it; we no-op so the bin
 /// (and its tests) build and run. Production endpoints only ever run on Linux.
+/// Still calls `resolver_uds_path` (result discarded) so the decision function
+/// is exercised — and therefore testable — on every host, matching the parity
+/// the jailer module keeps for its own types.
 #[cfg(not(target_os = "linux"))]
 fn confine_endpoint(cfg: &EndpointConfig) -> Result<()> {
-    let _ = cfg;
+    let _ = resolver_uds_path(cfg);
     Ok(())
 }
 
@@ -358,6 +378,7 @@ async fn serve_raw(
 mod tests {
     use super::*;
     use mvm_core::plan::{SecretBinding, SecretSource};
+    use std::path::PathBuf;
 
     fn uds_cfg() -> EndpointConfig {
         EndpointConfig {
@@ -380,6 +401,30 @@ mod tests {
                 )],
             )),
             egress_mode: EgressMode::Raw,
+            resolver: ResolverBackend::default(),
+        }
+    }
+
+    /// A minimal `EndpointConfig`, varying only `resolver`, for exercising
+    /// `resolver_uds_path`'s decision logic. Field values otherwise don't
+    /// matter — this test never spawns or serves.
+    fn config_with_resolver(resolver: ResolverBackend) -> EndpointConfig {
+        EndpointConfig {
+            tenant_id: "acme".into(),
+            secrets: vec![],
+            transport: EndpointTransport::Uds {
+                path: PathBuf::from("/tmp/mvm-substitution-endpoint-test.sock"),
+            },
+            redaction: mvm_core::policy::RedactionPolicy::default(),
+            reversible_replacement: mvm_core::policy::ReversibleReplacementPolicy::default(),
+            forward_timeout_secs: 30,
+            secret_store_dir: None,
+            binding_store_dir: None,
+            terminator_listen: None,
+            tls_intermediate: None,
+            network_policy: None,
+            egress_mode: EgressMode::Wire,
+            resolver,
         }
     }
 
@@ -399,5 +444,21 @@ mod tests {
             },
         });
         assert!(!can_skip_substitution_assembly(&cfg));
+    }
+
+    #[test]
+    fn resolver_uds_path_is_none_for_local_backend() {
+        let cfg = config_with_resolver(ResolverBackend::Local);
+        assert!(resolver_uds_path(&cfg).is_none());
+    }
+
+    #[test]
+    fn resolver_uds_path_is_some_for_remote_backend() {
+        let uds = PathBuf::from("/run/mvmd/tenant-vault/resolver.sock");
+        let cfg = config_with_resolver(ResolverBackend::Remote {
+            uds_path: uds.clone(),
+            timeout_secs: 5,
+        });
+        assert_eq!(resolver_uds_path(&cfg), Some(uds.as_path()));
     }
 }

--- a/crates/mvm-hostd/src/jailer/LANDLOCK.md
+++ b/crates/mvm-hostd/src/jailer/LANDLOCK.md
@@ -33,6 +33,37 @@ Everything else returns EACCES at the kernel level. passt's sockets
 are inherited fds, not opened by name, so no network paths appear in
 the ruleset.
 
+## `mvm-substitution-endpoint` — resolver UDS (M3)
+
+`ConfinementSpec::substitution_endpoint(..., resolver_uds)` additionally
+grants `read_write_paths` on the fleet-secrets daemon's UDS path when
+the endpoint's `ResolverBackend` is `Remote { uds_path, .. }` — `Local`
+(`resolver_uds: None`) leaves the ruleset unchanged. Unlike every other
+entry in `read_write_paths` (which are directories), the resolver UDS
+is a socket special file, so it gets the narrower `rw_file_access()`
+bit-set (`ReadFile | WriteFile` only) rather than `rw_bridge_access()`'s
+directory rights — `ReadDir` / `MakeReg` / `Refer` / `RemoveFile` are
+meaningless on a non-directory target and downgrade the whole ruleset
+to `PartiallyEnforced` if requested there (`landlock.rs::apply()`
+branches on `path.is_dir()` for exactly this reason). `MakeSock` is
+deliberately absent — the resolver daemon creates the socket; this
+process only ever `connect()`s to it.
+
+This grant is also, deliberately, **not** filtered through
+`existing_paths()` the way the readable TLS/DNS paths are. `Remote`
+mode is useless without the resolver reachable, so a missing socket
+path should surface as Landlock's own `PathNotFound` (fail-closed) —
+not silently vanish into an empty grant that lets confinement
+"succeed" while `Remote` can never resolve anything.
+
+No seccomp change accompanies this grant: `socket` / `connect` / `read`
+/ `write` / `setsockopt` are already unconditionally in the endpoint's
+`allowed_syscalls` (the TLS forward leg's TCP egress already needs
+them), and seccomp here filters by syscall number only — there is no
+per-call AF_UNIX-vs-AF_INET argument predicate to narrow. The
+confinement narrowing for `Remote` is entirely a Landlock (path)
+concern; see `SECCOMP.md` for the syscall table.
+
 ABI v2 (Linux 5.19+) required for the file-execute permission split —
 v1 collapses read + exec into a single bit, which would force us to
 choose between letting the bridge exec into other binaries or

--- a/crates/mvm-hostd/src/jailer/landlock.rs
+++ b/crates/mvm-hostd/src/jailer/landlock.rs
@@ -36,6 +36,24 @@ fn rw_bridge_access() -> BitFlags<AccessFs> {
         | AccessFs::RemoveFile
 }
 
+/// Minimal `AccessFs` bit-set for a non-directory `read_write_paths` entry —
+/// today, only the M3 resolver-UDS grant (`ConfinementSpec::substitution_endpoint`'s
+/// `resolver_uds`, a socket special file, not a directory).
+///
+/// `rw_bridge_access()` above is tuned for the audit-dir's append +
+/// atomic-rename use case and includes directory-only rights (`ReadDir`,
+/// `MakeReg`, `Refer`, `RemoveFile`). Those rights are meaningless — and
+/// unenforceable — on a non-directory target; requesting them there
+/// downgrades the whole ruleset to `PartiallyEnforced`, which the fail-closed
+/// check in `apply()` refuses outright. `connect()`-ing to (and then
+/// reading/writing) an already-created UNIX domain socket file only needs the
+/// same open-for-read/open-for-write rights a regular file would: `ReadFile`
+/// and `WriteFile`. Notably absent: `MakeSock` — the resolver daemon creates
+/// the socket, this process only ever connects to it.
+fn rw_file_access() -> BitFlags<AccessFs> {
+    AccessFs::ReadFile | AccessFs::WriteFile
+}
+
 pub fn apply(spec: &ConfinementSpec) -> Result<(), JailerError> {
     let abi = ABI::V2;
     let mut ruleset = Ruleset::default()
@@ -67,8 +85,20 @@ pub fn apply(spec: &ConfinementSpec) -> Result<(), JailerError> {
     }
     for p in &spec.read_write_paths {
         let fd = PathFd::new(p).map_err(|e| path_open_error(p, e))?;
+        // Mirror the readable-paths branch above: directory-only rights
+        // requested on a non-directory target (e.g. the M3 resolver-UDS
+        // socket special file) downgrade the whole ruleset to
+        // `PartiallyEnforced`, which the fail-closed check below refuses.
+        // Grant the full directory rw set on directories (the audit dir's
+        // append + atomic-rename use case) and the narrower file-only set on
+        // non-directories (open-for-connect on the socket file).
+        let access = if p.is_dir() {
+            rw_access
+        } else {
+            rw_file_access()
+        };
         ruleset = ruleset
-            .add_rule(PathBeneath::new(fd, rw_access))
+            .add_rule(PathBeneath::new(fd, access))
             .map_err(|e| JailerError::LandlockApply(format!("{e:?}")))?;
     }
     let status: RestrictionStatus = ruleset
@@ -150,5 +180,22 @@ mod tests {
         assert!(access.contains(AccessFs::MakeReg));
         assert!(access.contains(AccessFs::Refer));
         assert!(access.contains(AccessFs::RemoveFile));
+    }
+
+    /// M3: the resolver-UDS grant must carry only file-open rights — no
+    /// directory-only bit, which would downgrade the whole ruleset to
+    /// `PartiallyEnforced` on the non-directory socket path (see
+    /// `rw_file_access`'s doc).
+    #[test]
+    fn rw_file_access_excludes_directory_only_bits() {
+        let access = rw_file_access();
+        assert!(access.contains(AccessFs::ReadFile));
+        assert!(access.contains(AccessFs::WriteFile));
+        assert!(!access.contains(AccessFs::ReadDir), "ReadDir granted");
+        assert!(!access.contains(AccessFs::MakeReg), "MakeReg granted");
+        assert!(!access.contains(AccessFs::Refer), "Refer granted");
+        assert!(!access.contains(AccessFs::RemoveFile), "RemoveFile granted");
+        assert!(!access.contains(AccessFs::MakeSock), "MakeSock granted");
+        assert!(!access.contains(AccessFs::Execute), "Execute granted");
     }
 }

--- a/crates/mvm-hostd/src/jailer/mod.rs
+++ b/crates/mvm-hostd/src/jailer/mod.rs
@@ -18,7 +18,7 @@
 
 #![cfg_attr(not(target_os = "linux"), allow(dead_code))]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, thiserror::Error)]
 pub enum JailerError {
@@ -99,11 +99,37 @@ impl ConfinementSpec {
     /// reaching it). `existing_paths` filters to paths that exist on this host
     /// — `/etc/pki`, `/etc/resolv.conf`, etc. are distro-dependent, and a
     /// missing readable path makes the Landlock `open` step fail closed.
+    ///
+    /// `resolver_uds` threads in the M2 `ResolverBackend::Remote { uds_path,
+    /// .. }` socket path: `Some(path)` when the endpoint config selects the
+    /// remote fleet-secrets daemon, additionally permitting connect +
+    /// read/write on that ONE socket so `RemoteResolver` can reach it after
+    /// confinement. `None` (the `Local` backend, and the default) leaves the
+    /// confinement identical to before this parameter existed — no socket
+    /// egress at all.
+    ///
+    /// Deliberately **not** run through `existing_paths` like the TLS/DNS
+    /// grants above: `Remote` mode is useless without the resolver reachable,
+    /// so a socket path that doesn't (yet) exist should make Landlock's own
+    /// `PathNotFound` refuse to serve — not silently vanish into an empty
+    /// grant that "succeeds" while leaving `Remote` unable to resolve
+    /// anything. That would be confinement quietly defeating the feature it
+    /// was supposed to permit.
+    ///
+    /// No seccomp change accompanies this: `socket` / `connect` / `read` /
+    /// `write` / `setsockopt` are already unconditionally in this spec's
+    /// `allowed_syscalls` (the same `BRIDGE_SYSCALLS` rows the TLS forward
+    /// leg's TCP egress already relies on) — seccomp here filters by syscall
+    /// number only, with no per-call argument/address-family predicate, so
+    /// there is nothing narrower to add for AF_UNIX specifically. The
+    /// confinement narrowing for `Remote` is entirely a Landlock (path)
+    /// concern.
     pub fn substitution_endpoint(
         secret_store_dir: PathBuf,
         binding_store_dir: PathBuf,
         audit_dir: PathBuf,
         keys_dir: PathBuf,
+        resolver_uds: Option<&Path>,
     ) -> Self {
         #[cfg(target_os = "linux")]
         let allowed_syscalls: Vec<&'static str> = crate::jailer::seccomp::BRIDGE_SYSCALLS
@@ -136,12 +162,20 @@ impl ConfinementSpec {
         let mut readable_paths = vec![secret_store_dir, binding_store_dir, keys_dir];
         readable_paths.extend(tls_dns_paths);
 
+        let mut read_write_paths = existing_paths(vec![audit_dir]);
+        if let Some(uds) = resolver_uds {
+            // NOT filtered by `existing_paths` — see the doc comment above:
+            // this grant must fail closed (via Landlock's `PathNotFound`) if
+            // the socket isn't there, rather than silently drop out.
+            read_write_paths.push(uds.to_path_buf());
+        }
+
         Self {
             // Filter to extant paths: /etc/pki / /etc/resolv.conf are distro-
             // dependent, and Landlock's `open` on a missing path fails closed
             // (PathNotFound), which would abort an otherwise-healthy endpoint.
             readable_paths: existing_paths(readable_paths),
-            read_write_paths: existing_paths(vec![audit_dir]),
+            read_write_paths,
             allowed_syscalls,
         }
     }
@@ -268,6 +302,7 @@ mod tests {
             bindings.clone(),
             store.clone(),
             store.clone(),
+            None,
         );
         assert!(
             spec.readable_paths.iter().any(|p| p == &store),
@@ -289,6 +324,7 @@ mod tests {
             dir.clone(),
             dir.clone(),
             dir.clone(),
+            None,
         );
         assert!(
             spec.read_write_paths.iter().any(|p| p == &dir),
@@ -306,10 +342,79 @@ mod tests {
             missing.clone(),
             missing.clone(),
             missing.clone(),
+            None,
         );
         assert!(
             !spec.readable_paths.iter().any(|p| p == &missing),
             "nonexistent store dir must be filtered out"
+        );
+    }
+
+    /// M3: `Local` (`None`) must leave the confinement byte-for-byte
+    /// identical to before the resolver-UDS grant existed — no socket path
+    /// anywhere in either grant set.
+    #[test]
+    fn substitution_endpoint_spec_local_backend_grants_no_socket() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let spec = ConfinementSpec::substitution_endpoint(
+            dir.clone(),
+            dir.clone(),
+            dir.clone(),
+            dir.clone(),
+            None,
+        );
+        assert_eq!(
+            spec.read_write_paths,
+            vec![dir],
+            "Local must add nothing beyond the audit dir"
+        );
+    }
+
+    /// M3: `Remote { uds_path, .. }` (`Some(uds)`) additionally permits
+    /// connect + read/write on that ONE socket — the exact extra grant this
+    /// task adds, and nothing more.
+    #[test]
+    fn substitution_endpoint_spec_remote_backend_grants_resolver_uds() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let uds = dir.join("Cargo.toml");
+        let spec = ConfinementSpec::substitution_endpoint(
+            dir.clone(),
+            dir.clone(),
+            dir.clone(),
+            dir.clone(),
+            Some(uds.as_path()),
+        );
+        assert!(
+            spec.read_write_paths.contains(&uds),
+            "resolver UDS path must be read-write granted under Remote"
+        );
+        assert_eq!(
+            spec.read_write_paths.len(),
+            2,
+            "exactly audit dir + resolver uds, nothing broader"
+        );
+    }
+
+    /// M3: unlike the best-effort TLS/DNS grants, the resolver UDS grant must
+    /// NOT be silently dropped when the path doesn't exist (yet) — `Remote`
+    /// mode is useless without it, so a missing socket should surface as
+    /// Landlock's own `PathNotFound` (fail-closed) rather than a quietly
+    /// empty grant that lets confinement "succeed" while leaving `Remote`
+    /// unable to resolve anything.
+    #[test]
+    fn substitution_endpoint_spec_keeps_resolver_uds_even_if_missing() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let missing = PathBuf::from("/definitely/not/a/real/resolver/socket/xyzzy.sock");
+        let spec = ConfinementSpec::substitution_endpoint(
+            dir.clone(),
+            dir.clone(),
+            dir.clone(),
+            dir.clone(),
+            Some(missing.as_path()),
+        );
+        assert!(
+            spec.read_write_paths.contains(&missing),
+            "resolver uds path must survive even when absent from disk"
         );
     }
 
@@ -325,6 +430,7 @@ mod tests {
             store.clone(),
             store.clone(),
             store.clone(),
+            None,
         );
         // Thread creation for tokio workers / blocking pool.
         assert!(spec.allowed_syscalls.contains(&"clone"));
@@ -348,6 +454,7 @@ mod tests {
             store.clone(),
             store.clone(),
             store.clone(),
+            None,
         );
         assert!(spec.allowed_syscalls.is_empty());
     }

--- a/crates/mvm-hostd/src/keyholder/mod.rs
+++ b/crates/mvm-hostd/src/keyholder/mod.rs
@@ -26,3 +26,9 @@ pub use substitution::{
     PLACEHOLDER_PREFIX, Placeholder, SignDispatchError, SubstituteError, SubstitutionEndpoint,
     SubstitutionRegistry, find_placeholder,
 };
+
+/// Re-exported so a caller who only depends on `mvm-hostd` (e.g. mvmd,
+/// which registers `SecretBindingMeta`s for a VM's substitution endpoint)
+/// can name `SecretBindingMeta::auth_type`'s type without also taking a
+/// direct `mvm-sdk` dependency edge.
+pub use mvm_sdk::ir::{AuthType, Sigv4Params};

--- a/crates/mvm-hostd/src/keyholder/mod.rs
+++ b/crates/mvm-hostd/src/keyholder/mod.rs
@@ -9,6 +9,7 @@
 pub mod admission;
 pub mod binding;
 pub mod injector;
+pub mod remote_resolver;
 pub mod resolver;
 pub mod signer;
 pub mod sigv4;
@@ -17,6 +18,7 @@ pub mod substitution;
 pub use admission::{AssembleError, HandedPlaceholders, assemble_registry, secret_placeholder_env};
 pub use binding::{BindingStore, FileBindingStore, SecretBindingMeta};
 pub use injector::{InjectError, Injector};
+pub use remote_resolver::RemoteResolver;
 pub use resolver::{LocalResolver, ResolveError, SecretResolver};
 pub use signer::{SigV4Input, SignError, Signature, Signer, SigningInput};
 pub use sigv4::{SigV4BuildError, build_sigv4_input};

--- a/crates/mvm-hostd/src/keyholder/mod.rs
+++ b/crates/mvm-hostd/src/keyholder/mod.rs
@@ -30,5 +30,10 @@ pub use substitution::{
 /// Re-exported so a caller who only depends on `mvm-hostd` (e.g. mvmd,
 /// which registers `SecretBindingMeta`s for a VM's substitution endpoint)
 /// can name `SecretBindingMeta::auth_type`'s type without also taking a
-/// direct `mvm-sdk` dependency edge.
-pub use mvm_sdk::ir::{AuthType, Sigv4Params};
+/// direct `mvm-sdk` dependency edge. `SecretRef`/`SecretMount` are
+/// re-exported for the same reason: a fleet-side loopback caller
+/// driving `RemoteResolver::resolve(&SecretRef)` directly (e.g. mvmd's
+/// `secret_resolver_daemon` test) needs to construct a `SecretRef`
+/// literal, which requires naming its `mount: SecretMount` field's
+/// type too.
+pub use mvm_sdk::ir::{AuthType, SecretMount, SecretRef, Sigv4Params};

--- a/crates/mvm-hostd/src/keyholder/remote_resolver.rs
+++ b/crates/mvm-hostd/src/keyholder/remote_resolver.rs
@@ -1,0 +1,231 @@
+//! `RemoteResolver` — a [`SecretResolver`] that fetches a secret's raw value
+//! from a remote fleet-secrets daemon (mvmd's tenant vault) over a Unix
+//! domain socket, instead of [`super::LocalResolver`]'s on-disk store.
+//!
+//! The wire contract (`ResolveWireRequest`/`ResolveWireResponse`,
+//! length-prefixed JSON) lives in `mvm_core::substitution_wire` so mvmd's
+//! socket server and this client serialize the exact same bytes — a drifted
+//! copy on either side would silently break fleet secret resolution.
+//!
+//! Synchronous and dyn-safe, matching [`SecretResolver`]: each `resolve`
+//! call opens a fresh blocking connection, sends one request, reads one
+//! response, and closes. No connection pooling — that's a follow-up, not
+//! this seam.
+
+#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::io::{self, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use base64::Engine;
+use mvm_core::substitution_wire::{ResolveWireRequest, ResolveWireResponse};
+use mvm_sdk::ir::{AuthType, SecretRef};
+use secrecy::SecretBox;
+
+use super::resolver::{ResolveError, SecretResolver};
+
+/// Cap on a resolver response frame. A credential value, not a bulk
+/// payload — generous enough for any real secret while still bounding an
+/// adversarial or malfunctioning peer.
+const MAX_FRAME_BYTES: usize = 1 << 20; // 1 MiB
+
+/// Fetches a secret's value from a remote fleet-secrets daemon over a Unix
+/// socket. The client-side half of the mvmd tenant-vault seam: `resolve`
+/// mirrors `LocalResolver`'s fail-closed `allowed_hosts` check, but the
+/// value source is a UDS round trip instead of the local `SecretStore`.
+pub struct RemoteResolver {
+    uds_path: PathBuf,
+    timeout: Duration,
+}
+
+impl RemoteResolver {
+    pub fn new(uds_path: impl Into<PathBuf>, timeout: Duration) -> Self {
+        Self {
+            uds_path: uds_path.into(),
+            timeout,
+        }
+    }
+
+    /// One request/response round trip over a fresh connection. All I/O and
+    /// framing errors are folded into `io::Error` so the caller has a single
+    /// error type to map onto `ResolveError::Backend`.
+    fn round_trip(&self, req: &ResolveWireRequest) -> io::Result<ResolveWireResponse> {
+        let mut stream = UnixStream::connect(&self.uds_path)?;
+        stream.set_read_timeout(Some(self.timeout))?;
+        stream.set_write_timeout(Some(self.timeout))?;
+        write_frame(&mut stream, req)?;
+        read_frame(&mut stream)
+    }
+}
+
+impl SecretResolver for RemoteResolver {
+    fn resolve(&self, r: &SecretRef) -> Result<SecretBox<Vec<u8>>, ResolveError> {
+        // Mirror `LocalResolver`: an unbound secret must never resolve
+        // (claim 12, fail-closed) — refuse before ever touching the socket.
+        if r.allowed_hosts.is_empty() {
+            return Err(ResolveError::Unbound {
+                name: r.name.clone(),
+            });
+        }
+
+        let req = ResolveWireRequest {
+            name: r.name.clone(),
+            allowed_hosts: r.allowed_hosts.clone(),
+            auth_type: auth_type_label(r.auth_type).to_string(),
+        };
+
+        let resp = self
+            .round_trip(&req)
+            .map_err(|source| ResolveError::Backend {
+                name: r.name.clone(),
+                source: source.into(),
+            })?;
+
+        match resp {
+            ResolveWireResponse::Ok { value_b64 } => {
+                let bytes = base64::engine::general_purpose::STANDARD
+                    .decode(value_b64)
+                    .map_err(|source| ResolveError::Backend {
+                        name: r.name.clone(),
+                        source: source.into(),
+                    })?;
+                Ok(SecretBox::new(Box::new(bytes)))
+            }
+            ResolveWireResponse::Refused { message } => Err(ResolveError::Backend {
+                name: r.name.clone(),
+                source: anyhow::anyhow!(message),
+            }),
+        }
+    }
+}
+
+fn auth_type_label(t: AuthType) -> &'static str {
+    match t {
+        AuthType::Sigv4 => "sigv4",
+        AuthType::Hmac => "hmac",
+        AuthType::Bearer => "bearer",
+        AuthType::Basic => "basic",
+    }
+}
+
+/// Write a length-prefixed JSON frame: 4-byte BE length + JSON body.
+/// Blocking I/O — `RemoteResolver` is a sync `SecretResolver`, so this
+/// stays sync rather than pulling a tokio runtime into the resolve path.
+fn write_frame<T: serde::Serialize>(w: &mut impl Write, value: &T) -> io::Result<()> {
+    let body =
+        serde_json::to_vec(value).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let len = u32::try_from(body.len())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "frame too large"))?;
+    w.write_all(&len.to_be_bytes())?;
+    w.write_all(&body)?;
+    w.flush()
+}
+
+/// Read a length-prefixed JSON frame, enforcing `MAX_FRAME_BYTES`.
+fn read_frame<T: serde::de::DeserializeOwned>(r: &mut impl Read) -> io::Result<T> {
+    let mut len_buf = [0u8; 4];
+    r.read_exact(&mut len_buf)?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len > MAX_FRAME_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "frame too large",
+        ));
+    }
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf)?;
+    serde_json::from_slice(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use mvm_sdk::ir::SecretMount;
+    use secrecy::ExposeSecret;
+    use std::os::unix::net::UnixListener;
+    use std::thread;
+    use tempfile::tempdir;
+
+    fn secret_ref_with_hosts(hosts: &[&str]) -> SecretRef {
+        SecretRef {
+            name: "STRIPE".into(),
+            mount: SecretMount::Env {
+                var: "STRIPE_KEY".into(),
+            },
+            auth_type: AuthType::Bearer,
+            allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: None,
+        }
+    }
+
+    /// Spawn a throwaway UDS server that accepts one connection, reads one
+    /// framed `ResolveWireRequest`, and replies with `response`. The
+    /// listener is bound (and thus already accepting) before this returns,
+    /// so the caller can connect immediately with no race. The backing
+    /// tempdir is moved into the server thread and only drops (removing the
+    /// socket file) once the one exchange completes.
+    fn spawn_server(response: ResolveWireResponse) -> PathBuf {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("resolver.sock");
+        let listener = UnixListener::bind(&path).expect("bind uds");
+        thread::spawn(move || {
+            let _dir = dir;
+            if let Ok((mut stream, _)) = listener.accept() {
+                let _req: io::Result<ResolveWireRequest> = read_frame(&mut stream);
+                let _ = write_frame(&mut stream, &response);
+            }
+        });
+        path
+    }
+
+    #[test]
+    fn remote_resolver_fetches_value_over_uds() {
+        let value_b64 = base64::engine::general_purpose::STANDARD.encode(b"sk_live_x");
+        let path = spawn_server(ResolveWireResponse::Ok { value_b64 });
+
+        let resolver = RemoteResolver::new(path, Duration::from_secs(5));
+        let secret = resolver
+            .resolve(&secret_ref_with_hosts(&["api.stripe.com"]))
+            .unwrap();
+        assert_eq!(secret.expose_secret().as_slice(), b"sk_live_x");
+    }
+
+    #[test]
+    fn remote_resolver_maps_refusal_to_resolve_error() {
+        let path = spawn_server(ResolveWireResponse::Refused {
+            message: "secret not bound".into(),
+        });
+
+        let resolver = RemoteResolver::new(path, Duration::from_secs(5));
+        let err = resolver
+            .resolve(&secret_ref_with_hosts(&["api.stripe.com"]))
+            .unwrap_err();
+        assert!(matches!(err, ResolveError::Backend { .. }));
+    }
+
+    #[test]
+    fn remote_resolver_maps_connect_failure_to_resolve_error_without_panicking() {
+        let dir = tempdir().expect("tempdir");
+        // Never bound — nothing is listening at this path.
+        let path = dir.path().join("nobody-home.sock");
+
+        let resolver = RemoteResolver::new(path, Duration::from_secs(5));
+        let err = resolver
+            .resolve(&secret_ref_with_hosts(&["api.stripe.com"]))
+            .unwrap_err();
+        assert!(matches!(err, ResolveError::Backend { .. }));
+    }
+
+    #[test]
+    fn remote_resolver_rejects_unbound_ref_without_connecting() {
+        // A path that isn't bound: if `resolve` tried to connect, it would
+        // hit connection-refused/backend-error instead of `Unbound`.
+        let path = PathBuf::from("/nonexistent/nobody-home.sock");
+        let resolver = RemoteResolver::new(path, Duration::from_secs(5));
+        let err = resolver.resolve(&secret_ref_with_hosts(&[])).unwrap_err();
+        assert!(matches!(err, ResolveError::Unbound { .. }));
+    }
+}

--- a/crates/mvm-hostd/src/keyholder/remote_resolver.rs
+++ b/crates/mvm-hostd/src/keyholder/remote_resolver.rs
@@ -194,6 +194,19 @@ mod tests {
     }
 
     #[test]
+    fn remote_resolver_maps_invalid_base64_to_resolve_error_without_panicking() {
+        let path = spawn_server(ResolveWireResponse::Ok {
+            value_b64: "!!not-valid-base64!!".into(),
+        });
+
+        let resolver = RemoteResolver::new(path, Duration::from_secs(5));
+        let err = resolver
+            .resolve(&secret_ref_with_hosts(&["api.stripe.com"]))
+            .unwrap_err();
+        assert!(matches!(err, ResolveError::Backend { .. }));
+    }
+
+    #[test]
     fn remote_resolver_maps_refusal_to_resolve_error() {
         let path = spawn_server(ResolveWireResponse::Refused {
             message: "secret not bound".into(),

--- a/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
@@ -70,18 +70,21 @@ fn default_resolve_timeout_secs() -> u64 {
 /// The registry (which placeholders exist, their `allowed_hosts`/`auth_type`)
 /// is always assembled from the local binding store regardless of backend —
 /// only *value* resolution moves off-host in `Remote` mode.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// `Local` is a unit variant — deliberately. `EndpointConfig::secret_store_dir`
+/// is already the single source of truth for the local store dir (it also
+/// drives [`resolve_store_dirs`]'s Landlock confinement grant); a second,
+/// per-backend override here would let the two silently drift the moment
+/// anyone set it, so there is exactly one place to look.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "backend", rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 pub enum ResolverBackend {
-    /// Resolve locally via [`FileSecretStore`]. `store_dir` overrides
-    /// `EndpointConfig::secret_store_dir` when set; `None` (the default) falls
-    /// back to `EndpointConfig::secret_store_dir`, then the host default
-    /// (`~/.mvm/secrets`) — i.e. today's exact resolution rule.
-    Local {
-        #[serde(default)]
-        store_dir: Option<PathBuf>,
-    },
+    /// Resolve locally via [`FileSecretStore`] over
+    /// `EndpointConfig::secret_store_dir` (falling back to the host default,
+    /// `~/.mvm/secrets`, when unset) — today's exact resolution rule.
+    #[default]
+    Local,
     /// Resolve remotely over a Unix domain socket to a fleet-secrets daemon.
     Remote {
         /// Path to the daemon's UDS.
@@ -90,12 +93,6 @@ pub enum ResolverBackend {
         #[serde(default = "default_resolve_timeout_secs")]
         timeout_secs: u64,
     },
-}
-
-impl Default for ResolverBackend {
-    fn default() -> Self {
-        Self::Local { store_dir: None }
-    }
 }
 
 /// How the guest reaches this endpoint. Defined in `mvm-backend` (next to the
@@ -250,12 +247,12 @@ pub fn assemble(
     // inside `from_plan` from the same local binding store — only value
     // resolution moves off-host under `ResolverBackend::Remote`.
     let resolver: Arc<dyn SecretResolver> = match &cfg.resolver {
-        ResolverBackend::Local { store_dir } => {
-            // `store_dir` overrides `cfg.secret_store_dir` when set; absent
-            // (the default) preserves today's exact rule: fall back to
-            // `cfg.secret_store_dir`, then the host default.
-            let dir = store_dir.clone().or_else(|| cfg.secret_store_dir.clone());
-            let secret_store: Arc<dyn SecretStore> = Arc::new(match dir {
+        ResolverBackend::Local => {
+            // The single source of truth for the local store dir is
+            // `cfg.secret_store_dir` — the same field `resolve_store_dirs`
+            // uses to compute the Landlock confinement grant, so the two
+            // can never drift.
+            let secret_store: Arc<dyn SecretStore> = Arc::new(match &cfg.secret_store_dir {
                 Some(dir) => FileSecretStore::with_dir(dir),
                 None => FileSecretStore::with_dir(default_secrets_dir()?),
             });
@@ -844,7 +841,27 @@ mod tests {
             "transport": {"kind": "uds", "path": "/tmp/sub.sock"},
         });
         let cfg = parse(&serde_json::to_vec(&json).unwrap()).unwrap();
-        assert_eq!(cfg.resolver, ResolverBackend::Local { store_dir: None });
+        assert_eq!(cfg.resolver, ResolverBackend::Local);
+    }
+
+    #[test]
+    fn resolver_backend_local_round_trips_as_unit_variant() {
+        // `Local` carries no fields — `cfg.secret_store_dir` remains the sole
+        // source of truth for the local store dir. Verify the wire shape is
+        // just the tag, and that it round-trips through `ResolverBackend`
+        // directly as well as inside a full `EndpointConfig`.
+        let json = serde_json::json!({ "backend": "local" });
+        assert_eq!(
+            serde_json::from_value::<ResolverBackend>(json).unwrap(),
+            ResolverBackend::Local
+        );
+
+        let mut cfg = vsock_cfg(vec![], std::path::Path::new("/tmp/x"));
+        cfg.resolver = ResolverBackend::Local;
+        let bytes = serde_json::to_vec(&cfg).unwrap();
+        assert_eq!(parse(&bytes).unwrap(), cfg);
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["resolver"], serde_json::json!({"backend": "local"}));
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
@@ -16,6 +16,7 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Context;
 
@@ -25,7 +26,9 @@ use mvm_contract::stream::secret_fingerprint::{SecretCategory, SecretFingerprint
 use mvm_core::crypto::secret_store::{FileSecretStore, SecretStore, default_secrets_dir};
 use mvm_core::plan::SecretBinding;
 
-use crate::keyholder::{FileBindingStore, HandedPlaceholders};
+use crate::keyholder::{
+    FileBindingStore, HandedPlaceholders, LocalResolver, RemoteResolver, SecretResolver,
+};
 use crate::supervisor::substitution_proxy::SubstitutionService;
 
 /// The endpoint's ready-handshake line. Defined next to
@@ -50,6 +53,49 @@ pub fn build_egress_gate(
     let pins = mvm_core::policy::dns_pin::resolve_network_policy_pins(policy);
     let now = chrono::Utc::now().to_rfc3339();
     mvm_runtime::vmm::egress_gate::EgressGate::from_network_policy(policy, &pins, &now)
+}
+
+/// Default remote-resolver round-trip timeout (connect + one request/response
+/// over the UDS to the fleet-secrets daemon), in seconds.
+fn default_resolve_timeout_secs() -> u64 {
+    5
+}
+
+/// How `assemble` resolves a bound secret's raw value at request time: on this
+/// host's local encrypted secret store (`Local`, the default — the unchanged
+/// `mvmctl secret set` flow), or from a remote fleet-secrets daemon over a
+/// Unix domain socket (`Remote` — mvmd's tenant vault; see
+/// [`crate::keyholder::RemoteResolver`]).
+///
+/// The registry (which placeholders exist, their `allowed_hosts`/`auth_type`)
+/// is always assembled from the local binding store regardless of backend —
+/// only *value* resolution moves off-host in `Remote` mode.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "backend", rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub enum ResolverBackend {
+    /// Resolve locally via [`FileSecretStore`]. `store_dir` overrides
+    /// `EndpointConfig::secret_store_dir` when set; `None` (the default) falls
+    /// back to `EndpointConfig::secret_store_dir`, then the host default
+    /// (`~/.mvm/secrets`) — i.e. today's exact resolution rule.
+    Local {
+        #[serde(default)]
+        store_dir: Option<PathBuf>,
+    },
+    /// Resolve remotely over a Unix domain socket to a fleet-secrets daemon.
+    Remote {
+        /// Path to the daemon's UDS.
+        uds_path: PathBuf,
+        /// Round-trip timeout, seconds.
+        #[serde(default = "default_resolve_timeout_secs")]
+        timeout_secs: u64,
+    },
+}
+
+impl Default for ResolverBackend {
+    fn default() -> Self {
+        Self::Local { store_dir: None }
+    }
 }
 
 /// How the guest reaches this endpoint. Defined in `mvm-backend` (next to the
@@ -154,6 +200,11 @@ pub struct EndpointConfig {
     /// selects the raw-TCP splice serve loop. Fixed at admission — never sniffed.
     #[serde(default)]
     pub egress_mode: EgressMode,
+    /// How to resolve a bound secret's raw value: this host's local encrypted
+    /// store (default), or a remote fleet-secrets daemon over a UDS. See
+    /// [`ResolverBackend`].
+    #[serde(default)]
+    pub resolver: ResolverBackend,
 }
 
 /// Parse an [`EndpointConfig`] from the JSON the backend writes on stdin.
@@ -189,14 +240,36 @@ pub fn resolve_store_dirs(cfg: &EndpointConfig) -> anyhow::Result<(PathBuf, Path
 pub fn assemble(
     cfg: &EndpointConfig,
 ) -> anyhow::Result<(Arc<SubstitutionService>, HandedPlaceholders)> {
-    let secret_store: Arc<dyn SecretStore> = Arc::new(match &cfg.secret_store_dir {
-        Some(dir) => FileSecretStore::with_dir(dir),
-        None => FileSecretStore::with_dir(default_secrets_dir()?),
-    });
     let bindings = match &cfg.binding_store_dir {
         Some(dir) => FileBindingStore::with_dir(dir),
         None => FileBindingStore::default_location()?,
     };
+    // Build the value resolver up front so `from_plan` builds the service
+    // over it instead of its hardcoded `LocalResolver`. The registry (which
+    // placeholders exist, their allowed_hosts/auth_type) is still assembled
+    // inside `from_plan` from the same local binding store — only value
+    // resolution moves off-host under `ResolverBackend::Remote`.
+    let resolver: Arc<dyn SecretResolver> = match &cfg.resolver {
+        ResolverBackend::Local { store_dir } => {
+            // `store_dir` overrides `cfg.secret_store_dir` when set; absent
+            // (the default) preserves today's exact rule: fall back to
+            // `cfg.secret_store_dir`, then the host default.
+            let dir = store_dir.clone().or_else(|| cfg.secret_store_dir.clone());
+            let secret_store: Arc<dyn SecretStore> = Arc::new(match dir {
+                Some(dir) => FileSecretStore::with_dir(dir),
+                None => FileSecretStore::with_dir(default_secrets_dir()?),
+            });
+            Arc::new(LocalResolver::new(&cfg.tenant_id, secret_store))
+        }
+        ResolverBackend::Remote {
+            uds_path,
+            timeout_secs,
+        } => Arc::new(RemoteResolver::new(
+            uds_path.clone(),
+            Duration::from_secs(*timeout_secs),
+        )),
+    };
+
     // Reconstruct the per-VM intermediate minter from the delivered PEMs (the
     // key never left the host) so the terminator can terminate bound-host
     // `https`. Absent ⇒ `http`-only.
@@ -215,12 +288,17 @@ pub fn assemble(
     // audit rather than refusing (the same optional posture `with_recorder` had).
     let recorder = build_audit_recorder(&cfg.tenant_id);
 
+    // Build the service over the resolver assembled above. `from_plan` builds
+    // the registry (from the local binding store), the forwarder, and threads
+    // the redaction / reversible-replacement / TLS / recorder wiring; passing
+    // `resolver` in means it no longer hardcodes a `LocalResolver`, so a
+    // `Remote` backend actually reaches its `RemoteResolver`.
     let (service, handed) =
         SubstitutionService::from_plan(crate::supervisor::substitution_proxy::FromPlanInputs {
             plan_secrets: &cfg.secrets,
             tenant: &cfg.tenant_id,
             bindings: &bindings,
-            secret_store,
+            resolver,
             forward_timeout_secs: cfg.forward_timeout_secs,
             redaction: cfg.redaction.clone(),
             reversible_replacement: cfg.reversible_replacement.clone(),
@@ -369,6 +447,7 @@ mod tests {
             tls_intermediate: None,
             network_policy: None,
             egress_mode: EgressMode::Wire,
+            resolver: ResolverBackend::default(),
         }
     }
 
@@ -752,5 +831,137 @@ mod tests {
         assert_eq!(handed.len(), 1);
         assert_eq!(handed[0].0, "OPENAI_API_KEY");
         assert!(handed[0].1.as_str().starts_with("mvm-secret-"));
+    }
+
+    #[test]
+    fn resolver_backend_defaults_to_local_when_field_omitted() {
+        // Back-compat: a config the backend wrote before `resolver` existed
+        // (or one that simply omits it) must still parse and land on the
+        // local-store behaviour existing `mvmctl secret set` flows rely on.
+        let json = serde_json::json!({
+            "tenant_id": "local",
+            "secrets": [],
+            "transport": {"kind": "uds", "path": "/tmp/sub.sock"},
+        });
+        let cfg = parse(&serde_json::to_vec(&json).unwrap()).unwrap();
+        assert_eq!(cfg.resolver, ResolverBackend::Local { store_dir: None });
+    }
+
+    #[test]
+    fn resolver_backend_remote_round_trips_through_endpoint_config() {
+        let mut cfg = vsock_cfg(vec![], std::path::Path::new("/tmp/x"));
+        cfg.resolver = ResolverBackend::Remote {
+            uds_path: "/run/mvmd/tenant-a.sock".into(),
+            timeout_secs: 9,
+        };
+        let bytes = serde_json::to_vec(&cfg).unwrap();
+        assert_eq!(parse(&bytes).unwrap(), cfg);
+
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["resolver"]["backend"], serde_json::json!("remote"));
+        assert_eq!(
+            v["resolver"]["uds_path"],
+            serde_json::json!("/run/mvmd/tenant-a.sock")
+        );
+        assert_eq!(v["resolver"]["timeout_secs"], serde_json::json!(9));
+    }
+
+    #[test]
+    fn resolver_backend_remote_timeout_defaults_when_omitted() {
+        let json = serde_json::json!({
+            "backend": "remote",
+            "uds_path": "/run/mvmd/tenant-a.sock",
+        });
+        let backend: ResolverBackend = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            backend,
+            ResolverBackend::Remote {
+                uds_path: "/run/mvmd/tenant-a.sock".into(),
+                timeout_secs: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn resolver_backend_rejects_unknown_fields() {
+        let json = serde_json::json!({
+            "backend": "remote",
+            "uds_path": "/run/mvmd/tenant-a.sock",
+            "smuggled": "x",
+        });
+        let err = serde_json::from_value::<ResolverBackend>(json).unwrap_err();
+        assert!(err.to_string().contains("unknown field"), "got {err}");
+    }
+
+    /// Spawn a throwaway UDS server standing in for mvmd's tenant vault:
+    /// accepts one connection, reads one length-prefixed `ResolveWireRequest`,
+    /// replies with `response` framed the same way. Mirrors
+    /// `RemoteResolver`'s own test helper (M1) — kept local here rather than
+    /// exported since it's a one-shot single-exchange stand-in, not a general
+    /// test double.
+    fn spawn_resolve_server(response: mvm_core::substitution_wire::ResolveWireResponse) -> PathBuf {
+        use std::io::{Read, Write};
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("resolver.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        std::thread::spawn(move || {
+            let _dir = dir;
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut len_buf = [0u8; 4];
+                if stream.read_exact(&mut len_buf).is_ok() {
+                    let len = u32::from_be_bytes(len_buf) as usize;
+                    let mut buf = vec![0u8; len];
+                    if stream.read_exact(&mut buf).is_ok() {
+                        let _req: Result<mvm_core::substitution_wire::ResolveWireRequest, _> =
+                            serde_json::from_slice(&buf);
+                        let body = serde_json::to_vec(&response).unwrap();
+                        let out_len = (body.len() as u32).to_be_bytes();
+                        let _ = stream.write_all(&out_len);
+                        let _ = stream.write_all(&body);
+                    }
+                }
+            }
+        });
+        path
+    }
+
+    #[test]
+    fn assemble_wires_remote_resolver_backend_to_the_live_uds_server() {
+        use base64::Engine;
+        use mvm_core::substitution_wire::ResolveWireResponse;
+        use mvm_sdk::ir::{AuthType, SecretMount, SecretRef};
+        use secrecy::ExposeSecret;
+
+        let value_b64 = base64::engine::general_purpose::STANDARD.encode(b"sk-live-from-vault");
+        let uds_path = spawn_resolve_server(ResolveWireResponse::Ok { value_b64 });
+
+        let dir = tempdir().unwrap();
+        let mut cfg = vsock_cfg(vec![], dir.path());
+        cfg.resolver = ResolverBackend::Remote {
+            uds_path: uds_path.clone(),
+            timeout_secs: 5,
+        };
+
+        // `assemble` must not touch the local secret store at all when the
+        // backend is `Remote` — no secret is ever written to `dir/secrets`.
+        let (service, handed) = assemble(&cfg).unwrap();
+        assert!(handed.is_empty(), "no plan secrets ⇒ nothing handed");
+
+        // Observable-behaviour probe (per the task brief): resolve a
+        // `SecretRef` directly through the assembled service's resolver and
+        // assert the value came from the live UDS server, not a local store.
+        let secret_ref = SecretRef {
+            name: "openai".into(),
+            mount: SecretMount::Env {
+                var: "OPENAI_API_KEY".into(),
+            },
+            auth_type: AuthType::Bearer,
+            allowed_hosts: vec!["api.openai.com".into()],
+            sigv4: None,
+        };
+        let resolved = service.resolver().resolve(&secret_ref).unwrap();
+        assert_eq!(resolved.expose_secret().as_slice(), b"sk-live-from-vault");
     }
 }

--- a/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
@@ -22,15 +22,14 @@ use tokio::net::{UnixListener, UnixStream};
 use url::Url;
 
 use mvm_contract::ir::AuthType;
-use mvm_core::crypto::secret_store::SecretStore;
 use mvm_core::plan::SecretBinding;
 use mvm_core::substitution_wire::{WireRequest, WireResponse};
 
 use crate::framing::{FrameError, read_json_frame, write_json_frame};
 use crate::keyholder::{
-    AssembleError, BindingStore, HandedPlaceholders, LocalResolver, SecretResolver,
-    SignDispatchError, SigningInput, SubstituteError, SubstitutionEndpoint, SubstitutionRegistry,
-    assemble_registry, build_sigv4_input, find_placeholder,
+    AssembleError, BindingStore, HandedPlaceholders, SecretResolver, SignDispatchError,
+    SigningInput, SubstituteError, SubstitutionEndpoint, SubstitutionRegistry, assemble_registry,
+    build_sigv4_input, find_placeholder,
 };
 use crate::supervisor::audit_recorder::Recorder;
 use crate::supervisor::network::stages::{RedactingSubstitution, RedactionHits};
@@ -535,7 +534,11 @@ pub struct FromPlanInputs<'a> {
     pub plan_secrets: &'a [SecretBinding],
     pub tenant: &'a str,
     pub bindings: &'a dyn BindingStore,
-    pub secret_store: Arc<dyn SecretStore>,
+    /// The value resolver the service resolves each bound secret through. Built
+    /// by the caller (`assemble`) from `EndpointConfig.resolver`: a
+    /// [`LocalResolver`] over the host secret store (default), or a
+    /// [`crate::keyholder::RemoteResolver`] dialing a fleet-secrets daemon UDS.
+    pub resolver: Arc<dyn SecretResolver>,
     pub forward_timeout_secs: u64,
     pub redaction: mvm_core::policy::RedactionPolicy,
     pub reversible_replacement: mvm_core::policy::ReversibleReplacementPolicy,
@@ -725,6 +728,15 @@ impl SubstitutionService {
         &self.redaction_policy
     }
 
+    /// The attached resolver. Test-only: lets `assemble`'s resolver-backend
+    /// tests prove which `SecretResolver` (`LocalResolver` vs `RemoteResolver`)
+    /// actually reached the service, via an observable `resolve()` call rather
+    /// than reaching into a private field.
+    #[cfg(test)]
+    pub(crate) fn resolver(&self) -> &Arc<dyn SecretResolver> {
+        &self.resolver
+    }
+
     /// Run the service's redactor for a destination action. Test-only seam so the
     /// endpoint-config tests can prove the threaded policy fires end-to-end.
     #[cfg(test)]
@@ -761,11 +773,12 @@ impl SubstitutionService {
     }
 
     /// Assemble a ready-to-serve service from an admitted plan's secret
-    /// bindings: build the registry ([`assemble_registry`]), a [`LocalResolver`]
-    /// over the tenant's secret store, and a hardened-reqwest forwarder.
-    /// Returns the service plus the `(guest name, placeholder)` pairs the
-    /// supervisor injects into the guest. The caller binds the listener and
-    /// calls [`Self::serve`].
+    /// bindings: build the registry ([`assemble_registry`]) and a
+    /// hardened-reqwest forwarder, and resolve values through the caller-supplied
+    /// [`SecretResolver`] (a [`LocalResolver`] over the tenant's secret store by
+    /// default, or a remote fleet-secrets resolver). Returns the service plus the
+    /// `(guest name, placeholder)` pairs the supervisor injects into the guest.
+    /// The caller binds the listener and calls [`Self::serve`].
     pub fn from_plan(
         inputs: FromPlanInputs<'_>,
     ) -> Result<(Arc<Self>, HandedPlaceholders), FromPlanError> {
@@ -773,7 +786,7 @@ impl SubstitutionService {
             plan_secrets,
             tenant,
             bindings,
-            secret_store,
+            resolver,
             forward_timeout_secs,
             redaction,
             reversible_replacement,
@@ -781,7 +794,6 @@ impl SubstitutionService {
             recorder,
         } = inputs;
         let (registry, handed) = assemble_registry(plan_secrets, tenant, bindings)?;
-        let resolver: Arc<dyn SecretResolver> = Arc::new(LocalResolver::new(tenant, secret_store));
         let forwarder: Arc<dyn Forwarder> = Arc::new(ReqwestForwarder::new(forward_timeout_secs)?);
         let mut service = Self::new(Arc::new(registry), resolver, forwarder).with_tenant(tenant);
         service = service.with_redaction_policy(redaction);
@@ -2643,7 +2655,8 @@ mod server_tests {
                 &SecretBox::new(Box::new("sk".to_string())),
             )
             .unwrap();
-        let secret_store: Arc<dyn SecretStore> = Arc::new(store);
+        let resolver: Arc<dyn SecretResolver> =
+            Arc::new(LocalResolver::new("local", Arc::new(store)));
 
         let plan = [SecretBinding {
             name: "OPENAI_API_KEY".into(),
@@ -2655,7 +2668,7 @@ mod server_tests {
             plan_secrets: &plan,
             tenant: "local",
             bindings: &bindings,
-            secret_store,
+            resolver,
             forward_timeout_secs: 30,
             redaction: mvm_core::policy::RedactionPolicy::default(),
             reversible_replacement: mvm_core::policy::ReversibleReplacementPolicy::default(),
@@ -2695,7 +2708,8 @@ mod server_tests {
                 &SecretBox::new(Box::new("sk".to_string())),
             )
             .unwrap();
-        let secret_store: Arc<dyn SecretStore> = Arc::new(store);
+        let resolver: Arc<dyn SecretResolver> =
+            Arc::new(LocalResolver::new("local", Arc::new(store)));
 
         let plan = [SecretBinding {
             name: "OPENAI_API_KEY".into(),
@@ -2724,7 +2738,7 @@ mod server_tests {
             plan_secrets: &plan,
             tenant: "local",
             bindings: &bindings,
-            secret_store,
+            resolver,
             forward_timeout_secs: 30,
             redaction: policy,
             reversible_replacement: mvm_core::policy::ReversibleReplacementPolicy::default(),

--- a/crates/mvm-hostd/tests/egress_secret_leak_gate.rs
+++ b/crates/mvm-hostd/tests/egress_secret_leak_gate.rs
@@ -105,6 +105,7 @@ fn handed_placeholders_never_contain_the_secret_value() {
         )
         .unwrap();
     let secret_store: Arc<dyn SecretStore> = Arc::new(store);
+    let resolver: Arc<dyn SecretResolver> = Arc::new(LocalResolver::new("local", secret_store));
 
     let plan = [SecretBinding {
         name: "OPENAI_API_KEY".into(),
@@ -116,7 +117,7 @@ fn handed_placeholders_never_contain_the_secret_value() {
         plan_secrets: &plan,
         tenant: "local",
         bindings: &bindings,
-        secret_store,
+        resolver,
         forward_timeout_secs: 30,
         redaction: mvm_core::policy::RedactionPolicy::default(),
         reversible_replacement: mvm_core::policy::ReversibleReplacementPolicy::default(),

--- a/crates/mvm-hostd/tests/substitution_endpoint_bin.rs
+++ b/crates/mvm-hostd/tests/substitution_endpoint_bin.rs
@@ -17,7 +17,9 @@ use mvm_core::crypto::secret_store::{FileSecretStore, SecretStore};
 use mvm_core::plan::{SecretBinding, SecretSource};
 use mvm_core::substitution_wire::{WireRequest, WireResponse};
 use mvm_hostd::keyholder::{BindingStore, FileBindingStore, SecretBindingMeta};
-use mvm_hostd::supervisor::substitution_endpoint::{EgressMode, EndpointConfig, EndpointTransport};
+use mvm_hostd::supervisor::substitution_endpoint::{
+    EgressMode, EndpointConfig, EndpointTransport, ResolverBackend,
+};
 use secrecy::SecretBox;
 
 const BIN: &str = env!("CARGO_BIN_EXE_mvm-substitution-endpoint");
@@ -89,7 +91,8 @@ fn endpoint_bin_serves_substitution_and_refuses_unbound_destination() {
         terminator_listen: None,
         tls_intermediate: None,
         network_policy: None,
-        egress_mode: mvm_hostd::supervisor::substitution_endpoint::EgressMode::Wire,
+        egress_mode: EgressMode::Wire,
+        resolver: ResolverBackend::default(),
     };
 
     let mut child = Command::new(BIN)
@@ -192,6 +195,7 @@ fn endpoint_bin_claim10_gate_refuses_a_bound_but_unadmitted_destination() {
         // Deny-all: the endpoint gates every destination — even the bound one.
         network_policy: Some(mvm_core::policy::network_policy::NetworkPolicy::deny_all()),
         egress_mode: mvm_hostd::supervisor::substitution_endpoint::EgressMode::Wire,
+        resolver: ResolverBackend::default(),
     };
 
     let mut child = Command::new(BIN)
@@ -261,6 +265,7 @@ fn endpoint_bin_raw_no_secret_mode_handshakes_without_placeholders() {
             )],
         )),
         egress_mode: EgressMode::Raw,
+        resolver: ResolverBackend::default(),
     };
 
     let mut child = Command::new(BIN)

--- a/crates/mvm-runtime/src/builder_runner/runner.rs
+++ b/crates/mvm-runtime/src/builder_runner/runner.rs
@@ -146,6 +146,8 @@ impl<D: VmmDriver + 'static> BuilderRunner<D> {
             tls_intermediate: None,
             network_policy: Some(&builder_policy),
             raw_egress: true,
+            resolver_remote: None,
+            binding_store_dir: None,
         })?;
         let mut endpoint_guard = EndpointGuard::new(b.name);
 

--- a/crates/mvm-runtime/src/docker_backend.rs
+++ b/crates/mvm-runtime/src/docker_backend.rs
@@ -356,6 +356,8 @@ fn docker_substitution_spawn_params<'a>(
         tls_intermediate: None,
         network_policy: Some(network_policy),
         raw_egress: false,
+        resolver_remote: None,
+        binding_store_dir: None,
     }
 }
 

--- a/crates/mvm-runtime/src/lib.rs
+++ b/crates/mvm-runtime/src/lib.rs
@@ -190,6 +190,19 @@ pub use mvm_vmm::host::host_agent_spawn::{
 /// `mvmctl` secrets-drive path. Re-exported from `mvm-vmm::host::substitution_spawn`.
 pub use mvm_vmm::host::substitution_spawn::{EndpointHandshake, record_secret_fingerprints};
 
+/// Spawn/reap the per-VM substitution-endpoint moat, its params, and the
+/// remote-resolver spawn config — re-exported at the crate root so fleet
+/// callers outside this crate (mvmd's tenant-secrets vault, Phase 1 egress
+/// broker / D8 spawn-wiring, reaching them via `mvmctl::backend`) can drive the
+/// same per-VM endpoint the libkrun/Vz/Firecracker backends use, instead of
+/// duplicating the subprocess spawn/handshake/PID-file logic. The
+/// `substitution_spawn` module is also re-exported above; these root aliases
+/// mirror the original `mvm-backend` crate-root surface those callers named.
+pub use mvm_vmm::host::substitution_spawn::{
+    RemoteResolverSpawnConfig, SubstitutionSpawnParams, reap_substitution_endpoint,
+    spawn_substitution_endpoint,
+};
+
 /// Crate-wide test serialization for tests that mutate `HOME` or
 /// other process-global env vars. Re-exported from
 /// [`crate::base::runtime_meta::HOME_TEST_LOCK`] so the

--- a/crates/mvm-runtime/src/lib.rs
+++ b/crates/mvm-runtime/src/lib.rs
@@ -194,7 +194,7 @@ pub use mvm_vmm::host::substitution_spawn::{EndpointHandshake, record_secret_fin
 /// remote-resolver spawn config — re-exported at the crate root so fleet
 /// callers outside this crate (mvmd's tenant-secrets vault, Phase 1 egress
 /// broker / D8 spawn-wiring, reaching them via `mvmctl::backend`) can drive the
-/// same per-VM endpoint the libkrun/Vz/Firecracker backends use, instead of
+/// same per-VM endpoint the libkrun/HVF/Firecracker backends use, instead of
 /// duplicating the subprocess spawn/handshake/PID-file logic. The
 /// `substitution_spawn` module is also re-exported above; these root aliases
 /// mirror the original `mvm-backend` crate-root surface those callers named.

--- a/crates/mvm-runtime/src/wasm_backend.rs
+++ b/crates/mvm-runtime/src/wasm_backend.rs
@@ -279,6 +279,8 @@ fn wasm_substitution_spawn_params<'a>(
         tls_intermediate: None,
         network_policy: Some(network_policy),
         raw_egress: false,
+        resolver_remote: None,
+        binding_store_dir: None,
     }
 }
 

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -97,6 +97,8 @@ impl EndpointSpawner for RealEndpointSpawner {
             tls_intermediate: None,
             network_policy: Some(req.network_policy),
             raw_egress: req.raw_egress,
+            resolver_remote: None,
+            binding_store_dir: None,
         })?;
         Ok(uds)
     }

--- a/crates/mvm-vmm/src/host/substitution_spawn.rs
+++ b/crates/mvm-vmm/src/host/substitution_spawn.rs
@@ -191,6 +191,23 @@ fn resolve_substitution_endpoint_path() -> Result<PathBuf> {
     })
 }
 
+/// `resolver_remote` config for [`SubstitutionSpawnParams`]: resolve secret
+/// *values* over a UDS to a remote fleet-secrets daemon (mvmd's tenant
+/// vault) instead of the endpoint's local encrypted secret store. Mirrors
+/// `mvm_hostd::supervisor::substitution_endpoint::ResolverBackend::Remote`'s
+/// two fields exactly — but is defined here (not imported from `mvm-hostd`)
+/// because `mvm-hostd` depends on `mvm-vmm`, never the reverse; a shared
+/// field-shape (not a shared type) is how the two stay in sync without a
+/// dependency cycle, the same trick already used for [`EndpointTransport`]
+/// (defined here, re-exported by `mvm-hostd`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemoteResolverSpawnConfig<'a> {
+    /// Path to the daemon's UDS.
+    pub uds_path: &'a Path,
+    /// Round-trip timeout, seconds.
+    pub timeout_secs: u64,
+}
+
 /// Inputs to [`spawn_substitution_endpoint`]. Grouped into a struct (rather
 /// than threading bare positional args) so the backend-shaped fields —
 /// `transport` (vsock vs UDS), `terminator_listen`, `tls_intermediate` — read
@@ -223,6 +240,14 @@ pub struct SubstitutionSpawnParams<'a> {
     /// endpoint serves `egress_mode: "raw"`; false ⇒ the WireRequest substitution
     /// protocol (`"wire"`, the default). A VM's mode is fixed at admission.
     pub raw_egress: bool,
+    /// `Some` ⇒ the endpoint resolves secret *values* remotely (see
+    /// [`RemoteResolverSpawnConfig`]) instead of its local encrypted store.
+    /// `None` preserves today's `Local` (unchanged) resolver behavior.
+    pub resolver_remote: Option<RemoteResolverSpawnConfig<'a>>,
+    /// Override the endpoint's binding-store dir (where `allowed_hosts`/
+    /// `auth_type` per secret name are read from at `assemble()` time).
+    /// `None` preserves today's host-default dir.
+    pub binding_store_dir: Option<&'a Path>,
 }
 
 /// Build the EndpointConfig JSON the endpoint reads on stdin. Pure (no spawn)
@@ -266,6 +291,28 @@ fn build_endpoint_config_json(params: &SubstitutionSpawnParams<'_>) -> serde_jso
         // byte-identical to before (the in-loop gate stays the enforcer).
         cfg["network_policy"] =
             serde_json::to_value(policy).expect("NetworkPolicy serializes to JSON");
+    }
+    if let Some(RemoteResolverSpawnConfig {
+        uds_path,
+        timeout_secs,
+    }) = params.resolver_remote
+    {
+        // `EndpointConfig.resolver`: internally tagged on `backend` (see
+        // `ResolverBackend`'s `#[serde(tag = "backend", rename_all =
+        // "snake_case")]`) — `Remote { uds_path, timeout_secs }` becomes
+        // `{"backend":"remote","uds_path":...,"timeout_secs":...}`. Built by
+        // hand (not by depending on `mvm_hostd::ResolverBackend`) for the same
+        // reason `RemoteResolverSpawnConfig` isn't that type: the dependency
+        // only runs `mvm-hostd -> mvm-vmm`, never back. Omitted when `None` so
+        // legacy configs land on `EndpointConfig`'s `#[serde(default)]` Local.
+        cfg["resolver"] = serde_json::json!({
+            "backend": "remote",
+            "uds_path": uds_path,
+            "timeout_secs": timeout_secs,
+        });
+    }
+    if let Some(dir) = params.binding_store_dir {
+        cfg["binding_store_dir"] = serde_json::json!(dir);
     }
     cfg
 }
@@ -595,6 +642,8 @@ mod tests {
             tls_intermediate: None,
             network_policy: None,
             raw_egress: false,
+            resolver_remote: None,
+            binding_store_dir: None,
         });
 
         res.expect("spawn with stub endpoint should succeed");
@@ -652,6 +701,8 @@ mod tests {
             tls_intermediate: None,
             network_policy: None,
             raw_egress: false,
+            resolver_remote: None,
+            binding_store_dir: None,
         })
         .expect("spawn with stub endpoint should succeed");
 
@@ -714,6 +765,8 @@ mod tests {
             tls_intermediate: None,
             network_policy: None,
             raw_egress: false,
+            resolver_remote: None,
+            binding_store_dir: None,
         })
         .expect_err("an unparseable handshake is not a ready endpoint");
         assert!(
@@ -777,6 +830,8 @@ mod tests {
             tls_intermediate: None,
             network_policy: None,
             raw_egress: false,
+            resolver_remote: None,
+            binding_store_dir: None,
         });
 
         assert!(result.is_err(), "invalid MVM_HOME must fail sidecar setup");
@@ -834,6 +889,8 @@ mod tests {
             tls_intermediate: None,
             network_policy,
             raw_egress,
+            resolver_remote: None,
+            binding_store_dir: None,
         }
     }
 
@@ -855,6 +912,45 @@ mod tests {
         assert_eq!(cfg["tenant_id"], "tenant-x");
         assert_eq!(cfg["secrets"], serde_json::json!([]));
         assert_eq!(cfg["transport"]["kind"], "uds");
+        // No remote resolver / binding_store_dir requested ⇒ the keys must be
+        // entirely absent (not `null`) so `EndpointConfig`'s `#[serde(default)]`
+        // fields fall back to `Local` / host-default, exactly like before these
+        // two fields existed.
+        assert!(cfg.get("resolver").is_none());
+        assert!(cfg.get("binding_store_dir").is_none());
+    }
+
+    // mvmd's tenant-secrets vault (D8 wiring) needs the endpoint to resolve
+    // values over a UDS to its per-VM resolver daemon, and to read
+    // allowed_hosts/auth_type bindings from a per-VM binding-store dir — not the
+    // host defaults. Assert both land in the JSON exactly as
+    // `mvm_hostd::supervisor::substitution_endpoint::EndpointConfig`'s
+    // `#[serde(tag = "backend", rename_all = "snake_case")]` `ResolverBackend`
+    // and `binding_store_dir` fields expect them shaped. Pure (no subprocess).
+    #[test]
+    fn endpoint_config_json_emits_remote_resolver_and_binding_store_dir() {
+        let redaction = mvm_core::policy::RedactionPolicy::default();
+        let sock = Path::new("/tmp/vsock-5253.sock");
+        let resolver_uds = Path::new("/run/mvmd/tenant-x/resolver.sock");
+        let binding_dir = Path::new("/var/lib/mvm/tenant-x/secret-bindings");
+        let mut params = minimal_params(&redaction, sock, None, false);
+        params.resolver_remote = Some(RemoteResolverSpawnConfig {
+            uds_path: resolver_uds,
+            timeout_secs: 5,
+        });
+        params.binding_store_dir = Some(binding_dir);
+        let cfg = build_endpoint_config_json(&params);
+
+        assert_eq!(cfg["resolver"]["backend"], "remote");
+        assert_eq!(
+            cfg["resolver"]["uds_path"],
+            resolver_uds.to_string_lossy().as_ref()
+        );
+        assert_eq!(cfg["resolver"]["timeout_secs"], 5);
+        assert_eq!(
+            cfg["binding_store_dir"],
+            binding_dir.to_string_lossy().as_ref()
+        );
     }
 
     // The relay path: `Some(policy)` + `raw_egress: true` must land the policy in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //! | [`runtime`] | mvm-runtime | Shell execution, VM lifecycle, template management |
 //! | [`build`] | mvm-build | Nix builder pipeline |
 //! | [`guest`] | mvm-agentd | Vsock protocol, integration manifest, guest agent |
+//! | [`hostd`] | mvm-hostd | Host daemon roles: substitution-endpoint config/assembly, secret keyholder (`FileBindingStore`, `SecretResolver`) |
 //!
 //! ## Usage
 //!
@@ -77,6 +78,17 @@ pub use mvm_build as build;
 ///
 /// See [`mvm_agentd`] for full documentation.
 pub use mvm_agentd as guest;
+
+/// Host daemon roles: the trusted supervisor library (substitution-endpoint
+/// `EndpointConfig`/`assemble`, egress proxy) and the secret keyholder
+/// (`SecretResolver`, `FileBindingStore`, the resolver wire protocol).
+/// mvmd's tenant-secrets vault (Phase 1 egress broker) uses this to write a
+/// VM's `SecretBindingMeta` (`auth_type`/`allowed_hosts`) into the per-VM
+/// binding store the substitution endpoint reads at spawn, and to build the
+/// `EndpointConfig` handed to it on stdin.
+///
+/// See [`mvm_hostd`] for full documentation.
+pub use mvm_hostd as hostd;
 
 // ============================================================================
 // Prelude


### PR DESCRIPTION
## mvm-side primitives for the mvmd tenant-secrets vault (egress credential broker)

These are the shared, mvm-side building blocks the **mvmd** tenant-secrets vault (Phase 1, egress credential broker) builds on. mvmd resolves `${SECRET_NAME}` credentials **host-side** and injects them into outbound requests at the per-VM substitution endpoint — **no key material ever reaches the guest** (it holds only opaque `mvm-secret-…` placeholders). This PR is the mvm half of that seam; the mvmd half is a separate PR that depends on it via the `mvmctl = { path = "../mvm" }` facade.

Stacked on `feat/plan-202-shared-wire`; base advances with it.

### What's here (9 commits)

- **`RemoteResolver` over UDS** (`mvm-hostd::keyholder`) — a synchronous `SecretResolver` that fetches a secret's value from a fleet-secrets daemon over a `0600` Unix socket, mirroring `LocalResolver`'s fail-closed `allowed_hosts` check. Wire types (`ResolveWireRequest`/`ResolveWireResponse`, 4-byte-BE-length + JSON, 1 MiB cap, redacting `Debug`) live once in `mvm_core::substitution_wire` so client and server can't drift.
- **Pluggable resolver backend** — `EndpointConfig` gains a `ResolverBackend::{Local, Remote{uds_path, timeout_secs}}`; `Local` stays byte-identical to prior behavior (unit variant, single store-dir source).
- **Resolver-UDS confinement (M3)** — the substitution endpoint's Landlock profile grants the resolver UDS only when `Remote`; a missing socket surfaces as `PathNotFound` (fail-closed on boot) rather than a silently-empty grant.
- **Facade / spawn plumbing** — additive re-exports so fleet callers (mvmd) can reach what they need without a direct `mvm-sdk`/`mvm-hostd` dependency edge: `mvm_hostd as hostd` (`EndpointConfig`, `FileBindingStore`), `spawn_substitution_endpoint`/`reap_substitution_endpoint`/`SubstitutionSpawnParams`, and `SecretRef`/`SecretMount`. `spawn_substitution_endpoint` now threads `resolver_remote` + `binding_store_dir` through to the endpoint (existing backends pass `None`/`None`, byte-for-byte unchanged).

### Verification

- Per-commit reviewed during development; all touched crates are `fmt` + `clippy` clean. The `substitution_spawn` handshake tests pass isolated/serialized (they flake only under heavy parallel CPU load — a pre-existing 10s-timeout tightness, noted for follow-up, not introduced here).
- Purely **additive** to existing callers — the three VM backends (FC/libkrun/vz) are unchanged, and an omitted `resolver` key deserializes to `Local` (back-compat test present).
- Cross-repo wire coherence is proven end-to-end by the mvmd-side loopback test, which drives this exact `RemoteResolver` against the mvmd resolver daemon.

> Note: 3 pre-existing `clippy` lints in `mvm-backend/src/microvm.rs` (`redundant reference in format!`) predate this branch (base `eb030da`) and are unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
