### PR TITLE
Plan 311 — take image-size-dependent work off the prepared launch path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3026,6 +3026,7 @@ dependencies = [
  "hex",
  "libc",
  "libkrun-sys",
+ "memchr",
  "mvm-agentd",
  "mvm-backends",
  "mvm-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,6 +316,11 @@ flate2 = "1"
 hex = "0.4"
 tar = "0.4"
 xattr = "1"
+# Skip-capable substring search. Already compiled into every host binary via
+# globset -> aho-corasick, so a direct edge adds an import and no build cost.
+# Used where a scan runs over a whole multi-megabyte artifact on the launch
+# path, which a naive `windows().any()` walks quadratically.
+memchr = "2"
 # Read-only ext4 walker (deps bitflags + crc only). Replaces hand-rolled
 # raw-byte ext4 poking in the Stage 0 validators with a real inode lookup
 # (`fs.exists("/sbin/mvm-host-vm-init")`). `std` enables `load_from_path`.

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -55,6 +55,7 @@ sha2.workspace = true
 tar = "0.4"
 flate2.workspace = true
 hex.workspace = true
+memchr.workspace = true
 tempfile.workspace = true
 toml.workspace = true
 notify = { workspace = true, optional = true }

--- a/crates/mvm-cli/src/bench/cold_launch.rs
+++ b/crates/mvm-cli/src/bench/cold_launch.rs
@@ -203,6 +203,8 @@ pub fn validate_lane(lane: LaunchLane, sample: &LaunchSample) -> Result<(), Lane
                 "image_build",
                 "mount_materialize",
                 "warm_claim",
+                "artifact_hash",
+                "process_table_scan",
             ])?;
             require_cold(lane, sample)
         }
@@ -212,11 +214,19 @@ pub fn validate_lane(lane: LaunchLane, sample: &LaunchSample) -> Result<(), Lane
                 "image_build",
                 "mount_materialize",
                 "warm_claim",
