### PR TITLE
Fix long-running console input and shutdown

### DIFF
--- a/crates/mvm-agentd/src/console.rs
+++ b/crates/mvm-agentd/src/console.rs
@@ -9,7 +9,7 @@
 //! authenticated vsock protocol).
 
 use std::io::{Read, Write};
-use std::os::fd::{FromRawFd, RawFd};
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use crate::vsock::{CONSOLE_PORT_BASE, HOST_CID};
@@ -487,9 +487,12 @@ pub fn run_console_relay(session: &ConsoleSession) -> i32 {
         return close_session(session);
     };
 
-    // Set read timeout for idle detection (15 minutes)
-    let idle_timeout = std::time::Duration::from_secs(15 * 60);
-    let _ = vsock_read.set_read_timeout(Some(idle_timeout));
+    // Output-only programs remain interactive: a lack of keyboard input must
+    // never silently retire the only thread capable of forwarding Ctrl-C.
+    if let Err(error) = configure_console_input(&vsock_read) {
+        eprintln!("console: failed to configure input stream: {error}");
+        return close_session(session);
+    }
 
     // SAFETY: `master_fd` is the PTY master from openpty; we transfer sole
     // ownership of it to this File.
@@ -500,38 +503,30 @@ pub fn run_console_relay(session: &ConsoleSession) -> i32 {
         return close_session(session);
     };
 
-    let done = std::sync::Arc::new(AtomicBool::new(false));
-    let done2 = done.clone();
-
     // vsock → PTY (host input → shell)
-    // Idle timeout: if no input for 15 minutes, the read times out and we close.
     let h1 = std::thread::spawn(move || {
         let mut buf = [0u8; 4096];
         loop {
             match vsock_read.read(&mut buf) {
-                Ok(0) => {
-                    done2.store(true, Ordering::SeqCst);
-                    break;
-                }
-                Err(ref e)
-                    if e.kind() == std::io::ErrorKind::WouldBlock
-                        || e.kind() == std::io::ErrorKind::TimedOut =>
-                {
-                    eprintln!("console: idle timeout reached, closing session");
-                    done2.store(true, Ordering::SeqCst);
-                    break;
-                }
-                Err(_) => {
-                    done2.store(true, Ordering::SeqCst);
-                    break;
-                }
+                Ok(0) => break,
+                Err(ref error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
                 Ok(n) => {
                     if pty_write.write_all(&buf[..n]).is_err() {
-                        done2.store(true, Ordering::SeqCst);
                         break;
                     }
                 }
             }
+        }
+
+        // A host disconnect or local escape ends the console session. Terminate
+        // the PTY foreground process group so the output pump cannot remain
+        // blocked forever on a command such as `top`.
+        terminate_console_processes(child_pid, pty_write.as_raw_fd());
+        // SAFETY: `conn_fd` is the socket underlying `vsock_read`; shutdown
+        // wakes the cloned writer without taking ownership from either thread.
+        unsafe {
+            shutdown(conn_fd, SHUT_RDWR);
         }
     });
 
@@ -583,6 +578,34 @@ pub fn run_console_relay(session: &ConsoleSession) -> i32 {
     };
     record_completed_session(session.session_id, exit_code);
     exit_code
+}
+
+fn configure_console_input(stream: &std::os::unix::net::UnixStream) -> std::io::Result<()> {
+    stream.set_read_timeout(None)
+}
+
+fn terminate_console_processes(child_pid: i32, pty_fd: RawFd) {
+    // The interactive shell may have placed its current job in a distinct
+    // foreground process group. Signal that group first, then the shell/session
+    // leader itself. ESRCH is expected when either already exited.
+    let foreground = unsafe { libc::tcgetpgrp(pty_fd) };
+    for target in console_signal_targets(child_pid, foreground)
+        .into_iter()
+        .flatten()
+    {
+        // SAFETY: a negative target addresses the PTY foreground process group;
+        // a positive target is the child created for this console session.
+        unsafe {
+            kill(target, SIGTERM);
+        }
+    }
+}
+
+fn console_signal_targets(child_pid: i32, foreground: i32) -> [Option<i32>; 2] {
+    [
+        (foreground > 0).then(|| -foreground),
+        (foreground != child_pid).then_some(child_pid),
+    ]
 }
 
 /// Check if a console session is currently active.
