### PR TITLE
feat(dx): add `just worktrees-prune` to remove worktrees that are finished

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -562,6 +562,62 @@ clean-dev-state:
 worktrees *ARGS:
     ./scripts/worktree-status.sh {{ ARGS }}
 
+# Remove worktrees the classifier calls finished — preview by default, APPLY=1 to do it
+worktrees-prune:
+    #!/usr/bin/env bash
+    # Separate from `just worktrees`, which is read-only and says so in its own
+    # header. Classifying and deleting are different risks, so they stay
+    # different commands. This one only ever acts on paths that classifier
+    # already called SAFE: the PR merged, and this tip is exactly the merged head.
+    #
+    # Previews by default. `clean-dev-state` is the other way round (DRY_RUN=1)
+    # because its blast radius is one regenerable directory; here it is whole
+    # checkouts, so the cautious mode is the one you get without asking.
+    #
+    # Never passes --force, so git independently refuses any worktree with
+    # uncommitted or untracked files — a second veto behind the classifier.
+    # Branches are kept: removing a worktree does not touch its commits, so
+    # anything that never landed stays reachable by branch name.
+    set -euo pipefail
+    paths=$(./scripts/worktree-status.sh --safe-only)
+    if [ -z "$paths" ]; then
+        echo "worktrees-prune: nothing finished to remove"
+        exit 0
+    fi
+    # Snapshot the process list ONCE. Grepping ps per path inside the loop looks
+    # equivalent and is not: the grep's own argv holds the path it searches for,
+    # so every worktree matches itself and the whole set reads as busy.
+    ps_snapshot=$(ps -eo command 2>/dev/null || true)
+    removed=0
+    while IFS= read -r p; do
+        [ -d "$p" ] || continue
+        # Re-checked at the moment of action: the classification is seconds old,
+        # and a session may have started work in one since.
+        case "$ps_snapshot" in
+            *"$p"*) echo "  skip (in use)     $(basename "$p")"; continue ;;
+        esac
+        if [ -n "$(git -C "$p" status --porcelain 2>/dev/null)" ]; then
+            echo "  skip (now dirty)  $(basename "$p")"; continue
+        fi
+        size=$(du -sh "$p" 2>/dev/null | cut -f1 | tr -d ' ')
+        if [ -z "${APPLY:-}" ]; then
+            echo "  would remove      $(basename "$p")  (${size})"
+            continue
+        fi
+        if git worktree remove "$p" 2>/tmp/wtprune-err.$$; then
+            echo "  removed           $(basename "$p")  (${size})"
+            removed=$((removed + 1))
+        else
+            echo "  refused           $(basename "$p"): $(head -1 /tmp/wtprune-err.$$)"
+        fi
+        rm -f /tmp/wtprune-err.$$
+    done <<< "$paths"
+    if [ -z "${APPLY:-}" ]; then
+        echo "worktrees-prune: preview only — re-run with APPLY=1 to remove"
+    else
+        echo "worktrees-prune: removed ${removed}; branches kept"
+    fi
+
 # Reap leaked host-side helper subprocesses (broker/host-agent/signer/etc.)
 # older than N minutes (default 30). Backstop for the in-binary parent-death
 # watchdog; clears orphans from past test runs across worktrees. DRY_RUN=1 to

--- a/scripts/worktree-status.sh
+++ b/scripts/worktree-status.sh
@@ -45,6 +45,13 @@ fi
 # Snapshot the process list ONCE, up front. Grepping `ps` per worktree inside
 # the loop looks equivalent and is not: the grep's own argv contains the path it
 # is searching for, so every worktree matches itself and everything looks busy.
+#
+# The match is deliberately coarse: any process whose command line *mentions* a
+# worktree path counts as using it, including a shell that merely names it in an
+# argument. That over-protects — such a worktree reports KEEP and is never
+# offered for removal — which is the right direction for a check whose wrong
+# answer should be "left it alone". It does mean a path you just typed
+# somewhere can read as busy until that process exits.
 ps_snapshot=$(ps -eo command 2>/dev/null || true)
 
 [ "$safe_only" -eq 1 ] || printf '%-40s %-34s %-14s %s\n' WORKTREE BRANCH PR VERDICT


### PR DESCRIPTION
`just worktrees` classifies but never deletes, so removing the finished ones meant hand-assembling a pipe into `git worktree remove`. I argued for that separation deliberately when I wrote it, and a day of evidence says I was half wrong: **eleven finished worktrees accumulated in about 24 hours**, and a disk that had just been cleared went back down by half a terabyte. A cleanup step people have to assemble themselves is one that does not happen — which is how this repo reached 99% full in the first place.

## Behaviour

`just worktrees-prune` **previews by default**; `APPLY=1 just worktrees-prune` acts.

That is the inverse of `clean-dev-state` (`DRY_RUN=1`), on purpose: that one removes a single regenerable directory, this one removes whole checkouts, so the cautious mode is the one you get without asking for it.

## Guards, each made to fire before this landed

| Guard | Verified |
|---|---|
| Only paths the classifier calls **SAFE** (PR merged, tip == merged head) | fixture appeared only when clean |
| **Never `--force`** — git independently refuses a dirty worktree | dirty → dropped from list; clean → back in |
| **Re-checks liveness and dirtiness at removal time**, not from a stale classification | `ps` snapshotted once, then re-read per path |
| **Branches kept** | removed a fixture worktree, confirmed `tmp/prune-fixture` still resolved |

End-to-end: `APPLY=1` removed 13 worktrees (40 → 27), leaving **0 SAFE** and **all open PRs intact**.

## A property of the liveness check, found while testing it

My fixture kept reporting `KEEP (a process is running in it)` — because **my own test command named its path**, so it appeared in the `ps` snapshot. The match is coarse: any process whose command line *mentions* a worktree counts as using it.

That errs toward keeping, which is the right direction for a check whose wrong answer should be "left it alone". But it is surprising enough to document, so it is now written next to the snapshot.

## Note on testing this

The worktree set churns while you look at it. An early guard test produced three impossible zeros because other sessions created and merged worktrees between consecutive runs — `git worktree list | grep -c mvm-2293` returned 2 at one point. That was a racing measurement, not a failing guard, which is why the verification above uses a fixture rather than whatever happened to be on disk.

shellcheck clean; `check-no-spec-refs-in-comments` and `check-honesty` pass. No Rust changed.