### PR TITLE
fix(cli): clarify workload-kernel artifact recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,23 @@ Nix store still warm.
 For an interactive shell you want a *workload* microVM, not the builder — use a
 transient run against a dev-tier image: `mvmctl machine run --image alpine -it -- /bin/sh`.
 
+On the first image-backed run, mvm may build and cache the workload kernel
+through Stage 0. If the output includes `builder egress endpoint ... exited
+with status signal: 15 (SIGTERM)`, that line is normally cleanup: the
+host-side builder egress endpoint is terminated after the one-shot Stage 0
+build exits. The actionable error is the following one. In particular, a
+message saying that the resolved workload kernel has no device-mapper/dm-verity
+support means the cached kernel cannot boot a verity-sealed workload. Rebuild
+or download the workload kernel explicitly:
+
+```bash
+# Use the release's hash-verified kernel
+mvmctl build kernel build --which workload --source download
+
+# Or compile the host-architecture kernel from this source checkout
+mvmctl build kernel build --which workload --source compile
+```
+
 ### Examples
 
 Working example workloads live in [`examples/`](examples/) — build any of them

--- a/crates/mvm-cli/src/commands/env/artifact_verify.rs
+++ b/crates/mvm-cli/src/commands/env/artifact_verify.rs
@@ -181,6 +181,23 @@ pub(super) fn curl_download_args(dest: &str, url: &str) -> Vec<String> {
     ]
 }
 
+fn download_failure_message() -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    format!(
+        "Download failed. Published artifacts for v{version} may not yet be\n\
+         available — release tags are pushed before the artifact-build matrix\n\
+         completes, so a 404 often means publishing is still in progress.\n\
+         Check the release page or retry in a few minutes:\n\
+         \n\
+         \x20   https://github.com/tinylabscom/mvm/releases/tag/v{version}\n\
+         \n\
+         mvm manages its own Linux builder; no host Nix configuration is required.\n\
+         If you are developing from a source checkout, use the\n\
+         mvmctl binary built from that checkout so it bootstraps the project\n\
+         builder VM from the in-repo image source."
+    )
+}
+
 /// Download a file from a URL using curl, resuming a partial `dest`.
 pub(super) fn download_file(url: &str, dest: &str) -> Result<()> {
     let status = std::process::Command::new("curl")
@@ -196,25 +213,7 @@ pub(super) fn download_file(url: &str, dest: &str) -> Result<()> {
         // run. It's never hash-accepted while incomplete — verify runs
         // only after a successful download, and the SHA-256 gate deletes
         // on mismatch — so leaving it is safe and saves re-fetching.
-        anyhow::bail!(
-            "Download failed. Pre-built images for v{version} may not yet be\n\
-             published — release tags are pushed before the artifact-build\n\
-             matrix completes, so a 404 here often just means the build is\n\
-             still in flight. Check the release page or retry in a few\n\
-             minutes:\n\
-             \n\
-             \x20   https://github.com/tinylabscom/mvm/releases/tag/v{version}\n\
-             \n\
-             To build locally instead, set up a Nix Linux builder:\n\
-             \n\
-             \x20 Option 1 — Temporary (run in another terminal):\n\
-             \x20   nix run 'nixpkgs#darwin.linux-builder'\n\
-             \n\
-             \x20 Option 2 — Permanent (add to /etc/nix/nix.conf):\n\
-             \x20   builders = ssh-ng://builder@linux-builder aarch64-linux /etc/nix/builder_ed25519 4 1 kvm,big-parallel - -\n\
-             \x20   builders-use-substitutes = true",
-            version = env!("CARGO_PKG_VERSION")
-        );
+        anyhow::bail!("{}", download_failure_message());
     }
     Ok(())
 }
@@ -239,6 +238,21 @@ mod tests {
         );
         assert!(args.contains(&"-fSL".to_string()));
         assert_eq!(args.last().unwrap(), "https://example/x");
