### PR TITLE
Plan 327: a CPU quota for the HVF tier, with its Phase 0 spike measured

### DIFF
--- a/specs/plans/327-hvf-quota-spike-findings.md
+++ b/specs/plans/327-hvf-quota-spike-findings.md
@@ -1,0 +1,287 @@
+# Plan 327 Phase 0 — HVF vCPU quota spike: findings
+
+**Verdict: Phase 1 proceeds**
+
+Measured on this host, 2026-08-12.
+
+## Environment
+
+| | |
+|---|---|
+| OS | macOS 26.5.2 (build 25F84) |
+| Arch | arm64, Apple M4 Max |
+| CPUs | 16 logical (12 P + 4 E) |
+| `kern.hv_support` | 1 |
+| Toolchain | rustup 1.96.0-aarch64-apple-darwin (Homebrew rustc shadow pinned around) |
+| Tree | worktree `mvm-327-quota`, branch `plan/327-hvf-vcpu-quota`, off `origin/main` |
+
+## What was measured, and through what
+
+Two tiers. Both drive **real Hypervisor.framework** through the **real in-repo
+seam**; the difference is the guest.
+
+- **Tier A — real hypervisor, real run loop, synthetic guest.** A throwaway
+  harness creates a real `HvfVm`, a real `HvfVcpu`, and drives
+  `mvm_vmm::vmm::run::run_with_pause_hook` — the production run loop — with a
+  real `HvfHandle::force_exit` from the controller thread. The guest program is
+  hand-assembled arm64 running at EL1 out of mapped guest RAM: a tight loop
+  incrementing a counter the host reads out of the same mapping (so guest
+  forward progress is directly observable at fine granularity). It is **not** a
+  booted Linux kernel. This tier owns the precision numbers because it gives the
+  controller a directly held `force_exit` token and a guest whose instantaneous
+  progress the host can sample.
+- **Tier B — real Linux guest, real device model, production pause path.** The
+  builder-VM kernel and 758 MiB ext4 rootfs already cached at
+  `~/.mvm/cache/builder-vm/aarch64/` booted through the production
+  `boot_kernel_until` with virtio-blk + PL011 + virtio-rng. The controller drives
+  the production `paused: &'static AtomicBool`, which the production watchdog
+  turns into `force_exit`. This tier owns the real-guest confirmation and the
+  hazard provocation.
+
+Accounting in both tiers is per-thread Mach `thread_info(THREAD_BASIC_INFO)`,
+user + system, summed as the plan proposes.
+
+Both binaries were ad-hoc codesigned with `com.apple.security.hypervisor`. No
+production code was modified; the harness lives in `/tmp` and is not committed.
+
+## Structural facts found while wiring the spike
+
+These constrain the design and are not opinions.
+
+1. **The HVF backend is uniprocessor.** `kernel_boot` creates exactly one vCPU
+   and the FDT emits a single `cpu@0`. "Spin every vCPU" is "spin the one vCPU".
+   A quota on this tier can therefore bound at most **1.0 core**, and
+   `max_cpu_millicores > 1000` is not expressible on HVF today.
+2. **The run loop's pause hold sleeps 1 ms per iteration**
+   (`crates/mvm-vmm/src/vmm/run.rs`, the `while should_pause() && !should_stop()`
+   loop). That is the resume-latency quantum, and it is what makes very short
+   periods and extreme quota ratios inaccurate (§Q1).
+3. **The production HVF watchdog force-exits at 5 ms**
+   (`crates/mvm-runtime/src/backends/hvf/kernel_boot.rs`, `step =
+   Duration::from_millis(5)`). A controller that only sets `paused` and lets the
+   watchdog do the cancel therefore cannot enforce a period below ~10 ms. A real
+   quota controller must hold the `VcpuHandle` and call `force_exit` itself.
+   Measured directly in §Q1, tier B.
+4. **`force_exit` cannot interrupt host-side device work.** It only latches a
+   cancel that takes effect at the next `hv_vcpu_run`. This is why the named
+   hazard turns out to be structurally absent rather than merely unobserved
+   (§Hazard).
+
+## Q1 — does holding vCPUs out of `step()` bound a spinning guest?
+
+**Yes.** Headline, tier A, predictive controller, 10 ms period, 50 % quota, 60 s:
+
+```
+wall 60.0044 s   vCPU CPU 30.0000 s   achieved 0.5000 cores   target 0.5000   err -0.01 %
+```
+
+For comparison the Linux cgroup spike reached 1.4937 against 1.5 (-0.42 %).
+
+A first-draft controller that forgave a period's overshoot sat 8–33 % **above**
+target at every period length. Carrying the overshoot forward as debt into the
+next period's budget — which is what `cpu.max` does — is what makes it converge,
+and it is a required part of the design, not an optimisation.
+
+### Period sweep, 50 % quota, 10 s each, debt carry on
+
+| period | controller | achieved cores | err | stall p50 | stall p99 | stall max |
+|---|---|---|---|---|---|---|
+| 1 ms | poll | 0.5808 | **+16.15 %** | 663 µs | 986 µs | 4476 µs |
+| 5 ms | poll | 0.4878 | -2.45 % | 2321 µs | 4901 µs | 5020 µs |
+| 10 ms | poll | 0.5000 | +0.01 % | 4844 µs | 9632 µs | 9958 µs |
+| 20 ms | poll | 0.5002 | +0.05 % | 9069 µs | 13920 µs | 15846 µs |
+| 50 ms | poll | 0.5006 | +0.13 % | 24783 µs | 32673 µs | 36289 µs |
+| 1 ms | predict | 0.3888 | **-22.23 %** | 6 µs | 802 µs | 1031 µs |
+| 5 ms | predict | 0.4997 | -0.07 % | 1890 µs | 3315 µs | 4124 µs |
+| 10 ms | predict | 0.5000 | 0.00 % | 4343 µs | 6888 µs | 7531 µs |
+| 20 ms | predict | 0.4995 | -0.10 % | 9336 µs | 13481 µs | 14230 µs |
+| 50 ms | predict | 0.4998 | -0.05 % | 24203 µs | 31455 µs | 31472 µs |
+
+"poll" reads `thread_info` every `period/16`; "predict" sleeps to the predicted
+exhaustion instant and reads `thread_info` once per period for the debt
+correction.
+
+**1 ms periods do not work** in either controller, for the reason in structural
+fact 2: the hold quantum is 1 ms, so a 500 µs hold cannot be expressed.
+
+### Quota sweep, 10 ms period, predictive, 15 s each
+
+| quota | achieved | target | err |
+|---|---|---|---|
+| 10 % | 0.0572 | 0.1000 | **-42.79 %** |
+| 25 % | 0.2497 | 0.2500 | -0.13 % |
+| 50 % | 0.5000 | 0.5000 | +0.01 % |
+| 75 % | 0.7498 | 0.7500 | -0.02 % |
+| 90 % | 0.8565 | 0.9000 | **-4.83 %** |
+
+The two failures are the same 1 ms quantum seen from both ends: at 10 % the run
+slice is 1 ms, at 90 % the hold is 1 ms. Lengthening the period fixes both,
+confirming the diagnosis:
+
+| period | quota | achieved | target | err |
+|---|---|---|---|---|
+| 50 ms | 10 % | 0.0988 | 0.1000 | -1.22 % |
+| 50 ms | 90 % | 0.9000 | 0.9000 | 0.00 % |
+
+**Enforceable envelope:** accurate to ≈0.1 % whenever both the run slice and the
+hold exceed ~2 ms. At a 10 ms period that is quota ∈ [20 %, 80 %]; a controller
+wanting a wider ratio must lengthen the period.
+
+### Tier B — real Linux guest
+
+Builder rootfs boots, mounts ext4 off virtio-blk, runs `/init` →
+`mvm-host-vm-init`, finds no job, powers off. Whole guest life measured.
+
+| quota (20 ms period) | boot wall | achieved cores | guest clock to poweroff | console bytes |
+|---|---|---|---|---|
+| unthrottled | 0.7939 s | 0.9732 | 0.657084 s | 12747 |
+| 50 % | 1.2177 s | 0.5450 | 1.091662 s | 12747 |
+| 25 % | 2.3679 s | 0.2856 | 2.227390 s | 12749 |
+
+The console output is byte-identical: the guest does the same work, more slowly.
+Accuracy is looser than tier A (+9 %, +14 %) because the measured window is only
+1–2 s — a handful of debt-correction periods — and includes non-CPU-bound VM
+setup and teardown. Tier A is the precision number; this is the confirmation
+that a real guest with a real device model behaves the same way.
+
+Driving the **production `paused` flag alone** at a 500 µs period achieved only
+0.82 cores against a 0.50 target across 20 runs — the 5 ms watchdog cadence
+(structural fact 3), not a failure of the mechanism. Phase 1 must call
+`force_exit` from the quota controller directly.
+
+## Q2 — what does it cost in jitter?
+
+The guest counter is sampled every 5 ms; the per-window increment rate is the
+guest's visible forward progress. Unthrottled baseline over 15 s:
+
+```
+mean 12.72 M/s   p1 11.35 M   p10 11.67 M   p50 11.91 M   p90 14.82 M   p99 15.81 M
+```
+
+The ±10 % spread with no controller running at all is P-core/E-core migration.
+That is the noise floor; anything inside it is not attributable to the quota.
+
+Rates below normalised against the 12.72 M/s baseline. 50 % quota, predictive.
+
+| period | p1 | p10 | p50 | p90 | p99 | stall p50 | stall max |
+|---|---|---|---|---|---|---|---|
+| 5 ms | 0.29 | 0.37 | 0.49 | 0.61 | 0.69 | 1.9 ms | 4.1 ms |
+| 10 ms | 0.23 | 0.36 | 0.52 | 0.70 | 0.83 | 4.3 ms | 7.5 ms |
+| 20 ms | 0.00 | 0.15 | 0.51 | 0.89 | 1.07 | 9.3 ms | 14.2 ms |
+| 50 ms | 0.00 | 0.00 | 0.49 | 1.03 | 1.12 | 24.2 ms | 31.5 ms |
+
+**This is the trade, and it is sharp.** At a 5 ms period the guest paces
+smoothly: the 1st-to-99th percentile band is 0.29–0.69 of baseline, never fully
+stopped, and the longest single freeze is 4.1 ms. At a 50 ms period the same
+mean is delivered by alternating full speed and frozen: over 10 % of 5 ms
+windows show *zero* guest progress, p90 is at full unthrottled rate, and the
+longest freeze is 31.5 ms. A latency-sensitive workload sees a 31 ms stall
+roughly 20 times a second at the long period and nothing above 4 ms at the short
+one.
+
+Stall length tracks `period × (1 - quota)` closely, so the freeze a workload can
+see is predictable from the configuration and should be surfaced as such.
+**Recommended default: 10 ms period** — 7.5 ms worst-case stall, 0.01 % accuracy,
+0.4 % controller cost. 5 ms buys a 2× smaller stall for 2× the controller cost.
+
+The guest sees this as stolen time. Nothing hides it, exactly as the plan's risk
+section says.
+
+## Q3 — is the accounting cheap enough?
+
+Controller thread's own CPU, measured with `thread_info` on itself, 50 % quota.
+
+| period | controller | `thread_info` calls | ctrl cores | **ctrl as % of the enforced budget** |
+|---|---|---|---|---|
+| 1 ms | poll | 121 369 / 10 s | 0.0498 | **8.57 %** |
+| 5 ms | poll | 26 390 | 0.0138 | 2.82 % |
+| 10 ms | poll | 13 517 | 0.0078 | 1.55 % |
+| 20 ms | poll | 6 902 | 0.0045 | 0.90 % |
+| 50 ms | poll | 2 838 | 0.0021 | 0.41 % |
+| 1 ms | predict | 10 006 | 0.0109 | 2.81 % |
+| 5 ms | predict | 2 001 | 0.0038 | 0.76 % |
+| 10 ms | predict | 1 001 | 0.0020 | 0.41 % |
+| 20 ms | predict | 501 | 0.0012 | 0.23 % |
+| 50 ms | predict | 201 | 0.0005 | 0.10 % |
+
+**Yes, if the controller is predictive.** Reading `thread_info` once per period
+and sleeping to the predicted exhaustion instant costs 0.41 % of the budget it
+enforces at a 10 ms period, and does not lose accuracy relative to polling
+(0.00 % vs +0.01 % error) because the debt carry corrects the prediction after
+the fact.
+
+**Where it stops being worth it:** polling at a 1 ms period spends 8.57 % of the
+enforced budget on enforcement, while simultaneously missing the target by
++16 %, so it is strictly dominated. Predictive at 1 ms is cheap (2.81 %) but
+misses by -22 % for the quantum reason. **Below a 5 ms period the mechanism is
+not worth building at any controller design**, because the run loop's 1 ms hold
+quantum caps the achievable precision regardless of how the controller is
+written. Between 5 ms and 50 ms it costs 0.10–0.76 % and is accurate to 0.1 %.
+
+The 60 s headline run at the recommended settings spent 0.13755 CPU-seconds in
+the controller against 30.0000 CPU-seconds delivered to the guest: **0.46 %**.
+
+## The hazard, provoked deliberately
+
+The plan names it: forcing a vCPU out of `step()` while a device operation is
+mid-flight. It was attacked from both tiers.
+
+**Tier A — synthetic device, maximum collision rate.** A `RunDevice` whose
+`write()` busy-waits for a configured span, with a guest program that stores to
+the device window on every loop iteration, and a controller force-exiting every
+500 µs:
+
+| device work per access | duration | device dispatches | force exits | run loop stuck | join | outcome |
+|---|---|---|---|---|---|---|
+| 0 µs | 20 s | 5 886 127 | ~40 000 | none > 25 ms | 0 ms | `Ok(Canceled)`, 0 unexpected exceptions |
+| 1000 µs | 20 s | 8 995 | ~40 000 | none | 0 ms | `Ok(Canceled)`, 0 unexpected exceptions |
+
+In the 1 ms case every force-exit lands while a device operation is in flight by
+construction — the device is busy more than half the time. Nothing deadlocked,
+hung, or produced an unmodelled exit.
+
+**Tier B — real device model, 20 consecutive real Linux boots** under
+pause/resume hammering at a 500 µs period (≈1 640 toggles per 0.8 s boot,
+≈33 000 toggles total), through the ext4 mount and module load where virtio-blk
+traffic is heaviest:
+
+```
+OK=20  FAIL=0
+```
+
+Every boot completed, reached `mvm-host-vm-init`, and returned from the run
+loop. `other_exceptions` stayed at 2 in every run — identical to the
+unhammered control, so the hammering introduced no new exception class. Console
+output was byte-identical in 19 of 20 runs and differed by 4 bytes in one (a
+kernel timestamp digit width — the guest ran slower, so a printk crossed
+`[ 1.0…]`), not corruption.
+
+**Why it does not deadlock, structurally.** `hv_vcpus_exit` cannot interrupt
+host-side device work: the run loop is inside `dispatch()` on the vCPU thread,
+not inside `hv_vcpu_run`, so the cancel is merely latched and takes effect at the
+next entry. Device operations are therefore never torn in half. The consequence
+is a *bounding* limit rather than a safety one: the guest's charge overruns the
+deadline by up to the length of the longest uninterruptible host-side device
+operation. Measured, with a 1 ms synthetic device op and a 500 µs period, that
+showed up as -11.54 % error on the instantaneous target while remaining bounded
+in the long run because the debt carry absorbs it. Phase 1 should state this as
+the granularity floor: **the period must exceed the slowest device operation.**
+
+No defect in `force_exit` or the run loop was found. The 1 ms pause-hold sleep
+and the 5 ms watchdog cadence are design parameters that Phase 1 must work with
+or change, not bugs.
+
+## What Phase 1 inherits from this
+
+- Predictive controller, one `thread_info` read per period, debt carried forward.
+- Default 10 ms period; refuse or round periods below 5 ms.
+- Refuse quota ratios whose run slice or hold would fall below ~2 ms at the
+  chosen period.
+- Hold the `VcpuHandle` and call `force_exit` directly; do not rely on the
+  watchdog's 5 ms cadence.
+- Ceiling of 1.0 core on this tier until the HVF backend becomes multi-vCPU.
+- Phase 2's `EnforcedTier` should report the *measured* achieved fraction: the
+  controller already computes it, and it is the only honest read-back available
+  since there is no kernel file to consult.
+- Surface the worst-case stall (`period × (1 - quota)`) alongside the grant. It
+  is the guest-visible cost and it is predictable.

