### PR TITLE
Move the placeholder leaf down, and give the two prefixes distinct names

### DIFF
--- a/crates/mvm-contract/src/lib.rs
+++ b/crates/mvm-contract/src/lib.rs
@@ -50,6 +50,11 @@ pub mod policy;
 pub mod protocol;
 #[cfg(feature = "protocol")]
 pub mod stream;
+/// The guest-side placeholder token a secret-bearing request carries: its
+/// reserved namespace, its opaque newtype, and the header scan. Minting and
+/// custody stay host-side.
+#[cfg(feature = "protocol")]
+pub mod substitution;
 #[cfg(feature = "protocol")]
 pub mod verify;
 

--- a/crates/mvm-contract/src/substitution.rs
+++ b/crates/mvm-contract/src/substitution.rs
@@ -1,0 +1,116 @@
+//! The guest-side placeholder token: its reserved namespace, its opaque
+//! newtype, and the scan that locates one inside a request header.
+//!
+//! A guest never holds a credential. It holds a [`Placeholder`] — an opaque,
+//! per-session token — and routes the request to a host-local substitution
+//! endpoint, which resolves the token, checks the destination binding, and
+//! puts the real credential on the wire. This module is the part of that
+//! path with no custody, no I/O and no randomness: what a token looks like,
+//! and how to find one in a string.
+//!
+//! Minting stays host-side. Generating a token draws from the OS RNG, which
+//! is exactly the `getrandom`-in-the-bundle dependency the browser build
+//! avoids, so [`Placeholder::new`] takes the token as given and the caller
+//! decides where the bytes came from.
+//!
+//! # Three prefixes, none interchangeable
+//!
+//! Be precise about which notation you mean:
+//!
+//! | Notation | Where | What it is |
+//! |---|---|---|
+//! | `mvm-secret-<hex>` | here | the runtime wire token a guest actually holds |
+//! | `mvm-managed:<var>` | [`crate::policy::secret_binding`] | a CLI binding's display form |
+//! | `${NAME}` | the Workload IR | an authoring notation; nothing resolves it at runtime |
+//!
+//! The constant here is [`SECRET_PLACEHOLDER_PREFIX`] rather than a third
+//! `PLACEHOLDER_PREFIX` precisely so the first two cannot be confused at a
+//! glance in this crate.
+
+use alloc::string::String;
+
+/// The host-owned namespace every minted [`Placeholder`] carries. This prefix
+/// is reserved: it must never appear in a workload's own egress, so the
+/// leak scan can drop any non-substitution egress that contains it — the
+/// legitimate substitution path routes the placeholder to the host-local
+/// endpoint, never out the raw egress wire.
+pub const SECRET_PLACEHOLDER_PREFIX: &str = "mvm-secret-";
+
+/// An opaque, per-session placeholder standing in for a secret on the guest
+/// side. **Not** the secret name and **not** the value: a leaked
+/// placeholder reveals nothing and resolves to nothing outside the session
+/// registry that minted it. Destination non-replay comes from the binding
+/// check at substitution time, not the token itself.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Placeholder(String);
+
+impl Placeholder {
+    /// Wrap an already-generated token.
+    ///
+    /// Deliberately does not generate one: entropy is the caller's business,
+    /// which keeps the RNG on the host side of this crate's boundary. A
+    /// caller that hands over a low-entropy or attacker-chosen string gets a
+    /// guessable placeholder — the type is a wrapper, not a guarantee.
+    pub fn new(token: impl Into<String>) -> Self {
+        Self(token.into())
+    }
+
+    /// The on-the-wire token form the guest embeds in its request.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Find the first placeholder token embedded in `text` (e.g. a header value
+/// `Bearer mvm-secret-<hex>`). Returns the `mvm-secret-<hex>` slice — the
+/// reserved prefix plus its trailing hex run — or `None` if no token is
+/// present. Used by the substitution endpoint to locate the placeholder a
+/// guest put in a request header without the guest having to name the header.
+pub fn find_placeholder(text: &str) -> Option<&str> {
+    let start = text.find(SECRET_PLACEHOLDER_PREFIX)?;
+    let after = start + SECRET_PLACEHOLDER_PREFIX.len();
+    let hex_len = text[after..]
+        .bytes()
+        .take_while(u8::is_ascii_hexdigit)
+        .count();
+    if hex_len == 0 {
+        return None;
+    }
+    Some(&text[start..after + hex_len])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use alloc::format;
+
+    #[test]
+    fn find_placeholder_extracts_token_from_a_header_value() {
+        let ph = Placeholder::new(format!("{SECRET_PLACEHOLDER_PREFIX}deadbeef"));
+        let header = format!("Bearer {}", ph.as_str());
+        assert_eq!(find_placeholder(&header), Some(ph.as_str()));
+    }
+
+    #[test]
+    fn find_placeholder_stops_at_non_hex_and_ignores_clean_text() {
+        // Trailing non-hex (quote, space) bounds the token.
+        assert_eq!(
+            find_placeholder("Bearer mvm-secret-abc123\"; x=1"),
+            Some("mvm-secret-abc123")
+        );
+        // No token, and the bare prefix with no hex run, both yield None.
+        assert_eq!(find_placeholder("Bearer ya29.real-token"), None);
+        assert_eq!(find_placeholder("mvm-secret-"), None);
+    }
+
+    #[test]
+    fn the_two_reserved_prefixes_do_not_collide() {
+        // `mvm-managed:` is the CLI binding's display form and must never be
+        // mistaken for a runtime token. Asserted rather than assumed, because
+        // both now live in this crate.
+        let managed = crate::policy::secret_binding::PLACEHOLDER_PREFIX;
+        assert_ne!(managed, SECRET_PLACEHOLDER_PREFIX);
+        assert_eq!(find_placeholder("mvm-managed:OPENAI_API_KEY"), None);
+    }
+}

--- a/crates/mvm-hostd/src/keyholder/mod.rs
+++ b/crates/mvm-hostd/src/keyholder/mod.rs
@@ -23,8 +23,8 @@ pub use resolver::{LocalResolver, ResolveError, SecretResolver};
 pub use signer::{SigV4Input, SignError, Signature, Signer, SigningInput};
 pub use sigv4::{SigV4BuildError, build_sigv4_input};
 pub use substitution::{
-    PLACEHOLDER_PREFIX, Placeholder, SignDispatchError, SubstituteError, SubstitutionEndpoint,
-    SubstitutionRegistry, find_placeholder,
+    Placeholder, SECRET_PLACEHOLDER_PREFIX, SignDispatchError, SubstituteError,
+    SubstitutionEndpoint, SubstitutionRegistry, find_placeholder,
 };
 
 /// Re-exported so a caller who only depends on `mvm-hostd` (e.g. mvmd,

--- a/crates/mvm-hostd/src/keyholder/substitution.rs
+++ b/crates/mvm-hostd/src/keyholder/substitution.rs
@@ -15,52 +15,13 @@
 use std::collections::HashMap;
 
 use mvm_contract::ir::{AuthType, SecretRef, host_is_bound};
+pub use mvm_contract::substitution::{Placeholder, SECRET_PLACEHOLDER_PREFIX, find_placeholder};
 use rand::RngCore;
 use zeroize::Zeroizing;
 
 use super::injector::{InjectError, Injector};
 use super::resolver::SecretResolver;
 use super::signer::{SignError, Signature, Signer, SigningInput};
-
-/// The host-owned namespace every minted [`Placeholder`] carries. This prefix
-/// is reserved: it must never appear in a workload's own egress, so the
-/// leak scan can drop any non-substitution egress that contains it — the
-/// legitimate substitution path routes the placeholder to the host-local
-/// endpoint, never out the raw egress wire.
-pub const PLACEHOLDER_PREFIX: &str = "mvm-secret-";
-
-/// An opaque, per-session placeholder standing in for a secret on the guest
-/// side. **Not** the secret name and **not** the value: a leaked
-/// placeholder reveals nothing and resolves to nothing outside the session
-/// registry that minted it. Destination non-replay comes from the binding
-/// check at substitution time, not the token itself.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Placeholder(String);
-
-impl Placeholder {
-    /// The on-the-wire token form the guest embeds in its request.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Find the first placeholder token embedded in `text` (e.g. a header value
-/// `Bearer mvm-secret-<hex>`). Returns the `mvm-secret-<hex>` slice — the
-/// reserved prefix plus its trailing hex run — or `None` if no token is
-/// present. Used by the substitution endpoint to locate the placeholder a
-/// guest put in a request header without the guest having to name the header.
-pub fn find_placeholder(text: &str) -> Option<&str> {
-    let start = text.find(PLACEHOLDER_PREFIX)?;
-    let after = start + PLACEHOLDER_PREFIX.len();
-    let hex_len = text[after..]
-        .bytes()
-        .take_while(u8::is_ascii_hexdigit)
-        .count();
-    if hex_len == 0 {
-        return None;
-    }
-    Some(&text[start..after + hex_len])
-}
 
 /// Per-session map from a minted [`Placeholder`] to the [`SecretRef`] it
 /// stands for. Session-scoped: dropped when the session ends, so a
@@ -83,7 +44,7 @@ impl SubstitutionRegistry {
     pub fn mint(&mut self, secret: SecretRef) -> Placeholder {
         let mut bytes = [0u8; 24];
         rand::thread_rng().fill_bytes(&mut bytes);
-        let ph = Placeholder(format!("{PLACEHOLDER_PREFIX}{}", hex::encode(bytes)));
+        let ph = Placeholder::new(format!("{SECRET_PLACEHOLDER_PREFIX}{}", hex::encode(bytes)));
         self.map.insert(ph.clone(), secret);
         ph
     }
@@ -91,7 +52,7 @@ impl SubstitutionRegistry {
     /// Resolve a placeholder by its on-the-wire string form. `None` for a
     /// token this session never minted (a smuggled or stale token).
     pub fn resolve(&self, token: &str) -> Option<&SecretRef> {
-        self.map.get(&Placeholder(token.to_string()))
+        self.map.get(&Placeholder::new(token))
     }
 
     /// Whether any secret in this session is bound to `host` (a [`host_matches`]
@@ -406,26 +367,6 @@ mod tests {
             err,
             SignDispatchError::Sign(SignError::WrongAuthType(AuthType::Bearer))
         ));
-    }
-
-    #[test]
-    fn find_placeholder_extracts_token_from_a_header_value() {
-        let mut reg = SubstitutionRegistry::new();
-        let ph = reg.mint(bearer_ref("openai", &["api.openai.com"]));
-        let header = format!("Bearer {}", ph.as_str());
-        assert_eq!(find_placeholder(&header), Some(ph.as_str()));
-    }
-
-    #[test]
-    fn find_placeholder_stops_at_non_hex_and_ignores_clean_text() {
-        // Trailing non-hex (quote, space) bounds the token.
-        assert_eq!(
-            find_placeholder("Bearer mvm-secret-abc123\"; x=1"),
-            Some("mvm-secret-abc123")
-        );
-        // No token, and the bare prefix with no hex run, both yield None.
-        assert_eq!(find_placeholder("Bearer ya29.real-token"), None);
-        assert_eq!(find_placeholder("mvm-secret-"), None);
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/network/stages.rs
+++ b/crates/mvm-hostd/src/supervisor/network/stages.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 
 use mvm_core::network_policy::{NetworkPolicy, is_mandatory_deny};
 
-use crate::keyholder::substitution::PLACEHOLDER_PREFIX;
 use crate::supervisor::network::packet::{L4Proto, ParsedPacket};
 use crate::supervisor::network::{FlowDirection, PacketCtx};
 use crate::supervisor::pii_redactor::{PiiRedactor, REDACTION_MASK};
@@ -20,6 +19,7 @@ use crate::supervisor::secrets_scanner::SecretsScanner;
 use crate::supervisor::sensitive_detector::{
     LeakGuardCredentialDetector, SensitiveDetector, mask_matches,
 };
+use mvm_contract::substitution::SECRET_PLACEHOLDER_PREFIX;
 use mvm_core::policy::projection::{CanonicalEgress, Proto as CanonProto};
 
 /// Outcome of the scan stage. `Pass` forwards the packet; `Drop` kills the
@@ -466,7 +466,7 @@ impl ScanStage for MandatoryDenyEgressScan {
 }
 
 /// Drops any egress packet whose L4 payload contains a substitution
-/// placeholder — the host-owned [`PLACEHOLDER_PREFIX`] namespace (leak
+/// placeholder — the host-owned [`SECRET_PLACEHOLDER_PREFIX`] namespace (leak
 /// backstop). The legitimate substitution path routes
 /// placeholders to the host-local endpoint, never out the raw egress wire, so a
 /// placeholder seen here is a guest trying to smuggle the token out a side
@@ -489,7 +489,7 @@ impl ScanStage for PlaceholderLeakScan {
             FlowDirection::Egress => {}
             _ => return ScanOutcome::Pass,
         }
-        let needle = PLACEHOLDER_PREFIX.as_bytes();
+        let needle = SECRET_PLACEHOLDER_PREFIX.as_bytes();
         if pkt.l4_payload.windows(needle.len()).any(|w| w == needle) {
             ScanOutcome::Drop { by: self.name() }
         } else {


### PR DESCRIPTION
Plan 320 E2.1 — the first leaf of the substitution extraction.

## What moves

A guest never holds a credential. It holds an opaque per-session token and routes the request to a host-local substitution endpoint, which resolves it, checks the destination binding, and puts the real credential on the wire. What that token *looks like*, and how to find one in a header, is pure — no custody, no I/O, no randomness — so it moves to `mvm-contract` and the browser demo runs the host's scan instead of a second copy.

Moved: the reserved prefix, the `Placeholder` newtype with `as_str`, and `find_placeholder`, plus the two tests covering the scan.

**Minting stays.** Generating a token draws from the OS RNG — the `getrandom`-in-the-bundle dependency the browser build exists to avoid. `Placeholder::new` takes the token as given, and its doc says plainly that the type is a wrapper, not a guarantee of entropy: a caller passing a low-entropy string gets a guessable placeholder.

## The rename is the part worth reviewing

`mvm-contract` **already had** a `PLACEHOLDER_PREFIX` — `"mvm-managed:"`, the CLI binding's display form in `policy::secret_binding`. Moving a second reserved prefix in under the same name would have left two unrelated constants in one crate distinguishable only by module path: the exact shape of the `AuditEntry` collision that E3 is currently blocked on untangling.

So the moved one lands as `SECRET_PLACEHOLDER_PREFIX`, and its four call sites are updated. Hard rename, no alias — matching how Increment 3 resolved the `NetworkPolicy` collision.

There are in fact **three** notations in play, and the module header tabulates all of them:

| Notation | Where | What it is |
|---|---|---|
| `mvm-secret-<hex>` | `mvm_contract::substitution` | the runtime wire token a guest actually holds |
| `mvm-managed:<var>` | `policy::secret_binding` | a CLI binding's display form |
| `${NAME}` | the Workload IR | authoring-only; **nothing resolves it at runtime** |

A test asserts the two constants differ and that `find_placeholder` returns `None` on an `mvm-managed:` string, so the distinction is checked rather than merely documented.

That last row also corrects the plan's own prose, which described E2 as extracting `${NAME}` resolution. It isn't — `${NAME}` never reaches the runtime. This matters beyond naming: the demo's "what the guest holds" pane must render the opaque minted token, because rendering `${API_KEY}` would show a form the runtime never produces, in the one pane whose job is to be exactly what the guest holds.

## Side effect

The placeholder scan now runs under `wasm32-wasip1` for the first time: 653 → 656.

## Gates

- `cargo nextest run --workspace` — 11226/11226 passed
- `cargo test --workspace --doc` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo build -p mvm-contract --target wasm32-unknown-unknown` — pass
- `cargo test -p mvm-contract --target wasm32-wasip1` — 656 passed
- all 50 `xtask check-*` gates from `ci.yml` — pass