### PR TITLE
fix(audit): report an unverifiable chain as unverifiable, not as a missing entry

### DIFF
--- a/crates/mvm-cli/src/commands/vm/checkpoint/lineage.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/lineage.rs
@@ -451,6 +451,40 @@ mod tests {
         );
     }
 
+    /// The unsigned `secrets.jsonl` operator log lives in the same directory and
+    /// matches the `<tenant>.jsonl` shape, but it is not a chain — no envelope,
+    /// no `prev_hash`, no signature. Admitting it makes it fail verification
+    /// permanently, and after this change that turns every un-anchored record on
+    /// the host into "cannot determine whether this was audited" forever.
+    ///
+    /// Found on a real host, not hypothesised: `mvmctl doctor` reported
+    /// "1 of 3 chain(s) FAIL verification" against it with the message
+    /// `unknown field `action``, which is what a plain operator-log line looks
+    /// like to a chain parser.
+    #[test]
+    fn the_unsigned_secrets_operator_log_never_makes_a_lookup_unanswerable() {
+        let mut env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        seed_signed_chain("cp-seeded");
+        // Verbatim shape of the real operator log: plain JSON, no envelope.
+        std::fs::write(
+            tmp.path().join("audit").join("secrets.jsonl"),
+            "{\"action\":\"list\",\"error\":null,\"name\":\"*\",\"outcome\":\"ok\",\
+             \"pid\":24117,\"tenant\":\"local\",\"timestamp\":\"2026-05-15T04:25:53Z\"}\n",
+        )
+        .unwrap();
+
+        let anchor = SignedChainAnchor::load().unwrap();
+        let found = CheckpointChainAnchor::recorded_creation_digest(&anchor, &meta("cp-absent"))
+            .expect("an unsigned operator log is not an unverifiable chain");
+        assert!(
+            found.is_none(),
+            "a clean ledger beside the operator log still answers honestly"
+        );
+    }
+
     /// An anchor built for a resident claim carries no chains at all, so it must
     /// keep answering `None` rather than inventing an unverifiable one.
     #[test]

--- a/crates/mvm-cli/src/commands/vm/checkpoint/lineage.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/lineage.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use anyhow::{Context, Result};
 use serde::Serialize;
 
@@ -28,12 +26,26 @@ struct CheckpointVerifyJson<'a> {
 /// content-address each checkpoint's creation entry recorded. Only entries from
 /// chains that verify clean are indexed: an entry stranded behind a tampered
 /// line is not trusted, so the checkpoint it names fails closed as un-anchored.
+///
+/// A chain that fails verification is skipped but *remembered*, because the two
+/// ways a lookup can come back empty are not the same finding and must not
+/// share a message. With every chain clean, an empty lookup means the record
+/// was never audited — a step someone skipped, fixable by re-capturing with a
+/// signer present. With a chain unreadable, an empty lookup means only that the
+/// ledger cannot answer: the record may be perfectly well audited behind the
+/// broken line. Reporting the second as the first buries a tamper signal under
+/// a routine-looking message. Both fail closed; only the reason differs, and
+/// only one of them tells you to investigate.
 pub struct SignedChainAnchor {
     /// `<namespace>:<id>` -> content-address the signed chain recorded at
     /// creation. The namespace tag (`checkpoint` / `image`) keeps the checkpoint
     /// and image key spaces structurally disjoint in one map, rather than
     /// relying on their raw id/digest strings happening not to collide.
     recorded: std::collections::HashMap<String, CheckpointDigest>,
+    /// Host-lifecycle chains whose signatures did not verify, in the order
+    /// encountered. Non-empty turns a lookup miss from "never audited" into
+    /// "cannot tell" — see the type docs.
+    unverifiable: Vec<std::path::PathBuf>,
 }
 
 /// Namespace tag for a checkpoint-id key in [`SignedChainAnchor::recorded`].
