### PR TITLE
fix(audit): serialize chain-head reads so concurrent writers cannot fork a chain

### DIFF
--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -912,34 +912,18 @@ impl AuditEmitter {
             Some(r) => r,
             None => return,
         };
-        let head = match store.head() {
-            Ok(h) => h,
-            Err(e) => {
-                tracing::warn!(event = entry.event, error = %e, "failed to read receipt store head");
-                return;
-            }
-        };
-        receipt.prev_receipt_id = head.last_receipt_id;
-        receipt.receipt_id = match receipt.compute_id() {
-            Ok(id) => id,
-            Err(e) => {
-                tracing::warn!(event = entry.event, error = %e, "failed to compute receipt id");
-                return;
-            }
-        };
-        let signed_at = chrono::Utc::now().to_rfc3339();
-        let signed = match mvm_core::receipt::SignedExecutionReceipt::sign(
-            receipt,
-            &self.signing_key,
-            signed_at,
-        ) {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::warn!(event = entry.event, error = %e, "failed to sign execution receipt");
-                return;
-            }
-        };
-        if let Err(e) = store.append(&signed) {
+        // Link, identify, and sign inside the store's lock. The parent is part
+        // of the receipt id and of the signed bytes, so reading the head out
+        // here and appending afterwards would let a concurrent emitter claim
+        // the same parent between the two.
+        let appended = store.append_chained(|prev| {
+            receipt.prev_receipt_id = prev;
+            receipt.receipt_id = receipt.compute_id().context("computing receipt id")?;
+            let signed_at = chrono::Utc::now().to_rfc3339();
+            mvm_core::receipt::SignedExecutionReceipt::sign(receipt, &self.signing_key, signed_at)
+                .context("signing execution receipt")
+        });
+        if let Err(e) = appended {
             tracing::warn!(event = entry.event, error = %e, "failed to append execution receipt");
         }
     }
@@ -972,7 +956,7 @@ impl AuditEmitter {
 /// written, fsync'd, then `rename`d over `path`. A concurrent reader sees
 /// either the old file or the complete new one, never a torn write. The
 /// temp name carries the pid so two publishers don't collide on it.
-fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
     use std::io::Write;
     let dir = path
         .parent()

--- a/crates/mvm-hostd/src/audit/receipt_store.rs
+++ b/crates/mvm-hostd/src/audit/receipt_store.rs
@@ -14,9 +14,12 @@
 //! ```
 //!
 //! Each receipt's `prev_receipt_id` points at the previous receipt emitted
-//! for the same tenant, forming a host-signer chain. Updates to `head.json`
-//! and receipt files are made under a per-tenant file lock so concurrent
-//! emitters cannot interleave sequences or lose the chain head.
+//! for the same tenant, forming a host-signer chain. Reading the chain head,
+//! linking a receipt to it, signing, and persisting all happen inside one
+//! exclusive per-tenant lock ([`ReceiptStore::append_chained`]) — the read is
+//! what has to be serialized, not just the write. Two writers that observe
+//! the same head produce two receipts naming the same parent, which every
+//! offline verifier is obliged to read as a deleted or reordered receipt.
 
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
@@ -24,6 +27,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use mvm_core::receipt::SignedExecutionReceipt;
 use serde::{Deserialize, Serialize};
+
+use crate::audit::emitter::write_atomic;
+use crate::supervisor::audit_file::flock_exclusive;
 
 /// Head file content: the chain tip for one tenant's receipt store.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -68,36 +74,34 @@ impl ReceiptStore {
         })
     }
 
-    /// Append a signed receipt to the store, returning the assigned sequence
-    /// number. The caller is responsible for setting the receipt's
-    /// `prev_receipt_id` to the value returned by [`Self::head`] before
-    /// calling this method; this method only persists the receipt and bumps
-    /// the head.
+    /// Link a receipt to the current chain head, sign it, and persist it,
+    /// returning the assigned sequence number.
     ///
