### PR TITLE
docs(plan-326): clean up status section wording

### DIFF
--- a/specs/plans/326-builder-store-durability.md
+++ b/specs/plans/326-builder-store-durability.md
@@ -5,7 +5,6 @@
 COMPLETE — WS-A, WS-B, and the WS-D reproduction merged in PR #2419, and the
 mechanism behind the observed corruption is identified and fixed by Plan 324 /
 PR #2416. WS-C is re-scoped / not built. The follow-up regression test is in
-end-to-end regression test proving the store image stays locked across the
 PR #2432.
 
 ## The problem


### PR DESCRIPTION
Fixes the awkward wording introduced by the previous status update; no semantic change.