### PR TITLE
feat: add typed agent capability bindings

### DIFF
--- a/crates/mvm-agentd/src/broker_client.rs
+++ b/crates/mvm-agentd/src/broker_client.rs
@@ -25,7 +25,11 @@
 
 use std::os::unix::net::UnixStream;
 
-use mvm_core::protocol::broker::{ServiceCall, ServiceErrorCode, ServiceResponse};
+use mvm_contract::protocol::agent_capability::{CapabilityBinding, CapabilityInvocation};
+use mvm_contract::protocol::agent_session::AgentRequestId;
+use mvm_core::protocol::broker::{
+    CorrelationId, ServiceCall, ServiceErrorCode, ServiceId, ServiceResponse,
+};
 
 use crate::vsock::{BROKER_PORT, connect_host_vsock, read_frame, write_frame};
 
@@ -73,11 +77,39 @@ pub fn broker_call(
     call(&mut stream, request)
 }
 
+/// Build and exchange one exact typed capability invocation over an existing
+/// broker stream. The payload is serialized once for the wire and its digest
+/// is bound into the invocation metadata.
+pub fn capability_call<T: serde::Serialize>(
+    stream: &mut UnixStream,
+    service: ServiceId,
+    verb: impl Into<String>,
+    binding: CapabilityBinding,
+    invocation_id: AgentRequestId,
+    payload: T,
+) -> Result<serde_json::Value, BrokerError> {
+    let payload = serde_json::to_value(payload)
+        .map_err(|error| BrokerError::Transport(anyhow::anyhow!(error)))?;
+    let invocation = CapabilityInvocation::from_payload(binding, invocation_id.clone(), &payload)
+        .map_err(|error| BrokerError::Transport(anyhow::anyhow!(error)))?;
+    let request = ServiceCall {
+        service,
+        verb: verb.into(),
+        correlation_id: CorrelationId::new(format!("agent-capability-{invocation_id}")),
+        payload,
+        capability: Some(invocation),
+    };
+    call(stream, &request)
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Write;
     use std::thread;
 
+    use mvm_contract::protocol::agent_capability::{
+        CapabilityDescriptor, CapabilityId, CapabilityLimits, SchemaRef, payload_digest,
+    };
     use mvm_core::protocol::broker::{CorrelationId, ServiceId};
 
     use super::*;
@@ -88,6 +120,7 @@ mod tests {
             verb: "now".into(),
             correlation_id: CorrelationId::new("01HGUEST0000000000000000"),
             payload: serde_json::json!({}),
+            capability: None,
         }
     }
 
@@ -113,6 +146,53 @@ mod tests {
 
         let payload = call(&mut client, &sample_call()).expect("ok call must succeed");
         assert_eq!(payload, serde_json::json!({"wall_ms": 1717000000000_u64}));
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn capability_call_binds_the_payload_digest_into_the_envelope() {
+        let (mut client, mut server) = UnixStream::pair().unwrap();
+        let descriptor = CapabilityDescriptor::builder()
+            .id(CapabilityId::new(ServiceId::parse("host.dev.echo.v1").unwrap(), "echo").unwrap())
+            .description("echo a bounded value")
+            .input_schema(SchemaRef::new("echo.input.v1", [1; 32]).unwrap())
+            .output_schema(SchemaRef::new("echo.output.v1", [2; 32]).unwrap())
+            .limits(CapabilityLimits::new(128, 128, 100).unwrap())
+            .build()
+            .unwrap();
+        let binding = descriptor.binding();
+        let request_id = AgentRequestId::parse("typed-client-request-1").unwrap();
+        let payload = serde_json::json!({"value": "bounded"});
+        let expected_digest = payload_digest(&payload);
+        let expected_binding = binding.clone();
+        let expected_request_id = request_id.clone();
+
+        let handle = thread::spawn(move || {
+            let got: ServiceCall = read_frame(&mut server).unwrap();
+            let invocation = got.capability.expect("typed invocation must be present");
+            assert_eq!(invocation.binding, expected_binding);
+            assert_eq!(invocation.invocation_id, expected_request_id);
+            assert_eq!(invocation.input_digest, expected_digest);
+            write_frame(
+                &mut server,
+                &ServiceResponse::Ok {
+                    correlation_id: got.correlation_id,
+                    payload: serde_json::json!({"ok": true}),
+                },
+            )
+            .unwrap();
+        });
+
+        let result = capability_call(
+            &mut client,
+            ServiceId::parse("host.dev.echo.v1").unwrap(),
+            "echo",
+            descriptor.binding(),
+            AgentRequestId::parse("typed-client-request-1").unwrap(),
+            payload,
+        )
+        .expect("typed call must succeed");
+        assert_eq!(result, serde_json::json!({"ok": true}));
         handle.join().unwrap();
     }
 

--- a/crates/mvm-agentd/src/host_audit.rs
+++ b/crates/mvm-agentd/src/host_audit.rs
@@ -118,6 +118,7 @@ fn build_call<T: serde::Serialize>(verb: &str, payload: &T) -> Result<ServiceCal
         verb: verb.to_string(),
         correlation_id: next_correlation_id(),
         payload,
+        capability: None,
     })
 }
 

--- a/crates/mvm-agentd/src/host_cost.rs
+++ b/crates/mvm-agentd/src/host_cost.rs
@@ -114,6 +114,7 @@ fn build_call(verb: &str) -> ServiceCall {
         verb: verb.to_string(),
         correlation_id: next_correlation_id(),
         payload: serde_json::json!({}),
+        capability: None,
     }
 }
 

--- a/crates/mvm-agentd/src/host_time.rs
+++ b/crates/mvm-agentd/src/host_time.rs
@@ -87,6 +87,7 @@ fn build_call() -> ServiceCall {
         verb: "now".to_string(),
         correlation_id: next_correlation_id(),
         payload: serde_json::json!({}),
+        capability: None,
     }
 }
 

--- a/crates/mvm-conformance/tests/steps/agent_capability.rs
+++ b/crates/mvm-conformance/tests/steps/agent_capability.rs
@@ -1,0 +1,103 @@
+//! BDD witnesses for typed capability descriptor and binding invariants.
+
+use cucumber::{given, then, when};
+use mvm_contract::protocol::agent_capability::{
+    CapabilityAuditEvent, CapabilityDescriptor, CapabilityFailureCode, CapabilityId,
+    CapabilityInvocation, CapabilityLimits, SchemaRef,
+};
+use mvm_contract::protocol::agent_session::AgentRequestId;
+use mvm_contract::protocol::broker::ServiceId;
+
+use crate::world::CliWorld;
+
+fn descriptor() -> CapabilityDescriptor {
+    CapabilityDescriptor::builder()
+        .id(CapabilityId::new(
+            ServiceId::parse("host.dev.echo.v1").expect("valid BDD service"),
+            "echo",
+        )
+        .expect("valid BDD capability"))
+        .description("echo a bounded structured value")
+        .input_schema(SchemaRef::new("host.dev.echo.input.v1", [1; 32]).expect("valid schema"))
+        .output_schema(SchemaRef::new("host.dev.echo.output.v1", [2; 32]).expect("valid schema"))
+        .limits(CapabilityLimits::new(1024, 1024, 100).expect("valid limits"))
+        .build()
+        .expect("valid descriptor")
+}
+
+#[given("an admitted typed echo capability")]
+fn admitted_typed_capability(world: &mut CliWorld) {
+    world.capability_descriptor = Some(descriptor());
+    world.capability_outcome = None;
+    world.capability_audit_json = None;
+}
+
+#[when(expr = "I create a typed invocation for the private value {string}")]
+fn create_typed_invocation(world: &mut CliWorld, value: String) {
+    let descriptor = world
+        .capability_descriptor
+        .as_ref()
+        .expect("the capability must be admitted first");
+    let payload = serde_json::json!({"value": value});
+    let invocation = CapabilityInvocation::from_payload(
+        descriptor.binding(),
+        AgentRequestId::parse("bdd-capability-request").expect("valid request id"),
+        &payload,
+    )
+    .expect("create typed invocation");
+    world.capability_outcome = Some(invocation.validate_payload(descriptor, &payload));
+    world.capability_invocation = Some(invocation.clone());
+    world.capability_audit_json = Some(
+        serde_json::to_string(&CapabilityAuditEvent::Invoked {
+            capability: descriptor.id.clone(),
+            descriptor_digest: descriptor.digest(),
+            invocation_id: invocation.invocation_id,
+            input_digest: invocation.input_digest,
+        })
+        .expect("serialize capability audit"),
+    );
+}
+
+#[then("the typed invocation is valid")]
+fn typed_invocation_is_valid(world: &mut CliWorld) {
+    assert_eq!(world.capability_outcome, Some(Ok(())));
+}
+
+#[then("the capability audit excludes the private value")]
+fn capability_audit_excludes_private_value(world: &mut CliWorld) {
+    let audit = world
+        .capability_audit_json
+        .as_ref()
+        .expect("the invocation must produce audit evidence");
+    assert!(!audit.contains("private credential"));
+    assert!(audit.contains("input_digest"));
+}
+
+#[when("I change the admitted descriptor limits")]
+fn change_descriptor_limits(world: &mut CliWorld) {
+    let descriptor = world
+        .capability_descriptor
+        .as_mut()
+        .expect("the capability must be admitted first");
+    descriptor.limits = CapabilityLimits::new(1024, 1024, 101).expect("valid changed limits");
+    let payload = serde_json::json!({"value": "bounded"});
+    let invocation = CapabilityInvocation::from_payload(
+        descriptor.binding(),
+        AgentRequestId::parse("bdd-capability-request-2").expect("valid request id"),
+        &payload,
+    )
+    .expect("create typed invocation");
+    let mut admitted_binding = descriptor.binding();
+    admitted_binding.descriptor_digest[0] ^= 1;
+    let mut downgraded = invocation;
+    downgraded.binding = admitted_binding;
+    world.capability_outcome = Some(downgraded.validate_payload(descriptor, &payload));
+}
+
+#[then("the typed invocation is refused for a binding mismatch")]
+fn typed_invocation_binding_mismatch(world: &mut CliWorld) {
+    assert_eq!(
+        world.capability_outcome,
+        Some(Err(CapabilityFailureCode::BindingMismatch))
+    );
+}

--- a/crates/mvm-conformance/tests/steps/mod.rs
+++ b/crates/mvm-conformance/tests/steps/mod.rs
@@ -1,6 +1,7 @@
 //! Step definitions, one module per scenario surface.
 
 mod admission_audit;
