### PR TITLE
Repoint the vsock-only-egress gate at its real workload paths

### DIFF
--- a/specs/sprint/delivery/2400-vsock-egress-gate-paths.md
+++ b/specs/sprint/delivery/2400-vsock-egress-gate-paths.md
@@ -1,0 +1,47 @@
+# 2400 — check-vsock-only-egress was scanning zero files
+
+The claim-10 witness `xtask check-vsock-only-egress` had been passing
+vacuously. `GUARDED_PATHS` still named the pre-driver-seam locations under
+`crates/mvm-runtime/src/{vmm,hvf,driver/fc.rs,libkrun.rs,vsock_egress_bridge}`,
+all of which moved to `mvm-vmm` and `mvm-backends` during the driver-seam
+convergence. `collect_rs_files` no-ops on a path that is neither a file nor a
+directory, so every entry resolved to nothing and the gate printed
+`clean (0 files; …)` — reporting a security claim as verified after reading no
+source at all.
+
+The claim itself was never violated: the production drivers are NIC-free, and
+that was confirmed by hand. What was broken was the evidence.
+
+## Delivered
+
+- `GUARDED_PATHS` repointed at the six paths that implement a workload guest's
+  device model and production launch paths today: `mvm-vmm`'s `vmm/` and
+  `vsock_egress_bridge/`, plus the `driver/{fc,hvf,hvf_restore,libkrun}`
+  `VmmDriver` impls in `mvm-backends`.
+- `driver/qemu.rs` and everything under `legacy/` excluded, with the reason
+  recorded in the module docs: QEMU is a Tier-2 dev/test backend ADR-001
+  deliberately keeps outside claim-10 egress enforcement, and the legacy shims
+  are bench/example-only, unreached from `AnyBackend`'s production dispatch.
+  `fc/snapshot.rs` is excluded too — it parses the `network-interfaces`
+  snapshot field in order to assert it is empty, so guarding it would flag its
+  own fail-closed check.
+- Two backstops against silent rot: `check_guarded_paths_exist` turns a missing
+  guarded path into a hard error naming the stale entry, and
+  `check_scanned_file_floor` fails closed when the scan covers fewer files than
+  the guard list should hold, rather than reporting a suspiciously small
+  "clean".
+
+Files scanned: **0 → 24** across 6 guarded paths.
+
+## Witnesses
+
+`xtask/src/check_vsock_only_egress.rs` tests, all in `cargo nextest run -p xtask`:
+
+- `every_guarded_path_exists_in_this_workspace` — goes red the next time one of
+  these paths moves, instead of the gate going quiet.
+- `check_guarded_paths_exist_names_every_stale_entry` — the error names each
+  missing entry.
+- `check_scanned_file_floor_rejects_a_near_empty_scan` — the exact old failure
+  mode (zero files reading as clean) now fails.
+- `scan_files_forbidden_skips_comments_and_flags_code_tokens` — the gate still
+  catches a real forbidden token and still ignores prose.

--- a/xtask/src/check_vsock_only_egress.rs
+++ b/xtask/src/check_vsock_only_egress.rs
@@ -20,15 +20,15 @@
 //!   (`mvm-cli/src/bench/probe.rs`, `examples/hvf-backend-*.rs`). QEMU's
 //!   legacy shell in particular attaches a real `virtio-net-pci` slirp NIC on
 //!   purpose — QEMU is a Tier-2 dev/test backend never used by `mvmd`, and
-//!   ADR-001 deliberately does not wire claim-10 egress enforcement into it.
+//!   claim-10 egress enforcement is deliberately not wired into it.
 //! * `crates/mvm-backends/src/fc/snapshot.rs` — parses Firecracker's
 //!   `network-interfaces` snapshot field *in order to assert it is empty*
 //!   (`assert_vsock_only_device_model`). Guarding this file would flag its
 //!   own fail-closed check and its negative-path tests as violations.
 //!
