### PR TITLE
Make the interactive guest usable as the uid it actually runs as

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/interactive.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/interactive.rs
@@ -424,22 +424,26 @@ pub(crate) fn handle_console_open(
 }
 
 pub(crate) fn handle_console_close(session_id: u32) -> GuestResponse {
-    // Console sessions end when the shell exits or the host disconnects.
-    // Explicit close is a no-op if already closed.
-    if mvm_agentd::console::is_active() {
-        GuestResponse::Error {
-            message: "explicit close not yet supported — disconnect to end session".to_string(),
-        }
-    } else if let Some(exit_code) = mvm_agentd::console::completed_exit_code(session_id) {
-        GuestResponse::ConsoleExited {
+    // A session that has already finished has its exit code on record — the
+    // answer whether the shell exited on its own or a prior close ended it.
+    if let Some(exit_code) = mvm_agentd::console::completed_exit_code(session_id) {
+        return GuestResponse::ConsoleExited {
             session_id,
             exit_code,
-        }
-    } else {
-        GuestResponse::ConsoleExited {
+        };
+    }
+    // Otherwise end the session and wait for it. The host reaches here on every
+    // ordinary logout: it sends the close the instant its relay sees EOF, which
+    // is before the guest has reaped the shell, so refusing while a session was
+    // still winding down turned every clean exit into an error.
+    match mvm_agentd::console::close_active_session(mvm_agentd::console::CLOSE_SETTLE_TIMEOUT) {
+        Some(exit_code) => GuestResponse::ConsoleExited {
             session_id,
-            exit_code: 0,
-        }
+            exit_code,
+        },
+        None => GuestResponse::Error {
+            message: "console session did not terminate".to_string(),
+        },
     }
 }
 

--- a/crates/mvm-agentd/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-oci-init.rs
@@ -38,13 +38,6 @@ mod linux {
         if provision_guest_environment().is_err() {
             std::process::exit(1);
         }
-        if let Err(error) = mvm_agentd::guest_mount::ensure_workload_home() {
-            eprintln!(
-                "mvm-oci-init: failed to create workload home ({}): {error}; falling back to {}",
-                mvm_agentd::guest_mount::WORKLOAD_HOME,
-                mvm_agentd::guest_mount::WORKLOAD_HOME_FALLBACK
-            );
-        }
         if cmdline_has_flag(mvm_contract::l3::GUEST_CMDLINE_FLAG) {
             start_l3_tunnel();
         }

--- a/crates/mvm-agentd/src/console.rs
+++ b/crates/mvm-agentd/src/console.rs
@@ -21,6 +21,16 @@ static COMPLETED_SESSION_ID: AtomicU32 = AtomicU32::new(0);
 static COMPLETED_EXIT_CODE: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(0);
 /// Active PTY master fd for resize support. -1 when no session is active.
 static CONSOLE_MASTER_FD: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
+/// Active session's shell pid, so an explicit close can end it. -1 when idle.
+static CONSOLE_CHILD_PID: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
+
+/// How long an explicit close waits for the session to finish winding down.
+///
+/// The host sends `ConsoleClose` the instant its relay sees EOF, which the
+/// guest produces *before* it reaps the shell and joins its relay threads — so
+/// the request routinely arrives while the session is still tearing itself
+/// down. Waiting is what turns that race into the exit code the host asked for.
+pub const CLOSE_SETTLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Result of opening a console session.
 pub struct ConsoleSession {
@@ -83,6 +93,9 @@ const AF_VSOCK: i32 = 40;
 const SOCK_STREAM: i32 = 1;
 const VMADDR_CID_ANY: u32 = 0xFFFF_FFFF;
 const SIGTERM: i32 = 15;
+/// Sent to an interactive shell on explicit close: a hangup is what a terminal
+/// going away looks like, so job-control shells clean up their children.
+const SIGHUP: i32 = 1;
 
 fn console_peer_is_authorized(cid: u32) -> bool {
     cid == HOST_CID
@@ -222,6 +235,12 @@ pub fn open_session(
     let shell_env = build_shell_env_with(extra_env);
     let mut envp: Vec<*const u8> = shell_env.iter().map(|c| c.as_ptr().cast::<u8>()).collect();
     envp.push(std::ptr::null());
+    // Same reason as `envp`: the child's `chdir` target has to be a NUL string
+    // allocated before the fork. Start where `$HOME` points — the workload's
+    // own writable home — rather than in root's, which the workload uid can
+    // neither write nor, on most images, read.
+    let start_dir = std::ffi::CString::new(crate::guest_mount::workload_home())
+        .unwrap_or_else(|_| c"/".to_owned());
     // SAFETY: fork() takes no arguments and has no preconditions; it returns
     // twice (0 in the child, the child pid in the parent).
     let pid = unsafe { fork() };
@@ -260,7 +279,7 @@ pub fn open_session(
             }
 
             // Start in $HOME.
-            let _ = chdir(c"/root".as_ptr().cast());
+            let _ = chdir(start_dir.as_ptr().cast());
 
             // Exec the prepared absolute command path. There is no PATH search
             // here because the post-fork child must avoid allocation.
@@ -277,6 +296,7 @@ pub fn open_session(
         close(slave_fd);
     }
     CONSOLE_MASTER_FD.store(master_fd, std::sync::atomic::Ordering::SeqCst);
+    CONSOLE_CHILD_PID.store(pid, std::sync::atomic::Ordering::SeqCst);
 
     Ok(ConsoleSession {
         session_id,
@@ -353,16 +373,18 @@ pub fn close_session(session: &ConsoleSession) -> i32 {
         close(session.master_fd);
     }
 
-    CONSOLE_MASTER_FD.store(-1, std::sync::atomic::Ordering::SeqCst);
-    CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
-
     // Extract exit code
     let exit_code = if status & 0x7f == 0 {
         (status >> 8) & 0xff // normal exit
     } else {
         128 + (status & 0x7f) // signal
     };
+    // Recorded before the active flag clears, for the reason given in
+    // `run_console_relay`'s teardown.
     record_completed_session(session.session_id, exit_code);
+    CONSOLE_MASTER_FD.store(-1, std::sync::atomic::Ordering::SeqCst);
+    CONSOLE_CHILD_PID.store(-1, std::sync::atomic::Ordering::SeqCst);
+    CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
     exit_code
 }
 
@@ -571,9 +593,6 @@ pub fn run_console_relay(session: &ConsoleSession) -> i32 {
         waitpid(child_pid, &mut status, 0);
     }
 
-    CONSOLE_MASTER_FD.store(-1, std::sync::atomic::Ordering::SeqCst);
-    CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
-
     // Don't call close_session — we already waited and the fds are owned
     // by the File/UnixStream objects which will drop.
     let exit_code = if status & 0x7f == 0 {
@@ -581,13 +600,60 @@ pub fn run_console_relay(session: &ConsoleSession) -> i32 {
     } else {
         128 + (status & 0x7f)
     };
+    // Record before clearing the active flag, never after: a close waiting on
+    // that flag would otherwise read the previous session's exit code.
     record_completed_session(session.session_id, exit_code);
+    CONSOLE_MASTER_FD.store(-1, std::sync::atomic::Ordering::SeqCst);
+    CONSOLE_CHILD_PID.store(-1, std::sync::atomic::Ordering::SeqCst);
+    CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
     exit_code
 }
 
 /// Check if a console session is currently active.
 pub fn is_active() -> bool {
     CONSOLE_ACTIVE.load(Ordering::SeqCst)
+}
+
+/// Block until no session is active, or `timeout` elapses. Returns whether the
+/// session settled.
+fn wait_until_idle(timeout: std::time::Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while is_active() {
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    true
+}
+
+/// End the active console session and return the shell's exit code.
+///
+/// Two callers arrive here and both must be served. The common one is a host
+/// that already saw its relay EOF and only wants the exit code — its session is
+/// mid-teardown, so the first wait is all it needs. The other is a host that
+/// wants a still-running session gone, which takes a `SIGHUP` to the shell:
+/// that closes the PTY, ends the relay, and the same teardown path records the
+/// exit code.
+///
+/// Returns `None` only if the session outlives both waits (`timeout` each),
+/// which means the relay is wedged rather than merely slow.
+pub fn close_active_session(timeout: std::time::Duration) -> Option<i32> {
+    if !wait_until_idle(timeout) {
+        let pid = CONSOLE_CHILD_PID.load(Ordering::SeqCst);
+        if pid > 0 {
+            // SAFETY: `kill` takes no pointers. `pid` is the shell forked by
+            // `open_session`; if it has already been reaped this returns ESRCH,
+            // which is exactly the case the wait below then observes.
+            unsafe {
+                kill(pid, SIGHUP);
+            }
+        }
+        if !wait_until_idle(timeout) {
+            return None;
+        }
+    }
+    Some(COMPLETED_EXIT_CODE.load(Ordering::SeqCst))
 }
 
 fn record_completed_session(session_id: u32, exit_code: i32) {
@@ -756,6 +822,77 @@ mod tests {
         );
         let strs: Vec<&str> = out.iter().filter_map(|c| c.to_str().ok()).collect();
         assert!(strs.contains(&"MVM_SESSION_TAG=abc123"));
+    }
+
+    /// The reported bug: `mvmctl machine run -it` printed
+    /// "explicit close not yet supported" on every clean logout. The host
+    /// sends its close as soon as the relay EOFs, which the guest emits
+    /// before it reaps the shell — so the close lands on a session that is
+    /// still active and must wait for it, not refuse it.
+    #[test]
+    fn close_waits_out_a_session_that_is_still_tearing_down() {
+        CONSOLE_ACTIVE.store(true, Ordering::SeqCst);
+        std::thread::spawn(|| {
+            std::thread::sleep(std::time::Duration::from_millis(120));
+            record_completed_session(7, 42);
+            CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
+        });
+
+        assert_eq!(
+            close_active_session(std::time::Duration::from_secs(5)),
+            Some(42)
+        );
+    }
+
+    /// A wedged relay is the one case that still fails, and it fails as a
+    /// refusal rather than by blocking the agent forever.
+    #[test]
+    fn close_reports_a_session_that_never_terminates() {
+        CONSOLE_ACTIVE.store(true, Ordering::SeqCst);
+        // No shell pid is recorded, so the SIGHUP escalation has nothing to
+        // signal and both waits lapse.
+        CONSOLE_CHILD_PID.store(-1, Ordering::SeqCst);
+
+        assert_eq!(
+            close_active_session(std::time::Duration::from_millis(50)),
+            None
+        );
+
+        CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
+    }
+
+    /// An idle agent answers immediately from the recorded exit code.
+    #[test]
+    fn close_returns_the_recorded_code_when_no_session_is_active() {
+        CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
+        record_completed_session(3, 130);
+
+        assert_eq!(close_active_session(CLOSE_SETTLE_TIMEOUT), Some(130));
+        assert_eq!(completed_exit_code(3), Some(130));
+        assert_eq!(
+            completed_exit_code(4),
+            None,
+            "other sessions must not match"
+        );
+    }
+
+    /// The exit code has to be on record before the active flag clears, or a
+    /// close released by that flag reads whatever the previous session left.
+    #[test]
+    fn the_exit_code_is_recorded_before_the_active_flag_clears() {
+        record_completed_session(1, 9);
+        CONSOLE_ACTIVE.store(true, Ordering::SeqCst);
+        let observer = std::thread::spawn(|| {
+            while is_active() {
+                std::hint::spin_loop();
+            }
+            COMPLETED_EXIT_CODE.load(Ordering::SeqCst)
+        });
+
+        record_completed_session(2, 55);
+        CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
+
+        assert_eq!(observer.join().unwrap(), 55);
     }
 
     #[test]

--- a/crates/mvm-agentd/src/guest_bootstrap.rs
+++ b/crates/mvm-agentd/src/guest_bootstrap.rs
@@ -24,6 +24,7 @@ pub struct EgressClientMissing;
 /// privileged: the mounts, `/run/mvm` writes and interface changes all need root.
 pub fn provision_guest_environment() -> Result<(), EgressClientMissing> {
     ensure_runtime_dirs();
+    provision_workload_identity();
     mount_mediated_tools();
     provision_egress_ca();
     provision_verb_grant();
@@ -32,6 +33,31 @@ pub fn provision_guest_environment() -> Result<(), EgressClientMissing> {
         start_vsock_egress()?;
     }
     Ok(())
+}
+
+/// Give the workload a home it owns and a name for its uid.
+///
+/// Both are cosmetic-until-they-aren't: without the home the shell starts in a
+/// directory it cannot write, and without the `/etc/passwd` entry `whoami`
+/// exits nonzero and `getpwuid()` returns `NULL` to any library that asks.
+/// Neither failure is worth refusing to boot over — a read-only rootfs that
+/// takes neither write still runs the workload — so both are reported and
+/// stepped past.
+fn provision_workload_identity() {
+    if let Err(error) = crate::guest_mount::ensure_workload_home() {
+        eprintln!(
+            "mvm-guest-init: could not create the workload home ({}): {error}; falling back to {}",
+            crate::guest_mount::WORKLOAD_HOME,
+            crate::guest_mount::WORKLOAD_HOME_FALLBACK
+        );
+    }
+    if let Err(error) = crate::workload_identity::provision() {
+        eprintln!(
+            "mvm-guest-init: could not name uid {} in /etc/passwd: {error}; \
+             whoami and getpwuid will not resolve it",
+            crate::guest_mount::WORKLOAD_UID
+        );
+    }
 }
 
 fn start_vsock_egress() -> Result<(), EgressClientMissing> {
@@ -93,7 +119,24 @@ pub fn ensure_runtime_dirs() {
             eprintln!("mvm-guest-init: mkdir {path}: {e}");
         }
     }
+    // The workload runs unprivileged, so the two world-writable scratch
+    // directories have to actually be world-writable. An image that ships them
+    // already has them at 1777; one that does not (`scratch`, distroless) gets
+    // whatever `create_dir_all` chose, which is root-owned 0755 — and every
+    // tempfile the workload opens then fails with EACCES.
+    for path in ["/tmp", "/dev/shm"] {
+        if let Err(e) = fs::set_permissions(
+            path,
+            std::os::unix::fs::PermissionsExt::from_mode(SCRATCH_DIR_MODE),
+        ) {
+            eprintln!("mvm-guest-init: chmod 1777 {path}: {e}");
+        }
+    }
 }
+
+/// `drwxrwxrwt` — world-writable with the sticky bit, so one workload process
+/// cannot delete another's files.
+const SCRATCH_DIR_MODE: u32 = 0o1777;
 
 /// Deliver each mediated tool, by both routes available.
 ///

--- a/crates/mvm-agentd/src/lib.rs
+++ b/crates/mvm-agentd/src/lib.rs
@@ -104,6 +104,9 @@ pub mod volume;
 pub mod vsock;
 pub mod worker_pool;
 pub mod worker_protocol;
+/// Names the fixed workload uid/gid in the workload rootfs account databases,
+/// so `whoami`/`id`/`getpwuid` resolve inside images mvm did not build.
+pub mod workload_identity;
 
 /// Process control RPC handler. Requests are admitted only after the guest
 /// agent's runtime profile and signed verb grant checks succeed.

--- a/crates/mvm-agentd/src/workload_identity.rs
+++ b/crates/mvm-agentd/src/workload_identity.rs
@@ -1,0 +1,247 @@
+//! Name the fixed workload uid/gid inside the workload rootfs.
+//!
+//! The agent and every workload process run as uid [`WORKLOAD_UID`], but an
+//! arbitrary image — an OCI base like `alpine`, a distroless tree, `scratch` —
+//! carries its own `/etc/passwd` that has never heard of it. Everything that
+//! resolves a uid to a name then fails: `whoami` exits nonzero, `id` prints a
+//! bare number, `ls -l` shows digits, and library code calling `getpwuid()`
+//! gets `NULL` and often treats that as fatal.
+//!
+//! Nix-built images get these entries from `mk-guest.nix`; this module is the
+//! equivalent for images mvm did not build. It only ever *appends* an entry
+//! for the workload identity, and never when the uid, gid, or name is already
+//! spoken for — the image's own accounts win, and no existing line (uid 0
+//! least of all) is rewritten.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::guest_mount::{WORKLOAD_GID, WORKLOAD_UID};
+
+/// Account name given to the workload identity.
+pub const WORKLOAD_USER: &str = "mvm-worker";
+
+/// Login shell recorded for the workload account.
+const WORKLOAD_SHELL: &str = "/bin/sh";
+
+const PASSWD_PATH: &str = "/etc/passwd";
+const GROUP_PATH: &str = "/etc/group";
+
+/// The `/etc/passwd` line naming the workload identity.
+fn passwd_entry(home: &str) -> String {
+    format!(
+        "{WORKLOAD_USER}:x:{WORKLOAD_UID}:{WORKLOAD_GID}:mvm workload:{home}:{WORKLOAD_SHELL}\n"
+    )
+}
+
+/// The `/etc/group` line naming the workload group.
+fn group_entry() -> String {
+    format!("{WORKLOAD_USER}:x:{WORKLOAD_GID}:\n")
+}
+
+/// Whether a colon-separated database already claims `name` or `id` in its
+/// name and id columns. Comment and blank lines carry neither.
+fn claims(existing: &str, name: &str, id: u32) -> bool {
+    existing.lines().any(|line| {
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() || line.starts_with('#') {
+            return false;
+        }
+        let mut fields = line.split(':');
+        let entry_name = fields.next().unwrap_or_default();
+        // Field 1 is the password placeholder in both databases; field 2 is
+        // the numeric id in both.
+        let entry_id = fields.nth(1).unwrap_or_default();
+        entry_name == name || entry_id.parse::<u32>() == Ok(id)
+    })
+}
+
+/// Append `entry` to `existing` when neither `name` nor `id` is taken,
+/// returning the new file content. `None` means the file already covers the
+/// identity and must be left byte-for-byte alone.
+fn with_entry(existing: &str, name: &str, id: u32, entry: &str) -> Option<String> {
+    if claims(existing, name, id) {
+        return None;
+    }
+    let mut updated = String::with_capacity(existing.len() + entry.len() + 1);
+    updated.push_str(existing);
+    // A database whose last line has no terminator would otherwise absorb the
+    // new entry into it.
+    if !existing.is_empty() && !existing.ends_with('\n') {
+        updated.push('\n');
+    }
+    updated.push_str(entry);
+    Some(updated)
+}
+
+/// A missing database is not an error — `scratch` images ship neither file,
+/// and creating them is exactly what makes the identity resolvable there.
+fn read_or_empty(path: &Path) -> io::Result<String> {
+    match fs::read_to_string(path) {
+        Ok(content) => Ok(content),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(String::new()),
+        Err(error) => Err(error),
+    }
+}
+
+fn update_database(path: &Path, name: &str, id: u32, entry: &str) -> io::Result<()> {
+    let existing = read_or_empty(path)?;
+    let Some(updated) = with_entry(&existing, name, id, entry) else {
+        return Ok(());
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, updated)?;
+    Ok(())
+}
+
+/// Give the workload uid/gid a name in the account databases under `root`.
+///
+/// Runs as root after the pivot and before the privilege drop, so the write
+/// lands in the workload's own rootfs (or its writable overlay) while the
+/// agent can still perform it.
+pub fn provision_in(root: &Path, home: &str) -> io::Result<()> {
+    let joined = |absolute: &str| -> PathBuf { root.join(absolute.trim_start_matches('/')) };
+    update_database(
+        &joined(PASSWD_PATH),
+        WORKLOAD_USER,
+        WORKLOAD_UID,
+        &passwd_entry(home),
+    )?;
+    update_database(
+        &joined(GROUP_PATH),
+        WORKLOAD_USER,
+        WORKLOAD_GID,
+        &group_entry(),
+    )
+}
+
+/// Provision the workload identity in the live root.
+///
+/// A read-only rootfs that refuses the write is reported but not fatal: an
+/// unnamed uid degrades `whoami` and friends, it does not stop the workload.
+pub fn provision() -> io::Result<()> {
+    provision_in(Path::new("/"), crate::guest_mount::workload_home())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::guest_mount::WORKLOAD_HOME;
+
+    fn passwd_of(dir: &Path) -> String {
+        fs::read_to_string(dir.join("etc/passwd")).unwrap()
+    }
+
+    /// The reported bug: an Alpine rootfs knows nothing about uid 901, so
+    /// `whoami` fails with `unknown uid 901`. After provisioning, the uid
+    /// resolves — and Alpine's own accounts are untouched.
+    #[test]
+    fn names_the_workload_uid_in_an_image_that_never_heard_of_it() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("etc")).unwrap();
+        let alpine = "root:x:0:0:root:/root:/bin/ash\nbin:x:1:1:bin:/bin:/sbin/nologin\n";
+        fs::write(dir.path().join("etc/passwd"), alpine).unwrap();
+        fs::write(
+            dir.path().join("etc/group"),
+            "root:x:0:root\nbin:x:1:root,bin\n",
+        )
+        .unwrap();
+
+        provision_in(dir.path(), WORKLOAD_HOME).unwrap();
+
+        let passwd = passwd_of(dir.path());
+        assert!(passwd.starts_with(alpine), "existing accounts rewritten");
+        assert!(
+            passwd.contains(&format!(
+                "{WORKLOAD_USER}:x:901:901:mvm workload:{WORKLOAD_HOME}:"
+            )),
+            "workload uid not named: {passwd}"
+        );
+        let group = fs::read_to_string(dir.path().join("etc/group")).unwrap();
+        assert!(group.contains("mvm-worker:x:901:"), "{group}");
+    }
+
+    /// A `scratch` image ships no account databases at all; provisioning
+    /// creates them rather than failing.
+    #[test]
+    fn creates_the_databases_when_the_image_ships_none() {
+        let dir = tempfile::tempdir().unwrap();
+        provision_in(dir.path(), WORKLOAD_HOME).unwrap();
+        assert!(passwd_of(dir.path()).contains("mvm-worker:x:901:901:"));
+    }
+
+    /// An image that already assigns uid 901 to one of its own accounts keeps
+    /// it. Appending a second entry for the same uid would make `getpwuid`
+    /// resolution order-dependent.
+    #[test]
+    fn leaves_an_image_that_already_claims_the_uid_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("etc")).unwrap();
+        let existing = "root:x:0:0:root:/root:/bin/sh\napp:x:901:901:app:/app:/bin/sh\n";
+        fs::write(dir.path().join("etc/passwd"), existing).unwrap();
+
+        provision_in(dir.path(), WORKLOAD_HOME).unwrap();
+
+        assert_eq!(passwd_of(dir.path()), existing);
+    }
+
+    /// Provisioning twice — a warm VM reactivated, or both guest inits running
+    /// the same step — must not append the entry a second time.
+    #[test]
+    fn is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        provision_in(dir.path(), WORKLOAD_HOME).unwrap();
+        let once = passwd_of(dir.path());
+        provision_in(dir.path(), WORKLOAD_HOME).unwrap();
+        assert_eq!(passwd_of(dir.path()), once);
+    }
+
+    /// A final line with no newline must not swallow the appended entry.
+    #[test]
+    fn terminates_an_unterminated_final_line_before_appending() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("etc")).unwrap();
+        fs::write(
+            dir.path().join("etc/passwd"),
+            "root:x:0:0:root:/root:/bin/sh",
+        )
+        .unwrap();
+
+        provision_in(dir.path(), WORKLOAD_HOME).unwrap();
+
+        let passwd = passwd_of(dir.path());
+        assert!(
+            passwd.starts_with("root:x:0:0:root:/root:/bin/sh\nmvm-worker:"),
+            "{passwd}"
+        );
+    }
+
+    /// Claim 2 is that no guest write can mint a uid-0 entry. This provisioner
+    /// runs as root pre-drop, so the guard that matters is that it only ever
+    /// appends the workload identity and never rewrites a line.
+    #[test]
+    fn never_writes_a_uid_zero_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        provision_in(dir.path(), WORKLOAD_HOME).unwrap();
+        let passwd = passwd_of(dir.path());
+        for line in passwd.lines() {
+            let uid = line.split(':').nth(2).unwrap_or_default();
+            assert_ne!(uid, "0", "provisioner emitted a uid-0 entry: {line}");
+        }
+    }
+
+    #[test]
+    fn a_taken_name_blocks_the_append_even_at_another_id() {
+        let taken = format!("{WORKLOAD_USER}:x:5000:5000:other:/x:/bin/sh\n");
+        assert!(with_entry(&taken, WORKLOAD_USER, WORKLOAD_UID, "ignored").is_none());
+    }
+
+    #[test]
+    fn comments_and_blank_lines_claim_nothing() {
+        let content = "# comment\n\n";
+        assert!(with_entry(content, WORKLOAD_USER, WORKLOAD_UID, "new\n").is_some());
+    }
+}


