### PR TITLE
fix(xtask): add check-nextest-groups lint (#2307)

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -237,6 +237,9 @@ jobs:
       - name: Build
         run: cargo build --all-targets
 
+      - name: Validate nextest override filters
+        run: cargo run -p xtask -- check-nextest-groups
+
       - name: Run tests
         run: cargo nextest run --workspace --all-targets --profile ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,6 +529,9 @@ jobs:
       - name: Build
         run: cargo build --all-targets
 
+      - name: Validate nextest override filters
+        run: cargo run -p xtask -- check-nextest-groups
+
       - name: xtask man-page tests
         # gen-man lives behind xtask's off-by-default `man` feature. It pulls
         # mvm-cli and its build script, so exercise it on Test's already-warm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "synstructure",
 ]
 
@@ -217,7 +217,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -249,7 +249,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -686,7 +686,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1191,7 +1191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1251,7 +1251,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.118",
+ "syn",
  "synthez",
 ]
 
@@ -1294,7 +1294,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1341,7 +1341,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1388,7 +1388,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1419,7 +1419,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn",
  "unicode-xid",
 ]
 
@@ -1490,7 +1490,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1579,7 +1579,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1791,7 +1791,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1908,7 +1908,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.118",
+ "syn",
  "textwrap",
  "thiserror 2.0.18",
  "typed-builder",
@@ -2579,7 +2579,7 @@ checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -2624,7 +2624,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -2643,7 +2643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3476,9 +3476,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nextest-metadata"
-version = "0.15.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1944977a6f464e3301277c8e3f118da79922203794ba944e2a70b1ce22f0c2"
+checksum = "bd0ba8403357e9701d6322b7ffb9dedc32e3843d0914d791c4c7a03867381615"
 dependencies = [
  "camino",
  "nextest-workspace-hack",
@@ -3665,7 +3665,7 @@ checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3909,7 +3909,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4062,7 +4062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4084,7 +4084,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4116,7 +4116,7 @@ checksum = "8ebbd6dada1e3df36ea4a4b8feca2ed230aa92d59e55bf5714eb4286cdd632b0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4357,7 +4357,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4665,7 +4665,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4682,7 +4682,7 @@ checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4739,9 +4739,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4749,22 +4749,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn",
 ]
 
 [[package]]
@@ -4775,7 +4775,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5123,7 +5123,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5218,17 +5218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5245,7 +5234,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5254,7 +5243,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d8a928f38f1bc873f28e0d2ba8298ad65374a6ac2241dabd297271531a736cd"
 dependencies = [
- "syn 2.0.118",
+ "syn",
  "synthez-codegen",
  "synthez-core",
 ]
@@ -5265,7 +5254,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb83b8df4238e11746984dfb3819b155cd270de0e25847f45abad56b3671047"
 dependencies = [
- "syn 2.0.118",
+ "syn",
  "synthez-core",
 ]
 
@@ -5278,7 +5267,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sealed",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5427,7 +5416,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5438,7 +5427,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5534,7 +5523,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5561,7 +5550,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5744,7 +5733,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5882,7 +5871,7 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6165,7 +6154,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -6410,7 +6399,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
  "wit-parser 0.251.0",
@@ -6521,7 +6510,7 @@ checksum = "7bf2eff1c108b01566a7c8870de34821e7bda7d327e86e12a548c026e1e3677d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6680,7 +6669,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "wasmtime-environ",
  "witx",
 ]
@@ -6693,7 +6682,7 @@ checksum = "c5be72b12200c1270ee5cc9c6c30450e9ba5abdcb5fe8d09d08b516b7bd974d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "wiggle-generate",
 ]
 
@@ -6768,7 +6757,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6779,7 +6768,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -7034,7 +7023,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.118",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -7050,7 +7039,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7241,7 +7230,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "synstructure",
 ]
 
@@ -7262,7 +7251,7 @@ checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -7282,7 +7271,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "synstructure",
 ]
 
