### PR TITLE
docs(plan-315,316): spin out local builder-VM gates into Plan 316

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -216,13 +216,22 @@ for detailed scope and acceptance criteria.
         prove no lifetime quota over a simulated 4 GiB transfer; prove active
         download credit prevents request-side idle eviction after 60 seconds;
         add the live documented pandas-install scenario
-  - [x] Pass all 446 `mvm-vmm` tests, the serial aggregate workspace suite,
+  - [x] Pass all 503 `mvm-vmm` tests, the serial aggregate workspace suite,
         workspace check, macOS workspace all-target Clippy, and the focused
-        x86_64 Linux cross-build
+        x86_64 and aarch64 Linux cross-builds
   - [x] Run Linux-native workspace Clippy/tests — CI test-linux and
-        lint-core passed on PR #2324; local x86_64 Linux cross-build
-        (`cargo zigbuild --target x86_64-unknown-linux-gnu -p mvm-vmm
---lib --all-features`) passes on current `main`
+        lint-core passed on PR #2324; local x86_64 and aarch64 Linux
+        cross-builds (`cargo zigbuild --target x86_64-unknown-linux-gnu`
+        and `--target aarch64-unknown-linux-gnu -p mvm-vmm --lib
+        --all-features`) pass on current `main`. Local Linux-native
+        builder-VM gates are tracked in Plan 316.
+
+- [ ] Plan 316 — Local Linux builder-VM gates via `mvmctl __builder-shell-job`
+      (`specs/plans/316-builder-vm-shell-job-runner.md`)
+  - [ ] Add hidden `mvmctl __builder-shell-job` command and example scripts
+  - [ ] Run `mvm-vmm` tests and crate-level Clippy inside the HVF/libkrun
+        builder VM
+  - [ ] Update Plan 315 and `specs/SPRINT.md` to reference this plan
 
 - [x] Plan 318 — span-timing profiling
       (`specs/plans/318-span-timing-profiling.md`)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -68,11 +68,11 @@
       reply; a simulated continuous 4 GiB transfer proves the refillable rate
       budget is not a lifetime quota. A live BDD scenario pins the documented
       `python:3.12` pandas
-      install through PyPI. All 446 `mvm-vmm` tests, workspace check, macOS
-      workspace all-target Clippy, the serial aggregate workspace suite, and
-      the focused x86_64 Linux cross-build are green. The CI test-linux and lint-core lanes passed on PR #2324, and a
-      local x86_64 Linux cross-build passes on current main; the platform
-      gates are complete.
+      install through PyPI. All 503 `mvm-vmm` tests on the macOS host,
+      workspace check, macOS workspace all-target Clippy, the serial aggregate
+      workspace suite, and the focused x86_64 and aarch64 Linux cross-builds
+      are green. The CI test-linux and lint-core lanes passed on PR #2324;
+      local Linux-native builder-VM gates are tracked in Plan 316.
 - [x] Issue-closeout batch — **#2165, #2321, #2323**. Closed 2026-08-13.
       #2165 closed as
       completed by PR #2330: workload-runner root bootargs now agree with

