### PR TITLE
Grant surfaces: make a workload grant expressible, and therefore real (Plan 308 WS6)

### DIFF
--- a/crates/mvm-cli/src/commands/machine/lifecycle.rs
+++ b/crates/mvm-cli/src/commands/machine/lifecycle.rs
@@ -80,7 +80,15 @@ pub(super) fn start_machine(args: MachineStartArgs) -> Result<()> {
         .map(String::from)
         .unwrap_or_else(|| shared::resolve_effective_hypervisor("firecracker"));
     let receipt_input = machine_start_receipt_input(&spec, &effective_hypervisor)?;
-    let network_policy = shared::resolve_run_network_policy(spec.net, &spec.allow_host)?;
+    // A granted allow-list is what the gate enforces; the legacy
+    // `net`/`allow_host` fields decide the policy only for a spec that granted
+    // no egress. Deriving it from the same spec the plan is admitted under is
+    // what keeps the enforced policy and the signed one from diverging.
+    let network_policy = shared::enforced_network_policy(
+        spec.grants.as_ref().and_then(|g| g.egress.as_ref()),
+        spec.net,
+        &spec.allow_host,
+    )?;
     let (memory_mib, mem_initial_mib) =
         validate_machine_memory(&spec.memory, spec.mem_initial.as_deref())?;
     let volume_cfg = build_machine_volume_cfg(&spec.volumes)?;
@@ -170,6 +178,7 @@ pub(super) fn start_machine(args: MachineStartArgs) -> Result<()> {
         kernel_path,
         agent_verb: spec.agent_verb.clone(),
         has_ad_hoc_argv: args.has_ad_hoc_argv,
+        grants: spec.grants.clone(),
     })?;
     if !spec.init.is_empty()
         && let Err(err) = run_machine_init_commands(&spec.name, &spec.init)

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -273,9 +273,15 @@ pub(in crate::commands) struct MachineRunArgs {
     /// Allow outbound access to HOST[:PORT] (repeatable).
     #[arg(long = "allow-host", value_name = "HOST[:PORT]")]
     pub allow_host: Vec<String>,
-    /// Set the vCPU count.
+    /// Set how many vCPUs the guest sees (not a host CPU share).
     #[arg(long, default_value = "2")]
     pub cpus: u32,
+    /// Cap host CPU time in millicores (1500 = 1.5 cores); not `--cpus`.
+    #[arg(long = "cpu-limit", value_name = "MILLICORES")]
+    pub cpu_limit: Option<u32>,
+    /// Read grants (CPU, wall clock, egress) from a JSON file.
+    #[arg(long = "grants-file", value_name = "PATH")]
+    pub grants_file: Option<PathBuf>,
     /// Set memory (for example, 512M or 1G).
     #[arg(long, default_value = "512M")]
     pub memory: String,
@@ -419,6 +425,8 @@ impl MachineRunArgs {
             net: self.net,
             allow_host: self.allow_host,
             cpus: self.cpus,
+            cpu_limit: self.cpu_limit,
+            grants_file: self.grants_file,
             memory: self.memory,
             profile: self.profile,
             agent_verb: self.agent_verb,
@@ -698,7 +706,19 @@ fn machine_run_spec(
                  `--runtime-pack` to create machine {name:?}"
         );
     };
-    super::shared::resolve_run_network_policy(args.net, &args.allow_host)?;
+    let config = mvm_core::user_config::load(None);
+    let resolved = super::shared::resolve_run_grants(super::shared::GrantInputs {
+        cpu_limit_millicores: args.cpu_limit,
+        timeout_secs: args.timeout,
+        allow_host: &args.allow_host,
+        net: args.net,
+        grants_file: args.grants_file.as_deref(),
+        // A persistent `machine run` names its source on the command line and
+        // reads no project manifest; `machine create` is the verb that sources
+        // a `[grants]` table.
+        manifest: None,
+        config: &config,
+    })?;
     let _ = validate_machine_memory(&args.memory, None)?;
     let profile = run_profile_name(args.profile).to_string();
     Ok(MachineSpec {
@@ -727,6 +747,7 @@ fn machine_run_spec(
             args.health_retries,
             args.health_start_period,
         ),
+        grants: resolved.plan_grants,
     })
 }
 
@@ -750,9 +771,18 @@ pub(in crate::commands) struct MachineCreateArgs {
     /// Allow egress only to these hosts: `HOST[:PORT]` (repeatable).
     #[arg(long = "allow-host", value_name = "HOST[:PORT]")]
     pub allow_host: Vec<String>,
-    /// vCPU cores for lifecycle starts.
+    /// vCPU cores the guest sees on lifecycle starts (not a host CPU share).
     #[arg(long)]
     pub cpus: Option<u32>,
+    /// Cap host CPU time in millicores (1500 = 1.5 cores); not `--cpus`.
+    #[arg(long = "cpu-limit", value_name = "MILLICORES")]
+    pub cpu_limit: Option<u32>,
+    /// Bound each start's wall-clock runtime in seconds.
+    #[arg(long, value_name = "SECS")]
+    pub timeout: Option<u64>,
+    /// Read grants (CPU, wall clock, egress) from a JSON file.
+    #[arg(long = "grants-file", value_name = "PATH")]
+    pub grants_file: Option<PathBuf>,
     /// Memory for lifecycle starts (supports human-readable: 512M, 1G, ...).
     #[arg(long)]
     pub memory: Option<String>,
@@ -1066,7 +1096,18 @@ impl MachineCreateArgs {
         } else {
             self.allow_host
         };
-        super::shared::resolve_run_network_policy(net, &allow_host)?;
+        // Resolving grants also settles the egress policy, so validating it
+        // here validates the same policy the machine will actually boot under.
+        let config = mvm_core::user_config::load(None);
+        let resolved = super::shared::resolve_run_grants(super::shared::GrantInputs {
+            cpu_limit_millicores: self.cpu_limit,
+            timeout_secs: self.timeout,
+            allow_host: &allow_host,
+            net,
+            grants_file: self.grants_file.as_deref(),
+            manifest: workflow.map(|workflow| &workflow.grants),
+            config: &config,
+        })?;
         let cpus = self
             .cpus
             .or_else(|| workflow.map(|workflow| workflow.cpus))
@@ -1123,6 +1164,7 @@ impl MachineCreateArgs {
             created_at: Some(mvm_core::time::utc_now()),
             last_started_at: None,
             health_check: None,
+            grants: resolved.plan_grants,
         })
     }
 }
@@ -1503,6 +1545,8 @@ fn run_args_for_image_revert(
             net: false,
             allow_host: Vec::new(),
             cpus: 2,
+            cpu_limit: None,
+            grants_file: None,
             memory: "512M".to_string(),
             profile: RunProfile::Dev,
             agent_verb: Vec::new(),

--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -452,6 +452,8 @@ pub(in crate::commands) fn boot_persistent_by_name(
             net: false,
             allow_host: Vec::new(),
             cpus: 2,
+            cpu_limit: None,
+            grants_file: None,
             memory: "512M".to_string(),
             profile: RunProfile::Dev,
             agent_verb: Vec::new(),

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -2866,3 +2866,57 @@ allow_hosts = ["api.example.com:443"]
         "the manifest keeps the egress dimension the CLI said nothing about"
     );
 }
+
+#[test]
+fn the_argv_the_sdk_facade_emits_parses_back_into_the_grant_it_encoded() {
+    // The receiving half of the SDK's encoding contract. `mvm-sdk`'s
+    // `grant_argv` emits exactly these flags for a CPU share, a bounded wall
+    // clock, and an egress allow-list; this asserts the CLI turns them back
+    // into the grant that produced them. A flag that did not exist, or meant
+    // something else here, would be a silently dropped grant — the SDK would
+    // emit it, the CLI would ignore it, and nothing on either side would
+    // notice.
+    let args = parse_run(&[
+        "run",
+        "--image",
+        "alpine:latest",
+        "--cpu-limit",
+        "1500",
+        "--timeout",
+        "600",
+        "--allow-host",
+        "api.example.com:443",
+        "--allow-host",
+        "db.internal:5432",
+    ])
+    .expect("the facade's argv parses");
+
+    let config = mvm_core::user_config::MvmConfig::default();
+    let resolved =
+        crate::commands::shared::resolve_run_grants(crate::commands::shared::GrantInputs {
+            cpu_limit_millicores: args.cpu_limit,
+            timeout_secs: args.timeout,
+            allow_host: &args.allow_host,
+            net: args.net,
+            grants_file: args.grants_file.as_deref(),
+            manifest: None,
+            config: &config,
+        })
+        .expect("resolves");
+
+    assert_eq!(
+        resolved.plan_grants,
+        Some(mvm_contract::grants::Grants {
+            cpu: Some(mvm_contract::grants::CpuGrant::Share { millicores: 1500 }),
+            wall_clock: Some(mvm_contract::grants::WallClockGrant::Secs {
+                secs: std::num::NonZeroU32::new(600).expect("nonzero"),
+            }),
+            egress: Some(mvm_contract::grants::EgressGrant {
+                allow: vec![
+                    mvm_core::network_policy::HostPort::new("api.example.com", 443),
+                    mvm_core::network_policy::HostPort::new("db.internal", 5432),
+                ],
+            }),
+        })
+    );
+}

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -611,6 +611,7 @@ fn spec_fixture(name: &str) -> MachineSpec {
         created_at: None,
         last_started_at: None,
         health_check: None,
+        grants: None,
     }
 }
 
@@ -1483,6 +1484,7 @@ fn mark_machine_started_sets_digest_and_timestamp() {
         created_at: Some("2026-06-18T00:00:00Z".to_string()),
         last_started_at: None,
         health_check: None,
+        grants: None,
     };
     mark_machine_started(&mut spec, "sha256:abc".to_string());
     assert_eq!(spec.resolved_digest.as_deref(), Some("sha256:abc"));
