### PR TITLE
fix(ci): stop paying a full validation cycle for a flake or a stuck requeue

### DIFF
--- a/.github/workflows/merge-queue-requeue.yml
+++ b/.github/workflows/merge-queue-requeue.yml
@@ -72,6 +72,39 @@ jobs:
             exit 0
           fi
 
+          # `mergeable` above is computed against `main`, but the queue does not
+          # validate entries against `main` — it validates them batched on top
+          # of the entries ahead of them. A PR that conflicts with another queue
+          # *member* is clean by the check above and dirty in every batch it
+          # joins, so requeuing it burns a validation cycle and ejects again.
+          #
+          # There is no API for "did this conflict with its batch", so use the
+          # one signal that separates the two cases: a transient ejection is
+          # followed by the head moving on, while a batch conflict reproduces
+          # unchanged. If this PR's head is the same one that was ejected last
+          # time, the retry has nothing new to try.
+          head_sha=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha')
+          # `--jq` runs per page under `--paginate`, so this emits one marker
+          # per page that has any; take the last line rather than trusting a
+          # `| last` inside the filter, which would be per-page.
+          last_sha=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+            --jq '.[] | select(.body | startswith("<!-- requeue-head:")) | .body' \
+            | sed -n 's/^<!-- requeue-head: \([0-9a-f]\{7,40\}\) -->.*/\1/p' \
+            | tail -1)
+          if [ -n "${last_sha}" ] && [ "${last_sha}" = "${head_sha}" ]; then
+            echo "::warning::PR #${PR} ejected again at the same head ${head_sha}; not requeuing."
+            printf '%s\n\n%s\n' \
+              "Ejected again at commit \`${head_sha}\`, with nothing about this PR having changed since the last automatic requeue. Not requeuing." \
+              "That pattern usually means a conflict with another PR **in the queue** rather than with \`main\`. The queue validates entries batched on top of one another, so a clash with a queue member is invisible to a \`mergeable\` check against \`main\` — which is what this workflow can see. Rebasing onto whatever has landed since, or waiting for the other entry to merge, is usually the fix." \
+              > /tmp/requeue-note.md
+            gh pr comment "${PR}" --repo "${REPO}" --body-file /tmp/requeue-note.md || true
+            exit 0
+          fi
+          # Record the head this retry is being spent on. An HTML comment so it
+          # renders as nothing; the timeline is already the attempt counter and
+          # this only adds which commit each attempt was for.
+          gh pr comment "${PR}" --repo "${REPO}" --body "<!-- requeue-head: ${head_sha} -->" || true
+
           attempts=$(gh api "repos/${REPO}/issues/${PR}/timeline" --paginate \
             --jq '[.[] | select(.event == "labeled") | select(.label.name == "auto-requeued")] | length')
           if [ "${attempts}" -ge "${MAX_ATTEMPTS}" ]; then

