### PR TITLE
fix: filter HVF builder work inputs

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -6,6 +6,7 @@
 //!
 //! - `cmd.sh` emission (Flake jobs) and `install_spec.json` staging
 //!   (Install jobs)
+//! - Filtered staging for disk-transport `/work` inputs
 //! - `/job/result` JSON parsing
 //! - Per-variant artifact finalisation (rootfs path resolution,
 //!   revision hash extraction, install-volume sidecar discovery)
@@ -704,6 +705,30 @@ pub fn stage_shell_job_dir(job_dir: &Path, script: &str) -> Result<(), BuilderVm
         BuilderVmError::ExtractionFailed(format!("writing {}: {e}", cmd_path.display()))
     })?;
     Ok(())
+}
+
+/// Stage a filtered copy of `src` for a disk-transport `/work` input.
+///
+/// A source checkout can carry `target/`, `.worktrees/`, `.git/`, and other
+/// build or VCS scratch measured in tens of GiB. Raw-disk builder transports
+/// must not archive that host-local state into the guest. Reuse the same
+/// exclusion contract as the staged mvm-workspace snapshot so all disk-backed
+/// builders pack only source inputs.
+///
+/// The returned temporary directory owns the staged tree and must remain alive
+/// until the caller finishes packing its transport disk.
+pub fn stage_filtered_work_input(src: &Path) -> Result<tempfile::TempDir, BuilderVmError> {
+    let staged = tempfile::TempDir::new().map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("creating filtered work staging dir: {e}"))
+    })?;
+    copy_dir_filtered(src, staged.path()).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "staging filtered work input {} -> {}: {e}",
+            src.display(),
+            staged.path().display()
+        ))
+    })?;
+    Ok(staged)
 }
 
 /// Filename of the install report `mvm-host-vm-init` writes into

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -83,8 +83,8 @@ use crate::builder_vm_runtime::{
     CLOSURE_SEED_TAG, NixStoreImageLock, acquire_nix_store_image_lock,
     acquire_nix_store_image_lock_named, builder_vm_timeout, finalize_flake_job,
     finalize_install_job, read_job_result_with_diagnostics, shell_job_exit_error,
-    stage_closure_seed_dir, stage_job_dir, stage_shell_job_dir, supervisor_exit_error,
-    verbose_from_env,
+    stage_closure_seed_dir, stage_filtered_work_input, stage_job_dir, stage_shell_job_dir,
+    supervisor_exit_error, verbose_from_env,
 };
 use crate::pipeline::build::BUILDER_OUTPUT_DISK_MIB;
 
@@ -579,32 +579,6 @@ fn prepare_builder_transport_disks(
         ))
     })?;
     Ok((input_disk, output_disk))