+mod agent_capability;
 mod agent_session;
 mod apple_container;
 mod claim;

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -360,6 +360,17 @@ pub struct CliWorld {
         Option<mvm_contract::protocol::agent_session::AgentSessionEventEnvelope>,
     /// Sanitized serialized history captured by a security assertion.
     pub agent_session_history_json: Option<String>,
+    /// Descriptor used by the typed capability BDD contract scenarios.
+    pub capability_descriptor:
+        Option<mvm_contract::protocol::agent_capability::CapabilityDescriptor>,
+    /// Invocation metadata used by the typed capability BDD scenarios.
+    pub capability_invocation:
+        Option<mvm_contract::protocol::agent_capability::CapabilityInvocation>,
+    /// Last typed capability validation outcome.
+    pub capability_outcome:
+        Option<Result<(), mvm_contract::protocol::agent_capability::CapabilityFailureCode>>,
+    /// Serialized digest-only capability audit event.
+    pub capability_audit_json: Option<String>,
     /// Typed policy evaluation used by the runtime-approval scenarios.
     pub approval_evaluation: Option<mvm_contract::policy::approval::PolicyEvaluation>,
     /// Durable approval ledger reconstructed from the agent-session journal.

--- a/crates/mvm-contract/src/protocol/agent_capability.rs
+++ b/crates/mvm-contract/src/protocol/agent_capability.rs
@@ -1,0 +1,483 @@
+//! Versioned host-mediated capability bindings for agent calls.
+//!
+//! A capability is a specific versioned service verb, not an arbitrary host
+//! function. The descriptor advertises stable schema identities and resource
+//! limits; the binding pins the descriptor digest that admission approved; an
+//! invocation carries only a bounded id and a digest of the existing payload.
+//! Payload bytes, credentials, and handler errors never enter the audit DTOs.
+
+use alloc::string::String;
+use core::fmt;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::agent_session::AgentRequestId;
+use super::broker::ServiceId;
+
+/// Current wire version for typed capability invocations.
+pub const AGENT_CAPABILITY_PROTOCOL_VERSION: u16 = 1;
+/// Maximum descriptor description length.
+pub const MAX_DESCRIPTION_BYTES: usize = 512;
+/// Maximum schema-name length.
+pub const MAX_SCHEMA_NAME_BYTES: usize = 128;
+/// Maximum accepted capability input or output size.
+pub const MAX_CAPABILITY_PAYLOAD_BYTES: u32 = 256 * 1024;
+/// Maximum handler execution time.
+pub const MAX_CAPABILITY_TIMEOUT_MS: u32 = 60_000;
+
+/// A versioned service verb that can be admitted independently.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CapabilityId {
+    /// Versioned host service identity.
+    pub service: ServiceId,
+    /// Verb within the versioned service.
+    pub verb: String,
+}
+
+impl CapabilityId {
+    /// Construct a validated capability identity.
+    pub fn new(service: ServiceId, verb: impl Into<String>) -> Result<Self, CapabilityError> {
+        let verb = verb.into();
+        if verb.is_empty() {
+            return Err(CapabilityError::EmptyVerb);
+        }
+        if verb.len() > MAX_SCHEMA_NAME_BYTES
+            || !verb.bytes().all(|byte| {
+                byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_' || byte == b'-'
+            })
+        {
+            return Err(CapabilityError::InvalidVerb);
+        }
+        Ok(Self { service, verb })
+    }
+}
+
+impl fmt::Display for CapabilityId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}::{}", self.service, self.verb)
+    }
+}
+
+/// A stable schema identity and digest. The schema document remains on the
+/// host/SDK side; only this bounded reference crosses the agent boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SchemaRef {
+    /// Stable schema name, including its schema version.
+    pub name: String,
+    /// SHA-256 of the canonical schema document.
+    pub digest: [u8; 32],
+}
+
+impl SchemaRef {
+    /// Construct a validated schema reference.
+    pub fn new(name: impl Into<String>, digest: [u8; 32]) -> Result<Self, CapabilityError> {
+        let name = name.into();
+        if name.is_empty() {
+            return Err(CapabilityError::EmptySchemaName);
+        }
+        if name.len() > MAX_SCHEMA_NAME_BYTES
+            || !name.bytes().all(|byte| {
+                byte.is_ascii_lowercase()
+                    || byte.is_ascii_digit()
+                    || matches!(byte, b'.' | b'_' | b'-')
+            })
+        {
+            return Err(CapabilityError::InvalidSchemaName);
+        }
+        Ok(Self { name, digest })
+    }
+}
+
+/// Resource bounds the host must enforce for one capability invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CapabilityLimits {
+    /// Maximum serialized input payload size.
+    pub max_input_bytes: u32,
+    /// Maximum serialized output payload size.
+    pub max_output_bytes: u32,
+    /// Maximum handler execution time.
+    pub timeout_ms: u32,
+}
+
+impl CapabilityLimits {
+    /// Construct bounds, rejecting zero and values above the protocol caps.
+    pub fn new(
+        max_input_bytes: u32,
+        max_output_bytes: u32,
+        timeout_ms: u32,
+    ) -> Result<Self, CapabilityError> {
+        if max_input_bytes == 0
+            || max_output_bytes == 0
+            || max_input_bytes > MAX_CAPABILITY_PAYLOAD_BYTES
+            || max_output_bytes > MAX_CAPABILITY_PAYLOAD_BYTES
+            || timeout_ms == 0
+            || timeout_ms > MAX_CAPABILITY_TIMEOUT_MS
+        {
+            return Err(CapabilityError::InvalidLimits);
+        }
+        Ok(Self {
+            max_input_bytes,
+            max_output_bytes,
+            timeout_ms,
+        })
+    }
+}
+
+/// Host-advertised metadata for one capability.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CapabilityDescriptor {
+    /// Exact service and verb identity.
+    pub id: CapabilityId,
+    /// Human-readable description with no credential or host-path content.
+    pub description: String,
+    /// Input schema reference.
+    pub input_schema: SchemaRef,
+    /// Output schema reference.
+    pub output_schema: SchemaRef,
+    /// Enforced execution and payload bounds.
+    pub limits: CapabilityLimits,
+}
+
+impl CapabilityDescriptor {
+    /// Begin descriptor construction.
+    pub fn builder() -> CapabilityDescriptorBuilder {
+        CapabilityDescriptorBuilder::default()
+    }
+
+    /// Digest the canonical serde representation used by admission binding.
+    #[must_use]
+    pub fn digest(&self) -> [u8; 32] {
+        let bytes = serde_json::to_vec(self)
+            .expect("capability descriptor contains only serializable fields");
+        Sha256::digest(bytes).into()
+    }
+
+    /// Produce the exact binding an admission record should carry.
+    #[must_use]
+    pub fn binding(&self) -> CapabilityBinding {
+        CapabilityBinding {
+            capability: self.id.clone(),
+            descriptor_digest: self.digest(),
+        }
+    }
+}
+
+/// Builder for the multi-field capability descriptor.
+#[derive(Debug, Default)]
+pub struct CapabilityDescriptorBuilder {
+    id: Option<CapabilityId>,
+    description: Option<String>,
+    input_schema: Option<SchemaRef>,
+    output_schema: Option<SchemaRef>,
+    limits: Option<CapabilityLimits>,
+}
+
+impl CapabilityDescriptorBuilder {
+    /// Set the capability identity.
+    pub fn id(mut self, id: CapabilityId) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    /// Set the public description.
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the input schema reference.
+    pub fn input_schema(mut self, schema: SchemaRef) -> Self {
+        self.input_schema = Some(schema);
+        self
+    }
+
+    /// Set the output schema reference.
+    pub fn output_schema(mut self, schema: SchemaRef) -> Self {
+        self.output_schema = Some(schema);
+        self
+    }
+
+    /// Set the execution and payload limits.
+    pub fn limits(mut self, limits: CapabilityLimits) -> Self {
+        self.limits = Some(limits);
+        self
+    }
+
+    /// Validate and build the descriptor.
+    pub fn build(self) -> Result<CapabilityDescriptor, CapabilityError> {
+        let description = self
+            .description
+            .ok_or(CapabilityError::MissingField("description"))?;
+        if description.is_empty() || description.len() > MAX_DESCRIPTION_BYTES {
+            return Err(CapabilityError::InvalidDescription);
+        }
+        Ok(CapabilityDescriptor {
+            id: self.id.ok_or(CapabilityError::MissingField("id"))?,
+            description,
+            input_schema: self
+                .input_schema
+                .ok_or(CapabilityError::MissingField("input_schema"))?,
+            output_schema: self
+                .output_schema
+                .ok_or(CapabilityError::MissingField("output_schema"))?,
+            limits: self.limits.ok_or(CapabilityError::MissingField("limits"))?,
+        })
+    }
+}
+
+/// Exact descriptor identity admitted for one workload.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CapabilityBinding {
+    /// Capability identity approved by admission.
+    pub capability: CapabilityId,
+    /// Digest of the complete descriptor approved by admission.
+    pub descriptor_digest: [u8; 32],
+}
+
+impl CapabilityBinding {
+    /// Check this binding against a host descriptor.
+    pub fn matches(&self, descriptor: &CapabilityDescriptor) -> bool {
+        self.capability == descriptor.id && self.descriptor_digest == descriptor.digest()
+    }
+}
+
+/// Typed invocation metadata carried alongside the existing broker payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CapabilityInvocation {
+    /// Version of this invocation contract.
+    pub protocol_version: u16,
+    /// Exact binding the caller claims to use.
+    pub binding: CapabilityBinding,
+    /// Bounded request identity used for replay refusal and audit joins.
+    pub invocation_id: AgentRequestId,
+    /// Digest of the `ServiceCall::payload` value.
+    pub input_digest: [u8; 32],
+}
+
+impl CapabilityInvocation {
+    /// Build a typed invocation and digest its payload without retaining it.
+    pub fn from_payload<T: Serialize>(
+        binding: CapabilityBinding,
+        invocation_id: AgentRequestId,
+        payload: &T,
+    ) -> Result<Self, CapabilityError> {
+        let bytes = serde_json::to_vec(payload).map_err(|_| CapabilityError::PayloadEncoding)?;
+        Ok(Self {
+            protocol_version: AGENT_CAPABILITY_PROTOCOL_VERSION,
+            binding,
+            invocation_id,
+            input_digest: Sha256::digest(bytes).into(),
+        })
+    }
+
+    /// Verify the invocation metadata and payload digest against a descriptor.
+    pub fn validate_payload<T: Serialize>(
+        &self,
+        descriptor: &CapabilityDescriptor,
+        payload: &T,
+    ) -> Result<(), CapabilityFailureCode> {
+        if self.protocol_version != AGENT_CAPABILITY_PROTOCOL_VERSION {
+            return Err(CapabilityFailureCode::ProtocolMismatch);
+        }
+        if !self.binding.matches(descriptor) {
+            return Err(CapabilityFailureCode::BindingMismatch);
+        }
+        let bytes = serde_json::to_vec(payload).map_err(|_| CapabilityFailureCode::InvalidInput)?;
+        if Sha256::digest(bytes) != self.input_digest {
+            return Err(CapabilityFailureCode::InputDigestMismatch);
+        }
+        Ok(())
+    }
+}
+
+/// Closed failure vocabulary safe to expose to an agent and to audit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum CapabilityFailureCode {
+    ProtocolMismatch,
+    NotRegistered,
+    AdmissionDenied,
+    BindingMismatch,
+    InputDigestMismatch,
+    InputTooLarge,
+    InvalidInput,
+    OutputTooLarge,
+    Timeout,
+    Canceled,
+    Replay,
+    HandlerFailed,
+}
+
+/// Digest-only evidence of capability lifecycle and invocation outcomes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum CapabilityAuditEvent {
+    Registered {
+        capability: CapabilityId,
+        descriptor_digest: [u8; 32],
+    },
+    Admitted {
+        capability: CapabilityId,
+        descriptor_digest: [u8; 32],
+    },
+    Invoked {
+        capability: CapabilityId,
+        descriptor_digest: [u8; 32],
+        invocation_id: AgentRequestId,
+        input_digest: [u8; 32],
+    },
+    Completed {
+        capability: CapabilityId,
+        invocation_id: AgentRequestId,
+        output_digest: [u8; 32],
+    },
+    Refused {
+        capability: CapabilityId,
+        invocation_id: Option<AgentRequestId>,
+        code: CapabilityFailureCode,
+    },
+    TimedOut {
+        capability: CapabilityId,
+        invocation_id: AgentRequestId,
+    },
+    Canceled {
+        capability: CapabilityId,
+        invocation_id: AgentRequestId,
+    },
+    Failed {
+        capability: CapabilityId,
+        invocation_id: AgentRequestId,
+        code: CapabilityFailureCode,
+    },
+}
+
+/// Contract construction and encoding errors.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum CapabilityError {
+    #[error("capability verb is empty")]
+    EmptyVerb,
+    #[error("capability verb is invalid")]
+    InvalidVerb,
+    #[error("schema name is empty")]
+    EmptySchemaName,
+    #[error("schema name is invalid")]
+    InvalidSchemaName,
+    #[error("capability limits are outside the supported bounds")]
+    InvalidLimits,
+    #[error("capability description is invalid")]
+    InvalidDescription,
+    #[error("capability descriptor is missing {0}")]
+    MissingField(&'static str),
+    #[error("capability payload could not be encoded")]
+    PayloadEncoding,
+}
+
+/// Digest a serialized output for a completion audit event.
+#[must_use]
+pub fn payload_digest<T: Serialize>(payload: &T) -> [u8; 32] {
+    let bytes = serde_json::to_vec(payload).expect("capability payload is serializable");
+    Sha256::digest(bytes).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn descriptor() -> CapabilityDescriptor {
+        CapabilityDescriptor::builder()
+            .id(CapabilityId::new(
+                ServiceId::parse("host.dev.echo.v1").expect("service id"),
+                "echo",
+            )
+            .expect("capability id"))
+            .description("echoes a bounded structured value")
+            .input_schema(SchemaRef::new("host.dev.echo.input.v1", [1; 32]).expect("schema"))
+            .output_schema(SchemaRef::new("host.dev.echo.output.v1", [2; 32]).expect("schema"))
+            .limits(CapabilityLimits::new(1024, 2048, 100).expect("limits"))
+            .build()
+            .expect("descriptor")
+    }
+
+    #[test]
+    fn descriptor_digest_binds_identity_schemas_and_limits() {
+        let descriptor = descriptor();
+        let binding = descriptor.binding();
+        assert!(binding.matches(&descriptor));
+
+        let mut changed = descriptor.clone();
+        changed.limits.timeout_ms = 101;
+        assert!(!binding.matches(&changed));
+    }
+
+    #[test]
+    fn invocation_round_trip_and_payload_digest_are_stable() {
+        let descriptor = descriptor();
+        let invocation = CapabilityInvocation::from_payload(
+            descriptor.binding(),
+            AgentRequestId::parse("request-1").expect("request id"),
+            &serde_json::json!({"value": 7}),
+        )
+        .expect("invocation");
+        invocation
+            .validate_payload(&descriptor, &serde_json::json!({"value": 7}))
+            .expect("valid payload");
+        let bytes = serde_json::to_vec(&invocation).expect("serialize");
+        let parsed: CapabilityInvocation = serde_json::from_slice(&bytes).expect("parse");
+        assert_eq!(parsed, invocation);
+    }
+
+    #[test]
+    fn binding_mismatch_and_input_tampering_fail_closed() {
+        let descriptor = descriptor();
+        let mut invocation = CapabilityInvocation::from_payload(
+            descriptor.binding(),
+            AgentRequestId::parse("request-2").expect("request id"),
+            &serde_json::json!({"value": 7}),
+        )
+        .expect("invocation");
+        invocation.input_digest = [9; 32];
+        assert_eq!(
+            invocation.validate_payload(&descriptor, &serde_json::json!({"value": 7})),
+            Err(CapabilityFailureCode::InputDigestMismatch)
+        );
+
+        let mut binding = descriptor.binding();
+        binding.descriptor_digest = [8; 32];
+        invocation.binding = binding;
+        assert_eq!(
+            invocation.validate_payload(&descriptor, &serde_json::json!({"value": 7})),
+            Err(CapabilityFailureCode::BindingMismatch)
+        );
+    }
+
+    #[test]
+    fn audit_event_does_not_contain_payload_bytes() {
+        let descriptor = descriptor();
+        let secret = "do-not-cross-boundary";
+        let event = CapabilityAuditEvent::Invoked {
+            capability: descriptor.id.clone(),
+            descriptor_digest: descriptor.digest(),
+            invocation_id: AgentRequestId::parse("request-3").expect("request id"),
+            input_digest: payload_digest(&secret),
+        };
+        let encoded = serde_json::to_string(&event).expect("serialize");
+        assert!(!encoded.contains(secret));
+        assert!(!encoded.contains("payload"));
+    }
+}