### PR DESCRIPTION
Three defects that all surface in one `mvmctl machine run --image alpine -it -- /bin/sh` session:

```
/root $ whoami
whoami: unknown uid 901
/root $ Error: guest agent returned error: explicit close not yet supported — disconnect to end session
```

### `whoami: unknown uid 901`

Every workload process runs as uid 901, but that uid is only named in
`/etc/passwd` for images mvm builds itself (`nix/lib/mk-guest.nix`). An OCI
image brings its own passwd file that has never heard of it, and nothing in the
Rust guest path ever provisioned an entry — so every uid-to-name lookup fails:
`whoami` exits nonzero, `id` prints a bare number, `ls -l` shows digits, and
`getpwuid()` hands library code a NULL it often treats as fatal.

`workload_identity` is the `mk-guest.nix` equivalent for images we don't build.
It runs as root after the pivot and before the privilege drop, and only ever
*appends*: if the image already claims the uid, the gid, or the name, it writes
nothing, so an image's own accounts win and no existing line — uid 0 least of
all — is rewritten. A `scratch` image with no databases at all gets them
created.

### `explicit close not yet supported`

This fired on **every** clean logout, not intermittently. The host sends
`ConsoleClose` the instant its relay sees EOF; the guest emits that EOF from
`run_console_relay`'s `shutdown()` *before* it reaps the shell and joins its
relay threads. So the close reliably lands while the session is still tearing
itself down, and the handler refused any session that was still active.

