### PR TITLE
Keep CLI help within 80 columns

### DIFF
--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -54,6 +54,8 @@ use dispatch::TopLevelCommand;
 
 use shared::{CHILD_PIDS, IN_CONSOLE_MODE, with_hints};
 
+const CLI_HELP_WIDTH: usize = 80;
+
 #[derive(Parser, Debug, Clone)]
 #[command(
     name = "mvmctl",
@@ -250,7 +252,11 @@ pub fn run() -> Result<()> {
             print!("{}", constrain_help_output(&error.to_string()));
             return Ok(());
         }
-        Err(error) => error.exit(),
+        Err(error) => {
+            let exit_code = error.exit_code();
+            eprint!("{}", constrain_help_output(&error.to_string()));
+            std::process::exit(exit_code);
+        }
     };
     apply_startup_env(&cli);
     register_inhouse_builder();
@@ -281,14 +287,16 @@ pub fn run() -> Result<()> {
 }
 
 fn constrain_help_width(command: clap::Command) -> clap::Command {
-    let mut command = command.term_width(80).max_term_width(80);
+    let mut command = command
+        .term_width(CLI_HELP_WIDTH)
+        .max_term_width(CLI_HELP_WIDTH);
     if let Some(usage) = command
         .clone()
         .render_help()
         .to_string()
         .lines()
         .find(|line| line.starts_with("Usage:"))
-        && usage.chars().count() > 80
+        && usage.chars().count() > CLI_HELP_WIDTH
     {
         command = command.override_usage(wrap_usage(usage));
     }
@@ -324,7 +332,7 @@ fn constrain_help_output(help: &str) -> String {
     let trailing_newline = help.ends_with('\n');
     let mut constrained = help
         .lines()
-        .map(|line| wrap_help_line(line, 80))
+        .map(|line| wrap_help_line(line, CLI_HELP_WIDTH))
         .collect::<Vec<_>>()
         .join("\n");
     if trailing_newline {
@@ -352,17 +360,35 @@ fn wrap_help_line(line: &str, width: usize) -> String {
     let mut current_limit = width.saturating_sub(indentation);
     let mut wrapped = Vec::new();
 
-    for word in line.split_whitespace() {
-        let word_width = word.chars().count();
-        if current.is_empty() {
-            current.push_str(word);
-        } else if current.chars().count() + 1 + word_width <= current_limit {
-            current.push(' ');
-            current.push_str(word);
-        } else {
-            wrapped.push(current);
-            current = word.to_owned();
-            current_limit = width.saturating_sub(continuation.chars().count());
+    for source_word in line.split_whitespace() {
+        let mut word = source_word.to_owned();
+        loop {
+            if current.is_empty() {
+                let available = current_limit.max(1);
+                let word_width = word.chars().count();
+                if word_width <= available {
+                    current = word;
+                    break;
+                }
+
+                let mut characters = word.chars();
+                current = characters.by_ref().take(available).collect();
+                wrapped.push(current);
+                current = String::new();
+                word = characters.collect();
+                current_limit = width.saturating_sub(continuation.chars().count());
+            } else {
+                let available = current_limit.saturating_sub(current.chars().count() + 1);
+                if word.chars().count() <= available {
+                    current.push(' ');
+                    current.push_str(&word);
+                    break;
+                }
+
+                wrapped.push(current);
+                current = String::new();
+                current_limit = width.saturating_sub(continuation.chars().count());
+            }
         }
     }
     if !current.is_empty() {

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -12,9 +12,73 @@ fn help_output_wraps_long_lines() {
         "  command  A long description that must wrap before it exceeds the fixed output width";
     let wrapped = constrain_help_output(help);
 
-    assert!(wrapped.lines().all(|line| line.chars().count() <= 80));
+    assert!(
+        wrapped
+            .lines()
+            .all(|line| line.chars().count() <= CLI_HELP_WIDTH)
+    );
     assert!(wrapped.lines().count() > 1);
     assert!(wrapped.contains("\n  "));
+}
+
+#[test]
+fn help_output_splits_unbreakable_tokens() {
+    let help = format!("  command  {}", "x".repeat(CLI_HELP_WIDTH * 2));
+    let wrapped = constrain_help_output(&help);
+
+    assert!(
+        wrapped
+            .lines()
+            .all(|line| line.chars().count() <= CLI_HELP_WIDTH)
+    );
+}
+
+#[test]
+fn every_command_help_surface_stays_within_80_columns() {
+    let mut violations = Vec::new();
+    collect_help_width_violations(cli_command(), &mut Vec::new(), &mut violations);
+
+    assert!(
+        violations.is_empty(),
+        "CLI help lines must be 80 characters or shorter:\n{}",
+        violations.join("\n")
+    );
+}
+
+fn collect_help_width_violations(
+    command: clap::Command,
+    path: &mut Vec<String>,
+    violations: &mut Vec<String>,
+) {
+    path.push(command.get_name().to_owned());
+
+    for (help_kind, help) in [
+        (
+            "help",
+            constrain_help_output(&command.clone().render_help().to_string()),
+        ),
+        (
+            "long-help",
+            constrain_help_output(&command.clone().render_long_help().to_string()),
+        ),
+    ] {
+        for (line_number, line) in help.lines().enumerate() {
+            let width = line.chars().count();
+            if width > CLI_HELP_WIDTH {
+                violations.push(format!(
+                    "{} --{help_kind} line {} is {width} columns: {line}",
+                    path.join(" "),
+                    line_number + 1
+                ));
+            }
+        }
+    }
+
+    for subcommand in command.get_subcommands().cloned().collect::<Vec<_>>() {
+        collect_help_width_violations(subcommand, path, violations);
+    }
+
+    path.pop();
 }
 
 // Group module aliases — give tests short names (`cleanup`, `up`, etc.) that

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -430,22 +430,27 @@ fn help_options_fit_within(world: &mut CliWorld, width: i64) {
     }
 }
 
-#[then(expr = "every mvmctl subcommand help fits within {int} columns")]
-fn every_subcommand_help_fits_within(_world: &mut CliWorld, width: i64) {
-    let mut command_paths = Vec::new();
-    collect_command_paths(&mvm_cli::commands::cli_command(), &[], &mut command_paths);
+#[then(expr = "every mvmctl command and subcommand help fits within {int} columns")]
+fn every_command_help_fits_within(_world: &mut CliWorld, width: i64) {
+    let command = mvm_cli::commands::cli_command();
+    let mut command_paths = vec![Vec::new()];
+    collect_command_paths(&command, &[], &mut command_paths);
 
     for path in command_paths {
+        let command_name = if path.is_empty() {
+            "mvmctl".to_string()
+        } else {
+            format!("mvmctl {}", path.join(" "))
+        };
         let mut args = path.clone();
         args.push("--help".to_string());
         let output = mvmctl_command()
             .args(&args)
             .output()
-            .unwrap_or_else(|e| panic!("failed to run `mvmctl {}`: {e}", args.join(" ")));
+            .unwrap_or_else(|e| panic!("failed to run `{command_name}`: {e}"));
         assert!(
             output.status.success(),
-            "`mvmctl {}` failed:\n{}",
-            args.join(" "),
+            "`{command_name}` failed:\n{}",
             String::from_utf8_lossy(&output.stderr)
         );
 
@@ -454,8 +459,7 @@ fn every_subcommand_help_fits_within(_world: &mut CliWorld, width: i64) {
             let line_width = i64::try_from(line.chars().count()).expect("line width fits in i64");
             assert!(
                 line_width <= width,
-                "`mvmctl {}` line {} exceeds {width} columns ({}):\n{}",
-                args.join(" "),
+                "`{command_name}` line {} exceeds {width} columns ({}):\n{}",
                 line_number + 1,
                 line_width,
                 help

--- a/features/suites/s0_cli/verbs.feature
+++ b/features/suites/s0_cli/verbs.feature
@@ -32,5 +32,5 @@ Feature: mvmctl top-level CLI surface
     But the help output does not contain "Mutually exclusive with"
     And the help output does not contain "production-safe call surface"
 
-  Scenario: every CLI subcommand help fits within 80 columns
-    Then every mvmctl subcommand help fits within 80 columns
+  Scenario: every CLI command and subcommand help fits within 80 columns
+    Then every mvmctl command and subcommand help fits within 80 columns


### PR DESCRIPTION
## Summary

- Bound all CLI help and Clap error output to 80 characters.
- Hard-wrap unbreakable help tokens.
- Add recursive unit coverage for every visible and hidden command.
- Strengthen the BDD scenario to cover `mvmctl --help` and every subcommand.

## Validation

- `cargo fmt --check`
- `cargo check --workspace`
- Full `mvm-cli` library tests passed before final branch packaging.

Workspace clippy was attempted but is currently blocked by an unrelated existing
`mvm-hostd` all-targets compile failure involving missing
`HostAuditV1Handler::capability_descriptors` and
`Registry::register_capability`.
