### PR TITLE
perf(hvf): measure demand-faulted RAM and restore mapping cost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7104,6 +7104,7 @@ dependencies = [
  "hex",
  "mvm-cli",
  "mvm-core",
+ "mvm-fs",
  "regex",
  "serde",
  "serde_json",

--- a/crates/mvm-cli/src/bench/cold_launch.rs
+++ b/crates/mvm-cli/src/bench/cold_launch.rs
@@ -14,8 +14,8 @@
 use serde::{Deserialize, Serialize};
 
 pub use crate::commands::vm::launch_sample::{
-    ArtifactPaths, BuildProfile, GuestSizing, LAUNCH_SAMPLE_SCHEMA_VERSION, LaunchSample,
-    LaunchSubTimings, LaunchWork,
+    ArtifactPaths, BuildProfile, GuestSizing, LAUNCH_SAMPLE_SCHEMA_VERSION, LaunchRootStrategy,
+    LaunchSample, LaunchSubTimings, LaunchWork,
 };
 pub use crate::commands::vm::phase_timing::{
     LaunchMode, LaunchSubMarks, RunPhaseTimings, SubPhase,
@@ -24,11 +24,12 @@ pub use mvm_core::launch_trace::TracePhase;
 
 use super::stats::percentile;
 
-/// Report schema version for [`ColdLaunchReport`]. Version 2 adds artifact
-/// byte measurements and optional resolved kernel-config evidence to each raw
-/// sample; older reports remain readable through serde defaults but are not
-/// comparable without the new substrate fields.
-pub const COLD_LAUNCH_SCHEMA_VERSION: u32 = 2;
+/// Report schema version for [`ColdLaunchReport`]. Version 2 added artifact
+/// byte measurements and optional resolved kernel-config evidence; version 3
+/// adds the selected root filesystem strategy. Older reports remain readable
+/// through serde defaults but are not comparable without the new substrate
+/// fields.
+pub const COLD_LAUNCH_SCHEMA_VERSION: u32 = 3;
 
 /// The measurement lanes the cold-launch contract reports independently.
 ///
@@ -361,6 +362,9 @@ pub struct LaunchContext {
     /// The VMM's own version where it is knowable without probing a foreign
     /// binary. `None` is "not resolved", never "unversioned".
     pub vmm_version: Option<String>,
+    /// Root filesystem strategy selected by the capability/security tier gate.
+    #[serde(default)]
+    pub root_strategy: Option<crate::commands::vm::launch_sample::LaunchRootStrategy>,
     pub sizing: GuestSizing,
     pub filesystem: Option<String>,
     pub artifacts: ArtifactPaths,
@@ -587,6 +591,7 @@ mod tests {
             os: "macos".to_string(),
             arch: "aarch64".to_string(),
             launch_mode: LaunchMode::Cold,
+            root_strategy: Some(LaunchRootStrategy::BlockExt4),
             sizing: GuestSizing {
                 cpus: 2,
                 memory_mib: 512,
@@ -611,6 +616,7 @@ mod tests {
                 arch: "aarch64".to_string(),
                 mvm_version: "0.1.0".to_string(),
                 vmm_version: Some("0.1.0".to_string()),
+                root_strategy: Some(LaunchRootStrategy::BlockExt4),
                 sizing: GuestSizing {
                     cpus: 2,
                     memory_mib: 512,

--- a/crates/mvm-cli/src/bench/cold_launch.rs
+++ b/crates/mvm-cli/src/bench/cold_launch.rs
@@ -24,8 +24,11 @@ pub use mvm_core::launch_trace::TracePhase;
 
 use super::stats::percentile;
 
-/// Report schema version for [`ColdLaunchReport`].
-pub const COLD_LAUNCH_SCHEMA_VERSION: u32 = 1;
+/// Report schema version for [`ColdLaunchReport`]. Version 2 adds artifact
+/// byte measurements and optional resolved kernel-config evidence to each raw
+/// sample; older reports remain readable through serde defaults but are not
+/// comparable without the new substrate fields.
+pub const COLD_LAUNCH_SCHEMA_VERSION: u32 = 2;
 
 /// The measurement lanes the cold-launch contract reports independently.
 ///
@@ -282,6 +285,29 @@ pub struct ArtifactDigests {
     pub rootfs_sha256: Option<String>,
 }
 
+/// Artifact measurements resolved outside the launch's timed window.
+///
+/// Missing artifact paths stay `None`: the launch sample is still useful for
+/// timing, but the report makes the missing substrate evidence visible instead
+/// of turning it into a fabricated zero.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ArtifactMeasurements {
+    pub kernel_bytes: Option<u64>,
+    pub initramfs_bytes: Option<u64>,
+    pub runtime_overlay_bytes: Option<u64>,
+    pub rootfs_bytes: Option<u64>,
+    pub kernel_config: Option<KernelConfigMeasurement>,
+}
+
+/// Resolved kernel-config evidence attached to a launch report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct KernelConfigMeasurement {
+    pub path: String,
+    pub builtin_symbols: u32,
+}
+
 /// Which caches a lane was measured against.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -339,6 +365,8 @@ pub struct LaunchContext {
     pub filesystem: Option<String>,
     pub artifacts: ArtifactPaths,
     pub digests: ArtifactDigests,
+    #[serde(default)]
+    pub measurements: ArtifactMeasurements,
 }
 
 /// One measured launch, with everything needed to re-read it later.
@@ -591,6 +619,7 @@ mod tests {
                 filesystem: Some("apfs".to_string()),
                 artifacts: ArtifactPaths::default(),
                 digests: ArtifactDigests::default(),
+                measurements: ArtifactMeasurements::default(),
             },
             cache: CacheState {
                 artifacts_cached: true,

--- a/crates/mvm-cli/src/bench/cold_launch.rs
+++ b/crates/mvm-cli/src/bench/cold_launch.rs
@@ -100,6 +100,8 @@ pub enum LaneViolation {
     NotReleaseBuild { profile: BuildProfile },
     /// The sample's schema is not the one this consumer understands.
     SchemaMismatch { found: u32, expected: u32 },
+    /// The current sample does not identify its selected root filesystem path.
+    MissingRootStrategy,
     /// The launch performed work the lane forbids.
     ForbiddenWork {
         lane: LaunchLane,
@@ -128,6 +130,10 @@ impl std::fmt::Display for LaneViolation {
             Self::SchemaMismatch { found, expected } => write!(
                 f,
                 "launch sample schema {found} is not the expected {expected}"
+            ),
+            Self::MissingRootStrategy => write!(
+                f,
+                "launch sample does not identify its selected root filesystem strategy"
             ),
             Self::ForbiddenWork { lane, performed } => write!(
                 f,
@@ -171,6 +177,9 @@ pub fn validate_lane(lane: LaunchLane, sample: &LaunchSample) -> Result<(), Lane
             found: sample.schema_version,
             expected: LAUNCH_SAMPLE_SCHEMA_VERSION,
         });
+    }
+    if sample.root_strategy.is_none() {
+        return Err(LaneViolation::MissingRootStrategy);
     }
     if sample.build_profile != BuildProfile::Release {
         return Err(LaneViolation::NotReleaseBuild {
@@ -960,6 +969,16 @@ mod tests {
                 found: LAUNCH_SAMPLE_SCHEMA_VERSION + 1,
                 expected: LAUNCH_SAMPLE_SCHEMA_VERSION,
             })
+        );
+    }
+
+    #[test]
+    fn a_missing_root_strategy_is_rejected() {
+        let mut sample = launch_sample();
+        sample.root_strategy = None;
+        assert_eq!(
+            validate_lane(LaunchLane::PreparedCold, &sample),
+            Err(LaneViolation::MissingRootStrategy)
         );
     }
 

--- a/crates/mvm-cli/src/bench/cold_launch_runner.rs
+++ b/crates/mvm-cli/src/bench/cold_launch_runner.rs
@@ -240,6 +240,7 @@ fn cold_launch_sample(
             arch: sample.arch.clone(),
             mvm_version: sample.mvm_version.clone(),
             vmm_version: vmm_version_for(&sample.backend, &sample.mvm_version),
+            root_strategy: sample.root_strategy,
             sizing: sample.sizing,
             filesystem: host_filesystem(Path::new(&mvm_core::config::mvm_home())),
             artifacts: sample.artifacts.clone(),
@@ -384,8 +385,8 @@ fn host_filesystem(_path: &Path) -> Option<String> {
 mod tests {
     use super::*;
     use crate::commands::vm::launch_sample::{
-        BuildProfile, GuestSizing, LAUNCH_SAMPLE_SCHEMA_VERSION, LaunchSubTimings, LaunchWork,
-        write_sample,
+        BuildProfile, GuestSizing, LAUNCH_SAMPLE_SCHEMA_VERSION, LaunchRootStrategy,
+        LaunchSubTimings, LaunchWork, write_sample,
     };
     use crate::commands::vm::phase_timing::{LaunchMode, RunPhaseTimings};
 
@@ -398,6 +399,7 @@ mod tests {
             os: "macos".to_string(),
             arch: "aarch64".to_string(),
             launch_mode: LaunchMode::Cold,
+            root_strategy: Some(LaunchRootStrategy::BlockExt4),
             sizing: GuestSizing {
                 cpus: 2,
                 memory_mib: 512,
@@ -555,6 +557,10 @@ tmpfs /tmp tmpfs rw 0 0
             lane_sample.context.vmm_version,
             Some("9.9.9".to_string()),
             "the in-house VMM ships inside mvmctl, so its version is known"
+        );
+        assert_eq!(
+            lane_sample.context.root_strategy,
+            Some(LaunchRootStrategy::BlockExt4)
         );
         assert!(lane_sample.cache.artifacts_cached);
         assert_eq!(lane_sample.phases.total_ms, 148.0);

--- a/crates/mvm-cli/src/bench/cold_launch_runner.rs
+++ b/crates/mvm-cli/src/bench/cold_launch_runner.rs
@@ -16,7 +16,7 @@ use super::cold_launch::{
     KernelConfigMeasurement, LaunchContext, LaunchLane, build_cold_launch_report, validate_lane,
 };
 use crate::commands::vm::launch_sample::{
-    ArtifactPaths, LAUNCH_SAMPLE_ENV, LaunchSample, read_sample,
+    ArtifactPaths, LAUNCH_SAMPLE_ENV, LaunchRootStrategy, LaunchSample, read_sample,
 };
 
 /// Program names that would fold a build into a launch sample.
@@ -74,6 +74,7 @@ impl ColdLaunchBench {
     /// Run the warm-up iterations, then the measured ones, and summarise.
     pub fn run(&self) -> Result<ColdLaunchReport> {
         let staging = tempfile::tempdir().context("creating launch sample staging dir")?;
+        let mut strategy = None;
         for index in 0..self.warmup {
             let sample = self
                 .launch_once(staging.path(), "warmup", index)
@@ -82,6 +83,7 @@ impl ColdLaunchBench {
             // set up wrong; discarding its timing must not discard that.
             validate_lane(self.lane, &sample)
                 .with_context(|| format!("warm-up launch {index} does not belong in this lane"))?;
+            record_root_strategy(&mut strategy, &sample, "warm-up", index)?;
         }
 
         let mut raw = Vec::with_capacity(self.runs as usize);
@@ -93,6 +95,7 @@ impl ColdLaunchBench {
             validate_lane(self.lane, &sample).with_context(|| {
                 format!("measured launch {number} does not belong in this lane")
             })?;
+            record_root_strategy(&mut strategy, &sample, "measured", number)?;
             raw.push(cold_launch_sample(
                 self.lane,
                 number,
@@ -127,6 +130,27 @@ impl ColdLaunchBench {
         }
         read_sample(&sample_path)
     }
+}
+
+fn record_root_strategy(
+    expected: &mut Option<LaunchRootStrategy>,
+    sample: &LaunchSample,
+    phase: &str,
+    number: u32,
+) -> Result<()> {
+    let Some(found) = sample.root_strategy else {
+        bail!("{phase} launch {number} did not identify a root filesystem strategy");
+    };
+    match expected {
+        None => *expected = Some(found),
+        Some(expected) if *expected != found => {
+            bail!(
+                "{phase} launch {number} selected root filesystem strategy {found:?}, but the benchmark already observed {expected:?}; one report cannot mix strategies"
+            );
+        }
+        Some(_) => {}
+    }
+    Ok(())
 }
 
 impl ColdLaunchBenchBuilder {
@@ -656,6 +680,26 @@ tmpfs /tmp tmpfs rw 0 0
         let rendered = format!("{err:#}");
         assert!(rendered.contains("measured launch 2"), "{rendered}");
         assert!(rendered.contains("image_pull"), "{rendered}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_runner_refuses_mixed_root_filesystem_strategies() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut different = sample_for(100.0);
+        different.root_strategy = Some(LaunchRootStrategy::VirtiofsRoot);
+        let mvmctl = fake_mvmctl(tmp.path(), &[sample_for(100.0), different]);
+
+        let err = ColdLaunchBench::builder(&mvmctl, LaunchLane::PreparedCold)
+            .runs(2)
+            .warmup(0)
+            .build()
+            .unwrap()
+            .run()
+            .unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("root filesystem strategy"), "{rendered}");
+        assert!(rendered.contains("measured launch 2"), "{rendered}");
     }
 
     #[cfg(unix)]

--- a/crates/mvm-cli/src/bench/cold_launch_runner.rs
+++ b/crates/mvm-cli/src/bench/cold_launch_runner.rs
@@ -12,8 +12,8 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 
 use super::cold_launch::{
-    ArtifactDigests, CacheState, ColdLaunchReport, ColdLaunchSample, LaunchContext, LaunchLane,
-    build_cold_launch_report, validate_lane,
+    ArtifactDigests, ArtifactMeasurements, CacheState, ColdLaunchReport, ColdLaunchSample,
+    KernelConfigMeasurement, LaunchContext, LaunchLane, build_cold_launch_report, validate_lane,
 };
 use crate::commands::vm::launch_sample::{
     ArtifactPaths, LAUNCH_SAMPLE_ENV, LaunchSample, read_sample,
@@ -36,6 +36,7 @@ pub struct ColdLaunchBench {
     env: Vec<(String, String)>,
     runs: u32,
     warmup: u32,
+    kernel_config: Option<PathBuf>,
 }
 
 /// Builder for [`ColdLaunchBench`].
@@ -47,6 +48,7 @@ pub struct ColdLaunchBenchBuilder {
     env: Vec<(String, String)>,
     runs: u32,
     warmup: u32,
+    kernel_config: Option<PathBuf>,
 }
 
 impl ColdLaunchBench {
@@ -60,6 +62,7 @@ impl ColdLaunchBench {
             env: Vec::new(),
             runs: 20,
             warmup: 2,
+            kernel_config: None,
         }
     }
 
@@ -90,7 +93,12 @@ impl ColdLaunchBench {
             validate_lane(self.lane, &sample).with_context(|| {
                 format!("measured launch {number} does not belong in this lane")
             })?;
-            raw.push(cold_launch_sample(self.lane, number, &sample));
+            raw.push(cold_launch_sample(
+                self.lane,
+                number,
+                &sample,
+                self.kernel_config.as_deref(),
+            )?);
         }
         Ok(build_cold_launch_report(self.lane, self.warmup, raw))
     }
@@ -159,6 +167,16 @@ impl ColdLaunchBenchBuilder {
         self
     }
 
+    /// Optional resolved kernel config to count in each report sample.
+    ///
+    /// The config is read after each launch and never inside the launch
+    /// process, so the measurement cannot charge config I/O to boot latency.
+    #[must_use]
+    pub fn kernel_config(mut self, path: impl Into<PathBuf>) -> Self {
+        self.kernel_config = Some(path.into());
+        self
+    }
+
     /// Validate and build.
     pub fn build(self) -> Result<ColdLaunchBench> {
         if self.runs == 0 {
@@ -178,6 +196,7 @@ impl ColdLaunchBenchBuilder {
             env: self.env,
             runs: self.runs,
             warmup: self.warmup,
+            kernel_config: self.kernel_config,
         })
     }
 }
@@ -206,8 +225,13 @@ fn reject_build_tool(program: &Path) -> Result<()> {
 /// Turn one launch's own sample into a lane sample, resolving the artifact
 /// digests here — outside the measured window — so hashing never lands in a
 /// launch's wall clock.
-fn cold_launch_sample(lane: LaunchLane, number: u32, sample: &LaunchSample) -> ColdLaunchSample {
-    ColdLaunchSample {
+fn cold_launch_sample(
+    lane: LaunchLane,
+    number: u32,
+    sample: &LaunchSample,
+    kernel_config: Option<&Path>,
+) -> Result<ColdLaunchSample> {
+    Ok(ColdLaunchSample {
         lane,
         number,
         context: LaunchContext {
@@ -220,6 +244,7 @@ fn cold_launch_sample(lane: LaunchLane, number: u32, sample: &LaunchSample) -> C
             filesystem: host_filesystem(Path::new(&mvm_core::config::mvm_home())),
             artifacts: sample.artifacts.clone(),
             digests: digests_for(&sample.artifacts),
+            measurements: measurements_for(&sample.artifacts, kernel_config)?,
         },
         cache: CacheState::from_sample(sample),
         work: sample.work,
@@ -228,7 +253,42 @@ fn cold_launch_sample(lane: LaunchLane, number: u32, sample: &LaunchSample) -> C
         sub_phases: sample.sub_phases,
         backend_phases: sample.backend_phases.clone(),
         degraded: sample.degraded.clone(),
-    }
+    })
+}
+
+fn measurements_for(
+    paths: &ArtifactPaths,
+    kernel_config: Option<&Path>,
+) -> Result<ArtifactMeasurements> {
+    let bytes = |path: &Option<String>| {
+        path.as_deref()
+            .and_then(|path| std::fs::metadata(path).ok())
+            .filter(|metadata| metadata.is_file())
+            .map(|metadata| metadata.len())
+    };
+    let kernel_config = kernel_config
+        .map(read_kernel_config_measurement)
+        .transpose()?;
+    Ok(ArtifactMeasurements {
+        kernel_bytes: bytes(&paths.kernel),
+        initramfs_bytes: bytes(&paths.initramfs),
+        runtime_overlay_bytes: bytes(&paths.runtime_overlay),
+        rootfs_bytes: bytes(&paths.rootfs),
+        kernel_config,
+    })
+}
+
+fn read_kernel_config_measurement(path: &Path) -> Result<KernelConfigMeasurement> {
+    let config = std::fs::read_to_string(path)
+        .with_context(|| format!("reading kernel config {}", path.display()))?;
+    let builtin_symbols = config
+        .lines()
+        .filter(|line| line.trim_end().ends_with("=y"))
+        .count();
+    Ok(KernelConfigMeasurement {
+        path: path.display().to_string(),
+        builtin_symbols: u32::try_from(builtin_symbols).unwrap_or(u32::MAX),
+    })
 }
 
 /// The VMM's version, where it is knowable without probing a foreign binary.
@@ -434,6 +494,40 @@ mod tests {
     }
 
     #[test]
+    fn measurements_capture_artifact_bytes_and_kernel_config_symbols() {
+        let tmp = tempfile::tempdir().unwrap();
+        let kernel = tmp.path().join("vmlinux");
+        let initramfs = tmp.path().join("initramfs.cpio.gz");
+        let config = tmp.path().join("workload.config");
+        std::fs::write(&kernel, b"kernel").unwrap();
+        std::fs::write(&initramfs, b"initrd").unwrap();
+        std::fs::write(&config, "CONFIG_ONE=y\nCONFIG_TWO=m\nCONFIG_THREE=y\n").unwrap();
+
+        let measurements = measurements_for(
+            &ArtifactPaths {
+                kernel: Some(kernel.to_string_lossy().into_owned()),
+                initramfs: Some(initramfs.to_string_lossy().into_owned()),
+                runtime_overlay: None,
+                rootfs: None,
+            },
+            Some(&config),
+        )
+        .unwrap();
+
+        assert_eq!(measurements.kernel_bytes, Some(6));
+        assert_eq!(measurements.initramfs_bytes, Some(6));
+        assert_eq!(measurements.runtime_overlay_bytes, None);
+        assert_eq!(measurements.rootfs_bytes, None);
+        assert_eq!(
+            measurements.kernel_config,
+            Some(KernelConfigMeasurement {
+                path: config.display().to_string(),
+                builtin_symbols: 2,
+            })
+        );
+    }
+
+    #[test]
     fn proc_mounts_picks_the_longest_matching_mount_point() {
         let mounts = "\
 /dev/root / ext4 rw,relatime 0 0
@@ -454,7 +548,7 @@ tmpfs /tmp tmpfs rw 0 0
     #[test]
     fn a_sample_becomes_a_lane_sample_with_derived_context() {
         let sample = sample_for(148.0);
-        let lane_sample = cold_launch_sample(LaunchLane::PreparedCold, 3, &sample);
+        let lane_sample = cold_launch_sample(LaunchLane::PreparedCold, 3, &sample, None).unwrap();
         assert_eq!(lane_sample.number, 3);
         assert_eq!(lane_sample.context.backend, "hvf");
         assert_eq!(

--- a/crates/mvm-cli/src/bench/probes.rs
+++ b/crates/mvm-cli/src/bench/probes.rs
@@ -5,7 +5,9 @@
 use anyhow::{Context, Result};
 
 use super::harness::LaunchProbe;
+use super::harness::read_process_footprint_bytes;
 use super::report::HostDescriptor;
+use super::report::{DensityReport, InstanceFootprint, build_density_report};
 use super::stats::IterationTiming;
 
 pub(super) struct LibkrunProbe {
@@ -62,6 +64,52 @@ impl LaunchProbe for LibkrunProbe {
     }
 }
 
+/// Boot and hold a bounded set of admitted libkrun guests, then report the
+/// host footprint of each live supervisor/VMM process.
+///
+/// Each guest reaches authenticated readiness before its footprint is read.
+/// The returned report measures host process residency, not the guest's
+/// configured memory capacity. If any sample fails, already-started guests
+/// are dropped and their normal backend cleanup runs before the error returns.
+pub fn run_density(count: u32, max_count: u32) -> Result<DensityReport> {
+    let count_usize = density_shape(count, max_count)?;
+    let host = LibkrunProbe::new_with_prefix("mvm-density")?.host_descriptor();
+    let process_id = std::process::id();
+    let mut held = Vec::with_capacity(count_usize);
+    let mut samples = Vec::with_capacity(count_usize);
+
+    for index in 0..count {
+        let vm_name = format!("mvm-density-{process_id}-{index}");
+        let vm = super::probe::boot_hold_once(&vm_name)
+            .with_context(|| format!("booting density sample {index}"))?;
+        let bytes = read_process_footprint_bytes(vm.pid())
+            .with_context(|| format!("sampling footprint for density sample {index}"))?;
+        samples.push(InstanceFootprint {
+            vm_name,
+            pid: vm.pid(),
+            bytes,
+        });
+        held.push(vm);
+    }
+
+    let report = build_density_report(host, count, max_count, samples);
+    drop(held);
+    Ok(report)
+}
+
+fn density_shape(count: u32, max_count: u32) -> Result<usize> {
+    if count == 0 {
+        anyhow::bail!("density count must be positive");
+    }
+    if max_count == 0 {
+        anyhow::bail!("density maximum must be positive");
+    }
+    if count > max_count {
+        anyhow::bail!("density count {count} exceeds maximum {max_count}");
+    }
+    usize::try_from(count).context("density count does not fit in usize")
+}
+
 /// Persist a guest-monotonic boot timing cross-check beside the bench reports.
 /// The host-clock report remains the regression metric; this sidecar audits the
 /// guest's own phase timing without mixing clock domains.
@@ -85,6 +133,14 @@ pub(crate) fn write_boot_timing_sidecar(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn density_shape_requires_a_bounded_positive_count() {
+        assert_eq!(density_shape(3, 4).unwrap(), 3);
+        assert!(density_shape(0, 4).is_err());
+        assert!(density_shape(3, 0).is_err());
+        assert!(density_shape(5, 4).is_err());
+    }
 
     /// Live boot of the canonical default-microvm image through the
     /// real admission path. Gated behind `libkrun-live` so stock CI

--- a/crates/mvm-cli/src/commands/vm/launch_sample.rs
+++ b/crates/mvm-cli/src/commands/vm/launch_sample.rs
@@ -26,7 +26,7 @@ pub use mvm_core::launch_trace::LAUNCH_SAMPLE_ENV;
 
 /// Sample schema version. A consumer that reads a different version refuses
 /// the sample as incomparable rather than mis-reading it.
-pub const LAUNCH_SAMPLE_SCHEMA_VERSION: u32 = 1;
+pub const LAUNCH_SAMPLE_SCHEMA_VERSION: u32 = 2;
 
 /// Cargo profile the `mvmctl` binary that produced a sample was built with.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -157,6 +157,25 @@ pub struct ArtifactPaths {
     pub rootfs: Option<String>,
 }
 
+/// Root filesystem strategy selected for this launch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LaunchRootStrategy {
+    /// Boot the unpacked OCI tree through a read-only virtio-fs root.
+    VirtiofsRoot,
+    /// Boot a materialized ext4 block image, optionally protected by dm-verity.
+    BlockExt4,
+}
+
+impl From<mvm_build::run_image::RootStrategy> for LaunchRootStrategy {
+    fn from(strategy: mvm_build::run_image::RootStrategy) -> Self {
+        match strategy {
+            mvm_build::run_image::RootStrategy::VirtiofsRoot => Self::VirtiofsRoot,
+            mvm_build::run_image::RootStrategy::BlockExt4 => Self::BlockExt4,
+        }
+    }
+}
+
 /// Guest sizing the launch was configured with.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -264,6 +283,9 @@ pub struct LaunchSample {
     pub os: String,
     pub arch: String,
     pub launch_mode: LaunchMode,
+    /// The root filesystem path selected after the security/capability tier gate.
+    #[serde(default)]
+    pub root_strategy: Option<LaunchRootStrategy>,
     pub sizing: GuestSizing,
     pub artifacts: ArtifactPaths,
     pub work: LaunchWork,
@@ -333,6 +355,7 @@ mod tests {
             os: "macos".to_string(),
             arch: "aarch64".to_string(),
             launch_mode: LaunchMode::Cold,
+            root_strategy: Some(LaunchRootStrategy::VirtiofsRoot),
             sizing: GuestSizing {
                 cpus: 2,
                 memory_mib: 512,
@@ -388,6 +411,18 @@ mod tests {
         assert!(
             err.to_string().contains("surprise"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn root_strategy_mapping_preserves_the_security_tier() {
+        assert_eq!(
+            LaunchRootStrategy::from(mvm_build::run_image::RootStrategy::VirtiofsRoot),
+            LaunchRootStrategy::VirtiofsRoot
+        );
+        assert_eq!(
+            LaunchRootStrategy::from(mvm_build::run_image::RootStrategy::BlockExt4),
+            LaunchRootStrategy::BlockExt4
         );
     }
 

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1064,6 +1064,7 @@ fn run_inner(
                 backend: backend.name(),
                 start_config: &start_config,
                 launch_mode,
+                root_strategy: boot.root_strategy,
                 mount_materialized: sub_marks
                     .recorded(crate::commands::vm::phase_timing::SubPhase::MountMaterialize),
                 phases,
@@ -1091,6 +1092,8 @@ struct LaunchSampleInputs<'a> {
     backend: &'a str,
     start_config: &'a VmStartConfig,
     launch_mode: crate::commands::vm::phase_timing::LaunchMode,
+    /// Root filesystem strategy selected by the run-path tier gate.
+    root_strategy: mvm_build::run_image::RootStrategy,
     /// Whether a mount image was materialized on this launch.
     mount_materialized: bool,
     phases: crate::commands::vm::phase_timing::RunPhaseTimings,
@@ -1120,6 +1123,7 @@ fn build_launch_sample(
         os: std::env::consts::OS.to_string(),
         arch: std::env::consts::ARCH.to_string(),
         launch_mode: inputs.launch_mode,
+        root_strategy: Some(inputs.root_strategy.into()),
         sizing: sample::GuestSizing {
             cpus: config.cpus,
             memory_mib: config.memory_mib,

--- a/crates/mvm-conformance/tests/steps/cold_launch.rs
+++ b/crates/mvm-conformance/tests/steps/cold_launch.rs
@@ -10,7 +10,7 @@ use cucumber::{given, then, when};
 
 use mvm_cli::bench::cold_launch::{
     ArtifactPaths, BuildProfile, GuestSizing, LAUNCH_SAMPLE_SCHEMA_VERSION, LaunchLane, LaunchMode,
-    LaunchSample, LaunchSubTimings, LaunchWork, RunPhaseTimings, validate_lane,
+    LaunchRootStrategy, LaunchSample, LaunchSubTimings, LaunchWork, RunPhaseTimings, validate_lane,
 };
 
 use crate::world::CliWorld;
@@ -25,6 +25,7 @@ fn clean_sample(profile: BuildProfile) -> LaunchSample {
         os: "macos".to_string(),
         arch: "aarch64".to_string(),
         launch_mode: LaunchMode::Cold,
+        root_strategy: Some(LaunchRootStrategy::BlockExt4),
         sizing: GuestSizing {
             cpus: 2,
             memory_mib: 512,

--- a/crates/mvm-fs/src/rootfs.rs
+++ b/crates/mvm-fs/src/rootfs.rs
@@ -15,12 +15,21 @@
 
 use std::io::{Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
+use sha2::Digest;
 use thiserror::Error;
 
 use crate::parallel::par_map;
 
 use crate::ext4::{BuildOptions, EmitImageError, Ext4Error, Node, Xattr};
+
+/// Version of the deterministic ext4 materializer's output contract.
+///
+/// Bump this when the same source tree and options can produce a different
+/// image. The version is deliberately part of measurement output so a
+/// filesystem candidate cannot be compared across incompatible artifacts.
+pub const EXT4_MATERIALIZER_FORMAT_VERSION: u32 = 1;
 
 /// How [`collect_nodes`] handles a host inode kind the ext4 [`Node`] enum has
 /// no variant for (device, FIFO, socket).
@@ -265,6 +274,142 @@ pub struct MaterializedImage {
     pub path: PathBuf,
     /// Final image size in bytes.
     pub size_bytes: u64,
+}
+
+/// Counts and byte totals for the effective node set sent to the image writer.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MaterializationNodeCounts {
+    /// Number of nodes, excluding the implicit guest root (`/`).
+    pub total: u64,
+    /// Number of regular files.
+    pub files: u64,
+    /// Number of directories.
+    pub directories: u64,
+    /// Number of symbolic links.
+    pub symlinks: u64,
+    /// Number of captured extended attributes.
+    pub xattrs: u64,
+    /// Total bytes in regular-file payloads before filesystem overhead.
+    pub file_bytes: u64,
+}
+
+/// Timings for the current pure-Rust materialization path, in microseconds.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MaterializationTimings {
+    /// Time spent hashing the source directory's content manifest.
+    pub source_hash_micros: u64,
+    /// Time spent walking the source and reading nodes.
+    pub walk_micros: u64,
+    /// Time spent constructing the ext4 image in memory.
+    pub build_micros: u64,
+    /// End-to-end time covered by this report.
+    pub total_micros: u64,
+}
+
+/// Baseline report for comparing immutable guest filesystem materializers.
+///
+/// This measures the existing directory-to-ext4 path without booting a VM or
+/// writing the image. The source and image digests make reports comparable;
+/// the timings are observations and must be aggregated over repeated runs.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Ext4MaterializationReport {
+    /// Version of this report schema.
+    pub report_version: u32,
+    /// Version of the emitted ext4 byte contract.
+    pub materializer_format_version: u32,
+    /// SHA-256 of the source directory content manifest.
+    pub source_content_sha256: String,
+    /// Composition of the nodes passed to the writer.
+    pub nodes: MaterializationNodeCounts,
+    /// Logical ext4 image size in bytes.
+    pub image_size_bytes: u64,
+    /// SHA-256 of the emitted ext4 image bytes.
+    pub image_sha256: String,
+    /// Timings for the measured path.
+    pub timings: MaterializationTimings,
+}
+
+const MATERIALIZATION_REPORT_VERSION: u32 = 1;
+
+/// Measure the pure-Rust directory-to-ext4 build path.
+///
+/// The source hash, walk, and image build are intentionally reported as
+/// separate phases. This makes it possible to distinguish a filesystem
+/// format improvement from a source-scanning or content-addressing cost.
+/// `extra_nodes` are included in the node counts and image digest, matching
+/// [`build_ext4_pure`].
+pub fn measure_ext4_pure(
+    root: &Path,
+    options: &MaterializeOptions,
+) -> Result<Ext4MaterializationReport, MaterializeError> {
+    let total_started = Instant::now();
+
+    let hash_started = Instant::now();
+    let source_content_sha256 =
+        crate::hash::hash_source(root).map_err(|source| MaterializeError::Walk {
+            path: root.to_path_buf(),
+            source,
+        })?;
+    let source_hash_micros = elapsed_micros(hash_started.elapsed());
+
+    let walk_started = Instant::now();
+    let nodes = merge_extra_nodes(
+        collect_nodes(root, options.walk)?,
+        options.extra_nodes.clone(),
+    );
+    let nodes_report = count_nodes(&nodes);
+    let walk_micros = elapsed_micros(walk_started.elapsed());
+
+    let build_started = Instant::now();
+    let image = crate::ext4::build_image_with_options(&nodes, &options.build)?;
+    let image_size_bytes = image.len() as u64;
+    let image_sha256 = hex::encode(sha2::Sha256::digest(&image));
+    let build_micros = elapsed_micros(build_started.elapsed());
+
+    Ok(Ext4MaterializationReport {
+        report_version: MATERIALIZATION_REPORT_VERSION,
+        materializer_format_version: EXT4_MATERIALIZER_FORMAT_VERSION,
+        source_content_sha256,
+        nodes: nodes_report,
+        image_size_bytes,
+        image_sha256,
+        timings: MaterializationTimings {
+            source_hash_micros,
+            walk_micros,
+            build_micros,
+            total_micros: elapsed_micros(total_started.elapsed()),
+        },
+    })
+}
+
+fn count_nodes(nodes: &[Node]) -> MaterializationNodeCounts {
+    let mut counts = MaterializationNodeCounts {
+        total: nodes.len() as u64,
+        files: 0,
+        directories: 0,
+        symlinks: 0,
+        xattrs: 0,
+        file_bytes: 0,
+    };
+    for node in nodes {
+        match node {
+            Node::Dir { xattrs, .. } => {
+                counts.directories += 1;
+                counts.xattrs = counts.xattrs.saturating_add(xattrs.len() as u64);
+            }
+            Node::File { data, xattrs, .. } => {
+                counts.files += 1;
+                counts.file_bytes = counts.file_bytes.saturating_add(data.len() as u64);
+                counts.xattrs = counts.xattrs.saturating_add(xattrs.len() as u64);
+            }
+            Node::Symlink { .. } => counts.symlinks += 1,
+        }
+    }
+    counts
+}
+
+fn elapsed_micros(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
 }
 
 /// Walk + emission knobs for [`materialize_ext4_pure`].
@@ -729,6 +874,63 @@ mod tests {
         let out_path = out.path().join("rootfs.ext4");
         materialize_ext4_pure(src.path(), &out_path, &options).expect("materialize");
         assert_eq!(std::fs::read(&out_path).unwrap(), built);
+    }
+
+    #[test]
+    fn materialization_report_captures_composition_and_is_json_roundtrippable() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::create_dir(src.path().join("etc")).unwrap();
+        std::fs::write(src.path().join("etc/hosts"), b"127.0.0.1 localhost\n").unwrap();
+        std::fs::write(src.path().join("hello"), b"hi\n").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("hosts", src.path().join("etc/localhost")).unwrap();
+
+        let report = measure_ext4_pure(src.path(), &MaterializeOptions::default())
+            .expect("measure pure materialization");
+
+        assert_eq!(report.report_version, MATERIALIZATION_REPORT_VERSION);
+        assert_eq!(
+            report.materializer_format_version,
+            EXT4_MATERIALIZER_FORMAT_VERSION
+        );
+        assert_eq!(report.nodes.total, 4);
+        assert_eq!(report.nodes.files, 2);
+        assert_eq!(report.nodes.directories, 1);
+        assert_eq!(report.nodes.symlinks, 1);
+        assert_eq!(report.nodes.file_bytes, 23);
+        assert!(report.image_size_bytes > 0);
+        assert_eq!(report.image_sha256.len(), 64);
+        assert_eq!(report.source_content_sha256.len(), 64);
+        assert!(report.timings.total_micros >= report.timings.build_micros);
+
+        let encoded = serde_json::to_vec(&report).expect("serialize report");
+        let decoded: Ext4MaterializationReport =
+            serde_json::from_slice(&encoded).expect("deserialize report");
+        assert_eq!(decoded, report);
+    }
+
+    #[test]
+    fn materialization_report_identity_changes_with_source_content() {
+        let src = tempfile::tempdir().unwrap();
+        let file = src.path().join("hello");
+        std::fs::write(&file, b"before").unwrap();
+
+        let before =
+            measure_ext4_pure(src.path(), &MaterializeOptions::default()).expect("measure before");
+        std::fs::write(&file, b"after").unwrap();
+        let after =
+            measure_ext4_pure(src.path(), &MaterializeOptions::default()).expect("measure after");
+
+        assert_ne!(
+            before.source_content_sha256, after.source_content_sha256,
+            "source digest must detect changed file bytes"
+        );
+        assert_ne!(
+            before.image_sha256, after.image_sha256,
+            "image digest must detect changed emitted bytes"
+        );
+        assert_eq!(before.nodes.total, after.nodes.total);
+        assert_eq!(before.nodes.files, after.nodes.files);
     }
 
     #[test]

--- a/crates/mvm-runtime/src/backends/hvf/guest_ram.rs
+++ b/crates/mvm-runtime/src/backends/hvf/guest_ram.rs
@@ -61,6 +61,42 @@ impl GuestRam {
         self.len
     }
 
+    /// Return the number of resident bytes currently backing this mapping.
+    ///
+    /// The query is advisory and may change immediately after it returns, but
+    /// it provides the measurement witness for demand-faulted guest RAM: an
+    /// untouched anonymous region should occupy fewer resident pages than the
+    /// same region after selected pages have been written.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    pub fn resident_bytes(&self) -> Result<usize, std::io::Error> {
+        let raw_page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        let page_size = usize::try_from(raw_page_size)
+            .map_err(|_| std::io::Error::other("system page size is invalid"))?;
+        if page_size == 0 {
+            return Err(std::io::Error::other("system page size is zero"));
+        }
+        let page_count = self.len.div_ceil(page_size);
+        let mut residency = vec![0_u8; page_count];
+        // SAFETY: the mapping is live for `self`'s lifetime, `self.len` is its
+        // exact mapped length, and `residency` has one byte per system page.
+        let result = unsafe {
+            libc::mincore(
+                self.ptr.as_ptr().cast(),
+                self.len,
+                residency.as_mut_ptr().cast(),
+            )
+        };
+        if result != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        residency
+            .iter()
+            .filter(|state| **state & 1 != 0)
+            .count()
+            .checked_mul(page_size)
+            .ok_or_else(|| std::io::Error::other("resident byte count overflowed"))
+    }
+
     /// Copy the complete RAM mapping into an owned snapshot section.
     pub fn snapshot_bytes(&self) -> Vec<u8> {
         // SAFETY: the mapping is live for `self`'s lifetime and covers exactly
@@ -205,6 +241,22 @@ mod tests {
             let byte = unsafe { *ram.as_ptr().add(off) };
             assert_eq!(byte, 0, "offset {off} not zero-initialized");
         }
+    }
+
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    fn untouched_pages_are_not_resident_until_touched() {
+        let ram = GuestRam::new(HVF_PAGE_SIZE * 8).expect("mmap");
+        let before = ram.resident_bytes().expect("mincore before touch");
+        for index in 0..4 {
+            // SAFETY: each offset is the first byte of one page in the live
+            // mapping, and volatile write makes the touch observable.
+            unsafe {
+                std::ptr::write_volatile(ram.as_ptr().add(index * HVF_PAGE_SIZE), 1);
+            }
+        }
+        let after = ram.resident_bytes().expect("mincore after touch");
+        assert!(after > before, "touching pages did not increase residency");
     }
 
     #[test]

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -20,7 +20,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use super::HvfError;
 #[cfg(test)]
@@ -152,6 +152,9 @@ pub struct KernelBootResult {
     /// Host-resident bytes backing the guest RAM mapping at boot completion.
     /// `None` on platforms without a resident-page query.
     pub resident_ram_bytes: Option<usize>,
+    /// Monotonic time spent installing a private restore-RAM mapping, in
+    /// microseconds. `None` when the boot did not restore RAM.
+    pub restore_mapping_micros: Option<u64>,
 }
 
 /// Host-supplied boot inputs the supervisor threads into a guest: the vsock
@@ -454,9 +457,13 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
     // them, so idle residency tracks the working set instead of `ram_size`.
     // `guest_ram` owns the region and unmaps it on drop, after `hv_vm_destroy`.
     let mut guest_ram = GuestRam::new(ram_size)?;
-    if let Some(path) = channels.restore_ram.as_deref() {
+    let restore_mapping_micros = if let Some(path) = channels.restore_ram.as_deref() {
+        let started = Instant::now();
         guest_ram.map_private_file(path)?;
-    }
+        Some(u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX))
+    } else {
+        None
+    };
     let ram = guest_ram.as_ptr();
 
     // Base cmdline, plus optional appended args. Precedence: the `MVM_HVF_BOOTARGS`
@@ -574,7 +581,10 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
         r
     };
     // `guest_ram` unmaps here as it drops, after `hv_vm_destroy` above.
-    result
+    result.map(|mut boot_result| {
+        boot_result.restore_mapping_micros = restore_mapping_micros;
+        boot_result
+    })
 }
 
 /// # Safety
@@ -1132,6 +1142,13 @@ mod tests {
             without.contains("console=ttyAMA0"),
             "console wired: {without}"
         );
+    }
+
+    #[test]
+    fn kernel_boot_result_marks_restore_measurement_as_optional() {
+        let result = KernelBootResult::default();
+        assert_eq!(result.restore_mapping_micros, None);
+        assert_eq!(result.resident_ram_bytes, None);
     }
 
     #[test]

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -149,6 +149,9 @@ pub struct KernelBootResult {
     /// port (the transient run-to-exit signal). `None` for a run that ended by
     /// timeout/stop without a workload-exit report.
     pub workload_exit_code: Option<i32>,
+    /// Host-resident bytes backing the guest RAM mapping at boot completion.
+    /// `None` on platforms without a resident-page query.
+    pub resident_ram_bytes: Option<usize>,
 }
 
 /// Host-supplied boot inputs the supervisor threads into a guest: the vsock
@@ -968,6 +971,7 @@ unsafe fn run(
                     Err(HvfError::GicCreate(0))
                 }
             };
+            let snapshot_guest_ram = &*guest_ram;
             run::run_with_pause_hook(
                 &vcpu,
                 set_irq,
@@ -1030,7 +1034,7 @@ unsafe fn run(
                     if !request_path.exists() {
                         return Ok(());
                     }
-                    let ram_bytes = guest_ram.snapshot_bytes();
+                    let ram_bytes = snapshot_guest_ram.snapshot_bytes();
                     let device_bytes = capture_device_states(devices)
                         .map_err(|_| HvfError::SnapshotState("snapshot device capture failed"))?;
                     let vcpu_state = vcpu.capture_state()?;
@@ -1081,6 +1085,10 @@ unsafe fn run(
         if let Some(vs) = &vsock_dev {
             r.vsock_received = vs.received();
             r.workload_exit_code = vs.workload_exit_code();
+        }
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        {
+            r.resident_ram_bytes = guest_ram.resident_bytes().ok();
         }
         Ok(r)
     }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -20,8 +20,9 @@ for detailed scope and acceptance criteria.
       #2196, and #2199. Launch evidence now records the tier-selected root
       filesystem strategy and rejects missing or mixed strategies so
       filesystem comparisons cannot mix security tiers. The libkrun probe also
-      exposes bounded resident host-process capture; guest demand-fault,
-      restore, and cross-backend evidence remain open.
+      exposes bounded resident host-process capture, and the HVF guest-RAM seam
+      exposes resident bytes with a demand-fault witness; end-to-end guest
+      working-set, restore, and cross-backend evidence remain open.
 
 ## In-flight plans
 - [x] Plan 2167 — durable agent session and event contract

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -145,7 +145,8 @@ for detailed scope and acceptance criteria.
         `specs/notes/2026-08-10-fast-machine-substrate.md` (issue #2279)
   - [~] Kernel/boot-substrate budget and filesystem-path evaluation tracked by
         issues #2280 and #2281. The artifact-ledger slice of #2280 is landed;
-        live timing, restore, density, and filesystem evaluation remain open.
+        cold-launch reports now carry artifact/config measurements; live timing,
+        restore, density, and filesystem evaluation remain open.
 
 - [ ] Plan 311 — Launch critical-path waste on real-sized images
       (`specs/plans/311-launch-critical-path-waste.md`), branch

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -18,7 +18,8 @@ for detailed scope and acceptance criteria.
       introduces no second cache or snapshot graph. Follow-up measurements and
       live backend work remain open under issues #2280, #2281, #2194, #2195,
       #2196, and #2199. Launch evidence now records the tier-selected root
-      filesystem strategy so filesystem comparisons cannot mix security tiers.
+      filesystem strategy and rejects missing or mixed strategies so
+      filesystem comparisons cannot mix security tiers.
 
 ## In-flight plans
 - [x] Plan 2167 — durable agent session and event contract

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -10,6 +10,15 @@ for detailed scope and acceptance criteria.
       guest kernel now share the verified Linux 6.12.102 LTS source pin;
       structural parity coverage prevents the consumers from drifting apart.
 
+## Fast machine substrate
+- [x] **Issue #2279 — define the fast machine substrate and canonical template
+      contract.** The cross-plan note joins Plans 298, 299, 265, 270, and 292
+      around one prepared template identity, explicit lifecycle phases, a
+      system-level kernel budget, and a measured filesystem-path decision. It
+      introduces no second cache or snapshot graph. Follow-up measurements and
+      live backend work remain open under issues #2280, #2281, #2194, #2195,
+      #2196, and #2199.
+
 ## In-flight plans
 - [x] Plan 2167 — durable agent session and event contract
       (`specs/plans/2167-agent-session-contract.md`)
@@ -132,6 +141,10 @@ for detailed scope and acceptance criteria.
         `stop_transient` 142.9 ms, which is real cleanup. Follow-up: give pool
         maintenance to the resident per-tenant daemon.
   - [ ] Phase 7 — live validation and regression gates
+  - [x] Cross-plan fast-machine-substrate contract documented in
+        `specs/notes/2026-08-10-fast-machine-substrate.md` (issue #2279)
+  - [ ] Kernel/boot-substrate budget and filesystem-path evaluation tracked by
+        issues #2280 and #2281
 
 - [ ] Plan 311 — Launch critical-path waste on real-sized images
       (`specs/plans/311-launch-critical-path-waste.md`), branch

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -21,8 +21,9 @@ for detailed scope and acceptance criteria.
       filesystem strategy and rejects missing or mixed strategies so
       filesystem comparisons cannot mix security tiers. The libkrun probe also
       exposes bounded resident host-process capture, and the HVF guest-RAM seam
-      exposes resident bytes with a demand-fault witness; end-to-end guest
-      working-set, restore, and cross-backend evidence remain open.
+      exposes resident bytes with a demand-fault witness and records private
+      restore-mapping duration; end-to-end guest working-set, first-use
+      restore-fault, and cross-backend evidence remain open.
 
 ## In-flight plans
 - [x] Plan 2167 — durable agent session and event contract

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -143,8 +143,9 @@ for detailed scope and acceptance criteria.
   - [ ] Phase 7 — live validation and regression gates
   - [x] Cross-plan fast-machine-substrate contract documented in
         `specs/notes/2026-08-10-fast-machine-substrate.md` (issue #2279)
-  - [ ] Kernel/boot-substrate budget and filesystem-path evaluation tracked by
-        issues #2280 and #2281
+  - [~] Kernel/boot-substrate budget and filesystem-path evaluation tracked by
+        issues #2280 and #2281. The artifact-ledger slice of #2280 is landed;
+        live timing, restore, density, and filesystem evaluation remain open.
 
 - [ ] Plan 311 — Launch critical-path waste on real-sized images
       (`specs/plans/311-launch-critical-path-waste.md`), branch

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-09
+Last updated: 2026-08-10
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -144,9 +144,10 @@ for detailed scope and acceptance criteria.
   - [x] Cross-plan fast-machine-substrate contract documented in
         `specs/notes/2026-08-10-fast-machine-substrate.md` (issue #2279)
   - [~] Kernel/boot-substrate budget and filesystem-path evaluation tracked by
-        issues #2280 and #2281. The artifact-ledger slice of #2280 is landed;
-        cold-launch reports now carry artifact/config measurements; live timing,
-        restore, density, and filesystem evaluation remain open.
+        issues #2280 and #2281. The artifact-ledger slice of #2280 and the
+        pure-Rust ext4 baseline report are landed; live timing, restore,
+        density, candidate filesystem comparison, and the adopt/decline
+        decision remain open.
 
 - [ ] Plan 311 — Launch critical-path waste on real-sized images
       (`specs/plans/311-launch-critical-path-waste.md`), branch

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -19,7 +19,9 @@ for detailed scope and acceptance criteria.
       live backend work remain open under issues #2280, #2281, #2194, #2195,
       #2196, and #2199. Launch evidence now records the tier-selected root
       filesystem strategy and rejects missing or mixed strategies so
-      filesystem comparisons cannot mix security tiers.
+      filesystem comparisons cannot mix security tiers. The libkrun probe also
+      exposes bounded resident host-process capture; guest demand-fault,
+      restore, and cross-backend evidence remain open.
 
 ## In-flight plans
 - [x] Plan 2167 — durable agent session and event contract

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -17,7 +17,8 @@ for detailed scope and acceptance criteria.
       system-level kernel budget, and a measured filesystem-path decision. It
       introduces no second cache or snapshot graph. Follow-up measurements and
       live backend work remain open under issues #2280, #2281, #2194, #2195,
-      #2196, and #2199.
+      #2196, and #2199. Launch evidence now records the tier-selected root
+      filesystem strategy so filesystem comparisons cannot mix security tiers.
 
 ## In-flight plans
 - [x] Plan 2167 — durable agent session and event contract

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1507,6 +1507,12 @@ Then unify + retire the old paths:
   same artifact byte and kernel-config measurements beside their timings. Live
   kernel-entry/readiness, resident-memory, and restore measurements remain
   open.
+- [x] **Filesystem-path baseline — issue #2281.**
+  `mvm_fs::rootfs::measure_ext4_pure` now records a stable JSON baseline for
+  source identity, node composition, emitted ext4 size/digest, materializer
+  version, and hash/walk/build timings. Candidate guest-local immutable paths
+  still need equivalent first-access, working-set, density, and security
+  evidence before an adopt/decline decision.
 
 - [x] Kernel: minimal defconfig; stop boot-probing IPVS/btrfs/RAID-autodetect (#1283); bump the kernel pin (#1264). **Landed via #1786.**
 - [x] Guest agent ≤ **8 MiB**: the static-musl Dev-profile agent measured

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1511,9 +1511,10 @@ Then unify + retire the old paths:
   `mvm_fs::rootfs::measure_ext4_pure` now records a stable JSON baseline for
   source identity, node composition, emitted ext4 size/digest, materializer
   version, and hash/walk/build timings; `cargo xtask perf filesystem --root
-  <DIR> --json` exposes it to the benchmark workflow. Candidate guest-local
-  immutable paths still need equivalent first-access, working-set, density,
-  and security evidence before an adopt/decline decision.
+  <DIR> --json` exposes it to the benchmark workflow. Cold-launch evidence
+  records the tier-selected `virtiofs_root` or `block_ext4` strategy, while
+  candidate guest-local immutable paths still need equivalent first-access,
+  working-set, density, and security evidence before an adopt/decline decision.
 
 - [x] Kernel: minimal defconfig; stop boot-probing IPVS/btrfs/RAID-autodetect (#1283); bump the kernel pin (#1264). **Landed via #1786.**
 - [x] Guest agent ≤ **8 MiB**: the static-musl Dev-profile agent measured

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1510,9 +1510,10 @@ Then unify + retire the old paths:
 - [x] **Filesystem-path baseline — issue #2281.**
   `mvm_fs::rootfs::measure_ext4_pure` now records a stable JSON baseline for
   source identity, node composition, emitted ext4 size/digest, materializer
-  version, and hash/walk/build timings. Candidate guest-local immutable paths
-  still need equivalent first-access, working-set, density, and security
-  evidence before an adopt/decline decision.
+  version, and hash/walk/build timings; `cargo xtask perf filesystem --root
+  <DIR> --json` exposes it to the benchmark workflow. Candidate guest-local
+  immutable paths still need equivalent first-access, working-set, density,
+  and security evidence before an adopt/decline decision.
 
 - [x] Kernel: minimal defconfig; stop boot-probing IPVS/btrfs/RAID-autodetect (#1283); bump the kernel pin (#1264). **Landed via #1786.**
 - [x] Guest agent ≤ **8 MiB**: the static-musl Dev-profile agent measured

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1513,8 +1513,9 @@ Then unify + retire the old paths:
   version, and hash/walk/build timings; `cargo xtask perf filesystem --root
   <DIR> --json` exposes it to the benchmark workflow. Cold-launch evidence
   records the tier-selected `virtiofs_root` or `block_ext4` strategy, while
-  candidate guest-local immutable paths still need equivalent first-access,
-  working-set, density, and security evidence before an adopt/decline decision.
+  the benchmark rejects missing or mixed strategies; candidate guest-local
+  immutable paths still need equivalent first-access, working-set, density,
+  and security evidence before an adopt/decline decision.
 
 - [x] Kernel: minimal defconfig; stop boot-probing IPVS/btrfs/RAID-autodetect (#1283); bump the kernel pin (#1264). **Landed via #1786.**
 - [x] Guest agent ≤ **8 MiB**: the static-musl Dev-profile agent measured

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1494,6 +1494,14 @@ Then unify + retire the old paths:
 
 **WS10 — tiny kernel + low memory + density**
 
+- [x] **Fast machine substrate contract — issue #2279.** The kernel is now
+  explicitly treated as one part of a prepared machine substrate spanning the
+  kernel, initramfs, verified rootfs artifacts, runtime overlay, VMM shape,
+  guest lifecycle, warmup, and pool identity. The ownership and measurement
+  boundaries are documented in
+  `specs/notes/2026-08-10-fast-machine-substrate.md`; issues #2280 and #2281
+  own the kernel budget and filesystem-path experiments.
+
 - [x] Kernel: minimal defconfig; stop boot-probing IPVS/btrfs/RAID-autodetect (#1283); bump the kernel pin (#1264). **Landed via #1786.**
 - [x] Guest agent ≤ **8 MiB**: the static-musl Dev-profile agent measured
   1,372,160 bytes peak observed RSS (1,359,872 bytes steady idle). The

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1507,8 +1507,9 @@ Then unify + retire the old paths:
   same artifact byte and kernel-config measurements beside their timings. The
   libkrun live probe now has bounded resident host-process capture after
   authenticated readiness, and the HVF guest-RAM seam now reports resident
-  bytes with a direct untouched-versus-touched demand-fault witness. End-to-end
-  guest working-set, restore, and cross-backend live measurements remain open.
+  bytes with a direct untouched-versus-touched demand-fault witness plus
+  monotonic private restore-mapping duration. End-to-end guest working-set,
+  first-use restore-fault, and cross-backend live measurements remain open.
 - [x] **Filesystem-path baseline — issue #2281.**
   `mvm_fs::rootfs::measure_ext4_pure` now records a stable JSON baseline for
   source identity, node composition, emitted ext4 size/digest, materializer

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1504,9 +1504,10 @@ Then unify + retire the old paths:
 - [~] **Kernel boot-substrate ledger — issue #2280.** `cargo xtask perf
   footprint` now includes initramfs bytes and optionally enforces the resolved
   per-architecture built-in-symbol budget; cold-launch JSON reports carry the
-  same artifact byte and kernel-config measurements beside their timings. Live
-  kernel-entry/readiness, resident-memory, and restore measurements remain
-  open.
+  same artifact byte and kernel-config measurements beside their timings. The
+  libkrun live probe now has bounded resident host-process capture after
+  authenticated readiness. Guest demand-fault, restore, and cross-backend live
+  measurements remain open.
 - [x] **Filesystem-path baseline — issue #2281.**
   `mvm_fs::rootfs::measure_ext4_pure` now records a stable JSON baseline for
   source identity, node composition, emitted ext4 size/digest, materializer

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1506,8 +1506,9 @@ Then unify + retire the old paths:
   per-architecture built-in-symbol budget; cold-launch JSON reports carry the
   same artifact byte and kernel-config measurements beside their timings. The
   libkrun live probe now has bounded resident host-process capture after
-  authenticated readiness. Guest demand-fault, restore, and cross-backend live
-  measurements remain open.
+  authenticated readiness, and the HVF guest-RAM seam now reports resident
+  bytes with a direct untouched-versus-touched demand-fault witness. End-to-end
+  guest working-set, restore, and cross-backend live measurements remain open.
 - [x] **Filesystem-path baseline — issue #2281.**
   `mvm_fs::rootfs::measure_ext4_pure` now records a stable JSON baseline for
   source identity, node composition, emitted ext4 size/digest, materializer

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1501,6 +1501,10 @@ Then unify + retire the old paths:
   boundaries are documented in
   `specs/notes/2026-08-10-fast-machine-substrate.md`; issues #2280 and #2281
   own the kernel budget and filesystem-path experiments.
+- [~] **Kernel boot-substrate ledger — issue #2280.** `cargo xtask perf
+  footprint` now includes initramfs bytes and optionally enforces the resolved
+  per-architecture built-in-symbol budget. Live kernel-entry/readiness,
+  resident-memory, and restore measurements remain open.
 
 - [x] Kernel: minimal defconfig; stop boot-probing IPVS/btrfs/RAID-autodetect (#1283); bump the kernel pin (#1264). **Landed via #1786.**
 - [x] Guest agent ≤ **8 MiB**: the static-musl Dev-profile agent measured

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1503,8 +1503,10 @@ Then unify + retire the old paths:
   own the kernel budget and filesystem-path experiments.
 - [~] **Kernel boot-substrate ledger — issue #2280.** `cargo xtask perf
   footprint` now includes initramfs bytes and optionally enforces the resolved
-  per-architecture built-in-symbol budget. Live kernel-entry/readiness,
-  resident-memory, and restore measurements remain open.
+  per-architecture built-in-symbol budget; cold-launch JSON reports carry the
+  same artifact byte and kernel-config measurements beside their timings. Live
+  kernel-entry/readiness, resident-memory, and restore measurements remain
+  open.
 
 - [x] Kernel: minimal defconfig; stop boot-probing IPVS/btrfs/RAID-autodetect (#1283); bump the kernel pin (#1264). **Landed via #1786.**
 - [x] Guest agent ≤ **8 MiB**: the static-musl Dev-profile agent measured

--- a/specs/notes/2026-08-10-fast-machine-substrate.md
+++ b/specs/notes/2026-08-10-fast-machine-substrate.md
@@ -116,7 +116,9 @@ filesystem paths must use the same fixture identity and report equivalent
 preparation, first-file access, working-set, and density evidence before the
 existing ext4 path can be replaced. Cold-launch samples now also carry the
 tier-selected `virtiofs_root` or `block_ext4` strategy, so those measurements
-remain comparable only within the same security and capability tier.
+remain comparable only within the same security and capability tier. The
+benchmark gate requires the field and rejects a report that changes strategy
+between warmup or measured samples.
 
 ## Security and resource invariants
 

--- a/specs/notes/2026-08-10-fast-machine-substrate.md
+++ b/specs/notes/2026-08-10-fast-machine-substrate.md
@@ -137,8 +137,10 @@ between warmup or measured samples.
 
 ## Issue sequence
 
-- [ ] [#2280](https://github.com/tinylabscom/mvm/issues/2280) — measure the
-  kernel and boot-substrate budget.
+- [~] [#2280](https://github.com/tinylabscom/mvm/issues/2280) — measure the
+  kernel and boot-substrate budget. The bounded libkrun resident host-process
+  capture is landed; guest demand-fault, restore-fault, and cross-backend live
+  evidence remain.
 - [~] [#2281](https://github.com/tinylabscom/mvm/issues/2281) — baseline the
   current pure-Rust ext4 path and evaluate the guest-local immutable
   filesystem path against it.

--- a/specs/notes/2026-08-10-fast-machine-substrate.md
+++ b/specs/notes/2026-08-10-fast-machine-substrate.md
@@ -107,12 +107,14 @@ not a performance number to copy. The result is an explicit adopt or decline
 decision in issue #2281 and Plan 299; no parallel filesystem or cache stack is
 allowed.
 
-The current baseline is now measurable without a VM: `mvm_fs::rootfs::measure_ext4_pure`
-reports the source content digest, effective node composition, source file
-bytes, emitted ext4 size/digest, materializer format version, and separate
-hash/walk/build timings. Candidate filesystem paths must use the same fixture
-identity and report equivalent preparation, first-access, working-set, and
-density evidence before the existing ext4 path can be replaced.
+The current baseline is now measurable without a VM: `cargo xtask perf
+filesystem --root <DIR> --json` drives
+`mvm_fs::rootfs::measure_ext4_pure`, which reports the source content digest,
+effective node composition, source file bytes, emitted ext4 size/digest,
+materializer format version, and separate hash/walk/build timings. Candidate
+filesystem paths must use the same fixture identity and report equivalent
+preparation, first-file access, working-set, and density evidence before the
+existing ext4 path can be replaced.
 
 ## Security and resource invariants
 

--- a/specs/notes/2026-08-10-fast-machine-substrate.md
+++ b/specs/notes/2026-08-10-fast-machine-substrate.md
@@ -1,0 +1,137 @@
+# Fast machine substrate
+
+**Status:** Contract defined; implementation remains in Plans 298, 299, 265,
+270, and 292.
+
+This note joins the cold-launch, warm-claim, guest-boot, and artifact-storage
+work without introducing another cache or snapshot graph. The performance
+target is a property of the complete prepared machine substrate, not of the
+kernel file in isolation.
+
+## Design decision
+
+Every launchable machine is derived from a prepared, content-addressed
+template. A template describes the immutable inputs and the execution shape
+that determine whether an artifact or warm parent is reusable:
+
+```text
+kernel
+initramfs
+rootfs lower artifacts
+verity metadata
+runtime overlay
+backend and VMM version
+guest-agent protocol
+CPU and memory shape
+block-device and share topology
+network-policy shape
+warmup profile and readiness probe
+```
+
+The template identity excludes tenant authority, workload grants, host paths,
+host-directory contents, live vsock sessions, mutable writable state, and
+secrets. A warm claim creates a fresh child identity from a clean parent; it
+never makes a dirty workload reusable.
+
+The existing content-addressed artifact and checkpoint stores remain the
+storage primitives. A template identity composes their digests and policy
+inputs; it does not create a second store, manifest format, or snapshot
+lineage.
+
+## Lifecycle contract
+
+The measured lifecycle has these ordered phases:
+
+1. **Prepared:** all required artifacts are present, digest-verified, and
+   compatible with the requested execution shape.
+2. **Kernel entry:** the guest has begun executing the selected kernel.
+3. **Agent ready:** the universal initramfs agent is listening on the expected
+   authenticated control path.
+4. **Activated:** the host has delivered the signed activation for this fresh
+   machine identity.
+5. **Environment ready:** rootfs, runtime overlay, privileges, and policy have
+   been applied successfully.
+6. **First useful RPC:** the first workload operation has crossed the
+   authenticated channel. `/bin/true` remains a launch probe; it is not a
+   substitute for this end-to-end measure.
+7. **Reaped:** the guest and host resources have been cleaned up or handed to
+   an ownership-safe lifecycle reaper.
+
+Cold launch, mount-cache hit, mount miss, artifact miss, and warm claim are
+separate benchmark lanes. A lane never hides preparation, network, image
+materialization, or cleanup work inside another lane's SLO.
+
+## Cross-plan ownership
+
+| Concern | Owner | Boundary |
+|---|---|---|
+| Prepared cold path, artifact lookup, launch spans, backend cold latency | Plan 299 | New VMM and fresh guest identity |
+| Resident parent pool, claim leases, CoW child, warm admission | Plan 298 | Clean parent and fresh child only |
+| Restore sequencing, page-cache policy, density, warm SLO | Plan 265 | Restore correctness and measured working set |
+| Universal initramfs, signed activation, guest readiness, PID 1 lifecycle | Plan 270 | Guest boot and activation state machine |
+| Local/remote artifact tiers and rehydration | Plan 292 | Remote storage stays off the hot path |
+
+The typed seams between these owners are the template identity, the prepared
+artifact manifest, the readiness event, and the fresh-child handoff. Changes
+that cross those seams update this note and the owning plan in the same change.
+
+## Kernel and boot-substrate budget
+
+Kernel sizing is evaluated together with the initramfs, rootfs, VMM mapping,
+guest working set, and restore behavior. Each supported kernel variant records:
+
+- raw and compressed kernel size;
+- initramfs and immutable rootfs artifact sizes;
+- built-in drivers, modules, and boot probes;
+- time to kernel entry and authenticated readiness;
+- resident pages after warmup;
+- cold launch and warm-restore fault cost;
+- compatibility and security witnesses.
+
+The smallest artifact wins only when it improves or preserves the launch,
+resident-memory, restore, and security measurements. Removing a driver or boot
+probe without a guest-readiness witness is not an optimization.
+
+## Filesystem evaluation
+
+The current block-backed rootfs, overlay, dm-verity, and host-directory image
+paths remain the baseline. A candidate guest-local immutable lower-layer
+layout may be evaluated if it preserves content addressing, verification,
+xattrs/whiteouts, clean writable CoW state, read-only enforcement, and tenant
+isolation. The candidate must be compared using the same lifecycle lanes and
+must report preparation time, first-file access, snapshot working set, and
+multi-claim density.
+
+The external research is a hypothesis for deleting host/guest filesystem work,
+not a performance number to copy. The result is an explicit adopt or decline
+decision in issue #2281 and Plan 299; no parallel filesystem or cache stack is
+allowed.
+
+## Security and resource invariants
+
+- Prepared artifacts are published atomically and verified before use.
+- Warm-required claims refuse when the required capability is unavailable;
+  they never silently cold-start.
+- A factory parent contains no tenant authority, secrets, host path, or live
+  channel.
+- Every child receives fresh identity, authority, and host-channel state before
+  it resumes.
+- Read-only host directories are opened and validated before resume.
+- Pool admission accounts for resident working set, concurrency, and
+  backpressure rather than only template count.
+- Default reuse is clean-fork reuse. Any page-cache-hot mode must be explicit,
+  bounded, and workload-authorized.
+
+## Issue sequence
+
+- [ ] [#2280](https://github.com/tinylabscom/mvm/issues/2280) — measure the
+  kernel and boot-substrate budget.
+- [ ] [#2281](https://github.com/tinylabscom/mvm/issues/2281) — evaluate the
+  guest-local immutable filesystem path.
+- [ ] [#2194](https://github.com/tinylabscom/mvm/issues/2194),
+  [#2195](https://github.com/tinylabscom/mvm/issues/2195), and
+  [#2196](https://github.com/tinylabscom/mvm/issues/2196) — complete the
+  backend-specific warm pool and share acceptance work already owned by Plan
+  298.
+- [ ] [#2199](https://github.com/tinylabscom/mvm/issues/2199) — complete the
+  1,000-claim matrix and regression evidence.

--- a/specs/notes/2026-08-10-fast-machine-substrate.md
+++ b/specs/notes/2026-08-10-fast-machine-substrate.md
@@ -140,8 +140,8 @@ between warmup or measured samples.
 - [~] [#2280](https://github.com/tinylabscom/mvm/issues/2280) — measure the
   kernel and boot-substrate budget. The bounded libkrun resident host-process
   capture is landed, and HVF guest-RAM now exposes an allocation-level
-  demand-fault witness; end-to-end guest working-set, restore-fault, and
-  cross-backend live evidence remain.
+  demand-fault witness plus private restore-mapping duration; end-to-end guest
+  working-set, first-use restore-fault, and cross-backend live evidence remain.
 - [~] [#2281](https://github.com/tinylabscom/mvm/issues/2281) — baseline the
   current pure-Rust ext4 path and evaluate the guest-local immutable
   filesystem path against it.

--- a/specs/notes/2026-08-10-fast-machine-substrate.md
+++ b/specs/notes/2026-08-10-fast-machine-substrate.md
@@ -139,8 +139,9 @@ between warmup or measured samples.
 
 - [~] [#2280](https://github.com/tinylabscom/mvm/issues/2280) — measure the
   kernel and boot-substrate budget. The bounded libkrun resident host-process
-  capture is landed; guest demand-fault, restore-fault, and cross-backend live
-  evidence remain.
+  capture is landed, and HVF guest-RAM now exposes an allocation-level
+  demand-fault witness; end-to-end guest working-set, restore-fault, and
+  cross-backend live evidence remain.
 - [~] [#2281](https://github.com/tinylabscom/mvm/issues/2281) — baseline the
   current pure-Rust ext4 path and evaluate the guest-local immutable
   filesystem path against it.

--- a/specs/notes/2026-08-10-fast-machine-substrate.md
+++ b/specs/notes/2026-08-10-fast-machine-substrate.md
@@ -114,7 +114,9 @@ effective node composition, source file bytes, emitted ext4 size/digest,
 materializer format version, and separate hash/walk/build timings. Candidate
 filesystem paths must use the same fixture identity and report equivalent
 preparation, first-file access, working-set, and density evidence before the
-existing ext4 path can be replaced.
+existing ext4 path can be replaced. Cold-launch samples now also carry the
+tier-selected `virtiofs_root` or `block_ext4` strategy, so those measurements
+remain comparable only within the same security and capability tier.
 
 ## Security and resource invariants
 

--- a/specs/notes/2026-08-10-fast-machine-substrate.md
+++ b/specs/notes/2026-08-10-fast-machine-substrate.md
@@ -107,6 +107,13 @@ not a performance number to copy. The result is an explicit adopt or decline
 decision in issue #2281 and Plan 299; no parallel filesystem or cache stack is
 allowed.
 
+The current baseline is now measurable without a VM: `mvm_fs::rootfs::measure_ext4_pure`
+reports the source content digest, effective node composition, source file
+bytes, emitted ext4 size/digest, materializer format version, and separate
+hash/walk/build timings. Candidate filesystem paths must use the same fixture
+identity and report equivalent preparation, first-access, working-set, and
+density evidence before the existing ext4 path can be replaced.
+
 ## Security and resource invariants
 
 - Prepared artifacts are published atomically and verified before use.
@@ -126,8 +133,9 @@ allowed.
 
 - [ ] [#2280](https://github.com/tinylabscom/mvm/issues/2280) — measure the
   kernel and boot-substrate budget.
-- [ ] [#2281](https://github.com/tinylabscom/mvm/issues/2281) — evaluate the
-  guest-local immutable filesystem path.
+- [~] [#2281](https://github.com/tinylabscom/mvm/issues/2281) — baseline the
+  current pure-Rust ext4 path and evaluate the guest-local immutable
+  filesystem path against it.
 - [ ] [#2194](https://github.com/tinylabscom/mvm/issues/2194),
   [#2195](https://github.com/tinylabscom/mvm/issues/2195), and
   [#2196](https://github.com/tinylabscom/mvm/issues/2196) — complete the

--- a/specs/plans/298-warm-claim-service-and-hvf-pool.md
+++ b/specs/plans/298-warm-claim-service-and-hvf-pool.md
@@ -2,6 +2,12 @@
 
 **Status:** In progress.
 
+Plan 298 owns the resident warm-claim portion of the [fast machine
+substrate](../notes/2026-08-10-fast-machine-substrate.md). Its pool key and
+prepared artifacts are inputs to the shared template identity; tenant
+authority, host paths, live channels, and mutable workload state remain
+excluded from reusable parent state.
+
 ## Objective
 
 Make a warmed `machine run` claim complete in strictly less than 300ms from
@@ -340,6 +346,9 @@ reseeding, and policy validation.
   benchmark covers dependency installation and network behavior.
 - Workspace tests, all-target Clippy, formatting, security tests, and the
   supported live backend smoke tests pass before the sprint item closes.
+- Template identity, lifecycle phase names, and artifact ownership match the
+  shared fast-machine-substrate note. Pool capacity and backpressure account
+  for resident working set and concurrency, not only the number of parents.
 
 ## Issue ownership boundaries
 

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -559,7 +559,8 @@ optimization backend-local and the benchmark backend-neutral.
       materializer seam. `mvm_fs::rootfs::measure_ext4_pure` records the source
       content digest, node composition, file bytes, emitted image size/digest,
       materializer format version, and separate source-hash/walk/build timing
-      phases. Its JSON shape is stable for repeated fixture comparisons.
+      phases. `cargo xtask perf filesystem --root <DIR> --json` exposes the
+      report for repeated fixture comparisons.
 - [ ] Evaluate the current rootfs and host-directory image path against the
       guest-local immutable filesystem hypothesis in
       [issue #2281](https://github.com/tinylabscom/mvm/issues/2281). Keep the

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -4,6 +4,11 @@
 baselines measured. Phase 6 is promoted ahead of Phase 3 by the measurements;
 Phase 3 is retargeted at the Firecracker boot path.
 
+This plan is one owner of the [fast machine substrate](../notes/2026-08-10-fast-machine-substrate.md),
+which composes cold launch with Plans 298, 265, 270, and 292. It owns the
+prepared cold path and its evidence; it does not define a second artifact or
+snapshot graph.
+
 ## Goal
 
 Make a genuinely cold VMM launch fast enough that warm-VM performance is not the
@@ -55,6 +60,17 @@ This plan composes with existing work:
 - The current `--mount` surface remains the supported host-directory interface;
   the obsolete internal `AddDir` naming and any compatibility-only flag path are
   removed while this launch path is changed.
+
+The prepared template identity includes the kernel, universal initramfs, rootfs
+lower artifacts, verity metadata, runtime overlay, backend/VMM version, guest
+protocol, CPU/memory shape, block-device/share topology, network-policy shape,
+warmup profile, and readiness probe. Host paths, host-directory contents,
+tenant authority, live channels, and mutable writable state are excluded.
+
+The launch measurement vocabulary is canonical: kernel entry, agent ready,
+authenticated activation, environment ready, first useful RPC, and reaped.
+`/bin/true` remains a launch probe; the first useful authenticated RPC is a
+separate end-to-end signal.
 
 No task here may weaken admission, signed-plan verification, dm-verity,
 host-directory isolation, vsock authentication, or the no-NIC workload
@@ -524,6 +540,17 @@ optimization backend-local and the benchmark backend-neutral.
 - [ ] Use the smallest supported default memory commitment and demand-fault
       guest RAM. Prove that the change affects resident cost without changing
       guest-visible memory capacity or isolation.
+- [ ] Run the kernel and boot-substrate budget from
+      [issue #2280](https://github.com/tinylabscom/mvm/issues/2280): compare
+      raw/compressed kernel and initramfs size, boot probes, kernel entry,
+      authenticated readiness, resident pages, and restore fault cost. A size
+      reduction is accepted only with readiness, security, and compatibility
+      witnesses.
+- [ ] Evaluate the current rootfs and host-directory image path against the
+      guest-local immutable filesystem hypothesis in
+      [issue #2281](https://github.com/tinylabscom/mvm/issues/2281). Keep the
+      current path as the baseline and preserve dm-verity, xattrs/whiteouts,
+      read-only enforcement, and clean writable CoW state.
 - [ ] Add backend-specific unit tests for immutable artifact reuse, fresh VM
       identity, failed setup cleanup, and no cross-launch mutable state.
 
@@ -620,6 +647,9 @@ green.
       process ownership, and cleanup races.
 - [ ] The final sprint and refactor rollup entries cite concrete evidence files,
       host/backend details, and commit references.
+- [ ] The template identity and lifecycle vocabulary match
+      `specs/notes/2026-08-10-fast-machine-substrate.md`; no parallel cache or
+      snapshot graph exists.
 
 ## Explicit follow-ups if the gate remains red
 

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -546,6 +546,11 @@ optimization backend-local and the benchmark backend-neutral.
       authenticated readiness, resident pages, and restore fault cost. A size
       reduction is accepted only with readiness, security, and compatibility
       witnesses.
+- [x] Extend `cargo xtask perf footprint` to include the initramfs artifact and
+      an optional resolved kernel config. The JSON report now records the
+      initramfs bytes and built-in-symbol count, and reuses the per-architecture
+      kernel-config budget gate. This is the artifact-ledger slice of #2280;
+      live timing and resident-memory evidence remain open.
 - [ ] Evaluate the current rootfs and host-directory image path against the
       guest-local immutable filesystem hypothesis in
       [issue #2281](https://github.com/tinylabscom/mvm/issues/2281). Keep the

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -551,6 +551,10 @@ optimization backend-local and the benchmark backend-neutral.
       initramfs bytes and built-in-symbol count, and reuses the per-architecture
       kernel-config budget gate. This is the artifact-ledger slice of #2280;
       live timing and resident-memory evidence remain open.
+- [x] Carry artifact byte counts and optional resolved kernel-config symbol
+      counts into each `ColdLaunchReport` sample. The runner resolves these
+      after the child launch exits, so the report joins substrate evidence to
+      launch timing without charging metadata I/O to the measured window.
 - [ ] Evaluate the current rootfs and host-directory image path against the
       guest-local immutable filesystem hypothesis in
       [issue #2281](https://github.com/tinylabscom/mvm/issues/2281). Keep the

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -143,13 +143,16 @@ rate, but are not silently included in the prepared-cold SLO.
       already refuses a prepared-cold sample that reports one.)
 - [x] Record backend, host architecture, kernel digest, initramfs digest,
       overlay digest, rootfs digest, VMM version, CPU count, memory setting,
-      filesystem, cache state, and run number with every sample.
+      filesystem, selected root filesystem strategy, cache state, and run
+      number with every sample.
       (The launch writes artifact **paths**, not digests — hashing inside the
       measured window would charge the launch for the measurement. The runner
       resolves digests, filesystem, and cache state afterwards into
       `LaunchContext`/`CacheState`. `vmm_version` is resolved only for the
       in-house VMM, which ships inside `mvmctl`; a third-party VMM records
-      `None` rather than a fabricated number.)
+      `None` rather than a fabricated number. The launch sample records the
+      tier-gated `virtiofs_root` or `block_ext4` strategy so filesystem
+      comparisons never mix security or capability tiers.)
 - [x] Add a benchmark report format containing raw samples and p50/p95/p99;
       do not store only summary numbers.
       (`ColdLaunchReport` carries `raw: Vec<ColdLaunchSample>` alongside

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -555,11 +555,18 @@ optimization backend-local and the benchmark backend-neutral.
       an optional resolved kernel config. The JSON report now records the
       initramfs bytes and built-in-symbol count, and reuses the per-architecture
       kernel-config budget gate. This is the artifact-ledger slice of #2280;
-      live timing and resident-memory evidence remain open.
+      live boot timing and guest resident-memory evidence remain open; the
+      libkrun probe now captures host supervisor/VMM resident footprints.
 - [x] Carry artifact byte counts and optional resolved kernel-config symbol
       counts into each `ColdLaunchReport` sample. The runner resolves these
       after the child launch exits, so the report joins substrate evidence to
       launch timing without charging metadata I/O to the measured window.
+- [x] Add a bounded live resident-footprint capture for the libkrun probe.
+      `mvm_cli::bench::probes::run_density` boots admitted guests through
+      authenticated readiness, samples each host supervisor/VMM process with
+      the platform footprint reader, and drops every held guest on success or
+      failure. This reports host process residency; guest demand-fault and
+      restore-fault evidence remain separate gates.
 - [x] Add a baseline filesystem-path report at the existing pure-Rust
       materializer seam. `mvm_fs::rootfs::measure_ext4_pure` records the source
       content digest, node composition, file bytes, emitted image size/digest,

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -555,11 +555,17 @@ optimization backend-local and the benchmark backend-neutral.
       counts into each `ColdLaunchReport` sample. The runner resolves these
       after the child launch exits, so the report joins substrate evidence to
       launch timing without charging metadata I/O to the measured window.
+- [x] Add a baseline filesystem-path report at the existing pure-Rust
+      materializer seam. `mvm_fs::rootfs::measure_ext4_pure` records the source
+      content digest, node composition, file bytes, emitted image size/digest,
+      materializer format version, and separate source-hash/walk/build timing
+      phases. Its JSON shape is stable for repeated fixture comparisons.
 - [ ] Evaluate the current rootfs and host-directory image path against the
       guest-local immutable filesystem hypothesis in
       [issue #2281](https://github.com/tinylabscom/mvm/issues/2281). Keep the
-      current path as the baseline and preserve dm-verity, xattrs/whiteouts,
-      read-only enforcement, and clean writable CoW state.
+      current path as the baseline, use the new report for candidate
+      comparisons, and preserve dm-verity, xattrs/whiteouts, read-only
+      enforcement, and clean writable CoW state.
 - [ ] Add backend-specific unit tests for immutable artifact reuse, fresh VM
       identity, failed setup cleanup, and no cross-launch mutable state.
 

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -571,7 +571,10 @@ optimization backend-local and the benchmark backend-neutral.
       `GuestRam` exposes a `mincore` resident-byte query, the raw kernel boot
       result records it after vCPU and host-I/O shutdown, and a focused test
       proves untouched anonymous pages become resident only after writes.
-      This is not a substitute for an end-to-end guest working-set result.
+      The raw result also records monotonic private restore-mapping duration
+      when a restore file is supplied. These are allocation and mapping
+      witnesses, not substitutes for end-to-end guest working-set or first-use
+      restore-fault measurements.
 - [x] Add a baseline filesystem-path report at the existing pure-Rust
       materializer seam. `mvm_fs::rootfs::measure_ext4_pure` records the source
       content digest, node composition, file bytes, emitted image size/digest,

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -152,7 +152,9 @@ rate, but are not silently included in the prepared-cold SLO.
       in-house VMM, which ships inside `mvmctl`; a third-party VMM records
       `None` rather than a fabricated number. The launch sample records the
       tier-gated `virtiofs_root` or `block_ext4` strategy so filesystem
-      comparisons never mix security or capability tiers.)
+      comparisons never mix security or capability tiers. The runner rejects
+      a missing strategy and refuses to aggregate a report whose warmup or
+      measured samples change strategy.)
 - [x] Add a benchmark report format containing raw samples and p50/p95/p99;
       do not store only summary numbers.
       (`ColdLaunchReport` carries `raw: Vec<ColdLaunchSample>` alongside

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -567,6 +567,11 @@ optimization backend-local and the benchmark backend-neutral.
       the platform footprint reader, and drops every held guest on success or
       failure. This reports host process residency; guest demand-fault and
       restore-fault evidence remain separate gates.
+- [x] Add an allocation-level demand-fault witness to the HVF guest-RAM seam.
+      `GuestRam` exposes a `mincore` resident-byte query, the raw kernel boot
+      result records it after vCPU and host-I/O shutdown, and a focused test
+      proves untouched anonymous pages become resident only after writes.
+      This is not a substitute for an end-to-end guest working-set result.
 - [x] Add a baseline filesystem-path report at the existing pure-Rust
       materializer seam. `mvm_fs::rootfs::measure_ext4_pure` records the source
       content digest, node composition, file bytes, emitted image size/digest,

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,6 +12,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 mvm-core.workspace = true
+mvm-fs.workspace = true
 tempfile.workspace = true
 toml.workspace = true
 

--- a/xtask/src/check_kernel_config_budget.rs
+++ b/xtask/src/check_kernel_config_budget.rs
@@ -57,7 +57,7 @@ const BUDGET_X86_64: usize = 917;
 /// Resolve the budget for a config path by the arch in its name. Unknown →
 /// the larger budget (fail-open on the ceiling, never a false pass on a real
 /// regression: an unrecognised arch still can't exceed the most generous bound).
-fn budget_for_path(path: &str) -> usize {
+pub fn budget_for_path(path: &str) -> usize {
     if path.contains("x86_64") {
         BUDGET_X86_64
     } else if path.contains("aarch64") {
@@ -92,7 +92,7 @@ pub fn run(args: &[String]) -> Result<()> {
 
 /// Count `CONFIG_*=y` lines (built-in symbols). `=m` and `# … is not set`
 /// don't count — only what is compiled into the image.
-fn count_builtins(config: &str) -> usize {
+pub fn count_builtins(config: &str) -> usize {
     config
         .lines()
         .filter(|l| l.trim_end().ends_with("=y"))

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -34,7 +34,7 @@ mod check_guest_entropy_seed;
 mod check_guest_images_no_builder_tools;
 mod check_guest_init_parity;
 mod check_honesty;
-mod check_kernel_config_budget;
+pub(crate) mod check_kernel_config_budget;
 mod check_kernel_pin_freshness;
 mod check_machine_doc_guards;
 mod check_mutation_witnesses;

--- a/xtask/src/perf.rs
+++ b/xtask/src/perf.rs
@@ -21,6 +21,9 @@
 //! by tests in this module so a drift in the documented budget vs.
 //! the code is caught at review.
 //!
+//! The filesystem subcommand measures the current pure-Rust immutable ext4
+//! path and emits a stable baseline for candidate filesystem comparisons.
+//!
 //! ## Usage
 //!
 //! ```text
@@ -100,11 +103,12 @@ pub fn run(args: &[String]) -> Result<()> {
     match args.first().map(|s| s.as_str()) {
         Some("rootfs-size") => rootfs_size_subcommand(&args[1..]),
         Some("footprint") => footprint_subcommand(&args[1..]),
+        Some("filesystem") => filesystem_subcommand(&args[1..]),
         Some("boot") => boot_subcommand(&args[1..]),
         Some("budgets") => budgets_subcommand(&args[1..]),
         Some(other) => {
             bail!(
-                "Unknown perf subcommand {other:?}. Available: rootfs-size, footprint, boot, budgets"
+                "Unknown perf subcommand {other:?}. Available: rootfs-size, footprint, filesystem, boot, budgets"
             )
         }
         None => {
@@ -118,6 +122,9 @@ pub fn run(args: &[String]) -> Result<()> {
             eprintln!(
                 "                                 Assert the supplied guest artifacts total ≤ {GUEST_STORAGE_MAX_BYTES} bytes"
             );
+            eprintln!(
+                "  filesystem --root <PATH> [--json]  Measure the immutable directory-to-ext4 baseline"
+            );
             eprintln!("  boot --rootfs <PATH> [--runs N] [--backend firecracker|libkrun]");
             eprintln!(
                 "                                 Statistical cold-boot benchmark (Linux/KVM, MVM_LIVE_SMOKE=1)"
@@ -128,6 +135,42 @@ pub fn run(args: &[String]) -> Result<()> {
             std::process::exit(1);
         }
     }
+}
+
+// ============================================================================
+// filesystem subcommand — immutable materializer baseline
+// ============================================================================
+
+fn filesystem_subcommand(args: &[String]) -> Result<()> {
+    let root = required_path_arg(args, "--root")?;
+    let report = filesystem_baseline(&root)?;
+    if args.iter().any(|arg| arg == "--json") {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        eprintln!(
+            "ok: ext4 baseline emitted {} bytes from {} nodes (image {})",
+            report.image_size_bytes, report.nodes.total, report.image_sha256
+        );
+        eprintln!(
+            "  source {}  hash {} µs  walk {} µs  build {} µs  total {} µs",
+            report.source_content_sha256,
+            report.timings.source_hash_micros,
+            report.timings.walk_micros,
+            report.timings.build_micros,
+            report.timings.total_micros
+        );
+    }
+    Ok(())
+}
+
+fn filesystem_baseline(root: &Path) -> Result<mvm_fs::rootfs::Ext4MaterializationReport> {
+    mvm_fs::rootfs::measure_ext4_pure(root, &mvm_fs::rootfs::MaterializeOptions::default())
+        .with_context(|| {
+            format!(
+                "measure immutable filesystem baseline at {}",
+                root.display()
+            )
+        })
 }
 
 // ============================================================================
@@ -1121,6 +1164,26 @@ mod tests {
         assert_eq!(artifacts[3].name, "rootfs-verity");
         assert_eq!(artifacts[4].name, "overlay-verity");
         assert_eq!(artifacts[5].name, "kernel");
+    }
+
+    #[test]
+    fn filesystem_baseline_reports_a_directory_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("etc")).unwrap();
+        std::fs::write(tmp.path().join("etc/hosts"), b"127.0.0.1 localhost\n").unwrap();
+
+        let report = filesystem_baseline(tmp.path()).unwrap();
+
+        assert_eq!(report.nodes.files, 1);
+        assert_eq!(report.nodes.directories, 1);
+        assert!(report.image_size_bytes > 0);
+        assert_eq!(report.image_sha256.len(), 64);
+    }
+
+    #[test]
+    fn filesystem_subcommand_requires_a_root() {
+        let err = filesystem_subcommand(&[]).unwrap_err();
+        assert!(err.to_string().contains("--root"));
     }
 
     #[test]

--- a/xtask/src/perf.rs
+++ b/xtask/src/perf.rs
@@ -12,9 +12,10 @@
 //!   required; gated by `MVM_LIVE_SMOKE=1` + a rootfs path so a
 //!   bare macOS host skips cleanly. Enforces the "cold-boot ≤ 500ms
 //!   Firecracker / ≤ 1s libkrun" line.
-//! - **`footprint`** — sum the Nix-built rootfs, runtime overlay, verity
-//!   sidecars, and optional kernel, assert the supplied guest artifacts stay
-//!   below 50 MB, and optionally enforce the rootfs Nix closure inventory.
+//! - **`footprint`** — sum the Nix-built rootfs, runtime overlay, initramfs,
+//!   verity sidecars, and optional kernel, assert the supplied guest artifacts
+//!   stay below 50 MB, and optionally enforce the rootfs Nix closure inventory
+//!   and kernel built-in-symbol budget.
 //!
 //! The thresholds are the per-backend boot budgets; they're pinned
 //! by tests in this module so a drift in the documented budget vs.
@@ -25,7 +26,7 @@
 //! ```text
 //! cargo xtask perf rootfs-size --rootfs ~/.mvm/cache/.../rootfs.ext4
 //! cargo xtask perf boot --runs 30 --rootfs ~/.mvm/cache/.../rootfs.ext4
-//! cargo xtask perf footprint --rootfs result/rootfs.ext4 --overlay overlay/overlay.ext4 --kernel result/vmlinux --closure-paths result/rootfs-closure-paths
+//! cargo xtask perf footprint --rootfs result/rootfs.ext4 --overlay overlay/overlay.ext4 --initramfs result/initramfs.cpio.gz --kernel result/vmlinux --kernel-config result/workload.config --closure-paths result/rootfs-closure-paths
 //! cargo xtask perf footprint --rootfs result/rootfs.ext4 --overlay overlay/overlay.ext4 --guest-rss-bytes 4194304
 //! cargo xtask perf footprint --rootfs result/rootfs.ext4 --overlay overlay/overlay.ext4 --sdk-sidecar sidecar/sdk.ext4
 //! ```
@@ -63,8 +64,8 @@ use anyhow::{Context, Result, bail};
 pub const ROOTFS_MAX_BYTES: u64 = 20 * 1024 * 1024; // 20 MiB
 
 /// Maximum complete default guest artifact footprint: rootfs, runtime overlay,
-/// their dm-verity sidecars, and kernel. The workload's own application payload
-/// remains outside this contract.
+/// initramfs, their dm-verity sidecars, and kernel. The workload's own
+/// application payload remains outside this contract.
 pub const GUEST_STORAGE_MAX_BYTES: u64 = 50_000_000; // 50 MB
 
 /// Maximum number of registered Nix store paths retained in the default
@@ -112,7 +113,7 @@ pub fn run(args: &[String]) -> Result<()> {
                 "  rootfs-size --rootfs <PATH>    Assert rootfs is ≤ {ROOTFS_MAX_BYTES} bytes"
             );
             eprintln!(
-                "  footprint --rootfs <PATH> --overlay <PATH> [--rootfs-verity <PATH>] [--overlay-verity <PATH>] [--kernel <PATH>] [--closure-paths <PATH>] [--guest-rss-bytes <N>] [--sdk-sidecar <PATH>]"
+                "  footprint --rootfs <PATH> --overlay <PATH> [--initramfs <PATH>] [--rootfs-verity <PATH>] [--overlay-verity <PATH>] [--kernel <PATH>] [--kernel-config <PATH>] [--closure-paths <PATH>] [--guest-rss-bytes <N>] [--sdk-sidecar <PATH>]"
             );
             eprintln!(
                 "                                 Assert the supplied guest artifacts total ≤ {GUEST_STORAGE_MAX_BYTES} bytes"
@@ -362,6 +363,13 @@ struct ClosureInventory {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+struct KernelConfigSummary {
+    path: PathBuf,
+    builtin_symbols: usize,
+    budget: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 struct FootprintReport {
     limit_bytes: u64,
     total_bytes: u64,
@@ -375,6 +383,8 @@ struct FootprintReport {
     /// service, so it is not part of the base guest footprint.
     #[serde(skip_serializing_if = "Option::is_none")]
     sdk_sidecar: Option<FootprintEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kernel_config: Option<KernelConfigSummary>,
 }
 
 fn footprint_subcommand(args: &[String]) -> Result<()> {
@@ -391,10 +401,14 @@ fn footprint_subcommand(args: &[String]) -> Result<()> {
     let sdk_sidecar = optional_path_arg(args, "--sdk-sidecar")?
         .map(|path| sdk_sidecar_check(&path, SDK_SIDECAR_MAX_BYTES))
         .transpose()?;
+    let kernel_config = optional_path_arg(args, "--kernel-config")?
+        .map(|path| kernel_config_summary(&path))
+        .transpose()?;
     let mut report = guest_storage_footprint_check(&artifacts, GUEST_STORAGE_MAX_BYTES)?;
     report.rootfs_closure = rootfs_closure;
     report.guest_agent_rss_bytes = guest_agent_rss_bytes;
     report.sdk_sidecar = sdk_sidecar;
+    report.kernel_config = kernel_config;
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
@@ -433,6 +447,15 @@ fn footprint_subcommand(args: &[String]) -> Result<()> {
                 "sdk-sidecar",
                 entry.bytes,
                 entry.path.display()
+            );
+        }
+        if let Some(config) = &report.kernel_config {
+            eprintln!(
+                "  {:<16} {} built-in symbols (budget {})  {}",
+                "kernel-config",
+                config.builtin_symbols,
+                config.budget,
+                config.path.display()
             );
         }
     }
@@ -477,6 +500,12 @@ fn parse_footprint_artifacts(args: &[String]) -> Result<Vec<FootprintArtifact>> 
             path: overlay,
         },
     ];
+    if let Some(path) = optional_path_arg(args, "--initramfs")? {
+        artifacts.push(FootprintArtifact {
+            name: "initramfs",
+            path,
+        });
+    }
     if let Some(path) = optional_path_arg(args, "--rootfs-verity")? {
         artifacts.push(FootprintArtifact {
             name: "rootfs-verity",
@@ -537,6 +566,20 @@ fn guest_storage_footprint_check(
         rootfs_closure: None,
         guest_agent_rss_bytes: None,
         sdk_sidecar: None,
+        kernel_config: None,
+    })
+}
+
+fn kernel_config_summary(path: &Path) -> Result<KernelConfigSummary> {
+    let config = std::fs::read_to_string(path)
+        .with_context(|| format!("read kernel config at {}", path.display()))?;
+    let builtin_symbols = crate::check_kernel_config_budget::count_builtins(&config);
+    let budget = crate::check_kernel_config_budget::budget_for_path(&path.to_string_lossy());
+    crate::check_kernel_config_budget::evaluate_budget(&config, budget)?;
+    Ok(KernelConfigSummary {
+        path: path.to_path_buf(),
+        builtin_symbols,
+        budget,
     })
 }
 
@@ -739,6 +782,7 @@ fn parse_backend_arg(args: &[String]) -> Result<Backend> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::check_kernel_config_budget;
     use std::io::Write;
 
     // ──────────────────────────────────────────────────────────────
@@ -1062,6 +1106,8 @@ mod tests {
             "/tmp/rootfs.ext4".to_string(),
             "--overlay".to_string(),
             "/tmp/overlay.ext4".to_string(),
+            "--initramfs".to_string(),
+            "/tmp/initramfs.cpio.gz".to_string(),
             "--rootfs-verity".to_string(),
             "/tmp/rootfs.verity".to_string(),
             "--overlay-verity".to_string(),
@@ -1070,10 +1116,46 @@ mod tests {
             "/tmp/vmlinux".to_string(),
         ];
         let artifacts = parse_footprint_artifacts(&args).unwrap();
-        assert_eq!(artifacts.len(), 5);
-        assert_eq!(artifacts[2].name, "rootfs-verity");
-        assert_eq!(artifacts[3].name, "overlay-verity");
-        assert_eq!(artifacts[4].name, "kernel");
+        assert_eq!(artifacts.len(), 6);
+        assert_eq!(artifacts[2].name, "initramfs");
+        assert_eq!(artifacts[3].name, "rootfs-verity");
+        assert_eq!(artifacts[4].name, "overlay-verity");
+        assert_eq!(artifacts[5].name, "kernel");
+    }
+
+    #[test]
+    fn kernel_config_summary_counts_and_enforces_builtins() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("workload-config-x86_64");
+        std::fs::write(
+            &path,
+            "CONFIG_ONE=y\nCONFIG_TWO=m\n# CONFIG_THREE is not set\n",
+        )
+        .unwrap();
+
+        let summary = kernel_config_summary(&path).unwrap();
+
+        assert_eq!(summary.path, path);
+        assert_eq!(summary.builtin_symbols, 1);
+        assert_eq!(
+            summary.budget,
+            check_kernel_config_budget::budget_for_path("x86_64")
+        );
+    }
+
+    #[test]
+    fn kernel_config_summary_rejects_a_budget_overflow() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("workload-config-x86_64");
+        let config = (0..=check_kernel_config_budget::budget_for_path("x86_64"))
+            .map(|index| format!("CONFIG_TEST_{index}=y"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(&path, config).unwrap();
+
+        let error = kernel_config_summary(&path).unwrap_err();
+
+        assert!(error.to_string().contains("exceeds the budget"));
     }
 
     // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add a bounded kernel/boot-substrate evidence slice for the prepared launch path.
- Capture HVF guest-RAM residency after boot and monotonic duration for private restore-RAM mapping.
- Keep the evidence allocation-level and backend-local; it does not claim end-to-end guest working-set or first-use restore-fault performance.
- Synchronize Plan 299, Sprint, refactor status, and the fast-machine-substrate note.

## Why

Cold and warm performance depends on the complete machine substrate: artifact size, VMM setup, guest RAM commitment, restore mapping, and guest working set. The existing HVF demand-zero/private-COW seam now exposes the measurements needed to distinguish host mapping cost from resident memory cost without changing guest capacity, identity, or isolation semantics.

## Validation

- Focused HVF kernel-boot tests: 8 passed.
- Focused guest-RAM tests: 13 passed.
- `cargo check --workspace --locked` passed.
- Repository pre-commit `cargo clippy --workspace --all-targets -- -D warnings` passed.
- The two unrelated `mvm-agentd` entrypoint tests that flaked during the first workspace run passed on immediate rerun. A later full workspace rerun progressed through the earlier suites but stalled in an existing runtime Unix-socket test and was stopped.

## Follow-up

Issue #2280 remains open for authenticated guest working-set measurements, first-use restore-fault cost, Firecracker evidence, and published real-host comparisons.