--- a/specs/plans/327-hvf-vcpu-quota.md
+++ b/specs/plans/327-hvf-vcpu-quota.md
@@ -1,6 +1,12 @@
 # Plan 327 — A CPU quota for the HVF tier, enforced in our own run loop
 
-**Status: OPEN — Phase 0 (spike) blocks everything else**
+**Status: OPEN — Phase 0 COMPLETE (verdict: Phase 1 proceeds); Phases 1+ open**
+
+Phase 0 results: [`327-hvf-quota-spike-findings.md`](327-hvf-quota-spike-findings.md).
+Measured 0.5000 cores against a 0.5000 target (-0.01 %) over 60 s at a 10 ms
+period, through the real HVF vCPU and the real run loop, with the controller
+costing 0.46 % of the budget it enforces. The mechanism bounds; the constraints
+Phase 1 must build inside are in that document.
 
 ## Why
 

--- a/specs/plans/327-hvf-vcpu-quota.md
+++ b/specs/plans/327-hvf-vcpu-quota.md
@@ -66,11 +66,24 @@ what it would take instead"**.
 Write the spike as a throwaway harness, not shipped code. It exists to answer
 the three questions, and its value is the numbers.
 
-## Phase 1 — the scheduler (only if Phase 0 says proceed)
+## Phase 1 — the scheduler
 
 - [ ] A quota controller owning `(quota, period)` per VM, driving the existing
       `force_exit` seam and the `run_with_pause_hook` seam already in the run
       loop. No new hypervisor plumbing.
