### PR TITLE
ci: cache Rust builds so a validation cycle stops recompiling the world

### DIFF
--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -1,0 +1,48 @@
+name: Rust build cache
+description: >
+  Restore the shared Rust build cache for this workspace. Restore-only by
+  default; only the cache-warm workflow on main writes it.
+
+inputs:
+  save:
+    description: >
+      Whether this job may write the cache. Leave false everywhere except the
+      warm job — see the note below on why writers are centralised.
+    required: false
+    default: "false"
+  key:
+    description: >
+      Extra discriminator for jobs whose target dir is genuinely different
+      (a cross-compiled target, a different feature set). Jobs sharing a value
+      share a cache.
+    required: false
+    default: "workspace"
+
+runs:
+  using: composite
+  steps:
+    # Why one writer:
+    #
+    # GitHub scopes a cache to the ref that wrote it, and only caches written on
+    # the default branch are readable from every other ref. Merge-queue refs are
+    # ephemeral — one run each, then gone — so an entry written by a queue run
+    # can never be read again. Pull-request runs can only ever hit their own
+    # branch's entries.
+    #
+    # So the useful cache is the one main writes, and every other job restores
+    # it. Letting PR jobs write as well would not help them (they already
+    # restore main's) and would actively hurt: the repo cache is capped at 10 GB
+    # with LRU eviction, and a Rust target directory this size means a busy day
+    # of PR writes would evict the very entry everything else depends on.
+    - name: Restore Rust build cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: ${{ inputs.key }}
+        # The toolchain and lockfile are already part of the key that
+        # rust-cache computes, so nightly and stable jobs never collide.
+        save-if: ${{ inputs.save }}
+        # Dependencies only — rust-cache already drops this workspace's own
+        # crates from the saved tree, which is what keeps the entry small
+        # enough to stay under the repo cache cap. `cache-bin` stays on so the
+        # eBPF lane's `cargo install bpf-linker` is not rebuilt every run.
+        cache-all-crates: "false"

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,83 @@
+name: Warm the Rust build cache
+
+# CI runs on `pull_request` and `merge_group`, never on a push to main — so
+# without this workflow nothing ever writes a cache entry that another ref can
+# read, and every job in every validation cycle compiles the dependency graph
+# from scratch.
+#
+# This is the one writer. It builds the workspace once per merge so that every
+# pull-request job and, more importantly, every merge-queue job starts from a
+# warm target directory. The queue is the throughput bottleneck and its refs are
+# ephemeral, so main is the only place a cache useful to it can come from.
+#
+# It costs one build per merge and saves several per validation cycle: the
+# workspace is compiled by lint-core, lint-features, test-workspace, test-linux
+# and test-ebpf-telemetry, each from cold today.
+
+on:
+  push:
+    branches: [main]
+    # Only the inputs that can change what gets compiled. A docs-only merge
+    # leaves the previous entry valid, and rewriting it would spend a build to
+    # produce a byte-identical cache.
+    paths:
+      - "crates/**"
+      - "src/**"
+      - "xtask/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/cache-warm.yml"
+      - ".github/actions/rust-cache/**"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# One warm at a time. Merges can land faster than a build completes, and the
+# newest main is the one worth caching — but let an in-flight build finish
+# rather than cancelling, since a half-built target dir caches nothing useful.
+concurrency:
+  group: cache-warm
+  cancel-in-progress: false
+
+jobs:
+  warm:
+    name: Warm
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/free-disk
+
+      # Nightly is what the heavy lanes (lint-core, lint-features,
+      # test-workspace) use, so it is the toolchain worth warming. Stable lanes
+      # still benefit from the cargo registry half of the cache.
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+
+      - name: Install system build deps
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
+          sudo apt-get update
+          sudo apt-get install -y attr cryptsetup-bin libcap-ng-dev lld
+
+      - uses: ./.github/actions/install-zigbuild
+
+      - uses: ./.github/actions/rust-cache
+        with:
+          save: "true"
+
+      # `clippy --all-targets` compiles every crate, every test target, and
+      # every dependency — the same artifacts the lint and test lanes each
+      # rebuild from cold. Running clippy rather than build also warms the
+      # clippy-specific artifacts that lint-core and lint-features need.
+      #
+      # Failures here are not a merge gate: this runs after the merge that
+      # already passed CI, and its only job is to leave a cache behind. A
+      # genuine breakage is caught by the lanes that gate.
+      - name: Build the workspace to populate the cache
+        run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
 
       - uses: ./.github/actions/install-zigbuild
 
