### PR TITLE
perf(core): fdatasync the atomic write, not fsync

### DIFF
--- a/crates/mvm-core/src/util/atomic_io.rs
+++ b/crates/mvm-core/src/util/atomic_io.rs
@@ -13,6 +13,20 @@ use anyhow::{Context, Result};
 ///
 /// On crash or power loss, the file either has the old content or the new
 /// content — never a partial write.
+///
+/// The sync is `sync_data` (`fdatasync`), not `sync_all`. `fdatasync` still
+/// flushes the metadata a later read needs to retrieve the data — the file's
+/// size above all, which is the part that matters for a temp file this call
+/// just created — and skips the rest. On rotational storage that is the
+/// difference between one seek and two, and this is the shared write path
+/// behind the audit chain, the receipt store, and every other record mvm
+/// persists, so it is paid on the launch critical path.
+///
+/// The metadata `sync_all` additionally flushed was not buying a stronger
+/// guarantee here in any case: this function never fsyncs the *parent
+/// directory* after the rename, so the rename's own durability across a crash
+/// is unguaranteed either way. Making that stronger means adding a directory
+/// fsync, not keeping a more expensive file sync.
 pub fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
     let parent = path
         .parent()
@@ -26,7 +40,7 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
     tmp.write_all(data)
         .with_context(|| format!("failed to write temp file for {}", path.display()))?;
     tmp.flush()?;
-    tmp.as_file().sync_all()?;
+    tmp.as_file().sync_data()?;
 
     tmp.persist(path)
         .with_context(|| format!("failed to persist temp file to {}", path.display()))?;


### PR DESCRIPTION
One line, but on the shared durability primitive: `atomic_write` is behind the audit chain, the receipt store, and every other record mvm persists, so its sync is paid on the launch critical path. 34 call sites across 7 crates.

## Measured, not estimated

7200rpm md array, 20 iterations each:

```
fsync     (sync_all)   p50 49.87 ms   min 41.52   max 153.14
fdatasync (sync_data)  p50 41.56 ms   min 41.13   max  91.78
```

**~17% per persisted record on rotational storage** — not the halving a seek-count argument suggests. The bulk is rotational latency either way. On NVMe both collapse to well under a millisecond and this is noise.

I am proposing it because it is free and strictly correct, not because it is a large win. An earlier draft of this claimed "roughly half"; the benchmark disproved that and the commit message carries the real numbers.

## Why it is correct

`fdatasync` still flushes the metadata a later read needs to *retrieve* the data — the size of the temp file this call just created, above all. That is the only metadata that matters for a fresh file written then renamed.

The metadata `sync_all` additionally flushed was not buying a stronger guarantee here in any case: **this function never fsyncs the parent directory after the rename**, so the rename's own crash-durability is unguaranteed either way. If we want that guarantee, the fix is *adding* a directory fsync, not keeping a more expensive file sync. That is a separate decision and is not made here — but it is worth someone deciding, because the current code implies a durability level it does not deliver.

## Validation

`cargo nextest run -p mvm-core` — **1775 passed, 1 skipped**, including the transcript and manifest suites that exercise this write path directly.

## Context

Found while attributing a 406.8 ms transient teardown (#2323, #2339). The manifest seal's ~89 ms residual is one of these syncs. Worth stating plainly: three of the largest costs measured on that host — `admit`'s 149 ms, the receipt store's 117 ms, this 89 ms — are all rotational-latency artifacts that mostly vanish on NVMe. Optimising further against that disk would send someone at ~350 ms that production hardware does not have.