### PR TITLE
fix: retry transient busy lifecycle hooks

### DIFF
--- a/crates/mvm-agentd/src/console.rs
+++ b/crates/mvm-agentd/src/console.rs
@@ -748,6 +748,14 @@ where
 mod tests {
     use super::*;
 
+    static CONSOLE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn console_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        CONSOLE_TEST_LOCK
+            .lock()
+            .expect("console-test mutex not poisoned")
+    }
+
     // `Winsize`'s layout is pinned by the `const _` contract next to the
     // struct: a compile-time assertion that also covers alignment and every
     // field offset, and that holds for cross-compiled targets which never
@@ -831,23 +839,24 @@ mod tests {
     /// still active and must wait for it, not refuse it.
     #[test]
     fn close_waits_out_a_session_that_is_still_tearing_down() {
+        let _guard = console_test_lock();
         CONSOLE_ACTIVE.store(true, Ordering::SeqCst);
-        std::thread::spawn(|| {
+        let completion = std::thread::spawn(|| {
             std::thread::sleep(std::time::Duration::from_millis(120));
             record_completed_session(7, 42);
             CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
         });
 
-        assert_eq!(
-            close_active_session(std::time::Duration::from_secs(5)),
-            Some(42)
-        );
+        let result = close_active_session(std::time::Duration::from_secs(5));
+        completion.join().expect("completion thread");
+        assert_eq!(result, Some(42));
     }
 
     /// A wedged relay is the one case that still fails, and it fails as a
     /// refusal rather than by blocking the agent forever.
     #[test]
     fn close_reports_a_session_that_never_terminates() {
+        let _guard = console_test_lock();
         CONSOLE_ACTIVE.store(true, Ordering::SeqCst);
         // No shell pid is recorded, so the SIGHUP escalation has nothing to
         // signal and both waits lapse.
@@ -864,6 +873,7 @@ mod tests {
     /// An idle agent answers immediately from the recorded exit code.
     #[test]
     fn close_returns_the_recorded_code_when_no_session_is_active() {
+        let _guard = console_test_lock();
         CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
         record_completed_session(3, 130);
 
@@ -880,6 +890,7 @@ mod tests {
     /// close released by that flag reads whatever the previous session left.
     #[test]
     fn the_exit_code_is_recorded_before_the_active_flag_clears() {
+        let _guard = console_test_lock();
         record_completed_session(1, 9);
         CONSOLE_ACTIVE.store(true, Ordering::SeqCst);
         let observer = std::thread::spawn(|| {
@@ -920,6 +931,7 @@ mod tests {
 
     #[test]
     fn open_session_rejects_invalid_argv_before_marking_active() {
+        let _guard = console_test_lock();
         CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
         let err = match open_session(80, 24, &[], &["sh".to_string()]) {
             Ok(_) => panic!("relative command should be rejected before PTY allocation"),
@@ -954,8 +966,7 @@ mod tests {
 
     #[test]
     fn test_is_active_default() {
-        // Reset state for test (note: tests run in parallel, so this
-        // tests the initial value only in isolation)
+        let _guard = console_test_lock();
         CONSOLE_ACTIVE.store(false, Ordering::SeqCst);
         assert!(!is_active());
     }

--- a/crates/mvm-agentd/src/lifecycle_hooks.rs
+++ b/crates/mvm-agentd/src/lifecycle_hooks.rs
@@ -28,6 +28,9 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus};
 use std::time::{Duration, Instant};
 
+const EXECUTABLE_BUSY_RETRIES: usize = 3;
+const EXECUTABLE_BUSY_RETRY_DELAY: Duration = Duration::from_millis(10);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct HookExit {
     success: bool,
@@ -288,7 +291,7 @@ fn run_shutdown_hook_with_runner<R>(
 where
     R: HookRunner,
 {
-    let mut child = match runner.spawn(script_path) {
+    let mut child = match spawn_shutdown_hook(runner, script_path) {
         Ok(c) => c,
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
             return Err(ShutdownError::ScriptMissing {
@@ -332,6 +335,25 @@ where
                     source: e,
                 });
             }
+        }
+    }
+}
+
+fn spawn_shutdown_hook<R>(runner: &R, script_path: &Path) -> io::Result<R::Child>
+where
+    R: HookRunner,
+{
+    let mut retries = 0;
+    loop {
+        match runner.spawn(script_path) {
+            Err(error)
+                if error.kind() == io::ErrorKind::ExecutableFileBusy
+                    && retries < EXECUTABLE_BUSY_RETRIES =>
+            {
+                retries += 1;
+                runner.sleep(EXECUTABLE_BUSY_RETRY_DELAY);
+            }
+            result => return result,
         }
     }
 }
@@ -419,6 +441,7 @@ mod tests {
 
     struct FakeSpawnRunner {
         child: Mutex<Option<FakeChild>>,
+        spawn_errors: Mutex<VecDeque<io::ErrorKind>>,
     }
 
     impl FakeSpawnRunner {
@@ -431,9 +454,18 @@ mod tests {
             (
                 Self {
                     child: Mutex::new(Some(child)),
+                    spawn_errors: Mutex::new(VecDeque::new()),
                 },
                 state,
             )
+        }
+
+        fn with_spawn_errors(self, errors: impl IntoIterator<Item = io::ErrorKind>) -> Self {
+            *self
+                .spawn_errors
+                .lock()
+                .expect("fake spawn-error mutex poisoned") = errors.into_iter().collect();
+            self
         }
     }
 
@@ -445,6 +477,14 @@ mod tests {
         }
 
         fn spawn(&self, _script_path: &Path) -> io::Result<Self::Child> {
+            if let Some(kind) = self
+                .spawn_errors
+                .lock()
+                .expect("fake spawn-error mutex poisoned")
+                .pop_front()
+            {
+                return Err(io::Error::from(kind));
+            }
             self.child
                 .lock()
                 .expect("fake child slot mutex poisoned")
@@ -512,6 +552,50 @@ mod tests {
             &runner,
         )
         .expect("clean shutdown");
+    }
+
+    #[test]
+    fn run_shutdown_hook_retries_transient_executable_busy() {
+        let (runner, _state) = FakeSpawnRunner::new(FakeChildBehavior::ExitAfter {
+            polls: 1,
+            exit: HookExit::success(),
+        });
+        let runner = runner.with_spawn_errors([io::ErrorKind::ExecutableFileBusy]);
+
+        run_shutdown_hook_with_runner(
+            Path::new("/fake/stop.sh"),
+            Duration::from_secs(1),
+            Duration::from_millis(50),
+            &runner,
+        )
+        .expect("transient executable-busy error should be retried");
+    }
+
+    #[test]
+    fn run_shutdown_hook_bounds_executable_busy_retries() {
+        let (runner, _state) = FakeSpawnRunner::new(FakeChildBehavior::ExitAfter {
+            polls: 1,
+            exit: HookExit::success(),
+        });
+        let runner = runner.with_spawn_errors([
+            io::ErrorKind::ExecutableFileBusy,
+            io::ErrorKind::ExecutableFileBusy,
+            io::ErrorKind::ExecutableFileBusy,
+            io::ErrorKind::ExecutableFileBusy,
+        ]);
+
+        let err = run_shutdown_hook_with_runner(
+            Path::new("/fake/stop.sh"),
+            Duration::from_secs(1),
+            Duration::from_millis(50),
+            &runner,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ShutdownError::ExecError { source, .. }
+                if source.kind() == io::ErrorKind::ExecutableFileBusy
+        ));
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -122,6 +122,9 @@ for detailed scope and acceptance criteria.
         shutdown-hook fixture spawn that remained; workspace all-target Clippy
         passes, and the sole parallel CLI failure passed its exact isolated
         rerun
+  - [x] Serialize the guest-console tests that share process-global session
+        state after the next exact run exposed their race; join the completion
+        thread and pass 20/20 parallel stress runs
   - [ ] Run the exact Linux Security workflow, merge the fix, and observe a
         clean scheduled or release run before closing the issue
 - [~] Plan 300 — 30-issue reconciliation and closeout

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -117,6 +117,11 @@ for detailed scope and acceptance criteria.
         formatting, and the static mutation surface gate; the workspace suite
         passed all repaired areas before one unrelated host-agent socket-bind
         timeout whose isolated integration rerun passed 4/4
+  - [x] Pass every mutation and security job in exact run 31516221103 and add a
+        bounded, directly witnessed retry for the repeated Linux `ETXTBSY`
+        shutdown-hook fixture spawn that remained; workspace all-target Clippy
+        passes, and the sole parallel CLI failure passed its exact isolated
+        rerun
   - [ ] Run the exact Linux Security workflow, merge the fix, and observe a
         clean scheduled or release run before closing the issue
 - [~] Plan 300 — 30-issue reconciliation and closeout

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -238,10 +238,16 @@
       focused five-mutant hostd proof are green. Workspace all-target Clippy,
       formatting, and the static surface gate are also green. The workspace
       suite passed every repaired area but hit one unrelated host-agent
-      socket-bind timeout; its isolated integration rerun passed 4/4. A clean
-      exact Linux Security workflow rerun remains the final merge gate; a
-      subsequent scheduled or release run is still required before issue
-      closure.
+      socket-bind timeout; its isolated integration rerun passed 4/4. Exact
+      Security run 31516221103 passed every mutation and security job, then
+      twice hit Linux `ETXTBSY` while spawning freshly published shutdown-hook
+      fixtures. The lifecycle runner now retries that transient error with a
+      bounded delay, witnessed for recovery and retry exhaustion; workspace
+      all-target Clippy passes. The workspace suite passed the repaired area but
+      one parallel CLI test observed another test's temporary host CPU ceiling;
+      its exact isolated rerun passed. A clean exact Linux Security workflow
+      rerun remains the final merge gate; a subsequent scheduled or release run
+      is still required before issue closure.
 
 - [x] `mvmctl deps capture` — **plan 291 WS3**. Reseals a sandbox-captured
       dependency tree with fresh audit sidecars, updates the lockfile index,

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -245,9 +245,12 @@
       bounded delay, witnessed for recovery and retry exhaustion; workspace
       all-target Clippy passes. The workspace suite passed the repaired area but
       one parallel CLI test observed another test's temporary host CPU ceiling;
-      its exact isolated rerun passed. A clean exact Linux Security workflow
-      rerun remains the final merge gate; a subsequent scheduled or release run
-      is still required before issue closure.
+      its exact isolated rerun passed. The next exact run exposed guest-console
+      tests sharing process-global session state; the stateful tests now share
+      one lock and join their completion thread, with 20/20 parallel stress
+      passes. A clean exact Linux Security workflow rerun remains the final
+      merge gate; a subsequent scheduled or release run is still required
+      before issue closure.
 
 - [x] `mvmctl deps capture` — **plan 291 WS3**. Reseals a sandbox-captured
       dependency tree with fresh audit sidecars, updates the lockfile index,

--- a/specs/plans/300-open-issue-closeout.md
+++ b/specs/plans/300-open-issue-closeout.md
@@ -115,9 +115,11 @@ mentions it.
       bounded delay, with success-after-retry and retry-exhaustion witnesses;
       workspace all-target Clippy passes. The workspace suite passed the
       repaired area but one parallel CLI test observed another test's temporary
-      host CPU ceiling; its exact isolated rerun passed. A clean exact Linux
-      Security workflow and subsequent scheduled or release run remain the
-      merge-and-close gates.
+      host CPU ceiling; its exact isolated rerun passed. The next exact run
+      exposed the guest-console tests sharing process-global session state;
+      those stateful tests now share one lock and join their completion thread,
+      with 20/20 parallel stress passes. A clean exact Linux Security workflow
+      and subsequent scheduled or release run remain the merge-and-close gates.
 - [ ] **#2289 — finish the kernel freshness closeout.** Linux 6.12.103 and the
       verified shared hash are merged in #2301, and kernel build/freshness CI
       passed. Build the release artifacts, run the verified-boot and

--- a/specs/plans/300-open-issue-closeout.md
+++ b/specs/plans/300-open-issue-closeout.md
@@ -108,8 +108,15 @@ mentions it.
       mutation proofs, workspace all-target Clippy, formatting, and the static
       surface gate pass on the fix branch. The workspace suite passed every
       repaired area but hit one unrelated host-agent socket-bind timeout; its
-      isolated integration rerun passed 4/4. A clean exact Linux Security
-      workflow and subsequent scheduled or release run remain the
+      isolated integration rerun passed 4/4. Exact Security run 31516221103
+      passed every mutation and security job, then twice exposed a Linux
+      `ETXTBSY` race while spawning freshly published shutdown-hook fixtures.
+      The lifecycle runner now retries that transient spawn error with a
+      bounded delay, with success-after-retry and retry-exhaustion witnesses;
+      workspace all-target Clippy passes. The workspace suite passed the
+      repaired area but one parallel CLI test observed another test's temporary
+      host CPU ceiling; its exact isolated rerun passed. A clean exact Linux
+      Security workflow and subsequent scheduled or release run remain the
       merge-and-close gates.
 - [ ] **#2289 — finish the kernel freshness closeout.** Linux 6.12.103 and the
       verified shared hash are merged in #2301, and kernel build/freshness CI


### PR DESCRIPTION
## Summary
- retry transient executable-file-busy errors when spawning shutdown hooks
- bound the retry loop and preserve the original typed error after exhaustion
- add recovery and exhaustion witnesses and synchronize issue #2135 progress docs

## Validation
- cargo test -p mvm-agentd lifecycle_hooks
- cargo test -p mvm-agentd --bin mvm-guest-agent run_shutdown_hook_via_lifecycle_api
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all --check
- cargo test --workspace (repaired area green; one unrelated parallel CLI global-state collision passed its exact isolated rerun)