+      - uses: ./.github/actions/rust-cache
+
       - name: Check formatting
         run: cargo fmt -- --check
 
@@ -95,6 +97,8 @@ jobs:
           node-version: "22"
 
       - uses: ./.github/actions/install-zigbuild
+
+      - uses: ./.github/actions/rust-cache
 
       - name: ADR coverage (informational)
         continue-on-error: true
@@ -284,6 +288,8 @@ jobs:
 
       - uses: ./.github/actions/install-zigbuild
 
+      - uses: ./.github/actions/rust-cache
+
       - name: Clippy (mvm-client tracing-bridge)
         run: cargo clippy -p mvm-client --all-targets --features tracing-bridge -- -D warnings
 
@@ -377,6 +383,8 @@ jobs:
 
       - uses: ./.github/actions/install-zigbuild
 
+      - uses: ./.github/actions/rust-cache
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -438,6 +446,8 @@ jobs:
 
       - uses: ./.github/actions/install-zigbuild
 
+      - uses: ./.github/actions/rust-cache
+
       - name: Install pinned no_std toolchain and targets
         run: |
           rustup toolchain install 1.96.0 --profile minimal \
@@ -472,6 +482,13 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update
           sudo apt-get install -y libcap-ng-dev lld
+
+      # This lane compiles a different crate set from the shared workspace key
+      # and builds bpf-linker from source, so it gets its own entry rather than
+      # diluting the one every other lane restores.
+      - uses: ./.github/actions/rust-cache
+        with:
+          key: ebpf
 
       - name: Install bpf-linker
         run: cargo +nightly install --locked bpf-linker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,14 +512,63 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # The scope decision below needs both ends of the range.
+          fetch-depth: 0
+
+      # This lane costs ~30 minutes and, being merge_group-only, spends all of
+      # it on the queue's critical path where nobody sees it during review.
+      # Three merges in four change nothing it evaluates, so those three spent
+      # half an hour re-deriving an unchanged answer while the queue waited.
+      #
+      # Gating the steps rather than the job keeps the required check reporting
+      # on every entry — a check that can be absent cannot stay required.
+      - name: Decide whether anything Nix evaluates changed
+        id: scope
+        env:
+          # `merge_group` carries its own base/head, and neither is a ref the
+          # runner has checked out, so both come from the event payload.
+          EVENT: ${{ github.event_name }}
+          MG_BASE: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD: ${{ github.event.merge_group.head_sha }}
+        run: |
+          set -euo pipefail
+          # An explicit dispatch is an explicit ask, not a diff.
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "manual dispatch — evaluating"
+            exit 0
+          fi
+
+          # Fail closed: an unresolvable range evaluates rather than assumes
+          # the change was irrelevant.
+          if ! CHANGED=$(git diff --name-only "$MG_BASE" "$MG_HEAD" 2>/dev/null); then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "could not diff $MG_BASE..$MG_HEAD — evaluating to stay safe"
+            exit 0
+          fi
+
+          # Everything the flakes read. Deliberately wider than `nix/`: the
+          # runtime overlay builds guest binaries out of the Rust workspace, so
+          # a crate or lockfile change can move what these checks produce.
+          if printf '%s\n' "$CHANGED" | grep -qE '^(nix/|flake\.(nix|lock)$|Cargo\.(toml|lock)$|rust-toolchain\.toml$|crates/|src/|\.github/workflows/ci\.yml$)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "Nix inputs changed — evaluating"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing Nix evaluates changed — skipping the eval"
+          fi
 
       - name: Install Nix
+        if: steps.scope.outputs.relevant == 'true'
         uses: DeterminateSystems/nix-installer-action@main
 
       - name: Install Rust toolchain
+        if: steps.scope.outputs.relevant == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Eval-check every flake
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           set -euo pipefail
           find nix -name flake.nix -type f -print0 | sort -z | while IFS= read -r -d '' flake; do
@@ -532,6 +581,7 @@ jobs:
       # here; the aarch64-linux variant stays defined for parity and for a
       # future arm64 runner.
       - name: Baked guest rootfs closure stays lean and glibc-free
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           set -euo pipefail
           nix build --print-build-logs \
