### PR TITLE
Cover the whole security claim set in the docs, not just the first seven

### DIFF
--- a/public/astro.config.mjs
+++ b/public/astro.config.mjs
@@ -189,7 +189,7 @@ export default defineConfig({
             { label: "Matryoshka Model", slug: "security/matryoshka" },
             { label: "Security claim ledger", slug: "security/claim-ledger" },
             { label: "Threat model", slug: "security/threat-model" },
-            { label: "Seven CI claims", slug: "security/ci-claims" },
+            { label: "CI-enforced claims", slug: "security/ci-claims" },
             { label: "Verified boot", slug: "security/verified-boot" },
             { label: "Sandbox parity status", slug: "security/sandbox-parity-status" },
           ],

--- a/public/src/content/docs/security/ci-claims.md
+++ b/public/src/content/docs/security/ci-claims.md
@@ -1,32 +1,73 @@
 ---
-title: Seven CI claims
+title: CI-enforced security claims
 description: The security claims that must stay backed by tests and documentation.
 ---
 
 The public security model is claim-gated. A claim should be presented as a
 guarantee only when implementation, tests, and docs agree.
 
+This page mirrors the claims table in
+[ADR-001](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/001-microvm-security-posture.md).
+**That table is the source of truth**, not this page: it is machine-checked,
+so a claim whose named witness stops existing fails the build. When the two
+disagree, the ADR is right and this page is stale — please fix it.
+
 ## Current claim set
 
-| # | Claim | Evidence path |
+Each numbered claim is backed by a test or a CI workflow gate.
+
+| # | Claim | Category |
 | --- | --- | --- |
-| 1 | No host filesystem access beyond explicit shares. | Guest profile, seccomp, mount policy, docs examples. |
-| 2 | Guest binaries cannot elevate to uid 0. | `no_new_privs`, readonly account files, launch tests. |
-| 3 | Tampered rootfs fails where verified boot is supported. | dm-verity/root hash tests and backend caveats. |
-| 4 | Production guest agent excludes development exec handlers. | Symbol checks and profile-gated request refusal. |
-| 5 | Vsock framing is fuzzed and closed over known messages. | Fuzz targets, `deny_unknown_fields`, protocol tests. |
-| 6 | Prebuilt dev images are hash-verified. | Manifest verification before use. |
-| 7 | Supply-chain dependencies are audited on every PR. | `cargo audit`, dependency policy, CI gates. |
+| 1 | No host-filesystem access from a guest beyond explicit shares. | Guest confinement |
+| 2 | No guest binary can elevate to uid 0. | Guest confinement |
+| 3 | A tampered rootfs ext4 fails to boot, on the block+ext4 backends. | Verified boot |
+| 4 | A production-safe run cannot invoke DevOnly guest-agent verbs. | Guest confinement |
+| 5 | Vsock framing, supervisor-config JSON, and the userspace datapath's guest-facing ingress are fuzzed. | Interface hardening |
+| 6 | The pre-built dev image is hash-verified. | Supply chain |
+| 7 | Cargo dependencies are audited on every PR. | Supply chain |
+| 8 | Every workload runs from a signed, audited `ExecutionPlan`. | Admission and audit |
+| 9 | Every published bundle is content-addressed, key_id-pinned, and re-verified at fetch and at admit time. | Supply chain |
+| 10 | No untrusted workload reaches the network unless explicitly admitted by policy. | Data containment |
+| 11 | Every application-dependency volume is hash-locked, attestation-checked, CVE-scanned, SBOM-enumerated, and bound to the workload's audit chain. | Supply chain (app layer) |
+| 12 | Every host-side broker service is bound to a signed `ExecutionPlan.services` binding, enforced before handler dispatch, and audited. | Admission and audit |
+| 13 | No raw secret value crosses the broker channel. | Data containment |
+| 14 | Every OCI image admission records provenance in the chain-signed audit log. | Supply chain |
+| 15 | A sealed production microVM has no shell, no DevOnly guest-agent verbs, and no PTY. | Guest confinement |
+
+## Preview claims
+
+Three further claims have machine-checked witnesses but have not been promoted
+into ADR-001's numbered prose. Treat them as preview: the witnesses run, but
+the guarantee is narrower than a numbered claim, and each carries a limits note
+in the ADR that you should read before relying on it.
+
+| # | Claim | Why it is still preview |
+| --- | --- | --- |
+| 16 | Egress substitution keeps a raw secret off the guest — bound-only, with no value in the audit log. | Promotion is a pending maintainer decision. |
+| 17 | Workload stdin is grant-gated, single-writer, secret-scanned across frames, and every refusal is audited. | The secret scan matches a length and a rolling hash, not an identity; encoding, derivation, or a window-straddling split defeat it. |
+| 18 | A workload's resource consumption is bounded at admission, and CPU-bound at spawn where the host has a mechanism. | Admission bounding holds everywhere. CPU binding is Linux-with-systemd only, wall-clock has no enforcement mechanism at all, and a restored or warm-claimed child is not re-bound. |
+
+## What is out of scope
+
+ADR-001 names three explicit non-goals, so no claim above should be read as
+covering them:
+
+- A malicious **host**. mvm trusts the host with the hypervisor and the private
+  build keys.
+- **Multi-tenant guests.** One guest is one workload.
+- **Hardware-backed key attestation.**
 
 ## How to use this page
 
 When writing docs, link strong claims to the [Security claim ledger](/security/claim-ledger/)
 or [Matryoshka model](/security/matryoshka/). If the behavior is backend-specific,
-name the backend.
+name the backend — the [per-backend tier matrix](/security/matryoshka/#per-backend-tier-matrix)
+is where which-claims-hold-where is recorded.
 
 ## What not to claim
 
-- Do not claim the dev/test QEMU backend carries the same claims as Firecracker (claim 3 partial; Tier 2 dev/test only).
+- Do not claim the dev/test QEMU backend carries the same claims as Firecracker (claim 3 partial; Tier 2 dev/test only, and deliberately outside claim 10's egress enforcement).
 - Do not claim secret non-leakage for manual file mounts.
 - Do not claim cold-start numbers without a published benchmark.
 - Do not imply Windows local runtime support is shipped.
+- Do not describe claims 16, 17, or 18 as enforced without their limits.

--- a/public/src/content/docs/security/claim-ledger.md
+++ b/public/src/content/docs/security/claim-ledger.md
@@ -48,5 +48,5 @@ Examples of safer wording:
 Tutorials and SDK pages should link to at least one of:
 
 - [Sandbox parity status](/security/sandbox-parity-status/)
-- [Seven CI claims](/security/ci-claims/)
+- [CI-enforced security claims](/security/ci-claims/)
 - [Threat model](/security/threat-model/)

--- a/public/src/content/docs/security/matryoshka.md
+++ b/public/src/content/docs/security/matryoshka.md
@@ -1,6 +1,6 @@
 ---
 title: "The Matryoshka model: how mvm isolates untrusted code"
-description: "mvm runs untrusted Linux workloads in microVMs. This page explains the five trust layers, the seven CI-enforced security claims, and which claims hold for each backend."
+description: "mvm runs untrusted Linux workloads in microVMs. This page explains the five trust layers, the CI-enforced security claims, and which claims hold for each backend."
 ---
 
 mvm's job is to let you run **untrusted code** — third-party software, AI-generated scripts, CI runners, sandbox workloads — and trust the isolation. This page explains the security model in one diagram and one matrix.
@@ -74,19 +74,38 @@ Each layer trusts only the layer **below** it. An attacker has to break through 
 
 This pattern (sometimes called the *matryoshka* model after the nested Russian dolls) is the same defense-in-depth used across the production microVM / hardened-isolation ecosystem. mvm's adaptation is that **L5 is enforced inside the guest** — even a guest-kernel compromise doesn't give arbitrary access to other in-guest services. See [ADR-001](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/001-microvm-security-posture.md) for the full decision record.
 
-## The seven claims
+## The claims
 
-mvm makes seven CI-enforced security claims. Each one is backed by a continuous-integration check that fails the build if the claim ceases to hold.
+mvm makes fifteen CI-enforced security claims, plus three preview claims whose
+witnesses run but whose guarantee is narrower. Each one is backed by a test or a
+continuous-integration check that fails the build if the claim ceases to hold.
+The claims that defend a nesting layer are what the layer model is about; the
+rest defend the supply chain and the admission path, which decide what is
+allowed to run inside those layers at all.
 
 | # | Claim | Defends layer | How it's enforced |
 |---|---|---|---|
-| 1 | No host-fs access from a guest beyond explicit shares | L2 / L5 | Per-service uid + seccomp `standard` default + setpriv bounding-set drop |
+| 1 | No host-fs access from a guest beyond explicit shares | L2 / L5 | Per-service uid + seccomp `standard` default + setpriv bounding-set drop; user-volume allow-list defaulting to read-only |
 | 2 | No guest binary can elevate to uid 0 | L2 / L4 | `setpriv --no-new-privs` in launch path; `/etc/{passwd,group}` are read-only bind-mounts |
-| 3 | A tampered rootfs ext4 fails to boot | L3 | dm-verity sidecar + roothash on cmdline + `mvm-verity-init` initramfs |
+| 3 | A tampered rootfs ext4 fails to boot | L3 | dm-verity sidecar + roothash on cmdline + a verity-aware initramfs owning the boot pivot |
 | 4 | A production-safe run cannot invoke DevOnly guest-agent verbs | L4 | Runtime profile + signed `VerbGrant` intersection; grant and conformance tests enforce the full DevOnly set |
-| 5 | Vsock framing is fuzzed | L2 / L4 | `cargo-fuzz` targets cover every host↔guest message; `deny_unknown_fields` on every type |
-| 6 | Pre-built dev image is hash-verified | supply chain | SHA-256 manifest streamed through the download |
+| 5 | Vsock framing, supervisor-config JSON, and the datapath ingress are fuzzed | L2 / L4 | `cargo-fuzz` targets over the host↔guest messages, the supervisor config parser, and the userspace datapath ingress; `deny_unknown_fields` on every type |
+| 6 | Pre-built dev image is hash-verified | supply chain | SHA-256 manifest streamed through the download; a mismatch rejects and deletes it |
 | 7 | Cargo deps are audited on every PR | supply chain | `cargo-deny` + `cargo-audit` jobs; reproducibility double-build |
+| 8 | Every workload runs from a signed, audited `ExecutionPlan` | admission | Ed25519 host-signer keypair; validity window + nonce replay-store; chain-signed admission entries |
+| 9 | Every published bundle is content-addressed and key_id-pinned | supply chain | A rejection ladder at fetch and at admit time: unknown key, tampered manifest, key_id mismatch, unsafe path, pin drift |
+| 10 | No untrusted workload reaches the network unless policy admits it | data containment | Policy defaults to deny-all; the workload guest has no NIC, so egress leaves only over vsock to a host endpoint that authorizes it |
+| 11 | Every application-dependency volume is sealed and audited | supply chain (app layer) | A hash-locked volume carrying an SBOM, a CVE scan, and a hash-chained manifest; admission refuses a tampered volume |
+| 12 | Every broker service is bound to a signed plan binding | admission | Binding-gated dispatch, enforced before the handler runs, with a rejection ladder for unbound and out-of-profile calls |
+| 13 | No raw secret value crosses the broker channel | data containment | Destination-bound, time-bound signed credentials only; raw secret bytes never leave the supervisor's address space |
+| 14 | Every OCI image admission records provenance in the audit log | supply chain | A provenance entry carries registry, repo, resolved digest, layer digests, and trust verdict; production refuses a mutable reference |
+| 15 | A sealed production microVM has no shell, no DevOnly verbs, no PTY | L4 | Only the dev `/init` serves a console; console capture is write-only with no host input; the host gate refuses `console` on a sealed image |
+
+Three further claims — 16 (egress substitution keeps a raw secret off the
+guest), 17 (workload stdin is grant-gated and secret-scanned), and 18 (workload
+resource bounding) — are **preview**. Their witnesses run in CI, but each
+carries a limits note in ADR-001 that has to be read before treating it as
+enforced. See [CI-enforced security claims](/security/ci-claims/#preview-claims).
 
 L1 (host + hypervisor) doesn't carry its own claim — the host is **trusted** by definition. If your host is compromised, every layer falls. Locking down the host (firewall, package hygiene, full-disk encryption) is your responsibility.
 
@@ -106,14 +125,20 @@ This does **not** add a second seccomp implementation or new execution capabilit
 
 ## Per-backend tier matrix
 
-mvm runs on multiple backends. Not all backends carry all seven claims. The tier you actually get depends on which backend mvm picks for your run.
+mvm runs on multiple backends. Not all backends carry every claim. The tier you
+actually get depends on which backend mvm picks for your run.
+
+The columns below are the **nesting layers**, so this matrix covers the claims
+that defend a layer. The supply-chain and admission claims (6, 7, 8, 9, 11, 12,
+14) are backend-independent — they gate what is allowed to run before any
+backend is chosen, and hold identically across all of them.
 
 | Backend | L1 | L2 | L3 | L4 | L5 | Tier |
 |---|---|---|---|---|---|---|
-| **Firecracker** (Linux + KVM) | ✅ | ✅ | ✅ | ✅ | ✅ | **Tier 1** — full ADR-001. All seven claims hold. |
+| **Firecracker** (Linux + KVM) | ✅ | ✅ | ✅ | ✅ | ✅ | **Tier 1** — full ADR-001. Every layer-defending claim holds. |
 | **HVF** (macOS 26+ Apple Silicon — auto-default) | ✅ | ✅ | ⚠️ | ✅ | ✅ | Tier 2 — claim 3 (verified boot) partial; `Hypervisor.framework`, vsock-only egress (no guest NIC). The macOS-26 auto-default. |
 | **libkrun** (Linux KVM, macOS Apple Silicon HVF) | ✅ | ✅ | ⚠️ | ✅ | ✅ | Tier 2 — same as HVF. |
-| **QEMU** (Linux KVM/TCG) | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | Tier 2 — claim 3 partial; QEMU's larger device model raises L2 audit cost. **Dev/test only** (`--hypervisor qemu`; the no-`/dev/kvm` path via TCG software emulation). Never selected by `mvmd`. |
+| **QEMU** (Linux KVM/TCG) | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | Tier 2 — claim 3 partial; QEMU's larger device model raises L2 audit cost. Deliberately outside claim 10's egress enforcement, because it carries no untrusted multi-tenant workload. **Dev/test only** (`--hypervisor qemu`; the no-`/dev/kvm` path via TCG software emulation). Never selected by `mvmd`. |
 
 ✅ = layer fully enforced.  ⚠️ = layer partial (named exception).  ❌ = layer collapsed (claim does not apply).
 
@@ -145,6 +170,6 @@ If your threat model needs any of those, mvm is not the right tool today. ADR-00
 ## See also
 
 - [ADR-001 (full decision record)](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/001-microvm-security-posture.md)
-- [Plan 25 (microVM hardening — the implementation sequence for the seven claims)](https://github.com/tinylabscom/mvm/blob/main/specs/plans/25-microvm-hardening.md)
+- [Plan 25 (microVM hardening — the implementation sequence for claims 1–7)](https://github.com/tinylabscom/mvm/blob/main/specs/plans/25-microvm-hardening.md)
 - [Plan 53 (cross-platform roadmap — backend tier discipline)](https://github.com/tinylabscom/mvm/blob/main/specs/plans/53-cross-platform-roadmap.md)
 - ["Your container is not a sandbox" (emirb, 2026)](https://emirb.github.io/blog/microvm-2026/) — the post that crystallized the matryoshka framing in the broader microVM ecosystem.

--- a/public/src/content/docs/security/sandbox-parity-status.md
+++ b/public/src/content/docs/security/sandbox-parity-status.md
@@ -217,6 +217,7 @@ so audit bypasses stay visible in git blame.
 - [ADR-048: Claim-safe sandbox parity roadmap](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/048-claim-safe-sandbox-parity.md)
 - [Plan 74: workstreams W0-W6](https://github.com/tinylabscom/mvm/blob/main/specs/plans/74-claim-safe-sandbox-parity.md)
 - [Plan 74 attack plan: sequencing for W1-W6](https://github.com/tinylabscom/mvm/blob/main/specs/plans/83-w1-w6-attack-plan.md)
-- [Seven CI-enforced security claims](/security/ci-claims/) — the
-  existing operator-facing security guarantees this page does NOT
-  duplicate.
+- [CI-enforced security claims](/security/ci-claims/) — the existing
+  operator-facing security guarantees this page does NOT duplicate. That
+  is a separate, larger claim family from the seven sandbox-parity claims
+  tracked here, and the two numberings do not correspond.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-11
+Last updated: 2026-08-12
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -147,7 +147,18 @@ for detailed scope and acceptance criteria.
         gutters 108/34/26 across every section and the header
   - [ ] Maintainer design review — ongoing; the remaining question is whether
         the result reads well, which no measurement answers
-  - [ ] PR #2359 open against `main`
+  - [x] PR #2359 merged to `main`
+  - [x] Implementation plan reconciled against what shipped: five tasks named
+        components that were never created, because the mid-flight review
+        restructured the page, and two stated goals (the scroll-synced code
+        walkthrough and the SDK/CLI tab block as its own section) were dropped
+        by that review. Mapping recorded in the plan's status header; the step
+        checkboxes were never ticked during execution and are not a record of
+        what happened
+  - [x] Docs security pages carried a "seven claims" framing predating most of
+        ADR-001's ledger (#2398); `ci-claims.md` now mirrors the full table and
+        `matryoshka.md` separates layer-defending from backend-independent
+        claims
 
 - [~] Plan 315 — HVF virtio-vsock transmit-credit regression
       (`specs/plans/315-hvf-vsock-credit-regression.md`)

--- a/specs/plans/316-website-redesign-implementation.md
+++ b/specs/plans/316-website-redesign-implementation.md
@@ -20,6 +20,35 @@ gate and a code-sample provenance gate — run in CI-able Node scripts.
 **Tech Stack:** Astro 5.18, Starlight 0.37.6, Tailwind 4, React 19 islands,
 prism-react-renderer, pnpm 10, Node 22.
 
+## Status: DELIVERED, RESHAPED IN PART (#2359, merged)
+
+The redesign shipped in #2359. The step checkboxes below were never ticked
+during execution and are **not** a record of what happened — read this section
+instead, and treat the boxes as the original intent.
+
+Five tasks named a component that was never created, because a maintainer
+review midway through restructured the page (the numbered eyebrows, card grids
+and multi-bloom treatment were what made it read as generated, and were cut).
+What shipped maps onto the plan like this:
+
+| Task | Planned artifact | Outcome |
+| --- | --- | --- |
+| 1–10 | toolchain pin, both gates, tokens, self-hosted fonts, five primitives, Hero | **Shipped as specified.** |
+| 11 | `Install.tsx` | Shipped as `Quickstart.tsx`. |
+| 12 | `Features.tsx` — numbered feature walk | **Reshaped.** The numbered walk was cut in review; the content lives in `WhyMicrovm.tsx` and `Positioning.tsx`. |
+| 13 | `Walkthrough.tsx` — scroll-synced code walkthrough | **Dropped.** `CodeExample.tsx` was deleted rather than replaced; no scroll-synced walkthrough is on the page. |
+| 14 | `Surfaces.tsx` — SDK/CLI tab block | **Reshaped.** No standalone section; the tab treatment is folded into `Hero.tsx` and `Quickstart.tsx`. |
+| 15 | `Architecture.tsx` | **Reshaped** into `Boundary.tsx` plus two inline-SVG diagrams (`HeroStackDiagram.tsx`, `ContainmentDiagram.tsx`), which carry the visual identity the card grid was meant to. |
+| 16–19 | Security, CTA/Footer, docs chrome, docs prose | **Shipped as specified**, with the docs top bar additionally removed at maintainer request. |
+| 20 | Final verification + screenshot matrix | Verification was performed and is recorded in `specs/REFACTOR-STATUS.md` (focus indicators, contrast, reduced-motion, overflow, gutters). The screenshot matrix itself was scratch under `/tmp` and is not an artifact. |
+
+Two goals stated in the header did **not** ship: the scroll-synced code
+walkthrough and the SDK/CLI tab block as a distinct section. Both were
+deliberate review decisions, not oversights.
+
+Still open: maintainer design review — the remaining question is whether the
+result reads well, which no measurement answers.
+
 ## Global Constraints
 
 - **Work in the worktree** `/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-website-redesign` on branch `feat/website-redesign`. Do not `cd` to the main checkout.

--- a/specs/sprint/delivery/2398-security-claims-docs-coverage.md
+++ b/specs/sprint/delivery/2398-security-claims-docs-coverage.md
@@ -1,0 +1,55 @@
+# 2398 — the docs described seven claims; the ledger has eighteen
+
+`public/src/content/docs/security/` framed the security posture around seven
+CI-enforced claims. ADR-001's table runs to fifteen numbered claims plus three
+`Preview` rows, and the highest claim number appearing anywhere in that
+directory was 3. A reader arriving at claim 13 or claim 15 found nothing that
+substantiated it.
+
+This surfaced during the website redesign: the homepage security cards wanted
+to cite claim numbers, found no docs page that carried them, and shipped
+witness identifiers instead. That was a workaround for the gap, not a fix.
+
+## Delivered
+
+- `ci-claims.md` rewritten as a mirror of ADR-001's table — fifteen numbered
+  claims, the three preview claims each with the reason it is still preview,
+  and the three out-of-scope non-goals. The page says outright that the ADR's
+  table is the source of truth and this page is the copy, so the next drift has
+  a defined direction of repair.
+- `matryoshka.md` claim table extended to match, and the two kinds of claim it
+  conflated are now separated: the layer-defending claims, which is what the
+  per-backend tier matrix actually measures, and the supply-chain/admission
+  claims (6, 7, 8, 9, 11, 12, 14), which hold identically across every backend
+  because they gate what is allowed to run before a backend is chosen. The
+  Firecracker row's "All seven claims hold" became "every layer-defending claim
+  holds"; the QEMU row gained its claim-10 exclusion.
+- `claim-ledger.md` link text and the Starlight sidebar label follow the
+  retitle.
+
+`sandbox-parity-status.md` kept its own "seven" — those are the sandbox-parity
+claims, a different family against a different ADR. Only its cross-link to this
+claim set was wrong, and it now states that the two numberings do not
+correspond.
+
+## Also in this change
+
+Plan 316's implementation plan carried 110 unticked step checkboxes despite the
+redesign having merged. Rather than tick them retroactively — nobody can verify
+a step-level box after the fact — the plan gained a status header mapping
+planned artifacts to what shipped. Five tasks named components that were never
+created because a maintainer review restructured the page mid-flight, and two
+stated goals were dropped by that review: the scroll-synced code walkthrough
+and the SDK/CLI tab block as its own section. `specs/REFACTOR-STATUS.md` records
+the merge and the reconciliation.
+
+## Witnesses
+
+- `xtask check-doc-claims`, `check-no-overclaim`, `check-witness-citations`,
+  `check-claim-catalog`, `check-honesty`, `check-adr-coverage` — all clean
+- the site's own gates, `check-no-hardcoded-hex` and `check-sample-provenance`
+  — both pass
+
+No claim text was invented: every row's statement comes from the ADR-001 table
+it mirrors, and mechanism detail is summarized rather than copied, so the page
+cannot drift into asserting a mechanism the ADR no longer describes.


### PR DESCRIPTION
Closes #2398.

## Problem

`public/src/content/docs/security/` described the posture under a "seven claims" framing that predates most of the ledger. ADR-001's claims table runs to **15** numbered claims plus three `Preview` rows; the highest claim number referenced anywhere in that directory was **3**.

The practical effect: a reader arriving at claim 13 (no raw secret crosses the broker channel) or claim 15 (a sealed production microVM has no shell, no DevOnly verbs, no PTY) found no page substantiating it. The redesign worked around this by dropping numeric claim badges from the homepage cards and citing witness identifiers instead — real and checkable, but a workaround for this gap rather than a fix.

## Change

**`ci-claims.md`** — rewritten as a mirror of ADR-001's table: all fifteen numbered claims, the three preview claims each with the reason it is still preview, and the three out-of-scope non-goals. It states plainly that the ADR's table is the source of truth and this page is the copy, so the next drift has an obvious direction of repair.

**`matryoshka.md`** — claim table extended to match, and the two kinds of claim it was conflating are now separated:

- the **layer-defending** claims, which is what the per-backend tier matrix is actually about
- the **supply-chain and admission** claims (6, 7, 8, 9, 11, 12, 14), which hold identically across every backend because they gate what is allowed to run before a backend is chosen

The Firecracker row said "All seven claims hold" — it now says every layer-defending claim holds, which is what the matrix's five columns actually check. The QEMU row gains its claim-10 exclusion, which was missing.

**`claim-ledger.md`, `astro.config.mjs`** — link text and sidebar label follow the retitle.

## What I deliberately did not change

`sandbox-parity-status.md` keeps its own "seven". Those are the **sandbox-parity** claims — a different family, with a different numbering, tracked against a different ADR. The issue listed this page among the four using "seven" framing, but only its cross-link to *this* claim set was wrong. That link is fixed and now says explicitly that the two numberings do not correspond, which is the trap a future reader would otherwise fall into.

## Verification

- `check-doc-claims`, `check-no-overclaim`, `check-witness-citations`, `check-claim-catalog`, `check-honesty`, `check-adr-coverage` — all clean
- the site's own gates: `check-no-hardcoded-hex` and `check-sample-provenance` — both pass
- no claim text was invented: every row's statement is taken from the ADR-001 table it mirrors, and mechanism detail is summarized rather than copied, so this page cannot drift into asserting a mechanism the ADR no longer describes