### PR TITLE
Design a live wasm sandbox demo, and plan wasm-in-microVM

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -619,6 +619,37 @@ for detailed scope and acceptance criteria.
         + gzipped-size budget in the existing wasm lane; B5 delete
         `web/audit-verify/`, fix the stale `mvm-verify` refs in ADR-031, add
         `mvmctl audit pubkey`
+- [ ] Plan 320 — A live wasm sandbox demo on the website
+      (`specs/plans/320-wasm-browser-demo.md`) — design approved, execution not
+      started. Browser-engine sandbox at `/demo` + landing teaser; relocates the
+      egress decision (`projection.rs`), `${NAME}` substitution, and audit-entry
+      construction/chain-signing into `mvm-contract` so host and browser run
+      identical code. Claim-free by ADR-024 §3; adds no claim-catalog witness.
+      Sequencing: the landing teaser must be built against PR #2359's redesigned
+      landing page, not the current one.
+  - [ ] E1 relocate `projection.rs` → `mvm-contract` (`mvm_core::ln` re-export
+        keeps ~20 call sites unchanged); E2 substitution core; E3 audit writer
+        core. Oracle: `wasm_egress_witness.rs` must stay green **unmodified**.
+  - [ ] `web/mvm-demo/` wasm-bindgen crate, workspace-excluded; Worker + thin
+        proxy; three curated fixtures (allowed / denied / unbound); tamper
+        button; `wasm-opt -Oz` + gzipped-size budget in the existing wasm lane
+  - [ ] Does **not** retire `web/audit-verify/` (no Merkle inclusion) — B5 and
+        `mvmctl audit pubkey` remain plan 301's
+- [ ] Plan 321 — wasm as a workload format inside a real microVM
+      (`specs/plans/321-wasm-in-microvm-workload-format.md`) — design, not
+      started. ADR-024's sanctioned engine-in-guest path: a wasm workload
+      inherits claims 3/10/13/15 from the microVM it runs inside, because the
+      isolation boundary is the microVM and wasm is only the executable format.
+      No new `BackendKind`.
+  - [ ] WS1 Nix factory row (`interpreter = null` + wrapper-kind discriminator,
+        per `nix/lib/factories/languages/default.nix:17-20`); WS2 end-to-end
+        compute-only run on a real backend; WS3 egress is blocked on WASI
+        Preview 1 having no sockets — deferred deliberately, not shipped
+        half-governed; WS4 stale-reference cleanup + ADR-024 Status fix
+  - [ ] Already present: `Language::Wasm` in `mvm-agentd/src/runner/config.rs`,
+        `wasmtime run` in `mvm-runner.rs:154`, `wasm` in
+        `mvm-contract/data/supported_languages.txt`. Only the image half is
+        missing.
 - [ ] Plan 298 — NANDA-style execution receipts and conformance badges
       (`specs/plans/298-nanda-receipts-and-conformance-badges.md`)
   - [x] WS1 RFC approved: `ExecutionReceipt` and `ConformanceBadge` envelopes,