@@ -539,6 +589,7 @@ jobs:
             ./nix#checks.x86_64-linux.guest-rootfs-package-budget
 
       - name: Runtime overlay uses static-musl guest binaries
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           set -euo pipefail
           nix build --print-build-logs \
@@ -560,6 +611,7 @@ jobs:
       # change that deleted the SDK cdylib outright would satisfy every
       # no-glibc assertion and read as a footprint win.
       - name: Runtime overlay is glibc-free and the SDK closure moved to the sidecar
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           set -euo pipefail
           overlay=./nix/images/runtime-overlay
@@ -594,6 +646,7 @@ jobs:
 
 
       - name: Nix-built guest artifacts fit the 50 MB footprint
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           set -euo pipefail
           nix build --print-build-logs --impure --no-link --print-out-paths \


### PR DESCRIPTION
## Why

The queue merges one PR per **~93 minutes** — which matches the 30-day count (468 merges ≈ one per 92 min). It isn't backed up by an incident; it's running at its ceiling. The ceiling is ~180 runner-minutes per merge against **3 concurrent runners**.

Almost none of that is testing. The 10,592-test suite executes in **under 2 minutes**. The long poles are all compilation:

```
32m  Lint feature coverage        22m  Test Linux and conformance
30m  Nix flake check              14m  Lint core (fmt + clippy)
29m  Test workspace               10m  Lint policy
```

`ci.yml` had **no build cache and 22 cargo invocations** — `ring`, `rustls`, `tokio`, `curve25519` and fourteen workspace crates compiled from scratch, in five separate jobs, every cycle.

## What changed

Every cargo lane now restores a shared cache via a small composite action.

The subtlety worth stating, because it dictates the design: **GitHub scopes a cache entry to the ref that wrote it, and only entries written on the default branch are readable from other refs.** CI runs on `pull_request` and `merge_group`, never on a push to `main` — so nothing was in a position to write an entry the queue could read, and merge-group refs are ephemeral (one run each, then gone).

Hence `cache-warm.yml` on `main` as the **single writer**, with every CI lane restore-only. Letting the lanes write instead wouldn't help them — they already restore main's — and would actively hurt: the repo cache is capped at 10 GB with LRU eviction, so a busy day of PR writes would evict the entry everything else depends on.

The eBPF lane keys separately (`key: ebpf`): different crate set, plus it builds `bpf-linker` from source, so sharing the workspace entry would dilute it. `cache-bin` stays on so that install isn't repeated.

Cost is one build per merge; it replaces five cold compiles per validation cycle.

## Expected effect

Dependency compilation is the bulk of each lane. I'd expect the five cargo lanes to drop substantially once a warm entry exists on `main` — but the honest version is that the first merge after this lands writes the first entry, and the cycle after that is the first real measurement. Worth checking the numbers then rather than trusting my estimate.

## Deliberately not in this PR

- **`Nix flake check` (30m) runs no cargo at all**, so a Rust cache does nothing for it. It matters more than its size suggests: it is `merge_group`-only, so it sits squarely on the queue's critical path and never shows up on a PR. The lever there is a Nix store cache, which needs a decision (Determinate's magic-nix-cache was retired; Cachix needs an account and token) — so it's flagged, not guessed at.
- **Merge-queue batching.** `min_entries_to_merge: 1` and `max_entries_to_build: 4` means four speculative batches are validated on a three-runner pool to merge one PR, and three of those results are discarded whenever the head advances. That's repo config rather than code and is a separate call — plan 307 carries the exact edit.
- **Dependency reduction.** Real, and it compounds with caching, but it's weeks of work for maybe 20–30% against an afternoon for this. Worth starting from `cargo build --timings` so the cuts land on what actually dominates.

## Verification

`check-workflow-paths` clean across 21 workflow files; full `xtask` suite green (439/439); all three YAML files parse.

I can't exercise a GitHub cache locally, so the restore path is unproven until this runs — I'd watch the first post-merge `Warm` run and the cycle after it. One self-correction already caught in review: my first draft passed `cache-workspace-crates`, which isn't a real `rust-cache` input (the real one is `cache-all-crates`, and workspace crates are excluded by default regardless).