@@ -1499,6 +1501,9 @@ fn create_persists_machine_spec_under_data_dir() {
         net: true,
         allow_host: vec!["api.example.com".to_string()],
         cpus: Some(4),
+        cpu_limit: None,
+        timeout: None,
+        grants_file: None,
         memory: Some("1G".to_string()),
         mem_initial: None,
         profile: Some(RunProfile::Dev),
@@ -1527,6 +1532,9 @@ fn create_auto_generates_a_name_when_omitted() {
         net: false,
         allow_host: Vec::new(),
         cpus: None,
+        cpu_limit: None,
+        timeout: None,
+        grants_file: None,
         memory: None,
         mem_initial: None,
         profile: None,
@@ -1572,6 +1580,9 @@ volumes = ["./src:/work:rw"]
         net: false,
         allow_host: Vec::new(),
         cpus: None,
+        cpu_limit: None,
+        timeout: None,
+        grants_file: None,
         memory: None,
         mem_initial: None,
         profile: Some(RunProfile::Dev),
@@ -1606,6 +1617,9 @@ fn create_rejects_flake_backed_manifest_for_machine_specs() {
         net: false,
         allow_host: Vec::new(),
         cpus: None,
+        cpu_limit: None,
+        timeout: None,
+        grants_file: None,
         memory: None,
         mem_initial: None,
         profile: None,
@@ -1635,6 +1649,9 @@ fn create_defaults_to_dev_profile_when_manifest_declares_dev_init() {
         net: false,
         allow_host: Vec::new(),
         cpus: None,
+        cpu_limit: None,
+        timeout: None,
+        grants_file: None,
         memory: None,
         mem_initial: None,
         profile: None,
@@ -1652,6 +1669,9 @@ fn create_defaults_to_dev_profile_when_manifest_declares_dev_init() {
         net: false,
         allow_host: Vec::new(),
         cpus: None,
+        cpu_limit: None,
+        timeout: None,
+        grants_file: None,
         memory: None,
         mem_initial: None,
         profile: Some(RunProfile::Standard),
@@ -1688,6 +1708,7 @@ fn machine_start_receipt_input_redacts_host_paths_and_surfaces_policy() {
         created_at: Some("2026-06-18T00:00:00Z".to_string()),
         last_started_at: None,
         health_check: None,
+        grants: None,
     };
 
     let summary = machine_start_preflight_summary(
@@ -1775,6 +1796,7 @@ fn machine_start_preflight_reports_uniform_l4_enforcement_for_oci_allow_host() {
         created_at: Some("2026-06-18T00:00:00Z".to_string()),
         last_started_at: None,
         health_check: None,
+        grants: None,
     };
 
     let summary = machine_start_preflight_summary(&spec, Some("libkrun"), None)
@@ -1798,6 +1820,9 @@ fn create_rejects_unsafe_machine_name() {
         net: false,
         allow_host: Vec::new(),
         cpus: Some(2),
+        cpu_limit: None,
+        timeout: None,
+        grants_file: None,
         memory: Some("512M".to_string()),
         mem_initial: None,
         profile: Some(RunProfile::Standard),
@@ -1831,6 +1856,7 @@ fn create_refuses_overwrite_without_force() {
         created_at: Some(mvm_core::time::utc_now()),
         last_started_at: None,
         health_check: None,
+        grants: None,
     };
     save_machine_spec(&spec, false).expect("first save");
     let err = save_machine_spec(&spec, false).expect_err("overwrite rejected");
@@ -1861,6 +1887,7 @@ fn remove_machine_spec_requires_confirmation_and_deletes_dir() {
         created_at: Some(mvm_core::time::utc_now()),
         last_started_at: None,
         health_check: None,
+        grants: None,
     };
     save_machine_spec(&spec, false).expect("save");
     let err = remove_machine_spec("web", false).expect_err("confirmation required");
@@ -1893,6 +1920,7 @@ fn seed_machine_spec(name: &str) {
         created_at: Some(mvm_core::time::utc_now()),
         last_started_at: None,
         health_check: None,
+        grants: None,
     };
     save_machine_spec(&spec, false).expect("save");
 }
@@ -2331,6 +2359,7 @@ fn reconfigure_spec_fixture() -> MachineSpec {
         created_at: None,
         last_started_at: None,
         health_check: None,
+        grants: None,
     }
 }
 
@@ -2649,5 +2678,191 @@ fn an_allow_host_rule_does_not_influence_the_transport() {
     assert_eq!(
         super::derive_network_mode(false),
         mvm_contract::plan::NetworkMode::HostVsockProxy
+    );
+}
+
+// ── the grant flags ───────────────────────────────────────
+
+#[test]
+fn cpus_and_cpu_limit_are_independent_controls() {
+    // Different questions: how many vCPUs the guest sees, and what share of
+    // host CPU time it may consume. Conflating them is the mistake every
+    // container runtime made once, so they must be separately settable and
+    // neither may move the other.
+    let args = parse_run(&[
+        "run",
+        "--image",
+        "alpine",
+        "--cpus",
+        "4",
+        "--cpu-limit",
+        "500",
+    ])
+    .expect("both flags parse together");
+    assert_eq!(args.cpus, 4);
+    assert_eq!(args.cpu_limit, Some(500));
+
+    let only_cpus = parse_run(&["run", "--image", "alpine", "--cpus", "4"]).expect("parses");
+    assert_eq!(only_cpus.cpus, 4);
+    assert_eq!(only_cpus.cpu_limit, None, "--cpus must not imply a share");
+
+    let only_limit =
+        parse_run(&["run", "--image", "alpine", "--cpu-limit", "500"]).expect("parses");
+    assert_eq!(only_limit.cpu_limit, Some(500));
+    assert_eq!(
+        only_limit.cpus, 2,
+        "--cpu-limit must not move the vCPU count off its default"
+    );
+}
+
+#[test]
+fn the_cpu_flags_help_text_tells_them_apart() {
+    // A user who cannot tell which flag caps what will reach for the wrong
+    // one, and the wrong one silently does nothing they wanted.
+    let help = {
+        let mut cmd = Cli::command();
+        cmd.find_subcommand_mut("machine")
+            .expect("machine noun")
+            .find_subcommand_mut("run")
+            .expect("run verb")
+            .render_long_help()
+            .to_string()
+    };
+    assert!(help.contains("--cpu-limit"), "help must list --cpu-limit");
+    assert!(
+        help.contains("millicores"),
+        "the share flag must name its unit: {help}"
+    );
+    assert!(
+        help.contains("vCPUs the guest sees"),
+        "the vCPU flag must say what it sets: {help}"
+    );
+}
+
+#[test]
+fn a_grants_file_is_accepted_on_run_and_create() {
+    let run = parse_run(&["run", "--image", "alpine", "--grants-file", "/tmp/g.json"])
+        .expect("run accepts --grants-file");
+    assert_eq!(run.grants_file.as_deref(), Some(Path::new("/tmp/g.json")));
+
+    let create = match parse(&[
+        "create",
+        "--image",
+        "alpine",
+        "--grants-file",
+        "/tmp/g.json",
+    ])
+    .expect("create accepts --grants-file")
+    {
+        MachineAction::Create(c) => c,
+        other => panic!("expected create action, got {other:?}"),
+    };
+    assert_eq!(
+        create.grants_file.as_deref(),
+        Some(Path::new("/tmp/g.json"))
+    );
+}
+
+#[test]
+fn a_manifest_grant_lands_on_the_created_machine_spec() {
+    // `machine create` is the verb that reads a project manifest, so it is
+    // where a `[grants]` table becomes a persisted permission set — the one a
+    // later `machine start` re-admits under.
+    let home = tempfile::tempdir().expect("scratch mvm home");
+    let mut env = mvm_core::util::test_env::TestEnv::new();
+    env.isolate_mvm_home(home.path());
+
+    let project = tempfile::tempdir().expect("project dir");
+    std::fs::write(
+        project.path().join("mvm.toml"),
+        r#"
+image = "alpine:3.20"
+
+[grants]
+cpu_millicores = 1500
+allow_hosts = ["api.example.com:443"]
+"#,
+    )
+    .expect("write manifest");
+
+    let args = match parse_owned(&[
+        "create".to_string(),
+        "--name".to_string(),
+        "granted".to_string(),
+        "--manifest".to_string(),
+        project.path().display().to_string(),
+    ])
+    .expect("create parses")
+    {
+        MachineAction::Create(c) => c,
+        other => panic!("expected create action, got {other:?}"),
+    };
+    let spec = args.into_spec().expect("spec");
+    let grants = spec.grants.expect("the manifest's grants were persisted");
+    assert_eq!(
+        grants.cpu,
+        Some(mvm_contract::grants::CpuGrant::Share { millicores: 1500 })
+    );
+    assert_eq!(
+        grants.egress.expect("egress granted").allow,
+        vec![mvm_core::network_policy::HostPort::new(
+            "api.example.com",
+            443
+        )]
+    );
+}
+
+#[test]
+fn a_cli_cpu_limit_does_not_discard_the_manifests_egress_grant() {
+    // Per-dimension precedence, at the surface a user actually types. Whole
+    // object precedence would drop the allow-list silently.
+    let home = tempfile::tempdir().expect("scratch mvm home");
+    let mut env = mvm_core::util::test_env::TestEnv::new();
+    env.isolate_mvm_home(home.path());
+
+    let project = tempfile::tempdir().expect("project dir");
+    std::fs::write(
+        project.path().join("mvm.toml"),
+        r#"
+image = "alpine:3.20"
+
+[grants]
+cpu_millicores = 4000
+allow_hosts = ["api.example.com:443"]
+"#,
+    )
+    .expect("write manifest");
+
+    let args = match parse_owned(&[
+        "create".to_string(),
+        "--name".to_string(),
+        "narrowed".to_string(),
+        "--manifest".to_string(),
+        project.path().display().to_string(),
+        "--cpu-limit".to_string(),
+        "500".to_string(),
+    ])
+    .expect("create parses")
+    {
+        MachineAction::Create(c) => c,
+        other => panic!("expected create action, got {other:?}"),
+    };
+    let grants = args
+        .into_spec()
+        .expect("spec")
+        .grants
+        .expect("something was granted");
+    assert_eq!(
+        grants.cpu,
+        Some(mvm_contract::grants::CpuGrant::Share { millicores: 500 }),
+        "the CLI wins the CPU dimension"
+    );
+    assert_eq!(
+        grants.egress.expect("egress survived").allow,
+        vec![mvm_core::network_policy::HostPort::new(
+            "api.example.com",
+            443
+        )],
+        "the manifest keeps the egress dimension the CLI said nothing about"
     );
 }

--- a/crates/mvm-cli/src/commands/shared/grants.rs
+++ b/crates/mvm-cli/src/commands/shared/grants.rs
@@ -1,0 +1,379 @@
+//! Where the CLI's grant surfaces meet: flags, a JSON grants file, the
+//! project manifest, and the operator's host config are folded into one
+//! permission set, and the egress policy the gate enforces is derived from it
+//! in the same step.
+//!
+//! Resolving the grants and deriving the policy together is deliberate. Two
+//! separate calls could be made in one order here and the other order there,
+//! and then the enforced policy would depend on which call site a launch went
+//! through. One function, one answer.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+use mvm_contract::grants::{CpuGrant, EgressGrant, Grants, WallClockGrant};
+use mvm_core::grants_resolve::{
+    GrantLayer, GrantProvenance, GrantSurface, load_grants_file, resolve_grants,
+};
+use mvm_core::network_policy::NetworkPolicy;
+use mvm_core::user_config::MvmConfig;
+
+/// The grant-authoring flags of one invocation, plus the lower surfaces it
+/// should fall back to. Grouped rather than passed positionally because they
+/// are one decision's inputs and threading six arguments through the CLI would
+/// invite a caller to swap two of them.
+pub(in crate::commands) struct GrantInputs<'a> {
+    /// `--cpu-limit`: the share of host CPU time, in millicores. Distinct from
+    /// `--cpus`, which is the vCPU count the guest sees.
+    pub cpu_limit_millicores: Option<u32>,
+    /// `--timeout`: the wall-clock bound on the run, in seconds.
+    pub timeout_secs: Option<u64>,
+    /// `--allow-host`: the CLI's egress allow-list, in `HOST[:PORT]` form.
+    pub allow_host: &'a [String],
+    /// `--net`: the dev-tier preset. It has no grant representation — it names
+    /// a preset rather than destinations — so it only reaches the policy when
+    /// nothing authored an egress grant.
+    pub net: bool,
+    /// `--grants-file`: a JSON document naming any subset of the dimensions.
+    pub grants_file: Option<&'a Path>,
+    /// The project manifest's `[grants]` table, already typed.
+    pub manifest: Option<&'a Grants>,
+    /// The operator's host config, for the dimensions nothing above named.
+    pub config: &'a MvmConfig,
+}
+
+/// One invocation's resolved permission set and the egress policy that follows
+/// from it.
+#[derive(Debug, Clone, PartialEq)]
+pub(in crate::commands) struct RunGrants {
+    /// What the signed plan carries. `None` when no surface authored anything.
+    pub plan_grants: Option<Grants>,
+    /// What the egress gate enforces for this run.
+    pub network_policy: NetworkPolicy,
+    /// Which surface won each dimension, for diagnostics.
+    pub provenance: GrantProvenance,
+}
+
+/// Fold every surface, highest precedence first, and derive the egress policy.
+///
+/// Precedence is per dimension: a `--cpu-limit` on the command line does not
+/// discard an egress allow-list the manifest declared.
+pub(in crate::commands) fn resolve_run_grants(inputs: GrantInputs<'_>) -> Result<RunGrants> {
+    let cli = cli_layer(&inputs)?;
+    let file = match inputs.grants_file {
+        Some(path) => load_grants_file(path)?,
+        None => Grants::default(),
+    };
+
+    let mut layers = vec![
+        GrantLayer::new(GrantSurface::Cli, cli),
+        GrantLayer::new(GrantSurface::GrantsFile, file),
+    ];
+    if let Some(manifest) = inputs.manifest {
+        layers.push(GrantLayer::new(GrantSurface::Manifest, manifest.clone()));
+    }
+    layers.push(GrantLayer::new(
+        GrantSurface::HostConfig,
+        inputs.config.default_grants(),
+    ));
+
+    let resolved = resolve_grants(&layers);
+    let provenance = *resolved.provenance();
+    let plan_grants = resolved.into_plan_grants();
+    let network_policy = enforced_network_policy(
+        plan_grants.as_ref().and_then(|g| g.egress.as_ref()),
+        inputs.net,
+        inputs.allow_host,
+    )?;
+    Ok(RunGrants {
+        plan_grants,
+        network_policy,
+        provenance,
+    })
+}
+
+/// The egress policy a run enforces.
+///
+/// Takes the egress dimension rather than the whole permission set because
+/// that dimension is all the projection reads; nothing else about a grant
+/// bears on where a workload may connect.
+///
+/// A granted allow-list is projected — that projection is the only permitted
+/// derivation of egress policy from a grant. With no egress grant the legacy
+/// `--net` / `--allow-host` resolution stands, which is deny-all unless the
+/// caller asked for something.
+pub(in crate::commands) fn enforced_network_policy(
+    egress: Option<&EgressGrant>,
+    net: bool,
+    allow_host: &[String],
+) -> Result<NetworkPolicy> {
+    match egress {
+        Some(egress) => Ok(
+            mvm_contract::grants::projection::network_policy_from_grants(&Grants {
+                egress: Some(egress.clone()),
+                ..Default::default()
+            }),
+        ),
+        None => super::resolve_run_network_policy(net, allow_host),
+    }
+}
+
+/// The command line's own contribution.
+fn cli_layer(inputs: &GrantInputs<'_>) -> Result<Grants> {
+    let cpu = match inputs.cpu_limit_millicores {
+        None => None,
+        Some(0) => anyhow::bail!(
+            "--cpu-limit must be > 0 millicores; omit it to leave CPU uncapped \
+             (--cpu-limit bounds the share of host CPU time, --cpus sets the vCPU count)"
+        ),
+        Some(millicores) => Some(CpuGrant::Share { millicores }),
+    };
+
+    let wall_clock = match inputs.timeout_secs {
+        None | Some(0) => None,
+        Some(secs) => {
+            let secs = u32::try_from(secs)
+                .ok()
+                .and_then(std::num::NonZeroU32::new)
+                .with_context(|| format!("--timeout {secs} does not fit a wall-clock grant"))?;
+            Some(WallClockGrant::Secs { secs })
+        }
+    };
+
+    let egress = if inputs.allow_host.is_empty() {
+        None
+    } else {
+        // Reuse the one `--allow-host` parser so the granted allow-list and the
+        // legacy policy path agree on what `HOST` without a port means, and on
+        // which ports are refused outright.
+        let policy = super::resolve_run_network_policy(false, inputs.allow_host)?;
+        Some(EgressGrant {
+            allow: policy.resolve_rules().unwrap_or_default(),
+        })
+    };
+
+    Ok(Grants {
+        cpu,
+        wall_clock,
+        egress,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::network_policy::HostPort;
+
+    fn inputs<'a>(config: &'a MvmConfig, allow_host: &'a [String]) -> GrantInputs<'a> {
+        GrantInputs {
+            cpu_limit_millicores: None,
+            timeout_secs: None,
+            allow_host,
+            net: false,
+            grants_file: None,
+            manifest: None,
+            config,
+        }
+    }
+
+    #[test]
+    fn no_surface_authors_anything_and_the_plan_stays_grant_free() {
+        let cfg = MvmConfig::default();
+        let resolved = resolve_run_grants(inputs(&cfg, &[])).expect("resolves");
+        assert_eq!(resolved.plan_grants, None);
+        assert_eq!(
+            resolved.network_policy.resolve_rules().as_deref(),
+            Some(&[][..]),
+            "no grant and no flags is deny-all"
+        );
+    }
+
+    #[test]
+    fn cli_overrides_the_manifest_per_dimension_not_wholesale() {
+        // The CLI caps CPU; the manifest declared egress. Both must survive —
+        // whole-object precedence would drop the allow-list silently.
+        let cfg = MvmConfig::default();
+        let manifest = Grants {
+            egress: Some(EgressGrant {
+                allow: vec![HostPort::new("api.example.com", 443)],
+            }),
+            ..Default::default()
+        };
+        let resolved = resolve_run_grants(GrantInputs {
+            cpu_limit_millicores: Some(500),
+            manifest: Some(&manifest),
+            ..inputs(&cfg, &[])
+        })
+        .expect("resolves");
+
+        let grants = resolved.plan_grants.expect("something was authored");
+        assert_eq!(grants.cpu, Some(CpuGrant::Share { millicores: 500 }));
+        assert_eq!(
+            grants.egress.as_ref().map(|e| e.allow.as_slice()),
+            Some(&[HostPort::new("api.example.com", 443)][..]),
+            "the manifest's allow-list must survive a CLI CPU cap"
+        );
+        assert_eq!(resolved.provenance.cpu, Some(GrantSurface::Cli));
+        assert_eq!(resolved.provenance.egress, Some(GrantSurface::Manifest));
+    }
+
+    #[test]
+    fn a_manifest_egress_grant_is_what_the_gate_enforces() {
+        let cfg = MvmConfig::default();
+        let manifest = Grants {
+            egress: Some(EgressGrant {
+                allow: vec![HostPort::new("api.example.com", 443)],
+            }),
+            ..Default::default()
+        };
+        // `--net` would otherwise select the broad dev preset; the granted
+        // allow-list is narrower and is what the gate gets.
+        let resolved = resolve_run_grants(GrantInputs {
+            net: true,
+            manifest: Some(&manifest),
+            ..inputs(&cfg, &[])
+        })
+        .expect("resolves");
+
+        let rules = resolved
+            .network_policy
+            .resolve_rules()
+            .expect("an allow-list resolves to rules");
+        assert_eq!(rules, vec![HostPort::new("api.example.com", 443)]);
+        assert!(!resolved.network_policy.is_unrestricted());
+    }
+
+    #[test]
+    fn an_empty_manifest_allow_list_is_not_an_egress_grant() {
+        // An empty `[grants]` egress must not shadow `--net`: nothing was
+        // granted, so the legacy resolution still applies. (Had it been an
+        // explicit empty allow-list, the projection would deny all — also
+        // closed, but a different answer, and the manifest cannot express it.)
+        let cfg = MvmConfig::default();
+        let manifest = Grants::default();
+        let resolved = resolve_run_grants(GrantInputs {
+            net: true,
+            manifest: Some(&manifest),
+            ..inputs(&cfg, &[])
+        })
+        .expect("resolves");
+        assert!(
+            !resolved
+                .network_policy
+                .resolve_rules()
+                .unwrap_or_default()
+                .is_empty(),
+            "--net still selects the dev preset when nothing granted egress"
+        );
+    }
+
+    #[test]
+    fn the_cli_allow_host_flag_becomes_a_granted_allow_list() {
+        let cfg = MvmConfig::default();
+        let allow = vec![
+            "api.example.com".to_string(),
+            "db.internal:5432".to_string(),
+        ];
+        let resolved = resolve_run_grants(inputs(&cfg, &allow)).expect("resolves");
+        let grants = resolved.plan_grants.expect("egress authored");
+        assert_eq!(
+            grants.egress.expect("egress").allow,
+            vec![
+                HostPort::new("api.example.com", 443),
+                HostPort::new("db.internal", 5432),
+            ],
+            "a bare host defaults to 443, matching the legacy parser"
+        );
+    }
+
+    #[test]
+    fn a_zero_cpu_limit_is_refused_rather_than_read_as_uncapped() {
+        let cfg = MvmConfig::default();
+        let err = resolve_run_grants(GrantInputs {
+            cpu_limit_millicores: Some(0),
+            ..inputs(&cfg, &[])
+        })
+        .expect_err("zero millicores is not a bound");
+        assert!(format!("{err:#}").contains("--cpu-limit"));
+    }
+
+    #[test]
+    fn host_config_defaults_fill_only_unnamed_dimensions() {
+        let cfg = MvmConfig {
+            default_cpu_millicores: Some(2000),
+            ..MvmConfig::default()
+        };
+        let resolved = resolve_run_grants(inputs(&cfg, &[])).expect("resolves");
+        assert_eq!(
+            resolved.plan_grants.and_then(|g| g.cpu),
+            Some(CpuGrant::Share { millicores: 2000 })
+        );
+        assert_eq!(resolved.provenance.cpu, Some(GrantSurface::HostConfig));
+
+        let resolved = resolve_run_grants(GrantInputs {
+            cpu_limit_millicores: Some(500),
+            ..inputs(&cfg, &[])
+        })
+        .expect("resolves");
+        assert_eq!(
+            resolved.plan_grants.and_then(|g| g.cpu),
+            Some(CpuGrant::Share { millicores: 500 })
+        );
+    }
+
+    #[test]
+    fn an_unknown_grants_file_field_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("grants.json");
+        std::fs::write(&path, r#"{"cpu_limt":{"unit":"share","millicores":1500}}"#).expect("write");
+        let cfg = MvmConfig::default();
+        let err = resolve_run_grants(GrantInputs {
+            grants_file: Some(&path),
+            ..inputs(&cfg, &[])
+        })
+        .expect_err("a misspelled key must refuse the run");
+        assert!(format!("{err:#}").contains("unknown field"));
+    }
+
+    #[test]
+    fn the_grants_file_loses_a_contested_dimension_to_the_cli() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("grants.json");
+        std::fs::write(
+            &path,
+            r#"{"cpu":{"unit":"share","millicores":4000},
+                "egress":{"allow":[{"host":"api.example.com","port":443}]}}"#,
+        )
+        .expect("write");
+        let cfg = MvmConfig::default();
+        let resolved = resolve_run_grants(GrantInputs {
+            cpu_limit_millicores: Some(500),
+            grants_file: Some(&path),
+            ..inputs(&cfg, &[])
+        })
+        .expect("resolves");
+        let grants = resolved.plan_grants.expect("authored");
+        assert_eq!(grants.cpu, Some(CpuGrant::Share { millicores: 500 }));
+        assert_eq!(
+            grants.egress.map(|e| e.allow),
+            Some(vec![HostPort::new("api.example.com", 443)]),
+            "the file's egress survives a CLI CPU cap"
+        );
+    }
+
+    #[test]
+    fn a_timeout_becomes_a_wall_clock_grant() {
+        let cfg = MvmConfig::default();
+        let resolved = resolve_run_grants(GrantInputs {
+            timeout_secs: Some(600),
+            ..inputs(&cfg, &[])
+        })
+        .expect("resolves");
+        assert_eq!(
+            resolved.plan_grants.and_then(|g| g.wall_clock),
+            Some(WallClockGrant::Secs {
+                secs: std::num::NonZeroU32::new(600).expect("nonzero")
+            })
+        );
+    }
+}

--- a/crates/mvm-cli/src/commands/shared/grants.rs
+++ b/crates/mvm-cli/src/commands/shared/grants.rs
@@ -80,6 +80,9 @@ pub(in crate::commands) fn resolve_run_grants(inputs: GrantInputs<'_>) -> Result
     let resolved = resolve_grants(&layers);
     let provenance = *resolved.provenance();
     let plan_grants = resolved.into_plan_grants();
+    if let Some(grants) = plan_grants.as_ref() {
+        refuse_over_ceiling(grants, &provenance, inputs.config)?;
+    }
     let network_policy = enforced_network_policy(
         plan_grants.as_ref().and_then(|g| g.egress.as_ref()),
         inputs.net,
@@ -90,6 +93,35 @@ pub(in crate::commands) fn resolve_run_grants(inputs: GrantInputs<'_>) -> Result
         network_policy,
         provenance,
     })
+}
+
+/// Refuse a resolved grant this host's ceiling will not admit, naming the
+/// surface that asked for it.
+///
+/// Admission runs the same ceiling against host config it reads itself, and
+/// that check is the authoritative one — nothing here can be skipped to get
+/// past it. What this adds is the one fact only the resolver holds: with four
+/// places a grant can come from, "this host allows at most 1000" leaves the
+/// user to guess which of them to edit, and the provenance says which.
+fn refuse_over_ceiling(
+    grants: &Grants,
+    provenance: &GrantProvenance,
+    config: &MvmConfig,
+) -> Result<()> {
+    let Err(violation) = config.grant_ceiling().admits_grants(grants) else {
+        return Ok(());
+    };
+    let source = match provenance.surface_for_dimension(violation.dimension) {
+        Some(surface) => format!(", asked for by the {} surface", surface.as_str()),
+        None => String::new(),
+    };
+    anyhow::bail!(
+        "grant exceeds this host's ceiling: {dimension} requested {requested}, host allows \
+         at most {ceiling}{source}",
+        dimension = violation.dimension,
+        requested = violation.requested,
+        ceiling = violation.ceiling,
+    )
 }
 
 /// The egress policy a run enforces.

--- a/crates/mvm-cli/src/commands/shared/mod.rs
+++ b/crates/mvm-cli/src/commands/shared/mod.rs
@@ -7,6 +7,7 @@ mod build_mode;
 mod drive;
 mod event;
 mod format;
+mod grants;
 mod hints;
 mod parse;
 mod resolve;
@@ -17,6 +18,7 @@ mod vsock;
 pub(super) use build_mode::BuildModeFlags;
 pub(super) use event::PhaseEvent;
 pub(super) use format::{human_age_secs, human_bytes};
+pub(in crate::commands) use grants::{GrantInputs, enforced_network_policy, resolve_run_grants};
 pub(super) use hints::with_hints;
 pub(crate) use parse::{DirShareSpec, parse_dir_share_spec};
 pub(super) use parse::{

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -973,6 +973,8 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
         restrict_agent_verbs: !parent_agent_verbs.is_empty()
             || super::agent_verbs::grant_eligible(false, false, false),
         services: Vec::new(),
+        grants: None,
+        backend_kind: None,
         entrypoint: crate::commands::vm::entrypoint_resolve::ResolvedEntrypoint::unresolved(
             "a checkpoint fork boots the image the parent booted; this path resolves no entrypoint",
         ),

--- a/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
@@ -365,6 +365,8 @@ fn admit_forked_child(p: &AdmitForkedChildParams<'_>) -> Result<AdmittedForkChil
             restrict_agent_verbs: !parent_agent_verbs.is_empty()
                 || crate::commands::vm::agent_verbs::grant_eligible(false, false, false),
             services: Vec::new(),
+            grants: None,
+            backend_kind: None,
             entrypoint: crate::commands::vm::entrypoint_resolve::ResolvedEntrypoint::unresolved(
                 "a checkpoint fork boots the image the parent booted; this path resolves no entrypoint",
             ),

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -146,9 +146,15 @@ pub(in crate::commands) struct RunArgs {
     /// 443), repeatable. Implies networking and **wins over `--net`**.
     #[arg(long = "allow-host", value_name = "HOST[:PORT]")]
     pub allow_host: Vec<String>,
-    /// vCPU cores (default: 2)
+    /// vCPU cores the guest sees (default: 2). Not a host CPU share.
     #[arg(long, default_value = "2")]
     pub cpus: u32,
+    /// Cap host CPU time in millicores (1500 = 1.5 cores); not `--cpus`.
+    #[arg(long = "cpu-limit", value_name = "MILLICORES")]
+    pub cpu_limit: Option<u32>,
+    /// Read grants (CPU, wall clock, egress) from a JSON file.
+    #[arg(long = "grants-file", value_name = "PATH")]
+    pub grants_file: Option<PathBuf>,
     /// Memory (supports human-readable: 512M, 1G, ...)
     #[arg(long, default_value = "512M")]
     pub memory: String,
@@ -368,9 +374,23 @@ pub(in crate::commands) fn run_secure_with_source(
         }
         return Ok(());
     }
-    // One policy model for every backend: resolve the egress flags here and
-    // thread the result down both the json/receipt and the streaming paths.
-    let network_policy = super::shared::resolve_run_network_policy(args.net, &args.allow_host)?;
+    // One policy model for every backend: resolve the grant surfaces here —
+    // which settles the egress policy in the same step — and thread the result
+    // down both the json/receipt and the streaming paths.
+    let host_config = mvm_core::user_config::load(None);
+    let resolved_grants = super::shared::resolve_run_grants(super::shared::GrantInputs {
+        cpu_limit_millicores: args.cpu_limit,
+        timeout_secs: args.timeout,
+        allow_host: &args.allow_host,
+        net: args.net,
+        grants_file: args.grants_file.as_deref(),
+        // A transient run names its image on the command line and reads no
+        // project manifest; `machine create` is the verb that sources a
+        // `[grants]` table.
+        manifest: None,
+        config: &host_config,
+    })?;
+    let network_policy = resolved_grants.network_policy.clone();
 
     // Every transient run is admitted as a locally-signed workload (uniform
     // with `up`): a signed `ExecutionPlan` sets `tenant_id`, which makes the
@@ -379,17 +399,21 @@ pub(in crate::commands) fn run_secure_with_source(
     // unfiltered path. The closure runs inside the boot path with the resolved
     // rootfs + generated vm_name. cpus/mem are captured here because `args` is
     // consumed by `into_exec_args()` below.
-    let admit_backend = crate::exec::select_exec_backend(
+    let selected_backend = crate::exec::select_exec_backend(
         args.image.is_some(),
         &network_policy,
         args.hypervisor.as_deref(),
-    )?
-    .name()
-    .to_string();
+    )?;
+    // The typed kind, taken off the backend object itself: admission measures a
+    // declared grant against the mechanisms this tier really has, and a name
+    // parsed back into a tier would be measuring against whatever was typed.
+    let admit_backend_kind = selected_backend.kind();
+    let admit_backend = selected_backend.name().to_string();
     // The closure below moves `admit_backend`; keep a copy for the receipt's
     // honest per-backend enforcement tier.
     let receipt_backend = admit_backend.clone();
     let admit_network_mode = args.network_mode;
+    let admit_grants = resolved_grants.plan_grants.clone();
     let admit_cpus = args.cpus;
     let admit_mem_mib = u64::from(parse_human_size(&args.memory).context("Invalid --memory")?);
     let admit_network_policy = network_policy.clone();
@@ -446,6 +470,8 @@ pub(in crate::commands) fn run_secure_with_source(
                 admit_is_dev,
             ),
             services: admit_host_services.clone(),
+            grants: admit_grants.clone(),
+            backend_kind: Some(admit_backend_kind),
             entrypoint: crate::commands::vm::entrypoint_resolve::ResolvedEntrypoint::unresolved(
                 "an ad-hoc argv run replaces the image entrypoint",
             ),
@@ -1574,6 +1600,8 @@ mod tests {
             net: false,
             allow_host: Vec::new(),
             cpus: 2,
+            cpu_limit: None,
+            grants_file: None,
             memory: "512M".to_string(),
             profile,
             agent_verb: Vec::new(),

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -302,6 +302,11 @@ fn admit_entrypoint_boot(
         // resolved on every boot rather than only when the grant is asked for,
         // so the path that feeds the refusal is the ordinary path.
         entrypoint: super::entrypoint_resolve::resolve_for_rootfs(params.rootfs),
+        // The entrypoint dispatch path admits a template's own launch and
+        // authors no grant of its own; the transient and persistent machine
+        // paths are where a user names one.
+        grants: None,
+        backend_kind: None,
     })?;
     let Some(ctx) = ctx else { return Ok(None) };
 

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -564,6 +564,8 @@ mod tests {
             net: false,
             allow_host: Vec::new(),
             cpus: 2,
+            cpu_limit: None,
+            grants_file: None,
             memory: "512M".to_string(),
             profile: RunProfile::Standard,
             agent_verb: Vec::new(),

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -1040,6 +1040,8 @@ fn cmd_start(args: StartArgs) -> Result<()> {
                 false, false, is_dev,
             ),
             services: Vec::new(),
+            grants: None,
+            backend_kind: None,
             entrypoint: crate::commands::vm::entrypoint_resolve::ResolvedEntrypoint::unresolved(
                 "the session boot path resolves no entrypoint",
             ),

--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -128,6 +128,25 @@ pub(in crate::commands::vm) struct AdmitPlanForBootParams<'a> {
     /// input grant may pass `Unresolved` freely — the check is reached only
     /// through the grant.
     pub entrypoint: ResolvedEntrypoint,
+    /// What this workload is permitted to consume or reach, as resolved from
+    /// the surfaces that may author one (CLI flags, a JSON grants file, the
+    /// project manifest, the operator's host config). Baked into the signed
+    /// plan and checked against the host's ceiling inside `admit_for_run`. Its
+    /// egress dimension is already reflected in
+    /// [`network_policy`](Self::network_policy), which the caller derived from
+    /// the same resolution.
+    ///
+    /// `None` means no surface authored anything, which is the pre-grant
+    /// baseline: no CPU cap, no wall-clock bound, deny-all egress.
+    pub grants: Option<mvm_contract::grants::Grants>,
+    /// The backend this run will actually boot on, when the caller has one in
+    /// hand. Admission measures a declared grant against the mechanisms that
+    /// tier really has; without it a sealed run refuses a grant whose
+    /// enforceability nothing can confirm, and a dev run is warned. Taken from
+    /// the backend object, never parsed from
+    /// [`backend_name`](Self::backend_name) — a name is a label, and a grant
+    /// checked against a label is checked against whatever the caller typed.
+    pub backend_kind: Option<mvm_contract::protocol::vm_backend::BackendKind>,
 }
 
 /// Shell basenames [`entrypoint_is_shell_shaped`] refuses on direct match.
@@ -338,7 +357,10 @@ pub(in crate::commands::vm) fn admit_plan_for_boot(
         .map(|(policy_ref, _)| policy_ref.as_str());
 
     let input = SynthesisInput {
-        grants: None,
+        // The resolved permission set rides into the plan body, so the ceiling
+        // check below measures what the user actually asked for and the
+        // signature covers it.
+        grants: p.grants.clone(),
         stream_edges: Vec::new(),
         kernel_sha256: None,
         network_mode: p.network_mode,
@@ -415,13 +437,18 @@ pub(in crate::commands::vm) fn admit_plan_for_boot(
         p.ledger,
         p.keys_dir,
         admission_ctx.as_ref(),
-        // This path admits before the caller hands us anything typed for the
-        // backend — it carries a name, and a name is not a tier. So a declared
-        // grant is unverifiable here: a sealed run refuses it, a dev run is
-        // warned. Threading the resolved backend in is what makes a grant
-        // admissible on a sealed boot, and belongs with the surface that first
-        // lets one be authored.
-        RunPosture::without_backend(variant),
+        // A caller that already resolved its backend hands the typed kind over,
+        // and the grant gate measures against the mechanisms that tier really
+        // has. A caller that has not resolved one yet passes `None` and gets
+        // the fail-closed answer: a sealed run refuses a grant whose
+        // enforceability nothing can confirm, a dev run is warned. The plan's
+        // own `runtime_profile` is never consulted for this — it is a label its
+        // author chose, and believing it would let a mislabelled plan pick the
+        // controls it is measured against.
+        match p.backend_kind {
+            Some(kind) => RunPosture::on_backend(variant, kind),
+            None => RunPosture::without_backend(variant),
+        },
     )?;
     let t_signed = std::time::Instant::now();
     tracing::debug!(
@@ -1123,6 +1150,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: Vec::new(),
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
         })
         .expect("must succeed");
@@ -1163,6 +1192,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: Vec::new(),
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
         })
         .expect("admission")
@@ -1224,6 +1255,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: Vec::new(),
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
         })
         .expect_err("missing rootfs must fail");
@@ -1331,6 +1364,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: Vec::new(),
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
         })
         .unwrap()
@@ -1361,6 +1396,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: Vec::new(),
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
         })
         .unwrap()
