### PR TITLE
fix(test): stop the builder-runner tests leaking a shell process per run

### DIFF
--- a/crates/mvm-runtime/src/builder_runner/runner.rs
+++ b/crates/mvm-runtime/src/builder_runner/runner.rs
@@ -257,6 +257,16 @@ mod tests {
         let fx = builder_fixture(&mut env);
         let tmp = &fx.tmp;
 
+        // Reap the endpoint this test spawns. `build` defuses its own guard on
+        // success, because in production the endpoint outlives the build and is
+        // reaped by the stop path — but a test has no stop path, so without a
+        // guard of its own the stub survives the run. It does not even reach its
+        // `sleep 30`: it blocks in `cat >/dev/null` waiting for an stdin EOF
+        // that never comes, so the leak is permanent rather than brief. Held as
+        // a guard rather than reaped at the end of the test so a panicking
+        // assertion cannot skip it.
+        let _endpoint = EndpointGuard::new("bld-unit");
+
         // A run-to-completion builder: the mock VM reports Stopped so the
         // poll-until-off loop returns at once.
         let runner = BuilderRunner::new(MockDriver::default().reporting_status(VmStatus::Stopped));
@@ -302,6 +312,10 @@ mod tests {
         let tmp = &fx.tmp;
         let closure = tmp.path().join("nix-closure.nar");
         std::fs::write(&closure, b"pretend-nar-bytes").unwrap();
+
+        // See the sibling test: `build` defuses its own guard on success, so
+        // without one here the stub endpoint outlives the run permanently.
+        let _endpoint = EndpointGuard::new("bld-closure");
 
         let runner = BuilderRunner::new(MockDriver::default().reporting_status(VmStatus::Stopped));
         let outcome = runner

--- a/crates/mvm-runtime/src/test_support.rs
+++ b/crates/mvm-runtime/src/test_support.rs
@@ -1,13 +1,16 @@
 #[cfg(all(test, feature = "test-support"))]
 use std::error::Error;
-#[cfg(test)]
-#[cfg(test)]
+// Gated exactly like its only user below. Under plain `#[cfg(test)]` this is an
+// unused import whenever `test-support` is off, which is what a package-scoped
+// `cargo clippy -p mvm-runtime --all-targets` builds — green in CI, where the
+// workspace build turns the feature on, and a hard error locally.
+#[cfg(all(test, feature = "test-support"))]
 use std::path::Path;
 
 #[cfg(all(test, feature = "test-support"))]
 use crate::mock_guest_agent::MockGuestAgent;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-support"))]
 fn is_permission_denied_io(err: &std::io::Error) -> bool {
     err.kind() == std::io::ErrorKind::PermissionDenied
 }
@@ -29,7 +32,6 @@ pub(crate) fn error_chain_has_permission_denied(err: &(dyn Error + 'static)) -> 
     false
 }
 
-#[cfg(test)]
 #[cfg(all(test, feature = "test-support"))]
 pub(crate) fn start_mock_guest_agent(vm_dir: &Path) -> Option<MockGuestAgent> {
     match MockGuestAgent::start(vm_dir) {


### PR DESCRIPTION
Closes the rest of #2264.

## The builder-runner tests were leaking a process per run

Not "flaky under load" as the issue assumed — **leaking**. Both tests spawn a stub substitution endpoint and never reaped it. Two of those stubs were still running on this machine **a day and eight hours** after the run that started them.

The stub is:

```sh
#!/bin/sh
cat >/dev/null
echo '{"env":[],"input_fingerprints":[]}'
sleep 30
```

It never reaches `sleep 30`, so it never times out on its own — it blocks in `cat` waiting for an stdin EOF that never arrives. The leak is permanent, not brief.

The cause is a production behaviour the tests inherited: `build` **defuses its own `EndpointGuard` on success**, because in production the endpoint is meant to outlive the build and the stop path reaps it later via the pid file. A test has no stop path.

## The fix

Each test holds an `EndpointGuard` of its own — the existing production mechanism, not a new one — so the endpoint is reaped on drop, and a panicking assertion can't skip it.

Verified with a controlled A/B rather than by assertion:

| | stub processes before → after one run |
|---|---|
| with the guard | 2 → 2 |
| without it (fix stashed) | 2 → **4** |

nextest also stops reporting the second test as `LEAK`, and the pair runs in roughly half the wall time (1.04s → 0.57s).

This matters beyond tidiness: `scripts/reap-helper-orphans.sh` exists as a backstop for exactly these orphans, and leaked helpers *are* load — the same contention that makes the timing-bound tests in this family flake. The leak was feeding the problem the issue was filed about.

## Also: a package-scoped clippy failure on main

While verifying, `cargo clippy -p mvm-runtime --all-targets` turned out to **fail on main** — reproduced with my change stashed, so it is not mine.

In `test_support.rs`, `Path` and `is_permission_denied_io` were gated `#[cfg(test)]`, but their only users are gated `#[cfg(all(test, feature = "test-support"))]`. Without that feature they are unused, which is a hard error under `-D warnings`. CI never saw it because the workspace build turns the feature on; only a package-scoped local build hits it — a papercut for anyone iterating on one crate.

Both now carry the same gate as their users, and two duplicated `#[cfg(test)]` attributes are removed.

Include or drop this hunk as you prefer — it is four lines and unrelated to the leak, but it makes a command contributors actually run stop failing.

## Verification

- `cargo clippy -p mvm-runtime --all-targets` passes **with and without** `test-support`.
- `cargo nextest run -p mvm-runtime`: 764 pass. With `--features test-support`: 802 pass.
- Leaked stubs from previous runs reaped from the machine.
