### PR TITLE
docs(status): mark Plan 316 website redesign sign-off complete

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-12
+Last updated: 2026-08-13
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -156,7 +156,7 @@ for detailed scope and acceptance criteria.
         KVM-backed ARM64 cold bootstrap, kernel publication, persistent Stage 0
         reuse, and two fully warm Alpine runs complete without a second Stage 0
 
-- [~] Plan 316 — website and docs redesign (agent review complete; maintainer sign-off pending)
+- [x] Plan 316 — website and docs redesign (agent design review completed and maintainer sign-off received; merged via #2438)
       (`specs/plans/316-website-redesign.md`)
   - [x] Homepage sections, docs chrome, and shared primitives rebuilt onto
         token-driven surfaces; stale Apple Virtualization / Docker-fallback /

--- a/specs/plans/316-website-redesign.md
+++ b/specs/plans/316-website-redesign.md
@@ -1,7 +1,7 @@
 # Plan 316 — Website and docs redesign
 
-**Status: COMPLETE — merged behaviour verified by measurement; agent design review completed (see `specs/notes/316-design-review.md`); maintainer sign-off pending**
-**Last updated: 2026-08-11**
+**Status: COMPLETE — merged behaviour verified by measurement; agent design review completed (see `specs/notes/316-design-review.md`); maintainer sign-off received and final polish merged via #2438**
+**Last updated: 2026-08-13**
 **Branch:** `feat/website-redesign`
 **Scope:** `public/` only. No Rust crate, CLI, or doc *content* changes.
 


### PR DESCRIPTION
Updates the refactor rollup and Plan 316 status now that #2438 has merged the final design-review polish and received maintainer sign-off.