### PR TITLE
fix: automate macOS VM entitlement signing

### DIFF
--- a/assets/mvm-supervisor.entitlements
+++ b/assets/mvm-supervisor.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.hypervisor</key>
+	<true/>
+</dict>
+</plist>

--- a/crates/mvm-cli/src/commands/env/sign.rs
+++ b/crates/mvm-cli/src/commands/env/sign.rs
@@ -1,6 +1,6 @@
-//! `mvmctl sign` — re-sign mvmctl + supervisor binaries with the
-//! virtualization/hypervisor entitlements (user-facing repair of the auto-sign
-//! path). macOS-only; a no-op on other platforms.
+//! `mvmctl env sign` — repair the macOS entitlements on mvmctl's VM launch
+//! targets. Normal installs and updates do this automatically; this remains
+//! useful for source builds and older installations.
 
 use anyhow::Result;
 use clap::Args as ClapArgs;
@@ -22,13 +22,13 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         if args.json {
             crate::json_out::emit_json(&Vec::<mvm_runtime::codesign::SignReport>::new())?;
         } else {
-            ui::info("mvmctl sign is macOS-only (codesign entitlements); nothing to do here.");
+            ui::info("mvmctl env sign is macOS-only (codesign entitlements); nothing to do here.");
         }
         return Ok(());
     }
 
     let targets = mvm_runtime::codesign::collect_sign_targets();
-    let reports = mvm_runtime::codesign::sign_binaries(&targets);
+    let reports = mvm_runtime::codesign::sign_targets(&targets);
 
     if args.json {
         crate::json_out::emit_json(&reports)?;
@@ -45,9 +45,11 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         ui::status_line(&format!("  {} {}:", mark, r.path.display()), verb);
     }
     if reports.iter().all(|r| r.entitlements_present) {
-        ui::success("All binaries carry the virtualization + hypervisor entitlements.");
+        ui::success("All VM launch targets carry their required macOS entitlements.");
         Ok(())
     } else {
-        anyhow::bail!("one or more binaries failed to acquire both entitlements");
+        anyhow::bail!(
+            "one or more VM launch targets failed to acquire their required entitlements"
+        );
     }
 }

--- a/crates/mvm-cli/src/doctor/security_checks.rs
+++ b/crates/mvm-cli/src/doctor/security_checks.rs
@@ -686,20 +686,20 @@ pub(super) fn security_snapshot_dirs_check() -> Check {
     }
 }
 
