### PR TITLE
perf(stream): wake the console follower on stop — 174ms of a 407ms teardown

### DIFF
--- a/crates/mvm-backends/src/driver/fc.rs
+++ b/crates/mvm-backends/src/driver/fc.rs
@@ -1002,12 +1002,31 @@ fn prepare_guest_filesystems_for_stop(vsock_uds: &str) -> Result<()> {
     require_guest_filesystem_flush(response)
 }
 
+/// Two spans, emitted at debug, splitting teardown into the only two things it
+/// does. `stop_transient` is one opaque number to the launch sample, and the
+/// guest flush and the kill-and-wait have unrelated costs and unrelated fixes —
+/// a vsock round-trip the guest controls, versus a signal plus a host-side poll
+/// loop. Without the split, a slow teardown cannot be attributed to either.
 fn stop_after_guest_flush(
     prepare: impl FnOnce() -> Result<()>,
     terminate: impl FnOnce() -> Result<()>,
 ) -> Result<()> {
-    prepare()?;
-    terminate()
+    let flush_started = Instant::now();
+    let prepared = prepare();
+    tracing::debug!(
+        ms = flush_started.elapsed().as_secs_f64() * 1000.0,
+        ok = prepared.is_ok(),
+        "fc stop: guest filesystem flush"
+    );
+    prepared?;
+
+    let terminate_started = Instant::now();
+    let terminated = terminate();
+    tracing::debug!(
+        ms = terminate_started.elapsed().as_secs_f64() * 1000.0,
+        "fc stop: signal + exit wait"
+    );
+    terminated
 }
 
 impl RunningVm for FcRunningVm {

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1571,13 +1571,23 @@ pub fn resolve_launch(
     // `run_supervisor` dispatch. Routing template restores through
     // admission would add an `admit_for_run` call here and a
     // `populate_audit_substrate` invocation after the struct literal.
+    // `admit_ms` is a window, not a call: it spans config assembly, admission,
+    // and the two artifact attachments. Admission instruments itself, and its
+    // spans account for roughly half the window, so the rest needs naming
+    // before any of it can be acted on.
+    let t_build = std::time::Instant::now();
     let mut start_config = build_start_config(shape, &vm_name, &image, &boot);
+    tracing::debug!(
+        ms = t_build.elapsed().as_secs_f64() * 1000.0,
+        "admit window: build_start_config"
+    );
     let mut use_snapshot = boot.use_snapshot;
 
     // Admit the transient run as a locally-signed workload. Setting
     // tenant_id + plan_json makes the runner-backed microVM supervisor enforce
     // `network_policy` and chain-audit the run. Force cold boot when admitted —
     // snapshot restore is unavailable for workload admission.
+    let t_admission = std::time::Instant::now();
     if let Some(admit_fn) = admit
         && let Some(sub) = admit_fn(std::path::Path::new(&image.rootfs), &vm_name)?
     {
@@ -1587,9 +1597,31 @@ pub fn resolve_launch(
         start_config.config_files.extend(sub.config_files);
         use_snapshot = false;
     }
+    tracing::debug!(
+        ms = t_admission.elapsed().as_secs_f64() * 1000.0,
+        "admit window: admission"
+    );
+
+    let t_overlay = std::time::Instant::now();
     crate::commands::vm::up::attach_runtime_overlay_if_cached(&mut start_config, backend.name())?;
+    tracing::debug!(
+        ms = t_overlay.elapsed().as_secs_f64() * 1000.0,
+        "admit window: attach runtime overlay"
+    );
+
+    let t_initramfs = std::time::Instant::now();
     crate::commands::vm::up::attach_universal_initramfs_if_cached(&mut start_config)?;
+    tracing::debug!(
+        ms = t_initramfs.elapsed().as_secs_f64() * 1000.0,
+        "admit window: attach universal initramfs"
+    );
+
+    let t_status = std::time::Instant::now();
     crate::commands::vm::up::emit_runtime_source_status(&start_config);
+    tracing::debug!(
+        ms = t_status.elapsed().as_secs_f64() * 1000.0,
+        "admit window: runtime source status"
+    );
     marks.admitted = marks.now();
 
     Ok(ResolvedLaunch {

--- a/crates/mvm-hostd/src/stream/console_source.rs
+++ b/crates/mvm-hostd/src/stream/console_source.rs
@@ -33,8 +33,7 @@ use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::os::unix::fs::MetadataExt;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard, PoisonError};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -51,6 +50,43 @@ pub type SharedBroker = Arc<Mutex<StreamBroker>>;
 
 /// How often the follower re-checks the file for new bytes.
 const POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// The follower's stop flag, waitable so a stop does not have to sit out the
+/// rest of the current poll interval.
+///
+/// A plain flag plus `sleep` made stopping cost whatever remained of
+/// [`POLL_INTERVAL`], which is paid on the teardown path of every workload and
+/// measured as the largest single span of a transient stop. Waiting on a
+/// condvar keeps the same idle cadence when nothing is happening while making
+/// the stop itself immediate.
+#[derive(Default)]
+struct StopSignal {
+    stopped: Mutex<bool>,
+    wake: Condvar,
+}
+
+impl StopSignal {
+    /// Recovered rather than propagated on poison, matching the rest of this
+    /// module: a panicking producer must not strand a follower thread that
+    /// would otherwise exit cleanly.
+    fn set(&self) {
+        *self.stopped.lock().unwrap_or_else(PoisonError::into_inner) = true;
+        self.wake.notify_all();
+    }
+
+    fn is_set(&self) -> bool {
+        *self.stopped.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Idle for at most `timeout`, returning as soon as a stop lands.
+    fn wait(&self, timeout: Duration) {
+        let stopped = self.stopped.lock().unwrap_or_else(PoisonError::into_inner);
+        if *stopped {
+            return;
+        }
+        let _ = self.wake.wait_timeout(stopped, timeout);
+    }
+}
 
 /// Largest read per poll tick. Bounds one tick's memory use even after the
 /// file grew hugely while the follower was busy elsewhere; the remainder is
@@ -104,7 +140,7 @@ impl ConsoleSource {
         path: &Path,
         broker: SharedBroker,
     ) -> io::Result<ConsoleSourceHandle> {
-        let stop = Arc::new(AtomicBool::new(false));
+        let stop = Arc::new(StopSignal::default());
         let thread_stop = Arc::clone(&stop);
         let owned_path = path.to_path_buf();
         let thread = match builder
@@ -134,7 +170,7 @@ impl ConsoleSource {
 /// no thread behind — `stop` is the documented, join-and-confirm way to end
 /// it, not the only way it ends.
 pub struct ConsoleSourceHandle {
-    stop: Arc<AtomicBool>,
+    stop: Arc<StopSignal>,
     thread: Option<JoinHandle<()>>,
 }
 
@@ -149,7 +185,7 @@ impl ConsoleSourceHandle {
     }
 
     fn join(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
+        self.stop.set();
         if let Some(thread) = self.thread.take() {
             // A follower panic is not this caller's problem to propagate;
             // the thread is already gone either way once join returns.
@@ -168,22 +204,22 @@ impl Drop for ConsoleSourceHandle {
 /// chunks so a stop signal is honored within one chunk read even under a
 /// heavy backlog, then idle-poll once caught up. A stop request takes the
 /// bounded final drain on the way out rather than returning on the spot.
-fn run(path: &Path, broker: &SharedBroker, stop: &AtomicBool) {
+fn run(path: &Path, broker: &SharedBroker, stop: &StopSignal) {
     let mut state = FollowState::default();
     loop {
         while poll_once(path, &mut state, broker) {
-            if stop.load(Ordering::Relaxed) {
+            if stop.is_set() {
                 return final_drain(path, &mut state, broker);
             }
         }
-        if stop.load(Ordering::Relaxed) {
+        if stop.is_set() {
             // Drains here too, not just out of the loop above. A caught-up
             // tick followed by a write and a stop — the exact shape of a
             // workload's last line before teardown — would otherwise exit on
             // a stop flag set after the poll that missed those bytes.
             return final_drain(path, &mut state, broker);
         }
-        std::thread::sleep(POLL_INTERVAL);
+        stop.wait(POLL_INTERVAL);
     }
 }
 

--- a/crates/mvm-hostd/src/stream/plane.rs
+++ b/crates/mvm-hostd/src/stream/plane.rs
@@ -601,10 +601,26 @@ fn seal_capture(vm: &str, stream: VmStream) {
         broker,
         transcript_dir,
     } = stream;
+    // Teardown reports console cleanup as one number, and it is the largest
+    // span of a transient stop. The work behind it is two independent writer
+    // joins and a manifest write, so the total is not actionable until split.
+    let t_console = std::time::Instant::now();
     if let Some(console) = console {
         console.stop();
     }
+    tracing::debug!(
+        vm = %vm,
+        ms = t_console.elapsed().as_secs_f64() * 1000.0,
+        "seal: console writer stop"
+    );
+
+    let t_server = std::time::Instant::now();
     server.stop();
+    tracing::debug!(
+        vm = %vm,
+        ms = t_server.elapsed().as_secs_f64() * 1000.0,
+        "seal: server writer stop"
+    );
 
     let Some(broker) = Arc::into_inner(broker) else {
         // Unreachable while the two joins above are the only other holders,

--- a/crates/mvm-runtime/src/workload_runner/runner/backend.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner/backend.rs
@@ -171,7 +171,21 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 
     }
 
     fn stop(&self, id: &VmId) -> Result<()> {
-        self.stop_with_timing(id).map(|_| ())
+        let timing = self.stop_with_timing(id)?;
+        // `stop_transient` reaches teardown through here, and the launch sample
+        // records only the one opaque total for it. The breakdown is computed on
+        // every stop regardless, so dropping it left the majority of a teardown
+        // unattributable while the numbers already existed.
+        tracing::debug!(
+            vm = %id.0,
+            attach_ms = timing.attach.as_secs_f64() * 1000.0,
+            endpoint_reaping_ms = timing.endpoint_reaping.as_secs_f64() * 1000.0,
+            driver_kill_ms = timing.driver_kill.as_secs_f64() * 1000.0,
+            console_cleanup_ms = timing.console_cleanup.as_secs_f64() * 1000.0,
+            total_ms = timing.total.as_secs_f64() * 1000.0,
+            "stop: teardown breakdown"
+        );
+        Ok(())
     }
 
     fn stop_all(&self) -> Result<()> {


### PR DESCRIPTION
Teardown of a transient `machine run` is 406.8 ms p50 on Linux/KVM. This attributes all of it and fixes the largest piece.

## What the numbers said

Firecracker, x86_64, release, `machine run --image alpine -- /bin/true`, warmup then 3 runs, `degraded` empty:

```
attach              3.5 ms
endpoint_reaping    1.3 ms
driver_kill       113.9 ms
console_cleanup   288.2 ms   <- 71%
total             406.8 ms
```

and inside `console_cleanup`:

```
seal: console writer stop  173.7 ms
seal: server writer stop    25.2 ms
```

## The fix

`ConsoleSource` tails `console.log` on a 200 ms sleep. `stop()` set an `AtomicBool` and joined, so teardown sat out whatever remained of the current tick before the thread noticed — 173.7 ms of pure waiting for a VM that was already dead.

A small `StopSignal` (`Mutex<bool>` + `Condvar`) keeps the same idle cadence when nothing is happening and makes the stop immediate. Poison is recovered rather than propagated, matching the rest of the module: a panicking producer must not strand a follower that would otherwise exit cleanly.

## Why the rest of this is here

`WorkloadRunner::stop_with_timing` already measured `attach` / `endpoint_reaping` / `driver_kill` / `console_cleanup` on **every** stop, and `VmBackend::stop` threw the whole breakdown away with `.map(|_| ())`. The launch sample carried one opaque `stop_transient` number, so ~290 ms of a 400 ms teardown could not be attributed to anything. The numbers already existed; only the reporting was missing.

Two span splits are kept because they are what made this findable, and the same blind spot exists elsewhere:

- `seal_capture` → console writer stop vs server writer stop
- the **admit window** → its five segments. `admit_ms` is `ms(drives_ready → admitted)`, a *window* containing config assembly, admission, and two artifact attachments — not a call. Admission instruments itself and accounts for only ~149 ms of a 280 ms window.

## What is deliberately not here

- **`escalate_kill`'s flat 100 ms tick.** I had this fix locally; #2330 shipped the same change first. Dropped rather than conflicted.
- **Detaching the transcript seal off the critical path.** That would remove the remaining ~90 ms of `console_cleanup`, but `StreamRetention` comes off the signed plan, so returning before a durable transcript exists is a semantic change, not a latency one. It deserves its own PR with a barrier for transcript readers.

## Validation

`cargo check` and full `cargo nextest` on `mvm-hostd` and `mvm-backends` pass, including the existing follower stop-semantics coverage (`stop_terminates_the_follower_without_losing_already_read_bytes`) — the drain-before-exit behaviour is what the condvar must not regress.

A before/after run on the KVM box is in flight; I will post the delta here. If `console_cleanup` does not move, this does not merge.

Refs #2323.