### PR TITLE
Fix Stage 0 cache reuse and ARM64 workload boot

### DIFF
--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -419,11 +419,8 @@ fn vsock_egress_requested_from_cmdline(cmdline: &str) -> bool {
 /// non-positive values so a malformed token can't wind the clock backwards.
 #[cfg(any(target_os = "linux", test))]
 fn hostepoch_from_cmdline(cmdline: &str) -> Option<i64> {
-    cmdline
-        .split_whitespace()
-        .find_map(|tok| tok.strip_prefix("mvm.hostepoch="))
-        .and_then(|v| v.parse::<i64>().ok())
-        .filter(|secs| *secs > 0)
+    mvm_vmm::host::boot_config::builder_hostepoch_from_cmdline(cmdline)
+        .and_then(|seconds| seconds.try_into().ok())
 }
 
 #[cfg(any(target_os = "linux", test))]

--- a/crates/mvm-build/src/bin/stage0-init.rs
+++ b/crates/mvm-build/src/bin/stage0-init.rs
@@ -88,7 +88,8 @@ mod linux {
     /// Stage 0's dedicated persistent Nix-store block device. The libkrun
     /// launcher attaches this before the virtio-fs shares, so it enumerates as
     /// `/dev/vda`. QEMU uses `/dev/vda` as the rootfs, so this is libkrun-only.
-    const STAGE0_NIX_STORE_DEV: &str = "/dev/vda";
+    const LIBKRUN_STAGE0_NIX_STORE_DEV: &str = "/dev/vda";
+    const QEMU_STAGE0_NIX_STORE_DEV: &str = "/dev/vde";
     /// Mount point for the persistent Stage 0 Nix store before binding it over
     /// `/nix`.
     const STAGE0_NIX_STORE_MOUNT: &str = "/nix-stage0-store";
@@ -400,6 +401,7 @@ mod linux {
     /// writable store.
     fn setup() -> Result<(), String> {
         let cmdline = std::fs::read_to_string("/proc/cmdline").unwrap_or_default();
+        sync_clock_from_host_epoch(&cmdline)?;
         mount_pseudofs()?;
         // `/dev/null` insurance — some libkrun set_root boots reach
         // userspace without it, which then masks every `2>/dev/null`
@@ -438,13 +440,7 @@ mod linux {
             ])?;
         }
 
-        if qemu {
-            // The QEMU root is a writable ext4 seed, so `/nix` is already a
-            // writable store — no virtiofs-over-FUSE problem, no tmpfs copy
-            // (and no EMFILE). nix writes directly to `/nix/store`.
-        } else {
-            setup_nix_store()?;
-        }
+        setup_nix_store(qemu)?;
         if should_enable_vsock_egress(qemu, &cmdline) {
             best_effort_raise_loopback();
             mvm_agentd::guest_net::seed_loopback_resolver()
@@ -453,6 +449,21 @@ mod linux {
         let mut egress_child = fork_vsock_egress_client_if_requested(&cmdline);
         wait_for_vsock_egress_proxy_if_requested(&cmdline, egress_child.as_mut());
         configure_nix_runtime()?;
+        Ok(())
+    }
+
+    /// Seed the RTC-less Stage 0 guest clock before starting the egress client
+    /// or Nix. Without this, TLS validation observes 1970 and every fresh
+    /// bootstrap download fails with a misleading certificate error.
+    fn sync_clock_from_host_epoch(cmdline: &str) -> Result<(), String> {
+        let Some(epoch_seconds) =
+            mvm_vmm::host::boot_config::builder_hostepoch_from_cmdline(cmdline)
+        else {
+            return Ok(());
+        };
+        mvm_agentd::restore_clock::resync(epoch_seconds)
+            .map_err(|error| format!("set wall clock from host epoch: {error}"))?;
+        eprintln!("stage0-init: wall clock set from host epoch {epoch_seconds}");
         Ok(())
     }
 
@@ -506,8 +517,8 @@ mod linux {
     /// from the verified RootDir store, then bind it over `/nix` on every later
     /// boot. If the current seed lacks `mkfs.ext4` and the disk is still blank,
     /// fall back to the old tmpfs copy so the bootstrap remains functional.
-    fn setup_nix_store() -> Result<(), String> {
-        match setup_persistent_nix_store() {
+    fn setup_nix_store(qemu: bool) -> Result<(), String> {
+        match setup_persistent_nix_store(qemu) {
             Ok(()) => return Ok(()),
             Err(e) => eprintln!(
                 "stage0-init: persistent Stage 0 /nix store unavailable ({e}); falling back to tmpfs seed copy"
@@ -537,37 +548,40 @@ mod linux {
         Ok(())
     }
 
-    fn setup_persistent_nix_store() -> Result<(), String> {
-        if !Path::new(STAGE0_NIX_STORE_DEV).exists() {
-            return Err(format!("{STAGE0_NIX_STORE_DEV} is not present"));
+    fn stage0_nix_store_device(qemu: bool) -> &'static str {
+        if qemu {
+            QEMU_STAGE0_NIX_STORE_DEV
+        } else {
+            LIBKRUN_STAGE0_NIX_STORE_DEV
+        }
+    }
+
+    fn setup_persistent_nix_store(qemu: bool) -> Result<(), String> {
+        let device = stage0_nix_store_device(qemu);
+        if !Path::new(device).exists() {
+            return Err(format!("{device} is not present"));
         }
 
         std::fs::create_dir_all(STAGE0_NIX_STORE_MOUNT)
             .map_err(|e| format!("create {STAGE0_NIX_STORE_MOUNT}: {e}"))?;
-        mount_stage0_nix_store()?;
+        mount_stage0_nix_store(device)?;
 
         let seed_store = Path::new(NIX_TARGET).join("store");
         let expected_marker = stage0_nix_store_marker(&seed_store)?;
         if persistent_nix_store_matches(&expected_marker)? {
-            eprintln!(
-                "stage0-init: reusing persistent Stage 0 Nix store at {STAGE0_NIX_STORE_DEV}"
-            );
+            eprintln!("stage0-init: reusing persistent Stage 0 Nix store at {device}");
             bind_mount(STAGE0_NIX_STORE_MOUNT, NIX_TARGET)?;
             return Ok(());
         }
         if persistent_nix_store_matches_seed(&seed_store)? {
             std::fs::write(STAGE0_NIX_STORE_MARKER, expected_marker)
                 .map_err(|e| format!("write {STAGE0_NIX_STORE_MARKER}: {e}"))?;
-            eprintln!(
-                "stage0-init: adopting host-prepopulated Stage 0 Nix store at {STAGE0_NIX_STORE_DEV}"
-            );
+            eprintln!("stage0-init: adopting host-prepopulated Stage 0 Nix store at {device}");
             bind_mount(STAGE0_NIX_STORE_MOUNT, NIX_TARGET)?;
             return Ok(());
         }
 
-        eprintln!(
-            "stage0-init: initializing persistent Stage 0 Nix store at {STAGE0_NIX_STORE_DEV}"
-        );
+        eprintln!("stage0-init: initializing persistent Stage 0 Nix store at {device}");
         clear_dir_children(Path::new(STAGE0_NIX_STORE_MOUNT))
             .map_err(|e| format!("clearing {STAGE0_NIX_STORE_MOUNT}: {e}"))?;
         let dst_store = Path::new(STAGE0_NIX_STORE_MOUNT).join("store");
@@ -588,8 +602,8 @@ mod linux {
         Ok(())
     }
 
-    fn mount_stage0_nix_store() -> Result<(), String> {
-        match mount_fs(STAGE0_NIX_STORE_DEV, STAGE0_NIX_STORE_MOUNT, "ext4") {
+    fn mount_stage0_nix_store(device: &str) -> Result<(), String> {
+        match mount_fs(device, STAGE0_NIX_STORE_MOUNT, "ext4") {
             Ok(()) => return Ok(()),
             Err(first_mount_err) => {
                 let Some(mkfs) = find_mkfs_ext4() else {
@@ -598,12 +612,12 @@ mod linux {
                     ));
                 };
                 eprintln!(
-                    "stage0-init: formatting {STAGE0_NIX_STORE_DEV} for persistent Stage 0 store ({first_mount_err})"
+                    "stage0-init: formatting {device} for persistent Stage 0 store ({first_mount_err})"
                 );
-                format_ext4_with(&mkfs, STAGE0_NIX_STORE_DEV)?;
+                format_ext4_with(&mkfs, device)?;
             }
         }
-        mount_fs(STAGE0_NIX_STORE_DEV, STAGE0_NIX_STORE_MOUNT, "ext4")
+        mount_fs(device, STAGE0_NIX_STORE_MOUNT, "ext4")
     }
 
     fn find_mkfs_ext4() -> Option<PathBuf> {
@@ -1293,9 +1307,16 @@ mod linux {
         use super::{
             VSOCK_EGRESS_NO_PROXY, VSOCK_EGRESS_PROXY_URL, copy_artifacts_into,
             ext4_volume_label_from_superblock, find_labeled_ext4_disk, run_streaming,
+            stage0_nix_store_device,
         };
         use std::os::unix::fs::symlink;
         use std::process::Command;
+
+        #[test]
+        fn stage0_nix_store_device_matches_backend_disk_order() {
+            assert_eq!(stage0_nix_store_device(false), "/dev/vda");
+            assert_eq!(stage0_nix_store_device(true), "/dev/vde");
+        }
 
         #[test]
         fn ext4_volume_label_from_superblock_rejects_too_short_buffers() {

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -2648,7 +2648,7 @@ pub(crate) fn stage0_nix_store_image_name() -> String {
     format!("nix-store-stage0-{}.img", host_arch_tag())
 }
 
-fn prepopulate_stage0_nix_store_image(
+pub(crate) fn prepopulate_stage0_nix_store_image(
     image: &BuilderVmImage,
     store_image: &Path,
 ) -> Result<(), BuilderVmError> {

--- a/crates/mvm-build/src/qemu_builder.rs
+++ b/crates/mvm-build/src/qemu_builder.rs
@@ -25,11 +25,13 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::builder_vm::{BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmError};
 #[cfg(feature = "builder-vm")]
-use crate::builder_vm_runtime::CLOSURE_SEED_TAG;
+use crate::builder_vm_runtime::{CLOSURE_SEED_TAG, acquire_nix_store_image_lock_named};
 #[cfg(feature = "builder-vm")]
 use crate::libkrun_builder::{
-    BuilderEndpointTransport, BuilderShellJob, BuilderShellResult, BuilderVsockEgressEndpoint,
-    builder_runtime_overlay_attachment, require_runtime_overlay_ext4,
+    BuilderEndpointTransport, BuilderShellJob, BuilderShellResult, BuilderVmImage,
+    BuilderVsockEgressEndpoint, DEFAULT_NIX_STORE_MIB, builder_runtime_overlay_attachment,
+    builder_vm_cache_dir, prepopulate_stage0_nix_store_image, require_runtime_overlay_ext4,
+    stage0_nix_store_image_name,
 };
 use mvm_core::config::DEFAULT_MVM_HOME_DIR_NAME;
 
@@ -94,7 +96,7 @@ impl BuilderVm for QemuBuilderVm {
 
 /// Max wall-clock for a Stage 0 QEMU run (kernel compile + downloads). Wraps
 /// the qemu child in `timeout` so a hung guest can't block forever.
-const STAGE0_TIMEOUT_SECS: u32 = 3600;
+const STAGE0_TIMEOUT_SECS: u32 = 7200;
 const QEMU_BUILDER_VSOCK_EGRESS_TOKEN: &str = "mvm.vsock_egress=1";
 const QEMU_BUILDER_VSOCK_EGRESS_PORT_TOKEN_PREFIX: &str = "mvm.vsock_egress_port=";
 const QEMU_BUILDER_VSOCK_EGRESS_PORT_BASE: u32 = 45_253;
@@ -110,6 +112,7 @@ const QEMU_STAGE0_OUT_ARTIFACT_NAMES: &[&str] = &[
     "rootfs.ext4",
     "cmdline.txt",
     "manifest.json",
+    "mvm-kernel.config",
     "nix-stderr.log",
 ];
 
@@ -164,6 +167,17 @@ fn run_stage0_qemu(
 ) -> Result<(), BuilderVmError> {
     let qemu_bin = locate_qemu()?;
     let (kernel, initrd) = locate_host_kernel()?;
+    #[cfg(feature = "builder-vm")]
+    let nix_store_lock = {
+        let image = BuilderVmImage::new_root_dir(guest_root_dir.to_path_buf(), entry_path);
+        let lock = acquire_nix_store_image_lock_named(
+            &builder_vm_cache_dir(),
+            &stage0_nix_store_image_name(),
+            u64::from(DEFAULT_NIX_STORE_MIB),
+        )?;
+        prepopulate_stage0_nix_store_image(&image, lock.path())?;
+        lock
+    };
     let kvm = kvm_available();
     if !kvm {
         eprintln!(
@@ -213,8 +227,9 @@ fn run_stage0_qemu(
     // 2. Launch QEMU (the validated recipe), serial → console.log.
     let egress_port = allocate_qemu_builder_egress_port();
     let hostepoch = crate::builder_vm::builder_hostepoch_cmdline_token();
+    let serial_console = qemu_console_for_arch(std::env::consts::ARCH);
     let append = format!(
-        "console=ttyS0 root=/dev/vda rw init={entry_path} mvm.backend=qemu {QEMU_BUILDER_VSOCK_EGRESS_TOKEN} {QEMU_BUILDER_VSOCK_EGRESS_PORT_TOKEN_PREFIX}{egress_port} {hostepoch} panic=-1"
+        "console={serial_console} root=/dev/vda rw init={entry_path} mvm.backend=qemu {QEMU_BUILDER_VSOCK_EGRESS_TOKEN} {QEMU_BUILDER_VSOCK_EGRESS_PORT_TOKEN_PREFIX}{egress_port} {hostepoch} panic=-1"
     );
     let guest_cid = allocate_qemu_builder_guest_cid();
     #[cfg(feature = "builder-vm")]
@@ -224,7 +239,11 @@ fn run_stage0_qemu(
     )?;
     let mut cmd = Command::new("timeout");
     cmd.arg(STAGE0_TIMEOUT_SECS.to_string()).arg(&qemu_bin);
-    cmd.args(["-m", "8G", "-smp", "6"]);
+    let mem_arg = format!("{QEMU_BUILD_MEMORY_MIB}M");
+    cmd.args(["-m", &mem_arg, "-smp", &QEMU_BUILD_VCPUS.to_string()]);
+    if let Some(machine) = qemu_machine_for_arch(std::env::consts::ARCH) {
+        cmd.args(["-machine", machine]);
+    }
     if kvm {
         cmd.args(["-enable-kvm", "-cpu", "host"]);
     } else {
@@ -237,6 +256,11 @@ fn run_stage0_qemu(
         cmd.arg("-drive")
             .arg(format!("file={},if=virtio,format=raw", disk.display()));
     }
+    #[cfg(feature = "builder-vm")]
+    cmd.arg("-drive").arg(format!(
+        "file={},if=virtio,format=raw",
+        nix_store_lock.path().display()
+    ));
     cmd.arg("-device")
         .arg(format!("vhost-vsock-pci,guest-cid={guest_cid}"));
     cmd.args(["-display", "none"]);
@@ -268,7 +292,7 @@ fn run_stage0_qemu(
     }
     if !log.contains("stage0-init: done; halting") {
         return Err(BuilderVmError::ExtractionFailed(format!(
-            "QEMU Stage 0 did not reach a clean halt; console at {}\n{}",
+            "QEMU Stage 0 exited with {status} before reaching a clean halt; console at {}\n{}",
             console_log.display(),
             tail(&log, 20)
         )));
@@ -465,6 +489,21 @@ fn locate_qemu() -> Result<String, BuilderVmError> {
         })
 }
 
+fn qemu_machine_for_arch(arch: &str) -> Option<&'static str> {
+    match arch {
+        "aarch64" => Some("virt"),
+        "x86_64" => None,
+        _ => None,
+    }
+}
+
+fn qemu_console_for_arch(arch: &str) -> &'static str {
+    match arch {
+        "aarch64" => "ttyAMA0",
+        _ => "ttyS0",
+    }
+}
+
 /// The running kernel's `vmlinuz` + `initrd.img` under `/boot`. The stock
 /// initramfs carries the modular virtio/ext4 drivers Stage 0 needs.
 fn locate_host_kernel() -> Result<(PathBuf, PathBuf), BuilderVmError> {
@@ -555,6 +594,14 @@ mod tests {
     #[test]
     fn qemu_stage0_extracts_manifest_sidecar() {
         assert!(QEMU_STAGE0_OUT_ARTIFACT_NAMES.contains(&"manifest.json"));
+    }
+
+    #[test]
+    fn qemu_stage0_extracts_resolved_kernel_config() {
+        assert!(
+            QEMU_STAGE0_OUT_ARTIFACT_NAMES.contains(&"mvm-kernel.config"),
+            "QEMU Stage 0 must retain the config required for verified kernel publication"
+        );
     }
 
     #[test]
@@ -676,14 +723,11 @@ fn io_err(ctx: &str, path: &Path, e: std::io::Error) -> BuilderVmError {
 // `finalize_flake_job` reads /job/result), so `BuilderArtifacts` is
 // byte-identical regardless of which VMM ran the build.
 
-/// Guest RAM (MiB) + vCPUs for a QEMU steady-state build. Mirror the
-/// values proven on the x86_64 box for Stage 0 — same build class on the
-/// same hardware. The `memory-backend-memfd` is lazily
-/// backed, so the figure is a ceiling, not a reservation.
-#[cfg(feature = "builder-vm")]
-const QEMU_BUILD_MEMORY_MIB: u32 = 8192;
-#[cfg(feature = "builder-vm")]
-const QEMU_BUILD_VCPUS: u8 = 6;
+/// Guest RAM (MiB) + vCPUs for QEMU Stage 0 and steady-state builds. Leave
+/// enough headroom for QEMU and the Linux host on a common 8 GiB / 4-vCPU
+/// development machine.
+const QEMU_BUILD_MEMORY_MIB: u32 = 6144;
+const QEMU_BUILD_VCPUS: u8 = 4;
 
 #[cfg(not(feature = "builder-vm"))]
 fn run_build_qemu(
@@ -822,6 +866,9 @@ fn run_shell_script_qemu(job: &BuilderShellJob) -> Result<BuilderShellResult, Bu
     let mut cmd = Command::new("timeout");
     cmd.arg(timeout_secs.to_string()).arg(&qemu_bin);
     cmd.args(["-m", &mem_arg, "-smp", &QEMU_BUILD_VCPUS.to_string()]);
+    if let Some(machine) = qemu_machine_for_arch(std::env::consts::ARCH) {
+        cmd.args(["-machine", machine]);
+    }
     if kvm {
         cmd.args(["-enable-kvm", "-cpu", "host"]);
     } else {
@@ -1057,8 +1104,9 @@ fn run_build_qemu(
             })?;
     }
 
-    // 9. Build the QEMU cmdline from the image's (swap hvc0→ttyS0, force
-    //    eth0, mark the backend); `root=/dev/vda ro init=…` ride unchanged.
+    // 9. Build the QEMU cmdline from the image's (swap hvc0 for the native
+    //    QEMU serial console, force eth0, mark the backend); `root=/dev/vda ro
+    //    init=…` ride unchanged.
     // The QEMU builder is always a lean Rootfs builder, so the runtime overlay
     // is required — fail closed rather than booting a builder whose guest agent
     // can never launch (it bakes none of its guest binaries).
@@ -1088,6 +1136,9 @@ fn run_build_qemu(
     let mut cmd = Command::new("timeout");
     cmd.arg(timeout_secs.to_string()).arg(&qemu_bin);
     cmd.args(["-m", &mem_arg, "-smp", &QEMU_BUILD_VCPUS.to_string()]);
+    if let Some(machine) = qemu_machine_for_arch(std::env::consts::ARCH) {
+        cmd.args(["-machine", machine]);
+    }
     if kvm {
         cmd.args(["-enable-kvm", "-cpu", "host"]);
     } else {
@@ -1275,11 +1326,18 @@ fn allocate_qemu_builder_egress_port() -> u32 {
 /// Idempotent: running it on its own output is a no-op.
 #[cfg(any(feature = "builder-vm", test))]
 fn qemu_build_cmdline(image_cmdline: &str, egress_port: u32) -> String {
+    qemu_build_cmdline_for_arch(image_cmdline, egress_port, std::env::consts::ARCH)
+}
+
+#[cfg(any(feature = "builder-vm", test))]
+fn qemu_build_cmdline_for_arch(image_cmdline: &str, egress_port: u32, arch: &str) -> String {
     let mut s = image_cmdline.trim().to_string();
+    let serial_console = qemu_console_for_arch(arch);
+    let serial_console_token = format!("console={serial_console}");
     if s.contains("console=hvc0") {
-        s = s.replace("console=hvc0", "console=ttyS0");
-    } else if !s.split_whitespace().any(|t| t == "console=ttyS0") {
-        s = format!("console=ttyS0 {s}");
+        s = s.replace("console=hvc0", &serial_console_token);
+    } else if !s.split_whitespace().any(|t| t == serial_console_token) {
+        s = format!("{serial_console_token} {s}");
     }
     for tok in [
         "mvm.backend=qemu",
@@ -1331,9 +1389,9 @@ mod vsock_module_tests {
     }
 
     #[test]
-    fn cmdline_swaps_hvc0_for_serial_and_adds_qemu_markers() {
+    fn x86_64_cmdline_swaps_hvc0_for_serial_and_adds_qemu_markers() {
         let img = "console=hvc0 root=/dev/vda ro rootfstype=ext4 init=/sbin/mvm-host-vm-init";
-        let out = qemu_build_cmdline(img, 45253);
+        let out = qemu_build_cmdline_for_arch(img, 45253, "x86_64");
         assert!(out.contains("console=ttyS0"), "got: {out}");
         assert!(!out.contains("hvc0"), "got: {out}");
         // init + root + ro are preserved from the image verbatim.
@@ -1371,18 +1429,51 @@ mod vsock_module_tests {
     }
 
     #[test]
-    fn cmdline_is_idempotent() {
-        let once = qemu_build_cmdline(
+    fn aarch64_qemu_stage0_selects_virt_machine() {
+        assert_eq!(qemu_machine_for_arch("aarch64"), Some("virt"));
+    }
+
+    #[test]
+    fn aarch64_qemu_uses_pl011_serial_console() {
+        let out = qemu_build_cmdline_for_arch(
             "console=hvc0 root=/dev/vda ro init=/sbin/mvm-host-vm-init",
             45253,
+            "aarch64",
         );
-        let twice = qemu_build_cmdline(&once, 45253);
+        assert!(out.contains("console=ttyAMA0"), "got: {out}");
+        assert!(!out.contains("console=ttyS0"), "got: {out}");
+    }
+
+    #[test]
+    fn x86_64_qemu_stage0_keeps_default_machine() {
+        assert_eq!(qemu_machine_for_arch("x86_64"), None);
+    }
+
+    #[test]
+    fn qemu_builder_defaults_leave_host_headroom() {
+        assert_eq!(QEMU_BUILD_MEMORY_MIB, 6144);
+        assert_eq!(QEMU_BUILD_VCPUS, 4);
+        assert_eq!(STAGE0_TIMEOUT_SECS, 7200);
+    }
+
+    #[test]
+    fn cmdline_is_idempotent() {
+        let once = qemu_build_cmdline_for_arch(
+            "console=hvc0 root=/dev/vda ro init=/sbin/mvm-host-vm-init",
+            45253,
+            "aarch64",
+        );
+        let twice = qemu_build_cmdline_for_arch(&once, 45253, "aarch64");
         assert_eq!(once, twice);
     }
 
     #[test]
     fn cmdline_adds_serial_when_no_console_present() {
-        let out = qemu_build_cmdline("root=/dev/vda ro init=/sbin/mvm-host-vm-init", 45253);
+        let out = qemu_build_cmdline_for_arch(
+            "root=/dev/vda ro init=/sbin/mvm-host-vm-init",
+            45253,
+            "x86_64",
+        );
         assert!(out.starts_with("console=ttyS0 "), "got: {out}");
     }
 

--- a/crates/mvm-cli/src/commands/env/builder_vm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm.rs
@@ -51,12 +51,12 @@ use image_ops::validate_dev_image_artifacts;
 #[cfg(feature = "builder-vm")]
 use image_ops::verify_stage0_rootfs_has_init;
 pub(crate) use kernel::KernelSource;
-#[cfg(all(test, feature = "builder-vm"))]
-use kernel::format_compile_elapsed;
 #[cfg(feature = "builder-vm")]
 pub(crate) use kernel::resolve_kernel_source;
 #[cfg(feature = "builder-vm")]
 pub(crate) use kernel::{KernelVariant, build_kernel_via_stage0};
+#[cfg(all(test, feature = "builder-vm"))]
+use kernel::{format_compile_elapsed, format_compile_start};
 #[cfg(feature = "builder-vm")]
 use stage0_cache::Stage0FailureStage;
 #[cfg(any(

--- a/crates/mvm-cli/src/commands/env/builder_vm/kernel.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/kernel.rs
@@ -156,6 +156,13 @@ pub(super) fn format_compile_elapsed(elapsed: std::time::Duration) -> String {
     format!("still compiling… ({}m{:02}s elapsed)", secs / 60, secs % 60)
 }
 
+#[cfg(feature = "builder-vm")]
+pub(super) fn format_compile_start(label: &str, arch: &str) -> String {
+    format!(
+        "Compiling {label} kernel ({arch}) via Stage 0 — the first build can take several minutes depending on the host; later runs reuse the persistent Nix store."
+    )
+}
+
 /// `mvmctl kernel build --source compile`: compile a single kernel attr
 /// through the Stage 0 nix-seed bootstrap and land its `vmlinux` in the
 /// per-arch builder-VM cache. Returns the cached kernel path.
@@ -229,11 +236,7 @@ pub(crate) fn build_kernel_via_stage0(
     std::fs::write(staging_dir.join("stage0-build.conf"), conf)
         .with_context(|| format!("writing stage0-build.conf in {}", staging_dir.display()))?;
 
-    ui::info(&format!(
-        "Compiling {} kernel ({arch}) via Stage 0 — first build is slow \
-         (3-10 min); later runs hit the nix store cache.",
-        variant.label()
-    ));
+    ui::info(&format_compile_start(variant.label(), arch));
 
     {
         use mvm_build::builder_backend_select as bbs;

--- a/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
@@ -655,7 +655,7 @@ mod reap_orphans_tests {
 
 #[cfg(all(test, feature = "builder-vm"))]
 mod heartbeat_tests {
-    use super::format_compile_elapsed;
+    use super::{format_compile_elapsed, format_compile_start};
     use std::time::Duration;
 
     #[test]
@@ -668,5 +668,13 @@ mod heartbeat_tests {
             format_compile_elapsed(Duration::from_secs(130)),
             "still compiling… (2m10s elapsed)"
         );
+    }
+
+    #[test]
+    fn compile_start_message_avoids_a_false_fixed_duration_promise() {
+        let message = format_compile_start("workload", "aarch64");
+        assert!(message.contains("depending on the host"));
+        assert!(message.contains("reuse the persistent Nix store"));
+        assert!(!message.contains("3-10"));
     }
 }

--- a/crates/mvm-fs/src/oci/registry.rs
+++ b/crates/mvm-fs/src/oci/registry.rs
@@ -1,11 +1,14 @@
 use crate::oci::OciError;
 use crate::oci::reference::ImageReference;
-use mvm_http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, WWW_AUTHENTICATE};
+use mvm_http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, LOCATION, WWW_AUTHENTICATE};
 use secrecy::{ExposeSecret, SecretString};
 
 const DOCKER_HUB_REGISTRY: &str = "docker.io";
 const DOCKER_HUB_LEGACY_REGISTRY: &str = "index.docker.io";
 const DOCKER_HUB_REGISTRY_API_HOST: &str = "registry-1.docker.io";
+const DOCKER_HUB_CLOUDFLARE_BLOB_HOST: &str = "production.cloudflare.docker.com";
+const DOCKER_HUB_CLOUDFRONT_BLOB_HOST: &str = "production.cloudfront.docker.com";
+const MAX_BLOB_REDIRECTS: usize = 5;
 
 #[derive(Debug, Clone, Default)]
 pub enum ClientProtocol {
@@ -103,8 +106,13 @@ impl RegistryClient {
         reference: &ImageReference,
         accept: &[&str],
     ) -> Result<RegistryResponse, OciError> {
-        self.get(reference, &manifest_path(reference), Some(accept))
-            .await
+        self.get(
+            reference,
+            &manifest_path(reference),
+            Some(accept),
+            RedirectPolicy::Refuse,
+        )
+        .await
     }
 
     pub async fn get_blob(
@@ -112,8 +120,13 @@ impl RegistryClient {
         reference: &ImageReference,
         digest: &str,
     ) -> Result<RegistryResponse, OciError> {
-        self.get(reference, &blob_path(reference, digest), None)
-            .await
+        self.get(
+            reference,
+            &blob_path(reference, digest),
+            None,
+            RedirectPolicy::Blob,
+        )
+        .await
     }
 
     async fn get(
@@ -121,6 +134,7 @@ impl RegistryClient {
         reference: &ImageReference,
         path: &str,
         accept: Option<&[&str]>,
+        redirect_policy: RedirectPolicy,
     ) -> Result<RegistryResponse, OciError> {
         let url = self.endpoint(reference, path);
         let request = self.build_request(url.clone(), accept, None);
@@ -129,7 +143,7 @@ impl RegistryClient {
             .await
             .map_err(|e| OciError::Registry(format!("GET {url}: {e}")))?;
         if response.status() != mvm_http::StatusCode::UNAUTHORIZED {
-            return self.registry_response(url, response).await;
+            return self.registry_response(url, response, redirect_policy).await;
         }
 
         let challenge = parse_auth_challenge(
@@ -144,7 +158,7 @@ impl RegistryClient {
             .send()
             .await
             .map_err(|e| OciError::Registry(format!("GET {url} after auth: {e}")))?;
-        self.registry_response(url, retry).await
+        self.registry_response(url, retry, redirect_policy).await
     }
 
     fn build_request(
@@ -173,7 +187,41 @@ impl RegistryClient {
         &self,
         url: String,
         response: mvm_http::Response,
+        redirect_policy: RedirectPolicy,
     ) -> Result<RegistryResponse, OciError> {
+        let mut current_url = mvm_http::Url::parse(&url).map_err(|e| {
+            OciError::Registry(format!("registry endpoint is not a valid URL: {e}"))
+        })?;
+        let mut response = response;
+        let mut redirect_count = 0;
+
+        while is_preserving_redirect(response.status()) {
+            if redirect_policy == RedirectPolicy::Refuse {
+                break;
+            }
+            if redirect_count == MAX_BLOB_REDIRECTS {
+                return Err(OciError::Registry(format!(
+                    "GET {} exceeded the {MAX_BLOB_REDIRECTS}-redirect OCI blob limit",
+                    display_url(&current_url)
+                )));
+            }
+            let location = response.headers().get(LOCATION).ok_or_else(|| {
+                OciError::Registry(format!(
+                    "GET {} returned a redirect without Location",
+                    display_url(&current_url)
+                ))
+            })?;
+            let next_url = validate_blob_redirect(&current_url, location)?;
+            response = self.http.get(next_url.as_str()).send().await.map_err(|e| {
+                OciError::Registry(format!(
+                    "GET redirected OCI blob from {}: {e}",
+                    display_url(&next_url)
+                ))
+            })?;
+            current_url = next_url;
+            redirect_count += 1;
+        }
+
         let status = response.status();
         if !status.is_success() {
             let body = response
@@ -181,7 +229,8 @@ impl RegistryClient {
                 .await
                 .unwrap_or_else(|_| "<body unreadable>".to_string());
             return Err(OciError::Registry(format!(
-                "GET {url} failed with {status}: {body}"
+                "GET {} failed with {status}: {body}",
+                display_url(&current_url)
             )));
         }
         let headers = response.headers().clone();
@@ -263,6 +312,77 @@ impl RegistryClient {
         };
         format!("{scheme}://{host}{path}")
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RedirectPolicy {
+    Refuse,
+    Blob,
+}
+
+fn is_preserving_redirect(status: mvm_http::StatusCode) -> bool {
+    matches!(status.as_u16(), 307 | 308)
+}
+
+fn validate_blob_redirect(
+    current: &mvm_http::Url,
+    location: &mvm_http::header::HeaderValue,
+) -> Result<mvm_http::Url, OciError> {
+    let location = location
+        .to_str()
+        .map_err(|_| OciError::Registry("OCI blob redirect Location is not valid text".into()))?;
+    let next = current
+        .join(location)
+        .map_err(|_| OciError::Registry("OCI blob redirect Location is not a valid URL".into()))?;
+
+    if !next.username().is_empty() || next.password().is_some() || next.fragment().is_some() {
+        return Err(OciError::Registry(
+            "OCI blob redirect URL must not contain credentials or a fragment".into(),
+        ));
+    }
+    if !matches!(next.scheme(), "http" | "https") {
+        return Err(OciError::Registry(
+            "OCI blob redirect URL must use HTTP or HTTPS".into(),
+        ));
+    }
+    if current.scheme() == "https" && next.scheme() != "https" {
+        return Err(OciError::Registry(
+            "OCI blob redirect refused an HTTPS downgrade".into(),
+        ));
+    }
+    if same_origin(current, &next) || is_docker_hub_cdn_redirect(current, &next) {
+        return Ok(next);
+    }
+
+    Err(OciError::Registry(format!(
+        "OCI blob redirect from {} to an untrusted origin was refused",
+        display_url(current)
+    )))
+}
+
+fn same_origin(left: &mvm_http::Url, right: &mvm_http::Url) -> bool {
+    left.scheme() == right.scheme()
+        && left.host_str() == right.host_str()
+        && left.port_or_known_default() == right.port_or_known_default()
+}
+
+fn is_docker_hub_cdn_redirect(current: &mvm_http::Url, next: &mvm_http::Url) -> bool {
+    current.scheme() == "https"
+        && current.host_str() == Some(DOCKER_HUB_REGISTRY_API_HOST)
+        && current.port_or_known_default() == Some(443)
+        && next.scheme() == "https"
+        && matches!(
+            next.host_str(),
+            Some(DOCKER_HUB_CLOUDFLARE_BLOB_HOST | DOCKER_HUB_CLOUDFRONT_BLOB_HOST)
+        )
+        && next.port_or_known_default() == Some(443)
+}
+
+fn display_url(url: &mvm_http::Url) -> String {
+    let mut safe = url.clone();
+    safe.set_query(None);
+    safe.set_fragment(None);
+    safe.to_string()
 }
 
 pub struct RegistryResponse {
@@ -410,5 +530,92 @@ mod tests {
             .expect("reference parses");
 
         assert_eq!(registry_api_host(&reference.registry), "ghcr.io");
+    }
+
+    #[test]
+    fn blob_redirect_accepts_same_origin_relative_location() {
+        let current =
+            mvm_http::Url::parse("http://127.0.0.1:5000/v2/library/alpine/blobs/sha256:abc")
+                .expect("current URL parses");
+        let location = mvm_http::header::HeaderValue::from_static("/blob-data/sha256:abc");
+
+        let next = validate_blob_redirect(&current, &location).expect("redirect is accepted");
+
+        assert_eq!(next.as_str(), "http://127.0.0.1:5000/blob-data/sha256:abc");
+    }
+
+    #[test]
+    fn blob_redirect_accepts_exact_docker_hub_cdn_origin() {
+        let current =
+            mvm_http::Url::parse("https://registry-1.docker.io/v2/library/alpine/blobs/sha256:abc")
+                .expect("current URL parses");
+        let location = mvm_http::header::HeaderValue::from_static(
+            "https://production.cloudflare.docker.com/registry-v2/blobs/data?verify=secret",
+        );
+
+        let next = validate_blob_redirect(&current, &location).expect("redirect is accepted");
+
+        assert_eq!(next.host_str(), Some("production.cloudflare.docker.com"));
+
+        let current_cdn = mvm_http::header::HeaderValue::from_static(
+            "https://production.cloudfront.docker.com/registry-v2/blobs/data?verify=secret",
+        );
+        let next = validate_blob_redirect(&current, &current_cdn).expect("current CDN is accepted");
+        assert_eq!(next.host_str(), Some("production.cloudfront.docker.com"));
+    }
+
+    #[test]
+    fn blob_redirect_rejects_untrusted_cross_origin() {
+        let current =
+            mvm_http::Url::parse("https://registry-1.docker.io/v2/library/alpine/blobs/sha256:abc")
+                .expect("current URL parses");
+        let location = mvm_http::header::HeaderValue::from_static("https://example.com/blob");
+
+        let error = validate_blob_redirect(&current, &location).unwrap_err();
+
+        assert!(error.to_string().contains("untrusted origin"));
+    }
+
+    #[test]
+    fn blob_redirect_rejects_https_downgrade() {
+        let current =
+            mvm_http::Url::parse("https://registry-1.docker.io/v2/library/alpine/blobs/sha256:abc")
+                .expect("current URL parses");
+        let location = mvm_http::header::HeaderValue::from_static(
+            "http://production.cloudflare.docker.com/blob",
+        );
+
+        let error = validate_blob_redirect(&current, &location).unwrap_err();
+
+        assert!(error.to_string().contains("HTTPS downgrade"));
+    }
+
+    #[test]
+    fn blob_redirect_rejects_credentials_and_fragments() {
+        let current = mvm_http::Url::parse("https://registry.example/v2/blobs/sha256:abc")
+            .expect("current URL parses");
+        for value in [
+            "https://user:pass@registry.example/blob",
+            "https://registry.example/blob#fragment",
+        ] {
+            let location = mvm_http::header::HeaderValue::from_str(value)
+                .expect("test redirect header is valid");
+
+            let error = validate_blob_redirect(&current, &location).unwrap_err();
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("must not contain credentials or a fragment")
+            );
+        }
+    }
+
+    #[test]
+    fn display_url_redacts_signed_query() {
+        let url =
+            mvm_http::Url::parse("https://cdn.example/blob?token=secret").expect("URL parses");
+
+        assert_eq!(display_url(&url), "https://cdn.example/blob");
     }
 }

--- a/crates/mvm-fs/tests/common/http_fixture.rs
+++ b/crates/mvm-fs/tests/common/http_fixture.rs
@@ -300,6 +300,8 @@ async fn write_response(stream: &mut TcpStream, response: &TestResponse) -> std:
 fn reason_phrase(status: u16) -> &'static str {
     match status {
         200 => "OK",
+        307 => "Temporary Redirect",
+        308 => "Permanent Redirect",
         400 => "Bad Request",
         404 => "Not Found",
         503 => "Service Unavailable",

--- a/crates/mvm-fs/tests/common/mod.rs
+++ b/crates/mvm-fs/tests/common/mod.rs
@@ -308,6 +308,56 @@ impl HermeticRegistry {
         digest
     }
 
+    /// Serve an authenticated blob route that redirects to an unauthenticated
+    /// same-origin object route. This proves clients strip registry credentials
+    /// before following a blob redirect.
+    pub async fn register_redirected_bearer_blob(
+        &self,
+        repository: &str,
+        media_type: &str,
+        bytes: &[u8],
+        token: &str,
+    ) -> String {
+        let digest = format!("sha256:{}", hex::encode(Sha256::digest(bytes)));
+        let redirected_path = format!("/redirected/blobs/{digest}");
+        self.server.register(
+            Route::exact(
+                "GET",
+                format!("/v2/{repository}/blobs/{digest}"),
+                Responder::Static(
+                    TestResponse::builder(307)
+                        .header("Location", redirected_path.clone())
+                        .build(),
+                ),
+            )
+            .with_bearer_auth(token),
+        );
+        self.server.register(Route::exact(
+            "GET",
+            redirected_path,
+            Responder::Static(
+                TestResponse::builder(200)
+                    .header("Content-Type", media_type)
+                    .body_bytes(bytes.to_vec())
+                    .build(),
+            ),
+        ));
+        digest
+    }
+
+    /// Serve a blob route that redirects to itself indefinitely. Clients must
+    /// stop at their redirect bound instead of looping forever.
+    pub async fn register_blob_redirect_loop(&self, repository: &str, bytes: &[u8]) -> String {
+        let digest = format!("sha256:{}", hex::encode(Sha256::digest(bytes)));
+        let path = format!("/v2/{repository}/blobs/{digest}");
+        self.server.register(Route::exact(
+            "GET",
+            path.clone(),
+            Responder::Static(TestResponse::builder(307).header("Location", path).build()),
+        ));
+        digest
+    }
+
     /// Serve a *tampered* blob: the path is the legitimate digest
     /// (so the caller's request reaches us) but the response body
     /// is different bytes (so digest verification fails).

--- a/crates/mvm-fs/tests/hermetic_registry.rs
+++ b/crates/mvm-fs/tests/hermetic_registry.rs
@@ -391,6 +391,67 @@ async fn layer_fetch_happy_path_verifies_digest_and_byte_count() {
 }
 
 #[tokio::test]
+async fn layer_fetch_follows_same_origin_redirect_without_forwarding_auth() {
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes = b"redirected-layer";
+    let token = "registry-only-token";
+    let layer_digest = reg
+        .register_redirected_bearer_blob("library/test", LAYER_MEDIA, layer_bytes, token)
+        .await;
+    let layer = LayerDescriptor {
+        digest: layer_digest,
+        size: layer_bytes.len() as u64,
+        media_type: LAYER_MEDIA.to_string(),
+    };
+    let fetcher = OciLayerFetcher::with_config_and_auth(
+        client_config_for(&reg),
+        LayerFetchOptions::default(),
+        RegistryAuthConfig::bearer(token),
+    );
+    let image = reg.image_ref("library/test", "v1");
+    let mut sink = Vec::new();
+
+    let count = fetcher
+        .fetch_layer(&image, &layer, &mut sink)
+        .await
+        .expect("redirected blob fetch succeeds");
+
+    assert_eq!(count, layer_bytes.len() as u64);
+    assert_eq!(sink, layer_bytes);
+}
+
+#[tokio::test]
+async fn layer_fetch_stops_at_bounded_blob_redirect_limit() {
+    let reg = HermeticRegistry::start().await;
+    let layer_bytes = b"redirect-loop";
+    let layer_digest = reg
+        .register_blob_redirect_loop("library/test", layer_bytes)
+        .await;
+    let layer = LayerDescriptor {
+        digest: layer_digest,
+        size: layer_bytes.len() as u64,
+        media_type: LAYER_MEDIA.to_string(),
+    };
+    let fetcher = OciLayerFetcher::with_config(
+        client_config_for(&reg),
+        LayerFetchOptions {
+            max_retries: 1,
+            ..LayerFetchOptions::default()
+        },
+    );
+    let image = reg.image_ref("library/test", "v1");
+    let mut sink = Vec::new();
+
+    let error = fetcher
+        .fetch_layer(&image, &layer, &mut sink)
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("5-redirect OCI blob limit"));
+    assert!(sink.is_empty());
+}
+
+#[tokio::test]
 async fn layer_fetch_rejects_tampered_blob_with_digest_mismatch() {
     let reg = HermeticRegistry::start().await;
 

--- a/crates/mvm-vmm/src/host/boot_config.rs
+++ b/crates/mvm-vmm/src/host/boot_config.rs
@@ -23,6 +23,17 @@ pub fn builder_hostepoch_cmdline_token() -> String {
     format!("mvm.hostepoch={secs}")
 }
 
+/// Parse the positive Unix epoch carried by an `mvm.hostepoch=` kernel
+/// command-line token. Malformed, zero, and negative values are rejected so a
+/// guest cannot accidentally wind its clock back to the Unix epoch.
+pub fn builder_hostepoch_from_cmdline(cmdline: &str) -> Option<u64> {
+    cmdline
+        .split_whitespace()
+        .find_map(|token| token.strip_prefix("mvm.hostepoch="))
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+}
+
 pub fn probe_verity_sidecar(rootfs_path: &str) -> (Option<String>, Option<String>) {
     use std::path::Path;
 
@@ -196,6 +207,23 @@ pub fn balloon_body(amount_mib: u32) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn builder_hostepoch_parser_accepts_only_positive_unix_epochs() {
+        assert_eq!(
+            builder_hostepoch_from_cmdline(
+                "console=ttyAMA0 mvm.hostepoch=1786425335 root=/dev/vda"
+            ),
+            Some(1_786_425_335)
+        );
+        assert_eq!(builder_hostepoch_from_cmdline("mvm.hostepoch=0"), None);
+        assert_eq!(builder_hostepoch_from_cmdline("mvm.hostepoch=-5"), None);
+        assert_eq!(
+            builder_hostepoch_from_cmdline("mvm.hostepoch=notanumber"),
+            None
+        );
+        assert_eq!(builder_hostepoch_from_cmdline("root=/dev/vda"), None);
+    }
 
     // ------------------------------------------------------------------
     // Firecracker API body builders — byte-identical pins

--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -169,6 +169,15 @@ let
     # neither needs nor compiles this in (keeping it off the arm64 built-in
     # symbol budget).
     "VIRTIO_MMIO_CMDLINE_DEVICES"
+  ]
+  ++ pkgs.lib.optionals (kernelArch == "arm64") [
+    # Firecracker exposes an 8250 serial device on both supported host
+    # architectures. Keep that console alongside PL011 (QEMU virt) and hvc0
+    # (libkrun) so one published arm64 workload kernel remains observable on
+    # every backend. SERIAL_OF_PLATFORM binds the DT-described UART on ARM.
+    "SERIAL_8250"
+    "SERIAL_8250_CONSOLE"
+    "SERIAL_OF_PLATFORM"
   ];
 
   # ── Base disables ──
@@ -418,10 +427,9 @@ let
     # AF_ALG userspace crypto families. Their selectors otherwise restore the
     # workload's required CGROUPS and CRYPTO_USER_API cuts.
     "SCHED_AUTOGROUP"
-    # ARM guests use PL011 early/legacy console or virtio-console. They expose
-    # no legacy 8250 UART, VGA device, error-reporting controller, or SCMI
-    # firmware transport.
-    "SERIAL_8250"
+    # ARM guests expose no VGA device, error-reporting controller, or SCMI
+    # firmware transport. PL011, virtio-console, and Firecracker's 8250 UART
+    # are retained above.
     "VGA_ARB"
     "EDAC"
     "ARM_SCMI_PROTOCOL"

--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -90,7 +90,9 @@ builds: one shared config in `nix/images/kernel/base.nix` plus a
 per-variant delta (`workload.nix` adds dm-verity; `builder.nix` adds
 the nix-build sandbox + egress-lockdown bits). Because the config is
 custom, `cache.nixos.org` has no substitute, so the first build on a
-fresh machine compiles the kernel from source (3-10 min, memory-heavy).
+fresh machine compiles the kernel from source. It can take several minutes
+depending on the host and is memory-heavy; later builds reuse the persistent
+Nix store.
 
 `mvmctl build kernel build` makes that compile explicit and one-time. Image
 backed runs from a source checkout also bootstrap this kernel automatically;

--- a/public/src/content/docs/guides/kernels.md
+++ b/public/src/content/docs/guides/kernels.md
@@ -88,8 +88,9 @@ The legacy `metrics` output remains an alias of `workload-metrics`.
 
 - **compile** builds locally through the Stage 0 bootstrap. It can only build
   the **host** architecture — Stage 0 boots a host-arch VM, so it cannot
-  cross-compile. First compile is 3–10 min; later runs hit the persistent Nix
-  store. The compile path prints an elapsed-time heartbeat, and `--verbose`
+  cross-compile. The first build can take several minutes depending on the
+  host; later runs reuse the persistent Nix store. The compile path prints an
+  elapsed-time heartbeat, and `--verbose`
   streams the live `nix build` console output.
 - **download** fetches a prebuilt `vmlinux-<arch>-<variant>` from the GitHub
   release whose tag matches **this mvmctl's own version**. A given mvmctl can

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-10
+Last updated: 2026-08-11
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -43,13 +43,15 @@ for detailed scope and acceptance criteria.
       canonical budget table, and gates remain open.
 
 ## In-flight plans
-- [~] Plan 315 — Bootstrap means machine-ready
+- [x] Plan 315 — Bootstrap means machine-ready
       (`specs/plans/315-bootstrap-machine-readiness.md`)
   - [x] Bootstrap acquires and verifies both builder image and workload kernel
   - [x] Downloaded/local kernel publication is staged and verified reads fail closed
   - [x] Local dm-verity capability uses resolved config, not raw-image strings
-  - [~] Workspace tests expose unrelated non-deterministic `mvm-hostd` failures;
-        Linux all-target Clippy remains for CI or a supported builder entry point
+  - [x] Full serialized workspace tests and doctests, host all-target Clippy,
+        the 461-test `xtask --features man` CI lane, and 172 BDD scenarios pass;
+        KVM-backed ARM64 cold bootstrap, kernel publication, persistent Stage 0
+        reuse, and two fully warm Alpine runs complete without a second Stage 0
 
 - [~] Plan 315 — HVF virtio-vsock transmit-credit regression
       (`specs/plans/315-hvf-vsock-credit-regression.md`)

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -48,6 +48,8 @@ for detailed scope and acceptance criteria.
   - [x] Bootstrap acquires and verifies both builder image and workload kernel
   - [x] Downloaded/local kernel publication is staged and verified reads fail closed
   - [x] Local dm-verity capability uses resolved config, not raw-image strings
+  - [x] Required ARM64 cross-backend console support is pinned to its measured
+        959-symbol budget; the unaffected x86_64 ratchet remains 917
   - [x] Full serialized workspace tests and doctests, host all-target Clippy,
         the 461-test `xtask --features man` CI lane, and 172 BDD scenarios pass;
         KVM-backed ARM64 cold bootstrap, kernel publication, persistent Stage 0

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,7 +10,7 @@
 
 ## Current issue delivery
 
-- [~] Bootstrap machine readiness — **plan 315**. `mvmctl bootstrap` now
+- [x] Bootstrap machine readiness — **plan 315**. `mvmctl bootstrap` now
       prepares both the builder VM and verified dm-verity workload kernel, so a
       successful bootstrap does not defer an infrastructure build to the next
       `machine run`. Kernel downloads verify before replacement, local Stage 0
@@ -18,12 +18,17 @@
       verified reads reject any crash-skewed cache. Interrupted staging is swept
       on retry while the persistent Nix store remains warm. Local capability validation
       uses the resolved kernel config instead of searching a KALLSYMS-free raw
-      image for symbol strings. Formatting, focused tests, all 172 BDD
-      scenarios, workspace check, and host workspace all-target Clippy pass.
-      Full workspace tests pass the changed crates but expose unrelated,
-      non-deterministic `mvm-hostd` shared-state/timing failures; the Linux
-      all-target Clippy rerun remains for CI or a supported builder-VM entry
-      point.
+      image for symbol strings. QEMU Stage 0 now has a reusable Nix-store disk,
+      an accurate guest clock, architecture-correct console wiring, and a
+      two-hour cold-build window. ARM64 workload kernels carry the console
+      drivers required by Firecracker and HVF/QEMU, while bounded OCI blob
+      redirects reach only exact trusted Docker CDN origins without forwarding
+      registry authorization. Formatting, workspace check, host workspace
+      all-target Clippy, the complete serialized workspace suite and doctests,
+      the exact 461-test `xtask --features man` CI lane, and all 172 BDD
+      scenarios pass. A KVM-backed ARM64 acceptance run completed cold
+      bootstrap and kernel publication, then ran Alpine twice from a fully warm
+      cache without launching Stage 0.
 
 - [~] HVF large-response integrity — **plan 315**. Restored bounded
       virtio-vsock host-to-guest credit accounting that had been removed while

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -23,7 +23,9 @@
       two-hour cold-build window. ARM64 workload kernels carry the console
       drivers required by Firecracker and HVF/QEMU, while bounded OCI blob
       redirects reach only exact trusted Docker CDN origins without forwarding
-      registry authorization. Formatting, workspace check, host workspace
+      registry authorization. The required console dependencies move only the
+      ARM64 built-in-symbol ratchet from 944 to its measured 959; x86_64 stays
+      at 917. Formatting, workspace check, host workspace
       all-target Clippy, the complete serialized workspace suite and doctests,
       the exact 461-test `xtask --features man` CI lane, and all 172 BDD
       scenarios pass. A KVM-backed ARM64 acceptance run completed cold

--- a/specs/plans/315-bootstrap-machine-readiness.md
+++ b/specs/plans/315-bootstrap-machine-readiness.md
@@ -44,7 +44,8 @@ store remains reusable.
       allow a real cold kernel compile to run for up to two hours with honest
       first-build messaging.
 - [x] Keep the ARM64 workload kernel bootable across Firecracker, HVF/QEMU,
-      and libkrun by building in both 8250 and PL011/HVC console support.
+      and libkrun by building in both 8250 and PL011/HVC console support. Pin
+      its measured built-in-symbol ratchet at 959 while leaving x86_64 at 917.
 - [x] Follow only bounded, HTTPS OCI blob redirects to the exact trusted Docker
       CDN origins, stripping registry authorization at the origin boundary and
       refusing redirects for manifests.

--- a/specs/plans/315-bootstrap-machine-readiness.md
+++ b/specs/plans/315-bootstrap-machine-readiness.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Implementation complete; repository-wide verification exceptions documented.** Opened 2026-08-10 after
+**COMPLETE.** Opened 2026-08-10 after
 an explicit `mvmctl bootstrap` prepared the builder VM but left the workload
 kernel absent, causing the next `machine run --image` to launch Stage 0. The
 interrupted repair then exposed a second defect: Stage 0 copied the resolved Nix
@@ -39,18 +39,26 @@ store remains reusable.
 - [x] Track in-process Stage 0 ownership for truthful Ctrl-C messaging, retain
       the persistent Nix store, and sweep only matching orphan staging
       directories under the shared Stage 0 lock on retry.
+- [x] Give QEMU Stage 0 a persistent Nix-store disk, synchronize its guest
+      clock before TLS/Nix access, use the correct architecture console, and
+      allow a real cold kernel compile to run for up to two hours with honest
+      first-build messaging.
+- [x] Keep the ARM64 workload kernel bootable across Firecracker, HVF/QEMU,
+      and libkrun by building in both 8250 and PL011/HVC console support.
+- [x] Follow only bounded, HTTPS OCI blob redirects to the exact trusted Docker
+      CDN origins, stripping registry authorization at the origin boundary and
+      refusing redirects for manifests.
 - [x] Cover bootstrap ordering/failure, verified resolution, incompatible-cache
       eviction, KALLSYMS-free acceptance, config rejection, atomic publication,
       interrupted-staging cleanup, buffered symlink copy, and Ctrl-C messaging.
-- [ ] Close repository-wide verification exceptions. Formatting, focused tests,
-      `cargo check --workspace`, host `cargo clippy --workspace --all-targets --
-      -D warnings`, and all 172 BDD scenarios pass. The full workspace test run
-      passes the changed crates but remains red in untouched `mvm-hostd`
-      shared-state/timing tests; isolated reruns produce a different telemetry
-      failure and a hanging UDS test. The Linux all-target Clippy rerun remains
-      for CI or a supported builder-VM execution entry point; the shipped
-      builder is headless and this macOS session must not run Linux tooling
-      outside it.
+- [x] Close repository-wide verification. Formatting, focused tests, `cargo
+      check --workspace`, host `cargo clippy --workspace --all-targets -- -D
+      warnings`, the complete serialized workspace suite including doctests,
+      the exact 461-test `xtask --features man` CI lane, and all 172 BDD
+      scenarios pass. A KVM-backed ARM64 acceptance run completed a cold
+      bootstrap, reused the persistent Stage 0 Nix store, rebuilt and published
+      the workload kernel with dm-verity plus 8250 console support, and then ran
+      Alpine twice from the fully warm cache without launching Stage 0.
 
 ## Security properties
 

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -766,18 +766,28 @@ fn mk_guest_seeds_vsock_egress_dns_before_privilege_drop() {
 }
 
 #[test]
-fn shared_kernel_base_forces_hvc0_console_support() {
+fn shared_kernel_base_forces_backend_console_support() {
     let path = nix_dir().join("images").join("kernel").join("base.nix");
     let content = fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("nix/images/kernel/base.nix must be present: {e}"));
 
-    assert!(
-        content.contains("\"VIRTIO_CONSOLE\"") && content.contains("\"HVC_DRIVER\""),
-        "the shared microVM kernel base must force both VIRTIO_CONSOLE and \
-         HVC_DRIVER when libkrun workloads boot with `console=hvc0`; \
-         otherwise the kernel can boot silently even though the backend \
-         wires a virtio-console."
-    );
+    let enables = content
+        .split_once("baseEnables =")
+        .and_then(|(_, tail)| tail.split_once("requiredDisables ="))
+        .map(|(enables, _)| enables)
+        .expect("base kernel enables precede required disables");
+    for symbol in [
+        "VIRTIO_CONSOLE",
+        "HVC_DRIVER",
+        "SERIAL_8250",
+        "SERIAL_8250_CONSOLE",
+        "SERIAL_OF_PLATFORM",
+    ] {
+        assert!(
+            enables.contains(&format!("\"{symbol}\"")),
+            "the shared microVM kernel base must force CONFIG_{symbol} for a supported backend console"
+        );
+    }
 }
 
 #[test]
@@ -820,7 +830,6 @@ fn shared_kernel_base_enforces_audited_subsystem_removals() {
         "ACPI_PROCESSOR",
         "X86_PLATFORM_DEVICES",
         "ARM_SCMI_PROTOCOL",
-        "SERIAL_8250",
     ] {
         assert!(
             required.contains(&format!("\"{symbol}\"")),

--- a/xtask/src/check_kernel_config_budget.rs
+++ b/xtask/src/check_kernel_config_budget.rs
@@ -50,8 +50,13 @@ use std::path::Path;
 /// has one point-to-point link and no tunnel endpoint to encapsulate toward.
 /// The v6 IPsec families remain in the required-disable set, so XFRM is not
 /// absorbed into this budget. These values are measured from resolved configs
-/// on the native CI architectures — x86_64 measures 917, confirmed by CI.
-const BUDGET_AARCH64: usize = 944;
+/// on the native CI architectures.
+///
+/// ARM64 then rose by 15 when the shared workload kernel gained the 8250 and
+/// device-tree serial support required by Firecracker while retaining the
+/// PL011 and HVC consoles used by the other supported backends. Its resolved
+/// config measures 959 built-ins. The x86_64 config is unchanged at 917.
+const BUDGET_AARCH64: usize = 959;
 const BUDGET_X86_64: usize = 917;
 
 /// Resolve the budget for a config path by the arch in its name. Unknown →
@@ -156,5 +161,11 @@ mod tests {
             budget_for_path("/tmp/some.config"),
             BUDGET_AARCH64.max(BUDGET_X86_64)
         );
+    }
+
+    #[test]
+    fn architecture_budgets_are_pinned_to_resolved_counts() {
+        assert_eq!(BUDGET_AARCH64, 959);
+        assert_eq!(BUDGET_X86_64, 917);
     }
 }

--- a/xtask/src/check_no_gateway_names.rs
+++ b/xtask/src/check_no_gateway_names.rs
@@ -56,6 +56,8 @@ const EXEMPT: &[&str] = &[
 /// would fail the gate on prose that has already been corrected at the source.
 const SKIP_DIRS: &[&str] = &[
     ".git",
+    ".mvm-test",
+    ".mvm-verify",
     "target",
     "node_modules",
     ".worktrees",
@@ -216,6 +218,20 @@ mod tests {
         );
         // ...and the gate itself passes despite the planted name behind it.
         run(&root).expect("a symlinked tree must not fail the gate");
+    }
+
+    #[test]
+    fn generated_mvm_state_directories_are_not_scanned() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        for dir in [".mvm-test", ".mvm-verify"] {
+            let generated = tmp.path().join(dir).join("cargo");
+            std::fs::create_dir_all(&generated).expect("generated state directory");
+            std::fs::write(generated.join("third-party.txt"), "gvproxy\n")
+                .expect("generated state file");
+        }
+        std::fs::write(tmp.path().join("source.txt"), "clean\n").expect("source file");
+
+        run(tmp.path()).expect("generated mvm state must not enter source policy scans");
     }
 
     /// `passthru` is a Nix attribute used throughout the builder pipeline and


### PR DESCRIPTION
## What changed

- give QEMU Stage 0 a persistent Nix-store disk, host-synchronized clock, architecture-correct console, bounded two-hour cold-build window, and honest first-build messaging
- publish the resolved kernel config and keep ARM64 workload kernels observable on Firecracker, HVF/QEMU, and libkrun by enabling the required 8250, PL011, and HVC console support
- follow OCI blob redirects only through bounded, HTTPS, trusted origins while stripping registry authorization and redacting signed query strings from errors
- record the completed cold/warm ARM64 acceptance evidence in Plan 315 and the project rollups

## Why

The first bootstrap could build a workload kernel inside QEMU Stage 0 but lose the expensive Nix cache afterwards. A real ARM64 cold compile could also exceed the old one-hour timeout, and the resulting workload kernel lacked Firecracker's 8250 console support. Once those were corrected, Docker Hub's authenticated blob redirect exposed a separate image-pull compatibility gap.

This is the final follow-up to merged PR #2329. It makes a successful bootstrap durable: later machine runs reuse the verified kernel and persistent Nix store instead of unexpectedly rebuilding Stage 0.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- serialized `cargo test --workspace -- --test-threads=1`, including doctests
- `cargo nextest run -p xtask --features man`: 461/461 passed
- `just bdd`: 172/172 scenarios and 716/716 steps passed
- KVM-backed ARM64 cold bootstrap and workload-kernel publication completed; the published config contains dm-verity and 8250 console support
- two fully warm Alpine machine runs completed without launching Stage 0
