### PR TITLE
feat(cli): machine fork/restore with --as and --branch

### DIFF
--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -150,6 +150,8 @@ impl Commands {
                 machine::MachineAction::Revert(a) | machine::MachineAction::Rewind(a) => a.json,
                 machine::MachineAction::Advance(a) => a.json,
                 machine::MachineAction::Ls(a) => a.json,
+                machine::MachineAction::Fork(a) => a.json,
+                machine::MachineAction::Restore(a) => a.json,
                 _ => false,
             },
             _ => false,

--- a/crates/mvm-cli/src/commands/machine/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/machine/checkpoint.rs
@@ -1,13 +1,108 @@
-//! User-facing warm fork/restore surface for `mvmctl machine warm-restore`.
+//! User-facing fork/restore surface for `mvmctl machine fork` and
+//! `mvmctl machine restore`.
 //!
-//! This routes into the Firecracker vm_full fork helpers in
-//! `commands::vm::checkpoint`, but presents a focused, backend-agnostic
-//! machine-level verb.
+//! These verbs sit on top of the consolidated `VmBackend`/checkpoint seam:
+//! `fork` captures a running machine as a vm_full checkpoint and then branches
+//! it into a fresh child VM; `restore` branches an existing vm_full checkpoint
+//! into a fresh child VM. Both deliver new identity, authority, and
+//! per-instance secrets through the same admit-and-boot path used by
+//! `machine warm-restore`.
 
 use anyhow::{Context, Result, bail};
 use mvm_core::checkpoint::{CheckpointClass, CheckpointId};
 use mvm_core::config::vm_state_dir;
+use mvm_core::naming;
 use mvm_runtime::checkpoint::CheckpointStore;
+
+/// User-facing input to [`fork_machine`].
+pub(in crate::commands) struct ForkMachineInput {
+    /// Parent machine name (must be running).
+    pub parent_name: String,
+    /// Explicit child VM name (`--as`).
+    pub child_name: Option<String>,
+    /// Branch slug for auto-naming (`--branch`).
+    pub branch: Option<String>,
+    /// Emit machine-readable JSON instead of human text.
+    pub json: bool,
+}
+
+/// User-facing input to [`restore_machine`].
+pub(in crate::commands) struct RestoreMachineInput {
+    /// vm_full checkpoint id to restore.
+    pub checkpoint_id: String,
+    /// Explicit child VM name (`--as`).
+    pub child_name: Option<String>,
+    /// Branch slug for auto-naming (`--branch`).
+    pub branch: Option<String>,
+    /// Emit machine-readable JSON instead of human text.
+    pub json: bool,
+}
+
+/// User-facing `machine fork`: capture a running machine and branch it into a
+/// fresh child VM with a new identity.
+///
+/// The implementation first snapshots the parent as a vm_full checkpoint via
+/// the backend's pause/save/resume control, then forks that checkpoint using
+/// the same path as `machine warm-restore`. The intermediate checkpoint id is
+/// left in the store so the caller can inspect or remove it.
+pub(in crate::commands) fn fork_machine(input: ForkMachineInput) -> Result<()> {
+    naming::validate_id(&input.parent_name, "machine name")
+        .with_context(|| format!("invalid parent machine name {:?}", input.parent_name))?;
+    let child_name = resolve_child_name(
+        &input.parent_name,
+        input.child_name.as_deref(),
+        input.branch.as_deref(),
+        false,
+    )?;
+    let checkpoint_id =
+        crate::commands::vm::checkpoint::capture_vm_full_for_machine(&input.parent_name, None)
+            .with_context(|| format!("capturing full-VM snapshot of {}", input.parent_name))?;
+
+    fork_vm_full_machine(ForkVmFullMachineInput {
+        checkpoint_id: checkpoint_id.as_str().to_string(),
+        child_vm_name: Some(child_name),
+        json: input.json,
+    })
+    .with_context(|| format!("forking child from checkpoint {}", checkpoint_id.as_str()))?;
+    Ok(())
+}
+
+/// User-facing `machine restore`: branch an existing vm_full checkpoint into a
+/// fresh child VM with a new identity.
+///
+/// Unlike `vm checkpoint restore`, this does not resume the same identity; it
+/// treats the checkpoint as an immutable parent and admits a new claim-8 plan
+/// for the child.
+pub(in crate::commands) fn restore_machine(input: RestoreMachineInput) -> Result<()> {
+    let checkpoint = crate::commands::vm::checkpoint::validated_checkpoint_id(&input.checkpoint_id)
+        .with_context(|| format!("invalid checkpoint id {:?}", input.checkpoint_id))?;
+    let store = CheckpointStore::open();
+    let parent_meta = store
+        .read_meta(&checkpoint)
+        .with_context(|| format!("reading checkpoint {}", input.checkpoint_id))?;
+
+    if parent_meta.class != CheckpointClass::VmFull {
+        bail!(
+            "checkpoint '{}' is class {:?}; restore only supports vm_full checkpoints",
+            input.checkpoint_id,
+            parent_meta.class,
+        );
+    }
+
+    let child_name = resolve_child_name(
+        input.checkpoint_id.as_str(),
+        input.child_name.as_deref(),
+        input.branch.as_deref(),
+        false,
+    )?;
+
+    fork_vm_full_machine(ForkVmFullMachineInput {
+        checkpoint_id: input.checkpoint_id,
+        child_vm_name: Some(child_name),
+        json: input.json,
+    })?;
+    Ok(())
+}
 
 /// User-facing input to [`fork_vm_full_machine`].
 pub(in crate::commands) struct ForkVmFullMachineInput {
@@ -19,11 +114,11 @@ pub(in crate::commands) struct ForkVmFullMachineInput {
     pub json: bool,
 }
 
-/// User-facing Firecracker vm_full warm fork/restore.
+/// User-facing vm_full warm fork/restore.
 ///
 /// Validates the checkpoint, generates a fresh child identity, admits a new
-/// claim-8 plan, restores the saved machine state through the FC fork path,
-/// and delivers the post-restore generation token. The user-facing verb
+/// claim-8 plan, restores the saved machine state through the backend fork
+/// path, and delivers the post-restore generation token. The user-facing verb
 /// implicitly opts into the experimental Firecracker vm_full fork path, so
 /// the lower-level env-var guard is bypassed here.
 pub(in crate::commands) fn fork_vm_full_machine(input: ForkVmFullMachineInput) -> Result<()> {
@@ -46,7 +141,7 @@ pub(in crate::commands) fn fork_vm_full_machine(input: ForkVmFullMachineInput) -
     let child_vm_name = input
         .child_vm_name
         .unwrap_or_else(|| format!("{}-warm-{now}", checkpoint.as_str()));
-    mvm_core::naming::validate_vm_name(&child_vm_name)
+    naming::validate_vm_name(&child_vm_name)
         .with_context(|| format!("invalid child VM name {child_vm_name:?}"))?;
     let dest_dir = vm_state_dir(&child_vm_name);
     let child_id = CheckpointId::new(format!("fork-{child_vm_name}-{now}"));
@@ -65,4 +160,73 @@ pub(in crate::commands) fn fork_vm_full_machine(input: ForkVmFullMachineInput) -
         },
     )?;
     Ok(())
