### PR TITLE
Take the shell and its subprocesses off the Firecracker boot path

### DIFF
--- a/crates/mvm-backends/src/driver/fc.rs
+++ b/crates/mvm-backends/src/driver/fc.rs
@@ -804,10 +804,31 @@ impl VmmDriver for FcDriver {
                 )
             })?;
 
+        // Four spans inside this boot, emitted at debug. `driver_boot` is one
+        // opaque number to the launch sample, and on this backend it covers
+        // both VMM start and guest boot — the two things a cold-start budget
+        // most needs told apart. A trace-level split is not the sidecar the
+        // launch sample uses; it is the cheapest thing that makes the residual
+        // attributable without widening the driver trait for a diagnostic.
+        let boot_started = Instant::now();
+
         // Spawn the Firecracker daemon (writes fc.pid, waits for its API socket).
         let socket = format!("{abs_dir}/fc.socket");
         let mut firecracker_guard = FirecrackerGuard::new(&abs_dir);
         start_vm_firecracker(&abs_dir, &socket)?;
+        let spawned_at = Instant::now();
+        tracing::debug!(
+            vm = %spec.name,
+            ms = boot_started.elapsed().as_secs_f64() * 1000.0,
+            "fc boot: process spawn + API socket"
+        );
+
+        // Take ownership of the API socket so the config sequence below can
+        // speak to it in-process. Firecracker was launched through `sudo` and
+        // created the socket as root; without this every call would need its
+        // own `sudo curl`.
+        crate::fc::adopt_api_socket(&socket)
+            .context("adopting the Firecracker API socket for the invoking user")?;
 
         // Drive the NIC-less API config sequence.
         let vsock_uds = firecracker_vsock_uds_path(&abs_dir);
@@ -829,14 +850,33 @@ impl VmmDriver for FcDriver {
         // boots and dials out.
         arm_host_channels(&spec.vsock, &state_dir, &runtime_dir)?;
 
+        let configured_at = Instant::now();
+        tracing::debug!(
+            vm = %spec.name,
+            ms = (configured_at - spawned_at).as_secs_f64() * 1000.0,
+            "fc boot: API config sequence"
+        );
+
         // Boot the configured instance.
         api_put_socket(&socket, "/actions", r#"{"action_type": "InstanceStart"}"#)
             .context("Firecracker API PUT /actions InstanceStart")?;
+        let started_at = Instant::now();
+        tracing::debug!(
+            vm = %spec.name,
+            ms = (started_at - configured_at).as_secs_f64() * 1000.0,
+            "fc boot: InstanceStart"
+        );
 
         // Confirm the guest is up: a successful agent CONNECT over the vsock mux
         // means userspace booted and the agent is listening. Bounded so a guest
         // that never comes up fails closed rather than hanging forever.
+        // Backoff, not a tick. This was a flat 200 ms sleep, which put a 200 ms
+        // floor under every Firecracker launch: the driver confirms boot before
+        // returning, so this wait sits inside the span the cold-launch budget
+        // is measured against, and a guest that answered in 20 ms was reported
+        // as taking a full tick to do it.
         let deadline = Instant::now() + AGENT_READY_TIMEOUT;
+        let mut attempt = 0u32;
         loop {
             // Fail fast if Firecracker itself died on boot (kernel panic,
             // rejected config) rather than waiting out the full agent deadline.
@@ -858,8 +898,15 @@ impl VmmDriver for FcDriver {
                     abs_dir
                 );
             }
-            std::thread::sleep(Duration::from_millis(200));
+            std::thread::sleep(mvm_core::poll_backoff::poll_delay(attempt));
+            attempt = attempt.saturating_add(1);
         }
+
+        tracing::debug!(
+            vm = %spec.name,
+            ms = started_at.elapsed().as_secs_f64() * 1000.0,
+            "fc boot: guest boot to serving agent"
+        );
 
         let vm = Box::new(FcRunningVm {
             id: VmId(spec.name.clone()),

--- a/crates/mvm-backends/src/fc/daemon.rs
+++ b/crates/mvm-backends/src/fc/daemon.rs
@@ -52,33 +52,64 @@ fn start_vm_firecracker_inner(abs_dir: &str, abs_socket: &str, clean_vsock: bool
         sudo bash -c 'nohup setsid firecracker --api-sock {socket} --enable-pci \
             </dev/null >{dir}/console.log 2>{dir}/firecracker.log &
             echo $! > {dir}/fc.pid'
-
-        echo "[mvm] Waiting for API socket..."
-        for i in $(seq 1 30); do
-            [ -S {socket} ] && break
-            sleep 0.1
-        done
-
-        if [ ! -S {socket} ]; then
-            echo "[mvm] ERROR: API socket did not appear." >&2
-            exit 1
-        fi
-        echo "[mvm] Firecracker started."
         "#,
         socket = abs_socket,
         dir = abs_dir,
         vsock_cleanup = vsock_cleanup,
-    ))
+    ))?;
+
+    // The socket wait used to live in the heredoc above as
+    // `for i in $(seq 1 30); do [ -S sock ] && break; sleep 0.1; done`, which
+    // put a 100 ms floor under every launch — the socket normally appears in
+    // single-digit milliseconds and was rounded up to the tick. Waiting here
+    // lets it use the shared backoff, and keeps the shell to the one thing it
+    // is needed for: becoming root to exec Firecracker.
+    wait_for_api_socket(std::path::Path::new(abs_socket), API_SOCKET_TIMEOUT)?;
+    ui::info("Firecracker started.");
+    Ok(())
 }
 