--- a/crates/mvm-contract/src/protocol/broker.rs
+++ b/crates/mvm-contract/src/protocol/broker.rs
@@ -155,6 +155,10 @@ pub struct ServiceCall {
     pub verb: String,
     pub correlation_id: CorrelationId,
     pub payload: serde_json::Value,
+    /// Optional typed capability metadata. Omitted for the established
+    /// service-call path so its serialized shape remains byte-compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability: Option<super::agent_capability::CapabilityInvocation>,
 }
 
 // ============================================================================
@@ -232,6 +236,22 @@ pub enum ServiceErrorCode {
     /// Catch-all for unexpected handler-internal errors. Never carries
     /// payload-derived information in the message.
     InternalError,
+    /// Typed capability admission refused the request.
+    CapabilityDenied,
+    /// Typed capability binding identity or descriptor digest did not match.
+    CapabilityBindingMismatch,
+    /// Typed capability protocol version is unsupported.
+    CapabilityProtocolMismatch,
+    /// Typed capability invocation id was already consumed.
+    CapabilityReplay,
+    /// Typed capability input exceeded its admitted bound.
+    CapabilityInputTooLarge,
+    /// Typed capability output exceeded its admitted bound.
+    CapabilityOutputTooLarge,
+    /// Typed capability invocation was canceled.
+    CapabilityCanceled,
+    /// Typed capability handler failed without exposing handler details.
+    CapabilityHandlerFailed,
 }
 
 // ============================================================================
@@ -336,6 +356,7 @@ mod tests {
             verb: "now".into(),
             correlation_id: CorrelationId::new("01HBROKER0000000000000000"),
             payload: serde_json::json!({}),
+            capability: None,
         };
         let bytes = serde_json::to_vec(&call).unwrap();
         let parsed: ServiceCall = serde_json::from_slice(&bytes).unwrap();

--- a/crates/mvm-contract/src/protocol/broker_control.rs
+++ b/crates/mvm-contract/src/protocol/broker_control.rs
@@ -30,6 +30,7 @@ use alloc::vec::Vec;
 
 use serde::{Deserialize, Serialize};
 
+use super::agent_capability::CapabilityBinding;
 use super::broker::ServiceId;
 
 /// Register a VM with the host-agent daemon: bind its `BROKER_PORT` listen
@@ -70,6 +71,10 @@ pub struct RegisterVm {
     /// implicitly available and need not be listed.
     #[serde(default)]
     pub services_bindings: Vec<ServiceId>,
+    /// Exact per-verb capability bindings approved for this workload. The
+    /// host-signed registration is the only source of this list.
+    #[serde(default)]
+    pub capability_bindings: Vec<CapabilityBinding>,
 }
 
 /// Deregister a VM at teardown: the daemon unbinds + drops its listen socket
@@ -138,6 +143,7 @@ mod tests {
             workload_chain_head_path: Some("/run/state/vm-1/audit-signer.head".into()),
             audit_signer_uds_path: Some("/run/state/vm-1/audit-signer.sock".into()),
             services_bindings: vec![ServiceId::parse("host.time.v1").unwrap()],
+            capability_bindings: vec![],
         })
     }
 

--- a/crates/mvm-contract/src/protocol/broker_control.rs
+++ b/crates/mvm-contract/src/protocol/broker_control.rs
@@ -73,7 +73,13 @@ pub struct RegisterVm {
     pub services_bindings: Vec<ServiceId>,
     /// Exact per-verb capability bindings approved for this workload. The
     /// host-signed registration is the only source of this list.
-    #[serde(default)]
+    ///
+    /// Skip-serialized when empty. `ControlRequest` is signed over its JCS
+    /// canonical bytes, so a field that serialized as `[]` on every
+    /// registration would change those bytes for workloads that bind no
+    /// capabilities — invalidating signatures produced before this field
+    /// existed. Omitting the empty case keeps them byte-identical.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub capability_bindings: Vec<CapabilityBinding>,
 }
 

--- a/crates/mvm-contract/src/protocol/mod.rs
+++ b/crates/mvm-contract/src/protocol/mod.rs
@@ -3,6 +3,7 @@
 //! transport I/O) stays in `mvm-core::protocol`, which re-exports these
 //! modules at their existing paths.
 
+pub mod agent_capability;
 pub mod agent_session;
 pub mod audit_signer;
 pub mod broker;

--- a/crates/mvm-core/src/protocol/broker_control.rs
+++ b/crates/mvm-core/src/protocol/broker_control.rs
@@ -127,6 +127,51 @@ mod tests {
         );
     }
 
+    /// An empty `capability_bindings` must vanish from the signed bytes
+    /// entirely rather than appear as `[]`.
+    ///
+    /// `ControlRequest` is signed over its JCS canonical bytes, so a field
+    /// that serialized on every registration would change the bytes for every
+    /// workload binding no capabilities — breaking signatures produced before
+    /// the field existed. The pin above covers the whole document; this
+    /// asserts the specific property directly, so a future edit that drops
+    /// `skip_serializing_if` fails with a message naming the cause instead of
+    /// a whole-string diff the reader has to decode.
+    #[test]
+    fn empty_capability_bindings_are_omitted_from_the_signed_bytes() {
+        let json = String::from_utf8(serde_jcs::to_vec(&sample_register()).unwrap()).unwrap();
+        assert!(
+            !json.contains("capability_bindings"),
+            "an empty capability binding set must be omitted, not serialized as []: {json}"
+        );
+    }
+
+    /// The converse: a non-empty binding set is carried in the signed bytes.
+    /// Without this, `skip_serializing_if` could be widened to always skip and
+    /// the test above would still pass while the host silently signed a
+    /// registration that authorized nothing.
+    #[test]
+    fn non_empty_capability_bindings_reach_the_signed_bytes() {
+        use mvm_contract::protocol::agent_capability::{CapabilityBinding, CapabilityId};
+
+        let mut req = sample_register();
+        if let ControlRequest::Register(ref mut r) = req {
+            r.capability_bindings = vec![CapabilityBinding {
+                capability: CapabilityId::new(
+                    mvm_contract::protocol::broker::ServiceId::parse("host.time.v1").unwrap(),
+                    "now",
+                )
+                .unwrap(),
+                descriptor_digest: [9u8; 32],
+            }];
+        }
+        let json = String::from_utf8(serde_jcs::to_vec(&req).unwrap()).unwrap();
+        assert!(
+            json.contains("capability_bindings"),
+            "a non-empty capability binding set must be signed over: {json}"
+        );
+    }
+
     #[test]
     fn sign_with_key_bytes_matches_sign() {
         let kb = [7u8; 32];

--- a/crates/mvm-core/src/protocol/broker_control.rs
+++ b/crates/mvm-core/src/protocol/broker_control.rs
@@ -100,6 +100,7 @@ mod tests {
             services_bindings: vec![
                 mvm_contract::protocol::broker::ServiceId::parse("host.time.v1").unwrap(),
             ],
+            capability_bindings: vec![],
         })
     }
 

