### PR TITLE
Name an unknown flag instead of shipping it to the guest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,8 +225,11 @@ thiserror = "2"
 toml = "0.8"
 
 # CLI
+# `error-context` is what makes a parse error name the offending argument;
+# without it clap prints only the error kind ("unexpected argument found").
 clap = { version = "4", default-features = false, features = [
     "derive",
+    "error-context",
     "help",
     "std",
     "usage",

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -400,7 +400,10 @@ pub(in crate::commands) struct MachineRunArgs {
     )]
     pub attach: bool,
     /// Command and arguments to run in the guest.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    // No `allow_hyphen_values`: it makes an unrecognized flag a silent argv
+    // element, so a typo boots a VM and fails inside the guest shell instead of
+    // being named here. Hyphenated guest argv still works after `--`.
+    #[arg(trailing_var_arg = true)]
     pub argv: Vec<String>,
 }
 
@@ -980,7 +983,7 @@ pub(in crate::commands) struct MachineExecArgs {
     pub interactive: bool,
     /// Argv to run inside the guest (use `--` to separate). Omit to drop into
     /// an interactive shell, like `machine shell`.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    #[arg(trailing_var_arg = true)]
     pub argv: Vec<String>,
 }
 

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -251,6 +251,38 @@ fn run_parses_image_and_trailing_argv() {
 }
 
 #[test]
+fn run_rejects_an_unknown_flag_before_the_argv_separator() {
+    // Swallowing it into argv ships the typo to the guest shell, which answers
+    // with something like `exec: illegal option --` instead of naming the flag.
+    let err = parse_run(&[
+        "run",
+        "--image",
+        "alpine",
+        "--nonexistent",
+        "8080:80",
+        "--",
+        "uname",
+        "-a",
+    ])
+    .expect_err("unknown flag must not be swallowed into argv");
+    assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+}
+
+#[test]
+fn exec_rejects_an_unknown_flag_before_the_argv_separator() {
+    let err = parse(&["exec", "web", "--nonexistent", "--", "uname", "-a"])
+        .expect_err("unknown flag must not be swallowed into argv");
+    assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+}
+
+#[test]
+fn run_keeps_hyphenated_argv_after_the_separator() {
+    let args = parse_run(&["run", "--image", "alpine", "--", "uname", "-a", "--all"])
+        .expect("hyphenated argv after `--` stays argv");
+    assert_eq!(args.argv, vec!["uname", "-a", "--all"]);
+}
+
+#[test]
 fn run_parses_hypervisor_flag_and_forwards_to_run_args() {
     let args = parse_run(&[
         "run",
@@ -2680,16 +2712,11 @@ fn machine_run_exposes_no_network_mode_selector() {
             "machine run must not expose a networking transport selector, found {id:?}"
         );
     }
-    // `argv` is a trailing var-arg, so a stray `--network-mode` is not
-    // rejected — it is collected as workload arguments. What matters is
-    // that it configures nothing: the transport is derived either way.
-    let args = parse_run(&["run", "--image", "alpine", "--network-mode", "l3-vsock"])
-        .expect("trailing args parse as workload argv");
-    assert!(
-        args.argv.iter().any(|a| a == "--network-mode"),
-        "a stray flag must land in the workload's argv, not configure mvm: {:?}",
-        args.argv
-    );
+    // A stray `--network-mode` configures nothing: it is not an mvm flag, and
+    // it is refused rather than smuggled into the workload's argv.
+    let err = parse_run(&["run", "--image", "alpine", "--network-mode", "l3-vsock"])
+        .expect_err("a transport selector must not parse");
+    assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
 }
 
 /// The default is the socket-aware transport — the stronger posture, and

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -68,11 +68,9 @@ pub(in crate::commands) struct Args {
     pub launch_plan: Option<String>,
     /// Argv to run inside the guest (use `--` to separate). Required unless
     /// `--launch-plan` is supplied.
-    #[arg(
-        trailing_var_arg = true,
-        allow_hyphen_values = true,
-        required_unless_present = "launch_plan"
-    )]
+    // No `allow_hyphen_values`: it turns an unrecognized flag into a silent
+    // argv element, so a typo fails inside the guest shell instead of here.
+    #[arg(trailing_var_arg = true, required_unless_present = "launch_plan")]
     pub argv: Vec<String>,
     /// Internal (not a CLI flag): stdin bytes to forward into the guest `Exec`
     /// frame. Empty ⇒ no stdin (`Exec.stdin = None`). Populated at the
@@ -221,9 +219,9 @@ pub(in crate::commands) struct RunArgs {
     /// Argv to run inside the guest (use `--` to separate). Required unless
     /// `--launch-plan` is supplied. Under `--mode plan`, the first
     /// argv element is a `.py`/`.ts`/`.js` script path.
+    // No `allow_hyphen_values` — see `Args::argv` above.
     #[arg(
         trailing_var_arg = true,
-        allow_hyphen_values = true,
         required_unless_present_any = ["launch_plan", "mode", "dev", "prod"]
     )]
     pub argv: Vec<String>,

