### PR TITLE
ci: repair the confinement lane and gate cargo -p against workspace members

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -361,23 +361,23 @@ jobs:
         # or rename — the count guard turns that into a red lane.
         run: ./scripts/check-sealed-prod-allowlist.sh
 
-  # ── Lane: jailer-lite-property (Plan 113 §Task 9 + Task 15) ───────
+  # ── Lane: jailer-property (Plan 113 §Task 9 + Task 15) ───────────
   # Runs the `#[ignore]`-gated seccomp + Landlock property tests in
-  # `crates/mvm-jailer-lite/tests/{seccomp_property,landlock_property}.rs`.
+  # `crates/mvm-hostd/tests/{seccomp_property,landlock_property}.rs`.
   # Both tests are integration-test binaries gated behind
   # `#![cfg(target_os = "linux")]` and `#[ignore = "..."]` so a
-  # plain `cargo test -p mvm-jailer-lite` is a no-op on Linux + a
+  # plain `cargo test -p mvm-hostd` is a no-op on Linux + a
   # zero-binary on macOS / Windows. This lane drives them explicitly
   # with `-- --ignored` on Ubuntu 24.04 (kernel 6.x, which strictly
   # satisfies Landlock ABI v2 best-effort installation — see
-  # `crates/mvm-jailer-lite/src/landlock.rs::install_landlock`).
+  # `crates/mvm-hostd/src/jailer/landlock.rs::apply`).
   # Ubuntu 22.04 ships kernel 5.15 (borderline for ABI v2) and lacks
   # passt in its default apt repos (passt landed in main archives only
   # in 24.04 / noble), so this lane targets 24.04 outright.
   #
   # Runtime: a few seconds. PR-time, every push.
-  jailer-lite-property:
-    name: jailer-lite property tests (seccomp + Landlock) (Plan 113 §Task 9)
+  jailer-property:
+    name: jailer property tests (seccomp + Landlock) (Plan 113 §Task 9)
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     steps:
@@ -388,7 +388,7 @@ jobs:
 
       - name: Install system build deps (see `test` job for why)
         # `lld` matches `.cargo/config.toml`'s linux-gnu link-arg
-        # override. mvm-jailer-lite itself doesn't link libcap-ng,
+        # override. the jailer itself does not link libcap-ng,
         # but the workspace's `mvm-supervisor` transitive does on
         # other crates the cache restores, so keep the apt set
         # aligned with the `test` lane to maximise cache reuse.
@@ -436,20 +436,30 @@ jobs:
         # availability as a step output; the combined property-test
         # step below gates on it so the lane *skips* (not fails) where
         # the LSM can't enforce.
+        # Probe the kernel's own list of active LSMs, not the securityfs
+        # directory. `/sys/kernel/security/landlock/` is absent on kernels
+        # where Landlock is active and enforcing — verified on a 6.8 host that
+        # carries `landlock` in the LSM list and passes both property tests
+        # while that directory does not exist. Gating on the directory made
+        # this lane skip itself on a working kernel, which is exactly the
+        # failure a skip-rather-than-fail gate is least able to surface.
         run: |
           set -euo pipefail
           uname -r
-          if [ ! -d /sys/kernel/security/landlock ]; then
-            echo "::warning::Landlock LSM not active on this runner — skipping the jailer-lite property tests (both seccomp and Landlock probes share confine_self, which applies Landlock first)."
+          echo "active LSMs: $(cat /sys/kernel/security/lsm 2>/dev/null || echo '(unreadable)')"
+          if ! grep -qw landlock /sys/kernel/security/lsm 2>/dev/null; then
+            echo "::warning::Landlock LSM not active on this runner — skipping the jailer property tests (both seccomp and Landlock probes share confine_self, which applies Landlock first)."
             echo "available=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "Landlock ABI versions exposed:"
