### PR TITLE
refactor: remove the retired backend's name from the tree, and gate it

### DIFF
--- a/crates/deps/libkrun-sys/examples/libkrun-smoke.rs
+++ b/crates/deps/libkrun-sys/examples/libkrun-smoke.rs
@@ -68,7 +68,7 @@ fn main() -> ExitCode {
     }
 
     // macOS Hypervisor.framework rejects any process that lacks the
-    // `com.apple.security.hypervisor` entitlement (the joint VZ +
+    // `com.apple.security.hypervisor` entitlement (the joint virtualization +
     // Hypervisor entitlement set). `ensure_signed`
     // ad-hoc codesigns the current binary on first run and re-spawns
     // with `MVM_SIGNED=1`; subsequent runs are silent. Without this

--- a/crates/deps/libkrun-sys/src/supervisor.rs
+++ b/crates/deps/libkrun-sys/src/supervisor.rs
@@ -89,7 +89,7 @@ pub struct SupervisorConfig {
     /// `~/.mvm/audit/gateway-events-<vm>.sock` — per-VM ingest
     /// socket an out-of-process gateway bridge connects to (one writer
     /// only). Ignored on libkrun (which spawns its bridge in-process); the
-    /// out-of-process backend that needed it (the removed Vz backend's
+    /// out-of-process backend that needed it (a removed backend's
     /// Swift bridge) is gone, so no current backend sets this.
     #[serde(default)]
     pub gateway_events_socket: Option<std::path::PathBuf>,

--- a/crates/mvm-build/src/bin/mvm-rootfs-patcher.rs
+++ b/crates/mvm-build/src/bin/mvm-rootfs-patcher.rs
@@ -5,7 +5,7 @@
 //! read-write and copies each binary in `/payload` to its install path per
 //! `/payload/manifest` (built by `mvm_build::rootfs_inject`), then powers off.
 //! The result is a rootfs with the current mvm host binaries baked in, produced
-//! with no legacy (vz/libkrun) builder — the primitive that breaks the builder
+//! with no legacy libkrun builder — the primitive that breaks the builder
 //! bootstrap chicken-and-egg.
 //!
 //! Linux-only (mount/reboot syscalls). Cross-compiled to static aarch64-musl; a

--- a/crates/mvm-build/src/builder_backend_select.rs
+++ b/crates/mvm-build/src/builder_backend_select.rs
@@ -621,15 +621,6 @@ mod tests {
         });
     }
 
-    #[test]
-    fn resolve_env_override_vz_is_unrecognised() {
-        // The Vz builder was removed; `vz` is no longer a valid choice and
-        // falls through to auto-detect like any unrecognised value.
-        with_env(Some("vz"), || {
-            assert_eq!(resolve_env_override(), None);
-        });
-    }
-
     // ── Priority: flag > env > auto-detect ──
 
     #[test]
@@ -693,19 +684,6 @@ mod tests {
         assert_eq!(BuilderBackendChoice::Qemu.name(), "qemu");
     }
 
