### PR TITLE
Record the transport a launch gives the guest, not None

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -404,6 +404,10 @@ impl MachineRunArgs {
 
     fn into_run_args(self) -> RunArgs {
         RunArgs {
+            // Placeholder; `run_dispatch` overwrites it with the mode
+            // `preflight_network` actually settled on for this launch, which is
+            // the value that reaches the signed plan.
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             manifest: self.manifest,
             // Default off; `run_dispatch` sets it for the warm-claim-eligible
             // transient mode.

--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -388,6 +388,9 @@ pub(super) fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig)
                 args.manifest = Some(slot);
             }
             let mut run_args = args.into_run_args();
+            // The mode settled above, not a re-derivation: one value reaches
+            // both the transport decision and the signed plan.
+            run_args.network_mode = network_mode;
             run_args.warm_pool_size = warm_pool_size;
             use std::io::IsTerminal as _;
             run_args.stdin = invoke::read_auto_stdin(std::io::stdin().is_terminal())?;
@@ -407,6 +410,9 @@ pub(super) fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig)
                 args.manifest = Some(slot);
             }
             let mut run_args = args.into_run_args();
+            // The mode settled above, not a re-derivation: one value reaches
+            // both the transport decision and the signed plan.
+            run_args.network_mode = network_mode;
             run_args.pty = true;
             run_args.warm_pool_size = warm_pool_size;
             run_args.stdin = invoke::read_auto_stdin(std::io::stdin().is_terminal())?;

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -944,6 +944,7 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
 
     let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::new();
     let admission = super::up::admit_plan_for_boot(super::up::AdmitPlanForBootParams {
+        network_mode: parent_network_mode(p.parent_checkpoint, p.store),
         tenant: &tenant,
         vm_name: p.child_vm_name,
         backend_name: &effective_hypervisor,
@@ -1138,6 +1139,32 @@ fn parent_agent_verb_override(
         .into_iter()
         .map(|v| v.as_str().to_string())
         .collect()
+}
+
+/// The transport a forked or restored child is admitted with.
+///
+/// Inherits the parent's, because a child that boots from a parent's memory
+/// and rootfs is continuing that workload rather than starting a new one: if
+/// the parent was admitted onto the raw-IP tunnel, its child is on it too.
+/// Falls back to what a fresh launch of the same shape would derive when the
+/// parent's plan cannot be read, which is the same shape `parent_plan_resources`
+/// already takes for cpus and memory.
+///
+/// Not `NetworkMode::None` on the fallback: that value means the guest has no
+/// broker at all, and claiming it for a child that is about to be given one is
+/// the defect this function exists to avoid rather than a safe default.
+fn parent_network_mode(
+    parent_checkpoint: &CheckpointId,
+    store: &CheckpointStore,
+) -> mvm_contract::plan::NetworkMode {
+    let fallback = crate::commands::machine::derive_network_mode(false);
+    let Ok(parent_meta) = store.read_meta(parent_checkpoint) else {
+        return fallback;
+    };
+    let Ok(plan) = super::plan_persist::read_plan(&parent_meta.vm_name) else {
+        return fallback;
+    };
+    plan.network_mode
 }
 
 fn parent_plan_resources(

--- a/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
@@ -337,6 +337,7 @@ fn admit_forked_child(p: &AdmitForkedChildParams<'_>) -> Result<AdmittedForkChil
     let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::new();
     let admission = crate::commands::vm::up::admit_plan_for_boot(
         crate::commands::vm::up::AdmitPlanForBootParams {
+            network_mode: super::parent_network_mode(p.checkpoint, p.store),
             tenant: &tenant,
             vm_name: p.child_vm_name,
             backend_name: p.backend_name,

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -107,6 +107,11 @@ pub(in crate::commands) enum RunProfile {
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct RunArgs {
+    /// The transport this launch derived, carried to admission so the signed
+    /// plan records the mode the workload actually gets. Not a flag: the
+    /// machine surface derives it from what the workload declares it needs.
+    #[arg(skip)]
+    pub network_mode: mvm_contract::plan::NetworkMode,
     /// Boot a pre-built manifest (path to `mvm.toml`, its directory, or a
     /// legacy slot name). If omitted, the bundled default microVM image is used.
     #[arg(short = 'm', long, conflicts_with = "image")]
@@ -384,6 +389,7 @@ pub(in crate::commands) fn run_secure_with_source(
     // The closure below moves `admit_backend`; keep a copy for the receipt's
     // honest per-backend enforcement tier.
     let receipt_backend = admit_backend.clone();
+    let admit_network_mode = args.network_mode;
     let admit_cpus = args.cpus;
     let admit_mem_mib = u64::from(parse_human_size(&args.memory).context("Invalid --memory")?);
     let admit_network_policy = network_policy.clone();
@@ -410,6 +416,7 @@ pub(in crate::commands) fn run_secure_with_source(
           -> Result<Option<crate::exec::SessionAuditSubstrate>> {
         let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::default();
         let ctx = super::up::admit_plan_for_boot(super::up::AdmitPlanForBootParams {
+            network_mode: admit_network_mode,
             tenant: "local",
             vm_name,
             backend_name: &admit_backend,
@@ -1557,6 +1564,7 @@ mod tests {
 
     fn run_args(profile: RunProfile) -> RunArgs {
         RunArgs {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             warm_pool_size: 0,
             pty: false,
             vm_name: None,

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -259,6 +259,7 @@ fn admit_entrypoint_boot(
 ) -> Result<Option<EntrypointAdmission>> {
     let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::default();
     let ctx = super::up::admit_plan_for_boot(super::up::AdmitPlanForBootParams {
+        network_mode: crate::commands::machine::derive_network_mode(false),
         tenant: "local",
         vm_name: params.vm_name,
         backend_name: params.backend_name,

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -544,6 +544,7 @@ mod tests {
 
     fn base_run_args() -> RunArgs {
         RunArgs {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             manifest: None,
             warm_pool_size: 0,
             pty: false,

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -1011,6 +1011,7 @@ fn cmd_start(args: StartArgs) -> Result<()> {
           -> Result<Option<crate::exec::SessionAuditSubstrate>> {
         let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::default();
         let ctx = super::up::admit_plan_for_boot(super::up::AdmitPlanForBootParams {
+            network_mode: crate::commands::machine::derive_network_mode(false),
             tenant: "local",
             vm_name,
             backend_name: &admit_backend,

--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -48,6 +48,14 @@ pub(in crate::commands::vm) struct AdmitPlanForBootParams<'a> {
     pub boot_artifact_identity: Option<&'a BootArtifactIdentity>,
     pub cpus: u32,
     pub mem_mib: u64,
+    /// The transport this launch gives the guest, recorded on the plan.
+    ///
+    /// Was hardcoded to `Default::default()` — `NetworkMode::None`, whose own
+    /// doc reads "no guest NIC, no broker, the workload cannot reach the
+    /// network" — while every ordinary launch derives `HostVsockProxy` and the
+    /// host stands a broker up for it. The signed record said the workload had
+    /// no path to the network while it was being given one.
+    pub network_mode: mvm_contract::plan::NetworkMode,
     pub seccomp_tier: mvm_core::plan::PlanSeccompTier,
     pub secret_release: mvm_core::plan::SecretReleasePolicy,
     pub secrets: Vec<mvm_core::plan::SecretBinding>,
@@ -325,7 +333,7 @@ pub(in crate::commands::vm) fn admit_plan_for_boot(
     let input = SynthesisInput {
         stream_edges: Vec::new(),
         kernel_sha256: None,
-        network_mode: Default::default(),
+        network_mode: p.network_mode,
         l3_network: None,
         vm_name: p.vm_name,
         tenant: Some(p.tenant),
@@ -1042,6 +1050,7 @@ mod admit_plan_tests {
         let rootfs = write_rootfs(dir.path(), b"unused");
         let ledger = InMemoryNonceLedger::new();
         let result = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             tenant: "local",
             vm_name: "vm-skip",
             backend_name: "firecracker",
@@ -1081,6 +1090,7 @@ mod admit_plan_tests {
         let boot_artifact = mvm_sdk::deploy::digest_boot_artifact(&rootfs).unwrap();
         let ledger = InMemoryNonceLedger::new();
         let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             tenant: "local",
             vm_name: "vm-happy",
             backend_name: "firecracker",
@@ -1141,6 +1151,7 @@ mod admit_plan_tests {
         let audit_dir = tempfile::tempdir().unwrap();
         let ledger = InMemoryNonceLedger::new();
         let err = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             tenant: "local",
             vm_name: "vm-missing",
             backend_name: "firecracker",
@@ -1174,6 +1185,67 @@ mod admit_plan_tests {
         );
     }
 
+    /// The plan must record the transport the launch gives the guest.
+    ///
+    /// This was hardcoded to `NetworkMode::None` — "no guest NIC, no broker,
+    /// the workload cannot reach the network" — for every admission, including
+    /// the ordinary ones that derive `HostVsockProxy` and get a broker stood up
+    /// for them. The value is inside the signature, so the record was
+    /// confidently wrong rather than merely absent.
+    #[test]
+    fn the_admitted_plan_records_the_transport_the_launch_derived() {
+        let keys_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let rootfs_dir = tempfile::tempdir().unwrap();
+        let rootfs = write_rootfs(rootfs_dir.path(), b"transport");
+
+        for mode in [
+            mvm_contract::plan::NetworkMode::HostVsockProxy,
+            mvm_contract::plan::NetworkMode::L3Vsock,
+            mvm_contract::plan::NetworkMode::None,
+        ] {
+            let ledger = InMemoryNonceLedger::new();
+            let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+                network_mode: mode,
+                tenant: "local",
+                vm_name: "vm-transport",
+                backend_name: "firecracker",
+                rootfs_path: &rootfs,
+                precomputed_image_sha256: None,
+                boot_artifact_identity: None,
+                cpus: 1,
+                mem_mib: 128,
+                seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
+                secret_release: mvm_core::plan::SecretReleasePolicy::None,
+                secrets: Vec::new(),
+                no_supervisor: false,
+                ledger: &ledger,
+                keys_dir: Some(keys_dir.path()),
+                audit_dir: Some(audit_dir.path()),
+                policy_dir: None,
+                bundle_pin: None,
+                deps_volume: None,
+                shares: Vec::new(),
+                redaction: mvm_core::policy::RedactionPolicy::default(),
+                network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
+                agent_verb_override: vec![],
+                restrict_agent_verbs: false,
+                services: Vec::new(),
+                entrypoint: crate::commands::vm::entrypoint_resolve::ResolvedEntrypoint::unresolved(
+                    "test",
+                ),
+            })
+            .expect("admit")
+            .expect("a supervisor-backed admission returns a context");
+
+            assert_eq!(
+                ctx.admitted.plan().network_mode,
+                mode,
+                "the plan must record the mode the launch was admitted with"
+            );
+        }
+    }
+
     #[test]
     fn two_admissions_in_same_run_produce_distinct_plan_ids() {
         // The shared ledger is the per-`cmd_run` replay-store. Two
@@ -1186,6 +1258,7 @@ mod admit_plan_tests {
         let ledger = InMemoryNonceLedger::new();
 
         let a1 = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             tenant: "local",
             vm_name: "vm-1",
             backend_name: "firecracker",
@@ -1215,6 +1288,7 @@ mod admit_plan_tests {
         .unwrap()
         .unwrap();
         let a2 = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             tenant: "local",
             vm_name: "vm-2",
             backend_name: "firecracker",
@@ -1269,6 +1343,7 @@ mod admit_plan_tests {
         let rootfs = write_rootfs(rootfs_dir.path(), b"boot-posture-payload");
         let ledger = InMemoryNonceLedger::new();
         let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             tenant: "local",
             vm_name: "vm-boot-posture",
             backend_name: "firecracker",
@@ -1345,6 +1420,7 @@ mod admit_plan_tests {
         let rootfs = write_rootfs(rootfs_dir.path(), b"local-default-payload");
         let ledger = InMemoryNonceLedger::new();
         let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             tenant: "local",
             vm_name: "vm-local-default",
             backend_name: "firecracker",
@@ -1399,6 +1475,7 @@ mod admit_plan_tests {
         let rootfs = write_rootfs(rootfs_dir.path(), b"allow-list-payload");
         let ledger = InMemoryNonceLedger::new();
         let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             tenant: "local",
             vm_name: "vm-allow-list",
             backend_name: "libkrun",
@@ -1460,6 +1537,7 @@ mod admit_plan_tests {
         let rootfs = write_rootfs(rootfs_dir.path(), b"unrestricted-payload");
         let ledger = InMemoryNonceLedger::new();
         let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             tenant: "local",
             vm_name: "vm-unrestricted",
             backend_name: "hvf",
@@ -1547,6 +1625,7 @@ mod admit_plan_tests {
         let ledger = InMemoryNonceLedger::new();
 
         let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             boot_artifact_identity: None,
             tenant: "local",
             vm_name: "vm-non-shell-granted",
@@ -1605,6 +1684,7 @@ mod admit_plan_tests {
         let ledger = InMemoryNonceLedger::new();
 
         let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             boot_artifact_identity: None,
             tenant: "local",
             vm_name: "vm-shell-ungranted",
@@ -1653,6 +1733,7 @@ mod admit_plan_tests {
         let ledger = InMemoryNonceLedger::new();
 
         let err = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             boot_artifact_identity: None,
             tenant: "local",
             vm_name: "vm-shell-granted",
@@ -1709,6 +1790,7 @@ mod admit_plan_tests {
         let ledger = InMemoryNonceLedger::new();
 
         let err = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             boot_artifact_identity: None,
             tenant: "local",
             vm_name: "vm-entrypoint-unknown",
@@ -1761,6 +1843,7 @@ mod admit_plan_tests {
         let ledger = InMemoryNonceLedger::new();
 
         let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             boot_artifact_identity: None,
             tenant: "local",
             vm_name: "vm-entrypoint-unknown-ungranted",
@@ -1806,6 +1889,7 @@ mod admit_plan_tests {
         let ledger = InMemoryNonceLedger::new();
 
         let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             boot_artifact_identity: None,
             tenant: "local",
             vm_name: "vm-dev-shell",

--- a/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
+++ b/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
@@ -223,6 +223,7 @@ pub(in crate::commands) fn start_persistent_oci_machine(
 
     let admission_ledger = InMemoryNonceLedger::new();
     let admission = admit_plan_for_boot(AdmitPlanForBootParams {
+        network_mode: crate::commands::machine::derive_network_mode(false),
         tenant: "local",
         vm_name: name,
         backend_name,


### PR DESCRIPTION
Fixes #2303. **Stacked on #2302** — base is `feat/2293-audit-fsync`, retarget to `main` once that merges.

## The defect

Every signed `ExecutionPlan` recorded `network_mode: None`. That variant's own doc:

> No guest NIC, no broker — the workload cannot reach the network.

Meanwhile every ordinary launch derives `HostVsockProxy` and the host stands a broker up for it. `admit_plan_for_boot` hardcoded `Default::default()` and no caller could override it.

The field is inside the signature, so the record was **confidently wrong rather than merely absent** — and nothing downstream could key off `plan.network_mode`, because it was the same constant for every workload on every backend.

## Why it survived

The derived mode *did* have a reader: the throwaway plan the OCI provenance path synthesized, which recorded it correctly and never booted anything. #2302 removed that plan, leaving the field with no reader at all — which is how this surfaced.

## What each of the six admission sites now passes

- **Transient run** — the mode `preflight_network` settled on, so one value reaches both the transport decision and the plan. This is the only path that can be `L3Vsock`, and it now says so when the workload declares `raw_ip_stack`.
- **Entrypoint, session, OCI-persist** — derived. None carries a workload IR that could ask for the tunnel.
- **Restore and fork** — the parent's. A child booting from a parent's memory and rootfs is continuing that workload, not starting a new one, so if the parent was admitted onto the tunnel its child is on it too. `parent_network_mode` reads it exactly the way `parent_plan_resources` already reads cpus and memory.

The inheritance fallback is what a fresh launch of the same shape would derive, **not `None`**. `None` means the guest has no broker at all; claiming it for a child that is about to be given one is the defect being fixed, not a safe default.

## Test

`the_admitted_plan_records_the_transport_the_launch_derived` round-trips all three modes through admission. Verified it goes red against the old constant:

```
assertion `left == right` failed: the plan must record the mode the launch was admitted with
  left: None
 right: HostVsockProxy
```

## Scope

This is a **record-integrity fix, not an egress fix**. Claim 10's default-deny is enforced at the per-VM substitution endpoint and never read this field, so nothing about what a workload can reach changes. What changes is that the signed record now describes it.

Worth a reviewer's eye on the fork/restore inheritance rule — that is the one place I made a judgement call rather than reading it off an existing derivation.

## Verification

Full workspace suite, doctests, nightly fmt, workspace clippy `-D warnings`, seven xtask gates including `check-honesty`, `check-no-overclaim`, `check-claim-catalog`, `check-conformance`.

Two `mvm-hostd::host_agent_restart` tests failed under `-j 4` and pass isolated — the same pre-existing contention flake that hit the #2298 branch, unrelated to admission.