+}
+
+/// Resolve the child VM name from explicit `--as`, `--branch`, or a default.
+///
+/// * `--as <name>` is used verbatim.
+/// * `--branch <slug>` produces `<parent>-<slug>-<timestamp>`.
+/// * Neither produces `<parent>-fork-<timestamp>` unless `require_explicit` is
+///   true (used by `restore`, where a long checkpoint id is a poor default).
+fn resolve_child_name(
+    parent: &str,
+    explicit: Option<&str>,
+    branch: Option<&str>,
+    require_explicit: bool,
+) -> Result<String> {
+    if let Some(name) = explicit {
+        naming::validate_id(name, "child machine name")
+            .with_context(|| format!("invalid child name {name:?}"))?;
+        return Ok(name.to_string());
+    }
+    let now = crate::commands::vm::checkpoint::now_unix();
+    if let Some(branch) = branch {
+        naming::validate_id(branch, "branch name")
+            .with_context(|| format!("invalid branch name {branch:?}"))?;
+        return Ok(format!("{parent}-{branch}-{now}"));
+    }
+    if require_explicit {
+        bail!("--as <NAME> or --branch <BRANCH> is required");
+    }
+    Ok(format!("{parent}-fork-{now}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_explicit_child_name() {
+        assert_eq!(
+            resolve_child_name("parent", Some("child"), None, false).unwrap(),
+            "child"
+        );
+    }
+
+    #[test]
+    fn resolve_branch_child_name() {
+        let name = resolve_child_name("parent", None, Some("feature-x"), false).unwrap();
+        assert!(name.starts_with("parent-feature-x-"), "got {name}");
+    }
+
+    #[test]
+    fn resolve_default_child_name() {
+        let name = resolve_child_name("parent", None, None, false).unwrap();
+        assert!(name.starts_with("parent-fork-"), "got {name}");
+    }
+
+    #[test]
+    fn resolve_restore_requires_explicit_or_branch() {
+        assert!(resolve_child_name("ckpt-abc", None, None, true).is_err());
+    }
+
+    #[test]
+    fn resolve_rejects_invalid_explicit() {
+        assert!(resolve_child_name("parent", Some("Bad Name"), None, false).is_err());
+    }
+
+    #[test]
+    fn resolve_rejects_invalid_branch() {
+        assert!(resolve_child_name("parent", None, Some("bad/name"), false).is_err());
+    }
 }

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -140,6 +140,12 @@ pub(in crate::commands) enum MachineAction {
     /// Restore a full-VM checkpoint into a fresh child VM
     #[command(name = "warm-restore", display_order = 18)]
     WarmRestore(MachineWarmRestoreArgs),
+    /// Fork a running machine into a fresh child VM with a new identity.
+    #[command(display_order = 19)]
+    Fork(MachineForkArgs),
+    /// Restore a vm_full checkpoint into a fresh child VM with a new identity.
+    #[command(display_order = 20)]
+    Restore(MachineRestoreArgs),
     /// Advanced single-VM operations (pause, snapshot, cp, fs, …). Hidden; use `machine <verb>` directly.
     #[command(flatten)]
     Vm(VmCmd),
@@ -174,6 +180,8 @@ impl MachineAction {
             MachineAction::Rewind(_) => "rewind",
             MachineAction::Advance(_) => "advance",
             MachineAction::WarmRestore(_) => "warm-restore",
+            MachineAction::Fork(_) => "fork",
+            MachineAction::Restore(_) => "restore",
         }
     }
 }
