### PR TITLE
fix(test): size lease-TTL tests from a measured stall, not a 20ms guess

### DIFF
--- a/crates/mvm-cli/src/metrics_server.rs
+++ b/crates/mvm-cli/src/metrics_server.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::os::unix::fs::OpenOptionsExt;
 use std::sync::{
     Arc,
@@ -22,13 +22,23 @@ const MAX_SCRAPE_FILE_BYTES: usize = 1024 * 1024;
 pub struct MetricsServer {
     shutdown: Arc<AtomicBool>,
     handle: Option<std::thread::JoinHandle<()>>,
+    local_addr: SocketAddr,
 }
 
 impl MetricsServer {
     /// Bind to `127.0.0.1:<port>` and start serving in a background thread.
+    ///
+    /// Port 0 binds an ephemeral port; read the actual one back with
+    /// [`MetricsServer::local_addr`].
     pub fn start(port: u16) -> Result<Self> {
         let listener = TcpListener::bind(format!("127.0.0.1:{}", port))
             .with_context(|| format!("Failed to bind metrics server on port {}", port))?;
+        // Read the bound address before the listener moves into the thread. With
+        // port 0 the requested port is not the served one, so this is the only
+        // truthful thing to report or connect to.
+        let local_addr = listener
+            .local_addr()
+            .context("Failed to read metrics listener address")?;
         // Non-blocking accept so the shutdown flag is checked promptly.
         listener
             .set_nonblocking(true)
@@ -41,12 +51,19 @@ impl MetricsServer {
             serve_loop(listener, shutdown_clone);
         });
 
-        tracing::info!("Metrics available at http://127.0.0.1:{}/metrics", port);
+        tracing::info!("Metrics available at http://{}/metrics", local_addr);
 
         Ok(Self {
             shutdown,
             handle: Some(handle),
+            local_addr,
         })
+    }
+
+    /// The address actually bound, which differs from the requested port
+    /// whenever port 0 was requested.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
     }
 
     /// Signal the background thread to stop and wait for it to exit.