--- a/specs/plans/315-hvf-vsock-credit-regression.md
+++ b/specs/plans/315-hvf-vsock-credit-regression.md
@@ -40,7 +40,9 @@ host response can overrun the guest receive window.
       the CI `test-linux` and `lint-core` lanes passed on PR #2324; local
       x86_64 and aarch64 Linux cross-builds (`cargo zigbuild --target
       x86_64-unknown-linux-gnu -p mvm-vmm --lib --all-features` and `--target
-      aarch64-unknown-linux-gnu`) pass on current `main`.
+      aarch64-unknown-linux-gnu`) pass on current `main`. Local Linux-native
+      `mvm-vmm` tests and crate-level Clippy inside the builder VM are
+      tracked separately in Plan 316.
 - [x] Record the repair in `specs/SPRINT.md` and
       `specs/REFACTOR-STATUS.md`.
 
@@ -77,7 +79,8 @@ host response can overrun the guest receive window.
   `--all-features` clippy/test binaries need, so a local builder-VM run of
   those gates would first require either a cargo-capable dev image/flake or
   an exposed `BuilderShellJob` runner that can `nix shell` the required
-  toolchain and libraries into the persistent Nix store.
+  toolchain and libraries into the persistent Nix store. That local-gates
+  work is now tracked in Plan 316.
 
 ## Non-goals
 

--- a/specs/plans/316-builder-vm-shell-job-runner.md
+++ b/specs/plans/316-builder-vm-shell-job-runner.md
@@ -1,0 +1,59 @@
+# Plan 316 — Local Linux builder-VM gates via `mvmctl __builder-shell-job`
+
+## Status
+
+**OPEN.** Spun out of Plan 315 because the HVF virtio-vsock fix was
+complete and merged, but the macOS host still had no local path for running
+Linux-native cargo gates. The missing piece is an exposed, scriptable way to
+run arbitrary shell commands inside the project builder VM so contributors on
+macOS can execute Linux-only checks without waiting for CI.
+
+## Problem
+
+Plan 315 proved the credit-regression fix with macOS tests and x86_64/aarch64
+Linux cross-builds, but several gates are only meaningful on real Linux:
+
+- `cargo test -p mvm-vmm` with Linux-only tests (vsock, jailer/seccomp,
+  dm-verity, network namespaces, `/dev/kvm` and `/proc/net` paths).
+- Crate-level `cargo clippy -p mvm-vmm --all-targets` against Linux-gated
+  code.
+- Broader workspace checks that the macOS host cannot compile because of
+  Linux-only dependencies and features.
+
+The macOS 26 execution tier auto-detects the HVF builder backend and has no
+interactive builder-VM shell path. The existing `BuilderShellJob` /
+`run_shell_script` machinery already supports libkrun, QEMU, and HVF, but it
+is only used internally during builds; there is no CLI entry point for
+arbitrary scripts.
+
+## Scope and acceptance
+
+- [ ] Add a hidden `mvmctl __builder-shell-job` command that:
+  - accepts a host script path (`--script`) and stages it as `/job/cmd.sh`,
+  - binds a host directory read-only at `/work` (default: cwd),
+  - binds a host directory read-write at `/out` (default: temp dir),
+  - dispatches to the selected builder backend (libkrun/HVF; QEMU may defer).
+- [ ] Provide example scripts for common gates:
+  - `scripts/linux-gate-mvm-vmm-test.sh` — run `cargo test -p mvm-vmm --quiet`,
+  - `scripts/linux-gate-mvm-vmm-clippy.sh` — run `cargo clippy -p mvm-vmm --all-targets -- -D warnings`.
+- [ ] Scripts bootstrap the pinned Rust 1.96 toolchain via `nix shell` into
+      the persistent `/nix-store` disk so the first run is slow but later
+      runs reuse the cache.
+- [ ] Verify `mvm-vmm` tests and clippy pass inside the HVF builder VM.
+- [ ] Update Plan 315 and `specs/SPRINT.md` to reference this plan.
+- [ ] Record any remaining blockers (e.g., full workspace clippy inside the VM)
+      honestly; do not claim gates that still require CI.
+
+## Non-goals
+
+- Solving the full workspace all-target Clippy cross-compile blocker inside
+  the VM. `mvm-cli/build.rs` cross-compiles embedded host binaries with
+  `cargo zigbuild --target aarch64-unknown-linux-musl`; the builder VM image
+  lacks `zig`, `cargo-zigbuild`, and the `aarch64-unknown-linux-musl` target.
+  Fixing that toolchain mismatch is out of scope and remains covered by CI's
+  `lint-core` lane on native Linux.
+- Making `__builder-shell-job` a public, documented command. It stays hidden
+  because the builder VM is headless and the `/work`/`/out`/`/job/cmd.sh`
+  contract is an internal build boundary.
+- Adding QEMU backend support if it is not already wired for
+  `run_shell_script`.


### PR DESCRIPTION
Plan 315 is complete and merged. The remaining open item from its verification list — a local path for Linux-native cargo gates on macOS — is broader than the vsock credit fix, so spin it out into a new Plan 316.

Changes:
- Update `specs/plans/315-hvf-vsock-credit-regression.md` to reference Plan 316 for local Linux builder-VM gates.
- Add `specs/plans/316-builder-vm-shell-job-runner.md` describing the hidden `mvmctl __builder-shell-job` command and example scripts.
- Update `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md` to reflect the split.

This is the docs-only companion to the implementation PR (the shell-job runner code itself is in a separate feature PR).