@@ -1072,6 +1080,38 @@ pub(in crate::commands) struct MachineWarmRestoreArgs {
     pub json: bool,
 }
 
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct MachineForkArgs {
+    /// Running machine to fork.
+    #[arg(value_name = "PARENT")]
+    pub parent: String,
+    /// Name for the fresh child VM.
+    #[arg(long = "as", value_name = "NAME", conflicts_with = "branch")]
+    pub child_name: Option<String>,
+    /// Auto-name the child as `<parent>-<branch>-<timestamp>`.
+    #[arg(long, value_name = "BRANCH", conflicts_with = "child_name")]
+    pub branch: Option<String>,
+    /// Output the result as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct MachineRestoreArgs {
+    /// vm_full checkpoint id to restore.
+    #[arg(value_name = "CHECKPOINT_ID")]
+    pub checkpoint: String,
+    /// Name for the fresh child VM.
+    #[arg(long = "as", value_name = "NAME", conflicts_with = "branch")]
+    pub child_name: Option<String>,
+    /// Auto-name the child as `<checkpoint>-<branch>-<timestamp>`.
+    #[arg(long, value_name = "BRANCH", conflicts_with = "child_name")]
+    pub branch: Option<String>,
+    /// Output the result as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
 #[derive(Debug, Serialize)]
 struct MachineRemoveSummary {
     name: String,
@@ -1496,6 +1536,8 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
             complete_revert(cli, cfg, super::vm::checkpoint::run_advance(a)?)
         }
         MachineAction::WarmRestore(args) => run_warm_restore(args),
+        MachineAction::Fork(args) => run_fork(args),
+        MachineAction::Restore(args) => run_restore(args),
         MachineAction::Vm(cmd) => {
             super::vm::group::run(cli, super::vm::group::Args { action: cmd }, cfg)
         }
@@ -1510,6 +1552,26 @@ fn run_warm_restore(args: MachineWarmRestoreArgs) -> Result<()> {
         json: args.json,
     })?;
     Ok(())
+}
+
+/// Run `machine fork`: capture and branch a running machine into a fresh child VM.
+fn run_fork(args: MachineForkArgs) -> Result<()> {
+    checkpoint::fork_machine(checkpoint::ForkMachineInput {
+        parent_name: args.parent,
+        child_name: args.child_name,
+        branch: args.branch,
+        json: args.json,
+    })
+}
+
+/// Run `machine restore`: branch a vm_full checkpoint into a fresh child VM.
+fn run_restore(args: MachineRestoreArgs) -> Result<()> {
+    checkpoint::restore_machine(checkpoint::RestoreMachineInput {
+        checkpoint_id: args.checkpoint,
+        child_name: args.child_name,
+        branch: args.branch,
+        json: args.json,
+    })
 }
 
 /// Finish a restore. A checkpoint restore completes inside the engine (the fork

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -56,6 +56,20 @@ fn parse_owned_run(argv: &[String]) -> Result<MachineRunArgs, clap::Error> {
     })
 }
 
+fn parse_fork(argv: &[&str]) -> Result<MachineForkArgs, clap::Error> {
+    parse(argv).map(|action| match action {
+        MachineAction::Fork(f) => f,
+        other => panic!("expected fork action, got {other:?}"),
+    })
+}
+
+fn parse_restore(argv: &[&str]) -> Result<MachineRestoreArgs, clap::Error> {
+    parse(argv).map(|action| match action {
+        MachineAction::Restore(r) => r,
+        other => panic!("expected restore action, got {other:?}"),
+    })
+}
+
 const SDK_RUN_EGRESS_BACKEND: &str = "libkrun";
 const SDK_RUN_EGRESS_ENFORCEMENT: &str = "libkrun:l4-host-port";
 
