### PR TITLE
Pin AppleContainer's egress coverage as a checked invariant

### DIFF
--- a/specs/plans/308-workload-grants-implementation.md
+++ b/specs/plans/308-workload-grants-implementation.md
@@ -3134,3 +3134,43 @@ holds; leave anything you cannot verify alone and say so.
 - `a_signature_inside_a_string_literal_is_not_flagged` (both gates)
 - `a_guard_comparing_a_string_is_still_a_wildcard` (resource-controls gate)
 - each gate proven red against its new shape, then green after
+
+---
+
+### Task 22: Pin AppleContainer's transitive egress coverage
+
+`check-uniform-vsock-egress` locks Firecracker, libkrun and HVF onto the one
+launch seam that spawns the per-VM substitution endpoint — the sole claim-10
+egress gate. It never mentions `AppleContainer`, which **is** a workload
+backend: `as_workload_backend` returns `Some` for it, so it carries untrusted
+workloads through the admitted funnel.
+
+Investigated before changing anything, and the coverage turns out to be real:
+`AppleContainerBackend` holds an `HvfRunner`, `start` delegates to
+`self.runner.start(&self.config_with_kernel(config)?)` substituting only the
+kernel path, and the file spawns no endpoint of its own. So it reaches the
+endpoint spawner through the runner the gate already locks.
+
+**The defect is that this is an unchecked invariant, not a hole.** Nothing
+stops a future edit from giving `AppleContainerBackend` its own field in place
+of the runner, or making `start` spawn directly — and the gate would stay
+green while a second egress seam appeared on a workload-bearing tier. The
+gate's header also implies the tier is out of scope by omission, which is how
+the invariant stayed implicit.
+
+**The work:**
+- Assert `AppleContainerBackend` holds an `HvfRunner` and that its `start`
+  delegates to it, so the transitive coverage cannot silently break.
+- Extend Assertion B's guarded set to `apple_container_backend.rs`, so an
+  egress-spawn token appearing there trips the gate the same way it would in a
+  driver.
+- Correct the header: name AppleContainer as covered *transitively* and say
+  why, rather than leaving it unmentioned. State plainly that Wasm, Qemu and
+  Docker are barred from the funnel (`as_workload_backend` returns `None`),
+  which is a different thing from being an unconverged workload.
+
+**Witnesses — each proven red before green:**
+- swapping `AppleContainerBackend`'s runner field for a raw backend trips the gate
+- making its `start` bypass the runner trips the gate
+- an egress-spawn token in `apple_container_backend.rs` trips the gate
+- the gate stays green on the real tree

--- a/specs/plans/308-workload-grants-implementation.md
+++ b/specs/plans/308-workload-grants-implementation.md
@@ -3174,3 +3174,16 @@ the invariant stayed implicit.
 - making its `start` bypass the runner trips the gate
 - an egress-spawn token in `apple_container_backend.rs` trips the gate
 - the gate stays green on the real tree
+
+**Resolved while pinning (a):** `warm_start` passes `config` through without
+`config_with_kernel`, unlike `start` and `start_with_mode`. That looked like an
+inconsistency but is correct: `VmBackend::warm_start` is documented to fail
+closed and "never a silent cold boot", so it either restores a snapshot — where
+the kernel already lives in the restored guest memory — or errors. There is no
+kernel to substitute on a restore path.
+
+**Also fixed:** the round-1 matcher was per-line, so it never found the real
+`start_with_mode`, which rustfmt wraps across two lines. It failed closed rather
+than passing green, but the matcher now squeezes whitespace and the fixture
+carries a wrapped body so the regression is caught in unit tests. This is the
+third gate in this plan to be tripped by rustfmt wrapping a signature.

--- a/xtask/src/check_uniform_vsock_egress.rs
+++ b/xtask/src/check_uniform_vsock_egress.rs
@@ -10,7 +10,7 @@
 //! reverts a converged variant to a raw backend, swaps the endpoint spawner off
 //! the seam, or wires an egress endpoint inside a driver.
 //!
-//! Two assertions:
+//! Three assertions:
 //!
 //! - **A — the converged CLI workload variants ARE runners.** `backend.rs` keeps
 //!   the `FcRunner`/`LibkrunRunner`/`HvfRunner` aliases at the full
@@ -20,17 +20,32 @@
 //!   `Firecracker(FcRunner)` + `Libkrun(LibkrunRunner)` + `Hvf(HvfRunner)` —
 //!   never a raw `Firecracker(FirecrackerBackend)` / `Libkrun(LibkrunBackend)` /
 //!   `Hvf(HvfBackend)`.