+    }
+
+    #[test]
+    fn download_failure_guidance_uses_mvm_managed_builder_without_sudo() {
+        let message = download_failure_message();
+
+        assert!(message.contains("mvm manages its own Linux builder"));
+        assert!(message.contains("no host Nix configuration is required"));
+        assert!(message.contains("https://github.com/tinylabscom/mvm/releases/tag/v"));
+        for forbidden in ["sudo", "darwin.linux-builder", "/etc/nix"] {
+            assert!(
+                !message.contains(forbidden),
+                "download recovery guidance must not recommend {forbidden}: {message}"
+            );
+        }
     }
 
     /// Compute the canonical lowercase-hex SHA-256 of a byte slice. Tests

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -1563,8 +1563,11 @@ mod tests {
     /// Isolate `MVM_HOME` and write an operator config carrying `ceiling`.
     ///
     /// Admission reads the ceiling from host config rather than from a
-    /// parameter, so a test that wants a bounded host has to *be* one. Returns
-    /// the guard and the home dir; both must outlive the admission call.
+    /// parameter, so a test that wants a bounded host has to *be* one. Every
+    /// test that reaches `admit_for_run` or `admit_and_start` must hold the
+    /// returned guard, including tests using the default ceiling; otherwise it
+    /// can observe another parallel test's process-wide `MVM_HOME`. The guard
+    /// and home dir must both outlive the admission call.
     fn host_with_ceiling(
         ceiling: mvm_contract::grants::ceiling::GrantCeiling,
     ) -> (mvm_core::util::test_env::TestEnv, tempfile::TempDir) {
@@ -1985,6 +1988,7 @@ mod tests {
 
     #[test]
     fn happy_path_returns_admitted_plan_with_plan_id() {
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let clock = SystemClock;
         let ledger = InMemoryNonceLedger::new();
@@ -2010,6 +2014,7 @@ mod tests {
 
     #[test]
     fn admitted_plan_id_is_a_content_address() {
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let admitted = admit_for_run(
             &fixture_input("vm1"),
@@ -2081,6 +2086,7 @@ mod tests {
 
     #[test]
     fn admitted_plan_signed_field_round_trips_through_verify() {
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let admitted = admit_for_run(
             &fixture_input("vm1"),
@@ -2119,6 +2125,7 @@ mod tests {
 
     #[test]
     fn two_distinct_admit_calls_produce_distinct_plan_ids_and_nonces() {
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let clock = SystemClock;
         let ledger = InMemoryNonceLedger::new();
@@ -2245,6 +2252,7 @@ mod tests {
         // Generate the publisher key out of band, build a bundle,
         // enrol the pubkey in the trust store, hand admit_for_run a
         // matching pin + context.
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let sk = {
             let mut __ed_seed = [0u8; 32];
@@ -2279,6 +2287,7 @@ mod tests {
         // mvmctl up path didn't wire a BundleAdmissionContext. The
         // admit path refuses rather than silently skipping the
         // re-verify step (fail closed, not fail open).
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let sk = {
             let mut __ed_seed = [0u8; 32];
@@ -2301,6 +2310,7 @@ mod tests {
 
     #[test]
     fn admit_with_unknown_publisher_in_trust_store_refuses() {
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let sk = {
             let mut __ed_seed = [0u8; 32];
@@ -2338,6 +2348,7 @@ mod tests {
         // Resolver returns a different archive than the pin describes.
         // The bundle_sha256 cross-check catches it before the
         // signature verify even runs.
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let sk = {
             let mut __ed_seed = [0u8; 32];
@@ -2372,6 +2383,7 @@ mod tests {
     #[test]
     fn thread_tenant_id_sets_only_tenant_label_not_the_bridge_plan() {
         use mvm_core::vm_backend::VmStartConfig;
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let admitted = admit_for_run(
             &fixture_input("vm-tenant-only"),
@@ -2407,6 +2419,7 @@ mod tests {
     #[test]
     fn populate_audit_substrate_threads_tenant_and_signed_envelope() {
         use mvm_core::vm_backend::VmStartConfig;
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let clock = SystemClock;
         let ledger = InMemoryNonceLedger::new();
@@ -2448,6 +2461,7 @@ mod tests {
         // policy_bundle arg, NOT from `admitted.plan().bundle` (the .mvmpkg
         // PlanArtifact pin, a different bundle verified separately).
         use mvm_core::vm_backend::VmStartConfig;
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let clock = SystemClock;
         let ledger = InMemoryNonceLedger::new();
@@ -2599,6 +2613,7 @@ mod tests {
 
     #[test]
     fn caller_audit_labels_flow_through_admission() {
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let mut input = fixture_input("vm-label");
         input.audit_labels.insert(
@@ -2799,6 +2814,7 @@ mod tests {
 
     #[test]
     fn admit_and_start_admits_then_boots_on_mock() {
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let backend = mvm_runtime::AnyBackend::from_hypervisor("mock");
         let ledger = InMemoryNonceLedger::new();
@@ -2841,6 +2857,7 @@ mod tests {
     #[test]
     fn the_admitted_grant_reaches_the_launch_config_and_a_caller_supplied_one_does_not() {
         use mvm_core::vm_backend::VmStartConfig;
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let mut input = fixture_input("vm-grant-threaded");
         let grants = mvm_contract::grants::Grants {
@@ -2876,6 +2893,7 @@ mod tests {
     #[test]
     fn an_ungranted_plan_clears_a_caller_supplied_bound() {
         use mvm_core::vm_backend::VmStartConfig;
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let admitted = admit_for_run(
             &fixture_input("vm-no-grant"),
@@ -2901,6 +2919,7 @@ mod tests {
     /// a bound nobody reports is indistinguishable from a bound nobody applied.
     #[test]
     fn an_admitted_boot_records_the_tier_that_bounded_it() {
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let backend = mvm_runtime::AnyBackend::from_hypervisor("mock");
         let ledger = InMemoryNonceLedger::new();
@@ -2937,6 +2956,7 @@ mod tests {
     /// trail alone must not have to take the caller's word for it.
     #[test]
     fn an_admitted_boot_writes_the_achieved_tier_to_the_audit_chain() {
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let backend = mvm_runtime::AnyBackend::from_hypervisor("mock");
         let ledger = InMemoryNonceLedger::new();
@@ -3040,6 +3060,7 @@ mod tests {
     fn a_required_admission_record_that_cannot_be_written_stops_the_boot() {
         use crate::audit::durability::AuditDurability;
 
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let backend = mvm_runtime::AnyBackend::from_hypervisor("mock");
         let ledger = InMemoryNonceLedger::new();
@@ -3094,6 +3115,7 @@ mod tests {
     fn a_best_effort_admission_record_does_not_stop_the_boot() {
         use crate::audit::durability::AuditDurability;
 
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let backend = mvm_runtime::AnyBackend::from_hypervisor("mock");
         let ledger = InMemoryNonceLedger::new();
@@ -3136,6 +3158,7 @@ mod tests {
     #[test]
     fn admit_and_start_refuses_unadmitted_volume_before_boot() {
         use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let backend = mvm_runtime::AnyBackend::from_hypervisor("mock");
         let ledger = InMemoryNonceLedger::new();

--- a/features/suites/s8_readme_contract/readme_coverage.toml
+++ b/features/suites/s8_readme_contract/readme_coverage.toml
@@ -31,6 +31,10 @@ classification = "cli-bdd"
 language = "bash"
 
 [[block]]
+classification = "cli-bdd"
+language = "bash"
+
+[[block]]
 classification = "nix-static"
 language = "nix"
 

--- a/public/src/content/docs/guides/kernels.md
+++ b/public/src/content/docs/guides/kernels.md
@@ -46,6 +46,20 @@ When the kernel was compiled locally, the cache directory also carries a
 resolved `config` sidecar and `kernel-metrics-<arch>.json`, so you can inspect
 the exact `olddefconfig` result without a CI round-trip.
 
+### Troubleshooting a first-run kernel failure
+
+The first image-backed run may build the workload kernel through Stage 0. If
+the output says `builder egress endpoint ... exited with status signal: 15
+(SIGTERM)`, that is normally the host-side egress endpoint being stopped as
+Stage 0 cleans up. It is not, by itself, a workload boot failure.
+
+Treat a following error such as `resolved workload kernel ... carries no
+device-mapper/dm-verity support` as the real failure. Workloads boot from a
+verity-sealed root and require the workload kernel's device-mapper and
+dm-verity support; a builder kernel cannot be used for this purpose. Rebuild
+the workload variant with `--which workload`, or download the matching
+published kernel.
+
 ## Inspect resolved configs and metrics
 
 ```bash

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -109,6 +109,37 @@ mvmctl machine run --flake <project-dir> --name <name> -d
 
 ## Build Issues
 
+### Workload kernel error is preceded by `SIGTERM`
+
+On the first image-backed run, mvm may build the workload kernel through the
+Stage 0 builder. You may see both of these messages:
+
+```text
+builder egress endpoint pid=... exited with status signal: 15 (SIGTERM)
+resolved workload kernel ... carries no device-mapper/dm-verity support
+```
+
+The `SIGTERM` is normally expected cleanup, not the cause of the failure. The
+Stage 0 build starts a host-side egress endpoint and terminates it when the
+one-shot build exits. The actionable message is the dm-verity error: the
+resolved kernel cannot provide `/dev/mapper/control`, so it cannot boot the
+verity-sealed workload.
+
+Rebuild or download the workload kernel explicitly:
+
+```bash
+# Use the release's hash-verified kernel
+mvmctl build kernel build --which workload --source download
+
+# Or compile the host-architecture kernel from a source checkout
+mvmctl build kernel build --which workload --source compile
+```
+
+For a local compile, the cache also contains the resolved kernel config and
+metrics under `~/.mvm/cache/builder-vm/<arch>/kernels/workload/`. An empty
+config sidecar or a zero built-in-symbol count indicates that the generated
+kernel artifact is incomplete and should not be used for a sealed workload.
+
 ### Nix build fails
 
 ```bash

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -49,6 +49,14 @@
       uses the shared bounded poll backoff. Targeted tests and clippy pass;
       merge and backend live evidence remain before closure.
 
+- [x] Release-artifact download failures no longer send macOS users into a
+      host-Nix setup that writes SSH credentials under `/etc/nix` and forces a
+      fresh `sudo` password prompt. Recovery guidance now matches the product
+      boundary: mvm manages its own Linux builder, release users retry or inspect
+      the versioned release assets, and source-checkout users bootstrap from the
+      in-repo builder image. A focused regression test forbids the stale
+      `sudo`, `darwin.linux-builder`, and `/etc/nix` instructions.
+
 - [ ] Launch critical-path waste on real-sized images — **issues #2273–#2276,
       plan 311**. Plan 299's prepared-cold baseline runs `alpine`, whose cached
       rootfs is 9.9 MB, and reports the ≤200 ms p50 contract as met. Three

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -327,9 +327,12 @@
       dedicated dm-verity workload kernel automatically during the first
       `machine run --image`, reports the first-run cost, and caches the result;
       installed binaries download the matching hash-verified release kernel,
-      while `MVM_KERNEL_SOURCE=download|auto` remains explicit. The landing
-      page and security docs now state the warm-millisecond promise alongside
-      first-run behavior and the default-deny trust model.
+      while `MVM_KERNEL_SOURCE=download|auto` remains explicit. Admission-path
+      tests now share the process-environment guard even under the default
+      grant ceiling, preventing parallel tests from observing another test's
+      temporary host configuration. The landing page and security docs now
+      state the warm-millisecond promise alongside first-run behavior and the
+      default-deny trust model.
 
 - [~] Extract `mvm-backends` crate — **plan 298**
       (`specs/plans/298-extract-mvm-backends-crate.md`). Rebased


### PR DESCRIPTION
## Summary

- Explain that the Stage 0 builder egress endpoint's SIGTERM is expected cleanup and identify a following dm-verity failure as the actionable workload-kernel error.
- Replace obsolete host-Nix recovery instructions with guidance that matches mvm's managed Linux builder and versioned release artifacts.
- Add a focused regression test that forbids the stale `sudo`, `darwin.linux-builder`, and `/etc/nix` instructions.
- Register the added README shell block in the conformance coverage manifest and update the sprint record.

## Rebase note

PR #2329 landed while this change was in review and now provides verified workload-kernel preparation, digest/config validation, cache eviction, and atomic publication. The older marker-scan and replacement commits from this branch were dropped during the rebase instead of retaining duplicate, weaker logic. This PR now contains only the still-unique troubleshooting, conformance, and artifact-recovery guidance.

## Validation

- `cargo fmt --all -- --check` on the rebased committed tree
- `cargo clippy --workspace --all-targets -- -D warnings` on the prior head containing these unchanged commits
- Focused artifact-guidance unit test: passed
- README coverage witness BDD scenario: passed
- Prior full GitHub Actions matrix: passed; fresh checks will validate the exact rebased combination
- `git diff --check origin/main...HEAD`