### PR TITLE
Share the builder that holds the store image instead of queueing for it

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -41,7 +41,7 @@ mod image_lock;
 
 pub use image_lock::{
     DEFAULT_LOCK_WAIT, LOCK_WAIT_ENV, LockWait, NixStoreImageLock, acquire_nix_store_image_lock,
-    acquire_nix_store_image_lock_named,
+    acquire_nix_store_image_lock_named, nix_store_image_is_contended,
 };
 pub(crate) use image_lock::{
     acquire_sidecar_lock_within, pid_alive, sidecar_lock_path, sparse_create_image,

--- a/crates/mvm-build/src/builder_vm_runtime/image_lock.rs
+++ b/crates/mvm-build/src/builder_vm_runtime/image_lock.rs
@@ -466,6 +466,32 @@ fn contended_lock_error(lock_path: &Path, waited: Duration, wait: LockWait) -> B
     ))
 }
 
+/// Is another process holding the store image right now?
+///
+/// A probe, not a claim: it tries the lock without waiting and releases it
+/// immediately. `true` means a builder VM currently owns the image, which is
+/// the signal that this build should look for a session to share rather than
+/// queue behind it.
+///
+/// Any non-contention error reads as not-contended, so a broken or
+/// unlockable sidecar sends the caller down the ordinary path, where the real
+/// acquire reports the real error instead of this probe guessing at it.
+pub fn nix_store_image_is_contended(builder_cache_dir: &Path, arch: &str) -> bool {
+    let image = builder_cache_dir.join(format!("nix-store-{arch}.img"));
+    let lock_path = sidecar_lock_path(&image);
+    if !lock_path.exists() {
+        // No sidecar means no builder has ever locked this image, and probing
+        // would create the file as a side effect. Report free.
+        return false;
+    }
+    match acquire_sidecar_lock_within(&lock_path, LockWait::none()) {
+        // Took it, so nobody else held it. Released as this returns.
+        Ok(_) => false,
+        Err(BuilderVmError::ExtractionFailed(msg)) => msg.contains("is still held by"),
+        Err(_) => false,
+    }
+}
+
 /// Find or create the persistent `<builder_cache_dir>/nix-store-<arch>.img`
 /// sparse image and hold an exclusive host-side lock on it.
 ///
@@ -727,6 +753,43 @@ mod tests {
             describe_lock_holder(&lock_path, 0),
             "another mvm builder process"
         );
+    }
+
+    #[test]
+    fn a_free_store_image_does_not_read_as_contended() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let cache = scratch.path().join("builder-vm");
+
+        // Never locked: no sidecar exists yet, and probing must not create one
+        // as a side effect.
+        assert!(!nix_store_image_is_contended(&cache, "aarch64"));
+        assert!(
+            !cache.join("nix-store-aarch64.img.lock").exists(),
+            "the probe must not leave a sidecar behind"
+        );
+
+        // Locked once, then released.
+        let guard = acquire_nix_store_image_lock(&cache, "aarch64", 64).unwrap();
+        drop(guard);
+        assert!(
+            !nix_store_image_is_contended(&cache, "aarch64"),
+            "a released lock is not contention"
+        );
+    }
+
+    #[test]
+    fn a_held_store_image_reads_as_contended_and_the_probe_does_not_steal_it() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let cache = scratch.path().join("builder-vm");
+        let guard = acquire_nix_store_image_lock(&cache, "aarch64", 64).unwrap();
+
+        assert!(nix_store_image_is_contended(&cache, "aarch64"));
+        // Probing is not acquiring: the holder still holds it afterwards, so a
+        // second probe sees the same answer.
+        assert!(nix_store_image_is_contended(&cache, "aarch64"));
+
+        drop(guard);
+        assert!(!nix_store_image_is_contended(&cache, "aarch64"));
     }
 
     #[test]

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -744,6 +744,120 @@ pub fn session_record_path() -> Option<PathBuf> {
         .map(|d| d.join("run").join("persistent-builder.json"))
 }
 
