### PR TITLE
Make builder-store durability expressible, and fail fast when it is gone

### DIFF
--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -268,6 +268,35 @@ const EXT4_SUPERBLOCK_READ: usize = 512;
 /// Pure function so darwin `cargo test` exercises it without a
 /// Linux cross-compile; the file-IO and `BLKGETSIZE64` ioctl that
 /// feed it live inside the linux module.
+/// Whether the kernel has recorded filesystem errors on this ext4 volume.
+///
+/// Reads `s_state` (u16 at `0x3A` of the superblock). Bit 1
+/// (`EXT4_ERROR_FS`) is set by the kernel when it detects corruption and
+/// survives a remount, so it is still set on the *next* boot — which is
+/// exactly when we want to refuse.
+///
+/// `None` means there is no ext4 here to judge; the caller treats that as
+/// "needs formatting", not as an error.
+///
+/// Catching this up front matters because the damage otherwise surfaces
+/// somewhere arbitrary and unrecognisable downstream: a corrupt store showed
+/// up as `/bin/chown -R 902:902 /nix/var/nix exited 1`, which names neither
+/// the disk nor corruption.
+#[cfg(any(target_os = "linux", test))]
+fn parse_ext4_recorded_error_state(sb: &[u8]) -> Option<bool> {
+    /// `s_state` bit 1: the kernel detected filesystem errors.
+    const EXT4_ERROR_FS: u16 = 0x0002;
+
+    if sb.len() < 0x3A + 2 {
+        return None;
+    }
+    if sb[0x38] != 0x53 || sb[0x39] != 0xEF {
+        return None;
+    }
+    let state = u16::from_le_bytes(sb[0x3A..0x3C].try_into().ok()?);
+    Some(state & EXT4_ERROR_FS != 0)
+}
+
 #[cfg(any(target_os = "linux", test))]
 fn parse_ext4_recorded_size_bytes(sb: &[u8]) -> Option<u64> {
     if sb.len() < 0x150 + 4 {
@@ -599,6 +628,51 @@ fn closure_marker_contents(closure_hash: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── ext4 store damage detection ──
+
+    /// A minimal ext4 superblock with the magic set and `s_state` as given.
+    fn sb_with_state(state: u16) -> Vec<u8> {
+        let mut sb = vec![0u8; 0x160];
+        sb[0x38] = 0x53;
+        sb[0x39] = 0xEF;
+        sb[0x3A..0x3C].copy_from_slice(&state.to_le_bytes());
+        sb
+    }
+
+    #[test]
+    fn a_cleanly_unmounted_store_is_not_flagged_as_damaged() {
+        // EXT4_VALID_FS only. The common case must not start refusing builds.
+        assert_eq!(
+            parse_ext4_recorded_error_state(&sb_with_state(0x0001)),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn a_store_the_kernel_flagged_is_reported_as_damaged() {
+        // EXT4_ERROR_FS. This is what an abruptly-killed builder VM left
+        // behind, and what previously surfaced as an unrelated chown failure.
+        assert_eq!(
+            parse_ext4_recorded_error_state(&sb_with_state(0x0002)),
+            Some(true)
+        );
+        // Set alongside VALID_FS, which is how it actually appears.
+        assert_eq!(
+            parse_ext4_recorded_error_state(&sb_with_state(0x0003)),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn a_non_ext4_or_short_superblock_yields_no_verdict() {
+        // No ext4 to judge; the caller formats rather than refusing.
+        let mut not_ext4 = sb_with_state(0x0002);
+        not_ext4[0x38] = 0x00;
+        assert_eq!(parse_ext4_recorded_error_state(&not_ext4), None);
+        assert_eq!(parse_ext4_recorded_error_state(&[]), None);
+        assert_eq!(parse_ext4_recorded_error_state(&[0u8; 0x3A]), None);
+    }
 
     // ── guest-agent fork (universal-agent invariant) ──
 
@@ -2814,6 +2888,11 @@ mod linux {
             append_init_breadcrumb("setup_nix_store_format", &reason);
             eprintln!("mvm-host-vm-init: formatting {NIX_STORE_DEV} ({reason})");
             format_ext4(NIX_STORE_DEV)?;
+        } else {
+            // A store the kernel has already flagged is not safe to build on:
+            // mounting it succeeds, and the damage then surfaces somewhere
+            // arbitrary downstream. Refuse here, where we can name the cause.
+            nix_store_dev_refuse_if_damaged(NIX_STORE_DEV)?;
         }
         mount_fs(NIX_STORE_DEV, NIX_STORE_MOUNT, "ext4")?;
         append_init_breadcrumb("setup_nix_store_mounted", NIX_STORE_MOUNT);
@@ -3780,6 +3859,24 @@ mod linux {
     /// rather than aborting before the build can run. The
     /// `/nix-store` volume is a cache; reformatting loses nothing
     /// that can't be rebuilt by the next nix build.
+    /// Refuse a store volume the kernel has recorded errors on.
+    ///
+    /// The message is the whole point: it names the device, says the store is
+    /// damaged, and gives the narrow recovery, so nobody has to read kernel
+    /// output to find `EXT4-fs (vdb): mounting fs with errors`.
+    fn nix_store_dev_refuse_if_damaged(dev: &str) -> Result<(), String> {
+        let sb = read_ext4_superblock(dev)?;
+        if crate::parse_ext4_recorded_error_state(&sb) == Some(true) {
+            return Err(format!(
+                "nix store on {dev} is damaged: the kernel recorded ext4 errors on it. \
+                 Refusing to build on a corrupt store. \
+                 Recover with `mvmctl cache repair --store-only`, which resets only \
+                 this store image and keeps the builder images and stage0 seed."
+            ));
+        }
+        Ok(())
+    }
+
     fn nix_store_dev_needs_format(dev: &str) -> Result<Option<String>, String> {
         let sb = read_ext4_superblock(dev)?;
         let Some(fs_bytes) = crate::parse_ext4_recorded_size_bytes(&sb) else {

--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -611,6 +611,54 @@ pub fn clear_builder_store(dry_run: bool) -> std::io::Result<BuilderStoreRepair>
     clear_builder_store_at(&builder_vm_cache_dir(), dry_run)
 }
 
+/// The architecture tag used in cached builder artifact filenames
+/// (`nix-store-<arch>.img`).
+///
+/// Lives here rather than in `libkrun_builder` because that module is gated
+/// behind the `builder-vm` feature, and store recovery must work without it.
+pub fn host_arch_tag() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x86_64"
+    }
+}
+
+/// Remove only the persistent Nix store image for `arch`, leaving the builder
+/// kernel/rootfs, the Stage 0 seed, and the job dirs in place.
+///
+/// The narrow counterpart to [`clear_builder_store`]. When the store image
+/// itself is the damaged piece — the kernel recorded ext4 errors on it — there
+/// is no reason to also discard tens of gigabytes of intact, expensive-to-
+/// rebuild builder images. The next build recreates the store from the seed.
+pub fn clear_builder_store_image(dry_run: bool) -> std::io::Result<BuilderStoreRepair> {
+    clear_builder_store_image_at(&builder_vm_cache_dir(), host_arch_tag(), dry_run)
+}
+
+/// [`clear_builder_store_image`] with an explicit dir — the unit-testable core.
+pub fn clear_builder_store_image_at(
+    dir: &std::path::Path,
+    arch: &str,
+    dry_run: bool,
+) -> std::io::Result<BuilderStoreRepair> {
+    let image = dir.join(format!("nix-store-{arch}.img"));
+    let existed = image.exists();
+    let bytes_freed = if existed {
+        std::fs::metadata(&image).map(|m| m.len()).unwrap_or(0)
+    } else {
+        0
+    };
+    if existed && !dry_run {
+        std::fs::remove_file(&image)?;
+    }
+    Ok(BuilderStoreRepair {
+        path: image.display().to_string(),
+        existed,
+        bytes_freed,
+        dry_run,
+    })
+}
+
 /// [`clear_builder_store`] with an explicit dir — the unit-testable core.
 pub fn clear_builder_store_at(
     dir: &std::path::Path,
@@ -1155,6 +1203,51 @@ mod tests {
         assert!(done.existed && !done.dry_run);
         assert_eq!(done.bytes_freed, 4196);
         assert!(!store.exists(), "repair must remove the store dir");
+    }
+
+    #[test]
+    fn clearing_only_the_store_image_keeps_the_expensive_builder_artifacts() {
+        // The whole point: a damaged store image must not cost the intact
+        // stage0 seed and builder images alongside it.
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("builder-vm");
+        std::fs::create_dir_all(store.join("hvf")).unwrap();
+        std::fs::write(store.join("nix-store-aarch64.img"), vec![0u8; 4096]).unwrap();
+        std::fs::write(store.join("nix-store-stage0-aarch64.img"), vec![0u8; 512]).unwrap();
+        std::fs::write(store.join("hvf/rootfs.ext4"), vec![0u8; 256]).unwrap();
+
+        let dry = clear_builder_store_image_at(&store, "aarch64", true).unwrap();
+        assert!(dry.existed && dry.dry_run);
+        assert_eq!(dry.bytes_freed, 4096);
+        assert!(
+            store.join("nix-store-aarch64.img").exists(),
+            "dry-run must not delete"
+        );
+
+        let done = clear_builder_store_image_at(&store, "aarch64", false).unwrap();
+        assert!(done.existed && !done.dry_run);
+        assert_eq!(done.bytes_freed, 4096);
+        assert!(
+            !store.join("nix-store-aarch64.img").exists(),
+            "the damaged image goes"
+        );
+        assert!(
+            store.join("nix-store-stage0-aarch64.img").exists(),
+            "the stage0 seed must survive"
+        );
+        assert!(
+            store.join("hvf/rootfs.ext4").exists(),
+            "builder images must survive"
+        );
+    }
+
+    #[test]
+    fn clearing_a_store_image_that_is_absent_is_a_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("builder-vm");
+        std::fs::create_dir_all(&store).unwrap();
+        let r = clear_builder_store_image_at(&store, "aarch64", false).unwrap();
+        assert!(!r.existed && r.bytes_freed == 0);
     }
 
     #[test]

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -2175,11 +2175,7 @@ fn krun_context_for_image(
 /// ARM Linux, `x86_64` everywhere else. The builder-vm flake
 /// emits both per release.
 pub(crate) fn host_arch_tag() -> &'static str {
-    if cfg!(target_arch = "aarch64") {
-        "aarch64"
-    } else {
-        "x86_64"
-    }
+    crate::builder_vm::host_arch_tag()
 }
 
 /// `~/.mvm/cache/builder-vm/`. Wrapper around

--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -88,6 +88,13 @@ pub(in crate::commands) enum CacheAction {
         /// (e.g. left by a crashed run).
         #[arg(long)]
         force: bool,
+        /// Remove only the persistent Nix store image, keeping the builder
+        /// kernel/rootfs and the Stage 0 seed. Use this when the store itself
+        /// is the damaged piece — the guest refuses to build and names ext4
+        /// errors on it — so recovery costs one image instead of the whole
+        /// cache.
+        #[arg(long)]
+        store_only: bool,
     },
 }
 
@@ -293,6 +300,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             dry_run,
             json,
             force,
+            store_only,
         } => {
             use super::super::env::builder_vm;
 
@@ -309,8 +317,13 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 );
             }
 
-            let repair = mvm_build::builder_vm::clear_builder_store(dry_run)
-                .map_err(|e| anyhow::anyhow!("clearing builder store: {e}"))?;
+            let repair = if store_only {
+                mvm_build::builder_vm::clear_builder_store_image(dry_run)
+                    .map_err(|e| anyhow::anyhow!("clearing builder store image: {e}"))?
+            } else {
+                mvm_build::builder_vm::clear_builder_store(dry_run)
+                    .map_err(|e| anyhow::anyhow!("clearing builder store: {e}"))?
+            };
             if json {
                 crate::json_out::emit_json(&repair)?;
                 return Ok(());

--- a/crates/mvm-vmm/src/vmm/virtio.rs
+++ b/crates/mvm-vmm/src/vmm/virtio.rs
@@ -72,12 +72,19 @@ const SECTOR: u64 = 512;
 
 const VIRTIO_BLK_T_IN: u32 = 0; // read
 const VIRTIO_BLK_T_OUT: u32 = 1; // write
+const VIRTIO_BLK_T_FLUSH: u32 = 4; // flush the write-back cache
 const VIRTIO_BLK_S_OK: u8 = 0;
 const VIRTIO_BLK_S_IOERR: u8 = 1;
 /// virtio-blk feature bit 5 (low feature word): the device is read-only. Offered
 /// for a read-only backing so the guest mounts it `ro`; writes are also rejected
 /// at the device (below), so RO is hypervisor-enforced, not guest-honour-system.
 const VIRTIO_BLK_F_RO: u32 = 1 << 5;
+/// virtio-blk feature bit 9 (low feature word): the device honours
+/// `VIRTIO_BLK_T_FLUSH`. Offered for every writable backing. Without it the
+/// guest is entitled to assume a completed write is already durable and never
+/// issues a barrier, so ext4's journal ordering rests on an assumption nothing
+/// enforces — and a host that dies with dirty page cache loses the filesystem.
+const VIRTIO_BLK_F_FLUSH: u32 = 1 << 9;
 
 /// Backing store for a virtio-blk device.
 ///
@@ -118,6 +125,22 @@ impl DiskImage {
         match self {
             Self::Mem(v) => v.len() as u64,
             Self::File { len, .. } => *len,
+        }
+    }
+
+    /// Force everything written so far to stable storage. A RAM-backed or
+    /// read-only image has nothing to push, so it succeeds trivially.
+    ///
+    /// `sync_data` rather than `sync_all`: the guest filesystem's consistency
+    /// depends on its own bytes reaching the disk, not on the host's metadata
+    /// for a file whose length never changes.
+    fn flush(&mut self) -> bool {
+        match self {
+            Self::Mem(_) => true,
+            Self::File {
+                read_only: true, ..
+            } => true,
+            Self::File { file, .. } => file.sync_data().is_ok(),
         }
     }
 
@@ -277,10 +300,11 @@ impl VirtioBlk {
             R_DEVICE_ID => VIRTIO_ID_BLOCK,
             R_VENDOR_ID => VIRTIO_VENDOR,
             // High word (bit 32): VIRTIO_F_VERSION_1. Low word: VIRTIO_BLK_F_RO
-            // for a read-only backing (else no low-word features).
+            // for a read-only backing, which takes no writes and so has nothing
+            // to flush; VIRTIO_BLK_F_FLUSH for a writable one.
             R_DEVICE_FEATURES if self.device_features_sel == 1 => 1,
             R_DEVICE_FEATURES if self.disk.read_only() => VIRTIO_BLK_F_RO,
-            R_DEVICE_FEATURES => 0,
+            R_DEVICE_FEATURES => VIRTIO_BLK_F_FLUSH,
             R_QUEUE_NUM_MAX => super::QUEUE_SIZE_MAX,
             R_QUEUE_READY => self.queue_ready,
             R_INTERRUPT_STATUS => self.interrupt_status,
@@ -465,7 +489,15 @@ impl VirtioBlk {
             io_ok &= self.transfer(req_type, sector, addr, len, &mut written);
             sector += u64::from(len) / SECTOR;
         }
-        let ok = io_ok && matches!(req_type, VIRTIO_BLK_T_IN | VIRTIO_BLK_T_OUT);
+        // A flush carries no data descriptors, so it is serviced here rather
+        // than in `transfer`.
+        let flushed = req_type != VIRTIO_BLK_T_FLUSH || self.disk.flush();
+        let ok = io_ok
+            && flushed
+            && matches!(
+                req_type,
+                VIRTIO_BLK_T_IN | VIRTIO_BLK_T_OUT | VIRTIO_BLK_T_FLUSH
+            );
         if let Some(s) = status_addr {
             self.wr_u8(
                 s,
@@ -1099,7 +1131,8 @@ mod tests {
     fn offers_version_1_feature_in_high_word() {
         let mut d = dev(vec![0u8; 4096]);
         d.write(R_DEVICE_FEATURES_SEL, 0);
-        assert_eq!(d.read(R_DEVICE_FEATURES) as u32, 0);
+        // Writable, so the low word carries FLUSH.
+        assert_eq!(d.read(R_DEVICE_FEATURES) as u32, VIRTIO_BLK_F_FLUSH);
         d.write(R_DEVICE_FEATURES_SEL, 1);
         assert_eq!(d.read(R_DEVICE_FEATURES) as u32, 1); // VIRTIO_F_VERSION_1 (bit 32)
     }
@@ -1217,6 +1250,48 @@ mod tests {
     }
 
     #[test]
+    fn a_writable_backing_offers_the_flush_feature_bit() {
+        // Without this bit the guest never issues a barrier, because it is
+        // entitled to treat a completed write as already durable.
+        let f = tempfile::NamedTempFile::new().unwrap();
+        f.as_file().set_len(512).unwrap();
+        let mut d = blk_dev(DiskImage::open(f.path(), false).unwrap());
+        d.write(R_DEVICE_FEATURES_SEL, 0);
+        assert_eq!(
+            d.read(R_DEVICE_FEATURES) as u32 & VIRTIO_BLK_F_FLUSH,
+            VIRTIO_BLK_F_FLUSH
+        );
+    }
+
+    #[test]
+    fn a_read_only_backing_does_not_offer_flush() {
+        // It takes no writes, so it has nothing to push.
+        let f = tempfile::NamedTempFile::new().unwrap();
+        f.as_file().set_len(512).unwrap();
+        let mut d = blk_dev(DiskImage::open(f.path(), true).unwrap());
+        d.write(R_DEVICE_FEATURES_SEL, 0);
+        assert_eq!(d.read(R_DEVICE_FEATURES) as u32 & VIRTIO_BLK_F_FLUSH, 0);
+    }
+
+    #[test]
+    fn flushing_a_writable_file_succeeds() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        f.as_file().set_len(512).unwrap();
+        let mut d = DiskImage::open(f.path(), false).unwrap();
+        assert!(d.write_at(0, b"durable"));
+        assert!(d.flush(), "a writable backing must be able to sync");
+        assert_eq!(&std::fs::read(f.path()).unwrap()[..7], b"durable");
+    }
+
+    #[test]
+    fn flushing_a_read_only_or_ram_backing_is_a_no_op_that_succeeds() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        f.as_file().set_len(512).unwrap();
+        assert!(DiskImage::open(f.path(), true).unwrap().flush());
+        assert!(DiskImage::mem(vec![0u8; 512]).flush());
+    }
+
+    #[test]
     fn read_only_backing_offers_the_ro_feature_bit() {
         let f = tempfile::NamedTempFile::new().unwrap();
         f.as_file().set_len(512).unwrap();
@@ -1226,10 +1301,11 @@ mod tests {
         assert_eq!(d.read(R_DEVICE_FEATURES) as u32, VIRTIO_BLK_F_RO);
         d.write(R_DEVICE_FEATURES_SEL, 1);
         assert_eq!(d.read(R_DEVICE_FEATURES) as u32, 1);
-        // A writable (mem) backing offers no low-word features.
+        // A writable backing offers FLUSH instead, so the guest can force its
+        // journal to stable storage.
         let mut w = dev(vec![0u8; 512]);
         w.write(R_DEVICE_FEATURES_SEL, 0);
-        assert_eq!(w.read(R_DEVICE_FEATURES) as u32, 0);
+        assert_eq!(w.read(R_DEVICE_FEATURES) as u32, VIRTIO_BLK_F_FLUSH);
     }
 
     /// Queue sizes a hostile guest can program that are illegal geometry: zero,
@@ -1361,6 +1437,16 @@ mod tests {
             2 => vec![
                 ("read-no-payload", vec![read(0, &[])]),
                 ("write-no-payload", vec![write(1, &[])]),
+                // A flush is header + status by definition: it carries no data.
+                (
+                    "flush",
+                    vec![BlkChain {
+                        req_type: VIRTIO_BLK_T_FLUSH,
+                        sector: 0,
+                        data: Vec::new(),
+                        status: true,
+                    }],
+                ),
                 (
                     "two-header-only-chains",
                     vec![
@@ -1569,7 +1655,13 @@ mod tests {
                 break;
             }
         }
-        let ok = io_ok && matches!(req_type, VIRTIO_BLK_T_IN | VIRTIO_BLK_T_OUT);
+        let flushed = req_type != VIRTIO_BLK_T_FLUSH || d.disk.flush();
+        let ok = io_ok
+            && flushed
+            && matches!(
+                req_type,
+                VIRTIO_BLK_T_IN | VIRTIO_BLK_T_OUT | VIRTIO_BLK_T_FLUSH
+            );
         if let Some(s) = status_addr {
             d.wr_u8(
                 s,
@@ -1582,6 +1674,31 @@ mod tests {
             written += 1;
         }
         written
+    }
+
+    #[test]
+    fn a_flush_request_is_acknowledged_not_refused() {
+        // Absolute, not differential: the reference walk mirrors production, so
+        // only a concrete status byte proves a flush is actually honoured.
+        // Before FLUSH support this returned VIRTIO_BLK_S_IOERR, and ext4 reads
+        // a failed barrier as disk failure.
+        let file = tempfile::NamedTempFile::new().unwrap();
+        file.as_file().set_len(4096).unwrap();
+        let mut d = blk_dev(DiskImage::open(file.path(), false).unwrap());
+
+        let chains = vec![BlkChain {
+            req_type: VIRTIO_BLK_T_FLUSH,
+            sector: 0,
+            data: Vec::new(),
+            status: true,
+        }];
+        let (avail, _used) = program_blk_queue(&mut d, 2, &chains);
+        d.mem.wr_u16(avail + 2, 1);
+        assert!(d.process_queue(), "the flush chain must be consumed");
+
+        // Descriptor 1 is the status byte; descriptor 0 is the request header.
+        let status_addr = d.rd_u64(BLK_BASE + 0x1000 + 16);
+        assert_eq!(d.mem.read_bytes(status_addr, 1)[0], VIRTIO_BLK_S_OK);
     }
 
     #[test]

--- a/specs/plans/326-builder-store-durability.md
+++ b/specs/plans/326-builder-store-durability.md
@@ -96,15 +96,44 @@ base image. This is the workstream that actually delivers "never".
 
 ### WS-D — establish the mechanism, then keep it fixed
 
-- [ ] Reproduce: kill a builder VM mid-write and check whether the store
+- [x] Reproduce: kill a builder VM mid-write and check whether the store
       mounts clean afterwards.
-- [ ] If `kill -9` alone does not corrupt, find what did — a second writer, an
-      I/O error path, or a host-level event — and record it here.
-- [ ] Regression coverage for whatever WS-D establishes.
+
+**`kill -9` does not corrupt the store.** Measured 2026-08-12 against a
+pre-WS-A binary, so the result describes the original code:
+
+| step | `s_state` |
+| --- | --- |
+| baseline | `0x0001` VALID_FS, no ERROR_FS |
+| after `kill -9` mid-write (8 sustained write ticks observed) | `0x0001` unchanged |
+| after remount + a full successful build | `0x0001` unchanged |
+
+The build following the kill completed normally. This matches the analysis
+above: the writes were already in host page cache, which the kernel owns and
+which outlives the process.
+
+So **the premise that a killed builder VM caused the observed corruption is
+refuted.** Something else did.
+
+- [ ] Find what did. Two candidates, in order of suspicion:
+      1. **Two writers on the same image.** This is the shape that produces
+         `deleted inode referenced` after a successful journal replay: two
+         mounts disagreeing about metadata, not one mount losing writes. Plan
+         324 / #2416 is reworking store-lock ownership precisely because the
+         lock did not cover the whole window a VM is alive; that gap and this
+         corruption are consistent with each other.
+      2. A host-level event (panic / power loss) losing page cache. WS-A
+         closes this one regardless.
+- [ ] Regression coverage for whatever this establishes.
 
 ## Sequencing
 
 WS-A is independent and lands first. WS-B is independent of WS-A and can land
-in parallel. WS-C depends on neither but is the largest change and should
-follow WS-D's findings, so the design answers the real failure mode rather
-than the assumed one.
+in parallel.
+
+WS-C should now be re-scoped before it is built. WS-D refuted the failure mode
+WS-C was conceived to prevent: a CoW overlay protects the base image from a
+*build that dies*, and a build that dies turns out not to damage it. If the
+real mechanism is concurrent writers, the fix is single-writer enforcement
+(#2416's territory), and a CoW overlay would add a large amount of machinery
+against a threat that is not the one we have. Settle WS-D's open item first.

--- a/specs/plans/326-builder-store-durability.md
+++ b/specs/plans/326-builder-store-durability.md
@@ -1,0 +1,110 @@
+# Plan 326: the builder nix store must survive any abrupt failure
+
+## Status
+
+IN PROGRESS — WS-A and WS-B complete; WS-D next, then WS-C.
+
+## The problem
+
+A builder VM that dies abruptly can leave `~/.mvm/cache/builder-vm/nix-store-<arch>.img`
+ext4-corrupt. Observed 2026-08-11:
+
+```
+EXT4-fs (vdb): warning: mounting fs with errors, running e2fsck is recommended
+EXT4-fs (vdb): recovery complete
+EXT4-fs error (device vdb): ext4_lookup:1821: inode #3932165: comm chown:
+    deleted inode referenced: 3981611
+```
+
+Journal replay ran and the filesystem was *still* inconsistent, so ordering
+guarantees had already been violated. The surfaced error was
+`mvm-host-vm-init: setup_nix_store failed: /bin/chown -R 902:902 /nix/var/nix
+exited 1` — which names neither the disk nor corruption, and the only
+documented recovery (`mvmctl cache repair`) clears all 147 GB when one 63 GB
+image was bad.
+
+## What the code actually does today
+
+Three findings in `crates/mvm-vmm/src/vmm/virtio.rs`:
+
+1. The device advertises only `VIRTIO_F_VERSION_1` and, when read-only,
+   `VIRTIO_BLK_F_RO`. **`VIRTIO_BLK_F_FLUSH` is never offered.**
+2. `VIRTIO_BLK_T_FLUSH` is not handled. The status line is
+   `matches!(req_type, VIRTIO_BLK_T_IN | VIRTIO_BLK_T_OUT)`, so a flush would
+   be answered `VIRTIO_BLK_S_IOERR`.
+3. **The backing file is never synced.** There is no `sync_all`, `sync_data`,
+   or `F_FULLFSYNC` anywhere in `mvm-vmm` or the HVF backend. Writes are
+   `pwrite` into the host page cache and stay there.
+
+So no mechanism exists, at any layer, by which the guest or the host can make
+the store durable.
+
+## What that does and does not explain
+
+It **does** explain host-crash corruption. On panic or power loss the page
+cache is gone, an arbitrary subset of writes survives in arbitrary order, and
+ext4 cannot recover. That is unconditional and is a real hole regardless of
+anything below.
+
+It does **not** explain `kill -9` of the supervisor. Those writes are already
+in the host page cache, which the kernel owns and which outlives the process.
+On that analysis a killed builder VM should not corrupt the store — yet one
+did. **The mechanism behind the observed failure is not yet established.**
+WS-D exists to settle that rather than assume it.
+
+Do not describe WS-A as fixing the observed corruption until WS-D says so.
+
+## Workstreams
+
+### WS-A — make durability expressible
+
+- [x] Advertise `VIRTIO_BLK_F_FLUSH` on writable disks.
+- [x] Handle `VIRTIO_BLK_T_FLUSH`: fsync the backing file, report
+      `VIRTIO_BLK_S_OK` on success and `VIRTIO_BLK_S_IOERR` on failure.
+- [x] A read-only or RAM-backed disk answers flush `OK` without work.
+- [x] Device-level tests: flush is accepted; a flush reaches the file; an
+      unknown request type is still refused.
+
+Closes the host-crash hole. With `F_FLUSH` negotiated, guest ext4 issues real
+barriers and jbd2's commit ordering becomes enforceable instead of assumed.
+
+### WS-B — fail fast, and recover narrowly
+
+- [x] Guest init reads the ext4 superblock's `s_state` error bit on the store
+      device before mounting and refuses with a message naming the disk, the
+      cause, and the recovery — rather than letting a downstream `chown` fail
+      with `exited 1`. Reading `s_state` beats parsing kernel output: the bit
+      survives remount, so it is still set on the next boot.
+- [x] `clear_builder_store_image` removes only the store image, keeping the
+      Stage 0 seed and the builder images.
+- [x] `mvmctl cache repair --store-only` exposes it; the blanket clear stays
+      available but stops being the only option.
+
+This is the piece that converts an hour of misdirected debugging into one
+actionable line.
+
+### WS-C — a build cannot damage the base store
+
+- [ ] Each build attaches a CoW overlay over the base store image rather than
+      mutating it in place.
+- [ ] The overlay is committed to the base only on a clean, synced exit.
+- [ ] An abrupt death discards the overlay; the base is untouched by
+      construction, so no failure mode can corrupt it.
+
+WS-A makes corruption unlikely; WS-C makes it structurally impossible for the
+base image. This is the workstream that actually delivers "never".
+
+### WS-D — establish the mechanism, then keep it fixed
+
+- [ ] Reproduce: kill a builder VM mid-write and check whether the store
+      mounts clean afterwards.
+- [ ] If `kill -9` alone does not corrupt, find what did — a second writer, an
+      I/O error path, or a host-level event — and record it here.
+- [ ] Regression coverage for whatever WS-D establishes.
+
+## Sequencing
+
+WS-A is independent and lands first. WS-B is independent of WS-A and can land
+in parallel. WS-C depends on neither but is the largest change and should
+follow WS-D's findings, so the design answers the real failure mode rather
+than the assumed one.


### PR DESCRIPTION
Plan 326 WS-A + WS-B. See `specs/plans/326-builder-store-durability.md`.

## WS-A — nothing could make the store durable

Three findings in `crates/mvm-vmm/src/vmm/virtio.rs`:

1. The device advertised only `VIRTIO_F_VERSION_1` and, read-only, `VIRTIO_BLK_F_RO`. **`VIRTIO_BLK_F_FLUSH` was never offered.**
2. `VIRTIO_BLK_T_FLUSH` was unhandled, so it fell through to `VIRTIO_BLK_S_IOERR` — and ext4 reads a failed barrier as disk failure.
3. **The backing file was never synced.** No `sync_all`, `sync_data`, or `F_FULLFSYNC` anywhere in `mvm-vmm` or the HVF backend; writes were `pwrite` into the host page cache and stayed there.

So no mechanism existed, at any layer, for the guest or host to make the nix store durable. A host panic or power loss would take that 63 GB image every time.

Now: FLUSH advertised on writable backings, `T_FLUSH` serviced with a real `sync_data`. Read-only and RAM backings answer OK without work — one takes no writes, the other has no stable storage to reach.

`sync_data` rather than `sync_all`: guest filesystem consistency depends on its own bytes landing, not on host metadata for a file whose length never changes.

## WS-B — a damaged store said the wrong thing

It surfaced as `/bin/chown -R 902:902 /nix/var/nix exited 1`, naming neither the disk nor corruption. The real signal (`EXT4-fs (vdb): mounting fs with errors`) was buried in kernel output, and the only documented recovery cleared all 147 GB when one 63 GB image was bad.

The guest now reads the ext4 superblock's `s_state` error bit **before** mounting and refuses with a message naming the disk, the cause, and the recovery. Reading `s_state` beats parsing kernel output: the bit survives remount, so it is still set on the next boot — exactly when we want to refuse.

Paired with `mvmctl cache repair --store-only`, which drops just the store image and keeps the Stage 0 seed and builder images. Verified end-to-end against a real layout: 4 MB image removed, seed and builder images untouched.

`host_arch_tag` moves to the ungated `builder_vm` module with `libkrun_builder` delegating — store recovery must work without the `builder-vm` feature.

## What this does NOT claim

**WS-A is not yet known to fix the corruption actually observed.** `kill -9` leaves those writes in the host page cache, which the kernel owns and which outlives the process, so on analysis a killed supervisor should *not* corrupt the store — yet one did. The mechanism remains unestablished. WS-D settles it; the plan says so rather than implying this closes it.

What WS-A does close, unconditionally, is the host-crash hole.

## Tests

WS-A, 7 tests. The queue-level one is deliberately **absolute rather than differential** — the test reference walk mirrors production, so a differential test would agree by construction — and was confirmed red before the fix. Two pre-existing tests encoded the old "a writable device offers no low-word features" behaviour and now assert FLUSH; that is the intended change.

WS-B, 5 tests: clean/flagged/short/non-ext4 superblock verdicts, and that a store-only clear keeps the seed and builder images.

3130 tests pass across `mvm-vmm`/`mvm-build`/`mvm-cli`; clippy clean.