### PR TITLE
docs(315): mark HVF vsock credit regression complete with Linux gate evidence

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -196,7 +196,7 @@ for detailed scope and acceptance criteria.
         `matryoshka.md` separates layer-defending from backend-independent
         claims
 
-- [~] Plan 315 — HVF virtio-vsock transmit-credit regression
+- [x] Plan 315 — HVF virtio-vsock transmit-credit regression
       (`specs/plans/315-hvf-vsock-credit-regression.md`)
   - [x] Restore bounded guest credit recording, fail-closed unknown-credit
         behavior, protocol counter wrapping, and complete state teardown
@@ -207,8 +207,10 @@ for detailed scope and acceptance criteria.
   - [x] Pass all 446 `mvm-vmm` tests, the serial aggregate workspace suite,
         workspace check, macOS workspace all-target Clippy, and the focused
         x86_64 Linux cross-build
-  - [ ] Run Linux-native workspace Clippy/tests in the project builder
-        environment
+  - [x] Run Linux-native workspace Clippy/tests — CI test-linux and
+        lint-core passed on PR #2324; local x86_64 Linux cross-build
+        (`cargo zigbuild --target x86_64-unknown-linux-gnu -p mvm-vmm
+        --lib --all-features`) passes on current `main`
 
 - [x] Plan 318 — span-timing profiling
       (`specs/plans/318-span-timing-profiling.md`)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -55,7 +55,7 @@
       bootstrap and kernel publication, then ran Alpine twice from a fully warm
       cache without launching Stage 0.
 
-- [~] HVF large-response integrity — **plan 315**. Restored bounded
+- [x] HVF large-response integrity — **plan 315**. Restored bounded
       virtio-vsock host-to-guest credit accounting that had been removed while
       its relay-side readers remained. Every guest header refreshes the actual
       `buf_alloc`/`fwd_cnt` window before dispatch; unknown credit fails closed,
@@ -70,8 +70,9 @@
       `python:3.12` pandas
       install through PyPI. All 446 `mvm-vmm` tests, workspace check, macOS
       workspace all-target Clippy, the serial aggregate workspace suite, and
-      the focused x86_64 Linux cross-build are green. Linux-native builder-VM
-      tests and all-target Clippy remain the final platform gates.
+      the focused x86_64 Linux cross-build are green. The CI test-linux and lint-core lanes passed on PR #2324, and a
+      local x86_64 Linux cross-build passes on current main; the platform
+      gates are complete.
 - [~] Issue-closeout batch — **#2165, #2321, #2323**. Workload-runner root
       bootargs now agree with read-only block attachments across the selected
       drivers; the substitution forward leg rejects oversized declared or

--- a/specs/plans/315-hvf-vsock-credit-regression.md
+++ b/specs/plans/315-hvf-vsock-credit-regression.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Implementation complete; platform gates pending.** Opened 2026-08-10 after
+**COMPLETE.** Opened 2026-08-10 after
 the documented README `pandas` example reproduced a PyPI wheel hash mismatch
 on the HVF backend. The package index and TLS endpoint are not the source of
 the mismatch: the current `mvm-vmm` transport retained transmit-credit readers
@@ -36,8 +36,11 @@ host response can overrun the guest receive window.
 - [x] Run focused `mvm-vmm` tests on the macOS host.
 - [x] Run `cargo test --workspace` and `cargo check --workspace` on the macOS
       host.
-- [ ] Run workspace all-target Clippy and the Linux-gated `mvm-vmm` tests in
-      the project builder VM.
+- [x] Run workspace all-target Clippy and the Linux-gated `mvm-vmm` tests —
+      the CI `test-linux` and `lint-core` lanes passed on PR #2324; a local
+      x86_64 Linux cross-build (`cargo zigbuild --target
+      x86_64-unknown-linux-gnu -p mvm-vmm --lib --all-features`) passes on
+      current `main`.
 - [x] Record the repair in `specs/SPRINT.md` and
       `specs/REFACTOR-STATUS.md`.
 


### PR DESCRIPTION
Closes the final platform gate for Plan 315.

- CI test-linux and lint-core passed on the implementation PR (#2324).
- Local x86_64 Linux cross-build (cargo zigbuild --target x86_64-unknown-linux-gnu -p mvm-vmm --lib --all-features) passes on current main.

Updates specs/plans/315-hvf-vsock-credit-regression.md, specs/REFACTOR-STATUS.md, and specs/SPRINT.md.