### PR TITLE
fix(dx): make `just clean` remove the dev state root, and classify worktrees

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -524,10 +524,43 @@ setup-libkrun:
 
 # ── Utilities ────────────────────────────────────────────────────────────
 
-# Clean build artifacts and the regenerable mvm cache
-clean:
+# Clean build artifacts, the regenerable mvm cache, and the dev state root
+clean: clean-dev-state
     cargo clean
     cargo run --quiet -- env cleanup --cache --yes
+
+# Remove this worktree's dev state root `.mvm-test` (DRY_RUN=1 to preview)
+clean-dev-state:
+    #!/usr/bin/env bash
+    # `scripts/dev-env.sh` points MVM_HOME, CARGO_TARGET_DIR *and* CARGO_HOME at
+    # `<repo>/.mvm-test`, so every `just dev-*` run accumulates VM images, a full
+    # build tree and a per-worktree cargo registry in one gitignored directory.
+    # It is the largest thing a checkout owns and nothing used to sweep it:
+    # `cargo clean` cleans `./target`, and `mvmctl env cleanup` only ever sees
+    # whatever MVM_HOME points at in the shell that invokes it — which, outside
+    # `just dev-*`, is not this directory. Measured 2026-08-09: 65 GB in one
+    # worktree and 282 GB across a machine's worktrees, none of it reported by
+    # any clean command.
+    #
+    # Safe whenever no dev VM is live out of this worktree; the contents are
+    # rebuilt or re-fetched on demand.
+    set -euo pipefail
+    root="$(git rev-parse --show-toplevel)/.mvm-test"
+    if [ ! -d "$root" ]; then
+        echo "clean-dev-state: nothing at $root"
+        exit 0
+    fi
+    size=$(du -sh "$root" 2>/dev/null | cut -f1)
+    if [ -n "${DRY_RUN:-}" ]; then
+        echo "clean-dev-state: would remove $root ($size)"
+        exit 0
+    fi
+    rm -rf "$root"
+    echo "clean-dev-state: removed $root ($size)"
+
+# Classify worktrees: finished, needs-a-human, or in use (--safe-only for paths)
+worktrees *ARGS:
+    ./scripts/worktree-status.sh {{ ARGS }}
 
 # Reap leaked host-side helper subprocesses (broker/host-agent/signer/etc.)
 # older than N minutes (default 30). Backstop for the in-binary parent-death

