### PR TITLE
feat(hvf): complete save/restore so checkpoint and fork work on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3112,6 +3112,7 @@ dependencies = [
  "mvm-hostd",
  "mvm-net",
  "mvm-runtime",
+ "mvm-vmm",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -29,12 +29,16 @@ use mvm_vmm::hvf_handoff::HvfHandoffRequest;
 use crate::legacy::hvf::{
     self as hvf_backend, HvfBackend, PID_FILE_NAME, PID_FILE_TIMEOUT, resolve_supervisor_path,
 };
-use mvm_core::checkpoint::DeviceAnchors;
+use mvm_core::checkpoint::{DeviceAnchors, HVF_FRAME_BLOB};
 use mvm_vmm::checkpoint::VmFullControl;
 use mvm_vmm::driver::spec::{BlockDev, KernelImage, VmmSpec};
 use mvm_vmm::driver::traits::{
     ChildForkRequest, DuplexStream, RunningVm, StandbyParentSpawn, VmmDriver,
 };
+
+/// How long a capture waits for the paused supervisor to publish both halves of
+/// its snapshot. Generous: the write is proportional to guest RAM.
+const SNAPSHOT_PUBLISH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// The first-party VMM driver: pure VMM mechanics, no policy and no admission.
 /// It boots what a `VmmSpec` describes and relays the guest's egress port to the
@@ -654,6 +658,37 @@ impl HvfVmFullControl {
             self.state_dir.join("snapshot.frame"),
         )
     }
+
+    /// Refuse to capture a VM whose guest can write to a block device.
+    ///
+    /// A snapshot carries guest RAM plus the devices' control plane, never a
+    /// device's backing bytes. That is sound for a read-only, file-served disk:
+    /// the restore rebinds the same unchanged image. It is not sound for a
+    /// writable one — a RAM-backed ephemeral rootfs loses every guest write
+    /// when the VMM exits, and a write-through image keeps changing after the
+    /// capture — so a restore would resume a guest whose page cache disagrees
+    /// with its disk. Fail closed at capture rather than mint a checkpoint that
+    /// silently reverts data.
+    fn ensure_every_disk_is_restorable(&self) -> Result<()> {
+        let Some(path) = self.supervisor_config_path()? else {
+            return Ok(());
+        };
+        let cfg: HvfSupervisorConfig = serde_json::from_slice(
+            &std::fs::read(&path)
+                .with_context(|| format!("reading HVF launch config {}", path.display()))?,
+        )
+        .with_context(|| format!("parsing HVF launch config {}", path.display()))?;
+        if let Some(writable) = cfg.disks.iter().find(|disk| !disk.read_only) {
+            bail!(
+                "cannot capture a full-VM checkpoint of HVF VM '{}': its disk {} is \
+                 writable, and a snapshot does not carry device backing bytes. \
+                 Capture an fs_quick checkpoint of the paused VM instead.",
+                self.vm_name,
+                writable.path.display()
+            );
+        }
+        Ok(())
+    }
 }
 
 impl VmFullControl for HvfVmFullControl {
@@ -672,6 +707,7 @@ impl VmFullControl for HvfVmFullControl {
             "save_memory requires an absolute path, got {}",
             memory_path.display()
         );
+        self.ensure_every_disk_is_restorable()?;
         let parent = memory_path
             .parent()
             .ok_or_else(|| anyhow!("memory path has no parent directory"))?;
@@ -682,13 +718,15 @@ impl VmFullControl for HvfVmFullControl {
         let _ = std::fs::remove_file(&frame);
         std::fs::write(&request, b"capture\n")
             .with_context(|| format!("request HVF snapshot at {}", request.display()))?;
-        let deadline = Instant::now() + std::time::Duration::from_secs(30);
+        let deadline = Instant::now() + SNAPSHOT_PUBLISH_TIMEOUT;
+        let mut wait = std::time::Duration::from_micros(200);
         while (!ram.exists() || !frame.exists()) && Instant::now() < deadline {
-            std::thread::sleep(std::time::Duration::from_millis(10));
+            std::thread::sleep(wait);
+            wait = (wait * 2).min(std::time::Duration::from_millis(5));
         }
         anyhow::ensure!(
             ram.exists() && frame.exists(),
-            "HVF supervisor did not publish its paused snapshot within 30s"
+            "HVF supervisor did not publish its paused snapshot within {SNAPSHOT_PUBLISH_TIMEOUT:?}"
         );
         std::fs::copy(&ram, memory_path).with_context(|| {
             format!(
@@ -751,12 +789,12 @@ impl VmFullControl for HvfVmFullControl {
     }
 
     fn extra_content(&self, content_dir: &Path) -> Result<Vec<mvm_core::checkpoint::ContentBlob>> {
-        let frame = content_dir.join("memory.bin.hvf-frame");
+        let frame = content_dir.join(HVF_FRAME_BLOB);
         if !frame.exists() {
             return Ok(Vec::new());
         }
         Ok(vec![mvm_core::checkpoint::ContentBlob {
-            name: "memory.bin.hvf-frame".into(),
+            name: HVF_FRAME_BLOB.into(),
             sha256: mvm_core::crypto::image_verify::sha256_file(&frame)?,
         }])
     }
@@ -896,7 +934,7 @@ mod tests {
         assert_eq!(d.name(), "hvf");
         assert_eq!(d.kind(), BackendKind::Hvf);
         assert!(d.capabilities().vsock);
-        assert_eq!(d.snapshot_capability(), SnapshotCapability::Unsupported);
+        assert_eq!(d.snapshot_capability(), SnapshotCapability::SaveRestore);
         assert_eq!(
             d.security_profile().tier,
             HvfBackend.security_profile().tier

--- a/crates/mvm-backends/src/driver/hvf_restore.rs
+++ b/crates/mvm-backends/src/driver/hvf_restore.rs
@@ -1,0 +1,473 @@
+//! Booting a fresh HVF VMM out of a saved machine state.
+//!
+//! The capture side already exists: a paused supervisor serializes guest RAM
+//! plus its vCPU and deterministic device state into `snapshot.ram` /
+//! `snapshot.frame`, and `HvfVmFullControl::save_memory` copies both out. This
+//! module is the inverse — it takes a checkpoint that has already been
+//! materialized into a state directory and starts a supervisor that maps that
+//! RAM privately and restores the frame instead of loading a kernel.
+//!
+//! Two properties make the rewrite load-bearing rather than cosmetic:
+//!
+//! * **Every per-VM host path is re-derived from the child's own state dir.**
+//!   A config that kept the parent's pid file, console log or agent socket
+//!   would make two live VMMs fight over one identity.
+//! * **No authority-bearing relay survives the rewrite.** The substitution
+//!   endpoint, the host-services broker and the dev console sockets are
+//!   dropped, so a restored guest comes up with no path off the box until a
+//!   claim binds one. That is the same deny-all posture a workload boot gets
+//!   when its plan admits no egress.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+use anyhow::{Context, Result, anyhow, bail};
+use mvm_core::checkpoint::{
+    DEVICE_ANCHORS_BLOB, DeviceAnchors, HVF_FRAME_BLOB, MEMORY_BLOB, ROOTFS_BLOB,
+    ROOTFS_VERITY_BLOB, SUPERVISOR_CONFIG_BLOB,
+};
+use mvm_vmm::host::hvf_supervisor::{HvfDisk, HvfSupervisorConfig};
+
+use crate::legacy::hvf::{PID_FILE_NAME, PID_FILE_TIMEOUT, read_pid, resolve_supervisor_path};
+
+/// A materialized HVF checkpoint about to be booted under a fresh identity.
+///
+/// `state_dir` must already hold the checkpoint's cloned content — the saved
+/// memory image, the HVF frame, the launch config, the device anchors and the
+/// child's own copies of every remappable device file.
+pub struct HvfRestoreRequest<'a> {
+    /// Fresh, registry-unique name the restored guest runs under.
+    pub vm_name: &'a str,
+    /// The child's state directory, already holding the materialized content.
+    pub state_dir: &'a Path,
+}
+
+/// The live supervisor a restore produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RestoredHvfVm {
+    /// The supervisor process now owning the restored machine.
+    pub pid: u32,
+    /// Host→guest agent RPC socket the supervisor bound for this VM.
+    pub agent_socket: PathBuf,
+}
+
+/// Read the parent launch config a vm_full checkpoint carried.
+fn read_parent_config(state_dir: &Path) -> Result<HvfSupervisorConfig> {
+    let path = state_dir.join(SUPERVISOR_CONFIG_BLOB);
+    let raw = std::fs::read(&path)
+        .with_context(|| format!("reading the captured HVF launch config {}", path.display()))?;
+    serde_json::from_slice(&raw)
+        .with_context(|| format!("parsing the captured HVF launch config {}", path.display()))
+}
+
+/// Read the absolute device paths the saved state embeds.
+fn read_anchors(state_dir: &Path) -> Result<DeviceAnchors> {
+    let path = state_dir.join(DEVICE_ANCHORS_BLOB);
+    let raw = std::fs::read(&path)
+        .with_context(|| format!("reading HVF restore device anchors {}", path.display()))?;
+    serde_json::from_slice(&raw)
+        .with_context(|| format!("parsing HVF restore device anchors {}", path.display()))
+}
+
+/// Point one captured disk at the child's own copy.
+///
+/// A restored guest resumes with its page cache and in-flight virtio descriptors
+/// intact, so the bytes behind each device must be the ones the capture froze.
+/// The two device files a checkpoint clones (rootfs and its verity sidecar) are
+/// remapped to the child's copies; anything else is an immutable shared artifact
+/// (the runtime overlay, its verity tree) that both parent and child read from
+/// the same path. A disk the child can write is refused outright: the capture
+/// never froze its backing bytes, so restoring against it would resume a guest
+/// whose page cache disagrees with its disk.
+fn remap_disk(disk: &HvfDisk, anchors: &DeviceAnchors, state_dir: &Path) -> Result<HvfDisk> {
+    if !disk.read_only {
+        bail!(
+            "cannot restore an HVF checkpoint whose disk {} was writable: its \
+             backing bytes are not part of the saved machine state",
+            disk.path.display()
+        );
+    }
+    let remapped = if disk.path == anchors.rootfs {
+        state_dir.join(ROOTFS_BLOB)
+    } else if anchors.rootfs_verity.as_deref() == Some(disk.path.as_path()) {
+        state_dir.join(ROOTFS_VERITY_BLOB)
+    } else {
+        disk.path.clone()
+    };
+    if !remapped.is_file() {
+        bail!(
+            "HVF restore needs disk image {}, which is not on disk",
+            remapped.display()
+        );
+    }
+    Ok(HvfDisk {
+        path: remapped,
+        read_only: true,
+        ephemeral: false,
+    })
+}
+
+/// Rewrite a captured parent's launch config into one that boots `req.vm_name`
+/// from its own materialized copies. See the module docs for the two invariants
+/// this rewrite carries.
+///
+/// Public because the rewrite *is* the security boundary of an HVF restore: the
+/// path re-homing and the relay drop are what keep a restored guest from
+/// sharing its parent's identity or inheriting its egress. Conformance asserts
+/// on this value directly rather than on a booted VM.
+pub fn hvf_child_restore_config(
+    parent: &HvfSupervisorConfig,
+    anchors: &DeviceAnchors,
+    req: &HvfRestoreRequest<'_>,
+) -> Result<HvfSupervisorConfig> {
+    if !parent.kernel.is_file() {
+        bail!(
+            "HVF restore needs the captured kernel {}, which is not on disk",
+            parent.kernel.display()
+        );
+    }
+    let restore_ram = req.state_dir.join(MEMORY_BLOB);
+    let restore_frame = req.state_dir.join(HVF_FRAME_BLOB);
+    for required in [&restore_ram, &restore_frame] {
+        if !required.is_file() {
+            bail!(
+                "HVF restore needs saved machine state at {}, which is not on disk",
+                required.display()
+            );
+        }
+    }
+    let disks = parent
+        .disks
+        .iter()
+        .map(|disk| remap_disk(disk, anchors, req.state_dir))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(HvfSupervisorConfig {
+        kernel: parent.kernel.clone(),
+        cmdline: parent.cmdline.clone(),
+        memory_mib: parent.memory_mib,
+        initramfs: parent.initramfs.clone(),
+        disks,
+        virtiofs_root: parent.virtiofs_root.clone(),
+        virtiofs_shares: parent.virtiofs_shares.clone(),
+        vsock: parent.vsock,
+        console_log: req.state_dir.join("console.log"),
+        pid_file: req.state_dir.join(PID_FILE_NAME),
+        workload_exit: req.state_dir.join("workload.exit"),
+        pause_state: Some(req.state_dir.join("pause.state")),
+        snapshot_request: Some(req.state_dir.join("snapshot.request")),
+        snapshot_ram: Some(req.state_dir.join("snapshot.ram")),
+        snapshot_frame: Some(req.state_dir.join("snapshot.frame")),
+        restore_ram: Some(restore_ram),
+        restore_frame: Some(restore_frame),
+        timeout_secs: parent.timeout_secs,
+        agent_socket: Some(mvm_core::config::vm_hvf_agent_socket_at(req.state_dir)),
+        // Authority-bearing relays never survive a restore: the child reaches
+        // the network, the broker and an interactive console only through
+        // channels a claim binds for its own admitted plan.
+        substitution_socket: None,
+        egress_relay_socket: None,
+        broker_socket: None,
+        console_data_sockets: Vec::new(),
+        // The live-handoff control socket is a privileged path onto a resident
+        // parent. A restored child is not a standby factory and must never
+        // serve it.
+        handoff_socket: None,
+        handoff_root: None,
+        handoff_verify_key: None,
+    })
+}
+
+/// Start a supervisor that loads `req`'s materialized saved state instead of
+/// booting a kernel, and wait for it to confirm the VM is live.
+pub fn restore_hvf_vm(req: &HvfRestoreRequest<'_>) -> Result<RestoredHvfVm> {
+    if !req.state_dir.is_dir() {
+        bail!(
+            "HVF restore of '{}': state dir {} is missing",
+            req.vm_name,
+            req.state_dir.display()
+        );
+    }
+    let parent = read_parent_config(req.state_dir)?;
+    let anchors = read_anchors(req.state_dir)?;
+    let cfg = hvf_child_restore_config(&parent, &anchors, req)?;
+
+    // Persist the child's own launch config before spawning: a later capture of
+    // this VM reads it back through `supervisor_config_path`, so a restored
+    // child is itself checkpointable.
+    let config_path = req.state_dir.join("supervisor.json");
+    std::fs::write(
+        &config_path,
+        serde_json::to_vec(&cfg).context("serializing the restored HVF launch config")?,
+    )
+    .with_context(|| format!("writing {}", config_path.display()))?;
+    let _ = std::fs::remove_file(&cfg.workload_exit);
+    let _ = std::fs::remove_file(req.state_dir.join("pause.state"));
+
+    let supervisor = resolve_supervisor_path()?;
+    let json = serde_json::to_string(&cfg).context("serializing HvfSupervisorConfig")?;
+    let mut child = Command::new(&supervisor)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .with_context(|| format!("spawning {}", supervisor.display()))?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("supervisor stdin was not piped"))?
+        .write_all(json.as_bytes())
+        .context("piping HvfSupervisorConfig to the supervisor")?;
+
+    let deadline = Instant::now() + PID_FILE_TIMEOUT;
+    loop {
+        if let Some(pid) = read_pid(&cfg.pid_file) {
+            let pid = u32::try_from(pid).map_err(|_| {
+                anyhow!("restored HVF VM '{}' published a negative pid", req.vm_name)
+            })?;
+            return Ok(RestoredHvfVm {
+                pid,
+                agent_socket: cfg
+                    .agent_socket
+                    .clone()
+                    .expect("the restored config always binds an agent socket"),
+            });
+        }
+        if let Some(status) = child.try_wait().context("polling the HVF supervisor")? {
+            bail!(
+                "HVF restore of '{}' exited before publishing its pid (status: {status}); see {}",
+                req.vm_name,
+                cfg.console_log.display()
+            );
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            bail!(
+                "HVF restore of '{}' did not confirm within {PID_FILE_TIMEOUT:?}; see {}",
+                req.vm_name,
+                cfg.console_log.display()
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parent_config(state: &Path, disks: Vec<HvfDisk>) -> HvfSupervisorConfig {
+        HvfSupervisorConfig {
+            kernel: state.join("Image"),
+            cmdline: Some("console=ttyAMA0 root=/dev/vda ro".into()),
+            memory_mib: 512,
+            initramfs: None,
+            disks,
+            virtiofs_root: None,
+            virtiofs_shares: Vec::new(),
+            vsock: true,
+            console_log: PathBuf::from("/parent/console.log"),
+            pid_file: PathBuf::from("/parent/hvf.pid"),
+            workload_exit: PathBuf::from("/parent/workload.exit"),
+            pause_state: Some(PathBuf::from("/parent/pause.state")),
+            snapshot_request: Some(PathBuf::from("/parent/snapshot.request")),
+            snapshot_ram: Some(PathBuf::from("/parent/snapshot.ram")),
+            snapshot_frame: Some(PathBuf::from("/parent/snapshot.frame")),
+            restore_ram: None,
+            restore_frame: None,
+            timeout_secs: 0,
+            agent_socket: Some(PathBuf::from("/parent/hvf-agent.sock")),
+            substitution_socket: Some(PathBuf::from("/parent/substitution.sock")),
+            egress_relay_socket: Some(PathBuf::from("/parent/egress.sock")),
+            broker_socket: Some(PathBuf::from("/parent/broker.sock")),
+            console_data_sockets: vec![mvm_vmm::host::hvf_supervisor::ConsoleDataSocket {
+                guest_port: 20001,
+                host_socket: PathBuf::from("/parent/vsock/vsock-20001.sock"),
+            }],
+            handoff_socket: Some(PathBuf::from("/parent/hvf-handoff.sock")),
+            handoff_root: Some(PathBuf::from("/parent/vms")),
+            handoff_verify_key: Some("aa".repeat(32)),
+        }
+    }
+
+    /// Lay down everything a restore needs: kernel, saved state, and the child's
+    /// own rootfs copy.
+    fn materialized(dir: &Path) -> DeviceAnchors {
+        std::fs::write(dir.join("Image"), b"kernel").unwrap();
+        std::fs::write(dir.join(MEMORY_BLOB), b"ram").unwrap();
+        std::fs::write(dir.join(HVF_FRAME_BLOB), b"frame").unwrap();
+        std::fs::write(dir.join(ROOTFS_BLOB), b"child-rootfs").unwrap();
+        DeviceAnchors {
+            rootfs: PathBuf::from("/parent/rootfs.ext4"),
+            rootfs_verity: None,
+            config: None,
+            secrets: None,
+            vsock: PathBuf::from("/parent/hvf-agent.sock"),
+        }
+    }
+
+    fn request<'a>(vm_name: &'a str, dir: &'a Path) -> HvfRestoreRequest<'a> {
+        HvfRestoreRequest {
+            vm_name,
+            state_dir: dir,
+        }
+    }
+
+    #[test]
+    fn child_config_rehomes_every_per_vm_path_onto_the_child_state_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let anchors = materialized(dir);
+        let parent = parent_config(
+            dir,
+            vec![HvfDisk {
+                path: PathBuf::from("/parent/rootfs.ext4"),
+                read_only: true,
+                ephemeral: false,
+            }],
+        );
+
+        let cfg = hvf_child_restore_config(&parent, &anchors, &request("child", dir)).unwrap();
+
+        assert_eq!(cfg.pid_file, dir.join(PID_FILE_NAME));
+        assert_eq!(cfg.console_log, dir.join("console.log"));
+        assert_eq!(cfg.workload_exit, dir.join("workload.exit"));
+        assert_eq!(cfg.pause_state, Some(dir.join("pause.state")));
+        assert_eq!(cfg.snapshot_ram, Some(dir.join("snapshot.ram")));
+        assert_eq!(
+            cfg.agent_socket,
+            Some(mvm_core::config::vm_hvf_agent_socket_at(dir))
+        );
+        // The parent's rootfs anchor resolves to the child's own clone.
+        assert_eq!(cfg.disks[0].path, dir.join(ROOTFS_BLOB));
+    }
+
+    #[test]
+    fn child_config_loads_saved_state_instead_of_booting_a_kernel() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let anchors = materialized(dir);
+        let parent = parent_config(dir, Vec::new());
+
+        let cfg = hvf_child_restore_config(&parent, &anchors, &request("child", dir)).unwrap();
+
+        assert_eq!(cfg.restore_ram, Some(dir.join(MEMORY_BLOB)));
+        assert_eq!(cfg.restore_frame, Some(dir.join(HVF_FRAME_BLOB)));
+        // The saved shape is authoritative: memory size and cmdline are inherited
+        // verbatim, because the restored guest is already running against them.
+        assert_eq!(cfg.memory_mib, 512);
+        assert_eq!(cfg.cmdline, parent.cmdline);
+    }
+
+    #[test]
+    fn child_config_drops_every_authority_bearing_relay() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let anchors = materialized(dir);
+        let parent = parent_config(dir, Vec::new());
+        assert!(parent.egress_relay_socket.is_some(), "parent has egress");
+
+        let cfg = hvf_child_restore_config(&parent, &anchors, &request("child", dir)).unwrap();
+
+        assert_eq!(cfg.egress_relay_socket, None);
+        assert_eq!(cfg.substitution_socket, None);
+        assert_eq!(cfg.broker_socket, None);
+        assert!(cfg.console_data_sockets.is_empty());
+        assert_eq!(cfg.handoff_socket, None);
+        assert_eq!(cfg.handoff_root, None);
+        assert_eq!(cfg.handoff_verify_key, None);
+    }
+
+    #[test]
+    fn child_config_remaps_a_verity_sidecar_to_the_child_copy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let mut anchors = materialized(dir);
+        anchors.rootfs_verity = Some(PathBuf::from("/parent/rootfs.verity"));
+        std::fs::write(dir.join(ROOTFS_VERITY_BLOB), b"verity").unwrap();
+        let parent = parent_config(
+            dir,
+            vec![
+                HvfDisk {
+                    path: PathBuf::from("/parent/rootfs.ext4"),
+                    read_only: true,
+                    ephemeral: false,
+                },
+                HvfDisk {
+                    path: PathBuf::from("/parent/rootfs.verity"),
+                    read_only: true,
+                    ephemeral: false,
+                },
+            ],
+        );
+
+        let cfg = hvf_child_restore_config(&parent, &anchors, &request("child", dir)).unwrap();
+
+        assert_eq!(cfg.disks[0].path, dir.join(ROOTFS_BLOB));
+        assert_eq!(cfg.disks[1].path, dir.join(ROOTFS_VERITY_BLOB));
+    }
+
+    #[test]
+    fn child_config_refuses_a_writable_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let anchors = materialized(dir);
+        let parent = parent_config(
+            dir,
+            vec![HvfDisk {
+                path: PathBuf::from("/parent/rootfs.ext4"),
+                read_only: false,
+                ephemeral: true,
+            }],
+        );
+
+        let error =
+            hvf_child_restore_config(&parent, &anchors, &request("child", dir)).unwrap_err();
+        assert!(
+            error.to_string().contains("writable"),
+            "expected the writable-disk refusal, got: {error}"
+        );
+    }
+
+    #[test]
+    fn child_config_refuses_missing_saved_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let anchors = materialized(dir);
+        std::fs::remove_file(dir.join(HVF_FRAME_BLOB)).unwrap();
+        let parent = parent_config(dir, Vec::new());
+
+        let error =
+            hvf_child_restore_config(&parent, &anchors, &request("child", dir)).unwrap_err();
+        assert!(
+            error.to_string().contains(HVF_FRAME_BLOB),
+            "the refusal must name the missing frame, got: {error}"
+        );
+    }
+
+    #[test]
+    fn child_config_refuses_a_missing_kernel() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let anchors = materialized(dir);
+        std::fs::remove_file(dir.join("Image")).unwrap();
+        let parent = parent_config(dir, Vec::new());
+
+        let error =
+            hvf_child_restore_config(&parent, &anchors, &request("child", dir)).unwrap_err();
+        assert!(
+            error.to_string().contains("kernel"),
+            "the refusal must name the kernel, got: {error}"
+        );
+    }
+
+    #[test]
+    fn restore_refuses_a_state_dir_that_was_never_materialized() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("never-created");
+        let error = restore_hvf_vm(&request("child", &missing)).unwrap_err();
+        assert!(error.to_string().contains("state dir"), "got: {error}");
+    }
+}