--- a/features/suites/s0_cli/machine_run_contract.feature
+++ b/features/suites/s0_cli/machine_run_contract.feature
@@ -53,7 +53,7 @@ Feature: machine run request contract
   Scenario: machine run refuses to detach an attached port forward
     When I run mvmctl with "machine run --image alpine --port 8080:3000 --detach" and an isolated mvm home
     Then the command exits with code 2
-    And the error output contains "an argument cannot be used"
+    And the error output contains "cannot be used"
 
   # Egress-enabling dry runs are deliberately absent. `--allow-host` / `--net`
   # make the dry run resolve an *available* egress-capable backend, so the

--- a/specs/sprint/delivery/2401-unknown-flag-not-swallowed-into-argv.md
+++ b/specs/sprint/delivery/2401-unknown-flag-not-swallowed-into-argv.md
@@ -1,0 +1,20 @@
+# An unknown flag is named, not shipped to the guest
+
+`machine run`, `machine exec`, and `exec` declared their trailing argv with
+`allow_hyphen_values`, so clap stopped flag parsing at the first unrecognized
+`--flag` and collected it — and the `--` separator behind it — as guest argv.
+A typo boots a VM and dies in the guest shell with `exec: illegal option --`,
+naming the separator the caller wrote correctly instead of the flag they got
+wrong.
+
+Dropping `allow_hyphen_values` from the four trailing-argv positionals makes
+clap refuse the unknown flag by name before admission. Hyphenated argv after
+`--` is unaffected — the escape already makes the rest of the line literal —
+and the parser tests lock both halves: `--nonexistent` is an
+`UnknownArgument`, `-- uname -a --all` is still three argv elements. The
+network-transport test that asserted a stray `--network-mode` lands in argv now
+asserts it is refused; the property it guards (the flag configures nothing) is
+strictly better served.
+
+`mvm-cli` + `mvmctl` suites (1931 tests), formatting, and `mvm-cli`
+all-target Clippy pass.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -344,3 +344,40 @@ fn machine_warm_restore_json_flag_parses() {
     );
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+/// A mistyped flag must be named here, not shipped to the guest as argv where
+/// it surfaces as `/bin/sh: exec: illegal option --` after a boot the caller
+/// already paid for.
+#[test]
+fn machine_run_names_an_unknown_flag_instead_of_booting() {
+    let tmp = tempfile::tempdir().unwrap();
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .env("HOME", tmp.path())
+        .env("MVM_HOME", tmp.path())
+        .env("MVM_NO_AUTO_DEV", "1")
+        .args([
+            "machine",
+            "run",
+            "--image",
+            "alpine",
+            "--no-such-flag",
+            "8080:80",
+            "--",
+            "uname",
+            "-a",
+        ])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success(), "an unknown flag must not run");
+    assert!(
+        stderr.contains("--no-such-flag"),
+        "the error must name the flag, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("illegal option"),
+        "the flag must never reach a guest shell, stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
Fixes #2401.

```
$ mvmctl machine run --image alpine --port 8080:80 -- uname -a
/bin/sh: exec: line 2: illegal option --
```

`machine run`, `machine exec`, and `exec` declared their trailing argv with `allow_hyphen_values`, so clap stopped flag parsing at the first unrecognized `--flag` and collected it — plus the `--` separator behind it — as guest argv. The VM boots, the guest shell chokes on a separator the caller wrote correctly, and the flag that was actually wrong is never mentioned. (In the report above the flag was `--port` on a binary older than #2386; any typo does the same.)

**Parsing.** Dropping `allow_hyphen_values` from the four trailing-argv positionals makes clap refuse the unknown flag by name before admission. Hyphenated guest argv is unaffected: the `--` escape already makes the rest of the line literal.

**Message.** The workspace `clap` had `default-features = false` without `error-context`, so every parse error rendered through the kind-only formatter — `error: unexpected argument found`, no name, no usage. Enabling that feature restores:

```
error: unexpected argument '--no-such-flag' found

  tip: to pass '--no-such-flag' as a value, use '-- --no-such-flag'

Usage: mvmctl machine run --image <REF> [ARGV]...
```

`Cargo.lock` is unchanged — the feature adds no dependency.

**Tests.** Parser coverage locks both halves (`UnknownArgument` for `--nonexistent`; `-- uname -a --all` still three argv elements), plus a real-binary test in `tests/cli.rs` asserting the flag is named and `illegal option` never appears. The transport-selector test that asserted a stray `--network-mode` lands in argv now asserts it is refused — the property it guards (the flag configures nothing) is strictly better served.

`mvm-cli` + `mvmctl` (1932 tests), formatting, `mvm-cli` all-target Clippy, and the CLI/doc/model/closure-budget xtask gates pass.