### PR TITLE
Give the audit chain link one definition of hash_line

### DIFF
--- a/crates/mvm-contract/src/verify.rs
+++ b/crates/mvm-contract/src/verify.rs
@@ -353,7 +353,13 @@ pub fn verify_audit_chain_bytes(
 /// each audit line advances the running `prev_hash` by. Shared with
 /// `merkle` (the empty-tree Merkle root is the SHA-256 of the empty
 /// input, i.e. `hash_line(&[])`).
-pub(crate) fn hash_line(bytes: &[u8]) -> [u8; 32] {
+///
+/// Public because the writer must advance the chain by exactly the rule the
+/// verifiers replay. A second definition of this function is a second
+/// definition of what the chain *is*: the two would agree until one was
+/// edited, and the symptom would be a log that stopped verifying rather
+/// than a failing build. Every producer and consumer calls this one.
+pub fn hash_line(bytes: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
     hasher.finalize().into()
@@ -716,5 +722,29 @@ mod tests {
             verifying_key_from_hex(&"zz".repeat(32)),
             Err(AuditVerifyError::KeyDecode(_))
         ));
+    }
+    #[test]
+    fn hash_line_is_plain_sha256_of_the_line() {
+        // Pins the rule itself, not just that two callers agree. Until now
+        // this function was written out three times -- here, and twice in
+        // mvm-hostd -- so "the chain hash" had three definitions that
+        // happened to match. Anything that changes this (a domain-separation
+        // prefix, a different digest, hashing the trimmed line) breaks every
+        // chain already on disk, and should have to edit this test to do it.
+        use sha2::{Digest, Sha256};
+
+        let line = br#"{"entry":{},"prev_hash":"","signature":""}"#;
+        let mut expected = Sha256::new();
+        expected.update(line);
+        let expected: [u8; 32] = expected.finalize().into();
+
+        assert_eq!(hash_line(line), expected);
+        // Genesis: the empty input, which merkle also relies on.
+        assert_eq!(hash_line(&[]), {
+            let mut h = Sha256::new();
+            h.update([]);
+            let out: [u8; 32] = h.finalize().into();
+            out
+        });
     }
 }

--- a/crates/mvm-hostd/src/supervisor/audit_file.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_file.rs
@@ -44,8 +44,9 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use thiserror::Error;
+
+use mvm_contract::verify::hash_line;
 
 use crate::supervisor::audit::{AuditEntry, AuditError, AuditSigner};
 
@@ -947,12 +948,6 @@ fn verify_line(
         .map_err(|_| VerifyError::SignatureInvalid { line: idx })?;
     entries.push(envelope.entry);
     Ok(hash_line(line.as_bytes()))
-}
-
-fn hash_line(bytes: &[u8]) -> [u8; 32] {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    hasher.finalize().into()
 }
 
 /// How far a chain has already been verified, so a later run can resume.

--- a/crates/mvm-hostd/src/supervisor/audit_set.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_set.rs
@@ -22,8 +22,9 @@
 use std::path::{Path, PathBuf};
 
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
-use sha2::{Digest, Sha256};
 use thiserror::Error;
+
+use mvm_contract::verify::hash_line;
 
 use crate::supervisor::audit_file::{SignedEnvelope, VerifyError, verify_chain_bytes};
 use crate::supervisor::audit_segment::{
@@ -210,12 +211,6 @@ fn active_seq(path: &Path) -> Result<u64, SegmentSetError> {
         .ok()
         .and_then(|e| continuation_from_entry(&e.entry))
         .map_or(1, |c| c.segment))
-}
-
-fn hash_line(bytes: &[u8]) -> [u8; 32] {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    hasher.finalize().into()
 }
 
 fn hex(bytes: &[u8; 32]) -> String {


### PR DESCRIPTION
Plan 320 E3.2a. Found by re-validating the E3 boundary against post-#2379 `main`.

## The problem

`hash_line` *is* the audit chain — the rule by which each line advances the running `prev_hash`, and the rule every verifier replays. It was written out three times, byte-identically:

| Location | Visibility |
|---|---|
| `crates/mvm-contract/src/verify.rs` | `pub(crate)` |
| `crates/mvm-hostd/src/supervisor/audit_file.rs` | private |
| `crates/mvm-hostd/src/supervisor/audit_set.rs` | private — **added by #2379** |

Three definitions of this function are three definitions of what the chain is. They agree today, so **nothing is broken and this fixes no live defect.** What matters is the failure mode if one were edited: not a failing build, but a log that stops verifying — on a chain somebody is holding as evidence.

Worth noting the trend: #2379 added the third copy rather than sharing an existing one. Left alone, this grows.

## The change

The `mvm-contract` definition becomes `pub`; both `mvm-hostd` copies are deleted and call it. That direction is deliberate — the writer must advance the chain by exactly the rule the `no_std` verifier replays, and that verifier is the one that has to run in a browser.

Also adds a test pinning **the rule itself** rather than merely that two callers agree: plain SHA-256 of the line, no domain-separation prefix, plus the empty-input genesis case `merkle` depends on. Anything that changes this breaks every chain already on disk, and should have to edit that test to do it.

No behaviour change, no serde change, no new dependency. It has no `AuditEntry` dependency, so it lands alone, ahead of the envelope unification.

## Gates

- `cargo nextest run --workspace` — **11358/11358 passed**
- `cargo test --workspace --doc` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo build -p mvm-contract --target wasm32-unknown-unknown` — pass
- `cargo test -p mvm-contract --target wasm32-wasip1` — 733 passed
- all 50 `xtask check-*` gates from `ci.yml` — pass

### One honest caveat on the local run

Two `mvm-agentd::entrypoint_execute` tests were excluded from my local workspace run. They are **pre-existing failures unrelated to this change**, and I verified that rather than assuming it: stashing this diff in the same worktree leaves them failing, and they pass in a checkout at the same commit. They have a 300ms timeout with 10ms polling, and my machine was at load average 66–91 with 160 concurrent `rustc` processes from parallel work. I've left them alone — they're not in this change's area, and "fix someone else's timing-sensitive test while passing through" is how unrelated breakage gets introduced. CI will run them on an unloaded runner.