### PR TITLE
Verify audit chains incrementally in doctor, keep the full walk for trust audit verify (#2346)

### DIFF
--- a/crates/mvm-cli/src/doctor/security_checks.rs
+++ b/crates/mvm-cli/src/doctor/security_checks.rs
@@ -34,6 +34,13 @@ pub(crate) struct AuditChainScan {
     /// Set when the sweep could not run at all (no host signer key yet, or the
     /// audit directory is unreadable). Distinct from "found nothing broken".
     pub(crate) not_assessed: Option<String>,
+    /// Chains verified by resuming from a checkpoint rather than from genesis.
+    ///
+    /// Tracked so the check can say what it actually did. A resumed walk takes
+    /// the prefix on a stored value's word instead of re-deriving it from the
+    /// all-zero anchor, so it is not the same statement as a full verification
+    /// and must not be reported as one.
+    pub(crate) resumed: usize,
 }
 
 /// Verification status of the chain-signed audit log.
@@ -88,8 +95,23 @@ fn scan_audit_chains() -> AuditChainScan {
         if !mvm_core::config::is_host_lifecycle_chain(&path) {
             continue;
         }
-        match mvm_hostd::supervisor::verify_audit_chain(&path, &signer.verifying) {
-            Ok(_) => scan.verified += 1,
+        // Routine health check: resume from a checkpoint when one is
+        // available. `mvmctl trust audit verify` deliberately keeps the
+        // genesis-anchored walk — full re-derivation is what that command is
+        // for, and it is claim 8's witness.
+        let checkpoint = mvm_hostd::supervisor::audit_checkpoint::load(&path);
+        match mvm_hostd::supervisor::verify_audit_chain_incremental(
+            &path,
+            &signer.verifying,
+            checkpoint.as_ref(),
+        ) {
+            Ok(outcome) => {
+                scan.verified += 1;
+                if !outcome.walked_from_genesis {
+                    scan.resumed += 1;
+                }
+                mvm_hostd::supervisor::audit_checkpoint::store(&path, &outcome.checkpoint);
+            }
             Err(e) => scan
                 .broken
                 .push((path.display().to_string(), format!("{e:#}"))),
@@ -139,9 +161,17 @@ fn audit_chain_check_from_scan(scan: &AuditChainScan) -> Check {
         name,
         category,
         ok: true,
-        info: match scan.verified {
-            0 => "no host-lifecycle chains yet".to_string(),
-            n => format!("{n} chain(s) verify against the host signer"),
+        info: match (scan.verified, scan.resumed) {
+            (0, _) => "no host-lifecycle chains yet".to_string(),
+            (n, 0) => format!("{n} chain(s) verify against the host signer"),
+            // Naming the resumed chains keeps this from reading as a
+            // full-chain statement. A resumed walk re-derived only the entries
+            // appended since the last run; `mvmctl trust audit verify` is the
+            // genesis-anchored check.
+            (n, r) => format!(
+                "{n} chain(s) verify against the host signer ({r} verified incrementally since \
+                 the last run; `mvmctl trust audit verify` re-checks from the first entry)"
+            ),
         },
     }
 }
@@ -783,6 +813,41 @@ mod tests {
     /// informational line. It used to surface only as an unrelated verb
     /// refusing a record, which reads as a problem with that record.
     #[test]
+    fn a_fully_walked_scan_does_not_mention_incremental_verification() {
+        let scan = AuditChainScan {
+            verified: 3,
+            broken: vec![],
+            not_assessed: None,
+            resumed: 0,
+        };
+        let info = audit_chain_check_from_scan(&scan).info;
+        assert!(info.contains("3 chain(s) verify"), "{info}");
+        assert!(
+            !info.contains("incrementally"),
+            "a genesis-anchored sweep should not qualify itself: {info}"
+        );
+    }
+
+    #[test]
+    fn a_resumed_scan_says_so_rather_than_claiming_a_full_walk() {
+        // The check must not report a resumed walk as a full-chain guarantee:
+        // the prefix was taken on a stored checkpoint's word, not re-derived
+        // from the genesis anchor.
+        let scan = AuditChainScan {
+            verified: 3,
+            broken: vec![],
+            not_assessed: None,
+            resumed: 2,
+        };
+        let info = audit_chain_check_from_scan(&scan).info;
+        assert!(info.contains("2 verified incrementally"), "{info}");
+        assert!(
+            info.contains("trust audit verify"),
+            "it must point at the genesis-anchored check: {info}"
+        );
+    }
+
+    #[test]
     fn a_broken_chain_fails_the_check_and_names_the_file() {
         let scan = AuditChainScan {
             verified: 2,
@@ -791,6 +856,7 @@ mod tests {
                 "prev_hash mismatch at line 3".into(),
             )],
             not_assessed: None,
+            resumed: 0,
         };
         let c = audit_chain_check_from_scan(&scan);
         assert!(!c.ok, "a broken chain is a posture failure: {}", c.info);
@@ -812,6 +878,7 @@ mod tests {
             verified: 0,
             broken: vec![("local.jsonl".into(), "bad signature".into())],
             not_assessed: None,
+            resumed: 0,
         };
         let info = audit_chain_check_from_scan(&scan).info;
         assert!(info.contains("Quarantine"), "{info}");
@@ -871,6 +938,7 @@ mod tests {
             verified: 0,
             broken: vec![("local.jsonl".into(), "bad signature".into())],
             not_assessed: Some("partial sweep".into()),
+            resumed: 0,
         };
         assert!(!audit_chain_check_from_scan(&scan).ok);
     }

--- a/crates/mvm-hostd/src/supervisor/audit_checkpoint.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_checkpoint.rs
@@ -71,18 +71,19 @@ pub fn store(chain_path: &Path, checkpoint: &ChainCheckpoint) {
 mod tests {
     use super::*;
 
-    /// Point `MVM_HOME` at a scratch dir so the cache never touches a real one.
+    /// Point the mvm world at a scratch dir so the cache never touches a real
+    /// one.
+    ///
+    /// Goes through `TestEnv` rather than mutating the environment directly:
+    /// env mutation is process-wide, and these tests share a binary with
+    /// hundreds of others running in parallel. `TestEnv` serializes on the
+    /// shared lock and restores prior values on drop, which is the difference
+    /// between a test that is isolated and one that merely passes locally.
     fn with_scratch_home<T>(body: impl FnOnce(&Path) -> T) -> T {
         let dir = tempfile::tempdir().expect("tempdir");
-        // SAFETY: single-threaded test body; the guard restores the prior value.
-        let prior = std::env::var_os("MVM_HOME");
-        unsafe { std::env::set_var("MVM_HOME", dir.path()) };
-        let out = body(dir.path());
-        match prior {
-            Some(v) => unsafe { std::env::set_var("MVM_HOME", v) },
-            None => unsafe { std::env::remove_var("MVM_HOME") },
-        }
-        out
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.isolate_mvm_home(dir.path());
+        body(dir.path())
     }
 
     fn checkpoint(lines: usize) -> ChainCheckpoint {
@@ -123,9 +124,13 @@ mod tests {
 
     #[test]
     fn same_basename_under_different_roots_gets_different_files() {
-        let a = checkpoint_path(Path::new("/a/audit/local.jsonl"));
-        let b = checkpoint_path(Path::new("/b/audit/local.jsonl"));
-        assert_ne!(a, b, "path must key the checkpoint, not just the basename");
+        // Reads the cache dir, so it holds the env guard too rather than
+        // racing a concurrent test that is moving MVM_HOME.
+        with_scratch_home(|_| {
+            let a = checkpoint_path(Path::new("/a/audit/local.jsonl"));
+            let b = checkpoint_path(Path::new("/b/audit/local.jsonl"));
+            assert_ne!(a, b, "path must key the checkpoint, not just the basename");
+        });
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/audit_checkpoint.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_checkpoint.rs
@@ -1,0 +1,164 @@
+//! Persistence for audit-chain verification checkpoints.
+//!
+//! A checkpoint is a cache, never an authority: every read and write here is
+//! best-effort, and losing one costs a full re-verification rather than
+//! producing a wrong answer. It lives under the mvm cache dir rather than
+//! beside the audit log so that a checkpoint is never mistaken for part of the
+//! chain, and so wiping the cache restores genesis-anchored verification.
+
+use std::path::{Path, PathBuf};
+
+use super::audit_file::ChainCheckpoint;
+
+/// Directory holding one checkpoint per verified chain.
+fn checkpoint_dir() -> PathBuf {
+    Path::new(&mvm_core::config::mvm_cache_dir()).join("audit-verify")
+}
+
+/// Cache filename for `chain_path`.
+///
+/// Keyed on the full path, not just the file name: two chains with the same
+/// basename under different roots (a test `MVM_HOME`, a second audit dir) must
+/// not share a checkpoint, or one would resume onto the other's history.
+fn checkpoint_name(chain_path: &Path) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(chain_path.as_os_str().as_encoded_bytes());
+    let digest: [u8; 32] = hasher.finalize().into();
+    let stem = chain_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("chain");
+    // The readable stem is for a human looking in the cache dir; the digest is
+    // what actually distinguishes entries.
+    format!("{stem}-{}.json", hex::encode(&digest[..8]))
+}
+
+/// Path of the checkpoint file for `chain_path`.
+pub fn checkpoint_path(chain_path: &Path) -> PathBuf {
+    checkpoint_dir().join(checkpoint_name(chain_path))
+}
+
+/// Load the stored checkpoint for `chain_path`, if any is readable.
+///
+/// A missing, unreadable, or unparseable checkpoint is `None` — the caller
+/// falls back to a full walk, which is always correct.
+pub fn load(chain_path: &Path) -> Option<ChainCheckpoint> {
+    let raw = std::fs::read_to_string(checkpoint_path(chain_path)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Store `checkpoint` for `chain_path`. Best-effort; a failure to persist only
+/// costs the next run a full walk.
+pub fn store(chain_path: &Path, checkpoint: &ChainCheckpoint) {
+    let path = checkpoint_path(chain_path);
+    let Some(parent) = path.parent() else { return };
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let Ok(encoded) = serde_json::to_string(checkpoint) else {
+        return;
+    };
+    // Write via a temp file and rename so a concurrent reader never sees a
+    // half-written checkpoint and resumes onto a truncated hash.
+    let tmp = path.with_extension("json.tmp");
+    if std::fs::write(&tmp, encoded).is_ok() {
+        let _ = std::fs::rename(&tmp, &path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Point `MVM_HOME` at a scratch dir so the cache never touches a real one.
+    fn with_scratch_home<T>(body: impl FnOnce(&Path) -> T) -> T {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // SAFETY: single-threaded test body; the guard restores the prior value.
+        let prior = std::env::var_os("MVM_HOME");
+        unsafe { std::env::set_var("MVM_HOME", dir.path()) };
+        let out = body(dir.path());
+        match prior {
+            Some(v) => unsafe { std::env::set_var("MVM_HOME", v) },
+            None => unsafe { std::env::remove_var("MVM_HOME") },
+        }
+        out
+    }
+
+    fn checkpoint(lines: usize) -> ChainCheckpoint {
+        ChainCheckpoint {
+            verified_lines: lines,
+            chain_hash: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string(),
+        }
+    }
+
+    #[test]
+    fn absent_checkpoint_reads_as_none() {
+        with_scratch_home(|_| {
+            assert!(load(Path::new("/a/audit/local.jsonl")).is_none());
+        });
+    }
+
+    #[test]
+    fn a_stored_checkpoint_round_trips() {
+        with_scratch_home(|_| {
+            let chain = Path::new("/a/audit/local.jsonl");
+            let cp = checkpoint(42);
+            store(chain, &cp);
+            assert_eq!(load(chain), Some(cp));
+        });
+    }
+
+    #[test]
+    fn distinct_chains_do_not_share_a_checkpoint() {
+        with_scratch_home(|_| {
+            let a = Path::new("/a/audit/local.jsonl");
+            let b = Path::new("/b/audit/local.jsonl");
+            store(a, &checkpoint(1));
+            store(b, &checkpoint(2));
+            assert_eq!(load(a).unwrap().verified_lines, 1);
+            assert_eq!(load(b).unwrap().verified_lines, 2);
+        });
+    }
+
+    #[test]
+    fn same_basename_under_different_roots_gets_different_files() {
+        let a = checkpoint_path(Path::new("/a/audit/local.jsonl"));
+        let b = checkpoint_path(Path::new("/b/audit/local.jsonl"));
+        assert_ne!(a, b, "path must key the checkpoint, not just the basename");
+    }
+
+    #[test]
+    fn a_corrupt_checkpoint_reads_as_none_rather_than_erroring() {
+        with_scratch_home(|_| {
+            let chain = Path::new("/a/audit/local.jsonl");
+            store(chain, &checkpoint(3));
+            std::fs::write(checkpoint_path(chain), "{ not json").expect("clobber");
+            assert!(
+                load(chain).is_none(),
+                "a corrupt cache entry must degrade to a full walk"
+            );
+        });
+    }
+
+    #[test]
+    fn storing_twice_overwrites_rather_than_appending() {
+        with_scratch_home(|_| {
+            let chain = Path::new("/a/audit/local.jsonl");
+            store(chain, &checkpoint(1));
+            store(chain, &checkpoint(9));
+            assert_eq!(load(chain).unwrap().verified_lines, 9);
+        });
+    }
+
+    #[test]
+    fn the_checkpoint_lives_outside_the_audit_directory() {
+        // A checkpoint beside the chain could be mistaken for part of it, and
+        // `is_host_lifecycle_chain` would have to learn to skip it.
+        with_scratch_home(|home| {
+            let path = checkpoint_path(Path::new("/a/audit/local.jsonl"));
+            assert!(path.starts_with(home), "{path:?} should be under MVM_HOME");
+            assert!(!path.to_string_lossy().contains("/audit/local.jsonl"));
+        });
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/audit_file.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_file.rs
@@ -12,6 +12,26 @@
 //! seed (`prev_hash` for the first entry) is `[0u8; 32]`. The signer
 //! restores its in-memory cursor from the last line on disk so that
 //! a process restart resumes the chain without gaps.
+//!
+//! # Two verifiers, on purpose
+//!
+//! [`verify_audit_chain`] walks from the genesis seed every time. That zero
+//! prefix is an anchor, not a formality: it is what makes a *removed* prefix
+//! detectable, because a truncated file's new first line claims a non-zero
+//! predecessor and fails at line 0.
+//!
+//! [`verify_audit_chain_incremental`] can resume from a [`ChainCheckpoint`],
+//! verifying only what was appended since. It is sound in the sense that
+//! matters — the resumed line's signature covers its `prev_hash`, so the state
+//! the prefix ended in is authenticated and cannot be forged without the host
+//! key. What it gives up is the anchor: whoever can write the checkpoint can
+//! drop history and have the remainder verify clean, since every surviving
+//! line really is signed. Cost is O(entries since the checkpoint) instead of
+//! O(all history), on a log that never shrinks.
+//!
+//! So the fast path is confined to the routine `mvmctl doctor` health check,
+//! which reports that it resumed. `mvmctl trust audit verify` — the on-demand
+//! integrity check — always walks from genesis.
 
 use std::collections::{HashMap, HashSet};
 use std::fs::OpenOptions;
@@ -451,68 +471,213 @@ pub fn verify_audit_chain_entries(
     verifying_key: &VerifyingKey,
 ) -> Result<Vec<AuditEntry>, VerifyError> {
     let content = std::fs::read_to_string(path).map_err(|e| VerifyError::Io(e.to_string()))?;
+    let walk = walk_chain(&content, verifying_key, ChainStart::Genesis)?;
+    Ok(walk.entries)
+}
+
+/// Where a chain walk begins.
+enum ChainStart {
+    /// Line 0, with the all-zero chain hash. The zero prefix is the anchor
+    /// that makes a removed prefix detectable: a truncated file's new first
+    /// line claims a non-zero predecessor and fails immediately.
+    Genesis,
+    /// Line `line`, with `chain_hash` as the running hash. Sound only because
+    /// the resumed line's signature covers its `prev_hash`, so a valid
+    /// signature there authenticates the state the prefix ended in.
+    Resume { line: usize, chain_hash: [u8; 32] },
+}
+
+/// What a completed walk established.
+struct ChainWalk {
+    entries: Vec<AuditEntry>,
+    /// Total lines consumed, including any skipped prefix.
+    lines: usize,
+    /// Running chain hash after the last line.
+    chain_hash: [u8; 32],
+}
+
+/// Verify every line from `start` to the end of `content`.
+fn walk_chain(
+    content: &str,
+    verifying_key: &VerifyingKey,
+    start: ChainStart,
+) -> Result<ChainWalk, VerifyError> {
     // A record is only complete once its terminator is on disk. `str::lines`
     // does not distinguish "last line" from "last line so far", so check the
     // final byte before walking: without this, a half-written record is
     // reported as malformed JSON or a bad signature, and a crash becomes
     // indistinguishable from someone having edited the log.
     let truncated_tail = !content.is_empty() && !content.ends_with('\n');
-    let mut prev_hash = [0u8; 32];
+    let (skip_to, mut prev_hash) = match start {
+        ChainStart::Genesis => (0, [0u8; 32]),
+        ChainStart::Resume { line, chain_hash } => (line, chain_hash),
+    };
     let mut entries = Vec::new();
-    let last_idx = content.lines().count().saturating_sub(1);
+    let total = content.lines().count();
+    let last_idx = total.saturating_sub(1);
     for (idx, line) in content.lines().enumerate() {
-        if line.is_empty() {
+        if idx < skip_to || line.is_empty() {
             continue;
         }
         if truncated_tail && idx == last_idx {
             return Err(VerifyError::TruncatedTail { line: idx });
         }
-        let envelope: SignedEnvelope =
-            serde_json::from_str(line).map_err(|e| VerifyError::Malformed {
-                line: idx,
-                reason: e.to_string(),
-            })?;
-        let claimed_prev =
-            URL_SAFE_NO_PAD
-                .decode(&envelope.prev_hash)
-                .map_err(|e| VerifyError::Malformed {
-                    line: idx,
-                    reason: format!("prev_hash b64: {e}"),
-                })?;
-        if claimed_prev.as_slice() != prev_hash.as_slice() {
-            return Err(VerifyError::PrevHashMismatch { line: idx });
-        }
-        let sig_bytes =
-            URL_SAFE_NO_PAD
-                .decode(&envelope.signature)
-                .map_err(|e| VerifyError::Malformed {
-                    line: idx,
-                    reason: format!("signature b64: {e}"),
-                })?;
-        let sig_arr: [u8; 64] =
-            sig_bytes
-                .as_slice()
-                .try_into()
-                .map_err(|_| VerifyError::Malformed {
-                    line: idx,
-                    reason: "signature must be 64 bytes".to_string(),
-                })?;
-        let signature = Signature::from_bytes(&sig_arr);
-        let mut to_verify = signed_bytes_for(&envelope, idx)?;
-        to_verify.extend_from_slice(&prev_hash);
-        verifying_key
-            .verify(&to_verify, &signature)
-            .map_err(|_| VerifyError::SignatureInvalid { line: idx })?;
-        prev_hash = hash_line(line.as_bytes());
-        entries.push(envelope.entry);
+        prev_hash = verify_line(line, idx, &prev_hash, verifying_key, &mut entries)?;
     }
-    Ok(entries)
+    Ok(ChainWalk {
+        entries,
+        lines: total,
+        chain_hash: prev_hash,
+    })
+}
+
+/// Verify one line against the running chain hash, push its entry, and return
+/// the advanced chain hash.
+fn verify_line(
+    line: &str,
+    idx: usize,
+    prev_hash: &[u8; 32],
+    verifying_key: &VerifyingKey,
+    entries: &mut Vec<AuditEntry>,
+) -> Result<[u8; 32], VerifyError> {
+    let envelope: SignedEnvelope =
+        serde_json::from_str(line).map_err(|e| VerifyError::Malformed {
+            line: idx,
+            reason: e.to_string(),
+        })?;
+    let claimed_prev =
+        URL_SAFE_NO_PAD
+            .decode(&envelope.prev_hash)
+            .map_err(|e| VerifyError::Malformed {
+                line: idx,
+                reason: format!("prev_hash b64: {e}"),
+            })?;
+    if claimed_prev.as_slice() != prev_hash.as_slice() {
+        return Err(VerifyError::PrevHashMismatch { line: idx });
+    }
+    let sig_bytes =
+        URL_SAFE_NO_PAD
+            .decode(&envelope.signature)
+            .map_err(|e| VerifyError::Malformed {
+                line: idx,
+                reason: format!("signature b64: {e}"),
+            })?;
+    let sig_arr: [u8; 64] =
+        sig_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| VerifyError::Malformed {
+                line: idx,
+                reason: "signature must be 64 bytes".to_string(),
+            })?;
+    let signature = Signature::from_bytes(&sig_arr);
+    let mut to_verify = signed_bytes_for(&envelope, idx)?;
+    to_verify.extend_from_slice(prev_hash);
+    verifying_key
+        .verify(&to_verify, &signature)
+        .map_err(|_| VerifyError::SignatureInvalid { line: idx })?;
+    entries.push(envelope.entry);
+    Ok(hash_line(line.as_bytes()))
 }
 
 fn hash_line(bytes: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
     hasher.finalize().into()
+}
+
+/// How far a chain has already been verified, so a later run can resume.
+///
+/// Persisted between runs. Resuming trades the genesis anchor for this stored
+/// value: whoever can write it can have a prefix-truncated chain accepted,
+/// because every surviving line is still genuinely signed. That is why only
+/// the routine health check resumes, and `mvmctl trust audit verify` — claim
+/// 8's witness — always walks from genesis.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainCheckpoint {
+    /// Lines already verified; the next walk resumes at this index.
+    pub verified_lines: usize,
+    /// Running chain hash after `verified_lines`, base64url unpadded.
+    pub chain_hash: String,
+}
+
+impl ChainCheckpoint {
+    fn new(verified_lines: usize, chain_hash: [u8; 32]) -> Self {
+        Self {
+            verified_lines,
+            chain_hash: URL_SAFE_NO_PAD.encode(chain_hash),
+        }
+    }
+
+    /// Decode the stored hash, or `None` when it is not 32 base64url bytes.
+    /// An undecodable checkpoint is treated as absent rather than as an error:
+    /// it is a cache, and the fallback is a full walk.
+    fn hash_bytes(&self) -> Option<[u8; 32]> {
+        let raw = URL_SAFE_NO_PAD.decode(&self.chain_hash).ok()?;
+        raw.as_slice().try_into().ok()
+    }
+}
+
+/// What an incremental verification established.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IncrementalVerification {
+    /// Checkpoint to persist for the next run.
+    pub checkpoint: ChainCheckpoint,
+    /// Entries verified on this pass.
+    pub verified_now: usize,
+    /// Whether the whole chain was walked from genesis. False means the
+    /// prefix was taken on the checkpoint's word, which callers must not
+    /// report as a full-chain guarantee.
+    pub walked_from_genesis: bool,
+}
+
+/// Verify a chain, resuming from `checkpoint` when one is supplied.
+///
+/// A checkpoint that does not fit the file — too long, undecodable, or failing
+/// to verify at the resume point — is **discarded, not reported as tampering**.
+/// A mismatch is equally consistent with log rotation, a replaced file, or a
+/// stale checkpoint, and only a full walk can tell those apart; falling back
+/// keeps the fast path from ever manufacturing a false alarm, and leaves every
+/// refusal backed by a genesis-anchored verification.
+pub fn verify_audit_chain_incremental(
+    path: &Path,
+    verifying_key: &VerifyingKey,
+    checkpoint: Option<&ChainCheckpoint>,
+) -> Result<IncrementalVerification, VerifyError> {
+    let content = std::fs::read_to_string(path).map_err(|e| VerifyError::Io(e.to_string()))?;
+    let total = content.lines().count();
+
+    if let Some(resume) = usable_resume(checkpoint, total)
+        && let Ok(walk) = walk_chain(&content, verifying_key, resume)
+    {
+        return Ok(IncrementalVerification {
+            checkpoint: ChainCheckpoint::new(walk.lines, walk.chain_hash),
+            verified_now: walk.entries.len(),
+            walked_from_genesis: false,
+        });
+    }
+
+    let walk = walk_chain(&content, verifying_key, ChainStart::Genesis)?;
+    Ok(IncrementalVerification {
+        checkpoint: ChainCheckpoint::new(walk.lines, walk.chain_hash),
+        verified_now: walk.entries.len(),
+        walked_from_genesis: true,
+    })
+}
+
+/// A resume point, when the checkpoint is decodable and within the file.
+///
+/// A checkpoint at or beyond the line count means the file shrank (rotation,
+/// truncation, replacement) and there is nothing to resume onto.
+fn usable_resume(checkpoint: Option<&ChainCheckpoint>, total_lines: usize) -> Option<ChainStart> {
+    let checkpoint = checkpoint?;
+    if checkpoint.verified_lines == 0 || checkpoint.verified_lines >= total_lines {
+        return None;
+    }
+    Some(ChainStart::Resume {
+        line: checkpoint.verified_lines,
+        chain_hash: checkpoint.hash_bytes()?,
+    })
 }
 
 #[cfg(test)]

--- a/crates/mvm-hostd/src/supervisor/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/mod.rs
@@ -29,6 +29,7 @@
 
 pub mod artifact;
 pub mod audit;
+pub mod audit_checkpoint;
 pub mod audit_dedup;
 pub mod audit_file;
 pub mod audit_recorder;
@@ -132,7 +133,8 @@ pub use artifact::{
 pub use audit::{AuditEntry, AuditError, AuditSigner, CapturingAuditSigner, NoopAuditSigner};
 pub use audit_dedup::{Decision, DedupKey, RetryStormSummary, RetryStormSuppressor};
 pub use audit_file::{
-    FileAuditSigner, SignedEnvelope, VerifyError, verify_audit_chain, verify_audit_chain_entries,
+    ChainCheckpoint, FileAuditSigner, IncrementalVerification, SignedEnvelope, VerifyError,
+    verify_audit_chain, verify_audit_chain_entries, verify_audit_chain_incremental,
 };
 pub use audit_recorder::{
     EventCategory, Recorder, RecorderError, UNBOUND_IMAGE_NAME, UNBOUND_IMAGE_SHA256,

--- a/crates/mvm-hostd/tests/audit_verify_cost.rs
+++ b/crates/mvm-hostd/tests/audit_verify_cost.rs
@@ -57,6 +57,7 @@ fn entry(seq: usize) -> AuditEntry {
 }
 
 #[tokio::test]
+#[cfg_attr(debug_assertions, ignore = "release-build performance measurement")]
 async fn full_chain_verification_cost_per_entry() {
     let dir = tempfile::tempdir().expect("tempdir");
     let key = signing_key();

--- a/crates/mvm-hostd/tests/audit_verify_cost.rs
+++ b/crates/mvm-hostd/tests/audit_verify_cost.rs
@@ -1,0 +1,95 @@
+//! Measures what full audit-chain verification costs per entry.
+//!
+//! `verify_audit_chain_entries` re-derives the whole chain from genesis on
+//! every call, and the log is append-only with no rotation, so the cost of the
+//! `doctor` health check grows with total audit history. Whether that is worth
+//! optimizing is a question about a release-build number, so the number is
+//! measured here rather than extrapolated from a debug run:
+//!
+//! ```text
+//! cargo test --release -p mvm-hostd --test audit_verify_cost -- --nocapture
+//! ```
+//!
+//! The assertion is a loose ceiling to catch a pathological regression, not a
+//! performance pin — the measurement is the point, and it is printed.
+
+use std::collections::BTreeMap;
+use std::time::Instant;
+
+use chrono::Utc;
+use ed25519_dalek::SigningKey;
+use mvm_core::plan::{PlanId, TenantId};
+use mvm_hostd::supervisor::{AuditEntry, AuditSigner, FileAuditSigner, verify_audit_chain_entries};
+
+/// Chain length to measure. Chosen to match the ~3.3k entries a few months of
+/// ordinary use produced on a real host, so the per-entry figure is taken at a
+/// realistic size rather than extrapolated from a toy chain.
+const ENTRIES: usize = 3_289;
+
+/// Ceiling per entry. Generous: a loaded CI box is slow, and this exists to
+/// catch a deadlock or quadratic behaviour, not to pin a number.
+const MAX_NS_PER_ENTRY: u128 = 5_000_000;
+
+fn signing_key() -> SigningKey {
+    SigningKey::from_bytes(&[7u8; 32])
+}
+
+/// An entry shaped like a real one: the labels and identifiers are what the
+/// launch path actually emits, so the JSON parsed per line is representative
+/// in size.
+fn entry(seq: usize) -> AuditEntry {
+    let mut labels = BTreeMap::new();
+    labels.insert("backend".to_string(), "hvf".to_string());
+    labels.insert("vm".to_string(), format!("machine-{seq}"));
+    AuditEntry {
+        timestamp: Utc::now(),
+        tenant: TenantId("local".to_string()),
+        plan_id: PlanId(format!("plan-{seq}")),
+        plan_version: 1,
+        bundle_id: None,
+        bundle_version: None,
+        image_name: "docker.io/library/alpine:latest".to_string(),
+        image_sha256: "e7a1a92a5bfe6a2fdbcbbbd0e0e0b4d7b6a5c4d3e2f1a0b9c8d7e6f5a4b3c2d1"
+            .to_string(),
+        event: "plan.admitted".to_string(),
+        labels,
+    }
+}
+
+#[tokio::test]
+async fn full_chain_verification_cost_per_entry() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let key = signing_key();
+    let verifying = key.verifying_key();
+
+    let signer = FileAuditSigner::open(key, dir.path()).expect("signer");
+    for seq in 0..ENTRIES {
+        signer.sign_and_emit(&entry(seq)).await.expect("emit");
+    }
+    drop(signer);
+
+    let path = dir.path().join("local.jsonl");
+    let bytes = std::fs::metadata(&path).expect("stat").len();
+
+    // Verify once untimed so the page cache is warm; the question is compute
+    // cost, not first-read I/O.
+    let warm = verify_audit_chain_entries(&path, &verifying).expect("warm verify");
+    assert_eq!(warm.len(), ENTRIES, "chain should verify end to end");
+
+    let start = Instant::now();
+    let entries = verify_audit_chain_entries(&path, &verifying).expect("verify");
+    let elapsed = start.elapsed();
+
+    assert_eq!(entries.len(), ENTRIES);
+    let per_entry = elapsed.as_nanos() / ENTRIES as u128;
+    println!(
+        "audit chain verify: {ENTRIES} entries, {} KiB, total {:?}, {per_entry} ns/entry",
+        bytes / 1024,
+        elapsed,
+    );
+
+    assert!(
+        per_entry < MAX_NS_PER_ENTRY,
+        "{per_entry} ns/entry exceeds the ceiling"
+    );
+}

--- a/crates/mvm-hostd/tests/audit_verify_incremental.rs
+++ b/crates/mvm-hostd/tests/audit_verify_incremental.rs
@@ -1,0 +1,263 @@
+//! Behaviour of incremental audit-chain verification.
+//!
+//! Resuming from a checkpoint trades the genesis anchor — the requirement that
+//! line 0 claim an all-zero predecessor — for a stored value. These tests pin
+//! both halves of that bargain: the speedup it buys, and the properties it
+//! must not give up.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use chrono::Utc;
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use mvm_core::plan::{PlanId, TenantId};
+use mvm_hostd::supervisor::{
+    AuditEntry, AuditSigner, ChainCheckpoint, FileAuditSigner, VerifyError,
+    verify_audit_chain_entries, verify_audit_chain_incremental,
+};
+
+fn signing_key() -> SigningKey {
+    SigningKey::from_bytes(&[11u8; 32])
+}
+
+fn entry(seq: usize) -> AuditEntry {
+    AuditEntry {
+        timestamp: Utc::now(),
+        tenant: TenantId("local".to_string()),
+        plan_id: PlanId(format!("plan-{seq}")),
+        plan_version: 1,
+        bundle_id: None,
+        bundle_version: None,
+        image_name: "img".to_string(),
+        image_sha256: "abc123".to_string(),
+        event: "plan.admitted".to_string(),
+        labels: BTreeMap::new(),
+    }
+}
+
+/// Write an `n`-entry chain and return its path plus the verifying key.
+async fn chain(dir: &Path, n: usize) -> (std::path::PathBuf, VerifyingKey) {
+    let key = signing_key();
+    let verifying = key.verifying_key();
+    let signer = FileAuditSigner::open(key, dir).expect("signer");
+    for seq in 0..n {
+        signer.sign_and_emit(&entry(seq)).await.expect("emit");
+    }
+    drop(signer);
+    (dir.join("local.jsonl"), verifying)
+}
+
+/// Append `n` more entries to an existing chain.
+async fn append(dir: &Path, from: usize, n: usize) {
+    let signer = FileAuditSigner::open(signing_key(), dir).expect("signer");
+    for seq in from..from + n {
+        signer.sign_and_emit(&entry(seq)).await.expect("emit");
+    }
+}
+
+#[tokio::test]
+async fn without_a_checkpoint_it_walks_from_genesis() {
+    let dir = tempfile::tempdir().unwrap();
+    let (path, key) = chain(dir.path(), 5).await;
+
+    let out = verify_audit_chain_incremental(&path, &key, None).expect("verify");
+    assert!(out.walked_from_genesis);
+    assert_eq!(out.verified_now, 5);
+    assert_eq!(out.checkpoint.verified_lines, 5);
+}
+
+#[tokio::test]
+async fn a_checkpoint_verifies_only_the_new_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let (path, key) = chain(dir.path(), 5).await;
+    let first = verify_audit_chain_incremental(&path, &key, None).expect("first");
+
+    append(dir.path(), 5, 3).await;
+    let second =
+        verify_audit_chain_incremental(&path, &key, Some(&first.checkpoint)).expect("second");
+
+    assert!(!second.walked_from_genesis, "should have resumed");
+    assert_eq!(second.verified_now, 3, "only the appended entries");
+    assert_eq!(second.checkpoint.verified_lines, 8);
+}
+
+#[tokio::test]
+async fn a_current_checkpoint_on_an_unchanged_file_verifies_nothing_new() {
+    let dir = tempfile::tempdir().unwrap();
+    let (path, key) = chain(dir.path(), 4).await;
+    let first = verify_audit_chain_incremental(&path, &key, None).expect("first");
+
+    // verified_lines == total, so there is no resume point and it re-walks.
+    // Correct but not free; the value of the checkpoint is in the append case.
+    let second =
+        verify_audit_chain_incremental(&path, &key, Some(&first.checkpoint)).expect("second");
+    assert_eq!(second.checkpoint.verified_lines, 4);
+}
+
+#[tokio::test]
+async fn tampering_after_the_checkpoint_is_still_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let (path, key) = chain(dir.path(), 4).await;
+    let first = verify_audit_chain_incremental(&path, &key, None).expect("first");
+    append(dir.path(), 4, 2).await;
+
+    // Corrupt the last entry's signature.
+    let content = std::fs::read_to_string(&path).unwrap();
+    let mut lines: Vec<String> = content.lines().map(str::to_string).collect();
+    let last = lines.last_mut().unwrap();
+    *last = last.replace("\"signature\":\"", "\"signature\":\"AA");
+    std::fs::write(&path, format!("{}\n", lines.join("\n"))).unwrap();
+
+    let err = verify_audit_chain_incremental(&path, &key, Some(&first.checkpoint))
+        .expect_err("tampered tail must be refused");
+    assert!(
+        matches!(
+            err,
+            VerifyError::SignatureInvalid { .. } | VerifyError::Malformed { .. }
+        ),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn a_checkpoint_past_the_end_of_the_file_falls_back_to_genesis() {
+    let dir = tempfile::tempdir().unwrap();
+    let (path, key) = chain(dir.path(), 3).await;
+
+    let bogus = ChainCheckpoint {
+        verified_lines: 99,
+        chain_hash: "AAAA".to_string(),
+    };
+    let out = verify_audit_chain_incremental(&path, &key, Some(&bogus)).expect("verify");
+    assert!(out.walked_from_genesis, "a short file cannot be resumed");
+    assert_eq!(out.verified_now, 3);
+}
+
+#[tokio::test]
+async fn an_undecodable_checkpoint_falls_back_rather_than_erroring() {
+    let dir = tempfile::tempdir().unwrap();
+    let (path, key) = chain(dir.path(), 3).await;
+
+    let bogus = ChainCheckpoint {
+        verified_lines: 1,
+        chain_hash: "!!! not base64 !!!".to_string(),
+    };
+    let out = verify_audit_chain_incremental(&path, &key, Some(&bogus)).expect("verify");
+    assert!(out.walked_from_genesis);
+    assert_eq!(out.verified_now, 3);
+}
+
+#[tokio::test]
+async fn a_checkpoint_with_the_wrong_hash_falls_back_and_still_passes() {
+    // A stale checkpoint is not evidence of tampering — it is equally
+    // consistent with rotation or a replaced file. It must never produce a
+    // "broken chain" verdict on a chain that is in fact intact.
+    let dir = tempfile::tempdir().unwrap();
+    let (path, key) = chain(dir.path(), 5).await;
+
+    let wrong = ChainCheckpoint {
+        verified_lines: 2,
+        chain_hash: base64_of([9u8; 32]),
+    };
+    let out = verify_audit_chain_incremental(&path, &key, Some(&wrong)).expect("intact chain");
+    assert!(out.walked_from_genesis, "must fall back to a full walk");
+    assert_eq!(out.verified_now, 5);
+}
+
+#[tokio::test]
+async fn a_truncated_prefix_is_refused_by_the_full_verifier() {
+    // The property the genesis anchor buys, and the reason `trust audit
+    // verify` keeps using the full walk: removing history is detectable.
+    let dir = tempfile::tempdir().unwrap();
+    let (path, key) = chain(dir.path(), 6).await;
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    let kept: Vec<&str> = content.lines().skip(2).collect();
+    std::fs::write(&path, format!("{}\n", kept.join("\n"))).unwrap();
+
+    let err = verify_audit_chain_entries(&path, &key).expect_err("prefix removal must be caught");
+    assert!(
+        matches!(err, VerifyError::PrevHashMismatch { line: 0 }),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn a_zero_line_checkpoint_never_suppresses_the_genesis_anchor() {
+    // `verified_lines == 0` carries no information and is rejected outright,
+    // so the cheapest forgery — "resume at the start with a hash of my
+    // choosing" — cannot skip the anchor.
+    let dir = tempfile::tempdir().unwrap();
+    let (path, key) = chain(dir.path(), 6).await;
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    let kept: Vec<&str> = content.lines().skip(2).collect();
+    std::fs::write(&path, format!("{}\n", kept.join("\n"))).unwrap();
+
+    let forged = ChainCheckpoint {
+        verified_lines: 0,
+        chain_hash: base64_of([3u8; 32]),
+    };
+    let err = verify_audit_chain_incremental(&path, &key, Some(&forged))
+        .expect_err("a zero-line checkpoint must fall back to the genesis anchor");
+    assert!(
+        matches!(err, VerifyError::PrevHashMismatch { line: 0 }),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn a_forged_checkpoint_hides_a_truncated_prefix() {
+    // The documented cost of resuming, pinned so it cannot be forgotten and
+    // cannot regress into something worse without a test turning red.
+    //
+    // An adversary who can write the checkpoint drops the first k entries and
+    // records `(1, hash(new line 0))` — a hash they can compute from the file
+    // they just wrote. The resumed walk starts at line 1, whose `prev_hash` is
+    // genuinely that value, and every surviving line is genuinely signed, so
+    // it has nothing to object to. The removed history is gone silently.
+    //
+    // This is exactly why the incremental path is confined to the routine
+    // health check, why its result must not be reported as a full-chain
+    // guarantee, and why `mvmctl trust audit verify` still walks from genesis.
+    let dir = tempfile::tempdir().unwrap();
+    let (path, key) = chain(dir.path(), 6).await;
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    let kept: Vec<&str> = content.lines().skip(2).collect();
+    std::fs::write(&path, format!("{}\n", kept.join("\n"))).unwrap();
+
+    // The hash the adversary records: line 0 of the file they just wrote.
+    let truncated = std::fs::read_to_string(&path).unwrap();
+    let after_new_line_0 = {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(truncated.lines().next().unwrap().as_bytes());
+        let out: [u8; 32] = h.finalize().into();
+        out
+    };
+
+    let forged = ChainCheckpoint {
+        verified_lines: 1,
+        chain_hash: base64_of(after_new_line_0),
+    };
+    let out = verify_audit_chain_incremental(&path, &key, Some(&forged))
+        .expect("the truncation is invisible to a resumed walk — this is the cost");
+    assert!(
+        !out.walked_from_genesis,
+        "the forged checkpoint was accepted, which is the point of this test"
+    );
+
+    // And the property that makes it survivable: the full walk still catches it.
+    let err = verify_audit_chain_entries(&path, &key)
+        .expect_err("the genesis-anchored walk must still refuse the truncation");
+    assert!(
+        matches!(err, VerifyError::PrevHashMismatch { line: 0 }),
+        "unexpected error: {err}"
+    );
+}
+
+fn base64_of(bytes: [u8; 32]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}


### PR DESCRIPTION
Closes #2346.

## Why

Span profiling (#2341) found `verify_audit_chain_entries` taking **92.8% of `mvmctl doctor`'s measured time**. The chain is re-derived from genesis on every call, and the log is append-only with **no rotation anywhere in the tree** (`checkpoint.forked` is an audit event type, not log rotation), so the cost is O(entire audit history) and grows forever.

## Measured before designing anything

The first figure came from a debug binary, which would have been a poor basis for a design:

| profile | entries | size | total | per entry |
| --- | --- | --- | --- | --- |
| debug | 3,289 | 2,830 KiB | 2.246 s | 683 us |
| **release** | 3,289 | 2,830 KiB | **380 ms** | **115.5 us** |

380 ms today, linear from there: ~1.2 s at 10k entries. An earlier extrapolation put release at ~180 ms — **wrong by 2x in the optimistic direction**, which is exactly why the measurement gated the work. `crates/mvm-hostd/tests/audit_verify_cost.rs` keeps it reproducible.

## What changed

`verify_audit_chain_incremental` resumes from a `ChainCheckpoint` of `(verified_lines, chain_hash)`, verifying only what was appended. This is sound in the sense that matters: **the resumed line's signature covers its `prev_hash`**, so the state the prefix ended in is authenticated and cannot be forged without the host key.

## The security consideration, stated plainly

What resuming gives up is the **genesis anchor**. The all-zero seed is what makes a *removed* prefix detectable — a truncated file's new first line claims a non-zero predecessor and fails at line 0. Resuming replaces that with a stored value, so whoever can write the checkpoint can drop history and have the remainder verify clean, because every surviving line really is signed.

`a_forged_checkpoint_hides_a_truncated_prefix` **demonstrates that attack succeeding** rather than describing it in a comment, then asserts the full walk still catches the same file. Writing that test corrected an error in my own reasoning: the first version used `verified_lines: 0`, which is rejected outright, so it "passed" while proving nothing. The real attack needs `verified_lines >= 1`.

Second, non-adversarial cost: entries below the checkpoint are never re-read, so silent corruption there stops being detected.

ADR-001 already places a malicious host out of scope, so the truncation capability arguably grants an in-scope attacker nothing new — but that argument does not cover the corruption-detection loss.

## Claim 8 is unchanged

Rather than weaken the claim, the callers split:

- **`mvmctl trust audit verify` still walks from genesis.** It is claim 8's named witness and an explicit on-demand integrity check; ~700 ms there is fine.
- **Only `doctor`'s routine health check resumes**, and it says so: `"N chain(s) verify against the host signer (R verified incrementally since the last run; mvmctl trust audit verify re-checks from the first entry)"`.

That wording matches the existing care in that check, which is already careful that an un-assessable chain is "not known to be broken, which is not the same as clean". No ADR amendment needed.

## Fail-safe behaviour

A checkpoint that does not fit — too long, undecodable, or failing at the resume point — is **discarded, never reported as tampering**, and the walk falls back to genesis. A mismatch is equally consistent with rotation, a replaced file, or a stale cache, and only a full walk can tell those apart. The fast path can never manufacture a false alarm, and every refusal stays genesis-backed.

The checkpoint lives under the mvm cache dir rather than beside the log (so it cannot be mistaken for part of the chain, and wiping the cache restores full verification), keyed on the chain's full path so two chains sharing a basename cannot resume onto each other's history, and written temp-and-rename so a reader never sees a half-written hash. Every read and write is best-effort: losing one costs a re-verification, never a wrong answer.

## Rejected alternative

`ed25519_dalek::verify_batch` is ~3x faster with an identical guarantee, but its `batch` feature pulls in `keccak` + `strobe-rs`, taking `check-closure-budget` from 242 to 244. It also speeds the work up rather than avoiding it, while the log still grows without bound.

## Testing

`cargo +nightly fmt --all --check` (exit 0), `cargo clippy --workspace --all-targets -- -D warnings` (exit 0), `cargo nextest run --workspace` — **10,992 passed, 0 failed**.

19 new tests: 10 covering incremental verification (resume, append-only reverification, tampering after the checkpoint still refused, checkpoint past EOF, undecodable checkpoint, wrong hash falling back and still passing, truncated prefix refused by the full walk, the forged-checkpoint cost, zero-line checkpoints never suppressing the anchor), 7 for the checkpoint store, and 2 pinning doctor's wording so a resumed walk cannot be reported as a full-chain guarantee.