--- a/crates/mvm-hostd/src/stream/input_gate.rs
+++ b/crates/mvm-hostd/src/stream/input_gate.rs
@@ -1385,16 +1385,27 @@ mod tests {
     fn a_holder_that_stops_refreshing_loses_the_lease() {
         // The reason the lease has an expiry at all: a consumer that took it
         // and died must not hold a VM's stdin until teardown.
+        //
+        // Decided by degenerate TTLs rather than by a wall clock, the same way
+        // the idle-flush tests above are: a zero TTL has lapsed the moment it
+        // is taken, an hour has not lapsed by the end of the test. Sleeping
+        // past a short TTL makes the outcome depend on scheduler luck — this
+        // test failed exactly that way on a loaded CI runner, at a 20ms TTL
+        // with a 40ms sleep.
         let vm = unique_vm("vm-lease-expiry");
-        InputGate::bind(
-            &vm,
-            InputBinding::new().with_lease_ttl(Duration::from_millis(20)),
-        );
+        InputGate::bind(&vm, InputBinding::new().with_lease_ttl(Duration::ZERO));
         let plan = admitted_with(vec![stream_service()]);
         let mut stale = InputGate::open(&vm, &plan).expect("first session");
-        std::thread::sleep(Duration::from_millis(40));
 
         assert_eq!(InputGate::lease_holder(&vm), None, "the lease lapsed");
+
+        // Re-bind before the second open so the taker gets a live lease.
+        // `bind` replaces the binding and leaves the lease table alone (only
+        // `unbind` clears it), so the lapsed lease is still there to take over.
+        InputGate::bind(
+            &vm,
+            InputBinding::new().with_lease_ttl(Duration::from_secs(3600)),
+        );
         let mut fresh = InputGate::open(&vm, &plan).expect("a lapsed lease is takeable");
         assert!(matches!(
             stale.write(InputFrame {

--- a/specs/plans/307-merge-queue-latency.md
+++ b/specs/plans/307-merge-queue-latency.md
@@ -1,0 +1,102 @@
+# Plan 307 — Merge-queue latency
+
+**Status: IN PROGRESS**
+
+## Why
+
+On 2026-08-08 the merge queue stopped merging for roughly four hours with ten
+entries waiting. The investigation is worth writing down, because the visible
+symptom pointed at the wrong cause and the wrong cause has an expensive fix.
+
+What it looked like: runner starvation. Thirteen workflow runs queued against
+three executing, queue-head entries sitting in `AWAITING_CHECKS` for hours. The
+tempting conclusion is "buy more runners".
+
+What it was: **one PR at queue position 1 failing a policy gate**. `#2232`
+carried a `check-no-vz` violation — a doc comment naming the retired backend,
+which the gate added in #2235 forbids. The merge queue validates entries in
+batches built on top of each other, so every batch inherited the failure,
+`Lint policy` went red, the batch was discarded, `merge-queue-requeue.yml` put
+the entry back, and the cycle repeated. Starvation was real but secondary: the
+queue was converting runner time into nothing at a steady rate.
+
+The generalisable lesson: **in a serial queue, a bad head entry is
+indistinguishable from a slow queue.** Both present as "nothing merges". The
+distinguishing evidence is per-entry check state on the `gh-readonly-queue/**`
+branches, not the queue's own position/state display, which shows
+`AWAITING_CHECKS` in both cases.
+
+## Workstreams
+
+- [x] **WS0 — unjam.** Fixed the `check-no-vz` violation on #2232 directly and
+      dequeued/re-pushed it. One line. Nothing else in the queue was wrong.
+
+- [ ] **WS1 — a required check that cannot report is a 90-minute tax.**
+      Already in flight as **#2252**, independently authored — not duplicated
+      here. `kernel-build.yml` had no `merge_group` trigger and was
+      `paths:`-filtered, so on any PR not touching kernel paths the required
+      `Build kernels (aarch64|x86_64)` contexts were simply *absent*. An absent
+      required check leaves the entry waiting out
+      `check_response_timeout_minutes: 90` before ejection. #2252 moves the
+      filter off the trigger into a `scope` job that always reports. This plan
+      records the interaction and defers to that PR.
+
+- [ ] **WS2 — the queue merges one PR per validation cycle.**
+      The ruleset has `min_entries_to_merge: 1` with
+      `min_entries_to_merge_wait_minutes: 0`, so a batch ships the instant one
+      entry is green and never accumulates — despite `max_entries_to_merge: 5`.
+      Every PR therefore pays a full validation cycle (~30 min of CI plus two
+      kernel builds at 15–30 min each) alone.
+
+      **Not applied — needs a maintainer to run it.** This is repo
+      configuration rather than code, and the change was refused by the local
+      permission policy. The exact edit, against ruleset `17624371`
+      (`main merge queue`, whose only rule is `merge_queue` — required status
+      checks live in classic branch protection and are untouched):
+
+      ```
+      min_entries_to_merge:              1 -> 3
+      min_entries_to_merge_wait_minutes: 0 -> 5
+      ```
+
+      A quiet period then costs at most five extra minutes; a busy one
+      amortises one validation cycle across up to five PRs
+      (`max_entries_to_merge` is already 5). Revert by setting them back to
+      `1` and `0`.
+
+      This trades against `grouping_strategy: ALLGREEN`, under which one bad
+      entry discards the whole batch — bigger batches mean a flake costs more,
+      which is why WS3 is sequenced first.
+
+- [x] **WS3 — flaky tests are unusually expensive under ALLGREEN.**
+      A flake does not merely retry a job; it discards a batch and burns
+      another full validation cycle for every entry in it. `#2246`
+      (`a_holder_that_stops_refreshing_loses_the_lease`, a 20 ms lease TTL
+      against a 40 ms sleep) already cost one red queue run. Fix the timing
+      dependence rather than widening the margin: the property under test is
+      that an expiry exists and is enforced, which does not need real time.
+
+- [x] **WS4 — auto-requeue re-queues entries that cannot merge.**
+      `merge-queue-requeue.yml` decides whether an ejection was transient by
+      reading `mergeable` / `mergeable_state`, which are computed against
+      **`main`** — not against the batch the entry was being validated in. An
+      entry that conflicts with another *queue member* reads as clean and gets
+      requeued, where it conflicts again. Observed live: #2249 conflicts with
+      #2251 in `crates/mvm-client/src/audit/normalize.rs`, is clean against
+      `main`, and was requeued after a manual dequeue.
+
+      Each such cycle costs a full validation run. Proposal: when an entry is
+      ejected and its own head is unchanged since the last ejection, require a
+      distinct signal before requeuing rather than treating "clean against
+      main" as proof the ejection was transient.
+
+## Not doing
+
+**Buying runners.** Capacity is not the binding constraint while a poisoned
+head entry can consume the pool indefinitely, and WS1–WS4 reduce demand rather
+than raise supply. Revisit only with WS1–WS4 landed and evidence of queue
+latency that is not explained by them.
+
+**`max_entries_to_build: 4` → lower.** It multiplies concurrent runner demand,
+but lowering it also lowers throughput once the queue is healthy. No change
+until WS2 is measured.


### PR DESCRIPTION
Plan 307. Follows the four-hour merge-queue stall on 2026-08-08.

## What actually happened

It presented as runner starvation — 13 runs queued against 3 executing, head entries in `AWAITING_CHECKS` for hours. That reading has an expensive fix (buy runners) and it was wrong.

The cause was **one PR at queue position 1 failing a policy gate**. #2232 carried a `check-no-vz` violation (a doc comment naming the retired backend, banned by the gate from #2235). The queue validates entries *batched on top of each other*, so every batch inherited the failure, went red on `Lint policy`, was discarded, and `merge-queue-requeue.yml` put it straight back. Starvation was real but downstream: the queue was converting runner time into nothing at a steady rate.

Fixed separately on that PR — one line, already pushed.

The generalisable bit, which is why plan 307 exists: **in a serial queue a bad head entry is indistinguishable from a slow queue.** Both look like "nothing merges", and the queue's own position/state display says `AWAITING_CHECKS` either way. The distinguishing evidence is per-entry check state on the `gh-readonly-queue/**` branches.

## What this PR changes

**The lease-expiry test no longer races a wall clock.** It bound a 20 ms TTL and slept 40 ms; a 2× margin is not a margin on a loaded runner, and it failed exactly that way (#2246). It now uses degenerate TTLs — zero has lapsed the moment it's taken, an hour hasn't lapsed by the end — which is the idiom the idle-flush tests in the same module already use. No sleep, 0.01 s instead of 10 s, and verified still red when `Lease::is_live` is stubbed to `true`.

Under `grouping_strategy: ALLGREEN` a flake doesn't just retry a job — it discards a whole batch and costs every entry in it another full cycle. So this is worth more than one test.

**Auto-requeue stops spending cycles on entries that can't merge.** It judged an ejection transient by reading `mergeable` against `main`. But the queue doesn't validate against `main` — it validates batched, so a PR conflicting with another *queue member* reads clean and gets requeued into the same conflict. Seen live: #2249 conflicts with #2251 in `audit/normalize.rs`, is clean against `main`, and came straight back after a manual dequeue. There's no API for "did this conflict with its batch", so it now refuses to spend a retry on a head that was already ejected once, and explains why on the PR.

While in that file I also fixed two bugs in my own first draft: `--jq` runs per page under `--paginate` (so `| last` returns one per page), and an indented multi-line body would have leaked whitespace into the rendered comment. No `${{ }}` interpolation inside `run:` — all inputs arrive via `env:` or API calls.

## Not in this PR

- **WS1 — required checks that can't report.** `kernel-build.yml` had no `merge_group` trigger and was `paths:`-filtered, so on any PR not touching kernel paths the required `Build kernels` contexts were simply *absent* — and an absent required check burns the full `check_response_timeout_minutes: 90` before ejection. Already in flight as **#2252**, independently authored. Not duplicated; plan 307 records the interaction.
- **WS2 — the queue merges one PR per cycle.** `min_entries_to_merge: 1`, `min_entries_to_merge_wait_minutes: 0`, despite `max_entries_to_merge: 5`. **This one needs you:** it's repo config, and the write was refused by local permission policy. Plan 307 carries the exact edit (`1 -> 3` and `0 -> 5` on ruleset `17624371`) and how to revert. Sequenced after the flake fix, since bigger batches make flakes cost more.
- **Buying runners.** Capacity isn't the binding constraint while a poisoned head entry can consume the pool indefinitely.

`mvm-hostd` suite green (1809/1809), clippy clean, `check-workflow-paths` and `check-sync` pass.