@@ -1416,6 +1453,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: Vec::new(),
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
         })
         .expect("admission")
@@ -1493,6 +1532,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: Vec::new(),
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
         })
         .expect("admission")
@@ -1548,6 +1589,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: Vec::new(),
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
         })
         .expect("admission")
@@ -1610,6 +1653,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: Vec::new(),
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
         })
         .expect("admission")
@@ -1705,6 +1750,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: vec![stream_grant_service()],
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::Known {
                 argv: vec!["python".to_string(), "-m".to_string(), "app".to_string()],
                 shebang: None,
@@ -1757,6 +1804,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: Vec::new(), // no host.stream.v1 grant
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::Known {
                 argv: vec![
                     "/bin/sh".to_string(),
@@ -1806,6 +1855,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: vec![stream_grant_service()],
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::Known {
                 argv: vec![
                     "/bin/sh".to_string(),
@@ -1863,6 +1914,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: vec![stream_grant_service()],
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::unresolved("this launch path resolves no entrypoint"),
         })
         .expect_err("an unresolved entrypoint carrying the grant must be refused");
@@ -1916,6 +1969,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: true,
             services: Vec::new(),
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::unresolved("this launch path resolves no entrypoint"),
         })
         .expect("an unresolved entrypoint that asked for nothing must still boot")
@@ -1962,6 +2017,8 @@ mod admit_plan_tests {
             agent_verb_override: vec![],
             restrict_agent_verbs: false,
             services: vec![stream_grant_service()],
+            grants: None,
+            backend_kind: None,
             entrypoint: ResolvedEntrypoint::Known {
                 argv: vec![
                     "/bin/sh".to_string(),
@@ -2064,5 +2121,305 @@ mod entrypoint_shape_tests {
     #[test]
     fn an_empty_argv_is_not_shell_shaped() {
         assert!(!entrypoint_is_shell_shaped(&[], None));
+    }
+}
+
+// ── the surfaces, end to end ─────────────────────────────
+//
+// Everything above proves a piece. These prove the whole path: a grant
+// written in a project's manifest is resolved, checked against the host's
+// ceiling, signed into the plan, and — for egress — becomes the policy the
+// gate enforces. Asserting on the admitted `ExecutionPlan` rather than on an
+// intermediate struct is the point; every previous version of this feature
+// was correct in the middle and unreachable at the ends.
+
+#[cfg(test)]
+mod grant_surface_tests {
+    use super::*;
+    use crate::commands::shared::{GrantInputs, resolve_run_grants};
+    use mvm_contract::grants::CpuGrant;
+    use mvm_core::network_policy::HostPort;
+    use mvm_core::user_config::MvmConfig;
+
+    // `localhost` rather than a public name on purpose: admission lowers a
+    // non-deny policy into a signed bundle and pins each allowed host to its
+    // resolved addresses, so a name needing a real resolver would make these
+    // tests depend on the network.
+    const MANIFEST: &str = r#"
+image = "alpine:3.20"
+cpus = 4
+
+[grants]
+cpu_millicores = 1500
+wall_clock_secs = 600
+allow_hosts = ["localhost:8443"]
+"#;
+
+    fn manifest_grants(text: &str) -> mvm_contract::grants::Grants {
+        mvm_core::manifest::Manifest::from_toml_str(text)
+            .expect("the manifest parses")
+            .machine_workflow()
+            .expect("an image-backed manifest yields a machine workflow")
+            .grants
+    }
+
+    fn write_rootfs(dir: &std::path::Path) -> std::path::PathBuf {
+        let path = dir.join("rootfs.ext4");
+        std::fs::write(&path, b"grant rootfs").expect("write rootfs");
+        path
+    }
+
+    #[test]
+    fn a_manifest_grant_reaches_the_signed_plan() {
+        let declared = manifest_grants(MANIFEST);
+        let config = MvmConfig::default();
+        let resolved = resolve_run_grants(GrantInputs {
+            cpu_limit_millicores: None,
+            timeout_secs: None,
+            allow_host: &[],
+            net: false,
+            grants_file: None,
+            manifest: Some(&declared),
+            config: &config,
+        })
+        .expect("the manifest's grants resolve");
+
+        let keys_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let rootfs_dir = tempfile::tempdir().unwrap();
+        let rootfs = write_rootfs(rootfs_dir.path());
+        let ledger = InMemoryNonceLedger::new();
+        let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            tenant: "local",
+            vm_name: "vm-granted",
+            backend_name: "firecracker",
+            rootfs_path: &rootfs,
+            precomputed_image_sha256: None,
+            boot_artifact_identity: None,
+            cpus: 4,
+            mem_mib: 512,
+            seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
+            secret_release: mvm_core::plan::SecretReleasePolicy::None,
+            secrets: Vec::new(),
+            no_supervisor: false,
+            ledger: &ledger,
+            keys_dir: Some(keys_dir.path()),
+            audit_dir: Some(audit_dir.path()),
+            policy_dir: None,
+            bundle_pin: None,
+            deps_volume: None,
+            shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
+            network_policy: resolved.network_policy.clone(),
+            agent_verb_override: vec![],
+            // A dev posture: the grant is recorded and, on a tier without a
+            // CPU mechanism, warned about rather than refused. The refusal
+            // half is `plan_admission`'s to test; this one is about reach.
+            restrict_agent_verbs: false,
+            services: Vec::new(),
+            grants: resolved.plan_grants.clone(),
+            backend_kind: Some(mvm_contract::protocol::vm_backend::BackendKind::Firecracker),
+            entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
+        })
+        .expect("admission")
+        .expect("Some when admission ran");
+
+        let plan_grants = ctx
+            .admitted
+            .plan()
+            .grants
+            .as_ref()
+            .expect("the signed plan carries the manifest's grants");
+        assert_eq!(
+            plan_grants.cpu,
+            Some(CpuGrant::Share { millicores: 1500 }),
+            "the manifest's CPU share must survive into the signed plan"
+        );
+        assert_eq!(
+            plan_grants
+                .egress
+                .as_ref()
+                .map(|egress| egress.allow.as_slice()),
+            Some(&[HostPort::new("localhost", 8443)][..]),
+            "the manifest's allow-list must survive into the signed plan"
+        );
+        assert_eq!(
+            ctx.admitted.plan().resources.cpus,
+            4,
+            "the vCPU count is its own resource and is untouched by the CPU share"
+        );
+    }
+
+    #[test]
+    fn a_manifest_egress_grant_is_what_the_gate_enforces() {
+        // The gate reads the resolved `NetworkPolicy`; the only thing allowed
+        // to derive one from a grant is the projection. So the policy handed
+        // to the launch must be exactly what the projection yields for the
+        // grant the plan was signed over.
+        let declared = manifest_grants(MANIFEST);
+        let config = MvmConfig::default();
+        let resolved = resolve_run_grants(GrantInputs {
+            cpu_limit_millicores: None,
+            timeout_secs: None,
+            allow_host: &[],
+            // `--net` would select the broad dev preset; the granted allow-list
+            // is what wins.
+            net: true,
+            grants_file: None,
+            manifest: Some(&declared),
+            config: &config,
+        })
+        .expect("resolves");
+
+        let plan_grants = resolved
+            .plan_grants
+            .as_ref()
+            .expect("the manifest granted egress");
+        assert_eq!(
+            resolved.network_policy,
+            mvm_contract::grants::projection::network_policy_from_grants(plan_grants),
+            "the enforced policy must be the projection of the signed grant"
+        );
+        assert_eq!(
+            resolved
+                .network_policy
+                .resolve_rules()
+                .expect("an allow-list resolves to rules"),
+            vec![HostPort::new("localhost", 8443)]
+        );
+        assert!(!resolved.network_policy.is_unrestricted());
+    }
+
+    #[test]
+    fn a_grant_over_the_hosts_ceiling_is_refused_before_the_plan_is_signed() {
+        // Admission reads the ceiling from host config, so the test has to be
+        // a bounded host. The refusal must land before signing: a signed plan
+        // we would have refused is indistinguishable downstream from one we
+        // admitted.
+        let home = tempfile::tempdir().expect("scratch mvm home");
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.isolate_mvm_home(home.path());
+        mvm_core::user_config::save(
+            &MvmConfig {
+                max_cpu_millicores: Some(1000),
+                ..MvmConfig::default()
+            },
+            None,
+        )
+        .expect("writing the host config");
+
+        let declared = manifest_grants(MANIFEST);
+        let config = mvm_core::user_config::load(None);
+        let resolved = resolve_run_grants(GrantInputs {
+            cpu_limit_millicores: None,
+            timeout_secs: None,
+            allow_host: &[],
+            net: false,
+            grants_file: None,
+            manifest: Some(&declared),
+            config: &config,
+        })
+        .expect("resolving a grant is not where the ceiling applies");
+
+        let keys_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let rootfs_dir = tempfile::tempdir().unwrap();
+        let rootfs = write_rootfs(rootfs_dir.path());
+        let ledger = InMemoryNonceLedger::new();
+        let err = admit_plan_for_boot(AdmitPlanForBootParams {
+            tenant: "local",
+            vm_name: "vm-over-ceiling",
+            backend_name: "firecracker",
+            rootfs_path: &rootfs,
+            precomputed_image_sha256: None,
+            boot_artifact_identity: None,
+            cpus: 4,
+            mem_mib: 512,
+            seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
+            secret_release: mvm_core::plan::SecretReleasePolicy::None,
+            secrets: Vec::new(),
+            no_supervisor: false,
+            ledger: &ledger,
+            keys_dir: Some(keys_dir.path()),
+            audit_dir: Some(audit_dir.path()),
+            policy_dir: None,
+            bundle_pin: None,
+            deps_volume: None,
+            shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
+            network_policy: resolved.network_policy.clone(),
+            agent_verb_override: vec![],
+            restrict_agent_verbs: false,
+            services: Vec::new(),
+            grants: resolved.plan_grants.clone(),
+            backend_kind: Some(mvm_contract::protocol::vm_backend::BackendKind::Firecracker),
+            entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
+        })
+        .expect_err("1500 millicores on a 1000-millicore host must be refused");
+        assert!(
+            format!("{err:#}").contains("ceiling"),
+            "the refusal must name the ceiling, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_run_that_grants_nothing_still_admits_a_grant_free_plan() {
+        // The pre-grant baseline has to stay byte-identical: an untouched
+        // permission set must not become an empty-but-present one.
+        let config = MvmConfig::default();
+        let resolved = resolve_run_grants(GrantInputs {
+            cpu_limit_millicores: None,
+            timeout_secs: None,
+            allow_host: &[],
+            net: false,
+            grants_file: None,
+            manifest: None,
+            config: &config,
+        })
+        .expect("resolves");
+        assert_eq!(resolved.plan_grants, None);
+
+        let keys_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let rootfs_dir = tempfile::tempdir().unwrap();
+        let rootfs = write_rootfs(rootfs_dir.path());
+        let ledger = InMemoryNonceLedger::new();
+        let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            tenant: "local",
+            vm_name: "vm-ungranted",
+            backend_name: "firecracker",
+            rootfs_path: &rootfs,
+            precomputed_image_sha256: None,
+            boot_artifact_identity: None,
+            cpus: 2,
+            mem_mib: 512,
+            seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
+            secret_release: mvm_core::plan::SecretReleasePolicy::None,
+            secrets: Vec::new(),
+            no_supervisor: false,
+            ledger: &ledger,
+            keys_dir: Some(keys_dir.path()),
+            audit_dir: Some(audit_dir.path()),
+            policy_dir: None,
+            bundle_pin: None,
+            deps_volume: None,
+            shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
+            network_policy: resolved.network_policy.clone(),
+            agent_verb_override: vec![],
+            restrict_agent_verbs: true,
+            services: Vec::new(),
+            grants: resolved.plan_grants.clone(),
+            backend_kind: Some(mvm_contract::protocol::vm_backend::BackendKind::Firecracker),
+            entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
+        })
+        .expect("admission")
+        .expect("Some when admission ran");
+        assert_eq!(ctx.admitted.plan().grants, None);
+        assert_eq!(
+            resolved.network_policy.resolve_rules().as_deref(),
+            Some(&[][..]),
+            "granting nothing still means deny-all"
+        );
     }
 }

--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -1288,6 +1288,8 @@ mod admit_plan_tests {
             let ledger = InMemoryNonceLedger::new();
             let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
                 network_mode: mode,
+                grants: None,
+                backend_kind: None,
                 tenant: "local",
                 vm_name: "vm-transport",
                 backend_name: "firecracker",
@@ -2190,6 +2192,7 @@ allow_hosts = ["localhost:8443"]
         let rootfs = write_rootfs(rootfs_dir.path());
         let ledger = InMemoryNonceLedger::new();
         let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             tenant: "local",
             vm_name: "vm-granted",
             backend_name: "firecracker",
@@ -2350,6 +2353,7 @@ allow_hosts = ["localhost:8443"]
         let rootfs = write_rootfs(rootfs_dir.path());
         let ledger = InMemoryNonceLedger::new();
         let err = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             tenant: "local",
             vm_name: "vm-over-ceiling",
             backend_name: "firecracker",
@@ -2408,6 +2412,7 @@ allow_hosts = ["localhost:8443"]
         let rootfs = write_rootfs(rootfs_dir.path());
         let ledger = InMemoryNonceLedger::new();
         let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
             tenant: "local",
             vm_name: "vm-ungranted",
             backend_name: "firecracker",

--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -2310,7 +2310,10 @@ allow_hosts = ["localhost:8443"]
 
         let declared = manifest_grants(MANIFEST);
         let config = mvm_core::user_config::load(None);
-        let resolved = resolve_run_grants(GrantInputs {
+        // The resolver refuses first and names the surface to go edit: with
+        // four places a grant can come from, the dimension alone is not
+        // actionable.
+        let early = resolve_run_grants(GrantInputs {
             cpu_limit_millicores: None,
             timeout_secs: None,
             allow_host: &[],
@@ -2319,7 +2322,27 @@ allow_hosts = ["localhost:8443"]
             manifest: Some(&declared),
             config: &config,
         })
-        .expect("resolving a grant is not where the ceiling applies");
+        .expect_err("the resolver refuses a grant over this host's ceiling");
+        let early = format!("{early:#}");
+        assert!(early.contains("ceiling"), "got: {early}");
+        assert!(
+            early.contains("manifest"),
+            "the refusal must name the surface that asked for it: {early}"
+        );
+
+        // Admission refuses independently, against host config it reads itself.
+        // That is the authoritative check — resolve with an unbounded config so
+        // the grant reaches it, and it must still refuse.
+        let resolved = resolve_run_grants(GrantInputs {
+            cpu_limit_millicores: None,
+            timeout_secs: None,
+            allow_host: &[],
+            net: false,
+            grants_file: None,
+            manifest: Some(&declared),
+            config: &MvmConfig::default(),
+        })
+        .expect("an unbounded config resolves the same grant");
 
         let keys_dir = tempfile::tempdir().unwrap();
         let audit_dir = tempfile::tempdir().unwrap();

--- a/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
+++ b/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
@@ -90,6 +90,11 @@ pub(in crate::commands) struct PersistentImageStartParams<'a> {
     /// carry an attenuated ProdSafe-only grant. Baked-entrypoint boots (no
     /// trailing argv, non-dev profile) may still receive the grant.
     pub has_ad_hoc_argv: bool,
+    /// The machine spec's resolved permission set, baked into the signed plan
+    /// on every start. Its egress dimension is already reflected in
+    /// [`network_policy`](Self::network_policy), which the caller derived from
+    /// the same spec.
+    pub grants: Option<mvm_contract::grants::Grants>,
 }
 
 fn persistent_oci_rootfs_requires_overlay_policy(rootfs_path: &std::path::Path) -> bool {
@@ -187,6 +192,7 @@ pub(in crate::commands) fn start_persistent_oci_machine(
         kernel_path,
         agent_verb,
         has_ad_hoc_argv,
+        grants,
     } = params;
     validate_vm_name(name).with_context(|| format!("Invalid VM name: {:?}", name))?;
     let mut prepared_volumes =
@@ -255,6 +261,11 @@ pub(in crate::commands) fn start_persistent_oci_machine(
             profile == "dev",
         ),
         services: Vec::new(),
+        grants,
+        // The typed kind of the backend this start resolved, so the grant gate
+        // measures a declared bound against the mechanisms that tier has rather
+        // than refusing for want of an answer.
+        backend_kind: Some(mvm_client::backend_kind_for(backend_name)),
         entrypoint: crate::commands::vm::entrypoint_resolve::ResolvedEntrypoint::unresolved(
             "the persistent OCI start path resolves no entrypoint",
         ),

--- a/crates/mvm-client/src/boot.rs
+++ b/crates/mvm-client/src/boot.rs
@@ -33,6 +33,19 @@ pub fn start_prepared(
     Ok(())
 }
 
+/// The typed tier behind a hypervisor name.
+///
+/// Admission measures a workload's declared grants against the mechanisms its
+/// backend actually has, and that question has to be asked of a `BackendKind`
+/// rather than of a string: a name is a label, and a gate that parsed one would
+/// be deciding which resource controls apply from whatever the caller typed.
+/// The conversion lives here, at the seam that already owns name-to-backend
+/// resolution, so a caller holding only a name still never touches
+/// `AnyBackend` itself.
+pub fn backend_kind_for(hypervisor: &str) -> mvm_core::protocol::vm_backend::BackendKind {
+    mvm_runtime::backend::AnyBackend::from_hypervisor(hypervisor).kind()
+}
+
 /// Whether the named VM is currently `Running` on `hypervisor`. A status-query
 /// error (VM absent) reads as not-running — mirrors the CLI's former inline
 /// `from_hypervisor(...).status(...)` check.

--- a/crates/mvm-client/src/inventory.rs
+++ b/crates/mvm-client/src/inventory.rs
@@ -341,6 +341,7 @@ mod tests {
             created_at: Some("2026-07-01T00:00:00Z".to_string()),
             last_started_at: None,
             health_check: None,
+            grants: None,
         }
     }
 

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -182,6 +182,9 @@ pub(crate) struct BootParams {
     pub(crate) backend_override: Option<String>,
     pub(crate) volumes: Vec<mvm_core::vm_backend::VmVolume>,
     pub(crate) transient: bool,
+    /// The request's permission set, carried into the signed plan and — for
+    /// its egress dimension — into the policy the gate enforces.
+    pub(crate) grants: Option<mvm_contract::grants::Grants>,
 }
 
 impl LocalBackend {
@@ -259,6 +262,7 @@ impl LocalBackend {
             backend_name: backend.name().to_string(),
             volumes: params.volumes,
             destroy_on_exit: params.transient,
+            grants: params.grants,
         };
 
         // A fresh per-launch ledger: local launches are one-shot from this
@@ -394,6 +398,9 @@ fn persisted_spec_from_request(request: &LaunchRequest, name: &str) -> mp::Machi
         created_at: Some(mvm_core::util::time::utc_now()),
         last_started_at: None,
         health_check: None,
+        // The permission set the launch was admitted under, so a later
+        // `start` by name re-admits under the same bounds.
+        grants: request.grants.clone(),
     }
 }
 
@@ -618,6 +625,7 @@ impl LocalBackend {
                 backend_override: request.backend.clone(),
                 volumes,
                 transient,
+                grants: request.grants.clone(),
             })
             .await?;
         preparation.commit();

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -376,6 +376,31 @@ impl LocalBackend {
     }
 }
 