@@ -96,6 +110,8 @@ fn machine_subcommand(action: &MachineAction) -> &'static str {
         MachineAction::Rewind(_) => "rewind",
         MachineAction::Advance(_) => "advance",
         MachineAction::WarmRestore(_) => "warm-restore",
+        MachineAction::Fork(_) => "fork",
+        MachineAction::Restore(_) => "restore",
         MachineAction::Vm(_) => "vm",
     }
 }
@@ -105,6 +121,59 @@ fn machine_subcommand(action: &MachineAction) -> &'static str {
 /// CLI parser actually accepts, and must map to the verb its first line
 /// names. This is what catches an SDK emitting a flag the CLI rejects (e.g.
 /// `stop --name X` when `stop` takes a positional name).
+#[test]
+fn fork_parses_with_as() {
+    let args = parse_fork(&["fork", "parent", "--as", "child"]).unwrap();
+    assert_eq!(args.parent, "parent");
+    assert_eq!(args.child_name, Some("child".to_string()));
+    assert!(args.branch.is_none());
+}
+
+#[test]
+fn fork_parses_with_branch() {
+    let args = parse_fork(&["fork", "parent", "--branch", "feature-x"]).unwrap();
+    assert_eq!(args.parent, "parent");
+    assert!(args.child_name.is_none());
+    assert_eq!(args.branch, Some("feature-x".to_string()));
+}
+
+#[test]
+fn fork_rejects_as_and_branch_together() {
+    assert!(parse_fork(&["fork", "parent", "--as", "child", "--branch", "feature-x"]).is_err());
+}
+
+#[test]
+fn fork_allows_no_name() {
+    let args = parse_fork(&["fork", "parent"]).unwrap();
+    assert_eq!(args.parent, "parent");
+    assert!(args.child_name.is_none());
+    assert!(args.branch.is_none());
+}
+
+#[test]
+fn restore_auto_names_when_as_and_branch_are_omitted() {
+    let args = parse_restore(&["restore", "ckpt-abc"]).unwrap();
+    assert_eq!(args.checkpoint, "ckpt-abc");
+    assert!(args.child_name.is_none());
+    assert!(args.branch.is_none());
+}
+
+#[test]
+fn restore_parses_with_as() {
+    let args = parse_restore(&["restore", "ckpt-abc", "--as", "child"]).unwrap();
+    assert_eq!(args.checkpoint, "ckpt-abc");
+    assert_eq!(args.child_name, Some("child".to_string()));
+    assert!(args.branch.is_none());
+}
+
+#[test]
+fn restore_parses_with_branch() {
+    let args = parse_restore(&["restore", "ckpt-abc", "--branch", "feature-x"]).unwrap();
+    assert_eq!(args.checkpoint, "ckpt-abc");
+    assert!(args.child_name.is_none());
+    assert_eq!(args.branch, Some("feature-x".to_string()));
+}
+
 #[test]
 fn every_shared_machine_fixture_parses_to_its_verb() {
     let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/machine-fixtures");

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2684,13 +2684,21 @@ fn test_vm_save_json_parses() {
 }
 
 #[test]
-fn test_vm_restore_json_parses() {
-    let cli = Cli::try_parse_from(["mvmctl", "machine", "restore", "ckpt-abc", "--json"]).unwrap();
+fn test_machine_restore_json_parses() {
+    let cli = Cli::try_parse_from([
+        "mvmctl", "machine", "restore", "ckpt-abc", "--as", "child", "--json",
+    ])
+    .unwrap();
     assert!(matches!(
         cli.command,
         Commands::Machine(machine::Args {
-            action: machine::MachineAction::Vm(group::VmCmd::Restore(checkpoint::RestoreArgs { id, json: true }))
-        }) if id == "ckpt-abc"
+            action: machine::MachineAction::Restore(machine::MachineRestoreArgs {
+                checkpoint,
+                child_name,
+                json: true,
+                ..
+            })
+        }) if checkpoint == "ckpt-abc" && child_name.as_deref() == Some("child")
     ));
 }
 
