### PR TITLE
Plan 330: decision provenance layer

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -111,6 +111,15 @@ for detailed scope and acceptance criteria.
 
 ## In-flight plans
 
+- [~] Plan 330 — Decision provenance layer
+  (`specs/plans/330-decision-provenance-layer.md`)
+  - [ ] Phase 0 — RFC and ADR approved
+  - [ ] Phase 1 — PROV-O export of existing events
+  - [ ] Phase 2 — Enrich existing audit events with authorizer/rationale
+  - [ ] Phase 3 — DecisionRecord API and content-addressed store
+  - [ ] Phase 4 — Query API and causal chains
+  - [ ] Phase 5 — Optional standards interoperability
+
 - [~] Plan 325 — SDK sidecar reserved mount
   (`specs/plans/325-sdk-sidecar-reserved-mount.md`)
   - [x] Reserved SDK disk is excluded from generic user-volume activation
@@ -213,7 +222,7 @@ for detailed scope and acceptance criteria.
   - [x] Run Linux-native workspace Clippy/tests — CI test-linux and
         lint-core passed on PR #2324; local x86_64 Linux cross-build
         (`cargo zigbuild --target x86_64-unknown-linux-gnu -p mvm-vmm
-    --lib --all-features`) passes on current `main`
+--lib --all-features`) passes on current `main`
 
 - [x] Plan 318 — span-timing profiling
       (`specs/plans/318-span-timing-profiling.md`)
@@ -282,7 +291,7 @@ for detailed scope and acceptance criteria.
   - [ ] Run the exact Linux Security workflow, merge the fix, and observe a
         clean scheduled or release run before closing the issue
 - [~] Plan 300 — 31-issue reconciliation and closeout
-      (`specs/plans/300-open-issue-closeout.md`)
+  (`specs/plans/300-open-issue-closeout.md`)
   - [x] Inventory all 39 issues open at the 2026-08-13 snapshot against
         current `origin/main`, issue comments, owning plans, and workflow state
   - [x] Close eight issues on 2026-08-13: #2165, #2289, #2333, #2423 as
@@ -1042,7 +1051,7 @@ for detailed scope and acceptance criteria.
         test fidelity, not liveness
   - [x] T17 — the operator surface, landed with a live entrypoint resolver in
         the same change as the plan required. `machine run --entrypoint --stdin
-    -` opens the route under the plan that boot was admitted under, pumps
+-` opens the route under the plan that boot was admitted under, pumps
         the caller's stdin through the gate in acceptance order on its own
         thread, refreshes the lease on a ticker while the writer is idle, and
         closes the workload's stdin on the caller's EOF. The grant is
