### PR TITLE
fix(pool): a failed claim must stop advertising the child it destroyed

### DIFF
--- a/crates/mvm-runtime/src/standby_pool.rs
+++ b/crates/mvm-runtime/src/standby_pool.rs
@@ -200,6 +200,30 @@ impl SupervisorStandbyPool {
         self.record(&h)
     }
 
+    /// Demote a standby that has lost its preloaded child back to saved-only.
+    ///
+    /// A preloaded child is an optimization layered on the parent's checkpoint:
+    /// the record owns a paused VMM *instead of* being saved-only. When a claim
+    /// fails, its cleanup destroys that child — but the parent and its
+    /// checkpoint are still healthy, so the record must go on advertising the
+    /// parent while no longer naming a child that has been killed and whose
+    /// state dir is gone.
+    ///
+    /// Without this the record stayed `Idle` pointing at a destroyed child, so
+    /// every later claim against it failed with `Firecracker socket … does not
+    /// exist — VM is not running`, while `idle_count_compatible` still counted
+    /// it — capacity the pool advertised, could never serve, and which
+    /// `warm_to_target` therefore never replaced. Clearing `pid` restores the
+    /// `is_saved_state` sentinel so the next claim materializes a fresh child
+    /// from the checkpoint instead.
+    pub fn demote_to_saved_state(&self, id: &str) -> Result<()> {
+        let mut h = self.load(id)?;
+        h.preloaded_child_vm_name = None;
+        h.control_socket = String::new();
+        h.pid = 0;
+        self.record(&h)
+    }
+
     /// Remove a standby's dir (after claim/boot, or when reaping a dead one).
     pub fn remove(&self, id: &str) -> Result<()> {
         let dir = self.root.join(id);

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -1112,6 +1112,22 @@ impl Drop for WarmClaimLease<'_> {
                     "stopping preloaded standby child after failed claim"
                 );
             }