--- a/crates/mvm-backends/src/driver/mod.rs
+++ b/crates/mvm-backends/src/driver/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod fc;
 pub mod hvf;
+pub mod hvf_restore;
 pub mod libkrun;
 pub mod qemu;
 

--- a/crates/mvm-backends/src/legacy/hvf.rs
+++ b/crates/mvm-backends/src/legacy/hvf.rs
@@ -393,7 +393,11 @@ impl VmBackend for HvfBackend {
         // pause/snapshot/networking are wired onto the primitive.
         VmCapabilities {
             pause_resume: true,
-            snapshot_capability: SnapshotCapability::Unsupported,
+            // The supervisor serializes guest RAM plus vCPU and deterministic
+            // device state under an acknowledged pause, and reloads both into a
+            // fresh VMM. That is coarse save/restore of machine state, not the
+            // incremental live-memory tier: a capture copies the whole mapping.
+            snapshot_capability: SnapshotCapability::SaveRestore,
             // The native resident handoff is the warm-launch implementation;
             // admission still requires the backend's ordinary availability and
             // security gates before a parent can be created or claimed.

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -18,18 +18,22 @@ use mvm_core::checkpoint::{CheckpointClass, CheckpointDigest, CheckpointId, Chec
 use mvm_core::config::vm_state_dir;
 use mvm_core::vm_backend::SnapshotCapability;
 use mvm_hostd::audit::bind::class_str;
+use mvm_runtime::backend::AnyBackend;
 use mvm_runtime::checkpoint::{
     CaptureFsQuickParams, CaptureVmFullParams, CheckpointStore, ForkParams, capture_fs_quick,
-    capture_vm_full, checkpoint_carries_supervisor_config, fork_checkpoint, fork_vm_full_fc,
+    capture_vm_full, fork_checkpoint,
 };
 
 use super::Cli;
 use super::shared::clap_vm_name;
 use crate::ui;
 
+mod fork_vm_full;
 mod lineage;
 mod revert;
 mod timeline;
+use fork_vm_full::fork_vm_full_arm;
+pub(in crate::commands) use fork_vm_full::{ForkVmFullArmFcParams, fork_vm_full_arm_fc};
 pub(in crate::commands) use lineage::SignedChainAnchor;
 pub(in crate::commands) use revert::{
     AdvanceArgs, RevertArgs, RevertImageSource, RevertOutcome, RevertRunImage, run_advance,
@@ -319,15 +323,14 @@ fn rootfs_from_mode_json(state_dir: &std::path::Path) -> Result<Option<PathBuf>>
 }
 
 /// Best-effort liveness: a VM is "running" iff one of its per-backend PID
-/// files names a live process.
-///
-/// Every backend writes its marker into the same per-VM directory
-/// (`<mvm_home>/vms/<name>/`) under a backend-disjoint name, so one pass over
-/// the shared marker list covers all of them. Delegating also picks up the
-/// `EPERM`-means-alive rule, which matters for a root-owned Firecracker: a
-/// bare `kill(pid, 0) == 0` reads that as stopped.
+/// files names a live process. Delegates to the runtime's probe so this side
+/// cannot keep its own marker list — every registered backend's marker
+/// (`fc.pid`, `libkrun.pid`, `hvf.pid`, `qemu.pid`) is covered by one pass over
+/// the shared list, which is also where the `EPERM`-means-alive rule lives. A
+/// hand-kept list here is how a live HVF VM used to read as stopped, and a
+/// root-owned Firecracker with it.
 fn vm_is_running(name: &str) -> bool {
-    mvm_vmm::host::process_liveness::state_dir_has_live_process(&vm_state_dir(name))
+    mvm_runtime::checkpoint::vm_is_running(name)
 }
 
 /// fs_quick clones the instance rootfs, so the guest must not be writing:
@@ -340,7 +343,17 @@ fn vm_is_quiesced(name: &str) -> bool {
     if !vm_is_running(name) {
         return true;
     }
-    fc_pause_marker_matches_live_pid(name)
+    fc_pause_marker_matches_live_pid(name) || hvf_pause_marker_present(name)
+}
+
+/// The HVF supervisor writes `pause.state` only after its vCPU has entered the
+/// pause hold, and removes it on resume. Unlike Firecracker's marker this one is
+/// written by the process that owns the vCPU, so its presence beside a live
+/// `hvf.pid` is itself the acknowledgement — there is no pid to cross-check
+/// against a marker some other verb stamped.
+fn hvf_pause_marker_present(name: &str) -> bool {
+    let dir = vm_state_dir(name);
+    dir.join("hvf.pid").is_file() && dir.join("pause.state").is_file()
 }
 
 /// `machine pause` snapshot-seals FC but leaves the fc process running, so a
@@ -379,8 +392,17 @@ fn runtime_contract_for_checkpoint(
         .unwrap_or((None, None)))
 }
 
-fn ensure_save_restore_supported(action: &str) -> Result<()> {
-    let backend = mvm_runtime::backend::AnyBackend::auto_select();
+/// The backend that actually owns `name`, falling back to the host default for
+/// a VM with no live marker (a restore target that has not been started yet).
+fn backend_for_vm(name: &str) -> AnyBackend {
+    AnyBackend::for_started_vm(name).unwrap_or_else(AnyBackend::auto_select)
+}
+
+/// Refuse a memory-snapshot verb on a backend that cannot save and reload
+/// machine state. The check is against the backend that owns *this* VM, not the
+/// host default: on a host where several VMMs can run, the capability of the
+/// one holding the VM is the only one that matters.
+fn ensure_save_restore_supported(action: &str, backend: &AnyBackend) -> Result<()> {
     let available = backend.snapshot_capability();
     if !available.satisfies(SnapshotCapability::SaveRestore) {
         bail!(
@@ -438,37 +460,57 @@ fn create(name: &str, tag: Option<String>, json: bool) -> Result<()> {
     Ok(())
 }
 
-/// Capture the vm_full triple for the running VM. Firecracker (the sole
-/// full-VM capture backend) drives the pause/save/resume window. The caller
-/// has already verified the VM is running.
-fn capture_vm_full_for_running_vm(
-    name: &str,
-    state_dir: &std::path::Path,
-    store: &CheckpointStore,
+/// Inputs for [`capture_vm_full_for_running_vm`]. Grouped so the call site
+/// reads as one value rather than a positional list.
+struct CaptureVmFullArgs<'a> {
+    name: &'a str,
+    state_dir: &'a std::path::Path,
+    store: &'a CheckpointStore,
+    backend: &'a AnyBackend,
     id: CheckpointId,
     tag: Option<String>,
     created_unix: u64,
+}
+
+/// Capture the vm_full triple for the running VM through the pause/save/resume
+/// control of the backend that owns it. The caller has already verified the VM
+/// is running and that the backend advertises save/restore.
+fn capture_vm_full_for_running_vm(
+    args: CaptureVmFullArgs<'_>,
 ) -> Result<mvm_core::checkpoint::CheckpointMeta> {
-    let (runtime_source_policy, runtime_overlay_version) = runtime_contract_for_checkpoint(name)?;
+    let (runtime_source_policy, runtime_overlay_version) =
+        runtime_contract_for_checkpoint(args.name)?;
+    let control = args.backend.vm_full_control(args.name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "backend '{}' has no full-VM capture control for '{}'",
+            args.backend.name(),
+            args.name
+        )
+    })?;
     let params = CaptureVmFullParams {
-        id,
-        vm_name: name.to_string(),
-        supervisor_config_digest: supervisor_config_digest(state_dir),
+        id: args.id,
+        vm_name: args.name.to_string(),
+        supervisor_config_digest: supervisor_config_digest(args.state_dir),
         runtime_source_policy,
         runtime_overlay_version,
-        supervisor_config_src: None,
-        tag,
-        created_unix,
+        // Backends that drive their VMM through a supervisor config (HVF) carry
+        // it into the checkpoint: a restore has to rebuild the launch shape the
+        // capture froze, and every stop reaps the live copy. Firecracker returns
+        // None and the blob is simply absent.
+        supervisor_config_src: control.supervisor_config_path()?,
+        tag: args.tag,
+        created_unix: args.created_unix,
+        retain_paused: false,
     };
-    let control = mvm_runtime::firecracker::FcVmFullControl::new(name);
-    capture_vm_full(store, params, &control)
+    capture_vm_full(args.store, params, control.as_ref())
 }
 
 /// `mvmctl checkpoint create --class vm-full <vm>`: capture a RUNNING VM's
 /// memory + rootfs in one pause window. The inverse of fs_quick — a vm_full
 /// checkpoint carries memory, so the VM must be live.
 fn create_vm_full(name: &str, tag: Option<String>, json: bool) -> Result<()> {
-    ensure_save_restore_supported("save")?;
+    let backend = backend_for_vm(name);
+    ensure_save_restore_supported("save", &backend)?;
     if !vm_is_running(name) {
         bail!("checkpoint --class vm-full requires a running VM; start '{name}' first");
     }
@@ -477,8 +519,16 @@ fn create_vm_full(name: &str, tag: Option<String>, json: bool) -> Result<()> {
     let now = now_unix();
     let id = CheckpointId::new(format!("ckpt-{name}-{now}"));
 
-    let meta = capture_vm_full_for_running_vm(name, &state_dir, &store, id, tag, now)
-        .with_context(|| format!("capturing vm_full checkpoint of {name:?}"))?;
+    let meta = capture_vm_full_for_running_vm(CaptureVmFullArgs {
+        name,
+        state_dir: &state_dir,
+        store: &store,
+        backend: &backend,
+        id,
+        tag,
+        created_unix: now,
+    })
+    .with_context(|| format!("capturing vm_full checkpoint of {name:?}"))?;
 
     // Best-effort audit binding, same policy as fs_quick capture.
     bind_checkpoint_created(name, &meta);
@@ -644,17 +694,71 @@ fn rm(id: &str, json: bool) -> Result<()> {
     Ok(())
 }
 
+/// JSON shape of a completed same-identity restore.
+#[derive(Serialize)]
+struct CheckpointRestoreJson<'a> {
+    schema_version: u8,
+    action: &'static str,
+    id: &'a CheckpointId,
+    vm_name: &'a str,
+}
+
 /// `mvmctl vm checkpoint restore <id>`: same-identity resume of a vm_full
-/// checkpoint. The restore mechanism is being re-homed onto the in-house HVF
-/// VMM and is unavailable on the current macOS/Linux backends; a clear,
-/// tracked error is returned rather than a partial resume.
-fn restore(id: &str, _json: bool) -> Result<()> {
-    // Validate the id so an obviously bad argument still errors clearly.
-    let _ = validated_checkpoint_id(id)?;
-    bail!(
-        "vm restore requires full-VM save/restore, which is being re-homed onto \
-         the in-house HVF VMM and is unavailable on this backend for now"
-    );
+/// checkpoint.
+///
+/// The checkpoint is verified against the signed audit chain before a single
+/// byte is cloned, so a restore can never bring back a record that was edited
+/// after it was audited. The VM comes back under its own name from its own
+/// clone of the sealed content — the immutable checkpoint bytes are never
+/// booted against, because a resumed guest writes through to its rootfs.
+fn restore(id: &str, json: bool) -> Result<()> {
+    let id = validated_checkpoint_id(id)?;
+    let store = CheckpointStore::open();
+    let meta = store
+        .read_meta(&id)
+        .with_context(|| format!("reading checkpoint {}", id.as_str()))?;
+    if meta.class != CheckpointClass::VmFull {
+        bail!(
+            "checkpoint '{}' is class fs_quick; restore applies to vm_full checkpoints \
+             (fork an fs_quick checkpoint instead)",
+            id.as_str()
+        );
+    }
+    if vm_is_running(&meta.vm_name) {
+        bail!(
+            "cannot restore into '{}': it is still running; stop it first",
+            meta.vm_name
+        );
+    }
+    let restorer = mvm_runtime::checkpoint::vm_full_restorer_for(&meta)?;
+    let anchor = SignedChainAnchor::load()
+        .context("loading the signed audit chain to verify the restore source")?;
+    mvm_runtime::checkpoint::restore_checkpoint(
+        &store,
+        mvm_runtime::checkpoint::RestoreParams {
+            checkpoint: id.clone(),
+            target_vm: meta.vm_name.clone(),
+        },
+        restorer.as_ref(),
+        &anchor,
+    )
+    .with_context(|| format!("restoring checkpoint {}", id.as_str()))?;
+
+    if json {
+        crate::json_out::emit_json(&CheckpointRestoreJson {
+            schema_version: 1,
+            action: "restore",
+            id: &id,
+            vm_name: &meta.vm_name,
+        })?;
+    } else {
+        ui::success(&format!(
+            "restored {} into vm '{}'",
+            id.as_str(),
+            meta.vm_name
+        ));
+    }
+    Ok(())
 }
 
 fn fork(
@@ -778,359 +882,6 @@ fn fork_fs_quick_arm(p: ForkFsQuickArmParams<'_>) -> Result<()> {
             ));
         }
     }
-    Ok(())
-}
-
-/// Inputs for [`fork_vm_full_arm`]. Grouped to stay under the
-/// `clippy::too_many_arguments` workspace ceiling.
-struct ForkVmFullArmParams<'a> {
-    store: &'a CheckpointStore,
-    checkpoint: &'a CheckpointId,
-    new_id: Option<String>,
-    /// Refused with a user-visible error: a vm_full fork restores the saved
-    /// machine state (cpu/mem baked into the snapshot), so the shape is fixed.
-    /// Use an fs_quick fork to boot a resized child.
-    cpus_override: Option<u32>,
-    /// Refused with a user-visible error for the same reason as `cpus_override`.
-    memory_override: Option<&'a str>,
-    json: bool,
-}
-
-/// vm_full fork: clone the captured triple into a new child identity, admit a
-/// fresh claim-8 plan for the child (using the parent's saved cpu/mem — the
-/// restore shape is fixed), rewrite the supervisor config, and boot the child
-/// in restore mode. The child's admitted plan is distinct from the parent's.
-/// Whether the experimental Firecracker vm_full fork restore is opted into.
-///
-/// Off by default: a forked child restores the parent's saved guest memory,
-/// which carries the parent's IP/MAC, and there is no per-child guest
-/// re-addressing yet — so a booted child collides with its parent on the
-/// shared bridge. The opt-in exercises the (proven-sound) restore mechanism
-/// on an isolated single-child network while that per-child network model is
-/// still being settled.
-fn fc_vm_full_fork_experimental_enabled() -> bool {
-    std::env::var_os("MVM_FORK_VMFULL_FC_EXPERIMENTAL").is_some()
-}
-
-fn fork_vm_full_arm(
-    store: &CheckpointStore,
-    checkpoint: &CheckpointId,
-    new_id: Option<String>,
-    cpus_override: Option<u32>,
-    memory_override: Option<&str>,
-    json: bool,
-) -> Result<()> {
-    fork_vm_full_arm_inner(ForkVmFullArmParams {
-        store,
-        checkpoint,
-        new_id,
-        cpus_override,
-        memory_override,
-        json,
-    })
-}
-
-fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
-    // A vm_full fork restores a saved machine state whose cpu/mem are baked
-    // into the snapshot; a supervisor-config-bearing backend validated device config
-    // against the saved state and refused a mismatch. Accepting these flags
-    // would silently fail at restore time with a confusing hypervisor error
-    // — refuse early.
-    if p.cpus_override.is_some() {
-        anyhow::bail!(
-            "--cpus is not valid for a vm_full fork: a memory restore resumes the saved \
-             machine shape; use an fs_quick fork to resize"
-        );
-    }
-    if p.memory_override.is_some() {
-        anyhow::bail!(
-            "--memory is not valid for a vm_full fork: a memory restore resumes the saved \
-             machine shape; use an fs_quick fork to resize"
-        );
-    }
-
-    let now = now_unix();
-    let child_vm_name = p
-        .new_id
-        .unwrap_or_else(|| format!("{}-fork-{now}", p.checkpoint.as_str()));
-    let dest_dir = vm_state_dir(&child_vm_name);
-    let child_id = CheckpointId::new(format!("fork-{child_vm_name}-{now}"));
-
-    let parent_meta = p.store.read_meta(p.checkpoint)?;
-
-    fork_vm_full_arm_fc(ForkVmFullArmFcParams {
-        store: p.store,
-        checkpoint: p.checkpoint,
-        parent_meta,
-        child_vm_name,
-        dest_dir,
-        child_id,
-        now,
-        json: p.json,
-        bypass_experimental_guard: false,
-    })?;
-    Ok(())
-}
-
-/// Inputs for [`fork_vm_full_arm_fc`]. Grouped to stay under the
-/// `clippy::too_many_arguments` workspace ceiling.
-pub(in crate::commands) struct ForkVmFullArmFcParams<'a> {
-    pub(in crate::commands) store: &'a CheckpointStore,
-    pub(in crate::commands) checkpoint: &'a CheckpointId,
-    pub(in crate::commands) parent_meta: mvm_core::checkpoint::CheckpointMeta,
-    pub(in crate::commands) child_vm_name: String,
-    pub(in crate::commands) dest_dir: std::path::PathBuf,
-    pub(in crate::commands) child_id: CheckpointId,
-    pub(in crate::commands) now: u64,
-    pub(in crate::commands) json: bool,
-    /// When true, skip the `MVM_FORK_VMFULL_FC_EXPERIMENTAL` guard. The guard
-    /// stays on the lower-level `vm checkpoint fork` path; the user-facing
-    /// `machine warm-restore` verb opts in explicitly.
-    pub(in crate::commands) bypass_experimental_guard: bool,
-}
-
-/// FC vm_full fork: clone the captured triple, admit a fresh claim-8 plan for
-/// the child, rename `memory.bin` → `mem.bin`, and boot the child via a fresh
-/// Firecracker VMM loaded from the checkpoint snapshot.
-pub(in crate::commands) fn fork_vm_full_arm_fc(
-    p: ForkVmFullArmFcParams<'_>,
-) -> Result<mvm_core::checkpoint::CheckpointMeta> {
-    // FC vm_full fork loads a snapshot that still carries the parent's TAP
-    // name and guest MAC in bitcode. Remapping backing files is not enough to
-    // make a live-parent fork safe, so require the parent to be stopped first.
-    // The device-path remapping happens in a private mount namespace before
-    // the child Firecracker starts.
-    if vm_is_running(&p.parent_meta.vm_name) {
-        anyhow::bail!(
-            "Firecracker vm_full fork requires the parent VM '{}' to be stopped first;              live-parent fork would collide on the parent's TAP/MAC",
-            p.parent_meta.vm_name
-        );
-    }
-
-    // A supervisor-config.json blob means the capture rebuilds its VMM from a
-    // persisted supervisor config rather than from Firecracker's snapshot
-    // triple. Only the Firecracker fork path is implemented below, so refuse
-    // cleanly rather than misread the manifest.
-    if checkpoint_carries_supervisor_config(&p.parent_meta) {
-        anyhow::bail!(
-            "this vm_full checkpoint carries a supervisor config, so it was not \
-             captured under Firecracker; full-VM fork is only implemented for \
-             Firecracker captures. Use an fs_quick fork instead."
-        );
-    }
-
-    // Firecracker vm_full fork. A forked child restores the parent's saved guest
-    // memory verbatim, which carries the parent's IP/MAC. VMGenID reseeds the
-    // guest RNG on restore but does not re-address the network, so a booted child
-    // would collide with its parent on the shared dev-subnet bridge. The host-tap
-    // side is remappable, but re-IP'ing the guest is a per-child network-model
-    // decision that is not yet settled — refuse cleanly rather than boot a
-    // colliding child. The restore mechanism stays reachable behind an explicit
-    // opt-in for isolated single-child testing on that model, unless the caller
-    // has already opted in (the user-facing `machine warm-restore` path).
-    if !p.bypass_experimental_guard && !fc_vm_full_fork_experimental_enabled() {
-        anyhow::bail!(
-            "forking a vm_full checkpoint on Firecracker is not yet supported: the \
-             forked child inherits the parent's guest IP/MAC from the saved memory \
-             image and has no per-child network reconfiguration, so it would collide \
-             with the parent on the shared bridge. Use an fs_quick fork, or set \
-             MVM_FORK_VMFULL_FC_EXPERIMENTAL=1 to exercise the restore on an isolated \
-             single-child network."
-        );
-    }
-
-    // Use safe defaults for FC cpu/mem plan admission. The actual cpu/mem are
-    // baked into the snapshot and enforced by FC at load time; the plan values
-    // are used for claim-8 admission metadata only.
-    let user_cfg = mvm_core::user_config::load(None);
-    let cpus = user_cfg.default_cpus;
-    let mem_mib = user_cfg.default_memory_mib as u64;
-
-    // Admit a fresh plan for the child using the checkpoint's RECORDED rootfs sha.
-    let rootfs_blob = p.store.content_dir(p.checkpoint).join("rootfs.ext4");
-    let recorded_sha = p
-        .parent_meta
-        .content
-        .iter()
-        .find(|b| b.name == "rootfs.ext4")
-        .map(|b| b.sha256.clone());
-    let parent_agent_verbs = parent_agent_verb_override(p.checkpoint, p.store);
-    let tenant = super::tenant_resolution::resolve_tenant(None);
-    let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::new();
-    let admission = super::up::admit_plan_for_boot(super::up::AdmitPlanForBootParams {
-        tenant: &tenant,
-        vm_name: &p.child_vm_name,
-        backend_name: "firecracker",
-        rootfs_path: &rootfs_blob,
-        precomputed_image_sha256: recorded_sha,
-        boot_artifact_identity: None,
-        cpus,
-        mem_mib,
-        seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
-        secret_release: mvm_core::plan::SecretReleasePolicy::default(),
-        secrets: Vec::new(),
-        no_supervisor: false,
-        ledger: &ledger,
-        keys_dir: None,
-        audit_dir: None,
-        policy_dir: None,
-        bundle_pin: None,
-        deps_volume: None,
-        shares: Vec::new(),
-        redaction: mvm_core::policy::RedactionPolicy::default(),
-        network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
-        agent_verb_override: parent_agent_verbs.clone(),
-        // A restored child is never interactive, never carries ad-hoc argv, and
-        // is always prod-profile, so it qualifies for the attenuated grant.
-        restrict_agent_verbs: !parent_agent_verbs.is_empty()
-            || super::agent_verbs::grant_eligible(false, false, false),
-        services: Vec::new(),
-        entrypoint: crate::commands::vm::entrypoint_resolve::ResolvedEntrypoint::unresolved(
-            "a checkpoint fork boots the image the parent booted; this path resolves no entrypoint",
-        ),
-    })?;
-
-    let child_plan_json = admission.as_ref().map(|ctx| {
-        serde_json::to_string(ctx.admitted.signed()).expect("admitted plan is always serializable")
-    });
-    let child_tenant_id = admission
-        .as_ref()
-        .map(|ctx| ctx.admitted.plan().tenant.0.clone());
-
-    // Mint the child's verb-grant sidecar up front so it's readable below for
-    // post-restore delivery.
-    if let Some(ref plan_json_str) = child_plan_json {
-        let mint_cfg = mvm_core::vm_backend::VmStartConfig {
-            name: p.child_vm_name.clone(),
-            plan_json: Some(plan_json_str.clone()),
-            ..Default::default()
-        };
-        mvm_hostd::plan_admission::stash_plan_for_bridge(&mint_cfg)?;
-    }
-
-    // Verify the parent against the signed audit chain before cloning/restoring.
-    let parent_meta = p.store.read_meta(p.checkpoint)?;
-    let anchor = SignedChainAnchor::load()
-        .context("loading the signed audit chain to verify the fork parent")?;
-    let fork_result = fork_vm_full_fc(
-        p.store,
-        ForkParams {
-            checkpoint: p.checkpoint.clone(),
-            child_id: p.child_id,
-            child_vm_name: p.child_vm_name.clone(),
-            dest_dir: p.dest_dir,
-            created_unix: p.now,
-            child_plan_json,
-            child_tenant_id,
-        },
-        &|name, dir| mvm_runtime::firecracker::FcForkRestorer.restore_fork(name, dir),
-        &anchor,
-    );
-    if let Err(ref e) = fork_result {
-        super::up::emit_failed_if(&admission, "fork-vm-full-fc", e);
-    }
-    let meta = fork_result
-        .with_context(|| format!("forking FC vm_full checkpoint {:?}", p.checkpoint.as_str()))?;
-
-    bind_checkpoint_forked(p.checkpoint, &meta, &p.child_vm_name, p.store)?;
-    super::up::emit_launched_if(&admission, "firecracker", true);
-
-    // Deliver the fresh generation token to every restored child. A grant is
-    // optional for dev/test forks, but identity rotation is not: the token is
-    // bound to the child's recorded snapshot identity, not its human-readable
-    // VM name. When a grant exists, re-pin it in the same PostRestore RPC.
-    let mut grant_env = read_grant_envelope_for(&p.child_vm_name);
-    if let Some(grant) = grant_env.as_mut()
-        && let Some(parent_vm_name) = p.store.read_meta(p.checkpoint).ok().map(|m| m.vm_name)
-        && let Some((session_id, plan_nonce)) = grant_predecessor_from_vm_name(&parent_vm_name)
-    {
-        grant.predecessor_session_id = Some(session_id);
-        grant.predecessor_plan_nonce_hex = Some(plan_nonce.as_hex().to_string());
-    }
-    if let Err(error) = deliver_fc_fork_post_restore(
-        &p.child_vm_name,
-        parent_meta.meta_digest.as_str(),
-        grant_env,
-    ) {
-        let stop_result = mvm_runtime::microvm::stop_vm(&p.child_vm_name);
-        return match stop_result {
-            Ok(()) => Err(error.context(format!(
-                "stopped forked child '{}' after post-restore hygiene failure",
-                p.child_vm_name
-            ))),
-            Err(stop_error) => Err(error.context(format!(
-                "post-restore hygiene failed for '{}' and stopping the child also failed: {}",
-                p.child_vm_name, stop_error
-            ))),
-        };
-    }
-
-    if p.json {
-        crate::json_out::emit_json(&CheckpointForkJson {
-            schema_version: 1,
-            action: "fork",
-            parent_id: p.checkpoint,
-            child_vm_name: &p.child_vm_name,
-            booted: true,
-            checkpoint: &meta,
-        })?;
-    } else {
-        ui::success(&format!(
-            "forked {} -> checkpoint {} (vm '{}', auto-booted on firecracker)",
-            p.checkpoint.as_str(),
-            meta.id.as_str(),
-            p.child_vm_name
-        ));
-    }
-    Ok(meta)
-}
-
-fn deliver_fc_fork_post_restore(
-    child_vm_name: &str,
-    parent_snapshot_digest: &str,
-    grant_env: Option<mvm_core::protocol::vm_backend::VerbGrantEnvelope>,
-) -> Result<()> {
-    let vm_dir = mvm_runtime::microvm::resolve_running_vm_dir(child_vm_name)
-        .with_context(|| format!("resolving VM dir for '{child_vm_name}'"))?;
-    let vsock_path_str = mvm_runtime::microvm::firecracker_vsock_uds_path(&vm_dir);
-    const POLL_ATTEMPTS: u32 = 40; // 20 seconds max
-    for _ in 0..POLL_ATTEMPTS {
-        if mvm_agentd::vsock::ping_at(&vsock_path_str).unwrap_or(false) {
-            let token =
-                mvm_core::crypto::vmgenid::fresh_generation_token(parent_snapshot_digest).token;
-            let host_epoch_secs = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .context("reading host wall clock for fork PostRestore")?
-                .as_secs();
-            let reply = mvm_agentd::vsock::post_restore_with_grant_and_clock_at(
-                &vsock_path_str,
-                token,
-                grant_env,
-                Some(host_epoch_secs),
-            )
-            .with_context(|| format!("sending PostRestore to '{child_vm_name}'"))?;
-            require_fork_post_restore_success(reply)?;
-            tracing::info!(
-                "FC fork post-restore identity rotation acknowledged for '{}'",
-                child_vm_name
-            );
-            return Ok(());
-        }
-        std::thread::sleep(std::time::Duration::from_millis(500));
-    }
-    anyhow::bail!("guest agent not reachable for '{child_vm_name}' after fork restore")
-}
-
-fn require_fork_post_restore_success(reply: mvm_agentd::vsock::PostRestoreReply) -> Result<()> {
-    anyhow::ensure!(reply.acknowledged, "guest did not acknowledge PostRestore");
-    anyhow::ensure!(
-        reply.reseeded,
-        "guest acknowledged PostRestore without rotating its generation identity"
-    );
-    anyhow::ensure!(
-        reply.clock_resynced,
-        "guest acknowledged PostRestore without resynchronizing its wall clock"
-    );
     Ok(())
 }
 