@@ -1205,7 +1214,7 @@ for detailed scope and acceptance criteria.
         networking; `specs/refactor/03-networking.md` corrected from "the raw
         packet path is deleted" to the actual two-path state; ADR-001's tier
         matrix and claim-10 section qualified; `xtask
-    check-l3-expansion-freeze` added as a temporary shrink-only ratchet
+check-l3-expansion-freeze` added as a temporary shrink-only ratchet
         over `L3Vsock`/`raw_ip_stack`/`NetworkControl`/`NetworkData`/
         `spawn_netd`/`host_datapath` (29 allowlist entries); synthesis,
         admission, and CLI preflight refuse `raw_ip_stack=true`/`L3Vsock` with
@@ -1227,18 +1236,18 @@ for detailed scope and acceptance criteria.
         FlowMux, with tests for replay, tampering, wrong identity, and counter
         exhaustion. Remaining: the perf harness + baselines.
   - [x] Phase 2 — the one authenticated endpoint (#2371). `GuestService::NetworkFlow`
-    now names the port-5253 channel; the endpoint binary, proxy, spawner, and
-    test files are renamed to `mvm-network-endpoint`/`network_endpoint_*`;
-    `mvm-hostd::supervisor::flowmux` landed the authenticated FlowMux session
-    acceptor (`FlowMuxSession::accept`, `serve`, `Hello`/`HelloAck`, `GoAway`
-    for unimplemented flows) and bounded per-stream registries
-    (`flowmux::registry`) with unit tests for parity, ceilings, state
-    transitions, and credit accounting. The acceptor is wired into the
-    `mvm-network-endpoint` binary (`EgressMode::FlowMux`,
-    `EndpointConfig::flowmux_identity`, `serve_flowmux`) and the spawner emits
-    the identity on stdin. Backend witness tests in `mvm-vmm::host::spec_map`
-    and the Firecracker/HVF/libkrun driver modules prove exactly one
-    `NetworkFlow` service and no L3 services per granted workload.
+        now names the port-5253 channel; the endpoint binary, proxy, spawner, and
+        test files are renamed to `mvm-network-endpoint`/`network_endpoint_*`;
+        `mvm-hostd::supervisor::flowmux` landed the authenticated FlowMux session
+        acceptor (`FlowMuxSession::accept`, `serve`, `Hello`/`HelloAck`, `GoAway`
+        for unimplemented flows) and bounded per-stream registries
+        (`flowmux::registry`) with unit tests for parity, ceilings, state
+        transitions, and credit accounting. The acceptor is wired into the
+        `mvm-network-endpoint` binary (`EgressMode::FlowMux`,
+        `EndpointConfig::flowmux_identity`, `serve_flowmux`) and the spawner emits
+        the identity on stdin. Backend witness tests in `mvm-vmm::host::spec_map`
+        and the Firecracker/HVF/libkrun driver modules prove exactly one
+        `NetworkFlow` service and no L3 services per granted workload.
   - [ ] Phase 3 — converge egress TCP, UDP, and DNS (#2372)
   - [ ] Phase 4 — stream typed transformations (#2373)
   - [ ] Phase 5 — declared ingress on FlowMux (#2374)
@@ -1343,7 +1352,7 @@ for detailed scope and acceptance criteria.
   - [x] Linux cross-compile stubs for Hypervisor.framework symbols
   - [x] Console-streaming test isolated with temp `MVM_HOME`
   - [x] `cargo test -p mvm-runtime` green; `cargo clippy -p mvm-runtime
-    -p mvm-build -- -D warnings` clean on macOS and Linux builder VM
+-p mvm-build -- -D warnings` clean on macOS and Linux builder VM
   - [x] Full workspace test run on x86_64 Linux builder VM —
         `cargo nextest run --workspace`: 10372 passed, 19 skipped (4 threads)
 

