### PR TITLE
Fix workload root modes, bounded forward responses, and Firecracker teardown polling

### DIFF
--- a/crates/mvm-backends/src/driver/fc.rs
+++ b/crates/mvm-backends/src/driver/fc.rs
@@ -81,7 +81,7 @@ fn fc_base_bootargs(virtiofs_root: bool, has_disk: bool) -> String {
     // fields the raw Firecracker TAP path appends here are deliberately absent.
     let console = "console=ttyS0 reboot=k panic=1 net.ifnames=0";
     if virtiofs_root {
-        format!("{console} rootfstype=virtiofs root=mvmroot rw init=/init")
+        format!("{console} rootfstype=virtiofs root=mvmroot ro init=/init")
     } else if has_disk {
         // No `root=` declaration here: Firecracker itself appends the
         // authoritative `root=/dev/vda ro|rw` to the boot args from the root
@@ -440,7 +440,7 @@ fn clear_stale_pid_marker_for_start(
 /// VM or wall-clock waits.
 fn escalate_kill(
     grace: Duration,
-    poll: Duration,
+    mut poll: impl FnMut(u32) -> Duration,
     mut is_running: impl FnMut() -> Result<bool>,
     mut signal: impl FnMut(FcStopSignal),
     mut now: impl FnMut() -> Instant,
@@ -451,11 +451,13 @@ fn escalate_kill(
     }
     signal(FcStopSignal::Terminate);
     let deadline = now() + grace;
+    let mut attempt = 0;
     while now() < deadline {
         if !is_running()? {
             return Ok(KillOutcome::Stopped);
         }
-        sleep(poll);
+        sleep(poll(attempt));
+        attempt = attempt.saturating_add(1);
     }
     // Grace lapsed; force-kill and re-probe to decide whether the signal landed.
     signal(FcStopSignal::ForceKill);
@@ -482,7 +484,7 @@ fn remove_pid_marker_if_matches(pid_file: &Path, pid: u32) {
 pub(crate) fn terminate_firecracker_pid(name: &str, pid: u32, pid_file: &Path) -> Result<()> {
     let outcome = escalate_kill(
         crate::legacy::libkrun::STOP_TIMEOUT,
-        Duration::from_millis(100),
+        mvm_core::poll_backoff::poll_delay,
         || crate::fc::is_firecracker_pid_running(pid),
         |signal| fc_sudo_signal(pid, signal),
         Instant::now,
@@ -1594,7 +1596,7 @@ mod tests {
         let base = Instant::now();
         let outcome = escalate_kill(
             Duration::from_secs(10),
-            Duration::from_millis(10),
+            |_| Duration::from_millis(10),
             || {
                 assert_eq!(captured_pid, 4242);
                 let probe = probes.get();
@@ -1655,7 +1657,7 @@ mod tests {
         let mut signals = Vec::new();
         let outcome = escalate_kill(
             Duration::from_secs(2),
-            Duration::from_millis(10),
+            |_| Duration::from_millis(10),
             || Ok(false),
             |s| signals.push(s),
             Instant::now,
@@ -1682,7 +1684,7 @@ mod tests {
         let base = Instant::now();
         let outcome = escalate_kill(
             Duration::from_secs(10),
-            Duration::from_millis(10),
+            |_| Duration::from_millis(10),
             is_running,
             |s| signals.push(s),
             || base,
@@ -1711,7 +1713,7 @@ mod tests {
         };
         let outcome = escalate_kill(
             Duration::from_millis(1),
-            Duration::from_millis(10),
+            |_| Duration::from_millis(10),
             || Ok(true),
             |s| signals.push(s),
             now,

--- a/crates/mvm-backends/src/driver/libkrun.rs
+++ b/crates/mvm-backends/src/driver/libkrun.rs
@@ -61,9 +61,9 @@ impl Default for LibkrunDriver {
 fn libkrun_base_bootargs(virtiofs_root: bool, has_disk: bool) -> String {
     if virtiofs_root {
         // Dev virtiofs-root boot: hvc0 console + the virtiofs guest root.
-        "console=hvc0 rootfstype=virtiofs root=mvmroot rw init=/init".to_string()
+        "console=hvc0 rootfstype=virtiofs root=mvmroot ro init=/init".to_string()
     } else if has_disk {
-        crate::legacy::libkrun::DEFAULT_CMDLINE.to_string()
+        "console=hvc0 root=/dev/vda ro init=/init".to_string()
     } else {
         // Verity / initramfs boot: the initramfs PID 1 owns root/init selection,
         // so only the console base is emitted here.
@@ -744,7 +744,7 @@ mod tests {
         // Empty cmdline ⇒ the driver supplies the virtiofs-root base.
         assert_eq!(
             cfg.krun.kernel_cmdline.as_deref(),
-            Some("console=hvc0 rootfstype=virtiofs root=mvmroot rw init=/init")
+            Some("console=hvc0 rootfstype=virtiofs root=mvmroot ro init=/init")
         );
     }
 
@@ -875,7 +875,7 @@ mod tests {
         let cfg = relay(&spec);
         assert_eq!(
             cfg.krun.kernel_cmdline.as_deref(),
-            Some(crate::legacy::libkrun::DEFAULT_CMDLINE)
+            Some("console=hvc0 root=/dev/vda ro init=/init")
         );
 
         // Empty + an initramfs (no disk root) ⇒ the console-only verity base.

--- a/crates/mvm-backends/src/driver/qemu.rs
+++ b/crates/mvm-backends/src/driver/qemu.rs
@@ -68,9 +68,9 @@ fn qemu_base_bootargs(virtiofs_root: bool, has_disk: bool) -> String {
     // Serial console + reboot/panic behavior + stable interface naming.
     let console = "console=ttyS0 reboot=k panic=1 net.ifnames=0";
     if virtiofs_root {
-        format!("{console} rootfstype=virtiofs root=mvmroot rw init=/init")
+        format!("{console} rootfstype=virtiofs root=mvmroot ro init=/init")
     } else if has_disk {
-        format!("{console} root=/dev/vda rw rootwait init=/init")
+        format!("{console} root=/dev/vda ro rootwait init=/init")
     } else {
         // Verity / initramfs boot: the initramfs PID 1 owns root/init selection,
         // so only the serial-console base is emitted here.

--- a/crates/mvm-backends/src/legacy/hvf_bootargs.rs
+++ b/crates/mvm-backends/src/legacy/hvf_bootargs.rs
@@ -13,7 +13,7 @@ pub fn default_bootargs(has_disk: bool) -> String {
     let mut args =
         format!("earlycon=pl011,0x{UART_BASE:x} console=ttyAMA0 panic=-1 nokaslr loglevel=8");
     if has_disk {
-        args.push_str(" root=/dev/vda rw init=/init");
+        args.push_str(" root=/dev/vda ro init=/init");
     }
     args
 }
@@ -22,7 +22,7 @@ pub fn default_bootargs(has_disk: bool) -> String {
 pub fn default_virtiofs_bootargs() -> String {
     format!(
         "earlycon=pl011,0x{UART_BASE:x} console=ttyAMA0 panic=-1 nokaslr loglevel=8 \
-         rootfstype=virtiofs root=mvmroot rw init=/init"
+         rootfstype=virtiofs root=mvmroot ro init=/init"
     )
 }
 

--- a/crates/mvm-backends/src/mock.rs
+++ b/crates/mvm-backends/src/mock.rs
@@ -382,9 +382,9 @@ impl VmmDriver for MockDriver {
         // comes from the driver rather than a hardcoded HVF default.
         let mut args = "console=hvc0 panic=-1 nokaslr loglevel=8".to_string();
         if virtiofs_root {
-            args.push_str(" rootfstype=virtiofs root=mvmroot rw init=/init");
+            args.push_str(" rootfstype=virtiofs root=mvmroot ro init=/init");
         } else if has_disk {
-            args.push_str(" root=/dev/vda rw init=/init");
+            args.push_str(" root=/dev/vda ro init=/init");
         }
         args
     }

--- a/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
@@ -42,6 +42,8 @@ use crate::supervisor::tools::http_hardening::hardened_client_builder;
 
 /// 16 MiB cap on a single routed request/response frame.
 const MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
+/// The response body must fit inside the bounded guest-facing response frame.
+const MAX_FORWARD_RESPONSE_BYTES: usize = MAX_FRAME_BYTES;
 #[cfg(not(target_os = "linux"))]
 const RVPROXY_ORIGINAL_DST_MAGIC: &[u8; 8] = b"RVPXOD01";
 
@@ -516,6 +518,15 @@ pub enum ForwardError {
     Failed(String),
 }
 
+fn check_forward_response_length(length: Option<u64>) -> Result<(), ForwardError> {
+    if length.is_some_and(|length| length > MAX_FORWARD_RESPONSE_BYTES as u64) {
+        return Err(ForwardError::Failed(format!(
+            "response body exceeds the {MAX_FORWARD_RESPONSE_BYTES} byte limit"
+        )));
+    }
+    Ok(())
+}
+
 /// Errors from building a [`SubstitutionService`] from an admitted plan.
 #[derive(Debug, thiserror::Error)]
 pub enum FromPlanError {
@@ -592,6 +603,7 @@ impl Forwarder for HardenedForwarder {
         let method = mvm_http::Method::from_bytes(req.method.as_bytes())
             .map_err(|e| ForwardError::Failed(format!("bad method: {e}")))?;
         let client = hardened_client_builder(self.timeout_secs)
+            .max_response_bytes(MAX_FORWARD_RESPONSE_BYTES as u64)
             .build()
             .map_err(|e| ForwardError::Failed(e.to_string()))?;
         let mut rb = client.request(method, &req.url);
@@ -611,6 +623,7 @@ impl Forwarder for HardenedForwarder {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or_default().to_string()))
             .collect();
+        check_forward_response_length(resp.content_length())?;
         let body = resp
             .bytes()
             .await
@@ -1959,6 +1972,22 @@ mod tests {
             prepare_request(&endpoint, req).unwrap_err(),
             ProxyError::BadUrl(_)
         ));
+    }
+}
+
+#[cfg(test)]
+mod response_body_tests {
+    use super::*;
+
+    #[test]
+    fn declared_response_length_is_checked_before_reading() {
+        check_forward_response_length(Some(MAX_FORWARD_RESPONSE_BYTES as u64))
+            .expect("a body exactly at the limit is accepted");
+        let err = check_forward_response_length(Some((MAX_FORWARD_RESPONSE_BYTES as u64) + 1))
+            .expect_err("an oversized declaration must be refused before allocation");
+        assert!(err.to_string().contains("response body exceeds"));
+        check_forward_response_length(None)
+            .expect("chunked or close-delimited bodies are streamed");
     }
 }
 

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -1119,11 +1119,11 @@ mod tests {
     #[test]
     fn default_bootargs_mounts_rootfs_when_disk_present() {
         // A virtio-blk disk is a real mkGuest workload rootfs: mount it and run
-        // the baked init, matching the `root=/dev/vda rw init=/init` contract
+        // the baked init, matching the read-only root-device contract
         // the other backends boot mkGuest images with.
         let with = default_bootargs(true);
         assert!(
-            with.contains("root=/dev/vda rw"),
+            with.contains("root=/dev/vda ro"),
             "real workload must mount the virtio-blk rootfs: {with}"
         );
         assert!(

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -10,6 +10,11 @@ for detailed scope and acceptance criteria.
       at 80 columns for `--help`, `-h`, and `mvmctl help <path>`; generated-tree
       BDD coverage executes the real binary and automatically includes future
       subcommands.
+- [~] **Issue-closeout batch — #2165, #2321, and #2323.** The workload runner
+      now emits read-only root bootargs for read-only root devices, the
+      credential-bearing substitution response is incrementally capped, and
+      Firecracker teardown uses the shared poll backoff. PR merge and required
+      live evidence remain before these issues close.
 - [x] **Issue #2128 — kernel pin freshness.** The libkrunfw bundle and custom
       guest kernel now share the verified Linux 6.12.102 LTS source pin;
       structural parity coverage prevents the consumers from drifting apart.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -27,6 +27,12 @@
       workspace all-target Clippy, the serial aggregate workspace suite, and
       the focused x86_64 Linux cross-build are green. Linux-native builder-VM
       tests and all-target Clippy remain the final platform gates.
+- [~] Issue-closeout batch — **#2165, #2321, #2323**. Workload-runner root
+      bootargs now agree with read-only block attachments across the selected
+      drivers; the substitution forward leg rejects oversized declared or
+      streamed response bodies before accumulation; and Firecracker teardown
+      uses the shared bounded poll backoff. Targeted tests and clippy pass;
+      merge and backend live evidence remain before closure.
 
 - [ ] Launch critical-path waste on real-sized images — **issues #2273–#2276,
       plan 311**. Plan 299's prepared-cold baseline runs `alpine`, whose cached

--- a/specs/plans/300-open-issue-closeout.md
+++ b/specs/plans/300-open-issue-closeout.md
@@ -1,6 +1,6 @@
 # Plan 300 — Open issue closeout
 
-**Status:** TRIAGE COMPLETE — execution pending
+**Status:** IN PROGRESS — concrete-fix batch underway
 **Snapshot date:** 2026-08-10
 
 ## Objective
@@ -12,6 +12,15 @@ tests, live witnesses where required, documentation, and GitHub state agree.
 This plan is a closeout map, not permission to weaken a security claim or to
 close an issue because a nearby implementation exists. Mixed issues must be
 split or narrowed before closure.
+
+## Execution update — first concrete-fix batch
+
+The first implementation batch addresses two user-visible correctness/security
+defects before the larger dependency graphs: #2165 makes every workload-runner
+root command line agree with the read-only root block, and #2321 bounds the
+credential-bearing forward response before it can be accumulated. #2323 uses
+the shared bounded poll backoff for Firecracker teardown. These changes stay
+open until their PRs are merged and the required live witnesses are recorded.
 
 ## Closure rules
 


### PR DESCRIPTION
## Summary

- align workload-runner root bootargs with the read-only root blocks attached by the VMM drivers
- cap substitution forward responses before accumulation, including lying or absent Content-Length cases
- replace Firecracker teardown's fixed 100 ms polling tick with the shared bounded backoff
- record the closeout batch in the sprint, refactor rollup, and open-issue closeout plan

## Validation

- targeted `mvm-backends` tests for workload bootargs and teardown behavior
- targeted `mvm-runtime` HVF bootargs regression test
- targeted `mvm-hostd` response-body cap tests
- targeted clippy for `mvm-backends` and `mvm-hostd`
- full workspace pre-commit clippy was attempted but overlapped another checkout-wide cargo validation process

The issues remain open until this branch is merged and the required live witnesses are recorded.
