### PR TITLE
perf(bench): add unprivileged warm resident/fault evidence

### DIFF
--- a/crates/mvm-backends/src/driver/fc.rs
+++ b/crates/mvm-backends/src/driver/fc.rs
@@ -1007,6 +1007,10 @@ impl RunningVm for FcRunningVm {
         &self.id
     }
 
+    fn host_process_id(&self) -> Option<u32> {
+        self.pid
+    }
+
     fn wait(&self) -> Result<VmExitStatus> {
         Ok(mvm_vmm::host::workload_wait::wait_for_workload_exit(
             &self.state_dir,
@@ -1556,6 +1560,18 @@ mod tests {
         });
         vm.kill().unwrap();
         assert!(!pid_file.exists(), "pid marker must be removed on kill");
+    }
+
+    #[test]
+    fn running_vm_exposes_the_captured_host_process() {
+        let vm = FcRunningVm {
+            id: VmId("measured-vm".into()),
+            state_dir: PathBuf::from("/state/measured-vm"),
+            pid_file: PathBuf::from("/state/measured-vm/fc.pid"),
+            pid: Some(4242),
+            vsock_uds: "/state/measured-vm/runtime/v.sock".into(),
+        };
+        assert_eq!(vm.host_process_id(), Some(4242));
     }
 
     #[test]

--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -814,6 +814,10 @@ impl RunningVm for HvfRunningVm {
         &self.id
     }
 
+    fn host_process_id(&self) -> Option<u32> {
+        hvf_backend::read_pid(&self.pid_file).and_then(|pid| u32::try_from(pid).ok())
+    }
+
     fn wait(&self) -> Result<VmExitStatus> {
         Ok(mvm_vmm::host::workload_wait::wait_for_workload_exit(
             &self.state_dir,
@@ -1233,6 +1237,20 @@ mod tests {
 
         // Ports outside the agent port and the console data range are not host-dialable.
         assert!(vm.vsock_connect(GUEST_AGENT_PORT + 1).is_err());
+    }
+
+    #[test]
+    fn running_vm_reads_the_supervisor_host_process() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join(PID_FILE_NAME);
+        std::fs::write(&pid_file, "4242\n").unwrap();
+        let vm = HvfRunningVm {
+            id: VmId("measured-vm".into()),
+            state_dir: dir.path().to_path_buf(),
+            pid_file,
+            agent_socket: dir.path().join("hvf-agent.sock"),
+        };
+        assert_eq!(vm.host_process_id(), Some(4242));
     }
 
     // --- console_socket_for_port ---

--- a/crates/mvm-backends/src/driver/libkrun.rs
+++ b/crates/mvm-backends/src/driver/libkrun.rs
@@ -404,6 +404,10 @@ impl RunningVm for LibkrunRunningVm {
         &self.id
     }
 
+    fn host_process_id(&self) -> Option<u32> {
+        crate::legacy::libkrun::read_pid(&self.pid_file).and_then(|pid| u32::try_from(pid).ok())
+    }
+
     fn wait(&self) -> Result<VmExitStatus> {
         Ok(mvm_vmm::host::workload_wait::wait_for_workload_exit(
             &self.state_dir,
@@ -930,6 +934,19 @@ mod tests {
         // A port outside the agent + console data range is not host-dialable.
         assert!(vm.vsock_connect(GUEST_AGENT_PORT + 1).is_err());
         assert!(vm.vsock_connect(9999).is_err());
+    }
+
+    #[test]
+    fn running_vm_reads_the_supervisor_host_process() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("libkrun.pid");
+        std::fs::write(&pid_file, "4242\n").unwrap();
+        let vm = LibkrunRunningVm {
+            id: VmId("measured-vm".into()),
+            state_dir: dir.path().to_path_buf(),
+            pid_file,
+        };
+        assert_eq!(vm.host_process_id(), Some(4242));
     }
 
     #[test]

--- a/crates/mvm-cli/src/bench/cold_launch.rs
+++ b/crates/mvm-cli/src/bench/cold_launch.rs
@@ -15,7 +15,8 @@ use serde::{Deserialize, Serialize};
 
 pub use crate::commands::vm::launch_sample::{
     ArtifactPaths, BuildProfile, GuestSizing, LAUNCH_SAMPLE_SCHEMA_VERSION, LaunchRootStrategy,
-    LaunchSample, LaunchSubTimings, LaunchWork,
+    LaunchSample, LaunchSubTimings, LaunchWork, ProcessMemoryDelta, ProcessMemorySnapshot,
+    WarmFirstCommandMemory,
 };
 pub use crate::commands::vm::phase_timing::{
     LaunchMode, LaunchSubMarks, RunPhaseTimings, SubPhase,
@@ -26,10 +27,10 @@ use super::stats::percentile;
 
 /// Report schema version for [`ColdLaunchReport`]. Version 2 added artifact
 /// byte measurements and optional resolved kernel-config evidence; version 3
-/// adds the selected root filesystem strategy. Older reports remain readable
-/// through serde defaults but are not comparable without the new substrate
-/// fields.
-pub const COLD_LAUNCH_SCHEMA_VERSION: u32 = 3;
+/// adds the selected root filesystem strategy; version 4 adds whole-VMM warm
+/// working-set and first-command fault evidence. Older reports remain readable
+/// through serde defaults but are not comparable without the new substrate.
+pub const COLD_LAUNCH_SCHEMA_VERSION: u32 = 4;
 
 /// The measurement lanes the cold-launch contract reports independently.
 ///
@@ -102,6 +103,8 @@ pub enum LaneViolation {
     SchemaMismatch { found: u32, expected: u32 },
     /// The current sample does not identify its selected root filesystem path.
     MissingRootStrategy,
+    /// A warm sample omitted the required process-memory evidence.
+    MissingWarmMemory,
     /// The launch performed work the lane forbids.
     ForbiddenWork {
         lane: LaunchLane,
@@ -134,6 +137,10 @@ impl std::fmt::Display for LaneViolation {
             Self::MissingRootStrategy => write!(
                 f,
                 "launch sample does not identify its selected root filesystem strategy"
+            ),
+            Self::MissingWarmMemory => write!(
+                f,
+                "warm launch sample does not contain whole-VMM first-command memory evidence"
             ),
             Self::ForbiddenWork { lane, performed } => write!(
                 f,
@@ -264,6 +271,9 @@ pub fn validate_lane(lane: LaunchLane, sample: &LaunchSample) -> Result<(), Lane
                     lane,
                     expected: "warm_claim",
                 });
+            }
+            if sample.warm_first_command_memory.is_none() {
+                return Err(LaneViolation::MissingWarmMemory);
             }
             Ok(())
         }
@@ -396,6 +406,9 @@ pub struct ColdLaunchSample {
     pub launch_mode: LaunchMode,
     pub phases: RunPhaseTimings,
     pub sub_phases: LaunchSubTimings,
+    /// Whole-VMM warm-ready and first-command memory evidence.
+    #[serde(default)]
+    pub warm_first_command_memory: Option<WarmFirstCommandMemory>,
     /// Phases the backend recorded inside its own `start`.
     #[serde(default)]
     pub backend_phases: Vec<TracePhase>,
@@ -610,8 +623,28 @@ mod tests {
             work: LaunchWork::default(),
             phases: phases(148.0),
             sub_phases: LaunchSubTimings::default(),
+            warm_first_command_memory: None,
             backend_phases: Vec::new(),
             degraded: Vec::new(),
+        }
+    }
+
+    fn warm_memory() -> WarmFirstCommandMemory {
+        let ready = ProcessMemorySnapshot {
+            working_set_bytes: 10,
+            minor_faults: Some(2),
+            major_faults: Some(0),
+        };
+        let after_first_command = ProcessMemorySnapshot {
+            working_set_bytes: 14,
+            minor_faults: Some(5),
+            major_faults: Some(1),
+        };
+        WarmFirstCommandMemory {
+            pid: 42,
+            ready,
+            after_first_command,
+            delta: ProcessMemoryDelta::between(ready, after_first_command),
         }
     }
 
@@ -647,6 +680,7 @@ mod tests {
                 vmm_create_ms: Some(total_ms / 2.0),
                 ..LaunchSubTimings::default()
             },
+            warm_first_command_memory: None,
             backend_phases: vec![TracePhase {
                 name: "boot_confirm".to_string(),
                 ms: total_ms / 4.0,
@@ -931,6 +965,11 @@ mod tests {
         ));
         sample.work.warm_claim = true;
         sample.launch_mode = LaunchMode::Warm;
+        assert_eq!(
+            validate_lane(LaunchLane::WarmClaim, &sample),
+            Err(LaneViolation::MissingWarmMemory)
+        );
+        sample.warm_first_command_memory = Some(warm_memory());
         assert_eq!(validate_lane(LaunchLane::WarmClaim, &sample), Ok(()));
     }
 

--- a/crates/mvm-cli/src/bench/cold_launch.rs
+++ b/crates/mvm-cli/src/bench/cold_launch.rs
@@ -28,9 +28,10 @@ use super::stats::percentile;
 /// Report schema version for [`ColdLaunchReport`]. Version 2 added artifact
 /// byte measurements and optional resolved kernel-config evidence; version 3
 /// adds the selected root filesystem strategy; version 4 adds whole-VMM warm
-/// working-set and first-command fault evidence. Older reports remain readable
-/// through serde defaults but are not comparable without the new substrate.
-pub const COLD_LAUNCH_SCHEMA_VERSION: u32 = 4;
+/// resident-memory and first-command fault evidence; version 5 changes Linux
+/// memory accounting from PSS to RSS. Older reports remain readable through
+/// serde defaults but are not comparable without the new substrate.
+pub const COLD_LAUNCH_SCHEMA_VERSION: u32 = 5;
 
 /// The measurement lanes the cold-launch contract reports independently.
 ///
@@ -631,12 +632,12 @@ mod tests {
 
     fn warm_memory() -> WarmFirstCommandMemory {
         let ready = ProcessMemorySnapshot {
-            working_set_bytes: 10,
+            resident_bytes: 10,
             minor_faults: Some(2),
             major_faults: Some(0),
         };
         let after_first_command = ProcessMemorySnapshot {
-            working_set_bytes: 14,
+            resident_bytes: 14,
             minor_faults: Some(5),
             major_faults: Some(1),
         };

--- a/crates/mvm-cli/src/bench/cold_launch_runner.rs
+++ b/crates/mvm-cli/src/bench/cold_launch_runner.rs
@@ -598,12 +598,12 @@ tmpfs /tmp tmpfs rw 0 0
     fn lane_sample_preserves_warm_memory_evidence() {
         let mut sample = sample_for(148.0);
         let ready = ProcessMemorySnapshot {
-            working_set_bytes: 100,
+            resident_bytes: 100,
             minor_faults: Some(3),
             major_faults: Some(1),
         };
         let after_first_command = ProcessMemorySnapshot {
-            working_set_bytes: 120,
+            resident_bytes: 120,
             minor_faults: Some(8),
             major_faults: Some(1),
         };

--- a/crates/mvm-cli/src/bench/cold_launch_runner.rs
+++ b/crates/mvm-cli/src/bench/cold_launch_runner.rs
@@ -276,6 +276,7 @@ fn cold_launch_sample(
         launch_mode: sample.launch_mode,
         phases: sample.phases,
         sub_phases: sample.sub_phases,
+        warm_first_command_memory: sample.warm_first_command_memory,
         backend_phases: sample.backend_phases.clone(),
         degraded: sample.degraded.clone(),
     })
@@ -410,7 +411,8 @@ mod tests {
     use super::*;
     use crate::commands::vm::launch_sample::{
         BuildProfile, GuestSizing, LAUNCH_SAMPLE_SCHEMA_VERSION, LaunchRootStrategy,
-        LaunchSubTimings, LaunchWork, write_sample,
+        LaunchSubTimings, LaunchWork, ProcessMemoryDelta, ProcessMemorySnapshot,
+        WarmFirstCommandMemory, write_sample,
     };
     use crate::commands::vm::phase_timing::{LaunchMode, RunPhaseTimings};
 
@@ -449,6 +451,7 @@ mod tests {
                 vmm_create_ms: Some(90.0),
                 ..LaunchSubTimings::default()
             },
+            warm_first_command_memory: None,
             backend_phases: Vec::new(),
             degraded: Vec::new(),
         }
@@ -589,6 +592,31 @@ tmpfs /tmp tmpfs rw 0 0
         assert!(lane_sample.cache.artifacts_cached);
         assert_eq!(lane_sample.phases.total_ms, 148.0);
         assert_eq!(lane_sample.sub_phases.vmm_create_ms, Some(90.0));
+    }
+
+    #[test]
+    fn lane_sample_preserves_warm_memory_evidence() {
+        let mut sample = sample_for(148.0);
+        let ready = ProcessMemorySnapshot {
+            working_set_bytes: 100,
+            minor_faults: Some(3),
+            major_faults: Some(1),
+        };
+        let after_first_command = ProcessMemorySnapshot {
+            working_set_bytes: 120,
+            minor_faults: Some(8),
+            major_faults: Some(1),
+        };
+        let measurement = WarmFirstCommandMemory {
+            pid: 42,
+            ready,
+            after_first_command,
+            delta: ProcessMemoryDelta::between(ready, after_first_command),
+        };
+        sample.warm_first_command_memory = Some(measurement);
+
+        let lane_sample = cold_launch_sample(LaunchLane::WarmClaim, 1, &sample, None).unwrap();
+        assert_eq!(lane_sample.warm_first_command_memory, Some(measurement));
     }
 
     /// A stand-in `mvmctl` that writes the sample its argument names. It

--- a/crates/mvm-cli/src/bench/harness.rs
+++ b/crates/mvm-cli/src/bench/harness.rs
@@ -2,8 +2,6 @@
 
 #[cfg(target_os = "linux")]
 use std::path::PathBuf;
-#[cfg(target_os = "linux")]
-use std::process::Command;
 use std::thread;
 
 use anyhow::{Context, Result, bail};
@@ -141,62 +139,25 @@ pub fn parse_linux_proc_stat_faults(input: &str) -> Result<(u64, u64)> {
 
 #[cfg(target_os = "linux")]
 pub fn read_process_footprint_bytes(pid: u32) -> Result<u64> {
-    let body = read_linux_proc_file(pid, "smaps_rollup")?;
+    let path = PathBuf::from("/proc")
+        .join(pid.to_string())
+        .join("smaps_rollup");
+    let body =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
     parse_linux_smaps_rollup_pss_bytes(&body)
 }
 
-/// Read one proc file, retrying through non-interactive sudo for root-owned
-/// VMMs such as Firecracker. The fallback passes the path as an argument to
-/// `cat`, never through a shell, and fails rather than prompting during a
-/// benchmark.
-#[cfg(target_os = "linux")]
-fn read_linux_proc_file(pid: u32, file: &str) -> Result<String> {
-    let path = PathBuf::from("/proc").join(pid.to_string()).join(file);
-    match std::fs::read_to_string(&path) {
-        Ok(body) => Ok(body),
-        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
-            read_linux_proc_file_as_root(&path).with_context(|| {
-                format!(
-                    "reading {} directly was denied and the non-interactive privileged read failed",
-                    path.display()
-                )
-            })
-        }
-        Err(error) => Err(error).with_context(|| format!("reading {}", path.display())),
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn read_linux_proc_file_as_root(path: &std::path::Path) -> Result<String> {
-    let output = Command::new("sudo")
-        .args(["-n", "cat", path.to_string_lossy().as_ref()])
-        .output()
-        .with_context(|| format!("running sudo -n cat {}", path.display()))?;
-    if !output.status.success() {
-        let detail = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let suffix = if detail.is_empty() {
-            String::new()
-        } else {
-            format!(": {detail}")
-        };
-        anyhow::bail!(
-            "sudo -n cat {} exited with {}{}",
-            path.display(),
-            output.status,
-            suffix
-        );
-    }
-    String::from_utf8(output.stdout).context("sudo returned non-UTF-8 proc data")
-}
-
-/// Read whole-process working-set and fault counters for one Linux VMM.
+/// Read whole-process resident memory and fault counters for one Linux VMM.
 #[cfg(target_os = "linux")]
 pub fn read_process_memory_snapshot(pid: u32) -> Result<ProcessMemorySnapshot> {
-    let working_set_bytes = read_process_footprint_bytes(pid)?;
-    let stat = read_linux_proc_file(pid, "stat")?;
+    let resident_bytes = mvm_agentd::worker_pool::process_rss_bytes(pid)
+        .with_context(|| format!("reading unprivileged RSS for host process {pid}"))?;
+    let path = PathBuf::from("/proc").join(pid.to_string()).join("stat");
+    let stat =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
     let (minor_faults, major_faults) = parse_linux_proc_stat_faults(&stat)?;
     Ok(ProcessMemorySnapshot {
-        working_set_bytes,
+        resident_bytes,
         minor_faults: Some(minor_faults),
         major_faults: Some(major_faults),
     })
@@ -225,7 +186,7 @@ pub fn read_process_footprint_bytes(pid: u32) -> Result<u64> {
 #[cfg(target_os = "macos")]
 pub fn read_process_memory_snapshot(pid: u32) -> Result<ProcessMemorySnapshot> {
     Ok(ProcessMemorySnapshot {
-        working_set_bytes: read_process_footprint_bytes(pid)?,
+        resident_bytes: read_process_footprint_bytes(pid)?,
         minor_faults: None,
         major_faults: None,
     })
@@ -297,10 +258,10 @@ Pss_Dirty:           128 kB
 
     #[test]
     #[cfg(target_os = "linux")]
-    fn proc_file_reader_reads_the_current_process() {
-        let stat = read_linux_proc_file(std::process::id(), "stat").unwrap();
-        assert!(!stat.is_empty());
-        assert!(parse_linux_proc_stat_faults(&stat).is_ok());
+    fn process_memory_reader_uses_unprivileged_rss() {
+        let sample = read_process_memory_snapshot(std::process::id()).unwrap();
+        assert!(sample.resident_bytes > 0);
+        assert!(sample.minor_faults.is_some());
     }
 
     /// Deterministic probe so the orchestration loop is testable

--- a/crates/mvm-cli/src/bench/harness.rs
+++ b/crates/mvm-cli/src/bench/harness.rs
@@ -2,6 +2,8 @@
 
 #[cfg(target_os = "linux")]
 use std::path::PathBuf;
+#[cfg(target_os = "linux")]
+use std::process::Command;
 use std::thread;
 
 use anyhow::{Context, Result, bail};
@@ -139,21 +141,59 @@ pub fn parse_linux_proc_stat_faults(input: &str) -> Result<(u64, u64)> {
 
 #[cfg(target_os = "linux")]
 pub fn read_process_footprint_bytes(pid: u32) -> Result<u64> {
-    let path = PathBuf::from("/proc")
-        .join(pid.to_string())
-        .join("smaps_rollup");
-    let body =
-        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let body = read_linux_proc_file(pid, "smaps_rollup")?;
     parse_linux_smaps_rollup_pss_bytes(&body)
+}
+
+/// Read one proc file, retrying through non-interactive sudo for root-owned
+/// VMMs such as Firecracker. The fallback passes the path as an argument to
+/// `cat`, never through a shell, and fails rather than prompting during a
+/// benchmark.
+#[cfg(target_os = "linux")]
+fn read_linux_proc_file(pid: u32, file: &str) -> Result<String> {
+    let path = PathBuf::from("/proc").join(pid.to_string()).join(file);
+    match std::fs::read_to_string(&path) {
+        Ok(body) => Ok(body),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+            read_linux_proc_file_as_root(&path).with_context(|| {
+                format!(
+                    "reading {} directly was denied and the non-interactive privileged read failed",
+                    path.display()
+                )
+            })
+        }
+        Err(error) => Err(error).with_context(|| format!("reading {}", path.display())),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn read_linux_proc_file_as_root(path: &std::path::Path) -> Result<String> {
+    let output = Command::new("sudo")
+        .args(["-n", "cat", path.to_string_lossy().as_ref()])
+        .output()
+        .with_context(|| format!("running sudo -n cat {}", path.display()))?;
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let suffix = if detail.is_empty() {
+            String::new()
+        } else {
+            format!(": {detail}")
+        };
+        anyhow::bail!(
+            "sudo -n cat {} exited with {}{}",
+            path.display(),
+            output.status,
+            suffix
+        );
+    }
+    String::from_utf8(output.stdout).context("sudo returned non-UTF-8 proc data")
 }
 
 /// Read whole-process working-set and fault counters for one Linux VMM.
 #[cfg(target_os = "linux")]
 pub fn read_process_memory_snapshot(pid: u32) -> Result<ProcessMemorySnapshot> {
     let working_set_bytes = read_process_footprint_bytes(pid)?;
-    let stat_path = PathBuf::from("/proc").join(pid.to_string()).join("stat");
-    let stat = std::fs::read_to_string(&stat_path)
-        .with_context(|| format!("reading {}", stat_path.display()))?;
+    let stat = read_linux_proc_file(pid, "stat")?;
     let (minor_faults, major_faults) = parse_linux_proc_stat_faults(&stat)?;
     Ok(ProcessMemorySnapshot {
         working_set_bytes,
@@ -253,6 +293,14 @@ Pss_Dirty:           128 kB
             err.to_string().contains("minflt"),
             "unexpected error: {err:#}"
         );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn proc_file_reader_reads_the_current_process() {
+        let stat = read_linux_proc_file(std::process::id(), "stat").unwrap();
+        assert!(!stat.is_empty());
+        assert!(parse_linux_proc_stat_faults(&stat).is_ok());
     }
 
     /// Deterministic probe so the orchestration loop is testable

--- a/crates/mvm-cli/src/bench/harness.rs
+++ b/crates/mvm-cli/src/bench/harness.rs
@@ -6,6 +6,8 @@ use std::thread;
 
 use anyhow::{Context, Result, bail};
 
+use crate::commands::vm::launch_sample::ProcessMemorySnapshot;
+
 use super::report::{BenchReport, build_report};
 use super::report::{HostDescriptor, LaunchDistributionReport, build_launch_distribution_report};
 use super::stats::IterationTiming;
@@ -113,6 +115,28 @@ pub fn parse_linux_smaps_rollup_pss_bytes(input: &str) -> Result<u64> {
     bail!("smaps_rollup did not contain a Pss line")
 }
 
+/// Parse the process's own minor and major page-fault counters from Linux
+/// `/proc/<pid>/stat`. The command name is parenthesized and may contain
+/// whitespace or parentheses, so fields are counted only after its final `)`.
+#[cfg(any(test, target_os = "linux"))]
+pub fn parse_linux_proc_stat_faults(input: &str) -> Result<(u64, u64)> {
+    let command_end = input
+        .rfind(')')
+        .context("proc stat did not contain a parenthesized command")?;
+    let fields: Vec<&str> = input[command_end + 1..].split_whitespace().collect();
+    let minor = fields
+        .get(7)
+        .context("proc stat did not contain minflt field 10")?
+        .parse::<u64>()
+        .context("parsing proc stat minflt field")?;
+    let major = fields
+        .get(9)
+        .context("proc stat did not contain majflt field 12")?
+        .parse::<u64>()
+        .context("parsing proc stat majflt field")?;
+    Ok((minor, major))
+}
+
 #[cfg(target_os = "linux")]
 pub fn read_process_footprint_bytes(pid: u32) -> Result<u64> {
     let path = PathBuf::from("/proc")
@@ -121,6 +145,21 @@ pub fn read_process_footprint_bytes(pid: u32) -> Result<u64> {
     let body =
         std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
     parse_linux_smaps_rollup_pss_bytes(&body)
+}
+
+/// Read whole-process working-set and fault counters for one Linux VMM.
+#[cfg(target_os = "linux")]
+pub fn read_process_memory_snapshot(pid: u32) -> Result<ProcessMemorySnapshot> {
+    let working_set_bytes = read_process_footprint_bytes(pid)?;
+    let stat_path = PathBuf::from("/proc").join(pid.to_string()).join("stat");
+    let stat = std::fs::read_to_string(&stat_path)
+        .with_context(|| format!("reading {}", stat_path.display()))?;
+    let (minor_faults, major_faults) = parse_linux_proc_stat_faults(&stat)?;
+    Ok(ProcessMemorySnapshot {
+        working_set_bytes,
+        minor_faults: Some(minor_faults),
+        major_faults: Some(major_faults),
+    })
 }
 
 #[cfg(target_os = "macos")]
@@ -141,9 +180,25 @@ pub fn read_process_footprint_bytes(pid: u32) -> Result<u64> {
     Ok(info.ri_phys_footprint)
 }
 
+/// Read whole-process physical footprint for one macOS VMM. macOS does not
+/// expose Linux-equivalent minor/major fault counters through this API.
+#[cfg(target_os = "macos")]
+pub fn read_process_memory_snapshot(pid: u32) -> Result<ProcessMemorySnapshot> {
+    Ok(ProcessMemorySnapshot {
+        working_set_bytes: read_process_footprint_bytes(pid)?,
+        minor_faults: None,
+        major_faults: None,
+    })
+}
+
 #[cfg(all(not(target_os = "linux"), not(target_os = "macos")))]
 pub fn read_process_footprint_bytes(_pid: u32) -> Result<u64> {
     bail!("process footprint sampling is only implemented on Linux and macOS")
+}
+
+#[cfg(all(not(target_os = "linux"), not(target_os = "macos")))]
+pub fn read_process_memory_snapshot(_pid: u32) -> Result<ProcessMemorySnapshot> {
+    bail!("process memory sampling is only implemented on Linux and macOS")
 }
 
 #[cfg(test)]
@@ -183,6 +238,21 @@ Pss_Dirty:           128 kB
     fn smaps_rollup_pss_parser_rejects_missing_pss() {
         let err = parse_linux_smaps_rollup_pss_bytes("Rss: 10 kB\n").unwrap_err();
         assert!(err.to_string().contains("Pss"), "unexpected error: {err:#}");
+    }
+
+    #[test]
+    fn proc_stat_parser_handles_spaces_and_parentheses_in_command() {
+        let fixture = "4321 (vmm worker (ready)) S 1 2 3 4 5 6 701 8 11 9 10";
+        assert_eq!(parse_linux_proc_stat_faults(fixture).unwrap(), (701, 11));
+    }
+
+    #[test]
+    fn proc_stat_parser_rejects_missing_fault_fields() {
+        let err = parse_linux_proc_stat_faults("4321 (vmm) S 1 2").unwrap_err();
+        assert!(
+            err.to_string().contains("minflt"),
+            "unexpected error: {err:#}"
+        );
     }
 
     /// Deterministic probe so the orchestration loop is testable

--- a/crates/mvm-cli/src/commands/vm/launch_sample.rs
+++ b/crates/mvm-cli/src/commands/vm/launch_sample.rs
@@ -26,15 +26,15 @@ pub use mvm_core::launch_trace::LAUNCH_SAMPLE_ENV;
 
 /// Sample schema version. A consumer that reads a different version refuses
 /// the sample as incomparable rather than mis-reading it.
-pub const LAUNCH_SAMPLE_SCHEMA_VERSION: u32 = 3;
+pub const LAUNCH_SAMPLE_SCHEMA_VERSION: u32 = 4;
 
 /// Point-in-time memory counters for the host process that owns a VM.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProcessMemorySnapshot {
-    /// Host working set in bytes. Linux records proportional set size; macOS
-    /// records the process physical footprint.
-    pub working_set_bytes: u64,
+    /// Host resident bytes. Linux records RSS; macOS records physical
+    /// footprint.
+    pub resident_bytes: u64,
     /// Process-wide minor page faults on platforms that expose the counter.
     pub minor_faults: Option<u64>,
     /// Process-wide major page faults on platforms that expose the counter.
@@ -45,10 +45,10 @@ pub struct ProcessMemorySnapshot {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProcessMemoryDelta {
-    /// Working-set bytes added between the two samples.
-    pub working_set_growth_bytes: u64,
-    /// Working-set bytes released between the two samples.
-    pub working_set_reclaimed_bytes: u64,
+    /// Resident bytes added between the two samples.
+    pub resident_growth_bytes: u64,
+    /// Resident bytes released between the two samples.
+    pub resident_reclaimed_bytes: u64,
     /// Minor page faults incurred between samples, when available.
     pub minor_faults: Option<u64>,
     /// Major page faults incurred between samples, when available.
@@ -60,12 +60,8 @@ impl ProcessMemoryDelta {
     #[must_use]
     pub fn between(before: ProcessMemorySnapshot, after: ProcessMemorySnapshot) -> Self {
         Self {
-            working_set_growth_bytes: after
-                .working_set_bytes
-                .saturating_sub(before.working_set_bytes),
-            working_set_reclaimed_bytes: before
-                .working_set_bytes
-                .saturating_sub(after.working_set_bytes),
+            resident_growth_bytes: after.resident_bytes.saturating_sub(before.resident_bytes),
+            resident_reclaimed_bytes: before.resident_bytes.saturating_sub(after.resident_bytes),
             minor_faults: counter_delta(before.minor_faults, after.minor_faults),
             major_faults: counter_delta(before.major_faults, after.major_faults),
         }
@@ -78,7 +74,7 @@ fn counter_delta(before: Option<u64>, after: Option<u64>) -> Option<u64> {
         .map(|(before, after)| after.saturating_sub(before))
 }
 
-/// Whole-VMM memory observed after warm readiness and after its first command.
+/// Whole-VMM resident memory observed after warm readiness and after its first command.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct WarmFirstCommandMemory {
@@ -355,7 +351,7 @@ pub struct LaunchSample {
     pub work: LaunchWork,
     pub phases: RunPhaseTimings,
     pub sub_phases: LaunchSubTimings,
-    /// Whole-VMM warm-ready working set and first-command memory/fault delta.
+    /// Whole-VMM warm-ready resident memory and first-command fault delta.
     /// Absent for cold launches and platforms/backends without a process
     /// observation surface.
     #[serde(default)]
@@ -459,18 +455,18 @@ mod tests {
             warm_first_command_memory: Some(WarmFirstCommandMemory {
                 pid: 42,
                 ready: ProcessMemorySnapshot {
-                    working_set_bytes: 10,
+                    resident_bytes: 10,
                     minor_faults: None,
                     major_faults: None,
                 },
                 after_first_command: ProcessMemorySnapshot {
-                    working_set_bytes: 12,
+                    resident_bytes: 12,
                     minor_faults: None,
                     major_faults: None,
                 },
                 delta: ProcessMemoryDelta {
-                    working_set_growth_bytes: 2,
-                    working_set_reclaimed_bytes: 0,
+                    resident_growth_bytes: 2,
+                    resident_reclaimed_bytes: 0,
                     minor_faults: None,
                     major_faults: None,
                 },
@@ -494,20 +490,20 @@ mod tests {
     #[test]
     fn process_memory_delta_reports_growth_faults_and_unavailable_counters() {
         let before = ProcessMemorySnapshot {
-            working_set_bytes: 100,
+            resident_bytes: 100,
             minor_faults: Some(20),
             major_faults: None,
         };
         let after = ProcessMemorySnapshot {
-            working_set_bytes: 140,
+            resident_bytes: 140,
             minor_faults: Some(27),
             major_faults: None,
         };
         assert_eq!(
             ProcessMemoryDelta::between(before, after),
             ProcessMemoryDelta {
-                working_set_growth_bytes: 40,
-                working_set_reclaimed_bytes: 0,
+                resident_growth_bytes: 40,
+                resident_reclaimed_bytes: 0,
                 minor_faults: Some(7),
                 major_faults: None,
             }
@@ -517,20 +513,20 @@ mod tests {
     #[test]
     fn process_memory_delta_reports_reclamation_and_counter_reset_safely() {
         let before = ProcessMemorySnapshot {
-            working_set_bytes: 200,
+            resident_bytes: 200,
             minor_faults: Some(30),
             major_faults: Some(4),
         };
         let after = ProcessMemorySnapshot {
-            working_set_bytes: 150,
+            resident_bytes: 150,
             minor_faults: Some(2),
             major_faults: Some(6),
         };
         assert_eq!(
             ProcessMemoryDelta::between(before, after),
             ProcessMemoryDelta {
-                working_set_growth_bytes: 0,
-                working_set_reclaimed_bytes: 50,
+                resident_growth_bytes: 0,
+                resident_reclaimed_bytes: 50,
                 minor_faults: Some(0),
                 major_faults: Some(2),
             }

--- a/crates/mvm-cli/src/commands/vm/launch_sample.rs
+++ b/crates/mvm-cli/src/commands/vm/launch_sample.rs
@@ -26,7 +26,71 @@ pub use mvm_core::launch_trace::LAUNCH_SAMPLE_ENV;
 
 /// Sample schema version. A consumer that reads a different version refuses
 /// the sample as incomparable rather than mis-reading it.
-pub const LAUNCH_SAMPLE_SCHEMA_VERSION: u32 = 2;
+pub const LAUNCH_SAMPLE_SCHEMA_VERSION: u32 = 3;
+
+/// Point-in-time memory counters for the host process that owns a VM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProcessMemorySnapshot {
+    /// Host working set in bytes. Linux records proportional set size; macOS
+    /// records the process physical footprint.
+    pub working_set_bytes: u64,
+    /// Process-wide minor page faults on platforms that expose the counter.
+    pub minor_faults: Option<u64>,
+    /// Process-wide major page faults on platforms that expose the counter.
+    pub major_faults: Option<u64>,
+}
+
+/// Change in process memory counters across the first guest command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProcessMemoryDelta {
+    /// Working-set bytes added between the two samples.
+    pub working_set_growth_bytes: u64,
+    /// Working-set bytes released between the two samples.
+    pub working_set_reclaimed_bytes: u64,
+    /// Minor page faults incurred between samples, when available.
+    pub minor_faults: Option<u64>,
+    /// Major page faults incurred between samples, when available.
+    pub major_faults: Option<u64>,
+}
+
+impl ProcessMemoryDelta {
+    /// Compute a non-negative delta while preserving counter unavailability.
+    #[must_use]
+    pub fn between(before: ProcessMemorySnapshot, after: ProcessMemorySnapshot) -> Self {
+        Self {
+            working_set_growth_bytes: after
+                .working_set_bytes
+                .saturating_sub(before.working_set_bytes),
+            working_set_reclaimed_bytes: before
+                .working_set_bytes
+                .saturating_sub(after.working_set_bytes),
+            minor_faults: counter_delta(before.minor_faults, after.minor_faults),
+            major_faults: counter_delta(before.major_faults, after.major_faults),
+        }
+    }
+}
+
+fn counter_delta(before: Option<u64>, after: Option<u64>) -> Option<u64> {
+    before
+        .zip(after)
+        .map(|(before, after)| after.saturating_sub(before))
+}
+
+/// Whole-VMM memory observed after warm readiness and after its first command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WarmFirstCommandMemory {
+    /// Host process sampled for both observations.
+    pub pid: u32,
+    /// Snapshot after the warm readiness barrier and before command dispatch.
+    pub ready: ProcessMemorySnapshot,
+    /// Snapshot immediately after the first guest command returns.
+    pub after_first_command: ProcessMemorySnapshot,
+    /// Derived change from `ready` to `after_first_command`.
+    pub delta: ProcessMemoryDelta,
+}
 
 /// Cargo profile the `mvmctl` binary that produced a sample was built with.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -291,6 +355,11 @@ pub struct LaunchSample {
     pub work: LaunchWork,
     pub phases: RunPhaseTimings,
     pub sub_phases: LaunchSubTimings,
+    /// Whole-VMM warm-ready working set and first-command memory/fault delta.
+    /// Absent for cold launches and platforms/backends without a process
+    /// observation surface.
+    #[serde(default)]
+    pub warm_first_command_memory: Option<WarmFirstCommandMemory>,
     /// Phases the backend recorded inside its own `start`, read back from the
     /// sidecar it dropped in the VM state directory. Empty when the backend
     /// does not trace itself yet — the coarse `vmm_create` span still stands,
@@ -387,6 +456,25 @@ mod tests {
                 agent_auth_ms: Some(1.25),
                 ..LaunchSubTimings::default()
             },
+            warm_first_command_memory: Some(WarmFirstCommandMemory {
+                pid: 42,
+                ready: ProcessMemorySnapshot {
+                    working_set_bytes: 10,
+                    minor_faults: None,
+                    major_faults: None,
+                },
+                after_first_command: ProcessMemorySnapshot {
+                    working_set_bytes: 12,
+                    minor_faults: None,
+                    major_faults: None,
+                },
+                delta: ProcessMemoryDelta {
+                    working_set_growth_bytes: 2,
+                    working_set_reclaimed_bytes: 0,
+                    minor_faults: None,
+                    major_faults: None,
+                },
+            }),
             backend_phases: vec![TracePhase {
                 name: "boot_confirm".to_string(),
                 ms: 2.0,
@@ -401,6 +489,52 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
         let back: LaunchSample = serde_json::from_str(&json).unwrap();
         assert_eq!(back, original);
+    }
+
+    #[test]
+    fn process_memory_delta_reports_growth_faults_and_unavailable_counters() {
+        let before = ProcessMemorySnapshot {
+            working_set_bytes: 100,
+            minor_faults: Some(20),
+            major_faults: None,
+        };
+        let after = ProcessMemorySnapshot {
+            working_set_bytes: 140,
+            minor_faults: Some(27),
+            major_faults: None,
+        };
+        assert_eq!(
+            ProcessMemoryDelta::between(before, after),
+            ProcessMemoryDelta {
+                working_set_growth_bytes: 40,
+                working_set_reclaimed_bytes: 0,
+                minor_faults: Some(7),
+                major_faults: None,
+            }
+        );
+    }
+
+    #[test]
+    fn process_memory_delta_reports_reclamation_and_counter_reset_safely() {
+        let before = ProcessMemorySnapshot {
+            working_set_bytes: 200,
+            minor_faults: Some(30),
+            major_faults: Some(4),
+        };
+        let after = ProcessMemorySnapshot {
+            working_set_bytes: 150,
+            minor_faults: Some(2),
+            major_faults: Some(6),
+        };
+        assert_eq!(
+            ProcessMemoryDelta::between(before, after),
+            ProcessMemoryDelta {
+                working_set_growth_bytes: 0,
+                working_set_reclaimed_bytes: 50,
+                minor_faults: Some(0),
+                major_faults: Some(2),
+            }
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -999,13 +999,7 @@ fn run_inner(
     let warm_memory_start = if sample_path.is_some()
         && launch_mode == crate::commands::vm::phase_timing::LaunchMode::Warm
     {
-        match begin_warm_memory_measurement(&backend, &vm_name) {
-            Ok(start) => Some(start),
-            Err(error) => {
-                eprintln!("[mvm] warm-ready process memory not measured: {error:#}");
-                None
-            }
-        }
+        Some(begin_warm_memory_measurement(&backend, &vm_name))
     } else {
         None
     };
@@ -1020,15 +1014,14 @@ fn run_inner(
         Ok((either, vsock_ready)) => (Ok(either), vsock_ready),
         Err(e) => (Err(e), None),
     };
-    let warm_first_command_memory = warm_memory_start.and_then(|start| {
-        match finish_warm_memory_measurement(&backend, &vm_name, start) {
-            Ok(measurement) => Some(measurement),
-            Err(error) => {
-                eprintln!("[mvm] first-command process memory not measured: {error:#}");
-                None
-            }
-        }
+    let warm_memory_result = warm_memory_start.map(|start| {
+        start.and_then(|start| finish_warm_memory_measurement(&backend, &vm_name, start))
     });
+    let warm_memory_error = warm_memory_result
+        .as_ref()
+        .and_then(|result| result.as_ref().err())
+        .map(|error| format!("{error:#}"));
+    let warm_first_command_memory = warm_memory_result.and_then(Result::ok);
 
     // Reap state dirs a killed or crashed prior transient run left behind: a
     // SIGKILL or a closed terminal skips teardown, so `~/.mvm/vms/<name>` leaks.
@@ -1083,30 +1076,41 @@ fn run_inner(
             eprintln!("{}", sub_phases.render());
         }
         if let Some(path) = sample_path.as_deref() {
-            let sample = build_launch_sample(LaunchSampleInputs {
-                backend: backend.name(),
-                start_config: &start_config,
-                launch_mode,
-                root_strategy: boot.root_strategy,
-                mount_materialized: sub_marks
-                    .recorded(crate::commands::vm::phase_timing::SubPhase::MountMaterialize),
-                phases,
-                sub_phases,
-                warm_first_command_memory,
-                backend_phases: backend_phases.clone(),
-                degraded: degraded.clone(),
-            });
-            if let Err(e) = crate::commands::vm::launch_sample::write_sample(path, &sample) {
-                // A measurement that cannot be recorded must be loud: a
-                // silently missing sample reads downstream as a launch that
-                // never ran, not as a launch nobody wrote down.
-                eprintln!("[mvm] launch sample not written: {e:#}");
+            if let Some(error) = warm_memory_error.as_deref() {
+                eprintln!(
+                    "[mvm] launch sample not written: warm memory measurement failed: {error}"
+                );
+            } else {
+                let sample = build_launch_sample(LaunchSampleInputs {
+                    backend: backend.name(),
+                    start_config: &start_config,
+                    launch_mode,
+                    root_strategy: boot.root_strategy,
+                    mount_materialized: sub_marks
+                        .recorded(crate::commands::vm::phase_timing::SubPhase::MountMaterialize),
+                    phases,
+                    sub_phases,
+                    warm_first_command_memory,
+                    backend_phases: backend_phases.clone(),
+                    degraded: degraded.clone(),
+                });
+                if let Err(e) = crate::commands::vm::launch_sample::write_sample(path, &sample) {
+                    // A measurement that cannot be recorded must be loud: a
+                    // silently missing sample reads downstream as a launch that
+                    // never ran, not as a launch nobody wrote down.
+                    eprintln!("[mvm] launch sample not written: {e:#}");
+                }
             }
         }
     }
 
     if interrupted.load(std::sync::atomic::Ordering::SeqCst) {
         anyhow::bail!("interrupted");
+    }
+    if let Some(error) = warm_memory_error {
+        if result.is_ok() {
+            anyhow::bail!("warm memory measurement failed: {error}");
+        }
     }
     result
 }

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1107,10 +1107,10 @@ fn run_inner(
     if interrupted.load(std::sync::atomic::Ordering::SeqCst) {
         anyhow::bail!("interrupted");
     }
-    if let Some(error) = warm_memory_error {
-        if result.is_ok() {
-            anyhow::bail!("warm memory measurement failed: {error}");
-        }
+    if let Some(error) = warm_memory_error
+        && result.is_ok()
+    {
+        anyhow::bail!("warm memory measurement failed: {error}");
     }
     result
 }

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -996,6 +996,20 @@ fn run_inner(
         .map(|trace| trace.degraded)
         .unwrap_or_default();
 
+    let warm_memory_start = if sample_path.is_some()
+        && launch_mode == crate::commands::vm::phase_timing::LaunchMode::Warm
+    {
+        match begin_warm_memory_measurement(&backend, &vm_name) {
+            Ok(start) => Some(start),
+            Err(error) => {
+                eprintln!("[mvm] warm-ready process memory not measured: {error:#}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // Install Ctrl-C handler that tears the VM down.
     let interrupted = install_ctrlc_teardown(&vm_name, backend.name());
 
@@ -1006,6 +1020,15 @@ fn run_inner(
         Ok((either, vsock_ready)) => (Ok(either), vsock_ready),
         Err(e) => (Err(e), None),
     };
+    let warm_first_command_memory = warm_memory_start.and_then(|start| {
+        match finish_warm_memory_measurement(&backend, &vm_name, start) {
+            Ok(measurement) => Some(measurement),
+            Err(error) => {
+                eprintln!("[mvm] first-command process memory not measured: {error:#}");
+                None
+            }
+        }
+    });
 
     // Reap state dirs a killed or crashed prior transient run left behind: a
     // SIGKILL or a closed terminal skips teardown, so `~/.mvm/vms/<name>` leaks.
@@ -1069,6 +1092,7 @@ fn run_inner(
                     .recorded(crate::commands::vm::phase_timing::SubPhase::MountMaterialize),
                 phases,
                 sub_phases,
+                warm_first_command_memory,
                 backend_phases: backend_phases.clone(),
                 degraded: degraded.clone(),
             });
@@ -1098,6 +1122,8 @@ struct LaunchSampleInputs<'a> {
     mount_materialized: bool,
     phases: crate::commands::vm::phase_timing::RunPhaseTimings,
     sub_phases: crate::commands::vm::launch_sample::LaunchSubTimings,
+    /// Whole-VMM memory evidence surrounding the first warm command.
+    warm_first_command_memory: Option<crate::commands::vm::launch_sample::WarmFirstCommandMemory>,
     /// Phases the backend recorded inside `start`, read from its sidecar
     /// before teardown removed the state directory holding it.
     backend_phases: Vec<mvm_core::launch_trace::TracePhase>,
@@ -1141,9 +1167,62 @@ fn build_launch_sample(
         ),
         phases: inputs.phases,
         sub_phases: inputs.sub_phases,
+        warm_first_command_memory: inputs.warm_first_command_memory,
         backend_phases: inputs.backend_phases,
         degraded: inputs.degraded,
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WarmMemoryMeasurementStart {
+    pid: u32,
+    ready: crate::commands::vm::launch_sample::ProcessMemorySnapshot,
+}
+
+fn begin_warm_memory_measurement(
+    backend: &AnyBackend,
+    vm_name: &str,
+) -> Result<WarmMemoryMeasurementStart> {
+    let id = VmId(vm_name.to_string());
+    let pid = backend.host_process_id(&id)?.with_context(|| {
+        format!(
+            "{} did not expose a host process for {vm_name}",
+            backend.name()
+        )
+    })?;
+    let ready = crate::bench::harness::read_process_memory_snapshot(pid)
+        .with_context(|| format!("sampling warm-ready host process {pid}"))?;
+    Ok(WarmMemoryMeasurementStart { pid, ready })
+}
+
+fn finish_warm_memory_measurement(
+    backend: &AnyBackend,
+    vm_name: &str,
+    start: WarmMemoryMeasurementStart,
+) -> Result<crate::commands::vm::launch_sample::WarmFirstCommandMemory> {
+    use crate::commands::vm::launch_sample::{ProcessMemoryDelta, WarmFirstCommandMemory};
+
+    let id = VmId(vm_name.to_string());
+    let observed_pid = backend.host_process_id(&id)?.with_context(|| {
+        format!(
+            "{} no longer exposes a host process for {vm_name}",
+            backend.name()
+        )
+    })?;
+    if observed_pid != start.pid {
+        anyhow::bail!(
+            "host process changed from {} to {observed_pid} during the first command",
+            start.pid
+        );
+    }
+    let after_first_command = crate::bench::harness::read_process_memory_snapshot(start.pid)
+        .with_context(|| format!("sampling host process {} after first command", start.pid))?;
+    Ok(WarmFirstCommandMemory {
+        pid: start.pid,
+        ready: start.ready,
+        after_first_command,
+        delta: ProcessMemoryDelta::between(start.ready, after_first_command),
+    })
 }
 
 /// Kernel/rootfs/initrd + provenance resolved from `req.image`: either a

--- a/crates/mvm-conformance/tests/steps/cold_launch.rs
+++ b/crates/mvm-conformance/tests/steps/cold_launch.rs
@@ -56,6 +56,7 @@ fn clean_sample(profile: BuildProfile) -> LaunchSample {
             cleanup_handoff_ms: Some(19.0),
             ..LaunchSubTimings::default()
         },
+        warm_first_command_memory: None,
         backend_phases: Vec::new(),
         degraded: Vec::new(),
     }

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -464,6 +464,13 @@ pub trait VmBackend: Send + Sync {
         self.start_with_mode(config, StartMode::Detached)
     }
 
+    /// Host process that owns a running VM's address space, when the backend
+    /// can identify it. The process may exit immediately after this call, so
+    /// consumers must treat the PID as a point-in-time observation only.
+    fn host_process_id(&self, _id: &VmId) -> Result<Option<u32>> {
+        Ok(None)
+    }
+
     /// Start a VM with explicit attach/detach semantics.
     ///
     /// See [`StartMode`] for the contract. The default impl bails —

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -937,6 +937,11 @@ impl AnyBackend {
         self.inner().start(config)
     }
 
+    /// Host process that owns the running VM's address space, when known.
+    pub fn host_process_id(&self, id: &VmId) -> Result<Option<u32>> {
+        self.inner().host_process_id(id)
+    }
+
     pub fn stop(&self, id: &VmId) -> Result<()> {
         self.inner().stop(id)
     }

--- a/crates/mvm-runtime/src/workload_runner/runner/backend.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner/backend.rs
@@ -136,6 +136,10 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 
         }
     }
 
+    fn host_process_id(&self, id: &VmId) -> Result<Option<u32>> {
+        Ok(self.driver.attach(id)?.host_process_id())
+    }
+
     fn wait(&self, id: &VmId) -> Result<VmExitStatus> {
         self.driver.attach(id)?.wait()
     }

--- a/crates/mvm-vmm/src/driver/traits.rs
+++ b/crates/mvm-vmm/src/driver/traits.rs
@@ -283,6 +283,12 @@ pub trait VmmDriver: Send + Sync {
 /// and an external supervisor all present the same surface.
 pub trait RunningVm: Send {
     fn id(&self) -> &VmId;
+    /// Host process that owns this VM's address space, when the driver can
+    /// identify it. This is an observation surface for diagnostics and
+    /// benchmarks, not a lifecycle handle; callers must tolerate process exit.
+    fn host_process_id(&self) -> Option<u32> {
+        None
+    }
     /// Block until the VM exits; returns its status.
     fn wait(&self) -> Result<VmExitStatus>;
     /// Force-terminate the VM.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -27,8 +27,11 @@ for detailed scope and acceptance criteria.
       exposes bounded resident host-process capture, and the HVF guest-RAM seam
       exposes resident bytes with a demand-fault witness and records private
       restore-mapping duration. The libkrun density report also carries the
-      readiness-bound guest-agent RSS witness; whole-VM guest working-set,
-      first-use restore-fault, and cross-backend evidence remain open.
+      readiness-bound guest-agent RSS witness. Backend-neutral warm launch
+      evidence now samples the whole VMM host process at authenticated
+      readiness and after the first command, including Linux fault deltas and
+      macOS physical footprint. The real-host Firecracker/HVF matrix,
+      canonical budget table, and gates remain open.
 
 ## In-flight plans
 - [x] Plan 2167 — durable agent session and event contract
@@ -174,9 +177,10 @@ for detailed scope and acceptance criteria.
         `specs/notes/2026-08-10-fast-machine-substrate.md` (issue #2279)
   - [~] Kernel/boot-substrate budget and filesystem-path evaluation tracked by
         issues #2280 and #2281. The artifact-ledger slice of #2280 and the
-        pure-Rust ext4 baseline report are landed; live timing, restore,
-        density, candidate filesystem comparison, and the adopt/decline
-        decision remain open.
+        pure-Rust ext4 baseline report are landed. Whole-VMM warm-ready and
+        first-command memory/fault instrumentation is also landed; its
+        real-host matrix, canonical budget/gates, candidate filesystem
+        comparison, and the adopt/decline decision remain open.
 
 - [ ] Plan 311 — Launch critical-path waste on real-sized images
       (`specs/plans/311-launch-critical-path-waste.md`), branch

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1522,9 +1522,13 @@ Then unify + retire the old paths:
   authenticated readiness, and the HVF guest-RAM seam now reports resident
   bytes with a direct untouched-versus-touched demand-fault witness plus
   monotonic private restore-mapping duration. The libkrun density report now
-  also carries guest-agent RSS from the existing ResourceUsage RPC. Whole-VM
-  guest working-set, first-use restore-fault, and cross-backend live
-  measurements remain open.
+  also carries guest-agent RSS from the existing ResourceUsage RPC. The
+  backend-neutral warm launch sample now records the whole VMM host process at
+  authenticated readiness and after the first command: Linux reports PSS and
+  minor/major fault deltas, while macOS reports physical footprint with fault
+  counters explicitly unavailable. Warm-lane validation refuses missing
+  evidence. The real-host Firecracker/HVF matrix, canonical budget table, and
+  resulting gates remain open.
 - [x] **Filesystem-path baseline — issue #2281.**
   `mvm_fs::rootfs::measure_ext4_pure` now records a stable JSON baseline for
   source identity, node composition, emitted ext4 size/digest, materializer

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1524,7 +1524,8 @@ Then unify + retire the old paths:
   monotonic private restore-mapping duration. The libkrun density report now
   also carries guest-agent RSS from the existing ResourceUsage RPC. The
   backend-neutral warm launch sample now records the whole VMM host process at
-  authenticated readiness and after the first command: Linux reports PSS and
+  authenticated readiness and after the first command: Linux reports RSS from
+  `/proc/<pid>/statm` and
   minor/major fault deltas, while macOS reports physical footprint with fault
   counters explicitly unavailable. Warm-lane validation refuses missing
   evidence. The real-host Firecracker/HVF matrix, canonical budget table, and

--- a/specs/notes/2026-08-10-fast-machine-substrate.md
+++ b/specs/notes/2026-08-10-fast-machine-substrate.md
@@ -95,7 +95,8 @@ probe without a guest-readiness witness is not an optimization.
 Warm launch samples now provide the end-to-end process witness needed for this
 comparison. The workload backend resolves the VMM/supervisor PID through the
 shared running-VM trait, then samples the same process after authenticated
-readiness and immediately after the first guest command. Linux records PSS and
+readiness and immediately after the first guest command. Linux records RSS from
+`/proc/<pid>/statm` and
 minor/major page-fault deltas; macOS records physical footprint and marks those
 Linux-specific counters unavailable. Firecracker, libkrun, and HVF use the same
 schema and lane gate, which rejects missing warm evidence. Results remain

--- a/specs/notes/2026-08-10-fast-machine-substrate.md
+++ b/specs/notes/2026-08-10-fast-machine-substrate.md
@@ -92,6 +92,15 @@ The smallest artifact wins only when it improves or preserves the launch,
 resident-memory, restore, and security measurements. Removing a driver or boot
 probe without a guest-readiness witness is not an optimization.
 
+Warm launch samples now provide the end-to-end process witness needed for this
+comparison. The workload backend resolves the VMM/supervisor PID through the
+shared running-VM trait, then samples the same process after authenticated
+readiness and immediately after the first guest command. Linux records PSS and
+minor/major page-fault deltas; macOS records physical footprint and marks those
+Linux-specific counters unavailable. Firecracker, libkrun, and HVF use the same
+schema and lane gate, which rejects missing warm evidence. Results remain
+comparable only within a matching host, backend, artifact, and sizing context.
+
 ## Filesystem evaluation
 
 The current block-backed rootfs, overlay, dm-verity, and host-directory image
@@ -141,8 +150,10 @@ between warmup or measured samples.
   kernel and boot-substrate budget. The bounded libkrun resident host-process
   capture is landed, and HVF guest-RAM now exposes an allocation-level
   demand-fault witness plus private restore-mapping duration. The live libkrun
-  density report also records guest-agent RSS after readiness; whole-VM guest
-  working-set, first-use restore-fault, and cross-backend live evidence remain.
+  density report also records guest-agent RSS after readiness. Backend-neutral
+  warm samples now capture whole-VMM ready/first-command working set and Linux
+  fault deltas; the real-host Firecracker/HVF matrix, canonical budget table,
+  and enforcement gates remain.
 - [~] [#2281](https://github.com/tinylabscom/mvm/issues/2281) — baseline the
   current pure-Rust ext4 path and evaluate the guest-local immutable
   filesystem path against it.

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -655,6 +655,16 @@ optimization backend-local and the benchmark backend-neutral.
       when a restore file is supplied. These are allocation and mapping
       witnesses, not substitutes for end-to-end guest working-set or first-use
       restore-fault measurements.
+- [x] Add a backend-neutral whole-VMM warm first-command witness. The shared
+      running-VM and backend traits expose the host process that owns each VM,
+      implemented for Firecracker, libkrun, and HVF without backend-name
+      dispatch. A warm launch sample captures that process after authenticated
+      readiness and immediately after the first guest command. Linux records
+      PSS plus process minor/major fault deltas; macOS records physical
+      footprint and explicitly leaves Linux-only fault counters unavailable.
+      Launch-sample schema v3 and cold-launch schema v4 carry the evidence, and
+      the warm-lane gate rejects a sample that omits it. The real-host backend
+      matrix and canonical budget table remain before #2280 can close.
 - [x] Add a baseline filesystem-path report at the existing pure-Rust
       materializer seam. `mvm_fs::rootfs::measure_ext4_pure` records the source
       content digest, node composition, file bytes, emitted image size/digest,

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -660,9 +660,10 @@ optimization backend-local and the benchmark backend-neutral.
       implemented for Firecracker, libkrun, and HVF without backend-name
       dispatch. A warm launch sample captures that process after authenticated
       readiness and immediately after the first guest command. Linux records
-      PSS plus process minor/major fault deltas; macOS records physical
-      footprint and explicitly leaves Linux-only fault counters unavailable.
-      Launch-sample schema v3 and cold-launch schema v4 carry the evidence, and
+      RSS from `/proc/<pid>/statm` plus process minor/major fault deltas; macOS
+      records physical footprint and explicitly leaves Linux-only fault counters
+      unavailable.
+      Launch-sample schema v4 and cold-launch schema v5 carry the evidence, and
       the warm-lane gate rejects a sample that omits it. The real-host backend
       matrix and canonical budget table remain before #2280 can close.
 - [x] Add a baseline filesystem-path report at the existing pure-Rust


### PR DESCRIPTION
## Summary

- Capture backend-neutral warm first-command evidence for the whole VMM host process.
- On Linux, record unprivileged RSS from `/proc/<pid>/statm` and process-wide minor/major faults from `/proc/<pid>/stat`.
- On macOS, record physical footprint; Linux-only fault counters remain unavailable there.
- Require the warm memory measurement for a successful warm benchmark: if it fails, omit the sample and fail the otherwise-successful command instead of publishing partial evidence.
- Bump the launch-sample schema to v4 and cold-launch schema to v5, and name the fields for resident memory rather than working set.

The warm evidence path uses no `sudo` or privileged helper and does not require elevated access. Existing density reporting continues to use its separate Linux PSS footprint path; this PR's warm evidence is explicitly RSS-based and comparable only within the same accounting definition.

## Validation

- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `cargo check -p mvm-cli --lib` — reached the final `mvm-cli` check/link phase but stalled in the local environment; GitHub CI remains required
- Host/backend matrix and canonical budget gates remain follow-up work for #2280