--- a/scripts/worktree-status.sh
+++ b/scripts/worktree-status.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Classify this repo's git worktrees by whether they are still needed.
+#
+# Two problems this exists for, both of which cost real time on 2026-08-09:
+#
+#   1. Finished work is invisible. Ninety-five worktrees had accumulated, most
+#      of them behind merged PRs, holding roughly a terabyte of build output and
+#      dev state. Nothing said which were done.
+#   2. In-flight work is invisible. `git worktree list` shows only paths, so a
+#      branch someone else already has open reads the same as a free one — which
+#      is how the same fix gets written twice.
+#
+# Verdicts:
+#   SAFE    the PR merged and this worktree's tip is exactly the merged head,
+#           with a clean tree — nothing here that is not already on main.
+#   REVIEW  commits that never landed, or a closed-unmerged PR. A human call.
+#   KEEP    an open PR, or uncommitted work.
+#
+# Never deletes anything. Pipe `--safe-only` into your own removal step once you
+# have read the list.
+#
+# Usage:
+#   scripts/worktree-status.sh              # full table
+#   scripts/worktree-status.sh --safe-only  # bare paths, for scripting
+set -euo pipefail
+
+safe_only=0
+[ "${1:-}" = "--safe-only" ] && safe_only=1
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+main_ref="origin/main"
+
+git fetch --quiet origin main 2>/dev/null || true
+
+prs=""
+if command -v gh >/dev/null 2>&1; then
+    # One call, then matched locally: a call per worktree is slow and rate-limited.
+    prs=$(gh pr list --state all --limit 400 \
+        --json number,headRefName,state,headRefOid \
+        --jq '.[] | "\(.headRefName)\t\(.number)\t\(.state)\t\(.headRefOid)"' 2>/dev/null || true)
+fi
+
+# Snapshot the process list ONCE, up front. Grepping `ps` per worktree inside
+# the loop looks equivalent and is not: the grep's own argv contains the path it
+# is searching for, so every worktree matches itself and everything looks busy.
+ps_snapshot=$(ps -eo command 2>/dev/null || true)
+
+[ "$safe_only" -eq 1 ] || printf '%-40s %-34s %-14s %s\n' WORKTREE BRANCH PR VERDICT
+
+git worktree list --porcelain | awk '
+    /^worktree /{p=substr($0,10)}
+    /^HEAD /{h=substr($0,6)}
+    /^branch /{b=substr($0,8); sub(/^refs\/heads\//,"",b); print p"\t"h"\t"b; b=""}
+    /^detached/{print p"\t"h"\t-"}
+' | while IFS=$'\t' read -r path head branch; do
+    [ "$path" = "$repo_root" ] && continue
+    [ -d "$path" ] || continue
+
+    dirty=$(git -C "$path" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    ahead=$(git -C "$path" rev-list --count "${main_ref}..${head}" 2>/dev/null || echo 0)
+
+    pr_num=""; pr_state=""; pr_head=""
+    if [ -n "$prs" ] && [ "$branch" != "-" ]; then
+        line=$(printf '%s\n' "$prs" | awk -F'\t' -v b="$branch" '$1==b{print; exit}')
+        if [ -n "$line" ]; then
+            pr_num=$(printf '%s' "$line" | cut -f2)
+            pr_state=$(printf '%s' "$line" | cut -f3)
+            pr_head=$(printf '%s' "$line" | cut -f4)
+        fi
+    fi
+
+    in_use=0
+    case "$ps_snapshot" in *"$path"*) in_use=1 ;; esac
+
+    if [ "$in_use" -eq 1 ]; then
+        # A fresh worktree has no commits of its own yet, which otherwise reads
+        # as "nothing here that isn't on main" — exactly the shape of one
+        # somebody just created and is about to work in.
+        verdict="KEEP (a process is running in it)"
+    elif [ "$dirty" -ne 0 ]; then
+        verdict="KEEP (uncommitted: $dirty)"
+    elif [ "$ahead" -eq 0 ]; then
+        verdict="SAFE (nothing not already on main)"
+    elif [ "$pr_state" = MERGED ] && [ "$pr_head" = "$head" ]; then
+        verdict="SAFE (PR merged, tip matches merged head)"
+    elif [ "$pr_state" = MERGED ]; then
+        verdict="REVIEW (merged, but $ahead commit(s) not on main)"
+    elif [ "$pr_state" = OPEN ]; then
+        verdict="KEEP (open PR)"
+    elif [ "$pr_state" = CLOSED ]; then
+        verdict="REVIEW (closed unmerged; $ahead commit(s))"
+    else
+        verdict="REVIEW (no PR; $ahead commit(s) not on main)"
+    fi
+
+    if [ "$safe_only" -eq 1 ]; then
+        case "$verdict" in SAFE*) printf '%s\n' "$path" ;; esac
+    else
+        pr_label="-"
+        [ -n "$pr_num" ] && pr_label="#${pr_num} ${pr_state}"
+        printf '%-40s %-34s %-14s %s\n' \
+            "$(basename "$path")" "${branch:0:34}" "$pr_label" "$verdict"
+    fi
+done
+
+if [ "$safe_only" -eq 0 ] && [ -z "$prs" ]; then
+    echo
+    echo "note: gh unavailable, so PR state is unknown and nothing can be called SAFE" >&2
+fi


### PR DESCRIPTION
Two directories in this repo grow without bound, and nothing reported either one. Both were found by running out of disk on a dev machine — 99% full, with roughly a terabyte recoverable.

## `.mvm-test` — 282 GB nothing swept

`scripts/dev-env.sh` points **MVM_HOME, CARGO_TARGET_DIR *and* CARGO_HOME** at `<repo>/.mvm-test`. So every `just dev-*` run piles VM images, a full build tree, and a per-worktree cargo registry into one gitignored directory.

Nothing cleaned it:

- `cargo clean` cleans `./target`, which is not that directory.
- `mvmctl env cleanup` only ever sees whatever `MVM_HOME` points at in the shell that invokes it — outside `just dev-*`, not that directory.
- `mvmctl cache prune --dry-run` reported **"Nothing to prune"** while 282 GB sat there. It was right: it inspects `~/.mvm`.

Measured: **65 GB in a single worktree, 282 GB across one machine's.**

`just clean` now depends on a new `clean-dev-state`, which reports what it removed and honours `DRY_RUN=1`.

## `just worktrees` — because `git worktree list` only prints paths

A finished worktree and a branch someone else already has open look identical in `git worktree list`. Both failure modes cost real time on the same day: ninety-five worktrees had accumulated behind merged PRs, and the same fix got written twice, because checking `gh pr list` first is not what `git worktree list` invites.

`scripts/worktree-status.sh` classifies each worktree:

| Verdict | Meaning |
|---|---|
| **SAFE** | PR merged, this tip is exactly the merged head, tree clean — nothing here that is not already on main |
| **REVIEW** | commits that never landed, or a closed-unmerged PR — a human call |
| **KEEP** | open PR, uncommitted work, or a live process |

It never deletes. `--safe-only` prints bare paths so a removal step can be the caller's own, deliberately kept separate from the classification.

## Two details found the hard way

Both of these are why the script looks the way it does, and both are commented in place:

1. **The `ps` snapshot is taken once, up front.** Grepping `ps` per worktree inside the loop looks equivalent and is not — the grep's own argv contains the path it is searching for, so every worktree matches itself and the entire set reads as busy. I hit exactly this: a first pass skipped all 49 candidates as "in use".

2. **Liveness is checked before "has no commits of its own".** A freshly created worktree has no unique commits, which otherwise classifies as SAFE — precisely the shape of one somebody just created and is about to work in. Caught when the script flagged a live session's brand-new worktree as safe to delete.

## Verification

- `clean-dev-state` exercised for all three paths: absent directory, `DRY_RUN=1` (preserves, reports size), and real removal.
- `worktree-status.sh` run against a 45-worktree checkout; live sessions correctly classified KEEP, only genuinely-merged worktrees SAFE.
- `shellcheck` clean.
- `check-no-spec-refs-in-comments`, `check-single-home`, `check-test-home-isolation`, `check-no-network-literals`, `check-honesty`, `check-deferrals` all pass.

No Rust changed.