-//! - **B — no egress-endpoint wiring on the converged driver surface.** The
-//!   `driver/*.rs` files carry none of the raw egress-spawn tokens; the one legal
-//!   spawn site (`workload_runner/runner.rs`) is out of the guarded set.
+//! - **B — no egress-endpoint wiring on the guarded surface.** The
+//!   `driver/*.rs` files and `apple_container_backend.rs` carry none of the raw
+//!   egress-spawn tokens; the one legal spawn site
+//!   (`workload_runner/runner.rs`) is out of the guarded set.
+//! - **C — `AppleContainerBackend` still delegates to an `HvfRunner`.** It holds
+//!   a `runner: HvfRunner` field and its `start` body calls
+//!   `self.runner.start(...)`, so its egress reaches the endpoint spawner
+//!   through the runner Assertion A already locks.
 //!
-//! Scope — this gate is **incremental by design**. It cannot yet assert "every
-//! workload backend is a runner": `Wasm` is a workload but still raw — it
-//! mediates no networking, so it carries no egress seam to converge. That one
-//! variant is the **sole remaining exemption** — the exemption list is the
-//! remaining-convergence ledger, and it shrinks to nothing once the wasm
-//! portability tier grows a governed WASI egress seam. Until then this gate locks
-//! Firecracker + libkrun + HVF and leaves raw Wasm alone.
+//! Scope — the covered set is what `AnyBackend::as_workload_backend` admits:
+//!
+//! - Firecracker, libkrun and HVF are covered **directly** (A + B).
+//! - `AppleContainer` is covered **transitively**, and C is why that is a
+//!   checked fact rather than an implicit one: the backend is the HVF workload
+//!   runner with only the kernel image substituted, so it spawns no endpoint of
+//!   its own and inherits the runner's single egress seam. Without C, replacing
+//!   the runner field or bypassing it in `start` would grow a second seam on a
+//!   workload-bearing tier while this gate stayed green.
+//! - `Mock` is admitted only when the test-support feature is on; it is an
+//!   in-memory double, not a host VMM.
+//!
+//! `Wasm`, `Qemu` and `Docker` are **barred** from the admitted funnel —
+//! `as_workload_backend` returns `None` for each — so no admitted workload
+//! dispatches through them and there is no egress seam here to lock. That is a
+//! different thing from being an unconverged workload backend: they are not on
+//! the funnel at all.
 
 use anyhow::{Result, bail};
 use regex::Regex;
@@ -38,6 +53,10 @@ use std::path::{Path, PathBuf};
 
 /// The converged dispatch surface — the aliases and enum arms Assertion A reads.
 const BACKEND_RS: &str = "crates/mvm-runtime/src/backend.rs";
+
+/// The Apple Container backend — the transitively covered workload tier
+/// Assertion C reads, and part of Assertion B's guarded set.
+const APPLE_CONTAINER_RS: &str = "crates/mvm-runtime/src/apple_container_backend.rs";
 
 /// A converged runner alias and the driver it must wrap. The alias must stay at
 /// the `WorkloadRunner<Driver, RealEndpointSpawner, RealBrokerRegistrar>` shape;
@@ -77,8 +96,10 @@ const FORBIDDEN_ENUM_ARMS: &[&str] = &[
     "Hvf(HvfBackend)",
 ];
 
-/// The converged driver surface Assertion B guards: a `VmmDriver` only wires the
-/// guest port through, so no per-VM egress endpoint may be spawned here.
+/// The surface Assertion B guards: a `VmmDriver` only wires the guest port
+/// through, so no per-VM egress endpoint may be spawned here — and neither may
+/// `apple_container_backend.rs`, which is covered transitively precisely
+/// because it spawns nothing of its own.
 ///
 /// Deliberately NOT guarded (they legitimately construct or hold endpoints and
 /// sit outside the converged CLI scope): `workload_runner/runner.rs` (the one
