### PR TITLE
chore(deps): drop 9 stale windows-targets entries from duplicate-major allowlist

### DIFF
--- a/xtask/src/check_duplicate_majors.rs
+++ b/xtask/src/check_duplicate_majors.rs
@@ -21,11 +21,10 @@ use std::path::Path;
 use std::process::Command;
 
 /// Crates known to resolve at more than one major today. Baseline recaptured
-/// 2026-08-10 from `cargo metadata --locked` after Plan 309 Phases 0-1 cut 23
-/// crates from the shipped closure (ratcheted 44 → 11 entries). Remove an entry
-/// freely once the duplication is gone (the gate flags stale entries); adding
-/// one must be justified in the PR that does — it admits a new duplicate major
-/// into the build.
+/// 2026-08-10 from `cargo metadata --locked` (ratcheted 44 → 11 entries).
+/// Remove an entry freely once the duplication is gone (the gate flags stale
+/// entries); adding one must be justified in the PR that does — it admits a
+/// new duplicate major into the build.
 const ALLOWLIST: &[&str] = &[
     "bitflags",
     // Neither defmt major is compiled: both are optional dependencies nobody
@@ -56,9 +55,8 @@ const ALLOWLIST: &[&str] = &[
     "vmm-sys-util",
     // windows-sys 0.52 and 0.60/0.61 remain a split; windows-core follows.
     // The per-architecture support crates (windows_aarch64_*, windows_i686_*,
-    // windows_x86_64_*, windows-targets) converged after Plan 309 dropped rayon
-    // and the rcgen x509-parser feature, so they are no longer duplicated and
-    // are not listed here.
+    // windows_x86_64_*, windows-targets) converged once rayon and rcgen's
+    // x509-parser feature were dropped — they are no longer duplicated.
     "windows-core",
     "windows-sys",
 ];

--- a/xtask/src/check_duplicate_majors.rs
+++ b/xtask/src/check_duplicate_majors.rs
@@ -21,8 +21,8 @@ use std::path::Path;
 use std::process::Command;
 
 /// Crates known to resolve at more than one major today. Baseline recaptured
-/// 2026-07-19 from `cargo metadata --locked` after the workspace consolidation
-/// de-duplicated the OCI/TLS stack (ratcheted 44 → 11 entries). Remove an entry
+/// 2026-08-10 from `cargo metadata --locked` after Plan 309 Phases 0-1 cut 23
+/// crates from the shipped closure (ratcheted 44 → 11 entries). Remove an entry
 /// freely once the duplication is gone (the gate flags stale entries); adding
 /// one must be justified in the PR that does — it admits a new duplicate major
 /// into the build.
@@ -54,21 +54,13 @@ const ALLOWLIST: &[&str] = &[
     // pins 0.12.1; the two rust-vmm families track different vmm-sys-util
     // majors until they converge.
     "vmm-sys-util",
-    // windows-sys 0.52 and 0.60/0.61 are already an accepted split. Those
-    // versions necessarily resolve matching windows-targets and per-architecture
-    // support crates at 0.52 and 0.53; none of these crates is independently
-    // selectable until the upstream windows-sys users converge.
+    // windows-sys 0.52 and 0.60/0.61 remain a split; windows-core follows.
+    // The per-architecture support crates (windows_aarch64_*, windows_i686_*,
+    // windows_x86_64_*, windows-targets) converged after Plan 309 dropped rayon
+    // and the rcgen x509-parser feature, so they are no longer duplicated and
+    // are not listed here.
     "windows-core",
     "windows-sys",
-    "windows-targets",
-    "windows_aarch64_gnullvm",
-    "windows_aarch64_msvc",
-    "windows_i686_gnu",
-    "windows_i686_gnullvm",
-    "windows_i686_msvc",
-    "windows_x86_64_gnu",
-    "windows_x86_64_gnullvm",
-    "windows_x86_64_msvc",
 ];
 
 pub fn run(workspace: &Path) -> Result<()> {


### PR DESCRIPTION
## What

Removes 9 stale entries from `ALLOWLIST` in `xtask/src/check_duplicate_majors.rs`:
`windows-targets`, `windows_aarch64_gnullvm`, `windows_aarch64_msvc`, `windows_i686_gnu`, `windows_i686_gnullvm`, `windows_i686_msvc`, `windows_x86_64_gnu`, `windows_x86_64_gnullvm`, `windows_x86_64_msvc`.

## Why

Plan 309 Phases 0-1 (merged #2285) dropped `rayon` and rcgen's `x509-parser` feature. Those were the packages causing the per-architecture Windows support crates to resolve at two incompatible majors. The gate now flags all 9 as stale entries. After removal, `check-duplicate-majors` reports "clean (11 known duplicate-major crates, all allowlisted)" with no stale-entry warning.

`windows-core` and `windows-sys` remain listed — their 0.52 / 0.60 split persists until the upstream `windows-sys` consumers converge. The baseline comment in the source is updated to reflect the current count.

## Verification

- `cargo run -p xtask -- check-duplicate-majors` → clean, no stale-entry warning
- `cargo run -p xtask -- check-forbidden-deps` → clean (`aws-lc-rs` absent from default closure, confirming Plan 126 B4/C1 status)
- `cargo test -p xtask` → 449 passed, 0 failed
- `cargo fmt --all -- --check` → clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01GezRLL1kmCcw122uTpyGJ5)_