-/// macOS-only: every sign target (mvmctl plus the supervisor binaries) needs
-/// the virtualization and hypervisor entitlements. Probes all paths from
+/// macOS-only: every executable in the active VM launch set needs the
+/// entitlement for its runtime role. Probes all paths from
 /// `collect_sign_targets` so an unsigned supervisor is not left unreported.
 /// Off macOS the check is n/a (returns the early-exit n/a `Check`).
 pub(super) fn security_signing_check() -> Check {
-    use mvm_runtime::codesign::{collect_sign_targets, entitlements_present};
+    use mvm_runtime::codesign::{collect_sign_targets, entitlement_present};
     let targets = collect_sign_targets();
-    // `entitlements_present` returns `None` off macOS for every path, so if
+    // `entitlement_present` returns `None` off macOS for every path, so if
     // the first target gives `None` the whole check is n/a.
     let probed: Vec<(std::path::PathBuf, Option<bool>)> = targets
         .into_iter()
-        .map(|p| {
-            let r = entitlements_present(&p);
-            (p, r)
+        .map(|target| {
+            let r = entitlement_present(&target.path, target.required);
+            (target.path, r)
         })
         .collect();
     signing_check_from_probes(&probed)
@@ -738,8 +738,7 @@ fn signing_check_from_probes(probes: &[(std::path::PathBuf, Option<bool>)]) -> C
             name: "signing",
             category: "security",
             ok: true,
-            info: "virtualization + hypervisor entitlements present on all sign targets"
-                .to_string(),
+            info: "required VM entitlements present on all launch targets".to_string(),
         }
     } else {
         Check {
@@ -747,7 +746,8 @@ fn signing_check_from_probes(probes: &[(std::path::PathBuf, Option<bool>)]) -> C
             category: "security",
             ok: false,
             info: format!(
-                "entitlements missing on: {} — run `mvmctl sign`",
+                "required VM entitlements missing on: {} — reinstall or update mvmctl \
+                 (advanced repair: `mvmctl env sign`)",
                 unsigned.join(", ")
             ),
         }
@@ -924,8 +924,8 @@ mod tests {
         let c = signing_check_from_probes(&probes);
         assert!(c.ok, "all signed → ok; got: {}", c.info);
         assert!(
-            c.info.contains("all sign targets"),
-            "expected 'all sign targets', got: {}",
+            c.info.contains("all launch targets"),
+            "expected 'all launch targets', got: {}",
             c.info
         );
     }
@@ -951,7 +951,7 @@ mod tests {
             c.info
         );
         assert!(
-            c.info.contains("mvmctl sign"),
+            c.info.contains("mvmctl env sign"),
             "info must carry the remediation hint; got: {}",
             c.info
         );

--- a/crates/mvm-cli/src/update.rs
+++ b/crates/mvm-cli/src/update.rs
@@ -437,6 +437,7 @@ fn extract_and_install(target: &str, tmp_dir: &Path, current_exe: &Path) -> Resu
 
     install_release_host_binaries(&extracted_dir, install_dir, needs_sudo)
         .context("Failed to update adjacent host helper binaries")?;
+    sign_installed_binaries().context("Failed to apply macOS VM entitlements")?;
 
     // --- Replace resources ---
     let new_resources = extracted_dir.join("resources");
@@ -516,6 +517,31 @@ fn install_release_host_binaries(
         }
     }
     Ok(())
+}
+
+/// Apply the macOS entitlements immediately after replacing a release binary
+/// and its adjacent supervisors. A successful update must not leave the next
+/// invocation dependent on a lazy first-boot repair.
+fn sign_installed_binaries() -> Result<()> {
+    if !cfg!(target_os = "macos") {
+        return Ok(());
+    }
+
+    let targets = mvm_runtime::codesign::collect_sign_targets();
+    let reports = mvm_runtime::codesign::sign_targets(&targets);
+    let failed: Vec<String> = reports
+        .iter()
+        .filter(|report| !report.entitlements_present)
+        .map(|report| report.path.display().to_string())
+        .collect();
+    if failed.is_empty() {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "required VM entitlements are missing on: {}",
+            failed.join(", ")
+        )
+    }
 }
 
 fn run_sudo_mv(from: &Path, to: &Path) -> Result<()> {

--- a/crates/mvm-runtime/src/codesign.rs
+++ b/crates/mvm-runtime/src/codesign.rs
@@ -19,6 +19,7 @@ pub enum RequiredEntitlement {
     VirtualizationAndHypervisor,
 }
 
+#[cfg(target_os = "macos")]
 impl RequiredEntitlement {
     fn keys(self) -> &'static [&'static str] {
         match self {
@@ -59,7 +60,7 @@ pub fn entitlement_present(path: &Path, required: RequiredEntitlement) -> Option
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = path;
+        let _ = (path, required);
         None
     }
 }

--- a/crates/mvm-runtime/src/codesign.rs
+++ b/crates/mvm-runtime/src/codesign.rs
@@ -1,13 +1,45 @@
-//! macOS codesigning of mvm's VMM binaries with the virtualization +
-//! hypervisor entitlements.
+//! macOS codesigning of mvm's VMM binaries with their required entitlements.
 //!
-//! Apple Hypervisor.framework refuses to launch a VM unless the
-//! launching binary carries both `com.apple.security.virtualization` and
-//! `com.apple.security.hypervisor`. The CLI (`mvmctl`) and the per-VM
-//! libkrun supervisor must both be signed. Everything here is a no-op off
-//! macOS.
+//! Apple requires the binary that launches a Virtualization.framework VM to
+//! carry `com.apple.security.virtualization` and the binary that enters
+//! Hypervisor.framework to carry `com.apple.security.hypervisor`. The CLI
+//! and per-VM supervisors are signed separately because they have different
+//! roles. Everything here is a no-op off macOS.
 
 use std::path::{Path, PathBuf};
+
+/// The macOS entitlement required by a signed mvm executable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequiredEntitlement {
+    /// Required by the CLI's Virtualization.framework path.
+    Virtualization,
+    /// Required by the per-VM Hypervisor.framework supervisor.
+    Hypervisor,
+    /// The combined profile retained for callers of the legacy bulk API.
+    VirtualizationAndHypervisor,
+}
+
+impl RequiredEntitlement {
+    fn keys(self) -> &'static [&'static str] {
+        match self {
+            Self::Virtualization => &["com.apple.security.virtualization"],
+            Self::Hypervisor => &["com.apple.security.hypervisor"],
+            Self::VirtualizationAndHypervisor => &[
+                "com.apple.security.virtualization",
+                "com.apple.security.hypervisor",
+            ],
+        }
+    }
+}
+
+/// An executable and the entitlement required by its runtime role.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignTarget {
+    /// Path to the executable to inspect or sign.
+    pub path: PathBuf,
+    /// Entitlement the executable must carry.
+    pub required: RequiredEntitlement,
+}
 
 /// Outcome of attempting to sign one binary.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -15,16 +47,15 @@ pub struct SignReport {
     pub path: PathBuf,
     /// Whether codesign was (re)applied during this call.
     pub applied: bool,