--- a/crates/mvm-hostd/src/bin/mvm-broker.rs
+++ b/crates/mvm-hostd/src/bin/mvm-broker.rs
@@ -122,7 +122,13 @@ fn register_handlers(registry: &mut Registry, cfg: &SubprocessConfig) {
     match &cfg.audit_signer_uds_path {
         Some(path) => {
             let client = AuditClient::new(path.clone());
-            registry.register(Arc::new(HostAuditV1Handler::new(client)));
+            let handler = Arc::new(HostAuditV1Handler::new(client));
+            registry.register(handler.clone());
+            for descriptor in HostAuditV1Handler::capability_descriptors() {
+                registry
+                    .register_capability(handler.clone(), descriptor)
+                    .expect("host.audit capability descriptors are unique and valid");
+            }
             info!(
                 audit_signer_uds_path = %path.display(),
                 "host.audit.v1 handler registered"

--- a/crates/mvm-hostd/src/broker/daemon.rs
+++ b/crates/mvm-hostd/src/broker/daemon.rs
@@ -367,14 +367,28 @@ impl HostAgentDaemon {
         // at the resident helper with this server-derived `vm_id`; legacy
         // per-VM broker mode still points at a per-VM audit-signer UDS.
         let mut registry = Registry::new();
+        registry
+            .admit_capabilities(r.capability_bindings.clone())
+            .context("load host-signed capability bindings")?;
         if let Some(helper) = &self.signer_helper_uds_path {
-            registry.register(Arc::new(HostAuditV1Handler::new(
-                AuditClient::new_signer_helper(helper.clone(), r.vm_id.clone()),
+            let handler = Arc::new(HostAuditV1Handler::new(AuditClient::new_signer_helper(
+                helper.clone(),
+                r.vm_id.clone(),
             )));
+            registry.register(handler.clone());
+            for descriptor in HostAuditV1Handler::capability_descriptors() {
+                registry
+                    .register_capability(handler.clone(), descriptor)
+                    .context("register host.audit typed capability")?;
+            }
         } else if let Some(signer) = &r.audit_signer_uds_path {
-            registry.register(Arc::new(HostAuditV1Handler::new(AuditClient::new(
-                signer.clone(),
-            ))));
+            let handler = Arc::new(HostAuditV1Handler::new(AuditClient::new(signer.clone())));
+            registry.register(handler.clone());
+            for descriptor in HostAuditV1Handler::capability_descriptors() {
+                registry
+                    .register_capability(handler.clone(), descriptor)
+                    .context("register host.audit typed capability")?;
+            }
         }
         let registry = Arc::new(registry);
 
@@ -696,6 +710,7 @@ mod tests {
             ),
             audit_signer_uds_path: signer.map(|p| p.to_string_lossy().into_owned()),
             services_bindings: vec![],
+            capability_bindings: vec![],
         }
     }
 
@@ -754,6 +769,7 @@ mod tests {
                 "ts": "2026-06-17T00:00:00Z",
                 "fields": {"vm": vm}
             }),
+            capability: None,
         };
         write_frame(&mut client, &call).await.unwrap();
         read_frame(&mut client, 64 * 1024).await.unwrap()
@@ -1013,6 +1029,7 @@ mod tests {
             verb: "emit".into(),
             correlation_id: mvm_core::protocol::broker::CorrelationId::new("guest-picked-id"),
             payload: serde_json::json!({"ts": "2026-06-16T00:00:00Z", "fields": {"a": 1}}),
+            capability: None,
         };
         write_frame(&mut client, &call).await.unwrap();
         let resp: ServiceResponse = read_frame(&mut client, 64 * 1024).await.unwrap();
@@ -1058,6 +1075,7 @@ mod tests {
                 "ts": "2026-06-17T00:00:00Z",
                 "fields": {"vm": "a"}
             }),
+            capability: None,
         };
         write_frame(&mut client, &call).await.unwrap();
         let resp: ServiceResponse = read_frame(&mut client, 64 * 1024).await.unwrap();

--- a/crates/mvm-hostd/src/broker/handlers/host_audit_v1.rs
+++ b/crates/mvm-hostd/src/broker/handlers/host_audit_v1.rs
@@ -32,6 +32,9 @@
 use std::pin::Pin;
 use std::time::Duration;
 
+use mvm_contract::protocol::agent_capability::{
+    CapabilityDescriptor, CapabilityId, CapabilityLimits, SchemaRef, payload_digest,
+};
 use mvm_core::policy::security::AgentProfile;
 use mvm_core::protocol::audit_signer::{AppendEntryRequest, AppendEntryResponse};
 use mvm_core::protocol::broker::{AuditDurability, Idempotency, ServiceErrorCode, ServiceId};
@@ -84,6 +87,63 @@ impl HostAuditV1Handler {
             rate_limiter: Mutex::new(TokenBucket::new(tokens_per_sec)),
             call_timeout: Duration::from_secs(5),
         }
+    }
+
+    /// Descriptors for the two typed verbs this handler exposes. The schema
+    /// digests are derived from the canonical JSON schema documents used by
+    /// the host parser; no request or response value is included.
+    pub fn capability_descriptors() -> Vec<CapabilityDescriptor> {
+        let service = || ServiceId::parse("host.audit.v1").expect("host.audit.v1 is valid");
+        let emit_input = payload_digest(&serde_json::json!({
+            "type": "object",
+            "required": ["ts", "fields"],
+            "properties": {"ts": {"type": "string"}, "fields": {}}
+        }));
+        let emit_output = payload_digest(&serde_json::json!({
+            "type": "object",
+            "required": ["chain_head"],
+            "properties": {"chain_head": {"type": "string"}}
+        }));
+        let batch_input = payload_digest(&serde_json::json!({
+            "type": "object",
+            "required": ["entries"],
+            "properties": {"entries": {"type": "array"}}
+        }));
+        let batch_output = payload_digest(&serde_json::json!({
+            "type": "object",
+            "required": ["chain_head", "statuses"],
+            "properties": {"chain_head": {"type": "string"}, "statuses": {"type": "array"}}
+        }));
+        vec![
+            CapabilityDescriptor::builder()
+                .id(CapabilityId::new(service(), "emit").expect("emit capability id"))
+                .description("append a bounded workload audit entry")
+                .input_schema(
+                    SchemaRef::new("host.audit.emit.input.v1", emit_input)
+                        .expect("emit input schema"),
+                )
+                .output_schema(
+                    SchemaRef::new("host.audit.emit.output.v1", emit_output)
+                        .expect("emit output schema"),
+                )
+                .limits(CapabilityLimits::new(4096, 32 * 1024, 5_000).expect("emit limits"))
+                .build()
+                .expect("emit descriptor"),
+            CapabilityDescriptor::builder()
+                .id(CapabilityId::new(service(), "emit_batch").expect("batch capability id"))
+                .description("append a bounded batch of workload audit entries")
+                .input_schema(
+                    SchemaRef::new("host.audit.emit-batch.input.v1", batch_input)
+                        .expect("batch input schema"),
+                )
+                .output_schema(
+                    SchemaRef::new("host.audit.emit-batch.output.v1", batch_output)
+                        .expect("batch output schema"),
+                )
+                .limits(CapabilityLimits::new(256 * 1024, 32 * 1024, 5_000).expect("batch limits"))
+                .build()
+                .expect("batch descriptor"),
+        ]
     }
 
     async fn handle_emit(

--- a/crates/mvm-hostd/src/broker/registry.rs
+++ b/crates/mvm-hostd/src/broker/registry.rs
@@ -6,26 +6,117 @@
 //! workload verb, and the `broker.v1/list_services` introspection verb
 //! wire in their handlers via [`Registry::register`].
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
+use mvm_contract::protocol::agent_capability::{
+    CapabilityAuditEvent, CapabilityBinding, CapabilityDescriptor, CapabilityFailureCode,
+    CapabilityId, CapabilityInvocation, payload_digest,
+};
+use mvm_contract::protocol::agent_session::AgentRequestId;
 use mvm_core::protocol::broker::{ServiceErrorCode, ServiceId};
 use mvm_core::protocol::handler::{
     ServiceCallCtx, ServiceDispatchResult, ServiceError, ServiceHandler,
 };
+
+/// Minimal cancellation primitive for one host-side capability invocation.
+#[derive(Clone, Default)]
+pub struct CancellationToken {
+    canceled: Arc<AtomicBool>,
+    notify: Arc<tokio::sync::Notify>,
+}
+
+impl CancellationToken {
+    /// Create a token that has not been canceled.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Cancel all current and future waiters.
+    pub fn cancel(&self) {
+        self.canceled.store(true, Ordering::Release);
+        self.notify.notify_waiters();
+    }
+
+    /// Whether cancellation has already been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.canceled.load(Ordering::Acquire)
+    }
+
+    async fn cancelled(&self) {
+        if self.is_cancelled() {
+            return;
+        }
+        self.notify.notified().await;
+    }
+}
+
+/// Host-owned sink for digest-only capability lifecycle evidence.
+pub trait CapabilityAuditSink: Send + Sync + 'static {
+    /// Record one event without receiving payload or handler error text.
+    fn record(&self, event: CapabilityAuditEvent);
+}
+
+struct NoopCapabilityAuditSink;
+
+impl CapabilityAuditSink for NoopCapabilityAuditSink {
+    fn record(&self, _event: CapabilityAuditEvent) {}
+}
+
+struct CapabilityRegistration {
+    descriptor: CapabilityDescriptor,
+    handler: Arc<dyn ServiceHandler>,
+}
 
 /// Per-subprocess handler registry. Handlers registered at startup live
 /// for the subprocess lifetime; runtime registration is not supported
 /// (the static catalog is the contract).
 pub struct Registry {
     handlers: HashMap<ServiceId, Arc<dyn ServiceHandler>>,
+    capabilities: HashMap<CapabilityId, CapabilityRegistration>,
+    admitted: HashMap<CapabilityId, [u8; 32]>,
+    consumed_invocations: std::sync::Mutex<HashSet<(CapabilityId, AgentRequestId)>>,
+    audit: Arc<dyn CapabilityAuditSink>,
 }
 
 impl Registry {
     pub fn new() -> Self {
         Self {
             handlers: HashMap::new(),
+            capabilities: HashMap::new(),
+            admitted: HashMap::new(),
+            consumed_invocations: std::sync::Mutex::new(HashSet::new()),
+            audit: Arc::new(NoopCapabilityAuditSink),
         }
+    }
+
+    /// Install the host-signed exact bindings for this workload.
+    pub fn admit_capabilities<I>(&mut self, bindings: I) -> Result<(), RegistryError>
+    where
+        I: IntoIterator<Item = CapabilityBinding>,
+    {
+        for binding in bindings {
+            if self
+                .admitted
+                .insert(binding.capability.clone(), binding.descriptor_digest)
+                .is_some()
+            {
+                return Err(RegistryError::DuplicateAdmission(binding.capability));
+            }
+            self.audit.record(CapabilityAuditEvent::Admitted {
+                capability: binding.capability,
+                descriptor_digest: binding.descriptor_digest,
+            });
+        }
+        Ok(())
+    }
+
+    /// Replace the audit sink used by typed dispatch.
+    pub fn with_capability_audit_sink(mut self, audit: Arc<dyn CapabilityAuditSink>) -> Self {
+        self.audit = audit;
+        self
     }
 
     /// Register a handler. Replaces any previous handler for the same
@@ -33,6 +124,40 @@ impl Registry {
     /// bindings at the plan-verification layer, not here).
     pub fn register(&mut self, handler: Arc<dyn ServiceHandler>) {
         self.handlers.insert(handler.id(), handler);
+    }
+
+    /// Register one explicitly described per-verb capability.
+    pub fn register_capability(
+        &mut self,
+        handler: Arc<dyn ServiceHandler>,
+        descriptor: CapabilityDescriptor,
+    ) -> Result<(), RegistryError> {
+        if handler.id() != descriptor.id.service {
+            return Err(RegistryError::HandlerIdentityMismatch {
+                handler: handler.id(),
+                descriptor: descriptor.id.service,
+            });
+        }
+        let id = descriptor.id.clone();
+        if self
+            .capabilities
+            .insert(
+                id.clone(),
+                CapabilityRegistration {
+                    descriptor: descriptor.clone(),
+                    handler,
+                },
+            )
+            .is_some()
+        {
+            return Err(RegistryError::DuplicateRegistration(id));
+        }
+        let descriptor_digest = descriptor.digest();
+        self.audit.record(CapabilityAuditEvent::Registered {
+            capability: descriptor.id.clone(),
+            descriptor_digest,
+        });
+        Ok(())
     }
 
     /// Dispatch a call. Returns `Err(NotBound)` for any service not in
@@ -57,11 +182,204 @@ impl Registry {
         handler.dispatch(ctx, verb, payload).await
     }
 
+    /// Dispatch a typed capability call after every admission and resource
+    /// gate has passed. The cancellation token is owned by the host protocol
+    /// layer; canceling it drops the handler future before returning.
+    pub async fn dispatch_capability(
+        &self,
+        ctx: &ServiceCallCtx,
+        service: &ServiceId,
+        verb: &str,
+        invocation: &CapabilityInvocation,
+        payload: serde_json::Value,
+        cancellation: &CancellationToken,
+    ) -> ServiceDispatchResult {
+        let capability = match CapabilityId::new(service.clone(), verb.to_string()) {
+            Ok(capability) => capability,
+            Err(_) => return Err(capability_error(CapabilityFailureCode::ProtocolMismatch)),
+        };
+        let Some(registration) = self.capabilities.get(&capability) else {
+            return Err(capability_error(CapabilityFailureCode::NotRegistered));
+        };
+        let Some(admitted_digest) = self.admitted.get(&capability) else {
+            self.record_refusal(
+                &capability,
+                invocation,
+                CapabilityFailureCode::AdmissionDenied,
+            );
+            return Err(capability_error(CapabilityFailureCode::AdmissionDenied));
+        };
+        if *admitted_digest != invocation.binding.descriptor_digest
+            || !invocation.binding.matches(&registration.descriptor)
+        {
+            self.record_refusal(
+                &capability,
+                invocation,
+                CapabilityFailureCode::BindingMismatch,
+            );
+            return Err(capability_error(CapabilityFailureCode::BindingMismatch));
+        }
+        if let Err(code) = invocation.validate_payload(&registration.descriptor, &payload) {
+            self.record_refusal(&capability, invocation, code);
+            return Err(capability_error(code));
+        }
+        let input_bytes = match serde_json::to_vec(&payload) {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                self.record_refusal(&capability, invocation, CapabilityFailureCode::InvalidInput);
+                return Err(capability_error(CapabilityFailureCode::InvalidInput));
+            }
+        };
+        if input_bytes.len() > registration.descriptor.limits.max_input_bytes as usize {
+            self.record_refusal(
+                &capability,
+                invocation,
+                CapabilityFailureCode::InputTooLarge,
+            );
+            return Err(capability_error(CapabilityFailureCode::InputTooLarge));
+        }
+        let replay_key = (capability.clone(), invocation.invocation_id.clone());
+        let inserted = self
+            .consumed_invocations
+            .lock()
+            .expect("capability replay mutex is not poisoned")
+            .insert(replay_key);
+        if !inserted {
+            self.record_refusal(&capability, invocation, CapabilityFailureCode::Replay);
+            return Err(capability_error(CapabilityFailureCode::Replay));
+        }
+        if cancellation.is_cancelled() {
+            self.record_canceled(&capability, invocation);
+            return Err(capability_error(CapabilityFailureCode::Canceled));
+        }
+
+        self.audit.record(CapabilityAuditEvent::Invoked {
+            capability: capability.clone(),
+            descriptor_digest: registration.descriptor.digest(),
+            invocation_id: invocation.invocation_id.clone(),
+            input_digest: invocation.input_digest,
+        });
+        let timeout = Duration::from_millis(u64::from(registration.descriptor.limits.timeout_ms));
+        let dispatch = registration.handler.dispatch(ctx, verb, payload);
+        tokio::pin!(dispatch);
+        let result = tokio::select! {
+            _ = cancellation.cancelled() => {
+                self.record_canceled(&capability, invocation);
+                return Err(capability_error(CapabilityFailureCode::Canceled));
+            }
+            result = tokio::time::timeout(timeout, &mut dispatch) => result,
+        };
+        let output = match result {
+            Ok(Ok(output)) => output,
+            Ok(Err(error)) => {
+                let code = if error.code == ServiceErrorCode::BadRequest {
+                    CapabilityFailureCode::InvalidInput
+                } else {
+                    CapabilityFailureCode::HandlerFailed
+                };
+                self.audit.record(CapabilityAuditEvent::Failed {
+                    capability,
+                    invocation_id: invocation.invocation_id.clone(),
+                    code,
+                });
+                return Err(capability_error(code));
+            }
+            Err(_) => {
+                self.audit.record(CapabilityAuditEvent::TimedOut {
+                    capability,
+                    invocation_id: invocation.invocation_id.clone(),
+                });
+                return Err(capability_error(CapabilityFailureCode::Timeout));
+            }
+        };
+        let output_bytes = match serde_json::to_vec(&output) {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                self.audit.record(CapabilityAuditEvent::Failed {
+                    capability,
+                    invocation_id: invocation.invocation_id.clone(),
+                    code: CapabilityFailureCode::HandlerFailed,
+                });
+                return Err(capability_error(CapabilityFailureCode::HandlerFailed));
+            }
+        };
+        if output_bytes.len() > registration.descriptor.limits.max_output_bytes as usize {
+            self.audit.record(CapabilityAuditEvent::Failed {
+                capability,
+                invocation_id: invocation.invocation_id.clone(),
+                code: CapabilityFailureCode::OutputTooLarge,
+            });
+            return Err(capability_error(CapabilityFailureCode::OutputTooLarge));
+        }
+        self.audit.record(CapabilityAuditEvent::Completed {
+            capability,
+            invocation_id: invocation.invocation_id.clone(),
+            output_digest: payload_digest(&output),
+        });
+        Ok(output)
+    }
+
+    fn record_refusal(
+        &self,
+        capability: &CapabilityId,
+        invocation: &CapabilityInvocation,
+        code: CapabilityFailureCode,
+    ) {
+        self.audit.record(CapabilityAuditEvent::Refused {
+            capability: capability.clone(),
+            invocation_id: Some(invocation.invocation_id.clone()),
+            code,
+        });
+    }
+
+    fn record_canceled(&self, capability: &CapabilityId, invocation: &CapabilityInvocation) {
+        self.audit.record(CapabilityAuditEvent::Canceled {
+            capability: capability.clone(),
+            invocation_id: invocation.invocation_id.clone(),
+        });
+    }
+
     /// True if any handler is registered. Useful for the broker's
     /// startup readiness gate.
     pub fn is_empty(&self) -> bool {
         self.handlers.is_empty()
     }
