### PR TITLE
Resolve a bootable launch config without starting a VM, so the warm pool can be filled

### DIFF
--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -32,7 +32,6 @@ use mvm_runtime::workload_runner::{ChildGrantIssuer, ClaimContext, PreloadContex
 use sha2::{Digest, Sha256};
 
 use super::Cli;
-use super::env::builder_vm::ensure_default_microvm_image;
 use super::vm::checkpoint::SignedChainAnchor;
 use super::vm::host_signer;
 use mvm_core::plan::{PlanSeccompTier, SecretReleasePolicy, SynthesisInput};
@@ -380,7 +379,7 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
     let checkpoints = CheckpointStore::open();
     let spawn_ctx = SpawnContext {
         checkpoints: &checkpoints,
-        launch: p.launch,
+        launch: Some(p.launch),
     };
     let mut spawned = 0u32;
     let mut failed = 0u32;
@@ -2017,7 +2016,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
             memory,
         } => {
             let memory_mib = match memory.as_deref() {
-                Some(raw) => crate::commands::parse_human_size(raw).context("Invalid --memory")?,
+                Some(raw) => mvm_core::util::parse_human_size(raw).context("Invalid --memory")?,
                 None => cfg.default_memory_mib,
             };
             run_warm(

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -153,24 +153,20 @@ pub fn build_standby_spec(p: &StandbySpecParams<'_>) -> Result<StandbySpec> {
 /// Parameters for [`warm_to_target`] — grouped to keep the signature small.
 pub struct WarmParams<'a> {
     pub backend: &'a AnyBackend,
-    /// Registered template identity for the warm-parent set, if applicable.
-    pub template_id: Option<&'a str>,
-    pub kernel: &'a Path,
-    pub vcpus: u8,
-    pub mem_mib: u32,
     pub signer_id: &'a str,
     pub signing_key_path: &'a Path,
     pub target: u32,
-    /// The launch this warm set is being spawned for, already carrying
-    /// everything the run path resolved for it — the sealed rootfs, its verity
-    /// sidecar, and the runtime overlay that holds the guest agent. A warm
-    /// parent boots the same shape, so an explicit `pool warm` always threads
-    /// the just-completed launch through here, and both the compat key's image
-    /// identity and the parent's own boot inputs come from this one value
-    /// rather than from two fields that could disagree. `pool warm` has no
-    /// launch to mirror and passes `None`; the spawn then refuses rather than
-    /// inventing a boot shape of its own.
-    pub launch: Option<&'a VmStartConfig>,
+    /// The resolved launch config the warm parents mirror, carrying everything
+    /// the run path resolves for a boot — the rootfs and its verity sidecar, the
+    /// runtime overlay that holds the guest agent, the universal initramfs, and
+    /// the cmdline-bearing policy fields.
+    ///
+    /// Every other input to the parent's shape is derived from this one value:
+    /// template, kernel, vCPUs, memory, image digest and egress enablement all
+    /// come out of [`compat_for_launch`]. They used to be separate fields, which
+    /// let a caller record a compat key describing something other than what
+    /// booted — a pool that fills and never drains, with no error anywhere.
+    pub launch: &'a VmStartConfig,
 }
 
 /// Summary returned by [`warm_to_target`].
@@ -373,22 +369,11 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
     // are built by `compat_for_launch` from the same launch config. Building it
     // twice from two field sets is how the pool came to fill with parents no
     // claim could ever match.
-    let image = p.launch.map(|c| Path::new(c.rootfs_path.as_str()));
-    let want = match p.launch {
-        Some(cfg) => compat_for_launch(p.backend.as_vm_backend(), cfg)?,
-        // `pool warm` has no launch to mirror, so the target shape stands in and
-        // the standby is image-less. The spawn then refuses it — a parent with
-        // no rootfs cannot boot the shape a workload does — but the eviction
-        // sweep below still runs.
-        None => StandbyCompat {
-            template_id: p.template_id.map(str::to_string),
-            kernel_sha256: kernel_identity(p.backend.as_vm_backend(), p.kernel.to_str())?,
-            vcpus: p.vcpus,
-            mem_mib: p.mem_mib,
-            image_sha256: None,
-            vsock_egress: false,
-        },
-    };
+    let image = Path::new(p.launch.rootfs_path.as_str());
+    let kernel = Path::new(p.launch.kernel_path.as_deref().ok_or_else(|| {
+        anyhow::anyhow!("the launch config names no kernel for its warm parents to boot")
+    })?);
+    let want = compat_for_launch(p.backend.as_vm_backend(), p.launch)?;
     let have = pool.idle_count_compatible(&want)? as u32;
     let pool_root = mvm_core::config::mvm_pool_dir()?;
     let vms_root = mvm_core::config::vms_dir();
@@ -406,13 +391,13 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
             pool_root: &pool_root,
             template_id: want.template_id.as_deref(),
             vms_root: &vms_root,
-            kernel: p.kernel,
+            kernel,
             kernel_sha256: &want.kernel_sha256,
             vcpus: want.vcpus,
             mem_mib: want.mem_mib,
             signer_id: p.signer_id,
             signing_key_path: p.signing_key_path,
-            image_path: image,
+            image_path: Some(image),
             image_sha256: want.image_sha256.as_deref(),
             vsock_egress: want.vsock_egress,
         })?;
@@ -423,7 +408,8 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
                 // buys a refusal, a quarantine and another spawn next launch.
                 let tenant = p
                     .launch
