### PR TITLE
Skip Rust CI for non-code merge groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,78 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  # Classify the exact commit range once, before allocating expensive runners.
+  # Pull-request and merge-group events expose different SHA fields, so keeping
+  # this in one fail-closed job prevents lane-specific path filters drifting.
+  scope:
+    name: CI scope
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.validate.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          MG_BASE: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD: ${{ github.event.merge_group.head_sha }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          set_all() {
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          }
+
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            set_all
+            echo "manual dispatch — running every lane"
+            exit 0
+          fi
+
+          case "$EVENT" in
+            merge_group)  BASE="$MG_BASE"; HEAD="$MG_HEAD" ;;
+            pull_request) BASE="$PR_BASE"; HEAD="$PR_HEAD" ;;
+            *) echo "::error::unhandled event $EVENT" >&2; exit 1 ;;
+          esac
+
+          CHANGED_FILE=$(mktemp)
+          trap 'rm -f "$CHANGED_FILE"' EXIT
+          if ! git diff --name-only -z "$BASE" "$HEAD" > "$CHANGED_FILE" 2>/dev/null; then
+            set_all
+            echo "could not diff $BASE..$HEAD — running every lane to stay safe"
+            exit 0
+          fi
+
+          # Anything that can change a compiled target, generated artifact, or
+          # the commands used by a Rust lane keeps the full compiler/test
+          # matrix. Prose, site assets, and process-only specs do not.
+          if grep -zE '^(crates/|src/|tests/|xtask/|scripts/|features/|schema/|model/|assets/|\.cargo/|\.config/|\.github/actions/|\.github/workflows/ci\.yml$|nix/packaging/release/verify-release-assets[^/]*\.sh$|Cargo\.(toml|lock)$|rust-toolchain\.toml$|build\.rs$|install\.sh$|[Jj]ustfile$)' "$CHANGED_FILE" >/dev/null; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate classification
+        id: validate
+        env:
+          CODE: ${{ steps.decide.outputs.code }}
+        run: |
+          set -euo pipefail
+          case "$CODE" in
+            true|false) echo "code=$CODE" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::invalid or missing code scope: $CODE" >&2; exit 1 ;;
+          esac
+
   lint-core:
     name: Lint core (fmt + clippy)
+    needs: [scope]
+    if: needs.scope.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -75,6 +145,7 @@ jobs:
 
   lint-policy:
     name: Lint policy
+    needs: [scope]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -288,6 +359,8 @@ jobs:
 
   lint-features:
     name: Lint feature coverage
+    needs: [scope]
+    if: needs.scope.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -348,20 +421,31 @@ jobs:
   lint:
     name: Lint (fmt + clippy + policy)
     if: ${{ always() }}
-    needs: [lint-core, lint-policy, lint-features]
+    needs: [scope, lint-core, lint-policy, lint-features]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Require every lint lane to pass
         env:
+          SCOPE_RESULT: ${{ needs.scope.result }}
+          SCOPE_CODE: ${{ needs.scope.outputs.code }}
           CORE_RESULT: ${{ needs.lint-core.result }}
           POLICY_RESULT: ${{ needs.lint-policy.result }}
           FEATURES_RESULT: ${{ needs.lint-features.result }}
         run: |
           set -euo pipefail
-          for result in "$CORE_RESULT" "$POLICY_RESULT" "$FEATURES_RESULT"; do
-            if [ "$result" != success ]; then
-              echo "A lint lane did not pass: $result"
+          if [ "$SCOPE_RESULT" != success ] || [ "$POLICY_RESULT" != success ]; then
+            echo "CI scope or policy did not pass: scope=$SCOPE_RESULT policy=$POLICY_RESULT"
+            exit 1
+          fi
+          case "$SCOPE_CODE" in
+            true) required=success ;;
+            false) required=skipped ;;
+            *) echo "Invalid code scope: $SCOPE_CODE"; exit 1 ;;
+          esac
+          for result in "$CORE_RESULT" "$FEATURES_RESULT"; do
+            if [ "$result" != "$required" ]; then
+              echo "A lint lane did not match scope $SCOPE_CODE: $result"
               exit 1
             fi
           done
@@ -369,26 +453,39 @@ jobs:
   test:
     name: Test
     if: ${{ always() }}
-    needs: [test-workspace, test-linux, test-release-witness]
+    needs: [scope, test-workspace, test-linux, test-release-witness]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Require every test lane to pass
         env:
+          SCOPE_RESULT: ${{ needs.scope.result }}
+          SCOPE_CODE: ${{ needs.scope.outputs.code }}
           WORKSPACE_RESULT: ${{ needs.test-workspace.result }}
           LINUX_RESULT: ${{ needs.test-linux.result }}
           RELEASE_WITNESS_RESULT: ${{ needs.test-release-witness.result }}
         run: |
           set -euo pipefail
+          if [ "$SCOPE_RESULT" != success ]; then
+            echo "CI scope did not pass: $SCOPE_RESULT"
+            exit 1
+          fi
+          case "$SCOPE_CODE" in
+            true) required=success ;;
+            false) required=skipped ;;
+            *) echo "Invalid code scope: $SCOPE_CODE"; exit 1 ;;
+          esac
           for result in "$WORKSPACE_RESULT" "$LINUX_RESULT" "$RELEASE_WITNESS_RESULT"; do
