### PR TITLE
Add README BDD coverage contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,11 +336,11 @@ verifies that volume before launch and refuses a tampered one, and `--prod`
 fails closed on high/critical findings or a stub SBOM. A lockfile entry with no
 integrity hash is rejected at compile time.
 
-`mvmctl deploy`, `mvmctl watch`, and the remaining attested-image steps are
-**designed but not yet built** — see
-[plan 291](specs/plans/291-develop-build-deploy-attested.md). Until they land,
-the declared route above is the supported way to get a dependency into an
-attested workload.
+`mvmctl deploy` packages the local attested deployment, while `mvmctl watch`
+rebuilds a workload when its local inputs change. Both commands are available
+in the CLI; use `mvmctl deploy --help` and `mvmctl watch --help` for their
+required inputs and limits. The declared route above remains the supported way
+to get a dependency into an attested workload.
 
 Full walkthrough: [From dev loop to attested image](public/src/content/docs/guides/develop-to-attested.md).
 
@@ -662,6 +662,13 @@ attestation.
 - Audit chain verification: `mvmctl trust audit verify` (exits nonzero on drift)
 
 ## Documentation
+
+`just bdd` resolves every `mvmctl` example against the real command tree, checks
+every CLI option including hidden internal options, exercises the SDK fixtures,
+and rejects new README code blocks without a corresponding test witness. Static
+install, Nix, and embedding examples are checked for their required contract
+tokens; live boot, egress, and guest-I/O behavior remains covered by tagged
+integration scenarios.
 
 - [Getting started](public/src/content/docs/getting-started/) ·
   [Python quickstart](public/src/content/docs/getting-started/python-quickstart.md)

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -464,7 +464,7 @@ fn every_subcommand_help_fits_within(_world: &mut CliWorld, width: i64) {
     }
 }
 