@@ -1467,40 +1218,6 @@ mod tests {
     }
 
     #[test]
-    fn fork_post_restore_requires_acknowledgement_and_reseed() {
-        let acknowledged = mvm_agentd::vsock::PostRestoreReply {
-            acknowledged: true,
-            reseeded: true,
-            clock_resynced: true,
-        };
-        assert!(require_fork_post_restore_success(acknowledged).is_ok());
-
-        let not_reseeded = mvm_agentd::vsock::PostRestoreReply {
-            acknowledged: true,
-            reseeded: false,
-            clock_resynced: true,
-        };
-        let err = require_fork_post_restore_success(not_reseeded).unwrap_err();
-        assert!(err.to_string().contains("without rotating"));
-
-        let not_acknowledged = mvm_agentd::vsock::PostRestoreReply {
-            acknowledged: false,
-            reseeded: false,
-            clock_resynced: false,
-        };
-        let err = require_fork_post_restore_success(not_acknowledged).unwrap_err();
-        assert!(err.to_string().contains("did not acknowledge"));
-
-        let not_clock_resynced = mvm_agentd::vsock::PostRestoreReply {
-            acknowledged: true,
-            reseeded: true,
-            clock_resynced: false,
-        };
-        let err = require_fork_post_restore_success(not_clock_resynced).unwrap_err();
-        assert!(err.to_string().contains("wall clock"));
-    }
-
-    #[test]
     fn parent_agent_verb_override_inherits_parent_verbs() {
         use mvm_contract::plan::VerbId;
         use mvm_core::checkpoint::{CheckpointClass, CheckpointId};
@@ -1560,23 +1277,6 @@ mod tests {
     }
 
     // ── FC vm_full fork gate ─────────────────────────────────────────────
-
-    /// The FC vm_full fork is refused by default (guest re-IP unsettled) and
-    /// only reachable behind the explicit experimental opt-in.
-    #[test]
-    fn fc_vm_full_fork_gated_off_without_optin() {
-        let mut env = mvm_core::util::test_env::TestEnv::new();
-        env.remove("MVM_FORK_VMFULL_FC_EXPERIMENTAL");
-        assert!(
-            !fc_vm_full_fork_experimental_enabled(),
-            "FC vm_full fork must be gated off unless explicitly opted in"
-        );
-        env.set("MVM_FORK_VMFULL_FC_EXPERIMENTAL", "1");
-        assert!(
-            fc_vm_full_fork_experimental_enabled(),
-            "opt-in must enable the experimental FC vm_full fork restore"
-        );
-    }
 
     // ── vm_is_quiesced ───────────────────────────────────────────────────
 
@@ -2138,50 +1838,6 @@ mod tests {
     }
 
     // ── vm_full fork: --cpus/--memory refused ────────────────────────────────
-
-    /// Passing --cpus to a vm_full fork is refused with a clear error message
-    /// that explains the memory-restore constraint and names the fs_quick
-    /// alternative.
-    #[test]
-    fn vm_full_fork_refuses_cpus_override() {
-        let tmp = tempfile::tempdir().unwrap();
-        let err = fork_vm_full_arm_inner(ForkVmFullArmParams {
-            store: &CheckpointStore::at(tmp.path()),
-            checkpoint: &CheckpointId::new("ck-unused"),
-            new_id: None,
-            cpus_override: Some(8),
-            memory_override: None,
-            json: false,
-        })
-        .unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("--cpus"), "error must name --cpus: {msg}");
-        assert!(
-            msg.contains("fs_quick") || msg.contains("fs-quick"),
-            "error must name the fs_quick alternative: {msg}"
-        );
-    }
-
-    /// Passing --memory to a vm_full fork is refused with a clear error message.
-    #[test]
-    fn vm_full_fork_refuses_memory_override() {
-        let tmp = tempfile::tempdir().unwrap();
-        let err = fork_vm_full_arm_inner(ForkVmFullArmParams {
-            store: &CheckpointStore::at(tmp.path()),
-            checkpoint: &CheckpointId::new("ck-unused"),
-            new_id: None,
-            cpus_override: None,
-            memory_override: Some("2G"),
-            json: false,
-        })
-        .unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("--memory"), "error must name --memory: {msg}");
-        assert!(
-            msg.contains("fs_quick") || msg.contains("fs-quick"),
-            "error must name the fs_quick alternative: {msg}"
-        );
-    }
 
     // ── vm_is_running / vm_is_quiesced: Firecracker fc.pid path ──────────
 