+}
+
+/// Registration failures are host configuration errors, never guest data.
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    #[error("capability {0} was admitted more than once")]
+    DuplicateAdmission(CapabilityId),
+    #[error("capability {0} was registered more than once")]
+    DuplicateRegistration(CapabilityId),
+    #[error("handler service {handler} does not own descriptor service {descriptor}")]
+    HandlerIdentityMismatch {
+        handler: ServiceId,
+        descriptor: ServiceId,
+    },
+}
+
+fn capability_error(code: CapabilityFailureCode) -> ServiceError {
+    let service_code = match code {
+        CapabilityFailureCode::ProtocolMismatch => ServiceErrorCode::CapabilityProtocolMismatch,
+        CapabilityFailureCode::NotRegistered => ServiceErrorCode::NotBound,
+        CapabilityFailureCode::AdmissionDenied => ServiceErrorCode::CapabilityDenied,
+        CapabilityFailureCode::BindingMismatch | CapabilityFailureCode::InputDigestMismatch => {
+            ServiceErrorCode::CapabilityBindingMismatch
+        }
+        CapabilityFailureCode::InputTooLarge => ServiceErrorCode::CapabilityInputTooLarge,
+        CapabilityFailureCode::InvalidInput => ServiceErrorCode::BadRequest,
+        CapabilityFailureCode::OutputTooLarge => ServiceErrorCode::CapabilityOutputTooLarge,
+        CapabilityFailureCode::Timeout => ServiceErrorCode::Timeout,
+        CapabilityFailureCode::Canceled => ServiceErrorCode::CapabilityCanceled,
+        CapabilityFailureCode::Replay => ServiceErrorCode::CapabilityReplay,
+        CapabilityFailureCode::HandlerFailed => ServiceErrorCode::CapabilityHandlerFailed,
+    };
+    ServiceError::new(
+        service_code,
+        format!("typed capability request refused: {code:?}"),
+    )
 }
 
 impl Default for Registry {
@@ -77,8 +395,14 @@ impl Default for Registry {
 #[cfg(test)]
 mod tests {
     use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
+    use mvm_contract::protocol::agent_capability::{
+        CapabilityAuditEvent, CapabilityDescriptor, CapabilityId, CapabilityInvocation,
+        CapabilityLimits, SchemaRef,
+    };
+    use mvm_contract::protocol::agent_session::AgentRequestId;
     use mvm_core::policy::security::AgentProfile;
     use mvm_core::protocol::broker::{
         AuditDurability, CorrelationId, Idempotency, ServiceErrorCode, ServiceId,
@@ -115,6 +439,89 @@ mod tests {
         }
     }
 
+    struct InvalidInputHandler;
+
+    impl ServiceHandler for InvalidInputHandler {
+        fn id(&self) -> ServiceId {
+            ServiceId::parse("host.dev.echo.v1").unwrap()
+        }
+        fn profiles(&self) -> &[AgentProfile] {
+            &[AgentProfile::Dev]
+        }
+        fn audit_durability(&self) -> AuditDurability {
+            AuditDurability::default_batched()
+        }
+        fn idempotency(&self) -> Idempotency {
+            Idempotency::MintFresh
+        }
+        fn call_timeout(&self) -> Duration {
+            Duration::from_millis(5)
+        }
+        fn dispatch<'a>(
+            &'a self,
+            _ctx: &'a ServiceCallCtx,
+            _verb: &'a str,
+            _payload: serde_json::Value,
+        ) -> Pin<Box<dyn std::future::Future<Output = ServiceDispatchResult> + Send + 'a>> {
+            Box::pin(async {
+                Err(ServiceError::new(
+                    ServiceErrorCode::BadRequest,
+                    "input does not match the capability schema",
+                ))
+            })
+        }
+    }
+
+    enum Behavior {
+        Delay,
+        Expand,
+        Fail,
+    }
+
+    struct BehaviorHandler {
+        behavior: Behavior,
+    }
+
+    impl ServiceHandler for BehaviorHandler {
+        fn id(&self) -> ServiceId {
+            ServiceId::parse("host.dev.echo.v1").unwrap()
+        }
+        fn profiles(&self) -> &[AgentProfile] {
+            &[AgentProfile::Dev]
+        }
+        fn audit_durability(&self) -> AuditDurability {
+            AuditDurability::default_batched()
+        }
+        fn idempotency(&self) -> Idempotency {
+            Idempotency::MintFresh
+        }
+        fn call_timeout(&self) -> Duration {
+            Duration::from_millis(100)
+        }
+        fn dispatch<'a>(
+            &'a self,
+            _ctx: &'a ServiceCallCtx,
+            _verb: &'a str,
+            payload: serde_json::Value,
+        ) -> Pin<Box<dyn std::future::Future<Output = ServiceDispatchResult> + Send + 'a>> {
+            Box::pin(async move {
+                match self.behavior {
+                    Behavior::Delay => {
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                        Ok(payload)
+                    }
+                    Behavior::Expand => Ok(serde_json::json!({
+                        "expanded": "x".repeat(200),
+                    })),
+                    Behavior::Fail => Err(ServiceError::new(
+                        ServiceErrorCode::Unavailable,
+                        "private handler failure detail",
+                    )),
+                }
+            })
+        }
+    }
+
     fn ctx() -> ServiceCallCtx {
         ServiceCallCtx {
             workload_id: "wl-test".into(),
@@ -124,6 +531,30 @@ mod tests {
             profile: AgentProfile::Dev,
             composition_depth: 0,
             composition_width: 0,
+        }
+    }
+
+    fn descriptor() -> CapabilityDescriptor {
+        CapabilityDescriptor::builder()
+            .id(CapabilityId::new(
+                ServiceId::parse("host.dev.echo.v1").expect("service id"),
+                "echo",
+            )
+            .expect("capability id"))
+            .description("echo a bounded test value")
+            .input_schema(SchemaRef::new("host.dev.echo.input.v1", [1; 32]).expect("schema"))
+            .output_schema(SchemaRef::new("host.dev.echo.output.v1", [2; 32]).expect("schema"))
+            .limits(CapabilityLimits::new(128, 128, 50).expect("limits"))
+            .build()
+            .expect("descriptor")
+    }
+
+    #[derive(Clone, Default)]
+    struct TestAudit(Arc<Mutex<Vec<CapabilityAuditEvent>>>);
+
+    impl CapabilityAuditSink for TestAudit {
+        fn record(&self, event: CapabilityAuditEvent) {
+            self.0.lock().expect("test audit mutex").push(event);
         }
     }
 
@@ -151,6 +582,291 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result, payload);
+    }
+
+    #[tokio::test]
+    async fn typed_dispatch_requires_exact_admission_and_rejects_replay() {
+        let descriptor = descriptor();
+        let binding = descriptor.binding();
+        let audit = TestAudit::default();
+        let mut registry = Registry::new().with_capability_audit_sink(Arc::new(audit.clone()));
+        registry
+            .register_capability(Arc::new(EchoHandler), descriptor)
+            .expect("register");
+        registry
+            .admit_capabilities([binding.clone()])
+            .expect("admit");
+        let payload = serde_json::json!({"hello": "world"});
+        let invocation = CapabilityInvocation::from_payload(
+            binding.clone(),
+            AgentRequestId::parse("typed-request-1").expect("request id"),
+            &payload,
+        )
+        .expect("invocation");
+        let cancel = CancellationToken::new();
+        let response = registry
+            .dispatch_capability(
+                &ctx(),
+                &ServiceId::parse("host.dev.echo.v1").expect("service"),
+                "echo",
+                &invocation,
+                payload.clone(),
+                &cancel,
+            )
+            .await
+            .expect("typed call succeeds");
+        assert_eq!(response, payload);
+
+        let replay = registry
+            .dispatch_capability(
+                &ctx(),
+                &ServiceId::parse("host.dev.echo.v1").expect("service"),
+                "echo",
+                &invocation,
+                serde_json::json!({"hello": "world"}),
+                &cancel,
+            )
+            .await
+            .expect_err("replay must fail");
+        assert_eq!(replay.code, ServiceErrorCode::CapabilityReplay);
+        assert!(
+            audit
+                .0
+                .lock()
+                .expect("test audit mutex")
+                .iter()
+                .any(|event| matches!(event, CapabilityAuditEvent::Completed { .. }))
+        );
+    }
+
+    #[tokio::test]
+    async fn typed_dispatch_rejects_downgrade_oversize_and_cancellation() {
+        let descriptor = descriptor();
+        let binding = descriptor.binding();
+        let mut registry = Registry::new();
+        registry
+            .register_capability(Arc::new(EchoHandler), descriptor)
+            .expect("register");
+        registry
+            .admit_capabilities([binding.clone()])
+            .expect("admit");
+
+        let payload = serde_json::json!({"hello": "world"});
+        let mut wrong = CapabilityInvocation::from_payload(
+            binding.clone(),
+            AgentRequestId::parse("typed-request-2").expect("request id"),
+            &payload,
+        )
+        .expect("invocation");
+        wrong.binding.descriptor_digest = [7; 32];
+        let error = registry
+            .dispatch_capability(
+                &ctx(),
+                &ServiceId::parse("host.dev.echo.v1").expect("service"),
+                "echo",
+                &wrong,
+                payload.clone(),
+                &CancellationToken::new(),
+            )
+            .await
+            .expect_err("downgrade must fail");
+        assert_eq!(error.code, ServiceErrorCode::CapabilityBindingMismatch);
+
+        let oversized = serde_json::json!({"hello": "x".repeat(200)});
+        let invocation = CapabilityInvocation::from_payload(
+            binding.clone(),
+            AgentRequestId::parse("typed-request-3").expect("request id"),
+            &oversized,
+        )
+        .expect("invocation");
+        let error = registry
+            .dispatch_capability(
+                &ctx(),
+                &ServiceId::parse("host.dev.echo.v1").expect("service"),
+                "echo",
+                &invocation,
+                oversized,
+                &CancellationToken::new(),
+            )
+            .await
+            .expect_err("oversize must fail");
+        assert_eq!(error.code, ServiceErrorCode::CapabilityInputTooLarge);
+
+        let invocation = CapabilityInvocation::from_payload(
+            binding,
+            AgentRequestId::parse("typed-request-4").expect("request id"),
+            &payload,
+        )
+        .expect("invocation");
+        let canceled = CancellationToken::new();
+        canceled.cancel();
+        let error = registry
+            .dispatch_capability(
+                &ctx(),
+                &ServiceId::parse("host.dev.echo.v1").expect("service"),
+                "echo",
+                &invocation,
+                payload,
+                &canceled,
+            )
+            .await
+            .expect_err("canceled call must fail");
+        assert_eq!(error.code, ServiceErrorCode::CapabilityCanceled);
+    }
+
+    #[tokio::test]
+    async fn typed_dispatch_classifies_schema_rejection_without_leaking_handler_text() {
+        let descriptor = descriptor();
+        let binding = descriptor.binding();
+        let mut registry = Registry::new();
+        registry
+            .register_capability(Arc::new(InvalidInputHandler), descriptor)
+            .expect("register");
+        registry
+            .admit_capabilities([binding.clone()])
+            .expect("admit");
+        let payload = serde_json::json!({"hello": "world"});
+        let invocation = CapabilityInvocation::from_payload(
+            binding,
+            AgentRequestId::parse("typed-request-5").expect("request id"),
+            &payload,
+        )
+        .expect("invocation");
+
+        let error = registry
+            .dispatch_capability(
+                &ctx(),
+                &ServiceId::parse("host.dev.echo.v1").expect("service"),
+                "echo",
+                &invocation,
+                payload,
+                &CancellationToken::new(),
+            )
+            .await
+            .expect_err("invalid schema must fail");
+        assert_eq!(error.code, ServiceErrorCode::BadRequest);
+        assert!(
+            !error
+                .message
+                .contains("does not match the capability schema")
+        );
+    }
+
+    #[tokio::test]
+    async fn typed_dispatch_enforces_timeout_output_and_handler_failure() {
+        let payload = serde_json::json!({"hello": "world"});
+
+        let mut timeout_descriptor = descriptor();
+        timeout_descriptor.limits = CapabilityLimits::new(128, 128, 5).unwrap();
+        let timeout_binding = timeout_descriptor.binding();
+        let mut timeout_registry = Registry::new();
+        timeout_registry
+            .register_capability(
+                Arc::new(BehaviorHandler {
+                    behavior: Behavior::Delay,
+                }),
+                timeout_descriptor,
+            )
+            .unwrap();
+        timeout_registry
+            .admit_capabilities([timeout_binding.clone()])
+            .unwrap();
+        let timeout_invocation = CapabilityInvocation::from_payload(
+            timeout_binding,
+            AgentRequestId::parse("typed-request-6").unwrap(),
+            &payload,
+        )
+        .unwrap();
+        let timeout_error = timeout_registry
+            .dispatch_capability(
+                &ctx(),
+                &ServiceId::parse("host.dev.echo.v1").unwrap(),
+                "echo",
+                &timeout_invocation,
+                payload.clone(),
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(timeout_error.code, ServiceErrorCode::Timeout);
+
+        let mut output_descriptor = descriptor();
+        output_descriptor.limits = CapabilityLimits::new(128, 8, 50).unwrap();
+        let output_binding = output_descriptor.binding();
+        let mut output_registry = Registry::new();
+        output_registry
+            .register_capability(
+                Arc::new(BehaviorHandler {
+                    behavior: Behavior::Expand,
+                }),
+                output_descriptor,
+            )
+            .unwrap();
+        output_registry
+            .admit_capabilities([output_binding.clone()])
+            .unwrap();
+        let output_invocation = CapabilityInvocation::from_payload(
+            output_binding,
+            AgentRequestId::parse("typed-request-7").unwrap(),
+            &payload,
+        )
+        .unwrap();
+        let output_error = output_registry
+            .dispatch_capability(
+                &ctx(),
+                &ServiceId::parse("host.dev.echo.v1").unwrap(),
+                "echo",
+                &output_invocation,
+                payload.clone(),
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            output_error.code,
+            ServiceErrorCode::CapabilityOutputTooLarge
+        );
+
+        let failure_descriptor = descriptor();
+        let failure_binding = failure_descriptor.binding();
+        let mut failure_registry = Registry::new();
+        failure_registry
+            .register_capability(
+                Arc::new(BehaviorHandler {
+                    behavior: Behavior::Fail,
+                }),
+                failure_descriptor,
+            )
+            .unwrap();
+        failure_registry
+            .admit_capabilities([failure_binding.clone()])
+            .unwrap();
+        let failure_invocation = CapabilityInvocation::from_payload(
+            failure_binding,
+            AgentRequestId::parse("typed-request-8").unwrap(),
+            &payload,
+        )
+        .unwrap();
+        let failure_error = failure_registry
+            .dispatch_capability(
+                &ctx(),
+                &ServiceId::parse("host.dev.echo.v1").unwrap(),
+                "echo",
+                &failure_invocation,
+                payload,
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            failure_error.code,
+            ServiceErrorCode::CapabilityHandlerFailed
+        );
+        assert!(
+            !failure_error
+                .message
+                .contains("private handler failure detail")
+        );
     }
 
     /// Both directions. Asserting only that a fresh registry is empty

--- a/crates/mvm-hostd/src/broker/server.rs
+++ b/crates/mvm-hostd/src/broker/server.rs
@@ -20,7 +20,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::{UnixListener, UnixStream};
 use tracing::{debug, info, warn};
 
-use crate::broker::registry::Registry;
+use crate::broker::registry::{CancellationToken, Registry};
 
 /// Accept loop. Each accepted UDS connection runs to completion in its
 /// own `tokio::spawn`; one connection per supervisor-proxy call.
@@ -105,10 +105,27 @@ async fn handle_connection(
         composition_width: 0,
     };
 
-    let response = match registry
-        .dispatch(&ctx, &call.service, &call.verb, call.payload)
-        .await
-    {
+    let cancellation = CancellationToken::new();
+    let result = match call.capability {
+        Some(invocation) => {
+            registry
+                .dispatch_capability(
+                    &ctx,
+                    &call.service,
+                    &call.verb,
+                    &invocation,
+                    call.payload,
+                    &cancellation,
+                )
+                .await
+        }
+        None => {
+            registry
+                .dispatch(&ctx, &call.service, &call.verb, call.payload)
+                .await
+        }
+    };
+    let response = match result {
         Ok(payload) => ServiceResponse::Ok {
             correlation_id,
             payload,
@@ -168,8 +185,16 @@ pub async fn write_frame<T: serde::Serialize>(stream: &mut UnixStream, value: &T
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::pin::Pin;
+    use std::time::Duration;
 
+    use mvm_contract::protocol::agent_capability::{
+        CapabilityDescriptor, CapabilityId, CapabilityInvocation, CapabilityLimits, SchemaRef,
+    };
+    use mvm_contract::protocol::agent_session::AgentRequestId;
+    use mvm_core::policy::security::AgentProfile;
     use mvm_core::protocol::broker::{CorrelationId, ServiceCall, ServiceErrorCode, ServiceId};
+    use mvm_core::protocol::handler::{ServiceCallCtx, ServiceDispatchResult, ServiceHandler};
     use tempfile::tempdir;
     use tokio::net::UnixStream as ClientStream;
 
@@ -197,11 +222,63 @@ mod tests {
         dir.path().join("broker.sock")
     }
 
+    struct TypedEchoHandler;
+
+    impl ServiceHandler for TypedEchoHandler {
+        fn id(&self) -> ServiceId {
+            ServiceId::parse("host.dev.echo.v1").expect("service id")
+        }
+
+        fn profiles(&self) -> &[AgentProfile] {
+            &[AgentProfile::Dev]
+        }
+
+        fn audit_durability(&self) -> mvm_core::protocol::broker::AuditDurability {
+            mvm_core::protocol::broker::AuditDurability::default_batched()
+        }
+
+        fn idempotency(&self) -> mvm_core::protocol::broker::Idempotency {
+            mvm_core::protocol::broker::Idempotency::MintFresh
+        }
+
+        fn call_timeout(&self) -> Duration {
+            Duration::from_millis(50)
+        }
+
+        fn dispatch<'a>(
+            &'a self,
+            _ctx: &'a ServiceCallCtx,
+            _verb: &'a str,
+            payload: serde_json::Value,
+        ) -> Pin<Box<dyn std::future::Future<Output = ServiceDispatchResult> + Send + 'a>> {
+            Box::pin(async move { Ok(payload) })
+        }
+    }
+
+    fn typed_echo_descriptor() -> CapabilityDescriptor {
+        CapabilityDescriptor::builder()
+            .id(CapabilityId::new(
+                ServiceId::parse("host.dev.echo.v1").expect("service id"),
+                "echo",
+            )
+            .expect("capability id"))
+            .description("echo a bounded test value")
+            .input_schema(SchemaRef::new("host.dev.echo.input.v1", [1; 32]).expect("schema"))
+            .output_schema(SchemaRef::new("host.dev.echo.output.v1", [2; 32]).expect("schema"))
+            .limits(CapabilityLimits::new(1024, 1024, 100).expect("limits"))
+            .build()
+            .expect("descriptor")
+    }
+
     #[tokio::test]
     async fn round_trips_a_call_and_returns_not_bound_with_empty_registry() {
         let dir = tempdir().unwrap();
         let path = uds_path(&dir);
-        let listener = UnixListener::bind(&path).unwrap();
+        let listener = match UnixListener::bind(&path) {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+            Err(error) => panic!("failed to bind typed broker test listener: {error}"),
+        };
         let registry = Arc::new(Registry::new());
 
         let server_task = tokio::spawn({
@@ -229,6 +306,7 @@ mod tests {
             verb: "now".into(),
             correlation_id: CorrelationId::new("01HBROKER0000000000000000"),
             payload: serde_json::json!({}),
+            capability: None,
         };
         write_call(&mut client, &call).await.unwrap();
         let response = read_response(&mut client).await.unwrap();
@@ -253,6 +331,74 @@ mod tests {
             other => panic!("expected NotBound err, got {:?}", other),
         }
 
+        server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn typed_call_round_trips_over_uds_and_replay_is_refused() {
+        let dir = tempdir().unwrap();
+        let path = uds_path(&dir);
+        let listener = match UnixListener::bind(&path) {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+            Err(error) => panic!("failed to bind typed broker test listener: {error}"),
+        };
+        let descriptor = typed_echo_descriptor();
+        let binding = descriptor.binding();
+        let mut registry = Registry::new();
+        registry
+            .register_capability(Arc::new(TypedEchoHandler), descriptor)
+            .expect("register typed handler");
+        registry
+            .admit_capabilities([binding.clone()])
+            .expect("admit typed binding");
+        let registry = Arc::new(registry);
+        let server_task = tokio::spawn({
+            let registry = registry.clone();
+            async move {
+                let _ = serve_on_listener(
+                    listener,
+                    registry,
+                    "wl-test".into(),
+                    "t-test".into(),
+                    65_536,
+                )
+                .await;
+            }
+        });
+        tokio::task::yield_now().await;
+
+        let payload = serde_json::json!({"value": 7});
+        let invocation = CapabilityInvocation::from_payload(
+            binding,
+            AgentRequestId::parse("uds-request-1").expect("request id"),
+            &payload,
+        )
+        .expect("invocation");
+        let call = ServiceCall {
+            service: ServiceId::parse("host.dev.echo.v1").expect("service id"),
+            verb: "echo".into(),
+            correlation_id: CorrelationId::new("guest-correlation"),
+            payload: payload.clone(),
+            capability: Some(invocation.clone()),
+        };
+        let mut client = ClientStream::connect(&path).await.unwrap();
+        write_call(&mut client, &call).await.unwrap();
+        assert!(matches!(
+            read_response(&mut client).await.unwrap(),
+            ServiceResponse::Ok { payload: response, .. } if response == payload
+        ));
+
+        let mut replay_client = ClientStream::connect(&path).await.unwrap();
+        write_call(&mut replay_client, &call).await.unwrap();
+        let response = read_response(&mut replay_client).await.unwrap();
+        assert!(matches!(
+            response,
+            ServiceResponse::Err {
+                code: ServiceErrorCode::CapabilityReplay,
+                ..
+            }
+        ));
         server_task.abort();
     }
 
@@ -292,6 +438,7 @@ mod tests {
             verb: "now".into(),
             correlation_id: CorrelationId::new("01HBROKER0000000000000000"),
             payload: serde_json::json!({"padding": "x".repeat(256)}),
+            capability: None,
         };
         // Manually write the length prefix + body so the test exercises
         // the server-side cap check (the server reads the prefix, sees

--- a/crates/mvm-hostd/src/supervisor/services/broker_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/services/broker_proxy.rs
@@ -41,6 +41,7 @@ impl BrokerProxy {
             verb: verb.into(),
             correlation_id,
             payload,
+            capability: None,
         };
         let mut stream = connect(&self.uds_path).await?;
         write_frame(&mut stream, &self.uds_path, &call).await?;

--- a/crates/mvm-hostd/tests/broker_audit_round_trip.rs
+++ b/crates/mvm-hostd/tests/broker_audit_round_trip.rs
@@ -152,6 +152,7 @@ fn host_audit_v1_round_trip_signs_a_verifiable_workload_chain() {
             fields: serde_json::json!({"event": "it.round_trip", "n": 1}),
         })
         .unwrap(),
+        capability: None,
     };
     write_frame(&mut conn, &call);
     let resp: ServiceResponse = read_frame(&mut conn);

--- a/crates/mvm-hostd/tests/host_agent_restart.rs
+++ b/crates/mvm-hostd/tests/host_agent_restart.rs
@@ -92,6 +92,7 @@ impl HostAgentFixture {
             ),
             audit_signer_uds_path: None,
             services_bindings: vec![],
+            capability_bindings: vec![],
         };
         register_vm(&control_socket, &key_bytes, reg).expect("register vm");
 
@@ -287,6 +288,7 @@ async fn emit_audit(sock: &Path, event: &str) -> Result<ServiceResponse> {
             "ts": "2026-06-17T00:00:00Z",
             "fields": {"event": event},
         }),
+        capability: None,
     };
     write_frame(&mut conn, &call).await?;
     read_frame(&mut conn).await
@@ -357,6 +359,7 @@ async fn daemon_crash_mid_flight_loses_at_most_one_call_and_preserves_chain() {
             "ts": "2026-06-17T00:00:01Z",
             "fields": {"event": "in-flight"},
         }),
