### PR TITLE
docs(AGENTS): allow wasm backend to run on macOS host

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,18 @@ All Nix builds/evals, Firecracker operations, `mvmctl` runtime commands (anythin
 > other `mvmctl` runtime commands remain subject to the builder-VM rule. Do
 > not use Lima for this HVF exception.
 
+> **Exception (2026-08-13, owner-approved):** `mvmctl machine run --hypervisor wasm`
+> (or any other `mvmctl` invocation explicitly targeting the `wasm` backend) may run
+> on the macOS host. The wasm backend runs a `wasm32-wasip1` module under host
+> `wasmtime`; it does not boot a Linux microVM, needs no KVM, and does not touch
+> Firecracker / jailer / seccomp / network-namespace tooling. All other `mvmctl`
+> runtime commands remain subject to the builder-VM rule.
+
 **Run cargo on the macOS host wherever it compiles cleanly.** `cargo test`, `cargo check`, and `cargo build` should default to the host so worktrees don't deadlock on shared builder state (cargo target-dir contention, registry locks, and `.git/index` cross-mount races are real and have caused us to lose work). Tests that genuinely need Linux — vsock, jailer/seccomp, dm-verity, network namespaces, anything that pokes at `/dev/kvm` or `/proc/net` — should be gated with `#[cfg(target_os = "linux")]` and only those sub-targets are run inside the builder VM. Workspace-wide `cargo clippy --workspace --all-targets -- -D warnings` is still expected to pass in the Linux builder environment before merge, since clippy needs to see the Linux-gated code paths.
 
 **git only runs from the main `mvm/` checkout, never from inside a worktree directory and never from inside the builder VM.** The main checkout is the single git operator for the whole repo. To act on a worktree's branch, use `git -C /path/to/.worktrees/mvm-<slug> <cmd>` from the main checkout — that drives the worktree's index/HEAD/refs while keeping the running git process anchored at the main checkout. Reasons: (1) only one git process at a time touches `.git/objects`, `.git/packed-refs`, and the shared `.git/hooks/` invocation context, eliminating the cross-worktree contention that has caused us to lose work; (2) VM/shared-filesystem lock semantics can deadlock against host-side git. Cargo/nix/firecracker/mvmctl commands still run from each worktree's own directory — only `git` is centralized.
 
-**Important:** `mvmctl` (via `cargo run`) commands like `build`, `up`, `down`, `logs`, and `ls` must be run inside the builder VM — they talk to Linux-only microVM tooling. `cargo test` / `cargo check` / `cargo build` should run on the macOS host by default (see "Run cargo on the macOS host" above); only `cargo clippy --workspace --all-targets`, Nix eval/build checks, and tests gated on `target_os = "linux"` need the builder VM.
+**Important:** `mvmctl` (via `cargo run`) commands like `build`, `up`, `down`, `logs`, and `ls` must be run inside the builder VM — they talk to Linux-only microVM tooling. The exception is an explicit `--hypervisor wasm` target, which may run on the macOS host. `cargo test` / `cargo check` / `cargo build` should run on the macOS host by default (see "Run cargo on the macOS host" above); only `cargo clippy --workspace --all-targets`, Nix eval/build checks, and tests gated on `target_os = "linux"` need the builder VM.
 
 ## Worktree Workflow for Features
 


### PR DESCRIPTION
Documents the owner-approved exception for `mvmctl machine run --hypervisor wasm` and related wasm-backend invocations to run on the macOS host, since they execute a `wasm32-wasip1` module under host `wasmtime` and do not boot a Linux microVM or touch KVM/Firecracker/jailer/seccomp/network-namespace tooling.