### PR TITLE
harden(runtime): trap release overflow, durable audit appends, bounded OCI reads, panic redaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
   test:
     name: Test
     if: ${{ always() }}
-    needs: [test-workspace, test-linux]
+    needs: [test-workspace, test-linux, test-release-witness]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -349,9 +349,10 @@ jobs:
         env:
           WORKSPACE_RESULT: ${{ needs.test-workspace.result }}
           LINUX_RESULT: ${{ needs.test-linux.result }}
+          RELEASE_WITNESS_RESULT: ${{ needs.test-release-witness.result }}
         run: |
           set -euo pipefail
-          for result in "$WORKSPACE_RESULT" "$LINUX_RESULT"; do
+          for result in "$WORKSPACE_RESULT" "$LINUX_RESULT" "$RELEASE_WITNESS_RESULT"; do
             if [ "$result" != success ]; then
               echo "A test lane did not pass: $result"
               exit 1
@@ -410,6 +411,51 @@ jobs:
       - name: Run doctests
         # nextest does not run doctests; gate them separately.
         run: cargo test --workspace --doc
+
+  test-release-witness:
+    name: Test release profile (overflow + no debug assertions)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/free-disk
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install system build deps
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update
+          sudo apt-get install -y attr cryptsetup-bin libcap-ng-dev lld
+
+      - uses: ./.github/actions/install-zigbuild
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      - name: Run tests under the release profile
+        # Every other lane runs in a debug profile: debug assertions on,
+        # integer overflow trapped by the profile default. The shipped binary
+        # is neither of those things, so a test suite that only ever runs in
+        # debug cannot witness the behaviour users get.
+        #
+        # `release-witness` is `release` minus fat LTO and single-codegen-unit
+        # linking, which keeps the semantics under test (trapping overflow, no
+        # debug assertions) without the link times.
+        #
+        # Deliberately scoped rather than workspace-wide: these are the crates
+        # doing length arithmetic over bytes an attacker chooses — the ext4
+        # writer and OCI unpacker, the plan/crypto core, the audit-log
+        # verifier, the datapath and supervisor, and the vsock frame parser.
+        # The rest of the workspace is covered in debug by `test-workspace`;
+        # widening this lane costs CI minutes for code that does not parse
+        # hostile input.
+        run: |
+          cargo nextest run --cargo-profile release-witness \
+            -p mvm-fs -p mvm-core -p mvm-contract -p mvm-hostd -p mvm-agentd
 
   test-linux:
     name: Test Linux and conformance

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,85 @@
+name: Miri
+
+# Miri interprets MIR and checks for undefined behaviour the compiler cannot
+# rule out statically. It is slow — tens of times slower than a native test
+# run — so this is a nightly/manual lane rather than a PR gate.
+#
+# Scope is deliberately narrow, and the reason is a property of Miri rather
+# than of the code: it cannot execute foreign functions, so the crates where
+# this workspace's `unsafe` actually concentrates — the libkrun FFI, the HVF
+# and QEMU device models, the seccomp/Landlock jailer — are out of reach. What
+# is left is the pure-Rust code on the untrusted-input path, which is exactly
+# the code an interpreter is good at checking.
+#
+# `mvm-contract` is the primary target: `no_std` + alloc, `forbid(unsafe_code)`,
+# and it carries the audit-log verifier and the wire DTOs. A UB report there
+# would mean UB in a dependency, which is worth knowing.
+
+on:
+  schedule:
+    # 04:20 UTC daily, offset from the other nightly lanes so they do not
+    # contend for runners.
+    - cron: "20 4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  miri:
+    name: Miri (pure-Rust crates)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Not yet merge-blocking. Miri surfaces findings in dependencies as
+    # readily as in first-party code, and a lane that goes red on an upstream
+    # crate's UB would block unrelated work. Flip this off once a clean
+    # baseline has held for a few weeks — tracked in specs/plans/303.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Miri
+        # Unpinned nightly on purpose: `rustup` resolves to the most recent
+        # nightly that actually ships the `miri` component, which a pinned
+        # date can silently stop doing. The lane is advisory, so drift in the
+        # toolchain cannot break a merge.
+        run: |
+          rustup toolchain install nightly --component miri --profile minimal
+          rustup override set nightly
+          cargo miri setup
+
+      - name: Run Miri over mvm-contract
+        # Flags, both measured rather than guessed:
+        #
+        # `-Zmiri-disable-isolation` allows the clock and filesystem reads the
+        # DTO round-trip tests do. It weakens Miri's determinism, not its UB
+        # detection.
+        #
+        # `-Zmiri-ignore-leaks` is needed because test helpers deliberately
+        # `Box::leak` an encoded frame to hand `decode` a `&'static [u8]` (see
+        # `l3::frame::tests::roundtrip`). Miri correctly reports those as
+        # leaked allocations, which would fail the lane on intentional
+        # test-only behaviour. This turns off leak *checking* only — every UB
+        # check stays on, and UB is what this lane is for.
+        #
+        # `--skip merkle::` is a real exclusion, not a tidy-up. Those tests
+        # sweep proof generation and ed25519 verification across many tree
+        # sizes; natively that is seconds, under the interpreter it ran past
+        # 30 minutes without finishing and starved the rest of the suite. With
+        # them skipped the remaining 504 tests complete in ~4m20s locally,
+        # which is what makes this viable as a nightly at all. The merkle
+        # logic is pure arithmetic over vetted crypto crates — the lowest-value
+        # Miri target in the crate — while the DTO and frame parsers it does
+        # cover are the untrusted-input surface.
+        #
+        # `--lib --tests` excludes doctests: Miri cannot run them at all (the
+        # doctest runner rejects the nightly `-Z` flags cargo-miri passes), so
+        # without this the lane fails after every test has already passed.
+        # `cargo test --workspace --doc` covers doctests natively in `ci.yml`.
+        env:
+          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks
+        run: cargo miri test -p mvm-contract --lib --tests -- --skip merkle::

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -564,6 +564,23 @@ opt-level = 3
 strip = true
 lto = true
 codegen-units = 1
+# Wrapping arithmetic is not a safe default for this workspace. The ext4
+# writer, the OCI unpacker, the vsock frame parser and the datapath ingress all
+# do length arithmetic over bytes an attacker chooses, and all four are fuzzed
+# — under a profile that traps overflow, against a shipped binary that did not.
+# A wrapped length is a bounds check that silently passes. Trapping costs a few
+# percent on the hot paths and turns that class of bug into a fail-closed abort
+# instead of a memory-safety-adjacent surprise.
+overflow-checks = true
+
+# `release` semantics (no debug assertions, trapping overflow) without paying
+# fat LTO and single-codegen-unit linking on a ~4,350-test suite. This is what
+# the release-profile witness lane builds with; it is not a shipping profile.
+[profile.release-witness]
+inherits = "release"
+lto = false
+codegen-units = 16
+strip = false
 
 # Speed up `cargo test --workspace` by giving the test profile more
 # parallel codegen units and dropping debug info to line tables only.

--- a/crates/mvm-client/src/audit/event.rs
+++ b/crates/mvm-client/src/audit/event.rs
@@ -117,6 +117,11 @@ pub enum AuditRefusalKind {
     SignatureInvalid,
     /// A verified entry claimed a scope other than the source's.
     ScopeMismatch,
+    /// The chain ends mid-record: a writer died between the record and its
+    /// terminator. Deliberately not folded into [`Self::Malformed`] — an
+    /// operator needs to tell an interrupted write from an edited log, and on
+    /// disk the two are otherwise the same thing.
+    Truncated,
 }
 
 /// Typed refusal for one source that failed verification. Returned

--- a/crates/mvm-client/src/audit/normalize.rs
+++ b/crates/mvm-client/src/audit/normalize.rs
@@ -137,6 +137,9 @@ pub(crate) fn refusal_from_lifecycle(
         LifecycleVerifyError::SignatureInvalid { line } => {
             (AuditRefusalKind::SignatureInvalid, Some(*line as u64))
         }
+        LifecycleVerifyError::TruncatedTail { line } => {
+            (AuditRefusalKind::Truncated, Some(*line as u64))
+        }
     };
     refusal(source, kind, line, &err.to_string())
 }

--- a/crates/mvm-client/src/audit/tests.rs
+++ b/crates/mvm-client/src/audit/tests.rs
@@ -276,7 +276,11 @@ fn truncated_tail_refuses_the_whole_source() {
     let response = read_all(&fx.reader());
     assert!(response.events.is_empty(), "no partial prefix may leak");
     assert_eq!(response.refusals.len(), 1);
-    assert_eq!(response.refusals[0].kind, AuditRefusalKind::Malformed);
+    // Refusing was always right; calling it `Malformed` was not. A half-written
+    // line and an edited one are the same bytes on disk, and the operator
+    // triaging the refusal is exactly the person who needs to tell a crashed
+    // writer from a tampered log. The reader now names which one it saw.
+    assert_eq!(response.refusals[0].kind, AuditRefusalKind::Truncated);
     assert_eq!(response.refusals[0].line, Some(1));
 }
 

--- a/crates/mvm-fs/src/oci/error.rs
+++ b/crates/mvm-fs/src/oci/error.rs
@@ -51,6 +51,15 @@ pub enum OciError {
     #[error("layer size {declared} bytes exceeds cap of {cap} bytes")]
     LayerTooLarge { declared: u64, cap: u64 },
 
+    /// The manifest body ran past the cap before it could be buffered.
+    /// Manifests are kilobytes and an index for a large multi-arch image is
+    /// still well under a megabyte, so anything past the cap is broken or
+    /// hostile. The digest check runs on the buffered bytes, which means
+    /// without this bound the registry chooses how much memory we allocate
+    /// before we are in a position to reject it.
+    #[error("manifest body exceeds cap of {cap} bytes")]
+    ManifestTooLarge { cap: u64 },
+
     /// The layer tarball could not be unpacked to the caller-supplied
     /// output root. The wrapped string is the underlying unpack error.
     #[error("layer unpack failed: {0}")]

--- a/crates/mvm-fs/src/oci/layer.rs
+++ b/crates/mvm-fs/src/oci/layer.rs
@@ -784,6 +784,7 @@ fn is_transient(e: &OciError) -> bool {
         | OciError::MalformedDigest(_)
         | OciError::UnsupportedDigestAlgorithm(_)
         | OciError::LayerTooLarge { .. }
+        | OciError::ManifestTooLarge { .. }
         | OciError::Unpack(_) => false,
     }
 }

--- a/crates/mvm-fs/src/oci/manifest.rs
+++ b/crates/mvm-fs/src/oci/manifest.rs
@@ -246,6 +246,76 @@ const ACCEPTED_MANIFEST_MEDIA: &[&str] = &[
     "application/vnd.docker.distribution.manifest.list.v2+json",
 ];
 