@@ -87,7 +108,7 @@ const FORBIDDEN_ENUM_ARMS: &[&str] = &[
 /// supervisor + Firecracker standby fleet path), the endpoint definition
 /// (`substitution_spawn.rs`) + the `mvm-hostd` supervisor + the substitution
 /// endpoint binary, and `bench/probe.rs`.
-const GUARDED_PATHS: &[&str] = &["crates/mvm-runtime/src/driver"];
+const GUARDED_PATHS: &[&str] = &["crates/mvm-runtime/src/driver", APPLE_CONTAINER_RS];
 
 /// Raw egress-spawn tokens. Any of these on the guarded driver surface means a
 /// per-VM endpoint is being spawned outside `RealEndpointSpawner`.
@@ -102,11 +123,12 @@ const FORBIDDEN: &[&str] = &[
 
 pub fn run(workspace: &Path) -> Result<()> {
     check_converged_runner_shape(workspace)?;
+    check_apple_container_delegates_to_runner(workspace)?;
     let scanned = check_no_driver_egress_spawn(workspace)?;
     eprintln!(
         "check-uniform-vsock-egress: clean (Firecracker + libkrun + HVF bind WorkloadRunner \
-         runners; {scanned} driver file(s) spawn no egress endpoint — only raw Wasm \
-         remains exempt)"
+         runners; apple-container delegates to an HvfRunner; {scanned} guarded file(s) spawn \
+         no egress endpoint — Wasm, Qemu and Docker are barred from the admitted funnel)"
     );
     Ok(())
 }
@@ -127,8 +149,8 @@ fn check_converged_runner_shape(workspace: &Path) -> Result<()> {
                 "check-uniform-vsock-egress: {alias} lost its converged runner shape. \
                  Expected `type {alias} = WorkloadRunner<{driver}, RealEndpointSpawner, \
                  RealBrokerRegistrar>`. Swapping the endpoint spawner or broker registrar \
-                 off this seam breaks the uniform vsock-egress convergence. (Raw Wasm \
-                 remains exempt — see the module doc.)",
+                 off this seam breaks the uniform vsock-egress convergence — including \
+                 for apple-container, which reaches the endpoint through `HvfRunner`.",
                 alias = alias.alias,
                 driver = alias.driver
             );
@@ -162,7 +184,68 @@ fn check_converged_runner_shape(workspace: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Assertion B — the converged driver surface spawns no egress endpoint. Returns
+/// The `VmBackend::start` signature on the Apple Container backend. Assertion C
+/// reads the body that follows it.
+const APPLE_CONTAINER_START_SIG: &str = "fn start(&self, config: &VmStartConfig)";
+
+/// Assertion C — `AppleContainerBackend` still reaches egress through an
+/// `HvfRunner`. Its coverage is transitive, so both halves must hold: it holds
+/// the runner, and `start` goes through it rather than around it.
+fn check_apple_container_delegates_to_runner(workspace: &Path) -> Result<()> {
+    let path = workspace.join(APPLE_CONTAINER_RS);
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        bail!(
+            "check-uniform-vsock-egress: cannot read {APPLE_CONTAINER_RS} — the \
+             apple-container workload backend must exist"
+        );
+    };
+    let code = code_lines(&text);
+
+    let field = Regex::new(r"\brunner\s*:\s*HvfRunner\b").expect("static field regex");
+    if !code.iter().any(|(_, line)| field.is_match(line)) {
+        bail!(
+            "check-uniform-vsock-egress: {APPLE_CONTAINER_RS}: `AppleContainerBackend` no \
+             longer holds a `runner: HvfRunner`. Its claim-10 coverage is transitive — it \
+             reaches the one `RealEndpointSpawner` through the HVF runner. Holding anything \
+             else means this workload tier needs its own egress seam, which is the \
+             convergence this gate exists to prevent."
+        );
+    }
+
+    let body = fn_body(&code, APPLE_CONTAINER_START_SIG).ok_or_else(|| {
+        anyhow::anyhow!(
+            "check-uniform-vsock-egress: {APPLE_CONTAINER_RS}: cannot find \
+             `{APPLE_CONTAINER_START_SIG}` — `AppleContainerBackend::start` must exist for \
+             its delegation to be checkable."
+        )
+    })?;
+    if !body.iter().any(|line| line.contains("self.runner.start(")) {
+        bail!(
+            "check-uniform-vsock-egress: {APPLE_CONTAINER_RS}: \
+             `AppleContainerBackend::start` no longer delegates to `self.runner.start(...)`. \
+             A start that bypasses the HVF runner bypasses the per-VM substitution endpoint \
+             that owns claim-10 for this tier."
+        );
+    }
+    Ok(())
+}
+
+/// The code lines of the function whose signature line contains `signature`, up
+/// to the next `fn ` at the same-or-shallower nesting. Returns `None` when the
+/// signature is absent.
+fn fn_body<'a>(code: &[(usize, &'a str)], signature: &str) -> Option<Vec<&'a str>> {
+    let start = code.iter().position(|(_, line)| line.contains(signature))?;
+    let mut body = Vec::new();
+    for (_, line) in &code[start + 1..] {
+        if line.contains("fn ") {
+            break;
+        }
+        body.push(*line);
+    }
+    Some(body)
+}
+
+/// Assertion B — the guarded surface spawns no egress endpoint. Returns
 /// the number of guarded files scanned.
 fn check_no_driver_egress_spawn(workspace: &Path) -> Result<usize> {
     let re = forbidden_regex();
@@ -171,9 +254,10 @@ fn check_no_driver_egress_spawn(workspace: &Path) -> Result<usize> {
     if !hits.is_empty() {
         bail!(
             "check-uniform-vsock-egress: a per-VM egress endpoint is spawned on the \
-             converged driver surface. The only legal spawn site is \
+             guarded surface. The only legal spawn site is \
              `RealEndpointSpawner::spawn` in workload_runner/runner.rs; a driver wires \
-             the guest port through and spawns nothing:\n{}",
+             the guest port through and spawns nothing, and the apple-container backend \
+             delegates rather than spawning:\n{}",
             hits.join("\n")
         );
     }
@@ -343,6 +427,93 @@ mod tests {
             err.to_string().contains("Firecracker(FirecrackerBackend)"),
             "got {err}"
         );
+    }
+
+    /// Write an apple-container fixture with the given struct field and `start`
+    /// body, and run Assertion C over it.
+    fn apple_container_fixture(field: &str, start_body: &str) -> (tempfile::TempDir, Result<()>) {
+        let root = tempfile::tempdir().expect("tempdir");
+        let path = root.path().join(APPLE_CONTAINER_RS);
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create dirs");
+        std::fs::write(
+            &path,
+            format!(
+                "pub struct AppleContainerBackend {{\n    {field}\n}}\n\
+                 impl VmBackend for AppleContainerBackend {{\n    \
+                 fn start(&self, config: &VmStartConfig) -> Result<VmId> {{\n        \
+                 {start_body}\n    }}\n\n    \
+                 fn stop(&self, id: &VmId) -> Result<()> {{\n        self.runner.stop(id)\n    }}\n}}\n"
+            ),
+        )
+        .expect("write apple-container fixture");
+        let outcome = check_apple_container_delegates_to_runner(root.path());
+        (root, outcome)
+    }
+
+    #[test]
+    fn apple_container_holding_the_hvf_runner_and_delegating_passes() {
+        let (_root, outcome) = apple_container_fixture(
+            "runner: HvfRunner,",
+            "self.runner.start(&self.config_with_kernel(config)?)",
+        );
+        outcome.expect("the real shape must pass Assertion C");
+    }
+
+    #[test]
+    fn swapping_the_apple_container_runner_for_a_raw_backend_fails() {
+        // The transitive coverage rests on the runner: a raw backend field
+        // would need its own egress seam.
+        let (_root, outcome) = apple_container_fixture(
+            "runner: HvfBackend,",
+            "self.runner.start(&self.config_with_kernel(config)?)",
+        );
+        let err = outcome.expect_err("a raw runner field must fail the gate");
+        assert!(err.to_string().contains("runner: HvfRunner"), "got {err}");
+    }
+
+    #[test]
+    fn an_apple_container_start_that_bypasses_the_runner_fails() {
+        let (_root, outcome) = apple_container_fixture(
+            "runner: HvfRunner,",
+            "hvf_backend().start(&self.config_with_kernel(config)?)",
+        );
+        let err = outcome.expect_err("a start bypassing the runner must fail the gate");
+        assert!(err.to_string().contains("self.runner.start("), "got {err}");
+    }
+
+    #[test]
+    fn a_deleted_apple_container_start_fails() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let path = root.path().join(APPLE_CONTAINER_RS);
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create dirs");
+        std::fs::write(
+            &path,
+            "pub struct AppleContainerBackend {\n    runner: HvfRunner,\n}\n",
+        )
+        .expect("write fixture");
+        let err = check_apple_container_delegates_to_runner(root.path())
+            .expect_err("an absent start must fail rather than pass vacuously");
+        assert!(err.to_string().contains("cannot find"), "got {err}");
+    }
+
+    #[test]
+    fn forbidden_token_in_the_apple_container_backend_is_detected() {
+        // Assertion B's guarded set covers this file: an egress-spawn token
+        // here is a second seam on a workload-bearing tier.
+        let root = tempfile::tempdir().expect("tempdir");
+        let path = root.path().join(APPLE_CONTAINER_RS);
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create dirs");
+        std::fs::write(
+            &path,
+            "fn start(&self) {\n    spawn_substitution_endpoint(params);\n}\n",
+        )
+        .expect("write rogue apple-container backend");
+
+        let err = check_no_driver_egress_spawn(root.path())
+            .expect_err("an egress spawn in the apple-container backend must fail the gate");
+        let err = err.to_string();
+        assert!(err.contains("spawn_substitution_endpoint"), "got {err}");
+        assert!(err.contains("apple_container_backend.rs"), "got {err}");
     }
 
     #[test]

