### PR TITLE
Test every CLI help entry point at 80 columns

### DIFF
--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -432,39 +432,61 @@ fn help_options_fit_within(world: &mut CliWorld, width: i64) {
 
 #[then(expr = "every mvmctl command and subcommand help fits within {int} columns")]
 fn every_command_help_fits_within(_world: &mut CliWorld, width: i64) {
+    for path in all_command_paths() {
+        let mut args = path.clone();
+        args.push("--help".to_string());
+        assert_help_invocation_fits(&args, width);
+    }
+}
+
+#[then(
+    expr = "every mvmctl command and subcommand alternative help entry point fits within {int} columns"
+)]
+fn every_alternative_help_entry_point_fits_within(_world: &mut CliWorld, width: i64) {
+    for path in all_command_paths() {
+        let mut short_help_args = path.clone();
+        short_help_args.push("-h".to_string());
+        assert_help_invocation_fits(&short_help_args, width);
+
+        let mut help_subcommand_args = vec!["help".to_string()];
+        help_subcommand_args.extend(path);
+        assert_help_invocation_fits(&help_subcommand_args, width);
+    }
+}
+
+fn all_command_paths() -> Vec<Vec<String>> {
     let command = mvm_cli::commands::cli_command();
     let mut command_paths = vec![Vec::new()];
     collect_command_paths(&command, &[], &mut command_paths);
+    command_paths
+}
 
-    for path in command_paths {
-        let command_name = if path.is_empty() {
-            "mvmctl".to_string()
-        } else {
-            format!("mvmctl {}", path.join(" "))
-        };
-        let mut args = path.clone();
-        args.push("--help".to_string());
-        let output = mvmctl_command()
-            .args(&args)
-            .output()
-            .unwrap_or_else(|e| panic!("failed to run `{command_name}`: {e}"));
+fn assert_help_invocation_fits(args: &[String], width: i64) {
+    let invocation = format!("mvmctl {}", args.join(" "));
+    let output = mvmctl_command()
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run `{invocation}`: {e}"));
+    assert!(
+        output.status.success(),
+        "`{invocation}` failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !help.trim().is_empty(),
+        "`{invocation}` exited successfully without printing help"
+    );
+    for (line_number, line) in help.lines().enumerate() {
+        let line_width = i64::try_from(line.chars().count()).expect("line width fits in i64");
         assert!(
-            output.status.success(),
-            "`{command_name}` failed:\n{}",
-            String::from_utf8_lossy(&output.stderr)
+            line_width <= width,
+            "`{invocation}` line {} exceeds {width} columns ({}):\n{}",
+            line_number + 1,
+            line_width,
+            help
         );
-
-        let help = String::from_utf8_lossy(&output.stdout);
-        for (line_number, line) in help.lines().enumerate() {
-            let line_width = i64::try_from(line.chars().count()).expect("line width fits in i64");
-            assert!(
-                line_width <= width,
-                "`{command_name}` line {} exceeds {width} columns ({}):\n{}",
-                line_number + 1,
-                line_width,
-                help
-            );
-        }
     }
 }
 

--- a/features/suites/s0_cli/verbs.feature
+++ b/features/suites/s0_cli/verbs.feature
@@ -34,3 +34,6 @@ Feature: mvmctl top-level CLI surface
 
   Scenario: every CLI command and subcommand help fits within 80 columns
     Then every mvmctl command and subcommand help fits within 80 columns
+
+  Scenario: every alternative CLI help entry point fits within 80 columns
+    Then every mvmctl command and subcommand alternative help entry point fits within 80 columns

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -6,6 +6,10 @@ This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
+- [x] **CLI help width invariant.** Every visible and hidden command is capped
+      at 80 columns for `--help`, `-h`, and `mvmctl help <path>`; generated-tree
+      BDD coverage executes the real binary and automatically includes future
+      subcommands.
 - [x] **Issue #2128 — kernel pin freshness.** The libkrunfw bundle and custom
       guest kernel now share the verified Linux 6.12.102 LTS source pin;
       structural parity coverage prevents the consumers from drifting apart.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1505,6 +1505,10 @@ Then unify + retire the old paths:
 
 **WS7 — simple CLI**
 
+- [x] Enforce an 80-column maximum across every visible and hidden command's
+      `--help`, `-h`, and `mvmctl help <path>` output. The BDD suite discovers
+      paths from the generated Clap tree and executes the real binary, so new
+      subcommands are covered automatically.
 - [ ] Redesign to a small, discoverable verb set; `env` shown in `--help`.
 - [ ] Merge `setup`/`bootstrap` into one first-run `bootstrap`. Add the lifecycle verbs: **`upgrade`** (self-update `mvmctl`); **`uninstall`** (remove everything — the binary, `~/.mvm`, and installed host/guest artifacts); **`env cleanup`** (reclaim `~/.mvm` — caches + transient VM/build state, keeping config + keys); **`env reset`** (wipe `~/.mvm` back to a clean slate). These replace the fragmented `cache prune` / `pack prune` / `storage gc`. `env` becomes a visible top-level subcommand (today `hide = true`).
 - [ ] Replace the 31-arm dispatch `match` with a `Command` trait (`fn run(&self, ctx: &Cli) -> Result<()>`); one module per command; every command calls `mvm-client`.


### PR DESCRIPTION
## Summary

- discover every visible and hidden command path from the generated Clap tree
- execute the real `mvmctl` binary for `--help`, `-h`, and `mvmctl help <path>`
- require successful, non-empty help output and fail with the exact invocation and offending line when any line exceeds 80 characters
- record the completed CLI help-width invariant in the sprint and refactor rollup

## Why

The existing BDD scenario covered only the canonical `<path> --help` form. Alternate help entry points could regress independently, leaving users with output wider than 80 characters even though the generated command tree itself was constrained recursively.

## User impact

Every current and future command or subcommand, including hidden commands, is now exercised through all supported help entry points. A width regression blocks CI with a precise failure.

## Validation

- exhaustive canonical `--help` BDD scenario passes
- exhaustive alternative `-h` and `mvmctl help <path>` BDD scenario passes
- `cargo fmt --all` passes
- `cargo clippy --workspace --all-targets -- -D warnings` passes in the pre-commit gate
- workspace tests reached one unrelated current-directory race; that exact test passed when rerun in isolation
