### PR TITLE
Fix the libkrun supervisor's build: the field is `plan`, not `plan_json`

### DIFF
--- a/crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs
@@ -228,7 +228,7 @@ fn dispatch_config(mut cfg: SupervisorConfig) -> ExitCode {
     // scope: dropping the guard stands the timer down.
     let _wall_clock = match mvm_hostd::supervisor::wall_clock::arm_for_supervisor(
         mvm_hostd::supervisor::wall_clock::SupervisorTimerInputs {
-            plan_json: cfg.plan_json.as_ref(),
+            plan_json: cfg.plan.as_ref(),
             audit_dir: cfg.audit_dir.as_deref(),
             signing_key_path: cfg.signing_key_path.as_deref(),
             vm_state_dir: std::path::Path::new(&cfg.vm_state_dir),


### PR DESCRIPTION
## The break

`mvm-libkrun-supervisor` does not compile on `main`:

```
error[E0609]: no field `plan_json` on type `SupervisorConfig`
   --> crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs:231:28
```

Clean checkout of `b17dc4666`, no local changes. That bin is the per-VM host
process every libkrun VM boots through.

`SupervisorTimerInputs.plan_json` is the **parameter** name; the config field
carrying the signed plan envelope is `SupervisorConfig.plan`. Same type
(`Option<serde_json::Value>`), so this is a one-word fix.

Introduced by #2356 (wall-clock bound), merged earlier today.

## Why CI didn't catch it

The bin needs `--features libkrun-sys`, and that crate's build script requires
`libkrun.h` — so it only compiles where the Homebrew trio is installed, i.e. a
macOS runner. The pre-commit hook and the PR clippy lane both run
`--workspace --all-targets` **without** that feature, so neither sees this file
at all.

The lanes that do build it:

- `release.yml` — tag pushes
- `ci-full.yml` — `workflow_dispatch` only

So the first sign of this would have been a failed release build.

## Follow-up worth doing (not in this PR)

The macOS lane that already installs libkrun could `cargo check -p mvm-hostd
--bin mvm-libkrun-supervisor --features libkrun-sys`. `check` doesn't link, so
it catches a type error like this one without needing the dylib present at link
time — cheap enough to gate every PR. I've left that out here rather than guess
at the runner setup; happy to add it if you want it in the same change.

## Verification

- `cargo check -p mvm-hostd --bin mvm-libkrun-supervisor --features libkrun-sys`
  — fails on `main`, clean with this patch
- pre-commit hook (`cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`) — clean