### PR TITLE
Stop resetting throttled egress streams; lift workload ceilings off the builder VM

### DIFF
--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -205,7 +205,7 @@ fn relay_supervisor_config_with_handoff(
             })
             .collect(),
         vsock: true,
-        egress_unmetered: spec.trusted_builder,
+        trusted_builder_egress: spec.trusted_builder,
         console_log: paths.console_log.clone(),
         pid_file: paths.pid_file.clone(),
         workload_exit: paths.workload_exit.clone(),
@@ -1193,7 +1193,7 @@ mod tests {
     }
 
     #[test]
-    fn only_a_trusted_builder_relays_egress_unmetered() {
+    fn only_a_trusted_builder_relays_trusted_builder_egress() {
         let mut spec = spec_with(
             KernelImage::Path("/img/Image".into()),
             vec![
@@ -1205,13 +1205,13 @@ mod tests {
 
         let workload = relay_supervisor_config(&spec, &sample_paths()).unwrap();
         assert!(
-            !workload.egress_unmetered,
+            !workload.trusted_builder_egress,
             "a workload must stay rate-limited"
         );
 
         spec.trusted_builder = true;
         let builder = relay_supervisor_config(&spec, &sample_paths()).unwrap();
-        assert!(builder.egress_unmetered);
+        assert!(builder.trusted_builder_egress);
     }
 
     #[test]

--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -205,6 +205,7 @@ fn relay_supervisor_config_with_handoff(
             })
             .collect(),
         vsock: true,
+        egress_unmetered: spec.trusted_builder,
         console_log: paths.console_log.clone(),
         pid_file: paths.pid_file.clone(),
         workload_exit: paths.workload_exit.clone(),
@@ -1189,6 +1190,28 @@ mod tests {
             cfg.egress_relay_socket,
             Some(PathBuf::from("/run/egress.sock"))
         );
+    }
+
+    #[test]
+    fn only_a_trusted_builder_relays_egress_unmetered() {
+        let mut spec = spec_with(
+            KernelImage::Path("/img/Image".into()),
+            vec![
+                agent_port("/run/agent.sock"),
+                egress_port("/run/egress.sock"),
+            ],
+            vec![],
+        );
+
+        let workload = relay_supervisor_config(&spec, &sample_paths()).unwrap();
+        assert!(
+            !workload.egress_unmetered,
+            "a workload must stay rate-limited"
+        );
+
+        spec.trusted_builder = true;
+        let builder = relay_supervisor_config(&spec, &sample_paths()).unwrap();
+        assert!(builder.egress_unmetered);
     }
 
     #[test]

--- a/crates/mvm-backends/src/driver/hvf_restore.rs
+++ b/crates/mvm-backends/src/driver/hvf_restore.rs
@@ -146,7 +146,7 @@ pub fn hvf_child_restore_config(
 
     Ok(HvfSupervisorConfig {
         // Same tier as the parent it forked from.
-        egress_unmetered: parent.egress_unmetered,
+        trusted_builder_egress: parent.trusted_builder_egress,
         kernel: parent.kernel.clone(),
         cmdline: parent.cmdline.clone(),
         memory_mib: parent.memory_mib,
@@ -263,7 +263,7 @@ mod tests {
 
     fn parent_config(state: &Path, disks: Vec<HvfDisk>) -> HvfSupervisorConfig {
         HvfSupervisorConfig {
-            egress_unmetered: false,
+            trusted_builder_egress: false,
             kernel: state.join("Image"),
             cmdline: Some("console=ttyAMA0 root=/dev/vda ro".into()),
             memory_mib: 512,

--- a/crates/mvm-backends/src/driver/hvf_restore.rs
+++ b/crates/mvm-backends/src/driver/hvf_restore.rs
@@ -145,6 +145,8 @@ pub fn hvf_child_restore_config(
         .collect::<Result<Vec<_>>>()?;
 
     Ok(HvfSupervisorConfig {
+        // Same tier as the parent it forked from.
+        egress_unmetered: parent.egress_unmetered,
         kernel: parent.kernel.clone(),
         cmdline: parent.cmdline.clone(),
         memory_mib: parent.memory_mib,
@@ -261,6 +263,7 @@ mod tests {
 
     fn parent_config(state: &Path, disks: Vec<HvfDisk>) -> HvfSupervisorConfig {
         HvfSupervisorConfig {
+            egress_unmetered: false,
             kernel: state.join("Image"),
             cmdline: Some("console=ttyAMA0 root=/dev/vda ro".into()),
             memory_mib: 512,

--- a/crates/mvm-backends/src/legacy/hvf.rs
+++ b/crates/mvm-backends/src/legacy/hvf.rs
@@ -553,6 +553,8 @@ impl VmBackend for HvfBackend {
         let broker_listen_socket = mvm_core::config::vm_hvf_broker_socket(&config.name);
 
         let cfg = HvfSupervisorConfig {
+            // A workload is always metered.
+            egress_unmetered: false,
             kernel: PathBuf::from(kernel),
             // Thread a full cmdline only when we need extra workload tokens;
             // otherwise keep the supervisor default (`init=/init`).

--- a/crates/mvm-backends/src/legacy/hvf.rs
+++ b/crates/mvm-backends/src/legacy/hvf.rs
@@ -554,7 +554,7 @@ impl VmBackend for HvfBackend {
 
         let cfg = HvfSupervisorConfig {
             // A workload is always metered.
-            egress_unmetered: false,
+            trusted_builder_egress: false,
             kernel: PathBuf::from(kernel),
             // Thread a full cmdline only when we need extra workload tokens;
             // otherwise keep the supervisor default (`init=/init`).

--- a/crates/mvm-conformance/tests/steps/hvf_save_restore.rs
+++ b/crates/mvm-conformance/tests/steps/hvf_save_restore.rs
@@ -70,6 +70,7 @@ fn parent_config(state_dir: &std::path::Path) -> HvfSupervisorConfig {
         virtiofs_root: None,
         virtiofs_shares: Vec::new(),
         vsock: true,
+        trusted_builder_egress: false,
         console_log: PathBuf::from("/parent/state/console.log"),
         pid_file: PathBuf::from("/parent/state/hvf.pid"),
         workload_exit: PathBuf::from("/parent/state/workload.exit"),

--- a/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
@@ -305,7 +305,7 @@ fn main() -> anyhow::Result<()> {
                 agent_socket: cfg.agent_socket.clone(),
                 substitution_socket: cfg.substitution_socket.clone(),
                 egress_relay: cfg.egress_relay_socket.clone(),
-                egress_unmetered: cfg.egress_unmetered,
+                trusted_builder_egress: cfg.trusted_builder_egress,
                 broker_socket: cfg.broker_socket.clone(),
                 console_data_sockets: cfg
                     .console_data_sockets

--- a/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
@@ -305,6 +305,7 @@ fn main() -> anyhow::Result<()> {
                 agent_socket: cfg.agent_socket.clone(),
                 substitution_socket: cfg.substitution_socket.clone(),
                 egress_relay: cfg.egress_relay_socket.clone(),
+                egress_unmetered: cfg.egress_unmetered,
                 broker_socket: cfg.broker_socket.clone(),
                 console_data_sockets: cfg
                     .console_data_sockets

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -195,7 +195,7 @@ pub struct HostChannels {
     pub egress_relay: Option<PathBuf>,
     /// Trusted-builder tier: relay egress without the per-workload byte-rate
     /// cap. False for every workload.
-    pub egress_unmetered: bool,
+    pub trusted_builder_egress: bool,
     /// Per-VM host-services broker UDS. When set, `BROKER_PORT` relays here — the
     /// socket the host-agent daemon bound for this VM — so a guest `host.audit.v1`
     /// call reaches the broker. `None` ⇒ `BROKER_PORT` fails closed at the bridge.
@@ -585,7 +585,7 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
                 agent_socket: channels.agent_socket,
                 substitution_socket: channels.substitution_socket,
                 egress_relay: channels.egress_relay,
-                egress_unmetered: channels.egress_unmetered,
+                trusted_builder_egress: channels.trusted_builder_egress,
                 broker_socket: channels.broker_socket,
                 console_data_sockets: channels.console_data_sockets,
                 virtiofs_root: channels.virtiofs_root,
@@ -638,7 +638,7 @@ struct RunInputs {
     /// endpoint is the sole gate + substituter.
     egress_relay: Option<PathBuf>,
     /// Trusted-builder tier: relay egress without the per-workload byte-rate cap.
-    egress_unmetered: bool,
+    trusted_builder_egress: bool,
     /// Per-VM host-services broker UDS. When set, `BROKER_PORT` relays here — the
     /// socket the host-agent daemon bound for this VM.
     broker_socket: Option<PathBuf>,
@@ -676,7 +676,7 @@ unsafe fn run(
         agent_socket,
         substitution_socket,
         egress_relay,
-        egress_unmetered,
+        trusted_builder_egress,
         broker_socket,
         console_data_sockets,
         virtiofs_root,
@@ -897,8 +897,8 @@ unsafe fn run(
                 v.set_substitution_activity(egress_active.clone());
                 v.set_substitution_endpoint(relay);
             }
-            if egress_unmetered {
-                v.set_egress_unmetered();
+            if trusted_builder_egress {
+                v.set_trusted_builder_egress();
             }
             // Host-services broker (BROKER_PORT): a pure relay to the per-VM broker
             // UDS the host-agent daemon bound, so a guest `host.audit.v1` call
@@ -994,8 +994,8 @@ unsafe fn run(
                 };
                 v.rebind_host_channels(&bindings, Arc::new(GicSpi))
                     .map_err(|_| HvfError::SnapshotState("restore channel rebind failed"))?;
-                if egress_unmetered {
-                    v.set_egress_unmetered();
+                if trusted_builder_egress {
+                    v.set_trusted_builder_egress();
                 }
             }
         }

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -193,6 +193,9 @@ pub struct HostChannels {
     /// endpoint gates (claim-10) and substitutes secrets. `None` ⇒ egress fails
     /// closed at the bridge (an hvf VM must always carry a relay socket).
     pub egress_relay: Option<PathBuf>,
+    /// Trusted-builder tier: relay egress without the per-workload byte-rate
+    /// cap. False for every workload.
+    pub egress_unmetered: bool,
     /// Per-VM host-services broker UDS. When set, `BROKER_PORT` relays here — the
     /// socket the host-agent daemon bound for this VM — so a guest `host.audit.v1`
     /// call reaches the broker. `None` ⇒ `BROKER_PORT` fails closed at the bridge.
@@ -582,6 +585,7 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
                 agent_socket: channels.agent_socket,
                 substitution_socket: channels.substitution_socket,
                 egress_relay: channels.egress_relay,
+                egress_unmetered: channels.egress_unmetered,
                 broker_socket: channels.broker_socket,
                 console_data_sockets: channels.console_data_sockets,
                 virtiofs_root: channels.virtiofs_root,
@@ -633,6 +637,8 @@ struct RunInputs {
     /// Per-VM egress bridge UDS. When set, `EGRESS_PORT` relays here — the
     /// endpoint is the sole gate + substituter.
     egress_relay: Option<PathBuf>,
+    /// Trusted-builder tier: relay egress without the per-workload byte-rate cap.
+    egress_unmetered: bool,
     /// Per-VM host-services broker UDS. When set, `BROKER_PORT` relays here — the
     /// socket the host-agent daemon bound for this VM.
     broker_socket: Option<PathBuf>,
@@ -670,6 +676,7 @@ unsafe fn run(
         agent_socket,
         substitution_socket,
         egress_relay,
+        egress_unmetered,
         broker_socket,
         console_data_sockets,
         virtiofs_root,
@@ -890,6 +897,9 @@ unsafe fn run(
                 v.set_substitution_activity(egress_active.clone());
                 v.set_substitution_endpoint(relay);
             }
+            if egress_unmetered {
+                v.set_egress_unmetered();
+            }
             // Host-services broker (BROKER_PORT): a pure relay to the per-VM broker
             // UDS the host-agent daemon bound, so a guest `host.audit.v1` call
             // reaches the broker. Shares the heartbeat counter so an in-flight
@@ -984,6 +994,9 @@ unsafe fn run(
                 };
                 v.rebind_host_channels(&bindings, Arc::new(GicSpi))
                     .map_err(|_| HvfError::SnapshotState("restore channel rebind failed"))?;
+                if egress_unmetered {
+                    v.set_egress_unmetered();
+                }
             }
         }
 

--- a/crates/mvm-runtime/src/builder_runner/inject.rs
+++ b/crates/mvm-runtime/src/builder_runner/inject.rs
@@ -56,6 +56,8 @@ pub fn inject_host_binaries(req: &InjectRequest<'_>) -> Result<()> {
 
     let console_log = req.work_dir.join("inject-console.log");
     let cfg = HvfSupervisorConfig {
+        // Irrelevant here: this helper VM carries no egress relay at all.
+        egress_unmetered: false,
         kernel: req.kernel.to_path_buf(),
         // Default cmdline runs the initramfs /init (the patcher); the default RAM
         // is plenty for a mount + copy.

--- a/crates/mvm-runtime/src/builder_runner/inject.rs
+++ b/crates/mvm-runtime/src/builder_runner/inject.rs
@@ -57,7 +57,7 @@ pub fn inject_host_binaries(req: &InjectRequest<'_>) -> Result<()> {
     let console_log = req.work_dir.join("inject-console.log");
     let cfg = HvfSupervisorConfig {
         // Irrelevant here: this helper VM carries no egress relay at all.
-        egress_unmetered: false,
+        trusted_builder_egress: false,
         kernel: req.kernel.to_path_buf(),
         // Default cmdline runs the initramfs /init (the patcher); the default RAM
         // is plenty for a mount + copy.

--- a/crates/mvm-vmm/src/host/hvf_supervisor.rs
+++ b/crates/mvm-vmm/src/host/hvf_supervisor.rs
@@ -126,7 +126,7 @@ pub struct HvfSupervisorConfig {
     /// A builder carries no untrusted workload and pulls multi-gigabyte
     /// substituter closures. Defaults false so a workload stays metered.
     #[serde(default)]
-    pub egress_unmetered: bool,
+    pub trusted_builder_egress: bool,
     /// Where to write the captured guest console.
     pub console_log: PathBuf,
     /// Where to write this process's PID once booting starts (the backend polls
@@ -229,7 +229,7 @@ mod tests {
             virtiofs_root: None,
             virtiofs_shares: vec![],
             vsock: true,
-            egress_unmetered: false,
+            trusted_builder_egress: false,
             console_log: "/state/console.log".into(),
             pid_file: "/state/hvf.pid".into(),
             workload_exit: "/state/workload.exit".into(),
@@ -323,7 +323,7 @@ mod tests {
             virtiofs_root: None,
             virtiofs_shares: vec![],
             vsock: true,
-            egress_unmetered: false,
+            trusted_builder_egress: false,
             console_log: "/state/console.log".into(),
             pid_file: "/state/hvf.pid".into(),
             workload_exit: "/state/workload.exit".into(),

--- a/crates/mvm-vmm/src/host/hvf_supervisor.rs
+++ b/crates/mvm-vmm/src/host/hvf_supervisor.rs
@@ -122,6 +122,11 @@ pub struct HvfSupervisorConfig {
     /// Attach a virtio-vsock device.
     #[serde(default)]
     pub vsock: bool,
+    /// Trusted-builder VM: relay egress without the per-workload byte-rate cap.
+    /// A builder carries no untrusted workload and pulls multi-gigabyte
+    /// substituter closures. Defaults false so a workload stays metered.
+    #[serde(default)]
+    pub egress_unmetered: bool,
     /// Where to write the captured guest console.
     pub console_log: PathBuf,
     /// Where to write this process's PID once booting starts (the backend polls
@@ -224,6 +229,7 @@ mod tests {
             virtiofs_root: None,
             virtiofs_shares: vec![],
             vsock: true,
+            egress_unmetered: false,
             console_log: "/state/console.log".into(),
             pid_file: "/state/hvf.pid".into(),
             workload_exit: "/state/workload.exit".into(),
@@ -317,6 +323,7 @@ mod tests {
             virtiofs_root: None,
             virtiofs_shares: vec![],
             vsock: true,
+            egress_unmetered: false,
             console_log: "/state/console.log".into(),
             pid_file: "/state/hvf.pid".into(),
             workload_exit: "/state/workload.exit".into(),

--- a/crates/mvm-vmm/src/vmm/vsock.rs
+++ b/crates/mvm-vmm/src/vmm/vsock.rs
@@ -207,8 +207,8 @@ impl VsockShared {
         self.handlers.set_substitution_endpoint(path);
     }
 
-    pub fn set_egress_unmetered(&mut self) {
-        self.handlers.set_egress_unmetered();
+    pub fn set_trusted_builder_egress(&mut self) {
+        self.handlers.set_trusted_builder_egress();
     }
 
     pub fn set_substitution_activity(&mut self, counter: Arc<std::sync::atomic::AtomicUsize>) {
@@ -379,8 +379,8 @@ impl VirtioVsock {
         self.notify_io();
     }
 
-    pub fn set_egress_unmetered(&mut self) {
-        self.lock().set_egress_unmetered();
+    pub fn set_trusted_builder_egress(&mut self) {
+        self.lock().set_trusted_builder_egress();
         self.notify_io();
     }
 

--- a/crates/mvm-vmm/src/vmm/vsock.rs
+++ b/crates/mvm-vmm/src/vmm/vsock.rs
@@ -207,6 +207,10 @@ impl VsockShared {
         self.handlers.set_substitution_endpoint(path);
     }
 
+    pub fn set_egress_unmetered(&mut self) {
+        self.handlers.set_egress_unmetered();
+    }
+
     pub fn set_substitution_activity(&mut self, counter: Arc<std::sync::atomic::AtomicUsize>) {
         self.handlers.set_substitution_activity(counter);
     }
@@ -372,6 +376,11 @@ impl VirtioVsock {
 
     pub fn set_substitution_endpoint(&mut self, path: &std::path::Path) {
         self.lock().set_substitution_endpoint(path);
+        self.notify_io();
+    }
+
+    pub fn set_egress_unmetered(&mut self) {
+        self.lock().set_egress_unmetered();
         self.notify_io();
     }
 

--- a/crates/mvm-vmm/src/vmm/vsock_handlers/mod.rs
+++ b/crates/mvm-vmm/src/vmm/vsock_handlers/mod.rs
@@ -202,6 +202,21 @@ impl VsockHandlerRegistry {
             .set_endpoint(path);
     }
 
+    /// Lift the egress byte rate for a trusted-builder VM. Both ports keep
+    /// sharing one budget, so the concurrency cap is unchanged.
+    pub(crate) fn set_egress_unmetered(&mut self) {
+        let budget = EgressBudget::unmetered();
+        for port in [
+            mvm_agentd::vsock::EGRESS_PORT,
+            mvm_agentd::vsock::BROKER_PORT,
+        ] {
+            self.guest_handler_mut::<StreamRelayHandler>(port)
+                .expect("relay handler present")
+                .bridge
+                .set_budget(budget.clone());
+        }
+    }
+
     pub(crate) fn set_substitution_activity(
         &mut self,
         counter: Arc<std::sync::atomic::AtomicUsize>,

--- a/crates/mvm-vmm/src/vmm/vsock_handlers/mod.rs
+++ b/crates/mvm-vmm/src/vmm/vsock_handlers/mod.rs
@@ -202,10 +202,10 @@ impl VsockHandlerRegistry {
             .set_endpoint(path);
     }
 
-    /// Lift the egress byte rate for a trusted-builder VM. Both ports keep
-    /// sharing one budget, so the concurrency cap is unchanged.
-    pub(crate) fn set_egress_unmetered(&mut self) {
-        let budget = EgressBudget::unmetered();
+    /// Drop the workload egress ceilings for a trusted-builder VM. Both ports
+    /// keep sharing one budget.
+    pub(crate) fn set_trusted_builder_egress(&mut self) {
+        let budget = EgressBudget::trusted_builder();
         for port in [
             mvm_agentd::vsock::EGRESS_PORT,
             mvm_agentd::vsock::BROKER_PORT,

--- a/crates/mvm-vmm/src/vsock_egress_bridge/substitution_bridge.rs
+++ b/crates/mvm-vmm/src/vsock_egress_bridge/substitution_bridge.rs
@@ -53,16 +53,49 @@ pub(crate) struct EndpointRelayDrain {
 /// for byte tokens.
 const BUDGET_REFILL_POLL: std::time::Duration = std::time::Duration::from_millis(1);
 
-/// Shared per-workload egress budget. The egress and broker ports use one
-/// instance so a workload cannot multiply its allowance by opening both paths.
+/// Host-side resource ceilings applied to one VM's relayed egress. `None` on any
+/// field means that ceiling does not apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EgressLimits {
+    /// Sustained byte rate, refilled continuously.
+    pub bytes_per_second: Option<u64>,
+    /// Concurrent relayed streams.
+    pub max_streams: Option<usize>,
+    /// Evict a relayed stream after this long with no traffic.
+    pub idle_timeout: Option<std::time::Duration>,
+}
+
+impl EgressLimits {
+    /// An untrusted workload: every ceiling applies.
+    pub(crate) const fn workload() -> Self {
+        Self {
+            bytes_per_second: Some(EGRESS_BYTES_PER_SECOND),
+            max_streams: Some(MAX_EGRESS_STREAMS),
+            idle_timeout: Some(CONNECTION_IDLE_TIMEOUT),
+        }
+    }
+
+    /// A trusted builder VM: it builds nix templates, reports stdout/stderr, and
+    /// exits. It carries no untrusted workload, so none of the workload ceilings
+    /// apply — each one only breaks builds. The rate cap throttles
+    /// multi-gigabyte substituter pulls; the stream cap refuses connections once
+    /// nix parallelizes past it; the idle timeout drops keep-alive connections
+    /// while a derivation compiles.
+    pub(crate) const fn trusted_builder() -> Self {
+        Self {
+            bytes_per_second: None,
+            max_streams: None,
+            idle_timeout: None,
+        }
+    }
+}
+
+/// Shared per-VM egress budget. The egress and broker ports use one instance so
+/// a workload cannot multiply its allowance by opening both paths.
 #[derive(Clone)]
 pub(crate) struct EgressBudget {
     state: Arc<Mutex<EgressBudgetState>>,
-    /// Trusted-builder tier: the concurrency cap still applies, but the byte
-    /// rate does not. A builder VM carries no untrusted workload and pulls
-    /// multi-gigabyte substituter closures, so metering it throttles builds to
-    /// a fraction of the host link for no security gain.
-    metered: bool,
+    limits: EgressLimits,
 }
 
 struct EgressBudgetState {
@@ -77,27 +110,32 @@ impl EgressBudget {
     }
 
     fn new_at(now: Instant) -> Self {
-        Self::at(now, true)
+        Self::at(now, EgressLimits::workload())
     }
 
-    /// A budget that caps concurrent streams but not throughput.
-    pub(crate) fn unmetered() -> Self {
-        Self::unmetered_at(Instant::now())
+    /// A budget carrying no workload ceiling — see [`EgressLimits::trusted_builder`].
+    pub(crate) fn trusted_builder() -> Self {
+        Self::trusted_builder_at(Instant::now())
     }
 
-    fn unmetered_at(now: Instant) -> Self {
-        Self::at(now, false)
+    fn trusted_builder_at(now: Instant) -> Self {
+        Self::at(now, EgressLimits::trusted_builder())
     }
 
-    fn at(now: Instant, metered: bool) -> Self {
+    fn at(now: Instant, limits: EgressLimits) -> Self {
         Self {
             state: Arc::new(Mutex::new(EgressBudgetState {
                 active_streams: 0,
                 byte_tokens: EGRESS_BURST_BYTES,
                 last_refill: now,
             })),
-            metered,
+            limits,
         }
+    }
+
+    /// How long a relayed stream may sit idle before eviction.
+    fn idle_timeout(&self) -> Option<std::time::Duration> {
+        self.limits.idle_timeout
     }
 
     /// Acquire `bytes` tokens, waiting for the bucket to refill if it is dry.
@@ -110,7 +148,7 @@ impl EgressBudget {
     /// drain already backpressures this way, and resetting the guest→host side
     /// instead killed in-flight TLS transfers mid-download.
     fn consume_waiting(&self, bytes: usize) -> bool {
-        if !self.metered {
+        if self.limits.bytes_per_second.is_none() {
             return true;
         }
         if u64::try_from(bytes).unwrap_or(u64::MAX) > EGRESS_BURST_BYTES {
@@ -124,7 +162,9 @@ impl EgressBudget {
 
     fn try_reserve_stream(&self) -> bool {
         let mut state = self.state.lock().expect("egress budget mutex poisoned");
-        if state.active_streams >= MAX_EGRESS_STREAMS {
+        if let Some(max) = self.limits.max_streams
+            && state.active_streams >= max
+        {
             return false;
         }
         state.active_streams += 1;
@@ -141,11 +181,11 @@ impl EgressBudget {
     }
 
     fn try_consume_at(&self, bytes: usize, now: Instant) -> bool {
-        if !self.metered {
+        let Some(rate) = self.limits.bytes_per_second else {
             return true;
-        }
+        };
         let mut state = self.state.lock().expect("egress budget mutex poisoned");
-        refill_tokens(&mut state, now);
+        refill_tokens(&mut state, rate, now);
 
         let bytes = u64::try_from(bytes).unwrap_or(u64::MAX);
         if bytes > state.byte_tokens {
@@ -158,11 +198,11 @@ impl EgressBudget {
     /// Reserve up to `max` bytes for a non-blocking read. The caller must
     /// refund bytes it reserved but did not receive from the socket.
     fn reserve_read(&self, max: usize, now: Instant) -> usize {
-        if !self.metered {
+        let Some(rate) = self.limits.bytes_per_second else {
             return max;
-        }
+        };
         let mut state = self.state.lock().expect("egress budget mutex poisoned");
-        refill_tokens(&mut state, now);
+        refill_tokens(&mut state, rate, now);
         let max = u64::try_from(max).unwrap_or(u64::MAX);
         let reserved = state.byte_tokens.min(max);
         state.byte_tokens -= reserved;
@@ -179,9 +219,9 @@ impl EgressBudget {
     }
 }
 
-fn refill_tokens(state: &mut EgressBudgetState, now: Instant) {
+fn refill_tokens(state: &mut EgressBudgetState, rate: u64, now: Instant) {
     let elapsed_nanos = now.saturating_duration_since(state.last_refill).as_nanos();
-    let refill = elapsed_nanos.saturating_mul(u128::from(EGRESS_BYTES_PER_SECOND)) / 1_000_000_000;
+    let refill = elapsed_nanos.saturating_mul(u128::from(rate)) / 1_000_000_000;
     let refill = u64::try_from(refill).unwrap_or(u64::MAX);
     state.byte_tokens = state
         .byte_tokens
@@ -285,9 +325,12 @@ impl SubstitutionBridge {
     }
 
     fn evict_idle_at(&mut self, now: Instant) -> Vec<u32> {
+        let Some(idle_timeout) = self.budget.idle_timeout() else {
+            return Vec::new();
+        };
         let mut expired = Vec::new();
         self.conns.retain(|conn_id, conn| {
-            let keep = now.saturating_duration_since(conn.last_activity) < CONNECTION_IDLE_TIMEOUT;
+            let keep = now.saturating_duration_since(conn.last_activity) < idle_timeout;
             if !keep {
                 expired.push(*conn_id);
             }
@@ -695,25 +738,44 @@ mod tests {
     }
 
     #[test]
-    fn an_unmetered_budget_ignores_the_byte_rate() {
+    fn a_trusted_builder_budget_ignores_the_byte_rate() {
         let now = Instant::now();
-        let budget = EgressBudget::unmetered_at(now);
+        let budget = EgressBudget::trusted_builder_at(now);
         let ten_mib = 10 * 1024 * 1024;
         for _ in 0..64 {
             assert!(budget.try_consume_at(ten_mib, now));
         }
         assert!(budget.consume_waiting(ten_mib));
+        // Even a payload past the workload burst ceiling, which a metered
+        // budget refuses outright.
+        assert!(budget.consume_waiting(usize::try_from(EGRESS_BURST_BYTES).unwrap() + 1));
     }
 
     #[test]
-    fn an_unmetered_budget_still_caps_concurrent_streams() {
-        // Lifting the byte rate for a trusted builder must not lift the host-fd
-        // guard.
-        let budget = EgressBudget::unmetered();
-        for _ in 0..MAX_EGRESS_STREAMS {
+    fn a_trusted_builder_budget_does_not_cap_concurrent_streams() {
+        // nix parallelizes downloads well past the workload ceiling; refusing
+        // there resets the connection.
+        let budget = EgressBudget::trusted_builder();
+        for _ in 0..(MAX_EGRESS_STREAMS * 4) {
             assert!(budget.try_reserve_stream());
         }
-        assert!(!budget.try_reserve_stream());
+    }
+
+    #[test]
+    fn a_trusted_builder_stream_is_never_evicted_for_being_idle() {
+        // A connection kept open while a derivation compiles must survive.
+        let mut bridge = SubstitutionBridge::with_budget(EgressBudget::trusted_builder());
+        let (stream, _peer) = UnixStream::pair().unwrap();
+        bridge.conns.insert(
+            7,
+            EndpointConn {
+                stream,
+                last_activity: Instant::now() - CONNECTION_IDLE_TIMEOUT - Duration::from_secs(600),
+            },
+        );
+
+        assert!(bridge.evict_idle_at(Instant::now()).is_empty());
+        assert!(bridge.conns.contains_key(&7));
     }
 
     #[test]

--- a/crates/mvm-vmm/src/vsock_egress_bridge/substitution_bridge.rs
+++ b/crates/mvm-vmm/src/vsock_egress_bridge/substitution_bridge.rs
@@ -49,11 +49,20 @@ pub(crate) struct EndpointRelayDrain {
     pub closed: Vec<u32>,
 }
 
+/// How long to sleep between refill checks while an established stream waits
+/// for byte tokens.
+const BUDGET_REFILL_POLL: std::time::Duration = std::time::Duration::from_millis(1);
+
 /// Shared per-workload egress budget. The egress and broker ports use one
 /// instance so a workload cannot multiply its allowance by opening both paths.
 #[derive(Clone)]
 pub(crate) struct EgressBudget {
     state: Arc<Mutex<EgressBudgetState>>,
+    /// Trusted-builder tier: the concurrency cap still applies, but the byte
+    /// rate does not. A builder VM carries no untrusted workload and pulls
+    /// multi-gigabyte substituter closures, so metering it throttles builds to
+    /// a fraction of the host link for no security gain.
+    metered: bool,
 }
 
 struct EgressBudgetState {
@@ -68,13 +77,49 @@ impl EgressBudget {
     }
 
     fn new_at(now: Instant) -> Self {
+        Self::at(now, true)
+    }
+
+    /// A budget that caps concurrent streams but not throughput.
+    pub(crate) fn unmetered() -> Self {
+        Self::unmetered_at(Instant::now())
+    }
+
+    fn unmetered_at(now: Instant) -> Self {
+        Self::at(now, false)
+    }
+
+    fn at(now: Instant, metered: bool) -> Self {
         Self {
             state: Arc::new(Mutex::new(EgressBudgetState {
                 active_streams: 0,
                 byte_tokens: EGRESS_BURST_BYTES,
                 last_refill: now,
             })),
+            metered,
         }
+    }
+
+    /// Acquire `bytes` tokens, waiting for the bucket to refill if it is dry.
+    ///
+    /// Returns false only when `bytes` exceeds the burst ceiling — a payload no
+    /// amount of waiting can admit. Everything else eventually succeeds, because
+    /// tokens refill monotonically at a fixed rate.
+    ///
+    /// Throttling must never tear down an established stream: the host→guest
+    /// drain already backpressures this way, and resetting the guest→host side
+    /// instead killed in-flight TLS transfers mid-download.
+    fn consume_waiting(&self, bytes: usize) -> bool {
+        if !self.metered {
+            return true;
+        }
+        if u64::try_from(bytes).unwrap_or(u64::MAX) > EGRESS_BURST_BYTES {
+            return false;
+        }
+        while !self.try_consume(bytes) {
+            std::thread::sleep(BUDGET_REFILL_POLL);
+        }
+        true
     }
 
     fn try_reserve_stream(&self) -> bool {
@@ -96,6 +141,9 @@ impl EgressBudget {
     }
 
     fn try_consume_at(&self, bytes: usize, now: Instant) -> bool {
+        if !self.metered {
+            return true;
+        }
         let mut state = self.state.lock().expect("egress budget mutex poisoned");
         refill_tokens(&mut state, now);
 
@@ -110,6 +158,9 @@ impl EgressBudget {
     /// Reserve up to `max` bytes for a non-blocking read. The caller must
     /// refund bytes it reserved but did not receive from the socket.
     fn reserve_read(&self, max: usize, now: Instant) -> usize {
+        if !self.metered {
+            return max;
+        }
         let mut state = self.state.lock().expect("egress budget mutex poisoned");
         refill_tokens(&mut state, now);
         let max = u64::try_from(max).unwrap_or(u64::MAX);
@@ -208,6 +259,12 @@ impl SubstitutionBridge {
         self.endpoint = Some(path.to_path_buf());
     }
 
+    /// Swap the shared budget. Called during device setup, before any stream
+    /// exists, so no in-flight reservation is stranded.
+    pub(crate) fn set_budget(&mut self, budget: EgressBudget) {
+        self.budget = budget;
+    }
+
     /// Share the open-connection counter with the run loop heartbeat.
     pub fn set_activity(&mut self, counter: Arc<AtomicUsize>) {
         self.active = Some(counter);
@@ -264,7 +321,7 @@ impl SubstitutionBridge {
 impl GuestEndpointRelay for SubstitutionBridge {
     fn relay_guest_bytes(&mut self, conn_id: u32, payload: &[u8]) -> EndpointRelayAction {
         if let Some(conn) = self.conns.get_mut(&conn_id) {
-            if !self.budget.try_consume(payload.len()) {
+            if !self.budget.consume_waiting(payload.len()) {
                 return EndpointRelayAction::Refused;
             }
             write_nonblocking(&mut conn.stream, payload);
@@ -284,7 +341,7 @@ impl GuestEndpointRelay for SubstitutionBridge {
         match UnixStream::connect(&path) {
             Ok(stream) => {
                 let _ = stream.set_nonblocking(true);
-                if !self.budget.try_consume(payload.len()) {
+                if !self.budget.consume_waiting(payload.len()) {
                     self.budget.release_stream();
                     return EndpointRelayAction::Refused;
                 }
@@ -588,6 +645,75 @@ mod tests {
         assert_eq!(expired, vec![7]);
         assert!(!b.is_active());
         assert_eq!(active.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn an_established_stream_is_throttled_not_reset_when_the_budget_is_dry() {
+        let sock =
+            std::env::temp_dir().join(format!("mvm-egress-throttle-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&sock);
+        let listener = bind_unix_listener(&sock).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut sink = Vec::new();
+            let _ = stream.read_to_end(&mut sink);
+            sink.len()
+        });
+
+        let mut bridge = SubstitutionBridge::new();
+        bridge.set_endpoint(&sock);
+        assert_eq!(
+            bridge.relay_guest_bytes(7, b"open"),
+            EndpointRelayAction::Relayed
+        );
+
+        // Drain every token, then keep writing on the already-open stream. A
+        // rate-limited stream must survive: resetting it here is what tore down
+        // nix's in-flight TLS downloads mid-transfer.
+        while bridge.budget.try_consume(64 * 1024) {}
+        for _ in 0..4 {
+            assert_eq!(
+                bridge.relay_guest_bytes(7, &[b'x'; 1024]),
+                EndpointRelayAction::Relayed,
+                "an open stream must backpressure, never reset"
+            );
+        }
+
+        bridge.close_connection(7);
+        drop(bridge);
+        assert_eq!(server.join().unwrap(), 4 + 4 * 1024);
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[test]
+    fn a_payload_larger_than_the_burst_ceiling_is_refused() {
+        // No amount of waiting admits this one, so it must fail closed rather
+        // than spin forever.
+        let budget = EgressBudget::new();
+        let oversized = usize::try_from(EGRESS_BURST_BYTES).unwrap() + 1;
+        assert!(!budget.consume_waiting(oversized));
+    }
+
+    #[test]
+    fn an_unmetered_budget_ignores_the_byte_rate() {
+        let now = Instant::now();
+        let budget = EgressBudget::unmetered_at(now);
+        let ten_mib = 10 * 1024 * 1024;
+        for _ in 0..64 {
+            assert!(budget.try_consume_at(ten_mib, now));
+        }
+        assert!(budget.consume_waiting(ten_mib));
+    }
+
+    #[test]
+    fn an_unmetered_budget_still_caps_concurrent_streams() {
+        // Lifting the byte rate for a trusted builder must not lift the host-fd
+        // guard.
+        let budget = EgressBudget::unmetered();
+        for _ in 0..MAX_EGRESS_STREAMS {
+            assert!(budget.try_reserve_stream());
+        }
+        assert!(!budget.try_reserve_stream());
     }
 
     #[test]


### PR DESCRIPTION
`mvmctl machine build --flake ./out` ran for ~8 minutes and then failed. Two defects, one of them the cause.

## Defect 1 — throttling reset established connections

The shared egress token bucket was enforced asymmetrically:

- **host→guest** (`substitution_bridge.rs`, drain path): bucket dry → `sleep(1ms); continue`. Backpressure, stream preserved. The comment says it outright — *"without tearing down a valid TLS stream that is merely being rate-limited."*
- **guest→host** (relay path): bucket dry → `EndpointRelayAction::Refused` → `OP_RST`. An established, already-authorized connection torn down.

That reset is the `Broken pipe (os error 32)` in the builder's console log. It killed nix's in-flight TLS transfers mid-download; the retries tripped nix's substituter circuit breaker (`substituter 'https://cache.nixos.org' is disabled`), and with no binary cache the build fell back to compiling the whole toolchain from source before dying on an unrelated fixed-output fetch.

The guest→host path now waits for tokens. `Refused` is kept only for a payload larger than the burst ceiling — one no amount of waiting can admit, so it cannot spin forever. Waiting is already the established idiom on this path: `write_nonblocking` spin-waits on `WouldBlock` rather than dropping bytes.

## Defect 2 — the builder VM inherited workload ceilings

The builder VM builds nix templates, reports stdout/stderr, and exits. It carries no untrusted workload, so the per-workload egress ceilings have nothing to protect against there — they only break builds. Three applied to it:

- `EGRESS_BYTES_PER_SECOND` (4 MiB/s, shared across all streams) throttling multi-gigabyte substituter pulls on a 20 MB/s link
- `MAX_EGRESS_STREAMS` (128), whose refusal is an `OP_RST`
- `CONNECTION_IDLE_TIMEOUT` (60s), which evicts a relayed connection that goes quiet — as a keep-alive connection does while a derivation compiles

Replaced the implicit constants with an explicit policy:

```rust
pub(crate) struct EgressLimits {
    bytes_per_second: Option<u64>,
    max_streams: Option<usize>,
    idle_timeout: Option<Duration>,
}
```

`workload()` sets all three; `trusted_builder()` sets none. Threaded through the existing `spec.trusted_builder` tier marker into `HvfSupervisorConfig.trusted_builder_egress`, defaulting false so a workload stays metered.

**Workload behavior is unchanged.** The pre-existing workload tests (`egress_budget_caps_concurrency_and_releases_slots`, `idle_endpoint_stream_is_evicted_and_activity_drops`, `egress_budget_refills_bytes_at_a_fixed_rate`) still pass unmodified, which is what pins that.

## On attribution

Only the byte rate is a confirmed contributor. The builder sets `http-connections = 8`, so the 128-stream cap was never close to binding; the idle timeout is plausible but was not isolated. The other two are lifted as tier hygiene, not as a targeted fix — the commit message says so rather than implying all three were causes.

## Verification

End-to-end, same flake, same 455 derivations:

| | before | after |
|---|---|---|
| nix download retries | 99 | **0** |
| `substituter is disabled` | ~50 | **0** |
| `unable to download` | many | **0** |
| result | failed | **exit 0** in 8m45s, kernel + rootfs |

One `Broken pipe` warning remains in the guest log mid-run. It disrupted nothing measurable — zero retries, zero failed downloads — but I have not explained it, and I am not claiming it is gone.

Also green: 11254 workspace tests, doctests, `clippy --workspace --all-targets -D warnings`, nightly `fmt --all`, and the `check-uniform-vsock-egress` / `check-vsock-only-egress` / `check-claim-catalog` / `check-backend-resource-controls` / `check-honesty` / `check-no-overclaim` gates.

5 new tests, each confirmed red before the fix.

## Not addressed

`MAX_CONNECTIONS = 256` in `vsock_transport.rs` is a fourth ceiling, at the transport layer rather than the bridge, bounding guest-chosen `(host_port, guest_port)` keys against host memory growth. It applies to every tier. With `http-connections = 8` it is nowhere near binding, so it is left alone deliberately.