--- a/specs/plans/330-decision-provenance-layer.md
+++ b/specs/plans/330-decision-provenance-layer.md
@@ -1,0 +1,242 @@
+# Plan 330 — Decision provenance layer for `mvm`
+
+**Status:** RFC / planning
+**Issue:** #330
+**Date:** 2026-08-13
+**Owner:** mvm
+**Related:** `specs/research/semantica-decision-provenance-assessment.md`, ADR-001, ADR-014
+
+## Summary
+
+Add a **decision-provenance layer** on top of `mvm`'s existing chain-signed audit substrate so that every security-relevant control-plane decision records **who** authorized it and **why**. Keep the existing Ed25519 chain-signed log as the source of truth; do not introduce a new authority or a heavy external dependency.
+
+This is the implementation of the gap identified in `semantica-decision-provenance-assessment.md`: `mvm` has strong cryptographic provenance but lacks first-class decision records with causal links and standards-based export.
+
+## Background
+
+`mvm` already records:
+
+- content-addressed `ExecutionPlan`s signed by the host signer;
+- chain-signed `AuditEntry` events in `tenant.jsonl` / `local.jsonl`;
+- RFC-6962 Merkle roots;
+- capability invocations, approval lifecycles, and admission events.
+
+What is missing:
+
+- a durable, structured record of the **authorizer principal** (human, on-call rotation, or automated system);
+- a free-form **rationale** for approvals, denials, and admissions;
+- a **ticket / change / incident reference**;
+- causal links between decisions (admission → launch → egress allow → checkpoint);
+- standards-based regulator export (PROV-O / RDF).
+
+The codebase explicitly acknowledges this gap:
+
+```rust
+/// Terminal operator outcome. Reasons remain outside durable metadata.
+pub enum ApprovalOutcome {
+    Approved,
+    Denied,
+}
+```
+
+## Goals
+
+1. Every admission, launch, egress, checkpoint, approval, and control-plane decision is attributable to a principal and a rationale.
+2. The chain-signed audit log remains the single source of truth.
+3. Existing audit readers continue to work; new fields are backward-compatible.
+4. Regulators and auditors can export decision chains to PROV-O / RDF.
+5. No new runtime authority is introduced; provenance records decisions, it does not make them.
+
+## Non-goals
+
+1. Replace existing signing, grants, capability bindings, or policy enforcement.
+2. Add a Python, graph database, or heavy AI-platform dependency.
+3. Build a general-purpose knowledge graph.
+4. Adopt `tibet-core` or Semantica as a runtime dependency.
+
+## Design
+
+### Core types
+
+```rust
+/// Content-addressed decision record. Stored as a chain-signed audit event.
+pub struct DecisionRecord {
+    pub decision_id: DecisionId,
+    pub version: u32,
+    pub category: DecisionCategory,
+    pub actor: ActorRef,
+    pub scenario: DecisionScenario,
+    pub reasoning: String,
+    pub outcome: DecisionOutcome,
+    pub confidence: Option<f64>,
+    pub timestamp: DateTime<Utc>,
+    pub causal_links: Vec<CausalLink>,
+    pub metadata: DecisionMetadata,
+}
+
+/// Principal that authorized the decision.
+pub struct ActorRef {
+    pub principal: String,        // human/on-call/service identity
+    pub key_id: String,           // signing key identifier
+    pub key_role: Option<ControlKeyRole>, // Promoter / Inventory / Orchestrator
+}
+
+/// What triggered the decision.
+pub struct DecisionScenario {
+    pub plan_id: Option<PlanId>,
+    pub workload_addr: Option<SemanticAddress>,
+    pub capability_id: Option<CapabilityId>,
+    pub approval_id: Option<ApprovalRequestId>,
+}
+
+/// Link to a prior decision.
+pub struct CausalLink {
+    pub relation: CausalRelation, // Caused, Influenced, PrecedentFor, Invalidated
+    pub decision_id: DecisionId,
+}
+
+/// Free-form compliance metadata.
+pub struct DecisionMetadata {
+    pub ticket_ref: Option<String>,
+    pub policy_ref: Option<String>,
+    pub regulation_scope: Vec<String>, // e.g. ["EU-AI-Act", "NIS2"]
+}
+
+/// Cryptographic binding to the existing audit substrate.
+pub struct AttestationBinding {
+    pub plan_id: Option<PlanId>,
+    pub workload_addr: Option<SemanticAddress>,
+    pub artifact_digests: BTreeMap<String, String>,
+    pub audit_entry_hash: String,
+    pub signer_pubkey: String,
+}
+```
+
+### Serialization
+
+`DecisionRecord` serializes as an `AuditEntry` event under a new `decision_record` label or as an enriched payload on existing events. The canonical JSON of the decision body (minus `decision_id`) is SHA-256 hashed to produce `DecisionId`, so the record is content-addressed and independently verifiable.
+
+### Storage
+
+- **Source of truth:** existing chain-signed `tenant.jsonl` / `local.jsonl`.
+- **Derived index:** optional content-addressed decision store (append-only, rebuildable from the chain).
+
+### Export
+
+- **PROV-O / RDF / Turtle:** read-only exporter over the chain-signed log.
+- **Optional TIBET-compatible JSON:** future interoperability serialization, not a runtime dependency.
+
+## Phases
+
+### Phase 0 — RFC and ADR
+
+- [ ] Write `specs/plans/330-decision-provenance-layer.md` (this file).
+- [ ] Write or update ADR defining `DecisionRecord`, `AttestationBinding`, PROV-O mapping, and explicit rejection of external provenance platforms as dependencies.
+- [ ] Identify all decision points in `mvm-hostd`, `mvm-agentd`, and `mvmd` control-plane paths.
+- [ ] Define backward-compatibility contract for `tenant.jsonl` readers.
+- [ ] Get RFC approved.
+
+### Phase 1 — PROV-O export of existing events
+
+Read-only exporter; no new runtime instrumentation.
+
+- [ ] Add `mvm-contract::provenance` module with PROV-O entity/activity/agent types.
+- [ ] Implement exporter that reads existing `tenant.jsonl` and emits Turtle/RDF.
+- [ ] Map existing events:
+  - `plan.admitted` → `prov:Activity`
+  - host signer → `prov:Agent`
+  - `plan_id` → `prov:Entity`
+- [ ] Add round-trip tests: export → parse → verify signatures still hold on original chain.
+- [ ] Validate output with a compliance/ops stakeholder.
+- [ ] Update `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md`.
+
+### Phase 2 — Enrich existing audit events
+
+Add structured decision fields to events that already exist.
+
+- [ ] Extend `ApprovalResponse` with `reason: Option<String>` and `ticket_ref: Option<String>`.
+- [ ] Extend `AgentApprovalEvent::Responded` with the same fields.
+- [ ] Extend `PlanAuditEntry` / `AuditEntry` with optional `authorizer_principal`, `authorization_reason`, `authorization_ticket_ref`.
+- [ ] Emit admission **refusals** as chain-signed events with rationale.
+- [ ] Emit orchestrator `ControlKey` usage events (kid, role, action digest, timestamp, optional rationale).
+- [ ] Add serde round-trip and schema tests for all enriched types.
+- [ ] Add negative tests: missing rationale on required events fails validation.
+- [ ] Update audit reader (`mvm-client::audit`) to surface new fields.
+- [ ] Update `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md`.
+
+### Phase 3 — DecisionRecord API and content-addressed store
+
+- [ ] Add `DecisionRecord`, `ActorRef`, `DecisionScenario`, `CausalLink`, `DecisionMetadata`, `AttestationBinding` types to `mvm-contract::provenance`.
+- [ ] Implement `DecisionId` as SHA-256 of canonical decision body.
+- [ ] Add `DecisionRecordBuilder`.
+- [ ] Integrate `DecisionRecord` emission into `AuditEmitter` for admission/launch/egress/checkpoint/approval events.
+- [ ] Add optional content-addressed decision store under `~/.mvm/decisions/` (rebuildable from chain).
+- [ ] Ensure decision store is derivable from the chain-signed log.
+- [ ] Add tests: builder, content-address stability, store rebuild, chain verification.
+- [ ] Update CLI `mvmctl trust audit` subcommands to optionally include decision records.
+- [ ] Update `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md`.
+
+### Phase 4 — Query API and causal chains
+
+- [ ] Implement `trace_decision_chain(decision_id)` over the decision store.
+- [ ] Implement `analyze_decision_impact(decision_id)` (forward traversal).
+- [ ] Implement `find_similar_decisions(scenario)` by category and artifact digests.
+- [ ] Add read-only query commands to `mvmctl` or `mvm-client`.
+- [ ] Add property-based tests for chain traversal.
+- [ ] Update `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md`.
+
+### Phase 5 — Optional standards interoperability
+
+- [ ] Evaluate `tibet-core` as an export format (not dependency) for decision records.
+- [ ] If valuable, add optional TIBET-JSON serializer without taking a crate dependency.
+- [ ] Evaluate C2PA / in-toto / SPDX relevance for build-time vs runtime provenance.
+- [ ] Update `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md`.
+
+## Testing strategy
+
+- **Serde round-trip tests** for every new type.
+- **Content-address stability** tests: same decision body → same `DecisionId`.
+- **Chain verification** tests: decision records verify as part of the existing chain.
+- **Rebuild tests:** delete decision store, replay chain, store recovers.
+- **PROV-O export tests:** parse generated Turtle with an RDF library in tests only.
+- **Negative tests:** refusal events include rationale; missing rationale on required events fails validation.
+- **Regression tests:** existing audit readers still parse old and new `tenant.jsonl`.
+
+## Guardrails
+
+- Do not introduce a Python / graph DB / LLM dependency.
+- Do not make the provenance layer an authority.
+- Do not store secrets, tokens, or PII in decision metadata.
+- Do not break the existing chain-signed log format.
+- Keep the decision store derivable from the chain.
+- Run `cargo clippy --workspace -- -D warnings` after every phase.
+- Run `cargo test --workspace` after every phase.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Schema churn in early versions | Version `DecisionRecord`, keep it an enrichment on existing events, not a replacement. |
+| PII / secrets in rationale | Validation rejects or redacts known patterns; field-level encryption optional. |
+| Performance cost of decision store | Store is optional and rebuildable; index lazily. |
+| Regulator wants a specific format | PROV-O export first; TIBET/C2PA/in-toto as optional serializers later. |
+| Scope creep into policy engine | Strict non-goal: provenance records only; enforcement stays in existing code. |
+
+## Open questions
+
+1. Should human approvals require a `reason` field, or remain optional?
+2. Which existing events beyond admission/launch/egress/checkpoint/approval should carry decision records in Phase 2?
+3. Should the decision store be per-tenant or global?
+4. Do we need retention / tombstone semantics for decision records under GDPR?
+5. Is PROV-O the right primary export, or should we prioritize a simpler JSON-LD format first?
+
+## Deliverables
+
+- [ ] `specs/plans/330-decision-provenance-layer.md`
+- [ ] Updated or new ADR
+- [ ] `crates/mvm-contract/src/provenance.rs` (types, builder, exporter traits)
+- [ ] `crates/mvm-hostd/src/audit/decisions.rs` (emitter integration)
+- [ ] `crates/mvm-client/src/provenance/` (query + export CLI)
+- [ ] `specs/sprint/delivery/330-decision-provenance-layer.md` (when complete)
+- [ ] Updated `specs/SPRINT.md`
+- [ ] Updated `specs/REFACTOR-STATUS.md`


