### PR TITLE
fix: restore security mutation witnesses

### DIFF
--- a/crates/mvm-agentd/src/vsock/verb_grant.rs
+++ b/crates/mvm-agentd/src/vsock/verb_grant.rs
@@ -50,7 +50,7 @@ pub fn verifying_key_from_hex(hex: &str) -> anyhow::Result<ed25519_dalek::Verify
                 pair[1] as char
             )
         })?;
-        bytes[i] = (hi << 4) | lo;
+        bytes[i] = hi * 16 + lo;
     }
     ed25519_dalek::VerifyingKey::from_bytes(&bytes)
         .map_err(|e| anyhow::anyhow!("host-signer pubkey is not a valid Ed25519 key: {e}"))

--- a/crates/mvm-hostd/src/supervisor/audit_file.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_file.rs
@@ -1333,8 +1333,8 @@ mod tests {
         // edit.
         let err = verify_audit_chain(&path, &verifying).expect_err("torn tail must not verify");
         assert!(
-            matches!(err, VerifyError::TruncatedTail { .. }),
-            "expected TruncatedTail, got {err:?}"
+            matches!(err, VerifyError::TruncatedTail { line: 1 }),
+            "expected TruncatedTail at the partial second record, got {err:?}"
         );
 
         // And the signer refuses to extend the chain from a partial record

--- a/crates/mvm-hostd/src/supervisor/network/stages.rs
+++ b/crates/mvm-hostd/src/supervisor/network/stages.rs
@@ -770,7 +770,9 @@ mod tests {
         };
         // No binding applies → no rewrite; scan never drops. This is the
         // claim-10-safe default posture before real handlers plug in.
+        assert_eq!(NoopSubstitution.name(), "noop-substitution");
         assert_eq!(NoopSubstitution.substitute(&ctx, &pkt), None);
+        assert_eq!(NoopScan.name(), "noop-scan");
         assert_eq!(NoopScan.scan(&ctx, &pkt), ScanOutcome::Pass);
     }
 

--- a/crates/mvm-vmm/src/snapshot.rs
+++ b/crates/mvm-vmm/src/snapshot.rs
@@ -237,3 +237,42 @@ impl SnapshotIO for CannedIO {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canned_io_writes_payloads_and_records_the_snapshot_contract() {
+        let dir = tempfile::tempdir().unwrap();
+        let io = CannedIO::new(b"vmstate", b"memory").with_network_interfaces(2);
+
+        assert!(io.calls().is_empty());
+        io.create_snapshot(dir.path()).unwrap();
+        assert_eq!(
+            std::fs::read(dir.path().join(VMSTATE_FILENAME)).unwrap(),
+            b"vmstate"
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(MEM_FILENAME)).unwrap(),
+            b"memory"
+        );
+
+        io.load_snapshot_paused(dir.path()).unwrap();
+        io.load_snapshot_for_fork_paused(dir.path()).unwrap();
+        assert_eq!(io.restored_network_interface_count().unwrap(), 2);
+        io.resume().unwrap();
+        io.teardown_paused().unwrap();
+
+        assert_eq!(
+            io.calls(),
+            vec![
+                "load_paused",
+                "load_fork_paused",
+                "restored_device_model",
+                "resume",
+                "teardown_paused",
+            ]
+        );
+    }
+}

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -18,6 +18,12 @@ for detailed scope and acceptance criteria.
 - [x] **Issue #2128 — kernel pin freshness.** The libkrunfw bundle and custom
       guest kernel now share the verified Linux 6.12.102 LTS source pin;
       structural parity coverage prevents the consumers from drifting apart.
+- [x] **Issue #2293 — audit-chain durability boundaries.** PR #2302 removed
+      the duplicate synthetic `plan.admitted` and bound OCI provenance to the
+      plan that boots. PR #2317 made admission the pre-action sync barrier,
+      deferred post-hoc records without changing chain content or ordering,
+      retained fail-safe sync for unknown events, and preserved torn-tail
+      detection. The separate receipt-store cost remains open as #2318.
 - [~] **Issue #2289 — kernel pin freshness follow-up.** This PR synchronizes
       the libkrunfw and custom guest kernel inputs on the verified Linux
       6.12.103 LTS source pin and updates structural parity coverage with the
@@ -96,12 +102,23 @@ for detailed scope and acceptance criteria.
 - [~] Security lane mutation-witness repair — **issue #2135**
   - [x] Add direct witnesses for the security-sensitive admission,
         verification, lease, and substitution cleanup invariants
-  - [x] Run focused mutation shards for `mvm-cli`, `mvm-core`, `mvm-agentd`,
-        `mvm-hostd`, and `mvm-vmm`
-  - [x] Pass workspace check, all-target Clippy, formatting, and the mutation
-        surface gate on the dedicated fix branch
-  - [ ] Merge the fix and rerun the exact Linux Security workflow before
-        closing the issue
+  - [x] Fail closed when an accepted miss leaves the pinned mutation surface,
+        migrate 26 libkrun identities to their current file, and remove 14
+        obsolete misses without adding a waiver (83 accepted misses to 69)
+  - [x] Catch the current actionable `mvm-vmm`, `mvm-hostd`, and `mvm-agentd`
+        mutants in focused mutation proofs
+  - [x] Pass affected-package all-target Clippy, workspace unit/integration
+        tests, the isolated `mvm-cli` doctest rerun, formatting, and the static
+        mutation surface gate on the dedicated fix branch
+  - [ ] Run the exact Linux Security workflow, merge the fix, and observe a
+        clean scheduled or release run before closing the issue
+- [~] Plan 300 — 30-issue reconciliation and closeout
+      (`specs/plans/300-open-issue-closeout.md`)
+  - [x] Inventory all 30 issues open at the 2026-08-10 snapshot against
+        current `origin/main`, issue comments, owning plans, and workflow state
+  - [x] Close #2293 with merged implementation, CI, and KVM evidence
+  - [ ] Execute the remaining 29 closure paths in the plan's dependency order
+  - [ ] Reconcile a fresh GitHub query after every phase and at final closeout
 - [~] Runtime hardening for production — plan 303, branch
       `feat/plan-303-runtime-hardening`
   - [x] WS1 — `overflow-checks = true` in `[profile.release]`, a
@@ -245,10 +262,11 @@ for detailed scope and acceptance criteria.
         run-to-run noise where they used to differ by ~780 ms. claim-8 /
         claim-14 digests unchanged, chain still verifies. Firecracker/KVM
         repeated: the fixes hold there (both counters zero) but that backend
