### PR TITLE
fix(public): constrain landing diagrams and space positioning heading

### DIFF
--- a/public/src/components/landing/Hero.tsx
+++ b/public/src/components/landing/Hero.tsx
@@ -191,7 +191,9 @@ export function Hero() {
               headline does. */}
           <Reveal delay={360} className="relative">
             <div className="pointer-events-none absolute -inset-4 rounded-2xl bg-linear-to-br from-glow-1 via-transparent to-glow-3 blur-xl" />
-            <HeroStackDiagram />
+            <div className="mx-auto w-full max-w-[18rem] sm:max-w-[22rem] lg:max-w-none">
+              <HeroStackDiagram />
+            </div>
           </Reveal>
         </div>
       </div>

--- a/public/src/components/landing/Positioning.tsx
+++ b/public/src/components/landing/Positioning.tsx
@@ -94,7 +94,7 @@ export function Positioning() {
   return (
     <Section rule space="roomy" className="bg-raised">
       <Reveal>
-        <h2 className="max-w-xl lowercase font-display text-3xl font-bold leading-tight text-title sm:text-4xl">
+        <h2 className="mb-6 max-w-xl lowercase font-display text-3xl font-bold leading-tight text-title sm:text-4xl">
           one project.
           <br />
           <span className="inline-block bg-accent-2 px-2 py-0.5 text-canvas">
@@ -103,7 +103,7 @@ export function Positioning() {
         </h2>
       </Reveal>
 
-      <div className="mt-16 flex flex-col gap-16 lg:mt-20 lg:gap-24">
+      <div className="mt-20 flex flex-col gap-16 lg:mt-24 lg:gap-24">
         {ROWS.map((row, i) => (
           <Reveal key={row.heading} delay={i * 60}>
             <div className="grid gap-8 lg:grid-cols-2 lg:items-center lg:gap-16">

--- a/public/src/components/landing/WhyMicrovm.tsx
+++ b/public/src/components/landing/WhyMicrovm.tsx
@@ -42,7 +42,7 @@ export function WhyMicrovm() {
           </ul>
         </div>
 
-        <Reveal>
+        <Reveal className="mx-auto w-full max-w-[18rem] sm:max-w-[22rem] lg:max-w-none">
           <ContainmentDiagram />
         </Reveal>
       </div>


### PR DESCRIPTION
Fixes two landing-page responsiveness issues on the redesigned marketing site:

- **Diagrams were too large on narrow viewports.** Both HeroStackDiagram and ContainmentDiagram scaled to the full width of the single-column mobile/tablet layout, making them dominate the page. They are now capped with responsive max-widths below the lg breakpoint and centered, while still filling their column on desktop.

- **Positioning heading sat too close to the first row.** The highlighted "three ways to drive it." block was nearly touching the "cli" eyebrow below it. Added bottom margin to the heading and increased the top margin on the rows container.

Verified with Playwright screenshots at 390/768/1024/1280 px, and pnpm check:tokens + pnpm check:samples + pnpm build passes.