### PR TITLE
Correct claim 18's limits to what main actually enforces

### DIFF
--- a/specs/adrs/001-microvm-security-posture.md
+++ b/specs/adrs/001-microvm-security-posture.md
@@ -241,8 +241,8 @@ not paraphrase this row without them.
 
 **Preview 18 limits — what the resource bound does and does not enforce.**
 
-1. **CPU is enforced on Linux and declared-only on macOS. (OPEN,
-   permanent on macOS.)** The mechanism is a cgroup v2 `cpu.max` on a
+1. **CPU is enforced on Linux and declared-only on macOS. (OPEN; not
+   built on macOS rather than impossible there.)** The mechanism is a cgroup v2 `cpu.max` on a
    systemd transient scope. macOS has no equivalent — thread QoS is priority,
    not quota — so `ResourceControls::for_backend` answers `CpuControl::None`
    there and the enforceability gate refuses a CPU grant under `--prod` and
@@ -254,29 +254,45 @@ not paraphrase this row without them.
    `fn:prod_refuses_a_cpu_grant_on_a_backend_that_cannot_bound_cpu`,
    `fn:a_share_grant_binds_the_spawn_when_the_mechanism_is_present` and
    `fn:a_vm_with_no_recorded_scope_reads_back_as_declared_not_as_an_error`.
-2. **Wall clock has no mechanism at all. (OPEN.)** A `WallClockGrant::Secs`
-   is parsed, ceiling-checked, admitted, projected and audited, and nothing
-   ever kills the workload. There is no supervisor timer in this tree;
-   `WallClockControl::SupervisorTimer` in the capability table is a
-   declaration of what the tier *could* bound, and `negotiate_grants` accepts
-   a wall-clock grant against it, which means such a grant passes the `--prod`
-   enforceability gate today with nothing behind it. The negotiation half is
-   witnessed by `fn:a_wall_clock_bound_needs_a_clock_that_can_stop_the_workload`;
-   the enforcement half has no witness because it has no code. Read every
-   `supervisor:timer` tier label in an audit chain accordingly.
-3. **wasm fuel and epoch are declared, not wired. (OPEN.)** The wasm tier
-   advertises `WasmFuel` and `WasmEpoch` and its backend does not override
-   `apply_grants`, so it honestly reports `Declared`. The capability
-   declaration is checked; the enforcement is absent.
-4. **A restored or warm-claimed child is admission-bounded, not
-   spawn-bounded. (OPEN.)** A restored child boots under its own admitted
-   plan, so its charge is checked against the ceiling and counted against the
-   budget — but the restore spawns a fresh VMM without re-entering the
-   scope-binding path, so no `cpu.max` is re-armed and its CPU bound is a
-   ledger entry rather than an enforcement. A warm-claimed child is worse: the
-   standby parent is deliberately spawned with no CPU grant, and the claim
-   path applies none either, so the child is unbounded by its parent for CPU
-   and, per limit 2, for wall clock.
+   Note the qualifier: macOS has no *host-level* quota primitive, but HVF is
+   an in-house VMM, so bounding a guest by time-slicing its own vCPU threads
+   is implementable — substantial work, not a closed door. Recorded so the
+   distinction between "nobody has built it" and "cannot be built" does not
+   quietly harden into the latter.
+2. **Wall clock is enforced on libkrun only. (PARTIAL.)** The mechanism is a
+   supervisor-side timer that audits `plan.wall_clock_expired` to the
+   chain-signed log *before* killing, so an enforced timeout is
+   distinguishable from a crash; it is armed in `mvm-libkrun-supervisor`.
+   libkrun is the only tier that has one, and the reason is structural rather
+   than incidental: it is the only VMM tier with a process of ours that
+   outlives the workload. `ResourceControls::for_backend` answers
+   `WallClockControl::None` for Firecracker, QEMU, HVF, AppleContainer and
+   Docker, so a wall-clock grant on those tiers is refused under `--prod` and
+   warned under dev rather than admitted against nothing. Witnessed by
+   `fn:an_expired_workload_is_killed_and_the_kill_is_audited` and
+   `fn:a_wall_clock_bound_needs_a_clock_that_can_stop_the_workload`.
+3. **wasm fuel, epoch and store limits are wired. (CLOSED.)** The wasm tier
+   overrides `apply_grants` and reports `WasmFuel`/`WasmEpoch` from a
+   read-back rather than from a setter's return, because wasmtime exposes no
+   getter for either. Fuel and epoch are *jointly* required — a module blocked
+   inside a host call consumes no fuel, so a fuel-only grant is refused rather
+   than accepted as partial enforcement. Witnessed by
+   `fn:a_fuel_grant_halts_a_runaway_module`.
+4. **A warm-claimed child is unbounded by its parent. (PARTIAL.)** A
+   *restored* child is now spawn-bounded: its admitted grant rides
+   `RestoredChild.cpu_grant` to the restore callback, where HVF wraps the
+   supervisor spawn and Firecracker prefixes its launch line through the same
+   seams their cold boots use — witnessed by
+   `fn:a_restored_child_is_cpu_bounded_by_its_admitted_grant`.
+   A *warm-claimed* child is not, and the reason is deliberate: a factory
+   parent holds no plan, tenant or `cpu_grant` by construction, because one
+   parent serves every later claim and sealing the provisioning workload's
+   grant would bound unrelated claims to a stranger's number. The claim path
+   checks a child's grants against the parent's (so it cannot widen) but has
+   nothing to bind against. Closing this needs a grant on `StandbySpec`
+   plumbed from pool configuration — a declaring surface that does not exist
+   yet, plus a decision on whether that grant joins the pool compatibility
+   key.
 5. **The budget is not a precise cliff. (OPEN, by choice.)** Two admissions
    racing each other can both read the same total and both be admitted,
    overshooting by one boot; closing that needs a host-wide lock held across