--- a/xtask/src/check_uniform_vsock_egress.rs
+++ b/xtask/src/check_uniform_vsock_egress.rs
@@ -25,9 +25,12 @@
 //!   egress-spawn tokens; the one legal spawn site
 //!   (`workload_runner/runner.rs`) is out of the guarded set.
 //! - **C — `AppleContainerBackend` still delegates to an `HvfRunner`.** It holds
-//!   a `runner: HvfRunner` field and its `start` body calls
-//!   `self.runner.start(...)`, so its egress reaches the endpoint spawner
-//!   through the runner Assertion A already locks.
+//!   a `runner: HvfRunner` field, and each of its launch paths — `start`,
+//!   `start_with_mode`, `warm_start` — calls the matching `self.runner.*`,
+//!   so its egress reaches the endpoint spawner through the runner Assertion A
+//!   already locks. Those three are the methods that bring a guest up; the rest
+//!   of the surface acts on an already-launched VM or reports metadata, so it
+//!   opens no egress seam.
 //!
 //! Scope — the covered set is what `AnyBackend::as_workload_backend` admits:
 //!
@@ -184,13 +187,41 @@ fn check_converged_runner_shape(workspace: &Path) -> Result<()> {
     Ok(())
 }
 
-/// The `VmBackend::start` signature on the Apple Container backend. Assertion C
-/// reads the body that follows it.
-const APPLE_CONTAINER_START_SIG: &str = "fn start(&self, config: &VmStartConfig)";
+/// A launch path on the Apple Container backend: a method that brings a guest
+/// up, and so must reach the runner that owns the egress seam. `signature` is
+/// matched against the method's signature line; `delegation` must appear in the
+/// body that follows.
+struct LaunchPath {
+    signature: &'static str,
+    delegation: &'static str,
+}
+
+/// Every `AppleContainerBackend` method that starts or restores a guest. These
+/// are the ones whose delegation carries egress; the rest of the `VmBackend`
+/// surface (`wait`/`pause`/`resume`/`stop`/`stop_all`/`status`/`list`/`logs`/
+/// `install`/`name`/`kind`/`capabilities`/`security_profile`) acts on an
+/// already-launched VM or reports metadata, so it opens no egress seam and is
+/// deliberately not pinned here.
+const APPLE_CONTAINER_LAUNCH_PATHS: &[LaunchPath] = &[
+    LaunchPath {
+        signature: "fn start(&self, config: &VmStartConfig)",
+        delegation: "self.runner.start(",
+    },
+    LaunchPath {
+        signature: "fn start_with_mode(",
+        delegation: "self.runner.start_with_mode(",
+    },
+    // A warm start restores a guest that then runs a workload, so it reaches
+    // the same endpoint the cold path does.
+    LaunchPath {
+        signature: "fn warm_start(",
+        delegation: "self.runner.warm_start(",
+    },
+];
 
 /// Assertion C — `AppleContainerBackend` still reaches egress through an
 /// `HvfRunner`. Its coverage is transitive, so both halves must hold: it holds
