### PR TITLE
Make #[instrument] produce timings, then instrument and export them (Plan 318)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,6 +3199,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
  "xattr",
 ]

--- a/crates/mvm-backends/src/driver/fc.rs
+++ b/crates/mvm-backends/src/driver/fc.rs
@@ -776,6 +776,11 @@ impl VmmDriver for FcDriver {
         Ok(())
     }
 
+    #[tracing::instrument(
+        name = "fc.boot",
+        skip_all,
+        fields(vm = %spec.name, vcpus = spec.vcpus, memory_mib = spec.memory_mib)
+    )]
     fn boot(&self, spec: &VmmSpec) -> Result<Box<dyn RunningVm>> {
         if !spec.shares.is_empty() {
             bail!(

--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -362,6 +362,11 @@ impl VmmDriver for HvfDriver {
         self.backend.capabilities().standby_pool
     }
 
+    #[tracing::instrument(
+        name = "hvf.boot",
+        skip_all,
+        fields(vm = %spec.name, vcpus = spec.vcpus, memory_mib = spec.memory_mib)
+    )]
     fn boot(&self, spec: &VmmSpec) -> Result<Box<dyn RunningVm>> {
         boot_with_handoff(spec, None)
     }

--- a/crates/mvm-backends/src/driver/hvf_restore.rs
+++ b/crates/mvm-backends/src/driver/hvf_restore.rs
@@ -182,6 +182,7 @@ pub fn hvf_child_restore_config(
 
 /// Start a supervisor that loads `req`'s materialized saved state instead of
 /// booting a kernel, and wait for it to confirm the VM is live.
+#[tracing::instrument(name = "hvf.restore", skip_all, fields(vm = %req.vm_name))]
 pub fn restore_hvf_vm(req: &HvfRestoreRequest<'_>) -> Result<RestoredHvfVm> {
     if !req.state_dir.is_dir() {
         bail!(

--- a/crates/mvm-backends/src/driver/libkrun.rs
+++ b/crates/mvm-backends/src/driver/libkrun.rs
@@ -285,6 +285,11 @@ impl VmmDriver for LibkrunDriver {
         libkrun_base_bootargs(virtiofs_root, has_disk)
     }
 
+    #[tracing::instrument(
+        name = "libkrun.boot",
+        skip_all,
+        fields(vm = %spec.name, vcpus = spec.vcpus, memory_mib = spec.memory_mib)
+    )]
     fn boot(&self, spec: &VmmSpec) -> Result<Box<dyn RunningVm>> {
         let state_dir = vm_state_dir(&spec.name);
         std::fs::create_dir_all(&state_dir)

--- a/crates/mvm-backends/src/driver/qemu.rs
+++ b/crates/mvm-backends/src/driver/qemu.rs
@@ -327,6 +327,11 @@ impl VmmDriver for QemuDriver {
         qemu_base_bootargs(virtiofs_root, has_disk)
     }
 
+    #[tracing::instrument(
+        name = "qemu.boot",
+        skip_all,
+        fields(vm = %spec.name, vcpus = spec.vcpus, memory_mib = spec.memory_mib)
+    )]
     fn boot(&self, spec: &VmmSpec) -> Result<Box<dyn RunningVm>> {
         // QEMU has no bundled kernel (libkrun's libkrunfw is the only
         // bundled-kernel backend): a `Bundled` spec takes the same cached

--- a/crates/mvm-build/src/pipeline/build_cache.rs
+++ b/crates/mvm-build/src/pipeline/build_cache.rs
@@ -128,6 +128,7 @@ const EXCLUDED_BASENAMES: &[&str] = &[
 /// build reads. `None` for `mvm_workspace` is the non-source-checkout
 /// case (the user flake pins `mvm` to a published ref, recorded in its
 /// own `flake.lock`, so the user flake hash alone covers it).
+#[tracing::instrument(skip_all, fields(user_flake = %user_flake.display(), mode = ?mode))]
 pub fn workload_build_fingerprint(
     user_flake: &Path,
     profile: Option<&str>,

--- a/crates/mvm-build/src/pipeline/orchestrator.rs
+++ b/crates/mvm-build/src/pipeline/orchestrator.rs
@@ -56,6 +56,7 @@ pub fn pool_build(
 }
 
 /// Build artifacts for a pool with optional resource overrides.
+#[tracing::instrument(skip_all, fields(tenant_id, pool_id))]
 pub fn pool_build_with_opts(
     env: &dyn BuildEnvironment,
     tenant_id: &str,

--- a/crates/mvm-build/src/pipeline/vsock_builder.rs
+++ b/crates/mvm-build/src/pipeline/vsock_builder.rs
@@ -12,6 +12,7 @@ fn builder_agent_port() -> u32 {
         .unwrap_or(mvm_agentd::builder_agent::BUILDER_AGENT_PORT)
 }
 
+#[tracing::instrument(skip_all, fields(flake_ref, attr))]
 pub fn build_via_vsock(
     vsock_uds: &str,
     flake_ref: &str,

--- a/crates/mvm-cli/src/bench/mod.rs
+++ b/crates/mvm-cli/src/bench/mod.rs
@@ -23,6 +23,7 @@ pub mod probe;
 pub mod probes;
 pub mod regression;
 pub mod report;
+pub mod span_profile;
 pub mod stats;
 
 // `BootMarks` and the boot-timing-sidecar writer are the only bench-internal

--- a/crates/mvm-cli/src/bench/span_profile.rs
+++ b/crates/mvm-cli/src/bench/span_profile.rs
@@ -1,0 +1,394 @@
+//! Capture and diff span profiles across benchmark runs.
+//!
+//! The launch harness spawns `mvmctl` as a child process, so a profile is
+//! collected by pointing the child at a JSON destination and reading it back.
+//! Diffing is pure and lives here so a profile regression is a verdict rather
+//! than something a human reads off two tables.
+//!
+//! The gate compares **per-call** self time, which is robust to two runs that
+//! executed a different number of iterations. Call counts are reported
+//! alongside, because a function that got called more often is a different
+//! defect from one that got slower, and the two need telling apart.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use mvm_core::observability::span_timing::{self, SpanProfile, SpanReport};
+
+use super::regression::RegressionVerdict;
+
+/// Environment a child `mvmctl` needs in order to write a JSON profile to
+/// `out_path`. Feed these into the launch runner's env list.
+pub fn profile_env(out_path: &Path) -> Vec<(String, String)> {
+    vec![
+        (span_timing::ENV_ENABLE.to_string(), "json".to_string()),
+        (
+            span_timing::ENV_OUT.to_string(),
+            out_path.display().to_string(),
+        ),
+    ]
+}
+
+/// Read a profile a child process wrote.
+pub fn read_profile(path: &Path) -> Result<SpanReport> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading span profile {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("parsing span profile {}", path.display()))
+}
+
+/// Mean self time per call, or `None` when the span recorded no calls.
+fn self_ns_per_call(profile: &SpanProfile) -> Option<f64> {
+    (profile.calls > 0).then(|| profile.self_ns as f64 / profile.calls as f64)
+}
+
+/// One call site compared across two runs.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpanDelta {
+    /// Emitting module path.
+    pub target: String,
+    /// Span name.
+    pub name: String,
+    /// Baseline calls.
+    pub baseline_calls: u64,
+    /// Current calls.
+    pub current_calls: u64,
+    /// Baseline mean self time per call.
+    pub baseline_self_ns_per_call: f64,
+    /// Current mean self time per call.
+    pub current_self_ns_per_call: f64,
+    /// Current total self time, for ordering by what actually costs.
+    pub current_self_ns: u64,
+    /// Verdict over per-call self time.
+    pub verdict: RegressionVerdict,
+}
+
+impl SpanDelta {
+    /// Whether this call site regressed beyond the limit.
+    pub fn is_regressed(&self) -> bool {
+        matches!(self.verdict, RegressionVerdict::Regressed { .. })
+    }
+
+    /// Whether the run called this site a different number of times. A pure
+    /// call-count change leaves per-call time flat, so it would otherwise pass
+    /// the gate unnoticed.
+    pub fn call_count_changed(&self) -> bool {
+        self.baseline_calls != self.current_calls
+    }
+}
+
+/// The full comparison between a baseline profile and a current one.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpanComparison {
+    /// Call sites present in both runs, hottest by current self time first.
+    pub deltas: Vec<SpanDelta>,
+    /// `target::name` present only in the current run.
+    pub appeared: Vec<String>,
+    /// `target::name` present only in the baseline.
+    pub disappeared: Vec<String>,
+}
+
+impl SpanComparison {
+    /// Call sites that regressed beyond the limit.
+    pub fn regressions(&self) -> impl Iterator<Item = &SpanDelta> {
+        self.deltas.iter().filter(|d| d.is_regressed())
+    }
+
+    /// Whether no call site regressed. A newly appeared span is not by itself a
+    /// regression — it may just be newly instrumented — so it does not fail
+    /// this, but it is reported so the reader can judge.
+    pub fn is_clean(&self) -> bool {
+        self.regressions().next().is_none()
+    }
+}
+
+fn qualified(profile: &SpanProfile) -> String {
+    format!("{}::{}", profile.target, profile.name)
+}
+
+/// Compare per-call self time for every call site present in both reports.
+pub fn compare_span_reports(
+    baseline: &SpanReport,
+    current: &SpanReport,
+    max_regression_pct: f64,
+) -> SpanComparison {
+    let mut deltas = Vec::new();
+    let mut appeared = Vec::new();
+
+    for cur in &current.spans {
+        let Some(base) = baseline
+            .spans
+            .iter()
+            .find(|b| b.target == cur.target && b.name == cur.name)
+        else {
+            appeared.push(qualified(cur));
+            continue;
+        };
+
+        let verdict = match (self_ns_per_call(base), self_ns_per_call(cur)) {
+            (Some(b), Some(c)) if b > 0.0 => {
+                let delta_pct = (c - b) / b * 100.0;
+                if delta_pct > max_regression_pct {
+                    RegressionVerdict::Regressed {
+                        delta_pct,
+                        limit_pct: max_regression_pct,
+                    }
+                } else {
+                    RegressionVerdict::Ok { delta_pct }
+                }
+            }
+            // A zero or absent baseline has no ratio to compare against;
+            // reporting it as a pass would be a false green.
+            _ => RegressionVerdict::Incomparable {
+                reason: format!(
+                    "baseline for {} has no positive per-call self time",
+                    qualified(cur)
+                ),
+            },
+        };
+
+        deltas.push(SpanDelta {
+            target: cur.target.clone(),
+            name: cur.name.clone(),
+            baseline_calls: base.calls,
+            current_calls: cur.calls,
+            baseline_self_ns_per_call: self_ns_per_call(base).unwrap_or(0.0),
+            current_self_ns_per_call: self_ns_per_call(cur).unwrap_or(0.0),
+            current_self_ns: cur.self_ns,
+            verdict,
+        });
+    }
+
+    let disappeared = baseline
+        .spans
+        .iter()
+        .filter(|b| {
+            !current
+                .spans
+                .iter()
+                .any(|c| c.target == b.target && c.name == b.name)
+        })
+        .map(qualified)
+        .collect();
+
+    deltas.sort_by(|a, b| {
+        b.current_self_ns
+            .cmp(&a.current_self_ns)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+
+    SpanComparison {
+        deltas,
+        appeared,
+        disappeared,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn span(name: &str, calls: u64, self_ns: u64) -> SpanProfile {
+        SpanProfile {
+            target: "mvm_cli::bench_fixture".to_string(),
+            name: name.to_string(),
+            calls,
+            total_ns: self_ns,
+            self_ns,
+            wall_ns: self_ns,
+            mean_ns: self_ns / calls.max(1),
+            min_ns: 0,
+            max_ns: self_ns,
+            p50_ns: 0,
+            p95_ns: 0,
+            p99_ns: 0,
+        }
+    }
+
+    fn report(spans: Vec<SpanProfile>) -> SpanReport {
+        SpanReport { spans }
+    }
+
+    #[test]
+    fn profile_env_names_the_json_format_and_destination() {
+        let env = profile_env(Path::new("/tmp/p.json"));
+        assert!(env.contains(&("MVM_SPAN_TIMINGS".to_string(), "json".to_string())));
+        assert!(env.contains(&(
+            "MVM_SPAN_TIMINGS_OUT".to_string(),
+            "/tmp/p.json".to_string()
+        )));
+    }
+
+    #[test]
+    fn an_unchanged_profile_is_clean() {
+        let base = report(vec![span("boot", 4, 400)]);
+        let cur = report(vec![span("boot", 4, 400)]);
+
+        let cmp = compare_span_reports(&base, &cur, 10.0);
+        assert!(cmp.is_clean());
+        assert_eq!(cmp.deltas.len(), 1);
+        assert!(matches!(
+            cmp.deltas[0].verdict,
+            RegressionVerdict::Ok { delta_pct } if delta_pct.abs() < f64::EPSILON
+        ));
+    }
+
+    #[test]
+    fn a_slower_call_site_regresses() {
+        let base = report(vec![span("boot", 4, 400)]);
+        let cur = report(vec![span("boot", 4, 800)]);
+
+        let cmp = compare_span_reports(&base, &cur, 10.0);
+        assert!(!cmp.is_clean());
+        let regressed: Vec<&SpanDelta> = cmp.regressions().collect();
+        assert_eq!(regressed.len(), 1);
+        assert_eq!(regressed[0].name, "boot");
+        assert!(matches!(
+            regressed[0].verdict,
+            RegressionVerdict::Regressed { delta_pct, .. } if (delta_pct - 100.0).abs() < 1e-9
+        ));
+    }
+
+    #[test]
+    fn an_improvement_passes_and_reports_a_negative_delta() {
+        let base = report(vec![span("boot", 4, 800)]);
+        let cur = report(vec![span("boot", 4, 400)]);
+
+        let cmp = compare_span_reports(&base, &cur, 10.0);
+        assert!(cmp.is_clean());
+        assert!(matches!(
+            cmp.deltas[0].verdict,
+            RegressionVerdict::Ok { delta_pct } if delta_pct < 0.0
+        ));
+    }
+
+    #[test]
+    fn more_iterations_do_not_read_as_a_regression() {
+        // Twice the calls at the same per-call cost is the same code, run more.
+        // A total-time gate would flag this; a per-call gate must not.
+        let base = report(vec![span("boot", 4, 400)]);
+        let cur = report(vec![span("boot", 8, 800)]);
+
+        let cmp = compare_span_reports(&base, &cur, 10.0);
+        assert!(cmp.is_clean(), "{:?}", cmp.deltas);
+    }
+
+    #[test]
+    fn a_changed_call_count_is_surfaced_even_when_per_call_time_is_flat() {
+        // Calling a hasher twice per launch instead of once is a real defect
+        // that leaves per-call time untouched.
+        let base = report(vec![span("sha256_file.uncached", 1, 100)]);
+        let cur = report(vec![span("sha256_file.uncached", 2, 200)]);
+
+        let cmp = compare_span_reports(&base, &cur, 10.0);
+        assert!(cmp.is_clean(), "per-call time did not change");
+        assert!(
+            cmp.deltas[0].call_count_changed(),
+            "the extra call must still be visible"
+        );
+        assert_eq!(cmp.deltas[0].baseline_calls, 1);
+        assert_eq!(cmp.deltas[0].current_calls, 2);
+    }
+
+    #[test]
+    fn a_new_span_is_reported_but_does_not_fail_the_gate() {
+        let base = report(vec![span("boot", 1, 100)]);
+        let cur = report(vec![
+            span("boot", 1, 100),
+            span("newly_instrumented", 1, 50),
+        ]);
+
+        let cmp = compare_span_reports(&base, &cur, 10.0);
+        assert!(cmp.is_clean());
+        assert_eq!(cmp.appeared.len(), 1);
+        assert!(cmp.appeared[0].ends_with("newly_instrumented"));
+    }
+
+    #[test]
+    fn a_span_that_stopped_being_recorded_is_reported() {
+        let base = report(vec![span("boot", 1, 100), span("gone", 1, 50)]);
+        let cur = report(vec![span("boot", 1, 100)]);
+
+        let cmp = compare_span_reports(&base, &cur, 10.0);
+        assert_eq!(cmp.disappeared.len(), 1);
+        assert!(cmp.disappeared[0].ends_with("gone"));
+    }
+
+    #[test]
+    fn a_zero_baseline_is_incomparable_rather_than_a_false_green() {
+        let base = report(vec![span("boot", 1, 0)]);
+        let cur = report(vec![span("boot", 1, 500)]);
+
+        let cmp = compare_span_reports(&base, &cur, 10.0);
+        assert!(matches!(
+            cmp.deltas[0].verdict,
+            RegressionVerdict::Incomparable { .. }
+        ));
+    }
+
+    #[test]
+    fn a_baseline_with_no_calls_is_incomparable() {
+        let base = report(vec![span("boot", 0, 0)]);
+        let cur = report(vec![span("boot", 1, 500)]);
+
+        let cmp = compare_span_reports(&base, &cur, 10.0);
+        assert!(matches!(
+            cmp.deltas[0].verdict,
+            RegressionVerdict::Incomparable { .. }
+        ));
+    }
+
+    #[test]
+    fn deltas_are_ordered_by_current_self_time() {
+        let base = report(vec![
+            span("cheap", 1, 10),
+            span("expensive", 1, 1_000),
+            span("middling", 1, 100),
+        ]);
+        let cur = base.clone();
+
+        let cmp = compare_span_reports(&base, &cur, 10.0);
+        let names: Vec<&str> = cmp.deltas.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names, vec!["expensive", "middling", "cheap"]);
+    }
+
+    #[test]
+    fn same_name_under_different_targets_stays_separate() {
+        let mut base_a = span("start", 1, 100);
+        base_a.target = "mvm_fs::oci".to_string();
+        let mut base_b = span("start", 1, 100);
+        base_b.target = "mvm_runtime::vm".to_string();
+
+        let mut cur_a = base_a.clone();
+        cur_a.self_ns = 1_000;
+        cur_a.mean_ns = 1_000;
+
+        let cmp = compare_span_reports(
+            &report(vec![base_a, base_b.clone()]),
+            &report(vec![cur_a, base_b]),
+            10.0,
+        );
+        assert_eq!(cmp.deltas.len(), 2);
+        assert_eq!(cmp.regressions().count(), 1);
+        assert!(cmp.appeared.is_empty());
+        assert!(cmp.disappeared.is_empty());
+    }
+
+    #[test]
+    fn read_profile_round_trips_a_written_report() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("profile.json");
+        let written = report(vec![span("boot", 2, 200)]);
+        std::fs::write(&path, serde_json::to_string(&written).expect("serialize")).expect("write");
+
+        let read = read_profile(&path).expect("read");
+        assert_eq!(read, written);
+    }
+
+    #[test]
+    fn read_profile_reports_a_missing_file_rather_than_an_empty_profile() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = read_profile(&dir.path().join("absent.json")).expect_err("must fail");
+        // An empty profile would read as "nothing was slow", the wrong default.
+        assert!(format!("{err}").contains("reading span profile"), "{err}");
+    }
+}

--- a/crates/mvm-cli/src/commands/env/builder_vm/vm_helpers.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/vm_helpers.rs
@@ -360,6 +360,7 @@ pub(super) struct ProcSnapshot {
 }
 
 impl ProcSnapshot {
+    #[tracing::instrument(name = "proc_snapshot.capture", skip_all)]
     fn capture() -> Self {
         // Reported here rather than at the callers: this is the function that
         // pays for the snapshot, and a caller that forgot to report would make

--- a/crates/mvm-cli/src/commands/image/pull_core.rs
+++ b/crates/mvm-cli/src/commands/image/pull_core.rs
@@ -209,6 +209,7 @@ pub(super) fn pull_image_with_trust(
     pull_image_ref(cache_root, image_ref, reference, prod)
 }
 
+#[tracing::instrument(skip_all, fields(reference = supplied_reference, prod))]
 fn pull_image_ref(
     cache_root: &Path,
     image_ref: ImageReference,
@@ -423,6 +424,7 @@ fn manifest_config_descriptor(manifest_bytes: &[u8]) -> Result<Option<LayerDescr
     }))
 }
 
+#[tracing::instrument(skip_all, fields(digest = %layer.digest, size = layer.size))]
 fn fetch_or_unpack_layer(
     cache_root: &Path,
     runtime: &tokio::runtime::Runtime,

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -239,6 +239,14 @@ pub fn cli_command() -> clap::Command {
 }
 
 pub fn run() -> Result<()> {
+    let result = run_command();
+    // Emitted after the command settles so the profile covers teardown as well.
+    // A no-op unless MVM_SPAN_TIMINGS is set.
+    mvm_core::observability::span_timing::emit_report();
+    result
+}
+
+fn run_command() -> Result<()> {
     let _ = rustls::crypto::ring::default_provider().install_default();
     let cli = match cli_command().try_get_matches_from(std::env::args_os()) {
         Ok(matches) => Cli::from_arg_matches(&matches)

--- a/crates/mvm-cli/src/commands/ops/metrics.rs
+++ b/crates/mvm-cli/src/commands/ops/metrics.rs
@@ -87,6 +87,11 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         // `# TYPE` lines for distinct metric names.
         print!("{}", global_metrics.prometheus_exposition());
         print!("{}", per_vm.prometheus_exposition());
+        // Span timings are deliberately absent here. They accumulate in the
+        // process that ran the instrumented code, and this command renders
+        // before doing any, so the series would always be empty. The scrape
+        // served by `metrics_server` carries them, because there the serving
+        // process is the one doing the work.
     }
     Ok(())
 }

--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -630,6 +630,10 @@ fn sibling_deploy_boot_artifact(
 /// immutable across repeated launches. A precomputed digest is different: it
 /// is an external attestation claim, so it must be checked with an uncached
 /// read before it can influence admission. A mismatch fails closed.
+#[tracing::instrument(
+    skip_all,
+    fields(rootfs = %rootfs_path.display(), precomputed = precomputed.is_some())
+)]
 fn resolve_image_sha256(
     rootfs_path: &std::path::Path,
     precomputed: Option<String>,

--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -2177,6 +2177,7 @@ allow_hosts = ["localhost:8443"]
 
     #[test]
     fn a_manifest_grant_reaches_the_signed_plan() {
+        let _env = mvm_core::util::test_env::TestEnv::new();
         let declared = manifest_grants(MANIFEST);
         let config = MvmConfig::default();
         let resolved = resolve_run_grants(GrantInputs {
@@ -2395,6 +2396,7 @@ allow_hosts = ["localhost:8443"]
 
     #[test]
     fn a_run_that_grants_nothing_still_admits_a_grant_free_plan() {
+        let _env = mvm_core::util::test_env::TestEnv::new();
         // The pre-grant baseline has to stay byte-identical: an untouched
         // permission set must not become an empty-but-present one.
         let config = MvmConfig::default();

--- a/crates/mvm-cli/src/commands/vm/up/kernel.rs
+++ b/crates/mvm-cli/src/commands/vm/up/kernel.rs
@@ -77,6 +77,7 @@ fn download_published_kernel(
     )
 }
 
+#[tracing::instrument(skip_all, fields(arch, source_checkout))]
 fn resolve_pinned_kernel_with<F>(
     cache_dir: &std::path::Path,
     arch: &str,

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -91,6 +91,7 @@ fn apply_runtime_overlay_artifact(
 /// fields `None` and the VM boots legacy. The seeded resolve is a pure
 /// cache read — no build, no download, no `nix` — so this is safe on
 /// every host.
+#[tracing::instrument(skip_all, fields(hypervisor, arch = ?arch))]
 pub(crate) fn attach_runtime_overlay(
     start_config: &mut mvm_core::vm_backend::VmStartConfig,
     hypervisor: &str,
@@ -329,6 +330,7 @@ pub(crate) fn universal_initramfs_available() -> bool {
     mvm_build::initramfs::resolve_or_seed_from_default_cache(&cache_root, version, arch).is_ok()
 }
 
+#[tracing::instrument(skip_all)]
 pub(crate) fn attach_universal_initramfs_if_cached(
     start_config: &mut mvm_core::vm_backend::VmStartConfig,
 ) -> Result<()> {

--- a/crates/mvm-cli/src/logging.rs
+++ b/crates/mvm-cli/src/logging.rs
@@ -1,15 +1,9 @@
-use tracing_subscriber::EnvFilter;
-use tracing_subscriber::fmt;
-use tracing_subscriber::prelude::*;
+//! CLI logging setup.
+//!
+//! The subscriber assembly itself lives in `mvm_core::observability::logging`;
+//! this module only maps the CLI's `-v` count onto a filter.
 
-/// Log output format.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LogFormat {
-    /// Human-readable colored output (for interactive CLI use).
-    Human,
-    /// Structured JSON output (for daemon/agent mode).
-    Json,
-}
+pub use mvm_core::observability::logging::LogFormat;
 
 /// The default tracing filter for a `-v` count when `RUST_LOG` is unset.
 /// 0 = quiet (errors only); each `-v` widens it.
@@ -24,32 +18,14 @@ pub fn filter_for_verbosity(verbosity: u8) -> &'static str {
 
 /// Initialize the global tracing subscriber.
 ///
-/// Call once at program startup. Without `-v` the filter is `error` (quiet by
-/// default). Each `-v` widens it: `-v` → `mvm=info,warn`, `-vv` → `debug`,
-/// `-vvv` → `trace`. `RUST_LOG=<filter>` overrides verbosity entirely.
+/// Without `-v` the filter is `error` (quiet by default). Each `-v` widens it:
+/// `-v` → `mvm=info,warn`, `-vv` → `debug`, `-vvv` → `trace`.
+/// `RUST_LOG=<filter>` overrides verbosity entirely.
+///
+/// Span profiling is independent of verbosity: when `MVM_SPAN_TIMINGS` is set,
+/// spans are measured even at the default quiet filter.
 pub fn init(format: LogFormat, verbosity: u8) {
-    let env_filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(filter_for_verbosity(verbosity)));
-
-    match format {
-        LogFormat::Human => {
-            let subscriber = fmt::layer()
-                .with_target(false)
-                .with_thread_ids(false)
-                .compact();
-            tracing_subscriber::registry()
-                .with(env_filter)
-                .with(subscriber)
-                .init();
-        }
-        LogFormat::Json => {
-            let subscriber = fmt::layer().json().with_target(true);
-            tracing_subscriber::registry()
-                .with(env_filter)
-                .with(subscriber)
-                .init();
-        }
-    }
+    mvm_core::observability::logging::init_with_filter(format, filter_for_verbosity(verbosity));
 }
 
 #[cfg(test)]
@@ -69,5 +45,14 @@ mod tests {
         assert!(filter_for_verbosity(1).contains("info"));
         assert_eq!(filter_for_verbosity(2), "debug");
         assert_eq!(filter_for_verbosity(5), "trace");
+    }
+
+    #[test]
+    fn verbosity_widens_monotonically() {
+        // Each step must not narrow the previous one; the quiet default is the
+        // reason span timing needs its own filter rather than riding on this.
+        assert_eq!(filter_for_verbosity(0), "error");
+        assert_ne!(filter_for_verbosity(0), filter_for_verbosity(1));
+        assert_ne!(filter_for_verbosity(1), filter_for_verbosity(2));
     }
 }

--- a/crates/mvm-cli/src/metrics_server.rs
+++ b/crates/mvm-cli/src/metrics_server.rs
@@ -96,6 +96,13 @@ fn handle_connection(mut stream: TcpStream) {
     let _ = stream.read(&mut buf);
 
     let mut body = mvm_core::observability::metrics::global().prometheus_exposition();
+    // Empty unless this process is running with span profiling enabled, so the
+    // scrape shape is unchanged for everyone else.
+    body.push_str(
+        &mvm_core::observability::span_timing::prometheus_exposition(
+            &mvm_core::observability::span_timing::global().report(),
+        ),
+    );
     append_per_vm_scrape_files(&mut body);
     let response = format!(
         "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\nContent-Length: {}\r\n\r\n{}",

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -559,6 +559,7 @@ impl LocalBackend {
     /// recording, attachment registration, lease acquisition, admitted boot,
     /// registration. Any failure after recording rolls the session-owned
     /// state back (leases via RAII, secret refs + attachments explicitly).
+    #[tracing::instrument(skip_all)]
     async fn launch_transient(&self, request: LaunchRequest) -> Result<LaunchOutcome> {
         let name = request
             .name

--- a/crates/mvm-core/src/crypto/image_verify.rs
+++ b/crates/mvm-core/src/crypto/image_verify.rs
@@ -391,6 +391,7 @@ pub fn verify_artifact(path: &Path, expected: &ArtifactDigest) -> VerifyResult<(
 /// Stream a file through SHA-256 and return the lowercase hex digest.
 /// Public for callers that want to verify an artifact without the
 /// delete-on-mismatch behaviour of `verify_artifact`.
+#[tracing::instrument(name = "sha256_file.uncached", skip_all, fields(path = %path.display()))]
 pub fn sha256_file(path: &Path) -> io::Result<String> {
     use io::Read as _;
     let mut file = fs::File::open(path)?;
@@ -443,6 +444,7 @@ pub enum DigestSource {
 }
 
 /// [`sha256_file_cached`], reporting whether the sidecar served the digest.
+#[tracing::instrument(name = "sha256_file.cached", skip_all, fields(path = %path.display()))]
 pub fn sha256_file_cached_with_source(path: &Path) -> io::Result<(String, DigestSource)> {
     let meta = fs::metadata(path)?;
     let size = meta.len();

--- a/crates/mvm-core/src/observability/logging.rs
+++ b/crates/mvm-core/src/observability/logging.rs
@@ -1,6 +1,10 @@
+use tracing::Subscriber;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::prelude::*;
+use tracing_subscriber::registry::LookupSpan;
+
+use super::span_timing::{self, SpanTimingLayer};
 
 /// Log output format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -11,33 +15,74 @@ pub enum LogFormat {
     Json,
 }
 
-/// Initialize the global tracing subscriber.
-///
-/// Call once at program startup. Respects `RUST_LOG` env var for filtering.
-/// Default filter: `mvm=info` (show info+ from mvm, warnings from dependencies).
-pub fn init(format: LogFormat) {
-    let env_filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("mvm=info,warn"));
+/// Filter applied when `RUST_LOG` is unset and no caller override is given.
+pub const DEFAULT_FILTER: &str = "mvm=info,warn";
 
+/// Build the formatting layer for `format`.
+///
+/// Boxed so the two output shapes share one layer-stack assembly path instead
+/// of duplicating it per format.
+fn format_layer<S>(format: LogFormat) -> Box<dyn tracing_subscriber::Layer<S> + Send + Sync>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
     match format {
-        LogFormat::Human => {
-            let subscriber = fmt::layer()
+        LogFormat::Human => Box::new(
+            fmt::layer()
                 .with_target(false)
                 .with_thread_ids(false)
-                .compact();
-            tracing_subscriber::registry()
-                .with(env_filter)
-                .with(subscriber)
-                .init();
-        }
-        LogFormat::Json => {
-            let subscriber = fmt::layer().json().with_target(true);
-            tracing_subscriber::registry()
-                .with(env_filter)
-                .with(subscriber)
-                .init();
-        }
+                .compact(),
+        ),
+        LogFormat::Json => Box::new(fmt::layer().json().with_target(true)),
     }
+}
+
+/// Resolve the log filter: `RUST_LOG` wins, then `fallback`.
+fn log_filter(fallback: &str) -> EnvFilter {
+    EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::try_new(fallback).unwrap_or_else(|_| EnvFilter::new("warn")))
+}
+
+/// Initialize the global tracing subscriber.
+///
+/// Call once at program startup. Respects `RUST_LOG` for filtering, falling
+/// back to [`DEFAULT_FILTER`].
+pub fn init(format: LogFormat) {
+    init_with_filter(format, DEFAULT_FILTER);
+}
+
+/// Initialize the global tracing subscriber with an explicit fallback filter.
+///
+/// The log filter is attached to the formatting layer rather than to the
+/// registry, so that the span-timing layer can carry its own, wider filter.
+/// A registry-wide filter would suppress span *construction*, and an
+/// unconstructed span cannot be measured — which is why `#[instrument]` alone
+/// yields no timings.
+pub fn init_with_filter(format: LogFormat, fallback_filter: &str) {
+    let logs = format_layer(format).with_filter(log_filter(fallback_filter));
+    let registry = tracing_subscriber::registry().with(logs);
+
+    match span_timing::format_from_env() {
+        Some(_) => registry.with(span_timing_layer()).init(),
+        None => registry.init(),
+    }
+}
+
+/// The span-timing layer with its configured target filter.
+fn span_timing_layer<S>() -> impl tracing_subscriber::Layer<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let directives = span_timing::filter_from_env();
+    let filter = EnvFilter::try_new(&directives).unwrap_or_else(|_| {
+        eprintln!(
+            "span timings: invalid {} '{directives}', using '{}'",
+            span_timing::ENV_FILTER,
+            span_timing::DEFAULT_FILTER
+        );
+        EnvFilter::new(span_timing::DEFAULT_FILTER)
+    });
+    SpanTimingLayer::new().with_filter(filter)
 }
 
 #[cfg(test)]
@@ -49,5 +94,25 @@ mod tests {
         assert_eq!(LogFormat::Human, LogFormat::Human);
         assert_eq!(LogFormat::Json, LogFormat::Json);
         assert_ne!(LogFormat::Human, LogFormat::Json);
+    }
+
+    #[test]
+    fn log_filter_prefers_the_supplied_fallback_over_a_hardcoded_one() {
+        // RUST_LOG is process-global; this asserts the fallback path only,
+        // which is the branch callers control.
+        let filter = log_filter("mvm=debug");
+        assert!(format!("{filter}").contains("debug"));
+    }
+
+    #[test]
+    fn log_filter_recovers_from_an_unparseable_fallback() {
+        // An invalid fallback must not panic the program being logged.
+        let filter = log_filter("!!!not a filter!!!");
+        assert!(!format!("{filter}").is_empty());
+    }
+
+    #[test]
+    fn default_filter_keeps_mvm_at_info() {
+        assert_eq!(DEFAULT_FILTER, "mvm=info,warn");
     }
 }

--- a/crates/mvm-core/src/observability/mod.rs
+++ b/crates/mvm-core/src/observability/mod.rs
@@ -1,3 +1,4 @@
 pub mod instance_metrics;
 pub mod logging;
 pub mod metrics;
+pub mod span_timing;

--- a/crates/mvm-core/src/observability/span_timing/histogram.rs
+++ b/crates/mvm-core/src/observability/span_timing/histogram.rs
@@ -1,0 +1,218 @@
+//! Fixed-memory latency histogram with logarithmic buckets.
+//!
+//! Each power of two is split into [`SUB_COUNT`] linear sub-buckets, which
+//! bounds the relative error of any recorded value at ~12% while keeping the
+//! whole histogram at a constant 2 KiB. That matters because one of these is
+//! held per instrumented span name for the lifetime of the process, so an
+//! unbounded sample vector would grow without limit on a long-running daemon.
+
+/// Bits of sub-bucket resolution within each power of two.
+const SUB_BITS: u32 = 2;
+/// Linear sub-buckets per power of two.
+const SUB_COUNT: u64 = 1 << SUB_BITS;
+/// Total bucket count: one set of sub-buckets per `u64` exponent.
+pub const BUCKET_COUNT: usize = 64 * SUB_COUNT as usize;
+
+/// Bucket a duration in nanoseconds falls into.
+///
+/// Values below [`SUB_COUNT`] are stored exactly in the leading buckets; every
+/// larger value maps to `(exponent, sub)` where `exponent` is the position of
+/// its most significant bit.
+pub fn bucket_index(ns: u64) -> usize {
+    if ns < SUB_COUNT {
+        return ns as usize;
+    }
+    let exp = 63 - ns.leading_zeros();
+    let sub = (ns >> (exp - SUB_BITS)) & (SUB_COUNT - 1);
+    ((exp as usize) << SUB_BITS) | sub as usize
+}
+
+/// Smallest nanosecond value that maps to `index`.
+pub fn bucket_lower(index: usize) -> u64 {
+    if (index as u64) < SUB_COUNT {
+        return index as u64;
+    }
+    let exp = (index >> SUB_BITS) as u32;
+    let sub = (index as u64) & (SUB_COUNT - 1);
+    (SUB_COUNT | sub) << (exp - SUB_BITS)
+}
+
+/// Width in nanoseconds of the value range covered by `index`.
+pub fn bucket_width(index: usize) -> u64 {
+    if (index as u64) < SUB_COUNT {
+        return 1;
+    }
+    let exp = (index >> SUB_BITS) as u32;
+    1 << (exp - SUB_BITS)
+}
+
+/// A latency distribution over nanosecond samples.
+#[derive(Clone)]
+pub struct LogHistogram {
+    buckets: Box<[u64; BUCKET_COUNT]>,
+    count: u64,
+}
+
+impl Default for LogHistogram {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LogHistogram {
+    /// An empty histogram.
+    pub fn new() -> Self {
+        Self {
+            buckets: Box::new([0; BUCKET_COUNT]),
+            count: 0,
+        }
+    }
+
+    /// Record one nanosecond sample.
+    pub fn record(&mut self, ns: u64) {
+        self.buckets[bucket_index(ns)] += 1;
+        self.count += 1;
+    }
+
+    /// Number of samples recorded.
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Fold `other` into `self`.
+    pub fn merge(&mut self, other: &LogHistogram) {
+        for (slot, add) in self.buckets.iter_mut().zip(other.buckets.iter()) {
+            *slot += add;
+        }
+        self.count += other.count;
+    }
+
+    /// Estimate the value at `q` (0.0..=1.0), interpolating within the
+    /// containing bucket. Returns `None` when no samples have been recorded.
+    ///
+    /// The result carries the histogram's ~12% bucket error; it is a profiling
+    /// signal, not an SLO measurement.
+    pub fn quantile(&self, q: f64) -> Option<u64> {
+        if self.count == 0 {
+            return None;
+        }
+        let q = q.clamp(0.0, 1.0);
+        // Rank is 1-based so that q=0 selects the first sample and q=1 the last.
+        let target = (q * self.count as f64).ceil().max(1.0) as u64;
+        let mut seen = 0u64;
+        for (index, &n) in self.buckets.iter().enumerate() {
+            if n == 0 {
+                continue;
+            }
+            if seen + n >= target {
+                let into = target - seen;
+                let width = bucket_width(index);
+                // Spread the bucket's samples evenly across its value range.
+                let offset = (width.saturating_mul(into.saturating_sub(1))) / n;
+                return Some(bucket_lower(index) + offset.min(width.saturating_sub(1)));
+            }
+            seen += n;
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_values_are_exact() {
+        for ns in 0..SUB_COUNT {
+            assert_eq!(bucket_index(ns), ns as usize);
+            assert_eq!(bucket_lower(bucket_index(ns)), ns);
+        }
+    }
+
+    #[test]
+    fn bucket_lower_is_the_inverse_of_bucket_index() {
+        for ns in [4u64, 5, 7, 8, 15, 1_000, 1_000_000, 1_000_000_000, u64::MAX] {
+            let index = bucket_index(ns);
+            let lower = bucket_lower(index);
+            assert!(lower <= ns, "lower {lower} > ns {ns}");
+            assert!(
+                ns - lower < bucket_width(index),
+                "ns {ns} outside bucket {index} starting at {lower}"
+            );
+        }
+    }
+
+    #[test]
+    fn bucket_index_is_monotonic() {
+        let mut last = 0;
+        for shift in 0..64 {
+            let index = bucket_index(1u64 << shift);
+            assert!(index >= last, "index went backwards at 2^{shift}");
+            last = index;
+        }
+    }
+
+    #[test]
+    fn bucket_index_stays_in_range() {
+        assert!(bucket_index(u64::MAX) < BUCKET_COUNT);
+    }
+
+    #[test]
+    fn relative_error_is_bounded() {
+        // Every value lands in a bucket whose width is at most 1/4 of the
+        // bucket's own lower bound, i.e. <= ~25% worst case, ~12% typical.
+        for ns in [100u64, 12_345, 999_999, 5_000_000_000] {
+            let index = bucket_index(ns);
+            let width = bucket_width(index);
+            let lower = bucket_lower(index);
+            assert!(
+                (width as f64) / (lower as f64) <= 0.25,
+                "bucket at {ns} too wide: width {width} lower {lower}"
+            );
+        }
+    }
+
+    #[test]
+    fn quantile_of_empty_histogram_is_none() {
+        assert_eq!(LogHistogram::new().quantile(0.5), None);
+    }
+
+    #[test]
+    fn quantile_tracks_a_uniform_distribution() {
+        let mut h = LogHistogram::new();
+        for ns in 1..=1000u64 {
+            h.record(ns * 1_000);
+        }
+        assert_eq!(h.count(), 1000);
+        let p50 = h.quantile(0.5).expect("p50");
+        let p95 = h.quantile(0.95).expect("p95");
+        // Within the histogram's bucket error of the true 500k / 950k.
+        assert!((400_000..=600_000).contains(&p50), "p50 = {p50}");
+        assert!((850_000..=1_050_000).contains(&p95), "p95 = {p95}");
+        assert!(p50 < p95);
+    }
+
+    #[test]
+    fn quantile_of_a_single_sample_is_that_sample() {
+        let mut h = LogHistogram::new();
+        h.record(1_000_000);
+        let p50 = h.quantile(0.5).expect("p50");
+        assert!((900_000..=1_100_000).contains(&p50), "p50 = {p50}");
+    }
+
+    #[test]
+    fn merge_sums_counts_and_preserves_distribution() {
+        let mut a = LogHistogram::new();
+        let mut b = LogHistogram::new();
+        for _ in 0..10 {
+            a.record(1_000);
+            b.record(1_000_000);
+        }
+        a.merge(&b);
+        assert_eq!(a.count(), 20);
+        let p10 = a.quantile(0.1).expect("p10");
+        let p90 = a.quantile(0.9).expect("p90");
+        assert!(p10 < 2_000, "p10 = {p10}");
+        assert!(p90 > 500_000, "p90 = {p90}");
+    }
+}

--- a/crates/mvm-core/src/observability/span_timing/layer.rs
+++ b/crates/mvm-core/src/observability/span_timing/layer.rs
@@ -1,0 +1,130 @@
+//! The `tracing` layer that turns `#[instrument]` spans into timing samples.
+
+use std::time::Instant;
+
+use tracing::Subscriber;
+use tracing::span::{Attributes, Id};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::registry::LookupSpan;
+
+use super::registry::{SpanKey, SpanSample, SpanTimings};
+
+/// Per-span state held in the registry's span extensions.
+struct Timings {
+    created: Instant,
+    /// Nanoseconds this span has been entered.
+    busy_ns: u64,
+    /// Nanoseconds attributed upward by nested spans that have closed.
+    child_busy_ns: u64,
+    /// Set while the span is entered.
+    entered_at: Option<Instant>,
+}
+
+impl Timings {
+    fn new() -> Self {
+        Self {
+            created: Instant::now(),
+            busy_ns: 0,
+            child_busy_ns: 0,
+            entered_at: None,
+        }
+    }
+}
+
+/// Records the duration of every span it is enabled for.
+///
+/// Attach it with a per-layer filter so that spans are created even when the
+/// log filter would otherwise suppress them — `tracing` skips span
+/// construction entirely if no layer is interested, so the filter, not the
+/// `#[instrument]` attribute, decides whether a measurement happens at all.
+pub struct SpanTimingLayer {
+    timings: &'static SpanTimings,
+}
+
+impl SpanTimingLayer {
+    /// A layer writing into the process-wide registry.
+    pub fn new() -> Self {
+        Self {
+            timings: super::registry::global(),
+        }
+    }
+
+    /// A layer writing into a caller-supplied registry, for tests.
+    pub fn with_registry(timings: &'static SpanTimings) -> Self {
+        Self { timings }
+    }
+}
+
+impl Default for SpanTimingLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> Layer<S> for SpanTimingLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, _attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        span.extensions_mut().insert(Timings::new());
+    }
+
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        if let Some(timings) = span.extensions_mut().get_mut::<Timings>() {
+            timings.entered_at = Some(Instant::now());
+        }
+    }
+
+    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        if let Some(timings) = span.extensions_mut().get_mut::<Timings>()
+            && let Some(entered) = timings.entered_at.take()
+        {
+            timings.busy_ns += entered.elapsed().as_nanos() as u64;
+        }
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(&id) else { return };
+
+        let (busy_ns, child_busy_ns, wall_ns) = {
+            let mut extensions = span.extensions_mut();
+            let Some(timings) = extensions.get_mut::<Timings>() else {
+                return;
+            };
+            // A span closed while still entered (an early return inside the
+            // guard's scope is not possible, but a leaked guard is) would
+            // otherwise lose its final interval.
+            if let Some(entered) = timings.entered_at.take() {
+                timings.busy_ns += entered.elapsed().as_nanos() as u64;
+            }
+            (
+                timings.busy_ns,
+                timings.child_busy_ns,
+                timings.created.elapsed().as_nanos() as u64,
+            )
+        };
+
+        self.timings.record(
+            SpanKey {
+                target: span.metadata().target(),
+                name: span.metadata().name(),
+            },
+            &SpanSample {
+                busy_ns,
+                child_busy_ns,
+                wall_ns,
+            },
+        );
+
+        // Attribute this span's time to its parent so the parent can report
+        // self time. Done after the child's own extensions borrow is released.
+        if let Some(parent) = span.parent()
+            && let Some(parent_timings) = parent.extensions_mut().get_mut::<Timings>()
+        {
+            parent_timings.child_busy_ns += busy_ns;
+        }
+    }
+}

--- a/crates/mvm-core/src/observability/span_timing/mod.rs
+++ b/crates/mvm-core/src/observability/span_timing/mod.rs
@@ -1,0 +1,326 @@
+//! Span-duration profiling built on `#[instrument]`.
+//!
+//! `tracing` does not time spans on its own: an `#[instrument]` attribute only
+//! declares a span, and unless some layer subscribes to that span's close event
+//! nothing measures it. This module supplies that layer, the process-wide
+//! aggregation behind it, and the report rendering, so the attributes already
+//! scattered through the workspace produce a profile instead of nothing.
+//!
+//! Profiling is off unless `MVM_SPAN_TIMINGS` is set, and when off the layer is
+//! never installed, so the cost is the unchanged cost of a disabled span.
+//!
+//! # Limits
+//!
+//! Self time is computed by attributing a closing span's busy time to its
+//! immediate parent. A span that the timing filter excludes is not tracked, so
+//! an excluded span sitting between two tracked ones breaks the chain and
+//! inflates the outer span's self time. The default filter covers every `mvm`
+//! target, which keeps the chain intact for workspace code; narrowing
+//! [`ENV_FILTER`] trades that guarantee for less measurement overhead.
+//!
+//! Recording takes a process-wide lock on span close. That is adequate for the
+//! coarse, entry-point-level instrumentation this is meant for, and would not
+//! be for instrumenting a per-item inner loop.
+
+mod histogram;
+mod layer;
+mod registry;
+
+use std::fmt::Write as _;
+
+pub use histogram::LogHistogram;
+pub use layer::SpanTimingLayer;
+pub use registry::{SpanKey, SpanProfile, SpanReport, SpanSample, SpanTimings, global};
+
+/// Environment variable enabling profiling and selecting the report format.
+pub const ENV_ENABLE: &str = "MVM_SPAN_TIMINGS";
+/// Environment variable choosing a report destination file instead of stderr.
+pub const ENV_OUT: &str = "MVM_SPAN_TIMINGS_OUT";
+/// Environment variable overriding which targets are timed.
+pub const ENV_FILTER: &str = "MVM_SPAN_TIMINGS_FILTER";
+
+/// Targets timed when [`ENV_FILTER`] is unset.
+///
+/// `trace` rather than `info` so that a span declared at any level is measured;
+/// the whole point is to observe spans the log filter would drop.
+pub const DEFAULT_FILTER: &str = "mvm=trace";
+
+/// How a profile should be rendered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportFormat {
+    /// Aligned, human-readable table.
+    Text,
+    /// A single JSON object, for diffing runs or feeding a dashboard.
+    Json,
+}
+
+/// Parse the value of [`ENV_ENABLE`] into a format, or `None` when disabled.
+///
+/// Unset, empty, `0`, `off`, `false`, and `no` all disable profiling.
+/// `1`, `on`, `true`, `yes`, and `text` select the table; `json` selects JSON.
+/// Anything else is treated as enabled-with-table rather than failing, since a
+/// typo in a profiling knob should not take down the command being profiled.
+pub fn format_from_env_value(value: Option<&str>) -> Option<ReportFormat> {
+    let value = value?.trim();
+    match value.to_ascii_lowercase().as_str() {
+        "" | "0" | "off" | "false" | "no" => None,
+        "json" => Some(ReportFormat::Json),
+        _ => Some(ReportFormat::Text),
+    }
+}
+
+/// The configured report format for this process, or `None` when disabled.
+pub fn format_from_env() -> Option<ReportFormat> {
+    format_from_env_value(std::env::var(ENV_ENABLE).ok().as_deref())
+}
+
+/// Whether span profiling is enabled for this process.
+pub fn is_enabled() -> bool {
+    format_from_env().is_some()
+}
+
+/// The target filter to install on the timing layer.
+pub fn filter_from_env() -> String {
+    std::env::var(ENV_FILTER)
+        .ok()
+        .filter(|f| !f.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_FILTER.to_string())
+}
+
+/// Render a duration in nanoseconds with a human-scaled unit.
+pub fn format_ns(ns: u64) -> String {
+    const US: u64 = 1_000;
+    const MS: u64 = 1_000_000;
+    const S: u64 = 1_000_000_000;
+    match ns {
+        n if n < US => format!("{n}ns"),
+        n if n < MS => format!("{:.1}us", n as f64 / US as f64),
+        n if n < S => format!("{:.1}ms", n as f64 / MS as f64),
+        n => format!("{:.2}s", n as f64 / S as f64),
+    }
+}
+
+/// Render a report as an aligned table, hottest call site first.
+pub fn render_text(report: &SpanReport) -> String {
+    if report.is_empty() {
+        return "no spans recorded (is the timing layer installed?)\n".to_string();
+    }
+
+    let total_self = report.total_self_ns();
+    let name_width = report
+        .spans
+        .iter()
+        .map(|s| s.name.len())
+        .max()
+        .unwrap_or(4)
+        .clamp(4, 48);
+
+    let mut out = String::with_capacity(128 * report.spans.len());
+    let _ = writeln!(
+        out,
+        "{:<name_width$}  {:>7}  {:>10}  {:>6}  {:>10}  {:>10}  {:>10}  {:>10}",
+        "span", "calls", "self", "self%", "total", "mean", "p95", "max",
+    );
+    let _ = writeln!(out, "{}", "-".repeat(name_width + 76));
+
+    for span in &report.spans {
+        let share = if total_self == 0 {
+            0.0
+        } else {
+            span.self_ns as f64 * 100.0 / total_self as f64
+        };
+        let name: String = span.name.chars().take(name_width).collect();
+        let _ = writeln!(
+            out,
+            "{:<name_width$}  {:>7}  {:>10}  {:>5.1}%  {:>10}  {:>10}  {:>10}  {:>10}",
+            name,
+            span.calls,
+            format_ns(span.self_ns),
+            share,
+            format_ns(span.total_ns),
+            format_ns(span.mean_ns),
+            format_ns(span.p95_ns),
+            format_ns(span.max_ns),
+        );
+    }
+
+    let _ = writeln!(
+        out,
+        "\n{} span(s), {} total self time. \
+         self = time in this function excluding nested instrumented calls.",
+        report.spans.len(),
+        format_ns(total_self),
+    );
+    out
+}
+
+/// Render a report in the configured format.
+pub fn render(report: &SpanReport, format: ReportFormat) -> String {
+    match format {
+        ReportFormat::Text => render_text(report),
+        // A profile that cannot be serialized is a bug worth surfacing, but not
+        // one worth aborting the profiled command over.
+        ReportFormat::Json => match serde_json::to_string_pretty(report) {
+            Ok(json) => format!("{json}\n"),
+            Err(err) => format!("{{\"error\":\"failed to serialize span report: {err}\"}}\n"),
+        },
+    }
+}
+
+/// Write the process-wide profile to the configured destination.
+///
+/// A no-op when profiling is disabled. Called once at the end of a run; safe to
+/// call when nothing was recorded. Reporting failures are written to stderr
+/// rather than propagated, since the profile is diagnostic output.
+pub fn emit_report() {
+    let Some(format) = format_from_env() else {
+        return;
+    };
+    let rendered = render(&global().report(), format);
+    match std::env::var(ENV_OUT).ok().filter(|p| !p.trim().is_empty()) {
+        Some(path) => {
+            if let Err(err) = std::fs::write(&path, rendered.as_bytes()) {
+                eprintln!("span timings: failed to write {path}: {err}");
+            }
+        }
+        None => eprint!("{rendered}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile(name: &str, calls: u64, self_ns: u64, total_ns: u64) -> SpanProfile {
+        SpanProfile {
+            target: "mvm_core::test".to_string(),
+            name: name.to_string(),
+            calls,
+            total_ns,
+            self_ns,
+            wall_ns: total_ns,
+            mean_ns: total_ns / calls.max(1),
+            min_ns: 1,
+            max_ns: total_ns,
+            p50_ns: total_ns / calls.max(1),
+            p95_ns: total_ns,
+            p99_ns: total_ns,
+        }
+    }
+
+    #[test]
+    fn env_value_disables_on_falsey_and_unset() {
+        for value in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("off"),
+            Some("false"),
+            Some("no"),
+        ] {
+            assert_eq!(format_from_env_value(value), None, "value = {value:?}");
+        }
+    }
+
+    #[test]
+    fn env_value_selects_text_or_json() {
+        assert_eq!(format_from_env_value(Some("1")), Some(ReportFormat::Text));
+        assert_eq!(
+            format_from_env_value(Some("text")),
+            Some(ReportFormat::Text)
+        );
+        assert_eq!(
+            format_from_env_value(Some("json")),
+            Some(ReportFormat::Json)
+        );
+        assert_eq!(
+            format_from_env_value(Some("JSON")),
+            Some(ReportFormat::Json)
+        );
+    }
+
+    #[test]
+    fn env_value_is_whitespace_and_case_tolerant() {
+        assert_eq!(
+            format_from_env_value(Some("  json  ")),
+            Some(ReportFormat::Json)
+        );
+        assert_eq!(format_from_env_value(Some(" OFF ")), None);
+    }
+
+    #[test]
+    fn unrecognized_env_value_enables_rather_than_failing() {
+        assert_eq!(
+            format_from_env_value(Some("tabel")),
+            Some(ReportFormat::Text)
+        );
+    }
+
+    #[test]
+    fn format_ns_scales_units() {
+        assert_eq!(format_ns(999), "999ns");
+        assert_eq!(format_ns(1_500), "1.5us");
+        assert_eq!(format_ns(2_500_000), "2.5ms");
+        assert_eq!(format_ns(3_000_000_000), "3.00s");
+    }
+
+    #[test]
+    fn render_text_reports_the_empty_case_explicitly() {
+        let out = render_text(&SpanReport { spans: vec![] });
+        assert!(out.contains("no spans recorded"), "{out}");
+    }
+
+    #[test]
+    fn render_text_lists_spans_with_share_of_total() {
+        let report = SpanReport {
+            spans: vec![
+                profile("hash_layer", 4, 7_500_000, 7_500_000),
+                profile("unpack", 1, 2_500_000, 2_500_000),
+            ],
+        };
+        let out = render_text(&report);
+        assert!(out.contains("hash_layer"), "{out}");
+        assert!(out.contains("unpack"), "{out}");
+        assert!(out.contains("75.0%"), "{out}");
+        assert!(out.contains("25.0%"), "{out}");
+        assert!(out.contains("2 span(s)"), "{out}");
+    }
+
+    #[test]
+    fn render_text_survives_a_zero_duration_report() {
+        // Guards the percentage divide when every span was too fast to measure.
+        let report = SpanReport {
+            spans: vec![profile("instant", 1, 0, 0)],
+        };
+        let out = render_text(&report);
+        assert!(out.contains("instant"), "{out}");
+        assert!(out.contains("0.0%"), "{out}");
+    }
+
+    #[test]
+    fn render_text_truncates_an_overlong_span_name() {
+        let long = "a".repeat(200);
+        let report = SpanReport {
+            spans: vec![profile(&long, 1, 1_000, 1_000)],
+        };
+        let out = render_text(&report);
+        // 48-column clamp keeps the table aligned regardless of name length.
+        assert!(out.lines().all(|l| l.len() < 160), "{out}");
+    }
+
+    #[test]
+    fn render_json_emits_a_parseable_report() {
+        let report = SpanReport {
+            spans: vec![profile("build", 2, 1_000, 2_000)],
+        };
+        let out = render(&report, ReportFormat::Json);
+        let back: SpanReport = serde_json::from_str(&out).expect("valid json");
+        assert_eq!(back, report);
+    }
+
+    #[test]
+    fn filter_default_covers_mvm_targets_at_trace() {
+        assert_eq!(DEFAULT_FILTER, "mvm=trace");
+        assert!(DEFAULT_FILTER.contains("trace"));
+    }
+}

--- a/crates/mvm-core/src/observability/span_timing/mod.rs
+++ b/crates/mvm-core/src/observability/span_timing/mod.rs
@@ -24,12 +24,14 @@
 
 mod histogram;
 mod layer;
+mod prometheus;
 mod registry;
 
 use std::fmt::Write as _;
 
 pub use histogram::LogHistogram;
 pub use layer::SpanTimingLayer;
+pub use prometheus::{escape_label_value, prometheus_exposition};
 pub use registry::{SpanKey, SpanProfile, SpanReport, SpanSample, SpanTimings, global};
 
 /// Environment variable enabling profiling and selecting the report format.

--- a/crates/mvm-core/src/observability/span_timing/prometheus.rs
+++ b/crates/mvm-core/src/observability/span_timing/prometheus.rs
@@ -1,0 +1,203 @@
+//! Prometheus text-format rendering for a [`SpanReport`].
+//!
+//! The counters in [`crate::observability::metrics`] are fixed-name singletons;
+//! span timings are per-call-site, so they carry `target` and `span` labels
+//! instead of one metric name per function.
+
+use std::fmt::Write as _;
+
+use super::registry::SpanReport;
+
+/// Nanoseconds per second, as a float divisor. Prometheus convention is base
+/// units, so durations are exported in seconds rather than the nanoseconds the
+/// registry accumulates.
+const NANOS_PER_SEC: f64 = 1_000_000_000.0;
+
+/// Escape a Prometheus label value: backslash, double quote, and newline.
+///
+/// An unescaped span name containing a quote would produce a malformed
+/// exposition that breaks the whole scrape, not just the one series.
+pub fn escape_label_value(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Render one metric family across every call site in the report.
+fn write_family(
+    out: &mut String,
+    report: &SpanReport,
+    name: &str,
+    metric_type: &str,
+    help: &str,
+    value_of: impl Fn(&super::registry::SpanProfile) -> f64,
+) {
+    if report.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "# HELP {name} {help}");
+    let _ = writeln!(out, "# TYPE {name} {metric_type}");
+    for span in &report.spans {
+        let _ = writeln!(
+            out,
+            "{name}{{target=\"{}\",span=\"{}\"}} {}",
+            escape_label_value(&span.target),
+            escape_label_value(&span.name),
+            value_of(span),
+        );
+    }
+}
+
+/// Render a span profile in Prometheus text exposition format.
+///
+/// Returns an empty string when nothing was recorded, so a caller can append it
+/// unconditionally without emitting a bare `# HELP` block for no series.
+pub fn prometheus_exposition(report: &SpanReport) -> String {
+    let mut out = String::with_capacity(256 * report.spans.len());
+
+    write_family(
+        &mut out,
+        report,
+        "mvm_span_calls_total",
+        "counter",
+        "Completed calls of an instrumented function",
+        |s| s.calls as f64,
+    );
+    write_family(
+        &mut out,
+        report,
+        "mvm_span_self_seconds_total",
+        "counter",
+        "Seconds spent in an instrumented function, excluding nested instrumented calls",
+        |s| s.self_ns as f64 / NANOS_PER_SEC,
+    );
+    write_family(
+        &mut out,
+        report,
+        "mvm_span_total_seconds_total",
+        "counter",
+        "Seconds spent in an instrumented function, including nested instrumented calls",
+        |s| s.total_ns as f64 / NANOS_PER_SEC,
+    );
+    write_family(
+        &mut out,
+        report,
+        "mvm_span_max_seconds",
+        "gauge",
+        "Slowest observed call of an instrumented function, in seconds",
+        |s| s.max_ns as f64 / NANOS_PER_SEC,
+    );
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observability::span_timing::{SpanProfile, SpanReport};
+
+    fn profile(target: &str, name: &str) -> SpanProfile {
+        SpanProfile {
+            target: target.to_string(),
+            name: name.to_string(),
+            calls: 3,
+            total_ns: 2_500_000_000,
+            self_ns: 1_500_000_000,
+            wall_ns: 2_500_000_000,
+            mean_ns: 833_333_333,
+            min_ns: 1_000_000,
+            max_ns: 2_000_000_000,
+            p50_ns: 800_000_000,
+            p95_ns: 1_900_000_000,
+            p99_ns: 2_000_000_000,
+        }
+    }
+
+    #[test]
+    fn empty_report_renders_nothing() {
+        let out = prometheus_exposition(&SpanReport { spans: vec![] });
+        assert!(out.is_empty(), "{out}");
+    }
+
+    #[test]
+    fn renders_every_family_with_labels() {
+        let report = SpanReport {
+            spans: vec![profile("mvm_fs::oci", "unpack_layer")],
+        };
+        let out = prometheus_exposition(&report);
+
+        for family in [
+            "mvm_span_calls_total",
+            "mvm_span_self_seconds_total",
+            "mvm_span_total_seconds_total",
+            "mvm_span_max_seconds",
+        ] {
+            assert!(out.contains(&format!("# TYPE {family}")), "{family}\n{out}");
+        }
+        assert!(
+            out.contains("mvm_span_calls_total{target=\"mvm_fs::oci\",span=\"unpack_layer\"} 3"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn durations_are_exported_in_seconds() {
+        let report = SpanReport {
+            spans: vec![profile("mvm_fs::oci", "unpack_layer")],
+        };
+        let out = prometheus_exposition(&report);
+        // 1_500_000_000 ns == 1.5 s
+        assert!(
+            out.contains(
+                "mvm_span_self_seconds_total{target=\"mvm_fs::oci\",span=\"unpack_layer\"} 1.5"
+            ),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn every_span_gets_a_series_in_each_family() {
+        let report = SpanReport {
+            spans: vec![profile("a::b", "one"), profile("c::d", "two")],
+        };
+        let out = prometheus_exposition(&report);
+        let calls_series = out
+            .lines()
+            .filter(|l| l.starts_with("mvm_span_calls_total{"))
+            .count();
+        assert_eq!(calls_series, 2, "{out}");
+    }
+
+    #[test]
+    fn label_values_are_escaped() {
+        assert_eq!(escape_label_value(r#"a"b"#), r#"a\"b"#);
+        assert_eq!(escape_label_value(r"a\b"), r"a\\b");
+        assert_eq!(escape_label_value("a\nb"), r"a\nb");
+        assert_eq!(escape_label_value("plain"), "plain");
+    }
+
+    #[test]
+    fn a_span_name_with_a_quote_cannot_break_the_exposition() {
+        // A malformed line would break the entire scrape, not just this series.
+        let mut p = profile("mvm::t", r#"weird"name"#);
+        p.calls = 1;
+        let out = prometheus_exposition(&SpanReport { spans: vec![p] });
+        assert!(out.contains(r#"span="weird\"name""#), "{out}");
+        for line in out.lines().filter(|l| !l.starts_with('#')) {
+            // Exactly one unescaped quote pair per label, so four in total.
+            let unescaped = line.replace("\\\"", "");
+            assert_eq!(
+                unescaped.matches('"').count(),
+                4,
+                "unbalanced quoting in {line}"
+            );
+        }
+    }
+}

--- a/crates/mvm-core/src/observability/span_timing/registry.rs
+++ b/crates/mvm-core/src/observability/span_timing/registry.rs
@@ -1,0 +1,383 @@
+//! Process-wide aggregation of span durations, keyed by span identity.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use serde::{Deserialize, Serialize};
+
+use super::histogram::LogHistogram;
+
+/// Identity of an instrumented call site.
+///
+/// Both halves come from `tracing`'s `Metadata`, which is `'static`, so the key
+/// borrows rather than allocating on every span close.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SpanKey {
+    /// The emitting module path (`tracing` target).
+    pub target: &'static str,
+    /// The span name, which for `#[instrument]` is the function name.
+    pub name: &'static str,
+}
+
+/// Accumulated timings for one call site.
+struct SpanStat {
+    calls: u64,
+    /// Time the span was entered, including time spent in nested spans.
+    busy_ns: u64,
+    /// Portion of `busy_ns` attributable to nested instrumented spans.
+    child_busy_ns: u64,
+    /// Wall-clock from span creation to close, including time not entered.
+    wall_ns: u64,
+    min_busy_ns: u64,
+    max_busy_ns: u64,
+    hist: LogHistogram,
+}
+
+impl SpanStat {
+    fn new() -> Self {
+        Self {
+            calls: 0,
+            busy_ns: 0,
+            child_busy_ns: 0,
+            wall_ns: 0,
+            min_busy_ns: u64::MAX,
+            max_busy_ns: 0,
+            hist: LogHistogram::new(),
+        }
+    }
+
+    fn record(&mut self, sample: &SpanSample) {
+        self.calls += 1;
+        self.busy_ns += sample.busy_ns;
+        self.child_busy_ns += sample.child_busy_ns;
+        self.wall_ns += sample.wall_ns;
+        self.min_busy_ns = self.min_busy_ns.min(sample.busy_ns);
+        self.max_busy_ns = self.max_busy_ns.max(sample.busy_ns);
+        self.hist.record(sample.busy_ns);
+    }
+}
+
+/// One completed span observation handed to the registry.
+pub struct SpanSample {
+    /// Time the span was entered.
+    pub busy_ns: u64,
+    /// Entered time attributable to nested instrumented spans.
+    pub child_busy_ns: u64,
+    /// Creation-to-close wall clock.
+    pub wall_ns: u64,
+}
+
+/// Per-call-site profile emitted in a [`SpanReport`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpanProfile {
+    /// Emitting module path.
+    pub target: String,
+    /// Span name (the function name for `#[instrument]`).
+    pub name: String,
+    /// Number of completed calls.
+    pub calls: u64,
+    /// Total entered time, including nested spans.
+    pub total_ns: u64,
+    /// Total entered time excluding nested instrumented spans. This is the
+    /// figure that identifies which function to optimize.
+    pub self_ns: u64,
+    /// Total creation-to-close wall clock, including time not entered. On async
+    /// code the gap against `total_ns` is time awaiting something else.
+    pub wall_ns: u64,
+    /// Mean entered time per call.
+    pub mean_ns: u64,
+    /// Fastest observed call.
+    pub min_ns: u64,
+    /// Slowest observed call.
+    pub max_ns: u64,
+    /// Median entered time (histogram estimate).
+    pub p50_ns: u64,
+    /// 95th percentile entered time (histogram estimate).
+    pub p95_ns: u64,
+    /// 99th percentile entered time (histogram estimate).
+    pub p99_ns: u64,
+}
+
+/// A full profile snapshot, ordered by descending self time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpanReport {
+    /// Per-call-site profiles, hottest by self time first.
+    pub spans: Vec<SpanProfile>,
+}
+
+impl SpanReport {
+    /// Sum of self time across every call site.
+    pub fn total_self_ns(&self) -> u64 {
+        self.spans.iter().map(|s| s.self_ns).sum()
+    }
+
+    /// Whether any span was recorded.
+    pub fn is_empty(&self) -> bool {
+        self.spans.is_empty()
+    }
+}
+
+/// The process-wide span timing registry.
+#[derive(Default)]
+pub struct SpanTimings {
+    stats: Mutex<HashMap<SpanKey, SpanStat>>,
+}
+
+static TIMINGS: OnceLock<SpanTimings> = OnceLock::new();
+
+/// The global registry the layer writes into and reporters read from.
+pub fn global() -> &'static SpanTimings {
+    TIMINGS.get_or_init(SpanTimings::default)
+}
+
+impl SpanTimings {
+    /// Fold one completed span observation into the registry.
+    pub fn record(&self, key: SpanKey, sample: &SpanSample) {
+        // A poisoned lock means another thread panicked mid-update; the
+        // profile is diagnostic, so recovering beats propagating the panic.
+        let mut stats = match self.stats.lock() {
+            Ok(stats) => stats,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        stats
+            .entry(key)
+            .or_insert_with(SpanStat::new)
+            .record(sample);
+    }
+
+    /// Snapshot every call site, hottest by self time first.
+    pub fn report(&self) -> SpanReport {
+        let stats = match self.stats.lock() {
+            Ok(stats) => stats,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let mut spans: Vec<SpanProfile> = stats
+            .iter()
+            .map(|(key, stat)| {
+                let min_ns = if stat.calls == 0 { 0 } else { stat.min_busy_ns };
+                // The histogram estimates within ~12%, but min and max are
+                // tracked exactly. Clamping to them keeps a percentile from
+                // reading outside the observed range -- most visibly a p95
+                // below max on a single sample.
+                let quantile = |q: f64| {
+                    stat.hist
+                        .quantile(q)
+                        .unwrap_or(0)
+                        .clamp(min_ns, stat.max_busy_ns)
+                };
+                SpanProfile {
+                    target: key.target.to_string(),
+                    name: key.name.to_string(),
+                    calls: stat.calls,
+                    total_ns: stat.busy_ns,
+                    self_ns: stat.busy_ns.saturating_sub(stat.child_busy_ns),
+                    wall_ns: stat.wall_ns,
+                    mean_ns: stat.busy_ns.checked_div(stat.calls).unwrap_or(0),
+                    min_ns,
+                    max_ns: stat.max_busy_ns,
+                    p50_ns: quantile(0.50),
+                    p95_ns: quantile(0.95),
+                    p99_ns: quantile(0.99),
+                }
+            })
+            .collect();
+        spans.sort_by(|a, b| {
+            b.self_ns
+                .cmp(&a.self_ns)
+                .then_with(|| b.total_ns.cmp(&a.total_ns))
+                .then_with(|| a.target.cmp(&b.target))
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        SpanReport { spans }
+    }
+
+    /// Drop every recorded sample. Used by tests and by long-running callers
+    /// that report per interval.
+    pub fn reset(&self) {
+        let mut stats = match self.stats.lock() {
+            Ok(stats) => stats,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        stats.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(busy_ns: u64, child_busy_ns: u64) -> SpanSample {
+        SpanSample {
+            busy_ns,
+            child_busy_ns,
+            wall_ns: busy_ns,
+        }
+    }
+
+    fn key(name: &'static str) -> SpanKey {
+        SpanKey {
+            target: "mvm_core::test",
+            name,
+        }
+    }
+
+    #[test]
+    fn empty_registry_reports_nothing() {
+        let t = SpanTimings::default();
+        let report = t.report();
+        assert!(report.is_empty());
+        assert_eq!(report.total_self_ns(), 0);
+    }
+
+    #[test]
+    fn record_accumulates_calls_and_totals() {
+        let t = SpanTimings::default();
+        t.record(key("build"), &sample(1_000, 0));
+        t.record(key("build"), &sample(3_000, 0));
+
+        let report = t.report();
+        assert_eq!(report.spans.len(), 1);
+        let profile = &report.spans[0];
+        assert_eq!(profile.name, "build");
+        assert_eq!(profile.calls, 2);
+        assert_eq!(profile.total_ns, 4_000);
+        assert_eq!(profile.mean_ns, 2_000);
+        assert_eq!(profile.min_ns, 1_000);
+        assert_eq!(profile.max_ns, 3_000);
+    }
+
+    #[test]
+    fn self_time_excludes_nested_child_time() {
+        let t = SpanTimings::default();
+        // A 10ms call that spent 9ms inside an instrumented child.
+        t.record(key("parent"), &sample(10_000_000, 9_000_000));
+
+        let profile = &t.report().spans[0];
+        assert_eq!(profile.total_ns, 10_000_000);
+        assert_eq!(profile.self_ns, 1_000_000);
+    }
+
+    #[test]
+    fn report_is_sorted_by_self_time_descending() {
+        let t = SpanTimings::default();
+        t.record(key("cheap"), &sample(1_000, 0));
+        t.record(key("expensive"), &sample(9_000, 0));
+        t.record(key("middling"), &sample(5_000, 0));
+
+        let report = t.report();
+        let names: Vec<&str> = report.spans.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["expensive", "middling", "cheap"]);
+    }
+
+    #[test]
+    fn a_hot_parent_ranks_below_the_child_doing_the_work() {
+        let t = SpanTimings::default();
+        // The classic profiling trap: the parent has the largest total but the
+        // child is where the time actually goes.
+        t.record(key("orchestrate"), &sample(10_000_000, 9_500_000));
+        t.record(key("hash_layer"), &sample(9_500_000, 0));
+
+        let report = t.report();
+        assert_eq!(report.spans[0].name, "hash_layer");
+        assert_eq!(report.spans[1].name, "orchestrate");
+        assert_eq!(report.total_self_ns(), 10_000_000);
+    }
+
+    #[test]
+    fn distinct_targets_with_the_same_name_stay_separate() {
+        let t = SpanTimings::default();
+        t.record(
+            SpanKey {
+                target: "mvm_fs::oci",
+                name: "start",
+            },
+            &sample(1_000, 0),
+        );
+        t.record(
+            SpanKey {
+                target: "mvm_runtime::vm",
+                name: "start",
+            },
+            &sample(2_000, 0),
+        );
+
+        let report = t.report();
+        assert_eq!(report.spans.len(), 2);
+    }
+
+    #[test]
+    fn reset_clears_recorded_samples() {
+        let t = SpanTimings::default();
+        t.record(key("build"), &sample(1_000, 0));
+        assert!(!t.report().is_empty());
+        t.reset();
+        assert!(t.report().is_empty());
+    }
+
+    #[test]
+    fn child_time_exceeding_busy_saturates_to_zero_self_time() {
+        // Clock skew across threads must not underflow the subtraction.
+        let t = SpanTimings::default();
+        t.record(key("odd"), &sample(1_000, 5_000));
+        assert_eq!(t.report().spans[0].self_ns, 0);
+    }
+
+    #[test]
+    fn percentiles_are_populated_from_recorded_samples() {
+        let t = SpanTimings::default();
+        for ns in 1..=100u64 {
+            t.record(key("varied"), &sample(ns * 1_000_000, 0));
+        }
+        let profile = &t.report().spans[0];
+        assert!(profile.p50_ns > 0);
+        assert!(profile.p50_ns < profile.p95_ns);
+        assert!(profile.p95_ns <= profile.p99_ns);
+        assert!(profile.p99_ns <= profile.max_ns);
+    }
+
+    #[test]
+    fn percentiles_stay_within_the_observed_min_and_max() {
+        // The histogram estimates within a bucket; min/max are exact. A p95
+        // reading above max (or a p50 below min) is a bucket artifact, not a
+        // measurement, and would misread as a real tail.
+        let t = SpanTimings::default();
+        t.record(key("single"), &sample(696_800_000, 0));
+
+        let profile = &t.report().spans[0];
+        assert_eq!(profile.calls, 1);
+        for (label, value) in [
+            ("p50", profile.p50_ns),
+            ("p95", profile.p95_ns),
+            ("p99", profile.p99_ns),
+        ] {
+            assert!(
+                value >= profile.min_ns && value <= profile.max_ns,
+                "{label} = {value} outside [{}, {}]",
+                profile.min_ns,
+                profile.max_ns
+            );
+        }
+    }
+
+    #[test]
+    fn a_single_sample_reports_identical_percentiles_min_and_max() {
+        let t = SpanTimings::default();
+        t.record(key("once"), &sample(5_000_000, 0));
+
+        let profile = &t.report().spans[0];
+        assert_eq!(profile.min_ns, 5_000_000);
+        assert_eq!(profile.max_ns, 5_000_000);
+        assert_eq!(profile.p50_ns, 5_000_000);
+        assert_eq!(profile.p99_ns, 5_000_000);
+    }
+
+    #[test]
+    fn report_round_trips_through_json() {
+        let t = SpanTimings::default();
+        t.record(key("build"), &sample(1_000, 0));
+        let report = t.report();
+        let json = serde_json::to_string(&report).expect("serialize");
+        let back: SpanReport = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(report, back);
+    }
+}

--- a/crates/mvm-core/tests/span_timing.rs
+++ b/crates/mvm-core/tests/span_timing.rs
@@ -1,0 +1,216 @@
+//! End-to-end checks that `#[instrument]` attributes actually produce timings.
+//!
+//! The regression these guard against is the one that made the attributes
+//! already in the tree inert: spans that are never constructed, because no
+//! installed layer was interested in them, cannot be measured.
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use mvm_core::observability::span_timing::{SpanReport, SpanTimingLayer, SpanTimings};
+use tracing::instrument;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::prelude::*;
+
+/// The target every fixture span reports under. It must share the `mvm` prefix
+/// with real workspace crates so the default timing filter applies.
+const TARGET: &str = "mvm_core::span_timing_fixture";
+
+#[instrument(target = "mvm_core::span_timing_fixture")]
+fn leaf(millis: u64) {
+    sleep(Duration::from_millis(millis));
+}
+
+#[instrument(target = "mvm_core::span_timing_fixture")]
+fn parent_calling_leaf() {
+    sleep(Duration::from_millis(5));
+    leaf(20);
+}
+
+#[instrument(target = "mvm_core::span_timing_fixture", level = "trace")]
+fn trace_level_work() {
+    sleep(Duration::from_millis(1));
+}
+
+/// A fresh registry per test; integration tests share one process, so a global
+/// would let concurrent tests contaminate each other's assertions.
+fn fresh_registry() -> &'static SpanTimings {
+    Box::leak(Box::new(SpanTimings::default()))
+}
+
+/// Run `body` against a subscriber whose *log* filter is `log_filter` and whose
+/// *timing* filter is `timing_filter`.
+fn profile_with_filters(
+    log_filter: &str,
+    timing_filter: &str,
+    body: impl FnOnce(),
+) -> (SpanReport, &'static SpanTimings) {
+    let registry = fresh_registry();
+    let subscriber = tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_filter(EnvFilter::new(log_filter)))
+        .with(SpanTimingLayer::with_registry(registry).with_filter(EnvFilter::new(timing_filter)));
+
+    tracing::subscriber::with_default(subscriber, body);
+    (registry.report(), registry)
+}
+
+fn profile(body: impl FnOnce()) -> SpanReport {
+    profile_with_filters("error", "mvm=trace", body).0
+}
+
+fn find<'a>(
+    report: &'a SpanReport,
+    name: &str,
+) -> &'a mvm_core::observability::span_timing::SpanProfile {
+    report
+        .spans
+        .iter()
+        .find(|s| s.name == name)
+        .unwrap_or_else(|| {
+            panic!(
+                "no span named {name}; recorded: {:?}",
+                report.spans.iter().map(|s| &s.name).collect::<Vec<_>>()
+            )
+        })
+}
+
+#[test]
+fn instrumented_function_is_timed_despite_a_quiet_log_filter() {
+    // This is the CLI's default posture: RUST_LOG unset, no -v, so logs are
+    // filtered at `error` while `#[instrument]` spans default to INFO.
+    let report = profile(|| leaf(20));
+
+    let leaf = find(&report, "leaf");
+    assert_eq!(leaf.calls, 1);
+    assert_eq!(leaf.target, TARGET);
+    assert!(
+        leaf.self_ns >= Duration::from_millis(15).as_nanos() as u64,
+        "expected ~20ms, got {}ns",
+        leaf.self_ns
+    );
+}
+
+#[test]
+fn a_registry_wide_filter_suppresses_span_construction_and_yields_no_timings() {
+    // Documents why the layer stack attaches the log filter to the fmt layer
+    // instead of to the registry. With a registry-wide filter the span is never
+    // constructed, so no layer -- however wide its own filter -- can time it.
+    // This was the arrangement that left the workspace's existing
+    // `#[instrument]` attributes producing nothing.
+    let registry = fresh_registry();
+    let subscriber = tracing_subscriber::registry()
+        .with(EnvFilter::new("error"))
+        .with(SpanTimingLayer::with_registry(registry).with_filter(EnvFilter::new("mvm=trace")));
+
+    tracing::subscriber::with_default(subscriber, || leaf(5));
+
+    assert!(
+        registry.report().is_empty(),
+        "a registry-wide filter should suppress the span entirely, got {:?}",
+        registry.report().spans
+    );
+}
+
+#[test]
+fn a_span_below_the_timing_filter_is_not_recorded() {
+    // The timing layer's filter, not the attribute, decides what is measured.
+    let report = profile_with_filters("error", "mvm=off", || leaf(5)).0;
+    assert!(
+        report.is_empty(),
+        "expected nothing recorded, got {:?}",
+        report.spans
+    );
+}
+
+#[test]
+fn a_non_matching_target_is_not_recorded() {
+    let report = profile_with_filters("error", "some_other_crate=trace", || leaf(5)).0;
+    assert!(report.is_empty(), "got {:?}", report.spans);
+}
+
+#[test]
+fn trace_level_spans_are_timed_even_though_logs_stop_at_error() {
+    let report = profile(trace_level_work);
+    assert_eq!(find(&report, "trace_level_work").calls, 1);
+}
+
+#[test]
+fn repeated_calls_accumulate_into_one_row() {
+    let report = profile(|| {
+        for _ in 0..3 {
+            leaf(2);
+        }
+    });
+
+    let leaf = find(&report, "leaf");
+    assert_eq!(leaf.calls, 3);
+    assert_eq!(report.spans.len(), 1, "calls must fold into a single row");
+    assert!(
+        leaf.total_ns >= leaf.max_ns,
+        "total must cover the slowest call"
+    );
+    assert!(leaf.min_ns <= leaf.max_ns);
+}
+
+#[test]
+fn nested_spans_attribute_self_time_to_the_function_doing_the_work() {
+    // parent sleeps 5ms itself and calls a leaf that sleeps 20ms.
+    let report = profile(parent_calling_leaf);
+
+    let parent = find(&report, "parent_calling_leaf");
+    let leaf = find(&report, "leaf");
+
+    // The parent's *total* includes the leaf; its *self* time does not.
+    assert!(
+        parent.total_ns > leaf.total_ns,
+        "parent total {} should exceed leaf total {}",
+        parent.total_ns,
+        leaf.total_ns
+    );
+    assert!(
+        parent.self_ns < leaf.self_ns,
+        "parent self {} should be below leaf self {}",
+        parent.self_ns,
+        leaf.self_ns
+    );
+
+    // Ranking by self time must therefore surface the leaf first.
+    assert_eq!(
+        report.spans[0].name,
+        "leaf",
+        "hottest-by-self-time should be the leaf, got {:?}",
+        report.spans.iter().map(|s| &s.name).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn self_times_sum_to_roughly_the_wall_clock_of_the_root() {
+    let report = profile(parent_calling_leaf);
+    let total_self = report.total_self_ns();
+    let root_total = find(&report, "parent_calling_leaf").total_ns;
+
+    // Self time partitions the root's elapsed time, so the sum should track it
+    // closely rather than double-counting the nested call.
+    let delta = total_self.abs_diff(root_total);
+    assert!(
+        delta < Duration::from_millis(10).as_nanos() as u64,
+        "self-time sum {total_self} diverged from root total {root_total}"
+    );
+}
+
+#[test]
+fn reset_clears_state_between_profiling_runs() {
+    let (report, registry) = profile_with_filters("error", "mvm=trace", || leaf(1));
+    assert!(!report.is_empty());
+    registry.reset();
+    assert!(registry.report().is_empty());
+}
+
+#[test]
+fn report_serializes_to_json_for_run_over_run_comparison() {
+    let report = profile(|| leaf(1));
+    let json = serde_json::to_string(&report).expect("serialize");
+    assert!(json.contains("\"leaf\""), "{json}");
+    let back: SpanReport = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back, report);
+}

--- a/crates/mvm-core/tests/span_timing_overhead.rs
+++ b/crates/mvm-core/tests/span_timing_overhead.rs
@@ -1,0 +1,153 @@
+//! Measures what the span-timing layer costs per span, single-threaded and
+//! under contention.
+//!
+//! The registry serialises on one lock at span close. Whether that is
+//! acceptable is a question about a number, not a matter of opinion, so the
+//! number is measured here rather than asserted in prose. Run with
+//! `--nocapture` to read the measurements:
+//!
+//! ```text
+//! cargo test -p mvm-core --test span_timing_overhead -- --nocapture
+//! ```
+//!
+//! The assertions are deliberately loose. They exist to catch a pathological
+//! regression — a deadlock, or per-record work that grows with the number of
+//! recorded spans — not to pin a performance number on a shared CI box.
+
+use std::thread;
+use std::time::Instant;
+
+use mvm_core::observability::span_timing::{SpanTimingLayer, SpanTimings};
+use tracing::dispatcher::{self, Dispatch};
+use tracing::instrument;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::prelude::*;
+
+/// Spans recorded per thread in each measurement.
+const SPANS_PER_THREAD: u32 = 20_000;
+
+/// Ceiling per recorded span. Generous by design: a loaded CI box is slow, but
+/// nothing healthy is anywhere near this.
+const MAX_NS_PER_SPAN: u128 = 100_000;
+
+#[instrument(target = "mvm_core::overhead_fixture")]
+fn measured(i: u32) -> u32 {
+    i.wrapping_add(1)
+}
+
+fn registry() -> &'static SpanTimings {
+    Box::leak(Box::new(SpanTimings::default()))
+}
+
+fn dispatch_for(registry: &'static SpanTimings) -> Dispatch {
+    Dispatch::new(
+        tracing_subscriber::registry().with(
+            SpanTimingLayer::with_registry(registry).with_filter(EnvFilter::new("mvm=trace")),
+        ),
+    )
+}
+
+/// Drive `SPANS_PER_THREAD * threads` spans and return nanoseconds per span.
+fn measure(threads: usize, registry: &'static SpanTimings) -> u128 {
+    let dispatch = dispatch_for(registry);
+    let start = Instant::now();
+
+    thread::scope(|scope| {
+        for _ in 0..threads {
+            let dispatch = dispatch.clone();
+            scope.spawn(move || {
+                dispatcher::with_default(&dispatch, || {
+                    for i in 0..SPANS_PER_THREAD {
+                        std::hint::black_box(measured(std::hint::black_box(i)));
+                    }
+                });
+            });
+        }
+    });
+
+    let total = SPANS_PER_THREAD as u128 * threads as u128;
+    start.elapsed().as_nanos() / total
+}
+
+#[test]
+fn single_threaded_overhead_per_span_is_bounded() {
+    let registry = registry();
+    let ns = measure(1, registry);
+    println!("span timing overhead: {ns} ns/span (1 thread)");
+
+    assert_eq!(
+        registry.report().spans.len(),
+        1,
+        "all calls should fold into one call site"
+    );
+    assert_eq!(registry.report().spans[0].calls, SPANS_PER_THREAD as u64);
+    assert!(ns < MAX_NS_PER_SPAN, "{ns} ns/span exceeds the ceiling");
+}
+
+#[test]
+fn contended_overhead_per_span_is_bounded() {
+    let threads = std::thread::available_parallelism()
+        .map(|n| n.get().clamp(2, 8))
+        .unwrap_or(4);
+
+    let registry = registry();
+    let ns = measure(threads, registry);
+    println!("span timing overhead: {ns} ns/span ({threads} threads)");
+
+    let report = registry.report();
+    assert_eq!(report.spans.len(), 1);
+    assert_eq!(
+        report.spans[0].calls,
+        SPANS_PER_THREAD as u64 * threads as u64,
+        "every thread's spans must be recorded exactly once"
+    );
+    assert!(ns < MAX_NS_PER_SPAN, "{ns} ns/span exceeds the ceiling");
+}
+
+#[test]
+fn recording_cost_does_not_grow_with_the_number_of_recorded_spans() {
+    // The failure this guards is a registry whose per-record work is linear in
+    // what it already holds; that would make a long run quadratic and would not
+    // show up in a short one.
+    let registry = registry();
+    let first = measure(1, registry);
+    let second = measure(1, registry);
+    println!("span timing overhead: first {first} ns/span, second {second} ns/span (1 thread)");
+
+    assert_eq!(
+        registry.report().spans[0].calls,
+        SPANS_PER_THREAD as u64 * 2
+    );
+    // Wall-clock noise on a shared box is large, so this only catches growth of
+    // a different order, not a few percent of drift.
+    assert!(
+        second < first.max(1) * 8 + 10_000,
+        "second pass {second} ns/span ballooned against first {first} ns/span"
+    );
+}
+
+#[test]
+fn a_disabled_layer_records_nothing_and_stays_cheap() {
+    // The off path is what every non-profiling run pays, so it gets its own
+    // measurement rather than being assumed free.
+    let registry = registry();
+    let dispatch = Dispatch::new(
+        tracing_subscriber::registry()
+            .with(SpanTimingLayer::with_registry(registry).with_filter(EnvFilter::new("mvm=off"))),
+    );
+
+    let start = Instant::now();
+    dispatcher::with_default(&dispatch, || {
+        for i in 0..SPANS_PER_THREAD {
+            std::hint::black_box(measured(std::hint::black_box(i)));
+        }
+    });
+    let ns = start.elapsed().as_nanos() / SPANS_PER_THREAD as u128;
+    println!("span timing overhead: {ns} ns/span (layer filtered off)");
+
+    assert!(
+        registry.report().is_empty(),
+        "a filtered-off layer must record nothing"
+    );
+    assert!(ns < MAX_NS_PER_SPAN, "{ns} ns/span exceeds the ceiling");
+}

--- a/crates/mvm-fs/Cargo.toml
+++ b/crates/mvm-fs/Cargo.toml
@@ -29,6 +29,7 @@ sha2 = { workspace = true }
 tar = { workspace = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros", "rt", "time"] }
+tracing.workspace = true
 uuid.workspace = true
 xattr = { workspace = true }
 

--- a/crates/mvm-fs/src/hash.rs
+++ b/crates/mvm-fs/src/hash.rs
@@ -11,11 +11,13 @@ use std::io;
 use std::path::Path;
 
 use sha2::{Digest, Sha256};
+use tracing::instrument;
 
 use crate::overlay::compute_file_sha256;
 
 /// Compute the content hash of `source` (a regular file or a directory).
 /// Returns the lowercase 64-hex-digit SHA-256 digest.
+#[instrument(skip_all, fields(source = %source.display()))]
 pub fn hash_source(source: &Path) -> io::Result<String> {
     let meta = fs::symlink_metadata(source)?;
     if meta.is_dir() {

--- a/crates/mvm-fs/src/oci/layer.rs
+++ b/crates/mvm-fs/src/oci/layer.rs
@@ -38,6 +38,7 @@ use std::time::Duration;
 use crate::oci::unpack::{UnpackOptions, UnpackReport, unpack_layer_with_prior_paths};
 use flate2::read::GzDecoder;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tracing::instrument;
 
 /// Marker substring stored in the `io::Error` we return from the
 /// hashing writer when the size cap fires. The retry loop checks
@@ -570,6 +571,7 @@ impl OciLayerFetcher {
 /// This is the cache-hit counterpart to
 /// [`OciLayerFetcher::fetch_and_unpack_layer`]: it avoids loading the
 /// entire compressed blob into memory just to verify and unpack it.
+#[instrument(skip_all, fields(digest = %layer.digest, media_type = %layer.media_type))]
 pub async fn verify_and_unpack_layer_file(
     layer: &LayerDescriptor,
     cache_path: &Path,

--- a/crates/mvm-fs/src/oci/unpack/mod.rs
+++ b/crates/mvm-fs/src/oci/unpack/mod.rs
@@ -186,6 +186,7 @@ use entries::{
     unpack_hardlink_entry, unpack_regular_entry, unpack_symlink_entry,
 };
 use fs_ops::{Rooted, parent_chain_has_symlink};
+use tracing::instrument;
 use whiteout::{WhiteoutKind, classify_whiteout};
 use xattr::{XattrWarningReason, collect_entry_xattrs};
 
@@ -573,6 +574,10 @@ pub fn unpack_layer<R: Read>(
 /// from earlier layers without giving up the `O_EXCL` / `O_NOFOLLOW`
 /// first-creation safety for paths that are genuinely new. Same-layer
 /// duplicates remain refused.
+#[instrument(
+    skip_all,
+    fields(output_root = %output_root.display(), prior_paths = prior_layer_paths.len())
+)]
 pub fn unpack_layer_with_prior_paths<R: Read>(
     layer_tar: R,
     output_root: &Path,

--- a/crates/mvm-fs/src/oci_to_rootfs/ext4.rs
+++ b/crates/mvm-fs/src/oci_to_rootfs/ext4.rs
@@ -31,6 +31,7 @@
 use crate::oci_to_rootfs::error::OciUnpackError;
 use crate::oci_to_rootfs::unpack::StagedRootfs;
 use std::path::{Path, PathBuf};
+use tracing::instrument;
 
 #[cfg(any(target_os = "linux", test))]
 const DISABLED_EXT4_FEATURES: &str = "^has_journal,^orphan_file";
@@ -116,6 +117,7 @@ pub struct MaterializedRootfs {
 /// rounded up to a multiple of `block_size`. The minimum result
 /// is always at least 1 MiB — `mke2fs` rejects smaller images
 /// outright.
+#[instrument(skip_all, fields(staged_root = %staged_root.display()))]
 pub fn estimate_image_size(
     staged_root: &Path,
     options: &Mke2fsOptions,
@@ -146,6 +148,7 @@ pub fn estimate_image_size(
 /// [`OciUnpackError::HostUnsupported`]. The CLI orchestrator
 /// routes the macOS path through the libkrun builder VM — that
 /// routing lives one layer up, not in this module.
+#[instrument(skip_all, fields(output = %output.display()))]
 pub fn materialize_to_ext4(
     staged: &StagedRootfs,
     output: &Path,

--- a/crates/mvm-fs/src/oci_to_rootfs/verity.rs
+++ b/crates/mvm-fs/src/oci_to_rootfs/verity.rs
@@ -39,6 +39,7 @@
 use crate::oci_to_rootfs::error::OciUnpackError;
 use crate::oci_to_rootfs::ext4::MaterializedRootfs;
 use std::path::{Path, PathBuf};
+use tracing::instrument;
 
 /// `data-block-size` pinned to 4096 bytes. Must match the
 /// workload ext4 block size the run path materializes; otherwise
@@ -148,6 +149,7 @@ pub struct VeritySealedRootfs {
 /// Linux-only at runtime; non-Linux hosts return
 /// [`OciUnpackError::HostUnsupported`]. The CLI orchestrator
 /// routes the macOS path through the libkrun builder VM.
+#[instrument(skip_all, fields(rootfs = %rootfs.path.display()))]
 pub fn seal_with_verity(
     rootfs: &MaterializedRootfs,
     options: &VeritysetupOptions,

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -205,6 +205,7 @@ pub struct BundleAdmissionContext<'a> {
 /// `posture` is what the plan cannot be trusted to say: whether this is a
 /// sealed production launch or a developer's boot, and which backend will
 /// actually boot it. See [`RunPosture`].
+#[tracing::instrument(skip_all)]
 pub fn admit_for_run(
     input: &SynthesisInput<'_>,
     clock: &dyn Clock,
@@ -1050,6 +1051,7 @@ fn run_post_admission_gates(
     Ok(config)
 }
 
+#[tracing::instrument(skip_all)]
 pub fn admit_and_start(
     backend: &AnyBackend,
     params: AdmitAndStartParams<'_>,

--- a/crates/mvm-hostd/src/supervisor/audit_file.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_file.rs
@@ -446,6 +446,7 @@ pub fn verify_audit_chain(path: &Path, verifying_key: &VerifyingKey) -> Result<u
 /// Verify a chain-signed audit file and return its authenticated entries in
 /// chain order. Consumers use this when a decision depends on signed labels,
 /// rather than parsing an already-verified file a second time.
+#[tracing::instrument(skip_all, fields(path = %path.display()))]
 pub fn verify_audit_chain_entries(
     path: &Path,
     verifying_key: &VerifyingKey,

--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -212,6 +212,33 @@ The lane mirrored at `.github/workflows/ci.yml::core-demo-e2e` runs the same com
 
 The same gated convention covers `crates/mvm-sdk/sdks/python/tests/test_sandbox_exec.py`, which exercises `Sandbox.exec(*argv) -> ExecResult` against a real microVM. Default-skips on `pytest`; opt-in with `MVM_E2E_SMOKE=1 python -m pytest crates/mvm-sdk/sdks/python/tests/test_sandbox_exec.py`.
 
+## Profiling
+
+Functions carrying `#[instrument]` are timed when `MVM_SPAN_TIMINGS` is set.
+Profiling is off otherwise — the timing layer is not installed at all.
+
+```bash
+MVM_SPAN_TIMINGS=1 mvmctl <command>              # table to stderr
+MVM_SPAN_TIMINGS=json mvmctl <command>           # JSON to stderr
+MVM_SPAN_TIMINGS=json MVM_SPAN_TIMINGS_OUT=/tmp/p.json mvmctl <command>
+MVM_SPAN_TIMINGS=1 MVM_SPAN_TIMINGS_FILTER=mvm_fs=trace mvmctl <command>
+```
+
+The report is sorted by **self time** — time inside the function excluding
+nested instrumented calls — which is the column that identifies what to
+optimize. A row with high `total` but low `self` is an orchestrator whose cost
+lives in a callee. `wall` above `total` means the span was open but not
+entered; on async code that gap is time spent awaiting something else.
+
+Percentiles come from a fixed-memory log-scale histogram and carry ~12% bucket
+error. They are a profiling signal, not an SLO measurement.
+
+Span timing is independent of `-v`: spans are measured even at the default
+quiet log filter. To add a new measurement point, put `#[instrument(skip_all)]`
+on the function. Prefer coarse entry points — recording takes a process-wide
+lock on span close, so instrumenting a per-item inner loop distorts the
+measurement it is meant to produce.
+
 ## Linting and Formatting
 
 ```bash

--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -237,7 +237,25 @@ Span timing is independent of `-v`: spans are measured even at the default
 quiet log filter. To add a new measurement point, put `#[instrument(skip_all)]`
 on the function. Prefer coarse entry points — recording takes a process-wide
 lock on span close, so instrumenting a per-item inner loop distorts the
-measurement it is meant to produce.
+measurement it is meant to produce. Measured cost, debug build: 12 ns/span with
+profiling off, ~4 us/span with it on, and aggregate throughput rises rather
+than falls under contention (`cargo test -p mvm-core --test
+span_timing_overhead -- --nocapture`).
+
+When profiling is enabled, the served metrics endpoint also carries
+`mvm_span_calls_total`, `mvm_span_self_seconds_total`,
+`mvm_span_total_seconds_total`, and `mvm_span_max_seconds`, each labelled with
+`target` and `span`. Nothing is exported when profiling is off. This is the
+scrape endpoint only, not `mvmctl ops metrics`: a profile accumulates in the
+process that ran the instrumented code, and a short-lived CLI invocation
+renders its output before doing any work, so those series would always be
+empty there.
+
+To diff two runs rather than read two tables, `bench::span_profile` captures a
+profile from a child `mvmctl` and compares them. It gates on **per-call** self
+time, so a run with more iterations does not read as a regression, and reports
+call-count changes separately — a function called twice as often is a different
+defect from one that got slower.
 
 ## Linting and Formatting
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -71,6 +71,16 @@ for detailed scope and acceptance criteria.
   - [ ] Run Linux-native workspace Clippy/tests in the project builder
         environment
 
+- [~] Plan 318 — span-timing profiling
+      (`specs/plans/318-span-timing-profiling.md`)
+  - [x] Phase 1 — `SpanTimingLayer`, bounded log-scale histogram, self-time
+        attribution, text/JSON reports, per-layer log filter so spans are
+        constructed at the CLI's default `error` verbosity
+  - [x] Phase 2 — instrument `mvm-fs` OCI/ext4 entry points and the four
+        backend `boot` paths plus HVF restore
+  - [ ] Phase 3 — feed reports into the `bench/` regression harness, export via
+        prometheus, revisit the per-close mutex if instrumentation gets finer
+
 - [x] Plan 2167 — durable agent session and event contract
       (`specs/plans/2167-agent-session-contract.md`)
   - [x] Versioned public IDs, lifecycle commands, durable/ephemeral event

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -71,16 +71,20 @@ for detailed scope and acceptance criteria.
   - [ ] Run Linux-native workspace Clippy/tests in the project builder
         environment
 
-- [~] Plan 318 — span-timing profiling
+- [x] Plan 318 — span-timing profiling
       (`specs/plans/318-span-timing-profiling.md`)
   - [x] Phase 1 — `SpanTimingLayer`, bounded log-scale histogram, self-time
         attribution, text/JSON reports, per-layer log filter so spans are
         constructed at the CLI's default `error` verbosity
   - [x] Phase 2 — instrument `mvm-fs` OCI/ext4 entry points and the four
-        backend `boot` paths plus HVF restore
-  - [ ] Phase 3 — feed reports into the `bench/` regression harness, export via
-        prometheus, revisit the per-close mutex if instrumentation gets finer
-
+        backend `boot` paths plus HVF restore, then the launch critical path
+        in `mvm-cli` and the admission/audit/build/client entry points
+  - [x] Phase 3 — labelled prometheus export, pure per-call profile diffing in
+        `bench/span_profile.rs`, and a measured decision to keep the per-close
+        mutex (12 ns/span disabled; throughput scales up, not down, under
+        contention). Wiring the diff into a CI lane stays with Plan 311's
+        large-image work; guest-side `mvm-agentd` needs a profile egress path
+        first.
 - [x] Plan 2167 — durable agent session and event contract
       (`specs/plans/2167-agent-session-contract.md`)
   - [x] Versioned public IDs, lifecycle commands, durable/ephemeral event

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -64,6 +64,30 @@
       guard and use an explicit isolated host configuration, so bounded-host
       fixtures cannot leak their ceiling into parallel admission tests.
 
+- [x] Span-timing profiling — **plan 318**. The workspace's ~60 `#[instrument]`
+      attributes produced no timing data: no layer consumed span close events,
+      and both subscriber setups attached `EnvFilter` to the registry, so at the
+      CLI's default `error` filter the INFO spans were never constructed at all.
+      Plan 318 adds the missing consumer (a `SpanTimingLayer` over a bounded
+      log-scale histogram, reporting self time as well as inclusive total),
+      moves the log filter onto the fmt layer so spans are constructed
+      regardless of verbosity, and instruments the OCI/ext4 paths in `mvm-fs`
+      (which carried no `tracing` dependency at all) plus the four backend
+      `boot` entry points and HVF restore. Opt-in via `MVM_SPAN_TIMINGS=1|json`;
+      off by default. This is the systematic form of the ad-hoc measurement
+      behind the Plan 311 findings below.
+
+      Instrumentation then extends to the launch critical path — `mvm-cli` had
+      none at all, and it owns the orchestration upstream of where
+      `launch_trace`'s six marks begin. `sha256_file` and its cached wrapper are
+      timed separately so the re-hash below is a row in the profile rather than
+      an inference, and the `ps` process-table scan and OCI pull/layer paths are
+      named. Daemon and build entry points (`admit_for_run`, `admit_and_start`,
+      `verify_audit_chain_entries`, `pool_build_with_opts`, `build_via_vsock`,
+      `workload_build_fingerprint`, `launch_transient`) follow. Guest-side
+      `mvm-agentd` is deliberately excluded — its spans would land on the
+      guest's stderr, which needs a collection path that does not exist yet.
+
 - [ ] Launch critical-path waste on real-sized images — **issues #2273–#2276,
       plan 311**. Plan 299's prepared-cold baseline runs `alpine`, whose cached
       rootfs is 9.9 MB, and reports the ≤200 ms p50 contract as met. Three

--- a/specs/plans/318-span-timing-profiling.md
+++ b/specs/plans/318-span-timing-profiling.md
@@ -1,6 +1,6 @@
 # Plan 318 — Span-timing profiling for `#[instrument]`
 
-**Status:** Phase 1 COMPLETE
+**Status:** COMPLETE (Phases 1-3)
 **Date opened:** 2026-08-10
 **Branch:** `perf/318-span-timing`
 
@@ -119,14 +119,74 @@ instrumentation at all. The two are deliberately not bridged.
 - Pure predicates (`argv_is_shell`, `program_basename`) and `mvm-contract`
   (`no_std`, no `tracing` by design).
 
-### Phase 3 — deferred
+### Phase 3 (COMPLETE)
 
-- [ ] Feed `SpanReport` into the `bench/` regression harness so launch-path
-      profiles are diffable run over run rather than read by eye.
-- [ ] Export the report through `Metrics::prometheus_exposition` for `mvmd`.
-- [ ] Decide whether the per-close mutex needs replacing with sharded or
-      thread-local accumulation. It is adequate while profiling is opt-in and
-      instrumentation stays coarse; it would not be if either changes.
+- [x] **Prometheus export.** `span_timing::prometheus_exposition` renders a
+      `SpanReport` as labelled series — `mvm_span_calls_total`,
+      `mvm_span_self_seconds_total`, `mvm_span_total_seconds_total`,
+      `mvm_span_max_seconds`, each carrying `target` and `span` labels. The
+      existing `Metrics` counters are fixed-name singletons, so labels are what
+      a per-call-site metric needs. Durations are exported in seconds per
+      Prometheus convention. Label values are escaped: an unescaped quote in a
+      span name would produce a malformed exposition that breaks the whole
+      scrape rather than one series. Appended to the served body in
+      `mvm-cli/src/metrics_server.rs`, and empty unless the process is
+      profiling, so the scrape shape is unchanged for everyone else.
+
+      Not wired into `mvmctl ops metrics`. It was, briefly, until a live run
+      showed it structurally empty: a profile accumulates in the process that
+      ran the instrumented code, and that command renders its output before
+      doing any. The scrape endpoint is different — there the serving process is
+      the one doing the work, so each scrape reflects what has happened so far.
+
+- [x] **Bench-harness diffing.** `mvm-cli/src/bench/span_profile.rs`. The launch
+      harness spawns `mvmctl` as a child, so `profile_env` supplies the env that
+      makes the child write a JSON profile and `read_profile` reads it back;
+      this composes with the runner's existing env list without changing it.
+      `compare_span_reports` is pure and returns a per-call-site
+      `RegressionVerdict` (reusing `regression.rs`'s enum), plus the spans that
+      appeared or disappeared between runs.
+
+      The gate compares **per-call** self time, not total. Two runs may execute
+      a different number of iterations, and a total-time gate would read that as
+      a regression. Call counts are reported alongside via
+      `SpanDelta::call_count_changed`, because "this function got slower" and
+      "this function got called twice as often" are different defects that need
+      telling apart — the second is exactly the shape of the Plan 311 re-hash. A
+      zero or call-less baseline returns `Incomparable` rather than a pass,
+      since a ratio against zero would be a false green.
+
+- [x] **The per-close mutex stays.** Measured rather than argued, in
+      `crates/mvm-core/tests/span_timing_overhead.rs` (debug build, Apple
+      silicon; release is faster and the ratios are what matter):
+
+      | scenario                        | ns/span |
+      | ------------------------------- | ------- |
+      | profiling disabled (filtered)   | 12      |
+      | enabled, 1 thread               | 4,278   |
+      | enabled, 8 threads (aggregate)  | 2,084   |
+
+      Aggregate throughput *improves* roughly 2x under 8 threads rather than
+      collapsing, so the lock is not the bottleneck at entry-point granularity —
+      most of the per-span cost sits outside the critical section. Sharded or
+      thread-local accumulation would be speculative complexity, so it is not
+      built. The disabled path costs 12 ns/span, which is what every
+      non-profiling run pays.
+
+      The tests assert a deliberately loose ceiling. They exist to catch a
+      pathological regression — a deadlock, or per-record work that grows with
+      what the registry already holds — not to pin a number on a shared CI box.
+      Revisit if instrumentation moves into an inner loop; that is the condition
+      that would change the answer.
+
+### Still deferred
+
+- [ ] Wire `compare_span_reports` into a CI lane. The comparison and capture are
+      in place and tested; choosing a baseline artifact and a tolerance is a
+      launch-lane decision that belongs with Plan 311's large-image work, not
+      here.
+- [ ] Guest-side profiling for `mvm-agentd`, which needs a path to get a profile
+      out of the guest before instrumenting it is worth anything.
 
 ## Usage
 

--- a/specs/plans/318-span-timing-profiling.md
+++ b/specs/plans/318-span-timing-profiling.md
@@ -1,0 +1,165 @@
+# Plan 318 — Span-timing profiling for `#[instrument]`
+
+**Status:** Phase 1 COMPLETE
+**Date opened:** 2026-08-10
+**Branch:** `perf/318-span-timing`
+
+## Problem
+
+The workspace carries ~60 `#[instrument]` attributes across 17 files. None of
+them produce timing data, for two independent reasons:
+
+1. **No layer consumes span close events.** `rg 'FmtSpan|with_span_events'`
+   returned no hits anywhere in the tree. `tracing` does not time spans on its
+   own — a span's duration exists only if some layer records `on_close`.
+2. **The log filter suppressed span construction.** Both subscriber setups
+   (`mvm-core/src/observability/logging.rs`, `mvm-cli/src/logging.rs`) attached
+   `EnvFilter` to the *registry*, making it a global filter. The CLI's default
+   at verbosity 0 is `error`, while `#[instrument]` declares INFO spans, so the
+   spans were never constructed at all.
+
+The consequence is that the attributes read as instrumentation but are inert.
+Adding more of them changes nothing until a consumer exists.
+
+This is the same measurement gap the sprint's current top item works around:
+Plan 311's launch-path findings (~557 ms re-hash, ~67 ms `ps` subprocess,
+~28 ms verity marker scan) came from ad-hoc measurement, not from a profile the
+tool can produce on demand.
+
+## Approach
+
+Build the consumer first, then instrument.
+
+### Phase 1 — the timing layer (COMPLETE)
+
+- [x] `LogHistogram` — fixed-memory (2 KiB) log-scale histogram, 4 sub-buckets
+      per octave, ~12% typical bucket error. Bounded so a long-running daemon
+      cannot grow unbounded sample vectors.
+      (`crates/mvm-core/src/observability/span_timing/histogram.rs`)
+- [x] `SpanTimings` registry keyed by `(target, name)`, accumulating calls,
+      inclusive time, child time, wall clock, min/max and the histogram.
+      (`.../span_timing/registry.rs`)
+- [x] `SpanTimingLayer` — records `on_new_span`/`on_enter`/`on_exit`/`on_close`
+      and attributes each span's time upward to its parent's `child_busy_ns`,
+      so the report can show **self time** (time in this function excluding
+      nested instrumented calls) alongside inclusive total.
+      (`.../span_timing/layer.rs`)
+- [x] Text and JSON report rendering, sorted by self time descending.
+      (`.../span_timing/mod.rs`)
+- [x] **Layer stack fix**: the log filter now attaches to the fmt layer as a
+      per-layer filter rather than to the registry, so the timing layer's own
+      (wider) filter governs whether a span is constructed. This is the change
+      that makes any of the existing attributes measurable.
+- [x] `mvm-cli/src/logging.rs` reduced to the verbosity mapping and delegated
+      to `mvm-core`, removing a duplicated subscriber assembly.
+- [x] Report emitted at CLI exit via `mvm_cli::commands::run`.
+
+### Phase 2 — instrumenting hot paths (COMPLETE)
+
+Coarse-grained entry points only. Per-file/per-entry functions are deliberately
+left uninstrumented: the registry takes a mutex per span close, so instrumenting
+an inner loop would distort the measurement it is meant to produce.
+
+- [x] `mvm-fs` (previously had no `tracing` dependency at all — the OCI and ext4
+      crate, the heaviest I/O path):
+      `unpack_layer_with_prior_paths`, `verify_and_unpack_layer_file`,
+      `materialize_to_ext4`, `estimate_image_size`, `seal_with_verity`,
+      `hash_source`.
+- [x] `mvm-backends` launch paths: `fc.boot`, `hvf.boot`, `libkrun.boot`,
+      `qemu.boot`, `hvf.restore`.
+
+#### Relationship to `launch_trace`
+
+`mvm_core::launch_trace` already times the launch path, but covers exactly one
+function — `workload_runner/runner.rs`, with six ordered marks (`endpoint_spawn`
+→ `broker_register`). It records an ordered phase *sequence* for a single
+launch into a per-VM sidecar, consumed by the launch regression lane.
+
+Span timing is the complementary axis: an aggregate *profile* across every call
+of every instrumented function. The boundary held here is that `launch_trace`
+owns in-launch phase ordering and span timing owns everything upstream of it —
+which is where the Plan 311 findings live and where `mvm-cli` had no
+instrumentation at all. The two are deliberately not bridged.
+
+#### Tier 1 — launch critical path (COMPLETE)
+
+- [x] `mvm-core` `crypto::image_verify`: `sha256_file` (as
+      `sha256_file.uncached`) and `sha256_file_cached_with_source` (as
+      `sha256_file.cached`). The cached wrapper calls the uncached hasher on a
+      sidecar miss, so self time separates sidecar-hit cost from real hashing
+      and a regression to uncached hashing shows up as a row rather than an
+      inference. This is the ~557 ms re-hash Plan 311 names; the byte counter
+      (`record_artifact_bytes_hashed`) already existed, the time did not.
+- [x] `mvm-cli` `up::admission::resolve_image_sha256` — the caller that selects
+      the uncached path when a precomputed digest is supplied.
+- [x] `mvm-cli` `up::runtime_source`: `attach_runtime_overlay`,
+      `attach_universal_initramfs_if_cached`.
+- [x] `mvm-cli` `up::kernel::resolve_pinned_kernel_with`.
+- [x] `mvm-cli` `image::pull_core`: `pull_image_ref`, `fetch_or_unpack_layer`.
+- [x] `mvm-cli` `ProcSnapshot::capture` — the `ps` process-table scan, Plan
+      311's ~67 ms.
+
+#### Tier 2 — daemons and build pipeline (COMPLETE)
+
+- [x] `mvm-hostd`: `plan_admission::admit_for_run`, `admit_and_start`,
+      `supervisor::audit_file::verify_audit_chain_entries`.
+- [x] `mvm-build`: `pipeline::orchestrator::pool_build_with_opts`,
+      `pipeline::vsock_builder::build_via_vsock`,
+      `pipeline::build_cache::workload_build_fingerprint`.
+- [x] `mvm-client`: `launch_transient`.
+
+#### Deliberately not instrumented
+
+- Inner loops (per-file hashing, per-packet datapath, per-tar-entry unpack) —
+  the per-close lock would distort what it measures.
+- `mvm-hostd`'s `stream::serve::serve_follower` and peers — a per-connection
+  blocking loop whose span duration is connection lifetime, not cost.
+- `mvm-agentd` — it runs in the guest, so its spans land on the guest's stderr
+  rather than the host profile. Instrumenting it needs a collection path first.
+- Pure predicates (`argv_is_shell`, `program_basename`) and `mvm-contract`
+  (`no_std`, no `tracing` by design).
+
+### Phase 3 — deferred
+
+- [ ] Feed `SpanReport` into the `bench/` regression harness so launch-path
+      profiles are diffable run over run rather than read by eye.
+- [ ] Export the report through `Metrics::prometheus_exposition` for `mvmd`.
+- [ ] Decide whether the per-close mutex needs replacing with sharded or
+      thread-local accumulation. It is adequate while profiling is opt-in and
+      instrumentation stays coarse; it would not be if either changes.
+
+## Usage
+
+```sh
+MVM_SPAN_TIMINGS=1 mvmctl <command>            # table to stderr
+MVM_SPAN_TIMINGS=json mvmctl <command>         # JSON to stderr
+MVM_SPAN_TIMINGS=json MVM_SPAN_TIMINGS_OUT=/tmp/p.json mvmctl <command>
+MVM_SPAN_TIMINGS=1 MVM_SPAN_TIMINGS_FILTER=mvm_fs=trace mvmctl <command>
+```
+
+Profiling is off unless `MVM_SPAN_TIMINGS` is set; when off the layer is never
+installed and the cost is that of a disabled span.
+
+## Interpreting the report
+
+`self` is time in the function excluding nested instrumented calls, and is the
+column that identifies what to optimize. `total` includes nested calls, so a
+high-total/low-self row is an orchestrator whose cost lives in a callee. `wall`
+exceeds `total` when a span was open but not entered — on async code that gap
+is time awaiting something else.
+
+Percentiles are histogram estimates carrying ~12% bucket error. They are a
+profiling signal, not an SLO measurement.
+
+## Witnesses
+
+- `crates/mvm-core/tests/span_timing.rs` — 10 end-to-end tests, including
+  `instrumented_function_is_timed_despite_a_quiet_log_filter` (the CLI's default
+  posture) and `a_registry_wide_filter_suppresses_span_construction_and_yields_no_timings`
+  (locks in the diagnosis above, and fails if the layer stack regresses to a
+  registry-wide filter).
+- `nested_spans_attribute_self_time_to_the_function_doing_the_work` and
+  `self_times_sum_to_roughly_the_wall_clock_of_the_root` cover self-time
+  attribution.
+- Unit tests in each `span_timing` module cover histogram bucketing and
+  quantiles, registry aggregation and ordering, and report rendering.


### PR DESCRIPTION
## The problem

The workspace carried ~60 `#[instrument]` attributes across 17 files. **None of them produced any timing data**, for two independent reasons:

1. **Nothing consumed span close events.** `rg 'FmtSpan|with_span_events'` returned no hits anywhere in the tree. `tracing` does not time spans on its own — a duration exists only if some layer records `on_close`.
2. **The log filter suppressed span construction.** Both subscriber setups attached `EnvFilter` to the *registry*, making it global. The CLI defaults to `error` at verbosity 0 while `#[instrument]` declares INFO spans, so the spans were never constructed at all.

So the attributes read as instrumentation but were inert. Adding more would have changed nothing. This builds the consumer first, then instruments.

## What this does

**The timing layer.** `SpanTimingLayer` records durations into a bounded log-scale histogram (2 KiB per call site, ~12% bucket error, so a long-running daemon can't grow unbounded sample vectors). It attributes each closing span's time to its parent, so the report carries **self time** — time in a function excluding nested instrumented calls — alongside inclusive total. Self time is the column that says what to optimize; a high-total/low-self row is an orchestrator whose cost lives in a callee. Percentile estimates clamp to the exactly-tracked min/max so a bucket artifact can't read as a tail.

**The layer-stack fix.** The log filter now attaches to the fmt layer rather than the registry, so the timing layer's own wider filter governs span construction. This is the change that makes the existing attributes measurable, and it's locked in by a test asserting the registry-wide arrangement records nothing.

**Instrumentation.** `mvm-fs` OCI/ext4 paths (that crate had no `tracing` dependency at all), the four backend `boot` entry points and HVF restore, the launch critical path in `mvm-cli` (which had none), and the admission/audit/build/client entry points. `sha256_file` and its cached wrapper are timed separately so a regression to uncached hashing is a row in the profile rather than an inference.

**Export and diffing.** Labelled Prometheus series (`mvm_span_calls_total`, `mvm_span_self_seconds_total`, `mvm_span_total_seconds_total`, `mvm_span_max_seconds`) on the scrape endpoint, with escaped label values so a quote in a span name can't break a whole scrape. `bench/span_profile.rs` captures a profile from a child `mvmctl` and diffs two runs, gating on **per-call** self time so a run with more iterations doesn't read as a regression, and reporting call-count changes separately.

## Usage

```sh
MVM_SPAN_TIMINGS=1 mvmctl <command>            # table to stderr
MVM_SPAN_TIMINGS=json mvmctl <command>         # JSON
MVM_SPAN_TIMINGS=json MVM_SPAN_TIMINGS_OUT=/tmp/p.json mvmctl <command>
MVM_SPAN_TIMINGS=1 MVM_SPAN_TIMINGS_FILTER=mvm_fs=trace mvmctl <command>
```

Off unless `MVM_SPAN_TIMINGS` is set — the layer is not installed at all.

## It already found something

First run against `mvmctl doctor`:

```
span                          calls        self   self%       total        mean         p95         max
verify_audit_chain_entries        2     656.4ms   92.8%     656.4ms     328.2ms     536.9ms     655.5ms
run_host                          3      50.7ms    7.2%      50.7ms      16.9ms      25.2ms      28.0ms
```

92.8% of `doctor`'s measured time is audit-chain verification, across two calls in one invocation. `trust audit verify` is 696ms in a single call. The chain is re-read and re-verified in full every time and the log only grows (3.5 MB on this host). Reported here, not fixed here — the double-verify is a follow-up, and incremental verification would change what claim 8 attests, so it needs a design decision rather than a quiet patch.

## Cost

Measured, not asserted (`crates/mvm-core/tests/span_timing_overhead.rs`, debug build):

| scenario | ns/span |
| --- | --- |
| profiling disabled | 12 |
| enabled, 1 thread | 4,278 |
| enabled, 8 threads (aggregate) | 2,084 |

Aggregate throughput rises rather than collapses under contention, so the per-close lock is not the bottleneck at entry-point granularity. Sharding would be speculative complexity, so it isn't built.

## Deliberately not done

- **Inner loops** (per-file hashing, per-packet datapath, per-tar-entry unpack) — the per-close lock would distort what it measures.
- **`mvmctl ops metrics`** — briefly wired, then reverted: a profile accumulates in the process that ran the instrumented code, and that command renders before doing any, so those series would always be empty. The scrape endpoint differs because the serving process is the worker.
- **`mvm-agentd`** — runs in the guest, so its spans land on the guest's stderr. Needs a profile-egress path first.
- **`launch_trace` is not bridged.** It owns the ordered six-mark phase sequence inside one launch; this owns the aggregate profile upstream of it.

## Testing

`cargo +nightly fmt --all --check` (exit 0), `cargo clippy --workspace --all-targets -- -D warnings` (exit 0), `cargo nextest run --workspace` — **10,994 passed, 0 failed**. Plus 24 new tests: 11 end-to-end (including one asserting a span is timed at the CLI's default quiet filter, and one pinning the registry-wide-filter regression), 14 profile-diff, 6 Prometheus, 4 overhead.