-                    .and_then(|c| c.tenant_id.as_deref())
+                    .tenant_id
+                    .as_deref()
                     .unwrap_or(STANDBY_PARENT_TENANT);
                 match audit_captured_parent(&checkpoints, &handle, p.backend.name(), tenant) {
                     Ok(()) => {
@@ -480,11 +466,11 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
     // also the intended number of parents, so its per-parent memory cap gives
     // the warm set a deterministic upper bound even when older records were
     // created with a different resource shape.
-    let max_memory_mib = u64::from(p.target).saturating_mul(u64::from(p.mem_mib));
-    let evicted = pool.evict_to_memory_budget(p.template_id, max_memory_mib)?;
+    let max_memory_mib = u64::from(p.target).saturating_mul(u64::from(want.mem_mib));
+    let evicted = pool.evict_to_memory_budget(want.template_id.as_deref(), max_memory_mib)?;
     if !evicted.is_empty() {
         tracing::debug!(
-            template_id = ?p.template_id,
+            template_id = ?want.template_id,
             count = evicted.len(),
             "evicted warm parents over memory budget"
         );
@@ -1594,14 +1580,10 @@ mod tests {
             &pool,
             &WarmParams {
                 backend: &backend,
-                template_id: cfg.template_id.as_deref(),
-                kernel: &kernel,
-                vcpus: 2,
-                mem_mib: 1024,
                 signer_id: "host:test",
                 signing_key_path: &key,
                 target: 1,
-                launch: Some(&cfg),
+                launch: &cfg,
             },
         )
         .unwrap();
@@ -1631,6 +1613,84 @@ mod tests {
         other.rootfs_path = other_rootfs.display().to_string();
         let other_want = compat_for_launch(backend.as_vm_backend(), &other).unwrap();
         assert_ne!(other_want, want);
+    }
+
+    /// `pool warm` and the run path must resolve the *same* compat key for the
+    /// same image and sizing, or the verb warms parents nothing claims — which
+    /// is the failure this whole path exists to fix, and it is silent:
+    /// `StandbyHandle::is_compatible` is exact equality, so a disagreement
+    /// cold-boots every launch while the pool fills.
+    ///
+    /// Both sides go through `crate::exec::resolve_launch`, so this asserts the
+    /// composition end to end rather than comparing two locally-built keys.
+    #[cfg(feature = "test-support")]
+    #[test]
+    fn pool_warm_and_the_run_path_resolve_the_same_compat_key() {
+        let _guard = mvm_runtime::vm::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(tmp.path());
+
+        let kernel = tmp.path().join("vmlinux");
+        std::fs::write(&kernel, b"kernel").unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"rootfs").unwrap();
+
+        let image = crate::exec::ImageSource::Prebuilt {
+            kernel_path: kernel.display().to_string(),
+            rootfs_path: rootfs.display().to_string(),
+            initrd_path: None,
+            label: "fixture".into(),
+            virtiofs_oci_root: None,
+        };
+        let policy = mvm_core::network_policy::NetworkPolicy::deny_all();
+        let shape = |name: Option<&'static str>| crate::exec::LaunchShape {
+            name,
+            image: &image,
+            cpus: 2,
+            memory_mib: 1024,
+            mem_initial_mib: None,
+            dir_shares: &[],
+            pty: false,
+            network_policy: &policy,
+            warm_pool_size: 1,
+            sdk_sidecar: None,
+            hypervisor: Some("mock"),
+        };
+        let resolve = |name| {
+            crate::exec::resolve_launch(
+                &shape(name),
+                None,
+                &mut crate::exec::LaunchResolveMarks::new(false),
+                &mut crate::commands::vm::phase_timing::LaunchSubMarks::new(false),
+            )
+            .unwrap()
+        };
+
+        // The warm side resolves ahead of any launch; the run side resolves for
+        // the launch itself. Only the VM name differs, and the compat key must
+        // not depend on it — a claimed parent runs under its own standby id.
+        let warmed = resolve(None);
+        let launched = resolve(Some("the-launch"));
+        assert_ne!(warmed.start_config.name, launched.start_config.name);
+
+        let backend = AnyBackend::Mock(mvm_runtime::mock::MockBackend::new().with_standby());
+        let warm_key = compat_for_launch(backend.as_vm_backend(), &warmed.start_config).unwrap();
+        let claim_key = compat_for_launch(backend.as_vm_backend(), &launched.start_config).unwrap();
+        assert_eq!(
+            warm_key, claim_key,
+            "a parent warmed for this image must be found by the launch that boots it"
+        );
+        assert!(
+            warm_key.image_sha256.is_some(),
+            "the warm key must name the rootfs, or it matches nothing"
+        );
+        assert!(
+            warm_eligible_launch(&warmed.start_config),
+            "the resolved warm shape must be one a shared parent can serve"
+        );
     }
 
     /// `claim_or_cold` must hand the runner a parent that is still claimable.
@@ -1672,14 +1732,10 @@ mod tests {
                 &pool,
                 &WarmParams {
                     backend: &backend,
-                    template_id: cfg.template_id.as_deref(),
-                    kernel: &kernel,
-                    vcpus: 2,
-                    mem_mib: 1024,
                     signer_id: "host:test",
                     signing_key_path: &key,
                     target: 1,
-                    launch: Some(&cfg),
+                    launch: &cfg,
                 },
             )
             .unwrap()
@@ -1716,8 +1772,13 @@ mod tests {
         let pool = SupervisorStandbyPool::at(tmp.path().join("pool"));
         let kernel = tmp.path().join("vmlinux");
         std::fs::write(&kernel, b"k").unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"r").unwrap();
         let key = tmp.path().join("host-signer.ed25519");
         std::fs::write(&key, b"fake-key").unwrap();
+        let mut cfg = eligible_cfg();
+        cfg.kernel_path = Some(kernel.display().to_string());
+        cfg.rootfs_path = rootfs.display().to_string();
 
         let backend = AnyBackend::Mock(
             mvm_runtime::mock::MockBackend::new()
@@ -1728,14 +1789,10 @@ mod tests {
             &pool,
             &WarmParams {
                 backend: &backend,
-                template_id: None,
-                kernel: &kernel,
-                vcpus: 2,
-                mem_mib: 1024,
                 signer_id: "host:test",
                 signing_key_path: &key,
                 target: 2,
-                launch: None,
+                launch: &cfg,
             },
         )
         .unwrap();
@@ -1755,27 +1812,33 @@ mod tests {
         let pool = SupervisorStandbyPool::at(tmp.path().join("pool"));
         let kernel = tmp.path().join("vmlinux");
         std::fs::write(&kernel, b"k").unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"r").unwrap();
         let key = tmp.path().join("key");
         std::fs::write(&key, b"fake-key").unwrap();
-
-        // Pre-fill the pool with 1 idle standby.
-        let mut h = idle_handle("s1", &kernel_sha256_hex(&kernel).unwrap());
-        h.kernel_sha256 = kernel_sha256_hex(&kernel).unwrap();
-        pool.record(&h).unwrap();
+        let mut cfg = eligible_cfg();
+        cfg.kernel_path = Some(kernel.display().to_string());
+        cfg.rootfs_path = rootfs.display().to_string();
 
         let backend = AnyBackend::Mock(mvm_runtime::mock::MockBackend::new().with_standby());
+        // Pre-fill the pool with 1 idle standby carrying the launch's own compat
+        // key, so the warm below sees the target already met.
+        let want = compat_for_launch(backend.as_vm_backend(), &cfg).unwrap();
+        let mut h = idle_handle("s1", &want.kernel_sha256);
+        h.vcpus = want.vcpus;
+        h.mem_mib = want.mem_mib;
+        h.image_sha256 = want.image_sha256.clone();
+        h.vsock_egress = want.vsock_egress;
+        pool.record(&h).unwrap();
+
         let result = warm_to_target(
             &pool,
             &WarmParams {
                 backend: &backend,
-                template_id: None,
-                kernel: &kernel,
-                vcpus: h.vcpus,
-                mem_mib: h.mem_mib,
                 signer_id: "host:test",
                 signing_key_path: &key,
                 target: 1,
-                launch: None,
+                launch: &cfg,
             },
         )
         .unwrap();
@@ -1821,14 +1884,10 @@ mod tests {
                 pool,
                 &WarmParams {
                     backend,
-                    template_id: None,
-                    kernel,
-                    vcpus: 2,
-                    mem_mib: 1024,
                     signer_id: "host:test",
                     signing_key_path: key,
                     target: 2,
-                    launch: Some(launch),
+                    launch,
                 },
             )
             .unwrap();
@@ -1862,21 +1921,29 @@ pub(in crate::commands) struct Args {
 
 #[derive(Subcommand, Debug, Clone)]
 pub(in crate::commands) enum PoolAction {
-    /// Sweep the standby pool toward a target count. Spawns nothing today: a
-    /// warm parent boots the shape of the launch it will serve, and this verb
-    /// warms ahead of any launch, so every spawn is refused for having no
-    /// launch to mirror and only the pool's eviction sweep runs. The pool is
-    /// populated by a run replenishing after itself, not by this verb.
-    /// Default count 1.
+    /// Sweep the standby pool toward a target count, warming parents that boot
+    /// the shape a matching launch will claim.
+    ///
+    /// The shape is resolved the same way a real launch resolves it — same
+    /// image, kernel, verity sidecars, runtime overlay and cmdline tokens — so a
+    /// later `mvmctl machine run` with the same image and sizing claims what
+    /// this spawned. A launch that differs in image, kernel, vCPUs, memory or
+    /// egress enablement is a different shape and cold-boots. Default count 1.
     Warm {
         /// How many idle standbys to warm the pool toward (default 1).
         count: Option<u32>,
-        /// Accepted but ignored: a rootfs path cannot describe a warm parent's
-        /// boot, which also needs the verity sidecar, the runtime overlay
-        /// carrying the guest agent, and the matching kernel cmdline tokens —
-        /// all of which come from a resolved launch config, not from a path.
+        /// OCI image the warmed parents boot, matching the `--image` the launch
+        /// will pass. Omit to warm the image a bare `machine run` boots.
         #[arg(long)]
-        rootfs: Option<String>,
+        image: Option<String>,
+        /// vCPUs the warmed parents boot with; must match the launch's `--cpus`
+        /// (default: the configured `default_cpus`).
+        #[arg(long)]
+        cpus: Option<u32>,
+        /// Memory the warmed parents boot with; must match the launch's
+        /// `--memory` (default: the configured `default_memory_mib`).
+        #[arg(long)]
+        memory: Option<String>,
     },
     /// Show the standby pool — recorded standbys and their idle/claimed state.
     Status {
@@ -1886,69 +1953,99 @@ pub(in crate::commands) enum PoolAction {
     },
 }
 
-/// The default launch shape the warm pool targets: default-microVM kernel + the config's
-/// default cpus/mem + the effective hypervisor. Both `pool warm` and the `up` auto-claim
-/// resolve through the same pieces so a warmed standby is claimable by a default `up`.
-struct WarmShape {
-    backend: AnyBackend,
-    kernel: std::path::PathBuf,
-    vcpus: u8,
-    mem_mib: u32,
+/// What `pool warm` warms toward, expressed as the launch it must mirror.
+struct WarmRequest {
+    image: Option<String>,
+    cpus: u32,
+    memory_mib: u32,
+    target: u32,
 }
 
-fn resolve_warm_shape(cfg: &MvmConfig, rootfs_override: Option<&str>) -> Result<WarmShape> {
-    let backend_name = super::shared::resolve_effective_hypervisor("firecracker");
-    let backend = AnyBackend::from_hypervisor(&backend_name);
-    let (default_kernel, default_rootfs) =
-        ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Prod)
-            .context("resolve default-microvm kernel for the warm pool")?;
-    let vcpus = u8::try_from(cfg.default_cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX);
-    // `pool warm` warms ahead of any launch, so it has no resolved launch
-    // config to mirror — and a warm parent's boot shape is the launch's, not a
-    // rootfs path on its own. `--rootfs` / `MVM_POOL_ROOTFS` remain accepted but
-    // are unused: naming a rootfs would not supply the verity sidecar, the
-    // runtime overlay, or the cmdline tokens a parent must boot with.
-    let _ = (rootfs_override, default_rootfs);
-    let kernel = std::path::PathBuf::from(default_kernel);
-    Ok(WarmShape {
-        backend,
-        kernel,
-        vcpus,
-        mem_mib: cfg.default_memory_mib,
-    })
+/// Resolve the launch shape a warm parent must boot, without booting one.
+///
+/// This is the whole point of the verb working at all: a claimable parent needs
+/// the rootfs *and* its verity sidecars, the runtime overlay carrying the guest
+/// agent, the universal initramfs, and the cmdline-bearing policy fields — none
+/// of which a rootfs path supplies, and all of which
+/// [`crate::exec::resolve_launch`] produces. Resolving through the run path's
+/// own function is what keeps the recorded compat key equal to the one a claim
+/// will search for.
+///
+/// No admission hook is passed. A factory parent carries no workload authority
+/// and `factory_parent_config` drops the tenant and plan from whatever it is
+/// handed, so admitting one here would buy a signed plan that is discarded —
+/// while giving a shared parent a workload's authority is exactly the posture
+/// the pool is built to avoid. The launch that later claims the parent supplies
+/// its own admitted plan.
+fn resolve_warm_launch(req: &WarmRequest) -> Result<crate::exec::ResolvedLaunch> {
+    let image = super::vm::exec::resolve_launch_image_source(req.image.as_deref(), false, None)
+        .context("resolving the image the warm parents boot")?;
+    // Deny-all is the default a `machine run` resolves to, and it is the half
+    // of the policy the compat key reads: `StandbyCompat::vsock_egress` records
+    // whether the guest boots an egress client, never a destination.
+    let network_policy = mvm_core::network_policy::NetworkPolicy::default();
+    let shape = crate::exec::LaunchShape {
+        name: None,
+        image: &image,
+        cpus: req.cpus,
+        memory_mib: req.memory_mib,
+        mem_initial_mib: None,
+        dir_shares: &[],
+        pty: false,
+        network_policy: &network_policy,
+        warm_pool_size: req.target,
+        sdk_sidecar: None,
+        hypervisor: None,
+    };
+    crate::exec::resolve_launch(
+        &shape,
+        None,
+        &mut crate::exec::LaunchResolveMarks::new(false),
+        &mut crate::commands::vm::phase_timing::LaunchSubMarks::new(false),
+    )
+    .context("resolving the launch shape the warm parents mirror")
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
     let pool = SupervisorStandbyPool::open()?;
     match args.action {
         PoolAction::Status { json } => run_status(&pool, json),
-        PoolAction::Warm { count, rootfs } => {
-            run_warm(&pool, cfg, count.unwrap_or(1), rootfs.as_deref())
+        PoolAction::Warm {
+            count,
+            image,
+            cpus,
+            memory,
+        } => {
+            let memory_mib = match memory.as_deref() {
+                Some(raw) => crate::commands::parse_human_size(raw).context("Invalid --memory")?,
+                None => cfg.default_memory_mib,
+            };
+            run_warm(
+                &pool,
+                &WarmRequest {
+                    image,
+                    cpus: cpus.unwrap_or(cfg.default_cpus),
+                    memory_mib,
+                    target: count.unwrap_or(1),
+                },
+            )
         }
     }
 }
 
-fn run_warm(
-    pool: &SupervisorStandbyPool,
-    cfg: &MvmConfig,
-    target: u32,
-    rootfs_override: Option<&str>,
-) -> Result<()> {
-    let shape = resolve_warm_shape(cfg, rootfs_override)?;
+fn run_warm(pool: &SupervisorStandbyPool, req: &WarmRequest) -> Result<()> {
+    let target = req.target;
+    let launch = resolve_warm_launch(req)?;
     // Ensure the host signer exists — the standby re-verifies the attach plan against it.
     let signer = host_signer::load_or_init()?;
     let result = warm_to_target(
         pool,
         &WarmParams {
-            backend: &shape.backend,
-            template_id: None,
-            kernel: &shape.kernel,
-            vcpus: shape.vcpus,
-            mem_mib: shape.mem_mib,
+            backend: &launch.backend,
             signer_id: &host_signer::host_signer_id(),
             signing_key_path: &signer.secret_path,
             target,
-            launch: None,
+            launch: &launch.start_config,
         },
     )?;
     // A state-changing verb emits one audit record per attempt.
@@ -1979,8 +2076,9 @@ fn run_warm(
         ));
     }
     crate::ui::info(
-        "Note: a warm `up` claim boots through the gateway-bridge supervisor path \
-         (MVM_GATEWAY_BRIDGE=1); the default `up` cold-boots.",
+        "A launch claims one of these only if it matches on image, kernel, vCPUs, memory and \
+         egress enablement, is auto-named, and runs with a non-zero warm pool size \
+         (MVM_RESIDENCY=warm on hosts whose default is parked).",
     );
     Ok(())
 }
@@ -2004,10 +2102,8 @@ struct PoolStatusEntry {
     vcpus: u8,
     mem_mib: u32,
     /// The image half of the compat key: sha256 of the rootfs the parent
-    /// booted, recorded for every standby spawned for a real launch. Absent
-    /// only for a standby recorded without one — which is every standby today,
-    /// since no backend advertises the pool and the launch-less `pool warm`
-    /// path records nothing.
+    /// booted. Every standby carries one, since a parent is only ever spawned
+    /// for a resolved launch shape; absent marks a record predating that.
     image_sha256: Option<String>,
 }
 

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -1875,7 +1875,6 @@ mod tests {
         fn warm_once(
             pool: &SupervisorStandbyPool,
             backend: &AnyBackend,
-            kernel: &std::path::Path,
             key: &std::path::Path,
             launch: &VmStartConfig,
         ) {
@@ -1893,8 +1892,8 @@ mod tests {
         }
 
         std::thread::scope(|s| {
-            let a = s.spawn(|| warm_once(&pool, &backend, &kernel, &key, &cfg));
-            let b = s.spawn(|| warm_once(&pool, &backend, &kernel, &key, &cfg));
+            let a = s.spawn(|| warm_once(&pool, &backend, &key, &cfg));
+            let b = s.spawn(|| warm_once(&pool, &backend, &key, &cfg));
             a.join().unwrap();
             b.join().unwrap();
         });

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -731,6 +731,138 @@ fn run_run_args(
     Ok(())
 }
 
+/// Resolve the [`crate::exec::ImageSource`] a launch boots from: the OCI image
+/// named by `--image`, or — when none was named — the same verified runtime pack
+/// or bundled default microVM a bare `machine run` falls back to.
+///
+/// Shared by the run path and by `pool warm`, because a warm parent must boot
+/// the same rootfs a claim will be matched against: the pool keys on that
+/// rootfs's digest, so resolving the image a second way is how the pool fills
+/// with parents nothing claims. `provenance` is `None` for the warm path — a
+/// factory parent is admitted under no workload plan, so there is no plan for
+/// the claim-14 provenance entry to bind to.
+pub(in crate::commands) fn resolve_launch_image_source(
+    image_ref: Option<&str>,
+    prod: bool,
+    provenance: Option<&OciProvenanceSink>,
+) -> Result<crate::exec::ImageSource> {
+    let Some(reference) = image_ref else {
+        return resolve_default_image_source(prod);
+    };
+    let oci_cache_root = super::super::image::oci_cache_root();
+    // A prod run refuses a mutable OCI tag before ANY work — the
+    // digest-pin policy refusal must be what the user sees, not an
+    // incidental missing-kernel error from the local resolution
+    // below. The pull path re-checks it, so this only reorders the
+    // refusal ahead of the workload-kernel resolution.
+    super::super::image::ensure_prod_digest_pin(reference, prod)?;
+    // Resolve the workload kernel BEFORE the pull. An `--image` run
+    // boots the materialized OCI rootfs (with its injected agent), so
+    // it needs only a workload kernel — a cached workload/default-image
+    // kernel, a local build (source checkout), or the published
+    // download — rather than building/downloading a whole default image
+    // whose rootfs we'd discard. Resolving it first makes a missing or
+    // cold-cache kernel fail fast with an actionable error instead of
+    // surfacing only after a full pull + rootfs materialization. The
+    // rootfs boots verity-sealed, so the kernel must carry dm-verity;
+    // the builder kernel (which drops it) is never a stand-in.
+    let kernel_path = ensure_workload_kernel()?;
+    // Enforce that invariant host-side: a kernel with no dm-verity
+    // support would panic the guest in early init opening
+    // /dev/mapper/control, with no host signal. Fail fast instead.
+    assert_workload_kernel_supports_verity(&kernel_path)?;
+    // A source-checkout run that needs the legacy rootfs guest runtime
+    // cross-compiles it inside materialization — a slow,
+    // output-silent host `cargo zigbuild`. Announce it so the run does
+    // not look wedged after the OCI pull logs.
+    if super::super::image::oci_guest_runtime_compile_pending(&oci_cache_root) {
+        ui::info(
+            "Compiling the mvm guest runtime from your source checkout \
+             (first build for these sources; cached afterward)…",
+        );
+    }
+    let cached = super::super::image::resolve_or_pull_run_image(&oci_cache_root, reference, prod)?;
+    ui::info(&format!(
+        "Using OCI image {} ({})",
+        cached.reference, cached.resolved_digest
+    ));
+    // Hand the provenance to the real admission rather than
+    // minting a plan here to hang it on. This used to synthesize a
+    // throwaway `ExecutionPlan` and emit `plan.admitted` for it,
+    // so one launch wrote two `plan.admitted` entries with
+    // different plan ids — and the first authorized nothing, since
+    // no VM ever booted under it. A reader of the chain could not
+    // tell which of the two was the admission that mattered.
+    if let Some(sink) = provenance {
+        *sink.borrow_mut() = Some(cached.provenance.audit_labels());
+    }
+    if cached.pulled {
+        let auth_source = cached.auth_source.as_deref().unwrap_or("unknown");
+        mvm_core::audit_emit!(
+            ImageFetch,
+            "source=run_image reference={} digest={} prod={} layers={} trust_policy={} verification_status={} auth_source={}",
+            cached.reference,
+            cached.resolved_digest,
+            prod,
+            cached.provenance.layer_digests.len(),
+            cached.provenance.trust_policy,
+            cached.provenance.verification_status,
+            auth_source
+        );
+    }
+    Ok(crate::exec::ImageSource::Prebuilt {
+        kernel_path,
+        rootfs_path: cached.rootfs_path.display().to_string(),
+        initrd_path: None,
+        label: format!("oci:{}", cached.resolved_digest),
+        // Offer the unpacked+injected tree as a virtiofs-root candidate;
+        // the run-path tier gate (backend cap × prod × sealed) decides.
+        virtiofs_oci_root: cached
+            .unpacked_root
+            .as_ref()
+            .map(|tree| crate::exec::VirtiofsOciRoot {
+                tree_dir: tree.display().to_string(),
+                prod,
+            }),
+    })
+}
+
+/// The image a launch boots when the caller named none: a verified runtime pack
+/// if one is cached for this host, else the bundled default microVM built in the
+/// builder VM.
+fn resolve_default_image_source(prod: bool) -> Result<crate::exec::ImageSource> {
+    if let Some(src) = super::runtime_pack::try_runtime_pack_image_source(prod) {
+        let label = match &src {
+            crate::exec::ImageSource::Prebuilt { label, .. } => label.clone(),
+            crate::exec::ImageSource::Template(name) => name.clone(),
+            crate::exec::ImageSource::PinnedTemplate {
+                slot_hash,
+                revision_hash,
+            } => format!("{slot_hash}@{revision_hash}"),
+        };
+        ui::info(&format!(
+            "Instant boot from verified runtime pack ({label}); skipping the build."
+        ));
+        return Ok(src);
+    }
+    let reason = super::runtime_pack::runtime_pack_diagnosis()
+        .ok()
+        .and_then(|d| super::runtime_pack::not_instant_reason(&d))
+        .unwrap_or_else(|| "no verified runtime pack is cached for this host".to_string());
+    ui::info(&format!(
+        "{reason}; building the bundled default microVM in the builder VM."
+    ));
+    let (kernel_path, rootfs_path) =
+        ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Dev)?;
+    Ok(crate::exec::ImageSource::Prebuilt {
+        kernel_path,
+        rootfs_path,
+        initrd_path: None,
+        label: "default-microvm".to_string(),
+        virtiofs_oci_root: None,
+    })
+}
+
 fn build_exec_request(
     args: Args,
     command_name: &str,
@@ -804,122 +936,9 @@ fn build_exec_request(
                 };
                 crate::exec::ImageSource::Template(resolved)
             }
-            (None, Some(reference)) => {
-                let oci_cache_root = super::super::image::oci_cache_root();
-                // A prod run refuses a mutable OCI tag before ANY work — the
-                // digest-pin policy refusal must be what the user sees, not an
-                // incidental missing-kernel error from the local resolution
-                // below. The pull path re-checks it, so this only reorders the
-                // refusal ahead of the workload-kernel resolution.
-                super::super::image::ensure_prod_digest_pin(&reference, prod)?;
-                // Resolve the workload kernel BEFORE the pull. An `--image` run
-                // boots the materialized OCI rootfs (with its injected agent), so
-                // it needs only a workload kernel — a cached workload/default-image
-                // kernel, a local build (source checkout), or the published
-                // download — rather than building/downloading a whole default image
-                // whose rootfs we'd discard. Resolving it first makes a missing or
-                // cold-cache kernel fail fast with an actionable error instead of
-                // surfacing only after a full pull + rootfs materialization. The
-                // rootfs boots verity-sealed, so the kernel must carry dm-verity;
-                // the builder kernel (which drops it) is never a stand-in.
-                let kernel_path = ensure_workload_kernel()?;
-                // Enforce that invariant host-side: a kernel with no dm-verity
-                // support would panic the guest in early init opening
-                // /dev/mapper/control, with no host signal. Fail fast instead.
-                assert_workload_kernel_supports_verity(&kernel_path)?;
-                // A source-checkout run that needs the legacy rootfs guest runtime
-                // cross-compiles it inside materialization — a slow,
-                // output-silent host `cargo zigbuild`. Announce it so the run does
-                // not look wedged after the OCI pull logs.
-                if super::super::image::oci_guest_runtime_compile_pending(&oci_cache_root) {
-                    ui::info(
-                        "Compiling the mvm guest runtime from your source checkout \
-                         (first build for these sources; cached afterward)…",
-                    );
-                }
-                let cached = super::super::image::resolve_or_pull_run_image(
-                    &oci_cache_root,
-                    &reference,
-                    prod,
-                )?;
-                ui::info(&format!(
-                    "Using OCI image {} ({})",
-                    cached.reference, cached.resolved_digest
-                ));
-                // Hand the provenance to the real admission rather than
-                // minting a plan here to hang it on. This used to synthesize a
-                // throwaway `ExecutionPlan` and emit `plan.admitted` for it,
-                // so one launch wrote two `plan.admitted` entries with
-                // different plan ids — and the first authorized nothing, since
-                // no VM ever booted under it. A reader of the chain could not
-                // tell which of the two was the admission that mattered.
-                *oci_provenance.borrow_mut() = Some(cached.provenance.audit_labels());
-                if cached.pulled {
-                    let auth_source = cached.auth_source.as_deref().unwrap_or("unknown");
-                    mvm_core::audit_emit!(
-                        ImageFetch,
-                        "source=run_image reference={} digest={} prod={} layers={} trust_policy={} verification_status={} auth_source={}",
-                        cached.reference,
-                        cached.resolved_digest,
-                        prod,
-                        cached.provenance.layer_digests.len(),
-                        cached.provenance.trust_policy,
-                        cached.provenance.verification_status,
-                        auth_source
-                    );
-                }
-                crate::exec::ImageSource::Prebuilt {
-                    kernel_path,
-                    rootfs_path: cached.rootfs_path.display().to_string(),
-                    initrd_path: None,
-                    label: format!("oci:{}", cached.resolved_digest),
-                    // Offer the unpacked+injected tree as a virtiofs-root candidate;
-                    // the run-path tier gate (backend cap × prod × sealed) decides.
-                    virtiofs_oci_root: cached.unpacked_root.as_ref().map(|tree| {
-                        crate::exec::VirtiofsOciRoot {
-                            tree_dir: tree.display().to_string(),
-                            prod,
-                        }
-                    }),
-                }
+            (None, image_ref) => {
+                resolve_launch_image_source(image_ref.as_deref(), prod, Some(oci_provenance))?
             }
-            (None, None) => match super::runtime_pack::try_runtime_pack_image_source(prod) {
-                Some(src) => {
-                    let label = match &src {
-                        crate::exec::ImageSource::Prebuilt { label, .. } => label.clone(),
-                        crate::exec::ImageSource::Template(name) => name.clone(),
-                        crate::exec::ImageSource::PinnedTemplate {
-                            slot_hash,
-                            revision_hash,
-                        } => format!("{slot_hash}@{revision_hash}"),
-                    };
-                    ui::info(&format!(
-                        "Instant boot from verified runtime pack ({label}); \
-                             skipping the build."
-                    ));
-                    src
-                }
-                None => {
-                    let reason = super::runtime_pack::runtime_pack_diagnosis()
-                        .ok()
-                        .and_then(|d| super::runtime_pack::not_instant_reason(&d))
-                        .unwrap_or_else(|| {
-                            "no verified runtime pack is cached for this host".to_string()
-                        });
-                    ui::info(&format!(
-                        "{reason}; building the bundled default microVM in the builder VM."
-                    ));
-                    let (kernel_path, rootfs_path) =
-                        ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Dev)?;
-                    crate::exec::ImageSource::Prebuilt {
-                        kernel_path,
-                        rootfs_path,
-                        initrd_path: None,
-                        label: "default-microvm".to_string(),
-                        virtiofs_oci_root: None,
-                    }
-                }
-            },
         }
     };
     let (_, sdk_sidecar) = super::host_services::resolve_bindings_and_sidecar(&args.host_service)?;

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -271,6 +271,30 @@ fn effective_transient_initrd(
     )
 }
 
+/// The part of a request that decides a launch's **boot shape** — every field
+/// [`resolve_launch`] reads, and nothing about what the guest will then run.
+///
+/// It exists so a caller that has no command can still resolve a bootable
+/// config: `pool warm` warms ahead of any launch and has no argv, no timeout
+/// and no stdin, but must mirror the boot a real launch performs down to the
+/// verity sidecar and the cmdline-bearing policy fields. Threading an
+/// [`ExecRequest`] with a fabricated empty command would have said the opposite
+/// of what is true.
+pub struct LaunchShape<'a> {
+    /// Explicit VM name, or `None` to generate a throwaway one.
+    pub name: Option<&'a str>,
+    pub image: &'a ImageSource,
+    pub cpus: u32,
+    pub memory_mib: u32,
+    pub mem_initial_mib: Option<u32>,
+    pub dir_shares: &'a [DirShareSpec],
+    pub pty: bool,
+    pub network_policy: &'a mvm_core::network_policy::NetworkPolicy,
+    pub warm_pool_size: u32,
+    pub sdk_sidecar: Option<&'a crate::commands::vm::up::SdkSidecarAttachment>,
+    pub hypervisor: Option<&'a str>,
+}
+
 /// All inputs to the orchestrator.
 #[derive(Debug, Clone)]
 pub struct ExecRequest {
@@ -325,6 +349,27 @@ pub struct ExecRequest {
     /// auto-detect. Kept here so `run_inner`'s backend selection agrees with the
     /// admit/build sites that read it off `RunArgs`.
     pub hypervisor: Option<String>,
+}
+
+impl ExecRequest {
+    /// Borrow the boot-shape half of this request. The launch resolution reads
+    /// only these fields, so a run and a `pool warm` that agree on them resolve
+    /// the same config — which is what makes the warm-pool compat key match.
+    pub fn launch_shape(&self) -> LaunchShape<'_> {
+        LaunchShape {
+            name: self.name.as_deref(),
+            image: &self.image,
+            cpus: self.cpus,
+            memory_mib: self.memory_mib,
+            mem_initial_mib: self.mem_initial_mib,
+            dir_shares: &self.dir_shares,
+            pty: self.pty,
+            network_policy: &self.network_policy,
+            warm_pool_size: self.warm_pool_size,
+            sdk_sidecar: self.sdk_sidecar.as_ref(),
+            hypervisor: self.hypervisor.as_deref(),
+        }
+    }
 }
 
 pub(crate) fn select_exec_backend(
@@ -462,14 +507,14 @@ pub(crate) fn validate_image_egress_backend_name(
     validate_image_egress_backend(&backend, image_requested, network_policy)
 }
 
-fn request_uses_vsock_proxy_backend(req: &ExecRequest) -> bool {
+fn shape_uses_vsock_proxy_backend(shape: &LaunchShape<'_>) -> bool {
     matches!(
-        &req.image,
+        shape.image,
         ImageSource::Prebuilt {
             virtiofs_oci_root: Some(_),
             ..
         }
-    ) && req.network_policy.allows_egress()
+    ) && shape.network_policy.allows_egress()
 }
 
 /// Build the IR healthcheck from the CLI flags. A shell command string becomes
@@ -892,12 +937,6 @@ fn run_inner(
     posture: Option<&PostureSink>,
     runtime_source_policy_sink: Option<&RuntimeSourcePolicySink>,
 ) -> Result<Either<i32, ExecOutput>> {
-    let backend = select_exec_backend(
-        request_uses_vsock_proxy_backend(&req),
-        &req.network_policy,
-        req.hypervisor.as_deref(),
-    )?;
-
     // Phase timing (off unless `MVM_PHASE_TIMING` or a launch-sample path is
     // set): capture a host-monotonic mark at each run seam, then emit a
     // one-line breakdown and/or the machine-readable sample at teardown. When
@@ -908,61 +947,41 @@ fn run_inner(
     let mut sub_marks = crate::commands::vm::phase_timing::LaunchSubMarks::new(timing);
     let t_start = timing.then(std::time::Instant::now);
 
-    // Resolve image artifacts: either a named template or a pre-built pair.
-    // For templates, also probe for a pre-built snapshot so we can skip the
-    // cold-boot cost when the request is snapshot-eligible.
-    let resolved = resolve_image_artifacts(&req.image)?;
-
-    let t_image_resolved = timing.then(std::time::Instant::now);
-
-    // A transient run owns only its state directory. Host directories are
-    // attached as live virtio-fs shares; no host tree is copied or staged.
-    let vm_name = req.name.clone().unwrap_or_else(transient_vm_name);
-
-    // Snapshot eligibility, the dm-verity sidecar probe, the virtiofs-root
-    // tier gate, and the effective initrd all fall out of the resolved image
-    // + backend capabilities; see `resolve_boot_strategy`.
-    let boot = resolve_boot_strategy(&req, &backend, &resolved, &mut sub_marks)?;
+    // Everything from backend selection through admission and the runtime
+    // overlay attach. It yields a bootable config without booting, which is
+    // also what `pool warm` needs — so it lives in one function both call
+    // rather than two that are free to drift.
+    let mut resolve_marks = LaunchResolveMarks::new(timing);
+    let launch = resolve_launch(
+        &req.launch_shape(),
+        admit,
+        &mut resolve_marks,
+        &mut sub_marks,
+    )?;
+    let ResolvedLaunch {
+        backend,
+        start_config,
+        use_snapshot,
+        root_strategy,
+        runtime_source_policy,
+        image: resolved,
+    } = launch;
+    let vm_name = start_config.name.clone();
 
     // Report the resolved strategy to the command layer for chain-audit. This is
     // the single source of truth — the same value that drives the boot below —
     // so the `plan.boot_posture` entry can never diverge from what actually
     // booted.
     if let Some(sink) = posture {
-        sink.set(boot.root_strategy);
+        sink.set(root_strategy);
     }
     if let Some(sink) = runtime_source_policy_sink {
-        sink.set(boot.runtime_source_policy);
+        sink.set(runtime_source_policy);
     }
-    let mut use_snapshot = boot.use_snapshot;
 
-    let t_drives_ready = timing.then(std::time::Instant::now);
-
-    // Template-restore VMs run without plan admission. Leave tenant_id /
-    // plan_json / bundle_json at their None defaults (via
-    // `..Default::default()`) so the libkrun/HVF backends take the legacy
-    // `run_supervisor` dispatch. Routing template restores through
-    // admission would add an `admit_for_run` call here and a
-    // `populate_audit_substrate` invocation after the struct literal.
-    let mut start_config = build_start_config(&req, &vm_name, &resolved, &boot);
-
-    // Admit the transient run as a locally-signed workload. Setting
-    // tenant_id + plan_json makes the runner-backed microVM supervisor enforce
-    // `network_policy` and chain-audit the run. Force cold boot when admitted —
-    // snapshot restore is unavailable for workload admission.
-    if let Some(admit_fn) = admit
-        && let Some(sub) = admit_fn(std::path::Path::new(&resolved.rootfs), &vm_name)?
-    {
-        start_config.tenant_id = Some(sub.tenant_id);
-        start_config.plan_json = Some(sub.plan_json);
-        start_config.bundle_json = sub.bundle_json;
-        start_config.config_files.extend(sub.config_files);
-        use_snapshot = false;
-    }
-    crate::commands::vm::up::attach_runtime_overlay_if_cached(&mut start_config, backend.name())?;
-    crate::commands::vm::up::attach_universal_initramfs_if_cached(&mut start_config)?;
-    crate::commands::vm::up::emit_runtime_source_status(&start_config);
-    let t_admitted = timing.then(std::time::Instant::now);
+    let t_image_resolved = resolve_marks.image_resolved;
+    let t_drives_ready = resolve_marks.drives_ready;
+    let t_admitted = resolve_marks.admitted;
 
     // Reap stale standbys, try a warm-pool claim, then fall back to
     // snapshot-restore / cold boot. See `boot_transient_vm`.
@@ -1085,7 +1104,7 @@ fn run_inner(
                     backend: backend.name(),
                     start_config: &start_config,
                     launch_mode,
-                    root_strategy: boot.root_strategy,
+                    root_strategy,
                     mount_materialized: sub_marks
                         .recorded(crate::commands::vm::phase_timing::SubPhase::MountMaterialize),
                     phases,
@@ -1328,7 +1347,7 @@ struct BootStrategy {
 /// policy, and the effective initrd. All of these fall out of the resolved
 /// image + `req` + the backend's capabilities.
 fn resolve_boot_strategy(
-    req: &ExecRequest,
+    shape: &LaunchShape<'_>,
     backend: &AnyBackend,
     resolved: &ResolvedImage,
     sub: &mut crate::commands::vm::phase_timing::LaunchSubMarks,
@@ -1337,8 +1356,8 @@ fn resolve_boot_strategy(
 
     // Snapshot path is taken when the request is eligible; otherwise cold boot.
     let use_snapshot = snapshot_eligible(
-        &req.image,
-        &req.dir_shares,
+        shape.image,
+        shape.dir_shares,
         resolved.snap_info.is_some(),
         backend.capabilities().snapshot_capability,
     );
@@ -1355,7 +1374,7 @@ fn resolve_boot_strategy(
     // dev run boots from the unpacked tree over virtio-fs (no ext4 materialize);
     // prod, sealed, and block backends stay on the materialized rootfs (claim 3).
     let virtiofs_root = resolve_virtiofs_root(
-        &req.image,
+        shape.image,
         backend.capabilities().virtiofs_root,
         verity_path.is_some(),
     );
@@ -1365,13 +1384,13 @@ fn resolve_boot_strategy(
         mvm_build::run_image::RootStrategy::BlockExt4
     };
     let runtime_source_policy = runtime_source_policy_for(
-        &req.image,
+        shape.image,
         backend.name(),
         verity_path.is_some(),
         root_strategy,
     );
     let effective_initrd = effective_transient_initrd(
-        &req.image,
+        shape.image,
         resolved.initrd.as_deref(),
         &resolved.rootfs,
         runtime_source_policy,
@@ -1394,7 +1413,7 @@ fn resolve_boot_strategy(
 /// overlay attach happen in the caller, after this returns — this only
 /// assembles the struct.
 fn build_start_config(
-    req: &ExecRequest,
+    shape: &LaunchShape<'_>,
     vm_name: &str,
     resolved: &ResolvedImage,
     boot: &BootStrategy,
@@ -1403,7 +1422,7 @@ fn build_start_config(
     // non-sealed images. OCI/dev images can carry verity sidecars and still be
     // interactive, so the sidecar's sealed bit is the load-bearing signal here.
     let image_sealed = crate::commands::vm::image_is_sealed(std::path::Path::new(&resolved.rootfs));
-    let dev_console = transient_run_dev_console(req.pty, image_sealed);
+    let dev_console = transient_run_dev_console(shape.pty, image_sealed);
 
     VmStartConfig {
         name: vm_name.to_string(),
@@ -1418,13 +1437,13 @@ fn build_start_config(
         revision_hash: resolved.revision.clone(),
         flake_ref: resolved.flake_ref.clone(),
         profile: resolved.profile.clone(),
-        cpus: req.cpus,
-        memory_mib: req.memory_mib,
-        mem_initial_mib: req.mem_initial_mib,
+        cpus: shape.cpus,
+        memory_mib: shape.memory_mib,
+        mem_initial_mib: shape.mem_initial_mib,
         ports: Vec::new(),
         // Live shares precede the SDK sidecar so their tags and admission
         // records remain stable across sidecar changes.
-        volumes: req
+        volumes: shape
             .dir_shares
             .iter()
             .map(|share| VmVolume {
@@ -1434,16 +1453,153 @@ fn build_start_config(
                 kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
                 ..Default::default()
             })
-            .chain(req.sdk_sidecar.iter().map(|a| a.volume.clone()))
+            .chain(shape.sdk_sidecar.iter().map(|a| a.volume.clone()))
             .collect(),
         config_files: Vec::new(),
         secret_files: Vec::new(),
         runner_dir: None,
-        network_policy: req.network_policy.clone(),
-        warm_pool_size: req.warm_pool_size,
+        network_policy: shape.network_policy.clone(),
+        warm_pool_size: shape.warm_pool_size,
         runtime_source_policy: boot.runtime_source_policy,
         ..Default::default()
     }
+}
+
+/// Host-monotonic marks the launch resolution crosses, handed back so the run
+/// path can render its phase breakdown. `new(false)` records nothing and costs
+/// nothing — the shape `pool warm` uses, since it emits no breakdown.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LaunchResolveMarks {
+    enabled: bool,
+    /// After the image artifacts (kernel/rootfs/initrd) are resolved.
+    pub image_resolved: Option<std::time::Instant>,
+    /// After the boot strategy — verity probe, tier gate, effective initrd.
+    pub drives_ready: Option<std::time::Instant>,
+    /// After admission and the runtime-overlay/initramfs attach.
+    pub admitted: Option<std::time::Instant>,
+}
+
+impl LaunchResolveMarks {
+    #[must_use]
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            ..Self::default()
+        }
+    }
+
+    fn now(&self) -> Option<std::time::Instant> {
+        self.enabled.then(std::time::Instant::now)
+    }
+}
+
+/// One launch's boot shape, resolved without starting a VM.
+///
+/// This is the whole of what a launch knows about itself before
+/// [`boot_transient_vm`] runs: the backend it resolved against, a
+/// [`VmStartConfig`] carrying the rootfs and its verity sidecars, the runtime
+/// overlay and universal initramfs, the cmdline-bearing policy fields, and —
+/// when the caller supplied an admission hook — the tenant and signed plan.
+///
+/// Producing one without booting is what lets the warm pool spawn a parent that
+/// mirrors a real launch: `pool warm` resolves this, hands it to
+/// `warm_to_target`, and the spawn derives the parent's boot shape and the
+/// pool's compat key from the same value the launch will later be matched on.
+pub struct ResolvedLaunch {
+    /// The backend the launch resolved against. Selected here rather than by
+    /// the caller so a warm spawn and the run it serves cannot disagree about
+    /// which backend's capabilities shaped the config.
+    pub backend: AnyBackend,
+    pub start_config: VmStartConfig,
+    /// Whether snapshot restore survives admission (an admitted workload
+    /// always cold-boots).
+    pub use_snapshot: bool,
+    /// Rootfs strategy the run-path tier gate selected — the value the run path
+    /// records as `plan.boot_posture`.
+    pub root_strategy: mvm_build::run_image::RootStrategy,
+    pub runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy,
+    /// Resolved image artifacts, kept for the snapshot-restore leg of the boot.
+    image: ResolvedImage,
+}
+
+/// Resolve a launch's bootable [`VmStartConfig`] **without starting a VM**.
+///
+/// Composes the four steps that used to exist only inline in [`run_inner`]:
+/// image-artifact resolution, the boot-strategy tier gate, the start-config
+/// assembly, and the admission + runtime-overlay/initramfs attach. Anything
+/// that wants a launch's boot shape calls this; resolving it a second way is
+/// how a warm parent comes to boot a shape no claim can match.
+///
+/// `admit` binds the run to a signed [`mvm_core::plan::ExecutionPlan`] and is
+/// what makes the config claim-eligible. A warm spawn passes `None`: a factory
+/// parent carries no workload authority, and the spawn drops the tenant and
+/// plan from the config it is handed anyway.
+pub fn resolve_launch(
+    shape: &LaunchShape<'_>,
+    admit: Option<&SessionAdmit<'_>>,
+    marks: &mut LaunchResolveMarks,
+    sub: &mut crate::commands::vm::phase_timing::LaunchSubMarks,
+) -> Result<ResolvedLaunch> {
+    let backend = select_exec_backend(
+        shape_uses_vsock_proxy_backend(shape),
+        shape.network_policy,
+        shape.hypervisor,
+    )?;
+
+    // Resolve image artifacts: either a named template or a pre-built pair.
+    // For templates, also probe for a pre-built snapshot so we can skip the
+    // cold-boot cost when the request is snapshot-eligible.
+    let image = resolve_image_artifacts(shape.image)?;
+    marks.image_resolved = marks.now();
+
+    // A transient run owns only its state directory. Host directories are
+    // attached as live virtio-fs shares; no host tree is copied or staged.
+    let vm_name = shape
+        .name
+        .map(str::to_string)
+        .unwrap_or_else(transient_vm_name);
+
+    // Snapshot eligibility, the dm-verity sidecar probe, the virtiofs-root
+    // tier gate, and the effective initrd all fall out of the resolved image
+    // + backend capabilities; see `resolve_boot_strategy`.
+    let boot = resolve_boot_strategy(shape, &backend, &image, sub)?;
+    marks.drives_ready = marks.now();
+
+    // Template-restore VMs run without plan admission. Leave tenant_id /
+    // plan_json / bundle_json at their None defaults (via
+    // `..Default::default()`) so the libkrun/HVF backends take the legacy
+    // `run_supervisor` dispatch. Routing template restores through
+    // admission would add an `admit_for_run` call here and a
+    // `populate_audit_substrate` invocation after the struct literal.
+    let mut start_config = build_start_config(shape, &vm_name, &image, &boot);
+    let mut use_snapshot = boot.use_snapshot;
+
+    // Admit the transient run as a locally-signed workload. Setting
+    // tenant_id + plan_json makes the runner-backed microVM supervisor enforce
+    // `network_policy` and chain-audit the run. Force cold boot when admitted —
+    // snapshot restore is unavailable for workload admission.
+    if let Some(admit_fn) = admit
+        && let Some(sub) = admit_fn(std::path::Path::new(&image.rootfs), &vm_name)?
+    {
+        start_config.tenant_id = Some(sub.tenant_id);
+        start_config.plan_json = Some(sub.plan_json);
+        start_config.bundle_json = sub.bundle_json;
+        start_config.config_files.extend(sub.config_files);
+        use_snapshot = false;
+    }
+    crate::commands::vm::up::attach_runtime_overlay_if_cached(&mut start_config, backend.name())?;
+    crate::commands::vm::up::attach_universal_initramfs_if_cached(&mut start_config)?;
+    crate::commands::vm::up::emit_runtime_source_status(&start_config);
+    marks.admitted = marks.now();
+
+    Ok(ResolvedLaunch {
+        backend,
+        start_config,
+        use_snapshot,
+        root_strategy: boot.root_strategy,
+        runtime_source_policy: boot.runtime_source_policy,
+        image,
+    })
 }
 
 /// Everything [`boot_transient_vm`] needs beyond the caller-varying
@@ -2263,6 +2419,142 @@ mod tests {
         .expect("hvf should satisfy the proxy backend requirement");
 
         assert_eq!(selected, "hvf");
+    }
+
+    /// A launch shape resolved from an `ExecRequest` must carry every field the
+    /// resolution reads. If one is dropped here, a `pool warm` that builds its
+    /// shape by hand and a run that builds one from its request resolve
+    /// different configs — and the pool fills with parents no claim matches,
+    /// with no error anywhere.
+    #[test]
+    fn launch_shape_borrows_every_field_the_resolution_reads() {
+        let share = crate::commands::DirShareSpec {
+            host_dir: "/host/data".into(),
+            guest_mount: "/data".into(),
+            read_only: true,
+        };
+        let req = ExecRequest {
+            name: Some("named-vm".into()),
+            warm_pool_size: 3,
+            image: ImageSource::Template("t".into()),
+            cpus: 4,
+            memory_mib: 2048,
+            mem_initial_mib: Some(512),
+            dir_shares: vec![share.clone()],
+            env: vec![("K".into(), "V".into())],
+            target: ExecTarget::Inline { argv: vec![] },
+            timeout_secs: Some(30),
+            pty: true,
+            network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
+            stdin: b"ignored".to_vec(),
+            healthcheck: None,
+            hypervisor: Some("mock".into()),
+            sdk_sidecar: None,
+        };
+
+        let shape = req.launch_shape();
+
+        assert_eq!(shape.name, Some("named-vm"));
+        assert!(matches!(shape.image, ImageSource::Template(n) if n == "t"));
+        assert_eq!(shape.cpus, 4);
+        assert_eq!(shape.memory_mib, 2048);
+        assert_eq!(shape.mem_initial_mib, Some(512));
+        assert_eq!(shape.dir_shares.len(), 1);
+        assert_eq!(shape.dir_shares[0].guest_mount, share.guest_mount);
+        assert!(shape.pty);
+        assert_eq!(shape.warm_pool_size, 3);
+        assert_eq!(shape.hypervisor, Some("mock"));
+        assert!(shape.sdk_sidecar.is_none());
+        assert_eq!(*shape.network_policy, req.network_policy);
+    }
+
+    /// The whole point of the extraction: a bootable config, verity sidecars
+    /// included, obtained without starting a VM. `pool warm` depends on this —
+    /// a pre-warm that had to boot to learn its own boot shape would be no
+    /// pre-warm at all.
+    #[cfg(feature = "test-support")]
+    #[test]
+    fn resolve_launch_yields_a_bootable_config_without_starting_a_vm() {
+        let _guard = mvm_runtime::vm::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(tmp.path());
+
+        let kernel = tmp.path().join("vmlinux");
+        std::fs::write(&kernel, b"kernel").unwrap();
+        let rootfs = tmp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"rootfs").unwrap();
+        // A production rootfs ships its dm-verity sidecar pair beside it; the
+        // resolution must pick both up, since a parent booting without them
+        // boots a different shape than the launch it is meant to serve.
+        std::fs::write(tmp.path().join("rootfs.verity"), b"verity").unwrap();
+        std::fs::write(tmp.path().join("rootfs.roothash"), b"deadbeef\n").unwrap();
+
+        let image = ImageSource::Prebuilt {
+            kernel_path: kernel.display().to_string(),
+            rootfs_path: rootfs.display().to_string(),
+            initrd_path: None,
+            label: "fixture".into(),
+            virtiofs_oci_root: None,
+        };
+        let policy = mvm_core::network_policy::NetworkPolicy::deny_all();
+        let shape = LaunchShape {
+            name: None,
+            image: &image,
+            cpus: 2,
+            memory_mib: 1024,
+            mem_initial_mib: None,
+            dir_shares: &[],
+            pty: false,
+            network_policy: &policy,
+            warm_pool_size: 1,
+            sdk_sidecar: None,
+            hypervisor: Some("mock"),
+        };
+
+        let resolved = resolve_launch(
+            &shape,
+            None,
+            &mut LaunchResolveMarks::new(false),
+            &mut crate::commands::vm::phase_timing::LaunchSubMarks::new(false),
+        )
+        .expect("a prebuilt image resolves without a VM");
+
+        assert_eq!(resolved.start_config.rootfs_path, rootfs.display().to_string());
+        assert_eq!(
+            resolved.start_config.kernel_path.as_deref(),
+            Some(kernel.display().to_string().as_str())
+        );
+        assert!(
+            resolved.start_config.verity_path.is_some(),
+            "the verity sidecar beside the rootfs must reach the config"
+        );
+        assert_eq!(resolved.start_config.roothash.as_deref(), Some("deadbeef"));
+        assert_eq!(resolved.start_config.cpus, 2);
+        assert_eq!(resolved.start_config.memory_mib, 1024);
+        assert!(
+            !resolved.start_config.name.is_empty(),
+            "an unnamed launch generates a throwaway name"
+        );
+        // No admission hook, so no workload authority is bound.
+        assert!(resolved.start_config.tenant_id.is_none());
+        assert!(resolved.start_config.plan_json.is_none());
+        // And nothing booted: the mock backend records every started VM.
+        assert!(
+            resolved.backend.list_all().unwrap_or_default().is_empty(),
+            "resolving a launch must not start a VM"
+        );
+    }
+
+    /// Timing marks are opt-in. `pool warm` resolves with them off and must pay
+    /// nothing for a breakdown it never renders.
+    #[test]
+    fn launch_resolve_marks_record_nothing_when_disabled() {
+        let marks = LaunchResolveMarks::new(false);
+        assert!(marks.now().is_none());
+        assert!(LaunchResolveMarks::new(true).now().is_some());
     }
 
     #[test]

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -2488,9 +2488,12 @@ mod tests {
         std::fs::write(&rootfs, b"rootfs").unwrap();
         // A production rootfs ships its dm-verity sidecar pair beside it; the
         // resolution must pick both up, since a parent booting without them
-        // boots a different shape than the launch it is meant to serve.
+        // boots a different shape than the launch it is meant to serve. The
+        // probe requires a full 64-hex roothash, so a short stand-in reads as
+        // "no sidecar" and would make this assert nothing.
+        const ROOTHASH: &str = "1111111111111111111111111111111111111111111111111111111111111111";
         std::fs::write(tmp.path().join("rootfs.verity"), b"verity").unwrap();
-        std::fs::write(tmp.path().join("rootfs.roothash"), b"deadbeef\n").unwrap();
+        std::fs::write(tmp.path().join("rootfs.roothash"), format!("{ROOTHASH}\n")).unwrap();
 
         let image = ImageSource::Prebuilt {
             kernel_path: kernel.display().to_string(),
@@ -2534,7 +2537,7 @@ mod tests {
             resolved.start_config.verity_path.is_some(),
             "the verity sidecar beside the rootfs must reach the config"
         );
-        assert_eq!(resolved.start_config.roothash.as_deref(), Some("deadbeef"));
+        assert_eq!(resolved.start_config.roothash.as_deref(), Some(ROOTHASH));
         assert_eq!(resolved.start_config.cpus, 2);
         assert_eq!(resolved.start_config.memory_mib, 1024);
         assert!(
@@ -2544,9 +2547,10 @@ mod tests {
         // No admission hook, so no workload authority is bound.
         assert!(resolved.start_config.tenant_id.is_none());
         assert!(resolved.start_config.plan_json.is_none());
-        // And nothing booted: the mock backend records every started VM.
+        // And nothing booted: starting a VM creates its state directory, so
+        // resolving one must leave none behind.
         assert!(
-            resolved.backend.list_all().unwrap_or_default().is_empty(),
+            !mvm_core::config::vm_state_dir(&resolved.start_config.name).exists(),
             "resolving a launch must not start a VM"
         );
     }

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -2522,7 +2522,10 @@ mod tests {
         )
         .expect("a prebuilt image resolves without a VM");
 
-        assert_eq!(resolved.start_config.rootfs_path, rootfs.display().to_string());
+        assert_eq!(
+            resolved.start_config.rootfs_path,
+            rootfs.display().to_string()
+        );
         assert_eq!(
             resolved.start_config.kernel_path.as_deref(),
             Some(kernel.display().to_string().as_str())

--- a/crates/mvm-runtime/src/workload_runner/claim.rs
+++ b/crates/mvm-runtime/src/workload_runner/claim.rs
@@ -15,7 +15,7 @@ use mvm_core::checkpoint::CheckpointMeta;
 use mvm_core::plan::SecretBinding;
 use mvm_core::policy::RedactionPolicy;
 use mvm_core::policy::network_policy::NetworkPolicy;
-use mvm_core::vm_backend::{VmId, VmStartConfig};
+use mvm_core::vm_backend::VmId;
 
 use crate::substitution_spawn::EndpointGuard;
 use crate::workload_runner::runner::{EndpointSpawnRequest, EndpointSpawner};
@@ -139,15 +139,28 @@ impl<'a> ClaimGuards<'a> {
         Self { spawner }
     }
 
-    /// Refuse a rootfs whose parent dir carries no overlay-aware sidecar (no
+    /// Refuse an image whose dir carries no overlay-aware sidecar (no
     /// `/mvm/runtime` mount point) before any endpoint spawn or boot — the same
     /// gate the raw backends run, so a claim admits exactly what a cold boot does.
-    pub fn admit_overlay_contract(&self, cfg: &VmStartConfig) -> Result<()> {
-        let rootfs = Path::new(&cfg.rootfs_path);
-        let rootfs_dir = rootfs.parent().unwrap_or_else(|| Path::new("."));
+    ///
+    /// `image_rootfs` is the rootfs the claim was **admitted for**, not the
+    /// copy-on-write clone the child boots from. The sidecar records how the
+    /// image was built (`overlayAware`, `runtimeLean`), so it lives beside the
+    /// image and travels with neither the snapshot capture nor the clone: a
+    /// materialized child dir holds `rootfs.ext4` and the saved memory, and
+    /// nothing else. Gating on the clone therefore refused every saved-state
+    /// claim for a missing sidecar while the identical cold boot of the same
+    /// image was admitted — the resident-handoff path already passed the image
+    /// dir here for exactly this reason, and the two must not disagree.
+    pub fn admit_overlay_contract(
+        &self,
+        image_rootfs: &Path,
+        runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy,
+    ) -> Result<()> {
+        let rootfs_dir = image_rootfs.parent().unwrap_or_else(|| Path::new("."));
         mvm_vmm::host::runtime_meta::admit_runtime_overlay_contract(
             rootfs_dir,
-            cfg.runtime_source_policy,
+            runtime_source_policy,
         )
     }
 
@@ -187,6 +200,7 @@ impl<'a> ClaimGuards<'a> {
 mod tests {
     use super::*;
     use mvm_core::checkpoint::{CheckpointClass, CheckpointId, ContentBlob};
+    use mvm_core::vm_backend::RuntimeSourcePolicy;
 
     fn fake_meta_with_rootfs(hex: String) -> CheckpointMeta {
         CheckpointMeta::builder(
@@ -249,7 +263,6 @@ mod tests {
     use crate::workload_runner::runner::{EndpointSpawnRequest, EndpointSpawner};
     use mvm_core::policy::RedactionPolicy;
     use mvm_core::policy::network_policy::NetworkPolicy;
-    use mvm_core::vm_backend::VmStartConfig;
     use std::path::PathBuf;
     use std::sync::Mutex;
 
@@ -355,29 +368,61 @@ mod tests {
         mvm_build::builder_vm::GuestSidecar::for_oci_run("cg-valid", false, true)
             .write_to_dir(ok_dir.path())
             .unwrap();
-        let valid = VmStartConfig {
-            name: "cg-valid".into(),
-            rootfs_path: ok_rootfs.display().to_string(),
-            ..Default::default()
-        };
-        assert!(guards.admit_overlay_contract(&valid).is_ok());
+        assert!(
+            guards
+                .admit_overlay_contract(&ok_rootfs, RuntimeSourcePolicy::default())
+                .is_ok()
+        );
 
         // A rootfs whose dir carries no sidecar is refused — same message the
         // cold-boot gate emits.
         let bare_dir = tempfile::tempdir().unwrap();
         let bare_rootfs = bare_dir.path().join("rootfs.ext4");
         std::fs::write(&bare_rootfs, b"rootfs").unwrap();
-        let invalid = VmStartConfig {
-            name: "cg-invalid".into(),
-            rootfs_path: bare_rootfs.display().to_string(),
-            ..Default::default()
-        };
         let err = guards
-            .admit_overlay_contract(&invalid)
+            .admit_overlay_contract(&bare_rootfs, RuntimeSourcePolicy::default())
             .expect_err("a rootfs with no overlay-aware sidecar must be refused");
         assert!(
             err.to_string().contains("mvm-meta.json"),
             "refusal must name the missing sidecar: {err}"
+        );
+    }
+
+    /// A saved-state claim gates the image it was admitted for, not the
+    /// copy-on-write clone the child boots. The clone carries `rootfs.ext4` and
+    /// the saved memory and nothing else — the sidecar is not part of the
+    /// capture — so gating the clone refused every such claim for a missing
+    /// sidecar while the identical cold boot of the same image was admitted.
+    #[test]
+    fn admit_overlay_contract_gates_the_image_not_the_materialized_clone() {
+        let spawner = FakeSpawner::default();
+        let guards = ClaimGuards::new(&spawner);
+
+        let image_dir = tempfile::tempdir().unwrap();
+        let image_rootfs = image_dir.path().join("rootfs.ext4");
+        std::fs::write(&image_rootfs, b"rootfs").unwrap();
+        mvm_build::builder_vm::GuestSidecar::for_oci_run("cg-image", false, true)
+            .write_to_dir(image_dir.path())
+            .unwrap();
+
+        // What a materialization actually produces: the blob and the memory
+        // image, no sidecar.
+        let clone_dir = tempfile::tempdir().unwrap();
+        let clone_rootfs = clone_dir.path().join("rootfs.ext4");
+        std::fs::write(&clone_rootfs, b"rootfs").unwrap();
+        std::fs::write(clone_dir.path().join("memory.bin"), b"mem").unwrap();
+
+        assert!(
+            guards
+                .admit_overlay_contract(&image_rootfs, RuntimeSourcePolicy::default())
+                .is_ok(),
+            "the admitted image carries the sidecar and must be admitted"
+        );
+        assert!(
+            guards
+                .admit_overlay_contract(&clone_rootfs, RuntimeSourcePolicy::default())
+                .is_err(),
+            "the clone has no sidecar — proving the gate must not be pointed at it"
         );
     }
 }

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -638,8 +638,14 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
         // keyed on its fresh id (never a sibling's; the factory parent has none).
         let child_cfg = child_start_config(claim, &child, &child_rootfs_dir);
         let guards = ClaimGuards::new(&self.spawner);
+        // Gate the image the claim was admitted for, not the clone the child
+        // boots: the sidecar describes how the image was built and is not part
+        // of the captured snapshot, so it exists only beside the image.
         guards
-            .admit_overlay_contract(&child_cfg)
+            .admit_overlay_contract(
+                std::path::Path::new(&claim.rootfs_path),
+                child_cfg.runtime_source_policy,
+            )
             .map_err(|e| StandbyError::ClaimFailed(format!("overlay contract: {e}")))?;
 
         let grant_envelope = issue_child_grant(&plan, &child_cfg, ctx.grant_issuer)

--- a/crates/mvm-runtime/src/workload_runner/runner/backend.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner/backend.rs
@@ -112,7 +112,12 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 
         std::fs::create_dir_all(&state_dir)
             .with_context(|| format!("create state dir {}", state_dir.display()))?;
 
-        ClaimGuards::new(&self.spawner).admit_overlay_contract(config)?;
+        // A cold boot's rootfs *is* its image, so the gate reads the dir it
+        // already boots from.
+        ClaimGuards::new(&self.spawner).admit_overlay_contract(
+            std::path::Path::new(&config.rootfs_path),
+            config.runtime_source_policy,
+        )?;
         crate::base::runtime_meta::record_from_start_config(
             &config.name,
             StartMode::Detached,

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -161,7 +161,14 @@ for detailed scope and acceptance criteria.
         path. Foreground teardown is the other dominant cost, promoting
         Phase 6 ahead of Phase 3.
   - [ ] Phase 1 — content-addressed `--mount` image cache
-  - [ ] Phase 2 — artifact preparation outside the launch path
+  - [~] Phase 2 — artifact preparation outside the launch path. The resolution
+        half landed as the warm pool's hard prerequisite (**#2333**):
+        `crate::exec::resolve_launch` yields a bootable `VmStartConfig` without
+        starting a VM, `run_inner` calls it instead of inlining it, and
+        `pool warm --image` uses it to spawn parents a matching launch claims.
+        `pool warm` could previously spawn nothing on any backend. The
+        prepared-artifact manifest and the acquire/prepare split are still open,
+        so a cold cache is still populated inline.
   - [~] Phase 3 — reduce backend cold-start latency. Re-measured on KVM at
         `c866611af` as Phase 5 asked: `driver_boot` is 630.5 ms, unmoved from
         623.6 ms, so the cost is real rather than a poll artifact and can be

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1800,6 +1800,18 @@ Then unify + retire the old paths:
   / 77.01 ms p99 to supervisor PID disappearance after SIGTERM; attach,
   endpoint reaping, console cleanup, state-marker removal, and force-kill
   escalation do not account for the stop latency.
+- [x] **Launch resolution without a launch (Plan 299 Phase 2, #2333).**
+  `mvmctl pool warm` could spawn nothing on any backend: it passed no launch
+  config, so the spawn built an image-less compat key and refused itself, and
+  nothing could produce a launch shape without running a launch. The four things
+  a claimable parent needs — rootfs plus verity sidecars, runtime overlay plus
+  universal initramfs, cmdline tokens, and admission — existed only inline in
+  the run path. They now compose into `crate::exec::resolve_launch`, which
+  returns a bootable `VmStartConfig` without booting; `run_inner` calls it, and
+  `pool warm --image/--cpus/--memory` resolves its parents' shape through the
+  same function, so the recorded compat key is the one a claim searches for. The
+  accepted-and-ignored `--rootfs` flag is removed. This is the resolution half
+  of Phase 2 only — the prepared-artifact manifest is still open.
 - [ ] **Prepared cold launch:** with a local, verified kernel/initramfs/artifact
   set and a new guest identity, reach authenticated guest readiness and run
   `/bin/true` in ≤200 ms p50, ≤250 ms p95, and ≤300 ms p99 on Apple Silicon

--- a/specs/plans/255-live-fc-warm-claim.md
+++ b/specs/plans/255-live-fc-warm-claim.md
@@ -1022,12 +1022,52 @@ already states the intent (`crates/mvm-cli/src/exec.rs`): the runtime overlay is
 "the single source of the guest agent + helpers … never silently replaced by a
 baked rootfs copy". The standby spawn is the one path that skipped it.
 
-**BUG-2 — pre-existing, not this branch's.** The transient run path persists the
+**BUG-1 is FIXED — and fixed the way this section asked for.** Plan 299
+Phase 2's launch resolution (**#2333**) made the run path's own
+`crate::exec::resolve_launch` produce a bootable `VmStartConfig` without
+booting, and `pool warm --image` now spawns its parents from that value. No
+overlay field was threaded through `StandbySpec`; the parent inherits whatever
+the workload path resolved, which is exactly the fix this section argued for.
+
+Live evidence on the KVM host (Firecracker, `alpine`): `mvmctl pool warm 1
+--image alpine` fills the pool — `pool status` reports `1 idle` with an image
+digest for the first time on any host — and the forked child's console shows
+the full four-drive device model coming back (`kick block blk0`..`blk3` after
+`load snapshot` + `Resumed`), not the bare single-`BlockDev` shape. The parent
+captures, the checkpoint exists, and a claim now gets all the way to the reseed
+handshake that "was never exercised".
+
+**BUG-2 — pre-existing, not this branch's. Now the live blocker, exactly as
+predicted below.** The transient run path persists the
 plan via `write_plan` but never mints `verb-grant.json`, so no
 `mvm.host_signer_pub` reaches the guest and the agent rejects the control
 connection with `rejecting control connection without a pinned host key`. It
 predates this branch's merge base. Track it separately; expect it to be the next
 blocker once BUG-1 is fixed.
+
+Confirmed live once BUG-1 was fixed. The claim reaches `child_forked`, the
+child resumes, and then the guest prints
+
+```
+mvm-guest-agent: authenticated control handshake failed: Failed to read frame length
+```
+
+so the post-restore identity handshake is never answered and the claim fails
+closed with `forked child '<vm>' never answered the post-restore identity
+handshake`. The fail-closed posture is correct — a child that cannot prove it
+reseeded must not be admitted — but it means no warm claim can complete on
+Firecracker until this is fixed, and therefore no claimed-launch measurement
+against the cold baseline is possible yet.
+
+**BUG-5 — a failed claim strands the standby and orphans its VMM.** Found while
+exercising the above. When a claim fails after the child is materialized, the
+cleanup removes the preloaded child's state directory but does **not** kill its
+`firecracker` process. The pool record stays `Idle` while pointing at a child
+whose socket path no longer exists, so every subsequent claim against that
+standby fails with `resume preloaded child: Firecracker socket
+<dir>/fc.socket does not exist — VM is not running`, and a stray VMM leaks per
+attempt (observed: pid alive, `/root/.mvm/vms/vm-*` gone). A standby is
+therefore single-use even against a retryable failure.
 
 **BLOCKER-3 — resolved in code; live delivery remains gated behind #1962.**
 #1959 established the host-signer public key as boot-pinned *host identity*

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -586,6 +586,15 @@ families.
       the prepared-artifact manifest and the acquire/prepare split below are
       untouched, so a `pool warm` against a cold cache still performs the pull
       and the materialization inline.
+- [ ] Measure a claimed launch against the cold baseline. **Blocked, not
+      skipped:** the pool now fills on the KVM host (`pool status` reports
+      `1 idle`) and a claim reaches the fork, but the child's guest agent fails
+      its authenticated control handshake, so the post-restore identity
+      handshake goes unanswered and the claim fails closed. That is Plan 255
+      BUG-2, pre-existing and predicted there as "the next blocker once BUG-1 is
+      fixed". Cold baseline re-measured on the same binary for when the claim
+      lands: `backend_start` 549.8 / 564.7 / 554.4 ms, dispatch window
+      551.6 / 566.8 / 556.2 ms.
 - [ ] Define a prepared-artifact manifest for the kernel, universal initramfs,
       runtime overlay, rootfs, verity sidecars, and their compatibility
       fingerprints. Reuse existing content-addressed verification rather than

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -575,6 +575,17 @@ families.
 
 ## Phase 2 — Artifact preparation outside the launch path
 
+- [x] Make launch-config resolution a step that yields a bootable
+      `VmStartConfig` without starting a VM (`crate::exec::resolve_launch`),
+      composing image-artifact resolution, the boot-strategy tier gate, the
+      start-config assembly, and admission plus the runtime-overlay and
+      universal-initramfs attach. `run_inner` calls it instead of inlining it,
+      and `pool warm --image` calls it to obtain the shape its parents mirror.
+      This was a hard prerequisite for the warm pool, not a parallel
+      optimization — **#2333**. It is the *resolution* half of this phase only:
+      the prepared-artifact manifest and the acquire/prepare split below are
+      untouched, so a `pool warm` against a cold cache still performs the pull
+      and the materialization inline.
 - [ ] Define a prepared-artifact manifest for the kernel, universal initramfs,
       runtime overlay, rootfs, verity sidecars, and their compatibility
       fingerprints. Reuse existing content-addressed verification rather than

--- a/specs/plans/311-launch-critical-path-waste.md
+++ b/specs/plans/311-launch-critical-path-waste.md
@@ -349,11 +349,13 @@ Issue #2276.
       p99 contract. Done at p50/p95/p99 on both images.
 - [x] Repeat on Firecracker/KVM. The fixes hold (both counters zero); that
       backend's remaining gap is #2292 and #2293, recorded in Plan 299 Phase 3.
-- [~] Confirm the warm lane has not regressed against Plan 265. **Not run:**
-      the standby pool is empty on this host (`pool status` reports 0 idle) and
-      `pool warm` spawns nothing today, so there is no warm claim to measure.
-      Nothing in this change touches the claim path; the check is owed once a
-      pool can be filled.
+- [~] Confirm the warm lane has not regressed against Plan 265. **Not run at
+      the time:** the standby pool was empty on this host (`pool status`
+      reported 0 idle) and `pool warm` could spawn nothing, so there was no warm
+      claim to measure. Nothing in this change touches the claim path. That
+      blocker is gone — Plan 299 Phase 2's launch resolution lets
+      `pool warm --image` fill the pool (**#2333**) — so the check is owed
+      against a filled pool.
 - [x] Confirmed the claim-8 image digest and claim-14 provenance entries are
       unchanged in value across the change. Baseline and fixed runs both record
       `image_sha256=c20b3c26ac72e7ae147045438354173c159c4dd42ab9cb09e9e335d694b5fe07`


### PR DESCRIPTION
Closes the blocker in #2333: `mvmctl pool warm` could spawn nothing on any backend, because nothing could produce a launch shape without running a launch.

## The blocker

`run_warm` passed `launch: None`, so `warm_to_target` built an image-less `StandbyCompat` and the spawn refused it — *a parent with no rootfs cannot boot the shape a workload does*. The four things a claimable parent needs existed only inline in `run_inner`, between the drives-ready mark and `boot_transient_vm`.

## What this does

`crate::exec::resolve_launch` composes all four into one function that returns a bootable `VmStartConfig` **without starting a VM**: image artifacts, the boot-strategy tier gate (verity sidecar, virtiofs root, effective initrd), the start-config assembly, and admission plus the runtime-overlay and universal-initramfs attach. `run_inner` calls it instead of inlining it; `pool warm --image` calls it to get the shape its parents mirror. Nothing is duplicated into `pool.rs`.

The boot-shape inputs move to a `LaunchShape` borrow of `ExecRequest`, so a caller with no command can resolve a shape without fabricating an empty argv — `pool warm` warms ahead of any launch and has no argv, timeout or stdin.

`pool warm` gains `--image`, `--cpus` and `--memory`. `--rootfs` is **removed**: a path supplies neither the verity sidecar, the runtime overlay nor the cmdline tokens, which is exactly why it was accepted-and-ignored.

`WarmParams.launch` is no longer optional, and template/kernel/vCPUs/memory derive from it rather than being passed alongside — deleting both the self-refusing branch and the second field set that let a recorded compat key describe something other than what booted.

**No admission on the warm path.** `factory_parent_config` destructures the launch config and explicitly drops `tenant_id`, `plan_json` and `network_policy`; a factory parent boots authority-free by construction. Admitting one would hand a shared parent a workload's authority for a value that is then discarded. The launch that claims it brings its own admitted plan.

## Also fixed: the overlay contract gated the wrong directory

A saved-state claim materializes the child as a CoW clone holding `rootfs.ext4` and the saved memory. The gate read `mvm-meta.json` beside `cfg.rootfs_path` — the clone. The sidecar records how the *image* was built, so it is not part of the capture and exists only beside the image. Every saved-state claim was refused for a missing sidecar while the identical cold boot of the same image was admitted. The resident-handoff branch already passed the image dir here for exactly this reason; the two disagreed.

## Live evidence (Firecracker/KVM, `alpine`)

The pool fills for the first time on any host:

```
$ mvmctl pool warm 1 --image alpine
$ mvmctl pool status
Supervisor standby pool: 1 idle, 0 claimed, 0 parked, 0 dead
  standby-73bdc5d4163b53b8 · idle · pid 1787969 · 2 vcpu / 512 MiB · kernel 607e4033829f · image 6c603cfcbfbf
```

A matching launch selects that parent (compat key matches), passes the overlay gate, and forks. The child's console shows the full four-drive workload device model coming back:

```
[load snapshot] → [Resumed] → kick block blk0, blk1, blk2, blk3
```

**This fixes Plan 255 BUG-1** ("`spawn_standby_parent` boots a bare rootfs: one block device"), and fixes it the way that plan insisted — by reusing the run path's resolution rather than threading overlay fields through `StandbySpec`.

## What is still blocked

The claim then fails closed:

```
mvm-guest-agent: authenticated control handshake failed: Failed to read frame length
→ forked child never answered the post-restore identity handshake
```

That is **Plan 255 BUG-2**, pre-existing and predicted there verbatim: *"expect it to be the next blocker once BUG-1 is fixed."* So **no claimed-launch measurement is possible on this branch** — #2333's acceptance item 4 is blocked, not skipped. Cold baseline re-measured on this binary for when it lands: `backend_start` 549.8 / 564.7 / 554.4 ms (confirming the 549 ms figure).

Also recorded as **BUG-5**: a failed claim deletes the preloaded child's state dir without killing its `firecracker`, so the standby stays `Idle` pointing at a dead socket — single-use even on a retryable failure, leaking a VMM per attempt.

Both are written up in `specs/plans/255-live-fc-warm-claim.md`; scope is recorded honestly in Plan 299 Phase 2 (this is the *resolution* half only — the prepared-artifact manifest is untouched, so a cold cache is still populated inline).

## Tests

- `launch_shape_borrows_every_field_the_resolution_reads`
- `resolve_launch_yields_a_bootable_config_without_starting_a_vm` — asserts verity sidecars reach the config and that nothing booted
- `pool_warm_and_the_run_path_resolve_the_same_compat_key` — guards the silent failure mode (exact-equality compat keys)
- `admit_overlay_contract_gates_the_image_not_the_materialized_clone`

## Gates

nightly `fmt --all`; `clippy --workspace --all-targets -D warnings`; `nextest --workspace` 10921/10921; `test --workspace --doc`; xtask `check-honesty`, `check-no-overclaim`, `check-claim-catalog`, `check-conformance`.