+/// Rebuild the launch request for a persistent start from the stored
+/// definition.
+///
+/// Every field a start needs comes from the spec, `grants` included. A start
+/// that reassembled the request from sizing alone would let a permission set
+/// hold for the machine's first boot and lapse on every one after — deny-all
+/// for egress, and simply unbounded for CPU and wall clock. Split out from
+/// `start_persistent` so that is checkable without booting a VM.
+fn start_request_from_spec(
+    name: &str,
+    image: String,
+    memory_mib: u32,
+    spec: &mp::MachineSpec,
+) -> Result<LaunchRequest> {
+    let mut builder = LaunchRequest::builder(LifecycleMode::Persistent, image)
+        .name(name)
+        .cpus(spec.cpus)
+        .memory_mib(memory_mib)
+        .profile(spec.profile.clone());
+    if let Some(grants) = spec.grants.clone() {
+        builder = builder.grants(grants);
+    }
+    builder.build()
+}
+
 /// Build the persisted declarative spec a persistent launch writes.
 fn persisted_spec_from_request(request: &LaunchRequest, name: &str) -> mp::MachineSpec {
     mp::MachineSpec {
@@ -743,12 +768,7 @@ impl LocalBackend {
         self.validate_sidecar_refs(name)?;
         let memory_mib =
             mvm_core::util::parse_human_size(&spec.memory).map_err(crate::local::backend_err)?;
-        let request = LaunchRequest::builder(LifecycleMode::Persistent, image)
-            .name(name)
-            .cpus(spec.cpus)
-            .memory_mib(memory_mib)
-            .profile(spec.profile.clone())
-            .build()?;
+        let request = start_request_from_spec(name, image, memory_mib, &spec)?;
         let outcome = self.attach_lease_and_boot(name, &request, false).await?;
         Ok(outcome.machine)
     }

--- a/crates/mvm-client/src/launch/request.rs
+++ b/crates/mvm-client/src/launch/request.rs
@@ -8,9 +8,10 @@
 //! Every field is validated at the client boundary, in
 //! [`LaunchRequestBuilder::build`]. Fields the in-process backend cannot
 //! honor are **refused**, never silently dropped: a command/entrypoint
-//! override, guest environment variables, and any network policy other than
-//! deny-all all fail the build with an error naming the CLI path that does
-//! support them.
+//! override, guest environment variables, and an untyped network policy other
+//! than deny-all all fail the build with an error naming what does support
+//! them. Egress is expressed as a grant, which the plan is signed over and the
+//! gate reads.
 
 use mvm_core::client::{MvmError, Result};
 
@@ -29,17 +30,21 @@ pub enum LifecycleMode {
     Persistent,
 }
 
-/// Guest network policy for the launch. The in-process backend enforces
-/// claim-10 default-deny at the shared substitution seam; it has no path
-/// that could honor an allow-list, so anything but deny-all is refused at
-/// validation rather than persisted-but-not-enforced.
+/// Untyped network policy for the launch. Superseded by the egress grant on
+/// [`LaunchRequestBuilder::allow_egress`], which is derived into the policy the
+/// gate reads and is covered by the plan's signature.
+///
+/// This one is not: it is a bare carrier travelling next to the plan rather
+/// than inside it, so an allow-list here would authorize egress that nothing
+/// signed. Anything but deny-all is refused at validation rather than
+/// persisted-but-not-enforced.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum LaunchNetworkPolicy {
-    /// Deny all egress (the only policy the in-process backend admits).
+    /// Deny all egress (the only value this carrier admits).
     #[default]
     DenyAll,
     /// Named host allow-list — refused by [`LaunchRequestBuilder::build`];
-    /// use the CLI verbs, whose boot path enforces the resolved policy.
+    /// express it as an egress grant instead.
     AllowHosts(Vec<String>),
 }
 
@@ -71,6 +76,12 @@ pub struct LaunchRequest {
     pub(crate) volumes: Vec<LaunchVolumeSpec>,
     pub(crate) secret_refs: Vec<MachineSecretRef>,
     pub(crate) force: bool,
+    /// What the workload is permitted to consume or reach. Rides into the
+    /// signed plan, and its egress dimension is projected onto the launch
+    /// config the egress gate reads — so an allow-list here is authorized by
+    /// the same plan that was signed over it, rather than by a carrier
+    /// travelling alongside one.
+    pub(crate) grants: Option<mvm_contract::grants::Grants>,
 }
 
 impl LaunchRequest {
@@ -93,6 +104,7 @@ impl LaunchRequest {
             volumes: Vec::new(),
             secret_refs: Vec::new(),
             force: false,
+            grants: mvm_contract::grants::Grants::default(),
         }
     }
 
@@ -125,6 +137,7 @@ pub struct LaunchRequestBuilder {
     volumes: Vec<LaunchVolumeSpec>,
     secret_refs: Vec<MachineSecretRef>,
     force: bool,
+    grants: mvm_contract::grants::Grants,
 }
 
 impl LaunchRequestBuilder {
@@ -197,6 +210,46 @@ impl LaunchRequestBuilder {
     #[must_use]
     pub fn network(mut self, network: LaunchNetworkPolicy) -> Self {
         self.network = network;
+        self
+    }
+
+    /// Bound the workload to `millicores` thousandths of one host core — a
+    /// share of host CPU *time*, unrelated to [`cpus`], which is the vCPU count
+    /// the guest sees.
+    ///
+    /// [`cpus`]: LaunchRequestBuilder::cpus
+    #[must_use]
+    pub fn cpu_millicores(mut self, millicores: u32) -> Self {
+        self.grants.cpu = Some(mvm_contract::grants::CpuGrant::Share { millicores });
+        self
+    }
+
+    /// Bound the workload's wall-clock runtime.
+    #[must_use]
+    pub fn wall_clock_secs(mut self, secs: std::num::NonZeroU32) -> Self {
+        self.grants.wall_clock = Some(mvm_contract::grants::WallClockGrant::Secs { secs });
+        self
+    }
+
+    /// Permit outbound access to one `host:port`. Repeatable; each call
+    /// appends. Calling it at all is what lifts the workload off deny-all, and
+    /// the allow-list lands in the signed plan the gate's policy is derived
+    /// from.
+    #[must_use]
+    pub fn allow_egress(mut self, host: impl Into<String>, port: u16) -> Self {
+        self.grants
+            .egress
+            .get_or_insert_with(Default::default)
+            .allow
+            .push(mvm_core::policy::network_policy::HostPort::new(host, port));
+        self
+    }
+
+    /// Replace the whole permission set at once, for a caller that already has
+    /// one in hand. Overwrites every dimension the setters above may have set.
+    #[must_use]
+    pub fn grants(mut self, grants: mvm_contract::grants::Grants) -> Self {
+        self.grants = grants;
         self
     }
 
@@ -299,6 +352,10 @@ impl LaunchRequestBuilder {
             volumes: self.volumes,
             secret_refs: self.secret_refs,
             force: self.force,
+            // An untouched permission set stays absent, so a request that
+            // granted nothing produces exactly the plan it produced before
+            // grants were expressible.
+            grants: (self.grants != mvm_contract::grants::Grants::default()).then_some(self.grants),
         })
     }
 }

--- a/crates/mvm-client/src/launch/tests.rs
+++ b/crates/mvm-client/src/launch/tests.rs
@@ -544,6 +544,7 @@ async fn start_refuses_spec_shapes_the_in_process_backend_cannot_honor() {
         created_at: None,
         last_started_at: None,
         health_check: None,
+        grants: None,
     };
     mvm_runtime::machine::persist::save_machine_spec(&spec, false).unwrap();
     let err = client
@@ -876,4 +877,119 @@ async fn lifecycle_audit_carries_no_secret_values_or_env() {
             }
         }
     }
+}
+
+// ── Grants across the library verbs ──────────────────────────────────
+//
+// The CLI half of this got the persistence right; the library half is where a
+// caller's permission set can vanish without a word. Both verbs below dropped
+// grants before these tests existed: `create_machine` never put them on the
+// request, and `start_persistent` rebuilt the request from sizing alone.
+
+fn egress_grants(host: &str, port: u16) -> mvm_contract::grants::Grants {
+    mvm_contract::grants::Grants {
+        cpu: Some(mvm_contract::grants::CpuGrant::Share { millicores: 1500 }),
+        egress: Some(mvm_contract::grants::EgressGrant {
+            allow: vec![mvm_core::policy::network_policy::HostPort::new(host, port)],
+        }),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn create_machine_persists_the_callers_grants() {
+    // `MachineSpec.grants` is the only way a library caller expresses an egress
+    // allow-list. Dropping it on the persistent verb would leave that
+    // expression with nowhere to land — silently, which is what the sibling
+    // `env` refusal in the same function exists to avoid.
+    let home = Isolated::new();
+    let client = mock_client();
+    let rootfs = home.rootfs();
+
+    let spec = mvm_core::client::dto::MachineSpec::builder("p-granted", rootfs)
+        .cpus(2)
+        .memory_mib(256)
+        .cpu_millicores(1500)
+        .allow_egress("api.example.com", 443)
+        .build();
+    client.create_machine(spec).await.expect("create");
+
+    let persisted = mp::load_machine_spec("p-granted").expect("definition persisted");
+    let grants = persisted
+        .grants
+        .expect("the caller's grants reached the persisted definition");
+    assert_eq!(
+        grants.cpu,
+        Some(mvm_contract::grants::CpuGrant::Share { millicores: 1500 })
+    );
+    assert_eq!(
+        grants.egress.expect("egress granted").allow,
+        vec![mvm_core::policy::network_policy::HostPort::new(
+            "api.example.com",
+            443
+        )]
+    );
+}
+
+#[test]
+fn a_restart_re_admits_under_the_persisted_grants_not_deny_all() {
+    // A permission set that holds for the first boot and lapses on the next is
+    // the "my allowlist stopped applying" failure in its purest form: closed
+    // for egress, so nothing breaks loudly, and silent for CPU and wall clock.
+    let mut spec = mp::MachineSpec {
+        schema_version: mp::MACHINE_SPEC_SCHEMA_VERSION,
+        name: "p-restart".to_string(),
+        image: Some("alpine:latest".to_string()),
+        manifest: None,
+        deployment: None,
+        resolved_digest: None,
+        runtime_pack: false,
+        net: false,
+        allow_host: vec![],
+        cpus: 2,
+        memory: "256M".to_string(),
+        mem_initial: None,
+        profile: "standard".to_string(),
+        volumes: vec![],
+        init: vec![],
+        agent_verb: vec![],
+        created_at: None,
+        last_started_at: None,
+        health_check: None,
+        grants: Some(egress_grants("api.example.com", 443)),
+    };
+
+    let request =
+        super::start_request_from_spec("p-restart", "alpine:latest".to_string(), 256, &spec)
+            .expect("the start request builds");
+    let carried = request
+        .grants
+        .as_ref()
+        .expect("the start carries the definition's grants");
+    assert_eq!(
+        carried.cpu,
+        Some(mvm_contract::grants::CpuGrant::Share { millicores: 1500 })
+    );
+
+    // The policy the boot installs is derived from exactly those grants, so
+    // asserting the projection is asserting what the gate will enforce.
+    let policy = mvm_contract::grants::projection::network_policy_from_grants(carried);
+    assert_eq!(
+        policy
+            .resolve_rules()
+            .expect("an allow-list resolves to rules"),
+        vec![mvm_core::policy::network_policy::HostPort::new(
+            "api.example.com",
+            443
+        )],
+        "a restart must not silently fall back to deny-all"
+    );
+
+    // And a definition that granted nothing stays grant-free, so the pre-grant
+    // baseline is unchanged.
+    spec.grants = None;
+    let ungranted =
+        super::start_request_from_spec("p-restart", "alpine:latest".to_string(), 256, &spec)
+            .expect("the start request builds");
+    assert_eq!(ungranted.grants, None);
 }

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -41,7 +41,8 @@ pub use mvm_core::client::mock::{self, MockBackend};
 pub use mvm_core::client::{MvmClient, MvmError, Result};
 
 pub use boot::{
-    backend_is_running, backend_stop_by_name, require_hypervisor_selectable, start_prepared,
+    backend_is_running, backend_kind_for, backend_stop_by_name, require_hypervisor_selectable,
+    start_prepared,
 };
 pub use connect::{Target, connect};
 pub use launch::{

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -640,15 +640,17 @@ impl MvmClient for LocalBackend {
                     .into(),
             });
         }
-        let request = crate::launch::LaunchRequest::builder(
+        let mut builder = crate::launch::LaunchRequest::builder(
             crate::launch::LifecycleMode::Transient,
             spec.image,
         )
         .name(spec.name)
         .cpus(spec.cpus)
-        .memory_mib(spec.memory_mib)
-        .build()?;
-        let outcome = self.launch(request).await?;
+        .memory_mib(spec.memory_mib);
+        if let Some(grants) = spec.grants {
+            builder = builder.grants(grants);
+        }
+        let outcome = self.launch(builder.build()?).await?;
         Ok(outcome.machine)
     }
 

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -619,15 +619,21 @@ impl MvmClient for LocalBackend {
                     .into(),
             });
         }
