### PR TITLE
Freeze the raw-packet networking path and ratify one flow-aware vsock path (Plan 316 Phase 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,12 @@ jobs:
       - name: no reference to a removed userspace network gateway
         run: cargo run -p xtask -- check-no-gateway-names
 
+      # Temporary, shrink-only ratchet: the raw-packet workload networking path
+      # is frozen while the single flow-aware vsock path is built. Deleted with
+      # its last allowlist entry.
+      - name: l3 expansion freeze (no new raw-packet networking references)
+        run: cargo run -p xtask -- check-l3-expansion-freeze
+
       - name: uniform vsock egress (Firecracker + libkrun + HVF use the WorkloadRunner seam)
         run: cargo run -p xtask -- check-uniform-vsock-egress
 

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -228,9 +228,17 @@ pub(in crate::commands) fn check_host_can_serve(
 }
 
 /// Settle and validate the networking configuration before anything boots.
+///
+/// A workload declaring `raw_ip_stack` is refused here, at the declaration it
+/// wrote, rather than deeper down at a transport it never named: the in-guest
+/// IP stack has been retired, and the refusal names the loopback adapters and
+/// typed connectors that replace it. Everything below this point still
+/// resolves the tunnel for a VM that is already running, which is what lets
+/// those drain instead of being killed mid-flight.
 pub(in crate::commands) fn preflight_network(
     needs_raw_ip_stack: bool,
 ) -> anyhow::Result<mvm_contract::plan::NetworkMode> {
+    mvm_core::plan::refuse_raw_ip_stack(needs_raw_ip_stack)?;
     let mode = derive_network_mode(needs_raw_ip_stack);
     check_host_can_serve(mode)?;
     Ok(mode)

--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -1276,6 +1276,79 @@ mod admit_plan_tests {
     /// the ordinary ones that derive `HostVsockProxy` and get a broker stood up
     /// for them. The value is inside the signature, so the record was
     /// confidently wrong rather than merely absent.
+    /// Admit a plan carrying `mode`, with everything else held constant.
+    ///
+    /// Shared by the record-the-transport test and the retired-transport
+    /// refusal so the two differ only in the mode they pass.
+    fn admit_with_mode(
+        mode: mvm_contract::plan::NetworkMode,
+        keys_dir: &std::path::Path,
+        audit_dir: &std::path::Path,
+        rootfs: &std::path::Path,
+        ledger: &InMemoryNonceLedger,
+    ) -> Result<Option<AdmissionContext>> {
+        admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mode,
+            grants: None,
+            backend_kind: None,
+            tenant: "local",
+            vm_name: "vm-transport",
+            backend_name: "firecracker",
+            rootfs_path: rootfs,
+            precomputed_image_sha256: None,
+            boot_artifact_identity: None,
+            cpus: 1,
+            mem_mib: 128,
+            seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
+            secret_release: mvm_core::plan::SecretReleasePolicy::None,
+            secrets: Vec::new(),
+            no_supervisor: false,
+            ledger,
+            keys_dir: Some(keys_dir),
+            audit_dir: Some(audit_dir),
+            policy_dir: None,
+            bundle_pin: None,
+            deps_volume: None,
+            shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
+            network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
+            agent_verb_override: vec![],
+            restrict_agent_verbs: false,
+            services: Vec::new(),
+            entrypoint: crate::commands::vm::entrypoint_resolve::ResolvedEntrypoint::unresolved(
+                "test",
+            ),
+        })
+    }
+
+    /// The retired in-guest IP stack does not boot, and says why.
+    ///
+    /// The refusal is the thing that keeps the migration to a single
+    /// networking path from ever running three live production paths at once,
+    /// so it is asserted on the message an operator actually reads — naming
+    /// both replacements — not merely on `is_err()`.
+    #[test]
+    fn a_launch_asking_for_the_retired_ip_stack_is_refused() {
+        let keys_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let rootfs_dir = tempfile::tempdir().unwrap();
+        let rootfs = write_rootfs(rootfs_dir.path(), b"transport");
+        let ledger = InMemoryNonceLedger::new();
+
+        let err = admit_with_mode(
+            mvm_contract::plan::NetworkMode::L3Vsock,
+            keys_dir.path(),
+            audit_dir.path(),
+            &rootfs,
+            &ledger,
+        )
+        .expect_err("the retired transport must not admit");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("has been retired"), "{msg}");
+        assert!(msg.contains("loopback adapters"), "{msg}");
+        assert!(msg.contains("typed SDK connector"), "{msg}");
+    }
+
     #[test]
     fn the_admitted_plan_records_the_transport_the_launch_derived() {
         let keys_dir = tempfile::tempdir().unwrap();
@@ -1285,7 +1358,6 @@ mod admit_plan_tests {
 
         for mode in [
             mvm_contract::plan::NetworkMode::HostVsockProxy,
-            mvm_contract::plan::NetworkMode::L3Vsock,
             mvm_contract::plan::NetworkMode::None,
         ] {
             let ledger = InMemoryNonceLedger::new();

--- a/crates/mvm-core/src/plan/l3_retirement.rs
+++ b/crates/mvm-core/src/plan/l3_retirement.rs
@@ -1,0 +1,133 @@
+//! Refuse a workload that asks for the retired raw-packet networking path.
+//!
+//! The guest-TUN tunnel gave a workload its own IP stack and had the *guest*
+//! originate connections. That is a second egress decision point with its own
+//! policy code, and it cannot carry host-side credential substitution or
+//! cleartext redaction at all, because what crosses the boundary for a TLS
+//! flow is ciphertext the host never holds a key for.
+//!
+//! It is being removed in favour of a single flow-aware vsock path. Removal is
+//! staged rather than atomic, so this is the gate that keeps the staging
+//! honest: no new workload may boot onto the tunnel while its replacement is
+//! built, which is what stops the tree from carrying three live production
+//! networking paths at once. VMs already running on the tunnel are unaffected
+//! — they drain.
+//!
+//! One function, called from both synthesis and admission, because a
+//! pre-signed plan that never passed through synthesis must be refused too.
+
+use mvm_contract::plan::NetworkMode;
+
+/// Why a launch that asked for the retired raw-packet path was refused.
+///
+/// The message names the replacements rather than only the refusal: an
+/// operator reading it needs to know what to do next, and the answer differs
+/// depending on whether they wanted plain egress or a transformed request.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum L3RetiredError {
+    /// The plan selected the tunnel, or declared `raw_ip_stack`, which is
+    /// what selects it.
+    #[error(
+        "the in-guest IP stack (raw_ip_stack / l3-vsock) has been retired and no longer boots. \
+         Route ordinary traffic through the guest loopback adapters — the HTTP proxy, SOCKS5h, \
+         SOCKS5 UDP, and the DNS stub the guest already exports — or, for a request that needs \
+         host-side credential substitution or redaction, declare a typed SDK connector. Raw \
+         sockets, arbitrary IP protocols, in-guest resolvers, and general ICMP are unsupported \
+         rather than routed through a second network stack. Already-running VMs are unaffected."
+    )]
+    RawIpStackRetired,
+    /// The mode did not select the tunnel but a tunnel spec rode along. Refused
+    /// separately so a half-set plan is never treated as a plain one.
+    #[error(
+        "this plan carries an l3 network spec without selecting the retired l3-vsock mode; \
+         the raw-packet path no longer boots, so drop the spec"
+    )]
+    StraySpec,
+}
+
+/// Refuse a plan that would boot onto the retired raw-packet path.
+///
+/// `has_l3_spec` is passed separately rather than read off the mode because
+/// the two can disagree, and a disagreement is itself a refusal — a plan whose
+/// two halves describe different transports has not made a decision.
+pub fn refuse_retired_l3(mode: &NetworkMode, has_l3_spec: bool) -> Result<(), L3RetiredError> {
+    if mode.is_l3_vsock() {
+        return Err(L3RetiredError::RawIpStackRetired);
+    }
+    if has_l3_spec {
+        return Err(L3RetiredError::StraySpec);
+    }
+    Ok(())
+}
+
+/// Refuse a workload whose IR declares it needs a real in-guest IP stack.
+///
+/// The CLI leg of the same refusal: `raw_ip_stack` is what *selects* the
+/// tunnel, so catching it before a mode is derived gives the operator the
+/// error at the declaration they wrote rather than at a transport they never
+/// named.
+pub fn refuse_raw_ip_stack(needs_raw_ip_stack: bool) -> Result<(), L3RetiredError> {
+    if needs_raw_ip_stack {
+        return Err(L3RetiredError::RawIpStackRetired);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_tunnel_mode_is_refused() {
+        assert_eq!(
+            refuse_retired_l3(&NetworkMode::L3Vsock, true),
+            Err(L3RetiredError::RawIpStackRetired)
+        );
+        assert_eq!(
+            refuse_retired_l3(&NetworkMode::L3Vsock, false),
+            Err(L3RetiredError::RawIpStackRetired)
+        );
+    }
+
+    #[test]
+    fn a_stray_spec_on_a_non_tunnel_plan_is_refused() {
+        assert_eq!(
+            refuse_retired_l3(&NetworkMode::HostVsockProxy, true),
+            Err(L3RetiredError::StraySpec)
+        );
+        assert_eq!(
+            refuse_retired_l3(&NetworkMode::None, true),
+            Err(L3RetiredError::StraySpec)
+        );
+    }
+
+    #[test]
+    fn the_supported_modes_still_pass() {
+        assert!(refuse_retired_l3(&NetworkMode::None, false).is_ok());
+        assert!(refuse_retired_l3(&NetworkMode::HostVsockProxy, false).is_ok());
+    }
+
+    #[test]
+    fn raw_ip_stack_is_refused_and_absence_is_not() {
+        assert_eq!(
+            refuse_raw_ip_stack(true),
+            Err(L3RetiredError::RawIpStackRetired)
+        );
+        assert!(refuse_raw_ip_stack(false).is_ok());
+    }
+
+    #[test]
+    fn the_refusal_names_both_replacements() {
+        let msg = L3RetiredError::RawIpStackRetired.to_string();
+        assert!(msg.contains("loopback"), "no loopback proxy named: {msg}");
+        assert!(msg.contains("SOCKS5h"), "no SOCKS proxy named: {msg}");
+        assert!(
+            msg.contains("typed SDK connector"),
+            "no typed connector named: {msg}"
+        );
+        assert!(
+            msg.contains("Already-running VMs are unaffected"),
+            "the drain allowance is not stated: {msg}"
+        );
+    }
+}

--- a/crates/mvm-core/src/plan/mod.rs
+++ b/crates/mvm-core/src/plan/mod.rs
@@ -26,6 +26,7 @@
 
 pub mod bundle;
 pub mod content_id;
+pub mod l3_retirement;
 pub mod signing;
 pub mod synthesis;
 #[cfg(any(test, feature = "test-support"))]
@@ -48,6 +49,7 @@ pub use bundle::{
 };
 pub use content_id::{PlanIdMismatch, compute_plan_id, verify_plan_id};
 pub use execution_plan::{ExecutionPlan, SCHEMA_VERSION};
+pub use l3_retirement::{L3RetiredError, refuse_raw_ip_stack, refuse_retired_l3};
 pub use sdk_sidecar::{
     SDK_HOST_SERVICES, SDK_SIDECAR_GUEST_PATH, SDK_SIDECAR_LIB_PATH, is_sdk_host_service,
     sdk_host_services_in, sdk_sidecar_required, sdk_sidecar_required_for,

--- a/crates/mvm-core/src/plan/synthesis.rs
+++ b/crates/mvm-core/src/plan/synthesis.rs
@@ -227,6 +227,11 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
     let nonce = fresh_nonce();
     let now = Utc::now();
 
+    // Refuse the retired raw-packet transport before anything else is derived,
+    // so the operator gets the migration error rather than a plan that would
+    // fail later at a transport they never named.
+    crate::plan::refuse_retired_l3(&input.network_mode, input.l3_network.is_some())?;
+
     let tenant_str = input.tenant.unwrap_or(DEFAULT_TENANT);
     if tenant_str.is_empty() {
         anyhow::bail!("tenant must not be empty");

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -245,6 +245,11 @@ pub fn admit_for_run(
     // admitted under an id that genuinely addresses its content.
     verify_plan_id(&verified).context("plan_id content-address check")?;
 
+    // The retired raw-packet transport, checked again on the verified plan and
+    // not only in synthesis: admission is what a plan built elsewhere reaches,
+    // and the refusal has to hold for those too.
+    mvm_core::plan::refuse_retired_l3(&verified.network_mode, verified.l3_network.is_some())?;
+
     // Validity window — refuses plans whose now() is outside
     // [valid_from, valid_until). For freshly-synthesized plans this
     // can only fire if the host's clock changed during signing or if

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -389,6 +389,10 @@ for detailed scope and acceptance criteria.
       Tracked end to end under epic #2111, which also carries plan 285's
       deferred set. Every workstream below has its own issue; the epic
       records the ordering and the two gates that are not preference.
+      **Frozen by plan 316 Phase 0.** ADR-037 is superseded for production
+      workload networking: this datapath forwarded raw IP packets for
+      `l3-vsock`, which no longer boots. No feature work lands on its runtime
+      path; deletion is plan 316 Phase 7 (#2376).
   - [x] Phase A (WS0) — fix the two platform-neutral defects in the shipped
         `mvm-netd` drive loop that blocked this work and affected Linux
         today: a pollable descriptor out of `GuestConnection`, a
@@ -1063,8 +1067,39 @@ for detailed scope and acceptance criteria.
         chain (recon §7.6 → plan 280, #2017); post-restore child verb grant
         (recon §7.7 → #2019)
 
+- [~] Plan 316 — Single flow-aware vsock networking path
+  (`specs/plans/316-single-flow-vsock-networking.md`, ADR-042, umbrella #2368)
+  Collapses the two production workload networking paths to one authenticated
+  FlowMux session on `GuestService::NetworkFlow` through one
+  `mvm-network-endpoint`. Supersedes the production-path decisions in plan 285
+  and plan 287; both are frozen, not yet deleted.
+  - [x] Phase 0 — ratify the invariant and freeze expansion (#2369): ADR-042
+        accepted; ADR-036 and ADR-037 marked superseded for production workload
+        networking; `specs/refactor/03-networking.md` corrected from "the raw
+        packet path is deleted" to the actual two-path state; ADR-001's tier
+        matrix and claim-10 section qualified; `xtask
+        check-l3-expansion-freeze` added as a temporary shrink-only ratchet
+        over `L3Vsock`/`raw_ip_stack`/`NetworkControl`/`NetworkData`/
+        `spawn_netd`/`host_datapath` (29 allowlist entries); synthesis,
+        admission, and CLI preflight refuse `raw_ip_stack=true`/`L3Vsock` with
+        a migration error naming the loopback adapters and typed connectors
+  - [ ] Phase 1 — pin protocol, resource, and performance baselines (#2370)
+  - [ ] Phase 2 — the one authenticated endpoint (#2371)
+  - [ ] Phase 3 — converge egress TCP, UDP, and DNS (#2372)
+  - [ ] Phase 4 — stream typed transformations (#2373)
+  - [ ] Phase 5 — declared ingress on FlowMux (#2374)
+  - [ ] Phase 6 — compatibility boundary (#2375)
+  - [ ] Phase 7 — delete L3 completely (#2376)
+  - [ ] Phase 8 — make "one path" mechanically enforceable (#2377)
+
 - [~] Plan 285 — L3 TUN-over-vsock network mode
   (`specs/plans/285-l3-tun-over-vsock.md`, ADR-036)
+  **Frozen by plan 316 Phase 0.** No feature work lands on this runtime path;
+  only security fixes needed to keep the tree safe during migration may modify
+  it. ADR-036 is superseded for production workload networking, and new
+  `raw_ip_stack=true` / `NetworkMode::L3Vsock` launches are refused. Deletion
+  is plan 316 Phase 7 (#2376). The completed workstreams below stand as
+  historical record.
   - [x] W1–W8 — canonical `NetworkMode::L3Vsock`, the shared fuzzable wire
         protocol, the pure policy core, the guest `mvm-net-agent`, the
         machine-scoped host gateway, audit kinds, docs, and the unprivileged

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -864,6 +864,49 @@ updates only its own entry below.
       run on a KVM host (6/6, live forwarding witness, clean teardown); 23
       hermetic BDD scenarios in `s25_l3_vsock`. macOS is capability-declared
       and refuses; native Windows is not claimed.
+      **Retired by plan 316 (ADR-042).** This shipped, and it is now a second
+      production networking path with its own policy code — which is the
+      problem plan 316 fixes. Frozen as of Phase 0: new
+      `raw_ip_stack=true`/`L3Vsock` launches are refused at synthesis,
+      admission, and CLI preflight; running VMs drain; deletion is Phase 7.
+
+- [~] Single flow-aware vsock networking path (plan 316 / ADR-042, umbrella
+      #2368). One external networking path for every untrusted workload:
+      guest loopback adapter → authenticated FlowMux session on
+      `GuestService::NetworkFlow` (vsock 5253) → one per-VM
+      `mvm-network-endpoint` → canonical policy, DNS, substitution/redaction,
+      rate and audit pipeline → host-originated socket or host-owned ingress
+      listener. Flow-aware at L4 with selective L7: opaque TCP/UDP is relayed
+      unparsed, and transformation runs only for a typed flow whose signed
+      plan requires it — a plan requiring transformation refuses an opaque
+      shape rather than downgrading. Supersedes the production-path decisions
+      in plans 285 and 287.
+  - [x] **Phase 0 — ratify the invariant and freeze expansion** (#2369).
+        ADR-042 accepted, recording the L4-with-selective-L7 decision, why
+        arbitrary guest TLS and host-side replacement are mutually exclusive,
+        and the rejection of a universal MITM CA. ADR-036 and ADR-037 marked
+        superseded for production workload networking with their measurements
+        retained. `specs/refactor/03-networking.md` corrected — it claimed the
+        raw-packet path was deleted, which stopped being true when ADR-036
+        reintroduced it. ADR-001's tier matrix and claim-10 section qualified
+        to name the second path and its retirement. New temporary
+        `xtask check-l3-expansion-freeze` ratchet: no new non-test reference
+        to `L3Vsock`, `raw_ip_stack`, `NetworkControl`, `NetworkData`,
+        `spawn_netd`, or `host_datapath` outside a 29-entry allowlist that
+        fails closed on a stale entry, so it can only shrink. Synthesis
+        (`mvm_core::plan::refuse_retired_l3`), supervisor admission
+        (`admit_for_run`), and CLI preflight
+        (`mvm_cli::commands::machine::preflight_network`) all refuse the
+        retired transport with one shared error naming the loopback adapters
+        and typed connectors; running VMs are unaffected.
+  - [ ] Phase 1 — pin protocol, resource, and performance baselines (#2370)
+  - [ ] Phase 2 — the one authenticated endpoint (#2371)
+  - [ ] Phase 3 — converge egress TCP, UDP, and DNS (#2372)
+  - [ ] Phase 4 — stream typed transformations (#2373)
+  - [ ] Phase 5 — declared ingress on FlowMux (#2374)
+  - [ ] Phase 6 — compatibility boundary (#2375)
+  - [ ] Phase 7 — delete L3 completely (#2376)
+  - [ ] Phase 8 — make "one path" mechanically enforceable (#2377)
 
 - [~] Workload stream plane — 22 tasks, **Phase 1 complete, Phase 2 landed
       dormant**. Tracked in `specs/plans/295-workload-stream-plane.md` and

--- a/specs/adrs/001-microvm-security-posture.md
+++ b/specs/adrs/001-microvm-security-posture.md
@@ -258,21 +258,30 @@ backend falls below Tier 1.
 | QEMU (Linux KVM/TCG) | ✅ KVM where available | ⚠️ larger device-model TCB | ⚠️ partial verified boot | ✅ | ✅ | Tier 2 — a `mvm`-only Linux dev/test substrate, opt-in only, never reachable from the fleet orchestrator. It carries no untrusted multi-tenant workload, so claim-10 egress enforcement is deliberately not wired into its start path. This carve-out is type-enforced: a `WorkloadBackend` marker trait gates the admitted workload-launch path, and QEMU does not implement it, so it cannot reach that path regardless of prose. The test-only mock backend does implement the marker — it is a hermetic lifecycle test double that carries no real workload, so permitting it costs nothing. |
 | `wasm-sandbox` (browser / WASI preview) | ❌ | ❌ | ❌ | ❌ | ❌ | **Off the isolation scale.** No KVM, no real kernel, no TAP/virtio/vsock. Asserts none of the numbered claims and declares its own non-virtualization honestly; fails closed on any kernel/TAP/vsock request. Opt-in only; auto-detection never selects it. It is safe *because* it is single-principal — a developer's own code in their own browser sandbox, where the "malicious guest" adversary class does not apply — not because it holds any isolation claim. Promotion to a real, claim-bearing microVM re-materializes the workload from recorded intent through the audited build and admission pipeline; nothing produced in this claims-free tier carries authority into a claim-bearing one. |
 
+**Matrix scope — networking.** Every "no guest network interface" statement in
+the rows above describes the default socket-aware vsock path, which is the
+only path a new workload can now take. It does not describe the frozen
+`l3-vsock` mode, where the guest holds an `mvm0` TUN by design; see
+"The `l3-vsock` second path, and its retirement" below. A run's tier is
+otherwise unaffected by this: `l3-vsock` never changed a backend's isolation
+tier, only which policy implementation decided its egress.
+
 **Tier discipline.** Tier 1 is the production default and the only tier
 that carries every numbered claim. Tier 2 backends hold every claim
 except claim 3, which is scoped to the block+ext4 backends. There is no
 Tier 3: a shared-kernel container runtime holds none of the L1–L3
 isolation claims, so mvm ships no container-based backend at any tier.
 
-**Claim-10 coverage.** Claim 10's default-deny egress is enforced at **one**
-seam for every backend that runs an untrusted workload: the per-VM
-substitution endpoint reached over vsock, whose shared `EgressGate` is the
-sole decision point. There is no host-side network chokepoint to enforce at,
-because a workload guest has no network interface at all — Firecracker omits
-`/network-interfaces`, libkrun pins `NetworkingMode::VsockDirect`, and the
-HVF device model has no net device. Egress leaves a guest only over vsock, to
-a host-side endpoint the host itself originates the outbound connection from,
-which is what makes admission, substitution and the audit record possible.
+**Claim-10 coverage.** On the default socket-aware path, claim 10's
+default-deny egress is enforced at **one** seam for every backend that runs an
+untrusted workload: the per-VM substitution endpoint reached over vsock, whose
+shared `EgressGate` is the sole decision point. There is no host-side network
+chokepoint to enforce at, because such a workload guest has no network
+interface at all — Firecracker omits `/network-interfaces`, libkrun pins
+`NetworkingMode::VsockDirect`, and the HVF device model has no net device.
+Egress leaves the guest only over vsock, to a host-side endpoint the host
+itself originates the outbound connection from, which is what makes admission,
+substitution and the audit record possible.
 
 Two gates keep that true rather than aspirational. `xtask
 check-uniform-vsock-egress` pins Firecracker, libkrun and HVF to a single
@@ -281,6 +290,31 @@ gate or revert to a raw backend. `xtask check-vsock-only-egress` fails closed
 if `virtio_net`, a tap, or a userspace-gateway token appears on a workload
 path. QEMU is intentionally excluded, for the reason given in the tier matrix
 above.
+
+**The `l3-vsock` second path, and its retirement.** ADR-036 added an opt-in
+compatibility mode (`raw_ip_stack=true`, `NetworkMode::L3Vsock`) in which the
+guest *does* get an IP stack, on an `mvm0` TUN, and tunnels raw IP packets to
+a host forwarder; ADR-037 added a second forwarder for it. On that path the
+guest originates connections, so the decision point is the L3 admitter and the
+forwarder's policy — not the `EgressGate` above — and host-side substitution
+and redaction cannot apply at all. Claim 10 held on that path through its own
+admitter, but through a *second* implementation, which is a weaker property
+than the "one decision point" this section asserts for the default path.
+
+ADR-042 retires it. `raw_ip_stack=true` / `NetworkMode::L3Vsock` is now
+refused at synthesis and admission with a migration error; already-running VMs
+drain, and no new production L3 workload boots. `xtask
+check-l3-expansion-freeze` is a temporary shrink-only ratchet holding that
+line until Plan 316 Phase 7 deletes the path and Phase 8 replaces
+`check-uniform-vsock-egress`, `check-vsock-only-egress`, and the ratchet with
+`check-single-network-path` plus a socket-owner gate. Until that lands, read
+claim 10 as: one decision point on the only path a new workload can take, and
+a frozen second implementation with no new entrants.
+
+*Corrected 2026-08-11.* This section, and `specs/refactor/03-networking.md`,
+both asserted that a workload guest has no network interface at all, with no
+qualifier. That was written before `l3-vsock` shipped and was not revisited
+when it did. The paragraphs above restore the qualifier.
 
 *Corrected 2026-08-02.* This section previously described enforcement as
 "Firecracker via nftables default-deny on the TAP, and libkrun via the

--- a/specs/adrs/036-l3-tun-over-vsock.md
+++ b/specs/adrs/036-l3-tun-over-vsock.md
@@ -1,7 +1,16 @@
 # ADR-036 — L3 TUN-over-vsock, an opt-in compatibility network mode
 
-**Status: Accepted**
+**Status: Superseded for production workload networking by ADR-042
+(2026-08-11).**
 **Date: 2026-07-31**
+**Superseded by: ADR-042 (one flow-aware vsock networking path). The
+`l3-vsock` mode this ADR introduced is leaving the production workload path;
+new `raw_ip_stack=true` / `NetworkMode::L3Vsock` launches are refused. The
+measurements, threat analysis, and compatibility-wall reasoning below remain
+accurate history, and are why ADR-042 states an explicit compatibility
+ceiling rather than pretending the wall does not exist. Nothing below
+describes a live production transport. The staged removal is
+`specs/plans/316-single-flow-vsock-networking.md`.**
 **Supersedes: nothing. Complements ADR-003 (cross-platform backends),
 ADR-014 (signed/audited execution plans), ADR-020 (host-services broker),
 ADR-023 (secrets subsystem / egress substitution), plan 278 (transparent

--- a/specs/adrs/037-userspace-socket-datapath.md
+++ b/specs/adrs/037-userspace-socket-datapath.md
@@ -1,7 +1,14 @@
 # ADR-037 — The userspace socket datapath
 
-**Status: Accepted**
+**Status: Superseded for production workload networking by ADR-042
+(2026-08-11).**
 **Date: 2026-08-02**
+**Superseded by: ADR-042 (one flow-aware vsock networking path). This ADR's
+datapath forwarded raw IP packets for `l3-vsock`, which is leaving the
+production workload path along with the mode itself. Its unprivileged-
+forwarding analysis and its performance measurements remain accurate history;
+its `UserspaceSocketDatapath` is not a live production transport. The staged
+removal is `specs/plans/316-single-flow-vsock-networking.md`.**
 **Supersedes: ADR-036 §"macOS (Apple Silicon)" in part — that section
 staged `MacosUserspaceGateway` as a capability declaration plus a refusal
 and left the translator undesigned. This ADR designs it, and widens it

--- a/specs/adrs/042-single-flow-vsock-networking.md
+++ b/specs/adrs/042-single-flow-vsock-networking.md
@@ -1,0 +1,162 @@
+# ADR-042 — One flow-aware vsock networking path
+
+**Status: Accepted**
+**Date: 2026-08-11**
+**Supersedes: ADR-036 (L3 TUN-over-vsock) and ADR-037
+(`037-userspace-socket-datapath.md`) for the production workload networking
+path. Their measurements, threat analysis, and historical rationale stand;
+their implementations stop being a supported production transport.
+Complements ADR-003 (hypervisor egress policy), ADR-014 (signed/audited
+execution plans), ADR-020 (host-services broker), and ADR-023 (secrets
+subsystem / egress substitution).**
+
+## Context
+
+A workload microVM was designed with no NIC. Every byte a guest sends leaves
+over AF_VSOCK to a host-side endpoint that originates the real connection.
+That is what makes claim 10 (default-deny egress), claim 13 (no raw secret
+reaches the guest), and the chain-signed audit log enforceable: the host, not
+the guest, is the party that opens sockets.
+
+ADR-036 then added `l3-vsock`, an opt-in compatibility mode that gives the
+guest a real IP stack on a `mvm0` TUN and tunnels raw IPv4/IPv6 packets to a
+host forwarder. ADR-037 added a second, unprivileged forwarding backend for
+it. Both shipped. The tree therefore carries **two** production workload
+networking paths with different policy code, different resource accounting,
+different audit shapes, and different security properties — and
+`specs/refactor/03-networking.md` still asserts the raw-packet path was
+deleted, which stopped being true when it was reintroduced.
+
+Two paths is the problem this ADR resolves. It is not primarily a performance
+or a code-size argument. It is that claim 10's "one decision point" is only
+true of one of the two paths, and a reader cannot tell from a workload which
+one applies.
+
+## Decision
+
+There is exactly one external networking path for an untrusted workload:
+
+```text
+guest loopback adapter
+  -> authenticated FlowMux session on GuestService::NetworkFlow (vsock port 5253)
+  -> one per-VM mvm-network-endpoint
+  -> canonical policy, DNS, substitution/redaction, rate and audit pipeline
+  -> host-originated TCP/UDP socket or host-owned ingress listener
+```
+
+The endpoint is **flow-aware at L4, with selective L7** — not universally L7.
+
+- TCP and UDP payloads whose signed plan requests no content transformation
+  are relayed as opaque bytes. The host does not parse them, does not
+  reconstruct a guest TCP stack, and does not claim to have inspected them.
+- L7 parsing, host TLS origination, credential substitution, reversible
+  replacement, and redaction run **only** for an explicitly typed
+  HTTP/connector flow whose signed plan requires them.
+- If a plan requires a transformation, admission refuses an opaque flow shape
+  rather than silently downgrading it.
+
+`Off` is the absence of a network grant and the absence of `NetworkFlow`. It
+is not a second networking mode, and there is no transport selector.
+
+## Why not universal L7
+
+The obvious way to make every flow transformable is to terminate all guest TLS
+at the host. That requires the host to present certificates the guest trusts,
+which requires a host-controlled CA in the guest trust store — a
+man-in-the-middle CA applied universally.
+
+We reject that as the universal path, for reasons that are independent of how
+well it is implemented:
+
+- **It is not achievable in general.** Certificate pinning, mutual TLS, QUIC,
+  and ECH each defeat it, and each is common in exactly the workloads that
+  care most. A mechanism that silently stops applying for a subset of traffic
+  is worse than one that never claimed to apply, because the operator cannot
+  tell the difference from the outside.
+- **It inverts the trust story.** The project's stated posture is that the
+  guest is untrusted and the host does not need to read guest payloads to
+  enforce policy. A universal MITM CA makes the host's ability to enforce
+  depend on its ability to decrypt everything the workload does, which is a
+  strictly larger and more fragile capability than the one claim 10 needs.
+- **It enlarges the blast radius of the endpoint.** The endpoint already holds
+  credentials in the clear for substitution. Giving it a CA key that the guest
+  trusts for every destination turns a per-destination compromise into a
+  universal one.
+- **It would make claim honesty impossible to state.** "Every flow is
+  inspected" would be false in practice while being the documented behavior.
+
+So arbitrary guest-originated TLS and host-side credential replacement are
+**mutually exclusive**, and this ADR makes that explicit rather than implicit.
+A workload that wants host-side substitution or redaction declares a typed
+transform flow, whose TLS the host originates to a plan-bound destination. A
+workload that wants opaque TLS gets opaque TLS, and gets told plainly that no
+transformation applies to it.
+
+## Consequences
+
+**Accepted.**
+
+- The raw-packet transport is retired. `NetworkMode`, `L3Vsock`,
+  `HostVsockProxy`, `raw_ip_stack`, the guest `mvm0` TUN, `mvm-net-agent`,
+  `mvm-netd`, `NetworkControl`, `NetworkData`, host TUN, nftables forwarding,
+  and the smoltcp datapath are removed.
+- Raw sockets, arbitrary IP protocols, custom in-guest resolvers, and general
+  ICMP are **unsupported** for production workloads. A program that ignores
+  the supported loopback adapters has no network route and fails closed. This
+  is a deliberate compatibility ceiling, not an unfinished feature.
+- Compatibility is served by adapters that terminate in the single FlowMux
+  client: the loopback HTTP proxy, SOCKS5h, SOCKS5 UDP, the controlled DNS
+  stub, the mediated ping helper, and the typed SDK connectors.
+- No compatibility concession may weaken `PR_SET_DUMPABLE`, ptrace isolation,
+  capability bounding, seccomp, Landlock, verified boot, the read-only
+  workload rootfs, or secret handling. Reading workload memory or installing
+  seccomp user-notification to fake up transparent connect interception is
+  rejected.
+
+**Claim effects.**
+
+- **Claim 10 strengthened.** The sole network decision and socket creation
+  site is the per-VM endpoint, so no compatibility path can diverge from it.
+- **Claims 12 and 13 preserved.** Typed connectors and listeners stay bound to
+  the signed `ExecutionPlan` before dispatch; broker calls can request
+  destination-bound use of a credential but never receive or transmit its raw
+  value.
+- **Preview claim 16 strengthened but still scoped.** Substitution and its
+  leak gate sit on the only endpoint that can create an external connection.
+  The claim remains scoped to typed transform flows and never extends to
+  opaque ciphertext — which is precisely the honesty this ADR buys.
+- **Claims 5 and 8 preserved.** The new frame decoder is fuzzed, and every
+  endpoint capability derives from the admitted signed plan.
+
+**Costs.**
+
+- Workloads that genuinely need an in-guest IP stack lose their supported
+  path. `raw_ip_stack=true` is refused with a migration error naming the
+  loopback proxy and typed-connector alternatives.
+- The migration is staged rather than atomic. During it, no new production L3
+  workload may boot, so the tree never runs three live production paths.
+
+## Alternatives considered
+
+- **Keep both paths and document the difference.** Rejected: it is the status
+  quo, and it is the thing that made ADR-001's claim-10 section wrong. Two
+  policy implementations drift; one of them is always the one nobody audited
+  most recently.
+- **Universal host TLS termination via a MITM CA.** Rejected above.
+- **Transparent connect interception via ptrace/seccomp user-notification.**
+  Rejected: it requires weakening `PR_SET_DUMPABLE` and ptrace isolation, or
+  reading workload memory, to buy compatibility for programs that deliberately
+  bypass the supported adapters. The isolation is worth more than the
+  compatibility.
+- **Keep a raw-packet path as a dev/test escape hatch.** Rejected: a real
+  alternate network implementation retained for testing is a second production
+  path with a different label. Hermetic protocol doubles are allowed; a second
+  network stack is not.
+
+## Migration
+
+Staged in `specs/plans/316-single-flow-vsock-networking.md`, phases 0–8. The
+plan's performance gate is a merge gate: opaque TCP/UDP may regress at most 5%
+on p50/p95 latency, must retain at least 95% throughput, and may not grow peak
+RSS by more than 10%, measured against baselines recorded before the endpoint
+changes.

--- a/specs/plans/316-single-flow-vsock-networking.md
+++ b/specs/plans/316-single-flow-vsock-networking.md
@@ -2,7 +2,12 @@
 
 ## Status
 
-**Phase 0 in progress.**
+**Phase 0 complete (#2369). Phases 1–8 open.**
+
+ADR-042 is accepted and the raw-packet path is frozen: new
+`raw_ip_stack=true` / `NetworkMode::L3Vsock` launches are refused at synthesis,
+admission, and CLI preflight, and `xtask check-l3-expansion-freeze` holds the
+line. No FlowMux runtime exists yet.
 
 ## Tracking issues
 
@@ -161,27 +166,37 @@ the admitted launch state, never from guest bytes.
       existing `machine forward` seam. It adds no networking runtime path,
       binds host loopback explicitly, and refuses detached ownership; Phase 5
       will replace the transitional proxy with signed FlowMux ingress.
-- [ ] Add an accepted ADR that records the L4-with-selective-L7 decision, the
+- [x] Add an accepted ADR that records the L4-with-selective-L7 decision, the
       impossibility of arbitrary guest TLS plus host replacement without TLS
       interception, and the rejection of a host MITM CA as the universal path.
-- [ ] Mark ADR-036 and ADR-037 superseded for production workload networking;
+- [x] Mark ADR-036 and ADR-037 superseded for production workload networking;
       retain their measurements and historical rationale without describing
       either implementation as live.
-- [ ] Reconcile `specs/refactor/03-networking.md`, ADR-001's backend matrix and
+- [x] Reconcile `specs/refactor/03-networking.md`, ADR-001's backend matrix and
       claim-10 section, `specs/SPRINT.md`, and `specs/REFACTOR-STATUS.md` with
       the actual two-path starting state and this target invariant.
-- [ ] Add a temporary CI ratchet that forbids new non-test references to
+- [x] Add a temporary CI ratchet that forbids new non-test references to
       `L3Vsock`, `raw_ip_stack`, `NetworkControl`, `NetworkData`, `spawn_netd`,
       and `host_datapath` outside the files scheduled for deletion by this
       plan. The allowlist is an explicit file list and can only shrink.
-- [ ] Freeze Plan 285 and Plan 287: no feature work lands on their runtime path;
+- [x] Freeze Plan 285 and Plan 287: no feature work lands on their runtime path;
       only security fixes needed to keep the tree safe during migration may
       modify it.
-- [ ] In the first implementation change, make synthesis and admission reject
+- [x] In the first implementation change, make synthesis and admission reject
       `raw_ip_stack=true`/`L3Vsock` with an error naming the supported loopback
       proxy and typed-connector alternatives. Existing running VMs may drain,
       but no new production L3 workload may boot while FlowMux is built. This
       ensures the migration never operates three live production paths.
+
+**Landed as.** ADR-042 (`specs/adrs/042-single-flow-vsock-networking.md`);
+superseded-for-production markers on ADR-036 and ADR-037; a rewritten
+`specs/refactor/03-networking.md`; a qualified tier matrix and claim-10 section
+in ADR-001; `xtask check-l3-expansion-freeze`
+(`xtask/src/check_l3_expansion_freeze.rs`, wired into the CI Lint job) with a
+29-entry allowlist that fails closed on a stale entry so it can only shrink;
+and one shared refusal, `mvm_core::plan::l3_retirement`, called from
+`synthesize_plan`, `admit_for_run`, and
+`mvm_cli::commands::machine::preflight_network`.
 
 ### Phase 1 — Pin protocol, resource, and performance baselines
 

--- a/specs/refactor/03-networking.md
+++ b/specs/refactor/03-networking.md
@@ -1,39 +1,77 @@
 # Consolidated Vsock Networking
 
-## Current invariant
+## Actual state today: two paths, not one
 
-Every workload backend uses the authenticated, default-deny vsock runner seam.
-The workload guest has no NIC surface, and no raw packet tunnel or userspace
-L3 forwarder is part of the production path.
+This document previously said the raw-packet tunnel was retired and that no
+raw packet tunnel or userspace L3 forwarder was part of the production path.
+That stopped being true when ADR-036 reintroduced the tunnel as `l3-vsock` and
+ADR-037 added a second, unprivileged forwarder for it. Both shipped. The
+statement was never corrected here, which is exactly the failure this section
+now records rather than repeats.
 
-## Data path
+The tree carries **two** production workload networking paths:
 
+1. **Socket-aware vsock (the default).** The guest has no network device. Its
+   loopback adapters hand traffic to a host-side endpoint over AF_VSOCK; the
+   host originates every outbound connection, so admission, substitution,
+   redaction, and the audit record are all possible.
+2. **`l3-vsock` (opt-in, `raw_ip_stack=true`).** The guest gets a real IP
+   stack on an `mvm0` TUN and tunnels raw IPv4/IPv6 packets to a host
+   forwarder (Linux host TUN + nftables, or the unprivileged userspace socket
+   datapath). The *guest* originates connections, so host-side substitution
+   and redaction cannot apply to them.
+
+Two paths means two policy implementations, two resource accountings, and two
+audit shapes. Claim 10's "one decision point" describes only the first.
+
+## Target invariant
+
+ADR-042 and `specs/plans/316-single-flow-vsock-networking.md` collapse this to
+one path:
+
+```text
+guest loopback adapter
+  -> authenticated FlowMux session on GuestService::NetworkFlow (vsock port 5253)
+  -> one per-VM mvm-network-endpoint
+  -> canonical policy, DNS, substitution/redaction, rate and audit pipeline
+  -> host-originated TCP/UDP socket or host-owned ingress listener
 ```
-guest app → guest loopback / mvm-egress-client → authenticated vsock
-  → WorkloadRunner → RealEndpointSpawner / broker / substitution
-  → supervisor L4 policy gate → approved endpoint
-```
 
+The endpoint is flow-aware at L4 with selective L7: opaque TCP/UDP is relayed
+without parsing, and L7 parsing, host TLS origination, substitution,
+reversible replacement, and redaction run only for an explicitly typed
+HTTP/connector flow whose signed plan requires them. `Off` is the absence of a
+network grant and of `NetworkFlow` — not a second mode. There is no transport
+selector.
+
+## Migration state
+
+The raw-packet path is **frozen, not yet deleted**. New
+`raw_ip_stack=true` / `NetworkMode::L3Vsock` launches are refused at synthesis
+and admission with a migration error naming the loopback proxy and
+typed-connector alternatives; already-running VMs drain. A temporary
+`xtask check-l3-expansion-freeze` ratchet forbids new non-test references to
+`L3Vsock`, `raw_ip_stack`, `NetworkControl`, `NetworkData`, `spawn_netd`, and
+`host_datapath` outside a shrink-only allowlist of the files scheduled for
+deletion. Plan 285 and Plan 287 are frozen: only security fixes may touch
+their runtime path.
+
+Deletion of `mvm-contract::l3`, `NetworkMode`, `mvm-net/src/l3/`,
+`mvm-agentd/src/l3/`, `mvm-hostd/src/netd/`, `mvm-netd`, `mvm-net-agent`,
+`netd_spawn`, and smoltcp lands in Plan 316 Phase 7; the permanent
+`check-single-network-path` and socket-owner gates replace the temporary
+ratchet in Phase 8.
+
+## Security properties on the socket-aware path
+
+Firecracker, libkrun, and HVF all bind
+`WorkloadRunner<VmmDriver, RealEndpointSpawner, RealBrokerRegistrar>`; their
+capability shape advertises host-vsock mediation and no routable guest NIC.
 The runner owns admission and default-deny. The endpoint spawner owns admitted
-raw host/port connections. The broker and substitution endpoint own
-secret-bearing requests, so credentials never enter the guest. The supervisor
-L4 gate applies the final host/port policy and audit boundary.
-
-## Retired Model A
-
-The former guest-TUN → framed raw-packet vsock → host-UDS → smoltcp path is
-retired. Its guest TUN device, host packet worker, network-tunnel protocol,
-smoltcp dependency, and guest-netd binary are deleted. No backend may restore
-that path as a fallback: the uniform runner must fail closed if its host vsock
-seam is unavailable.
-
-## Model B and security properties
-
-Model B is the sole workload egress model. Firecracker, libkrun, and HVF all
-bind `WorkloadRunner<VmmDriver, RealEndpointSpawner, RealBrokerRegistrar>`;
-their capability shape advertises host-vsock mediation and no routable guest
-NIC. The same typed seam enforces default-deny egress and secret substitution
-for every workload backend.
+host/port connections. The broker and substitution endpoint own secret-bearing
+requests, so credentials never enter the guest. The supervisor L4 gate applies
+the final host/port policy and audit boundary. Plan 316 keeps this seam and
+makes it the only one.
 
 QEMU remains an explicit development/test substrate outside the production
 workload claim boundary. Its networking behavior is not a production egress

--- a/xtask/src/check_l3_expansion_freeze.rs
+++ b/xtask/src/check_l3_expansion_freeze.rs
@@ -1,0 +1,351 @@
+//! `xtask check-l3-expansion-freeze`
+//!
+//! The raw-packet workload networking path is frozen while its replacement is
+//! built. Frozen means two things, and this gate is both of them:
+//!
+//! - **No new entrants.** A non-test reference to one of the retired symbols
+//!   may appear only in a file that already had one. The allowlist below is an
+//!   explicit file list, not a pattern.
+//! - **It can only shrink.** An allowlist entry that no longer matches
+//!   anything fails the gate, so a file that gets cleaned up must be struck
+//!   from the list in the same change. Without that arm the list would decay
+//!   into a permanent exemption set, which is the failure mode every
+//!   long-lived allowlist has.
+//!
+//! This gate is temporary by construction. It is deleted along with the last
+//! allowlist entry, and replaced by a permanent single-network-path gate and a
+//! socket-owner gate once the raw-packet stack is gone. Tests are out of scope
+//! on purpose: a test that pins today's behaviour of code scheduled for
+//! deletion is doing its job, and forcing it onto an allowlist would make the
+//! list grow for the wrong reason.
+
+use anyhow::{Context, Result, bail};
+use regex::Regex;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// The retired symbols. Matched on word boundaries and case-sensitively, so
+/// `refuse_raw_ip_stack` and the `l3-vsock` prose spelling do not trip it.
+const FROZEN: &[&str] = &[
+    "L3Vsock",
+    "raw_ip_stack",
+    "NetworkControl",
+    "NetworkData",
+    "spawn_netd",
+    "host_datapath",
+];
+
+/// Files that already reference a frozen symbol and are scheduled for deletion
+/// or migration. **Append nothing.** Entries leave as the stack is removed; an
+/// entry that stops matching is a hard failure, which is what makes the list
+/// monotonically shrink.
+const ALLOWLIST: &[&str] = &[
+    // The refusal itself has to name what it refuses.
+    "crates/mvm-core/src/plan/l3_retirement.rs",
+    // Plan type + IR surface.
+    "crates/mvm-contract/src/ir/workload.rs",
+    "crates/mvm-contract/src/plan/execution_plan.rs",
+    "crates/mvm-contract/src/plan/types.rs",
+    "crates/mvm-core/src/plan/synthesis.rs",
+    // CLI mode derivation and the launch paths that carry the mode.
+    "crates/mvm-cli/src/commands/machine/mod.rs",
+    "crates/mvm-cli/src/commands/machine/runtime.rs",
+    "crates/mvm-cli/src/commands/vm/run_plan.rs",
+    "crates/mvm-cli/src/commands/vm/up/admission.rs",
+    // Host forwarder and its channel identities.
+    "crates/mvm-hostd/src/bin/mvm-netd.rs",
+    "crates/mvm-hostd/src/netd/",
+    "crates/mvm-net/src/channel.rs",
+    "crates/mvm-net/src/l3/",
+    // Launch-spec guards and the VMM wiring behind them.
+    "crates/mvm-runtime/src/machine/mod.rs",
+    "crates/mvm-runtime/src/machine/nic_guard.rs",
+    "crates/mvm-vmm/src/driver/spec.rs",
+    "crates/mvm-vmm/src/host/egress_shared.rs",
+    "crates/mvm-vmm/src/host/netd_spawn.rs",
+    "crates/mvm-vmm/src/host/spec_map.rs",
+    // SDK surfaces that still spell the declaration, plus the generated schema
+    // and the user-facing guide. All three go when the declaration goes.
+    "crates/mvm-sdk/src/ctor/network.rs",
+    "crates/mvm-sdk/src/decorator/python.rs",
+    "crates/mvm-sdk/src/decorator/value.rs",
+    "crates/mvm-sdk/src/deploy.rs",
+    "crates/mvm-sdk/sdks/python/mvm/_dsl.py",
+    "crates/mvm-sdk/sdks/python/mvm/_ir/workload.py",
+    "crates/mvm-sdk/sdks/typescript/src/index.ts",
+    "crates/mvm-sdk/sdks/typescript/src/ir/workload.ts",
+    "public/src/content/docs/guides/l3-vsock-networking.md",
+    "schema/workload-ir-v0.json",
+];
+
+/// Path fragments that mark a file as test code, which this gate does not read.
+const TEST_MARKERS: &[&str] = &[
+    "/tests/",
+    "/tests.rs",
+    "/test_support.rs",
+    "/fuzz/",
+    "/benches/",
+];
+
+/// Trees the gate never reads: the gate and the plan/ADR record that describe
+/// the retirement, plus VCS and build output.
+const EXEMPT: &[&str] = &[
+    "xtask/src/check_l3_expansion_freeze.rs",
+    "specs/",
+    "CHANGELOG.md",
+];
+
+const SKIP_DIRS: &[&str] = &[
+    ".git",
+    ".mvm-test",
+    ".mvm-verify",
+    "target",
+    "node_modules",
+    ".worktrees",
+    "dist",
+    ".astro",
+];
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let re = frozen_regex()?;
+    let mut new_entrants: Vec<String> = Vec::new();
+    let mut matched_allowlist: BTreeSet<&str> = BTreeSet::new();
+    let mut scanned = 0usize;
+
+    for path in walk(workspace)? {
+        let rel = relative(workspace, &path);
+        if is_skipped(&rel) {
+            continue;
+        }
+        let Ok(body) = std::fs::read_to_string(&path) else {
+            continue; // binary or unreadable
+        };
+        scanned += 1;
+        let allowed = allowlist_entry_for(&rel);
+        for (i, line) in body.lines().enumerate() {
+            for m in re.find_iter(line) {
+                match allowed {
+                    Some(entry) => {
+                        matched_allowlist.insert(entry);
+                    }
+                    None => new_entrants.push(format!("{rel}:{}: {}", i + 1, m.as_str())),
+                }
+            }
+        }
+    }
+
+    if !new_entrants.is_empty() {
+        bail!(
+            "check-l3-expansion-freeze: {} new non-test reference(s) to a frozen \
+             raw-packet networking symbol:\n  {}\n\n\
+             The in-guest IP stack is frozen while the single flow-aware vsock path is \
+             built, and the allowlist in this gate may only shrink. Route the work \
+             through the guest loopback adapters or a typed connector instead of \
+             extending the retired stack.",
+            new_entrants.len(),
+            joined(&new_entrants)
+        );
+    }
+
+    let stale: Vec<&str> = ALLOWLIST
+        .iter()
+        .copied()
+        .filter(|e| !matched_allowlist.contains(e))
+        .collect();
+    if !stale.is_empty() {
+        bail!(
+            "check-l3-expansion-freeze: {} allowlist entr(y/ies) no longer reference a \
+             frozen symbol:\n  {}\n\n\
+             Delete them from ALLOWLIST in the same change that cleaned the file. The \
+             allowlist is the remaining-work ledger; an entry that no longer matches is \
+             a permanent exemption in the making.",
+            stale.len(),
+            stale.join("\n  ")
+        );
+    }
+
+    eprintln!(
+        "check-l3-expansion-freeze: frozen ({scanned} text file(s) scanned, \
+         {} allowlist entr(y/ies) remaining)",
+        ALLOWLIST.len()
+    );
+    Ok(())
+}
+
+fn frozen_regex() -> Result<Regex> {
+    Regex::new(&format!(r"\b({})\b", FROZEN.join("|"))).context("compile frozen-symbol regex")
+}
+
+fn relative(workspace: &Path, path: &Path) -> String {
+    path.strip_prefix(workspace)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+/// Whether the gate reads this file at all.
+///
+/// Test code and the retirement's own record are out of scope; a lockfile
+/// carries transitive names we do not control.
+fn is_skipped(rel: &str) -> bool {
+    if EXEMPT.iter().any(|e| rel.starts_with(e) || rel == *e) {
+        return true;
+    }
+    if rel.ends_with(".lock") {
+        return true;
+    }
+    let probe = format!("/{rel}");
+    TEST_MARKERS.iter().any(|m| probe.contains(m))
+        || probe
+            .rsplit('/')
+            .next()
+            .is_some_and(|f| f.starts_with("test_") && f.ends_with(".py"))
+}
+
+/// The allowlist entry covering `rel`, if any. A trailing `/` entry covers a
+/// directory; anything else is an exact file.
+fn allowlist_entry_for(rel: &str) -> Option<&'static str> {
+    ALLOWLIST.iter().copied().find(|e| {
+        if e.ends_with('/') {
+            rel.starts_with(e)
+        } else {
+            rel == *e
+        }
+    })
+}
+
+fn joined(hits: &[String]) -> String {
+    let shown = hits
+        .iter()
+        .take(40)
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n  ");
+    if hits.len() > 40 {
+        format!("{shown}\n  ... and {} more", hits.len() - 40)
+    } else {
+        shown
+    }
+}
+
+/// Every file under `root`, skipping [`SKIP_DIRS`] and never following a
+/// symlink — `nix build` drops a `result` symlink into the repo root pointing
+/// at `/nix/store`, and following it would walk the store.
+fn walk(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            let path = entry.path();
+            if file_type.is_dir() {
+                let name = entry.file_name().to_string_lossy().into_owned();
+                if SKIP_DIRS.contains(&name.as_str()) {
+                    continue;
+                }
+                stack.push(path);
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("..")
+    }
+
+    /// The whole point: the tree is frozen today, and stays frozen.
+    #[test]
+    fn the_workspace_is_frozen() {
+        run(&workspace()).expect("no new raw-packet references and no stale allowlist entries");
+    }
+
+    #[test]
+    fn every_frozen_symbol_is_matched_on_a_word_boundary() {
+        let re = frozen_regex().expect("regex");
+        for sym in FROZEN {
+            assert!(re.is_match(sym), "{sym} does not match its own pattern");
+        }
+        // The refusal helper's name embeds a frozen symbol after an underscore,
+        // which is a word character — so it must not trip the gate.
+        assert!(!re.is_match("refuse_raw_ip_stack"));
+        // Prose spells the mode with a hyphen; only the type name is frozen.
+        assert!(!re.is_match("l3-vsock"));
+    }
+
+    #[test]
+    fn a_new_non_test_file_would_be_flagged() {
+        let re = frozen_regex().expect("regex");
+        let synthetic = "crates/mvm-runtime/src/some_new_module.rs";
+        assert!(
+            allowlist_entry_for(synthetic).is_none(),
+            "a file nobody allowlisted must not be covered"
+        );
+        assert!(!is_skipped(synthetic), "a src file is in scope");
+        assert!(re.is_match("let mode = NetworkMode::L3Vsock;"));
+    }
+
+    #[test]
+    fn test_paths_are_out_of_scope() {
+        for rel in [
+            "crates/mvm-hostd/tests/l3_tunnel_e2e.rs",
+            "crates/mvm-cli/src/commands/machine/tests.rs",
+            "crates/mvm-core/src/plan/test_support.rs",
+            "crates/mvm-agentd/fuzz/fuzz_targets/x.rs",
+            "crates/mvm-sdk/sdks/python/tests/test_hooks_and_helpers.py",
+        ] {
+            assert!(is_skipped(rel), "{rel} should be out of scope");
+        }
+    }
+
+    #[test]
+    fn the_retirement_record_is_out_of_scope() {
+        assert!(is_skipped(
+            "specs/plans/316-single-flow-vsock-networking.md"
+        ));
+        assert!(is_skipped("specs/adrs/036-l3-tun-over-vsock.md"));
+        assert!(is_skipped("xtask/src/check_l3_expansion_freeze.rs"));
+    }
+
+    #[test]
+    fn a_directory_entry_covers_its_files_and_a_file_entry_does_not_prefix_match() {
+        assert_eq!(
+            allowlist_entry_for("crates/mvm-net/src/l3/compat.rs"),
+            Some("crates/mvm-net/src/l3/")
+        );
+        assert_eq!(
+            allowlist_entry_for("crates/mvm-net/src/channel.rs"),
+            Some("crates/mvm-net/src/channel.rs")
+        );
+        assert_eq!(
+            allowlist_entry_for("crates/mvm-net/src/channel_extra.rs"),
+            None
+        );
+    }
+
+    /// A stale entry is a hard failure, which is what makes the list shrink.
+    #[test]
+    fn the_allowlist_has_no_duplicates() {
+        let unique: BTreeSet<&&str> = ALLOWLIST.iter().collect();
+        assert_eq!(
+            unique.len(),
+            ALLOWLIST.len(),
+            "duplicate allowlist entries hide a stale one"
+        );
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -38,6 +38,7 @@ mod check_guest_init_parity;
 mod check_honesty;
 pub(crate) mod check_kernel_config_budget;
 mod check_kernel_pin_freshness;
+mod check_l3_expansion_freeze;
 mod check_machine_doc_guards;
 mod check_mutation_witnesses;
 mod check_mvm_host_binaries_sync;
@@ -290,6 +291,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_guest_init_parity::run(&workspace)
         }
+        Some("check-l3-expansion-freeze") => {
+            let workspace = workspace_root();
+            check_l3_expansion_freeze::run(&workspace)
+        }
         Some("check-uniform-vsock-egress") => {
             let workspace = workspace_root();
             check_uniform_vsock_egress::run(&workspace)
@@ -346,7 +351,7 @@ fn main() -> Result<()> {
             ir_parity::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-dormant-controls, check-witness-citations, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-conformance, check-trust-gradient, check-vsock-only-egress, check-no-gateway-names, check-uniform-vsock-egress, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-backend-resource-controls, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-dormant-controls, check-witness-citations, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-conformance, check-trust-gradient, check-vsock-only-egress, check-no-gateway-names, check-uniform-vsock-egress, check-l3-expansion-freeze, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-backend-resource-controls, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {


### PR DESCRIPTION
Phase 0 of Plan 316. Ratifies the single-networking-path decision and freezes
the raw-packet path so the migration never runs three live production paths.

- Umbrella: #2368
- This phase: #2369
- Plan: `specs/plans/316-single-flow-vsock-networking.md`

## Why

The tree carries two production workload networking paths. The default one has
the guest hold no network device, so the host originates every outbound
connection and can admit, substitute, redact, and audit it. The opt-in
`l3-vsock` mode (`raw_ip_stack=true`) gives the guest an `mvm0` TUN and has the
*guest* originate connections, decided by a second policy implementation that
cannot carry substitution or redaction at all.

That second path is why two documents were wrong. ADR-001's claim-10 section and
`specs/refactor/03-networking.md` both stated that a workload guest has no
network interface, with no qualifier. Both were true when written and stopped
being true when the tunnel shipped, and nothing checks prose.

## What landed

**ADR-042 (accepted)** — `specs/adrs/042-single-flow-vsock-networking.md`.
Records the L4-with-selective-L7 decision; why arbitrary guest TLS and
host-side credential replacement are mutually exclusive without terminating
TLS; and why a universal MITM CA is rejected as the answer — certificate
pinning, mutual TLS, QUIC, and ECH each defeat it, and a mechanism that
silently stops applying for a subset of traffic is worse than one that never
claimed to apply.

**Doc reconciliation.** ADR-036 and ADR-037 are marked superseded for
production workload networking; their measurements and threat analysis stay,
and neither is described as a live transport. `specs/refactor/03-networking.md`
now records the actual two-path starting state and the target invariant instead
of asserting a deletion that was reversed. ADR-001's tier matrix and claim-10
section gain the missing qualifier and name the second path's retirement, with
a dated correction note.

**Temporary shrink-only ratchet** — `xtask check-l3-expansion-freeze`, wired
into the CI Lint job. No new non-test reference to `L3Vsock`, `raw_ip_stack`,
`NetworkControl`, `NetworkData`, `spawn_netd`, or `host_datapath` outside a
29-entry explicit file allowlist. An allowlist entry that stops matching is a
hard failure, so the list cannot decay into a permanent exemption set — it can
only shrink. The gate is deleted with its last entry and replaced by
`check-single-network-path` plus a socket-owner gate in Phase 8.

**Fail closed** — one shared refusal, `mvm_core::plan::l3_retirement`, called
from `synthesize_plan`, `admit_for_run`, and the CLI's `preflight_network`. A
pre-signed plan that never passed through synthesis is refused too. The error
names the loopback adapters and the typed connectors rather than only reporting
a refusal. Running VMs are unaffected — they drain.

## Constraints held

No change to `PR_SET_DUMPABLE`, ptrace isolation, capability bounding, seccomp,
Landlock, verified boot, or secret handling. No second temporary production
networking path. No universal TLS interception. Claims 5, 8, 10, 12, 13 and
scoped preview claim 16 preserved — `check-claim-catalog`, `check-doc-claims`,
`check-no-overclaim`, `check-honesty`, and `check-witness-citations` all pass.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo nextest run --workspace` — **11054 passed, 0 failed**, 25 skipped
- `cargo test --workspace --doc` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (exit 0)
- `just check-linux` (`cargo zigbuild --target x86_64-unknown-linux-gnu
  --workspace --lib --all-features`) — clean, so `cfg(target_os = "linux")`
  code compiles
- xtask gates run individually and green: `check-l3-expansion-freeze`,
  `check-no-gateway-names`, `check-vsock-only-egress`,
  `check-uniform-vsock-egress`, `check-adr-coverage`, `check-claim-catalog`,
  `check-doc-claims`, `check-no-overclaim`, `check-honesty`,
  `check-witness-citations`, `check-no-spec-refs-in-comments`,
  `check-deferrals`, `check-conformance`, `check-workflow-paths`

The Linux-gated test execution is CI's `Test Linux and conformance` job — the
local builder VM is a headless Nix build engine and carries no workspace
toolchain, so cross-compilation is the strongest local Linux signal available.

### New tests

- `mvm_core::plan::l3_retirement` — tunnel mode refused, stray spec refused,
  supported modes still pass, `raw_ip_stack` refused and its absence not, and
  the message names both replacements plus the drain allowance.
- `mvm_cli` `a_launch_asking_for_the_retired_ip_stack_is_refused` — admission
  refuses `L3Vsock` and says why;
  `the_admitted_plan_records_the_transport_the_launch_derived` now covers only
  the two supported modes, sharing one `admit_with_mode` helper with the
  refusal test.
- `xtask::check_l3_expansion_freeze` — the workspace is frozen; word-boundary
  behaviour (`refuse_raw_ip_stack` and `l3-vsock` prose do not trip it); a new
  non-test file would be flagged; test paths and the retirement record are out
  of scope; directory vs exact-file allowlist matching; no duplicate entries.

## Docs kept in sync

Plan 316 Phase 0 checkboxes ticked with a "Landed as" note, plus `specs/SPRINT.md`
and `specs/REFACTOR-STATUS.md` in the same change.

## Next

Phase 1 (#2370) — pin the `mvm-contract::protocol::network_flow` codec, the
resource ceilings, and the legacy performance baselines. Blocked on this PR.