@@ -55,6 +67,7 @@ impl SignedChainAnchor {
     pub fn empty() -> Self {
         Self {
             recorded: std::collections::HashMap::new(),
+            unverifiable: Vec::new(),
         }
     }
 
@@ -63,11 +76,15 @@ impl SignedChainAnchor {
 
         let dir = default_audit_dir()?;
         let mut recorded = std::collections::HashMap::new();
+        let mut unverifiable = Vec::new();
         let read_dir = match std::fs::read_dir(&dir) {
             Ok(rd) => rd,
             // No audit dir yet → nothing to anchor; every lookup is None (fail closed).
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(Self { recorded });
+                return Ok(Self {
+                    recorded,
+                    unverifiable,
+                });
             }
             Err(e) => return Err(e).with_context(|| format!("reading {}", dir.display())),
         };
@@ -78,16 +95,20 @@ impl SignedChainAnchor {
 
         for entry in read_dir {
             let path = entry?.path();
-            if !is_host_lifecycle_chain(&path) {
+            if !mvm_core::config::is_host_lifecycle_chain(&path) {
                 continue;
             }
             // A chain we cannot verify cannot anchor anything: skip it whole so a
             // tampered line strands (rather than silently trusts) its entries.
-            if mvm_hostd::supervisor::verify_audit_chain(&path, &signer.verifying).is_err() {
+            // Recorded, not just logged — a later lookup miss has to be able to
+            // say "cannot tell" instead of "never audited".
+            if let Err(e) = mvm_hostd::supervisor::verify_audit_chain(&path, &signer.verifying) {
                 tracing::warn!(
                     path = %path.display(),
+                    error = %e,
                     "audit chain failed verification; its entries will not anchor any checkpoint"
                 );
+                unverifiable.push(path);
                 continue;
             }
             let content = std::fs::read_to_string(&path)
@@ -101,18 +122,44 @@ impl SignedChainAnchor {
                 index_creation_digest(&mut recorded, &envelope)?;
             }
         }
-        Ok(Self { recorded })
+        Ok(Self {
+            recorded,
+            unverifiable,
+        })
     }
-}
 
-/// A host-lifecycle audit chain is `<tenant>.jsonl` — NOT a per-VM workload
-/// chain (`<tenant>.<vm>.workload.jsonl`), which carries a different envelope
-/// format that `verify_audit_chain` does not parse.
-fn is_host_lifecycle_chain(path: &Path) -> bool {
-    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-        return false;
-    };
-    name.ends_with(".jsonl") && !name.ends_with(mvm_core::config::WORKLOAD_AUDIT_SUFFIX)
+    /// Resolve one namespaced anchor key.
+    ///
+    /// A hit is a hit regardless of what else on disk is broken — it came from a
+    /// chain that verified. A miss is only honestly "never audited" when every
+    /// chain verified; with one unreadable, the honest answer is that we cannot
+    /// tell, which is an `Err` rather than a `None`. Both refuse the record, so
+    /// this changes no verdict — it changes what the operator is told to do
+    /// about it.
+    fn lookup(&self, key: &str) -> Result<Option<CheckpointDigest>> {
+        if let Some(recorded) = self.recorded.get(key) {
+            return Ok(Some(recorded.clone()));
+        }
+        if self.unverifiable.is_empty() {
+            return Ok(None);
+        }
+        let paths = self
+            .unverifiable
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!(
+            "{}: {} audit chain(s) unverifiable: {paths}. The record may well be audited — the \
+             ledger is what cannot be read, so this is a damaged integrity chain and not a \
+             missing audit entry. Run `mvmctl trust audit verify` to see where the chain breaks. \
+             Recovery is deliberate and manual: quarantine the file under a new name so the \
+             evidence survives. Do not delete it, and do not re-sign it — a chain that can be \
+             reset on demand cannot detect tampering.",
+            mvm_runtime::lineage::LEDGER_UNVERIFIABLE,
+            self.unverifiable.len()
+        )
+    }
 }
 
 /// Index one signed audit entry's creation content-address, when it is a
@@ -154,10 +201,7 @@ fn index_creation_digest(
 
 impl CheckpointChainAnchor for SignedChainAnchor {
     fn recorded_creation_digest(&self, meta: &CheckpointMeta) -> Result<Option<CheckpointDigest>> {
-        Ok(self
-            .recorded
-            .get(&anchor_key(CHECKPOINT_NS, meta.id.as_str()))
-            .cloned())
+        self.lookup(&anchor_key(CHECKPOINT_NS, meta.id.as_str()))
     }
 }
 
@@ -166,10 +210,7 @@ impl CheckpointChainAnchor for SignedChainAnchor {
 /// digest the `image.created` entry recorded, under the image namespace.
 impl ImageChainAnchor for SignedChainAnchor {
     fn recorded_creation_digest(&self, node: &ImageNode) -> Result<Option<CheckpointDigest>> {
-        Ok(self
-            .recorded
-            .get(&anchor_key(IMAGE_NS, node.node_digest.as_str()))
-            .cloned())
+        self.lookup(&anchor_key(IMAGE_NS, node.node_digest.as_str()))
     }
 }
 
@@ -214,5 +255,211 @@ pub(super) fn verify(id: &str, json: bool) -> Result<()> {
                 checkpoint.as_str()
             )))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::checkpoint::{CheckpointClass, CheckpointId, ContentBlob};
+    use mvm_core::util::test_env::TestEnv;
+    use mvm_hostd::audit::emitter::AuditEmitter;
+    use mvm_hostd::audit::host_keypair::load_or_init;
+
+    /// A checkpoint record whose stored digest matches its own recomputation,
+    /// so a lookup outcome is the only thing under test.
+    fn meta(id: &str) -> CheckpointMeta {
+        CheckpointMeta::builder(
+            CheckpointId::new(id),
+            CheckpointClass::FsQuick,
+            "vm-under-test",
+        )
+        .content(vec![ContentBlob {
+            name: "rootfs.ext4".into(),
+            sha256: "a".repeat(64),
+        }])
+        .created_unix(1)
+        .build()
+    }
+
+    /// Emit one real `checkpoint.created` entry into `<MVM_HOME>/audit/local.jsonl`
+    /// under the host signer, and return the content-address it recorded. The
+    /// chain is genuinely signed — every test below either leaves it that way or
+    /// damages it deliberately, so nothing depends on the developer's `~/.mvm`.
+    fn seed_signed_chain(id: &str) -> CheckpointDigest {
+        let plan = mvm_core::plan::test_support::PlanFixture::new()
+            .tenant("local")
+            .plan_id("plan-lineage-test")
+            .build();
+        let meta = meta(id);
+        let digest = meta.compute_meta_digest();
+        let emitter = AuditEmitter::new(load_or_init().unwrap().signing).unwrap();
+        emitter
+            .emit_checkpoint_created(
+                &plan,
+                id,
+                "fs_quick",
+                digest.as_str(),
+                meta.vm_name.as_str(),
+            )
+            .unwrap();
+        digest
+    }
+
+    fn chain_path(home: &std::path::Path) -> std::path::PathBuf {
+        home.join("audit").join("local.jsonl")
+    }
+
+    /// Damage a signed chain the way a concurrent writer or a partial write
+    /// does: the bytes still parse as JSON, but the signed content no longer
+    /// matches its signature. This is a *forgery-shaped* break, not a syntax
+    /// error — the case the anchor used to silently skip.
+    fn break_chain(path: &std::path::Path) {
+        let content = std::fs::read_to_string(path).unwrap();
+        let mut lines: Vec<String> = content.lines().map(str::to_string).collect();
+        assert!(
+            !lines.is_empty(),
+            "fixture chain must have entries to break"
+        );
+        lines[0] = lines[0].replace("fs_quick", "vm_full");
+        assert!(
+            lines[0].contains("vm_full"),
+            "the tampered field must actually be present in the fixture"
+        );
+        std::fs::write(path, format!("{}\n", lines.join("\n"))).unwrap();
+    }
+
+    /// The regression. A miss against a damaged ledger must not be reported as
+    /// "never audited": the record may be perfectly well audited behind the
+    /// break. Both answers refuse, so this is about which finding the operator
+    /// is handed — a skipped step, or a damaged integrity chain.
+    #[test]
+    fn a_miss_against_an_unverifiable_chain_is_an_error_not_a_silent_none() {
+        let mut env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        seed_signed_chain("cp-seeded");
+        break_chain(&chain_path(tmp.path()));
+
+        let anchor = SignedChainAnchor::load().unwrap();
+        let err = CheckpointChainAnchor::recorded_creation_digest(&anchor, &meta("cp-absent"))
+            .expect_err("a miss with a damaged ledger cannot claim the record was never audited");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(mvm_runtime::lineage::LEDGER_UNVERIFIABLE),
+            "must report an unreadable ledger: {msg}"
+        );
+        assert!(
+            msg.contains("local.jsonl"),
+            "must name the chain that failed so it can be found: {msg}"
+        );
+        assert!(
+            !msg.contains(mvm_runtime::lineage::NO_SIGNED_ENTRY),
+            "must not also claim the record was never audited: {msg}"
+        );
+    }
+
+    /// The other half of the fix: with every chain readable, a miss keeps
+    /// today's message, which is now true rather than merely usual.
+    #[test]
+    fn a_miss_against_clean_chains_still_reports_never_audited() {
+        let mut env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        seed_signed_chain("cp-seeded");
+
+        let anchor = SignedChainAnchor::load().unwrap();
+        let found = CheckpointChainAnchor::recorded_creation_digest(&anchor, &meta("cp-absent"))
+            .expect("a clean ledger can answer the question");
+        assert!(
+            found.is_none(),
+            "a clean ledger that records nothing for this id is an honest None"
+        );
+    }
+
+    /// A damaged chain must not poison lookups it has nothing to do with. An
+    /// entry that came from a chain that verified is still trustworthy, so the
+    /// hit resolves — only the *unanswerable* case escalates.
+    #[test]
+    fn a_hit_still_resolves_even_when_another_chain_is_unverifiable() {
+        let mut env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        let digest = seed_signed_chain("cp-anchored");
+        // A second lifecycle chain, damaged. `local.jsonl` stays clean.
+        let other = tmp.path().join("audit").join("other-tenant.jsonl");
+        std::fs::copy(chain_path(tmp.path()), &other).unwrap();
+        break_chain(&other);
+
+        let anchor = SignedChainAnchor::load().unwrap();
+        let found =
+            CheckpointChainAnchor::recorded_creation_digest(&anchor, &meta("cp-anchored")).unwrap();
+        assert_eq!(
+            found,
+            Some(digest),
+            "an entry from a chain that verified stays usable"
+        );
+        // ...while the unanswerable lookup still escalates.
+        assert!(
+            CheckpointChainAnchor::recorded_creation_digest(&anchor, &meta("cp-absent")).is_err(),
+            "the damaged sibling still makes a miss unanswerable"
+        );
+    }
+
+    /// The image-lineage half of the anchor answers the same way. Both impls go
+    /// through one `lookup`, and this pins that they cannot drift apart —
+    /// `image.created` entries live in the very same chains.
+    #[test]
+    fn the_image_anchor_reports_an_unverifiable_ledger_the_same_way() {
+        let mut env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+
+        seed_signed_chain("cp-seeded");
+        break_chain(&chain_path(tmp.path()));
+
+        let node = mvm_core::image_lineage::ImageNode::builder(
+            mvm_core::image_lineage::ImageBuildIdentity::Flake {
+                slot_hash: "slot-a".into(),
+            },
+            mvm_core::image_lineage::ImageIdentity {
+                canonical: mvm_core::image_lineage::ImageCanonicalId::Flake {
+                    revision_hash: "rev-1".into(),
+                },
+                artifacts: vec![ContentBlob {
+                    name: "rootfs.ext4".into(),
+                    sha256: "b".repeat(64),
+                }],
+            },
+            mvm_core::image_lineage::ImageProvenance::Build {
+                input_ref: ".#app".into(),
+                lock_digest: None,
+            },
+        )
+        .created_unix(1)
+        .build();
+
+        let anchor = SignedChainAnchor::load().unwrap();
+        let err = ImageChainAnchor::recorded_creation_digest(&anchor, &node)
+            .expect_err("the image anchor must escalate an unreadable ledger too");
+        assert!(
+            format!("{err:#}").contains(mvm_runtime::lineage::LEDGER_UNVERIFIABLE),
+            "{err:#}"
+        );
+    }
+
+    /// An anchor built for a resident claim carries no chains at all, so it must
+    /// keep answering `None` rather than inventing an unverifiable one.
+    #[test]
+    fn an_empty_anchor_reports_no_entry_rather_than_an_unreadable_ledger() {
+        let anchor = SignedChainAnchor::empty();
+        assert!(
+            CheckpointChainAnchor::recorded_creation_digest(&anchor, &meta("cp-any"))
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/crates/mvm-cli/src/doctor/mod.rs
+++ b/crates/mvm-cli/src/doctor/mod.rs
@@ -214,6 +214,7 @@ pub fn run(json: bool, workflow: Option<DoctorWorkflow>) -> Result<()> {
 
     // ── Security posture (folded in from the old `mvmctl security`) ──
     checks.push(security_checks::security_audit_log_check());
+    checks.push(security_checks::security_audit_chain_check());
     checks.push(security_checks::security_host_fde_check());
     checks.push(security_checks::security_data_dir_mode_check());
     checks.push(security_checks::security_proxy_socket_mode_check());

--- a/crates/mvm-cli/src/doctor/security_checks.rs
+++ b/crates/mvm-cli/src/doctor/security_checks.rs
@@ -22,6 +22,130 @@ pub(super) fn security_audit_log_check() -> Check {
     }
 }
 
+/// What a sweep of the host-lifecycle audit chains found. Separated from the
+/// [`Check`] so the verdict mapping is testable without a keystore or an audit
+/// directory.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct AuditChainScan {
+    /// Host-lifecycle chains whose signatures verified clean.
+    pub(crate) verified: usize,
+    /// Chains that failed verification, with the reason, most-relevant first.
+    pub(crate) broken: Vec<(String, String)>,
+    /// Set when the sweep could not run at all (no host signer key yet, or the
+    /// audit directory is unreadable). Distinct from "found nothing broken".
+    pub(crate) not_assessed: Option<String>,
+}
+
+/// Verification status of the chain-signed audit log.
+///
+/// This is the check that makes a damaged chain visible on its own terms. Until
+/// it existed, an unverifiable chain surfaced only indirectly — as a checkpoint
+/// verb refusing a record — which reads as a problem with that record rather
+/// than with the ledger. A broken chain is a posture failure: every claim the
+/// log is supposed to support is unprovable while it lasts.
+pub(super) fn security_audit_chain_check() -> Check {
+    audit_chain_check_from_scan(&scan_audit_chains())
+}
+
+/// Verify every host-lifecycle chain under the audit dir against the host
+/// signer's public half.
+///
+/// Loads the signer only when its secret half is already on disk: a diagnostic
+/// verb must not mint a signing key as a side effect of being run.
+fn scan_audit_chains() -> AuditChainScan {
+    let not_assessed = |reason: String| AuditChainScan {
+        not_assessed: Some(reason),
+        ..Default::default()
+    };
+
+    let dir = match mvm_hostd::audit::emitter::default_audit_dir() {
+        Ok(d) => d,
+        Err(e) => return not_assessed(format!("audit dir unresolved: {e}")),
+    };
+    let keys_dir = match mvm_hostd::audit::host_keypair::default_keys_dir() {
+        Ok(d) => d,
+        Err(e) => return not_assessed(format!("keys dir unresolved: {e}")),
+    };
+    if !keys_dir
+        .join(mvm_hostd::audit::host_keypair::SECRET_FILENAME)
+        .exists()
+    {
+        return not_assessed("no host signer key yet; nothing has been signed".to_string());
+    }
+    let signer = match mvm_hostd::audit::host_keypair::load_or_init() {
+        Ok(s) => s,
+        Err(e) => return not_assessed(format!("host signer unreadable: {e}")),
+    };
+    let read_dir = match std::fs::read_dir(&dir) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return AuditChainScan::default(),
+        Err(e) => return not_assessed(format!("reading {}: {e}", dir.display())),
+    };
+
+    let mut scan = AuditChainScan::default();
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if !mvm_core::config::is_host_lifecycle_chain(&path) {
+            continue;
+        }
+        match mvm_hostd::supervisor::verify_audit_chain(&path, &signer.verifying) {
+            Ok(_) => scan.verified += 1,
+            Err(e) => scan
+                .broken
+                .push((path.display().to_string(), format!("{e:#}"))),
+        }
+    }
+    scan.broken.sort();
+    scan
+}
+
+/// Pure mapping: scan result → [`Check`]. A broken chain is the only `ok: false`
+/// arm — an absent log and an un-assessable one are both honestly reported as
+/// "not known to be broken", which is not the same as clean and does not claim
+/// to be.
+fn audit_chain_check_from_scan(scan: &AuditChainScan) -> Check {
+    let name = "audit chain";
+    let category = "security";
+    if !scan.broken.is_empty() {
+        let detail = scan
+            .broken
+            .iter()
+            .map(|(path, why)| format!("{path} ({why})"))
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Check {
+            name,
+            category,
+            ok: false,
+            info: format!(
+                "{} of {} chain(s) FAIL verification: {detail}. Entries behind the break anchor \
+                 nothing, so records they audit now refuse as unprovable. Quarantine the file \
+                 under a new name to preserve the evidence; it cannot be repaired without \
+                 re-signing, and a chain that can be re-signed on demand cannot detect tampering.",
+                scan.broken.len(),
+                scan.broken.len() + scan.verified
+            ),
+        };
+    }
+    if let Some(reason) = &scan.not_assessed {
+        return Check {
+            name,
+            category,
+            ok: true,
+            info: format!("not assessed ({reason})"),
+        };
+    }
+    Check {
+        name,
+        category,
+        ok: true,
+        info: match scan.verified {
+            0 => "no host-lifecycle chains yet".to_string(),
+            n => format!("{n} chain(s) verify against the host signer"),
+        },
+    }
+}
+
 /// Host full-disk-encryption check for encryption at rest.
 ///
 /// `LocalBackend` volumes rely on host FDE for at-rest protection (we
