### PR TITLE
test: close remaining mutation witness gaps

### DIFF
--- a/crates/mvm-contract/src/protocol/vm_backend.rs
+++ b/crates/mvm-contract/src/protocol/vm_backend.rs
@@ -493,18 +493,8 @@ pub struct VmCapabilities {
     pub virtiofs_root: bool,
     /// Which resource dimensions this backend can actually bound. Declared
     /// separately from what a caller requests so a refusal can name the gap.
-    #[serde(default = "default_resource_controls")]
+    #[serde(default)]
     pub resource_controls: crate::protocol::resource_controls::ResourceControls,
-}
-
-fn default_resource_controls() -> crate::protocol::resource_controls::ResourceControls {
-    use crate::protocol::resource_controls::{CpuControl, ResourceControls, WallClockControl};
-    // The safe default is "enforces nothing", so an unset value understates
-    // rather than overstates what a backend does.
-    ResourceControls {
-        cpu: CpuControl::None,
-        wall_clock: WallClockControl::None,
-    }
 }
 
 /// The capabilities a run/plan requires from its backend.
@@ -1362,6 +1352,23 @@ impl BackendKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn omitted_resource_controls_deserialize_to_the_fail_closed_default() {
+        let mut encoded = serde_json::to_value(VmCapabilities::default())
+            .expect("default capabilities serialize");
+        encoded
+            .as_object_mut()
+            .expect("capabilities serialize as an object")
+            .remove("resource_controls");
+
+        let decoded: VmCapabilities =
+            serde_json::from_value(encoded).expect("legacy capabilities deserialize");
+        assert_eq!(
+            decoded.resource_controls,
+            crate::protocol::resource_controls::ResourceControls::default()
+        );
+    }
 
     #[test]
     fn every_label_parses_back_to_the_kind_that_rendered_it() {

--- a/crates/mvm-hostd/src/broker/registry.rs
+++ b/crates/mvm-hostd/src/broker/registry.rs
@@ -715,6 +715,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn typed_dispatch_accepts_input_at_the_exact_byte_limit() {
+        let descriptor = descriptor();
+        let binding = descriptor.binding();
+        let mut registry = Registry::new();
+        registry
+            .register_capability(Arc::new(EchoHandler), descriptor)
+            .expect("register");
+        registry
+            .admit_capabilities([binding.clone()])
+            .expect("admit");
+
+        let payload = serde_json::Value::String("x".repeat(126));
+        assert_eq!(
+            serde_json::to_vec(&payload)
+                .expect("payload serializes")
+                .len(),
+            128,
+            "the fixture must sit exactly on the descriptor's input limit"
+        );
+        let invocation = CapabilityInvocation::from_payload(
+            binding,
+            AgentRequestId::parse("typed-request-boundary").expect("request id"),
+            &payload,
+        )
+        .expect("invocation");
+
+        let response = registry
+            .dispatch_capability(
+                &ctx(),
+                &ServiceId::parse("host.dev.echo.v1").expect("service"),
+                "echo",
+                &invocation,
+                payload.clone(),
+                &CancellationToken::new(),
+            )
+            .await
+            .expect("an input exactly at the limit is admitted");
+        assert_eq!(response, payload);
+    }
+
+    #[tokio::test]
+    async fn typed_dispatch_rejects_an_admitted_digest_that_differs_from_the_invocation() {
+        let descriptor = descriptor();
+        let binding = descriptor.binding();
+        let mut admitted_binding = binding.clone();
+        admitted_binding.descriptor_digest = [9; 32];
+        let mut registry = Registry::new();
+        registry
+            .register_capability(Arc::new(EchoHandler), descriptor)
+            .expect("register");
+        registry
+            .admit_capabilities([admitted_binding])
+            .expect("admit");
+        let payload = serde_json::json!({"hello": "world"});
+        let invocation = CapabilityInvocation::from_payload(
+            binding,
+            AgentRequestId::parse("typed-request-admission-digest").expect("request id"),
+            &payload,
+        )
+        .expect("invocation");
+
+        let error = registry
+            .dispatch_capability(
+                &ctx(),
+                &ServiceId::parse("host.dev.echo.v1").expect("service"),
+                "echo",
+                &invocation,
+                payload,
+                &CancellationToken::new(),
+            )
+            .await
+            .expect_err("the admitted digest must match the invocation binding");
+        assert_eq!(error.code, ServiceErrorCode::CapabilityBindingMismatch);
+    }
+
+    #[tokio::test]
     async fn typed_dispatch_classifies_schema_rejection_without_leaking_handler_text() {
         let descriptor = descriptor();
         let binding = descriptor.binding();

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -1650,6 +1650,38 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn host_cpu_mechanism_gap_requires_a_share_capable_tier_and_a_reported_gap() {
+        use mvm_core::cpu_scope::MechanismGap;
+
+        let missing_bus = Some(MechanismGap::NoUserSessionBus);
+        assert_eq!(
+            host_cpu_mechanism_gap(
+                &mvm_contract::grants::Grants::default(),
+                BackendKind::Firecracker,
+                missing_bus,
+            ),
+            None,
+            "a plan with no CPU share has no CPU mechanism gap"
+        );
+        assert_eq!(
+            host_cpu_mechanism_gap(&cpu_share(1000), BackendKind::Wasm, missing_bus),
+            None,
+            "a tier whose CPU control is not a cgroup share does not use the host mechanism"
+        );
+        assert_eq!(
+            host_cpu_mechanism_gap(&cpu_share(1000), BackendKind::Firecracker, None),
+            None,
+            "an available host mechanism leaves no gap"
+        );
+
+        let detail =
+            host_cpu_mechanism_gap(&cpu_share(1000), BackendKind::Firecracker, missing_bus)
+                .expect("a missing mechanism must be reported for a share-capable tier");
+        assert!(detail.contains("no user session bus"), "{detail}");
+    }
+
     #[test]
     fn admission_refuses_a_grant_over_the_ceiling() {
         let (_env, _home) = host_with_ceiling(mvm_contract::grants::ceiling::GrantCeiling {

--- a/crates/mvm-hostd/src/supervisor/audit_file.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_file.rs
@@ -17,7 +17,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use base64::Engine;
@@ -83,7 +83,7 @@ pub struct FileAuditSigner {
     /// Emptied whenever a barrier entry syncs the file it is on, since
     /// `sync_data` is file-wide and carries every earlier write with it. What
     /// remains at drop is flushed there.
-    pending_sync: Mutex<HashSet<PathBuf>>,
+    pending_sync: Arc<Mutex<HashSet<PathBuf>>>,
 }
 
 /// Whether an entry must be on disk before this call returns.
@@ -156,7 +156,7 @@ impl FileAuditSigner {
             audit_dir,
             fixed_file: None,
             cursors: Mutex::new(HashMap::new()),
-            pending_sync: Mutex::new(HashSet::new()),
+            pending_sync: Arc::new(Mutex::new(HashSet::new())),
         })
     }
 
@@ -180,7 +180,7 @@ impl FileAuditSigner {
                 .unwrap_or_else(|| PathBuf::from(".")),
             fixed_file: Some(audit_file),
             cursors: Mutex::new(HashMap::new()),
-            pending_sync: Mutex::new(HashSet::new()),
+            pending_sync: Arc::new(Mutex::new(HashSet::new())),
         })
     }
 
@@ -687,6 +687,10 @@ mod tests {
                 .unwrap();
         }
         signer.flush_deferred();
+        assert!(
+            signer.pending_sync.lock().unwrap().is_empty(),
+            "an explicit flush drains every pending file"
+        );
 
         let body = std::fs::read_to_string(dir.path().join("t1.jsonl")).unwrap();
         let lines: Vec<&str> = body.lines().collect();
@@ -695,6 +699,27 @@ mod tests {
             let v: serde_json::Value = serde_json::from_str(line).unwrap();
             assert_eq!(v["entry"]["event"], expected, "order is preserved");
         }
+    }
+
+    #[tokio::test]
+    async fn dropping_the_signer_flushes_every_deferred_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let pending = {
+            let signer = FileAuditSigner::open(fresh_key(), dir.path()).unwrap();
+            signer
+                .sign_and_emit(&make_entry("t1", "plan.launched"))
+                .await
+                .unwrap();
+            let pending = Arc::clone(&signer.pending_sync);
+            assert_eq!(pending.lock().unwrap().len(), 1);
+            drop(signer);
+            pending
+        };
+
+        assert!(
+            pending.lock().unwrap().is_empty(),
+            "drop must flush and drain every deferred file"
+        );
     }
 
     #[tokio::test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-10
