### PR TITLE
fix(ci): make the kernel budget check able to block a merge

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -19,6 +19,14 @@ on:
     paths:
       - "nix/images/kernel/**"
       - "nix/images/builder-vm/flake.nix"
+      # The lock is as much an input to the resolved config as the flake is:
+      # this workflow builds `./nix/images/builder-vm#...`, so a nixpkgs bump
+      # here moves the toolchain that runs `olddefconfig`.
+      - "nix/images/builder-vm/flake.lock"
+      # The budget this job enforces. Editing the ceiling without rebuilding
+      # the kernel it describes is how the ceiling drifts below the real
+      # count: the number is only meaningful against a measured config.
+      - "xtask/src/check_kernel_config_budget.rs"
       - ".github/workflows/kernel-build.yml"
   workflow_dispatch: {}
   push:
@@ -116,9 +124,16 @@ jobs:
           du -h vmlinux-${ARCH}-*
 
       - name: Upload kernel artifacts (CI visibility)
+        # `always()` because the budget gate above exits non-zero on a
+        # regression, and that is precisely the run whose resolved `.config`
+        # you need in order to see which symbol was added. Without this, a
+        # budget failure reports a count and discards the only evidence that
+        # explains it. Partial output is fine: the step globs what exists.
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: kernels-${{ matrix.arch }}
+          if-no-files-found: ignore
           path: |
             staging/vmlinux-${{ matrix.arch }}-builder
             staging/vmlinux-${{ matrix.arch }}-workload

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -14,20 +14,19 @@ name: Kernel build
 #   - push tag v* → build + publish to the release ("no prebuilt until
 #     release" — PRs never publish).
 
+# Deliberately unfiltered at the trigger, with the scope decision moved into
+# the `scope` job below. A `paths:` filter here means the check simply does
+# not appear on an unrelated PR, and a check that never appears cannot be a
+# required one — which is how a kernel budget lowered below the real symbol
+# count reached main and stayed there. `merge_group` additionally accepts no
+# `paths:` filter at all, so filtering at the trigger cannot block a bad merge
+# even in principle.
 on:
   pull_request:
-    paths:
-      - "nix/images/kernel/**"
-      - "nix/images/builder-vm/flake.nix"
-      # The lock is as much an input to the resolved config as the flake is:
-      # this workflow builds `./nix/images/builder-vm#...`, so a nixpkgs bump
-      # here moves the toolchain that runs `olddefconfig`.
-      - "nix/images/builder-vm/flake.lock"
-      # The budget this job enforces. Editing the ceiling without rebuilding
-      # the kernel it describes is how the ceiling drifts below the real
-      # count: the number is only meaningful against a measured config.
-      - "xtask/src/check_kernel_config_budget.rs"
-      - ".github/workflows/kernel-build.yml"
+  # Required for the merge queue: the check must run against the merge_group
+  # event to be able to stop a merge.
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch: {}
   push:
     tags:
@@ -41,10 +40,71 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/bdd.yml
 
+  # Does this change touch anything that can move the resolved kernel config?
+  # Cheap (a checkout and a diff), and it runs on every event so the kernel
+  # check is always reported and can therefore be marked required.
+  scope:
+    name: Kernel scope
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether the kernel needs rebuilding
+        id: decide
+        env:
+          # `merge_group` carries its own base/head; `pull_request` does not
+          # expose them as refs the runner has, so they are read from the event.
+          EVENT: ${{ github.event_name }}
+          MG_BASE: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD: ${{ github.event.merge_group.head_sha }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # A tag build publishes release assets and a manual dispatch is an
+          # explicit ask; neither is a diff, so both always build.
+          if [ "$EVENT" = "push" ] || [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "event=$EVENT — always builds"
+            exit 0
+          fi
+
+          case "$EVENT" in
+            merge_group)   BASE="$MG_BASE"; HEAD="$MG_HEAD" ;;
+            pull_request)  BASE="$PR_BASE"; HEAD="$PR_HEAD" ;;
+            *) echo "::error::unhandled event $EVENT" >&2; exit 1 ;;
+          esac
+
+          # Fail closed: if the range cannot be resolved, build rather than
+          # assume the change is irrelevant.
+          if ! CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null); then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "could not diff $BASE..$HEAD — building to stay safe"
+            exit 0
+          fi
+
+          # The inputs that can move the resolved config. Kept here rather than
+          # in a trigger `paths:` so the same list governs pull_request and
+          # merge_group, which cannot express one.
+          if printf '%s\n' "$CHANGED" | grep -Eq \
+            '^(nix/images/kernel/|nix/images/builder-vm/flake\.(nix|lock)$|xtask/src/check_kernel_config_budget\.rs$|\.github/workflows/kernel-build\.yml$)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "kernel-relevant paths changed:"
+            printf '%s\n' "$CHANGED" | grep -E \
+              '^(nix/images/kernel/|nix/images/builder-vm/flake\.(nix|lock)$|xtask/src/check_kernel_config_budget\.rs$|\.github/workflows/kernel-build\.yml$)'
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "no kernel-relevant paths in $BASE..$HEAD"
+          fi
+
   kernel:
     name: Build kernels (${{ matrix.arch }})