-//! `crates/mvm-backends/src/driver/qemu.rs` is excluded for the same
-//! ADR-001 reason as the legacy QEMU shell above: QEMU is dev/test-only and
-//! out of the claim-10 workload tier.
+//! `crates/mvm-backends/src/driver/qemu.rs` is excluded for the same reason
+//! as the legacy QEMU shell above: QEMU is dev/test-only and out of the
+//! claim-10 workload tier.
 
 use anyhow::{Result, bail};
 use regex::Regex;

--- a/xtask/src/check_vsock_only_egress.rs
+++ b/xtask/src/check_vsock_only_egress.rs
@@ -3,26 +3,68 @@
 //! vsock-only egress: a workload guest's only off-guest channel is vsock — there is **no
 //! guest NIC**, and egress flows guest → vsock → the host endpoint seam. This gate
 //! locks that in for the converged vsock-only path (the portable `vmm` device
-//! model + the raw-HVF backend): a regression that attaches a virtio-net device,
-//! a tap, or a userspace net gateway to that path re-introduces a guest NIC and
-//! fails closed here.
+//! model + the per-backend `VmmDriver` workload drivers): a regression that
+//! attaches a virtio-net device, a tap, or a userspace net gateway to that path
+//! re-introduces a guest NIC and fails closed here.
 //!
-//! Scope note: this gate covers the converged workload paths and fails closed
-//! if any of them grows a guest NIC or alternate host gateway.
+//! Scope note: this gate covers the converged workload paths — the ones a real
+//! `mvmctl up`/`mvmctl run` boot goes through — and fails closed if any of them
+//! grows a guest NIC or alternate host gateway. It deliberately excludes two
+//! kinds of code that legitimately mention these tokens without being a
+//! workload-NIC regression:
+//!
+//! * `crates/mvm-backends/src/legacy/` — the pre-`VmmDriver` backend shims.
+//!   Every production launch path (`AnyBackend`'s hvf/libkrun/fc/qemu
+//!   variants) goes through `crate::driver`, not these; the legacy shims are
+//!   identity/capability delegates plus a bench/example-only boot path
+//!   (`mvm-cli/src/bench/probe.rs`, `examples/hvf-backend-*.rs`). QEMU's
+//!   legacy shell in particular attaches a real `virtio-net-pci` slirp NIC on
+//!   purpose — QEMU is a Tier-2 dev/test backend never used by `mvmd`, and
+//!   ADR-001 deliberately does not wire claim-10 egress enforcement into it.
+//! * `crates/mvm-backends/src/fc/snapshot.rs` — parses Firecracker's
+//!   `network-interfaces` snapshot field *in order to assert it is empty*
+//!   (`assert_vsock_only_device_model`). Guarding this file would flag its
+//!   own fail-closed check and its negative-path tests as violations.
+//!
+//! `crates/mvm-backends/src/driver/qemu.rs` is excluded for the same
+//! ADR-001 reason as the legacy QEMU shell above: QEMU is dev/test-only and
+//! out of the claim-10 workload tier.
 
 use anyhow::{Result, bail};
 use regex::Regex;
 use std::path::{Path, PathBuf};
 
-/// Files/directories that implement the current no-guest-NIC path. These must
-/// stay free of guest-NIC and legacy helper tokens.
+/// Files/directories that implement the current no-guest-NIC workload path.
+/// These must stay free of guest-NIC and legacy helper tokens.
+///
+/// Every entry here must exist — `run` treats a missing entry as a hard
+/// error rather than silently scanning zero files, because that's exactly
+/// how this gate went vacuous before: a refactor moved every one of these
+/// paths and nothing noticed.
 const GUARDED_PATHS: &[&str] = &[
-    "crates/mvm-runtime/src/vmm",
-    "crates/mvm-runtime/src/hvf",
-    "crates/mvm-runtime/src/driver/fc.rs",
-    "crates/mvm-runtime/src/libkrun.rs",
-    "crates/mvm-runtime/src/vsock_egress_bridge",
+    // Portable, hypervisor-agnostic device model (virtio-mmio: console,
+    // block, entropy, vsock). No hypervisor FFI, no NIC device, shared by
+    // every backend that drives it (HVF today).
+    "crates/mvm-vmm/src/vmm",
+    // The vsock egress seam — the single claim-10 decision point every
+    // workload backend's substitution endpoint shares.
+    "crates/mvm-vmm/src/vsock_egress_bridge",
+    // `FcDriver` — Firecracker's sole production `VmmDriver` workload path.
+    "crates/mvm-backends/src/driver/fc.rs",
+    // `HvfDriver` — HVF's sole production `VmmDriver` workload path.
+    "crates/mvm-backends/src/driver/hvf.rs",
+    // Booting a fresh HVF VMM from a checkpoint — same production family as
+    // `hvf.rs`, same NIC-less contract.
+    "crates/mvm-backends/src/driver/hvf_restore.rs",
+    // `LibkrunDriver` — libkrun's sole production `VmmDriver` workload path.
+    "crates/mvm-backends/src/driver/libkrun.rs",
 ];