`close_active_session` now waits out the teardown, escalates to `SIGHUP` if the
session is genuinely still running (which is what makes explicit close actually
supported rather than merely tolerated), and errors only if the relay is wedged.

`record_completed_session` also moved to before the active-flag clear — in the
other order a waiter released by that flag reads the *previous* session's exit
code.

### A workload that can't write anywhere

The console `chdir`'d to a hardcoded `/root`, which uid 901 can neither write
nor usually read — `$HOME` was already set correctly, just unused. And `/tmp` /
`/dev/shm` were left root-owned 0755 on images that ship neither, so every
tempfile the workload opens fails with EACCES. Both fixed.

Creating the workload home also moved into the one place both guest inits
share, which gives it to the universal-initramfs activation path that never
created one.

### Deliberately not changed

Writable virtio-fs volumes keep their host ownership
(`guest_mount::writable_block_volume_owner`, pinned by
`read_only_and_virtiofs_volumes_keep_their_existing_owner`). Chowning one
mutates the host's own directory through the share; making those land as the
workload uid needs a host-side uid-mapping answer, not a guest chown.

### Verification

- `cargo nextest run --workspace` — 10940 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --doc` — clean
- `cargo zigbuild --target aarch64-unknown-linux-gnu -p mvm-agentd --lib --bins` — the Linux-gated `guest_bootstrap` / `mvm-oci-init` changes don't compile on macOS at all
- xtask gates: `check-guest-init-parity`, `check-guest-agent-runtime-free`,
  `check-no-spec-refs-in-comments`, `check-honesty`, `check-no-overclaim`,
  `check-single-home`, `check-test-home-isolation`, `check-two-surfaces`,
  `check-guest-binary-lists` — all pass

New coverage: 8 tests for the identity provisioner (alpine-shaped passwd,
scratch image, uid already claimed, idempotency, unterminated final line, no
uid-0 entry) and 4 for the console close (the teardown race itself, the wedged
relay, the idle path, and the record-before-clear ordering).