-/// the runner, and `start` goes through it rather than around it.
+/// the runner, and every launch path goes through it rather than around it.
 fn check_apple_container_delegates_to_runner(workspace: &Path) -> Result<()> {
     let path = workspace.join(APPLE_CONTAINER_RS);
     let Ok(text) = std::fs::read_to_string(&path) else {
@@ -212,22 +243,34 @@ fn check_apple_container_delegates_to_runner(workspace: &Path) -> Result<()> {
         );
     }
 
-    let body = fn_body(&code, APPLE_CONTAINER_START_SIG).ok_or_else(|| {
-        anyhow::anyhow!(
-            "check-uniform-vsock-egress: {APPLE_CONTAINER_RS}: cannot find \
-             `{APPLE_CONTAINER_START_SIG}` — `AppleContainerBackend::start` must exist for \
-             its delegation to be checkable."
-        )
-    })?;
-    if !body.iter().any(|line| line.contains("self.runner.start(")) {
-        bail!(
-            "check-uniform-vsock-egress: {APPLE_CONTAINER_RS}: \
-             `AppleContainerBackend::start` no longer delegates to `self.runner.start(...)`. \
-             A start that bypasses the HVF runner bypasses the per-VM substitution endpoint \
-             that owns claim-10 for this tier."
-        );
+    for path in APPLE_CONTAINER_LAUNCH_PATHS {
+        let Some(body) = fn_body(&code, path.signature) else {
+            bail!(
+                "check-uniform-vsock-egress: {APPLE_CONTAINER_RS}: cannot find `{sig}` — \
+                 this launch path must exist for its delegation to be checkable. Removing a \
+                 launch path instead of pinning it is not a way past this gate.",
+                sig = path.signature
+            );
+        };
+        if !squeeze(&body.concat()).contains(&squeeze(path.delegation)) {
+            bail!(
+                "check-uniform-vsock-egress: {APPLE_CONTAINER_RS}: the launch path `{sig}` no \
+                 longer delegates to `{delegation}...)`. A launch that bypasses the HVF runner \
+                 bypasses the per-VM substitution endpoint that owns claim-10 for this tier.",
+                sig = path.signature,
+                delegation = path.delegation
+            );
+        }
     }
     Ok(())
+}
+
+/// Drop all whitespace, so a delegation rustfmt wrapped across lines
+/// (`self.runner\n    .start_with_mode(...)`) still matches the token being
+/// looked for. Without this the gate reads as green on a wrapped call it never
+/// actually found.
+fn squeeze(text: &str) -> String {
+    text.chars().filter(|c| !c.is_whitespace()).collect()
 }
 
 /// The code lines of the function whose signature line contains `signature`, up
@@ -429,33 +472,110 @@ mod tests {
         );
     }
 
