### PR TITLE
Make bootstrap prepare a verified workload kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3014,7 +3014,6 @@ dependencies = [
  "hex",
  "libc",
  "libkrun-sys",
- "memchr",
  "mvm-agentd",
  "mvm-backends",
  "mvm-build",

--- a/README.md
+++ b/README.md
@@ -144,12 +144,18 @@ mvmctl machine inspect web
 Nix builds run inside a **headless builder VM** that mvm manages for you — there
 is no interactive shell into it. It exists only to run `nix build`, and you debug
 it through its logs. It auto-bootstraps on the first `machine build` / `machine
-run`; to set up host tooling and pre-acquire its image ahead of time:
+run`; to set up host tooling and pre-acquire both the builder image and the
+dm-verity workload kernel ahead of time:
 
 ```bash
-mvmctl bootstrap      # host setup + pre-fetch the builder VM image (fast first build)
+mvmctl bootstrap      # host setup + builder VM and workload-kernel acquisition
 mvmctl doctor         # diagnose host deps + the resolved builder/runtime backend
 ```
+
+`bootstrap` is safe to rerun. It verifies warm artifacts and only rebuilds or
+downloads what is missing or invalid. If a Stage 0 source build is interrupted,
+the incomplete output is never installed; rerunning resumes with the persistent
+Nix store still warm.
 
 For an interactive shell you want a *workload* microVM, not the builder — use a
 transient run against a dev-tier image: `mvmctl machine run --image alpine -it -- /bin/sh`.

--- a/crates/mvm-build/src/bin/stage0-init.rs
+++ b/crates/mvm-build/src/bin/stage0-init.rs
@@ -1268,10 +1268,9 @@ mod linux {
     }
 
     fn copy_deref(src: &Path, dst: &Path) -> Result<(), String> {
-        // `cp -L`: follow the store symlink and copy the real file.
-        std::fs::copy(src, dst)
+        mvm_build::stage0::copy_nonempty_file(src, dst)
             .map(|_| ())
-            .map_err(|e| format!("copy {} -> {}: {e}", src.display(), dst.display()))
+            .map_err(|error| error.to_string())
     }
 
     fn power_off() -> ExitCode {
@@ -1559,6 +1558,7 @@ mod linux {
                 std::fs::read(out.join("manifest.json")).expect("read source manifest")
             );
         }
+
         #[test]
         fn seed_store_runtime_check_requires_nix_and_cacert() {
             let root = tempfile::tempdir().expect("tempdir");

--- a/crates/mvm-build/src/kernel_fetch.rs
+++ b/crates/mvm-build/src/kernel_fetch.rs
@@ -143,11 +143,13 @@ fn verify_cached_kernel(kernel: &Path) -> Result<VerifiedKernel, KernelFetchErro
     Ok(VerifiedKernel(kernel.to_path_buf()))
 }
 
-/// Remove a rejected kernel and its sidecar. Removing only one would leave the
-/// other to be re-adopted, which is how a poisoned artifact survives eviction.
+/// Remove a rejected kernel, its sidecar, and its optional resolved config.
+/// Removing only part of the entry can leave stale capability metadata beside
+/// the replacement, or let a poisoned artifact be re-adopted.
 fn evict_kernel(kernel: &Path) {
     let _ = std::fs::remove_file(kernel);
     let _ = std::fs::remove_file(kernel_digest_sidecar(kernel));
+    let _ = std::fs::remove_file(kernel.with_file_name("config"));
 }
 
 /// How a kernel pin resolves to a concrete `vmlinux` for a given backend.
@@ -386,10 +388,12 @@ mod tests {
         }
 
         #[test]
-        fn a_modified_kernel_is_rejected_and_both_files_evicted() {
+        fn a_modified_kernel_is_rejected_and_the_full_entry_is_evicted() {
             let _env = env_guard();
             let dir = tempfile::tempdir().unwrap();
             let kernel = staged(dir.path(), b"the real kernel", true);
+            let config = kernel.with_file_name("config");
+            std::fs::write(&config, "CONFIG_DM_VERITY=y\n").unwrap();
             // Same length, so a size check would not notice.
             std::fs::write(&kernel, b"the fake kernel").unwrap();
 
@@ -402,6 +406,7 @@ mod tests {
                 !kernel_digest_sidecar(&kernel).exists(),
                 "its pin removed too — leaving one lets the other be re-adopted"
             );
+            assert!(!config.exists(), "stale capability metadata removed too");
         }
 
         #[test]

--- a/crates/mvm-build/src/stage0.rs
+++ b/crates/mvm-build/src/stage0.rs
@@ -39,6 +39,47 @@ use sha2::{Digest, Sha256};
 const ROOT_MARKER_FILE: &str = ".mvm-stage0-root";
 const ROOT_MARKER_SCHEMA_VERSION: u32 = 1;
 
+/// Copy a non-empty artifact through an explicit userspace buffer.
+///
+/// Stage 0 copies from its ext4-backed Nix store to a virtio-fs host share.
+/// Optimized cross-filesystem copy syscalls have produced zero-byte outputs on
+/// that boundary, so bootstrap artifacts use ordinary reads and writes and
+/// reject an empty source before it can be reported as successfully emitted.
+pub fn copy_nonempty_file(src: &Path, dst: &Path) -> Result<u64> {
+    let mut input = std::io::BufReader::new(
+        std::fs::File::open(src).with_context(|| format!("open {} for copy", src.display()))?,
+    );
+    let mut output = std::io::BufWriter::new(
+        std::fs::File::create(dst).with_context(|| format!("create {} for copy", dst.display()))?,
+    );
+    let mut buffer = [0u8; 64 * 1024];
+    let mut copied = 0u64;
+    loop {
+        let read = input
+            .read(&mut buffer)
+            .with_context(|| format!("read {}", src.display()))?;
+        if read == 0 {
+            break;
+        }
+        output
+            .write_all(&buffer[..read])
+            .with_context(|| format!("write {}", dst.display()))?;
+        copied = copied.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
+    }
+    output
+        .flush()
+        .with_context(|| format!("flush {}", dst.display()))?;
+    if copied == 0 {
+        let _ = std::fs::remove_file(dst);
+        bail!(
+            "copy {} -> {} produced an empty artifact",
+            src.display(),
+            dst.display()
+        );
+    }
+    Ok(copied)
+}
+
 /// One downloadable bootstrap asset, pinned by upstream URL + SHA-256.
 /// The cache key is [`Self::cache_filename`].
 #[derive(Debug, Clone, Copy)]
@@ -592,6 +633,35 @@ fn fetch_to(target: &Path, asset: &BootstrapAsset) -> Result<()> {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[cfg(unix)]
+    #[test]
+    fn buffered_artifact_copy_follows_symlinks_and_rejects_empty_sources() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("config.real");
+        let link = temp.path().join("config");
+        let copied = temp.path().join("copied.config");
+        std::fs::write(&source, b"CONFIG_BLK_DEV_DM=y\nCONFIG_DM_VERITY=y\n").unwrap();
+        symlink(&source, &link).unwrap();
+
+        assert_eq!(
+            copy_nonempty_file(&link, &copied).unwrap(),
+            std::fs::metadata(&source).unwrap().len()
+        );
+        assert_eq!(
+            std::fs::read(&copied).unwrap(),
+            std::fs::read(&source).unwrap()
+        );
+
+        let empty = temp.path().join("empty");
+        let empty_copy = temp.path().join("empty-copy");
+        std::fs::write(&empty, b"").unwrap();
+        let error = copy_nonempty_file(&empty, &empty_copy).unwrap_err();
+        assert!(error.to_string().contains("empty artifact"));
+        assert!(!empty_copy.exists());
+    }
 
     // ---------------- VendorBlobReport ----------------
 

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -55,7 +55,6 @@ sha2.workspace = true
 tar = "0.4"
 flate2.workspace = true
 hex.workspace = true
-memchr.workspace = true
 tempfile.workspace = true
 toml.workspace = true
 notify = { workspace = true, optional = true }

--- a/crates/mvm-cli/README.md
+++ b/crates/mvm-cli/README.md
@@ -7,7 +7,7 @@ Clap-based CLI commands, bootstrap workflow, diagnostics, update mechanism, and 
 | Module | Purpose |
 |--------|---------|
 | `commands` | Main CLI entry point (`run()`), all command definitions and handlers |
-| `bootstrap` | Full environment setup (Homebrew/apt, Nix, builder VM image pre-fetch) |
+| `bootstrap` | Full environment setup and machine infrastructure readiness |
 | `doctor` | System diagnostics and dependency checks (`mvmctl doctor`) |
 | `update` | Self-update from GitHub releases |
 | `template_cmd` | Template CRUD commands (create, list, build, delete, push, pull) |
@@ -20,7 +20,7 @@ Clap-based CLI commands, bootstrap workflow, diagnostics, update mechanism, and 
 
 | Command | Description |
 |---------|-------------|
-| `mvmctl bootstrap` | Full setup from scratch (builder VM image pre-fetch) |
+| `mvmctl bootstrap` | Full setup plus builder VM and workload-kernel acquisition |
 | `mvmctl build image --flake .` | Build a microVM image from a Nix flake |
 | `mvmctl run --flake .` | Build + start a microVM |
 | `mvmctl console <name>` | Interactive PTY over vsock (dev-mode only) |

--- a/crates/mvm-cli/src/commands/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/bootstrap.rs
@@ -1,13 +1,13 @@
 //! `mvmctl bootstrap` — prepare the local environment from scratch.
 //!
-//! Runs the host-tooling setup and **pre-acquires the builder VM image** so
-//! the first build is fast: the expensive first-run image
-//! download (release install) or local build (source checkout) is paid here,
-//! ahead of time, not on the hot path. Idempotent — a fast no-op when the
-//! environment is already set up and the image is cached.
+//! Runs the host-tooling setup and **pre-acquires the builder VM image and
+//! workload kernel** so the first machine run is ready: expensive first-run
+//! downloads (release install) or local builds (source checkout) are paid here,
+//! ahead of time, not on the launch path. Idempotent — a fast verification when
+//! the environment and both artifacts are already cached.
 //!
-//! `install.sh` runs this automatically after installing the binary (unless
-//! `MVM_SKIP_BUILDER_PREFETCH=1`), and users can run it explicitly any time.
+//! `install.sh` runs this automatically after installing the binary unless
+//! `MVM_SKIP_BOOTSTRAP=1`, and users can run it explicitly any time.
 
 use anyhow::{Context, Result, bail};
 use clap::Args as ClapArgs;

--- a/crates/mvm-cli/src/commands/env/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/env/bootstrap.rs
@@ -1,6 +1,6 @@
 //! `mvmctl bootstrap` — full environment setup from scratch.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 
 use crate::bootstrap;
@@ -22,19 +22,34 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     bootstrap_environment(args.production)
 }
 
-/// Full environment bootstrap: host-tooling setup **plus** pre-acquiring the
-/// builder VM image so the first build is fast (no first-run download/build on
-/// the hot path). Shared by the top-level `mvmctl bootstrap` and `mvmctl env
-/// bootstrap`.
+/// Full environment bootstrap: host tooling plus the builder VM image and
+/// workload kernel. Completion means the next `machine run` does not discover
+/// a builder-image or workload-kernel build on its hot path.
 pub(in crate::commands) fn bootstrap_environment(production: bool) -> Result<()> {
     run_steps(production)?;
-    // Pre-fetch the builder VM image. On a release install this downloads the
-    // published, SHA-256-verified image; on a source checkout it builds it
-    // locally (a source checkout never downloads mvm-release artifacts).
-    // Cache-gated, so it is a fast no-op when the image is already present.
-    super::builder_vm::bootstrap_builder_vm_image()?;
-    ui::success("\nBootstrap complete.");
+    let kernel = acquire_bootstrap_artifacts_with(
+        super::builder_vm::bootstrap_builder_vm_image,
+        super::builder_vm::ensure_workload_kernel,
+    )?;
+    ui::success(&format!(
+        "\nBootstrap complete. Builder VM and workload kernel are ready.\nFuture machine runs will reuse these artifacts.\nWorkload kernel: {kernel}"
+    ));
     Ok(())
+}
+
+fn acquire_bootstrap_artifacts_with<B, K>(builder: B, workload_kernel: K) -> Result<String>
+where
+    B: FnOnce() -> Result<()>,
+    K: FnOnce() -> Result<String>,
+{
+    ui::info("Preparing builder VM...");
+    builder().context("preparing builder VM")?;
+    ui::success("Builder VM ready.");
+
+    ui::info("Preparing workload kernel...");
+    let kernel = workload_kernel().context("preparing workload kernel")?;
+    ui::success("Workload kernel ready.");
+    Ok(kernel)
 }
 
 /// Run the host-tooling bootstrap steps only (no builder-image prefetch) —
@@ -55,4 +70,55 @@ pub(super) fn run_steps(production: bool) -> Result<()> {
     // setup path.
     run_setup_steps(false, 8, 16)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::acquire_bootstrap_artifacts_with;
+    use std::cell::RefCell;
+
+    #[test]
+    fn bootstrap_acquires_builder_then_workload_kernel() {
+        let calls = RefCell::new(Vec::new());
+        let kernel = acquire_bootstrap_artifacts_with(
+            || {
+                calls.borrow_mut().push("builder");
+                Ok(())
+            },
+            || {
+                calls.borrow_mut().push("workload");
+                Ok("/cache/workload/vmlinux".to_string())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(calls.into_inner(), ["builder", "workload"]);
+        assert_eq!(kernel, "/cache/workload/vmlinux");
+    }
+
+    #[test]
+    fn bootstrap_never_reports_ready_after_builder_failure() {
+        let workload_called = std::cell::Cell::new(false);
+        let result = acquire_bootstrap_artifacts_with(
+            || anyhow::bail!("builder failed"),
+            || {
+                workload_called.set(true);
+                Ok("/cache/workload/vmlinux".to_string())
+            },
+        );
+
+        assert!(result.is_err());
+        assert!(!workload_called.get());
+    }
+
+    #[test]
+    fn bootstrap_fails_when_workload_kernel_is_not_ready() {
+        let result = acquire_bootstrap_artifacts_with(
+            || Ok(()),
+            || anyhow::bail!("kernel acquisition failed"),
+        );
+
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("workload kernel"), "unexpected error: {err}");
+    }
 }

--- a/crates/mvm-cli/src/commands/env/builder_vm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm.rs
@@ -37,6 +37,7 @@ use bootstrap::{
 };
 #[cfg(all(test, feature = "builder-vm"))]
 use default_microvm::DefaultMicrovmVariant;
+#[cfg(any(feature = "builder-vm", test))]
 use default_microvm::workload_config_carries_dm_verity;
 pub(crate) use default_microvm::{
     assert_workload_kernel_supports_verity, ensure_default_microvm_image, ensure_workload_kernel,

--- a/crates/mvm-cli/src/commands/env/builder_vm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm.rs
@@ -37,14 +37,14 @@ use bootstrap::{
 };
 #[cfg(all(test, feature = "builder-vm"))]
 use default_microvm::DefaultMicrovmVariant;
-#[cfg(test)]
-use default_microvm::{
-    WorkloadKernelBootstrap, default_microvm_assets, find_cached_workload_kernel,
-    kernel_carries_dm_verity, missing_workload_kernel_message, resolve_workload_kernel_bootstrap,
-};
+use default_microvm::workload_config_carries_dm_verity;
 pub(crate) use default_microvm::{
     assert_workload_kernel_supports_verity, ensure_default_microvm_image, ensure_workload_kernel,
     ensure_workload_verity_initrd,
+};
+#[cfg(test)]
+use default_microvm::{
+    default_microvm_assets, evict_incompatible_workload_kernel, missing_workload_kernel_message,
 };
 use image_ops::validate_dev_image_artifacts;
 #[cfg(feature = "builder-vm")]
@@ -70,10 +70,13 @@ use stage0_cache::builder_vm_artifact_names;
 #[cfg(feature = "release-artifact-bootstrap")]
 use stage0_cache::download_builder_vm_image;
 pub(in crate::commands) use stage0_cache::{
-    Stage0SweepOutcome, stage0_bootstrap_in_flight, sweep_orphaned_stage0_staging_dirs,
+    Stage0SweepOutcome, stage0_active_in_process, stage0_bootstrap_in_flight,
+    sweep_orphaned_stage0_staging_dirs,
 };
 #[cfg(any(feature = "builder-vm", test))]
-use stage0_cache::{acquire_stage0_lock, unique_builder_vm_stage0_staging_dir};
+use stage0_cache::{
+    acquire_stage0_lock, sweep_stage0_staging_siblings, unique_builder_vm_stage0_staging_dir,
+};
 #[cfg(test)]
 use stage0_cache::{
     builder_vm_source_cache_ready, builder_vm_source_cache_status, builder_vm_source_fingerprint,

--- a/crates/mvm-cli/src/commands/env/builder_vm/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/bootstrap.rs
@@ -877,6 +877,13 @@ fn bootstrap_builder_vm_image_via_root_dir_stage0(
     verbose: bool,
 ) -> Result<()> {
     let _stage0_guard = acquire_stage0_lock(out_dir)?;
+    let removed = sweep_stage0_staging_siblings(std::path::Path::new(out_dir))?;
+    if removed > 0 {
+        ui::info(&format!(
+            "Removed {removed} incomplete Stage 0 builder-image director{} from an earlier interruption.",
+            if removed == 1 { "y" } else { "ies" }
+        ));
+    }
 
     // Time each host-visible Stage 0 step and print a one-line
     // `[mvm] <step> … <secs>s` so perceived speed matches the actual

--- a/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
@@ -3,185 +3,90 @@ use super::*;
 use std::io::Write;
 
 #[test]
-fn only_the_dedicated_workload_kernel_qualifies() {
-    let tmp = tempfile::tempdir().unwrap();
-    let cache = tmp.path().to_str().unwrap();
-    let arch = "x86_64";
-    assert_eq!(find_cached_workload_kernel(cache, arch), None);
+fn workload_config_is_the_capability_witness() {
+    let supported = "CONFIG_MD=y\nCONFIG_BLK_DEV_DM=y\nCONFIG_DM_VERITY=y\n";
+    assert_eq!(workload_config_carries_dm_verity(supported), Some(true));
 
-    let mk = |rel: &str| {
-        let p = tmp.path().join(rel);
-        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
-        std::fs::write(&p, b"vmlinux").unwrap();
-        p.to_str().unwrap().to_string()
-    };
+    let builder = "# CONFIG_MD is not set\n# CONFIG_BLK_DEV_DM is not set\n";
+    assert_eq!(workload_config_carries_dm_verity(builder), Some(false));
 
-    // The default-microvm images ship a general-purpose NixOS kernel. It used to
-    // be accepted here as a stand-in, which silently gave workloads a kernel with
-    // CONFIG_USER_NS enabled whenever the real workload kernel was not cached.
-    // Neither variant qualifies now, however convenient the reuse was.
-    mk("default-microvm/prod/vmlinux");
-    mk("default-microvm/dev/vmlinux");
+    assert_eq!(workload_config_carries_dm_verity(""), None);
     assert_eq!(
-        find_cached_workload_kernel(cache, arch),
-        None,
-        "a default-microvm kernel must never stand in for the workload kernel"
-    );
-
-    // Only the dedicated kernel resolves, so a cold cache reaches the
-    // build-or-download path instead of booting on whatever is lying around.
-    let dedicated = mk(&format!("builder-vm/{arch}/kernels/workload/vmlinux"));
-    assert_eq!(
-        find_cached_workload_kernel(cache, arch).as_deref(),
-        Some(dedicated.as_str())
+        workload_config_carries_dm_verity("not a kernel config"),
+        None
     );
 }
 
 #[test]
-fn cold_cache_downloads_instead_of_building_locally() {
+fn assert_workload_kernel_supports_verity_rejects_an_explicit_non_verity_config() {
     let tmp = tempfile::tempdir().unwrap();
-    let cache = tmp.path().to_str().unwrap();
-    let arch = "x86_64";
-    assert_eq!(
-        resolve_workload_kernel_bootstrap(cache, arch, false),
-        WorkloadKernelBootstrap::Download(format!(
-            "{cache}/builder-vm/{arch}/kernels/workload/vmlinux"
-        ))
-    );
-}
-
-#[test]
-fn source_checkout_cold_cache_downloads_by_default() {
-    let tmp = tempfile::tempdir().unwrap();
-    let cache = tmp.path().to_str().unwrap();
-    let arch = "aarch64";
-    assert_eq!(
-        resolve_workload_kernel_bootstrap(cache, arch, false),
-        WorkloadKernelBootstrap::Download(format!(
-            "{cache}/builder-vm/{arch}/kernels/workload/vmlinux"
-        ))
-    );
-}
-
-#[test]
-fn explicit_source_build_request_builds_workload_kernel_locally() {
-    let tmp = tempfile::tempdir().unwrap();
-    let cache = tmp.path().to_str().unwrap();
-    let arch = "aarch64";
-    assert_eq!(
-        resolve_workload_kernel_bootstrap(cache, arch, true),
-        WorkloadKernelBootstrap::BuildLocal(format!(
-            "{cache}/builder-vm/{arch}/kernels/workload/vmlinux"
-        ))
-    );
-}
-
-#[test]
-fn workload_kernel_never_reuses_the_non_verity_builder_kernel() {
-    let tmp = tempfile::tempdir().unwrap();
-    let cache = tmp.path().to_str().unwrap();
-    let arch = "aarch64";
-
-    // A builder-image kernel on disk must NOT satisfy the workload kernel: the
-    // builder kernel force-drops device-mapper + dm-verity, but every workload
-    // boots through the verity initrd, so reusing it panics the guest at boot.
-    // It is also not a workload-kernel cache candidate.
-    let dir = tmp.path().join(format!("builder-vm/{arch}"));
-    std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(dir.join("vmlinux"), b"vmlinux").unwrap();
-    assert!(find_cached_workload_kernel(cache, arch).is_none());
-    assert!(find_cached_workload_kernel(cache, arch).is_none());
-
-    // With no workload/default kernel cached, resolution builds it (source
-    // checkout) or downloads it (installed) — never the builder kernel, in
-    // either dev or prod.
-    let dest = format!("{cache}/builder-vm/{arch}/kernels/workload/vmlinux");
-    assert_eq!(
-        resolve_workload_kernel_bootstrap(cache, arch, true),
-        WorkloadKernelBootstrap::BuildLocal(dest.clone())
-    );
-    assert_eq!(
-        resolve_workload_kernel_bootstrap(cache, arch, false),
-        WorkloadKernelBootstrap::Download(dest.clone())
-    );
-    assert_eq!(
-        resolve_workload_kernel_bootstrap(cache, arch, false),
-        WorkloadKernelBootstrap::Download(dest)
-    );
-}
-
-#[test]
-fn kernel_carries_dm_verity_flags_only_a_readable_marker_free_kernel() {
-    // A readable kernel carrying any device-mapper/dm-verity symbol → supported.
-    let verity = b"boot Linux version 6.6.0 ... dm_table_create ... verity_ctr ...".to_vec();
-    assert_eq!(kernel_carries_dm_verity(&verity), Some(true));
-    let dm_only = b"Linux version 6.6 device-mapper: ioctl:".to_vec();
-    assert_eq!(kernel_carries_dm_verity(&dm_only), Some(true));
-
-    // A readable kernel with no dm marker at all → the builder-kernel signature.
-    // This is the only case that fails the launch guard.
-    let builder = b"Linux version 6.6.0 (nixbld) rootwait console=hvc0 target_type".to_vec();
-    assert_eq!(kernel_carries_dm_verity(&builder), Some(false));
-
-    // Not a recognizable kernel (compressed Image, truncated file, junk) →
-    // inconclusive; the guard must never reject on `None`.
-    assert_eq!(kernel_carries_dm_verity(b"\x1f\x8b\x08 gzip payload"), None);
-    assert_eq!(kernel_carries_dm_verity(b""), None);
-    assert_eq!(kernel_carries_dm_verity(b"device-mapper"), None);
-}
-
-#[test]
-fn assert_workload_kernel_supports_verity_rejects_a_marker_free_kernel() {
-    let tmp = tempfile::tempdir().unwrap();
-    // A readable kernel with no dm-verity symbol is refused with a clear message.
-    let bad = tmp.path().join("builder-vmlinux");
-    std::fs::write(&bad, b"Linux version 6.6.0 (nixbld) console=hvc0 rootwait").unwrap();
+    let bad = tmp.path().join("vmlinux");
+    std::fs::write(&bad, b"valid raw ARM64 Image without KALLSYMS strings").unwrap();
+    std::fs::write(
+        tmp.path().join("config"),
+        "# CONFIG_BLK_DEV_DM is not set\n",
+    )
+    .unwrap();
     let err = assert_workload_kernel_supports_verity(bad.to_str().unwrap()).unwrap_err();
     assert!(
-        err.to_string().contains("dm-verity"),
+        err.to_string().contains("CONFIG_DM_VERITY=y"),
         "unexpected error: {err}"
     );
-
-    // A dm-verity-capable kernel passes; an unrecognized blob passes (inconclusive).
-    let good = tmp.path().join("workload-vmlinux");
-    std::fs::write(&good, b"Linux version 6.6.0 dm_table_create verity_ctr").unwrap();
-    assert!(assert_workload_kernel_supports_verity(good.to_str().unwrap()).is_ok());
-    let opaque = tmp.path().join("compressed-image");
-    std::fs::write(&opaque, b"\x1f\x8b\x08 not a decodable kernel").unwrap();
-    assert!(assert_workload_kernel_supports_verity(opaque.to_str().unwrap()).is_ok());
 }
 
-/// The scan runs over a whole multi-megabyte kernel on every launch, so its
-/// implementation was swapped for a skip-capable search. These are the cases
-/// where a naive and a skipping search can disagree: a marker at the very end
-/// (the worst offset), a long run of near-misses that share a marker's prefix,
-/// and a needle longer than the haystack.
 #[test]
-fn kernel_marker_search_finds_markers_at_any_offset_and_rejects_near_misses() {
-    let mut trailing = b"Linux version 6.6.0 ".to_vec();
-    trailing.extend(std::iter::repeat_n(b'\0', 512 * 1024));
-    trailing.extend_from_slice(b"dm-verity");
-    assert_eq!(
-        kernel_carries_dm_verity(&trailing),
-        Some(true),
-        "a marker in the final bytes must still be found"
-    );
+fn assert_workload_kernel_supports_verity_accepts_kallsyms_free_image_with_valid_config() {
+    let tmp = tempfile::tempdir().unwrap();
+    let kernel = tmp.path().join("vmlinux");
+    std::fs::write(&kernel, b"raw ARM64 Image with no searchable dm symbols").unwrap();
+    std::fs::write(
+        tmp.path().join("config"),
+        "CONFIG_MD=y\nCONFIG_BLK_DEV_DM=y\nCONFIG_DM_VERITY=y\n",
+    )
+    .unwrap();
 
-    // Repeated partial matches of `dm_table_create` that never complete: the
-    // shape a naive search walks quadratically, and which must still answer
-    // false.
-    let mut near_miss = b"Linux version 6.6.0 ".to_vec();
-    for _ in 0..40_000 {
-        near_miss.extend_from_slice(b"dm_table_creat_");
-    }
-    assert_eq!(
-        kernel_carries_dm_verity(&near_miss),
-        Some(false),
-        "a prefix that never completes a marker is not a marker"
-    );
+    assert_workload_kernel_supports_verity(kernel.to_str().unwrap()).unwrap();
+}
 
-    // Needle longer than haystack must not panic or match.
-    assert_eq!(kernel_carries_dm_verity(b"Linux vers"), None);
+#[test]
+fn assert_workload_kernel_supports_verity_accepts_raw_image_without_optional_local_config() {
+    let tmp = tempfile::tempdir().unwrap();
+    let kernel = tmp.path().join("vmlinux");
+    std::fs::write(
+        &kernel,
+        b"published raw ARM64 Image with no KALLSYMS strings",
+    )
+    .unwrap();
+
+    assert_workload_kernel_supports_verity(kernel.to_str().unwrap()).unwrap();
+}
+
+#[test]
+fn incompatible_cached_kernel_is_fully_evicted_for_automatic_recovery() {
+    let tmp = tempfile::tempdir().unwrap();
+    let kernel = mvm_build::kernel_fetch::cached_kernel_path(tmp.path(), "aarch64", "workload");
+    std::fs::create_dir_all(kernel.parent().unwrap()).unwrap();
+    std::fs::write(&kernel, b"builder kernel in workload slot").unwrap();
+    std::fs::write(
+        kernel.with_file_name("config"),
+        "# CONFIG_BLK_DEV_DM is not set\n# CONFIG_DM_VERITY is not set\n",
+    )
+    .unwrap();
+    mvm_build::kernel_fetch::record_kernel_digest(&kernel).unwrap();
+
+    assert!(
+        assert_workload_kernel_supports_verity(kernel.to_str().unwrap()).is_err(),
+        "the explicit non-verity config must be rejected"
+    );
+    evict_incompatible_workload_kernel(&kernel).unwrap();
+
+    assert!(!kernel.exists());
+    assert!(!mvm_build::kernel_fetch::kernel_digest_sidecar(&kernel).exists());
+    assert!(!kernel.with_file_name("config").exists());
+    assert!(matches!(
+        mvm_build::kernel_fetch::resolve_kernel(tmp.path(), "aarch64", "workload", true),
+        mvm_build::kernel_fetch::KernelResolution::NeedsBuild(_)
+    ));
 }
 
 #[test]
@@ -507,6 +412,35 @@ fn stage0_in_flight_tracks_the_lock() {
     );
 }
 
+#[test]
+fn kernel_stage0_retry_sweeps_only_matching_orphan_staging_dirs() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let kernels = tmp.path().join("aarch64/kernels");
+    let final_dir = kernels.join("workload");
+    let old_a = kernels.join(".workload.stage0-123-456");
+    let old_b = kernels.join(".workload.stage0-789-012");
+    let unrelated = kernels.join(".builder.stage0-123-456");
+    let live = kernels.join("workload");
+    for dir in [&old_a, &old_b, &unrelated, &live] {
+        std::fs::create_dir_all(dir).expect("create test directory");
+        std::fs::write(dir.join("artifact"), b"bytes").expect("write test artifact");
+    }
+
+    let removed = sweep_stage0_staging_siblings(&final_dir).expect("sweep matching orphans");
+
+    assert_eq!(removed, 2);
+    assert!(!old_a.exists());
+    assert!(!old_b.exists());
+    assert!(
+        unrelated.exists(),
+        "another variant's staging belongs to its producer"
+    );
+    assert!(
+        live.exists(),
+        "the live cache directory must never be swept"
+    );
+}
+
 /// Name predicate must match both the current hidden
 /// `.<arch>.stage0-<pid>-<nonce>` form and the legacy
 /// `<arch>-staging[-...]` form, and reject everything else that
@@ -551,7 +485,7 @@ fn is_orphan_stage0_staging_dir_name_matches_known_shapes() {
 /// reported block here is always spurious. Tests that deliberately
 /// contend the lock (`sweep_skips_when_stage0_lock_is_held`) do not use
 /// these — they want the real "held" outcome.
-fn acquire_stage0_lock_uncontended(out_dir: &str) -> mvm_core::atomic_io::FileLock {
+fn acquire_stage0_lock_uncontended(out_dir: &str) -> super::stage0_cache::Stage0LockGuard {
     for attempt in 0..200u32 {
         match acquire_stage0_lock(out_dir) {
             Ok(guard) => return guard,

--- a/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
@@ -18,57 +18,93 @@ pub(crate) fn ensure_default_microvm_image(
 }
 
 pub(crate) fn ensure_workload_kernel() -> Result<String> {
-    let cache = mvm_core::config::mvm_cache_dir();
+    use mvm_build::kernel_fetch::{KernelResolution, resolve_kernel};
+
+    let cache = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir());
     let arch = builder_vm_host_arch();
     let source_checkout = find_builder_vm_flake().is_ok();
-    let resolved = resolve_workload_kernel_bootstrap(&cache, arch, source_checkout);
-    // Name which kernel variant a run resolved and where it came from. Without
-    // this breadcrumb a wrong-kernel boot (e.g. a non-verity kernel under a
-    // verity-sealed rootfs) is invisible host-side until the guest panics.
-    let (provenance, path) = match resolved {
-        WorkloadKernelBootstrap::Cached(path) => ("cached", path),
-        WorkloadKernelBootstrap::BuildLocal(path) => {
-            match workload_kernel_source(source_checkout) {
-                KernelSource::Download => {
-                    download_workload_kernel(arch, &path)?;
-                    ("downloaded", path)
-                }
-                #[cfg(feature = "builder-vm")]
-                KernelSource::Auto => match download_workload_kernel(arch, &path) {
-                    Ok(()) => ("downloaded", path),
-                    Err(download_error) => {
-                        ui::warn(&format!(
-                            "Published workload kernel unavailable ({download_error}); building it locally from the source checkout."
-                        ));
-                        ("built", build_local_workload_kernel()?)
-                    }
-                },
-                KernelSource::Compile => ("built", build_local_workload_kernel()?),
+    let mut resolved = resolve_kernel(&cache, arch, "workload", source_checkout);
+
+    if let KernelResolution::Cached(verified) = &resolved {
+        let cached = verified.path().display().to_string();
+        if let Err(error) = assert_workload_kernel_supports_verity(&cached) {
+            ui::warn(&format!(
+                "Cached workload kernel capability check failed ({error}); discarding it and preparing a correct kernel."
+            ));
+            evict_incompatible_workload_kernel(verified.path())?;
+            resolved = resolve_kernel(&cache, arch, "workload", source_checkout);
+        }
+    }
+
+    let source = workload_kernel_source(source_checkout);
+    let (provenance, path, produced) = match resolved {
+        KernelResolution::Cached(verified) => {
+            ("cached", verified.path().display().to_string(), false)
+        }
+        KernelResolution::NeedsBuild(dest) | KernelResolution::NeedsFetch(dest) => {
+            let (provenance, path) = acquire_workload_kernel(source, source_checkout, arch, &dest)?;
+            (provenance, path, true)
+        }
+    };
+
+    // Re-enter the shared resolver after every producer. This makes a missing
+    // or mismatched digest an acquisition failure instead of allowing the
+    // caller to boot bytes merely because the destination path exists.
+    let verified_path = if produced {
+        match resolve_kernel(&cache, arch, "workload", source_checkout) {
+            KernelResolution::Cached(verified) => verified.path().display().to_string(),
+            KernelResolution::NeedsBuild(dest) | KernelResolution::NeedsFetch(dest) => {
+                anyhow::bail!(
+                    "workload kernel producer left no verified artifact at {}",
+                    dest.display()
+                )
             }
         }
-        WorkloadKernelBootstrap::Download(dest) => match workload_kernel_source(source_checkout) {
-            KernelSource::Compile => {
-                if !source_checkout {
-                    anyhow::bail!(
-                        "{} MVM_KERNEL_SOURCE=compile requires an mvm source checkout so the workload kernel can be built locally. Set MVM_KERNEL_SOURCE=download or unset it to use the published kernel.",
-                        missing_workload_kernel_message(&dest)
-                    );
-                }
-                ("built", build_local_workload_kernel()?)
-            }
-            KernelSource::Download => {
-                download_workload_kernel(arch, &dest)?;
-                ("downloaded", dest)
-            }
-            #[cfg(feature = "builder-vm")]
-            KernelSource::Auto => {
-                download_workload_kernel(arch, &dest)?;
-                ("downloaded", dest)
-            }
-        },
+    } else {
+        path.clone()
     };
+    if verified_path != path {
+        anyhow::bail!(
+            "workload kernel producer returned {path}, but the verified cache resolved {verified_path}"
+        );
+    }
+    assert_workload_kernel_supports_verity(&verified_path)?;
     ui::info(&format!("Workload kernel: {provenance} at {path}"));
     Ok(path)
+}
+
+fn acquire_workload_kernel(
+    source: KernelSource,
+    source_checkout: bool,
+    arch: &str,
+    dest: &std::path::Path,
+) -> Result<(&'static str, String)> {
+    match source {
+        KernelSource::Compile => {
+            if !source_checkout {
+                anyhow::bail!(
+                    "{} MVM_KERNEL_SOURCE=compile requires an mvm source checkout so the workload kernel can be built locally. Set MVM_KERNEL_SOURCE=download or unset it to use the published kernel.",
+                    missing_workload_kernel_message(&dest.display().to_string())
+                );
+            }
+            Ok(("built", build_local_workload_kernel()?))
+        }
+        KernelSource::Download => {
+            download_workload_kernel(arch, dest)?;
+            Ok(("downloaded", dest.display().to_string()))
+        }
+        #[cfg(feature = "builder-vm")]
+        KernelSource::Auto => match download_workload_kernel(arch, dest) {
+            Ok(()) => Ok(("downloaded", dest.display().to_string())),
+            Err(download_error) if source_checkout => {
+                ui::warn(&format!(
+                    "Published workload kernel unavailable ({download_error}); building it locally from the source checkout."
+                ));
+                Ok(("built", build_local_workload_kernel()?))
+            }
+            Err(download_error) => Err(download_error),
+        },
+    }
 }
 
 #[cfg(feature = "builder-vm")]
@@ -92,7 +128,7 @@ pub(super) fn default_workload_kernel_source(source_checkout: bool) -> KernelSou
 #[cfg(feature = "builder-vm")]
 fn build_local_workload_kernel() -> Result<String> {
     ui::notice(
-        "No cached workload kernel. Building it once in Stage 0; the first run can take several minutes, then warm starts use the cache.",
+        "Preparing the workload kernel using the Stage 0 builder. The first source build can take several minutes; the persistent Nix store and finished kernel are reused afterward.",
     );
     let path = build_kernel_via_stage0(KernelVariant::Workload, false)
         .context(
@@ -112,59 +148,61 @@ fn build_local_workload_kernel() -> Result<String> {
     )
 }
 
-/// Whether a kernel image carries device-mapper + dm-verity support (needed to
-/// boot a verity-sealed rootfs). `None` when the input is not a readable,
-/// uncompressed kernel we can judge (a compressed `Image`, a truncated file, or
-/// any non-kernel blob) — callers must NOT block on `None`. `Some(false)` only
-/// when the kernel is readable yet carries no device-mapper/dm-verity symbol at
-/// all — the signature of a kernel built without `CONFIG_BLK_DEV_DM`/`DM_VERITY`
-/// (e.g. the builder kernel, which force-drops them).
-pub(super) fn kernel_carries_dm_verity(bytes: &[u8]) -> Option<bool> {
-    // Only an uncompressed vmlinux exposes symbol strings; anything else is
-    // inconclusive, and blocking on it would false-reject a valid kernel.
-    if !byte_contains(bytes, b"Linux version") {
+pub(super) fn workload_config_carries_dm_verity(config: &str) -> Option<bool> {
+    if !config
+        .lines()
+        .any(|line| line.starts_with("CONFIG_") || line.starts_with("# CONFIG_"))
+    {
         return None;
     }
-    // A dm-verity-capable kernel carries these device-mapper / dm-verity symbols
-    // (via KALLSYMS + the dm subsystem's log strings). A kernel built without the
-    // device-mapper umbrella carries none of them.
-    const MARKERS: &[&[u8]] = &[
-        b"device-mapper",
-        b"dm_bufio",
-        b"verity_ctr",
-        b"dm_table_create",
-        b"dm-verity",
-    ];
-    Some(MARKERS.iter().any(|m| byte_contains(bytes, m)))
-}
-
-/// Substring search across a whole kernel image.
-///
-/// `windows(n).any(..)` is the obvious spelling and is quadratic: it compares
-/// at every offset with no way to skip ahead. Over an 8 MB `vmlinux`, repeated
-/// once per marker, that is milliseconds of every launch — and the refusal
-/// case pays the most, because it is the one that finds no marker and so scans
-/// the image for all of them. `memmem` skips, and is already linked in.
-fn byte_contains(haystack: &[u8], needle: &[u8]) -> bool {
-    needle.len() <= haystack.len() && memchr::memmem::find(haystack, needle).is_some()
+    Some(
+        config.lines().any(|line| line == "CONFIG_BLK_DEV_DM=y")
+            && config.lines().any(|line| line == "CONFIG_DM_VERITY=y"),
+    )
 }
 
 /// Fail fast when a verity-sealed launch resolved a kernel with no dm-verity
-/// support. Without this the guest panics in early init opening
-/// `/dev/mapper/control` ("No such file or directory") with zero host signal —
-/// so surface a clear host-side error instead. Conservative: only a *readable*
-/// kernel with no dm-verity symbol at all trips it, so an unrecognized/compressed
-/// kernel is never wrongly rejected.
+/// support. Local builds carry their resolved config beside the kernel, which
+/// is authoritative even when the size-optimized image deliberately omits
+/// KALLSYMS and contains no searchable dm-verity symbols. Published kernels
+/// may not carry a local config; their variant-specific release checksum is the
+/// capability identity and the absence of this optional local witness is not a
+/// rejection.
 pub(crate) fn assert_workload_kernel_supports_verity(kernel_path: &str) -> Result<()> {
-    let bytes = std::fs::read(kernel_path)
+    std::fs::metadata(kernel_path)
         .with_context(|| format!("read resolved workload kernel {kernel_path}"))?;
-    if kernel_carries_dm_verity(&bytes) == Some(false) {
+    let config_path = std::path::Path::new(kernel_path).with_file_name("config");
+    let capability = std::fs::read_to_string(&config_path)
+        .ok()
+        .and_then(|config| workload_config_carries_dm_verity(&config));
+    if capability == Some(false) {
         anyhow::bail!(
-            "resolved workload kernel {kernel_path} carries no device-mapper/dm-verity \
-             support, but the workload boots verity-sealed. It would panic the guest at boot \
-             (mvm-verity-init: open /dev/mapper/control: No such file or directory). This \
-             kernel cannot back a sealed workload — rebuild it with `mvmctl kernel build --which workload` or resolve a published kernel."
+            "resolved workload kernel {kernel_path} has a config without CONFIG_BLK_DEV_DM=y \
+             and CONFIG_DM_VERITY=y, but the workload boots verity-sealed. This kernel cannot \
+             back a sealed workload"
         );
+    }
+    Ok(())
+}
+
+pub(super) fn evict_incompatible_workload_kernel(kernel: &std::path::Path) -> Result<()> {
+    for path in [
+        kernel.to_path_buf(),
+        mvm_build::kernel_fetch::kernel_digest_sidecar(kernel),
+        kernel.with_file_name("config"),
+    ] {
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "discarding incompatible workload kernel file {}",
+                        path.display()
+                    )
+                });
+            }
+        }
     }
     Ok(())
 }
@@ -227,36 +265,6 @@ fn embedded_verity_init_bytes() -> Option<&'static [u8]> {
         .filter(|b| !b.is_empty())
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum WorkloadKernelBootstrap {
-    Cached(String),
-    BuildLocal(String),
-    Download(String),
-}
-
-pub(super) fn resolve_workload_kernel_bootstrap(
-    cache_dir: &str,
-    arch: &str,
-    source_checkout: bool,
-) -> WorkloadKernelBootstrap {
-    if let Some(cached) = find_cached_workload_kernel(cache_dir, arch) {
-        return WorkloadKernelBootstrap::Cached(cached);
-    }
-    // The workload always boots through the verity initrd (mvm-verity-init opens
-    // /dev/mapper/control and builds the dm-verity target), so its kernel must
-    // carry device-mapper + dm-verity built in. The builder kernel force-drops
-    // both (it boots `root=/dev/vda ro` with no roothash), so it can never stand
-    // in for the workload kernel — reusing it panics the guest at boot. Always
-    // resolve the real workload kernel: build it (source checkout) or download
-    // the published one.
-    let dest = format!("{cache_dir}/builder-vm/{arch}/kernels/workload/vmlinux");
-    if source_checkout {
-        WorkloadKernelBootstrap::BuildLocal(dest)
-    } else {
-        WorkloadKernelBootstrap::Download(dest)
-    }
-}
-
 pub(super) fn missing_workload_kernel_message(expected_path: &str) -> String {
     format!(
         "workload kernel missing (expected at {expected_path}). \
@@ -267,48 +275,8 @@ pub(super) fn missing_workload_kernel_message(expected_path: &str) -> String {
     )
 }
 
-fn download_workload_kernel(arch: &str, dest: &str) -> Result<()> {
-    if let Some(parent) = std::path::Path::new(dest).parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let version = env!("CARGO_PKG_VERSION");
-    let base_url = format!("https://github.com/tinylabscom/mvm/releases/download/v{version}");
-    let asset = format!("vmlinux-{arch}-workload");
-    let checksums_url = format!("{base_url}/kernel-{arch}-checksums-sha256.txt");
-
-    ui::info(&format!(
-        "Downloading workload kernel {asset} (v{version})..."
-    ));
-    let expected = fetch_expected_hashes(&checksums_url, &[asset.as_str()])?;
-    let asset_url = format!("{base_url}/{asset}");
-    download_file(&asset_url, dest).with_context(|| format!("Failed to download {asset_url}"))?;
-    verify_artifact_hash(dest, &asset, expected.get(&asset))?;
-    ui::success(&format!(
-        "Workload kernel {asset} downloaded, hash-verified, and cached."
-    ));
-    Ok(())
-}
-
-/// The dedicated workload kernel, or `None` when it has not been built or
-/// downloaded yet.
-///
-/// Only the dedicated kernel qualifies. The default-microvm images ship a
-/// general-purpose NixOS kernel, and borrowing it used to be allowed here —
-/// which meant that on a host with no workload kernel cached, a workload
-/// silently booted a kernel built for a different job. Those kernels enable
-/// `CONFIG_USER_NS`, which the workload kernel deliberately leaves unset, so
-/// the borrow handed the guest a user-namespace escape hatch the workload
-/// kernel exists to remove. It was invisible: same command, same image, and a
-/// posture that depended on which kernels happened to be in the local cache.
-///
-/// A cold cache is now resolved by building or downloading the real workload
-/// kernel — which is what the caller already does, and what its own comment
-/// already claimed it did.
-pub(super) fn find_cached_workload_kernel(cache_dir: &str, arch: &str) -> Option<String> {
-    let dedicated = format!("{cache_dir}/builder-vm/{arch}/kernels/workload/vmlinux");
-    std::path::Path::new(&dedicated)
-        .is_file()
-        .then_some(dedicated)
+fn download_workload_kernel(arch: &str, dest: &std::path::Path) -> Result<()> {
+    crate::update::download_kernel(arch, "workload", dest)
 }
 
 fn ensure_default_microvm_prod_image(cache_dir: &str) -> Result<(String, String)> {

--- a/crates/mvm-cli/src/commands/env/builder_vm/kernel.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/kernel.rs
@@ -183,6 +183,13 @@ pub(crate) fn build_kernel_via_stage0(
         .with_context(|| format!("creating kernel cache dir {out_dir}"))?;
 
     let _stage0_guard = acquire_stage0_lock(&out_dir)?;
+    let removed = sweep_stage0_staging_siblings(out_dir_path)?;
+    if removed > 0 {
+        ui::info(&format!(
+            "Removed {removed} incomplete Stage 0 kernel build director{} from an earlier interruption.",
+            if removed == 1 { "y" } else { "ies" }
+        ));
+    }
 
     let stage0_assets = mvm_build::stage0::assets_for_host_arch();
     let vendor_reports = mvm_build::stage0::prepare_assets(stage0_assets)
@@ -271,38 +278,127 @@ pub(crate) fn build_kernel_via_stage0(
         result.map_err(|e| anyhow::anyhow!("Stage 0 kernel build: {e}"))?;
     }
 
+    let published = publish_kernel_artifacts(&staging_dir, out_dir_path, variant);
+    let _ = std::fs::remove_dir_all(&staging_dir);
+    published
+}
+
+#[cfg(feature = "builder-vm")]
+fn publish_kernel_artifacts(
+    staging_dir: &std::path::Path,
+    out_dir: &std::path::Path,
+    variant: KernelVariant,
+) -> Result<std::path::PathBuf> {
     let built = staging_dir.join("vmlinux");
-    if !built.is_file() {
-        let _ = std::fs::remove_dir_all(&staging_dir);
-        anyhow::bail!(
-            "Stage 0 produced no kernel at {} (attr {})",
-            built.display(),
-            variant.attr()
-        );
+    let kernel_bytes = std::fs::read(&built)
+        .with_context(|| format!("reading Stage 0 kernel {}", built.display()))?;
+    if kernel_bytes.is_empty() {
+        anyhow::bail!("Stage 0 produced an empty kernel at {}", built.display());
     }
-    let dest = out_dir_path.join("vmlinux");
-    std::fs::copy(&built, &dest)
-        .with_context(|| format!("copying kernel to {}", dest.display()))?;
 
     let staged_config = staging_dir.join("mvm-kernel.config");
-    if staged_config.is_file() {
-        let config_dest = out_dir_path.join("config");
-        if let Err(e) = std::fs::copy(&staged_config, &config_dest) {
-            ui::warn(&format!("could not cache the resolved kernel config: {e}"));
-        }
+    let config = std::fs::read_to_string(&staged_config)
+        .with_context(|| format!("reading resolved kernel config {}", staged_config.display()))?;
+    if workload_config_carries_dm_verity(&config).is_none() {
+        anyhow::bail!(
+            "Stage 0 produced no usable resolved kernel config at {}",
+            staged_config.display()
+        );
     }
-    let _ = std::fs::remove_dir_all(&staging_dir);
-
-    // A locally built kernel has no published checksum to check against — a
-    // source checkout is never fetched. The pin records what we just built, so
-    // a later read can still catch rot, truncation, or a swap. It claims that
-    // and nothing more.
-    if let Err(e) = mvm_build::kernel_fetch::record_kernel_digest(&dest) {
-        ui::warn(&format!(
-            "could not record the kernel digest beside {} ({e}); it will be rebuilt on next use",
-            dest.display()
-        ));
+    if variant == KernelVariant::Workload
+        && workload_config_carries_dm_verity(&config) != Some(true)
+    {
+        anyhow::bail!(
+            "Stage 0 workload config must contain CONFIG_BLK_DEV_DM=y and CONFIG_DM_VERITY=y"
+        );
     }
 
+    std::fs::create_dir_all(out_dir)
+        .with_context(|| format!("creating kernel cache dir {}", out_dir.display()))?;
+    let config_dest = out_dir.join("config");
+    mvm_core::util::atomic_io::atomic_write(&config_dest, config.as_bytes())
+        .with_context(|| format!("publishing kernel config {}", config_dest.display()))?;
+    let dest = out_dir.join("vmlinux");
+    mvm_core::util::atomic_io::atomic_write(&dest, &kernel_bytes)
+        .with_context(|| format!("publishing kernel {}", dest.display()))?;
+
+    // A locally built kernel has no published checksum to compare against. The
+    // sidecar records the bytes Stage 0 just produced so later reads detect
+    // truncation, rot, or replacement. Failure is fatal and evicts the kernel:
+    // no producer may leave a path that the verified resolver cannot serve.
+    if let Err(error) = mvm_build::kernel_fetch::record_kernel_digest(&dest) {
+        let _ = std::fs::remove_file(&dest);
+        let _ = std::fs::remove_file(&config_dest);
+        return Err(error).context("recording locally built kernel digest");
+    }
     Ok(dest)
+}
+
+#[cfg(all(test, feature = "builder-vm"))]
+mod tests {
+    use super::*;
+
+    fn stage_kernel(dir: &std::path::Path, kernel: &[u8], config: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join("vmlinux"), kernel).unwrap();
+        std::fs::write(dir.join("mvm-kernel.config"), config).unwrap();
+    }
+
+    #[test]
+    fn workload_publish_requires_dm_verity_config_and_preserves_old_cache_on_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let staging = tmp.path().join("staging");
+        let live = tmp.path().join("workload");
+        stage_kernel(
+            &staging,
+            b"new kernel",
+            "# CONFIG_BLK_DEV_DM is not set\n# CONFIG_DM_VERITY is not set\n",
+        );
+        std::fs::create_dir_all(&live).unwrap();
+        std::fs::write(live.join("vmlinux"), b"old kernel").unwrap();
+        mvm_build::kernel_fetch::record_kernel_digest(&live.join("vmlinux")).unwrap();
+
+        let err = publish_kernel_artifacts(&staging, &live, KernelVariant::Workload).unwrap_err();
+
+        assert!(err.to_string().contains("CONFIG_DM_VERITY=y"));
+        assert_eq!(std::fs::read(live.join("vmlinux")).unwrap(), b"old kernel");
+        let expected = mvm_fs::overlay::compute_file_sha256(&live.join("vmlinux")).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(mvm_build::kernel_fetch::kernel_digest_sidecar(
+                &live.join("vmlinux")
+            ))
+            .unwrap()
+            .trim(),
+            expected
+        );
+    }
+
+    #[test]
+    fn workload_publish_installs_validated_kernel_config_and_digest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let staging = tmp.path().join("staging");
+        let live = tmp.path().join("workload");
+        stage_kernel(
+            &staging,
+            b"new kernel",
+            "CONFIG_MD=y\nCONFIG_BLK_DEV_DM=y\nCONFIG_DM_VERITY=y\n",
+        );
+
+        let kernel = publish_kernel_artifacts(&staging, &live, KernelVariant::Workload).unwrap();
+
+        assert_eq!(kernel, live.join("vmlinux"));
+        assert_eq!(std::fs::read(&kernel).unwrap(), b"new kernel");
+        assert!(
+            std::fs::read_to_string(live.join("config"))
+                .unwrap()
+                .contains("CONFIG_DM_VERITY=y")
+        );
+        let expected = mvm_fs::overlay::compute_file_sha256(&kernel).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(mvm_build::kernel_fetch::kernel_digest_sidecar(&kernel))
+                .unwrap()
+                .trim(),
+            expected
+        );
+    }
 }

--- a/crates/mvm-cli/src/commands/env/builder_vm/stage0_cache.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/stage0_cache.rs
@@ -1,5 +1,33 @@
 use super::*;
 
+#[cfg(any(feature = "builder-vm", test))]
+static ACTIVE_STAGE0_BUILDS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Held for the lifetime of an in-process Stage 0 build. The inner file lock
+/// serializes the shared store; the process-local count lets Ctrl-C explain
+/// exactly what was interrupted without probing another process's lock.
+#[cfg(any(feature = "builder-vm", test))]
+pub(super) struct Stage0LockGuard {
+    _lock: mvm_core::atomic_io::FileLock,
+}
+
+#[cfg(any(feature = "builder-vm", test))]
+impl Drop for Stage0LockGuard {
+    fn drop(&mut self) {
+        ACTIVE_STAGE0_BUILDS.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+pub(in crate::commands) fn stage0_active_in_process() -> bool {
+    #[cfg(any(feature = "builder-vm", test))]
+    {
+        ACTIVE_STAGE0_BUILDS.load(std::sync::atomic::Ordering::SeqCst) > 0
+    }
+    #[cfg(not(any(feature = "builder-vm", test)))]
+    false
+}
+
 /// Which phase of Stage 0 failed. Each variant maps to a
 /// `stage=...` value in the `Stage0Failed` audit detail so a dashboard
 /// can break down "Stage 0 reliability" by failure phase. String
@@ -104,7 +132,7 @@ pub(super) fn stage0_failure_reason_summary(err: &anyhow::Error) -> String {
 /// the lock anchor is its sibling `stage0` (so `FileLock::try_acquire`
 /// produces `stage0.lock`).
 #[cfg(any(feature = "builder-vm", test))]
-pub(super) fn acquire_stage0_lock(out_dir: &str) -> Result<mvm_core::atomic_io::FileLock> {
+pub(super) fn acquire_stage0_lock(out_dir: &str) -> Result<Stage0LockGuard> {
     use mvm_core::atomic_io::FileLock;
 
     let parent = std::path::Path::new(out_dir)
@@ -115,7 +143,10 @@ pub(super) fn acquire_stage0_lock(out_dir: &str) -> Result<mvm_core::atomic_io::
     let lock_anchor = parent.join("stage0");
 
     match FileLock::try_acquire(&lock_anchor) {
-        Ok(Some(guard)) => Ok(guard),
+        Ok(Some(guard)) => {
+            ACTIVE_STAGE0_BUILDS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(Stage0LockGuard { _lock: guard })
+        }
         Ok(None) => anyhow::bail!(
             "another caller of Stage 0 is already bootstrapping the \
              builder VM image on this host (lock held at {}.lock). Wait for it to finish, or — \
@@ -125,6 +156,38 @@ pub(super) fn acquire_stage0_lock(out_dir: &str) -> Result<mvm_core::atomic_io::
         ),
         Err(e) => Err(e.context("acquiring Stage 0 advisory lock")),
     }
+}
+
+/// Remove incomplete Stage 0 directories belonging to one final cache
+/// directory. The caller holds the shared Stage 0 lock, so every matching
+/// sibling is from an earlier interrupted process rather than a live writer.
+#[cfg(any(feature = "builder-vm", test))]
+pub(super) fn sweep_stage0_staging_siblings(final_dir: &std::path::Path) -> Result<u64> {
+    let parent = final_dir.parent().ok_or_else(|| {
+        anyhow::anyhow!("Stage 0 cache path has no parent: {}", final_dir.display())
+    })?;
+    if !parent.is_dir() {
+        return Ok(0);
+    }
+    let name = final_dir
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| anyhow::anyhow!("kernel cache basename is not UTF-8"))?;
+    let prefix = format!(".{name}.stage0-");
+    let mut removed = 0u64;
+    for entry in std::fs::read_dir(parent)
+        .with_context(|| format!("reading Stage 0 cache parent {}", parent.display()))?
+        .flatten()
+    {
+        let path = entry.path();
+        if !path.is_dir() || !entry.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        std::fs::remove_dir_all(&path)
+            .with_context(|| format!("removing interrupted Stage 0 output {}", path.display()))?;
+        removed = removed.saturating_add(1);
+    }
+    Ok(removed)
 }
 
 #[cfg(any(feature = "builder-vm", test))]

--- a/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
@@ -65,10 +65,7 @@ mod builder_backend_attempt_order_tests {
 #[cfg(test)]
 mod default_microvm_tests {
     use super::default_microvm::default_workload_kernel_source;
-    use super::{
-        KernelSource, WorkloadKernelBootstrap, default_microvm_assets, find_cached_workload_kernel,
-        missing_workload_kernel_message, resolve_workload_kernel_bootstrap,
-    };
+    use super::{KernelSource, default_microvm_assets, missing_workload_kernel_message};
 
     #[test]
     fn default_microvm_assets_pins_the_five_asset_contract() {
@@ -107,52 +104,22 @@ mod default_microvm_tests {
     fn no_default_microvm_kernel_is_ever_reused_as_the_workload_kernel() {
         for variant in ["dev", "prod"] {
             let tmp = tempfile::tempdir().unwrap();
-            let cache_dir = tmp.path().to_string_lossy().to_string();
             let kernel = tmp
                 .path()
                 .join(format!("default-microvm/{variant}/vmlinux"));
             std::fs::create_dir_all(kernel.parent().unwrap()).unwrap();
             std::fs::write(&kernel, b"default-kernel").unwrap();
 
-            assert_eq!(
-                find_cached_workload_kernel(&cache_dir, "x86_64"),
-                None,
+            let resolved =
+                mvm_build::kernel_fetch::resolve_kernel(tmp.path(), "x86_64", "workload", true);
+            assert!(
+                matches!(
+                    resolved,
+                    mvm_build::kernel_fetch::KernelResolution::NeedsBuild(_)
+                ),
                 "the {variant} default-microvm kernel must not stand in for the workload kernel"
             );
         }
-    }
-
-    #[test]
-    fn prod_workload_kernel_bootstrap_downloads_when_only_dev_default_kernel_exists() {
-        let tmp = tempfile::tempdir().unwrap();
-        let cache_dir = tmp.path().to_string_lossy().to_string();
-        let dev_kernel = tmp.path().join("default-microvm/dev/vmlinux");
-        std::fs::create_dir_all(dev_kernel.parent().unwrap()).unwrap();
-        std::fs::write(&dev_kernel, b"dev-kernel").unwrap();
-
-        let resolved = resolve_workload_kernel_bootstrap(&cache_dir, "x86_64", false);
-        assert_eq!(
-            resolved,
-            WorkloadKernelBootstrap::Download(format!(
-                "{cache_dir}/builder-vm/{}/kernels/workload/vmlinux",
-                "x86_64"
-            ))
-        );
-    }
-
-    #[test]
-    fn prod_workload_kernel_bootstrap_builds_locally_from_source_checkout() {
-        let tmp = tempfile::tempdir().unwrap();
-        let cache_dir = tmp.path().to_string_lossy().to_string();
-
-        let resolved = resolve_workload_kernel_bootstrap(&cache_dir, "x86_64", true);
-        assert_eq!(
-            resolved,
-            WorkloadKernelBootstrap::BuildLocal(format!(
-                "{cache_dir}/builder-vm/{}/kernels/workload/vmlinux",
-                "x86_64"
-            ))
-        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -152,11 +152,11 @@ pub(in crate::commands) enum Commands {
     /// Internal SDK host-dispatch transport for `MVM_NO_VM=1`.
     #[command(name = "__sdk-no-vm", hide = true)]
     SdkNoVm(vm::sdk_no_vm::Args),
-    /// Prepare the environment + pre-fetch the builder VM image
+    /// Prepare the environment and machine infrastructure
     ///
-    /// Runs host-tooling setup and pre-acquires the builder VM image so the
-    /// first build is fast. Run automatically by install.sh unless
-    /// `MVM_SKIP_BUILDER_PREFETCH=1`.
+    /// Runs host-tooling setup and pre-acquires the builder VM image plus the
+    /// verified workload kernel. Run automatically by install.sh unless
+    /// `MVM_SKIP_BOOTSTRAP=1`.
     Bootstrap(bootstrap::Args),
     /// Internal: bootstrap only the builder VM image cache.
     #[command(name = "__builder-vm-bootstrap", hide = true)]
@@ -512,7 +512,8 @@ fn install_signal_handler() {
         if IN_CONSOLE_MODE.load(std::sync::atomic::Ordering::SeqCst) {
             return;
         }
-        eprintln!("\nInterrupted, cleaning up...");
+        let stage0_active = env::builder_vm::stage0_active_in_process();
+        eprintln!("\n{}", interrupt_cleanup_message(stage0_active));
         let _ = mvm_runtime::handle_registry::stop_all_attached();
         if let Ok(pids) = pids.lock() {
             for &pid in pids.iter() {
@@ -524,6 +525,35 @@ fn install_signal_handler() {
         std::process::exit(130);
     }) {
         tracing::warn!("failed to install signal handler: {e}");
+    }
+}
+
+fn interrupt_cleanup_message(stage0_active: bool) -> &'static str {
+    if stage0_active {
+        "Stage 0 build interrupted; no incomplete artifact was cached. The persistent Nix build store was preserved for retry. Cleaning up..."
+    } else {
+        "Interrupted, cleaning up..."
+    }
+}
+
+#[cfg(test)]
+mod interrupt_message_tests {
+    use super::interrupt_cleanup_message;
+
+    #[test]
+    fn stage0_interrupt_explains_cache_and_retry_state() {
+        let message = interrupt_cleanup_message(true);
+        assert!(message.contains("Stage 0 build interrupted"));
+        assert!(message.contains("incomplete artifact was cached"));
+        assert!(message.contains("Nix build store was preserved"));
+    }
+
+    #[test]
+    fn ordinary_interrupt_keeps_the_generic_cleanup_message() {
+        assert_eq!(
+            interrupt_cleanup_message(false),
+            "Interrupted, cleaning up..."
+        );
     }
 }
 

--- a/crates/mvm-cli/src/update.rs
+++ b/crates/mvm-cli/src/update.rs
@@ -212,10 +212,9 @@ fn download_release(version: &str, target: &str, tmp_dir: &Path) -> Result<()> {
 /// `MVM_SKIP_HASH_VERIFY` is the documented emergency escape — never
 /// set it in CI.
 ///
-/// Gated to `builder-vm`: the only callers (`mvmctl kernel build`'s
-/// download arm + the `mvmctl bootstrap --kernel-source` path) live behind
-/// that feature.
-#[cfg(feature = "builder-vm")]
+/// Available without `builder-vm`: lean clients cannot compile kernels
+/// locally, so downloading the release-matched kernel is their supported
+/// acquisition path.
 pub(crate) fn download_kernel(arch: &str, variant: &str, dest: &Path) -> Result<()> {
     let tag = format!("v{}", current_version());
     let asset = format!("vmlinux-{arch}-{variant}");
@@ -282,16 +281,11 @@ pub(crate) fn download_kernel(arch: &str, variant: &str, dest: &Path) -> Result<
 /// Record the fetched kernel's digest beside it so the *read* path can check
 /// it later.
 ///
-/// Gated to match `download_kernel`, its only caller. Without the gate it is
-/// dead code in every build that compiles this crate without `builder-vm` —
-/// invisible to the default workspace run, caught by the feature-matrix lanes.
-///
 /// The checksum-manifest comparison above happens once, at fetch. Nothing
 /// re-derived it afterwards, so a kernel that rotted, was truncated, or was
 /// replaced on disk was served on the strength of its filename. The staged
 /// download is renamed into place only after checksum verification, and a
 /// sidecar failure evicts it rather than leaving an unservable cache entry.
-#[cfg(feature = "builder-vm")]
 fn publish_downloaded_kernel(download: tempfile::TempPath, dest: &Path) -> Result<()> {
     download
         .persist(dest)

--- a/crates/mvm-cli/src/update.rs
+++ b/crates/mvm-cli/src/update.rs
@@ -228,8 +228,19 @@ pub(crate) fn download_kernel(arch: &str, variant: &str, dest: &Path) -> Result<
     }
 
     let asset_url = format!("{base}/{GITHUB_REPO}/releases/download/{tag}/{asset}");
+    let parent = dest
+        .parent()
+        .with_context(|| format!("kernel destination has no parent: {}", dest.display()))?;
+    let download = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| {
+            format!(
+                "creating kernel download staging file in {}",
+                parent.display()
+            )
+        })?
+        .into_temp_path();
     let sp = ui::spinner(&format!("Downloading {asset} ({tag})..."));
-    let dl = http::download_file(&asset_url, dest);
+    let dl = http::download_file(&asset_url, &download);
     sp.finish_and_clear();
     dl.with_context(|| {
         format!(
@@ -240,7 +251,7 @@ pub(crate) fn download_kernel(arch: &str, variant: &str, dest: &Path) -> Result<
 
     if std::env::var("MVM_SKIP_HASH_VERIFY").is_ok() {
         ui::warn("MVM_SKIP_HASH_VERIFY set — skipping kernel checksum verification (never in CI).");
-        record_kernel_pin(dest);
+        publish_downloaded_kernel(download, dest)?;
         return Ok(());
     }
 
@@ -252,20 +263,19 @@ pub(crate) fn download_kernel(arch: &str, variant: &str, dest: &Path) -> Result<
         .with_context(|| format!("{asset} not found in {checksums}"))
         .and_then(parse_checksum_line)?;
 
-    let bytes =
-        std::fs::read(dest).with_context(|| format!("reading {} for checksum", dest.display()))?;
+    let bytes = std::fs::read(&download)
+        .with_context(|| format!("reading {} for checksum", download.display()))?;
     let actual: [u8; 32] = Sha256::digest(&bytes).into();
     if actual != expected {
-        let _ = std::fs::remove_file(dest);
         anyhow::bail!(
             "Kernel checksum mismatch for {asset}!\n  expected: {}\n  actual:   {}\n\
-             Download rejected and removed.",
+             Staged download rejected; any existing cached kernel was preserved.",
             hex_encode(&expected),
             hex_encode(&actual),
         );
     }
     ui::success(&format!("Verified {asset}."));
-    record_kernel_pin(dest);
+    publish_downloaded_kernel(download, dest)?;
     Ok(())
 }
 
@@ -278,17 +288,21 @@ pub(crate) fn download_kernel(arch: &str, variant: &str, dest: &Path) -> Result<
 ///
 /// The checksum-manifest comparison above happens once, at fetch. Nothing
 /// re-derived it afterwards, so a kernel that rotted, was truncated, or was
-/// replaced on disk was served on the strength of its filename. Best-effort:
-/// failing to write the pin costs a re-fetch next time, which is the safe
-/// direction.
+/// replaced on disk was served on the strength of its filename. The staged
+/// download is renamed into place only after checksum verification, and a
+/// sidecar failure evicts it rather than leaving an unservable cache entry.
 #[cfg(feature = "builder-vm")]
-fn record_kernel_pin(dest: &Path) {
-    if let Err(e) = mvm_build::kernel_fetch::record_kernel_digest(dest) {
-        ui::warn(&format!(
-            "could not record the kernel digest beside {} ({e}); it will be re-fetched on next use",
-            dest.display()
-        ));
+fn publish_downloaded_kernel(download: tempfile::TempPath, dest: &Path) -> Result<()> {
+    download
+        .persist(dest)
+        .map_err(|error| error.error)
+        .with_context(|| format!("publishing downloaded kernel to {}", dest.display()))?;
+    if let Err(error) = mvm_build::kernel_fetch::record_kernel_digest(dest) {
+        let _ = std::fs::remove_file(dest);
+        let _ = std::fs::remove_file(mvm_build::kernel_fetch::kernel_digest_sidecar(dest));
+        return Err(error).context("recording downloaded kernel digest");
     }
+    Ok(())
 }
 
 /// Check if a directory is writable by the current user.
@@ -892,6 +906,27 @@ mod tests {
             valid_targets.contains(&target),
             "Unexpected target: {}",
             target
+        );
+    }
+
+    #[cfg(feature = "builder-vm")]
+    #[test]
+    fn downloaded_kernel_publish_replaces_atomically_and_records_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("vmlinux");
+        std::fs::write(&dest, b"old kernel").unwrap();
+        let mut download = tempfile::NamedTempFile::new_in(dir.path()).unwrap();
+        download.write_all(b"new verified kernel").unwrap();
+        download.flush().unwrap();
+
+        publish_downloaded_kernel(download.into_temp_path(), &dest).unwrap();
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"new verified kernel");
+        let recorded =
+            std::fs::read_to_string(mvm_build::kernel_fetch::kernel_digest_sidecar(&dest)).unwrap();
+        assert_eq!(
+            recorded.trim(),
+            mvm_fs::overlay::compute_file_sha256(&dest).unwrap()
         );
     }
 }

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -118,12 +118,14 @@ fn run_mvmctl_in_isolated_home(world: &mut CliWorld, args: String) {
     let mut cmd = Command::cargo_bin("mvmctl").unwrap_or_else(|e| {
         panic!("mvmctl binary not found ({e}) — run `cargo build --bin mvmctl` before `just bdd`")
     });
-    let output = cmd
-        .args(args.split_whitespace())
+    cmd.args(args.split_whitespace())
         .env("HOME", home.path())
-        .env("MVM_HOME", home.path())
-        .output()
-        .expect("failed to spawn mvmctl");
+        .env("MVM_HOME", home.path());
+    if world.kernel_reacquisition_must_fail {
+        cmd.env("MVM_KERNEL_SOURCE", "download")
+            .env("MVM_UPDATE_DOWNLOAD_URL", "http://127.0.0.1:9");
+    }
+    let output = cmd.output().expect("failed to spawn mvmctl");
     world.last_run = Some(output);
 }
 
@@ -144,14 +146,39 @@ fn isolated_mvm_home_with_non_verity_kernel(world: &mut CliWorld) {
         .join("kernels")
         .join("workload");
     std::fs::create_dir_all(&kernel_dir).expect("create fake workload kernel cache dir");
-    // A kernel file that is recognisably a kernel but carries no device-mapper /
-    // dm-verity markers, so `assert_workload_kernel_supports_verity` fails fast.
+    let kernel = kernel_dir.join("vmlinux");
+    std::fs::write(&kernel, b"KALLSYMS-free fake kernel bytes\n")
+        .expect("write fake workload kernel");
+    mvm_build::kernel_fetch::record_kernel_digest(&kernel)
+        .expect("record fake workload kernel digest");
     std::fs::write(
-        kernel_dir.join("vmlinux"),
-        b"Linux version 6.12.0 (fake non-verity kernel for BDD)\n",
+        kernel_dir.join("config"),
+        "# CONFIG_BLK_DEV_DM is not set\n# CONFIG_DM_VERITY is not set\n",
     )
-    .expect("write fake workload kernel");
+    .expect("write fake non-verity kernel config");
     world.isolated_home = Some(home);
+    world.kernel_reacquisition_must_fail = true;
+}
+
+#[then(expr = "the incompatible workload kernel cache is evicted")]
+fn incompatible_workload_kernel_cache_is_evicted(world: &mut CliWorld) {
+    let home = world
+        .isolated_home
+        .as_ref()
+        .expect("isolated home must remain available");
+    let kernel_dir = home
+        .path()
+        .join("cache")
+        .join("builder-vm")
+        .join(std::env::consts::ARCH)
+        .join("kernels")
+        .join("workload");
+    for name in ["vmlinux", "vmlinux.sha256", "config"] {
+        assert!(
+            !kernel_dir.join(name).exists(),
+            "incompatible cache member {name} survived"
+        );
+    }
 }
 
 #[given(expr = "warm residency is enabled")]

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -157,6 +157,9 @@ pub struct CliWorld {
     /// An isolated `MVM_HOME` created by a `Given` step and reused by later
     /// steps that need to inspect the filesystem after a run.
     pub isolated_home: Option<tempfile::TempDir>,
+    /// Force workload-kernel reacquisition through a closed local endpoint so
+    /// invalid-cache scenarios prove eviction without network or Stage 0.
+    pub kernel_reacquisition_must_fail: bool,
     /// Process-wide `MVM_HOME` override held across the steps of one
     /// scenario (dropped — and the previous value restored — when the
     /// world is dropped at scenario end).
@@ -429,6 +432,10 @@ impl fmt::Debug for CliWorld {
             .field(
                 "isolated_home",
                 &self.isolated_home.as_ref().map(|t| t.path().to_path_buf()),
+            )
+            .field(
+                "kernel_reacquisition_must_fail",
+                &self.kernel_reacquisition_must_fail,
             )
             .field("warm_residency", &self.warm_residency)
             .field("kernel_pins", &self.kernel_pins)

--- a/features/suites/s0_cli/machine_run_image_workload_kernel.feature
+++ b/features/suites/s0_cli/machine_run_image_workload_kernel.feature
@@ -1,13 +1,14 @@
 Feature: machine run --image workload-kernel precondition
 
-  Booting an OCI image needs a dm-verity-capable workload kernel. When the
-  cached workload kernel cannot boot a verity-sealed rootfs, `machine run
-  --image` must fail fast with an actionable message *before* pulling the image
-  — never a silent hang after the pull.
+  Booting an OCI image needs a dm-verity-capable workload kernel. When a
+  verified cache entry carries an explicit non-verity config, `machine run
+  --image` must discard the whole entry and start verified reacquisition before
+  pulling the image. This hermetic scenario points reacquisition at a closed
+  local endpoint so it proves the transition without network or Stage 0.
 
-  Scenario: machine run --image fails fast when the workload kernel cannot boot verity-sealed rootfs
+  Scenario: machine run --image evicts an incompatible workload kernel and reacquires it
     Given an isolated mvm home with a cached non-verity workload kernel
     When I run mvmctl in the isolated mvm home with "machine run --image alpine -- /bin/true"
     Then the command exits with code 1
-    And the error output contains "workload kernel"
-    And the error output contains "kernel build --which workload"
+    And the output contains "discarding it and preparing a correct kernel"
+    And the incompatible workload kernel cache is evicted

--- a/features/suites/s14_universal_initramfs/initramfs_cache.feature
+++ b/features/suites/s14_universal_initramfs/initramfs_cache.feature
@@ -4,12 +4,13 @@ Feature: Universal initramfs cache attachment
   local cache.  Its absence must never be the reason a workload fails to start;
   the boot path falls back to the legacy per-rootfs /init when the initramfs is
   not yet cached, and the CLI must fail fast for the *next* real precondition
-  (e.g., an unusable workload kernel) rather than emitting an initramfs error.
+  (e.g., failed verified kernel reacquisition) rather than emitting an initramfs
+  error.
 
   @cli
   Scenario: A cold initramfs cache does not block machine run
     Given an isolated mvm home with a cached non-verity workload kernel
     When I run mvmctl in the isolated mvm home with "machine run --image alpine -- /bin/true"
     Then the command exits with code 1
-    And the error output contains "workload kernel"
+    And the output contains "workload kernel capability check failed"
     And the error output does not contain "initramfs"

--- a/install.sh
+++ b/install.sh
@@ -172,20 +172,20 @@ case ":$PATH:" in
   *) say "Add to PATH:  export PATH=\"$INSTALL_DIR:\$PATH\"" ;;
 esac
 
-# Pre-fetch the builder VM + dev images so the first `mvmctl dev up` is fast
-# instead of paying a one-time download/build on the hot path. Opt out with
-# MVM_SKIP_BUILDER_PREFETCH=1 (bandwidth-limited, headless, or CI installs);
+# Prepare the builder VM and workload kernel ahead of the first machine run
+# instead of paying their one-time download/build cost on the launch path. Opt out with
+# MVM_SKIP_BOOTSTRAP=1 (bandwidth-limited, headless, or CI installs).
 # `mvmctl bootstrap` also honors the finer MVM_SKIP_DEV_IMAGE_PREFETCH knob.
-# Non-fatal: a failure just defers the fetch to first `dev up`.
-if [ "${MVM_SKIP_BUILDER_PREFETCH:-}" != "1" ]; then
-  say "Pre-fetching the builder VM + dev images so your first 'dev up' is instant (skip with MVM_SKIP_BUILDER_PREFETCH=1)..."
+# Non-fatal: a failure defers acquisition to the first command that needs it.
+if [ "${MVM_SKIP_BOOTSTRAP:-}" != "1" ]; then
+  say "Preparing the builder VM and workload kernel for your first machine run (skip with MVM_SKIP_BOOTSTRAP=1)..."
   if "$INSTALL_DIR/mvmctl" bootstrap; then
-    say "Builder VM + dev images ready."
+    say "Builder VM and workload kernel ready."
   else
-    warn "image prefetch failed — 'mvmctl dev up' will fetch on first run, or re-run 'mvmctl bootstrap'."
+    warn "bootstrap failed — the first machine command will retry, or re-run 'mvmctl bootstrap' now."
   fi
 else
-  say "Skipping image prefetch — run 'mvmctl bootstrap' before your first 'dev up' for a fast start."
+  say "Skipping bootstrap — run 'mvmctl bootstrap' before your first machine command for a ready first run."
 fi
 
 say "Run 'mvmctl doctor' to check your host."

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -34,6 +34,14 @@ for detailed scope and acceptance criteria.
       canonical budget table, and gates remain open.
 
 ## In-flight plans
+- [~] Plan 315 — Bootstrap means machine-ready
+      (`specs/plans/315-bootstrap-machine-readiness.md`)
+  - [x] Bootstrap acquires and verifies both builder image and workload kernel
+  - [x] Downloaded/local kernel publication is staged and verified reads fail closed
+  - [x] Local dm-verity capability uses resolved config, not raw-image strings
+  - [~] Workspace tests expose unrelated non-deterministic `mvm-hostd` failures;
+        Linux all-target Clippy remains for CI or a supported builder entry point
+
 - [x] Plan 2167 — durable agent session and event contract
       (`specs/plans/2167-agent-session-contract.md`)
   - [x] Versioned public IDs, lifecycle commands, durable/ephemeral event

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,21 @@
 
 ## Current issue delivery
 
+- [~] Bootstrap machine readiness — **plan 315**. `mvmctl bootstrap` now
+      prepares both the builder VM and verified dm-verity workload kernel, so a
+      successful bootstrap does not defer an infrastructure build to the next
+      `machine run`. Kernel downloads verify before replacement, local Stage 0
+      builds validate every artifact before per-file atomic publication, and
+      verified reads reject any crash-skewed cache. Interrupted staging is swept
+      on retry while the persistent Nix store remains warm. Local capability validation
+      uses the resolved kernel config instead of searching a KALLSYMS-free raw
+      image for symbol strings. Formatting, focused tests, all 172 BDD
+      scenarios, workspace check, and host workspace all-target Clippy pass.
+      Full workspace tests pass the changed crates but expose unrelated,
+      non-deterministic `mvm-hostd` shared-state/timing failures; the Linux
+      all-target Clippy rerun remains for CI or a supported builder-VM entry
+      point.
+
 - [ ] Launch critical-path waste on real-sized images — **issues #2273–#2276,
       plan 311**. Plan 299's prepared-cold baseline runs `alpine`, whose cached
       rootfs is 9.9 MB, and reports the ≤200 ms p50 contract as met. Three

--- a/specs/plans/288-kernel-cache-verify-on-read.md
+++ b/specs/plans/288-kernel-cache-verify-on-read.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Status:** WS1–WS3 landed; WS4 (shared sidecar helper) and WS5 (CI caller gate) open. Completes plan 276 WS6 — its dev-build-artifact half shipped in #2053; this is the kernel half. Not yet scheduled into `specs/SPRINT.md`.
+**Status:** WS1–WS3 landed; WS4 (shared sidecar helper) and WS5 (CI caller gate) open. The 2026-08-10 bootstrap-readiness repair closed the remaining producer interruption gaps and routed the default workload-kernel acquisition through the verified resolver. Completes plan 276 WS6 — its dev-build-artifact half shipped in #2053; this is the kernel half.
 
 **Goal:** No workload or builder kernel is booted from cache without its bytes being checked against a recorded digest. The check must fail closed, evict what it rejects, and be impossible for a future caller to skip by accident.
 
@@ -65,24 +65,24 @@ Plan 276 WS6, second half. Recon §7.1 (`specs/research/uor-hologram-cross-proje
 
 ### WS1 — Make an unverified kernel path unrepresentable
 
-- [ ] Replace `KernelResolution::Cached(PathBuf)` with a variant carrying a type that cannot be constructed without a successful verification (`VerifiedKernel`, private field, constructor only in `kernel_fetch`).
-- [ ] `NeedsBuild` / `NeedsFetch` keep bare paths — they are *destinations*, not artifacts to trust.
-- [ ] The only way to a bootable path is a method on the verified type, so a future caller that skips verification does not compile.
-- [ ] Compile-fail test pinning that boundary (mirror `apple_container`'s existing compile-fail test for its asserter anchor).
+- [x] Replace `KernelResolution::Cached(PathBuf)` with a variant carrying a type that cannot be constructed without a successful verification (`VerifiedKernel`, private field, constructor only in `kernel_fetch`).
+- [x] `NeedsBuild` / `NeedsFetch` keep bare paths — they are *destinations*, not artifacts to trust.
+- [x] The only way to a bootable path is a method on the verified type, so a future caller that skips verification does not compile.
+- [x] Compile-fail test pinning that boundary (mirror `apple_container`'s existing compile-fail test for its asserter anchor).
 
 ### WS2 — Producers record a digest
 
-- [ ] **Fetch path:** after `crate::update::download_kernel`, verify the bytes against the published `checksums-sha256.txt` entry *before* admitting them to the cache, then write the sidecar. This is verify-on-write, which S3's read check then rests on.
-- [ ] **Build path:** after `build_kernel_via_stage0` produces a kernel, write the sidecar from the bytes just built (S2 — records what we built, claims nothing more).
-- [ ] Both writes are atomic (temp + rename) so an interrupted producer cannot leave a sidecar that disagrees with the artifact beside it.
-- [ ] A producer that cannot write a sidecar must not leave the kernel in place — an unverifiable artifact is worse than a missing one, because the next resolve will trust the path.
+- [x] **Fetch path:** after `crate::update::download_kernel`, verify the bytes against the published `checksums-sha256.txt` entry *before* admitting them to the cache, then write the sidecar. This is verify-on-write, which S3's read check then rests on.
+- [x] **Build path:** after `build_kernel_via_stage0` produces a kernel, write the sidecar from the bytes just built (S2 — records what we built, claims nothing more).
+- [x] Both writes are atomic (temp + rename) so an interrupted producer cannot leave a sidecar that disagrees with the artifact beside it.
+- [x] A producer that cannot write a sidecar must not leave the kernel in place — an unverifiable artifact is worse than a missing one, because the next resolve will trust the path.
 
 ### WS3 — Consumers verify on read
 
-- [ ] `resolve_kernel` verifies before returning `Cached`, via `verify_fetched_kernel` — giving that function the production callers it has never had.
-- [ ] On mismatch or missing sidecar: fail closed, evict kernel + sidecar, and fall through to `NeedsBuild` / `NeedsFetch` so the next step re-derives rather than re-adopting.
-- [ ] Update `resolve_pinned_kernel_with` (`crates/mvm-cli/src/commands/vm/up/kernel.rs`) and `mvm_client::local`'s `cached_kernel_path` use to the verified type.
-- [ ] Log the eviction at warn with the reason — a silent re-download is indistinguishable from a slow one.
+- [x] `resolve_kernel` verifies before returning `Cached`, via `verify_fetched_kernel` — giving that function the production callers it has never had.
+- [x] On mismatch or missing sidecar: fail closed, evict kernel + sidecar, and fall through to `NeedsBuild` / `NeedsFetch` so the next step re-derives rather than re-adopting.
+- [x] Update `resolve_pinned_kernel_with` (`crates/mvm-cli/src/commands/vm/up/kernel.rs`) and `mvm_client::local`'s `cached_kernel_path` use to the verified type.
+- [x] Log the eviction at warn with the reason — a silent re-download is indistinguishable from a slow one.
 
 ### WS4 — One sidecar helper, not two
 

--- a/specs/plans/311-launch-critical-path-waste.md
+++ b/specs/plans/311-launch-critical-path-waste.md
@@ -304,6 +304,16 @@ Issue #2274.
 
 Issue #2275.
 
+**Corrected 2026-08-10:** the byte-marker probe was not a valid capability
+witness. The size-optimized raw ARM64 workload image deliberately disables
+`CONFIG_KALLSYMS`, so a correct dm-verity kernel can contain none of the searched
+symbol strings. The resulting linear scan was both launch-path waste and a
+false rejection. Local Stage 0 builds now publish and validate the resolved
+kernel config (`CONFIG_BLK_DEV_DM=y` and `CONFIG_DM_VERITY=y`); published kernels
+are bound to their variant-specific release checksum. No kernel-byte scan runs
+at launch. The historical checklist below records what landed in the original
+phase, but its marker-preservation premise is superseded by this correction.
+
 - [x] Replace `byte_contains`
       (`crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs:141`) with a
       skip-capable substring search. Confirm whether `memchr` is already in the

--- a/specs/plans/315-bootstrap-machine-readiness.md
+++ b/specs/plans/315-bootstrap-machine-readiness.md
@@ -1,0 +1,64 @@
+# Plan 315: Bootstrap means machine-ready
+
+## Status
+
+**Implementation complete; repository-wide verification exceptions documented.** Opened 2026-08-10 after
+an explicit `mvmctl bootstrap` prepared the builder VM but left the workload
+kernel absent, causing the next `machine run --image` to launch Stage 0. The
+interrupted repair then exposed a second defect: Stage 0 copied the resolved Nix
+kernel config as a zero-byte file across the ext4-to-virtio-fs boundary, while a
+byte-marker probe falsely rejected the valid KALLSYMS-free ARM64 kernel.
+
+## Outcome
+
+`mvmctl bootstrap` is one idempotent readiness command for the foundational
+machine path. It prepares host tooling, the builder VM, and the verified workload kernel.
+An interrupted producer never replaces a usable cache entry or leaves a partial
+entry that can be served, and the next retry explains that its persistent Nix
+store remains reusable.
+
+## Work
+
+- [x] Make bootstrap acquire the builder image and workload kernel in dependency
+      order, fail if either is unavailable, and report both as ready.
+- [x] Hard-rename the installer opt-out to the accurate
+      `MVM_SKIP_BOOTSTRAP=1` name.
+- [x] Route default workload-kernel acquisition through the shared verified
+      resolver and re-enter it after every producer.
+- [x] Stage release downloads in the destination directory, verify before
+      publish, preserve an existing cache on checksum failure, and remove a
+      newly published kernel if its digest sidecar cannot be recorded.
+- [x] Publish local kernels only after non-empty kernel and config validation;
+      require workload configs to enable device mapper and dm-verity; write live
+      files atomically and require the digest sidecar.
+- [x] Replace Stage 0 cross-filesystem artifact copies with explicit buffered
+      reads/writes that follow Nix output symlinks and reject empty output.
+- [x] Remove the raw-image byte-marker capability probe. Use the resolved config
+      for local builds and the variant-specific release checksum identity for
+      published kernels, so stripped/KALLSYMS-free kernels are accepted.
+- [x] Track in-process Stage 0 ownership for truthful Ctrl-C messaging, retain
+      the persistent Nix store, and sweep only matching orphan staging
+      directories under the shared Stage 0 lock on retry.
+- [x] Cover bootstrap ordering/failure, verified resolution, incompatible-cache
+      eviction, KALLSYMS-free acceptance, config rejection, atomic publication,
+      interrupted-staging cleanup, buffered symlink copy, and Ctrl-C messaging.
+- [ ] Close repository-wide verification exceptions. Formatting, focused tests,
+      `cargo check --workspace`, host `cargo clippy --workspace --all-targets --
+      -D warnings`, and all 172 BDD scenarios pass. The full workspace test run
+      passes the changed crates but remains red in untouched `mvm-hostd`
+      shared-state/timing tests; isolated reruns produce a different telemetry
+      failure and a hanging UDS test. The Linux all-target Clippy rerun remains
+      for CI or a supported builder-VM execution entry point; the shipped
+      builder is headless and this macOS session must not run Linux tooling
+      outside it.
+
+## Security properties
+
+- Cache presence is never evidence: only `VerifiedKernel` reaches a consumer.
+- Published bytes are checked against the release manifest before replacement.
+- Locally built bytes have integrity identity, not overstated upstream
+  provenance; their sidecar detects truncation, skew, and later replacement.
+- A local workload capability claim is derived from the resolved kernel config,
+  not from an attacker-controlled filename or an unreliable binary substring.
+- Interrupted staging directories are exact-name scoped and removed only while
+  holding the same lock that excludes a live Stage 0 producer.

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -445,7 +445,8 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     // uninstall/update/sign grouped under `env <sub>`.
     ("env", AuditPosture::DelegatesToSub(ENV_SUB)),
     // Top-level `mvmctl bootstrap` — installer surface (host tooling + builder
-    // VM image prefetch). Same posture as `env bootstrap` and `init`.
+    // VM image and workload-kernel acquisition). Same posture as `env bootstrap`
+    // and `init`.
     ("bootstrap", AuditPosture::InteractiveOrControl),
     ("doctor", AuditPosture::ReadOnly),
     // Deploy mutates the local sealed-artifact store and is wrapped by the

--- a/tests/install_sh.rs
+++ b/tests/install_sh.rs
@@ -226,7 +226,7 @@ fn install_sh_downloads_verifies_and_installs() {
 }
 
 #[test]
-fn install_sh_prefetches_builder_image_by_default_and_skips_on_optout() {
+fn install_sh_runs_machine_readiness_bootstrap_by_default_and_honors_optout() {
     let target = host_target();
     let tarball = make_tarball(target);
     let archive = format!("mvmctl-{target}.tar.gz");
@@ -243,7 +243,7 @@ fn install_sh_prefetches_builder_image_by_default_and_skips_on_optout() {
     ];
     let (base, _stop) = serve(routes);
 
-    let run = |skip_prefetch: bool| -> String {
+    let run = |skip_env: Option<&str>| -> String {
         let install_dir = tempfile::tempdir().unwrap();
         let log = install_dir.path().join("invocations.log");
         let mut cmd = Command::new("sh");
@@ -253,8 +253,8 @@ fn install_sh_prefetches_builder_image_by_default_and_skips_on_optout() {
             .env("MVM_INSTALL_DIR", install_dir.path())
             .env("MVM_SKIP_CODESIGN", "1")
             .env("MVM_TEST_INVOCATION_LOG", &log);
-        if skip_prefetch {
-            cmd.env("MVM_SKIP_BUILDER_PREFETCH", "1");
+        if let Some(name) = skip_env {
+            cmd.env(name, "1");
         }
         assert!(cmd.status().unwrap().success(), "install.sh should succeed");
         std::fs::read_to_string(&log).unwrap_or_default()
@@ -262,13 +262,13 @@ fn install_sh_prefetches_builder_image_by_default_and_skips_on_optout() {
 
     // Default: install.sh runs `mvmctl bootstrap`.
     assert!(
-        run(false).contains("bootstrap"),
-        "default install must prefetch via `mvmctl bootstrap`"
+        run(None).contains("bootstrap"),
+        "default install must prepare infrastructure via `mvmctl bootstrap`"
     );
-    // Opt-out: MVM_SKIP_BUILDER_PREFETCH=1 suppresses the prefetch.
+    // Preferred opt-out suppresses the whole readiness bootstrap.
     assert!(
-        !run(true).contains("bootstrap"),
-        "MVM_SKIP_BUILDER_PREFETCH=1 must skip the prefetch"
+        !run(Some("MVM_SKIP_BOOTSTRAP")).contains("bootstrap"),
+        "MVM_SKIP_BOOTSTRAP=1 must skip bootstrap"
     );
 }
 


### PR DESCRIPTION
## What changed

- make `mvmctl bootstrap` acquire and verify both the builder VM image and workload kernel
- route workload-kernel reads through the shared digest-verifying resolver
- automatically evict and reacquire incompatible cache entries
- stage and validate downloaded and locally built kernel artifacts before atomic publication
- replace the Stage 0 cross-filesystem copy with an explicit buffered copy that follows Nix output symlinks and rejects empty artifacts
- use kernel config/release identity for dm-verity capability instead of raw-image substring scanning
- clean exact orphan staging directories under the Stage 0 lock and improve interruption messaging
- update installer naming, CLI documentation, BDD coverage, and project tracking

## Why

`mvmctl bootstrap` previously prepared only the builder image, so the first later `machine run --image ...` unexpectedly launched a Stage 0 kernel build. An interrupted repair could also leave a zero-byte copied config. Finally, a valid stripped/KALLSYMS-free ARM64 kernel was falsely rejected because capability detection searched raw kernel bytes for symbol strings.

## User impact

A successful bootstrap now means the foundational machine artifacts are ready. Warm machine runs reuse the verified cache, interrupted builds never publish partial artifacts, and incompatible cached kernels are repaired automatically with actionable progress messaging.

## Validation

- `cargo fmt --all -- --check`
- focused kernel/bootstrap/publication/interruption tests
- `cargo check --workspace`
- host `cargo clippy --workspace --all-targets -- -D warnings`
- pre-commit workspace all-target Clippy hook
- BDD: 53 features, 172/172 scenarios, 716/716 steps
- changed `mvm-cli` library suite: 1,622 passed, 2 ignored

## Pending environment-dependent validation

- Linux all-target Clippy must run in CI or through a supported project builder-VM execution entry point; the builder is headless and this macOS session has no generic builder exec surface.
- The real bootstrap-to-Alpine smoke must run in an authorized environment that satisfies the repository's builder-VM execution-boundary rule.
- Full workspace tests pass the changed crates but exposed unrelated nondeterministic `mvm-hostd` shared-state/timing failures; isolated reruns produced different failures/hangs, documented in Plan 315.
