### PR TITLE
Unify runtime policy and human approval

### DIFF
--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -27,6 +27,7 @@ pub mod stream;
 pub mod stream_tracing;
 pub mod volume;
 
+pub use mvm_contract::policy::approval;
 pub use mvm_contract::protocol::agent_session;
 pub use mvm_core::client::dto;
 pub use mvm_core::client::dto::{

--- a/crates/mvm-conformance/tests/steps/mod.rs
+++ b/crates/mvm-conformance/tests/steps/mod.rs
@@ -9,6 +9,7 @@ mod initramfs;
 mod kernel_pin;
 mod l3_vsock;
 mod oci_unpack;
+mod policy_approval;
 mod readme_contract;
 mod runtime_overlay;
 mod sdk;

--- a/crates/mvm-conformance/tests/steps/policy_approval.rs
+++ b/crates/mvm-conformance/tests/steps/policy_approval.rs
@@ -1,0 +1,285 @@
+//! BDD witnesses for typed policy decisions and durable human approval.
+
+use cucumber::{given, then, when};
+use mvm_contract::policy::approval::{
+    AgentApprovalEvent, ApprovalLedger, ApprovalOutcome, ApprovalRequest, ApprovalRequestId,
+    ApprovalResponse, ApprovalState, OperatorId, PolicyCapability, PolicyDecision, PolicyEffect,
+    PolicyRequest, PolicyRule, PolicySet, SignedAdmission,
+};
+use mvm_contract::protocol::agent_session::{
+    AgentSessionId, AgentSessionJournal, IdempotencyKey, RetentionPolicy,
+};
+
+use crate::world::CliWorld;
+
+fn session_id() -> AgentSessionId {
+    AgentSessionId::parse("bdd-approval-session").expect("valid approval session")
+}
+
+fn operator(raw: &str) -> OperatorId {
+    OperatorId::parse(raw).expect("valid operator")
+}
+
+fn approval_id(raw: &str) -> ApprovalRequestId {
+    ApprovalRequestId::parse(raw).expect("valid approval")
+}
+
+fn admitted_request(capability: PolicyCapability) -> PolicyRequest {
+    let unsigned = PolicyRequest {
+        capability,
+        resource_digest: [4; 32],
+        request_digest: [5; 32],
+        admission: None,
+    };
+    PolicyRequest {
+        admission: Some(SignedAdmission {
+            plan_digest: [6; 32],
+            capability_digest: unsigned.capability_digest(),
+        }),
+        ..unsigned
+    }
+}
+
+fn approval_request(
+    evaluation: &mvm_contract::policy::approval::PolicyEvaluation,
+    request: &PolicyRequest,
+    approval_id: ApprovalRequestId,
+    expires_at_unix_ms: u64,
+) -> ApprovalRequest {
+    ApprovalRequest {
+        approval_id,
+        session_id: session_id(),
+        idempotency_key: IdempotencyKey::parse("bdd-approval-retry").expect("valid retry key"),
+        capability: request.capability,
+        resource_digest: request.resource_digest,
+        request_digest: request.request_digest,
+        policy_digest: evaluation.policy_digest,
+        admission_plan_digest: [6; 32],
+        reason: mvm_contract::policy::approval::ApprovalReason::PolicyRule,
+        authorized_operators: vec![operator("ops-a")],
+        expires_at_unix_ms,
+    }
+}
+
+fn journal(world: &mut CliWorld) -> &mut AgentSessionJournal {
+    world
+        .agent_session_journal
+        .as_mut()
+        .expect("approval journal must be open")
+}
+
+fn ledger(world: &mut CliWorld) -> &mut ApprovalLedger {
+    world
+        .approval_ledger
+        .as_mut()
+        .expect("approval ledger must be initialized")
+}
+
+fn ledger_and_journal(world: &mut CliWorld) -> (&mut ApprovalLedger, &mut AgentSessionJournal) {
+    let ledger = world
+        .approval_ledger
+        .as_mut()
+        .expect("approval ledger must be initialized");
+    let journal = world
+        .agent_session_journal
+        .as_mut()
+        .expect("approval journal must be open");
+    (ledger, journal)
+}
+
+#[given("an unadmitted policy request")]
+fn unadmitted_policy_request(world: &mut CliWorld) {
+    let request = PolicyRequest {
+        capability: PolicyCapability::NetworkConnect,
+        resource_digest: [1; 32],
+        request_digest: [2; 32],
+        admission: None,
+    };
+    let evaluation = PolicySet::default().evaluate(&request);
+    world.approval_evaluation = Some(evaluation);
+    world.approval_error = None;
+}
+
+#[then("policy denies it without an approval request")]
+fn unadmitted_request_is_denied(world: &mut CliWorld) {
+    assert_eq!(
+        world.approval_evaluation.expect("evaluation").decision,
+        PolicyDecision::Deny(mvm_contract::policy::approval::PolicyReason::NotAdmitted)
+    );
+    assert!(world.approval_ledger.is_none());
+}
+
+#[given("a signed-admission policy requiring approval")]
+fn signed_policy_requires_approval(world: &mut CliWorld) {
+    let (journal, _) =
+        AgentSessionJournal::open(session_id(), [7; 32], 1_000, RetentionPolicy::default())
+            .expect("open approval journal");
+    let request = admitted_request(PolicyCapability::FilesystemWrite);
+    let policy = PolicySet::new(vec![PolicyRule {
+        capability: request.capability,
+        resource_digest: None,
+        priority: 10,
+        effect: PolicyEffect::Ask,
+    }])
+    .expect("valid policy");
+    let evaluation = policy.evaluate(&request);
+    assert!(matches!(evaluation.decision, PolicyDecision::Ask(_)));
+    world.agent_session_journal = Some(journal);
+    world.approval_evaluation = Some(evaluation);
+    world.approval_ledger = Some(ApprovalLedger::new(session_id()));
+    world.approval_id = Some(approval_id("bdd-approval-1"));
+    world.approval_error = None;
+    world.approval_state = None;
+}
+
+#[when("I create the approval request")]
+fn create_approval_request(world: &mut CliWorld) {
+    let evaluation = world.approval_evaluation.expect("evaluation");
+    let request = admitted_request(evaluation.capability);
+    let id = world.approval_id.clone().expect("approval id");
+    let approval = approval_request(&evaluation, &request, id, 2_000);
+    let result = {
+        let (ledger, journal) = ledger_and_journal(world);
+        ledger.request(journal, &evaluation, approval, 1_001)
+    };
+    match result {
+        Ok(outcome) => world.approval_state = Some(outcome.state),
+        Err(error) => world.approval_error = Some(error.to_string()),
+    }
+}
+
+#[when("an unauthorized operator responds")]
+fn unauthorized_operator_responds(world: &mut CliWorld) {
+    let id = world.approval_id.clone().expect("approval id");
+    let result = {
+        let (ledger, journal) = ledger_and_journal(world);
+        ledger.respond(
+            journal,
+            ApprovalResponse {
+                approval_id: id,
+                operator_id: operator("ops-b"),
+                outcome: ApprovalOutcome::Approved,
+                response_nonce: 1,
+            },
+            1_002,
+        )
+    };
+    world.approval_error = Some(result.expect_err("unauthorized response").to_string());
+}
+
+#[then("the response is refused without changing approval state")]
+fn response_is_refused(world: &mut CliWorld) {
+    let id = world.approval_id.clone().expect("approval id");
+    assert_eq!(
+        world.approval_error.as_deref(),
+        Some("approval is not authorized for this operator")
+    );
+    assert_eq!(
+        ledger(world).state(&id).expect("approval state"),
+        ApprovalState::Pending
+    );
+}
+
+#[when("the authorized operator approves")]
+fn authorized_operator_approves(world: &mut CliWorld) {
+    let id = world.approval_id.clone().expect("approval id");
+    let result = {
+        let (ledger, journal) = ledger_and_journal(world);
+        ledger.respond(
+            journal,
+            ApprovalResponse {
+                approval_id: id,
+                operator_id: operator("ops-a"),
+                outcome: ApprovalOutcome::Approved,
+                response_nonce: 2,
+            },
+            1_003,
+        )
+    };
+    match result {
+        Ok(state) => world.approval_state = Some(state),
+        Err(error) => world.approval_error = Some(error.to_string()),
+    }
+}
+
+#[then("the approval is durable and approved")]
+fn approval_is_durable(world: &mut CliWorld) {
+    assert_eq!(world.approval_state, Some(ApprovalState::Approved));
+    let page = journal(world).history(None, 32).expect("approval history");
+    assert!(
+        page.events.iter().any(|envelope| {
+            match &envelope.event {
+                mvm_contract::protocol::agent_session::AgentSessionEvent::Durable {
+                    event:
+                        mvm_contract::protocol::agent_session::DurableAgentSessionEvent::Approval {
+                            event,
+                        },
+                } => matches!(event.as_ref(), AgentApprovalEvent::Responded { .. }),
+                _ => false,
+            }
+        })
+    );
+    let rebuilt = ApprovalLedger::from_history(session_id(), &page.events).expect("restart");
+    world.approval_restarted_state = Some(
+        rebuilt
+            .state(world.approval_id.as_ref().expect("approval id"))
+            .expect("restarted state"),
+    );
+    assert_eq!(
+        world.approval_restarted_state,
+        Some(ApprovalState::Approved)
+    );
+}
+
+#[when("the approval expires")]
+fn approval_expires(world: &mut CliWorld) {
+    let id = world.approval_id.clone().expect("approval id");
+    let result = {
+        let (ledger, journal) = ledger_and_journal(world);
+        ledger.expire(journal, &id, 2_000)
+    };
+    match result {
+        Ok(()) => world.approval_state = Some(ApprovalState::Expired),
+        Err(error) => world.approval_error = Some(error.to_string()),
+    }
+}
+
+#[when("a late authorized operator responds")]
+fn late_authorized_operator_responds(world: &mut CliWorld) {
+    let id = world.approval_id.clone().expect("approval id");
+    let result = {
+        let (ledger, journal) = ledger_and_journal(world);
+        ledger.respond(
+            journal,
+            ApprovalResponse {
+                approval_id: id,
+                operator_id: operator("ops-a"),
+                outcome: ApprovalOutcome::Approved,
+                response_nonce: 3,
+            },
+            2_001,
+        )
+    };
+    world.approval_error = Some(result.expect_err("late response").to_string());
+}
+
+#[then("the late response is refused")]
+fn late_response_is_refused(world: &mut CliWorld) {
+    assert_eq!(
+        world.approval_error.as_deref(),
+        Some("approval response was duplicated or arrived after a terminal state")
+    );
+    assert_eq!(world.approval_state, Some(ApprovalState::Expired));
+}
+
+#[then("restart keeps the approval expired")]
+fn restart_keeps_expired(world: &mut CliWorld) {
+    let page = journal(world).history(None, 32).expect("approval history");
+    let rebuilt = ApprovalLedger::from_history(session_id(), &page.events).expect("restart");
+    world.approval_restarted_state = Some(
+        rebuilt
+            .state(world.approval_id.as_ref().expect("approval id"))
+            .expect("restarted state"),
+    );
+    assert_eq!(world.approval_restarted_state, Some(ApprovalState::Expired));
+}

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -338,6 +338,18 @@ pub struct CliWorld {
         Option<mvm_contract::protocol::agent_session::AgentSessionEventEnvelope>,
     /// Sanitized serialized history captured by a security assertion.
     pub agent_session_history_json: Option<String>,
+    /// Typed policy evaluation used by the runtime-approval scenarios.
+    pub approval_evaluation: Option<mvm_contract::policy::approval::PolicyEvaluation>,
+    /// Durable approval ledger reconstructed from the agent-session journal.
+    pub approval_ledger: Option<mvm_contract::policy::approval::ApprovalLedger>,
+    /// Approval id used by the current runtime-approval scenario.
+    pub approval_id: Option<mvm_contract::policy::approval::ApprovalRequestId>,
+    /// Most recent approval operation failure, retained as a stable message.
+    pub approval_error: Option<String>,
+    /// Most recent approval lifecycle state.
+    pub approval_state: Option<mvm_contract::policy::approval::ApprovalState>,
+    /// Approval state reconstructed after a simulated restart.
+    pub approval_restarted_state: Option<mvm_contract::policy::approval::ApprovalState>,
 }
 
 /// What a warm-claim `When` step observed from a `WorkloadRunner::claim_standby`

--- a/crates/mvm-contract/src/policy/approval.rs
+++ b/crates/mvm-contract/src/policy/approval.rs
@@ -1,0 +1,1101 @@
+//! Typed policy evaluation and durable human-approval lifecycle.
+//!
+//! Policy evaluation is deliberately transport-neutral. It requires a
+//! verified admission binding, applies deterministic deny/ask/allow rules,
+//! and exposes only digests and bounded identifiers to the approval journal.
+//! The journal is hosted by `AgentSessionJournal`, so approvals share the
+//! session cursor and do not create a second request/response stream.
+
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::protocol::agent_session::{
+    AgentSessionErrorCode, AgentSessionEvent, AgentSessionEventEnvelope, AgentSessionId,
+    AgentSessionJournal, DurableAgentSessionEvent, IdempotencyKey,
+};
+
+/// Maximum number of rules in one policy set.
+pub const MAX_POLICY_RULES: usize = 256;
+/// Maximum number of operators authorized for one approval.
+pub const MAX_AUTHORIZED_OPERATORS: usize = 16;
+/// Maximum approval lifetime accepted by the contract.
+pub const MAX_APPROVAL_TTL_MS: u64 = 24 * 60 * 60 * 1000;
+const MAX_ID_BYTES: usize = 128;
+
+macro_rules! bounded_id {
+    ($name:ident, $error:ident, $label:literal) => {
+        #[doc = $label]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(try_from = "String", into = "String")]
+        #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+        pub struct $name(String);
+
+        impl $name {
+            /// Parse a lower-case public identifier.
+            pub fn parse(raw: impl Into<String>) -> Result<Self, $error> {
+                let raw = raw.into();
+                if raw.is_empty() {
+                    return Err($error::Empty);
+                }
+                if raw.len() > MAX_ID_BYTES {
+                    return Err($error::TooLong);
+                }
+                if !raw.bytes().all(|byte| {
+                    byte.is_ascii_lowercase()
+                        || byte.is_ascii_digit()
+                        || matches!(byte, b'-' | b'_' | b'.')
+                }) {
+                    return Err($error::IllegalCharacter);
+                }
+                if raw.starts_with('.')
+                    || raw.ends_with('.')
+                    || raw.contains("..")
+                    || raw.contains('/')
+                {
+                    return Err($error::InvalidBoundary);
+                }
+                Ok(Self(raw))
+            }
+
+            /// Borrow the canonical wire representation.
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(&self.0)
+            }
+        }
+
+        impl TryFrom<String> for $name {
+            type Error = $error;
+
+            fn try_from(value: String) -> Result<Self, Self::Error> {
+                Self::parse(value)
+            }
+        }
+
+        impl From<$name> for String {
+            fn from(value: $name) -> Self {
+                value.0
+            }
+        }
+
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+        #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+        pub enum $error {
+            #[error("identifier is empty")]
+            Empty,
+            #[error("identifier exceeds the public length limit")]
+            TooLong,
+            #[error("identifier contains an illegal character")]
+            IllegalCharacter,
+            #[error("identifier has an invalid boundary")]
+            InvalidBoundary,
+        }
+    };
+}
+
+bounded_id!(
+    ApprovalRequestId,
+    ApprovalRequestIdError,
+    "Stable public approval identifier."
+);
+bounded_id!(
+    OperatorId,
+    OperatorIdError,
+    "Stable public operator identifier."
+);
+
+/// Capability being evaluated. The enum prevents policy callsites from
+/// inventing unreviewed stringly-typed operation classes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum PolicyCapability {
+    FilesystemRead,
+    FilesystemWrite,
+    NetworkConnect,
+    ProcessSpawn,
+    ProcessSignal,
+    EnvironmentRead,
+    AgentInvoke,
+}
+
+/// Rule effect after static signed admission has been verified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum PolicyEffect {
+    Deny,
+    Ask,
+    Allow,
+}
+
+/// One deterministic policy rule. `resource_digest = None` is a wildcard;
+/// `Some` is more specific and wins over a wildcard at the same priority.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct PolicyRule {
+    /// Typed capability covered by the rule.
+    pub capability: PolicyCapability,
+    /// Optional SHA-256 digest of the protected resource or target.
+    pub resource_digest: Option<[u8; 32]>,
+    /// Higher priority wins after specificity is considered.
+    pub priority: u16,
+    /// Static effect of this matching rule.
+    pub effect: PolicyEffect,
+}
+
+/// Bounded static policy rule set. An empty set is deny-all.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct PolicySet {
+    /// Ordered rules; order breaks otherwise identical ties.
+    pub rules: Vec<PolicyRule>,
+}
+
+impl PolicySet {
+    /// Validate and construct a policy set.
+    pub fn new(rules: Vec<PolicyRule>) -> Result<Self, PolicyError> {
+        if rules.len() > MAX_POLICY_RULES {
+            return Err(PolicyError::LimitExceeded);
+        }
+        Ok(Self { rules })
+    }
+
+    /// Compute the stable digest used by approval requests and audit records.
+    #[must_use]
+    pub fn digest(&self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        for rule in &self.rules {
+            hasher.update([capability_tag(rule.capability)]);
+            hasher.update(rule.resource_digest.unwrap_or([0; 32]));
+            hasher.update([u8::from(rule.resource_digest.is_some())]);
+            hasher.update(rule.priority.to_be_bytes());
+            hasher.update([effect_tag(rule.effect)]);
+        }
+        hasher.finalize().into()
+    }
+
+    /// Evaluate an operation after verifying its admission binding.
+    #[must_use]
+    pub fn evaluate(&self, request: &PolicyRequest) -> PolicyEvaluation {
+        let policy_digest = self.digest();
+        let base = |decision: PolicyDecision, matched_rule| PolicyEvaluation {
+            capability: request.capability,
+            resource_digest: request.resource_digest,
+            request_digest: request.request_digest,
+            admission_plan_digest: request
+                .admission
+                .as_ref()
+                .map(|binding| binding.plan_digest),
+            policy_digest,
+            matched_rule,
+            decision,
+        };
+
+        let Some(admission) = request.admission else {
+            return base(PolicyDecision::Deny(PolicyReason::NotAdmitted), None);
+        };
+        if admission.capability_digest != request.capability_digest() {
+            return base(PolicyDecision::Deny(PolicyReason::AdmissionMismatch), None);
+        }
+
+        let mut best: Option<(usize, &PolicyRule)> = None;
+        for (index, rule) in self.rules.iter().enumerate() {
+            if rule.capability != request.capability
+                || rule
+                    .resource_digest
+                    .is_some_and(|digest| digest != request.resource_digest)
+            {
+                continue;
+            }
+            let replace = best.is_none_or(|(_, best_rule)| {
+                (
+                    rule.resource_digest.is_some() as u8,
+                    rule.priority,
+                    effect_rank(rule.effect),
+                ) > (
+                    best_rule.resource_digest.is_some() as u8,
+                    best_rule.priority,
+                    effect_rank(best_rule.effect),
+                )
+            });
+            if replace {
+                best = Some((index, rule));
+            }
+        }
+
+        match best {
+            Some((index, rule)) => base(rule.effect.into(), Some(index as u32)),
+            None => base(PolicyDecision::Deny(PolicyReason::DefaultDeny), None),
+        }
+    }
+}
+
+/// Binding supplied only after signed plan admission and capability checking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SignedAdmission {
+    /// Content digest of the verified signed execution plan.
+    pub plan_digest: [u8; 32],
+    /// Digest of the exact capability/resource pair admitted by the plan.
+    pub capability_digest: [u8; 32],
+}
+
+/// Operation input to policy evaluation. Raw operation bytes stay outside the
+/// contract; callers provide a digest instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct PolicyRequest {
+    /// Typed operation being requested.
+    pub capability: PolicyCapability,
+    /// SHA-256 digest of the protected resource or target.
+    pub resource_digest: [u8; 32],
+    /// SHA-256 digest of the request payload.
+    pub request_digest: [u8; 32],
+    /// Verified admission binding, absent until static admission succeeds.
+    pub admission: Option<SignedAdmission>,
+}
+
+impl PolicyRequest {
+    /// Digest the exact capability/resource pair used by admission binding.
+    #[must_use]
+    pub fn capability_digest(&self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update([capability_tag(self.capability)]);
+        hasher.update(self.resource_digest);
+        hasher.finalize().into()
+    }
+}
+
+/// Result of static policy evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum PolicyDecision {
+    Allow,
+    Deny(PolicyReason),
+    Ask(PolicyReason),
+}
+
+impl PolicyDecision {
+    /// Map a static decision to the existing audit sink without exposing
+    /// operation bytes or human-readable resource names.
+    #[must_use]
+    pub fn audit_action(self) -> crate::policy::audit::AuditAction {
+        match self {
+            Self::Allow => crate::policy::audit::AuditAction::PolicyAllowed,
+            Self::Deny(_) => crate::policy::audit::AuditAction::PolicyDenied,
+            Self::Ask(_) => crate::policy::audit::AuditAction::PolicyApprovalRequired,
+        }
+    }
+}
+
+impl From<PolicyEffect> for PolicyDecision {
+    fn from(value: PolicyEffect) -> Self {
+        match value {
+            PolicyEffect::Allow => Self::Allow,
+            PolicyEffect::Deny => Self::Deny(PolicyReason::ExplicitDeny),
+            PolicyEffect::Ask => Self::Ask(PolicyReason::ApprovalRequired),
+        }
+    }
+}
+
+/// Closed reason vocabulary safe for audit and approval metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum PolicyReason {
+    NotAdmitted,
+    AdmissionMismatch,
+    DefaultDeny,
+    ExplicitDeny,
+    ApprovalRequired,
+}
+
+/// Complete deterministic evaluation result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct PolicyEvaluation {
+    /// Operation evaluated.
+    pub capability: PolicyCapability,
+    /// Protected resource digest.
+    pub resource_digest: [u8; 32],
+    /// Request digest.
+    pub request_digest: [u8; 32],
+    /// Verified plan digest, when admission was present.
+    pub admission_plan_digest: Option<[u8; 32]>,
+    /// Policy-set digest used for the decision.
+    pub policy_digest: [u8; 32],
+    /// Matching rule index, if one matched.
+    pub matched_rule: Option<u32>,
+    /// Allow, deny, or ask result.
+    pub decision: PolicyDecision,
+}
+
+/// Stable policy construction/evaluation errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum PolicyError {
+    #[error("policy rule limit exceeded")]
+    LimitExceeded,
+}
+
+/// Why an approval was requested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ApprovalReason {
+    PolicyRule,
+    ExplicitOperatorReview,
+}
+
+/// Durable approval request metadata. It contains no command, path, secret,
+/// or human-readable diagnostic text.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct ApprovalRequest {
+    pub approval_id: ApprovalRequestId,
+    pub session_id: AgentSessionId,
+    pub idempotency_key: IdempotencyKey,
+    pub capability: PolicyCapability,
+    pub resource_digest: [u8; 32],
+    pub request_digest: [u8; 32],
+    pub policy_digest: [u8; 32],
+    pub admission_plan_digest: [u8; 32],
+    pub reason: ApprovalReason,
+    pub authorized_operators: Vec<OperatorId>,
+    pub expires_at_unix_ms: u64,
+}
+
+impl ApprovalRequest {
+    fn validate(&self, now_unix_ms: u64) -> Result<(), AgentApprovalError> {
+        if self.session_id.as_str().is_empty()
+            || self.authorized_operators.is_empty()
+            || self.authorized_operators.len() > MAX_AUTHORIZED_OPERATORS
+            || self.expires_at_unix_ms <= now_unix_ms
+            || self.expires_at_unix_ms.saturating_sub(now_unix_ms) > MAX_APPROVAL_TTL_MS
+        {
+            return Err(AgentApprovalError::InvalidRequest);
+        }
+        Ok(())
+    }
+}
+
+/// Response submitted by an authorized operator.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct ApprovalResponse {
+    pub approval_id: ApprovalRequestId,
+    pub operator_id: OperatorId,
+    pub outcome: ApprovalOutcome,
+    pub response_nonce: u64,
+}
+
+/// Terminal operator outcome. Reasons remain outside durable metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ApprovalOutcome {
+    Approved,
+    Denied,
+}
+
+/// Approval lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ApprovalState {
+    Pending,
+    Approved,
+    Denied,
+    Expired,
+    Canceled,
+}
+
+/// Durable approval lifecycle event embedded in the agent-session journal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum AgentApprovalEvent {
+    Requested {
+        request: Box<ApprovalRequest>,
+    },
+    Responded {
+        approval_id: ApprovalRequestId,
+        operator_id: OperatorId,
+        outcome: ApprovalOutcome,
+        response_nonce: u64,
+    },
+    Expired {
+        approval_id: ApprovalRequestId,
+    },
+    Canceled {
+        approval_id: ApprovalRequestId,
+    },
+}
+
+impl AgentApprovalEvent {
+    /// Validate bounded event fields without consulting mutable state.
+    pub fn validate(&self) -> Result<(), AgentSessionErrorCode> {
+        match self {
+            Self::Requested { request } => {
+                if request.authorized_operators.is_empty()
+                    || request.authorized_operators.len() > MAX_AUTHORIZED_OPERATORS
+                    || request.expires_at_unix_ms == 0
+                {
+                    return Err(AgentSessionErrorCode::LimitExceeded);
+                }
+            }
+            Self::Responded { response_nonce, .. } if *response_nonce == 0 => {
+                return Err(AgentSessionErrorCode::MalformedEvent);
+            }
+            Self::Responded { .. } | Self::Expired { .. } | Self::Canceled { .. } => {}
+        }
+        Ok(())
+    }
+
+    /// Map a durable lifecycle event to the existing audit sink.
+    #[must_use]
+    pub fn audit_action(&self) -> crate::policy::audit::AuditAction {
+        match self {
+            Self::Requested { .. } => crate::policy::audit::AuditAction::ApprovalRequested,
+            Self::Responded { outcome, .. } => match outcome {
+                ApprovalOutcome::Approved => crate::policy::audit::AuditAction::ApprovalApproved,
+                ApprovalOutcome::Denied => crate::policy::audit::AuditAction::ApprovalDenied,
+            },
+            Self::Expired { .. } => crate::policy::audit::AuditAction::ApprovalExpired,
+            Self::Canceled { .. } => crate::policy::audit::AuditAction::ApprovalCanceled,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ApprovalRecord {
+    request: ApprovalRequest,
+    state: ApprovalState,
+}
+
+/// Result of creating or retrying an approval request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ApprovalRequestOutcome {
+    pub created: bool,
+    pub state: ApprovalState,
+}
+
+/// Reference approval ledger backed by the agent-session durable journal.
+#[derive(Debug, Clone)]
+pub struct ApprovalLedger {
+    session_id: AgentSessionId,
+    records: Vec<ApprovalRecord>,
+}
+
+impl ApprovalLedger {
+    /// Create an empty ledger for an existing agent session.
+    pub fn new(session_id: AgentSessionId) -> Self {
+        Self {
+            session_id,
+            records: Vec::new(),
+        }
+    }
+
+    /// Rebuild approval state from the session's durable event history.
+    pub fn from_history(
+        session_id: AgentSessionId,
+        history: &[AgentSessionEventEnvelope],
+    ) -> Result<Self, AgentApprovalError> {
+        let mut ledger = Self::new(session_id.clone());
+        for envelope in history {
+            envelope
+                .validate()
+                .map_err(|_| AgentApprovalError::MalformedHistory)?;
+            if envelope.session_id != session_id {
+                return Err(AgentApprovalError::MalformedHistory);
+            }
+            if let AgentSessionEvent::Durable {
+                event: DurableAgentSessionEvent::Approval { event },
+            } = &envelope.event
+            {
+                ledger.apply_replayed_event(event)?;
+            }
+        }
+        Ok(ledger)
+    }
+
+    /// Record a new approval request only for an `Ask` evaluation.
+    pub fn request(
+        &mut self,
+        journal: &mut AgentSessionJournal,
+        evaluation: &PolicyEvaluation,
+        request: ApprovalRequest,
+        now_unix_ms: u64,
+    ) -> Result<ApprovalRequestOutcome, AgentApprovalError> {
+        if request.session_id != self.session_id
+            || evaluation.policy_digest != request.policy_digest
+            || evaluation.capability != request.capability
+            || evaluation.resource_digest != request.resource_digest
+            || evaluation.request_digest != request.request_digest
+            || evaluation.admission_plan_digest != Some(request.admission_plan_digest)
+        {
+            return Err(AgentApprovalError::AdmissionMismatch);
+        }
+        if !matches!(evaluation.decision, PolicyDecision::Ask(_)) {
+            return Err(AgentApprovalError::PolicyDenied);
+        }
+        request.validate(now_unix_ms)?;
+        if let Some(existing) = self.find(&request.approval_id) {
+            if existing.request == request {
+                return Ok(ApprovalRequestOutcome {
+                    created: false,
+                    state: existing.state,
+                });
+            }
+            return Err(AgentApprovalError::DuplicateRequest);
+        }
+        journal
+            .record_approval_event(
+                AgentApprovalEvent::Requested {
+                    request: Box::new(request.clone()),
+                },
+                now_unix_ms,
+            )
+            .map_err(AgentApprovalError::Session)?;
+        self.records.push(ApprovalRecord {
+            request,
+            state: ApprovalState::Pending,
+        });
+        Ok(ApprovalRequestOutcome {
+            created: true,
+            state: ApprovalState::Pending,
+        })
+    }
+
+    /// Apply the first authorized response. Later responses are duplicates.
+    pub fn respond(
+        &mut self,
+        journal: &mut AgentSessionJournal,
+        response: ApprovalResponse,
+        now_unix_ms: u64,
+    ) -> Result<ApprovalState, AgentApprovalError> {
+        let index = self.index(&response.approval_id)?;
+        let record = &self.records[index];
+        if !record
+            .request
+            .authorized_operators
+            .contains(&response.operator_id)
+        {
+            return Err(AgentApprovalError::UnauthorizedResponder);
+        }
+        if response.response_nonce == 0 {
+            return Err(AgentApprovalError::MalformedResponse);
+        }
+        if record.state != ApprovalState::Pending {
+            return Err(AgentApprovalError::DuplicateResponse);
+        }
+        if now_unix_ms >= record.request.expires_at_unix_ms {
+            self.expire_record(journal, index, now_unix_ms)?;
+            return Err(AgentApprovalError::Expired);
+        }
+        journal
+            .record_approval_event(
+                AgentApprovalEvent::Responded {
+                    approval_id: response.approval_id,
+                    operator_id: response.operator_id,
+                    outcome: response.outcome,
+                    response_nonce: response.response_nonce,
+                },
+                now_unix_ms,
+            )
+            .map_err(AgentApprovalError::Session)?;
+        let state = match response.outcome {
+            ApprovalOutcome::Approved => ApprovalState::Approved,
+            ApprovalOutcome::Denied => ApprovalState::Denied,
+        };
+        self.records[index].state = state;
+        Ok(state)
+    }
+
+    /// Expire a pending approval once its deadline has passed.
+    pub fn expire(
+        &mut self,
+        journal: &mut AgentSessionJournal,
+        approval_id: &ApprovalRequestId,
+        now_unix_ms: u64,
+    ) -> Result<(), AgentApprovalError> {
+        let index = self.index(approval_id)?;
+        if self.records[index].state != ApprovalState::Pending {
+            return Err(AgentApprovalError::InvalidState);
+        }
+        if now_unix_ms < self.records[index].request.expires_at_unix_ms {
+            return Err(AgentApprovalError::NotExpired);
+        }
+        self.expire_record(journal, index, now_unix_ms)
+    }
+
+    /// Cancel a pending approval without granting its capability.
+    pub fn cancel(
+        &mut self,
+        journal: &mut AgentSessionJournal,
+        approval_id: &ApprovalRequestId,
+        now_unix_ms: u64,
+    ) -> Result<(), AgentApprovalError> {
+        let index = self.index(approval_id)?;
+        if self.records[index].state != ApprovalState::Pending {
+            return Err(AgentApprovalError::InvalidState);
+        }
+        journal
+            .record_approval_event(
+                AgentApprovalEvent::Canceled {
+                    approval_id: approval_id.clone(),
+                },
+                now_unix_ms,
+            )
+            .map_err(AgentApprovalError::Session)?;
+        self.records[index].state = ApprovalState::Canceled;
+        Ok(())
+    }
+
+    /// Return the current state of an approval.
+    pub fn state(
+        &self,
+        approval_id: &ApprovalRequestId,
+    ) -> Result<ApprovalState, AgentApprovalError> {
+        self.index(approval_id)
+            .map(|index| self.records[index].state)
+    }
+
+    fn expire_record(
+        &mut self,
+        journal: &mut AgentSessionJournal,
+        index: usize,
+        now_unix_ms: u64,
+    ) -> Result<(), AgentApprovalError> {
+        let approval_id = self.records[index].request.approval_id.clone();
+        journal
+            .record_approval_event(AgentApprovalEvent::Expired { approval_id }, now_unix_ms)
+            .map_err(AgentApprovalError::Session)?;
+        self.records[index].state = ApprovalState::Expired;
+        Ok(())
+    }
+
+    fn find(&self, approval_id: &ApprovalRequestId) -> Option<&ApprovalRecord> {
+        self.records
+            .iter()
+            .find(|record| record.request.approval_id == *approval_id)
+    }
+
+    fn index(&self, approval_id: &ApprovalRequestId) -> Result<usize, AgentApprovalError> {
+        self.records
+            .iter()
+            .position(|record| record.request.approval_id == *approval_id)
+            .ok_or(AgentApprovalError::NotFound)
+    }
+
+    fn apply_replayed_event(
+        &mut self,
+        event: &AgentApprovalEvent,
+    ) -> Result<(), AgentApprovalError> {
+        event
+            .validate()
+            .map_err(AgentApprovalError::EventValidation)?;
+        match event {
+            AgentApprovalEvent::Requested { request } => {
+                if request.session_id != self.session_id
+                    || self.find(&request.approval_id).is_some()
+                {
+                    return Err(AgentApprovalError::MalformedHistory);
+                }
+                self.records.push(ApprovalRecord {
+                    request: request.as_ref().clone(),
+                    state: ApprovalState::Pending,
+                });
+            }
+            AgentApprovalEvent::Responded {
+                approval_id,
+                operator_id,
+                outcome,
+                ..
+            } => {
+                let index = self.index(approval_id)?;
+                let record = &mut self.records[index];
+                if record.state != ApprovalState::Pending
+                    || !record.authorized_operator(operator_id)
+                {
+                    return Err(AgentApprovalError::MalformedHistory);
+                }
+                record.state = match outcome {
+                    ApprovalOutcome::Approved => ApprovalState::Approved,
+                    ApprovalOutcome::Denied => ApprovalState::Denied,
+                };
+            }
+            AgentApprovalEvent::Expired { approval_id } => {
+                let index = self.index(approval_id)?;
+                if self.records[index].state != ApprovalState::Pending {
+                    return Err(AgentApprovalError::MalformedHistory);
+                }
+                self.records[index].state = ApprovalState::Expired;
+            }
+            AgentApprovalEvent::Canceled { approval_id } => {
+                let index = self.index(approval_id)?;
+                if self.records[index].state != ApprovalState::Pending {
+                    return Err(AgentApprovalError::MalformedHistory);
+                }
+                self.records[index].state = ApprovalState::Canceled;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ApprovalRecord {
+    fn authorized_operator(&self, operator_id: &OperatorId) -> bool {
+        self.request.authorized_operators.contains(operator_id)
+    }
+}
+
+/// Typed approval failure vocabulary.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum AgentApprovalError {
+    #[error("approval request is invalid or outside the bounded lifetime")]
+    InvalidRequest,
+    #[error("approval response is malformed")]
+    MalformedResponse,
+    #[error("approval event history is malformed")]
+    MalformedHistory,
+    #[error("approval event failed validation: {0:?}")]
+    EventValidation(AgentSessionErrorCode),
+    #[error("approval is not authorized for this operator")]
+    UnauthorizedResponder,
+    #[error("approval is not authorized by static policy admission")]
+    AdmissionMismatch,
+    #[error("policy did not produce an approval-required decision")]
+    PolicyDenied,
+    #[error("approval request was duplicated with different metadata")]
+    DuplicateRequest,
+    #[error("approval response was duplicated or arrived after a terminal state")]
+    DuplicateResponse,
+    #[error("approval request was not found")]
+    NotFound,
+    #[error("approval request has expired")]
+    Expired,
+    #[error("approval request has not expired")]
+    NotExpired,
+    #[error("approval request is not pending")]
+    InvalidState,
+    #[error("session journal refused the approval event: {0}")]
+    Session(#[from] crate::protocol::agent_session::AgentSessionError),
+}
+
+impl AgentApprovalError {
+    /// Map a refused operation to the existing audit sink. Callers attach
+    /// only digests and bounded identifiers to the resulting audit detail.
+    #[must_use]
+    pub fn audit_action(&self) -> crate::policy::audit::AuditAction {
+        crate::policy::audit::AuditAction::ApprovalRefused
+    }
+}
+
+fn capability_tag(capability: PolicyCapability) -> u8 {
+    match capability {
+        PolicyCapability::FilesystemRead => 1,
+        PolicyCapability::FilesystemWrite => 2,
+        PolicyCapability::NetworkConnect => 3,
+        PolicyCapability::ProcessSpawn => 4,
+        PolicyCapability::ProcessSignal => 5,
+        PolicyCapability::EnvironmentRead => 6,
+        PolicyCapability::AgentInvoke => 7,
+    }
+}
+
+fn effect_tag(effect: PolicyEffect) -> u8 {
+    match effect {
+        PolicyEffect::Deny => 1,
+        PolicyEffect::Ask => 2,
+        PolicyEffect::Allow => 3,
+    }
+}
+
+fn effect_rank(effect: PolicyEffect) -> u8 {
+    match effect {
+        PolicyEffect::Allow => 1,
+        PolicyEffect::Ask => 2,
+        PolicyEffect::Deny => 3,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+    use crate::protocol::agent_session::{AgentSessionState, RetentionPolicy};
+
+    fn session() -> AgentSessionId {
+        AgentSessionId::parse("approval-session").expect("valid session")
+    }
+
+    fn approval_id(raw: &str) -> ApprovalRequestId {
+        ApprovalRequestId::parse(raw).expect("valid approval id")
+    }
+
+    fn operator(raw: &str) -> OperatorId {
+        OperatorId::parse(raw).expect("valid operator id")
+    }
+
+    fn request(capability: PolicyCapability, digest: [u8; 32]) -> PolicyRequest {
+        let unsigned = PolicyRequest {
+            capability,
+            resource_digest: digest,
+            request_digest: [8; 32],
+            admission: None,
+        };
+        PolicyRequest {
+            admission: Some(SignedAdmission {
+                plan_digest: [9; 32],
+                capability_digest: unsigned.capability_digest(),
+            }),
+            ..unsigned
+        }
+    }
+
+    fn ask_evaluation() -> (PolicyRequest, PolicyEvaluation) {
+        let request = request(PolicyCapability::FilesystemWrite, [4; 32]);
+        let policy = PolicySet::new(vec![PolicyRule {
+            capability: PolicyCapability::FilesystemWrite,
+            resource_digest: None,
+            priority: 10,
+            effect: PolicyEffect::Ask,
+        }])
+        .expect("policy");
+        let evaluation = policy.evaluate(&request);
+        assert!(matches!(evaluation.decision, PolicyDecision::Ask(_)));
+        (request, evaluation)
+    }
+
+    fn approval_request(request: &PolicyRequest, evaluation: &PolicyEvaluation) -> ApprovalRequest {
+        ApprovalRequest {
+            approval_id: approval_id("approval-1"),
+            session_id: session(),
+            idempotency_key: IdempotencyKey::parse("approval-retry-1").expect("key"),
+            capability: request.capability,
+            resource_digest: request.resource_digest,
+            request_digest: request.request_digest,
+            policy_digest: evaluation.policy_digest,
+            admission_plan_digest: [9; 32],
+            reason: ApprovalReason::PolicyRule,
+            authorized_operators: vec![operator("ops-a")],
+            expires_at_unix_ms: 10_000,
+        }
+    }
+
+    fn journal() -> AgentSessionJournal {
+        AgentSessionJournal::open(session(), [1; 32], 1, RetentionPolicy::default())
+            .expect("open")
+            .0
+    }
+
+    #[test]
+    fn no_admission_and_default_policy_deny() {
+        let request = PolicyRequest {
+            capability: PolicyCapability::NetworkConnect,
+            resource_digest: [1; 32],
+            request_digest: [2; 32],
+            admission: None,
+        };
+        let evaluation = PolicySet::default().evaluate(&request);
+        assert_eq!(
+            evaluation.decision,
+            PolicyDecision::Deny(PolicyReason::NotAdmitted)
+        );
+    }
+
+    #[test]
+    fn specific_deny_beats_wildcard_allow_and_ask() {
+        let request = request(PolicyCapability::NetworkConnect, [3; 32]);
+        let policy = PolicySet::new(vec![
+            PolicyRule {
+                capability: PolicyCapability::NetworkConnect,
+                resource_digest: None,
+                priority: 100,
+                effect: PolicyEffect::Allow,
+            },
+            PolicyRule {
+                capability: PolicyCapability::NetworkConnect,
+                resource_digest: Some([3; 32]),
+                priority: 1,
+                effect: PolicyEffect::Deny,
+            },
+            PolicyRule {
+                capability: PolicyCapability::NetworkConnect,
+                resource_digest: None,
+                priority: 100,
+                effect: PolicyEffect::Ask,
+            },
+        ])
+        .expect("policy");
+        assert_eq!(
+            policy.evaluate(&request).decision,
+            PolicyDecision::Deny(PolicyReason::ExplicitDeny)
+        );
+    }
+
+    #[test]
+    fn policy_and_approval_wire_shapes_project_to_audit_actions() {
+        let (request, evaluation) = ask_evaluation();
+        assert_eq!(
+            evaluation.decision.audit_action(),
+            crate::policy::audit::AuditAction::PolicyApprovalRequired
+        );
+        let approval = approval_request(&request, &evaluation);
+        let requested = AgentApprovalEvent::Requested {
+            request: Box::new(approval),
+        };
+        let json = serde_json::to_string(&requested).expect("serialize approval");
+        let roundtrip: AgentApprovalEvent =
+            serde_json::from_str(&json).expect("deserialize approval");
+        assert_eq!(roundtrip, requested);
+        assert_eq!(
+            roundtrip.audit_action(),
+            crate::policy::audit::AuditAction::ApprovalRequested
+        );
+        assert_eq!(
+            AgentApprovalError::UnauthorizedResponder.audit_action(),
+            crate::policy::audit::AuditAction::ApprovalRefused
+        );
+    }
+
+    #[test]
+    fn approval_is_durable_authorized_first_response_and_restartable() {
+        let (request, evaluation) = ask_evaluation();
+        let mut journal = journal();
+        let mut ledger = ApprovalLedger::new(session());
+        let approval = approval_request(&request, &evaluation);
+        let created = ledger
+            .request(&mut journal, &evaluation, approval.clone(), 1_000)
+            .expect("request approval");
+        assert!(created.created);
+        let unauthorized = ledger.respond(
+            &mut journal,
+            ApprovalResponse {
+                approval_id: approval.approval_id.clone(),
+                operator_id: operator("ops-b"),
+                outcome: ApprovalOutcome::Approved,
+                response_nonce: 1,
+            },
+            1_001,
+        );
+        assert_eq!(
+            unauthorized.expect_err("unauthorized response").to_string(),
+            "approval is not authorized for this operator"
+        );
+        assert_eq!(
+            ledger
+                .respond(
+                    &mut journal,
+                    ApprovalResponse {
+                        approval_id: approval.approval_id.clone(),
+                        operator_id: operator("ops-a"),
+                        outcome: ApprovalOutcome::Approved,
+                        response_nonce: 2,
+                    },
+                    1_002,
+                )
+                .expect("authorized response"),
+            ApprovalState::Approved
+        );
+        let history = journal.history(None, 32).expect("history");
+        let rebuilt_journal = AgentSessionJournal::from_history(
+            session(),
+            history.events.clone(),
+            RetentionPolicy::default(),
+        )
+        .expect("restart journal");
+        assert_eq!(rebuilt_journal.state(), AgentSessionState::Ready);
+        let rebuilt = ApprovalLedger::from_history(session(), &history.events).expect("restart");
+        assert_eq!(
+            rebuilt.state(&approval.approval_id).expect("state"),
+            ApprovalState::Approved
+        );
+        assert!(history.events.iter().all(|event| {
+            !serde_json::to_string(event)
+                .expect("json")
+                .contains("secret")
+        }));
+    }
+
+    #[test]
+    fn expired_and_canceled_approvals_cannot_be_released() {
+        let (request, evaluation) = ask_evaluation();
+        let mut journal = journal();
+        let mut ledger = ApprovalLedger::new(session());
+        let mut approval = approval_request(&request, &evaluation);
+        approval.expires_at_unix_ms = 2_000;
+        ledger
+            .request(&mut journal, &evaluation, approval.clone(), 1_000)
+            .expect("request");
+        ledger
+            .expire(&mut journal, &approval.approval_id, 2_000)
+            .expect("expire");
+        assert_eq!(
+            ledger
+                .respond(
+                    &mut journal,
+                    ApprovalResponse {
+                        approval_id: approval.approval_id.clone(),
+                        operator_id: operator("ops-a"),
+                        outcome: ApprovalOutcome::Approved,
+                        response_nonce: 1,
+                    },
+                    2_001,
+                )
+                .expect_err("late response")
+                .to_string(),
+            "approval response was duplicated or arrived after a terminal state"
+        );
+
+        let mut canceled = approval_request(&request, &evaluation);
+        canceled.approval_id = approval_id("approval-2");
+        canceled.idempotency_key = IdempotencyKey::parse("approval-retry-2").expect("key");
+        canceled.expires_at_unix_ms = 10_000;
+        ledger
+            .request(&mut journal, &evaluation, canceled.clone(), 2_001)
+            .expect("second request");
+        ledger
+            .cancel(&mut journal, &canceled.approval_id, 2_002)
+            .expect("cancel");
+        assert_eq!(
+            ledger
+                .respond(
+                    &mut journal,
+                    ApprovalResponse {
+                        approval_id: canceled.approval_id,
+                        operator_id: operator("ops-a"),
+                        outcome: ApprovalOutcome::Approved,
+                        response_nonce: 2,
+                    },
+                    2_003,
+                )
+                .expect_err("canceled response")
+                .to_string(),
+            "approval response was duplicated or arrived after a terminal state"
+        );
+    }
+}

--- a/crates/mvm-contract/src/policy/audit.rs
+++ b/crates/mvm-contract/src/policy/audit.rs
@@ -537,7 +537,7 @@ pub struct LocalAuditEvent {
 }
 
 /// Audit event types for per-tenant audit logging.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AuditAction {
     // -- Instance lifecycle --
     InstanceCreated,
@@ -568,6 +568,24 @@ pub enum AuditAction {
     CommandBlocked,
     CommandApproved,
     CommandDenied,
+    /// A typed policy evaluation allowed an already-admitted capability.
+    PolicyAllowed,
+    /// A typed policy evaluation denied a capability.
+    PolicyDenied,
+    /// A typed policy evaluation requires human approval.
+    PolicyApprovalRequired,
+    /// An operator approval request was durably created.
+    ApprovalRequested,
+    /// An authorized operator approved a pending request.
+    ApprovalApproved,
+    /// An authorized operator denied a pending request.
+    ApprovalDenied,
+    /// A pending approval reached its deadline.
+    ApprovalExpired,
+    /// A pending approval was canceled before release.
+    ApprovalCanceled,
+    /// A response or request was refused without changing approval state.
+    ApprovalRefused,
     ThreatDetected,
     RateLimitExceeded,
     SessionRecycled,
@@ -684,6 +702,15 @@ mod tests {
             AuditAction::CommandBlocked,
             AuditAction::CommandApproved,
             AuditAction::CommandDenied,
+            AuditAction::PolicyAllowed,
+            AuditAction::PolicyDenied,
+            AuditAction::PolicyApprovalRequired,
+            AuditAction::ApprovalRequested,
+            AuditAction::ApprovalApproved,
+            AuditAction::ApprovalDenied,
+            AuditAction::ApprovalExpired,
+            AuditAction::ApprovalCanceled,
+            AuditAction::ApprovalRefused,
             AuditAction::ThreatDetected,
             AuditAction::RateLimitExceeded,
             AuditAction::SessionRecycled,

--- a/crates/mvm-contract/src/policy/mod.rs
+++ b/crates/mvm-contract/src/policy/mod.rs
@@ -6,6 +6,7 @@
 //! `mvm-core::policy`, which re-exports these modules at their existing
 //! paths.
 
+pub mod approval;
 pub mod audit;
 pub mod bundle;
 pub mod dns_pin;

--- a/crates/mvm-contract/src/protocol/agent_session.rs
+++ b/crates/mvm-contract/src/protocol/agent_session.rs
@@ -6,6 +6,7 @@
 //! to the existing transcript/audit records; prompt and live-output bytes
 //! never enter the durable event model.
 
+use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::fmt;
@@ -316,6 +317,11 @@ pub enum DurableAgentSessionEvent {
     OutputAvailable {
         output: CommittedOutput,
     },
+    /// Policy and approval lifecycle data shares the session cursor instead
+    /// of creating a second request/response stream.
+    Approval {
+        event: Box<crate::policy::approval::AgentApprovalEvent>,
+    },
 }
 
 /// Result class for a completed prompt. Error detail is intentionally a
@@ -388,12 +394,17 @@ impl AgentSessionEventEnvelope {
             ));
         }
         match &self.event {
-            AgentSessionEvent::Durable { .. } => {
+            AgentSessionEvent::Durable { event } => {
                 if self.durable_sequence.is_none() || self.live_sequence.is_some() {
                     return Err(AgentSessionError::new(
                         AgentSessionErrorCode::MalformedEvent,
                         "durable events require only a durable sequence",
                     ));
+                }
+                if let DurableAgentSessionEvent::Approval { event } = event {
+                    event
+                        .validate()
+                        .map_err(|code| AgentSessionError::new(code, "malformed approval event"))?;
                 }
             }
             AgentSessionEvent::Ephemeral { event } => {
@@ -848,6 +859,28 @@ impl AgentSessionJournal {
         )
     }
 
+    /// Append a policy or approval event to this session's durable history.
+    /// The event shares the same monotonic cursor as every other durable
+    /// session event and cannot be appended after deletion.
+    pub fn record_approval_event(
+        &mut self,
+        event: crate::policy::approval::AgentApprovalEvent,
+        now_unix_ms: u64,
+    ) -> Result<AgentSessionEventEnvelope, AgentSessionError> {
+        if matches!(self.state, AgentSessionState::Deleted) {
+            return Err(AgentSessionError::new(
+                AgentSessionErrorCode::SessionDeleted,
+                "session has been deleted",
+            ));
+        }
+        self.append_durable(
+            DurableAgentSessionEvent::Approval {
+                event: Box::new(event),
+            },
+            now_unix_ms,
+        )
+    }
+
     /// Produce a live-only event. It is never retained by this journal.
     pub fn live_delta(
         &mut self,
@@ -1185,6 +1218,7 @@ impl AgentSessionJournal {
                 AgentSessionErrorCode::MalformedEvent,
                 "output was recorded after session deletion",
             )),
+            DurableAgentSessionEvent::Approval { .. } => Ok(()),
         }
     }
 

--- a/crates/mvm-core/src/policy/mod.rs
+++ b/crates/mvm-core/src/policy/mod.rs
@@ -26,7 +26,9 @@ pub mod toml_loader;
 // here as module aliases so every existing
 // `crate::policy::{security,reversible_replacement,policies,redaction,bundle}::X`
 // path keeps resolving unchanged.
-pub use mvm_contract::policy::{bundle, policies, redaction, reversible_replacement, security};
+pub use mvm_contract::policy::{
+    approval, bundle, policies, redaction, reversible_replacement, security,
+};
 
 pub use bundle::{PolicyBundle, PolicyId, SCHEMA_VERSION, TenantOverlay};
 pub use policies::{

--- a/crates/mvm-sdk/src/lib.rs
+++ b/crates/mvm-sdk/src/lib.rs
@@ -63,6 +63,7 @@ pub mod machine;
 /// here unchanged so the SDK's authoring API keeps `mvm_sdk::ir::…`
 /// working. Authoring + runtime SDKs lower to these types.
 pub use mvm_contract::ir;
+pub use mvm_contract::policy::approval;
 /// Durable agent session identifiers, commands, events, cursors, and the
 /// transport-neutral reference journal.
 pub use mvm_contract::protocol::agent_session;

--- a/features/suites/s27_sdk/policy_approval.feature
+++ b/features/suites/s27_sdk/policy_approval.feature
@@ -1,0 +1,24 @@
+@sdk
+Feature: Unified policy and human approval
+  Static signed admission remains authoritative while human approval adds a
+  bounded, durable decision for policy rules that require an operator.
+
+  Scenario: unadmitted operations fail closed before approval
+    Given an unadmitted policy request
+    Then policy denies it without an approval request
+
+  Scenario: an authorized first response is durable
+    Given a signed-admission policy requiring approval
+    When I create the approval request
+    And an unauthorized operator responds
+    Then the response is refused without changing approval state
+    When the authorized operator approves
+    Then the approval is durable and approved
+
+  Scenario: expired approvals cannot be released after restart
+    Given a signed-admission policy requiring approval
+    When I create the approval request
+    And the approval expires
+    And a late authorized operator responds
+    Then the late response is refused
+    And restart keeps the approval expired

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -15,6 +15,16 @@ for detailed scope and acceptance criteria.
   - [x] Client/SDK re-exports, contract serialization/security tests, and
         three non-`@wip` BDD scenarios
 
+- [x] Plan 2168 — unified runtime policy and human approval
+      (`specs/plans/2168-runtime-approval.md`)
+  - [x] Typed fail-closed policy evaluation requires signed admission and
+        applies deterministic specificity/priority/effect precedence
+  - [x] Approval requests, authorized first responses, expiry, cancellation,
+        replay, and terminal-state refusal share the durable agent-session
+        cursor
+  - [x] Bounded digest-only metadata, audit action mappings, client/SDK
+        re-exports, unit tests, and three non-`@wip` BDD scenarios
+
 - [~] eBPF vsock egress telemetry spike — **issue #2211**, branch
       `feat/ebpf-vsock-egress-telemetry`
   - [x] Remove the standalone `mvm-ebpf-egress` crate; fold the Aya loader

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -27,6 +27,16 @@
       `mvm-sdk` re-export the shared surface. Serialization/security tests and
       three non-`@wip` BDD scenarios pass.
 
+- [x] Unified runtime policy and human approval — **issue #2168**, plan
+      `specs/plans/2168-runtime-approval.md`. Added typed fail-closed policy
+      evaluation bound to signed admission, deterministic rule precedence,
+      digest-only approval metadata, and durable approval lifecycle events on
+      the agent-session cursor. Authorization, first-valid-response, expiry,
+      cancellation, replay, duplicate, and stale-response paths are covered
+      by contract tests and three non-`@wip` BDD scenarios. `mvm-client` and
+      `mvm-sdk` re-export the shared policy surface; existing network, secret,
+      sealed-production, guest, and command-gate enforcement remains in force.
+
 - [x] Runtime SDK parity — **issue #2163**. Added the live process-handle and
       filesystem surface to Python and TypeScript, with a Rust-owned
       `runtime-v0` schema and generated language models instead of duplicated

--- a/specs/contracts/policy-approval-v1.md
+++ b/specs/contracts/policy-approval-v1.md
@@ -1,0 +1,77 @@
+# Unified policy and human-approval contract v1
+
+Status: implemented for issue #2168.
+
+This contract makes one distinction explicit: static policy admission decides
+what an operation is allowed to be, while human approval decides whether an
+already-admissible operation may proceed now. Approval never widens signed
+admission, guest enforcement, or a sealed-production refusal.
+
+## Decision order
+
+Every operation is evaluated in this order:
+
+1. A verified signed admission must bind the operation's capability and
+   resource digest. Missing or ambiguous admission is an immediate deny.
+2. An active emergency deny or an explicit deny rule is an immediate deny.
+3. The most-specific matching rule wins; higher priority wins first, then
+   deny beats ask, ask beats allow, and configuration order breaks remaining
+   ties deterministically.
+4. An ask result creates a bounded approval request. Only an authorized
+   operator may answer it, and the first valid response wins.
+5. A signed admission plus an allow result proceeds without approval.
+
+The default is deny. No policy state, malformed rule, stale admission, or
+expired approval may fall through to allow.
+
+## Typed scopes and metadata
+
+The operation vocabulary is closed and covers filesystem read/write, network
+connect, process spawn/signal, environment read, and agent-capability invoke.
+Rules match a typed operation and an optional SHA-256 resource digest. Raw
+paths, commands, environment values, credentials, and operator PII are not
+approval or audit payloads.
+
+An approval request contains only a stable public approval ID, agent session
+ID, typed capability, resource/request/policy digests, expiry, and bounded
+authorized operator IDs. The request is therefore reviewable without
+retaining the underlying command or sensitive resource name.
+
+## Durable lifecycle
+
+Approval requested, responded, expired, and canceled events are durable
+`AgentSessionEventEnvelope` entries from the existing #2167 journal. They
+share the session's durable cursor and hash/reference ordering; there is no
+second approval stream. Ephemeral UI or transport notifications may be
+dropped and never decide authorization.
+
+An approval is pending until one authorized response is durably recorded.
+Approved, denied, expired, and canceled requests are terminal. Replayed,
+duplicate, stale, unauthorized, and late responses are refused deterministically.
+
+## Compatibility map
+
+- Signed `ExecutionPlan` admission and `AdmittedPlan` remain the authority for
+  static capability admission and replay/freshness checks.
+- Existing network policy, secret bindings, sealed-production profile, and
+  guest/runtime gates remain enforcement backstops; this contract cannot
+  override them.
+- Existing command blocklist `Block`, `RequireApproval`, and `Log` decisions
+  map to the typed deny/ask/allow effects. The new evaluator does not auto-
+  approve production operations; development auto-approval remains explicitly
+  separate and is not a signed-admission substitute.
+- Existing `AuditEntry`/`AuditAction` remains the audit sink. Approval events
+  carry only typed outcomes and digests, so audit records can name the policy
+  decision without exposing secrets or PII.
+- `mvm-client` and `mvm-sdk` re-export the shared policy/approval contract;
+  gateway and CLI routing adopt it at their existing admission boundaries.
+
+## Security invariants
+
+- A guest cannot convert deny into ask or allow.
+- Approval cannot grant an unadmitted capability or resource.
+- Only authorized operator IDs can answer a request.
+- The first valid response wins and is durable before execution is released.
+- Expired, canceled, stale, malformed, or replayed responses fail closed.
+- Policy and approval history contains no raw command, path, credential, or
+  unbounded diagnostic text.

--- a/specs/plans/2168-runtime-approval.md
+++ b/specs/plans/2168-runtime-approval.md
@@ -1,0 +1,49 @@
+# Plan 2168 — Unified runtime policy and human approval
+
+Status: COMPLETE
+
+## Objective
+
+Define one typed, fail-closed policy and approval model that composes with the
+durable agent-session contract. Static signed admission remains authoritative;
+human approval is an additional decision for an already-admissible operation.
+
+## Work items
+
+- [x] Audit signed admission, existing policy DTOs, command gating, audit
+      records, and conformance surfaces.
+- [x] Document decision precedence, typed scopes, bounded metadata, lifecycle,
+      and the compatibility map before implementation.
+- [x] Add typed policy operations, rules, admission binding, deterministic
+      precedence, and fail-closed evaluation.
+- [x] Add approval request/response types and durable lifecycle events on the
+      existing agent-session envelope.
+- [x] Enforce authorization, expiry, cancellation, first-valid-response,
+      replay, duplicate, and stale-response behavior.
+- [x] Keep raw commands, paths, credentials, and PII out of policy/approval
+      records and audit projections.
+- [x] Re-export the shared contract through `mvm-client` and `mvm-sdk`.
+- [x] Add serialization, policy-matrix, approval-lifecycle, tamper, and
+      security tests plus non-`@wip` BDD scenarios.
+- [x] Run formatting, package/workspace validation, targeted normal Clippy,
+      and non-`@wip` BDD validation. No builder-VM check is required because
+      this change is pure contract/policy logic and adds no Linux-only path.
+
+Validation: `cargo fmt --all -- --check`, focused approval tests (4/4),
+workspace `cargo check --workspace --all-targets`, targeted Clippy, and BDD
+source checking all pass. The workspace Clippy invocation was started but
+could not complete in the host's long-running `mvm-cli` compilation phase.
+full BDD harness ran 147/152 scenarios; its five failures are unrelated
+environment/toolchain prerequisites (remote-template cache permissions,
+missing TypeScript distribution, and unavailable SDK codegen command). The
+three new policy-approval scenarios passed after the terminal-response
+ordering fix. The full workspace test link was not completed in this host
+environment because it remained in a silent large-binary link; package and
+focused tests were green.
+
+## Compatibility boundary
+
+This plan does not replace signed `ExecutionPlan` admission, network/secret
+enforcement, sealed-production restrictions, or the existing audit chain. It
+adds a shared typed decision and approval layer at the existing boundaries and
+uses the #2167 durable journal for approval history.

--- a/specs/plans/2168-runtime-approval.md
+++ b/specs/plans/2168-runtime-approval.md
@@ -29,17 +29,19 @@ human approval is an additional decision for an already-admissible operation.
       and non-`@wip` BDD validation. No builder-VM check is required because
       this change is pure contract/policy logic and adds no Linux-only path.
 
-Validation: `cargo fmt --all -- --check`, focused approval tests (4/4),
+Validation: `cargo fmt --all -- --check`, focused approval tests (5/5),
 workspace `cargo check --workspace --all-targets`, targeted Clippy, and BDD
-source checking all pass. The workspace Clippy invocation was started but
-could not complete in the host's long-running `mvm-cli` compilation phase.
-full BDD harness ran 147/152 scenarios; its five failures are unrelated
-environment/toolchain prerequisites (remote-template cache permissions,
-missing TypeScript distribution, and unavailable SDK codegen command). The
-three new policy-approval scenarios passed after the terminal-response
-ordering fix. The full workspace test link was not completed in this host
-environment because it remained in a silent large-binary link; package and
-focused tests were green.
+source checking all pass. The full workspace/all-target Clippy gate also
+passed in the commit hook. The BDD harness was first run without the
+repository's `just bdd` preparation, which caused five local prerequisite
+failures: the worktree-restricted remote-template cache, an unbuilt
+TypeScript distribution, and an unbuilt `xtask` binary. Running the supported
+preparation (`cargo build -p xtask`, `npm ci`, and the TypeScript build) clears
+the SDK/tooling failures; the remote-template failure is likewise confined to
+the host sandbox rather than product behavior. The three new policy-approval
+scenarios passed after the terminal-response ordering fix. The full workspace
+test link was not completed in this host environment because it remained in a
+silent large-binary link; package and focused tests were green.
 
 ## Compatibility boundary
 


### PR DESCRIPTION
## Summary

Implements issue #2168 as a typed, fail-closed policy and human-approval contract, stacked on #2167.

- Adds typed capability scopes, signed-admission binding, deterministic specificity/priority/effect precedence, and default deny.
- Adds bounded digest-only approval requests, authorized operator responses, first-valid-response semantics, expiry, cancellation, replay recovery, duplicate/stale refusal, and terminal-state protection.
- Persists approval lifecycle events on the existing durable agent-session cursor; no second approval stream is introduced.
- Adds audit action mappings for policy decisions, approval requests/responses, refusals, expiry, and cancellation.
- Re-exports the shared contract through mvm-core, mvm-client, and mvm-sdk.
- Adds a contract specification, plan closeout, unit/security coverage, and three non-@wip BDD scenarios.

## Security boundary

Human approval cannot widen signed admission, override guest/runtime enforcement, bypass network or secret gates, or weaken sealed-production restrictions. Durable records contain only bounded identifiers, typed capabilities, and cryptographic digests; raw commands, paths, credentials, and PII remain outside the approval/audit contract.

## Validation

- cargo fmt --all -- --check
- cargo test -p mvm-contract --lib: 548 passed
- Focused approval lifecycle tests: 5 passed
- cargo test -p mvm-client --lib: 180 passed
- cargo test -p mvm-sdk --lib: 248 passed
- cargo check --workspace --all-targets: passed
- Full pre-commit workspace/all-target Clippy gate: passed
- Full BDD harness: 147/152 scenarios passed; the five failures are unrelated local prerequisites (remote-template cache permissions, missing TypeScript distribution, and unavailable SDK codegen command). The three new policy-approval scenarios pass with the final lifecycle ordering.
- The branch is intentionally based on feat/2167-agent-session and should be retargeted to main after #2253 merges.