+            // The child is gone either way — killed above, or already dead and
+            // about to lose its state dir below. The record has to stop naming
+            // it: left alone it keeps advertising a paused VMM that no longer
+            // exists, so every later claim refuses on a missing control socket
+            // while the pool still counts the parent as usable capacity. The
+            // parent and its checkpoint are healthy, so demote rather than
+            // remove; the next claim materializes a fresh child from it.
+            if let Err(error) = self.pool.demote_to_saved_state(self.parent_id) {
+                tracing::warn!(
+                    parent = %self.parent_id,
+                    child = %vm_name,
+                    %error,
+                    "could not demote standby to saved-state after its preloaded child was \
+                     destroyed; it will refuse every claim until reaped"
+                );
+            }
         }
         if let Some(dir) = &self.child_dir {
             match std::fs::remove_dir_all(dir) {
@@ -4321,6 +4337,94 @@ mod tests {
         );
         // The fork never ran.
         assert!(runner.driver.forked_children().is_empty());
+    }
+
+    /// A failed claim destroys the preloaded child, so the record must stop
+    /// naming it — otherwise the standby stays `Idle` advertising a paused VMM
+    /// that no longer exists, and every later claim refuses on a missing control
+    /// socket while `idle_count_compatible` still counts it as capacity. That
+    /// made a standby single-use against even a retryable failure.
+    ///
+    /// The parent and its checkpoint are healthy, so it demotes to saved-state
+    /// (the `pid == 0` sentinel) rather than being removed: warm capacity
+    /// survives and the next claim materializes a fresh child from the
+    /// checkpoint.
+    #[test]
+    fn a_failed_claim_demotes_a_preloaded_standby_instead_of_stranding_it() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
+        let store_root = tempfile::tempdir().unwrap();
+        let src = tempfile::tempdir().unwrap();
+        // No overlay sidecar → the claim fails the overlay-contract gate, which
+        // is a non-parent-fault failure reached after the child is tracked.
+        let (checkpoints, snapshots, parent_id, parent_meta) =
+            seed_audited_parent(store_root.path(), src.path(), false);
+        let parent_digest = parent_rootfs_digest(&parent_meta).unwrap().to_string();
+
+        let pool = SupervisorStandbyPool::at(store_root.path().join("pool"));
+        let mut handle = idle_parent_handle("warm-parent", &store_root.path().join("control.sock"));
+        // A preloaded standby: the pool owns a paused child VMM instead of being
+        // saved-only, so it carries the child's name and a live pid.
+        let child_name = "preloaded-child".to_string();
+        handle.preloaded_child_vm_name = Some(child_name.clone());
+        handle.pid = std::process::id();
+        pool.record(&handle).unwrap();
+        std::fs::create_dir_all(vm_state_dir(&child_name)).unwrap();
+        let registry_path = store_root.path().join("vm-names.json");
+        let anchor = ClaimTestAnchor::audited(&parent_meta);
+
+        let claim = admitted_child_claim(
+            &src.path().join("rootfs.ext4"),
+            signed_child_plan_json(&parent_digest),
+        );
+        let runner = WorkloadRunner::new(
+            MockDriver::default(),
+            KeyingSpawner::default(),
+            RecordingBrokerRegistrar::new(),
+        );
+        let ctx = ClaimContext {
+            pool: &pool,
+            checkpoints: &checkpoints,
+            snapshots: &snapshots,
+            anchor: &anchor,
+            parent_checkpoint: &parent_id,
+            registry_path: &registry_path,
+            grant_issuer: None,
+        };
+
+        runner
+            .claim_standby(&ctx, &handle, &claim)
+            .expect_err("the overlay-contract gate must refuse this claim");
+
+        let after = pool.load("warm-parent").unwrap();
+        assert_eq!(
+            after.state,
+            StandbyState::Idle,
+            "a non-parent-fault failure must return the parent to claimable"
+        );
+        assert!(
+            after.preloaded_child_vm_name.is_none(),
+            "the record must stop naming a child the cleanup destroyed"
+        );
+        assert!(
+            after.is_saved_state(),
+            "a standby with no preloaded child is saved-only (pid == 0), so the next \
+             claim materializes a fresh child from the checkpoint"
+        );
+        assert!(
+            SupervisorStandbyPool::is_live_or_saved(&after),
+            "the demoted parent must remain usable capacity, not read as dead"
+        );
+        assert!(
+            runner.driver.killed_vms().contains(&child_name),
+            "the destroyed child's VMM must be stopped, not orphaned: killed {:?}",
+            runner.driver.killed_vms()
+        );
     }
 
     /// An un-audited parent (no signed creation entry) is quarantined by removal,

--- a/specs/plans/255-live-fc-warm-claim.md
+++ b/specs/plans/255-live-fc-warm-claim.md
@@ -1059,15 +1059,32 @@ reseeded must not be admitted — but it means no warm claim can complete on
 Firecracker until this is fixed, and therefore no claimed-launch measurement
 against the cold baseline is possible yet.
 
