### PR TITLE
perf(bench): capture guest-agent RSS in density reports

### DIFF
--- a/crates/mvm-cli/src/bench/probe.rs
+++ b/crates/mvm-cli/src/bench/probe.rs
@@ -147,7 +147,7 @@ impl Drop for HeldProbeVm {
 /// which the supervisor never writes to, so the `start_to_pid` mark never resolved and the
 /// probe timed out on every dev-host run.
 #[cfg(feature = "libkrun-live")]
-fn probe_state_dir(vm_name: &str) -> std::path::PathBuf {
+pub(super) fn probe_state_dir(vm_name: &str) -> std::path::PathBuf {
     mvm_core::config::vm_state_dir(vm_name)
 }
 

--- a/crates/mvm-cli/src/bench/probes.rs
+++ b/crates/mvm-cli/src/bench/probes.rs
@@ -84,10 +84,15 @@ pub fn run_density(count: u32, max_count: u32) -> Result<DensityReport> {
             .with_context(|| format!("booting density sample {index}"))?;
         let bytes = read_process_footprint_bytes(vm.pid())
             .with_context(|| format!("sampling footprint for density sample {index}"))?;
+        let instance_dir = super::probe::probe_state_dir(&vm_name);
+        let guest_agent_rss_bytes =
+            mvm_agentd::vsock::query_resource_usage(&instance_dir.to_string_lossy())
+                .with_context(|| format!("sampling guest-agent RSS for density sample {index}"))?;
         samples.push(InstanceFootprint {
             vm_name,
             pid: vm.pid(),
             bytes,
+            guest_agent_rss_bytes: Some(guest_agent_rss_bytes),
         });
         held.push(vm);
     }

--- a/crates/mvm-cli/src/bench/regression.rs
+++ b/crates/mvm-cli/src/bench/regression.rs
@@ -269,11 +269,13 @@ mod tests {
                     vm_name: "a".to_string(),
                     pid: 1,
                     bytes: 100,
+                    guest_agent_rss_bytes: None,
                 },
                 InstanceFootprint {
                     vm_name: "b".to_string(),
                     pid: 2,
                     bytes: 100,
+                    guest_agent_rss_bytes: None,
                 },
             ],
         );
@@ -286,11 +288,13 @@ mod tests {
                     vm_name: "a".to_string(),
                     pid: 1,
                     bytes: 130,
+                    guest_agent_rss_bytes: None,
                 },
                 InstanceFootprint {
                     vm_name: "b".to_string(),
                     pid: 2,
                     bytes: 130,
+                    guest_agent_rss_bytes: None,
                 },
             ],
         );

--- a/crates/mvm-cli/src/bench/report.rs
+++ b/crates/mvm-cli/src/bench/report.rs
@@ -48,6 +48,20 @@ pub struct InstanceFootprint {
     pub vm_name: String,
     pub pid: u32,
     pub bytes: u64,
+    /// Guest-agent process RSS queried after the guest reached readiness.
+    /// This is a guest-process witness, not the whole VM working set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guest_agent_rss_bytes: Option<u64>,
+}
+
+/// Aggregate guest-agent RSS across the samples that reported it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GuestRssStats {
+    pub instances: u32,
+    pub total_bytes: u64,
+    pub per_instance_bytes: u64,
+    pub min_instance_bytes: u64,
+    pub max_instance_bytes: u64,
 }
 
 /// Aggregate density result for a held-live instance set.
@@ -58,6 +72,9 @@ pub struct DensityStats {
     pub per_instance_bytes: u64,
     pub min_instance_bytes: u64,
     pub max_instance_bytes: u64,
+    /// None when the live backend did not return guest-agent RSS.
+    #[serde(default)]
+    pub guest_agent_rss: Option<GuestRssStats>,
 }
 
 /// Read-only density report. Live orchestration boots `count`