+
+/// Below this many scanned files, treat the guard list as broken rather than
+/// trust a "clean" result — the second backstop for the failure mode that
+/// let this gate rot silently: a near-empty scan reads as passing even
+/// though it is barely checking anything.
+const MIN_EXPECTED_FILES: usize = 20;
 
 /// Tokens that signal a guest NIC / userspace net gateway on the data path.
 /// `virtio_net`/`virtio-net`, a virtio net device id, tap attach, or the
@@ -41,8 +83,13 @@ const FORBIDDEN: &[&str] = &[
 ];
 
 pub fn run(workspace: &Path) -> Result<()> {
+    check_guarded_paths_exist(workspace)?;
+
     let re = forbidden_regex();
     let rs_files = guarded_rs_files(workspace)?;
+
+    check_scanned_file_floor(rs_files.len())?;
+
     let hits = scan_files_forbidden(workspace, &rs_files, &re);
 
     if !hits.is_empty() {
@@ -53,9 +100,50 @@ pub fn run(workspace: &Path) -> Result<()> {
         );
     }
     eprintln!(
-        "check-vsock-only-egress: clean ({} files; the vmm/HVF workload path is NIC-free)",
-        rs_files.len()
+        "check-vsock-only-egress: clean — {} files scanned across {} guarded paths, \
+         no guest-NIC/net-gateway token found. The vmm/HVF/libkrun/FC workload path is NIC-free.",
+        rs_files.len(),
+        GUARDED_PATHS.len(),
     );
+    Ok(())
+}
+
+/// Every entry in `GUARDED_PATHS` must exist on disk. A guard that silently
+/// scans zero files because its targets moved reads as a passing check —
+/// which is exactly the bug this function exists to prevent from recurring.
+fn check_guarded_paths_exist(workspace: &Path) -> Result<()> {
+    let missing: Vec<&str> = GUARDED_PATHS
+        .iter()
+        .filter(|guarded| !workspace.join(guarded).exists())
+        .copied()
+        .collect();
+
+    if !missing.is_empty() {
+        bail!(
+            "check-vsock-only-egress: GUARDED_PATHS is stale — the following guarded \
+             path(s) do not exist on disk and the check would silently scan nothing for \
+             them:\n{}\n\
+             Update GUARDED_PATHS in xtask/src/check_vsock_only_egress.rs to point at \
+             wherever this code actually moved.",
+            missing.join("\n")
+        );
+    }
+    Ok(())
+}
+
+/// A scan that covers far fewer files than the guarded paths hold is a broken
+/// gate, not a clean result — the second backstop against silent rot.
+fn check_scanned_file_floor(scanned: usize) -> Result<()> {
+    if scanned < MIN_EXPECTED_FILES {
+        bail!(
+            "check-vsock-only-egress: only {scanned} files scanned across {} guarded paths — \
+             below the expected floor of {MIN_EXPECTED_FILES}. Either GUARDED_PATHS has \
+             drifted from the real workload code again, or a path resolved to something \
+             far smaller than it should. Treating this as a broken gate rather than a \
+             clean result.",
+            GUARDED_PATHS.len(),
+        );
+    }
     Ok(())
 }
 