+/// Starts a persistent builder session and returns its record.
+///
+/// Registered by `mvm-cli`, which owns what a start needs — host-binary
+/// extraction, builder-image resolution, writing the session record — none of
+/// which this crate can reach without inverting the dependency direction. Same
+/// arrangement as `builder_backend_select::register_hvf_builder`.
+pub type SessionStarter = Box<dyn Fn() -> anyhow::Result<SessionRecord> + Send + Sync>;
+
+static SESSION_STARTER: std::sync::OnceLock<SessionStarter> = std::sync::OnceLock::new();
+
+/// Register the session starter. Called once at CLI startup; later calls are
+/// ignored.
+pub fn register_session_starter(starter: SessionStarter) {
+    let _ = SESSION_STARTER.set(starter);
+}
+
+/// Marker naming the process currently starting a session.
+///
+/// Created with `create_new`, so exactly one racing builder wins it. Two builds
+/// hitting a contended store image at the same moment would otherwise both
+/// boot a VM, and the loser's supervisor would fail to take the store lock and
+/// exit — safe, but a wasted boot and a confusing error.
+fn session_start_marker_path() -> Option<PathBuf> {
+    session_record_path().map(|p| p.with_extension("starting"))
+}
+
+/// How long a build that lost the start race waits for the winner's record.
+/// Covers a cold builder boot, which formats and seeds the store disk; the
+/// alternative is falling through to queue for the image anyway.
+const SESSION_START_WAIT: Duration = Duration::from_secs(180);
+
+/// Outcome of trying to obtain a session to dispatch into.
+#[derive(Debug)]
+pub enum SessionAcquisition {
+    /// A session to dispatch this build into.
+    Ready(SessionRecord),
+    /// No session, and none was started. The caller falls back to the
+    /// single-shot builder, which queues for the store image.
+    Unavailable,
+}
+
+/// Get a session to share, starting one if nobody has.
+///
+/// Called when the store image is already held: this build cannot have the
+/// image to itself, so its options are to queue for it or to join the VM that
+/// holds it. This is the second option.
+///
+/// Losing the start race is not a failure — the loser waits for the winner's
+/// record and dispatches into that same session, which is the point.
+pub fn adopt_or_start_session() -> SessionAcquisition {
+    if let Some(record) = read_active_session() {
+        return SessionAcquisition::Ready(record);
+    }
+    let Some(starter) = SESSION_STARTER.get() else {
+        // Nothing registered (mvmd, tests): adoption only, never auto-start.
+        return SessionAcquisition::Unavailable;
+    };
+    let Some(marker) = session_start_marker_path() else {
+        return SessionAcquisition::Unavailable;
+    };
+    if let Some(parent) = marker.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&marker)
+    {
+        Ok(_) => {
+            let started = starter();
+            // The marker arbitrates the race; it is not a lock. Remove it as
+            // soon as the outcome is known, win or lose, so a failed start
+            // cannot wedge every later build into the waiting branch.
+            let _ = std::fs::remove_file(&marker);
+            match started {
+                Ok(record) => SessionAcquisition::Ready(record),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "starting a persistent builder for the contended store image failed; \
+                         falling back to the single-shot builder"
+                    );
+                    SessionAcquisition::Unavailable
+                }
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            wait_for_started_session(&marker)
+        }
+        Err(_) => SessionAcquisition::Unavailable,
+    }
+}
+
+/// Wait for whoever won the start race to publish a session record.
+fn wait_for_started_session(marker: &Path) -> SessionAcquisition {
+    let deadline = std::time::Instant::now() + SESSION_START_WAIT;
+    while std::time::Instant::now() < deadline {
+        if let Some(record) = read_active_session() {
+            return SessionAcquisition::Ready(record);
+        }
+        if !marker.exists() {
+            // The winner finished or gave up. One more read closes the gap
+            // between it writing the record and removing the marker.
+            return match read_active_session() {
+                Some(record) => SessionAcquisition::Ready(record),
+                None => SessionAcquisition::Unavailable,
+            };
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    SessionAcquisition::Unavailable
+}
+
 /// Read the session record and verify the supervisor is alive.
 /// Returns `None` if the record is missing, malformed, or the
 /// recorded PID isn't a live process — all of which are "no
@@ -1352,6 +1466,75 @@ mod tests {
         let body = std::fs::read(run_dir.join("persistent-builder.json")).unwrap();
         let back: SessionRecord = serde_json::from_slice(&body).unwrap();
         assert_eq!(back.last_activity_unix_secs, Some(55));
+    }
+
+    #[test]
+    fn adoption_prefers_a_live_session_over_starting_another() {
+        // A build that finds the image busy and a session already serving it
+        // must join that session, not boot a second builder.
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let run_dir = scratch.path().join("mvm-home").join("run");
+        std::fs::create_dir_all(&run_dir).expect("run dir");
+        let record = SessionRecord {
+            session_id: "live".into(),
+            dispatch_socket_path: run_dir.join("dispatch.sock"),
+            job_dir: run_dir.join("jobs"),
+            workspace_root: scratch.path().to_path_buf(),
+            // This process: alive by construction.
+            supervisor_pid: std::process::id(),
+            last_activity_unix_secs: None,
+        };
+        std::fs::write(
+            run_dir.join("persistent-builder.json"),
+            serde_json::to_vec(&record).unwrap(),
+        )
+        .expect("write record");
+
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", scratch.path().join("mvm-home"));
+
+        match adopt_or_start_session() {
+            SessionAcquisition::Ready(got) => assert_eq!(got.session_id, "live"),
+            other => panic!("expected the live session, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn without_a_registered_starter_there_is_nothing_to_adopt_or_start() {
+        // mvmd and the unit suite register no starter: adoption only, and
+        // never an auto-start behind the caller's back.
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", scratch.path().join("mvm-home"));
+
+        assert!(matches!(
+            adopt_or_start_session(),
+            SessionAcquisition::Unavailable
+        ));
+        // And no marker was left behind to wedge a later build into waiting.
+        assert!(
+            !scratch
+                .path()
+                .join("mvm-home")
+                .join("run")
+                .join("persistent-builder.starting")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn the_start_marker_sits_beside_the_session_record() {
+        // The two must share a directory: the loser of the race polls for the
+        // record while watching the marker, so a mismatch would make it wait
+        // the full window every time.
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", scratch.path().join("mvm-home"));
+
+        let record = session_record_path().expect("record path");
+        let marker = session_start_marker_path().expect("marker path");
+        assert_eq!(record.parent(), marker.parent());
+        assert_ne!(record, marker);
     }
 
     #[test]

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -406,6 +406,39 @@ fn dev_build_via_builder_vm_uncached(
         }
     }
 
+    // No session was adopted above. Before falling through to a single-shot
+    // builder — which will *queue* for the store image — check whether the
+    // image is already held. If it is, this build cannot have it to itself,
+    // and waiting serializes two builds that could have shared one warm store.
+    // A session is how they share it: adopt a live one, or start one.
+    //
+    // Contention is the trigger, deliberately. An uncontended build takes the
+    // image directly, which is cheaper than booting a session it would be the
+    // only user of.
+    if persistent_routing_allowed(&residency, persistent_dispatch_disabled())
+        && crate::builder_vm_runtime::nix_store_image_is_contended(
+            &crate::builder_vm::builder_vm_cache_dir(),
+            crate::libkrun_builder::host_arch_tag(),
+        )
+        && let crate::persistent_builder::SessionAcquisition::Ready(record) =
+            crate::persistent_builder::adopt_or_start_session()
+    {
+        tracing::info!(
+            session_id = %record.session_id,
+            "store image is busy; sharing the persistent builder that holds it"
+        );
+        match try_typed_persistent_build(env, &record, profile) {
+            Some(Ok(result)) => return Ok(result),
+            Some(Err(e)) => {
+                tracing::warn!(
+                    error = %e,
+                    "dispatch into the shared builder failed; queueing for the store image"
+                );
+            }
+            None => {}
+        }
+    }
+
     // The single-shot path honours the builder-backend selection
     // (`--builder` / `MVM_BUILDER_BACKEND` / auto-detect) instead of
     // hardcoding libkrun, so `mvmctl build` routes a steady-state build through

--- a/crates/mvm-cli/src/commands/build/persistent_builder.rs
+++ b/crates/mvm-cli/src/commands/build/persistent_builder.rs
@@ -84,9 +84,14 @@ pub struct StartArgs {
     #[arg(long)]
     pub workspace: Option<PathBuf>,
     /// Guest memory in MiB for the persistent Nix builder.
-    #[arg(long, default_value_t = 4096)]
+    #[arg(long, default_value_t = DEFAULT_MEMORY_MIB)]
     pub memory_mib: u32,
 }
+
+/// Guest memory for a persistent builder when nobody names one. Shared by the
+/// `--memory-mib` default and the auto-start path, so a build that starts a
+/// session on contention gets the same builder an explicit `start` would.
+const DEFAULT_MEMORY_MIB: u32 = 4096;
 
 #[derive(ClapArgs, Debug, Clone)]
 pub struct SubmitArgs {
@@ -231,6 +236,49 @@ fn run_start(args: StartArgs) -> Result<()> {
     println!("dispatch_socket: {}", record.dispatch_socket_path.display());
     println!("supervisor_pid: {}", record.supervisor_pid);
     Ok(())
+}
+
+/// Start a session on behalf of a build that found the store image busy.
+///
+/// Registered into `mvm-build`, which decides *when* a session is worth
+/// starting but cannot start one: extracting host binaries, resolving a
+/// builder image and writing the session record all live above it in the
+/// dependency graph.
+///
+/// The workspace is the build's own working directory — the tree it would have
+/// handed a single-shot builder — so the session serves `/work` from where the
+/// build expects it.
+pub(crate) fn start_session_for_contended_build()
+-> Result<mvm_build::persistent_builder::SessionRecord> {
+    // Another process may have published a record between `mvm-build`'s check
+    // and this call.
+    if let Ok(existing) = read_session_record() {
+        return Ok(as_build_record(&existing));
+    }
+
+    let backend = persistent_backend(resolve_env_override())?;
+    let workspace = std::env::current_dir()
+        .context("resolving the working directory for the builder session")?;
+    let record = match backend {
+        PersistentBackend::Libkrun => start_libkrun_persistent(workspace, DEFAULT_MEMORY_MIB)?,
+        PersistentBackend::Hvf => start_hvf_persistent(workspace, DEFAULT_MEMORY_MIB)?,
+    };
+    write_session_record(&record)?;
+    Ok(as_build_record(&record))
+}
+
+/// Project the CLI's session record onto `mvm-build`'s copy of the shape. The
+/// two are deliberately separate types — `mvm-build` sits below this crate —
+/// and `session_record_serde_matches_mvm_cli` pins them together.
+fn as_build_record(record: &SessionRecord) -> mvm_build::persistent_builder::SessionRecord {
+    mvm_build::persistent_builder::SessionRecord {
+        session_id: record.session_id.clone(),
+        dispatch_socket_path: record.dispatch_socket_path.clone(),
+        job_dir: record.job_dir.clone(),
+        workspace_root: record.workspace_root.clone(),
+        supervisor_pid: record.supervisor_pid,
+        last_activity_unix_secs: record.last_activity_unix_secs,
+    }
 }
 
 /// Extract the host-vm binaries a persistent builder serves at `/mvm-bins`,

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -511,11 +511,15 @@ fn aux_bin_dir_to_apply(baked: &str, already_set: bool) -> Option<String> {
 /// itself, because host-binary extraction, builder-image resolution and the
 /// session record all live up here. Same inversion as the hvf builder ctor
 /// below.
+#[cfg(feature = "builder-vm")]
 fn register_builder_session_starter() {
     mvm_build::persistent_builder::register_session_starter(Box::new(|| {
         crate::commands::build::persistent_builder::start_session_for_contended_build()
     }));
 }
+
+#[cfg(not(feature = "builder-vm"))]
+fn register_builder_session_starter() {}
 
 fn register_inhouse_builder() {
     // Wire the HVF builder constructor so that

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -269,6 +269,7 @@ fn run_command() -> Result<()> {
     };
     apply_startup_env(&cli);
     register_inhouse_builder();
+    register_builder_session_starter();
     register_stream_plane();
     configure_runtime_logging(&cli);
 
@@ -502,6 +503,18 @@ fn aux_bin_dir_to_apply(baked: &str, already_set: bool) -> Option<String> {
         return None;
     }
     Some(baked.to_string())
+}
+
+/// Let a build start a persistent builder when it finds the store image busy.
+///
+/// `mvm-build` decides *when* sharing beats queueing; it cannot start a session
+/// itself, because host-binary extraction, builder-image resolution and the
+/// session record all live up here. Same inversion as the hvf builder ctor
+/// below.
+fn register_builder_session_starter() {
+    mvm_build::persistent_builder::register_session_starter(Box::new(|| {
+        crate::commands::build::persistent_builder::start_session_for_contended_build()
+    }));
 }
 
 fn register_inhouse_builder() {


### PR DESCRIPTION
Plan 323 Phase 3 — the phase that actually makes two builds concurrent. Builds
on #2391 (queue instead of failing), #2396 (an hvf persistent builder exists at
all) and #2416 (the store lock belongs to the supervisor).

## The problem this closes

Two concurrent `mvmctl build` runs still serialized. The first took the store
image; the second waited. Waiting is correct — one writer per ext4 — but it
makes two builds that *could* have shared one warm store run one after the
other.

A persistent builder is how they share it: Nix inside the guest parallelizes
derivations on its own, so one session serves several builds at once off a
single store. The mechanism has existed for a while, and nothing reached for it
automatically. Now a build that finds the image already held **adopts the
session serving it, or starts one**, and dispatches there.

## Design notes worth a reviewer's attention

**Contention is the trigger, deliberately.** An uncontended build takes the
image directly — booting a session it would be the sole user of is pure
overhead.

**The probe is a probe, not a claim.** `nix_store_image_is_contended` tries the
lock without waiting and releases immediately; treats any non-contention error
as "not contended", so a broken sidecar falls through to the real acquire
rather than this function guessing at the error; and returns early when no
sidecar exists so asking never *creates* one. Tests cover all three.

**Starting is arbitrated by an `O_EXCL` marker** beside the session record.
Without it, two builds hitting a busy image at the same moment both boot a VM,
and with #2416 in place the loser's supervisor fails to take the store lock and
exits — safe, but a wasted boot and a confusing error. The loser instead waits
for the winner's record and dispatches into that same session. The marker is
removed win or lose, so a failed start cannot wedge later builds into the
waiting branch.

**The starter is registered, not called directly.** `mvm-build` decides *when*
sharing beats queueing but cannot start a session — host-binary extraction,
builder-image resolution and the session record all live above it in the
dependency graph. `register_session_starter` inverts that the same way
`register_hvf_builder` already does. Nothing registered (mvmd, the unit suite)
means adoption only, never an auto-start behind the caller's back.

The `--memory-mib` default moves to a constant both paths read, so an
auto-started session is the same builder an explicit `start` would give you
rather than a second literal that can drift.

## Verification

- `cargo nextest run --workspace` — 11364 passed, 26 skipped, 0 failures
- all 53 `xtask check-*` gates — clean
- `cargo clippy --workspace --all-targets -- -D warnings` + nightly fmt — clean

## Note on CI

The `Test eBPF telemetry load/attach` lane is broken repo-wide right now:
`bpf-linker 0.11.0` published 2026-08-12 and its build script fails against the
runner's LLVM, and the lane installs it unpinned. #2403 pins it and is queued;
this PR will need a re-run behind it.