-    /// Write an apple-container fixture with the given struct field and `start`
-    /// body, and run Assertion C over it.
-    fn apple_container_fixture(field: &str, start_body: &str) -> (tempfile::TempDir, Result<()>) {
+    /// One launch path in a fixture: the signature line, and the single body
+    /// line under it.
+    struct FixtureMethod {
+        signature: &'static str,
+        body: String,
+    }
+
+    /// A faithful fixture's launch paths — each delegating to the runner, as the
+    /// real backend does. Tests mutate or drop one entry to model a regression.
+    fn faithful_launch_paths() -> Vec<FixtureMethod> {
+        [
+            (
+                "fn start(&self, config: &VmStartConfig) -> Result<VmId> {",
+                "self.runner.start(&self.config_with_kernel(config)?)",
+            ),
+            // Wrapped across lines exactly as rustfmt writes it in the real
+            // file — a per-line match would miss this and read as green.
+            (
+                "fn start_with_mode(&self, config: &VmStartConfig, mode: StartMode) -> Result<VmId> {",
+                "self.runner\n            .start_with_mode(&self.config_with_kernel(config)?, mode)",
+            ),
+            (
+                "fn warm_start(&self, config: &VmStartConfig, req: SnapshotCapability) -> Outcome {",
+                "self.runner.warm_start(config, req)",
+            ),
+        ]
+        .into_iter()
+        .map(|(signature, body)| FixtureMethod {
+            signature,
+            body: body.to_string(),
+        })
+        .collect()
+    }
+
+    /// The faithful launch paths with the one whose signature contains
+    /// `signature` rewritten to `body`.
+    fn with_launch_body(signature: &str, body: &str) -> Vec<FixtureMethod> {
+        let mut paths = faithful_launch_paths();
+        let entry = paths
+            .iter_mut()
+            .find(|m| m.signature.contains(signature))
+            .expect("fixture must carry the launch path under test");
+        entry.body = body.to_string();
+        paths
+    }
+
+    /// The faithful launch paths with the one whose signature contains
+    /// `signature` deleted entirely.
+    fn without_launch_path(signature: &str) -> Vec<FixtureMethod> {
+        faithful_launch_paths()
+            .into_iter()
+            .filter(|m| !m.signature.contains(signature))
+            .collect()
+    }
+
+    /// Write an apple-container fixture with the given struct field and launch
+    /// paths, and run Assertion C over it.
+    fn apple_container_fixture(
+        field: &str,
+        paths: &[FixtureMethod],
+    ) -> (tempfile::TempDir, Result<()>) {
         let root = tempfile::tempdir().expect("tempdir");
         let path = root.path().join(APPLE_CONTAINER_RS);
         std::fs::create_dir_all(path.parent().expect("parent")).expect("create dirs");
-        std::fs::write(
-            &path,
-            format!(
-                "pub struct AppleContainerBackend {{\n    {field}\n}}\n\
-                 impl VmBackend for AppleContainerBackend {{\n    \
-                 fn start(&self, config: &VmStartConfig) -> Result<VmId> {{\n        \
-                 {start_body}\n    }}\n\n    \
-                 fn stop(&self, id: &VmId) -> Result<()> {{\n        self.runner.stop(id)\n    }}\n}}\n"
-            ),
-        )
-        .expect("write apple-container fixture");
+        let mut source = format!("pub struct AppleContainerBackend {{\n    {field}\n}}\n");
+        source.push_str("impl VmBackend for AppleContainerBackend {\n");
+        for method in paths {
+            source.push_str(&format!(
+                "    {}\n        {}\n    }}\n\n",
+                method.signature, method.body
+            ));
+        }
+        // A lifecycle method that is deliberately NOT a launch path, so the
+        // fixture proves the gate pins the launch set rather than everything.
+        source.push_str("    fn stop(&self, id: &VmId) -> Result<()> {\n        self.runner.stop(id)\n    }\n}\n");
+        std::fs::write(&path, source).expect("write apple-container fixture");
         let outcome = check_apple_container_delegates_to_runner(root.path());
         (root, outcome)
     }
 
+    /// The launch paths under test, with the bypass that models rerouting each
+    /// one past the runner and the delegation the gate must name.
+    const LAUNCH_PATH_CASES: &[(&str, &str, &str)] = &[
+        (
+            "fn start(",
+            "hvf_runner().start(&self.config_with_kernel(config)?)",
+            "self.runner.start(",
+        ),
+        (
+            "fn start_with_mode(",
+            "hvf_runner().start_with_mode(&self.config_with_kernel(config)?, mode)",
+            "self.runner.start_with_mode(",
+        ),
+        (
+            "fn warm_start(",
+            "hvf_runner().warm_start(config, req)",
+            "self.runner.warm_start(",
+        ),
+    ];
+
     #[test]
     fn apple_container_holding_the_hvf_runner_and_delegating_passes() {
-        let (_root, outcome) = apple_container_fixture(
-            "runner: HvfRunner,",
-            "self.runner.start(&self.config_with_kernel(config)?)",
-        );
+        let (_root, outcome) =
+            apple_container_fixture("runner: HvfRunner,", &faithful_launch_paths());
         outcome.expect("the real shape must pass Assertion C");
     }
 
@@ -463,37 +583,40 @@ mod tests {
     fn swapping_the_apple_container_runner_for_a_raw_backend_fails() {
         // The transitive coverage rests on the runner: a raw backend field
         // would need its own egress seam.
-        let (_root, outcome) = apple_container_fixture(
-            "runner: HvfBackend,",
-            "self.runner.start(&self.config_with_kernel(config)?)",
-        );
+        let (_root, outcome) =
+            apple_container_fixture("runner: HvfBackend,", &faithful_launch_paths());
         let err = outcome.expect_err("a raw runner field must fail the gate");
         assert!(err.to_string().contains("runner: HvfRunner"), "got {err}");
     }
 
     #[test]
-    fn an_apple_container_start_that_bypasses_the_runner_fails() {
-        let (_root, outcome) = apple_container_fixture(
-            "runner: HvfRunner,",
-            "hvf_backend().start(&self.config_with_kernel(config)?)",
-        );
-        let err = outcome.expect_err("a start bypassing the runner must fail the gate");
-        assert!(err.to_string().contains("self.runner.start("), "got {err}");
+    fn an_apple_container_launch_path_that_bypasses_the_runner_fails() {
+        // Each launch path is pinned independently: rerouting any one of them
+        // past the runner opens a second egress seam on this tier. The bypass
+        // still reaches an `HvfRunner`, so a check that merely looked for that
+        // token would pass — the delegation through the held field is the point.
+        for (signature, bypass, named) in LAUNCH_PATH_CASES {
+            let (_root, outcome) =
+                apple_container_fixture("runner: HvfRunner,", &with_launch_body(signature, bypass));
+            let err = outcome
+                .expect_err("a launch path bypassing the runner must fail the gate")
+                .to_string();
+            assert!(err.contains(named), "for {signature}: got {err}");
+        }
     }
 
     #[test]
-    fn a_deleted_apple_container_start_fails() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let path = root.path().join(APPLE_CONTAINER_RS);
-        std::fs::create_dir_all(path.parent().expect("parent")).expect("create dirs");
-        std::fs::write(
-            &path,
-            "pub struct AppleContainerBackend {\n    runner: HvfRunner,\n}\n",
-        )
-        .expect("write fixture");
-        let err = check_apple_container_delegates_to_runner(root.path())
-            .expect_err("an absent start must fail rather than pass vacuously");
-        assert!(err.to_string().contains("cannot find"), "got {err}");
+    fn a_deleted_apple_container_launch_path_fails() {
+        // Deleting a launch path must not be a way past the gate: the check
+        // fails rather than passing vacuously on a method it cannot find.
+        for (signature, _, _) in LAUNCH_PATH_CASES {
+            let (_root, outcome) =
+                apple_container_fixture("runner: HvfRunner,", &without_launch_path(signature));
+            let err = outcome
+                .expect_err("an absent launch path must fail rather than pass vacuously")
+                .to_string();
+            assert!(err.contains("cannot find"), "for {signature}: got {err}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`check-uniform-vsock-egress` locks Firecracker, libkrun and HVF onto the single launch seam that spawns the per-VM substitution endpoint — the sole claim-10 egress gate. It never mentioned `AppleContainer`, which **is** a workload backend: `as_workload_backend` returns `Some` for it, so it carries untrusted workloads through the admitted funnel.

**The coverage turned out to be real, but unchecked.** `AppleContainerBackend` holds an `HvfRunner`, its launch methods delegate to it substituting only the kernel path, and the file spawns no endpoint of its own — so it reaches the endpoint spawner through a runner the gate already locks.

That made this a different problem than a hole: nothing stopped a future edit from replacing the runner field or making a launch method spawn directly, and the gate would have stayed green while a second egress seam appeared on a workload-bearing tier. The invariant held only because nobody had broken it yet.

## What the gate now pins

- `AppleContainerBackend` holds an `HvfRunner`
- **all three launch paths** delegate to it: `start`, `start_with_mode`, `warm_start`
- no egress-spawn token appears in `apple_container_backend.rs` (guarded set 4 → 5)

Lifecycle methods that act on an already-launched VM or report metadata (`wait`, `pause`, `resume`, `stop`, `status`, `list`, `logs`, `capabilities`, …) are deliberately unpinned — they reach no launch or spawn path.

Every shape was proven **red before green on the real tree**, not against fixtures: swapping the runner field for a raw backend, rerouting `start`/`start_with_mode`/`warm_start` past the runner, deleting `start_with_mode` outright, and inserting an egress-spawn token — each failed with a specific named error, then reverted green.

## Header corrected

The gate's prose implied AppleContainer was out of scope by omitting it. It now names the tier as covered *transitively* and says why. It also distinguishes two things the old "sole remaining exemption" phrasing blurred: Wasm is an unconverged workload, while Qemu and Docker are **barred** from the admitted funnel (`as_workload_backend` returns `None`) — different situations with different futures.

## Two findings recorded

**A bug in this PR's own first round.** The initial matcher was per-line and never found the real `start_with_mode`, which rustfmt wraps across two lines. It failed *closed* rather than passing green, but the matcher now squeezes whitespace and the fixture carries a wrapped body so the regression is caught in unit tests. This is the third gate in this plan tripped by rustfmt wrapping a signature.

**`warm_start` does not call `config_with_kernel`,** unlike the other two launch paths. Investigated rather than assumed: `VmBackend::warm_start` is documented to fail closed and "never a silent cold boot", so it either restores a snapshot — where the kernel already lives in restored guest memory — or errors. There is no kernel to substitute on a restore path, so the omission is correct.

## Validation

`cargo nextest run --workspace` — 11,364 passed, 0 failed. `cargo test --workspace --no-run` builds. Gates: `check-uniform-vsock-egress`, `check-vsock-only-egress`, `check-no-spec-refs-in-comments`, `check-workflow-paths` — all clean. fmt and clippy `-D warnings` clean.

No production Rust changed; this is a gate and its documentation.
