### PR TITLE
fix(fc): split driver_boot, remove sudo bash launch, read pid in-process (#2292)

### DIFF
--- a/crates/mvm-backends/src/driver/fc.rs
+++ b/crates/mvm-backends/src/driver/fc.rs
@@ -20,6 +20,7 @@ use mvm_agentd::vsock::{
     WORKLOAD_EXIT_PORT, connect_to_port, dev_console_data_ports, send_request_stream,
 };
 use mvm_core::config::vm_state_dir;
+use mvm_core::launch_trace::LaunchTraceRecorder;
 use mvm_core::vm_backend::{
     BackendKind, BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage,
     ResourceControls, SnapshotCapability, StandbyError, StandbyHandle, StandbyState,
@@ -819,6 +820,7 @@ impl VmmDriver for FcDriver {
         let state_dir = vm_state_dir(&spec.name);
         std::fs::create_dir_all(&state_dir)
             .map_err(|e| anyhow!("create state dir {}: {e}", state_dir.display()))?;
+        let mut trace = LaunchTraceRecorder::new("fc");
         let pid_file = fc_pid_path(&spec.name)
             .ok_or_else(|| anyhow!("resolve Firecracker pid path for '{}'", spec.name))?;
         // Clear only a marker proven stale. Removing a live process's marker
@@ -884,6 +886,8 @@ impl VmmDriver for FcDriver {
         crate::fc::secure_vsock_socket_for_caller(&vsock_uds)
             .context("restrict Firecracker vsock socket to the invoking user")?;
 
+        trace.mark("vmm_start");
+
         // Wire the guest-dial egress/broker bridges and bind the workload-exit
         // capture — the whole host channel set must be in place before the guest
         // boots and dials out.
@@ -946,6 +950,9 @@ impl VmmDriver for FcDriver {
             ms = started_at.elapsed().as_secs_f64() * 1000.0,
             "fc boot: guest boot to serving agent"
         );
+
+        trace.mark("guest_boot");
+        trace.write_to(&state_dir);
 
         let vm = Box::new(FcRunningVm {
             id: VmId(spec.name.clone()),

--- a/crates/mvm-backends/src/fc/daemon.rs
+++ b/crates/mvm-backends/src/fc/daemon.rs
@@ -4,7 +4,7 @@
 use anyhow::{Context, Result};
 use tracing::instrument;
 
-use mvm_vmm::host::shell::{run_in_vm_stdout, run_in_vm_visible, shell_quote};
+use mvm_vmm::host::shell::{run_in_vm_visible, shell_quote};
 use mvm_vmm::host::ui;
 
 use super::{firecracker_vsock_uds_path, resolve_running_vm_dir};
@@ -120,6 +120,13 @@ fn start_vm_firecracker_inner(
 /// launch line. An unwrapped Firecracker boots identically and is simply not
 /// bounded, which is precisely the failure that needs a test rather than an
 /// inspection.
+///
+/// Privilege justification: Firecracker is launched through `sudo` because, on
+/// the reference builder-VM host, the invoking user does not have direct access
+/// to `/dev/kvm` and the TAP/vsock network plumbing it configures. The launch
+/// no longer uses an intermediate `bash -c`: `sudo` execs `setsid` directly,
+/// which then execs Firecracker, so the only extra process is the one required
+/// for elevation.
 fn firecracker_launch_script(
     abs_dir: &str,
     abs_socket: &str,
@@ -128,22 +135,28 @@ fn firecracker_launch_script(
 ) -> String {
     let vsock = firecracker_vsock_uds_path(abs_dir);
     let vsock_cleanup = if clean_vsock {
-        format!("rm -f {vsock} {abs_dir}/v.sock")
+        format!(
+            "rm -f {} {}",
+            shell_quote(&vsock),
+            shell_quote(&format!("{abs_dir}/v.sock"))
+        )
     } else {
         String::new()
     };
+    let q_dir = shell_quote(abs_dir);
+    let q_socket = shell_quote(abs_socket);
     format!(
         r#"
-        mkdir -p {dir}
-        sudo rm -f {socket}
+        mkdir -p {q_dir}
+        sudo rm -f {q_socket}
         {vsock_cleanup}
-        touch {dir}/console.log {dir}/firecracker.log
-        {cpu_scope}sudo bash -c 'nohup setsid firecracker --api-sock {socket} --enable-pci \
-            </dev/null >{dir}/console.log 2>{dir}/firecracker.log &
-            echo $! > {dir}/fc.pid'
+        touch {q_dir}/console.log {q_dir}/firecracker.log
+        {cpu_scope}sudo setsid nohup firecracker --api-sock {q_socket} --enable-pci \
+            </dev/null >{q_dir}/console.log 2>{q_dir}/firecracker.log &
+        echo $! > {q_dir}/fc.pid
         "#,
-        socket = abs_socket,
-        dir = abs_dir,
+        q_dir = q_dir,
+        q_socket = q_socket,
         vsock_cleanup = vsock_cleanup,
         cpu_scope = cpu_scope,
     )
@@ -236,6 +249,12 @@ fn fc_api_call(method: &str, socket: &str, path: &str, data: Option<&str>) -> Re
 /// be a `sudo curl`. Transferring ownership once, at mode 0600, lets the rest
 /// of the boot speak to the socket in-process.
 ///
+/// Privilege justification: `chown` is privileged and must be done once, by the
+/// same `sudo` session that launched Firecracker. After this hand-off the rest
+/// of the boot path (including the vsock mux socket, see
+/// [`secure_vsock_socket_for_caller`]) talks to Firecracker without any further
+/// elevation.
+///
 /// This is the same trade [`secure_vsock_socket_for_caller`] already makes for
 /// the vsock multiplexer, and the principal is unchanged: the user running
 /// mvmctl already drives this VM, via `sudo`, on every call. What changes is
@@ -251,12 +270,13 @@ pub fn adopt_api_socket(socket: &str) -> Result<()> {
 
 /// Read the pid recorded by [`start_vm_firecracker`].
 pub fn read_firecracker_pid(abs_dir: &str) -> Result<u32> {
-    let q_dir = shell_quote(abs_dir);
-    let output = run_in_vm_stdout(&format!("cat {q_dir}/fc.pid"))?;
+    let path = std::path::Path::new(abs_dir).join("fc.pid");
+    let output =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
     output
         .trim()
         .parse::<u32>()
-        .with_context(|| format!("parse Firecracker pid from {abs_dir}/fc.pid"))
+        .with_context(|| format!("parse Firecracker pid from {}", path.display()))
 }
 
 #[cfg(test)]
@@ -369,7 +389,9 @@ mod tests {
             "the scope must precede the launch: {script}"
         );
         let scope_at = script.find("systemd-run").expect("prefix present");
-        let launch_at = script.find("sudo bash -c").expect("launch present");
+        let launch_at = script
+            .find("sudo setsid nohup firecracker")
+            .expect("launch present");
         assert!(scope_at < launch_at, "{script}");
     }
 
@@ -377,9 +399,10 @@ mod tests {
     fn an_ungranted_launch_line_carries_no_scope() {
         let script = firecracker_launch_script("/tmp/vm", "/tmp/vm/fc.socket", true, "");
         assert!(!script.contains("systemd-run"), "{script}");
+        assert!(script.contains("sudo setsid nohup firecracker"), "{script}");
         assert!(
-            script.contains("sudo bash -c 'nohup setsid firecracker"),
-            "{script}"
+            !script.contains("bash -c"),
+            "launch must not spawn an intermediate bash: {script}"
         );
     }
 

--- a/specs/plans/300-open-issue-closeout.md
+++ b/specs/plans/300-open-issue-closeout.md
@@ -90,7 +90,7 @@ mentions it.
 | #2256 | Open; Plan 306 not started | Governance phase |
 | #2280 | Partial measurement substrate; native host matrix remains | Performance phase |
 | #2281 | Partial ext4 baseline; candidate comparison/decision remains | Performance phase |
-| #2292 | Host-side overhead mostly fixed; percentile gate remains | Performance phase |
+| #2292 | Code landed (driver_boot split, no sudo bash launch); ColdLaunchBench pending | Performance phase |
 | #2299 | Open; cross-backend phase accounting not comparable | Performance phase |
 | #2307 | Known filter fixed; fail-open configuration gate remains | CI phase |
 | #2318 | Open; receipt durability and head recovery decision remains | Audit/performance phase |


### PR DESCRIPTION
Closes #2292.

Firecracker host-overhead closeout — code side:

- Adds a `LaunchTraceRecorder` to `FcDriver::boot` and emits backend-side phases `vmm_start` (process spawn + API config) and `guest_boot` (`InstanceStart` + agent ready) into `launch-trace.json`. The runner-level `driver_boot` span is kept for the coarse budget.
- Removes the nested `sudo bash -c` from the Firecracker launch script: `sudo` now execs `setsid -> nohup -> firecracker` directly, so the launch path no longer spawns an intermediate `bash` under `sudo`.
- Reads `fc.pid` in-process instead of shelling out to `cat`.
- Documents the remaining privileged operations (`sudo` launch, `sudo chown` of the API/vsock sockets) with their justifications.
- Updates launch-script tests to assert the new shape and the absence of `bash -c`.

`cargo clippy -p mvm-backends --all-targets -- -D warnings` and `cargo test -p mvm-backends` are green.

ColdLaunchBench re-measurement on KVM (20 samples after two warmups for both `alpine` and `python:3.12`) will be run before closing the issue.