### PR TITLE
fix(ci): re-point the process-handshake test group at the package that has the tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -44,7 +44,7 @@ final-status-level = "flaky"
 # liveness short-circuit so a dead daemon fails immediately with a reason
 # instead of waiting one out. They stay in the group as belt-and-braces.
 #
-# It does NOT apply to the `mvm-runtime` members, and that is the point of
+# It does NOT apply to the `mvm-vmm` members, and that is the point of
 # keeping the group: their budget is `SUBST_HANDSHAKE_TIMEOUT`, a production
 # constant. The wait those tests race is the one the product itself enforces,
 # so raising it to suit the test suite would change shipped behaviour. For
@@ -54,10 +54,19 @@ final-status-level = "flaky"
 # and does not have one is a bug in the test, and a group here would hide
 # it — see the fixture fix in tests/audit_emissions_live.rs, which was a
 # real defect that looked like contention.
+#
+# The `package(...)` in each filter below is load-bearing and easy to strand.
+# These filters named `mvm-runtime` until the substitution/broker spawn
+# modules moved to `mvm-vmm`, after which they matched nothing at all and the
+# cap silently stopped applying — a filter that matches no test fails open and
+# says nothing. When moving a module between packages, re-point any filter
+# naming it, and confirm with:
+#
+#   cargo nextest list -p <pkg> -E '<the filter>'
 process-handshake = { max-threads = 4 }
 
 [[profile.default.overrides]]
-filter = 'package(mvm-runtime) and (test(/substitution_spawn::/) or test(/broker_services_spawn::/))'
+filter = 'package(mvm-vmm) and (test(/substitution_spawn::/) or test(/broker_services_spawn::/))'
 test-group = "process-handshake"
 
 [[profile.default.overrides]]
@@ -65,7 +74,7 @@ filter = 'package(mvm-hostd) and (binary(host_agent_restart) or binary(per_tenan
 test-group = "process-handshake"
 
 [[profile.ci.overrides]]
-filter = 'package(mvm-runtime) and (test(/substitution_spawn::/) or test(/broker_services_spawn::/))'
+filter = 'package(mvm-vmm) and (test(/substitution_spawn::/) or test(/broker_services_spawn::/))'
 test-group = "process-handshake"
 
 [[profile.ci.overrides]]

--- a/specs/plans/307-merge-queue-latency.md
+++ b/specs/plans/307-merge-queue-latency.md
@@ -31,9 +31,11 @@ branches, not the queue's own position/state display, which shows
 - [x] **WS0 — unjam.** Fixed the `check-no-vz` violation on #2232 directly and
       dequeued/re-pushed it. One line. Nothing else in the queue was wrong.
 
-- [ ] **WS1 — a required check that cannot report is a 90-minute tax.**
-      Already in flight as **#2252**, independently authored — not duplicated
-      here. `kernel-build.yml` had no `merge_group` trigger and was
+- [x] **WS1 — a required check that cannot report is a 90-minute tax.**
+      Landed as **#2252**, independently authored — not duplicated here.
+      `kernel-build.yml` now carries the `merge_group` trigger, so the required
+      contexts report instead of being absent. Previously it had no such
+      trigger and was
       `paths:`-filtered, so on any PR not touching kernel paths the required
       `Build kernels (aarch64|x86_64)` contexts were simply *absent*. An absent
       required check leaves the entry waiting out


### PR DESCRIPTION
The `process-handshake` group caps how many process-spawning tests race a clock at once. Its two `mvm-runtime` filters have matched **nothing** since the substitution and broker spawn modules moved to `mvm-vmm` in #2231 — so the cap silently stopped applying to the 21 tests it exists for.

## Why this survived

**A nextest filter that matches no test is not an error.** It fails open and reports nothing. The config still read as protection, and the group's own comment still explained why those members need a concurrency cap rather than a bigger timeout — while providing neither.

I found it by accident, auditing whether that comment was still accurate after the #2264 flaky-test work.

## The fix

Both filters (default and `ci` profiles) now name `package(mvm-vmm)`. Verified with `cargo nextest list`:

```
mvm-vmm host::substitution_spawn::tests::…      (15 tests)
mvm-vmm host::broker_services_spawn::tests::…   (6 tests)
```

`cargo nextest run` over the corrected filter: **21 passed**. Config parses under both `default` and `ci`.

The group's comment now records the trap: the `package(...)` is load-bearing, moving a module between packages strands any filter naming it, and the confirmation command is written down.

## Also

Ticks plan 307 **WS1**, which #2252 landed — `kernel-build.yml` now carries the `merge_group` trigger, so the required kernel contexts report instead of being absent and burning the 90-minute ejection timeout. That leaves **WS2** (the ruleset edit, which needs a maintainer) as the only open item in plan 307.

## Follow-up

#2307 tracks a gate for this class, since a filter that matches nothing fails open. The repo already gates the same shape elsewhere (`check-workflow-paths`, `check-claim-catalog`). Deliberately not bundled here — registering an xtask gate is four touch points plus a CI lane and deserves its own change.