-    /// The write is atomic: the receipt is written to a temp file and
-    /// renamed, and the head is rewritten atomically under the tenant lock.
-    pub fn append(&self, receipt: &SignedExecutionReceipt) -> Result<u64> {
+    /// `build` receives the head's `prev_receipt_id` and returns the finished
+    /// signed receipt. It runs *inside* the tenant lock, which is the whole
+    /// point: the head a receipt commits to has to still be the head when the
+    /// receipt lands. Handing the caller a head to link against and taking the
+    /// lock only for the write leaves a window in which two writers claim one
+    /// parent — a fork, indistinguishable to a verifier from a deleted line.
+    ///
+    /// Signing happens under the lock because the parent is inside the signed
+    /// bytes; a receipt cannot be re-linked after the fact without re-signing.
+    pub fn append_chained<F>(&self, build: F) -> Result<u64>
+    where
+        F: FnOnce(Option<String>) -> Result<SignedExecutionReceipt>,
+    {
         let _guard = self.lock()?;
         let mut head = self.read_head();
+        let receipt = build(head.last_receipt_id.take())?;
+
         head.sequence += 1;
         let seq = head.sequence;
         let receipt_path = self.receipt_path(seq, &receipt.payload.receipt_type);
 
-        // Write receipt atomically.
-        let tmp_path = receipt_path.with_extension("tmp");
         let bytes =
-            serde_json::to_vec_pretty(receipt).context("serializing signed execution receipt")?;
-        std::fs::write(&tmp_path, bytes)
-            .with_context(|| format!("writing receipt temp file {}", tmp_path.display()))?;
-        std::fs::rename(&tmp_path, &receipt_path).with_context(|| {
-            format!(
-                "renaming receipt file {} -> {}",
-                tmp_path.display(),
-                receipt_path.display()
-            )
-        })?;
+            serde_json::to_vec_pretty(&receipt).context("serializing signed execution receipt")?;
+        write_atomic(&receipt_path, &bytes)?;
 
-        // Update head atomically.
         head.last_receipt_id = Some(receipt.payload.receipt_id.clone());
         self.write_head(&head)?;
 
@@ -132,47 +136,24 @@ impl ReceiptStore {
     }
 
     fn write_head(&self, head: &Head) -> Result<()> {
-        let tmp_path = self.head_path.with_extension("tmp");
         let bytes = serde_json::to_vec_pretty(head).context("serializing receipt head")?;
-        std::fs::write(&tmp_path, bytes)
-            .with_context(|| format!("writing head temp file {}", tmp_path.display()))?;
-        std::fs::rename(&tmp_path, &self.head_path).with_context(|| {
-            format!(
-                "renaming head file {} -> {}",
-                tmp_path.display(),
-                self.head_path.display()
-            )
-        })?;
-        Ok(())
+        write_atomic(&self.head_path, &bytes)
     }
 
-    #[cfg(unix)]
+    /// Take the exclusive per-tenant lock, blocking until it is available.
+    /// Released when the returned guard drops.
     fn lock(&self) -> Result<LockGuard> {
-        use std::os::fd::AsRawFd;
         let file = OpenOptions::new()
             .create(true)
-            .truncate(true)
+            // The file is a lock, never a payload — its contents are
+            // irrelevant and truncating it would be pointless churn.
+            .truncate(false)
             .write(true)
             .open(&self.lock_path)
             .with_context(|| format!("opening lock file {}", self.lock_path.display()))?;
-        let fd = file.as_raw_fd();
-        // SAFETY: fcntl flock is safe when fd is valid and we hold the file
-        // object for the lifetime of the guard.
-        unsafe {
-            let mut flock: libc::flock = std::mem::zeroed();
-            flock.l_type = libc::F_WRLCK as _;
-            flock.l_whence = libc::SEEK_SET as _;
-            if libc::fcntl(fd, libc::F_SETLKW, &flock) != 0 {
-                anyhow::bail!("failed to acquire receipt store lock");
-            }
-        }
+        flock_exclusive(&file)
+            .with_context(|| format!("locking receipt store {}", self.lock_path.display()))?;
         Ok(LockGuard { _file: file })
-    }
-
-    #[cfg(not(unix))]
-    fn lock(&self) -> Result<LockGuard> {
-        // Non-Unix platforms get a best-effort guard with no locking.
-        Ok(LockGuard)
     }
 }
 
@@ -185,13 +166,12 @@ pub struct ReceiptHead {
     pub sequence: u64,
 }
 
-#[cfg(unix)]
+/// Holds the receipt store's exclusive lock for as long as it is alive. The
+/// `flock` is advisory and released by the kernel when the fd closes, so a
+/// crashed writer cannot wedge the store behind a lock nobody holds.
 struct LockGuard {
     _file: std::fs::File,
 }
-
-#[cfg(not(unix))]
-struct LockGuard;
 
 #[cfg(test)]
 mod tests {
@@ -235,40 +215,165 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = ReceiptStore::open(dir.path(), "local").unwrap();
 
-        let r1 = sample_receipt(None, 1);
-        let seq1 = store.append(&r1).unwrap();
+        // The store supplies the parent; the first receipt gets none.
+        let mut first_id = None;
+        let seq1 = store
+            .append_chained(|prev| {
+                assert_eq!(prev, None, "a fresh store has no head to chain to");
+                let r = sample_receipt(prev, 1);
+                first_id = Some(r.payload.receipt_id.clone());
+                Ok(r)
+            })
+            .unwrap();
         assert_eq!(seq1, 1);
+        let first_id = first_id.unwrap();
 
         let head = store.head().unwrap();
         assert_eq!(head.sequence, 1);
-        assert_eq!(head.last_receipt_id, Some(r1.payload.receipt_id.clone()));
+        assert_eq!(head.last_receipt_id, Some(first_id.clone()));
 
-        let r2 = sample_receipt(Some(r1.payload.receipt_id.clone()), 2);
-        let seq2 = store.append(&r2).unwrap();
+        let seq2 = store
+            .append_chained(|prev| {
+                assert_eq!(prev.as_deref(), Some(first_id.as_str()));
+                Ok(sample_receipt(prev, 2))
+            })
+            .unwrap();
         assert_eq!(seq2, 2);
 
         let head = store.head().unwrap();
         assert_eq!(head.sequence, 2);
-        assert_eq!(head.last_receipt_id, Some(r2.payload.receipt_id.clone()));
+        assert_ne!(head.last_receipt_id, Some(first_id));
+    }
+
+    /// Concurrent writers must extend one chain, never fork it.
+    ///
+    /// A fork — two receipts naming the same parent — is what an offline
+    /// verifier reads as "a preceding receipt was deleted or reordered". It
+    /// can only be created at write time, by two writers that both observed
+    /// the same head, so the head read and the link it produces have to sit
+    /// inside one lock rather than two.
+    #[test]
+    fn concurrent_writers_extend_one_chain_without_forking() {
+        const WRITERS: u64 = 8;
+        const EACH: u64 = 12;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(dir.path(), "local").unwrap();
+
+        std::thread::scope(|scope| {
+            for w in 0..WRITERS {
+                let store = store.clone();
+                scope.spawn(move || {
+                    for i in 0..EACH {
+                        store
+                            .append_chained(|prev| Ok(sample_receipt(prev, w * EACH + i)))
+                            .unwrap();
+                    }
+                });
+            }
+        });
+
+        let total = WRITERS * EACH;
+        assert_eq!(store.head().unwrap().sequence, total);
+
+        // Walk the store in sequence order: each receipt must name exactly its
+        // predecessor, and the genesis receipt must name nobody.
+        let chain: Vec<SignedExecutionReceipt> = (1..=total)
+            .map(|seq| {
+                let path = store.receipt_path(seq, receipt_type::PLAN_ADMITTED);
+                let bytes = std::fs::read(&path)
+                    .unwrap_or_else(|e| panic!("receipt {seq} missing at {}: {e}", path.display()));
+                serde_json::from_slice(&bytes).expect("stored receipt parses")
+            })
+            .collect();
+
+        assert_eq!(
+            chain[0].payload.prev_receipt_id, None,
+            "genesis has no parent"
+        );
+        for (idx, pair) in chain.windows(2).enumerate() {
+            assert_eq!(
+                pair[1].payload.prev_receipt_id.as_deref(),
+                Some(pair[0].payload.receipt_id.as_str()),
+                "receipt at sequence {} must chain to sequence {}",
+                idx + 2,
+                idx + 1,
+            );
+        }
+
+        // State the fork property directly: no parent is ever claimed twice.
+        let mut parents: Vec<&str> = chain
+            .iter()
+            .filter_map(|r| r.payload.prev_receipt_id.as_deref())
+            .collect();
+        let claimed = parents.len();
+        parents.sort_unstable();
+        parents.dedup();
+        assert_eq!(
+            parents.len(),
+            claimed,
+            "a parent was claimed by two receipts"
+        );
     }
 
     #[test]
     fn receipt_files_are_written_atomically() {
         let dir = tempfile::tempdir().unwrap();
         let store = ReceiptStore::open(dir.path(), "local").unwrap();
-        let receipt = sample_receipt(None, 3);
-        store.append(&receipt).unwrap();
+        let mut expected_id = None;
+        store
+            .append_chained(|prev| {
+                let r = sample_receipt(prev, 3);
+                expected_id = Some(r.payload.receipt_id.clone());
+                Ok(r)
+            })
+            .unwrap();
 
         let path = store.receipt_path(1, receipt_type::PLAN_ADMITTED);
         assert!(path.exists());
         let bytes = std::fs::read(&path).unwrap();
         let loaded: SignedExecutionReceipt = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(loaded.payload.receipt_id, receipt.payload.receipt_id);
+        assert_eq!(Some(loaded.payload.receipt_id), expected_id);
+
+        // No temp file survives a successful write, whatever it was named.
+        let leftovers: Vec<_> = std::fs::read_dir(&store.tenant_dir)
+            .unwrap()
+            .filter_map(|e| e.ok().map(|e| e.file_name()))
+            .filter(|n| n.to_string_lossy().contains(".tmp"))
+            .collect();
         assert!(
-            !store
-                .tenant_dir
-                .join("00000001-plan.admitted.json.tmp")
-                .exists()
+            leftovers.is_empty(),
+            "temp files left behind: {leftovers:?}"
         );
+    }
+
+    /// A failure inside `build` must leave the store exactly as it was: no
+    /// sequence burned, no head moved, no partial receipt on disk. A receipt
+    /// that could not be signed is a receipt that never happened.
+    #[test]
+    fn a_failed_build_advances_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(dir.path(), "local").unwrap();
+        store
+            .append_chained(|prev| Ok(sample_receipt(prev, 1)))
+            .unwrap();
+        let before = store.head().unwrap();
+
+        let err = store
+            .append_chained(|_| anyhow::bail!("signing key unavailable"))
+            .unwrap_err();
+        assert!(err.to_string().contains("signing key unavailable"));
+
+        assert_eq!(store.head().unwrap(), before, "head must not have moved");
+        assert!(
+            !store.receipt_path(2, receipt_type::PLAN_ADMITTED).exists(),
+            "no receipt file for the sequence that was never assigned"
+        );
+
+        // And the next real append takes the sequence the failure did not.
+        let seq = store
+            .append_chained(|prev| Ok(sample_receipt(prev, 2)))
+            .unwrap();
+        assert_eq!(seq, 2);
     }
 }