--- a/specs/plans/320-wasm-browser-demo.md
+++ b/specs/plans/320-wasm-browser-demo.md
@@ -1,0 +1,299 @@
+# Plan 320: A live wasm sandbox demo on the website
+
+## Status
+
+DESIGN — approved in brainstorming, implementation not started.
+
+Bound by [ADR-024](../adrs/024-wasm-sandbox-backend.md)'s three constraints.
+Adds no numbered security claim, and does not request one.
+
+Companion: [plan 321](321-wasm-in-microvm-workload-format.md) covers the
+*other* half of "support wasm fully" — running a wasm workload inside a real
+microVM (engine-in-guest), which is where the numbered claims actually come
+from. 320 and 321 are independent; 320 ships first.
+
+## Context
+
+### What exists today
+
+- `WasmBackend` is real: `crates/mvm-runtime/src/wasm_backend.rs` (1,706 lines),
+  behind the off-by-default `wasm-backend` feature, on `wasmtime` 46. It runs a
+  user-supplied WASI module and mediates the module's `mvm:egress` host-import
+  through the same substitution endpoint the microVM backends use.
+- `crates/mvm-hostd/tests/wasm_egress_witness.rs` drives that seam through the
+  real `SubstitutionService` (real registry/resolver/encrypted secret store/
+  claim-10 gate/chain-signed recorder), swapping only the outbound TCP dial.
+- `mvm-contract` is `#![no_std] + alloc`, builds on `wasm32-unknown-unknown` in
+  CI, and already carries `NetworkPolicy`, the audit DTOs,
+  `verify_audit_chain_bytes`, `ed25519-dalek` v3 and `sha2`.
+- `web/audit-verify/` is a `wasm_bindgen` shim + static page, excluded from the
+  workspace so `wasm-bindgen` never enters `cargo build --workspace`.
+
+### The premise this plan corrects
+
+"We have a microVM that runs as a wasm container" is half true, and the half
+that is false determines the whole design. `WasmBackend` runs **on the host**
+under native `wasmtime`. `wasmtime` is a native embedding; it does not run in a
+browser. Nothing in the tree can be dropped onto a web page as-is.
+
+A browser demo therefore uses **the browser's own wasm engine** as the
+execution substrate, with mvm's governance seam recompiled from `mvm-contract`.
+The host `WasmBackend` is never exercised by the page. The page must say so.
+
+## Scope (decided)
+
+| Question | Decision |
+|---|---|
+| What the visitor sees | A live in-browser sandbox run — real WASI module, real policy gate, real chain-signed audit log, verified on screen |
+| What runs | Curated modules picked from a list, shipped as fixtures |
+| Egress on allow | A simulated destination, rendered on screen, labelled as simulated |
+| Placement | A dedicated `/demo` route; a compact teaser card on the landing page links to it |
+| Shared with the host | The egress decision, `${NAME}` substitution, and audit-entry construction + chain signing — all three relocated into `mvm-contract`, not reimplemented |
+
+Rationale for the simulated destination: it is the only option that can
+actually *show* the substitution. The demo's core assertion is that the
+destination received the real secret while the module held only a placeholder.
+A real remote destination cannot show you its own inbox, and there is no real
+credential to substitute anyway.
+
+## Architecture
+
+Three layers.
+
+**1. `mvm-contract` — the shared `no_std` core.** Gains three pure cores by
+relocation. Nothing new enters the workspace dependency graph except `ipnet`
+gaining a `no_std` configuration.
+
+**2. `web/mvm-demo/` — a new crate, excluded from the workspace.** A
+`wasm-bindgen` shim over `mvm-contract`, for the same reason `web/audit-verify/`
+is excluded: `wasm-bindgen` and the `wasm32` target must never enter
+`cargo build --workspace` or CI. It exposes `run(module_id, policy_json)` and
+`verify(chain_bytes)`, and owns the `mvm:egress` host-call handler.
+
+**3. `public/` — the existing Astro/Starlight + React site.** A `/demo` route, a
+dedicated Web Worker owning both wasm instances, and a thin async proxy on the
+main thread. No signing or verification on the main thread.
+
+### Who instantiates the visitor's module
+
+A wasm module cannot instantiate another wasm module; the host does. Here the
+host is the Worker's JavaScript. The Worker holds two instances — the
+`mvm-demo` core and the curated WASI module — and supplies the module's
+`mvm:egress` import as a JS trampoline that calls into the core.
+
+This is the honest structural difference from the host tier, and it is the
+reason the page carries no claim: the isolation boundary is the browser's,
+not mvm's.
+
+## The extraction
+
+Three pure cores move down into `mvm-contract`. Each is a relocation, following
+the verbatim-relocation discipline of
+[10-increment3-protocol-core-split.md](../refactor/10-increment3-protocol-core-split.md)
+— leaf-first, green and wasm-clean after every step, no serde-shape change.
+
+### E1 — the egress decision
+
+`crates/mvm-core/src/policy/projection.rs` (1,456 lines) already contains
+`Proto`, `CanonicalRule`, `CanonicalEgress`, `WasiEgress`, `to_wasi_grants()`
+and `wasi_allows(egress, proto, ip, port)` — the last of which exists
+specifically to project a `NetworkPolicy` onto a WASI grant set. That is the
+demo's gate, already written and already tested.
+
+Its dependencies are near-entirely portable:
+
+| Dependency | Status |
+|---|---|
+| `crate::policy::{dns_pin, network_policy, resolver}` | already in `mvm-contract` |
+| `thiserror` | already a `mvm-contract` `no_std` dep |
+| `std::net::IpAddr` | → `core::net::IpAddr`, the swap Increment 3 already made |
+| `ipnet` | supports `no_std` via `default-features = false` |
+
+Every consumer imports through the `mvm_core::ln` alias — `EgressGate`,
+`mvm-net`'s L3 admit, `mvm-hostd`'s proxy and DNS handler, `mvm-conformance` —
+roughly twenty call sites. `mvm-core` re-exports the relocated module under the
+same alias, so none of them change.
+
+`projection_fs_env.rs` (567 lines, the fs/env analogue) stays in `mvm-core`.
+The demo does not need it.
+
+### E2 — `${NAME}` substitution
+
+The pure resolution core teased out of
+`crates/mvm-hostd/src/keyholder/substitution.rs` (509 lines). The boundary,
+stated explicitly so the extraction is not a judgement call at implementation
+time:
+
+**Moves down** — locating `${NAME}` placeholders in a request, checking the
+name against the destination binding, and producing the substituted result from
+a supplied value. Pure functions over owned data.
+
+**Stays in `mvm-hostd`** — key custody and the encrypted secret store, the
+outbound forward leg, sockets and files, and anything async. The browser
+supplies its own fixture values through the same function signature the host
+supplies real ones through.
+
+### E3 — audit-entry construction and chain signing
+
+The pure core of `crates/mvm-hostd/src/supervisor/audit_file.rs` (1,400 lines):
+building a `SignedEnvelope` (entry + canonical bytes + `prev_hash` + signature)
+and `hash_line`. `FileAuditSigner`'s filesystem, mutex and async wrapper stay
+in `mvm-hostd`.
+
+This one is lower-risk than its line count suggests: `mvm-contract`'s
+`verify.rs` already implements the exact inverse, and its `signed_bytes_for` is
+documented as the byte-for-byte counterpart of `audit_file.rs`'s. The chain
+semantics are already portable; only the writer half is not.
+
+### Why relocate rather than reimplement
+
+After E1–E3 the host and the browser run identical code for all three things
+the page asserts on screen. A demo-local reimplementation would be a second
+copy of claim-10 and claim-13 logic with nothing keeping it in sync; the page
+would eventually market a behavior the product does not have, and we would find
+out from a user rather than from a red test.
+
+## The demo
+
+### Three curated modules
+
+Chosen to restate the existing host witness rather than invent new behavior.
+`wasm_egress_witness.rs` already asserts the first two against the real
+`SubstitutionService`.
+
+| Module | Policy | What the visitor sees | Audit event |
+|---|---|---|---|
+| `allowed` | allow-list contains the destination | Destination receives the real secret; module memory holds only `${API_KEY}` | `secret.substituted` |
+| `denied` | default-deny | Refused; destination never contacted | refusal entry |
+| `unbound` | host admitted, secret not bound to it | Request forwarded **without** the secret; placeholder dropped | `secret.placeholder_dropped` |
+
+The third is the claim-12 bind check, and it is the one most people do not
+expect: the destination is reachable and the request still goes out stripped.
+
+### Four panes at `/demo`
+
+1. **Module + policy** — pick a module; edit the allow-list. The editor's
+   output is a real `NetworkPolicy` deserialized by `mvm-contract`, not a
+   demo-shaped struct.
+2. **Module view** — what the guest holds. Shows the placeholder, never a value.
+3. **Destination view** — the exact bytes a simulated destination received,
+   labelled as simulated.
+4. **Audit chain** — entries append live. **Verify** runs
+   `verify_audit_chain_bytes`. **Tamper** flips one byte and re-verifies,
+   surfacing the typed failure with its line index (`PrevHashMismatch { line }`
+   or `SignatureInvalid { line }`, straight out of `AuditVerifyError`).
+
+The tamper button is the demo's strongest moment: it is the one property a
+visitor can falsify themselves, in their own browser, offline.
+
+### One run, end to end
+
+1. Main thread posts `{moduleId, policyJson}` to the Worker.
+2. The Worker instantiates the curated module, supplying `mvm:egress` as a JS
+   trampoline into the core.
+3. On each host-call the core canonicalizes the policy via
+   `canonicalize_network_policy`, decides via `wasi_allows`, resolves `${NAME}`
+   on allow, constructs and chain-signs an audit entry, and returns the outcome.
+4. On completion the Worker posts back the module view, the destination view and
+   the raw chain bytes.
+
+### Two stated simplifications
+
+- **No resolver.** `wasi_allows` takes an `IpAddr` and a browser has no
+  resolver, so the demo ships a fixed hostname→IP map as a fixture. DNS pinning
+  is out of scope.
+- **A fixed demo key, committed to the repo.** Reproducible, and it keeps a
+  `getrandom` shim out of the bundle. It demonstrates chain integrity and
+  tamper detection, not host key custody.
+
+Both appear in the page's own copy, not only here.
+
+## Error handling
+
+ADR-024 §2 binds the demo core exactly as it binds the host tier. A curated
+module that reaches for a capability the core does not provide receives a typed
+error naming what *is* supported — never a silent no-op, never a degraded
+approximation.
+
+The Worker propagates every error to the UI; nothing is swallowed into a blank
+pane. A failed run renders *why*, because a fail-closed refusal is the product
+behavior on display, not an embarrassment to hide.
+
+## Honesty guardrails
+
+The failure mode ADR-024 warns about is a demo that overstates. Three
+assertions, all in Rust, all in CI:
+
+- [ ] The fixture secret value does **not** appear anywhere in the
+      module-visible bytes, on any of the three modules. (claim-13 property,
+      asserted the way `wasm_egress_witness.rs` asserts it)
+- [ ] The secret **does** appear in the destination view on `allowed`, and
+      **does not** on `unbound`. Positive and negative, so a broken
+      substitution cannot pass by doing nothing.
+- [ ] The tier's capability description renders from a Rust-owned constant, so
+      the page's "what this does not prove" text cannot drift from the code.
+
+No claim-catalog witness is added. `xtask check-claim-catalog` reads ADR-001's
+table; this work touches no row. That is deliberate, and it is ADR-024 §3.
+
+### What the page must state plainly
+
+- The browser is the wasm engine. The host `WasmBackend` is not exercised.
+- This is a portability and governance demo, not an isolation boundary.
+- The claims-bearing way to run a wasm workload is plan 321's engine-in-guest
+  path, and the page links to it.
+
+## Testing
+
+The regression oracle is `crates/mvm-hostd/tests/wasm_egress_witness.rs`. It
+drives the real `SubstitutionService`, so if E2 or E3 changes behavior it goes
+red. **It must stay green unmodified** — that is the condition for believing the
+extraction was faithful. If it needs editing, the extraction was not a
+relocation and the design is wrong.
+
+- [ ] Full `cargo nextest run --workspace` for E1's ~20 call sites.
+- [ ] The existing wasm lane (`scripts/ci-linux-coverage.sh:20,23`) already
+      builds `mvm-contract` for `wasm32-unknown-unknown` and runs its tests
+      under `wasm32-wasip1`. The relocated projection tests then run *under
+      wasm* for free — closing plan 301 P1's "tests under wasm" gap for this
+      module as a side effect.
+- [ ] A fixture-parity test: the three browser fixtures produce the same
+      outcomes the host witness asserts.
+- [ ] `web/mvm-demo/` excluded from the workspace, as `web/audit-verify/` is.
+- [ ] `wasm-opt -Oz` plus a gzipped-size budget in that same lane (plan 301 B4's
+      discipline), failing the lane on regression.
+- [ ] Built in the builder VM, never a host toolchain (ADR-004 / ADR-007).
+- [ ] `cargo fmt --all -- --check` (nightly, per CI Lint),
+      `cargo clippy --workspace --all-targets -- -D warnings`,
+      `cargo test --workspace --doc`, xtask gates.
+
+## Sequencing constraints
+
+- **PR #2359 "Redesign the marketing site and docs chrome"** is open and
+  rewrites all of `public/src/components/landing/` (54 files), plus
+  `astro.config.mjs` and two new site gates
+  (`check-no-hardcoded-hex.mjs`, `check-sample-provenance.mjs`). The landing
+  teaser must be built against the redesigned page or it will be written and
+  then deleted. The `/demo` route itself is independent. Check both new gates
+  apply cleanly to the demo's rendered sample output.
+- **`feat/301-b1-nostd-oci-decoders`** is in flight and is also extracting into
+  `mvm-contract`, in a different module (OCI decoders vs. projection). Low
+  semantic conflict, but expect `crates/mvm-contract/Cargo.toml` to conflict
+  textually.
+- **PR #2355 `feat/308-wasm-bounds`** touches the host wasm tier (fuel and
+  epoch bounds). No overlap with this plan's files, but land order matters if
+  both touch `wasm_backend.rs`.
+
+## Non-goals
+
+- Any numbered security claim for the browser tier. ADR-024 §3.
+- Exercising the host `WasmBackend` or `wasmtime` from the page. Structurally
+  impossible; the page says so.
+- Merkle inclusion proofs. Plan 301 B5 retires `web/audit-verify/` only once its
+  replacement covers chain verification **and** Merkle inclusion. This demo
+  covers the former only, so `web/audit-verify/` stays and B5 remains plan
+  301's.
+- `mvmctl audit pubkey`. Not needed here — the demo uses a fixed key. Remains
+  plan 301 B5's.
+- Arbitrary user-uploaded modules. Curated fixtures only.
+- Replacing JCS canonical JSON anywhere on the signed control plane.

