### PR TITLE
fix(kernel): two boot paths routed around the verified kernel seam

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -127,6 +127,9 @@ jobs:
       - name: No positional audit::emit / event-chain calls
         run: cargo run -p xtask -- check-audit-positional
 
+      - name: Workload-kernel reads go through the verified seam
+        run: cargo run -p xtask -- check-verified-kernel-reads
+
       - name: No host-nix invocation (builds route through the builder VM)
         run: cargo run -p xtask -- check-no-host-nix
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Broad-egress constructor stays builder-only
         run: cargo run -p xtask -- check-build-egress-callers
 
+      - name: Workload-kernel reads go through the verified seam
+        run: cargo run -p xtask -- check-verified-kernel-reads
+
       - name: No host-nix invocation (builds route through the builder VM)
         run: cargo run -p xtask -- check-no-host-nix
 

--- a/crates/mvm-cli/src/commands/vm/up/kernel.rs
+++ b/crates/mvm-cli/src/commands/vm/up/kernel.rs
@@ -5,12 +5,17 @@
 /// Kernel-less images (mkGuest ships no kernel) boot fine on libkrun,
 /// which materializes its own bundled kernel and ignores this path. The
 /// out-of-process backends (hvf and firecracker) need a real kernel file;
-/// fall back to the cached builder-VM kernel — the same kernel the builder
+/// fall back to the cached workload kernel — the same kernel the builder
 /// and dev VMs boot — rather than handing them a missing path.
 ///
 /// Firecracker's direct/manifest boot path already performs this same
 /// fallback; without it here the flake path would refuse a kernel-less
 /// mkGuest workload that the manifest path boots fine.