-          cat /sys/kernel/security/landlock/abi_versions 2>/dev/null || echo "(file missing)"
+          # Informational only: the file is a later-kernel addition, and its
+          # absence says nothing about whether Landlock enforces.
+          cat /sys/kernel/security/landlock/abi_versions 2>/dev/null \
+            || echo "(abi_versions not exposed on this kernel)"
           echo "available=true" >> "$GITHUB_OUTPUT"
 
       - name: Run property tests (seccomp + Landlock)
-        # Both property tests share mvm_jailer_lite::confine_self, which
+        # Both property tests share mvm_hostd::jailer::confine_self, which
         # applies Landlock first then seccomp. On runners where Landlock
         # isn't fully enforced (Azure kernel on GitHub's stock
         # ubuntu-24.04, etc.), confine_self errors out before the
@@ -463,7 +473,7 @@ jobs:
         # readable in the log.
         if: steps.landlock_probe.outputs.available == 'true'
         run: |
-          cargo test -p mvm-jailer-lite \
+          cargo test -p mvm-hostd \
             --test seccomp_property \
             --test landlock_property \
             -- --ignored --nocapture
@@ -592,7 +602,12 @@ jobs:
             builder_vm:
               - 'nix/images/builder-vm/**'
               - 'nix/lib/**'
-              - 'crates/mvm-host-vm-init/**'
+              # `mvm-host-vm-init` is a [[bin]] of mvm-build, not a crate of
+              # its own — the standalone directory this used to name was
+              # absorbed. A filter on a path that cannot exist never matches,
+              # so edits to the builder VM's PID 1 stopped triggering this
+              # lane silently.
+              - 'crates/mvm-build/src/bin/mvm-host-vm-init/**'
 
       - name: Install Nix
         if: steps.filter.outputs.builder_vm == 'true' || github.ref == 'refs/heads/main'
@@ -904,7 +919,7 @@ jobs:
           MVM_FC_BOOT_SMOKE: "1"
           MVM_FC_SMOKE_KERNEL: ${{ github.workspace }}/ci-artifacts/vmlinux
           MVM_FC_SMOKE_ROOTFS: ${{ github.workspace }}/ci-artifacts/rootfs.ext4
-        run: cargo test -p mvm-host-vm-init live_firecracker_boot_smoke -- --nocapture
+        run: cargo test -p mvm-build --bin mvm-host-vm-init live_firecracker_boot_smoke -- --nocapture
 
   # ── Plan 85 finalization: named, path-gated OCI gates ─────────────
   #

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -383,7 +383,7 @@ jobs:
           RUSTUP_TOOLCHAIN: nightly-2026-06-11
         # Plan 113 §Task 15 / ADR-064 — the `mvm-bridge`
         # sidecar reads a `BridgeConfigJson` document on stdin BEFORE
-        # installing `mvm-jailer-lite` confinement or touching the
+        # installing the jailer confinement or touching the
         # parent-inherited socketpair fds. The producer (Task 13's
         # `FirecrackerBackend`) is trusted, but the bytes traverse a
         # pipe the bridge must defend; a panic here is a hard process