-    needs: [bdd]
-    if: ${{ always() && (needs.bdd.result == 'success' || needs.bdd.result == 'skipped') }}
+    needs: [bdd, scope]
+    if: ${{ always() && (needs.bdd.result == 'success' || needs.bdd.result == 'skipped') && needs.scope.result == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -55,12 +115,25 @@ jobs:
             runner: ubuntu-latest
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Report scope
+        run: |
+          if [ "${{ needs.scope.outputs.relevant }}" = "true" ]; then
+            echo "kernel inputs changed — building and enforcing the symbol budget"
+          else
+            echo "no kernel-relevant change; nothing to rebuild, so the budget"
+            echo "cannot have moved. Reporting success so this check stays"
+            echo "required rather than absent."
+          fi
+
       - uses: actions/checkout@v6
+        if: needs.scope.outputs.relevant == 'true'
 
       - name: Install Nix
+        if: needs.scope.outputs.relevant == 'true'
         uses: DeterminateSystems/nix-installer-action@main
 
       - name: Build builder + workload kernels
+        if: needs.scope.outputs.relevant == 'true'
         env:
           ARCH: ${{ matrix.arch }}
         # `--impure` lets the builder-vm flake read MVM_WORKSPACE_PATH via
@@ -126,10 +199,11 @@ jobs:
       - name: Upload kernel artifacts (CI visibility)
         # `always()` because the budget gate above exits non-zero on a
         # regression, and that is precisely the run whose resolved `.config`
-        # you need in order to see which symbol was added. Without this, a
-        # budget failure reports a count and discards the only evidence that
-        # explains it. Partial output is fine: the step globs what exists.
-        if: always()
+        # you need in order to see which symbol was added. Without it, a budget
+        # failure reports a count and discards the only evidence that explains
+        # it. Scoped to a run that actually built, since a skipped run has
+        # nothing to upload. Partial output is fine: the glob takes what exists.
+        if: ${{ always() && needs.scope.outputs.relevant == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: kernels-${{ matrix.arch }}

--- a/xtask/src/check_kernel_config_budget.rs
+++ b/xtask/src/check_kernel_config_budget.rs
@@ -43,8 +43,16 @@ use std::path::Path;
 /// ZONE_DEVICE, FS_DAX, FUSE_DAX) in the workload kernel. PCI, virtio-net,
 /// virtio-balloon, KVM time, and x86 ACPI core remain because supported
 /// backends exercise them.
+///
+/// Both figures then rose by exactly one when the workload kernel gained IPv6,
+/// so the guest can hold the v6 half of the pair its plan leases. The
+/// additional IPv6-only tunnel plumbing is dropped in `workload.nix`; the guest
+/// has one point-to-point link and no tunnel endpoint to encapsulate toward.
+/// The v6 IPsec families remain in the required-disable set, so XFRM is not
+/// absorbed into this budget. These values are measured from resolved configs
+/// on the native CI architectures — x86_64 measures 917, confirmed by CI.
 const BUDGET_AARCH64: usize = 944;
-const BUDGET_X86_64: usize = 916;
+const BUDGET_X86_64: usize = 917;
 
 /// Resolve the budget for a config path by the arch in its name. Unknown →
 /// the larger budget (fail-open on the ceiling, never a false pass on a real


### PR DESCRIPTION
Follow-up to #2245, which restored the x86_64 symbol budget and added the budget file to the workflow's path filter. This closes the larger hole underneath it.

## The gate could not stop anything

Two independent reasons, either sufficient on its own:

1. **`kernel-build.yml` had no `merge_group` trigger.** `ci.yml` has one, with an explicit comment — *"Required for the merge queue: all checks must run against the merge_group event."* The kernel workflow did not, so it never ran in the queue and a PR red on it merged anyway. That is not hypothetical: **#2238 merged while red on `Build kernels (x86_64)`** during the window this branch was open.
2. **The trigger was `paths:`-filtered**, so on an unrelated PR the check was simply *absent* — and a check that can be absent cannot be marked required in branch protection.

Between them the gate was advisory on every path that mattered. That is how a ceiling lowered below the real symbol count reached main and sat there for a day before an unrelated PR inherited the red build.

## What changed

The filter moves off the trigger and into a `scope` job:

- The workflow now runs on **every** pull request and **every** merge-group check request.
- `scope` does a checkout and a diff, and decides whether anything that can move the resolved config actually changed.
- The build steps run only when it did. The check is **always reported** — green with an explanatory log line when there was nothing to rebuild.

That last part is the point: an always-reported check can be marked **required**, which is the half of this fix that lives in branch-protection settings rather than in the repo. Once merged, `Build kernels (aarch64)` and `Build kernels (x86_64)` should be added to the required set.

**Why the decision had to move into a job rather than be duplicated in the trigger:** `merge_group` accepts no `paths:` filter at all. Keeping the list in one place means the same rule governs both events, instead of a trigger filter the queue cannot express.

The scope job reads its range from the event (`merge_group.base_sha`/`head_sha`, `pull_request.base.sha`/`head.sha`) and **fails closed** — an unresolvable range builds rather than assumes irrelevance. Tags and manual dispatch always build, since neither is a diff.

## Cost

Unchanged in practice. An unrelated PR pays one checkout and a diff instead of ~12 minutes per arch; only a change that actually touches kernel inputs pays the build. This is why it is not simply "add `merge_group`" — that would have charged every merge in the queue a full two-arch kernel build.

## Verification

- YAML parses under a loader that **rejects duplicate keys** — which caught a real defect: the scope guard and the pre-existing `if: always()` on the artifact upload collided into two `if:` keys on one step. Python's default loader silently takes the last; GitHub would not. They are now one condition, `always() && relevant`, so a failing build still uploads the `.config` that explains it while a skipped run uploads nothing.
- `check-workflow-paths` clean across 20 workflow files.

Contains #2245's commit until that one merges, after which this is a single commit.