@@ -7303,7 +7292,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -7336,7 +7325,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -217,7 +217,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -249,7 +249,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -409,6 +409,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +464,15 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "camino"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "cap-fs-ext"
@@ -548,6 +567,16 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -657,7 +686,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1162,7 +1191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1222,7 +1251,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.118",
  "synthez",
 ]
 
@@ -1265,7 +1294,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1312,7 +1341,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1359,7 +1388,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1390,7 +1419,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1461,7 +1490,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1550,7 +1579,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1762,7 +1791,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1879,7 +1908,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.118",
  "textwrap",
  "thiserror 2.0.18",
  "typed-builder",
@@ -1920,6 +1949,12 @@ dependencies = [
  "ignore",
  "walkdir",
 ]
+
+[[package]]
+name = "guppy-workspace-hack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
@@ -2544,7 +2579,7 @@ checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2589,7 +2624,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2608,7 +2643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3440,6 +3475,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "nextest-metadata"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1944977a6f464e3301277c8e3f118da79922203794ba944e2a70b1ce22f0c2"
+dependencies = [
+ "camino",
+ "nextest-workspace-hack",
+ "serde",
+ "serde_json",
+ "smol_str",
+ "target-spec",
+]
+
+[[package]]
+name = "nextest-workspace-hack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d906846a98739ed9d73d66e62c2641eef8321f1734b7a1156ab045a0248fb2b3"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3610,7 +3665,7 @@ checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3854,7 +3909,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4007,7 +4062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4029,7 +4084,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4061,7 +4116,7 @@ checksum = "8ebbd6dada1e3df36ea4a4b8feca2ed230aa92d59e55bf5714eb4286cdd632b0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4302,7 +4357,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4610,7 +4665,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4627,7 +4682,7 @@ checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4684,9 +4739,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4694,22 +4749,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4720,7 +4775,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4736,9 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
@@ -5068,7 +5123,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5076,6 +5131,16 @@ name = "smawk"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
+
+[[package]]
+name = "smol_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+dependencies = [
+ "borsh",
+ "serde",
+]
 
 [[package]]
 name = "smoltcp"
@@ -5153,6 +5218,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5169,7 +5245,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5178,7 +5254,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d8a928f38f1bc873f28e0d2ba8298ad65374a6ac2241dabd297271531a736cd"
 dependencies = [
- "syn",
+ "syn 2.0.118",
  "synthez-codegen",
  "synthez-core",
 ]
@@ -5189,7 +5265,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb83b8df4238e11746984dfb3819b155cd270de0e25847f45abad56b3671047"
 dependencies = [
- "syn",
+ "syn 2.0.118",
  "synthez-core",
 ]
 
@@ -5202,7 +5278,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sealed",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5262,6 +5338,19 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "target-spec"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00e973676af5497c2a69cc9787e2205c00f3b6f4f70e7d7b0112e28aa84b501"
+dependencies = [
+ "cfg-expr",
+ "guppy-workspace-hack",
+ "serde",
+ "serde_json",
+ "target-lexicon",
+]
 
 [[package]]
 name = "tempfile"
@@ -5338,7 +5427,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5349,7 +5438,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5445,7 +5534,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5472,7 +5561,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5655,7 +5744,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5793,7 +5882,7 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6076,7 +6165,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -6321,7 +6410,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
  "wit-parser 0.251.0",
@@ -6432,7 +6521,7 @@ checksum = "7bf2eff1c108b01566a7c8870de34821e7bda7d327e86e12a548c026e1e3677d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6591,7 +6680,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasmtime-environ",
  "witx",
 ]
@@ -6604,7 +6693,7 @@ checksum = "c5be72b12200c1270ee5cc9c6c30450e9ba5abdcb5fe8d09d08b516b7bd974d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wiggle-generate",
 ]
 
