### PR TITLE
Enforce single-line CLI help

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -83,13 +83,13 @@ pub(in crate::commands) enum MachineAction {
     /// Build a microVM image from a manifest or Nix flake
     #[command(display_order = 2)]
     Build(build::Args),
-    /// Create or update a persistent named machine spec without booting it
+    /// Create or update a persistent machine spec
     #[command(display_order = 3)]
     Create(MachineCreateArgs),
-    /// Boot one or more persistent named machines without running a one-shot command
+    /// Boot one or more persistent machines
     #[command(display_order = 4)]
     Start(MachineStartCmd),
-    /// Restart one or more named machines (stop if running, then start)
+    /// Restart one or more persistent machines
     #[command(display_order = 5)]
     Restart(MachineStartCmd),
     /// Stop a running VM by name, or all running VMs with --all
@@ -101,13 +101,13 @@ pub(in crate::commands) enum MachineAction {
     /// Remove one or more persistent named machine specs (or --all)
     #[command(name = "rm", display_order = 6)]
     Rm(MachineRemoveArgs),
-    /// List every microVM: persistent machines and running transients (alias: `ps`)
+    /// List persistent and transient microVMs
     #[command(name = "ls", visible_alias = "ps", display_order = 7)]
     Ls(MachineListArgs),
     /// Show one persistent named machine spec
     #[command(display_order = 8)]
     Inspect(MachineInspectArgs),
-    /// Attach an interactive shell/console to an already-started named machine
+    /// Open a shell in a running persistent machine
     #[command(display_order = 9)]
     Shell(MachineShellArgs),
     /// Run a command inside an already-started named machine
@@ -119,34 +119,25 @@ pub(in crate::commands) enum MachineAction {
     /// Show console logs from a running VM
     #[command(display_order = 12)]
     Logs(super::vm::logs::Args),
-    /// Interactive PTY console to a running VM (dev images only; claim-15 gated)
+    /// Open a PTY console for a development image
     #[command(display_order = 13)]
     Console(super::vm::console::Args),
-    /// Verify a portable `.mvm` artifact and preview how `machine run` would
-    /// admit it (arch, profile, seccomp, egress, volumes). Read-only: no
-    /// extraction, no boot.
+    /// Verify a portable `.mvm` artifact without booting
     #[command(name = "check-artifact", display_order = 13)]
     CheckArtifact(portable::CheckArtifactArgs),
-    /// Render a checkpoint or image's lineage (ancestors to genesis + immediate
-    /// children), verifying each hop against the signed audit chain. Read-only:
-    /// no restore, no admission, no boot.
+    /// Show and verify checkpoint or image lineage
     #[command(display_order = 14)]
     Timeline(super::vm::checkpoint::TimelineArgs),
-    /// Restore a prior state: launch a fresh, re-admitted VM at the checkpoint or
-    /// image node the target names. Verifies the target against the signed audit
-    /// chain first and fails closed on an un-audited, tampered, or dangling
-    /// record.
+    /// Restore a verified checkpoint or image into a new VM
     #[command(display_order = 15)]
     Revert(super::vm::checkpoint::RevertArgs),
     /// Rewind one step: restore the target's parent in the lineage.
     #[command(display_order = 16)]
     Rewind(super::vm::checkpoint::RevertArgs),
-    /// Advance one step: restore a child of the target (a fork needs `--to`).
+    /// Restore a child of the target (`--to` selects a fork)
     #[command(display_order = 17)]
     Advance(super::vm::checkpoint::AdvanceArgs),
-    /// Warm-restore a vm_full checkpoint into a fresh child VM.
-    /// The child inherits the saved machine state and receives a fresh
-    /// generation token; the parent must be stopped.
+    /// Restore a full-VM checkpoint into a fresh child VM
     #[command(name = "warm-restore", display_order = 18)]
     WarmRestore(MachineWarmRestoreArgs),
     /// Advanced single-VM operations (pause, snapshot, cp, fs, …). Hidden; use `machine <verb>` directly.
@@ -376,7 +367,7 @@ pub(in crate::commands) struct MachineRunArgs {
     /// Load entrypoint secrets from workload IR.
     #[arg(long, value_name = "PATH", requires = "entrypoint")]
     pub from_workload_ir: Option<PathBuf>,
-    /// Feed the entrypoint's stdin from PATH, or `-` to stream yours.
+    /// `-` to stream yours; otherwise read PATH.
     // Deliberately one line: this crate's help-length rule measures clap's
     // long help, which is the whole doc comment, so extended paragraphs here
     // would land in `machine run --help` and break it. The difference between

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -54,7 +54,8 @@ use dispatch::TopLevelCommand;
 
 use shared::{CHILD_PIDS, IN_CONSOLE_MODE, with_hints};
 
-const CLI_HELP_WIDTH: usize = 80;
+const CLI_HELP_WIDTH: usize = 79;
+const CLAP_RENDER_WIDTH: usize = 4096;
 
 #[derive(Parser, Debug, Clone)]
 #[command(
@@ -81,7 +82,7 @@ pub(in crate::commands) struct Cli {
     )]
     pub builder: Option<String>,
 
-    /// Kernel source: compile, download, or auto
+    /// Kernel source: compile, download, auto
     #[arg(
         long,
         global = true,
@@ -288,8 +289,16 @@ pub fn run() -> Result<()> {
 
 fn constrain_help_width(command: clap::Command) -> clap::Command {
     let mut command = command
-        .term_width(CLI_HELP_WIDTH)
-        .max_term_width(CLI_HELP_WIDTH);
+        .disable_help_flag(true)
+        .arg(
+            clap::Arg::new("help")
+                .short('h')
+                .long("help")
+                .action(clap::ArgAction::HelpShort)
+                .help("Print help"),
+        )
+        .term_width(CLAP_RENDER_WIDTH)
+        .max_term_width(CLAP_RENDER_WIDTH);
     if let Some(usage) = command
         .clone()
         .render_help()
@@ -306,7 +315,7 @@ fn constrain_help_width(command: clap::Command) -> clap::Command {
 fn wrap_usage(usage: &str) -> String {
     let body = usage.strip_prefix("Usage: ").unwrap_or(usage);
     let continuation_indent = "       ";
-    let line_limit = 80 - continuation_indent.chars().count();
+    let line_limit = CLI_HELP_WIDTH - continuation_indent.chars().count();
     let mut wrapped = String::new();
     let mut line_width = 0;
 
@@ -330,9 +339,9 @@ fn wrap_usage(usage: &str) -> String {
 
 fn constrain_help_output(help: &str) -> String {
     let trailing_newline = help.ends_with('\n');
-    let mut constrained = help
-        .lines()
-        .map(|line| wrap_help_line(line, CLI_HELP_WIDTH))
+    let mut constrained = compact_help_items(help)
+        .iter()
+        .map(|line| truncate_help_line(line, CLI_HELP_WIDTH))
         .collect::<Vec<_>>()
         .join("\n");
     if trailing_newline {
@@ -341,72 +350,105 @@ fn constrain_help_output(help: &str) -> String {
     constrained
 }
 
-fn wrap_help_line(line: &str, width: usize) -> String {
+#[derive(Clone, Copy)]
+enum HelpItemSection {
+    Arguments,
+    Commands,
+    Options,
+}
+
+fn compact_help_items(help: &str) -> Vec<String> {
+    let mut compacted = Vec::new();
+    let mut section = None;
+    let mut item = None;
+    let mut pending_blank = false;
+
+    for line in help.lines() {
+        let trimmed = line.trim();
+        let heading = match trimmed {
+            "Arguments:" => Some(HelpItemSection::Arguments),
+            "Commands:" => Some(HelpItemSection::Commands),
+            "Options:" => Some(HelpItemSection::Options),
+            _ => None,
+        };
+
+        if let Some(heading) = heading {
+            flush_help_item(&mut compacted, &mut item);
+            if pending_blank && compacted.last().is_some_and(|line| !line.is_empty()) {
+                compacted.push(String::new());
+            }
+            compacted.push(line.to_owned());
+            section = Some(heading);
+            pending_blank = false;
+            continue;
+        }
+
+        if trimmed.is_empty() {
+            if section.is_some() {
+                pending_blank = true;
+            } else if compacted.last().is_some_and(|line| !line.is_empty()) {
+                compacted.push(String::new());
+            }
+            continue;
+        }
+
+        if section.is_some() && !line.starts_with(char::is_whitespace) {
+            flush_help_item(&mut compacted, &mut item);
+            if pending_blank && compacted.last().is_some_and(|line| !line.is_empty()) {
+                compacted.push(String::new());
+            }
+            compacted.push(line.to_owned());
+            section = None;
+            pending_blank = false;
+            continue;
+        }
+
+        let indentation = line
+            .chars()
+            .take_while(|character| character.is_whitespace())
+            .count();
+        let starts_item = match section {
+            Some(HelpItemSection::Arguments) => {
+                matches!(trimmed.chars().next(), Some('<' | '['))
+            }
+            Some(HelpItemSection::Commands) => indentation <= 2,
+            Some(HelpItemSection::Options) => indentation <= 6 && trimmed.starts_with('-'),
+            None => false,
+        };
+
+        if starts_item {
+            flush_help_item(&mut compacted, &mut item);
+            item = Some(line.to_owned());
+        } else if let Some(current) = item.as_mut() {
+            current.push_str("  ");
+            current.push_str(trimmed);
+        } else {
+            compacted.push(line.to_owned());
+        }
+        pending_blank = false;
+    }
+
+    flush_help_item(&mut compacted, &mut item);
+    compacted
+}
+
+fn flush_help_item(compacted: &mut Vec<String>, item: &mut Option<String>) {
+    if let Some(item) = item.take() {
+        compacted.push(item);
+    }
+}
+
+fn truncate_help_line(line: &str, width: usize) -> String {
     if line.chars().count() <= width {
         return line.to_owned();
     }
 
-    let indentation = line
+    let mut truncated = line
         .chars()
-        .take_while(|character| character.is_whitespace())
-        .count();
-    let prefix = &line[..line.len() - line.trim_start().len()];
-    let continuation = if line.trim_start().starts_with("Usage:") {
-        "       "
-    } else {
-        prefix
-    };
-    let mut current = String::new();
-    let mut current_limit = width.saturating_sub(indentation);
-    let mut wrapped = Vec::new();
-
-    for source_word in line.split_whitespace() {
-        let mut word = source_word.to_owned();
-        loop {
-            if current.is_empty() {
-                let available = current_limit.max(1);
-                let word_width = word.chars().count();
-                if word_width <= available {
-                    current = word;
-                    break;
-                }
-
-                let mut characters = word.chars();
-                current = characters.by_ref().take(available).collect();
-                wrapped.push(current);
-                current = String::new();
-                word = characters.collect();
-                current_limit = width.saturating_sub(continuation.chars().count());
-            } else {
-                let available = current_limit.saturating_sub(current.chars().count() + 1);
-                if word.chars().count() <= available {
-                    current.push(' ');
-                    current.push_str(&word);
-                    break;
-                }
-
-                wrapped.push(current);
-                current = String::new();
-                current_limit = width.saturating_sub(continuation.chars().count());
-            }
-        }
-    }
-    if !current.is_empty() {
-        wrapped.push(current);
-    }
-
-    wrapped
-        .into_iter()
-        .enumerate()
-        .map(|(index, text)| {
-            if index == 0 {
-                format!("{prefix}{text}")
-            } else {
-                format!("{continuation}{text}")
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
+        .take(width.saturating_sub(1))
+        .collect::<String>();
+    truncated.push('…');
+    truncated
 }
 
 /// Set a process-global environment variable from the CLI.

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -7,30 +7,35 @@ use clap::Parser;
 use std::path::Path;
 
 #[test]
-fn help_output_wraps_long_lines() {
+fn help_output_truncates_long_lines() {
     let help =
         "  command  A long description that must wrap before it exceeds the fixed output width";
     let wrapped = constrain_help_output(help);
 
-    assert!(
-        wrapped
-            .lines()
-            .all(|line| line.chars().count() <= CLI_HELP_WIDTH)
-    );
-    assert!(wrapped.lines().count() > 1);
-    assert!(wrapped.contains("\n  "));
+    assert_eq!(wrapped.lines().count(), 1);
+    assert_eq!(wrapped.chars().count(), CLI_HELP_WIDTH);
+    assert!(wrapped.ends_with('…'));
 }
 
 #[test]
-fn help_output_splits_unbreakable_tokens() {
+fn help_output_truncates_unbreakable_tokens() {
     let help = format!("  command  {}", "x".repeat(CLI_HELP_WIDTH * 2));
     let wrapped = constrain_help_output(&help);
 
-    assert!(
-        wrapped
-            .lines()
-            .all(|line| line.chars().count() <= CLI_HELP_WIDTH)
-    );
+    assert_eq!(wrapped.lines().count(), 1);
+    assert_eq!(wrapped.chars().count(), CLI_HELP_WIDTH);
+    assert!(wrapped.ends_with('…'));
+}
+
+#[test]
+fn help_output_compacts_each_item_onto_one_line() {
+    let help = "Arguments:\n  [ARGV]...\n          Command to run\n\nOptions:\n      --image <REF>\n          Boot an OCI image\n\n  -h, --help\n          Print help\n";
+    let compacted = constrain_help_output(help);
+
+    assert!(compacted.contains("  [ARGV]...  Command to run"));
+    assert!(compacted.contains("      --image <REF>  Boot an OCI image"));
+    assert!(compacted.contains("  -h, --help  Print help"));
+    assert!(!compacted.contains("\n          "));
 }
 
 #[test]

--- a/crates/mvm-cli/src/commands/vm/artifact.rs
+++ b/crates/mvm-cli/src/commands/vm/artifact.rs
@@ -232,8 +232,7 @@ pub(in crate::commands) struct ModelConfigArgs {
     /// Artifact ID (UUID) or unique prefix to look up under
     /// `~/.mvm/artifacts/<id>/`.
     pub id: String,
-    /// Backend to write config for. Currently only `firecracker` is
-    /// implemented in this slice.
+    /// `firecracker` backend (the only supported choice).
     #[arg(long, default_value = "firecracker")]
     pub backend: BackendArg,
 }

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -457,27 +457,35 @@ fn help_options_fit_within(world: &mut CliWorld, width: i64) {
     }
 }
 
-#[then(expr = "every mvmctl command and subcommand help fits within {int} columns")]
-fn every_command_help_fits_within(_world: &mut CliWorld, width: i64) {
-    for path in all_command_paths() {
-        let mut args = path.clone();
-        args.push("--help".to_string());
-        assert_help_invocation_fits(&args, width);
-    }
+#[then(
+    expr = "every mvmctl command and subcommand help item is one line shorter than {int} columns"
+)]
+fn every_command_help_item_is_one_line_shorter_than(_world: &mut CliWorld, width: i64) {
+    let violations = all_command_paths()
+        .into_iter()
+        .flat_map(|mut path| {
+            path.push("--help".to_string());
+            help_invocation_violations(&path, width, true)
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        violations.is_empty(),
+        "CLI help items must each occupy one line shorter than {width} columns:\n{}",
+        violations.join("\n")
+    );
 }
 
-#[then(
-    expr = "every mvmctl command and subcommand alternative help entry point fits within {int} columns"
-)]
+#[then(expr = "every alternative CLI help item is one line shorter than {int} columns")]
 fn every_alternative_help_entry_point_fits_within(_world: &mut CliWorld, width: i64) {
     for path in all_command_paths() {
         let mut short_help_args = path.clone();
         short_help_args.push("-h".to_string());
-        assert_help_invocation_fits(&short_help_args, width);
+        assert_help_invocation_fits(&short_help_args, width, true);
 
         let mut help_subcommand_args = vec!["help".to_string()];
         help_subcommand_args.extend(path);
-        assert_help_invocation_fits(&help_subcommand_args, width);
+        assert_help_invocation_fits(&help_subcommand_args, width, true);
     }
 }
 
@@ -488,32 +496,104 @@ fn all_command_paths() -> Vec<Vec<String>> {
     command_paths
 }
 
-fn assert_help_invocation_fits(args: &[String], width: i64) {
+fn assert_help_invocation_fits(args: &[String], width: i64, require_single_line_items: bool) {
+    let violations = help_invocation_violations(args, width, require_single_line_items);
+    assert!(violations.is_empty(), "{}", violations.join("\n"));
+}
+
+fn help_invocation_violations(
+    args: &[String],
+    width: i64,
+    require_single_line_items: bool,
+) -> Vec<String> {
     let invocation = format!("mvmctl {}", args.join(" "));
     let output = mvmctl_command()
         .args(args)
         .output()
         .unwrap_or_else(|e| panic!("failed to run `{invocation}`: {e}"));
-    assert!(
-        output.status.success(),
-        "`{invocation}` failed:\n{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    if !output.status.success() {
+        return vec![format!(
+            "`{invocation}` failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        )];
+    }
 
     let help = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        !help.trim().is_empty(),
-        "`{invocation}` exited successfully without printing help"
-    );
+    if help.trim().is_empty() {
+        return vec![format!(
+            "`{invocation}` exited successfully without printing help"
+        )];
+    }
+
+    let mut violations = Vec::new();
+    if require_single_line_items {
+        collect_wrapped_help_items(&invocation, &help, &mut violations);
+    }
     for (line_number, line) in help.lines().enumerate() {
         let line_width = i64::try_from(line.chars().count()).expect("line width fits in i64");
-        assert!(
-            line_width <= width,
-            "`{invocation}` line {} exceeds {width} columns ({}):\n{}",
-            line_number + 1,
-            line_width,
-            help
-        );
+        if line_width >= width {
+            violations.push(format!(
+                "`{invocation}` line {} is {line_width} columns: {line}",
+                line_number + 1
+            ));
+        }
+    }
+    violations
+}
+
+fn collect_wrapped_help_items(invocation: &str, help: &str, violations: &mut Vec<String>) {
+    #[derive(Clone, Copy)]
+    enum ItemSection {
+        Arguments,
+        Commands,
+        Options,
+    }
+
+    let command_names = all_command_paths()
+        .into_iter()
+        .filter_map(|path| path.last().cloned())
+        .collect::<Vec<_>>();
+    let mut section = None;
+
+    for (line_number, line) in help.lines().enumerate() {
+        let trimmed = line.trim();
+        match trimmed {
+            "Arguments:" => {
+                section = Some(ItemSection::Arguments);
+                continue;
+            }
+            "Commands:" => {
+                section = Some(ItemSection::Commands);
+                continue;
+            }
+            "Options:" => {
+                section = Some(ItemSection::Options);
+                continue;
+            }
+            "" => {
+                section = None;
+                continue;
+            }
+            _ => {}
+        }
+
+        let is_item = match section {
+            Some(ItemSection::Arguments) => {
+                matches!(trimmed.chars().next(), Some('<' | '['))
+            }
+            Some(ItemSection::Commands) => trimmed.split_whitespace().next().is_some_and(|word| {
+                word == "help" || command_names.iter().any(|name| name == word)
+            }),
+            Some(ItemSection::Options) => trimmed.starts_with('-'),
+            None => true,
+        };
+
+        if !is_item {
+            violations.push(format!(
+                "`{invocation}` help item wraps onto line {}: {line}",
+                line_number + 1
+            ));
+        }
     }
 }
 

--- a/features/suites/s0_cli/verbs.feature
+++ b/features/suites/s0_cli/verbs.feature
@@ -17,7 +17,7 @@ Feature: mvmctl top-level CLI surface
     Then the command exits with code 0
     And the help output contains "Output format"
     And the help output contains "Builder VMM: libkrun, qemu, or hvf"
-    And the help output contains "Kernel source: compile, download, or auto"
+    And the help output contains "Kernel source: compile, download, auto"
     And the help options fit within 80 columns
     But the help output does not contain "Highest priority"
     And the help output does not contain "platform-default auto-detect"
@@ -32,8 +32,8 @@ Feature: mvmctl top-level CLI surface
     But the help output does not contain "Mutually exclusive with"
     And the help output does not contain "production-safe call surface"
 
-  Scenario: every CLI command and subcommand help fits within 80 columns
-    Then every mvmctl command and subcommand help fits within 80 columns
+  Scenario: every CLI help item is one line shorter than 80 columns
+    Then every mvmctl command and subcommand help item is one line shorter than 80 columns
 
-  Scenario: every alternative CLI help entry point fits within 80 columns
-    Then every mvmctl command and subcommand alternative help entry point fits within 80 columns
+  Scenario: every alternative CLI help entry point obeys the one-line limit
+    Then every alternative CLI help item is one line shorter than 80 columns

--- a/features/suites/s0_cli/verbs.feature
+++ b/features/suites/s0_cli/verbs.feature
@@ -26,9 +26,9 @@ Feature: mvmctl top-level CLI surface
     When I run mvmctl with "machine run --help"
     Then the command exits with code 0
     And the help output contains "Boot an OCI image"
-    And the help output contains "Allow outbound access to HOST[:PORT] (repeatable)"
-    And the help output contains "Select the VMM (firecracker, hvf, libkrun, or qemu)"
-    And the help output contains "Record check interval in seconds (not yet enforced)"
+    And the help output contains "Allow outbound access"
+    And the help output contains "Select the VMM"
+    And the help output contains "Record check interval"
     But the help output does not contain "Mutually exclusive with"
     And the help output does not contain "production-safe call surface"
 

--- a/features/suites/s8_readme_contract/readme_contract.feature
+++ b/features/suites/s8_readme_contract/readme_contract.feature
@@ -28,8 +28,8 @@ Feature: README CLI contract
     When I run mvmctl with "run --help"
     Then the command exits with code 0
     And the help output contains "--mode"
-    And the help output contains "Plan transport"
-    And the help output contains "Live transport"
+    And the help output contains "run --mode live/plan"
+    And the help output contains "SDK transport mode"
 
   Scenario: `trust audit verify` is a real command
     When I run mvmctl with "trust audit --help"

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,15 +1,17 @@
 # Refactor status
 
-Last updated: 2026-08-10
+Last updated: 2026-08-11
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
-- [x] **CLI help width invariant.** Every visible and hidden command is capped
-      at 80 columns for `--help`, `-h`, and `mvmctl help <path>`; generated-tree
-      BDD coverage executes the real binary and automatically includes future
-      subcommands.
+- [x] **CLI help layout invariant.** Every visible and hidden command emits one
+      physical line per help item, strictly shorter than 80 columns, for
+      `--help`, `-h`, and `mvmctl help <path>`. The shared renderer compacts
+      long-help blocks and caps overlong summaries at 79 columns; generated-tree
+      BDD coverage executes the real binary, rejects continuation lines and
+      overlong output, and automatically includes future subcommands.
 - [~] **Issue-closeout batch — #2165, #2321, and #2323.** The workload runner
       now emits read-only root bootargs for read-only root devices, the
       credential-bearing substitution response is incrementally capped, and

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1570,10 +1570,15 @@ Then unify + retire the old paths:
 
 **WS7 — simple CLI**
 
-- [x] Enforce an 80-column maximum across every visible and hidden command's
-      `--help`, `-h`, and `mvmctl help <path>` output. The BDD suite discovers
-      paths from the generated Clap tree and executes the real binary, so new
-      subcommands are covered automatically.
+- [x] Enforce one physical line per help item, strictly shorter than 80 columns,
+      across every visible and hidden command's `--help`, `-h`, and
+      `mvmctl help <path>` output. The shared renderer compacts long-help item
+      blocks and caps overlong summaries at 79 columns with an ellipsis. The BDD
+      suite discovers paths from the generated Clap tree, executes the real
+      binary, and rejects both continuation lines and lines at or above 80
+      columns, so new subcommands are covered automatically. Focused renderer
+      tests, both exhaustive BDD scenarios, the serial full workspace suite,
+      workspace check, formatting, and host workspace all-target Clippy pass.
 - [ ] Redesign to a small, discoverable verb set; `env` shown in `--help`.
 - [ ] Merge `setup`/`bootstrap` into one first-run `bootstrap`. Add the lifecycle verbs: **`upgrade`** (self-update `mvmctl`); **`uninstall`** (remove everything — the binary, `~/.mvm`, and installed host/guest artifacts); **`env cleanup`** (reclaim `~/.mvm` — caches + transient VM/build state, keeping config + keys); **`env reset`** (wipe `~/.mvm` back to a clean slate). These replace the fragmented `cache prune` / `pack prune` / `storage gc`. `env` becomes a visible top-level subcommand (today `hide = true`).
 - [ ] Replace the 31-arm dispatch `match` with a `Command` trait (`fn run(&self, ctx: &Cli) -> Result<()>`); one module per command; every command calls `mvm-client`.


### PR DESCRIPTION
## What changed

- Render every CLI help item on one physical line.
- Cap every rendered help line at 79 columns, using an ellipsis for overlong text.
- Shorten the `machine` command summaries so the primary help remains readable.
- Add generated-command-tree BDD coverage for `--help`, `-h`, and `mvmctl help <path>`.
- Update the sprint and refactor status records.

## Why

Clap's default wrapping split command and option descriptions across continuation
lines, making the help output difficult to scan. The previous width check only
enforced a maximum line length and did not reject multi-line items.

## Impact

All visible and hidden command help paths now keep each command, argument, and
option on one line strictly shorter than 80 columns. Future subcommands are
included automatically by the BDD traversal.

## Validation

- `cargo test --workspace -- --test-threads=1`
- `cargo test -p mvmctl --tests -- --test-threads=1`
- Scoped exhaustive BDD: 2 scenarios, 2 steps passed.
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