--- a/crates/mvm-hostd/src/audit_signer/chain.rs
+++ b/crates/mvm-hostd/src/audit_signer/chain.rs
@@ -44,7 +44,11 @@ pub struct Chain {
     pub_key_bytes: Vec<u8>,
     head: String,
     jsonl_file: File,
+    jsonl_path: std::path::PathBuf,
     secondary_head_path: std::path::PathBuf,
+    /// Set when an append failed partway. The next append re-seeds the head
+    /// from the on-disk tail rather than trusting memory — see [`Chain::append`].
+    resync_needed: bool,
 }
 
 impl Chain {
@@ -52,6 +56,14 @@ impl Chain {
     /// scans the file to find the latest entry-hash and uses it as the
     /// initial head. Otherwise initializes with [`CanonicalEntry::
     /// genesis_prev_hash`].
+    ///
+    /// Takes an exclusive advisory lock on the JSONL and holds it for the
+    /// chain's lifetime, so a second signer on the same file is refused rather
+    /// than admitted to fork it. This type caches the head in memory and only
+    /// re-reads it on recovery, which is sound exactly as long as it is the
+    /// only writer — the lock is what makes that an enforced property instead
+    /// of a convention. Fails fast rather than blocking: a signer waiting on a
+    /// lock is a boot hanging with no explanation.
     pub fn open(
         jsonl_path: &Path,
         secondary_head_path: &Path,
@@ -96,6 +108,13 @@ impl Chain {
                 )
             })?;
 
+        lock_sole_writer(&jsonl_file).with_context(|| {
+            format!(
+                "mvm-audit-signer chain already held by another writer: {}",
+                jsonl_path.display()
+            )
+        })?;
+
         let head = recover_head(jsonl_path, secondary_head_path)?;
 
         Ok(Self {
@@ -103,7 +122,9 @@ impl Chain {
             pub_key_bytes,
             head,
             jsonl_file,
+            jsonl_path: jsonl_path.to_path_buf(),
             secondary_head_path: secondary_head_path.to_path_buf(),
+            resync_needed: false,
         })
     }
 
@@ -118,12 +139,23 @@ impl Chain {
     }
 
     /// Append one canonical entry. Returns the new head on success.
-    pub fn append(&mut self, mut entry: CanonicalEntry) -> Result<String, AuditSignerErrorCode> {
+    pub fn append(&mut self, entry: CanonicalEntry) -> Result<String, AuditSignerErrorCode> {
         // Allow-list gate: unknown categories are rejected before any
         // signing work happens. Keeps the chain to a known set of values
         // so downstream tooling can rely on category meaning.
         if !crate::audit_signer::category::is_allowed(&entry.category) {
             return Err(AuditSignerErrorCode::InvalidRequest);
+        }
+        // An earlier append failed after it had begun writing. Whether its
+        // line reached the file is not knowable from here, so believe the file
+        // rather than memory: a head left behind the tail would hand this
+        // entry a parent the tail has already claimed, forking the chain on
+        // our own recovery path. The caller's stale prev_hash then fails the
+        // drift check below, which is the correct fail-closed answer.
+        if self.resync_needed {
+            self.head = recover_head(&self.jsonl_path, &self.secondary_head_path)
+                .map_err(|_| AuditSignerErrorCode::InternalError)?;
+            self.resync_needed = false;
         }
         // Cross-check the caller's prev_hash matches our in-memory head.
         // If a caller (the audit-signer's own RPC handler) hands us an
@@ -145,23 +177,49 @@ impl Chain {
             sig_alg: SIG_ALG_ED25519,
             entry_hash: entry_hash.clone(),
         };
-        let line =
+        let mut line =
             serde_json::to_string(&on_disk).map_err(|_| AuditSignerErrorCode::InternalError)?;
-        // Append line + newline. O_APPEND ensures the write is atomic
-        // up to the OS write-size guarantee (typically 4 KiB on Linux).
-        writeln!(self.jsonl_file, "{}", line).map_err(|_| AuditSignerErrorCode::FsyncFailed)?;
-        // Fsync. Hard-fail on error.
-        self.jsonl_file
-            .sync_all()
-            .map_err(|_| AuditSignerErrorCode::FsyncFailed)?;
-        // Update in-memory head + persist secondary location.
+        // One buffer, one `write_all`. `writeln!` emits the payload and the
+        // newline as separate writes, and O_APPEND makes each of those atomic
+        // without making the pair atomic — a second writer can land a whole
+        // line between them and splice two entries into one unparseable line.
+        // The exclusive lock this chain holds rules that out, but a single
+        // write costs nothing and keeps the guarantee local to this function.
+        line.push('\n');
+        if let Err(e) = self.write_line(line.as_bytes()) {
+            // Part of the line may be on disk. Don't trust the in-memory head
+            // again until it has been re-derived from the file.
+            self.resync_needed = true;
+            return Err(e);
+        }
         self.head = entry_hash.clone();
-        std::fs::write(&self.secondary_head_path, &self.head)
-            .map_err(|_| AuditSignerErrorCode::FsyncFailed)?;
-        // Caller might also want the canonical entry back for diagnostics.
-        entry.prev_hash = self.head.clone(); // unused but keeps the value tidy
+        if std::fs::write(&self.secondary_head_path, &self.head).is_err() {
+            self.resync_needed = true;
+            return Err(AuditSignerErrorCode::FsyncFailed);
+        }
         Ok(entry_hash)
     }
+
+    /// Write one already-newline-terminated line and flush it to stable
+    /// storage.
+    fn write_line(&mut self, bytes: &[u8]) -> Result<(), AuditSignerErrorCode> {
+        self.jsonl_file
+            .write_all(bytes)
+            .map_err(|_| AuditSignerErrorCode::FsyncFailed)?;
+        self.jsonl_file
+            .sync_all()
+            .map_err(|_| AuditSignerErrorCode::FsyncFailed)
+    }
+}
+
+/// Take the sole-writer lock on an open chain file, failing immediately if
+/// another process holds it. Advisory and released by the kernel when the fd
+/// closes, so a crashed signer cannot wedge the chain.
+fn lock_sole_writer(file: &File) -> Result<()> {
+    use rustix::fs::{FlockOperation, flock};
+    use std::os::fd::AsFd;
+    flock(file.as_fd(), FlockOperation::NonBlockingLockExclusive)
+        .map_err(|e| anyhow::anyhow!("exclusive chain lock unavailable: {e}"))
 }
 
 fn recover_head(jsonl_path: &Path, secondary_head_path: &Path) -> Result<String> {
@@ -384,6 +442,107 @@ mod tests {
         let chain = Chain::open(&jsonl, &head, None).unwrap();
         assert_eq!(chain.head(), expected_head);
         assert_eq!(std::fs::read_to_string(&head).unwrap(), expected_head);
+    }
+
+    /// A second writer on one chain file is refused, not admitted to fork it.
+    ///
+    /// The head lives in memory between appends, which is only sound while
+    /// this is the sole writer. Two open chains would each believe they held
+    /// the tail and hand out the same parent twice.
+    #[test]
+    fn a_second_chain_on_the_same_file_is_refused() {
+        let dir = tempdir().unwrap();
+        let jsonl = dir.path().join("audit.jsonl");
+        let head = dir.path().join("HEAD");
+
+        let first = Chain::open(&jsonl, &head, None).unwrap();
+        // `Chain` owns a signing key and deliberately has no `Debug`, so
+        // unwrap the result by hand rather than via `expect_err`.
+        let Err(err) = Chain::open(&jsonl, &head, None) else {
+            panic!("a second writer must not get the chain");
+        };
+        assert!(
+            err.to_string().contains("already held by another writer"),
+            "unexpected error: {err:#}"
+        );
+
+        // Releasing the first hands the chain over cleanly.
+        drop(first);
+        Chain::open(&jsonl, &head, None).expect("the lock is released on drop");
+    }
+
+    /// Each entry is one write, so nothing can be spliced into the middle of a
+    /// line — including the gap between the payload and its newline.
+    #[test]
+    fn an_entry_and_its_newline_are_written_together() {
+        use std::io::Read;
+
+        let dir = tempdir().unwrap();
+        let jsonl = dir.path().join("audit.jsonl");
+        let head = dir.path().join("HEAD");
+        let mut chain = Chain::open(&jsonl, &head, None).unwrap();
+
+        // A payload past any single-page write the append path might otherwise
+        // get away with.
+        let mut entry = sample_entry(chain.head().to_string());
+        entry.fields = serde_json::json!({ "verb": "now", "filler": "x".repeat(16 * 1024) });
+        chain.append(entry).unwrap();
+
+        let mut raw = Vec::new();
+        File::open(&jsonl).unwrap().read_to_end(&mut raw).unwrap();
+        assert!(raw.len() > 16 * 1024, "fixture must exceed one page");
+        assert_eq!(
+            raw.iter().filter(|b| **b == b'\n').count(),
+            1,
+            "exactly one line terminator"
+        );
+        assert_eq!(raw.last(), Some(&b'\n'), "the line is newline-terminated");
+        let parsed: OnDiskEntry =
+            serde_json::from_slice(&raw[..raw.len() - 1]).expect("the line parses whole");
+        assert_eq!(parsed.entry_hash, chain.head());
+    }
+
+    /// If persisting an append fails partway, the head must not stay behind
+    /// the file — the next entry would otherwise claim a parent the tail has
+    /// already claimed, forking the chain from the inside.
+    #[test]
+    fn a_failed_append_does_not_leave_the_head_behind_the_tail() {
+        let dir = tempdir().unwrap();
+        let jsonl = dir.path().join("audit.jsonl");
+        let head_path = dir.path().join("HEAD");
+        let mut chain = Chain::open(&jsonl, &head_path, None).unwrap();
+
+        // Make the secondary-head write fail: the line lands, the head file
+        // does not. Point it at a directory, which is never writable as a file.
+        let blocked = dir.path().join("blocked");
+        std::fs::create_dir(&blocked).unwrap();
+        chain.secondary_head_path = blocked;
+
+        let before = chain.head().to_string();
+        let err = chain.append(sample_entry(before.clone())).unwrap_err();
+        assert_eq!(err, AuditSignerErrorCode::FsyncFailed);
+
+        // The entry did reach the file, so the tail has moved on.
+        let contents = std::fs::read_to_string(&jsonl).unwrap();
+        let written: OnDiskEntry = serde_json::from_str(contents.lines().next().unwrap()).unwrap();
+        assert_ne!(written.entry_hash, before);
+
+        // Recovery: repoint at a writable head file and re-drive. The chain
+        // must refuse the stale parent, then accept the real tail.
+        chain.secondary_head_path = dir.path().join("HEAD2");
+        assert_eq!(
+            chain.append(sample_entry(before)).unwrap_err(),
+            AuditSignerErrorCode::ChainDriftDetected,
+            "the parent the failed append consumed must not be reusable"
+        );
+        assert_eq!(
+            chain.head(),
+            written.entry_hash,
+            "the head re-seeded from the on-disk tail"
+        );
+        chain
+            .append(sample_entry(written.entry_hash.clone()))
+            .expect("appending onto the true tail succeeds");
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit_signer/helper.rs
+++ b/crates/mvm-hostd/src/audit_signer/helper.rs
@@ -76,6 +76,12 @@ impl SignerHelper {
 
     fn register(&mut self, req: SignerHelperRegisterVm) -> SignerHelperResponse {
         let request_id = req.request_id.clone();
+        // Drop any chain already registered under this vm_id before opening
+        // the replacement: the open takes the file's sole-writer lock, and the
+        // old handle still holds it. Re-registering is a supervisor restart,
+        // and the head is recovered from the file, so releasing early costs
+        // nothing.
+        self.chains.remove(&req.vm_id);
         match self.open_chain(&req) {
             Ok(chain) => {
                 let chain_head = chain.head().to_string();

--- a/crates/mvm-hostd/src/supervisor/audit_file.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_file.rs
@@ -188,7 +188,12 @@ impl AuditSigner for FileAuditSigner {
 /// Take an exclusive advisory lock on `file`. Blocks until acquired.
 /// Released when the OwnedFd backing `file` is dropped. This is what
 /// gives the per-tenant audit chain cross-process integrity.
-fn flock_exclusive(file: &std::fs::File) -> std::io::Result<()> {
+///
+/// `flock` is held per open file description rather than per process, so two
+/// threads that each opened the file are serialized against one another the
+/// same way two processes are. `fcntl` record locks are not — they are owned
+/// by the process and grant a second thread the lock it is already holding.
+pub(crate) fn flock_exclusive(file: &std::fs::File) -> std::io::Result<()> {
     use rustix::fs::{FlockOperation, flock};
     use std::os::fd::AsFd;
     flock(file.as_fd(), FlockOperation::LockExclusive).map_err(std::io::Error::from)

--- a/crates/mvm-hostd/tests/audit_chain_concurrent_writers.rs
+++ b/crates/mvm-hostd/tests/audit_chain_concurrent_writers.rs
@@ -1,0 +1,199 @@
+//! The per-tenant audit chain under concurrent writers.
+//!
+//! `FileAuditSigner` serializes the whole read-cursor / sign / append window
+//! under an exclusive `flock` because the guarantee it owes a verifier is not
+//! "each line is well-formed" but "each line names the line before it". Two
+//! writers that both observe the same tail produce two entries claiming one
+//! parent, and a fork is indistinguishable, to anyone holding only the log,
+//! from a deleted or reordered entry. The chain would accuse an operator of
+//! tampering that never happened.
+//!
+//! The interesting case is **separate processes**. Every per-VM supervisor is
+//! its own process that opens the tenant chain, restores the cursor from disk,
+//! and appends; nothing but the kernel lock stands between two of them. A
+//! same-process test cannot substitute, because the two would contend on
+//! in-process state that a second supervisor does not share.
+//!
+//! So the parent re-execs this test binary N times, each child emitting into
+//! one shared chain, and then verifies the result. `verify_audit_chain` is the
+//! whole assertion: it rejects a duplicated parent and equally rejects a line
+//! that two interleaved writes tore in half.
+
+use std::path::{Path, PathBuf};
+
+use ed25519_dalek::SigningKey;
+use mvm_hostd::supervisor::{
+    AuditEntry, AuditSigner, FileAuditSigner, VerifyError, verify_audit_chain,
+};
+
+/// Set on a re-exec'd child: `<audit_dir>|<key_path>|<worker_index>`.
+const WORKER_ENV: &str = "MVM_AUDIT_CONCURRENT_WORKER";
+
+const WORKERS: usize = 6;
+const ENTRIES_PER_WORKER: usize = 20;
+const TENANT: &str = "local";
+
+#[test]
+fn concurrent_writer_processes_extend_one_chain_without_forking() {
+    if let Ok(spec) = std::env::var(WORKER_ENV) {
+        run_worker(&spec);
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let audit_dir = dir.path().join("audit");
+    std::fs::create_dir_all(&audit_dir).expect("audit dir");
+
+    // One key, shared by every writer — a fork has to be provably ours, the
+    // way it would be in production, or the test proves nothing about forks.
+    let key_path = dir.path().join("chain.key");
+    let mut seed = [0u8; 32];
+    rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut seed);
+    std::fs::write(&key_path, seed).expect("write key seed");
+    let verifying = SigningKey::from_bytes(&seed).verifying_key();
+
+    let exe = std::env::current_exe().expect("test binary path");
+    let children: Vec<_> = (0..WORKERS)
+        .map(|idx| {
+            std::process::Command::new(&exe)
+                .args([
+                    "--exact",
+                    "concurrent_writer_processes_extend_one_chain_without_forking",
+                    "--nocapture",
+                ])
+                .env(
+                    WORKER_ENV,
+                    format!("{}|{}|{idx}", audit_dir.display(), key_path.display()),
+                )
+                // A child is a writer, not a test run: its harness chatter
+                // would interleave with this one's and make the real result
+                // unreadable. Keep stderr so a panicking writer still explains
+                // itself.
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .expect("spawn writer process")
+        })
+        .collect();
+
+    for (idx, child) in children.into_iter().enumerate() {
+        let out = child.wait_with_output().expect("wait for writer process");
+        assert!(
+            out.status.success(),
+            "writer {idx} failed: {}\n{}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    let path = audit_dir.join(format!("{TENANT}.jsonl"));
+    let expected = WORKERS * ENTRIES_PER_WORKER;
+
+    // Every line landed. A torn line would have swallowed one; a lost append
+    // would have too.
+    let lines = std::fs::read_to_string(&path).expect("read chain");
+    assert_eq!(
+        lines.lines().filter(|l| !l.is_empty()).count(),
+        expected,
+        "every writer's entries must be on disk"
+    );
+
+    // And the chain is linear: no duplicate parent, no torn line, every
+    // signature ours.
+    match verify_audit_chain(&path, &verifying) {
+        Ok(count) => assert_eq!(count, expected, "verified entry count"),
+        Err(e) => panic!("{}", explain(&e, &path)),
+    }
+
+    // Each writer's entries all survived — a fork that happened to verify by
+    // luck would still show up as a missing writer.
+    for idx in 0..WORKERS {
+        let marker = format!("\"writer\":\"{idx}\"");
+        assert_eq!(
+            lines.matches(&marker).count(),
+            ENTRIES_PER_WORKER,
+            "writer {idx} lost entries"
+        );
+    }
+}
+
+/// One re-exec'd writer: open the shared chain and append its entries.
+fn run_worker(spec: &str) {
+    let mut parts = spec.split('|');
+    let audit_dir = PathBuf::from(parts.next().expect("audit dir in worker spec"));
+    let key_path = PathBuf::from(parts.next().expect("key path in worker spec"));
+    let idx: usize = parts
+        .next()
+        .expect("worker index in worker spec")
+        .parse()
+        .expect("worker index parses");
+
+    let seed: [u8; 32] = std::fs::read(&key_path)
+        .expect("read key seed")
+        .try_into()
+        .expect("key seed is 32 bytes");
+    let signer = FileAuditSigner::open(SigningKey::from_bytes(&seed), &audit_dir).expect("signer");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("worker runtime");
+    for i in 0..ENTRIES_PER_WORKER {
+        rt.block_on(signer.sign_and_emit(&entry(idx, i)))
+            .expect("sign and emit");
+    }
+}
+
+/// An entry big enough that its line exceeds a single atomic write. A short
+/// entry can slip past an unlocked appender by accident; the torn-line half of
+/// this test needs a line the kernel will not write in one piece.
+fn entry(worker: usize, seq: usize) -> AuditEntry {
+    use mvm_core::plan::{PlanId, TenantId};
+
+    let mut labels = std::collections::BTreeMap::new();
+    labels.insert("writer".to_string(), worker.to_string());
+    labels.insert("seq".to_string(), seq.to_string());
+    // ~8 KiB of payload, past the page-sized write the append path would
+    // otherwise get away with.
+    for chunk in 0..16 {
+        labels.insert(
+            format!("filler_{chunk:02}"),
+            format!("{worker:02}{seq:03}").repeat(64),
+        );
+    }
+
+    AuditEntry {
+        timestamp: chrono::Utc::now(),
+        tenant: TenantId(TENANT.to_string()),
+        plan_id: PlanId(format!("plan-{worker}-{seq}")),
+        plan_version: 1,
+        bundle_id: None,
+        bundle_version: None,
+        image_name: "concurrency-fixture".to_string(),
+        image_sha256: "00".repeat(32),
+        event: "plan.admitted".to_string(),
+        labels,
+    }
+}
+
+/// Render a verify failure with the offending line, so a regression reads as
+/// "line 37 claims the parent line 36 already claimed" rather than a bare
+/// error string.
+fn explain(err: &VerifyError, path: &Path) -> String {
+    let line_no = match err {
+        VerifyError::PrevHashMismatch { line }
+        | VerifyError::SignatureInvalid { line }
+        | VerifyError::Malformed { line, .. } => Some(*line),
+        VerifyError::Io(_) => None,
+    };
+    let context = line_no
+        .and_then(|n| {
+            std::fs::read_to_string(path)
+                .ok()?
+                .lines()
+                .nth(n)
+                .map(|l| l.chars().take(200).collect::<String>())
+        })
+        .unwrap_or_default();
+    format!("chain verification failed: {err}\n  offending line: {context}")
+}

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-07
+Last updated: 2026-08-08
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -749,3 +749,16 @@ for detailed scope and acceptance criteria.
         restore and live Apple Silicon witnesses remain open.
   - [ ] Typed-connector egress-policy enrichment
   - [ ] OCI-image template build path and CLI facade completion
+
+- [~] Plan 302 — audit-chain write-path hardening
+  (`specs/plans/302-audit-chain-write-path-hardening.md`)
+  - [x] `ReceiptStore` links and signs under one lock — the head read was
+        outside it, so two emitters could claim one parent
+  - [x] Receipt lock switched from process-scoped `fcntl` to `flock`, which
+        actually excludes two threads
+  - [x] `audit_signer::Chain` takes a sole-writer lock, writes each line in
+        one `write_all`, and re-seeds its head after a failed append
+  - [ ] Audit emission fails closed under `--prod` (currently advisory, so a
+        missing entry leaves no gap to detect)
+  - [ ] Converge the primary chain on JCS canonical bytes so no verifier has
+        to reproduce serde field order

--- a/specs/plans/302-audit-chain-write-path-hardening.md
+++ b/specs/plans/302-audit-chain-write-path-hardening.md
@@ -1,0 +1,79 @@
+# Plan 302 — Audit-chain write-path hardening
+
+**Status: PARTIAL — WS1–WS3 landed, WS4–WS5 open**
+
+## Why
+
+An audit chain accuses. When the writer can produce a broken chain by itself,
+every break it ever reports carries an asterisk, and the first person to find
+that asterisk is an auditor rather than us. This plan covers the write-path
+defects found by auditing our chain writers against a published post-mortem of
+the same class of bug in another signed-receipt system.
+
+The distinction that organises the work: a chain link is created at *write*
+time, from an observation of the head. Serializing the write is not enough —
+the *read of the head* has to be inside the same lock, or two writers link to
+one parent and produce a fork. A fork is not distinguishable, to anyone holding
+only the log, from a deleted or reordered entry.
+
+## Workstreams
+
+- [x] **WS1 — `ReceiptStore` linked outside its own lock.** `head()` took the
+      lock and released it; the emitter then signed and called `append()`,
+      which retook it. Two emitters could observe one head and claim one
+      parent. Replaced `append` with `append_chained`, which reads the head,
+      runs the caller's build-and-sign closure, and persists, all under one
+      lock. The parent is inside both the receipt id and the signed bytes, so
+      signing has to be under the lock too — a receipt cannot be re-linked
+      afterwards without re-signing.
+- [x] **WS2 — the receipt lock was not a lock.** It used `fcntl(F_SETLKW)`
+      record locks, which are owned by the *process*: two threads each
+      "acquired" it and proceeded. Switched to `flock`, held per open file
+      description, which serializes threads and processes alike. Reused the
+      helper the primary chain already had rather than growing a second one.
+- [x] **WS3 — `audit_signer::Chain` write path.** Three fixes: an exclusive
+      non-blocking lock taken at `open` and held for the chain's lifetime, so
+      the in-memory head is a *checked* sole-writer assumption rather than a
+      convention; one `write_all` of line-plus-newline instead of `writeln!`,
+      which emitted two writes that O_APPEND made individually — not jointly —
+      atomic; and a `resync_needed` flag so an append that fails partway
+      re-seeds the head from the on-disk tail instead of handing the next
+      entry a parent the tail already claimed.
+
+Regression coverage, all three verified to fail with the fix reverted:
+`concurrent_writers_extend_one_chain_without_forking`,
+`concurrent_writer_processes_extend_one_chain_without_forking` (re-execs real
+writer processes — a same-process test cannot stand in for two supervisors),
+`a_second_chain_on_the_same_file_is_refused`,
+`an_entry_and_its_newline_are_written_together`,
+`a_failed_append_does_not_leave_the_head_behind_the_tail`,
+`a_failed_build_advances_nothing`.
+
+- [ ] **WS4 — audit emission is advisory, so a missing entry is invisible.**
+      Every `emit_*` call site warns and continues
+      (`crates/mvm-cli/src/commands/vm/up/admission.rs`,
+      `crates/mvm-hostd/src/plan_admission.rs`). The chain proves completeness
+      of what was *retained*; nothing detects an entry that was never written,
+      because there is no gap to detect. Claim 8 reads "every workload runs
+      from a signed, audited `ExecutionPlan`" and the audited half is currently
+      best-effort. Proposal: `--prod` fails closed when `plan.admitted` cannot
+      persist, making the receipt a control rather than a record. Dev keeps the
+      warn-and-continue behaviour. Needs a decision on whether a chain that is
+      unreachable at boot should block the boot.
+
+- [ ] **WS5 — two canonicalization schemes for one job.**
+      `supervisor/audit_file.rs` signs `serde_json::to_vec(entry) || prev_hash`,
+      so every verifier must reproduce serde's field order forever and any
+      future field-layout change silently invalidates history.
+      `audit_signer/chain.rs` signs JCS bytes and stores them base64, so its
+      verifier never re-serializes anything. The second is strictly better and
+      the two should converge on it. This is a format change to the primary
+      chain, so it needs a migration story for existing on-disk logs — which is
+      the reason it is not folded into this pass.
+
+## Not in scope
+
+The `prev_hash`-over-raw-line decision and the single parity-tested verifier
+(`mvm-contract`'s wasm-clean implementation, pinned against the hostd verifier
+by `mvm_verify_matches_supervisor_chain` and the frozen-vector corpus) were
+already right and are unchanged.


### PR DESCRIPTION
## Why

A chain link is created when a writer **observes the head**, not when it writes. Serializing only the write leaves a window in which two writers link to the same parent — and a fork is indistinguishable, to anyone holding just the log, from a deleted or reordered entry. The verifier ends up accusing an operator of tampering that never happened.

This came out of auditing our chain writers against a published post-mortem of the same bug class in another signed-receipt system. Our primary chain (`FileAuditSigner`) already had the right fix. Two other writers did not.

## What changed

**`ReceiptStore` linked outside its own lock.** `head()` took the per-tenant lock and released it, the emitter then signed, and `append()` retook it. Replaced both with `append_chained()`, which reads the head, runs the caller's build-and-sign closure, and persists — all under one lock. Signing has to be inside it: the parent is part of the receipt id *and* of the signed bytes, so a receipt can't be re-linked afterwards without re-signing.

**That store's lock wasn't a lock.** It used `fcntl(F_SETLKW)` record locks, which are owned by the *process* — two threads each "acquired" it and proceeded. The new test caught them colliding on sequence 1 and renaming each other's temp files out from under themselves. Switched to `flock` (held per open file description), reusing the helper the primary chain already had.

**`audit_signer::Chain`**, from the other direction — it caches the head in memory from `open()` onward, which is sound only while it's the sole writer:
- exclusive non-blocking lock at `open`, held for the chain's lifetime, so that's a checked property rather than a convention;
- one `write_all` of line-plus-newline instead of `writeln!`, which emitted the payload and the newline as two writes — `O_APPEND` makes each atomic without making the pair atomic, so a second writer could splice two entries into one unparseable line;
- an append that failed partway left the head *behind* the tail, so the next entry would claim a parent already taken. It now re-seeds from the on-disk tail, and the caller's stale parent trips the existing drift check.

## Tests

The primary chain's `flock` was correct but untested — deleting it left all twelve of its tests green. The new multi-process test re-execs real writer processes (a same-process test can't stand in for two supervisors) and asserts through `verify_audit_chain`, which rejects a duplicated parent and a torn line alike.

Every regression was confirmed to fail with its fix reverted. Without the lock, the multi-process test destroys 24 of 120 lines:

```
assertion `left == right` failed: every writer's entries must be on disk
  left: 96
 right: 120
```

Full workspace suite green (10588 tests; one unrelated `mvm-agentd` PTY test is a known parallel flake and passes isolated), clippy clean, nightly fmt clean, policy gates pass.

## Left open

Recorded in `specs/plans/302-audit-chain-write-path-hardening.md`:
- Audit emission is still advisory — every call site warns and continues, so an entry that was never written leaves no gap for the chain to detect. Claim 8's "audited" half is currently best-effort.
- The primary chain signs re-serialized bytes (`serde_json::to_vec(entry)`), so every verifier must reproduce serde's field order forever. The audit-signer chain already signs JCS bytes and stores them; converging is a format change needing a migration story.