### PR TITLE
docs(plan-326): point status section at the merged regression test

### DIFF
--- a/specs/plans/326-builder-store-durability.md
+++ b/specs/plans/326-builder-store-durability.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-COMPLETE — WS-A, WS-B, and the WS-D reproduction merged in PR #2419. The
+COMPLETE — WS-A, WS-B, and the WS-D reproduction merged in PR #2419, and the
 mechanism behind the observed corruption is identified and fixed by Plan 324 /
-PR #2416. WS-C is re-scoped / not built. One follow-up item remains: an
+PR #2416. WS-C is re-scoped / not built. The follow-up regression test is in
 end-to-end regression test proving the store image stays locked across the
-persistent-builder start/exit boundary.
+PR #2432.
 
 ## The problem
 


### PR DESCRIPTION
The Plan 326 status section still said the regression test was an open follow-up; PR #2432 has now merged it. Update the status blurb to match the checked-off workstream item below.