-    /// Compile-time + behaviour guard: the Vz builder choice is gone; every
-    /// remaining choice round-trips through `name()` without yielding "vz".
-    #[test]
-    fn builder_backend_choice_has_no_vz_variant() {
-        for c in [
-            BuilderBackendChoice::Libkrun,
-            BuilderBackendChoice::Qemu,
-            BuilderBackendChoice::Hvf,
-        ] {
-            assert_ne!(c.name(), "vz");
-        }
-    }
-
     #[test]
     fn closure_nar_for_host_arch_is_none_when_the_arch_cache_dir_has_no_closure() {
         let scratch = tempfile::TempDir::new().unwrap();
@@ -743,8 +721,8 @@ mod tests {
 
     #[test]
     fn resolve_builder_backend_with_override_honours_flag() {
-        with_env(Some("vz"), || {
-            // Flag forces libkrun even though env says vz.
+        with_env(Some("not-a-backend"), || {
+            // Flag forces libkrun even though env names an unknown backend.
             let _backend =
                 resolve_builder_backend_with_override(Some(BuilderBackendChoice::Libkrun));
         });
@@ -1067,7 +1045,7 @@ mod tests {
     // ── Hvf attempt order ─────────────────────────────────────
 
     #[test]
-    fn attempt_order_hvf_auto_falls_back_to_libkrun_no_vz() {
+    fn attempt_order_hvf_auto_falls_back_to_libkrun() {
         use BuilderBackendChoice::*;
         assert_eq!(
             builder_attempt_order(Hvf, false, false, false),

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -1160,15 +1160,13 @@ pub fn finalize_install_job(artifact_out: &Path) -> Result<BuilderArtifacts, Bui
 /// the full VM lifetime.
 ///
 /// The lock lives on a **sidecar** `<image>.lock` file, NOT on the
-/// image fd itself. The macOS hypervisor (formerly Apple
-// allow(no-vz): historical design-note reference in a doc comment, not a dependency or API use
-/// `Virtualization.framework`'s `VZDiskImageStorageDeviceAttachment`, now
-/// HVF) takes its own exclusive lock on the disk image at `vm.start()`;
-/// if the host also held an `flock` on the image it would collide
-/// ("The storage device attachment is invalid"). libkrun doesn't lock
-/// the image, so it was unaffected — the sidecar split keeps the
-/// cross-process serialisation while letting the hypervisor open the
-/// image exclusively. The host holds no fd on the image.
+/// image fd itself. The macOS hypervisor takes its own exclusive lock on
+/// the disk image when the VM starts; if the host also held an `flock` on
+/// the image it would collide ("The storage device attachment is
+/// invalid"). libkrun doesn't lock the image, so it was unaffected — the
+/// sidecar split keeps the cross-process serialisation while letting the
+/// hypervisor open the image exclusively. The host holds no fd on the
+/// image.
 ///
 /// `_file: std::fs::File` is **load-bearing** — it's the sidecar lock
 /// handle; dropping the guard releases the lock. Callers must keep the

--- a/crates/mvm-build/src/rootfs_inject.rs
+++ b/crates/mvm-build/src/rootfs_inject.rs
@@ -1,6 +1,6 @@
 //! Self-hosting builder-rootfs bootstrap: inject freshly built mvm host binaries
 //! (`/sbin/mvm-host-vm-init`, …) into a builder rootfs using ONLY the hvf
-//! VMM — no legacy (vz/libkrun) builder.
+//! VMM — no legacy libkrun builder.
 //!
 //! The mechanism is an initramfs boot: this module builds a newc cpio carrying a
 //! tiny patcher init (`mvm-rootfs-patcher`) plus a payload of binaries + a

--- a/crates/mvm-cli/src/commands/GROUPING.md
+++ b/crates/mvm-cli/src/commands/GROUPING.md
@@ -44,7 +44,7 @@ The clear single-verb wins are `attest`/`receipt`/`audit`.)
 **`ops/`** — `ops metrics` · `bench` · `config`.
 
 **`env/`** (D5) — `env bootstrap` · `cleanup` · `uninstall` · `update`
-· `sign` (`env::sign` — re-sign mvmctl+supervisors with VZ entitlements).
+· `sign` (`env::sign` — re-sign mvmctl+supervisors with the VMM entitlements).
 Lift `dev`/`doctor`/`init` OUT of `env/` to their own top-level modules so
 `env/` = the `env` group 1:1.
 

--- a/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
@@ -692,23 +692,21 @@ fn sweep_is_noop_when_root_missing() {
     }
 }
 
-/// Pin that the orphan reaper covers `mvm-builder-vz-<job_id>`
-/// dirs the same way it covers
-/// `mvm-builder-vm-<job_id>`. The traversal in
-/// `reap_orphaned_vm_helpers_at` is prefix-agnostic and
-/// `VzBuilderVm` writes a `builder.pid` sidecar under the shared
-/// `~/.mvm/cache/builder-vm/vms/` tree; this test guards against
-/// a future refactor narrowing either invariant.
+/// Pin that the orphan reaper covers a builder state dir whatever its
+/// name prefix. The traversal in `reap_orphaned_vm_helpers_at` is
+/// prefix-agnostic and every builder writes a `builder.pid` sidecar under
+/// the shared `~/.mvm/cache/builder-vm/vms/` tree; this test guards
+/// against a future refactor narrowing either invariant.
 #[test]
-fn reap_picks_up_orphaned_vz_builder_state_dir() {
+fn reap_picks_up_orphaned_builder_state_dir_regardless_of_prefix() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let vms = tmp.path();
-    let vz_dir = vms.join("mvm-builder-vz-abc12345");
-    std::fs::create_dir_all(&vz_dir).unwrap();
+    let builder_dir = vms.join("mvm-builder-unrecognised-prefix-abc12345");
+    std::fs::create_dir_all(&builder_dir).unwrap();
     // `i32::MAX` is guaranteed not to be a live process on any
     // supported host — classify_pid → Dead, so the dir has no
     // live owner and is eligible for removal.
-    std::fs::write(vz_dir.join("builder.pid"), format!("{}\n", i32::MAX)).unwrap();
+    std::fs::write(builder_dir.join("builder.pid"), format!("{}\n", i32::MAX)).unwrap();
 
     let outcome = reap_orphaned_vm_helpers_at(
         vms,
@@ -721,11 +719,11 @@ fn reap_picks_up_orphaned_vz_builder_state_dir() {
 
     assert_eq!(
         outcome.removed_dirs, 1,
-        "vz builder state dir should be reaped"
+        "builder state dir should be reaped whatever its prefix"
     );
     assert!(
-        !vz_dir.exists(),
-        "vz builder state dir should be gone on disk"
+        !builder_dir.exists(),
+        "builder state dir should be gone on disk"
     );
 }
 

--- a/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
@@ -310,7 +310,7 @@ mod reap_orphans_tests {
 
         let dir = tempfile::tempdir().expect("tempdir");
         let vms_root = dir.path().join("vms");
-        let vm = vms_root.join("mvm-persistent-builder-vz-dev");
+        let vm = vms_root.join("mvm-persistent-builder-hvf-dev");
         std::fs::create_dir_all(&vm).expect("mkdir");
         std::fs::write(vm.join("builder.pid"), format!("{pid}\n")).expect("write pid");
 
@@ -346,7 +346,7 @@ mod reap_orphans_tests {
         let vms_root = dir.path().join("vms");
         let vm = vms_root.join("mvm-workload-livetest-3b1f-running");
         std::fs::create_dir_all(&vm).expect("mkdir");
-        std::fs::write(vm.join("vz.pid"), format!("{pid}\n")).expect("write pid");
+        std::fs::write(vm.join("libkrun.pid"), format!("{pid}\n")).expect("write pid");
 
         let out = reap_orphaned_vm_helpers_at_with_snapshot(
             &vms_root,
@@ -367,8 +367,8 @@ mod reap_orphans_tests {
 
     #[test]
     fn reap_spares_live_hvf_workload_under_launchd() {
-        // Regression: WORKLOAD_SIDECARS previously carried only `vz.pid` /
-        // `libkrun.pid`, so a live HVF supervisor's `hvf.pid` was never read
+        // Regression: WORKLOAD_SIDECARS previously omitted `hvf.pid`, so a
+        // live HVF supervisor's marker was never read
         // in the supervisor phase — an argv-scanned helper match on the same
         // dir could then be misclassified as an unprotected orphan and
         // SIGTERM'd. `hvf.pid` must now be recognised the same as the other
@@ -453,7 +453,7 @@ mod reap_orphans_tests {
 
         let dir = tempfile::tempdir().expect("tempdir");
         let vms_root = dir.path().join("vms");
-        let vm = vms_root.join("mvm-builder-vz-abc12345");
+        let vm = vms_root.join("mvm-builder-hvf-abc12345");
         std::fs::create_dir_all(&vm).expect("mkdir");
         std::fs::write(vm.join("builder.pid"), format!("{pid}\n")).expect("write pid");
 
@@ -496,7 +496,7 @@ mod reap_orphans_tests {
             vec![(helper_pid, helper_cmd)],
         );
 
-        std::fs::write(vm.join("vz.pid"), format!("{sup_pid}\n")).expect("write sup pid");
+        std::fs::write(vm.join("libkrun.pid"), format!("{sup_pid}\n")).expect("write sup pid");
 
         let out = reap_orphaned_vm_helpers_at_with_snapshot(
             &vms_root,
@@ -539,7 +539,8 @@ mod reap_orphans_tests {
             vec![(helper_pid, helper_cmd)],
         );
 
-        std::fs::write(vm.join("vz.pid"), format!("{dead_sup}\n")).expect("write dead sup pid");
+        std::fs::write(vm.join("libkrun.pid"), format!("{dead_sup}\n"))
+            .expect("write dead sup pid");
 
         let out = reap_orphaned_vm_helpers_at_with_snapshot(
             &vms_root,
@@ -564,7 +565,7 @@ mod reap_orphans_tests {
     fn prune_spares_stopped_persistent_builder_store() {
         let dir = tempfile::tempdir().expect("tempdir");
         let vms_root = dir.path().join("vms");
-        let vm = vms_root.join("mvm-persistent-builder-vz-dev");
+        let vm = vms_root.join("mvm-persistent-builder-hvf-dev");
         std::fs::create_dir_all(&vm).expect("mkdir");
         std::fs::write(vm.join("builder.pid"), format!("{}\n", i32::MAX)).expect("write pid");
         std::fs::write(vm.join("store"), vec![0u8; 4096]).expect("write store payload");
@@ -594,7 +595,7 @@ mod reap_orphans_tests {
     fn prune_still_reclaims_dead_ephemeral_builder() {
         let dir = tempfile::tempdir().expect("tempdir");
         let vms_root = dir.path().join("vms");
-        let vm = vms_root.join("mvm-builder-vz-deadjob1");
+        let vm = vms_root.join("mvm-builder-hvf-deadjob1");
         std::fs::create_dir_all(&vm).expect("mkdir");
         std::fs::write(vm.join("builder.pid"), format!("{}\n", i32::MAX)).expect("write pid");
 

--- a/crates/mvm-cli/src/commands/env/builder_vm/vm_helpers.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/vm_helpers.rs
@@ -22,13 +22,12 @@ pub(in crate::commands) struct ReapOutcome {
 ///
 /// The dir traversal below is **prefix-agnostic**: it iterates every
 /// subdirectory of `~/.mvm/cache/builder-vm/vms/` regardless of naming, so
-/// `mvm-builder-vm-<job_id>` (libkrun) state dirs, any HVF builder state
-/// dirs, and leftover `mvm-builder-vz-<job_id>` (the removed Vz backend)
-/// state dirs are all picked up by the same loop, and the sidecar PID
-/// names (`builder.pid` / `stage0.pid`) are shared across backends. The
-/// `reap_picks_up_orphaned_vz_builder_state_dir` test pins the
-/// leftover-Vz-dir case: a future refactor that narrows the traversal or
-/// renames the sidecar must update that test.
+/// `mvm-builder-vm-<job_id>` (libkrun) and HVF builder state dirs are picked
+/// up by the same loop, and the sidecar PID names (`builder.pid` /
+/// `stage0.pid`) are shared across backends. The
+/// `reap_picks_up_orphaned_builder_state_dir_regardless_of_prefix` test pins
+/// that: a future refactor narrowing the traversal or renaming the sidecar
+/// must update it.
 ///
 /// The persistent builder egress wrapper is the one exception to root-scoped
 /// discovery. Its exact argv identifies an internal process whose owner is
@@ -42,7 +41,7 @@ pub(in crate::commands) struct ReapOutcome {
 /// liveness signal, so the sweep runs in two phases per dir:
 ///
 /// 1. **Supervisor phase.** Read the supervisor sidecars (`builder.pid` /
-///    `stage0.pid` / `vz.pid` / `libkrun.pid` / `hvf.pid`: see
+///    `stage0.pid` / `libkrun.pid` / `hvf.pid`: see
 ///    [`is_supervisor_sidecar`]). On a managed dir (the persistent dev
 ///    builder `mvm-persistent-builder-*`, or any named workload under
 ///    `~/.mvm/vms/`) an alive supervisor is the running VM, spared:
@@ -103,11 +102,10 @@ pub(in crate::commands) fn sweep_orphaned_vm_helpers_on_startup() {
 pub(super) const BUILDER_SIDECARS: &[&str] = &["builder.pid", "stage0.pid"];
 
 /// Sidecar PID file names a workload VM dir under `~/.mvm/vms/<name>/`.
-/// `vz.pid` stays recognised so a leftover from the removed Vz backend still
-/// gets reaped. Keep this aligned with the workload supervisor markers in
-/// mvm-runtime's reconciliation pass so every live backend protects its
-/// associated helper processes.
-pub(super) const WORKLOAD_SIDECARS: &[&str] = &["libkrun.pid", "vz.pid", "hvf.pid", "fc.pid"];
+/// Keep this aligned with the workload supervisor markers in mvm-runtime's
+/// reconciliation pass so every live backend protects its associated helper
+/// processes.
+pub(super) const WORKLOAD_SIDECARS: &[&str] = &["libkrun.pid", "hvf.pid", "fc.pid"];
 
 /// Dir-name prefix of the persistent dev builder VM.
 const PERSISTENT_BUILDER_DIR_PREFIX: &str = "mvm-persistent-builder-";
@@ -334,7 +332,7 @@ fn reap_or_track(
 fn is_supervisor_sidecar(name: &str) -> bool {
     matches!(
         name,
-        "builder.pid" | "stage0.pid" | "vz.pid" | "libkrun.pid" | "hvf.pid" | "fc.pid"
+        "builder.pid" | "stage0.pid" | "libkrun.pid" | "hvf.pid" | "fc.pid"
     )
 }
 

--- a/crates/mvm-cli/src/commands/env/group.rs
+++ b/crates/mvm-cli/src/commands/env/group.rs
@@ -29,7 +29,7 @@ pub(in crate::commands) enum EnvCmd {
     Uninstall(uninstall::Args),
     /// Check for and install the latest version of mvmctl
     Update(update::Args),
-    /// Re-sign mvmctl + supervisors with VZ entitlements (macOS)
+    /// Re-sign mvmctl + supervisors with the VMM entitlements (macOS)
     Sign(sign::Args),
 }
 

--- a/crates/mvm-cli/src/commands/env/sign.rs
+++ b/crates/mvm-cli/src/commands/env/sign.rs
@@ -1,5 +1,5 @@
 //! `mvmctl sign` — re-sign mvmctl + supervisor binaries with the
-//! VZ/Hypervisor entitlements (user-facing repair of the auto-sign
+//! virtualization/hypervisor entitlements (user-facing repair of the auto-sign
 //! path). macOS-only; a no-op on other platforms.
 
 use anyhow::Result;
@@ -45,7 +45,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         ui::status_line(&format!("  {} {}:", mark, r.path.display()), verb);
     }
     if reports.iter().all(|r| r.entitlements_present) {
-        ui::success("All binaries carry the VZ + Hypervisor entitlements.");
+        ui::success("All binaries carry the virtualization + hypervisor entitlements.");
         Ok(())
     } else {
         anyhow::bail!("one or more binaries failed to acquire both entitlements");

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -4284,19 +4284,6 @@ fn builder_flag_accepts_libkrun() {
 }
 
 #[test]
-fn builder_flag_rejects_vz() {
-    // The vz backend was removed; `--builder vz` must no longer parse.
-    let err = Cli::try_parse_from(["mvmctl", "--builder", "vz", "doctor"]).unwrap_err();
-    let msg = err.to_string();
-    assert!(
-        msg.contains("invalid value")
-            || msg.contains("possible values")
-            || msg.contains("one of the values isn't valid for an argument"),
-        "expected clap to reject `--builder vz`, got: {msg}"
-    );
-}
-
-#[test]
 fn builder_flag_rejects_unknown_value() {
     // Clap's `value_parser = ["libkrun", "qemu", "hvf"]` should refuse
     // anything outside that set. Catches typos like `=vmz` early

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -20,7 +20,7 @@ use mvm_core::vm_backend::SnapshotCapability;
 use mvm_hostd::audit::bind::class_str;
 use mvm_runtime::checkpoint::{
     CaptureFsQuickParams, CaptureVmFullParams, CheckpointStore, ForkParams, capture_fs_quick,
-    capture_vm_full, checkpoint_is_vz, fork_checkpoint, fork_vm_full_fc,
+    capture_vm_full, checkpoint_carries_supervisor_config, fork_checkpoint, fork_vm_full_fc,
 };
 
 use super::Cli;
@@ -319,38 +319,15 @@ fn rootfs_from_mode_json(state_dir: &std::path::Path) -> Result<Option<PathBuf>>
 }
 
 /// Best-effort liveness: a VM is "running" iff one of its per-backend PID
-/// files names a live process. Mirrors the per-backend `kill(pid, 0)` probe.
+/// files names a live process.
 ///
-/// NOTE: libkrun writes `libkrun.pid` and Firecracker writes `fc.pid`, both
-/// into the shared per-VM directory (`<mvm_home>/vms/<name>/`). The file
-/// names are backend-disjoint, so both probes read the same tree.
+/// Every backend writes its marker into the same per-VM directory
+/// (`<mvm_home>/vms/<name>/`) under a backend-disjoint name, so one pass over
+/// the shared marker list covers all of them. Delegating also picks up the
+/// `EPERM`-means-alive rule, which matters for a root-owned Firecracker: a
+/// bare `kill(pid, 0) == 0` reads that as stopped.
 fn vm_is_running(name: &str) -> bool {
-    let state_dir = vm_state_dir(name);
-    // libkrun.pid lives under vm_state_dir (the host metadata store).
-    let state_dir_running = ["libkrun.pid"]
-        .iter()
-        .filter_map(|f| std::fs::read_to_string(state_dir.join(f)).ok())
-        .filter_map(|s| s.trim().parse::<libc::pid_t>().ok())
-        // SAFETY: signal 0 only probes existence; it delivers nothing.
-        .any(|pid| unsafe { libc::kill(pid, 0) == 0 });
-
-    if state_dir_running {
-        return true;
-    }
-
-    // Firecracker's fc.pid is written via fc_pid_path() (strict resolver —
-    // None in hermetic environments). Probe it so a live FC VM is detected.
-    if let Some(fc_pid_path) = mvm_runtime::microvm::fc_pid_path(name)
-        && let Ok(s) = std::fs::read_to_string(&fc_pid_path)
-        && let Ok(pid) = s.trim().parse::<libc::pid_t>()
-    {
-        // SAFETY: signal 0 only probes existence; it delivers nothing.
-        if unsafe { libc::kill(pid, 0) } == 0 {
-            return true;
-        }
-    }
-
-    false
+    mvm_vmm::host::process_liveness::state_dir_has_live_process(&vm_state_dir(name))
 }
 
 /// fs_quick clones the instance rootfs, so the guest must not be writing:
@@ -855,7 +832,7 @@ fn fork_vm_full_arm(
 
 fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
     // A vm_full fork restores a saved machine state whose cpu/mem are baked
-    // into the snapshot; the removed Vz backend validated device config
+    // into the snapshot; a supervisor-config-bearing backend validated device config
     // against the saved state and refused a mismatch. Accepting these flags
     // would silently fail at restore time with a confusing hypervisor error
     // — refuse early.
@@ -930,14 +907,15 @@ pub(in crate::commands) fn fork_vm_full_arm_fc(
         );
     }
 
-    // Checkpoints captured under the removed Apple-Virtualization backend carry
-    // a supervisor-config.json blob. Their full-VM fork is being re-homed onto
-    // the in-house HVF VMM and is unavailable for now — refuse cleanly.
-    if checkpoint_is_vz(&p.parent_meta) {
+    // A supervisor-config.json blob means the capture rebuilds its VMM from a
+    // persisted supervisor config rather than from Firecracker's snapshot
+    // triple. Only the Firecracker fork path is implemented below, so refuse
+    // cleanly rather than misread the manifest.
+    if checkpoint_carries_supervisor_config(&p.parent_meta) {
         anyhow::bail!(
-            "this vm_full checkpoint was captured under a backend that has been removed; \
-             its full-VM fork is being re-homed onto the in-house HVF VMM and is \
-             unavailable for now. Use an fs_quick fork instead."
+            "this vm_full checkpoint carries a supervisor config, so it was not \
+             captured under Firecracker; full-VM fork is only implemented for \
+             Firecracker captures. Use an fs_quick fork instead."
         );
     }
 
@@ -1020,7 +998,7 @@ pub(in crate::commands) fn fork_vm_full_arm_fc(
         .map(|ctx| ctx.admitted.plan().tenant.0.clone());
 
     // Mint the child's verb-grant sidecar up front so it's readable below for
-    // post-restore delivery. Mirrors the former Vz backend's fork path.
+    // post-restore delivery.
     if let Some(ref plan_json_str) = child_plan_json {
         let mint_cfg = mvm_core::vm_backend::VmStartConfig {
             name: p.child_vm_name.clone(),
@@ -1745,7 +1723,7 @@ mod tests {
 
     /// When mode.json carries `rootfs_path` but the file no longer exists on
     /// disk, the error mentions the pause workflow (same user-visible guidance
-    /// as the former Vz backend's supervisor-config path).
+    /// as a supervisor-config-bearing capture).
     #[test]
     fn mode_json_rootfs_path_missing_on_disk_produces_actionable_error() {
         let mut env = mvm_core::util::test_env::TestEnv::new();

--- a/crates/mvm-cli/src/doctor/builder.rs
+++ b/crates/mvm-cli/src/doctor/builder.rs
@@ -379,7 +379,7 @@ pub(super) fn builder_residency_check() -> Check {
     let session = builder_residency_session_summary(
         policy.kind(),
         mvm_build::persistent_builder::read_active_session().is_some(),
-        builder_vz_snapshot_present(&vms_root),
+        builder_parked_snapshot_present(&vms_root),
     );
     Check {
         name: "builder residency",
@@ -389,11 +389,12 @@ pub(super) fn builder_residency_check() -> Check {
     }
 }
 
-/// The persistent-builder snapshot/park mechanism belonged to the removed Vz
+/// The persistent-builder snapshot/park mechanism belonged to a removed
 /// builder; the libkrun builder has no memory snapshot, so no builder VM
-/// carries a resumable snapshot today.
+/// carries a resumable snapshot today. Always `false` until some builder
+/// grows one.
 #[cfg(feature = "builder-vm")]
-fn builder_vz_snapshot_present(_vms_root: &std::path::Path) -> bool {
+fn builder_parked_snapshot_present(_vms_root: &std::path::Path) -> bool {
     false
 }
 
@@ -401,15 +402,15 @@ fn builder_vz_snapshot_present(_vms_root: &std::path::Path) -> bool {
 fn builder_residency_session_summary(
     kind: mvm_core::residency::ResidencyKind,
     persistent_active: bool,
-    vz_snapshot_present: bool,
+    parked_snapshot_present: bool,
 ) -> &'static str {
     match kind {
-        mvm_core::residency::ResidencyKind::Parked if vz_snapshot_present => {
+        mvm_core::residency::ResidencyKind::Parked if parked_snapshot_present => {
             "parked (snapshot present)"
         }
         mvm_core::residency::ResidencyKind::Parked => "parked (no snapshot)",
         _ if persistent_active => "persistent builder active",
-        _ if vz_snapshot_present => "parked snapshot present",
+        _ if parked_snapshot_present => "parked snapshot present",
         _ => "no persistent builder",
     }
 }

--- a/crates/mvm-cli/src/doctor/runtime.rs
+++ b/crates/mvm-cli/src/doctor/runtime.rs
@@ -46,18 +46,13 @@ mod tests {
     use mvm_core::platform::Platform;
 
     #[test]
-    fn runtime_backend_check_macos_reports_hvf_not_vz() {
+    fn runtime_backend_check_macos_reports_hvf_and_libkrun() {
         let c = runtime_backend_check(Platform::MacOS);
         assert!(c.ok);
         assert!(c.info.contains("`hvf`"), "got: {}", c.info);
         assert!(
             c.info.contains("`libkrun`"),
             "expected libkrun fallback in macOS summary; got: {}",
-            c.info
-        );
-        assert!(
-            !c.info.contains("`vz`"),
-            "stale Vz wording must not remain in runtime backend summary: {}",
             c.info
         );
     }

--- a/crates/mvm-cli/src/doctor/security_checks.rs
+++ b/crates/mvm-cli/src/doctor/security_checks.rs
@@ -563,7 +563,7 @@ pub(super) fn security_snapshot_dirs_check() -> Check {
 }
 
 /// macOS-only: every sign target (mvmctl plus the supervisor binaries) needs
-/// the VZ and Hypervisor entitlements. Probes all paths from
+/// the virtualization and hypervisor entitlements. Probes all paths from
 /// `collect_sign_targets` so an unsigned supervisor is not left unreported.
 /// Off macOS the check is n/a (returns the early-exit n/a `Check`).
 pub(super) fn security_signing_check() -> Check {
@@ -614,7 +614,8 @@ fn signing_check_from_probes(probes: &[(std::path::PathBuf, Option<bool>)]) -> C
             name: "signing",
             category: "security",
             ok: true,
-            info: "VZ + Hypervisor entitlements present on all sign targets".to_string(),
+            info: "virtualization + hypervisor entitlements present on all sign targets"
+                .to_string(),
         }
     } else {
         Check {

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1400,7 +1400,7 @@ fn teardown_transient_vm(
 
     // Top the warm pool back toward target after the run (best-effort,
     // no-daemon replenish-on-use). No-ops when `warm_pool_size == 0`; the
-    // image-bound boot+capture rewarm the removed Vz backend used to do
+    // image-bound boot+capture rewarm a supervisor-config backend used to do
     // stays explicit via `pool warm` so teardown does not spawn background
     // work that can contend with foreground launches.
     if let Err(e) = crate::commands::pool::replenish_after_launch(backend, start_config) {

--- a/crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs
@@ -537,7 +537,7 @@ fn run_with_bridge(mut cfg: SupervisorConfig) -> Result<std::convert::Infallible
     // reaching this code).
     //
     // Leaf capabilities are fixed per backend: libkrun reports
-    // `payload_tap: true`. The Vz drainer will
+    // `payload_tap: true`. The drainer will
     // set `payload_tap: false` from its own bin.
     let leaf_caps = mvm_hostd::supervisor::network::ProviderCapabilities {
         flow_events: true,

--- a/crates/mvm-hostd/src/supervisor/audit.rs
+++ b/crates/mvm-hostd/src/supervisor/audit.rs
@@ -237,7 +237,7 @@ impl FlowDirection {
 /// catch / I/O error / drop guard. `PolicyDropped` is the
 /// `FlowPolicy` hook returning `FlowAction::Drop` — the substrate
 /// enforcement plugs into. `Shutdown` covers graceful
-/// supervisor teardown (Vz Swift bridge cancellation, libkrun
+/// supervisor teardown (libkrun
 /// `exit()`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/mvm-hostd/src/supervisor/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/mod.rs
@@ -53,7 +53,7 @@ pub mod firewall;
 // mpsc.
 pub mod gateway_audit;
 // Per-VM gateway audit bridge. Splices guest virtio-net <-> host
-// gateway (passt / native gateway / Vz ingest), emits FlowOpened/FlowClosed
+// gateway (passt / native gateway), emits FlowOpened/FlowClosed
 // through a per-VM signer_task into the claim-8 chain, broadcasts
 // NDJSON to gateway_audit subscribers, and exposes a `FlowPolicy` hook
 // for SNI / L7 inspectors.

--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -422,7 +422,7 @@ impl ObserverAllowlist {
 /// the `Vec<Arc<dyn Observer>>` for `BridgeConfig.observers`.
 ///
 /// The leaf capability is fixed at construction-time per backend:
-/// libkrun + Firecracker leaves report `payload_tap: true`; Vz drainer
+/// libkrun + Firecracker leaves report `payload_tap: true`; the drainer
 /// reports `payload_tap: false`.
 ///
 /// `local-default` plan refs short-circuit to empty observers without

--- a/crates/mvm-runtime/examples/hvf-builder-transport.rs
+++ b/crates/mvm-runtime/examples/hvf-builder-transport.rs
@@ -128,7 +128,7 @@ fn main() {
     if ok {
         println!(
             "PROOF: the builder ran on the HVF VMM and the output tar came \
-             back to the host. No vz, no virtio-fs."
+             back to the host. No virtio-fs."
         );
     } else {
         eprintln!("FAILED: job did not complete cleanly (see output + result above)");

--- a/crates/mvm-runtime/examples/hvf-rootfs-inject.rs
+++ b/crates/mvm-runtime/examples/hvf-rootfs-inject.rs
@@ -1,6 +1,6 @@
 //! Self-hosting builder-rootfs bootstrap: inject the freshly
 //! cross-compiled `mvm-host-vm-init` into a builder rootfs using ONLY the hvf
-//! VMM — no vz, no legacy builder. Thin driver over
+//! VMM — no legacy builder. Thin driver over
 //! `mvm_runtime::builder_runner::inject_host_binaries`. Output: a patched rootfs
 //! at `$OUT` (default `/tmp/mvm-patched-rootfs.ext4`).
 //!
@@ -66,7 +66,7 @@ fn main() {
 
     println!(
         "PROOF: the hvf VMM patched a builder rootfs with the current \
-         mvm-host-vm-init — no vz, no legacy builder. Patched rootfs: {}",
+         mvm-host-vm-init — no legacy builder. Patched rootfs: {}",
         out.display()
     );
 }

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -1212,13 +1212,16 @@ mod tests {
     }
 
     #[test]
-    fn from_hypervisor_vz_falls_back_to_default_not_vz() {
-        // The Vz backend is deleted: the `vz` / `virtualization` selectors no
-        // longer resolve to a distinct Vz backend and fall through to the
-        // default like any unrecognised hypervisor value.
-        for alias in ["vz", "virtualization"] {
+    fn from_hypervisor_falls_back_to_default_for_unrecognised_selectors() {
+        // An unknown selector must resolve to the default backend rather than
+        // silently naming itself, so a typo cannot conjure a backend.
+        for alias in ["virtualization", "not-a-hypervisor", ""] {
             let backend = AnyBackend::from_hypervisor(alias);
-            assert_ne!(backend.name(), "vz", "alias {alias} must not resolve to Vz");
+            assert_ne!(
+                backend.name(),
+                alias,
+                "unrecognised selector {alias:?} must fall through to the default"
+            );
         }
     }
 

--- a/crates/mvm-runtime/src/builder_runner/inject.rs
+++ b/crates/mvm-runtime/src/builder_runner/inject.rs
@@ -1,5 +1,5 @@
 //! Self-hosting rootfs bootstrap primitive: inject mvm host binaries into a
-//! builder rootfs using ONLY the hvf VMM (no vz / no legacy builder).
+//! builder rootfs using ONLY the hvf VMM (no legacy builder).
 //!
 //! Boots `kernel + an inject initramfs + a writable copy of the base rootfs`; the
 //! `mvm-rootfs-patcher` init (carried in the initramfs) mounts the rootfs

--- a/crates/mvm-runtime/src/checkpoint/mod.rs
+++ b/crates/mvm-runtime/src/checkpoint/mod.rs
@@ -13,8 +13,9 @@ use crate::lineage::{LineageAnchor, LineageGraph, LineageRecord};
 
 /// Filename of the persisted supervisor launch config inside a vm_full
 /// checkpoint's content dir. Present only on checkpoints captured from a
-/// backend that writes a supervisor config (legacy captures); Firecracker
-/// checkpoints omit it, which is how [`checkpoint_is_vz`] distinguishes them.
+/// backend that writes a supervisor config (today, HVF); Firecracker
+/// checkpoints omit it, which is how
+/// [`checkpoint_carries_supervisor_config`] distinguishes them.
 pub const SUPERVISOR_CONFIG_FILE_NAME: &str = "supervisor-config.json";
 
 /// Filesystem-backed registry over `config::checkpoints_dir()` (or any root,
@@ -322,17 +323,19 @@ const FORK_ALLOW_PARENT_RUNNING: bool = false;
 /// Boots a forked child from its staged snapshot files. Abstracted so
 /// `fork_vm_full_fc` is testable without a live hypervisor; the FC impl
 /// (`FcForkRestorer`) lives in `crate::firecracker` and is the only current
-/// non-Vz implementation.
+/// implementation.
 pub trait ForkVmFullRestorer {
     /// Stage the child's snapshot into position and start the VM. `child_dir`
     /// is the child's state dir with all checkpoint blobs already cloned there.
     fn restore_fork(&self, child_vm_name: &str, child_dir: &std::path::Path) -> Result<()>;
 }
 
-/// Returns `true` when the checkpoint was captured from a Vz VM (its content
-/// manifest carries a `supervisor-config.json` blob). FC checkpoints do not
-/// include that blob — use this to dispatch fork to the right path.
-pub fn checkpoint_is_vz(meta: &mvm_core::checkpoint::CheckpointMeta) -> bool {
+/// Returns `true` when the checkpoint's content manifest carries a
+/// `supervisor-config.json` blob — i.e. it was captured from a backend that
+/// rebuilds its VMM from a persisted supervisor config (today, HVF).
+/// Firecracker checkpoints omit that blob, so this dispatches fork to the
+/// right path.
+pub fn checkpoint_carries_supervisor_config(meta: &mvm_core::checkpoint::CheckpointMeta) -> bool {
     meta.content
         .iter()
         .any(|b| b.name == SUPERVISOR_CONFIG_FILE_NAME)
@@ -568,18 +571,14 @@ fn validate_child_fork_plan(params: &ForkParams) -> Result<()> {
 
 /// Liveness probe for a VM by name: any backend pid marker whose process still
 /// exists. Missing or malformed markers are treated as stopped.
+///
+/// Delegates to the shared marker list so a backend cannot be live here and
+/// stopped elsewhere. This gates the refuse-to-fork-a-live-parent rule, so a
+/// marker this probe does not know reads as stopped and lets a fork through.
 fn vm_is_running(vm_name: &str) -> bool {
-    ["fc.pid", "vz.pid"].into_iter().any(|marker| {
-        let pid_file = mvm_core::config::vm_state_dir(vm_name).join(marker);
-        let Ok(s) = std::fs::read_to_string(pid_file) else {
-            return false;
-        };
-        let Ok(pid) = s.trim().parse::<libc::pid_t>() else {
-            return false;
-        };
-        // kill(pid, 0) → 0 if the process exists, -1/ESRCH if not.
-        unsafe { libc::kill(pid, 0) == 0 }
-    })
+    mvm_vmm::host::process_liveness::state_dir_has_live_process(&mvm_core::config::vm_state_dir(
+        vm_name,
+    ))
 }
 
 pub use mvm_core::checkpoint::DeviceAnchors;
@@ -593,7 +592,7 @@ pub struct CaptureVmFullParams {
     pub runtime_overlay_version: Option<String>,
     /// The live VM's persisted supervisor config, copied into the checkpoint so
     /// restore can rebuild the state dir (every stop reaps the live one).
-    /// `None` for backends that do not use a Vz-style supervisor config (the
+    /// `None` for backends that do not persist a supervisor config (the
     /// blob is omitted from the checkpoint manifest and restore is handled
     /// differently by those backends).
     pub supervisor_config_src: Option<PathBuf>,
@@ -660,7 +659,7 @@ fn capture_vm_full_inner(
         let live_rootfs = control.rootfs_path()?;
         crate::base::cow::clone_rootfs_for_instance(&live_rootfs, &rootfs_dst)
             .context("cloning rootfs in the pause window")?;
-        // Collect the machine-id sidecar when the backend wrote one (e.g. Vz).
+        // Collect the machine-id sidecar when the backend wrote one.
         // Backends that do not have a machine-id concept (e.g. Firecracker) skip
         // this step — the blob is absent from the manifest and restore does not
         // require it.
@@ -707,7 +706,7 @@ fn capture_vm_full_inner(
 
     // Persist the launch config into the checkpoint when the backend provides one.
     // Restore needs it to rebuild the state dir the stop reaped. Backends that do
-    // not use a Vz-style supervisor config omit this blob.
+    // not persist a supervisor config omit this blob.
     if let Some(ref src) = params.supervisor_config_src {
         let config_dst = content_dir.join(SUPERVISOR_CONFIG_FILE_NAME);
         std::fs::copy(src, &config_dst).with_context(|| {
@@ -2112,26 +2111,26 @@ mod tests {
         );
     }
 
-    // ── checkpoint_is_vz ────────────────────────────────────────────────────
+    // ── checkpoint_carries_supervisor_config ────────────────────────────────
 
     #[test]
-    fn checkpoint_is_vz_true_when_supervisor_config_blob_present() {
+    fn supervisor_config_detected_when_the_blob_is_present() {
         let tmp = tempfile::tempdir().unwrap();
         let store = CheckpointStore::at(tmp.path().join("store"));
-        let meta = seed_vm_full_checkpoint(&store, tmp.path(), "vz1");
+        let meta = seed_vm_full_checkpoint(&store, tmp.path(), "supcfg1");
         assert!(
-            checkpoint_is_vz(&meta),
-            "Vz checkpoint carries the supervisor-config.json blob"
+            checkpoint_carries_supervisor_config(&meta),
+            "a supervisor-config-bearing checkpoint is detected by the blob"
         );
     }
 
     #[test]
-    fn checkpoint_is_vz_false_for_fc_checkpoint() {
+    fn supervisor_config_absent_for_fc_checkpoint() {
         let tmp = tempfile::tempdir().unwrap();
         let store = CheckpointStore::at(tmp.path().join("store"));
         let meta = seed_fc_vm_full_checkpoint(&store, tmp.path(), "fc1");
         assert!(
-            !checkpoint_is_vz(&meta),
+            !checkpoint_carries_supervisor_config(&meta),
             "FC checkpoint has no supervisor-config.json blob"
         );
     }
@@ -2181,19 +2180,31 @@ mod tests {
         assert!(same_vm.to_string().contains("child VM name"));
     }
 
+    /// Every workload backend's marker counts, not just Firecracker's. This
+    /// probe gates the refuse-to-fork-a-live-parent rule, so a backend whose
+    /// marker went unrecognised would read as stopped and let a fork proceed
+    /// against a running VM.
     #[test]
-    fn vm_is_running_detects_firecracker_and_legacy_pid_markers() {
+    fn vm_is_running_detects_every_workload_backend_pid_marker() {
         let tmp = tempfile::tempdir().unwrap();
         let mut env = mvm_core::util::test_env::TestEnv::new();
         env.set("MVM_HOME", tmp.path());
         let state = mvm_core::config::vm_state_dir("pid-check");
         std::fs::create_dir_all(&state).unwrap();
-        std::fs::write(state.join("fc.pid"), std::process::id().to_string()).unwrap();
-        assert!(vm_is_running("pid-check"));
 
-        std::fs::remove_file(state.join("fc.pid")).unwrap();
-        std::fs::write(state.join("vz.pid"), std::process::id().to_string()).unwrap();
-        assert!(vm_is_running("pid-check"));
+        for marker in ["fc.pid", "hvf.pid", "libkrun.pid", "qemu.pid"] {
+            std::fs::write(state.join(marker), std::process::id().to_string()).unwrap();
+            assert!(
+                vm_is_running("pid-check"),
+                "{marker} must read as a live parent"
+            );
+            std::fs::remove_file(state.join(marker)).unwrap();
+        }
+
+        assert!(
+            !vm_is_running("pid-check"),
+            "no marker left means the VM is stopped"
+        );
     }
 
     #[test]
@@ -2320,7 +2331,7 @@ mod tests {
         )
         .unwrap();
 
-        // The FC triple is cloned into the child's state dir; no Vz supervisor
+        // The FC triple is cloned into the child's state dir; no supervisor
         // config or machine-id ever existed for this checkpoint.
         for name in ["rootfs.ext4", "memory.bin", "vmstate.bin"] {
             assert!(dest.join(name).exists(), "{name} not cloned");

--- a/crates/mvm-runtime/src/codesign.rs
+++ b/crates/mvm-runtime/src/codesign.rs
@@ -1,5 +1,5 @@
-//! macOS codesigning of mvm's VMM binaries with the Virtualization +
-//! Hypervisor entitlements.
+//! macOS codesigning of mvm's VMM binaries with the virtualization +
+//! hypervisor entitlements.
 //!
 //! Apple Hypervisor.framework refuses to launch a VM unless the
 //! launching binary carries both `com.apple.security.virtualization` and
@@ -15,7 +15,7 @@ pub struct SignReport {
     pub path: PathBuf,
     /// Whether codesign was (re)applied during this call.
     pub applied: bool,
-    /// Whether both VZ + Hypervisor entitlements are present after.
+    /// Whether both entitlements are present after.
     pub entitlements_present: bool,
 }
 
@@ -33,7 +33,7 @@ pub fn entitlements_present(path: &Path) -> Option<bool> {
     }
 }
 
-/// Ad-hoc re-sign each target with the VZ + Hypervisor entitlements and
+/// Ad-hoc re-sign each target with both entitlements and
 /// report the post-sign state. No-op (empty) off macOS.
 pub fn sign_binaries(targets: &[PathBuf]) -> Vec<SignReport> {
     #[cfg(target_os = "macos")]
@@ -47,7 +47,7 @@ pub fn sign_binaries(targets: &[PathBuf]) -> Vec<SignReport> {
     }
 }
 
-/// The binaries that need VZ/Hypervisor entitlements to launch a VM:
+/// The binaries that need both entitlements to launch a VM:
 /// the running CLI plus whichever supervisors resolve on this host.
 /// Unresolved supervisors are silently skipped (a host may have only
 /// one backend installed).
@@ -101,8 +101,8 @@ mod macos {
         }
     }
 
-    /// Sign the binary ad-hoc with both VZ and Hypervisor.framework
-    /// entitlements (no self-restart).
+    /// Sign the binary ad-hoc with both Virtualization.framework and
+    /// Hypervisor.framework entitlements (no self-restart).
     fn sign_binary(exe_str: &str) {
         let ent_path = std::env::temp_dir().join("mvm-entitlements.plist");
         if std::fs::write(&ent_path, ENTITLEMENTS_PLIST).is_err() {

--- a/crates/mvm-runtime/src/compat.rs
+++ b/crates/mvm-runtime/src/compat.rs
@@ -15,7 +15,7 @@
 //!   TAP device. It provides transparent guest TCP/UDP for the dev tier; it
 //!   is not part of the production claim boundary.
 //!
-//! `MicrovmBackend` has no `Hvf` variant yet (the removed Vz backend's row
+//! `MicrovmBackend` has no `Hvf` variant yet (a removed backend's row
 //! was deleted rather than repurposed); the raw HVF backend
 //! (`crates/mvm-runtime/src/hvf_backend.rs`) does not go through this table.
 

--- a/crates/mvm-runtime/src/vm/reconcile.rs
+++ b/crates/mvm-runtime/src/vm/reconcile.rs
@@ -761,7 +761,7 @@ mod tests {
         let root = tmp.path();
         let dir = root.join("hvf-vm");
         std::fs::create_dir_all(&dir).unwrap();
-        // Only hvf.pid present (no libkrun.pid / vz.pid), pointing at us.
+        // Only hvf.pid present (no libkrun.pid / fc.pid), pointing at us.
         std::fs::write(dir.join("hvf.pid"), std::process::id().to_string()).unwrap();
 
         let view = FsRuntimeView::new(root);

--- a/crates/mvm-vmm/src/checkpoint.rs
+++ b/crates/mvm-vmm/src/checkpoint.rs
@@ -16,7 +16,7 @@ pub trait VmFullControl {
     fn pause(&self) -> Result<()>;
     /// Save machine memory state to `memory_path` while paused; also writes a
     /// `<memory_path>.machine-id` sidecar when the backend has a machine
-    /// identifier (e.g. Vz). Backends that do not have a separate machine-id
+    /// identifier. Backends that do not have a separate machine-id
     /// concept (e.g. Firecracker) may skip the sidecar — the caller only
     /// promotes it to a content blob when the file exists.
     fn save_memory(&self, memory_path: &Path) -> Result<()>;

--- a/crates/mvm-vmm/src/host/audit_substrate.rs
+++ b/crates/mvm-vmm/src/host/audit_substrate.rs
@@ -1,6 +1,6 @@
 //! Shared audit-substrate resolution for backends that own a
 //! `SupervisorConfig`-shaped audit surface. Currently used by libkrun
-//! only; the removed Vz backend used to share it too, and the hvf
+//! only; a removed backend used to share it too, and the hvf
 //! backend may adopt it as its own audit surface lands.
 //!
 //! Lifts the path-derivation + `vm_name` / `tenant_id` allowlist

--- a/crates/mvm-vmm/src/host/process_liveness.rs
+++ b/crates/mvm-vmm/src/host/process_liveness.rs
@@ -2,14 +2,10 @@
 
 use std::path::{Path, PathBuf};
 
-const PID_FILE_NAMES: &[&str] = &[
-    "libkrun.pid",
-    "vz.pid",
-    "hvf.pid",
-    "fc.pid",
-    "qemu.pid",
-    "pid",
-];
+/// Supervisor PID markers, one per workload backend plus the generic `pid`
+/// fallback. This is the single list every liveness probe reads — a backend
+/// missing here reads as stopped everywhere at once.
+const PID_FILE_NAMES: &[&str] = &["libkrun.pid", "hvf.pid", "fc.pid", "qemu.pid", "pid"];
 
 /// `kill(pid, 0)` existence probe — delivers no signal, just checks the
 /// process is alive. `EPERM` is a positive existence result for a supervisor

--- a/examples/sleeper/flake.nix
+++ b/examples/sleeper/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "sleeper — long-lived sealed workload fixture for live Vz validation.";
+  description = "sleeper — long-lived sealed workload fixture for live validation.";
 
   # A minimal sealed (prod) workload whose PID-1 command never exits, so the
   # VM stays resident long enough to checkpoint / fork / pause / resume and be

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -316,7 +316,7 @@ const PROC_SUB: &[(&str, AuditPosture)] = &[
 ];
 
 // `snapshot` now covers only the Firecracker instance-snapshot inventory verbs
-// (`ls` / `rm`). The Vz machine-state save/restore verbs were retired in favor
+// (`ls` / `rm`). The machine-state save/restore verbs were retired in favor
 // of `checkpoint --class vm-full` / `checkpoint restore`.
 const SNAPSHOT_SUB: &[(&str, AuditPosture)] = &[
     ("ls", AuditPosture::ReadOnly),

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -774,7 +774,7 @@ fn shared_kernel_base_forces_hvc0_console_support() {
     assert!(
         content.contains("\"VIRTIO_CONSOLE\"") && content.contains("\"HVC_DRIVER\""),
         "the shared microVM kernel base must force both VIRTIO_CONSOLE and \
-         HVC_DRIVER when libkrun/vz workloads boot with `console=hvc0`; \
+         HVC_DRIVER when libkrun workloads boot with `console=hvc0`; \
          otherwise the kernel can boot silently even though the backend \
          wires a virtio-console."
     );

--- a/xtask/src/check_kernel_config_budget.rs
+++ b/xtask/src/check_kernel_config_budget.rs
@@ -25,9 +25,9 @@ use std::path::Path;
 /// SoC-errata and other off-the-boot-path subsystems), each cut boot-validated
 /// under libkrun.
 ///
-/// PCI was re-added after the initial shrink dropped it: vz (Apple
-/// Virtualization.framework) presents virtio over PCI, not MMIO, so a PCI-less
-/// kernel boots blind under vz (no console/net/block). Re-enabling PCI +
+/// PCI was re-added after the initial shrink dropped it: a backend that
+/// presents virtio over PCI rather than MMIO leaves a PCI-less kernel booting
+/// blind (no console/net/block). Re-enabling PCI +
 /// PCI_MSI + VIRTIO_PCI raised x86_64 by 73 (1130 → 1203, measured). aarch64 is
 /// set to a comparable delta (core PCI is arch-shared; the SoC PCIe host
 /// controllers stay off since their deps are disabled) and is confirmed by CI's

--- a/xtask/src/check_no_string_backend_dispatch.rs
+++ b/xtask/src/check_no_string_backend_dispatch.rs
@@ -21,10 +21,10 @@ use anyhow::{Context, Result, bail};
 use regex::Regex;
 use std::path::Path;
 
-/// The full known-backend-selector set, including the retired `vz` — a
-/// reintroduced `vz` arm is exactly the regression this lint exists to
-/// catch, since there is no `BackendKind::Vz` for it to belong to.
-const BACKEND_SELECTORS: &str = "firecracker|libkrun|hvf|qemu|mock|vz";
+/// The full known-backend-selector set. A retired backend's selector is not
+/// listed here: `check-no-vz` bans naming it at all, which is a stricter
+/// rule than this lint could express.
+const BACKEND_SELECTORS: &str = "firecracker|libkrun|hvf|qemu|mock";
 
 /// This file's own doc comment above describes the banned shapes in prose
 /// rather than as literal comparisons, so it never matches its own
@@ -112,17 +112,6 @@ mod tests {
             tmp.path(),
             "bad.rs",
             "fn f(b: &dyn VmBackend) -> bool { b.name() == \"libkrun\" }\n",
-        );
-        assert!(run(tmp.path()).is_err());
-    }
-
-    #[test]
-    fn dead_vz_arm_is_flagged() {
-        let tmp = tempfile::tempdir().unwrap();
-        write(
-            tmp.path(),
-            "bad.rs",
-            "fn f(b: &dyn VmBackend) -> bool { b.name() == \"vz\" }\n",
         );
         assert!(run(tmp.path()).is_err());
     }

--- a/xtask/src/check_no_vz.rs
+++ b/xtask/src/check_no_vz.rs
@@ -8,15 +8,31 @@
 //! guest-side kernel image itself, and the Containerization SwiftPM
 //! package — including its `vminitd` init — is banned outright.
 //!
-//! Flags VZ API symbols (`VZVirtualMachine*`, `VZLinuxBootLoader`,
-//! `VZDiskImage*`), Swift imports (`import Virtualization`,
-//! `import Containerization`), the SwiftPM package URL, and SwiftPM
-//! manifests (`swift-tools-version`) in `crates/*/src/**/*.rs`, plus any
+//! Two rules, because there are two ways the retired backend comes back.
+//!
+//! **Usage.** Flags VZ API symbols (`VZVirtualMachine*`,
+//! `VZLinuxBootLoader`, `VZDiskImage*`), Swift imports
+//! (`import Virtualization`, `import Containerization`), the SwiftPM
+//! package URL, and SwiftPM manifests (`swift-tools-version`), plus any
 //! `Package.swift` / `Package.resolved` / `*.swift` file anywhere under
-//! the workspace root (`target/`, `.git/`, and `node_modules/` skipped), so a Swift shim
-//! cannot sneak in outside the crates tree either. Prose references like
-//! "no Virtualization.framework" do not match — the needles target usage
-//! (symbols, imports, package coordinates), not words.
+//! the workspace root (`target/`, `.git/`, and `node_modules/` skipped),
+//! so a Swift shim cannot sneak in outside the crates tree either.
+//!
+//! **Naming.** Flags a bare `vz` / `Vz` / `VZ` word anywhere in the Rust
+//! we own (`crates/`, `tests/`, `src/`, `examples/`, `xtask/`). The usage
+//! rule alone left the name free to persist for months after the backend
+//! was deleted — in a `vz.pid` marker still probed at runtime, in a
+//! `checkpoint_is_vz` predicate that had silently come to mean "HVF", and
+//! in user-facing text blaming a backend the user never ran. A name on a
+//! live code path is not cosmetic: it misdescribes what actually executes.
+//! `virtualization` does not match, so Apple's
+//! `com.apple.security.virtualization` entitlement — still required
+//! alongside `com.apple.security.hypervisor` — is unaffected.
+//!
+//! This lint's own names (`check-no-vz`, `check_no_vz`, `allow(no-vz)`,
+//! `NO_VZ`) are elided before the naming rule runs, so the gate and its
+//! registration can spell the word without ceremony while any other
+//! mention on the same line still trips.
 //!
 //! Opt-out: `// allow(no-vz): <reason>` on the line directly above the
 //! mention (one per line). Reserved for historical design notes — never a
@@ -42,6 +58,21 @@ const NO_VZ_NEEDLES: &[&str] = &[
 ];
 const ALLOW_MARKER: &str = "// allow(no-vz):";
 
+/// Bare `vz` / `Vz` / `VZ` as a whole word. The symbol needles above only
+/// stop the framework being *used*; this stops the retired backend being
+/// *named* — in an identifier, a path fragment like `vz.pid`, a test
+/// fixture, or a user-facing string. A stale name on a live code path is
+/// worse than clutter: a marker list or dispatch predicate carrying it
+/// misdescribes which backend actually runs there.
+///
+/// Bounded by any non-alphanumeric on both sides. `_` counts as a boundary
+/// on purpose: snake_case is where this actually hides — `checkpoint_is_vz`
+/// is the case that motivated the rule, and treating `_` as a word
+/// character would let every `*_vz` / `vz_*` identifier through.
+/// Alphanumerics still bind, so `virtualization` does not match and neither
+/// does a hash that happens to contain the pair.
+const NO_VZ_IDENT: &str = r"(?i)(?:^|[^0-9A-Za-z])vz(?:[^0-9A-Za-z]|$)";
+
 /// File names (or the Swift extension) scanned outside the crates tree so
 /// a SwiftPM shim cannot be introduced under a non-crate path.
 fn is_swift_surface(path: &Path) -> bool {
@@ -58,8 +89,21 @@ pub fn run(workspace: &Path) -> Result<()> {
     }
     let mut findings: Vec<String> = Vec::new();
 
-    // Rust sources under crates/.
-    visit_rust_files(&crates_dir, &mut |path| scan(path, &mut findings))?;
+    // Rust sources we own, checked for usage needles *and* bare `vz` names.
+    // `xtask/` is included so a gate cannot quietly reintroduce the word,
+    // except in this file, which has to spell it to ban it.
+    for root in ["crates", "tests", "src", "examples", "xtask"] {
+        let dir = workspace.join(root);
+        if !dir.is_dir() {
+            continue;
+        }
+        visit_rust_files(&dir, &mut |path| {
+            if path.ends_with("xtask/src/check_no_vz.rs") {
+                return Ok(());
+            }
+            scan_idents(path, &mut findings)
+        })?;
+    }
     // SwiftPM manifests and Swift sources anywhere under the root.
     visit_swift_surface(workspace, &mut |path| scan(path, &mut findings))?;
 
@@ -71,30 +115,52 @@ pub fn run(workspace: &Path) -> Result<()> {
         return Ok(());
     }
     eprintln!(
-        "check-no-vz: {} VZ/Containerization mention(s) — the Apple Container backend is 100% \
-         Rust-native: it boots Apple's prebuilt container kernel with the universal initramfs on \
-         the in-house HVF VMM. Virtualization.framework, SwiftPM, and the Containerization \
-         package (including vminitd) are banned from the tree. If this is a genuine historical \
-         design note, annotate with `// allow(no-vz): <reason>`:",
+        "check-no-vz: {} mention(s) — the retired backend is gone and stays gone. The Apple \
+         Container backend is 100% Rust-native: it boots Apple's prebuilt container kernel with \
+         the universal initramfs on the in-house HVF VMM. Virtualization.framework, SwiftPM, and \
+         the Containerization package (including vminitd) are banned from the tree, and so is \
+         naming the retired backend in an identifier, a pid-marker string, a test fixture, or \
+         user-facing text. If this is a genuine historical design note, annotate with \
+         `// allow(no-vz): <reason>`:",
         findings.len()
     );
     for f in &findings {
         eprintln!("  {f}");
     }
-    bail!(
-        "check-no-vz: {} unannotated VZ/Containerization mention(s)",
-        findings.len()
-    );
+    bail!("check-no-vz: {} unannotated mention(s)", findings.len());
 }
 
 /// Scan one file line-by-line for the needles, honoring the per-line
 /// opt-out marker on the line directly above.
 fn scan(path: &Path, findings: &mut Vec<String>) -> Result<()> {
+    scan_with(path, findings, false)
+}
+
+/// As [`scan`], plus the bare-identifier rule. Split out because the
+/// identifier rule applies to Rust/Nix/Markdown sources we own, while the
+/// Swift-surface sweep only ever needs the usage needles.
+fn scan_idents(path: &Path, findings: &mut Vec<String>) -> Result<()> {
+    scan_with(path, findings, true)
+}
+
+/// This lint's own names, which necessarily contain the banned word. Elided
+/// before the identifier rule runs so the gate, its registration, and any
+/// doc comment pointing at it can spell it without an allow-marker — while
+/// every *other* mention on the same line still trips.
+const SELF_NAMES: &[&str] = &["check-no-vz", "check_no_vz", "allow(no-vz)", "NO_VZ"];
+
+fn scan_with(path: &Path, findings: &mut Vec<String>, idents: bool) -> Result<()> {
     let src =
         std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let ident = regex::Regex::new(NO_VZ_IDENT).expect("NO_VZ_IDENT is a valid regex");
     let lines: Vec<&str> = src.lines().collect();
     for (i, line) in lines.iter().enumerate() {
-        if NO_VZ_NEEDLES.iter().any(|n| line.contains(n)) {
+        let without_self_names = SELF_NAMES
+            .iter()
+            .fold(line.to_string(), |acc, n| acc.replace(n, ""));
+        let hit = NO_VZ_NEEDLES.iter().any(|n| line.contains(n))
+            || (idents && ident.is_match(&without_self_names));
+        if hit {
             let allowed = i > 0 && lines[i - 1].trim_start().starts_with(ALLOW_MARKER);
             if !allowed {
                 findings.push(format!("{}:{}: {}", path.display(), i + 1, line.trim()));
@@ -206,6 +272,49 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("main.swift"), "import Virtualization\n").unwrap();
         assert!(run(tmp.path()).is_err());
+    }
+
+    #[test]
+    fn a_bare_vz_identifier_is_flagged() {
+        // The failure this rule exists for: a marker string on a live code
+        // path, naming a backend that no longer runs.
+        for line in [
+            r#"const MARKERS: &[&str] = &["vz.pid", "fc.pid"];"#,
+            "pub fn checkpoint_is_vz(m: &Meta) -> bool { false }\n",
+            r#"    ui::success("re-signed with VZ entitlements");"#,
+            "// The removed Vz backend used to do this.\n",
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            write_rust(tmp.path(), "x.rs", line);
+            assert!(
+                run(tmp.path()).is_err(),
+                "must flag a bare vz mention: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn words_merely_containing_the_pair_are_not_flagged() {
+        // `virtualization` must survive: Apple's entitlement key is still
+        // required, so a substring rule here would be unusable.
+        let tmp = tempfile::tempdir().unwrap();
+        write_rust(
+            tmp.path(),
+            "ok.rs",
+            "const E: &str = \"com.apple.security.virtualization\";\nconst H: &str = \"abvzcd\";\n",
+        );
+        assert!(run(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn an_annotated_vz_mention_is_allowed() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_rust(
+            tmp.path(),
+            "ok.rs",
+            "// allow(no-vz): historical design note\n/// The removed Vz backend locked the image.\nfn f() {}\n",
+        );
+        assert!(run(tmp.path()).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #2234 (the mutation-baseline re-pin there is a prerequisite).

The Apple Virtualization backend was deleted a month ago, but its name survived in 97 places. Three were live code paths where it had stopped being true.

## The bugs this fixes

**The fork liveness guard missed three backends.** `checkpoint`'s `vm_is_running` probed only `fc.pid` and the retired backend's marker, so a running **HVF, libkrun, or QEMU** parent read as *stopped* — and `FORK_ALLOW_PARENT_RUNNING = false`, the rule that refuses to fork a live parent, let the fork through. It also used a bare `kill(pid, 0) == 0`, which reads a **root-owned Firecracker as stopped**.

`mvm-cli` carried a *second* copy of the same probe with a *different* stale list (`libkrun.pid` + `fc.pid`, missing HVF and QEMU, same `EPERM` bug). Both now delegate to `mvm_vmm::host::process_liveness`, which already had the full marker list and the correct "`EPERM` means alive" rule.

**`checkpoint_is_vz` had come to mean its opposite.** It tests whether a checkpoint carries a `supervisor-config.json` blob — and **HVF writes that blob** (`HvfDriver::supervisor_config_path`). So it identified HVF captures while claiming to identify a removed backend, and the refusal it gates told users their checkpoint "was captured under a backend that has been removed." Renamed to `checkpoint_carries_supervisor_config`, with a message describing what actually happened.

**The reaper's marker lists** still carried the retired backend's pid file.

## Not touched

`com.apple.security.virtualization` in `codesign.rs` stays. It is an Apple entitlement key required alongside `com.apple.security.hypervisor` to launch a VM, unrelated to the retired backend. Only the prose calling it "VZ" changed.

## The gate

`check-no-vz` passed with all 97 mentions present, because it only matched Swift/VZ *symbols*. It gains a naming rule covering `crates/`, `tests/`, `src/`, `examples/`, and `xtask/`.

Snake_case counts as a word boundary — `checkpoint_is_vz` is precisely the case that motivated the rule, and treating `_` as a word character would let every `*_vz` identifier through. That is not hypothetical: it is how the gate found 16 mentions (`builder_vz_snapshot_present` and friends) that a `\b`-anchored grep had missed. `virtualization` does not match, so the entitlement key is unaffected.

## Verification

- `cargo nextest run --workspace` — 10,581 tests; one unrelated pre-existing flake (`metrics_server::tests::test_metrics_server_responds`, a port bind under parallelism) passes in isolation
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `check-no-vz`, `check-mutation-witnesses`, `check-no-string-backend-dispatch`, `check-claim-catalog` — clean