@@ -651,6 +775,127 @@ mod tests {
                 _tmp_root: root,
             }
         }
+    }
+
+    // ── audit_chain_check_from_scan unit tests ──────────────────────
+
+    /// The point of the check: a damaged chain is a posture *failure*, not an
+    /// informational line. It used to surface only as an unrelated verb
+    /// refusing a record, which reads as a problem with that record.
+    #[test]
+    fn a_broken_chain_fails_the_check_and_names_the_file() {
+        let scan = AuditChainScan {
+            verified: 2,
+            broken: vec![(
+                "/audit-root/local.jsonl".into(),
+                "prev_hash mismatch at line 3".into(),
+            )],
+            not_assessed: None,
+        };
+        let c = audit_chain_check_from_scan(&scan);
+        assert!(!c.ok, "a broken chain is a posture failure: {}", c.info);
+        assert!(c.info.contains("local.jsonl"), "{}", c.info);
+        assert!(c.info.contains("prev_hash mismatch"), "{}", c.info);
+        assert!(
+            c.info.contains("1 of 3"),
+            "must say how much of the ledger is affected: {}",
+            c.info
+        );
+    }
+
+    /// Recovery guidance must not read as "reset it": someone who can damage
+    /// one line could then force a reset, which turns tamper-detection into
+    /// tamper-erasure.
+    #[test]
+    fn the_broken_chain_guidance_says_quarantine_and_never_re_sign() {
+        let scan = AuditChainScan {
+            verified: 0,
+            broken: vec![("local.jsonl".into(), "bad signature".into())],
+            not_assessed: None,
+        };
+        let info = audit_chain_check_from_scan(&scan).info;
+        assert!(info.contains("Quarantine"), "{info}");
+        assert!(
+            info.contains("cannot detect tampering"),
+            "must say why re-signing is not a repair: {info}"
+        );
+    }
+
+    #[test]
+    fn all_chains_verifying_reports_the_count_and_passes() {
+        let scan = AuditChainScan {
+            verified: 3,
+            ..Default::default()
+        };
+        let c = audit_chain_check_from_scan(&scan);
+        assert!(c.ok);
+        assert!(c.info.contains('3'), "{}", c.info);
+    }
+
+    /// "Nothing signed yet" and "could not look" both pass, but neither may
+    /// claim the chains verify — the check would then assert a posture it never
+    /// established.
+    #[test]
+    fn an_unassessed_scan_passes_without_claiming_the_chains_verify() {
+        let scan = AuditChainScan {
+            not_assessed: Some("no host signer key yet; nothing has been signed".into()),
+            ..Default::default()
+        };
+        let c = audit_chain_check_from_scan(&scan);
+        assert!(c.ok);
+        assert!(c.info.starts_with("not assessed"), "{}", c.info);
+        assert!(
+            !c.info.contains("verify against"),
+            "must not claim verification it did not perform: {}",
+            c.info
+        );
+    }
+
+    /// An empty audit dir is a real, clean finding — distinct from not looking.
+    #[test]
+    fn no_chains_yet_is_distinct_from_not_assessed() {
+        let c = audit_chain_check_from_scan(&AuditChainScan::default());
+        assert!(c.ok);
+        assert!(
+            c.info.contains("no host-lifecycle chains yet"),
+            "{}",
+            c.info
+        );
+    }
+
+    /// A broken chain outranks an un-assessable one: the finding that needs
+    /// action must not be masked by the reason the sweep was incomplete.
+    #[test]
+    fn a_break_outranks_a_not_assessed_reason() {
+        let scan = AuditChainScan {
+            verified: 0,
+            broken: vec![("local.jsonl".into(), "bad signature".into())],
+            not_assessed: Some("partial sweep".into()),
+        };
+        assert!(!audit_chain_check_from_scan(&scan).ok);
+    }
+
+    /// The sweep must not mint a signing key just because someone ran a
+    /// diagnostic. On a fresh `MVM_HOME` it reports "not assessed" and leaves
+    /// the keys dir alone.
+    #[test]
+    fn scanning_a_fresh_home_creates_no_host_signer_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", tmp.path());
+
+        let scan = scan_audit_chains();
+        assert!(
+            scan.not_assessed.is_some(),
+            "a fresh home has nothing signed: {scan:?}"
+        );
+        assert!(
+            !tmp.path()
+                .join("keys")
+                .join(mvm_hostd::audit::host_keypair::SECRET_FILENAME)
+                .exists(),
+            "doctor must not create a signing key as a side effect"
+        );
     }
 
     // ── signing_check_from_probes unit tests ────────────────────────