### PR DESCRIPTION
## Summary

Introduces Plan 330, which adds a decision-provenance layer on top of mvm's existing chain-signed audit substrate so that security-relevant control-plane decisions capture *who* authorized them and *why*.

The plan is the implementation response to the gap identified in `specs/research/semantica-decision-provenance-assessment.md`: mvm already has strong cryptographic provenance, but lacks first-class decision records with causal links and standards-based export.

## Changes

- Add `specs/plans/330-decision-provenance-layer.md` with phased design, checklists, and acceptance criteria.
- Add Plan 330 to `specs/REFACTOR-STATUS.md` as an in-flight plan.

## Design highlights

- Keeps the existing Ed25519 chain-signed audit log as the single source of truth.
- Defines `DecisionRecord`, `ActorRef`, `AttestationBinding`, and causal-link types.
- Phased rollout: RFC/ADR → PROV-O export of existing events → enrich audit events with authorizer/rationale → `DecisionRecord` API + store → query API → optional standards interoperability.
- Explicitly avoids heavy external dependencies (no Semantica, no Python/graph DB, and `tibet-core` considered only as a future optional export format).

## Testing

This PR contains spec/planning documentation only; no code changes. Implementation phases will include unit tests, serde round-trips, chain-verification tests, PROV-O export validation, and regression tests for existing audit readers.