-    /// Whether both entitlements are present after.
+    /// Whether the target's required entitlement is present after signing.
     pub entitlements_present: bool,
 }
 
-/// `Some(true/false)` on macOS (both required entitlements present?),
-/// `None` on platforms where the question is meaningless.
-pub fn entitlements_present(path: &Path) -> Option<bool> {
+/// Check whether an executable carries a specific required entitlement.
+pub fn entitlement_present(path: &Path, required: RequiredEntitlement) -> Option<bool> {
     #[cfg(target_os = "macos")]
     {
-        Some(macos::entitlements_present(path))
+        Some(macos::entitlement_present(path, required))
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -33,12 +64,37 @@ pub fn entitlements_present(path: &Path) -> Option<bool> {
     }
 }
 
-/// Ad-hoc re-sign each target with both entitlements and
-/// report the post-sign state. No-op (empty) off macOS.
+/// Check whether an executable carries both historical VM entitlements.
+///
+/// New callers should use [`entitlement_present`] with the target's specific
+/// runtime role. This compatibility wrapper remains for existing consumers of
+/// the original bulk signing API.
+pub fn entitlements_present(path: &Path) -> Option<bool> {
+    entitlement_present(path, RequiredEntitlement::VirtualizationAndHypervisor)
+}
+
+/// Ad-hoc re-sign a list of executables with the historical combined profile.
+///
+/// New callers should use [`sign_targets`] so each executable receives only
+/// the entitlement required by its runtime role.
 pub fn sign_binaries(targets: &[PathBuf]) -> Vec<SignReport> {
+    let targets: Vec<SignTarget> = targets
+        .iter()
+        .cloned()
+        .map(|path| SignTarget {
+            path,
+            required: RequiredEntitlement::VirtualizationAndHypervisor,
+        })
+        .collect();
+    sign_targets(&targets)
+}
+
+/// Ad-hoc re-sign each role-specific target and report the post-sign state.
+/// No-op (empty) off macOS.
+pub fn sign_targets(targets: &[SignTarget]) -> Vec<SignReport> {
     #[cfg(target_os = "macos")]
     {
-        targets.iter().map(|p| macos::sign_path(p)).collect()
+        targets.iter().map(macos::sign_path).collect()
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -47,25 +103,38 @@ pub fn sign_binaries(targets: &[PathBuf]) -> Vec<SignReport> {
     }
 }
 
-/// The binaries that need both entitlements to launch a VM:
-/// the running CLI plus whichever supervisors resolve on this host.
+/// The binaries that need macOS entitlements to launch a VM: the running CLI
+/// plus whichever supervisors resolve on this host.
 /// Unresolved supervisors are silently skipped (a host may have only
 /// one backend installed).
-pub fn collect_sign_targets() -> Vec<PathBuf> {
+pub fn collect_sign_targets() -> Vec<SignTarget> {
     let mut out = Vec::new();
     if let Ok(exe) = std::env::current_exe() {
-        out.push(exe);
+        out.push(SignTarget {
+            path: exe,
+            required: RequiredEntitlement::Virtualization,
+        });
     }
     if let Ok(p) = mvm_backends::legacy::libkrun::resolve_supervisor_path() {
-        out.push(p);
+        out.push(SignTarget {
+            path: p,
+            required: RequiredEntitlement::Hypervisor,
+        });
     }
-    out.dedup();
+    if let Ok(p) = mvm_backends::legacy::hvf::resolve_supervisor_path() {
+        out.push(SignTarget {
+            path: p,
+            required: RequiredEntitlement::Hypervisor,
+        });
+    }
+    out.dedup_by(|a, b| a.path == b.path);
     out
 }
 
-/// Auto-sign the running CLI on first launch if it lacks the
-/// entitlements, then re-exec the signed binary (`MVM_SIGNED=1` guards
-/// against a recursion loop). No-op off macOS / when already signed.
+/// Auto-sign the running supervisor on first launch if it lacks the
+/// Hypervisor.framework entitlement, then re-exec the signed binary
+/// (`MVM_SIGNED=1` guards against a recursion loop). No-op off macOS / when
+/// already signed.
 pub fn ensure_signed() {
     #[cfg(target_os = "macos")]
     {
@@ -75,13 +144,24 @@ pub fn ensure_signed() {
 
 #[cfg(target_os = "macos")]
 mod macos {
-    use super::SignReport;
+    use super::{RequiredEntitlement, SignReport, SignTarget};
     use std::path::Path;
 
-    /// Ad-hoc entitlements plist applied by [`sign_binary`]. Lifted to a
-    /// const so the entitlement set is testable — inlining the XML would
-    /// make the "did we keep both keys" invariant invisible to CI.
-    const ENTITLEMENTS_PLIST: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+    const VIRTUALIZATION_ENTITLEMENTS_PLIST: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+        \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+        <plist version=\"1.0\"><dict>\n\
+        <key>com.apple.security.virtualization</key><true/>\n\
+        </dict></plist>";
+
+    const HYPERVISOR_ENTITLEMENTS_PLIST: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+        \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+        <plist version=\"1.0\"><dict>\n\
+        <key>com.apple.security.hypervisor</key><true/>\n\
+        </dict></plist>";
+
+    const COMBINED_ENTITLEMENTS_PLIST: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
         <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
         \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
         <plist version=\"1.0\"><dict>\n\
@@ -89,23 +169,27 @@ mod macos {
         <key>com.apple.security.hypervisor</key><true/>\n\
         </dict></plist>";
 
-    pub(super) fn sign_path(path: &Path) -> SignReport {
-        let already = entitlements_present(path);
+    pub(super) fn sign_path(target: &SignTarget) -> SignReport {
+        let already = entitlement_present(&target.path, target.required);
         if !already {
-            sign_binary(&path.to_string_lossy());
+            sign_binary(&target.path.to_string_lossy(), target.required);
         }
         SignReport {
-            path: path.to_path_buf(),
+            path: target.path.clone(),
             applied: !already,
-            entitlements_present: entitlements_present(path),
+            entitlements_present: entitlement_present(&target.path, target.required),
         }
     }
 
-    /// Sign the binary ad-hoc with both Virtualization.framework and
-    /// Hypervisor.framework entitlements (no self-restart).
-    fn sign_binary(exe_str: &str) {
+    /// Sign the binary ad-hoc with the entitlement required by its role.
+    fn sign_binary(exe_str: &str, required: RequiredEntitlement) {
         let ent_path = std::env::temp_dir().join("mvm-entitlements.plist");
-        if std::fs::write(&ent_path, ENTITLEMENTS_PLIST).is_err() {
+        let entitlements = match required {
+            RequiredEntitlement::Virtualization => VIRTUALIZATION_ENTITLEMENTS_PLIST,
+            RequiredEntitlement::Hypervisor => HYPERVISOR_ENTITLEMENTS_PLIST,
+            RequiredEntitlement::VirtualizationAndHypervisor => COMBINED_ENTITLEMENTS_PLIST,
+        };
+        if std::fs::write(&ent_path, entitlements).is_err() {
             return;
         }
         let _ = std::process::Command::new("codesign")
@@ -129,14 +213,10 @@ mod macos {
         Some(String::from_utf8_lossy(&out.stdout).into_owned())
     }
 
-    /// True only when BOTH the virtualization and hypervisor entitlements
-    /// are present (the launch path requires both).
-    pub(super) fn entitlements_present(path: &Path) -> bool {
+    /// True when the executable carries the entitlement required by its role.
+    pub(super) fn entitlement_present(path: &Path, required: RequiredEntitlement) -> bool {
         match read_entitlements_xml(path) {
-            Some(xml) => {
-                xml.contains("com.apple.security.virtualization")
-                    && xml.contains("com.apple.security.hypervisor")
-            }
+            Some(xml) => required.keys().iter().all(|key| xml.contains(key)),
             None => false,
         }
     }
@@ -155,13 +235,13 @@ mod macos {
         // Binaries signed before the hypervisor entitlement was added have
         // only `virtualization`; the missing `hypervisor` key forces a
         // one-time re-sign on first run after upgrade.
-        if entitlements_present(&exe) {
+        if entitlement_present(&exe, RequiredEntitlement::Hypervisor) {
             return;
         }
         let _ = exe_str;
 
-        tracing::info!("Signing binary with virtualization + hypervisor entitlements...");
-        sign_binary(&exe.to_string_lossy());
+        tracing::info!("Signing binary with the Hypervisor.framework entitlement...");
+        sign_binary(&exe.to_string_lossy(), RequiredEntitlement::Hypervisor);
 
         use std::os::unix::process::CommandExt;
         let err = std::process::Command::new(&exe)
@@ -193,18 +273,34 @@ mod tests {
     fn collect_sign_targets_includes_current_exe() {
         let targets = collect_sign_targets();
         let exe = std::env::current_exe().unwrap();
-        assert!(targets.contains(&exe));
+        assert!(targets.iter().any(|target| target.path == exe));
     }
 
     #[cfg(not(target_os = "macos"))]
     #[test]
     fn entitlements_present_is_none_off_macos() {
-        assert!(entitlements_present(std::path::Path::new("/bin/sh")).is_none());
+        assert!(
+            entitlement_present(
+                std::path::Path::new("/bin/sh"),
+                RequiredEntitlement::Virtualization
+            )
+            .is_none()
+        );
     }
 
     #[cfg(not(target_os = "macos"))]
     #[test]
-    fn sign_binaries_is_noop_off_macos() {
+    fn sign_targets_is_noop_off_macos() {
+        let target = SignTarget {
+            path: std::path::PathBuf::from("/bin/sh"),
+            required: RequiredEntitlement::Virtualization,
+        };
+        assert!(sign_targets(&[target]).is_empty());
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn legacy_sign_binaries_is_noop_off_macos() {
         assert!(sign_binaries(&[std::path::PathBuf::from("/bin/sh")]).is_empty());
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 # mvmctl installer. Downloads the released binary for this platform from
 # GitHub releases, verifies its sha256 (and cosign signature if cosign is
-# present), installs it, and on macOS re-codesigns with the
-# Hypervisor.framework entitlement.
+# present), installs it, and on macOS applies the required VM entitlements.
 #
 # Env knobs:
 #   MVM_VERSION            pin a release tag (e.g. v0.15.2); default: latest
@@ -137,9 +136,8 @@ $SUDO install -m 0755 "$SRC/mvmctl" "$INSTALL_DIR/mvmctl"
 # them — installing only mvmctl strands them. copy-if-exists: the bundled set
 # differs by platform (macOS ships the supervisors + bridge + endpoint; Linux
 # ships the bridge + endpoint).
-# No codesigning here: the hvf/libkrun supervisors self-sign with the
-# required entitlements on first spawn (ensure_signed); mvm-bridge and the
-# substitution endpoint need no entitlement.
+# mvm-bridge and the substitution endpoint need no VM entitlement. The
+# supervisors are signed below before the install is reported successful.
 for hostbin in mvm-bridge mvm-hvf-supervisor mvm-libkrun-supervisor mvm-substitution-endpoint; do
   if [ -f "$SRC/$hostbin" ]; then
     $SUDO install -m 0755 "$SRC/$hostbin" "$INSTALL_DIR/$hostbin"
@@ -152,17 +150,29 @@ if [ -d "$SRC/assets" ]; then
   $SUDO cp -R "$SRC/assets" "$INSTALL_DIR/assets"
 fi
 
-# macOS: Hypervisor.framework needs the entitlement. Best-effort —
-# a re-sign failure warns but doesn't fail the install (the binary
-# still runs for non-hypervisor uses; `codesign` can be re-run).
-if [ "$(uname -s)" = "Darwin" ] && [ "${MVM_SKIP_CODESIGN:-}" != "1" ]; then
-  ent="$INSTALL_DIR/assets/mvmctl.entitlements"
-  if command -v codesign >/dev/null 2>&1 && [ -f "$ent" ]; then
-    if $SUDO codesign --entitlements "$ent" -f -s - "$INSTALL_DIR/mvmctl" 2>/dev/null; then
-      say "Codesigned with Hypervisor.framework entitlement."
-    else
-      warn "codesign failed — re-run: codesign --entitlements $ent -f -s - $INSTALL_DIR/mvmctl"
-    fi
+# macOS: every executable on the VM launch path must carry its role-specific
+# entitlement. Treat this as part of installation integrity: a successful
+# install must be ready to launch a VM without a hidden first-run repair.
+if [ "$(uname -s)" = "Darwin" ]; then
+  if [ "${MVM_SKIP_CODESIGN:-}" = "1" ]; then
+    warn "MVM_SKIP_CODESIGN=1 — skipping macOS VM entitlement signing"
+  else
+    command -v codesign >/dev/null 2>&1 || die "codesign is required on macOS"
+
+    sign_target() {
+      target="$1"
+      entitlements="$2"
+      [ -f "$target" ] || return 0
+      [ -f "$entitlements" ] || die "missing entitlement profile: $entitlements"
+      output="$($SUDO codesign --sign - --force --entitlements "$entitlements" "$target" 2>&1)" \
+        || die "codesign failed for $target: $output"
+      say "Codesigned: $target"
+    }
+
+    sign_target "$INSTALL_DIR/mvmctl" "$INSTALL_DIR/assets/mvmctl.entitlements"
+    for hostbin in mvm-hvf-supervisor mvm-libkrun-supervisor; do
+      sign_target "$INSTALL_DIR/$hostbin" "$INSTALL_DIR/assets/mvm-supervisor.entitlements"
+    done
   fi
 fi
 

--- a/nix/packaging/homebrew/mvmctl.rb.tmpl
+++ b/nix/packaging/homebrew/mvmctl.rb.tmpl
@@ -42,10 +42,16 @@ class Mvmctl < Formula
       bin.install hostbin if File.exist?(hostbin)
     end
     (prefix/"assets").install Dir["assets/*"] if Dir.exist?("assets")
-    # macOS: Hypervisor.framework requires the entitlement; re-sign ad-hoc.
-    if OS.mac? && File.exist?("assets/mvmctl.entitlements")
-      system "codesign", "--entitlements", "assets/mvmctl.entitlements",
-             "-f", "-s", "-", bin/"mvmctl"
+    # macOS: sign the complete VM launch path with role-specific entitlements.
+    if OS.mac?
+      system "codesign", "--sign", "-", "--force", "--entitlements",
+             prefix/"assets/mvmctl.entitlements", bin/"mvmctl"
+      %w[mvm-hvf-supervisor mvm-libkrun-supervisor].each do |hostbin|
+        next unless (bin/hostbin).exist?
+
+        system "codesign", "--sign", "-", "--force", "--entitlements",
+               prefix/"assets/mvm-supervisor.entitlements", bin/hostbin
+      end
     end
   end
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -38,6 +38,14 @@
       fenced examples are covered by the test-owned manifest, and README
       status text matches the shipped `deploy` and `watch` commands.
 
+- [x] Automatic macOS VM entitlement signing — installers and self-update now
+      sign `mvmctl` and shipped supervisors before reporting success, with
+      role-specific entitlement profiles. `doctor` validates the active launch
+      targets and points normal users to reinstall/update; `mvmctl env sign`
+      remains an advanced repair path for source and legacy installations.
+      Focused Rust and CLI tests plus installer shell validation cover the
+      changed behavior; see `specs/plans/312-automatic-macos-entitlement-signing.md`.
+
 - [x] Audit-chain verification failure no longer reports as "never audited" —
       **issue #2258, plan 302 WS6**. `SignedChainAnchor` remembers the chains
       that failed verification and returns `Err` naming them when a lookup

--- a/specs/plans/312-automatic-macos-entitlement-signing.md
+++ b/specs/plans/312-automatic-macos-entitlement-signing.md
@@ -1,0 +1,35 @@
+# Plan 312: Automatic macOS VM entitlement signing
+
+**Status: COMPLETE**
+
+## Goal
+
+Make macOS entitlement signing an installation and update invariant instead of
+a routine user action, while keeping an explicit repair path for source builds
+and older installations.
+
+## Delivered
+
+- [x] Sign `mvmctl` and shipped VM supervisors during `install.sh`.
+- [x] Sign the replaced executable and adjacent supervisors during
+      `mvmctl update`.
+- [x] Add the supervisor entitlement profile to the release assets and
+      Homebrew installation path.
+- [x] Model Virtualization.framework and Hypervisor.framework requirements as
+      separate target roles.
+- [x] Make `mvmctl doctor` validate role-specific entitlements and recommend
+      reinstall/update before the advanced repair command.
+- [x] Retain `mvmctl env sign` for source-build and legacy-install repair.
+- [x] Cover the command surface, doctor mapping, shell syntax, and focused
+      Rust compilation paths.
+
+## Operational policy
+
+On macOS, an install or update that cannot apply the required entitlements is
+not a complete VM-ready installation. `MVM_SKIP_CODESIGN=1` remains an
+explicit escape hatch for development and test environments; `doctor` then
+reports the resulting missing entitlement state.
+
+Verification: focused runtime, doctor, and CLI tests passed; installer tests
+passed with a fake macOS `codesign`; the workspace test suite passed after the
+one restricted-sandbox socket test was rerun with loopback permissions.

--- a/tests/install_sh.rs
+++ b/tests/install_sh.rs
@@ -67,8 +67,8 @@ fn sha256_hex(bytes: &[u8]) -> String {
     d.iter().map(|b| format!("{:02x}", b)).collect()
 }
 
-/// Build a gzipped tar containing `mvmctl-<target>/mvmctl` (+ an
-/// assets dir) where mvmctl is a shell stub printing a version.
+/// Build a gzipped tar containing release-shaped VM binaries and assets where
+/// mvmctl is a shell stub printing a version.
 fn make_tarball(target: &str) -> Vec<u8> {
     use flate2::Compression;
     use flate2::write::GzEncoder;
@@ -96,6 +96,26 @@ fn make_tarball(target: &str) -> Vec<u8> {
         &ent[..],
     )
     .unwrap();
+    let supervisor_entitlements = b"<plist><key>com.apple.security.hypervisor</key></plist>\n";
+    let mut h3 = tar::Header::new_gnu();
+    h3.set_size(supervisor_entitlements.len() as u64);
+    h3.set_mode(0o644);
+    h3.set_cksum();
+    tar.append_data(
+        &mut h3,
+        format!("{dir}/assets/mvm-supervisor.entitlements"),
+        &supervisor_entitlements[..],
+    )
+    .unwrap();
+    for hostbin in ["mvm-hvf-supervisor", "mvm-libkrun-supervisor"] {
+        let bytes = hostbin.as_bytes();
+        let mut header = tar::Header::new_gnu();
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        tar.append_data(&mut header, format!("{dir}/{hostbin}"), bytes)
+            .unwrap();
+    }
     let tar_bytes = tar.into_inner().unwrap();
     let mut gz = GzEncoder::new(Vec::new(), Compression::default());
     gz.write_all(&tar_bytes).unwrap();
@@ -304,5 +324,66 @@ fn install_sh_rejects_tampered_checksum() {
     assert!(
         !install_dir.path().join("mvmctl").exists(),
         "no binary on failure"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn install_sh_codesigns_all_macos_vm_targets() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let target = host_target();
+    let tarball = make_tarball(target);
+    let archive = format!("mvmctl-{target}.tar.gz");
+    let checks = format!("{}  {}\n", sha256_hex(&tarball), archive);
+    let routes = vec![
+        (
+            format!("/tinylabscom/mvm/releases/download/v9.9.9/{archive}"),
+            tarball,
+        ),
+        (
+            "/tinylabscom/mvm/releases/download/v9.9.9/checksums-sha256.txt".to_string(),
+            checks.into_bytes(),
+        ),
+    ];
+    let (base, _stop) = serve(routes);
+
+    let root = tempfile::tempdir().unwrap();
+    let fake_bin = root.path().join("bin");
+    std::fs::create_dir_all(&fake_bin).unwrap();
+    let log = root.path().join("codesign.log");
+    let codesign = fake_bin.join("codesign");
+    std::fs::write(
+        &codesign,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\n",
+            log.display()
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&codesign, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let install_dir = root.path().join("install");
+    let path = format!("{}:{}", fake_bin.display(), std::env::var("PATH").unwrap());
+    let status = Command::new("sh")
+        .arg(repo_root().join("install.sh"))
+        .env("MVM_VERSION", "v9.9.9")
+        .env("MVM_UPDATE_DOWNLOAD_URL", &base)
+        .env("MVM_INSTALL_DIR", &install_dir)
+        .env("MVM_SKIP_BUILDER_PREFETCH", "1")
+        .env("PATH", path)
+        .status()
+        .unwrap();
+    assert!(status.success(), "install.sh should sign the VM targets");
+
+    let log = std::fs::read_to_string(log).unwrap();
+    assert!(log.contains("mvmctl"), "mvmctl was not codesigned: {log}");
+    assert!(
+        log.contains("mvm-hvf-supervisor"),
+        "HVF supervisor was not codesigned: {log}"
+    );
+    assert!(
+        log.contains("mvm-libkrun-supervisor"),
+        "libkrun supervisor was not codesigned: {log}"
     );
 }

--- a/tests/sign_cli.rs
+++ b/tests/sign_cli.rs
@@ -1,4 +1,4 @@
-//! CLI surface tests for `mvmctl sign`.
+//! CLI surface tests for `mvmctl env sign`.
 
 use assert_cmd::cargo::CommandCargoExt;
 use std::process::Command;
@@ -23,7 +23,7 @@ fn sign_help_lists_json_flag() {
     );
     assert!(
         stdout.contains("--json"),
-        "`mvmctl sign --help` missing --json; got:\n{stdout}"
+        "`mvmctl env sign --help` missing --json; got:\n{stdout}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Sign macOS VM launch binaries automatically during install, update, and Homebrew installation.
- Use role-specific Virtualization.framework and Hypervisor.framework entitlement profiles.
- Keep `mvmctl env sign` as an advanced repair path and update doctor guidance.

## Root cause

The installer signed only `mvmctl`, updates left replaced binaries unsigned, and supervisors relied on lazy first-use signing. Doctor also treated every launch target as requiring both entitlements, producing a confusing failure for otherwise role-specific binaries.

## Validation

- `cargo check -p mvm-runtime -p mvm-cli --offline`
- `cargo clippy -p mvm-runtime --lib --offline -- -D warnings`
- `cargo clippy -p mvm-cli --lib --offline -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings` (pre-commit hook)
- `cargo test -p mvm-runtime codesign --lib --offline`
- `cargo test -p mvm-cli doctor::security_checks --lib --offline`
- `cargo test -p mvmctl --test sign_cli --offline`
- `cargo test -p mvmctl --test install_sh --offline`
- `cargo test --workspace --offline`
- `cargo fmt --all -- --check`
- `sh -n install.sh`

The installer integration test and one workspace socket test required loopback/nonblocking socket permissions outside the restricted sandbox; both passed there.
