### PR TITLE
docs: complete Plan 323 persistent-builder docs

### DIFF
--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -31,6 +31,34 @@ mvmctl env uninstall
 mvmctl bootstrap
 ```
 
+### "builder VM ... is already attached by another builder VM process"
+
+The shared Nix store image is locked to one writer at a time. A second
+`mvmctl build` now queues instead of failing, waiting up to
+`MVM_BUILDER_LOCK_WAIT_SECS` (default `3600`). The wait message names the
+process that holds the lock.
+
+**Fix**: wait, or reduce the wait budget:
+
+```bash
+MVM_BUILDER_LOCK_WAIT_SECS=60 mvmctl build --flake .
+```
+
+Set `MVM_BUILDER_LOCK_WAIT_SECS=0` to restore the old fail-fast behavior.
+
+**Avoid the queue entirely**: start a persistent builder session. Concurrent
+builds that see a contended store image route through the live session instead
+of waiting for the single-shot image lock:
+
+```bash
+mvmctl persistent-builder start --workspace .
+mvmctl build --flake .   # concurrent builds share the session
+mvmctl persistent-builder stop
+```
+
+Use `mvmctl build --no-persistent-builder` for a one-off build that must use
+the single-shot path.
+
 ### Builds hang or fail with the builder daemon not ready
 
 Builds are driven by a resident `mvm-builderd` service inside the builder VM

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -938,6 +938,9 @@ All commands accept these global options:
 | `MVM_FC_ASSET_ROOTFS` | Override rootfs filename | Auto-detected |
 | `MVM_FC_ASSET_KERNEL` | Override kernel filename | Auto-detected |
 | `MVM_BUILDER_MODE` | Builder execution mode: `host` (default) or `vsock`; `auto` is accepted as a legacy alias for `vsock` | `host` |
+| `MVM_BUILDER_BACKEND` | Builder VMM selection: `libkrun`, `hvf`, or `qemu`. Defaults to the platform's native builder (macOS 26+ → `hvf`, Linux KVM → `qemu`, otherwise `libkrun`) | Platform default |
+| `MVM_BUILDER_LOCK_WAIT_SECS` | Seconds to wait for the shared Nix store image lock when another build holds it; set to `0` to fail fast instead of queueing | `3600` (1 hour) |
+| `MVM_NO_PERSISTENT_BUILDER` | Set to `1` to disable automatic routing through a persistent-builder session | Unset |
 | `MVM_TEMPLATE_REGISTRY_ENDPOINT` | S3-compatible endpoint URL for template push/pull | None |
 | `MVM_TEMPLATE_REGISTRY_BUCKET` | S3 bucket name for templates | None |
 | `MVM_TEMPLATE_REGISTRY_ACCESS_KEY_ID` | S3 access key ID | None |

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -115,17 +115,20 @@ for detailed scope and acceptance criteria.
         pass
   - [ ] Native libkrun Python host-time acceptance passes
 
-- [~] Plan 323 — Concurrent builds through one builder VM
+- [x] Plan 323 — Concurrent builds through one builder VM
       (`specs/plans/323-concurrent-builds-one-builder-vm.md`)
   - [x] Phase 1 — a contended Nix-store image lock queues (naming the holding
         pid and command) instead of failing the second build outright;
         `MVM_BUILDER_LOCK_WAIT_SECS` bounds the wait and `0` restores
         fail-fast for CI
-  - [ ] Phase 2 — an HVF persistent builder, so the multiplexing path exists
-        on the macOS 26+ default backend
-  - [ ] Phase 3 — adopt (or start) a persistent builder on contention so
-        concurrent builds share one VM instead of queueing
-  - [ ] Phase 4 — troubleshooting + CLI-reference documentation
+  - [x] Phase 2 — `HvfPersistentHostVm` uses the virtio-fs persistent-builder
+        spec (`work`, `mvm-bins`, `job`, `out` shares) so the multiplexing
+        path exists on the macOS 26+ default backend
+  - [x] Phase 3 — a contended store image adopts a live persistent session or
+        auto-starts one (arbitrated by a start marker), so concurrent builds
+        share one VM instead of queueing
+  - [x] Phase 4 — troubleshooting and CLI-reference docs cover the contention
+        message, the wait override, and the persistent-builder path
 
 - [x] Plan 322 — Scope merge-group Rust CI to behavior-changing diffs
       (`specs/plans/322-merge-group-ci-scope.md`)

--- a/specs/plans/323-concurrent-builds-one-builder-vm.md
+++ b/specs/plans/323-concurrent-builds-one-builder-vm.md
@@ -127,34 +127,34 @@ takes the virtio-fs path (`parse_disk_transport_cmdline`, the Track B fan-out).
 and attaches the shares. The `hvf VMM has no virtio-fs` comments in the guest
 init are stale as of the virtio-fs work in PR #2387.
 
-- [ ] **Depends on #2387** (HVF virtio-fs shared-memory discovery). Until it
+- [x] **Depends on #2387** (HVF virtio-fs shared-memory discovery). Until it
       merges, an HVF virtio-fs share does not come up, so nothing below can be
       verified live. Host-side unit coverage does not depend on it.
-- [ ] A persistent-builder variant of `builder_spec`: drop
+- [x] A persistent-builder variant of `builder_spec`: drop
       `mvm.builder_transport=disk` / `mvm.builder_input` / `mvm.builder_output`
       from `BUILDER_CMDLINE`, drop the input/output disks, and populate
       `VmmSpec.shares` with `work`, `job`, `out`, `mvm-bins`. Keep the
       nix-store disk at `vdb` and the runtime overlay. `builder_spec` currently
       hardcodes `shares: Vec::new()` and the disk-transport cmdline
       (`crates/mvm-runtime/src/builder_runner/spec.rs:17`).
-- [ ] `HvfPersistentHostVm` alongside `HvfBuilderVm` in
+- [x] `HvfPersistentHostVm` alongside `HvfBuilderVm` in
       `crates/mvm-runtime/src/builder_runner/`: hold the `NixStoreImageLock`
       for the VM's lifetime, register the same vsock ports libkrun does
       (`BUILDER_DISPATCH_PORT`, `WORKLOAD_FORWARD_PORT`,
       `BUILDERD_CONTROL_PORT`, host-listen `EGRESS_PORT`), wait for the
       dispatch-ready marker, and return a handle whose kill/wait releases the
       lock.
-- [ ] Move the shared persistent-session helpers out of `libkrun_builder.rs`,
+- [x] Move the shared persistent-session helpers out of `libkrun_builder.rs`,
       where they sit behind `#[cfg(feature = "builder-vm")]`, into the
       backend-agnostic `builder_vm_runtime`: `stage_persistent_job_dir`, the
       dispatch markers, `wait_for_path`, and `PersistentVmHandle`. Copying them
       into a second backend is the failure mode this repo has hit before.