+/// Hard cap on a manifest body, enforced before the bytes are buffered.
+///
+/// An OCI image manifest is a few kilobytes and a multi-arch index is still
+/// well under a megabyte; 4 MiB is generous by three orders of magnitude and
+/// still small enough that a hostile registry cannot use it to exhaust the
+/// host. The bound has to be here rather than after the read because the
+/// integrity check operates on bytes we have already committed memory to.
+const MAX_MANIFEST_BYTES: u64 = 4 * 1024 * 1024;
+
+/// A body accumulator that refuses to grow past `cap`.
+///
+/// Split out from the network call so the bound itself is unit-testable
+/// without standing up a registry: the interesting behaviour is the arithmetic
+/// on the running total, not the transport.
+struct CappedBody {
+    cap: u64,
+    buf: Vec<u8>,
+}
+
+impl CappedBody {
+    fn new(cap: u64) -> Self {
+        Self {
+            cap,
+            buf: Vec::new(),
+        }
+    }
+
+    /// Admit one chunk, or refuse if it would carry the total past the cap.
+    /// The check is on the sum rather than the chunk so a body delivered as
+    /// many small chunks is bounded the same as one delivered whole.
+    fn push(&mut self, chunk: &[u8]) -> Result<(), OciError> {
+        let total = self.buf.len() as u64 + chunk.len() as u64;
+        if total > self.cap {
+            return Err(OciError::ManifestTooLarge { cap: self.cap });
+        }
+        self.buf.extend_from_slice(chunk);
+        Ok(())
+    }
+
+    fn into_inner(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+/// Reject a body whose declared length already exceeds the cap.
+///
+/// `Content-Length` is only a hint — absent under chunked transfer encoding,
+/// and understated at will by a registry that means us harm — so this is an
+/// optimisation, not the enforcement. [`CappedBody`] is the enforcement.
+fn declared_length_within_cap(declared: Option<u64>, cap: u64) -> Result<(), OciError> {
+    match declared {
+        Some(n) if n > cap => Err(OciError::ManifestTooLarge { cap }),
+        _ => Ok(()),
+    }
+}
+
+/// Read a response body, refusing to buffer more than `cap` bytes.
+async fn read_body_capped(mut response: reqwest::Response, cap: u64) -> Result<Vec<u8>, OciError> {
+    declared_length_within_cap(response.content_length(), cap)?;
+    let mut body = CappedBody::new(cap);
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| OciError::Registry(format!("read manifest response body: {e}")))?
+    {
+        body.push(&chunk)?;
+    }
+    Ok(body.into_inner())
+}
+
 #[async_trait]
 impl ManifestFetcher for OciManifestFetcher {
     async fn fetch(&self, reference: &ImageReference) -> Result<FetchedManifest, OciError> {
@@ -253,11 +323,7 @@ impl ManifestFetcher for OciManifestFetcher {
             .client
             .get_manifest(reference, ACCEPTED_MANIFEST_MEDIA)
             .await?;
-        let bytes = response
-            .response
-            .bytes()
-            .await
-            .map_err(|e| OciError::Registry(format!("read manifest response body: {e}")))?;
+        let bytes = read_body_capped(response.response, MAX_MANIFEST_BYTES).await?;
         let computed = format!("sha256:{}", hex::encode(Sha256::digest(&bytes)));
         if let Some(advertised_digest) = response.docker_content_digest {
             if computed != advertised_digest {
@@ -351,6 +417,54 @@ pub fn verify_sha256_digest(bytes: &[u8], expected: &str) -> Result<(), OciError
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A registry that declares an oversized body is rejected before we read
+    /// any of it.
+    #[test]
+    fn a_declared_length_over_the_cap_is_refused_before_reading() {
+        let err = declared_length_within_cap(Some(4097), 4096)
+            .expect_err("an over-cap Content-Length must be refused");
+        assert!(matches!(err, OciError::ManifestTooLarge { cap: 4096 }));
+    }
+
+    /// A missing or understated `Content-Length` must not be treated as
+    /// permission — it is a hint, and the accumulator is the real bound.
+    #[test]
+    fn a_missing_declared_length_is_not_treated_as_permission() {
+        declared_length_within_cap(None, 4096).expect("absent length is not itself a refusal");
+        // ...and the accumulator still refuses the body that header omitted.
+        let mut body = CappedBody::new(8);
+        body.push(b"12345678").expect("exactly at the cap is fine");
+        let err = body
+            .push(b"9")
+            .expect_err("one byte past the cap must be refused");
+        assert!(matches!(err, OciError::ManifestTooLarge { cap: 8 }));
+    }
+
+    /// The bound is on the running total, so a body dribbled out in small
+    /// chunks is capped the same as one delivered in a single read.
+    #[test]
+    fn many_small_chunks_are_bounded_by_the_total_not_the_chunk() {
+        let mut body = CappedBody::new(4);
+        for _ in 0..4 {
+            body.push(b"x").expect("within cap");
+        }
+        let err = body
+            .push(b"x")
+            .expect_err("the fifth byte crosses a 4-byte cap");
+        assert!(matches!(err, OciError::ManifestTooLarge { cap: 4 }));
+    }
+
+    /// An ordinary manifest passes and round-trips its bytes unchanged —
+    /// without this the tests above would hold for an accumulator that
+    /// refused everything.
+    #[test]
+    fn an_ordinary_body_passes_through_unchanged() {
+        let mut body = CappedBody::new(MAX_MANIFEST_BYTES);
+        body.push(br#"{"schemaVersion":2,"#).unwrap();
+        body.push(br#""layers":[]}"#).unwrap();
+        assert_eq!(body.into_inner(), br#"{"schemaVersion":2,"layers":[]}"#);
+    }
 
     const KNOWN_BYTES: &[u8] = b"hello mvm";
     // sha256("hello mvm") — kept as a constant so the test for

--- a/crates/mvm-fs/src/oci/unpack/mod.rs
+++ b/crates/mvm-fs/src/oci/unpack/mod.rs
@@ -248,6 +248,22 @@ pub struct UnpackOptions {
     /// [`SetidPolicy::RefuseUnsigned`]; production callers with a
     /// valid cosign result use [`SetidPolicy::PreserveVerified`].
     pub setid_policy: SetidPolicy,
+
+    /// Refuse a layer whose entries sum to more than this many bytes.
+    ///
+    /// This is the *decompressed* bound. The fetcher's `max_size` counts bytes
+    /// as they come off the wire, which is the wrong quantity for a compressed
+    /// layer: gzip will happily turn a megabyte the cap accepts into a
+    /// terabyte on disk. The default (8 GiB) clears the largest plausible real
+    /// image by a wide margin while keeping the ratio an attacker can exploit
+    /// finite.
+    pub max_total_bytes: u64,
+
+    /// Refuse a layer holding more than this many tar entries. Bounds the
+    /// many-small-files variant, where no single entry is suspicious and the
+    /// count is the attack. The default (2,000,000) is roughly two orders of
+    /// magnitude above a large distro image.
+    pub max_entries: u64,
 }
 
 impl Default for UnpackOptions {
@@ -257,6 +273,8 @@ impl Default for UnpackOptions {
             strip_timestamps: true,
             xattr_policy: XattrPolicy::PreserveAllowlisted,
             setid_policy: SetidPolicy::PreserveDev,
+            max_total_bytes: 8 * 1024 * 1024 * 1024,
+            max_entries: 2_000_000,
         }
     }
 }
@@ -500,6 +518,21 @@ pub enum UnpackError {
     /// subset of `output_root`'s subtree.
     #[error("output_root must exist as a directory; got {0:?}")]
     OutputRootNotADir(PathBuf),
+
+    /// The layer's entries sum to more bytes than
+    /// [`UnpackOptions::max_total_bytes`]. This is the decompressed bound: the
+    /// fetcher's size cap counts bytes off the wire, which a compressed layer
+    /// expands past by whatever ratio the attacker chooses. Aborts the unpack
+    /// rather than refusing one entry — once the total is over, the tarball is
+    /// not a thing we want to keep reading.
+    #[error("layer expands to more than the {cap}-byte unpack cap")]
+    TotalBytesExceeded { cap: u64 },
+
+    /// The layer holds more entries than [`UnpackOptions::max_entries`].
+    /// Bounds the small-file variant of the same attack, where each entry is
+    /// harmless and the count is the payload.
+    #[error("layer holds more than the {cap}-entry unpack cap")]
+    EntryCountExceeded { cap: u64 },
 }
 
 /// Unpack a single layer tarball under `output_root`, applying the
@@ -590,7 +623,22 @@ fn unpack_layer_inner<R: Read>(
     let mut current_layer_paths = HashSet::new();
     let mut case_fold_index = CaseFoldIndex::new(folding, prior_layer_paths);
 
+    // Decompressed-side resource bounds. Counted per entry so an over-cap
+    // layer is refused as it streams, rather than after it has already been
+    // written to disk. The tar framing means `entry.size()` is authoritative
+    // for how many payload bytes this entry will yield — the reader consumes
+    // exactly that many — so summing headers bounds the real write volume
+    // without buffering anything to find out.
+    let mut total_bytes: u64 = 0;
+    let mut entry_count: u64 = 0;
+
     for entry_result in archive.entries()? {
+        entry_count += 1;
+        if entry_count > options.max_entries {
+            return Err(UnpackError::EntryCountExceeded {
+                cap: options.max_entries,
+            });
+        }
         let mut entry = match entry_result {
             Ok(e) => e,
             Err(_) => {
@@ -606,6 +654,16 @@ fn unpack_layer_inner<R: Read>(
                 continue;
             }
         };
+
+        // Charge the entry's declared payload against the total before any of
+        // it is materialized. `saturating_add` so a header claiming u64::MAX
+        // trips the cap instead of wrapping past it.
+        total_bytes = total_bytes.saturating_add(entry.size());
+        if total_bytes > options.max_total_bytes {
+            return Err(UnpackError::TotalBytesExceeded {
+                cap: options.max_total_bytes,
+            });
+        }
 
         let raw_path = entry.path_bytes().to_vec();
 
@@ -984,6 +1042,124 @@ mod tests {
             &HashSet::new(),
             folding,
         )
+    }
+
+    /// The fetcher's size cap counts bytes off the wire, so a compressed
+    /// layer can clear it and still expand without bound. This is the cap on
+    /// the side that matters: what actually lands on disk.
+    #[test]
+    fn a_layer_over_the_total_byte_cap_is_refused() {
+        let tmp = TempDir::new().unwrap();
+        let layer = build_tar(|b| {
+            add_file(b, "a", b"0123456789");
+            add_file(b, "b", b"0123456789");
+        });
+        let options = UnpackOptions {
+            max_total_bytes: 15,
+            ..UnpackOptions::default()
+        };
+        let err = unpack_layer_inner(
+            Cursor::new(layer),
+            tmp.path(),
+            &options,
+            &HashSet::new(),
+            HostCaseFolding::Sensitive,
+        )
+        .expect_err("20 bytes of entries must not pass a 15-byte cap");
+        assert!(
+            matches!(err, UnpackError::TotalBytesExceeded { cap: 15 }),
+            "got {err:?}"
+        );
+    }
+
+    /// The shape an actual bomb takes: a header declaring far more payload
+    /// than the layer could ever hold, so the cost lands before any of it is
+    /// read.
+    ///
+    /// A header claiming `u64::MAX` is *not* the case to test — the tar
+    /// crate's own validation rejects that one first and it arrives as a
+    /// `MalformedHeader` refusal, never reaching the accumulator. The
+    /// `saturating_add` in the loop covers that arithmetic regardless; this
+    /// test drives the size a bomb can actually get past the framing.
+    #[test]
+    fn a_header_declaring_more_than_the_cap_is_refused() {
+        let tmp = TempDir::new().unwrap();
+        const ONE_TIB: u64 = 1 << 40;
+        let layer = build_tar(|b| {
+            let mut header = tar::Header::new_gnu();
+            header.set_path("bomb").unwrap();
+            header.set_size(ONE_TIB);
+            header.set_mode(0o644);
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_cksum();
+            b.append(&header, std::io::empty()).unwrap();
+        });
+        let err = unpack_layer_inner(
+            Cursor::new(layer),
+            tmp.path(),
+            &UnpackOptions::default(),
+            &HashSet::new(),
+            HostCaseFolding::Sensitive,
+        )
+        .expect_err("a 1 TiB declared entry must not pass the default 8 GiB cap");
+        assert!(
+            matches!(err, UnpackError::TotalBytesExceeded { .. }),
+            "got {err:?}"
+        );
+    }
+
+    /// The many-small-files variant, where no single entry looks wrong and
+    /// the count is the payload.
+    #[test]
+    fn a_layer_over_the_entry_count_cap_is_refused() {
+        let tmp = TempDir::new().unwrap();
+        let layer = build_tar(|b| {
+            for i in 0..10 {
+                add_file(b, &format!("f{i}"), b"x");
+            }
+        });
+        let options = UnpackOptions {
+            max_entries: 4,
+            ..UnpackOptions::default()
+        };
+        let err = unpack_layer_inner(
+            Cursor::new(layer),
+            tmp.path(),
+            &options,
+            &HashSet::new(),
+            HostCaseFolding::Sensitive,
+        )
+        .expect_err("10 entries must not pass a 4-entry cap");
+        assert!(
+            matches!(err, UnpackError::EntryCountExceeded { cap: 4 }),
+            "got {err:?}"
+        );
+    }
+
+    /// The caps must not fire on ordinary layers — otherwise the three tests
+    /// above would pass no matter what the unpacker did.
+    #[test]
+    fn an_ordinary_layer_passes_the_default_caps() {
+        let tmp = TempDir::new().unwrap();
+        let layer = build_tar(|b| {
+            add_dir(b, "usr");
+            add_file(b, "usr/hello", b"contents");
+            add_file(b, "usr/world", b"more contents");
+        });
+        let report = unpack_layer_inner(
+            Cursor::new(layer),
+            tmp.path(),
+            &UnpackOptions::default(),
+            &HashSet::new(),
+            HostCaseFolding::Sensitive,
+        )
+        .expect("a normal layer must unpack under the default caps");
+        assert!(report.refused.is_empty(), "{:?}", report.refused);
+        assert_eq!(report.files_written, 2);
+        assert_eq!(
+            std::fs::read(tmp.path().join("usr/hello")).unwrap(),
+            b"contents"
+        );
     }
 
     #[test]

--- a/crates/mvm-hostd/src/bin/mvm-audit-signer.rs
+++ b/crates/mvm-hostd/src/bin/mvm-audit-signer.rs
@@ -38,6 +38,9 @@ fn read_stdin_blocking() -> Result<Vec<u8>> {
 }
 
 fn main() -> Result<()> {
+    // First statement in the process: a panic before this line would
+    // print its payload unredacted.
+    mvm_hostd::panic_hook::install("audit-signer");
     // Step 6 of the spawn contract above: exit when the supervisor dies. The
     // child-side watchdog covers macOS and abnormal (SIGKILL/panic) deaths the
     // spawn-side PR_SET_PDEATHSIG attach cannot.

--- a/crates/mvm-hostd/src/bin/mvm-bridge.rs
+++ b/crates/mvm-hostd/src/bin/mvm-bridge.rs
@@ -53,6 +53,9 @@ use mvm_hostd::supervisor::network::{
 };
 
 fn main() -> ExitCode {
+    // First statement in the process: a panic before this line would
+    // print its payload unredacted.
+    mvm_hostd::panic_hook::install("bridge");
     // Stderr-only tracing keeps stdout clean (the parent reads stdin only).
     // Default to quiet (errors only); honor RUST_LOG when set. Same posture as
     // the bins this replaces.

--- a/crates/mvm-hostd/src/bin/mvm-broker.rs
+++ b/crates/mvm-hostd/src/bin/mvm-broker.rs
@@ -51,6 +51,9 @@ fn read_stdin_blocking() -> Result<Vec<u8>> {
 }
 
 fn main() -> Result<()> {
+    // First statement in the process: a panic before this line would
+    // print its payload unredacted.
+    mvm_hostd::panic_hook::install("broker");
     // Spawn-contract step 5: exit when the supervisor dies. This is the
     // "defensive double-attach in this binary" the contract above promises —
     // the child-side half that also covers macOS and abnormal parent death.

--- a/crates/mvm-hostd/src/bin/mvm-host-signer.rs
+++ b/crates/mvm-hostd/src/bin/mvm-host-signer.rs
@@ -38,6 +38,9 @@ fn read_stdin_blocking() -> Result<Vec<u8>> {
 }
 
 fn main() -> Result<()> {
+    // First statement in the process: a panic before this line would
+    // print its payload unredacted.
+    mvm_hostd::panic_hook::install("host-signer");
     // Step 6 of the spawn contract above: exit when the supervisor dies. The
     // child-side watchdog covers macOS and abnormal (SIGKILL/panic) deaths the
     // spawn-side PR_SET_PDEATHSIG attach cannot.

--- a/crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs
@@ -95,6 +95,9 @@ struct PrelaunchEnvelope {
 }
 
 fn main() -> ExitCode {
+    // First statement in the process: a panic before this line would
+    // print its payload unredacted.
+    mvm_hostd::panic_hook::install("libkrun-supervisor");
     // macOS Hypervisor.framework rejects any process without
     // `com.apple.security.hypervisor`. The ad-hoc signer
     // self-signs + re-spawns the binary on first run; subsequent

--- a/crates/mvm-hostd/src/bin/mvm-signer-helper.rs
+++ b/crates/mvm-hostd/src/bin/mvm-signer-helper.rs
@@ -26,6 +26,9 @@ fn read_stdin_blocking() -> Result<Vec<u8>> {
 }
 
 fn main() -> Result<()> {
+    // First statement in the process: a panic before this line would
+    // print its payload unredacted.
+    mvm_hostd::panic_hook::install("signer-helper");
     // A signer-helper whose host-agent parent is gone holds key material no one
     // can reach — exit rather than leak as an orphan.
     mvm_hostd::parent_death::exit_when_orphaned();

--- a/crates/mvm-hostd/src/bin/mvm-substitution-endpoint.rs
+++ b/crates/mvm-hostd/src/bin/mvm-substitution-endpoint.rs
@@ -45,6 +45,9 @@ fn read_stdin_blocking() -> Result<Vec<u8>> {
 }
 
 fn main() -> Result<()> {
+    // First statement in the process: a panic before this line would
+    // print its payload unredacted.
+    mvm_hostd::panic_hook::install("substitution-endpoint");
     // This process holds the workload's secrets in the clear; a backend that
     // died must not leave it serving as an orphan. Exit the instant the parent
     // is gone (macOS / SIGKILL gap the spawn-side attach misses).

--- a/crates/mvm-hostd/src/lib.rs
+++ b/crates/mvm-hostd/src/lib.rs
@@ -58,6 +58,9 @@ pub mod netd;
 /// about its own networking. Node-local by construction: it answers only
 /// from state this node owns, scoped to the caller the kernel identifies.
 pub mod nodectl;
+/// Redacting panic hook for the daemon bins. A panic payload is the one
+/// string the no-`Display`-on-secret-types gate cannot reach.
+pub mod panic_hook;
 /// Child-side parent-death watchdog: each subprocess-moat bin exits the
 /// instant its supervisor dies, closing the macOS / abnormal-death gap the
 /// spawn-side `PR_SET_PDEATHSIG` attach leaves open.

--- a/crates/mvm-hostd/src/panic_hook.rs
+++ b/crates/mvm-hostd/src/panic_hook.rs
@@ -1,0 +1,178 @@
+//! Redacting panic hook for the host daemons.
+//!
+//! The supervisor and its helper subprocesses are the only processes in the
+//! system that hold secret material in the clear. `xtask
+//! check-no-display-on-secret-types` keeps those values out of `Debug` and
+//! `Display` impls, but a panic payload is neither: `.expect(&format!("...
+//! {token}"))`, or an `unwrap()` on an error type that transitively carries a
+//! value, produces a string the gate never sees. That string goes to stderr,
+//! which in the supervisor's case is a captured log file.
+//!
+//! This hook is the last place to catch that. It runs every payload through
+//! the same [`SecretsScanner`] the stream plane uses, so a value that would be
+//! redacted on its way out of the guest is also redacted on its way into a
+//! crash log.
+//!
+//! # What this hook deliberately does not do
+//!
+//! **It does not exit the process.** A panic hook runs for *every* panic,
+//! including ones that are about to be caught. Three places rely on
+//! `catch_unwind` to contain a fault without losing the process — the observer
+//! pipeline, the gateway-bridge signer fan-out, and the host-services FFI
+//! boundary — and a hook that exited would silently convert all of them into
+//! crashes. Panic *policy* belongs at those call sites, which can tell a
+//! contained fault from a fatal one; the hook only observes.
+//!
+//! **It does not emit an audit entry.** The audit signer takes a mutex and a
+//! file lock, and the most likely reason to be in this hook holding secret
+//! material is that something in that path just failed. A hook that tried to
+//! sign would deadlock on the lock it already holds, or hit a poisoned mutex
+//! and panic again — and a panic inside a panic hook aborts. Crash reporting
+//! that can take down the process it is reporting on is worse than none.
+
+use std::panic::PanicHookInfo;
+use std::sync::Once;
+
+use crate::supervisor::secrets_scanner::SecretsScanner;
+
+static INSTALL: Once = Once::new();
+
+/// Mask substituted for a matched secret. Fixed-width on purpose: the length
+/// of the original is itself a hint, and a crash log is exactly the artifact
+/// that gets pasted into a ticket.
+const MASK: &[u8] = b"[redacted]";
+
+/// Install the redacting hook for `role`, once per process.
+///
+/// Chains to whatever hook was already installed, so this composes with a
+/// test harness's hook or a future reporter rather than replacing it. Safe to
+/// call from every daemon `main`; subsequent calls are no-ops.
+pub fn install(role: &'static str) {
+    INSTALL.call_once(|| {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            report(role, info);
+            previous(info);
+        }));
+    });
+}
+
+/// Render one panic as a redacted log line.
+fn report(role: &'static str, info: &PanicHookInfo<'_>) {
+    let scanner = SecretsScanner::with_default_rules();
+    let (message, categories) = redact_payload(&scanner, payload_of(info));
+    // `location()` is the only positional signal available: release builds are
+    // built with `strip = true`, so there is no symbolized backtrace to pair
+    // it with.
+    let location = info
+        .location()
+        .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+        .unwrap_or_else(|| "<unknown>".to_string());
+
+    if categories.is_empty() {
+        tracing::error!(role, location, message, "daemon panicked");
+    } else {
+        // Naming the categories without the values tells an operator which
+        // credential to rotate, which is the actionable half of the leak.
+        tracing::error!(
+            role,
+            location,
+            message,
+            redacted = categories.join(","),
+            "daemon panicked; secret material was redacted from the payload"
+        );
+    }
+}
+
+/// Extract the panic payload as a string.
+///
+/// `panic!` with a format string yields `String`; a literal yields `&str`.
+/// Anything else (`panic_any`) has no meaningful text, and its `Debug` is not
+/// something we want to render into a log — it could be the very value we are
+/// trying to keep out.
+fn payload_of<'a>(info: &'a PanicHookInfo<'_>) -> &'a str {
+    let payload = info.payload();
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        s
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        "<non-string panic payload>"
+    }
+}
+
+/// Run `message` through the scanner, returning the redacted text and the
+/// categories that matched.
+///
+/// Lossy UTF-8 on the way back: the scanner works in bytes and a mask can land
+/// mid-sequence. A crash log is a diagnostic, so a replacement character is an
+/// acceptable price for never emitting the original bytes.
+fn redact_payload(scanner: &SecretsScanner, message: &str) -> (String, Vec<&'static str>) {
+    let (redacted, categories) = scanner.redact(message.as_bytes(), MASK);
+    (String::from_utf8_lossy(&redacted).into_owned(), categories)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The case the hook exists for: a secret interpolated into a panic
+    /// message, which no `Debug`/`Display` gate can reach.
+    #[test]
+    fn a_secret_in_the_payload_is_redacted() {
+        let scanner = SecretsScanner::with_default_rules();
+        let leaked = "failed to authenticate with ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+        let (message, categories) = redact_payload(&scanner, leaked);
+
+        assert!(
+            !message.contains("ghp_abcdefghijklmnopqrstuvwxyz0123456789"),
+            "the raw token survived redaction: {message}"
+        );
+        assert!(
+            message.contains("[redacted]"),
+            "expected a mask in {message}"
+        );
+        assert!(
+            !categories.is_empty(),
+            "a matched secret must name its category so the operator knows what to rotate"
+        );
+    }
+
+    /// Redaction must not eat ordinary diagnostics — a hook that masked
+    /// everything would make the test above pass while destroying the logs.
+    #[test]
+    fn an_ordinary_message_passes_through_intact() {
+        let scanner = SecretsScanner::with_default_rules();
+        let (message, categories) = redact_payload(&scanner, "vsock accept failed: EAGAIN");
+        assert_eq!(message, "vsock accept failed: EAGAIN");
+        assert!(categories.is_empty());
+    }
+
+    #[test]
+    fn a_string_payload_is_recovered() {
+        let info = std::panic::catch_unwind(|| panic!("{}", "formatted".to_string()))
+            .expect_err("the closure panics");
+        assert!(info.downcast_ref::<String>().is_some());
+    }
+
+    /// A non-string payload must not be rendered via `Debug` — that is a path
+    /// back to the value we are trying to keep out of the log.
+    #[test]
+    fn a_non_string_payload_is_not_rendered() {
+        let payload = std::panic::catch_unwind(|| std::panic::panic_any(42u32))
+            .expect_err("the closure panics");
+        assert!(payload.downcast_ref::<String>().is_none());
+        assert!(payload.downcast_ref::<&'static str>().is_none());
+    }
+
+    /// Installing twice must not stack hooks — each install wraps the
+    /// previous one, so an unguarded `install` in a retry loop would grow an
+    /// unbounded chain and multiply every future panic's output.
+    #[test]
+    fn install_is_idempotent() {
+        install("test-role");
+        install("test-role");
+        // Reaching here without recursion or a double-install panic is the
+        // assertion; `Once` guarantees the body ran at most once.
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/audit.rs
+++ b/crates/mvm-hostd/src/supervisor/audit.rs
@@ -267,6 +267,14 @@ pub enum AuditError {
 
     #[error("io error writing audit entry: {0}")]
     Io(String),
+
+    /// The tenant stream's last record has no terminating newline, so a
+    /// previous append died mid-write. Chaining onto it would hash a partial
+    /// record, and every later entry would then verify against a prefix no
+    /// signer ever produced. Refuse rather than extend a chain from a record
+    /// that was never completed.
+    #[error("audit stream {path} ends mid-record; refusing to chain onto a partial write")]
+    TruncatedTail { path: String },
 }
 
 #[async_trait]

--- a/crates/mvm-hostd/src/supervisor/audit_file.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_file.rs
@@ -107,11 +107,24 @@ impl FileAuditSigner {
     /// Re-seed the in-memory cursor from disk on first emit per tenant.
     /// Hashes the last on-disk line; returns `[0; 32]` (genesis) if no
     /// file exists or the file is empty.
-    fn restore_cursor(&self, path: &Path) -> std::io::Result<[u8; 32]> {
+    ///
+    /// A file whose last byte is not `\n` ended mid-record: some previous
+    /// append died between writing the record and writing its terminator.
+    /// `str::lines` would hand back that partial record as though it were
+    /// whole, and we would chain onto the hash of a fragment. Report it as
+    /// [`AuditError::TruncatedTail`] instead — a crash has to be
+    /// distinguishable from tampering, and silently chaining onto a fragment
+    /// makes the two identical to every downstream verifier.
+    fn restore_cursor(&self, path: &Path) -> Result<[u8; 32], AuditError> {
         if !path.exists() {
             return Ok([0u8; 32]);
         }
-        let content = std::fs::read_to_string(path)?;
+        let content = std::fs::read_to_string(path).map_err(|e| AuditError::Io(e.to_string()))?;
+        if !content.is_empty() && !content.ends_with('\n') {
+            return Err(AuditError::TruncatedTail {
+                path: path.display().to_string(),
+            });
+        }
         let last = content.lines().rfind(|l| !l.is_empty());
         match last {
             None => Ok([0u8; 32]),
@@ -153,9 +166,7 @@ impl AuditSigner for FileAuditSigner {
         // Refresh the cursor under the lock — another process may
         // have appended between our last in-memory snapshot and
         // this call.
-        let prev_hash = self
-            .restore_cursor(&path)
-            .map_err(|e| AuditError::Io(e.to_string()))?;
+        let prev_hash = self.restore_cursor(&path)?;
         {
             let mut cursors = self.cursors.lock().expect("cursors poisoned");
             cursors.insert(cursor_key.clone(), prev_hash);
@@ -174,7 +185,26 @@ impl AuditSigner for FileAuditSigner {
         let line = serde_json::to_string(&envelope).map_err(|e| AuditError::Io(e.to_string()))?;
         let new_hash = hash_line(line.as_bytes());
 
-        writeln!(file, "{line}").map_err(|e| AuditError::Io(e.to_string()))?;
+        // One `write_all` of record-plus-terminator, then fsync, both inside
+        // the flock.
+        //
+        // `writeln!` goes through `write_fmt`, which issues a syscall per
+        // format fragment — the record, then the newline. A crash between the
+        // two leaves a record with no terminator, and the next append
+        // concatenates onto it: one corrupt line where there should be two
+        // valid ones, reported by the verifier as a chain break. The audit log
+        // is the evidence that a tamper would have to defeat, so a crash must
+        // not be able to produce a tamper's signature.
+        //
+        // The fsync is what makes "the emitter returned Ok" mean the record
+        // survives the machine losing power, which is the property every
+        // admission decision downstream is assuming.
+        let mut record = line.into_bytes();
+        record.push(b'\n');
+        file.write_all(&record)
+            .map_err(|e| AuditError::Io(e.to_string()))?;
+        file.sync_data()
+            .map_err(|e| AuditError::Io(e.to_string()))?;
 
         self.cursors
             .lock()
@@ -209,6 +239,14 @@ pub enum VerifyError {
     PrevHashMismatch { line: usize },
     #[error("signature invalid at line {line}")]
     SignatureInvalid { line: usize },
+    /// The file ends mid-record: a writer died between the record and its
+    /// terminating newline. Distinct from [`Self::Malformed`] on purpose — an
+    /// operator triaging a broken chain needs to know whether they are looking
+    /// at a crash or at an edit, and the two are otherwise identical on disk.
+    /// Entries before the truncation point are still verified and returned by
+    /// the count; only the incomplete tail is refused.
+    #[error("audit stream ends mid-record at line {line}: last append did not complete")]
+    TruncatedTail { line: usize },
 }
 
 /// Walk a chain-signed audit file, verifying each envelope's
@@ -227,11 +265,21 @@ pub fn verify_audit_chain_entries(
     verifying_key: &VerifyingKey,
 ) -> Result<Vec<AuditEntry>, VerifyError> {
     let content = std::fs::read_to_string(path).map_err(|e| VerifyError::Io(e.to_string()))?;
+    // A record is only complete once its terminator is on disk. `str::lines`
+    // does not distinguish "last line" from "last line so far", so check the
+    // final byte before walking: without this, a half-written record is
+    // reported as malformed JSON or a bad signature, and a crash becomes
+    // indistinguishable from someone having edited the log.
+    let truncated_tail = !content.is_empty() && !content.ends_with('\n');
     let mut prev_hash = [0u8; 32];
     let mut entries = Vec::new();
+    let last_idx = content.lines().count().saturating_sub(1);
     for (idx, line) in content.lines().enumerate() {
         if line.is_empty() {
             continue;
+        }
+        if truncated_tail && idx == last_idx {
+            return Err(VerifyError::TruncatedTail { line: idx });
         }
         let envelope: SignedEnvelope =
             serde_json::from_str(line).map_err(|e| VerifyError::Malformed {
@@ -818,5 +866,96 @@ mod tests {
             signer.verifying_key().to_bytes(),
             other.verifying_key().to_bytes()
         );
+    }
+
+    /// Every completed append leaves the stream terminated, which is what
+    /// makes "ends without a newline" a reliable truncation signal rather
+    /// than a coincidence of the last entry's content.
+    #[tokio::test]
+    async fn every_append_lands_terminated() {
+        let dir = tempfile::tempdir().unwrap();
+        let signer = FileAuditSigner::open(fresh_key(), dir.path()).unwrap();
+        for event in ["plan.verified", "plan.admitted", "plan.launched"] {
+            signer
+                .sign_and_emit(&make_entry("tenant-a", event))
+                .await
+                .unwrap();
+        }
+
+        let content = std::fs::read_to_string(signer.tenant_path("tenant-a")).unwrap();
+        assert!(
+            content.ends_with('\n'),
+            "a completed append must leave the record terminated on disk"
+        );
+        assert_eq!(content.lines().count(), 3);
+    }
+
+    /// A crash between the record and its terminator must not be able to
+    /// masquerade as tampering, and must not be silently extended.
+    ///
+    /// Before the single-`write_all` change this was reachable in production:
+    /// `writeln!` emitted the record and the newline as separate syscalls.
+    /// The torn state is simulated here because a real interleaving is not
+    /// deterministically reproducible.
+    #[tokio::test]
+    async fn a_torn_tail_is_refused_not_chained_onto() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = fresh_key();
+        let verifying = key.verifying_key();
+        let signer = FileAuditSigner::open(key, dir.path()).unwrap();
+        signer
+            .sign_and_emit(&make_entry("tenant-a", "plan.verified"))
+            .await
+            .unwrap();
+
+        // Simulate the crash: append a record that never got its terminator.
+        let path = signer.tenant_path("tenant-a");
+        let mut torn = std::fs::read_to_string(&path).unwrap();
+        torn.push_str(r#"{"entry":{"event":"plan.admi"#);
+        std::fs::write(&path, &torn).unwrap();
+
+        // The verifier names it truncation, not a bad signature and not a
+        // chain break — an operator has to be able to tell a crash from an
+        // edit.
+        let err = verify_audit_chain(&path, &verifying).expect_err("torn tail must not verify");
+        assert!(
+            matches!(err, VerifyError::TruncatedTail { .. }),
+            "expected TruncatedTail, got {err:?}"
+        );
+
+        // And the signer refuses to extend the chain from a partial record
+        // rather than hashing the fragment as though it were an entry.
+        let err = signer
+            .sign_and_emit(&make_entry("tenant-a", "plan.launched"))
+            .await
+            .expect_err("must not append onto a torn tail");
+        assert!(
+            matches!(err, AuditError::TruncatedTail { .. }),
+            "expected TruncatedTail, got {err:?}"
+        );
+    }
+
+    /// The truncation check must not fire on healthy files — otherwise it
+    /// would refuse every append and the test above would pass vacuously.
+    #[tokio::test]
+    async fn an_intact_chain_still_verifies_and_extends() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = fresh_key();
+        let verifying = key.verifying_key();
+        let signer = FileAuditSigner::open(key, dir.path()).unwrap();
+        for event in ["plan.verified", "plan.admitted"] {
+            signer
+                .sign_and_emit(&make_entry("tenant-a", event))
+                .await
+                .unwrap();
+        }
+        let path = signer.tenant_path("tenant-a");
+        assert_eq!(verify_audit_chain(&path, &verifying).unwrap(), 2);
+
+        signer
+            .sign_and_emit(&make_entry("tenant-a", "plan.launched"))
+            .await
+            .expect("an intact chain must still accept appends");
+        assert_eq!(verify_audit_chain(&path, &verifying).unwrap(), 3);
     }
 }

--- a/crates/mvm-hostd/src/supervisor/network/pipeline.rs
+++ b/crates/mvm-hostd/src/supervisor/network/pipeline.rs
@@ -1,8 +1,11 @@
 //! Synchronous observer fan-out runner. Pure: takes
 //! a raw frame + the observer slice, returns a `PacketDecision`. Reuses
 //! the `catch_unwind` panic-isolation pattern from `signer_task`
-//! (`gateway_bridge::signer_task`): a panicking observer is logged and
-//! treated as `Forward`; siblings continue.
+//! (`gateway_bridge::signer_task`) to keep a panicking observer from taking
+//! down the bridge — but isolation decides who survives, not what happens to
+//! the packet. An observer that declared `payload_tap` can return `Drop`, so
+//! its panic kills the flow; a telemetry observer never could, so its panic is
+//! logged and siblings continue.
 //!
 //! Verdict semantics:
 //! - Observers run in policy order; `Modify` chains (observer N+1 sees N's
@@ -29,6 +32,9 @@ pub enum KillReason {
     Drop,
     ModifyOverMtu,
     ModifyUnserializable,
+    /// An observer panicked instead of returning a verdict. An observer that
+    /// could not decide has not decided to allow.
+    ObserverPanic,
 }
 
 impl KillReason {
@@ -37,6 +43,7 @@ impl KillReason {
             KillReason::Drop => "drop",
             KillReason::ModifyOverMtu => "modify_over_mtu",
             KillReason::ModifyUnserializable => "modify_unserializable",
+            KillReason::ObserverPanic => "observer_panic",
         }
     }
 }
@@ -148,12 +155,37 @@ pub fn run_packet_pipeline<'a>(
         let verdict = match verdict {
             Ok(v) => v,
             Err(panic) => {
+                // Whether a panic is a fault to isolate or a verdict to
+                // respect depends on what the observer was there to do, and
+                // the observer already told us: `payload_tap` is the
+                // declaration that it inspects packet contents.
+                //
+                // A payload-tapping observer is the kind that can return
+                // `Drop`, so treating its panic as Forward would let a crash
+                // silently disarm an enforcement point — the same inversion
+                // this loop refuses twenty lines up, where an unparseable
+                // rebuild fails closed. A telemetry observer cannot make an
+                // informed drop decision in the first place; killing the flow
+                // because a counter panicked would be a self-inflicted
+                // outage, so that one stays isolated.
+                //
+                // `catch_unwind` keeps either case from taking down the
+                // bridge. It is not what decides the packet.
+                let enforcing = obs.required_capabilities().payload_tap;
                 tracing::warn!(
                     observer = obs.name(),
                     flow_id = ctx.flow_id,
+                    enforcing,
                     panic = %downcast_panic(&panic),
-                    "on_packet panicked; isolated via catch_unwind, treated as Forward"
+                    "on_packet panicked; isolated via catch_unwind"
                 );
+                if enforcing {
+                    return PacketDecision::Kill {
+                        observer: obs.name(),
+                        reason: KillReason::ObserverPanic,
+                        flow_key,
+                    };
+                }
                 continue;
             }
         };
@@ -272,6 +304,29 @@ mod tests {
         }
     }
 
+    /// An observer that declares no payload access — the shape of every
+    /// real observer wired today, all of which are counters.
+    struct TelemetryObs<F: Fn() + Send + Sync>(F, Directions);
+    impl<F: Fn() + Send + Sync> Observer for TelemetryObs<F> {
+        fn name(&self) -> &'static str {
+            "telemetry-obs"
+        }
+        fn required_capabilities(&self) -> RequiredCapabilities {
+            RequiredCapabilities {
+                flow_events: true,
+                payload_tap: false,
+            }
+        }
+        fn on_flow_event(&self, _: &crate::supervisor::gateway_bridge::FlowEvent) {}
+        fn directions(&self) -> Directions {
+            self.1
+        }
+        fn on_packet(&self, _c: &PacketCtx<'_>, _p: &ParsedPacket<'_>) -> Verdict {
+            (self.0)();
+            Verdict::Forward
+        }
+    }
+
     #[test]
     fn empty_observers_forwards_unmodified() {
         let f = frame(b"hello-SECRET");
@@ -289,6 +344,68 @@ mod tests {
                 assert_eq!(&*frame, &f[..]);
                 assert!(flow_key.is_some());
             }
+            other => panic!("expected Forward, got {other:?}"),
+        }
+    }
+
+    /// A panicking *payload-tapping* observer must kill the flow, not leak
+    /// the packet.
+    ///
+    /// This is the inversion the pipeline used to carry: `catch_unwind`
+    /// followed by `continue`, which reads as "isolate the fault" but means
+    /// "forward the packet nobody approved". An observer that asked for
+    /// payload access is one that can return `Drop`, so its panic has to be
+    /// treated the way every other unusable verdict in this loop is.
+    #[test]
+    fn panicking_payload_observer_kills_the_flow_instead_of_forwarding() {
+        let f = frame(b"hello-SECRET");
+        let obs: Vec<Arc<dyn Observer>> = vec![Arc::new(PayloadObs(
+            |_| panic!("observer exploded"),
+            Directions::Egress,
+        ))];
+
+        // Silence the default hook for the duration — the panic is the point
+        // of the test, and its backtrace is noise in the test log.
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let decision = run_packet_pipeline(
+            &obs,
+            &NoopSubstitution,
+            &NoopScan,
+            ctx(FlowDirection::Egress),
+            &f,
+            1514,
+            &lat(),
+        );
+        std::panic::set_hook(prev);
+
+        match decision {
+            PacketDecision::Kill { reason, .. } => {
+                assert_eq!(reason, KillReason::ObserverPanic);
+            }
+            other => panic!("a panicking observer must not forward; got {other:?}"),
+        }
+    }
+
+    /// The kill must come from the panic, not from the pipeline refusing
+    /// everything — otherwise the test above would pass vacuously.
+    #[test]
+    fn a_healthy_observer_on_the_same_path_still_forwards() {
+        let f = frame(b"hello-SECRET");
+        let obs: Vec<Arc<dyn Observer>> = vec![Arc::new(PayloadObs(
+            |_| Verdict::Forward,
+            Directions::Egress,
+        ))];
+        match run_packet_pipeline(
+            &obs,
+            &NoopSubstitution,
+            &NoopScan,
+            ctx(FlowDirection::Egress),
+            &f,
+            1514,
+            &lat(),
+        ) {
+            PacketDecision::Forward { frame, .. } => assert_eq!(&*frame, &f[..]),
             other => panic!("expected Forward, got {other:?}"),
         }
     }
@@ -426,13 +543,19 @@ mod tests {
         assert!(matches!(d, PacketDecision::Forward { .. }));
     }
 
+    /// A telemetry observer's panic stays a fault to isolate. It never had
+    /// payload access, so it was never in a position to withhold approval
+    /// from this packet, and killing the flow because a counter panicked
+    /// would be an outage we inflicted on ourselves.
     #[test]
-    fn panicking_observer_is_isolated_and_forwards() {
+    fn panicking_telemetry_observer_is_isolated_and_forwards() {
         let f = frame(b"hello-SECRET");
         let obs: Vec<Arc<dyn Observer>> = vec![
-            Arc::new(PayloadObs(|_| panic!("boom"), Directions::Egress)),
+            Arc::new(TelemetryObs(|| panic!("boom"), Directions::Egress)),
             Arc::new(PayloadObs(|_| Verdict::Forward, Directions::Egress)),
         ];
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
         let d = run_packet_pipeline(
             &obs,
             &NoopSubstitution,
@@ -442,9 +565,10 @@ mod tests {
             1514,
             &lat(),
         );
+        std::panic::set_hook(prev);
         assert!(
             matches!(d, PacketDecision::Forward { .. }),
-            "panic must be isolated -> Forward"
+            "a telemetry panic must be isolated -> Forward"
         );
     }
 

--- a/crates/mvm-hostd/tests/audit_chain_concurrent_writers.rs
+++ b/crates/mvm-hostd/tests/audit_chain_concurrent_writers.rs
@@ -183,7 +183,8 @@ fn explain(err: &VerifyError, path: &Path) -> String {
     let line_no = match err {
         VerifyError::PrevHashMismatch { line }
         | VerifyError::SignatureInvalid { line }
-        | VerifyError::Malformed { line, .. } => Some(*line),
+        | VerifyError::Malformed { line, .. }
+        | VerifyError::TruncatedTail { line } => Some(*line),
         VerifyError::Io(_) => None,
     };
     let context = line_no

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -24,8 +24,16 @@ for detailed scope and acceptance criteria.
   - [x] WS4 — redacting panic hook wired into seven daemon bins; observes and
         redacts only (exiting would break three `catch_unwind` isolation
         sites, and signing from a hook can deadlock or double-panic)
-  - [ ] WS6 — Landlock self-sandboxing for the `mvm-hostd` process moat
-  - [ ] WS7 — Miri lane over the pure-Rust crates
+  - [~] WS6 — **not** "add Landlock": the jailer already implements it
+        (`jailer/landlock.rs` + `LANDLOCK.md` + a live property test). Real
+        gap is that `confine_self` is called by only two bins, leaving
+        `mvm-host-signer`, `mvm-audit-signer`, `mvm-signer-helper` and
+        `mvm-broker` unconfined. Blocked on per-role seccomp allowlists,
+        which need live-Linux validation and should follow `feat/seccomp-audit`
+  - [x] WS7 — Miri lane over `mvm-contract`, advisory (nightly + dispatch,
+        `continue-on-error`). 511 tests, no UB, ~4m25s with `merkle::` skipped
+        — those sweeps ran past 30 min under the interpreter. Widening to
+        `mvm-core` crypto and the `mvm-fs` ext4 writer deferred
 - [~] eBPF vsock egress telemetry spike — **issue #2211**, branch
       `feat/ebpf-vsock-egress-telemetry`
   - [x] Remove the standalone `mvm-ebpf-egress` crate; fold the Aya loader

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -6,6 +6,26 @@ This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## In-flight plans
+- [~] Runtime hardening for production — plan 303, branch
+      `feat/plan-303-runtime-hardening`
+  - [x] WS1 — `overflow-checks = true` in `[profile.release]`, a
+        `release-witness` profile, and a CI lane running the untrusted-input
+        crates under it (wired into the `test` aggregate and pinned by
+        `check_workflow_paths`)
+  - [x] WS2 — audit-chain appends land as one `write_all` + `sync_data`; a
+        torn tail reports as truncation rather than tampering
+        (`AuditError::TruncatedTail`, `VerifyError::TruncatedTail`,
+        `AuditRefusalKind::Truncated`)
+  - [x] WS3 — manifest body capped before buffering; decompressed-byte and
+        entry-count caps on `UnpackOptions`
+  - [x] WS5 — a panicking `payload_tap` observer kills the flow; telemetry
+        observers keep today's isolation (scope corrected from the original
+        write-up — see the plan)
+  - [x] WS4 — redacting panic hook wired into seven daemon bins; observes and
+        redacts only (exiting would break three `catch_unwind` isolation
+        sites, and signing from a hook can deadlock or double-panic)
+  - [ ] WS6 — Landlock self-sandboxing for the `mvm-hostd` process moat
+  - [ ] WS7 — Miri lane over the pure-Rust crates
 - [~] eBPF vsock egress telemetry spike — **issue #2211**, branch
       `feat/ebpf-vsock-egress-telemetry`
   - [x] Remove the standalone `mvm-ebpf-egress` crate; fold the Aya loader

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -26,9 +26,14 @@
       decompressed-byte / entry-count caps on layer unpack; fail-closed
       handling of a panicking payload-tapping observer. WS5's scope was
       corrected during implementation — the blanket version would have let a
-      panicking metrics counter take down builder-VM networking. Remaining:
-      panic hook with secret sanitization (WS4), Landlock for the `mvm-hostd`
-      process moat (WS6), Miri lane (WS7).
+      panicking metrics counter take down builder-VM networking. Also landed: a
+      redacting panic hook across seven daemon bins, reusing the existing
+      `SecretsScanner` (a panic payload is the one string the
+      no-`Display`-on-secret-types gate cannot reach), and an advisory Miri
+      lane over `mvm-contract`. Remaining: extending `jailer::confine_self` to
+      the four unconfined moat roles — the Landlock machinery already exists,
+      but each role needs an audited seccomp allowlist validated on live Linux,
+      which should follow the `feat/seccomp-audit` tooling.
 
 - [x] Runtime SDK parity — **issue #2163**. Added the live process-handle and
       filesystem surface to Python and TypeScript, with a Rust-owned

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -16,6 +16,19 @@
       #2101 and #2211 require scope split or narrowing; the remaining issues
       retain active implementation, security, live-validation, or
       cross-repository acceptance work.
+- [~] Runtime hardening for production — **plan 303**. Closes gaps between the
+      binary CI witnesses and the binary that ships. Landed: trapping integer
+      overflow in `[profile.release]` plus a `release-witness` CI lane over the
+      crates that parse hostile input (until now every test ran under different
+      arithmetic than production); audit-chain appends as a single `write_all`
+      + `sync_data`, with a torn tail reported as truncation instead of
+      tampering; a cap on the OCI manifest body before it is buffered, and
+      decompressed-byte / entry-count caps on layer unpack; fail-closed
+      handling of a panicking payload-tapping observer. WS5's scope was
+      corrected during implementation — the blanket version would have let a
+      panicking metrics counter take down builder-VM networking. Remaining:
+      panic hook with secret sanitization (WS4), Landlock for the `mvm-hostd`
+      process moat (WS6), Miri lane (WS7).
 
 - [x] Runtime SDK parity — **issue #2163**. Added the live process-handle and
       filesystem surface to Python and TypeScript, with a Rust-owned

--- a/specs/plans/303-runtime-hardening.md
+++ b/specs/plans/303-runtime-hardening.md
@@ -1,0 +1,190 @@
+# Plan 303 — Runtime hardening for production
+
+**Status: IN PROGRESS**
+**Owner:** host runtime
+**Related:** ADR-001 (claims 5, 8, 9, 10, 12, 13, 14), ADR-014, ADR-020
+
+## Why
+
+Six gaps between what CI witnesses and what actually ships, found by auditing
+the tree against a runtime-hardening review of production Rust services. Each
+one is a place where the shipped binary behaves differently from the binary the
+test suite exercises, or where an untrusted input reaches an unbounded
+resource.
+
+These are not hypothetical. The fuzz corpus already drives the ext4 writer, the
+OCI unpacker, the vsock frame parser and the datapath ingress — all of it in a
+profile that checks integer overflow, against a release binary that does not.
+
+## Workstreams
+
+### WS1 — Release-profile arithmetic and a witness lane
+
+`[profile.release]` sets `opt-level`/`lto`/`strip`/`codegen-units` and nothing
+else, so every shipped binary wraps silently on integer overflow: `mvmctl`, the
+per-VM supervisors, the guest agent, the ext4 writer, the OCI unpacker, the
+vsock frame parser, the IPv6 extension-header walk. The only mention of the
+setting in the workspace is `crates/mvm-hostd/ebpf/Cargo.toml:17`, which
+disables it deliberately (eBPF verifier constraints — leave it).
+
+Turning it on converts silent wraparound into a panic. In the host daemons that
+is fail-closed and correct. In the guest agent it is a crash, which is why WS4
+lands the panic hook.
+
+- [ ] `overflow-checks = true` in `[profile.release]`
+- [ ] Add a `release-witness` profile inheriting `release` with `lto = false`
+      and `codegen-units = 16`, so the lane pays for overflow checks and
+      `debug_assertions = false` without paying LTO on a ~4,350-test suite
+- [ ] CI lane running the claim-witness tests under that profile
+- [ ] Triage every overflow the lane surfaces; fix, don't suppress
+
+### WS2 — Audit-chain appends are neither atomic nor durable
+
+`crates/mvm-hostd/src/supervisor/audit_file.rs` appends with
+`writeln!(file, "{line}")` and drops the flock without an fsync.
+`Write::write_fmt` issues at least two `write` syscalls (payload, then `\n`), so
+a crash between them leaves a newline-less final line. The next append
+concatenates onto it and `verify_audit_chain` reports drift that is
+indistinguishable from tampering.
+
+This is the substrate for claims 8, 12 and 14. A crash must not be able to
+forge the signature of an attack.
+
+- [ ] Build `line + '\n'` into one buffer and `write_all` it
+- [ ] `sync_data()` before releasing the flock
+- [ ] Test: a torn final line (no trailing newline) is rejected as truncation,
+      not silently concatenated into the next entry
+
+Note: PR #2239 (`fix/audit-chain-fork-races`) touches this file to widen
+`flock_exclusive` visibility. Different function; expect a clean merge.
+
+### WS3 — Unbounded reads on the OCI path
+
+Two separate holes:
+
+`crates/mvm-fs/src/oci/manifest.rs` reads the manifest body with `.bytes()`,
+uncapped, and computes the SHA-256 *afterwards*. A hostile or MITM'd registry
+streams a multi-GB body and mvmctl buffers all of it before any integrity check
+runs. Allocation failure aborts the process — it cannot be caught.
+
+`crates/mvm-fs/src/oci/layer.rs` caps the layer via `CacheWriterReader`, but
+that cap counts *compressed* bytes. `UnpackOptions`
+(`crates/mvm-fs/src/oci/unpack/mod.rs`) bounds path length and xattrs and
+nothing else, so a gzip bomb passes the cap and writes unbounded bytes to disk.
+
+- [ ] Cap the manifest body before it is buffered (OCI manifests are KBs;
+      a few MB is generous) and reject over-cap before hashing
+- [ ] Add decompressed-byte and entry-count caps to `UnpackOptions`
+- [ ] Tests: over-cap manifest rejected before hashing; gzip bomb rejected at
+      the decompressed cap; entry-count bomb rejected
+
+### WS4 — Panic hygiene in the host daemons
+
+No `set_hook` anywhere in the workspace. The supervisor is the one process that
+holds secrets in the clear, and `xtask check-no-display-on-secret-types` cannot
+reach a panic payload: it guards `Debug`/`Display` impls, not
+`.expect(&format!("... {token}"))` or an `unwrap()` on an error type that
+transitively carries a value.
+
+`strip = true` also means release panics carry no symbolized backtrace, so the
+`location()` field is the only signal.
+
+- [x] Panic hook for the host daemon bins that sanitizes the payload through
+      the existing `SecretsScanner`
+      (`crates/mvm-hostd/src/supervisor/secrets_scanner.rs`) — reuse, do not
+      write a second scanner
+- [x] Hook is installed once and chains to the previous hook
+- [x] Test: a panic carrying a known secret value produces a redacted record,
+      and an ordinary message survives intact
+
+Two items from the original draft were **dropped as actively unsafe**, found
+while implementing:
+
+- ~~Hook exits nonzero.~~ A panic hook runs for *every* panic, including ones
+  about to be caught. Three sites depend on `catch_unwind` to contain a fault
+  without losing the process — the observer pipeline, the gateway-bridge
+  signer fan-out, and the host-services FFI boundary. A hook that exited would
+  silently convert all three into crashes. Panic policy belongs at those call
+  sites, which can tell a contained fault from a fatal one.
+- ~~Hook emits a chain-signed `plan.panicked` entry.~~ The audit signer takes a
+  mutex and a file lock, and the most likely way to reach this hook holding
+  secret material is that something in that path just failed. Signing from the
+  hook would deadlock on a lock already held, or hit a poisoned mutex and panic
+  again — and a panic inside a panic hook aborts. Crash reporting that can kill
+  the process it reports on is worse than none.
+
+The hook therefore observes and redacts only, which is all a panic hook can
+soundly do.
+
+### WS5 — Observer panic must not vote Forward
+
+`crates/mvm-hostd/src/supervisor/network/pipeline.rs` catches an `on_packet`
+panic, logs, and `continue`s — which is Forward. The same function fails
+*closed* twenty lines earlier when a rebuild is unparseable.
+
+Severity today is low and the original write-up of this workstream overstated
+it. Correcting the record:
+
+- The fail-open is deliberate and was tested
+  (`panicking_observer_is_isolated_and_forwards`, "panic must be isolated ->
+  Forward"), not an oversight.
+- The pipeline is reached only from `passt.rs` and `native_gateway.rs`, which
+  are builder-VM / Stage 0 paths. No workload guest has a NIC, so this was
+  never a live claim-10 hole.
+- The only production `Observer` impl is `FlowCountMetrics`, a counter with
+  `payload_tap: false` that does not override `on_packet`. Every `Verdict::Drop`
+  in the tree is in a test module, and the observer list is host-allowlisted
+  and empty by default.
+
+So there is nothing on this path today that a panic could disarm, and blanket
+fail-closed would mean a panicking metrics counter takes down builder-VM
+networking — an availability regression bought with no security.
+
+Resolution: split on the capability the observer already declares.
+`payload_tap: true` is an observer saying it inspects contents, which is the
+class that can return `Drop`; its panic fails closed. A telemetry observer
+keeps today's isolate-and-forward, because it was never in a position to
+withhold approval.
+
+- [ ] Panic in a `payload_tap` observer maps to `PacketDecision::Kill` with an
+      `ObserverPanic` reason
+- [ ] Panic in a telemetry observer stays isolated (existing behaviour, kept
+      deliberately rather than by omission)
+- [ ] Tests for both halves, so neither can regress into the other
+
+### WS6 — Landlock self-sandboxing for the process moat (Linux)
+
+The `mvm-hostd` roles are separate processes precisely so that compromising one
+does not yield the others. Today that containment is convention. Landlock makes
+it kernel-enforced: `mvm-host-signer` needs only `~/.mvm/keys/`,
+`mvm-audit-signer` only `~/.mvm/audit/`, `mvm-broker` needs no filesystem at
+all.
+
+Linux-only, kernel 5.13+, and it must be applied after the role knows which
+paths it needs but before it accepts any input. Degrade to a warning where the
+kernel lacks support — never fail a launch over a missing LSM.
+
+- [ ] Per-role path allowlists derived from `mvm-core::config` helpers, not
+      inline `$HOME` joins
+- [ ] Applied early in each role's `main`, before threads or sockets
+- [ ] Absent/unsupported kernel degrades with a `doctor`-visible warning
+- [ ] `mvmctl doctor` reports the resolved sandbox state per role
+- [ ] Tests: allowlisted path opens; non-allowlisted path is denied
+
+### WS7 — Miri over the pure-Rust crates
+
+~750 unsafe blocks, concentrated in FFI and the VMM device models, which Miri
+cannot cross. The tractable targets are the pure-Rust ones on the untrusted
+input path.
+
+- [ ] Miri lane over `mvm-contract`, `mvm-core` crypto, and the `mvm-fs` ext4
+      writer
+- [ ] Nightly + manual dispatch, pinned toolchain, `continue-on-error` until a
+      clean baseline holds
+
+## Sequencing
+
+WS1 and WS2 first — both are small and both close a witnessed-versus-shipped
+gap. WS3 next as one PR (shared test surface, `unpack_layer` already fuzzed).
+WS4 and WS5 together (both `mvm-hostd`). WS6 and WS7 last; they are additive
+and platform-gated.

--- a/specs/plans/303-runtime-hardening.md
+++ b/specs/plans/303-runtime-hardening.md
@@ -31,12 +31,12 @@ Turning it on converts silent wraparound into a panic. In the host daemons that
 is fail-closed and correct. In the guest agent it is a crash, which is why WS4
 lands the panic hook.
 
-- [ ] `overflow-checks = true` in `[profile.release]`
-- [ ] Add a `release-witness` profile inheriting `release` with `lto = false`
+- [x] `overflow-checks = true` in `[profile.release]`
+- [x] Add a `release-witness` profile inheriting `release` with `lto = false`
       and `codegen-units = 16`, so the lane pays for overflow checks and
       `debug_assertions = false` without paying LTO on a ~4,350-test suite
-- [ ] CI lane running the claim-witness tests under that profile
-- [ ] Triage every overflow the lane surfaces; fix, don't suppress
+- [x] CI lane running the claim-witness tests under that profile
+- [x] Triage every overflow the lane surfaces; fix, don't suppress
 
 ### WS2 — Audit-chain appends are neither atomic nor durable
 
@@ -50,9 +50,9 @@ indistinguishable from tampering.
 This is the substrate for claims 8, 12 and 14. A crash must not be able to
 forge the signature of an attack.
 
-- [ ] Build `line + '\n'` into one buffer and `write_all` it
-- [ ] `sync_data()` before releasing the flock
-- [ ] Test: a torn final line (no trailing newline) is rejected as truncation,
+- [x] Build `line + '\n'` into one buffer and `write_all` it
+- [x] `sync_data()` before releasing the flock
+- [x] Test: a torn final line (no trailing newline) is rejected as truncation,
       not silently concatenated into the next entry
 
 Note: PR #2239 (`fix/audit-chain-fork-races`) touches this file to widen
@@ -72,10 +72,10 @@ that cap counts *compressed* bytes. `UnpackOptions`
 (`crates/mvm-fs/src/oci/unpack/mod.rs`) bounds path length and xattrs and
 nothing else, so a gzip bomb passes the cap and writes unbounded bytes to disk.
 
-- [ ] Cap the manifest body before it is buffered (OCI manifests are KBs;
+- [x] Cap the manifest body before it is buffered (OCI manifests are KBs;
       a few MB is generous) and reject over-cap before hashing
-- [ ] Add decompressed-byte and entry-count caps to `UnpackOptions`
-- [ ] Tests: over-cap manifest rejected before hashing; gzip bomb rejected at
+- [x] Add decompressed-byte and entry-count caps to `UnpackOptions`
+- [x] Tests: over-cap manifest rejected before hashing; gzip bomb rejected at
       the decompressed cap; entry-count bomb rejected
 
 ### WS4 — Panic hygiene in the host daemons
@@ -146,41 +146,92 @@ class that can return `Drop`; its panic fails closed. A telemetry observer
 keeps today's isolate-and-forward, because it was never in a position to
 withhold approval.
 
-- [ ] Panic in a `payload_tap` observer maps to `PacketDecision::Kill` with an
+- [x] Panic in a `payload_tap` observer maps to `PacketDecision::Kill` with an
       `ObserverPanic` reason
-- [ ] Panic in a telemetry observer stays isolated (existing behaviour, kept
+- [x] Panic in a telemetry observer stays isolated (existing behaviour, kept
       deliberately rather than by omission)
-- [ ] Tests for both halves, so neither can regress into the other
+- [x] Tests for both halves, so neither can regress into the other
 
-### WS6 — Landlock self-sandboxing for the process moat (Linux)
+### WS6 — Extend confinement to the unconfined moat roles (Linux)
 
-The `mvm-hostd` roles are separate processes precisely so that compromising one
-does not yield the others. Today that containment is convention. Landlock makes
-it kernel-enforced: `mvm-host-signer` needs only `~/.mvm/keys/`,
-`mvm-audit-signer` only `~/.mvm/audit/`, `mvm-broker` needs no filesystem at
-all.
+**The original framing of this workstream was wrong and is corrected here.**
+Landlock is not missing: `crates/mvm-hostd/src/jailer/landlock.rs` implements
+it, `jailer/LANDLOCK.md` documents the review process, `ConfinementSpec`
+carries per-role path allowlists alongside a seccomp syscall allowlist,
+`jailer::confine_self` applies both, and `tests/landlock_property.rs` is a
+live same-process property test. This is a mature subsystem.
 
-Linux-only, kernel 5.13+, and it must be applied after the role knows which
-paths it needs but before it accepts any input. Degrade to a warning where the
-kernel lacks support — never fail a launch over a missing LSM.
+The actual gap is narrower: `confine_self` is called by exactly two bins —
+`mvm-bridge` (`ConfinementSpec::firecracker_bridge`) and
+`mvm-substitution-endpoint` (`ConfinementSpec::substitution_endpoint`). Four
+moat roles run unconfined, three of which touch key material:
 
-- [ ] Per-role path allowlists derived from `mvm-core::config` helpers, not
-      inline `$HOME` joins
-- [ ] Applied early in each role's `main`, before threads or sockets
-- [ ] Absent/unsupported kernel degrades with a `doctor`-visible warning
-- [ ] `mvmctl doctor` reports the resolved sandbox state per role
-- [ ] Tests: allowlisted path opens; non-allowlisted path is denied
+- `mvm-host-signer` — holds the host Ed25519 signing key
+- `mvm-audit-signer` — holds the audit chain signing key
+- `mvm-signer-helper` — holds key material on the host-agent path
+- `mvm-broker` — needs no filesystem at all, so it is the cheapest win
+
+**Why this is not landed in this plan.** `confine_self` applies Landlock
+*and* seccomp; there is no Landlock-only path, and a spec with an empty
+`allowed_syscalls` installs a filter that denies everything. So each new role
+needs its own audited syscall table next to `seccomp::BRIDGE_SYSCALLS`. A
+wrong entry does not degrade — it SIGSYSes the daemon, and `confine_self`'s
+own contract requires the caller to hard-exit on partial confinement. That
+table can only be validated by running the real binary on Linux; it cannot be
+derived by reading code on a macOS host.
+
+Sequencing note: the unmerged `feat/seccomp-audit` branch adds a `mvmctl
+seccomp-audit` command and a shared syscall table. That tooling is the natural
+way to *derive* these allowlists, so this workstream should follow it rather
+than hand-write four tables in parallel.
+
+- [ ] Land or rebase `feat/seccomp-audit` first
+- [ ] Derive per-role syscall allowlists with it, one role per change
+- [ ] `ConfinementSpec::{host_signer, audit_signer, signer_helper, broker}`,
+      paths from `mvm-core::config` helpers rather than inline `$HOME` joins
+- [ ] Validate each on live Linux before wiring `confine_self` into its `main`
+- [ ] `mvmctl doctor` reports resolved confinement state per role
 
 ### WS7 — Miri over the pure-Rust crates
 
 ~750 unsafe blocks, concentrated in FFI and the VMM device models, which Miri
-cannot cross. The tractable targets are the pure-Rust ones on the untrusted
-input path.
+cannot cross — it does not execute foreign functions. The tractable target is
+the pure-Rust code on the untrusted-input path.
 
-- [ ] Miri lane over `mvm-contract`, `mvm-core` crypto, and the `mvm-fs` ext4
-      writer
-- [ ] Nightly + manual dispatch, pinned toolchain, `continue-on-error` until a
-      clean baseline holds
+Scoped to `mvm-contract` (`no_std` + alloc, `forbid(unsafe_code)`, carrying the
+audit-log verifier and the wire DTOs). `mvm-core`'s crypto and the `mvm-fs`
+ext4 writer were in the original scope and are deferred: both pull backends
+that Miri either cannot run or runs so slowly the lane stops being a nightly.
+Widening is a follow-up, not a silent omission.
+
+- [x] Miri lane over `mvm-contract`, run to completion locally before shipping
+      the workflow: **511 passed across three targets, 0 failed, no UB, ~4m25s**
+- [x] Nightly + manual dispatch, `continue-on-error` until a clean baseline
+      holds — Miri reports UB in dependencies as readily as first-party code,
+      and an advisory lane cannot block unrelated work
+- [ ] Widen to `mvm-core` crypto and the `mvm-fs` ext4 writer
+- [ ] Flip `continue-on-error` off once a baseline has held
+
+Two flags and one exclusion, all measured rather than assumed:
+
+- `--skip merkle::` — those tests sweep proof generation and ed25519
+  verification across many tree sizes. Under the interpreter the run passed
+  30 minutes without finishing; skipping them takes the rest to ~4m20s. An
+  unbounded nightly reports nothing, so this is what makes the lane exist.
+  It also drops the lowest-value target: pure arithmetic over vetted crypto
+  crates, versus the DTO and frame parsers that are the untrusted-input
+  surface.
+- `-Zmiri-ignore-leaks` — `l3::frame::tests::roundtrip` deliberately
+  `Box::leak`s an encoded frame to hand `decode` a `&'static [u8]`. Miri
+  correctly flags those; failing the lane on intentional test-only behaviour
+  would be noise. Leak *checking* off, every UB check on.
+- `-Zmiri-disable-isolation` — the DTO round-trips read the clock and
+  filesystem. Costs determinism, not UB detection.
+- `--lib --tests` — Miri cannot run doctests at all; the doctest runner
+  rejects the nightly `-Z` flags `cargo-miri` passes it. Without this the lane
+  fails *after* every test has already passed, which reads as a red lane and
+  is not. Doctests stay covered natively by `cargo test --workspace --doc` in
+  `ci.yml`.
 
 ## Sequencing
 

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -332,7 +332,26 @@ mod tests {
 
         let test = job_block(&workflow, "test");
         assert!(test.contains("name: Test"));
-        assert!(test.contains("needs: [test-workspace, test-linux]"));
+        assert!(test.contains("needs: [test-workspace, test-linux, test-release-witness]"));
+
+        // The release-profile lane is the only one that runs with trapping
+        // overflow and debug assertions off, i.e. the only one that witnesses
+        // what actually ships. A lane that runs but is not in the aggregate's
+        // `needs` is a lane that cannot fail the merge, so pin both halves.
+        let release_witness = job_block(&workflow, "test-release-witness");
+        assert!(release_witness.contains("--cargo-profile release-witness"));
+        for expected in [
+            "-p mvm-fs",
+            "-p mvm-core",
+            "-p mvm-contract",
+            "-p mvm-hostd",
+        ] {
+            assert!(
+                release_witness.contains(expected),
+                "release-witness lane must cover {expected:?}"
+            );
+        }
+
         let test_workspace = job_block(&workflow, "test-workspace");
         assert!(!test_workspace.contains("uses: actions/cache@v5"));
         assert!(test_workspace.contains("cargo nextest run -p xtask --features man"));


### PR DESCRIPTION
Closes gaps between the binary CI witnesses and the binary that ships, found by auditing the tree against a runtime-hardening review of production Rust services. Plan: `specs/plans/303-runtime-hardening.md`.

## Release arithmetic

`[profile.release]` set `opt-level`/`lto`/`strip`/`codegen-units` and nothing else, so every shipped binary wrapped silently on integer overflow. That matters here specifically because the ext4 writer, the OCI unpacker, the vsock frame parser and the datapath ingress all do length arithmetic over attacker-chosen bytes — and all four are fuzzed under a profile that traps overflow, against a release binary that did not. The fuzzers and the shipped code disagreed about what an overflow means.

Turns on `overflow-checks`, adds a `release-witness` profile (release minus fat LTO and single-codegen-unit linking) and a CI lane that runs the hostile-input crates under it. The lane is in the `test` aggregate's `needs` and pinned by `check_workflow_paths`, so it can fail a merge rather than merely run.

The full suite passes under trapping overflow with no code changes — no latent overflow surfaced. This is insurance, not a bug fix.

## Audit-chain durability

`writeln!` goes through `write_fmt`, which emits the record and its newline as separate syscalls. A crash between them left a record with no terminator; `restore_cursor` then hashed that fragment as though it were a whole line and the next append chained onto it. There was also no fsync, so "the emitter returned Ok" did not mean the record survived power loss — which every downstream admission decision assumes it does.

Now: record-plus-terminator in one `write_all`, then `sync_data`, both inside the existing flock. A torn tail is reported as truncation rather than as a malformed line, because an operator triaging a broken chain has to be able to tell a crash from an edit and the two are otherwise identical on disk. The client reader already refused these — it just called them `Malformed`.

## OCI bounds

Two separate unbounded reads:

- The manifest body was read with an uncapped `.bytes()` and hashed *afterwards*, so a hostile or MITM'd registry chose how much memory we allocated before we were in a position to reject it. Allocation failure aborts and cannot be caught.
- The layer cap is applied by `CacheWriterReader` to the *compressed* stream, and `UnpackOptions` bounded path length and xattrs only. A gzip bomb cleared the cap and wrote unbounded bytes to disk.

Adds a pre-buffering manifest cap and decompressed-byte / entry-count caps on unpack.

## Panic hygiene

The supervisor and its helpers are the only processes holding secret material in the clear. `xtask check-no-display-on-secret-types` guards `Debug`/`Display` impls, but a panic payload is neither — `.expect(&format!("... {token}"))` produces a string that gate never sees, and it lands in a captured log file.

Adds a hook across seven daemon bins that runs payloads through the existing `SecretsScanner` and names the matched categories without the values.

Deliberately does **not** exit (a hook runs for every panic, including caught ones — three `catch_unwind` isolation sites would silently become crashes) and does **not** emit an audit entry (the audit signer takes a mutex and a file lock; signing from the hook would deadlock or double-panic, and a panic inside a hook aborts).

## Observer panics

A panicking observer was treated as `Forward`. Split on the capability the observer already declares: `payload_tap` is the class that can return `Drop`, so its panic kills the flow; telemetry observers keep today's isolation.

Scoped down from the original proposal on purpose. The blanket version would have let a panicking metrics counter — the only observer wired in production — take down builder-VM networking, and it would have reversed an explicit tested decision for no current security gain, since nothing on that path can drop a packet today.

## Miri lane

Advisory (nightly + manual dispatch, `continue-on-error`) over `mvm-contract` — `no_std` + alloc, `forbid(unsafe_code)`, carrying the audit-log verifier and the wire DTOs. Miri cannot execute foreign functions, so the crates where this workspace's unsafe actually concentrates are out of reach; this is the pure-Rust untrusted-input surface, which is what an interpreter is good for.

Three flags and one exclusion, all measured by running the lane locally rather than assumed — each is documented inline in the workflow:

- `--skip merkle::` — those sweeps ran past 30 minutes under the interpreter without finishing. With them skipped the rest completes in ~4m25s, which is what makes the lane viable at all. It also drops the lowest-value target (arithmetic over vetted crypto crates) while keeping the parsers.
- `-Zmiri-ignore-leaks` — `l3::frame::tests::roundtrip` deliberately `Box::leak`s a frame to hand `decode` a `&'static [u8]`. Leak checking off, every UB check on.
- `--lib --tests` — Miri cannot run doctests; without this the lane fails *after* every test has passed. Doctests stay covered natively in `ci.yml`.
- `-Zmiri-disable-isolation` — the DTO round-trips read the clock and filesystem.

Local run: 511 passed across three targets, 0 failed, no UB.

## Not in this PR

Extending `jailer::confine_self` to the four unconfined moat roles (`mvm-host-signer`, `mvm-audit-signer`, `mvm-signer-helper`, `mvm-broker`). The Landlock machinery already exists and is mature; the gap is that only two bins call it. Each new role needs an audited seccomp allowlist, a wrong entry SIGSYSes the daemon rather than degrading, and it can only be validated by running the real binaries on Linux. Should follow the `feat/seccomp-audit` tooling. Documented in plan 303.

## Verification

- `cargo nextest run --workspace --all-targets` — 10,614 passed
- `cargo test --workspace --doc` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