--- a/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
@@ -1,0 +1,691 @@
+//! The `vm_full` fork arms: branching a fresh VM identity out of a saved
+//! machine state, per VMM.
+//!
+//! Everything above this module is backend-neutral — the clone, the verity
+//! binding check, the lineage record. What differs per VMM is the admission
+//! label, the restore mechanism, and how much the restored guest can collide
+//! with the parent it came from. That last one is why the Firecracker arm
+//! carries an opt-in guard and the HVF arm does not: a restored Firecracker
+//! child inherits the parent's guest IP/MAC out of saved memory, and an HVF
+//! guest has no NIC to inherit an address on.
+
+use anyhow::{Context, Result};
+use mvm_core::checkpoint::{CheckpointId, VmFullOrigin, vm_full_origin};
+use mvm_core::config::vm_state_dir;
+use mvm_runtime::checkpoint::{CheckpointStore, ForkParams, fork_vm_full};
+
+use super::{
+    CheckpointForkJson, SignedChainAnchor, bind_checkpoint_forked, grant_predecessor_from_vm_name,
+    now_unix, parent_agent_verb_override, read_grant_envelope_for, vm_is_running,
+};
+use crate::ui;
+
+/// Inputs for [`fork_vm_full_arm`]. Grouped to stay under the
+/// `clippy::too_many_arguments` workspace ceiling.
+struct ForkVmFullArmParams<'a> {
+    store: &'a CheckpointStore,
+    checkpoint: &'a CheckpointId,
+    new_id: Option<String>,
+    /// Refused with a user-visible error: a vm_full fork restores the saved
+    /// machine state (cpu/mem baked into the snapshot), so the shape is fixed.
+    /// Use an fs_quick fork to boot a resized child.
+    cpus_override: Option<u32>,
+    /// Refused with a user-visible error for the same reason as `cpus_override`.
+    memory_override: Option<&'a str>,
+    json: bool,
+}
+
+/// vm_full fork: clone the captured triple into a new child identity, admit a
+/// fresh claim-8 plan for the child (using the parent's saved cpu/mem — the
+/// restore shape is fixed), rewrite the supervisor config, and boot the child
+/// in restore mode. The child's admitted plan is distinct from the parent's.
+/// Whether the experimental Firecracker vm_full fork restore is opted into.
+///
+/// Off by default: a forked child restores the parent's saved guest memory,
+/// which carries the parent's IP/MAC, and there is no per-child guest
+/// re-addressing yet — so a booted child collides with its parent on the
+/// shared bridge. The opt-in exercises the (proven-sound) restore mechanism
+/// on an isolated single-child network while that per-child network model is
+/// still being settled.
+fn fc_vm_full_fork_experimental_enabled() -> bool {
+    std::env::var_os("MVM_FORK_VMFULL_FC_EXPERIMENTAL").is_some()
+}
+
+pub(super) fn fork_vm_full_arm(
+    store: &CheckpointStore,
+    checkpoint: &CheckpointId,
+    new_id: Option<String>,
+    cpus_override: Option<u32>,
+    memory_override: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    fork_vm_full_arm_inner(ForkVmFullArmParams {
+        store,
+        checkpoint,
+        new_id,
+        cpus_override,
+        memory_override,
+        json,
+    })
+}
+
+fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
+    // A vm_full fork restores a saved machine state whose cpu/mem are baked
+    // into the snapshot, and a restoring VMM validates device config against
+    // the saved state and refuses a mismatch. Accepting these flags
+    // would silently fail at restore time with a confusing hypervisor error
+    // — refuse early.
+    if p.cpus_override.is_some() {
+        anyhow::bail!(
+            "--cpus is not valid for a vm_full fork: a memory restore resumes the saved \
+             machine shape; use an fs_quick fork to resize"
+        );
+    }
+    if p.memory_override.is_some() {
+        anyhow::bail!(
+            "--memory is not valid for a vm_full fork: a memory restore resumes the saved \
+             machine shape; use an fs_quick fork to resize"
+        );
+    }
+
+    let now = now_unix();
+    let child_vm_name = p
+        .new_id
+        .unwrap_or_else(|| format!("{}-fork-{now}", p.checkpoint.as_str()));
+    let dest_dir = vm_state_dir(&child_vm_name);
+    let child_id = CheckpointId::new(format!("fork-{child_vm_name}-{now}"));
+
+    let parent_meta = p.store.read_meta(p.checkpoint)?;
+
+    // Dispatch on the machine state the checkpoint actually carries. HVF and
+    // Firecracker forks differ in more than mechanics: an HVF guest has no NIC
+    // at all, so the parent/child address collision that keeps the Firecracker
+    // arm behind an opt-in cannot arise there.
+    match vm_full_origin(&parent_meta) {
+        Some(VmFullOrigin::Hvf) => fork_vm_full_arm_hvf(ForkVmFullArmHvfParams {
+            store: p.store,
+            checkpoint: p.checkpoint,
+            parent_meta,
+            child_vm_name,
+            dest_dir,
+            child_id,
+            now,
+            json: p.json,
+        }),
+        Some(VmFullOrigin::Firecracker) => {
+            fork_vm_full_arm_fc(ForkVmFullArmFcParams {
+                store: p.store,
+                checkpoint: p.checkpoint,
+                parent_meta,
+                child_vm_name,
+                dest_dir,
+                child_id,
+                now,
+                json: p.json,
+                bypass_experimental_guard: false,
+            })?;
+            Ok(())
+        }
+        Some(VmFullOrigin::Retired) => anyhow::bail!(
+            "this vm_full checkpoint was captured under a backend that has been removed; \
+             nothing on this host can load its saved machine state. Use an fs_quick fork \
+             instead."
+        ),
+        None => anyhow::bail!(
+            "vm_full checkpoint '{}' names no saved machine state; use an fs_quick fork",
+            parent_meta.id
+        ),
+    }
+}
+
+/// Inputs for [`fork_vm_full_arm_fc`]. Grouped to stay under the
+/// `clippy::too_many_arguments` workspace ceiling.
+pub(in crate::commands) struct ForkVmFullArmFcParams<'a> {
+    pub(in crate::commands) store: &'a CheckpointStore,
+    pub(in crate::commands) checkpoint: &'a CheckpointId,
+    pub(in crate::commands) parent_meta: mvm_core::checkpoint::CheckpointMeta,
+    pub(in crate::commands) child_vm_name: String,
+    pub(in crate::commands) dest_dir: std::path::PathBuf,
+    pub(in crate::commands) child_id: CheckpointId,
+    pub(in crate::commands) now: u64,
+    pub(in crate::commands) json: bool,
+    /// When true, skip the `MVM_FORK_VMFULL_FC_EXPERIMENTAL` guard. The guard
+    /// stays on the lower-level `vm checkpoint fork` path; the user-facing
+    /// `machine warm-restore` verb opts in explicitly.
+    pub(in crate::commands) bypass_experimental_guard: bool,
+}
+
+/// FC vm_full fork: clone the captured triple, admit a fresh claim-8 plan for
+/// the child, rename `memory.bin` → `mem.bin`, and boot the child via a fresh
+/// Firecracker VMM loaded from the checkpoint snapshot.
+pub(in crate::commands) fn fork_vm_full_arm_fc(
+    p: ForkVmFullArmFcParams<'_>,
+) -> Result<mvm_core::checkpoint::CheckpointMeta> {
+    // FC vm_full fork loads a snapshot that still carries the parent's TAP
+    // name and guest MAC in bitcode. Remapping backing files is not enough to
+    // make a live-parent fork safe, so require the parent to be stopped first.
+    // The device-path remapping happens in a private mount namespace before
+    // the child Firecracker starts.
+    if vm_is_running(&p.parent_meta.vm_name) {
+        anyhow::bail!(
+            "Firecracker vm_full fork requires the parent VM '{}' to be stopped first;              live-parent fork would collide on the parent's TAP/MAC",
+            p.parent_meta.vm_name
+        );
+    }
+
+    // Only a Firecracker-produced machine state can be loaded here. A caller
+    // that reached this arm with anything else has mis-dispatched.
+    if vm_full_origin(&p.parent_meta) != Some(VmFullOrigin::Firecracker) {
+        anyhow::bail!(
+            "checkpoint '{}' does not carry a Firecracker machine state",
+            p.parent_meta.id
+        );
+    }
+
+    // Firecracker vm_full fork. A forked child restores the parent's saved guest
+    // memory verbatim, which carries the parent's IP/MAC. VMGenID reseeds the
+    // guest RNG on restore but does not re-address the network, so a booted child
+    // would collide with its parent on the shared dev-subnet bridge. The host-tap
+    // side is remappable, but re-IP'ing the guest is a per-child network-model
+    // decision that is not yet settled — refuse cleanly rather than boot a
+    // colliding child. The restore mechanism stays reachable behind an explicit
+    // opt-in for isolated single-child testing on that model, unless the caller
+    // has already opted in (the user-facing `machine warm-restore` path).
+    if !p.bypass_experimental_guard && !fc_vm_full_fork_experimental_enabled() {
+        anyhow::bail!(
+            "forking a vm_full checkpoint on Firecracker is not yet supported: the \
+             forked child inherits the parent's guest IP/MAC from the saved memory \
+             image and has no per-child network reconfiguration, so it would collide \
+             with the parent on the shared bridge. Use an fs_quick fork, or set \
+             MVM_FORK_VMFULL_FC_EXPERIMENTAL=1 to exercise the restore on an isolated \
+             single-child network."
+        );
+    }
+
+    let AdmittedForkChild {
+        admission,
+        child_plan_json,
+        child_tenant_id,
+    } = admit_forked_child(&AdmitForkedChildParams {
+        store: p.store,
+        checkpoint: p.checkpoint,
+        parent_meta: &p.parent_meta,
+        child_vm_name: &p.child_vm_name,
+        backend_name: "firecracker",
+    })?;
+
+    // Verify the parent against the signed audit chain before cloning/restoring.
+    let parent_meta = p.store.read_meta(p.checkpoint)?;
+    let anchor = SignedChainAnchor::load()
+        .context("loading the signed audit chain to verify the fork parent")?;
+    let fork_result = fork_vm_full(
+        p.store,
+        ForkParams {
+            checkpoint: p.checkpoint.clone(),
+            child_id: p.child_id,
+            child_vm_name: p.child_vm_name.clone(),
+            dest_dir: p.dest_dir,
+            created_unix: p.now,
+            child_plan_json,
+            child_tenant_id,
+        },
+        &|name, dir| mvm_runtime::firecracker::FcForkRestorer.restore_fork(name, dir),
+        &anchor,
+    );
+    if let Err(ref e) = fork_result {
+        crate::commands::vm::up::emit_failed_if(&admission, "fork-vm-full-fc", e);
+    }
+    let meta = fork_result
+        .with_context(|| format!("forking FC vm_full checkpoint {:?}", p.checkpoint.as_str()))?;
+
+    bind_checkpoint_forked(p.checkpoint, &meta, &p.child_vm_name, p.store)?;
+    crate::commands::vm::up::emit_launched_if(&admission, "firecracker", true);
+
+    // Deliver the fresh generation token to every restored child. A grant is
+    // optional for dev/test forks, but identity rotation is not: the token is
+    // bound to the child's recorded snapshot identity, not its human-readable
+    // VM name. When a grant exists, re-pin it in the same PostRestore RPC.
+    let mut grant_env = read_grant_envelope_for(&p.child_vm_name);
+    if let Some(grant) = grant_env.as_mut()
+        && let Some(parent_vm_name) = p.store.read_meta(p.checkpoint).ok().map(|m| m.vm_name)
+        && let Some((session_id, plan_nonce)) = grant_predecessor_from_vm_name(&parent_vm_name)
+    {
+        grant.predecessor_session_id = Some(session_id);
+        grant.predecessor_plan_nonce_hex = Some(plan_nonce.as_hex().to_string());
+    }
+    if let Err(error) = deliver_fc_fork_post_restore(
+        &p.child_vm_name,
+        parent_meta.meta_digest.as_str(),
+        grant_env,
+    ) {
+        let stop_result = mvm_runtime::microvm::stop_vm(&p.child_vm_name);
+        return match stop_result {
+            Ok(()) => Err(error.context(format!(
+                "stopped forked child '{}' after post-restore hygiene failure",
+                p.child_vm_name
+            ))),
+            Err(stop_error) => Err(error.context(format!(
+                "post-restore hygiene failed for '{}' and stopping the child also failed: {}",
+                p.child_vm_name, stop_error
+            ))),
+        };
+    }
+
+    if p.json {
+        crate::json_out::emit_json(&CheckpointForkJson {
+            schema_version: 1,
+            action: "fork",
+            parent_id: p.checkpoint,
+            child_vm_name: &p.child_vm_name,
+            booted: true,
+            checkpoint: &meta,
+        })?;
+    } else {
+        ui::success(&format!(
+            "forked {} -> checkpoint {} (vm '{}', auto-booted on firecracker)",
+            p.checkpoint.as_str(),
+            meta.id.as_str(),
+            p.child_vm_name
+        ));
+    }
+    Ok(meta)
+}
+
+/// Inputs for [`admit_forked_child`].
+struct AdmitForkedChildParams<'a> {
+    store: &'a CheckpointStore,
+    checkpoint: &'a CheckpointId,
+    parent_meta: &'a mvm_core::checkpoint::CheckpointMeta,
+    child_vm_name: &'a str,
+    backend_name: &'a str,
+}
+
+/// The admitted claim-8 envelope a vm_full fork boots its child under.
+struct AdmittedForkChild {
+    admission: Option<crate::commands::vm::up::AdmissionContext>,
+    child_plan_json: Option<String>,
+    child_tenant_id: Option<String>,
+}
+
+/// Admit a fresh claim-8 plan for a vm_full fork child, and mint its verb-grant
+/// sidecar so post-restore delivery can re-pin it.
+///
+/// The child's plan is its own, never the parent's: a distinct nonce, a distinct
+/// VM name, and `deny_all` networking. A restored guest resumes already past its
+/// own boot, so it must not inherit an egress capability from the state it came
+/// out of — the plan is what re-grants one, and this one grants none.
+///
+/// cpu/mem come from the host defaults rather than the parent plan on purpose:
+/// the real shape is baked into the saved machine state and enforced by the VMM
+/// at load time, so these values are claim-8 admission metadata only.
+fn admit_forked_child(p: &AdmitForkedChildParams<'_>) -> Result<AdmittedForkChild> {
+    let user_cfg = mvm_core::user_config::load(None);
+    // The checkpoint's RECORDED rootfs sha, so admission pins the bytes the
+    // capture sealed rather than re-hashing a file that could have moved.
+    let rootfs_blob = p
+        .store
+        .content_dir(p.checkpoint)
+        .join(mvm_core::checkpoint::ROOTFS_BLOB);
+    let recorded_sha = p
+        .parent_meta
+        .content
+        .iter()
+        .find(|b| b.name == mvm_core::checkpoint::ROOTFS_BLOB)
+        .map(|b| b.sha256.clone());
+    let parent_agent_verbs = parent_agent_verb_override(p.checkpoint, p.store);
+    let tenant = crate::commands::vm::tenant_resolution::resolve_tenant(None);
+    let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::new();
+    let admission = crate::commands::vm::up::admit_plan_for_boot(
+        crate::commands::vm::up::AdmitPlanForBootParams {
+            tenant: &tenant,
+            vm_name: p.child_vm_name,
+            backend_name: p.backend_name,
+            rootfs_path: &rootfs_blob,
+            precomputed_image_sha256: recorded_sha,
+            boot_artifact_identity: None,
+            cpus: user_cfg.default_cpus,
+            mem_mib: user_cfg.default_memory_mib as u64,
+            seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
+            secret_release: mvm_core::plan::SecretReleasePolicy::default(),
+            secrets: Vec::new(),
+            no_supervisor: false,
+            ledger: &ledger,
+            keys_dir: None,
+            audit_dir: None,
+            policy_dir: None,
+            bundle_pin: None,
+            deps_volume: None,
+            shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
+            network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
+            agent_verb_override: parent_agent_verbs.clone(),
+            // A restored child is never interactive, never carries ad-hoc argv, and
+            // is always prod-profile, so it qualifies for the attenuated grant.
+            restrict_agent_verbs: !parent_agent_verbs.is_empty()
+                || crate::commands::vm::agent_verbs::grant_eligible(false, false, false),
+            services: Vec::new(),
+            entrypoint: crate::commands::vm::entrypoint_resolve::ResolvedEntrypoint::unresolved(
+                "a checkpoint fork boots the image the parent booted; this path resolves no entrypoint",
+            ),
+        },
+    )?;
+
+    let child_plan_json = admission.as_ref().map(|ctx| {
+        serde_json::to_string(ctx.admitted.signed()).expect("admitted plan is always serializable")
+    });
+    let child_tenant_id = admission
+        .as_ref()
+        .map(|ctx| ctx.admitted.plan().tenant.0.clone());
+
+    if let Some(ref plan_json_str) = child_plan_json {
+        let mint_cfg = mvm_core::vm_backend::VmStartConfig {
+            name: p.child_vm_name.to_string(),
+            plan_json: Some(plan_json_str.clone()),
+            ..Default::default()
+        };
+        mvm_hostd::plan_admission::stash_plan_for_bridge(&mint_cfg)?;
+    }
+
+    Ok(AdmittedForkChild {
+        admission,
+        child_plan_json,
+        child_tenant_id,
+    })
+}
+
+/// Inputs for [`fork_vm_full_arm_hvf`].
+struct ForkVmFullArmHvfParams<'a> {
+    store: &'a CheckpointStore,
+    checkpoint: &'a CheckpointId,
+    parent_meta: mvm_core::checkpoint::CheckpointMeta,
+    child_vm_name: String,
+    dest_dir: std::path::PathBuf,
+    child_id: CheckpointId,
+    now: u64,
+    json: bool,
+}
+
+/// HVF vm_full fork: clone the captured state into a fresh child identity, admit
+/// a claim-8 plan of the child's own, restore the saved machine state into a new
+/// supervisor, and rotate the child's generation identity.
+///
+/// Unlike the Firecracker arm this needs no experimental opt-in. That guard
+/// exists because a restored Firecracker child inherits the parent's guest
+/// IP/MAC out of saved memory and collides with it on the shared bridge. An HVF
+/// guest has no NIC to inherit an address on: its only path off the box is the
+/// vsock relay the host binds, and the restore binds none.
+fn fork_vm_full_arm_hvf(p: ForkVmFullArmHvfParams<'_>) -> Result<()> {
+    let AdmittedForkChild {
+        admission,
+        child_plan_json,
+        child_tenant_id,
+    } = admit_forked_child(&AdmitForkedChildParams {
+        store: p.store,
+        checkpoint: p.checkpoint,
+        parent_meta: &p.parent_meta,
+        child_vm_name: &p.child_vm_name,
+        backend_name: "hvf",
+    })?;
+
+    // Verify the parent against the signed audit chain before cloning anything.
+    let anchor = SignedChainAnchor::load()
+        .context("loading the signed audit chain to verify the fork parent")?;
+    let fork_result = fork_vm_full(
+        p.store,
+        ForkParams {
+            checkpoint: p.checkpoint.clone(),
+            child_id: p.child_id,
+            child_vm_name: p.child_vm_name.clone(),
+            dest_dir: p.dest_dir,
+            created_unix: p.now,
+            child_plan_json,
+            child_tenant_id,
+        },
+        &|name, dir| mvm_runtime::hvf_restore::HvfForkRestorer.restore_fork(name, dir),
+        &anchor,
+    );
+    if let Err(ref e) = fork_result {
+        crate::commands::vm::up::emit_failed_if(&admission, "fork-vm-full-hvf", e);
+    }
+    let meta = fork_result
+        .with_context(|| format!("forking HVF vm_full checkpoint {:?}", p.checkpoint.as_str()))?;
+
+    bind_checkpoint_forked(p.checkpoint, &meta, &p.child_vm_name, p.store)?;
+    crate::commands::vm::up::emit_launched_if(&admission, "hvf", true);
+
+    if let Err(error) = deliver_hvf_fork_post_restore(
+        &p.child_vm_name,
+        p.parent_meta.meta_digest.as_str(),
+        read_grant_envelope_for(&p.child_vm_name),
+    ) {
+        return Err(stop_child_after_post_restore_failure(
+            &p.child_vm_name,
+            error,
+        ));
+    }
+
+    if p.json {
+        crate::json_out::emit_json(&CheckpointForkJson {
+            schema_version: 1,
+            action: "fork",
+            parent_id: p.checkpoint,
+            child_vm_name: &p.child_vm_name,
+            booted: true,
+            checkpoint: &meta,
+        })?;
+    } else {
+        ui::success(&format!(
+            "forked {} -> checkpoint {} (vm '{}', auto-booted on hvf)",
+            p.checkpoint.as_str(),
+            meta.id.as_str(),
+            p.child_vm_name
+        ));
+    }
+    Ok(())
+}
+
+/// A restored child that cannot prove it rotated its identity must not stay up:
+/// it is still running with the parent's CSPRNG state. Stop it and report both
+/// the original failure and the outcome of the stop.
+fn stop_child_after_post_restore_failure(
+    child_vm_name: &str,
+    error: anyhow::Error,
+) -> anyhow::Error {
+    match mvm_runtime::backend::AnyBackend::for_started_vm(child_vm_name) {
+        Some(backend) => match backend.stop(&mvm_core::vm_backend::VmId(child_vm_name.to_string()))
+        {
+            Ok(()) => error.context(format!(
+                "stopped forked child '{child_vm_name}' after post-restore hygiene failure"
+            )),
+            Err(stop_error) => error.context(format!(
+                "post-restore hygiene failed for '{child_vm_name}' and stopping the child \
+                 also failed: {stop_error}"
+            )),
+        },
+        None => error.context(format!(
+            "post-restore hygiene failed for '{child_vm_name}' and no backend claims it"
+        )),
+    }
+}
+
+/// Hand a freshly restored HVF child its fresh generation token (and its grant,
+/// when one was minted) over the backend-agnostic vsock dispatcher, and refuse
+/// anything short of a full acknowledgement.
+fn deliver_hvf_fork_post_restore(
+    child_vm_name: &str,
+    parent_snapshot_digest: &str,
+    grant_envelope: Option<mvm_core::protocol::vm_backend::VerbGrantEnvelope>,
+) -> Result<()> {
+    let token = mvm_core::crypto::vmgenid::fresh_generation_token(parent_snapshot_digest).token;
+    let outcome = mvm_vmm::post_restore::signal_post_restore(
+        child_vm_name,
+        &mvm_vmm::post_restore::VsockPostRestoreSignal {
+            token,
+            grant_envelope,
+        },
+        mvm_vmm::post_restore::POST_RESTORE_READY_TIMEOUT,
+    )
+    .with_context(|| format!("sending PostRestore to '{child_vm_name}'"))?;
+    anyhow::ensure!(
+        outcome.acknowledged,
+        "guest did not acknowledge PostRestore"
+    );
+    anyhow::ensure!(
+        outcome.reseeded,
+        "guest acknowledged PostRestore without rotating its generation identity"
+    );
+    anyhow::ensure!(
+        outcome.clock_resynced,
+        "guest acknowledged PostRestore without resynchronizing its wall clock"
+    );
+    Ok(())
+}
+
+fn deliver_fc_fork_post_restore(
+    child_vm_name: &str,
+    parent_snapshot_digest: &str,
+    grant_env: Option<mvm_core::protocol::vm_backend::VerbGrantEnvelope>,
+) -> Result<()> {
+    let vm_dir = mvm_runtime::microvm::resolve_running_vm_dir(child_vm_name)
+        .with_context(|| format!("resolving VM dir for '{child_vm_name}'"))?;
+    let vsock_path_str = mvm_runtime::microvm::firecracker_vsock_uds_path(&vm_dir);
+    const POLL_ATTEMPTS: u32 = 40; // 20 seconds max
+    for _ in 0..POLL_ATTEMPTS {
+        if mvm_agentd::vsock::ping_at(&vsock_path_str).unwrap_or(false) {
+            let token =
+                mvm_core::crypto::vmgenid::fresh_generation_token(parent_snapshot_digest).token;
+            let host_epoch_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .context("reading host wall clock for fork PostRestore")?
+                .as_secs();
+            let reply = mvm_agentd::vsock::post_restore_with_grant_and_clock_at(
+                &vsock_path_str,
+                token,
+                grant_env,
+                Some(host_epoch_secs),
+            )
+            .with_context(|| format!("sending PostRestore to '{child_vm_name}'"))?;
+            require_fork_post_restore_success(reply)?;
+            tracing::info!(
+                "FC fork post-restore identity rotation acknowledged for '{}'",
+                child_vm_name
+            );
+            return Ok(());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+    anyhow::bail!("guest agent not reachable for '{child_vm_name}' after fork restore")
+}
+
+fn require_fork_post_restore_success(reply: mvm_agentd::vsock::PostRestoreReply) -> Result<()> {
+    anyhow::ensure!(reply.acknowledged, "guest did not acknowledge PostRestore");
+    anyhow::ensure!(
+        reply.reseeded,
+        "guest acknowledged PostRestore without rotating its generation identity"
+    );
+    anyhow::ensure!(
+        reply.clock_resynced,
+        "guest acknowledged PostRestore without resynchronizing its wall clock"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fork_post_restore_requires_acknowledgement_and_reseed() {
+        let acknowledged = mvm_agentd::vsock::PostRestoreReply {
+            acknowledged: true,
+            reseeded: true,
+            clock_resynced: true,
+        };
+        assert!(require_fork_post_restore_success(acknowledged).is_ok());
+
+        let not_reseeded = mvm_agentd::vsock::PostRestoreReply {
+            acknowledged: true,
+            reseeded: false,
+            clock_resynced: true,
+        };
+        let err = require_fork_post_restore_success(not_reseeded).unwrap_err();
+        assert!(err.to_string().contains("without rotating"));
+
+        let not_acknowledged = mvm_agentd::vsock::PostRestoreReply {
+            acknowledged: false,
+            reseeded: false,
+            clock_resynced: false,
+        };
+        let err = require_fork_post_restore_success(not_acknowledged).unwrap_err();
+        assert!(err.to_string().contains("did not acknowledge"));
+
+        let not_clock_resynced = mvm_agentd::vsock::PostRestoreReply {
+            acknowledged: true,
+            reseeded: true,
+            clock_resynced: false,
+        };
+        let err = require_fork_post_restore_success(not_clock_resynced).unwrap_err();
+        assert!(err.to_string().contains("wall clock"));
+    }
+
+    /// The FC vm_full fork is refused by default (guest re-IP unsettled) and
+    /// only reachable behind the explicit experimental opt-in.
+    #[test]
+    fn fc_vm_full_fork_gated_off_without_optin() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.remove("MVM_FORK_VMFULL_FC_EXPERIMENTAL");
+        assert!(
+            !fc_vm_full_fork_experimental_enabled(),
+            "FC vm_full fork must be gated off unless explicitly opted in"
+        );
+        env.set("MVM_FORK_VMFULL_FC_EXPERIMENTAL", "1");
+        assert!(
+            fc_vm_full_fork_experimental_enabled(),
+            "opt-in must enable the experimental FC vm_full fork restore"
+        );
+    }
+
+    /// Passing --cpus to a vm_full fork is refused with a clear error message
+    /// that explains the memory-restore constraint and names the fs_quick
+    /// alternative.
+    #[test]
+    fn vm_full_fork_refuses_cpus_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = fork_vm_full_arm_inner(ForkVmFullArmParams {
+            store: &CheckpointStore::at(tmp.path()),
+            checkpoint: &CheckpointId::new("ck-unused"),
+            new_id: None,
+            cpus_override: Some(8),
+            memory_override: None,
+            json: false,
+        })
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("--cpus"), "error must name --cpus: {msg}");
+        assert!(
+            msg.contains("fs_quick") || msg.contains("fs-quick"),
+            "error must name the fs_quick alternative: {msg}"
+        );
+    }
+
+    /// Passing --memory to a vm_full fork is refused with a clear error message.
+    #[test]
+    fn vm_full_fork_refuses_memory_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = fork_vm_full_arm_inner(ForkVmFullArmParams {
+            store: &CheckpointStore::at(tmp.path()),
+            checkpoint: &CheckpointId::new("ck-unused"),
+            new_id: None,
+            cpus_override: None,
+            memory_override: Some("2G"),
+            json: false,
+        })
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("--memory"), "error must name --memory: {msg}");
+        assert!(
+            msg.contains("fs_quick") || msg.contains("fs-quick"),
+            "error must name the fs_quick alternative: {msg}"
+        );
+    }
+}

--- a/crates/mvm-cli/src/doctor/warm_start.rs
+++ b/crates/mvm-cli/src/doctor/warm_start.rs
@@ -244,9 +244,11 @@ mod tests {
         assert_eq!(r.backends.get("firecracker"), Some(&"unsupported"));
         assert_eq!(r.backends.get("libkrun"), Some(&"unsupported"));
         assert_eq!(r.backends.get("qemu"), Some(&"unsupported"));
-        assert_eq!(r.backends.get("hvf"), Some(&"unsupported"));
+        // HVF saves and reloads machine state; apple-container boots through
+        // the same supervisor and inherits the tier.
+        assert_eq!(r.backends.get("hvf"), Some(&"save-restore"));
         assert_eq!(r.backends.get("wasm"), Some(&"unsupported"));
-        assert_eq!(r.backends.get("apple-container"), Some(&"unsupported"));
+        assert_eq!(r.backends.get("apple-container"), Some(&"save-restore"));
     }
 
     #[test]