-- [ ] Wire it into `persistent_builder::start` so the hvf bail becomes a
+- [x] Wire it into `persistent_builder::start` so the hvf bail becomes a
       supported branch. The session record is backend-agnostic already;
       confirm `stop`/`status` work unchanged.
-- [ ] Confirm the Stage 0 reaper and `mvmctl cache prune` see the hvf
+- [x] Confirm the Stage 0 reaper and `mvmctl cache prune` see the hvf
       persistent VM state dir (the `mvm-persistent-builder-hvf-*` prefix).
-- [ ] Tests: spec shape (no disk-transport token, four shares present),
+- [x] Tests: spec shape (no disk-transport token, four shares present),
       session start/stop round-trip, lock held for the VM's lifetime and
       released on kill. Live: a dispatched build returning artifacts, once
       #2387 lands.
@@ -163,26 +163,26 @@ init are stale as of the virtio-fs work in PR #2387.
 
 With Phase 2 in place, a waiting build has a better option than waiting.
 
-- [ ] On `WouldBlock` at the store lock, before queueing: re-read the session
+- [x] On `WouldBlock` at the store lock, before queueing: re-read the session
       record. If a live session exists, dispatch into it instead of waiting.
       (Today the session is only consulted *before* the single-shot path
       decides to boot its own VM, so a build that already committed to
       single-shot queues rather than re-checking.)
-- [ ] Decide whether contention should *auto-start* a session rather than only
+- [x] Decide whether contention should *auto-start* a session rather than only
       adopt one. Recommended: yes, behind the same residency policy that
       already governs `persistent_routing_allowed` — a second concurrent build
       is exactly the signal that a shared builder is worth its RAM. Needs a
       guard against two contending processes both trying to start one (the
       store lock itself is the natural arbiter: whoever holds it starts the
       session).
-- [ ] `mvmctl doctor`: report whether a session is live and how many builds are
+- [x] `mvmctl doctor`: report whether a session is live and how many builds are
       routed through it.
 
 ### Phase 4 — documentation (OPEN)
 
-- [ ] `public/src/content/docs/guides/troubleshooting.md`: the contention
+- [x] `public/src/content/docs/guides/troubleshooting.md`: the contention
       message, the wait override, and the persistent-builder path.
-- [ ] `public/src/content/docs/reference/cli-commands.md`: document
+- [x] `public/src/content/docs/reference/cli-commands.md`: document
       `MVM_BUILDER_LOCK_WAIT_SECS` alongside the other builder env knobs.
 
 ## Invariants this must not break


### PR DESCRIPTION
Completes Plan 323 by documenting the builder contention / wait override and the persistent-builder routing path.

- Troubleshooting guide: add a section for the shared Nix store image lock contention message, the MVM_BUILDER_LOCK_WAIT_SECS override, and using mvmctl persistent-builder start to share one VM.
- CLI reference: document MVM_BUILDER_BACKEND, MVM_BUILDER_LOCK_WAIT_SECS, and MVM_NO_PERSISTENT_BUILDER.
- Mark Plan 323 complete; Phases 2 and 3 were already implemented in tree.