### PR TITLE
docs(320): mark plan shipped and update status/checkboxes post-#2429

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-12
+Last updated: 2026-08-13
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -771,16 +771,13 @@ for detailed scope and acceptance criteria.
         + gzipped-size budget in the existing wasm lane; B5 delete
         `web/audit-verify/`, fix the stale `mvm-verify` refs in ADR-031, add
         `mvmctl audit pubkey`
-- [~] Plan 320 — A live wasm sandbox demo on the website
-      (`specs/plans/320-wasm-browser-demo.md`) — E1 and E2 shipped; E3
-      (audit-entry construction / chain-signing relocation) is complete and
-      green against the frozen byte fixture. Browser-engine sandbox at `/demo`
-      + landing teaser; relocates the egress decision (`projection.rs`),
-      placeholder substitution, and audit-entry construction/chain-signing
-      into `mvm-contract` so host and browser run identical code. Claim-free
-      by ADR-024 §3; adds no claim-catalog witness.
-      Sequencing: the landing teaser must be built against PR #2359's redesigned
-      landing page, not the current one.
+- [x] Plan 320 — A live wasm sandbox demo on the website
+      (`specs/plans/320-wasm-browser-demo.md`) — PR #2429 merged to `main`.
+      E1, E2, and E3 shipped; the browser-engine sandbox at `/demo` + landing
+      teaser shipped against the redesigned landing page. Relocates the egress
+      decision (`projection.rs`), placeholder substitution, and audit-entry
+      construction/chain-signing into `mvm-contract` so host and browser run
+      identical code. Claim-free by ADR-024 §3; adds no claim-catalog witness.
   - [x] E2.1 — the placeholder leaf relocated as
         `mvm_contract::substitution`; the constant hard-renamed to
         `SECRET_PLACEHOLDER_PREFIX` to avoid colliding with
@@ -823,17 +820,15 @@ for detailed scope and acceptance criteria.
         green.
   - [x] Oracle for both: `wasm_egress_witness.rs` must stay green
         **unmodified**.
-  - [~] `web/mvm-demo/` wasm-bindgen crate, workspace-excluded; Worker + thin
-        proxy; three curated fixtures (allowed / denied / unbound); tamper
-        button; `wasm-opt -Oz` + gzipped-size budget in the existing wasm lane.
-        Crate skeleton created with `decide_egress`,
+  - [x] `web/mvm-demo/` wasm-bindgen crate, workspace-excluded; Worker-owned
+        UI + thin main-thread proxy; three curated WASI fixtures
+        (allowed / denied / unbound) with `wasm-opt -Oz` and a gzipped-size
+        budget; tamper button; Astro `/demo` route and landing teaser. The
+        `build.sh` produces the deployable bundle and the `website.yml`
+        workflow builds it before Astro. Crate exposes `decide_egress`,
         `substitute_placeholder`, `verify`, and `run_scenario` shims over
-        `mvm-contract`; `seal()` is now available in `mvm-contract` for the
-        demo to sign real audit entries. A standalone `index.html` demo page
-        (same deployment pattern as `web/audit-verify/`) lets the visitor run
-        the three scenarios, see module/destination views, and verify/tamper a
-        fixture audit chain. Full Worker ownership + real curated WASI modules
-        remain.
+        `mvm-contract`; `seal()` is available in `mvm-contract` for the demo
+        to sign real audit entries.
   - [ ] Does **not** retire `web/audit-verify/` (no Merkle inclusion) — B5 and
         `mvmctl audit pubkey` remain plan 301's
 - [ ] Plan 321 — wasm as a workload format inside a real microVM

--- a/specs/plans/320-wasm-browser-demo.md
+++ b/specs/plans/320-wasm-browser-demo.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-DESIGN — approved in brainstorming, implementation not started.
+**SHIPPED — PR #2429 merged to `main`.** E1, E2, and E3 are complete and the
+browser demo is live at `/demo`. A few hardening items (fixture-parity Rust
+assertion, size budget in the `wasm32` CI lane, builder-VM artifact build) remain
+open and are tracked in the checkboxes below.
 
 Bound by [ADR-024](../adrs/024-wasm-sandbox-backend.md)'s three constraints.
 Adds no numbered security claim, and does not request one.
@@ -367,12 +370,9 @@ E3.1 was unaffected and is done; the frozen fixture passes on post-319
       the legacy chain with `SignatureInvalid { line: 0 }`.
       Checked against #2379's branch as well: clean merge, 6/6 green, so
       rotation does not change whether existing logs verify.
-- [~] E3.2a — **one `hash_line`.** The re-validation found it written out
-      three times byte-identically: `mvm-contract`'s `verify.rs`,
-      `audit_file.rs`, and — added by #2379 — `audit_set.rs`. It is the
-      function that *is* the chain link, so three definitions are three
-      definitions of what the chain is. Independent of every other E3 step
-      (no `AuditEntry` dependency), so it lands first and alone.
+- [x] E3.2a — **one `hash_line`.** De-duplicated into `mvm-contract::verify`
+      as part of E3.3; `audit_file.rs` and `audit_set.rs` now call the single
+      definition.
 - [x] E3.2 — hard-rename one of the two `AuditEntry`s. No alias.
 - [x] E3.3 — `hash_line` + `signed_bytes_for` de-duplicated to one
       definition each, `mvm-hostd` calling `mvm-contract`.
@@ -502,10 +502,12 @@ relocation and the design is wrong.
 - [ ] A fixture-parity test: the three browser fixtures produce the same
       outcomes the host witness asserts.
 - [x] `web/mvm-demo/` excluded from the workspace, as `web/audit-verify/` is.
-- [ ] `wasm-opt -Oz` plus a gzipped-size budget in that same lane (plan 301 B4's
-      discipline), failing the lane on regression.
-- [ ] Built in the builder VM, never a host toolchain (ADR-004 / ADR-007).
-- [ ] `cargo fmt --all -- --check` (nightly, per CI Lint),
+- [ ] `wasm-opt -Oz` plus a gzipped-size budget in the existing `wasm32` CI lane
+      (plan 301 B4's discipline), failing the lane on regression. The demo's
+      local `build.sh` enforces this today; the lane itself does not yet run it.
+- [ ] Built in the builder VM, never a host toolchain (ADR-004 / ADR-007). The
+      website workflow currently builds the wasm bundle on the GitHub runner.
+- [x] `cargo fmt --all -- --check` (nightly, per CI Lint),
       `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace --doc`, xtask gates.
 


### PR DESCRIPTION
Post-landing paperwork for #2429. Updates `specs/plans/320-wasm-browser-demo.md` and `specs/REFACTOR-STATUS.md` to reflect that E1/E2/E3 and the browser demo are now merged, and leaves the remaining hardening checkboxes open.