### PR TITLE
docs: correct the warm-claim blocker diagnosis — it is not BUG-2

### DIFF
--- a/specs/plans/255-live-fc-warm-claim.md
+++ b/specs/plans/255-live-fc-warm-claim.md
@@ -1037,27 +1037,45 @@ the full four-drive device model coming back (`kick block blk0`..`blk3` after
 captures, the checkpoint exists, and a claim now gets all the way to the reseed
 handshake that "was never exercised".
 
-**BUG-2 — pre-existing, not this branch's. Now the live blocker, exactly as
-predicted below.** The transient run path persists the
+**BUG-2 — pre-existing, not this branch's.** The transient run path persists the
 plan via `write_plan` but never mints `verb-grant.json`, so no
 `mvm.host_signer_pub` reaches the guest and the agent rejects the control
 connection with `rejecting control connection without a pinned host key`. It
 predates this branch's merge base. Track it separately; expect it to be the next
 blocker once BUG-1 is fixed.
 
-Confirmed live once BUG-1 was fixed. The claim reaches `child_forked`, the
-child resumes, and then the guest prints
+**BUG-2 is NOT what blocks the live claim** (checked 2026-08-11, **#2336**).
+Once BUG-1 was fixed the claim reaches `child_forked`, the child resumes, and
+the claim then fails closed with `forked child '<vm>' never answered the
+post-restore identity handshake`. The guest console alongside it prints
 
 ```
 mvm-guest-agent: authenticated control handshake failed: Failed to read frame length
 ```
 
-so the post-restore identity handshake is never answered and the claim fails
-closed with `forked child '<vm>' never answered the post-restore identity
-handshake`. The fail-closed posture is correct — a child that cannot prove it
-reseeded must not be admitted — but it means no warm claim can complete on
-Firecracker until this is fixed, and therefore no claimed-launch measurement
-against the cold baseline is possible yet.
+but **that line is benign readiness-probe noise, not the failure.**
+`PostRestoreSignal::probe_ready` connects to `GUEST_AGENT_PORT` and drops the
+connection without a handshake, while the guest speaks *second*
+(`secure_guest_handshake` opens with `read_frame` awaiting the host's
+`SessionHello`). So every probe — one per `POST_RESTORE_PROBE_INTERVAL`, 50 ms —
+makes the agent accept, wait, hit EOF and print exactly that.
+
+It also rules BUG-2 out as the cause: `handle_client` returns early with
+`rejecting control connection without a pinned host key` when
+`host_signer_key()` is `None`, and that message never appeared — the failing
+line is the one *after* it, so the host key did reach the guest.
+
+The real error is still uncaptured: `probe_ready` succeeded (no `did not become
+reachable within` bail), so the failure is inside `signal.post_restore()`, and
+the reported chain stopped at its `signaling post-restore to {vm}` context
+because the capture was grepped and truncated. Diagnosis before fix: re-run the
+claim capturing complete stderr and read the full `Caused by:` chain. Candidates
+then: the host-side `AuthenticatedSession::host` handshake over vsock state that
+did not survive the restore, or the child's vsock CID/port mapping after the
+fork.
+
+Either way no warm claim completes on Firecracker yet, so no claimed-launch
+measurement against the cold baseline is possible.
 
 **BUG-5 — a failed claim strands the standby and orphans its VMM.** Found while
 exercising the above. When a claim fails after the child is materialized, the

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -588,11 +588,12 @@ families.
       and the materialization inline.
 - [ ] Measure a claimed launch against the cold baseline. **Blocked, not
       skipped:** the pool now fills on the KVM host (`pool status` reports
-      `1 idle`) and a claim reaches the fork, but the child's guest agent fails
-      its authenticated control handshake, so the post-restore identity
-      handshake goes unanswered and the claim fails closed. That is Plan 255
-      BUG-2, pre-existing and predicted there as "the next blocker once BUG-1 is
-      fixed". Cold baseline re-measured on the same binary for when the claim
+      `1 idle`) and a claim reaches the fork, but the child never answers the
+      post-restore identity handshake and the claim fails closed — **#2336**,
+      where the root cause is still open. (An earlier note here blamed Plan 255
+      BUG-2 on the strength of a guest console line; that line turned out to be
+      readiness-probe noise and BUG-2 is ruled out — see the #2336 row in Plan
+      255.) Cold baseline re-measured on the same binary for when the claim
       lands: `backend_start` 549.8 / 564.7 / 554.4 ms, dispatch window
       551.6 / 566.8 / 556.2 ms.
 - [ ] Define a prepared-artifact manifest for the kernel, universal initramfs,


### PR DESCRIPTION
Docs-only. #2335 left a wrong root cause on two plan pages; this removes it.

The live warm-claim writeup blamed Plan 255 BUG-2, on the strength of this guest console line:

```
mvm-guest-agent: authenticated control handshake failed: Failed to read frame length
```

Both the line and the attribution were misread.

## The line is readiness-probe noise

`PostRestoreSignal::probe_ready` connects and drops without a handshake:

```rust
// crates/mvm-vmm/src/post_restore.rs
fn probe_ready(&self, vm_name: &str) -> bool {
    let Ok(transport) = crate::vsock_transport::for_vm(vm_name) else { return false };
    transport.connect(mvm_agentd::vsock::GUEST_AGENT_PORT).is_ok()
}
```

The guest speaks **second** — `secure_guest_handshake` opens with `read_frame(stream)` awaiting the host's `SessionHello`. So each probe makes the agent accept, block, hit EOF and print exactly that line. `wait_for_primed_polling` runs one per `POST_RESTORE_PROBE_INTERVAL` (50 ms), so it is expected during *any* restore and indicates nothing.

## And it rules BUG-2 out

`handle_client` returns early with `rejecting control connection without a pinned host key` when `boot_state.host_signer_key()` is `None`. That message never appeared — the observed line is the one *after* it. So `mvm.host_signer_pub` did reach the guest, which is precisely what BUG-2 says does not happen.

## What is actually known

`probe_ready` succeeded (no `did not become reachable within` bail), so the failure is inside `signal.post_restore()`. The reported chain stopped at its `signaling post-restore to {vm}` context because the capture was grepped and truncated — the real `Caused by:` chain has never been read.

The pages now record diagnosis-before-fix as the next step, with the two candidates to check once the chain is in hand (host-side `AuthenticatedSession::host` over vsock state that did not survive the restore; child vsock CID/port mapping after the fork).

No code change. #2336 keeps the symptom in its title, which was always accurate; only the cause was wrong.