### PR TITLE
Replace fs2 with std file locking (Plan 309)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,16 +1692,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,7 +2971,6 @@ dependencies = [
  "ed25519-dalek",
  "ext4-view",
  "flate2",
- "fs2",
  "hex",
  "libc",
  "libkrun-sys",
@@ -3152,7 +3141,6 @@ dependencies = [
  "bs58",
  "chrono",
  "ed25519-dalek",
- "fs2",
  "hex",
  "hmac",
  "ipnet",
@@ -3297,7 +3285,6 @@ dependencies = [
  "chrono",
  "ed25519-dalek",
  "ext4-view",
- "fs2",
  "hex",
  "kvm-bindings",
  "kvm-ioctls",
@@ -3543,7 +3530,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,7 +287,6 @@ hickory-proto = "0.26"
 # Utilities
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
-fs2 = "0.4"
 # OS-native keystore (macOS Keychain / Linux Secret Service / Windows
 # Credential Manager). Plan 63 W3 — KeyringProvider impl uses this for
 # per-tenant DEK storage outside env vars or world-readable disk.

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -82,7 +82,6 @@ mvm-vmm = { workspace = true }
 mvm-sdk.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
-fs2.workspace = true
 hex.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
 # Optional libkrun FFI dep for the in-tree builder VM

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -1267,8 +1267,6 @@ pub(crate) fn sparse_create_image(path: &Path, size_bytes: u64) -> Result<(), Bu
 /// HVF; harmless for libkrun). Returns the locked handle; dropping it
 /// releases the lock.
 pub(crate) fn acquire_sidecar_lock(lock_path: &Path) -> Result<std::fs::File, BuilderVmError> {
-    use fs2::FileExt;
-
     let file = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
@@ -1279,7 +1277,7 @@ pub(crate) fn acquire_sidecar_lock(lock_path: &Path) -> Result<std::fs::File, Bu
             BuilderVmError::ExtractionFailed(format!("open lock {}: {e}", lock_path.display()))
         })?;
 
-    file.try_lock_exclusive().map_err(|e| {
+    file.try_lock().map_err(|e| {
         BuilderVmError::ExtractionFailed(format!(
             "image {} is already attached by another builder VM process; \
              wait for the running `mvmctl build` / `mvmctl deps install` to finish and retry: {e}",
@@ -1990,12 +1988,11 @@ mod tests {
         );
     }
 
-    /// fs2's `try_lock_exclusive` can spuriously return `EWOULDBLOCK` on
-    /// a fresh, uncontended path under heavy parallel test load (the
-    /// `reference_fs2_flock_spurious_ewouldblock` flake). Production must
-    /// NOT retry — there a refusal is a real concurrent holder — but a
-    /// test that expects the lock to be FREE retries briefly to absorb
-    /// the spurious failure.
+    /// `try_lock` can report `WouldBlock` on a fresh, uncontended path under
+    /// heavy parallel test load. The retry predates the move off `fs2`, and
+    /// nothing here proves the platform `flock` is innocent, so it stays.
+    /// Production must NOT retry — there a refusal is a real concurrent
+    /// holder — but a test that expects the lock to be FREE absorbs it.
     fn acquire_named_or_retry(
         cache_dir: &Path,
         file_name: &str,
@@ -2063,7 +2060,6 @@ mod tests {
     /// still locked the image. The lock lives on `<image>.lock` instead.
     #[test]
     fn nix_store_lock_does_not_lock_the_image_itself() {
-        use fs2::FileExt;
         let scratch = tempfile::TempDir::new().unwrap();
         let cache_dir = scratch.path().join("builder-vm");
         let guard = acquire_named_or_retry(&cache_dir, "nix-store-aarch64.img", 64);
@@ -2078,8 +2074,8 @@ mod tests {
         assert!(sidecar.to_string_lossy().ends_with(".img.lock"));
 
         // A second handle on the IMAGE can take an exclusive flock —
-        // proving the guard didn't lock the image. Retry to absorb the
-        // fs2 spurious-EWOULDBLOCK flake on a fresh path.
+        // proving the guard didn't lock the image. Retry to absorb a
+        // spurious `WouldBlock` on a fresh path under parallel test load.
         let img = std::fs::OpenOptions::new()
             .read(true)
             .write(true)
@@ -2087,7 +2083,7 @@ mod tests {
             .expect("open image");
         let mut locked = false;
         for _ in 0..40 {
-            if img.try_lock_exclusive().is_ok() {
+            if img.try_lock().is_ok() {
                 locked = true;
                 break;
             }
@@ -2097,8 +2093,8 @@ mod tests {
         drop(guard);
     }
 
-    /// fs2 spurious-EWOULDBLOCK retry wrapper for a RW volume image that
-    /// the test expects to be FREE (mirrors `acquire_named_or_retry`).
+    /// Spurious-`WouldBlock` retry wrapper for a RW volume image the test
+    /// expects to be FREE (mirrors `acquire_named_or_retry`).
     fn ensure_vol_rw_or_retry(path: &Path, size_bytes: u64) -> VolumeImageLock {
         let mut last = String::new();
         for _ in 0..40 {

--- a/crates/mvm-core/Cargo.toml
+++ b/crates/mvm-core/Cargo.toml
@@ -41,7 +41,6 @@ toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-fs2.workspace = true
 regex.workspace = true
 tempfile.workspace = true
 # `mandatory_deny_ranges` parses a small set of

--- a/crates/mvm-core/src/util/atomic_io.rs
+++ b/crates/mvm-core/src/util/atomic_io.rs
@@ -7,7 +7,6 @@ use std::io::Write;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use fs2::FileExt;
 
 /// Write `data` to `path` atomically: write to a temp file in the same
 /// directory, flush + sync, then rename into place.
@@ -64,7 +63,7 @@ impl FileLock {
             .write(true)
             .open(&lock_path)
             .with_context(|| format!("failed to open lock file: {}", lock_path.display()))?;
-        file.lock_exclusive()
+        file.lock()
             .with_context(|| format!("failed to acquire lock: {}", lock_path.display()))?;
         Ok(Self { _file: file })
     }
@@ -83,10 +82,12 @@ impl FileLock {
             .write(true)
             .open(&lock_path)
             .with_context(|| format!("failed to open lock file: {}", lock_path.display()))?;
-        match file.try_lock_exclusive() {
+        // std distinguishes contention from a real error in the type, so
+        // "another process holds it" no longer rides on an errno comparison.
+        match file.try_lock() {
             Ok(()) => Ok(Some(Self { _file: file })),
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
-            Err(e) => {
+            Err(std::fs::TryLockError::WouldBlock) => Ok(None),
+            Err(std::fs::TryLockError::Error(e)) => {
                 Err(e).with_context(|| format!("failed to try lock: {}", lock_path.display()))
             }
         }

--- a/crates/mvm-runtime/Cargo.toml
+++ b/crates/mvm-runtime/Cargo.toml
@@ -90,7 +90,6 @@ tracing.workspace = true
 # `fs`: `LocalBackend`'s atomic put (write-tmp + fsync + rename) over
 # `tokio::fs`.
 tokio = { workspace = true, features = ["fs"] }
-fs2.workspace = true
 # DEK held in `EncryptedStorage` is zeroized on drop.
 zeroize.workspace = true
 # Audited rust-vmm guest-memory primitive behind the in-house VMM's `GuestMem`

--- a/crates/mvm-runtime/src/vm/name_registry.rs
+++ b/crates/mvm-runtime/src/vm/name_registry.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result, bail};
-use fs2::FileExt;
 use mvm_core::domain::instance::InstanceReadiness;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
@@ -345,7 +344,7 @@ pub fn acquire_registry_lock(registry_path: &Path) -> Result<VmNameRegistryLock>
         .truncate(false)
         .open(&lock_path)
         .with_context(|| format!("opening VM name registry lock {}", lock_path.display()))?;
-    file.lock_exclusive()
+    file.lock()
         .with_context(|| format!("locking VM name registry {}", lock_path.display()))?;
     Ok(VmNameRegistryLock { _file: file })
 }

--- a/specs/plans/309-dependency-reduction.md
+++ b/specs/plans/309-dependency-reduction.md
@@ -209,6 +209,32 @@ stack on the egress path.
 
 ---
 
+## Phase 2 preflight: measured, before writing any client
+
+Feature narrowing is what made the rcgen cut cheap, so the same question was
+asked of `reqwest` first. **It does not apply.** Measured against the shipped
+closure:
+
+| Change | Δ | Verdict |
+|---|---|---|
+| drop `blocking` | 0 | `futures-channel`/`futures-util` are `hyper-util`'s anyway |
+| drop `json` | 0 | `serde_json` is already in the closure |
+| drop `rustls-no-provider` | −5 | drops TLS entirely — not viable |
+
+There is no public reqwest feature that yields rustls without
+`rustls-platform-verifier` (`__rustls` is private), and swapping the platform
+trust store for bundled `webpki-roots` would be a *downgrade* — it stops
+honouring enterprise CA policy and root revocation. So the 27 crates are the
+irreducible hyper/tower/http stack, and only a replacement wins them.
+
+That makes Phase 2 a genuine ~2000-line HTTP/1.1 client, on the path that
+carries OCI registry fetch, egress re-origination, and the `web_fetch` SSRF
+guard. The reqwest surface it must reproduce is not just request/response: the
+`reqwest::dns::Resolve` seam behind `SsrfFilteringResolver`, `min_tls_version`
+pinned to TLS 1.3, `redirect::Policy::none`, streaming `.chunk()` under exact
+byte caps, plus blocking and async faces. That is the whole cost, stated
+before starting rather than discovered halfway.
+
 ## Phase 3 — candidates requiring a product decision
 
 Not scheduled. Each needs a call that is not the implementer's to make.
@@ -221,9 +247,20 @@ Not scheduled. Each needs a call that is not the implementer's to make.
       body validator). Gating JS/TS behind an `sdk-node` feature would cut C
       compilation for the common Python case — but a default `mvmctl` would then
       refuse to compile Node workloads. **Product decision.**
-- [ ] **`tracing-subscriber` (−7).** Used in 12 files, mostly `init`. A minimal
-      in-house `Subscriber` is maybe 200 lines, but it means owning
-      `env-filter` semantics forever. Poor ratio; listed for completeness.
+- [ ] **`tracing-subscriber` (−4 measured, not −7).** Its features were
+      measured too: dropping `json` alone is −1, `env-filter` alone is −1, and
+      `fmt`+`std` only is −4. None is free — `EnvFilter::try_from_default_env`
+      backs `RUST_LOG` in the CLI, and `.json()` is what the signer and
+      substitution-endpoint daemons log through. Taking the −4 means owning
+      env-filter directive semantics and a JSON layer, and regressing a
+      `RUST_LOG` contract users rely on. Poor ratio.
+
+- [ ] **The −1 tail.** `keyring`, `ext4-view`, `xattr`, `bs58`, `aho-corasick`,
+      `hex`, `ipnet`, `uuid`, `lzma-rs`, `etherparse`, `sysinfo`, `leakguard`
+      are one crate each; `which` is −3 across 37 call sites and `url` is −2.
+      `keyring` is only −1 even on macOS — `security-framework` and the
+      `core-foundation`/`objc2` set are shared with `rustls-platform-verifier`.
+      Nothing here is worth bespoke code.
 - [ ] **`toml` (−6).** Investigated: bumping 0.8 → 0.9 is roughly a wash
       (`toml_edit` is replaced by `toml_parser` + `toml_writer`), *not* a free
       win. The lockfile currently carries both 0.8 and 0.9 — consolidating on
@@ -256,6 +293,7 @@ The ratchet only works if it moves. Every phase above must land its
 | Baseline | 286 | — | — |
 | Phase 0 | 280 | −6 | **landed** |
 | Phase 1 | 263 | −23 | **landed** |
+| `fs2` → std locking | 262 | −24 | **landed** |
 | Phase 2 | ~236 | ~−50 | not started |
 
 ## What landed (2026-08-09)
@@ -288,6 +326,17 @@ Verification performed:
   workload this size.
 - Linux cross-build (`cargo zigbuild x86_64-unknown-linux-gnu`) clean for
   every touched crate.
+
+### Also landed: `fs2` → std file locking (−1)
+
+`fs2` was in the closure for `FileExt` alone — advisory `flock` across four
+sites. std stabilized `File::lock`/`try_lock`/`unlock` in 1.89 and the
+toolchain is pinned at 1.96, so the dep bought nothing. std additionally
+splits contention out of the error type (`TryLockError::WouldBlock` vs
+`TryLockError::Error`), so "another process holds it" no longer rides on an
+errno comparison. The test-only spurious-`WouldBlock` retry wrappers were
+*kept*: nothing in this change proves the platform `flock` was innocent, so
+their comments were reworded rather than deleted.
 
 ### Deferred out of Phase 1
 

--- a/xtask/src/check_closure_budget.rs
+++ b/xtask/src/check_closure_budget.rs
@@ -115,7 +115,13 @@ const BUDGET_TARGET: &str = "x86_64-unknown-linux-gnu";
 /// had just serialized, and carried the whole ASN.1 stack including the
 /// closure's last `nom` 7), and replacing `rayon` with an order-preserving
 /// scoped-thread `par_map` in `mvm-fs`, which is all five call sites needed.
-const CLOSURE_BUDGET: usize = 263;
+///
+/// 262 (was 263): `fs2` existed only for `FileExt`'s advisory file locking,
+/// which std stabilized in 1.89 — well under the pinned 1.96 toolchain. std
+/// also splits contention out of the error type (`TryLockError::WouldBlock`
+/// vs `::Error`), so "another process holds it" stops riding on an errno
+/// comparison.
+const CLOSURE_BUDGET: usize = 262;
 
 pub fn run(workspace: &Path) -> Result<()> {
     let count = default_closure_crate_count(workspace)?;


### PR DESCRIPTION
Stacked on #2285.

`fs2` was in the shipped closure for `FileExt` alone — advisory `flock` across
four sites. std stabilized `File::lock`/`try_lock`/`unlock` in 1.89 and the
toolchain is pinned at **1.96**, so the dependency bought nothing.

Closure **263 → 262**; `CLOSURE_BUDGET` ratcheted.

### A correctness improvement, not just a crate count

std splits contention out of the error type — `TryLockError::WouldBlock` versus
`TryLockError::Error(io::Error)`. `atomic_io::FileLock::try_acquire` was
matching `ErrorKind::WouldBlock` to decide "another process holds this", which
conflated a real IO failure with contention. It now matches the variant.

### What I deliberately did not do

The test-only retry wrappers in `builder_vm_runtime.rs` absorb a spurious
`WouldBlock` on a fresh, uncontended path under parallel load, and their
comments blamed `fs2`. Nothing in this change proves the platform `flock` is
innocent, so **the retries stay** — only the attribution is reworded. Deleting
them on an unproven assumption would have traded a crate for a flake.

### Also in this PR

The Phase 2 preflight measurements, recorded in the plan doc. Feature narrowing
is what made the rcgen cut cheap, so the same question was put to `reqwest`
first — and the answer is no:

| Change | Δ closure |
|---|---|
| drop `blocking` | 0 (`futures-*` are `hyper-util`'s regardless) |
| drop `json` | 0 (`serde_json` already present) |
| drop `rustls-no-provider` | −5, but that drops TLS entirely |

No public reqwest feature yields rustls without `rustls-platform-verifier`, and
substituting bundled `webpki-roots` would stop honouring enterprise CA policy
and root revocation — a downgrade. So reqwest's 27 crates are the irreducible
hyper/tower/http stack and only a full replacement wins them. Same check was
run on `tracing-subscriber` (−4 available, but `EnvFilter` backs `RUST_LOG` and
`.json()` backs the daemon logs, so neither is free) and on the `−1` tail.

### Verification

Workspace `nextest` 10,641 pass, `clippy --all-targets -- -D warnings` clean,
nightly `fmt --check`, `check-closure-budget` at its new 262.