-        let request = crate::launch::LaunchRequest::builder(
+        let mut builder = crate::launch::LaunchRequest::builder(
             crate::launch::LifecycleMode::Persistent,
             spec.image,
         )
         .name(spec.name)
         .cpus(spec.cpus)
-        .memory_mib(spec.memory_mib)
-        .build()?;
-        self.create_from_request(&request)
+        .memory_mib(spec.memory_mib);
+        // Carried, never dropped — the same reason the env refusal above
+        // exists. A permission set the caller believes is in force and is not
+        // is worse than none at all, because it is believed. This is also the
+        // only way a library caller expresses an egress allow-list.
+        if let Some(grants) = spec.grants {
+            builder = builder.grants(grants);
+        }
+        self.create_from_request(&builder.build()?)
     }
 
     async fn run_machine(&self, spec: MachineSpec) -> Result<MachineState> {
@@ -1054,6 +1060,7 @@ mod tests {
             cpus: 1,
             memory_mib: 128,
             env: vec![],
+            grants: None,
         };
         let state = be
             .run_machine(spec)
@@ -1084,6 +1091,7 @@ mod tests {
             cpus: 1,
             memory_mib: 128,
             env: vec![],
+            grants: None,
         };
         let state = be.run_machine(spec).await.expect("boot");
         assert!(
@@ -1132,6 +1140,7 @@ mod tests {
             cpus: 1,
             memory_mib: 128,
             env: vec![],
+            grants: None,
         };
         let state = be.run_machine(spec).await.expect("boot");
         assert!(
@@ -1286,6 +1295,7 @@ mod tests {
             last_started_at: None,
             health_check: None,
             deployment: None,
+            grants: None,
         };
         save_machine_spec(&spec, false).expect("persist_test_spec: save failed");
     }

--- a/crates/mvm-contract/src/grants/ceiling.rs
+++ b/crates/mvm-contract/src/grants/ceiling.rs
@@ -38,8 +38,24 @@ impl GrantCeiling {
     /// fixed at VM creation rather than granted, but it still has to be
     /// bounded or a caller could reserve the entire host.
     pub fn admits(&self, grants: &Grants, memory_mib: u64) -> Result<(), CeilingViolation> {
+        // CPU first, memory second, wall clock last: when a request exceeds in
+        // more than one dimension the reported one has to be stable, or the
+        // refusal a user sees depends on evaluation order.
         self.admits_cpu(grants)?;
         self.admits_memory(memory_mib)?;
+        self.admits_wall_clock(grants)
+    }
+
+    /// Check only the dimensions a grant can author, for a caller holding the
+    /// grants but not a memory size — a surface settling what was asked for,
+    /// before anything has sized a VM.
+    ///
+    /// Not a second decision point: [`admits`](GrantCeiling::admits) is this
+    /// plus the memory check, and admission still runs the full one against
+    /// host config it reads itself. Calling this earlier buys a better message,
+    /// never a different verdict.
+    pub fn admits_grants(&self, grants: &Grants) -> Result<(), CeilingViolation> {
+        self.admits_cpu(grants)?;
         self.admits_wall_clock(grants)
     }
 

--- a/crates/mvm-contract/src/grants/mod.rs
+++ b/crates/mvm-contract/src/grants/mod.rs
@@ -16,7 +16,7 @@ pub mod projection;
 /// A workload's permission set. Every field is optional: absent means
 /// "unspecified", which each dimension resolves differently — an absent
 /// `egress` is deny-all, an absent `cpu` is uncapped.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Grants {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/mvm-core/src/client/dto.rs
+++ b/crates/mvm-core/src/client/dto.rs
@@ -58,12 +58,23 @@ pub struct MachineSpec {
     pub cpus: u32,
     pub memory_mib: u32,
     pub env: Vec<(String, String)>,
+    /// What this workload is permitted to consume or reach. `None` leaves
+    /// every dimension unspecified, which each resolves its own way: no CPU
+    /// cap, no wall-clock bound, and deny-all egress.
+    ///
+    /// This is the only way a library caller expresses an egress allow-list —
+    /// there is no separate network field, because a second representation of
+    /// the same decision is a second thing that can disagree with the signed
+    /// plan. `#[serde(default)]` so a record written before grants existed
+    /// still deserializes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grants: Option<mvm_contract::grants::Grants>,
 }
 
 impl MachineSpec {
     /// Start building a spec. `name` and `image` are the two required fields;
-    /// everything else defaults (1 vCPU, 512 MiB, no env) and is overridable on
-    /// the returned [`MachineSpecBuilder`].
+    /// everything else defaults (1 vCPU, 512 MiB, no env, no grants) and is
+    /// overridable on the returned [`MachineSpecBuilder`].
     pub fn builder(name: impl Into<String>, image: impl Into<String>) -> MachineSpecBuilder {
         MachineSpecBuilder {
             name: name.into(),
@@ -71,6 +82,7 @@ impl MachineSpec {
             cpus: 1,
             memory_mib: 512,
             env: Vec::new(),
+            grants: mvm_contract::grants::Grants::default(),
         }
     }
 }
@@ -89,6 +101,7 @@ pub struct MachineSpecBuilder {
     cpus: u32,
     memory_mib: u32,
     env: Vec<(String, String)>,
+    grants: mvm_contract::grants::Grants,
 }
 
 impl MachineSpecBuilder {
@@ -120,6 +133,61 @@ impl MachineSpecBuilder {
         self
     }
 
+    /// Bound the workload to `millicores` thousandths of one host core.
+    ///
+    /// A share of host CPU *time*, unrelated to [`cpus`], which sets how many
+    /// vCPUs the guest sees. A workload can hold four vCPUs and be bounded to
+    /// half a core; conflating the two is the mistake every container runtime
+    /// made once.
+    ///
+    /// [`cpus`]: MachineSpecBuilder::cpus
+    #[must_use]
+    pub fn cpu_millicores(mut self, millicores: u32) -> Self {
+        self.grants.cpu = Some(mvm_contract::grants::CpuGrant::Share { millicores });
+        self
+    }
+
+    /// Bound the workload to a deterministic executed-instruction budget.
+    /// A different unit from [`cpu_millicores`], not a finer one; the later
+    /// call wins.
+    ///
+    /// [`cpu_millicores`]: MachineSpecBuilder::cpu_millicores
+    #[must_use]
+    pub fn cpu_fuel(mut self, instructions: u64) -> Self {
+        self.grants.cpu = Some(mvm_contract::grants::CpuGrant::Fuel { instructions });
+        self
+    }
+
+    /// Bound the workload's wall-clock runtime. `NonZeroU32` because zero
+    /// seconds means "no time allowed", which is not a bound anyone wants, and
+    /// the legacy encoding it resembles reads zero as *unbounded*.
+    #[must_use]
+    pub fn wall_clock_secs(mut self, secs: std::num::NonZeroU32) -> Self {
+        self.grants.wall_clock = Some(mvm_contract::grants::WallClockGrant::Secs { secs });
+        self
+    }
+
+    /// Permit outbound access to one `host:port`. Repeatable; each call
+    /// appends. Calling it at all is what lifts the workload off deny-all.
+    #[must_use]
+    pub fn allow_egress(mut self, host: impl Into<String>, port: u16) -> Self {
+        self.grants
+            .egress
+            .get_or_insert_with(Default::default)
+            .allow
+            .push(crate::policy::network_policy::HostPort::new(host, port));
+        self
+    }
+
+    /// Replace the whole permission set at once, for a caller that already has
+    /// one in hand (read from a file, received over a wire). Overwrites every
+    /// dimension the per-dimension setters above may have set.
+    #[must_use]
+    pub fn grants(mut self, grants: mvm_contract::grants::Grants) -> Self {
+        self.grants = grants;
+        self
+    }
+
     /// Finish building. Infallible — `name` and `image` were required up front.
     #[must_use]
     pub fn build(self) -> MachineSpec {
@@ -129,6 +197,10 @@ impl MachineSpecBuilder {
             cpus: self.cpus,
             memory_mib: self.memory_mib,
             env: self.env,
+            // An untouched permission set serializes as absent, so a spec that
+            // granted nothing is byte-identical to one written before grants
+            // existed.
+            grants: (self.grants != mvm_contract::grants::Grants::default()).then_some(self.grants),
         }
     }
 }
@@ -369,10 +441,60 @@ mod tests {
             cpus: 2,
             memory_mib: 512,
             env: vec![("PORT".into(), "8080".into())],
+            grants: None,
         };
         let json = serde_json::to_string(&spec).unwrap();
         let back: MachineSpec = serde_json::from_str(&json).unwrap();
         assert_eq!(spec, back);
+    }
+
+    #[test]
+    fn a_persisted_machine_spec_without_grants_still_loads() {
+        // Specs written before grants existed are on disk and in flight; the
+        // field has to be optional in the wire form, not merely in the type.
+        let legacy = r#"{"name":"web","image":"nginx","cpus":1,"memory_mib":512,"env":[]}"#;
+        let spec: MachineSpec = serde_json::from_str(legacy).expect("legacy spec still loads");
+        assert_eq!(spec.grants, None);
+        // And a spec that grants nothing must round-trip back to that same
+        // legacy shape, so writing one does not gratuitously change the bytes.
+        assert_eq!(serde_json::to_string(&spec).unwrap(), legacy);
+    }
+
+    #[test]
+    fn the_builder_expresses_an_egress_allow_list() {
+        // The library surface's reason to exist: before this, a caller could
+        // not ask for outbound access at all without shelling out to the CLI.
+        let spec = MachineSpec::builder("web", "nginx")
+            .cpu_millicores(1500)
+            .allow_egress("api.example.com", 443)
+            .allow_egress("db.internal", 5432)
+            .build();
+        let grants = spec.grants.expect("grants were authored");
+        assert_eq!(
+            grants.cpu,
+            Some(mvm_contract::grants::CpuGrant::Share { millicores: 1500 })
+        );
+        let allow = &grants.egress.expect("egress authored").allow;
+        assert_eq!(allow.len(), 2);
+        assert_eq!(
+            allow[0],
+            crate::policy::network_policy::HostPort::new("api.example.com", 443)
+        );
+    }
+
+    #[test]
+    fn cpus_and_cpu_millicores_are_independent_controls() {
+        // vCPU count and host CPU share are different questions; setting one
+        // must not move the other.
+        let spec = MachineSpec::builder("web", "nginx")
+            .cpus(4)
+            .cpu_millicores(500)
+            .build();
+        assert_eq!(spec.cpus, 4);
+        assert_eq!(
+            spec.grants.and_then(|g| g.cpu),
+            Some(mvm_contract::grants::CpuGrant::Share { millicores: 500 })
+        );
     }
 
     #[test]
@@ -386,6 +508,7 @@ mod tests {
                 cpus: 1,
                 memory_mib: 512,
                 env: vec![],
+                grants: None,
             }
         );
 
@@ -421,6 +544,7 @@ mod tests {
             cpus: 2,
             memory_mib: 512,
             env: vec![("PORT".into(), "8080".into())],
+            grants: None,
         };
         assert_eq!(built, literal);
     }

--- a/crates/mvm-core/src/client/gateway.rs
+++ b/crates/mvm-core/src/client/gateway.rs
@@ -1024,6 +1024,7 @@ mod tests {
             cpus: 1,
             memory_mib: 64,
             env: vec![("A".into(), "B".into())],
+            grants: None,
         };
         // The env guard fires before any request, so no server is needed.
         let err = be.run_machine(spec).await.unwrap_err();

--- a/crates/mvm-core/src/client/mock.rs
+++ b/crates/mvm-core/src/client/mock.rs
@@ -206,6 +206,7 @@ mod tests {
             cpus: 1,
             memory_mib: 128,
             env: vec![],
+            grants: None,
         };
         let started = mock.run_machine(spec).await.unwrap();
         assert_eq!(started.status, MachineStatus::Running);
@@ -228,6 +229,7 @@ mod tests {
             cpus: 1,
             memory_mib: 128,
             env: vec![],
+            grants: None,
         };
 
         // create → stopped (not started).
@@ -280,6 +282,7 @@ mod tests {
                 cpus: 1,
                 memory_mib: 64,
                 env: vec![],
+                grants: None,
             })
             .await
             .unwrap();
@@ -333,6 +336,7 @@ mod tests {
                 cpus: 1,
                 memory_mib: 64,
                 env: vec![],
+                grants: None,
             })
             .await
             .unwrap();
@@ -358,6 +362,7 @@ mod tests {
                 cpus: 1,
                 memory_mib: 64,
                 env: vec![],
+                grants: None,
             })
             .await
             .unwrap();

