### PR TITLE
fix: refresh synchronized kernel pins

### DIFF
--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -48,10 +48,10 @@ let
   # kernel — lets both of mvm's kernels track the latest point release exactly
   # and keeps the two pins from drifting apart. Bump `kernelVersion` + `hash`
   # together (the tarball's own sha256, e.g. via `nix store prefetch-file`).
-  kernelVersion = "6.12.102";
+  kernelVersion = "6.12.103";
   kernelSrc = pkgs.fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${kernelVersion}.tar.xz";
-    hash = "sha256-aUu19JNxMjq5wrcEC9NY7YG/++gLNy12UHBFgo9lWAM=";
+    hash = "sha256-8UOqreiHe6VhbniLRIJXbbKEgbz1V+9Tf0/MOTj8MXY=";
   };
   # The builder's overlay filesystem triggers a GNU tar directory-metadata
   # race while unpacking this archive. Materialize the source with bsdtar once

--- a/nix/packages/libkrunfw.nix
+++ b/nix/packages/libkrunfw.nix
@@ -20,8 +20,8 @@ assert lib.elem variant [
 
 let
   kernelSrc = fetchurl {
-    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.102.tar.xz";
-    hash = "sha256-aUu19JNxMjq5wrcEC9NY7YG/++gLNy12UHBFgo9lWAM=";
+    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.103.tar.xz";
+    hash = "sha256-8UOqreiHe6VhbniLRIJXbbKEgbz1V+9Tf0/MOTj8MXY=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.102' \
+      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.103' \
       --replace-fail 'curl $(KERNEL_REMOTE) -o $(KERNEL_TARBALL)' 'ln -s ${kernelSrc} $(KERNEL_TARBALL)'
     substituteInPlace patches/0008-virtio-vsock-support-dgrams.patch \
       --replace-fail 'virtio_transport_alloc_skb(&info, dgram_len, false,' \

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-09
+Last updated: 2026-08-10
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -9,6 +9,10 @@ for detailed scope and acceptance criteria.
 - [x] **Issue #2128 — kernel pin freshness.** The libkrunfw bundle and custom
       guest kernel now share the verified Linux 6.12.102 LTS source pin;
       structural parity coverage prevents the consumers from drifting apart.
+- [~] **Issue #2289 — kernel pin freshness follow-up.** This PR synchronizes
+      the libkrunfw and custom guest kernel inputs on the verified Linux
+      6.12.103 LTS source pin and updates structural parity coverage with the
+      upstream tarball's verified SRI hash. Merge and rollout evidence remain.
 
 ## In-flight plans
 - [x] Plan 2167 — durable agent session and event contract

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -123,11 +123,12 @@
       and a real UDS round trip. The PR carries the remaining host-specific
       BDD execution note.
 
-- [x] Kernel pin freshness — **issue #2128**. Synchronized the libkrunfw
-      bundle and custom guest kernel on the verified Linux 6.12.102 LTS
-      tarball, replacing the stale 6.12.100 pin. Structural parity tests keep
+- [~] Kernel pin freshness — **issue #2289**. This PR synchronizes the libkrunfw
+      bundle and custom guest kernel on the verified Linux 6.12.103 LTS
+      tarball, replacing the stale 6.12.102 pin. Structural parity tests keep
       both consumers on one version/hash, and the existing freshness check
-      refuses a point release that trails kernel.org.
+      refuses a point release that trails kernel.org. The prior #2128 closeout
+      remains the history for the preceding 6.12.102 bump.
 
 - [x] Runtime SDK parity — **issue #2163**. Added the live process-handle and
       filesystem surface to Python and TypeScript, with a Rust-owned

--- a/specs/plans/300-open-issue-closeout.md
+++ b/specs/plans/300-open-issue-closeout.md
@@ -1,11 +1,11 @@
 # Plan 300 — Open issue closeout
 
 **Status:** TRIAGE COMPLETE — execution pending
-**Snapshot date:** 2026-08-08
+**Snapshot date:** 2026-08-10
 
 ## Objective
 
-Reduce the 22 open issues in `tinylabscom/mvm` to a set backed by current
+Reduce the current open issues in `tinylabscom/mvm` to a set backed by current
 product intent and evidence. Every issue closes only after its implementation,
 tests, live witnesses where required, documentation, and GitHub state agree.
 
@@ -108,15 +108,19 @@ Close path:
 - Let `.github/workflows/security-lane-watch.yml` close the issue after a clean
   scheduled or release run.
 
-#### #2128 — kernel pin freshness
+#### #2289 — kernel pin freshness
 
-Both synchronized kernel inputs remain on 6.12.100 while the latest advisory
-has advanced beyond that version.
+The generated freshness tracker reported both synchronized kernel inputs one
+point release behind the latest Linux 6.12 LTS release. The prior #2128
+closeout covered the preceding 6.12.102 update; #2289 is the current tracker
+for the next point-release remediation.
 
 Close path:
 
 - Update the custom workload kernel and libkrunfw inputs together, including
-  source hashes and any generated or recorded metadata.
+  source hashes and any generated or recorded metadata. This change updates
+  both consumers to Linux 6.12.103 with the verified SRI hash
+  `sha256-8UOqreiHe6VhbniLRIJXbbKEgbz1V+9Tf0/MOTj8MXY=`.
 - Build and verify both kernel artifacts and run the kernel-pin freshness
   check.
 - Run the relevant workspace, kernel, verified-boot, and reproducibility tests.
@@ -342,9 +346,10 @@ Studio server contract and an end-to-end local launch are both available.
 
 ## Execution sequence
 
-1. Close #2192 and split/narrow #2101 and #2211.
-2. Repair the generated security tracker (#2135) and kernel freshness issue
-   (#2128), because they affect the evidence quality of every later closeout.
+1. With #2192 closed, split/narrow #2101 and #2211.
+2. Repair the generated security tracker (#2135) and current kernel freshness
+   issue (#2289), because they affect the evidence quality of every later
+   closeout.
 3. Fix the rootfs boot contract (#2165), L3 wiring (#2180), and live IPv6
    witness (#2181).
 4. Finish the warm-launch dependency graph from #2193 through #2199.

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -240,8 +240,8 @@ fn native_vmm_recipes_are_source_built_and_pinned() {
         );
     }
 
-    const KERNEL_VERSION: &str = "6.12.102";
-    const KERNEL_HASH: &str = "sha256-aUu19JNxMjq5wrcEC9NY7YG/++gLNy12UHBFgo9lWAM=";
+    const KERNEL_VERSION: &str = "6.12.103";
+    const KERNEL_HASH: &str = "sha256-8UOqreiHe6VhbniLRIJXbbKEgbz1V+9Tf0/MOTj8MXY=";
     assert!(
         libkrunfw.contains(&format!("linux-{KERNEL_VERSION}.tar.xz"))
             && libkrunfw.contains(&format!("hash = \"{KERNEL_HASH}\""))


### PR DESCRIPTION
## Summary\n\n- bump the libkrunfw and custom workload kernel inputs together to Linux 6.12.103\n- pin both consumers to the verified upstream SRI hash\n- update the structural parity witness and closeout status for issue #2289\n\n## Validation\n\n- cargo test -p mvm-core kernel_advisory\n- cargo test -p xtask check_kernel_pin_freshness\n- cargo test --test nix_flake_structure native_vmm_recipes_are_source_built_and_pinned\n- cargo clippy -p mvm-core -p xtask --all-targets -- -D warnings\n- cargo fmt --all -- --check\n\nThe builder-VM kernel artifact build and freshness workflow will run in CI.