-/// Send API PUT request to a specific Firecracker socket.
+/// How long to wait for Firecracker to create its API socket. The shell loop
+/// this replaced allowed 30 x 100 ms, so keeping 3 s means a host slow enough
+/// to need the old ceiling still boots.
+const API_SOCKET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Wait for Firecracker to create its API socket, backing off rather than
+/// ticking.
 ///
-/// `data` is written to a temp file and passed via `curl --data @<file>`
-/// so the body never traverses the shell — guards against the
-/// `--data '{json}'` shape where a single-quote in `data` would
-/// escape into the host shell (`specs/01-project.md` flagged the v1
-/// shape's quoting fragility). `socket` and `path` are
-/// `shell_quote`d defensively.
+/// Takes the path and the timeout so the expiry branch is testable without
+/// spawning a VMM. A wait that never fires is the failure mode worth pinning,
+/// and it is unreachable through the launch path.
+fn wait_for_api_socket(socket: &std::path::Path, timeout: std::time::Duration) -> Result<()> {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut attempt = 0u32;
+    loop {
+        if is_unix_socket(socket) {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "Firecracker API socket {} did not appear within {timeout:?}",
+                socket.display()
+            );
+        }
+        std::thread::sleep(mvm_core::poll_backoff::poll_delay(attempt));
+        attempt = attempt.saturating_add(1);
+    }
+}
+
+/// Whether `path` is a unix socket — what `[ -S ]` tested. A regular file left
+/// at the path is not the API socket appearing.
+fn is_unix_socket(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::FileTypeExt as _;
+    std::fs::metadata(path).is_ok_and(|m| m.file_type().is_socket())
+}
+
+/// Send an API PUT to a specific Firecracker socket.
+///
+/// The body no longer traverses a shell at all: it is framed by
+/// `Content-Length` on a socket this process owns, so the quoting fragility
+/// the old `curl --data` shape had to defend against does not arise.
 #[instrument(skip_all, fields(path))]
 pub fn api_put_socket(socket: &str, path: &str, data: &str) -> Result<()> {
     fc_api_call("PUT", socket, path, Some(data))
@@ -96,53 +127,46 @@ pub fn secure_vsock_socket_for_caller(vsock: &str) -> Result<()> {
     ))
 }
 
-/// Shared body for FC's PUT/PATCH calls. Writes `data` (if Some) to a
-/// `NamedTempFile`, then shells out to curl with `--data @<file>` so
-/// the JSON body never goes through bash. All paths flowing into the
-/// script are `shell_quote`d.
+/// Shared body for FC's PUT/PATCH calls.
+///
+/// Delegates to [`crate::fc::fc_api::call`], the native HTTP-over-UDS client
+/// this crate already carries for the warm-restore path. That client exists
+/// precisely because each call used to be a `curl` subprocess, and it already
+/// encodes the one thing that is easy to get wrong here: Firecracker answers
+/// `Connection: keep-alive` and holds the socket open regardless of what the
+/// request asked for, so the body must be framed by `Content-Length` and never
+/// by EOF. The boot path was the last caller still shelling out.
+///
+/// Reaching the socket without `sudo` is what [`adopt_api_socket`] arranges.
 fn fc_api_call(method: &str, socket: &str, path: &str, data: Option<&str>) -> Result<()> {
-    use std::io::Write;
-    let q_socket = shell_quote(socket);
-    let url = format!("http://localhost{path}");
-    let q_url = shell_quote(&url);
-    let q_path = shell_quote(path);
+    // The request target is built by this crate, never by a caller, but it is
+    // interpolated into a request line: reject anything that could terminate
+    // it. A drive id that ever became externally influenced must not be able
+    // to smuggle a second request.
+    if !path.starts_with('/') || path.contains(['\r', '\n']) {
+        anyhow::bail!("refusing malformed Firecracker API path {path:?}");
+    }
+    crate::fc::fc_api::call(std::path::Path::new(socket), method, path, data).map(|_body| ())
+}
 