@@ -256,10 +258,10 @@ mod tests {
         let ordered_standby_pool: Vec<_> = r.standby_pool.into_iter().collect();
 
         let mut expected_backends = vec![
-            ("apple-container".to_string(), "unsupported"),
+            ("apple-container".to_string(), "save-restore"),
             ("docker".to_string(), "unsupported"),
             ("firecracker".to_string(), "unsupported"),
-            ("hvf".to_string(), "unsupported"),
+            ("hvf".to_string(), "save-restore"),
             ("libkrun".to_string(), "unsupported"),
             ("qemu".to_string(), "unsupported"),
             ("wasm".to_string(), "unsupported"),

--- a/crates/mvm-conformance/Cargo.toml
+++ b/crates/mvm-conformance/Cargo.toml
@@ -72,6 +72,10 @@ serde.workspace = true
 # than restating its rules, and stage a sidecar cache the resolver verifies.
 # Dev-only: `cargo tree -p mvm-conformance -e no-dev` must not gain these.
 mvm-hostd.workspace = true
+# The HVF supervisor launch contract the save/restore scenarios assert on: the
+# restore rewrite's output IS the security boundary, so the scenarios read the
+# config type directly rather than inferring it from a booted VM.
+mvm-vmm.workspace = true
 # The secrets/PII scenarios drive the local SecretService to prove there is no
 # reveal path for stored values.
 mvm-client.workspace = true

--- a/crates/mvm-conformance/tests/steps/hvf_save_restore.rs
+++ b/crates/mvm-conformance/tests/steps/hvf_save_restore.rs
@@ -1,0 +1,348 @@
+//! Step definitions for the HVF save/restore surface.
+//!
+//! Hermetic: every scenario drives the real host-side seams — the launch-config
+//! rewrite an HVF restore performs, the checkpoint origin classifier, and
+//! `restore_checkpoint`'s fail-closed lineage gate — with no hypervisor. The
+//! properties under test are refusals and what a restored machine comes up
+//! holding, neither of which needs a booted guest to observe.
+
+use std::path::PathBuf;
+
+use cucumber::{given, then, when};
+
+use mvm_core::checkpoint::{
+    CheckpointClass, CheckpointDigest, CheckpointId, CheckpointMeta, ContentBlob, DeviceAnchors,
+    HVF_FRAME_BLOB, MEMORY_BLOB, ROOTFS_BLOB, SUPERVISOR_CONFIG_BLOB, VmFullOrigin, vm_full_origin,
+};
+use mvm_runtime::checkpoint::{CheckpointChainAnchor, CheckpointStore, RestoreParams};
+use mvm_runtime::hvf_restore::{HvfRestoreRequest, hvf_child_restore_config};
+use mvm_vmm::host::hvf_supervisor::{ConsoleDataSocket, HvfDisk, HvfSupervisorConfig};
+
+use crate::world::CliWorld;
+
+/// A chain anchor whose verdict is fixed per scenario: either it echoes the
+/// digest the record was sealed with (audited), or it reports nothing (never
+/// audited). Echoing the *sealed* digest is what makes a post-seal edit
+/// detectable — the anchor keeps agreeing with the original.
+struct FixedAnchor(Option<CheckpointDigest>);
+
+impl CheckpointChainAnchor for FixedAnchor {
+    fn recorded_creation_digest(
+        &self,
+        _meta: &CheckpointMeta,
+    ) -> anyhow::Result<Option<CheckpointDigest>> {
+        Ok(self.0.clone())
+    }
+}
+
+/// A restore seam that records nothing and does nothing. Every scenario here
+/// asserts a refusal, so reaching this double at all is the failure.
+struct NeverReachedRestore;
+
+impl mvm_runtime::checkpoint::VmFullRestore for NeverReachedRestore {
+    fn restore(
+        &self,
+        _target_vm: &str,
+        _rootfs_src: &std::path::Path,
+        _memory: &std::path::Path,
+        _machine_id: &std::path::Path,
+        _config_src: Option<&std::path::Path>,
+    ) -> anyhow::Result<()> {
+        panic!("the VMM must not be started for a checkpoint that failed its gate");
+    }
+}
+
+// ── the launch-config rewrite ───────────────────────────────────────────────
+
+/// A parent config whose per-VM paths, relays and console sockets all point at
+/// the parent — the shape a live, admitted, dev-console HVF workload has.
+fn parent_config(state_dir: &std::path::Path) -> HvfSupervisorConfig {
+    HvfSupervisorConfig {
+        kernel: state_dir.join("Image"),
+        cmdline: Some("console=ttyAMA0 root=/dev/vda ro".into()),
+        memory_mib: 512,
+        initramfs: None,
+        disks: vec![HvfDisk {
+            path: PathBuf::from("/parent/state/rootfs.ext4"),
+            read_only: true,
+            ephemeral: false,
+        }],
+        virtiofs_root: None,
+        virtiofs_shares: Vec::new(),
+        vsock: true,
+        console_log: PathBuf::from("/parent/state/console.log"),
+        pid_file: PathBuf::from("/parent/state/hvf.pid"),
+        workload_exit: PathBuf::from("/parent/state/workload.exit"),
+        pause_state: Some(PathBuf::from("/parent/state/pause.state")),
+        snapshot_request: Some(PathBuf::from("/parent/state/snapshot.request")),
+        snapshot_ram: Some(PathBuf::from("/parent/state/snapshot.ram")),
+        snapshot_frame: Some(PathBuf::from("/parent/state/snapshot.frame")),
+        restore_ram: None,
+        restore_frame: None,
+        timeout_secs: 0,
+        agent_socket: Some(PathBuf::from("/parent/state/hvf-agent.sock")),
+        substitution_socket: Some(PathBuf::from("/parent/state/substitution.sock")),
+        egress_relay_socket: Some(PathBuf::from("/parent/state/egress.sock")),
+        broker_socket: Some(PathBuf::from("/parent/state/broker.sock")),
+        console_data_sockets: vec![ConsoleDataSocket {
+            guest_port: 20001,
+            host_socket: PathBuf::from("/parent/state/vsock/vsock-20001.sock"),
+        }],
+        handoff_socket: Some(PathBuf::from("/parent/state/hvf-handoff.sock")),
+        handoff_root: Some(PathBuf::from("/parent/vms")),
+        handoff_verify_key: Some("ab".repeat(32)),
+    }
+}
+
+/// Lay down everything a restore needs in the child's state dir.
+fn materialize_child_state(world: &mut CliWorld) -> PathBuf {
+    let tmp = tempfile::tempdir().expect("create HVF restore scenario tempdir");
+    let dir = tmp.path().to_path_buf();
+    std::fs::write(dir.join("Image"), b"kernel").expect("write kernel");
+    std::fs::write(dir.join(MEMORY_BLOB), b"saved-ram").expect("write saved RAM");
+    std::fs::write(dir.join(HVF_FRAME_BLOB), b"saved-frame").expect("write saved frame");
+    std::fs::write(dir.join(ROOTFS_BLOB), b"child-rootfs").expect("write child rootfs");
+    world.hvf_restore_tmp = Some(tmp);
+    dir
+}
+
+#[given(
+    expr = "a captured HVF launch config carrying an egress relay, a broker and a console socket"
+)]
+fn captured_config_with_relays(world: &mut CliWorld) {
+    let dir = materialize_child_state(world);
+    world.hvf_parent_config = Some(parent_config(&dir));
+}
+
+#[given(expr = "a captured HVF launch config whose per-VM paths all point at the parent")]
+fn captured_config_with_parent_paths(world: &mut CliWorld) {
+    let dir = materialize_child_state(world);
+    world.hvf_parent_config = Some(parent_config(&dir));
+}
+
+#[when(expr = "the captured config is rewritten for a restored child")]
+fn rewrite_for_child(world: &mut CliWorld) {
+    let dir = world
+        .hvf_restore_tmp
+        .as_ref()
+        .expect("a captured config must be prepared first")
+        .path()
+        .to_path_buf();
+    let parent = world
+        .hvf_parent_config
+        .as_ref()
+        .expect("a captured config must be prepared first");
+    let anchors = DeviceAnchors {
+        rootfs: PathBuf::from("/parent/state/rootfs.ext4"),
+        rootfs_verity: None,
+        config: None,
+        secrets: None,
+        vsock: PathBuf::from("/parent/state/hvf-agent.sock"),
+    };
+    let child = hvf_child_restore_config(
+        parent,
+        &anchors,
+        &HvfRestoreRequest {
+            vm_name: "restored-child",
+            state_dir: &dir,
+        },
+    )
+    .expect("rewrite the captured config for a restored child");
+    world.hvf_child_config = Some(child);
+}
+
+fn child_config(world: &CliWorld) -> &HvfSupervisorConfig {
+    world
+        .hvf_child_config
+        .as_ref()
+        .expect("the config must be rewritten first")
+}
+
+#[then(expr = "the restored config carries no egress relay, broker or console socket")]
+fn child_has_no_relays(world: &mut CliWorld) {
+    let child = child_config(world);
+    assert_eq!(child.egress_relay_socket, None, "egress relay survived");
+    assert_eq!(child.substitution_socket, None, "substitution survived");
+    assert_eq!(child.broker_socket, None, "broker survived");
+    assert!(
+        child.console_data_sockets.is_empty(),
+        "console data sockets survived"
+    );
+}
+
+#[then(expr = "the restored config carries no live-handoff control socket")]
+fn child_has_no_handoff(world: &mut CliWorld) {
+    let child = child_config(world);
+    assert_eq!(child.handoff_socket, None, "handoff socket survived");
+    assert_eq!(child.handoff_root, None, "handoff root survived");
+    assert_eq!(child.handoff_verify_key, None, "handoff key survived");
+}
+
+#[then(expr = "the restored config loads the saved machine state instead of booting a kernel")]
+fn child_loads_saved_state(world: &mut CliWorld) {
+    let dir = world
+        .hvf_restore_tmp
+        .as_ref()
+        .expect("scenario tempdir")
+        .path();
+    let child = child_config(world);
+    assert_eq!(child.restore_ram, Some(dir.join(MEMORY_BLOB)));
+    assert_eq!(child.restore_frame, Some(dir.join(HVF_FRAME_BLOB)));
+}
+
+#[then(expr = "every per-VM path in the restored config points at the child's own state directory")]
+fn child_paths_are_rehomed(world: &mut CliWorld) {
+    let dir = world
+        .hvf_restore_tmp
+        .as_ref()
+        .expect("scenario tempdir")
+        .path()
+        .to_path_buf();
+    let child = child_config(world);
+    assert_eq!(child.pid_file, dir.join("hvf.pid"));
+    assert_eq!(child.console_log, dir.join("console.log"));
+    assert_eq!(child.workload_exit, dir.join("workload.exit"));
+    assert_eq!(child.pause_state, Some(dir.join("pause.state")));
+    assert_eq!(child.snapshot_ram, Some(dir.join("snapshot.ram")));
+    assert_eq!(child.snapshot_frame, Some(dir.join("snapshot.frame")));
+    assert_eq!(
+        child.agent_socket,
+        Some(mvm_core::config::vm_hvf_agent_socket_at(&dir))
+    );
+}
+
+#[then(expr = "the restored config reads its rootfs from the child's own clone")]
+fn child_rootfs_is_its_own(world: &mut CliWorld) {
+    let dir = world
+        .hvf_restore_tmp
+        .as_ref()
+        .expect("scenario tempdir")
+        .path();
+    let child = child_config(world);
+    assert_eq!(child.disks.len(), 1, "one rootfs disk");
+    assert_eq!(child.disks[0].path, dir.join(ROOTFS_BLOB));
+    assert!(child.disks[0].read_only, "a restored disk stays read-only");
+}
+
+// ── checkpoint origin + the lineage gate ────────────────────────────────────
+
+/// Seal a vm_full checkpoint carrying `content` into a scenario-local store.
+fn seed_checkpoint(world: &mut CliWorld, id: &str, content: Vec<ContentBlob>) -> CheckpointMeta {
+    let tmp = world
+        .hvf_ckpt_tmp
+        .get_or_insert_with(|| tempfile::tempdir().expect("create checkpoint scenario tempdir"));
+    let store = CheckpointStore::at(tmp.path().join("checkpoints"));
+    let content_dir = store.content_dir(&CheckpointId::new(id));
+    std::fs::create_dir_all(&content_dir).expect("create checkpoint content dir");
+    for blob in &content {
+        std::fs::write(content_dir.join(&blob.name), blob.name.as_bytes())
+            .expect("write checkpoint blob");
+    }
+    let content = content
+        .into_iter()
+        .map(|blob| ContentBlob {
+            sha256: mvm_core::crypto::image_verify::sha256_file(&content_dir.join(&blob.name))
+                .expect("hash checkpoint blob"),
+            name: blob.name,
+        })
+        .collect();
+    let meta = CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::VmFull, "hvf-vm")
+        .created_unix(1)
+        .content(content)
+        .build();
+    store.write_meta(&meta).expect("seal checkpoint");
+    world.hvf_ckpt_store = Some(store);
+    world.hvf_ckpt_meta = Some(meta.clone());
+    meta
+}
+
+fn hvf_content() -> Vec<ContentBlob> {
+    [
+        "rootfs.ext4",
+        MEMORY_BLOB,
+        HVF_FRAME_BLOB,
+        SUPERVISOR_CONFIG_BLOB,
+    ]
+    .into_iter()
+    .map(|name| ContentBlob {
+        name: name.into(),
+        sha256: String::new(),
+    })
+    .collect()
+}
+
+#[given(expr = "an audited HVF vm_full checkpoint")]
+fn audited_hvf_checkpoint(world: &mut CliWorld) {
+    let meta = seed_checkpoint(world, "hvf-audited", hvf_content());
+    world.hvf_anchor = Some(FixedAnchor(Some(meta.compute_meta_digest())).0);
+}
+
+#[given(expr = "an HVF vm_full checkpoint that no signed audit entry covers")]
+fn unaudited_hvf_checkpoint(world: &mut CliWorld) {
+    seed_checkpoint(world, "hvf-unaudited", hvf_content());
+    world.hvf_anchor = Some(None);
+}
+
+#[given(expr = "a vm_full checkpoint carrying a launch config but no machine-state blob")]
+fn retired_backend_checkpoint(world: &mut CliWorld) {
+    let content = ["rootfs.ext4", MEMORY_BLOB, SUPERVISOR_CONFIG_BLOB]
+        .into_iter()
+        .map(|name| ContentBlob {
+            name: name.into(),
+            sha256: String::new(),
+        })
+        .collect();
+    let meta = seed_checkpoint(world, "retired", content);
+    world.hvf_anchor = Some(Some(meta.compute_meta_digest()));
+}
+
+#[when(expr = "the sealed record is edited after it was audited")]
+fn edit_after_seal(world: &mut CliWorld) {
+    let store = world.hvf_ckpt_store.as_ref().expect("a seeded checkpoint");
+    let mut meta = world.hvf_ckpt_meta.clone().expect("a seeded checkpoint");
+    meta.vm_name = "renamed-after-seal".into();
+    store.write_meta(&meta).expect("rewrite the sealed record");
+}
+
+/// Run the full refusal ladder a `checkpoint restore` walks: resolve the VMM
+/// that can load this machine state, then verify content and lineage. Either
+/// gate refusing is a refusal before any VMM starts — the injected restore seam
+/// panics if it is ever reached.
+#[then(expr = "restoring the checkpoint is refused before the VMM is started")]
+fn restore_is_refused(world: &mut CliWorld) {
+    let store = world.hvf_ckpt_store.as_ref().expect("a seeded checkpoint");
+    let meta = world.hvf_ckpt_meta.as_ref().expect("a seeded checkpoint");
+    let anchor = FixedAnchor(world.hvf_anchor.clone().expect("a scenario anchor"));
+    let error = mvm_runtime::checkpoint::vm_full_restorer_for(meta)
+        .and_then(|_| {
+            mvm_runtime::checkpoint::restore_checkpoint(
+                store,
+                RestoreParams {
+                    checkpoint: meta.id.clone(),
+                    target_vm: meta.vm_name.clone(),
+                },
+                &NeverReachedRestore,
+                &anchor,
+            )
+        })
+        .expect_err("the restore must be refused");
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("drift")
+            || rendered.contains("no signed audit entry")
+            || rendered.contains("has been removed"),
+        "expected a lineage or dispatch refusal, got: {rendered}"
+    );
+}
+
+#[then(expr = "its origin is reported as a removed backend")]
+fn origin_is_retired(world: &mut CliWorld) {
+    let meta = world.hvf_ckpt_meta.as_ref().expect("a seeded checkpoint");
+    assert_eq!(vm_full_origin(meta), Some(VmFullOrigin::Retired));
+}
+
+#[then(expr = "its origin is reported as the in-house HVF VMM")]
+fn origin_is_hvf(world: &mut CliWorld) {
+    let meta = world.hvf_ckpt_meta.as_ref().expect("a seeded checkpoint");
+    assert_eq!(vm_full_origin(meta), Some(VmFullOrigin::Hvf));
+}

--- a/crates/mvm-conformance/tests/steps/mod.rs
+++ b/crates/mvm-conformance/tests/steps/mod.rs
@@ -4,6 +4,7 @@ mod admission_audit;
 mod apple_container;
 mod claim;
 pub(crate) mod cli;
+mod hvf_save_restore;
 mod initramfs;
 mod kernel_pin;
 mod l3_vsock;

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -228,6 +228,21 @@ pub struct CliWorld {
     pub prior_layer_paths: HashSet<PathBuf>,
     /// The most recent OCI unpack report.
     pub last_unpack_report: Option<mvm_fs::oci::UnpackReport>,
+    /// Scratch directory backing the HVF restore config-rewrite scenarios.
+    pub hvf_restore_tmp: Option<tempfile::TempDir>,
+    /// The captured parent launch config a restore scenario rewrites.
+    pub hvf_parent_config: Option<mvm_vmm::host::hvf_supervisor::HvfSupervisorConfig>,
+    /// The rewritten child launch config under assertion.
+    pub hvf_child_config: Option<mvm_vmm::host::hvf_supervisor::HvfSupervisorConfig>,
+    /// Scratch directory backing the HVF checkpoint-origin/lineage scenarios.
+    pub hvf_ckpt_tmp: Option<tempfile::TempDir>,
+    /// Checkpoint store seeded by an HVF checkpoint scenario.
+    pub hvf_ckpt_store: Option<CheckpointStore>,
+    /// The sealed record a scenario classifies or tries to restore.
+    pub hvf_ckpt_meta: Option<CheckpointMeta>,
+    /// The digest the scenario's signed-chain double reports, or `None` for a
+    /// checkpoint no signed audit entry covers.
+    pub hvf_anchor: Option<Option<mvm_core::checkpoint::CheckpointDigest>>,
     /// Scratch directory backing the warm-snapshot scenarios: holds the
     /// snapshot store root, the synthetic template rootfs artifact, and
     /// every materialized instance path.

--- a/crates/mvm-core/src/checkpoint.rs
+++ b/crates/mvm-core/src/checkpoint.rs
@@ -131,6 +131,60 @@ pub struct ContentBlob {
     pub sha256: String,
 }
 
+/// Saved guest memory image inside a vm_full checkpoint's content dir.
+pub const MEMORY_BLOB: &str = "memory.bin";
+/// Cloned rootfs image inside any checkpoint's content dir.
+pub const ROOTFS_BLOB: &str = "rootfs.ext4";
+/// dm-verity hash-tree sidecar carried beside a sealed rootfs.
+pub const ROOTFS_VERITY_BLOB: &str = "rootfs.verity";
+/// Absolute host paths the saved machine state embeds by path.
+pub const DEVICE_ANCHORS_BLOB: &str = "device-anchors.json";
+/// Persisted launch config of the VM a vm_full checkpoint was captured from.
+/// Present only for backends that drive their VMM through a supervisor config
+/// (HVF, and the removed Apple-Virtualization backend); Firecracker omits it.
+pub const SUPERVISOR_CONFIG_BLOB: &str = "supervisor-config.json";
+/// vCPU + deterministic device state the in-house HVF VMM writes beside
+/// [`MEMORY_BLOB`]. Its presence in a content manifest is what identifies a
+/// vm_full checkpoint as HVF-produced.
+pub const HVF_FRAME_BLOB: &str = "memory.bin.hvf-frame";
+/// Firecracker's machine-state blob, written beside [`MEMORY_BLOB`]. Its
+/// presence identifies a vm_full checkpoint as Firecracker-produced.
+pub const FC_VMSTATE_BLOB: &str = "vmstate.bin";
+
+/// Which VMM produced a `vm_full` checkpoint. Derived from the content
+/// manifest rather than stored, so it cannot drift from the bytes a restore
+/// would actually load: each VMM writes a machine-state blob only it produces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmFullOrigin {
+    /// Firecracker: `memory.bin` + [`FC_VMSTATE_BLOB`].
+    Firecracker,
+    /// The in-house HVF VMM: `memory.bin` + [`HVF_FRAME_BLOB`].
+    Hvf,
+    /// A supervisor-config checkpoint with no recognizable machine-state blob —
+    /// the removed Apple-Virtualization backend. Nothing on this host can load
+    /// it, so every consumer must refuse rather than guess.
+    Retired,
+}
+
+/// Classify a checkpoint by the machine-state blob its content manifest names.
+///
+/// Returns `None` for a manifest that names no machine state at all, which is
+/// what an `fs_quick` checkpoint looks like — callers dispatching a full-VM
+/// restore treat that as "not a vm_full checkpoint" rather than a backend.
+#[must_use]
+pub fn vm_full_origin(meta: &CheckpointMeta) -> Option<VmFullOrigin> {
+    let named = |name: &str| meta.content.iter().any(|blob| blob.name == name);
+    if named(HVF_FRAME_BLOB) {
+        Some(VmFullOrigin::Hvf)
+    } else if named(FC_VMSTATE_BLOB) {
+        Some(VmFullOrigin::Firecracker)
+    } else if named(SUPERVISOR_CONFIG_BLOB) {
+        Some(VmFullOrigin::Retired)
+    } else {
+        None
+    }
+}
+
 /// Absolute host paths to resources a vm_full snapshot embeds by path.
 /// Captured at checkpoint time so a forked child can make those paths
 /// resolve to its own copies without editing the snapshot bitcode.

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -802,6 +802,33 @@ impl AnyBackend {
         }
     }
 