-            if [ "$result" != success ]; then
-              echo "A test lane did not pass: $result"
+            if [ "$result" != "$required" ]; then
+              echo "A test lane did not match scope $SCOPE_CODE: $result"
               exit 1
             fi
           done
 
   test-workspace:
     name: Test workspace
+    needs: [scope]
+    if: needs.scope.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -444,6 +541,8 @@ jobs:
 
   test-release-witness:
     name: Test release profile (overflow + no debug assertions)
+    needs: [scope]
+    if: needs.scope.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -489,6 +588,8 @@ jobs:
 
   test-linux:
     name: Test Linux and conformance
+    needs: [scope]
+    if: needs.scope.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -531,6 +632,8 @@ jobs:
 
   test-ebpf-telemetry:
     name: Test eBPF telemetry load/attach
+    needs: [scope]
+    if: needs.scope.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -62,6 +62,10 @@ for detailed scope and acceptance criteria.
       clippy are green.
 
 ## In-flight plans
+- [x] Plan 322 — Scope merge-group Rust CI to behavior-changing diffs
+      (`specs/plans/322-merge-group-ci-scope.md`)
+  - [x] Fail-closed path classification preserves required aggregates while
+        prose/site-only diffs avoid six cold Rust jobs; validation is complete.
 - [x] Plan 315 — Bootstrap means machine-ready
       (`specs/plans/315-bootstrap-machine-readiness.md`)
   - [x] Bootstrap acquires and verifies both builder image and workload kernel

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -26,6 +26,15 @@
       global test environment races; the affected tests pass in isolation and
       serially.
 
+- [x] Merge-group CI scoping — **plan 322**. A fail-closed SHA-range
+      classifier keeps the full Rust matrix for behavior-changing diffs and
+      manual runs, while prose/site-only pull requests and merge groups avoid
+      six cold Rust jobs. Policy and the independently scoped required Nix
+      check remain unconditional authorities for their own input surfaces.
+      Workflow syntax, formatting, workspace compilation, all-target Clippy,
+      and all 499 `xtask` tests pass; the sole transient workspace-suite
+      host-restart failure passed on its exact isolated rerun.
+
 - [x] Bootstrap machine readiness — **plan 315**. `mvmctl bootstrap` now
       prepares both the builder VM and verified dm-verity workload kernel, so a
       successful bootstrap does not defer an infrastructure build to the next

--- a/specs/adrs/012-ci-execution-policy.md
+++ b/specs/adrs/012-ci-execution-policy.md
@@ -56,6 +56,16 @@ The feature lanes retain the existing targeted package coverage, and the
 Linux-only filesystem/no-std/BDD commands live in one script rather than being
 duplicated between workflows.
 
+A fail-closed scope job compares the exact pull-request or merge-group base and
+head SHAs before allocating Rust runners. Diffs that cannot change compiled or
+generated behavior skip compiler lint, feature coverage, workspace tests,
+release-profile witnesses, Linux/conformance coverage, and eBPF coverage.
+Policy still runs for every diff because prose and claims are part of its input
+surface. Manual dispatch and an unresolvable diff run the complete matrix. The
+required aggregates accept a lane only when it passed or the successful scope
+decision deliberately skipped it; scope and policy themselves must pass. Nix
+retains its own independent, fail-closed classifier.
+
 ### The merge queue's required checks
 
 `ci.yml` and `architecture.yml` are the only two workflows that run on

