### PR TITLE
Relocate the egress-decision core into mvm-contract (plan 320 E1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,6 +3120,7 @@ dependencies = [
  "bytes",
  "chrono",
  "ed25519-dalek",
+ "ipnet",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/mvm-contract/Cargo.toml
+++ b/crates/mvm-contract/Cargo.toml
@@ -22,6 +22,11 @@ base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 # `DateTime<Utc>` fields byte-identical across the move.
 chrono = { version = "0.4", default-features = false, features = ["serde", "alloc"], optional = true }
 ed25519-dalek = { version = "3", default-features = false }
+# The egress-projection core decides over CIDRs. `default-features = false`
+# drops ipnet's `std` feature, under which its `AddrParseError` implements
+# `core::error::Error` instead — which is what the projection's `thiserror`
+# derive needs to carry it as an error `source` under `no_std`.
+ipnet = { version = "2", default-features = false }
 # Only under the `schema` feature (IR JSON-Schema codegen for
 # `mvm-sdk`'s `emit_schema`/`emit_addon_schema` bins). schemars 0.8's
 # derive macro emits `std::`-rooted paths unconditionally, so it can't

--- a/crates/mvm-contract/src/policy/mod.rs
+++ b/crates/mvm-contract/src/policy/mod.rs
@@ -1,10 +1,11 @@
 //! Policy DTO leaves — the pure serde types describing session/frame
 //! security posture, sub-policy shapes referenced by `PolicyBundle`,
 //! per-destination egress redaction, per-destination reversible-
-//! replacement rules, admission-time DNS pins, and CLI secret bindings.
-//! Resolution, signing, and clock-/env-dependent logic stays in
-//! `mvm-core::policy`, which re-exports these modules at their existing
-//! paths.
+//! replacement rules, admission-time DNS pins, and CLI secret bindings —
+//! plus the egress-projection decision core, which is pure decision logic
+//! over those DTOs with no I/O and no resolver. Signing and
+//! clock-/env-/fs-dependent logic stays in `mvm-core::policy`, which
+//! re-exports these modules at their existing paths.
 
 pub mod approval;
 pub mod audit;
@@ -12,6 +13,7 @@ pub mod bundle;
 pub mod dns_pin;
 pub mod network_policy;
 pub mod policies;
+pub mod projection;
 pub mod redaction;
 pub mod resolver;
 pub mod reversible_replacement;

--- a/crates/mvm-contract/src/policy/network_policy.rs
+++ b/crates/mvm-contract/src/policy/network_policy.rs
@@ -1,14 +1,14 @@
 //! Egress-policy DTOs — the pure, wire-shape half of `NetworkPolicy`.
 //!
 //! `HostPort`, `NetworkPreset`, `EgressMode`, `NetworkPolicy`, the
-//! `BANNED_SSH_PORT`/`MANDATORY_DENY_RANGES` consts, and every pure
-//! constructor/accessor live here. The `ipnet`/`std::net` mandatory-deny
-//! logic and the iptables script generators (which need a concrete
-//! `NetworkPolicy` plus host networking types) stay in
-//! `mvm_core::policy::network_policy`, which re-exports every type in
-//! this module at its existing path.
+//! `BANNED_SSH_PORT`/`MANDATORY_DENY_RANGES` consts, every pure
+//! constructor/accessor, and the mandatory-deny predicates the egress
+//! projection decides with live here. The iptables script generators
+//! (host-only shell emission) stay in `mvm_core::policy::network_policy`,
+//! which re-exports everything in this module at its existing path.
 
 use core::fmt;
+use core::net::IpAddr;
 use core::str::FromStr;
 
 use alloc::format;
@@ -487,6 +487,66 @@ pub const MANDATORY_DENY_RANGES: &[&str] = &[
     "fe80::/10",
 ];
 
+/// Parse [`MANDATORY_DENY_RANGES`] into typed [`ipnet::IpNet`]s.
+/// Done at call time (no `lazy_static` / `OnceLock`) — the list
+/// is small (<10 entries) and parse cost is dominated by the
+/// `Vec` allocation. A malformed entry is a programmer bug, not
+/// a runtime failure; the `mandatory_deny_ranges_const_parses`
+/// test catches typos before they ship.
+///
+/// Note: panics if any entry fails to parse. The single test
+/// guards the const, so a panic here can only happen if a future
+/// edit slips both the const review and CI — caller doesn't need
+/// to handle the error path.
+pub fn mandatory_deny_ranges() -> Vec<ipnet::IpNet> {
+    MANDATORY_DENY_RANGES
+        .iter()
+        .map(|s| {
+            s.parse().unwrap_or_else(|_| {
+                panic!("MANDATORY_DENY_RANGES contains invalid CIDR {s:?} — fix the const")
+            })
+        })
+        .collect()
+}
+
+/// Returns `true` if `ip` falls within any of the mandatory
+/// deny ranges. The defense-in-depth check every egress
+/// enforcer (iptables setup, `CanonicalEgress::permits`, the L7
+/// proxy) should run *before* consulting the user's allow-list — a
+/// hit here means the destination is forbidden full stop, no matter
+/// how permissive the allow-list is.
+///
+/// Allocates a small `Vec` per call today; the call site is
+/// admission-path or per-flow, neither of which is hot enough to
+/// justify cached parsing. A perf-sensitive consumer can hoist
+/// [`mandatory_deny_ranges`] outside its loop.
+pub fn is_mandatory_deny(ip: IpAddr) -> bool {
+    let ip = unmap_v4_mapped(ip);
+    mandatory_deny_ranges().iter().any(|net| net.contains(&ip))
+}
+
+/// Collapse an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) to its embedded
+/// IPv4 address, leaving every other address unchanged.
+///
+/// A dual-stack socket (the Linux default, without `IPV6_V6ONLY`) connecting
+/// to the mapped form is routed by the kernel to the embedded IPv4
+/// destination, so an egress range check that inspects the IPv6 form sees an
+/// opaque address and misses IPv4-only deny ranges — a `::ffff:169.254.169.254`
+/// would otherwise slip past the metadata deny. Normalizing here forces the
+/// check onto the address the kernel will actually reach. `::1`, `::`,
+/// `fe80::/10` and `fc00::/7` are not mapped forms, so they stay IPv6 and are
+/// classified by the IPv6 rules.
+#[must_use]
+pub fn unmap_v4_mapped(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => IpAddr::V4(v4),
+            None => IpAddr::V6(v6),
+        },
+        IpAddr::V4(_) => ip,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::vec;
@@ -907,5 +967,167 @@ mod tests {
         assert_eq!(policy, NetworkPolicy::unrestricted());
         assert_ne!(policy, NetworkPolicy::deny_all());
         assert_ne!(policy, NetworkPolicy::default());
+    }
+    // =====================================================================
+    // Mandatory deny ranges
+    // =====================================================================
+
+    /// Every entry in [`MANDATORY_DENY_RANGES`] must parse cleanly.
+    /// A typo here panics every consumer at runtime — catch it at
+    /// build time instead.
+    #[test]
+    fn mandatory_deny_ranges_const_parses() {
+        // `mandatory_deny_ranges()` itself panics on a parse
+        // failure, so calling it inside the test surfaces a typo
+        // as a test failure rather than a release-time panic.
+        let nets = mandatory_deny_ranges();
+        assert_eq!(
+            nets.len(),
+            MANDATORY_DENY_RANGES.len(),
+            "every constant entry should produce one IpNet"
+        );
+    }
+
+    /// The cloud metadata endpoint is the highest-stakes single
+    /// IP in the list. Asserting it directly (not just via the
+    /// containing `/16`) keeps the test loud if a future edit
+    /// removes the specific `/32` entry.
+    #[test]
+    fn cloud_metadata_endpoint_is_denied() {
+        let metadata: std::net::IpAddr = "169.254.169.254".parse().unwrap();
+        assert!(
+            is_mandatory_deny(metadata),
+            "AWS/GCP/Azure IMDS at 169.254.169.254 must be in the default-deny set"
+        );
+    }
+
+    #[test]
+    fn link_local_ipv4_is_denied() {
+        // Other points within the /16 must also fall in the deny
+        // set (the metadata `/32` is a subset of this `/16`).
+        for addr in ["169.254.0.1", "169.254.42.42", "169.254.255.254"] {
+            let ip: std::net::IpAddr = addr.parse().unwrap();
+            assert!(
+                is_mandatory_deny(ip),
+                "link-local IPv4 {addr} must be denied"
+            );
+        }
+    }
+
+    #[test]
+    fn link_local_ipv6_is_denied() {
+        for addr in ["fe80::1", "fe80::abcd:ef12:3456:7890"] {
+            let ip: std::net::IpAddr = addr.parse().unwrap();
+            assert!(
+                is_mandatory_deny(ip),
+                "link-local IPv6 {addr} must be denied"
+            );
+        }
+    }
+
+    #[test]
+    fn cgnat_range_is_denied() {
+        // 100.64.0.0/10 = 100.64.0.0 through 100.127.255.255.
+        for addr in ["100.64.0.1", "100.127.255.254"] {
+            let ip: std::net::IpAddr = addr.parse().unwrap();
+            assert!(is_mandatory_deny(ip), "CGNAT {addr} must be denied");
+        }
+        // Just outside the CGNAT range must NOT be denied.
+        let outside: std::net::IpAddr = "100.63.255.255".parse().unwrap();
+        assert!(
+            !is_mandatory_deny(outside),
+            "100.63.255.255 is one below CGNAT and should NOT be denied"
+        );
+        let above: std::net::IpAddr = "100.128.0.0".parse().unwrap();
+        assert!(
+            !is_mandatory_deny(above),
+            "100.128.0.0 is one above CGNAT and should NOT be denied"
+        );
+    }
+
+    #[test]
+    fn host_loopback_v4_and_v6_are_denied() {
+        let v4: std::net::IpAddr = "127.0.0.1".parse().unwrap();
+        let v6: std::net::IpAddr = "::1".parse().unwrap();
+        assert!(is_mandatory_deny(v4), "127.0.0.1 must be denied");
+        assert!(is_mandatory_deny(v6), "::1 must be denied");
+        // Anywhere inside 127.0.0.0/8 must be denied too.
+        let nested: std::net::IpAddr = "127.42.99.7".parse().unwrap();
+        assert!(is_mandatory_deny(nested), "127.42.99.7 must be denied");
+    }
+
+    #[test]
+    fn ipv4_mapped_forms_do_not_bypass_mandatory_deny() {
+        // The IPv4-only deny ranges must still catch the IPv4-mapped IPv6
+        // spelling — a dual-stack connect to `::ffff:a.b.c.d` reaches `a.b.c.d`.
+        for addr in [
+            "::ffff:169.254.169.254", // metadata
+            "::ffff:127.0.0.1",       // loopback
+            "::ffff:100.64.0.1",      // CGNAT
+        ] {
+            let ip: std::net::IpAddr = addr.parse().unwrap();
+            assert!(is_mandatory_deny(ip), "mapped {addr} must be denied");
+        }
+        // A mapped *public* address is not mandatory-deny.
+        let public: std::net::IpAddr = "::ffff:93.184.216.34".parse().unwrap();
+        assert!(
+            !is_mandatory_deny(public),
+            "mapped public must not be denied"
+        );
+    }
+
+    /// Legitimate public IPs must pass through cleanly so a
+    /// future regression that overzealously expands the deny
+    /// set (e.g. blocking all RFC1918) surfaces here.
+    #[test]
+    fn legitimate_public_ips_are_not_denied() {
+        let cases = [
+            "8.8.8.8",              // Google DNS
+            "1.1.1.1",              // Cloudflare DNS
+            "104.16.0.1",           // arbitrary Cloudflare anycast
+            "2001:4860:4860::8888", // Google DNS IPv6
+            "2606:4700:4700::1111", // Cloudflare DNS IPv6
+        ];
+        for addr in cases {
+            let ip: std::net::IpAddr = addr.parse().unwrap();
+            assert!(
+                !is_mandatory_deny(ip),
+                "{addr} must NOT be denied (legitimate public dest)"
+            );
+        }
+    }
+
+    /// RFC1918 ranges are deliberately NOT in the default-deny
+    /// set — corporate VPNs, home labs, and k8s pod networks live
+    /// here and breaking them would be a UX regression. If a
+    /// future edit accidentally adds RFC1918 to the const, this
+    /// test fails loudly and the maintainer reads the comment
+    /// above MANDATORY_DENY_RANGES that says why.
+    #[test]
+    fn rfc1918_is_not_in_default_deny() {
+        let cases = ["10.0.0.1", "172.16.0.1", "192.168.1.1"];
+        for addr in cases {
+            let ip: std::net::IpAddr = addr.parse().unwrap();
+            assert!(
+                !is_mandatory_deny(ip),
+                "{addr} is RFC1918 — must NOT be in default-deny (legitimate corp/VPN use)"
+            );
+        }
+    }
+
+    /// The first entry in the list is the cloud metadata `/32`.
+    /// Pinning the order matters: a maintainer scanning the
+    /// const should hit the most consequential entry first and
+    /// think twice before removing it. If a future PR rearranges
+    /// the entries, this assertion forces a conscious decision
+    /// rather than a silent reordering.
+    #[test]
+    fn cloud_metadata_is_first_entry_in_const() {
+        assert_eq!(
+            MANDATORY_DENY_RANGES[0], "169.254.169.254/32",
+            "cloud metadata /32 should be the first entry — it's the most \
+             consequential single address and a maintainer scanning the \
+             list should see it before anything else"
+        );
     }
 }

--- a/crates/mvm-contract/src/policy/projection.rs
+++ b/crates/mvm-contract/src/policy/projection.rs
@@ -18,7 +18,10 @@
 //!
 //! [`EffectivePolicy`]: crate::policy::resolver::EffectivePolicy
 
-use std::net::IpAddr;
+use core::net::IpAddr;
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 use ipnet::IpNet;
 use thiserror::Error;
@@ -37,7 +40,7 @@ pub enum Proto {
     Udp,
 }
 
-impl std::str::FromStr for Proto {
+impl core::str::FromStr for Proto {
     type Err = ProjectionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -52,7 +55,7 @@ impl std::str::FromStr for Proto {
 }
 
 impl Proto {
-    /// Named alias for [`std::str::FromStr`] used by the lowering code.
+    /// Named alias for [`core::str::FromStr`] used by the lowering code.
     pub fn parse(s: &str) -> Result<Self, ProjectionError> {
         s.parse()
     }

--- a/crates/mvm-core/src/policy/mod.rs
+++ b/crates/mvm-core/src/policy/mod.rs
@@ -15,19 +15,19 @@ pub mod security_profile;
 // Tenant policy bundles — authoring, resolution, signing, TOML loading.
 // Folded in from the former `mvm-policy` crate. mvmd consumes the
 // resolver + bundle types via the facade.
-pub mod projection;
 pub mod projection_fs_env;
 pub mod resolver;
 pub mod signing;
 pub mod toml_loader;
 
 // `security`, `reversible_replacement`, `policies`, `redaction`, and
-// `bundle` are pure-DTO leaves that now live in `mvm-contract`; re-exported
+// `bundle` are pure-DTO leaves that now live in `mvm-contract`, and
+// `projection` is the pure egress-decision core alongside them; re-exported
 // here as module aliases so every existing
-// `crate::policy::{security,reversible_replacement,policies,redaction,bundle}::X`
+// `crate::policy::{security,reversible_replacement,policies,redaction,bundle,projection}::X`
 // path keeps resolving unchanged.
 pub use mvm_contract::policy::{
-    approval, bundle, policies, redaction, reversible_replacement, security,
+    approval, bundle, policies, projection, redaction, reversible_replacement, security,
 };
 
 pub use bundle::{PolicyBundle, PolicyId, SCHEMA_VERSION, TenantOverlay};

--- a/crates/mvm-core/src/policy/network_policy.rs
+++ b/crates/mvm-core/src/policy/network_policy.rs
@@ -1,16 +1,17 @@
-//! Egress-policy logic — iptables script generation and the
-//! `ipnet`/`std::net` mandatory-deny enforcement.
+//! Egress-policy logic — iptables script generation.
 //!
 //! The DTO half (`HostPort`, `NetworkPreset`, `EgressMode`,
 //! `NetworkPolicy`, the `BANNED_SSH_PORT`/`MANDATORY_DENY_RANGES`
-//! consts, `is_banned_ssh_port`, and every pure constructor/accessor)
-//! lives in `mvm_contract::policy::network_policy` and is re-exported
-//! below so every existing `crate::policy::network_policy::X` /
-//! `mvm_core::policy::network_policy::X` path keeps resolving unchanged.
+//! consts, `is_banned_ssh_port`, every pure constructor/accessor, and
+//! the `ipnet`-typed mandatory-deny predicates the egress projection
+//! decides with) lives in `mvm_contract::policy::network_policy` and is
+//! re-exported below so every existing `crate::policy::network_policy::X`
+//! / `mvm_core::policy::network_policy::X` path keeps resolving unchanged.
 
 pub use mvm_contract::policy::network_policy::{
     BANNED_SSH_PORT, EgressMode, HostPort, MANDATORY_DENY_RANGES, NetworkPolicy,
-    NetworkPolicyParseError, NetworkPreset, is_banned_ssh_port,
+    NetworkPolicyParseError, NetworkPreset, is_banned_ssh_port, is_mandatory_deny,
+    mandatory_deny_ranges, unmap_v4_mapped,
 };
 
 const SSH_BANNER_HEX_PREFIX: &str = "|5353482d|";
@@ -96,70 +97,6 @@ pub fn iptables_cleanup_script(
         br = bridge_dev,
         ip = guest_ip,
     ))
-}
-
-// ============================================================================
-// Mandatory deny ranges
-// ============================================================================
-
-/// Parse [`MANDATORY_DENY_RANGES`] into typed [`ipnet::IpNet`]s.
-/// Done at call time (no `lazy_static` / `OnceLock`) — the list
-/// is small (<10 entries) and parse cost is dominated by the
-/// `Vec` allocation. A malformed entry is a programmer bug, not
-/// a runtime failure; the `mandatory_deny_ranges_const_parses`
-/// test catches typos before they ship.
-///
-/// Note: panics if any entry fails to parse. The single test
-/// guards the const, so a panic here can only happen if a future
-/// edit slips both the const review and CI — caller doesn't need
-/// to handle the error path.
-pub fn mandatory_deny_ranges() -> Vec<ipnet::IpNet> {
-    MANDATORY_DENY_RANGES
-        .iter()
-        .map(|s| {
-            s.parse().unwrap_or_else(|_| {
-                panic!("MANDATORY_DENY_RANGES contains invalid CIDR {s:?} — fix the const")
-            })
-        })
-        .collect()
-}
-
-/// Returns `true` if `ip` falls within any of the mandatory
-/// deny ranges. The defense-in-depth check every egress
-/// enforcer (iptables setup, `CanonicalEgress::permits`, the L7
-/// proxy) should run *before* consulting the user's allow-list — a
-/// hit here means the destination is forbidden full stop, no matter
-/// how permissive the allow-list is.
-///
-/// Allocates a small `Vec` per call today; the call site is
-/// admission-path or per-flow, neither of which is hot enough to
-/// justify cached parsing. A perf-sensitive consumer can hoist
-/// [`mandatory_deny_ranges`] outside its loop.
-pub fn is_mandatory_deny(ip: std::net::IpAddr) -> bool {
-    let ip = unmap_v4_mapped(ip);
-    mandatory_deny_ranges().iter().any(|net| net.contains(&ip))
-}
-
-/// Collapse an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) to its embedded
-/// IPv4 address, leaving every other address unchanged.
-///
-/// A dual-stack socket (the Linux default, without `IPV6_V6ONLY`) connecting
-/// to the mapped form is routed by the kernel to the embedded IPv4
-/// destination, so an egress range check that inspects the IPv6 form sees an
-/// opaque address and misses IPv4-only deny ranges — a `::ffff:169.254.169.254`
-/// would otherwise slip past the metadata deny. Normalizing here forces the
-/// check onto the address the kernel will actually reach. `::1`, `::`,
-/// `fe80::/10` and `fc00::/7` are not mapped forms, so they stay IPv6 and are
-/// classified by the IPv6 rules.
-#[must_use]
-pub fn unmap_v4_mapped(ip: std::net::IpAddr) -> std::net::IpAddr {
-    match ip {
-        std::net::IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
-            Some(v4) => std::net::IpAddr::V4(v4),
-            None => std::net::IpAddr::V6(v6),
-        },
-        std::net::IpAddr::V4(_) => ip,
-    }
 }
 
 /// Emit the iptables shell fragment that drops outbound from
@@ -305,169 +242,6 @@ mod tests {
         let policy = NetworkPolicy::deny_all();
         let script = iptables_cleanup_script(&policy, "br-mvm", "172.16.0.2").unwrap();
         assert!(script.contains("iptables -D FORWARD"));
-    }
-
-    // =====================================================================
-    // Mandatory deny ranges
-    // =====================================================================
-
-    /// Every entry in [`MANDATORY_DENY_RANGES`] must parse cleanly.
-    /// A typo here panics every consumer at runtime — catch it at
-    /// build time instead.
-    #[test]
-    fn mandatory_deny_ranges_const_parses() {
-        // `mandatory_deny_ranges()` itself panics on a parse
-        // failure, so calling it inside the test surfaces a typo
-        // as a test failure rather than a release-time panic.
-        let nets = mandatory_deny_ranges();
-        assert_eq!(
-            nets.len(),
-            MANDATORY_DENY_RANGES.len(),
-            "every constant entry should produce one IpNet"
-        );
-    }
-
-    /// The cloud metadata endpoint is the highest-stakes single
-    /// IP in the list. Asserting it directly (not just via the
-    /// containing `/16`) keeps the test loud if a future edit
-    /// removes the specific `/32` entry.
-    #[test]
-    fn cloud_metadata_endpoint_is_denied() {
-        let metadata: std::net::IpAddr = "169.254.169.254".parse().unwrap();
-        assert!(
-            is_mandatory_deny(metadata),
-            "AWS/GCP/Azure IMDS at 169.254.169.254 must be in the default-deny set"
-        );
-    }
-
-    #[test]
-    fn link_local_ipv4_is_denied() {
-        // Other points within the /16 must also fall in the deny
-        // set (the metadata `/32` is a subset of this `/16`).
-        for addr in ["169.254.0.1", "169.254.42.42", "169.254.255.254"] {
-            let ip: std::net::IpAddr = addr.parse().unwrap();
-            assert!(
-                is_mandatory_deny(ip),
-                "link-local IPv4 {addr} must be denied"
-            );
-        }
-    }
-
-    #[test]
-    fn link_local_ipv6_is_denied() {
-        for addr in ["fe80::1", "fe80::abcd:ef12:3456:7890"] {
-            let ip: std::net::IpAddr = addr.parse().unwrap();
-            assert!(
-                is_mandatory_deny(ip),
-                "link-local IPv6 {addr} must be denied"
-            );
-        }
-    }
-
-    #[test]
-    fn cgnat_range_is_denied() {
-        // 100.64.0.0/10 = 100.64.0.0 through 100.127.255.255.
-        for addr in ["100.64.0.1", "100.127.255.254"] {
-            let ip: std::net::IpAddr = addr.parse().unwrap();
-            assert!(is_mandatory_deny(ip), "CGNAT {addr} must be denied");
-        }
-        // Just outside the CGNAT range must NOT be denied.
-        let outside: std::net::IpAddr = "100.63.255.255".parse().unwrap();
-        assert!(
-            !is_mandatory_deny(outside),
-            "100.63.255.255 is one below CGNAT and should NOT be denied"
-        );
-        let above: std::net::IpAddr = "100.128.0.0".parse().unwrap();
-        assert!(
-            !is_mandatory_deny(above),
-            "100.128.0.0 is one above CGNAT and should NOT be denied"
-        );
-    }
-
-    #[test]
-    fn host_loopback_v4_and_v6_are_denied() {
-        let v4: std::net::IpAddr = "127.0.0.1".parse().unwrap();
-        let v6: std::net::IpAddr = "::1".parse().unwrap();
-        assert!(is_mandatory_deny(v4), "127.0.0.1 must be denied");
-        assert!(is_mandatory_deny(v6), "::1 must be denied");
-        // Anywhere inside 127.0.0.0/8 must be denied too.
-        let nested: std::net::IpAddr = "127.42.99.7".parse().unwrap();
-        assert!(is_mandatory_deny(nested), "127.42.99.7 must be denied");
-    }
-
-    #[test]
-    fn ipv4_mapped_forms_do_not_bypass_mandatory_deny() {
-        // The IPv4-only deny ranges must still catch the IPv4-mapped IPv6
-        // spelling — a dual-stack connect to `::ffff:a.b.c.d` reaches `a.b.c.d`.
-        for addr in [
-            "::ffff:169.254.169.254", // metadata
-            "::ffff:127.0.0.1",       // loopback
-            "::ffff:100.64.0.1",      // CGNAT
-        ] {
-            let ip: std::net::IpAddr = addr.parse().unwrap();
-            assert!(is_mandatory_deny(ip), "mapped {addr} must be denied");
-        }
-        // A mapped *public* address is not mandatory-deny.
-        let public: std::net::IpAddr = "::ffff:93.184.216.34".parse().unwrap();
-        assert!(
-            !is_mandatory_deny(public),
-            "mapped public must not be denied"
-        );
-    }
-
-    /// Legitimate public IPs must pass through cleanly so a
-    /// future regression that overzealously expands the deny
-    /// set (e.g. blocking all RFC1918) surfaces here.
-    #[test]
-    fn legitimate_public_ips_are_not_denied() {
-        let cases = [
-            "8.8.8.8",              // Google DNS
-            "1.1.1.1",              // Cloudflare DNS
-            "104.16.0.1",           // arbitrary Cloudflare anycast
-            "2001:4860:4860::8888", // Google DNS IPv6
-            "2606:4700:4700::1111", // Cloudflare DNS IPv6
-        ];
-        for addr in cases {
-            let ip: std::net::IpAddr = addr.parse().unwrap();
-            assert!(
-                !is_mandatory_deny(ip),
-                "{addr} must NOT be denied (legitimate public dest)"
-            );
-        }
-    }
-
-    /// RFC1918 ranges are deliberately NOT in the default-deny
-    /// set — corporate VPNs, home labs, and k8s pod networks live
-    /// here and breaking them would be a UX regression. If a
-    /// future edit accidentally adds RFC1918 to the const, this
-    /// test fails loudly and the maintainer reads the comment
-    /// above MANDATORY_DENY_RANGES that says why.
-    #[test]
-    fn rfc1918_is_not_in_default_deny() {
-        let cases = ["10.0.0.1", "172.16.0.1", "192.168.1.1"];
-        for addr in cases {
-            let ip: std::net::IpAddr = addr.parse().unwrap();
-            assert!(
-                !is_mandatory_deny(ip),
-                "{addr} is RFC1918 — must NOT be in default-deny (legitimate corp/VPN use)"
-            );
-        }
-    }
-
-    /// The first entry in the list is the cloud metadata `/32`.
-    /// Pinning the order matters: a maintainer scanning the
-    /// const should hit the most consequential entry first and
-    /// think twice before removing it. If a future PR rearranges
-    /// the entries, this assertion forces a conscious decision
-    /// rather than a silent reordering.
-    #[test]
-    fn cloud_metadata_is_first_entry_in_const() {
-        assert_eq!(
-            MANDATORY_DENY_RANGES[0], "169.254.169.254/32",
-            "cloud metadata /32 should be the first entry — it's the most \
-             consequential single address and a maintainer scanning the \
-             list should see it before anything else"
-        );
     }
 
     // =====================================================================

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -662,17 +662,27 @@ for detailed scope and acceptance criteria.
         + gzipped-size budget in the existing wasm lane; B5 delete
         `web/audit-verify/`, fix the stale `mvm-verify` refs in ADR-031, add
         `mvmctl audit pubkey`
-- [ ] Plan 320 — A live wasm sandbox demo on the website
-      (`specs/plans/320-wasm-browser-demo.md`) — design approved, execution not
-      started. Browser-engine sandbox at `/demo` + landing teaser; relocates the
+- [~] Plan 320 — A live wasm sandbox demo on the website
+      (`specs/plans/320-wasm-browser-demo.md`) — E1 shipped, E2/E3 and the demo
+      itself not started. Browser-engine sandbox at `/demo` + landing teaser; relocates the
       egress decision (`projection.rs`), `${NAME}` substitution, and audit-entry
       construction/chain-signing into `mvm-contract` so host and browser run
       identical code. Claim-free by ADR-024 §3; adds no claim-catalog witness.
       Sequencing: the landing teaser must be built against PR #2359's redesigned
       landing page, not the current one.
-  - [ ] E1 relocate `projection.rs` → `mvm-contract` (`mvm_core::ln` re-export
-        keeps ~20 call sites unchanged); E2 substitution core; E3 audit writer
-        core. Oracle: `wasm_egress_witness.rs` must stay green **unmodified**.
+  - [x] E1 — `projection.rs` relocated to `mvm-contract` verbatim; the
+        `mvm_core::policy::projection` module re-export kept all ~20 call sites
+        unchanged and `wasm_egress_witness.rs` green **unmodified**. The
+        `is_mandatory_deny`/`mandatory_deny_ranges`/`unmap_v4_mapped`
+        predicates it decides with moved down with it (re-exported the same
+        way); the iptables generators stayed in `mvm-core`. Side effect: the
+        54 projection tests plus 10 mandatory-deny tests now run under
+        `wasm32-wasip1` (651 → 715), closing plan 301 P1's "tests under wasm"
+        gap for this module.
+  - [ ] E2 substitution core; E3 audit writer core. Both are partial splits of
+        a custody/fs/async-bearing file, so each needs a moves/stays pass
+        before code. Oracle: `wasm_egress_witness.rs` must stay green
+        **unmodified**.
   - [ ] `web/mvm-demo/` wasm-bindgen crate, workspace-excluded; Worker + thin
         proxy; three curated fixtures (allowed / denied / unbound); tamper
         button; `wasm-opt -Oz` + gzipped-size budget in the existing wasm lane

--- a/specs/plans/320-wasm-browser-demo.md
+++ b/specs/plans/320-wasm-browser-demo.md
@@ -109,15 +109,55 @@ Its dependencies are near-entirely portable:
 | `std::net::IpAddr` | → `core::net::IpAddr`, the swap Increment 3 already made |
 | `ipnet` | supports `no_std` via `default-features = false` |
 
-Every consumer imports through the `mvm_core::ln` alias — `EgressGate`,
-`mvm-net`'s L3 admit, `mvm-hostd`'s proxy and DNS handler, `mvm-conformance` —
-roughly twenty call sites. `mvm-core` re-exports the relocated module under the
-same alias, so none of them change.
+Every consumer imports through the `mvm_core::policy::projection` path —
+`EgressGate`, `mvm-net`'s L3 admit, `mvm-hostd`'s proxy and DNS handler,
+`mvm-conformance` — roughly twenty call sites. `mvm-core` re-exports the
+relocated module under that same path, so none of them change.
 
 `projection_fs_env.rs` (567 lines, the fs/env analogue) stays in `mvm-core`.
 The demo does not need it.
 
+**Status: SHIPPED.** The relocation landed as a `git mv` plus a nine-line
+diff (the `std::net` → `core::net` swap, the `alloc` prelude, and
+`std::str::FromStr` → `core::str::FromStr`); no consumer moved.
+
+- [x] `crates/mvm-core/src/policy/projection.rs` →
+      `crates/mvm-contract/src/policy/projection.rs`, verbatim.
+- [x] `ipnet = { version = "2", default-features = false }` added to
+      `mvm-contract`. Under `no_std` its `AddrParseError` implements
+      `core::error::Error`, which is what `ProjectionError`'s `thiserror`
+      derive needs to carry it as a `source`.
+- [x] `mvm-core`'s `policy/mod.rs` re-exports the module as
+      `pub use mvm_contract::policy::projection`, alongside the existing
+      DTO-leaf module aliases. Every `mvm_core::policy::projection::X`
+      path resolves unchanged; zero call sites edited.
+- [x] `projection_fs_env.rs` stayed in `mvm-core`.
+- [x] `crates/mvm-hostd/tests/wasm_egress_witness.rs` green **unmodified**.
+
+One dependency the table above missed, resolved the same way: projection
+decides with `is_mandatory_deny` / `mandatory_deny_ranges`, which Increment
+3 left in `mvm-core`'s `network_policy.rs` logic half because they are
+`ipnet`/`std::net`-typed. Both are pure predicates over the already-relocated
+`MANDATORY_DENY_RANGES` const, so they moved down with `unmap_v4_mapped` and
+their ten tests, and `mvm-core` re-exports all three. The iptables script
+generators — the genuinely host-only half — stayed put.
+
+This supersedes
+[10-increment3-protocol-core-split.md](../refactor/10-increment3-protocol-core-split.md)'s
+`policy/` disposition table, which lists `projection.rs` as **core whole**.
+That was correct for a DTO-only increment; E1 moves a decision core, not a
+DTO, on the different rationale that the browser must run the host's gate
+rather than a copy of it.
+
 ### E2 — `${NAME}` substitution
+
+**Status: NOT STARTED, and not yet buildable from this section.** E1 was a
+whole-file relocation, so its boundary was a `git mv`. E2 and E3 are both
+partial splits of a file that mixes the pure core with key custody / fs /
+async, which is the shape Increment 3's risk register calls out as the most
+error-prone diff in the whole inversion. Do the per-`impl` moves/stays pass
+before writing code, the way Increment 3 did for `bundle.rs` and
+`vm_backend.rs` — the prose below states the intent, not the cut line.
 
 The pure resolution core teased out of
 `crates/mvm-hostd/src/keyholder/substitution.rs` (509 lines). The boundary,
@@ -134,6 +174,8 @@ supplies its own fixture values through the same function signature the host
 supplies real ones through.
 
 ### E3 — audit-entry construction and chain signing
+
+**Status: NOT STARTED.** Same planning-pass precondition as E2.
 
 The pure core of `crates/mvm-hostd/src/supervisor/audit_file.rs` (1,400 lines):
 building a `SignedEnvelope` (entry + canonical bytes + `prev_hash` + signature)
@@ -251,12 +293,19 @@ red. **It must stay green unmodified** — that is the condition for believing t
 extraction was faithful. If it needs editing, the extraction was not a
 relocation and the design is wrong.
 
-- [ ] Full `cargo nextest run --workspace` for E1's ~20 call sites.
-- [ ] The existing wasm lane (`scripts/ci-linux-coverage.sh:20,23`) already
+- [x] Full `cargo nextest run --workspace` for E1's ~20 call sites.
+      11064/11064 pass.
+- [x] The existing wasm lane (`scripts/ci-linux-coverage.sh:20,23`) already
       builds `mvm-contract` for `wasm32-unknown-unknown` and runs its tests
       under `wasm32-wasip1`. The relocated projection tests then run *under
       wasm* for free — closing plan 301 P1's "tests under wasm" gap for this
-      module as a side effect.
+      module as a side effect. **Holds:** `mvm-contract`'s wasip1 suite went
+      from 651 to 715 tests — 54 relocated projection tests plus the 10
+      mandatory-deny tests — and the pair that matters most, the
+      cross-projection consistency property and `clamp_never_widens`, now
+      decide under wasm. The same lane's `riscv32imac-unknown-none-elf`
+      lib build also stayed green, so the decision core is bare-metal clean,
+      not merely wasm clean.
 - [ ] A fixture-parity test: the three browser fixtures produce the same
       outcomes the host witness asserts.
 - [ ] `web/mvm-demo/` excluded from the workspace, as `web/audit-verify/` is.


### PR DESCRIPTION
`policy/projection.rs` decides every workload's egress: `wasi_allows` projects a `NetworkPolicy` onto a WASI grant set, and `CanonicalEgress::permits` is the counterpart the L3/L4 enforcers agree with. It is pure decision logic — no I/O, no resolver — and sat in `mvm-core` only because Increment 3 was scoped to DTOs.

This moves it down verbatim, so a no_std/edge/browser consumer runs the host's gate rather than a second copy of it. Plan 320 E1; the browser demo, E2 and E3 are not in this PR.

## The relocation

`git mv` plus nine lines: `std::net` → `core::net`, the `alloc` prelude, and `std::str::FromStr` → `core::str::FromStr`. `mvm-core`'s `policy/mod.rs` re-exports the module at `policy::projection` alongside the existing DTO-leaf aliases, so every `mvm_core::policy::projection::X` path resolves unchanged.

**Zero call sites edited** — `EgressGate`, mvm-net's L3 admit, mvm-hostd's proxy and DNS handler, mvm-conformance, ~20 in all. `crates/mvm-hostd/tests/wasm_egress_witness.rs` is green **unmodified**, which was the condition for believing the extraction was faithful.

`projection_fs_env.rs` stayed in `mvm-core`.

### One dependency the design missed

Projection decides with `is_mandatory_deny` / `mandatory_deny_ranges`, which Increment 3 left in `mvm-core`'s `network_policy.rs` logic half because they are `ipnet`/`std::net`-typed. Both are pure predicates over the already-relocated `MANDATORY_DENY_RANGES` const, so they moved down with `unmap_v4_mapped` and their ten tests, re-exported the same way. The iptables script generators — the genuinely host-only half — stayed put.

`ipnet` joins `mvm-contract` with `default-features = false`. Without its `std` feature its `AddrParseError` implements `core::error::Error`, which is what `ProjectionError`'s `thiserror` derive needs to carry it as a `source`.

No serde shape changes; these types carry no serde at all. No claim-catalog witness — this touches no ADR-001 row (ADR-024 §3).

## Side effect: projection now has wasm coverage

The wasm lane already builds `mvm-contract` for `wasm32-unknown-unknown` and runs its tests under `wasm32-wasip1`. The relocated tests join that for free: **651 → 715** wasip1 tests (54 projection + 10 mandatory-deny), including the cross-projection consistency property and `clamp_never_widens`. That closes plan 301 P1's "tests under wasm" gap for this module. The same lane's `riscv32imac-unknown-none-elf` lib build also stays green, so the decision core is bare-metal clean, not merely wasm clean.

## Gates

All run locally on the rebased tree:

- `cargo nextest run --workspace` — 11144/11144 passed
- `cargo test --workspace --doc` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, no new `#[allow]`
- `cargo +nightly fmt --all -- --check` — clean
- `cargo build -p mvm-contract --target wasm32-unknown-unknown` — pass
- `cargo test -p mvm-contract --target wasm32-wasip1` — 715 passed
- `cargo build -p mvm-contract --lib --target riscv32imac-unknown-none-elf` — pass
- `just check-linux` (zigbuild, `--workspace --lib --all-features`) — pass
- all 50 `xtask check-*` gates from `ci.yml` — pass

## Note on the first commit

`docs: design a live wasm sandbox demo, and plan wasm-in-microVM` is #2378's commit, carried here because E1's checkboxes live in that plan file. If #2378 lands first, rebase drops it.