### PR TITLE
Fix SDK sidecar host service startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3092,6 +3092,7 @@ dependencies = [
  "ed25519-dalek",
  "flate2",
  "hex",
+ "mvm-agentd",
  "mvm-build",
  "mvm-cli",
  "mvm-client",

--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
@@ -107,6 +107,10 @@ pub(crate) fn apply_activation(
     let new_root = guest_mount::mount_rootfs(&env.rootfs)?;
     guest_mount::mount_runtime_overlay(env.runtime.as_ref(), &new_root)?;
     guest_mount::mount_volumes(&env.volumes, &new_root)?;
+    #[cfg(target_os = "linux")]
+    if let Some(device) = mvm_agentd::guest_bootstrap::cmdline_value("mvm.sdk_dev") {
+        guest_mount::mount_sdk_sidecar(&device, &new_root)?;
+    }
     if env.rootfs.in_place {
         // Shared-kernel container: the runtime already owns `/`, so there is
         // no staged root to pivot into — activation is the privilege drop

--- a/crates/mvm-agentd/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-oci-init.rs
@@ -30,6 +30,10 @@ mod linux {
             std::process::exit(1);
         }
         ensure_runtime_dirs();
+        if let Err(error) = mount_sdk_sidecar() {
+            eprintln!("mvm-oci-init: SDK sidecar activation failed: {error}");
+            std::process::exit(1);
+        }
         if let Err(error) = mount_user_volumes() {
             eprintln!("mvm-oci-init: user-volume activation failed: {error}");
             std::process::exit(1);
@@ -122,6 +126,14 @@ mod linux {
             .map_err(|error| error.to_string())
     }
 
+    fn mount_sdk_sidecar() -> Result<(), String> {
+        let Some(device) = cmdline_value("mvm.sdk_dev") else {
+            return Ok(());
+        };
+        mvm_agentd::guest_mount::mount_sdk_sidecar(&device, Path::new("/"))
+            .map_err(|error| error.to_string())
+    }
+
     fn parse_user_volumes(encoded: &str) -> Result<Vec<mvm_agentd::vsock::VolumeConfig>, String> {
         let mut volumes = Vec::new();
         for item in encoded.split(';').filter(|s| !s.is_empty()) {
@@ -166,22 +178,26 @@ mod linux {
                 names.push(name.to_string());
             }
         }
-        trailing_user_block_devices(names, count)
+        let sdk_device = cmdline_value("mvm.sdk_dev");
+        trailing_user_block_devices(names, count, sdk_device.as_deref())
     }
 
     fn trailing_user_block_devices(
         names: Vec<String>,
         count: usize,
+        excluded_device: Option<&str>,
     ) -> Result<Vec<PathBuf>, String> {
         if count == 0 {
             return Ok(Vec::new());
         }
+        let excluded_name = excluded_device.and_then(|device| device.strip_prefix("/dev/"));
         let mut devices: Vec<String> = names
             .into_iter()
             .filter(|name| {
                 let bytes = name.as_bytes();
                 bytes.len() == 3 && bytes.starts_with(b"vd") && bytes[2].is_ascii_lowercase()
             })
+            .filter(|name| excluded_name != Some(name.as_str()))
             .collect();
         devices.sort_unstable();
         if devices.len() < count {
@@ -330,6 +346,7 @@ mod linux {
                     "nvme0n1".to_string(),
                 ],
                 2,
+                None,
             )
             .unwrap();
             assert_eq!(
@@ -340,17 +357,28 @@ mod linux {
 
         #[test]
         fn user_block_devices_refuse_an_incomplete_vmm_disk_set() {
-            let error = trailing_user_block_devices(vec!["vda".to_string()], 2).unwrap_err();
+            let error = trailing_user_block_devices(vec!["vda".to_string()], 2, None).unwrap_err();
             assert!(error.contains("expected 2 user block devices"));
         }
 
         #[test]
         fn user_block_devices_are_empty_when_no_block_volume_was_requested() {
             assert!(
-                trailing_user_block_devices(Vec::new(), 0)
+                trailing_user_block_devices(Vec::new(), 0, None)
                     .unwrap()
                     .is_empty()
             );
+        }
+
+        #[test]
+        fn user_block_devices_exclude_the_dedicated_sdk_sidecar() {
+            let devices = trailing_user_block_devices(
+                vec!["vda".to_string(), "vdb".to_string(), "vdc".to_string()],
+                1,
+                Some("/dev/vdc"),
+            )
+            .unwrap();
+            assert_eq!(devices, vec![PathBuf::from("/dev/vdb")]);
         }
 
         #[test]

--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -245,6 +245,32 @@ pub fn mount_runtime_overlay(runtime: Option<&RuntimeOverlayConfig>, root: &Path
     Ok(())
 }
 
+/// Mount the reserved SDK sidecar at its fixed guest path.
+///
+/// This disk is host-produced and is never part of the generic user-volume
+/// namespace. It remains read-only, nosuid, and nodev, while executable
+/// mappings stay enabled for the host-services shared library it contains.
+pub fn mount_sdk_sidecar(device: &str, root: &Path) -> Result<()> {
+    validate_virtio_block_device(device, "SDK sidecar")?;
+    let target = root.join(
+        mvm_core::plan::SDK_SIDECAR_GUEST_PATH
+            .strip_prefix('/')
+            .expect("SDK sidecar guest path is absolute"),
+    );
+    ensure_dir(&target.to_string_lossy())?;
+
+    #[cfg(target_os = "linux")]
+    mount(
+        device,
+        &target.to_string_lossy(),
+        "ext4",
+        libc::MS_RDONLY | libc::MS_NOSUID | libc::MS_NODEV,
+        "",
+    )?;
+
+    Ok(())
+}
+
 /// Reserved mountpoints that volumes are not allowed to shadow.
 #[cfg(test)]
 pub(crate) const RESERVED_MOUNTS: &[&str] =
@@ -351,19 +377,24 @@ fn resolve_volume_mount_source(volume: &VolumeConfig) -> Result<(&str, &'static 
                     volume.tag
                 ))
             })?;
-            let suffix = device.strip_prefix("/dev/vd").ok_or_else(|| {
-                MountError::PathPolicyDenied(format!(
-                    "block volume device {device:?} is outside /dev/vd[a-z]"
-                ))
-            })?;
-            if suffix.len() != 1 || !suffix.bytes().all(|byte| byte.is_ascii_lowercase()) {
-                return Err(MountError::PathPolicyDenied(format!(
-                    "block volume device {device:?} is outside /dev/vd[a-z]"
-                )));
-            }
+            validate_virtio_block_device(device, "block volume")?;
             Ok((device, "ext4"))
         }
     }
+}
+
+fn validate_virtio_block_device(device: &str, purpose: &str) -> Result<()> {
+    let suffix = device.strip_prefix("/dev/vd").ok_or_else(|| {
+        MountError::PathPolicyDenied(format!(
+            "{purpose} device {device:?} is outside /dev/vd[a-z]"
+        ))
+    })?;
+    if suffix.len() != 1 || !suffix.bytes().all(|byte| byte.is_ascii_lowercase()) {
+        return Err(MountError::PathPolicyDenied(format!(
+            "{purpose} device {device:?} is outside /dev/vd[a-z]"
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(any(target_os = "linux", test))]
@@ -1421,6 +1452,14 @@ mod tests {
             device: Some("/dev/sda".to_string()),
         };
         assert!(resolve_volume_mount_source(&invalid_block).is_err());
+    }
+
+    #[test]
+    fn sdk_sidecar_device_is_confined_to_virtio_block_nodes() {
+        assert!(validate_virtio_block_device("/dev/vde", "SDK sidecar").is_ok());
+        assert!(validate_virtio_block_device("/dev/sda", "SDK sidecar").is_err());
+        assert!(validate_virtio_block_device("/dev/vdaa", "SDK sidecar").is_err());
+        assert!(validate_virtio_block_device("../../dev/vde", "SDK sidecar").is_err());
     }
 
     #[test]

--- a/crates/mvm-backends/src/legacy/hvf.rs
+++ b/crates/mvm-backends/src/legacy/hvf.rs
@@ -670,6 +670,13 @@ impl VmBackend for HvfBackend {
         // still runs). The guard reaps the registration if a later start step
         // fails; defused once the VM is confirmed up (the stop path then owns
         // teardown).
+        let host_services = config
+            .plan_json
+            .as_deref()
+            .map(mvm_core::plan::plan_from_admitted_json)
+            .transpose()
+            .context("parse admitted plan host services")?
+            .map_or_else(Vec::new, |plan| plan.services);
         let mut host_agent_guard =
             match mvm_vmm::host::host_agent_spawn::register_host_agent_services_if_admitted(
                 mvm_vmm::host::host_agent_spawn::HostAgentServicesParams {
@@ -678,6 +685,7 @@ impl VmBackend for HvfBackend {
                     vm_name: &config.name,
                     state_dir: &state_dir,
                     broker_listen_socket: &broker_listen_socket,
+                    services: &host_services,
                 },
             ) {
                 Ok(g) => g,

--- a/crates/mvm-backends/src/legacy/libkrun.rs
+++ b/crates/mvm-backends/src/legacy/libkrun.rs
@@ -1016,6 +1016,13 @@ impl VmBackend for LibkrunBackend {
         // (the default; opt out with MVM_HOST_AGENT_DAEMON=0).
         let broker_listen_socket =
             mvm_core::config::vm_vsock_port_socket(&config.name, mvm_agentd::vsock::BROKER_PORT);
+        let host_services = config
+            .plan_json
+            .as_deref()
+            .map(mvm_core::plan::plan_from_admitted_json)
+            .transpose()
+            .context("parse admitted plan host services")?
+            .map_or_else(Vec::new, |plan| plan.services);
         let mut broker_guard = if mvm_vmm::host::host_agent_spawn::host_agent_daemon_enabled() {
             match mvm_vmm::host::host_agent_spawn::register_host_agent_services_if_admitted(
                 mvm_vmm::host::host_agent_spawn::HostAgentServicesParams {
@@ -1024,6 +1031,7 @@ impl VmBackend for LibkrunBackend {
                     vm_name: &config.name,
                     state_dir: &state_dir,
                     broker_listen_socket: &broker_listen_socket,
+                    services: &host_services,
                 },
             ) {
                 Ok(g) => mvm_vmm::host::host_agent_spawn::ServicesGuard::Agent(g),
@@ -1040,6 +1048,7 @@ impl VmBackend for LibkrunBackend {
                     vm_name: &config.name,
                     state_dir: &state_dir,
                     broker_listen_socket: &broker_listen_socket,
+                    services: &host_services,
                 },
             ) {
                 Ok(guard) => mvm_vmm::host::host_agent_spawn::ServicesGuard::Fork(guard),

--- a/crates/mvm-build/src/guest_agent_build.rs
+++ b/crates/mvm-build/src/guest_agent_build.rs
@@ -59,6 +59,10 @@ pub struct GuestRuntimeBinaryPaths<'a> {
     pub verity_init: &'a Path,
 }
 
+/// Bump when a previously populated source-keyed guest cache may contain
+/// outputs produced through an incompatible build-cache contract.
+const GUEST_SOURCE_CACHE_EPOCH: u32 = 2;
+
 impl GuestAgentLayout {
     /// `cache_key` names the cache generation: an mvmctl `version` for a
     /// compatibility cache, or a guest source fingerprint (`source_cache_key`)
@@ -259,11 +263,17 @@ impl GuestAgentBuildSpec {
     }
 }
 
-/// The cache-scoped cargo target dir for the guest cross-compile under
-/// `cache_root`. Kept off the source tree so a contributor's `run --image`
-/// guest build never writes into any checkout's `target/`.
-pub fn guest_build_target_dir(cache_root: &Path) -> PathBuf {
-    cache_root.join("guest-agent-build").join("target")
+/// The source-isolated Cargo target dir for a guest cross-compile.
+///
+/// Sharing one target directory across worktrees lets Cargo accept another
+/// checkout's newer output without recompiling. Hashing the content key keeps
+/// paths safe and gives every source generation a distinct dependency graph.
+pub fn guest_build_target_dir(cache_root: &Path, build_key: &str) -> PathBuf {
+    let digest = Sha256::digest(build_key.as_bytes());
+    cache_root
+        .join("guest-agent-build")
+        .join("targets")
+        .join(&hex::encode(digest)[..16])
 }
 
 /// True when `dir` is the root of an mvm source checkout: it carries a top-level
@@ -285,18 +295,31 @@ pub fn source_workspace_from(start: &Path) -> Option<PathBuf> {
 /// The mvm source workspace to build the legacy rootfs-injected guest runtime
 /// from, or `None` for an installed binary with no source fallback.
 ///
-/// Resolution: the invoking process's `current_dir` first (so a contributor
-/// running from any worktree/clone builds THAT tree's guest sources, not the
-/// checkout mvmctl happened to be compiled in), walking up to the root; then the
-/// compile-time `CARGO_MANIFEST_DIR` ancestor (preserves an in-place `cargo run`
-/// whose cwd isn't the root); else `None`.
+/// Resolution: the running executable's checkout first, then the invoking
+/// process's current checkout, then the compile-time `CARGO_MANIFEST_DIR`
+/// ancestor. An explicitly invoked worktree binary must keep its host and guest
+/// code from the same tree even when the caller's shell is in another checkout.
+/// Installed binaries have no checkout ancestor and therefore retain the
+/// current-directory source fallback.
 pub fn detect_source_workspace() -> Option<PathBuf> {
-    if let Ok(cwd) = std::env::current_dir()
-        && let Some(ws) = source_workspace_from(&cwd)
-    {
-        return Some(ws);
-    }
-    source_workspace_from(Path::new(env!("CARGO_MANIFEST_DIR")))
+    let executable = std::env::current_exe().ok();
+    let current_dir = std::env::current_dir().ok();
+    source_workspace_for(
+        executable.as_deref(),
+        current_dir.as_deref(),
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+    )
+}
+
+fn source_workspace_for(
+    executable: Option<&Path>,
+    current_dir: Option<&Path>,
+    compiled_manifest_dir: &Path,
+) -> Option<PathBuf> {
+    executable
+        .and_then(source_workspace_from)
+        .or_else(|| current_dir.and_then(source_workspace_from))
+        .or_else(|| source_workspace_from(compiled_manifest_dir))
 }
 
 /// Cache-key segment for a source-checkout guest build: a `src-` prefixed
@@ -305,7 +328,10 @@ pub fn detect_source_workspace() -> Option<PathBuf> {
 /// version+arch-cached agent. The `src-` prefix keeps it from ever colliding
 /// with a version-keyed (shipped-binary) cache entry.
 pub fn source_cache_key(workspace_root: &Path) -> Result<String, GuestAgentBuildError> {
-    Ok(format!("src-{}", guest_source_fingerprint(workspace_root)?))
+    Ok(format!(
+        "src-v{GUEST_SOURCE_CACHE_EPOCH}-{}",
+        guest_source_fingerprint(workspace_root)?
+    ))
 }
 
 /// Where the guest binaries come from on this host, and the cache key that
@@ -436,7 +462,7 @@ pub fn resolve_or_build_guest_binaries(
     let spec = GuestAgentBuildSpec::new(
         workspace_root.to_path_buf(),
         arch,
-        guest_build_target_dir(cache_root),
+        guest_build_target_dir(cache_root, cache_key),
     );
     let built = build_guest_binaries(&spec)?;
     install_into_cache(
@@ -524,7 +550,13 @@ pub fn resolve_or_build_runtime_overlay_guest_binaries(
     if layout.is_complete() {
         return Ok(layout.binaries());
     }
-    build_runtime_overlay_guest_binaries_into_cache(cache_root, &layout, workspace_root, arch)
+    build_runtime_overlay_guest_binaries_into_cache(
+        cache_root,
+        &layout,
+        workspace_root,
+        arch,
+        &fingerprint,
+    )
 }
 
 pub fn runtime_overlay_source_checkout_fingerprint(
@@ -558,12 +590,13 @@ fn build_runtime_overlay_guest_binaries_into_cache(
     layout: &RuntimeOverlayGuestLayout,
     workspace_root: &Path,
     arch: GuestArch,
+    fingerprint: &str,
 ) -> Result<RuntimeOverlayGuestBinaries, GuestAgentBuildError> {
     std::fs::create_dir_all(&layout.dir)?;
     let spec = GuestAgentBuildSpec::new(
         workspace_root.to_path_buf(),
         arch,
-        guest_build_target_dir(cache_root),
+        guest_build_target_dir(cache_root, fingerprint),
     );
     let triple = spec.target_triple();
     let cargo = spec.cargo.clone().unwrap_or_else(|| "cargo".into());
@@ -1041,10 +1074,13 @@ mod tests {
     }
 
     #[test]
-    fn guest_build_target_dir_is_under_cache_root() {
-        assert_eq!(
-            guest_build_target_dir(Path::new("/c")),
-            PathBuf::from("/c/guest-agent-build/target")
+    fn guest_build_target_dirs_are_isolated_by_source_key() {
+        let first = guest_build_target_dir(Path::new("/c"), "src-aaa");
+        assert!(first.starts_with("/c/guest-agent-build/targets"));
+        assert_ne!(
+            first,
+            guest_build_target_dir(Path::new("/c"), "src-bbb"),
+            "different source checkouts must never share Cargo outputs"
         );
     }
 
@@ -1207,6 +1243,24 @@ mod tests {
     fn source_workspace_from_none_for_non_checkout() {
         let tmp = tempfile::tempdir().unwrap();
         assert_eq!(source_workspace_from(tmp.path()), None);
+    }
+
+    #[test]
+    fn executable_checkout_wins_over_an_unrelated_current_checkout() {
+        let executable_checkout = tempfile::tempdir().unwrap();
+        let current_checkout = tempfile::tempdir().unwrap();
+        make_fake_checkout(executable_checkout.path(), "fn main() { /* executable */ }");
+        make_fake_checkout(current_checkout.path(), "fn main() { /* current */ }");
+
+        let executable = executable_checkout.path().join("target/debug/mvmctl");
+        let current_dir = current_checkout.path().join("crates/mvm-agentd");
+        let compiled_manifest = executable_checkout.path().join("crates/mvm-build");
+
+        assert_eq!(
+            source_workspace_for(Some(&executable), Some(&current_dir), &compiled_manifest),
+            Some(executable_checkout.path().to_path_buf()),
+            "an explicitly invoked worktree binary must inject guest code from that worktree"
+        );
     }
 
     #[test]

--- a/crates/mvm-build/src/oci_runtime_inject.rs
+++ b/crates/mvm-build/src/oci_runtime_inject.rs
@@ -13,6 +13,7 @@
 //! - `/usr/lib/mvm/wrappers/oci-entrypoint` plus `/etc/mvm/entrypoint`
 //!   when the OCI config declares Entrypoint/Cmd.
 //! - `/mvm/runtime`, the shared runtime overlay mount point.
+//! - `/mvm/sdk`, the reserved read-only SDK sidecar mount point.
 //! - `/etc/mvm/{name,variant}` and, for sealed boots,
 //!   `/etc/mvm/verb-trust.json`.
 //! - For rootfs-only launch shapes, baked guest binaries under
@@ -109,6 +110,7 @@ pub fn inject_mvm_runtime(
         ("data", 0o755),
         ("work", 0o755),
         ("mvm/runtime", 0o755),
+        ("mvm/sdk", 0o755),
         ("usr/lib/mvm/wrappers", 0o755),
     ] {
         ensure_dir(rootfs_dir, rel, mode)?;
@@ -319,6 +321,10 @@ mod tests {
         assert_eq!(written_entrypoint, entrypoint);
         assert!(injected.runtime_mount_point.is_dir());
         assert!(root.join("mvm/runtime").is_dir());
+        assert!(
+            root.join("mvm/sdk").is_dir(),
+            "the sealed root must carry the reserved SDK mountpoint"
+        );
         for rel in [
             "proc", "sys", "dev/pts", "dev/shm", "run", "tmp", "mnt", "data", "work",
         ] {

--- a/crates/mvm-cli/build_aux_helpers.rs
+++ b/crates/mvm-cli/build_aux_helpers.rs
@@ -25,6 +25,16 @@ pub(crate) fn aux_helper_specs(
     let mut specs = vec![
         AuxHelperSpec {
             package: "mvm-hostd",
+            bin: "mvm-host-agent",
+            features: &[],
+        },
+        AuxHelperSpec {
+            package: "mvm-hostd",
+            bin: "mvm-signer-helper",
+            features: &[],
+        },
+        AuxHelperSpec {
+            package: "mvm-hostd",
             bin: "mvm-substitution-endpoint",
             features: &[],
         },
@@ -99,6 +109,14 @@ mod tests {
                 .iter()
                 .any(|spec| spec.bin == "mvm-substitution-endpoint")
         );
+    }
+
+    #[test]
+    fn host_service_helpers_are_built_beside_mvmctl() {
+        let specs = aux_helper_specs("macos", "aarch64", false);
+        for required in ["mvm-host-agent", "mvm-signer-helper"] {
+            assert!(specs.iter().any(|spec| spec.bin == required));
+        }
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/image/materialize.rs
+++ b/crates/mvm-cli/src/commands/image/materialize.rs
@@ -32,7 +32,8 @@ use super::oci_types::OciImageConfig;
 /// cached runtime-lean rootfs entries otherwise panic after the verity handoff.
 /// Epoch 7 adds the allowed top-level block-volume mount roots to sealed OCI
 /// images; an older read-only image cannot create those mountpoints at boot.
-const OCI_RUNTIME_EPOCH: u32 = 7;
+/// Epoch 8 invalidates roots that may contain a stale cross-worktree `/init`.
+const OCI_RUNTIME_EPOCH: u32 = 8;
 
 /// Identity of the legacy guest runtime injected from the invoking source
 /// checkout. Cheap and build-free so it can gate the cache-hit path without

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -182,7 +182,7 @@ fn assert_sdk_run_admission_inputs(summary: super::super::vm::exec::RunSecurityS
     assert_eq!(summary.preflight_mounts, summary.receipt_mounts);
     assert_eq!(summary.preflight_mounts.len(), 1);
     let mount = &summary.preflight_mounts[0];
-    assert_eq!(mount.guest_path, "/workspace");
+    assert_eq!(mount.guest_path, "/work");
     assert!(mount.read_only);
     assert!(!mount.host_path_sha256.contains("/tmp/mvm-sdk-src"));
     assert_eq!(summary.preflight_timeout_secs, 30);
@@ -1117,7 +1117,7 @@ fn rust_sdk_machine_run_matches_cli_admission_and_receipt_inputs() {
         .cpus(4)
         .memory("1G")
         .profile("dev")
-        .volume("/tmp/mvm-sdk-src:/workspace:ro")
+        .volume("/tmp/mvm-sdk-src:/work:ro")
         .env("TOKEN=secret")
         .env("MODE=test")
         .timeout(30)

--- a/crates/mvm-cli/src/commands/shared/parse.rs
+++ b/crates/mvm-cli/src/commands/shared/parse.rs
@@ -214,11 +214,15 @@ pub fn parse_dir_share_spec(spec: &str) -> Result<DirShareSpec> {
             host_dir,
             guest_mount,
             read_only,
-        } => Ok(DirShareSpec {
-            host_dir,
-            guest_mount,
-            read_only,
-        }),
+        } => {
+            validate_guest_mount(&guest_mount)
+                .map_err(|error| anyhow::anyhow!("invalid mount '{spec}': {error}"))?;
+            Ok(DirShareSpec {
+                host_dir,
+                guest_mount,
+                read_only,
+            })
+        }
         VolumeSpec::Disk { .. } => anyhow::bail!(
             "mount '{spec}' includes a disk size; transient machine run accepts only live host-directory shares"
         ),
@@ -499,6 +503,19 @@ mod volume_spec_tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn transient_dir_share_rejects_a_guest_path_outside_the_mount_allow_list() {
+        let error = parse_dir_share_spec("/host/wheels:/wheels:ro")
+            .expect_err("/wheels is outside the guest mount allow-list")
+            .to_string();
+
+        assert!(error.contains("invalid mount"), "unexpected error: {error}");
+        assert!(
+            error.contains("user volumes may only mount under /data, /work, /mnt"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1908,6 +1908,7 @@ fn run_in_guest(
     use std::io::Write as _;
 
     if !wait_for_agent_timed(vm_name, 30, sub) {
+        emit_guest_console_diagnostic(vm_name);
         anyhow::bail!("guest agent did not become reachable within 30s");
     }
     // Agent reachable over vsock: the command is about to be dispatched.
@@ -1998,6 +1999,41 @@ fn run_in_guest(
         Either::Left(exit_code)
     };
     Ok((either, vsock_ready))
+}
+
+const AGENT_FAILURE_CONSOLE_LINES: usize = 80;
+
+fn emit_guest_console_diagnostic(vm_name: &str) {
+    let path = mvm_core::config::vm_console_log(vm_name);
+    let Ok(contents) = std::fs::read(&path) else {
+        eprintln!(
+            "[mvm] Guest console was unavailable at {} before transient cleanup.",
+            path.display()
+        );
+        return;
+    };
+    let diagnostic = redacted_console_tail(&contents, AGENT_FAILURE_CONSOLE_LINES);
+    if diagnostic.is_empty() {
+        eprintln!(
+            "[mvm] Guest console at {} was empty before transient cleanup.",
+            path.display()
+        );
+        return;
+    }
+    eprintln!(
+        "[mvm] Guest console tail before transient cleanup ({}):\n{}",
+        path.display(),
+        diagnostic
+    );
+}
+
+fn redacted_console_tail(contents: &[u8], line_count: usize) -> String {
+    let redactor = mvm_core::pii::PiiRedactor::with_default_rules();
+    let (redacted, _) = redactor.redact(contents);
+    let text = String::from_utf8_lossy(&redacted);
+    let lines = text.lines().collect::<Vec<_>>();
+    let start = lines.len().saturating_sub(line_count);
+    lines[start..].join("\n")
 }
 
 struct PtyConsoleRequest {
@@ -3341,6 +3377,20 @@ mod tests {
             transient_run_dev_console(true, image_sealed),
             "verity-backed accessible OCI images must keep the interactive console armed"
         );
+    }
+
+    #[test]
+    fn agent_failure_console_tail_is_bounded_and_redacted() {
+        let diagnostic = redacted_console_tail(
+            b"discarded\nbooting\nmvm-oci-init: failed for dev@example.com\nkernel panic\n",
+            3,
+        );
+        assert!(!diagnostic.contains("discarded"));
+        assert!(diagnostic.contains("booting"));
+        assert!(diagnostic.contains("mvm-oci-init: failed"));
+        assert!(!diagnostic.contains("dev@example.com"));
+        assert!(diagnostic.contains("XXX"));
+        assert!(diagnostic.contains("kernel panic"));
     }
 
     #[test]

--- a/crates/mvm-conformance/Cargo.toml
+++ b/crates/mvm-conformance/Cargo.toml
@@ -72,6 +72,7 @@ serde.workspace = true
 # than restating its rules, and stage a sidecar cache the resolver verifies.
 # Dev-only: `cargo tree -p mvm-conformance -e no-dev` must not gain these.
 mvm-hostd.workspace = true
+mvm-agentd.workspace = true
 # The HVF supervisor launch contract the save/restore scenarios assert on: the
 # restore rewrite's output IS the security boundary, so the scenarios read the
 # config type directly rather than inferring it from a booted VM.

--- a/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
+++ b/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
@@ -9,7 +9,7 @@ use cucumber::{given, then, when};
 use mvm_contract::protocol::broker::ServiceId;
 use mvm_core::arch::GuestArch;
 use mvm_core::plan::test_support::PlanFixture;
-use mvm_core::vm_backend::{RuntimeSourcePolicy, VmStartConfig};
+use mvm_core::vm_backend::{RuntimeSourcePolicy, VmStartConfig, VmVolume, VmVolumeKind};
 use mvm_fs::sdk_sidecar::{
     SDK_SIDECAR_IMAGE_FILE, SDK_SIDECAR_VERSION_FILE, SdkSidecarLayout, SdkSidecarResolver,
 };
@@ -224,6 +224,18 @@ fn plan_binds_service(world: &mut CliWorld, service: String) {
     world.sdk_sidecar_plan = Some(PlanFixture::new().services(vec![id]).build());
 }
 
+#[given(expr = "a read-only directory mount at {string}")]
+fn read_only_directory_mount(world: &mut CliWorld, guest_path: String) {
+    world.sdk_sidecar_user_volumes.push(VmVolume {
+        host: "/host/wheels".to_string(),
+        guest: guest_path,
+        size: String::new(),
+        read_only: true,
+        kind: VmVolumeKind::DirShare,
+        encrypted: false,
+    });
+}
+
 #[when(expr = "the launch path resolves the SDK sidecar")]
 fn resolve_sidecar(world: &mut CliWorld) {
     let root = cache_root(world);
@@ -236,6 +248,77 @@ fn resolve_sidecar(world: &mut CliWorld) {
             GuestArch::host(),
         )
         .map_err(|e| format!("{e:#}")),
+    );
+}
+
+#[when(expr = "the SDK sends a framed host time request to its bound broker")]
+fn sdk_sends_host_time_request(world: &mut CliWorld) {
+    use std::sync::Arc;
+    use std::sync::mpsc;
+
+    let state = tempfile::tempdir().expect("create broker state dir");
+    let socket = state.path().join("broker.sock");
+    let bindings = world.sdk_sidecar_services.clone();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
+    let server_socket = socket.clone();
+    let server = std::thread::spawn(move || -> Result<(), String> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| error.to_string())?;
+        runtime.block_on(async move {
+            let listener = tokio::net::UnixListener::bind(&server_socket)
+                .map_err(|error| error.to_string())?;
+            let mut registry = mvm_hostd::broker::registry::Registry::new();
+            mvm_hostd::broker::handlers::register_bound_handlers(&mut registry, &bindings);
+            ready_tx.send(()).map_err(|error| error.to_string())?;
+            tokio::select! {
+                result = mvm_hostd::broker::server::serve_on_listener(
+                    listener,
+                    Arc::new(registry),
+                    "bdd-workload".into(),
+                    "bdd-tenant".into(),
+                    65_536,
+                ) => result.map_err(|error| error.to_string()),
+                _ = stop_rx => Ok(()),
+            }
+        })
+    });
+
+    ready_rx
+        .recv()
+        .expect("broker must bind before the SDK dials");
+    let result = std::os::unix::net::UnixStream::connect(&socket)
+        .map_err(anyhow::Error::from)
+        .and_then(|mut stream| {
+            mvm_agentd::host_time::now_on(&mut stream).map_err(anyhow::Error::from)
+        })
+        .map(|response| response.wall_ms)
+        .map_err(|error| format!("{error:#}"));
+    let _ = stop_tx.send(());
+    server
+        .join()
+        .expect("broker server thread must not panic")
+        .expect("broker server must stop cleanly");
+    world.sdk_host_time_result = Some(result);
+}
+
+#[then(expr = "the SDK receives a current host wall clock without a transport error")]
+fn sdk_receives_host_time(world: &mut CliWorld) {
+    let wall_ms = world
+        .sdk_host_time_result
+        .as_ref()
+        .expect("a prior step must call host.time.v1")
+        .as_ref()
+        .unwrap_or_else(|error| panic!("host.time.v1 must cross the framed transport: {error}"));
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("host clock must be after the Unix epoch")
+        .as_millis();
+    assert!(
+        now_ms.saturating_sub(u128::from(*wall_ms)) < 5_000,
+        "broker returned a stale wall clock: {wall_ms}"
     );
 }
 
@@ -285,10 +368,11 @@ fn plan_of(world: &CliWorld) -> &mvm_core::plan::ExecutionPlan {
 }
 
 fn attached_volumes(world: &CliWorld) -> Vec<mvm_core::vm_backend::VmVolume> {
-    match resolved(world) {
-        Ok(Some(a)) => vec![a.volume.clone()],
-        _ => Vec::new(),
+    let mut volumes = world.sdk_sidecar_user_volumes.clone();
+    if let Ok(Some(attachment)) = resolved(world) {
+        volumes.push(attachment.volume.clone());
     }
+    volumes
 }
 
 #[then(expr = "admission accepts the launch with no sidecar attachment")]
@@ -403,5 +487,25 @@ fn cmdline_names_sidecar(world: &mut CliWorld) {
     assert!(
         cmdline.contains("mvm.sdk_dev=/dev/vde"),
         "the cmdline must name the device the backend attached: {cmdline}"
+    );
+}
+
+#[then(expr = "the user-volume manifest names {string} but not the SDK mount")]
+fn user_volume_manifest_excludes_sidecar(world: &mut CliWorld, guest_path: String) {
+    let cmdline = assembled_cmdline(world);
+    let user_path = hex::encode(guest_path.as_bytes());
+    let sdk_path = hex::encode(mvm_core::plan::SDK_SIDECAR_GUEST_PATH.as_bytes());
+    let manifest = cmdline
+        .split_ascii_whitespace()
+        .find(|token| token.starts_with("mvm.uvols="))
+        .expect("the ordinary directory mount must emit a user-volume manifest");
+
+    assert!(
+        manifest.contains(&format!("uvol0:{user_path}:ro:fs")),
+        "the ordinary mount must remain in user-volume activation: {cmdline}"
+    );
+    assert!(
+        !manifest.contains(&sdk_path),
+        "the reserved SDK mount must bypass user-volume activation: {cmdline}"
     );
 }

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -218,6 +218,10 @@ pub struct CliWorld {
     pub sdk_sidecar_release: Option<tempfile::TempDir>,
     /// Host-service bindings the scenario's plan carries.
     pub sdk_sidecar_services: Vec<mvm_contract::protocol::broker::ServiceId>,
+    /// Ordinary workload mounts assembled beside the reserved SDK sidecar.
+    /// Keeping these separate lets the sidecar scenarios prove the two guest
+    /// activation channels cannot accidentally be conflated.
+    pub sdk_sidecar_user_volumes: Vec<mvm_core::vm_backend::VmVolume>,
     /// The signed-plan fixture the sidecar scenarios gate against.
     pub sdk_sidecar_plan: Option<mvm_core::plan::ExecutionPlan>,
     /// Outcome of the most recent sidecar resolution: `Ok(None)` for "not
@@ -225,6 +229,9 @@ pub struct CliWorld {
     /// fail-closed refusal.
     pub sdk_sidecar_result:
         Option<Result<Option<mvm_runtime::sdk_sidecar::SdkSidecarAttachment>, String>>,
+    /// Result of a framed `host.time.v1::now` request against the same bound
+    /// broker registry the host-agent constructs for a workload.
+    pub sdk_host_time_result: Option<Result<u64, String>>,
     /// Root directory for the OCI unpack scenarios.
     pub unpack_root: Option<tempfile::TempDir>,
     /// Paths written by prior layers when unpacking multiple layers.

--- a/crates/mvm-contract/src/protocol/host_time.rs
+++ b/crates/mvm-contract/src/protocol/host_time.rs
@@ -9,9 +9,7 @@
 //!
 //! This module is the shared wire contract for the service: the in-guest
 //! typed client (`mvm_agentd::host_time`) and the host-side broker handler
-//! both deserialize against these types. The handler scaffold is not yet
-//! built, so these types are the sole definition today; when the handler
-//! lands it reuses them unchanged.
+//! both deserialize against these types.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/mvm-hostd/src/bin/mvm-broker.rs
+++ b/crates/mvm-hostd/src/bin/mvm-broker.rs
@@ -20,13 +20,14 @@
 //! Handlers registered at startup:
 //!
 //! - `host.audit.v1` — workload-emitted audit emission. Only
-//!   registered when `cfg.audit_signer_uds_path` is set, since the
+//!   registered when admitted and `cfg.audit_signer_uds_path` is set, since the
 //!   handler needs a UDS path to forward to. If the supervisor spawns
 //!   without an audit-signer (test fixtures, doctor probes), the
 //!   binary logs a warn and `host.audit.v1` calls return `NotBound`.
+//! - `host.time.v1` — registered only when named by the exact admitted
+//!   service bindings; returns the host-authoritative wall clock.
 //!
-//! `host.time.v1`, `host.cost.v1`, and `broker.v1` are still
-//! unregistered; their handler scaffolds land later.
+//! `host.cost.v1` and `broker.v1` remain unregistered.
 
 use std::io::Read;
 use std::sync::Arc;
@@ -38,6 +39,7 @@ use tracing::{error, info, warn};
 use mvm_hostd::broker::audit_client::AuditClient;
 use mvm_hostd::broker::config::{SubprocessConfig, parse as parse_config};
 use mvm_hostd::broker::handlers::host_audit_v1::HostAuditV1Handler;
+use mvm_hostd::broker::handlers::register_bound_handlers;
 use mvm_hostd::broker::registry::Registry;
 use mvm_hostd::broker::server::serve_on_listener;
 
@@ -119,6 +121,12 @@ fn main() -> Result<()> {
 /// leaves the registry without that handler; callers get
 /// `Err(NotBound)` for the missing service.
 fn register_handlers(registry: &mut Registry, cfg: &SubprocessConfig) {
+    register_bound_handlers(registry, &cfg.services_bindings);
+    let host_audit = mvm_core::protocol::broker::ServiceId::parse("host.audit.v1")
+        .expect("host.audit.v1 is a valid ServiceId");
+    if !cfg.services_bindings.contains(&host_audit) {
+        return;
+    }
     match &cfg.audit_signer_uds_path {
         Some(path) => {
             let client = AuditClient::new(path.clone());

--- a/crates/mvm-hostd/src/broker/config.rs
+++ b/crates/mvm-hostd/src/broker/config.rs
@@ -8,6 +8,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use mvm_core::protocol::broker::ServiceId;
 use serde::{Deserialize, Serialize};
 
 /// Config the supervisor hands to a `mvm-broker` subprocess at spawn.
@@ -44,6 +45,9 @@ pub struct SubprocessConfig {
     /// Parse timeout in milliseconds. Capped at 50ms by default.
     #[serde(default = "default_parse_timeout_ms", with = "duration_ms")]
     pub parse_timeout: Duration,
+    /// Exact host-service bindings admitted for this workload.
+    #[serde(default)]
+    pub services_bindings: Vec<ServiceId>,
 }
 
 fn default_max_frame_bytes() -> usize {
@@ -98,6 +102,7 @@ mod tests {
             audit_signer_uds_path: Some(PathBuf::from("/tmp/test/audit-signer.sock")),
             max_frame_bytes: 65_536,
             parse_timeout: Duration::from_millis(50),
+            services_bindings: vec![],
         };
         let bytes = serde_json::to_vec(&cfg).unwrap();
         let parsed: SubprocessConfig = parse(&bytes).unwrap();

--- a/crates/mvm-hostd/src/broker/daemon.rs
+++ b/crates/mvm-hostd/src/broker/daemon.rs
@@ -41,6 +41,7 @@ use crate::audit_signer::helper_client::SignerHelperClient;
 use super::audit_client::AuditClient;
 use super::control::{ControlRequest, ControlResponse, RegisterVm, SignedControl};
 use super::handlers::host_audit_v1::HostAuditV1Handler;
+use super::handlers::register_bound_handlers;
 use super::registry::Registry;
 use super::server::{read_frame, serve_on_listener, write_frame};
 
@@ -370,7 +371,12 @@ impl HostAgentDaemon {
         registry
             .admit_capabilities(r.capability_bindings.clone())
             .context("load host-signed capability bindings")?;
-        if let Some(helper) = &self.signer_helper_uds_path {
+        register_bound_handlers(&mut registry, &r.services_bindings);
+        let host_audit = mvm_core::protocol::broker::ServiceId::parse("host.audit.v1")
+            .expect("host.audit.v1 is a valid ServiceId");
+        if r.services_bindings.contains(&host_audit)
+            && let Some(helper) = &self.signer_helper_uds_path
+        {
             let handler = Arc::new(HostAuditV1Handler::new(AuditClient::new_signer_helper(
                 helper.clone(),
                 r.vm_id.clone(),
@@ -381,7 +387,9 @@ impl HostAgentDaemon {
                     .register_capability(handler.clone(), descriptor)
                     .context("register host.audit typed capability")?;
             }
-        } else if let Some(signer) = &r.audit_signer_uds_path {
+        } else if r.services_bindings.contains(&host_audit)
+            && let Some(signer) = &r.audit_signer_uds_path
+        {
             let handler = Arc::new(HostAuditV1Handler::new(AuditClient::new(signer.clone())));
             registry.register(handler.clone());
             for descriptor in HostAuditV1Handler::capability_descriptors() {
@@ -1046,6 +1054,37 @@ mod tests {
         assert_ne!(correlation_id.as_str(), "guest-picked-id");
     }
 
+    #[tokio::test]
+    async fn host_time_binding_serves_time_without_widening_to_host_audit() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut d = daemon("local");
+        let mut reg = register(dir.path(), "vm-time", "local", None);
+        reg.services_bindings = vec![ServiceId::parse("host.time.v1").unwrap()];
+        let sock = PathBuf::from(&reg.broker_listen_socket);
+        d.apply(&ControlRequest::Register(reg)).unwrap();
+
+        let mut time_client = UnixStream::connect(&sock).await.unwrap();
+        let time_call = ServiceCall {
+            service: ServiceId::parse("host.time.v1").unwrap(),
+            verb: "now".into(),
+            correlation_id: mvm_core::protocol::broker::CorrelationId::new("guest-time"),
+            payload: serde_json::json!({}),
+            capability: None,
+        };
+        write_frame(&mut time_client, &time_call).await.unwrap();
+        let time_response: ServiceResponse = read_frame(&mut time_client, 64 * 1024).await.unwrap();
+        assert!(matches!(time_response, ServiceResponse::Ok { .. }));
+
+        let audit_response = emit_audit(&sock, "not-bound").await;
+        assert!(matches!(
+            audit_response,
+            ServiceResponse::Err {
+                code: mvm_core::protocol::broker::ServiceErrorCode::NotBound,
+                ..
+            }
+        ));
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn helper_backed_registered_vm_can_only_write_its_own_chain() {
         let dir = tempfile::tempdir().unwrap();
@@ -1056,10 +1095,12 @@ mod tests {
 
         let vk = SigningKey::from_bytes(&[5u8; 32]).verifying_key();
         let mut d = HostAgentDaemon::new_with_signer_helper("local", vk, &helper_sock, 64 * 1024);
-        let reg_a = register(dir.path(), "vm-a", "local", None);
+        let mut reg_a = register(dir.path(), "vm-a", "local", None);
+        reg_a.services_bindings = vec![ServiceId::parse("host.audit.v1").unwrap()];
         let sock_a = PathBuf::from(&reg_a.broker_listen_socket);
         let chain_a = PathBuf::from(&reg_a.workload_chain_path);
-        let reg_b = register(dir.path(), "vm-b", "local", None);
+        let mut reg_b = register(dir.path(), "vm-b", "local", None);
+        reg_b.services_bindings = vec![ServiceId::parse("host.audit.v1").unwrap()];
         let chain_b = PathBuf::from(&reg_b.workload_chain_path);
 
         d.apply(&ControlRequest::Register(reg_a)).unwrap();
@@ -1101,7 +1142,8 @@ mod tests {
 
         let vk = SigningKey::from_bytes(&[5u8; 32]).verifying_key();
         let mut d = HostAgentDaemon::new_with_signer_helper("local", vk, &helper_sock, 64 * 1024);
-        let reg = register(dir.path(), "vm-a", "local", None);
+        let mut reg = register(dir.path(), "vm-a", "local", None);
+        reg.services_bindings = vec![ServiceId::parse("host.audit.v1").unwrap()];
         let sock = PathBuf::from(&reg.broker_listen_socket);
         let chain = PathBuf::from(&reg.workload_chain_path);
         d.apply(&ControlRequest::Register(reg)).unwrap();

--- a/crates/mvm-hostd/src/broker/handlers/host_time_v1.rs
+++ b/crates/mvm-hostd/src/broker/handlers/host_time_v1.rs
@@ -1,0 +1,150 @@
+//! `host.time.v1` — host-authoritative wall-clock queries.
+
+use std::pin::Pin;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use mvm_core::policy::security::AgentProfile;
+use mvm_core::protocol::broker::{AuditDurability, Idempotency, ServiceErrorCode, ServiceId};
+use mvm_core::protocol::handler::{
+    ServiceCallCtx, ServiceDispatchResult, ServiceError, ServiceHandler,
+};
+use mvm_core::protocol::host_time::TimeNowResponse;
+
+/// Handler for the `host.time.v1` service.
+pub struct HostTimeV1Handler;
+
+impl HostTimeV1Handler {
+    /// Construct the stateless host-time handler.
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn now(payload: &serde_json::Value) -> ServiceDispatchResult {
+        if payload.as_object().is_none_or(|object| !object.is_empty()) {
+            return Err(ServiceError::new(
+                ServiceErrorCode::BadRequest,
+                "host.time.v1 now payload must be an empty object",
+            ));
+        }
+        let elapsed = SystemTime::now().duration_since(UNIX_EPOCH).map_err(|_| {
+            ServiceError::new(
+                ServiceErrorCode::Unavailable,
+                "host wall clock is before the Unix epoch",
+            )
+        })?;
+        let wall_ms = u64::try_from(elapsed.as_millis()).map_err(|_| {
+            ServiceError::new(
+                ServiceErrorCode::InternalError,
+                "host wall clock does not fit the wire representation",
+            )
+        })?;
+        serde_json::to_value(TimeNowResponse { wall_ms }).map_err(|error| {
+            ServiceError::new(
+                ServiceErrorCode::InternalError,
+                format!("host.time.v1 response encode failed: {error}"),
+            )
+        })
+    }
+}
+
+impl Default for HostTimeV1Handler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ServiceHandler for HostTimeV1Handler {
+    fn id(&self) -> ServiceId {
+        ServiceId::parse("host.time.v1").expect("host.time.v1 is a valid ServiceId")
+    }
+
+    fn profiles(&self) -> &[AgentProfile] {
+        &[
+            AgentProfile::SealedProd,
+            AgentProfile::Dev,
+            AgentProfile::Builder,
+        ]
+    }
+
+    fn audit_durability(&self) -> AuditDurability {
+        AuditDurability::default_batched()
+    }
+
+    fn idempotency(&self) -> Idempotency {
+        Idempotency::MintFresh
+    }
+
+    fn call_timeout(&self) -> Duration {
+        Duration::from_secs(1)
+    }
+
+    fn dispatch<'a>(
+        &'a self,
+        _ctx: &'a ServiceCallCtx,
+        verb: &'a str,
+        payload: serde_json::Value,
+    ) -> Pin<Box<dyn std::future::Future<Output = ServiceDispatchResult> + Send + 'a>> {
+        Box::pin(async move {
+            match verb {
+                "now" => Self::now(&payload),
+                other => Err(ServiceError::new(
+                    ServiceErrorCode::NotImplemented,
+                    format!("host.time.v1: unknown verb `{other}`"),
+                )),
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context() -> ServiceCallCtx {
+        ServiceCallCtx {
+            workload_id: "workload".into(),
+            tenant_id: "tenant".into(),
+            correlation_id: mvm_core::protocol::broker::CorrelationId::new("correlation"),
+            session_id: "session".into(),
+            profile: AgentProfile::Dev,
+            composition_depth: 0,
+            composition_width: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn now_returns_host_wall_clock_milliseconds() {
+        let before = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        let response = HostTimeV1Handler::new()
+            .dispatch(&context(), "now", serde_json::json!({}))
+            .await
+            .unwrap();
+        let after = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        let decoded: TimeNowResponse = serde_json::from_value(response).unwrap();
+        assert!((before..=after).contains(&decoded.wall_ms));
+    }
+
+    #[tokio::test]
+    async fn now_rejects_nonempty_payloads() {
+        let error = HostTimeV1Handler::new()
+            .dispatch(&context(), "now", serde_json::json!({"timezone": "UTC"}))
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, ServiceErrorCode::BadRequest);
+    }
+
+    #[tokio::test]
+    async fn unknown_verb_is_not_implemented() {
+        let error = HostTimeV1Handler::new()
+            .dispatch(&context(), "tomorrow", serde_json::json!({}))
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, ServiceErrorCode::NotImplemented);
+    }
+}

--- a/crates/mvm-hostd/src/broker/handlers/mod.rs
+++ b/crates/mvm-hostd/src/broker/handlers/mod.rs
@@ -4,3 +4,21 @@
 //! the [`crate::broker::registry::Registry`] at startup.
 
 pub mod host_audit_v1;
+pub mod host_time_v1;
+
+use std::sync::Arc;
+
+use mvm_core::protocol::broker::ServiceId;
+
+use self::host_time_v1::HostTimeV1Handler;
+use super::registry::Registry;
+
+/// Register stateless built-in handlers named by an admitted service binding.
+/// Services absent from `bindings` remain unregistered and therefore fail with
+/// `NotBound` at the registry gate.
+pub fn register_bound_handlers(registry: &mut Registry, bindings: &[ServiceId]) {
+    let host_time = ServiceId::parse("host.time.v1").expect("host.time.v1 is a valid ServiceId");
+    if bindings.contains(&host_time) {
+        registry.register(Arc::new(HostTimeV1Handler::new()));
+    }
+}

--- a/crates/mvm-hostd/tests/broker_audit_round_trip.rs
+++ b/crates/mvm-hostd/tests/broker_audit_round_trip.rs
@@ -136,6 +136,7 @@ fn host_audit_v1_round_trip_signs_a_verifiable_workload_chain() {
         "uds_path": broker_sock,
         "host_signer_public_key_path": public_key,
         "audit_signer_uds_path": audit_sock,
+        "services_bindings": ["host.audit.v1"],
     });
     let _broker_guard = Kill(spawn_with_config(BROKER_BIN, &broker_cfg));
 

--- a/crates/mvm-hostd/tests/host_agent_restart.rs
+++ b/crates/mvm-hostd/tests/host_agent_restart.rs
@@ -91,7 +91,7 @@ impl HostAgentFixture {
                     .into_owned(),
             ),
             audit_signer_uds_path: None,
-            services_bindings: vec![],
+            services_bindings: vec![ServiceId::parse("host.audit.v1").expect("service id")],
             capability_bindings: vec![],
         };
         register_vm(&control_socket, &key_bytes, reg).expect("register vm");

--- a/crates/mvm-hostd/tests/per_tenant_isolation.rs
+++ b/crates/mvm-hostd/tests/per_tenant_isolation.rs
@@ -164,7 +164,7 @@ async fn start_tenant(id: &str) -> TenantHandle {
                 .into_owned(),
         ),
         audit_signer_uds_path: None,
-        services_bindings: vec![],
+        services_bindings: vec![ServiceId::parse("host.audit.v1").expect("service id")],
         capability_bindings: vec![],
     };
     register_vm(&control_socket, &key_bytes, reg).expect("register vm");

--- a/crates/mvm-runtime/src/microvm/activation.rs
+++ b/crates/mvm-runtime/src/microvm/activation.rs
@@ -252,6 +252,7 @@ fn build_volume_configs(config: &VmStartConfig) -> Result<Vec<VolumeConfig>> {
         .volumes
         .iter()
         .zip(block_devices)
+        .filter(|(volume, _)| !mvm_vmm::host::spec_map::is_sdk_sidecar_volume(volume))
         .enumerate()
         .map(|(idx, (volume, device))| {
             let (kind, device) = match volume.kind {
@@ -450,6 +451,31 @@ mod tests {
             mvm_agentd::vsock::VolumeConfigKind::Block
         ));
         assert_eq!(env.volumes[1].device.as_deref(), Some("/dev/vdb"));
+    }
+
+    #[test]
+    fn build_env_excludes_the_reserved_sdk_sidecar_from_user_volumes() {
+        let (_env, _dir) = test_env();
+        let config = VmStartConfig {
+            name: "test-vm".into(),
+            roothash: Some(VALID_HASH.into()),
+            runtime_overlay_roothash: Some(VALID_HASH.into()),
+            volumes: vec![
+                VmVolumeKind::Disk.into_volume("/host/data", "/data", false),
+                VmVolumeKind::Disk.into_volume(
+                    "/host/sdk.ext4",
+                    mvm_core::plan::SDK_SIDECAR_GUEST_PATH,
+                    true,
+                ),
+            ],
+            ..base_config()
+        };
+
+        let env = build_activation_environment(&config).unwrap();
+        assert_eq!(env.volumes.len(), 1);
+        assert_eq!(env.volumes[0].tag, "uvol0");
+        assert_eq!(env.volumes[0].mountpoint, "/data");
+        assert_eq!(env.volumes[0].device.as_deref(), Some("/dev/vdb"));
     }
 
     #[test]

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -17,6 +17,7 @@ use mvm_core::crypto::vmgenid::fresh_generation_token;
 use mvm_core::plan::{ExecutionPlan, SecretBinding, StreamRetention};
 use mvm_core::policy::RedactionPolicy;
 use mvm_core::policy::network_policy::NetworkPolicy;
+use mvm_core::protocol::broker::ServiceId;
 use mvm_core::protocol::vm_backend::VerbGrantEnvelope;
 use mvm_core::vm_backend::{
     BackendKind, BackendSecurityProfile, GuestChannelInfo, StandbyClaim, StandbyError,
@@ -121,13 +122,15 @@ pub struct BrokerRegisterRequest<'a> {
     /// The `BROKER_PORT` socket the broker/daemon binds — the same path the spec
     /// wires the guest's `BROKER_PORT` relay to. `None` on the unadmitted path.
     pub broker_listen_socket: Option<&'a Path>,
+    /// Host services from the admitted plan. Empty means no broker process is
+    /// needed and every broker call remains fail-closed.
+    pub services: &'a [ServiceId],
 }
 
 /// Register/spawn the per-VM host-services broker for an admitted workload,
 /// returning a guard whose Drop reaps until defused. The claims-12/13 seam:
-/// `host.audit.v1` / `host.secrets.v1` reach the guest over `BROKER_PORT`, and
-/// no raw secret ever crosses that channel. Behind a trait so the runner is
-/// unit-testable with no real broker subprocess.
+/// Admitted host services reach the guest over `BROKER_PORT`. Behind a trait so
+/// the runner is unit-testable with no real broker subprocess.
 pub trait BrokerRegistrar: Send + Sync {
     fn register(&self, req: &BrokerRegisterRequest<'_>) -> Result<BrokerGuard>;
 }
@@ -158,48 +161,40 @@ pub struct RealBrokerRegistrar;
 
 impl BrokerRegistrar for RealBrokerRegistrar {
     fn register(&self, req: &BrokerRegisterRequest<'_>) -> Result<BrokerGuard> {
-        // Unadmitted (no tenant, hence no broker socket): register nothing. The
-        // spec carries no BROKER_PORT either, so a stray guest dial fails closed.
+        // Unadmitted or carrying no service bindings: register nothing. The
+        // spec carries no usable broker channel, so a stray guest dial fails closed.
+        if req.services.is_empty() {
+            return Ok(BrokerGuard::defused());
+        }
         let (Some(tenant), Some(broker_listen_socket)) = (req.tenant, req.broker_listen_socket)
         else {
             return Ok(BrokerGuard::defused());
         };
 
-        // Best-effort, matching the raw backends: an absent broker only disables
-        // host.audit.v1 for this VM — the workload still runs and the host-side
-        // audit chain is intact — so a spawn failure is logged, never a rollback.
         let guard = if mvm_vmm::host::host_agent_spawn::host_agent_daemon_enabled() {
-            match mvm_vmm::host::host_agent_spawn::register_host_agent_services_if_admitted(
+            mvm_vmm::host::host_agent_spawn::register_host_agent_services_if_admitted(
                 mvm_vmm::host::host_agent_spawn::HostAgentServicesParams {
                     workload_id: req.vm_name,
                     tenant_id: Some(tenant),
                     vm_name: req.vm_name,
                     state_dir: req.state_dir,
                     broker_listen_socket,
+                    services: req.services,
                 },
-            ) {
-                Ok(g) => mvm_vmm::host::host_agent_spawn::ServicesGuard::Agent(g),
-                Err(e) => {
-                    tracing::warn!(vm = %req.vm_name, error = %e, "host-agent registration failed; host.audit.v1 unavailable for this VM");
-                    mvm_vmm::host::host_agent_spawn::ServicesGuard::None
-                }
-            }
+            )
+            .map(mvm_vmm::host::host_agent_spawn::ServicesGuard::Agent)?
         } else {
-            match mvm_vmm::host::broker_services_spawn::spawn_broker_services_if_admitted(
+            mvm_vmm::host::broker_services_spawn::spawn_broker_services_if_admitted(
                 mvm_vmm::host::broker_services_spawn::BrokerServicesSpawnParams {
                     workload_id: req.vm_name,
                     tenant_id: Some(tenant),
                     vm_name: req.vm_name,
                     state_dir: req.state_dir,
                     broker_listen_socket,
+                    services: req.services,
                 },
-            ) {
-                Ok(g) => mvm_vmm::host::host_agent_spawn::ServicesGuard::Fork(g),
-                Err(e) => {
-                    tracing::warn!(vm = %req.vm_name, error = %e, "host-services broker spawn failed; host.audit.v1 unavailable for this VM");
-                    mvm_vmm::host::host_agent_spawn::ServicesGuard::None
-                }
-            }
+            )
+            .map(mvm_vmm::host::host_agent_spawn::ServicesGuard::Fork)?
         };
         Ok(BrokerGuard(guard))
     }
@@ -482,17 +477,16 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
         }
         trace.mark("activate_workload");
 
-        // Register the per-VM host-services broker (host.audit.v1 /
-        // host.secrets.v1) for an admitted workload — the same registration the
-        // raw backends run, lifted here so a workload on this runner keeps those
-        // services. The guard's Drop reaps on any early return until it's defused;
-        // registration is best-effort (a failure is logged inside `register`,
-        // never a launch rollback).
+        // Register the per-VM broker for the exact admitted host-service set.
+        // The guard's Drop reaps on any early return until it is defused. A
+        // requested service whose broker cannot start fails the launch closed.
+        let services = admitted_services(inputs.config.plan_json.as_deref())?;
         let mut broker_guard = self.broker.register(&BrokerRegisterRequest {
             vm_name: &inputs.config.name,
             state_dir: &state_dir,
             tenant: inputs.config.tenant_id.as_deref(),
             broker_listen_socket: socks.broker.as_deref(),
+            services: &services,
         })?;
         endpoint.defuse();
         broker_guard.defuse();
@@ -698,14 +692,9 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
         let socks = standing_sockets(&child_dir, &child_cfg);
         let channels = workload_vsock_ports(&socks.with_egress(endpoint.egress_uds()));
 
-        // Register the child's host-services broker (host.audit.v1 /
-        // host.secrets.v1) — the same registration a cold boot performs, and for
-        // the same reason: without it the child would run silently short of the
-        // services an admitted workload is entitled to. Registered before the
-        // fork rather than after it, because the restore resumes a guest that
-        // can dial `BROKER_PORT` immediately. Best-effort inside `register` (a
-        // failure is logged, never a rollback); the guard reaps until the claim
-        // commits.
+        // Register the child's exact admitted host-service set before the fork,
+        // because the restored guest can dial `BROKER_PORT` immediately. Any
+        // registration failure refuses the claim; the guard reaps until commit.
         let mut broker_guard = self
             .broker
             .register(&BrokerRegisterRequest {
@@ -713,6 +702,7 @@ impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, 
                 state_dir: &child_dir,
                 tenant: child_cfg.tenant_id.as_deref(),
                 broker_listen_socket: socks.broker.as_deref(),
+                services: &plan.services,
             })
             .map_err(|e| StandbyError::ClaimFailed(format!("register child broker: {e}")))?;
         claim_phase!("broker_registered");
@@ -1383,6 +1373,14 @@ fn claim_plan(claim: &StandbyClaim) -> std::result::Result<ExecutionPlan, Standb
         .map_err(|_| refuse(ClaimRefusal::PlanMissing))
 }
 
+fn admitted_services(plan_json: Option<&str>) -> Result<Vec<ServiceId>> {
+    plan_json
+        .map(mvm_core::plan::plan_from_admitted_json)
+        .transpose()
+        .context("parse admitted plan host services")
+        .map(|plan| plan.map_or_else(Vec::new, |plan| plan.services))
+}
+
 /// How many times to redraw a fresh child name before giving up. A collision is
 /// astronomically unlikely (random suffix), so a small bound is a fail-closed
 /// backstop, never a hot loop.
@@ -1543,6 +1541,7 @@ mod tests {
         vm_name: String,
         tenant: Option<String>,
         broker_listen_socket: Option<PathBuf>,
+        services: Vec<ServiceId>,
     }
 
     impl RecordingBrokerRegistrar {
@@ -1559,6 +1558,7 @@ mod tests {
                 vm_name: req.vm_name.to_string(),
                 tenant: req.tenant.map(str::to_string),
                 broker_listen_socket: req.broker_listen_socket.map(Path::to_path_buf),
+                services: req.services.to_vec(),
             });
             Ok(BrokerGuard::defused())
         }
@@ -4028,6 +4028,7 @@ mod tests {
             "the broker is registered for the child's own id, never the parent's"
         );
         assert_eq!(broker.tenant.as_deref(), Some("tenant-x"));
+        assert!(broker.services.is_empty());
 
         let wired = run.driver.forked_children()[0]
             .channels

--- a/crates/mvm-sdk/sdks/python/tests/test_machine.py
+++ b/crates/mvm-sdk/sdks/python/tests/test_machine.py
@@ -108,7 +108,7 @@ def test_machine_run_admission_argv_matches_cli_parity_fixture() -> None:
         cpus=4,
         memory="1G",
         profile="dev",
-        volumes=["/tmp/mvm-sdk-src:/workspace:ro"],
+        volumes=["/tmp/mvm-sdk-src:/work:ro"],
         env=["TOKEN=secret", "MODE=test"],
         timeout=30,
         receipt="/tmp/mvm-sdk-machine.receipt.json",

--- a/crates/mvm-sdk/sdks/typescript/tests/machine.test.ts
+++ b/crates/mvm-sdk/sdks/typescript/tests/machine.test.ts
@@ -134,7 +134,7 @@ describe("Machine.run", () => {
       cpus: 4,
       memory: "1G",
       profile: "dev",
-      volumes: ["/tmp/mvm-sdk-src:/workspace:ro"],
+      volumes: ["/tmp/mvm-sdk-src:/work:ro"],
       env: ["TOKEN=secret", "MODE=test"],
       timeout: 30,
       receipt: "/tmp/mvm-sdk-machine.receipt.json",

--- a/crates/mvm-sdk/tests/machine.rs
+++ b/crates/mvm-sdk/tests/machine.rs
@@ -75,7 +75,7 @@ fn machine_run_builder_emits_machine_cli_argv() {
         .cpus(2)
         .memory("1G")
         .profile("dev")
-        .volume("/src:/workspace:ro")
+        .volume("/src:/work:ro")
         .env("RUST_LOG=info")
         .timeout(30)
         .receipt("/tmp/receipt.json")
@@ -101,7 +101,7 @@ fn machine_run_builder_emits_machine_cli_argv() {
             "--profile",
             "dev",
             "--mount",
-            "/src:/workspace:ro",
+            "/src:/work:ro",
             "--env",
             "RUST_LOG=info",
             "--timeout",

--- a/crates/mvm-sdk/tests/machine_verb_conformance.rs
+++ b/crates/mvm-sdk/tests/machine_verb_conformance.rs
@@ -67,7 +67,7 @@ fn run_admission_matches_shared_fixture() {
         .cpus(4)
         .memory("1G")
         .profile("dev")
-        .volume("/tmp/mvm-sdk-src:/workspace:ro")
+        .volume("/tmp/mvm-sdk-src:/work:ro")
         .env("TOKEN=secret")
         .env("MODE=test")
         .timeout(30)

--- a/crates/mvm-vmm/src/host/broker_services_spawn.rs
+++ b/crates/mvm-vmm/src/host/broker_services_spawn.rs
@@ -230,6 +230,8 @@ pub struct BrokerSpawnParams<'a> {
     /// `host.audit.v1` handler forwards entries here, and only registers that
     /// service when this is set.
     pub audit_signer_uds_path: &'a Path,
+    /// Exact host-service bindings from the admitted execution plan.
+    pub services: &'a [mvm_core::protocol::broker::ServiceId],
 }
 
 /// Handle to a spawned broker: the per-VM `BROKER_PORT` UDS the VMM proxies the
@@ -260,6 +262,7 @@ fn spawn_broker_with_timeout(
         broker_uds_path,
         state_dir,
         audit_signer_uds_path,
+        services,
     } = params;
 
     let bin = resolve_subprocess_bin("mvm-broker", "MVM_BROKER_PATH")?;
@@ -280,6 +283,7 @@ fn spawn_broker_with_timeout(
         // host.audit.v1 forwards each accepted entry to the per-VM audit-signer;
         // the broker only registers that service when this is set.
         "audit_signer_uds_path": audit_signer_uds_path,
+        "services_bindings": services,
     });
 
     let child = spawn_detached_with_config(&bin, &cfg, "mvm-broker")?;
@@ -376,6 +380,8 @@ pub struct BrokerServicesSpawnParams<'a> {
     /// passes `vm_vsock_port_socket` on libkrun, `vm_hvf_vsock_port_socket` on
     /// hvf; the VMM forwards the guest's `connect_host_vsock(BROKER_PORT)` here).
     pub broker_listen_socket: &'a Path,
+    /// Exact host-service bindings from the admitted execution plan.
+    pub services: &'a [mvm_core::protocol::broker::ServiceId],
 }
 
 /// Spawn the per-VM broker services (audit-signer **then** broker) when the VM
@@ -396,6 +402,7 @@ pub fn spawn_broker_services_if_admitted(
         vm_name,
         state_dir,
         broker_listen_socket,
+        services,
     } = params;
     let Some(tenant_id) = tenant_id else {
         return Ok(BrokerServicesGuard::defused());
@@ -416,6 +423,7 @@ pub fn spawn_broker_services_if_admitted(
         broker_uds_path: broker_listen_socket,
         state_dir,
         audit_signer_uds_path: &audit.uds_path,
+        services,
     })?;
     Ok(guard)
 }
@@ -632,6 +640,7 @@ mod tests {
             broker_uds_path: &uds,
             state_dir: &state_dir,
             audit_signer_uds_path: &audit_uds,
+            services: &[],
         });
 
         let handle = res.expect("spawn with stub broker should succeed");
@@ -678,6 +687,7 @@ mod tests {
             state_dir: &dir,
             // Unused on the unadmitted path (the gate short-circuits first).
             broker_listen_socket: &dir,
+            services: &[],
         })
         .expect("unadmitted VM yields a defused no-op guard");
         drop(guard); // a defused guard's Drop reaps nothing
@@ -733,6 +743,7 @@ mod tests {
             vm_name: "vm-1",
             state_dir: &state_dir,
             broker_listen_socket: &broker_uds,
+            services: &[],
         });
 
         let mut guard = res.expect("admitted VM spawns both broker services");

--- a/crates/mvm-vmm/src/host/cmdline.rs
+++ b/crates/mvm-vmm/src/host/cmdline.rs
@@ -209,7 +209,13 @@ pub fn runner_cmdline(
         // PyPI), using the same host epoch captured at boot time as the builder.
         tokens.push(crate::host::boot_config::builder_hostepoch_cmdline_token());
     }
-    if let Some(uvols) = mvm_core::vm_backend::encode_user_volumes_cmdline(&config.volumes) {
+    let user_volumes = config
+        .volumes
+        .iter()
+        .filter(|volume| !super::spec_map::is_sdk_sidecar_volume(volume))
+        .cloned()
+        .collect::<Vec<_>>();
+    if let Some(uvols) = mvm_core::vm_backend::encode_user_volumes_cmdline(&user_volumes) {
         tokens.push(uvols);
     }
     // Tell the guest which device the SDK sidecar landed on. The guest can't
@@ -595,8 +601,17 @@ mod tests {
             cmdline.contains("mvm.sdk_dev=/dev/vdc"),
             "cmdline missing the sidecar device token: {cmdline}"
         );
-        // Both tokens ride together, and the cmdline stays single-token-safe.
-        assert!(cmdline.contains("mvm.uvols=uvol0:"), "cmdline: {cmdline}");
+        // The reserved sidecar is named only by mvm.sdk_dev. It must not also
+        // enter the generic user-volume manifest, whose mountpoint policy
+        // deliberately excludes /mvm/sdk.
+        assert!(
+            cmdline.contains("mvm.uvols=uvol0:2f64617461:ro:blk"),
+            "cmdline missing the ordinary user volume: {cmdline}"
+        );
+        assert!(
+            !cmdline.contains("2f6d766d2f73646b"),
+            "cmdline encoded the SDK sidecar as a user volume: {cmdline}"
+        );
         assert_eq!(cmdline_overflow(&cmdline), None);
     }
 

--- a/crates/mvm-vmm/src/host/host_agent_spawn.rs
+++ b/crates/mvm-vmm/src/host/host_agent_spawn.rs
@@ -233,6 +233,8 @@ pub struct HostAgentServicesParams<'a> {
     /// The backend-specific `BROKER_PORT` socket the daemon should bind for this
     /// VM (libkrun `vm_vsock_port_socket`, hvf `vm_hvf_vsock_port_socket`).
     pub broker_listen_socket: &'a Path,
+    /// Exact host-service bindings from the admitted execution plan.
+    pub services: &'a [mvm_core::protocol::broker::ServiceId],
 }
 
 /// Daemon-path equivalent of `spawn_broker_services_if_admitted`: ensure the
@@ -251,6 +253,7 @@ pub fn register_host_agent_services_if_admitted(
         vm_name,
         state_dir,
         broker_listen_socket,
+        services,
     } = params;
     let Some(tenant) = tenant_id else {
         return Ok(HostAgentServicesGuard::defused());
@@ -284,7 +287,7 @@ pub fn register_host_agent_services_if_admitted(
                     .into_owned(),
             ),
             audit_signer_uds_path: None,
-            services_bindings: vec![],
+            services_bindings: services.to_vec(),
             capability_bindings: vec![],
         },
     )?;
@@ -746,6 +749,7 @@ mod tests {
             vm_name: "vm",
             state_dir: dir.path(),
             broker_listen_socket: &dir.path().join("vsock-5300.sock"),
+            services: &[],
         })
         .expect("unadmitted VM registers nothing");
         drop(guard); // defused Drop reaps nothing

--- a/crates/mvm-vmm/src/host/spec_map.rs
+++ b/crates/mvm-vmm/src/host/spec_map.rs
@@ -113,6 +113,15 @@ pub fn workload_volume_devices(config: &VmStartConfig) -> Vec<Option<String>> {
         .collect()
 }
 
+/// Return whether a configured volume is the reserved SDK sidecar.
+///
+/// The sidecar is physically a disk, but it is not a user volume: the guest
+/// mounts it through the dedicated `mvm.sdk_dev` contract at `/mvm/sdk`.
+pub fn is_sdk_sidecar_volume(volume: &mvm_core::vm_backend::VmVolume) -> bool {
+    volume.guest == mvm_core::plan::SDK_SIDECAR_GUEST_PATH
+        && matches!(volume.kind, VmVolumeKind::Disk)
+}
+
 /// The guest device node the SDK sidecar lands on for this launch config, or
 /// `None` when no sidecar is attached.
 ///
@@ -122,9 +131,7 @@ pub fn workload_volume_devices(config: &VmStartConfig) -> Vec<Option<String>> {
 /// boot carries a verity sidecar, a runtime overlay, and how many user volumes
 /// precede it.
 pub fn sdk_sidecar_block_device(config: &VmStartConfig) -> Option<String> {
-    let sidecar_index = config.volumes.iter().position(|v| {
-        v.guest == mvm_core::plan::SDK_SIDECAR_GUEST_PATH && matches!(v.kind, VmVolumeKind::Disk)
-    })?;
+    let sidecar_index = config.volumes.iter().position(is_sdk_sidecar_volume)?;
     workload_volume_devices(config)
         .get(sidecar_index)
         .cloned()

--- a/features/suites/s21_host_services/sdk_sidecar_attachment.feature
+++ b/features/suites/s21_host_services/sdk_sidecar_attachment.feature
@@ -26,6 +26,27 @@ Feature: SDK sidecar attaches only for admitted SDK host-service bindings
     And admission accepts the launch with the sidecar attachment
     And the assembled workload cmdline names the SDK sidecar device the backend attached
 
+  Scenario: the SDK sidecar bypasses user-volume activation beside a wheel mount
+    Given a verified SDK sidecar in the cache
+    And a workload plan that binds host service "host.time.v1"
+    And a read-only directory mount at "/mnt/wheels"
+    When the launch path resolves the SDK sidecar
+    Then the SDK sidecar is attached read-only at "/mvm/sdk"
+    And admission accepts the launch with the sidecar attachment
+    And the assembled workload cmdline names the SDK sidecar device the backend attached
+    And the user-volume manifest names "/mnt/wheels" but not the SDK mount
+
+  Scenario: a bound host time request crosses the SDK broker transport
+    Given a workload plan that binds host service "host.time.v1"
+    When the SDK sends a framed host time request to its bound broker
+    Then the SDK receives a current host wall clock without a transport error
+
+  Scenario: a wheel mount outside the guest allow-roots is refused before boot
+    When I run mvmctl with "machine run --image python:3.12 --mount .:/wheels:ro --dry-run -- /bin/true" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "user volumes may only mount under /data, /work, /mnt"
+    And the error output does not contain "guest agent did not become reachable"
+
   Scenario: a required sidecar that is missing from the cache fails the launch closed
     Given an empty SDK sidecar cache
     And a workload plan that binds host service "host.secrets.v1"

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-11
+Last updated: 2026-08-12
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -94,6 +94,23 @@ for detailed scope and acceptance criteria.
       zero; the later workload boot stopped at a separate readiness timeout.
 
 ## In-flight plans
+- [~] Plan 325 — SDK sidecar reserved mount
+      (`specs/plans/325-sdk-sidecar-reserved-mount.md`)
+  - [x] Reserved SDK disk is excluded from generic user-volume activation
+  - [x] Legacy and universal guest boot paths mount `mvm.sdk_dev` read-only at
+        `/mvm/sdk`
+  - [x] Explicit worktree binaries source guest artifacts from the same worktree
+  - [x] Guest Cargo target graphs and artifact caches are source-isolated
+  - [x] Sealed OCI roots carry the reserved `/mvm/sdk` mountpoint
+  - [x] Agent timeouts preserve a redacted console diagnostic before cleanup
+  - [x] The hermetic `/mnt/wheels` plus SDK-sidecar BDD regression passes, and
+        host preflight refuses invalid `/wheels` mounts before VM boot
+  - [x] Source builds include the host-agent helpers and exact admitted service
+        bindings reach a real `host.time.v1` handler
+  - [x] The framed broker/SDK BDD regression and native HVF Python-wheel command
+        pass
+  - [ ] Native libkrun Python host-time acceptance passes
+
 - [~] Plan 323 — Concurrent builds through one builder VM
       (`specs/plans/323-concurrent-builds-one-builder-vm.md`)
   - [x] Phase 1 — a contended Nix-store image lock queues (naming the holding

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -17,6 +17,37 @@
 > `specs/sprint/delivery/README.md` and issue #2353. `xtask check-sprint-append`
 > fails if this list grows.
 
+- [~] SDK host-service sidecar boot failure — **plan 325**. Guest-console
+      evidence showed that the dedicated SDK disk was also entering the
+      generic user-volume manifest, whose allowlist correctly rejects
+      `/mvm/sdk`; PID 1 then exited and both HVF and libkrun reported a
+      downstream 30-second agent-readiness timeout. The launcher now partitions
+      the reserved disk from user volumes, both guest boot paths mount it
+      read-only through `mvm.sdk_dev`, and legacy block discovery excludes it
+      from ordinary user disks. A follow-up live run exposed that invoking the
+      worktree binary from the main checkout paired the fixed host with the
+      main checkout's stale guest `/init`; executable-path source discovery now
+      keeps worktree host and guest artifacts together. A second attempt proved
+      the source key changed but exposed Cargo outputs shared across worktrees;
+      cross-build target dirs are now source-isolated and both affected cache
+      generations are advanced. OCI injection also pre-creates `/mvm/sdk`
+      before sealing, so fixed PID 1 does not attempt to mutate a read-only
+      dm-verity root. Agent-readiness failures now print a bounded, PII-redacted
+      guest-console tail before transient teardown removes the evidence.
+      The captured guest console then exposed a second, independent issue:
+      `/wheels` is outside the guest volume allow-roots (`/data`, `/work`,
+      `/mnt`). Directory-share parsing now rejects that path during host
+      preflight instead of booting a guest that can only panic and time out.
+      Hermetic BDD coverage exercises the corrected `/mnt/wheels` plus SDK
+      sidecar attachment and proves the user mount remains in `mvm.uvols`
+      while `/mvm/sdk` does not; a companion scenario proves `/wheels` fails
+      before boot. The host-service follow-up builds the host agent and signer
+      helper beside source-built `mvmctl`, threads the exact signed-plan service
+      set into the broker, implements `host.time.v1::now`, and adds a framed
+      broker/SDK BDD round trip. The original Python-wheel command now passes on
+      native HVF. Focused regressions and the full 176-scenario/732-step BDD
+      suite pass; native libkrun acceptance remains.
+
 - [x] Long-running interactive consoles no longer lose their input relay after
       15 minutes without keyboard activity. Guest output can continue
       indefinitely while later `Ctrl+C` bytes still reach the PTY foreground

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -17,37 +17,6 @@
 > `specs/sprint/delivery/README.md` and issue #2353. `xtask check-sprint-append`
 > fails if this list grows.
 
-- [~] SDK host-service sidecar boot failure — **plan 325**. Guest-console
-      evidence showed that the dedicated SDK disk was also entering the
-      generic user-volume manifest, whose allowlist correctly rejects
-      `/mvm/sdk`; PID 1 then exited and both HVF and libkrun reported a
-      downstream 30-second agent-readiness timeout. The launcher now partitions
-      the reserved disk from user volumes, both guest boot paths mount it
-      read-only through `mvm.sdk_dev`, and legacy block discovery excludes it
-      from ordinary user disks. A follow-up live run exposed that invoking the
-      worktree binary from the main checkout paired the fixed host with the
-      main checkout's stale guest `/init`; executable-path source discovery now
-      keeps worktree host and guest artifacts together. A second attempt proved
-      the source key changed but exposed Cargo outputs shared across worktrees;
-      cross-build target dirs are now source-isolated and both affected cache
-      generations are advanced. OCI injection also pre-creates `/mvm/sdk`
-      before sealing, so fixed PID 1 does not attempt to mutate a read-only
-      dm-verity root. Agent-readiness failures now print a bounded, PII-redacted
-      guest-console tail before transient teardown removes the evidence.
-      The captured guest console then exposed a second, independent issue:
-      `/wheels` is outside the guest volume allow-roots (`/data`, `/work`,
-      `/mnt`). Directory-share parsing now rejects that path during host
-      preflight instead of booting a guest that can only panic and time out.
-      Hermetic BDD coverage exercises the corrected `/mnt/wheels` plus SDK
-      sidecar attachment and proves the user mount remains in `mvm.uvols`
-      while `/mvm/sdk` does not; a companion scenario proves `/wheels` fails
-      before boot. The host-service follow-up builds the host agent and signer
-      helper beside source-built `mvmctl`, threads the exact signed-plan service
-      set into the broker, implements `host.time.v1::now`, and adds a framed
-      broker/SDK BDD round trip. The original Python-wheel command now passes on
-      native HVF. Focused regressions and the full 176-scenario/732-step BDD
-      suite pass; native libkrun acceptance remains.
-
 - [x] Long-running interactive consoles no longer lose their input relay after
       15 minutes without keyboard activity. Guest output can continue
       indefinitely while later `Ctrl+C` bytes still reach the PTY foreground

--- a/specs/plans/325-sdk-sidecar-reserved-mount.md
+++ b/specs/plans/325-sdk-sidecar-reserved-mount.md
@@ -1,0 +1,54 @@
+# Plan 325 — SDK sidecar reserved mount
+
+**Status:** IN PROGRESS — implementation, hermetic regressions, and native HVF
+acceptance are green; native libkrun acceptance remains.
+
+## Problem
+
+`machine run --host-service ...` attached the SDK sidecar as a dedicated
+read-only block device and named it with `mvm.sdk_dev`, but also encoded it in
+the generic `mvm.uvols` manifest. The generic user-volume policy correctly
+rejects `/mvm/sdk`, so the OCI init exited and the kernel panicked before the
+guest agent could register. HVF and libkrun then surfaced only the downstream
+30-second readiness timeout.
+
+## Scope
+
+- [x] Reproduce the failure from the guest console and identify the rejected
+      `/mvm/sdk` generic volume.
+- [x] Keep the SDK disk physically attached while excluding it from legacy and
+      universal generic-volume activation.
+- [x] Mount the device named by `mvm.sdk_dev` at the fixed `/mvm/sdk` path with
+      read-only, nosuid, and nodev flags.
+- [x] Exclude the dedicated SDK device when legacy init discovers trailing
+      virtio block devices for ordinary user volumes.
+- [x] Validate the SDK device against the narrow `/dev/vd[a-z]` policy.
+- [x] Add regressions for cmdline partitioning, activation partitioning,
+      device discovery, and device-path validation.
+- [x] Add hermetic BDD coverage for the corrected `/mnt/wheels` plus
+      SDK-sidecar attachment shape and prove the SDK mount bypasses
+      `mvm.uvols`.
+- [x] Refuse directory-share guest paths outside `/data`, `/work`, and `/mnt`
+      during host preflight so invalid mounts never become readiness timeouts.
+- [x] Keep an explicitly invoked worktree `mvmctl` paired with guest binaries
+      from that worktree even when the shell is inside another checkout.
+- [x] Isolate Cargo cross-build targets by source key and invalidate guest/OCI
+      caches that may contain outputs reused from another checkout.
+- [x] Pre-create `/mvm/sdk` before sealing OCI roots so PID 1 never has to
+      mutate a dm-verity-protected root to mount the sidecar.
+- [x] Preserve a bounded, PII-redacted guest-console tail in agent-readiness
+      errors before transient teardown removes the VM state directory.
+- [x] Build `mvm-host-agent` and `mvm-signer-helper` beside source-built
+      `mvmctl`, pass exact admitted service bindings to the broker, and serve
+      `host.time.v1::now` without widening the registry to unbound services.
+- [x] Add hermetic BDD coverage across the real framed broker server and typed
+      SDK time client.
+- [x] Prove the original Python `host.time.v1` command on native HVF.
+- [ ] Prove the same command with `--hypervisor libkrun`.
+- [x] Complete workspace tests, check, and all-target Clippy gates.
+
+## Acceptance
+
+The guest reaches authenticated agent readiness, `/mvm/sdk` is mounted only
+through its dedicated read-only contract, and `mvm.host.time()` succeeds on
+both native HVF and libkrun.

--- a/specs/sprint/delivery/325-sdk-host-service-sidecar-boot.md
+++ b/specs/sprint/delivery/325-sdk-host-service-sidecar-boot.md
@@ -1,0 +1,30 @@
+- [~] SDK host-service sidecar boot failure — **plan 325**. Guest-console
+      evidence showed that the dedicated SDK disk was also entering the
+      generic user-volume manifest, whose allowlist correctly rejects
+      `/mvm/sdk`; PID 1 then exited and both HVF and libkrun reported a
+      downstream 30-second agent-readiness timeout. The launcher now partitions
+      the reserved disk from user volumes, both guest boot paths mount it
+      read-only through `mvm.sdk_dev`, and legacy block discovery excludes it
+      from ordinary user disks. A follow-up live run exposed that invoking the
+      worktree binary from the main checkout paired the fixed host with the
+      main checkout's stale guest `/init`; executable-path source discovery now
+      keeps worktree host and guest artifacts together. A second attempt proved
+      the source key changed but exposed Cargo outputs shared across worktrees;
+      cross-build target dirs are now source-isolated and both affected cache
+      generations are advanced. OCI injection also pre-creates `/mvm/sdk`
+      before sealing, so fixed PID 1 does not attempt to mutate a read-only
+      dm-verity root. Agent-readiness failures now print a bounded, PII-redacted
+      guest-console tail before transient teardown removes the evidence.
+      The captured guest console then exposed a second, independent issue:
+      `/wheels` is outside the guest volume allow-roots (`/data`, `/work`,
+      `/mnt`). Directory-share parsing now rejects that path during host
+      preflight instead of booting a guest that can only panic and time out.
+      Hermetic BDD coverage exercises the corrected `/mnt/wheels` plus SDK
+      sidecar attachment and proves the user mount remains in `mvm.uvols`
+      while `/mvm/sdk` does not; a companion scenario proves `/wheels` fails
+      before boot. The host-service follow-up builds the host agent and signer
+      helper beside source-built `mvmctl`, threads the exact signed-plan service
+      set into the broker, implements `host.time.v1::now`, and adds a framed
+      broker/SDK BDD round trip. The original Python-wheel command now passes on
+      native HVF. Focused regressions and the full 176-scenario/732-step BDD
+      suite pass; native libkrun acceptance remains.

--- a/tests/machine-fixtures/run-admission.argv
+++ b/tests/machine-fixtures/run-admission.argv
@@ -10,7 +10,7 @@ api.example.com
 --profile
 dev
 --mount
-/tmp/mvm-sdk-src:/workspace:ro
+/tmp/mvm-sdk-src:/work:ro
 --env
 TOKEN=secret
 --env


### PR DESCRIPTION
## Summary

- reserve the SDK sidecar as a dedicated read-only `/mvm/sdk` device instead of routing it through generic user-volume activation
- pair source-built `mvmctl` with source-matched guest and host-agent binaries, and surface redacted guest-console diagnostics on readiness failure
- bind only admitted host services and implement the real `host.time.v1::now` broker path
- reject unsupported directory-share guest paths during host preflight and align SDK fixtures on `/work`
- add BDD coverage for sidecar attachment and a framed Python SDK host-time round trip

## Validation

- native macOS HVF Python-wheel `mvm.host.time()` workflow (confirmed live)
- `cargo test --workspace --quiet -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `just bdd` (53 features, 176 scenarios, 732 steps)

Native libkrun live acceptance remains tracked in Plan 325.