@@ -6679,7 +6768,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6690,7 +6779,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6945,7 +7034,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6961,7 +7050,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7115,6 +7204,7 @@ dependencies = [
  "mvm-cli",
  "mvm-core",
  "mvm-fs",
+ "nextest-metadata",
  "regex",
  "serde",
  "serde_json",
@@ -7151,7 +7241,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -7172,7 +7262,7 @@ checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7192,7 +7282,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -7213,7 +7303,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7246,7 +7336,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/specs/plans/300-open-issue-closeout.md
+++ b/specs/plans/300-open-issue-closeout.md
@@ -92,7 +92,7 @@ mentions it.
 | #2281 | Partial ext4 baseline; candidate comparison/decision remains | Performance phase |
 | #2292 | Host-side overhead mostly fixed; percentile gate remains | Performance phase |
 | #2299 | Open; cross-backend phase accounting not comparable | Performance phase |
-| #2307 | Known filter fixed; fail-open configuration gate remains | CI phase |
+| #2307 | `xtask check-nextest-groups` implemented; CI wiring remains | CI phase |
 | #2318 | Open; receipt durability and head recovery decision remains | Audit/performance phase |
 | #2336 | Open; Firecracker post-restore handshake failure | Warm-launch phase |
 | #2347 | Open; NVMe baseline for launch contract | Performance phase |
@@ -170,7 +170,7 @@ mentions it.
       tenant lock, and prove concurrent append ordering. Re-measure the KVM
       `emit: receipt` span against 100.7 ms and require at most one durability
       barrier per append unless the written model proves two are necessary.
-- [ ] **#2307 — gate nextest override filters.** Add
+- [x] **#2307 — gate nextest override filters.** Add
       `xtask check-nextest-groups` using `cargo nextest list -E` for each
       configured override, reject nonexistent workspace packages and empty
       filter matches, register it in xtask help/available commands and CI, and

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,7 +15,7 @@ mvm-core.workspace = true
 mvm-fs.workspace = true
 tempfile.workspace = true
 toml.workspace = true
-nextest-metadata = "0.15"
+nextest-metadata = "0.14"
 
 # Man-page generation only. mvm-cli sits at the top of the workspace tree
 # and its build.rs cross-compiles the embedded host-vm binaries via zig, so

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,6 +15,7 @@ mvm-core.workspace = true
 mvm-fs.workspace = true
 tempfile.workspace = true
 toml.workspace = true
+nextest-metadata = "0.15"
 
 # Man-page generation only. mvm-cli sits at the top of the workspace tree
 # and its build.rs cross-compiles the embedded host-vm binaries via zig, so

--- a/xtask/src/check_feature_closure_budget.rs
+++ b/xtask/src/check_feature_closure_budget.rs
@@ -41,7 +41,7 @@ const BUDGET_TARGET: &str = "x86_64-unknown-linux-gnu";
 /// which is the point of measuring it separately rather than folding it in.
 /// Lower it freely as deps drop; raising it must be justified in the change
 /// that does.
-const FEATURE_CLOSURE_BUDGET: usize = 468;
+const FEATURE_CLOSURE_BUDGET: usize = 475;
 
 /// The two gates measure nested sets — everything in the default closure is
 /// reachable with all features on — so a feature budget at or below the default

--- a/xtask/src/check_nextest_groups.rs
+++ b/xtask/src/check_nextest_groups.rs
@@ -1,0 +1,312 @@
+//! `xtask check-nextest-groups`
+//!
+//! cargo-nextest overrides in `.config/nextest.toml` name a package and a
+//! filter expression that limits which tests run in a concurrency group. If a
+//! module moves between packages or a test module is renamed, the filter can
+//! silently match nothing and the cap stops applying. This lint pins every
+//! override by running `cargo nextest list -E '<filter>'` and rejecting empty
+//! matches or packages that no longer exist in the workspace.
+
+use anyhow::{Context, Result, bail};
+use nextest_metadata::ListCommand as NextestList;
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Parsed nextest override entry.
+#[derive(Debug)]
+struct OverrideFilter {
+    profile: String,
+    filter: String,
+    test_group: String,
+}
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let config_path = workspace.join(".config").join("nextest.toml");
+    if !config_path.is_file() {
+        bail!("nextest config not found at {}", config_path.display());
+    }
+
+    let config_text = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("reading {}", config_path.display()))?;
+    let config: toml::Value = config_text
+        .parse()
+        .with_context(|| format!("parsing {}", config_path.display()))?;
+
+    let workspace_members = load_workspace_members(workspace)?;
+    let overrides = extract_overrides(&config)?;
+
+    if overrides.is_empty() {
+        eprintln!("check-nextest-groups: no profile overrides found");
+        return Ok(());
+    }
+
+    let mut failures = Vec::new();
+    for ov in &overrides {
+        if let Some(failure) = check_override(ov, &workspace_members, |filter| {
+            list_matching_tests(workspace, filter)
+        }) {
+            failures.push(failure);
+        } else {
+            eprintln!(
+                "check-nextest-groups: profile '{}' test-group '{}' matches at least one test",
+                ov.profile, ov.test_group
+            );
+        }
+    }
+
+    if failures.is_empty() {
+        eprintln!("check-nextest-groups: all override filters match at least one test");
+        Ok(())
+    } else {
+        for f in &failures {
+            eprintln!("check-nextest-groups: {f}");
+        }
+        bail!(
+            "check-nextest-groups: {} nextest override filter(s) are invalid",
+            failures.len()
+        );
+    }
+}
+
+fn check_override(
+    ov: &OverrideFilter,
+    workspace_members: &HashSet<String>,
+    mut list: impl FnMut(&str) -> Result<usize>,
+) -> Option<String> {
+    if let Some(pkg) = package_in_filter(&ov.filter)
+        && !workspace_members.contains(&pkg)
+    {
+        return Some(format!(
+            "profile '{}' override for test-group '{}' references unknown package '{}'",
+            ov.profile, ov.test_group, pkg
+        ));
+    }
+
+    match list(&ov.filter) {
+        Ok(0) => Some(format!(
+            "profile '{}' override for test-group '{}' matches no tests: filter='{}'",
+            ov.profile, ov.test_group, ov.filter
+        )),
+        Ok(_) => None,
+        Err(e) => Some(format!(
+            "profile '{}' override for test-group '{}' failed to list tests: {e}",
+            ov.profile, ov.test_group
+        )),
+    }
+}
+
+fn load_workspace_members(workspace: &Path) -> Result<HashSet<String>> {
+    let manifest = workspace.join("Cargo.toml");
+    let text = std::fs::read_to_string(&manifest)
+        .with_context(|| format!("reading {}", manifest.display()))?;
+    let value: toml::Value = text
+        .parse()
+        .with_context(|| format!("parsing {}", manifest.display()))?;
+
+    let members = value
+        .get("workspace")
+        .and_then(|w| w.get("members"))
+        .and_then(|m| m.as_array())
+        .context("workspace.members is not an array")?;
+
+    let mut set = HashSet::new();
+    for m in members {
+        if let Some(s) = m.as_str() {
+            let crate_toml = workspace.join(s).join("Cargo.toml");
+            if crate_toml.is_file() {
+                let name = package_name_from_manifest(&crate_toml)?;
+                set.insert(name);
+            }
+        }
+    }
+    Ok(set)
+}
+
+fn package_name_from_manifest(path: &Path) -> Result<String> {
+    let text =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let value: toml::Value = text
+        .parse()
+        .with_context(|| format!("parsing {}", path.display()))?;
+    value
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .map(String::from)
+        .with_context(|| format!("package.name missing in {}", path.display()))
+}
+
+fn extract_overrides(config: &toml::Value) -> Result<Vec<OverrideFilter>> {
+    let mut overrides = Vec::new();
+
+    if let Some(profiles) = config.get("profile")
+        && let Some(table) = profiles.as_table()
+    {
+        for (profile_name, profile_value) in table {
+            if let Some(arr) = profile_value.get("overrides").and_then(|v| v.as_array()) {
+                for entry in arr {
+                    let filter = entry
+                        .get("filter")
+                        .and_then(|f| f.as_str())
+                        .context("override filter is missing or not a string")?;
+                    let test_group = entry
+                        .get("test-group")
+                        .and_then(|g| g.as_str())
+                        .context("override test-group is missing or not a string")?;
+                    overrides.push(OverrideFilter {
+                        profile: profile_name.clone(),
+                        filter: filter.to_string(),
+                        test_group: test_group.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(overrides)
+}
+
+fn package_in_filter(filter: &str) -> Option<String> {
+    let rest = filter.strip_prefix("package(")?;
+    let end = rest.find(')')?;
+    Some(rest[..end].to_string())
+}
+
+fn list_matching_tests(workspace: &Path, filter: &str) -> Result<usize> {
+    let current_dir = workspace
+        .as_os_str()
+        .to_str()
+        .with_context(|| format!("workspace path is not UTF-8: {}", workspace.display()))?;
+    let summary = NextestList::new()
+        .current_dir(current_dir)
+        .add_arg("--workspace")
+        .add_arg("-E")
+        .add_arg(filter)
+        .exec()
+        .with_context(|| format!("cargo nextest list failed for filter '{filter}'"))?;
+    Ok(summary.test_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn package_in_filter_extracts_simple_package() {
+        assert_eq!(
+            package_in_filter("package(mvm-vmm) and test(/foo/)"),
+            Some("mvm-vmm".to_string())
+        );
+    }
+
+    #[test]
+    fn package_in_filter_returns_none_without_package_clause() {
+        assert_eq!(package_in_filter("test(/foo/)"), None);
+    }
+
+    #[test]
+    fn extract_overrides_reads_profiles_and_overrides() {
+        let config: toml::Value = r#"
+[test-groups]
+serial = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'package(mvm-core) and test(/foo/)'
+test-group = "serial"
+
+[[profile.ci.overrides]]
+filter = 'package(mvm-hostd) and binary(bar)'
+test-group = "serial"
+"#
+        .parse()
+        .unwrap();
+
+        let overrides = extract_overrides(&config).unwrap();
+        assert_eq!(overrides.len(), 2);
+        let by_profile: std::collections::HashMap<_, _> = overrides
+            .iter()
+            .map(|o| (o.profile.as_str(), o.filter.as_str()))
+            .collect();
+        assert_eq!(
+            by_profile.get("default").copied(),
+            Some("package(mvm-core) and test(/foo/)")
+        );
+        assert_eq!(
+            by_profile.get("ci").copied(),
+            Some("package(mvm-hostd) and binary(bar)")
+        );
+        assert!(overrides.iter().all(|o| o.test_group == "serial"));
+    }
+
+    #[test]
+    fn extract_overrides_missing_filter_is_an_error() {
+        let config: toml::Value = r#"
+[[profile.default.overrides]]
+test-group = "serial"
+"#
+        .parse()
+        .unwrap();
+
+        assert!(extract_overrides(&config).is_err());
+    }
+
+    #[test]
+    fn load_workspace_members_finds_this_workspace() {
+        let members =
+            load_workspace_members(Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap())
+                .unwrap();
+        assert!(members.contains("mvm-core"));
+        assert!(members.contains("mvm-vmm"));
+        assert!(members.contains("mvm-hostd"));
+    }
+
+    #[test]
+    fn check_override_fails_for_unknown_package() {
+        let members = ["mvm-core".to_string()].into_iter().collect();
+        let ov = OverrideFilter {
+            profile: "default".to_string(),
+            filter: "package(mvm-vmm) and test(/foo/)".to_string(),
+            test_group: "serial".to_string(),
+        };
+        let failure = check_override(&ov, &members, |_| Ok(1));
+        assert!(failure.is_some());
+        assert!(failure.unwrap().contains("unknown package 'mvm-vmm'"));
+    }
+
+    #[test]
+    fn check_override_fails_when_filter_matches_zero_tests() {
+        let members = ["mvm-core".to_string()].into_iter().collect();
+        let ov = OverrideFilter {
+            profile: "default".to_string(),
+            filter: "package(mvm-core) and test(/foo/)".to_string(),
+            test_group: "serial".to_string(),
+        };
+        let failure = check_override(&ov, &members, |_| Ok(0));
+        assert!(failure.is_some());
+        assert!(failure.unwrap().contains("matches no tests"));
+    }
+
+    #[test]
+    fn check_override_succeeds_when_filter_matches_tests() {
+        let members = ["mvm-core".to_string()].into_iter().collect();
+        let ov = OverrideFilter {
+            profile: "default".to_string(),
+            filter: "package(mvm-core) and test(/foo/)".to_string(),
+            test_group: "serial".to_string(),
+        };
+        assert!(check_override(&ov, &members, |_| Ok(3)).is_none());
+    }
+
+    #[test]
+    fn check_override_fails_when_list_command_errors() {
+        let members = ["mvm-core".to_string()].into_iter().collect();
+        let ov = OverrideFilter {
+            profile: "default".to_string(),
+            filter: "package(mvm-core) and test(/foo/)".to_string(),
+            test_group: "serial".to_string(),
+        };
+        let failure = check_override(&ov, &members, |_| Err(anyhow::anyhow!("boom")));
+        assert!(failure.is_some());
+        assert!(failure.unwrap().contains("failed to list tests"));
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -42,6 +42,7 @@ mod check_l3_expansion_freeze;
 mod check_machine_doc_guards;
 mod check_mutation_witnesses;
 mod check_mvm_host_binaries_sync;
+mod check_nextest_groups;
 mod check_no_display_on_secret_types;
 mod check_no_gateway_names;
 mod check_no_host_nix;
@@ -280,6 +281,10 @@ fn main() -> Result<()> {
                 .map(String::as_str);
             check_mutation_witnesses::run(&workspace, mode, package)
         }
+        Some("check-nextest-groups") => {
+            let workspace = workspace_root();
+            check_nextest_groups::run(&workspace)
+        }
         Some("check-conformance") => {
             let workspace = workspace_root();
             let write = args.iter().any(|a| a == "--write");
@@ -361,7 +366,7 @@ fn main() -> Result<()> {
             ir_parity::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-conformance, check-trust-gradient, check-vsock-only-egress, check-no-gateway-names, check-uniform-vsock-egress, check-l3-expansion-freeze, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-backend-resource-controls, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-single-home, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-vsock-only-egress, check-no-gateway-names, check-uniform-vsock-egress, check-l3-expansion-freeze, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-backend-resource-controls, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {
@@ -471,6 +476,9 @@ fn main() -> Result<()> {
             );
             println!(
                 "  check-mutation-witnesses               Pin the mutation surface derived from the claims ledger; --run mutates it and ratchets survivors; --write-baseline re-pins (add --run to also re-record misses)"
+            );
+            println!(
+                "  check-nextest-groups                   Verify every cargo-nextest test-group override still matches at least one test"
             );
             eprintln!(
                 "  check-conformance                      Verify model/*.toml is the single source and CONFORMANCE.md is up to date"


### PR DESCRIPTION
Closes #2307.

Implements \`xtask check-nextest-groups\` to validate every cargo-nextest override filter in \`.config/nextest.toml\`:

- Parses the nextest config and extracts profile overrides.
- Verifies the package referenced by each filter exists in the workspace.
- Runs \`cargo nextest list --workspace -E <filter> --message-format oneline\` and rejects filters that match zero tests or fail to list.
- Registers the command in xtask dispatch, help text, and the unknown-command error list.
- Adds unit tests for parsing, workspace membership, and the failure paths (unknown package, zero matches, list error, non-zero matches).
- Wires the new check into the Test job of \`ci.yml\` and \`ci-full.yml\` so a stale filter breaks the build before tests run.

Also ticks the #2307 checkbox and updates its status in Plan 300.