### PR TITLE
Pin bpf-linker so an upstream publish cannot break CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -676,8 +676,15 @@ jobs:
         with:
           key: ebpf
 
+      # Pinned deliberately. `--locked` only honors the crate's own bundled
+      # lockfile; it does not pin which version gets installed, so an upstream
+      # release silently changes this lane's toolchain. 0.11.0 did exactly that
+      # on 2026-08-12: it dropped `aya-rustc-llvm-proxy`, which had let the
+      # linker borrow rustc's bundled LLVM, and now needs a system LLVM the
+      # runner image does not ship. This version must move together with the
+      # `aya` version in Cargo.lock.
       - name: Install bpf-linker
-        run: cargo +nightly install --locked bpf-linker
+        run: cargo +nightly install --locked --version 0.10.4 bpf-linker
 
       - name: Install just
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
## The break

`Test eBPF telemetry load/attach` is failing on `main` right now, at the `Install bpf-linker` step. Nothing in this repo changed.

`bpf-linker 0.11.0` was published to crates.io at **2026-08-12T15:50:06Z**:

| Run | Time | Version taken | Result |
|---|---|---|---|
| 31608181684 | 14:41:51Z | 0.10.4 | pass |
| *0.11.0 published* | **15:50:06Z** | | |
| 31633534215 | 19:38:31Z | 0.11.0 | **fail** |

The lane ran `cargo +nightly install --locked bpf-linker` with no `--version`. `--locked` pins the installed crate's *own* dependency graph — it does **not** pin which version of that crate is selected, so the lane silently tracked whatever was newest.

## Why 0.11.0 breaks

0.10.4 depends on `aya-rustc-llvm-proxy ^0.10.0`, which lets the linker borrow **rustc's bundled LLVM** — so it needs no system LLVM at all. That is why it worked on a bare runner.

0.11.0 dropped that proxy and requires a real system `llvm-sys ^231.0.0-rc2`. Its build script now goes looking for `llvm-config`, finds nothing usable on `ubuntu-24.04`, and fails.

Confirmed against the crates.io dependency lists for both versions, and reproduced locally (same build script, same missing `llvm-config`).

## The fix

Pin `--version 0.10.4` — the version every green run today used. This restores the rustc-LLVM-proxy path, so it needs no runner-image or LLVM change.

Scoped deliberately to the one line plus its explanatory comment so it can land fast. A workflow-shape assertion that keeps the pin from being dropped again rides in #2399, which also makes this lane gate the `Test` reporter.

## Validation

- `actionlint .github/workflows/ci.yml` — clean
- pre-commit hook (workspace `cargo fmt --all` + `cargo clippy --workspace --all-targets -D warnings`) — clean
- The lane itself is the real test: it runs on this PR, since `.github/workflows/ci.yml` classifies as a code path.

## Follow-up, not in scope here

Moving to 0.11.0 later requires provisioning LLVM 231 on the lane and must move together with `aya 0.13.1` in `Cargo.lock`.