+Last updated: 2026-08-11
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -103,13 +103,16 @@ for detailed scope and acceptance criteria.
   - [x] Add direct witnesses for the security-sensitive admission,
         verification, lease, and substitution cleanup invariants
   - [x] Fail closed when an accepted miss leaves the pinned mutation surface,
-        migrate 26 libkrun identities to their current file, and remove 14
-        obsolete misses without adding a waiver (83 accepted misses to 69)
+        migrate 26 libkrun identities to their current file, and remove 15
+        obsolete misses without adding a waiver (83 accepted misses to 68)
   - [x] Catch the current actionable `mvm-vmm`, `mvm-hostd`, and `mvm-agentd`
         mutants in focused mutation proofs
-  - [x] Pass affected-package all-target Clippy, workspace unit/integration
-        tests, the isolated `mvm-cli` doctest rerun, formatting, and the static
-        mutation surface gate on the dedicated fix branch
+  - [x] Add the six witnesses exposed by the first exact rerun and prove the
+        complete contract shard plus the focused five-mutant hostd repair
+  - [x] Pass workspace all-target Clippy, the isolated `mvm-cli` doctest rerun,
+        formatting, and the static mutation surface gate; the workspace suite
+        passed all repaired areas before one unrelated host-agent socket-bind
+        timeout whose isolated integration rerun passed 4/4
   - [ ] Run the exact Linux Security workflow, merge the fix, and observe a
         clean scheduled or release run before closing the issue
 - [~] Plan 300 — 30-issue reconciliation and closeout

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -215,11 +215,19 @@
       catch the actionable snapshot-I/O, no-op stage-name, torn-tail, and grant
       parser mutants; the static gate rejects accepted misses outside the
       pinned surface; 26 moved libkrun identities name their current file; and
