### PR TITLE
Give the claim-12 bind check a single definition

### DIFF
--- a/crates/mvm-client/src/secret.rs
+++ b/crates/mvm-client/src/secret.rs
@@ -42,7 +42,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Context;
-use mvm_contract::ir::host_matches;
+use mvm_contract::ir::host_is_bound;
 use mvm_core::crypto::secret_store::{self, SecretStore};
 use mvm_hostd::keyholder::{BindingStore, FileBindingStore};
 use serde::Serialize;
@@ -424,11 +424,7 @@ impl SecretService {
             };
             validate_binding_meta(&r.tenant, &r.name, &meta)?;
             for destination in &r.destinations {
-                if !meta
-                    .allowed_hosts
-                    .iter()
-                    .any(|p| host_matches(p, destination))
-                {
+                if !host_is_bound(&meta.allowed_hosts, destination) {
                     return Err(SecretServiceError::UnauthorizedDestination {
                         tenant: r.tenant.clone(),
                         name: r.name.clone(),

--- a/crates/mvm-contract/src/ir/mod.rs
+++ b/crates/mvm-contract/src/ir/mod.rs
@@ -31,5 +31,5 @@ pub use workload::{
     Image, InProcessMode, JsonSchemaShape, MaterializedFile, Mount, MountMode, MountSource,
     Network, NetworkDns, NetworkEgress, NetworkMode, NodeTool, PortForward, PortProto, PythonTool,
     Resources, SecretMount, SecretRef, Sigv4Params, Source, Volume, WarmProcessConfig, Workload,
-    host_matches,
+    host_is_bound, host_matches,
 };

--- a/crates/mvm-contract/src/ir/workload.rs
+++ b/crates/mvm-contract/src/ir/workload.rs
@@ -552,6 +552,23 @@ pub fn host_matches(pattern: &str, host: &str) -> bool {
     }
 }
 
+/// Whether `destination` is bound by an `allowed_hosts` set — the claim-12
+/// predicate every path must decide identically.
+///
+/// A free function over the host list rather than a method, because the two
+/// types that carry one (`SecretRef` here, `SecretBindingMeta` in
+/// `mvm-hostd`) live in different crates and neither can grow an inherent
+/// method on the other. An empty set binds nothing, which is what makes an
+/// unbound secret fail closed.
+///
+/// Every enforcement point calls this. It is deliberately the only place the
+/// quantifier over `allowed_hosts` is written: a second copy is a second
+/// thing to keep in step, and the two would only be discovered to disagree by
+/// a destination reaching a secret it should not have.
+pub fn host_is_bound(allowed_hosts: &[String], destination: &str) -> bool {
+    allowed_hosts.iter().any(|p| host_matches(p, destination))
+}
+
 // allow(secret-debug): metadata-only — variants carry the env-var name
 // or filesystem path the secret will be delivered at, not the secret
 // itself. The actual material is resolved at admission time.
@@ -910,5 +927,27 @@ mod tests {
         // …but NOT the apex, and the leading dot guards a registrable lookalike.
         assert!(!host_matches("*.example.com", "example.com"));
         assert!(!host_matches("*.example.com", "evilexample.com"));
+    }
+
+    #[test]
+    fn an_empty_allowed_hosts_set_binds_no_destination() {
+        // The fail-closed end of claim 12: a secret that declares no
+        // destinations is reachable from none, rather than from all. An
+        // `any()` over an empty iterator is false, so this holds by
+        // construction — pinned because the opposite default is the kind of
+        // thing a "helpful" refactor introduces.
+        assert!(!host_is_bound(&[], "api.openai.com"));
+        assert!(!host_is_bound(&[], ""));
+    }
+
+    #[test]
+    fn host_is_bound_admits_only_a_listed_or_wildcarded_destination() {
+        let allowed = ["api.openai.com".to_string(), "*.example.com".to_string()];
+        assert!(host_is_bound(&allowed, "api.openai.com"));
+        assert!(host_is_bound(&allowed, "sub.example.com"));
+        // Unlisted host, the wildcard's apex, and a registrable lookalike.
+        assert!(!host_is_bound(&allowed, "evil.example.org"));
+        assert!(!host_is_bound(&allowed, "example.com"));
+        assert!(!host_is_bound(&allowed, "evilexample.com"));
     }
 }

--- a/crates/mvm-hostd/src/keyholder/injector.rs
+++ b/crates/mvm-hostd/src/keyholder/injector.rs
@@ -10,7 +10,7 @@
 //! claim 12: the destination allow-list is checked **before** the value is
 //! resolved, so an out-of-policy request never triggers a decrypt.
 
-use mvm_contract::ir::{AuthType, SecretRef, host_matches};
+use mvm_contract::ir::{AuthType, SecretRef, host_is_bound};
 use secrecy::ExposeSecret;
 use zeroize::Zeroizing;
 
@@ -63,7 +63,7 @@ impl<'a> Injector<'a> {
             AuthType::Bearer | AuthType::Basic => {}
             other => return Err(InjectError::WrongAuthType(other)),
         }
-        if !r.allowed_hosts.iter().any(|p| host_matches(p, destination)) {
+        if !host_is_bound(&r.allowed_hosts, destination) {
             return Err(InjectError::DestinationNotBound(destination.to_string()));
         }
         let value = self.resolver.resolve(r)?;

--- a/crates/mvm-hostd/src/keyholder/substitution.rs
+++ b/crates/mvm-hostd/src/keyholder/substitution.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 
-use mvm_contract::ir::{AuthType, SecretRef, host_matches};
+use mvm_contract::ir::{AuthType, SecretRef, host_is_bound};
 use rand::RngCore;
 use zeroize::Zeroizing;
 
@@ -103,7 +103,7 @@ impl SubstitutionRegistry {
     pub fn host_is_bound(&self, host: &str) -> bool {
         self.map
             .values()
-            .any(|r| r.allowed_hosts.iter().any(|p| host_matches(p, host)))
+            .any(|r| host_is_bound(&r.allowed_hosts, host))
     }
 }
 
@@ -188,11 +188,7 @@ impl<'a> SubstitutionEndpoint<'a> {
             .registry
             .resolve(placeholder)
             .ok_or(SignDispatchError::UnknownPlaceholder)?;
-        if !secret
-            .allowed_hosts
-            .iter()
-            .any(|p| host_matches(p, destination))
-        {
+        if !host_is_bound(&secret.allowed_hosts, destination) {
             return Err(SignDispatchError::DestinationNotBound(
                 destination.to_string(),
             ));


### PR DESCRIPTION
Whether a destination is bound by a secret's `allowed_hosts` is the claim-12 predicate. It was written out three times, plus a fourth spelling quantified over a whole registry:

| Site | Carrier type |
|---|---|
| `crates/mvm-hostd/src/keyholder/injector.rs:66` | `SecretRef` — inject path |
| `crates/mvm-hostd/src/keyholder/substitution.rs:194` | `SecretRef` — sign path |
| `crates/mvm-client/src/secret.rs:428` | `SecretBindingMeta` — client-side |
| `SubstitutionRegistry::host_is_bound` | same quantifier, over the registry |

**All four agree today, so this fixes no live defect.** What it removes is the possibility of them disagreeing tomorrow: three separate places a future edit could tighten or loosen the binding rule, with no test that would notice one had drifted. The way that failure presents is a destination reaching a secret it is not bound to — the one outcome claim 12 exists to prevent.

## The change

`host_is_bound(allowed_hosts: &[String], destination: &str) -> bool` now lives in `mvm_contract::ir`, beside `host_matches` and `SecretRef`, and all four call sites go through it.

A free function over the host slice rather than a method on either carrier: `SecretRef` is in `mvm-contract` and `SecretBindingMeta` is in `mvm-hostd`, so neither crate can add an inherent method covering both.

Two tests: the wildcard/apex/lookalike ladder, and that an empty `allowed_hosts` binds nothing. The second holds by construction — `any()` over an empty iterator is false — and is pinned because the opposite default is exactly what a well-meaning refactor introduces.

No behaviour change, no serde shape change, no new dependency, no new `#[allow]`.

## Provenance

Found by the plan 320 E2 moves/stays survey (#2381), where it is item E2.2. Landing it separately and first, because a drift hazard on a security predicate is worth fixing whether or not the browser demo is ever built — and because it means the predicate has one definition *before* it crosses a crate boundary, rather than during.

Deliberately **not** adding an `xtask` gate pinning the single definition. There is precedent for that shape (`check-uniform-vsock-egress` pins one spawn site), and it would be a reasonable follow-up, but adding CI surface is scope this PR did not ask for. Happy to add it if you'd rather have it enforced than merely true.

## Gates

- `cargo nextest run --workspace` — 11165/11165 passed
- `cargo test --workspace --doc` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo build -p mvm-contract --target wasm32-unknown-unknown` — pass
- `cargo test -p mvm-contract --target wasm32-wasip1` — 653 passed (651 + the two new)
- all 50 `xtask check-*` gates from `ci.yml` — pass