--- a/crates/mvm-core/src/domain/manifest.rs
+++ b/crates/mvm-core/src/domain/manifest.rs
@@ -164,6 +164,13 @@ pub struct Manifest {
     #[serde(default, skip_serializing_if = "ManifestDev::is_empty")]
     pub dev: ManifestDev,
 
+    /// Optional workload permission set — the project's default grants.
+    /// Empty means the project declares none, and each dimension then resolves
+    /// its own way: an absent egress grant is deny-all, an absent CPU grant is
+    /// uncapped.
+    #[serde(default, skip_serializing_if = "ManifestGrants::is_empty")]
+    pub grants: ManifestGrants,
+
     /// Human-readable data disk size; `"0"` means no data disk.
     #[serde(default = "default_data_disk")]
     pub data_disk: String,
@@ -257,6 +264,17 @@ impl Manifest {
         for entry in &self.network.allow_hosts {
             parse_allow_host(entry)?;
         }
+        // Two authored allow-lists are two answers to one question, and
+        // whichever the enforcement path happens to read becomes the real
+        // policy. Refuse the ambiguity instead of picking a winner silently.
+        if !self.network.allow_hosts.is_empty() && !self.grants.allow_hosts.is_empty() {
+            return Err(anyhow!(
+                "manifest declares an egress allow-list in both `[network].allow_hosts` and \
+                 `[grants].allow_hosts`; keep exactly one — `[grants]` is the granted form \
+                 the egress gate enforces"
+            ));
+        }
+        self.grants.to_grants()?;
         for cmd in &self.dev.init {
             if cmd.trim().is_empty() {
                 return Err(anyhow!(
@@ -299,6 +317,9 @@ impl Manifest {
             cpus: u32::from(self.cpus),
             mem: self.mem.clone(),
             mem_initial: self.mem_initial.clone(),
+            // `validate` already rejected a malformed `[grants]`, and every
+            // constructor runs it, so this cannot fail on a parsed manifest.
+            grants: self.grants.to_grants().unwrap_or_default(),
         })
     }
 
@@ -388,6 +409,107 @@ impl ManifestNetwork {
     }
 }
 
+/// The `[grants]` table: what this project's workload is permitted to consume
+/// or reach, in the manifest's own human-readable spelling.
+///
+/// Kept separate from [`mvm_contract::grants::Grants`] because the wire type is
+/// a tagged union tuned for a signed payload, and a TOML author should not have
+/// to write `cpu = { unit = "share", millicores = 1500 }`. [`to_grants`] is the
+/// one conversion.
+///
+/// [`to_grants`]: ManifestGrants::to_grants
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ManifestGrants {
+    /// CPU share in thousandths of one host core (`1500` = 1.5 cores). This is
+    /// a share of host CPU *time*, not the `cpus` count the guest sees — the
+    /// two are independent and a workload may hold four vCPUs bounded to half
+    /// a core.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_millicores: Option<u32>,
+    /// Deterministic executed-instruction budget. A different unit from
+    /// `cpu_millicores`, not a finer one; setting both is a parse error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_fuel: Option<u64>,
+    /// Wall-clock bound in seconds. Must be positive: zero means "no time
+    /// allowed", which is not expressible, and the legacy encoding it
+    /// resembles reads zero as *unbounded* — the exact inversion.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wall_clock_secs: Option<u32>,
+    /// Outbound destinations as `HOST[:PORT]`, port defaulting to 443. An
+    /// entry here is what the egress gate ends up enforcing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allow_hosts: Vec<String>,
+}
+
+impl ManifestGrants {
+    fn is_empty(&self) -> bool {
+        self.cpu_millicores.is_none()
+            && self.cpu_fuel.is_none()
+            && self.wall_clock_secs.is_none()
+            && self.allow_hosts.is_empty()
+    }
+
+    /// Convert to the typed permission set the plan carries.
+    pub fn to_grants(&self) -> Result<mvm_contract::grants::Grants> {
+        use mvm_contract::grants::{CpuGrant, EgressGrant, Grants, WallClockGrant};
+
+        let cpu = match (self.cpu_millicores, self.cpu_fuel) {
+            (Some(_), Some(_)) => {
+                return Err(anyhow!(
+                    "manifest fields `grants.cpu_millicores` and `grants.cpu_fuel` are \
+                     different units, not different precisions; set exactly one"
+                ));
+            }
+            (Some(millicores), None) => {
+                if millicores == 0 {
+                    return Err(anyhow!(
+                        "manifest field `grants.cpu_millicores` must be > 0; omit it to leave \
+                         CPU uncapped"
+                    ));
+                }
+                Some(CpuGrant::Share { millicores })
+            }
+            (None, Some(instructions)) => Some(CpuGrant::Fuel { instructions }),
+            (None, None) => None,
+        };
+
+        let wall_clock = match self.wall_clock_secs {
+            None => None,
+            Some(secs) => Some(WallClockGrant::Secs {
+                secs: std::num::NonZeroU32::new(secs).ok_or_else(|| {
+                    anyhow!(
+                        "manifest field `grants.wall_clock_secs` must be > 0; omit it to leave \
+                         the workload unbounded"
+                    )
+                })?,
+            }),
+        };
+
+        let egress = if self.allow_hosts.is_empty() {
+            None
+        } else {
+            Some(EgressGrant {
+                allow: self
+                    .allow_hosts
+                    .iter()
+                    .map(|entry| {
+                        parse_allow_host(entry).with_context(|| {
+                            format!("invalid `grants.allow_hosts` entry: {entry:?}")
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+            })
+        };
+
+        Ok(Grants {
+            cpu,
+            wall_clock,
+            egress,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct ManifestDev {
@@ -413,6 +535,9 @@ pub struct ManifestMachineWorkflow {
     pub cpus: u32,
     pub mem: String,
     pub mem_initial: Option<String>,
+    /// The project's declared permission set, already in the typed form the
+    /// signed plan carries. Every dimension may be absent.
+    pub grants: mvm_contract::grants::Grants,
 }
 
 /// If exactly one of `mvm.toml` / `Mvmfile.toml` exists in `dir`,
@@ -966,6 +1091,97 @@ mod tests {
         assert_eq!(workflow.mem, "8G");
         assert_eq!(workflow.mem_initial.as_deref(), Some("512M"));
         assert_eq!(workflow.allow_hosts, m.network.allow_hosts);
+    }
+
+    #[test]
+    fn a_grants_table_becomes_typed_workflow_grants() {
+        let toml = r#"
+            image = "alpine:3.20"
+
+            [grants]
+            cpu_millicores = 1500
+            wall_clock_secs = 600
+            allow_hosts = ["api.example.com:443", "db.internal"]
+        "#;
+        let workflow = Manifest::from_toml_str(toml)
+            .expect("parses")
+            .machine_workflow()
+            .expect("image-backed machine workflow");
+        assert_eq!(
+            workflow.grants.cpu,
+            Some(mvm_contract::grants::CpuGrant::Share { millicores: 1500 })
+        );
+        assert_eq!(
+            workflow.grants.wall_clock,
+            Some(mvm_contract::grants::WallClockGrant::Secs {
+                secs: std::num::NonZeroU32::new(600).expect("nonzero")
+            })
+        );
+        assert_eq!(
+            workflow.grants.egress.expect("egress granted").allow,
+            vec![
+                crate::network_policy::HostPort::new("api.example.com", 443),
+                // A bare host defaults to 443, matching `[network].allow_hosts`.
+                crate::network_policy::HostPort::new("db.internal", 443),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_manifest_without_a_grants_table_grants_nothing() {
+        let workflow = Manifest::from_toml_str("image = \"alpine:3.20\"")
+            .expect("parses")
+            .machine_workflow()
+            .expect("image-backed machine workflow");
+        assert_eq!(workflow.grants, mvm_contract::grants::Grants::default());
+    }
+
+    #[test]
+    fn two_egress_allow_lists_are_refused_rather_than_silently_ranked() {
+        // Two authored answers to one question; whichever the enforcement path
+        // read would become the real policy.
+        let err = Manifest::from_toml_str(
+            r#"
+            image = "alpine:3.20"
+
+            [network]
+            allow_hosts = ["a.example.com"]
+
+            [grants]
+            allow_hosts = ["b.example.com"]
+        "#,
+        )
+        .expect_err("two allow-lists must not parse");
+        assert!(format!("{err:#}").contains("both"), "got: {err:#}");
+    }
+
+    #[test]
+    fn a_zero_wall_clock_grant_is_refused_not_read_as_unbounded() {
+        // The legacy `exec_secs` encoding reads zero as *unbounded*, so a user
+        // writing 0 to mean "no time allowed" would get the exact inversion.
+        let err =
+            Manifest::from_toml_str("image = \"alpine:3.20\"\n[grants]\nwall_clock_secs = 0\n")
+                .expect_err("zero seconds must not parse");
+        assert!(
+            format!("{err:#}").contains("wall_clock_secs"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn cpu_millicores_and_cpu_fuel_are_units_not_precisions() {
+        let err = Manifest::from_toml_str(
+            "image = \"alpine:3.20\"\n[grants]\ncpu_millicores = 1500\ncpu_fuel = 100\n",
+        )
+        .expect_err("two CPU units must not parse");
+        assert!(format!("{err:#}").contains("exactly one"), "got: {err:#}");
+    }
+
+    #[test]
+    fn an_unknown_grants_key_is_refused() {
+        let err = Manifest::from_toml_str("image = \"alpine:3.20\"\n[grants]\ncpu_limt = 1500\n")
+            .expect_err("a misspelled key must not be silently dropped");
+        assert!(format!("{err:#}").contains("cpu_limt"), "got: {err:#}");
     }
 
     #[test]

--- a/crates/mvm-core/src/grants_resolve.rs
+++ b/crates/mvm-core/src/grants_resolve.rs
@@ -1,0 +1,314 @@
+//! Per-dimension resolution of a workload's [`Grants`] across the surfaces
+//! that may author one.
+//!
+//! **Per dimension, not per object.** A CLI flag that sets a CPU share must not
+//! discard an egress allow-list the project's manifest declared: the two are
+//! independent decisions that happen to share a struct. Whole-object precedence
+//! would drop the allow-list silently, and the symptom would surface much later
+//! as "my allow-list stopped applying".
+//!
+//! A higher surface may *loosen* a lower one. The manifest is a project
+//! default and the command line belongs to the developer running it, so there
+//! is no monotonic-narrowing rule between surfaces. What bounds the outcome is
+//! the ceiling, which no surface here can reach — it is read at admission from
+//! host configuration, never from anything resolved in this module.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use mvm_contract::grants::Grants;
+
+/// A surface that may author a grant, named so a resolved dimension can say
+/// where it came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GrantSurface {
+    /// Command-line flags on the invocation.
+    Cli,
+    /// A JSON document named by `--grants-file`.
+    GrantsFile,
+    /// The `[grants]` table of the project's `mvm.toml` / `Mvmfile.toml`.
+    Manifest,
+    /// The operator's `~/.mvm/config/config.toml` defaults.
+    HostConfig,
+}
+
+impl GrantSurface {
+    /// Operator-facing name, for diagnostics and audit labels.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cli => "cli",
+            Self::GrantsFile => "grants-file",
+            Self::Manifest => "manifest",
+            Self::HostConfig => "host-config",
+        }
+    }
+}
+
+/// One surface's contribution. Every dimension of `grants` is optional, and an
+/// absent dimension means "this surface said nothing about it" — which is what
+/// lets a lower surface supply it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GrantLayer {
+    pub surface: GrantSurface,
+    pub grants: Grants,
+}
+
+impl GrantLayer {
+    #[must_use]
+    pub fn new(surface: GrantSurface, grants: Grants) -> Self {
+        Self { surface, grants }
+    }
+}
+
+/// Which surface won each dimension. Carried alongside the resolution so a
+/// refusal can name the surface that asked for the refused thing, rather than
+/// leaving the user to guess which of four places to edit.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct GrantProvenance {
+    pub cpu: Option<GrantSurface>,
+    pub wall_clock: Option<GrantSurface>,
+    pub egress: Option<GrantSurface>,
+}
+
+impl GrantProvenance {
+    /// Dimension/surface pairs that were actually authored, in a stable order.
+    #[must_use]
+    pub fn authored(&self) -> Vec<(&'static str, GrantSurface)> {
+        [
+            ("cpu", self.cpu),
+            ("wall_clock", self.wall_clock),
+            ("egress", self.egress),
+        ]
+        .into_iter()
+        .filter_map(|(name, surface)| surface.map(|s| (name, s)))
+        .collect()
+    }
+}
+
+/// The outcome of resolving every surface.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ResolvedGrants {
+    grants: Grants,
+    provenance: GrantProvenance,
+}
+
+impl ResolvedGrants {
+    /// The resolved permission set.
+    #[must_use]
+    pub fn grants(&self) -> &Grants {
+        &self.grants
+    }
+
+    /// Which surface supplied each resolved dimension.
+    #[must_use]
+    pub fn provenance(&self) -> &GrantProvenance {
+        &self.provenance
+    }
+
+    /// True when no surface authored anything.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.grants == Grants::default()
+    }
+
+    /// What the plan should carry: `None` when nothing was authored, so a run
+    /// with no grants keeps producing exactly the plan it produced before this
+    /// resolver existed rather than an empty-but-present grant object.
+    #[must_use]
+    pub fn into_plan_grants(self) -> Option<Grants> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self.grants)
+        }
+    }
+}
+
+/// Resolve `layers` — highest precedence first — one dimension at a time.
+///
+/// The first layer that names a dimension wins it. Layers below still supply
+/// the dimensions the winner left unset, which is the whole point: an
+/// invocation that caps CPU on the command line keeps the manifest's egress
+/// allow-list.
+#[must_use]
+pub fn resolve_grants(layers: &[GrantLayer]) -> ResolvedGrants {
+    let mut resolved = ResolvedGrants::default();
+    for layer in layers {
+        if resolved.grants.cpu.is_none()
+            && let Some(cpu) = layer.grants.cpu
+        {
+            resolved.grants.cpu = Some(cpu);
+            resolved.provenance.cpu = Some(layer.surface);
+        }
+        if resolved.grants.wall_clock.is_none()
+            && let Some(wall_clock) = layer.grants.wall_clock
+        {
+            resolved.grants.wall_clock = Some(wall_clock);
+            resolved.provenance.wall_clock = Some(layer.surface);
+        }
+        if resolved.grants.egress.is_none()
+            && let Some(egress) = layer.grants.egress.as_ref()
+        {
+            resolved.grants.egress = Some(egress.clone());
+            resolved.provenance.egress = Some(layer.surface);
+        }
+    }
+    resolved
+}
+
+/// Read a `--grants-file`.
+///
+/// The document deserializes into [`Grants`] directly, which carries
+/// `deny_unknown_fields`: a misspelled key is a refusal, never a silently
+/// dropped cap. A cap the user believes is in force and is not is strictly
+/// worse than no cap at all, because it is believed.
+pub fn load_grants_file(path: &Path) -> Result<Grants> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("reading grants file {}", path.display()))?;
+    serde_json::from_str(&text).with_context(|| format!("parsing grants file {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::num::NonZeroU32;
+    use mvm_contract::grants::{CpuGrant, EgressGrant, WallClockGrant};
+    use mvm_contract::policy::network_policy::HostPort;
+
+    fn cpu(millicores: u32) -> Grants {
+        Grants {
+            cpu: Some(CpuGrant::Share { millicores }),
+            ..Default::default()
+        }
+    }
+
+    fn egress(host: &str, port: u16) -> Grants {
+        Grants {
+            egress: Some(EgressGrant {
+                allow: vec![HostPort::new(host, port)],
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn nothing_authored_resolves_to_no_plan_grants() {
+        let resolved = resolve_grants(&[]);
+        assert!(resolved.is_empty());
+        assert_eq!(resolved.into_plan_grants(), None);
+    }
+
+    #[test]
+    fn the_highest_surface_wins_a_contested_dimension() {
+        let resolved = resolve_grants(&[
+            GrantLayer::new(GrantSurface::Cli, cpu(500)),
+            GrantLayer::new(GrantSurface::Manifest, cpu(4000)),
+        ]);
+        assert_eq!(
+            resolved.grants().cpu,
+            Some(CpuGrant::Share { millicores: 500 })
+        );
+        assert_eq!(resolved.provenance().cpu, Some(GrantSurface::Cli));
+    }
+
+    #[test]
+    fn a_cli_cpu_grant_does_not_discard_a_manifest_egress_grant() {
+        // The defect this resolver exists to prevent: whole-object precedence
+        // would drop the allow-list the manifest declared.
+        let resolved = resolve_grants(&[
+            GrantLayer::new(GrantSurface::Cli, cpu(500)),
+            GrantLayer::new(GrantSurface::Manifest, egress("api.example.com", 443)),
+        ]);
+        assert_eq!(
+            resolved.grants().cpu,
+            Some(CpuGrant::Share { millicores: 500 })
+        );
+        assert_eq!(
+            resolved
+                .grants()
+                .egress
+                .as_ref()
+                .map(|e| e.allow.as_slice()),
+            Some(&[HostPort::new("api.example.com", 443)][..])
+        );
+        assert_eq!(resolved.provenance().egress, Some(GrantSurface::Manifest));
+    }
+
+    #[test]
+    fn a_higher_surface_may_loosen_a_lower_one() {
+        // The manifest is a project default; the command line belongs to the
+        // developer running it. Only the ceiling bounds the outcome.
+        let resolved = resolve_grants(&[
+            GrantLayer::new(GrantSurface::Cli, cpu(8000)),
+            GrantLayer::new(GrantSurface::Manifest, cpu(500)),
+        ]);
+        assert_eq!(
+            resolved.grants().cpu,
+            Some(CpuGrant::Share { millicores: 8000 })
+        );
+    }
+
+    #[test]
+    fn host_config_supplies_only_what_nothing_above_it_set() {
+        let wall = Grants {
+            wall_clock: Some(WallClockGrant::Secs {
+                secs: NonZeroU32::new(60).expect("nonzero"),
+            }),
+            ..Default::default()
+        };
+        let resolved = resolve_grants(&[
+            GrantLayer::new(GrantSurface::Cli, cpu(500)),
+            GrantLayer::new(GrantSurface::HostConfig, wall),
+        ]);
+        assert_eq!(resolved.provenance().cpu, Some(GrantSurface::Cli));
+        assert_eq!(
+            resolved.provenance().wall_clock,
+            Some(GrantSurface::HostConfig)
+        );
+        assert_eq!(
+            resolved.provenance().authored(),
+            vec![
+                ("cpu", GrantSurface::Cli),
+                ("wall_clock", GrantSurface::HostConfig)
+            ]
+        );
+    }
+
+    #[test]
+    fn an_unknown_grants_file_field_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("grants.json");
+        std::fs::write(&path, r#"{"cpu_limt":{"unit":"share","millicores":1500}}"#).expect("write");
+        let err = load_grants_file(&path).expect_err("a misspelled key must be refused");
+        assert!(
+            format!("{err:#}").contains("unknown field"),
+            "expected an unknown-field refusal, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_well_formed_grants_file_round_trips() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("grants.json");
+        std::fs::write(
+            &path,
+            r#"{"cpu":{"unit":"share","millicores":1500},
+                "egress":{"allow":[{"host":"api.example.com","port":443}]}}"#,
+        )
+        .expect("write");
+        let grants = load_grants_file(&path).expect("parses");
+        assert_eq!(grants.cpu, Some(CpuGrant::Share { millicores: 1500 }));
+        assert_eq!(
+            grants.egress.as_ref().map(|e| e.allow.as_slice()),
+            Some(&[HostPort::new("api.example.com", 443)][..])
+        );
+    }
+
+    #[test]
+    fn a_missing_grants_file_names_the_path() {
+        let err = load_grants_file(Path::new("/nonexistent/grants.json"))
+            .expect_err("a missing file must not resolve to no grants");
+        assert!(format!("{err:#}").contains("/nonexistent/grants.json"));
+    }
+}

--- a/crates/mvm-core/src/grants_resolve.rs
+++ b/crates/mvm-core/src/grants_resolve.rs
@@ -72,17 +72,21 @@ pub struct GrantProvenance {
 }
 
 impl GrantProvenance {
-    /// Dimension/surface pairs that were actually authored, in a stable order.
+    /// The surface that authored the dimension a ceiling violation names.
+    ///
+    /// Takes the violation's own dotted path (`cpu.share_millicores`,
+    /// `wall_clock.secs`) rather than a bare dimension name, so a caller can
+    /// hand the refusal straight through without translating it. A path naming
+    /// something no surface authors — `memory_mib`, which is sized rather than
+    /// granted — yields `None`.
     #[must_use]
-    pub fn authored(&self) -> Vec<(&'static str, GrantSurface)> {
-        [
-            ("cpu", self.cpu),
-            ("wall_clock", self.wall_clock),
-            ("egress", self.egress),
-        ]
-        .into_iter()
-        .filter_map(|(name, surface)| surface.map(|s| (name, s)))
-        .collect()
+    pub fn surface_for_dimension(&self, dimension: &str) -> Option<GrantSurface> {
+        match dimension.split('.').next()? {
+            "cpu" => self.cpu,
+            "wall_clock" => self.wall_clock,
+            "egress" => self.egress,
+            _ => None,
+        }
     }
 }
 
@@ -266,13 +270,29 @@ mod tests {
             resolved.provenance().wall_clock,
             Some(GrantSurface::HostConfig)
         );
+        assert_eq!(resolved.provenance().egress, None);
+    }
+
+    #[test]
+    fn a_ceiling_violations_dimension_resolves_to_its_authoring_surface() {
+        // The violation's dotted path is what a refusal has in hand, so that is
+        // what the lookup has to accept.
+        let provenance = GrantProvenance {
+            cpu: Some(GrantSurface::Manifest),
+            wall_clock: Some(GrantSurface::Cli),
+            egress: None,
+        };
         assert_eq!(
-            resolved.provenance().authored(),
-            vec![
-                ("cpu", GrantSurface::Cli),
-                ("wall_clock", GrantSurface::HostConfig)
-            ]
+            provenance.surface_for_dimension("cpu.share_millicores"),
+            Some(GrantSurface::Manifest)
         );
+        assert_eq!(
+            provenance.surface_for_dimension("wall_clock.secs"),
+            Some(GrantSurface::Cli)
+        );
+        // Memory is sized, not granted, so no surface authored it.
+        assert_eq!(provenance.surface_for_dimension("memory_mib"), None);
+        assert_eq!(provenance.surface_for_dimension("egress"), None);
     }
 
     #[test]

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -42,6 +42,9 @@ pub mod egress_handler;
 /// guest.
 pub mod egress_substitution;
 pub mod exit_capture;
+/// Per-dimension resolution of a workload's grants across the CLI, a JSON
+/// grants file, the project manifest, and the operator's host config.
+pub mod grants_resolve;
 /// Shared guest loopback-egress helpers (proxy env-var injection for cooperative apps).
 pub mod guest_netd;
 /// Pure health-state reducer: fold probe results into a health state and

--- a/crates/mvm-core/src/user_config.rs
+++ b/crates/mvm-core/src/user_config.rs
@@ -52,6 +52,19 @@ pub struct MvmConfig {
     /// value here refuses an explicitly unbounded grant rather than clamping
     /// it, so a caller learns the host forbids what it asked for.
     pub max_wall_clock_secs: Option<u32>,
+    /// Default CPU share, in thousandths of one host core, for a workload no
+    /// higher surface capped. `None` = uncapped.
+    ///
+    /// A default is not a ceiling. The three `max_*` keys above bound what a
+    /// grant may *ask for* and no surface can exceed them; this one only fills
+    /// in a dimension nobody else named, and any surface above host config
+    /// overrides it freely.
+    pub default_cpu_millicores: Option<u32>,
+    /// Default wall-clock bound, in seconds, for a workload no higher surface
+    /// bounded. `None` = unbounded. A configured `0` is ignored rather than
+    /// read as "no time allowed": zero is not expressible as a wall-clock
+    /// grant, and the legacy encoding it resembles means unbounded.
+    pub default_wall_clock_secs: Option<u32>,
 }
 
 impl MvmConfig {
@@ -66,6 +79,28 @@ impl MvmConfig {
             max_cpu_millicores: self.max_cpu_millicores,
             max_memory_mib: self.max_memory_mib,
             max_wall_clock_secs: self.max_wall_clock_secs,
+        }
+    }
+
+    /// The host's default grant: the dimensions this operator wants applied to
+    /// a workload that named none itself.
+    ///
+    /// Egress is deliberately absent and has no config key. A host-wide
+    /// allow-list would open outbound access for every workload that never
+    /// asked for any, which inverts default-deny — the one posture that has to
+    /// hold without anyone opting into it. Egress is authored per workload or
+    /// not at all.
+    #[must_use]
+    pub fn default_grants(&self) -> mvm_contract::grants::Grants {
+        mvm_contract::grants::Grants {
+            cpu: self
+                .default_cpu_millicores
+                .map(|millicores| mvm_contract::grants::CpuGrant::Share { millicores }),
+            wall_clock: self
+                .default_wall_clock_secs
+                .and_then(std::num::NonZeroU32::new)
+                .map(|secs| mvm_contract::grants::WallClockGrant::Secs { secs }),
+            egress: None,
         }
     }
 
@@ -101,6 +136,10 @@ impl Default for MvmConfig {
             max_cpu_millicores: None,
             max_memory_mib: None,
             max_wall_clock_secs: None,
+            // Also unset: a default invented here would cap every local run
+            // with a number nobody chose.
+            default_cpu_millicores: None,
+            default_wall_clock_secs: None,
         }
     }
 }

--- a/crates/mvm-hostd/src/health_probe.rs
+++ b/crates/mvm-hostd/src/health_probe.rs
@@ -526,6 +526,7 @@ mod tests {
             created_at: None,
             last_started_at: None,
             health_check,
+            grants: None,
         }
     }
 

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -392,14 +392,21 @@ fn enforceability_gate(grants: &Grants, plan: &ExecutionPlan, posture: RunPostur
     // A run that granted CPU or wall clock is the only one with anything to
     // enforce here; asking otherwise would warn on every unbounded boot.
     //
-    // `grants.egress` is deliberately outside both this gate and the ceiling.
-    // Egress is not bounded by a numeric ceiling and is not a per-backend
-    // mechanism question: it is enforced at the one substitution endpoint every
-    // workload's traffic already goes through, and the projection that would
-    // turn an egress grant into that endpoint's policy is not wired yet. Until
-    // it is, an egress grant is inert — which is closed, because the policy the
-    // endpoint installs without it is deny-all. Do not read this early return
-    // as egress having been checked.
+    // `grants.egress` is deliberately outside both this gate and the ceiling,
+    // and is enforced elsewhere rather than left unenforced. It is not bounded
+    // by a numeric ceiling, and "can this tier deliver it" is not a per-backend
+    // question for egress: every workload's traffic already leaves through the
+    // one per-VM substitution endpoint, so a granted allow-list is projected
+    // onto the policy that endpoint installs, and its gate is what admits or
+    // drops each flow.
+    //
+    // What this early return does not do is check that the projection happened.
+    // It cannot: the policy the endpoint installs rides on the launch config,
+    // not in the plan body this function reads, so keeping the two derived from
+    // one authored value is the obligation of the seam that builds both. What
+    // holds here unconditionally is the floor — an absent egress grant and an
+    // empty allow-list both project to deny-all, so a workload that granted
+    // nothing reaches nothing.
     if grants.cpu.is_none() && grants.wall_clock.is_none() {
         return Ok(());
     }

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -10,10 +10,13 @@
 //! window, and non-replayed — the same gate `mvmctl up`/`run` go through.
 //!
 //! The richer knobs the CLI threads (secrets, bundle pins, deps volumes,
-//! per-destination redaction, custom egress policy) are deliberately absent:
-//! the facade `MachineSpec` does not carry them, so exposing them here would
-//! invent a surface no caller can fill. When a driver needs them it uses the
-//! CLI admission path directly.
+//! per-destination redaction) are deliberately absent: the facade
+//! `MachineSpec` does not carry them, so exposing them here would invent a
+//! surface no caller can fill. When a driver needs them it uses the CLI
+//! admission path directly. Egress is the exception, and only because the
+//! facade grew a way to say it: an egress *grant* is carried, and the launch
+//! config's policy is derived from it, so the plan the boot was signed under
+//! and the policy the gate reads come from one authored value.
 
 use std::path::{Path, PathBuf};
 
@@ -65,6 +68,13 @@ pub struct LocalRunRequest {
     /// workload, `false` for a persistent machine that outlives the
     /// admitting call.
     pub destroy_on_exit: bool,
+    /// What this workload is permitted to consume or reach. Baked into the
+    /// signed plan and checked against the host's ceiling during admission; the
+    /// egress dimension additionally becomes the launch config's network
+    /// policy, so what the gate enforces is what the plan was signed for.
+    /// `None` keeps the pre-grant baseline: no CPU cap, no wall-clock bound,
+    /// deny-all egress.
+    pub grants: Option<mvm_contract::grants::Grants>,
 }
 
 /// Admission substrate for a local run: the clock and replay ledger that drive
@@ -168,7 +178,7 @@ pub fn admit_and_boot_local(
         .transpose()?;
 
     let synthesis = SynthesisInput {
-        grants: None,
+        grants: req.grants.clone(),
         stream_edges: Vec::new(),
         kernel_sha256: kernel_sha.as_deref(),
         network_mode: Default::default(),
@@ -226,7 +236,15 @@ pub fn admit_and_boot_local(
                 launch_kind: mvm_core::vm_backend::RuntimeSourceLaunchKind::WorkloadImage,
             },
         ),
-        // network_policy defaults to deny-all via VmStartConfig's Default.
+        // With no egress grant the deny-all default from `VmStartConfig` stands;
+        // a granted allow-list is projected onto it, so the policy the gate
+        // enforces is derived from the same grants the plan was signed for.
+        network_policy: match req.grants.as_ref() {
+            Some(grants) if grants.egress.is_some() => {
+                mvm_contract::grants::projection::network_policy_from_grants(grants)
+            }
+            _ => mvm_core::network_policy::NetworkPolicy::deny_all(),
+        },
         ..Default::default()
     };
     attach_runtime_overlay_from_cache(&mut config, &req.backend_name)?;
@@ -285,6 +303,7 @@ mod tests {
             backend_name: "mock".into(),
             volumes: Vec::new(),
             destroy_on_exit: false,
+            grants: None,
         };
 
         let started = admit_and_boot_local(
@@ -386,6 +405,7 @@ mod tests {
                 encrypted: false,
             }],
             destroy_on_exit: true,
+            grants: None,
         };
         let started = admit_and_boot_local(
             &backend,
@@ -450,6 +470,7 @@ mod tests {
                 encrypted: false,
             }],
             destroy_on_exit: true,
+            grants: None,
         };
         let err = admit_and_boot_local(
             &backend,
@@ -533,6 +554,7 @@ mod tests {
             backend_name: "mock".into(),
             volumes: Vec::new(),
             destroy_on_exit: false,
+            grants: None,
         };
         let err = admit_and_boot_local(
             &backend,

--- a/crates/mvm-runtime/src/machine/persist.rs
+++ b/crates/mvm-runtime/src/machine/persist.rs
@@ -72,6 +72,12 @@ pub struct MachineSpec {
     /// Recorded for inspection now; consumed by active probing later.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health_check: Option<mvm_contract::ir::HealthCheck>,
+    /// The permission set resolved when this machine was created, baked into
+    /// the signed plan on every start. `None` means nothing was granted, which
+    /// is also what every machine created before grants existed carries —
+    /// hence `#[serde(default)]`, without which those specs stop loading.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grants: Option<mvm_contract::grants::Grants>,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -178,6 +184,7 @@ pub fn machine_config_matches(a: &MachineSpec, b: &MachineSpec) -> bool {
         && a.volumes == b.volumes
         && a.init == b.init
         && a.agent_verb == b.agent_verb
+        && a.grants == b.grants
 }
 
 /// Human summary of which boot-affecting fields differ, for the loud
@@ -217,6 +224,12 @@ pub fn machine_config_diff(current: &MachineSpec, desired: &MachineSpec) -> Stri
     }
     if current.agent_verb != desired.agent_verb {
         changed.push("agent-verb");
+    }
+    // A changed permission set is a changed launch: the running VM was
+    // admitted under the old one, so reusing it would leave the machine
+    // running under bounds nobody asked for any more.
+    if current.grants != desired.grants {
+        changed.push("grants");
     }
     changed.join(", ")
 }
@@ -364,7 +377,46 @@ mod tests {
             created_at: None,
             last_started_at: None,
             health_check: None,
+            grants: None,
         }
+    }
+
+    #[test]
+    fn a_persisted_machine_spec_without_grants_still_loads() {
+        // Machines created before grants existed are on disk right now. The
+        // struct is `deny_unknown_fields`, so the *absence* of the new key has
+        // to be accepted explicitly or every one of them stops starting.
+        let legacy = serde_json::json!({
+            "schema_version": MACHINE_SPEC_SCHEMA_VERSION,
+            "name": "web",
+            "image": "alpine:latest",
+            "net": false,
+            "allow_host": [],
+            "cpus": 2,
+            "memory": "512M",
+            "profile": "standard",
+        })
+        .to_string();
+        let spec: MachineSpec =
+            serde_json::from_str(&legacy).expect("a pre-grants spec still loads");
+        assert_eq!(spec.grants, None);
+        // And a spec that granted nothing must not start emitting the key, so
+        // rewriting an old spec does not gratuitously change its bytes.
+        assert!(!serde_json::to_string(&spec).unwrap().contains("grants"));
+    }
+
+    #[test]
+    fn a_changed_grant_is_a_changed_launch_config() {
+        // The running VM was admitted under the old permission set; reusing it
+        // would leave it running under bounds nobody asked for any more.
+        let current = spec_fixture("web");
+        let mut desired = current.clone();
+        desired.grants = Some(mvm_contract::grants::Grants {
+            cpu: Some(mvm_contract::grants::CpuGrant::Share { millicores: 1500 }),
+            ..Default::default()
+        });
+        assert!(!machine_config_matches(&current, &desired));
+        assert!(machine_config_diff(&current, &desired).contains("grants"));
     }
 
     #[test]
@@ -540,6 +592,7 @@ mod tests {
             created_at: None,
             last_started_at: None,
             health_check: None,
+            grants: None,
         }
     }
 

--- a/crates/mvm-sdk/src/facade.rs
+++ b/crates/mvm-sdk/src/facade.rs
@@ -35,6 +35,130 @@ fn machine_err(e: MachineError) -> MvmError {
 // `machine.rs` builders, which the cross-language conformance harness pins to
 // `tests/machine-fixtures/*.argv`. The facade delegates to them rather than
 // hand-rolling a second copy, so it can never drift from the CLI contract.
+//
+// The workload's permission set is the one thing those builders do not model:
+// they describe the cross-language `machine` verb surface, and a `Grants` is
+// not part of it. [`grant_argv`] appends it, emitting only flags the CLI
+// already parses — so the exception is where that argv is assembled, never
+// what it says.
+
+/// A permission set encoded for the command line, plus anything that has to
+/// outlive the subprocess.
+///
+/// The temp file is held rather than returned as a path because `--grants-file`
+/// is read by the child: dropping the handle before the spawn would hand the
+/// CLI a path that no longer exists.
+struct GrantArgv {
+    args: Vec<String>,
+    /// Present only when a dimension had no faithful flag.
+    grants_file: Option<tempfile::NamedTempFile>,
+}
+
+/// Encode `grants` as `mvmctl` flags.
+///
+/// Three dimensions have a flag that means exactly them, and those are emitted
+/// directly: a CPU share as `--cpu-limit <millicores>`, a bounded wall clock as
+/// `--timeout <secs>`, and each granted destination as `--allow-host
+/// <host>:<port>`, which is the spelling the CLI's own `--allow-host` parser
+/// turns back into an egress grant.
+///
+/// Three cannot be said in flags at all, and each is written verbatim to a
+/// `--grants-file` instead of being flattened into something close:
+///
+/// - A **fuel** budget is an instruction count; `--cpu-limit` is millicores.
+///   There is no conversion between them, so there is nothing to emit.
+/// - An **`Unbounded`** wall clock is not the same as omitting `--timeout`.
+///   Omitting it leaves the dimension unspecified, which a host with a
+///   `max_wall_clock_secs` ceiling admits; an explicit `Unbounded` is refused
+///   by that same ceiling. Emitting nothing would turn a refusal into a boot.
+/// - An **empty** allow-list is an explicit "no destinations", which zero
+///   `--allow-host` flags would record as "no egress grant". Both deny all
+///   traffic, so nothing opens either way, but only one of them is what the
+///   caller declared, and the signed plan should say which.
+///
+/// An egress host containing a colon takes the same route: `--allow-host`
+/// splits on the last one, so such a value would be parsed back as a different
+/// host and port than it went in as.
+fn grant_argv(grants: Option<&mvm_contract::grants::Grants>) -> Result<GrantArgv> {
+    use mvm_contract::grants::{CpuGrant, WallClockGrant};
+
+    let Some(grants) = grants else {
+        return Ok(GrantArgv {
+            args: Vec::new(),
+            grants_file: None,
+        });
+    };
+
+    let mut args = Vec::new();
+    let mut needs_file = false;
+
+    match grants.cpu {
+        None => {}
+        Some(CpuGrant::Share { millicores }) => {
+            args.push("--cpu-limit".to_string());
+            args.push(millicores.to_string());
+        }
+        Some(CpuGrant::Fuel { .. }) => needs_file = true,
+    }
+
+    match grants.wall_clock {
+        None => {}
+        Some(WallClockGrant::Secs { secs }) => {
+            args.push("--timeout".to_string());
+            args.push(secs.get().to_string());
+        }
+        Some(WallClockGrant::Unbounded) => needs_file = true,
+    }
+
+    if let Some(egress) = grants.egress.as_ref() {
+        if egress.allow.is_empty() || egress.allow.iter().any(|hp| hp.host.contains(':')) {
+            needs_file = true;
+        } else {
+            for hp in &egress.allow {
+                args.push("--allow-host".to_string());
+                args.push(format!("{}:{}", hp.host, hp.port));
+            }
+        }
+    }
+
+    if !needs_file {
+        return Ok(GrantArgv {
+            args,
+            grants_file: None,
+        });
+    }
+
+    // One encoding or the other, never a mix: the file already carries every
+    // dimension, and adding flags beside it would be two statements of one
+    // decision that a precedence rule then has to reconcile.
+    let file = write_grants_file(grants)?;
+    Ok(GrantArgv {
+        args: vec![
+            "--grants-file".to_string(),
+            file.path().to_string_lossy().into_owned(),
+        ],
+        grants_file: Some(file),
+    })
+}
+
+/// Serialize `grants` to a temp file in the exact shape `--grants-file` parses.
+fn write_grants_file(grants: &mvm_contract::grants::Grants) -> Result<tempfile::NamedTempFile> {
+    let backend_err = |reason: String| MvmError::Backend { reason };
+    let json = serde_json::to_vec(grants)
+        .map_err(|e| backend_err(format!("serializing grants for --grants-file: {e}")))?;
+    let mut file = tempfile::Builder::new()
+        .prefix("mvm-grants-")
+        .suffix(".json")
+        .tempfile()
+        .map_err(|e| backend_err(format!("creating a temp file for --grants-file: {e}")))?;
+    {
+        use std::io::Write as _;
+        file.write_all(&json)
+            .and_then(|()| file.flush())
+            .map_err(|e| backend_err(format!("writing --grants-file: {e}")))?;
+    }
+    Ok(file)
+}
 
 fn list_args() -> Result<Vec<String>> {
     MachineLs::builder()
@@ -73,7 +197,7 @@ fn exec_args(id: &MachineId, command: Vec<String>) -> Result<Vec<String>> {
 /// afterward listable/stoppable) and prints the vm_id envelope. This is a
 /// facade-internal invocation — not one of the cross-language `machine` verbs the
 /// conformance harness pins — so it is built here rather than via a shared builder.
-fn run_args(spec: &MachineSpec) -> Result<Vec<String>> {
+fn run_args(spec: &MachineSpec) -> Result<GrantArgv> {
     if spec.name.is_empty() {
         return Err(MvmError::InvalidSpec {
             reason: "name must not be empty".into(),
@@ -99,13 +223,18 @@ fn run_args(spec: &MachineSpec) -> Result<Vec<String>> {
         args.push("--env".to_string());
         args.push(format!("{k}={v}"));
     }
+    let mut grants = grant_argv(spec.grants.as_ref())?;
+    args.append(&mut grants.args);
     args.push("--up-json".to_string());
-    Ok(args)
+    Ok(GrantArgv {
+        args,
+        grants_file: grants.grants_file,
+    })
 }
 
 /// Build the argv for `machine create --name … --image …` — persists the spec
 /// without booting. Uses the shared builder so it can't drift from the CLI.
-fn create_args(spec: &MachineSpec) -> Result<Vec<String>> {
+fn create_args(spec: &MachineSpec) -> Result<GrantArgv> {
     if spec.name.is_empty() {
         return Err(MvmError::InvalidSpec {
             reason: "name must not be empty".into(),
@@ -116,12 +245,18 @@ fn create_args(spec: &MachineSpec) -> Result<Vec<String>> {
             reason: "image must not be empty".into(),
         });
     }
-    MachineCreate::builder(&spec.name)
+    let mut args = MachineCreate::builder(&spec.name)
         .image(&spec.image)
         .cpus(spec.cpus as u16)
         .memory(format!("{}M", spec.memory_mib))
         .machine_args()
-        .map_err(machine_err)
+        .map_err(machine_err)?;
+    let mut grants = grant_argv(spec.grants.as_ref())?;
+    args.append(&mut grants.args);
+    Ok(GrantArgv {
+        args,
+        grants_file: grants.grants_file,
+    })
 }
 
 fn start_args(id: &MachineId) -> Result<Vec<String>> {
@@ -310,7 +445,11 @@ impl MvmClient for SubprocessBackend {
     async fn create_machine(&self, spec: MachineSpec) -> Result<MachineState> {
         // `machine create` persists the spec without booting → stopped.
         let name = spec.name.clone();
-        self.run_cli(&create_args(&spec)?)?;
+        // `invocation` is held across the call: when the grants needed a
+        // `--grants-file`, dropping it first would delete the file the child
+        // is about to read.
+        let invocation = create_args(&spec)?;
+        self.run_cli(&invocation.args)?;
         Ok(MachineState {
             id: MachineId(name.clone()),
             name,
@@ -323,7 +462,10 @@ impl MvmClient for SubprocessBackend {
         // `machine run` does the full OCI pull + rootfs materialize + signed-plan
         // admission (claim 8) + boot; `--up-json` boots it detached and prints the
         // vm_id envelope. Shelling it keeps the CLI as the one admitted-boot path.
-        let stdout = self.run_cli(&run_args(&spec)?)?;
+        // Held across the call for the same reason as `create_machine`: a
+        // `--grants-file` path must still exist when the child opens it.
+        let invocation = run_args(&spec)?;
+        let stdout = self.run_cli(&invocation.args)?;
         let id = parse_up_json(&stdout)?;
         Ok(MachineState {
             name: id.0.clone(),
@@ -475,9 +617,10 @@ mod tests {
             cpus: 2,
             memory_mib: 512,
             env: vec![("MODE".into(), "test".into())],
+            grants: None,
         };
         assert_eq!(
-            run_args(&spec).unwrap(),
+            run_args(&spec).unwrap().args,
             vec![
                 "run",
                 "--image",
@@ -505,9 +648,10 @@ mod tests {
             cpus: 2,
             memory_mib: 512,
             env: vec![],
+            grants: None,
         };
         assert_eq!(
-            create_args(&spec).unwrap(),
+            create_args(&spec).unwrap().args,
             vec![
                 "create",
                 "--name",
@@ -538,6 +682,7 @@ mod tests {
             cpus: 1,
             memory_mib: 64,
             env: vec![],
+            grants: None,
         };
         assert!(create_args(&bad).is_err());
     }
@@ -550,6 +695,7 @@ mod tests {
             cpus: 1,
             memory_mib: 64,
             env: vec![],
+            grants: None,
         };
         assert!(matches!(
             run_args(&MachineSpec {
@@ -565,6 +711,215 @@ mod tests {
             }),
             Err(MvmError::InvalidSpec { .. })
         ));
+    }
+
+    // ── Grants on the argv ────────────────────────────────────────────
+    //
+    // This is the impl every language SDK goes through, so a grant dropped
+    // here is a grant no Python or TypeScript caller can express at all.
+
+    #[test]
+    fn a_cpu_and_egress_grant_reach_the_run_argv() {
+        let spec = MachineSpec::builder("web", "alpine:latest")
+            .cpus(2)
+            .memory_mib(512)
+            .cpu_millicores(1500)
+            .wall_clock_secs(std::num::NonZeroU32::new(600).unwrap())
+            .allow_egress("api.example.com", 443)
+            .allow_egress("db.internal", 5432)
+            .build();
+        let invocation = run_args(&spec).unwrap();
+        assert_eq!(
+            invocation.args,
+            vec![
+                "run",
+                "--image",
+                "alpine:latest",
+                "--name",
+                "web",
+                "--cpus",
+                "2",
+                "--memory",
+                "512M",
+                "--cpu-limit",
+                "1500",
+                "--timeout",
+                "600",
+                "--allow-host",
+                "api.example.com:443",
+                "--allow-host",
+                "db.internal:5432",
+                "--up-json",
+            ]
+        );
+        assert!(
+            invocation.grants_file.is_none(),
+            "every dimension had a flag; no file should have been written"
+        );
+    }
+
+    #[test]
+    fn a_cpu_and_egress_grant_reach_the_create_argv() {
+        let spec = MachineSpec::builder("web", "alpine:3.20")
+            .cpus(2)
+            .memory_mib(512)
+            .cpu_millicores(1500)
+            .allow_egress("api.example.com", 443)
+            .build();
+        assert_eq!(
+            create_args(&spec).unwrap().args,
+            vec![
+                "create",
+                "--name",
+                "web",
+                "--image",
+                "alpine:3.20",
+                "--cpus",
+                "2",
+                "--memory",
+                "512M",
+                "--cpu-limit",
+                "1500",
+                "--allow-host",
+                "api.example.com:443",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_spec_that_grants_nothing_emits_the_argv_it_always_did() {
+        // The pre-grant baseline: no flags appear for a spec with no grants,
+        // so the conformance-pinned argv is unchanged.
+        let spec = MachineSpec::builder("web", "alpine:3.20")
+            .cpus(2)
+            .memory_mib(512)
+            .build();
+        assert!(
+            !create_args(&spec)
+                .unwrap()
+                .args
+                .iter()
+                .any(|a| a.starts_with("--cpu-limit")
+                    || a.starts_with("--allow-host")
+                    || a.starts_with("--grants-file"))
+        );
+    }
+
+    #[test]
+    fn the_emitted_flags_parse_back_to_the_grant_that_produced_them() {
+        // The encoding contract. What the SDK emits and what the CLI parses are
+        // two halves of one agreement, and a mismatch between them is a
+        // silently dropped grant wearing a different hat. Asserted against the
+        // CLI's own spellings: `--cpu-limit` is millicores, `--timeout` is
+        // seconds, and `--allow-host HOST:PORT` is the egress grant.
+        let spec = MachineSpec::builder("web", "alpine:latest")
+            .cpu_millicores(1500)
+            .wall_clock_secs(std::num::NonZeroU32::new(600).unwrap())
+            .allow_egress("api.example.com", 443)
+            .build();
+        let args = run_args(&spec).unwrap().args;
+
+        let flag_value = |flag: &str| -> Option<String> {
+            args.iter()
+                .position(|a| a == flag)
+                .and_then(|i| args.get(i + 1))
+                .cloned()
+        };
+        assert_eq!(flag_value("--cpu-limit").as_deref(), Some("1500"));
+        assert_eq!(flag_value("--timeout").as_deref(), Some("600"));
+
+        // Every `--allow-host` value must be the `HOST:PORT` form the CLI
+        // parser splits on its last colon, and must round-trip.
+        let hosts: Vec<&String> = args
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| i > &0 && args[i - 1] == "--allow-host")
+            .map(|(_, a)| a)
+            .collect();
+        assert_eq!(hosts.len(), 1);
+        let (host, port) = hosts[0].rsplit_once(':').expect("HOST:PORT");
+        assert_eq!(host, "api.example.com");
+        assert_eq!(port.parse::<u16>().unwrap(), 443);
+    }
+
+    #[test]
+    fn a_grant_no_flag_can_say_goes_to_a_grants_file_verbatim() {
+        // Fuel is an instruction count and `--cpu-limit` is millicores; there
+        // is no conversion, so flattening one into the other would be a
+        // different grant. The file carries it unchanged.
+        let spec = MachineSpec::builder("web", "alpine:latest")
+            .cpu_fuel(100_000)
+            .allow_egress("api.example.com", 443)
+            .build();
+        let invocation = run_args(&spec).unwrap();
+        let file = invocation
+            .grants_file
+            .as_ref()
+            .expect("an inexpressible dimension must produce a file");
+
+        // One encoding, not a mix: no per-dimension flags beside the file.
+        assert!(!invocation.args.iter().any(|a| a == "--cpu-limit"));
+        assert!(!invocation.args.iter().any(|a| a == "--allow-host"));
+        let idx = invocation
+            .args
+            .iter()
+            .position(|a| a == "--grants-file")
+            .expect("--grants-file emitted");
+        assert_eq!(
+            &invocation.args[idx + 1],
+            &file.path().display().to_string()
+        );
+
+        // And what it holds is exactly the grant, parseable by the same
+        // `deny_unknown_fields` type the CLI reads.
+        let written: mvm_contract::grants::Grants =
+            serde_json::from_slice(&std::fs::read(file.path()).unwrap()).unwrap();
+        assert_eq!(written, spec.grants.unwrap());
+    }
+
+    #[test]
+    fn an_unbounded_wall_clock_is_never_encoded_as_an_absent_timeout() {
+        // Omitting `--timeout` means "unspecified", which a host with a
+        // wall-clock ceiling admits; an explicit `Unbounded` is refused by that
+        // same ceiling. Dropping it would turn a refusal into a boot.
+        let spec = MachineSpec::builder("web", "alpine:latest")
+            .grants(mvm_contract::grants::Grants {
+                wall_clock: Some(mvm_contract::grants::WallClockGrant::Unbounded),
+                ..Default::default()
+            })
+            .build();
+        let invocation = run_args(&spec).unwrap();
+        assert!(invocation.grants_file.is_some());
+        assert!(invocation.args.iter().any(|a| a == "--grants-file"));
+    }
+
+    #[test]
+    fn an_explicitly_empty_allow_list_is_not_encoded_as_no_grant_at_all() {
+        // Both deny every destination, so nothing opens either way — but only
+        // one of them is what the caller declared, and the plan records which.
+        let spec = MachineSpec::builder("web", "alpine:latest")
+            .grants(mvm_contract::grants::Grants {
+                egress: Some(mvm_contract::grants::EgressGrant { allow: vec![] }),
+                ..Default::default()
+            })
+            .build();
+        let invocation = run_args(&spec).unwrap();
+        assert!(
+            invocation.grants_file.is_some(),
+            "an empty allow-list must survive as an empty allow-list"
+        );
+    }
+
+    #[test]
+    fn a_host_carrying_a_colon_is_not_emitted_as_an_allow_host_flag() {
+        // `--allow-host` splits on the last colon, so this would come back as a
+        // different host and port than it went in as.
+        let spec = MachineSpec::builder("web", "alpine:latest")
+            .allow_egress("::1", 443)
+            .build();
+        let invocation = run_args(&spec).unwrap();
+        assert!(invocation.grants_file.is_some());
+        assert!(!invocation.args.iter().any(|a| a == "--allow-host"));
     }
 
     #[test]
@@ -607,6 +962,7 @@ mod tests {
                 cpus: 1,
                 memory_mib: 128,
                 env: vec![],
+                grants: None,
             })
             .await
             .expect("run boots");

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -588,6 +588,15 @@ table, and the `~/.mvm/config/config.toml` defaults. Per dimension means a
 `--cpu-limit` on the command line does not discard an egress allowlist the
 manifest declared; each of CPU, wall clock, and egress is settled on its own.
 
+`machine create` is the verb that reads the `[grants]` table — from `--manifest
+<path>`, or from the `mvm.toml` / `Mvmfile.toml` in the current directory when
+`--image` is omitted. Transient `machine run` reads no project manifest at all
+(its own `--manifest` names a pre-built image, not an `mvm.toml`), so grants
+there come from `--cpu-limit`, `--timeout`, `--allow-host`, `--grants-file`, and
+the host config. That split is deliberate: discovering an `mvm.toml` from the
+working directory would let a manifest in an unrelated checkout cap a run that
+never meant to use it.
+
 ```toml
 # mvm.toml
 image = "alpine:3.20"

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -54,7 +54,9 @@ guest-RPC surface, fleet-shaped workflows).
 | `mvmctl machine run -d` | Boot a **persistent** machine detached and return immediately |
 | `mvmctl machine run --healthcheck '<cmd>'` | Declare the workload a long-running service: presence alone promotes the run to the **persistent** lifecycle (registered, shows in `machine ls`, torn down via `machine stop <name>`). Runs in the foreground unless combined with `-d`. `<cmd>` is exec'd in the guest by the resident host-agent daemon as its liveness check (exit 0 = healthy), actively probed on `--health-interval`; an unhealthy or crashed service is restarted with bounded exponential backoff. A run whose entrypoint exits still tears down on that exit code — a healthcheck on a run-to-completion task is a no-op |
 | `mvmctl machine run --health-interval <secs> --health-timeout <secs> --health-retries <n> --health-start-period <secs>` | Tune the healthcheck cadence: seconds between checks (default `30`), per-check timeout (default `5`), consecutive failures before unhealthy (default `3`), and grace period after start before checks count (default `0`). Recorded on the machine spec and actively enforced by the host-agent daemon's probe loop |
-| `mvmctl machine run --cpus N --memory SIZE` | vCPU count and memory (supports 512M, 4G, etc.) |
+| `mvmctl machine run --cpus N --memory SIZE` | vCPU count the guest sees, and memory (supports 512M, 4G, etc.) |
+| `mvmctl machine run --cpu-limit MILLICORES` | Cap the workload's share of **host CPU time**, in thousandths of a core (`1500` = 1.5 cores). A different control from `--cpus`, which sets how many vCPUs the guest sees — a workload can hold four vCPUs and be bounded to half a core. Recorded on the signed execution plan and refused when it exceeds the host's `max_cpu_millicores` ceiling |
+| `mvmctl machine run --grants-file PATH` | Read the workload's grants (CPU, wall clock, egress) from a JSON document. Unknown keys are refused, so a typo is an error rather than a silently dropped cap |
 | `mvmctl machine run -e KEY=VALUE` | Inject an environment variable (repeatable; gated by `--profile`) |
 | `mvmctl machine run --volume host:/guest[:mode]` | Share a host directory (mode defaults to `ro`; `rw` needs `--profile dev`/`permissive`) |
 | `mvmctl machine run --profile <p>` | Security posture: `restrictive`, `standard` (default), `dev`, `permissive` |
@@ -577,7 +579,39 @@ requires an argv after `--`; use `machine shell <name>` (or `machine exec
 both. When `--image` is omitted, it searches the current directory for
 `mvm.toml` / `Mvmfile.toml`; `--manifest <path>` selects a file explicitly. The
 persisted spec carries the manifest's image, CPU/memory sizing, `mem_initial`,
-network defaults, allow-hosts, and volumes. Relative manifest volume host paths
+network defaults, allow-hosts, volumes, and its `[grants]` table.
+
+A workload's grants — what it may consume and where it may reach — can be
+declared in four places, resolved **per dimension** from highest precedence to
+lowest: CLI flags, a `--grants-file` JSON document, the manifest's `[grants]`
+table, and the `~/.mvm/config/config.toml` defaults. Per dimension means a
+`--cpu-limit` on the command line does not discard an egress allowlist the
+manifest declared; each of CPU, wall clock, and egress is settled on its own.
+
+```toml
+# mvm.toml
+image = "alpine:3.20"
+
+[grants]
+cpu_millicores = 1500      # or cpu_fuel = <instructions>; the two are units, not precisions
+wall_clock_secs = 600      # must be > 0; omit to leave the workload unbounded
+allow_hosts = ["api.example.com:443"]
+```
+
+`[grants].allow_hosts` and `[network].allow_hosts` are two spellings of one
+decision, so declaring both is a parse error. The granted form is the one the
+egress gate enforces: the run's network policy is *derived* from it, never
+supplied alongside it, so the policy in force and the policy the plan was signed
+over cannot drift apart. An absent egress grant and an empty allowlist both mean
+deny-all.
+
+Every grant is bounded by the host operator's ceiling
+(`max_cpu_millicores`, `max_memory_mib`, `max_wall_clock_secs` in
+`~/.mvm/config/config.toml`), which no surface above can reach and which is
+checked before the plan is signed. Separately, `default_cpu_millicores` and
+`default_wall_clock_secs` supply defaults for dimensions nothing else named.
+There is no host-wide egress default: one would open outbound access for every
+workload that never asked for any. Relative manifest volume host paths
 are resolved relative to the manifest file; volume validation keeps the shared
 default of read-only mounts unless `:rw` is explicit. `--name` is optional: when
 omitted, `machine create` auto-generates a name and prints it (mirroring

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1124,6 +1124,13 @@ for detailed scope and acceptance criteria.
         call) + `StoreLimits`
   - [ ] WS5b — grants across snapshot/fork/restore; child ⊆ parent, closing
         the restore-laundering path
-  - [ ] WS6 — four surfaces: manifest, JSON, CLI, library + SDK parity fixture
+  - [~] WS6 — four surfaces: manifest `[grants]`, `--grants-file` JSON,
+        `--cpu-limit` CLI flag (`--timeout` supplies the wall-clock dimension),
+        and `grants` on the `MachineSpec` DTO + `LaunchRequest` builder,
+        resolved per dimension by `mvm_core::grants_resolve` and wired into the
+        real `mvmctl` admission — `admission.rs` no longer hardcodes
+        `grants: None`. The projection now has production callers, so its
+        `dormant-controls.toml` entry is deleted. STILL OPEN: the SDK parity
+        fixture
   - [ ] WS6b — doctor/inspect tier reporting, persisted-spec migration, docs
         gate, BDD suite

--- a/specs/plans/308-workload-grants-implementation.md
+++ b/specs/plans/308-workload-grants-implementation.md
@@ -2738,3 +2738,59 @@ the ceiling, which no surface can reach.
 - `a_persisted_machine_spec_without_grants_still_loads` — `#[serde(default)]`;
   machines created before this exist on disk.
 - `--cpus` and `--cpu-limit` are independently settable and do not alias.
+
+**Landed.** All six witnesses exist, the dormant entry is deleted, and
+`check-dormant-controls` passes — with the entry temporarily restored the gate
+fails naming `crates/mvm-cli/src/commands/shared/grants.rs` and
+`crates/mvm-hostd/src/run.rs` as production callers, which is the ratchet
+confirming the projection is reachable rather than merely present.
+
+Where each surface plugs in:
+
+- **Resolver** — `crates/mvm-core/src/grants_resolve.rs`
+  (`GrantLayer`/`GrantSurface`/`resolve_grants`/`load_grants_file`), folded by
+  `crates/mvm-cli/src/commands/shared/grants.rs::resolve_run_grants`, which
+  settles the grants and derives the egress policy in one step so the two
+  cannot be computed in different orders at different call sites.
+- **CLI** — `--cpu-limit <MILLICORES>` and `--grants-file <PATH>` on `machine
+  run` (and on `machine create`, which also takes `--timeout`). The existing
+  `--timeout` supplies the wall-clock dimension rather than a second flag
+  meaning the same thing, and `--allow-host` becomes the CLI's egress grant
+  through the same parser the legacy path uses.
+- **JSON** — `--grants-file` deserializes `Grants` directly, which already
+  carries `deny_unknown_fields`.
+- **Manifest** — `[grants]` on `Manifest`, converted by
+  `ManifestGrants::to_grants` and surfaced as `ManifestMachineWorkflow.grants`.
+  Declaring an allowlist in both `[grants]` and `[network]` is a parse error
+  rather than a silent ranking.
+- **Library** — `grants` on the `MachineSpec` DTO plus
+  `cpu_millicores`/`cpu_fuel`/`wall_clock_secs`/`allow_egress`/`grants` on both
+  its builder and `LaunchRequestBuilder`. `LocalRunRequest.grants` carries them
+  into `admit_and_boot_local`'s `SynthesisInput`, and the egress dimension is
+  projected onto `VmStartConfig.network_policy` — the value
+  `RealEndpointSpawner` hands the substitution endpoint, i.e. the claim-10
+  gate.
+
+The end-to-end path a manifest grant takes: `mvm.toml [grants]` →
+`Manifest::validate` → `ManifestGrants::to_grants` → `machine_workflow().grants`
+→ `resolve_run_grants` (per dimension, under CLI and grants-file) →
+`MachineSpec.grants` on disk → `machine start` → `PersistentImageStartParams`
+→ `AdmitPlanForBootParams.grants` → `SynthesisInput.grants` → `admit_for_run`
+(ceiling + enforceability) → signed `ExecutionPlan.grants`. Egress splits off at
+the resolver: `enforced_network_policy` projects it, `machine start` hands the
+result to the launch, and the substitution endpoint enforces it.
+
+Two things worth recording that the task text did not anticipate:
+
+- **`AdmitPlanForBootParams.backend_kind`.** `admit_grants`' enforceability gate
+  refuses a declared CPU or wall-clock grant on a sealed run when it cannot name
+  the tier that would enforce it, and the CLI was admitting `without_backend`.
+  Without threading the typed kind, `--cpu-limit` under a sealed posture would
+  have been unusable by construction. The transient path takes it off the
+  `AnyBackend` it already selected; the persistent path goes through a new
+  `mvm_client::backend_kind_for`, because `check-cli-runtime-surface` (rightly)
+  refuses a direct `AnyBackend` reach from a drive-a-machine call site.
+- **`Grants` gained `Eq`.** The DTO and the persisted spec both derive it, and
+  every field was already `Eq`.
+
+Not done here: the SDK parity fixture (WS6) and everything in WS6b.

--- a/specs/plans/308-workload-grants-implementation.md
+++ b/specs/plans/308-workload-grants-implementation.md
@@ -2675,3 +2675,66 @@ unknown spawn shape.
 `EnforcedTier::{declared, enforced}`, `EnforcedGrants::all_declared`,
 `resolve_grants`/`GrantSources`, `grants_are_subset` are used consistently
 across every task that references them.
+
+---
+
+### Task 16: The surfaces — make a grant expressible, and therefore real
+
+**This task combines what the plan originally split into Tasks 13 and 14, on
+purpose.** Task 13 was a precedence resolver with nothing to resolve and no
+caller. This branch has already produced four controls that shipped correct,
+tested, and unreachable — a fifth is registered in `dormant-controls.toml`
+right now. Landing a pure resolver on its own would make six. The two halves
+ship together or not at all.
+
+**The acceptance criterion is end-to-end, not per-file.** A CPU share and an
+egress allowlist declared in `Mvmfile.toml` must reach the signed
+`ExecutionPlan`, be checked against the ceiling, and — for egress — be the
+thing `EgressGate` enforces. When that holds, `network_policy_from_grants`
+has a production caller, and **the `dormant-controls.toml` entry for it is
+deleted as part of this task.** That deletion is the done-signal; the gate
+fails if the entry lingers once a caller exists, which is the ratchet working.
+
+**Files:**
+- Create: `crates/mvm-core/src/grants_resolve.rs`
+- Modify: `crates/mvm-core/src/client/dto.rs` (`MachineSpec` + builder)
+- Modify: `crates/mvm-core/src/domain/manifest.rs` (`[grants]` table)
+- Modify: `crates/mvm-core/src/user_config.rs` (defaults)
+- Modify: `crates/mvm-cli/src/commands/machine/mod.rs` (flags)
+- Modify: `crates/mvm-cli/src/commands/vm/up/admission.rs:327` — **the connection**
+- Modify: `xtask/dormant-controls.toml` (delete the entry)
+
+**The four surfaces, highest precedence first:**
+
+1. **CLI** — `--cpu-limit <MILLICORES>`, `--timeout <SECS>`, `--grants-file <PATH>`.
+   `--cpu-limit` is host CPU share; `--cpus` remains the vCPU count the guest
+   sees. They are different controls and conflating them is the mistake every
+   container runtime made once, so the help text must distinguish them.
+2. **JSON** — `--grants-file`, parsed with `deny_unknown_fields` so a typo is a
+   refusal rather than a silently dropped cap.
+3. **Manifest** — a `[grants]` table on `ManifestMachineWorkflow`.
+4. **Library** — `grants` on the `MachineSpec` DTO and its builder, so
+   `MvmClient::run_machine` can express an egress allowlist. It cannot today:
+   the DTO has no network field at all, which is why every SDK reaches egress
+   only by shelling out to `mvmctl`.
+
+**Precedence is per dimension, not per object.** A CLI `--cpu-limit` must not
+discard the manifest's egress allowlist. Whole-object precedence would do that
+silently, which is the kind of bug that surfaces as "my allowlist stopped
+applying" months later.
+
+A higher surface may *loosen* a lower one — the manifest is a project default
+and the CLI belongs to the developer running it. What bounds the outcome is
+the ceiling, which no surface can reach.
+
+**Witnesses:**
+- `a_manifest_grant_reaches_the_signed_plan` — the end-to-end one; assert on
+  the admitted `ExecutionPlan`, not on an intermediate struct.
+- `cli_overrides_the_manifest_per_dimension_not_wholesale` — set CPU on the
+  CLI and egress in the manifest; both must survive.
+- `an_unknown_grants_file_field_is_refused`.
+- `a_manifest_egress_grant_is_what_the_gate_enforces` — the projection's first
+  real caller.
+- `a_persisted_machine_spec_without_grants_still_loads` — `#[serde(default)]`;
+  machines created before this exist on disk.
+- `--cpus` and `--cpu-limit` are independently settable and do not alias.

--- a/xtask/dormant-controls.toml
+++ b/xtask/dormant-controls.toml
@@ -51,17 +51,3 @@ Pumps one workload's output into another's stdin. Caller-driven by design, and \
 the caller is mvmd: mvm has no fleet and so nothing here declares an edge to \
 drive. Covered by its own integration tests against the real broker, reader \
 and gate."""
-
-[[control]]
-symbol = "network_policy_from_grants"
-file = "crates/mvm-contract/src/grants/projection.rs"
-dormant = true
-why = """
-Derives a workload's egress policy from its grants, and is the only function \
-permitted to — `check-single-grants-projection` fails the build on a second \
-one. Dormant because no surface authors a grant yet: the manifest, JSON, CLI \
-and library paths that would set `ExecutionPlan.grants` are not built, so \
-every plan carries `None` and the hardcoded deny-all still stands. Fails \
-closed either way — an absent grant and an empty allow-list both project to \
-deny-all. This entry is the surfaces work's done-signal: the first real \
-author gives it a caller, and the entry goes."""


### PR DESCRIPTION
## Summary

Makes a workload grant expressible — and therefore real. Plan 308 WS6.

**Stacked on #2316.** That PR built `Grants`, a ceiling, a fail-closed projection to `NetworkPolicy`, a per-backend enforcement seam and a working Linux CPU quota, all of it correct, tested, and impossible to request: no surface could set a grant, so every plan carried `None`. This adds the four surfaces that close that. **Retarget to `main` before #2316 merges** — a squash-merged base would strand these commits.

## The bar this had to clear

Per-file correctness was not the acceptance criterion. `crates/mvm-cli/src/commands/vm/up/admission.rs` hardcoded `grants: None` on the production `mvmctl up` path; if that line still read `None`, the task was not done however many tests passed. It now reads `p.grants.clone()`, fed by two real callers — `machine run` (transient) and `machine start` (persistent) — and a manifest-declared egress allowlist becomes what `EgressGate` actually enforces rather than the hardcoded deny-all winning.

**The `network_policy_from_grants` entry is deleted from `xtask/dormant-controls.toml`.** That gate is a ratchet: it fails if a control declared dormant gains a production caller. The deletion was verified by temporarily restoring the entry and watching the gate go red naming the new callers, then confirming both are production, non-test, non-defining.

## The four surfaces

- **CLI** — `--cpu-limit <MILLICORES>`, `--timeout <SECS>`, `--grants-file <PATH>`. `--cpu-limit` is host CPU share; `--cpus` remains the guest's vCPU count. They do not alias, in parsing or effect, and the help text distinguishes them.
- **JSON** — `--grants-file`, `deny_unknown_fields`, so `cpu_limt` is a refusal rather than a silently dropped cap.
- **Manifest** — a `[grants]` table, read by `machine create`.
- **Library** — `grants` on the `MachineSpec` DTO, plus the SDK subprocess facade every language SDK goes through.

Precedence resolves **per dimension**: a `--cpu-limit` on the CLI does not discard an egress allowlist from the manifest. Whole-object precedence would drop it silently, and that is covered by a test at the argv + `mvm.toml` level, not just at the resolver.

## Three defects worth naming, all found by review

**The library half silently dropped grants**, twice. `create_machine` built its request without them, and `start_persistent` rebuilt from `image`/`cpus`/`memory`/`profile` only — so a permission set survived first boot and vanished on the next start, fail-closed for egress (silently back to deny-all) and silent for CPU. The CLI half was correct throughout, which is what made the asymmetry easy to miss.

**`SubprocessBackend` dropped them entirely** — the impl every language SDK uses, so the Python and TypeScript surfaces could not express a grant at all. It now emits argv the CLI's own parser accepts, and a receiving-side test runs that exact argv through real clap and `resolve_run_grants` to assert it yields the grant that produced it. Three cases go to a `--grants-file` temp file rather than argv: a `Fuel` budget, an explicit `Unbounded` wall clock (a ceiling *refuses* `Unbounded` but *admits* an absent grant, so dropping it would turn a refusal into a boot), and an authored empty allow-list (which survives into the signed plan and suppresses the `--net` fallback).

**Two feature lanes each hid a compile break** that `cargo check --workspace --all-targets` does not reach: `-p mvm-client --features test-support` and `-p mvm-sdk --features client-facade`. Both are in CI's Lint suite. The second was red on `main` already for a since-fixed reason, so it is green outright now rather than merely un-broken.

## Scoping, stated honestly

Manifest grants reach the plan via `machine create` → persisted spec → `machine start`, **not** transient `machine run`, which reads no project manifest at all today. Adding cwd discovery there would let a stray `mvm.toml` silently cap unrelated runs. `cli-commands.md` now names the verb that reads the table.

## Validation

- `cargo nextest run --workspace` — 10,892 passed, 0 failed
- `-p mvm-sdk --features client-facade` — 368 passed; `-p mvm-client --features test-support` — 213 passed
- Doctests pass; nightly `fmt --check` clean; clippy `-D warnings` clean on touched crates
- xtask gates re-run, including `check-dormant-controls` after the entry's removal