@@ -168,14 +185,11 @@ mod tests {
 
     #[test]
     fn test_metrics_server_binds() {
-        // Pick a port unlikely to be in use; retry once with a different port if needed.
-        let server = match MetricsServer::start(19091).or_else(|_| MetricsServer::start(19092)) {
-            Ok(server) => server,
-            Err(err) => {
-                eprintln!("skipping metrics server bind test: {err}");
-                return;
-            }
-        };
+        // Port 0: the kernel hands out a free ephemeral port, so this cannot
+        // collide with a sibling test, a previous run's leftover, or anything
+        // else on the host. A fixed port could, and the old "try 19091 then
+        // 19092, else skip" fallback turned that collision into a silent pass.
+        let server = MetricsServer::start(0).expect("binding 127.0.0.1:0 cannot fail for reuse");
         server.stop();
     }
 
@@ -184,23 +198,21 @@ mod tests {
         use std::io::{BufRead, BufReader, Write};
         use std::net::TcpStream;
 
-        let server = match MetricsServer::start(19093).or_else(|_| MetricsServer::start(19094)) {
-            Ok(server) => server,
-            Err(err) => {
-                eprintln!("skipping metrics server bind test: {err}");
-                return;
-            }
-        };
+        let server = MetricsServer::start(0).expect("binding 127.0.0.1:0 cannot fail for reuse");
 
-        // Give the background thread a moment to start.
-        std::thread::sleep(std::time::Duration::from_millis(50));
-
-        // Determine which port actually bound by inspecting the local addr.
-        // Since we can't easily query the bound port from MetricsServer,
-        // try both candidate ports.
-        let stream = TcpStream::connect("127.0.0.1:19093")
-            .or_else(|_| TcpStream::connect("127.0.0.1:19094"))
-            .expect("should connect to metrics server");
+        // No sleep: `start` returns only after `bind` (and the implicit
+        // `listen`) have completed, so the kernel completes the handshake into
+        // the accept backlog whether or not the serve thread has reached
+        // `accept` yet. The old 50ms sleep was guessing at a race that does not
+        // exist, and under load it was the guess that failed, not the server.
+        //
+        // Connecting to the address the server actually bound also removes a
+        // wrong-target bug: the old code bound 19093-or-19094 and then
+        // connected to 19093-or-19094 independently, so a foreign process
+        // holding 19093 would be scraped instead, failing on a response this
+        // server never sent.
+        let stream = TcpStream::connect(server.local_addr())
+            .expect("should connect to the port the server reported");
 
         let mut stream_clone = stream.try_clone().unwrap();
         stream_clone

--- a/crates/mvm-hostd/src/stream/input_gate.rs
+++ b/crates/mvm-hostd/src/stream/input_gate.rs
@@ -1005,6 +1005,43 @@ mod tests {
     /// Fixed so a test can verify the scratch chain's signatures.
     pub(super) const TEST_CHAIN_SEED: [u8; 32] = [9u8; 32];
 
+    /// A lease that has already lapsed when it is taken, so no test has to
+    /// sleep to watch one expire.
+    ///
+    /// The degenerate TTL, and the one to reach for first: `is_live` is
+    /// `now < expires_at`, so a zero TTL expires the instant it is claimed.
+    /// Deterministic and free. Use it whenever nothing has to be written
+    /// through the lease *before* it lapses — pair it with [`LIVE_LEASE_TTL`]
+    /// re-bound before the successor opens, since `bind` replaces the binding
+    /// and leaves the lease table alone.
+    const ALREADY_LAPSED: Duration = Duration::ZERO;
+
+    /// A lease that must be live for a write and lapse only afterwards, with
+    /// the wait that outlives it.
+    ///
+    /// [`ALREADY_LAPSED`] cannot express this: the write has to be admitted
+    /// first, so the lease has to be live first, so the test has to wait the
+    /// TTL out. That makes the TTL the *window the write has to land in*, and
+    /// it is therefore sized from measurement rather than taste. Sampling
+    /// adjacent-statement stalls on a 16-core host while the `mvm-hostd` suite
+    /// ran under 2x CPU oversubscription measured 27 stalls over 20ms in a
+    /// single pass, the worst 298ms. At the previous 20ms a writer descheduled
+    /// between `open` and its first `write` lost the lease mid-setup and the
+    /// write was refused — the flake, 3-4 times per full-suite run.
+    ///
+    /// One second gives the write roughly 3x the worst stall seen under load
+    /// harsher than CI.
+    const LAPSING_LEASE_TTL: Duration = Duration::from_secs(1);
+
+    /// A wait that outlives [`LAPSING_LEASE_TTL`] with room for the sleep
+    /// itself to be scheduled late.
+    const PAST_THE_LEASE: Duration = Duration::from_millis(1300);
+
+    /// For a lease that must stay live to the end of the test. Nothing waits
+    /// this out, so it is sized to be unreachable by scheduler jitter rather
+    /// than merely unlikely.
+    const LIVE_LEASE_TTL: Duration = Duration::from_secs(30);
+
     /// The scratch chain every test in this module shares, created once per
     /// test process.
     pub(super) fn test_chain_dir() -> &'static Path {
@@ -1393,7 +1430,7 @@ mod tests {
         // test failed exactly that way on a loaded CI runner, at a 20ms TTL
         // with a 40ms sleep.
         let vm = unique_vm("vm-lease-expiry");
-        InputGate::bind(&vm, InputBinding::new().with_lease_ttl(Duration::ZERO));
+        InputGate::bind(&vm, InputBinding::new().with_lease_ttl(ALREADY_LAPSED));
         let plan = admitted_with(vec![stream_service()]);
         let mut stale = InputGate::open(&vm, &plan).expect("first session");
 
@@ -1402,10 +1439,7 @@ mod tests {
         // Re-bind before the second open so the taker gets a live lease.
         // `bind` replaces the binding and leaves the lease table alone (only
         // `unbind` clears it), so the lapsed lease is still there to take over.
-        InputGate::bind(
-            &vm,
-            InputBinding::new().with_lease_ttl(Duration::from_secs(3600)),
-        );
+        InputGate::bind(&vm, InputBinding::new().with_lease_ttl(LIVE_LEASE_TTL));
         let mut fresh = InputGate::open(&vm, &plan).expect("a lapsed lease is takeable");
         assert!(matches!(
             stale.write(InputFrame {
@@ -1429,14 +1463,16 @@ mod tests {
     #[test]
     fn a_write_refreshes_the_lease() {
         let vm = unique_vm("vm-lease-refresh");
-        InputGate::bind(
-            &vm,
-            InputBinding::new().with_lease_ttl(Duration::from_millis(60)),
-        );
+        InputGate::bind(&vm, InputBinding::new().with_lease_ttl(LAPSING_LEASE_TTL));
         let plan = admitted_with(vec![stream_service()]);
         let mut session = InputGate::open(&vm, &plan).expect("first session");
+        // Four gaps of this size outlast the TTL, so reaching the end proves
+        // the writes refreshed it. Each gap still has to leave a write room to
+        // land inside the TTL, so the gap is the TTL less a wide margin for a
+        // late wakeup — see `LAPSING_LEASE_TTL` for where the margin comes from.
+        const BETWEEN_WRITES: Duration = Duration::from_millis(300);
         for seq in 0..4u64 {
-            std::thread::sleep(Duration::from_millis(20));
+            std::thread::sleep(BETWEEN_WRITES);
             session
                 .write(InputFrame {
                     seq,
@@ -1455,10 +1491,7 @@ mod tests {
         // session at compile time, but expiry is a runtime condition, so both
         // of A's byte-extraction paths have to check it too.
         let vm = unique_vm("vm-interleave");
-        InputGate::bind(
-            &vm,
-            InputBinding::new().with_lease_ttl(Duration::from_millis(20)),
-        );
+        InputGate::bind(&vm, InputBinding::new().with_lease_ttl(LAPSING_LEASE_TTL));
         let plan = admitted_with(vec![stream_service()]);
         let mut stalled = InputGate::open(&vm, &plan).expect("first session");
         stalled
@@ -1468,7 +1501,10 @@ mod tests {
             })
             .expect("cleared while the lease was live");
 
-        std::thread::sleep(Duration::from_millis(40));
+        std::thread::sleep(PAST_THE_LEASE);
+        // A's lease is the one under test; B's only has to still be there at
+        // the end, so it is not left racing the clock too.
+        InputGate::bind(&vm, InputBinding::new().with_lease_ttl(LIVE_LEASE_TTL));
         let mut successor = InputGate::open(&vm, &plan).expect("a lapsed lease is takeable");
         successor
             .write(InputFrame {
@@ -1692,6 +1728,69 @@ mod tests {
         );
     }
 
+    /// A test lease must be sized by a named constant, never by a magnitude
+    /// picked in place.
+    ///
+    /// The magnitudes are how this went wrong: a lease TTL is not only how long
+    /// the lease survives, it is the window every write before the lapse has to
+    /// land in. Written as `from_millis(20)` that reads like "a short lease",
+    /// not like "this test fails if the host stalls for 20ms" — and on a loaded
+    /// host stalls over 20ms happened 27 times in one suite pass. Seven tests
+    /// across four files flaked on it.
+    ///
+    /// `Duration::ZERO` is deliberately allowed: it is not a guess about how
+    /// fast the host is, it is the exact statement "already lapsed", and it is
+    /// the technique that removes the wait entirely. `from_millis` /
+    /// `from_secs` are the ones that encode an assumption about scheduling,
+    /// and those must come from a constant whose docs carry the measurement.
+    /// This checks the test halves only: production has its own default, and
+    /// the setter's own signature names `Duration`.
+    #[test]
+    fn a_test_lease_is_sized_by_a_named_constant_not_a_literal() {
+        // Every file that binds a lease from a test, including the integration
+        // tests, which are where three of the seven flakes lived.
+        let sources: [(&str, &str); 4] = [
+            ("input_gate.rs", include_str!("input_gate.rs")),
+            ("input_route.rs", include_str!("input_route.rs")),
+            (
+                "tests/workload_input_plane.rs",
+                include_str!("../../tests/workload_input_plane.rs"),
+            ),
+            (
+                "tests/stream_edge_connector.rs",
+                include_str!("../../tests/stream_edge_connector.rs"),
+            ),
+        ];
+
+        let mut literals = Vec::new();
+        for (name, src) in sources {
+            // A `src/` module keeps its tests at the end; an integration test
+            // file is tests all the way down.
+            let tests = src
+                .split_once("#[cfg(test)]\nmod tests {")
+                .map_or(src, |(_production, tests)| tests);
+            for (offset, _) in tests.match_indices(".with_lease_ttl(") {
+                let argument = tests[offset + ".with_lease_ttl(".len()..].trim_start();
+                let constructed = argument
+                    .strip_prefix("std::time::")
+                    .unwrap_or(argument)
+                    .starts_with("Duration::from_");
+                if constructed {
+                    let line = tests[..offset].lines().count() + 1;
+                    literals.push(format!(
+                        "{name}: a lease sized in place (test-half line ~{line})"
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            literals.is_empty(),
+            "size these from LAPSING_LEASE_TTL / LIVE_LEASE_TTL, whose docs carry \
+             the measured stall the value has to clear: {literals:#?}"
+        );
+    }
+
     #[test]
     fn a_fingerprint_refusal_does_not_claim_the_bytes_are_the_secret() {
         // A fingerprint match is a length-and-hash match; a collision produces
@@ -1907,7 +2006,7 @@ mod tests {
             InputBinding::new()
                 .with_fingerprint(fingerprint(LONG_SECRET))
                 .with_idle_flush_after(Duration::ZERO)
-                .with_lease_ttl(Duration::from_millis(20)),
+                .with_lease_ttl(LAPSING_LEASE_TTL),
         );
         let plan = admitted_with(vec![stream_service()]);
         let mut stalled = InputGate::open(&vm, &plan).expect("the plan grants input");
@@ -1917,7 +2016,7 @@ mod tests {
                 payload: b"hello\n".to_vec(),
             })
             .expect("cleared while the lease was live");
-        std::thread::sleep(Duration::from_millis(40));
+        std::thread::sleep(PAST_THE_LEASE);
 
         assert!(matches!(stalled.refresh(), Err(InputRefusal::LeaseExpired)));
         assert!(matches!(

--- a/crates/mvm-hostd/src/stream/input_route.rs
+++ b/crates/mvm-hostd/src/stream/input_route.rs
@@ -500,6 +500,20 @@ mod tests {
 
     use crate::stream::input_gate::InputBinding;
 
+    /// A lease already lapsed when it is taken, so nothing sleeps to watch one
+    /// expire. Reach for this first; it only fails to fit when something has to
+    /// be written through the lease before it lapses.
+    const ALREADY_LAPSED: std::time::Duration = std::time::Duration::ZERO;
+    /// For that case: the lease has to be live for the write, so the TTL is
+    /// also the window the write has to land in. On a loaded host the gap
+    /// between two adjacent statements measured up to 298ms, so the previous
+    /// 20ms expired mid-setup and refused a write the test required to succeed.
+    /// See `input_gate::tests::LAPSING_LEASE_TTL` for the measurement.
+    const LAPSING_LEASE_TTL: std::time::Duration = std::time::Duration::from_secs(1);
+    const PAST_THE_LEASE: std::time::Duration = std::time::Duration::from_millis(1300);
+    /// For a lease nothing waits out, so jitter cannot reach it.
+    const LIVE_LEASE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+
     /// The fingerprint of `secret`, as the substitution endpoint computes it.
     fn fingerprint(secret: &str) -> SecretFingerprint {
         SecretFingerprint::of(secret.as_bytes(), SecretCategory::HostSecret)
@@ -839,10 +853,9 @@ mod tests {
     #[test]
     fn a_route_that_lost_its_lease_delivers_nothing_further() {
         let vm = unique_vm("route-lease");
-        InputGate::bind(
-            &vm,
-            InputBinding::new().with_lease_ttl(std::time::Duration::from_millis(20)),
-        );
+        // Nothing is written before the lapse here, so the lease can simply
+        // start lapsed rather than be waited out.
+        InputGate::bind(&vm, InputBinding::new().with_lease_ttl(ALREADY_LAPSED));
         let carried = Recorder::default();
         let mut stalled = InputRoute::open(
             &vm,
@@ -851,7 +864,6 @@ mod tests {
             WireSequence::default(),
         )
         .expect("the plan grants input");
-        std::thread::sleep(std::time::Duration::from_millis(40));
 
         assert!(matches!(
             stalled.write(frame(0, b"too late")),
@@ -987,10 +999,7 @@ mod tests {
         // successor that restarted numbering would be refused for its
         // predecessor's sequence and the stdin would be wedged for good.
         let vm = unique_vm("route-resume");
-        InputGate::bind(
-            &vm,
-            InputBinding::new().with_lease_ttl(std::time::Duration::from_millis(20)),
-        );
+        InputGate::bind(&vm, InputBinding::new().with_lease_ttl(LAPSING_LEASE_TTL));
         let wire_seq = WireSequence::default();
         let carried = Recorder::default();
         let mut first = InputRoute::open(
@@ -1004,9 +1013,12 @@ mod tests {
             .write(frame(0, b"first"))
             .expect("the gate cleared it");
         first.write(frame(1, b"more")).expect("and this one");
-        std::thread::sleep(std::time::Duration::from_millis(40));
+        std::thread::sleep(PAST_THE_LEASE);
         let _ = first.displace();
 
+        // Only the predecessor's lease is meant to lapse; the successor has to
+        // survive the deliveries this test then checks.
+        InputGate::bind(&vm, InputBinding::new().with_lease_ttl(LIVE_LEASE_TTL));
         let mut second = InputRoute::open(
             &vm,
             &admitted(vec![stream_service()]),

--- a/crates/mvm-hostd/tests/stream_edge_connector.rs
+++ b/crates/mvm-hostd/tests/stream_edge_connector.rs
@@ -159,6 +159,18 @@ fn a_producers_output_reaches_a_consumers_stdin_in_order() {
     );
 }
 
+/// A lease these tests mean to step across or outwait, the gap between steps,
+/// and a wait that outlives the lease.
+///
+/// The TTL doubles as the window each step has to land in, so it is sized from
+/// measurement rather than taste: on a loaded host the gap between two adjacent
+/// statements measured up to 298ms, so the previous 60ms lease lapsed between
+/// two steps and handed the lease to the competitor the test expects to be
+/// refused. See `input_gate::tests::LAPSING_LEASE_TTL` for the measurement.
+const LAPSING_LEASE_TTL: Duration = Duration::from_secs(1);
+const BETWEEN_STEPS: Duration = Duration::from_millis(300);
+const PAST_THE_LEASE: Duration = Duration::from_millis(1300);
+
 /// An edge whose producer is quiet must not lose the single-writer lease.
 ///
 /// Observed the only way it can be: by a competing writer. A test that merely
@@ -177,7 +189,7 @@ fn stepping_across_the_ttl_keeps_the_lease_from_a_competitor() {
     InputGate::bind(
         &consumer,
         InputBinding::new()
-            .with_lease_ttl(Duration::from_millis(60))
+            .with_lease_ttl(LAPSING_LEASE_TTL)
             .with_audit(InputAudit::new(
                 AuditEmitter::with_dir(key, chain_dir.path()).expect("chain"),
             )),
@@ -189,10 +201,12 @@ fn stepping_across_the_ttl_keeps_the_lease_from_a_competitor() {
     let mut edge =
         EdgeConnector::new(&StreamEdge::new("quiet"), session, reader).expect("servable");
 
-    // Step across more than one whole TTL, with nothing to send.
+    // Step across more than one whole TTL, with nothing to send. Six gaps of
+    // this size outlast the TTL, while each one still leaves the next step room
+    // to land inside it.
     for _ in 0..6 {
         assert_eq!(edge.step().expect("idle step"), EdgeStep::Idle);
-        std::thread::sleep(Duration::from_millis(20));
+        std::thread::sleep(BETWEEN_STEPS);
     }
 
     assert!(
@@ -217,7 +231,7 @@ fn an_unstepped_edge_lets_the_lease_lapse() {
     InputGate::bind(
         &consumer,
         InputBinding::new()
-            .with_lease_ttl(Duration::from_millis(40))
+            .with_lease_ttl(LAPSING_LEASE_TTL)
             .with_audit(InputAudit::new(
                 AuditEmitter::with_dir(key, chain_dir.path()).expect("chain"),
             )),
@@ -229,7 +243,7 @@ fn an_unstepped_edge_lets_the_lease_lapse() {
     let _edge =
         EdgeConnector::new(&StreamEdge::new("abandoned"), session, reader).expect("servable");
 
-    std::thread::sleep(Duration::from_millis(140));
+    std::thread::sleep(PAST_THE_LEASE);
     assert!(
         InputGate::open(&consumer, &plan).is_ok(),
         "an abandoned lease must lapse, or the two tests above prove nothing"

--- a/crates/mvm-hostd/tests/workload_input_plane.rs
+++ b/crates/mvm-hostd/tests/workload_input_plane.rs
@@ -182,6 +182,29 @@ fn unique_vm(prefix: &str) -> String {
     format!("{prefix}-{}", NEXT.fetch_add(1, Ordering::Relaxed))
 }
 
+/// A lease a test means to watch lapse, and a wait that outlives it.
+///
+/// The TTL doubles as the window every write before the lapse has to land in,
+/// so it cannot be shortened to taste. On a loaded host the gap between two
+/// adjacent statements measured up to 298ms, which is why the previous 20ms
+/// lease expired mid-setup and refused a write the test required to succeed.
+/// See `input_gate::tests::LAPSING_LEASE_TTL` for the measurement.
+const LAPSING_LEASE_TTL: std::time::Duration = std::time::Duration::from_secs(1);
+const PAST_THE_LEASE: std::time::Duration = std::time::Duration::from_millis(1300);
+/// For a lease nothing waits out, so jitter cannot reach it.
+const LIVE_LEASE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// The input binding the fixtures share: a real chain, so the gate's
+/// record-the-decision path is exercised rather than stubbed.
+fn audit_binding(
+    chain_key: &ed25519_dalek::SigningKey,
+    chain_dir: &std::path::Path,
+) -> InputBinding {
+    InputBinding::new().with_audit(InputAudit::new(
+        AuditEmitter::with_dir(chain_key.clone(), chain_dir).expect("open the chain"),
+    ))
+}
+
 fn synthesis_input(vm_name: &str) -> SynthesisInput<'_> {
     const FIXTURE_SHA: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     SynthesisInput {
@@ -268,15 +291,25 @@ impl Fixture {
         Self::bound(prefix, None, Some(lease_ttl))
     }
 
+    /// Re-bind this VM's lease TTL, keeping the chain it was bound with.
+    ///
+    /// For a test where one lease is meant to lapse and the next is not: the
+    /// successor's TTL is not what the test is timing, so it should not be
+    /// racing the clock alongside the one that is.
+    fn rebind_lease(&self, lease_ttl: std::time::Duration) {
+        InputGate::bind(
+            &self.vm,
+            audit_binding(&self.chain_key, self.chain_dir.path()).with_lease_ttl(lease_ttl),
+        );
+    }
+
     fn bound(prefix: &str, secret: Option<&[u8]>, lease_ttl: Option<std::time::Duration>) -> Self {
         let (env, home) = isolated_home();
         let vm = unique_vm(prefix);
         let chain_dir = tempfile::tempdir().expect("chain dir");
         let chain_key = ed25519_dalek::SigningKey::from_bytes(&[11u8; 32]);
 
-        let mut binding = InputBinding::new().with_audit(InputAudit::new(
-            AuditEmitter::with_dir(chain_key.clone(), chain_dir.path()).expect("open the chain"),
-        ));
+        let mut binding = audit_binding(&chain_key, chain_dir.path());
         if let Some(ttl) = lease_ttl {
             binding = binding.with_lease_ttl(ttl);
         }
@@ -541,7 +574,7 @@ fn a_writer_that_let_its_lease_lapse_does_not_wedge_the_stream_for_its_successor
     // that started numbering afresh would be refused for its predecessor's
     // sequence and the workload's stdin would be wedged for good.
     let _guard = desk_test();
-    let fx = Fixture::with_lease_ttl("input-displaced", std::time::Duration::from_millis(20));
+    let fx = Fixture::with_lease_ttl("input-displaced", LAPSING_LEASE_TTL);
     let mut child = cat();
     fx.plane
         .open_input(&fx.vm, &fx.admit(true), Box::new(ToDesk::over(&mut child)))
@@ -551,12 +584,15 @@ fn a_writer_that_let_its_lease_lapse_does_not_wedge_the_stream_for_its_successor
         .expect("the gate cleared it");
 
     // The first writer goes quiet for longer than its lease.
-    std::thread::sleep(std::time::Duration::from_millis(60));
+    std::thread::sleep(PAST_THE_LEASE);
     assert_eq!(
         InputGate::lease_holder(&fx.vm),
         None,
         "the lease is there to be taken"
     );
+    // Only the first writer's lease is meant to lapse. The successor has to
+    // survive its write and its close, neither of which this test is timing.
+    fx.rebind_lease(LIVE_LEASE_TTL);
 
     // The successor points at the same guest — the desk is already open over
     // this workload — and starts its own numbering at zero.
@@ -585,7 +621,7 @@ fn an_idle_writer_can_keep_its_stream_alive_without_sending_anything() {
     // that is thinking. Without a way to hold it, a writer that paused past
     // the TTL would find its close refused too — and a refused close drops the
     // tail the gate withheld, which is the writer's last bytes.
-    let fx = Fixture::with_lease_ttl("input-refresh", std::time::Duration::from_millis(40));
+    let fx = Fixture::with_lease_ttl("input-refresh", LAPSING_LEASE_TTL);
     let mut child = cat();
     fx.plane
         .open_input(
@@ -598,8 +634,12 @@ fn an_idle_writer_can_keep_its_stream_alive_without_sending_anything() {
         .write_input(&fx.vm, frame(0, b"thinking"))
         .expect("the gate cleared it");
 
+    // Five pauses of this length outlast the TTL, so reaching the close proves
+    // the refreshes held the lease. Each pause still has to leave the refresh
+    // room to land inside the TTL, hence a pause well under it.
+    const THINKING_FOR: std::time::Duration = std::time::Duration::from_millis(300);
     for _ in 0..5 {
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::thread::sleep(THINKING_FOR);
         fx.plane
             .refresh_input(&fx.vm)
             .expect("an idle holder keeps its lease");


### PR DESCRIPTION
Closes part of #2264.

## What was actually wrong

#2264 lists seven tests. Four of them — the three `host_agent_restart` ones and the broker one — **were already fixed**: `.config/nextest.toml` documents the hang guards and liveness short-circuit, and #2263 landed the broker fix. Meanwhile the tests failing under load were **five the issue never names**, in `input_gate`, `input_route` and `stream_edge_connector`.

I found them by reproducing rather than by trusting the list: the full `mvm-hostd` suite under CPU saturation failed 3-4 tests per run, all in that family.

## The cause, measured

`.config/nextest.toml` refuses thresholds "set by feel rather than by measurement", so I measured instead of picking a number. Sampling adjacent-statement stalls while the suite ran under 2x oversubscription on a 16-core host:

> **max stall 297.7ms; 27 stalls over 20ms in a single pass**

Every failing test bound a **20ms** lease TTL — inside the host's scheduling noise.

The insight the old code missed is that a lease TTL is not only how long the lease survives; it is **the window every write before the lapse has to land in**. A writer descheduled between `open()` and its first `write()` loses the lease mid-setup, and the write it required to succeed is refused. That is the entire bug, and it is why simply sleeping longer never fixed it.

## The fix

While this was in progress, **#2265 landed a fix for one of these tests using a better technique than my first draft**: `with_lease_ttl(Duration::ZERO)`. Since `is_live` is `now < expires_at`, a zero TTL has lapsed the instant it is claimed — deterministic, and no sleep at all. This PR adopts that and generalizes it, so the rule is now explicit about which tool fits:

- **`ALREADY_LAPSED` (`Duration::ZERO`) — reach for this first.** Free and deterministic. Applies wherever nothing has to be written *through* the lease before it lapses.
- **`LAPSING_LEASE_TTL` — only where a write must be admitted first.** `ZERO` cannot express that case: the write needs a live lease, so the test must wait the TTL out, which makes the TTL the window the write has to land in. That is the one that needs the measurement.
- **`LIVE_LEASE_TTL`** for a lease that only has to stay live; nothing waits it out, so it is sized to be unreachable rather than merely unlikely.

Where only one of two successive leases should lapse, the successor is re-bound rather than left racing the same clock.

Two judgement calls worth flagging for review:

- `input_route`'s lapse test moved to `ALREADY_LAPSED`, dropping its sleep entirely.
- `stream_edge_connector::an_unstepped_edge_lets_the_lease_lapse` deliberately **keeps** the measured TTL. It is the explicit converse of `stepping_across_the_ttl_keeps_the_lease_from_a_competitor` ("so the test above is known to be observing something"), and a zero TTL would make it trivially true — no lease could survive stepping either — destroying the contrast the pair exists to draw.

The values are named constants whose doc comments carry the measurement, and a meta-test fails any test that sizes a lease in place instead. That is the durable half: `from_millis(20)` reads like "a short lease" rather than "this test fails if the host stalls for 20ms".

The guard allows `Duration::ZERO` on purpose — it is not a guess about how fast the host is, it is the exact statement "already lapsed", and it is the technique that removes the wait. Only `from_millis` / `from_secs` encode a scheduling assumption, and those must come from a constant carrying the measurement.

## Verification

Against the failure, not by assertion:

| | before | after |
|---|---|---|
| full `mvm-hostd` suite, loadavg ~33 | 3-4 failed per run | — |
| full `mvm-hostd` suite, loadavg 230-294 | — | **7 consecutive clean runs** |

Every changed test was confirmed to still go red when the property it guards is broken (e.g. stepping slower than the TTL makes the competitor win, and the refresh test fails). The new meta-test was confirmed to go red on a reintroduced literal, naming the file and line.

Workspace: fmt clean (nightly), `clippy --workspace --all-targets -D warnings` clean, `nextest run --workspace` 10,622/10,623.

## Also: the metrics server test

Its defects were **not** timing, which is why the issue's suggested fix would not have helped:

1. It bound `19093`-or-`19094`, then connected to `19093`-or-`19094` **independently** — so a foreign process holding the first port got scraped instead, failing on a response this server never sent. Reproduced: the connect landed on a leftover listener and read `NOT_ME`.
2. A bind collision hit `eprintln!("skipping…"); return` — turning the collision into a **silent pass**.
3. A 50ms startup sleep, deleted rather than enlarged: `start` returns after `bind` and `listen`, so the kernel completes the handshake into the accept backlog whether or not the serve thread has reached `accept`.

It now binds port 0 and connects to the address the server reports — which is also the only truthful thing to log, since the requested port is not the served one under port 0. Verified passing with all four legacy ports held by a foreign listener.

## Not in this PR

- **`crates/mvm-runtime`'s two `builder_runner` members.** These were blocked behind #2232, which has since merged and is in this branch's base — so they are now unblocked, just not yet investigated. They are a separate question from the lease family (their budget is a handshake timeout, not a lease TTL) and worth their own change rather than growing this one.
- **`mvm-agentd entrypoint_stream::tests::evicting_one_event_costs_the_same_on_a_long_queue_as_on_a_short_one`.** Same family, not on #2264's list, and **pre-existing** — this branch makes no `mvm-agentd` change. It is a wall-clock big-O ratio in a debug build (`long <= short * 8 + 50ms`), and it fails under heavy contention: it went red in a workspace run at loadavg ~300. At loadavg ~30 it passes 15 of 15, so it is load-sensitive rather than a high-rate flake, and not an O(n) regression. Added to #2264 rather than fixed here.
- **`MetricsServer` is unreachable in production** — `start()` has zero callers and `up`'s `metrics_port` field is never read. Flagged rather than deleted, since removing a feature is a maintainer call.