--- a/specs/plans/305-delete-dead-gateway-stack.md
+++ b/specs/plans/305-delete-dead-gateway-stack.md
@@ -1,0 +1,150 @@
+# Plan 305 — Delete the dead guest-NIC gateway stack
+
+**Status: IN PROGRESS**
+**Supersedes:** the confinement-first framing this plan opened with (see
+"History" below)
+**Related:** plan 303 WS6, ADR-003, ADR-014 claim 10, `xtask
+check-vsock-only-egress`
+
+## Why
+
+Workload egress converged on vsock. Every workload backend boots with a
+virtio-vsock device and no net device, and egress leaves the guest only over
+the per-VM substitution endpoint. The guest-NIC gateway stack that predates
+that convergence — passt, gvproxy, the native/rvproxy gateway, the `mvm-bridge`
+sidecar, and the observer packet pipeline they feed — is still in the tree but
+no longer reachable.
+
+This is not an inference from the docs. It is what the code says:
+
+- `crates/mvm-build/src/libkrun_builder.rs:154` — *"The active transport is now
+  direct vsock on every backend. `MVM_NETWORKING` is retained only as a
+  compatibility knob so stale shells produce a warning instead of silently
+  reopening legacy guest-NIC code paths."* The env var is read only to log
+  `"MVM_NETWORKING is ignored; libkrun networking is now direct-vsock only"`.
+- `crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs:470` — *"Historical
+  native-gateway hook: this now stays inert because the active libkrun
+  transport is direct-vsock only."*
+- `should_use_bridge_route()` (same file, ~252) returns **false** for
+  `Tsi | VsockDirect`, and those are the only modes anything produces.
+- `ConfigBuilder::with_passt` has **zero** non-test callers. The only
+  construction of `NetworkingMode::Passt` in the tree is inside a `#[test]`.
+- `with_native_gateway_config` is called only from inside a block already
+  guarded on `cfg.krun.networking` *being* `NativeGateway`, which nothing sets.
+- `run_packet_pipeline`'s only non-test callers are `gateway_bridge/passt.rs`
+  and `gateway_bridge/native_gateway.rs`.
+
+So the whole subtree is unreachable, and it is not inert weight: it is a second
+egress model sitting next to the real one, with its own policy surface, its own
+audit path, and its own confinement spec. `xtask check-vsock-only-egress`
+exists precisely to keep gateway tokens off workload paths — deleting the
+gateway makes that gate trivially true instead of continuously defended.
+
+## Two live findings this surfaced
+
+1. **The only CI lane exercising Landlock + seccomp confinement cannot run.**
+   `.github/workflows/ci-full.yml` invokes `cargo test -p mvm-jailer-lite`.
+   That crate was absorbed into `mvm-hostd` and no longer exists as a
+   workspace member, so the step fails to resolve its package. The lane is
+   `workflow_dispatch`-only, which is why nobody noticed. The tests themselves
+   are fine — run on a live Landlock kernel (6.8, `landlock` in
+   `/sys/kernel/security/lsm`) both pass.
+2. **`ConfinementSpec::firecracker_bridge` hard-requires `/usr/bin/passt` to
+   exist**, because Landlock's `PathFd::new` opens every allowlisted path. On a
+   box without passt the property tests fail with `landlock path missing`. That
+   is a spec pinned to a binary the runtime no longer launches.
+
+## Workstreams
+
+### WS1 — Fix the broken confinement lane
+
+Independent of the deletion and worth landing first: a gate that cannot run is
+worse than no gate, because the row in the ledger says it is covered.
+
+- [x] `-p mvm-jailer-lite` → `-p mvm-hostd` in `ci-full.yml`, and correct the
+      stale `crates/mvm-jailer-lite/...` paths in the lane comments and job name
+- [x] xtask gate: every `-p <pkg>` in a workflow names a real workspace member,
+      so the next crate consolidation cannot silently orphan a lane. Live over
+      121 `-p` references across 20 workflow files
+
+Writing the gate turned up three more defects in the same file, all of the
+same shape — `ci-full.yml` is `workflow_dispatch`-only, so nothing it says is
+ever contradicted by a run:
+
+- [x] **The Landlock probe skipped itself on working kernels.** It gated on
+      `[ -d /sys/kernel/security/landlock ]`. That directory does not exist on
+      the live 6.8 box, which nonetheless carries `landlock` in
+      `/sys/kernel/security/lsm` and passes both property tests. Now probes the
+      LSM list, which is the kernel's own answer.
+- [x] **`cargo test -p mvm-host-vm-init`** in the Firecracker boot-smoke lane.
+      That is a `[[bin]]` of `mvm-build`, not a package, so the lane could not
+      resolve it either. Now `-p mvm-build --bin mvm-host-vm-init`.
+- [x] **A paths filter on `crates/mvm-host-vm-init/**`**, a directory absorbed
+      into `mvm-build`. A trigger that cannot match never fires, so edits to
+      the builder VM's PID 1 silently stopped gating the builder-vm lane.
+
+Verified on the live Linux box: with the corrected command, both property
+tests pass under an enforcing Landlock (`landlock_denies_paths_outside_ruleset`,
+`seccomp_allows_listed_denies_unlisted`).
+
+One caveat found while doing it, feeding WS2: the tests only pass there because
+`passt` was installed. `ConfinementSpec::firecracker_bridge` lists the passt
+binary as a Landlock-readable path, and `PathFd::new` opens every path in the
+ruleset — so the spec cannot be built on a host without a binary the runtime
+never launches.
+
+### WS2 — Delete the gateway stack
+
+Staged so each step compiles and the test suite stays green.
+
+- [ ] `NetworkingMode::{Passt, NativeGateway}` and their builder setters
+- [ ] `libkrun-sys`: `bridge.rs`, `run_supervisor_with_bridge`,
+      `native_gateway.rs`, passt spawn in `start.rs`/`supervisor.rs`
+- [ ] `mvm-hostd`: `gateway_bridge/{passt,native_gateway,native_gateway_live}.rs`,
+      `supervisor/network/rvproxy_*.rs`, and whatever of `gateway_bridge/` is
+      left with no live caller
+- [ ] `mvm-bridge` sidecar bin + `src/bridge/`, and its `ConfinementSpec` +
+      `BRIDGE_SYSCALLS` if nothing else uses them
+- [ ] `run_with_bridge` / `should_use_bridge_route` in the libkrun supervisor
+- [ ] `MVM_NETWORKING` and `MVM_GATEWAY_BIN`
+- [ ] The observer packet pipeline (`supervisor/network/pipeline.rs`) **only if**
+      the compiler confirms no live caller survives — it is shared with the
+      scan/substitution stages, so this one gets checked, not assumed
+
+Anything whose deletion the compiler resists gets reported, not forced.
+
+### WS3 — Correct the docs the deletion falsifies
+
+- [ ] CLAUDE.md "Host dependencies (macOS)" still instructs `brew install
+      slp/krun/gvproxy` and documents an `MVM_NETWORKING` per-OS default table
+      that `libkrun_builder.rs:193` contradicts
+- [ ] ADR-003 and any claim-5/claim-10 prose that describes the gateway parsers
+      as a live surface
+
+### WS4 — Then confine the signer roles
+
+The original plan-305 scope, deferred behind the deletion because it is a
+smaller surface afterwards: `mvm-host-signer`, `mvm-audit-signer`,
+`mvm-signer-helper`, `mvm-broker` still run unconfined while `mvm-bridge` —
+about to be deleted — is one of only two bins that call `confine_self`.
+
+Blocked on: `mvmctl seccomp-audit` traces only the main thread, and all four
+roles build `tokio::runtime::Builder::new_multi_thread()`, so any allowlist it
+produces today is incomplete by construction and the failure mode is SIGSYS
+under load. Extend the tracer with `PTRACE_O_TRACECLONE` first.
+
+- [ ] Extend `seccomp-audit` to follow clones/threads
+- [ ] Derive the four allowlists on the live Linux box
+- [ ] One PR per role
+
+## History
+
+This plan opened as "confine the four unconfined moat roles". That framing
+survived until the gateway stack was examined and found inert: confining
+`mvm-bridge`'s peers is worth less than deleting the model `mvm-bridge` exists
+to serve. The confinement work is preserved as WS4 rather than dropped.
+
+## Validation
+
+The live Linux box (kernel 6.8, Landlock active, `/dev/kvm`) is the target for
+anything kernel-dependent. Both confinement property tests already pass there.

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -27,9 +27,11 @@ struct FuzzInvocation {
 
 pub fn run(workspace: &Path) -> Result<()> {
     let workflows = workflow_files(workspace)?;
+    let members = workspace_package_names(workspace)?;
     let mut problems = Vec::new();
     let mut checked_dirs = 0usize;
     let mut checked_targets = 0usize;
+    let mut checked_packages = 0usize;
 
     for path in &workflows {
         let src =
@@ -65,6 +67,18 @@ pub fn run(workspace: &Path) -> Result<()> {
                 problems.push(format!("{name}: fuzz target {rel:?} does not exist"));
             }
         }
+
+        for pkg in cargo_package_flags(&src) {
+            if pkg.contains("${{") {
+                continue;
+            }
+            checked_packages += 1;
+            if !members.contains(&pkg) {
+                problems.push(format!(
+                    "{name}: `cargo ... -p {pkg}` names no workspace member"
+                ));
+            }
+        }
     }
 
     if !problems.is_empty() {
@@ -79,12 +93,134 @@ pub fn run(workspace: &Path) -> Result<()> {
     }
 
     eprintln!(
-        "check-workflow-paths: clean ({} working-directory, {} fuzz target(s) across {} workflow file(s))",
+        "check-workflow-paths: clean ({} working-directory, {} fuzz target(s), {} cargo -p package(s) across {} workflow file(s))",
         checked_dirs,
         checked_targets,
+        checked_packages,
         workflows.len()
     );
     Ok(())
+}
+
+/// Every package name declared by a workspace member, plus the root package.
+///
+/// Read from the manifests rather than `cargo metadata` so the gate stays a
+/// cheap file-parse that can run in the PR lint lane — the same reason the
+/// path checks above stat rather than build.
+fn workspace_package_names(root: &Path) -> Result<std::collections::HashSet<String>> {
+    let root_manifest = root.join("Cargo.toml");
+    let src = std::fs::read_to_string(&root_manifest)
+        .with_context(|| format!("read {}", root_manifest.display()))?;
+
+    let mut names = std::collections::HashSet::new();
+    if let Some(n) = package_name(&src) {
+        names.insert(n);
+    }
+    for member in workspace_members(&src) {
+        let manifest = root.join(&member).join("Cargo.toml");
+        let Ok(body) = std::fs::read_to_string(&manifest) else {
+            // A members entry pointing at a deleted directory is its own bug,
+            // but it is the workspace's to report — `cargo` fails loudly on it
+            // long before this gate runs.
+            continue;
+        };
+        if let Some(n) = package_name(&body) {
+            names.insert(n);
+        }
+    }
+    Ok(names)
+}
+
+/// `members = [...]` entries from a workspace manifest, unquoted.
+fn workspace_members(src: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut in_members = false;
+    for line in src.lines() {
+        let t = line.trim();
+        if t.starts_with("members") && t.contains('[') {
+            in_members = true;
+            continue;
+        }
+        if in_members {
+            if t.starts_with(']') {
+                break;
+            }
+            let v = t.trim_end_matches(',').trim().trim_matches('"');
+            if !v.is_empty() && !v.starts_with('#') {
+                out.push(v.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// The `name = "..."` under a manifest's `[package]` table.
+fn package_name(src: &str) -> Option<String> {
+    let mut in_package = false;
+    for line in src.lines() {
+        let t = line.trim();
+        if t.starts_with('[') {
+            in_package = t == "[package]";
+            continue;
+        }
+        if in_package && let Some(rest) = t.strip_prefix("name") {
+            let v = rest
+                .trim_start()
+                .strip_prefix('=')?
+                .trim()
+                .trim_matches('"');
+            return Some(v.to_string());
+        }
+    }
+    None
+}
+
+/// Package names passed to cargo via `-p` / `--package` in a workflow.
+///
+/// Scoped to lines that actually invoke cargo. Other tools spell `-p`
+/// differently — `tar -p`, `gh release -p`, `mkdir -p` — and matching those
+/// would make the gate reject names that were never package references. The
+/// scan is line-based, so a `-p` continued onto the next line via `\` is
+/// missed; that is a deliberate false-negative, since the alternative is
+/// guessing at shell continuation and producing false positives instead.
+fn cargo_package_flags(src: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in src.lines() {
+        // Comment lines describe commands, they do not run them, and prose
+        // wraps names in backticks that are not part of the name.
+        if line.trim_start().starts_with('#') {
+            continue;
+        }
+        // `cargo` must appear as its own command token before the flag.
+        // Substring matching would take `mkdir -p .cargo` — where the *path*
+        // contains "cargo" — as a package reference.
+        let mut saw_cargo = false;
+        let mut it = line.split_whitespace();
+        while let Some(tok) = it.next() {
+            let bare = tok.trim_matches(['"', '\'', '`', '\\']);
+            if bare == "cargo" || bare.ends_with("/cargo") {
+                saw_cargo = true;
+                continue;
+            }
+            if !saw_cargo {
+                continue;
+            }
+            let value = match bare {
+                "-p" | "--package" => it.next(),
+                _ => bare.strip_prefix("--package="),
+            };
+            if let Some(v) = value {
+                let v = v.trim_matches(['"', '\'', '`', '\\', ',']);
+                // `${{ matrix.crate }}` and `${CRATE}` resolve at run time;
+                // there is no literal name to check.
+                if v.is_empty() || v.starts_with('-') || v.starts_with('$') {
+                    continue;
+                }
+                out.push(v.to_string());
+            }
+        }
+    }
+    out
 }
 
 fn workflow_files(root: &Path) -> Result<Vec<std::path::PathBuf>> {
@@ -462,5 +598,86 @@ mod tests {
             unexpected.is_empty(),
             "new test-support source owners need an explicit targeted CI command: {unexpected:?}"
         );
+    }
+
+    /// The bug this check was written for: `ci-full.yml` invoked
+    /// `cargo test -p mvm-jailer-lite` after that crate was absorbed into
+    /// `mvm-hostd`, so the only lane exercising Landlock + seccomp
+    /// confinement could not resolve its own package. The lane is
+    /// `workflow_dispatch`-only, which is why it went unnoticed.
+    #[test]
+    fn a_cargo_p_naming_a_dead_crate_is_caught() {
+        let flags = cargo_package_flags("          cargo test -p mvm-jailer-lite \\");
+        assert_eq!(flags, vec!["mvm-jailer-lite".to_string()]);
+
+        let members =
+            workspace_package_names(Path::new(env!("CARGO_MANIFEST_DIR")).join("..").as_path())
+                .expect("read workspace members");
+        assert!(
+            members.contains("mvm-hostd"),
+            "sanity: mvm-hostd must be a member"
+        );
+        assert!(
+            !members.contains("mvm-jailer-lite"),
+            "mvm-jailer-lite was absorbed into mvm-hostd and must not resolve"
+        );
+    }
+
+    /// `-p` belongs to plenty of tools that are not cargo. Matching those
+    /// would make the gate reject names that were never package references.
+    #[test]
+    fn non_cargo_dash_p_is_not_treated_as_a_package() {
+        for line in [
+            "          tar -xzf -p dist",
+            "          mkdir -p target/release-assets",
+            "          gh release upload -p staging",
+            // The one that caught the naive substring match out: the *path*
+            // contains "cargo", the command is not cargo.
+            "          mkdir -p .cargo",
+            // Prose describing a command is not a command.
+            "        # plain `cargo test -p mvm-hostd` is a no-op on Linux",
+        ] {
+            assert!(
+                cargo_package_flags(line).is_empty(),
+                "non-cargo line must yield no packages: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn package_flags_handle_both_spellings_and_quoting() {
+        assert_eq!(
+            cargo_package_flags("        run: cargo nextest run --package mvm-fs"),
+            vec!["mvm-fs".to_string()]
+        );
+        assert_eq!(
+            cargo_package_flags("        run: cargo build --package=mvm-core"),
+            vec!["mvm-core".to_string()]
+        );
+        // Names resolved at run time carry no literal to check, in either
+        // GitHub's `${{ }}` or shell `${}` spelling.
+        assert!(cargo_package_flags("        run: cargo test -p ${{ matrix.crate }}").is_empty());
+        assert!(cargo_package_flags("          cargo publish -p ${CRATE}").is_empty());
+    }
+
+    /// Every `cargo -p` across the real workflow tree resolves today. This is
+    /// the assertion that would have gone red on the stale reference.
+    #[test]
+    fn every_workflow_cargo_package_resolves() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        let members = workspace_package_names(&root).expect("members");
+        let mut stale = Vec::new();
+        for path in workflow_files(&root).expect("workflow files") {
+            let src = std::fs::read_to_string(&path).expect("read workflow");
+            for pkg in cargo_package_flags(&src) {
+                if pkg.contains("${{") {
+                    continue;
+                }
+                if !members.contains(&pkg) {
+                    stale.push(format!("{}: {pkg}", path.display()));
+                }
+            }
+        }
+        assert!(stale.is_empty(), "stale cargo -p references: {stale:?}");
     }
 }


### PR DESCRIPTION
`ci-full.yml`'s jailer lane — the only CI that exercises Landlock + seccomp confinement — could not run, in four independent ways. That file is `workflow_dispatch`-only, so nothing it claims is ever contradicted by a run: a lane that cannot execute still reads as coverage from the claims ledger.

Found while scoping plan 305. Each was verified against a live Linux host (kernel 6.8, `landlock` in `/sys/kernel/security/lsm`, `/dev/kvm`).

## The four defects

**1. `cargo test -p mvm-jailer-lite`** — that crate was absorbed into `mvm-hostd` and is not a workspace member, so the step fails to resolve its package before running anything. With the corrected command, both property tests pass on the live box under an enforcing Landlock:

```
test landlock_denies_paths_outside_ruleset ... ok
test seccomp_allows_listed_denies_unlisted ... ok
```

**2. The Landlock probe skipped the lane on kernels where Landlock works.** It gated on `[ -d /sys/kernel/security/landlock ]`. That directory does not exist on the same 6.8 host that carries `landlock` in the LSM list and passes both tests — `abi_versions` is a later-kernel addition. Now probes `/sys/kernel/security/lsm`, which is the kernel's own answer to the question being asked. A skip-rather-than-fail gate is exactly the shape that hides this: it prints a warning and goes green.

**3. `cargo test -p mvm-host-vm-init`** in the Firecracker boot-smoke lane — a `[[bin]]` of `mvm-build`, not a package. Same unresolvable-package failure. Now `-p mvm-build --bin mvm-host-vm-init`.

**4. A paths filter on `crates/mvm-host-vm-init/**`** — a directory absorbed into `mvm-build`. A trigger that cannot match never fires, so edits to the builder VM's PID 1 silently stopped gating the builder-vm lane.

## The gate

To stop 1 and 3 recurring, `check-workflow-paths` now resolves every `cargo ... -p <pkg>` across all workflows against the workspace members, alongside the working-directory and fuzz-target checks it already performs. Same file, same cheap file-parse — it runs in the PR lint lane.

Scoping matters and is tested: the check only considers lines that invoke `cargo` as a command token. `mkdir -p .cargo` has "cargo" in the *path*, and a substring match would reject a name that was never a package reference. Comment lines are skipped (prose describes commands in backticks), as are run-time-templated names in both `${{ }}` and `${}` spellings.

Live over **121 `-p` references across 20 workflow files**.

## Verification

- `cargo run -p xtask -- check-workflow-paths` — clean (19 working-directory, 16 fuzz targets, 121 packages)
- `cargo nextest run -p xtask` — 443 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- The corrected jailer command, run on live Linux — both property tests pass

## Caveat this surfaced

The property tests only pass on that host because `passt` was installed first. `ConfinementSpec::firecracker_bridge` lists the passt binary as a Landlock-readable path and `PathFd::new` opens every path in a ruleset — so the spec cannot be constructed on a host lacking a binary the runtime no longer launches. That feeds plan 305's main workstream (deleting the dead guest-NIC gateway stack) and is recorded there rather than patched over here.