@@ -125,12 +142,30 @@ pub(super) fn build_report(
     target_os = "macos"
 ))]
 pub fn summarize_density(samples: &[InstanceFootprint]) -> DensityStats {
-    let instances = samples.len() as u32;
+    let instances = u32::try_from(samples.len()).expect("density sample count fits in u32");
     let total_bytes = samples.iter().map(|sample| sample.bytes).sum::<u64>();
     let per_instance_bytes = if instances == 0 {
         0
     } else {
         total_bytes / u64::from(instances)
+    };
+    let guest_rss = samples
+        .iter()
+        .filter_map(|sample| sample.guest_agent_rss_bytes)
+        .collect::<Vec<_>>();
+    let guest_agent_rss = if guest_rss.is_empty() {
+        None
+    } else {
+        let guest_instances =
+            u32::try_from(guest_rss.len()).expect("guest RSS sample count fits in u32");
+        let guest_total = guest_rss.iter().sum::<u64>();
+        Some(GuestRssStats {
+            instances: guest_instances,
+            total_bytes: guest_total,
+            per_instance_bytes: guest_total / u64::from(guest_instances),
+            min_instance_bytes: guest_rss.iter().copied().min().unwrap_or(0),
+            max_instance_bytes: guest_rss.iter().copied().max().unwrap_or(0),
+        })
     };
     DensityStats {
         instances,
@@ -138,6 +173,7 @@ pub fn summarize_density(samples: &[InstanceFootprint]) -> DensityStats {
         per_instance_bytes,
         min_instance_bytes: samples.iter().map(|sample| sample.bytes).min().unwrap_or(0),
         max_instance_bytes: samples.iter().map(|sample| sample.bytes).max().unwrap_or(0),
+        guest_agent_rss,
     }
 }
 
@@ -271,16 +307,19 @@ mod tests {
                 vm_name: "bench-a".to_string(),
                 pid: 101,
                 bytes: 10 * 1024 * 1024,
+                guest_agent_rss_bytes: None,
             },
             InstanceFootprint {
                 vm_name: "bench-b".to_string(),
                 pid: 102,
                 bytes: 14 * 1024 * 1024,
+                guest_agent_rss_bytes: None,
             },
             InstanceFootprint {
                 vm_name: "bench-c".to_string(),
                 pid: 103,
                 bytes: 12 * 1024 * 1024,
+                guest_agent_rss_bytes: None,
             },
         ];
 