+- [ ] **Predictive, with debt carry-over — not polling.** The spike measured
+      polling at 1.55% of the budget at a 10 ms period and 8.57% at 1 ms *while
+      still missing by +16%*; the predictive controller hit -0.01% at 0.46%
+      cost. Without carrying debt across periods every period ran 8-33% high.
+- [ ] **Period floor of 5 ms**, and the period must exceed the slowest device
+      operation — a 1 ms device op at a 500 us period produced -11.5%
+      instantaneous error. Below 5 ms no controller design pays for itself.
+- [ ] **Three existing-code constraints**, each surfaced by the spike:
+      the HVF backend is uniprocessor, so the ceiling is 1.0 core until that
+      changes; the run-loop pause hold sleeps 1 ms, which kills 1 ms periods and
+      the 10%/90% quotas at 10 ms; and the production watchdog cancels only
+      every 5 ms, so the controller must hold the `VcpuHandle` itself rather
+      than relying on the watchdog.
 - [ ] Per-vCPU-thread accounting via Mach `thread_info`, summed per VM.
 - [ ] `ResourceControls::for_backend(Hvf)` gains a real `CpuControl`, replacing
       today's honest `None`.

--- a/specs/plans/327-hvf-vcpu-quota.md
+++ b/specs/plans/327-hvf-vcpu-quota.md
@@ -1,0 +1,98 @@
+# Plan 327 — A CPU quota for the HVF tier, enforced in our own run loop
+
+**Status: OPEN — Phase 0 (spike) blocks everything else**
+
+## Why
+
+Claim 18 records that CPU is enforced on Linux and declared-only on macOS.
+The mechanism on Linux is a cgroup v2 `cpu.max` on a systemd transient scope;
+macOS has no host-level quota primitive at all, so a `CpuGrant::Share` there
+is refused under `--prod` and warned about under dev.
+
+That limit is currently phrased as a property of macOS. It is really a
+property of *which VMM we are driving*. On the HVF tier the VMM is ours: the
+run loop calls `HypervisorVcpu::step()` and `VcpuHandle::force_exit` already
+exists to pull vCPUs out of it from another thread — "Batched: HVF does it in
+one call (`hv_vcpus_exit`)". A quota is therefore implementable above the
+hypervisor rather than below it: measure each vCPU thread's consumed CPU time,
+and when a period's budget is spent, force the vCPUs out and hold them until
+the period rolls over. That is what `cpu.max` does — quota over period — with
+the accounting in userspace.
+
+**libkrun is explicitly out of scope, permanently.** It is a third-party
+in-process VMM; we do not drive its vCPUs and cannot hold them. On macOS 13-25,
+where libkrun is the default, CPU stays declared-only. This plan bounds the
+macOS 26+ Apple Silicon tier and says so.
+
+A side benefit worth stating but not designing for: the seam is shared with
+KVM, so the same scheduler would give Linux a cgroup-free fallback on hosts
+where delegation is unavailable — which the Plan 308 spike found is not rare.
+
+## What this is not
+
+Not a replacement for cgroups where cgroups exist. Linux keeps `cpu.max`: it
+throttles below the guest, invisibly, and this cannot.
+
+## Phase 0 — the spike. Blocks Phases 1+.
+
+Three questions, answered by measurement on real Apple Silicon before any
+design is committed. A negative answer to (1) ends the plan.
+
+1. **Does holding vCPUs out of `step()` actually bound a spinning guest?**
+   Boot an HVF guest, spin every vCPU, hold them for a measured fraction of
+   each period, and compare achieved host CPU against the target. Report
+   measured-vs-target the way the Linux spike did (it reached 1.4937 cores
+   against 1.5).
+2. **What does it cost in jitter?** A vCPU held out of `step()` is a stall the
+   guest can see, where cgroup throttling is invisible below it. Measure the
+   distribution, not just the mean — a bound that meets its average by
+   alternating full-speed and frozen is a different product than one that
+   paces smoothly.
+3. **Is the accounting cheap enough?** Per-thread Mach `thread_info` polling
+   costs CPU itself. Measure the controller's own consumption; a scheduler that
+   spends a meaningful slice of the budget it is enforcing is not viable.
+
+**Deliverable:** `specs/plans/327-hvf-quota-spike-findings.md` with the raw
+numbers, the period/quota values tried, and a one-line verdict — **"Phase 1
+proceeds"** or **"the approach does not bound / costs too much, and here is
+what it would take instead"**.
+
+Write the spike as a throwaway harness, not shipped code. It exists to answer
+the three questions, and its value is the numbers.
+
+## Phase 1 — the scheduler (only if Phase 0 says proceed)
+
+- [ ] A quota controller owning `(quota, period)` per VM, driving the existing
+      `force_exit` seam and the `run_with_pause_hook` seam already in the run
+      loop. No new hypervisor plumbing.
+- [ ] Per-vCPU-thread accounting via Mach `thread_info`, summed per VM.
+- [ ] `ResourceControls::for_backend(Hvf)` gains a real `CpuControl`, replacing
+      today's honest `None`.
+
+## Phase 2 — report what was achieved, not what was asked
+
+- [ ] A new `EnforcedTier` variant for this mechanism, reported from the
+      scheduler's own state. This is the one place the Linux design does not
+      transfer: there is no kernel file to read back, so the tier's honesty
+      rests on the scheduler reporting its *measured* achievement, not its
+      configured target. Design that in from the start.
+- [ ] The tier reaches the audit chain and `machine inspect` through the paths
+      Plan 308 already built.
+
+## Phase 3 — claim 18
+
+- [ ] Update limit 1. It currently reads "not built on macOS rather than
+      impossible there"; if Phase 1 lands it becomes enforced on the HVF tier
+      and declared-only on libkrun, with the reason being the VMM rather than
+      the OS.
+- [ ] Witnesses for the achieved bound, including a live measurement — the
+      Plan 308 CPU claim rests on one and this should too.
+
+## Risks
+
+- **The guest sees stolen time.** Nothing hides it the way a cgroup does.
+- **The hot path is the hot path.** This adds work to the run loop, which is
+  the most latency-sensitive code in the system.
+- **A held vCPU must not deadlock the device model.** Forcing exit while a
+  device operation is mid-flight is the obvious hazard; the spike should
+  provoke it deliberately rather than hope.