+        capability: None,
     };
     write_frame(&mut conn, &call)
         .await

--- a/crates/mvm-hostd/tests/per_tenant_isolation.rs
+++ b/crates/mvm-hostd/tests/per_tenant_isolation.rs
@@ -70,6 +70,7 @@ async fn emit_audit(sock: &Path, event: &str) -> Result<ServiceResponse> {
             "ts": "2026-06-19T00:00:00Z",
             "fields": {"event": event},
         }),
+        capability: None,
     };
     write_frame(&mut conn, &call).await?;
     read_frame(&mut conn).await
@@ -164,6 +165,7 @@ async fn start_tenant(id: &str) -> TenantHandle {
         ),
         audit_signer_uds_path: None,
         services_bindings: vec![],
+        capability_bindings: vec![],
     };
     register_vm(&control_socket, &key_bytes, reg).expect("register vm");
 

--- a/crates/mvm-sdk/sdks/python/mvm/_broker/services.py
+++ b/crates/mvm-sdk/sdks/python/mvm/_broker/services.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, List, Union
+from typing import Any, List, Optional, Union
+
+AgentRequestId = str
+
+
+DescriptorDigestItem = int
+
+
+InputDigestItem = int
 
 
 @dataclass
@@ -122,6 +130,38 @@ class ServiceErrorCode15(Enum):
     internal_error = 'internal_error'
 
 