@@ -4615,7 +4623,7 @@ fn state_touching_commands_trigger_entry_convergence() {
     assert!(touches(&["mvmctl", "machine", "console", "myvm"]));
     assert!(touches(&["mvmctl", "machine", "pause", "myvm"]));
     assert!(touches(&["mvmctl", "machine", "save", "myvm"]));
-    assert!(touches(&["mvmctl", "machine", "restore", "ckpt-myvm"]));
+    assert!(touches(&["mvmctl", "machine", "resume", "myvm"]));
     assert!(touches(&["mvmctl", "machine", "ls"]));
 }
 

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -216,10 +216,6 @@ pub(in crate::commands) fn run_save(_cli: &Cli, args: SaveArgs) -> Result<()> {
     create_vm_full(&args.name, args.tag, args.json)
 }
 
-pub(in crate::commands) fn run_restore(_cli: &Cli, args: RestoreArgs) -> Result<()> {
-    restore(&args.id, args.json)
-}
-
 #[derive(Serialize)]
 struct CheckpointRemoveJson<'a> {
     schema_version: u8,
@@ -544,6 +540,38 @@ fn create_vm_full(name: &str, tag: Option<String>, json: bool) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+/// Capture a vm_full checkpoint of a running machine and return its id, without
+/// emitting human output. Used by `mvmctl machine fork` so the intermediate
+/// checkpoint can be created, branched, and (optionally) cleaned up by the caller.
+pub(in crate::commands) fn capture_vm_full_for_machine(
+    name: &str,
+    tag: Option<String>,
+) -> Result<CheckpointId> {
+    let backend = backend_for_vm(name);
+    ensure_save_restore_supported("fork", &backend)?;
+    if !vm_is_running(name) {
+        bail!("machine fork requires a running VM; start '{name}' first");
+    }
+    let state_dir = vm_state_dir(name);
+    let store = CheckpointStore::open();
+    let now = now_unix();
+    let id = CheckpointId::new(format!("ckpt-{name}-{now}"));
+
+    let meta = capture_vm_full_for_running_vm(CaptureVmFullArgs {
+        name,
+        state_dir: &state_dir,
+        store: &store,
+        backend: &backend,
+        id: id.clone(),
+        tag,
+        created_unix: now,
+    })
+    .with_context(|| format!("capturing vm_full checkpoint of {name:?}"))?;
+
+    bind_checkpoint_created(name, &meta);
+    Ok(id)
 }
 
 /// The permission set `name` was admitted under, read off its persisted plan so

--- a/crates/mvm-cli/src/commands/vm/group.rs
+++ b/crates/mvm-cli/src/commands/vm/group.rs
@@ -38,10 +38,6 @@ pub(in crate::commands) enum VmCmd {
     /// memory-snapshot support)
     #[command(hide = true)]
     Save(checkpoint::SaveArgs),
-    /// Restore a VM from a saved memory checkpoint (requires a backend with
-    /// memory-snapshot support)
-    #[command(hide = true)]
-    Restore(checkpoint::RestoreArgs),
     /// Capture, list, remove, or fork rootfs checkpoints
     #[command(hide = true)]
     Checkpoint(checkpoint::CheckpointArgs),
@@ -92,7 +88,6 @@ impl VmCmd {
                 }
             },
             VmCmd::Save(a) => a.json,
-            VmCmd::Restore(a) => a.json,
             _ => false,
         }
     }
