### PR TITLE
Fix hostd test environment isolation

### DIFF
--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -2107,6 +2107,7 @@ mod tests {
 
     #[test]
     fn propagates_synthesis_failures() {
+        let (_env, _home) = host_with_ceiling(Default::default());
         let dir = tempfile::tempdir().unwrap();
         let err = admit_for_run(
             &fixture_input(""), // empty vm_name fails synthesis

--- a/crates/mvm-hostd/src/supervisor/ebpf_telemetry/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/ebpf_telemetry/mod.rs
@@ -186,13 +186,9 @@ mod tests {
 
     #[test]
     fn attach_reads_observability_target_from_mode_json() {
-        let _lock = mvm_runtime::base::runtime_meta::HOME_TEST_LOCK
-            .lock()
-            .unwrap();
         let tmp = tempfile::tempdir().unwrap();
-        // SAFETY: test-scoped mutation of MVM_HOME, serialized by
-        // HOME_TEST_LOCK so no other test observes this value.
-        unsafe { std::env::set_var("MVM_HOME", tmp.path()) };
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", tmp.path());
 
         let vm_name = "ebpf-attach-test";
         let target = mvm_runtime::base::observability_target::VmObservabilityTarget {

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -57,6 +57,10 @@
       in-repo builder image. A focused regression test forbids the stale
       `sudo`, `darwin.linux-builder`, and `/etc/nix` instructions.
 
+- [x] The hostd eBPF observability-target test now uses the shared environment
+      guard for `MVM_HOME`, preventing parallel tests from observing a temporary
+      home and restoring the original value when the test completes.
+
 - [ ] Launch critical-path waste on real-sized images — **issues #2273–#2276,
       plan 311**. Plan 299's prepared-cold baseline runs `alpine`, whose cached
       rootfs is 9.9 MB, and reports the ≤200 ms p50 contract as met. Three

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -59,7 +59,10 @@
 
 - [x] The hostd eBPF observability-target test now uses the shared environment
       guard for `MVM_HOME`, preventing parallel tests from observing a temporary
-      home and restoring the original value when the test completes.
+      home and restoring the original value when the test completes. Admission
+      tests that read the host's configured grant ceiling now also hold that
+      guard and use an explicit isolated host configuration, so bounded-host
+      fixtures cannot leak their ceiling into parallel admission tests.
 
 - [ ] Launch critical-path waste on real-sized images — **issues #2273–#2276,
       plan 311**. Plan 299's prepared-cold baseline runs `alpine`, whose cached


### PR DESCRIPTION
## Summary

- serialize the eBPF telemetry test's `MVM_HOME` override through the shared `TestEnv` guard
- keep the remaining admission failure-path test isolated from concurrent host-ceiling fixtures
- record the completed test-isolation work in the sprint status

## Root cause

The eBPF telemetry test mutated the process-wide `MVM_HOME` value while admission tests ran in parallel. An admission test could therefore observe another test's temporary bounded-host configuration and fail with a spurious host-ceiling error.

The branch was rebased onto current `main`; workload-kernel recovery changes that landed independently were dropped from this PR during the rebase.

## Impact

Hostd tests no longer leak temporary host configuration across parallel test cases, eliminating the flaky eBPF CI failure without weakening admission checks.

## Validation

- `cargo test -p mvm-hostd --features ebpf-telemetry --lib plan_admission::tests:: -- --test-threads=8` — 53 passed
- `cargo test -p mvm-hostd --features ebpf-telemetry --lib supervisor::ebpf_telemetry::tests:: -- --test-threads=8` — 2 passed
- `cargo clippy -p mvm-hostd --features ebpf-telemetry --lib --tests -- -D warnings`
- pre-commit `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