+class ServiceErrorCode16(Enum):
+    capability_denied = 'capability_denied'
+
+
+class ServiceErrorCode17(Enum):
+    capability_binding_mismatch = 'capability_binding_mismatch'
+
+
+class ServiceErrorCode18(Enum):
+    capability_protocol_mismatch = 'capability_protocol_mismatch'
+
+
+class ServiceErrorCode19(Enum):
+    capability_replay = 'capability_replay'
+
+
+class ServiceErrorCode20(Enum):
+    capability_input_too_large = 'capability_input_too_large'
+
+
+class ServiceErrorCode21(Enum):
+    capability_output_too_large = 'capability_output_too_large'
+
+
+class ServiceErrorCode22(Enum):
+    capability_canceled = 'capability_canceled'
+
+
+class ServiceErrorCode23(Enum):
+    capability_handler_failed = 'capability_handler_failed'
+
+
 ServiceErrorCode = Union[
     ServiceErrorCode1,
     ServiceErrorCode2,
@@ -138,6 +178,14 @@ ServiceErrorCode = Union[
     ServiceErrorCode13,
     ServiceErrorCode14,
     ServiceErrorCode15,
+    ServiceErrorCode16,
+    ServiceErrorCode17,
+    ServiceErrorCode18,
+    ServiceErrorCode19,
+    ServiceErrorCode20,
+    ServiceErrorCode21,
+    ServiceErrorCode22,
+    ServiceErrorCode23,
 ]
 
 
@@ -176,6 +224,12 @@ class TimeNowResponse:
 
 
 @dataclass
+class CapabilityId:
+    service: ServiceId
+    verb: str
+
+
+@dataclass
 class EmitBatchEntryStatus2:
     code: EmitErrorCode
     kind: Kind1
@@ -199,11 +253,26 @@ class EmitBatchResponse:
 
 
 @dataclass
+class CapabilityBinding:
+    capability: CapabilityId
+    descriptor_digest: List[DescriptorDigestItem]
+
+
+@dataclass
+class CapabilityInvocation:
+    binding: CapabilityBinding
+    input_digest: List[InputDigestItem]
+    invocation_id: AgentRequestId
+    protocol_version: int
+
+
+@dataclass
 class ServiceCall:
     correlation_id: str
     payload: Any
     service: ServiceId
     verb: str
+    capability: Optional[CapabilityInvocation] = None
 
 
 @dataclass

--- a/crates/mvm-sdk/sdks/typescript/src/broker/services.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/broker/services.ts
@@ -31,6 +31,10 @@ export type EmitErrorCode = ("record_too_large" | "invalid_entry" | "audit_signe
  */
 export type ServiceId = string
 /**
+ * Stable public request identifier.
+ */
+export type AgentRequestId = string
+/**
  * The guest-bound envelope. Tagged variant; `Ok` carries the typed response payload, `Err` carries a typed error code + message.
  */
 export type ServiceResponse = ({
@@ -46,7 +50,7 @@ message: string
 /**
  * Typed broker error codes. Audit log entries carry the code as a stable snake_case string. New variants are additive; renames are wire-breaking.
  */
-export type ServiceErrorCode = ("not_bound" | "not_implemented" | "bad_request" | "rate_limit_exceeded" | "lifetime_quota_exhausted" | "queue_full" | "response_too_large" | "timeout" | "unavailable" | "not_ready" | "composition_depth" | "composition_width" | "service_call_abuse" | "session_revoked" | "internal_error")
+export type ServiceErrorCode = ("not_bound" | "not_implemented" | "bad_request" | "rate_limit_exceeded" | "lifetime_quota_exhausted" | "queue_full" | "response_too_large" | "timeout" | "unavailable" | "not_ready" | "composition_depth" | "composition_width" | "service_call_abuse" | "session_revoked" | "internal_error" | "capability_denied" | "capability_binding_mismatch" | "capability_protocol_mismatch" | "capability_replay" | "capability_input_too_large" | "capability_output_too_large" | "capability_canceled" | "capability_handler_failed")
 
 /**
  * Schema root: every broker wire type under one document so the shared `$defs` (`ServiceErrorCode`, `CorrelationId`, `EmitBatchEntryStatus`, …) are emitted once and the generated clients reference one definition set.
@@ -122,9 +126,66 @@ chain_head: string
  * The envelope itself is strictly typed (`deny_unknown_fields`); the `payload` is `serde_json::Value` because per-handler payloads vary. The handler's `parse_payload` step is the *real* schema gate for payload contents.
  */
 export interface ServiceCall {
+/**
+ * Optional typed capability metadata. Omitted for the established service-call path so its serialized shape remains byte-compatible.
+ */
+capability?: (CapabilityInvocation | null)
 correlation_id: string
 payload: unknown
 service: ServiceId
+verb: string
+}
+/**
+ * Typed invocation metadata carried alongside the existing broker payload.
+ */
+export interface CapabilityInvocation {
+/**
+ * Exact binding the caller claims to use.
+ */
+binding: CapabilityBinding
+/**
+ * Digest of the `ServiceCall::payload` value.
+ * 
+ * @minItems 32
+ * @maxItems 32
+ */
+input_digest: [number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number]
+/**
+ * Bounded request identity used for replay refusal and audit joins.
+ */
+invocation_id: AgentRequestId
+/**
+ * Version of this invocation contract.
+ */
+protocol_version: number
+}
+/**
+ * Exact descriptor identity admitted for one workload.
+ */
+export interface CapabilityBinding {
+/**
+ * Capability identity approved by admission.
+ */
+capability: CapabilityId
+/**
+ * Digest of the complete descriptor approved by admission.
+ * 
+ * @minItems 32
+ * @maxItems 32
+ */
+descriptor_digest: [number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number]
+}
+/**
+ * A versioned service verb that can be admitted independently.
+ */
+export interface CapabilityId {
+/**
+ * Versioned host service identity.
+ */
+service: ServiceId
+/**
+ * Verb within the versioned service.
+ */
 verb: string
 }
 /**

--- a/crates/mvm-vmm/src/host/host_agent_spawn.rs
+++ b/crates/mvm-vmm/src/host/host_agent_spawn.rs
@@ -285,6 +285,7 @@ pub fn register_host_agent_services_if_admitted(
             ),
             audit_signer_uds_path: None,
             services_bindings: vec![],
+            capability_bindings: vec![],
         },
     )?;
     warm_claim_debug("register_vm_done");
@@ -582,6 +583,7 @@ mod tests {
                 dir.join("audit-signer.sock").to_string_lossy().into_owned(),
             ),
             services_bindings: vec![],
+            capability_bindings: vec![],
         }
     }
 

--- a/features/suites/s27_sdk/agent_capability.feature
+++ b/features/suites/s27_sdk/agent_capability.feature
@@ -1,0 +1,15 @@
+@sdk
+Feature: Typed agent capability bindings
+  A typed host capability is admitted by exact descriptor identity and never
+  records the private payload that it serves.
+
+  Scenario: an admitted capability validates and audits only digests
+    Given an admitted typed echo capability
+    When I create a typed invocation for the private value "private credential"
+    Then the typed invocation is valid
+    And the capability audit excludes the private value
+
+  Scenario: a descriptor downgrade is refused
+    Given an admitted typed echo capability
+    When I change the admitted descriptor limits
+    Then the typed invocation is refused for a binding mismatch

--- a/schema/broker-services-v0.json
+++ b/schema/broker-services-v0.json
@@ -40,6 +40,109 @@
     }
   },
   "definitions": {
+    "AgentRequestId": {
+      "description": "Stable public request identifier.",
+      "type": "string"
+    },
+    "CapabilityBinding": {
+      "description": "Exact descriptor identity admitted for one workload.",
+      "type": "object",
+      "required": [
+        "capability",
+        "descriptor_digest"
+      ],
+      "properties": {
+        "capability": {
+          "description": "Capability identity approved by admission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CapabilityId"
+            }
+          ]
+        },
+        "descriptor_digest": {
+          "description": "Digest of the complete descriptor approved by admission.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxItems": 32,
+          "minItems": 32
+        }
+      },
+      "additionalProperties": false
+    },
+    "CapabilityId": {
+      "description": "A versioned service verb that can be admitted independently.",
+      "type": "object",
+      "required": [
+        "service",
+        "verb"
+      ],
+      "properties": {
+        "service": {
+          "description": "Versioned host service identity.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ServiceId"
+            }
+          ]
+        },
+        "verb": {
+          "description": "Verb within the versioned service.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "CapabilityInvocation": {
+      "description": "Typed invocation metadata carried alongside the existing broker payload.",
+      "type": "object",
+      "required": [
+        "binding",
+        "input_digest",
+        "invocation_id",
+        "protocol_version"
+      ],
+      "properties": {
+        "binding": {
+          "description": "Exact binding the caller claims to use.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CapabilityBinding"
+            }
+          ]
+        },
+        "input_digest": {
+          "description": "Digest of the `ServiceCall::payload` value.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxItems": 32,
+          "minItems": 32
+        },
+        "invocation_id": {
+          "description": "Bounded request identity used for replay refusal and audit joins.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AgentRequestId"
+            }
+          ]
+        },
+        "protocol_version": {
+          "description": "Version of this invocation contract.",
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
     "CostReport": {
       "description": "Response for both `host.cost.v1` verbs: the accumulated spend for the queried scope.",
       "type": "object",
@@ -228,6 +331,17 @@
         "verb"
       ],
       "properties": {
+        "capability": {
+          "description": "Optional typed capability metadata. Omitted for the established service-call path so its serialized shape remains byte-compatible.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CapabilityInvocation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "correlation_id": {
           "type": "string"
         },
@@ -347,6 +461,62 @@
           "type": "string",
           "enum": [
             "internal_error"
+          ]
+        },
+        {
+          "description": "Typed capability admission refused the request.",
+          "type": "string",
+          "enum": [
+            "capability_denied"
+          ]
+        },
+        {
+          "description": "Typed capability binding identity or descriptor digest did not match.",
+          "type": "string",
+          "enum": [
+            "capability_binding_mismatch"
+          ]
+        },
+        {
+          "description": "Typed capability protocol version is unsupported.",
+          "type": "string",
+          "enum": [
+            "capability_protocol_mismatch"
+          ]
+        },
+        {
+          "description": "Typed capability invocation id was already consumed.",
+          "type": "string",
+          "enum": [
+            "capability_replay"
+          ]
+        },
+        {
+          "description": "Typed capability input exceeded its admitted bound.",
+          "type": "string",
+          "enum": [
+            "capability_input_too_large"
+          ]
+        },
+        {
+          "description": "Typed capability output exceeded its admitted bound.",
+          "type": "string",
+          "enum": [
+            "capability_output_too_large"
+          ]
+        },
+        {
+          "description": "Typed capability invocation was canceled.",
+          "type": "string",
+          "enum": [
+            "capability_canceled"
+          ]
+        },
+        {
+          "description": "Typed capability handler failed without exposing handler details.",
+          "type": "string",
+          "enum": [
+            "capability_handler_failed"
           ]
         }
       ]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -30,6 +30,15 @@ for detailed scope and acceptance criteria.
   - [x] Bounded digest-only metadata, audit action mappings, client/SDK
         re-exports, unit tests, and three non-`@wip` BDD scenarios
 
+- [x] Plan 2170 — typed capability bindings
+      (`specs/plans/2170-typed-capability-bindings.md`)
+  - [x] Versioned per-verb descriptors, schema references, limits, and exact
+        descriptor-digest bindings
+  - [x] Host-signed admission allowlist and invocation-time fail-closed gates
+  - [x] Timeout, cancellation, replay, bounded I/O, typed failures, and
+        digest-only capability audit events
+  - [x] Real broker UDS round trip, BDD scenarios, and validation gates
+
 - [~] Security lane mutation-witness repair — **issue #2135**
   - [x] Add direct witnesses for the security-sensitive admission,
         verification, lease, and substitution cleanup invariants

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -93,6 +93,13 @@
       `mvm-sdk` re-export the shared policy surface; existing network, secret,
       sealed-production, guest, and command-gate enforcement remains in force.
 
+- [x] Typed capability bindings — **issue #2170**, plan
+      `specs/plans/2170-typed-capability-bindings.md`. The implementation is
+      complete through per-verb descriptors, exact signed admission bindings,
+      bounded typed invocation, digest-only audit events, refusal witnesses,
+      and a real UDS round trip. The PR carries the remaining host-specific
+      BDD execution note.
+
 - [x] Kernel pin freshness — **issue #2128**. Synchronized the libkrunfw
       bundle and custom guest kernel on the verified Linux 6.12.102 LTS
       tarball, replacing the stale 6.12.100 pin. Structural parity tests keep

--- a/specs/plans/2170-typed-capability-bindings.md
+++ b/specs/plans/2170-typed-capability-bindings.md
@@ -1,0 +1,72 @@
+# Plan 2170 — Typed capability bindings
+
+Status: READY FOR REVIEW
+
+## Objective
+
+Add a versioned, transport-neutral capability binding contract to the existing
+host broker. A guest may invoke a capability only when the host admitted the
+exact capability and descriptor digest for that workload. The handler remains
+host-owned; credentials, host paths, and handler internals never cross the
+guest boundary.
+
+## Design
+
+- `mvm-contract::protocol::agent_capability` owns the wire DTOs:
+  `CapabilityId` (`ServiceId` plus verb), `SchemaRef`, `CapabilityLimits`,
+  `CapabilityDescriptor`, `CapabilityBinding`, `CapabilityInvocation`,
+  `CapabilityFailureCode`, and digest-only `CapabilityAuditEvent` values.
+- A descriptor is versioned by its `ServiceId`, names the verb explicitly,
+  identifies input and output schemas by stable names and SHA-256 digests, and
+  carries maximum input/output bytes plus a maximum execution time. Descriptor
+  and binding validation rejects empty names, invalid IDs, zero or excessive
+  limits, and mismatched service/verb identities.
+- `ServiceCall` gains an optional capability invocation section. It is omitted
+  for the existing legacy host-service calls, so their serialized shape stays
+  unchanged. A typed call carries the protocol version, exact binding, bounded
+  invocation ID, and digest of the existing `payload` value.
+- `mvm-hostd::broker::Registry` gains per-verb registrations and a separate
+  admission allowlist. Typed dispatch checks, in order: protocol version,
+  registered descriptor, exact admitted binding, input digest and byte limit,
+  handler schema parsing, cancellation/timeout, and output byte limit. A
+  replayed invocation ID is refused before the handler runs. Legacy dispatch
+  remains on the existing path and never widens typed admission.
+- `RegisterVm` carries an optional list of exact typed bindings in addition to
+  the existing service list. The host-signed control request is the only source
+  of the typed allowlist; a guest cannot register or widen it.
+- Audit events contain only capability IDs, descriptor/binding digests,
+  invocation IDs, input/output digests, and closed outcome codes. They cover
+  registration, admission, invocation, refusal, timeout, cancellation, and
+  handler failure. No input/output JSON, credentials, tokens, or host error
+  text is recorded.
+
+## Implementation checklist
+
+- [x] Add and test the no-`std` capability contract and stable serialization.
+- [x] Add typed bindings to the signed broker registration DTO.
+- [x] Extend `ServiceCall` with the backward-compatible invocation envelope.
+- [x] Implement registry registration, exact allowlist admission, replay
+      refusal, bounded input/output, timeout, cancellation, and audit hooks.
+- [x] Route typed calls through the real UDS broker server and preserve the
+      existing legacy service path.
+- [x] Add positive and negative BDD scenarios plus focused protocol tests for
+      version mismatch, binding downgrade/confused deputy, denial, malformed
+      input, oversized input/output, timeout, cancellation, replay, handler
+      failure, and secret non-exposure.
+- [x] Update the sprint and refactor rollup, run the required host validation,
+      and link the evidence from issue #2170.
+
+Validation evidence: `cargo check --workspace`, focused contract/host/guest
+tests, the real host broker UDS round trip, the conformance BDD target compile,
+and targeted clippy all pass. The full `mvm-agentd` unit run has one unrelated
+macOS sandbox failure in `vsock::connection::tests::test_connect_response_preserves_bytes_after_ack`
+(`Operation not permitted`); its other 627 tests pass. Running the BDD binary
+itself remains dependent on a freshly built `mvmctl`; the repository's embedded
+helper build did not finish on this host.
+
+## Close gate
+
+Close #2170 only after a real client/UDS round trip proves an admitted typed
+capability succeeds, every listed refusal path is covered, audit records are
+digest-only, and workspace tests/checks/clippy plus the relevant BDD suite are
+green.


### PR DESCRIPTION
## Summary

Closes #2170.

- adds versioned per-verb capability descriptors, schema references, limits, exact descriptor-digest bindings, and digest-only audit events
- carries typed invocation metadata through the broker contract while preserving legacy ServiceCall serialization
- enforces host admission, replay refusal, bounded input/output, timeout, cancellation, typed failures, and handler error redaction
- routes admitted calls through the real host broker UDS server and adds guest helper and BDD coverage
- updates the sprint and refactor rollup

## Validation

- cargo fmt --all -- --check
- cargo check --workspace
- workspace pre-commit cargo clippy --workspace --all-targets -- -D warnings
- 602 mvm-contract tests pass
- typed registry, UDS, and guest envelope tests pass
- mvm-conformance BDD target compiles with the new scenarios

The full mvm-agentd unit run has one unrelated macOS sandbox failure in vsock::connection::tests::test_connect_response_preserves_bytes_after_ack (Operation not permitted); the other 627 tests pass. Running the BDD binary requires a freshly built mvmctl; the embedded helper build did not finish on this host.