### PR TITLE
feat(site): apply 316 design review polish

### DIFF
--- a/public/src/components/landing/Hero.tsx
+++ b/public/src/components/landing/Hero.tsx
@@ -129,24 +129,15 @@ export function Hero() {
             {/* Platform-specific install — the single install affordance in
                 the hero. */}
             <Reveal delay={240}>
-              <Tabs defaultValue="macos" className="max-w-lg">
+              <Tabs defaultValue="unix" className="max-w-lg">
                 <TabsList>
-                  <TabsTrigger value="macos">macOS</TabsTrigger>
-                  <TabsTrigger value="linux">Linux</TabsTrigger>
+                  <TabsTrigger value="unix">macOS / Linux</TabsTrigger>
                   <TabsTrigger value="windows">Windows (WSL2)</TabsTrigger>
                 </TabsList>
 
-                <TabsContent value="macos">
+                <TabsContent value="unix">
                   <p className="mb-4 text-sm leading-relaxed text-body">
-                    Apple Silicon only. Runs the HVF backend on macOS 26+, libkrun on
-                    macOS 13&ndash;25.
-                  </p>
-                  <InstallRow command={ONE_LINER} />
-                </TabsContent>
-
-                <TabsContent value="linux">
-                  <p className="mb-4 text-sm leading-relaxed text-body">
-                    Tier 1 target. Needs a kernel with KVM enabled at{" "}
+                    macOS 13+ (libkrun on 13&ndash;25, HVF on 26+) or Linux with{" "}
                     <code className="font-mono text-emphasis/90">/dev/kvm</code>.
                   </p>
                   <InstallRow command={ONE_LINER} />

--- a/public/src/components/landing/Quickstart.tsx
+++ b/public/src/components/landing/Quickstart.tsx
@@ -60,7 +60,6 @@ const STEPS = [
   { tab: "define", trigger: "Define", sampleId: "python-hello" },
   { tab: "build", trigger: "Build", sampleId: "walk-build" },
   { tab: "run", trigger: "Run", sampleId: "walk-run" },
-  { tab: "result", trigger: "Result", sampleId: "walk-result" },
 ] as const;
 
 export function Quickstart() {

--- a/public/src/components/landing/Security.tsx
+++ b/public/src/components/landing/Security.tsx
@@ -2,6 +2,7 @@ import { Section } from "./primitives/Section";
 import { Eyebrow } from "./primitives/Eyebrow";
 import { Reveal } from "./primitives/Reveal";
 import { Button } from "../ui/button";
+import { GlowCard } from "./primitives/GlowCard";
 
 // Copy below is deliberately narrower than plain-language marketing prose —
 // it tracks the exact wording of the project's gated security-claims table,
@@ -82,7 +83,7 @@ export function Security() {
                   rather than break-words because these are mono identifiers —
                   breaking mid-token is fine and wrapping at all is not
                   otherwise possible. */}
-              <div className="min-w-0 rounded-xl border border-edge/50 p-6 sm:p-7">
+              <GlowCard accent={3} className="min-w-0 p-6 sm:p-7">
                 <h3 className="mb-2 text-base font-semibold leading-snug text-title">
                   {c.title}
                 </h3>
@@ -90,7 +91,7 @@ export function Security() {
                 <p className="min-w-0 font-mono text-[11px] break-all text-label/70">
                   {c.witnesses}
                 </p>
-              </div>
+              </GlowCard>
             </Reveal>
           ))}
         </div>


### PR DESCRIPTION
Small UX polish following the Plan 316 design review note (specs/notes/316-design-review.md).\n\n- Wraps the four Security claim cards in GlowCard for consistent hover sheen.\n- Removes the weak "Result" tab from Quickstart; the Run tab already shows the terminal output.\n- Collapses the duplicate macOS/Linux install tabs in the hero into one "macOS / Linux" tab.\n\nBuild, token check, and sample provenance check all pass.