### PR DESCRIPTION
## Summary

Plan 327 plus its Phase 0 spike, run on real Apple Silicon. **Verdict: Phase 1 proceeds.**

Claim 18 records CPU as enforced on Linux and declared-only on macOS. That limit is really about *which VMM we drive*, not about the OS: on the HVF tier the VMM is ours, `VcpuHandle::force_exit` already pulls vCPUs out of `step()` from another thread, and `run_with_pause_hook` already exists in the run loop. So a quota is implementable above the hypervisor — account each vCPU thread's CPU time, and when a period's budget is spent, hold the vCPUs until it rolls over.

**libkrun is permanently out of scope.** It is a third-party in-process VMM; we do not drive its vCPUs and cannot hold them. macOS 13-25, where libkrun is the default, stays declared-only. This bounds the macOS 26+ Apple Silicon tier.

## What the spike measured

**It bounds, precisely.** 0.5000 achieved cores against a 0.5000 target — **-0.01%** — at a 10 ms period, through the real `HvfVm`/`HvfVcpu`, the real `run_with_pause_hook`, and the real `force_exit`. Confirmed on a **real Linux guest** with the real device model: 0.9732 / 0.5450 / 0.2856 cores at 100 / 50 / 25%, with byte-identical console output.

**The controller design is not a free choice.** Predictive with debt carry-over cost **0.46%** of the budget it enforces. Polling cost 1.55% at 10 ms and **8.57% at 1 ms while still missing by +16%**. Without carrying debt across periods, every period ran 8-33% high.