@@ -674,7 +690,7 @@ tracked separately as a follow-up audit (see "deferred follow-ups").
 | 15 | A sealed production microVM has no shell, no DevOnly guest-agent verbs, and no PTY | fn:console_refused_on_sealed_image, ci:guest-agent-runtime-boundary, fn:prod_console_attachment_has_no_input | runtime profile + signed VerbGrant + host accessible-gate + console policy (ADR-001 §W4.3 extension). The host→guest input plane is deliberately *not* claimed here: its properties are policy, not absence, and are witnessed at row 17 | Shipped |
 | 16 | Egress substitution keeps a raw secret off the guest, bound-only, no value in audit | fn:handed_placeholders_never_contain_the_secret_value, fn:substitution_endpoint_refuses_unbound_destination, fn:audit_chain_carries_no_secret_value | egress substitution leak-gate; reinforces claims 12+13 on the egress delivery (ADR-023, specs/claims/claim-egress-no-secret-to-guest.md) | Preview |
 | 17 | Workload stdin is grant-gated, single-writer, secret-scanned across frames, and every refusal is audited | fn:input_is_refused_without_a_plan_grant, fn:a_second_writer_is_refused_while_the_lease_is_held, fn:secret_material_split_across_frames_is_still_refused, fn:every_refusal_is_audited, fn:a_shell_entrypoint_with_the_grant_is_refused_and_names_the_reason, fn:the_endpoint_fingerprints_what_it_resolved_and_reports_no_value, fn:the_handshakes_two_halves_go_to_two_different_places, fn:a_secret_split_across_two_frames_does_not_reassemble_in_the_workload, fn:a_fingerprint_refusal_does_not_claim_the_bytes_are_the_secret | input grant token in a signed ExecutionPlan.services + per-VM lease with TTL + fingerprint-matching sliding-window secret scan + chain-signed payload-free refusal audit + sealed-tier shell-entrypoint refusal. Read the limits note below before treating this as enforced | Preview |
