### PR TITLE
test(broker): wait for the chain lock instead of assuming abort released it

### DIFF
--- a/crates/mvm-hostd/src/broker/daemon.rs
+++ b/crates/mvm-hostd/src/broker/daemon.rs
@@ -716,6 +716,32 @@ mod tests {
         task
     }
 
+    /// Rebind the daemon's signer-helper registrations, waiting out a
+    /// previous helper that still holds the chain file's exclusive writer
+    /// lock.
+    ///
+    /// Retries only that one refusal: any other error fails immediately, so a
+    /// genuine regression still surfaces as a failure rather than as a
+    /// timeout. Bounded, so a lock that is never released fails the test
+    /// instead of hanging it.
+    async fn rebind_when_chain_released(d: &HostAgentDaemon) -> usize {
+        const ATTEMPTS: usize = 100;
+        for attempt in 0..ATTEMPTS {
+            match d.rebind_signer_helper_registrations() {
+                Ok(n) => return n,
+                Err(e) if format!("{e:#}").contains("already held by another writer") => {
+                    assert!(
+                        attempt + 1 < ATTEMPTS,
+                        "the previous helper never released the chain lock: {e:#}"
+                    );
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Err(e) => panic!("rebind failed for an unexpected reason: {e:#}"),
+            }
+        }
+        unreachable!("the loop either returns or asserts on its last attempt")
+    }
+
     async fn emit_audit(sock: &Path, vm: &str) -> ServiceResponse {
         let mut client = UnixStream::connect(sock).await.unwrap();
         let call = ServiceCall {
@@ -1069,7 +1095,20 @@ mod tests {
         let _ = std::fs::remove_file(&helper_sock);
         let restarted = start_helper(helper_sock.clone(), "local", key_path).await;
 
-        assert_eq!(d.rebind_signer_helper_registrations().unwrap(), 1);
+        // Aborting the accept loop is not the same as the old helper being
+        // gone. `audit_signer::helper::serve` spawns a detached task per
+        // connection, each holding its own `SharedSignerHelper` clone, and
+        // those are not cancelled with the loop — so the previous helper, and
+        // the exclusive chain-file lock its `Chain` holds, can outlive the
+        // `await` above. Registering the restarted helper then fails with
+        // "chain already held by another writer".
+        //
+        // Production never hits this: the helper is its own process
+        // (`mvm-signer-helper`), so shutdown releases the lock at exit. This
+        // test is the only place a helper is torn down by cancelling a task,
+        // so it has to wait for the same condition process exit would give it.
+        // A fixed sleep would only make the window bigger, not closed.
+        assert_eq!(rebind_when_chain_released(&d).await, 1);
         let after = emit_audit(&sock, "after-restart").await;
         assert!(matches!(after, ServiceResponse::Ok { .. }));
 


### PR DESCRIPTION
Fixes #2254.

`helper_restart_rebinds_live_registration_and_preserves_chain` failed intermittently under full-workspace parallel load — on **two unrelated PRs** (#2247, #2248) in one afternoon:

```
signer-helper register refused: mvm-audit-signer chain already held by another writer
```

## Cause

The test aborted the helper's accept loop and asserted the rebind in the very next statement:

```rust
helper_task.abort();
let _ = helper_task.await;
...
assert_eq!(d.rebind_signer_helper_registrations().unwrap(), 1);
```

`audit_signer::helper::serve` spawns a **detached** task per connection, each holding its own `SharedSignerHelper` clone:

```rust
let helper = helper.clone();
tokio::spawn(async move { handle_connection(stream, helper, max_frame_bytes).await });
```

Those are not cancelled with the accept loop. So the previous helper — and the exclusive advisory lock its `Chain` holds on the JSONL — can outlive the `await`, and registering the restarted helper is refused. The test treated *"parent task aborted"* as *"writer released"*. They are not the same thing.

## This is test-only

In production the helper is its own process (`mvm-signer-helper` — the process moat), so shutdown releases the lock at **process exit**, and nothing aborts a task and immediately re-registers. I checked this before writing the fix, because if production had the same gap it would be a real bug rather than a test bug.

That is why the fix models what production gets for free: wait for the condition process exit would have provided.

## The fix

A bounded wait that retries **only** the writer-lock refusal. Any other error fails immediately, so a genuine regression still surfaces as a failure rather than as a timeout; and the bound means a lock that is never released fails the test instead of hanging it.

A fixed `sleep` was rejected — it widens the window without closing it.

## Honest limit on the evidence

**I could not reproduce the flake locally.** Fifteen runs of the full `mvm-hostd` suite against the *unfixed* code were all green, because this machine is not loaded the way CI's parallel 10k-test run is. So this fix is argued from the source of the race, not from a locally observed red-to-green — which is weaker evidence than I would like, and worth saying plainly.

What is verifiable without reproducing it: the mechanism is visible in `serve` — the per-connection `tokio::spawn` holds a clone that the accept loop's `JoinHandle` does not own, so aborting the handle cannot drop it.

## Verification

- 1809 `mvm-hostd` tests pass
- the target test passes 15/15 consecutive runs
- workspace clippy `-D warnings` clean