--- a/specs/plans/321-wasm-in-microvm-workload-format.md
+++ b/specs/plans/321-wasm-in-microvm-workload-format.md
@@ -1,0 +1,153 @@
+# Plan 321: wasm as a workload format inside a real microVM
+
+## Status
+
+DESIGN — not started. Captured so it is not lost; sequenced after
+[plan 320](320-wasm-browser-demo.md), which is independent of it.
+
+This is the **engine-in-guest** path [ADR-024](../adrs/024-wasm-sandbox-backend.md)
+explicitly sanctions:
+
+> If the backend is ever used to execute a workload as more than a demo/preview
+> […] the untrusted-bytes-executing engine (wasmtime or equivalent) runs as a
+> guest binary inside a real microVM, never as a host process dependency.
+
+## Why this, and not "finish the host wasm tier"
+
+"Support wasm fully as a backend" splits into two things, and only one of them
+is reachable.
+
+**Finishing the host tier** — plan 301 Part A (end-to-end `start()` coverage,
+TLS-terminating substitution, transparent WASI socket interception, Preview 1
+vs 2) — produces a better *portability* backend. Its ceiling is fixed by
+ADR-024 §3: no numbered claims, ever. Not for lack of effort; a host wasm
+engine provides no hardware isolation boundary, so there is nothing to claim.
+
+**This plan** produces something different: a wasm workload that **inherits
+every numbered claim from the microVM it runs inside** — verity-sealed rootfs
+(claim 3), NIC-less vsock-only egress (claim 10), no raw secret in the guest
+(claim 13), no shell or PTY (claim 15). The isolation boundary is the microVM;
+wasm is merely the executable format. Nothing new gets claimed, no ADR is
+amended, and no new backend is introduced.
+
+It is also the smaller of the two, because most of it already exists.
+
+## What already exists
+
+- `crates/mvm-agentd/src/runner/config.rs:30` — `Language::Wasm` is a variant of
+  the closed runtime language enum, with `interpreter() == "wasmtime"` and
+  `dispatch_filename() == "dispatch.wasm"`.
+- `crates/mvm-agentd/src/bin/mvm-runner.rs:154` — already emits
+  `wasmtime run <fragment>` in-guest.
+- `crates/mvm-contract/data/supported_languages.txt` already lists `wasm`, so
+  the host validator does not reject it with `E_UNSUPPORTED_LANGUAGE`.
+
+## What is missing
+
+The image half. `nix/lib/factories/languages/default.nix:17-20` states it
+plainly:
+
+> Wasm intentionally lives outside the registry today because its inputs differ
+> (the user's `.wasm` module IS the wrapper; no interpreter package is baked).
+> When it lands it becomes a row with `interpreter = null` + a wrapper-kind
+> discriminator the builder branches on.
+
+`nix/wrappers/` has `python/` and `node/` and no `wasm/` — correctly, since the
+user's module is the dispatch fragment and there is no wrapper script to write.
+
+## Workstreams
+
+### WS1 — the Nix factory row
+
+- [ ] Add a `wasm` row to `nix/lib/factories/languages/registry.nix` with
+      `interpreter = null` and a wrapper-kind discriminator, exactly as
+      `default.nix`'s comment prescribes.
+- [ ] Branch the generic builder in `default.nix` on that discriminator: bake
+      `pkgs.wasmtime` into `servicePackages` and the user-supplied `.wasm` as
+      `dispatch.wasm`, with no wrapper script and no shebang stamp.
+- [ ] Confirm `wasmtime` is on PATH inside the busybox workload rootfs. The
+      rootfs has no `/usr/bin/env`, which is why the other languages stamp store
+      paths; wasmtime is invoked as a real binary rather than via a shebang, so
+      this should be simpler — verify rather than assume.
+- [ ] Record the rootfs size delta. `wasmtime` is a large binary relative to a
+      busybox workload rootfs, and this tier boots per workload.
+- Gate: an image builds with a `.wasm` dispatch fragment and `wasmtime` on PATH.
+
+### WS2 — end-to-end run, compute-only
+
+- [ ] `mvmctl` builds and runs a `.wasm` workload end to end: image → boot on a
+      real backend → agent execs `wasmtime run dispatch.wasm` → stdin args → fn
+      → stdout return, over the existing framed wire contract.
+- [ ] Exercise on at least Firecracker and one macOS backend.
+- [ ] Assert the workload inherits the sealed-tier posture: verity-sealed
+      rootfs, no shell, no PTY, no DevOnly verbs.
+- Gate: a wasm workload runs to completion on a real microVM and returns its
+      value; the sealed-tier refusals hold.
+
+### WS3 — egress, and the Preview 1 wall
+
+**This is the plan's one real unknown, and it should not be discovered during
+implementation.**
+
+In-guest workloads reach the network through `HTTP_PROXY`/`HTTPS_PROXY` pointed
+at `mvm-agentd`'s loopback forward proxy
+(`crates/mvm-agentd/src/forward_proxy.rs`), which rides vsock to the host
+substitution endpoint. That is how Python and Node workloads get governed
+egress with no NIC.
+
+A wasm workload cannot use it as written: **WASI Preview 1 has no sockets at
+all.** `wasmtime run` under Preview 1 gives the module stdin, stdout and exit —
+nothing else. Proxy environment variables are meaningless to a module that
+cannot open a socket.
+
+So:
+
+- [ ] Ship WS1+WS2 as **compute-only wasm workloads** and say so plainly:
+      deterministic stdin → fn → stdout, no network. This is honest, useful,
+      and complete on its own — it is the shape most compile-to-wasm functions
+      take anyway.
+- [ ] Only then evaluate egress, which requires WASI Preview 2 sockets (or
+      `wasmtime serve -S http`), and resolve the same Preview 1 vs Preview 2
+      divergence plan 301 A4 tracks on the host tier. Do not start it before
+      WS2 is green.
+- [ ] When egress does land, confirm the loopback forward proxy is reachable —
+      the NIC-less tier has a known trap where `lo` is down under default-deny.
+- Gate for the compute-only cut: a wasm workload with no network runs green,
+  and any attempt at network access fails closed rather than silently
+  succeeding.
+
+### WS4 — documentation and stale-reference cleanup
+
+Found while scoping this; small, and it misleads the next reader.
+
+- [ ] `crates/mvm-agentd/src/runner/config.rs` cites
+      `mvm-sdk/src/ir/workload.rs` and `crates/mvm-ir/data/supported_languages.txt`.
+      Both moved: the IR is `crates/mvm-contract/src/ir/workload.rs` and the
+      allowlist is `crates/mvm-contract/data/supported_languages.txt`.
+- [ ] `crates/mvm-contract/data/supported_languages.txt` refers to "mvmforge"
+      and `crates/mvmforge/src/shims/`. There is no `mvmforge` crate.
+- [ ] Document the wasm workload path in the site's SDK/guides section once WS2
+      is green.
+- [ ] Update ADR-024's Status: it asserts "No implementation has landed yet",
+      which has been false since plan 301 P2 landed `WasmBackend`. (Also
+      tracked as plan 301 A5 — do it in whichever lands first.)
+
+## Non-goals
+
+- A host-side wasm backend carrying numbered claims. ADR-024 §3; that is
+  what plan 301 Part A's ceiling is about.
+- Replacing the host `WasmBackend`. It remains the claim-free portability tier
+  and this plan does not touch it.
+- Egress in the first cut. WS3 defers it deliberately rather than shipping a
+  half-governed network path.
+- A new `BackendKind`. This is a workload format on the existing backends, not
+  a backend.
+
+## Relationship to other plans
+
+- [Plan 320](320-wasm-browser-demo.md) — the browser demo. Independent; ships
+  first. Its page links here as the claims-bearing way to actually run a wasm
+  workload.
+- Plan 301 Part A — the host wasm tier's completion. Independent of this plan;
+  shares only the Preview 1 vs Preview 2 question (301 A4 / this plan's WS3) and
+  the ADR-024 Status fix (301 A5 / this plan's WS4).


### PR DESCRIPTION
Design-only. Two plans and the rollup update; no code changes.

## Plan 320 — a live wasm sandbox demo on the website

A dedicated `/demo` route where a visitor runs a curated WASI module in the browser's own wasm engine, edits its egress policy, watches a simulated destination receive a substituted secret the module never held, and then verifies — or tampers with — the resulting chain-signed audit log, offline. A compact teaser card on the landing page links to it.

Three fixtures, chosen to restate the existing host witness rather than invent behavior:

| Module | Policy | Audit event |
|---|---|---|
| `allowed` | allow-list contains the destination | `secret.substituted` |
| `denied` | default-deny | refusal entry |
| `unbound` | host admitted, secret not bound to it | `secret.placeholder_dropped` |

The third is the claim-12 bind check — the destination is reachable and the request still goes out stripped — which is the one most people don't expect.

**The load-bearing decision** is that the demo *shares* code with the host rather than reimplementing it. Three pure cores relocate into `mvm-contract`:

- the egress decision — `crates/mvm-core/src/policy/projection.rs`, which already contains `WasiEgress`, `to_wasi_grants()` and `wasi_allows()`. Near-verbatim: its dependencies (`dns_pin`, `network_policy`, `resolver`, `thiserror`) are already in `mvm-contract`, `std::net::IpAddr` becomes `core::net::IpAddr`, and `ipnet` supports `no_std`. `mvm_core::ln` stays a re-export, so its ~20 call sites don't move.
- the `${NAME}` substitution core, with the moves/stays boundary stated explicitly in the plan.
- the audit writer core. Lower-risk than its line count suggests — `mvm-contract`'s `verify.rs` already implements the exact inverse, and its `signed_bytes_for` is documented as the byte-for-byte counterpart of `audit_file.rs`'s.

`crates/mvm-hostd/tests/wasm_egress_witness.rs` is the oracle and **must stay green unmodified**. If it needs editing, the extraction wasn't a relocation and the design is wrong.

**A premise the plan corrects.** `WasmBackend` runs on the host under native `wasmtime`, which cannot run in a browser — so nothing in the tree drops onto a web page as-is, and the host backend is never exercised by the demo. The page uses the browser's own engine and says so. It carries no numbered claim (ADR-024 §3) and adds no claim-catalog witness.

## Plan 321 — wasm as a workload format inside a real microVM

ADR-024's sanctioned engine-in-guest path, captured so it isn't lost. A wasm workload run this way inherits claims 3/10/13/15 from the microVM around it, because the isolation boundary is the microVM and wasm is only the executable format. No new `BackendKind`.

Most of it already exists: `Language::Wasm` in `mvm-agentd/src/runner/config.rs`, `wasmtime run` at `mvm-runner.rs:154`, and `wasm` in `mvm-contract/data/supported_languages.txt`. Only the Nix image half is missing, and `nix/lib/factories/languages/default.nix:17-20` already spells out what landing it means.

Its one real unknown is named up front rather than discovered mid-build: **WASI Preview 1 has no sockets**, so a `wasmtime run` workload cannot use the `HTTP_PROXY` → loopback forward proxy → vsock path Python and Node workloads use for governed egress. The first cut is therefore compute-only, deliberately, rather than a half-governed network path.

## Sequencing notes for reviewers

- PR #2359 rewrites all of `public/src/components/landing/`. The `/demo` route is independent, but the landing teaser must be built against that redesign.
- `feat/301-b1-nostd-oci-decoders` is also extracting into `mvm-contract` (OCI decoders, a different module). Low semantic conflict; expect `crates/mvm-contract/Cargo.toml` to conflict textually.
- Plan 320 does **not** retire `web/audit-verify/` — it covers chain verification but not Merkle inclusion, so plan 301 B5 and `mvmctl audit pubkey` stay where they are.