--- a/specs/plans/322-merge-group-ci-scope.md
+++ b/specs/plans/322-merge-group-ci-scope.md
@@ -1,0 +1,54 @@
+# Plan 322 — Scope merge-group Rust CI to behavior-changing diffs
+
+**Status:** COMPLETE
+
+## Problem
+
+Every merge-queue entry currently allocates six expensive Rust runners even
+when its synthetic merge commit changes only prose, plans, or the website. The
+required Rust aggregates then take roughly 30–40 minutes to become conclusive,
+while those lanes have no affected Rust behavior to validate. Runner admission
+for that unnecessary work also delays code-bearing entries.
+
+The Nix, kernel, policy, and architecture gates already own broader or separate
+input surfaces. They remain independent and fail closed.
+
+## Work
+
+- [x] Add one fail-closed classifier for pull-request and merge-group SHA
+      ranges, with manual dispatch forcing the full matrix.
+- [x] Gate compiler lint, feature coverage, workspace tests, release-profile
+      witnesses, Linux/conformance coverage, and eBPF coverage on paths that
+      can change compiled or generated behavior.
+- [x] Keep policy checks running for every diff, and keep Nix's independent
+      required-check classifier unchanged.
+- [x] Make the stable `Lint (fmt + clippy + policy)` and `Test` aggregates
+      accept only deliberate `skipped` results while still failing on scope,
+      policy, cancellation, or lane failure.
+- [x] Pin the workflow shape with regression coverage and validate action
+      syntax, formatting, workspace compilation/tests, and all-target Clippy.
+
+## Safety boundary
+
+An unknown event or a failed diff never skips validation. Manual dispatch runs
+everything. Rust sources, manifests, tests, generators, BDD features, schemas,
+models, build scripts, CI actions, test configuration, and the scripts invoked
+by CI all select the full Rust matrix. Required aggregate names do not change.
+
+The Nix gate is intentionally not coupled to the new classifier: its existing
+independent scope remains the authority for everything the flakes evaluate or
+build, so a Rust-scope mistake cannot turn the required Nix context green.
+
+## Expected effect
+
+Code-bearing changes retain the current full coverage. Prose/site-only entries
+run the classifier, policy, existing Nix scope, architecture, kernel scope, and
+stable aggregate reporters, but avoid six cold Rust jobs. In the queue sampled
+on 2026-08-11, two of ten waiting entries matched that fast path.
+
+## Validation
+
+`actionlint`, formatting, workspace compilation, all-target Clippy, and all
+499 `xtask` tests pass. The serialized workspace suite passed every test except
+one transient host-agent restart assertion; its exact test passed immediately
+on an isolated rerun.

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -434,7 +434,7 @@ mod tests {
         let workflow = ci_workflow();
         let lint = job_block(&workflow, "lint");
         assert!(lint.contains("name: Lint (fmt + clippy + policy)"));
-        assert!(lint.contains("needs: [lint-core, lint-policy, lint-features]"));
+        assert!(lint.contains("needs: [scope, lint-core, lint-policy, lint-features]"));
 
         for unexpected in [
             "cargo nextest run --workspace --features test-support",
@@ -468,7 +468,7 @@ mod tests {
 
         let test = job_block(&workflow, "test");
         assert!(test.contains("name: Test"));
-        assert!(test.contains("needs: [test-workspace, test-linux, test-release-witness]"));
+        assert!(test.contains("needs: [scope, test-workspace, test-linux, test-release-witness]"));
 
         // The release-profile lane is the only one that runs with trapping
         // overflow and debug assertions off, i.e. the only one that witnesses
@@ -509,6 +509,63 @@ mod tests {
             assert!(
                 linux_coverage.contains(expected),
                 "Linux coverage script must contain {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn merge_group_ci_skips_rust_work_for_non_code_diffs_without_losing_gates() {
+        let workflow = ci_workflow();
+        let scope = job_block(&workflow, "scope");
+        for expected in [
+            "MG_BASE: ${{ github.event.merge_group.base_sha }}",
+            "MG_HEAD: ${{ github.event.merge_group.head_sha }}",
+            "PR_BASE: ${{ github.event.pull_request.base.sha }}",
+            "PR_HEAD: ${{ github.event.pull_request.head.sha }}",
+            "git diff --name-only -z",
+            "grep -zE",
+            "could not diff $BASE..$HEAD — running every lane to stay safe",
+            "invalid or missing code scope",
+            "code=true",
+        ] {
+            assert!(
+                scope.contains(expected),
+                "CI scope must contain fail-closed classifier fragment {expected:?}"
+            );
+        }
+
+        for job in [
+            "lint-core",
+            "lint-features",
+            "test-workspace",
+            "test-release-witness",
+            "test-linux",
+            "test-ebpf-telemetry",
+        ] {
+            let block = job_block(&workflow, job);
+            assert!(
+                block.contains("needs: [scope]"),
+                "{job} must depend on CI scope"
+            );
+            assert!(
+                block.contains("if: needs.scope.outputs.code == 'true'"),
+                "{job} must skip expensive Rust work for non-code diffs"
+            );
+        }
+
+        let policy = job_block(&workflow, "lint-policy");
+        assert!(policy.contains("needs: [scope]"));
+        assert!(!policy.contains("needs.scope.outputs.code == 'true'"));
+
+        for aggregate in ["lint", "test"] {
+            let block = job_block(&workflow, aggregate);
+            assert!(block.contains("needs.scope.result"));
+            assert!(block.contains("SCOPE_CODE: ${{ needs.scope.outputs.code }}"));
+            assert!(
+                block.contains("true) required=success")
+                    && block.contains("false) required=skipped")
+                    && block.contains(r#"if [ "$result" != "$required" ]"#),
+                "{aggregate} must require success or skip exactly as scope decided"
             );
         }
     }


### PR DESCRIPTION
## Summary
- classify the exact pull-request or merge-group SHA range before allocating Rust runners
- skip six expensive Rust lanes for prose/site-only diffs while keeping policy and Nix independently fail-closed
- preserve required check names and require aggregate results to match the scope decision exactly
- add workflow-shape regression coverage and document the execution policy

## Expected impact
Two of ten waiting entries in the sampled queue qualified for this fast path. Those entries avoid the roughly 25–37 minute Rust lanes, reducing runner pressure for code-bearing groups behind them.

## Validation
- actionlint .github/workflows/ci.yml
- cargo fmt --all -- --check
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p xtask (499 tests)
- cargo test --workspace -- --test-threads=1 (one unrelated host-agent restart assertion failed transiently; its exact test passed immediately on isolated rerun)