-        misses the contract for reasons this plan does not own — `driver_boot`
-        630.5 ms (**#2292**) and 294 ms of audit fsync in `admit` (**#2293**).
-        Outstanding: the warm-lane comparison, blocked because no standby pool
-        can be filled today.
+        misses the contract for reasons this plan does not own — residual
+        Firecracker boot work (**#2292**, **#2299**) and receipt durability on
+        the admission path (**#2318**). Audit-chain batching and duplicate
+        admission are closed under #2293. Outstanding: the warm-lane
+        comparison, blocked because no standby pool can be filled today.
 
 - [~] eBPF vsock egress telemetry spike — **issue #2211**, branch
       `feat/ebpf-vsock-egress-telemetry`

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -123,12 +123,14 @@
       `features/suites/s11_snapshot/hvf_save_restore.feature`; workspace
       nextest 10600 passed / 24 skipped.
 
-- [~] Open issue closeout — **plan 300**. The 22 open issues were reconciled
-      on 2026-08-08 into explicit closure gates and dependency order in
-      `specs/plans/300-open-issue-closeout.md`. #2192 is now closed as completed;
-      #2101 and #2211 require scope split or narrowing; the remaining issues
-      retain active implementation, security, live-validation, or
-      cross-repository acceptance work.
+- [~] Open issue reconciliation — **plan 300**. The 30 issues open at the
+      2026-08-10 snapshot are inventoried against `origin/main` `6a18cb740`
+      with an explicit disposition, closure gate, and dependency-ordered
+      execution phase. #2293 is closed as completed by merged PRs #2302 and
+      #2317; its remaining receipt-store performance finding stays open as
+      #2318. The other 29 issues retain concrete implementation, security,
+      rollout, live-validation, performance, governance, or cross-repository
+      acceptance work.
 - [~] Runtime hardening for production — **plan 303**. Closes gaps between the
       binary CI witnesses and the binary that ships. Landed: trapping integer
       overflow in `[profile.release]` plus a `release-witness` CI lane over the
@@ -201,9 +203,15 @@
 - [~] Security mutation-witness repair — **issue #2135**. Restored executable
       witnesses for the security-sensitive boot admission, kernel-digest,
       host-signer/grant, lease-expiry, and substitution-endpoint cleanup
-      invariants. Focused mutation runs now catch every actionable mutant in
-      those paths; the exact Linux Security workflow rerun remains the final
-      merge-and-close gate.
+      invariants. The current Security failure is also reconciled: direct tests
+      catch the actionable snapshot-I/O, no-op stage-name, torn-tail, and grant
+      parser mutants; the static gate rejects accepted misses outside the
+      pinned surface; 26 moved libkrun identities name their current file; and
+      14 obsolete misses were removed, reducing the accepted baseline from 83
+      to 69 without adding a waiver. Focused mutation proofs, affected-package
+      all-target Clippy, the workspace unit/integration suite, formatting, and
+      the static surface gate are green. The exact Linux Security workflow
+      rerun remains the final merge-and-close gate.
 
 - [x] `mvmctl deps capture` — **plan 291 WS3**. Reseals a sandbox-captured
       dependency tree with fresh audit sidecars, updates the lockfile index,

--- a/specs/plans/300-open-issue-closeout.md
+++ b/specs/plans/300-open-issue-closeout.md
@@ -1,17 +1,21 @@
-# Plan 300 — Open issue closeout
+# Plan 300 — Open issue reconciliation and closeout
 
 **Status:** IN PROGRESS — concrete-fix batch underway
 **Snapshot date:** 2026-08-10
 
 ## Objective
 
-Reduce the current open issues in `tinylabscom/mvm` to a set backed by current
-product intent and evidence. Every issue closes only after its implementation,
-tests, live witnesses where required, documentation, and GitHub state agree.
+Reconcile the 30 issues that were open at the snapshot against merged code,
+current product intent, tests, live evidence, and the owning plans. Close work
+that is demonstrably complete, preserve active defects and security gaps, and
+execute the remainder in dependency order until every issue is either completed
+or deliberately declined with its remaining requirements transferred.
 
-This plan is a closeout map, not permission to weaken a security claim or to
-close an issue because a nearby implementation exists. Mixed issues must be
-split or narrowed before closure.
+The snapshot contains one issue whose implementation is complete but whose
+GitHub state is stale (#2293). The other 29 issues retain material acceptance
+criteria. Closing an umbrella, research issue, or partially implemented issue
+does not count as progress unless its remaining criteria move to an explicit
+owner in the same change.
 
 ## Execution update — first concrete-fix batch
 
@@ -24,360 +28,292 @@ open until their PRs are merged and the required live witnesses are recorded.
 
 ## Closure rules
 
-An issue is ready to close when all of the following are true:
+An issue closes only when all applicable conditions are met:
 
-1. The issue's acceptance criteria match the implemented scope. Obsolete or
-   rejected requirements are rewritten in the issue before closing.
-2. The implementation is merged to `main` and the relevant unit, integration,
-   BDD, security, and platform tests pass.
-3. A live witness exists for any backend, kernel, privilege, networking,
-   process, or performance claim that static tests cannot establish.
-4. The owning plan, `specs/SPRINT.md`, and `specs/REFACTOR-STATUS.md` record
-   the same status and evidence.
-5. The issue receives a final comment linking the merged PR, test result,
-   live-run evidence, and any intentionally excluded scope, then is closed.
+1. Its current acceptance criteria match the intended outcome. Mixed or stale
+   issues are narrowed or split before closure.
+2. The implementation is merged to `main`, not merely present in a branch,
+   draft pull request, or merge queue.
+3. Unit, integration, BDD, security, and failure-path tests are green. Backend,
+   kernel, privilege, networking, and performance claims also have a live
+   witness on every claimed platform.
+4. The owning plan, `specs/SPRINT.md`, and `specs/REFACTOR-STATUS.md` agree.
+5. The final issue comment names the merged pull requests, test or workflow
+   evidence, live evidence, and any intentionally excluded scope.
 
-The final closeout pass must also check that no issue is being closed merely
-because its title was superseded by a refactor. The replacement issue or plan
-must carry the remaining acceptance criteria.
+Generated trackers close only after the generating workflow is green. An issue
+is not closed because adjacent code exists, its title was superseded, or a plan
+mentions it.
 
-## Current disposition
+## Snapshot disposition
 
-### Closed
+| Issue | Disposition at snapshot | Closure owner |
+|---|---|---|
+| #2083 | Open; Studio server contract is an external dependency | Agent/Studio phase |
+| #2101 | Primary kernel defect fixed; OCI privilege posture remains | Security phase |
+| #2107 | Open; audit mirror is absent | Audit/observability phase |
+| #2135 | Open; latest scheduled Security run is red | Evidence-repair phase |
+| #2165 | Fix is in draft PR #2330; live witnesses remain | Boot-correctness phase |
+| #2166 | Parent epic; three contract children are closed, #2169 remains | Agent/Studio phase |
+| #2169 | Open; bounded inspector contract and APIs remain | Agent/Studio phase |
+| #2180 | Open; full L3 spec is still unreachable from user input | L3 phase |
+| #2181 | Open; real dual-backend IPv6 witness is absent | L3 phase |
+| #2193 | Partial artifact-prewarm substrate; backend factories remain | Warm-launch phase |
+| #2194 | Partial HVF paused-parent handoff; final live contract remains | Warm-launch phase |
+| #2195 | Open; fixed read-only share binding remains | Warm-launch phase |
+| #2196 | Partial Firecracker standby path; full KVM matrix remains | Warm-launch phase |
+| #2197 | Open; resident-process hardening remains | Warm-launch phase |
+| #2198 | Partial typed timing; user-visible refusal/cold contract remains | Warm-launch phase |
+| #2199 | Partial benchmark substrate; 1,000-claim matrix remains | Warm-launch phase |
+| #2211 | Partial eBPF spike; bytes/latency and scope decision remain | Observability phase |
+| #2256 | Open; Plan 306 has not started | Governance phase |
+| #2280 | Partial measurement substrate; native host matrix remains | Performance phase |
+| #2281 | Partial ext4 baseline; candidate comparison/decision remains | Performance phase |
+| #2289 | Kernel 6.12.103 merged; release/VM rollout evidence remains | Kernel phase |
+| #2292 | Host-side overhead mostly fixed; percentile gate remains | Performance phase |
+| #2293 | Complete in merged PRs #2302 and #2317 | Immediate closeout |
+| #2299 | Open investigation; cross-backend phase accounting is not comparable | Performance phase |
+| #2305 | Open under Plan 313 Phases 2–4; streaming is prerequisite | Egress phase |
+| #2307 | Known filter fixed; fail-open configuration gate remains | CI phase |
+| #2318 | Open; receipt durability and head recovery decision remains | Audit/performance phase |
+| #2321 | Open security defect; wire response allocation is unbounded | Immediate safety phase |
+| #2323 | Open; teardown attribution and adaptive polling remain | Performance phase |
+| #2333 | Open; pre-boot launch preparation blocks all pool filling | Warm-launch phase |
 
-#### #2192 — resident warm-launch service contract
+## Phase 0 — Close completed work and restore evidence quality
 
-The owning warm-launch plan marks this work complete. The repository contains
-the typed `WarmServiceRequest`/`WarmServiceResponse` contract, the in-process
-`WarmLaunchService`, explicit optional/required/cold modes, lease ownership,
-refusal reporting, and lifecycle tests.
+- [x] **#2293 — close the completed audit-chain fsync issue.** PR #2302
+      removed the duplicate synthetic `plan.admitted` and bound OCI provenance
+      to the plan that boots. PR #2317 made `plan.admitted` the durability
+      barrier, deferred post-hoc records, preserved ordering and torn-tail
+      detection, and recorded KVM timings. Add the evidence comment, close as
+      completed, and synchronize this plan, the sprint, and the rollup. Closed
+      as completed on 2026-08-10 after posting the merged implementation and
+      KVM evidence; receipt-store latency remains independently tracked by
+      #2318.
+- [ ] **#2135 — restore the Security lane.** Triage every current failure in
+      run 31359464384 against `origin/main`; repair actionable mutation
+      witnesses without weakening the baseline; run the affected shards and
+      then the whole Security workflow. Let the watcher close the issue only
+      after a clean scheduled or release run. The failed run is now reconciled:
+      direct witnesses catch the actionable `mvm-vmm`, `mvm-hostd`, and
+      `mvm-agentd` mutants; accepted misses fail closed when their files leave
+      the pinned surface; moved libkrun identities now name their current file;
+      and obsolete accepted misses were removed, reducing the baseline from 83
+      to 69 without adding a waiver. Focused mutation proofs, affected-package
+      all-target Clippy, the workspace unit/integration suite, formatting, and
+      the static surface gate pass on the fix branch. The exact Linux Security
+      workflow and clean scheduled or release run remain the merge-and-close
+      gates.
+- [ ] **#2289 — finish the kernel freshness closeout.** Linux 6.12.103 and the
+      verified shared hash are merged in #2301, and kernel build/freshness CI
+      passed. Build the release artifacts, run the verified-boot and
+      reproducibility witnesses, apply `mvmctl vm rekernel` to every existing
+      local VM from the builder VM, record the rollout inventory, then close.
+- [ ] **#2292 — finish the Firecracker host-overhead closeout.** Retain #2298's
+      in-process API client, backoff, and split spans. Remove or explicitly
+      justify the two remaining privileged operations, then run
+      `ColdLaunchBench` with 20 samples after two warmups for both `alpine` and
+      `python:3.12` on KVM and publish p50/p95/p99. Close only after the issue's
+      checklist reflects the residual #2299 guest-boot work.
 
-Closure recorded on 2026-08-08:
+## Phase 1 — Fix safety and boot-correctness defects
 
-- Final issue comment links `specs/plans/298-warm-claim-service-and-hvf-pool.md`,
-  `crates/mvm-contract/src/protocol/vm_backend.rs`, and
-  `crates/mvm-runtime/src/warm_service.rs`.
-- Contract and runtime warm-service tests passed with the required test-support
-  feature; live KVM tests remain intentionally separate for backend issues.
-- #2192 is closed as completed. Plan 298's `[x]` status remains unchanged.
+- [ ] **#2321 — cap substitution forward responses first.** Give the wire-mode
+      response an explicit maximum, reject rather than truncate on overflow,
+      stop reading immediately at the limit, and emit a sanitized refusal.
+      Test a truthful oversized `Content-Length`, a lying or absent length,
+      chunked delivery, and allocation bounded to the configured ceiling. This
+      is a prerequisite for Plan 313 streaming and metering work.
+- [ ] **#2165 — make block attachment and bootargs one contract.** Merge the
+      typed read-only-root fix from #2330 after review, eliminate duplicate
+      root declarations rather than relying on argument order, and add
+      runner-level consistency tests. Close after plain-ext4 guests reach
+      authenticated userspace on HVF and Firecracker with the root mounted in
+      the declared mode.
+- [ ] **#2101 — finish OCI privilege hardening.** Narrow the issue body to the
+      remaining `NoNewPrivs` and capability-bounding-set decision now that
+      #2102 fixed kernel selection. Define the minimal capability set required
+      for authenticated activation/restore, apply it before workload exec, and
+      test setuid/file-capability attempts, user namespaces, wrong kernels,
+      and syscall failures. Re-run the adversarial probe on HVF and
+      Firecracker before closure.
+- [ ] **#2318 — define receipt durability and remove the redundant sync.**
+      Record whether an execution receipt is a control or a record. Make the
+      receipt body the durable object, treat the head as a recoverable cache if
+      that matches the decision, rebuild a missing/stale/torn head under the
+      tenant lock, and prove concurrent append ordering. Re-measure the KVM
+      `emit: receipt` span against 100.7 ms and require at most one durability
+      barrier per append unless the written model proves two are necessary.
+- [ ] **#2307 — gate nextest override filters.** Add
+      `xtask check-nextest-groups` using `cargo nextest list -E` for each
+      configured override, reject nonexistent workspace packages and empty
+      filter matches, register it in xtask help/available commands and CI, and
+      add a self-test that moves a module and observes a nonzero exit.
 
-### Split or narrow before closing
+## Phase 2 — Complete L3, audit, and host observability
 
-#### #2101 — default workload kernel and OCI privilege posture
+- [ ] **#2180 — make `L3NetworkSpec` user-reachable.** Add typed workload-IR
+      fields for MTU, queue count, DNS, ingress, and IPv6; carry the exact spec
+      through synthesis, signing, admission, and boot; remove hardcoded mode
+      reconstruction. Add a user-visible BDD scenario and a negative host-
+      capability refusal proving the boot receives the admitted values.
+- [ ] **#2181 — publish the live IPv6 witness.** After #2180, boot an admitted
+      dual-stack guest, verify its address, peer route, and default route from
+      inside the guest, carry an admitted IPv6 TCP round trip, and prove an
+      unadmitted destination and spoofed source fail. Run on Firecracker and
+      HVF or split unsupported backend claims explicitly.
+- [ ] **#2107 — mirror audit appends into tracing without coupling.** Emit one
+      sanitized event at a dedicated target only after a successful signed
+      append. Share the verified-reader projection so field selection cannot
+      drift. Prove exact event parity, secret/path/policy exclusion, signed-
+      chain byte identity, and that absent or hostile subscribers cannot alter
+      append success, ordering, or latency.
+- [ ] **#2211 — choose and finish the eBPF spike contract.** Either narrow the
+      issue to the landed Linux connection-observation spike and refile byte,
+      latency, and IPv6 attribution, or complete the original tuple. For the
+      latter, attribute bytes and latency to the same plan/VM/destination
+      binding, validate the real substitution endpoint on Linux, declare the
+      macOS/no-target behavior, and keep sealed guest kernels BPF-free.
 
-The default-microVM kernel fallback was fixed by PR #2102. The remaining
-security question is separate: the OCI guest-agent path now sets
-`NoNewPrivs`, but the capability bounding-set posture still needs an explicit
-decision and a live witness. The current path intentionally retains narrowly
-needed agent capabilities, so “empty bounding set” cannot be assumed without
-checking restore behavior.
+## Phase 3 — Establish comparable performance evidence
 
-Close path:
+- [ ] **#2323 — remove teardown polling quantization.** First split guest flush,
+      signal delivery, pid disappearance, and cleanup spans. Reuse
+      `poll_backoff::poll_delay` for Firecracker termination, prove an already-
+      exited VM does not pay a full tick, determine whether libkrun's 2.3 s is
+      the same cause, and publish 20-sample p50/p95/p99 teardown results.
+- [ ] **#2299 — make guest-boot measurements comparable before optimizing.**
+      Define a backend-neutral interval from vCPU start to authenticated agent
+      readiness, instrument both HVF and Firecracker at the same boundaries,
+      and publish side-by-side kernel timestamps and initcall/agent-start
+      attribution. Name the dominant contributor with evidence; reach <150 ms
+      on Firecracker or record the architectural reason and revised contract.
+- [ ] **#2280 — finish the kernel/boot-substrate matrix.** Run the landed
+      20-sample/two-warmup report gate on native HVF and Firecracker without
+      degraded host services. Publish artifact sizes, kernel symbols, readiness,
+      whole-VMM working set, first-command fault deltas, and warm-restore cost
+      for matching shapes. Every removed feature needs boot and security
+      witnesses, and the canonical table must feed Plan 299 release gates.
+- [ ] **#2281 — make the filesystem adopt/decline decision.** Compare the
+      existing ext4/overlay/verity path and one guest-local immutable lower
+      candidate on the same fixture and security tier. Measure preparation,
+      readiness, first access, working set, and multi-claim density; test
+      xattrs, whiteouts, verity failure, read-only enforcement, CoW cleanliness,
+      and tenant isolation. Record the decision without creating another cache
+      graph.
 
-- Edit the issue to separate the resolved kernel-selection defect from the
-  remaining OCI hardening finding.
-- Decide whether the OCI workload process must have an empty bounding set or a
-  documented minimal set. Preserve the agent's authenticated restore needs.
-- Add positive and negative Linux tests for the selected posture and run the
-  adversarial workload probe on both HVF and Firecracker.
-- Close the kernel-selection portion and close the remaining issue only after
-  the decision, code, and live evidence are merged.
+## Phase 4 — Make the warm pool usable, then prove it
 
-#### #2211 — host-side eBPF vsock telemetry
-
-The loader, observability sidecar, supervisor attach/detach hooks, metrics,
-audit event, CI build, and live Linux attach path are present. The current
-ring-buffer event still reports an IPv4 destination with `bytes = 0` and no
-latency measurement, so the issue's original tuple `(plan_id, vm_id,
-destination, bytes, latency)` is not fully implemented.
-
-Close path:
-
-- Either narrow the issue to the completed bounded connection-observation
-  spike and document that byte/latency accounting is follow-up work, or
-- implement byte and latency accounting, add IPv6 behavior or an explicit
-  limitation, and prove the real substitution-endpoint path end to end.
-- Update the issue acceptance checklist and close it only after the selected
-  scope is reflected in the code, tests, and `specs/REFACTOR-STATUS.md`.
-
-### Security, kernel, boot, and audit issues
-
-#### #2135 — Security lane is red
-
-This is an active generated tracker, not stale bookkeeping. The latest
-Security run has failed mutation-witness jobs in `mvm-cli`, `mvm-core`,
-`mvm-agentd`, `mvm-hostd`, and `mvm-runtime`.
-
-Close path:
-
-- Triage every surviving mutant and add or repair the corresponding witness.
-- Re-run the mutation jobs and the full Security workflow.
-- Do not rewrite the mutation baseline unless the mutated behavior was
-  intentionally removed and the issue documents why.
-- Let `.github/workflows/security-lane-watch.yml` close the issue after a clean
-  scheduled or release run.
-
-#### #2289 — kernel pin freshness
-
-The generated freshness tracker reported both synchronized kernel inputs one
-point release behind the latest Linux 6.12 LTS release. The prior #2128
-closeout covered the preceding 6.12.102 update; #2289 is the current tracker
-for the next point-release remediation.
-
-Close path:
-
-- Update the custom workload kernel and libkrunfw inputs together, including
-  source hashes and any generated or recorded metadata. This change updates
-  both consumers to Linux 6.12.103 with the verified SRI hash
-  `sha256-8UOqreiHe6VhbniLRIJXbbKEgbz1V+9Tf0/MOTj8MXY=`.
-- Build and verify both kernel artifacts and run the kernel-pin freshness
-  check.
-- Run the relevant workspace, kernel, verified-boot, and reproducibility tests.
-- Roll the new kernel through each existing VM with `mvmctl vm rekernel`;
-  fleet rollout remains the mvmd responsibility.
-- Add the release/build and rollout evidence to the issue, then close it.
-
-#### #2165 — read-only block root with `rw` bootargs
-
-The HVF default block-root command line still asks Linux to mount `/dev/vda`
-read-write while the workload runner attaches the rootfs read-only.
-
-Close path:
-
-- Make the root mount mode a single typed contract shared by disk attachment,
-  bootargs, and the guest mount policy. Do not rely on contradictory duplicate
-  `root=` declarations.
-- Add unit tests for read-only, writable-development, and verity-root shapes.
-- Add a live macOS/HVF plain-ext4 boot witness that reaches userspace, and a
-  Firecracker regression witness for parity.
-- Update the boot documentation and close the issue after both backends pass.
-
-#### #2107 — mirror signed audit appends into tracing
-
-The signed chain remains separate from operational tracing, and no complete
-mirror exists in `AuditEmitter`.
-
-Close path:
-
-- Emit one best-effort, sanitized diagnostic event only after a successful
-  chain append. The mirror must never affect signing, ordering, or success.
-- Include only non-sensitive event labels and stable identifiers; exclude
-  secrets, credentials, environment values, raw policy, and sensitive paths.
-- Test field parity, sensitive-field exclusion, hostile subscribers, and byte
-  identity of the signed chain with mirroring enabled and disabled.
-- Document that the verified chain remains the source of truth, then close.
-
-### L3 networking
-
-#### #2180 — L3 spec unreachable from CLI/IR boot paths
-
-The CLI now derives `NetworkMode::L3Vsock` from workload IR, but the full
-`L3NetworkSpec` is still not carried through every synthesis and boot path.
-Several `SynthesisInput` sites still use `l3_network: None`, and the local
-hostd boot path still defaults `network_mode`.
-
-Close path:
-
-- Add the user-facing L3 fields to the workload IR with secure defaults.
-- Thread the typed spec through `SynthesisInput`, plan signing, admission,
-  and the local boot request without reconstructing or discarding it.
-- Remove hardcoded defaults from boot paths except for deliberately networkless
-  test fixtures.
-- Add a conformance witness that declares MTU, DNS, ingress, and IPv6 fields,
-  then proves the same values reach a booting VM.
-- Add a negative test proving an unsupported host refuses before boot.
-
-#### #2181 — no IPv6 packet across a live guest boot
-
-Host allocation, kernel support, guest configuration, and userspace datapath
-coverage exist. The missing evidence is a real Firecracker/HVF guest boot
-carrying an admitted IPv6 flow.
-
-Close path:
-
-- Run a real guest with an admitted IPv6 lease and verify the guest address,
-  peer route, and default route from the guest/kernel view.
-- Carry an admitted IPv6 TCP flow and response through the real backend.
-- Prove an unadmitted destination is refused and a spoofed source is dropped.
-- Run the witness on both Firecracker and HVF, or explicitly split the issue
-  into backend-specific validation issues with honest capability labels.
-- Store the exact source revision, host, backend, and witness output in the
-  research note and issue before closing.
-
-### Warm-launch workstream
-
-The dependency order is:
+The executable dependency order is:
 
 ```text
-#2192 contract
-    ├── #2193 artifact prewarm
-    ├── #2194 HVF golden-VM restore
-    │     └── #2195 claim-time read-only shares
-    ├── #2196 Firecracker warm backend
-    ├── #2197 process hardening
-    ├── #2198 user-visible timing/refusal semantics
-    └── #2199 benchmark and CI gates
+#2333 pre-boot launch preparation
+    -> #2193 verified artifact prewarm
+    -> #2194 HVF parent / #2196 Firecracker parent
+    -> #2195 fixed read-only shares
+    -> #2197 resident-process hardening
+    -> #2198 CLI timing and refusal contract
+    -> #2199 1,000-claim release matrix
 ```
 
-#### #2193 — asynchronous content-addressed prewarm
+- [ ] **#2333 — extract bootless launch preparation.** Refactor Plan 299 Phase
+      2 into a reusable preparation result containing rootfs and verity
+      sidecars, runtime overlay/initramfs, kernel/cmdline, tenant, and signed
+      admitted plan without starting a VM. Make `pool warm --image <ref>` pass
+      that launch shape, remove or implement the ignored `--rootfs` option,
+      show a nonzero idle count, and claim it on Firecracker against the 549 ms
+      cold baseline.
+- [ ] **#2193 — connect asynchronous prewarm to real factories.** Feed the
+      bootless prepared shape through the existing content-addressed jobs and
+      authenticated readiness verifier. Test hit, miss, corruption,
+      invalidation, concurrency, restart recovery, and source mismatch before
+      either backend advertises capacity.
+- [ ] **#2194 — finalize the Apple Silicon parent contract.** Decide and record
+      whether the supported path is signed paused-parent handoff or a true CoW
+      child restore. Prove fresh identity/authority/channels, failure
+      quarantine, restart recovery, live readiness, and honest capability bits
+      on a release Apple Silicon build.
+- [ ] **#2196 — finish Firecracker warm claims on KVM.** Validate factory
+      capture, paused-child materialization, identity and grant delivery,
+      device/network restrictions, cleanup, quarantine, and restart recovery
+      on the exact merged source. Production admission must refuse until the
+      full live matrix passes.
+- [ ] **#2195 — bind fixed read-only share slots at claim time.** Use opened
+      directory handles rather than path re-resolution, reject symlink/race/
+      disappearance and writable expansion, keep host paths and contents out
+      of pool keys and saved state, and make unsupported backends refuse warm
+      mode rather than report a cold fallback as warm.
+- [ ] **#2197 — harden resident workers by platform.** On Linux apply
+      no-new-privileges, capability drop, seccomp/Landlock or the documented
+      equivalent, resource limits, and inherited-FD allowlists. On macOS use
+      process separation, restrictive entitlements, handle-scoped access, and
+      explicit ownership. Test unauthorized file/socket/signal access,
+      privilege retention, cleanup, and compromise boundaries.
+- [ ] **#2198 — make warm outcomes user-visible and exact.** Surface stable
+      pool-wait, claim, share-bind, restore, and warm-window fields; distinguish
+      warm success, cold success, refusal, and failure in text and JSON; add
+      explicit `--cold` and warm-required behavior; test exactly 300 ms and
+      prove command/teardown time cannot relabel a cold run as warm.
+- [ ] **#2199 — run and gate the 1,000-claim matrix.** Cover every advertised
+      backend, representative CPU/memory and image shapes, no-share and
+      supported read-only shares, cache state, and explicit cold comparison.
+      Retain all outliers and publish p50/p95/p99/max/refusal rate; CI fails at
+      `>=300 ms`, p50 >30 ms, p99 >50 ms, or any mislabeled fallback.
 
-The artifact store, durable jobs, restart recovery, source validation, and
-authenticated readiness verifier are implemented. Backend-specific golden-VM
-factories remain.
+## Phase 5 — Finish egress accounting and governance
 
-Close path: connect the Apple Silicon and Linux factories to the shared
-verifier; prove cache hit, miss, invalidation, corruption, concurrent
-prewarm, and restart recovery; then close only after a warm claim cannot enter
-with a missing or mismatched artifact.
+- [ ] **#2305 — implement Plan 313 Phases 1–4.** After #2321, stream responses
+      with bounded buffers and redaction-safe overlap; attribute bytes to the
+      admitted binding; parse provider usage including terminal SSE usage
+      without guessing; represent unavailable token counts as unknown; emit a
+      payload-free chain-signed `plan.egress_usage`; and expose per-VM totals
+      through the verified audit reader. Enforcement and prompt compression
+      remain separate decisions.
+- [ ] **#2256 — execute Plan 306 in its recorded order.** Land declared-backing
+      headers and a failing self-test; derive the ADR-001 backend matrix from
+      `capabilities()`; refuse unfaithful egress and add the pre-run probe;
+      state and classify the check-time law; pin deny-wins/default-deny
+      predicate algebra and deny-loud escalation; freeze audit JCS replay
+      vectors including non-ASCII, >2^53 integer, and float refusal; then
+      double-key stale-name exemptions. Each workstream updates its plan box,
+      sprint, and rollup only after its tests pass.
 
-#### #2194 — Apple Silicon HVF golden-VM pool
+## Phase 6 — Complete the agent and Studio surface
 
-Parent reservation, pause/resume, snapshot-frame codecs, channel rebinding,
-resident handoff, and a Darwin warm-claim matrix have landed. The remaining
-question is whether the final design is the signed paused-parent handoff or a
-true copy-on-write child restore with all required device/vCPU state.
-
-Close path: record that design decision in the issue, prove fresh identity,
-authority, channel setup, failure quarantine, restart recovery, and live
-readiness on release-built Apple Silicon. Close only when the advertised
-capability bits correspond exactly to the proven path.
-
-#### #2195 — fixed virtio-fs share slots
-
-Close path: add fixed share-slot topology, opened-directory claim bindings,
-read-only enforcement, race/symlink/disappeared-directory refusal tests, and
-proof that host paths and directory contents never enter pool keys or saved
-state. Unsupported backends must refuse warm mode rather than report a cold
-launch as warm.
-
-#### #2196 — Linux Firecracker warm backend
-
-The paused-child preload path and an authenticated source-matched witness
-exist, but the full Linux matrix and production standby admission remain.
-
-Close path: validate factory capture, child restore, identity/authority
-handoff, cleanup, quarantine, restart recovery, snapshot device/network
-restrictions, and timing on the exact merged source in the builder and real
-KVM environments.
-
-#### #2197 — resident process hardening
-
-Close path: document Linux and macOS process boundaries separately; enforce
-least privilege, inherited-resource allowlists, no-new-privileges, resource
-limits, and share confinement; then add unauthorized file/socket access,
-signal, privilege-retention, refusal, and cleanup tests for both platforms.
-
-#### #2198 — timing, refusal, and CLI fallback behavior
-
-Internal timing and typed warm outcomes exist, but the user-facing contract
-still needs explicit warm-required and cold behavior.
-
-Close path: add explicit `--cold` and warm-required behavior, stable text and
-machine-readable refusal fields, exact-300ms tests, and a regression proving
-that no launch labeled warm can fall back to cold. Keep command execution and
-teardown outside the warm readiness window.
-
-#### #2199 — benchmark and CI gates
-
-The Darwin 1,000-claim matrix is evidence, not the complete gate.
-
-Close path: run 1,000 claims for every supported backend, image, CPU/memory
-shape, cache state, and supported share shape; retain all outliers; publish
-p50, p95, p99, maximum, refusal rate, and cold comparison; then enforce
-strict `<300ms`, p50 ≤30ms, and p99 ≤50ms in CI.
-
-### Agent-runtime and Studio workstream
-
-Implement these in order so the later surfaces consume shared contracts:
+The durable session (#2167), runtime approval (#2168), typed bindings (#2170),
+and SDK parity (#2163) are already closed. Remaining order:
 
 ```text
-#2167 durable session/event contract
-    └── #2168 policy and human approval
-          └── #2170 typed capability bindings
-                └── #2169 bounded Studio inspector
-                      └── #2166 parent epic closeout
+#2169 bounded inspector -> #2083 versioned launcher -> #2166 epic closeout
 ```
 
-#### #2167 — durable agent session and event contract
+- [ ] **#2169 — expose the bounded inspector through shared contracts.** Add
+      live/history cursors, bounded/redacted output, process state, capability
+      discovery, posture-authorized filesystem and stop actions, and consistent
+      local/gateway errors. Test reconnect, stale cursor, replay prevention,
+      denied and failed mutations, audit emission, teardown, and secret
+      exclusion.
+- [ ] **#2083 — coordinate and implement the versioned Studio launcher.**
+      Freeze the matching server handshake with `mvm-studio#18`; locate only a
+      sibling or managed artifact; reject symlinks and unsafe ownership/mode;
+      use a private inherited readiness channel; keep credentials out of argv,
+      logs, errors, and state; refuse production/fleet/unknown posture; and
+      prove version mismatch, timeout, child failure, Ctrl-C, reaping, package
+      pairing, and an authenticated loopback inventory page.
+- [ ] **#2166 — close the parent epic last.** Update its child ledger to show
+      #2167, #2168, and #2170 complete, then close only after #2169 and #2083
+      merge and an end-to-end agent session reconnects through the shared
+      contracts without weakening admission, audit, or production-shell
+      restrictions.
 
-Define stable public session IDs, lifecycle states, versioned durable and
-ephemeral events, sequence/cursor rules, idempotent prompt delivery,
-retention, redaction, bounded history, and typed reconnect/error behavior.
-Use the existing transcript and audit mechanisms rather than creating a
-parallel persistence model.
+## Final reconciliation gate
 
-Close gate: serialization round trips, reconnect/cursor/idempotency tests,
-adapter restart tests, and proof that secrets never enter durable history.
-
-#### #2168 — runtime permissions and human approval
-
-Define policy vocabulary and precedence for allow, deny, and ask while keeping
-signed admission and guest enforcement authoritative. Approval can only add a
-decision for an already-admitted capability.
-
-Close gate: default denial, precedence, expiry, cancellation, replay,
-unauthorized response, tampering, missing state, bounded metadata, and audit
-tests.
-
-#### #2170 — typed capability bindings
-
-Add versioned descriptors, input/output schemas, admission-time and invocation-
-time allowlists, bounds, timeouts, cancellation, binding identity, and typed
-failures over the existing agent protocol.
-
-Close gate: positive and negative protocol round trips, authorization and
-confused-deputy tests, size/time limits, cancellation, and secret non-exposure.
-
-#### #2169 — bounded Studio inspector
-
-Expose session history, bounded output, process state, filesystem operations,
-approval requests, and capability discovery through the shared client and
-gateway contracts. Keep read-only-by-default behavior and fail closed when a
-backend cannot enforce an operation.
-
-Close gate: reconnect, stale cursor, authorization, denied mutation, bounded
-rendering, audit emission, teardown, and local/gateway parity tests. Studio
-UI work remains in the Studio repository.
-
-#### #2166 — parent epic
-
-Close after #2167, #2168, #2170, and #2169 have merged, their compatibility
-notes are written, and one end-to-end agent session uses the shared contracts
-without weakening MVM admission, audit, or production shell restrictions.
-
-#### #2083 — versioned mvmctl Studio launcher
-
-Keep this as a cross-repository dependency until the Studio server handshake
-is agreed. Then implement fixed artifact lookup, ownership/permission checks,
-private readiness handoff, version negotiation, production refusal, clean
-shutdown, and no-secret-in-argv/log/state tests. Close only after the matching
-Studio server contract and an end-to-end local launch are both available.
-
-## Execution sequence
-
-1. With #2192 closed, split/narrow #2101 and #2211.
-2. Repair the generated security tracker (#2135) and current kernel freshness
-   issue (#2289), because they affect the evidence quality of every later
-   closeout.
-3. Fix the rootfs boot contract (#2165), L3 wiring (#2180), and live IPv6
-   witness (#2181).
-4. Finish the warm-launch dependency graph from #2193 through #2199.
-5. Implement the agent-runtime contract sequence (#2167 → #2168 → #2170 →
-   #2169), then close #2166 and coordinate #2083 with Studio.
-6. Implement the audit-to-tracing mirror (#2107), or explicitly descope it
-   from the product roadmap with a recorded decision rather than leaving it
-   indefinitely open.
-7. Run a final open-issue query, compare every issue against this plan, update
-   all three progress documents, and close only issues with complete evidence.
-
-## Final closeout checklist
-
-- [ ] Every issue body has current acceptance criteria and no obsolete claim.
-- [ ] Every merged PR and live witness is linked from the issue.
-- [ ] `cargo test --workspace` is green on the host; Linux-only tests ran in
-      the builder VM.
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings` is green in the
-      required Linux builder environment.
-- [ ] Required Nix, Firecracker, KVM, kernel, and platform gates are green.
-- [ ] `specs/SPRINT.md`, the owning plan, and `specs/REFACTOR-STATUS.md` agree.
-- [ ] A fresh GitHub open-issue query contains only intentionally active work.
+- [ ] Every issue from the 30-issue snapshot has a final disposition and
+      linked evidence.
+- [ ] Every active requirement has exactly one issue and one owning plan; no
+      acceptance criterion exists only in a comment or in this rollup.
+- [ ] Host workspace tests are green; Linux-only clippy, Nix, Firecracker,
+      KVM, kernel, and privilege witnesses ran in the project builder VM.
+- [ ] `specs/SPRINT.md`, this plan, and `specs/REFACTOR-STATUS.md` agree.
+- [ ] A fresh GitHub query contains no completed or superseded open issue.

--- a/xtask/mutation-witness-baseline.json
+++ b/xtask/mutation-witness-baseline.json
@@ -385,204 +385,134 @@
       "reason": "equivalent: the guard rejects a payload shorter than the 12-byte DNS header, and the label walk that follows indexes through payload.get(i)?, which returns None rather than panicking. A 12-byte payload therefore yields None down both the mutated and unmutated paths."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "delete ! in <impl VmBackend for LibkrunBackend>::list",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "delete ! in <impl VmBackend for LibkrunBackend>::start",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "delete ! in <impl VmBackend for LibkrunBackend>::stop",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "delete ! in <impl VmBackend for LibkrunBackend>::warm_start",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "delete field balloon from struct VmCapabilities expression in <impl VmBackend for LibkrunBackend>::capabilities",
       "reason": "equivalent: VmCapabilities derives Default, and each of these fields is declared with the value Default already yields (false), so deleting it from the literal is a semantic no-op that no test can distinguish. The two fields whose declared value differs from Default -- standby_pool: true and snapshot_capability: DiskOnly -- are caught by libkrun_capabilities_declare_the_vsock_only_shape."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "delete field fs_quick_checkpoint from struct VmCapabilities expression in <impl VmBackend for LibkrunBackend>::capabilities",
       "reason": "equivalent: VmCapabilities derives Default, and each of these fields is declared with the value Default already yields (false), so deleting it from the literal is a semantic no-op that no test can distinguish. The two fields whose declared value differs from Default -- standby_pool: true and snapshot_capability: DiskOnly -- are caught by libkrun_capabilities_declare_the_vsock_only_shape."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "delete field l3_vsock from struct VmCapabilities expression in <impl VmBackend for LibkrunBackend>::capabilities",
       "reason": "equivalent: VmCapabilities derives Default, and each of these fields is declared with the value Default already yields (false), so deleting it from the literal is a semantic no-op that no test can distinguish. The two fields whose declared value differs from Default -- standby_pool: true and snapshot_capability: DiskOnly -- are caught by libkrun_capabilities_declare_the_vsock_only_shape."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "delete field pause_resume from struct VmCapabilities expression in <impl VmBackend for LibkrunBackend>::capabilities",
       "reason": "equivalent: VmCapabilities derives Default, and each of these fields is declared with the value Default already yields (false), so deleting it from the literal is a semantic no-op that no test can distinguish. The two fields whose declared value differs from Default -- standby_pool: true and snapshot_capability: DiskOnly -- are caught by libkrun_capabilities_declare_the_vsock_only_shape."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "delete field snapshots from struct VmCapabilities expression in <impl VmBackend for LibkrunBackend>::capabilities",
       "reason": "equivalent: VmCapabilities derives Default, and each of these fields is declared with the value Default already yields (false), so deleting it from the literal is a semantic no-op that no test can distinguish. The two fields whose declared value differs from Default -- standby_pool: true and snapshot_capability: DiskOnly -- are caught by libkrun_capabilities_declare_the_vsock_only_shape."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "delete field tap_networking from struct VmCapabilities expression in <impl VmBackend for LibkrunBackend>::capabilities",
       "reason": "equivalent: VmCapabilities derives Default, and each of these fields is declared with the value Default already yields (false), so deleting it from the literal is a semantic no-op that no test can distinguish. The two fields whose declared value differs from Default -- standby_pool: true and snapshot_capability: DiskOnly -- are caught by libkrun_capabilities_declare_the_vsock_only_shape."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace && with || in diagnose_vsock_sockets",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace && with || in spawn_libkrun_egress_endpoint_if_needed",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace + with - in <impl VmBackend for LibkrunBackend>::start",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace + with - in <impl VmBackend for LibkrunBackend>::stop",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace < with <= in <impl VmBackend for LibkrunBackend>::stop",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace < with == in <impl VmBackend for LibkrunBackend>::stop",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace < with > in <impl VmBackend for LibkrunBackend>::stop",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace <impl VmBackend for LibkrunBackend>::install -> Result<()> with Ok(())",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace <impl VmBackend for LibkrunBackend>::is_available -> Result<bool> with Ok(false)",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace <impl VmBackend for LibkrunBackend>::is_available -> Result<bool> with Ok(true)",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
-      "mutant": "replace <impl VmBackend for LibkrunBackend>::list -> Result<Vec<VmInfo>> with Ok(vec![])",
-      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
-      "mutant": "replace <impl VmBackend for LibkrunBackend>::logs -> Result<String> with Ok(\"xyzzy\".into())",
-      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
-      "mutant": "replace <impl VmBackend for LibkrunBackend>::logs -> Result<String> with Ok(String::new())",
-      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace <impl VmBackend for LibkrunBackend>::pause -> Result<()> with Ok(())",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace <impl VmBackend for LibkrunBackend>::resume -> Result<()> with Ok(())",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
-      "mutant": "replace <impl VmBackend for LibkrunBackend>::stop -> Result<()> with Ok(())",
-      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace <impl VmBackend for LibkrunBackend>::stop_all -> Result<()> with Ok(())",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace <impl VmBackend for LibkrunBackend>::supports_standby_pool -> bool with false",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
-      "mutant": "replace == with != in <impl VmBackend for LibkrunBackend>::list",
-      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace >= with < in <impl VmBackend for LibkrunBackend>::start",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
-      "mutant": "replace match guard e.kind() == std::io::ErrorKind::NotFound with false in <impl VmBackend for LibkrunBackend>::list",
-      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
-      "mutant": "replace match guard e.kind() == std::io::ErrorKind::NotFound with true in <impl VmBackend for LibkrunBackend>::list",
-      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
-      "mutant": "replace match guard pid_alive(pid) with false in <impl VmBackend for LibkrunBackend>::status",
-      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
-      "mutant": "replace match guard pid_alive(pid) with true in <impl VmBackend for LibkrunBackend>::status",
-      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
-      "mutant": "replace read_pid -> Option<libc::pid_t> with None",
-      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
-      "mutant": "replace send_signal with ()",
-      "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/libkrun.rs",
+      "file": "crates/mvm-backends/src/legacy/libkrun.rs",
       "mutant": "replace || with && in ensure_libkrun_runtime_source_supported",
       "reason": "libkrun VM lifecycle over a live supervisor: these paths spawn, signal, poll and reap an mvm-libkrun-supervisor process against its per-VM state dir. The claim-1 and claim-15 witnesses in this file (the read-only virtiofs refusal and the input-less prod console attachment) are caught; these are the surrounding VMM plumbing, which needs a libkrun host the lane's runner is not. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/microvm/snapshot.rs",
-      "mutant": "replace create_snapshot_files -> Result<()> with Ok(())",
-      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/microvm/snapshot.rs",
-      "mutant": "replace match guard outcome.reseeded with false in warm_restore_instance_from_path",
-      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-runtime/src/microvm/snapshot.rs",
-      "mutant": "replace restore_from_template_snapshot -> Result<()> with Ok(())",
-      "reason": "Firecracker snapshot driver I/O: create/load/resume/teardown talk to a live Firecracker API socket, and the vsock readiness probes need a booted guest. The claim-3 and claim-10 witnesses in these files (the NIC refusals on restore and the tampered-memory rejection) are caught; these are the driver calls around them, whose only witness is the live-KVM lane. Coverage debt tracked in #2033."
     },
     {
       "file": "crates/mvm-runtime/src/vm/instance_snapshot.rs",

--- a/xtask/src/check_mutation_witnesses.rs
+++ b/xtask/src/check_mutation_witnesses.rs
@@ -235,6 +235,10 @@ pub fn run(workspace: &Path, mode: Mode, package: Option<&str>) -> Result<()> {
 
     let baseline = read_baseline(&baseline_path)?;
     let mut errors = check_accepted_reasons(&baseline.accepted_misses);
+    errors.extend(check_accepted_files_on_surface(
+        &baseline.surface,
+        &baseline.accepted_misses,
+    ));
     errors.extend(check_scope_reasons(&baseline.surface));
     errors.extend(check_shard_matrix(workspace, &baseline.surface));
     errors.extend(diff_surface(&baseline.surface, &resolved));
@@ -643,6 +647,30 @@ pub fn check_accepted_reasons(accepted: &[AcceptedMiss]) -> Vec<String> {
             format!(
                 "accepted miss {} :: {} has no reason — state why the hole is tolerable",
                 a.file, a.mutant
+            )
+        })
+        .collect()
+}
+
+/// Every accepted miss must belong to a file on the pinned mutation surface.
+///
+/// Without this check, moving enforcement code to another crate leaves the old
+/// entries inert: package shards filter accepted misses by their current files,
+/// so the moved mutants are reported as new while the stale debt remains hidden.
+pub fn check_accepted_files_on_surface(
+    surface: &[SurfaceFile],
+    accepted: &[AcceptedMiss],
+) -> Vec<String> {
+    let surface_paths: BTreeSet<&str> = surface.iter().map(|file| file.path.as_str()).collect();
+    accepted
+        .iter()
+        .map(|miss| miss.file.as_str())
+        .filter(|file| !surface_paths.contains(file))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(|file| {
+            format!(
+                "accepted misses for {file} are outside the pinned mutation surface — remove them or migrate them to the current enforcement file"
             )
         })
         .collect()
@@ -1177,6 +1205,34 @@ a.rs:5:1: replace x with y
             &[miss("b.rs", "replace x")],
         );
         assert_eq!(v.new_misses, vec![miss("b.rs", "replace x")]);
+    }
+
+    #[test]
+    fn accepted_misses_must_belong_to_the_pinned_surface() {
+        let pinned = vec![surface("crates/a/src/live.rs", vec![1])];
+        let accepted = vec![
+            accepted("crates/a/src/live.rs", "replace live"),
+            accepted("crates/a/src/moved.rs", "replace moved one"),
+            accepted("crates/a/src/moved.rs", "replace moved two"),
+        ];
+
+        let errors = check_accepted_files_on_surface(&pinned, &accepted);
+
+        assert_eq!(
+            errors.len(),
+            1,
+            "one error per stale file keeps output concise"
+        );
+        assert!(errors[0].contains("crates/a/src/moved.rs"));
+        assert!(errors[0].contains("outside the pinned mutation surface"));
+    }
+
+    #[test]
+    fn accepted_misses_on_the_pinned_surface_are_valid() {
+        let pinned = vec![surface("crates/a/src/live.rs", vec![1])];
+        let accepted = vec![accepted("crates/a/src/live.rs", "replace live")];
+
+        assert!(check_accepted_files_on_surface(&pinned, &accepted).is_empty());
     }
 
     fn surface(path: &str, claims: Vec<u32>) -> SurfaceFile {


### PR DESCRIPTION
## What changed

- fail the static mutation gate when an accepted miss references a file outside the pinned surface
- migrate the 26 still-observed libkrun misses to the current backend file
- remove 14 obsolete accepted misses, reducing the baseline from 83 to 69 without adding waivers
- add direct witnesses for snapshot I/O, no-op network stage names, torn audit tails, and verifying-key hex parsing
- synchronize Plan 300, the sprint, and the refactor rollup

## Why

The scheduled Security run exposed two related gaps after code movement: accepted misses could remain attached to files that were no longer on the mutation surface, and several security contracts lacked assertions precise enough to kill their generated mutants. This made moved mutants appear new while stale baseline debt remained hidden.

The gate now fails closed on stale file identities, and the affected contracts have executable witnesses.

## Impact

Mutation baseline drift caused by future code movement is reported immediately with an actionable error. The baseline is smaller, names current enforcement files, and does not waive any newly observed behavior.

This progresses #2135. Do not close the issue until the exact Linux Security workflow and a subsequent scheduled or release run pass.

## Validation

- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings` via the commit hook
- affected-package all-target Clippy after rebasing onto current `main`
- focused unit tests for all changed witnesses
- static mutation gate: 31 files across 10 packages, 69 accepted misses
- focused mutation proofs caught all targeted actionable mutants
- the workspace unit/integration groups passed; the combined run's final `mvm-cli` doctest hit nested-Cargo target-state interference, and `cargo test -p mvm-cli --doc` passed when rerun in isolation
- formatting and `git diff --check`
