### PR TITLE
Refuse a restored child whose grants exceed its parent's (Plan 308 WS5b)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -435,7 +435,7 @@ fn create(name: &str, tag: Option<String>, json: bool) -> Result<()> {
             tag,
             created_unix: now,
             quiesced: true,
-            grants: admitted_grants_for(name),
+            grants: admitted_grants_for(name)?,
         },
     )
     .with_context(|| format!("capturing fs_quick checkpoint of {name:?}"))?;
@@ -502,7 +502,7 @@ fn capture_vm_full_for_running_vm(
         tag: args.tag,
         created_unix: args.created_unix,
         retain_paused: false,
-        grants: admitted_grants_for(args.name),
+        grants: admitted_grants_for(args.name)?,
     };
     capture_vm_full(args.store, params, control.as_ref())
 }
@@ -554,15 +554,24 @@ fn create_vm_full(name: &str, tag: Option<String>, json: bool) -> Result<()> {
 /// `checkpoint.created` entry, so the record it produces has nothing to anchor
 /// its content-address and every fork of it is refused before the grants are
 /// consulted at all.
-fn admitted_grants_for(name: &str) -> Option<mvm_contract::grants::Grants> {
-    match super::plan_persist::read_plan(name) {
-        Ok(plan) => plan.grants,
-        Err(e) => {
-            tracing::warn!(error = %e, vm = name,
-                "no persisted plan; checkpoint seals no admitted grant");
-            None
-        }
+fn admitted_grants_for(name: &str) -> Result<Option<mvm_contract::grants::Grants>> {
+    let path = super::plan_persist::plan_path(name)?;
+    // A VM that never had a plan legitimately has no grant to seal, and that is
+    // the only tolerated absence. Every other failure — a corrupt plan, one at
+    // loose permissions, one that will not parse — is refused rather than
+    // resolved to `None`, because `None` is not "unknown" here: for CPU and wall
+    // clock it means *unbounded*, so swallowing the error would widen the record
+    // silently and hand every child restored from it that widening.
+    if !path.exists() {
+        return Ok(None);
     }
+    let plan = super::plan_persist::read_plan_at(&path).with_context(|| {
+        format!(
+            "reading {name}'s admitted plan to seal its grants into the checkpoint; \
+             refusing to seal a checkpoint whose permission set cannot be determined"
+        )
+    })?;
+    Ok(plan.grants)
 }
 
 pub(crate) fn bind_checkpoint_created(name: &str, meta: &mvm_core::checkpoint::CheckpointMeta) {

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -435,6 +435,7 @@ fn create(name: &str, tag: Option<String>, json: bool) -> Result<()> {
             tag,
             created_unix: now,
             quiesced: true,
+            grants: admitted_grants_for(name),
         },
     )
     .with_context(|| format!("capturing fs_quick checkpoint of {name:?}"))?;
@@ -501,6 +502,7 @@ fn capture_vm_full_for_running_vm(
         tag: args.tag,
         created_unix: args.created_unix,
         retain_paused: false,
+        grants: admitted_grants_for(args.name),
     };
     capture_vm_full(args.store, params, control.as_ref())
 }
@@ -542,6 +544,25 @@ fn create_vm_full(name: &str, tag: Option<String>, json: bool) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+/// The permission set `name` was admitted under, read off its persisted plan so
+/// the checkpoint can seal it and a later restore can bound a child against it.
+///
+/// Degrades the same way [`bind_checkpoint_created`] does, and safely for the
+/// same reason: a VM with no readable plan also gets no chain-signed
+/// `checkpoint.created` entry, so the record it produces has nothing to anchor
+/// its content-address and every fork of it is refused before the grants are
+/// consulted at all.
+fn admitted_grants_for(name: &str) -> Option<mvm_contract::grants::Grants> {
+    match super::plan_persist::read_plan(name) {
+        Ok(plan) => plan.grants,
+        Err(e) => {
+            tracing::warn!(error = %e, vm = name,
+                "no persisted plan; checkpoint seals no admitted grant");
+            None
+        }
+    }
 }
 
 pub(crate) fn bind_checkpoint_created(name: &str, meta: &mvm_core::checkpoint::CheckpointMeta) {

--- a/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
@@ -365,7 +365,11 @@ fn admit_forked_child(p: &AdmitForkedChildParams<'_>) -> Result<AdmittedForkChil
             restrict_agent_verbs: !parent_agent_verbs.is_empty()
                 || crate::commands::vm::agent_verbs::grant_eligible(false, false, false),
             services: Vec::new(),
-            grants: None,
+            // The child inherits the permission set the parent was captured
+            // under. Anything else is refused downstream, and declaring nothing
+            // is the widest ask rather than the narrowest — an absent CPU or
+            // wall-clock grant means unbounded.
+            grants: p.parent_meta.grants.clone(),
             backend_kind: None,
             entrypoint: crate::commands::vm::entrypoint_resolve::ResolvedEntrypoint::unresolved(
                 "a checkpoint fork boots the image the parent booted; this path resolves no entrypoint",

--- a/crates/mvm-conformance/tests/steps/warm_claim.rs
+++ b/crates/mvm-conformance/tests/steps/warm_claim.rs
@@ -66,6 +66,7 @@ fn seed_parent(world: &mut CliWorld, chain_carries_creation_entry: bool) {
             tag: None,
             created_unix: 1,
             quiesced: true,
+            grants: None,
         },
     )
     .expect("capture the clean parent checkpoint");

--- a/crates/mvm-contract/src/grants/mod.rs
+++ b/crates/mvm-contract/src/grants/mod.rs
@@ -12,6 +12,7 @@ use crate::policy::network_policy::HostPort;
 
 pub mod ceiling;
 pub mod projection;
+pub mod subset;
 
 /// A workload's permission set. Every field is optional: absent means
 /// "unspecified", which each dimension resolves differently — an absent

--- a/crates/mvm-contract/src/grants/subset.rs
+++ b/crates/mvm-contract/src/grants/subset.rs
@@ -1,0 +1,435 @@
+//! Whether one permission set sits inside another.
+//!
+//! Distinct from [`GrantCeiling`](crate::grants::ceiling::GrantCeiling), which
+//! bounds a grant against host or fleet configuration. This bounds a grant
+//! against *another grant* — the one a running VM was already admitted under.
+//! Snapshot/restore needs it: a child plan is independently signed and
+//! internally consistent, so signature, plan id, tenant and validity all pass
+//! for a child that simply asks for more than its parent had. Without a
+//! containment check, restore launders a permission set.
+//!
+//! Absence does not mean the same thing in every dimension, and treating it
+//! uniformly is the way to get this wrong. An absent CPU or wall-clock grant is
+//! *unbounded*, so a child that drops one its parent carried has widened. An
+//! absent egress grant is deny-all, so a child that drops one has narrowed.
+
+use crate::grants::{CpuGrant, EgressGrant, Grants, WallClockGrant};
+use crate::policy::network_policy::HostPort;
+
+/// The dimension in which a child asked for more than its parent held.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum GrantWidening {
+    #[error("child drops the parent's CPU bound, and an absent CPU grant is unbounded")]
+    CpuBoundDropped,
+    #[error("child CPU share {child} millicores exceeds the parent's {parent}")]
+    CpuShareExceeded { child: u32, parent: u32 },
+    #[error("child CPU fuel {child} instructions exceeds the parent's {parent}")]
+    CpuFuelExceeded { child: u64, parent: u64 },
+    #[error(
+        "child and parent CPU grants are in different units; a share is a fraction of host CPU \
+         and fuel is an instruction count, and no conversion between them exists"
+    )]
+    CpuUnitMismatch,
+    #[error(
+        "child drops the parent's wall-clock bound, and an absent wall-clock grant is unbounded"
+    )]
+    WallClockBoundDropped,
+    #[error("child asks for an unbounded wall clock under a parent bounded to {parent} seconds")]
+    WallClockUnbounded { parent: u32 },
+    #[error("child wall clock of {child} seconds exceeds the parent's {parent}")]
+    WallClockExceeded { child: u32, parent: u32 },
+    #[error("child egress destination {0} was not admitted for the parent")]
+    EgressNotAdmitted(HostPort),
+}
+
+/// Whether `child` asks for no more than `parent` holds, in every dimension.
+///
+/// Dimensions are checked in a fixed order — CPU, wall clock, egress — so a
+/// child that widens in more than one reports a stable reason rather than one
+/// that depends on evaluation order.
+pub fn grants_are_subset(child: &Grants, parent: &Grants) -> Result<(), GrantWidening> {
+    cpu_is_subset(child.cpu, parent.cpu)?;
+    wall_clock_is_subset(child.wall_clock, parent.wall_clock)?;
+    egress_is_subset(child.egress.as_ref(), parent.egress.as_ref())
+}
+
+fn cpu_is_subset(child: Option<CpuGrant>, parent: Option<CpuGrant>) -> Result<(), GrantWidening> {
+    let (Some(parent), child) = (parent, child) else {
+        // An unbounded parent bounds nothing, so any child sits inside it.
+        return Ok(());
+    };
+    let Some(child) = child else {
+        return Err(GrantWidening::CpuBoundDropped);
+    };
+    match (child, parent) {
+        (CpuGrant::Share { millicores: c }, CpuGrant::Share { millicores: p }) => {
+            if c > p {
+                return Err(GrantWidening::CpuShareExceeded {
+                    child: c,
+                    parent: p,
+                });
+            }
+            Ok(())
+        }
+        (CpuGrant::Fuel { instructions: c }, CpuGrant::Fuel { instructions: p }) => {
+            if c > p {
+                return Err(GrantWidening::CpuFuelExceeded {
+                    child: c,
+                    parent: p,
+                });
+            }
+            Ok(())
+        }
+        // Refusing beats inventing an exchange rate: any conversion would be a
+        // host-specific guess, and guessing high is a silent widening.
+        (CpuGrant::Share { .. }, CpuGrant::Fuel { .. })
+        | (CpuGrant::Fuel { .. }, CpuGrant::Share { .. }) => Err(GrantWidening::CpuUnitMismatch),
+    }
+}
+
+fn wall_clock_is_subset(
+    child: Option<WallClockGrant>,
+    parent: Option<WallClockGrant>,
+) -> Result<(), GrantWidening> {
+    let parent = match parent {
+        None | Some(WallClockGrant::Unbounded) => return Ok(()),
+        Some(WallClockGrant::Secs { secs }) => secs.get(),
+    };
+    match child {
+        None => Err(GrantWidening::WallClockBoundDropped),
+        Some(WallClockGrant::Unbounded) => Err(GrantWidening::WallClockUnbounded { parent }),
+        Some(WallClockGrant::Secs { secs }) if secs.get() > parent => {
+            Err(GrantWidening::WallClockExceeded {
+                child: secs.get(),
+                parent,
+            })
+        }
+        Some(WallClockGrant::Secs { .. }) => Ok(()),
+    }
+}
+
+fn egress_is_subset(
+    child: Option<&EgressGrant>,
+    parent: Option<&EgressGrant>,
+) -> Result<(), GrantWidening> {
+    // Set containment on the allowlist. An absent grant is deny-all on either
+    // side, so an absent parent admits only an empty child and an absent child
+    // reaches nothing — the inverse of the CPU rule, deliberately.
+    let parent_allow: &[HostPort] = parent.map(|e| e.allow.as_slice()).unwrap_or(&[]);
+    let child_allow: &[HostPort] = child.map(|e| e.allow.as_slice()).unwrap_or(&[]);
+    for want in child_allow {
+        if !parent_allow.contains(want) {
+            return Err(GrantWidening::EgressNotAdmitted(want.clone()));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use core::num::NonZeroU32;
+
+    fn share(millicores: u32) -> Option<CpuGrant> {
+        Some(CpuGrant::Share { millicores })
+    }
+
+    fn secs(secs: u32) -> Option<WallClockGrant> {
+        Some(WallClockGrant::Secs {
+            secs: NonZeroU32::new(secs).expect("nonzero"),
+        })
+    }
+
+    fn egress(hosts: &[(&str, u16)]) -> Option<EgressGrant> {
+        Some(EgressGrant {
+            allow: hosts
+                .iter()
+                .map(|(h, p)| HostPort::new(*h, *p))
+                .collect::<alloc::vec::Vec<_>>(),
+        })
+    }
+
+    #[test]
+    fn a_child_may_narrow_every_dimension_at_once() {
+        let parent = Grants {
+            cpu: share(4000),
+            wall_clock: secs(600),
+            egress: egress(&[("api.example.com", 443), ("pypi.org", 443)]),
+        };
+        let child = Grants {
+            cpu: share(1000),
+            wall_clock: secs(60),
+            egress: egress(&[("api.example.com", 443)]),
+        };
+        assert_eq!(grants_are_subset(&child, &parent), Ok(()));
+    }
+
+    #[test]
+    fn an_identical_child_is_a_subset_of_its_parent() {
+        let g = Grants {
+            cpu: share(1000),
+            wall_clock: secs(60),
+            egress: egress(&[("api.example.com", 443)]),
+        };
+        assert_eq!(grants_are_subset(&g, &g), Ok(()));
+    }
+
+    #[test]
+    fn a_child_may_not_widen_its_parents_cpu_share() {
+        let parent = Grants {
+            cpu: share(1000),
+            ..Default::default()
+        };
+        let child = Grants {
+            cpu: share(4000),
+            ..Default::default()
+        };
+        assert_eq!(
+            grants_are_subset(&child, &parent),
+            Err(GrantWidening::CpuShareExceeded {
+                child: 4000,
+                parent: 1000
+            })
+        );
+    }
+
+    #[test]
+    fn a_child_may_not_widen_its_parents_fuel_budget() {
+        let parent = Grants {
+            cpu: Some(CpuGrant::Fuel {
+                instructions: 1_000,
+            }),
+            ..Default::default()
+        };
+        let child = Grants {
+            cpu: Some(CpuGrant::Fuel {
+                instructions: 1_001,
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            grants_are_subset(&child, &parent),
+            Err(GrantWidening::CpuFuelExceeded {
+                child: 1_001,
+                parent: 1_000
+            })
+        );
+    }
+
+    #[test]
+    fn a_child_may_not_drop_a_cpu_bound_its_parent_carried() {
+        // Absent means unbounded for CPU, so dropping the bound is the widest
+        // possible ask, not a narrowing.
+        let parent = Grants {
+            cpu: share(1000),
+            ..Default::default()
+        };
+        assert_eq!(
+            grants_are_subset(&Grants::default(), &parent),
+            Err(GrantWidening::CpuBoundDropped)
+        );
+    }
+
+    #[test]
+    fn a_child_may_bound_cpu_where_its_parent_did_not() {
+        let child = Grants {
+            cpu: share(1000),
+            ..Default::default()
+        };
+        assert_eq!(grants_are_subset(&child, &Grants::default()), Ok(()));
+    }
+
+    #[test]
+    fn mismatched_cpu_units_are_refused_rather_than_converted() {
+        let parent = Grants {
+            cpu: Some(CpuGrant::Fuel {
+                instructions: u64::MAX,
+            }),
+            ..Default::default()
+        };
+        let child = Grants {
+            cpu: share(1),
+            ..Default::default()
+        };
+        assert_eq!(
+            grants_are_subset(&child, &parent),
+            Err(GrantWidening::CpuUnitMismatch)
+        );
+        // Symmetric: neither direction has a defined conversion.
+        assert_eq!(
+            grants_are_subset(&parent, &child),
+            Err(GrantWidening::CpuUnitMismatch)
+        );
+    }
+
+    #[test]
+    fn a_child_may_not_widen_its_parents_wall_clock() {
+        let parent = Grants {
+            wall_clock: secs(60),
+            ..Default::default()
+        };
+        let child = Grants {
+            wall_clock: secs(61),
+            ..Default::default()
+        };
+        assert_eq!(
+            grants_are_subset(&child, &parent),
+            Err(GrantWidening::WallClockExceeded {
+                child: 61,
+                parent: 60
+            })
+        );
+    }
+
+    #[test]
+    fn an_unbounded_child_wall_clock_is_refused_under_a_bounded_parent() {
+        let parent = Grants {
+            wall_clock: secs(60),
+            ..Default::default()
+        };
+        let child = Grants {
+            wall_clock: Some(WallClockGrant::Unbounded),
+            ..Default::default()
+        };
+        assert_eq!(
+            grants_are_subset(&child, &parent),
+            Err(GrantWidening::WallClockUnbounded { parent: 60 })
+        );
+    }
+
+    #[test]
+    fn a_child_may_not_drop_a_wall_clock_bound_its_parent_carried() {
+        let parent = Grants {
+            wall_clock: secs(60),
+            ..Default::default()
+        };
+        assert_eq!(
+            grants_are_subset(&Grants::default(), &parent),
+            Err(GrantWidening::WallClockBoundDropped)
+        );
+    }
+
+    #[test]
+    fn any_child_wall_clock_sits_under_an_unbounded_parent() {
+        let parent = Grants {
+            wall_clock: Some(WallClockGrant::Unbounded),
+            ..Default::default()
+        };
+        for child in [
+            Grants::default(),
+            Grants {
+                wall_clock: Some(WallClockGrant::Unbounded),
+                ..Default::default()
+            },
+            Grants {
+                wall_clock: secs(u32::MAX),
+                ..Default::default()
+            },
+        ] {
+            assert_eq!(grants_are_subset(&child, &parent), Ok(()));
+        }
+    }
+
+    #[test]
+    fn a_child_may_not_reach_a_destination_its_parent_could_not() {
+        let parent = Grants {
+            egress: egress(&[("api.example.com", 443)]),
+            ..Default::default()
+        };
+        let child = Grants {
+            egress: egress(&[("api.example.com", 443), ("evil.example.com", 443)]),
+            ..Default::default()
+        };
+        assert_eq!(
+            grants_are_subset(&child, &parent),
+            Err(GrantWidening::EgressNotAdmitted(HostPort::new(
+                "evil.example.com",
+                443
+            )))
+        );
+    }
+
+    #[test]
+    fn a_child_may_not_reach_another_port_on_an_admitted_host() {
+        // Containment is on the (host, port) pair; an admitted host does not
+        // carry the whole port range with it.
+        let parent = Grants {
+            egress: egress(&[("api.example.com", 443)]),
+            ..Default::default()
+        };
+        let child = Grants {
+            egress: egress(&[("api.example.com", 8443)]),
+            ..Default::default()
+        };
+        assert_eq!(
+            grants_are_subset(&child, &parent),
+            Err(GrantWidening::EgressNotAdmitted(HostPort::new(
+                "api.example.com",
+                8443
+            )))
+        );
+    }
+
+    #[test]
+    fn dropping_egress_narrows_because_absent_egress_is_deny_all() {
+        // The inverse of the CPU rule, and the reason the two dimensions
+        // cannot share one absence rule.
+        let parent = Grants {
+            egress: egress(&[("api.example.com", 443)]),
+            ..Default::default()
+        };
+        assert_eq!(grants_are_subset(&Grants::default(), &parent), Ok(()));
+    }
+
+    #[test]
+    fn a_parent_without_egress_admits_no_child_destination() {
+        let child = Grants {
+            egress: egress(&[("api.example.com", 443)]),
+            ..Default::default()
+        };
+        assert_eq!(
+            grants_are_subset(&child, &Grants::default()),
+            Err(GrantWidening::EgressNotAdmitted(HostPort::new(
+                "api.example.com",
+                443
+            )))
+        );
+        // An empty allowlist is also deny-all, so it admits nothing either.
+        let empty_parent = Grants {
+            egress: Some(EgressGrant { allow: vec![] }),
+            ..Default::default()
+        };
+        assert!(grants_are_subset(&child, &empty_parent).is_err());
+    }
+
+    #[test]
+    fn cpu_is_reported_before_wall_clock_and_egress() {
+        // A child widening several dimensions must report a stable reason.
+        let parent = Grants {
+            cpu: share(1000),
+            wall_clock: secs(60),
+            egress: None,
+        };
+        let child = Grants {
+            cpu: share(2000),
+            wall_clock: Some(WallClockGrant::Unbounded),
+            egress: egress(&[("evil.example.com", 443)]),
+        };
+        assert_eq!(
+            grants_are_subset(&child, &parent),
+            Err(GrantWidening::CpuShareExceeded {
+                child: 2000,
+                parent: 1000
+            })
+        );
+    }
+
+    #[test]
+    fn two_empty_grants_contain_each_other() {
+        assert_eq!(
+            grants_are_subset(&Grants::default(), &Grants::default()),
+            Ok(())
+        );
+    }
+}

--- a/crates/mvm-core/src/checkpoint.rs
+++ b/crates/mvm-core/src/checkpoint.rs
@@ -236,6 +236,12 @@ pub struct CheckpointMeta {
     /// cannot redirect materialization to an unrelated staged snapshot.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snapshot_id: Option<String>,
+    /// The permission set the captured VM was admitted under. Load-bearing so a
+    /// restore can bound a child against it: the digest covers this field, the
+    /// signed chain covers the digest, and a record edited to widen what the
+    /// parent held stops verifying before it can justify a wider child.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grants: Option<mvm_contract::grants::Grants>,
     /// Content-address of the load-bearing fields above. Required with no serde
     /// default: a record that carries no content-address cannot be
     /// lineage-verified, so a pre-lineage meta.json must fail closed rather than
@@ -262,6 +268,7 @@ impl CheckpointMeta {
             runtime_source_policy: None,
             runtime_overlay_version: None,
             snapshot_id: None,
+            grants: None,
             audit_ref: None,
         }
     }
@@ -284,6 +291,7 @@ impl CheckpointMeta {
             runtime_source_policy: &self.runtime_source_policy,
             runtime_overlay_version: &self.runtime_overlay_version,
             snapshot_id: &self.snapshot_id,
+            grants: &self.grants,
         }
         .digest()
     }
@@ -308,6 +316,7 @@ impl CheckpointMeta {
             .runtime_source_policy(self.runtime_source_policy)
             .runtime_overlay_version(self.runtime_overlay_version.clone())
             .snapshot_id(Some(snapshot_id.into()))
+            .grants(self.grants.clone())
             .audit_ref(self.audit_ref.clone())
             .build()
     }
@@ -346,6 +355,7 @@ struct CheckpointDigestInput<'a> {
     runtime_source_policy: &'a Option<RuntimeSourcePolicy>,
     runtime_overlay_version: &'a Option<String>,
     snapshot_id: &'a Option<String>,
+    grants: &'a Option<mvm_contract::grants::Grants>,
 }
 
 impl CheckpointDigestInput<'_> {
@@ -395,6 +405,7 @@ pub struct CheckpointMetaBuilder {
     runtime_source_policy: Option<RuntimeSourcePolicy>,
     runtime_overlay_version: Option<String>,
     snapshot_id: Option<String>,
+    grants: Option<mvm_contract::grants::Grants>,
     audit_ref: Option<String>,
 }
 
@@ -433,6 +444,12 @@ impl CheckpointMetaBuilder {
         self.snapshot_id = id;
         self
     }
+    /// The permission set the captured VM was admitted under. Recorded so a
+    /// later restore can bound its child against it.
+    pub fn grants(mut self, grants: Option<mvm_contract::grants::Grants>) -> Self {
+        self.grants = grants;
+        self
+    }
     pub fn audit_ref(mut self, r: Option<String>) -> Self {
         self.audit_ref = r;
         self
@@ -454,6 +471,7 @@ impl CheckpointMetaBuilder {
             runtime_source_policy: &self.runtime_source_policy,
             runtime_overlay_version: &self.runtime_overlay_version,
             snapshot_id: &self.snapshot_id,
+            grants: &self.grants,
         }
         .digest();
         CheckpointMeta {
@@ -468,6 +486,7 @@ impl CheckpointMetaBuilder {
             runtime_source_policy: self.runtime_source_policy,
             runtime_overlay_version: self.runtime_overlay_version,
             snapshot_id: self.snapshot_id,
+            grants: self.grants,
             meta_digest,
             audit_ref: self.audit_ref,
         }
@@ -632,6 +651,38 @@ mod tests {
     }
 
     #[test]
+    fn the_admitted_grant_is_inside_the_content_address() {
+        // What makes the grant tamper-evident: a record edited to widen what
+        // the captured VM held stops matching its own content-address, and the
+        // signed chain records that address. Without this the grant would be
+        // free-floating metadata a restore could not safely trust.
+        let bounded =
+            CheckpointMeta::builder(CheckpointId::new("c1"), CheckpointClass::FsQuick, "vm")
+                .content(vec![blob("rootfs.ext4", "aa")])
+                .supervisor_config_digest("cfg")
+                .created_unix(7)
+                .grants(Some(mvm_contract::grants::Grants {
+                    cpu: Some(mvm_contract::grants::CpuGrant::Share { millicores: 1000 }),
+                    ..Default::default()
+                }))
+                .build();
+        let widened = CheckpointMeta {
+            grants: Some(mvm_contract::grants::Grants {
+                cpu: Some(mvm_contract::grants::CpuGrant::Share { millicores: 64_000 }),
+                ..Default::default()
+            }),
+            ..bounded.clone()
+        };
+        assert_ne!(widened.compute_meta_digest(), widened.meta_digest);
+        assert_ne!(bounded.meta_digest, widened.compute_meta_digest());
+        // An unbounded record is likewise distinguishable from a bounded one.
+        assert_ne!(
+            bounded.meta_digest,
+            digest_fixture_meta(vec![blob("rootfs.ext4", "aa")]).meta_digest
+        );
+    }
+
+    #[test]
     fn meta_digest_invariant_under_content_insertion_order() {
         // The blob manifest is content-addressed by name, not by the order
         // capture appended it — permuting the vec must not move the digest.
@@ -692,6 +743,7 @@ mod tests {
             cfg: String,
             policy: Option<RuntimeSourcePolicy>,
             overlay: Option<String>,
+            grants: Option<mvm_contract::grants::Grants>,
         }
         let build = |f: &Fields| {
             CheckpointMeta::builder(CheckpointId::new(f.id.clone()), f.class, f.vm.clone())
@@ -702,6 +754,7 @@ mod tests {
                 .supervisor_config_digest(f.cfg.clone())
                 .runtime_source_policy(f.policy)
                 .runtime_overlay_version(f.overlay.clone())
+                .grants(f.grants.clone())
                 .build()
                 .meta_digest
         };
@@ -716,6 +769,7 @@ mod tests {
             cfg: "cfg0".into(),
             policy: Some(RuntimeSourcePolicy::PreferOverlay),
             overlay: Some("0.1.0".into()),
+            grants: None,
         };
         let baseline = build(&base);
 
@@ -749,6 +803,12 @@ mod tests {
         let mut f = base.clone();
         f.parent = Some(parent_digest());
         assert_ne!(baseline, build(&f), "parent");
+        let mut f = base.clone();
+        f.grants = Some(mvm_contract::grants::Grants {
+            cpu: Some(mvm_contract::grants::CpuGrant::Share { millicores: 1000 }),
+            ..Default::default()
+        });
+        assert_ne!(baseline, build(&f), "grants");
     }
 
     #[test]

--- a/crates/mvm-core/src/checkpoint.rs
+++ b/crates/mvm-core/src/checkpoint.rs
@@ -355,6 +355,13 @@ struct CheckpointDigestInput<'a> {
     runtime_source_policy: &'a Option<RuntimeSourcePolicy>,
     runtime_overlay_version: &'a Option<String>,
     snapshot_id: &'a Option<String>,
+    /// Skipped when absent so a record that seals no grant hashes exactly as it
+    /// did before the field existed. Without this, every checkpoint captured
+    /// before grants were sealed would recompute to a different digest and be
+    /// reported as `meta_digest drift` — i.e. as *tampered*, when the record is
+    /// only schema-stale. The check is meant to be believed, so it must not cry
+    /// tamper over a field nobody touched.
+    #[serde(skip_serializing_if = "Option::is_none")]
     grants: &'a Option<mvm_contract::grants::Grants>,
 }
 
@@ -679,6 +686,21 @@ mod tests {
         assert_ne!(
             bounded.meta_digest,
             digest_fixture_meta(vec![blob("rootfs.ext4", "aa")]).meta_digest
+        );
+    }
+
+    #[test]
+    fn sealing_no_grant_leaves_a_records_digest_where_it_was() {
+        // A record that seals no grant must hash exactly as it did before the
+        // field existed, or every checkpoint captured earlier reports as
+        // `meta_digest drift` — as tampered rather than as schema-stale. The
+        // literal is this fixture's digest read off the commit before `grants`
+        // was added, not a value re-derived from the code it is checking.
+        let m = digest_fixture_meta(vec![blob("rootfs.ext4", "aa")]);
+        assert!(m.grants.is_none());
+        assert_eq!(
+            m.meta_digest.as_str(),
+            "sha256:47b3411659eddf390da230557216188e6fe4b56572f8f8545702fcc04a608e5b"
         );
     }
 

--- a/crates/mvm-core/src/plan/test_support.rs
+++ b/crates/mvm-core/src/plan/test_support.rs
@@ -36,6 +36,7 @@ pub struct PlanFixture {
     stream_edges: Vec<mvm_contract::stream::StreamEdge>,
     stream_retention: StreamRetention,
     audit_labels: BTreeMap<String, String>,
+    grants: Option<mvm_contract::grants::Grants>,
 }
 
 impl Default for PlanFixture {
@@ -53,6 +54,7 @@ impl Default for PlanFixture {
             stream_edges: Vec::new(),
             stream_retention: StreamRetention::default(),
             audit_labels: BTreeMap::new(),
+            grants: None,
         }
     }
 }
@@ -116,6 +118,13 @@ impl PlanFixture {
         self
     }
 
+    /// The permission set this plan is admitted under. Default `None`, which a
+    /// restore reads as unbounded CPU and wall clock but deny-all egress.
+    pub fn grants(mut self, grants: Option<mvm_contract::grants::Grants>) -> Self {
+        self.grants = grants;
+        self
+    }
+
     /// Pin an explicit validity window. Without this the plan is valid from
     /// `now` to `now + 10min`.
     pub fn validity(mut self, from: DateTime<Utc>, until: DateTime<Utc>) -> Self {
@@ -127,7 +136,7 @@ impl PlanFixture {
     pub fn build(self) -> ExecutionPlan {
         let now = Utc::now();
         ExecutionPlan {
-            grants: None,
+            grants: self.grants,
             environment: None,
             build_provenance: Default::default(),
             snapshot_at: Default::default(),

--- a/crates/mvm-runtime/src/checkpoint/mod.rs
+++ b/crates/mvm-runtime/src/checkpoint/mod.rs
@@ -573,24 +573,37 @@ fn validate_child_fork_plan(
         plan.valid_from <= now && now < plan.valid_until,
         "admitted child plan is outside its validity window"
     );
-    // An absent parent record is `Grants::default()`, not "unchecked": that
-    // still leaves CPU and wall clock open (absent means unbounded) while
-    // holding egress closed (absent means deny-all). Skipping the call instead
-    // would silently open egress.
+    ensure_child_grants_within_parent(plan.grants.as_ref(), parent_grants)?;
+    Ok(plan.grants)
+}
+
+/// Refuse a child whose grants exceed the permission set its parent checkpoint
+/// was sealed under.
+///
+/// The one decision point for "may this child run under these grants, given the
+/// parent it came from". Both restore paths call it — the vm_full fork and the
+/// warm-pool claim — because two implementations of a rule like this drift, and
+/// a path without one is exactly the hole this exists to close.
+///
+/// Either side being `None` means `Grants::default()`, never "unchecked". That
+/// leaves CPU and wall clock open (absent means unbounded) while holding egress
+/// closed (absent means deny-all); skipping the call instead would silently open
+/// egress on the very paths that most need it shut.
+pub fn ensure_child_grants_within_parent(
+    child: Option<&mvm_contract::grants::Grants>,
+    parent: Option<&mvm_contract::grants::Grants>,
+) -> Result<()> {
     let unbounded_cpu_deny_all_egress = mvm_contract::grants::Grants::default();
     mvm_contract::grants::subset::grants_are_subset(
-        plan.grants
-            .as_ref()
-            .unwrap_or(&unbounded_cpu_deny_all_egress),
-        parent_grants.unwrap_or(&unbounded_cpu_deny_all_egress),
+        child.unwrap_or(&unbounded_cpu_deny_all_egress),
+        parent.unwrap_or(&unbounded_cpu_deny_all_egress),
     )
     .map_err(|widening| {
         anyhow::anyhow!(
             "admitted child plan exceeds the permission set its parent checkpoint was \
              captured under: {widening}"
         )
-    })?;
-    Ok(plan.grants)
+    })
 }
 
 /// Liveness probe for a VM by name: any backend pid marker whose process still

--- a/crates/mvm-runtime/src/checkpoint/mod.rs
+++ b/crates/mvm-runtime/src/checkpoint/mod.rs
@@ -131,6 +131,12 @@ pub struct CaptureFsQuickParams {
     /// capture is refused: an fs_quick checkpoint has no memory, so the rootfs
     /// must be in a clean, deterministic state.
     pub quiesced: bool,
+    /// The permission set the captured VM was admitted under, sealed into the
+    /// checkpoint's content-address so a restore has something to bound its
+    /// child against. `None` records no bound and therefore permits any child
+    /// CPU or wall clock — but still no egress, since an absent egress grant is
+    /// deny-all.
+    pub grants: Option<mvm_contract::grants::Grants>,
 }
 
 /// Inputs for forking a child instance from a checkpoint.
@@ -375,6 +381,10 @@ pub fn fork_checkpoint(
     .supervisor_config_digest(parent.supervisor_config_digest)
     .runtime_source_policy(parent.runtime_source_policy)
     .runtime_overlay_version(parent.runtime_overlay_version)
+    // An fs_quick branch presents no plan of its own, so the child inherits
+    // rather than restates the parent's permission set — inheritance is the
+    // only shape that cannot widen.
+    .grants(parent.grants.clone())
     .build();
     store.write_meta(&child)?;
     Ok(child)
@@ -427,7 +437,7 @@ pub fn fork_vm_full(
         );
     }
 
-    validate_child_fork_plan(&params)?;
+    let child_grants = validate_child_fork_plan(&params, parent.grants.as_ref())?;
 
     // Clone the captured triple into the child's state dir, then boot the child
     // from its OWN copies — never the parent's live blobs.
@@ -457,6 +467,10 @@ pub fn fork_vm_full(
     .supervisor_config_digest(parent.supervisor_config_digest)
     .runtime_source_policy(parent.runtime_source_policy)
     .runtime_overlay_version(parent.runtime_overlay_version)
+    // The child's OWN grants, already checked to sit inside the parent's. A
+    // grandchild is then bounded by what this restore actually got, not by the
+    // wider set its grandparent held.
+    .grants(child_grants)
     .build();
     store.write_meta(&child)?;
     Ok(child)
@@ -509,11 +523,23 @@ fn validate_fork_verity_binding(parent: &CheckpointMeta, child_dir: &Path) -> Re
     Ok(())
 }
 
-/// Validate the child admission envelope before a vm_full restore starts a VMM.
+/// Validate the child admission envelope before a vm_full restore starts a VMM,
+/// returning the permission set the child is admitted to run under.
+///
 /// The trusted-key signature check happens in the admission supervisor; this
 /// boundary still refuses missing, malformed, tenant-mismatched, stale, and
 /// incorrectly content-addressed envelopes before any child bytes are cloned.
-fn validate_child_fork_plan(params: &ForkParams) -> Result<()> {
+///
+/// It also refuses a child asking for more than `parent_grants`. Every other
+/// check here passes for a child that simply wants a bigger permission set: the
+/// child plan is separately signed and internally consistent, so without this
+/// comparison restore is a laundering path — admit tight, snapshot, restore
+/// loose. `parent_grants` comes off the parent's sealed checkpoint record,
+/// which is verified against the signed chain before this runs.
+fn validate_child_fork_plan(
+    params: &ForkParams,
+    parent_grants: Option<&mvm_contract::grants::Grants>,
+) -> Result<Option<mvm_contract::grants::Grants>> {
     let plan_json = params
         .child_plan_json
         .as_deref()
@@ -547,7 +573,24 @@ fn validate_child_fork_plan(params: &ForkParams) -> Result<()> {
         plan.valid_from <= now && now < plan.valid_until,
         "admitted child plan is outside its validity window"
     );
-    Ok(())
+    // An absent parent record is `Grants::default()`, not "unchecked": that
+    // still leaves CPU and wall clock open (absent means unbounded) while
+    // holding egress closed (absent means deny-all). Skipping the call instead
+    // would silently open egress.
+    let unbounded_cpu_deny_all_egress = mvm_contract::grants::Grants::default();
+    mvm_contract::grants::subset::grants_are_subset(
+        plan.grants
+            .as_ref()
+            .unwrap_or(&unbounded_cpu_deny_all_egress),
+        parent_grants.unwrap_or(&unbounded_cpu_deny_all_egress),
+    )
+    .map_err(|widening| {
+        anyhow::anyhow!(
+            "admitted child plan exceeds the permission set its parent checkpoint was \
+             captured under: {widening}"
+        )
+    })?;
+    Ok(plan.grants)
 }
 
 /// Liveness probe for a VM by name: any backend pid marker whose process still
@@ -590,6 +633,9 @@ pub struct CaptureVmFullParams {
     /// this is `false` on the CLI path. Retention still requires the backend to
     /// support it — the two must agree.
     pub retain_paused: bool,
+    /// The permission set the captured VM was admitted under. See
+    /// [`CaptureFsQuickParams::grants`].
+    pub grants: Option<mvm_contract::grants::Grants>,
 }
 
 /// Capture a running VM's consistent {rootfs, memory, machine-id} triple in one
@@ -838,6 +884,7 @@ fn capture_vm_full_inner(
         .runtime_source_policy(params.runtime_source_policy)
         .runtime_overlay_version(params.runtime_overlay_version)
         .snapshot_id(snapshot_id)
+        .grants(params.grants)
         .build();
     store.write_meta(&meta)?;
     Ok(meta)
@@ -1149,6 +1196,7 @@ pub fn capture_fs_quick(
         .supervisor_config_digest(params.supervisor_config_digest)
         .runtime_source_policy(params.runtime_source_policy)
         .runtime_overlay_version(params.runtime_overlay_version)
+        .grants(params.grants)
         .build();
     store.write_meta(&meta)?;
     Ok(meta)
@@ -1292,6 +1340,7 @@ mod tests {
             tag: None,
             created_unix: 7,
             quiesced: false,
+            grants: None,
         };
         let err = capture_fs_quick(&store, params).unwrap_err();
         assert!(err.to_string().contains("quiesced"));
@@ -1311,6 +1360,7 @@ mod tests {
                 tag: None,
                 created_unix: 1,
                 quiesced: true,
+                grants: None,
             },
         )
         .unwrap()
@@ -1422,6 +1472,7 @@ mod tests {
                 tag: None,
                 created_unix: 1,
                 quiesced: true,
+                grants: None,
             },
         )
         .unwrap()
@@ -1465,6 +1516,7 @@ mod tests {
                 tag: None,
                 created_unix: 1,
                 quiesced: true,
+                grants: None,
             },
         )
         .unwrap();
@@ -1626,6 +1678,7 @@ mod tests {
                 tag: None,
                 created_unix: 9,
                 retain_paused,
+                grants: None,
             },
             &ctl,
         )
@@ -1676,6 +1729,7 @@ mod tests {
                 tag: None,
                 created_unix: 9,
                 retain_paused: false,
+                grants: None,
             },
             &ctl,
         )
@@ -1728,6 +1782,7 @@ mod tests {
                 tag: None,
                 created_unix: 10,
                 retain_paused: false,
+                grants: None,
             },
             &ctl,
         )
@@ -1791,6 +1846,7 @@ mod tests {
                 tag: None,
                 created_unix: 11,
                 retain_paused: false,
+                grants: None,
             },
             &ctl,
         )
@@ -1847,6 +1903,7 @@ mod tests {
                 tag: None,
                 created_unix: 1,
                 retain_paused: false,
+                grants: None,
             },
             &ctl,
         )