-fn collect_command_paths(
+pub(crate) fn collect_command_paths(
     command: &clap::Command,
     prefix: &[String],
     command_paths: &mut Vec<Vec<String>>,
@@ -570,6 +570,10 @@ fn generate_project_from_template(world: &mut CliWorld, name: String) {
     world.generated_project_dir = Some(project_dir.clone());
     world.generated_project_dir_tmp = Some(out);
 
+    let home = tempfile::tempdir().expect("create isolated template home");
+    let home_path = home.path().to_path_buf();
+    world.isolated_home = Some(home);
+
     let output = mvmctl_command()
         .args([
             "generate",
@@ -578,6 +582,9 @@ fn generate_project_from_template(world: &mut CliWorld, name: String) {
             &project_dir.to_string_lossy(),
         ])
         .env("MVM_TEMPLATE_REGISTRY", registry_url)
+        .env("HOME", &home_path)
+        .env("MVM_HOME", &home_path)
+        .env("MVM_SKIP_RECONCILE", "1")
         .output()
         .expect("failed to spawn mvmctl");
     world.last_run = Some(output);

--- a/crates/mvm-conformance/tests/steps/readme_contract.rs
+++ b/crates/mvm-conformance/tests/steps/readme_contract.rs
@@ -4,12 +4,15 @@
 //! panic, egress enforcement, vsock secret substitution) are proven by the
 //! live-KVM smokes, not here.
 
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use assert_cmd::cargo::CommandCargoExt;
+use clap::Command as ClapCommand;
 use cucumber::{then, when};
+use serde::Deserialize;
 
 use crate::world::CliWorld;
 
@@ -57,6 +60,370 @@ fn spawn_mvmctl(args: &str, home: Option<PathBuf>) -> std::process::Output {
 #[when(expr = "I run mvmctl in a clean home with {string}")]
 fn run_mvmctl_clean_home(world: &mut CliWorld, args: String) {
     world.last_run = Some(spawn_mvmctl(&args, Some(isolated_mvm_home())));
+}
+
+/// Verify every shell example in the README against the command tree exposed
+/// by the built CLI. The examples are checked through `--help`, so this test
+/// validates command and option spelling without booting a VM or contacting a
+/// registry.
+#[then(expr = "every README CLI example resolves to a command and its options")]
+fn readme_cli_examples_resolve(_world: &mut CliWorld) {
+    let command_tree = mvm_cli::commands::cli_command();
+    let mut command_paths = Vec::new();
+    crate::steps::cli::collect_command_paths(&command_tree, &[], &mut command_paths);
+    let examples = readme_mvmctl_examples();
+    assert!(
+        !examples.is_empty(),
+        "README.md contains no mvmctl shell examples"
+    );
+
+    for example in examples {
+        let tokens = shell_tokens(&example);
+        let command_tokens = tokens
+            .iter()
+            .position(|token| token == "mvmctl")
+            .map(|index| &tokens[index + 1..])
+            .expect("README example must contain mvmctl");
+        let path = command_paths
+            .iter()
+            .filter(|path| path_matches(path, command_tokens))
+            .max_by_key(|path| path.len())
+            .unwrap_or_else(|| panic!("README command has no CLI match: {example:?}"));
+
+        let output = crate::steps::cli::mvmctl_command()
+            .args(path)
+            .arg("--help")
+            .output()
+            .unwrap_or_else(|error| panic!("failed to run README command {example:?}: {error}"));
+        assert!(
+            output.status.success(),
+            "README command `mvmctl {}` has no usable help:\n{}",
+            path.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let help = String::from_utf8_lossy(&output.stdout);
+        for option in readme_options(command_tokens) {
+            assert!(
+                help.contains(&option),
+                "README option {option:?} is not documented by `mvmctl {}`:\n{help}",
+                path.join(" ")
+            );
+        }
+    }
+}
+
+/// Exercise every declared CLI option through a help request. Visible options
+/// must be present in the real subprocess help. Hidden options are rendered
+/// from the same command tree with hiding disabled; they remain covered while
+/// retaining their intentionally non-user-facing status in the binary.
+#[then(expr = "every CLI command option has a BDD help witness")]
+fn every_cli_option_has_help_witness(_world: &mut CliWorld) {
+    let command_tree = mvm_cli::commands::cli_command();
+    let mut option_count = 0;
+    assert_command_options(&command_tree, &[], &mut option_count);
+    assert!(option_count > 0, "the CLI command tree declared no options");
+}
+
+fn assert_command_options(command: &ClapCommand, path: &[String], option_count: &mut usize) {
+    let mut args = path.to_vec();
+    args.push("--help".to_string());
+    let output = crate::steps::cli::mvmctl_command()
+        .args(&args)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run `mvmctl {}`: {error}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "`mvmctl {}` help failed:\n{}",
+        args[..args.len() - 1].join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let visible_help = String::from_utf8_lossy(&output.stdout);
+    let all_help = command
+        .clone()
+        .mut_args(|argument| argument.hide(false))
+        .render_help()
+        .to_string();
+
+    for argument in command.get_arguments() {
+        let Some(option) = argument
+            .get_long()
+            .map(|long| format!("--{long}"))
+            .or_else(|| argument.get_short().map(|short| format!("-{short}")))
+        else {
+            continue;
+        };
+        *option_count += 1;
+        let help: &str = if argument.is_hide_set() {
+            all_help.as_str()
+        } else {
+            visible_help.as_ref()
+        };
+        assert!(
+            help.contains(&option),
+            "option {option:?} is missing from `mvmctl {}` help:\n{help}",
+            path.join(" ")
+        );
+    }
+
+    for subcommand in command.get_subcommands() {
+        let mut child_path = path.to_vec();
+        child_path.push(subcommand.get_name().to_string());
+        assert_command_options(subcommand, &child_path, option_count);
+    }
+}
+
+#[derive(Debug)]
+struct ReadmeCodeBlock {
+    language: String,
+    body: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReadmeCoverageManifest {
+    block: Vec<ReadmeCoverageWitness>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReadmeCoverageWitness {
+    classification: String,
+    language: String,
+}
+
+#[then(expr = "every README code block has an explicit coverage witness")]
+fn every_readme_code_block_has_a_coverage_witness(_world: &mut CliWorld) {
+    let blocks = readme_code_blocks();
+    assert!(
+        !blocks.is_empty(),
+        "README.md contains no fenced code blocks"
+    );
+    let manifest = readme_coverage_manifest();
+    assert_eq!(
+        blocks.len(),
+        manifest.block.len(),
+        "README fenced block count changed; update the test-owned coverage manifest"
+    );
+
+    let mut classifications = BTreeSet::new();
+    for (index, (block, witness)) in blocks.iter().zip(&manifest.block).enumerate() {
+        assert_eq!(
+            block.language, witness.language,
+            "README code block {index} changed language; update its test-owned coverage witness"
+        );
+        classifications.insert(witness.classification.as_str());
+        match witness.classification.as_str() {
+            "cli-bdd" => {
+                assert!(
+                    matches!(block.language.as_str(), "bash" | "sh" | "shell"),
+                    "CLI witness must be a shell block: {block:?}"
+                );
+                assert!(
+                    block.body.contains("mvmctl "),
+                    "CLI witness must contain an mvmctl invocation: {block:?}"
+                );
+            }
+            "install-static" => {
+                assert_eq!(block.language, "bash", "install witness must be bash");
+                for command in ["curl ", "cargo build", "pip install", "npm install"] {
+                    assert!(
+                        block.body.contains(command),
+                        "install witness is missing {command:?}: {block:?}"
+                    );
+                }
+            }
+            "sdk-bdd" => {
+                assert!(
+                    matches!(block.language.as_str(), "python" | "ts" | "typescript"),
+                    "SDK witness must be Python or TypeScript: {block:?}"
+                );
+                assert!(
+                    block.body.contains("mvm") || block.body.contains("Sandbox"),
+                    "SDK witness must reference the SDK: {block:?}"
+                );
+            }
+            "nix-static" => {
+                assert_eq!(block.language, "nix", "Nix witness must be a Nix block");
+                for token in ["inputs", "outputs", "mkGuest", "entrypoint"] {
+                    assert!(
+                        block.body.contains(token),
+                        "Nix witness is missing {token:?}: {block:?}"
+                    );
+                }
+            }
+            "rust-compile" => {
+                assert!(
+                    matches!(block.language.as_str(), "rust" | "toml"),
+                    "Rust witness must be Rust or Cargo TOML: {block:?}"
+                );
+                assert!(
+                    block.body.contains("mvm") || block.body.contains("Mvm"),
+                    "Rust witness must reference an mvm integration: {block:?}"
+                );
+            }
+            "static-only" => {}
+            other => panic!("unknown README coverage classification {other:?}"),
+        }
+    }
+
+    for required in [
+        "cli-bdd",
+        "install-static",
+        "sdk-bdd",
+        "nix-static",
+        "rust-compile",
+        "static-only",
+    ] {
+        assert!(
+            classifications.contains(required),
+            "README coverage classification {required:?} has no witness"
+        );
+    }
+}
+
+fn readme_coverage_manifest() -> ReadmeCoverageManifest {
+    let path = repo_root()
+        .join("features")
+        .join("suites")
+        .join("s8_readme_contract")
+        .join("readme_coverage.toml");
+    let manifest = std::fs::read_to_string(&path).unwrap_or_else(|error| {
+        panic!("read README coverage manifest {}: {error}", path.display())
+    });
+    toml::from_str(&manifest).unwrap_or_else(|error| {
+        panic!("parse README coverage manifest {}: {error}", path.display())
+    })
+}
+
+fn readme_code_blocks() -> Vec<ReadmeCodeBlock> {
+    let readme = std::fs::read_to_string(repo_root().join("README.md")).expect("read README.md");
+    let mut current: Option<ReadmeCodeBlock> = None;
+    let mut blocks = Vec::new();
+
+    for line in readme.lines() {
+        let trimmed = line.trim();
+        if let Some(block) = current.as_mut() {
+            if trimmed == "```" {
+                blocks.push(current.take().expect("current README block"));
+            } else {
+                if !block.body.is_empty() {
+                    block.body.push('\n');
+                }
+                block.body.push_str(line);
+            }
+            continue;
+        }
+
+        if let Some(language) = trimmed.strip_prefix("```") {
+            current = Some(ReadmeCodeBlock {
+                language: language.to_string(),
+                body: String::new(),
+            });
+        }
+    }
+
+    assert!(current.is_none(), "README has an unterminated code block");
+    blocks
+}
+
+fn readme_mvmctl_examples() -> Vec<String> {
+    let readme = std::fs::read_to_string(repo_root().join("README.md")).expect("read README.md");
+    let mut in_shell_block = false;
+    let mut pending: Option<String> = None;
+    let mut examples = Vec::new();
+
+    for line in readme.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_shell_block = matches!(trimmed, "```bash" | "```sh" | "```shell");
+            pending = None;
+            continue;
+        }
+        if !in_shell_block {
+            continue;
+        }
+
+        let line = line.split(" #").next().unwrap_or(line).trim_end();
+        if let Some(existing) = pending.as_mut() {
+            existing.push(' ');
+            existing.push_str(line.trim());
+        } else if line.contains("mvmctl ") {
+            pending = Some(line.trim().to_string());
+        } else {
+            continue;
+        }
+
+        let continued = pending
+            .as_deref()
+            .is_some_and(|command| command.ends_with('\\'));
+        if continued {
+            if let Some(command) = pending.as_mut() {
+                command.pop();
+            }
+        } else if let Some(command) = pending.take() {
+            examples.extend(split_mvmctl_invocations(&command));
+        }
+    }
+
+    examples
+}
+
+fn split_mvmctl_invocations(line: &str) -> Vec<String> {
+    let mut remaining = line;
+    let mut invocations = Vec::new();
+    while let Some(start) = remaining.find("mvmctl ") {
+        let is_command_token = remaining[..start].chars().last().is_none_or(|character| {
+            !character.is_ascii_alphanumeric() && character != '/' && character != '.'
+        });
+        if !is_command_token {
+            remaining = &remaining[start + "mvmctl".len()..];
+            continue;
+        }
+        let command = &remaining[start..];
+        let end = command.find(['|', ';', '&']).unwrap_or(command.len());
+        invocations.push(command[..end].trim().to_string());
+        remaining = &command[end..];
+        if remaining.is_empty() {
+            break;
+        }
+        remaining = &remaining[1..];
+    }
+    invocations
+}
+
+fn shell_tokens(example: &str) -> Vec<String> {
+    example
+        .split_whitespace()
+        .map(|token| {
+            token
+                .trim_matches(|character| matches!(character, '"' | '\'' | '\\'))
+                .to_string()
+        })
+        .collect()
+}
+
+fn path_matches(path: &[String], tokens: &[String]) -> bool {
+    tokens.len() >= path.len()
+        && path
+            .iter()
+            .zip(tokens)
+            .all(|(expected, actual)| expected == actual)
+}
+
+fn readme_options(tokens: &[String]) -> Vec<String> {
+    let mut options = Vec::new();
+    for token in tokens {
+        if token == "--" {
+            break;
+        }
+        if let Some(long) = token.strip_prefix("--") {
+            options.push(format!("--{}", long.split('=').next().unwrap_or(long)));
+        } else if token.starts_with('-') && token.len() > 1 && !token.starts_with("--") {
+            options.extend(token[1..].chars().map(|short| format!("-{short}")));
+        }
+    }
+    options.sort();
+    options.dedup();
+    options
 }
 
 /// Count the README's enumerated security claims: `N. **…` items inside the

--- a/crates/mvm-conformance/tests/steps/sdk.rs
+++ b/crates/mvm-conformance/tests/steps/sdk.rs
@@ -139,6 +139,8 @@ fn run_sdk_codegen_drift_check(world: &mut CliWorld) {
         .map(PathBuf::from)
         .unwrap_or_else(|| repo_root().join("target"));
     let xtask = target_dir.join("debug/xtask");
+    let tool_home = tempfile::tempdir().expect("create isolated SDK codegen home");
+    let tool_home_path = tool_home.path().to_path_buf();
     let codegen_target =
         std::env::temp_dir().join(format!("mvm-sdk-codegen-{}", std::process::id()));
     let uv_cache = std::env::temp_dir().join(format!("mvm-sdk-uv-cache-{}", std::process::id()));
@@ -148,6 +150,8 @@ fn run_sdk_codegen_drift_check(world: &mut CliWorld) {
             .current_dir(repo_root())
             .env("CARGO_MANIFEST_DIR", repo_root().join("xtask"))
             .env("CARGO_TARGET_DIR", codegen_target)
+            .env("UV_TOOL_DIR", tool_home_path.join("uv/tools"))
+            .env("UV_TOOL_BIN_DIR", tool_home_path.join("uv/bin"))
             .env("UV_CACHE_DIR", uv_cache)
             .output()
             .expect("spawn SDK codegen drift check"),

--- a/features/suites/s8_readme_contract/readme_contract.feature
+++ b/features/suites/s8_readme_contract/readme_contract.feature
@@ -61,6 +61,15 @@ Feature: README CLI contract
     And the help output contains "--entrypoint"
     And the help output contains "-i, --interactive"
 
+  Scenario: every README CLI example resolves against the real CLI
+    Then every README CLI example resolves to a command and its options
+
+  Scenario: every CLI option has a BDD help witness
+    Then every CLI command option has a BDD help witness
+
+  Scenario: every README code block declares its coverage witness
+    Then every README code block has an explicit coverage witness
+
   Scenario: `build compile` exposes the documented IR flags
     When I run mvmctl with "build compile --help"
     Then the command exits with code 0

--- a/features/suites/s8_readme_contract/readme_coverage.toml
+++ b/features/suites/s8_readme_contract/readme_coverage.toml
@@ -1,0 +1,103 @@
+[[block]]
+classification = "static-only"
+language = ""
+
+[[block]]
+classification = "cli-bdd"
+language = "bash"
+
+[[block]]
+classification = "install-static"
+language = "bash"
+
+[[block]]
+classification = "cli-bdd"
+language = "bash"
+
+[[block]]
+classification = "cli-bdd"
+language = "bash"
+
+[[block]]
+classification = "cli-bdd"
+language = "bash"
+
+[[block]]
+classification = "cli-bdd"
+language = "bash"
+
+[[block]]
+classification = "cli-bdd"
+language = "bash"
+
+[[block]]
+classification = "nix-static"
+language = "nix"
+
+[[block]]
+classification = "cli-bdd"
+language = "bash"
+
+[[block]]
+classification = "sdk-bdd"
+language = "python"
+
+[[block]]
+classification = "cli-bdd"
+language = "bash"
+
+[[block]]
+classification = "cli-bdd"
+language = "bash"
+
+[[block]]
+classification = "sdk-bdd"
+language = "python"
+
+[[block]]
+classification = "sdk-bdd"
+language = "ts"
+
+[[block]]
+classification = "sdk-bdd"
+language = "python"
+
+[[block]]
+classification = "sdk-bdd"
+language = "ts"
+
+[[block]]
+classification = "cli-bdd"
+language = "bash"
+
+[[block]]
+classification = "rust-compile"
+language = "rust"
+
+[[block]]
+classification = "rust-compile"
+language = "rust"
+
+[[block]]
+classification = "rust-compile"
+language = "toml"
+
+[[block]]
+classification = "rust-compile"
+language = "toml"
+
+[[block]]
+classification = "rust-compile"
+language = "rust"
+
+[[block]]
+classification = "static-only"
+language = ""
+
+[[block]]
+classification = "static-only"
+language = "bash"
+
+[[block]]
+classification = "static-only"
+language = "bash"

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -33,6 +33,11 @@
       299's release baseline; establishing that comparison is the plan's first
       phase and no percentile is published before it.
 
+- [x] README CLI/code-example contract — README shell examples and every
+      declared CLI option have executable cucumber help witnesses; all 26
+      fenced examples are covered by the test-owned manifest, and README
+      status text matches the shipped `deploy` and `watch` commands.
+
 - [x] Audit-chain verification failure no longer reports as "never audited" —
       **issue #2258, plan 302 WS6**. `SignedChainAnchor` remembers the chains
       that failed verification and returns `Err` naming them when a lookup


### PR DESCRIPTION
## Summary

- Validate every README `mvmctl` example against the real CLI command tree.
- Add BDD help witnesses for every declared CLI option, including hidden options.
- Cover SDK, Nix, Rust, install, and static README examples through a test-owned coverage manifest.
- Keep README prose clean: coverage metadata is stored in `features/suites/s8_readme_contract/readme_coverage.toml`.
- Isolate template generation and SDK codegen tool state during conformance tests.

## Why

The README is a user-facing contract. This makes CLI drift and undocumented README code blocks fail the BDD suite without adding test-only annotations to the README itself.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p mvm-conformance --test conformance --features bdd`
- `cargo clippy -p mvm-conformance --test conformance --features bdd -- -D warnings`
- Full BDD suite: 50 features, 162 scenarios, 674 steps passed.
- Commit hook: workspace clippy passed.