@@ -291,6 +330,42 @@ mod tests {
         assert_eq!(stats.per_instance_bytes, 12 * 1024 * 1024);
         assert_eq!(stats.min_instance_bytes, 10 * 1024 * 1024);
         assert_eq!(stats.max_instance_bytes, 14 * 1024 * 1024);
+        assert_eq!(stats.guest_agent_rss, None);
+    }
+
+    #[test]
+    fn density_summary_aggregates_available_guest_agent_rss() {
+        let samples = vec![
+            InstanceFootprint {
+                vm_name: "bench-a".to_string(),
+                pid: 101,
+                bytes: 100,
+                guest_agent_rss_bytes: Some(2_000),
+            },
+            InstanceFootprint {
+                vm_name: "bench-b".to_string(),
+                pid: 102,
+                bytes: 100,
+                guest_agent_rss_bytes: None,
+            },
+            InstanceFootprint {
+                vm_name: "bench-c".to_string(),
+                pid: 103,
+                bytes: 100,
+                guest_agent_rss_bytes: Some(4_000),
+            },
+        ];
+
+        assert_eq!(
+            summarize_density(&samples).guest_agent_rss,
+            Some(GuestRssStats {
+                instances: 2,
+                total_bytes: 6_000,
+                per_instance_bytes: 3_000,
+                min_instance_bytes: 2_000,
+                max_instance_bytes: 4_000,
+            })
+        );
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -22,8 +22,9 @@ for detailed scope and acceptance criteria.
       filesystem comparisons cannot mix security tiers. The libkrun probe also
       exposes bounded resident host-process capture, and the HVF guest-RAM seam
       exposes resident bytes with a demand-fault witness and records private
-      restore-mapping duration; end-to-end guest working-set, first-use
-      restore-fault, and cross-backend evidence remain open.
+      restore-mapping duration. The libkrun density report also carries the
+      readiness-bound guest-agent RSS witness; whole-VM guest working-set,
+      first-use restore-fault, and cross-backend evidence remain open.
 
 ## In-flight plans
 - [x] Plan 2167 — durable agent session and event contract

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1515,8 +1515,10 @@ Then unify + retire the old paths:
   libkrun live probe now has bounded resident host-process capture after
   authenticated readiness, and the HVF guest-RAM seam now reports resident
   bytes with a direct untouched-versus-touched demand-fault witness plus
-  monotonic private restore-mapping duration. End-to-end guest working-set,
-  first-use restore-fault, and cross-backend live measurements remain open.
+  monotonic private restore-mapping duration. The libkrun density report now
+  also carries guest-agent RSS from the existing ResourceUsage RPC. Whole-VM
+  guest working-set, first-use restore-fault, and cross-backend live
+  measurements remain open.
 - [x] **Filesystem-path baseline — issue #2281.**
   `mvm_fs::rootfs::measure_ext4_pure` now records a stable JSON baseline for
   source identity, node composition, emitted ext4 size/digest, materializer

--- a/specs/notes/2026-08-10-fast-machine-substrate.md
+++ b/specs/notes/2026-08-10-fast-machine-substrate.md
@@ -140,7 +140,8 @@ between warmup or measured samples.
 - [~] [#2280](https://github.com/tinylabscom/mvm/issues/2280) — measure the
   kernel and boot-substrate budget. The bounded libkrun resident host-process
   capture is landed, and HVF guest-RAM now exposes an allocation-level
-  demand-fault witness plus private restore-mapping duration; end-to-end guest
+  demand-fault witness plus private restore-mapping duration. The live libkrun
+  density report also records guest-agent RSS after readiness; whole-VM guest
   working-set, first-use restore-fault, and cross-backend live evidence remain.
 - [~] [#2281](https://github.com/tinylabscom/mvm/issues/2281) — baseline the
   current pure-Rust ext4 path and evaluate the guest-local immutable

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -641,6 +641,12 @@ optimization backend-local and the benchmark backend-neutral.
       the platform footprint reader, and drops every held guest on success or
       failure. This reports host process residency; guest demand-fault and
       restore-fault evidence remain separate gates.
+- [x] Add the guest-agent RSS witness to the same live libkrun density report.
+      After the readiness boundary, each held guest is queried through the
+      existing `ResourceUsage` RPC and the result is carried beside host
+      supervisor/VMM RSS, with aggregate statistics for samples that answered.
+      This measures the guest-agent process, not the whole guest working set;
+      whole-VM and first-use restore-fault evidence remain open.
 - [x] Add an allocation-level demand-fault witness to the HVF guest-RAM seam.
       `GuestRam` exposes a `mincore` resident-byte query, the raw kernel boot
       result records it after vCPU and host-I/O shutdown, and a focused test


### PR DESCRIPTION
## Summary

- add readiness-bound guest-agent RSS to live libkrun density samples
- aggregate available guest RSS without confusing it with whole-VM working set
- document the new evidence boundary and remaining #2280 work

This branch is stacked on #2296 and will become a focused follow-up once that substrate measurement PR merges.

## Validation

- cargo test --locked -p mvm-cli --lib (1616 passed, 2 ignored)
- cargo clippy --locked -p mvm-cli --features libkrun-live --lib -- -D warnings
- pre-commit workspace cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check

## Remaining scope

#2280 remains open for whole-VM working-set capture, first-use restore-fault evidence, and cross-backend comparability.