**The jitter trade is the real finding.** At a 5 ms period, guest progress stays between 0.29 and 0.69 of baseline (p1-p99), never zero, worst freeze 4.1 ms. At 50 ms the mean is identical but **>10% of windows show zero progress** and the worst freeze is 31.5 ms. Stall ≈ period × (1 − quota). A latency-sensitive workload cares enormously which of those it gets, and the mean alone would have hidden it.

**The named hazard did not materialise, for a structural reason.** Forcing a vCPU out mid-device-operation cannot deadlock: `hv_vcpus_exit` only latches, so device work is never torn in half — 5.9M synthetic dispatches and 20/20 real Linux boots under ~33,000 pause toggles all completed clean. The real consequence is a granularity floor: the period must exceed the slowest device operation.

## Three constraints in existing code, folded into Phase 1

The HVF backend is uniprocessor, so the ceiling is 1.0 core until that changes. The run-loop pause hold sleeps 1 ms, which kills 1 ms periods and the 10%/90% quotas at 10 ms. The production watchdog cancels only every 5 ms, so the controller must hold the `VcpuHandle` itself.

## What this is not

Not a replacement for cgroups where they exist. Linux keeps `cpu.max`: it throttles below the guest, invisibly, and this cannot — the guest sees stolen time.

Documentation only. No production code changed; the harness lived in `/tmp` and is deliberately not shipped.