-    let (data_arg, _body_holder) = match data {
-        Some(body) => {
-            let mut tmp = tempfile::NamedTempFile::new()
-                .with_context(|| "creating temp file for FC API body")?;
-            tmp.write_all(body.as_bytes())
-                .with_context(|| "writing FC API body to temp file")?;
-            tmp.flush()
-                .with_context(|| "flushing FC API body to temp file")?;
-            let path_str = tmp.path().to_string_lossy().into_owned();
-            let q_body_path = shell_quote(&path_str);
-            (
-                format!(
-                    "--data @{q_body_path} -H 'Content-Type: application/json'",
-                    q_body_path = &q_body_path[..]
-                ),
-                Some(tmp),
-            )
-        }
-        None => (String::new(), None),
-    };
-
-    let script = format!(
-        r#"
-        set -eu
-        response=$(sudo curl -s -w "\n%{{http_code}}" -X {method} --unix-socket {q_socket} \
-            {data_arg} {q_url})
-        code=$(printf '%s' "$response" | tail -n1)
-        body=$(printf '%s' "$response" | sed '$d')
-        if [ "$code" -ge 400 ]; then
-            echo "[mvm] ERROR: {method} $(printf '%s' {q_path}) returned $code: $body" >&2
-            exit 1
-        fi
-        "#,
-    );
-    run_in_vm_visible(&script)
-    // _body_holder drops at function exit, deleting the temp file.
+/// Hand the Firecracker-created API socket to the invoking user.
+///
+/// Firecracker is launched through `sudo`, so it creates its API socket as
+/// root and nothing but root can dial it — which is why every API call used to
+/// be a `sudo curl`. Transferring ownership once, at mode 0600, lets the rest
+/// of the boot speak to the socket in-process.
+///
+/// This is the same trade [`secure_vsock_socket_for_caller`] already makes for
+/// the vsock multiplexer, and the principal is unchanged: the user running
+/// mvmctl already drives this VM, via `sudo`, on every call. What changes is
+/// that they no longer need `sudo` to do it, so a process running as that user
+/// can reach the API socket directly. Mode 0600 keeps it off-limits to every
+/// other user on the host.
+pub fn adopt_api_socket(socket: &str) -> Result<()> {
+    let quoted = shell_quote(socket);
+    run_in_vm_visible(&format!(
+        "set -eu\nsudo chown -- \"$(id -u):$(id -g)\" {quoted}\nchmod 0600 {quoted}"
+    ))
 }
 
 /// Read the pid recorded by [`start_vm_firecracker`].
