### PR TITLE
Measure both backends at p50/p95/p99 and decompose the Firecracker gap

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-09
+Last updated: 2026-08-10
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -116,7 +116,13 @@ for detailed scope and acceptance criteria.
         Phase 6 ahead of Phase 3.
   - [ ] Phase 1 — content-addressed `--mount` image cache
   - [ ] Phase 2 — artifact preparation outside the launch path
-  - [ ] Phase 3 — reduce backend cold-start latency
+  - [~] Phase 3 — reduce backend cold-start latency. Re-measured on KVM at
+        `c866611af` as Phase 5 asked: `driver_boot` is 630.5 ms, unmoved from
+        623.6 ms, so the cost is real rather than a poll artifact and can be
+        decomposed. It is a shell `sleep 0.1` socket poll plus ~9 curl/sudo
+        subprocesses (**#2292**). On HVF there is little left — `vmm_create`
+        11.6 ms, `driver_boot` 7.8 ms — the remaining cold cost there is guest
+        boot at 58.6 ms.
   - [ ] Phase 4 — parallelize independent host work
   - [~] Phase 5 — event-driven guest readiness. The flat 50 ms readiness poll
         was quantizing every launch: adaptive backoff cut `guest_kernel_entry`
@@ -159,12 +165,16 @@ for detailed scope and acceptance criteria.
   - [x] Phase E — `artifact_bytes_hashed` + `process_table_scans` on the launch
         sample, both refused by the prepared lanes — **#2276**. Plan 299's
         contract table now names the image behind each percentile.
-  - [~] Phase F — HVF validated: both images converge at 0.43 s wall clock,
-        dispatch window 78.8-79.4 ms against the ≤200 ms p50 budget on a 1.1 GB
-        image, claim-8/claim-14 digests unchanged and the chain still verifies.
-        Outstanding: `ColdLaunchBench` percentiles on both images, the
-        Firecracker/KVM repeat, and the warm-lane comparison (no pool can be
-        filled on this host today).
+  - [~] Phase F — validated on both backends. HVF meets the contract at
+        p50/p95/p99 on a 1.1 GB image (dispatch 77.3 / 79.7 / 90.1 ms against
+        ≤200 / ≤250 / ≤300), and `alpine` and `python:3.12` now agree inside
+        run-to-run noise where they used to differ by ~780 ms. claim-8 /
+        claim-14 digests unchanged, chain still verifies. Firecracker/KVM
+        repeated: the fixes hold there (both counters zero) but that backend
+        misses the contract for reasons this plan does not own — `driver_boot`
+        630.5 ms (**#2292**) and 294 ms of audit fsync in `admit` (**#2293**).
+        Outstanding: the warm-lane comparison, blocked because no standby pool
+        can be filled today.
 
 - [~] eBPF vsock egress telemetry spike — **issue #2211**, branch
       `feat/ebpf-vsock-egress-telemetry`

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -217,6 +217,31 @@ What this establishes:
    54.1 ms. Neither dominates, and together they are only a third of the cold
    wall clock.
 
+### Post-Plan-311 re-measurement — Apple Silicon / HVF
+
+Release `mvmctl` at `c866611af`, `ColdLaunchBench`, 20 runs + 2 warm-ups per
+lane, every sample through the lane gate. Both images reported independently
+per the contract's image-naming rule.
+
+| lane | dispatch p50 | p95 | p99 | total p50 |
+|---|---:|---:|---:|---:|
+| `alpine` (9.9 MB rootfs) | 79.6 ms | 84.9 ms | 93.6 ms | 320.1 ms |
+| `python:3.12` (1.1 GB rootfs) | 77.3 ms | 79.7 ms | 90.1 ms | 316.1 ms |
+
+Plan 311 removed the per-launch work that made these two differ; they now agree
+inside run-to-run noise at every percentile. The prepared-cold contract is met
+on this backend with a 3.3x margin at p99, on a 1.1 GB image.
+
+What this changes for the remaining phases on HVF:
+
+- **Phase 3 has little left here.** `vmm_create` is 11.6 ms and the backend's
+  own `driver_boot` is 7.8 ms p50. `guest_kernel_entry` at 58.6 ms is now three
+  quarters of the dispatch window, so the remaining cold-start cost on this
+  backend is the guest booting, not the VMM being created.
+- **Phase 6 is still the largest single span in the run.** `stop_transient` is
+  128.1 ms p50 — larger than the whole dispatch window that precedes it, and it
+  runs after the command has already produced its answer.
+
 ### Measured baseline — Linux Firecracker / KVM
 
 Same lane, same 20 runs + 2 warm-ups, release build, on the established KVM
@@ -438,6 +463,49 @@ Two consequences for the rest of the plan. Phase 3's target on HVF is now
 known to be guest boot rather than VMM setup — 65 ms of the 70 ms. And the
 Firecracker `driver_boot` of 623.6 ms should be re-measured against these
 fixes before being decomposed, since it contains a poll of its own.
+
+### Phase 3 re-measurement — Linux Firecracker / KVM, post-Phase-5
+
+Phase 5 said the Firecracker `driver_boot` of 623.6 ms should be re-measured
+against the poll fixes before being decomposed, since it contains a poll of its
+own. Re-measured on `main` at `c866611af`, release, prepared cache, x86_64 KVM
+host:
+
+```
+phases:  drives=46.0  admit=294.4  backend_start=689.8  vsock_wait=2.1
+         command=57.3  teardown=423.8  total=1513.4   dispatch_window=691.9
+backend: driver_boot=630.5  console_stream_start=3.6  activate_workload=16.6
+         broker_register=38.7
+work:    artifact_bytes_hashed=0  process_table_scans=0
+```
+
+`driver_boot` **did not move**: 623.6 ms before, 630.5 ms after. The poll it was
+suspected of containing is not one of the four Phase 5 replaced. So Phase 3 is a
+real cost and can be decomposed — that was the open question and it is now
+closed.
+
+Note `guest_kernel_entry=0.0`: the Firecracker driver confirms boot before
+returning, so `driver_boot` spans VMM start *and* guest boot, which HVF reports
+as two spans. The like-for-like comparison is HVF's 11.6 + 58.6 = ~70 ms against
+630 ms, an excess of ~560 ms.
+
+Decomposed (**issue #2292**): the driver boots through a shell script that polls
+for the API socket on a fixed `sleep 0.1` — the same quantization Phase 5
+removed from four Rust sites, missed here because it lives in a shell heredoc —
+and then issues each API call as its own `curl` subprocess behind `sudo bash`.
+Measured on the same box: 7 ms per `sudo bash -c true`, 6 ms per `curl` spawn,
+about nine calls per boot. So ~100 ms of tick plus ~120 ms of spawn, roughly 35%
+of `driver_boot`, removable without touching the VMM.
+
+**A second cost this exposed (issue #2293).** `admit` is 294 ms here against
+~38 ms on HVF, and it is neither compute nor hashing. One launch appends **8**
+chain entries, each its own `write_all` + `sync_data` per Plan 303 WS2, and
+`fsync` on this host's md2 array costs 41.7 ms p50 — so ~334 ms of durability
+per launch. The entry list also shows `plan.admitted` twice, once from the OCI
+provenance path and once from the boot admission. On Linux, admission alone
+exceeds the ≤200 ms p50 contract before any VMM work happens; on macOS it is
+invisible. Phase 4's "keep admission entirely local" is necessary but not
+sufficient — local is not the same as cheap when every entry is a barrier.
 
 ## Phase 1 — Content-addressed `--mount` image cache
 

--- a/specs/plans/311-launch-critical-path-waste.md
+++ b/specs/plans/311-launch-critical-path-waste.md
@@ -1,7 +1,9 @@
 # Plan 311 — Launch critical-path waste on real-sized images
 
-**Status:** Phases A0, B, C, D, E complete and measured on Apple Silicon / HVF.
-Phase F partially complete — the Firecracker/KVM repeat is outstanding.
+**Status:** Phases A0-E complete and measured on Apple Silicon / HVF at
+p50/p95/p99. Phase F complete except the warm-lane comparison, which cannot run
+until a standby pool can be filled. The Firecracker/KVM repeat is done and
+surfaced two costs this plan does not own — see #2292 and #2293.
 
 ## Goal
 
@@ -164,6 +166,40 @@ prepared lanes when nonzero — so this is a gate, not a note. The six runs
 behind the table above vary by 0.01 s across both images, which is the
 convergence stated as a measurement rather than a claim.
 
+### Percentiles through the benchmark harness
+
+Wall clock above is the before/after. These are the contract numbers: release
+binary, `ColdLaunchBench` via the Plan 299 entry point, 20 measured runs after
+2 warm-ups per lane, every sample through the lane gate (the harness refuses a
+short report, so 20 samples means 20 launches cleared it).
+
+| lane | dispatch p50 | p95 | p99 | total p50 |
+|---|---:|---:|---:|---:|
+| `alpine` (9.9 MB rootfs) | 79.6 ms | 84.9 ms | 93.6 ms | 320.1 ms |
+| `python:3.12` (1.1 GB rootfs) | **77.3 ms** | **79.7 ms** | **90.1 ms** | 316.1 ms |
+| budget | ≤200 ms | ≤250 ms | ≤300 ms | — |
+
+The 116x image-size difference is now inside the run-to-run noise at every
+percentile, and `python:3.12` clears the p99 budget with a 3.3x margin. Before
+this change the same pair differed by ~780 ms.
+
+Sub-phases on the large image, p50 / p99:
+
+| span | p50 | p99 |
+|---|---:|---:|
+| `vmm_create` | 11.6 ms | 14.4 ms |
+| `guest_kernel_entry` | 58.6 ms | 67.9 ms |
+| `agent_auth` | 3.4 ms | 6.0 ms |
+| `artifact_verify`, `first_dispatch` | ≤0.1 ms | ≤0.1 ms |
+| `stop_transient` | 128.1 ms | 139.8 ms |
+| backend `driver_boot` | 7.8 ms | 8.9 ms |
+
+Two things this says. Guest boot to a serving agent is ~59 ms and is now three
+quarters of the dispatch window — VM creation is 11.6 ms and the backend's own
+`driver_boot` is 7.8 ms, so there is little left to win on the HVF VMM side.
+And `stop_transient` at 128 ms is larger than the entire dispatch window it
+follows.
+
 ### What is left, and who owns it
 
 Of the ~420 ms wall clock that remains, the largest single span is
@@ -174,15 +210,12 @@ serving agent and is Plan 299 Phase 3/5.
 
 ## What is still not measured
 
-- Every result above is Apple Silicon / HVF on one host. Firecracker/KVM is
-  **not** re-measured. Plan 299 Phase 0 records `driver_boot` at 623.6 ms there
-  against 53.8 ms on HVF, so the proportions certainly differ; whether the three
-  fixes help as much is unknown until the KVM host runs the same pair.
-- Wall clock via `/usr/bin/time`, 5–8 runs per lane, reported as a range rather
-  than percentiles. The Plan 299 benchmark entry point produces p50/p95/p99
-  through the lane gate and should be run on both images before any percentile
-  is published; the ranges here are evidence that the change works, not a
-  published number.
+- **Firecracker/KVM is now measured** (Plan 299 Phase 3 re-measurement section).
+  The Plan 311 fixes hold there — a prepared Firecracker launch reports
+  `artifact_bytes_hashed: 0` and `process_table_scans: 0` — but that backend
+  misses the contract for reasons this plan does not own: `driver_boot` 630.5 ms
+  (#2292) and 294 ms of audit-chain fsync in `admit` (#2293). The prepared-cold
+  contract is met on HVF and **not** on Firecracker.
 - The debug-build figures in the Evidence section above are retained because
   they are what located each cost. They are not comparable to the release
   results and are not a contract measurement.
@@ -293,12 +326,11 @@ Issue #2275.
 
 Issue #2276.
 
-- [~] Run the prepared-cold lane on a large-rootfs image, reported
+- [x] Ran the prepared-cold lane on a large-rootfs image, reported
       independently. The benchmark entry point already takes its argv from
-      `MVM_COLD_LAUNCH_ARGS`, so a large-image lane needs no new code — it needs
-      a second invocation. Measured here by hand (wall clock, 5-8 runs); a
-      p50/p95/p99 run through `ColdLaunchBench` on both images is still owed,
-      and is the first task of Phase F.
+      `MVM_COLD_LAUNCH_ARGS`, so the large-image lane needed a second
+      invocation rather than new code. Both lanes are recorded above at
+      p50/p95/p99 through the lane gate.
 - [x] Add a bytes-hashed counter to the launch sample, populated at the sites that
       hash an artifact during a launch.
 - [x] Extend the Plan 299 lane gate to refuse a `prepared_cold` sample that hashed
@@ -313,9 +345,10 @@ Issue #2276.
 ## Phase F — Validation
 
 - [x] Re-run the Phase A0 lanes on the final tree; publish `alpine` and
-      large-image prepared cold side by side against the ≤200 ms p50 / ≤300 ms p99
-      contract. (Wall clock + dispatch window; percentiles through
-      `ColdLaunchBench` still owed — see Phase E's first item.)
+      large-image prepared cold side by side against the ≤200 ms p50 / ≤300 ms
+      p99 contract. Done at p50/p95/p99 on both images.
+- [x] Repeat on Firecracker/KVM. The fixes hold (both counters zero); that
+      backend's remaining gap is #2292 and #2293, recorded in Plan 299 Phase 3.
 - [~] Confirm the warm lane has not regressed against Plan 265. **Not run:**
       the standby pool is empty on this host (`pool status` reports 0 idle) and
       `pool warm` spawns nothing today, so there is no warm claim to measure.


### PR DESCRIPTION
Documentation only. Closes the three measurement debts Plan 311 left open, and answers the question Plan 299 Phase 5 explicitly deferred.

## HVF meets the contract, on a large image, at p99

`ColdLaunchBench`, release, 20 runs + 2 warm-ups per lane, every sample through the lane gate:

| lane | dispatch p50 | p95 | p99 |
|---|---:|---:|---:|
| `alpine` (9.9 MB) | 79.6 ms | 84.9 ms | 93.6 ms |
| `python:3.12` (1.1 GB) | **77.3 ms** | **79.7 ms** | **90.1 ms** |
| budget | ≤200 ms | ≤250 ms | ≤300 ms |

The 116× image-size difference is now inside run-to-run noise at every percentile. Before Plan 311 the same pair differed by ~780 ms. This is the claim Plan 299 could not previously make, and it is now made with percentiles rather than wall clock.

Little left on the HVF VMM: `vmm_create` 11.6 ms, backend `driver_boot` 7.8 ms. `guest_kernel_entry` at 58.6 ms is three quarters of what remains.

## Firecracker: the deferred question, answered

Phase 5 said the 623.6 ms `driver_boot` "should be re-measured against these fixes before being decomposed, since it contains a poll of its own."

**Re-measured on current main: 630.5 ms. It did not move.** The cost is real, not a measurement artifact, and Phase 3 can proceed.

Decomposed in #2292 — the driver boots through a shell script polling for the API socket on a fixed `sleep 0.1` (the same quantization Phase 5 removed from four Rust sites, missed because it lives in a shell heredoc), then issues each API call as its own `curl` subprocess behind `sudo bash`. Measured on the box: 7 ms per `sudo bash -c true`, 6 ms per `curl` spawn, ~9 calls per boot. About 35% of `driver_boot` is tick and spawn, removable without touching the VMM.

Worth knowing when comparing backends: `guest_kernel_entry=0.0` on Firecracker because the driver confirms boot before returning, so `driver_boot` spans VMM start *and* guest boot. Like-for-like against HVF is 70 ms vs 630 ms.

## What the Linux run also exposed

`admit` is 294 ms on KVM against ~38 ms on HVF — neither compute nor hashing, since both Plan 311 counters read zero. One launch appends **8** chain entries, each its own `write_all` + `sync_data` per Plan 303 WS2, and `fsync` on that host costs **41.7 ms p50**. That is ~334 ms of durability per launch, and admission alone exceeds the ≤200 ms contract before any VMM work happens. The entry list also carries `plan.admitted` **twice** — once from the OCI provenance path, once from the boot admission — which is a correctness question before it is a performance one.

Filed as #2293. Not asking to weaken the durability Plan 303 WS2 established; asking for the per-launch fsync *count* to be costed, which nobody has done.

## Net

The prepared-cold contract is **met on HVF and missed on Firecracker**, and both reasons belong to Plan 299 Phase 3 and the audit chain rather than to Plan 311. Plan 311's own fixes hold on both backends.

Still unrun and marked as such: the warm-lane comparison. No standby pool can be filled today (`pool status` reports 0 idle, `pool warm` spawns nothing).

Evidence recorded in Plan 299 (a Phase 3 re-measurement section and a post-311 HVF section), Plan 311's Phase F, and the rollup.