-      14 obsolete misses were removed, reducing the accepted baseline from 83
-      to 69 without adding a waiver. Focused mutation proofs, affected-package
-      all-target Clippy, the workspace unit/integration suite, formatting, and
-      the static surface gate are green. The exact Linux Security workflow
-      rerun remains the final merge-and-close gate.
+      15 obsolete misses were removed, reducing the accepted baseline from 83
+      to 68 without adding a waiver. The first exact rerun exposed six further
+      survivors: the contract's omitted resource-control default plus hostd's
+      exact broker byte limit, admitted digest equality, host CPU mechanism
+      truth table, explicit deferred-audit flush, and drop-time flush. Direct
+      witnesses now catch all six; the complete contract mutation shard and a
+      focused five-mutant hostd proof are green. Workspace all-target Clippy,
+      formatting, and the static surface gate are also green. The workspace
+      suite passed every repaired area but hit one unrelated host-agent
+      socket-bind timeout; its isolated integration rerun passed 4/4. A clean
+      exact Linux Security workflow rerun remains the final merge gate; a
+      subsequent scheduled or release run is still required before issue
+      closure.
 
 - [x] `mvmctl deps capture` — **plan 291 WS3**. Reseals a sandbox-captured
       dependency tree with fresh audit sidecars, updates the lockfile index,

