### PR TITLE
feat(client): give MvmClient a capability surface

### DIFF
--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -27,6 +27,7 @@ use mvm_fs::oci::{
 };
 use mvm_runtime::AnyBackend;
 
+use mvm_core::client::BackendCapabilityReport;
 use mvm_core::client::dto::{
     ExecResult, LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus,
     PauseOpts, PauseOutcome, PortMapping, ResumeOpts, ResumeOutcome,
@@ -539,6 +540,15 @@ pub(crate) fn host_verity_sidecars(rootfs: &Path) -> (Option<String>, Option<Str
 
 #[async_trait]
 impl MvmClient for LocalBackend {
+    async fn backend_capabilities(&self) -> Result<BackendCapabilityReport> {
+        // Straight from the backend that will actually run the workload, so
+        // the report cannot drift from the thing it describes.
+        Ok(BackendCapabilityReport::new(
+            self.backend.kind(),
+            self.backend.capabilities(),
+        ))
+    }
+
     async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>> {
         let registry = load_name_registry();
 

--- a/crates/mvm-contract/src/protocol/capability_negotiation.rs
+++ b/crates/mvm-contract/src/protocol/capability_negotiation.rs
@@ -178,6 +178,41 @@ impl VmCapabilities {
     }
 }
 
+/// A backend's identity and capability matrix, together.
+///
+/// This is what a client facade hands back so a caller can decide *before*
+/// invoking a lifecycle method that the backend cannot serve. Both halves are
+/// needed: an alternative depends on the pair, so a matrix without its
+/// backend cannot be negotiated against.
+///
+/// Serializable on purpose. A remote client answers this over the wire, and
+/// [`negotiate`](Self::negotiate) then runs locally against the answer — so
+/// negotiation costs no round trip and a gateway needs no negotiation
+/// endpoint, only a capability one.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BackendCapabilityReport {
+    /// Which backend answered.
+    pub kind: BackendKind,
+    /// What it advertises.
+    pub capabilities: VmCapabilities,
+}
+
+impl BackendCapabilityReport {
+    pub fn new(kind: BackendKind, capabilities: VmCapabilities) -> Self {
+        Self { kind, capabilities }
+    }
+
+    /// Check `required` against this report, naming a substitute for every
+    /// capability the backend cannot serve.
+    ///
+    /// Pure: no I/O, so a caller holding a report fetched once can negotiate
+    /// as many requirement sets against it as it likes.
+    pub fn negotiate(&self, required: &RequiredCapabilities) -> Result<(), Vec<CapabilityGap>> {
+        self.capabilities.negotiate(required, self.kind)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -346,5 +381,74 @@ mod tests {
                 gap.capability
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod report_tests {
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn a_report_round_trips_through_json() {
+        let report = BackendCapabilityReport::new(
+            BackendKind::Wasm,
+            VmCapabilities {
+                vsock: false,
+                pty_exec: false,
+                ..VmCapabilities::default()
+            },
+        );
+        let json = serde_json::to_string(&report).expect("report serializes");
+        let back: BackendCapabilityReport =
+            serde_json::from_str(&json).expect("report deserializes");
+        assert_eq!(back, report, "a remote answer must survive the wire");
+    }
+
+    #[test]
+    fn an_unknown_field_is_refused_rather_than_ignored() {
+        // A gateway that grows a field this client does not know about must
+        // fail loudly: silently dropping it is how a caller ends up reasoning
+        // about a capability matrix that is not the one the server meant.
+        let json = r#"{"kind":"mock","capabilities":{"pause_resume":true}}"#;
+        let err = serde_json::from_str::<BackendCapabilityReport>(json);
+        assert!(err.is_err(), "a partial capability matrix must not decode");
+    }
+
+    #[test]
+    fn a_report_negotiates_without_touching_its_backend() {
+        let report = BackendCapabilityReport::new(BackendKind::Wasm, VmCapabilities::default());
+        let required = RequiredCapabilities {
+            vsock: true,
+            ..RequiredCapabilities::default()
+        };
+        let gaps = report
+            .negotiate(&required)
+            .expect_err("the wasm tier has no vsock device");
+        assert_eq!(
+            gaps,
+            vec![CapabilityGap {
+                capability: "vsock",
+                alternative: CapabilityAlternative::SubstitutionEndpointOverWasmImport,
+            }],
+            "the report must resolve the same alternative the backend would"
+        );
+    }
+
+    #[test]
+    fn one_fetched_report_answers_many_requirement_sets() {
+        // The reason the trait returns a report rather than taking a
+        // requirement set: a remote caller pays one round trip, not one per
+        // question.
+        let report = BackendCapabilityReport::new(BackendKind::Qemu, VmCapabilities::default());
+        assert!(report.negotiate(&RequiredCapabilities::default()).is_ok());
+        assert!(
+            report
+                .negotiate(&RequiredCapabilities {
+                    pty_exec: true,
+                    ..RequiredCapabilities::default()
+                })
+                .is_err()
+        );
     }
 }

--- a/crates/mvm-contract/src/protocol/capability_negotiation.rs
+++ b/crates/mvm-contract/src/protocol/capability_negotiation.rs
@@ -1,0 +1,350 @@
+//! What a caller should do when a backend cannot serve a capability.
+//!
+//! [`VmCapabilities::shortfall`] answers *which* capabilities are missing.
+//! That is enough for a host-side caller who already knows the backend
+//! matrix by heart, and not enough for someone using this crate as a
+//! library: a bare `["vcpu_state_snapshot"]` says a request was refused
+//! without saying what to do instead.
+//!
+//! This module answers the second question. Every gap resolves to a
+//! [`CapabilityAlternative`] — either a concrete substitute the caller can
+//! take, or [`CapabilityAlternative::None`] carrying the reason no
+//! substitute exists.
+//!
+//! **`None` is the load-bearing variant.** Some capabilities are security
+//! boundaries, not features, and inventing a substitute for one would be
+//! the silent degradation the backend ADR rules out. A backend that cannot
+//! keep a routable NIC away from a workload has no alternative path to
+//! offer; it has a refusal. Making that a distinct variant is what stops a
+//! caller from treating "no alternative" as "alternative not written yet".
+//!
+//! Alternatives are resolved per (capability, backend) because the honest
+//! answer differs: a tier with no vsock device reaches the host-side
+//! substitution endpoint over a Unix socket, whereas the wasm tier reaches
+//! the same endpoint through its `mvm:egress` host import. Both end at the
+//! same governance seam, which is why both are real answers rather than
+//! consolation prizes.
+
+use alloc::vec::Vec;
+
+use super::vm_backend::{BackendKind, RequiredCapabilities, VmCapabilities};
+
+/// The substitute for a capability a backend does not provide.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapabilityAlternative {
+    /// Boot from scratch and replay the signed plan rather than restoring
+    /// saved machine state. Costs a cold start; the workload is identical
+    /// because the plan is what defines it.
+    ColdStartFromSignedPlan,
+    /// Reach the per-VM substitution endpoint over a Unix socket instead of
+    /// a vsock device. Same endpoint, same policy and audit path.
+    SubstitutionEndpointOverUds,
+    /// Reach the per-VM substitution endpoint through the wasm tier's
+    /// `mvm:egress` host import. Same endpoint, same policy and audit path.
+    SubstitutionEndpointOverWasmImport,
+    /// Send bytes on the workload's stdin route rather than opening an
+    /// interactive terminal. Not a terminal: no program selection, no argv
+    /// or environment change.
+    WorkloadStdinRoute,
+    /// Prelaunch a standby rather than restoring a snapshot. Pays the setup
+    /// cost in advance instead of recovering saved state.
+    StandbyPool,
+    /// No substitute exists, for the stated reason. The request must be
+    /// refused and a different backend chosen.
+    None { why: &'static str },
+}
+
+impl CapabilityAlternative {
+    /// Whether this names something the caller can actually do.
+    pub fn is_actionable(&self) -> bool {
+        !matches!(self, CapabilityAlternative::None { .. })
+    }
+
+    /// One-line description, suitable for an error message.
+    pub fn describe(&self) -> &'static str {
+        match self {
+            Self::ColdStartFromSignedPlan => {
+                "cold start and replay the signed execution plan instead of restoring saved state"
+            }
+            Self::SubstitutionEndpointOverUds => {
+                "reach the per-VM substitution endpoint over a Unix socket instead of vsock"
+            }
+            Self::SubstitutionEndpointOverWasmImport => {
+                "reach the per-VM substitution endpoint through the `mvm:egress` host import"
+            }
+            Self::WorkloadStdinRoute => {
+                "write to the workload's stdin route instead of opening an interactive terminal"
+            }
+            Self::StandbyPool => "prelaunch a standby instead of restoring a snapshot",
+            Self::None { why } => why,
+        }
+    }
+}
+
+/// One capability the backend was asked for and cannot provide, paired with
+/// what to do instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityGap {
+    /// The capability name, matching [`VmCapabilities::shortfall`].
+    pub capability: &'static str,
+    /// What the caller can do instead, or why nothing will do.
+    pub alternative: CapabilityAlternative,
+}
+
+impl CapabilityGap {
+    /// Whether this gap can be worked around at all.
+    pub fn is_actionable(&self) -> bool {
+        self.alternative.is_actionable()
+    }
+}
+
+/// Resolve the substitute for one missing capability on one backend.
+///
+/// Kept as a free function over `(capability, backend)` rather than a method
+/// on either, because the answer is a property of the pair. Every arm is
+/// explicit: a new capability or a new backend has to be answered here
+/// rather than silently inheriting a neighbour's alternative.
+fn alternative_for(capability: &'static str, backend: BackendKind) -> CapabilityAlternative {
+    match capability {
+        // Recovery capabilities. Losing any one of them costs a warm restore,
+        // never correctness: the signed plan fully determines the workload, so
+        // replaying it reaches the same state from cold.
+        "eager_cow_restore"
+        | "guest_memory_mapping"
+        | "fixed_address_remap"
+        | "device_state_snapshot"
+        | "vcpu_state_snapshot" => match backend {
+            // A tier that can hold prelaunched standbys can hide most of the
+            // cold-start cost even without snapshot restore.
+            BackendKind::Firecracker | BackendKind::Libkrun | BackendKind::Hvf => {
+                CapabilityAlternative::StandbyPool
+            }
+            _ => CapabilityAlternative::ColdStartFromSignedPlan,
+        },
+
+        // Transport capabilities. Every one of these ends at the same per-VM
+        // substitution endpoint, so the substitute changes how the workload
+        // reaches the seam, never whether policy and audit apply to it.
+        "vsock" | "host_vsock_proxy" | "l3_vsock" => match backend {
+            BackendKind::Wasm => CapabilityAlternative::SubstitutionEndpointOverWasmImport,
+            _ => CapabilityAlternative::SubstitutionEndpointOverUds,
+        },
+
+        // Interactive access. The stdin route carries bytes to an already
+        // running entrypoint; it is not a terminal and cannot become one.
+        "pty_exec" => CapabilityAlternative::WorkloadStdinRoute,
+
+        // A security boundary, not a feature. A backend that cannot keep a
+        // routable NIC away from the workload cannot be made to by choosing a
+        // different call — the host would stop being the originator of every
+        // outbound connection, which is what makes egress policy and the audit
+        // chain mean anything.
+        "no_routable_guest_nic" => CapabilityAlternative::None {
+            why: "a routable guest NIC removes the host from the egress path; \
+                  no alternative call restores it — choose a backend that isolates the guest",
+        },
+
+        // An unrecognised capability gets no invented substitute.
+        other => {
+            debug_assert!(false, "capability {other} has no alternative arm");
+            CapabilityAlternative::None {
+                why: "unrecognised capability: no alternative is defined for it",
+            }
+        }
+    }
+}
+
+impl VmCapabilities {
+    /// Check `required` against this backend, naming a substitute for every
+    /// capability it cannot serve.
+    ///
+    /// `Ok(())` means the backend serves the request outright. `Err` carries
+    /// one [`CapabilityGap`] per missing capability, in the same order
+    /// [`VmCapabilities::shortfall`] reports them.
+    pub fn negotiate(
+        &self,
+        required: &RequiredCapabilities,
+        backend: BackendKind,
+    ) -> Result<(), Vec<CapabilityGap>> {
+        let gaps: Vec<CapabilityGap> = self
+            .shortfall(required)
+            .into_iter()
+            .map(|capability| CapabilityGap {
+                capability,
+                alternative: alternative_for(capability, backend),
+            })
+            .collect();
+        if gaps.is_empty() { Ok(()) } else { Err(gaps) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    /// A backend that advertises nothing, so any requirement is a gap.
+    fn barren() -> VmCapabilities {
+        VmCapabilities::default()
+    }
+
+    fn require(f: impl FnOnce(&mut RequiredCapabilities)) -> RequiredCapabilities {
+        let mut r = RequiredCapabilities::default();
+        f(&mut r);
+        r
+    }
+
+    #[test]
+    fn a_backend_that_serves_the_request_reports_no_gaps() {
+        let caps = VmCapabilities {
+            vsock: true,
+            ..VmCapabilities::default()
+        };
+        let required = require(|r| r.vsock = true);
+        assert_eq!(caps.negotiate(&required, BackendKind::Firecracker), Ok(()));
+    }
+
+    #[test]
+    fn a_missing_transport_points_at_the_same_endpoint_over_uds() {
+        let required = require(|r| r.vsock = true);
+        let gaps = barren()
+            .negotiate(&required, BackendKind::Qemu)
+            .expect_err("a barren backend cannot serve vsock");
+        assert_eq!(
+            gaps,
+            vec![CapabilityGap {
+                capability: "vsock",
+                alternative: CapabilityAlternative::SubstitutionEndpointOverUds,
+            }]
+        );
+        assert!(gaps[0].is_actionable());
+    }
+
+    #[test]
+    fn the_wasm_tier_reaches_the_endpoint_through_its_host_import() {
+        let required = require(|r| r.vsock = true);
+        let gaps = barren()
+            .negotiate(&required, BackendKind::Wasm)
+            .expect_err("the wasm tier has no vsock device");
+        assert_eq!(
+            gaps[0].alternative,
+            CapabilityAlternative::SubstitutionEndpointOverWasmImport
+        );
+    }
+
+    #[test]
+    fn a_missing_snapshot_tier_falls_back_to_replaying_the_signed_plan() {
+        let required = require(|r| r.vcpu_state_snapshot = true);
+        let gaps = barren()
+            .negotiate(&required, BackendKind::Wasm)
+            .expect_err("the wasm tier holds no vcpu state");
+        assert_eq!(
+            gaps[0].alternative,
+            CapabilityAlternative::ColdStartFromSignedPlan
+        );
+    }
+
+    #[test]
+    fn a_snapshotless_microvm_backend_is_offered_a_standby_instead() {
+        let required = require(|r| r.vcpu_state_snapshot = true);
+        let gaps = barren()
+            .negotiate(&required, BackendKind::Hvf)
+            .expect_err("a barren backend holds no vcpu state");
+        assert_eq!(gaps[0].alternative, CapabilityAlternative::StandbyPool);
+    }
+
+    #[test]
+    fn a_missing_pty_is_offered_the_stdin_route_and_nothing_richer() {
+        let required = require(|r| r.pty_exec = true);
+        let gaps = barren()
+            .negotiate(&required, BackendKind::Wasm)
+            .expect_err("the wasm tier has no pty");
+        assert_eq!(
+            gaps[0].alternative,
+            CapabilityAlternative::WorkloadStdinRoute
+        );
+        // The substitute must not read as an equivalent: a caller who wanted a
+        // terminal has to see that this is a byte route to an already-running
+        // entrypoint, or they will reach for it expecting a shell.
+        let described = gaps[0].alternative.describe();
+        assert!(
+            described.contains("instead of") && described.contains("interactive terminal"),
+            "the description must distinguish the stdin route from a terminal: {described}"
+        );
+    }
+
+    #[test]
+    fn a_guest_nic_gap_has_no_alternative_and_says_why() {
+        let required = require(|r| r.no_routable_guest_nic = true);
+        let gaps = barren()
+            .negotiate(&required, BackendKind::Docker)
+            .expect_err("a shared-kernel tier cannot promise a NIC-less guest");
+        assert!(
+            !gaps[0].is_actionable(),
+            "a security boundary must not resolve to a workaround"
+        );
+        assert!(gaps[0].alternative.describe().contains("egress path"));
+    }
+
+    #[test]
+    fn every_gap_is_reported_not_just_the_first() {
+        let required = require(|r| {
+            r.vsock = true;
+            r.pty_exec = true;
+            r.vcpu_state_snapshot = true;
+        });
+        let gaps = barren()
+            .negotiate(&required, BackendKind::Wasm)
+            .expect_err("a barren backend serves none of these");
+        assert_eq!(gaps.len(), 3, "got {gaps:?}");
+        let names: Vec<&str> = gaps.iter().map(|g| g.capability).collect();
+        assert_eq!(names, vec!["vcpu_state_snapshot", "vsock", "pty_exec"]);
+    }
+
+    #[test]
+    fn gap_order_matches_shortfall_order() {
+        let required = require(|r| {
+            r.pty_exec = true;
+            r.vsock = true;
+        });
+        let caps = barren();
+        let shortfall = caps.shortfall(&required);
+        let gaps = caps
+            .negotiate(&required, BackendKind::Libkrun)
+            .expect_err("neither capability is served");
+        let names: Vec<&'static str> = gaps.iter().map(|g| g.capability).collect();
+        assert_eq!(names, shortfall);
+    }
+
+    #[test]
+    fn every_capability_shortfall_can_name_has_an_alternative_arm() {
+        // The registry of capability names lives in `shortfall`. Ask for all
+        // of them at once against a backend that serves none, and assert each
+        // resolves to a deliberate arm rather than the unrecognised fallback.
+        let required = RequiredCapabilities {
+            eager_cow_restore: true,
+            guest_memory_mapping: true,
+            fixed_address_remap: true,
+            device_state_snapshot: true,
+            vcpu_state_snapshot: true,
+            vsock: true,
+            no_routable_guest_nic: true,
+            host_vsock_proxy: true,
+            l3_vsock: true,
+            pty_exec: true,
+        };
+        let gaps = barren()
+            .negotiate(&required, BackendKind::Firecracker)
+            .expect_err("a barren backend serves nothing");
+        assert_eq!(gaps.len(), 10, "every capability must produce a gap");
+        for gap in &gaps {
+            assert!(
+                !gap.alternative
+                    .describe()
+                    .contains("unrecognised capability"),
+                "{} fell through to the unrecognised arm",
+                gap.capability
+            );
+        }
+    }
+}

--- a/crates/mvm-contract/src/protocol/mod.rs
+++ b/crates/mvm-contract/src/protocol/mod.rs
@@ -6,6 +6,7 @@
 pub mod audit_signer;
 pub mod broker;
 pub mod broker_control;
+pub mod capability_negotiation;
 pub mod dns;
 pub mod handler;
 pub mod host_audit;

--- a/crates/mvm-contract/src/protocol/vm_backend.rs
+++ b/crates/mvm-contract/src/protocol/vm_backend.rs
@@ -420,7 +420,8 @@ impl VmExitStatus {
 /// them. Recovery capabilities are deliberately part of this same value so a
 /// caller cannot accidentally combine a snapshot tier from one backend with a
 /// standby answer from another.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct VmCapabilities {
     /// Can pause/resume vCPUs (Firecracker: yes, WASM: no).
     pub pause_resume: bool,
@@ -572,7 +573,8 @@ impl VmCapabilities {
 /// the honest per-backend warm-start *tier*. No path silently degrades —
 /// a request beyond the reported tier returns a typed error once the
 /// snapshot RPC is wired.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SnapshotCapability {
     /// Full live-memory snapshot + fast resume (Firecracker: UFFD/NBD/hugepages).
     LiveMemory,
@@ -1267,7 +1269,8 @@ pub struct VmInfo {
 /// `&dyn VmBackend` callers can call `.kind()` without an upward dependency
 /// on the higher-level backend registry that knows how to *construct* each
 /// variant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum BackendKind {
     Firecracker,
     Libkrun,

--- a/crates/mvm-core/src/client/gateway.rs
+++ b/crates/mvm-core/src/client/gateway.rs
@@ -14,6 +14,7 @@ use crate::client::dto::{
     PauseOutcome, ReconfigureRequest, ResumeOpts, ResumeOutcome,
 };
 use crate::client::error::{MvmError, Result};
+use mvm_contract::protocol::capability_negotiation::BackendCapabilityReport;
 
 /// How to reach a gateway: its base URL and the bearer token to present.
 pub struct GatewayConfig {
@@ -610,6 +611,25 @@ fn filter_machines(machines: Vec<MachineState>, filter: &MachineFilter) -> Vec<M
 
 #[async_trait]
 impl MvmClient for GatewayBackend {
+    async fn backend_capabilities(&self) -> Result<BackendCapabilityReport> {
+        // A gateway needs a capability endpoint, not a negotiation one:
+        // negotiation is pure, so the caller runs it locally on this answer.
+        let url = self.endpoint("/api/v1/backend/capabilities")?;
+        let resp = self
+            .authed(self.http.get(url))
+            .send()
+            .await
+            .map_err(|e| MvmError::Backend {
+                reason: format!("capability request failed: {e}"),
+            })?;
+        if let Some(e) = status_error(resp.status(), "") {
+            return Err(e);
+        }
+        resp.json().await.map_err(|e| MvmError::Backend {
+            reason: format!("decode capability report: {e}"),
+        })
+    }
+
     async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>> {
         let url = self.endpoint("/api/v1/sandboxes")?;
         let resp = self

--- a/crates/mvm-core/src/client/mock.rs
+++ b/crates/mvm-core/src/client/mock.rs
@@ -11,11 +11,26 @@ use crate::client::dto::{
     PauseOutcome, ReconfigureRequest, ResumeOpts, ResumeOutcome,
 };
 use crate::client::error::{MvmError, Result};
+use mvm_contract::protocol::capability_negotiation::BackendCapabilityReport;
+use mvm_contract::protocol::vm_backend::{BackendKind, VmCapabilities};
 
 #[derive(Default)]
 pub struct MockBackend {
     machines: Mutex<Vec<MachineState>>,
     next: Mutex<u64>,
+    /// What this mock advertises. Default is the all-false matrix, so a test
+    /// that forgets to set it sees refusals rather than a backend that
+    /// silently claims to do everything.
+    capabilities: Mutex<VmCapabilities>,
+}
+
+impl MockBackend {
+    /// Set the capability matrix this mock reports, for driving negotiation
+    /// paths a real backend would need hardware to reach.
+    pub fn with_capabilities(self, capabilities: VmCapabilities) -> Self {
+        *self.capabilities.lock().unwrap() = capabilities;
+        self
+    }
 }
 
 impl MockBackend {
@@ -42,6 +57,13 @@ impl MockBackend {
 
 #[async_trait]
 impl MvmClient for MockBackend {
+    async fn backend_capabilities(&self) -> Result<BackendCapabilityReport> {
+        Ok(BackendCapabilityReport::new(
+            BackendKind::Mock,
+            self.capabilities.lock().unwrap().clone(),
+        ))
+    }
+
     async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>> {
         let all = self.machines.lock().unwrap();
         Ok(all

--- a/crates/mvm-core/src/client/mod.rs
+++ b/crates/mvm-core/src/client/mod.rs
@@ -12,6 +12,8 @@
 
 use async_trait::async_trait;
 
+pub use mvm_contract::protocol::capability_negotiation::BackendCapabilityReport;
+
 pub mod dto;
 pub mod error;
 #[cfg(feature = "client-remote")]
@@ -86,6 +88,21 @@ pub trait MvmClient: Send + Sync {
     /// `Some(rfc3339)` arms it, `None` clears it. Errors if the machine is not
     /// registered.
     async fn set_ttl(&self, id: &MachineId, expires_at: Option<String>) -> Result<()>;
+
+    /// What the backend behind this client can do.
+    ///
+    /// Every other method on this trait is an instruction; this is the one
+    /// question. Without it a caller learns that a backend cannot pause by
+    /// calling `pause_machine` and reading the error — a poor way to find out
+    /// and impossible to plan around. With it, a consumer asks first and gets,
+    /// for anything unsupported, a substitute named by
+    /// [`BackendCapabilityReport::negotiate`].
+    ///
+    /// Deliberately returns the report rather than taking a requirement set:
+    /// negotiation is pure, so a remote client fetches this once over the wire
+    /// and answers any number of requirement sets locally. A gateway therefore
+    /// needs a capability endpoint, not a negotiation one.
+    async fn backend_capabilities(&self) -> Result<BackendCapabilityReport>;
 }
 
 #[cfg(test)]
@@ -97,5 +114,54 @@ mod tests {
     #[test]
     fn trait_is_object_safe() {
         fn _accepts(_c: &dyn MvmClient) {}
+    }
+
+    /// The consumer path: hold a `dyn MvmClient`, ask what it can do, and get a
+    /// substitute for what it cannot — without knowing which backend answered.
+    #[tokio::test]
+    async fn a_dyn_client_reports_capabilities_and_names_alternatives() {
+        use mvm_contract::protocol::capability_negotiation::CapabilityAlternative;
+        use mvm_contract::protocol::vm_backend::RequiredCapabilities;
+
+        let client: Box<dyn MvmClient> = Box::new(mock::MockBackend::default());
+        let report = client
+            .backend_capabilities()
+            .await
+            .expect("a client must be able to describe its backend");
+
+        // The default mock advertises nothing, so a pause requirement is a gap
+        // rather than a silent success.
+        let gaps = report
+            .negotiate(&RequiredCapabilities {
+                vcpu_state_snapshot: true,
+                ..RequiredCapabilities::default()
+            })
+            .expect_err("the default mock holds no vcpu state");
+        assert_eq!(
+            gaps[0].alternative,
+            CapabilityAlternative::ColdStartFromSignedPlan
+        );
+    }
+
+    /// A client whose backend serves the request answers without gaps, so a
+    /// consumer can gate on `is_ok()` rather than on backend lore.
+    #[tokio::test]
+    async fn a_capable_backend_reports_no_gaps() {
+        use mvm_contract::protocol::vm_backend::{RequiredCapabilities, VmCapabilities};
+
+        let client: Box<dyn MvmClient> = Box::new(mock::MockBackend::default().with_capabilities(
+            VmCapabilities {
+                vsock: true,
+                ..VmCapabilities::default()
+            },
+        ));
+        let report = client.backend_capabilities().await.expect("describes");
+        assert_eq!(
+            report.negotiate(&RequiredCapabilities {
+                vsock: true,
+                ..RequiredCapabilities::default()
+            }),
+            Ok(())
+        );
     }
 }

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -18,6 +18,7 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as B64;
 use serde::{Deserialize, Serialize};
 
+pub use mvm_contract::protocol::capability_negotiation::{CapabilityAlternative, CapabilityGap};
 pub use mvm_contract::protocol::vm_backend::{
     BackendKind, BackendSecurityProfile, BalloonState, ClaimStatus, GuestChannelInfo,
     LayerCoverage, RequiredCapabilities, ReseedStatus, RuntimeSourceLaunchKind,
@@ -354,6 +355,21 @@ pub trait VmBackend: Send + Sync {
 
     /// Capabilities supported by this backend.
     fn capabilities(&self) -> VmCapabilities;
+
+    /// Check `required` against this backend, naming a substitute for every
+    /// capability it cannot serve.
+    ///
+    /// This is the uniform entry point for a caller holding a backend it did
+    /// not choose — a library consumer, or any code behind `AnyBackend`. It
+    /// answers in one call what the backend refuses *and* what to do instead,
+    /// so a refusal is actionable without a table of per-backend lore.
+    ///
+    /// Not overridable: it is `capabilities()` and `kind()` composed, and a
+    /// backend that could answer differently here than its own capability
+    /// matrix says would be exactly the dishonest tier the backend ADR forbids.
+    fn negotiate(&self, required: &RequiredCapabilities) -> Result<(), Vec<CapabilityGap>> {
+        self.capabilities().negotiate(required, self.kind())
+    }
 
     /// Whether a warm claim transfers a resident paused VMM directly into the
     /// child, instead of restoring a saved-state bundle.

--- a/crates/mvm-runtime/src/wasm_backend.rs
+++ b/crates/mvm-runtime/src/wasm_backend.rs
@@ -860,6 +860,69 @@ mod engine {
 mod tests {
     use super::*;
 
+    /// The uniform negotiation entry point, exercised through the real trait
+    /// on a real backend rather than a hand-built capability matrix. This is
+    /// what a library consumer holding an `AnyBackend` actually calls.
+    #[test]
+    fn negotiating_unsupported_capabilities_names_the_wasm_alternatives() {
+        use mvm_core::protocol::vm_backend::{CapabilityAlternative, RequiredCapabilities};
+
+        let backend = WasmBackend::new();
+        let required = RequiredCapabilities {
+            vsock: true,
+            pty_exec: true,
+            vcpu_state_snapshot: true,
+            ..RequiredCapabilities::default()
+        };
+
+        let gaps = backend
+            .negotiate(&required)
+            .expect_err("the wasm tier serves none of these");
+
+        let by_name = |want: &str| {
+            gaps.iter()
+                .find(|g| g.capability == want)
+                .unwrap_or_else(|| panic!("no gap reported for {want}: {gaps:?}"))
+                .clone()
+        };
+
+        // Egress still reaches the same substitution endpoint, just through
+        // the host import rather than a vsock device.
+        assert_eq!(
+            by_name("vsock").alternative,
+            CapabilityAlternative::SubstitutionEndpointOverWasmImport
+        );
+        // No vCPU state to restore, so the substitute is a cold start driven
+        // by the same signed plan.
+        assert_eq!(
+            by_name("vcpu_state_snapshot").alternative,
+            CapabilityAlternative::ColdStartFromSignedPlan
+        );
+        // No PTY, and the stdin route is explicitly not one.
+        assert_eq!(
+            by_name("pty_exec").alternative,
+            CapabilityAlternative::WorkloadStdinRoute
+        );
+
+        assert!(
+            gaps.iter().all(|g| g.is_actionable()),
+            "every gap here has a real substitute: {gaps:?}"
+        );
+    }
+
+    /// A backend that serves the request must not manufacture gaps.
+    #[test]
+    fn negotiating_a_request_the_backend_serves_returns_ok() {
+        use mvm_core::protocol::vm_backend::RequiredCapabilities;
+
+        let backend = WasmBackend::new();
+        assert_eq!(
+            backend.negotiate(&RequiredCapabilities::default()),
+            Ok(()),
+            "an empty requirement set is served by every backend"
+        );
+    }
+
     fn cfg(name: &str, module_path: &str) -> VmStartConfig {
         VmStartConfig {
             name: name.to_string(),


### PR DESCRIPTION
Stacked on #2248, which added `VmBackend::negotiate`. This brings that surface to the facade external projects actually depend on.

## The gap

`MvmClient` had thirteen methods and every one of them was an *instruction*. There was no way to ask a *question*.

A consumer depending on this crate learned that a backend cannot pause by calling `pause_machine` and reading the error. That is a poor way to find out and impossible to plan around — and it meant the capability negotiation added in #2248 was reachable from host-side `VmBackend` code but not from the client facade.

## The addition

```rust
let report = client.backend_capabilities().await?;
match report.negotiate(&required) {
    Ok(()) => { /* backend serves it */ }
    Err(gaps) => for gap in gaps {
        eprintln!("{}: {}", gap.capability, gap.alternative.describe());
    }
}
```

`BackendCapabilityReport` carries *which* backend answered and *what* it advertises. `negotiate` resolves the same alternatives the `VmBackend` seam does, so a facade consumer and host-side code cannot disagree about what a backend can do.

**Why it returns a report rather than taking a requirement set:** negotiation is pure. A remote client pays one round trip and then answers any number of requirement sets locally — so a gateway needs a *capability* endpoint, not a *negotiation* one. `VmCapabilities`, `BackendKind` and `SnapshotCapability` gain serde for that hop; additive, since nothing serialized them before.

`deny_unknown_fields` on the report is deliberate: a server that grows a field should fail loudly rather than have it silently dropped, because a consumer reasoning about a partial capability matrix is worse off than one that got an error.

## All four implementors answer honestly

- **`LocalBackend`** reads the backend that will actually run the workload, so the report cannot drift from the thing it describes.
- **`GatewayBackend`** fetches over the wire.
- **`MockBackend`** defaults to the all-false matrix and gains `with_capabilities`, so a test that forgets to configure one sees refusals rather than a mock silently claiming everything.
- **`SubprocessBackend`** (mvm-sdk) inherits via the trait.

Deliberately a **required** method, not a defaulted one. A default would let an implementor quietly report a matrix it had never thought about — exactly the failure this exists to stop.

## Tests — 6

Four on the report: JSON round trip, unknown-field refusal, negotiating without touching a backend, and one report answering several requirement sets (the property that justifies the shape). Two drive a `dyn MvmClient`, which is the form an external consumer actually holds.

## Verification

- Full `cargo nextest run --workspace`: **10606 passed, 0 failed**
- 550 tests under `wasm32-wasip1`; `wasm32-unknown-unknown` builds
- `--features client` and `--features client-remote` both check clean
- Workspace clippy `-D warnings` clean (pre-commit)

## Note on the gateway

The gateway impl calls `GET /api/v1/backend/capabilities`. That endpoint has to exist server-side for the remote path to work; the local path is complete today. Worth confirming against the fleet API before anyone relies on `GatewayBackend::backend_capabilities`.
