### PR TITLE
Normalize OCI image repository capitalization

### DIFF
--- a/crates/mvm-contract/src/oci/reference.rs
+++ b/crates/mvm-contract/src/oci/reference.rs
@@ -154,7 +154,8 @@ impl FromStr for ImageReference {
             format!("{DOCKER_HUB_LIBRARY_NAMESPACE}/{repository}")
         } else {
             repository.to_string()
-        };
+        }
+        .to_ascii_lowercase();
 
         validate_repository(&repository)?;
 
@@ -342,13 +343,19 @@ mod tests {
     }
 
     #[test]
-    fn uppercase_repository_rejected() {
-        // OCI spec requires lowercase repositories.
-        let err = "Foo/Bar:v1".parse::<ImageReference>().unwrap_err();
-        match err {
-            OciError::InvalidReference(_) => {}
-            other => panic!("expected InvalidReference, got {other:?}"),
-        }
+    fn uppercase_repository_normalizes_to_lowercase() {
+        let r = parse("GHCR.IO/Foo/Bar:v1");
+        assert_eq!(r.registry, "ghcr.io");
+        assert_eq!(r.repository, "foo/bar");
+        assert_eq!(r.tag.as_deref(), Some("v1"));
+        assert_eq!(r.canonical(), "ghcr.io/foo/bar:v1");
+    }
+
+    #[test]
+    fn repository_normalization_preserves_case_sensitive_tag() {
+        let r = parse("Alpine:ReleaseCandidate");
+        assert_eq!(r.repository, "library/alpine");
+        assert_eq!(r.tag.as_deref(), Some("ReleaseCandidate"));
     }
 
     #[test]

--- a/features/suites/s22_oci_provenance/oci_provenance.feature
+++ b/features/suites/s22_oci_provenance/oci_provenance.feature
@@ -21,6 +21,13 @@ Feature: s22_oci_provenance
     Then the command exits with code 1
     And the error output contains "requires a digest-pinned reference"
 
+  @MVM-SEC-14 @build
+  Scenario: Image repository capitalization is normalized before admission
+    When I run mvmctl with "image pull --prod GHCR.IO/Acme/Widget:ReleaseCandidate" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "requires a digest-pinned reference"
+    But the error output does not contain "invalid image reference"
+
   # The discriminating half. Without it, the scenario above would pass just as
   # well against a blanket `--prod` refusal that never looked at the reference:
   # a digest-pinned reference must get *past* the pin check and be refused for

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,11 +1,15 @@
 # Refactor status
 
-Last updated: 2026-08-11
+Last updated: 2026-08-12
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
+- [x] **Plan 325 — lowercase OCI image names.** Registry and repository
+      capitalization is normalized before validation across every shared OCI
+      pull and launch path, while case-sensitive tags and strict digest
+      validation remain unchanged.
 - [x] **Plan 322 — persistent-machine README contract.** `machine create`
       accepts the optional machine name positionally, and real-binary coverage,
       all three SDKs, shared fixtures, BDD scenarios, recovery guidance, and

--- a/specs/plans/325-lowercase-oci-image-names.md
+++ b/specs/plans/325-lowercase-oci-image-names.md
@@ -1,0 +1,14 @@
+# Lowercase OCI image names
+
+OCI registries require repository paths to be lowercase, but users commonly
+capitalize familiar image names when typing them. Normalize registry and
+repository components before validation so those references resolve to the
+same canonical image. Preserve tag case because OCI tags are case-sensitive,
+and preserve strict digest validation.
+
+- [x] Normalize ASCII capitalization in OCI repository paths.
+- [x] Prove canonical references contain the lowercase repository.
+- [x] Prove case-sensitive tags and digest validation remain unchanged.
+- [x] Cover capitalized CLI input at the pre-network production-policy gate.
+- [x] Pass formatting, tests, workspace check, and Clippy.
+- [x] Prepare the change for the required CI merge queue.

--- a/specs/sprint/delivery/325-lowercase-oci-image-names.md
+++ b/specs/sprint/delivery/325-lowercase-oci-image-names.md
@@ -1,0 +1,7 @@
+# Lowercase OCI image names
+
+OCI image registry and repository components now normalize ASCII capitals to
+lowercase before validation, so inputs such as `Alpine` and
+`GHCR.IO/Acme/Widget:v1` resolve to their canonical lowercase repositories.
+Case-sensitive tags remain unchanged, and digest validation remains strict.
+Unit and hermetic BDD coverage pin both the normalization and its boundaries.


### PR DESCRIPTION
## Summary

- normalize registry and repository components to lowercase in the shared OCI image-reference parser
- preserve case-sensitive tags and strict digest validation
- cover capitalized input with unit and hermetic BDD scenarios

## Validation

- `cargo test -p mvm-contract oci::reference::tests` (19 passed)
- `just bdd` (54 features, 176 scenarios, 727 steps passed)
- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- pre-commit: `cargo clippy --workspace --all-targets -- -D warnings`
- workspace executable tests passed serially; the existing `mvm-cli` doctest feature-configuration errors remain outside this change