-}
-
-/// Stage a filtered copy of `src` for the disk-transport `work` input.
-///
-/// On a source checkout, `src` (`BuilderMounts::flake_src` /
-/// `BuilderShellJob::work_dir`) can be the repo root, which carries
-/// `target/`, `.worktrees/`, `.git/`, and other build/VCS scratch —
-/// tens of GB that the guest's RAM-capped extraction tmpfs can't
-/// absorb. Reuses the same `WORKSPACE_SNAPSHOT_SKIP` exclusion the
-/// mvm-workspace snapshot (`stage_job_dir`'s `mvm-src` staging) already
-/// applies, rather than forking a second skip list.
-///
-/// Returns the `TempDir` holding the filtered copy; callers must keep
-/// it alive until the disk-transport pack that reads it completes.
-fn stage_filtered_work_input(src: &Path) -> Result<tempfile::TempDir, BuilderVmError> {
-    let staged = tempfile::TempDir::new().map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!("creating filtered work staging dir: {e}"))
-    })?;
-    crate::builder_vm_runtime::copy_dir_filtered(src, staged.path()).map_err(|e| {
-        BuilderVmError::ExtractionFailed(format!(
-            "staging filtered work input {} -> {}: {e}",
-            src.display(),
-            staged.path().display()
-        ))
-    })?;
-    Ok(staged)
 }
 
 fn extract_builder_transport_output(

--- a/crates/mvm-runtime/src/builder_runner/runner.rs
+++ b/crates/mvm-runtime/src/builder_runner/runner.rs
@@ -11,6 +11,7 @@ use mvm_agentd::vsock::EGRESS_PORT;
 use mvm_build::builder_disk_transport::{
     InputTree, create_output_disk, pack_input_disk, read_output_disk,
 };
+use mvm_build::builder_vm_runtime::stage_filtered_work_input;
 use mvm_core::config::{vm_state_dir, vm_vsock_port_socket_at};
 use mvm_core::policy::RedactionPolicy;
 use mvm_core::policy::network_policy::NetworkPolicy;
@@ -95,7 +96,13 @@ impl<D: VmmDriver + 'static> BuilderRunner<D> {
         let output_dir = state_dir.join("out");
         let egress_socket = vm_vsock_port_socket_at(&state_dir, EGRESS_PORT);
 
-        // Pack {job, work, mvm-bins} onto the input disk; the guest extracts it.
+        // A source checkout's work tree may contain tens of GiB of local build
+        // state. Keep it out of the raw transport disk using the same filtering
+        // contract as the other disk-backed builder path.
+        let work_staging = stage_filtered_work_input(b.work_src)?;
+
+        // Pack {job, filtered work, mvm-bins} onto the input disk; the guest
+        // extracts it.
         pack_input_disk(
             &[
                 InputTree {
@@ -104,7 +111,7 @@ impl<D: VmmDriver + 'static> BuilderRunner<D> {
                 },
                 InputTree {
                     name: "work",
-                    src: b.work_src,
+                    src: work_staging.path(),
                 },
                 InputTree {
                     name: "mvm-bins",
@@ -214,6 +221,12 @@ mod tests {
         }
         std::fs::write(job.join("cmd.sh"), b"#!/bin/sh\nnix build\n").unwrap();
         std::fs::write(work.join("flake.nix"), b"{}").unwrap();
+        std::fs::create_dir_all(work.join("target/debug")).unwrap();
+        std::fs::write(
+            work.join("target/debug/host-build-artifact"),
+            b"large-local-state",
+        )
+        .unwrap();
         std::fs::write(bins.join("mvm-host-vm-init"), b"ELF").unwrap();
         let kernel = tmp.path().join("Image");
         let rootfs = tmp.path().join("rootfs.ext4");
@@ -297,6 +310,18 @@ mod tests {
         // mock guest, which writes nothing).
         assert!(tmp.path().join("vms/bld-unit/input.img").exists());
         assert!(outcome.output_dir.exists());
+
+        let packed_input = tmp.path().join("packed-input");
+        mvm_build::builder_disk_transport::read_output_disk(
+            &tmp.path().join("vms/bld-unit/input.img"),
+            &packed_input,
+        )
+        .unwrap();
+        assert!(packed_input.join("work/flake.nix").exists());
+        assert!(
+            !packed_input.join("work/target").exists(),
+            "HVF input transport must exclude host target/ state"
+        );
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -59,7 +59,12 @@ for detailed scope and acceptance criteria.
       watchdog, dominates internal HVF shutdown, so no unnecessary control
       protocol was added. The foreground-wait audit, repository waiting-model
       rule, complete workspace tests, formatting, checks, and Linux all-target
-      clippy are green.
+      clippy are green. The post-completion HVF builder regression is also
+      closed: work inputs now use the shared filtered staging seam before ext4
+      packing, and a transport-boundary test proves source is retained while
+      host `target/` scratch output is excluded. An authorized live sleeper
+      build packed 57.1 MiB instead of 55.7 GB and returned builder exit code
+      zero; the later workload boot stopped at a separate readiness timeout.
 
 ## In-flight plans
 - [x] Plan 315 — Bootstrap means machine-ready

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -128,7 +128,15 @@
       the dominant span, so no new control protocol was justified. The
       foreground-wait audit and repository event/timer/reconciliation rule are
       complete. Formatting, workspace check, the complete workspace test
-      suite, macOS focused clippy, and Linux all-target clippy pass.
+      suite, macOS focused clippy, and Linux all-target clippy pass. A
+      post-completion HVF builder fix now stages the work input through the
+      shared source filter before packing its ext4 disk, preventing host
+      `target/` and other scratch trees from inflating a small flake into a
+      multi-gigabyte guest input. The transport-boundary regression test proves
+      source files remain present while `work/target` is absent. The authorized
+      live sleeper command reduced the HVF work disk from 55.7 GB to 57.1 MiB
+      and produced a successful builder result; its subsequent workload boot
+      reached a separate guest-agent readiness timeout.
 
 - [x] README CLI/code-example contract — README shell examples and every
       declared CLI option have executable cucumber help witnesses; all 26

--- a/specs/plans/314-event-driven-lifecycle-shutdown.md
+++ b/specs/plans/314-event-driven-lifecycle-shutdown.md
@@ -407,6 +407,21 @@ CPU regression, so Phase 5 deliberately makes no mechanical async conversion.
 - [x] Update `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md` when an
       implementation phase lands, not merely when this design is created.
 
+## Post-completion builder regression
+
+- [x] Diagnose the HVF builder's missing-result failure as an oversized work
+      disk: the raw source checkout included host `target/` output and expanded
+      to a 55.7 GB guest input for a roughly 40 MB staged flake.
+- [x] Move filtered work staging into the shared builder runtime and route both
+      libkrun and HVF input preparation through that seam.
+- [x] Exercise the actual HVF ext4 packing boundary and prove `work/flake.nix`
+      is retained while `work/target` is excluded.
+- [x] Run the authorized live sleeper command from the fix worktree: its HVF
+      input disk is 57.1 MiB instead of 55.7 GB, and the guest writes a builder
+      result with exit code zero. The later workload boot reaches a separate
+      guest-agent readiness timeout rather than the original missing-result
+      failure.
+
 ## Resume instructions
 
 Plan 314 is complete. Implementation, the complete workspace suite, macOS and


### PR DESCRIPTION
## Summary

- stage HVF builder work trees through the shared source filter before packing the raw input disk
- reuse the same filtering seam for libkrun and HVF builder transports
- cover the real packed-disk boundary so source remains while host build scratch is excluded

## Root cause

The HVF builder packed the raw source checkout, including the host target directory. A roughly 40 MiB staged flake became a 55.7 GB guest input, and the guest never finalized its result.

## Verification

- cargo test -j 2 --workspace -- --test-threads=1
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- authorized live sleeper build: input disk reduced to 57.1 MiB and builder result returned exit code 0

The live command subsequently reached a separate workload guest-agent readiness timeout; the original builder missing-result failure did not recur.