### PR TITLE
feat(mvm-build): wire before_build lifecycle hook in builder VM

### DIFF
--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -122,7 +122,7 @@ which.workspace = true
 # (the builder VM's PID 1) — folded in with mvm-host-vm-init.
 # Linux-only so non-Linux workspace builds don't drag in the dep.
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = { version = "0.29", features = ["mount", "reboot", "signal", "ioctl"] }
+nix = { version = "0.29", features = ["mount", "reboot", "signal", "ioctl", "fs"] }
 
 # Thin CLI wrapper for the reusable Builder-pack producer. Release CI / a
 # maintainer invokes it to turn built artifacts into a signed pack.

--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -115,7 +115,26 @@ mod workload;
 #[path = "mvm-host-vm-init/workload_proxy.rs"]
 mod workload_proxy;
 
+/// Builder-VM lifecycle hook runner. Mounts a workload rootfs and runs
+/// `/etc/mvm/hooks/before_build.sh` inside a chroot. Linux-only; the
+/// module is compiled on other hosts only for workspace ergonomics.
+#[cfg(target_os = "linux")]
+#[allow(dead_code)]
+#[path = "mvm-host-vm-init/builder_hooks.rs"]
+mod builder_hooks;
+
 fn main() -> ExitCode {
+    // Subcommand dispatch for builder-VM utility operations. When invoked
+    // as `mvm-host-vm-init run-before-build-hook <rootfs.ext4>`, mount the
+    // rootfs, run the before_build lifecycle hook inside a chroot, and
+    // return the hook's exit status. This keeps the hook runner in the
+    // same cross-compiled binary the builder VM already embeds at
+    // `/sbin/mvm-host-vm-init`.
+    #[cfg(target_os = "linux")]
+    if std::env::args().nth(1).as_deref() == Some("run-before-build-hook") {
+        return run_before_build_hook_subcommand();
+    }
+
     #[cfg(target_os = "linux")]
     {
         linux::run()
@@ -131,6 +150,21 @@ fn main() -> ExitCode {
              specs/plans/72-builder-vm-via-libkrun.md §W3."
         );
         ExitCode::FAILURE
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn run_before_build_hook_subcommand() -> ExitCode {
+    let rootfs = std::env::args().nth(2).unwrap_or_else(|| {
+        eprintln!("usage: mvm-host-vm-init run-before-build-hook <rootfs.ext4>");
+        std::process::exit(2);
+    });
+    match builder_hooks::run_before_build_hook(std::path::Path::new(&rootfs)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("mvm-host-vm-init: run-before-build-hook failed: {e}");
+            ExitCode::FAILURE
+        }
     }
 }
 

--- a/crates/mvm-build/src/bin/mvm-host-vm-init/builder_hooks.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init/builder_hooks.rs
@@ -1,0 +1,264 @@
+//! Builder-VM lifecycle hook runner.
+//!
+//! Runs the `before_build` hook inside a writable copy of the workload
+//! rootfs before the artifact is copied to `/out`. The hook script is
+//! baked into the rootfs at `/etc/mvm/hooks/before_build.sh` by
+//! `nix/lib/factories/mkFunctionService.nix`; this module is the consumer
+//! that executes it in the builder VM.
+//!
+//! Linux-only: the runner uses `mount`, `chroot`, and `wait` syscalls.
+
+use std::os::unix::process::CommandExt;
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use nix::mount::{MsFlags, mount, umount};
+
+/// Canonical path to the before_build hook inside a workload rootfs.
+const HOOK_PATH: &str = "/etc/mvm/hooks/before_build.sh";
+
+/// Where the rootfs image is mounted while the hook runs. Lives on the
+/// builder VM's tmpfs (`/tmp`) so the mount point itself is writable and
+/// does not depend on any host share.
+const MOUNT_POINT: &str = "/tmp/mvm-before-build-rootfs";
+
+/// Grace period for the before_build hook. Build-time setup (DB
+/// migrations, cache warming) should complete promptly; if it hangs we
+/// fail the build rather than leaving a builder VM wedged.
+const HOOK_GRACE: Duration = Duration::from_secs(600);
+
+/// Poll interval while waiting for the hook process.
+const HOOK_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Standard PATH inside the chroot. The hook script itself uses absolute
+/// Nix store paths for `runtimeShell` and `env`; this PATH is a fallback
+/// for user-supplied commands that reference bare interpreter names.
+const CHROOT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/sbin:/usr/sbin:/bin:/usr/bin";
+
+/// Errors surfaced when running the before_build hook.
+#[derive(Debug, thiserror::Error)]
+pub enum BuilderHookError {
+    /// Could not create the mount point directory.
+    #[error("create mount point {path}: {source}")]
+    CreateMountPoint {
+        path: &'static str,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Could not mount the rootfs image.
+    #[error("mount rootfs {rootfs} at {mount_point}: {source}")]
+    MountRootfs {
+        rootfs: std::path::PathBuf,
+        mount_point: &'static str,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Could not bind-mount a pseudo-filesystem into the chroot.
+    #[error("bind-mount {src} -> {dst}: {source}")]
+    BindMount {
+        src: String,
+        dst: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The hook process could not be spawned.
+    #[error("spawn before_build hook {hook}: {source}")]
+    SpawnHook {
+        hook: &'static str,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The hook ran but exited non-zero.
+    #[error("before_build hook exited with code {code:?}")]
+    HookNonZero { code: Option<i32> },
+
+    /// The hook exceeded its grace deadline and was killed.
+    #[error("before_build hook exceeded grace deadline {grace:?}")]
+    GraceExceeded { grace: Duration },
+
+    /// Waiting on the hook process failed unexpectedly.
+    #[error("wait for hook process: {source}")]
+    WaitFailed {
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Mount `rootfs_path` read-write at [`MOUNT_POINT`], bind-mount
+/// `/proc`, `/sys`, and `/dev` into it, then run
+/// [`HOOK_PATH`] inside a chroot.
+///
+/// The rootfs image is modified in place at `rootfs_path`, so callers
+/// should operate on a writable copy rather than the original Nix store
+/// output.
+///
+/// Returns `Ok(())` if the hook is missing (treated as a no-op) or if it
+/// exits 0. Returns [`BuilderHookError::HookNonZero`] or
+/// [`BuilderHookError::GraceExceeded`] on hook failure.
+pub fn run_before_build_hook(rootfs_path: &Path) -> Result<(), BuilderHookError> {
+    std::fs::create_dir_all(MOUNT_POINT).map_err(|e| BuilderHookError::CreateMountPoint {
+        path: MOUNT_POINT,
+        source: e,
+    })?;
+
+    mount_rootfs(rootfs_path)?;
+
+    // Ensure the chroot has the target directories for bind mounts.
+    // mkGuest rootfses already include them, but creating them is
+    // idempotent and makes the runner tolerant of unusual images.
+    for subdir in ["proc", "sys", "dev"] {
+        let _ = std::fs::create_dir_all(format!("{MOUNT_POINT}/{subdir}"));
+    }
+
+    let mut bind_mounts = Vec::new();
+    for (src, dst) in [("/proc", "proc"), ("/sys", "sys"), ("/dev", "dev")] {
+        let dst_path = format!("{MOUNT_POINT}/{dst}");
+        bind_mount(src, &dst_path).map_err(|e| BuilderHookError::BindMount {
+            src: src.to_string(),
+            dst: dst_path.clone(),
+            source: e,
+        })?;
+        bind_mounts.push(dst_path);
+    }
+
+    let hook_in_chroot = format!("{MOUNT_POINT}{HOOK_PATH}");
+    let hook_present = std::fs::metadata(&hook_in_chroot)
+        .map(|m| m.is_file())
+        .unwrap_or(false);
+
+    if !hook_present {
+        eprintln!("mvm-host-vm-init: no before_build hook at {HOOK_PATH}; treating as no-op");
+        cleanup_mounts(&bind_mounts);
+        return Ok(());
+    }
+
+    eprintln!(
+        "mvm-host-vm-init: running before_build hook in {rootfs_path}",
+        rootfs_path = rootfs_path.display()
+    );
+    let result = run_hook_in_chroot();
+
+    cleanup_mounts(&bind_mounts);
+    result
+}
+
+fn mount_rootfs(rootfs_path: &Path) -> Result<(), BuilderHookError> {
+    // `loop` asks the kernel to auto-allocate a loop device for the
+    // file-backed ext4 image. The builder VM kernel keeps BLK_DEV_LOOP
+    // enabled for image assembly.
+    mount(
+        Some(rootfs_path.as_os_str()),
+        MOUNT_POINT,
+        Some("ext4"),
+        MsFlags::empty(),
+        Some("loop"),
+    )
+    .map_err(|e| BuilderHookError::MountRootfs {
+        rootfs: rootfs_path.to_path_buf(),
+        mount_point: MOUNT_POINT,
+        source: std::io::Error::other(format!("{e}")),
+    })
+}
+
+fn bind_mount(source: &str, target: &str) -> Result<(), std::io::Error> {
+    std::fs::create_dir_all(target)?;
+    mount(
+        Some(source),
+        target,
+        None::<&str>,
+        MsFlags::MS_BIND | MsFlags::MS_REC,
+        None::<&str>,
+    )
+    .map_err(|e| std::io::Error::other(format!("{e}")))
+}
+
+fn cleanup_mounts(bind_mounts: &[String]) {
+    for m in bind_mounts.iter().rev() {
+        if let Err(e) = umount(m.as_str()) {
+            eprintln!("mvm-host-vm-init: warning: umount {m} failed: {e}");
+        }
+    }
+    if let Err(e) = umount(MOUNT_POINT) {
+        eprintln!("mvm-host-vm-init: warning: umount {MOUNT_POINT} failed: {e}");
+    }
+}
+
+fn run_hook_in_chroot() -> Result<(), BuilderHookError> {
+    let mut child = spawn_hook().map_err(|e| BuilderHookError::SpawnHook {
+        hook: HOOK_PATH,
+        source: e,
+    })?;
+
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if status.success() {
+                    return Ok(());
+                }
+                return Err(BuilderHookError::HookNonZero {
+                    code: status.code(),
+                });
+            }
+            Ok(None) => {
+                if start.elapsed() >= HOOK_GRACE {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(BuilderHookError::GraceExceeded { grace: HOOK_GRACE });
+                }
+                std::thread::sleep(HOOK_POLL_INTERVAL);
+            }
+            Err(e) => return Err(BuilderHookError::WaitFailed { source: e }),
+        }
+    }
+}
+
+fn spawn_hook() -> std::io::Result<std::process::Child> {
+    let mut cmd = Command::new(HOOK_PATH);
+    cmd.env("PATH", CHROOT_PATH);
+    cmd.current_dir("/");
+
+    // SAFETY: `pre_exec` runs in the forked child before `execve`.
+    // It only calls async-signal-safe syscalls (`chdir`, `chroot`) and
+    // modifies the child's own address space. The closure captures no
+    // borrowed state from the parent.
+    unsafe {
+        cmd.pre_exec(|| {
+            // Change into the new root before chroot so the inherited
+            // working directory does not point outside the jail.
+            nix::unistd::chdir(MOUNT_POINT)
+                .map_err(|e| std::io::Error::other(format!("chdir {MOUNT_POINT}: {e}")))?;
+            nix::unistd::chroot(MOUNT_POINT)
+                .map_err(|e| std::io::Error::other(format!("chroot {MOUNT_POINT}: {e}")))?;
+            nix::unistd::chdir("/").map_err(|e| std::io::Error::other(format!("chdir /: {e}")))?;
+            Ok(())
+        });
+    }
+
+    // `execve` resolves `HOOK_PATH` inside the chroot; the absolute path
+    // string is passed through unchanged. The shebang points at a Nix
+    // store path that is part of the rootfs closure.
+    cmd.spawn()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constants_are_stable() {
+        // These paths are part of the contract with cmd.sh callers and
+        // the Nix factory. If they change, the wiring sites must update.
+        assert_eq!(HOOK_PATH, "/etc/mvm/hooks/before_build.sh");
+        assert_eq!(MOUNT_POINT, "/tmp/mvm-before-build-rootfs");
+        assert_eq!(
+            CHROOT_PATH,
+            "/usr/local/sbin:/usr/local/bin:/sbin:/usr/sbin:/bin:/usr/bin"
+        );
+    }
+}

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -591,25 +591,49 @@ mkdir -p /nix/var/nix/gcroots 2>/dev/null || true
 # Retire the pre-fix single root so it stops protecting a stale closure.
 rm -f /nix/var/nix/gcroots/mvm-warm-latest 2>/dev/null || true
 
-# Copy the artifacts the host expects into /out. A plain mkGuest
-# workload image is a *bare ext4 file* ($NIX_OUT is the rootfs
-# itself; libkrun boots its bundled libkrunfw kernel, so no vmlinux
-# is emitted). Builder / interactive images are a *directory* carrying
+# Resolve the rootfs source path and any kernel source path. A plain
+# mkGuest workload image is a bare ext4 file ($NIX_OUT is the rootfs
+# itself); builder / interactive images are a directory carrying
 # `vmlinux` + `rootfs.ext4`. Accept either `vmlinux` / `Image` /
 # `bzImage` for the kernel across flake conventions.
+ROOTFS_SRC=
+KERNEL_SRC=
 if [ -f "$NIX_OUT" ]; then
-    cp -L "$NIX_OUT" /out/rootfs.ext4
-else
-    if   [ -f "$NIX_OUT/vmlinux" ]; then cp -L "$NIX_OUT/vmlinux" /out/vmlinux
-    elif [ -f "$NIX_OUT/Image"   ]; then cp -L "$NIX_OUT/Image"   /out/vmlinux
-    elif [ -f "$NIX_OUT/bzImage" ]; then cp -L "$NIX_OUT/bzImage" /out/vmlinux
+    ROOTFS_SRC="$NIX_OUT"
+elif [ -d "$NIX_OUT" ]; then
+    if   [ -f "$NIX_OUT/vmlinux" ]; then KERNEL_SRC="$NIX_OUT/vmlinux"
+    elif [ -f "$NIX_OUT/Image"   ]; then KERNEL_SRC="$NIX_OUT/Image"
+    elif [ -f "$NIX_OUT/bzImage" ]; then KERNEL_SRC="$NIX_OUT/bzImage"
     fi
     if [ -f "$NIX_OUT/rootfs.ext4" ]; then
-        cp -L "$NIX_OUT/rootfs.ext4" /out/rootfs.ext4
-    else
-        echo "no rootfs.ext4 in nix build output at $NIX_OUT" >&2
-        exit 1
+        ROOTFS_SRC="$NIX_OUT/rootfs.ext4"
     fi
+fi
+
+if [ -z "$ROOTFS_SRC" ] || [ ! -f "$ROOTFS_SRC" ]; then
+    echo "no rootfs.ext4 in nix build output at $NIX_OUT" >&2
+    exit 1
+fi
+
+# Run the before_build lifecycle hook inside a writable copy of the
+# rootfs before the artifact is copied to /out. The hook is baked
+# into the rootfs at /etc/mvm/hooks/before_build.sh by
+# mkFunctionService; mvm-host-vm-init provides the builder-VM
+# consumer.
+BUILD_HOOK_ROOTFS="/tmp/mvm-rootfs-before-build.ext4"
+cp -L "$ROOTFS_SRC" "$BUILD_HOOK_ROOTFS"
+echo "mvm-builder-vm: running before_build hook" >&2
+if ! /sbin/mvm-host-vm-init run-before-build-hook "$BUILD_HOOK_ROOTFS"; then
+    hook_rc=$?
+    echo "mvm-builder-vm: before_build hook failed (exit $hook_rc)" >&2
+    rm -f "$BUILD_HOOK_ROOTFS"
+    exit $hook_rc
+fi
+cp -L "$BUILD_HOOK_ROOTFS" /out/rootfs.ext4
+rm -f "$BUILD_HOOK_ROOTFS"
+
+if [ -n "$KERNEL_SRC" ]; then
+    cp -L "$KERNEL_SRC" /out/vmlinux
 fi
 
 # Permissions for the host-side reader. Ignore failures —
@@ -1966,6 +1990,41 @@ mod tests {
         assert!(
             warm_idx < gc_idx,
             "warm gcroot must be registered before the GC tail"
+        );
+    }
+
+    #[test]
+    fn render_flake_cmd_sh_runs_before_build_hook_before_copying_artifact() {
+        let body = render_flake_cmd_sh(".", "default", false);
+        // The hook runner is invoked on a writable temp copy so the Nix
+        // store output is never modified in place.
+        assert!(
+            body.contains("/sbin/mvm-host-vm-init run-before-build-hook"),
+            "missing before_build hook runner invocation in:\n{body}"
+        );
+        assert!(
+            body.contains("/tmp/mvm-rootfs-before-build.ext4"),
+            "missing writable temp rootfs path in:\n{body}"
+        );
+        // The hook must run before the final rootfs is copied to /out.
+        let hook_idx = body
+            .find("/sbin/mvm-host-vm-init run-before-build-hook")
+            .expect("hook runner present");
+        let out_copy_idx = body
+            .find(r#"cp -L "$BUILD_HOOK_ROOTFS" /out/rootfs.ext4"#)
+            .expect("final rootfs copy present");
+        assert!(
+            hook_idx < out_copy_idx,
+            "before_build hook must run before /out/rootfs.ext4 is copied"
+        );
+        // A failed hook must fail the build, leaving no partial artifact.
+        assert!(
+            body.contains("mvm-builder-vm: before_build hook failed"),
+            "missing hook failure message in:\n{body}"
+        );
+        assert!(
+            body.contains(r#"rm -f "$BUILD_HOOK_ROOTFS""#),
+            "temp rootfs must be cleaned up on hook failure in:\n{body}"
         );
     }
 

--- a/crates/mvm-build/src/builderd.rs
+++ b/crates/mvm-build/src/builderd.rs
@@ -459,13 +459,19 @@ pub fn dispatch_nix_build(
 /// the legacy `render_flake_cmd_sh` copy block: an out-path that is itself a
 /// file is the rootfs; an out-path that is a directory carries the kernel under
 /// `vmlinux`/`Image`/`bzImage` plus `rootfs.ext4`.
+///
+/// Before the rootfs is copied to `output_dir`, a writable copy is mounted and
+/// the `before_build` lifecycle hook (`/etc/mvm/hooks/before_build.sh`) is run
+/// inside it. The hook is baked into workload rootfses by
+/// `mkFunctionService.nix`; if the script is absent (e.g., a host-tool image) it
+/// is treated as a no-op by the runner.
 fn export_image_artifacts(nix_out: &Path, output_dir: &Path) -> Result<(), String> {
     std::fs::create_dir_all(output_dir)
         .map_err(|e| format!("create {}: {e}", output_dir.display()))?;
     let meta =
         std::fs::metadata(nix_out).map_err(|e| format!("stat {}: {e}", nix_out.display()))?;
     if meta.is_file() {
-        copy_artifact(nix_out, &output_dir.join("rootfs.ext4"))?;
+        copy_rootfs_with_hook(nix_out, &output_dir.join("rootfs.ext4"))?;
         return Ok(());
     }
     if let Some(kernel) = ["vmlinux", "Image", "bzImage"]
@@ -477,11 +483,57 @@ fn export_image_artifacts(nix_out: &Path, output_dir: &Path) -> Result<(), Strin
     }
     let rootfs = nix_out.join("rootfs.ext4");
     if rootfs.is_file() {
-        copy_artifact(&rootfs, &output_dir.join("rootfs.ext4"))?;
+        copy_rootfs_with_hook(&rootfs, &output_dir.join("rootfs.ext4"))?;
     } else {
         return Err(format!("no rootfs.ext4 in {}", nix_out.display()));
     }
     Ok(())
+}
+
+/// Copy `src_rootfs` to `dst`, running the `before_build` hook on a writable
+/// temp copy first. The temp copy lives on `/tmp` inside the builder VM so the
+/// original Nix store output is never modified.
+fn copy_rootfs_with_hook(src_rootfs: &Path, dst: &Path) -> Result<(), String> {
+    let tmp = tempfile::NamedTempFile::with_suffix(".ext4")
+        .map_err(|e| format!("create temp rootfs copy: {e}"))?;
+    let tmp_path = tmp.path().to_path_buf();
+    std::fs::copy(src_rootfs, &tmp_path).map_err(|e| {
+        format!(
+            "copy {} -> {}: {e}",
+            src_rootfs.display(),
+            tmp_path.display()
+        )
+    })?;
+    run_before_build_hook(&tmp_path)?;
+    std::fs::copy(&tmp_path, dst)
+        .map_err(|e| format!("copy {} -> {}: {e}", tmp_path.display(), dst.display()))?;
+    let _ = tmp.close();
+    Ok(())
+}
+
+/// Run the builder-VM before_build hook runner on `rootfs_path`.
+///
+/// If the runner binary is not present (e.g., unit tests driving
+/// `export_image_artifacts` on a dev host), the hook is skipped. The
+/// binary is always baked into the builder VM rootfs in production.
+fn run_before_build_hook(rootfs_path: &Path) -> Result<(), String> {
+    let runner = std::path::Path::new("/sbin/mvm-host-vm-init");
+    if !runner.is_file() {
+        return Ok(());
+    }
+    let status = std::process::Command::new(runner)
+        .arg("run-before-build-hook")
+        .arg(rootfs_path)
+        .status()
+        .map_err(|e| format!("spawn before_build hook runner: {e}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "before_build hook failed (exit {:?})",
+            status.code()
+        ))
+    }
 }
 
 /// Copy one artifact, dereferencing symlinks (nix store paths are read-only

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -1004,7 +1004,17 @@ pub fn stage_flake_dispatch_job(
              exit 4\n\
          fi\n\
          cp -L \"$STORE_PATH/vmlinux\" \"$OUT_DIR/vmlinux\"\n\
-         cp -L \"$STORE_PATH/rootfs.ext4\" \"$OUT_DIR/rootfs.ext4\"\n\
+         BUILD_HOOK_ROOTFS=\"/tmp/mvm-rootfs-before-build.ext4\"\n\
+         cp -L \"$STORE_PATH/rootfs.ext4\" \"$BUILD_HOOK_ROOTFS\"\n\
+         echo 'mvm-host-vm-init: running before_build hook' >&2\n\
+         if ! /sbin/mvm-host-vm-init run-before-build-hook \"$BUILD_HOOK_ROOTFS\"; then\n\
+             hook_rc=$?\n\
+             echo \"mvm-host-vm-init: before_build hook failed (exit $hook_rc)\" >&2\n\
+             rm -f \"$BUILD_HOOK_ROOTFS\"\n\
+             exit $hook_rc\n\
+         fi\n\
+         cp -L \"$BUILD_HOOK_ROOTFS\" \"$OUT_DIR/rootfs.ext4\"\n\
+         rm -f \"$BUILD_HOOK_ROOTFS\"\n\
          if [ -f \"$STORE_PATH/manifest.json\" ]; then\n\
              cp -L \"$STORE_PATH/manifest.json\" \"$OUT_DIR/manifest.json\"\n\
          fi\n",
@@ -1603,6 +1613,38 @@ mod tests {
             artifact_dir.is_dir(),
             "expected pre-staged artifact dir at {}",
             artifact_dir.display()
+        );
+    }
+
+    #[test]
+    fn stage_flake_dispatch_job_runs_before_build_hook_before_copying_rootfs() {
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let job_dir = scratch.path().to_path_buf();
+        let job_id =
+            stage_flake_dispatch_job(&job_dir, "path:/work", "packages.aarch64-linux.default")
+                .expect("stage");
+        let body = std::fs::read_to_string(job_dir.join(&job_id).join("cmd.sh")).expect("read");
+        assert!(
+            body.contains("/sbin/mvm-host-vm-init run-before-build-hook"),
+            "missing before_build hook runner invocation in:\n{body}"
+        );
+        assert!(
+            body.contains("/tmp/mvm-rootfs-before-build.ext4"),
+            "missing writable temp rootfs path in:\n{body}"
+        );
+        let hook_idx = body
+            .find("/sbin/mvm-host-vm-init run-before-build-hook")
+            .expect("hook runner present");
+        let out_copy_idx = body
+            .find("cp -L \"$BUILD_HOOK_ROOTFS\" \"$OUT_DIR/rootfs.ext4\"")
+            .expect("final rootfs copy present");
+        assert!(
+            hook_idx < out_copy_idx,
+            "before_build hook must run before rootfs.ext4 is copied to OUT_DIR"
+        );
+        assert!(
+            body.contains("mvm-host-vm-init: before_build hook failed"),
+            "missing hook failure message in:\n{body}"
         );
     }
 

--- a/nix/lib/factories/mkFunctionService.nix
+++ b/nix/lib/factories/mkFunctionService.nix
@@ -205,10 +205,11 @@ in
     };
     # Lifecycle hook scripts. The bootScript
     # invokes `before_start.sh` before exec'ing PID 1's idle loop;
-    # `after_start.sh` is the readiness probe a future watchdog will
-    # poll; `before_stop.sh` runs at shutdown when wired by the agent;
-    # `before_build.sh` is rendered for parity but runs in the builder
-    # VM, whose consumer is not yet wired.
+    # `after_start.sh` is the readiness probe the worker pool polls;
+    # `before_stop.sh` runs at shutdown when wired by the agent;
+    # `before_build.sh` runs in the builder VM via
+    # `mvm-host-vm-init run-before-build-hook` before the rootfs is
+    # copied to /out.
     # `source =` (copy the script file), NOT `content =` (which would
     # writeText the store-PATH string as the file body — a 0755 file
     # whose only content is a bare /nix/store path with no shebang,


### PR DESCRIPTION
## Summary

Completes the `before_build` lifecycle hook wiring so the builder VM executes `/etc/mvm/hooks/before_build.sh` on a writable copy of the rootfs after `nix build` succeeds but before the final artifact is copied to `/out`.

## Changes

- Adds `mvm-host-vm-init run-before-build-hook <rootfs.ext4>` subcommand and a new `builder_hooks.rs` module that mounts the ext4 read-write, bind-mounts `/proc`, `/sys`, and `/dev`, chroots, and runs the hook with a 10-minute grace deadline.
- Wires the hook into the single-shot builder VM `cmd.sh`, the persistent builder dispatch `cmd.sh`, and the resident builder daemon's `export_image_artifacts` path.
- Enables the `fs` feature on the Linux `nix` dependency so `chdir`/`chroot` compile in the cross build.
- Replaces the hardcoded `/tmp/mvm-rootfs-before-build.ext4` temp path with `tempfile::NamedTempFile` to avoid parallel test races.
- Skips the hook-runner spawn when `/sbin/mvm-host-vm-init` is absent, allowing builderd unit tests to run on a dev host.
- Updates `mkFunctionService.nix` comment to note `before_build.sh` is now consumed.

## Testing

- `cargo test -p mvm-build --lib` — 567 passed, 0 failed
- `cargo clippy -p mvm-build --all-targets -- -D warnings` — clean
- `cargo check --workspace` — clean (cross-compiles `mvm-host-vm-init` for aarch64-linux-musl)
- Pre-commit hook (`cargo fmt --all`, `cargo clippy --workspace --all-targets`) passed.