-**BUG-5 — a failed claim strands the standby and orphans its VMM.** Found while
-exercising the above. When a claim fails after the child is materialized, the
-cleanup removes the preloaded child's state directory but does **not** kill its
-`firecracker` process. The pool record stays `Idle` while pointing at a child
-whose socket path no longer exists, so every subsequent claim against that
-standby fails with `resume preloaded child: Firecracker socket
-<dir>/fc.socket does not exist — VM is not running`, and a stray VMM leaks per
-attempt (observed: pid alive, `/root/.mvm/vms/vm-*` gone). A standby is
-therefore single-use even against a retryable failure.
+**BUG-5 — a failed claim stranded the standby. FIXED (#2337).** Found while
+exercising the above, and narrower than first reported: `WarmClaimLease::drop`
+does kill the preloaded child and remove its dir. What it never did was update
+the pool record naming that child — `mark_idle` restored `Idle` and left
+`preloaded_child_vm_name` plus a live-looking `pid` pointing at the VMM it had
+just killed.
+
+That is what made a standby single-use against even a retryable failure. Every
+later claim refused with `resume preloaded child: Firecracker socket
+<dir>/fc.socket does not exist — VM is not running`, while
+`idle_count_compatible` still counted it (`is_live_or_saved` sees a non-zero
+pid) — so the pool advertised capacity it could not serve, and `warm_to_target`
+never replaced it because the count already read at target. Silent, and
+self-perpetuating.
+
+`SupervisorStandbyPool::demote_to_saved_state` now clears the child name, the
+control socket and `pid`, restoring the `pid == 0` saved-state sentinel. The
+parent and its checkpoint are healthy, so the standby survives as a saved-state
+parent and the next claim materializes a fresh child from the checkpoint —
+demote rather than remove, because preloading is an optimization over the
+checkpoint, not the standby's value.
+
+The orphaned `firecracker` originally reported alongside this is a separate,
+milder thing: the kill is best-effort and only `warn!`s, so a kill that fails
+still leaves a VMM behind. That stays best-effort by design (the caller is on
+its way out), but it is no longer silent capacity loss.
 
 **BLOCKER-3 — resolved in code; live delivery remains gated behind #1962.**
 #1959 established the host-signer public key as boot-pinned *host identity*


### PR DESCRIPTION
Closes #2337.

## Narrower than the issue said

I filed #2337 assuming the cleanup removed the child dir without killing the process. Reading the code, `WarmClaimLease::drop` **already** kills the preloaded child *and* removes its dir. That part works.

What it never did was update the pool record that names that child. `mark_idle` restores `Idle` and leaves `preloaded_child_vm_name` plus a live-looking `pid` pointing at the VMM it just killed.

## Why that makes a standby single-use

Every later claim against it refuses:

```
resume preloaded child: Firecracker socket <dir>/fc.socket does not exist — VM is not running
```

…while `idle_count_compatible` still counts it, because `is_live_or_saved` sees a non-zero `pid`. So the pool advertises capacity it cannot serve **and** `warm_to_target` never replaces it — the count already reads at target. Silent and self-perpetuating: one retryable failure permanently burns a warm parent, and the pool reports itself healthy.

Observed live on the KVM host while exercising the warm path after #2335.

## Fix

`SupervisorStandbyPool::demote_to_saved_state` clears `preloaded_child_vm_name`, the control socket and `pid`, restoring the `pid == 0` saved-state sentinel. The lease calls it whenever it destroys a preloaded child.

Demote rather than remove: the parent and its checkpoint are healthy, and a preloaded child is an optimization layered on that checkpoint — `StandbyHandle::preloaded_child_vm_name`'s own docs say the pool owns the child *"instead of a saved-only parent"*. So the standby survives and the next claim materializes a fresh child from the checkpoint, costing a fork instead of a whole boot-and-capture.

The orphaned `firecracker` also reported in #2337 is separate and milder: the kill is best-effort and only `warn!`s, so a failed kill still leaves a VMM. That stays best-effort by design — the caller is already on its way out — but it is no longer *silent capacity loss*.

## Test

`a_failed_claim_demotes_a_preloaded_standby_instead_of_stranding_it` drives a real claim failure against a preloaded standby and asserts the parent returns to `Idle`, the child name is cleared, `is_saved_state()` holds, the record still reads as usable capacity, and the child's VMM was stopped.

Verified it goes red without the fix — stubbing out the demotion fails it on `the record must stop naming a child the cleanup destroyed`.

## Gates

nightly `fmt --all`; `clippy --workspace --all-targets` and again `--features test-support`; the test-support lane per-crate as `ci.yml` runs it (230 / 806 / 211 / 1641 / 446); `nextest --workspace` 10929 passed; doctests; xtask `check-honesty`, `check-no-overclaim`, `check-claim-catalog`, `check-conformance`.