@@ -1956,6 +2013,7 @@ mod tests {
             tag: Some("gold".into()),
             created_unix: 7,
             quiesced: true,
+            grants: None,
         };
         let meta = capture_fs_quick(&store, params).unwrap();
         let content_blob = store.content_dir(&meta.id).join("rootfs.ext4");
@@ -2139,6 +2197,7 @@ mod tests {
                 tag: None,
                 created_unix: 1,
                 retain_paused: false,
+                grants: None,
             },
             &ctl,
         )
@@ -2200,6 +2259,7 @@ mod tests {
                 tag: None,
                 created_unix: 2,
                 retain_paused: false,
+                grants: None,
             },
             &ctl,
         )
@@ -2403,6 +2463,15 @@ mod tests {
     /// Seeds an FC-shaped vm_full checkpoint: {rootfs.ext4, memory.bin,
     /// vmstate.bin}, no supervisor-config.json, no machine-id.
     fn seed_fc_vm_full_checkpoint(store: &CheckpointStore, tmp: &Path, id: &str) -> CheckpointMeta {
+        seed_fc_vm_full_checkpoint_with_grants(store, tmp, id, None)
+    }
+
+    fn seed_fc_vm_full_checkpoint_with_grants(
+        store: &CheckpointStore,
+        tmp: &Path,
+        id: &str,
+        grants: Option<mvm_contract::grants::Grants>,
+    ) -> CheckpointMeta {
         let rootfs = tmp.join(format!("{id}-live.ext4"));
         std::fs::write(&rootfs, b"disk").unwrap();
         let checkpoint_id = CheckpointId::new(id);
@@ -2430,6 +2499,7 @@ mod tests {
                 tag: None,
                 created_unix: 1,
                 retain_paused: false,
+                grants,
             },
             &ctl,
         )
@@ -2437,9 +2507,16 @@ mod tests {
     }
 
     fn admitted_child_plan() -> (String, String) {
+        admitted_child_plan_with_grants(None)
+    }
+
+    fn admitted_child_plan_with_grants(
+        grants: Option<mvm_contract::grants::Grants>,
+    ) -> (String, String) {
         let plan = mvm_core::plan::test_support::PlanFixture::new()
             .tenant("local")
             .workload("fc-childvm")
+            .grants(grants)
             .build();
         let signer = ed25519_dalek::SigningKey::from_bytes(&[91u8; 32]);
         let signed = mvm_core::plan::sign_plan(&plan, &signer, "test-signer");
@@ -2546,17 +2623,19 @@ mod tests {
             child_tenant_id,
         };
 
-        let err = validate_child_fork_plan(&params(
-            Some("not-json".to_string()),
-            Some("local".to_string()),
-        ))
+        let err = validate_child_fork_plan(
+            &params(Some("not-json".to_string()), Some("local".to_string())),
+            None,
+        )
         .unwrap_err();
         assert!(err.to_string().contains("decoding the admitted child"));
 
         let (valid_json, _) = admitted_child_plan();
-        let err =
-            validate_child_fork_plan(&params(Some(valid_json), Some("wrong-tenant".to_string())))
-                .unwrap_err();
+        let err = validate_child_fork_plan(
+            &params(Some(valid_json), Some("wrong-tenant".to_string())),
+            None,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("does not match"));
 
         let expired = mvm_core::plan::test_support::PlanFixture::new()
@@ -2569,12 +2648,252 @@ mod tests {
             .build();
         let signer = ed25519_dalek::SigningKey::from_bytes(&[92u8; 32]);
         let signed = mvm_core::plan::sign_plan(&expired, &signer, "test-signer");
-        let err = validate_child_fork_plan(&params(
-            Some(serde_json::to_string(&signed).unwrap()),
-            Some("local".to_string()),
-        ))
+        let err = validate_child_fork_plan(
+            &params(
+                Some(serde_json::to_string(&signed).unwrap()),
+                Some("local".to_string()),
+            ),
+            None,
+        )
         .unwrap_err();
         assert!(err.to_string().contains("outside its validity window"));
+    }
+
+    // ── restore may not launder a permission set ────────────────────────────
+
+    fn share(millicores: u32) -> Option<mvm_contract::grants::CpuGrant> {
+        Some(mvm_contract::grants::CpuGrant::Share { millicores })
+    }
+
+    fn destinations(hosts: &[(&str, u16)]) -> Option<mvm_contract::grants::EgressGrant> {
+        Some(mvm_contract::grants::EgressGrant {
+            allow: hosts
+                .iter()
+                .map(|(h, p)| mvm_core::network_policy::HostPort::new(*h, *p))
+                .collect(),
+        })
+    }
+
+    /// Fork a child carrying `child_grants` out of a parent captured under
+    /// `parent_grants`. The whole restore path runs, so a refusal here is a
+    /// refusal before any VMM starts.
+    fn fork_child_under(
+        tmp: &Path,
+        id: &str,
+        parent_grants: Option<mvm_contract::grants::Grants>,
+        child_grants: Option<mvm_contract::grants::Grants>,
+    ) -> Result<CheckpointMeta> {
+        let store = CheckpointStore::at(tmp.join(format!("{id}-store")));
+        let parent = seed_fc_vm_full_checkpoint_with_grants(&store, tmp, id, parent_grants);
+        let (child_plan_json, child_tenant_id) = admitted_child_plan_with_grants(child_grants);
+        let restorer = RecordedRestore::default();
+        fork_vm_full(
+            &store,
+            ForkParams {
+                checkpoint: parent.id,
+                child_id: CheckpointId::new(format!("{id}-child")),
+                child_vm_name: "fc-childvm".into(),
+                dest_dir: tmp.join(format!("{id}-child-state")),
+                created_unix: 2,
+                child_plan_json: Some(child_plan_json),
+                child_tenant_id: Some(child_tenant_id),
+            },
+            &restorer.restore(),
+            &AgreeingAnchor,
+        )
+    }
+
+    #[test]
+    fn a_restored_child_may_narrow_every_dimension_of_its_parents_grants() {
+        let tmp = tempfile::tempdir().unwrap();
+        let child = fork_child_under(
+            tmp.path(),
+            "narrow",
+            Some(mvm_contract::grants::Grants {
+                cpu: share(4000),
+                wall_clock: Some(mvm_contract::grants::WallClockGrant::Secs {
+                    secs: std::num::NonZeroU32::new(600).unwrap(),
+                }),
+                egress: destinations(&[("api.example.com", 443), ("pypi.org", 443)]),
+            }),
+            Some(mvm_contract::grants::Grants {
+                cpu: share(1000),
+                wall_clock: Some(mvm_contract::grants::WallClockGrant::Secs {
+                    secs: std::num::NonZeroU32::new(60).unwrap(),
+                }),
+                egress: destinations(&[("api.example.com", 443)]),
+            }),
+        )
+        .expect("a narrowing child is admitted");
+        // The child records its OWN narrower set, so a grandchild is bounded by
+        // what this restore actually got rather than by the grandparent's.
+        assert_eq!(child.grants.as_ref().and_then(|g| g.cpu), share(1000));
+    }
+
+    #[test]
+    fn a_restored_child_may_not_widen_its_parents_cpu_share() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = fork_child_under(
+            tmp.path(),
+            "widen-cpu",
+            Some(mvm_contract::grants::Grants {
+                cpu: share(1000),
+                ..Default::default()
+            }),
+            Some(mvm_contract::grants::Grants {
+                cpu: share(4000),
+                ..Default::default()
+            }),
+        )
+        .expect_err("a widening child must be refused");
+        assert!(
+            err.to_string().contains("exceeds the parent's 1000"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn a_restored_child_may_not_widen_its_parents_wall_clock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = fork_child_under(
+            tmp.path(),
+            "widen-clock",
+            Some(mvm_contract::grants::Grants {
+                wall_clock: Some(mvm_contract::grants::WallClockGrant::Secs {
+                    secs: std::num::NonZeroU32::new(60).unwrap(),
+                }),
+                ..Default::default()
+            }),
+            Some(mvm_contract::grants::Grants {
+                wall_clock: Some(mvm_contract::grants::WallClockGrant::Unbounded),
+                ..Default::default()
+            }),
+        )
+        .expect_err("an unbounded child clock must be refused");
+        assert!(
+            err.to_string().contains("unbounded wall clock"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn a_restored_child_may_not_drop_a_cpu_bound_its_parent_carried() {
+        // The laundering shape that looks most innocent: the child simply
+        // declares nothing. Absent means unbounded, so this is the widest ask.
+        let tmp = tempfile::tempdir().unwrap();
+        let err = fork_child_under(
+            tmp.path(),
+            "drop-cpu",
+            Some(mvm_contract::grants::Grants {
+                cpu: share(1000),
+                ..Default::default()
+            }),
+            None,
+        )
+        .expect_err("dropping the parent's bound must be refused");
+        assert!(
+            err.to_string().contains("drops the parent's CPU bound"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn a_restored_child_may_not_swap_the_unit_of_its_parents_cpu_bound() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = fork_child_under(
+            tmp.path(),
+            "unit-swap",
+            Some(mvm_contract::grants::Grants {
+                cpu: Some(mvm_contract::grants::CpuGrant::Fuel { instructions: 10 }),
+                ..Default::default()
+            }),
+            Some(mvm_contract::grants::Grants {
+                cpu: share(1),
+                ..Default::default()
+            }),
+        )
+        .expect_err("mismatched CPU units must be refused");
+        assert!(
+            err.to_string().contains("different units"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn a_restored_child_may_not_reach_a_destination_its_parent_could_not() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = fork_child_under(
+            tmp.path(),
+            "widen-egress",
+            Some(mvm_contract::grants::Grants {
+                egress: destinations(&[("api.example.com", 443)]),
+                ..Default::default()
+            }),
+            Some(mvm_contract::grants::Grants {
+                egress: destinations(&[("api.example.com", 443), ("evil.example.com", 443)]),
+                ..Default::default()
+            }),
+        )
+        .expect_err("an unadmitted destination must be refused");
+        assert!(
+            err.to_string().contains("evil.example.com:443"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn a_tampered_parent_grant_record_cannot_justify_a_wider_child() {
+        // Widening the parent's sealed record on disk is the way around a
+        // subset check that trusts it. The grant is inside the record's
+        // content-address, so the edit is caught before the comparison runs.
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let parent = seed_fc_vm_full_checkpoint_with_grants(
+            &store,
+            tmp.path(),
+            "tampered",
+            Some(mvm_contract::grants::Grants {
+                cpu: share(1000),
+                ..Default::default()
+            }),
+        );
+
+        let meta_path = store.dir_for(&parent.id).join("meta.json");
+        let mut raw: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&meta_path).unwrap()).unwrap();
+        raw["grants"]["cpu"]["millicores"] = serde_json::json!(64_000);
+        std::fs::write(&meta_path, serde_json::to_vec(&raw).unwrap()).unwrap();
+        // The stored content-address is untouched — only the grant moved.
+        let reread = store.read_meta(&parent.id).unwrap();
+        assert_eq!(reread.meta_digest, parent.meta_digest);
+        assert_eq!(reread.grants.and_then(|g| g.cpu), share(64_000));
+
+        let (child_plan_json, child_tenant_id) =
+            admitted_child_plan_with_grants(Some(mvm_contract::grants::Grants {
+                cpu: share(64_000),
+                ..Default::default()
+            }));
+        let restorer = RecordedRestore::default();
+        let err = fork_vm_full(
+            &store,
+            ForkParams {
+                checkpoint: parent.id,
+                child_id: CheckpointId::new("tampered-child"),
+                child_vm_name: "fc-childvm".into(),
+                dest_dir: tmp.path().join("tampered-child-state"),
+                created_unix: 2,
+                child_plan_json: Some(child_plan_json),
+                child_tenant_id: Some(child_tenant_id),
+            },
+            &restorer.restore(),
+            &AgreeingAnchor,
+        )
+        .expect_err("a post-seal edit of the parent's grant must be refused");
+        assert!(
+            err.to_string().contains("meta_digest drift"),
+            "unexpected error: {err}"
+        );
+        assert!(restorer.seen.borrow().is_none(), "no VMM may have started");
     }
 
     #[test]

--- a/crates/mvm-runtime/src/mock.rs
+++ b/crates/mvm-runtime/src/mock.rs
@@ -130,6 +130,7 @@ impl MockBackend {
                 tag: None,
                 created_unix: mvm_core::time::now_unix_secs(),
                 quiesced: true,
+                grants: None,
             },
         )
         .map_err(|e| StandbyError::SpawnFailed(format!("capture mock standby parent: {e}")))?;

--- a/crates/mvm-runtime/src/warm_snapshot.rs
+++ b/crates/mvm-runtime/src/warm_snapshot.rs
@@ -151,6 +151,7 @@ mod tests {
                 tag: None,
                 created_unix: 1,
                 quiesced: true,
+                grants: None,
             },
         )
         .unwrap()

--- a/crates/mvm-runtime/src/workload_runner/claim.rs
+++ b/crates/mvm-runtime/src/workload_runner/claim.rs
@@ -42,6 +42,12 @@ pub enum ClaimRefusal {
     PlanMissing,
     #[error("plan image digest {expected} does not match parent rootfs digest {got}")]
     PlanParentMismatch { expected: String, got: String },
+    /// The claimed child asked for more than the parent it is restored from was
+    /// sealed under. Same rule and same code path as a vm_full fork's — a warm
+    /// claim restores a child out of a parent's memory just as a fork does, so
+    /// it cannot be the one restore path that skips the comparison.
+    #[error("{reason}")]
+    GrantsExceedParent { reason: String },
 }
 
 /// Name of the [`mvm_core::checkpoint::ContentBlob`] holding the parent's

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -887,6 +887,7 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
             tag: None,
             created_unix: mvm_core::time::now_unix_secs(),
             retain_paused: true,
+            grants: None,
         };
         let trusted_backend = if cfg!(all(feature = "trusted-apfs", target_os = "macos"))
             && std::env::var("MVM_HVF_ENABLE_TRUSTED_SNAPSHOT").as_deref() == Ok("1")
@@ -3306,6 +3307,7 @@ mod tests {
                 tag: None,
                 created_unix: 1,
                 quiesced: true,
+                grants: None,
             },
         )
         .unwrap();

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -28,7 +28,7 @@ use mvm_fs::snapshot_store::{FsSnapshotStore, SnapshotStore};
 use crate::checkpoint::{
     CaptureVmFullParams, CheckpointChainAnchor, CheckpointStore, VmFullControl,
     capture_vm_full_with_snapshot_store, capture_vm_full_with_trusted_snapshot_backend,
-    verify_content, verify_lineage,
+    ensure_child_grants_within_parent, verify_content, verify_lineage,
 };
 use crate::driver::{
     ChildForkRequest, PreloadChildRequest, RunningVm, RunningVmStopTiming, StandbyParentSpawn,
@@ -571,6 +571,20 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
         // A missing plan or a digest mismatch refuses before any child side effect.
         let plan = claim_plan(claim)?;
         bind_plan_to_parent(&plan.image.sha256, &parent).map_err(refuse)?;
+        // The same comparison a vm_full fork makes, against the same
+        // chain-verified parent record and through the same predicate. A warm
+        // claim restores a child out of a parent's saved memory exactly as a
+        // fork does, so it must not be the one restore path where a child can
+        // ask for more than its parent held. Placed beside the image-digest
+        // bind — both bind the admitted plan to this verified parent — and
+        // before the child gets an identity, a state dir, or any bytes.
+        ensure_child_grants_within_parent(plan.grants.as_ref(), parent.grants.as_ref()).map_err(
+            |e| {
+                refuse(ClaimRefusal::GrantsExceedParent {
+                    reason: e.to_string(),
+                })
+            },
+        )?;
 
         // (6a) Fresh, registry-unique identity for the child.
         let child = match preloaded_child_name.clone() {
@@ -887,6 +901,20 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
             tag: None,
             created_unix: mvm_core::time::now_unix_secs(),
             retain_paused: true,
+            // A decision, not an omission. A factory parent holds no plan and
+            // no tenant by construction — `factory_parent_config` drops
+            // `plan_json` and `cpu_grant` precisely so a parent cannot carry a
+            // grant admitted for some other workload, and one parent serves
+            // every later claim against this pool. Sealing the mirrored
+            // launch's grant here would bind all of them to whichever workload
+            // happened to provision the pool.
+            //
+            // Sealing nothing is not the same as checking nothing: the claim
+            // path still compares, and an absent parent grant is deny-all
+            // egress, so a claimed child asking to reach anywhere is refused.
+            // It leaves CPU and wall clock unbounded by the *parent*; those are
+            // bounded for a warm child by the host ceiling its own plan was
+            // admitted against, never by this record.
             grants: None,
         };
         let trusted_backend = if cfg!(all(feature = "trusted-apfs", target_os = "macos"))
@@ -3281,6 +3309,22 @@ mod tests {
         CheckpointId,
         CheckpointMeta,
     ) {
+        seed_audited_parent_with_grants(store_root, src_root, with_overlay_sidecar, None)
+    }
+
+    /// Seed a warm parent whose sealed record carries `grants`, so a claim has a
+    /// real permission set to be bounded against.
+    fn seed_audited_parent_with_grants(
+        store_root: &Path,
+        src_root: &Path,
+        with_overlay_sidecar: bool,
+        grants: Option<mvm_contract::grants::Grants>,
+    ) -> (
+        CheckpointStore,
+        FsSnapshotStore,
+        CheckpointId,
+        CheckpointMeta,
+    ) {
         let checkpoints = CheckpointStore::at(store_root.join("checkpoints"));
         let snapshots = FsSnapshotStore::new(store_root.join("snapshots")).unwrap();
 
@@ -3307,7 +3351,7 @@ mod tests {
                 tag: None,
                 created_unix: 1,
                 quiesced: true,
-                grants: None,
+                grants,
             },
         )
         .unwrap();
@@ -3480,6 +3524,19 @@ mod tests {
     /// the CLI mints it before handing the runner the claim.
     fn signed_child_plan_json(image_sha256: &str) -> String {
         signed_child_plan_json_with_verbs(image_sha256, None)
+    }
+
+    fn signed_child_plan_json_with_grants(
+        image_sha256: &str,
+        grants: Option<mvm_contract::grants::Grants>,
+    ) -> String {
+        let mut plan = mvm_core::plan::test_support::PlanFixture::new()
+            .tenant("tenant-x")
+            .grants(grants)
+            .build();
+        plan.image.sha256 = image_sha256.to_string();
+        let key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        serde_json::to_string(&mvm_core::plan::sign_plan(&plan, &key, "host:test")).unwrap()
     }
 
     fn signed_child_plan_json_with_verbs(
@@ -4461,6 +4518,146 @@ mod tests {
             "no child dir on a plan/parent mismatch"
         );
         assert!(runner.driver.forked_children().is_empty());
+    }
+
+    /// A warm claim restores a child out of a parent's saved state exactly as a
+    /// vm_full fork does, so it must run the same subset check. A parent sealed
+    /// under a tight CPU share cannot hand a claimed child a wider one.
+    #[test]
+    fn claim_refuses_a_child_whose_grants_exceed_the_parents() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
+        let store_root = tempfile::tempdir().unwrap();
+        let src = tempfile::tempdir().unwrap();
+        let (checkpoints, snapshots, parent_id, parent_meta) = seed_audited_parent_with_grants(
+            store_root.path(),
+            src.path(),
+            true,
+            Some(mvm_contract::grants::Grants {
+                cpu: Some(mvm_contract::grants::CpuGrant::Share { millicores: 1000 }),
+                ..Default::default()
+            }),
+        );
+        let parent_digest = parent_rootfs_digest(&parent_meta).unwrap().to_string();
+
+        let pool = SupervisorStandbyPool::at(store_root.path().join("pool"));
+        let handle = idle_parent_handle("warm-parent", &store_root.path().join("control.sock"));
+        pool.record(&handle).unwrap();
+        let registry_path = store_root.path().join("vm-names.json");
+        let anchor = ClaimTestAnchor::audited(&parent_meta);
+
+        // Bound to the parent's own rootfs, so the image-digest bind passes and
+        // the grants comparison is what refuses.
+        let claim = admitted_child_claim(
+            &src.path().join("rootfs.ext4"),
+            signed_child_plan_json_with_grants(
+                &parent_digest,
+                Some(mvm_contract::grants::Grants {
+                    cpu: Some(mvm_contract::grants::CpuGrant::Share { millicores: 4000 }),
+                    ..Default::default()
+                }),
+            ),
+        );
+
+        let runner = WorkloadRunner::new(
+            MockDriver::default(),
+            KeyingSpawner::default(),
+            RecordingBrokerRegistrar::new(),
+        );
+        let ctx = ClaimContext {
+            pool: &pool,
+            checkpoints: &checkpoints,
+            snapshots: &snapshots,
+            anchor: &anchor,
+            parent_checkpoint: &parent_id,
+            registry_path: &registry_path,
+            grant_issuer: None,
+        };
+
+        let err = runner
+            .claim_standby(&ctx, &handle, &claim)
+            .expect_err("a claimed child may not widen its parent's grants");
+        assert!(
+            err.to_string().contains("exceeds the parent's 1000"),
+            "refusal must name the widening: {err}"
+        );
+
+        // Not the parent's fault, so warm capacity is returned rather than
+        // quarantined, and nothing was minted for the refused child.
+        assert_eq!(
+            pool.load("warm-parent").unwrap().state,
+            StandbyState::Idle,
+            "a child-side grant widening must return the parent to claimable"
+        );
+        assert_eq!(orphan_child_dirs(), 0, "no child dir on a grant widening");
+        assert!(runner.driver.forked_children().is_empty());
+    }
+
+    /// The other side of the same check: a claimed child that narrows, or that
+    /// matches, is admitted. Without this the refusal test above would pass just
+    /// as well against a check that refused every claim.
+    #[test]
+    fn claim_admits_a_child_that_narrows_the_parents_grants() {
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", home.path());
+
+        let store_root = tempfile::tempdir().unwrap();
+        let src = tempfile::tempdir().unwrap();
+        let (checkpoints, snapshots, parent_id, parent_meta) = seed_audited_parent_with_grants(
+            store_root.path(),
+            src.path(),
+            true,
+            Some(mvm_contract::grants::Grants {
+                cpu: Some(mvm_contract::grants::CpuGrant::Share { millicores: 4000 }),
+                ..Default::default()
+            }),
+        );
+        let parent_digest = parent_rootfs_digest(&parent_meta).unwrap().to_string();
+
+        let pool = SupervisorStandbyPool::at(store_root.path().join("pool"));
+        let handle = idle_parent_handle("warm-parent", &store_root.path().join("control.sock"));
+        pool.record(&handle).unwrap();
+        let registry_path = store_root.path().join("vm-names.json");
+        let anchor = ClaimTestAnchor::audited(&parent_meta);
+
+        let claim = admitted_child_claim(
+            &src.path().join("rootfs.ext4"),
+            signed_child_plan_json_with_grants(
+                &parent_digest,
+                Some(mvm_contract::grants::Grants {
+                    cpu: Some(mvm_contract::grants::CpuGrant::Share { millicores: 1000 }),
+                    ..Default::default()
+                }),
+            ),
+        );
+
+        let runner = WorkloadRunner::new(
+            MockDriver::default(),
+            KeyingSpawner::default(),
+            RecordingBrokerRegistrar::new(),
+        );
+        let ctx = ClaimContext {
+            pool: &pool,
+            checkpoints: &checkpoints,
+            snapshots: &snapshots,
+            anchor: &anchor,
+            parent_checkpoint: &parent_id,
+            registry_path: &registry_path,
+            grant_issuer: None,
+        };
+
+        runner
+            .claim_standby(&ctx, &handle, &claim)
+            .expect("a narrowing child must still be claimable");
     }
 
     /// A parent whose sealed `meta.json` is edited after capture — without

--- a/crates/mvm-runtime/tests/fc_warm_pool_live.rs
+++ b/crates/mvm-runtime/tests/fc_warm_pool_live.rs
@@ -227,6 +227,7 @@ fn fc_warm_pool_spawn_and_claim() {
             tag: None,
             created_unix: mvm_core::time::now_unix_secs(),
             retain_paused: false,
+            grants: None,
         },
         control.as_ref(),
     )

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1147,8 +1147,13 @@ for detailed scope and acceptance criteria.
         landing, so a bounded boot's *reported tier* is unwitnessed on hardware
   - [ ] WS5 — wasm fuel **and** epoch (fuel alone bounds nothing in a host
         call) + `StoreLimits`
-  - [ ] WS5b — grants across snapshot/fork/restore; child ⊆ parent, closing
-        the restore-laundering path
+  - [~] WS5b — grants across snapshot/fork/restore; child ⊆ parent, closing
+        the restore-laundering path. `grants_are_subset` in mvm-contract (CPU
+        and wall clock read absence as unbounded, egress as deny-all;
+        mismatched CPU units refused, never converted), `CheckpointMeta.grants`
+        inside the content-address so a tampered parent record cannot justify
+        a wider child, and the check wired into `validate_child_fork_plan`.
+        STILL OPEN: restore does not re-apply grants through `apply_grants`
   - [~] WS6 — four surfaces: manifest `[grants]`, `--grants-file` JSON,
         `--cpu-limit` CLI flag (`--timeout` supplies the wall-clock dimension),
         and `grants` on the `MachineSpec` DTO + `LaunchRequest` builder,

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1152,8 +1152,15 @@ for detailed scope and acceptance criteria.
         and wall clock read absence as unbounded, egress as deny-all;
         mismatched CPU units refused, never converted), `CheckpointMeta.grants`
         inside the content-address so a tampered parent record cannot justify
-        a wider child, and the check wired into `validate_child_fork_plan`.
-        STILL OPEN: restore does not re-apply grants through `apply_grants`
+        a wider child (skip-serialized when absent, so an older checkpoint
+        reads as schema-stale rather than tampered). BOTH restore paths check,
+        through one predicate `ensure_child_grants_within_parent`: the vm_full
+        fork and the warm-pool claim.
+        STILL OPEN: (a) restore does not re-apply grants through `apply_grants`;
+        (b) a warm parent seals no grant — a factory parent holds no plan or
+        `cpu_grant` by construction and one parent serves every claim, so
+        bounding a claimed child's CPU/wall clock needs a pool-level grant on
+        `StandbySpec`; its egress is already bounded (absent egress = deny-all)
   - [~] WS6 — four surfaces: manifest `[grants]`, `--grants-file` JSON,
         `--cpu-limit` CLI flag (`--timeout` supplies the wall-clock dimension),
         and `grants` on the `MachineSpec` DTO + `LaunchRequest` builder,

--- a/specs/plans/308-workload-grants.md
+++ b/specs/plans/308-workload-grants.md
@@ -1,6 +1,6 @@
 # Plan 308 — Workload grants: one declaration, per-backend enforcement
 
-**Status: IN FLIGHT — WS1, WS1b, WS2, WS3 complete; WS4 partial (CPU bound + prod gate landed, admission budget outstanding); WS5, WS5b, WS6, WS6b outstanding. No surface authors a grant yet, so the feature is inert by design until WS6.**
+**Status: IN FLIGHT — WS1, WS1b, WS2, WS3 complete; WS4 partial (CPU bound + prod gate landed, admission budget outstanding); WS5b partial (child ⊆ parent enforced and chain-anchored, `apply_grants` on restore outstanding); WS5, WS6, WS6b outstanding.**
 
 ## Why
 
@@ -321,7 +321,7 @@ cheapest and most rigorous, not the one where it is hardest.
       grant must be rejected at admission rather than accepted as partial
       enforcement.
 
-- [ ] **WS5b — Grants across snapshot, fork, and restore.**
+- [~] **WS5b — Grants across snapshot, fork, and restore.**
       Today's child-plan validation (`crates/mvm-runtime/src/checkpoint/mod.rs`)
       checks signature length, signer id, `verify_plan_id`, tenant match, and
       the validity window. It does not compare the child's resources against
@@ -333,6 +333,20 @@ cheapest and most rigorous, not the one where it is hardest.
       refuses a child whose grants are not a subset of its parent's. Same
       family as the restored-child authorization gap that disarmed the plan
       255 pool, so the two should be reviewed together.
+
+      LANDED: `mvm_contract::grants::subset::grants_are_subset` — CPU/wall
+      clock treat absence as *unbounded* (so a child dropping a bound has
+      widened), egress treats it as deny-all (so dropping it has narrowed),
+      and mismatched CPU units are refused rather than converted.
+      `CheckpointMeta.grants` is inside `CheckpointDigestInput`, so a parent
+      record edited to widen its own grant stops matching the digest the
+      signed chain recorded and is refused before the comparison runs. Capture
+      seals the VM's admitted grants; a vm_full fork checks the child plan's
+      set against the parent's in `validate_child_fork_plan` and records the
+      child's own (narrower) set; an fs_quick fork inherits the parent's.
+      STILL OPEN: restore does not re-apply the grants through `apply_grants`
+      the way a cold boot does — the child cannot be *admitted* wider, but
+      nothing re-arms the host-side control on the restored VM.
 
 - [ ] **WS6 — The four surfaces.**
       Manifest: `[grants]` table extending `ManifestMachineWorkflow`.

--- a/specs/plans/308-workload-grants.md
+++ b/specs/plans/308-workload-grants.md
@@ -340,13 +340,33 @@ cheapest and most rigorous, not the one where it is hardest.
       and mismatched CPU units are refused rather than converted.
       `CheckpointMeta.grants` is inside `CheckpointDigestInput`, so a parent
       record edited to widen its own grant stops matching the digest the
-      signed chain recorded and is refused before the comparison runs. Capture
-      seals the VM's admitted grants; a vm_full fork checks the child plan's
-      set against the parent's in `validate_child_fork_plan` and records the
-      child's own (narrower) set; an fs_quick fork inherits the parent's.
-      STILL OPEN: restore does not re-apply the grants through `apply_grants`
-      the way a cold boot does — the child cannot be *admitted* wider, but
-      nothing re-arms the host-side control on the restored VM.
+      signed chain recorded and is refused before the comparison runs (a
+      record sealing no grant is skip-serialized, so an older checkpoint keeps
+      its exact digest and reads as schema-stale rather than as tampered).
+      Capture seals the VM's admitted grants. **Both** restore paths run the
+      comparison through one predicate,
+      `checkpoint::ensure_child_grants_within_parent`: the vm_full fork in
+      `validate_child_fork_plan`, which records the child's own (narrower) set,
+      and the warm-pool claim in `claim_standby`, beside `bind_plan_to_parent`
+      and before the child has an identity or a byte. An fs_quick fork presents
+      no plan and inherits.
+
+      STILL OPEN, two gaps, both real:
+      (a) Restore does not re-apply the grants through `apply_grants` the way a
+      cold boot does — a child cannot be *admitted* wider, but nothing re-arms
+      the host-side control on the restored VM.
+      (b) A warm parent seals no grant, so it bounds a claimed child's egress
+      (absent egress is deny-all) but not its CPU or wall clock. Not an
+      oversight in the capture: a factory parent holds no plan, tenant or
+      `cpu_grant` by construction — `factory_parent_config` drops each so a
+      parent cannot carry authority admitted for some other workload — and one
+      parent serves every later claim, so sealing the provisioning workload's
+      grant would bound unrelated claims to a stranger's number. For the parent
+      to bound those dimensions the *pool* needs a grant of its own: a bound on
+      `StandbySpec`, plumbed from pool configuration and sealed at capture.
+      Until then a warm child's CPU and wall clock are bounded only by the host
+      `GrantCeiling` its own plan was admitted against. Belongs with the rest of
+      the warm-pool arming work.
 
 - [ ] **WS6 — The four surfaces.**
       Manifest: `[grants]` table extending `ManifestMachineWorkflow`.


### PR DESCRIPTION
## Summary

Closes the grant-laundering path through snapshot/restore. Plan 308 WS5b.

A workload's `Grants` live in its signed `ExecutionPlan`. Restore validated the child plan's signature shape, signer, `verify_plan_id`, tenant and validity window — but never compared the child's grants to the parent's. So a VM admitted under tight grants could be snapshotted and its child restored under loose ones, with every existing check passing, because the child plan is independently signed and internally consistent.

## The rules are asymmetric, and that is the point

A mechanical "child ⊆ parent" is wrong here:

- **CPU: absence means unbounded.** A child with no CPU grant under a parent that had one is a *widening*, and is refused.
- **Egress: absence means deny-all.** The same shape there is a *narrowing*, and is allowed.

Getting either backwards silently reopens the gap. Mismatched CPU units (`Share` under `Fuel`) are refused rather than converted, and an `Unbounded` wall clock under a bounded parent is a widening.

## Anchoring

`grants` joins `CheckpointMeta` and `CheckpointDigestInput`, so it inherits chain-anchoring rather than sitting beside it — a tampered parent grants record breaks digest verification. The subset check runs *after* `verify_checkpoint_against_chain` proves the parent un-tampered and *before* any child byte is cloned; a check against an unverified parent would prove nothing.

The check returns the child's grants so the child record seals its own narrower set, closing the grandchild re-widening hole. It compares against `Grants::default()` rather than skipping when either side is absent — skipping would have opened egress.

## Both restore paths

The warm-pool claim path is a second restore path with the same shape, and it is covered by the **same** predicate (`ensure_child_grants_within_parent`) — one rule, one implementation, two call sites. A second implementation of a security rule is how the original gap appeared.

The parent's grant is deliberately **not** sealed on standby capture. `factory_parent_config` already drops `plan_json` and `cpu_grant` so a parent cannot carry a grant admitted for another workload, and one parent serves every later claim — sealing the provisioning workload's grant would bind unrelated claims to it, refusing legitimate ones while protecting nothing.

## Known gaps, declared not hidden

Restore does not re-arm the host-side CPU control, so a restored child is admission-bounded but runs CPU-unbounded — the bound is a ledger entry, not an enforcement. Egress is the exception (the fork path forces deny-all). Warm-claimed children are unbounded *by the parent* for CPU/wall clock; bounding them needs a pool-level grant on `StandbySpec`. Both recorded in the plan and rollup as WS5b gaps.

## Validation

`cargo nextest run --workspace` — 11,000 passed, 0 failed. Tests compile (`--no-run`) and both feature lanes (`mvm-client/test-support`, `mvm-sdk/client-facade`) check clean.
