### PR TITLE
Fix HVF vsock credit accounting for large downloads

### DIFF
--- a/crates/mvm-vmm/src/vmm/vsock.rs
+++ b/crates/mvm-vmm/src/vmm/vsock.rs
@@ -24,7 +24,8 @@ use super::device_state::{
 use super::vsock_handlers::{VsockHandlerContext, VsockHandlerRegistry, VsockLifecycleState};
 #[cfg(test)]
 use super::vsock_transport::{
-    GUEST_CID, HOST_BUF_ALLOC, HOST_CID, TYPE_STREAM, VIRTIO_ID_VSOCK, VIRTIO_MAGIC, VIRTIO_VERSION,
+    GUEST_CID, HOST_BUF_ALLOC, HOST_CID, OP_SHUTDOWN, TYPE_STREAM, VIRTIO_ID_VSOCK, VIRTIO_MAGIC,
+    VIRTIO_VERSION,
 };
 use super::vsock_transport::{
     NUM_QUEUES, OP_CREDIT_UPDATE, OP_REQUEST, OP_RESPONSE, OP_RST, OP_RW, Queue, RegisterWrite,
@@ -257,6 +258,11 @@ impl VsockShared {
     }
 
     fn handle_packet(&mut self, hdr: VsockHdr, payload: &[u8]) {
+        if !self.transport.record_tx_credit(&hdr) {
+            let mut ctx = VsockHandlerContext::new(&mut self.transport, &mut self.lifecycle);
+            ctx.queue_reply(&hdr, OP_RST, &[]);
+            return;
+        }
         let mut ctx = VsockHandlerContext::new(&mut self.transport, &mut self.lifecycle);
         if self.handlers.dispatch_packet(&mut ctx, hdr, payload) {
             return;
@@ -292,6 +298,7 @@ impl VsockShared {
     pub(super) fn cancel(&mut self) {
         self.handlers.cancel();
         self.transport.recv_cnt.clear();
+        self.transport.clear_tx_credit();
         self.transport.pending_rx.clear();
     }
 
@@ -759,6 +766,12 @@ impl VsockShared {
                 field: "receive_credit_sessions",
             });
         }
+        if self.transport.has_tx_credit() {
+            return Err(DeviceStateError::InvalidValue {
+                kind,
+                field: "transmit_credit_sessions",
+            });
+        }
         if !self.transport.pending_rx.is_empty() {
             return Err(DeviceStateError::InvalidValue {
                 kind,
@@ -1013,6 +1026,35 @@ mod tests {
     }
 
     #[test]
+    fn transmit_credit_state_is_rejected_before_capture() {
+        let source = virtio_dev();
+        {
+            let mut shared = source.lock();
+            shared.handle_packet(
+                VsockHdr {
+                    src_cid: GUEST_CID,
+                    dst_cid: HOST_CID,
+                    src_port: 1000,
+                    dst_port: mvm_agentd::vsock::EGRESS_PORT,
+                    op: OP_CREDIT_UPDATE,
+                    typ: TYPE_STREAM,
+                    buf_alloc: 64,
+                    ..Default::default()
+                },
+                &[],
+            );
+            shared.transport.pending_rx.clear();
+        }
+        assert!(matches!(
+            source.snapshot_state(),
+            Err(DeviceStateError::InvalidValue {
+                kind: DeviceKind::VirtioVsock,
+                field: "transmit_credit_sessions"
+            })
+        ));
+    }
+
+    #[test]
     fn host_endpoint_binding_is_rejected_before_capture() {
         let dir = tempfile::tempdir().unwrap();
         let source = virtio_dev();
@@ -1086,6 +1128,7 @@ mod tests {
             len: 5,
             op: OP_RW,
             typ: TYPE_STREAM,
+            buf_alloc: HOST_BUF_ALLOC,
             ..Default::default()
         };
         d.handle_packet(rw, b"hello");
@@ -1163,6 +1206,7 @@ mod tests {
             len: raw.len() as u32,
             op: OP_RW,
             typ: TYPE_STREAM,
+            buf_alloc: HOST_BUF_ALLOC,
             ..Default::default()
         };
         d.handle_packet(rw, &raw);
@@ -1271,6 +1315,7 @@ mod tests {
             len: raw.len() as u32,
             op: OP_RW,
             typ: TYPE_STREAM,
+            buf_alloc: HOST_BUF_ALLOC,
             ..Default::default()
         };
         d.handle_packet(rw, &raw);
@@ -1334,6 +1379,7 @@ mod tests {
             len: 5,
             op: OP_RW,
             typ: TYPE_STREAM,
+            buf_alloc: HOST_BUF_ALLOC,
             ..Default::default()
         };
         d.handle_packet(cap, b"hello");
@@ -1426,6 +1472,7 @@ mod tests {
             len: 5,
             op: OP_RW,
             typ: TYPE_STREAM,
+            buf_alloc: HOST_BUF_ALLOC,
             ..Default::default()
         };
         d.handle_packet(rw, b"1.2.3");
@@ -1446,6 +1493,239 @@ mod tests {
             std::thread::sleep(std::time::Duration::from_millis(5));
         }
         assert!(framed);
+    }
+
+    #[test]
+    fn host_honors_guest_transmit_credit_and_resumes_after_update() {
+        use std::io::{Read, Write};
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("credit.sock");
+        let Some(listener) = bind_unix_listener(&sock) else {
+            return;
+        };
+        let server = std::thread::spawn(move || {
+            let (mut connection, _) = listener.accept().unwrap();
+            let mut request = [0u8; 64];
+            let _ = connection.read(&mut request).unwrap();
+            connection.write_all(&[b'x'; 200]).unwrap();
+            connection.flush().unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        });
+
+        let mut device = dev();
+        device.set_substitution_endpoint(&sock);
+        let target = b"files.pythonhosted.org:443\n";
+        device.handle_packet(
+            VsockHdr {
+                src_cid: GUEST_CID,
+                dst_cid: HOST_CID,
+                src_port: 1700,
+                dst_port: mvm_agentd::vsock::EGRESS_PORT,
+                len: target.len() as u32,
+                op: OP_RW,
+                typ: TYPE_STREAM,
+                buf_alloc: 64,
+                ..Default::default()
+            },
+            target,
+        );
+
+        let mut received = Vec::new();
+        for _ in 0..100 {
+            let _ = device.service_host_io();
+            for (header, payload) in device.transport.pending_rx.drain(..) {
+                if header.op == OP_RW && header.dst_port == 1700 {
+                    received.extend_from_slice(&payload);
+                }
+            }
+            if !received.is_empty() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        let first_window = received.len();
+
+        device.handle_packet(
+            VsockHdr {
+                src_cid: GUEST_CID,
+                dst_cid: HOST_CID,
+                src_port: 1700,
+                dst_port: mvm_agentd::vsock::EGRESS_PORT,
+                op: OP_CREDIT_UPDATE,
+                typ: TYPE_STREAM,
+                buf_alloc: 64,
+                fwd_cnt: 64,
+                ..Default::default()
+            },
+            &[],
+        );
+        for _ in 0..100 {
+            let _ = device.service_host_io();
+            for (header, payload) in device.transport.pending_rx.drain(..) {
+                if header.op == OP_RW && header.dst_port == 1700 {
+                    received.extend_from_slice(&payload);
+                }
+            }
+            if received.len() >= 128 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        server.join().unwrap();
+        assert_eq!(first_window, 64, "host exceeded the guest's first window");
+        assert_eq!(
+            received.len(),
+            128,
+            "host did not stop at or resume for the second window"
+        );
+    }
+
+    #[test]
+    fn large_egress_reply_obeys_credit_and_arrives_without_loss() {
+        use std::io::{Read, Write};
+
+        const PAYLOAD_LEN: usize = 32 * 1024 * 1024;
+        const GUEST_WINDOW: usize = 64 * 1024;
+        const SERVER_CHUNK: usize = 16 * 1024;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("large-credit.sock");
+        let Some(listener) = bind_unix_listener(&sock) else {
+            return;
+        };
+        let server = std::thread::spawn(move || {
+            let (mut connection, _) = listener.accept().unwrap();
+            let mut byte = [0u8; 1];
+            loop {
+                connection.read_exact(&mut byte).unwrap();
+                if byte[0] == b'\n' {
+                    break;
+                }
+            }
+            let mut offset = 0usize;
+            let mut chunk = [0u8; SERVER_CHUNK];
+            while offset < PAYLOAD_LEN {
+                let len = SERVER_CHUNK.min(PAYLOAD_LEN - offset);
+                for (index, byte) in chunk[..len].iter_mut().enumerate() {
+                    *byte = ((offset + index) % 251) as u8;
+                }
+                connection.write_all(&chunk[..len])?;
+                offset += len;
+            }
+            Ok::<(), std::io::Error>(())
+        });
+
+        let mut device = dev();
+        device.set_substitution_endpoint(&sock);
+        let target = b"files.pythonhosted.org:443\n";
+        device.handle_packet(
+            VsockHdr {
+                src_cid: GUEST_CID,
+                dst_cid: HOST_CID,
+                src_port: 1800,
+                dst_port: mvm_agentd::vsock::EGRESS_PORT,
+                len: target.len() as u32,
+                op: OP_RW,
+                typ: TYPE_STREAM,
+                buf_alloc: GUEST_WINDOW as u32,
+                ..Default::default()
+            },
+            target,
+        );
+
+        let mut received = Vec::with_capacity(PAYLOAD_LEN);
+        let mut largest_window = 0usize;
+        let mut shutdown_seen = false;
+        for _ in 0..40_000 {
+            let _ = device.service_host_io();
+            let mut window_bytes = 0usize;
+            for (header, payload) in device.transport.pending_rx.drain(..) {
+                if header.op == OP_RW && header.dst_port == 1800 {
+                    window_bytes += payload.len();
+                    received.extend_from_slice(&payload);
+                } else if header.op == OP_SHUTDOWN && header.dst_port == 1800 {
+                    shutdown_seen = true;
+                }
+            }
+            largest_window = largest_window.max(window_bytes);
+            if window_bytes > 0 {
+                device.handle_packet(
+                    VsockHdr {
+                        src_cid: GUEST_CID,
+                        dst_cid: HOST_CID,
+                        src_port: 1800,
+                        dst_port: mvm_agentd::vsock::EGRESS_PORT,
+                        op: OP_CREDIT_UPDATE,
+                        typ: TYPE_STREAM,
+                        buf_alloc: GUEST_WINDOW as u32,
+                        fwd_cnt: received.len() as u32,
+                        ..Default::default()
+                    },
+                    &[],
+                );
+            }
+            if !shutdown_seen {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            if shutdown_seen {
+                break;
+            }
+        }
+
+        drop(device);
+        let server_result = server.join().unwrap();
+        assert!(
+            shutdown_seen,
+            "large egress stream did not close gracefully"
+        );
+        assert!(server_result.is_ok(), "large egress writer was cut off");
+        assert!(
+            largest_window <= GUEST_WINDOW,
+            "host queued {largest_window} bytes into an {GUEST_WINDOW}-byte guest window"
+        );
+        assert_eq!(received.len(), PAYLOAD_LEN);
+        assert!(
+            received
+                .iter()
+                .enumerate()
+                .all(|(index, byte)| *byte == (index % 251) as u8),
+            "large egress stream was corrupted"
+        );
+    }
+
+    #[test]
+    fn cancel_clears_transmit_credit_state() {
+        let mut device = dev();
+        device.handle_packet(
+            VsockHdr {
+                src_cid: GUEST_CID,
+                dst_cid: HOST_CID,
+                src_port: 1900,
+                dst_port: mvm_agentd::vsock::EGRESS_PORT,
+                op: OP_CREDIT_UPDATE,
+                typ: TYPE_STREAM,
+                buf_alloc: 64,
+                ..Default::default()
+            },
+            &[],
+        );
+        assert_eq!(
+            device
+                .transport
+                .tx_credit_available(mvm_agentd::vsock::EGRESS_PORT, 1900),
+            64
+        );
+
+        device.cancel();
+
+        assert_eq!(
+            device
+                .transport
+                .tx_credit_available(mvm_agentd::vsock::EGRESS_PORT, 1900),
+            0
+        );
     }
 
     #[test]

--- a/crates/mvm-vmm/src/vmm/vsock_handlers/mod.rs
+++ b/crates/mvm-vmm/src/vmm/vsock_handlers/mod.rs
@@ -65,9 +65,9 @@ impl<'a> VsockHandlerContext<'a> {
         self.transport.consume_tx_credit(host_port, guest_port, n);
     }
 
-    pub(crate) fn evict_idle_recv(&mut self) -> Vec<(u32, u32)> {
+    pub(crate) fn evict_idle_connections(&mut self) -> Vec<(u32, u32)> {
         self.transport
-            .evict_idle_recv()
+            .evict_idle_connections()
             .into_iter()
             .map(|key| (key.host_port, key.guest_port))
             .collect()
@@ -281,7 +281,7 @@ impl VsockHandlerRegistry {
         for handler in self.guest_ports.values_mut() {
             delivered |= handler.drain(ctx).is_some();
         }
-        for (host_port, guest_port) in ctx.evict_idle_recv() {
+        for (host_port, guest_port) in ctx.evict_idle_connections() {
             ctx.queue_host_packet(host_port, guest_port, OP_RST, &[]);
             delivered = true;
         }

--- a/crates/mvm-vmm/src/vmm/vsock_transport.rs
+++ b/crates/mvm-vmm/src/vmm/vsock_transport.rs
@@ -318,23 +318,29 @@ impl VsockTransportCore {
     }
 
     fn evict_idle_connections_at(&mut self, now: Instant) -> Vec<VsockConnectionKey> {
-        let mut expired = Vec::new();
-        self.recv_cnt.retain(|key, credit| {
-            let keep =
-                now.saturating_duration_since(credit.last_activity) < CONNECTION_IDLE_TIMEOUT;
-            if !keep {
-                expired.push(*key);
-            }
-            keep
-        });
-        self.tx_credit.retain(|key, credit| {
-            let keep =
-                now.saturating_duration_since(credit.last_activity) < CONNECTION_IDLE_TIMEOUT;
-            if !keep && !expired.contains(key) {
-                expired.push(*key);
-            }
-            keep
-        });
+        let mut latest_activity =
+            HashMap::with_capacity(self.recv_cnt.len() + self.tx_credit.len());
+        for (key, credit) in &self.recv_cnt {
+            latest_activity.insert(*key, credit.last_activity);
+        }
+        for (key, credit) in &self.tx_credit {
+            latest_activity
+                .entry(*key)
+                .and_modify(|activity| *activity = (*activity).max(credit.last_activity))
+                .or_insert(credit.last_activity);
+        }
+
+        let mut expired: Vec<_> = latest_activity
+            .into_iter()
+            .filter_map(|(key, activity)| {
+                (now.saturating_duration_since(activity) >= CONNECTION_IDLE_TIMEOUT).then_some(key)
+            })
+            .collect();
+        expired.sort_unstable_by_key(|key| (key.host_port, key.guest_port));
+        for key in &expired {
+            self.recv_cnt.remove(key);
+            self.tx_credit.remove(key);
+        }
         expired
     }
 
@@ -1066,6 +1072,43 @@ mod tests {
                 guest_port: 7,
             }]
         );
+        assert!(core.tx_credit.is_empty());
+    }
+
+    #[test]
+    fn transmit_progress_keeps_download_connection_alive_past_receive_idle_timeout() {
+        let mut core = transport();
+        let opened_at = Instant::now();
+        let mut header = VsockHdr {
+            dst_port: 9000,
+            src_port: 7,
+            buf_alloc: 64,
+            ..Default::default()
+        };
+        assert!(core.try_add_recv_at(&header, 1, opened_at));
+        assert!(core.record_tx_credit_at(&header, opened_at));
+
+        let download_active_at = opened_at + CONNECTION_IDLE_TIMEOUT + Duration::from_secs(1);
+        header.fwd_cnt = 64;
+        assert!(core.record_tx_credit_at(&header, download_active_at));
+
+        assert!(
+            core.evict_idle_connections_at(download_active_at)
+                .is_empty(),
+            "fresh transmit progress must keep the whole connection alive"
+        );
+        assert_eq!(core.recv_cnt.len(), 1);
+        assert_eq!(core.tx_credit.len(), 1);
+
+        let wholly_idle_at = download_active_at + CONNECTION_IDLE_TIMEOUT + Duration::from_secs(1);
+        assert_eq!(
+            core.evict_idle_connections_at(wholly_idle_at),
+            vec![VsockConnectionKey {
+                host_port: 9000,
+                guest_port: 7,
+            }]
+        );
+        assert!(core.recv_cnt.is_empty());
         assert!(core.tx_credit.is_empty());
     }
 

--- a/crates/mvm-vmm/src/vmm/vsock_transport.rs
+++ b/crates/mvm-vmm/src/vmm/vsock_transport.rs
@@ -313,16 +313,24 @@ impl VsockTransportCore {
         true
     }
 
-    pub(crate) fn evict_idle_recv(&mut self) -> Vec<VsockConnectionKey> {
-        self.evict_idle_recv_at(Instant::now())
+    pub(crate) fn evict_idle_connections(&mut self) -> Vec<VsockConnectionKey> {
+        self.evict_idle_connections_at(Instant::now())
     }
 
-    fn evict_idle_recv_at(&mut self, now: Instant) -> Vec<VsockConnectionKey> {
+    fn evict_idle_connections_at(&mut self, now: Instant) -> Vec<VsockConnectionKey> {
         let mut expired = Vec::new();
         self.recv_cnt.retain(|key, credit| {
             let keep =
                 now.saturating_duration_since(credit.last_activity) < CONNECTION_IDLE_TIMEOUT;
             if !keep {
+                expired.push(*key);
+            }
+            keep
+        });
+        self.tx_credit.retain(|key, credit| {
+            let keep =
+                now.saturating_duration_since(credit.last_activity) < CONNECTION_IDLE_TIMEOUT;
+            if !keep && !expired.contains(key) {
                 expired.push(*key);
             }
             keep
@@ -337,6 +345,34 @@ impl VsockTransportCore {
         });
     }
 
+    /// Record the receive window advertised by the guest on an incoming packet.
+    /// Every virtio-vsock stream header carries the peer's current `buf_alloc`
+    /// and cumulative `fwd_cnt`, so refreshing this state before dispatch keeps
+    /// host-to-guest writes inside the guest's actual buffer capacity.
+    pub(crate) fn record_tx_credit(&mut self, inbound: &VsockHdr) -> bool {
+        self.record_tx_credit_at(inbound, Instant::now())
+    }
+
+    fn record_tx_credit_at(&mut self, inbound: &VsockHdr, now: Instant) -> bool {
+        let key = VsockConnectionKey {
+            host_port: inbound.dst_port,
+            guest_port: inbound.src_port,
+        };
+        if !self.tx_credit.contains_key(&key) && self.tx_credit.len() >= MAX_CONNECTIONS {
+            return false;
+        }
+        let entry = self.tx_credit.entry(key).or_insert(TxCredit {
+            peer_buf_alloc: inbound.buf_alloc,
+            peer_fwd_cnt: inbound.fwd_cnt,
+            tx_cnt: 0,
+            last_activity: now,
+        });
+        entry.peer_buf_alloc = inbound.buf_alloc;
+        entry.peer_fwd_cnt = inbound.fwd_cnt;
+        entry.last_activity = now;
+        true
+    }
+
     pub(crate) fn tx_credit_available(&self, host_port: u32, guest_port: u32) -> u32 {
         self.tx_credit
             .get(&VsockConnectionKey {
@@ -346,10 +382,9 @@ impl VsockTransportCore {
             .map(|credit| {
                 credit
                     .peer_buf_alloc
-                    .saturating_add(credit.peer_fwd_cnt)
-                    .saturating_sub(credit.tx_cnt)
+                    .saturating_sub(credit.tx_cnt.wrapping_sub(credit.peer_fwd_cnt))
             })
-            .unwrap_or(HOST_BUF_ALLOC)
+            .unwrap_or(0)
     }
 
     pub(crate) fn consume_tx_credit(&mut self, host_port: u32, guest_port: u32, n: u32) {
@@ -357,7 +392,7 @@ impl VsockTransportCore {
             host_port,
             guest_port,
         }) {
-            credit.tx_cnt = credit.tx_cnt.saturating_add(n);
+            credit.tx_cnt = credit.tx_cnt.wrapping_add(n);
             credit.last_activity = Instant::now();
         }
     }
@@ -367,6 +402,14 @@ impl VsockTransportCore {
             host_port,
             guest_port,
         });
+    }
+
+    pub(crate) fn clear_tx_credit(&mut self) {
+        self.tx_credit.clear();
+    }
+
+    pub(crate) fn has_tx_credit(&self) -> bool {
+        !self.tx_credit.is_empty()
     }
 
     pub(crate) fn queue_host_packet(
@@ -913,13 +956,117 @@ mod tests {
         );
 
         assert_eq!(
-            core.evict_idle_recv_at(now),
+            core.evict_idle_connections_at(now),
             vec![VsockConnectionKey {
                 host_port: 9000,
                 guest_port: 7,
             }]
         );
         assert!(core.recv_cnt.is_empty());
+    }
+
+    #[test]
+    fn unknown_transmit_credit_fails_closed() {
+        let core = transport();
+        assert_eq!(core.tx_credit_available(9000, 7), 0);
+    }
+
+    #[test]
+    fn transmit_credit_stops_at_the_window_and_resumes_on_forward_progress() {
+        let mut core = transport();
+        let mut header = VsockHdr {
+            dst_port: 9000,
+            src_port: 7,
+            buf_alloc: 64,
+            ..Default::default()
+        };
+        assert!(core.record_tx_credit(&header));
+        assert_eq!(core.tx_credit_available(9000, 7), 64);
+
+        core.consume_tx_credit(9000, 7, 64);
+        assert_eq!(core.tx_credit_available(9000, 7), 0);
+
+        header.fwd_cnt = 64;
+        assert!(core.record_tx_credit(&header));
+        assert_eq!(core.tx_credit_available(9000, 7), 64);
+    }
+
+    #[test]
+    fn transmit_credit_counters_wrap_without_reopening_the_window_early() {
+        let mut core = transport();
+        let key = VsockConnectionKey {
+            host_port: 9000,
+            guest_port: 7,
+        };
+        core.tx_credit.insert(
+            key,
+            TxCredit {
+                peer_buf_alloc: 64,
+                peer_fwd_cnt: u32::MAX - 31,
+                tx_cnt: u32::MAX - 31,
+                last_activity: Instant::now(),
+            },
+        );
+
+        core.consume_tx_credit(9000, 7, 64);
+        assert_eq!(core.tx_credit_available(9000, 7), 0);
+
+        assert!(core.record_tx_credit(&VsockHdr {
+            dst_port: 9000,
+            src_port: 7,
+            buf_alloc: 64,
+            fwd_cnt: 32,
+            ..Default::default()
+        }));
+        assert_eq!(core.tx_credit_available(9000, 7), 64);
+    }
+
+    #[test]
+    fn transmit_credit_table_refuses_new_connections_at_the_cap() {
+        let mut core = transport();
+        for guest_port in 0..MAX_CONNECTIONS as u32 {
+            assert!(core.record_tx_credit(&VsockHdr {
+                dst_port: 9000,
+                src_port: guest_port,
+                buf_alloc: 64,
+                ..Default::default()
+            }));
+        }
+
+        let refused_port = MAX_CONNECTIONS as u32;
+        assert!(!core.record_tx_credit(&VsockHdr {
+            dst_port: 9000,
+            src_port: refused_port,
+            buf_alloc: u32::MAX,
+            ..Default::default()
+        }));
+        assert_eq!(core.tx_credit_available(9000, refused_port), 0);
+        assert_eq!(core.tx_credit.len(), MAX_CONNECTIONS);
+    }
+
+    #[test]
+    fn idle_transmit_credit_is_evicted_and_releases_identity() {
+        let mut core = transport();
+        let now = Instant::now();
+        let header = VsockHdr {
+            dst_port: 9000,
+            src_port: 7,
+            buf_alloc: 64,
+            ..Default::default()
+        };
+        assert!(core.record_tx_credit_at(
+            &header,
+            now - CONNECTION_IDLE_TIMEOUT - Duration::from_secs(1)
+        ));
+
+        assert_eq!(
+            core.evict_idle_connections_at(now),
+            vec![VsockConnectionKey {
+                host_port: 9000,
+                guest_port: 7,
+            }]
+        );
+        assert!(core.tx_credit.is_empty());
     }
 
     // ---- TX virtio-queue migration: differential equivalence ----------------

--- a/crates/mvm-vmm/src/vsock_egress_bridge/substitution_bridge.rs
+++ b/crates/mvm-vmm/src/vsock_egress_bridge/substitution_bridge.rs
@@ -25,7 +25,8 @@ use crate::vmm::vsock_transport::MAX_CONNECTIONS;
 pub(crate) const READ_CHUNK: usize = 16 * 1024;
 /// Maximum number of active raw/SOCKS5/DNS/substitution streams per workload.
 pub(crate) const MAX_EGRESS_STREAMS: usize = 128;
-/// Sustained egress byte budget shared by all host-mediated workload streams.
+/// Sustained egress byte rate shared by all host-mediated workload streams.
+/// This is a refillable throughput limit, not a cumulative download-size cap.
 pub(crate) const EGRESS_BYTES_PER_SECOND: u64 = 4 * 1024 * 1024;
 /// Maximum burst accepted before the sustained budget must refill.
 pub(crate) const EGRESS_BURST_BYTES: u64 = 8 * 1024 * 1024;
@@ -611,6 +612,20 @@ mod tests {
             now + Duration::from_secs(1)
         ));
         assert!(!budget.try_consume_at(1, now + Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn egress_budget_has_no_lifetime_download_cap() {
+        const FOUR_GIB: u64 = 4 * 1024 * 1024 * 1024;
+
+        let now = Instant::now();
+        let budget = EgressBudget::new_at(now);
+        let chunk = usize::try_from(EGRESS_BYTES_PER_SECOND).unwrap();
+        let seconds = FOUR_GIB / EGRESS_BYTES_PER_SECOND;
+
+        for second in 0..seconds {
+            assert!(budget.try_consume_at(chunk, now + Duration::from_secs(second)));
+        }
     }
 
     #[test]

--- a/features/suites/s2_egress_vsock/hvf_egress_observable.feature
+++ b/features/suites/s2_egress_vsock/hvf_egress_observable.feature
@@ -13,6 +13,12 @@ Feature: HVF admitted egress is observable and does not hang
     And the output contains "httpbin.org"
 
   @live
+  Scenario: A multi-wheel pandas install arrives without truncation
+    When I run mvmctl with "machine run --image python:3.12 --allow-host pypi.org:443 --allow-host files.pythonhosted.org:443 -- python -m pip install --no-cache-dir pandas" with a 300 second timeout
+    Then the command exits with code 0
+    And the output contains "Successfully installed"
+
+  @live
   Scenario: Substitution endpoint diagnostics are written to /tmp
     When I run mvmctl with "machine run --name bdd-subst-log --image alpine --allow-host httpbin.org -- wget -q -O - https://httpbin.org/get" with a 120 second timeout
     Then the command exits with code 0

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -31,6 +31,19 @@ for detailed scope and acceptance criteria.
       first-use restore-fault, and cross-backend evidence remain open.
 
 ## In-flight plans
+- [~] Plan 315 — HVF virtio-vsock transmit-credit regression
+      (`specs/plans/315-hvf-vsock-credit-regression.md`)
+  - [x] Restore bounded guest credit recording, fail-closed unknown-credit
+        behavior, protocol counter wrapping, and complete state teardown
+  - [x] Prove first-window stop/resume and byte-for-byte 32 MiB delivery;
+        prove no lifetime quota over a simulated 4 GiB transfer; add the live
+        documented pandas-install scenario
+  - [x] Pass all 445 `mvm-vmm` tests, the serial aggregate workspace suite,
+        workspace check, macOS workspace all-target Clippy, and the focused
+        x86_64 Linux cross-build
+  - [ ] Run Linux-native workspace Clippy/tests in the project builder
+        environment
+
 - [x] Plan 2167 — durable agent session and event contract
       (`specs/plans/2167-agent-session-contract.md`)
   - [x] Versioned public IDs, lifecycle commands, durable/ephemeral event

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -36,9 +36,10 @@ for detailed scope and acceptance criteria.
   - [x] Restore bounded guest credit recording, fail-closed unknown-credit
         behavior, protocol counter wrapping, and complete state teardown
   - [x] Prove first-window stop/resume and byte-for-byte 32 MiB delivery;
-        prove no lifetime quota over a simulated 4 GiB transfer; add the live
-        documented pandas-install scenario
-  - [x] Pass all 445 `mvm-vmm` tests, the serial aggregate workspace suite,
+        prove no lifetime quota over a simulated 4 GiB transfer; prove active
+        download credit prevents request-side idle eviction after 60 seconds;
+        add the live documented pandas-install scenario
+  - [x] Pass all 446 `mvm-vmm` tests, the serial aggregate workspace suite,
         workspace check, macOS workspace all-target Clippy, and the focused
         x86_64 Linux cross-build
   - [ ] Run Linux-native workspace Clippy/tests in the project builder

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -15,12 +15,15 @@
       its relay-side readers remained. Every guest header refreshes the actual
       `buf_alloc`/`fwd_cnt` window before dispatch; unknown credit fails closed,
       32-bit counters wrap per the protocol, and connection/device teardown,
-      idle eviction, and snapshot guards cover the new state. The focused
+      connection-wide idle eviction, and snapshot guards cover the new state.
+      Active traffic in either direction keeps the whole stream alive, so a
+      download is not reset merely because its request side has been quiet for
+      60 seconds. The focused
       suite proves stop/resume behavior and byte-for-byte delivery of a 32 MiB
       reply; a simulated continuous 4 GiB transfer proves the refillable rate
       budget is not a lifetime quota. A live BDD scenario pins the documented
       `python:3.12` pandas
-      install through PyPI. All 445 `mvm-vmm` tests, workspace check, macOS
+      install through PyPI. All 446 `mvm-vmm` tests, workspace check, macOS
       workspace all-target Clippy, the serial aggregate workspace suite, and
       the focused x86_64 Linux cross-build are green. Linux-native builder-VM
       tests and all-target Clippy remain the final platform gates.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,21 @@
 
 ## Current issue delivery
 
+- [~] HVF large-response integrity — **plan 315**. Restored bounded
+      virtio-vsock host-to-guest credit accounting that had been removed while
+      its relay-side readers remained. Every guest header refreshes the actual
+      `buf_alloc`/`fwd_cnt` window before dispatch; unknown credit fails closed,
+      32-bit counters wrap per the protocol, and connection/device teardown,
+      idle eviction, and snapshot guards cover the new state. The focused
+      suite proves stop/resume behavior and byte-for-byte delivery of a 32 MiB
+      reply; a simulated continuous 4 GiB transfer proves the refillable rate
+      budget is not a lifetime quota. A live BDD scenario pins the documented
+      `python:3.12` pandas
+      install through PyPI. All 445 `mvm-vmm` tests, workspace check, macOS
+      workspace all-target Clippy, the serial aggregate workspace suite, and
+      the focused x86_64 Linux cross-build are green. Linux-native builder-VM
+      tests and all-target Clippy remain the final platform gates.
+
 - [ ] Launch critical-path waste on real-sized images — **issues #2273–#2276,
       plan 311**. Plan 299's prepared-cold baseline runs `alpine`, whose cached
       rootfs is 9.9 MB, and reports the ≤200 ms p50 contract as met. Three

--- a/specs/plans/315-hvf-vsock-credit-regression.md
+++ b/specs/plans/315-hvf-vsock-credit-regression.md
@@ -1,0 +1,72 @@
+# Plan 315 — HVF virtio-vsock transmit-credit regression
+
+## Status
+
+**Implementation complete; platform gates pending.** Opened 2026-08-10 after
+the documented README `pandas` example reproduced a PyPI wheel hash mismatch
+on the HVF backend. The package index and TLS endpoint are not the source of
+the mismatch: the current `mvm-vmm` transport retained transmit-credit readers
+and consumers, but no longer recorded the guest's advertised `buf_alloc` and
+`fwd_cnt` values.
+
+## Root cause
+
+Commit `1a515ae44` added per-connection host-to-guest credit tracking and tests
+for a 10 MiB lossless relay plus credit exhaustion/resumption. Commit
+`ca68dd9c0` removed `VsockTransportCore::record_tx_credit`, its call before
+packet dispatch, and both regression tests while retaining the rest of the
+credit-limited relay. Consequently `tx_credit_available` always falls back to
+`HOST_BUF_ALLOC`, `consume_tx_credit` has no map entry to update, and a fast
+host response can overrun the guest receive window.
+
+## Scope and acceptance
+
+- [x] Restore bounded per-connection recording of every guest packet's
+      advertised transmit credit before handler dispatch.
+- [x] Clear transmit-credit state whenever a connection or the device is torn
+      down, including snapshot preparation.
+- [x] Restore focused tests proving the host stops at the advertised window,
+      resumes only after `OP_CREDIT_UPDATE`, and removes state on teardown.
+- [x] Restore a multi-megabyte deterministic relay test that proves byte-for-byte
+      delivery without truncation.
+- [x] Add a live BDD scenario for the documented `python:3.12` + `pandas`
+      workflow through the admitted PyPI hosts.
+- [x] Run focused `mvm-vmm` tests on the macOS host.
+- [x] Run `cargo test --workspace` and `cargo check --workspace` on the macOS
+      host.
+- [ ] Run workspace all-target Clippy and the Linux-gated `mvm-vmm` tests in
+      the project builder VM.
+- [x] Record the repair in `specs/SPRINT.md` and
+      `specs/REFACTOR-STATUS.md`.
+
+## Verification evidence
+
+- `cargo test -p mvm-vmm --quiet`: 445 passed.
+- The focused credit group covers counter wrap, table bound,
+  idle eviction, teardown, first-window stop/resume, and the deterministic
+  32 MiB byte-for-byte relay. A separate token-bucket witness simulates a
+  continuous 4 GiB transfer to prove the throughput budget has no lifetime
+  download quota.
+- `cargo check --workspace`: passed.
+- `cargo clippy --workspace --all-targets -- -D warnings` on macOS: passed.
+- `cargo zigbuild --target x86_64-unknown-linux-gnu -p mvm-vmm --lib
+  --all-features` with the pinned Rust 1.96 toolchain: passed.
+- `cargo test --workspace -- --test-threads=1`: passed, including all doctests.
+  The serial run passed both `mvm-hostd` isolation tests that had failed in
+  separate earlier aggregate runs and then passed alone.
+- The non-live BDD run parsed the new live scenario and passed 170 of 172
+  runnable scenarios. Its two failures are the TypeScript SDK fixtures, whose
+  generated `dist/index.js` was not built because the direct safe runner did
+  not execute `just bdd`'s npm preparation steps.
+- The broader Linux workspace cross-build is currently blocked outside this
+  plan by `mvm-sdk`'s `SubprocessBackend` missing the all-features
+  `backend_capabilities` trait method. The macOS 26 execution tier has no
+  interactive project builder-VM command path, so Linux-native tests and
+  all-target Clippy remain open for CI or a builder-enabled session.
+
+## Non-goals
+
+- Changing the public egress policy or `--allow-host` semantics.
+- Disabling pip hash verification or retrying corrupted downloads.
+- Adding a second network path around the existing vsock-only boundary.
+- Changing Plan 313's response-streaming or usage-accounting scope.

--- a/specs/plans/315-hvf-vsock-credit-regression.md
+++ b/specs/plans/315-hvf-vsock-credit-regression.md
@@ -27,6 +27,8 @@ host response can overrun the guest receive window.
       down, including snapshot preparation.
 - [x] Restore focused tests proving the host stops at the advertised window,
       resumes only after `OP_CREDIT_UPDATE`, and removes state on teardown.
+- [x] Treat activity in either direction as connection activity so a long
+      download survives beyond the request side's 60-second idle timeout.
 - [x] Restore a multi-megabyte deterministic relay test that proves byte-for-byte
       delivery without truncation.
 - [x] Add a live BDD scenario for the documented `python:3.12` + `pandas`
@@ -41,12 +43,14 @@ host response can overrun the guest receive window.
 
 ## Verification evidence
 
-- `cargo test -p mvm-vmm --quiet`: 445 passed.
+- `cargo test -p mvm-vmm --quiet`: 446 passed.
 - The focused credit group covers counter wrap, table bound,
-  idle eviction, teardown, first-window stop/resume, and the deterministic
-  32 MiB byte-for-byte relay. A separate token-bucket witness simulates a
-  continuous 4 GiB transfer to prove the throughput budget has no lifetime
-  download quota.
+  connection-wide idle eviction, teardown, first-window stop/resume, and the
+  deterministic 32 MiB byte-for-byte relay. A zero-wait clock witness advances
+  beyond 60 seconds and proves transmit progress keeps a download connection
+  alive while wholly idle connections are still removed. A separate
+  token-bucket witness simulates a continuous 4 GiB transfer to prove the
+  throughput budget has no lifetime download quota.
 - `cargo check --workspace`: passed.
 - `cargo clippy --workspace --all-targets -- -D warnings` on macOS: passed.
 - `cargo zigbuild --target x86_64-unknown-linux-gnu -p mvm-vmm --lib


### PR DESCRIPTION
## Summary

- restore bounded host-to-guest virtio-vsock transmit-credit tracking on the HVF path
- stop sending when the guest-advertised window is exhausted and resume after forward progress
- treat traffic in either direction as connection activity so active downloads are not reset after 60 seconds of request-side silence
- handle 32-bit credit-counter wrapping, bounded connection state, connection-wide idle eviction, teardown, and snapshot safety
- add regression coverage for a byte-for-byte 32 MiB response, a simulated continuous 4 GiB transfer, a download active beyond the idle timeout, and the documented pandas/PyPI workflow

## Root cause

The transport still consumed guest transmit-credit state, but the code that recorded each packet's `buf_alloc` and `fwd_cnt` had been removed. The host therefore fell back to a fixed 256 KiB allowance and could overrun the guest receive window during fast multi-megabyte responses. The resulting truncation surfaced as pip's package hash-mismatch error.

The initial fix also exposed an independent long-transfer edge case: receive-side and transmit-side activity were evicted separately. A download could therefore be reset once its small request had been quiet for 60 seconds even while transmit credit was still advancing.

## Impact

Large downloads are now streamed across a sliding credit window rather than being treated as if the first window were the total transfer allowance. Active progress in either direction keeps the connection alive, while wholly idle connections are still removed. Unknown or exhausted credit fails closed instead of risking silent corruption. The existing refillable egress rate remains a throughput control, not a cumulative download quota.

## Validation

- `cargo test -p mvm-vmm --quiet` — 446 passed
- `cargo test --workspace -- --test-threads=1` — passed, including doctests
- `cargo check --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed via the pre-commit gate on macOS
- `cargo clippy -p mvm-vmm --all-targets -- -D warnings` — passed
- `cargo zigbuild --target x86_64-unknown-linux-gnu -p mvm-vmm --lib --all-features` — passed with Rust 1.96
- pre-commit formatting and workspace Clippy gates — passed

Linux-native builder-VM tests and all-target Clippy remain for CI because this macOS execution tier does not expose an interactive project builder-VM command path.
