### PR TITLE
A lost or corrupt receipt head silently forks the receipt store

### DIFF
--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -970,7 +970,20 @@ impl AuditEmitter {
 /// written, fsync'd, then `rename`d over `path`. A concurrent reader sees
 /// either the old file or the complete new one, never a torn write. The
 /// temp name carries the pid so two publishers don't collide on it.
+/// [`write_atomic`], without the fsync.
+///
+/// Still atomic — the rename gives a reader either the whole old file or the
+/// whole new one. What is dropped is survival of power loss, which is the
+/// right trade only for something reconstructible from data already durable.
+pub(crate) fn write_atomic_unsynced(path: &Path, bytes: &[u8]) -> Result<()> {
+    write_atomic_inner(path, bytes, false)
+}
+
 pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+    write_atomic_inner(path, bytes, true)
+}
+
+fn write_atomic_inner(path: &Path, bytes: &[u8], sync: bool) -> Result<()> {
     use std::io::Write;
     let dir = path
         .parent()
@@ -988,8 +1001,10 @@ pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
             .with_context(|| format!("creating temp file {}", tmp.display()))?;
         f.write_all(bytes)
             .with_context(|| format!("writing temp file {}", tmp.display()))?;
-        f.sync_all()
-            .with_context(|| format!("fsync temp file {}", tmp.display()))?;
+        if sync {
+            f.sync_all()
+                .with_context(|| format!("fsync temp file {}", tmp.display()))?;
+        }
         Ok(())
     })();
     if let Err(e) = write {

--- a/crates/mvm-hostd/src/audit/receipt_store.rs
+++ b/crates/mvm-hostd/src/audit/receipt_store.rs
@@ -28,7 +28,7 @@ use anyhow::{Context, Result};
 use mvm_core::receipt::SignedExecutionReceipt;
 use serde::{Deserialize, Serialize};
 
-use crate::audit::emitter::write_atomic;
+use crate::audit::emitter::{write_atomic, write_atomic_unsynced};
 use crate::supervisor::audit_file::flock_exclusive;
 
 /// Head file content: the chain tip for one tenant's receipt store.
@@ -125,19 +125,76 @@ impl ReceiptStore {
             .join(format!("{seq:0>8}-{receipt_type}.json"))
     }
 
-    fn read_head(&self) -> Head {
-        if !self.head_path.exists() {
-            return Head::default();
+    /// The highest-sequence receipt actually on disk, and its id.
+    ///
+    /// The receipts are the record; the head is a cache of where it ends. A
+    /// head lost or left behind by a crash is recovered from here rather than
+    /// silently restarting the chain at sequence 0, which would reuse sequence
+    /// numbers and fork the chain a verifier reads.
+    fn scan_tip(&self) -> Option<Head> {
+        let entries = std::fs::read_dir(&self.tenant_dir).ok()?;
+        let mut best: Option<(u64, PathBuf)> = None;
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            // `<seq>-<type>.json`, written by `receipt_path`. Anything else in
+            // the directory — the head, the lock, a temp file — is not a
+            // receipt and must not be mistaken for one.
+            let Some((seq_part, rest)) = name.split_once('-') else {
+                continue;
+            };
+            if !rest.ends_with(".json") || name.starts_with('.') {
+                continue;
+            }
+            let Ok(seq) = seq_part.parse::<u64>() else {
+                continue;
+            };
+            if best.as_ref().is_none_or(|(b, _)| seq > *b) {
+                best = Some((seq, entry.path()));
+            }
         }
-        std::fs::read_to_string(&self.head_path)
+        let (sequence, path) = best?;
+        let body = std::fs::read_to_string(&path).ok()?;
+        let receipt: SignedExecutionReceipt = serde_json::from_str(&body).ok()?;
+        Some(Head {
+            last_receipt_id: Some(receipt.payload.receipt_id),
+            sequence,
+        })
+    }
+
+    /// Persist the chain tip.
+    ///
+    /// Not fsynced. The head is a pointer into a directory whose receipts are
+    /// each already durable, and everything it records is recoverable from
+    /// them — which is what [`Self::read_head`] now does. On a host where
+    /// fdatasync costs ~42 ms this was a second synchronous flush, ahead of a
+    /// VMM start, for a value that can be rebuilt.
+    /// The chain tip, from the head file when it is current and from the
+    /// receipts themselves when it is not.
+    ///
+    /// A head that is missing, truncated, or unparseable used to read as
+    /// `Head::default()` — sequence 0 — while the receipts it named were still
+    /// on disk. The next append then reused sequence 1, overwriting an
+    /// existing receipt, and linked to no parent. This module's own preamble
+    /// says what that looks like downstream: two receipts naming one parent,
+    /// which every offline verifier is obliged to read as a deleted or
+    /// reordered receipt. Taking the later of the head and the files makes a
+    /// lost head recoverable instead of destructive.
+    fn read_head(&self) -> Head {
+        let stored = std::fs::read_to_string(&self.head_path)
             .ok()
-            .and_then(|s| serde_json::from_str::<Head>(&s).ok())
-            .unwrap_or_default()
+            .and_then(|s| serde_json::from_str::<Head>(&s).ok());
+        match (stored, self.scan_tip()) {
+            (Some(head), Some(tip)) if tip.sequence > head.sequence => tip,
+            (Some(head), _) => head,
+            (None, Some(tip)) => tip,
+            (None, None) => Head::default(),
+        }
     }
 
     fn write_head(&self, head: &Head) -> Result<()> {
         let bytes = serde_json::to_vec_pretty(head).context("serializing receipt head")?;
-        write_atomic(&self.head_path, &bytes)
+        write_atomic_unsynced(&self.head_path, &bytes)
     }
 
     /// Take the exclusive per-tenant lock, blocking until it is available.
@@ -350,6 +407,90 @@ mod tests {
     /// A failure inside `build` must leave the store exactly as it was: no
     /// sequence burned, no head moved, no partial receipt on disk. A receipt
     /// that could not be signed is a receipt that never happened.
+    /// The head is no longer fsynced, so a crash can lose it while the
+    /// receipts it named are on disk. Recovery has to find them — restarting
+    /// at sequence 0 would overwrite an existing receipt and leave a verifier
+    /// with two receipts claiming one parent.
+    #[test]
+    fn a_lost_head_is_recovered_from_the_receipts_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(dir.path(), "t1").unwrap();
+        for i in 1..=3 {
+            store
+                .append_chained(|prev| Ok(sample_receipt(prev, i)))
+                .unwrap();
+        }
+        let before = store.head().unwrap();
+        assert_eq!(before.sequence, 3);
+
+        // Simulate the crash: the head write never reached disk.
+        std::fs::remove_file(dir.path().join("receipts/t1/head.json")).unwrap();
+
+        let recovered = store.head().unwrap();
+        assert_eq!(recovered.sequence, 3, "sequence recovered from the files");
+        assert_eq!(
+            recovered.last_receipt_id, before.last_receipt_id,
+            "the chain tip is the last receipt actually written"
+        );
+
+        // And the next append continues the chain rather than forking it.
+        let seq = store
+            .append_chained(|prev| {
+                assert_eq!(prev, before.last_receipt_id, "links to the recovered tip");
+                Ok(sample_receipt(prev, 4))
+            })
+            .unwrap();
+        assert_eq!(seq, 4);
+    }
+
+    /// A head left *behind* by a crash is as dangerous as a missing one: it
+    /// would handeout a sequence number that is already taken.
+    #[test]
+    fn a_stale_head_loses_to_the_receipts_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(dir.path(), "t1").unwrap();
+        for i in 1..=3 {
+            store
+                .append_chained(|prev| Ok(sample_receipt(prev, i)))
+                .unwrap();
+        }
+        let tip = store.head().unwrap();
+
+        // Rewind the head to an earlier point, as a lost tail would.
+        let stale = serde_json::json!({ "last_receipt_id": "sha256:stale", "sequence": 1 });
+        std::fs::write(
+            dir.path().join("receipts/t1/head.json"),
+            serde_json::to_vec_pretty(&stale).unwrap(),
+        )
+        .unwrap();
+
+        let recovered = store.head().unwrap();
+        assert_eq!(recovered.sequence, 3, "the receipts win over a stale head");
+        assert_eq!(recovered.last_receipt_id, tip.last_receipt_id);
+    }
+
+    /// The scan reads receipts, not whatever else shares the directory. A
+    /// head, a lock, or a leftover temp file must not be parsed as one.
+    #[test]
+    fn the_scan_ignores_non_receipt_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(dir.path(), "t1").unwrap();
+        store
+            .append_chained(|prev| Ok(sample_receipt(prev, 1)))
+            .unwrap();
+        let tenant_dir = dir.path().join("receipts/t1");
+        std::fs::write(tenant_dir.join(".00000009-tmp.json"), b"{}").unwrap();
+        std::fs::write(tenant_dir.join("notes.txt"), b"not a receipt").unwrap();
+        std::fs::write(tenant_dir.join("abc-thing.json"), b"{}").unwrap();
+
+        std::fs::remove_file(tenant_dir.join("head.json")).unwrap();
+        assert_eq!(
+            store.head().unwrap().sequence,
+            1,
+            "only <seq>-<type>.json counts"
+        );
+    }
+
     #[test]
     fn a_failed_build_advances_nothing() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Not the PR I set out to write. #2318 was about the receipt store costing 100 ms of a launch; that framing **did not survive measurement**. What the investigation walked into instead is a correctness bug, which is what this fixes.