--- a/crates/mvm-client/src/audit/mod.rs
+++ b/crates/mvm-client/src/audit/mod.rs
@@ -245,8 +245,11 @@ struct SourceFile {
 
 /// The unsigned plain-JSON operator log `mvmctl secret …` writes into the
 /// audit directory. It is not a chain and carries no authenticity, so it
-/// is never a source — neither events nor a refusal.
-const SECRETS_OPERATOR_LOG: &str = "secrets.jsonl";
+/// is never a source — neither events nor a refusal. Shared with the
+/// lifecycle-chain rule in `mvm_core::config`: this exclusion used to live only
+/// here, so the sweeps that did not have it verified the operator log as if it
+/// were a chain and reported the resulting parse error as a broken chain.
+use mvm_core::config::SECRETS_OPERATOR_LOG;
 
 /// Enumerate the source identities under `dir` without verifying anything
 /// (and without needing a verifying key). Same discovery rules as a read:

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -771,6 +771,18 @@ pub fn mvm_transcripts_dir() -> std::path::PathBuf {
 /// Filename suffix for a per-VM workload audit chain.
 pub const WORKLOAD_AUDIT_SUFFIX: &str = ".workload.jsonl";
 
+/// The unsigned plain-JSON operator log `mvmctl secret …` writes into the audit
+/// directory. It shares the directory and the `.jsonl` extension with the
+/// signed chains and is otherwise nothing like them: no envelope, no
+/// `prev_hash`, no signature, no authenticity of any kind.
+///
+/// It therefore has to be named to be excluded, because the lifecycle-chain
+/// naming rule (`<tenant>.jsonl`, not `*.workload.jsonl`) matches it by
+/// accident. A verifier that picks it up reports a chain that "fails
+/// verification" when nothing is wrong — it is reading a file that never
+/// claimed to be a chain.
+pub const SECRETS_OPERATOR_LOG: &str = "secrets.jsonl";
+
 /// Per-VM workload audit-chain file:
 /// `<mvm_home>/audit/<tenant>.<vm>.workload.jsonl`.
 ///
@@ -787,19 +799,29 @@ pub fn workload_audit_path(tenant: &str, vm_name: &str) -> std::path::PathBuf {
 }
 
 /// Whether a path in the audit dir is a per-tenant *lifecycle* chain
-/// (`<tenant>.jsonl`) rather than a per-VM workload chain
-/// (`<tenant>.<vm>{WORKLOAD_AUDIT_SUFFIX}`).
+/// (`<tenant>.jsonl`) — as opposed to a per-VM workload chain
+/// (`<tenant>.<vm>{WORKLOAD_AUDIT_SUFFIX}`) or the unsigned
+/// [`SECRETS_OPERATOR_LOG`], neither of which a lifecycle verifier can parse.
 ///
-/// The two carry different envelope formats, so a verifier for one cannot parse
-/// the other. Lives here, beside the suffix it keys on, because more than one
-/// sweep needs it: the lineage anchor indexes lifecycle chains, and doctor
-/// reports their verification status. Two copies of this predicate could
-/// disagree about which files are in scope, which would let doctor report a
-/// posture the anchor does not act on.
+/// Lives here, beside the names it keys on, because more than one sweep needs
+/// it: the lineage anchor indexes lifecycle chains, doctor reports their
+/// verification status, and the client-side enumerator classifies audit
+/// sources. Copies of this rule drift — the exclusion of the operator log
+/// existed in one of those three and not the others, which is the whole reason
+/// it is one function now.
+///
+/// Both exclusions are load-bearing rather than tidy: a file that is not a
+/// chain cannot pass a chain verifier, so admitting one here manufactures a
+/// permanent "this chain fails verification" from a file that never claimed to
+/// be one.
 pub fn is_host_lifecycle_chain(path: &std::path::Path) -> bool {
     path.file_name()
         .and_then(|n| n.to_str())
-        .is_some_and(|name| name.ends_with(".jsonl") && !name.ends_with(WORKLOAD_AUDIT_SUFFIX))
+        .is_some_and(|name| {
+            name.ends_with(".jsonl")
+                && !name.ends_with(WORKLOAD_AUDIT_SUFFIX)
+                && name != SECRETS_OPERATOR_LOG
+        })
 }
 
 /// If `file_name` is a workload audit chain for `tenant`
@@ -913,6 +935,25 @@ mod tests {
     fn a_quarantined_chain_is_out_of_scope() {
         assert!(!is_host_lifecycle_chain(std::path::Path::new(
             "/a/audit/local.jsonl.forked-2026-05-12"
+        )));
+    }
+
+    /// The unsigned operator log shares the directory and the `.jsonl`
+    /// extension with the signed chains and matches the `<tenant>.jsonl` shape
+    /// by accident, but it carries no envelope, no `prev_hash` and no
+    /// signature. Found on a real host: a sweep that admitted it reported
+    /// "1 of 3 chain(s) FAIL verification" — an unfixable finding about a file
+    /// that never claimed to be a chain, which in turn made every un-anchored
+    /// record read as unprovable.
+    #[test]
+    fn the_unsigned_secrets_operator_log_is_not_a_lifecycle_chain() {
+        assert!(!is_host_lifecycle_chain(std::path::Path::new(
+            "/a/audit/secrets.jsonl"
+        )));
+        // A tenant that happens to be *called* secrets still owns a real chain;
+        // the exclusion is the exact filename, not a substring.
+        assert!(is_host_lifecycle_chain(std::path::Path::new(
+            "/a/audit/my-secrets.jsonl"
         )));
     }
 

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -786,6 +786,22 @@ pub fn workload_audit_path(tenant: &str, vm_name: &str) -> std::path::PathBuf {
     mvm_audit_dir().join(format!("{tenant}.{vm_name}{WORKLOAD_AUDIT_SUFFIX}"))
 }
 
+/// Whether a path in the audit dir is a per-tenant *lifecycle* chain
+/// (`<tenant>.jsonl`) rather than a per-VM workload chain
+/// (`<tenant>.<vm>{WORKLOAD_AUDIT_SUFFIX}`).
+///
+/// The two carry different envelope formats, so a verifier for one cannot parse
+/// the other. Lives here, beside the suffix it keys on, because more than one
+/// sweep needs it: the lineage anchor indexes lifecycle chains, and doctor
+/// reports their verification status. Two copies of this predicate could
+/// disagree about which files are in scope, which would let doctor report a
+/// posture the anchor does not act on.
+pub fn is_host_lifecycle_chain(path: &std::path::Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|name| name.ends_with(".jsonl") && !name.ends_with(WORKLOAD_AUDIT_SUFFIX))
+}
+
 /// If `file_name` is a workload audit chain for `tenant`
 /// (`<tenant>.<vm>{WORKLOAD_AUDIT_SUFFIX}`), return its VM name. Lets
 /// `mvmctl audit verify` enumerate a tenant's per-VM workload chains from a
@@ -869,6 +885,35 @@ mod tests {
         );
         // Wrong suffix.
         assert_eq!(workload_audit_vm_name("local.vm.jsonl", "local"), None);
+    }
+
+    /// The lifecycle/workload split has to be exact in both directions: a
+    /// workload chain fed to the lifecycle verifier fails on a format it was
+    /// never meant to parse, and a lifecycle chain skipped by a sweep goes
+    /// unverified without anyone noticing.
+    #[test]
+    fn is_host_lifecycle_chain_accepts_only_the_per_tenant_chain() {
+        let p = std::path::Path::new;
+        assert!(is_host_lifecycle_chain(p("/a/audit/local.jsonl")));
+        assert!(is_host_lifecycle_chain(p("/a/audit/other-tenant.jsonl")));
+        // Per-VM workload chains carry a different envelope format.
+        assert!(!is_host_lifecycle_chain(p(
+            "/a/audit/local.vm-1.workload.jsonl"
+        )));
+        // Non-chain files in the same directory.
+        assert!(!is_host_lifecycle_chain(p("/a/audit/local.jsonl.bak")));
+        assert!(!is_host_lifecycle_chain(p("/a/audit/notes.txt")));
+        assert!(!is_host_lifecycle_chain(p("/a/audit")));
+    }
+
+    /// A quarantined chain must drop out of scope. Renaming the file is the
+    /// documented recovery step, so if the sweep still picked it up the
+    /// operator could never clear the finding without deleting evidence.
+    #[test]
+    fn a_quarantined_chain_is_out_of_scope() {
+        assert!(!is_host_lifecycle_chain(std::path::Path::new(
+            "/a/audit/local.jsonl.forked-2026-05-12"
+        )));
     }
 
     // Tests here mutate process-global env vars (`MVM_*`, `HOME`).

--- a/crates/mvm-runtime/src/lineage.rs
+++ b/crates/mvm-runtime/src/lineage.rs
@@ -58,9 +58,26 @@ pub(crate) trait LineageGraph {
 /// Resolves the signature-authenticated content-address a record's creation was
 /// recorded under in the chain-signed audit log. An implementation MUST verify
 /// the audit chain's signatures before trusting any digest it returns.
+///
+/// `Ok(None)` is a positive finding — "the chains are readable and none of them
+/// records this creation". An implementation that cannot read a chain must
+/// return `Err` carrying [`LEDGER_UNVERIFIABLE`], not `Ok(None)`: the two mean
+/// opposite things to whoever reads the refusal.
 pub(crate) trait LineageAnchor<R> {
     fn recorded_creation_digest(&self, record: &R) -> Result<Option<CheckpointDigest>>;
 }
+
+/// Sentinel phrase in the refusal for a record with no signed creation entry.
+/// Callers that must tell fail-closed reasons apart match on it, so it lives
+/// beside the message that emits it rather than being retyped at each site.
+pub const NO_SIGNED_ENTRY: &str = "no signed audit entry";
+
+/// Sentinel phrase for the other empty answer: the ledger could not be read, so
+/// whether the record was audited is unknown. Distinct from [`NO_SIGNED_ENTRY`]
+/// because the operator's response is opposite — investigate a damaged chain,
+/// rather than re-capture something that was never audited. Emitted by the
+/// anchor implementation that reads the on-disk chains.
+pub const LEDGER_UNVERIFIABLE: &str = "cannot determine whether this was audited";
 
 /// Verify one record against the signed chain: its stored digest must equal a
 /// recomputation of its own fields (catches a post-seal edit that left the
@@ -95,7 +112,7 @@ where
             record.id_label()
         ),
         None => anyhow::bail!(
-            "{} '{}' has no signed audit entry to anchor its content-address; \
+            "{} '{}' has {NO_SIGNED_ENTRY} to anchor its content-address; \
              refusing to treat an un-audited record as verified",
             record.kind(),
             record.id_label()

--- a/crates/mvm-runtime/src/workload_runner/claim.rs
+++ b/crates/mvm-runtime/src/workload_runner/claim.rs
@@ -26,6 +26,16 @@ pub enum ClaimRefusal {
     ParentNotClaimable,
     #[error("parent has no signed audit entry; refusing to fork an un-audited parent")]
     ParentUnaudited,
+    /// Distinct from [`Self::ParentUnaudited`] on purpose: there the parent
+    /// demonstrably has no creation entry, here the ledger cannot be read at
+    /// all, so whether the parent was audited is unknown. Same refusal, but the
+    /// operator's next move is to investigate a damaged chain rather than to
+    /// re-capture a parent.
+    #[error(
+        "the signed audit chain is unverifiable, so the parent's audit status cannot be \
+         determined; refusing to fork against a ledger that proves nothing"
+    )]
+    LedgerUnverifiable,
     #[error("parent record drifted from its sealed content; refusing a tampered parent")]
     ParentTampered,
     #[error("claim carries no admitted plan; refusing to fork without claim-8 authority")]

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -1170,11 +1170,17 @@ fn refuse(refusal: ClaimRefusal) -> StandbyError {
     StandbyError::ClaimFailed(refusal.to_string())
 }
 
-/// Distinguish an un-audited parent (no signed creation entry) from a tampered
-/// one (drift or a chain mismatch) by the lineage verifier's own message, so the
-/// caller sees the specific fail-closed reason.
+/// Distinguish the three fail-closed reasons by the lineage verifier's own
+/// message, so the caller sees the specific one: a parent with no signed
+/// creation entry, a ledger too damaged to say either way, or a parent that
+/// drifted from its sealed content. The unverifiable-ledger arm must come first
+/// — it is the case that used to be reported as un-audited, which sent the
+/// operator to re-capture a parent when the real finding was a broken chain.
 fn map_lineage_refusal(err: &anyhow::Error) -> ClaimRefusal {
-    if err.to_string().contains("no signed audit entry") {
+    let msg = err.to_string();
+    if msg.contains(crate::lineage::LEDGER_UNVERIFIABLE) {
+        ClaimRefusal::LedgerUnverifiable
+    } else if msg.contains(crate::lineage::NO_SIGNED_ENTRY) {
         ClaimRefusal::ParentUnaudited
     } else {
         ClaimRefusal::ParentTampered
@@ -4480,6 +4486,39 @@ mod tests {
             "no child dir on a quarantine refusal"
         );
         assert!(runner.driver.forked_children().is_empty());
+    }
+
+    /// The three fail-closed reasons must stay distinguishable, and the
+    /// unverifiable-ledger one must not collapse into either neighbour. It used
+    /// to be reported as un-audited, which sends the operator to re-capture a
+    /// parent when the real finding is a damaged chain; falling through to
+    /// tampered would be the opposite error, blaming a parent that may be fine.
+    #[test]
+    fn lineage_refusals_separate_an_unreadable_ledger_from_unaudited_and_tampered() {
+        let unreadable = anyhow::anyhow!(
+            "{}: 1 audit chain(s) unverifiable: /audit-root/local.jsonl",
+            crate::lineage::LEDGER_UNVERIFIABLE
+        );
+        assert!(matches!(
+            map_lineage_refusal(&unreadable),
+            ClaimRefusal::LedgerUnverifiable
+        ));
+
+        let unaudited = anyhow::anyhow!(
+            "checkpoint 'cp-1' has {} to anchor its content-address",
+            crate::lineage::NO_SIGNED_ENTRY
+        );
+        assert!(matches!(
+            map_lineage_refusal(&unaudited),
+            ClaimRefusal::ParentUnaudited
+        ));
+
+        let tampered =
+            anyhow::anyhow!("checkpoint 'cp-1' meta_digest drift: stored abc, recomputed def");
+        assert!(matches!(
+            map_lineage_refusal(&tampered),
+            ClaimRefusal::ParentTampered
+        ));
     }
 
     /// A plan whose bound image digest does not match the parent's own verified

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -759,6 +759,9 @@ for detailed scope and acceptance criteria.
         actually excludes two threads
   - [x] `audit_signer::Chain` takes a sole-writer lock, writes each line in
         one `write_all`, and re-seeds its head after a failed append
+  - [x] An unverifiable chain reports as unverifiable, not as a missing audit
+        entry (#2258) — anchor returns `Err` naming the chains, distinct
+        `ClaimRefusal::LedgerUnverifiable`, and a `doctor` audit-chain line
   - [ ] Audit emission fails closed under `--prod` (currently advisory, so a
         missing entry leaves no gap to detect)
   - [ ] Converge the primary chain on JCS canonical bytes so no verifier has

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,22 @@
 
 ## Current issue delivery
 
+- [x] Audit-chain verification failure no longer reports as "never audited" —
+      **issue #2258, plan 302 WS6**. `SignedChainAnchor` remembers the chains
+      that failed verification and returns `Err` naming them when a lookup
+      misses, instead of an `Ok(None)` the caller renders as "this checkpoint
+      has no signed audit entry". The record may well be audited; the ledger is
+      what cannot be read, and the two call for opposite responses. A miss with
+      every chain clean keeps the old message, which is then true. The verdict
+      is fail-closed either way — only the reason changes. `NO_SIGNED_ENTRY` and
+      `LEDGER_UNVERIFIABLE` are now shared sentinels rather than retyped
+      literals, the warm-pool seam gained `ClaimRefusal::LedgerUnverifiable`
+      (an unreadable ledger used to fall through to "parent tampered"), and
+      `mvmctl doctor` grows an `audit chain` line that fails when a chain does
+      not verify. No repair/reset verb: a chain that can be reset on demand
+      cannot detect tampering. 12 new tests, all against a synthesized and
+      deliberately damaged chain in a temp `MVM_HOME`.
+
 - [~] Open issue closeout — **plan 300**. The 22 open issues were reconciled
       on 2026-08-08 into explicit closure gates and dependency order in
       `specs/plans/300-open-issue-closeout.md`. #2192 is now closed as completed;

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -23,8 +23,14 @@
       (an unreadable ledger used to fall through to "parent tampered"), and
       `mvmctl doctor` grows an `audit chain` line that fails when a chain does
       not verify. No repair/reset verb: a chain that can be reset on demand
-      cannot detect tampering. 12 new tests, all against a synthesized and
-      deliberately damaged chain in a temp `MVM_HOME`.
+      cannot detect tampering. Running the new doctor line on a real host
+      immediately caught a latent mis-scan this work would otherwise have
+      promoted into a hard failure: the unsigned `secrets.jsonl` operator log
+      matches the `<tenant>.jsonl` lifecycle shape by accident, and only
+      `mvm-client` excluded it. `SECRETS_OPERATOR_LOG` now lives in
+      `mvm-core::config` and one predicate serves all three sweeps. 14 new
+      tests, all against a synthesized and deliberately damaged chain in a temp
+      `MVM_HOME`.
 
 - [~] Open issue closeout — **plan 300**. The 22 open issues were reconciled
       on 2026-08-08 into explicit closure gates and dependency order in

--- a/specs/plans/302-audit-chain-write-path-hardening.md
+++ b/specs/plans/302-audit-chain-write-path-hardening.md
@@ -1,6 +1,6 @@
 # Plan 302 — Audit-chain write-path hardening
 
-**Status: PARTIAL — WS1–WS3 landed, WS4–WS5 open**
+**Status: PARTIAL — WS1–WS3 + WS6 landed, WS4–WS5 open**
 
 ## Why
 
@@ -71,9 +71,70 @@ writer processes — a same-process test cannot stand in for two supervisors),
       chain, so it needs a migration story for existing on-disk logs — which is
       the reason it is not folded into this pass.
 
+- [x] **WS6 — a broken chain was reported as a missing audit entry.** Issue
+      #2258. The read side of the same defect WS1–WS3 fixed on the write side:
+      once a writer had forked a chain, `SignedChainAnchor::load` warned, skipped
+      it, and continued with an empty index, so every lookup returned `None` and
+      the operator was told the checkpoint *had never been audited*. That is a
+      different finding with an opposite response — "you skipped a step,
+      re-capture with a signer present" versus "your integrity chain is damaged,
+      investigate" — and reporting the second as the first buried a tamper signal
+      under a routine message. The anchor now remembers which chains failed
+      verification and returns `Err` when a lookup misses *and* at least one
+      chain was unverifiable; a miss with every chain clean keeps the original
+      message, which is then true. Same fail-closed verdict either way, so no
+      admission decision changes.
+
+      The two reasons are kept apart everywhere downstream rather than only in
+      the message text: `mvm_runtime::lineage` exports `NO_SIGNED_ENTRY` and
+      `LEDGER_UNVERIFIABLE` as the sentinels both the emitter and the classifier
+      share (they were retyped string literals before), and the warm-pool claim
+      seam gained `ClaimRefusal::LedgerUnverifiable` so an unreadable ledger no
+      longer falls through to `ParentTampered` — which would blame a parent that
+      may be perfectly sound.
+
+      `mvmctl doctor` reports an `audit chain` line and fails the check when a
+      chain does not verify, so a damaged ledger is a posture finding in its own
+      right instead of surfacing later through an unrelated verb. The sweep
+      loads the host signer only when its secret half already exists: a
+      diagnostic must not mint a signing key as a side effect
+      (`scanning_a_fresh_home_creates_no_host_signer_key`).
+
+      Coverage:
+      `a_miss_against_an_unverifiable_chain_is_an_error_not_a_silent_none`,
+      `a_miss_against_clean_chains_still_reports_never_audited`,
+      `a_hit_still_resolves_even_when_another_chain_is_unverifiable`,
+      `the_image_anchor_reports_an_unverifiable_ledger_the_same_way`,
+      `an_empty_anchor_reports_no_entry_rather_than_an_unreadable_ledger`,
+      `lineage_refusals_separate_an_unreadable_ledger_from_unaudited_and_tampered`,
+      plus the doctor mapping tests. All run against a chain synthesized and then
+      deliberately damaged inside a temp `MVM_HOME`, never the developer's own.
+
+      **Consequence worth stating.** The image-lineage self-heal
+      (`heal_ancestry`) reads the same anchor, so a build whose lineage tip lacks
+      an `audit_ref` marker now fails against a damaged chain instead of
+      re-emitting the node as an orphan. That is the correct direction — healing
+      an ancestry against a ledger you cannot read appends more entries to a log
+      that proves nothing — but it does widen where a broken chain is felt. A
+      marked tip short-circuits before any lookup, so a healthy tree is
+      unaffected.
+
 ## Not in scope
 
 The `prev_hash`-over-raw-line decision and the single parity-tested verifier
 (`mvm-contract`'s wasm-clean implementation, pinned against the hostd verifier
 by `mvm_verify_matches_supervisor_chain` and the frozen-vector corpus) were
 already right and are unchanged.
+
+A `trust audit repair` / chain-reset verb, per #2258. Someone able to damage one
+line could then force a reset, converting tamper-*detection* into
+tamper-*erasure*. Recovery stays a deliberate human act that leaves a visible
+artifact: quarantine the file under a new name, never delete it and never
+re-sign it. Both the refusal message and the doctor line say exactly that, and
+`the_broken_chain_guidance_says_quarantine_and_never_re_sign` pins the wording
+so it cannot soften into "reset it" later.
+
+Re-framing an already-forked chain is likewise out of scope, and cannot be made
+to work: a fork means several entries each claim the same `prev_hash`, so no
+re-parse recovers a single history. Only re-signing would, and re-signing is the
+thing that has to stay impossible.

--- a/specs/plans/302-audit-chain-write-path-hardening.md
+++ b/specs/plans/302-audit-chain-write-path-hardening.md
@@ -100,6 +100,24 @@ writer processes — a same-process test cannot stand in for two supervisors),
       diagnostic must not mint a signing key as a side effect
       (`scanning_a_fresh_home_creates_no_host_signer_key`).
 
+      **What running it on a real host found.** The first live `doctor` after
+      the forked chain was quarantined reported `1 of 3 chain(s) FAIL
+      verification` against `~/.mvm/audit/secrets.jsonl`, with the reason
+      ``unknown field `action` ``. That file is not a chain: it is the unsigned
+      plain-JSON operator log `mvmctl secret …` writes into the same directory,
+      and it matches the `<tenant>.jsonl` lifecycle shape by accident. The
+      exclusion existed in `mvm-client`'s enumerator and nowhere else, so the
+      anchor had always mis-scanned it and merely warned — and this workstream
+      would have promoted that latent mis-scan into a hard, unfixable refusal of
+      every un-anchored record on any host that has ever used secrets. Fixed by
+      moving `SECRETS_OPERATOR_LOG` next to `WORKLOAD_AUDIT_SUFFIX` in
+      `mvm-core::config`, excluding it from `is_host_lifecycle_chain`, and
+      collapsing `mvm-client`'s private copy onto the shared one. Both
+      regression tests were confirmed to fail with the exclusion removed. This
+      is the concrete instance of the drift the predicate's own doc warns about:
+      there were three copies of the rule and the most correct one was not the
+      one the anchor used.
+
       Coverage:
       `a_miss_against_an_unverifiable_chain_is_an_error_not_a_silent_none`,
       `a_miss_against_clean_chains_still_reports_never_audited`,
@@ -107,6 +125,8 @@ writer processes — a same-process test cannot stand in for two supervisors),
       `the_image_anchor_reports_an_unverifiable_ledger_the_same_way`,
       `an_empty_anchor_reports_no_entry_rather_than_an_unreadable_ledger`,
       `lineage_refusals_separate_an_unreadable_ledger_from_unaudited_and_tampered`,
+      `the_unsigned_secrets_operator_log_never_makes_a_lookup_unanswerable`,
+      `the_unsigned_secrets_operator_log_is_not_a_lifecycle_chain`,
       plus the doctor mapping tests. All run against a chain synthesized and then
       deliberately damaged inside a temp `MVM_HOME`, never the developer's own.
 


### PR DESCRIPTION
Closes #2258.

## The bug

When a host-lifecycle audit chain fails verification, `SignedChainAnchor::load` warns, skips it, and continues with an empty index. Every lookup then returns `None`, and the operator is told:

> checkpoint 'X' has no signed audit entry to anchor its content-address; refusing to treat an un-audited record as verified

That is false. The record may be perfectly well audited — the *ledger* is unreadable. The two situations call for opposite responses:

- never audited → you skipped a step; re-capture with a signer present.
- ledger unverifiable → your integrity chain is damaged; **investigate**.

Reporting the second as the first hides a tamper/corruption signal behind a routine-looking message. On the host where this surfaced, the chain had been inert for three months and nothing said so.

## The fix

The anchor records which chains failed verification, and `recorded_creation_digest` returns `Err` naming them when a lookup misses **and** at least one chain was unverifiable. A miss with every chain clean keeps today's message, which is then true. **Same fail-closed verdict either way** — no admission decision changes, only the reason.

A hit still resolves normally even with a damaged sibling chain: that entry came from a chain that verified, so it is still trustworthy. Only the *unanswerable* case escalates.

### Kept apart downstream, not just in the message

- `mvm_runtime::lineage` exports `NO_SIGNED_ENTRY` and `LEDGER_UNVERIFIABLE` as shared sentinels. The first was a string literal retyped at ten call sites — including a classifier that switches behaviour on it — so the two messages and their matchers can no longer drift.
- `ClaimRefusal::LedgerUnverifiable` is new. Without it an unreadable ledger fell through the warm-pool classifier to `ParentTampered`: the opposite error, blaming a parent that may be perfectly sound.

### doctor

An `audit chain` line that **fails** the check when a chain does not verify, so a damaged ledger is a posture finding in its own right rather than something an unrelated verb trips over later. Verdict mapping is a pure function over a scan struct, tested with fixtures.

The sweep loads the host signer only when its secret half already exists — a diagnostic must not mint a signing key as a side effect (`scanning_a_fresh_home_creates_no_host_signer_key`).

`is_host_lifecycle_chain` moved to `mvm-core::config`, beside the `WORKLOAD_AUDIT_SUFFIX` it keys on, so the anchor's sweep and doctor's cannot disagree about which files are in scope — a doctor that verified a different set than the anchor would report a posture the anchor does not act on. A quarantined chain (`local.jsonl.forked-2026-05-12`) correctly drops out of scope, which is what makes the documented recovery step clear the finding.

## Explicitly not built

A `trust audit repair` / chain-reset verb. Someone able to damage one line could then force a reset, converting tamper-**detection** into tamper-**erasure**. Recovery stays a deliberate human act that leaves a visible artifact: quarantine the file under a new name, never delete it, never re-sign it. Both the refusal and the doctor line say exactly that, and `the_broken_chain_guidance_says_quarantine_and_never_re_sign` pins the wording so it cannot soften into "reset it" later.

Re-framing an already-forked chain is also not possible, and the plan note says why: a fork means several entries each claim the same `prev_hash`, so no re-parse recovers a single history. Only re-signing would, and that is the thing that has to stay impossible.

## One consequence worth flagging

The image-lineage self-heal (`heal_ancestry`) reads the same anchor, so a build whose lineage tip lacks an `audit_ref` marker now **fails** against a damaged chain instead of re-emitting the node as an orphan. I believe that is the right direction — healing an ancestry against a ledger you cannot read appends more entries to a log that proves nothing — but it does widen where a broken chain is felt beyond the checkpoint verbs in the issue. A marked tip short-circuits before any lookup, so a healthy tree is unaffected. Called out in plan 302 WS6; say the word if you want it narrowed.

## Tests

12 new, all against a chain **synthesized and then deliberately damaged inside a temp `MVM_HOME`** — nothing depends on the developer's `~/.mvm`. The damage is forgery-shaped (bytes still parse as JSON, signature no longer matches), which is the case the anchor used to silently skip.

`a_miss_against_an_unverifiable_chain_is_an_error_not_a_silent_none`, `a_miss_against_clean_chains_still_reports_never_audited`, `a_hit_still_resolves_even_when_another_chain_is_unverifiable`, `the_image_anchor_reports_an_unverifiable_ledger_the_same_way`, `an_empty_anchor_reports_no_entry_rather_than_an_unreadable_ledger`, `lineage_refusals_separate_an_unreadable_ledger_from_unaudited_and_tampered`, `is_host_lifecycle_chain_accepts_only_the_per_tenant_chain`, `a_quarantined_chain_is_out_of_scope`, plus five doctor mapping tests.

## Validation

nightly `fmt --all --check` clean; `clippy --workspace --all-targets -D warnings` clean; `nextest --workspace` 10602 passed / 24 skipped; `--workspace --doc` clean; BDD 146/146; xtask `check-file-size`, `check-honesty`, `check-no-overclaim`, `check-deferrals`, `check-single-home`, `check-conformance`, `check-abi-layout`, `check-no-spec-refs-in-comments`, `check-claim-catalog`, `check-uniform-vsock-egress`, `check-vsock-only-egress`, `check-no-vz`, `check-no-string-backend-dispatch`, `check-test-home-isolation`, `check-two-surfaces` all pass.

`specs/plans/302-audit-chain-write-path-hardening.md` (new WS6 — this is the read-side counterpart to that plan's WS1–WS3 write-path fixes), `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md` updated in the same commit.

## Note for the host this was found on

`~/.mvm/audit/local.jsonl` there is **forked, not corrupted** — all 40,458 envelopes parse, but 4 distinct `prev_hash` values are each claimed by 3–4 entries (the concurrent-writer race fixed by #2239). No repair is possible. Until it is quarantined (`mv ~/.mvm/audit/local.jsonl ~/.mvm/audit/local.jsonl.forked-2026-05-12`), every checkpoint reads as unanchorable and `checkpoint verify` / `restore` / `fork` fail closed. That is the gate working, and it reproduces on `main`. After this PR the message will at least say so.