### PR TITLE
test: kernel budget control run (do not merge)

### DIFF
--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -800,3 +800,5 @@ in
     mkKernel
     ;
 }
+
+# Control: no-op comment to trigger the path-filtered kernel build gate.


### PR DESCRIPTION
Control run. A single no-op comment appended to `nix/images/kernel/base.nix` on pristine main, to trigger the path-filtered kernel build gate.

Purpose: #2238 fails `Build kernels (x86_64)` at 917 =y symbols against a 916 budget, but its only kernel-file change is comment text, and `Build kernels (aarch64)` passes. A comment cannot move one arch and not the other. This run determines whether main is already at 917.

If this fails identically, the drift is pre-existing on main and unrelated to #2238 — latent because the kernel job only runs when a kernel path changes, and nothing has touched one recently.

Delete this branch once it reports.