@@ -881,6 +904,41 @@ mod tests {
             libc::WEXITSTATUS(status),
             0,
             "child could not open /dev/tty — no controlling terminal acquired"
+        );
+    }
+
+    #[test]
+    fn console_input_has_no_one_way_idle_timeout() {
+        let (stream, _peer) = std::os::unix::net::UnixStream::pair().expect("socket pair");
+        stream
+            .set_read_timeout(Some(std::time::Duration::from_millis(1)))
+            .expect("install test timeout");
+
+        configure_console_input(&stream).expect("configure console input");
+
+        assert_eq!(
+            stream.read_timeout().expect("read timeout"),
+            None,
+            "guest output may keep a console useful indefinitely, so host input must not expire"
+        );
+    }
+
+    #[test]
+    fn console_disconnect_targets_the_foreground_job_and_session_leader() {
+        assert_eq!(
+            console_signal_targets(42, 77),
+            [Some(-77), Some(42)],
+            "an interactive foreground job may be in a different process group"
+        );
+        assert_eq!(
+            console_signal_targets(42, 42),
+            [Some(-42), None],
+            "the process group signal already includes its leader"
+        );
+        assert_eq!(
+            console_signal_targets(42, -1),
+            [None, Some(42)],
+            "fall back to the session child when the PTY has no foreground group"
         );
     }
 }

--- a/crates/mvm-cli/src/commands/vm/console.rs
+++ b/crates/mvm-cli/src/commands/vm/console.rs
@@ -291,23 +291,31 @@ fn console_pty_with_argv(name: &str, env: Vec<(String, String)>, argv: Vec<Strin
     // Set up SIGWINCH handler to forward terminal resizes
     let resize_sender = setup_sigwinch_handler(transport.clone(), session_id);
 
-    // Enter raw terminal mode and suppress the Ctrl-C handler so that
-    // Ctrl+C is forwarded as a raw byte (\x03) to the guest shell
-    // instead of killing mvmctl.
-    IN_CONSOLE_MODE.store(true, std::sync::atomic::Ordering::SeqCst);
-    let orig_termios = enter_raw_mode()?;
+    // Enter raw terminal mode and suppress the Ctrl-C handler so that Ctrl+C
+    // is forwarded as a raw byte (\x03) to the guest shell instead of killing
+    // mvmctl. The guard restores both pieces of process state on every return.
+    let raw_terminal = RawTerminalGuard::enter()?;
     let result = run_console_relay(data_stream);
 
     // Restore terminal and clean up
-    restore_terminal(&orig_termios);
-    IN_CONSOLE_MODE.store(false, std::sync::atomic::Ordering::SeqCst);
+    drop(raw_terminal);
     drop(resize_sender);
 
     mvm_core::audit_emit!(ConsoleSessionEnd, vm: name, "session_id={session_id}");
 
-    let exit_code = console_exit_code(&transport, session_id)?;
-    println!("\nConsole session ended.");
-    result.map(|_| exit_code)
+    match result? {
+        ConsoleRelayExit::GuestClosed => {
+            let completion = console_exit_code(&transport, session_id);
+            let machine_stopped = completion.is_err() && wait_for_console_machine_stop(name);
+            let exit_code = classify_console_completion(completion, machine_stopped)?;
+            println!("\nConsole session ended.");
+            Ok(exit_code)
+        }
+        ConsoleRelayExit::LocalEscape => {
+            println!("\nConsole session ended.");
+            Ok(0)
+        }
+    }
 }
 
 fn console_exit_code(transport: &Arc<dyn VsockTransport>, session_id: u32) -> Result<i32> {
@@ -321,6 +329,39 @@ fn console_exit_code(transport: &Arc<dyn VsockTransport>, session_id: u32) -> Re
         mvm_agentd::vsock::GuestResponse::ConsoleExited { exit_code, .. } => Ok(exit_code),
         mvm_agentd::vsock::GuestResponse::Error { message } => anyhow::bail!("{message}"),
         other => anyhow::bail!("Unexpected response: {other:?}"),
+    }
+}
+
+fn wait_for_console_machine_stop(name: &str) -> bool {
+    const ATTEMPTS: usize = 40;
+    const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(25);
+
+    for attempt in 0..ATTEMPTS {
+        let still_present = mvm_client::LocalBackend::new()
+            .list_stop_targets()
+            .iter()
+            .any(|machine| machine.id.0 == name);
+        if !still_present {
+            return true;
+        }
+        if attempt + 1 < ATTEMPTS {
+            std::thread::sleep(RETRY_DELAY);
+        }
+    }
+    false
+}
+
+fn classify_console_completion(completion: Result<i32>, machine_stopped: bool) -> Result<i32> {
+    match completion {
+        Ok(exit_code) => Ok(exit_code),
+        Err(error) if machine_stopped => {
+            tracing::debug!(
+                error = %error,
+                "console exit-code channel closed after the machine stopped"
+            );
+            Ok(0)
+        }
+        Err(error) => Err(error),
     }
 }
 