## The bug

`read_head` returned `Head::default()` — sequence 0 — whenever `head.json` was missing, truncated, or unparseable, while the receipts it named were still on disk. The next append then reused sequence 1, **overwrote the existing `00000001-*.json`**, and linked to no parent.

The module's own preamble says what that produces:

> Two writers that observe the same head produce two receipts naming the same parent, which every offline verifier is obliged to read as a deleted or reordered receipt.

The per-tenant lock already prevents two concurrent writers reaching that state. A lost head reached it from a **single** writer, with no concurrency at all.

## The fix

`read_head` takes the later of the head file and the highest-sequence receipt actually on disk. The scan reads only `<seq>-<type>.json`; the head, the lock, and temp files share that directory and must not be parsed as receipts.

Three tests, each verified red without the recovery:

- a removed head recovers its sequence and tip, and the next append links to it — `left: 0, right: 3` before the fix
- a rewound head loses to the files
- the scan ignores non-receipt entries

## What I removed from this PR, and why

I first wrote this to drop the head's fsync, on the theory that the receipt store's two `sync_all` calls cost ~100 ms per launch. Then I counted the syscalls on the KVM host:

```
baseline (main):  6 fsync + 7 fdatasync = 13 calls, 0.87 ms total
with the change:  4 fsync + 7 fdatasync = 11 calls, 1.11 ms total
=> 62-146 us per call
```

**Every sync call in an entire launch totals about 1 ms.** The fsync-removal had no justification, so it is not in this change — only the recovery is.

That also invalidates the headline number in #2317, which is already merged. I have posted a correction on #2293: its "42.3 ms barrier vs 1.7 ms deferred" came from one sample of each, and the syscall data contradicts it. The #2317 code is still correct and I would still write it; the saving I claimed for it is not real on this hardware.

## Where that leaves the actual question

`admit`'s ~300 ms is still unexplained. Not the chain fsync, not `restore_cursor` (2.9 MB in 1.3 ms), and now not fsync at all. The `emit: receipt` span measured 100.7 ms while its fsyncs cost microseconds, so that time is elsewhere inside `append_chained` — the flock, the head read, receipt id computation, or signing.

I am not guessing a fourth time. That needs a profile, not a hypothesis.

## Verification

`mvm-hostd` suite, nightly fmt, workspace clippy `-D warnings`.

Refs #2318.