### PR TITLE
fix(test): wait for the old signer helper to release the chain lock

### DIFF
--- a/crates/mvm-hostd/src/broker/daemon.rs
+++ b/crates/mvm-hostd/src/broker/daemon.rs
@@ -699,6 +699,30 @@ mod tests {
         }
     }
 
+    /// Rebind registrations, retrying while the previous helper still holds the
+    /// chain's sole-writer `flock`. Bounded: a lock that never frees is a real
+    /// failure and must still surface as one rather than hanging the suite.
+    async fn rebind_once_the_old_writer_releases(d: &HostAgentDaemon) -> usize {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            match d.rebind_signer_helper_registrations() {
+                Ok(n) => return n,
+                Err(e) => {
+                    let err = format!("{e:#}");
+                    // Only the sole-writer contention is worth waiting out.
+                    // Anything else is a real failure and surfaces now rather
+                    // than after a ten-second retry that hides it.
+                    if !err.contains("already held by another writer")
+                        || std::time::Instant::now() >= deadline
+                    {
+                        panic!("rebind after helper restart failed: {err}");
+                    }
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+            }
+        }
+    }
+
     async fn start_helper(
         helper_sock: PathBuf,
         tenant_id: &str,
@@ -1069,7 +1093,16 @@ mod tests {
         let _ = std::fs::remove_file(&helper_sock);
         let restarted = start_helper(helper_sock.clone(), "local", key_path).await;
 
-        assert_eq!(d.rebind_signer_helper_registrations().unwrap(), 1);
+        // `abort()` cancels the old helper's task but does not synchronously
+        // close the chain file it held, and the sole-writer guard is an
+        // `flock` released only when that descriptor drops. So the restarted
+        // helper can briefly lose the race and be refused with "chain already
+        // held by another writer". A real deployment does not have this
+        // problem — the helper is its own process and the kernel drops the
+        // lock on exit — so wait for the release rather than assert the very
+        // first attempt wins.
+        let rebound = rebind_once_the_old_writer_releases(&d).await;
+        assert_eq!(rebound, 1);
         let after = emit_audit(&sock, "after-restart").await;
         assert!(matches!(after, ServiceResponse::Ok { .. }));
 


### PR DESCRIPTION
Unblocks the merge queue. `broker::daemon::tests::helper_restart_rebinds_live_registration_and_preserves_chain` has been failing merge-group CI across several unrelated PRs — #2250 twice and #2242 at least once — always at `daemon.rs:1072`, so nothing could merge.

## The cause

Not a generic flake. The actual error, from the CI log:

```
signer-helper register refused: mvm-audit-signer chain already held by another writer:
/tmp/.tmpdy26oX/local.vm-a.workload.jsonl
```

The test aborts the running signer helper and immediately starts a replacement for the same workload chain. The sole-writer guard — `lock_sole_writer`, an `flock(LOCK_EX|LOCK_NB)` — is released only when the chain's `File` descriptor drops, and `helper_task.abort()` cancels the task **without synchronously closing that descriptor**. On a loaded runner the replacement loses the race and is refused.

That guard is recent (chain-head reads were serialized so concurrent writers cannot fork a chain), which is why this started affecting several PRs at once rather than being long-standing.

## Why the fix is in the test

This is test-only. A real deployment runs the signer helper as its own process, and the kernel releases the `flock` when it exits — a restarted helper always gets the chain. The same-process abort-then-restart pattern is what makes the release non-deterministic, and only the test does that.

So the test waits for the release rather than asserting the first attempt wins. Bounded at ten seconds, and **any error other than sole-writer contention panics immediately** — a real regression still fails fast instead of hiding behind a retry.

## What I got wrong first

Worth recording, since it cost time: I initially attributed this to the load-sensitive test family in #2264 and then, when it recurred, to a socket-readiness race in `start_helper` (which relies on a single `yield_now()` for the spawned task to reach `accept()`). Both were wrong. The `.with_context` message was in the CI log the whole time and identified it exactly. `start_helper`'s `yield_now()` is still a fragile construct, but it is not what fails here and this PR leaves it alone.

## Verification

- `cargo nextest run -p mvm-hostd` — 1,809 passed
- `cargo nextest run --workspace` — 10,587 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean

Related: #2264 tracks the broader family of load-sensitive tests; this is one member with a specific, identified cause rather than a timeout.