@@ -430,13 +471,77 @@ fn restore_terminal(orig: &libc::termios) {
     }
 }
 
+/// Restores the caller's terminal and Ctrl-C disposition on every return path.
+struct RawTerminalGuard {
+    original: libc::termios,
+}
+
+impl RawTerminalGuard {
+    fn enter() -> Result<Self> {
+        let original = enter_raw_mode()?;
+        IN_CONSOLE_MODE.store(true, std::sync::atomic::Ordering::SeqCst);
+        Ok(Self { original })
+    }
+}
+
+impl Drop for RawTerminalGuard {
+    fn drop(&mut self) {
+        restore_terminal(&self.original);
+        IN_CONSOLE_MODE.store(false, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConsoleRelayExit {
+    GuestClosed,
+    LocalEscape,
+}
+
+/// Recognizes the documented SSH-style local detach without sending it through
+/// the guest channel. A leading `~` is held until the next byte so `~.` can span
+/// terminal reads; every other sequence is forwarded byte-for-byte.
+struct ConsoleEscapeFilter {
+    at_line_start: bool,
+    pending_tilde: bool,
+}
+
+impl ConsoleEscapeFilter {
+    fn new() -> Self {
+        Self {
+            at_line_start: true,
+            pending_tilde: false,
+        }
+    }
+
+    /// Append bytes for the guest to `forwarded`; return true on local detach.
+    fn filter(&mut self, input: &[u8], forwarded: &mut Vec<u8>) -> bool {
+        for &byte in input {
+            if self.pending_tilde {
+                self.pending_tilde = false;
+                if byte == b'.' {
+                    return true;
+                }
+                forwarded.push(b'~');
+                self.at_line_start = false;
+            } else if self.at_line_start && byte == b'~' {
+                self.pending_tilde = true;
+                continue;
+            }
+
+            forwarded.push(byte);
+            self.at_line_start = matches!(byte, b'\r' | b'\n');
+        }
+        false
+    }
+}
+
 /// Relay raw bytes between stdin/stdout and a vsock data stream.
 ///
 /// Exits when the guest closes the connection (e.g. `exit` or Ctrl+D
 /// in the shell) or when the user types the `~.` escape sequence
 /// (Enter, then `~.`, same as SSH).
 ///
-fn run_console_relay(data_stream: std::os::unix::net::UnixStream) -> Result<()> {
+fn run_console_relay(data_stream: std::os::unix::net::UnixStream) -> Result<ConsoleRelayExit> {
     use std::io::{Read, Write};
     use std::os::unix::io::AsRawFd;
 
@@ -457,8 +562,9 @@ fn run_console_relay(data_stream: std::os::unix::net::UnixStream) -> Result<()> 
     let mut stdout = std::io::stdout();
     let mut writer = write_stream;
     let mut buf = [0u8; 4096];
+    let mut escape = ConsoleEscapeFilter::new();
 
-    loop {
+    let outcome = loop {
         let mut fds = [
             libc::pollfd {
                 fd: stdin_fd,
@@ -476,50 +582,114 @@ fn run_console_relay(data_stream: std::os::unix::net::UnixStream) -> Result<()> 
             if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
                 continue;
             }
-            break;
+            break ConsoleRelayExit::GuestClosed;
+        }
+
+        // Check input first so sustained guest output cannot defer a local
+        // escape or an interrupt byte behind terminal rendering.
+        if fds[0].revents & (libc::POLLIN | libc::POLLHUP) != 0 {
+            let mut inbuf = [0u8; 1024];
+            match std::io::stdin().read(&mut inbuf) {
+                Ok(0) => break ConsoleRelayExit::GuestClosed,
+                Ok(n) => {
+                    let mut forwarded = Vec::with_capacity(n);
+                    let detach = escape.filter(&inbuf[..n], &mut forwarded);
+                    if !forwarded.is_empty() && writer.write_all(&forwarded).is_err() {
+                        break ConsoleRelayExit::GuestClosed;
+                    }
+                    let _ = writer.flush();
+                    if detach {
+                        let _ = writer.shutdown(std::net::Shutdown::Both);
+                        break ConsoleRelayExit::LocalEscape;
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(_) => break ConsoleRelayExit::GuestClosed,
+            }
         }
 
         // vsock → stdout (guest output)
         if fds[1].revents & libc::POLLIN != 0 {
             match (&read_stream).read(&mut buf) {
-                Ok(0) => break,
+                Ok(0) => break ConsoleRelayExit::GuestClosed,
                 Ok(n) => {
                     let _ = stdout.write_all(&buf[..n]);
                     let _ = stdout.flush();
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
-                Err(_) => break,
+                Err(_) => break ConsoleRelayExit::GuestClosed,
             }
         }
         if fds[1].revents & (libc::POLLHUP | libc::POLLERR) != 0
             && fds[1].revents & libc::POLLIN == 0
         {
-            break;
+            break ConsoleRelayExit::GuestClosed;
         }
+    };
 
-        // stdin → vsock (host input)
-        if fds[0].revents & (libc::POLLIN | libc::POLLHUP) != 0 {
-            let mut inbuf = [0u8; 1024];
-            match std::io::stdin().read(&mut inbuf) {
-                Ok(0) => break,
-                Ok(n) => {
-                    if writer.write_all(&inbuf[..n]).is_err() {
-                        break;
-                    }
-                    let _ = writer.flush();
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
-                Err(_) => break,
-            }
-        }
-    }
-
-    // Restore stdin to its original blocking mode
+    // Restore stdin's original file-status flags before returning to the shell.
     unsafe {
         libc::fcntl(stdin_fd, libc::F_SETFL, orig_stdin_flags);
     }
 
-    Ok(())
+    Ok(outcome)
+}
+
+#[cfg(test)]
+mod console_relay_tests {
+    use super::*;
+
+    #[test]
+    fn local_escape_is_recognized_across_input_chunks() {
+        let mut escape = ConsoleEscapeFilter::new();
+        let mut forwarded = Vec::new();
+
+        assert!(!escape.filter(b"echo ready\r~", &mut forwarded));
+        assert!(escape.filter(b".", &mut forwarded));
+        assert_eq!(forwarded, b"echo ready\r");
+    }
+
+    #[test]
+    fn escape_like_text_away_from_a_line_boundary_is_forwarded_verbatim() {
+        let mut escape = ConsoleEscapeFilter::new();
+        let mut forwarded = Vec::new();
+
+        assert!(!escape.filter(b"printf '~.'\r", &mut forwarded));
+        assert_eq!(forwarded, b"printf '~.'\r");
+    }
+
+    #[test]
+    fn an_unrecognized_line_escape_is_forwarded_without_losing_bytes() {
+        let mut escape = ConsoleEscapeFilter::new();
+        let mut forwarded = Vec::new();
+
+        assert!(!escape.filter(b"\r~x", &mut forwarded));
+        assert_eq!(forwarded, b"\r~x");
+    }
+
+    #[test]
+    fn stopped_machine_turns_a_lost_exit_code_reply_into_a_clean_console_end() {
+        let result =
+            classify_console_completion(Err(anyhow::anyhow!("Failed to read frame length")), true);
+
+        assert_eq!(result.expect("stopped VM is a clean console end"), 0);
+    }
+
+    #[test]
+    fn running_machine_preserves_a_lost_exit_code_reply_as_an_error() {
+        let result =
+            classify_console_completion(Err(anyhow::anyhow!("Failed to read frame length")), false);
+
+        let error = result.expect_err("a live VM must not hide a control-plane failure");
+        assert!(error.to_string().contains("Failed to read frame length"));
+    }
+
+    #[test]
+    fn an_absent_machine_is_confirmed_as_stopped() {
+        assert!(wait_for_console_machine_stop(
+            "console-completion-machine-that-does-not-exist"
+        ));
+    }
 }
 
 #[cfg(test)]

--- a/public/src/content/docs/console/attach.md
+++ b/public/src/content/docs/console/attach.md
@@ -38,6 +38,13 @@ Console behavior depends on the active backend, image mode, and launch policy:
 - Terminal resize, signal forwarding, and scrollback are backend-specific.
 - Console sessions end when the VM stops.
 
+Press `Ctrl+C` to interrupt the foreground command inside the guest. To end the
+console locally even when the guest command does not respond, press Enter and
+then type `~.`. The escape is handled by `mvmctl` and is not sent to the guest.
+Stopping the machine from another terminal also ends the attached console
+cleanly; the expected control-channel EOF during teardown is not reported as a
+protocol failure.
+
 When a backend cannot provide a console, use `mvmctl machine logs`, `mvmctl machine exec`, and
 guest readiness probes to debug the workload.
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,22 @@
 
 ## Current issue delivery
 
+- [x] Long-running interactive consoles no longer lose their input relay after
+      15 minutes without keyboard activity. Guest output can continue
+      indefinitely while later `Ctrl+C` bytes still reach the PTY foreground
+      job; host disconnect closes both relay directions and terminates the PTY
+      process group; and the documented line-start `~.` escape now provides a
+      host-local exit path. A concurrent `machine stop` is distinguished from a
+      live-VM control failure, so its expected exit-code-channel EOF ends the
+      attached console cleanly without hiding real framing errors. The
+      raw-terminal state is restored through an RAII guard. Focused console
+      regressions, the full serial workspace suite
+      (including 631 `mvm-agentd` and 1,661 `mvm-cli` library tests), workspace
+      check, macOS workspace all-target Clippy, and the aarch64 Linux guest-agent
+      cross-build pass. The default parallel workspace run exposes unrelated
+      global test environment races; the affected tests pass in isolation and
+      serially.
+
 - [~] Bootstrap machine readiness — **plan 315**. `mvmctl bootstrap` now
       prepares both the builder VM and verified dm-verity workload kernel, so a
       successful bootstrap does not defer an infrastructure build to the next


### PR DESCRIPTION
## Summary

- keep the guest console input relay alive indefinitely so long-running output-only commands still receive later `Ctrl+C` input
- add the documented line-start `~.` local escape, prioritize host input over sustained guest output, and restore terminal state through an RAII guard
- terminate the guest PTY foreground process group when the host disconnects
- treat the control-channel EOF caused by a concurrent successful `machine stop` as a clean console end while preserving framing errors for a VM that remains running
- document the interactive exit behavior and update sprint status

## Root cause

The guest-side input relay applied a 15-minute read timeout independently of console output. After 15 minutes without keyboard input, that relay exited while the output relay continued, leaving the console visibly active but unable to forward `Ctrl+C`. Separately, stopping the machine closed the data channel before the host's final exit-code RPC, which surfaced an expected teardown EOF as `Failed to read frame length`.

## User impact

Long-running interactive programs remain interruptible after idle keyboard periods. Users also have a host-local `~.` detach path, and stopping a VM from another terminal ends an attached console cleanly without masking real control-plane failures.

## Validation

- `cargo test -p mvm-agentd console::tests::` (13 passed)
- `cargo test -p mvm-cli console_relay_tests` (6 passed)
- `cargo test -p mvm-cli --lib -- --test-threads=1` (1,661 passed, 2 ignored)
- `cargo test --workspace -- --test-threads=1`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- aarch64 Linux guest-agent cross-build
- `cargo fmt --all -- --check`
- `git diff --check`