+///
+/// The fallback goes through `resolve_kernel`, so it is a verified cache hit
+/// rather than a filename that happens to exist. This path used to format the
+/// cache location itself and accept it on `exists()`, which meant a workload
+/// whose image shipped no kernel got the weakest check of any boot route.
 pub(in crate::commands::vm) fn resolve_workload_kernel(
     vmlinux_path: &str,
     hypervisor: &str,
@@ -23,22 +28,19 @@ pub(in crate::commands::vm) fn resolve_workload_kernel(
     if !matches!(hypervisor, "hvf" | "firecracker") {
         return Ok(vmlinux_path.to_string());
     }
-    let arch = if cfg!(target_arch = "aarch64") {
-        "aarch64"
-    } else {
-        "x86_64"
-    };
-    let fallback = format!(
-        "{}/builder-vm/{arch}/kernels/workload/vmlinux",
-        mvm_core::config::mvm_cache_dir()
-    );
-    if std::path::Path::new(&fallback).exists() {
-        return Ok(fallback);
+    let cache_dir = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir());
+    let arch = mvm_core::arch::GuestArch::host().to_string();
+    let fallback = mvm_build::kernel_fetch::cached_kernel_path(&cache_dir, &arch, "workload");
+    if let mvm_build::kernel_fetch::KernelResolution::Cached(verified) =
+        mvm_build::kernel_fetch::resolve_kernel(&cache_dir, &arch, "workload", false)
+    {
+        return Ok(verified.path().display().to_string());
     }
     anyhow::bail!(
         "image has no kernel ({vmlinux_path} missing) and the {hypervisor} backend \
-         needs one; the builder-VM kernel fallback at {fallback} is also absent — \
-         run `mvmctl kernel build --which workload` once to populate it"
+         needs one; no verified workload kernel is cached at {} — \
+         run `mvmctl kernel build --which workload` once to populate it",
+        fallback.display()
     )
 }
 
@@ -154,56 +156,82 @@ mod resolve_workload_kernel_tests {
         assert_eq!(result, "/nonexistent/vmlinux");
     }
 
+    /// Stage a workload kernel in the cache under `MVM_HOME`, optionally
+    /// recording the digest sidecar a verified read requires.
+    fn stage_cached_workload_kernel(
+        home: &std::path::Path,
+        bytes: &[u8],
+        pin: bool,
+    ) -> std::path::PathBuf {
+        let arch = mvm_core::arch::GuestArch::host().to_string();
+        let kernel =
+            mvm_build::kernel_fetch::cached_kernel_path(&home.join("cache"), &arch, "workload");
+        std::fs::create_dir_all(kernel.parent().unwrap()).unwrap();
+        std::fs::write(&kernel, bytes).unwrap();
+        if pin {
+            mvm_build::kernel_fetch::record_kernel_digest(&kernel).unwrap();
+        }
+        kernel
+    }
+
     #[test]
-    fn hvf_missing_kernel_falls_back_to_builder_vm_cache() {
+    fn hvf_missing_kernel_falls_back_to_cached_workload_kernel() {
         let mut env = TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        let arch = if cfg!(target_arch = "aarch64") {
-            "aarch64"
-        } else {
-            "x86_64"
-        };
-        let fallback_dir = tmp
-            .path()
-            .join("cache")
-            .join("builder-vm")
-            .join(arch)
-            .join("kernels")
-            .join("workload");
-        std::fs::create_dir_all(&fallback_dir).unwrap();
-        let fallback = fallback_dir.join("vmlinux");
-        std::fs::write(&fallback, b"builder-kernel").unwrap();
         env.set("MVM_HOME", tmp.path());
+        let fallback = stage_cached_workload_kernel(tmp.path(), b"builder-kernel", true);
         let result = resolve_workload_kernel("/nonexistent/vmlinux", "hvf").unwrap();
         assert_eq!(result, fallback.to_str().unwrap());
     }
 
     #[test]
-    fn firecracker_missing_kernel_falls_back_to_builder_vm_cache() {
-        // The firecracker flake path must reuse the cached builder-VM
-        // kernel for a kernel-less mkGuest workload, exactly as the
-        // firecracker manifest path does — otherwise a `sleeper`-style
-        // image (no emitted vmlinux) can't boot under firecracker.
+    fn firecracker_missing_kernel_falls_back_to_cached_workload_kernel() {
+        // The firecracker flake path must reuse the cached workload kernel
+        // for a kernel-less mkGuest workload, exactly as the firecracker
+        // manifest path does — otherwise a `sleeper`-style image (no emitted
+        // vmlinux) can't boot under firecracker.
         let mut env = TestEnv::new();
         let tmp = tempfile::tempdir().unwrap();
-        let arch = if cfg!(target_arch = "aarch64") {
-            "aarch64"
-        } else {
-            "x86_64"
-        };
-        let fallback_dir = tmp
-            .path()
-            .join("cache")
-            .join("builder-vm")
-            .join(arch)
-            .join("kernels")
-            .join("workload");
-        std::fs::create_dir_all(&fallback_dir).unwrap();
-        let fallback = fallback_dir.join("vmlinux");
-        std::fs::write(&fallback, b"builder-kernel").unwrap();
         env.set("MVM_HOME", tmp.path());
+        let fallback = stage_cached_workload_kernel(tmp.path(), b"builder-kernel", true);
         let result = resolve_workload_kernel("/nonexistent/vmlinux", "firecracker").unwrap();
         assert_eq!(result, fallback.to_str().unwrap());
+    }
+
+    #[test]
+    fn an_unpinned_fallback_kernel_is_refused() {
+        // The behaviour this replaces: the kernel-less-image route formatted
+        // the cache path itself and booted whatever sat there. Both tests
+        // above passed without a digest before this change.
+        let mut env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let kernel = stage_cached_workload_kernel(tmp.path(), b"builder-kernel", false);
+        let err = resolve_workload_kernel("/nonexistent/vmlinux", "firecracker").unwrap_err();
+        assert!(
+            err.to_string().contains("no verified workload kernel"),
+            "expected the verification refusal, got: {err}"
+        );
+        assert!(
+            !kernel.exists(),
+            "an unpinned kernel is evicted, not left to be re-adopted"
+        );
+    }
+
+    #[test]
+    fn a_tampered_fallback_kernel_is_refused() {
+        let mut env = TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.set("MVM_HOME", tmp.path());
+        let kernel = stage_cached_workload_kernel(tmp.path(), b"the real kernel", true);
+        // Same length, so a size check would not notice.
+        std::fs::write(&kernel, b"the fake kernel").unwrap();
+        let err = resolve_workload_kernel("/nonexistent/vmlinux", "firecracker").unwrap_err();
+        assert!(
+            err.to_string().contains("no verified workload kernel"),
+            "expected the verification refusal, got: {err}"
+        );
+        assert!(!kernel.exists(), "rejected kernel removed");
     }
 
     #[test]

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -188,9 +188,14 @@ pub(crate) struct BootParams {
 }
 
 impl LocalBackend {
-    /// Resolve the per-backend workload kernel: HVF boots an explicit
-    /// verified arm64 kernel from the CLI-populated cache; every other
-    /// backend carries its own.
+    /// Resolve the per-backend workload kernel: every explicit-kernel backend
+    /// boots a verified kernel from the CLI-populated cache; bundled-kernel
+    /// backends carry their own.
+    ///
+    /// One arm serves all of them. Firecracker and the qemu dev tier used to
+    /// take a separate branch that accepted the cache path on `is_file()`, so
+    /// the backend that carries real workloads on Linux booted whatever sat at
+    /// the expected filename while HVF next door required a digest match.
     pub(crate) fn resolve_workload_kernel(backend: &AnyBackend) -> Result<Option<PathBuf>> {
         use mvm_core::protocol::vm_backend::BackendKind;
         let cache = PathBuf::from(mvm_core::config::mvm_cache_dir());
@@ -199,38 +204,23 @@ impl LocalBackend {
             // Bundled-kernel backends: libkrun boots the libkrunfw kernel and
             // the hermetic mock boots nothing — no host kernel path needed.
             BackendKind::Mock | BackendKind::Libkrun => Ok(None),
-            BackendKind::Hvf => {
-                match mvm_build::kernel_fetch::resolve_kernel(&cache, &arch, "workload", false) {
-                    mvm_build::kernel_fetch::KernelResolution::Cached(verified) => {
-                        Ok(Some(verified.path().to_path_buf()))
-                    }
-                    _ => Err(crate::local::backend_err(format!(
-                        "hvf needs a verified workload kernel at {} — run a `mvmctl machine run` \
-                         once (or `mvmctl build kernel build`) to populate the cache",
-                        mvm_build::kernel_fetch::cached_kernel_path(&cache, &arch, "workload")
-                            .display()
-                    ))),
+            // Cache-hit-or-error; populating the cache is a CLI concern. A hit
+            // means the bytes matched their recorded digest, and an entry that
+            // fails to verify is evicted by the resolve — so the hint below is
+            // the right next step for a rejected kernel as much as a missing
+            // one.
+            _ => match mvm_build::kernel_fetch::resolve_kernel(&cache, &arch, "workload", false) {
+                mvm_build::kernel_fetch::KernelResolution::Cached(verified) => {
+                    Ok(Some(verified.path().to_path_buf()))
                 }
-            }
-            // Firecracker (and every other explicit-kernel backend, e.g. the
-            // qemu dev tier) hard-refuses a bundled-kernel spec, so resolve the
-            // same cached workload kernel the CLI's machine-run boot path
-            // supplies: `<cache>/builder-vm/<arch>/kernels/workload/vmlinux`
-            // by presence (the driver derives its own FC-loadable sibling from
-            // it). Cache-hit-or-error; populating the cache is a CLI concern.
-            _ => {
-                let path = mvm_build::kernel_fetch::cached_kernel_path(&cache, &arch, "workload");
-                if path.is_file() {
-                    Ok(Some(path))
-                } else {
-                    Err(crate::local::backend_err(format!(
-                        "{} needs the cached workload kernel at {} — create it once with \
-                         `mvmctl kernel build --which workload`, then retry",
-                        backend.name(),
-                        path.display()
-                    )))
-                }
-            }
+                _ => Err(crate::local::backend_err(format!(
+                    "{} needs a verified workload kernel at {} — create it once with \
+                     `mvmctl kernel build --which workload`, then retry",
+                    backend.name(),
+                    mvm_build::kernel_fetch::cached_kernel_path(&cache, &arch, "workload")
+                        .display()
+                ))),
+            },
         }
     }
 

--- a/crates/mvm-client/src/launch/tests.rs
+++ b/crates/mvm-client/src/launch/tests.rs
@@ -738,10 +738,33 @@ fn firecracker_admitted_boot_receives_a_concrete_kernel_path() {
     std::fs::create_dir_all(cached.parent().unwrap()).unwrap();
     std::fs::write(&cached, b"kernel-bytes").unwrap();
 
+    // Bytes with no recorded digest are not a cache hit. This assertion is the
+    // point of the arm: Firecracker used to accept the path on `is_file()`, so
+    // this staging — identical to the two lines above — booted.
+    let err = LocalBackend::resolve_workload_kernel(&fc)
+        .expect_err("an unpinned kernel must not resolve");
+    assert!(
+        err.to_string().contains("verified workload kernel"),
+        "got: {err}"
+    );
+
+    std::fs::write(&cached, b"kernel-bytes").unwrap();
+    mvm_build::kernel_fetch::record_kernel_digest(&cached).unwrap();
     let resolved = LocalBackend::resolve_workload_kernel(&fc)
         .expect("cached kernel resolves")
         .expect("firecracker must receive a concrete kernel path");
     assert_eq!(resolved, cached);
+
+    // Identity discrepancy: a complete, readable kernel that is the wrong one.
+    // Same length, so a size check would not notice either.
+    std::fs::write(&cached, b"kernel-forged").unwrap();
+    let err = LocalBackend::resolve_workload_kernel(&fc)
+        .expect_err("a kernel that no longer matches its digest must not resolve");
+    assert!(
+        err.to_string().contains("verified workload kernel"),
+        "got: {err}"
+    );
+    assert!(!cached.exists(), "the rejected entry is evicted");
 
     // Bundled-kernel backends need no host kernel path: libkrun boots the
     // libkrunfw kernel, the hermetic mock boots nothing.

--- a/crates/mvm-client/tests/launch_lifecycle_live.rs
+++ b/crates/mvm-client/tests/launch_lifecycle_live.rs
@@ -33,6 +33,10 @@ fn live_env() -> Option<(String, String)> {
 /// (`<cache>/builder-vm/<arch>/kernels/workload/vmlinux`) when the cache is
 /// cold. An already-populated cache is left untouched — the operator's own
 /// verified kernel wins.
+///
+/// The digest sidecar is recorded the way any other producer records it: the
+/// launch path serves a cached kernel only when its bytes match a recorded
+/// digest, so a seeded-but-unpinned kernel is refused rather than booted.
 fn seed_workload_kernel_cache(kernel: &str) {
     let cache = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir());
     let arch = mvm_core::arch::GuestArch::host().to_string();
@@ -43,6 +47,8 @@ fn seed_workload_kernel_cache(kernel: &str) {
     std::fs::create_dir_all(dest.parent().expect("kernel cache dir has a parent"))
         .expect("create workload kernel cache dir");
     std::fs::copy(kernel, &dest).expect("seed MVM_E2E_KERNEL into the workload kernel cache");
+    mvm_build::kernel_fetch::record_kernel_digest(&dest)
+        .expect("record the seeded workload kernel's digest");
 }
 
 #[tokio::test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-10
+Last updated: 2026-08-11
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -915,11 +915,16 @@ for detailed scope and acceptance criteria.
           miss, and eviction of **both** the record and the build directory —
           a record-only eviction would leave the poisoned tree under a name a
           later build re-adopts. Unblocks plan 279 WS1
-    - [ ] Workload/builder kernel cache: still path-trusting.
-          `verify_fetched_kernel` exists with **no production caller** —
-          neither the fetch nor the read path checks a kernel against its pin.
-          Scoped as plan 288
-          (`specs/plans/288-kernel-cache-verify-on-read.md`)
+    - [~] Workload/builder kernel cache: plan 288
+          (`specs/plans/288-kernel-cache-verify-on-read.md`). WS1–WS3 + WS5
+          landed — the fetch path verifies against the published checksum
+          manifest and records a digest sidecar, the read path verifies against
+          it and evicts the whole entry on failure, and
+          `check-verified-kernel-reads` keeps new callers on the seam. WS1's
+          `VerifiedKernel` initially reached only the arms that used it: the
+          Firecracker/qemu arm and the CLI's kernel-less-image fallback still
+          booted on presence until 2026-08-11. WS4 (shared sidecar helper with
+          the BLAKE3 artifact path) is the remainder
     - [ ] Cold-tier background scrub (recon §7.9)
   - [~] WS7 — σ/κ separation: `mvm_core::at_rest` gives the protocol digest
         over plaintext and the storage address over bytes at rest as disjoint

--- a/specs/VERIFICATION.md
+++ b/specs/VERIFICATION.md
@@ -23,6 +23,8 @@ row below records a defect that was planted to prove the gate fires.
 | --- | --- | --- |
 | `check-build-egress-callers` | Add a `NetworkPolicy::trusted_build_egress()` call to `workload_runner/runner.rs` — the shape of a future workload path reaching the unrestricted-egress constructor and turning off claim 10's default-deny | yes — named the file and line, refused |
 | `check-build-egress-callers` (vacuity) | Point the gate at a tree with no allow-listed call site, i.e. the state it would reach if the constructor were renamed and the gate silently stopped checking anything | yes — refused rather than passing empty |
+| `check-verified-kernel-reads` | Add a boot path that takes `cached_kernel_path` and accepts it on `is_file()` — the shape of the Firecracker arm and the kernel-less-image fallback that both booted an unverified kernel | yes — named the file and line, refused |
+| `check-verified-kernel-reads` (vacuity) | Point the gate at a tree where no file pairs the location helper with `resolve_kernel`, i.e. the state it would reach if either were renamed | yes — refused rather than passing empty |
 | `check-conformance` (R1) | Edit `CONFORMANCE.md` so it disagrees with `model/claims.toml` | yes |
 | `check-honesty` (R2) | Add "MVM-SEC-07 proves cargo deps are audited" to `README.md` | yes |
 | `meta` (R3) | Register `MVM-SEC-99` with no scenario, or remove a scenario's ID tag | yes |

--- a/specs/plans/288-kernel-cache-verify-on-read.md
+++ b/specs/plans/288-kernel-cache-verify-on-read.md
@@ -2,7 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Status:** WS1–WS3 landed; WS4 (shared sidecar helper) and WS5 (CI caller gate) open. The 2026-08-10 bootstrap-readiness repair closed the remaining producer interruption gaps and routed the default workload-kernel acquisition through the verified resolver. Completes plan 276 WS6 — its dev-build-artifact half shipped in #2053; this is the kernel half.
+**Status:** WS1–WS3 and WS5 landed; WS4 (shared sidecar helper) open. The 2026-08-10 bootstrap-readiness repair closed the remaining producer interruption gaps and routed the default workload-kernel acquisition through the verified resolver. Completes plan 276 WS6 — its dev-build-artifact half shipped in #2053; this is the kernel half.
+
+**2026-08-11 — WS1's type did not reach two of its callers.** `VerifiedKernel` made the unverified read unrepresentable only for code that resolved through the seam. `cached_kernel_path` stayed public (callers need the location for error messages), and two paths took it and booted on presence: the Firecracker/qemu arm of `mvm_client`'s per-backend resolution, and the CLI's kernel-less-image fallback, which formatted the cache path itself. So the backend carrying real workloads on Linux had the weakest kernel check of any boot route, next to an HVF arm that required a digest match — after this plan's WS1 shipped. Both now resolve through the seam, and WS5's gate is aimed at that shape rather than the one it was originally written for.
 
 **Goal:** No workload or builder kernel is booted from cache without its bytes being checked against a recorded digest. The check must fail closed, evict what it rejects, and be impossible for a future caller to skip by accident.
 
@@ -92,10 +94,10 @@ Plan 276 WS6, second half. Recon §7.1 (`specs/research/uor-hologram-cross-proje
 
 ### WS5 — Keep it connected
 
-- [ ] Tests: verified-hit boots; tampered kernel rejected + evicted; missing sidecar rejected; **intact-but-wrong kernel** (swap two variants' kernels — both complete, each the other's) rejected; sidecar/artifact mismatch after an interrupted write rejected.
-- [ ] `specs/VERIFICATION.md` falsifiability rows, each with its planted defect recorded and proved red.
-- [ ] An `xtask` gate asserting `verify_fetched_kernel` has at least one production caller — the failure mode this plan exists to fix was a correct function with no callers, and nothing in CI noticed for the life of the function. Wire it into **both** `ci.yml` and `ci-full.yml` Lint jobs.
-- [ ] Confirm `MVM_SKIP_HASH_VERIFY` is absent from every workflow.
+- [x] Tests: verified-hit boots; tampered kernel rejected + evicted; missing sidecar rejected; **intact-but-wrong kernel** (swap two variants' kernels — both complete, each the other's) rejected; sidecar/artifact mismatch after an interrupted write rejected.
+- [x] `specs/VERIFICATION.md` falsifiability rows, each with its planted defect recorded and proved red.
+- [x] An `xtask` gate — `check-verified-kernel-reads`, wired into **both** `ci.yml` and `ci-full.yml` Lint jobs. **It does not police what this line asked for**, because that target stopped being the right one: WS3 routed the read path through `verify_cached_kernel` against the sidecar, so `verify_fetched_kernel` legitimately has no production caller and a gate demanding one would fail on correct code. The live risk is the other direction — `cached_kernel_path` is public, returns a usable `PathBuf`, and two call sites took it and booted on `is_file()` *after* WS1 shipped the type that was supposed to prevent exactly that. The gate gives that its evidence: a file naming the cache location must also call `resolve_kernel`. Co-presence per file, not a proof the resolved value is the one used — a type that made the bare path unusable would be stronger, but the location is legitimately needed for diagnostics at the same sites that must not boot from it.
+- [x] Confirm `MVM_SKIP_HASH_VERIFY` is absent from every workflow (`rg MVM_SKIP_HASH_VERIFY .github/` — no hits).
 
 ## Sequencing
 

--- a/xtask/src/check_verified_kernel_reads.rs
+++ b/xtask/src/check_verified_kernel_reads.rs
@@ -1,0 +1,189 @@
+//! `xtask check-verified-kernel-reads`
+//!
+//! A workload kernel is served from the cache only when its bytes match a
+//! recorded digest. `resolve_kernel` is where that check happens, and
+//! `VerifiedKernel` exists so a cache hit cannot be spelled as a bare path.
+//!
+//! The type did its job for the arm that used it and nothing for the arms that
+//! did not. `cached_kernel_path` is public — it has to be, callers need the
+//! location for an error message — and it returns a perfectly usable
+//! `PathBuf`. So two call sites took it and booted whatever sat there: the
+//! Firecracker arm of the client's per-backend resolution, and the CLI's
+//! kernel-less-image fallback, which formatted the path itself. Both looked
+//! right, both were the weakest check of any boot route, and both passed every
+//! test in the tree.
+//!
+//! This gate says: a file that asks for the cache location must also resolve
+//! through the verified seam. It is co-presence within a file, not a proof that
+//! the resolved value is the one used — a file could still resolve in one
+//! function and use a bare path in another. A type that made the path
+//! unusable would be stronger, but `cached_kernel_path` is legitimately needed
+//! for diagnostics at exactly the sites that must not boot from it, so the
+//! honest cheap control is to make a bare use visible in review rather than
+//! impossible.
+
+use anyhow::{Result, bail};
+use std::path::Path;
+
+/// Asking where the cached kernel lives.
+const LOCATION: &str = "cached_kernel_path";
+
+/// Checking that what lives there is what should.
+const VERIFIED_SEAM: &str = "resolve_kernel";
+
+/// The module that defines both, plus the digest helpers. Not a "caller".
+const DEFINING_FILE: &str = "crates/mvm-build/src/kernel_fetch.rs";
+
+/// Files that may name the location without resolving through the seam.
+///
+/// A test lane that *stages* a kernel is the legitimate case: it writes the
+/// bytes and records the digest, which is a producer, not a reader. Adding a
+/// production launch path here re-opens the hole this gate closes.
+const ALLOWED_UNVERIFIED: &[&str] = &[
+    // Live E2E lane: seeds MVM_E2E_KERNEL into the cache and records its
+    // digest, then boots through the normal verified read.
+    "crates/mvm-client/tests/launch_lifecycle_live.rs",
+    // Stages pinned, unpinned and tampered kernels to assert which of them
+    // `resolve_workload_kernel` will serve. It names the location because
+    // that is the fixture it writes.
+    "crates/mvm-client/src/launch/tests.rs",
+];
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let mut offenders: Vec<String> = Vec::new();
+    let mut verified_sites = 0usize;
+
+    let mut files: Vec<(String, String)> = Vec::new();
+    crate::fs_walk::for_each_file(&workspace.join("crates"), Some("rs"), &mut |path, text| {
+        if text.contains(LOCATION) {
+            let rel = path
+                .strip_prefix(workspace)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            files.push((rel, text.to_string()));
+        }
+    })?;
+
+    for (rel, text) in files {
+        if rel == DEFINING_FILE || ALLOWED_UNVERIFIED.contains(&rel.as_str()) {
+            continue;
+        }
+        if text.contains(VERIFIED_SEAM) {
+            verified_sites += 1;
+            continue;
+        }
+        for (i, line) in text.lines().enumerate() {
+            if line.contains(LOCATION) {
+                offenders.push(format!("{rel}:{}: {}", i + 1, line.trim()));
+            }
+        }
+    }
+
+    if !offenders.is_empty() {
+        for o in &offenders {
+            eprintln!("[error] {o}");
+        }
+        bail!(
+            "check-verified-kernel-reads: {} site(s) take the workload-kernel cache path without \
+             calling `{VERIFIED_SEAM}`. A path that exists is not a kernel that verified — that \
+             is how an intact kernel from the wrong build boots, which reads as a mysterious \
+             guest failure rather than a cache fault. Resolve through the seam and use \
+             `VerifiedKernel::path`, or add the file to ALLOWED_UNVERIFIED if it stages a kernel \
+             rather than reading one.",
+            offenders.len()
+        );
+    }
+
+    // A gate that polices a symbol nobody calls passes for the wrong reason.
+    if verified_sites == 0 {
+        bail!(
+            "check-verified-kernel-reads: no file outside {DEFINING_FILE} pairs `{LOCATION}` with \
+             `{VERIFIED_SEAM}`. Either they were renamed — update this gate — or every read moved \
+             behind another seam, in which case re-point it there."
+        );
+    }
+
+    eprintln!(
+        "check-verified-kernel-reads: clean ({verified_sites} site(s) resolve through the \
+         verified seam)"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace_with(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        for (rel, body) in files {
+            let p = tmp.path().join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(p, body).unwrap();
+        }
+        tmp
+    }
+
+    /// A reader that does it correctly, so the vacuity check is satisfied.
+    fn verified_reader() -> (&'static str, &'static str) {
+        (
+            "crates/mvm-client/src/launch/mod.rs",
+            "fn k() { resolve_kernel(&c, &a, \"workload\", false); cached_kernel_path(&c, &a, \
+             \"workload\"); }",
+        )
+    }
+
+    #[test]
+    fn a_reader_that_resolves_through_the_seam_passes() {
+        let tmp = workspace_with(&[verified_reader()]);
+        assert!(run(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn a_bare_path_read_is_refused() {
+        let tmp = workspace_with(&[
+            verified_reader(),
+            (
+                "crates/mvm-runtime/src/workload_runner/boot.rs",
+                "fn boot() { let p = cached_kernel_path(&c, &a, \"workload\"); if p.is_file() {} }",
+            ),
+        ]);
+        let err = run(tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("without calling"), "{err}");
+    }
+
+    #[test]
+    fn a_staging_lane_on_the_allow_list_passes() {
+        let tmp = workspace_with(&[
+            verified_reader(),
+            (
+                "crates/mvm-client/tests/launch_lifecycle_live.rs",
+                "fn seed() { let d = cached_kernel_path(&c, &a, \"workload\"); }",
+            ),
+        ]);
+        assert!(run(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn the_defining_file_is_not_treated_as_a_caller() {
+        let tmp = workspace_with(&[
+            verified_reader(),
+            (
+                "crates/mvm-build/src/kernel_fetch.rs",
+                "pub fn cached_kernel_path() {}",
+            ),
+        ]);
+        assert!(run(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn a_workspace_with_no_verified_reader_is_refused_as_vacuous() {
+        let tmp = workspace_with(&[(
+            "crates/mvm-build/src/kernel_fetch.rs",
+            "pub fn cached_kernel_path() {}",
+        )]);
+        let err = run(tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("no file outside"), "{err}");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -58,6 +58,7 @@ mod check_test_home_isolation;
 mod check_trust_gradient;
 mod check_two_surfaces;
 mod check_uniform_vsock_egress;
+mod check_verified_kernel_reads;
 mod check_vsock_only_egress;
 mod check_witness_citations;
 mod check_workflow_paths;
@@ -102,6 +103,10 @@ fn main() -> Result<()> {
         Some("check-build-egress-callers") => {
             let workspace = workspace_root();
             check_build_egress_callers::run(&workspace)
+        }
+        Some("check-verified-kernel-reads") => {
+            let workspace = workspace_root();
+            check_verified_kernel_reads::run(&workspace)
         }
         Some("check-no-host-nix") => {
             let workspace = workspace_root();
@@ -335,7 +340,7 @@ fn main() -> Result<()> {
             ir_parity::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-dormant-controls, check-witness-citations, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-conformance, check-trust-gradient, check-vsock-only-egress, check-no-gateway-names, check-uniform-vsock-egress, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-backend-resource-controls, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-dormant-controls, check-witness-citations, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-conformance, check-trust-gradient, check-vsock-only-egress, check-no-gateway-names, check-uniform-vsock-egress, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-backend-resource-controls, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {


### PR DESCRIPTION
## What

`VerifiedKernel` (plan 288 WS1) exists so a cached workload kernel cannot be served without its bytes matching a recorded digest, and so a caller that skips the check does not compile. It protected the arms that resolved through the seam and nothing else.

`cached_kernel_path` is public — callers need the location for an error message — and it returns a usable `PathBuf`. Two call sites took it and booted on presence:

- **`crates/mvm-client/src/launch/mod.rs`** — the Firecracker/qemu arm of per-backend resolution accepted the path on `is_file()`, while the HVF arm immediately above it required a digest match. The backend that carries real workloads on Linux had the weakest kernel check of any boot route.
- **`crates/mvm-cli/src/commands/vm/up/kernel.rs`** — the kernel-less-image fallback formatted the cache path itself and accepted it on `exists()`.

Both now resolve through `resolve_kernel`. The client's per-backend match collapses to a single arm: bundled-kernel backends (`Mock`, `Libkrun`) get `None`, everything else gets a verified hit or an error naming the build command.

## Why it matters

The failure this prevents is not a corrupt file. It is an intact, readable kernel that belongs to a different build — same length, no I/O error, boots and then behaves strangely. A path-trusting cache cannot distinguish that from the right kernel, which is why kernel cache skew presents as a mysterious guest fault rather than a cache fault.

## Keeping it connected

New gate `xtask check-verified-kernel-reads`: a file that names the cache location must also call `resolve_kernel`. Wired into `ci.yml` and `ci-full.yml`.

It is co-presence per file, not a proof that the resolved value is the one used — a file could resolve in one function and use a bare path in another. A type that made the bare path unusable would be stronger, but the location is legitimately needed for diagnostics at exactly the sites that must not boot from it, so the proportionate control is to make a bare use visible in review rather than impossible. The gate refuses to pass vacuously if either symbol is renamed.

Note this is **not** the gate plan 288 WS5 originally specified ("assert `verify_fetched_kernel` has a production caller"). WS3 routed the read path through `verify_cached_kernel` against the sidecar, so `verify_fetched_kernel` legitimately has no production caller and that gate would fail on correct code. The live risk turned out to be the opposite direction, and the gate follows it. The plan records the substitution.

## Tests

- `an_unpinned_fallback_kernel_is_refused`, `a_tampered_fallback_kernel_is_refused` (CLI fallback)
- `firecracker_admitted_boot_receives_a_concrete_kernel_path` extended: unpinned refused → pinned serves → tampered refused and evicted
- Five gate unit tests including the planted bare-path read and the vacuity case; both recorded in `specs/VERIFICATION.md`

Each negative test was confirmed to pass only because of the change — the two fallback tests staged an unpinned kernel and passed before it.

## One behaviour change worth flagging

`crates/mvm-client/tests/launch_lifecycle_live.rs` seeded `MVM_E2E_KERNEL` into the cache without recording a digest, so the live KVM lane would have refused to boot after this change. It now records the sidecar like any other producer. That lane is `#[ignore]`d and needs real KVM, so CI would not have caught it.

Operators with an existing cache populated before plan 288's producers landed will see one eviction and re-derive per kernel, which is the intended fail-closed behaviour.

## Verification

`cargo nextest run -p mvm-cli` (1682 passed) · `-p mvm-client -p xtask -p mvm-build` (1596 passed) · `cargo clippy --workspace --all-targets -- -D warnings` clean · nightly `cargo fmt --all --check` clean · `check-verified-kernel-reads`, `check-claim-catalog`, `check-witness-citations`, `check-no-overclaim`, `check-honesty`, `check-deferrals`, `check-no-spec-refs-in-comments` all clean.

Closes plan 288 WS5.