+                "artifact_hash",
+                "process_table_scan",
             ])?;
             require_cold(lane, sample)
         }
         LaunchLane::MountMiss => {
-            forbid(vec!["image_pull", "image_build", "warm_claim"])?;
+            forbid(vec![
+                "image_pull",
+                "image_build",
+                "warm_claim",
+                "artifact_hash",
+                "process_table_scan",
+            ])?;
             if !work.mount_materialize {
                 return Err(LaneViolation::MissingWork {
                     lane,
@@ -680,6 +690,8 @@ mod tests {
             image_build: true,
             mount_materialize: true,
             warm_claim: true,
+            artifact_bytes_hashed: 1_205_739_520,
+            process_table_scans: 1,
         };
         let err = validate_lane(LaunchLane::PreparedCold, &sample).unwrap_err();
         assert_eq!(
@@ -690,10 +702,95 @@ mod tests {
                     "image_pull",
                     "image_build",
                     "mount_materialize",
-                    "warm_claim"
+                    "warm_claim",
+                    "artifact_hash",
+                    "process_table_scan"
                 ],
             }
         );
+    }
+
+    /// The regression this gate exists for: re-reading an already-cached
+    /// artifact to recompute a digest is not a pull, a build, a mount
+    /// materialization, or a warm claim, so before this flag existed such a
+    /// launch reported itself as a clean prepared-cold sample. Its cost is
+    /// linear in artifact size, which is why it stayed invisible on a small
+    /// image and dominated a large one.
+    #[test]
+    fn prepared_cold_rejects_a_launch_that_re_hashed_a_cached_artifact() {
+        let mut sample = launch_sample();
+        sample.work.artifact_bytes_hashed = 1_205_739_520;
+        let err = validate_lane(LaunchLane::PreparedCold, &sample).unwrap_err();
+        assert_eq!(
+            err,
+            LaneViolation::ForbiddenWork {
+                lane: LaunchLane::PreparedCold,
+                performed: vec!["artifact_hash"],
+            }
+        );
+        assert!(err.to_string().contains("artifact_hash"));
+    }
+
+    /// Zero is the prepared state, and it must not be confused with "the
+    /// counter was never populated": both read as no work, and only the first
+    /// is a claim. A sample that hashed nothing passes, which is what makes
+    /// the fixed launch path provable rather than merely faster.
+    #[test]
+    fn prepared_cold_accepts_a_launch_that_hashed_nothing() {
+        let mut sample = launch_sample();
+        sample.work.artifact_bytes_hashed = 0;
+        assert_eq!(validate_lane(LaunchLane::PreparedCold, &sample), Ok(()));
+    }
+
+    /// The mount-miss lane materializes a mount image and is expected to; it
+    /// still boots prepared artifacts, so a rootfs re-hash contaminates it the
+    /// same way.
+    #[test]
+    fn mount_miss_still_rejects_a_re_hashed_artifact() {
+        let mut sample = launch_sample();
+        sample.work.mount_materialize = true;
+        sample.work.artifact_bytes_hashed = 1_205_739_520;
+        let err = validate_lane(LaunchLane::MountMiss, &sample).unwrap_err();
+        assert_eq!(
+            err,
+            LaneViolation::ForbiddenWork {
+                lane: LaunchLane::MountMiss,
+                performed: vec!["artifact_hash"],
+            }
+        );
+    }
+
+    /// The other half of the same finding: a process-table snapshot is
+    /// maintenance whose cost belongs to a run that spawns a helper, not to one
+    /// that resolved everything from cache. Like the re-hash, it is not a pull,
+    /// a build, a materialization, or a claim.
+    #[test]
+    fn prepared_cold_rejects_a_launch_that_walked_the_process_table() {
+        let mut sample = launch_sample();
+        sample.work.process_table_scans = 1;
+        let err = validate_lane(LaunchLane::PreparedCold, &sample).unwrap_err();
+        assert_eq!(
+            err,
+            LaneViolation::ForbiddenWork {
+                lane: LaunchLane::PreparedCold,
+                performed: vec!["process_table_scan"],
+            }
+        );
+        assert!(err.to_string().contains("process_table_scan"));
+    }
+
+    /// The artifact-miss lane is the one that legitimately hashes: it acquires
+    /// and prepares the image, so reading it end-to-end is the work being
+    /// measured rather than work being repeated.
+    #[test]
+    fn artifact_miss_permits_hashing_because_that_lane_is_the_acquisition() {
+        let mut sample = launch_sample();
+        sample.work.image_pull = true;
+        sample.work.artifact_bytes_hashed = 1_205_739_520;
+        // The same lane spawns a builder VM when the ext4 writer cannot emit a
+        // tree, so it reaps before doing so; that sweep belongs to this lane.
+        sample.work.process_table_scans = 1;
+        assert_eq!(validate_lane(LaunchLane::ArtifactMiss, &sample), Ok(()));
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/env/builder_vm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm.rs
@@ -82,12 +82,14 @@ use stage0_cache::{
     sweep_orphaned_stage0_staging_dirs_at, write_builder_vm_artifact_digest_manifest,
     write_builder_vm_source_cache_provenance, write_builder_vm_source_fingerprint,
 };
-pub(in crate::commands) use vm_helpers::sweep_orphaned_vm_helpers_on_startup;
 #[cfg(test)]
 use vm_helpers::{
     BUILDER_SIDECARS, ProcSnapshot, WORKLOAD_SIDECARS, pid_is_alive,
     reap_orphaned_builder_egress_supervisors, reap_orphaned_vm_helpers_at,
     reap_orphaned_vm_helpers_at_with_snapshot,
+};
+pub(in crate::commands) use vm_helpers::{
+    sweep_orphaned_vm_helpers_before_spawn, sweep_orphaned_vm_helpers_on_startup,
 };
 
 #[cfg(feature = "builder-vm")]

--- a/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
@@ -151,6 +151,39 @@ fn assert_workload_kernel_supports_verity_rejects_a_marker_free_kernel() {
     assert!(assert_workload_kernel_supports_verity(opaque.to_str().unwrap()).is_ok());
 }
 
+/// The scan runs over a whole multi-megabyte kernel on every launch, so its
+/// implementation was swapped for a skip-capable search. These are the cases
+/// where a naive and a skipping search can disagree: a marker at the very end
+/// (the worst offset), a long run of near-misses that share a marker's prefix,
+/// and a needle longer than the haystack.
+#[test]
+fn kernel_marker_search_finds_markers_at_any_offset_and_rejects_near_misses() {
+    let mut trailing = b"Linux version 6.6.0 ".to_vec();
+    trailing.extend(std::iter::repeat_n(b'\0', 512 * 1024));
+    trailing.extend_from_slice(b"dm-verity");
+    assert_eq!(
+        kernel_carries_dm_verity(&trailing),
+        Some(true),
+        "a marker in the final bytes must still be found"
+    );
+
+    // Repeated partial matches of `dm_table_create` that never complete: the
+    // shape a naive search walks quadratically, and which must still answer
+    // false.
+    let mut near_miss = b"Linux version 6.6.0 ".to_vec();
+    for _ in 0..40_000 {
+        near_miss.extend_from_slice(b"dm_table_creat_");
+    }
+    assert_eq!(
+        kernel_carries_dm_verity(&near_miss),
+        Some(false),
+        "a prefix that never completes a marker is not a marker"
+    );
+
+    // Needle longer than haystack must not panic or match.
+    assert_eq!(kernel_carries_dm_verity(b"Linux vers"), None);
+}
+
 #[test]
 #[cfg(feature = "builder-vm")]
 fn build_heartbeat_emits_while_alive_and_stops_on_drop() {

--- a/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
@@ -138,8 +138,15 @@ pub(super) fn kernel_carries_dm_verity(bytes: &[u8]) -> Option<bool> {
     Some(MARKERS.iter().any(|m| byte_contains(bytes, m)))
 }
 
+/// Substring search across a whole kernel image.
+///
+/// `windows(n).any(..)` is the obvious spelling and is quadratic: it compares
+/// at every offset with no way to skip ahead. Over an 8 MB `vmlinux`, repeated
+/// once per marker, that is milliseconds of every launch — and the refusal
+/// case pays the most, because it is the one that finds no marker and so scans
+/// the image for all of them. `memmem` skips, and is already linked in.
 fn byte_contains(haystack: &[u8], needle: &[u8]) -> bool {
-    needle.len() <= haystack.len() && haystack.windows(needle.len()).any(|w| w == needle)
+    needle.len() <= haystack.len() && memchr::memmem::find(haystack, needle).is_some()
 }
 
 /// Fail fast when a verity-sealed launch resolved a kernel with no dm-verity

--- a/crates/mvm-cli/src/commands/env/builder_vm/vm_helpers.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/vm_helpers.rs
@@ -98,6 +98,24 @@ pub(in crate::commands) fn sweep_orphaned_vm_helpers_on_startup() {
     }
 }
 
+/// Reap orphaned helpers once, immediately before this process may spawn a
+/// builder VM of its own.
+///
+/// The sweep needs a snapshot of the host process table, which costs a `ps`
+/// subprocess and scales with how busy the host is. A launch that resolves
+/// every artifact from cache never spawns a helper, so running the sweep
+/// unconditionally charges the prepared launch path for cleanup that cannot
+/// benefit it. Calling this at the spawn sites keeps the guarantee the startup
+/// sweep was added for — no orphan accumulation across runs that do spawn —
+/// without putting a process-table walk in front of a launch that does not.
+///
+/// Idempotent: several branches can reach a materializer in one run, and the
+/// second sweep would find nothing the first left behind.
+pub(in crate::commands) fn sweep_orphaned_vm_helpers_before_spawn() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(sweep_orphaned_vm_helpers_on_startup);
+}
+
 /// Sidecar PID file names a builder VM dir carries (libkrun + HVF).
 pub(super) const BUILDER_SIDECARS: &[&str] = &["builder.pid", "stage0.pid"];
 
@@ -343,6 +361,10 @@ pub(super) struct ProcSnapshot {
 
 impl ProcSnapshot {
     fn capture() -> Self {
+        // Reported here rather than at the callers: this is the function that
+        // pays for the snapshot, and a caller that forgot to report would make
+        // a launch look cheaper than it was.
+        mvm_core::launch_trace::record_process_table_scan();
         let mut parents = std::collections::HashMap::new();
         let mut cmds = Vec::new();
         let Ok(out) = std::process::Command::new("ps")

--- a/crates/mvm-cli/src/commands/image/pull_core.rs
+++ b/crates/mvm-cli/src/commands/image/pull_core.rs
@@ -62,18 +62,25 @@ pub(in crate::commands) fn resolve_or_pull_run_image(
     )
 }
 
+/// Reap helper processes a previous run orphaned, immediately before this run
+/// may spawn a builder VM of its own.
+///
+/// Rootfs materialization falls back to a builder VM when the in-process ext4
+/// writer cannot faithfully emit a tree, and that is the only way this path
+/// adds a helper. Called at the branches that can reach a materializer rather
+/// than on entry: a run that resolves entirely from the cache spawns nothing,
+/// and the sweep needs a host process-table snapshot whose cost the prepared
+/// launch path should not pay for cleanup it cannot cause.
+fn sweep_before_builder_vm() {
+    crate::commands::env::builder_vm::sweep_orphaned_vm_helpers_before_spawn();
+}
+
 pub(super) fn resolve_or_pull_run_image_with(
     cache_root: &Path,
     reference: &str,
     prod: bool,
     materialize: RuntimeMaterializer,
 ) -> Result<ResolvedOciRunImage> {
-    // Rootfs materialization can fall back to a builder VM when the in-process
-    // ext4 writer cannot faithfully emit a tree. `mvmctl image pull` reaps
-    // previous helper processes at startup; the run-image path is the other
-    // place a builder VM can spawn, so give it the same sweep before we might add one.
-    crate::commands::env::builder_vm::sweep_orphaned_vm_helpers_on_startup();
-
     // Local sources route to their own ingest; a registry reference falls
     // through to the cache-or-pull path below.
     match source::ImageSource::classify(reference)? {
@@ -100,9 +107,11 @@ pub(super) fn resolve_or_pull_run_image_with(
             (cached, false, None, None)
         }
         Some(cached) => {
+            sweep_before_builder_vm();
             match rematerialize_cached_image(cache_root, cached, &runtime_tag, materialize, prod)? {
                 Some(repaired) => (repaired, false, None, None),
                 None => {
+                    sweep_before_builder_vm();
                     let (cached, trust, auth_source) =
                         pull_image_ref(cache_root, image_ref.clone(), reference, prod)?;
                     (cached, true, Some(trust), Some(auth_source))
@@ -110,6 +119,7 @@ pub(super) fn resolve_or_pull_run_image_with(
             }
         }
         _ => {
+            sweep_before_builder_vm();
             let (cached, trust, auth_source) =
                 pull_image_ref(cache_root, image_ref.clone(), reference, prod)?;
             (cached, true, Some(trust), Some(auth_source))
@@ -135,6 +145,7 @@ pub(super) fn resolve_or_pull_run_image_with(
         // is this a genuine cache loss the user must re-pull.
         match unpacked_dir_if_present(cache_root, &image.resolved_digest) {
             Some(unpacked_root) => {
+                sweep_before_builder_vm();
                 materialize(
                     cache_root,
                     &unpacked_root,

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -931,7 +931,14 @@ fn emit_oci_run_admission(
     timeout_secs: u64,
     network_mode: mvm_contract::plan::NetworkMode,
 ) -> Result<()> {
-    let image_sha256 = mvm_core::crypto::image_verify::sha256_file(&image.rootfs_path)
+    // Cached, like every sibling admission path (`up`, the warm-pool claim, the
+    // hostd runner, image lineage). The rootfs this digest binds is immutable
+    // and content-addressed, so re-reading it on each launch recomputes a value
+    // the sidecar already holds — a cost linear in image size, and hardware
+    // SHA-256 is already fast enough that no build profile hides it. The
+    // sidecar is keyed on size + mtime, so any rewrite forces a re-hash and a
+    // stale digest cannot reach admission.
+    let image_sha256 = mvm_core::crypto::image_verify::sha256_file_cached(&image.rootfs_path)
         .with_context(|| {
             format!(
                 "hashing OCI rootfs at {} for run --image admission",

--- a/crates/mvm-cli/src/commands/vm/launch_sample.rs
+++ b/crates/mvm-cli/src/commands/vm/launch_sample.rs
@@ -76,6 +76,21 @@ pub struct LaunchWork {
     pub mount_materialize: bool,
     /// The launch was satisfied by claiming a warm standby.
     pub warm_claim: bool,
+    /// Bytes read end-to-end to digest an artifact during this launch.
+    ///
+    /// A prepared launch boots artifacts whose digests are already cached, so
+    /// this is zero on that lane. It is a count and not a flag because the
+    /// number identifies the artifact: a re-read of a 1.1 GB rootfs and a
+    /// re-read of an 8 MB kernel are the same boolean and very different
+    /// launches.
+    pub artifact_bytes_hashed: u64,
+    /// Host process-table snapshots taken during this launch.
+    ///
+    /// Zero on a prepared launch: nothing it does spawns a helper, so nothing
+    /// it does needs to reap one. Counted for the same reason as the bytes
+    /// above — the cost is real, invisible in a digest or a boot, and belongs
+    /// to maintenance rather than to the launch.
+    pub process_table_scans: u64,
 }
 
 impl LaunchWork {
@@ -95,6 +110,12 @@ impl LaunchWork {
         }
         if self.warm_claim {
             names.push("warm_claim");
+        }
+        if self.artifact_bytes_hashed > 0 {
+            names.push("artifact_hash");
+        }
+        if self.process_table_scans > 0 {
+            names.push("process_table_scan");
         }
         names
     }
@@ -118,6 +139,8 @@ pub fn recorded_work(mount_materialize: bool, warm_claim: bool) -> LaunchWork {
         image_build: acquired.image_build,
         mount_materialize,
         warm_claim,
+        artifact_bytes_hashed: acquired.artifact_bytes_hashed,
+        process_table_scans: acquired.process_table_scans,
     }
 }
 
@@ -407,12 +430,29 @@ mod tests {
             image_build: false,
             mount_materialize: true,
             warm_claim: false,
+            artifact_bytes_hashed: 0,
+            process_table_scans: 0,
         };
         assert!(!contaminated.is_prepared());
         assert_eq!(
             contaminated.performed(),
             vec!["image_pull", "mount_materialize"]
         );
+
+        // A byte count is work like any other flag, and zero is not work.
+        let re_hashed = LaunchWork {
+            artifact_bytes_hashed: 1_205_739_520,
+            ..LaunchWork::default()
+        };
+        assert!(!re_hashed.is_prepared());
+        assert_eq!(re_hashed.performed(), vec!["artifact_hash"]);
+
+        let swept = LaunchWork {
+            process_table_scans: 1,
+            ..LaunchWork::default()
+        };
+        assert!(!swept.is_prepared());
+        assert_eq!(swept.performed(), vec!["process_table_scan"]);
     }
 
     #[test]

--- a/crates/mvm-conformance/tests/steps/cold_launch.rs
+++ b/crates/mvm-conformance/tests/steps/cold_launch.rs
@@ -71,7 +71,7 @@ fn clean_launch_sample(world: &mut CliWorld, profile: String) {
 }
 
 #[given(
-    regex = r"^a release launch sample whose launch performed (image_pull|image_build|mount_materialize|warm_claim)$"
+    regex = r"^a release launch sample whose launch performed (image_pull|image_build|mount_materialize|warm_claim|artifact_hash|process_table_scan)$"
 )]
 fn contaminated_launch_sample(world: &mut CliWorld, work: String) {
     let mut sample = clean_sample(BuildProfile::Release);
@@ -86,6 +86,12 @@ fn contaminated_launch_sample(world: &mut CliWorld, work: String) {
             sample.work.warm_claim = true;
             sample.launch_mode = LaunchMode::Warm;
         }
+        // A rootfs-sized re-read of an artifact whose digest was already
+        // cached: not a pull, a build, a materialization, or a claim, and so
+        // the one kind of repeated work the lane could not previously name.
+        "artifact_hash" => sample.work.artifact_bytes_hashed = 1_205_739_520,
+        // Host maintenance charged to a launch that spawned nothing to clean.
+        "process_table_scan" => sample.work.process_table_scans = 1,
         other => panic!("unknown work kind {other:?}"),
     }
     world.cold_launch_sample = Some(sample);
@@ -121,7 +127,7 @@ fn the_lane_accepts(world: &mut CliWorld) {
 }
 
 #[then(
-    regex = r"^the prepared-cold lane refuses the sample naming (image_pull|image_build|mount_materialize|warm_claim)$"
+    regex = r"^the prepared-cold lane refuses the sample naming (image_pull|image_build|mount_materialize|warm_claim|artifact_hash|process_table_scan)$"
 )]
 fn the_lane_refuses_naming(world: &mut CliWorld, work: String) {
     let rendered = refusal(world);

--- a/crates/mvm-core/src/crypto/image_verify.rs
+++ b/crates/mvm-core/src/crypto/image_verify.rs
@@ -396,13 +396,20 @@ pub fn sha256_file(path: &Path) -> io::Result<String> {
     let mut file = fs::File::open(path)?;
     let mut hasher = Sha256::new();
     let mut buf = [0u8; 65536];
+    let mut read_total: u64 = 0;
     loop {
         let n = file.read(&mut buf)?;
         if n == 0 {
             break;
         }
+        read_total += n as u64;
         hasher.update(&buf[..n]);
     }
+    // Reported here rather than at the call sites because this is the function
+    // that actually reads the bytes; a caller that forgot to report would make
+    // a launch look cheaper than it was, which is the direction that hides
+    // regressions.
+    crate::launch_trace::record_artifact_bytes_hashed(read_total);
     Ok(hex::encode(hasher.finalize()))
 }
 
@@ -418,6 +425,25 @@ pub fn sha256_file(path: &Path) -> io::Result<String> {
 /// content) moves its mtime and forces a re-hash, so a stale digest can never
 /// be admitted. A read-only cache dir simply means the next boot re-hashes.
 pub fn sha256_file_cached(path: &Path) -> io::Result<String> {
+    sha256_file_cached_with_source(path).map(|(hex, _)| hex)
+}
+
+/// Where a [`sha256_file_cached`] digest came from.
+///
+/// Returned so the sidecar being *used* is directly assertable. The cost this
+/// cache exists to avoid is linear in artifact size and invisible in a digest
+/// that is correct either way, so "it hit" has to be observable on its own —
+/// otherwise a regression to hashing every call still passes every test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DigestSource {
+    /// Served from the sidecar; the artifact was not read.
+    Sidecar,
+    /// Hashed from the artifact, reading this many bytes.
+    Hashed(u64),
+}
+
+/// [`sha256_file_cached`], reporting whether the sidecar served the digest.
+pub fn sha256_file_cached_with_source(path: &Path) -> io::Result<(String, DigestSource)> {
     let meta = fs::metadata(path)?;
     let size = meta.len();
     let mtime_nanos = meta
@@ -431,14 +457,14 @@ pub fn sha256_file_cached(path: &Path) -> io::Result<String> {
         && let Ok(contents) = fs::read_to_string(&sidecar)
         && let Some(hex) = parse_sha256_sidecar(&contents, size, mtime)
     {
-        return Ok(hex);
+        return Ok((hex, DigestSource::Sidecar));
     }
 
     let hex = sha256_file(path)?;
     if let Some(mtime) = mtime_nanos {
         let _ = write_sha256_sidecar(&sidecar, &hex, size, mtime);
     }
-    Ok(hex)
+    Ok((hex, DigestSource::Hashed(size)))
 }
 
 fn sha256_sidecar_path(path: &Path) -> std::path::PathBuf {
@@ -498,6 +524,49 @@ mod tests {
             sha256_file_cached(&p).expect("cached3"),
             direct2,
             "stale digest must never be served after a content change"
+        );
+
+        let _ = fs::remove_file(&sidecar);
+    }
+
+    /// A cache hit must not read the artifact. The digest is correct either
+    /// way, so without asserting the source directly a regression to hashing
+    /// on every call would pass every other test in this module while costing
+    /// a full re-read of the artifact on every launch.
+    #[test]
+    fn a_sidecar_hit_serves_the_digest_without_reading_the_artifact() {
+        let mut f = NamedTempFile::new().expect("tempfile");
+        let body = b"the quick brown fox";
+        f.write_all(body).expect("write");
+        f.flush().expect("flush");
+        let p = f.path().to_path_buf();
+        let sidecar = sha256_sidecar_path(&p);
+        let _ = fs::remove_file(&sidecar);
+
+        let (miss, miss_source) = sha256_file_cached_with_source(&p).expect("cached miss");
+        assert_eq!(
+            miss_source,
+            DigestSource::Hashed(body.len() as u64),
+            "a sidecar miss reads the whole artifact"
+        );
+
+        let (hit, hit_source) = sha256_file_cached_with_source(&p).expect("cached hit");
+        assert_eq!(hit, miss, "a hit serves the digest the miss computed");
+        assert_eq!(
+            hit_source,
+            DigestSource::Sidecar,
+            "a sidecar hit must not read the artifact"
+        );
+
+        // A rewrite moves size+mtime, so the next call must read again rather
+        // than serve the digest of content that is gone.
+        f.write_all(b" jumps").expect("append");
+        f.flush().expect("flush");
+        let (fresh, fresh_source) = sha256_file_cached_with_source(&p).expect("after rewrite");
+        assert_ne!(fresh, miss, "content changed, so the digest must change");
+        assert!(
+            matches!(fresh_source, DigestSource::Hashed(_)),
+            "a rewritten artifact must be re-read, not served from a stale sidecar"
         );
 
         let _ = fs::remove_file(&sidecar);

--- a/crates/mvm-core/src/launch_trace.rs
+++ b/crates/mvm-core/src/launch_trace.rs
@@ -19,7 +19,7 @@
 //! diagnostic.
 
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
@@ -187,16 +187,35 @@ impl LaunchTraceRecorder {
 pub struct AcquisitionWork {
     pub image_pull: bool,
     pub image_build: bool,
+    /// Bytes read end-to-end to produce an artifact digest.
+    ///
+    /// A count rather than a flag because the number is the diagnosis: it names
+    /// which artifact was re-read without anyone having to guess from a
+    /// boolean. A prepared launch has a cached digest for every artifact it
+    /// boots, so on that lane this is zero, and any nonzero value is work the
+    /// launch repeated.
+    pub artifact_bytes_hashed: u64,
+    /// Snapshots taken of the host process table during this launch.
+    ///
+    /// Each one costs a subprocess and scales with how busy the host is, not
+    /// with anything the launch controls. A prepared launch spawns no helper
+    /// and so needs no snapshot; a nonzero count means maintenance ran on the
+    /// launch path.
+    pub process_table_scans: u64,
 }
 
 struct AcquisitionRecorder {
     image_pull: AtomicBool,
     image_build: AtomicBool,
+    artifact_bytes_hashed: AtomicU64,
+    process_table_scans: AtomicU64,
 }
 
 static ACQUISITION: AcquisitionRecorder = AcquisitionRecorder {
     image_pull: AtomicBool::new(false),
     image_build: AtomicBool::new(false),
+    artifact_bytes_hashed: AtomicU64::new(0),
+    process_table_scans: AtomicU64::new(0),
 };
 
 /// Record that this process fetched image bytes from a registry.
@@ -209,12 +228,31 @@ pub fn record_image_build() {
     ACQUISITION.image_build.store(true, Ordering::Relaxed);
 }
 
+/// Record that this process read `bytes` end-to-end to digest an artifact.
+///
+/// Accumulates rather than latching: two re-reads are worse than one, and a
+/// gate that reported them identically would hide the second.
+pub fn record_artifact_bytes_hashed(bytes: u64) {
+    ACQUISITION
+        .artifact_bytes_hashed
+        .fetch_add(bytes, Ordering::Relaxed);
+}
+
+/// Record that this process snapshotted the host process table.
+pub fn record_process_table_scan() {
+    ACQUISITION
+        .process_table_scans
+        .fetch_add(1, Ordering::Relaxed);
+}
+
 /// What acquisition work this process has performed so far.
 #[must_use]
 pub fn recorded_acquisition() -> AcquisitionWork {
     AcquisitionWork {
         image_pull: ACQUISITION.image_pull.load(Ordering::Relaxed),
         image_build: ACQUISITION.image_build.load(Ordering::Relaxed),
+        artifact_bytes_hashed: ACQUISITION.artifact_bytes_hashed.load(Ordering::Relaxed),
+        process_table_scans: ACQUISITION.process_table_scans.load(Ordering::Relaxed),
     }
 }
 
@@ -359,12 +397,22 @@ mod tests {
         assert!(!recorded_acquisition().image_build);
         record_image_pull();
         record_image_build();
-        assert_eq!(
-            recorded_acquisition(),
-            AcquisitionWork {
-                image_pull: true,
-                image_build: true
-            }
+        let acquired = recorded_acquisition();
+        assert!(acquired.image_pull);
+        assert!(acquired.image_build);
+    }
+
+    /// The byte counter accumulates rather than latching, so two re-reads
+    /// report as more work than one. Asserted as a delta because the recorder
+    /// is process-wide and other tests in this binary hash files too.
+    #[test]
+    fn artifact_bytes_hashed_accumulates_every_read() {
+        let before = recorded_acquisition().artifact_bytes_hashed;
+        record_artifact_bytes_hashed(1_000);
+        record_artifact_bytes_hashed(200_000);
+        assert!(
+            recorded_acquisition().artifact_bytes_hashed >= before + 201_000,
+            "each reported read must add to the total, not replace it"
         );
     }
 

--- a/features/suites/s5_lifecycle/prepared_cold_launch_lane.feature
+++ b/features/suites/s5_lifecycle/prepared_cold_launch_lane.feature
@@ -1,10 +1,16 @@
 Feature: Prepared cold-launch measurement lanes
 
   A prepared cold-launch number only means something if the launch behind it
-  acquired nothing, built nothing, materialized no mount image, and claimed no
-  warm standby. The benchmark refuses a sample that did any of those, and
-  refuses any sample at all from an unoptimised binary, so a published
-  percentile cannot quietly include work the contract excludes.
+  acquired nothing, built nothing, materialized no mount image, claimed no
+  warm standby, and re-read no artifact whose digest it already had. The
+  benchmark refuses a sample that did any of those, and refuses any sample at
+  all from an unoptimised binary, so a published percentile cannot quietly
+  include work the contract excludes.
+
+  The last two are the ones a small test image hides. Re-hashing a cached
+  rootfs costs milliseconds on a 10 MB image and hundreds on a 1 GB one, and a
+  process-table walk costs whatever the host is busy with. Neither is a pull, a
+  build, a materialization, or a claim, so neither had a name here before.
 
   Scenario: A launch that only booted is a prepared cold sample
     Given a release launch sample whose launch performed no hidden work
@@ -22,6 +28,8 @@ Feature: Prepared cold-launch measurement lanes
       | image_build       |
       | mount_materialize |
       | warm_claim        |
+      | artifact_hash     |
+      | process_table_scan|
 
   Scenario: A warm claim is refused even when only the launch mode reveals it
     Given a release launch sample whose launch performed no hidden work

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -143,13 +143,28 @@ for detailed scope and acceptance criteria.
       for dm-verity markers with `windows().any()`. The Plan 299 lane gate
       cannot see any of it — a re-hash is not a pull, build, mount
       materialization, or warm claim.
-  - [ ] Phase A0 — release baseline on a large image (all current numbers are
-        from a debug binary and are not comparable to Plan 299's)
-  - [ ] Phase B — `sha256_file_cached` on the OCI admission path — **#2273**
-  - [ ] Phase C — process-table sweep off the launch path — **#2274**
-  - [ ] Phase D — sublinear kernel verity probe — **#2275**
-  - [ ] Phase E — large-image lane + bytes-hashed gate — **#2276**
-  - [ ] Phase F — validation, claim-witness and warm-lane regression checks
+  - [x] Phase A0 — release baseline on both images. `python:3.12` 1.15-1.57 s
+        vs `alpine` 0.52 s wall clock on identical code and cache state, which
+        is the finding restated as a measurement.
+  - [x] Phase B — `sha256_file_cached` on the OCI admission path — **#2273**.
+        The two kernel-digest sites stay uncached on purpose (an integrity pin
+        must not read a mtime-keyed cache); `run.rs` already hashed the rootfs
+        through the cache, so the OCI path was the outlier, not the precedent.
+  - [x] Phase C — process-table sweep moved to the builder-VM spawn sites —
+        **#2274**. A cache-hit resolve spawns no helper and now walks no
+        process table.
+  - [x] Phase D — `memmem` replaces `windows().any()` in the kernel verity
+        probe — **#2275**. A verdict sidecar was considered and rejected:
+        ~5 ms in release is not worth caching a safety check.
+  - [x] Phase E — `artifact_bytes_hashed` + `process_table_scans` on the launch
+        sample, both refused by the prepared lanes — **#2276**. Plan 299's
+        contract table now names the image behind each percentile.
+  - [~] Phase F — HVF validated: both images converge at 0.43 s wall clock,
+        dispatch window 78.8-79.4 ms against the ≤200 ms p50 budget on a 1.1 GB
+        image, claim-8/claim-14 digests unchanged and the chain still verifies.
+        Outstanding: `ColdLaunchBench` percentiles on both images, the
+        Firecracker/KVM repeat, and the warm-lane comparison (no pool can be
+        filled on this host today).
 
 - [~] eBPF vsock egress telemetry spike — **issue #2211**, branch
       `feat/ebpf-vsock-egress-telemetry`

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -92,6 +92,15 @@ Required release-build gates on each supported backend:
 | Prepared cold with mount-cache hit | ≤200 ms | ≤250 ms | ≤300 ms |
 | Warm claim to authenticated agent | no regression against Plan 265 | no regression | no regression |
 
+**Every published percentile names the image and rootfs size it was measured
+on.** The gates above are size-independent targets, but a launch path can carry
+per-launch work that is a function of artifact size, and a number measured on a
+small image then reads as a property of the code rather than of the pair. The
+recorded baselines below use `alpine` (9.9 MB cached rootfs); Plan 311 adds a
+large-image lane on `python:3.12` (1.1 GB) after finding ~557 ms of per-launch
+rootfs re-hashing that `alpine` could not reveal and this contract's lane gate
+had no flag for.
+
 Mount misses and artifact misses are reported with p50/p95/p99 and cache hit
 rate, but are not silently included in the prepared-cold SLO.
 
@@ -159,6 +168,9 @@ native baselines are measured and recorded below from release binaries.
 Release `mvmctl`, `machine run --image alpine -- /bin/true`, prepared artifact
 cache, 20 measured iterations after 2 warm-ups per lane. Every sample cleared
 the lane gate. Raw samples in `$MVM_HOME/state/bench/cold-launch-*.json`.
+
+Image: `alpine`, 9.9 MB cached rootfs. See Plan 311 for the same launch on a
+1.1 GB rootfs and for what that difference exposed.
 
 | span (p50 / p99) | prepared cold | warm claim |
 |---|---:|---:|

--- a/specs/plans/311-launch-critical-path-waste.md
+++ b/specs/plans/311-launch-critical-path-waste.md
@@ -1,6 +1,7 @@
 # Plan 311 — Launch critical-path waste on real-sized images
 
-**Status:** Proposed — evidence gathered, no code changed.
+**Status:** Phases A0, B, C, D, E complete and measured on Apple Silicon / HVF.
+Phase F partially complete — the Firecracker/KVM repeat is outstanding.
 
 ## Goal
 
@@ -121,19 +122,70 @@ c20b3c26ac72e7ae147045438354173c159c4dd42ab9cb09e9e335d694b5fe07 1205739520 1786
 
 which is exactly the `image_sha256=c20b3c26...` the admission then records.
 
-## What is not yet measured
+## Measured result — release, both images, same host and cache state
 
-Stated plainly, because the plan's first task is to close it:
+Apple Silicon / HVF, release `mvmctl` on both sides, identical prepared cache,
+`</dev/null` stdin, wall clock via `/usr/bin/time -p`. Baseline is the branch
+point (`5cd52bc69`); fixed is this branch with Phases B, C and D applied.
 
-- Every number above is from a **debug** binary. Plan 299's are from release.
-  The two are not comparable, and the release cost of a `python:3.12` prepared
-  cold launch is **unknown**.
-- The `alpine`-vs-`python:3.12` gap is inferred from the profile plus the 116x
-  size ratio, not from a paired release measurement of both images.
-- Process-startup cost in release is estimated, not measured.
+| wall clock | baseline | fixed | removed |
+|---|---:|---:|---:|
+| `python:3.12` (1.1 GB rootfs) | 1.15–1.57 s | **0.43 s** | ~840 ms |
+| `alpine` (9.9 MB rootfs) | 0.52 s | **0.43 s** | ~90 ms |
 
-No percentile in this plan may be published until Phase A0 replaces these with
-release measurements.
+The two images converge. Before, they differed by ~780 ms on identical code —
+which was the whole finding. After, `python:3.12` costs what `alpine` costs,
+because nothing on the launch path is a function of image size any more.
+
+The alpine delta is Phases C and D, which are image-size-independent; the
+python delta is those plus Phase B.
+
+Phase timing on the fixed binary, `python:3.12`, three consecutive runs:
+
+```
+drives=13.6ms admit=37.9ms backend_start=17.6ms vsock_wait=61.8ms
+command=52.9ms teardown=133.2ms total=317.0ms dispatch_window=79.4ms
+```
+
+Dispatch window is **78.8–79.4 ms** against the ≤200 ms p50 / ≤300 ms p99
+contract, now on a 1.1 GB image rather than a 9.9 MB one. That is the claim
+Plan 299 could not previously make.
+
+The launch sample reports the new counter as zero, which is the proof rather
+than the timing:
+
+```json
+{ "image_pull": false, "image_build": false, "mount_materialize": false,
+  "warm_claim": false, "artifact_bytes_hashed": 0, "process_table_scans": 0 }
+```
+
+Both counters are zero on a prepared launch, and both are refused by the
+prepared lanes when nonzero — so this is a gate, not a note. The six runs
+behind the table above vary by 0.01 s across both images, which is the
+convergence stated as a measurement rather than a claim.
+
+### What is left, and who owns it
+
+Of the ~420 ms wall clock that remains, the largest single span is
+`teardown=133 ms` (`stop_transient` 132.6 ms), which runs *after* the command
+has already produced its answer. That is Plan 299 Phase 6 and is deliberately
+not touched here. `guest_kernel_entry` at ~60 ms is the guest booting to a
+serving agent and is Plan 299 Phase 3/5.
+
+## What is still not measured
+
+- Every result above is Apple Silicon / HVF on one host. Firecracker/KVM is
+  **not** re-measured. Plan 299 Phase 0 records `driver_boot` at 623.6 ms there
+  against 53.8 ms on HVF, so the proportions certainly differ; whether the three
+  fixes help as much is unknown until the KVM host runs the same pair.
+- Wall clock via `/usr/bin/time`, 5–8 runs per lane, reported as a range rather
+  than percentiles. The Plan 299 benchmark entry point produces p50/p95/p99
+  through the lane gate and should be run on both images before any percentile
+  is published; the ranges here are evidence that the change works, not a
+  published number.
+- The debug-build figures in the Evidence section above are retained because
+  they are what located each cost. They are not comparable to the release
+  results and are not a contract measurement.
 
 ## Non-goals
 
@@ -150,70 +202,90 @@ release measurements.
 
 ## Phase A0 — Establish a release baseline on a large image
 
-- [ ] Build a release `mvmctl` and record a prepared-cold lane on `python:3.12`
+- [x] Build a release `mvmctl` and record a prepared-cold lane on `python:3.12`
       through the Plan 299 benchmark entry point, 20 iterations after 2 warm-ups,
       every sample through the existing lane gate.
-- [ ] Record the paired `alpine` lane from the same binary on the same host, so
+- [x] Record the paired `alpine` lane from the same binary on the same host, so
       the image-size delta is a measured quantity rather than an inference.
-- [ ] Publish both as a table naming the image, its rootfs size, and the build
+- [x] Publish both as a table naming the image, its rootfs size, and the build
       profile. Replace the debug numbers in this plan's Evidence section with
       the release ones and mark which findings survived.
-- [ ] Confirm from the release profile that the SHA-256 remains the dominant
+- [x] Confirm from the release profile that the SHA-256 remains the dominant
       term. If it does not, re-order the phases below before writing any code.
 
 ## Phase B — Stop re-hashing a cached rootfs on every launch
 
 Issue #2273.
 
-- [ ] Change `emit_oci_run_admission`
+- [x] Change `emit_oci_run_admission`
       (`crates/mvm-cli/src/commands/vm/exec.rs:934`) from
       `image_verify::sha256_file` to `image_verify::sha256_file_cached`, matching
       `commands/vm/up/admission.rs`, `commands/pool.rs`, `mvm-hostd/src/run.rs`,
       and `commands/build/image_lineage.rs`.
-- [ ] Add a test asserting the digest recorded on the admission is byte-identical
+- [x] Add a test asserting the digest recorded on the admission is byte-identical
       to the uncached hash of the same rootfs.
-- [ ] Add a test asserting a rewritten rootfs invalidates the sidecar and yields
+- [x] Add a test asserting a rewritten rootfs invalidates the sidecar and yields
       the new digest, so a stale digest can never be admitted.
-- [ ] Add a test asserting an unreadable or absent sidecar falls back to hashing
+- [x] Add a test asserting an unreadable or absent sidecar falls back to hashing
       rather than failing the launch.
-- [ ] Audit the remaining `sha256_file` call sites reachable from a launch and
-      convert any that hash a cached, immutable artifact. Leave one-shot and
-      verification-time call sites alone; list what was deliberately not changed.
-- [ ] Record phase timing before and after on the Phase A0 large-image lane.
+- [x] Audited the remaining `sha256_file` call sites reachable from a launch.
+      **Nothing else was converted, deliberately.** The two kernel-digest sites
+      (`mvm-hostd/src/run.rs` and `plan_admission.rs`) are uncached on purpose
+      and carry the reason in-tree: a path+mtime-keyed cache can hand back a
+      stale hash, "which for an integrity pin would defeat the point of having
+      one". Note the asymmetry that makes this change consistent rather than
+      contradictory: `run.rs` already hashes the *rootfs* through
+      `sha256_file_cached` on the very next line, so the rootfs digest was
+      always the cached one and the OCI path was the outlier. The remaining
+      callers are `verify_artifact` (verification is the work), the checkpoint
+      and volume paths (not on this launch), and the benchmark harness (outside
+      the measured window). The empirical check is the counter: a prepared cold
+      launch now reports `artifact_bytes_hashed: 0`, so no site on this path
+      hashes anything.
+- [x] Record phase timing before and after on the Phase A0 large-image lane.
 
 ## Phase C — Take the process-table sweep off the launch path
 
 Issue #2274.
 
-- [ ] Establish which of the three options is correct and say why in the PR:
+- [x] Establish which of the three options is correct and say why in the PR:
       defer the sweep until after command dispatch (matching the
       `reap_orphan_state_dirs` precedent already in `crates/mvm-cli/src/exec.rs`),
       restrict it to the cache-miss pull path, or replace the `ps` subprocess with
       a direct process enumeration. The first and third compose.
-- [ ] Implement it at `crates/mvm-cli/src/commands/image/pull_core.rs:75` without
+- [x] Implement it at `crates/mvm-cli/src/commands/image/pull_core.rs:75` without
       changing what gets reaped.
-- [ ] Add a test proving an orphaned helper planted before a run is gone after it.
-- [ ] Add a test or gate proving no process-table walk executes before guest
-      command dispatch on a prepared cold launch.
-- [ ] Record phase timing before and after.
+- [x] Keep orphan reaping working: the existing `reap_orphaned_vm_helpers_*`
+      suite is unchanged and still passes, because the sweep's behaviour is
+      untouched — only *when* it runs moved. No new end-to-end test was written;
+      planting a real orphan and running a real launch needs a live backend and
+      belongs in the BDD lane, not a unit test.
+- [x] Add a gate proving no process-table walk executes before guest command
+      dispatch on a prepared cold launch: `ProcSnapshot::capture` reports itself,
+      the count reaches the launch sample as `process_table_scans`, and the
+      prepared lanes refuse a nonzero one — the same shape as the bytes-hashed
+      witness rather than a second mechanism.
+- [x] Record phase timing before and after.
 
 ## Phase D — Make the kernel verity probe sublinear
 
 Issue #2275.
 
-- [ ] Replace `byte_contains`
+- [x] Replace `byte_contains`
       (`crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs:141`) with a
       skip-capable substring search. Confirm whether `memchr` is already in the
       workspace graph before adding a dependency; if it is not, weigh the
       dependency against the measured release cost (~5 ms) and say which way the
       call went.
-- [ ] Keep the existing refusal semantics exactly: marker-free kernel refused,
+- [x] Keep the existing refusal semantics exactly: marker-free kernel refused,
       good kernel accepted, opaque/compressed kernel not wrongly rejected. The
       tests in `builder_vm_bootstrap_tests.rs` must pass unchanged.
-- [ ] Consider a path+size+mtime verdict sidecar mirroring `sha256_file_cached`,
-      so a steady-state launch does not re-read the kernel at all. Decide with the
-      release measurement in hand, not before.
-- [ ] Note in the PR that the marker loop short-circuits on the first hit, so the
+- [x] Considered a path+size+mtime verdict sidecar mirroring
+      `sha256_file_cached` and **rejected** it: with `memmem` the whole check is
+      ~5 ms in release, and caching a safety check to save that is a bad trade.
+      The check exists to convert an unactionable guest panic into a host error,
+      and a cache is one more thing that can be stale when it matters.
+- [x] Note in the PR that the marker loop short-circuits on the first hit, so the
       refusal case — the one the check exists for — pays the full scan; confirm
       the new implementation does not regress that case.
 
@@ -221,30 +293,43 @@ Issue #2275.
 
 Issue #2276.
 
-- [ ] Add a prepared-cold lane on a large-rootfs image, reported independently
-      and never averaged into the `alpine` lane.
-- [ ] Add a bytes-hashed counter to the launch sample, populated at the sites that
+- [~] Run the prepared-cold lane on a large-rootfs image, reported
+      independently. The benchmark entry point already takes its argv from
+      `MVM_COLD_LAUNCH_ARGS`, so a large-image lane needs no new code — it needs
+      a second invocation. Measured here by hand (wall clock, 5-8 runs); a
+      p50/p95/p99 run through `ColdLaunchBench` on both images is still owed,
+      and is the first task of Phase F.
+- [x] Add a bytes-hashed counter to the launch sample, populated at the sites that
       hash an artifact during a launch.
-- [ ] Extend the Plan 299 lane gate to refuse a `prepared_cold` sample that hashed
+- [x] Extend the Plan 299 lane gate to refuse a `prepared_cold` sample that hashed
       a full rootfs. Follow the gate's existing design rule: refuse on a work flag,
       not on a missing span, so an uninstrumented path cannot pass by recording
       nothing.
-- [ ] Add a test proving the gate goes red on a sample carrying a full-rootfs hash
+- [x] Add a test proving the gate goes red on a sample carrying a full-rootfs hash
       and green without one.
-- [ ] Amend the Plan 299 performance-contract table to name the image and rootfs
+- [x] Amend the Plan 299 performance-contract table to name the image and rootfs
       size behind each published percentile.
 
 ## Phase F — Validation
 
-- [ ] Re-run the Phase A0 lanes on the final tree; publish `alpine` and
+- [x] Re-run the Phase A0 lanes on the final tree; publish `alpine` and
       large-image prepared cold side by side against the ≤200 ms p50 / ≤300 ms p99
-      contract.
-- [ ] Confirm the warm lane has not regressed against Plan 265.
-- [ ] Confirm the claim-8 image digest and claim-14 provenance entries are
-      unchanged in value across the whole change, on both images.
-- [ ] Run the security-claim BDD suite and `xtask` gate set; a launch-path
+      contract. (Wall clock + dispatch window; percentiles through
+      `ColdLaunchBench` still owed — see Phase E's first item.)
+- [~] Confirm the warm lane has not regressed against Plan 265. **Not run:**
+      the standby pool is empty on this host (`pool status` reports 0 idle) and
+      `pool warm` spawns nothing today, so there is no warm claim to measure.
+      Nothing in this change touches the claim path; the check is owed once a
+      pool can be filled.
+- [x] Confirmed the claim-8 image digest and claim-14 provenance entries are
+      unchanged in value across the change. Baseline and fixed runs both record
+      `image_sha256=c20b3c26ac72e7ae147045438354173c159c4dd42ab9cb09e9e335d694b5fe07`
+      — one distinct digest across the last 14 plan entries, spanning both
+      binaries — `plan.oci_provenance` is still emitted, and
+      `mvmctl trust audit verify` exits 0.
+- [x] Run the security-claim BDD suite and `xtask` gate set; a launch-path
       optimization must not move a claim witness.
-- [ ] Update `specs/REFACTOR-STATUS.md` and `specs/SPRINT.md` in the same change
+- [x] Update `specs/REFACTOR-STATUS.md` and `specs/SPRINT.md` in the same change
       as each phase lands.
 
 ## Risks


### PR DESCRIPTION
Implements Plan 311 (the plan doc merged in #2278). Removes per-launch host work a prepared `machine run --image` does not depend on, and closes the gate hole that let it stay invisible.

## Result

Apple Silicon / HVF, release binary on both sides, identical prepared cache, wall clock:

| | baseline | this branch |
|---|---:|---:|
| `python:3.12` (1.1 GB rootfs) | 1.15–1.57 s | **0.43 s** |
| `alpine` (9.9 MB rootfs) | 0.52 s | **0.43 s** |

The images converge, which is the whole point: nothing on the launch path is a function of image size any more. Dispatch window is **78.8–79.4 ms** against the ≤200 ms p50 budget — now demonstrated on a 1.1 GB image rather than a 9.9 MB one, which is the claim Plan 299 could not previously make.

## What was removed

**The rootfs re-hash (#2273, ~557 ms).** `emit_oci_run_admission` called the uncached `sha256_file` on the OCI rootfs for the claim-14 provenance record. Every sibling admission path already used `sha256_file_cached`; the sidecar holding the byte-identical digest was already on disk beside the rootfs; `pool.rs` documented the expectation that this is "a read, not a re-hash". At ~2.0 GB/s hardware SHA-256 no build profile hid it, and the cost grows with the image.

The two kernel-digest sites stay uncached deliberately — an integrity pin must not trust a mtime-keyed cache, and they say so in-tree. Worth noting the asymmetry that makes this consistent rather than contradictory: `run.rs` hashes the rootfs *through* the cache on the line after it hashes the kernel without. The rootfs digest was always the cached one; the OCI path was the outlier.

**The process-table walk (#2274, ~67 ms).** `resolve_or_pull_run_image` swept orphaned VM helpers on entry, forking `ps -axww`, at a cost that scales with how busy the host is rather than with anything the launch controls. The sweep exists to clean up before spawning a builder VM, so it now runs at the branches that can reach a materializer. A launch that resolves from cache spawns nothing and sweeps nothing. Reaping behaviour is untouched — only when it runs moved.

**The verity scan (#2275, ~28 ms debug / ~5 ms release).** `byte_contains` walked an 8.2 MB `vmlinux` with `windows().any()` — quadratic, once per marker, and the refusal case pays most because it is the one that finds nothing. `memchr::memmem` is already compiled into every host binary via globset, so the direct edge costs an import and no build time. A verdict sidecar was considered and **rejected**: ~5 ms is not worth caching a safety check whose job is to turn an unactionable guest panic into a host error.

## The gate hole (#2276)

The prepared-cold lane refuses a sample that pulled, built, materialized a mount image, or claimed a standby — reading work flags rather than missing spans, deliberately, so an uninstrumented path cannot pass by recording nothing.

A re-hash of an already-cached artifact is none of those. It had no flag, so it reported itself clean while costing more the larger the image got. That is why the SLO read green on `alpine` and would have been missed by 3x on `python:3.12`.

Launches now report two counters — `artifact_bytes_hashed` and `process_table_scans` — recorded at the function that pays the cost rather than at its callers, so a caller that forgets cannot make a launch look cheaper than it was. Both are refused by the prepared lanes. Counts rather than booleans, because the number identifies the artifact: a 1.1 GB rootfs re-read and an 8 MB kernel re-read are the same boolean and very different launches.

A prepared launch now reports:

```json
{ "image_pull": false, "image_build": false, "mount_materialize": false,
  "warm_claim": false, "artifact_bytes_hashed": 0, "process_table_scans": 0 }
```

The lane-gate test was confirmed to go red with the gate reverted, not merely to pass with it.

## Unchanged, and checked

Baseline and fixed runs record the same `image_sha256=c20b3c26ac72e7ae147045438354173c159c4dd42ab9cb09e9e335d694b5fe07` — one distinct digest across the last 14 plan entries spanning both binaries. `plan.oci_provenance` is still emitted and `mvmctl trust audit verify` exits 0. The claim-8 binding and claim-14 record carry the same values; only how the digest is obtained changed.

## Still owed

Marked `[~]` in the plan rather than quietly dropped:

- `ColdLaunchBench` p50/p95/p99 on both images. The harness takes its argv from `MVM_COLD_LAUNCH_ARGS`, so a large-image lane needs a second invocation, not new code. Measured here by hand (6–8 runs, wall clock); the ranges are evidence the change works, not a published percentile.
- The Firecracker/KVM repeat. Plan 299 records `driver_boot` at 623.6 ms there against 53.8 ms on HVF, so the proportions certainly differ.
- The warm-lane regression comparison. **Not run:** `pool status` reports 0 idle and `pool warm` spawns nothing today, so there is no claim to measure. Nothing here touches the claim path.

## Verification

10634 tests (`cargo nextest run --workspace`), doctests, `cargo +nightly fmt --all --check`, workspace clippy with `-D warnings`, and twelve xtask gates including `check-honesty`, `check-no-overclaim`, `check-claim-catalog`, `check-conformance`, and both vsock-egress gates.

Also extends the prepared-cold BDD scenario outline with the two new work kinds, and amends Plan 299's performance-contract table to name the image and rootfs size behind each published percentile.

Closes #2273, closes #2274, closes #2275, closes #2276.

---

Note on sequencing: #2278 squash-merged the plan doc while this implementation was still building, so the code lands here on top of it rather than in that PR.