@@ -158,6 +182,61 @@ pub fn read_firecracker_pid(abs_dir: &str) -> Result<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A boot that reaches the deadline with no socket must fail with a
+    /// message naming the path, not hang. The shell loop this replaced had the
+    /// same ceiling; the wait is unreachable from a unit test through the
+    /// launch path, which is why the timeout is a parameter.
+    #[test]
+    fn waiting_for_an_api_socket_that_never_appears_fails_with_the_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("fc.socket");
+        let err = wait_for_api_socket(&missing, std::time::Duration::from_millis(30))
+            .expect_err("a socket that never appears must not succeed");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("fc.socket"),
+            "unexpected error: {rendered}"
+        );
+    }
+
+    /// `[ -S ]`, which is what the shell tested: a regular file sitting at the
+    /// socket path is not Firecracker having come up.
+    #[test]
+    fn a_regular_file_at_the_socket_path_is_not_the_socket() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let decoy = dir.path().join("fc.socket");
+        std::fs::write(&decoy, b"not a socket").expect("write decoy");
+        assert!(!is_unix_socket(&decoy));
+
+        let listener_path = dir.path().join("real.socket");
+        let _listener =
+            std::os::unix::net::UnixListener::bind(&listener_path).expect("bind unix socket");
+        assert!(is_unix_socket(&listener_path));
+        // And the wait returns immediately for one that is already there.
+        wait_for_api_socket(&listener_path, std::time::Duration::from_millis(5))
+            .expect("an existing socket is observed on the first probe");
+    }
+
+    /// The request target is interpolated into a request line. Nothing builds
+    /// one from user input today, but a path carrying CRLF would append a
+    /// second request to the same connection, so it is refused before connect
+    /// rather than trusted because of where it came from.
+    #[test]
+    fn an_api_path_that_could_split_the_request_is_refused() {
+        for bad in [
+            "/drives/a\r\nPUT /actions HTTP/1.1",
+            "/drives/a\nPUT /actions HTTP/1.1",
+            "drives/no-leading-slash",
+        ] {
+            let err = fc_api_call("PUT", "/nonexistent.socket", bad, Some("{}"))
+                .expect_err("malformed path must be refused");
+            assert!(
+                err.to_string().contains("malformed"),
+                "expected a refusal for {bad:?}, got: {err}"
+            );
+        }
+    }
 
     #[test]
     fn vsock_socket_access_is_private_to_the_invoking_user() {


### PR DESCRIPTION
Addresses the host-side half of #2292. Measured on the KVM host, release build, prepared cache, `alpine`:

| | before | after |
|---|---:|---:|
| `driver_boot` | 630.5 ms | **491 ms** |
| dispatch window | 669 ms | **549 ms** |

## Three fixes, all host-side

**A shell socket poll.** The daemon launch heredoc ended with `for i in $(seq 1 30); do [ -S sock ] && break; sleep 0.1; done` — the same quantization Plan 299 Phase 5 removed from four Rust sites, missed because it lives in a shell string rather than in code. The wait moves into Rust on the shared `poll_backoff`; the shell keeps the one job it is there for, becoming root to exec Firecracker.

**A 200 ms agent-ready tick.** `sleep(Duration::from_millis(200))` in the boot-confirmation loop. On this backend the driver confirms boot before returning, so that tick sits *inside* the span the cold-launch budget is measured against — a guest answering in 20 ms was charged a full tick.

**A `curl` subprocess per API call.** Each `/logger`, `/boot-source`, `/machine-config`, `/vsock`, `/drives/{id}` and `/actions` was its own `sudo curl` — ~13 ms a call on this host, about nine calls a boot.

## On that last one: I initially wrote a duplicate

I hand-rolled an HTTP-over-UDS client, hit a hang on the first live run, and diagnosed it as Firecracker holding the connection open despite `Connection: close`. Then the test names revealed `fc::fc_api` — a native client this crate already carries for the warm-restore path, whose module doc opens by documenting that exact keep-alive behaviour against a live Firecracker.

The duplicate is gone; `fc_api_call` now delegates. The boot path was the last caller still shelling out.

Reaching the socket without `sudo` is what `adopt_api_socket` arranges — one chown at mode 0600, mirroring what `secure_vsock_socket_for_caller` already does for the vsock multiplexer. **Worth review attention:** the API socket controls the VM. The principal does not change (the user running mvmctl already drove this VM through `sudo` on every call, and 0600 keeps it off-limits to everyone else), but they no longer need `sudo` to reach it. Same trade the vsock precedent already made, on a more powerful socket.

## Attribution of what remains

`driver_boot` is one opaque number to the launch sample, and on this backend it spans VMM start *and* guest boot. Four debug spans now split it:

```
process spawn + API socket    17.4 ms
API config sequence           20.5 ms
InstanceStart                 11.5 ms
guest boot to serving agent    447 ms
```

Host-side work is now **49 ms**. The rest is the guest booting — 447 ms here against 58.6 ms on HVF for the same image.

## Two hypotheses tested and falsified

Both were tried against the live host and neither is in this PR:

- **virtio-rng entropy device.** The in-house VMM ships `virtio_rng` and the HVF path was fixed with an FDT rng-seed, so a `getrandom` stall looked likely. Adding Firecracker's `/entropy` device: 448 ms → 448 ms. No effect.
- **i8042 detection probes.** The console log shows a 370 ms gap ending at `input: AT Raw Set 2 keyboard`, and skipping the probes is standard Firecracker guidance. Measured ~8 ms, inside noise — the keyboard message lands after the agent is already serving, so the gap was never on the critical path.

The guest-boot gap is left filed rather than guessed at.

## Scope

Firecracker still misses the ≤200 ms contract. This removes the part of the gap that is not the VMM; #2293 (294 ms of audit fsync in `admit`) is the other half, and guest boot is now the largest single remaining span.

## Verification

10656 tests, doctests, nightly fmt, workspace clippy `-D warnings`, ten xtask gates including `check-honesty`, `check-no-overclaim`, and both vsock-egress gates. New unit tests cover the socket wait's timeout branch, `[ -S ]` semantics against a decoy regular file, and request-splitting refusal on a malformed API path.