--- a/specs/plans/300-open-issue-closeout.md
+++ b/specs/plans/300-open-issue-closeout.md
@@ -100,11 +100,17 @@ mentions it.
       `mvm-agentd` mutants; accepted misses fail closed when their files leave
       the pinned surface; moved libkrun identities now name their current file;
       and obsolete accepted misses were removed, reducing the baseline from 83
-      to 69 without adding a waiver. Focused mutation proofs, affected-package
-      all-target Clippy, the workspace unit/integration suite, formatting, and
-      the static surface gate pass on the fix branch. The exact Linux Security
-      workflow and clean scheduled or release run remain the merge-and-close
-      gates.
+      to 68 without adding a waiver. The first exact rerun exposed one
+      default-equivalent contract survivor and five hostd survivors; direct
+      witnesses now cover omitted fail-closed resource controls, exact broker
+      byte limits, admitted digest equality, the host CPU mechanism truth
+      table, explicit deferred-audit flushing, and drop-time flushing. Focused
+      mutation proofs, workspace all-target Clippy, formatting, and the static
+      surface gate pass on the fix branch. The workspace suite passed every
+      repaired area but hit one unrelated host-agent socket-bind timeout; its
+      isolated integration rerun passed 4/4. A clean exact Linux Security
+      workflow and subsequent scheduled or release run remain the
+      merge-and-close gates.
 - [ ] **#2289 — finish the kernel freshness closeout.** Linux 6.12.103 and the
       verified shared hash are merged in #2301, and kernel build/freshness CI
       passed. Build the release artifacts, run the verified-boot and

--- a/xtask/mutation-witness-baseline.json
+++ b/xtask/mutation-witness-baseline.json
@@ -588,11 +588,6 @@
       "file": "crates/mvm-sdk/src/compile/deps_audit.rs",
       "mutant": "replace * with + in hash_file_raw",
       "reason": "equivalent: the mutated expression is the read-buffer size (64 * 1024 versus 64 + 1024). It changes how many bytes are read per iteration and nothing else; the resulting SHA-256 is identical, so no assertion on behaviour can separate them."
-    },
-    {
-      "file": "crates/mvm-contract/src/policy/network_policy.rs",
-      "mutant": "replace NetworkPolicy::trusted_build_egress -> Self with Default::default()",
-      "reason": "Observed 2026-07-29. No mvm-contract test asserts the shape of the trusted-build egress policy. The mutant substitutes the deny-all default, so it makes the policy stricter, not weaker — a functional coverage gap rather than a security hole. Untriaged."
     }
   ]
 }


### PR DESCRIPTION
## What changed

- replace the redundant resource-control serde helper with the fail-closed type default and prove omitted fields deserialize safely
- add exact broker input-boundary and admitted-digest equality witnesses
- add the Linux host CPU mechanism truth-table witness
- prove both explicit and drop-time deferred audit flushing
- remove the now-witnessed trusted-build egress miss, reducing the accepted baseline from 69 to 68 without adding a waiver
- synchronize Plan 300, the sprint, and the refactor rollup

## Why

The first exact Security rerun after #2340 passed 26 of 28 jobs and exposed six remaining equivalent or surviving mutants: one in `mvm-contract` and five in `mvm-hostd`. These tests make the intended fail-closed and durability boundaries executable without weakening the mutation baseline.

This progresses #2135. Do not close the issue until this repair passes the exact Linux Security workflow and a subsequent scheduled or release run.

## Validation

- `cargo clippy --workspace --all-targets -- -D warnings`
- focused unit tests for all six witnesses
- complete `mvm-contract` mutation shard: no misses
- focused `mvm-hostd` mutation proof: 5/5 caught
- static mutation gate: 31 files across 10 packages, 68 accepted misses
- workspace tests passed all repaired areas; one unrelated host-agent socket-bind timeout passed 4/4 on isolated rerun
- formatting and `git diff --check`