@@ -136,6 +224,33 @@ mod tests {
         files.sort();
 
         assert_eq!(files, vec![nested, single]);
+    }
+
+    #[test]
+    fn every_guarded_path_exists_in_this_workspace() {
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        check_guarded_paths_exist(&workspace).expect("GUARDED_PATHS must point at live code");
+    }
+
+    #[test]
+    fn check_guarded_paths_exist_names_every_stale_entry() {
+        let empty = tempfile::tempdir().expect("tempdir");
+        let err = check_guarded_paths_exist(empty.path()).expect_err("empty tree must fail");
+        let msg = err.to_string();
+        for guarded in GUARDED_PATHS {
+            assert!(msg.contains(guarded), "{guarded} missing from: {msg}");
+        }
+    }
+
+    #[test]
+    fn check_scanned_file_floor_rejects_a_near_empty_scan() {
+        // The exact failure this backstop exists for: the guard list rotted,
+        // nothing matched, and zero files read as "clean".
+        let err = check_scanned_file_floor(0).expect_err("zero files must fail");
+        assert!(err.to_string().contains("only 0 files scanned"));
+
+        check_scanned_file_floor(MIN_EXPECTED_FILES).expect("at the floor is fine");
+        check_scanned_file_floor(MIN_EXPECTED_FILES - 1).expect_err("below the floor must fail");
     }
 
     #[test]


### PR DESCRIPTION
Closes #2400.

## The defect

`xtask check-vsock-only-egress` — the CI witness that a workload guest has no NIC and that egress is vsock-only (claim 10) — was scanning **zero files** and printing:

```
check-vsock-only-egress: clean (0 files; the vmm/HVF workload path is NIC-free)
```

`GUARDED_PATHS` still named the pre-driver-seam locations under `crates/mvm-runtime/src/{vmm,hvf,driver/fc.rs,libkrun.rs,vsock_egress_bridge}`. All five moved to `mvm-vmm` and `mvm-backends` during the driver-seam convergence. `collect_rs_files` silently no-ops on a path that is neither a file nor a directory, so every entry resolved to nothing.

**The claim itself was never violated** — the production drivers are NIC-free, and that was confirmed by reading them. What was broken was the evidence. A gate that passes when its targets vanish is worse than no gate, because it reads as proof.

## The fix

Repoint `GUARDED_PATHS` at the six paths that implement a workload guest's device model and production launch paths today:

- `crates/mvm-vmm/src/vmm` — the portable virtio-mmio device model
- `crates/mvm-vmm/src/vsock_egress_bridge` — the shared claim-10 decision point
- `crates/mvm-backends/src/driver/{fc,hvf,hvf_restore,libkrun}.rs` — the four production `VmmDriver` workload paths

Two exclusions, with the reason recorded in the module docs so the next reader doesn't have to re-derive it:

- `driver/qemu.rs` and everything under `legacy/` — QEMU is a Tier-2 dev/test backend ADR-001 deliberately keeps outside claim-10 egress enforcement (its legacy shell attaches a slirp NIC on purpose), and the legacy shims are bench/example-only, unreached from `AnyBackend`'s production dispatch.
- `fc/snapshot.rs` — it parses Firecracker's `network-interfaces` snapshot field *in order to assert it is empty*, so guarding it would flag its own fail-closed check and its negative-path tests.

## Backstops against this recurring

The repoint alone would leave the same trap armed for the next refactor. Two additions close it:

- `check_guarded_paths_exist` — a missing guarded path is now a hard error naming the stale entry, instead of a silent zero-file scan.
- `check_scanned_file_floor` — a scan covering fewer files than the guard list should hold fails closed, instead of reporting a suspiciously small "clean".

The success line now reports both the file count and the path count, so a shrinking scan is visible rather than inferred.

## Result

| | before | after |
|---|---|---|
| files scanned | 0 | **24** across 6 guarded paths |

## Witnesses

In `cargo nextest run -p xtask` (all 553 pass; clippy and fmt clean):

- `every_guarded_path_exists_in_this_workspace` — goes red the next time one of these paths moves, rather than the gate going quiet
- `check_guarded_paths_exist_names_every_stale_entry` — the error names each missing entry
- `check_scanned_file_floor_rejects_a_near_empty_scan` — the exact old failure mode now fails
- `scan_files_forbidden_skips_comments_and_flags_code_tokens` — the gate still catches a real forbidden token and still ignores prose