### PR TITLE
cli: hidden __builder-shell-job command for Linux builder-VM gates

### DIFF
--- a/crates/mvm-cli/src/commands/builder_shell_job.rs
+++ b/crates/mvm-cli/src/commands/builder_shell_job.rs
@@ -1,0 +1,105 @@
+//! Internal: run a shell script inside the Linux builder VM.
+//!
+//! This command exposes the existing `BuilderShellJob` / `run_shell_script`
+//! machinery to arbitrary in-tree scripts. It is hidden from the user-facing
+//! CLI because the builder VM is headless and the contract (`/work` in,
+//! `/out` out, `/job/cmd.sh` executed by `mvm-host-vm-init`) is an internal
+//! build boundary, not a public shell.
+//!
+//! Primary use case: running Linux-only cargo gates (`cargo test` / `cargo
+//! clippy`) on hosts whose default build backend is the HVF or libkrun
+//! builder VM, where there is otherwise no interactive project builder-VM
+//! command path.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use clap::Args as ClapArgs;
+
+use mvm_build::builder_backend_select::{BuilderBackendChoice, resolve_choice};
+use mvm_build::builder_vm::BuilderVmError;
+use mvm_build::libkrun_builder::{BuilderShellJob, LibkrunBuilderVm};
+use mvm_core::user_config::MvmConfig;
+
+use super::Cli;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub struct Args {
+    /// Path to the shell script to stage as `/job/cmd.sh` inside the builder VM.
+    #[arg(long, value_name = "PATH")]
+    pub script: PathBuf,
+    /// Host directory bound read-only at `/work` inside the builder VM.
+    /// Defaults to the current working directory.
+    #[arg(long, value_name = "DIR")]
+    pub work_dir: Option<PathBuf>,
+    /// Host directory bound read-write at `/out` inside the builder VM.
+    /// Defaults to a fresh temporary directory.
+    #[arg(long, value_name = "DIR")]
+    pub artifact_out: Option<PathBuf>,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    let script = std::fs::read_to_string(&args.script)
+        .with_context(|| format!("reading script {}", args.script.display()))?;
+    let work_dir = match args.work_dir {
+        Some(p) => p,
+        None => std::env::current_dir().context("resolving current working directory")?,
+    };
+    let artifact_out = match args.artifact_out {
+        Some(p) => p,
+        None => tempfile::tempdir()
+            .context("creating temporary artifact-out directory")?
+            .keep(),
+    };
+    std::fs::create_dir_all(&artifact_out)
+        .with_context(|| format!("creating artifact-out {}", artifact_out.display()))?;
+
+    let job = BuilderShellJob {
+        work_dir,
+        artifact_out,
+        script,
+        extra_disks: Vec::new(),
+    };
+
+    let choice = resolve_choice();
+    let result = match choice {
+        BuilderBackendChoice::Libkrun => LibkrunBuilderVm::default()
+            .run_shell_script(&job)
+            .map_err(builder_vm_err)?,
+        BuilderBackendChoice::Hvf => {
+            let (kernel, rootfs, _closure_nar) =
+                crate::commands::build::hvf_builder_image::resolve_hvf_builder_image()
+                    .map_err(builder_vm_err)?;
+            mvm_runtime::builder_runner::hvf_builder::HvfBuilderVm::new(kernel, rootfs)
+                .run_shell_script(&job)
+                .map_err(builder_vm_err)?
+        }
+        BuilderBackendChoice::Qemu => {
+            bail!(
+                "builder shell jobs are not yet wired for the QEMU backend; \
+                 use --builder hvf or --builder libkrun"
+            )
+        }
+    };
+
+    let console_log = result.vm_state_dir.join("console.log");
+    if console_log.is_file()
+        && let Ok(console) = std::fs::read_to_string(&console_log)
+        && !console.is_empty()
+    {
+        println!("--- builder VM console ---");
+        print!("{console}");
+        println!("--- end builder VM console ---");
+    }
+
+    println!(
+        "Shell job succeeded.\n  job_dir: {}\n  vm_state_dir: {}",
+        result.job_dir.display(),
+        result.vm_state_dir.display()
+    );
+    Ok(())
+}
+
+fn builder_vm_err(e: BuilderVmError) -> anyhow::Error {
+    anyhow::anyhow!("builder VM shell job failed: {e}")
+}

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -204,6 +204,8 @@ impl Commands {
             Commands::Bootstrap(_) => "bootstrap",
             Commands::BuilderVmBootstrap(_) => "__builder-vm-bootstrap",
             Commands::BuilderEgressSupervisor(_) => "__builder-egress-supervisor",
+            #[cfg(feature = "builder-vm")]
+            Commands::BuilderShellJob(_) => "__builder-shell-job",
             Commands::Explain(_) => "explain",
             Commands::Run(_) => "run",
             Commands::SdkNoVm(_) => "__sdk-no-vm",

--- a/crates/mvm-cli/src/commands/dispatch.rs
+++ b/crates/mvm-cli/src/commands/dispatch.rs
@@ -19,6 +19,8 @@ impl TopLevelCommand for Commands {
             Commands::BuilderEgressSupervisor(a) => {
                 bootstrap::run_builder_egress_supervisor(cli, a, cfg)
             }
+            #[cfg(feature = "builder-vm")]
+            Commands::BuilderShellJob(a) => builder_shell_job::run(cli, a, cfg),
             Commands::Explain(a) => vm::explain::run(a),
             Commands::Run(a) => vm::exec::run_secure(cli, a, cfg),
             Commands::SdkNoVm(a) => vm::sdk_no_vm::run(&a),

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -1,5 +1,7 @@
 mod bootstrap;
 mod build;
+#[cfg(feature = "builder-vm")]
+mod builder_shell_job;
 mod bundle;
 pub mod catalog;
 mod cmd_audit;
@@ -165,6 +167,10 @@ pub(in crate::commands) enum Commands {
     /// Internal: keep a persistent builder's egress endpoint alive.
     #[command(name = "__builder-egress-supervisor", hide = true)]
     BuilderEgressSupervisor(bootstrap::BuilderEgressSupervisorArgs),
+    /// Internal: run a shell script inside the Linux builder VM.
+    #[command(name = "__builder-shell-job", hide = true)]
+    #[cfg(feature = "builder-vm")]
+    BuilderShellJob(builder_shell_job::Args),
     /// Environment / install lifecycle (bootstrap, update, sign, …)
     #[command(hide = true)]
     Env(env::group::Args),

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -403,6 +403,7 @@ fn internal_subprocess_commands_are_hidden_from_help() {
         "persistent-builder",
         "__builder-vm-bootstrap",
         "__builder-egress-supervisor",
+        "__builder-shell-job",
         "__qemu-vsock-bridge",
     ] {
         assert!(
@@ -428,6 +429,14 @@ fn internal_builder_egress_supervisor_command_is_hidden_but_parseable() {
     ])
     .unwrap();
     assert!(matches!(cli.command, Commands::BuilderEgressSupervisor(_)));
+}
+
+#[test]
+#[cfg(feature = "builder-vm")]
+fn internal_builder_shell_job_command_is_hidden_but_parseable() {
+    let cli = Cli::try_parse_from(["mvmctl", "__builder-shell-job", "--script", "/tmp/dummy.sh"])
+        .unwrap();
+    assert!(matches!(cli.command, Commands::BuilderShellJob(_)));
 }
 
 #[test]

--- a/scripts/linux-gate-mvm-vmm-clippy.sh
+++ b/scripts/linux-gate-mvm-vmm-clippy.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -euo pipefail
+export HOME=/tmp
+export RUSTUP_HOME=/tmp/rustup
+export CARGO_HOME=/tmp/cargo
+mkdir -p "$RUSTUP_HOME" "$CARGO_HOME"
+cd /work
+nix --extra-experimental-features 'nix-command flakes' shell nixpkgs#rustup nixpkgs#gcc nixpkgs#binutils nixpkgs#lld -c sh -c '
+  rustup toolchain install 1.96.0 --profile minimal --component clippy
+  rustup default 1.96.0
+  cargo clippy -p mvm-vmm --all-targets -- -D warnings
+'

--- a/scripts/linux-gate-mvm-vmm-test.sh
+++ b/scripts/linux-gate-mvm-vmm-test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -euo pipefail
+export HOME=/tmp
+export RUSTUP_HOME=/tmp/rustup
+export CARGO_HOME=/tmp/cargo
+mkdir -p "$RUSTUP_HOME" "$CARGO_HOME"
+cd /work
+nix --extra-experimental-features 'nix-command flakes' shell nixpkgs#rustup nixpkgs#gcc nixpkgs#binutils nixpkgs#lld -c sh -c '
+  rustup toolchain install 1.96.0 --profile minimal
+  rustup default 1.96.0
+  cargo test -p mvm-vmm --quiet
+'

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -474,6 +474,7 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     ("run", AuditPosture::InteractiveOrControl),
     ("__sdk-no-vm", AuditPosture::InteractiveOrControl),
     ("__builder-vm-bootstrap", AuditPosture::InteractiveOrControl),
+    ("__builder-shell-job", AuditPosture::InteractiveOrControl),
     (
         "__builder-egress-supervisor",
         AuditPosture::InteractiveOrControl,


### PR DESCRIPTION
Implementation of Plan 316: adds `mvmctl __builder-shell-job`, a hidden command that stages a host script as `/job/cmd.sh` and runs it inside the selected builder VM (libkrun or HVF). The workspace is mounted read-only at `/work` and a scratch directory is mounted read-write at `/out`.

Primary use case is running Linux-only cargo gates on macOS hosts whose default backend is the builder VM. Includes example scripts for running `cargo test -p mvm-vmm` and `cargo clippy -p mvm-vmm --all-targets` inside the VM, bootstrapping the pinned Rust 1.96 toolchain through `nix shell` into the persistent `/nix-store` disk.

The command is gated behind the `builder-vm` feature because it resolves the HVF builder image and related builder-VM machinery.

Verification:
- `cargo test -p mvm-vmm --quiet` inside the HVF builder VM: 505 passed.
- `cargo clippy -p mvm-vmm --all-targets -- -D warnings` inside the HVF builder VM: passed.
- macOS host: `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p mvm-cli --quiet` all pass.

Full workspace all-target clippy inside the VM remains blocked by `mvm-cli/build.rs`, which cross-compiles embedded host binaries with `cargo zigbuild --target aarch64-unknown-linux-musl`; the builder VM image lacks the required zig/cargo-zigbuild/aarch64 target toolchain. CI lint-core lane continues to cover that check on native Linux.

Docs/plan updates are in #2456.