-| 18 | A workload's resource consumption is bounded at admission — per workload and across the host — and CPU-bound at spawn where the host has a mechanism | fn:a_boot_past_the_headroom_is_refused, fn:budget_ignores_dead_machines, fn:budget_counts_the_configured_maximum_not_current_usage, fn:an_empty_host_admits_a_boot_within_headroom, fn:an_unreadable_charge_record_is_skipped_rather_than_fatal, fn:admission_refuses_a_grant_over_the_ceiling, fn:the_ceiling_bounds_memory_even_though_no_one_granted_it, fn:prod_refuses_a_cpu_grant_on_a_backend_that_cannot_bound_cpu, fn:the_libkrun_tier_cannot_bound_cpu_off_linux, fn:a_share_grant_binds_the_spawn_when_the_mechanism_is_present, fn:a_vm_with_no_recorded_scope_reads_back_as_declared_not_as_an_error, fn:an_admitted_boot_writes_the_achieved_tier_to_the_audit_chain, fn:a_wall_clock_bound_needs_a_clock_that_can_stop_the_workload, fn:a_granted_cpu_share_binds_a_real_spawn_to_its_quota | operator-configured per-workload ceiling + host-wide budget summed over live machines only (pid-marker probe, configured maximum not current usage) + cgroup v2 `cpu.max` on a systemd transient scope, read back and written to the chain-signed audit log. CPU is declared-only off Linux, wall clock has no mechanism at all, and a restored or warm-claimed child is not re-bound — read the "Preview 18 limits" note below before treating this as enforced | Preview |
+| 18 | A workload's resource consumption is bounded at admission — per workload and across the host — and CPU-bound at spawn where the host has a mechanism | fn:a_boot_past_the_headroom_is_refused, fn:budget_ignores_dead_machines, fn:budget_counts_the_configured_maximum_not_current_usage, fn:an_empty_host_admits_a_boot_within_headroom, fn:an_unreadable_charge_record_is_skipped_rather_than_fatal, fn:admission_refuses_a_grant_over_the_ceiling, fn:the_ceiling_bounds_memory_even_though_no_one_granted_it, fn:prod_refuses_a_cpu_grant_on_a_backend_that_cannot_bound_cpu, fn:the_libkrun_tier_cannot_bound_cpu_off_linux, fn:a_share_grant_binds_the_spawn_when_the_mechanism_is_present, fn:a_vm_with_no_recorded_scope_reads_back_as_declared_not_as_an_error, fn:an_admitted_boot_writes_the_achieved_tier_to_the_audit_chain, fn:a_wall_clock_bound_needs_a_clock_that_can_stop_the_workload, fn:a_granted_cpu_share_binds_a_real_spawn_to_its_quota | operator-configured per-workload ceiling + host-wide budget summed over live machines only (pid-marker probe, configured maximum not current usage) + cgroup v2 `cpu.max` on a systemd transient scope, read back and written to the chain-signed audit log. CPU is declared-only off Linux, wall clock is enforced on libkrun only, wasm bounds via fuel and epoch, a restored child is re-bound at spawn and a warm-claimed one is not — read the "Preview 18 limits" note below before treating this as enforced | Preview |
 
 Row 16 is the egress-substitution leak-gate. Like claim 14 (OCI provenance),
 it is registered here for witness machine-checking and tracked by its own doc


### PR DESCRIPTION
## Summary

Claim 18's limits note described a weaker system than the one on `main`. Three of its five limits were stale — all understating what is enforced.

The row was written against a tree that predated the wasm-bounds (#2355), wall-clock (#2356) and restored-child (#2363) PRs. Those landed afterwards, and nothing re-checked the prose against them.

Understating is the safe direction, but a ledger that misdescribes the system is still a defect — and in a repo where `check-claim-catalog` treats this table as authoritative, "no mechanism exists" when a measured, audited one does is exactly the drift that makes claims untrustworthy. Every correction below was verified against the code before writing.

## What changed

**Limit 2 — wall clock.** Said "no mechanism at all… no supervisor timer in this tree". There is one: armed in `mvm-libkrun-supervisor`, auditing `plan.wall_clock_expired` to the chain-signed log *before* killing, so an enforced timeout is distinguishable from a crash. libkrun is the only tier that has one, and the reason is structural — it is the only VMM tier with a process of ours that outlives the workload. The other five answer `WallClockControl::None`, so a grant there is refused under `--prod` rather than admitted against nothing. Now `PARTIAL`.

**Limit 3 — wasm.** Said "declared, not wired… does not override `apply_grants`". It does override it, and reports `WasmFuel`/`WasmEpoch` from a read-back rather than a setter's return, because wasmtime exposes no getter for either. Now `CLOSED`.

**Limit 4 — restored child.** Said no `cpu.max` is re-armed. A restored child is now spawn-bounded: its admitted grant rides `RestoredChild.cpu_grant` to the restore callback, where HVF wraps the supervisor spawn and Firecracker prefixes its launch line, through the same seams their cold boots use. The *warm-claimed* half remains open, and the note now carries the reason rather than just the fact: a factory parent deliberately holds no grant, because one parent serves every later claim and sealing the provisioning workload's would bound unrelated claims to a stranger's number. Now `PARTIAL`.

**Limit 1 — macOS.** Softened "permanent on macOS" to "not built on macOS rather than impossible there". macOS has no host-level quota primitive, but HVF is an in-house VMM, so bounding a guest by time-slicing its own vCPU threads is implementable — substantial work, not a closed door. Recorded so the distinction between *nobody has built it* and *cannot be built* does not harden by omission.

Limit 5 (budget precision) was accurate and is unchanged. The claims-table row's one-line summary carried the same stale text and is corrected to match.

## Validation

Every witness cited was confirmed to exist before being named. Gates: `check-claim-catalog`, `check-witness-citations`, `check-honesty`, `check-doc-claims`, `check-no-overclaim`, `check-adr-coverage` — all pass.

Documentation only; no code changed.