+    /// Pause/save-memory/resume control over a running VM this backend owns —
+    /// the mechanics a `vm_full` checkpoint capture drives.
+    ///
+    /// `None` is the fail-closed answer for a backend with no memory-capture
+    /// mechanics; a caller must refuse the capture rather than substituting
+    /// another backend's control, which would pause the wrong process. The
+    /// exhaustive match means a new variant has to make that choice explicitly.
+    pub fn vm_full_control(
+        &self,
+        vm_name: &str,
+    ) -> Option<Box<dyn crate::checkpoint::VmFullControl>> {
+        use mvm_vmm::driver::traits::VmmDriver as _;
+        match self {
+            AnyBackend::Firecracker(runner) => runner.vm_full_control(vm_name),
+            AnyBackend::Libkrun(runner) => runner.vm_full_control(vm_name),
+            AnyBackend::Hvf(runner) => runner.vm_full_control(vm_name),
+            // Apple Container boots through the HVF supervisor, so its live VMs
+            // are captured by the same control the HVF driver hands back.
+            AnyBackend::AppleContainer(_) => HvfDriver::new().vm_full_control(vm_name),
+            // No memory capture: the mock keeps its VMs in memory, and qemu,
+            // wasm and docker have no save/restore mechanics at all.
+            #[cfg(feature = "test-support")]
+            AnyBackend::Mock(_) => None,
+            AnyBackend::Qemu(_) | AnyBackend::Wasm(_) | AnyBackend::Docker(_) => None,
+        }
+    }
+
     /// Whether refill can load a child VMM and keep it paused until claim.
     pub fn supports_preloaded_standby(&self) -> bool {
         match self {
@@ -1726,10 +1753,12 @@ mod tests {
     #[test]
     fn recovery_capability_matrix_is_explicit_for_every_selectable_backend() {
         let mut expected = vec![
-            ("apple-container", SnapshotCapability::Unsupported, false),
+            // Apple Container boots through the HVF supervisor, so it inherits
+            // that VMM's save/restore tier — one supervisor, one mechanism.
+            ("apple-container", SnapshotCapability::SaveRestore, false),
             ("docker", SnapshotCapability::Unsupported, false),
             ("firecracker", SnapshotCapability::Unsupported, true),
-            ("hvf", SnapshotCapability::Unsupported, true),
+            ("hvf", SnapshotCapability::SaveRestore, true),
             ("libkrun", SnapshotCapability::Unsupported, false),
             ("qemu", SnapshotCapability::Unsupported, false),
             ("wasm", SnapshotCapability::Unsupported, false),

--- a/crates/mvm-runtime/src/checkpoint/mod.rs
+++ b/crates/mvm-runtime/src/checkpoint/mod.rs
@@ -11,12 +11,7 @@ use mvm_fs::trusted_snapshot::TrustedSnapshotBackend;
 
 use crate::lineage::{LineageAnchor, LineageGraph, LineageRecord};
 
-/// Filename of the persisted supervisor launch config inside a vm_full
-/// checkpoint's content dir. Present only on checkpoints captured from a
-/// backend that writes a supervisor config (today, HVF); Firecracker
-/// checkpoints omit it, which is how
-/// [`checkpoint_carries_supervisor_config`] distinguishes them.
-pub const SUPERVISOR_CONFIG_FILE_NAME: &str = "supervisor-config.json";
+pub use mvm_core::checkpoint::SUPERVISOR_CONFIG_BLOB as SUPERVISOR_CONFIG_FILE_NAME;
 
 /// Filesystem-backed registry over `config::checkpoints_dir()` (or any root,
 /// for tests). Layout: `<root>/<id>/meta.json` + `<root>/<id>/content/`.
@@ -322,20 +317,11 @@ const FORK_ALLOW_PARENT_RUNNING: bool = false;
 
 /// Stages a forked child's snapshot into position and starts the VM, given the
 /// child's VM name and its state dir (with all checkpoint blobs already cloned
-/// there). Taken as a callback so [`fork_vm_full_fc`] is testable without a
-/// live hypervisor.
+/// there). Taken as a callback so [`fork_vm_full`] is testable without a live
+/// hypervisor, and so the VMM-specific restorers can live in `mvm-backends`
+/// without this crate naming them: `FcForkRestorer` loads Firecracker's
+/// snapshot triple, `HvfForkRestorer` maps private RAM and restores the frame.
 pub type ForkRestore<'a> = dyn Fn(&str, &Path) -> Result<()> + 'a;
-
-/// Returns `true` when the checkpoint's content manifest carries a
-/// `supervisor-config.json` blob — i.e. it was captured from a backend that
-/// rebuilds its VMM from a persisted supervisor config (today, HVF).
-/// Firecracker checkpoints omit that blob, so this dispatches fork to the
-/// right path.
-pub fn checkpoint_carries_supervisor_config(meta: &mvm_core::checkpoint::CheckpointMeta) -> bool {
-    meta.content
-        .iter()
-        .any(|b| b.name == SUPERVISOR_CONFIG_FILE_NAME)
-}
 
 /// Branch a new sandbox lineage from a checkpoint: verify the source content's
 /// integrity AND its content-address against the signed audit chain, CoW-clone
@@ -347,7 +333,7 @@ pub fn checkpoint_carries_supervisor_config(meta: &mvm_core::checkpoint::Checkpo
 /// edited after it was audited — fail-closed.
 ///
 /// fs_quick only — a vm_full checkpoint carries saved memory and must be forked
-/// through [`fork_vm_full_fc`], which restores the memory state into the new
+/// through [`fork_vm_full`], which restores the memory state into the new
 /// identity.
 pub fn fork_checkpoint(
     store: &CheckpointStore,
@@ -357,7 +343,7 @@ pub fn fork_checkpoint(
     let parent = store.read_meta(&params.checkpoint)?;
     if parent.class != CheckpointClass::FsQuick {
         anyhow::bail!(
-            "cannot fork checkpoint '{}' (class vm_full) via fork_checkpoint; use fork_vm_full_fc",
+            "cannot fork checkpoint '{}' (class vm_full) via fork_checkpoint; use fork_vm_full",
             parent.id
         );
     }
@@ -394,16 +380,15 @@ pub fn fork_checkpoint(
     Ok(child)
 }
 
-/// Branch a new FC VM identity from a Firecracker vm_full checkpoint and boot
-/// it via a fresh Firecracker VMM loaded from the checkpoint snapshot.
+/// Branch a new VM identity from a vm_full checkpoint and boot it from the
+/// saved machine state.
 ///
-/// FC checkpoints carry `{rootfs.ext4, memory.bin, vmstate.bin}` instead of a
-/// supervisor config.
-/// The child's blobs are cloned into `dest_dir`; `memory.bin` is renamed to
-/// `mem.bin` (Firecracker's canonical load name); a fresh FC VMM is started and
-/// `PUT /snapshot/load` restores the child's state; then the lineage checkpoint
-/// record is written.
-pub fn fork_vm_full_fc(
+/// Backend-neutral: the clone, the verity-binding check and the lineage record
+/// are the same for every VMM, and `restorer` owns the VMM-specific load
+/// (Firecracker's `PUT /snapshot/load`, HVF's private RAM mapping plus frame
+/// restore). The child's blobs are cloned into `dest_dir` and it boots from its
+/// OWN copies, never the parent's.
+pub fn fork_vm_full(
     store: &CheckpointStore,
     params: ForkParams,
     restore: &ForkRestore<'_>,
@@ -412,7 +397,7 @@ pub fn fork_vm_full_fc(
     let parent = store.read_meta(&params.checkpoint)?;
     if parent.class != CheckpointClass::VmFull {
         anyhow::bail!(
-            "cannot fork_vm_full_fc checkpoint '{}' (class fs_quick); use fork_checkpoint",
+            "cannot fork_vm_full checkpoint '{}' (class fs_quick); use fork_checkpoint",
             parent.id
         );
     }
@@ -477,7 +462,7 @@ pub fn fork_vm_full_fc(
     Ok(child)
 }
 
-/// Ensure a cloned FC checkpoint keeps the complete dm-verity binding and the
+/// Ensure a cloned checkpoint keeps the complete dm-verity binding and the
 /// device-path metadata needed to remap snapshot references to child files.
 fn validate_fork_verity_binding(parent: &CheckpointMeta, child_dir: &Path) -> Result<()> {
     let has_verity = parent
@@ -490,14 +475,14 @@ fn validate_fork_verity_binding(parent: &CheckpointMeta, child_dir: &Path) -> Re
         .any(|blob| blob.name == "rootfs.roothash");
     anyhow::ensure!(
         has_verity == has_roothash,
-        "FC checkpoint '{}' has an incomplete dm-verity sidecar set",
+        "checkpoint '{}' has an incomplete dm-verity sidecar set",
         parent.id
     );
 
     let anchors_path = child_dir.join("device-anchors.json");
     anyhow::ensure!(
         anchors_path.is_file(),
-        "FC checkpoint '{}' is missing device-anchors.json",
+        "checkpoint '{}' is missing device-anchors.json",
         parent.id
     );
     let anchors: DeviceAnchors = serde_json::from_slice(
@@ -511,13 +496,13 @@ fn validate_fork_verity_binding(parent: &CheckpointMeta, child_dir: &Path) -> Re
             anchors.rootfs_verity.is_some()
                 && child_dir.join("rootfs.verity").is_file()
                 && child_dir.join("rootfs.roothash").is_file(),
-            "FC checkpoint '{}' would drop its dm-verity binding during fork",
+            "checkpoint '{}' would drop its dm-verity binding during fork",
             parent.id
         );
     } else {
         anyhow::ensure!(
             anchors.rootfs_verity.is_none(),
-            "FC checkpoint '{}' has a verity device anchor without sidecars",
+            "checkpoint '{}' has a verity device anchor without sidecars",
             parent.id
         );
     }
@@ -570,8 +555,12 @@ fn validate_child_fork_plan(params: &ForkParams) -> Result<()> {
 ///
 /// Delegates to the shared marker list so a backend cannot be live here and
 /// stopped elsewhere. This gates the refuse-to-fork-a-live-parent rule, so a
-/// marker this probe does not know reads as stopped and lets a fork through.
-fn vm_is_running(vm_name: &str) -> bool {
+/// marker this probe does not know reads as stopped and lets a fork through —
+/// `vm_is_running_covers_every_catalog_pid_marker` holds the shared list to
+/// every backend the catalog registers. Delegating also picks up the
+/// `EPERM`-means-alive rule, which matters for a root-owned Firecracker: a bare
+/// `kill(pid, 0) == 0` reads that as stopped.
+pub fn vm_is_running(vm_name: &str) -> bool {
     mvm_vmm::host::process_liveness::state_dir_has_live_process(&mvm_core::config::vm_state_dir(
         vm_name,
     ))
@@ -594,6 +583,13 @@ pub struct CaptureVmFullParams {
     pub supervisor_config_src: Option<PathBuf>,
     pub tag: Option<String>,
     pub created_unix: u64,
+    /// Whether the caller wants the source VM left paused after a successful
+    /// capture. Only the warm pool does: for it the paused parent *is* the
+    /// claim resource, and the checkpoint is an integrity witness beside it. A
+    /// user checkpointing their own running VM wants it running afterwards, so
+    /// this is `false` on the CLI path. Retention still requires the backend to
+    /// support it — the two must agree.
+    pub retain_paused: bool,
 }
 
 /// Capture a running VM's consistent {rootfs, memory, machine-id} triple in one
@@ -667,11 +663,12 @@ fn capture_vm_full_inner(
         }
         Ok::<(), anyhow::Error>(())
     })();
-    let resumed = if control.retain_paused_after_capture() && captured.is_ok() {
-        Ok(())
-    } else {
-        control.resume()
-    };
+    let resumed =
+        if params.retain_paused && control.retain_paused_after_capture() && captured.is_ok() {
+            Ok(())
+        } else {
+            control.resume()
+        };
     captured?;
     resumed.context("resuming VM after vm_full capture")?;
 
@@ -867,19 +864,54 @@ pub trait VmFullRestore {
     ) -> Result<()>;
 }
 
+/// The same-identity restore mechanism for the VMM that produced `meta`.
+///
+/// Dispatch is on the machine-state blob the content manifest names, never on a
+/// stored backend label: the bytes a restore would load are what decides which
+/// VMM can load them, and a label can drift from them.
+pub fn vm_full_restorer_for(meta: &CheckpointMeta) -> Result<Box<dyn VmFullRestore>> {
+    match mvm_core::checkpoint::vm_full_origin(meta) {
+        Some(mvm_core::checkpoint::VmFullOrigin::Hvf) => {
+            Ok(Box::new(crate::hvf_restore::HvfVmFullRestore))
+        }
+        Some(mvm_core::checkpoint::VmFullOrigin::Firecracker) => anyhow::bail!(
+            "checkpoint '{}' was captured on Firecracker, which loads a saved machine state \
+             only into a fresh child identity; use `mvmctl machine warm-restore {}`",
+            meta.id,
+            meta.id
+        ),
+        Some(mvm_core::checkpoint::VmFullOrigin::Retired) => anyhow::bail!(
+            "checkpoint '{}' was captured under a backend that has been removed; nothing on \
+             this host can load its saved machine state",
+            meta.id
+        ),
+        None => anyhow::bail!(
+            "checkpoint '{}' names no saved machine state; there is nothing to restore",
+            meta.id
+        ),
+    }
+}
+
 pub struct RestoreParams {
     pub checkpoint: CheckpointId,
     /// Name of the VM to restore into (must match the supervisor-config shape).
     pub target_vm: String,
 }
 
-/// Resume a VM from a vm_full checkpoint (same identity). Verifies the manifest,
-/// then hands the three blob paths to the restore seam. Refusing fs_quick here is
-/// deliberate: fs_quick has no memory state, so `fork_checkpoint` is the right verb.
+/// Resume a VM from a vm_full checkpoint (same identity). Verifies the manifest
+/// AND the record's content-address against the signed audit chain, then hands
+/// the blob paths to the restore seam. Refusing fs_quick here is deliberate:
+/// fs_quick has no memory state, so `fork_checkpoint` is the right verb.
+///
+/// The chain check is the same fail-closed gate `fork_checkpoint` and
+/// [`fork_vm_full`] run, for the same reason: bringing a machine back to life is
+/// at least as consequential as branching from it, so a record edited after it
+/// was audited must not be restorable either.
 pub fn restore_checkpoint(
     store: &CheckpointStore,
     params: RestoreParams,
     restore: &dyn VmFullRestore,
+    anchor: &dyn CheckpointChainAnchor,
 ) -> Result<()> {
     let meta = store.read_meta(&params.checkpoint)?;
     if meta.class != CheckpointClass::VmFull {
@@ -890,6 +922,7 @@ pub fn restore_checkpoint(
         );
     }
     verify_content(store, &meta)?;
+    verify_checkpoint_against_chain(anchor, &meta)?;
     let dir = store.content_dir(&meta.id);
 
     // The checkpoint carries the launch config (for checkpoints captured after
@@ -1548,6 +1581,77 @@ mod tests {
         }
     }
 
+    /// A control that can hold its VM paused after a capture, as the HVF one
+    /// does for the warm pool.
+    struct RetainingControl(MockControl);
+    impl VmFullControl for RetainingControl {
+        fn pause(&self) -> Result<()> {
+            self.0.pause()
+        }
+        fn resume(&self) -> Result<()> {
+            self.0.resume()
+        }
+        fn save_memory(&self, memory_path: &Path) -> Result<()> {
+            self.0.save_memory(memory_path)
+        }
+        fn rootfs_path(&self) -> Result<PathBuf> {
+            self.0.rootfs_path()
+        }
+        fn device_anchors(&self) -> Result<DeviceAnchors> {
+            self.0.device_anchors()
+        }
+        fn retain_paused_after_capture(&self) -> bool {
+            true
+        }
+    }
+
+    fn capture_with_retention(retain_paused: bool) -> Vec<&'static str> {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let rootfs = tmp.path().join("live-rootfs.ext4");
+        std::fs::write(&rootfs, b"disk").unwrap();
+        let ctl = RetainingControl(MockControl {
+            rootfs,
+            events: RefCell::new(vec![]),
+        });
+        capture_vm_full(
+            &store,
+            CaptureVmFullParams {
+                id: CheckpointId::new("retain"),
+                vm_name: "vm".into(),
+                supervisor_config_digest: "d".into(),
+                runtime_source_policy: None,
+                runtime_overlay_version: None,
+                supervisor_config_src: None,
+                tag: None,
+                created_unix: 9,
+                retain_paused,
+            },
+            &ctl,
+        )
+        .unwrap();
+        let events = ctl.0.events.borrow().clone();
+        drop(ctl);
+        events
+    }
+
+    /// Retention takes both: a backend that can hold the pause AND a caller
+    /// that wants it. Only the warm pool wants it — for the pool the paused
+    /// parent is the claim resource. A user checkpointing their own running VM
+    /// must get it back running, so the CLI asks for no retention and the
+    /// capture resumes even on a retention-capable backend.
+    #[test]
+    fn capture_resumes_unless_the_caller_asks_for_retention() {
+        assert!(
+            capture_with_retention(false).contains(&"resume"),
+            "a caller that did not ask for retention must get its VM resumed"
+        );
+        assert!(
+            !capture_with_retention(true).contains(&"resume"),
+            "the warm pool keeps its captured parent paused"
+        );
+    }
+
     #[test]
     fn capture_vm_full_orders_pause_save_clone_resume_and_builds_triple() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1571,6 +1675,7 @@ mod tests {
                 supervisor_config_src: Some(config),
                 tag: None,
                 created_unix: 9,
+                retain_paused: false,
             },
             &ctl,
         )
@@ -1622,6 +1727,7 @@ mod tests {
                 supervisor_config_src: Some(config),
                 tag: None,
                 created_unix: 10,
+                retain_paused: false,
             },
             &ctl,
         )
@@ -1684,6 +1790,7 @@ mod tests {
                 supervisor_config_src: Some(config),
                 tag: None,
                 created_unix: 11,
+                retain_paused: false,
             },
             &ctl,
         )
@@ -1739,6 +1846,7 @@ mod tests {
                 supervisor_config_src: Some(config),
                 tag: None,
                 created_unix: 1,
+                retain_paused: false,
             },
             &ctl,
         )
@@ -1761,6 +1869,7 @@ mod tests {
                 target_vm: "origin".into(),
             },
             &restore,
+            &AgreeingAnchor,
         )
         .unwrap();
         let (vm, r, m, mid) = restore.seen.borrow().clone().unwrap();
@@ -1793,6 +1902,7 @@ mod tests {
                 target_vm: "origin".into(),
             },
             &restore,
+            &AgreeingAnchor,
         )
         .unwrap_err();
         assert!(
@@ -1820,6 +1930,7 @@ mod tests {
                 target_vm: "origin".into(),
             },
             &restore,
+            &AgreeingAnchor,
         )
         .unwrap_err();
         assert!(
@@ -2027,6 +2138,7 @@ mod tests {
                 supervisor_config_src: None,
                 tag: None,
                 created_unix: 1,
+                retain_paused: false,
             },
             &ctl,
         )
@@ -2087,6 +2199,7 @@ mod tests {
                 supervisor_config_src: None,
                 tag: None,
                 created_unix: 2,
+                retain_paused: false,
             },
             &ctl,
         )
@@ -2107,37 +2220,77 @@ mod tests {
         );
     }
 
-    // ── checkpoint_carries_supervisor_config ────────────────────────────────
+    // ── vm_full_origin ──────────────────────────────────────────────────────
 
+    use mvm_core::checkpoint::{VmFullOrigin, vm_full_origin};
+
+    /// A supervisor-config checkpoint with no recognizable machine-state blob
+    /// was captured by a backend that has since been removed: nothing on this
+    /// host can load it, so every consumer must refuse rather than guess.
     #[test]
-    fn supervisor_config_detected_when_the_blob_is_present() {
+    fn vm_full_origin_reports_retired_for_a_supervisor_config_only_checkpoint() {
         let tmp = tempfile::tempdir().unwrap();
         let store = CheckpointStore::at(tmp.path().join("store"));
-        let meta = seed_vm_full_checkpoint(&store, tmp.path(), "supcfg1");
-        assert!(
-            checkpoint_carries_supervisor_config(&meta),
-            "a supervisor-config-bearing checkpoint is detected by the blob"
-        );
+        let meta = seed_vm_full_checkpoint(&store, tmp.path(), "supcfg-only");
+        assert_eq!(vm_full_origin(&meta), Some(VmFullOrigin::Retired));
     }
 
     #[test]
-    fn supervisor_config_absent_for_fc_checkpoint() {
+    fn vm_full_origin_reports_firecracker_for_a_vmstate_checkpoint() {
         let tmp = tempfile::tempdir().unwrap();
         let store = CheckpointStore::at(tmp.path().join("store"));
         let meta = seed_fc_vm_full_checkpoint(&store, tmp.path(), "fc1");
-        assert!(
-            !checkpoint_carries_supervisor_config(&meta),
-            "FC checkpoint has no supervisor-config.json blob"
-        );
+        assert_eq!(vm_full_origin(&meta), Some(VmFullOrigin::Firecracker));
+    }
+
+    /// The HVF frame wins over a supervisor-config blob: an HVF checkpoint
+    /// carries both, and the machine-state blob is what decides who can load it.
+    #[test]
+    fn vm_full_origin_reports_hvf_when_the_frame_blob_is_present() {
+        let mut meta =
+            CheckpointMeta::builder(CheckpointId::new("hvf1"), CheckpointClass::VmFull, "hvf-vm")
+                .content(vec![
+                    ContentBlob {
+                        name: mvm_core::checkpoint::MEMORY_BLOB.into(),
+                        sha256: "a".into(),
+                    },
+                    ContentBlob {
+                        name: mvm_core::checkpoint::SUPERVISOR_CONFIG_BLOB.into(),
+                        sha256: "b".into(),
+                    },
+                    ContentBlob {
+                        name: mvm_core::checkpoint::HVF_FRAME_BLOB.into(),
+                        sha256: "c".into(),
+                    },
+                ])
+                .build();
+        assert_eq!(vm_full_origin(&meta), Some(VmFullOrigin::Hvf));
+        // Strip the frame and the same record reads as the retired backend's.
+        meta.content
+            .retain(|b| b.name != mvm_core::checkpoint::HVF_FRAME_BLOB);
+        assert_eq!(vm_full_origin(&meta), Some(VmFullOrigin::Retired));
+    }
+
+    /// An fs_quick manifest names no machine state at all.
+    #[test]
+    fn vm_full_origin_is_none_without_any_machine_state_blob() {
+        let meta =
+            CheckpointMeta::builder(CheckpointId::new("fsq"), CheckpointClass::FsQuick, "vm")
+                .content(vec![ContentBlob {
+                    name: mvm_core::checkpoint::ROOTFS_BLOB.into(),
+                    sha256: "a".into(),
+                }])
+                .build();
+        assert_eq!(vm_full_origin(&meta), None);
     }
 
     #[test]
-    fn fork_vm_full_fc_rejects_parent_identity_collisions() {
+    fn fork_vm_full_rejects_parent_identity_collisions() {
         let tmp = tempfile::tempdir().unwrap();
         let store = CheckpointStore::at(tmp.path().join("store"));
         let parent = seed_fc_vm_full_checkpoint(&store, tmp.path(), "fc-identity-parent");
 
-        let same_checkpoint = fork_vm_full_fc(
+        let same_checkpoint = fork_vm_full(
             &store,
             ForkParams {
                 checkpoint: parent.id.clone(),
@@ -2154,7 +2307,7 @@ mod tests {
         .unwrap_err();
         assert!(same_checkpoint.to_string().contains("child checkpoint id"));
 
-        let same_vm = fork_vm_full_fc(
+        let same_vm = fork_vm_full(
             &store,
             ForkParams {
                 checkpoint: parent.id.clone(),
@@ -2172,30 +2325,39 @@ mod tests {
         assert!(same_vm.to_string().contains("child VM name"));
     }
 
-    /// Every workload backend's marker counts, not just Firecracker's. This
-    /// probe gates the refuse-to-fork-a-live-parent rule, so a backend whose
-    /// marker went unrecognised would read as stopped and let a fork proceed
-    /// against a running VM.
+    /// Every registered backend's marker counts, not a hand-kept subset. The
+    /// probe reads one shared marker list, so this test drives it from the
+    /// backend catalog instead: a backend that grows a pid file but never
+    /// reaches that list goes red here rather than silently reading as stopped.
+    /// That matters because this probe gates the refuse-to-fork-a-live-parent
+    /// rule — an unrecognised marker lets a fork proceed against a running VM.
+    /// A marker no registered backend owns is, conversely, not liveness.
     #[test]
-    fn vm_is_running_detects_every_workload_backend_pid_marker() {
+    fn vm_is_running_covers_every_catalog_pid_marker() {
         let tmp = tempfile::tempdir().unwrap();
         let mut env = mvm_core::util::test_env::TestEnv::new();
         env.set("MVM_HOME", tmp.path());
         let state = mvm_core::config::vm_state_dir("pid-check");
         std::fs::create_dir_all(&state).unwrap();
 
-        for marker in ["fc.pid", "hvf.pid", "libkrun.pid", "qemu.pid"] {
+        let markers: Vec<&str> = crate::catalog::started_vm_probe_descriptors()
+            .into_iter()
+            .filter_map(|descriptor| descriptor.marker_file)
+            .collect();
+        assert!(
+            markers.contains(&"hvf.pid") && markers.contains(&"fc.pid"),
+            "the catalog must expose the HVF and Firecracker markers: {markers:?}"
+        );
+        for marker in &markers {
             std::fs::write(state.join(marker), std::process::id().to_string()).unwrap();
-            assert!(
-                vm_is_running("pid-check"),
-                "{marker} must read as a live parent"
-            );
+            assert!(vm_is_running("pid-check"), "{marker} must read as live");
             std::fs::remove_file(state.join(marker)).unwrap();
         }
 
+        std::fs::write(state.join("retired.pid"), std::process::id().to_string()).unwrap();
         assert!(
             !vm_is_running("pid-check"),
-            "no marker left means the VM is stopped"
+            "a marker no registered backend owns is not liveness"
         );
     }
 
@@ -2267,6 +2429,7 @@ mod tests {
                 supervisor_config_src: None,
                 tag: None,
                 created_unix: 1,
+                retain_paused: false,
             },
             &ctl,
         )
@@ -2303,7 +2466,7 @@ mod tests {
     }
 
     #[test]
-    fn fork_vm_full_fc_clones_triple_and_records_lineage() {
+    fn fork_vm_full_clones_triple_and_records_lineage() {
         let tmp = tempfile::tempdir().unwrap();
         let store = CheckpointStore::at(tmp.path().join("store"));
         let parent = seed_fc_vm_full_checkpoint(&store, tmp.path(), "fcv1");
@@ -2311,7 +2474,7 @@ mod tests {
 
         let dest = tmp.path().join("childvm-state");
         let restorer = RecordedRestore::default();
-        let child = fork_vm_full_fc(
+        let child = fork_vm_full(
             &store,
             ForkParams {
                 checkpoint: parent.id.clone(),
@@ -2347,12 +2510,12 @@ mod tests {
     }
 
     #[test]
-    fn fork_vm_full_fc_refuses_missing_child_admission() {
+    fn fork_vm_full_refuses_missing_child_admission() {
         let tmp = tempfile::tempdir().unwrap();
         let store = CheckpointStore::at(tmp.path().join("store"));
         let parent = seed_fc_vm_full_checkpoint(&store, tmp.path(), "fcv-missing-plan");
         let restorer = RecordedRestore::default();
-        let err = fork_vm_full_fc(
+        let err = fork_vm_full(
             &store,
             ForkParams {
                 checkpoint: parent.id,
@@ -2415,12 +2578,12 @@ mod tests {
     }
 
     #[test]
-    fn fork_vm_full_fc_refuses_fs_quick() {
+    fn fork_vm_full_refuses_fs_quick() {
         let tmp = tempfile::tempdir().unwrap();
         let store = CheckpointStore::at(tmp.path().join("store"));
         let fsq = seed_fs_quick_checkpoint(&store, tmp.path(), "fcp1");
         let restorer = RecordedRestore::default();
-        let err = fork_vm_full_fc(
+        let err = fork_vm_full(
             &store,
             ForkParams {
                 checkpoint: fsq.id.clone(),

--- a/crates/mvm-runtime/src/hvf_restore.rs
+++ b/crates/mvm-runtime/src/hvf_restore.rs
@@ -1,0 +1,141 @@
+//! The HVF end of the checkpoint restore seams.
+//!
+//! Both seams the checkpoint orchestration owns —
+//! the [`ForkRestore`](crate::checkpoint::ForkRestore) callback for a fork into
+//! a fresh identity and [`VmFullRestore`](crate::checkpoint::VmFullRestore) for
+//! a same-identity resume — reduce to one operation on HVF: start a supervisor
+//! that maps the saved RAM privately and restores the captured vCPU and device
+//! frame. The mechanics live one layer down in
+//! [`mvm_backends::driver::hvf_restore`]; this module is the thin adapter that
+//! keeps the checkpoint layer free of supervisor-config knowledge.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use mvm_backends::driver::hvf_restore::restore_hvf_vm;
+
+pub use mvm_backends::driver::hvf_restore::{
+    HvfRestoreRequest, RestoredHvfVm, hvf_child_restore_config,
+};
+
+/// Boots a forked child from an HVF checkpoint cloned into its state dir.
+///
+/// An inherent method rather than a trait impl, matching `FcForkRestorer`: the
+/// fork walk takes a [`crate::checkpoint::ForkRestore`] callback, so the two
+/// VMMs need no shared trait and neither has to be named where the other is.
+pub struct HvfForkRestorer;
+
+impl HvfForkRestorer {
+    pub fn restore_fork(&self, child_vm_name: &str, child_dir: &Path) -> Result<()> {
+        restore_hvf_vm(&HvfRestoreRequest {
+            vm_name: child_vm_name,
+            state_dir: child_dir,
+        })
+        .with_context(|| format!("HVF warm-restore for forked child '{child_vm_name}'"))?;
+        Ok(())
+    }
+}
+
+/// Resumes a VM under its own identity from an HVF vm_full checkpoint.
+pub struct HvfVmFullRestore;
+
+impl crate::checkpoint::VmFullRestore for HvfVmFullRestore {
+    /// The path arguments describe the checkpoint's content dir, which is
+    /// immutable; a restore must never boot a VMM against it, because a
+    /// resumed guest writes through to its rootfs and would corrupt the sealed
+    /// bytes every later fork of this checkpoint depends on. Instead the whole
+    /// content dir is cloned into the target's state dir and the VM boots from
+    /// that copy — the same "child boots its OWN copies" rule a fork follows.
+    fn restore(
+        &self,
+        target_vm: &str,
+        rootfs_src: &Path,
+        _memory: &Path,
+        _machine_id: &Path,
+        _config_src: Option<&Path>,
+    ) -> Result<()> {
+        let content_dir = rootfs_src
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("checkpoint rootfs path has no content directory"))?;
+        let state_dir = mvm_core::config::vm_state_dir(target_vm);
+        std::fs::create_dir_all(&state_dir)
+            .with_context(|| format!("creating {}", state_dir.display()))?;
+        clone_content_into(content_dir, &state_dir)?;
+        restore_hvf_vm(&HvfRestoreRequest {
+            vm_name: target_vm,
+            state_dir: &state_dir,
+        })
+        .with_context(|| format!("HVF restore of '{target_vm}'"))?;
+        Ok(())
+    }
+}
+
+/// Copy-on-write clone every file in a checkpoint's content dir into `dst`.
+fn clone_content_into(content_dir: &Path, dst: &Path) -> Result<()> {
+    let entries = std::fs::read_dir(content_dir)
+        .with_context(|| format!("reading checkpoint content {}", content_dir.display()))?;
+    for entry in entries {
+        let entry = entry.with_context(|| format!("reading {}", content_dir.display()))?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        crate::base::cow::clone_rootfs_for_instance(&entry.path(), &dst.join(&name))
+            .with_context(|| format!("cloning checkpoint blob {}", name.to_string_lossy()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checkpoint::VmFullRestore as _;
+
+    #[test]
+    fn clone_content_copies_every_blob_and_skips_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("content");
+        let dst = tmp.path().join("state");
+        std::fs::create_dir_all(src.join("nested")).unwrap();
+        std::fs::create_dir_all(&dst).unwrap();
+        std::fs::write(src.join("memory.bin"), b"ram").unwrap();
+        std::fs::write(src.join("rootfs.ext4"), b"root").unwrap();
+
+        clone_content_into(&src, &dst).unwrap();
+
+        assert_eq!(std::fs::read(dst.join("memory.bin")).unwrap(), b"ram");
+        assert_eq!(std::fs::read(dst.join("rootfs.ext4")).unwrap(), b"root");
+        assert!(!dst.join("nested").exists(), "directories are not cloned");
+    }
+
+    /// A restore must never point a VMM at the sealed checkpoint content: the
+    /// resumed guest writes through to its rootfs, and the bytes under
+    /// `content/` are what every later fork of this checkpoint verifies
+    /// against. The refusal here is structural — the restore always clones
+    /// first — so the assertion is that a content dir with no saved state
+    /// fails before any process is spawned.
+    #[test]
+    fn restore_refuses_before_spawning_when_the_checkpoint_has_no_saved_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.isolate_mvm_home(tmp.path());
+        let content = tmp.path().join("content");
+        std::fs::create_dir_all(&content).unwrap();
+        std::fs::write(content.join("rootfs.ext4"), b"root").unwrap();
+
+        let error = HvfVmFullRestore
+            .restore(
+                "hvf-restore-missing-state-vm",
+                &content.join("rootfs.ext4"),
+                &content.join("memory.bin"),
+                &content.join("machine-id"),
+                None,
+            )
+            .unwrap_err();
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("launch config"),
+            "expected the missing launch-config refusal, got: {rendered}"
+        );
+    }
+}

--- a/crates/mvm-runtime/src/lib.rs
+++ b/crates/mvm-runtime/src/lib.rs
@@ -59,6 +59,10 @@ pub mod driver;
 // `mvm_runtime::firecracker::<name>` keeps resolving for mvm-cli.
 pub use mvm_backends::fc::host as firecracker;
 pub mod handle_registry;
+/// The HVF end of the checkpoint restore seams (fork into a fresh identity,
+/// same-identity resume) — the counterpart of the capture control the HVF
+/// driver hands back through `vm_full_control`.
+pub mod hvf_restore;
 pub mod image;
 /// Content-addressed image version-lineage store + chain-anchored verification
 /// (the image analog of [`checkpoint`]). Reuses the shared `lineage` walk.

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -27,7 +27,7 @@ use mvm_core::vm_backend::{
 use mvm_fs::snapshot_store::{FsSnapshotStore, SnapshotStore};
 
 use crate::checkpoint::{
-    CaptureVmFullParams, CheckpointChainAnchor, CheckpointStore,
+    CaptureVmFullParams, CheckpointChainAnchor, CheckpointStore, VmFullControl,
     capture_vm_full_with_snapshot_store, capture_vm_full_with_trusted_snapshot_backend,
     verify_content, verify_lineage,
 };
@@ -58,7 +58,10 @@ use mvm_vmm::host::substitution_spawn::{
 use mvm_vmm::post_restore::PostRestoreOutcome;
 
 mod backend;
+mod refusal;
 mod warm_claim;
+
+use refusal::{map_lineage_refusal, refuse, require_fresh_child_identity};
 
 /// What the workload runner needs to stand up the per-VM gating endpoint.
 pub struct EndpointSpawnRequest<'a> {
@@ -437,6 +440,14 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
     #[must_use]
     pub fn supports_preloaded_standby(&self) -> bool {
         self.driver.supports_preloaded_standby()
+    }
+
+    /// Pause/save-memory/resume control over a running VM this runner's VMM
+    /// owns — what a checkpoint capture drives. `None` when the VMM has no
+    /// memory-capture mechanics to offer.
+    #[must_use]
+    pub fn vm_full_control(&self, vm_name: &str) -> Option<Box<dyn VmFullControl>> {
+        self.driver.vm_full_control(vm_name)
     }
 
     /// Spawn the optional gating endpoint, compose the spec, and boot. A
@@ -895,6 +906,7 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
             })?,
             tag: None,
             created_unix: mvm_core::time::now_unix_secs(),
+            retain_paused: true,
         };
         let trusted_backend = if cfg!(all(feature = "trusted-apfs", target_os = "macos"))
             && std::env::var("MVM_HVF_ENABLE_TRUSTED_SNAPSHOT").as_deref() == Ok("1")
@@ -1132,60 +1144,6 @@ impl Drop for WarmClaimLease<'_> {
                 ),
             }
         }
-    }
-}
-
-/// Judge a forked child's own report of what it did with its fresh generation
-/// token. Every flag must hold: `acknowledged` says the guest answered at all,
-/// `reseeded` says it rotated its generation identity (and so reseeded the CSPRNG
-/// it inherited from the parent's memory image), and `clock_resynced` says it
-/// took the host's wall clock instead of the parent's frozen one.
-///
-/// Pure, so the fail-closed verdict is unit-tested on its own. Any false flag is
-/// a refusal rather than a warning: a restored child that cannot prove it left
-/// the parent's random state behind is indistinguishable from a sibling that
-/// will produce the same "random" values, which is precisely what a fresh
-/// identity exists to rule out.
-fn require_fresh_child_identity(
-    child_vm_name: &str,
-    outcome: &PostRestoreOutcome,
-) -> std::result::Result<(), StandbyError> {
-    let unproven = if !outcome.acknowledged {
-        "did not acknowledge the post-restore signal"
-    } else if !outcome.reseeded {
-        "acknowledged without rotating its generation identity"
-    } else if !outcome.clock_resynced {
-        "acknowledged without resynchronizing its wall clock"
-    } else {
-        return Ok(());
-    };
-    Err(StandbyError::ClaimFailed(format!(
-        "forked child '{child_vm_name}' {unproven}; refusing to admit a child that cannot prove \
-         it left its parent's random state and clock behind"
-    )))
-}
-
-/// Map a fail-closed [`ClaimRefusal`] onto the transport-agnostic
-/// [`StandbyError`] the claim seam returns. The refusal reasons stay distinct in
-/// the message so a caller can tell an un-audited parent from a plan mismatch.
-fn refuse(refusal: ClaimRefusal) -> StandbyError {
-    StandbyError::ClaimFailed(refusal.to_string())
-}
-
-/// Distinguish the three fail-closed reasons by the lineage verifier's own
-/// message, so the caller sees the specific one: a parent with no signed
-/// creation entry, a ledger too damaged to say either way, or a parent that
-/// drifted from its sealed content. The unverifiable-ledger arm must come first
-/// — it is the case that used to be reported as un-audited, which sent the
-/// operator to re-capture a parent when the real finding was a broken chain.
-fn map_lineage_refusal(err: &anyhow::Error) -> ClaimRefusal {
-    let msg = err.to_string();
-    if msg.contains(crate::lineage::LEDGER_UNVERIFIABLE) {
-        ClaimRefusal::LedgerUnverifiable
-    } else if msg.contains(crate::lineage::NO_SIGNED_ENTRY) {
-        ClaimRefusal::ParentUnaudited
-    } else {
-        ClaimRefusal::ParentTampered
     }
 }
 
@@ -4311,44 +4269,6 @@ mod tests {
         );
     }
 
-    /// The verdict itself, without a claim around it: every flag is required, and
-    /// the refusal names which one the guest failed to prove.
-    #[test]
-    fn fresh_child_identity_requires_every_flag() {
-        let proven = PostRestoreOutcome {
-            acknowledged: true,
-            detail: None,
-            reseeded: true,
-            clock_resynced: true,
-        };
-        assert!(require_fresh_child_identity("vm-a", &proven).is_ok());
-
-        for (mutate, expected) in [
-            (
-                (|o: &mut PostRestoreOutcome| o.acknowledged = false)
-                    as fn(&mut PostRestoreOutcome),
-                "did not acknowledge",
-            ),
-            (
-                |o: &mut PostRestoreOutcome| o.reseeded = false,
-                "without rotating its generation identity",
-            ),
-            (
-                |o: &mut PostRestoreOutcome| o.clock_resynced = false,
-                "without resynchronizing its wall clock",
-            ),
-        ] {
-            let mut outcome = proven.clone();
-            mutate(&mut outcome);
-            let err = require_fresh_child_identity("vm-a", &outcome)
-                .expect_err("a false flag must refuse");
-            assert!(
-                err.to_string().contains(expected),
-                "refusal must name the unproven flag ({expected}): {err}"
-            );
-        }
-    }
-
     /// A post-materialize failure (here: the overlay-contract gate refusing a
     /// child whose clone carries no overlay sidecar) must return the healthy
     /// reserved parent to claimable and remove the orphaned child dir — no leaked
@@ -4488,39 +4408,6 @@ mod tests {
             "no child dir on a quarantine refusal"
         );
         assert!(runner.driver.forked_children().is_empty());
-    }
-
-    /// The three fail-closed reasons must stay distinguishable, and the
-    /// unverifiable-ledger one must not collapse into either neighbour. It used
-    /// to be reported as un-audited, which sends the operator to re-capture a
-    /// parent when the real finding is a damaged chain; falling through to
-    /// tampered would be the opposite error, blaming a parent that may be fine.
-    #[test]
-    fn lineage_refusals_separate_an_unreadable_ledger_from_unaudited_and_tampered() {
-        let unreadable = anyhow::anyhow!(
-            "{}: 1 audit chain(s) unverifiable: /audit-root/local.jsonl",
-            crate::lineage::LEDGER_UNVERIFIABLE
-        );
-        assert!(matches!(
-            map_lineage_refusal(&unreadable),
-            ClaimRefusal::LedgerUnverifiable
-        ));
-
-        let unaudited = anyhow::anyhow!(
-            "checkpoint 'cp-1' has {} to anchor its content-address",
-            crate::lineage::NO_SIGNED_ENTRY
-        );
-        assert!(matches!(
-            map_lineage_refusal(&unaudited),
-            ClaimRefusal::ParentUnaudited
-        ));
-
-        let tampered =
-            anyhow::anyhow!("checkpoint 'cp-1' meta_digest drift: stored abc, recomputed def");
-        assert!(matches!(
-            map_lineage_refusal(&tampered),
-            ClaimRefusal::ParentTampered
-        ));
     }
 
     /// A plan whose bound image digest does not match the parent's own verified

--- a/crates/mvm-runtime/src/workload_runner/runner/refusal.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner/refusal.rs
@@ -1,0 +1,138 @@
+//! Fail-closed verdicts a claim renders on a forked child and its parent.
+//!
+//! Three pure judgements, kept together and out of the runner body because they
+//! share one property: each turns evidence into a *refusal reason*, and the
+//! reason is the whole product. A claim that refuses for the wrong stated reason
+//! sends an operator to fix something that is not broken, so these are unit
+//! tested on their own rather than only through a claim.
+
+use super::{ClaimRefusal, PostRestoreOutcome, StandbyError};
+
+/// Judge a forked child's own report of what it did with its fresh generation
+/// token. Every flag must hold: `acknowledged` says the guest answered at all,
+/// `reseeded` says it rotated its generation identity (and so reseeded the CSPRNG
+/// it inherited from the parent's memory image), and `clock_resynced` says it
+/// took the host's wall clock instead of the parent's frozen one.
+///
+/// Any false flag is a refusal rather than a warning: a restored child that
+/// cannot prove it left the parent's random state behind is indistinguishable
+/// from a sibling that will produce the same "random" values, which is precisely
+/// what a fresh identity exists to rule out.
+pub(super) fn require_fresh_child_identity(
+    child_vm_name: &str,
+    outcome: &PostRestoreOutcome,
+) -> std::result::Result<(), StandbyError> {
+    let unproven = if !outcome.acknowledged {
+        "did not acknowledge the post-restore signal"
+    } else if !outcome.reseeded {
+        "acknowledged without rotating its generation identity"
+    } else if !outcome.clock_resynced {
+        "acknowledged without resynchronizing its wall clock"
+    } else {
+        return Ok(());
+    };
+    Err(StandbyError::ClaimFailed(format!(
+        "forked child '{child_vm_name}' {unproven}; refusing to admit a child that cannot prove \
+         it left its parent's random state and clock behind"
+    )))
+}
+
+/// Map a fail-closed [`ClaimRefusal`] onto the transport-agnostic
+/// [`StandbyError`] the claim seam returns. The refusal reasons stay distinct in
+/// the message so a caller can tell an un-audited parent from a plan mismatch.
+pub(super) fn refuse(refusal: ClaimRefusal) -> StandbyError {
+    StandbyError::ClaimFailed(refusal.to_string())
+}
+
+/// Distinguish the three fail-closed reasons by the lineage verifier's own
+/// message, so the caller sees the specific one: a parent with no signed
+/// creation entry, a ledger too damaged to say either way, or a parent that
+/// drifted from its sealed content. The unverifiable-ledger arm must come first
+/// — it is the case that used to be reported as un-audited, which sent the
+/// operator to re-capture a parent when the real finding was a broken chain.
+pub(super) fn map_lineage_refusal(err: &anyhow::Error) -> ClaimRefusal {
+    let msg = err.to_string();
+    if msg.contains(crate::lineage::LEDGER_UNVERIFIABLE) {
+        ClaimRefusal::LedgerUnverifiable
+    } else if msg.contains(crate::lineage::NO_SIGNED_ENTRY) {
+        ClaimRefusal::ParentUnaudited
+    } else {
+        ClaimRefusal::ParentTampered
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The verdict itself, without a claim around it: every flag is required, and
+    /// the refusal names which one the guest failed to prove.
+    #[test]
+    fn fresh_child_identity_requires_every_flag() {
+        let proven = PostRestoreOutcome {
+            acknowledged: true,
+            detail: None,
+            reseeded: true,
+            clock_resynced: true,
+        };
+        assert!(require_fresh_child_identity("vm-a", &proven).is_ok());
+
+        for (mutate, expected) in [
+            (
+                (|o: &mut PostRestoreOutcome| o.acknowledged = false)
+                    as fn(&mut PostRestoreOutcome),
+                "did not acknowledge",
+            ),
+            (
+                |o: &mut PostRestoreOutcome| o.reseeded = false,
+                "without rotating its generation identity",
+            ),
+            (
+                |o: &mut PostRestoreOutcome| o.clock_resynced = false,
+                "without resynchronizing its wall clock",
+            ),
+        ] {
+            let mut outcome = proven.clone();
+            mutate(&mut outcome);
+            let err = require_fresh_child_identity("vm-a", &outcome)
+                .expect_err("a false flag must refuse");
+            assert!(
+                err.to_string().contains(expected),
+                "refusal must name the unproven flag ({expected}): {err}"
+            );
+        }
+    }
+
+    /// The three fail-closed reasons must stay distinguishable, and the
+    /// unverifiable-ledger one must not collapse into either neighbour. It used
+    /// to be reported as un-audited, which sends the operator to re-capture a
+    /// parent when the real finding is a damaged chain; falling through to
+    /// tampered would be the opposite error, blaming a parent that may be fine.
+    #[test]
+    fn lineage_refusals_separate_an_unreadable_ledger_from_unaudited_and_tampered() {
+        let unreadable = anyhow::anyhow!(
+            "{}: 1 audit chain(s) unverifiable: /audit-root/local.jsonl",
+            crate::lineage::LEDGER_UNVERIFIABLE
+        );
+        assert!(matches!(
+            map_lineage_refusal(&unreadable),
+            ClaimRefusal::LedgerUnverifiable
+        ));
+
+        let unaudited = anyhow::anyhow!(
+            "checkpoint 'cp-1' has {} to anchor its content-address",
+            crate::lineage::NO_SIGNED_ENTRY
+        );
+        assert!(matches!(
+            map_lineage_refusal(&unaudited),
+            ClaimRefusal::ParentUnaudited
+        ));
+
+        let tampered =
+            anyhow::anyhow!("checkpoint 'cp-1' meta_digest drift: stored abc, recomputed def");
+        assert!(matches!(
+            map_lineage_refusal(&tampered),
+            ClaimRefusal::ParentTampered
+        ));
+    }
+}

--- a/crates/mvm-runtime/tests/fc_warm_pool_live.rs
+++ b/crates/mvm-runtime/tests/fc_warm_pool_live.rs
@@ -225,6 +225,7 @@ fn fc_warm_pool_spawn_and_claim() {
             supervisor_config_src: None,
             tag: None,
             created_unix: mvm_core::time::now_unix_secs(),
+            retain_paused: false,
         },
         control.as_ref(),
     )

--- a/features/suites/s11_snapshot/hvf_save_restore.feature
+++ b/features/suites/s11_snapshot/hvf_save_restore.feature
@@ -1,0 +1,38 @@
+Feature: HVF save/restore for checkpoint and fork
+
+  The in-house HVF VMM can freeze a running machine into a checkpoint and bring
+  one back — as a same-identity restore or as a fresh forked child. A checkpoint
+  is a lineage record that later admissions trust, so the properties that matter
+  are not "does it boot" but "what does it refuse, and what does the restored
+  machine come up holding".
+
+  Scenario: a restored HVF machine holds no path off the box
+    Given a captured HVF launch config carrying an egress relay, a broker and a console socket
+    When the captured config is rewritten for a restored child
+    Then the restored config carries no egress relay, broker or console socket
+    And the restored config carries no live-handoff control socket
+    And the restored config loads the saved machine state instead of booting a kernel
+
+  Scenario: a restored HVF machine never shares its parent's identity or files
+    Given a captured HVF launch config whose per-VM paths all point at the parent
+    When the captured config is rewritten for a restored child
+    Then every per-VM path in the restored config points at the child's own state directory
+    And the restored config reads its rootfs from the child's own clone
+
+  Scenario: an HVF checkpoint edited after it was audited cannot be restored
+    Given an audited HVF vm_full checkpoint
+    When the sealed record is edited after it was audited
+    Then restoring the checkpoint is refused before the VMM is started
+
+  Scenario: an HVF checkpoint that was never audited cannot be restored
+    Given an HVF vm_full checkpoint that no signed audit entry covers
+    Then restoring the checkpoint is refused before the VMM is started
+
+  Scenario: a checkpoint from a removed backend is refused rather than guessed
+    Given a vm_full checkpoint carrying a launch config but no machine-state blob
+    Then its origin is reported as a removed backend
+    And restoring the checkpoint is refused before the VMM is started
+
+  Scenario: an HVF checkpoint is classified by the machine state it carries
+    Given an audited HVF vm_full checkpoint
+    Then its origin is reported as the in-house HVF VMM

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -34,6 +34,21 @@ for detailed scope and acceptance criteria.
         `continue-on-error`). 511 tests, no UB, ~4m25s with `merkle::` skipped
         — those sweeps ran past 30 min under the interpreter. Widening to
         `mvm-core` crypto and the `mvm-fs` ext4 writer deferred
+- [x] HVF save/restore for checkpoint and fork — **plan 304**, branch
+      `feat/hvf-save-restore`
+  - [x] Audit `HvfVmFullControl` against the whole `VmFullControl` surface and
+        add the writable-disk capture refusal
+  - [x] Restore entry point: the launch-config rewrite in `mvm-backends`, and
+        the `ForkRestore` callback / `VmFullRestore` adapters in `mvm-runtime`
+  - [x] Backend-neutral dispatch: `AnyBackend::vm_full_control`, one shared
+        liveness marker list held to the backend catalog by test,
+        `vm_full_origin` replacing the supervisor-config fork predicate,
+        `fork_vm_full_fc` → `fork_vm_full`
+  - [x] Flip `snapshot_capability` to `SaveRestore` and update the pinned tests
+  - [x] Chain-anchor the restore path; keep `capture_fs_quick` and the verity
+        binding untouched; fresh child identity on every fork
+  - [x] BDD suite `s11_snapshot/hvf_save_restore.feature` + benchmark evidence
+
 - [~] eBPF vsock egress telemetry spike — **issue #2211**, branch
       `feat/ebpf-vsock-egress-telemetry`
   - [x] Remove the standalone `mvm-ebpf-egress` crate; fold the Aya loader

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -31,6 +31,22 @@
       `mvm-core::config` and one predicate serves all three sweeps. 14 new
       tests, all against a synthesized and deliberately damaged chain in a temp
       `MVM_HOME`.
+- [x] HVF save/restore for checkpoint and fork — **plan 304**. The HVF backend
+      now advertises `SnapshotCapability::SaveRestore`, and
+      `machine checkpoint create --class vm-full`, `checkpoint restore`, and
+      `checkpoint fork` work on it end to end. Capture dispatches through the
+      backend that owns the VM (`AnyBackend::vm_full_control`) instead of a
+      hardcoded Firecracker control; the fork-liveness probe reads the shared
+      marker list so `hvf.pid` counts, held to the backend catalog by
+      `vm_is_running_covers_every_catalog_pid_marker`; the checkpoint origin is
+      classified from the machine-state blob (`vm_full_origin`) rather than from
+      the supervisor-config blob, which every HVF checkpoint also carries and so
+      would have misread all of them. Restore
+      now runs the signed-chain lineage gate — previously it verified content
+      hashes only. A capture is refused when the VM has a writable disk, since
+      a snapshot carries no device backing bytes. 6 new BDD scenarios under
+      `features/suites/s11_snapshot/hvf_save_restore.feature`; workspace
+      nextest 10600 passed / 24 skipped.
 
 - [~] Open issue closeout — **plan 300**. The 22 open issues were reconciled
       on 2026-08-08 into explicit closure gates and dependency order in

--- a/specs/plans/304-hvf-save-restore-bench.md
+++ b/specs/plans/304-hvf-save-restore-bench.md
@@ -1,0 +1,88 @@
+# Plan 304 — HVF save/restore benchmark evidence
+
+Measured 2026-08-08 on macOS 26.5.2 (Darwin 25.5.2), Apple silicon, against a
+release `mvmctl` plus release `mvm-hostd` binaries (`mvm-host-agent`,
+`mvm-broker`, `mvm-host-signer`, `mvm-audit-signer`,
+`mvm-substitution-endpoint`, `mvm-netd`, `mvm-signer-helper`,
+`mvm-hvf-supervisor`) — a missing `mvm-host-agent` silently loses
+`host.audit.v1` and adds ~700 ms, so every number below is from a fully built
+tree.
+
+Subject: a persistent HVF workload, `machine run --image alpine --name
+hvf-ckpt-demo -d`. 512 MiB guest RAM; sealed rootfs (dm-verity) plus the
+runtime overlay — four read-only, file-served virtio-blk devices, which is the
+restorable disk shape.
+
+## `machine checkpoint create --class vm-full` (5 runs)
+
+| run | ms |
+|-----|------|
+| 1 | 1742.4 |
+| 2 | 1631.0 |
+| 3 | 1526.5 |
+| 4 | 1849.3 |
+| 5 | 1635.2 |
+
+**p50 1635 ms, min 1527 ms, max 1849 ms.**
+
+The window is dominated by two 512 MiB writes: `snapshot.ram` and the frame,
+which carries its own copy of RAM. It is I/O-bound in guest-RAM size, not in
+guest complexity. The source VM is running again when the command returns —
+verified by the absence of `pause.state` after each capture.
+
+## `machine checkpoint restore` (3 runs)
+
+| run | ms |
+|-----|------|
+| 1 | 689.5 |
+| 2 | 691.5 |
+| 3 | 684.0 |
+
+**p50 690 ms, min 684 ms, max 692 ms.**
+
+Includes cloning the whole checkpoint content dir into a fresh state directory
+(APFS copy-on-write), rewriting the launch config, spawning
+`mvm-hvf-supervisor`, mapping the saved RAM `MAP_PRIVATE` off the clone,
+restoring the vCPU and device frame, and waiting for the supervisor to publish
+its pid. Notably flat across runs — the private mapping is lazy, so the restore
+does not read 512 MiB before the guest runs.
+
+## What this is not
+
+**Restore is not the warm-launch path, and this work does not change warm-launch
+latency.** HVF's fast launch is resident handoff: a live, paused standby parent
+handed to a child identity in place, measured at 18.9 ms p50 dispatch on this
+machine. A checkpoint restore is ~36× that, and structurally must be — it starts
+a new VMM against bytes on disk, where a handoff transfers a process that is
+already running and never leaves memory.
+
+The two answer different questions. Handoff answers "start this workload now".
+A checkpoint answers "put this exact machine, with this exact memory, back —
+tomorrow, on a different boot of the host, with a signed record of where it came
+from". Plan 255's fork lineage needs the second and cannot be built on the first.
+
+## Reproducing
+
+```sh
+cargo build --release --bin mvmctl
+cargo build --release -p mvm-hostd --bin mvm-hvf-supervisor --bin mvm-host-agent \
+  --bin mvm-broker --bin mvm-host-signer --bin mvm-audit-signer \
+  --bin mvm-substitution-endpoint --bin mvm-netd --bin mvm-signer-helper
+
+./target/release/mvmctl machine run --image alpine --name hvf-ckpt-demo -d
+./target/release/mvmctl machine checkpoint create --class vm-full hvf-ckpt-demo --json
+./target/release/mvmctl machine stop hvf-ckpt-demo --yes
+./target/release/mvmctl machine checkpoint restore <id>
+```
+
+## One environmental caveat, recorded because it is easy to misread
+
+On a long-lived developer `~/.mvm`, `mvmctl trust audit verify` may already fail
+(`malformed envelope at line 3` on this machine, from accumulated dev history).
+`SignedChainAnchor::load` refuses to anchor anything from a chain it cannot
+verify, so on such a host **every** checkpoint reads as un-audited and both
+`checkpoint verify` and `checkpoint restore` fail closed — which is the gate
+working, not a regression. The restore timings above were taken after moving the
+broken pre-existing chain aside so a fresh, verifiable one was written. The same
+condition breaks `checkpoint verify` on `main` today, independently of this
+change.

--- a/specs/plans/304-hvf-save-restore.md
+++ b/specs/plans/304-hvf-save-restore.md
@@ -1,0 +1,184 @@
+# Plan 304 — HVF save/restore for checkpoint and fork
+
+**Status: COMPLETE**
+Owner: runtime
+Created: 2026-08-08
+
+## What this buys, and what it does not
+
+HVF already has fast warm launch. It comes from **resident handoff**: a standby
+parent stays live and paused, and a claim hands its machine instance straight to
+a child identity (`HvfDriver::fork_standby_child` → the supervisor's handoff
+socket). That path measures 18.9 ms p50 dispatch on an M-series Mac and does not
+go through a saved state at all.
+
+So this work is **not** a warm-start latency change. What it buys:
+
+- `mvmctl machine checkpoint create --class vm-full` on HVF — a durable,
+  content-addressed, chain-anchored record of a running machine.
+- `mvmctl machine checkpoint restore` — same-identity resume from one.
+- `mvmctl machine checkpoint fork` — a fresh child identity resumed from one.
+- The lineage those three feed: `timeline`, `revert`, `rewind`, `advance`, and
+  the fork tree the sandbox-branching model is built on.
+
+A checkpoint restore is slower than a resident handoff and always will be: it
+reads guest RAM back off disk and starts a new VMM, where a handoff transfers a
+process that is already running. Measured numbers are in "Benchmark evidence"
+below. Nothing in this plan changes the launch path.
+
+## Starting point
+
+More of this existed than the `SnapshotCapability::Unsupported` flag suggested.
+Verified by reading the code, then by running it:
+
+- `mvm-runtime/src/backends/hvf/snapshot.rs` — the frame codec: encode, parse,
+  restore, and the AArch64 vCPU state codec.
+- `mvm-runtime/src/backends/hvf/kernel_boot.rs` — capture (a `snapshot_request`
+  file makes the paused run loop serialize RAM + devices + vCPU into
+  `snapshot.ram`/`snapshot.frame`) and restore (`restore_ram` maps the saved RAM
+  privately, `restore_frame` restores the control plane and rebinds host
+  channels).
+- `mvm-backends/src/driver/hvf.rs` — `HvfVmFullControl` already implemented
+  `VmFullControl`: pause via SIGUSR1 + acknowledged marker, `save_memory`,
+  resume via SIGUSR2, `retain_paused_after_capture`, `device_anchors`,
+  `extra_content`, `supervisor_config_path`.
+
+What was missing was everything **around** the VMM primitives: nothing ever set
+`restore_ram`/`restore_frame` (a dead config path), the CLI hardcoded
+Firecracker's capture control, the liveness and quiescence probes did not know
+`hvf.pid` or the HVF pause marker, and `checkpoint restore` was a hard `bail!`.
+
+## Workstreams
+
+### WS1 — Audit `HvfVmFullControl` against the full `VmFullControl` surface
+
+- [x] Every method has a real implementation; none of the trait's defaults are
+      left standing where HVF needs a behaviour (`supervisor_config_path` and
+      `extra_content` were already overridden, and both are load-bearing here).
+- [x] `save_memory` gained the one precondition the surface could not express:
+      **refuse a VM with a writable disk**. A snapshot carries guest RAM plus the
+      devices' control plane, never a device's backing bytes. That is sound for a
+      read-only file-served disk (the restore rebinds the same unchanged image)
+      and unsound for a RAM-backed ephemeral rootfs, whose writes vanish with the
+      VMM. Failing closed at capture is the difference between "unsupported" and
+      "mints a checkpoint that silently reverts data".
+- [x] The capture rendezvous poll uses a bounded exponential backoff (200 µs →
+      5 ms) rather than a flat 10 ms tick, so it does not quantize its own
+      measurement.
+
+### WS2 — The restore entry point
+
+- [x] `mvm-backends/src/driver/hvf_restore.rs` — the mechanics. Reads the
+      captured launch config and device anchors out of the materialized state
+      dir and rewrites them into a child config that:
+      - re-derives **every** per-VM host path from the child's own state dir
+        (pid file, console log, workload exit, pause marker, snapshot
+        rendezvous, agent socket);
+      - remaps each device path through the recorded anchors to the child's own
+        clone, and refuses a writable disk (independently of WS1's gate);
+      - sets `restore_ram` / `restore_frame` so the supervisor maps the saved RAM
+        privately and restores the frame instead of loading a kernel;
+      - **drops every authority-bearing relay** — substitution endpoint, broker,
+        dev console sockets, live-handoff control. A restored guest reaches the
+        network only once a claim binds a relay, so a restore comes up deny-all
+        by construction, before its vCPU runs.
+- [x] `mvm-runtime/src/hvf_restore.rs` — the two adapters: `HvfForkRestorer`
+      (fork into a fresh identity, reached through the
+      `ForkRestore` callback the way `FcForkRestorer` is — an inherent method,
+      no shared trait, since plan 298 collapsed that trait when it extracted the
+      Firecracker driver) and
+      `HvfVmFullRestore: VmFullRestore` (same-identity resume). The latter clones
+      the checkpoint's content dir into the target's state dir first: a resumed
+      guest writes through to its rootfs, and the sealed bytes are what every
+      later fork verifies against.
+
+### WS3 — Backend-neutral dispatch
+
+- [x] `AnyBackend::vm_full_control` — the capture control of the backend that
+      owns the VM, with an exhaustive match so a new variant must decide.
+- [x] `mvm_runtime::checkpoint::vm_is_running` reads the one shared marker list
+      (`mvm_vmm::host::process_liveness`), so `hvf.pid` counts and `EPERM` on a
+      root-owned Firecracker still reads as alive. The CLI's private two-marker
+      list is gone — it now delegates here.
+      `vm_is_running_covers_every_catalog_pid_marker` drives that probe from the
+      backend descriptors, so a backend that registers a marker the shared list
+      does not carry goes red instead of silently reading as stopped.
+- [x] `vm_is_quiesced` understands the HVF pause marker. The supervisor writes
+      `pause.state` only after its vCPU has entered the pause hold, so its
+      presence beside a live `hvf.pid` *is* the acknowledgement.
+- [x] The supervisor-config predicate that gated fork dispatch (it would have
+      misread every HVF checkpoint, because HVF also carries a supervisor
+      config) is replaced by
+      `mvm_core::checkpoint::vm_full_origin` — a typed classification derived
+      from the machine-state blob the manifest names (`memory.bin.hvf-frame` →
+      HVF, `vmstate.bin` → Firecracker, supervisor config alone → the removed
+      backend, none → not a vm_full checkpoint). Dispatch is on the bytes a
+      restore would actually load.
+- [x] `fork_vm_full_fc` → `fork_vm_full`: the clone, the verity-binding check and
+      the lineage record were already backend-neutral; only the restorer differs.
+- [x] `ensure_save_restore_supported` checks the backend that owns *this* VM
+      rather than the host default.
+
+### WS4 — Capability flip
+
+- [x] `HvfBackend::capabilities().snapshot_capability` → `SaveRestore`.
+      `SaveRestore`, not `LiveMemory`: a capture copies the whole mapping.
+- [x] Tests that pinned `Unsupported` updated (`mvm-backends` driver identity
+      test, the `mvm-runtime` per-backend capability table).
+
+### WS5 — Security invariants
+
+- [x] **Lineage chain-anchoring.** `restore_checkpoint` now takes a
+      `CheckpointChainAnchor` and runs `verify_checkpoint_against_chain` — the
+      same fail-closed gate `fork_checkpoint` and `fork_vm_full` run. Bringing a
+      machine back to life is at least as consequential as branching from it, so
+      a record edited after it was audited must not be restorable either. This
+      closed a real hole: restore previously verified content hashes only.
+- [x] **Sealed-content verification.** `verify_content` still runs on both
+      paths, and the HVF fork inherits `validate_fork_verity_binding` — an
+      incomplete dm-verity sidecar set, a missing `device-anchors.json`, or a
+      verity anchor without sidecars all refuse before the VMM starts.
+- [x] **`capture_fs_quick` unchanged.** The fs_quick path is untouched; the only
+      change it sees is that a paused HVF VM now reads as quiesced, which is what
+      lets it be checkpointed at all.
+- [x] **Fresh child identity.** An HVF fork admits its own claim-8 plan (own
+      nonce, own VM name, `deny_all` networking), then delivers a fresh
+      generation token over the backend-agnostic vsock dispatcher and refuses
+      anything short of acknowledged + reseeded + clock-resynced. A child that
+      cannot prove it rotated is stopped.
+- [x] The Firecracker arm's experimental opt-in is **not** carried over, and the
+      reason is recorded in code: that guard exists because a restored
+      Firecracker child inherits the parent's guest IP/MAC out of saved memory
+      and collides with it on the shared bridge. An HVF guest has no NIC to
+      inherit an address on.
+
+### WS6 — Tests, BDD, benchmarks
+
+- [x] Unit coverage on every new seam, positive and negative.
+- [x] `features/suites/s11_snapshot/hvf_save_restore.feature`.
+- [x] Benchmark evidence (below).
+
+## Known limits
+
+Recorded here rather than papered over:
+
+1. **A writable disk is not checkpointable on HVF.** The device model's snapshot
+   section carries a device's control plane, not its backing bytes, and the
+   section is capped at 1 MiB. The two workload tiers HVF actually runs are
+   unaffected: a sealed/verity boot attaches only read-only file-served disks
+   (guest-writable state lives in guest RAM, which *is* captured), and a
+   virtiofs-root dev boot attaches no block device at all. The non-verity ext4
+   dev tier, whose rootfs is RAM-backed ephemeral, is refused with a message
+   naming the disk. Lifting this needs a new snapshot section for block-image
+   contents, which is a device-model change, not a checkpoint change.
+2. **A capture writes guest RAM twice** — once as `snapshot.ram` and once inside
+   the frame's RAM section — so a checkpoint of an N-MiB VM costs ~2N MiB on
+   disk before deduplication. Pre-existing: the standby-pool capture path has
+   always paid this. Collapsing the frame's RAM section into a reference to the
+   sibling file is a frame-format change.
+3. **Same-identity restore is HVF-only.** Firecracker's saved state loads only
+   into a fresh child (`machine warm-restore`), and `restore` says so.
+
+## Benchmark evidence
+
+See `specs/plans/304-hvf-save-restore-bench.md`.

--- a/xtask/src/check_cli_runtime_surface.rs
+++ b/xtask/src/check_cli_runtime_surface.rs
@@ -61,6 +61,14 @@ const EXEMPTIONS: &[(&str, &[Rule], &str)] = &[
         "store surface: checkpoint / fork / restore over the CoW rootfs",
     ),
     (
+        "commands/vm/checkpoint/fork_vm_full.rs",
+        &[Rule::AnyBackend],
+        "same store surface as commands/vm/checkpoint.rs — the vm_full fork arms live in \
+         their own file only because the parent crossed the production file-size cap. \
+         Listed per file rather than by directory prefix deliberately: a prefix would \
+         silently exempt whatever lands beside it next",
+    ),
+    (
         "commands/vm/exec.rs",
         &[Rule::AnyBackend],
         "streaming exec-over-vsock: selects the backend for the transient exec VM",


### PR DESCRIPTION
## What

Makes `mvmctl machine checkpoint create --class vm-full`, `checkpoint restore`,
and `checkpoint fork` work on the HVF backend, and flips
`snapshot_capability` from `Unsupported` to `SaveRestore`.

## Why the flag was the smallest part

The VMM primitives were already built and are exercised today by the warm-pool
capture path: the frame codec (`backends/hvf/snapshot.rs`), the paused capture
in the run loop, the `restore_ram`/`restore_frame` private-mapping restore, and
an `HvfVmFullControl` covering the whole `VmFullControl` surface. What was
missing was the plumbing around them:

- Nothing anywhere set `restore_ram`/`restore_frame` — a dead config path.
- The CLI hardcoded `FcVmFullControl`, so a capture on HVF would have paused
  the wrong thing.
- The liveness probe knew `fc.pid` and `vz.pid`; a live HVF VM read as stopped.
- `vm_is_quiesced` knew only Firecracker's pause marker.
- `checkpoint restore` was a `bail!`.

## Changes

**Restore entry point.** `mvm-backends/src/driver/hvf_restore.rs` rewrites a
captured parent's launch config into one that boots a child from its own
materialized copies. Two invariants carry the security weight:

1. Every per-VM host path is re-derived from the child's state dir — pid file,
   console log, workload exit, pause marker, snapshot rendezvous, agent socket.
   Keeping any of the parent's would make two live VMMs fight over one identity.
2. No authority-bearing relay survives: substitution endpoint, broker, dev
   console sockets, live-handoff control are all dropped. A restored guest has
   no path off the box until a claim binds one — and because the drop happens at
   config time, that holds *before* its vCPU runs.

`mvm-runtime/src/hvf_restore.rs` holds the two thin adapters
(`ForkVmFullRestorer`, `VmFullRestore`). The same-identity resume clones the
sealed content into the target's state dir first: a resumed guest writes through
to its rootfs, and those bytes are what every later fork verifies against.

**Backend-neutral dispatch.** `AnyBackend::vm_full_control` (exhaustive match),
a catalog-driven `vm_is_running`, and `mvm_core::checkpoint::vm_full_origin`
replacing `checkpoint_is_vz`. That last one mattered: the old heuristic keyed on
the `supervisor-config.json` blob, which every HVF checkpoint also carries, so
it would have classified all of them as the removed backend's. Dispatch is now
on the machine-state blob — the bytes a restore would actually load.
`fork_vm_full_fc` → `fork_vm_full`; only the restorer was ever VMM-specific.

## Security

- **Restore is now chain-anchored.** It previously verified content hashes
  only, so a record edited after it was audited was restorable even though it
  was not forkable. `restore_checkpoint` now takes a `CheckpointChainAnchor`
  and runs the same fail-closed gate the fork paths do.
- **Fresh child identity.** An HVF fork admits its own claim-8 plan (own nonce,
  own name, `deny_all`), delivers a fresh generation token, and refuses anything
  short of acknowledged + reseeded + clock-resynced — stopping the child if it
  cannot prove it rotated.
- **No experimental opt-in.** Firecracker's guard exists because a restored FC
  child inherits the parent's guest IP/MAC out of saved memory and collides on
  the shared bridge. An HVF guest has no NIC to inherit an address on, so the
  guard has nothing to protect against and is not carried over.
- `capture_fs_quick` and the dm-verity binding check are untouched.

## Two refusals worth calling out

**A capture is refused when the VM has a writable disk.** A snapshot carries the
devices' control plane, never their backing bytes. That is sound for a
read-only file-served disk and unsound for a RAM-backed ephemeral rootfs, whose
writes vanish with the VMM — restoring against one resumes a guest whose page
cache disagrees with its disk. The two workload tiers HVF actually runs are
unaffected (sealed/verity attaches only read-only disks; virtiofs-root attaches
none). Lifting this needs a new snapshot section for block-image contents; it is
recorded as a known limit in the plan, not papered over.

**Pause retention is now the caller's choice**, ANDed with the backend's
capability. Only the warm pool wants its captured parent held paused — for it
the paused parent is the claim resource. Routing the user-facing verb through
the HVF control was otherwise leaving a checkpointed VM stopped; caught by
running it, and now covered by a test.

## Benchmarks

Live on macOS 26.5.2 / Apple silicon, 512 MiB sealed workload, full release
binary set:

| operation | p50 | range |
|---|---|---|
| `checkpoint create --class vm-full` | 1635 ms | 1527–1849 |
| `checkpoint restore` | 690 ms | 684–692 |

**This is not a warm-launch change.** HVF's fast launch is resident handoff at
18.9 ms p50 dispatch, and a restore is ~36× that by construction — it starts a
new VMM against bytes on disk where a handoff transfers a running process. The
two answer different questions; the fork lineage needs the second. Full detail
and the reproduction recipe in `specs/plans/304-hvf-save-restore-bench.md`.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace` — 10601 passed, 24 skipped
- `cargo test --workspace --doc`
- `cargo test -p mvm-conformance --test conformance --features bdd` — 152/152
  scenarios, 649/649 steps, including 6 new ones under
  `features/suites/s11_snapshot/hvf_save_restore.feature`
- xtask: `check-file-size`, `check-honesty`, `check-no-overclaim`,
  `check-deferrals`, `check-single-home`, `check-conformance`,
  `check-abi-layout`, `check-no-spec-refs-in-comments`, `check-claim-catalog`,
  `check-uniform-vsock-egress`, `check-vsock-only-egress` — all clean
- `cargo zigbuild --target x86_64-unknown-linux-gnu` clean for every crate this
  touches (`mvm-core`, `mvm-runtime`, `mvm-backends`, `mvm-vmm`, `mvm-hostd`).
  The full-workspace form needs the pinned zig for `mvm-cli`'s embedded-binary
  build script (`just toolchain-embed`), which is not provisioned on this host.
- Live end-to-end: capture and restore driven against a real HVF VM, not just
  unit-level seams.

One environmental note, in the bench doc: on a developer `~/.mvm` whose
`local.jsonl` audit chain is already broken (`mvmctl trust audit verify` fails
on `main` there too), every checkpoint reads as un-audited and both
`checkpoint verify` and `checkpoint restore` fail closed. That is the gate
working. The restore timings were taken after moving the broken pre-existing
chain aside.

`checkpoint.rs` crossed the 1500-line production cap, so the vm_full fork arms
moved to `commands/vm/checkpoint/fork_vm_full.rs` with their tests.
