### PR TITLE
fix(web): build and deploy the wasm demo at /demo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,6 +40,21 @@ jobs:
           cache: pnpm
           cache-dependency-path: public/pnpm-lock.yaml
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+
+      - name: Install binaryen (wasm-opt)
+        run: sudo apt-get update && sudo apt-get install -y binaryen
+
+      - name: Build wasm demo
+        working-directory: web/mvm-demo
+        run: ./build.sh
+
       - name: Install dependencies
         working-directory: public
         run: pnpm install --frozen-lockfile

--- a/public/public/.gitignore
+++ b/public/public/.gitignore
@@ -1,0 +1,1 @@
+demo/pkg/

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -775,12 +775,15 @@ for detailed scope and acceptance criteria.
         `mvmctl audit pubkey`
 - [x] Plan 320 — A live wasm sandbox demo on the website
       (`specs/plans/320-wasm-browser-demo.md`) — PR #2429 merged to `main`;
-      hardening items closed in #2441. Browser-engine sandbox at `/demo`,
-      landing teaser, Web Worker ownership, curated `wasm32-wasip1` fixtures,
-      Rust fixture-parity tests, and `wasm-opt -Oz` + gzipped size budget in
-      the Linux wasm lane. Egress decision, placeholder substitution, and
-      audit-entry construction/chain signing are relocated into `mvm-contract`
-      so host and browser run
+      hardening items closed in #2441. This follow-up fix (#2447) adds the
+      wasm build to `.github/workflows/pages.yml` and corrects
+      `web/mvm-demo/build.sh` to preserve the `pkg/` subdirectory when staging,
+      so the live `/demo` route serves the bundle. Browser-engine sandbox at
+      `/demo`, landing teaser, Web Worker ownership, curated `wasm32-wasip1`
+      fixtures, Rust fixture-parity tests, and `wasm-opt -Oz` + gzipped size
+      budget in the Linux wasm lane. Egress decision, placeholder substitution,
+      and audit-entry construction/chain signing are relocated into
+      `mvm-contract` so host and browser run
       identical code. Claim-free by ADR-024 §3; adds no claim-catalog witness.
   - [x] E2.1 — the placeholder leaf relocated as
         `mvm_contract::substitution`; the constant hard-renamed to

--- a/specs/plans/320-wasm-browser-demo.md
+++ b/specs/plans/320-wasm-browser-demo.md
@@ -4,8 +4,10 @@
 
 **SHIPPED — PR #2429 merged to `main`; hardening items closed in #2441.** E1,
 E2, and E3 are complete, the browser demo is live at `/demo`, and the remaining
-hardening items (fixture-parity Rust assertion, size budget in the `wasm32` CI
-lane, builder-VM-style artifact build) are now closed.
+hardening items are now closed. This follow-up fix (#2447) adds the wasm build
+to `.github/workflows/pages.yml` and corrects `web/mvm-demo/build.sh` to
+preserve the `pkg/` subdirectory when staging, so the live `/demo` route serves
+the generated bundle.
 
 Bound by [ADR-024](../adrs/024-wasm-sandbox-backend.md)'s three constraints.
 Adds no numbered security claim, and does not request one.
@@ -508,6 +510,9 @@ relocation and the design is wrong.
 - [x] `cargo fmt --all -- --check` (nightly, per CI Lint),
       `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace --doc`, xtask gates.
+- [x] GitHub Pages deploy workflow (`.github/workflows/pages.yml`) builds the
+      wasm demo with `wasm-pack` + `wasm-opt` before `pnpm build`, so the live
+      `/demo` route includes the generated `pkg/` bundle.
 
 ## Sequencing constraints
 

--- a/web/mvm-demo/build.sh
+++ b/web/mvm-demo/build.sh
@@ -36,11 +36,12 @@ python3 "$SCRIPT_DIR/fixtures/build.py"
 
 # Stage everything the Astro site serves at /demo/.
 rm -rf "$DEST_DIR"
+mkdir -p "$DEST_DIR/pkg"
 mkdir -p "$DEST_DIR/fixtures"
 cp "$SCRIPT_DIR/index.html" "$DEST_DIR/index.html"
 cp "$SCRIPT_DIR/demo.js" "$DEST_DIR/demo.js"
 cp "$SCRIPT_DIR/worker.js" "$DEST_DIR/worker.js"
-cp "$SCRIPT_DIR/pkg"/* "$DEST_DIR/"
+cp "$SCRIPT_DIR/pkg"/* "$DEST_DIR/pkg/"
 cp "$SCRIPT_DIR/fixtures/"*.opt.wasm "$DEST_DIR/fixtures/"
 
 echo "Demo staged to $DEST_DIR"


### PR DESCRIPTION
## Problem

The browser wasm demo landed in #2429 and is linked from the landing-page header at `/demo`, but the GitHub Pages deploy workflow (`.github/workflows/pages.yml`) never built the wasm-bindgen bundle. The live site therefore 404'd at `/demo` (rendered as the splash 404 page) because the route contained only the committed source files and was missing the generated `pkg/` directory.

Additionally, `web/mvm-demo/build.sh` copied `pkg/*` into the demo root, but `worker.js` imports from `./pkg/mvm_demo_web.js`, so even after building the bundle the worker could not find it.

## Changes

- `.github/workflows/pages.yml`: install Rust `wasm32-unknown-unknown`, `wasm-pack`, and `binaryen`, then run `web/mvm-demo/build.sh` before `pnpm build`.
- `web/mvm-demo/build.sh`: stage the `pkg/` subdirectory intact into `public/public/demo/`.
- `public/public/.gitignore`: ignore the generated `demo/pkg/` directory.
- `specs/plans/320-wasm-browser-demo.md`: update status and tick the deploy-workflow checkbox.
- `specs/REFACTOR-STATUS.md`: record the follow-up deploy fix.

## Validation

- `./build.sh` in `web/mvm-demo/` succeeds and stays under the 300 KiB gzipped wasm budget.
- `pnpm build` in `public/` succeeds and emits `dist/demo/` with the correct `pkg/` subdirectory.
- Local static-server smoke test shows `/demo/`, `/demo/pkg/mvm_demo_web.js`, and `/demo/fixtures/*.opt.wasm` all returning 200.
- `pnpm check:tokens` and `pnpm check:samples` pass.

Fixes the live 404 at https://gomicrovm.com/demo/.