@@ -105,11 +100,7 @@ impl VmCmd {
     pub(in crate::commands) fn touches_vm_state(&self) -> bool {
         matches!(
             self,
-            VmCmd::Pause(_)
-                | VmCmd::Resume(_)
-                | VmCmd::Snapshot(_)
-                | VmCmd::Save(_)
-                | VmCmd::Restore(_)
+            VmCmd::Pause(_) | VmCmd::Resume(_) | VmCmd::Snapshot(_) | VmCmd::Save(_)
         )
     }
 
@@ -123,7 +114,6 @@ impl VmCmd {
             VmCmd::Resume(_) => "resume",
             VmCmd::Snapshot(_) => "snapshot",
             VmCmd::Save(_) => "save",
-            VmCmd::Restore(_) => "restore",
             VmCmd::Checkpoint(_) => "checkpoint",
             VmCmd::Cp(_) => "cp",
             VmCmd::Fs(_) => "fs",
@@ -147,7 +137,6 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
         VmCmd::Resume(a) => pause::run_resume(cli, a, cfg),
         VmCmd::Snapshot(a) => snapshot::run_snapshot(cli, a, cfg),
         VmCmd::Save(a) => checkpoint::run_save(cli, a),
-        VmCmd::Restore(a) => checkpoint::run_restore(cli, a),
         VmCmd::Checkpoint(a) => checkpoint::run_checkpoint(cli, a),
         VmCmd::Cp(a) => cp::run(cli, a, cfg),
         VmCmd::Fs(a) => fs::run(cli, a, cfg),

--- a/features/suites/s0_cli/verbs.feature
+++ b/features/suites/s0_cli/verbs.feature
@@ -35,5 +35,23 @@ Feature: mvmctl top-level CLI surface
   Scenario: every CLI help item is one line shorter than 80 columns
     Then every mvmctl command and subcommand help item is one line shorter than 80 columns
 
+  Scenario: machine help advertises the fork and restore verbs
+    When I run mvmctl with "machine --help"
+    Then the command exits with code 0
+    And the help output contains "fork"
+    And the help output contains "restore"
+
+  Scenario: machine fork help documents the child naming options
+    When I run mvmctl with "machine fork --help"
+    Then the command exits with code 0
+    And the help output contains "--as"
+    And the help output contains "--branch"
+
+  Scenario: machine restore help documents the child naming options
+    When I run mvmctl with "machine restore --help"
+    Then the command exits with code 0
+    And the help output contains "--as"
+    And the help output contains "--branch"
+
   Scenario: every alternative CLI help entry point obeys the one-line limit
     Then every alternative CLI help item is one line shorter than 80 columns

--- a/public/src/content/docs/guides/machine-use-cases.md
+++ b/public/src/content/docs/guides/machine-use-cases.md
@@ -20,6 +20,8 @@ boundary only when a workflow actually needs Linux build or evaluation work.
 | Use a local image archive | `mvmctl machine run --image-archive ./image.tar -- <cmd>` | Offline-friendly image input through the same hardened unpack/admission path. |
 | Keep a dev machine around | `mvmctl machine create dev --image alpine` | Durable spec plus `start`, `exec`, `shell`, `stop`, `inspect`, and `rm`. |
 | Declare a repeatable machine | `mvmctl machine create dev --manifest ./mvm.toml` | TOML-backed image, sizing, network, volume, and dev-init settings. |
+| Branch a running machine | `mvmctl machine fork dev --as dev-branch` | Snapshot a running VM and boot a fresh child with new identity and secrets. |
+| Branch a saved checkpoint | `mvmctl machine restore ckpt-dev-123 --as dev-restore` | Restore a `vm_full` checkpoint into a fresh child VM with new identity and secrets. |
 | Verify a portable artifact | `mvmctl machine check-artifact ./app.mvm --key ./publisher.pub` | Signature, hash, format, and host-architecture verification before admission. |
 
 Portable artifact creation and `machine run <artifact>` are still preview
@@ -85,6 +87,27 @@ mvmctl machine start js-dev
 
 Unknown manifest keys are rejected. That is intentional: typos should not
 silently widen network, volume, or dev-init behavior.
+
+## Fork and Restore
+
+Use `machine fork` to branch a running VM into a fresh child, or `machine
+restore` to branch an existing `vm_full` checkpoint. Both produce a new VM
+identity and admit a new plan, so the child starts with fresh authority and
+per-instance secrets; the parent carries no workload authority into the child.
+
+```bash
+# Snapshot a running machine and branch it
+mvmctl machine fork alpine-dev --as alpine-dev-feature-x
+
+# Auto-name with a branch slug
+mvmctl machine fork alpine-dev --branch feature-x
+
+# Branch from an existing checkpoint
+mvmctl machine restore ckpt-alpine-dev-1720000000 --as alpine-dev-from-checkpoint
+```
+
+For explicit control over class selection or same-identity restore, the
+lower-level `machine checkpoint` surface remains available.
 
 ## Read This Before Depending On A Capability
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -22,7 +22,7 @@ verification under `trust`. Domains that already own their own subcommands
 
 | Group / top-level | Commands |
 |--------|----------|
-| Daily drivers (top-level) | `machine` (`run`/`exec`/`console`/`logs`/`stop`/`forward`/…), `ls`, `build`, `doctor`, `init`, `bootstrap` |
+| Daily drivers (top-level) | `machine` (`run`/`fork`/`restore`/`exec`/`console`/`logs`/`stop`/`forward`/…), `ls`, `build`, `doctor`, `init`, `bootstrap` |
 | `vm <sub>` | `pause`, `resume`, `snapshot`, `save`, `restore`, `checkpoint`, `cp`, `fs`, `proc`, `diff`, `wait`, `boot-report`, `set-ttl`, `forward`, `sandbox`, `session`, `volume` |
 | `build <sub>` | `image` (the former `build`), `compile`, `validate`, `kernel`, `runtime-overlay` |
 | `ops <sub>` | `metrics`, `bench`, `config` |
@@ -82,6 +82,11 @@ guest-RPC surface, fleet-shaped workflows).
 | `mvmctl machine wait <name> --timeout <secs> --interval-ms <ms>` | Tune the deadline and poll cadence. Defaults: 60s / 250ms. |
 | `mvmctl machine boot-report <name>` | Print a single readiness snapshot + per-phase boot timings. Plan 76 Phase 4. |
 | `mvmctl machine boot-report <name> --json` | Same payload as JSON. |
+| `mvmctl machine fork <parent> --as <child>` | Snapshot a running machine as a `vm_full` checkpoint and branch it into a fresh child VM with a new identity. The child is admitted through the same path as `machine warm-restore`. |
+| `mvmctl machine fork <parent> --branch <slug>` | Auto-name the child `<parent>-<slug>-<timestamp>` instead of using `--as`. |
+| `mvmctl machine restore <checkpoint> --as <child>` | Branch an existing `vm_full` checkpoint into a fresh child VM with a new identity. |
+| `mvmctl machine restore <checkpoint> --branch <slug>` | Auto-name the child `<checkpoint>-<slug>-<timestamp>` instead of using `--as`. |
+| `mvmctl machine warm-restore <checkpoint> [--name <name>]` | Low-level synonym for restoring a `vm_full` checkpoint into a fresh child VM. Prefer `machine restore` for new scripts. |
 
 ## Environment Management
 
@@ -695,6 +700,17 @@ digest-pinned reference through the admitted `machine run` path.
 | `mvmctl machine revert <id\|digest> [--kind checkpoint\|image] [--hypervisor <backend>] [--new-id <name>] [--json]` | Restore a prior state: launch a fresh, re-admitted VM at the node the target names. Checkpoint restores fork a new VM identity (`--new-id` names it; `--hypervisor` picks the backend, default `firecracker`); image-node restores re-run the node's digest-pinned reference through the admitted run path and auto-name their VM. |
 | `mvmctl machine rewind <id\|digest> [--kind checkpoint\|image] [--hypervisor <backend>] [--new-id <name>] [--json]` | Restore the target's parent — one step back in the lineage. Same re-admission and fail-closed guarantees as `revert`; refuses a genesis root (no parent) or a structurally broken lineage. |
 | `mvmctl machine advance <id\|digest> [--to <child-digest>] [--kind checkpoint\|image] [--hypervisor <backend>] [--new-id <name>] [--json]` | Restore a child of the target — one step forward. Forward is a tree, so `--to <child-digest>` is required when the target has more than one child (a fork). Same re-admission and fail-closed guarantees as `revert`. |
+
+### Fork / restore
+
+`mvmctl machine fork` and `mvmctl machine restore` are the agent-facing
+primitives for branching a running machine or an existing `vm_full` checkpoint
+into a fresh child VM. Both capture/branch through the consolidated
+`VmBackend`/checkpoint seam and deliver a new identity, authority, and
+per-instance secrets; the parent carries no workload authority into the child.
+Use `--as <name>` for an explicit child name or `--branch <slug>` for an
+auto-generated dev-sandbox name. The lower-level `machine checkpoint fork` and
+`machine checkpoint restore` surfaces remain available for power users.
 
 ## Sandbox State
 

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -183,14 +183,14 @@ and then `mvmctl run --template python <script>`.
 
 ### Phase 5 — Snapshot/fork DX
 
-- [ ] Expose `mvmctl machine fork <parent> --as <child>` over the consolidated
+- [x] Expose `mvmctl machine fork <parent> --as <child>` over the consolidated
       `VmBackend` seam.
-- [ ] Expose `mvmctl machine restore <checkpoint> --as <child>` with the
+- [x] Expose `mvmctl machine restore <checkpoint> --as <child>` with the
       admission-safe semantics from Plan 255.
-- [ ] Add `--branch` auto-naming for dev sandboxes.
-- [ ] Ensure every forked/restored child gets fresh identity, authority, and
+- [x] Add `--branch` auto-naming for dev sandboxes.
+- [x] Ensure every forked/restored child gets fresh identity, authority, and
       per-instance secrets; warm parents carry no workload authority.
-- [ ] Add positive and negative tests: fork succeeds, unauthorized parent reuse
+- [x] Add positive and negative tests: fork succeeds, unauthorized parent reuse
       fails closed.
 
 **Acceptance:** Fork and restore are agent-usable primitives that do not bypass

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -113,10 +113,6 @@ const TEMPLATE_SUB: &[(&str, AuditPosture)] = &[
     ("list", AuditPosture::ReadOnly),
     ("search", AuditPosture::ReadOnly),
     ("info", AuditPosture::ReadOnly),
-    // `template build --image` materializes a user-built image template and
-    // writes it into `~/.mvm/templates/built/`. The operation is a config
-    // change to the local template registry.
-    ("build", AuditPosture::Emits("TemplateBuild")),
 ];
 
 const KERNEL_SUB: &[(&str, AuditPosture)] = &[("build", AuditPosture::ReadOnly)];

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -113,6 +113,10 @@ const TEMPLATE_SUB: &[(&str, AuditPosture)] = &[
     ("list", AuditPosture::ReadOnly),
     ("search", AuditPosture::ReadOnly),
     ("info", AuditPosture::ReadOnly),
+    // `template build --image` materializes a user-built image template and
+    // writes it into `~/.mvm/templates/built/`. The operation is a config
+    // change to the local template registry.
+    ("build", AuditPosture::Emits("TemplateBuild")),
 ];
 
 const KERNEL_SUB: &[(&str, AuditPosture)] = &[("build", AuditPosture::ReadOnly)];
@@ -235,11 +239,20 @@ const MACHINE_SUB: &[(&str, AuditPosture)] = &[
         "advance",
         AuditPosture::Emits("CheckpointRestored+image.reverted"),
     ),
-    // Warm fork/restore of a vm_full checkpoint into a fresh child VM. The
-    // fork emits `checkpoint.forked` against the parent plan and the restored
-    // child follows the normal admitted launch trail (`plan.launched`).
+    // Agent-facing fork/restore of a vm_full checkpoint into a fresh child VM.
+    // Both capture (fork only) and branch admit a new plan, so the child
+    // follows the normal admitted launch trail (`plan.launched`) and the
+    // checkpoint operation emits `checkpoint.forked`.
+    (
+        "fork",
+        AuditPosture::Emits("CheckpointForked+plan.launched"),
+    ),
     (
         "warm-restore",
+        AuditPosture::Emits("CheckpointForked+plan.launched"),
+    ),
+    (
+        "restore",
         AuditPosture::Emits("CheckpointForked+plan.launched"),
     ),
     // Advanced single-VM verbs folded under `machine` (hidden from default help).
@@ -248,7 +261,6 @@ const MACHINE_SUB: &[(&str, AuditPosture)] = &[
     ("resume", AuditPosture::Emits("VmStart")),
     ("snapshot", AuditPosture::DelegatesToSub(SNAPSHOT_SUB)),
     ("save", AuditPosture::Emits("CheckpointCreated")),
-    ("restore", AuditPosture::Emits("CheckpointRestored")),
     ("checkpoint", AuditPosture::DelegatesToSub(CHECKPOINT_SUB)),
     ("cp", AuditPosture::Emits("VmFileCopy")),
     ("fs", AuditPosture::Emits("VmFsMutate")),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -323,6 +323,76 @@ fn machine_warm_restore_rejects_missing_checkpoint() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
+/// `machine fork --help` advertises the expected child naming options.
+#[test]
+fn machine_fork_help_lists_args() {
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .args(["machine", "fork", "--help"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "machine fork --help must exit 0, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(help.contains("fork"));
+    assert!(help.contains("PARENT"));
+    assert!(help.contains("--as"));
+    assert!(help.contains("--branch"));
+    assert!(help.contains("--json"));
+}
+
+/// `machine restore --help` advertises the expected child naming options.
+#[test]
+fn machine_restore_help_lists_args() {
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .args(["machine", "restore", "--help"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "machine restore --help must exit 0, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(help.contains("restore"));
+    assert!(help.contains("CHECKPOINT_ID"));
+    assert!(help.contains("--as"));
+    assert!(help.contains("--branch"));
+    assert!(help.contains("--json"));
+}
+
+/// A non-existent checkpoint id fails gracefully from `machine restore`.
+#[test]
+fn machine_restore_rejects_missing_checkpoint() {
+    let tmp = std::env::temp_dir().join(format!("mvm-restore-test-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .env("HOME", &tmp)
+        .env("MVM_HOME", &tmp)
+        .args(["machine", "restore", "no-such-checkpoint", "--as", "child"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "restore must fail for a missing checkpoint; stderr: {stderr}"
+    );
+    assert!(!stderr.contains("panic"), "restore panicked: {stderr}");
+    assert!(
+        !stderr.contains("thread panicked"),
+        "restore panicked: {stderr}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
 /// The `--json` output flag is accepted by the parser.
 #[test]
 fn machine_warm_restore_json_flag_parses() {


### PR DESCRIPTION
Expose `mvmctl machine fork <parent> --as <child>` and `mvmctl machine restore <checkpoint> --as <child>` over the consolidated checkpoint/`VmBackend` seam.

- `fork` snapshots a running machine as `vm_full`, then branches it into a fresh child VM.
- `restore` branches an existing `vm_full` checkpoint into a fresh child VM.
- Both support `--branch <slug>` for auto-naming dev sandboxes.
- Every child gets a new identity, authority, and per-instance secrets via the existing admit-and-boot path (`fork_vm_full_machine`).
- Removed the hidden folded `machine restore` same-identity verb; same-identity restore remains available as `machine checkpoint restore`.
- Added unit tests, `mvmctl` integration tests, BDD help scenarios, and updated the audit-posture table.
