### PR TITLE
Align top-level command help descriptions

### DIFF
--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -113,7 +113,7 @@ pub(in crate::commands) enum Commands {
     /// Build-time commands (image, compile, validate, kernel)
     #[command(display_order = 3)]
     Build(build::group::Args),
-    /// Build, seal, and record a workload locally; optionally ship it to mvmd
+    /// Build, seal, and record a workload; optionally ship it to mvmd
     #[command(display_order = 4)]
     Deploy(deploy::Args),
     /// Build the custom microVM kernels (builder / workload)
@@ -140,7 +140,7 @@ pub(in crate::commands) enum Commands {
     /// Rebuild a workload when its local inputs change
     #[command(display_order = 8)]
     Watch(watch::Args),
-    /// Manage the versioned pack cache (list/rollback/prune/download/update)
+    /// Manage versioned packs (list/rollback/prune/download/update)
     #[command(display_order = 9)]
     Pack(pack::Args),
     /// SDK transport surface (`run --mode live/plan`). Hidden: the user-facing

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -167,6 +167,41 @@ fn top_level_command_summaries_stay_short() {
 }
 
 #[test]
+fn top_level_command_descriptions_share_a_column() {
+    let command = cli_command();
+    let visible_command_names = command
+        .get_subcommands()
+        .filter(|subcommand| !subcommand.is_hide_set())
+        .map(|subcommand| subcommand.get_name().to_owned())
+        .collect::<Vec<_>>();
+    let error = command
+        .try_get_matches_from(["mvmctl", "--help"])
+        .expect_err("--help must stop argument parsing");
+    let help = constrain_help_output(&error.to_string());
+    let description_columns = visible_command_names
+        .iter()
+        .map(|name| {
+            let prefix = format!("  {name}");
+            let line = help
+                .lines()
+                .find(|line| line.starts_with(&prefix))
+                .unwrap_or_else(|| panic!("help is missing the `{name}` command:\n{help}"));
+            line[prefix.len()..]
+                .find(|character: char| !character.is_whitespace())
+                .map(|offset| prefix.len() + offset)
+                .unwrap_or_else(|| panic!("help is missing the `{name}` description:\n{help}"))
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        description_columns
+            .windows(2)
+            .all(|columns| columns[0] == columns[1]),
+        "top-level command descriptions must share one column; got {description_columns:?}:\n{help}"
+    );
+}
+
+#[test]
 fn deps_capture_parses_seal_inputs() {
     let cli = Cli::try_parse_from([
         "mvmctl",


### PR DESCRIPTION
## What changed

- Shortened the `deploy` and `pack` top-level summaries so the 80-column help renderer preserves Clap's shared description padding.
- Added a regression test that renders the real `--help` error path, applies the production width constraint, and asserts that every visible command description starts in the same column.

## Why

The post-render 80-column constraint collapses spacing on rows that exceed the width. The longer `deploy` and `pack` summaries therefore lost their padding and appeared misaligned even though Clap initially formatted the command table correctly.

## Impact

`mvmctl --help` now renders all visible command summaries in one aligned column. Command behavior and argument parsing are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p mvm-cli commands::tests::top_level_command_descriptions_share_a_column -- --exact --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --doc`
- Workspace nextest coverage: 10,916 tests passed in the default-concurrency run; its two unrelated 300 ms entrypoint timing tests passed individually on the rebased branch. A reduced-concurrency run passed those tests and 10,914 others; four concurrent host-agent startup tests then passed serially, and the source-tree scanner passed after generated worktree caches were excluded from its walk.
